### PR TITLE
Pin controller/liquidsoap containers to Europe/London

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -59,6 +59,8 @@ services:
       - icecast
     environment:
       - ICECAST_SOURCE_PASSWORD=${ICECAST_SOURCE_PASSWORD:?must be set}
+      # Keeps the hourly archive paths (%Y-%m-%d/%H-00.mp3) on local wall time.
+      - TZ=${TZ:-Europe/London}
     extra_hosts:
       # Lets Liquidsoap fetch Subsonic stream URLs that point at host services
       # (e.g. NAVIDROME_URL=http://host.docker.internal:4533) without leaking
@@ -87,6 +89,11 @@ services:
       # ADMIN_USER + ADMIN_PASS are set in controller/.env. Local dev (using
       # docker-compose.yml) leaves NODE_ENV unset so admin auth stays opt-in.
       - NODE_ENV=production
+      # Schedule slots are stored by day-of-week + hour; resolveActiveShow()
+      # reads them with date.getHours(). Without TZ the container runs in UTC
+      # and fires shows an hour early during BST, out of sync with the admin UI
+      # (which computes the on-air slot in the browser's timezone).
+      - TZ=${TZ:-Europe/London}
     env_file:
       - ../controller/.env
     extra_hosts:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - icecast
     environment:
       - ICECAST_SOURCE_PASSWORD=${ICECAST_SOURCE_PASSWORD:-changeme}
+      - TZ=${TZ:-Europe/London}
     extra_hosts:
       # Lets Liquidsoap fetch Subsonic stream URLs that point at host services
       # (e.g. NAVIDROME_URL=http://host.docker.internal:4533) without leaking
@@ -59,6 +60,10 @@ services:
     platform: linux/amd64
     container_name: sub-wave-controller
     restart: unless-stopped
+    environment:
+      # Without TZ the container runs in UTC; schedule slots (day-of-week +
+      # hour) would then resolve an hour off from the admin UI during BST.
+      - TZ=${TZ:-Europe/London}
     depends_on:
       - liquidsoap
     ports:


### PR DESCRIPTION
Neither compose file set TZ, so both containers ran in UTC. The controller resolves schedule slots (stored as day-of-week + hour) with date.getHours(), so during BST it fired scheduled shows an hour early — out of sync with the admin UI, which computes the on-air slot in the browser's local timezone. A show could hand the hour to the wrong persona while the admin panel showed "no show — autonomous".

Set TZ=${TZ:-Europe/London} on controller and liquidsoap in both the dev and prod compose files. Also keeps liquidsoap's hourly archive paths (%Y-%m-%d/%H-00.mp3) on local wall time.