### PR TITLE
Pause DJ LLM calls when no one is listening

### DIFF
--- a/controller/src/broadcast/listeners.js
+++ b/controller/src/broadcast/listeners.js
@@ -1,0 +1,55 @@
+// Icecast listener-count monitor.
+//
+// Polls Icecast's status-json.xsl on an interval and caches the live listener
+// count for the /stream.mp3 mount, so the DJ gates can ask "is anyone
+// listening?" without each one hitting Icecast.
+//
+// Fail-open: if Icecast is unreachable the count is null and djCallsAllowed()
+// treats the station as occupied — a stats outage must never silence the DJ.
+
+import { config } from '../config.js';
+import * as settings from '../settings.js';
+
+let lastCount = null;        // null = unknown (not yet polled, or Icecast down)
+
+async function fetchCount() {
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 1500);
+    const r = await fetch(config.icecast.statusUrl, { signal: ctrl.signal });
+    clearTimeout(timer);
+    const ic = (await r.json())?.icestats;
+    const sources = Array.isArray(ic?.source) ? ic.source : ic?.source ? [ic.source] : [];
+    const src = sources.find(s => String(s?.listenurl || '').includes('/stream.mp3')) || null;
+    lastCount = src ? Number(src.listeners || 0) : 0;
+  } catch {
+    lastCount = null;
+  }
+  return lastCount;
+}
+
+// Last known listener count — a number, or null when it couldn't be read.
+export function getListenerCount() {
+  return lastCount;
+}
+
+// Force an immediate poll. Used by the request route so a listener who just
+// connected isn't rejected on a stale cached value.
+export async function refresh() {
+  return fetchCount();
+}
+
+// True when autonomous DJ LLM work is allowed right now. When the pause toggle
+// is off, always true. When on, allowed only if at least one listener is
+// counted — an unknown count (Icecast unreachable) is treated as occupied so a
+// stats outage can never take the DJ off the air.
+export function djCallsAllowed() {
+  if (!settings.get()?.llm?.pauseWhenEmpty) return true;
+  if (lastCount === null) return true;
+  return lastCount > 0;
+}
+
+export function startListenerMonitor() {
+  fetchCount();
+  setInterval(fetchCount, 15000);
+}

--- a/controller/src/broadcast/queue.js
+++ b/controller/src/broadcast/queue.js
@@ -13,6 +13,7 @@ import * as session from './session.js';
 import { getFullContext } from '../context.js';
 import * as settings from '../settings.js';
 import { logEvent } from '../observability/events.js';
+import { djCallsAllowed } from './listeners.js';
 
 // Random gap between DJ links on auto-played tracks. The frequency setting
 // scales how chatty the DJ is:
@@ -356,8 +357,12 @@ class Queue {
     // writes a between-track link to air over what just started. Fire-and-
     // forget: the pick lands in Liquidsoap's dj_queue before this track ends.
     // Listener requests bring their own intro and don't count toward the gap.
+    // When nobody is listening (and the pause toggle is on) skip the pick —
+    // `upcoming` stays empty and Liquidsoap coasts on the auto playlist. The
+    // watcher still gets onTrackStarted events for those auto tracks, so the
+    // first transition after a listener returns re-enters this block.
     const isAutonomous = this.current.source === 'auto' || this.current.source === 'ai';
-    if (this.autoPick && this.upcoming.length === 0 && !this.pickerBusy) {
+    if (this.autoPick && this.upcoming.length === 0 && !this.pickerBusy && djCallsAllowed()) {
       let wantLink = false;
       if (this.autoLink && isAutonomous && this.history[0]) {
         this.tracksUntilLink--;

--- a/controller/src/broadcast/scheduler.js
+++ b/controller/src/broadcast/scheduler.js
@@ -15,6 +15,7 @@ import { queue } from './queue.js';
 import * as session from './session.js';
 import { cleanupOldVoices } from '../audio/tts.js';
 import { shouldFire } from './dj-gate.js';
+import { djCallsAllowed } from './listeners.js';
 import { agenticTick, skillCatalog } from '../skills/_agent.js';
 import { withTrace } from '../observability/events.js';
 
@@ -166,6 +167,7 @@ async function hourlyCheck() {
     queue.log('error', `Session roll failed: ${err.message}`);
   }
   if (!shouldFire('hourly')) return;
+  if (!djCallsAllowed()) return;  // nobody listening — stay on the auto playlist
   try {
     await runHourlyCheck();
   } catch (err) {
@@ -204,6 +206,7 @@ export async function runLink() {
 // ---------------------------------------------------------------------------
 
 async function skillsTick() {
+  if (!djCallsAllowed()) return;  // nobody listening — skip the segment director
   try {
     await withTrace({ kind: 'segment' }, async () => {
       const ctx = await getFullContext();
@@ -235,6 +238,7 @@ export async function runStationId() {
 
 async function stationId() {
   if (!shouldFire('stationId')) return;
+  if (!djCallsAllowed()) return;  // nobody listening — skip the ident
   try {
     await runStationId();
   } catch (err) {

--- a/controller/src/config.js
+++ b/controller/src/config.js
@@ -60,6 +60,10 @@ export const config = {
     lang: process.env.KOKORO_LANG || 'en-gb',
     speed: parseFloat(process.env.KOKORO_SPEED || TTS_SPEED),
   },
+  icecast: {
+    // Public status JSON — listener counts + per-mount metadata. No auth.
+    statusUrl: process.env.ICECAST_STATUS_URL || 'http://icecast:7702/status-json.xsl',
+  },
   liquidsoap: {
     queueFile: `${STATE_DIR}/next.txt`,
     sayFile: `${STATE_DIR}/say.txt`,

--- a/controller/src/context.js
+++ b/controller/src/context.js
@@ -3,6 +3,7 @@
 
 import { config } from './config.js';
 import { resolveActiveShow } from './settings.js';
+import { getListenerCount } from './broadcast/listeners.js';
 
 export function getTimeContext(date = new Date()) {
   const h = date.getHours();
@@ -163,5 +164,9 @@ export async function getFullContext() {
   // Show > festival > weather > time, in that order of priority for mood.
   const dominantMood = activeShow?.mood || festival?.mood || weather.mood || time.mood;
 
-  return { time, weather, festival, dominantMood, date, clock, activeShow };
+  // Live audience size, from the cached Icecast monitor. `count` is null when
+  // it couldn't be read — callers treat that as "unknown" and stay quiet.
+  const listeners = { count: getListenerCount() };
+
+  return { time, weather, festival, dominantMood, date, clock, activeShow, listeners };
 }

--- a/controller/src/llm/dj.js
+++ b/controller/src/llm/dj.js
@@ -167,6 +167,12 @@ export function buildContextLines(context, { recentTracks } = {}) {
     const topic = context.activeShow.topic ? ` — ${context.activeShow.topic}` : '';
     lines.push(`On now: the show "${context.activeShow.name}"${topic}. Stay loosely on its theme.`);
   }
+  if (context?.listeners?.count != null) {
+    const n = context.listeners.count;
+    lines.push(n === 0
+      ? `No one is tuned in right now.`
+      : `Listeners tuned in right now: ${n}.`);
+  }
   if (recentTracks && recentTracks.length) {
     const list = recentTracks.slice(0, 5).map(t => `"${t.title}" by ${t.artist || 'unknown'}`).join('; ');
     lines.push(`Recently played (do not mention these artists or titles): ${list}`);

--- a/controller/src/routes/public.js
+++ b/controller/src/routes/public.js
@@ -1,6 +1,7 @@
 // Public, unauthenticated endpoints: liveness, now-playing, station/DJ info,
 // queue state, and the cover-art proxy.
 import express from 'express';
+import { config } from '../config.js';
 import * as subsonic from '../music/subsonic.js';
 import * as settings from '../settings.js';
 import { getFullContext } from '../context.js';
@@ -18,7 +19,7 @@ async function getStreamStatus() {
   try {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), 1500);
-    const r = await fetch('http://icecast:7702/status-json.xsl', { signal: ctrl.signal });
+    const r = await fetch(config.icecast.statusUrl, { signal: ctrl.signal });
     clearTimeout(timer);
     const ic = (await r.json())?.icestats;
     const sources = Array.isArray(ic?.source) ? ic.source : ic?.source ? [ic.source] : [];

--- a/controller/src/routes/request.js
+++ b/controller/src/routes/request.js
@@ -11,6 +11,7 @@ import { getFullContext } from '../context.js';
 import { queue } from '../broadcast/queue.js';
 import * as djAgent from '../broadcast/dj-agent.js';
 import * as session from '../broadcast/session.js';
+import * as listeners from '../broadcast/listeners.js';
 import {
   checkRateLimit, clientIp,
   REQUESTS_DISABLED, REQUEST_TEXT_MAX, REQUEST_NAME_MAX,
@@ -385,6 +386,17 @@ async function resolveRequest(entry) {
 router.post('/request', async (req, res) => {
   if (REQUESTS_DISABLED) {
     return res.status(503).json({ success: false, message: 'Requests are temporarily closed.' });
+  }
+
+  // Zero-listener pause: a request would mean LLM work, so it's gated too.
+  // Force a fresh Icecast read so a listener who just connected isn't turned
+  // away on a stale cached count.
+  await listeners.refresh();
+  if (!listeners.djCallsAllowed()) {
+    return res.status(503).json({
+      success: false,
+      message: "The DJ's on autopilot — requests reopen when someone's tuned in.",
+    });
   }
 
   const rawText = typeof req.body?.text === 'string' ? req.body.text : '';

--- a/controller/src/server.js
+++ b/controller/src/server.js
@@ -11,6 +11,7 @@ import { queue } from './broadcast/queue.js';
 import * as session from './broadcast/session.js';
 import { getFullContext } from './context.js';
 import { startScheduler } from './broadcast/scheduler.js';
+import { startListenerMonitor } from './broadcast/listeners.js';
 import { cors } from './middleware/cors.js';
 import { assertAdminConfigured } from './middleware/auth.js';
 import { router as publicRoutes } from './routes/public.js';
@@ -75,6 +76,7 @@ app.listen(config.server.port, async () => {
   queue.recover();
 
   queue.startWatcher();
+  startListenerMonitor();
   startScheduler();
   jingles.ensureDefaultIdent().catch(err => console.error('[jingles] ident generation failed:', err.message));
   sfx.ensureDefaults().catch(err => console.error('[sfx] default generation failed:', err.message));

--- a/controller/src/settings.js
+++ b/controller/src/settings.js
@@ -201,6 +201,11 @@ const DEFAULTS = {
     // dj-agent.js). When off, the stateless pool picker runs instead — still
     // inside a session, still logged, just without the conversational loop.
     pickerAgent: true,
+    // When on, autonomous DJ LLM work (track picks, links, station IDs,
+    // hourly checks, segments) and listener requests pause whenever Icecast
+    // reports zero listeners — the stream coasts on the auto playlist — and
+    // resume as soon as someone tunes in. Off by default.
+    pauseWhenEmpty: false,
   },
   skills: {
     enabled: {},
@@ -406,6 +411,9 @@ export async function load() {
       pickerAgent: typeof stored.llm?.pickerAgent === 'boolean'
         ? stored.llm.pickerAgent
         : DEFAULTS.llm.pickerAgent,
+      pauseWhenEmpty: typeof stored.llm?.pauseWhenEmpty === 'boolean'
+        ? stored.llm.pauseWhenEmpty
+        : DEFAULTS.llm.pauseWhenEmpty,
     },
     skills: {
       enabled: Object.fromEntries(
@@ -712,6 +720,9 @@ export async function update(patch) {
     }
     if (l.pickerAgent !== undefined) {
       next.llm.pickerAgent = !!l.pickerAgent;
+    }
+    if (l.pauseWhenEmpty !== undefined) {
+      next.llm.pauseWhenEmpty = !!l.pauseWhenEmpty;
     }
     // An OpenAI-compatible provider is useless without a server to talk to.
     if (next.llm.provider === 'openai-compatible' && !next.llm.baseUrl) {

--- a/web/components/admin/SettingsPanel.jsx
+++ b/web/components/admin/SettingsPanel.jsx
@@ -112,6 +112,7 @@ export default function SettingsPanel() {
         baseUrl: data.values.llm?.baseUrl ?? '',
         reasoning: !!data.values.llm?.reasoning,
         pickerAgent: !!data.values.llm?.pickerAgent,
+        pauseWhenEmpty: !!data.values.llm?.pauseWhenEmpty,
       },
     });
   }, [data, form]);
@@ -715,6 +716,7 @@ function LlmSection({ data, form, setForm, busy, saveMsg, saveSettings }) {
       baseUrl: form.llm.baseUrl,
       reasoning: form.llm.reasoning,
       pickerAgent: form.llm.pickerAgent,
+      pauseWhenEmpty: form.llm.pauseWhenEmpty,
       // The API key is never set from the UI — it comes from the controller's
       // environment (ANTHROPIC_API_KEY / OPENAI_API_KEY / AI_GATEWAY_API_KEY).
     },
@@ -912,6 +914,29 @@ function LlmSection({ data, form, setForm, busy, saveMsg, saveSettings }) {
               { id: 'agent', label: 'Agent' },
             ]}
             onChange={v => setForm(f => ({ ...f, llm: { ...f.llm, pickerAgent: v === 'agent' } }))}
+          />
+        </div>
+      </Card>
+
+      <Card title="Idle behaviour" sub="when no one's listening">
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: 16, alignItems: 'center' }}>
+          <div>
+            <div style={{ fontSize: 13, fontWeight: 700 }}>Pause DJ when empty</div>
+            <div style={{ fontSize: 11, color: 'var(--muted)', marginTop: 2, maxWidth: 480, lineHeight: 1.5 }}>
+              When on, the DJ stops making LLM calls — track picks, links, station
+              IDs, hourly checks, segments and listener requests — whenever Icecast
+              reports zero listeners. The stream keeps playing from the auto
+              playlist, and the DJ resumes the moment someone tunes back in.
+            </div>
+          </div>
+          <Seg
+            accent
+            value={form.llm.pauseWhenEmpty ? 'on' : 'off'}
+            options={[
+              { id: 'off', label: 'Off' },
+              { id: 'on', label: 'On' },
+            ]}
+            onChange={v => setForm(f => ({ ...f, llm: { ...f.llm, pauseWhenEmpty: v === 'on' } }))}
           />
         </div>
       </Card>


### PR DESCRIPTION
Add an opt-in mode that stops all autonomous DJ LLM work when Icecast
reports zero listeners, letting the stream coast on the auto playlist,
and resumes it as soon as someone tunes in.

- New broadcast/listeners.js polls Icecast status-json.xsl every 15s and
  caches the live listener count; fail-open if Icecast is unreachable.
- llm.pauseWhenEmpty setting (off by default) with an admin UI toggle.
- Gates the autonomous LLM triggers: scheduler segments, the between-
  track picker/link, and listener requests. Operator overrides stay live.
- Feeds the listener count into the DJ prompt context so dialogue can be
  aware of the audience size.

https://claude.ai/code/session_01P3yHBxfYwc4cZ22Dw9QMYY