### PR TITLE
player: default listener volume to 100%

### DIFF
--- a/web/hooks/usePlayer.js
+++ b/web/hooks/usePlayer.js
@@ -7,7 +7,7 @@ const STREAM_URL = process.env.NEXT_PUBLIC_STREAM_URL || '/stream.mp3';
 // Owns the <audio> element + tune-in state. The audioRef must be attached to
 // an <audio> tag rendered by the consumer (so the Waveform's Web Audio API
 // can also reach it).
-export function usePlayer({ initialVolume = 0.8 } = {}) {
+export function usePlayer({ initialVolume = 1 } = {}) {
   const audioRef = useRef(null);
   const [tunedIn, setTunedIn] = useState(false);
   const [volume, setVolume] = useState(initialVolume);


### PR DESCRIPTION
## What

Changes the player's default volume from 80% to 100%.

`usePlayer` exposed `initialVolume = 0.8`; `PlayerApp` calls `usePlayer()` with no args, so first-load listeners started at 80%. New listeners now tune in at full volume.

## Changes

- `web/hooks/usePlayer.js` — `initialVolume` default `0.8` → `1`