### PR TITLE
Add skip, manual library queue, and per-skill toggles to admin

### DIFF
--- a/controller/src/broadcast/liquidsoap-control.js
+++ b/controller/src/broadcast/liquidsoap-control.js
@@ -45,3 +45,9 @@ export async function restartLiquidsoap() {
     if (!/ECONNRESET|EPIPE|timeout/i.test(err.message)) throw err;
   }
 }
+
+// Skip the currently playing track via the custom "skip" command in radio.liq.
+// Unlike restart, this returns a normal "OK" response — Liquidsoap stays up.
+export async function skipTrack() {
+  return sendCommand('skip', 2000);
+}

--- a/controller/src/routes/dj.js
+++ b/controller/src/routes/dj.js
@@ -7,8 +7,11 @@ import express from 'express';
 import { requireAdmin } from '../middleware/auth.js';
 import { queue } from '../broadcast/queue.js';
 import * as dj from '../llm/dj.js';
+import * as subsonic from '../music/subsonic.js';
+import * as settings from '../settings.js';
 import { runStationId, runHourlyCheck, runLink, refreshAutoPlaylist } from '../broadcast/scheduler.js';
 import { skillCatalog, runSkill } from '../skills/_registry.js';
+import { skipTrack } from '../broadcast/liquidsoap-control.js';
 import { getFullContext } from '../context.js';
 
 export const router = express.Router();
@@ -120,4 +123,93 @@ router.post('/dj/auto-link', requireAdmin, (req, res) => {
   if (typeof req.body?.on === 'boolean') queue.autoLink = req.body.on;
   queue.log('scheduler', `auto-link ${queue.autoLink ? 'enabled' : 'disabled'}`);
   res.json({ autoLink: queue.autoLink });
+});
+
+// ---------------------------------------------------------------------------
+// POST /dj/skip — force-end the current track (operator override)
+// There is no listener-facing skip by design; this is admin-gated only.
+// ---------------------------------------------------------------------------
+router.post('/dj/skip', requireAdmin, async (req, res) => {
+  try {
+    await skipTrack();
+    queue.log('scheduler', 'track skipped by operator');
+    res.json({ ok: true });
+  } catch (err) {
+    queue.log('error', `/dj/skip failed: ${err.message}`);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /dj/search?q=<terms> — library search for the manual queue UI
+// ---------------------------------------------------------------------------
+router.get('/dj/search', requireAdmin, async (req, res) => {
+  const q = (typeof req.query?.q === 'string' ? req.query.q : '').trim();
+  if (!q) return res.status(400).json({ error: 'q is required' });
+  try {
+    const songs = await subsonic.search(q, { songCount: 12 });
+    const results = songs.map(s => ({
+      id: s.id,
+      title: s.title,
+      artist: s.artist,
+      album: s.album,
+      year: s.year ?? null,
+      genre: s.genre ?? null,
+      duration: s.duration ?? null,
+      // path lets getLocalPath() use the on-disk file when MUSIC_LIBRARY_PATH
+      // is mounted, matching how listener-requested tracks are queued.
+      path: s.path ?? null,
+    }));
+    res.json({ results });
+  } catch (err) {
+    queue.log('error', `/dj/search failed: ${err.message}`);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /dj/queue-track — push a specific track to the queue (operator pick)
+// Body: { id, title, artist, album, year?, genre? } — a /dj/search result.
+// No DJ intro is generated; an auto-link still fires if auto-link is on.
+// ---------------------------------------------------------------------------
+router.post('/dj/queue-track', requireAdmin, async (req, res) => {
+  const track = req.body || {};
+  if (!track.id || !track.title) {
+    return res.status(400).json({ error: 'id and title are required' });
+  }
+  try {
+    const queuePosition = await queue.push({ track, requestedBy: 'studio' });
+    res.json({
+      ok: true,
+      track: { title: track.title, artist: track.artist || null },
+      queuePosition,
+    });
+  } catch (err) {
+    queue.log('error', `/dj/queue-track failed: ${err.message}`);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /dj/skill-toggle — enable/disable a skill's autonomous firing
+// Body: { name, on: true | false }
+// Manual /dj/skill firing still works on a disabled skill (operator override).
+// ---------------------------------------------------------------------------
+router.post('/dj/skill-toggle', requireAdmin, async (req, res) => {
+  const name = req.body?.name;
+  const on = req.body?.on;
+  if (!name || typeof name !== 'string' || typeof on !== 'boolean') {
+    return res.status(400).json({ error: 'name (string) and on (boolean) are required' });
+  }
+  if (!skillCatalog().some(s => s.name === name)) {
+    return res.status(400).json({ error: `unknown skill: ${name}` });
+  }
+  try {
+    await settings.update({ skills: { enabled: { [name]: on } } });
+    queue.log('scheduler', `skill ${name} ${on ? 'enabled' : 'disabled'}`);
+    res.json({ skills: skillCatalog() });
+  } catch (err) {
+    queue.log('error', `/dj/skill-toggle failed: ${err.message}`);
+    res.status(500).json({ error: err.message });
+  }
 });

--- a/controller/src/settings.js
+++ b/controller/src/settings.js
@@ -102,6 +102,12 @@ const DEFAULTS = {
     apiKey: '',
     pickerAgent: false,
   },
+  // Per-skill enable map. A skill missing from this object is treated as
+  // enabled — only an explicit `false` disables a skill's autonomous firing.
+  // Operator manual-fire (/dj/skill) ignores this map.
+  skills: {
+    enabled: {},
+  },
 };
 
 const SOULS_LIMIT = 10;
@@ -195,6 +201,12 @@ export async function load() {
       pickerAgent: typeof stored.llm?.pickerAgent === 'boolean'
         ? stored.llm.pickerAgent
         : DEFAULTS.llm.pickerAgent,
+    },
+    skills: {
+      // Keep only boolean values — anything else falls back to "enabled".
+      enabled: Object.fromEntries(
+        Object.entries(stored.skills?.enabled || {}).filter(([, v]) => typeof v === 'boolean')
+      ),
     },
   };
   return cache;
@@ -373,6 +385,20 @@ export async function update(patch) {
     }
     if (l.pickerAgent !== undefined) {
       next.llm.pickerAgent = !!l.pickerAgent;
+    }
+  }
+  if ('skills' in patch) {
+    const sk = patch.skills || {};
+    if (sk.enabled !== undefined) {
+      if (sk.enabled === null || typeof sk.enabled !== 'object') {
+        throw new Error('skills.enabled must be an object of name → boolean');
+      }
+      for (const [name, on] of Object.entries(sk.enabled)) {
+        if (typeof on !== 'boolean') {
+          throw new Error(`skills.enabled.${name} must be a boolean`);
+        }
+        next.skills.enabled[name] = on;
+      }
     }
   }
 

--- a/controller/src/skills/_registry.js
+++ b/controller/src/skills/_registry.js
@@ -20,6 +20,7 @@
 
 import { queue } from '../broadcast/queue.js';
 import { shouldFire as gateAllows } from '../broadcast/dj-gate.js';
+import * as settings from '../settings.js';
 
 import weather from './weather.js';
 import news from './news.js';
@@ -40,6 +41,9 @@ for (const s of SKILLS) {
 }
 
 function eligible(skill, ctx, now) {
+  // Operator can disable a skill's autonomous firing via settings.skills.
+  // Missing or non-false → enabled. Manual /dj/skill firing bypasses this.
+  if (settings.get().skills?.enabled?.[skill.name] === false) return false;
   if (!gateAllows(skill.kind, now)) return false;
   const last = lastFired.get(skill.name) || 0;
   if (now.getTime() - last < (skill.cooldownMs || 0)) return false;
@@ -98,7 +102,13 @@ export function listSkills() {
 
 // Skill metadata for the admin command-center UI.
 export function skillCatalog() {
-  return SKILLS.map(s => ({ name: s.name, kind: s.kind, cooldownMs: s.cooldownMs || 0 }));
+  const enabledMap = settings.get().skills?.enabled || {};
+  return SKILLS.map(s => ({
+    name: s.name,
+    kind: s.kind,
+    cooldownMs: s.cooldownMs || 0,
+    enabled: enabledMap[s.name] !== false,
+  }));
 }
 
 // Run a named skill on demand — operator override from the /dj/skill route.

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -436,3 +436,19 @@ server.register(
     "OK"
   end
 )
+
+# Skip the currently playing track. `radio` is the final broadcast source;
+# .skip() propagates down through compress → blank.skip → fallback → rotate →
+# smooth_add → cross → music, force-ending the current track. `cross` then
+# runs the normal dj_transition crossfade into the next track (next dj_queue
+# item, else auto_playlist). Operator-only — listeners can't reach this.
+server.register(
+  "skip",
+  description="Skip the currently playing track",
+  usage="skip",
+  fun(_) -> begin
+    log("Skip requested via server command")
+    radio.skip()
+    "OK"
+  end
+)

--- a/web/app/admin/library/page.js
+++ b/web/app/admin/library/page.js
@@ -1,0 +1,7 @@
+import LibraryPanel from '../../../components/admin/LibraryPanel';
+
+export const metadata = { title: 'Library' };
+
+export default function AdminLibraryPage() {
+  return <LibraryPanel />;
+}

--- a/web/components/admin/AdminShell.jsx
+++ b/web/components/admin/AdminShell.jsx
@@ -8,6 +8,7 @@ import SignInForm from './SignInForm';
 
 const NAV = [
   { href: '/admin/dash',     label: 'Dash' },
+  { href: '/admin/library',  label: 'Library' },
   { href: '/admin/persona',  label: 'Persona' },
   { href: '/admin/settings', label: 'Settings' },
   { href: '/admin/debug',    label: 'Debug' },

--- a/web/components/admin/DashPanel.jsx
+++ b/web/components/admin/DashPanel.jsx
@@ -104,6 +104,20 @@ export default function DashPanel() {
     if (j?.ok) setSayText('');
   };
 
+  // Skip is disruptive — it cuts the track for every listener — so confirm.
+  const skipCurrent = async () => {
+    if (!window.confirm('Skip the current track for all listeners?')) return;
+    await act('skip', '/dj/skip', {}, 'skip track');
+  };
+
+  // Toggle a skill's autonomous firing. Server returns the fresh catalogue.
+  const toggleSkill = async (s) => {
+    const next = s.enabled === false;
+    const j = await act(`skilltoggle:${s.name}`, '/dj/skill-toggle',
+      { name: s.name, on: next }, `${s.name} ${next ? 'enable' : 'disable'}`);
+    if (Array.isArray(j?.skills)) setSkills(j.skills);
+  };
+
   const np = status?.nowPlaying;
   const ctx = status?.context;
   const q = status?.queue || {};
@@ -135,8 +149,16 @@ export default function DashPanel() {
           <Empty>nothing reported playing</Empty>
         ) : (
           <div className="space-y-2">
-            <div style={{ fontSize: 15, color: 'var(--ink)' }}>
-              {np.title} <span style={{ color: 'var(--muted)' }}>— {np.artist}</span>
+            <div className="flex items-start justify-between gap-3">
+              <div style={{ fontSize: 15, color: 'var(--ink)' }}>
+                {np.title} <span style={{ color: 'var(--muted)' }}>— {np.artist}</span>
+              </div>
+              <ActionButton
+                label="Skip"
+                busy={busy === 'skip'}
+                disabled={!!busy}
+                onClick={skipCurrent}
+              />
             </div>
             <div className="flex flex-wrap gap-x-5 gap-y-1 v3-caption" style={{ color: 'var(--muted)' }}>
               {status?.dj?.name && <span>dj · {status.dj.name}</span>}
@@ -236,16 +258,36 @@ export default function DashPanel() {
         {skills.length === 0 ? (
           <Empty>no skills reported</Empty>
         ) : (
-          <div className="flex flex-wrap gap-2">
-            {skills.map(s => (
-              <ActionButton
-                key={s.name}
-                label={s.name}
-                busy={busy === `skill:${s.name}`}
-                disabled={!!busy}
-                onClick={() => act(`skill:${s.name}`, '/dj/skill', { name: s.name }, s.name)}
-              />
-            ))}
+          <div className="space-y-2">
+            <div className="v3-caption" style={{ color: 'var(--muted)' }}>
+              fire on demand · toggle autonomous firing
+            </div>
+            {skills.map(s => {
+              const enabled = s.enabled !== false;
+              return (
+                <div key={s.name} className="flex items-center justify-between gap-3">
+                  <ActionButton
+                    label={s.name}
+                    busy={busy === `skill:${s.name}`}
+                    disabled={!!busy}
+                    onClick={() => act(`skill:${s.name}`, '/dj/skill', { name: s.name }, s.name)}
+                  />
+                  <button
+                    onClick={() => toggleSkill(s)}
+                    disabled={!!busy}
+                    className="v3-eyebrow v3-focus cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+                    style={{
+                      border: `1px solid ${enabled ? 'var(--accent)' : 'var(--ink)'}`,
+                      background: enabled ? 'var(--accent)' : 'transparent',
+                      color: enabled ? '#fff' : 'var(--ink)',
+                      padding: '5px 14px', fontSize: 10, minWidth: 56,
+                    }}
+                  >
+                    {busy === `skilltoggle:${s.name}` ? '…' : (enabled ? 'auto on' : 'auto off')}
+                  </button>
+                </div>
+              );
+            })}
           </div>
         )}
       </Section>

--- a/web/components/admin/LibraryPanel.jsx
+++ b/web/components/admin/LibraryPanel.jsx
@@ -1,0 +1,155 @@
+'use client';
+
+// Library — /admin/library. The operator searches the Navidrome library and
+// pushes a chosen track straight into the queue (an admin-grade version of
+// the listener request flow, without the LLM matching guesswork).
+import { useState } from 'react';
+import { useAdminAuth } from '../../lib/adminAuth';
+
+export default function LibraryPanel() {
+  const { adminFetch, needsAuth, hydrated } = useAdminAuth();
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState(null);  // null = not searched yet
+  const [searching, setSearching] = useState(false);
+  const [queuing, setQueuing] = useState(null);   // id of the row being queued
+  const [feedback, setFeedback] = useState(null); // { tone, text }
+
+  const ready = hydrated && !needsAuth;
+
+  const runSearch = async (e) => {
+    e?.preventDefault();
+    const q = query.trim();
+    if (!q || !ready) return;
+    setSearching(true);
+    setFeedback(null);
+    try {
+      const r = await adminFetch(`/dj/search?q=${encodeURIComponent(q)}`);
+      const j = await r.json().catch(() => ({}));
+      if (!r.ok) throw new Error(j.error || `search failed (${r.status})`);
+      setResults(Array.isArray(j.results) ? j.results : []);
+    } catch (err) {
+      setFeedback({ tone: 'err', text: err.message });
+      setResults([]);
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const queueTrack = async (track) => {
+    setQueuing(track.id);
+    setFeedback(null);
+    try {
+      const r = await adminFetch('/dj/queue-track', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(track),
+      });
+      const j = await r.json().catch(() => ({}));
+      if (!r.ok) throw new Error(j.error || `queue failed (${r.status})`);
+      setFeedback({
+        tone: 'ok',
+        text: `queued “${j.track?.title || track.title}” · position ${j.queuePosition}`,
+      });
+    } catch (err) {
+      setFeedback({ tone: 'err', text: err.message });
+    } finally {
+      setQueuing(null);
+    }
+  };
+
+  return (
+    <div className="space-y-4" style={{ fontSize: 12 }}>
+      <div className="flex flex-wrap items-center gap-3 pb-3" style={{ borderBottom: '1px solid var(--ink)' }}>
+        <span className="v3-caption" style={{ color: 'var(--ink)' }}>library</span>
+        <span className="v3-caption" style={{ color: 'var(--muted)' }}>search · queue a track</span>
+        {feedback && (
+          <span style={{ marginLeft: 'auto', fontSize: 11, color: feedback.tone === 'err' ? '#c5302a' : 'var(--accent)' }}>
+            {feedback.text}
+          </span>
+        )}
+      </div>
+
+      <Section title="Manual queue">
+        <form onSubmit={runSearch} className="flex gap-2">
+          <input
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="Artist, title, album…"
+            style={{
+              boxSizing: 'border-box', flex: 1,
+              border: '1px solid var(--ink)', background: 'transparent',
+              padding: '8px 12px', fontSize: 13, fontFamily: 'inherit',
+              color: 'var(--ink)', outline: 'none',
+            }}
+          />
+          <button
+            type="submit"
+            disabled={searching || !query.trim() || !ready}
+            className="v3-eyebrow v3-focus cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+            style={{
+              background: 'var(--accent)', color: '#fff',
+              border: '1px solid var(--accent)', padding: '8px 18px', fontSize: 10,
+            }}
+          >
+            {searching ? 'searching…' : 'search'}
+          </button>
+        </form>
+
+        <div className="mt-3">
+          {results === null ? (
+            <Empty>search the library to queue a track</Empty>
+          ) : results.length === 0 ? (
+            <Empty>no tracks found</Empty>
+          ) : (
+            <ul className="space-y-1">
+              {results.map(t => (
+                <li key={t.id} className="flex items-center gap-3">
+                  <span className="truncate flex-1" style={{ color: 'var(--ink)' }}>
+                    {t.title} <span style={{ color: 'var(--muted)' }}>— {t.artist}</span>
+                    {t.album && <span style={{ color: 'var(--muted)' }}> · {t.album}</span>}
+                  </span>
+                  {t.duration != null && (
+                    <span className="v3-tab-num shrink-0" style={{ color: 'var(--muted)' }}>
+                      {fmtDuration(t.duration)}
+                    </span>
+                  )}
+                  <button
+                    onClick={() => queueTrack(t)}
+                    disabled={!!queuing}
+                    className="v3-eyebrow v3-focus cursor-pointer shrink-0 disabled:opacity-40 disabled:cursor-not-allowed"
+                    style={{
+                      border: '1px solid var(--ink)', background: 'transparent',
+                      color: 'var(--ink)', padding: '5px 12px', fontSize: 10,
+                    }}
+                  >
+                    {queuing === t.id ? 'queuing…' : 'queue'}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+function fmtDuration(s) {
+  const sec = Math.max(0, Math.round(s));
+  return `${Math.floor(sec / 60)}:${String(sec % 60).padStart(2, '0')}`;
+}
+
+function Section({ title, children }) {
+  return (
+    <section style={{ border: '1px solid var(--ink)' }}>
+      <div className="px-3 py-2" style={{ borderBottom: '1px solid var(--ink)' }}>
+        <span className="v3-caption" style={{ color: 'var(--ink)' }}>{title}</span>
+      </div>
+      <div className="p-3">{children}</div>
+    </section>
+  );
+}
+
+function Empty({ children }) {
+  return <div className="italic" style={{ color: 'var(--muted)' }}>{children}</div>;
+}


### PR DESCRIPTION
Three new operator controls for the admin surface:

- Skip track: custom "skip" telnet command in radio.liq, skipTrack() in liquidsoap-control.js, POST /dj/skip, confirm-gated button on the dash. Admin-gated only — no listener-facing skip.
- Manual queue: GET /dj/search + POST /dj/queue-track reuse subsonic search and queue.push (requestedBy: 'studio'); new /admin/library page (LibraryPanel) with a Library nav entry.
- Per-skill toggles: settings.skills.enabled map gates eligible() in the skill registry; manual /dj/skill firing still bypasses it. POST /dj/skill-toggle + on/off pills on the dash.