### PR TITLE
Add /manual route — a multi-page user manual

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1213,6 +1213,115 @@ body::after {
 }
 
 /* ─────────────────────────────────────────────────────────────────────────
+   MANUAL — two-column docs layout: sticky sidebar contents + content pages.
+   ───────────────────────────────────────────────────────────────────────── */
+.bs-manual-layout {
+    display: grid;
+    grid-template-columns: 220px minmax(0, 1fr);
+    gap: clamp(24px, 4vw, 56px);
+}
+@media (max-width: 860px) {
+    .bs-manual-layout {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 0;
+    }
+}
+
+.bs-manual-nav {
+    align-self: start;
+    position: sticky;
+    top: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding-top: 28px;
+}
+@media (max-width: 860px) {
+    .bs-manual-nav {
+        position: static;
+        padding: 24px 0 16px;
+        border-bottom: 1px solid var(--ink);
+        margin-bottom: 8px;
+    }
+}
+
+.bs-manual-nav-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.bs-manual-nav-link {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 8px 10px;
+    font-size: 13px;
+    line-height: 1.3;
+    font-weight: 600;
+    color: var(--muted);
+    text-decoration: none;
+    border-left: 2px solid transparent;
+    transition: color 120ms, border-color 120ms, background 120ms;
+}
+.bs-manual-nav-link:hover {
+    color: var(--ink);
+}
+.bs-manual-nav-link[data-active] {
+    color: var(--ink);
+    border-left-color: var(--accent);
+    background: color-mix(in oklab, var(--ink) 5%, transparent);
+}
+.bs-manual-nav-num {
+    font-size: 10px;
+    letter-spacing: 0.14em;
+    font-weight: 700;
+    color: var(--accent);
+}
+
+.bs-manual-content {
+    min-width: 0;
+}
+.bs-manual-content .bs-section:first-of-type {
+    border-top: 0;
+    padding-top: clamp(8px, 2vw, 20px);
+}
+.bs-manual-pagelinks {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: space-between;
+    border-top: 1px solid var(--separator-strong);
+    padding-top: 24px;
+    margin-top: 8px;
+}
+.bs-manual-pagelink {
+    font-size: 12px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: var(--ink);
+    text-decoration: none;
+}
+.bs-manual-pagelink:hover {
+    color: var(--accent);
+}
+.bs-manual-pagelink span {
+    display: block;
+    font-size: 10px;
+    letter-spacing: 0.2em;
+    color: var(--muted);
+    margin-bottom: 4px;
+}
+.bs-manual-pagelink[data-dir="next"] {
+    text-align: right;
+    margin-left: auto;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
    REQUEST CAROUSEL — single-card rotating thread of example exchanges.
    ───────────────────────────────────────────────────────────────────────── */
 .bs-carousel {

--- a/web/app/manual/admin/page.js
+++ b/web/app/manual/admin/page.js
@@ -1,0 +1,7 @@
+import AdminSettings from '../../../components/manual/AdminSettings';
+
+export const metadata = { title: 'SUB/WAVE — Manual · Admin & Settings' };
+
+export default function AdminSettingsPage() {
+  return <AdminSettings />;
+}

--- a/web/app/manual/dj/page.js
+++ b/web/app/manual/dj/page.js
@@ -1,0 +1,7 @@
+import HowTheDjWorks from '../../../components/manual/HowTheDjWorks';
+
+export const metadata = { title: 'SUB/WAVE — Manual · How the DJ Works' };
+
+export default function HowTheDjWorksPage() {
+  return <HowTheDjWorks />;
+}

--- a/web/app/manual/getting-started/page.js
+++ b/web/app/manual/getting-started/page.js
@@ -1,0 +1,7 @@
+import GettingStarted from '../../../components/manual/GettingStarted';
+
+export const metadata = { title: 'SUB/WAVE — Manual · Getting Started' };
+
+export default function GettingStartedPage() {
+  return <GettingStarted />;
+}

--- a/web/app/manual/layout.js
+++ b/web/app/manual/layout.js
@@ -1,0 +1,11 @@
+import ManualShell from '../../components/manual/ManualShell';
+
+export const metadata = {
+  title: 'SUB/WAVE — Manual',
+  description:
+    'How to use SUB/WAVE — tuning in, making requests, how the AI DJ works, and running the station from the admin console.',
+};
+
+export default function ManualLayout({ children }) {
+  return <ManualShell>{children}</ManualShell>;
+}

--- a/web/app/manual/page.js
+++ b/web/app/manual/page.js
@@ -1,0 +1,7 @@
+import Overview from '../../components/manual/Overview';
+
+export const metadata = { title: 'SUB/WAVE — Manual' };
+
+export default function ManualOverviewPage() {
+  return <Overview />;
+}

--- a/web/app/manual/requests/page.js
+++ b/web/app/manual/requests/page.js
@@ -1,0 +1,7 @@
+import Requests from '../../../components/manual/Requests';
+
+export const metadata = { title: 'SUB/WAVE — Manual · Making Requests' };
+
+export default function RequestsPage() {
+  return <Requests />;
+}

--- a/web/components/landing/Masthead.jsx
+++ b/web/components/landing/Masthead.jsx
@@ -62,6 +62,8 @@ export default function Masthead() {
       >
         <Link href="/listen" className="bs-masthead-link">Listen</Link>
         <span aria-hidden="true" className="bs-masthead-sep">·</span>
+        <Link href="/manual" className="bs-masthead-link">Manual</Link>
+        <span aria-hidden="true" className="bs-masthead-sep">·</span>
         <Link href="/setup" className="bs-masthead-link">Setup</Link>
         <span aria-hidden="true" className="bs-masthead-sep">·</span>
         <a

--- a/web/components/manual/AdminSettings.jsx
+++ b/web/components/manual/AdminSettings.jsx
@@ -1,0 +1,102 @@
+import Link from 'next/link';
+import ManualPage from './ManualPage';
+
+export default function AdminSettings() {
+  return (
+    <ManualPage
+      eyebrow="MANUAL · 04"
+      title="Admin & settings."
+      intro="For the operator running the station. The admin console is where you shape the DJ, choose the AI providers, schedule shows, and manage the jingles — no redeploy required."
+      current="/manual/admin"
+    >
+      <section className="bs-section">
+        <p className="bs-eyebrow">SIGNING IN</p>
+        <h2>The admin console.</h2>
+        <p>
+          The console lives at <code className="bs-code-inline">/admin</code>. It's gated
+          by a single sign-in — the <code className="bs-code-inline">ADMIN_USER</code> and{' '}
+          <code className="bs-code-inline">ADMIN_PASS</code> set when the station was
+          installed. In production those credentials are mandatory: the station won't
+          start without them, because the admin surface reveals too much to leave open.
+        </p>
+        <p>
+          Behind the gate are three views — the console itself,{' '}
+          <code className="bs-code-inline">/admin/settings</code>, and{' '}
+          <code className="bs-code-inline">/admin/debug</code>.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">SETTINGS</p>
+        <h2>Tuning the station.</h2>
+        <p>
+          Settings are saved durably and take effect without a redeploy — most apply to
+          the next thing the DJ says. The main things you'll touch:
+        </p>
+        <ul className="bs-list">
+          <li>
+            <strong>DJ personas</strong> — the roster of souls (1&ndash;10), each with a
+            name and character. The DJ picks one at random per spoken moment.
+          </li>
+          <li>
+            <strong>DJ frequency</strong> — <em>quiet</em>, <em>moderate</em>, or{' '}
+            <em>aggressive</em>: how often the DJ talks, IDs the station, and reads the
+            time and weather.
+          </li>
+          <li>
+            <strong>LLM provider</strong> — which model writes the DJ's words and picks
+            tracks. Ollama on your own hardware by default, or a hosted provider
+            (Anthropic, OpenAI, Google, and others) with an API key. Switching reroutes
+            every call immediately.
+          </li>
+          <li>
+            <strong>Voice (TTS)</strong> — which text-to-speech engine and voice the DJ
+            speaks with, optionally a different one per kind of segment.
+          </li>
+          <li>
+            <strong>Shows schedule</strong> — paint named shows onto a weekly grid; the DJ
+            runs each as its own session.
+          </li>
+          <li>
+            <strong>Mix settings</strong> — crossfade length and how often a jingle plays
+            between tracks.
+          </li>
+        </ul>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">MIX CHANGES NEED A MIXER RESTART</div>
+          <p>
+            Crossfade and jingle-ratio changes are read by the audio mixer only at
+            startup. The settings page can trigger that restart for you — the stream drops
+            for a few seconds and comes back with the new values applied.
+          </p>
+        </div>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">JINGLES</p>
+        <h2>Station idents.</h2>
+        <p>
+          Jingles are short pre-rendered TTS stingers the station rotates between music
+          tracks. The admin console manages the set — adding, removing, and re-rendering
+          them through the configured voice. A fresh install ships with none until you
+          generate them; after that, new renders are picked up automatically.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">WHEN SOMETHING'S OFF</p>
+        <h2>The debug view.</h2>
+        <p>
+          <code className="bs-code-inline">/admin/debug</code> is a live snapshot for
+          diagnosing the station — recent AI calls, the mixer's status, and the most
+          recent log lines. It's the first place to look if the stream stalls or the DJ
+          goes quiet.
+        </p>
+        <p>
+          Installing or updating the station rather than tuning it? That's covered in{' '}
+          <Link href="/setup" className="bs-link">the setup guide</Link>.
+        </p>
+      </section>
+    </ManualPage>
+  );
+}

--- a/web/components/manual/GettingStarted.jsx
+++ b/web/components/manual/GettingStarted.jsx
@@ -1,0 +1,78 @@
+import Link from 'next/link';
+import ManualPage from './ManualPage';
+
+export default function GettingStarted() {
+  return (
+    <ManualPage
+      eyebrow="MANUAL · 01"
+      title="Tuning in."
+      intro="Everything a listener needs: how to start the stream, what the player shows you, and why it behaves a little differently from the music apps you're used to."
+      current="/manual/getting-started"
+    >
+      <section className="bs-section">
+        <p className="bs-eyebrow">PRESS PLAY</p>
+        <h2>Open the player and you're on the air.</h2>
+        <p>
+          The station lives at the home page, and always at{' '}
+          <Link href="/listen" className="bs-link">/listen</Link>. Open it and press play —
+          the stream connects and you hear the broadcast already in progress. There's
+          nothing to pick first; the DJ is already mid-show.
+        </p>
+        <p>
+          Because it's a live stream, pressing pause and playing again doesn't resume
+          where you left off — it drops you back into the broadcast as it is now, the same
+          as everyone else listening.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">THE PLAYER</p>
+        <h2>What you're looking at.</h2>
+        <p>
+          The player shows the track that's playing right now — title, artist, and cover
+          art — with a waveform for the transport. Three panels slide out for the rest:
+        </p>
+        <ul className="bs-list">
+          <li>
+            <strong>Make a request</strong> — ask the DJ for a song, an artist, or a mood.
+            See <Link href="/manual/requests" className="bs-link">Making Requests</Link>.
+          </li>
+          <li>
+            <strong>Timeline</strong> — what's played recently and what's queued up next.
+          </li>
+          <li>
+            <strong>The booth</strong> — a running feed of what the DJ has been saying:
+            intros, station IDs, the time, weather.
+          </li>
+        </ul>
+        <p className="muted">
+          Now-playing info refreshes every few seconds, so the player stays in step with
+          the broadcast without you doing anything.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">NO SKIP — ON PURPOSE</p>
+        <h2>There is no skip button.</h2>
+        <p>
+          A track ends when it ends. SUB/WAVE has no <code className="bs-code-inline">/skip</code> —
+          the only natural transition is track-end, and the mixer controls pacing. Skip is
+          deliberately left off the lock-screen and headphone controls too, so a stray
+          double-tap on your earbuds can't cut the song short for every other listener.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">INSTALL IT</p>
+        <h2>Add SUB/WAVE to your phone.</h2>
+        <p>
+          SUB/WAVE is an installable web app. Use your browser's &ldquo;Add to Home
+          Screen&rdquo; / &ldquo;Install&rdquo; option and it runs like a native app, with
+          its own icon. Once installed, your phone's lock screen, headphone buttons, and
+          car display can all start and stop the stream — with the cover art of whatever
+          is currently on the air.
+        </p>
+      </section>
+    </ManualPage>
+  );
+}

--- a/web/components/manual/HowTheDjWorks.jsx
+++ b/web/components/manual/HowTheDjWorks.jsx
@@ -1,0 +1,71 @@
+import Link from 'next/link';
+import ManualPage from './ManualPage';
+
+export default function HowTheDjWorks() {
+  return (
+    <ManualPage
+      eyebrow="MANUAL · 03"
+      title="How the DJ works."
+      intro="There's no human at the desk. An LLM picks every track, writes every line, and a text-to-speech voice reads it out. Here's how that adds up to a station that sounds like a station."
+      current="/manual/dj"
+    >
+      <section className="bs-section">
+        <p className="bs-eyebrow">PICKING TRACKS</p>
+        <h2>One song ends, the DJ chooses the next.</h2>
+        <p>
+          Every time a track finishes, the DJ picks what follows. It builds a pool of
+          candidates from your library — songs in a similar mood, similar artists,
+          recently-added and frequently-played albums, matching playlists — and the LLM
+          chooses from that pool, steering by the time of day, the weather, and the
+          current mood. When nothing's been requested, it runs a fallback playlist so the
+          music never stops.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">THE VOICES</p>
+        <h2>Personas, picked at random.</h2>
+        <p>
+          The operator gives the DJ one to ten <em>souls</em> — distinct personas, each
+          with its own name and character. Before each spoken moment the station picks one
+          at random, so the voice on air shifts through the day rather than reading from a
+          single script. Each line is generated fresh; the DJ doesn't repeat itself.
+        </p>
+        <p className="muted">
+          The spoken audio is rendered by a text-to-speech engine — a fast local voice by
+          default, or a more natural one if the operator configures it.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">WHEN IT TALKS</p>
+        <h2>Links, IDs, the time, the weather.</h2>
+        <p>
+          Between tracks the DJ does what radio DJs do — a short link tying one song to
+          the next, a station ID, the time at the top of the hour, a weather note when the
+          conditions change. Spoken segments ride <em>over</em> the music: the track ducks
+          down while the DJ talks, then comes back up.
+        </p>
+        <p>
+          How chatty the station is depends on a <strong>frequency</strong> setting the
+          operator chooses — <em>quiet</em>, <em>moderate</em>, or <em>aggressive</em>. A
+          quiet station checks the time every couple of hours and drops the occasional
+          ID; an aggressive one gives you full idents and weather updates through the hour.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">SHOWS &amp; SESSIONS</p>
+        <h2>It keeps a thread going.</h2>
+        <p>
+          The DJ runs in <em>sessions</em> — a continuous block with a memory of what it's
+          already played and said, so its links stay coherent instead of starting cold
+          each time. A session can be a scheduled <strong>show</strong> the operator paints
+          onto a weekly grid, or an autonomous block keyed to the time of day and the
+          dominant mood. When the show changes or the block ages out, the session rolls
+          over to a fresh one and carries a short handoff forward.
+        </p>
+      </section>
+    </ManualPage>
+  );
+}

--- a/web/components/manual/ManualNav.jsx
+++ b/web/components/manual/ManualNav.jsx
@@ -1,0 +1,33 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { MANUAL_PAGES } from './pages';
+
+export default function ManualNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="bs-manual-nav" aria-label="Manual contents">
+      <p className="bs-eyebrow">THE MANUAL</p>
+      <ol className="bs-manual-nav-list">
+        {MANUAL_PAGES.map((page, i) => {
+          const active = pathname === page.href;
+          return (
+            <li key={page.href}>
+              <Link
+                href={page.href}
+                className="bs-manual-nav-link"
+                data-active={active || undefined}
+                aria-current={active ? 'page' : undefined}
+              >
+                <span className="bs-manual-nav-num">{String(i + 1).padStart(2, '0')}</span>
+                {page.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/web/components/manual/ManualPage.jsx
+++ b/web/components/manual/ManualPage.jsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+import { MANUAL_PAGES } from './pages';
+
+// Wraps a manual page: a broadsheet-style header, the page body, and the
+// prev/next links derived from MANUAL_PAGES order.
+export default function ManualPage({ eyebrow, title, intro, current, children }) {
+  const idx = MANUAL_PAGES.findIndex((p) => p.href === current);
+  const prev = idx > 0 ? MANUAL_PAGES[idx - 1] : null;
+  const next = idx >= 0 && idx < MANUAL_PAGES.length - 1 ? MANUAL_PAGES[idx + 1] : null;
+
+  return (
+    <article>
+      <header className="bs-setup-hero">
+        <p className="bs-eyebrow">{eyebrow}</p>
+        <h1>{title}</h1>
+        {intro ? <p>{intro}</p> : null}
+      </header>
+
+      {children}
+
+      <nav className="bs-manual-pagelinks" aria-label="Manual pagination">
+        {prev ? (
+          <Link href={prev.href} className="bs-manual-pagelink" data-dir="prev">
+            <span>&larr; Previous</span>
+            {prev.label}
+          </Link>
+        ) : (
+          <span />
+        )}
+        {next ? (
+          <Link href={next.href} className="bs-manual-pagelink" data-dir="next">
+            <span>Next &rarr;</span>
+            {next.label}
+          </Link>
+        ) : null}
+      </nav>
+    </article>
+  );
+}

--- a/web/components/manual/ManualShell.jsx
+++ b/web/components/manual/ManualShell.jsx
@@ -1,0 +1,22 @@
+import Masthead from '../landing/Masthead';
+import StationFooter from '../landing/StationFooter';
+import ManualNav from './ManualNav';
+
+// Shared chrome for every /manual/* page: the broadsheet masthead, a sticky
+// sidebar table of contents, the page body, and the station footer. Wired up
+// once in app/manual/layout.js so each page component is just its content.
+export default function ManualShell({ children }) {
+  return (
+    <div style={{ background: 'var(--bg)', color: 'var(--ink)', minHeight: '100vh' }}>
+      <Masthead />
+
+      <main className="bs-paper">
+        <div className="bs-manual-layout">
+          <ManualNav />
+          <div className="bs-manual-content">{children}</div>
+        </div>
+        <StationFooter />
+      </main>
+    </div>
+  );
+}

--- a/web/components/manual/Overview.jsx
+++ b/web/components/manual/Overview.jsx
@@ -1,0 +1,73 @@
+import Link from 'next/link';
+import ManualPage from './ManualPage';
+
+const GUIDE = [
+  {
+    href: '/manual/getting-started',
+    label: 'Getting Started',
+    blurb: 'What SUB/WAVE is, how to tune in, and what every part of the player does.',
+  },
+  {
+    href: '/manual/requests',
+    label: 'Making Requests',
+    blurb: 'Ask the DJ for a track, an artist, or just a mood — and what happens after you do.',
+  },
+  {
+    href: '/manual/dj',
+    label: 'How the DJ Works',
+    blurb: 'The AI behind the desk: how it picks songs, when it talks, and who it sounds like.',
+  },
+  {
+    href: '/manual/admin',
+    label: 'Admin & Settings',
+    blurb: 'For the operator — signing in, tuning the DJ, scheduling shows, and managing jingles.',
+  },
+];
+
+export default function Overview() {
+  return (
+    <ManualPage
+      eyebrow="SUB/WAVE MANUAL"
+      title="How to use SUB/WAVE."
+      intro="SUB/WAVE is a personal internet radio station — one live stream that every listener hears at the same moment, with an AI DJ picking the tracks and talking between them. This manual covers both sides of the dial: tuning in as a listener, and running the station as its operator."
+      current="/manual"
+    >
+      <section className="bs-section">
+        <p className="bs-eyebrow">WHAT'S INSIDE</p>
+        <h2>Four short guides.</h2>
+        <p>
+          Start at the top if you're new. Each page links to the next, so you can read
+          straight through, or jump to whatever you need from the contents on the left.
+        </p>
+
+        <ul className="bs-list">
+          {GUIDE.map((g) => (
+            <li key={g.href}>
+              <Link href={g.href} className="bs-link">
+                <strong>{g.label}</strong>
+              </Link>{' '}
+              — {g.blurb}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">THE ONE THING TO KNOW</p>
+        <h2>It's a broadcast, not a playlist.</h2>
+        <p>
+          Streaming apps give everyone a private channel — shuffled for you, paused the
+          second you look away. SUB/WAVE goes the other way. There is one Icecast stream,
+          and everyone hears whatever is on the air <em>right now</em>. There is no
+          &ldquo;for you,&rdquo; and there is no skip button. You can ask for a song, but
+          it joins the broadcast for every listener — it doesn't jump the current track.
+        </p>
+        <p>
+          Want to run your own station instead of just listening?{' '}
+          <Link href="/setup" className="bs-link">The setup guide</Link> walks through
+          pointing SUB/WAVE at your own music library and LLM.
+        </p>
+      </section>
+    </ManualPage>
+  );
+}

--- a/web/components/manual/Requests.jsx
+++ b/web/components/manual/Requests.jsx
@@ -1,0 +1,65 @@
+import Link from 'next/link';
+import ManualPage from './ManualPage';
+
+export default function Requests() {
+  return (
+    <ManualPage
+      eyebrow="MANUAL · 02"
+      title="Making requests."
+      intro="You can ask the DJ for something. Here's how to send a request, what the DJ does with it, and what to expect on air."
+      current="/manual/requests"
+    >
+      <section className="bs-section">
+        <p className="bs-eyebrow">SEND IT</p>
+        <h2>Open &ldquo;Make a request.&rdquo;</h2>
+        <p>
+          In the player, open the <strong>Make a request</strong> panel. Type what you
+          want and, if you like, your name — so the DJ can give you a shout-out. You don't
+          have to be precise: a song title, an artist, or a mood all work.
+        </p>
+        <ul className="bs-list">
+          <li><strong>A track</strong> — &ldquo;play Just Like Heaven by The Cure.&rdquo;</li>
+          <li><strong>An artist</strong> — &ldquo;something by Aphex Twin.&rdquo;</li>
+          <li><strong>A mood</strong> — &ldquo;something for a rainy Sunday morning.&rdquo;</li>
+        </ul>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">WHAT HAPPENS NEXT</p>
+        <h2>The DJ reads it, then digs through the crates.</h2>
+        <p>
+          Your request is accepted instantly, and the panel then waits for the outcome.
+          Behind the desk, the AI DJ interprets what you asked for and searches the
+          station's music library for the best match. If it finds one, it usually records
+          a short spoken intro — acknowledging your request by name — and queues the track
+          to play when the current song finishes.
+        </p>
+        <p>
+          If nothing in the library fits, the DJ won't force it — you may get a different
+          take on the mood you asked for instead. The station only plays what's actually
+          in its collection.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">IT'S STILL A BROADCAST</p>
+        <h2>Your request plays for everyone.</h2>
+        <p>
+          A request doesn't cut in front of the song that's already playing — there's no
+          skip. It joins the broadcast as the next natural transition, and when it airs,
+          <em> every</em> listener hears it, not just you. That's the point: it's one
+          shared station, and you just put something on it.
+        </p>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">A FEW TIPS</div>
+          <p>
+            Be specific when you have a specific song in mind, and loose when you don't —
+            the DJ handles both. Watch <strong>the booth</strong> panel to catch your
+            shout-out, and the <strong>Timeline</strong> to see your track land in the
+            queue.
+          </p>
+        </div>
+      </section>
+    </ManualPage>
+  );
+}

--- a/web/components/manual/pages.js
+++ b/web/components/manual/pages.js
@@ -1,0 +1,10 @@
+// The manual's page list — order drives both the sidebar contents and the
+// prev/next links. Kept in a plain module (no 'use client') so it can be
+// imported by both the client nav and the server page components.
+export const MANUAL_PAGES = [
+  { href: '/manual', label: 'Overview' },
+  { href: '/manual/getting-started', label: 'Getting Started' },
+  { href: '/manual/requests', label: 'Making Requests' },
+  { href: '/manual/dj', label: 'How the DJ Works' },
+  { href: '/manual/admin', label: 'Admin & Settings' },
+];


### PR DESCRIPTION
Adds a manual under /manual with a shared sidebar layout: Overview,
Getting Started, Making Requests, How the DJ Works, and Admin & Settings.
Each page is its own route segment for deep links, with prev/next
navigation. Linked from the broadsheet masthead so it's reachable from
the landing page.

https://claude.ai/code/session_01GKaai6jo37c8AUcTkgnv4G