### PR TITLE
Fix TTS reading station name slash as "slash"

### DIFF
--- a/controller/src/audio/tts.js
+++ b/controller/src/audio/tts.js
@@ -80,6 +80,13 @@ async function speakWith(engine, text, opts, personaTts) {
   return piper.speak(text, opts);
 }
 
+// TTS engines read "SUB/WAVE" as "sub slash wave". Spell the station name
+// phonetically before synthesis — visual branding keeps the slash, audio doesn't.
+function normalizeForSpeech(text) {
+  if (!text) return text;
+  return text.replace(/\bSUB\s*(?:\/|slash)\s*WAVE\b/gi, 'Subwave');
+}
+
 // Public entry point. Tries the configured engine; on failure, falls back to
 // a local engine so the DJ never goes silent because a model (or the network)
 // failed. Piper is the universal fallback — local, keyless, fast.
@@ -87,12 +94,13 @@ async function speakWith(engine, text, opts, personaTts) {
 // Every call is timed and recorded into the TTS ring buffer (stats.js) so the
 // admin Stats page can show per-engine usage, latency, and the fallback rate.
 export async function speak(text, { kind = 'default', outPath } = {}) {
+  const speakText = normalizeForSpeech(text);
   const personaTts = djPersonaTts(kind);
   const primary = resolveEngine(kind, personaTts);
   const started = Date.now();
-  const chars = (text || '').length;
+  const chars = (speakText || '').length;
   try {
-    const result = await speakWith(primary, text, { outPath }, personaTts);
+    const result = await speakWith(primary, speakText, { outPath }, personaTts);
     recordTts({
       kind, engine: primary, requested: primary, fellBack: false,
       ok: true, ms: Date.now() - started, chars, t: new Date().toISOString(),
@@ -110,7 +118,7 @@ export async function speak(text, { kind = 'default', outPath } = {}) {
     }
     console.error(`[tts] ${primary} failed for kind=${kind}: ${err.message} — falling back to ${fallback}`);
     try {
-      const result = await speakWith(fallback, text, { outPath }, personaTts);
+      const result = await speakWith(fallback, speakText, { outPath }, personaTts);
       recordTts({
         kind, engine: fallback, requested: primary, fellBack: true,
         ok: true, ms: Date.now() - started, chars, t: new Date().toISOString(),

--- a/controller/src/broadcast/jingles.js
+++ b/controller/src/broadcast/jingles.js
@@ -18,7 +18,7 @@ const META = `${STATE_DIR}/jingles.json`;
 
 const DEFAULT_IDENT = {
   filename: 'station_ident_default.wav',
-  text: "You're listening to SUB slash WAVE. Personal frequency, broadcasting from the homelab.",
+  text: "You're listening to SUB/WAVE. Personal frequency, broadcasting from the homelab.",
   builtin: true,
 };
 

--- a/scripts/generate-jingles.sh
+++ b/scripts/generate-jingles.sh
@@ -17,11 +17,11 @@ COMPOSE_FILE="${COMPOSE_FILE:-docker/docker-compose.prod.yml}"
 COMPOSE="docker compose -f ${COMPOSE_FILE}"
 
 JINGLES=(
-  "You're listening to SUB/WAVE. Personal frequency from the homelab."
-  "SUB/WAVE radio. The signal continues."
-  "This is SUB/WAVE. Late night sounds for the connected few."
-  "You're tuned to SUB/WAVE. Single stream, one frequency."
-  "SUB/WAVE — broadcasting on whatever wavelength reaches you."
+  "You're listening to Subwave. Personal frequency from the homelab."
+  "Subwave radio. The signal continues."
+  "This is Subwave. Late night sounds for the connected few."
+  "You're tuned to Subwave. Single stream, one frequency."
+  "Subwave — broadcasting on whatever wavelength reaches you."
 )
 
 JINGLE_DIR_HOST="${STATE_DIR}/jingles"


### PR DESCRIPTION
Normalize "SUB/WAVE" to a phonetic spelling in tts.speak() before
synthesis so engines say "subwave" instead of "sub slash wave".
Visual branding keeps the slash; only spoken audio is changed.

https://claude.ai/code/session_01SMKiECav2tRDvVzixDtR68