### PR TITLE
Fix landing masthead header layout on mobile

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -382,13 +382,16 @@ body::after {
 }
 @media (max-width: 560px) {
     .bs-masthead-head {
-        grid-template-columns: 1fr 1fr;
         align-items: center;
-        gap: 12px 24px;
+        gap: 10px;
     }
-    .bs-masthead-mark {
-        grid-column: 1 / -1;
-        grid-row: 2;
+    /* The VOL/NO dateline is dropped on mobile so the theme toggle, the
+       wordmark and the ON AIR status sit together on a single row. */
+    .bs-masthead-issue {
+        display: none;
+    }
+    .bs-wordmark {
+        font-size: clamp(38px, 13vw, 64px);
     }
 }
 

--- a/web/components/landing/Masthead.jsx
+++ b/web/components/landing/Masthead.jsx
@@ -25,7 +25,10 @@ export default function Masthead() {
           className="bs-caption bs-masthead-meta flex items-center"
           style={{ color: 'var(--muted)', gap: 10 }}
         >
-          <span style={{ fontSize: 10, letterSpacing: '0.3em', textTransform: 'uppercase' }}>
+          <span
+            className="bs-masthead-issue"
+            style={{ fontSize: 10, letterSpacing: '0.3em', textTransform: 'uppercase' }}
+          >
             VOL. I &nbsp;·&nbsp; NO.&nbsp;{now ? issueNo(now) : '—'}
           </span>
           <ThemeToggle />


### PR DESCRIPTION
Drop the VOL/NO dateline on small screens and keep the theme toggle,
SUB/WAVE wordmark and ON AIR status aligned on a single row.

https://claude.ai/code/session_01CsWA4BdaLLn7pJCoJ5GWdJ