### PR TITLE
Add /what feature-story page introducing SUB/WAVE

### DIFF
--- a/web/app/what/page.js
+++ b/web/app/what/page.js
@@ -1,0 +1,17 @@
+import WhatPage from '../../components/WhatPage';
+
+export const metadata = {
+  title: 'What is SUB/WAVE — Inside the station',
+  description:
+    'A feature story on SUB/WAVE: a personal internet radio station with an LLM-driven DJ, live song requests, and a full operator console.',
+};
+
+// Fixed app-shell layout — lock out pinch-zoom on mobile. Merges with root.
+export const viewport = {
+  maximumScale: 1,
+  userScalable: false,
+};
+
+export default function WhatRoutePage() {
+  return <WhatPage />;
+}

--- a/web/components/WhatPage.jsx
+++ b/web/components/WhatPage.jsx
@@ -1,0 +1,32 @@
+import Masthead from './landing/Masthead';
+import StationFooter from './landing/StationFooter';
+import ArticleHead from './what/ArticleHead';
+import OnTheAir from './what/OnTheAir';
+import MeetTheVoices from './what/MeetTheVoices';
+import MakeARequest from './what/MakeARequest';
+import BehindTheDesk from './what/BehindTheDesk';
+import UnderTheHood from './what/UnderTheHood';
+import Coda from './what/Coda';
+
+// Feature-story page at /what. A newsprint-broadsheet article introducing
+// SUB/WAVE — the listener player, the AI DJ, song requests, the admin console,
+// and the architecture. Screenshot slots render placeholders until real images
+// are dropped in via the Figure component's `src` prop.
+export default function WhatPage() {
+  return (
+    <div style={{ background: 'var(--bg)', color: 'var(--ink)', minHeight: '100vh' }}>
+      <Masthead />
+
+      <main className="bs-paper">
+        <ArticleHead />
+        <OnTheAir />
+        <MeetTheVoices />
+        <MakeARequest />
+        <BehindTheDesk />
+        <UnderTheHood />
+        <Coda />
+        <StationFooter />
+      </main>
+    </div>
+  );
+}

--- a/web/components/landing/Masthead.jsx
+++ b/web/components/landing/Masthead.jsx
@@ -64,6 +64,8 @@ export default function Masthead() {
         <span aria-hidden="true" className="bs-masthead-sep">·</span>
         <Link href="/setup" className="bs-masthead-link">Setup</Link>
         <span aria-hidden="true" className="bs-masthead-sep">·</span>
+        <Link href="/what" className="bs-masthead-link">About</Link>
+        <span aria-hidden="true" className="bs-masthead-sep">·</span>
         <Link href="/landing" className="bs-masthead-link">Home</Link>
         <span aria-hidden="true" className="bs-masthead-sep">·</span>
         <a

--- a/web/components/what/ArticleHead.jsx
+++ b/web/components/what/ArticleHead.jsx
@@ -1,0 +1,50 @@
+export default function ArticleHead() {
+  return (
+    <section className="bs-hero" style={{ paddingBottom: 0 }}>
+      <div className="bs-hero-head">
+        <p className="bs-eyebrow">FEATURE · THE STATION</p>
+        <h1 className="bs-hero-title">
+          Inside SUB/WAVE — the radio station that runs itself.
+        </h1>
+        <p className="bs-hero-deck">
+          One stream, an LLM behind the desk, and a music library that already
+          belongs to you. We spent a week tuned in to find out what a personal
+          radio station actually feels like.
+        </p>
+      </div>
+
+      <div
+        className="flex flex-wrap items-baseline"
+        style={{
+          gap: 16,
+          fontSize: 10,
+          letterSpacing: '0.24em',
+          textTransform: 'uppercase',
+          fontWeight: 700,
+          color: 'var(--muted)',
+          borderTop: '1px solid var(--separator-strong)',
+          borderBottom: '1px solid var(--separator-strong)',
+          padding: '12px 0',
+        }}
+      >
+        <span style={{ color: 'var(--ink)' }}>By the SUB/WAVE Desk</span>
+        <span aria-hidden="true">·</span>
+        <span>May 2026</span>
+        <span aria-hidden="true">·</span>
+        <span style={{ color: 'var(--accent)' }}>Eight minute read</span>
+      </div>
+
+      <div className="bs-drop-cap" style={{ fontSize: 16, lineHeight: 1.6, maxWidth: '64ch' }}>
+        Streaming apps gave everyone their own private channel. A playlist tuned
+        to you, shuffled for you, paused the second you look away. SUB/WAVE goes
+        the other direction entirely. It is one Icecast stream — a single
+        broadcast every listener hears at the same moment — picked, announced,
+        and mixed by software running on a single box in someone&apos;s home.
+        There is no skip button. There is no &ldquo;for you.&rdquo; You tune in,
+        and you hear whatever is on the air right now, the same as everyone else.
+        What follows is a tour of the station: the player listeners see, the AI
+        DJ between the tracks, and the console the operator runs it all from.
+      </div>
+    </section>
+  );
+}

--- a/web/components/what/BehindTheDesk.jsx
+++ b/web/components/what/BehindTheDesk.jsx
@@ -1,0 +1,93 @@
+import Figure from './Figure';
+
+const PANELS = [
+  {
+    eyebrow: 'DASH',
+    title: 'The command center.',
+    body:
+      'Live status — who is on air, the mood, listener count, weather. See the queue, read the booth log, skip a track, fire a station ID, or send your own words to air as raw or styled voice.',
+  },
+  {
+    eyebrow: 'SETTINGS',
+    title: 'TTS, LLM, mixer, jingles.',
+    body:
+      'Pick the voice engine and the language model, set the crossfade and station location, build station idents. A danger zone starts, stops, and restarts the broadcast.',
+  },
+  {
+    eyebrow: 'PERSONAS',
+    title: 'The voices on the station.',
+    body:
+      'Up to twelve DJ identities — name, soul, tagline, talk frequency, voice, and which skills each one may use. One persona is on air at a time; a show can hand it the hour.',
+  },
+  {
+    eyebrow: 'SHOWS',
+    title: 'A weekly schedule you paint.',
+    body:
+      'A 24×7 grid you brush shows onto. Each show carries a persona, a music mood, and a topic brief — genres, eras, the host’s tone. Autonomous hours fill whatever you leave blank.',
+  },
+  {
+    eyebrow: 'LIBRARY',
+    title: 'Search, queue, and tag.',
+    body:
+      'Search the Navidrome library by text, mood, and energy, queue any track, and browse recent additions. The mood tagger walks the library album-by-album and classifies every track.',
+  },
+  {
+    eyebrow: 'SKILLS & DEBUG',
+    title: 'Segments and diagnostics.',
+    body:
+      'Skills are the autonomous segments the DJ runs between tracks — toggle them on, run any one now. Debug and Stats show health, logs, LLM call history, and usage at a glance.',
+  },
+];
+
+export default function BehindTheDesk() {
+  return (
+    <section className="bs-section">
+      <p className="bs-eyebrow">PART FOUR · THE CONSOLE</p>
+      <h2>Behind the desk.</h2>
+      <p className="muted">
+        Everything a listener hears is shaped from one place — a gated admin
+        console with eight panels. This is where the operator actually runs the
+        station.
+      </p>
+
+      <Figure
+        label="Admin — Dash"
+        caption="The Dash panel: live status, the queue, the booth log, and manual voice control."
+      />
+
+      <div className="bs-whatis-grid" style={{ marginTop: 16 }}>
+        {PANELS.map((p) => (
+          <article key={p.eyebrow} className="bs-whatis-card">
+            <div className="bs-eyebrow" style={{ marginBottom: 8 }}>{p.eyebrow}</div>
+            <h3
+              style={{
+                margin: '0 0 10px',
+                fontSize: 'clamp(20px, 2.2vw, 26px)',
+                fontWeight: 800,
+                letterSpacing: '-0.02em',
+                lineHeight: 1.15,
+              }}
+            >
+              {p.title}
+            </h3>
+            <p style={{ margin: 0, fontSize: 14, lineHeight: 1.55, color: 'var(--muted)' }}>
+              {p.body}
+            </p>
+          </article>
+        ))}
+      </div>
+
+      <div className="bs-grid-split" style={{ marginTop: 16 }}>
+        <Figure
+          label="Admin — Weekly Schedule"
+          caption="Shows: brush programming onto a 24×7 grid, each slot its own persona and mood."
+        />
+        <div className="bs-column-rule" aria-hidden="true" />
+        <Figure
+          label="Admin — Debug"
+          caption="Debug: a health strip, Liquidsoap logs, and recent LLM calls — refreshed live."
+        />
+      </div>
+    </section>
+  );
+}

--- a/web/components/what/Coda.jsx
+++ b/web/components/what/Coda.jsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+
+export default function Coda() {
+  return (
+    <section className="bs-section" style={{ alignItems: 'center', textAlign: 'center' }}>
+      <p className="bs-eyebrow" style={{ alignSelf: 'center' }}>END OF FEATURE</p>
+      <h2 style={{ maxWidth: '20ch' }}>The station is on air right now.</h2>
+      <p className="muted" style={{ textAlign: 'center' }}>
+        There is nothing to scroll and nothing to pick. Tune in and hear what
+        the DJ is playing — or stand up your own frequency from the source.
+      </p>
+
+      <div
+        className="flex flex-wrap items-center justify-center"
+        style={{ gap: 16, marginTop: 8 }}
+      >
+        <Link href="/listen" className="bs-tune">▶ Open the player</Link>
+        <Link href="/setup" className="bs-link" style={{ fontSize: 13, letterSpacing: '0.12em', textTransform: 'uppercase', fontWeight: 700 }}>
+          Run your own station →
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/web/components/what/Figure.jsx
+++ b/web/components/what/Figure.jsx
@@ -1,0 +1,65 @@
+'use client';
+
+// Screenshot slot for the /what feature story. While `src` is empty it renders
+// a labelled placeholder box; pass `src` later and the same component swaps in
+// the real image — no layout change. Inline styles only, no globals.css edits.
+export default function Figure({ src, alt, caption, label, ratio = '16 / 10' }) {
+  return (
+    <figure style={{ margin: 0, display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {src ? (
+        <img
+          src={src}
+          alt={alt || caption || label || ''}
+          style={{
+            display: 'block',
+            width: '100%',
+            border: '1px solid var(--ink)',
+            aspectRatio: ratio,
+            objectFit: 'cover',
+          }}
+        />
+      ) : (
+        <div
+          role="img"
+          aria-label={alt || `Placeholder: ${label}`}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            textAlign: 'center',
+            padding: 16,
+            aspectRatio: ratio,
+            border: '1px dashed var(--separator-strong)',
+            background: 'var(--overlay)',
+          }}
+        >
+          <span
+            style={{
+              fontSize: 11,
+              letterSpacing: '0.24em',
+              textTransform: 'uppercase',
+              fontWeight: 700,
+              color: 'var(--muted)',
+            }}
+          >
+            {label || 'Screenshot'}
+          </span>
+        </div>
+      )}
+      {caption && (
+        <figcaption
+          style={{
+            fontSize: 10,
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            color: 'var(--muted)',
+            fontWeight: 500,
+          }}
+        >
+          <span style={{ color: 'var(--accent)', fontWeight: 700 }}>FIG.&nbsp;</span>
+          {caption}
+        </figcaption>
+      )}
+    </figure>
+  );
+}

--- a/web/components/what/MakeARequest.jsx
+++ b/web/components/what/MakeARequest.jsx
@@ -1,0 +1,92 @@
+import Figure from './Figure';
+
+const STEPS = [
+  {
+    n: '01',
+    title: 'Ask in plain language.',
+    body:
+      'Open the request drawer and type what you want — a song title, an artist, a vibe. No exact spelling, no library browsing. Add your name if you want the DJ to use it on air.',
+  },
+  {
+    n: '02',
+    title: 'Get an instant nod.',
+    body:
+      '“Got it — taking it to the booth.” The acknowledgement is immediate while the matching happens in the background, so the drawer never just sits there.',
+  },
+  {
+    n: '03',
+    title: 'The DJ finds the match.',
+    body:
+      'An LLM reads your request, searches the library, and picks the closest real track. Suggestion chips — built from the current artist, the time of day, the weather — give you a head start if you are undecided.',
+  },
+  {
+    n: '04',
+    title: 'It airs, with an intro.',
+    body:
+      'When the match lands, the drawer shows the track and the DJ’s spoken intro. Your request joins the one queue everyone is hearing — and the DJ may say your name as it goes out.',
+  },
+];
+
+export default function MakeARequest() {
+  return (
+    <section className="bs-section">
+      <p className="bs-eyebrow">PART THREE · REQUESTS</p>
+      <h2>Phone the station, like you used to.</h2>
+      <p className="muted">
+        Requests are the one place a listener steers the broadcast — and it
+        works the way calling a radio station always should have.
+      </p>
+
+      <div className="bs-grid-split">
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+          {STEPS.map((s) => (
+            <div
+              key={s.n}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '48px 1fr',
+                gap: 14,
+                alignItems: 'baseline',
+              }}
+            >
+              <span
+                style={{
+                  fontSize: 22,
+                  fontWeight: 800,
+                  color: 'var(--accent)',
+                  letterSpacing: '-0.02em',
+                }}
+              >
+                {s.n}
+              </span>
+              <div>
+                <h3
+                  style={{
+                    margin: '0 0 6px',
+                    fontSize: 'clamp(17px, 1.8vw, 21px)',
+                    fontWeight: 800,
+                    letterSpacing: '-0.02em',
+                    lineHeight: 1.2,
+                  }}
+                >
+                  {s.title}
+                </h3>
+                <p style={{ margin: 0, fontSize: 14, lineHeight: 1.55, color: 'var(--muted)' }}>
+                  {s.body}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="bs-column-rule" aria-hidden="true" />
+        <div>
+          <Figure
+            label="Player — Request a Song"
+            caption="The request drawer: type a song, get an instant ack, watch the match land."
+            ratio="3 / 4"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/components/what/MeetTheVoices.jsx
+++ b/web/components/what/MeetTheVoices.jsx
@@ -1,0 +1,64 @@
+import Figure from './Figure';
+
+const HABITS = [
+  {
+    label: 'PICKS THE NEXT TRACK',
+    body:
+      'The DJ reads the time, the weather, the season, festivals on the calendar, what just played, and any listener requests — then asks an LLM what should come next and pulls a real song from the library.',
+  },
+  {
+    label: 'TALKS BETWEEN SONGS',
+    body:
+      'Intros, time checks, weather reads, and station idents are all written live in the DJ’s voice, then spoken aloud and ducked under the music. Nothing is pre-recorded.',
+  },
+  {
+    label: 'CHANGES WITH THE HOUR',
+    body:
+      'A scheduled show can hand the hour to a different persona — each with its own name, personality, voice, and how often it speaks. The 3am host is not the 8am host.',
+  },
+];
+
+export default function MeetTheVoices() {
+  return (
+    <section className="bs-section">
+      <p className="bs-eyebrow">PART TWO · THE DJ</p>
+      <h2>An LLM with a library and a microphone.</h2>
+      <p className="muted">
+        The voice between the tracks is not air talent. It is a persona — a name,
+        a soul, a voice engine, and a talk frequency — driven by a language model.
+      </p>
+
+      <Figure
+        label="Admin — Personas"
+        caption="The persona roster: up to twelve DJ identities, each with its own voice and habits."
+      />
+
+      <div className="bs-dj-cards" style={{ marginTop: 16 }}>
+        {HABITS.map((h) => (
+          <article key={h.label} className="bs-whatis-card">
+            <div className="bs-eyebrow" style={{ marginBottom: 8 }}>{h.label}</div>
+            <p style={{ margin: 0, fontSize: 14, lineHeight: 1.55, color: 'var(--muted)' }}>
+              {h.body}
+            </p>
+          </article>
+        ))}
+      </div>
+
+      <p
+        style={{
+          marginTop: 8,
+          fontSize: 14,
+          lineHeight: 1.6,
+          color: 'var(--muted)',
+          maxWidth: '64ch',
+        }}
+      >
+        The model behind it is the operator’s choice — a local Ollama box, or a
+        hosted provider like Anthropic, OpenAI, or Google. The voice is just as
+        swappable: bundled Piper and Kokoro run on-device, or a cloud voice from
+        OpenAI or ElevenLabs. Change either one in the console and the next
+        spoken line uses it. No redeploy.
+      </p>
+    </section>
+  );
+}

--- a/web/components/what/OnTheAir.jsx
+++ b/web/components/what/OnTheAir.jsx
@@ -1,0 +1,68 @@
+import Figure from './Figure';
+
+const POINTS = [
+  {
+    eyebrow: 'NOW PLAYING',
+    title: 'The track, the artist, the booth.',
+    body:
+      'The player opens on whatever is on air — cover art pulled straight from your library, title, artist, album, and elapsed time. A waveform tracks the audio underneath. It is not your queue. It is the station’s.',
+  },
+  {
+    eyebrow: 'TIMELINE & BOOTH',
+    title: 'See what is coming, hear what was said.',
+    body:
+      'Two drawers slide out from the side. The Timeline shows tracks queued and recently played; the Booth is a live log of every word the DJ has spoken — station IDs, time checks, weather, the links between songs.',
+  },
+  {
+    eyebrow: 'NO SKIP, ON PURPOSE',
+    title: 'A shared broadcast, not a remote control.',
+    body:
+      'There is no skip control for listeners — a stray double-tap on someone’s headphones should not change the song for everyone else. Track-end is the only natural transition. It is radio, so it behaves like radio.',
+  },
+  {
+    eyebrow: 'INSTALL IT',
+    title: 'A real app on the lock screen.',
+    body:
+      'SUB/WAVE installs as a PWA — a home-screen icon, full-screen, offline-aware. The OS media controls wire straight through, so the lock screen, your headphones, and the car display all show the station and pause it cleanly.',
+  },
+];
+
+export default function OnTheAir() {
+  return (
+    <section className="bs-section">
+      <p className="bs-eyebrow">PART ONE · THE PLAYER</p>
+      <h2>One stream, every listener.</h2>
+      <p className="muted">
+        Open the player and you join a broadcast already in progress. Here is
+        what a listener actually sees.
+      </p>
+
+      <Figure
+        label="Player — Now Playing"
+        caption="The listener view: cover art, now-playing metadata, and the live waveform."
+      />
+
+      <div className="bs-whatis-grid" style={{ marginTop: 16 }}>
+        {POINTS.map((p) => (
+          <article key={p.eyebrow} className="bs-whatis-card">
+            <div className="bs-eyebrow" style={{ marginBottom: 8 }}>{p.eyebrow}</div>
+            <h3
+              style={{
+                margin: '0 0 10px',
+                fontSize: 'clamp(20px, 2.2vw, 26px)',
+                fontWeight: 800,
+                letterSpacing: '-0.02em',
+                lineHeight: 1.15,
+              }}
+            >
+              {p.title}
+            </h3>
+            <p style={{ margin: 0, fontSize: 14, lineHeight: 1.55, color: 'var(--muted)' }}>
+              {p.body}
+            </p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/web/components/what/UnderTheHood.jsx
+++ b/web/components/what/UnderTheHood.jsx
@@ -1,0 +1,81 @@
+import { Fragment } from 'react';
+
+const BOXES = [
+  { label: 'CONTROLLER', tone: 'default', note: 'node.js' },
+  { label: 'DJ BRAIN', tone: 'accent', note: 'llm' },
+  { label: 'LIQUIDSOAP', tone: 'default', note: 'mixer' },
+  { label: 'ICECAST', tone: 'default', note: 'one stream' },
+];
+
+export default function UnderTheHood() {
+  return (
+    <section className="bs-section">
+      <p className="bs-eyebrow">PART FIVE · UNDER THE HOOD</p>
+      <h2>Four processes, one box, one stream out.</h2>
+
+      <div
+        className="bs-drop-cap"
+        style={{ fontSize: 15, lineHeight: 1.6, maxWidth: '64ch' }}
+      >
+        SUB/WAVE is not a cloud service. The whole stack — Icecast, Liquidsoap,
+        the Controller, the LLM, the voice engines, and a Caddy edge — runs on a
+        single machine in someone’s home, behind Cloudflare. The Controller is a
+        small Node.js process that decides what plays and what gets said.
+        Liquidsoap mixes the music, crossfades the tracks, ducks the DJ’s voice
+        over the bed, and rotates the jingles. Icecast pushes the one stream out
+        to every browser. The pieces talk through plain files in a shared folder
+        — no socket, no message queue, the Unix way.
+      </div>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(7, 1fr)',
+          alignItems: 'center',
+          gap: 8,
+          marginTop: 28,
+        }}
+      >
+        {BOXES.map((b, i) => (
+          <Fragment key={b.label}>
+            <div
+              className="bs-box"
+              data-tone={b.tone === 'accent' ? 'accent' : undefined}
+              style={{ gridColumn: 'span 1' }}
+            >
+              {b.label}
+              <div
+                style={{
+                  fontSize: 9,
+                  letterSpacing: '0.18em',
+                  color: 'var(--muted)',
+                  marginTop: 4,
+                  fontWeight: 500,
+                  textTransform: 'lowercase',
+                }}
+              >
+                {b.note}
+              </div>
+            </div>
+            {i < BOXES.length - 1 && <div className="bs-arrow">⟶</div>}
+          </Fragment>
+        ))}
+      </div>
+
+      <p
+        style={{
+          marginTop: 24,
+          fontSize: 14,
+          lineHeight: 1.6,
+          color: 'var(--muted)',
+          maxWidth: '64ch',
+        }}
+      >
+        No subscriptions, no round-trip to a data center, no algorithm tuned to
+        keep you scrolling. The whole source is open — so you can run your own
+        with a different DJ persona, a different library, and a different city
+        on the dateline.
+      </p>
+    </section>
+  );
+}


### PR DESCRIPTION
A newsprint-broadsheet article page at /what walking through the
listener player, the AI DJ, song requests, the admin console, and the
architecture. Screenshot slots render labelled placeholders until real
images are dropped in via the Figure component's src prop. Adds an
"About" link to the shared landing masthead nav.

https://claude.ai/code/session_01JuGKMAWyDdf4pafZkhKQpG