### PR TITLE
fix: subshell the cd fallback in health-check repo resolution

### DIFF
--- a/.claude/skills/subwave-deploy/scripts/health-check.sh
+++ b/.claude/skills/subwave-deploy/scripts/health-check.sh
@@ -14,7 +14,7 @@ set -u
 # Resolve the repo root from this script's own location — it lives at
 # <repo>/.claude/skills/subwave-deploy/scripts/health-check.sh.
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-REPO=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || cd "$SCRIPT_DIR/../../../.." && pwd)
+REPO=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || (cd "$SCRIPT_DIR/../../../.." && pwd))
 cd "$REPO" || { echo "subwave repo not found at $REPO"; exit 2; }
 
 # --- pick the live compose file ---------------------------------------------


### PR DESCRIPTION
Without the parens, `git ... || cd ... && pwd` changed the caller's working directory as a side effect of the fallback branch. Wrap the fallback in a subshell so it only yields a path.