### PR TITLE
admin: add light/dark mode toggle to console header

### DIFF
--- a/web/components/admin/AdminShell.jsx
+++ b/web/components/admin/AdminShell.jsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect } from 'react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { useStationFeed } from '../../hooks/useStationFeed';
 import SignInForm from './SignInForm';
+import ThemeToggle from './ThemeToggle';
 import { Toaster } from '../ui/toaster';
 
 const NAV = [
@@ -117,6 +118,7 @@ function ShellHeader({ pathname, signedIn, onSignOut }) {
           <Link href="/" className="caption" style={{ color: 'var(--muted)', textDecoration: 'none' }}>
             ← player
           </Link>
+          <ThemeToggle />
           {onSignOut && (
             <button className="sign-out" onClick={onSignOut}>sign out</button>
           )}
@@ -127,6 +129,7 @@ function ShellHeader({ pathname, signedIn, onSignOut }) {
           <Link href="/" className="caption" style={{ color: 'var(--muted)', textDecoration: 'none' }}>
             ← player
           </Link>
+          <ThemeToggle />
         </span>
       )}
     </header>

--- a/web/components/admin/ThemeToggle.jsx
+++ b/web/components/admin/ThemeToggle.jsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Sun, Moon } from 'lucide-react';
+import { getStoredTheme, setTheme as persistTheme } from '../../lib/theme';
+
+// Light/dark toggle for the admin console header. Resolves the *applied*
+// theme on mount (a stored manual choice, else prefers-color-scheme), then
+// flips between explicit 'light'/'dark' modes on click — committing to a
+// manual preference in localStorage + <html data-theme>.
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    const stored = getStoredTheme();
+    if (stored === 'light' || stored === 'dark') {
+      setTheme(stored);
+      return;
+    }
+    const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+    setTheme(prefersDark ? 'dark' : 'light');
+  }, []);
+
+  const toggle = () => {
+    setTheme(t => {
+      const next = t === 'dark' ? 'light' : 'dark';
+      persistTheme(next);
+      return next;
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className="v3-focus cursor-pointer inline-flex items-center"
+      style={{ color: 'var(--muted)' }}
+      aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={theme === 'dark' ? 'Light mode' : 'Dark mode'}
+    >
+      {theme === 'dark'
+        ? <Sun className="w-3.5 h-3.5" aria-hidden="true" />
+        : <Moon className="w-3.5 h-3.5" aria-hidden="true" />}
+    </button>
+  );
+}


### PR DESCRIPTION
Closes #11

## What

Adds a light/dark mode toggle to the admin console header.

## Details

The theme infrastructure already existed (`lib/theme.js` — `system`/`light`/`dark` modes, localStorage persistence, pre-paint init script, dark-palette CSS in `globals.css`). The player UI already had a toggle; the admin panel had none.

- New `components/admin/ThemeToggle.jsx` — a sun/moon button reusing `lib/theme.js` helpers, mirroring the player `TopBar` toggle pattern.
- Wired into `AdminShell`'s header in both signed-in and signed-out (sign-in gate) states, so the toggle is reachable before and after login.

The admin shell styles off `--bg`/`--ink`/etc. CSS variables that the existing `[data-theme="dark"]` palette overrides, so the toggle re-themes the whole console with no further CSS changes.

## Testing

`npm run build` passes cleanly — all `/admin/*` routes compile.