### PR TITLE
Bump player header text size

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -205,6 +205,11 @@ body::after {
 /* Mono is already tabular by design, but keep the class as a no-op alias. */
 .v3-tab-num { font-variant-numeric: tabular-nums; }
 
+/* Player header runs a touch larger than the shared v3 scale — the masthead
+   reads better at arm's length without disturbing the landing broadsheet. */
+.player-topbar .v3-eyebrow { font-size: 13px; }
+.player-topbar .v3-caption { font-size: 12px; }
+
 /* ─────────────────────────────────────────────────────────────────────────
    MASTHEAD NAV — sits inside the broadsheet header, between the rules.
    ───────────────────────────────────────────────────────────────────────── */

--- a/web/components/TopBar.jsx
+++ b/web/components/TopBar.jsx
@@ -39,7 +39,7 @@ export default function TopBar({ tunedIn, context, djName, activeShow, listeners
       // baseline gutter; left/right max() against the gutter so landscape
       // on a notched phone doesn't clip the wordmark, while desktop keeps
       // its wider sm: gutters.
-      className="absolute top-0 left-0 right-0 flex items-baseline justify-between gap-3 z-20
+      className="player-topbar absolute top-0 left-0 right-0 flex items-baseline justify-between gap-3 z-20
         pt-[calc(env(safe-area-inset-top)_+_1rem)] pb-4
         pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))]
         sm:pt-[calc(env(safe-area-inset-top)_+_1.5rem)] sm:pb-6


### PR DESCRIPTION
## Summary
- Increase the player header (`TopBar`) text size a notch for better arm's-length readability.
- Scoped via a new `.player-topbar` class so the shared `v3-eyebrow`/`v3-caption` typography on the landing broadsheet is untouched.

## Changes
- `web/components/TopBar.jsx` — add `player-topbar` class to the header root.
- `web/app/globals.css` — scoped rule: `v3-eyebrow` 11px → 13px, `v3-caption` 10px → 12px.

## Test plan
- CSS/markup only; `npm run dev` hot-reloads. No test runner configured in this repo.