### PR TITLE
Make DJ scripts sound more human (anti-AI-tell prompt rules)

### DIFF
--- a/controller/src/settings.js
+++ b/controller/src/settings.js
@@ -34,6 +34,20 @@ export const DJ_SOULS = [
   'quietly enthusiastic; treats every track like a small recommendation to a friend; specific over poetic',
 ];
 
+// Distilled from the "Signs of AI writing" guide — the subset that matters for
+// short spoken radio links. Appended to every DJ system prompt by renderDjPrompt()
+// and directorSystem(), so it survives custom operator templates. Kept tight on
+// purpose: a long forbidden-word list degrades small local models.
+export const DJ_HUMANNESS_RULES = `Sound like a person talking, not a write-up:
+- Skip AI-essay vocabulary: "delve", "tapestry", "testament", "boasts", "vibrant", "bustling", "elevate", "realm", "whilst", "moreover", "furthermore".
+- No significance inflation — a song is just a song; don't call it "more than just" anything or "a testament to" something.
+- Drop the "not just X, it's Y" / "not only... but also" framing.
+- No press-release hype: "iconic", "legendary", "timeless masterpiece", "must-listen".
+- Speak for yourself — never "many say", "it's often said", "critics agree".
+- No trailing "..., showcasing/highlighting..." analysis tacked onto a sentence.
+- Don't land on a tidy summary or a little moral. Make your point and stop.
+- Use contractions and plain words; let it have the rhythm of real speech.`;
+
 export const FREQUENCIES = ['quiet', 'moderate', 'aggressive'];
 
 // Per-persona verbosity. 'concise' is the historical one-liner behaviour;
@@ -747,11 +761,12 @@ export function renderDjPrompt(persona, ctx = {}) {
   const station = ctx.station || 'SUB/WAVE';
   const location = ctx.location || (cache?.weather?.locationName ?? DEFAULTS.weather.locationName);
   const tpl = (cache?.djPrompt && cache.djPrompt.trim()) ? cache.djPrompt : DEFAULT_DJ_PROMPT_TEMPLATE;
-  return tpl
+  const rendered = tpl
     .replaceAll('{name}', persona?.name || 'your host')
     .replaceAll('{soul}', persona?.soul || DJ_SOULS[0])
     .replaceAll('{station}', station)
     .replaceAll('{location}', location);
+  return `${rendered}\n\n${DJ_HUMANNESS_RULES}`;
 }
 
 // Liquidsoap reads two tiny text files instead of JSON.

--- a/controller/src/skills/_agent.js
+++ b/controller/src/skills/_agent.js
@@ -146,6 +146,8 @@ function directorSystem(persona, caps, freq) {
 
   return `You are ${name}, the on-air DJ for SUB/WAVE, a personal internet radio station. ${soul}
 
+${settings.DJ_HUMANNESS_RULES}
+
 YOUR ONLY JOB right now: decide whether to air ONE short spoken segment between tracks, or to stay silent. You are NOT choosing music — track selection is handled by another part of the station. Do not reason about which song should play next; that is not your decision.
 
 Staying silent is a perfectly good — often the best — answer. Only speak when there is something genuinely fresh and worth a listener's attention.
@@ -248,6 +250,8 @@ function forcedSystem(persona, cap) {
   const soul = persona?.soul || '';
 
   return `You are ${name}, the on-air DJ for SUB/WAVE, a personal internet radio station. ${soul}
+
+${settings.DJ_HUMANNESS_RULES}
 
 The operator has asked you to air ONE ${cap.kind} segment right now. You are NOT choosing music — track selection is handled by another part of the station. Your only job is to write the spoken line.
 


### PR DESCRIPTION
Distil the "Signs of AI writing" guide into DJ_HUMANNESS_RULES — a tight spoken-radio subset — and append it to every spoken-text system prompt: renderDjPrompt() (all six dj.js generators) plus directorSystem() and forcedSystem() in the skills agent. Appended at render time, so it also covers custom operator djPrompt templates.