### PR TITLE
Add Subsonic API call tracking to admin debug

### DIFF
--- a/controller/src/music/subsonic-log.js
+++ b/controller/src/music/subsonic-log.js
@@ -1,0 +1,87 @@
+// Ring buffer + aggregate tracker for Subsonic/Navidrome API calls — feeds the
+// admin /debug surface so every request to the music server is inspectable.
+// Mirrors llm/log.js. Lives in its own module so subsonic.js can record
+// without an import cycle.
+
+import { appendFile } from 'node:fs/promises';
+import { STATE_DIR } from '../config.js';
+
+const MAX_CALLS = 150;
+export const recentCalls = [];
+
+// endpoint -> { calls, errors, totalMs, songResults }
+const endpointStats = new Map();
+// songId -> { id, title, artist, count } — how often each song has come back,
+// the evidence for "is the picker drawing from the whole library or a pool?"
+const songCoverage = new Map();
+
+// Durable append-only log. The in-memory structures above are lost on restart;
+// this tab-separated file in the shared state volume survives, so pool
+// patterns stay reviewable over days. Best-effort — a write failure must never
+// break a request.
+const CALLS_LOG = `${STATE_DIR}/logs/subsonic.log`;
+
+export function record(entry) {
+  recentCalls.unshift(entry);
+  if (recentCalls.length > MAX_CALLS) recentCalls.length = MAX_CALLS;
+
+  let st = endpointStats.get(entry.endpoint);
+  if (!st) {
+    st = { calls: 0, errors: 0, totalMs: 0, songResults: 0 };
+    endpointStats.set(entry.endpoint, st);
+  }
+  st.calls += 1;
+  st.totalMs += entry.ms || 0;
+  if (!entry.ok) st.errors += 1;
+  st.songResults += entry.songIds?.length || 0;
+
+  for (const s of entry.songIds || []) {
+    const hit = songCoverage.get(s.id);
+    if (hit) hit.count += 1;
+    else songCoverage.set(s.id, { id: s.id, title: s.title, artist: s.artist, count: 1 });
+  }
+
+  const line = [
+    entry.t,
+    entry.endpoint,
+    entry.ms,
+    entry.ok ? 'ok' : 'err',
+    entry.count,
+  ].join('\t') + '\n';
+  appendFile(CALLS_LOG, line).catch(() => {});
+}
+
+export function snapshot(libraryTotal = null) {
+  const endpoints = [...endpointStats.entries()]
+    .map(([endpoint, st]) => ({
+      endpoint,
+      calls: st.calls,
+      errors: st.errors,
+      avgMs: st.calls ? Math.round(st.totalMs / st.calls) : 0,
+      songResults: st.songResults,
+    }))
+    .sort((a, b) => b.calls - a.calls);
+
+  const songs = [...songCoverage.values()];
+  const topSongs = songs
+    .slice()
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 25);
+
+  return {
+    recentCalls,
+    endpoints,
+    coverage: {
+      distinctSongs: songs.length,
+      totalSongResults: songs.reduce((sum, s) => sum + s.count, 0),
+      libraryTotal,
+      topSongs,
+    },
+  };
+}
+
+export function reset() {
+  recentCalls.length = 0;
+  endpointStats.clear();
+  songCoverage.clear();
+}

--- a/controller/src/music/subsonic.js
+++ b/controller/src/music/subsonic.js
@@ -3,6 +3,7 @@
 
 import crypto from 'node:crypto';
 import { config } from '../config.js';
+import * as subLog from './subsonic-log.js';
 
 function buildAuth() {
   const salt = crypto.randomBytes(8).toString('hex');
@@ -28,14 +29,49 @@ function buildUrl(endpoint, params = {}) {
   return url.toString();
 }
 
+// Response keys that carry item arrays, checked in order — first match wins.
+// Key-driven (not endpoint-switched) so new callers are covered automatically.
+const ITEM_PATHS = [
+  ['searchResult3', 'song'], ['randomSongs', 'song'], ['songsByGenre', 'song'],
+  ['similarSongs2', 'song'], ['starred2', 'song'], ['topSongs', 'song'],
+  ['album', 'song'], ['playlist', 'entry'], ['albumList2', 'album'],
+];
+
+function extractItems(sub) {
+  for (const [a, b] of ITEM_PATHS) {
+    const v = sub[a]?.[b];
+    if (Array.isArray(v)) return v;
+  }
+  return [];
+}
+
 async function call(endpoint, params = {}) {
-  const url = buildUrl(endpoint, params);
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`Subsonic ${endpoint} failed: ${res.status}`);
-  const data = await res.json();
-  const sub = data['subsonic-response'];
-  if (sub.status !== 'ok') throw new Error(`Subsonic error: ${sub.error?.message || 'unknown'}`);
-  return sub;
+  const started = Date.now();
+  try {
+    const url = buildUrl(endpoint, params);
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Subsonic ${endpoint} failed: ${res.status}`);
+    const data = await res.json();
+    const sub = data['subsonic-response'];
+    if (sub.status !== 'ok') throw new Error(`Subsonic error: ${sub.error?.message || 'unknown'}`);
+    const items = extractItems(sub);
+    subLog.record({
+      t: new Date().toISOString(), endpoint, params, ms: Date.now() - started,
+      ok: true, count: items.length,
+      // Songs carry both id and title; albumList2 rows have no title — keep
+      // them out of song coverage but still counted via `count` above.
+      songIds: items
+        .filter(i => i?.id && i?.title)
+        .map(i => ({ id: i.id, title: i.title, artist: i.artist })),
+    });
+    return sub;
+  } catch (err) {
+    subLog.record({
+      t: new Date().toISOString(), endpoint, params, ms: Date.now() - started,
+      ok: false, count: 0, songIds: [], error: err.message,
+    });
+    throw err;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/controller/src/routes/debug.js
+++ b/controller/src/routes/debug.js
@@ -6,6 +6,7 @@ import * as dj from '../llm/dj.js';
 import * as llmProvider from '../llm/provider.js';
 import * as tts from '../audio/tts.js';
 import * as library from '../music/library.js';
+import * as subsonicLog from '../music/subsonic-log.js';
 import { getFullContext } from '../context.js';
 import * as settings from '../settings.js';
 import { queue } from '../broadcast/queue.js';
@@ -123,6 +124,14 @@ router.get('/debug', requireAdmin, async (req, res) => {
     out.library = { error: err.message };
   }
 
+  // 6d. Subsonic API call tracking — every request to Navidrome, plus
+  // library-coverage stats (distinct songs returned vs. tagged total).
+  try {
+    out.subsonic = subsonicLog.snapshot(out.library?.total ?? null);
+  } catch (err) {
+    out.subsonic = { error: err.message };
+  }
+
   // 7. Context snapshot
   try {
     out.context = await getFullContext();
@@ -180,4 +189,11 @@ router.get('/sessions', requireAdmin, async (req, res) => {
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
+});
+
+// POST /debug/subsonic/reset — zero the Subsonic call tracker so coverage can
+// be watched building from scratch during a targeted test run.
+router.post('/debug/subsonic/reset', requireAdmin, (req, res) => {
+  subsonicLog.reset();
+  res.json({ ok: true });
 });

--- a/web/components/admin/DebugPanel.jsx
+++ b/web/components/admin/DebugPanel.jsx
@@ -146,6 +146,9 @@ export default function DebugPanel() {
           {/* ── LLM RECENT CALLS (full width) ───────────────────────────── */}
           <LlmCalls llm={data.llm} />
 
+          {/* ── SUBSONIC API CALLS (full width) ─────────────────────────── */}
+          <SubsonicCalls subsonic={data.subsonic} />
+
           {/* ── LIQUIDSOAP LOG (full width) ─────────────────────────────── */}
           <Card
             title="Liquidsoap log"
@@ -693,6 +696,202 @@ function LlmCalls({ llm }) {
             </div>
           </details>
         ))}
+      </div>
+    </Card>
+  );
+}
+
+// A single headline figure with a caption above and an optional sub-line.
+function Stat({ label, v, sub }) {
+  return (
+    <div style={{ display: 'grid', gap: 2, minWidth: 110 }}>
+      <span className="caption">{label}</span>
+      <span style={{ fontSize: 20, fontWeight: 700 }}>{v}</span>
+      {sub && <span className="caption" style={{ fontSize: 9 }}>{sub}</span>}
+    </div>
+  );
+}
+
+// Full-width Subsonic/Navidrome call browser: library-coverage headline,
+// per-endpoint stats, the most-returned songs, and a browsable recent-calls
+// list. Answers "is the picker drawing from the whole library or a pool?".
+function SubsonicCalls({ subsonic }) {
+  const { adminFetch } = useAdminAuth();
+  const [filter, setFilter] = useState('all');
+  const [resetting, setResetting] = useState(false);
+
+  if (!subsonic || subsonic.error) {
+    return (
+      <Card title="Subsonic API calls">
+        <span className="field-hint" style={{ fontStyle: 'italic' }}>
+          {subsonic?.error || 'no data yet'}
+        </span>
+      </Card>
+    );
+  }
+
+  const calls = subsonic.recentCalls || [];
+  const endpoints = subsonic.endpoints || [];
+  const cov = subsonic.coverage || {};
+  const totalCalls = endpoints.reduce((s, e) => s + e.calls, 0);
+  const shown = filter === 'all' ? calls : calls.filter(c => c.endpoint === filter);
+  const pct = cov.libraryTotal
+    ? Math.round((cov.distinctSongs / cov.libraryTotal) * 100)
+    : null;
+
+  const reset = async () => {
+    setResetting(true);
+    try { await adminFetch('/debug/subsonic/reset', { method: 'POST' }); } catch {}
+    setResetting(false);
+  };
+
+  return (
+    <Card
+      title="Subsonic API calls"
+      sub={`${calls.length} recent · ${totalCalls} total`}
+      right={
+        <Btn sm onClick={reset} disabled={resetting}>
+          {resetting ? 'Resetting…' : 'Reset'}
+        </Btn>
+      }
+    >
+      <div style={{ display: 'grid', gap: 16 }}>
+        {/* ── coverage headline ─────────────────────────────────────── */}
+        <div style={{ display: 'flex', gap: 28, flexWrap: 'wrap' }}>
+          <Stat
+            label="library coverage"
+            v={pct != null ? `${pct}%` : '—'}
+            sub={`${cov.distinctSongs ?? 0} of ${cov.libraryTotal ?? '?'} songs`}
+          />
+          <Stat label="distinct songs" v={cov.distinctSongs ?? 0} />
+          <Stat label="total song results" v={cov.totalSongResults ?? 0} />
+        </div>
+
+        {/* ── per-endpoint stats ────────────────────────────────────── */}
+        <div>
+          <div className="caption" style={{ marginBottom: 6 }}>by endpoint</div>
+          {endpoints.length === 0 ? (
+            <span className="field-hint" style={{ fontStyle: 'italic' }}>no calls yet</span>
+          ) : (
+            <div style={{ display: 'grid', gap: 0 }}>
+              <div style={{
+                display: 'grid', gridTemplateColumns: '1fr auto auto auto auto',
+                gap: 12, padding: '4px 0', fontSize: 9,
+                letterSpacing: '0.12em', textTransform: 'uppercase',
+                color: 'var(--muted)', borderBottom: '1px solid var(--separator-strong)',
+              }}>
+                <span>endpoint</span><span>calls</span><span>errors</span>
+                <span>avg ms</span><span>songs</span>
+              </div>
+              {endpoints.map((e, i) => (
+                <div key={e.endpoint} style={{
+                  display: 'grid', gridTemplateColumns: '1fr auto auto auto auto',
+                  gap: 12, padding: '6px 0', fontSize: 11,
+                  borderBottom: i < endpoints.length - 1 ? '1px dashed var(--separator-strong)' : 'none',
+                }}>
+                  <span style={{ fontWeight: 700 }}>{e.endpoint}</span>
+                  <span className="mono-num">{e.calls}</span>
+                  <span className="mono-num" style={{ color: e.errors ? 'var(--danger)' : 'var(--muted)' }}>
+                    {e.errors}
+                  </span>
+                  <span className="mono-num" style={{ color: 'var(--muted)' }}>{e.avgMs}</span>
+                  <span className="mono-num" style={{ color: 'var(--muted)' }}>{e.songResults}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* ── most-returned songs ───────────────────────────────────── */}
+        {(cov.topSongs?.length ?? 0) > 0 && (
+          <div>
+            <div className="caption" style={{ marginBottom: 6 }}>
+              most-returned songs — high counts mean a narrow pool
+            </div>
+            <div style={{ display: 'grid', gap: 0, maxHeight: 240, overflowY: 'auto' }}>
+              {cov.topSongs.map((s, i) => (
+                <div key={s.id} style={{
+                  display: 'grid', gridTemplateColumns: '24px 1fr auto', gap: 10,
+                  padding: '5px 0', fontSize: 11,
+                  borderBottom: i < cov.topSongs.length - 1 ? '1px dashed var(--separator-strong)' : 'none',
+                }}>
+                  <span className="mono-num" style={{ color: 'var(--muted)' }}>{i + 1}</span>
+                  <span style={{ wordBreak: 'break-word' }}>
+                    {s.title} <span style={{ color: 'var(--muted)' }}>— {s.artist}</span>
+                  </span>
+                  <span className="mono-num" style={{
+                    color: s.count > 1 ? 'var(--accent)' : 'var(--muted)', fontWeight: 700,
+                  }}>
+                    ×{s.count}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* ── recent calls ──────────────────────────────────────────── */}
+        <div>
+          <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginBottom: 6 }}>
+            <FilterChip active={filter === 'all'} onClick={() => setFilter('all')}>
+              all {calls.length}
+            </FilterChip>
+            {endpoints.map(e => (
+              <FilterChip
+                key={e.endpoint}
+                active={filter === e.endpoint}
+                onClick={() => setFilter(e.endpoint)}
+              >
+                {e.endpoint} {calls.filter(c => c.endpoint === e.endpoint).length}
+              </FilterChip>
+            ))}
+          </div>
+          <div style={{ display: 'grid', gap: 6, maxHeight: 480, overflowY: 'auto' }}>
+            {shown.length === 0 && (
+              <span className="field-hint" style={{ fontStyle: 'italic' }}>
+                {calls.length === 0 ? 'no calls yet' : 'no calls match this filter'}
+              </span>
+            )}
+            {shown.map((c, i) => (
+              <details key={i} style={{ border: '1px solid var(--separator-strong)' }}>
+                <summary style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'auto 1fr auto auto auto',
+                  gap: 10, padding: '8px 10px', alignItems: 'center', cursor: 'pointer',
+                }}>
+                  <span style={{ color: c.ok ? 'var(--accent)' : 'var(--danger)', fontWeight: 700 }}>
+                    {c.ok ? '✓' : '✗'}
+                  </span>
+                  <span style={{ fontSize: 12, fontWeight: 700 }}>{c.endpoint}</span>
+                  <span className="caption" style={{ fontSize: 10 }}>{c.count} results</span>
+                  <span className="mono-num" style={{ fontSize: 11, color: 'var(--muted)' }}>{c.ms}ms</span>
+                  <span className="mono-num" style={{ fontSize: 10, color: 'var(--muted)' }}>
+                    {c.t ? new Date(c.t).toLocaleTimeString('en-GB', { hour12: false }) : '—'}
+                  </span>
+                </summary>
+                <div style={{ padding: '4px 10px 10px', display: 'grid', gap: 4 }}>
+                  {c.error && (
+                    <CallSection label="error" tone="err" preview={oneLine(c.error)}>
+                      {c.error}
+                    </CallSection>
+                  )}
+                  <CallSection label="params" preview={oneLine(JSON.stringify(c.params || {}))}>
+                    {JSON.stringify(c.params || {}, null, 2)}
+                  </CallSection>
+                  {Array.isArray(c.songIds) && c.songIds.length > 0 && (
+                    <CallSection
+                      label="songs"
+                      count={c.songIds.length}
+                      preview={c.songIds.map(s => `${s.title} — ${s.artist}`).join(' · ')}
+                    >
+                      {c.songIds.map(s => `${s.title} — ${s.artist}`).join('\n')}
+                    </CallSection>
+                  )}
+                </div>
+              </details>
+            ))}
+          </div>
+        </div>
       </div>
     </Card>
   );


### PR DESCRIPTION
Every Navidrome/Subsonic request now records through a ring-buffer
tracker at the single call() chokepoint, with per-endpoint stats and
library-coverage tracking (distinct songs returned vs. tagged total).
Surfaces a new Subsonic API calls panel on /debug with a coverage
headline, most-returned songs, and a browsable recent-calls list, plus
a reset endpoint to zero the counters. Calls also append to a durable
state/logs/subsonic.log for long-horizon analysis.

https://claude.ai/code/session_01FTgiNkymLpw5KkXB5USHPA