### PR TITLE
Admin dashboard tweaks + Ollama config moved to Settings UI

### DIFF
--- a/.claude/skills/subwave-deploy/SKILL.md
+++ b/.claude/skills/subwave-deploy/SKILL.md
@@ -102,7 +102,7 @@ Ask the user (one question each, or as a single bundle):
 
 - `NAVIDROME_URL` — e.g. `http://navidrome.local:4533`
 - `NAVIDROME_USER`, `NAVIDROME_PASS`
-- `OLLAMA_URL` and `OLLAMA_MODEL` (default `qwen2.5:7b`)
+- (Ollama server URL + model are set in the admin Settings UI, not via env)
 
 Then patch `controller/.env` in place with `sed`, keeping the rest of the file as-is. Do **not** echo passwords back to the chat.
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -61,7 +61,7 @@ $EDITOR controller/.env
 
 Required values:
 - `NAVIDROME_URL`, `NAVIDROME_USER`, `NAVIDROME_PASS`
-- `OLLAMA_URL`, `OLLAMA_MODEL`
+- (Ollama server URL + model are set in the admin Settings UI, not via env)
 - `ICECAST_SOURCE_PASSWORD` — must match the value Caddy/Icecast see (next file)
 
 **`docker/.env`** — passwords compose passes to Icecast and shares with Liquidsoap:

--- a/controller/.env.example
+++ b/controller/.env.example
@@ -14,9 +14,9 @@ NAVIDROME_PASS=changeme
 #   - cloud API keys, auto-read by the AI SDK when the Settings UI leaves
 #     the key field blank.
 
-# Ollama — homelab default provider (no API key needed)
-OLLAMA_URL=http://localhost:11434
-OLLAMA_MODEL=nemotron-3-super:cloud
+# Ollama — homelab default provider (no API key needed).
+# Both the server URL and the model are set in the admin Settings UI
+# (LLM provider tab), not here.
 
 # Cloud providers — leave blank unless you switch to them in Settings.
 # The AI SDK reads these automatically when the Settings key field is empty.

--- a/controller/src/config.js
+++ b/controller/src/config.js
@@ -9,8 +9,11 @@ export const config = {
     clientName: 'sub-wave',
   },
   ollama: {
-    url: process.env.OLLAMA_URL || 'http://localhost:11434',
-    model: process.env.OLLAMA_MODEL || 'qwen2.5:7b',
+    // Default-when-blank server URL + model. The admin Settings UI
+    // (`llm.ollamaUrl` / `llm.model`) overrides both — there are no
+    // OLLAMA_URL / OLLAMA_MODEL env vars; the UI fields are the only source.
+    url: 'http://localhost:11434',
+    model: 'nemotron-3-super:cloud',
   },
   piper: {
     binary: process.env.PIPER_BIN || '/usr/local/bin/piper',

--- a/controller/src/llm/provider.js
+++ b/controller/src/llm/provider.js
@@ -6,9 +6,10 @@
 // without a redeploy and without touching a single call site.
 //
 // The active provider/model lives in `settings.llm` (see settings.js):
-//   { provider: 'ollama' | 'anthropic' | 'openai' | 'google' | 'openrouter' | 'gateway',
-//     model:    string,   // empty → provider default
-//     apiKey:   string }  // empty → read the provider's env var
+//   { provider:  'ollama' | 'anthropic' | 'openai' | 'google' | 'openrouter' | 'gateway',
+//     model:     string,   // empty → provider default
+//     apiKey:    string,   // empty → read the provider's env var
+//     ollamaUrl: string }  // empty → config.ollama.url default (Ollama only)
 //
 // `ollama` is the default and needs no key. The cloud providers are opt-in.
 
@@ -27,7 +28,13 @@ import * as settings from '../settings.js';
 const clientCache = new Map();
 
 function llmCfg() {
-  return settings.get().llm || { provider: 'ollama', model: '', apiKey: '' };
+  return settings.get().llm || { provider: 'ollama', model: '', apiKey: '', ollamaUrl: '' };
+}
+
+// Ollama server URL — from settings (admin UI), falling back to the config
+// default when the settings field is left blank.
+function ollamaBaseUrl(cfg) {
+  return cfg.ollamaUrl || config.ollama.url;
 }
 
 // Resolve the concrete model id. Ollama falls back to the env-configured
@@ -45,7 +52,7 @@ function resolveModelId(cfg) {
 export function languageModel() {
   const cfg = llmCfg();
   const id = resolveModelId(cfg);
-  const sig = `${cfg.provider}|${id}|${cfg.apiKey || ''}`;
+  const sig = `${cfg.provider}|${id}|${cfg.apiKey || ''}|${ollamaBaseUrl(cfg)}`;
 
   const cached = clientCache.get(sig);
   if (cached) return cached;
@@ -79,7 +86,7 @@ export function languageModel() {
     }
     case 'ollama':
     default: {
-      const provider = createOllama({ baseURL: `${config.ollama.url}/api` });
+      const provider = createOllama({ baseURL: `${ollamaBaseUrl(cfg)}/api` });
       model = provider(id);
       break;
     }
@@ -105,4 +112,10 @@ export function activeModelLabel() {
 // path or fall back to the pre-built candidate pool.
 export function providerName() {
   return llmCfg().provider;
+}
+
+// The effective Ollama server URL — settings field, or the config default.
+// Used by /debug to report what the registry will actually talk to.
+export function activeOllamaUrl() {
+  return ollamaBaseUrl(llmCfg());
 }

--- a/controller/src/music/tag-library.js
+++ b/controller/src/music/tag-library.js
@@ -9,7 +9,13 @@
 import { config } from '../config.js';
 import * as subsonic from './subsonic.js';
 import * as library from './library.js';
+import * as settings from '../settings.js';
 import { SHOW_MOODS as MOOD_VOCAB } from '../settings.js';
+
+// Resolved in main() from the admin Settings UI (llm.ollamaUrl / llm.model),
+// falling back to the config defaults when those fields are blank.
+let ollamaUrl = config.ollama.url;
+let ollamaModel = config.ollama.model;
 
 const SYSTEM = `You tag music tracks with mood and energy for a personal radio station.
 
@@ -34,11 +40,11 @@ async function tagOne(song) {
     `Year: ${song.year || '?'}\n` +
     `Genre: ${song.genre || '?'}`;
 
-  const res = await fetch(`${config.ollama.url}/api/chat`, {
+  const res = await fetch(`${ollamaUrl}/api/chat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      model: config.ollama.model,
+      model: ollamaModel,
       messages: [
         { role: 'system', content: SYSTEM },
         { role: 'user', content: userPrompt },
@@ -71,8 +77,12 @@ async function main() {
   const limit = limitIdx >= 0 ? parseInt(args[limitIdx + 1], 10) : Infinity;
 
   await library.load();
+  await settings.load();
+  const llm = settings.get().llm || {};
+  ollamaUrl = llm.ollamaUrl || config.ollama.url;
+  ollamaModel = llm.model || config.ollama.model;
   console.log(`[tag] starting. ${library.allTaggedIds().length} tracks already tagged.`);
-  console.log(`[tag] model: ${config.ollama.model} @ ${config.ollama.url}`);
+  console.log(`[tag] model: ${ollamaModel} @ ${ollamaUrl}`);
   if (limit !== Infinity) console.log(`[tag] limit: ${limit} new tracks`);
 
   let processed = 0;

--- a/controller/src/routes/debug.js
+++ b/controller/src/routes/debug.js
@@ -96,11 +96,11 @@ router.get('/debug', requireAdmin, async (req, res) => {
   }
 
   // 6. Recent LLM calls — `llm` reflects the active provider/model resolved
-  // by the registry; `ollama.url` is still shown as the homelab endpoint.
+  // by the registry; `ollamaUrl` is the effective endpoint (settings or default).
   out.llm = {
     provider: llmProvider.providerName(),
     activeModel: llmProvider.activeModelLabel(),
-    ollamaUrl: config.ollama.url,
+    ollamaUrl: llmProvider.activeOllamaUrl(),
     recentCalls: dj.recentCalls,
   };
 

--- a/controller/src/settings.js
+++ b/controller/src/settings.js
@@ -135,6 +135,9 @@ const DEFAULTS = {
     provider: 'ollama',
     model: '',
     apiKey: '',
+    // Ollama server URL. Empty → fall back to config.ollama.url. Only used
+    // when provider === 'ollama'.
+    ollamaUrl: '',
     pickerAgent: false,
   },
   skills: {
@@ -368,6 +371,9 @@ export async function load() {
         : DEFAULTS.llm.provider,
       model: typeof stored.llm?.model === 'string' ? stored.llm.model.trim() : DEFAULTS.llm.model,
       apiKey: typeof stored.llm?.apiKey === 'string' ? stored.llm.apiKey : DEFAULTS.llm.apiKey,
+      ollamaUrl: typeof stored.llm?.ollamaUrl === 'string'
+        ? stored.llm.ollamaUrl.trim()
+        : DEFAULTS.llm.ollamaUrl,
       pickerAgent: typeof stored.llm?.pickerAgent === 'boolean'
         ? stored.llm.pickerAgent
         : DEFAULTS.llm.pickerAgent,
@@ -641,6 +647,14 @@ export async function update(patch) {
     }
     if (l.apiKey !== undefined && l.apiKey !== 'set') {
       next.llm.apiKey = String(l.apiKey);
+    }
+    if (l.ollamaUrl !== undefined) {
+      const v = String(l.ollamaUrl).trim();
+      if (v.length > 200) throw new Error('llm.ollamaUrl must be 0-200 chars');
+      if (v && !/^https?:\/\//i.test(v)) {
+        throw new Error('llm.ollamaUrl must start with http:// or https://');
+      }
+      next.llm.ollamaUrl = v.replace(/\/+$/, '');  // strip trailing slashes
     }
     if (l.pickerAgent !== undefined) {
       next.llm.pickerAgent = !!l.pickerAgent;

--- a/controller/src/skills/_registry.js
+++ b/controller/src/skills/_registry.js
@@ -115,6 +115,10 @@ export function skillCatalog() {
     kind: s.kind,
     cooldownMs: s.cooldownMs || 0,
     enabled: enabledMap[s.name] !== false,
+    // `ready` is false when the skill needs an env key that isn't set.
+    // `requiresKey` names that key so the admin UI can tell the operator.
+    ready: typeof s.ready === 'function' ? !!s.ready() : true,
+    requiresKey: s.requiresKey || null,
   }));
 }
 

--- a/controller/src/skills/web-search.js
+++ b/controller/src/skills/web-search.js
@@ -40,6 +40,11 @@ export default {
   kind: 'web-search',
   cooldownMs: 60 * 60 * 1000,
 
+  // Env key this skill needs. `ready()` is surfaced in the skill catalogue so
+  // the admin UI can warn when the key is missing.
+  requiresKey: 'SEARCH_API_KEY',
+  ready() { return !!config.search.apiKey; },
+
   // No key, no artist, or the same artist we last searched → don't fire.
   shouldFire(_ctx, state) {
     if (!config.search.apiKey) return false;

--- a/docs/admin/settings.md
+++ b/docs/admin/settings.md
@@ -37,9 +37,12 @@ The model that writes DJ scripts and picks tracks.
 - **Provider** — `ollama` (homelab default, needs no key), `anthropic`,
   `openai`, `google`, `openrouter`, or `gateway`. Switching reroutes **every**
   LLM call — no redeploy.
-- **Model** — the model id for the chosen provider. For Ollama, leave blank to
-  use the `OLLAMA_MODEL` default; for cloud providers it is required, with a
-  hint giving the expected id format.
+- **Model** — the model id for the chosen provider, set here for every
+  provider including Ollama. Leave blank to use the built-in default
+  (`nemotron-3-super:cloud` for Ollama); for cloud providers a model is
+  required, with a hint giving the expected id format.
+- **Ollama server URL** *(Ollama only)* — where the Ollama server runs. Leave
+  blank to use the built-in default (`http://localhost:11434`).
 - For any non-Ollama provider, an **API key** banner reports whether the
   matching env var is present.
 - **Next-track picker** — choose how the DJ chooses the next track:

--- a/web/components/admin/DashPanel.jsx
+++ b/web/components/admin/DashPanel.jsx
@@ -124,11 +124,9 @@ export default function DashPanel() {
       {/* ── HEADER STRIP ───────────────────────────────────────────────── */}
       <div style={{
         display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap',
-        paddingBottom: 12, borderBottom: '1px solid var(--ink)',
       }}>
         <span className="live-dot" style={{ background: err ? 'var(--danger)' : 'var(--accent)' }} />
         <Eyebrow color={err ? 'var(--danger)' : 'var(--accent)'}>{err ? 'down' : 'live'}</Eyebrow>
-        <span className="caption">dj command center</span>
         {feedback && (
           <span style={{
             marginLeft: 'auto', fontSize: 11,
@@ -300,18 +298,22 @@ export default function DashPanel() {
                     key={s.type}
                     disabled={!!busy}
                     onClick={() => act(k, '/dj/segment', { type: s.type }, s.label)}
+                    onMouseEnter={e => { if (!busy) e.currentTarget.style.background = 'color-mix(in oklab, var(--accent) 18%, transparent)'; }}
+                    onMouseLeave={e => { e.currentTarget.style.background = 'color-mix(in oklab, var(--accent) 8%, transparent)'; }}
                     style={{
-                      border: '1px solid var(--ink)', background: 'transparent',
+                      border: '1px solid var(--accent)',
+                      background: 'color-mix(in oklab, var(--accent) 8%, transparent)',
                       padding: '12px 10px', textAlign: 'left', fontFamily: 'inherit',
                       display: 'flex', flexDirection: 'column', gap: 4, color: 'var(--ink)',
                       cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.4 : 1,
+                      transition: 'background 0.12s ease',
                     }}
                   >
                     <span style={{ fontSize: 11, letterSpacing: '0.18em', textTransform: 'uppercase', fontWeight: 700 }}>
                       {s.label}
                     </span>
-                    <span className="caption" style={{ fontSize: 9 }}>
-                      {busy === k ? 'firing…' : 'ready'}
+                    <span className="caption" style={{ fontSize: 9, color: 'var(--accent)', fontWeight: 700 }}>
+                      {busy === k ? 'firing…' : 'fire ▸'}
                     </span>
                   </button>
                 );

--- a/web/components/admin/PersonasPanel.jsx
+++ b/web/components/admin/PersonasPanel.jsx
@@ -48,15 +48,11 @@ function personaValid(p, defaultEngine) {
 }
 
 // For a cloud persona: why (if at all) its cloud voice won't actually play —
-// the global Cloud engine is switched off, or its provider's API key is
-// missing. Returns a human sentence, or null when the cloud voice is good to
-// go. A persona can look fully configured here yet still fall back silently;
-// this surfaces that gap before it airs.
+// its provider's API key is missing. Returns a human sentence, or null when
+// the cloud voice is good to go. A persona can look fully configured here yet
+// still fall back silently; this surfaces that gap before it airs.
 function cloudIssue(persona, data) {
   if (persona?.tts?.engine !== 'cloud') return null;
-  if (data?.values?.tts?.cloud?.enabled === false) {
-    return 'Cloud TTS is switched off in Settings → TTS voice.';
-  }
   const envKey = persona.tts.cloudProvider === 'elevenlabs'
     ? 'ELEVENLABS_API_KEY' : 'OPENAI_API_KEY';
   if (data?.env && !data.env[envKey]) {
@@ -456,7 +452,7 @@ export default function PersonasPanel() {
             <div className="field">
               <textarea
                 className="textarea"
-                rows="3"
+                rows="7"
                 value={focused.soul}
                 placeholder="e.g. warm and dry, never corny — observant, favours one good image over a list"
                 onChange={e => setPersona(safeIdx, { soul: e.target.value })}

--- a/web/components/admin/SettingsPanel.jsx
+++ b/web/components/admin/SettingsPanel.jsx
@@ -73,6 +73,7 @@ export default function SettingsPanel() {
       llm: {
         provider: data.values.llm?.provider ?? 'ollama',
         model: data.values.llm?.model ?? '',
+        ollamaUrl: data.values.llm?.ollamaUrl ?? '',
         pickerAgent: !!data.values.llm?.pickerAgent,
       },
     });
@@ -402,50 +403,22 @@ function KeyStatus({ envVar, present }) {
   );
 }
 
-/* Segmented engine picker built on the shared Seg primitive.
-   value is an engine name, or null when allowDefault and "use default". */
-function EngineSeg({ engines, available, value, onChange, allowDefault, defaultEngine }) {
-  const options = [];
-  if (allowDefault) options.push({ id: '__default__', label: `default · ${defaultEngine || 'piper'}` });
-  for (const e of engines) options.push({ id: e, label: e });
-  const selected = value == null ? '__default__' : value;
-
-  // Seg renders every option; disable unavailable engines by intercepting onChange.
-  return (
-    <div className="seg accent" style={{ flexWrap: 'wrap' }}>
-      {options.map(opt => {
-        const isEngine = opt.id !== '__default__';
-        const disabled = isEngine && available[opt.id] === false;
-        return (
-          <button
-            key={opt.id}
-            type="button"
-            disabled={disabled}
-            className={opt.id === selected ? 'active' : ''}
-            onClick={() => onChange(opt.id === '__default__' ? null : opt.id)}
-            title={disabled ? `${opt.id} is not installed in this build` : opt.label}
-          >
-            {opt.label}
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
 /* ── TTS ─────────────────────────────────────────────────────────────── */
 
 function TtsSection({ data, form, setForm, busy, saveMsg, saveSettings }) {
   const engines = data.tts.engines || ['piper'];
   const available = data.tts.available || {};
-  const hasCloud = engines.includes('cloud');
+  const ENGINE_LABELS = { piper: 'Piper', kokoro: 'Kokoro', cloud: 'Cloud' };
+  const engineOptions = engines.map(e => ({ id: e, label: ENGINE_LABELS[e] || e }));
 
   const save = () => saveSettings({
     tts: {
       defaultEngine: form.tts.defaultEngine,
       kokoro: { voice: form.tts.kokoro?.voice },
       cloud: {
-        enabled: form.tts.cloud.enabled,
+        // No "off" state — Cloud is configured-and-available whenever its
+        // API key is set; the real gate is the key, not a separate toggle.
+        enabled: true,
         provider: form.tts.cloud.provider,
         model: form.tts.cloud.model,
         voice: form.tts.cloud.voice,
@@ -455,15 +428,38 @@ function TtsSection({ data, form, setForm, busy, saveMsg, saveSettings }) {
     },
   });
 
+  // Switch the Cloud provider, revalidating the voice + model ids — both are
+  // provider-specific, so an OpenAI id is invalid against ElevenLabs.
+  const selectCloudProvider = (f, provider) => {
+    const provVoices = CLOUD_VOICES[provider] || [];
+    const voice = provVoices.some(pv => pv.id === f.tts.cloud.voice.trim())
+      ? f.tts.cloud.voice
+      : (provVoices[0]?.id || f.tts.cloud.voice);
+    const provModels = CLOUD_MODELS[provider] || [];
+    const model = provModels.includes(f.tts.cloud.model.trim())
+      ? f.tts.cloud.model
+      : (provModels[0] || f.tts.cloud.model);
+    return { ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, enabled: true, provider, voice, model } } };
+  };
+
+  // Pick the station engine; choosing Cloud also primes its provider config.
+  const selectEngine = (engine) => setForm(f => {
+    const base = engine === 'cloud'
+      ? selectCloudProvider(f, f.tts.cloud.provider || 'openai')
+      : f;
+    return { ...base, tts: { ...base.tts, defaultEngine: engine } };
+  });
+
   return (
     <>
       <SectionHeader
         eyebrow="tts voice"
-        title="The default voice engine and cloud config."
+        title="Pick a voice engine, then configure it."
         sub={<>
           Every spoken segment is voiced by the <strong>persona on air</strong> — set each
-          persona’s engine and voice on the Personas page. This page sets the default engine
-          used for jingle rendering and as the fallback, plus the shared Cloud engine config.
+          persona’s engine and voice on the Personas page. Here you pick the station’s
+          default engine (used for jingles and as the fallback) and configure whichever
+          one you choose.
           {available.kokoro === false && (
             <span style={{ color: 'var(--danger)' }}> Kokoro is unavailable in this build.</span>
           )}
@@ -473,137 +469,131 @@ function TtsSection({ data, form, setForm, busy, saveMsg, saveSettings }) {
         ]}
       />
 
-      {/* Station-level fallback — not per-persona */}
-      <Card title="Station TTS fallback" sub="jingle rendering + persona engine fallback">
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: 18 }}>
-          <div className="field">
-            <label className="field-label">Default engine</label>
-            <EngineSeg
-              engines={engines}
-              available={available}
-              value={form.tts.defaultEngine}
-              onChange={v => setForm(f => ({ ...f, tts: { ...f.tts, defaultEngine: v || 'piper' } }))}
-              allowDefault={false}
-            />
-            <div className="field-hint">Renders jingles, and is the fallback if a persona’s engine fails.</div>
+      {/* One engine selector — then only that engine's settings show. */}
+      <Card title="Voice engine" sub="pick one — then configure it">
+        <div className="field">
+          <label className="field-label">Engine</label>
+          <Seg
+            accent
+            value={form.tts.defaultEngine}
+            options={engineOptions}
+            onChange={selectEngine}
+          />
+          <div className="field-hint">
+            The station default — renders jingles and is the fallback when a persona’s
+            own engine fails. Per-segment voice still comes from the persona on air.
           </div>
-          {(data.tts.kokoroVoices?.length || 0) > 0 && (
-            <div className="field">
-              <label className="field-label">Kokoro voice</label>
-              <select
-                className="select"
-                value={form.tts.kokoro?.voice ?? 'bf_isabella'}
-                onChange={e => setForm(f => ({
-                  ...f, tts: { ...f.tts, kokoro: { ...f.tts.kokoro, voice: e.target.value } },
-                }))}
-              >
-                {data.tts.kokoroVoices.map(v => (
-                  <option key={v.id} value={v.id}>{v.label} — {v.id}</option>
-                ))}
-              </select>
-              <div className="field-hint">British English only. Applies to every kind routed through Kokoro.</div>
-            </div>
-          )}
         </div>
-      </Card>
 
-      {/* Cloud engine */}
-      {hasCloud && (
-        <Card title="Cloud engine" sub="optional · routes to OpenAI / ElevenLabs">
-          <div className="field">
-            <label className="field-label">Provider</label>
-            <Seg
-              accent
-              value={form.tts.cloud.enabled ? form.tts.cloud.provider : 'off'}
-              options={[
-                { id: 'off', label: 'off' },
-                ...(data.tts.cloudProviders || ['openai', 'elevenlabs']).map(p => ({ id: p, label: p })),
-              ]}
-              onChange={v => setForm(f => {
-                if (v === 'off') {
-                  return { ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, enabled: false } } };
-                }
-                // Switching provider invalidates the old voice id — default to
-                // the new provider's first curated voice unless the current one
-                // is already valid for it.
-                const provVoices = CLOUD_VOICES[v] || [];
-                const voice = provVoices.some(pv => pv.id === f.tts.cloud.voice.trim())
-                  ? f.tts.cloud.voice
-                  : (provVoices[0]?.id || f.tts.cloud.voice);
-                // Model ids are provider-specific too — an OpenAI id is invalid
-                // against ElevenLabs. Keep the current model only if it's known
-                // for the new provider, else fall back to its default.
-                const provModels = CLOUD_MODELS[v] || [];
-                const model = provModels.includes(f.tts.cloud.model.trim())
-                  ? f.tts.cloud.model
-                  : (provModels[0] || f.tts.cloud.model);
-                return { ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, enabled: true, provider: v, voice, model } } };
-              })}
-            />
-            {!form.tts.cloud.enabled && (
-              <div className="field-hint">Cloud TTS is off — engine pickers won’t offer it. Pick a provider to enable.</div>
+        {/* ── PIPER ────────────────────────────────────────────────── */}
+        {form.tts.defaultEngine === 'piper' && (
+          <div className="field" style={{ marginTop: 16 }}>
+            <div className="field-hint">
+              Piper is bundled with the controller — fast, lightweight, and always
+              available. Nothing to configure.
+            </div>
+          </div>
+        )}
+
+        {/* ── KOKORO ───────────────────────────────────────────────── */}
+        {form.tts.defaultEngine === 'kokoro' && (
+          <div className="field" style={{ marginTop: 16 }}>
+            <label className="field-label">Kokoro voice</label>
+            {available.kokoro === false && (
+              <div className="field-hint" style={{ color: 'var(--danger)' }}>
+                Kokoro is not installed in this build — it will fall back to Piper.
+              </div>
+            )}
+            {(data.tts.kokoroVoices?.length || 0) > 0 ? (
+              <>
+                <select
+                  className="select"
+                  value={form.tts.kokoro?.voice ?? 'bf_isabella'}
+                  onChange={e => setForm(f => ({
+                    ...f, tts: { ...f.tts, kokoro: { ...f.tts.kokoro, voice: e.target.value } },
+                  }))}
+                >
+                  {data.tts.kokoroVoices.map(v => (
+                    <option key={v.id} value={v.id}>{v.label} — {v.id}</option>
+                  ))}
+                </select>
+                <div className="field-hint">British English only. Applies to every kind routed through Kokoro.</div>
+              </>
+            ) : (
+              <div className="field-hint">This build reports no Kokoro voices.</div>
             )}
           </div>
-          {form.tts.cloud.enabled && (
-            <>
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 18, marginTop: 14 }}>
-                <div className="field">
-                  <label className="field-label">Model</label>
-                  <input
-                    className="input"
-                    value={form.tts.cloud.model}
-                    onChange={e => setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, model: e.target.value } } }))}
-                    placeholder={CLOUD_MODELS[form.tts.cloud.provider]?.[0] || 'gpt-4o-mini-tts'}
-                  />
-                  <div className="field-hint">e.g. “gpt-4o-mini-tts” (OpenAI) or “eleven_flash_v2_5” (ElevenLabs).</div>
-                </div>
-                {(() => {
-                  const provVoices = CLOUD_VOICES[form.tts.cloud.provider] || [];
-                  const voice = form.tts.cloud.voice.trim();
-                  const isPreset = provVoices.some(v => v.id === voice);
-                  return (
-                    <div className="field">
-                      <label className="field-label">Default voice</label>
-                      <select
-                        className="select"
-                        value={isPreset ? voice : '__custom__'}
-                        onChange={e => {
-                          if (e.target.value !== '__custom__') {
-                            setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, voice: e.target.value } } }));
-                          }
-                        }}
-                      >
-                        {provVoices.map(v => (
-                          <option key={v.id} value={v.id}>{v.label}</option>
-                        ))}
-                        <option value="__custom__">Custom voice id…</option>
-                      </select>
-                      {!isPreset && (
-                        <input
-                          className="input"
-                          style={{ marginTop: 8, borderColor: voice ? 'var(--ink)' : 'var(--danger)' }}
-                          value={form.tts.cloud.voice}
-                          maxLength={100}
-                          placeholder="Enter a custom voice id"
-                          onChange={e => setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, voice: e.target.value } } }))}
-                        />
-                      )}
-                      <div className="field-hint">
-                        Used when a Cloud persona hasn’t set its own voice. Pick a default, or choose
-                        <em> Custom voice id…</em> for any other OpenAI voice name / ElevenLabs voice id.
-                      </div>
-                    </div>
-                  );
-                })()}
-              </div>
-              <KeyStatus
-                envVar={form.tts.cloud.provider === 'elevenlabs' ? 'ELEVENLABS_API_KEY' : 'OPENAI_API_KEY'}
-                present={!!data.env?.[form.tts.cloud.provider === 'elevenlabs' ? 'ELEVENLABS_API_KEY' : 'OPENAI_API_KEY']}
+        )}
+
+        {/* ── CLOUD ────────────────────────────────────────────────── */}
+        {form.tts.defaultEngine === 'cloud' && (
+          <div style={{ marginTop: 16 }}>
+            <div className="field">
+              <label className="field-label">Provider</label>
+              <Seg
+                accent
+                value={form.tts.cloud.provider}
+                options={(data.tts.cloudProviders || ['openai', 'elevenlabs']).map(p => ({ id: p, label: p }))}
+                onChange={v => setForm(f => selectCloudProvider(f, v))}
               />
-            </>
-          )}
-        </Card>
-      )}
+            </div>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 18, marginTop: 14 }}>
+              <div className="field">
+                <label className="field-label">Model</label>
+                <input
+                  className="input"
+                  value={form.tts.cloud.model}
+                  onChange={e => setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, model: e.target.value } } }))}
+                  placeholder={CLOUD_MODELS[form.tts.cloud.provider]?.[0] || 'gpt-4o-mini-tts'}
+                />
+                <div className="field-hint">e.g. “gpt-4o-mini-tts” (OpenAI) or “eleven_flash_v2_5” (ElevenLabs).</div>
+              </div>
+              {(() => {
+                const provVoices = CLOUD_VOICES[form.tts.cloud.provider] || [];
+                const voice = form.tts.cloud.voice.trim();
+                const isPreset = provVoices.some(v => v.id === voice);
+                return (
+                  <div className="field">
+                    <label className="field-label">Default voice</label>
+                    <select
+                      className="select"
+                      value={isPreset ? voice : '__custom__'}
+                      onChange={e => {
+                        if (e.target.value !== '__custom__') {
+                          setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, voice: e.target.value } } }));
+                        }
+                      }}
+                    >
+                      {provVoices.map(v => (
+                        <option key={v.id} value={v.id}>{v.label}</option>
+                      ))}
+                      <option value="__custom__">Custom voice id…</option>
+                    </select>
+                    {!isPreset && (
+                      <input
+                        className="input"
+                        style={{ marginTop: 8, borderColor: voice ? 'var(--ink)' : 'var(--danger)' }}
+                        value={form.tts.cloud.voice}
+                        maxLength={100}
+                        placeholder="Enter a custom voice id"
+                        onChange={e => setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, voice: e.target.value } } }))}
+                      />
+                    )}
+                    <div className="field-hint">
+                      Used when a Cloud persona hasn’t set its own voice. Pick a default, or choose
+                      <em> Custom voice id…</em> for any other OpenAI voice name / ElevenLabs voice id.
+                    </div>
+                  </div>
+                );
+              })()}
+            </div>
+            <KeyStatus
+              envVar={form.tts.cloud.provider === 'elevenlabs' ? 'ELEVENLABS_API_KEY' : 'OPENAI_API_KEY'}
+              present={!!data.env?.[form.tts.cloud.provider === 'elevenlabs' ? 'ELEVENLABS_API_KEY' : 'OPENAI_API_KEY']}
+            />
+          </div>
+        )}
+      </Card>
 
       <SaveBar
         note="Applies to jingle rendering and the engine fallback · no mixer restart. Per-segment voice comes from the persona on air."
@@ -623,6 +613,7 @@ function LlmSection({ data, form, setForm, busy, saveMsg, saveSettings }) {
     llm: {
       provider: form.llm.provider,
       model: form.llm.model,
+      ollamaUrl: form.llm.ollamaUrl,
       pickerAgent: form.llm.pickerAgent,
       // The API key is never set from the UI — it comes from the controller's
       // environment (ANTHROPIC_API_KEY / OPENAI_API_KEY / AI_GATEWAY_API_KEY).
@@ -656,12 +647,12 @@ function LlmSection({ data, form, setForm, busy, saveMsg, saveSettings }) {
               className="input"
               value={form.llm.model}
               onChange={e => setForm(f => ({ ...f, llm: { ...f.llm, model: e.target.value } }))}
-              placeholder={form.llm.provider === 'ollama' ? '(OLLAMA_MODEL default)' : 'model id'}
+              placeholder={form.llm.provider === 'ollama' ? 'nemotron-3-super:cloud' : 'model id'}
               style={{ maxWidth: 360 }}
             />
             <div className="field-hint">
               {form.llm.provider === 'ollama'
-                ? 'Leave blank to use the OLLAMA_MODEL default.'
+                ? 'Ollama model tag, e.g. “nemotron-3-super:cloud”. Leave blank for the default.'
                 : form.llm.provider === 'gateway'
                   ? 'Gateway model id, e.g. “anthropic/claude-sonnet-4-5”.'
                   : form.llm.provider === 'openrouter'
@@ -671,6 +662,23 @@ function LlmSection({ data, form, setForm, busy, saveMsg, saveSettings }) {
                       : 'Model id for the chosen provider — required.'}
             </div>
           </div>
+
+          {form.llm.provider === 'ollama' && (
+            <div className="field">
+              <label className="field-label">Ollama server URL</label>
+              <input
+                className="input"
+                value={form.llm.ollamaUrl}
+                onChange={e => setForm(f => ({ ...f, llm: { ...f.llm, ollamaUrl: e.target.value } }))}
+                placeholder="http://localhost:11434"
+                style={{ maxWidth: 360 }}
+              />
+              <div className="field-hint">
+                Where the Ollama server runs. Leave blank for the default
+                (<code>http://localhost:11434</code>).
+              </div>
+            </div>
+          )}
 
           {form.llm.provider !== 'ollama' && (
             <KeyStatus

--- a/web/components/admin/ShowsPanel.jsx
+++ b/web/components/admin/ShowsPanel.jsx
@@ -357,7 +357,18 @@ export default function ShowsPanel() {
           display: 'grid', gridTemplateColumns: '1fr auto auto', gap: 16, alignItems: 'center',
         }}>
           <div>
-            <Eyebrow color="var(--accent)">shows · weekly grid</Eyebrow>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, flexWrap: 'wrap' }}>
+              <Eyebrow color="var(--accent)">shows · weekly grid</Eyebrow>
+              <span className="mono-num" style={{
+                fontSize: 12, fontWeight: 700, color: 'var(--ink)', letterSpacing: '0.04em',
+              }}>
+                {now.toLocaleDateString('en-GB', {
+                  weekday: 'short', day: '2-digit', month: 'short', year: 'numeric',
+                })}
+                {' · '}
+                {now.toLocaleTimeString('en-GB', { hour12: false })}
+              </span>
+            </div>
             <div style={{ fontSize: 22, fontWeight: 800, letterSpacing: '-0.02em', marginTop: 6 }}>
               Programme the week, one hour at a time.
             </div>

--- a/web/components/admin/SkillsPanel.jsx
+++ b/web/components/admin/SkillsPanel.jsx
@@ -12,6 +12,7 @@ import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { Card, Btn, Pill, Eyebrow, Toggle } from './ui';
+import { V3Alert } from '../ui/alert';
 
 function cooldownLabel(ms) {
   if (!ms) return 'no cooldown';
@@ -136,6 +137,15 @@ export default function SkillsPanel() {
             </>
           }
         >
+          {s.ready === false && (
+            <div style={{ marginBottom: 12 }}>
+              <V3Alert tone="error" title="API key not set">
+                This skill needs the <code>{s.requiresKey || 'required API key'}</code> environment
+                variable set in <code>controller/.env</code>. Until then it stays inert and never
+                fires autonomously — even when enabled.
+              </V3Alert>
+            </div>
+          )}
           <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: 16, alignItems: 'center' }}>
             <div>
               <div style={{ fontSize: 12, color: 'var(--muted)', lineHeight: 1.6 }}>


### PR DESCRIPTION
## Summary

A batch of admin-surface UX cleanups, plus moving Ollama's URL and model off env vars into the admin Settings UI.

### Admin UI tweaks
- **/admin/dash** — removed the "dj command center" header text and its bottom border; restyled the 3 DJ-segment buttons so they read as actionable (accent border, soft tint, hover state, "fire ▸" label instead of a passive "ready").
- **/admin/personas** — soul textarea height increased (3 → 7 rows).
- **/admin/skills** — a skill card now shows an error alert when its required env key is unset. Added generic `ready`/`requiresKey` fields to the controller's skill catalog; the Web search skill (`SEARCH_API_KEY`) is wired up.
- **/admin/shows** — hero header now shows a live current day / date / time, reusing the panel's existing clock state.
- **/admin/settings → TTS voice** — reworked the confusing two-card layout into a single Piper/Kokoro/Cloud engine selector that reveals only the selected engine's settings. The Cloud provider "off" option is removed — Cloud is configured-and-available whenever its API key is set.

### Ollama config → Settings UI
- New `llm.ollamaUrl` setting; the LLM provider tab now has an "Ollama server URL" field (Ollama only).
- `OLLAMA_URL` / `OLLAMA_MODEL` env vars dropped. `config.ollama` keeps `http://localhost:11434` / `nemotron-3-super:cloud` only as blank-fallback defaults.
- The provider registry, `/debug`, and the standalone library tagger all resolve URL + model from settings.
- Docs updated: `.env.example`, `DEPLOY.md`, `docs/admin/settings.md`, `subwave-deploy/SKILL.md`.

## Testing
- All modified controller files pass `node --check`.
- No test runner / linter is configured in this repo; web changes were reviewed by hand.

## Deploy note
The controller `COPY`s its source at build time — this needs `docker compose up -d --build controller` to take effect. The web changes hot-reload in dev.