### PR TITLE
Personas own skills · dedicated Skills page · persona-voiced segments

### DIFF
--- a/controller/src/audio/tts.js
+++ b/controller/src/audio/tts.js
@@ -26,15 +26,15 @@ export const VOICE_KINDS = [
   'default',        // fallback when a kind isn't explicitly mapped
 ];
 
-// DJ-spoken kinds — these are voiced by the persona on air, so their engine
-// and voice come from the effective persona's `tts` config rather than the
-// global byKind/defaultEngine routing. Everything else (weather, news,
-// jingles…) stays on the global routing.
-const DJ_SPOKEN_KINDS = new Set(['dj-speak', 'link', 'station-id', 'hourly-check']);
+// Every spoken segment — track intros, links, idents, weather, news, traffic,
+// facts — is voiced by the persona on air: engine and voice come from the
+// effective persona's `tts` config. Only jingle rendering (a pre-recorded,
+// persona-agnostic stinger) falls back to the global defaultEngine.
+const GLOBAL_VOICE_KINDS = new Set(['jingle', 'default']);
 
-// The effective persona's TTS config for a DJ-spoken kind, else null.
+// The effective persona's TTS config for a persona-voiced kind, else null.
 function djPersonaTts(kind) {
-  if (!DJ_SPOKEN_KINDS.has(kind)) return null;
+  if (GLOBAL_VOICE_KINDS.has(kind)) return null;
   return settings.getEffectivePersona()?.tts || null;
 }
 
@@ -42,10 +42,9 @@ function resolveEngine(kind, personaTts) {
   const tts = settings.get().tts || {};
   let chosen;
   if (personaTts && ENGINES.includes(personaTts.engine)) {
-    chosen = personaTts.engine;          // persona owns the DJ-spoken engine
+    chosen = personaTts.engine;          // persona owns the spoken engine
   } else {
-    const override = (tts.byKind && tts.byKind[kind]) || null;
-    chosen = override || tts.defaultEngine || 'piper';
+    chosen = tts.defaultEngine || 'piper';   // jingle / fallback
   }
   if (!ENGINES.includes(chosen)) return 'piper';
   // `cloud` without a configured key would just throw and fall back — skip

--- a/controller/src/routes/settings.js
+++ b/controller/src/routes/settings.js
@@ -13,6 +13,7 @@ import { restartLiquidsoap, startStream, stopStream, streamStatus } from '../bro
 import { invalidateWeatherCache } from '../context.js';
 import { requireAdmin } from '../middleware/auth.js';
 import { tagger } from '../broadcast/tagger.js';
+import { skillCatalog } from '../skills/_registry.js';
 
 export const router = express.Router();
 
@@ -58,7 +59,6 @@ router.get('/settings', requireAdmin, async (req, res) => {
       },
       tts: {
         engines: tts.ENGINES,
-        kinds: tts.VOICE_KINDS.filter(k => k !== 'default'),
         available: tts.availableEngines(),
         kokoroVoices: settings.KOKORO_VOICES_BRITISH,
         cloudProviders: settings.TTS_CLOUD_PROVIDERS,
@@ -69,6 +69,9 @@ router.get('/settings', requireAdmin, async (req, res) => {
         providers: settings.LLM_PROVIDERS,
         active: llmProvider.activeModelLabel(),
       },
+      // Skill catalogue — consumed by the Skills page and by Personas for the
+      // per-persona skill-assignment checklist.
+      skills: { catalog: skillCatalog() },
     });
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/controller/src/settings.js
+++ b/controller/src/settings.js
@@ -35,14 +35,13 @@ export const DJ_SOULS = [
 
 export const FREQUENCIES = ['quiet', 'moderate', 'aggressive'];
 
-// TTS engines + voice-kinds. Engine `null` (or missing) for a kind means
-// "use defaultEngine". The DJ-spoken kinds are overridden at runtime by the
-// active/effective persona's own TTS config — see audio/tts.js.
+// TTS engines. Every spoken segment is voiced by the on-air persona's own
+// `tts` config (see audio/tts.js); only jingle rendering falls back to the
+// global defaultEngine.
 //
 // `cloud` routes through the AI SDK (OpenAI / ElevenLabs speech models) —
 // see llm/speech.js. `piper` and `kokoro` stay local CLI/worker engines.
 export const TTS_ENGINES = ['piper', 'kokoro', 'cloud'];
-export const TTS_KINDS   = ['dj-speak', 'link', 'station-id', 'hourly-check', 'weather', 'news', 'traffic', 'random-facts', 'jingle'];
 
 // LLM provider abstraction. `ollama` is the homelab default; the cloud
 // providers are opt-in and resolved by llm/provider.js. `gateway` routes
@@ -77,12 +76,16 @@ export const KOKORO_VOICES_BRITISH = [
 
 const KOKORO_VOICE_RE = /^[a-z]{2}_[a-z0-9]+$/;
 const ID_RE = /^[a-z0-9_]{3,32}$/;
+// Skill slugs (e.g. 'weather', 'random-facts'). The skills registry is the
+// source of truth for which slugs exist; settings only checks the shape.
+const SKILL_SLUG_RE = /^[a-z0-9-]{1,40}$/;
 
 const PERSONA_LIMIT = 12;
 const SHOWS_LIMIT = 64;
 const SOULS_LIMIT = 10;
 const SOUL_MIN = 1;
 const SOUL_MAX = 400;
+const SKILLS_PER_PERSONA_LIMIT = 20;
 
 // Server-minted opaque id, e.g. mintId('p_') -> 'p_a1b2c3'.
 function mintId(prefix) {
@@ -120,7 +123,6 @@ const DEFAULTS = {
   schedule: emptyWeek(),
   tts: {
     defaultEngine: 'piper',
-    byKind: Object.fromEntries(TTS_KINDS.map(k => [k, null])),
     kokoro: { voice: 'bf_isabella' },
     // Cloud engine config — used when an engine resolves to 'cloud'. A persona
     // chooses provider+voice; `model` and `apiKey` stay shared here. `apiKey`
@@ -163,6 +165,25 @@ function normalizeSouls(raw) {
   return out;
 }
 
+// Persona skill assignment. `null` (raw not an array) is the "all skills"
+// sentinel — used by legacy personas and the code default so behaviour is
+// unchanged until the operator explicitly picks a subset. An empty array
+// means "this persona runs no skills".
+function normalizeSkills(raw) {
+  if (!Array.isArray(raw)) return null;
+  const seen = new Set();
+  const out = [];
+  for (const item of raw) {
+    if (typeof item !== 'string') continue;
+    const v = item.trim();
+    if (!SKILL_SLUG_RE.test(v) || seen.has(v)) continue;
+    seen.add(v);
+    out.push(v);
+    if (out.length >= SKILLS_PER_PERSONA_LIMIT) break;
+  }
+  return out;
+}
+
 function normalizeTts(raw) {
   const engine = TTS_ENGINES.includes(raw?.engine) ? raw.engine : 'piper';
   const cloudProvider = TTS_CLOUD_PROVIDERS.includes(raw?.cloudProvider) ? raw.cloudProvider : 'openai';
@@ -184,6 +205,7 @@ function normalizePersona(raw) {
     frequency: FREQUENCIES.includes(raw.frequency) ? raw.frequency : 'moderate',
     soul,
     tts: normalizeTts(raw.tts),
+    skills: normalizeSkills(raw.skills),
   };
 }
 
@@ -314,10 +336,6 @@ export async function load() {
       defaultEngine: TTS_ENGINES.includes(stored.tts?.defaultEngine)
         ? stored.tts.defaultEngine
         : DEFAULTS.tts.defaultEngine,
-      byKind: Object.fromEntries(TTS_KINDS.map(k => {
-        const v = stored.tts?.byKind?.[k];
-        return [k, TTS_ENGINES.includes(v) ? v : null];
-      })),
       kokoro: {
         voice: (typeof stored.tts?.kokoro?.voice === 'string'
                 && KOKORO_VOICE_RE.test(stored.tts.kokoro.voice))
@@ -417,10 +435,30 @@ function validatePersonasStrict(raw) {
       throw new Error(`personas[${i}].frequency must be one of: ${FREQUENCIES.join(', ')}`);
     }
     const tts = validateTtsBlock(item.tts, `personas[${i}]`);
+    // skills — optional. Absent → null ("all skills", legacy/default). Present
+    // → an explicit slug array (the UI always sends one once edited).
+    let skills = null;
+    if (item.skills !== undefined && item.skills !== null) {
+      if (!Array.isArray(item.skills)) {
+        throw new Error(`personas[${i}].skills must be an array of skill names`);
+      }
+      if (item.skills.length > SKILLS_PER_PERSONA_LIMIT) {
+        throw new Error(`personas[${i}].skills must be at most ${SKILLS_PER_PERSONA_LIMIT} entries`);
+      }
+      const seenSk = new Set();
+      skills = [];
+      for (const s of item.skills) {
+        const v = String(s ?? '').trim();
+        if (!SKILL_SLUG_RE.test(v)) {
+          throw new Error(`personas[${i}].skills entries must be slug strings`);
+        }
+        if (!seenSk.has(v)) { seenSk.add(v); skills.push(v); }
+      }
+    }
     let id = (typeof item.id === 'string' && ID_RE.test(item.id)) ? item.id : mintId('p_');
     if (seen.has(id)) id = mintId('p_');
     seen.add(id);
-    return { id, name, tagline, frequency: item.frequency, soul, tts };
+    return { id, name, tagline, frequency: item.frequency, soul, tts, skills };
   });
 }
 
@@ -542,24 +580,6 @@ export async function update(patch) {
         throw new Error(`tts.defaultEngine must be one of: ${TTS_ENGINES.join(', ')}`);
       }
       next.tts.defaultEngine = t.defaultEngine;
-    }
-    if (t.byKind !== undefined) {
-      if (t.byKind === null || typeof t.byKind !== 'object') {
-        throw new Error('tts.byKind must be an object');
-      }
-      for (const [k, v] of Object.entries(t.byKind)) {
-        if (!TTS_KINDS.includes(k)) {
-          throw new Error(`tts.byKind has unknown kind: ${k}`);
-        }
-        if (v === null || v === '' || v === undefined) {
-          next.tts.byKind[k] = null;
-          continue;
-        }
-        if (!TTS_ENGINES.includes(v)) {
-          throw new Error(`tts.byKind.${k} must be null or one of: ${TTS_ENGINES.join(', ')}`);
-        }
-        next.tts.byKind[k] = v;
-      }
     }
     if (t.kokoro !== undefined) {
       const k = t.kokoro || {};

--- a/controller/src/skills/_registry.js
+++ b/controller/src/skills/_registry.js
@@ -44,6 +44,10 @@ function eligible(skill, ctx, now) {
   // Operator can disable a skill's autonomous firing via settings.skills.
   // Missing or non-false → enabled. Manual /dj/skill firing bypasses this.
   if (settings.get().skills?.enabled?.[skill.name] === false) return false;
+  // The persona on air owns a subset of skills. `skills === null` means the
+  // persona runs every skill (legacy/default); otherwise it must opt in.
+  const persona = settings.getEffectivePersona();
+  if (persona?.skills && !persona.skills.includes(skill.name)) return false;
   if (!gateAllows(skill.kind, now)) return false;
   const last = lastFired.get(skill.name) || 0;
   if (now.getTime() - last < (skill.cooldownMs || 0)) return false;
@@ -105,6 +109,8 @@ export function skillCatalog() {
   const enabledMap = settings.get().skills?.enabled || {};
   return SKILLS.map(s => ({
     name: s.name,
+    label: s.label || s.name,
+    description: s.description || '',
     kind: s.kind,
     cooldownMs: s.cooldownMs || 0,
     enabled: enabledMap[s.name] !== false,

--- a/controller/src/skills/news.js
+++ b/controller/src/skills/news.js
@@ -50,6 +50,8 @@ async function fetchHeadlines() {
 
 export default {
   name: 'news',
+  label: 'News headlines',
+  description: 'Reads one top headline from the configured RSS feed, in character.',
   kind: 'news',
   cooldownMs: 45 * 60 * 1000,
 

--- a/controller/src/skills/random-facts.js
+++ b/controller/src/skills/random-facts.js
@@ -7,6 +7,8 @@ import { djSystem, buildContextLines, decoratePrompt } from '../llm/dj.js';
 
 export default {
   name: 'random-facts',
+  label: 'Random facts',
+  description: 'A one-line "did you know" filler between tracks, lightly themed to the hour.',
   kind: 'random-facts',
   cooldownMs: 60 * 60 * 1000,
 

--- a/controller/src/skills/traffic.js
+++ b/controller/src/skills/traffic.js
@@ -9,6 +9,8 @@ import { djSystem, buildContextLines, decoratePrompt } from '../llm/dj.js';
 
 export default {
   name: 'traffic',
+  label: 'Traffic',
+  description: 'Tongue-in-cheek made-up traffic for the listening area — only during commute hours.',
   kind: 'traffic',
   cooldownMs: 90 * 60 * 1000,
 

--- a/controller/src/skills/weather.js
+++ b/controller/src/skills/weather.js
@@ -11,6 +11,8 @@ import { djSystem, buildContextLines, decoratePrompt } from '../llm/dj.js';
 
 export default {
   name: 'weather',
+  label: 'Weather',
+  description: 'A short weather check, fired only when conditions change since the last mention.',
   kind: 'weather',
   cooldownMs: 25 * 60 * 1000,
 

--- a/web/app/admin/skills/page.js
+++ b/web/app/admin/skills/page.js
@@ -1,0 +1,7 @@
+import SkillsPanel from '../../../components/admin/SkillsPanel';
+
+export const metadata = { title: 'Skills' };
+
+export default function AdminSkillsPage() {
+  return <SkillsPanel />;
+}

--- a/web/components/admin/AdminShell.jsx
+++ b/web/components/admin/AdminShell.jsx
@@ -12,6 +12,7 @@ const NAV = [
   { href: '/admin/dash',     id: 'dash',     label: 'Dash' },
   { href: '/admin/library',  id: 'library',  label: 'Library' },
   { href: '/admin/personas', id: 'personas', label: 'Personas' },
+  { href: '/admin/skills',   id: 'skills',   label: 'Skills' },
   { href: '/admin/shows',    id: 'shows',    label: 'Shows' },
   { href: '/admin/settings', id: 'settings', label: 'Settings' },
   { href: '/admin/debug',    id: 'debug',    label: 'Debug' },

--- a/web/components/admin/PersonasPanel.jsx
+++ b/web/components/admin/PersonasPanel.jsx
@@ -8,7 +8,7 @@
 // Everything POSTs to /settings and applies live — no mixer restart.
 import { useEffect, useState } from 'react';
 import { useAdminAuth } from '../../lib/adminAuth';
-import { Card, Btn, Pill, Eyebrow, Seg } from './ui';
+import { Card, Btn, Pill, Eyebrow, Seg, Toggle } from './ui';
 
 const FREQUENCIES = [
   { id: 'quiet',      label: 'Quiet',      desc: 'Talks every 8–20 tracks · station ID once an hour · weather hourly on change.' },
@@ -77,6 +77,9 @@ export default function PersonasPanel() {
         const defaultPrompt = j.defaults?.djPrompt || '';
         const stored = v.djPrompt || '';
         const custom = stored !== '' && stored !== defaultPrompt;
+        // Catalog of every skill. A persona with no stored `skills` (legacy /
+        // code default) is treated as running all of them.
+        const allSkills = (j.skills?.catalog || []).map(s => s.name);
         setForm({
           personas: v.personas.map(p => ({
             id: p.id,
@@ -89,6 +92,7 @@ export default function PersonasPanel() {
               cloudProvider: p.tts?.cloudProvider ?? 'openai',
               voice: p.tts?.voice ?? 'bf_isabella',
             },
+            skills: Array.isArray(p.skills) ? p.skills : allSkills,
           })),
           activePersonaId: v.activePersonaId,
           useCustomPrompt: custom,
@@ -104,6 +108,8 @@ export default function PersonasPanel() {
     setForm(f => ({ ...f, personas: f.personas.map((p, idx) => (idx === i ? { ...p, ...patch } : p)) }));
   const setPersonaTts = (i, patch) =>
     setForm(f => ({ ...f, personas: f.personas.map((p, idx) => (idx === i ? { ...p, tts: { ...p.tts, ...patch } } : p)) }));
+  const setPersonaSkills = (i, skills) =>
+    setForm(f => ({ ...f, personas: f.personas.map((p, idx) => (idx === i ? { ...p, skills } : p)) }));
   const addPersona = () =>
     setForm(f => {
       if (f.personas.length >= PERSONA_MAX) return f;
@@ -113,6 +119,7 @@ export default function PersonasPanel() {
           id: clientMintId(), name: 'New persona', tagline: '',
           frequency: 'moderate', soul: '',
           tts: { engine: 'piper', cloudProvider: 'openai', voice: 'bf_isabella' },
+          skills: (data?.skills?.catalog || []).map(s => s.name),
         }],
       };
     });
@@ -153,6 +160,7 @@ export default function PersonasPanel() {
               cloudProvider: p.tts.cloudProvider,
               voice: p.tts.voice.trim() || 'bf_isabella',
             },
+            skills: p.skills,
           })),
           activePersonaId: form.activePersonaId,
           djPrompt: form.useCustomPrompt ? form.systemPrompt.trim() : '',
@@ -169,6 +177,7 @@ export default function PersonasPanel() {
 
   const kokoroVoices = data?.tts?.kokoroVoices || [];
   const cloudProviders = data?.tts?.cloudProviders || ['openai', 'elevenlabs'];
+  const skillCatalog = data?.skills?.catalog || [];
 
   if (err) {
     return (
@@ -340,6 +349,7 @@ export default function PersonasPanel() {
                   {p.tts.engine !== 'piper' && p.tts.voice.trim() && (
                     <Pill style={{ fontSize: 8 }}>{p.tts.voice.trim()}</Pill>
                   )}
+                  <Pill style={{ fontSize: 8 }}>{p.skills.length} skill{p.skills.length === 1 ? '' : 's'}</Pill>
                   {!valid && <Pill style={{ fontSize: 8, color: 'var(--danger)', borderColor: 'var(--danger)' }}>incomplete</Pill>}
                 </div>
               </button>
@@ -528,6 +538,50 @@ export default function PersonasPanel() {
                     The voice id for the chosen provider, e.g. <code>alloy</code> (OpenAI) or an ElevenLabs voice id.
                   </div>
                 </div>
+              </div>
+            )}
+          </Card>
+
+          <Card title="Skills" sub="autonomous segments this persona runs">
+            <p style={{ color: 'var(--muted)', fontSize: 12, lineHeight: 1.6, marginBottom: 10 }}>
+              When this persona is on air, only the skills ticked here can fire. A skill must
+              also be enabled station-wide on the <strong>Skills</strong> page.
+            </p>
+            {skillCatalog.length === 0 ? (
+              <div style={{ color: 'var(--muted)', fontStyle: 'italic', fontSize: 12 }}>
+                no skills available
+              </div>
+            ) : (
+              <div style={{ display: 'grid', gap: 0 }}>
+                {skillCatalog.map(s => {
+                  const on = focused.skills.includes(s.name);
+                  return (
+                    <div
+                      key={s.name}
+                      style={{
+                        display: 'grid', gridTemplateColumns: '1fr auto', gap: 16,
+                        padding: '12px 0', alignItems: 'center',
+                        borderBottom: '1px dashed var(--separator-strong)',
+                      }}
+                    >
+                      <div>
+                        <div style={{ fontSize: 13, fontWeight: 700 }}>{s.label || s.name}</div>
+                        <div style={{ fontSize: 11, color: 'var(--muted)', marginTop: 2 }}>
+                          {s.description}
+                        </div>
+                      </div>
+                      <Toggle
+                        on={on}
+                        onClick={() => setPersonaSkills(
+                          safeIdx,
+                          on
+                            ? focused.skills.filter(n => n !== s.name)
+                            : [...focused.skills, s.name],
+                        )}
+                      />
+                    </div>
+                  );
+                })}
               </div>
             )}
           </Card>

--- a/web/components/admin/SettingsPanel.jsx
+++ b/web/components/admin/SettingsPanel.jsx
@@ -7,31 +7,8 @@ import { useAdminAuth } from '../../lib/adminAuth';
 import { V3AlertDialog } from '../ui/alert-dialog';
 import { Card, Btn, Pill, Eyebrow, Seg, Metric } from './ui';
 
-const TTS_KIND_LABEL = {
-  'dj-speak':     'Track intros',
-  'link':         'Between-track links',
-  'station-id':   'Station IDs',
-  'hourly-check': 'Hourly check-ins',
-  'weather':      'Weather updates',
-  'news':         'News headlines',
-  'traffic':     'Traffic filler',
-  'random-facts': 'Random facts',
-  'jingle':       'Jingle rendering',
-};
-const TTS_KIND_HINT = {
-  'dj-speak':     'Played before a listener-requested track.',
-  'link':         'Short talkover links between back-to-back auto tracks.',
-  'station-id':   'Identification at :15 and :45 (frequency-dependent).',
-  'hourly-check': 'Top-of-hour time/weather mention.',
-  'weather':      'Fired when conditions change since the last announcement.',
-  'news':         'One headline from the configured RSS feed, read in DJ tone.',
-  'traffic':      'Tongue-in-cheek made-up traffic — only during commute hours.',
-  'random-facts': 'A one-liner "did you know" between tracks.',
-  'jingle':       'Engine used when you create a new jingle from text in the Jingles section.',
-};
-
 const SECTIONS = [
-  { id: 'tts',     label: 'TTS voice', hint: 'engines per kind' },
+  { id: 'tts',     label: 'TTS voice', hint: 'default engine' },
   { id: 'llm',     label: 'LLM provider', hint: 'model routing' },
   { id: 'mixer',   label: 'Mixer', hint: 'crossfade · weather' },
   { id: 'jingles', label: 'Jingles', hint: 'stingers' },
@@ -75,7 +52,6 @@ export default function SettingsPanel() {
       },
       tts: {
         defaultEngine: data.values.tts?.defaultEngine ?? 'piper',
-        byKind: { ...(data.values.tts?.byKind || {}) },
         kokoro: { voice: data.values.tts?.kokoro?.voice ?? 'bf_isabella' },
         cloud: {
           provider: data.values.tts?.cloud?.provider ?? 'openai',
@@ -419,13 +395,11 @@ function EngineSeg({ engines, available, value, onChange, allowDefault, defaultE
 function TtsSection({ data, form, setForm, busy, saveMsg, saveSettings }) {
   const engines = data.tts.engines || ['piper'];
   const available = data.tts.available || {};
-  const kinds = data.tts.kinds || [];
   const hasCloud = engines.includes('cloud');
 
   const save = () => saveSettings({
     tts: {
       defaultEngine: form.tts.defaultEngine,
-      byKind: form.tts.byKind,
       kokoro: { voice: form.tts.kokoro?.voice },
       cloud: {
         provider: form.tts.cloud.provider,
@@ -442,16 +416,16 @@ function TtsSection({ data, form, setForm, busy, saveMsg, saveSettings }) {
     <>
       <SectionHeader
         eyebrow="tts voice"
-        title="Pick a voice engine for every kind of segment."
+        title="The default voice engine and cloud config."
         sub={<>
-          Piper is fast and CPU-cheap. Kokoro is more natural but 3–5× slower per line.
-          Cloud routes through OpenAI or ElevenLabs. Failures fall back to Piper.
+          Every spoken segment is voiced by the <strong>persona on air</strong> — set each
+          persona’s engine and voice on the Personas page. This page sets the default engine
+          used for jingle rendering and as the fallback, plus the shared Cloud engine config.
           {available.kokoro === false && (
             <span style={{ color: 'var(--danger)' }}> Kokoro is unavailable in this build.</span>
           )}
         </>}
         metrics={[
-          { n: String(kinds.length), l: 'kinds' },
           { n: String(engines.length), l: 'engines', accent: true },
         ]}
       />
@@ -468,7 +442,7 @@ function TtsSection({ data, form, setForm, busy, saveMsg, saveSettings }) {
               onChange={v => setForm(f => ({ ...f, tts: { ...f.tts, defaultEngine: v || 'piper' } }))}
               allowDefault={false}
             />
-            <div className="field-hint">Used for any kind below set to “default”.</div>
+            <div className="field-hint">Renders jingles, and is the fallback if a persona’s engine fails.</div>
           </div>
           {(data.tts.kokoroVoices?.length || 0) > 0 && (
             <div className="field">
@@ -487,41 +461,6 @@ function TtsSection({ data, form, setForm, busy, saveMsg, saveSettings }) {
               <div className="field-hint">British English only. Applies to every kind routed through Kokoro.</div>
             </div>
           )}
-        </div>
-      </Card>
-
-      {/* By kind */}
-      <Card title="Engine by kind" sub={`${kinds.length} segment types`}>
-        <div style={{ display: 'grid', gap: 0 }}>
-          {kinds.map(k => (
-            <div
-              key={k}
-              style={{
-                display: 'grid', gridTemplateColumns: '1fr auto', gap: 16,
-                padding: '14px 0', alignItems: 'center',
-                borderBottom: '1px dashed var(--separator-strong)',
-              }}
-            >
-              <div>
-                <div style={{ fontSize: 13, fontWeight: 700, letterSpacing: '-0.005em' }}>
-                  {TTS_KIND_LABEL[k] || k}
-                </div>
-                <div style={{ fontSize: 11, color: 'var(--muted)', marginTop: 2 }}>
-                  {TTS_KIND_HINT[k]}
-                </div>
-              </div>
-              <EngineSeg
-                engines={engines}
-                available={available}
-                value={form.tts.byKind?.[k] ?? null}
-                onChange={v => setForm(f => ({
-                  ...f, tts: { ...f.tts, byKind: { ...f.tts.byKind, [k]: v } },
-                }))}
-                allowDefault
-                defaultEngine={form.tts.defaultEngine}
-              />
-            </div>
-          ))}
         </div>
       </Card>
 
@@ -582,7 +521,7 @@ function TtsSection({ data, form, setForm, busy, saveMsg, saveSettings }) {
       )}
 
       <SaveBar
-        note="Applies to the next spoken segment · no mixer restart. Jingle changes only affect newly generated jingles."
+        note="Applies to jingle rendering and the engine fallback · no mixer restart. Per-segment voice comes from the persona on air."
         busy={busy}
         saveMsg={saveMsg}
         onSave={save}

--- a/web/components/admin/SkillsPanel.jsx
+++ b/web/components/admin/SkillsPanel.jsx
@@ -1,0 +1,161 @@
+'use client';
+
+// Skills editor — /admin/skills. The autonomous DJ segments (weather, news,
+// traffic, random facts) the station can fire between tracks.
+//
+// Each skill is toggled on/off station-wide here. A skill only fires
+// autonomously when it is enabled here AND assigned to the persona on air
+// (see /admin/personas). "Run now" is an operator override — it fires the
+// segment immediately, bypassing the enable toggle, the persona assignment,
+// the frequency gate, and the cooldown.
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { useAdminAuth } from '../../lib/adminAuth';
+import { Card, Btn, Pill, Eyebrow, Toggle } from './ui';
+
+function cooldownLabel(ms) {
+  if (!ms) return 'no cooldown';
+  const min = Math.round(ms / 60000);
+  if (min < 60) return `${min} min cooldown`;
+  const h = Math.round(min / 6) / 10;
+  return `${h} h cooldown`;
+}
+
+export default function SkillsPanel() {
+  const { adminFetch, needsAuth, hydrated } = useAdminAuth();
+  const [skills, setSkills] = useState(null);
+  const [err, setErr] = useState(null);
+  const [busy, setBusy] = useState(null);   // skill name currently mutating, or null
+
+  const load = async () => {
+    try {
+      const r = await adminFetch('/dj/skills');
+      if (!r.ok) throw new Error(`failed (${r.status})`);
+      const j = await r.json();
+      setSkills(Array.isArray(j.skills) ? j.skills : []);
+      setErr(null);
+    } catch (e) { setErr(e.message); }
+  };
+
+  useEffect(() => {
+    if (!hydrated || needsAuth) return;
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hydrated, needsAuth]);
+
+  const toggle = async (name, on) => {
+    setBusy(name);
+    try {
+      const r = await adminFetch('/dj/skill-toggle', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, on }),
+      });
+      const j = await r.json().catch(() => ({}));
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      if (Array.isArray(j.skills)) setSkills(j.skills);
+    } catch (e) {
+      toast.error(`Toggle failed: ${e.message}`);
+    } finally { setBusy(null); }
+  };
+
+  const runNow = async (name) => {
+    setBusy(name);
+    try {
+      const r = await adminFetch('/dj/skill', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      });
+      const j = await r.json().catch(() => ({}));
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      toast.success(j.spoken ? `On air: “${j.spoken}”` : `${name} fired`);
+    } catch (e) {
+      toast.error(`Run failed: ${e.message}`);
+    } finally { setBusy(null); }
+  };
+
+  if (err) {
+    return (
+      <div style={{ display: 'grid', gap: 16 }}>
+        <Card title="Skills">
+          <div style={{ color: 'var(--danger)', fontSize: 13 }}>controller error: {err}</div>
+        </Card>
+      </div>
+    );
+  }
+  if (!skills) {
+    return (
+      <div style={{ display: 'grid', gap: 16 }}>
+        <Card title="Skills">
+          <div style={{ color: 'var(--muted)', fontSize: 13, fontStyle: 'italic' }}>loading…</div>
+        </Card>
+      </div>
+    );
+  }
+
+  const enabledCount = skills.filter(s => s.enabled).length;
+
+  return (
+    <div style={{ display: 'grid', gap: 16 }}>
+      {/* ── HERO ─────────────────────────────────────────────────────────── */}
+      <section className="card">
+        <div style={{ padding: 16, borderBottom: '1px solid var(--ink)' }}>
+          <Eyebrow color="var(--accent)">skills</Eyebrow>
+          <div style={{ fontSize: 22, fontWeight: 800, letterSpacing: '-0.02em', marginTop: 6 }}>
+            What the DJ does between tracks.
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--muted)', marginTop: 4, lineHeight: 1.6 }}>
+            Each skill is an autonomous segment. A skill fires only when it is enabled here
+            <strong> and</strong> assigned to the persona on air — set per-persona assignments
+            on the Personas page. “Run now” is an operator override and ignores both.
+          </div>
+        </div>
+        <div style={{ padding: 14, display: 'flex', gap: 16, alignItems: 'center', background: 'var(--ink-softer)' }}>
+          <span className="caption">{skills.length} skill{skills.length === 1 ? '' : 's'}</span>
+          <span className="caption" style={{ color: 'var(--accent)' }}>{enabledCount} enabled</span>
+        </div>
+      </section>
+
+      {/* ── SKILL LIST ───────────────────────────────────────────────────── */}
+      {skills.map(s => (
+        <Card
+          key={s.name}
+          title={s.label || s.name}
+          sub={s.kind}
+          right={
+            <>
+              <Pill tone={s.enabled ? 'accent' : ''} dot={s.enabled}>
+                {s.enabled ? 'enabled' : 'disabled'}
+              </Pill>
+              <Toggle
+                on={s.enabled}
+                disabled={busy === s.name}
+                onClick={() => toggle(s.name, !s.enabled)}
+              />
+            </>
+          }
+        >
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: 16, alignItems: 'center' }}>
+            <div>
+              <div style={{ fontSize: 12, color: 'var(--muted)', lineHeight: 1.6 }}>
+                {s.description || 'No description.'}
+              </div>
+              <div style={{ marginTop: 8, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                <Pill style={{ fontSize: 8 }}>{cooldownLabel(s.cooldownMs)}</Pill>
+                <Pill style={{ fontSize: 8 }}>kind · {s.kind}</Pill>
+              </div>
+            </div>
+            <Btn
+              tone="accent"
+              onClick={() => runNow(s.name)}
+              disabled={busy === s.name}
+            >
+              {busy === s.name ? 'Working…' : 'Run now'}
+            </Btn>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Context

The four autonomous DJ skills (`weather`, `news`, `traffic`, `random-facts`) had three rough edges: no persona ownership, no management UI, and skill segments were *written* in the on-air persona's voice but *spoken* with global per-kind TTS routing. This PR addresses all three.

## Changes

**1. Personas own skills**
- Personas gain a `skills` field (`controller/src/settings.js`). `null` is the "runs all" sentinel — legacy personas and the code default behave exactly as before with zero migration.
- The skills registry (`_registry.js`) gates autonomous firing on the on-air persona's set: a skill fires only if enabled station-wide **and** assigned to that persona.
- `PersonasPanel` adds a per-persona "Skills" checklist; roster chips show a skill count.

**2. Dedicated Skills page**
- New `/admin/skills` route + `SkillsPanel.jsx` + nav entry.
- Catalogue of every skill with label, description, kind, cooldown; an enable/disable toggle (`POST /dj/skill-toggle`) and a "Run now" override (`POST /dj/skill`).
- Skill files now carry `label`/`description`, surfaced via `skillCatalog()` and the `GET /settings` response.

**3. Voice comes from personas**
- `audio/tts.js` now routes every spoken kind (intros, links, idents, weather, news, traffic, facts) through the on-air persona's TTS config; only `jingle` uses the global default engine.
- `tts.byKind` is removed from the controller settings schema, and the per-kind voice routing table is removed from the Settings page (it now sets only the default/fallback engine + Cloud config).

## Verification

- `node --check` passes on all 8 modified controller files.
- `next build` passes — 23 routes compiled, including the new `/admin/skills`.