### PR TITLE
Ignore session.json + sessions/ runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ state/icecast.xml
 state/jingles.json
 state/moods.json
 state/settings.json
+state/session.json
+state/sessions/
 state/liquidsoap_*.txt
 
 # OS / editor


### PR DESCRIPTION
PR #15 added `state/session.json` (the live DJ session) and `state/sessions/` (archived rolled sessions) — both controller-written runtime state. This adds them to `.gitignore` alongside the other `state/*` entries so they don't surface as untracked.