### PR TITLE
Add keyboard shortcuts and command palette to the player

### DIFF
--- a/web/components/CommandPalette.jsx
+++ b/web/components/CommandPalette.jsx
@@ -1,0 +1,69 @@
+'use client';
+
+import {
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from './ui/command';
+import { Kbd } from './ui/kbd';
+
+/* ⌘K command palette for the listener-facing player. Scope is player
+   actions only — no jumping to admin/site routes. Each item runs its
+   handler and closes the palette. */
+export default function CommandPalette({
+  open,
+  onOpenChange,
+  container,
+  tunedIn,
+  theme,
+  muted,
+  onTune,
+  onOpenDrawer,
+  onToggleTheme,
+  onToggleMute,
+  onShowShortcuts,
+}) {
+  const run = (fn) => () => {
+    onOpenChange(false);
+    fn();
+  };
+
+  const items = [
+    { label: tunedIn ? 'Tune out' : 'Tune in', hint: 'Space', onSelect: run(onTune) },
+    { label: 'Open Timeline', hint: '1', onSelect: run(() => onOpenDrawer('timeline')) },
+    { label: 'Open Booth feed', hint: '2', onSelect: run(() => onOpenDrawer('booth')) },
+    { label: 'Make a request', hint: '3', onSelect: run(() => onOpenDrawer('request')) },
+    {
+      label: theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme',
+      hint: 'T',
+      onSelect: run(onToggleTheme),
+    },
+    { label: muted ? 'Unmute' : 'Mute', hint: 'M', onSelect: run(onToggleMute) },
+    { label: 'Keyboard shortcuts', hint: '?', onSelect: run(onShowShortcuts) },
+  ];
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      container={container}
+      label="Command palette"
+    >
+      <CommandInput placeholder="Type a command…" />
+      <CommandList>
+        <CommandEmpty>No commands found.</CommandEmpty>
+        <CommandGroup heading="Player">
+          {items.map((it) => (
+            <CommandItem key={it.label} value={it.label} onSelect={it.onSelect}>
+              <span>{it.label}</span>
+              <Kbd>{it.hint}</Kbd>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/web/components/PlayerApp.jsx
+++ b/web/components/PlayerApp.jsx
@@ -9,6 +9,8 @@ import Waveform from './Waveform';
 import TransportBar from './TransportBar';
 import TuneInOverlay from './TuneInOverlay';
 import DotRail from './DotRail';
+import CommandPalette from './CommandPalette';
+import ShortcutsDialog from './ShortcutsDialog';
 import { Sheet } from './ui/sheet';
 import { Toaster } from './ui/toaster';
 import TimelineDrawer from './drawers/TimelineDrawer';
@@ -17,6 +19,7 @@ import RequestDrawer from './drawers/RequestDrawer';
 import { useStationFeed } from '../hooks/useStationFeed';
 import { usePlayer } from '../hooks/usePlayer';
 import { useMediaSession } from '../hooks/useMediaSession';
+import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import { getStoredTheme, setTheme as persistTheme } from '../lib/theme';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || '/api';
@@ -30,7 +33,7 @@ const DRAWER_TITLES = {
 export default function PlayerApp({ contained = false }) {
   const { nowPlaying, context, dj, activeShow, listeners, streamOnline, state, session, elapsed, progress } = useStationFeed();
   const boothFeed = session.messages;
-  const { audioRef, tunedIn, volume, setVolume, tune, stop } = usePlayer();
+  const { audioRef, tunedIn, volume, setVolume, tune, stop, toggleMute, muted } = usePlayer();
 
   // streamOnline is null until the first poll resolves — only treat an
   // explicit false as offline so the player never flashes "offline" on load.
@@ -58,6 +61,8 @@ export default function PlayerApp({ contained = false }) {
   const [drawer, setDrawer] = useState(null);
   const [tickerOn, setTickerOn] = useState(true);
   const [theme, setTheme] = useState('light');
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
 
   // First-paint tune-in gate. Shown on every fresh load until the listener
   // taps it; dismissed permanently for the rest of the session once they've
@@ -96,6 +101,35 @@ export default function PlayerApp({ contained = false }) {
       return next;
     });
   };
+
+  // Tune toggle for shortcuts/palette — also dismisses the first-paint gate,
+  // so Space behaves like tapping the overlay before the listener has tuned in.
+  const handleTune = () => {
+    if (showTuneIn) tuneInFromOverlay();
+    else tune();
+  };
+  const adjustVolume = (delta) =>
+    setVolume(v => Math.min(1, Math.max(0, Math.round((v + delta) * 100) / 100)));
+
+  // Global keyboard shortcuts. Bare keys are suppressed while a text field
+  // is focused or while the palette/help dialog owns input; ⌘K always works.
+  useKeyboardShortcuts(
+    {
+      space: handleTune,
+      k: handleTune,
+      arrowup: () => adjustVolume(0.05),
+      arrowdown: () => adjustVolume(-0.05),
+      m: toggleMute,
+      t: toggleTheme,
+      '1': () => setDrawer('timeline'),
+      '2': () => setDrawer('booth'),
+      '3': () => setDrawer('request'),
+      r: () => setDrawer('request'),
+      '?': () => setShortcutsOpen(true),
+      'mod+k': () => setPaletteOpen(o => !o),
+    },
+    { disabled: paletteOpen || shortcutsOpen },
+  );
 
   // Submit a request. The controller accepts in ~50ms and returns a request
   // id; the actual matching runs in the booth. The drawer then polls
@@ -209,6 +243,26 @@ export default function PlayerApp({ contained = false }) {
       {showTuneIn && !offline && (
         <TuneInOverlay onTune={tuneInFromOverlay} nowPlaying={nowPlaying} />
       )}
+
+      <CommandPalette
+        open={paletteOpen}
+        onOpenChange={setPaletteOpen}
+        container={portalNode}
+        tunedIn={tunedIn}
+        theme={theme}
+        muted={muted}
+        onTune={handleTune}
+        onOpenDrawer={setDrawer}
+        onToggleTheme={toggleTheme}
+        onToggleMute={toggleMute}
+        onShowShortcuts={() => setShortcutsOpen(true)}
+      />
+
+      <ShortcutsDialog
+        open={shortcutsOpen}
+        onOpenChange={setShortcutsOpen}
+        container={portalNode}
+      />
 
       {!contained && <Toaster />}
     </div>

--- a/web/components/ShortcutsDialog.jsx
+++ b/web/components/ShortcutsDialog.jsx
@@ -1,0 +1,88 @@
+'use client';
+
+import * as Dialog from '@radix-ui/react-dialog';
+import { cn } from '../lib/cn';
+import { Kbd } from './ui/kbd';
+
+const SHORTCUTS = [
+  { keys: ['Space', 'K'], label: 'Tune in / out' },
+  { keys: ['↑'], label: 'Volume up' },
+  { keys: ['↓'], label: 'Volume down' },
+  { keys: ['M'], label: 'Mute / unmute' },
+  { keys: ['T'], label: 'Toggle theme' },
+  { keys: ['1'], label: 'Open Timeline' },
+  { keys: ['2'], label: 'Open Booth feed' },
+  { keys: ['3', 'R'], label: 'Make a request' },
+  { keys: ['?'], label: 'This shortcuts list' },
+  { keys: ['⌘K'], label: 'Command palette' },
+  { keys: ['Esc'], label: 'Close drawer / dialog' },
+];
+
+/* Help dialog listing every player keyboard shortcut. Centered newsprint
+   modal — accepts `container` so it stays inside the frame in contained
+   mode, matching FullDialog / Modal. */
+export default function ShortcutsDialog({ open, onOpenChange, container }) {
+  const contained = !!container;
+  const pos = contained ? 'absolute' : 'fixed';
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal container={container}>
+        <Dialog.Overlay
+          className={cn('v3-drawer-overlay inset-0 z-40', pos)}
+          style={{ background: 'var(--overlay)' }}
+        />
+        <Dialog.Content
+          aria-describedby={undefined}
+          className={cn('v3-modal-pop z-50 left-1/2 top-1/2 outline-none flex flex-col', pos)}
+          style={{
+            transform: 'translate(-50%, -50%)',
+            width: 'min(420px, calc(100vw - 2rem))',
+            maxHeight: 'calc(100vh - 3rem)',
+            background: 'var(--bg)',
+            color: 'var(--ink)',
+            border: '1px solid var(--ink)',
+            boxShadow: 'var(--drawer-shadow)',
+          }}
+        >
+          <div
+            className="flex items-baseline justify-between gap-3 px-6 py-4"
+            style={{ borderBottom: '1px solid var(--ink)' }}
+          >
+            <Dialog.Title
+              className="v3-eyebrow m-0"
+              style={{ fontSize: 13, letterSpacing: '0.3em' }}
+            >
+              Keyboard shortcuts
+            </Dialog.Title>
+            <Dialog.Close
+              className="cursor-pointer text-xl leading-none v3-focus"
+              aria-label="Close"
+              style={{ background: 'transparent', border: 'none', color: 'var(--muted)' }}
+            >
+              ×
+            </Dialog.Close>
+          </div>
+
+          <div className="flex-1 overflow-auto v3-scroll px-6 py-3">
+            <ul className="flex flex-col">
+              {SHORTCUTS.map((s) => (
+                <li
+                  key={s.label}
+                  className="flex items-center justify-between gap-4 py-2.5"
+                  style={{ borderBottom: '1px dashed var(--separator-soft)' }}
+                >
+                  <span className="text-sm">{s.label}</span>
+                  <span className="flex items-center gap-1">
+                    {s.keys.map((k) => (
+                      <Kbd key={k}>{k}</Kbd>
+                    ))}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/web/components/ui/command.jsx
+++ b/web/components/ui/command.jsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { forwardRef } from 'react';
+import { Command as CommandPrimitive } from 'cmdk';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Search } from 'lucide-react';
+import { cn } from '../../lib/cn';
+
+/* shadcn-style Command wrappers over `cmdk`, restyled with the newsprint
+   tokens. CommandDialog is hand-built on @radix-ui/react-dialog rather than
+   the stock shadcn version — this repo has no stock DialogContent, and the
+   `container` prop keeps the palette inside the frame in contained mode. */
+
+export const Command = forwardRef(({ className, ...props }, ref) => (
+  <CommandPrimitive
+    ref={ref}
+    className={cn('flex h-full w-full flex-col overflow-hidden', className)}
+    style={{ background: 'var(--bg)', color: 'var(--ink)' }}
+    {...props}
+  />
+));
+Command.displayName = 'Command';
+
+export function CommandDialog({
+  open,
+  onOpenChange,
+  container,
+  label = 'Command palette',
+  children,
+}) {
+  const contained = !!container;
+  const pos = contained ? 'absolute' : 'fixed';
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal container={container}>
+        <Dialog.Overlay
+          className={cn('v3-drawer-overlay inset-0 z-40', pos)}
+          style={{ background: 'var(--overlay)' }}
+        />
+        <Dialog.Content
+          aria-describedby={undefined}
+          className={cn('z-50 left-1/2 outline-none', pos)}
+          style={{
+            top: '16%',
+            transform: 'translateX(-50%)',
+            width: 'min(540px, calc(100vw - 2rem))',
+            background: 'var(--bg)',
+            color: 'var(--ink)',
+            border: '1px solid var(--ink)',
+            boxShadow: 'var(--drawer-shadow)',
+            animation: 'v3-fade-in 160ms ease-out',
+          }}
+        >
+          <Dialog.Title className="sr-only">{label}</Dialog.Title>
+          <Command loop>{children}</Command>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+export const CommandInput = forwardRef(({ className, ...props }, ref) => (
+  <div
+    className="flex items-center gap-2 px-4"
+    style={{ borderBottom: '1px solid var(--ink)' }}
+  >
+    <Search size={15} strokeWidth={1.5} style={{ color: 'var(--muted)', flexShrink: 0 }} />
+    <CommandPrimitive.Input
+      ref={ref}
+      className={cn(
+        'flex-1 bg-transparent py-3 text-sm outline-none placeholder:text-[var(--muted)]',
+        className,
+      )}
+      {...props}
+    />
+  </div>
+));
+CommandInput.displayName = 'CommandInput';
+
+export const CommandList = forwardRef(({ className, ...props }, ref) => (
+  <CommandPrimitive.List
+    ref={ref}
+    className={cn('v3-scroll max-h-[320px] overflow-y-auto overflow-x-hidden py-1', className)}
+    {...props}
+  />
+));
+CommandList.displayName = 'CommandList';
+
+export const CommandEmpty = forwardRef((props, ref) => (
+  <CommandPrimitive.Empty
+    ref={ref}
+    className="py-6 text-center text-sm"
+    style={{ color: 'var(--muted)' }}
+    {...props}
+  />
+));
+CommandEmpty.displayName = 'CommandEmpty';
+
+export const CommandGroup = forwardRef(({ className, ...props }, ref) => (
+  <CommandPrimitive.Group
+    ref={ref}
+    className={cn(
+      'overflow-hidden p-1',
+      '[&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:py-2',
+      '[&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:uppercase',
+      '[&_[cmdk-group-heading]]:tracking-[0.3em] [&_[cmdk-group-heading]]:text-[var(--muted)]',
+      className,
+    )}
+    {...props}
+  />
+));
+CommandGroup.displayName = 'CommandGroup';
+
+export const CommandItem = forwardRef(({ className, ...props }, ref) => (
+  <CommandPrimitive.Item
+    ref={ref}
+    className={cn(
+      'flex cursor-pointer select-none items-center justify-between gap-2 px-3 py-2.5 text-sm outline-none',
+      'data-[selected=true]:bg-[var(--ink)] data-[selected=true]:text-[var(--bg)]',
+      'data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-40',
+      className,
+    )}
+    {...props}
+  />
+));
+CommandItem.displayName = 'CommandItem';

--- a/web/components/ui/kbd.jsx
+++ b/web/components/ui/kbd.jsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { cn } from '../../lib/cn';
+
+/* Small newsprint key-cap badge for rendering shortcut hints. Pure CSS — no
+   dependency. Used by the command palette and the shortcuts help dialog. */
+export function Kbd({ children, className }) {
+  return (
+    <kbd
+      className={cn(
+        'inline-flex items-center justify-center font-mono leading-none select-none',
+        className,
+      )}
+      style={{
+        minWidth: 20,
+        height: 20,
+        padding: '0 6px',
+        fontSize: 11,
+        border: '1px solid var(--soft-border)',
+        color: 'var(--muted)',
+        background: 'transparent',
+      }}
+    >
+      {children}
+    </kbd>
+  );
+}

--- a/web/hooks/useKeyboardShortcuts.js
+++ b/web/hooks/useKeyboardShortcuts.js
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+const TEXT_INPUT_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
+
+function isTextEntry(el) {
+  if (!el) return false;
+  if (TEXT_INPUT_TAGS.has(el.tagName)) return true;
+  return el.isContentEditable === true;
+}
+
+// Registers global keydown shortcuts on window. `handlers` maps a normalised
+// key string ('space', 'arrowup', 't', '?', 'mod+k', …) to a callback.
+//
+// Bare-key shortcuts are suppressed while the user is typing in a field or
+// while `disabled` is true; the command-palette chord (Cmd/Ctrl+K) always
+// fires so the palette can be opened — and toggled shut — from anywhere.
+//
+// Handlers/disabled are read through refs so the window listener binds once
+// and survives PlayerApp's per-second re-renders.
+export function useKeyboardShortcuts(handlers, { disabled = false } = {}) {
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+  const disabledRef = useRef(disabled);
+  disabledRef.current = disabled;
+
+  useEffect(() => {
+    function onKeyDown(e) {
+      const mod = e.metaKey || e.ctrlKey;
+
+      // Command palette chord — available even inside text fields.
+      if (mod && e.key.toLowerCase() === 'k') {
+        const run = handlersRef.current['mod+k'];
+        if (run) {
+          e.preventDefault();
+          run(e);
+        }
+        return;
+      }
+
+      // Leave every other modifier combo to the browser (copy/paste/etc).
+      if (mod || e.altKey) return;
+
+      // Bare keys: never while typing, or while a palette/dialog owns input.
+      if (disabledRef.current || isTextEntry(e.target)) return;
+
+      const key = e.key === ' ' ? 'space' : e.key.toLowerCase();
+      const run = handlersRef.current[key];
+      if (!run) return;
+      e.preventDefault();
+      run(e);
+    }
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+}

--- a/web/hooks/usePlayer.js
+++ b/web/hooks/usePlayer.js
@@ -11,6 +11,7 @@ export function usePlayer({ initialVolume = 1 } = {}) {
   const audioRef = useRef(null);
   const [tunedIn, setTunedIn] = useState(false);
   const [volume, setVolume] = useState(initialVolume);
+  const preMuteVolume = useRef(initialVolume || 1);
 
   useEffect(() => {
     if (audioRef.current) audioRef.current.volume = volume;
@@ -38,5 +39,16 @@ export function usePlayer({ initialVolume = 1 } = {}) {
     }
   };
 
-  return { audioRef, tunedIn, volume, setVolume, tune, stop };
+  // Mute is just volume 0; toggling restores the last non-zero level so the
+  // keyboard 'M' shortcut and the command palette have a sensible round-trip.
+  const toggleMute = () => {
+    if (volume > 0) {
+      preMuteVolume.current = volume;
+      setVolume(0);
+    } else {
+      setVolume(preMuteVolume.current || 1);
+    }
+  };
+
+  return { audioRef, tunedIn, volume, setVolume, tune, stop, toggleMute, muted: volume === 0 };
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,6 +22,7 @@
         "@radix-ui/react-toggle-group": "^1.1.11",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.0.0",
         "lucide-react": "^0.460.0",
         "next": "^15.0.0",
         "react": "^19.0.0",
@@ -1953,6 +1954,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/commander": {

--- a/web/package.json
+++ b/web/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-toggle-group": "^1.1.11",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.0.0",
     "lucide-react": "^0.460.0",
     "next": "^15.0.0",
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary

Adds keyboard-driven control and navigation to the listener-facing player, which was previously mouse/touch only.

- **Global shortcuts** — a `useKeyboardShortcuts` hook binds one `window` listener. Bare keys are suppressed while a text field is focused or a dialog owns input; `⌘K` always works.
  - `Space`/`K` tune in-out · `↑`/`↓` volume ±5% · `M` mute · `T` theme · `1`/`2`/`3` drawers · `R` request · `?` help · `⌘K`/`Ctrl+K` palette · `Esc` close (Radix-native)
- **⌘K command palette** — built on `cmdk` (the lib behind shadcn's Command component, newly added). `components/ui/command.jsx` is restyled to the newsprint tokens; `CommandDialog` is hand-wrapped on `@radix-ui/react-dialog` with a `container` prop so it works in contained mode. Scope is player actions only — no admin/site routes.
- **`?` help dialog** — `ShortcutsDialog.jsx` lists every shortcut with `Kbd` key-cap badges.
- Mute support added to `usePlayer.js` (volume 0, restores last non-zero level); `Space` also dismisses the first-paint tune-in overlay.

## Test plan

- [x] `/listen`, `/`, `/landing` compile and serve 200 with `cmdk` bundled, no errors
- [ ] Bare keys (Space, arrows, M, T, 1/2/3, R, ?) drive the player when the page is focused
- [ ] Bare keys do nothing while typing in the Request drawer fields
- [ ] `⌘K`/`Ctrl+K` opens the palette (including from inside a text field); filter, arrows + Enter run items
- [ ] `Esc` closes drawers, palette, and help dialog
- [ ] Contained-mode player (landing page) renders the palette/help dialog inside the frame

_Keyboard interaction needs a manual in-browser pass — no headless browser is available in the build env, and the repo has no test runner._

https://claude.ai/code/session_01FhNMTeXxsTy6xxzaDzPY6j

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhNMTeXxsTy6xxzaDzPY6j)_