### PR TITLE
Add tap-to-tune-in overlay for first-time listeners

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -210,6 +210,21 @@ body::after {
     animation: v3-blink 1s steps(1) infinite;
 }
 
+/* Tune-in gate — the play disc emits an expanding ink ring so the overlay's
+   call-to-action keeps drawing the eye until the listener taps. */
+@keyframes v3-tunein-pulse {
+    0% {
+        box-shadow: 0 0 0 0 color-mix(in oklab, var(--ink) 35%, transparent);
+    }
+    70%,
+    100% {
+        box-shadow: 0 0 0 26px color-mix(in oklab, var(--ink) 0%, transparent);
+    }
+}
+.v3-tunein-pulse {
+    animation: v3-tunein-pulse 2s ease-out infinite;
+}
+
 /* Sonner toast styling — sharp ink-bordered cream cards. */
 .v3-toast {
     background: var(--bg);
@@ -232,7 +247,8 @@ body::after {
 @media (prefers-reduced-motion: reduce) {
     .v3-drawer-content,
     .v3-drawer-overlay,
-    .v3-blink {
+    .v3-blink,
+    .v3-tunein-pulse {
         animation: none !important;
     }
 }

--- a/web/components/PlayerApp.jsx
+++ b/web/components/PlayerApp.jsx
@@ -7,6 +7,7 @@ import TopBar from './TopBar';
 import CenterStage from './CenterStage';
 import Waveform from './Waveform';
 import TransportBar from './TransportBar';
+import TuneInOverlay from './TuneInOverlay';
 import DotRail from './DotRail';
 import { Sheet } from './ui/sheet';
 import { Toaster } from './ui/toaster';
@@ -57,6 +58,15 @@ export default function PlayerApp({ contained = false }) {
   const [drawer, setDrawer] = useState(null);
   const [tickerOn, setTickerOn] = useState(true);
   const [theme, setTheme] = useState('light');
+
+  // First-paint tune-in gate. Shown on every fresh load until the listener
+  // taps it; dismissed permanently for the rest of the session once they've
+  // tuned in, so a later Tune Out doesn't bring the overlay back.
+  const [showTuneIn, setShowTuneIn] = useState(true);
+  const tuneInFromOverlay = () => {
+    setShowTuneIn(false);
+    tune();
+  };
 
   // Hydrate ticker preference from localStorage (avoids SSR hydration mismatch).
   useEffect(() => {
@@ -195,6 +205,10 @@ export default function PlayerApp({ contained = false }) {
           />
         )}
       </Sheet>
+
+      {showTuneIn && !offline && (
+        <TuneInOverlay onTune={tuneInFromOverlay} nowPlaying={nowPlaying} />
+      )}
 
       {!contained && <Toaster />}
     </div>

--- a/web/components/TuneInOverlay.jsx
+++ b/web/components/TuneInOverlay.jsx
@@ -18,7 +18,12 @@ export default function TuneInOverlay({ onTune, nowPlaying }) {
       onClick={onTune}
       aria-label="Tune in to the live stream"
       className="absolute inset-0 z-50 v3-focus v3-fade-in flex flex-col items-center justify-center gap-7 cursor-pointer text-center px-6"
-      style={{ background: 'var(--bg)', color: 'var(--ink)' }}
+      style={{
+        background: 'color-mix(in oklab, var(--bg) 6%, transparent)',
+        color: 'var(--ink)',
+        backdropFilter: 'blur(1.5px) saturate(1.9) brightness(1.07)',
+        WebkitBackdropFilter: 'blur(1.5px) saturate(1.9) brightness(1.07)',
+      }}
     >
       <span className="v3-eyebrow flex items-center gap-2" style={{ color: 'var(--accent)' }}>
         <span className="bs-live-dot" />

--- a/web/components/TuneInOverlay.jsx
+++ b/web/components/TuneInOverlay.jsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { Play } from 'lucide-react';
+
+// Full-bleed first-paint gate. A new listener lands on a player that shows
+// live track info but isn't actually playing — the small "Tune In" button in
+// the footer is easy to miss. This overlay makes the call-to-action
+// unmissable, and the tap doubles as the browser gesture that unblocks audio,
+// so the stream starts on the first interaction with no second click.
+export default function TuneInOverlay({ onTune, nowPlaying }) {
+  const track = nowPlaying?.title
+    ? `${nowPlaying.title}${nowPlaying.artist ? ` — ${nowPlaying.artist}` : ''}`
+    : null;
+
+  return (
+    <button
+      type="button"
+      onClick={onTune}
+      aria-label="Tune in to the live stream"
+      className="absolute inset-0 z-50 v3-focus v3-fade-in flex flex-col items-center justify-center gap-7 cursor-pointer text-center px-6"
+      style={{ background: 'var(--bg)', color: 'var(--ink)' }}
+    >
+      <span className="v3-eyebrow flex items-center gap-2" style={{ color: 'var(--accent)' }}>
+        <span className="bs-live-dot" />
+        on air now
+      </span>
+
+      <span
+        className="v3-tunein-pulse flex items-center justify-center rounded-full"
+        style={{ width: 92, height: 92, background: 'var(--ink)', color: 'var(--bg)' }}
+      >
+        <Play size={34} strokeWidth={1.5} fill="currentColor" style={{ marginLeft: 4 }} />
+      </span>
+
+      <span className="flex flex-col items-center gap-2 max-w-[34ch]">
+        <span className="v3-title">Tap to tune in</span>
+        <span className="v3-caption" style={{ color: 'var(--muted)' }}>
+          audio is paused — tap anywhere to start listening
+        </span>
+        {track && (
+          <span className="mt-1 text-[13px]" style={{ color: 'var(--muted)' }}>
+            now playing · <span style={{ color: 'var(--ink)' }}>{track}</span>
+          </span>
+        )}
+      </span>
+    </button>
+  );
+}


### PR DESCRIPTION
New listeners often miss the small footer "Tune In" button and assume
the live track info means audio is already playing. A full-bleed overlay
now gates the player on every load until the listener taps it; the tap
doubles as the browser gesture that unblocks audio, so the stream starts
on first interaction.

https://claude.ai/code/session_018s3oFShc2uUMwW5fNpwB3i