### PR TITLE
Derive state paths from STATE_DIR instead of hardcoding /var/sub-wave

### DIFF
--- a/controller/src/broadcast/jingles.js
+++ b/controller/src/broadcast/jingles.js
@@ -1,8 +1,8 @@
 // Jingles — pre-recorded TTS stingers that rotate into the broadcast at
 // 1-per-30-track intervals (see liquidsoap/radio.liq).
 //
-// Files live at /var/sub-wave/jingles/<hash>.wav and are referenced from
-// /var/sub-wave/jingles.m3u (one path per line). A sidecar /var/sub-wave/
+// Files live at <stateDir>/jingles/<hash>.wav and are referenced from
+// <stateDir>/jingles.m3u (one path per line). A sidecar <stateDir>/
 // jingles.json maps filename → { text, createdAt, builtin }.
 
 import { readFile, writeFile, unlink, mkdir, stat } from 'node:fs/promises';
@@ -10,10 +10,11 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { speak } from '../audio/tts.js';
+import { STATE_DIR } from '../config.js';
 
-const DIR = '/var/sub-wave/jingles';
-const PLAYLIST = '/var/sub-wave/jingles.m3u';
-const META = '/var/sub-wave/jingles.json';
+const DIR = `${STATE_DIR}/jingles`;
+const PLAYLIST = `${STATE_DIR}/jingles.m3u`;
+const META = `${STATE_DIR}/jingles.json`;
 
 const DEFAULT_IDENT = {
   filename: 'station_ident_default.wav',

--- a/controller/src/config.js
+++ b/controller/src/config.js
@@ -1,6 +1,20 @@
 // Centralised config — reads from env, with sensible defaults
 
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+// The shared state directory — every file-based IPC channel lives under here.
+// In Docker the compose files mount <repo>/state → /var/sub-wave and pass
+// STATE_DIR=/var/sub-wave. Native dev (`npm run dev` from controller/) has no
+// such mount, so it falls back to the repo-local state/ dir resolved relative
+// to this file (controller/src/config.js → ../../state).
+export const STATE_DIR = process.env.STATE_DIR
+  || resolve(dirname(fileURLToPath(import.meta.url)), '../../state');
+
 export const config = {
+  // Absolute path to the shared state dir — modules build their own file
+  // paths from this rather than hardcoding /var/sub-wave.
+  stateDir: STATE_DIR,
   navidrome: {
     url: process.env.NAVIDROME_URL || 'http://navidrome:4533',
     user: process.env.NAVIDROME_USER || '',
@@ -19,7 +33,7 @@ export const config = {
     binary: process.env.PIPER_BIN || '/usr/local/bin/piper',
     voice: process.env.PIPER_VOICE || '/opt/piper/voices/en_GB-alan-medium.onnx',
     voiceConfig: process.env.PIPER_VOICE_CONFIG || '/opt/piper/voices/en_GB-alan-medium.onnx.json',
-    outDir: process.env.PIPER_OUT || '/var/sub-wave/voice',
+    outDir: process.env.PIPER_OUT || `${STATE_DIR}/voice`,
   },
   kokoro: {
     python: process.env.KOKORO_PYTHON || '/opt/kokoro/venv/bin/python',
@@ -31,20 +45,20 @@ export const config = {
     speed: parseFloat(process.env.KOKORO_SPEED || '1.0'),
   },
   liquidsoap: {
-    queueFile: '/var/sub-wave/next.txt',
-    sayFile: '/var/sub-wave/say.txt',
+    queueFile: `${STATE_DIR}/next.txt`,
+    sayFile: `${STATE_DIR}/say.txt`,
     // Separate channel for talk-over voice (auto-links, anything that should
     // play OVER a track that's already started with light ducking instead of
     // heavy ducking the music to 25%). Read by a second poll thread in radio.liq.
-    introFile: '/var/sub-wave/intro.txt',
-    autoPlaylist: '/var/sub-wave/auto.m3u',
-    nowPlayingFile: '/var/sub-wave/now-playing.json',
+    introFile: `${STATE_DIR}/intro.txt`,
+    autoPlaylist: `${STATE_DIR}/auto.m3u`,
+    nowPlayingFile: `${STATE_DIR}/now-playing.json`,
   },
   session: {
     // The live DJ session — a chat-history JSON the controller rewrites as
     // tracks play and the DJ talks. Archived sessions land in `dir` on roll.
-    currentFile: '/var/sub-wave/session.json',
-    dir: '/var/sub-wave/sessions',
+    currentFile: `${STATE_DIR}/session.json`,
+    dir: `${STATE_DIR}/sessions`,
   },
   weather: {
     // Wolverhampton — your home location

--- a/controller/src/llm/log.js
+++ b/controller/src/llm/log.js
@@ -6,6 +6,7 @@
 // layer (dj.js) can record without an import cycle.
 
 import { appendFile } from 'node:fs/promises';
+import { STATE_DIR } from '../config.js';
 
 const MAX_CALLS = 120;
 export const recentCalls = [];
@@ -19,7 +20,7 @@ export function record(call) {
 // above is lost on restart; this tab-separated file in the shared state volume
 // survives, so repeated-pick patterns stay reviewable after the fact.
 // Best-effort: a write failure must never break a pick.
-const PICKS_LOG = '/var/sub-wave/logs/picks.log';
+const PICKS_LOG = `${STATE_DIR}/logs/picks.log`;
 
 export function recordPick({ song, reason, source }) {
   const line = [

--- a/controller/src/music/library.js
+++ b/controller/src/music/library.js
@@ -4,8 +4,9 @@
 
 import { readFile, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
+import { STATE_DIR } from '../config.js';
 
-const PATH = '/var/sub-wave/moods.json';
+const PATH = `${STATE_DIR}/moods.json`;
 
 let store = { tracks: {}, updatedAt: null };
 let loaded = false;

--- a/controller/src/routes/debug.js
+++ b/controller/src/routes/debug.js
@@ -65,10 +65,10 @@ router.get('/debug', requireAdmin, async (req, res) => {
 
   // 4. Liquidsoap log tail — Liquidsoap writes radio.log into the shared
   // state dir's logs/ subfolder (see radio.liq + the liquidsoap volume
-  // mount), which the controller sees via the /var/sub-wave state mount.
+  // mount), which the controller sees via the shared state mount.
   // Reading it here means no extra controller-side log mount is needed.
   try {
-    const log = await readFile('/var/sub-wave/logs/radio.log', 'utf8');
+    const log = await readFile(`${config.stateDir}/logs/radio.log`, 'utf8');
     out.liquidsoapLog = log.split('\n').slice(-100).join('\n');
   } catch (err) {
     out.liquidsoapLog = `error: ${err.message}`;
@@ -76,7 +76,7 @@ router.get('/debug', requireAdmin, async (req, res) => {
 
   // 5. State dir listing
   try {
-    const dir = '/var/sub-wave';
+    const dir = config.stateDir;
     const entries = await readdir(dir);
     out.stateFiles = await Promise.all(entries.map(async (name) => {
       try {

--- a/controller/src/settings.js
+++ b/controller/src/settings.js
@@ -1,14 +1,15 @@
 // Durable settings — overrides for values that have static defaults in code.
-// Stored at /var/sub-wave/settings.json. Some apply live (weather location,
+// Stored at <stateDir>/settings.json. Some apply live (weather location,
 // DJ personas, shows); others require a Liquidsoap restart (jingle frequency,
 // crossfade duration).
 
 import { readFile, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
+import { STATE_DIR } from './config.js';
 
-const SETTINGS_PATH = '/var/sub-wave/settings.json';
-const LIQ_SETTINGS_PATH = '/var/sub-wave/liquidsoap_settings.json';
+const SETTINGS_PATH = `${STATE_DIR}/settings.json`;
+const LIQ_SETTINGS_PATH = `${STATE_DIR}/liquidsoap_settings.json`;
 
 // Default DJ system-prompt template. Placeholders are substituted at LLM
 // call time via renderDjPrompt(). Keep {name} mandatory — update() refuses
@@ -759,8 +760,8 @@ export function renderDjPrompt(persona, ctx = {}) {
 }
 
 // Liquidsoap reads two tiny text files instead of JSON.
-const LIQ_JINGLE_RATIO_PATH = '/var/sub-wave/liquidsoap_jingle_ratio.txt';
-const LIQ_CROSSFADE_PATH = '/var/sub-wave/liquidsoap_crossfade.txt';
+const LIQ_JINGLE_RATIO_PATH = `${STATE_DIR}/liquidsoap_jingle_ratio.txt`;
+const LIQ_CROSSFADE_PATH = `${STATE_DIR}/liquidsoap_crossfade.txt`;
 
 export async function writeLiquidsoapSettings(s) {
   await writeFile(LIQ_JINGLE_RATIO_PATH, String(s.jingleRatio));

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -94,6 +94,10 @@ services:
       # and fires shows an hour early during BST, out of sync with the admin UI
       # (which computes the on-air slot in the browser's timezone).
       - TZ=${TZ:-Europe/London}
+      # In-container path of the *state-mount below. The controller derives
+      # every state file path from this. Note this is distinct from the
+      # host-side STATE_DIR used to interpolate the mount source above.
+      - STATE_DIR=/var/sub-wave
     env_file:
       - ../controller/.env
     extra_hosts:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -64,6 +64,10 @@ services:
       # Without TZ the container runs in UTC; schedule slots (day-of-week +
       # hour) would then resolve an hour off from the admin UI during BST.
       - TZ=${TZ:-Europe/London}
+      # In-container path of the shared state mount below. The controller
+      # derives every state file path from this; native dev (npm run dev)
+      # has no STATE_DIR and falls back to the repo-local state/ dir.
+      - STATE_DIR=/var/sub-wave
     depends_on:
       - liquidsoap
     ports:


### PR DESCRIPTION
## What

The controller hardcoded the in-container mount path `/var/sub-wave` across six files. Native `npm run dev` from `controller/` has no Docker mount, so it wrote to a path that doesn't exist.

This introduces a single `STATE_DIR` in `config.js`, and derives every state file path from it.

- **In Docker** — both compose files pass `STATE_DIR=/var/sub-wave`, so behaviour is unchanged.
- **Native dev** — no env var → falls back to the repo-local `state/` dir, resolved relative to `config.js`.

## Changes

| File | Paths now derived from `STATE_DIR` |
|------|-----|
| `config.js` | exports `STATE_DIR` + `config.stateDir`; `piper.outDir`, `liquidsoap.*`, `session.*` |
| `settings.js` | `settings.json`, `liquidsoap_settings.json`, `liquidsoap_jingle_ratio.txt`, `liquidsoap_crossfade.txt` |
| `music/library.js` | `moods.json` |
| `llm/log.js` | `logs/picks.log` |
| `broadcast/jingles.js` | `jingles/`, `jingles.m3u`, `jingles.json` |
| `routes/debug.js` | `logs/radio.log`, state-dir listing |
| `docker-compose.yml` / `.prod.yml` | added `STATE_DIR=/var/sub-wave` to controller env |

`liquidsoap/radio.liq` still hardcodes `/var/sub-wave` — correct, it only ever runs in-container.

## Test

- All 6 modules syntax-checked (`node --check`).
- Verified path resolution both modes: native dev → `<repo>/state/...`, Docker → `/var/sub-wave/...`.
- Brought up the dev stack: controller `{"status":"on-air"}`, web HTTP 200, `session.json` landed in `state/` via the mount.