### PR TITLE
Collapse admin panel multi-column layouts to single column on mobile

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1435,6 +1435,20 @@ body::after {
   .admin-root .shell-nav .nav-foot { display: none; }
 }
 
+/* Mobile — collapse the panels' multi-column inline-grid layouts so every
+   admin page reads as a single column. `!important` is required because the
+   panels set `grid-template-columns` via inline styles. */
+@media (max-width: 640px) {
+  .admin-root .stack-mobile { grid-template-columns: 1fr !important; }
+  .admin-root .strip-mobile { grid-template-columns: repeat(2, 1fr) !important; }
+  /* Re-flow the status-strip cell rules for two columns: left dividers only
+     between columns, top dividers between the new rows. */
+  .admin-root .strip-mobile > *:nth-child(odd) { border-left: none !important; }
+  .admin-root .strip-mobile > *:nth-child(n + 3) {
+    border-top: 1px solid var(--separator-strong);
+  }
+}
+
 /* ── Card ── */
 .admin-root .card { border: 1px solid var(--ink); background: var(--card-bg); }
 .admin-root .card-head {

--- a/web/components/admin/DashPanel.jsx
+++ b/web/components/admin/DashPanel.jsx
@@ -143,7 +143,7 @@ export default function DashPanel() {
 
       {/* ── ON AIR HERO ────────────────────────────────────────────────── */}
       <section className="card" style={{ borderColor: 'var(--ink)' }}>
-        <div style={{
+        <div className="stack-mobile" style={{
           padding: 18, display: 'grid', gridTemplateColumns: '1fr auto', gap: 24,
           alignItems: 'center', borderBottom: '1px solid var(--ink)',
         }}>
@@ -178,7 +178,7 @@ export default function DashPanel() {
         </div>
 
         {/* status strip */}
-        <div style={{
+        <div className="strip-mobile" style={{
           display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)',
         }}>
           {strip.map((c, i) => (
@@ -201,7 +201,7 @@ export default function DashPanel() {
       </section>
 
       {/* ── 2-COL OPS ──────────────────────────────────────────────────── */}
-      <div style={{ display: 'grid', gridTemplateColumns: '1.4fr 1fr', gap: 16 }}>
+      <div className="stack-mobile" style={{ display: 'grid', gridTemplateColumns: '1.4fr 1fr', gap: 16 }}>
         {/* LEFT */}
         <div style={{ display: 'grid', gridTemplateRows: 'auto 1fr', gap: 16 }}>
           <Card

--- a/web/components/admin/DebugPanel.jsx
+++ b/web/components/admin/DebugPanel.jsx
@@ -69,7 +69,7 @@ export default function DebugPanel() {
             <Btn sm onClick={() => setPaused(!paused)}>{paused ? 'Resume' : 'Pause'}</Btn>
           </span>
         </div>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)' }}>
+        <div className="strip-mobile" style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)' }}>
           <HealthCell
             label="Icecast"
             status={data?.icecast && !data.icecast.error ? 'ok' : err ? 'down' : 'idle'}
@@ -120,7 +120,7 @@ export default function DebugPanel() {
       {data && (
         <>
           {/* ── ROW 1 — NOW PLAYING / ICECAST / DJ CONTEXT ──────────────── */}
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 16 }}>
+          <div className="stack-mobile" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 16 }}>
             <Card title="Now playing" sub="now-playing.json" bodyStyle={{ maxHeight: 320, overflowY: 'auto' }}>
               <KvTable obj={data.nowPlaying} />
             </Card>
@@ -135,7 +135,7 @@ export default function DebugPanel() {
           </div>
 
           {/* ── ROW 2 — LLM + LIQUIDSOAP ────────────────────────────────── */}
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1.2fr', gap: 16 }}>
+          <div className="stack-mobile" style={{ display: 'grid', gridTemplateColumns: '1fr 1.2fr', gap: 16 }}>
             <Card
               title="LLM recent calls"
               sub={`${data.llm?.recentCalls?.length ?? 0} · ${data.llm?.provider || '—'} / ${data.llm?.activeModel || '—'}`}
@@ -201,7 +201,7 @@ export default function DebugPanel() {
           </div>
 
           {/* ── ROW 3 — STATE DIR + VOICE WAVS + LIBRARY ────────────────── */}
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1.2fr', gap: 16 }}>
+          <div className="stack-mobile" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1.2fr', gap: 16 }}>
             <Card title="State dir" sub="/var/sub-wave" bodyStyle={{ maxHeight: 320, overflowY: 'auto' }}>
               <FilesTable files={data.stateFiles} />
             </Card>
@@ -248,7 +248,7 @@ export default function DebugPanel() {
           </div>
 
           {/* ── QUEUE — current request + upcoming ──────────────────────── */}
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1.2fr', gap: 16 }}>
+          <div className="stack-mobile" style={{ display: 'grid', gridTemplateColumns: '1fr 1.2fr', gap: 16 }}>
             <Card title="Queue" sub="current served request">
               {data.queue?.current ? (
                 <KvTable obj={data.queue.current} />

--- a/web/components/admin/LibraryPanel.jsx
+++ b/web/components/admin/LibraryPanel.jsx
@@ -205,7 +205,7 @@ export default function LibraryPanel() {
       </section>
 
       {/* ── 2-COL ─────────────────────────────────────────────────────── */}
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 240px', gap: 16, alignItems: 'flex-start' }}>
+      <div className="stack-mobile" style={{ display: 'grid', gridTemplateColumns: '1fr 240px', gap: 16, alignItems: 'flex-start' }}>
         {/* RESULTS */}
         <div style={{ display: 'grid', gap: 16 }}>
           <Card

--- a/web/components/admin/PersonasPanel.jsx
+++ b/web/components/admin/PersonasPanel.jsx
@@ -308,7 +308,7 @@ export default function PersonasPanel() {
       )}
 
       {/* ── 2-COL ───────────────────────────────────────────────────────── */}
-      <div style={{ display: 'grid', gridTemplateColumns: '280px 1fr', gap: 16, alignItems: 'flex-start' }}>
+      <div className="stack-mobile" style={{ display: 'grid', gridTemplateColumns: '280px 1fr', gap: 16, alignItems: 'flex-start' }}>
         {/* ROSTER */}
         <div style={{ display: 'grid', gap: 10 }}>
           <span className="caption">roster · {form.personas.length} / {PERSONA_MAX}</span>
@@ -393,7 +393,7 @@ export default function PersonasPanel() {
               </>
             }
           >
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+            <div className="stack-mobile" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
               <div className="field">
                 <label className="field-label">On-air name</label>
                 <input
@@ -445,7 +445,7 @@ export default function PersonasPanel() {
 
             <div className="rule-label">talk frequency</div>
 
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8 }}>
+            <div className="stack-mobile" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8 }}>
               {FREQUENCIES.map(f => {
                 const active = f.id === focused.frequency;
                 return (
@@ -515,7 +515,7 @@ export default function PersonasPanel() {
             )}
 
             {focused.tts.engine === 'cloud' && (
-              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+              <div className="stack-mobile" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
                 <div className="field">
                   <label className="field-label">Cloud provider</label>
                   <Seg

--- a/web/components/admin/SettingsPanel.jsx
+++ b/web/components/admin/SettingsPanel.jsx
@@ -172,7 +172,7 @@ export default function SettingsPanel() {
   };
 
   return (
-    <div style={{ display: 'grid', gridTemplateColumns: '240px 1fr', gap: 24, alignItems: 'flex-start' }}>
+    <div className="stack-mobile" style={{ display: 'grid', gridTemplateColumns: '240px 1fr', gap: 24, alignItems: 'flex-start' }}>
       {/* Section rail */}
       <aside style={{ display: 'grid', gap: 4, position: 'sticky', top: 24 }}>
         <span className="caption" style={{ padding: '0 0 8px' }}>settings</span>

--- a/web/components/admin/ShowsPanel.jsx
+++ b/web/components/admin/ShowsPanel.jsx
@@ -352,7 +352,7 @@ export default function ShowsPanel() {
     <div style={{ display: 'grid', gap: 16 }}>
       {/* ── HERO ─────────────────────────────────────────────────────────── */}
       <section className="card">
-        <div style={{
+        <div className="stack-mobile" style={{
           padding: 16, borderBottom: '1px solid var(--ink)',
           display: 'grid', gridTemplateColumns: '1fr auto auto', gap: 16, alignItems: 'center',
         }}>
@@ -374,7 +374,7 @@ export default function ShowsPanel() {
         </div>
 
         {/* Now / Up next / After that strip */}
-        <div style={{
+        <div className="stack-mobile" style={{
           display: 'grid', gridTemplateColumns: '1fr 1fr 1fr',
           borderBottom: '1px solid var(--separator-strong)',
         }}>
@@ -631,7 +631,7 @@ export default function ShowsPanel() {
               <span className="field-hint">{draft.name.trim().length}/{NAME_MAX}</span>
             </label>
 
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+            <div className="stack-mobile" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
               <label className="field">
                 <span className="field-label">persona owner</span>
                 <select


### PR DESCRIPTION
Admin panels use inline-grid layouts that stayed multi-column on phones.
Add a `stack-mobile` class (single column under 640px) and a `strip-mobile`
class (two columns) and apply them to the two-column page layouts and status
strips across Dash, Personas, Shows, Settings, Library, and Debug.

https://claude.ai/code/session_017ngSUpxFCZ6zhUbW1TCFwr