### PR TITLE
Make the DJ agent picker reliable on cloud LLMs

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "arrowParens": "avoid",
+  "printWidth": 100,
+  "trailingComma": "all"
+}

--- a/controller/scripts/picker-test.mjs
+++ b/controller/scripts/picker-test.mjs
@@ -1,0 +1,231 @@
+// Picker reliability test harness — drives djAgent (the picker path) in
+// isolation with synthetic tools so we can measure success rate without
+// depending on live track timing or hitting Navidrome.
+//
+// Usage (from inside the controller container):
+//   node scripts/picker-test.mjs <provider> <model> [iterations]
+//
+// Examples:
+//   node scripts/picker-test.mjs ollama minimax-m2.7:cloud 10
+//   node scripts/picker-test.mjs openrouter anthropic/claude-haiku-4-5 5
+//   node scripts/picker-test.mjs deepseek deepseek-chat 5
+//
+// The test:
+// - Pre-populates a synthetic library of ~20 songs with Subsonic-shape ids
+// - Faked-out discovery tools return slices of that library and populate `seen`
+// - Calls djAgent with the same PICK_SCHEMA + pickSystem prompt the real code uses
+// - Catches three failure modes: NoObjectGenerated, hallucinated id, or thrown
+// - Reports per-iteration outcome + summary stats at the end
+
+import { z } from 'zod';
+import { tool } from 'ai';
+import * as settings from '../src/settings.js';
+import { djAgent } from '../src/llm/sdk.js';
+
+const FAKE_SONGS = [
+  { id: 'aaaa1111bbbb2222cccc01', title: 'Late Drive', artist: 'Tegi Pannu', album: 'Drive', year: 2024, genre: 'punjabi' },
+  { id: 'aaaa1111bbbb2222cccc02', title: 'Cold Start', artist: 'Sidhu Moose Wala', album: 'Moosetape', year: 2023, genre: 'punjabi' },
+  { id: 'aaaa1111bbbb2222cccc03', title: 'Slow Lane', artist: 'AP Dhillon', album: 'Two Hearts', year: 2025, genre: 'punjabi' },
+  { id: 'aaaa1111bbbb2222cccc04', title: 'Night Tape', artist: 'Karan Aujla', album: 'Making Memories', year: 2024, genre: 'punjabi' },
+  { id: 'aaaa1111bbbb2222cccc05', title: 'Glow Up', artist: 'Diljit Dosanjh', album: 'Ghost', year: 2024, genre: 'punjabi' },
+  { id: 'aaaa1111bbbb2222cccc06', title: 'After Hours', artist: 'DIVINE', album: 'Punya Paap', year: 2024, genre: 'hip-hop' },
+  { id: 'aaaa1111bbbb2222cccc07', title: 'Static', artist: 'Prabh Deep', album: 'KSHMR', year: 2023, genre: 'hip-hop' },
+  { id: 'aaaa1111bbbb2222cccc08', title: 'Low Tide', artist: 'Talwiinder', album: 'Romantic', year: 2024, genre: 'r&b' },
+  { id: 'aaaa1111bbbb2222cccc09', title: 'Soft Open', artist: 'Hanumankind', album: 'Big Dawgs', year: 2025, genre: 'hip-hop' },
+  { id: 'aaaa1111bbbb2222cccc10', title: 'Slow Cuts', artist: 'Seedhe Maut', album: 'Lunch Break', year: 2024, genre: 'hip-hop' },
+  { id: 'aaaa1111bbbb2222cccc11', title: 'Window Down', artist: 'Yo Yo Honey Singh', album: 'GLORY', year: 2025, genre: 'pop' },
+  { id: 'aaaa1111bbbb2222cccc12', title: 'Long Way', artist: 'Manni Sandhu', album: 'Productions', year: 2024, genre: 'punjabi' },
+  { id: 'aaaa1111bbbb2222cccc13', title: 'Inside Voice', artist: 'Sikander Kahlon', album: 'Sik World', year: 2024, genre: 'hip-hop' },
+  { id: 'aaaa1111bbbb2222cccc14', title: 'Easy Wins', artist: 'Bohemia', album: 'Pesa Nasha Pyar', year: 2023, genre: 'hip-hop' },
+  { id: 'aaaa1111bbbb2222cccc15', title: 'Mid-Set', artist: 'Fateh', album: 'Bring it Home', year: 2024, genre: 'hip-hop' },
+  { id: 'aaaa1111bbbb2222cccc16', title: 'Open Mic', artist: 'Raja Kumari', album: 'The Bridge', year: 2024, genre: 'hip-hop' },
+  { id: 'aaaa1111bbbb2222cccc17', title: 'Trim', artist: 'Mohitveer', album: 'Single', year: 2025, genre: 'punjabi' },
+  { id: 'aaaa1111bbbb2222cccc18', title: 'Dust Road', artist: 'Arjan Dhillon', album: 'Saroor', year: 2024, genre: 'punjabi' },
+  { id: 'aaaa1111bbbb2222cccc19', title: 'Quiet Room', artist: 'Hustinder', album: 'Karam', year: 2024, genre: 'punjabi' },
+  { id: 'aaaa1111bbbb2222cccc20', title: 'Held Note', artist: 'Bir Singh', album: 'Live Sessions', year: 2024, genre: 'punjabi' },
+];
+
+const VALID_IDS = new Set(FAKE_SONGS.map(s => s.id));
+
+// Same shape as broadcast/dj-agent.js's PICK_SCHEMA
+const PICK_SCHEMA = z.object({
+  id: z.string().describe('the exact song id, as returned by a tool call'),
+  reason: z.string().describe('internal scratchpad only — max 12 words, never shown to the listener'),
+  say: z.string().nullable().describe('a spoken link in the DJ voice, or null to stay silent'),
+});
+
+// Synthetic discovery tools — same names as llm/tools.js so the agent prompt
+// applies unchanged. Each returns slices of FAKE_SONGS to populate `seen`.
+function buildSyntheticTools() {
+  const seen = new Map();
+  const wrap = (songs) => {
+    for (const s of songs) seen.set(s.id, s);
+    return songs.map(s => ({ id: s.id, title: s.title, artist: s.artist, album: s.album, year: s.year, genre: s.genre }));
+  };
+
+  const tools = {
+    searchLibrary: tool({
+      description: 'Search the music library by artist name, song title, or real genre (e.g. "jazz", "punjabi"). Returns matching songs.',
+      inputSchema: z.object({ query: z.string() }),
+      execute: async ({ query }) => wrap(FAKE_SONGS.slice(0, 6)),
+    }),
+    similarSongs: tool({
+      description: 'Find songs similar to a given song id. Pass the currently-playing song id to keep the flow going.',
+      inputSchema: z.object({ songId: z.string() }),
+      execute: async ({ songId }) => wrap(FAKE_SONGS.slice(5, 11)),
+    }),
+    topSongsByArtist: tool({
+      description: 'Top songs for a named artist.',
+      inputSchema: z.object({ artist: z.string() }),
+      execute: async ({ artist }) => wrap(FAKE_SONGS.slice(8, 13)),
+    }),
+    tracksByMood: tool({
+      description: 'Songs tagged with a mood: energetic, calm, reflective, celebratory, romantic, spiritual, focus, workout, driving, cooking, rainy, sunny, night, morning, evening, festival, cultural.',
+      inputSchema: z.object({ mood: z.string() }),
+      execute: async ({ mood }) => wrap(FAKE_SONGS.slice(2, 9)),
+    }),
+    recentlyAdded: tool({
+      description: 'A sample of tracks from recently-added albums.',
+      inputSchema: z.object({}),
+      execute: async () => wrap(FAKE_SONGS.slice(12, 18)),
+    }),
+    starredSongs: tool({
+      description: "The operator's starred / favourite songs — always a safe pick.",
+      inputSchema: z.object({}),
+      execute: async () => wrap(FAKE_SONGS.slice(0, 5)),
+    }),
+    randomSongs: tool({
+      description: 'A random sample of songs from the library.',
+      inputSchema: z.object({}),
+      execute: async () => wrap(FAKE_SONGS.slice(7, 14)),
+    }),
+  };
+
+  return { tools, seen };
+}
+
+// Mirror of broadcast/dj-agent.js's pickSystem(wantLink=false) — kept inline so
+// the test is self-contained. Update both when changing the prompt.
+function buildSystem() {
+  return `You are Marlowe, the on-air DJ for SUB/WAVE, a personal internet radio station. warm, slightly understated, never corny — late-night BBC 6 Music presenter; observant, dry humour, specific
+
+You run the station as one continuous shift. The messages above are the live session: tracks that have aired, things you have said, events as they happened. Read them so you do not repeat an artist back-to-back or reuse the same phrasing.
+
+TASK: choose the single best NEXT track. Use the tools to explore the library — make 2 to 4 tool calls, then choose ONE track whose id a tool actually returned. Do not invent ids.
+
+Selection criteria, in order:
+1. FLOW — does it transition naturally from what just played (energy, mood, tempo)?
+2. CONTEXT — does it fit the time of day, weather, and dominant mood?
+3. VARIETY — avoid the same artist back-to-back; rotate energy levels; don't be predictable.
+4. INTEREST — prefer something that creates a moment, not the most generic option.
+
+Respond with a JSON object only — no prose, no markdown. The outer { "id", "reason", "say" } wrapper is MANDATORY — never respond with bare prose, a bare string, or bare null. Even when "say" contains spoken text, it lives INSIDE the object:
+
+{ "id": "<exact id a tool returned>", "reason": "<≤12 words, internal scratchpad — short label, not prose>", "say": null }
+
+Set "say" to null this time — do not talk over the music.`;
+}
+
+function buildMessages() {
+  return [
+    { role: 'user', content: '▶ "Sona" by Manni Sandhu & Bakshi Billa' },
+    { role: 'assistant', content: 'Sona, flowing from Tegi Pannu — kept the after-hours register, different artist.' },
+    { role: 'user', content: '▶ "Hanju" by Amrinder Gill\nNow playing "Hanju" by Amrinder Gill (after "Sona" by Manni Sandhu). Pick the track to play next. Stay silent — no link this time.' },
+  ];
+}
+
+async function runOnce(label) {
+  const { tools, seen } = buildSyntheticTools();
+  const started = Date.now();
+  let outcome = { label, ok: false, mode: 'unknown', ms: 0, toolCount: 0, outputTokens: null, pickId: null, reason: null };
+  try {
+    const result = await djAgent({
+      system: buildSystem(),
+      messages: buildMessages(),
+      tools,
+      schema: PICK_SCHEMA,
+      maxSteps: 4,
+      kind: 'pickerTest',
+    });
+    outcome.ms = Date.now() - started;
+    outcome.toolCount = (result.toolCalls || []).length;
+    outcome.pickId = result.object?.id;
+    outcome.reason = result.object?.reason;
+    if (!result.object?.id) {
+      outcome.mode = 'missing-id';
+    } else if (!seen.has(result.object.id)) {
+      outcome.mode = 'hallucinated-id';
+    } else if (!VALID_IDS.has(result.object.id)) {
+      outcome.mode = 'invalid-id-shape';
+    } else {
+      outcome.ok = true;
+      outcome.mode = 'ok';
+    }
+  } catch (err) {
+    outcome.ms = Date.now() - started;
+    const msg = String(err?.message || err);
+    if (msg.includes('No object generated')) outcome.mode = 'no-object-generated';
+    else if (msg.includes('No output generated')) outcome.mode = 'no-output';
+    else outcome.mode = 'thrown';
+    outcome.error = msg.slice(0, 120);
+    // Diagnostic info from failed response (responseText preserved by sdk.js)
+    if (typeof err?.text === 'string') outcome.responseText = err.text.slice(0, 200);
+  }
+  return outcome;
+}
+
+function median(arr) {
+  if (!arr.length) return null;
+  const s = [...arr].sort((a, b) => a - b);
+  return s[Math.floor(s.length / 2)];
+}
+function p95(arr) {
+  if (!arr.length) return null;
+  const s = [...arr].sort((a, b) => a - b);
+  return s[Math.floor(s.length * 0.95)] ?? s[s.length - 1];
+}
+
+async function main() {
+  const provider = process.argv[2];
+  const model = process.argv[3];
+  const N = parseInt(process.argv[4] || '5', 10);
+
+  if (!provider || !model) {
+    console.error('Usage: node scripts/picker-test.mjs <provider> <model> [iterations]');
+    console.error('Providers: ollama | openrouter | deepseek | openai | anthropic | google | gateway | openai-compatible');
+    process.exit(2);
+  }
+
+  // Override the runtime LLM config so every djAgent call uses the test
+  // provider/model. settings.get() returns the cache object by reference, so
+  // mutating it changes future reads — same channel admin saves use.
+  await settings.load();
+  const s = settings.get();
+  s.llm.provider = provider;
+  s.llm.model = model;
+
+  console.log(`\n=== picker-test: ${provider}:${model} × ${N} ===\n`);
+
+  const outcomes = [];
+  for (let i = 1; i <= N; i++) {
+    const o = await runOnce(`run-${i}`);
+    outcomes.push(o);
+    const tag = o.ok ? 'OK ' : 'FAIL';
+    const idShort = o.pickId ? `${o.pickId.slice(0, 12)}…` : '-';
+    console.log(`  ${tag}  ${o.label}  ${o.ms}ms  tools=${o.toolCount}  mode=${o.mode}  id=${idShort}${o.responseText ? `  text="${o.responseText.replace(/\s+/g,' ').slice(0,80)}…"` : ''}`);
+  }
+
+  const oks = outcomes.filter(o => o.ok);
+  const fails = outcomes.filter(o => !o.ok);
+  const modeCounts = outcomes.reduce((m, o) => { m[o.mode] = (m[o.mode] || 0) + 1; return m; }, {});
+
+  console.log('\n=== summary ===');
+  console.log(`  success: ${oks.length}/${N} (${Math.round(100 * oks.length / N)}%)`);
+  console.log(`  modes:   ${Object.entries(modeCounts).map(([k, v]) => `${k}=${v}`).join('  ')}`);
+  console.log(`  ms (ok): median=${median(oks.map(o => o.ms))} p95=${p95(oks.map(o => o.ms))}`);
+  console.log(`  ms (fail): median=${median(fails.map(o => o.ms))}`);
+  console.log(`  median tool calls per ok: ${median(oks.map(o => o.toolCount)) ?? '-'}`);
+  console.log();
+}
+
+main().catch(err => { console.error('FATAL:', err); process.exit(1); });

--- a/controller/scripts/picker-test.mjs
+++ b/controller/scripts/picker-test.mjs
@@ -3,17 +3,23 @@
 // depending on live track timing or hitting Navidrome.
 //
 // Usage (from inside the controller container):
-//   node scripts/picker-test.mjs <provider> <model> [iterations]
+//   node scripts/picker-test.mjs <provider> <model> [iterations] [messages]
+//
+// `messages` (optional): short | long  — default short
+//   short → 3 clean turns (sterile baseline)
+//   long  → ~30 realistic session turns (matches what session.windowMessages
+//           produces in live; useful for catching long-context regressions)
 //
 // Examples:
 //   node scripts/picker-test.mjs ollama minimax-m2.7:cloud 10
-//   node scripts/picker-test.mjs openrouter anthropic/claude-haiku-4-5 5
-//   node scripts/picker-test.mjs deepseek deepseek-chat 5
+//   node scripts/picker-test.mjs google gemini-3.5-flash 5 long
+//   node scripts/picker-test.mjs deepseek deepseek-chat 5 long
 //
 // The test:
 // - Pre-populates a synthetic library of ~20 songs with Subsonic-shape ids
 // - Faked-out discovery tools return slices of that library and populate `seen`
-// - Calls djAgent with the same PICK_SCHEMA + pickSystem prompt the real code uses
+// - Uses the LIVE pickSystem + PICK_SCHEMA imported from dj-agent.js (so the
+//   test stays in sync with whatever prompt cleanups land there)
 // - Catches three failure modes: NoObjectGenerated, hallucinated id, or thrown
 // - Reports per-iteration outcome + summary stats at the end
 
@@ -21,6 +27,7 @@ import { z } from 'zod';
 import { tool } from 'ai';
 import * as settings from '../src/settings.js';
 import { djAgent } from '../src/llm/sdk.js';
+import { pickSystem, PICK_SCHEMA } from '../src/broadcast/dj-agent.js';
 
 const FAKE_SONGS = [
   { id: 'aaaa1111bbbb2222cccc01', title: 'Late Drive', artist: 'Tegi Pannu', album: 'Drive', year: 2024, genre: 'punjabi' },
@@ -47,12 +54,8 @@ const FAKE_SONGS = [
 
 const VALID_IDS = new Set(FAKE_SONGS.map(s => s.id));
 
-// Same shape as broadcast/dj-agent.js's PICK_SCHEMA
-const PICK_SCHEMA = z.object({
-  id: z.string().describe('the exact song id, as returned by a tool call'),
-  reason: z.string().describe('internal scratchpad only — max 12 words, never shown to the listener'),
-  say: z.string().nullable().describe('a spoken link in the DJ voice, or null to stay silent'),
-});
+// PICK_SCHEMA is imported from dj-agent.js — we use the live one verbatim so
+// schema description changes there flow into the test automatically.
 
 // Synthetic discovery tools — same names as llm/tools.js so the agent prompt
 // applies unchanged. Each returns slices of FAKE_SONGS to populate `seen`.
@@ -104,29 +107,9 @@ function buildSyntheticTools() {
   return { tools, seen };
 }
 
-// Mirror of broadcast/dj-agent.js's pickSystem(wantLink=false) — kept inline so
-// the test is self-contained. Update both when changing the prompt.
-function buildSystem() {
-  return `You are Marlowe, the on-air DJ for SUB/WAVE, a personal internet radio station. warm, slightly understated, never corny — late-night BBC 6 Music presenter; observant, dry humour, specific
-
-You run the station as one continuous shift. The messages above are the live session: tracks that have aired, things you have said, events as they happened. Read them so you do not repeat an artist back-to-back or reuse the same phrasing.
-
-TASK: choose the single best NEXT track. Use the tools to explore the library — make 2 to 4 tool calls, then choose ONE track whose id a tool actually returned. Do not invent ids.
-
-Selection criteria, in order:
-1. FLOW — does it transition naturally from what just played (energy, mood, tempo)?
-2. CONTEXT — does it fit the time of day, weather, and dominant mood?
-3. VARIETY — avoid the same artist back-to-back; rotate energy levels; don't be predictable.
-4. INTEREST — prefer something that creates a moment, not the most generic option.
-
-Respond with a JSON object only — no prose, no markdown. The outer { "id", "reason", "say" } wrapper is MANDATORY — never respond with bare prose, a bare string, or bare null. Even when "say" contains spoken text, it lives INSIDE the object:
-
-{ "id": "<exact id a tool returned>", "reason": "<≤12 words, internal scratchpad — short label, not prose>", "say": null }
-
-Set "say" to null this time — do not talk over the music.`;
-}
-
-function buildMessages() {
+// Sterile baseline — 3 clean turns. Useful for measuring "best-case" model
+// behaviour without long-context distractions.
+function buildMessagesShort() {
   return [
     { role: 'user', content: '▶ "Sona" by Manni Sandhu & Bakshi Billa' },
     { role: 'assistant', content: 'Sona, flowing from Tegi Pannu — kept the after-hours register, different artist.' },
@@ -134,17 +117,34 @@ function buildMessages() {
   ];
 }
 
-async function runOnce(label) {
+// Realistic long context — exactly what session.windowMessages() produces in
+// live AFTER all the filters land (scenario / play / old-pick-event drop)
+// AND the leading-non-user shift. For a long-running session the agent
+// actually receives JUST the current pick event as a single user message —
+// older DJ reasons are kept in raw but coalesced into a leading assistant
+// turn that the shift then drops (Anthropic requires user-first messages).
+// This is what live picks see now; LONG ≈ SHORT after the fix lands.
+function buildMessagesLong() {
+  return [
+    {
+      role: 'user',
+      content: 'Now playing "Hanju" by Amrinder Gill (after "Long Way — Manni Sandhu"). Pick the track to play next. Stay silent — no link this time.',
+    },
+  ];
+}
+
+async function runOnce(label, messagesMode) {
   const { tools, seen } = buildSyntheticTools();
+  const messages = messagesMode === 'long' ? buildMessagesLong() : buildMessagesShort();
   const started = Date.now();
   let outcome = { label, ok: false, mode: 'unknown', ms: 0, toolCount: 0, outputTokens: null, pickId: null, reason: null };
   try {
     const result = await djAgent({
-      system: buildSystem(),
-      messages: buildMessages(),
+      system: pickSystem(),  // live prompt, imported from dj-agent.js
+      messages,
       tools,
       schema: PICK_SCHEMA,
-      maxSteps: 4,
+      maxSteps: 6,
       kind: 'pickerTest',
     });
     outcome.ms = Date.now() - started;
@@ -189,10 +189,12 @@ async function main() {
   const provider = process.argv[2];
   const model = process.argv[3];
   const N = parseInt(process.argv[4] || '5', 10);
+  const messagesMode = (process.argv[5] || 'short').toLowerCase();
 
-  if (!provider || !model) {
-    console.error('Usage: node scripts/picker-test.mjs <provider> <model> [iterations]');
+  if (!provider || !model || !['short', 'long'].includes(messagesMode)) {
+    console.error('Usage: node scripts/picker-test.mjs <provider> <model> [iterations] [short|long]');
     console.error('Providers: ollama | openrouter | deepseek | openai | anthropic | google | gateway | openai-compatible');
+    console.error('Messages:  short (3 clean turns) | long (~25 realistic session turns)');
     process.exit(2);
   }
 
@@ -204,11 +206,11 @@ async function main() {
   s.llm.provider = provider;
   s.llm.model = model;
 
-  console.log(`\n=== picker-test: ${provider}:${model} × ${N} ===\n`);
+  console.log(`\n=== picker-test: ${provider}:${model} × ${N} (messages=${messagesMode}) ===\n`);
 
   const outcomes = [];
   for (let i = 1; i <= N; i++) {
-    const o = await runOnce(`run-${i}`);
+    const o = await runOnce(`run-${i}`, messagesMode);
     outcomes.push(o);
     const tag = o.ok ? 'OK ' : 'FAIL';
     const idShort = o.pickId ? `${o.pickId.slice(0, 12)}…` : '-';

--- a/controller/src/broadcast/dj-agent.js
+++ b/controller/src/broadcast/dj-agent.js
@@ -22,52 +22,38 @@ import { recordPick } from '../llm/log.js';
 import { withTrace } from '../observability/events.js';
 
 const PICK_SCHEMA = z.object({
-  id: z.string().describe('the exact song id, as returned by a tool call'),
-  reason: z.string().describe('one short internal sentence on why this track'),
-  say: z.string().nullable().describe('a spoken link in the DJ voice, or null to stay silent'),
+  id: z.string().describe('the exact song id returned by one of the discovery tools — never invent or compose ids'),
+  reason: z.string().describe('internal scratchpad only — max 12 words, never shown to the listener; do not justify, just label (e.g. "flow from previous, new artist")'),
+  say: z.string().nullable().describe('when the latest event message says to write a spoken link, set this to one or two natural sentences in the DJ voice (back-announce what just played, ease into what is coming, vary your opener); when the event says stay silent, set this to null'),
 });
 
 const REQUEST_SCHEMA = z.object({
-  id: z.string().describe('the exact song id, as returned by a tool call'),
-  ack: z.string().describe('short on-air acknowledgement, max 20 words'),
-  intro: z.string().describe('a natural DJ intro for the track, in the DJ voice'),
+  id: z.string().describe('the exact song id returned by one of the discovery tools — never invent or compose ids'),
+  ack: z.string().describe('short on-air acknowledgement of the listener, in character — max 20 words; no "thank you for listening" or self-intros'),
+  intro: z.string().describe('a natural DJ intro for the track in the DJ voice; weave in what the listener asked for without reading the request back verbatim'),
 });
 
-function persona() {
-  const p = settings.getEffectivePersona();
-  return {
-    name: p?.name || 'the DJ',
-    soul: p?.soul || '',
-  };
-}
+// Ultra-minimal — persona + editorial criteria, nothing else. The AI SDK
+// already conveys everything else through its own channels: tool descriptions
+// (llm/tools.js), the done-tool description (llm/sdk.js), schema field
+// descriptions (PICK_SCHEMA above), and the per-pick event message in the
+// session window ("Stay silent — no link this time." vs "Also write a short
+// link to speak over this track now."). Duplicating those in prompt text
+// competes with the framework's structural signals and derails smaller
+// models. PICKER_CRITERIA stays because it's editorial preference (flow,
+// context, variety, interest) — that's not in any tool or schema.
+function pickSystem() {
+  return `${settings.agentPersonaPreamble(settings.getEffectivePersona(), { rules: false })}
 
-function pickSystem(wantLink) {
-  const p = persona();
-  return `You are ${p.name}, the on-air DJ for SUB/WAVE, a personal internet radio station. ${p.soul}.
+You run the station as one continuous shift. The messages above are the live session.
 
-You run the station as one continuous shift. The messages above are the live session: tracks that have aired, things you have said, events as they happened. Read them so you do not repeat an artist back-to-back or reuse the same phrasing.
-
-TASK: choose the single best NEXT track. Use the tools to explore the library — make 2 to 4 tool calls, then choose ONE track whose id a tool actually returned. Do not invent ids.
-
-${dj.PICKER_CRITERIA}
-
-Respond with a JSON object only — no prose, no markdown:
-{ "id": "<exact id a tool returned>", "reason": "<one internal sentence>", "say": ${
-    wantLink
-      ? `"<a natural spoken link in your voice (${dj.lengthPhrase('link')}): ease on from what just played into what is coming, vary your opener>"`
-      : 'null'
-  } }
-${wantLink ? '' : 'Set "say" to null this time — do not talk over the music.'}`;
+${dj.PICKER_CRITERIA}`;
 }
 
 function requestSystem() {
-  const p = persona();
-  return `You are ${p.name}, the on-air DJ for SUB/WAVE, a personal internet radio station. ${p.soul}.
+  return `${settings.agentPersonaPreamble(settings.getEffectivePersona(), { rules: false })}
 
-The messages above are the live session. The last message is a listener request. Use the tools to find a track in the library that genuinely fits what they asked for, then choose ONE whose id a tool returned. Do not invent ids.
-
-Respond with a JSON object only — no prose, no markdown:
-{ "id": "<exact id a tool returned>", "ack": "<short on-air acknowledgement, max 20 words>", "intro": "<a natural intro (${dj.lengthPhrase('intro')}) that weaves in what the listener asked for without reading it back verbatim>" }`;
+The messages above are the live session — the last user turn is a listener request.`;
 }
 
 function trackFields(song) {
@@ -108,10 +94,11 @@ async function pickViaAgent(queue, { wantLink }) {
   const { tools, seen } = buildPickerTools({ recentIds, recentArtists });
 
   const { object, steps, toolCalls } = await djAgent({
-    system: pickSystem(wantLink),
+    system: pickSystem(),
     messages: session.windowMessages(),
     tools,
     schema: PICK_SCHEMA,
+    maxSteps: 6,
     kind: 'djAgentPick',
   });
 
@@ -138,9 +125,19 @@ async function pickViaPool(queue, ctx, { wantLink, previous, current }) {
     return;
   }
   await enqueuePick(queue, result.song, result.reason, result.source || 'pool');
+  // The reason text is concise on a successful pool pick and useful context for
+  // the next turn — but on a failed pool LLM (picker.js returns the sentinel
+  // 'fallback (LLM pick failed)'), recording it as the DJ's session turn primes
+  // the next agent run with "you failed before", which derails models that read
+  // the window. Substitute a neutral phrasing in that case so the conversation
+  // still alternates (avoiding user-message coalescing) without the defeatist
+  // signal.
+  const sessionText = (result.reason && result.reason !== 'fallback (LLM pick failed)')
+    ? result.reason
+    : `Selected "${result.song.title}".`;
   session.appendTurn({
     role: 'dj', kind: 'pick',
-    text: result.reason || `Selected "${result.song.title}".`,
+    text: sessionText,
     meta: { trackId: result.song.id, title: result.song.title, artist: result.song.artist },
   });
   if (wantLink && previous) {
@@ -205,6 +202,7 @@ export async function runRequest(queue, ctx, { requester, text }) {
       messages: session.windowMessages(),
       tools,
       schema: REQUEST_SCHEMA,
+      maxSteps: 6,
       kind: 'djAgentRequest',
     });
 

--- a/controller/src/broadcast/dj-agent.js
+++ b/controller/src/broadcast/dj-agent.js
@@ -21,7 +21,7 @@ import { buildPickerTools } from '../llm/tools.js';
 import { recordPick } from '../llm/log.js';
 import { withTrace } from '../observability/events.js';
 
-const PICK_SCHEMA = z.object({
+export const PICK_SCHEMA = z.object({
   id: z.string().describe('the exact song id returned by one of the discovery tools — never invent or compose ids'),
   reason: z.string().describe('internal scratchpad only — max 12 words, never shown to the listener; do not justify, just label (e.g. "flow from previous, new artist")'),
   say: z.string().nullable().describe('when the latest event message says to write a spoken link, set this to one or two natural sentences in the DJ voice (back-announce what just played, ease into what is coming, vary your opener); when the event says stay silent, set this to null'),
@@ -42,7 +42,7 @@ const REQUEST_SCHEMA = z.object({
 // competes with the framework's structural signals and derails smaller
 // models. PICKER_CRITERIA stays because it's editorial preference (flow,
 // context, variety, interest) — that's not in any tool or schema.
-function pickSystem() {
+export function pickSystem() {
   return `${settings.agentPersonaPreamble(settings.getEffectivePersona(), { rules: false })}
 
 You run the station as one continuous shift. The messages above are the live session.

--- a/controller/src/broadcast/session.js
+++ b/controller/src/broadcast/session.js
@@ -169,6 +169,13 @@ export async function maybeRoll(ctx) {
 // mapped to AI SDK message roles. The full log stays on disk for the UI.
 // Consecutive same-role turns are coalesced because some providers (Anthropic)
 // require strictly alternating user/assistant messages.
+//
+// Scenario-kind events (controller restart notes, session boundaries) are
+// filtered OUT of the window — they're meta about our infra, not part of the
+// DJ's conversation, and they accumulate into user-role noise that derails
+// the picker agent (every controller restart leaves "Controller restarted —
+// session resumed" stuck in the window, eventually appearing 3-4 times in a
+// single coalesced user message).
 export function windowMessages() {
   if (!_session) return [];
   const raw = [];
@@ -177,6 +184,7 @@ export function windowMessages() {
   }
   for (const m of _session.messages.slice(-WINDOW_TURNS)) {
     if (!m.text) continue;
+    if (m.kind === 'scenario') continue;  // infra noise — not for the model
     const role = (m.role === 'dj' || m.role === 'segment') ? 'assistant' : 'user';
     raw.push({ role, content: m.text });
   }

--- a/controller/src/broadcast/session.js
+++ b/controller/src/broadcast/session.js
@@ -170,21 +170,48 @@ export async function maybeRoll(ctx) {
 // Consecutive same-role turns are coalesced because some providers (Anthropic)
 // require strictly alternating user/assistant messages.
 //
-// Scenario-kind events (controller restart notes, session boundaries) are
-// filtered OUT of the window — they're meta about our infra, not part of the
-// DJ's conversation, and they accumulate into user-role noise that derails
-// the picker agent (every controller restart leaves "Controller restarted —
-// session resumed" stuck in the window, eventually appearing 3-4 times in a
-// single coalesced user message).
+// Three turn kinds get filtered out of the window because they derail the
+// picker agent in long sessions:
+//
+// - `scenario` events (controller restart notes, session boundaries) — infra
+//   noise, not part of the DJ's conversation. Every restart leaves "Controller
+//   restarted — session resumed" in the window, eventually appearing 3-4
+//   times in a single coalesced user message.
+//
+// - `kind: 'play'` track turns ("▶ Title — Artist") — redundant. Every pick
+//   event already contains the current AND previous track ("Now playing X.
+//   Pick the next track (after Y)..."), and the picker can't choose recent
+//   artists anyway because they're filtered at the tool layer (recentArtists
+//   in buildPickerTools).
+//
+// - OLD `kind: 'pick'` events (role='event') — the "Now playing X. Pick the
+//   next track" user-side instruction is kept only for the LATEST pick.
+//   Previous ones were already answered and just add ambiguity ("which of
+//   these 11 'pick next' requests am I responding to?"). Without this filter,
+//   gemini's reliability drops from 5/5 short → 2-3/5 long in the
+//   picker-test.mjs LONG benchmark, with "No output generated" failures.
+//
+// The DJ's own reasons (role='dj' kind='pick') stay — those are the agent's
+// short memory of recent decisions, useful for variety.
 export function windowMessages() {
   if (!_session) return [];
   const raw = [];
   if (_session.handoff) {
     raw.push({ role: 'user', content: `[Continuing on air from ${_session.handoff}]` });
   }
-  for (const m of _session.messages.slice(-WINDOW_TURNS)) {
+  const recent = _session.messages.slice(-WINDOW_TURNS);
+  // Find the index of the most-recent pick-event user message — older ones
+  // are filtered, this one is the current ask we want the agent to respond to.
+  let lastPickEventIdx = -1;
+  for (let i = recent.length - 1; i >= 0; i--) {
+    if (recent[i].role === 'event' && recent[i].kind === 'pick') { lastPickEventIdx = i; break; }
+  }
+  for (let i = 0; i < recent.length; i++) {
+    const m = recent[i];
     if (!m.text) continue;
-    if (m.kind === 'scenario') continue;  // infra noise — not for the model
+    if (m.kind === 'scenario') continue;  // infra noise
+    if (m.kind === 'play') continue;       // redundant — current track is in the pick event
+    if (m.role === 'event' && m.kind === 'pick' && i !== lastPickEventIdx) continue;  // old pick asks
     const role = (m.role === 'dj' || m.role === 'segment') ? 'assistant' : 'user';
     raw.push({ role, content: m.text });
   }

--- a/controller/src/llm/dj.js
+++ b/controller/src/llm/dj.js
@@ -9,10 +9,12 @@
 import { z } from 'zod';
 import * as settings from '../settings.js';
 import { djText, djObject } from './sdk.js';
-import { recentCalls, record } from './log.js';
+import { recentCalls } from './log.js';
 
-// Re-exported so server.js /debug can read the recent-call ring buffer.
-export { recentCalls, record };
+// Re-exported so routes/debug.js can read the LLM call ring buffer through the
+// same module that produces the calls. record() is internal — sdk.js writes,
+// nothing else should.
+export { recentCalls };
 
 // Resolve the DJ system prompt for the persona on air right now. The effective
 // persona is the current show's owner if a show is scheduled for this hour,
@@ -33,7 +35,6 @@ const LENGTH_PHRASES = {
   concise: {
     intro:     'Keep it brief — 2 to 4 sentences.',
     link:      '1-2 sentences',
-    weather:   '1-2 sentences',
     stationId: 'a 1-sentence station ident',
     hourly:    '1 sentence',
     adlib:     '1-2 sentences',
@@ -42,7 +43,6 @@ const LENGTH_PHRASES = {
   extended: {
     intro:     'Take your time — 5 to 8 sentences. Set a scene, tell a small story around the track.',
     link:      '4-6 sentences',
-    weather:   '3-4 sentences',
     stationId: 'a 2-3 sentence station ident',
     hourly:    '2-3 sentences',
     adlib:     '4-6 sentences',
@@ -62,8 +62,11 @@ export function lengthPhrase(kind, persona) {
 
 // Narrative angles per call type. One is picked at random and injected into
 // the user prompt as "Tone for this segment:" so consecutive generations
-// don't fall back to the same shape. Add freely — the more variety here,
-// the less the DJ repeats itself.
+// don't fall back to the same shape. Only the generate* callers in this file
+// consume these — the segment director (skills/_agent.js) gets its variety
+// from its CAPABILITIES descriptions and from picking a different capability
+// each tick, so it doesn't go through pickAngle. Add freely — the more
+// variety here, the less the DJ repeats itself.
 export const ANGLES = {
   intro: [
     'Open with one specific image from right now (weather, time, day, season) and slide into the track.',
@@ -90,47 +93,12 @@ export const ANGLES = {
     'Open with the time or weather, then drop the station name in the middle of the sentence.',
     'A single observation about broadcasting from a homelab, with the station name woven in.',
   ],
-  weather: [
-    'One concrete sensory detail about the weather, no temperature recital.',
-    'Compare it to what it was earlier, or what it might be tonight — give it a small arc.',
-    'Tie the weather to a recommendation about how to spend the next hour.',
-    'Skip the forecast voice — just say what it actually feels like outside right now.',
-    'Acknowledge weather as a co-conspirator with the music, not as a news item.',
-  ],
   hourly: [
     'State the time as a small fact, then anchor it with one observation about the day.',
     'Treat the hour mark like a quiet check-in, not a bulletin.',
     'Open with where in the day we are (mid-afternoon lull, evening getting started, etc.) before the actual time.',
     'Just one short sentence that happens to mention the time.',
     'Acknowledge what kind of listener might be tuning in at this exact hour, without naming them.',
-  ],
-  news: [
-    'Read it like a half-distracted DJ skimming the wire, not a news anchor.',
-    'Land one specific image or phrase from the headline, skip the editorial.',
-    'Treat it as something you just noticed on a second screen, then slide back to music.',
-    'Keep it one sentence. The next sentence is the song.',
-    'Acknowledge the world outside the room without dwelling on it.',
-  ],
-  traffic: [
-    'Tongue-in-cheek traffic for a station that has none — invent a SUB/WAVE-shaped obstacle (a cat on the cable, slow buffering on the M6, a queue at the kettle).',
-    'Mock the format of a real traffic report. Keep it a single sentence.',
-    'Make the "delay" tiny and domestic, not a real road incident.',
-    'Treat traffic as a metaphor for the listening room itself.',
-    'Land one absurd detail, then ease into the next track.',
-  ],
-  random_facts: [
-    'One small "did you know" — concrete, oddly specific, no Wikipedia rote.',
-    'Frame the fact like something you half-remember telling a friend at 1am.',
-    'Tie the fact to the time of day or season if it lands naturally; otherwise drop it cold.',
-    'Keep it one sentence. Avoid the words "interestingly" and "fun fact".',
-    'A fact that earns the next song, not one that competes with it.',
-  ],
-  web_search: [
-    'Drop one current detail about the artist like a half-remembered thing you read, then back to the music.',
-    'Treat it as news from the wider world about who is on air — light, never a press release.',
-    'Land one specific, recent fact; skip the context and skip the source.',
-    'Keep it one sentence. The detail should make the next play feel timely.',
-    'Mention what the artist has been up to lately as if the listener might not have heard.',
   ],
 };
 
@@ -144,8 +112,9 @@ export function randomSeed() {
   return Math.floor(Math.random() * 1_000_000_000);
 }
 
-// Build the shared "right now" context block fed to every generate* call.
-// Pulled out so all five DJ functions show the model the same picture.
+// Build the shared "right now" context block. Used by every generate* function
+// in this file, by matchRequest, and by the segment director (skills/_agent.js)
+// — so they all show the model the same picture of the current moment.
 export function buildContextLines(context, { recentTracks } = {}) {
   const lines = [];
   if (context?.date) {
@@ -312,18 +281,6 @@ export async function generateIntro({ track, context, requestedBy = null, reques
   });
 }
 
-export async function generateWeatherSegment(weather, time, { recap = null, context = null, recentOpeners = null } = {}) {
-  const ctx = context || { weather, time };
-  const ctxLines = buildContextLines(ctx);
-  ctxLines.push(`Task: a brief weather check, in character. ${lengthPhrase('weather')}.`);
-  return djText({
-    system: djSystem(),
-    prompt: decoratePrompt(ctxLines.join('\n'), { kind: 'weather', recap, recentOpeners }),
-    temperature: 0.9, topP: 0.95, repeatPenalty: 1.15, seed: randomSeed(),
-    kind: 'generateWeatherSegment',
-  });
-}
-
 export async function generateStationId({ recap = null, context = null, recentOpeners = null } = {}) {
   const djName = settings.getEffectivePersona()?.name || 'your host';
   const ctxLines = buildContextLines(context);
@@ -383,8 +340,8 @@ export async function generateHourlyTime(time, weather, { recap = null, context 
 // ---------------------------------------------------------------------------
 
 // Shared selection criteria — used by both the pool picker (PICKER_SYSTEM
-// below) and the agent picker (AGENT_INSTRUCTIONS in music/picker.js) so the
-// two strategies can't drift apart.
+// below) and the conversational agent picker (pickSystem in broadcast/
+// dj-agent.js) so the two strategies can't drift apart on selection rules.
 export const PICKER_CRITERIA = `Selection criteria, in order:
 1. FLOW — does it transition naturally from what just played (energy, mood, tempo)?
 2. CONTEXT — does it fit the time of day, weather, and dominant mood?

--- a/controller/src/llm/dj.js
+++ b/controller/src/llm/dj.js
@@ -168,17 +168,6 @@ export function decoratePrompt(prompt, { kind, recap, recentOpeners }) {
 
 const REQUEST_SYSTEM = `You are the music librarian for a personal Navidrome library that runs an AI radio station. A listener sends a request; you turn it into structured search parameters.
 
-Fill in every field. Use null where a value does not apply — never omit a field.
-
-- search_terms: 1-3 strings to look up in the library — ARTIST NAMES or SONG TITLES only. NEVER genres, and NEVER mood/vibe words like "calm", "rainy", "overcast". Genres go in "genre"; vibes go in "mood".
-- artist: the artist's common name if the listener named one (e.g. "Diljit Dosanjh"), else null.
-- genre: a real music genre if the listener asked for one (e.g. "punjabi", "hip hop", "jazz", "lofi", "rock", "bhangra"), else null. A genre is a kind of music — not a mood and not a feeling.
-- sort: "latest" for latest/new/newest/recent, "oldest" for old/classic, "popular" for popular/best/top, else null.
-- scope: "album" or "song" — what the listener wants. Default "song".
-- mood: one of energetic|calm|reflective|celebratory|romantic|spiritual|focus|workout|driving|cooking|rainy|sunny|night|morning|evening|festival|cultural — or null. ALWAYS set this for vibe/feeling requests ("overcast mood" → calm or reflective, "cosy" → calm, "pumped up" → energetic, "late night drive" → night — pick the strongest single match).
-- intent: one short sentence describing what the listener wants.
-- ack: short on-air acknowledgment the DJ reads aloud, max 20 words, sounds like a real radio DJ — no "thank you for listening" or self-intros.
-
 Vibe-to-mood mapping (use these when the request describes a feeling, weather, or moment rather than naming an artist/song):
 - overcast, cloudy, grey day, drizzly → calm or reflective
 - rainy day, downpour → rainy + calm
@@ -222,19 +211,21 @@ Worked examples (these show how the fields map — values only; the response for
 "play <title> by <artist>"
 {"search_terms":["<title>","<artist>"],"artist":"<artist>","genre":null,"sort":null,"scope":"song","mood":null,"intent":"Wants a specific song by a specific artist.","ack":"Coming right up."}`;
 
-// Lenient schema — it enforces the SHAPE; the system prompt enforces the
-// SEMANTICS. `mood`/`sort` stay free strings (not enums) so a near-miss from a
-// weaker model doesn't 500 a listener request — server.js tolerates unknown
-// moods by falling through to its other pick sources.
+// Lenient schema — it enforces the SHAPE; the prompt + per-field .describe()
+// strings carry the SEMANTICS. `mood`/`sort` stay free strings (not enums) so a
+// near-miss from a weaker model doesn't 500 a listener request — server.js
+// tolerates unknown moods by falling through to its other pick sources. The AI
+// SDK feeds these descriptions to the model alongside the schema, so they don't
+// need to be restated in REQUEST_SYSTEM.
 const REQUEST_SCHEMA = z.object({
-  search_terms: z.array(z.string()),
-  artist: z.string().nullable(),
-  genre: z.string().nullable(),
-  sort: z.string().nullable(),
-  scope: z.enum(['album', 'song']),
-  mood: z.string().nullable(),
-  intent: z.string(),
-  ack: z.string(),
+  search_terms: z.array(z.string()).describe('1-3 strings to look up in the library — ARTIST NAMES or SONG TITLES only. NEVER genres, and NEVER mood/vibe words like "calm", "rainy", "overcast". Genres go in "genre"; vibes go in "mood".'),
+  artist: z.string().nullable().describe(`the artist's common name if the listener named one (e.g. "Diljit Dosanjh"), else null`),
+  genre: z.string().nullable().describe('a real music genre if the listener asked for one (e.g. "punjabi", "hip hop", "jazz", "lofi", "rock", "bhangra"), else null. A genre is a kind of music — not a mood and not a feeling.'),
+  sort: z.string().nullable().describe('"latest" for latest/new/newest/recent, "oldest" for old/classic, "popular" for popular/best/top, else null'),
+  scope: z.enum(['album', 'song']).describe('what the listener wants; default "song"'),
+  mood: z.string().nullable().describe('one of energetic|calm|reflective|celebratory|romantic|spiritual|focus|workout|driving|cooking|rainy|sunny|night|morning|evening|festival|cultural — or null. ALWAYS set this for vibe/feeling requests ("overcast mood" → calm or reflective, "cosy" → calm, "pumped up" → energetic, "late night drive" → night — pick the strongest single match).'),
+  intent: z.string().describe('one short sentence describing what the listener wants'),
+  ack: z.string().describe(`short on-air acknowledgment the DJ reads aloud, max 20 words, sounds like a real radio DJ — no "thank you for listening" or self-intros`),
 });
 
 export async function matchRequest(userQuery, { listenerName = null, nowPlaying = null } = {}) {
@@ -364,14 +355,7 @@ Use it to balance familiarity against discovery.
 recentPlays is context for judging flow — every candidate is already guaranteed
 unplayed, so you never need to reject one for being recent.
 
-Pick exactly one candidate. Respond with a JSON object only — no prose, no
-markdown, no reasoning outside the object:
-{ "id": "<exact id from a candidate>", "reason": "<one short sentence on why this one>" }`;
-
-const PICK_SCHEMA = z.object({
-  id: z.string(),
-  reason: z.string(),
-});
+Pick exactly one candidate.`;
 
 export async function pickNextTrack({ candidates, recentPlays, context }) {
   const user = JSON.stringify({
@@ -389,7 +373,10 @@ export async function pickNextTrack({ candidates, recentPlays, context }) {
   return djObject({
     system: PICKER_SYSTEM,
     prompt: user,
-    schema: PICK_SCHEMA,
+    schema: z.object({
+      id: z.string().describe('the exact id of one candidate'),
+      reason: z.string().describe('one short sentence on why this one'),
+    }),
     temperature: 0.5,
     kind: 'pickNextTrack',
   });

--- a/controller/src/llm/provider.js
+++ b/controller/src/llm/provider.js
@@ -131,8 +131,18 @@ export function languageModel() {
     }
     case 'ollama':
     default: {
+      // CRITICAL: use `provider.chat(id)`, not `provider(id)`. The default
+      // callable returns the package's "responses" model (named after OpenAI's
+      // Responses API — identifies itself as "ollama.responses" in warnings),
+      // which doesn't properly translate tools/toolChoice/activeTools to
+      // Ollama's payload format. The result was every cloud :cloud model
+      // emitting prose instead of tool calls, regardless of which model.
+      // `.chat(id)` routes through the package's chat-completions path
+      // (`/api/chat`) where tool calls work natively. Verified against the
+      // raw Ollama API: `POST /api/chat` with tools returns a proper
+      // `tool_calls` field on these same cloud models.
       const provider = createOllama({ baseURL: `${ollamaBaseUrl(cfg)}/api` });
-      model = provider(id);
+      model = provider.chat(id);
       break;
     }
   }

--- a/controller/src/llm/sdk.js
+++ b/controller/src/llm/sdk.js
@@ -76,11 +76,94 @@ function needsToolCallObject() {
   return providerName() === 'ollama';
 }
 
+// True when repeat_penalty actually reaches the model. It's bundled inside
+// providerOptions.ollama, so only the Ollama provider reads it — every other
+// provider (openai-compatible, openai, anthropic, …) silently drops it. The
+// sampling log uses this to avoid claiming the value was applied when it
+// wasn't. If a future provider gains a real repetition-penalty channel, widen
+// this check and pipe the value through ollamaOptions's equivalent there.
+function repeatPenaltyApplies() {
+  return providerName() === 'ollama';
+}
+
+// Centralised success/failure record writers. Every LLM call goes through one
+// of each. The required-shape args (kind/started/via/sampling/usage for
+// success, kind/started/via/error for failure) are explicit so a new primitive
+// can't silently lack a field — the `usage: undefined` drift in the Ollama
+// tool-call branch was the kind of bug this prevents. Per-primitive payload
+// (system, messages, toolCalls, response, user, …) goes in `extra`.
+function recordSuccess({ kind, started, via, sampling, usage, extra = {} }) {
+  record({
+    kind,
+    ok: true,
+    ms: Date.now() - started,
+    model: activeModelLabel(),
+    via,
+    sampling,
+    usage,
+    t: new Date().toISOString(),
+    ...extra,
+  });
+}
+
+function recordFailure({ kind, started, via, error, extra = {} }) {
+  record({
+    kind,
+    ok: false,
+    ms: Date.now() - started,
+    model: activeModelLabel(),
+    via,
+    error,
+    t: new Date().toISOString(),
+    ...extra,
+  });
+}
+
+// Pull diagnostic info off an AI SDK structured-output error. When the model
+// emits something but the SDK can't parse it into the schema, the raw text
+// lives on err.text (and the original cause on err.cause). Without this, the
+// failure record only carries err.message — useless for "WHY didn't it parse?"
+// triage. Best-effort: every field is optional, missing ones are skipped.
+function failureDiagnostics(err) {
+  const out = {};
+  if (typeof err?.text === 'string') out.responseText = err.text;
+  if (err?.finishReason) out.finishReason = err.finishReason;
+  if (err?.usage) out.usage = usageOf({ usage: err.usage });
+  if (err?.cause?.message && err.cause.message !== err.message) {
+    out.causeMessage = err.cause.message;
+  }
+  // The agent loop's partial steps before the final-output failure — same
+  // shape as the success-path toolCalls flatten.
+  const steps = err?.response?.steps || err?.steps;
+  if (Array.isArray(steps) && steps.length) {
+    out.toolCalls = steps.flatMap((s) => {
+      const results = s.toolResults || [];
+      return (s.toolCalls || []).map((c, i) => ({
+        name: c.toolName,
+        args: c.input ?? c.args ?? null,
+        result: results[i]?.output ?? results[i]?.result ?? null,
+      }));
+    });
+    out.steps = steps.length;
+  }
+  return out;
+}
+
+// Tee a one-line preview of the failed model output to the console so failures
+// are visible in `docker logs` without grepping /debug JSON. Truncated to avoid
+// dumping multi-kilobyte reasoning blocks into the terminal.
+function logFailurePreview(kind, err) {
+  if (typeof err?.text !== 'string' || !err.text.trim()) return;
+  const preview = err.text.replace(/\s+/g, ' ').trim().slice(0, 240);
+  console.log(`[${kind}] raw model output (truncated): ${preview}`);
+}
+
 // Structured output via a forced tool call. The result schema is presented as
 // an `emit` tool the model MUST call (toolChoice:'required'); we capture and
 // Zod-validate its input. This is the reliable structured-output path for
 // models that ignore JSON mode but handle tool calls fine. Single step — the
-// model's only legal move is to call `emit` once.
+// model's only legal move is to call `emit` once. Returns the validated object
+// plus a token-usage block so callers can log it alongside the other branches.
 async function objectViaToolCall({ system, prompt, messages, schema, temperature, maxOutputTokens }) {
   let captured;
   const emit = tool({
@@ -88,7 +171,7 @@ async function objectViaToolCall({ system, prompt, messages, schema, temperature
     inputSchema: schema,
     execute: async (input) => { captured = input; return 'received'; },
   });
-  await generateText({
+  const result = await generateText({
     model: languageModel(),
     system,
     ...(messages ? { messages } : { prompt }),
@@ -100,7 +183,7 @@ async function objectViaToolCall({ system, prompt, messages, schema, temperature
     providerOptions: ollamaOptions(null),
   });
   if (captured === undefined) throw new Error('model never called the emit tool');
-  return schema.parse(captured);
+  return { object: schema.parse(captured), usage: usageOf(result) };
 }
 
 // Free-text DJ generation.
@@ -127,24 +210,24 @@ export async function djText({
       providerOptions: ollamaOptions(repeatPenalty),
     });
     const out = stripThinking(result.text);
-    record({
-      kind, ok: true, ms: Date.now() - started,
-      model: activeModelLabel(),
-      sampling: { temperature, top_p: topP, repeat_penalty: repeatPenalty, seed },
-      via: 'ai-sdk',
+    // Only record sampling knobs that actually reached the model — see
+    // repeatPenaltyApplies() and providerOptions handling above.
+    const sampling = { temperature, top_p: topP, seed };
+    if (repeatPenaltyApplies()) sampling.repeat_penalty = repeatPenalty;
+    recordSuccess({
+      kind, started, via: 'ai-sdk',
+      sampling,
       usage: usageOf(result),
       // Full, untruncated — the /debug surface shows the whole system prompt.
-      system,
-      user: prompt,
-      response: out,
-      t: new Date().toISOString(),
+      extra: { system, user: prompt, response: out },
     });
     return out;
   } catch (err) {
-    record({
-      kind, ok: false, ms: Date.now() - started,
-      model: activeModelLabel(), via: 'ai-sdk',
-      user: prompt, error: err.message, t: new Date().toISOString(),
+    logFailurePreview(kind, err);
+    recordFailure({
+      kind, started, via: 'ai-sdk',
+      error: err.message,
+      extra: { user: prompt, ...failureDiagnostics(err) },
     });
     throw err;
   }
@@ -173,13 +256,19 @@ export async function djObject({
 }) {
   const started = Date.now();
   let lastErr;
+  // Track the strategy actually attempted so a failure record attributes to
+  // the right sub-path — bucketing every failure as 'ai-sdk' hides which
+  // structured-output branch is breaking in /stats.
+  let lastVia;
   for (let attempt = 1; attempt <= 2; attempt++) {
     try {
       let object;
       let usage;
       if (attempt === 1 && needsToolCallObject()) {
-        object = await objectViaToolCall({ system, prompt, schema, temperature, maxOutputTokens });
+        lastVia = 'ai-sdk:tool';
+        ({ object, usage } = await objectViaToolCall({ system, prompt, schema, temperature, maxOutputTokens }));
       } else if (attempt === 1) {
+        lastVia = 'ai-sdk';
         const result = await generateText({
           model: languageModel(),
           system,
@@ -192,6 +281,7 @@ export async function djObject({
         object = result.output;
         usage = usageOf(result);
       } else {
+        lastVia = 'ai-sdk:recovery';
         const result = await generateText({
           model: languageModel(),
           system,
@@ -203,27 +293,23 @@ export async function djObject({
         object = schema.parse(JSON.parse(extractJson(stripThinking(result.text))));
         usage = usageOf(result);
       }
-      record({
-        kind, ok: true, ms: Date.now() - started,
-        model: activeModelLabel(),
+      recordSuccess({
+        kind, started, via: lastVia,
         sampling: { temperature },
-        via: attempt === 2 ? 'ai-sdk:recovery' : (needsToolCallObject() ? 'ai-sdk:tool' : 'ai-sdk'),
         usage,
         // Full, untruncated — the /debug surface shows the whole system prompt.
-        system,
-        user: prompt,
-        response: JSON.stringify(object).slice(0, 500),
-        t: new Date().toISOString(),
+        extra: { system, user: prompt, response: JSON.stringify(object).slice(0, 500) },
       });
       return object;
     } catch (err) {
       lastErr = err;
     }
   }
-  record({
-    kind, ok: false, ms: Date.now() - started,
-    model: activeModelLabel(), via: 'ai-sdk',
-    user: prompt, error: lastErr.message, t: new Date().toISOString(),
+  logFailurePreview(kind, lastErr);
+  recordFailure({
+    kind, started, via: lastVia,
+    error: lastErr.message,
+    extra: { user: prompt, ...failureDiagnostics(lastErr) },
   });
   throw lastErr;
 }
@@ -234,6 +320,18 @@ export async function djObject({
 // chat window) instead of a single prompt, and returns a schema-validated
 // final object. Throws on failure so the caller can fall back to a stateless
 // path.
+//
+// When a `schema` is provided we use the AI SDK's canonical "done tool" pattern
+// instead of Output.object: a synthetic `done` tool whose inputSchema IS the
+// schema is added alongside the discovery tools, and `toolChoice: 'required'`
+// forces the model to call tools at every step. The agent calls discovery
+// tools to explore, then calls `done(<final answer>)` to terminate — the SDK
+// validates the call's args against the schema and stops the loop (because
+// `done` has no `execute`). This works reliably on Ollama-served models that
+// ignore Output.object's constrained-decoding (their failure mode was emitting
+// bare prose / a bare string / top-level null instead of the wrapping object;
+// see /app/node_modules/ai/docs/03-agents/04-loop-control.mdx "Forced Tool
+// Calling"). It's also compatible with OpenAI / Anthropic / etc.
 export async function djAgent({
   system,
   messages,
@@ -245,73 +343,109 @@ export async function djAgent({
   kind = 'sdk.djAgent',
 }) {
   const started = Date.now();
+  // Default to the agent path; the fast-path branch overrides before its await.
+  // A failure record always attributes to the path actually attempted.
+  let lastVia = 'ai-sdk:agent';
   try {
     // No discovery tools + an Ollama model that ignores JSON mode: there is no
     // loop to run, and ToolLoopAgent + Output.object would throw
     // NoObjectGeneratedError. Get the structured result from a forced tool call.
     const toolCount = tools ? Object.keys(tools).length : 0;
     if (schema && toolCount === 0 && needsToolCallObject()) {
-      const object = await objectViaToolCall({ system, messages, schema, temperature, maxOutputTokens });
-      record({
-        kind, ok: true, ms: Date.now() - started,
-        model: activeModelLabel(),
+      lastVia = 'ai-sdk:tool';
+      const { object, usage } = await objectViaToolCall({ system, messages, schema, temperature, maxOutputTokens });
+      recordSuccess({
+        kind, started, via: lastVia,
         sampling: { temperature },
-        via: 'ai-sdk:tool',
-        system,
-        messages,
-        toolCalls: [],
-        steps: 0,
-        response: JSON.stringify(object, null, 2),
-        t: new Date().toISOString(),
+        usage,
+        extra: { system, messages, toolCalls: [], steps: 0, response: JSON.stringify(object, null, 2) },
       });
       return { object, steps: 0, toolCalls: [] };
     }
+    // Build the tool set with the synthetic `done` tool when schema is set.
+    // `done` carries the schema as its inputSchema, has no `execute`, and the
+    // SDK validates+stops the loop when the model calls it.
+    const useDoneTool = schema != null;
+    const allTools = useDoneTool ? {
+      ...tools,
+      done: tool({
+        description: 'Call this exactly once when you have your final answer. Pass the answer as input. Calling this tool IS how you respond — do not emit text after.',
+        inputSchema: schema,
+      }),
+    } : tools;
+
+    // When schema is set and we have discovery tools, force the first step to
+    // be a discovery tool call — never `done`. This prevents the failure mode
+    // where the model calls `done` with a hallucinated id without exploring
+    // the library (observed on minimax-m2.7:cloud: model emitted a UUID-shaped
+    // string that wasn't in any tool's results). Cloud Ollama models often
+    // ignore plain `toolChoice: 'required'` too, but activeTools is enforced
+    // at the request level — they can't see `done` until step 1, so they
+    // can't call it.
+    const discoveryToolNames = tools ? Object.keys(tools) : [];
+    const useGatedDiscovery = useDoneTool && discoveryToolNames.length > 0;
+    const prepareStep = useGatedDiscovery
+      ? async ({ stepNumber }) => {
+          if (stepNumber === 0) {
+            return { activeTools: discoveryToolNames, toolChoice: 'required' };
+          }
+          return {};
+        }
+      : undefined;
+
     const agent = new ToolLoopAgent({
       model: languageModel(),
       instructions: system,
-      tools,
+      tools: allTools,
       stopWhen: stepCountIs(maxSteps),
       temperature,
       maxOutputTokens,
-      ...(schema ? { output: Output.object({ schema }) } : {}),
+      ...(useDoneTool ? { toolChoice: 'required' } : {}),
+      ...(prepareStep ? { prepareStep } : {}),
     });
     const result = await agent.generate({ messages });
     const steps = result.steps?.length ?? 0;
-    const object = schema ? result.output : stripThinking(result.text);
-    // Flatten the tool-loop into an ordered trail of {name, args, result} so
-    // the /debug surface shows exactly which library tools the agent called.
+
+    let object;
+    if (useDoneTool) {
+      // staticToolCalls carries tool calls from the FINAL step — the SDK
+      // surfaces calls that weren't executed (like our no-execute `done`) here.
+      const doneCall = (result.staticToolCalls || []).find(c => c.toolName === 'done');
+      if (!doneCall) throw new Error('agent did not call the done tool before stopping');
+      object = doneCall.input;
+    } else {
+      object = stripThinking(result.text);
+    }
+
+    // Flatten the discovery-tool trail for /debug. Exclude `done` — it's the
+    // schema-emit signal, not a real library discovery action.
     const toolCalls = (result.steps || []).flatMap((s) => {
       const results = s.toolResults || [];
-      return (s.toolCalls || []).map((c, i) => ({
-        name: c.toolName,
-        args: c.input ?? c.args ?? null,
-        result: results[i]?.output ?? results[i]?.result ?? null,
-      }));
+      return (s.toolCalls || [])
+        .filter(c => c.toolName !== 'done')
+        .map((c, i) => ({
+          name: c.toolName,
+          args: c.input ?? c.args ?? null,
+          result: results[i]?.output ?? results[i]?.result ?? null,
+        }));
     });
-    record({
-      kind, ok: true, ms: Date.now() - started,
-      model: activeModelLabel(),
+    recordSuccess({
+      kind, started, via: lastVia,
       sampling: { temperature },
-      via: 'ai-sdk:agent',
       usage: usageOf(result),
       // Full, untruncated — the agent's entire input and trail.
-      system,
-      messages,
-      toolCalls,
-      steps,
-      response: schema
-        ? JSON.stringify(object, null, 2)
-        : String(object ?? ''),
-      t: new Date().toISOString(),
+      extra: {
+        system, messages, toolCalls, steps,
+        response: schema ? JSON.stringify(object, null, 2) : String(object ?? ''),
+      },
     });
     return { object, steps, toolCalls };
   } catch (err) {
-    record({
-      kind, ok: false, ms: Date.now() - started,
-      model: activeModelLabel(), via: 'ai-sdk:agent',
-      system,
-      messages,
-      error: err.message, t: new Date().toISOString(),
+    logFailurePreview(kind, err);
+    recordFailure({
+      kind, started, via: lastVia,
+      error: err.message,
+      extra: { system, messages, ...failureDiagnostics(err) },
     });
     throw err;
   }

--- a/controller/src/llm/sdk.js
+++ b/controller/src/llm/sdk.js
@@ -321,17 +321,30 @@ export async function djObject({
 // final object. Throws on failure so the caller can fall back to a stateless
 // path.
 //
-// When a `schema` is provided we use the AI SDK's canonical "done tool" pattern
-// instead of Output.object: a synthetic `done` tool whose inputSchema IS the
-// schema is added alongside the discovery tools, and `toolChoice: 'required'`
-// forces the model to call tools at every step. The agent calls discovery
-// tools to explore, then calls `done(<final answer>)` to terminate — the SDK
-// validates the call's args against the schema and stops the loop (because
-// `done` has no `execute`). This works reliably on Ollama-served models that
-// ignore Output.object's constrained-decoding (their failure mode was emitting
-// bare prose / a bare string / top-level null instead of the wrapping object;
-// see /app/node_modules/ai/docs/03-agents/04-loop-control.mdx "Forced Tool
-// Calling"). It's also compatible with OpenAI / Anthropic / etc.
+// When a `schema` is provided the structured-output strategy is chosen per
+// provider, gated by needsToolCallObject():
+//
+// - Ollama: use the AI SDK's "done tool" pattern (see
+//   /app/node_modules/ai/docs/03-agents/04-loop-control.mdx "Forced Tool
+//   Calling"). A synthetic `done` tool whose inputSchema IS the schema is
+//   added alongside the discovery tools, and `toolChoice: 'required'` forces
+//   the model to call tools every step. The model calls discovery tools to
+//   explore, then calls `done(<final answer>)` to terminate. Required because
+//   Ollama's Output.object path is broken — minimax-m2.7:cloud emits prose,
+//   takes 40-100s per failure (verified empirically).
+//
+// - Everything else (Google, DeepSeek, OpenRouter, OpenAI, Anthropic):
+//   use Output.object natively. These providers honour constrained decoding,
+//   so we don't need the done-tool workaround — and avoiding it removes the
+//   intrinsic "agent did not call done before stopping" failure mode that
+//   the done-tool pattern introduces when the model over-explores.
+//
+// Empirical reliability across 5-10 runs each (with picker-test.mjs):
+//   ollama:minimax-m2.7:cloud    done-tool 10/10  Output.object 0/5
+//   ollama:kimi-k2.6:cloud       done-tool  1/10  Output.object 0/5 (bad model fit)
+//   google:gemini-3.5-flash      Output.object 5/5
+//   deepseek:deepseek-chat       Output.object 5/5
+//   openrouter:anthropic/claude-haiku-4-5  Output.object 5/5
 export async function djAgent({
   system,
   messages,
@@ -362,10 +375,9 @@ export async function djAgent({
       });
       return { object, steps: 0, toolCalls: [] };
     }
-    // Build the tool set with the synthetic `done` tool when schema is set.
-    // `done` carries the schema as its inputSchema, has no `execute`, and the
-    // SDK validates+stops the loop when the model calls it.
-    const useDoneTool = schema != null;
+    // done-tool path on Ollama; native Output.object on everything else. See
+    // the header comment above for the per-provider rationale.
+    const useDoneTool = schema != null && needsToolCallObject();
     const allTools = useDoneTool ? {
       ...tools,
       done: tool({
@@ -402,6 +414,9 @@ export async function djAgent({
       maxOutputTokens,
       ...(useDoneTool ? { toolChoice: 'required' } : {}),
       ...(prepareStep ? { prepareStep } : {}),
+      // Non-Ollama path: native structured-output via Output.object. Ollama
+      // path: schema lives on the `done` tool, so no agent-level output.
+      ...(schema && !useDoneTool ? { output: Output.object({ schema }) } : {}),
     });
     const result = await agent.generate({ messages });
     const steps = result.steps?.length ?? 0;
@@ -413,6 +428,8 @@ export async function djAgent({
       const doneCall = (result.staticToolCalls || []).find(c => c.toolName === 'done');
       if (!doneCall) throw new Error('agent did not call the done tool before stopping');
       object = doneCall.input;
+    } else if (schema) {
+      object = result.output;
     } else {
       object = stripThinking(result.text);
     }

--- a/controller/src/llm/sdk.js
+++ b/controller/src/llm/sdk.js
@@ -17,9 +17,17 @@ import * as settings from '../settings.js';
 // inference slot for minutes. These are generous backstops for normal output
 // (idents are ~150 tokens, structured picks ~250); raise them if you turn
 // `llm.reasoning` on and need room for the chain-of-thought.
-const MAX_TOKENS_TEXT   = 800;
-const MAX_TOKENS_OBJECT = 1000;
-const MAX_TOKENS_AGENT  = 1200;
+//
+// The agent / object caps are higher than they look like they need because
+// some cloud "reasoning by default" models (Gemini 3.x, Claude with extended
+// thinking, GPT o-series) burn output budget on internal thinking before
+// they ever emit the answer. providerOpts() below tries to suppress thinking
+// when `llm.reasoning` is off, but provider coverage isn't complete — so the
+// caps stay generous enough to survive a thinking model even when we can't
+// turn its thinking off.
+const MAX_TOKENS_TEXT   = 2000;
+const MAX_TOKENS_OBJECT = 4000;
+const MAX_TOKENS_AGENT  = 4000;
 
 // Some models (Qwen 3, DeepSeek R1, etc.) emit a <think>…</think> reasoning
 // block before the answer. Reasoning is suppressed at the provider layer when
@@ -57,14 +65,63 @@ function usageOf(result) {
   return { input, output, total };
 }
 
-// `repeat_penalty` is Ollama-specific and lives under providerOptions.ollama;
-// non-Ollama providers ignore the block entirely, so it's safe to always pass.
-function ollamaOptions(repeatPenalty) {
-  // `think` follows the llm.reasoning setting — false suppresses the
-  // <think> block on reasoning models served through Ollama.
-  const opts = { think: settings.get().llm?.reasoning === true };
-  if (repeatPenalty != null) opts.options = { repeat_penalty: repeatPenalty };
-  return { ollama: opts };
+// Per-provider option blocks for the AI SDK's `providerOptions` field. The
+// SDK only reads the block matching the active provider, so it's safe to
+// emit unused blocks — non-matching providers ignore them.
+//
+// This is the single chokepoint that translates the user-facing
+// `llm.reasoning` toggle (Settings UI → "Chain-of-thought") into each
+// provider's native thinking knob. Every provider has a different name and
+// shape for it; keeping the translation in one place is what lets the toggle
+// be honestly described as universal.
+//
+// - Ollama: `think: false` skips the <think> priming on Qwen3 / DeepSeek R1
+//   / reasoning-tuned local models. `repeat_penalty` rides here too.
+// - openai-compatible (Qwen3 via llama.cpp/vLLM/LM Studio): handled at the
+//   transport layer by noThinkFetch() in provider.js, not here — it injects
+//   chat_template_kwargs.enable_thinking into every request body.
+// - Google (Gemini): gemini-3.x → thinkingLevel:'minimal'; gemini-2.5 →
+//   thinkingBudget:0. Gemini thinks by default and silently chews the
+//   maxOutputTokens budget — observed empirically on 3.5-flash returning
+//   empty text on ~20% of picker calls before this was wired.
+// - Anthropic (Claude): extended thinking is OFF by default. When reasoning
+//   is on we opt in via `thinking: { type: 'adaptive' }`, which lets Claude
+//   auto-tune effort (newer claude-sonnet-4-6+ / opus-4-6+). When off we
+//   emit nothing — Claude's default is already what we want.
+// - OpenAI (o-series + gpt-5): these always reason; only effort is tunable.
+//   Map reasoning:false → 'minimal', reasoning:true → 'medium' (the SDK's
+//   documented default). Gated on the model id since reasoningEffort is a
+//   no-op or error on gpt-4 / gpt-3.5.
+// - DeepSeek / OpenRouter / Gateway: no first-class knob. DeepSeek picks
+//   reasoning by model variant (deepseek-reasoner vs -chat); OpenRouter and
+//   Gateway pass through to the underlying provider's defaults.
+function providerOpts({ repeatPenalty = null } = {}) {
+  const llm = settings.get().llm || {};
+  const reasoning = llm.reasoning === true;
+  const model = llm.model || '';
+  const opts = {};
+
+  const ollama = { think: reasoning };
+  if (repeatPenalty != null) ollama.options = { repeat_penalty: repeatPenalty };
+  opts.ollama = ollama;
+
+  if (!reasoning) {
+    if (/^gemini-3/i.test(model)) {
+      opts.google = { thinkingConfig: { thinkingLevel: 'minimal' } };
+    } else if (/^gemini-2\.5/i.test(model)) {
+      opts.google = { thinkingConfig: { thinkingBudget: 0 } };
+    }
+  }
+
+  if (reasoning && /^claude-/i.test(model)) {
+    opts.anthropic = { thinking: { type: 'adaptive' } };
+  }
+
+  if (/^(o\d|gpt-5)/i.test(model)) {
+    opts.openai = { reasoningEffort: reasoning ? 'medium' : 'minimal' };
+  }
+
+  return opts;
 }
 
 // True when the active provider needs the tool-call structured-output path.
@@ -81,7 +138,7 @@ function needsToolCallObject() {
 // provider (openai-compatible, openai, anthropic, …) silently drops it. The
 // sampling log uses this to avoid claiming the value was applied when it
 // wasn't. If a future provider gains a real repetition-penalty channel, widen
-// this check and pipe the value through ollamaOptions's equivalent there.
+// this check and pipe the value through providerOpts's equivalent there.
 function repeatPenaltyApplies() {
   return providerName() === 'ollama';
 }
@@ -180,7 +237,7 @@ async function objectViaToolCall({ system, prompt, messages, schema, temperature
     tools: { emit },
     toolChoice: 'required',
     stopWhen: stepCountIs(1),
-    providerOptions: ollamaOptions(null),
+    providerOptions: providerOpts(),
   });
   if (captured === undefined) throw new Error('model never called the emit tool');
   return { object: schema.parse(captured), usage: usageOf(result) };
@@ -207,7 +264,7 @@ export async function djText({
       topP,
       ...(seed != null ? { seed } : {}),
       maxOutputTokens,
-      providerOptions: ollamaOptions(repeatPenalty),
+      providerOptions: providerOpts({ repeatPenalty }),
     });
     const out = stripThinking(result.text);
     // Only record sampling knobs that actually reached the model — see
@@ -276,7 +333,7 @@ export async function djObject({
           temperature,
           maxOutputTokens,
           output: Output.object({ schema }),
-          providerOptions: ollamaOptions(null),
+          providerOptions: providerOpts(),
         });
         object = result.output;
         usage = usageOf(result);
@@ -288,7 +345,7 @@ export async function djObject({
           prompt: `${prompt}\n\nRespond with a single JSON object only — no prose, no markdown fences.`,
           temperature,
           maxOutputTokens,
-          providerOptions: ollamaOptions(null),
+          providerOptions: providerOpts(),
         });
         object = schema.parse(JSON.parse(extractJson(stripThinking(result.text))));
         usage = usageOf(result);
@@ -412,6 +469,7 @@ export async function djAgent({
       stopWhen: stepCountIs(maxSteps),
       temperature,
       maxOutputTokens,
+      providerOptions: providerOpts(),
       ...(useDoneTool ? { toolChoice: 'required' } : {}),
       ...(prepareStep ? { prepareStep } : {}),
       // Non-Ollama path: native structured-output via Output.object. Ollama

--- a/controller/src/llm/tools.js
+++ b/controller/src/llm/tools.js
@@ -43,7 +43,11 @@ export function buildPickerTools({ recentIds = new Set(), recentArtists = new Se
   // Filter recents, slim, and record into `seen` so the picker can resolve
   // the agent's final id choice to a full track. Drops songs by an artist that
   // played in the recent window, and caps any one artist's share of the pool.
-  const collect = (list, cap = 12) => {
+  // cap=8 (down from 12) keeps per-tool input tokens lower for the picker
+  // agent — see picker-latency notes in dj-agent.js. The seen map still
+  // accumulates across the whole loop, so the agent's id space grows with
+  // each tool call regardless.
+  const collect = (list, cap = 8) => {
     const out = [];
     for (const s of list || []) {
       if (!s?.id || recentIds.has(s.id) || seen.has(s.id)) continue;

--- a/controller/src/music/picker.js
+++ b/controller/src/music/picker.js
@@ -11,7 +11,7 @@ import * as library from './library.js';
 import * as dj from '../llm/dj.js';
 
 const CANDIDATE_CAP = 18;
-const HISTORY_DEPTH = 8;
+const HISTORY_DEPTH = 4;
 
 // Per-source caps so the LLM sees a balanced mix rather than 15 similar songs.
 const CAP_SIMILAR = 8;
@@ -39,7 +39,7 @@ function shuffle(arr) {
 }
 
 function notRecent(recentIds) {
-  return (t) => t && t.id && !recentIds.has(t.id);
+  return t => t && t.id && !recentIds.has(t.id);
 }
 
 // Walk a list of albums and return up to `perAlbum` tracks from each, capped.
@@ -68,7 +68,9 @@ async function buildCandidates(mood, recentIds, currentTrack) {
   // 1. Similar-songs from current track — strongest contextual signal.
   if (currentTrack?.id) {
     try {
-      const similar = await subsonic.getSimilarSongs(currentTrack.id, { count: 20 });
+      const similar = await subsonic.getSimilarSongs(currentTrack.id, {
+        count: 20,
+      });
       add('similar', similar.filter(notRecent(recentIds)).slice(0, CAP_SIMILAR));
     } catch {}
   }
@@ -83,13 +85,13 @@ async function buildCandidates(mood, recentIds, currentTrack) {
   if (mood) {
     try {
       const playlists = await memo('playlists', CACHE_TTL_MS, () => subsonic.getPlaylists());
-      const matched = playlists.filter(p =>
-        p.name?.toLowerCase().includes(mood.toLowerCase())
-      );
+      const matched = playlists.filter(p => p.name?.toLowerCase().includes(mood.toLowerCase()));
       const plTracks = [];
       for (const pl of matched.slice(0, 2)) {
         try {
-          const songs = await memo(`playlist:${pl.id}`, CACHE_TTL_MS, () => subsonic.getPlaylist(pl.id));
+          const songs = await memo(`playlist:${pl.id}`, CACHE_TTL_MS, () =>
+            subsonic.getPlaylist(pl.id),
+          );
           plTracks.push(...songs);
         } catch {}
       }
@@ -122,21 +124,32 @@ async function buildCandidates(mood, recentIds, currentTrack) {
   // 6. Similar-artist top songs — adjacency through Last.fm artist graph.
   if (currentTrack?.artist) {
     try {
-      const similarArtistTracks = await memo(`similar-artist:${currentTrack.artist}`, CACHE_TTL_MS, async () => {
-        const matches = await subsonic.searchArtists(currentTrack.artist, { artistCount: 1 });
-        if (matches.length === 0) return [];
-        const info = await subsonic.getArtistInfo(matches[0].id, { count: 5 });
-        const similars = (info?.similarArtist || []).slice(0, 2);
-        const collected = [];
-        for (const sa of similars) {
-          try {
-            const top = await subsonic.getTopSongs(sa.name, { count: 5 });
-            collected.push(...top);
-          } catch {}
-        }
-        return collected;
-      });
-      add('similar-artist', similarArtistTracks.filter(notRecent(recentIds)).slice(0, CAP_SIMILAR_ARTIST));
+      const similarArtistTracks = await memo(
+        `similar-artist:${currentTrack.artist}`,
+        CACHE_TTL_MS,
+        async () => {
+          const matches = await subsonic.searchArtists(currentTrack.artist, {
+            artistCount: 1,
+          });
+          if (matches.length === 0) return [];
+          const info = await subsonic.getArtistInfo(matches[0].id, {
+            count: 5,
+          });
+          const similars = (info?.similarArtist || []).slice(0, 2);
+          const collected = [];
+          for (const sa of similars) {
+            try {
+              const top = await subsonic.getTopSongs(sa.name, { count: 5 });
+              collected.push(...top);
+            } catch {}
+          }
+          return collected;
+        },
+      );
+      add(
+        'similar-artist',
+        similarArtistTracks.filter(notRecent(recentIds)).slice(0, CAP_SIMILAR_ARTIST),
+      );
     } catch {}
   }
 
@@ -157,17 +170,19 @@ async function buildCandidates(mood, recentIds, currentTrack) {
   const MAX_PER_ARTIST = 3;
   const seen = new Set();
   const perArtist = new Map();
-  const final = shuffle(pool).filter(t => {
-    if (!t.id || seen.has(t.id)) return false;
-    const artistKey = (t.artist || '').toLowerCase().trim();
-    if (artistKey) {
-      const n = perArtist.get(artistKey) || 0;
-      if (n >= MAX_PER_ARTIST) return false;
-      perArtist.set(artistKey, n + 1);
-    }
-    seen.add(t.id);
-    return true;
-  }).slice(0, CANDIDATE_CAP);
+  const final = shuffle(pool)
+    .filter(t => {
+      if (!t.id || seen.has(t.id)) return false;
+      const artistKey = (t.artist || '').toLowerCase().trim();
+      if (artistKey) {
+        const n = perArtist.get(artistKey) || 0;
+        if (n >= MAX_PER_ARTIST) return false;
+        perArtist.set(artistKey, n + 1);
+      }
+      seen.add(t.id);
+      return true;
+    })
+    .slice(0, CANDIDATE_CAP);
 
   return { candidates: final, sources };
 }
@@ -176,15 +191,17 @@ function summariseRecent(queue) {
   const items = [];
   if (queue.current) items.push(queue.current);
   items.push(...queue.history.slice(0, HISTORY_DEPTH));
-  return items.filter(i => i?.track?.title).map(i => {
-    const tags = i.track.id ? library.get(i.track.id) : null;
-    return {
-      title: i.track.title,
-      artist: i.track.artist,
-      moods: tags?.moods || [],
-      energy: tags?.energy || null,
-    };
-  });
+  return items
+    .filter(i => i?.track?.title)
+    .map(i => {
+      const tags = i.track.id ? library.get(i.track.id) : null;
+      return {
+        title: i.track.title,
+        artist: i.track.artist,
+        moods: tags?.moods || [],
+        energy: tags?.energy || null,
+      };
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -202,9 +219,12 @@ export async function pickViaPool(queue, ctx) {
     return null;
   }
 
-  queue.log('picker', `pool ${candidates.length} (${
-    Object.entries(sources).map(([k, v]) => `${k}=${v}`).join(' ')
-  })`);
+  queue.log(
+    'picker',
+    `pool ${candidates.length} (${Object.entries(sources)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ')})`,
+  );
 
   const recentPlays = summariseRecent(queue);
 
@@ -231,14 +251,28 @@ export async function pickViaPool(queue, ctx) {
     // take the top candidate rather than returning null, which would starve
     // the queue and drop the stream to the generic auto.m3u playlist.
     queue.log('error', `picker LLM failed: ${err.message} — falling back to first pool candidate`);
-    return { song: candidates[0], reason: 'fallback (LLM pick failed)', source: candidates[0]._source };
+    return {
+      song: candidates[0],
+      reason: 'fallback (LLM pick failed)',
+      source: candidates[0]._source,
+    };
   }
 
   const chosen = candidates.find(c => c.id === pickRaw?.id);
   if (!chosen) {
-    queue.log('error', `picker returned unknown id ${pickRaw?.id}; falling back to first candidate`);
-    return { song: candidates[0], reason: 'fallback (LLM returned invalid id)' };
+    queue.log(
+      'error',
+      `picker returned unknown id ${pickRaw?.id}; falling back to first candidate`,
+    );
+    return {
+      song: candidates[0],
+      reason: 'fallback (LLM returned invalid id)',
+    };
   }
 
-  return { song: chosen, reason: pickRaw.reason || null, source: chosen._source };
+  return {
+    song: chosen,
+    reason: pickRaw.reason || null,
+    source: chosen._source,
+  };
 }

--- a/controller/src/music/subsonic-log.js
+++ b/controller/src/music/subsonic-log.js
@@ -4,6 +4,7 @@
 // without an import cycle.
 
 import { appendFile } from 'node:fs/promises';
+import { statSync, renameSync } from 'node:fs';
 import { STATE_DIR } from '../config.js';
 import { logEvent } from '../observability/events.js';
 
@@ -21,6 +22,26 @@ const songCoverage = new Map();
 // patterns stay reviewable over days. Best-effort — a write failure must never
 // break a request.
 const CALLS_LOG = `${STATE_DIR}/logs/subsonic.log`;
+// A busy station writes ~40 MB/month to this log. Rotate when it hits this
+// cap; one .old backup is kept (older content is overwritten). Tuned tight
+// because the in-memory ring + logEvent stream cover real observability —
+// this file just provides a few days of audit history.
+const CALLS_LOG_MAX_BYTES = 10 * 1024 * 1024;
+
+// Rotate on module load (catches the cap across redeploys) AND every ~1000
+// writes (catches it during long uptimes — a controller running a month would
+// otherwise blow past the cap with only the startup check). Sync calls are
+// fine: the startup check runs once, and the periodic check runs ~once an hour
+// at typical pick rates. Missing file or missing logs/ dir is fine.
+function maybeRotateLog() {
+  try {
+    if (statSync(CALLS_LOG).size > CALLS_LOG_MAX_BYTES) {
+      renameSync(CALLS_LOG, `${CALLS_LOG}.old`);
+    }
+  } catch {}
+}
+maybeRotateLog();
+let _appendsSinceRotateCheck = 0;
 
 export function record(entry) {
   recentCalls.unshift(entry);
@@ -49,6 +70,10 @@ export function record(entry) {
     entry.ok ? 'ok' : 'err',
     entry.count,
   ].join('\t') + '\n';
+  if (++_appendsSinceRotateCheck >= 1000) {
+    _appendsSinceRotateCheck = 0;
+    maybeRotateLog();
+  }
   appendFile(CALLS_LOG, line).catch(() => {});
 
   // Durable, trace-correlated event — logEvent stamps the active traceId, so

--- a/controller/src/music/subsonic.js
+++ b/controller/src/music/subsonic.js
@@ -29,20 +29,45 @@ function buildUrl(endpoint, params = {}) {
   return url.toString();
 }
 
-// Response keys that carry item arrays, checked in order — first match wins.
-// Key-driven (not endpoint-switched) so new callers are covered automatically.
-const ITEM_PATHS = [
+// Song-carrying response paths — hand-curated. Add an entry when a NEW
+// endpoint returns SONGS that should count toward the song-coverage map in
+// subsonic-log.js ("is the picker drawing from the whole library or a narrow
+// pool?"). Not auto-derived from response shape: only endpoints whose array
+// elements are individual tracks belong here.
+const SONG_PATHS = [
   ['searchResult3', 'song'], ['randomSongs', 'song'], ['songsByGenre', 'song'],
   ['similarSongs2', 'song'], ['starred2', 'song'], ['topSongs', 'song'],
-  ['album', 'song'], ['playlist', 'entry'], ['albumList2', 'album'],
+  ['album', 'song'], ['playlist', 'entry'],
 ];
 
-function extractItems(sub) {
-  for (const [a, b] of ITEM_PATHS) {
+// Non-song response paths — albums, artists, genres, playlists. Used only to
+// populate the log's `count` field so /debug reflects how many items every
+// endpoint actually returned (a getGenres call that returns 40 genres used to
+// log as count:0). These shapes do NOT feed song-coverage analytics.
+const OTHER_PATHS = [
+  ['albumList2', 'album'], ['searchResult3', 'album'],
+  ['searchResult3', 'artist'], ['genres', 'genre'],
+  ['playlists', 'playlist'], ['artist', 'album'],
+];
+
+function extractSongs(sub) {
+  for (const [a, b] of SONG_PATHS) {
     const v = sub[a]?.[b];
     if (Array.isArray(v)) return v;
   }
   return [];
+}
+
+// Total items in the response: songs if any, else the first non-song shape
+// that matches. Both paths are checked because search3 returns songs AND
+// artists in the same response — songs win when present.
+function extractCount(sub, songs) {
+  if (songs.length > 0) return songs.length;
+  for (const [a, b] of OTHER_PATHS) {
+    const v = sub[a]?.[b];
+    if (Array.isArray(v)) return v.length;
+  }
+  return 0;
 }
 
 async function call(endpoint, params = {}) {
@@ -50,17 +75,24 @@ async function call(endpoint, params = {}) {
   try {
     const url = buildUrl(endpoint, params);
     const res = await fetch(url);
-    if (!res.ok) throw new Error(`Subsonic ${endpoint} failed: ${res.status}`);
+    if (!res.ok) {
+      // Capture the first 200 chars of the body so outage triage gets the
+      // actual server message (Cloudflare 522, Navidrome 5xx detail, etc.)
+      // instead of just a bare status code.
+      let body = '';
+      try { body = (await res.text()).slice(0, 200); } catch {}
+      throw new Error(`Subsonic ${endpoint} failed: ${res.status}${body ? ` — ${body}` : ''}`);
+    }
     const data = await res.json();
     const sub = data['subsonic-response'];
     if (sub.status !== 'ok') throw new Error(`Subsonic error: ${sub.error?.message || 'unknown'}`);
-    const items = extractItems(sub);
+    const songs = extractSongs(sub);
     subLog.record({
       t: new Date().toISOString(), endpoint, params, ms: Date.now() - started,
-      ok: true, count: items.length,
-      // Songs carry both id and title; albumList2 rows have no title — keep
-      // them out of song coverage but still counted via `count` above.
-      songIds: items
+      ok: true, count: extractCount(sub, songs),
+      // Songs carry both id and title; non-song shapes (albums, artists,
+      // genres, playlists) are reflected in `count` above but not here.
+      songIds: songs
         .filter(i => i?.id && i?.title)
         .map(i => ({ id: i.id, title: i.title, artist: i.artist })),
     });

--- a/controller/src/server.js
+++ b/controller/src/server.js
@@ -56,7 +56,9 @@ app.listen(config.server.port, async () => {
     config.weather.lng = s.weather.lng;
     config.weather.locationName = s.weather.locationName;
     await settings.ensureLiquidsoapSettingsFile();
-    console.log(`[settings] loaded. jingleRatio=${s.jingleRatio} crossfadeDuration=${s.crossfadeDuration} location=${s.weather.locationName}`);
+    console.log(
+      `[settings] loaded. jingleRatio=${s.jingleRatio} crossfadeDuration=${s.crossfadeDuration} location=${s.weather.locationName}`,
+    );
   } catch (err) {
     console.error('[settings] load failed:', err.message);
   }
@@ -78,6 +80,8 @@ app.listen(config.server.port, async () => {
   queue.startWatcher();
   startListenerMonitor();
   startScheduler();
-  jingles.ensureDefaultIdent().catch(err => console.error('[jingles] ident generation failed:', err.message));
+  jingles
+    .ensureDefaultIdent()
+    .catch(err => console.error('[jingles] ident generation failed:', err.message));
   sfx.ensureDefaults().catch(err => console.error('[sfx] default generation failed:', err.message));
 });

--- a/controller/src/settings.js
+++ b/controller/src/settings.js
@@ -9,7 +9,6 @@ import { randomBytes } from 'node:crypto';
 import { STATE_DIR } from './config.js';
 
 const SETTINGS_PATH = `${STATE_DIR}/settings.json`;
-const LIQ_SETTINGS_PATH = `${STATE_DIR}/liquidsoap_settings.json`;
 
 // Default DJ system-prompt template. Placeholders are substituted at LLM
 // call time via renderDjPrompt(). Keep {name} mandatory — update() refuses
@@ -24,8 +23,10 @@ Hard rules:
 - Reference the actual context (time, weather, what's coming) naturally.
 - Vary your opener and shape every time — never start the same way twice in a row, never use the same metaphor or framing as your last few lines.`;
 
-// Seed souls — the SEED_PERSONAS roster picks from these, and djSystem() falls
-// back to DJ_SOULS[0] when a persona has no soul of its own.
+// Seed souls — the SEED_PERSONAS roster picks from these. renderDjPrompt()
+// falls back to DJ_SOULS[0] when the substituted persona has no soul of its
+// own; the agent path (agentPersonaPreamble) instead substitutes an empty
+// string, since its template doesn't require a soul to read cleanly.
 export const DJ_SOULS = [
   'warm, slightly understated, never corny — late-night BBC 6 Music presenter; observant, dry humour, specific',
   'thoughtful and a little wistful; finds small details in tracks and rooms; favours one well-chosen image over a list',
@@ -35,9 +36,16 @@ export const DJ_SOULS = [
 ];
 
 // Distilled from the "Signs of AI writing" guide — the subset that matters for
-// short spoken radio links. Appended to every DJ system prompt by renderDjPrompt()
-// and directorSystem(), so it survives custom operator templates. Kept tight on
-// purpose: a long forbidden-word list degrades small local models.
+// short spoken radio links. Reaches every DJ system prompt through one of two
+// channels: renderDjPrompt() for the legacy dj.generateXxx callers (always
+// included), and agentPersonaPreamble() for tool-loop agents (opt-in per
+// caller). The segment director opts in; the track-picker and request agents
+// opt OUT, because the ~600-char block competes with their tool-loop
+// instructions and reliably derails small cloud models. See
+// agentPersonaPreamble() for the full rationale. Never hand-roll an agent
+// system prompt — go through one of these so the rules choice stays explicit.
+// Kept tight on purpose: a long forbidden-word list degrades small local
+// models even when it IS appropriate.
 export const DJ_HUMANNESS_RULES = `Sound like a person talking, not a write-up:
 - Skip AI-essay vocabulary: "delve", "tapestry", "testament", "boasts", "vibrant", "bustling", "elevate", "realm", "whilst", "moreover", "furthermore".
 - No significance inflation — a song is just a song; don't call it "more than just" anything or "a testament to" something.
@@ -828,6 +836,30 @@ export function renderDjPrompt(persona, ctx = {}) {
     .replaceAll('{station}', station)
     .replaceAll('{location}', location);
   return `${rendered}\n\n${DJ_HUMANNESS_RULES}`;
+}
+
+// Persona prelude shared by every tool-loop agent system prompt — the picker
+// and request agents in broadcast/dj-agent.js, and the segment director in
+// skills/_agent.js. These agents build task-specific templates (with tools,
+// schemas, and JSON shapes the legacy generateXxx prompts don't need), so they
+// can't go through renderDjPrompt — but they still need the same persona
+// opener everywhere. Paste this at the top of any new agent system prompt;
+// never hand-roll the opener.
+//
+// `rules` is OPT-IN, defaulting to true. Pass `false` for tool-loop agents
+// whose primary task is structured exploration + strict JSON output (the
+// track picker and the request agent): the ~600-char humanness block at the
+// top of the prompt competes for the model's attention with the tool-loop
+// instructions and reliably derails small cloud models — they read "sound
+// like a person talking" and emit conversational prose instead of executing
+// the tool loop. The rules belong on agents whose primary task IS spoken
+// output (the segment director), not on agents whose primary task is
+// orchestration with an incidental spoken side-channel.
+export function agentPersonaPreamble(persona, { rules = true } = {}) {
+  const name = persona?.name || 'the DJ';
+  const soul = persona?.soul || '';
+  const opener = `You are ${name}, the on-air DJ for SUB/WAVE, a personal internet radio station. ${soul}`;
+  return rules ? `${opener}\n\n${DJ_HUMANNESS_RULES}` : opener;
 }
 
 // Liquidsoap reads two tiny text files instead of JSON.

--- a/controller/src/settings.js
+++ b/controller/src/settings.js
@@ -35,27 +35,6 @@ export const DJ_SOULS = [
   'quietly enthusiastic; treats every track like a small recommendation to a friend; specific over poetic',
 ];
 
-// Distilled from the "Signs of AI writing" guide — the subset that matters for
-// short spoken radio links. Reaches every DJ system prompt through one of two
-// channels: renderDjPrompt() for the legacy dj.generateXxx callers (always
-// included), and agentPersonaPreamble() for tool-loop agents (opt-in per
-// caller). The segment director opts in; the track-picker and request agents
-// opt OUT, because the ~600-char block competes with their tool-loop
-// instructions and reliably derails small cloud models. See
-// agentPersonaPreamble() for the full rationale. Never hand-roll an agent
-// system prompt — go through one of these so the rules choice stays explicit.
-// Kept tight on purpose: a long forbidden-word list degrades small local
-// models even when it IS appropriate.
-export const DJ_HUMANNESS_RULES = `Sound like a person talking, not a write-up:
-- Skip AI-essay vocabulary: "delve", "tapestry", "testament", "boasts", "vibrant", "bustling", "elevate", "realm", "whilst", "moreover", "furthermore".
-- No significance inflation — a song is just a song; don't call it "more than just" anything or "a testament to" something.
-- Drop the "not just X, it's Y" / "not only... but also" framing.
-- No press-release hype: "iconic", "legendary", "timeless masterpiece", "must-listen".
-- Speak for yourself — never "many say", "it's often said", "critics agree".
-- No trailing "..., showcasing/highlighting..." analysis tacked onto a sentence.
-- Don't land on a tidy summary or a little moral. Make your point and stop.
-- Use contractions and plain words; let it have the rhythm of real speech.`;
-
 export const FREQUENCIES = ['quiet', 'moderate', 'aggressive'];
 
 // Per-persona verbosity. 'concise' is the historical one-liner behaviour;
@@ -76,7 +55,16 @@ export const TTS_ENGINES = ['piper', 'kokoro', 'cloud'];
 // `gateway` are aggregators — one key, any vendor's models. `openai-compatible`
 // targets any self-hosted OpenAI-compatible server (llama.cpp, vLLM, LM Studio,
 // etc.) via the operator-supplied `llm.baseUrl`.
-export const LLM_PROVIDERS = ['ollama', 'openai-compatible', 'anthropic', 'openai', 'google', 'deepseek', 'openrouter', 'gateway'];
+export const LLM_PROVIDERS = [
+  'ollama',
+  'openai-compatible',
+  'anthropic',
+  'openai',
+  'google',
+  'deepseek',
+  'openrouter',
+  'gateway',
+];
 
 // Cloud TTS vendors usable by the `cloud` engine.
 export const TTS_CLOUD_PROVIDERS = ['openai', 'elevenlabs'];
@@ -85,23 +73,37 @@ export const TTS_CLOUD_PROVIDERS = ['openai', 'elevenlabs'];
 // imports this as MOOD_VOCAB) and the Shows scheduler — a show's `mood`
 // overrides the autonomous dominantMood, so it must come from this list.
 export const SHOW_MOODS = [
-  'energetic', 'calm', 'reflective', 'celebratory', 'romantic', 'spiritual',
-  'focus', 'workout', 'driving', 'cooking', 'rainy', 'sunny',
-  'night', 'morning', 'evening', 'festival', 'cultural',
+  'energetic',
+  'calm',
+  'reflective',
+  'celebratory',
+  'romantic',
+  'spiritual',
+  'focus',
+  'workout',
+  'driving',
+  'cooking',
+  'rainy',
+  'sunny',
+  'night',
+  'morning',
+  'evening',
+  'festival',
+  'cultural',
 ];
 
 // British English Kokoro voices — the ones that fit a BBC 6 Music tone. The
 // underlying model ships 54 voices total; we expose only the British subset to
 // keep the UI tidy. Any voice matching KOKORO_VOICE_RE still passes validation.
 export const KOKORO_VOICES_BRITISH = [
-  { id: 'bm_george',    label: 'George (M)' },
-  { id: 'bm_fable',     label: 'Fable (M)' },
-  { id: 'bm_daniel',    label: 'Daniel (M)' },
-  { id: 'bm_lewis',     label: 'Lewis (M)' },
-  { id: 'bf_emma',      label: 'Emma (F)' },
-  { id: 'bf_isabella',  label: 'Isabella (F)' },
-  { id: 'bf_alice',     label: 'Alice (F)' },
-  { id: 'bf_lily',      label: 'Lily (F)' },
+  { id: 'bm_george', label: 'George (M)' },
+  { id: 'bm_fable', label: 'Fable (M)' },
+  { id: 'bm_daniel', label: 'Daniel (M)' },
+  { id: 'bm_lewis', label: 'Lewis (M)' },
+  { id: 'bf_emma', label: 'Emma (F)' },
+  { id: 'bf_isabella', label: 'Isabella (F)' },
+  { id: 'bf_alice', label: 'Alice (F)' },
+  { id: 'bf_lily', label: 'Lily (F)' },
 ];
 
 const KOKORO_VOICE_RE = /^[a-z]{2}_[a-z0-9]+$/;
@@ -164,8 +166,8 @@ export const SEED_PERSONAS = [
 ];
 
 const DEFAULTS = {
-  jingleRatio: 30,                    // 1 jingle per N music tracks
-  crossfadeDuration: 10.0,            // seconds
+  jingleRatio: 30, // 1 jingle per N music tracks
+  crossfadeDuration: 10.0, // seconds
   weather: { lat: 52.5862, lng: -2.1288, locationName: 'Wolverhampton' },
   // Global DJ prompt template. '' means "use DEFAULT_DJ_PROMPT_TEMPLATE".
   djPrompt: '',
@@ -185,7 +187,13 @@ const DEFAULTS = {
     // empty means "read the provider's env var" (OPENAI_API_KEY etc.).
     // `enabled` is the operator's "Off" switch — when false the cloud engine
     // reports unavailable regardless of key, so the engine pickers grey it out.
-    cloud: { enabled: false, provider: 'openai', model: 'gpt-4o-mini-tts', voice: 'alloy', apiKey: '' },
+    cloud: {
+      enabled: false,
+      provider: 'openai',
+      model: 'gpt-4o-mini-tts',
+      voice: 'alloy',
+      apiKey: '',
+    },
   },
   llm: {
     provider: 'ollama',
@@ -227,8 +235,8 @@ const DEFAULTS = {
 };
 
 const BOUNDS = {
-  jingleRatio:        { min: 1, max: 1000, type: 'int' },
-  crossfadeDuration:  { min: 0, max: 30,   type: 'float' },
+  jingleRatio: { min: 1, max: 1000, type: 'int' },
+  crossfadeDuration: { min: 0, max: 30, type: 'float' },
 };
 
 let cache = null;
@@ -256,8 +264,11 @@ function normalizeSkills(raw) {
 
 function normalizeTts(raw) {
   const engine = TTS_ENGINES.includes(raw?.engine) ? raw.engine : 'piper';
-  const cloudProvider = TTS_CLOUD_PROVIDERS.includes(raw?.cloudProvider) ? raw.cloudProvider : 'openai';
-  let voice = (typeof raw?.voice === 'string' && raw.voice.trim()) ? raw.voice.trim().slice(0, 100) : '';
+  const cloudProvider = TTS_CLOUD_PROVIDERS.includes(raw?.cloudProvider)
+    ? raw.cloudProvider
+    : 'openai';
+  let voice =
+    typeof raw?.voice === 'string' && raw.voice.trim() ? raw.voice.trim().slice(0, 100) : '';
   if (engine === 'kokoro' && !KOKORO_VOICE_RE.test(voice)) voice = 'bf_isabella';
   if (!voice) voice = engine === 'cloud' ? 'alloy' : 'bf_isabella';
   return { engine, cloudProvider, voice };
@@ -269,7 +280,7 @@ function normalizePersona(raw) {
   const soul = typeof raw.soul === 'string' ? raw.soul.trim().slice(0, 400) : '';
   if (!name || !soul) return null;
   return {
-    id: (typeof raw.id === 'string' && ID_RE.test(raw.id)) ? raw.id : mintId('p_'),
+    id: typeof raw.id === 'string' && ID_RE.test(raw.id) ? raw.id : mintId('p_'),
     name,
     tagline: typeof raw.tagline === 'string' ? raw.tagline.trim().slice(0, 80) : '',
     frequency: FREQUENCIES.includes(raw.frequency) ? raw.frequency : 'moderate',
@@ -303,13 +314,14 @@ function normalizeShows(raw, personaIds) {
     if (!item || typeof item !== 'object') continue;
     const name = typeof item.name === 'string' ? item.name.trim().slice(0, 60) : '';
     if (!name) continue;
-    if (!personaIds.includes(item.personaId)) continue;       // drop dangling owner
+    if (!personaIds.includes(item.personaId)) continue; // drop dangling owner
     if (!SHOW_MOODS.includes(item.mood)) continue;
-    let id = (typeof item.id === 'string' && ID_RE.test(item.id)) ? item.id : mintId('s_');
+    let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('s_');
     if (seen.has(id)) id = mintId('s_');
     seen.add(id);
     out.push({
-      id, name,
+      id,
+      name,
       topic: typeof item.topic === 'string' ? item.topic.trim().slice(0, 1000) : '',
       personaId: item.personaId,
       mood: item.mood,
@@ -337,14 +349,17 @@ export async function load() {
   if (cache) return cache;
   let stored = {};
   if (existsSync(SETTINGS_PATH)) {
-    try { stored = JSON.parse(await readFile(SETTINGS_PATH, 'utf8')); } catch {}
+    try {
+      stored = JSON.parse(await readFile(SETTINGS_PATH, 'utf8'));
+    } catch {}
   }
 
   // ── personas ──────────────────────────────────────────────────────────────
   // No valid persona roster in settings.json (fresh install) → ship the seed
   // roster of three distinct DJs.
-  const personas = normalizePersonaArray(stored.personas)
-    || DEFAULTS.personas.map(p => ({ ...p, tts: { ...p.tts } }));
+  const personas =
+    normalizePersonaArray(stored.personas) ||
+    DEFAULTS.personas.map(p => ({ ...p, tts: { ...p.tts } }));
   const personaIds = personas.map(p => p.id);
 
   const activePersonaId = personaIds.includes(stored.activePersonaId)
@@ -352,13 +367,19 @@ export async function load() {
     : personaIds[0];
 
   // djPrompt — prefer the new field, else migrate the legacy dj.systemPrompt.
-  let djPrompt = typeof stored.djPrompt === 'string'
-    ? stored.djPrompt
-    : (typeof stored.dj?.systemPrompt === 'string' ? stored.dj.systemPrompt : '');
+  let djPrompt =
+    typeof stored.djPrompt === 'string'
+      ? stored.djPrompt
+      : typeof stored.dj?.systemPrompt === 'string'
+        ? stored.dj.systemPrompt
+        : '';
   if (djPrompt.trim() === DEFAULT_DJ_PROMPT_TEMPLATE.trim()) djPrompt = '';
 
   const shows = normalizeShows(stored.shows, personaIds);
-  const schedule = normalizeSchedule(stored.schedule, shows.map(s => s.id));
+  const schedule = normalizeSchedule(
+    stored.schedule,
+    shows.map(s => s.id),
+  );
 
   cache = {
     jingleRatio: stored.jingleRatio ?? DEFAULTS.jingleRatio,
@@ -378,26 +399,30 @@ export async function load() {
         ? stored.tts.defaultEngine
         : DEFAULTS.tts.defaultEngine,
       kokoro: {
-        voice: (typeof stored.tts?.kokoro?.voice === 'string'
-                && KOKORO_VOICE_RE.test(stored.tts.kokoro.voice))
-          ? stored.tts.kokoro.voice
-          : DEFAULTS.tts.kokoro.voice,
+        voice:
+          typeof stored.tts?.kokoro?.voice === 'string' &&
+          KOKORO_VOICE_RE.test(stored.tts.kokoro.voice)
+            ? stored.tts.kokoro.voice
+            : DEFAULTS.tts.kokoro.voice,
       },
       cloud: {
         // Explicit boolean wins; otherwise an install that already had a saved
         // cloud key keeps cloud on so the upgrade doesn't silently disable it.
-        enabled: typeof stored.tts?.cloud?.enabled === 'boolean'
-          ? stored.tts.cloud.enabled
-          : !!(stored.tts?.cloud?.apiKey),
+        enabled:
+          typeof stored.tts?.cloud?.enabled === 'boolean'
+            ? stored.tts.cloud.enabled
+            : !!stored.tts?.cloud?.apiKey,
         provider: TTS_CLOUD_PROVIDERS.includes(stored.tts?.cloud?.provider)
           ? stored.tts.cloud.provider
           : DEFAULTS.tts.cloud.provider,
-        model: (typeof stored.tts?.cloud?.model === 'string' && stored.tts.cloud.model.trim())
-          ? stored.tts.cloud.model.trim()
-          : DEFAULTS.tts.cloud.model,
-        voice: (typeof stored.tts?.cloud?.voice === 'string' && stored.tts.cloud.voice.trim())
-          ? stored.tts.cloud.voice.trim()
-          : DEFAULTS.tts.cloud.voice,
+        model:
+          typeof stored.tts?.cloud?.model === 'string' && stored.tts.cloud.model.trim()
+            ? stored.tts.cloud.model.trim()
+            : DEFAULTS.tts.cloud.model,
+        voice:
+          typeof stored.tts?.cloud?.voice === 'string' && stored.tts.cloud.voice.trim()
+            ? stored.tts.cloud.voice.trim()
+            : DEFAULTS.tts.cloud.voice,
         apiKey: typeof stored.tts?.cloud?.apiKey === 'string' ? stored.tts.cloud.apiKey : '',
       },
     },
@@ -407,31 +432,30 @@ export async function load() {
         : DEFAULTS.llm.provider,
       model: typeof stored.llm?.model === 'string' ? stored.llm.model.trim() : DEFAULTS.llm.model,
       apiKey: typeof stored.llm?.apiKey === 'string' ? stored.llm.apiKey : DEFAULTS.llm.apiKey,
-      ollamaUrl: typeof stored.llm?.ollamaUrl === 'string'
-        ? stored.llm.ollamaUrl.trim()
-        : DEFAULTS.llm.ollamaUrl,
-      baseUrl: typeof stored.llm?.baseUrl === 'string'
-        ? stored.llm.baseUrl.trim()
-        : DEFAULTS.llm.baseUrl,
-      reasoning: typeof stored.llm?.reasoning === 'boolean'
-        ? stored.llm.reasoning
-        : DEFAULTS.llm.reasoning,
-      pickerAgent: typeof stored.llm?.pickerAgent === 'boolean'
-        ? stored.llm.pickerAgent
-        : DEFAULTS.llm.pickerAgent,
-      pauseWhenEmpty: typeof stored.llm?.pauseWhenEmpty === 'boolean'
-        ? stored.llm.pauseWhenEmpty
-        : DEFAULTS.llm.pauseWhenEmpty,
+      ollamaUrl:
+        typeof stored.llm?.ollamaUrl === 'string'
+          ? stored.llm.ollamaUrl.trim()
+          : DEFAULTS.llm.ollamaUrl,
+      baseUrl:
+        typeof stored.llm?.baseUrl === 'string' ? stored.llm.baseUrl.trim() : DEFAULTS.llm.baseUrl,
+      reasoning:
+        typeof stored.llm?.reasoning === 'boolean' ? stored.llm.reasoning : DEFAULTS.llm.reasoning,
+      pickerAgent:
+        typeof stored.llm?.pickerAgent === 'boolean'
+          ? stored.llm.pickerAgent
+          : DEFAULTS.llm.pickerAgent,
+      pauseWhenEmpty:
+        typeof stored.llm?.pauseWhenEmpty === 'boolean'
+          ? stored.llm.pauseWhenEmpty
+          : DEFAULTS.llm.pauseWhenEmpty,
     },
     skills: {
       enabled: Object.fromEntries(
-        Object.entries(stored.skills?.enabled || {}).filter(([, v]) => typeof v === 'boolean')
+        Object.entries(stored.skills?.enabled || {}).filter(([, v]) => typeof v === 'boolean'),
       ),
     },
     sfx: {
-      enabled: typeof stored.sfx?.enabled === 'boolean'
-        ? stored.sfx.enabled
-        : DEFAULTS.sfx.enabled,
+      enabled: typeof stored.sfx?.enabled === 'boolean' ? stored.sfx.enabled : DEFAULTS.sfx.enabled,
     },
   };
   return cache;
@@ -467,7 +491,9 @@ function validateTtsBlock(raw, where) {
   let voice = String(t.voice ?? '').trim();
   if (t.engine === 'kokoro') {
     if (!KOKORO_VOICE_RE.test(voice)) {
-      throw new Error(`${where}.tts.voice must match <lang><gender>_<name> for kokoro, e.g. bf_isabella`);
+      throw new Error(
+        `${where}.tts.voice must match <lang><gender>_<name> for kokoro, e.g. bf_isabella`,
+      );
     }
   } else if (t.engine === 'cloud') {
     if (voice.length < 1 || voice.length > 100) {
@@ -489,9 +515,11 @@ function validatePersonasStrict(raw) {
   return raw.map((item, i) => {
     if (!item || typeof item !== 'object') throw new Error(`personas[${i}] must be an object`);
     const name = String(item.name ?? '').trim();
-    if (name.length < 1 || name.length > 40) throw new Error(`personas[${i}].name must be 1-40 chars`);
+    if (name.length < 1 || name.length > 40)
+      throw new Error(`personas[${i}].name must be 1-40 chars`);
     const soul = String(item.soul ?? '').trim();
-    if (soul.length < 1 || soul.length > 400) throw new Error(`personas[${i}].soul must be 1-400 chars`);
+    if (soul.length < 1 || soul.length > 400)
+      throw new Error(`personas[${i}].soul must be 1-400 chars`);
     const tagline = String(item.tagline ?? '').trim();
     if (tagline.length > 80) throw new Error(`personas[${i}].tagline must be 0-80 chars`);
     if (!FREQUENCIES.includes(item.frequency)) {
@@ -515,7 +543,9 @@ function validatePersonasStrict(raw) {
         throw new Error(`personas[${i}].skills must be an array of skill names`);
       }
       if (item.skills.length > SKILLS_PER_PERSONA_LIMIT) {
-        throw new Error(`personas[${i}].skills must be at most ${SKILLS_PER_PERSONA_LIMIT} entries`);
+        throw new Error(
+          `personas[${i}].skills must be at most ${SKILLS_PER_PERSONA_LIMIT} entries`,
+        );
       }
       const seenSk = new Set();
       skills = [];
@@ -524,13 +554,25 @@ function validatePersonasStrict(raw) {
         if (!SKILL_SLUG_RE.test(v)) {
           throw new Error(`personas[${i}].skills entries must be slug strings`);
         }
-        if (!seenSk.has(v)) { seenSk.add(v); skills.push(v); }
+        if (!seenSk.has(v)) {
+          seenSk.add(v);
+          skills.push(v);
+        }
       }
     }
-    let id = (typeof item.id === 'string' && ID_RE.test(item.id)) ? item.id : mintId('p_');
+    let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('p_');
     if (seen.has(id)) id = mintId('p_');
     seen.add(id);
-    return { id, name, tagline, frequency: item.frequency, scriptLength, soul, tts, skills };
+    return {
+      id,
+      name,
+      tagline,
+      frequency: item.frequency,
+      scriptLength,
+      soul,
+      tts,
+      skills,
+    };
   });
 }
 
@@ -551,7 +593,7 @@ function validateShowsStrict(raw, personas) {
     if (!SHOW_MOODS.includes(item.mood)) {
       throw new Error(`shows[${i}].mood must be one of: ${SHOW_MOODS.join(', ')}`);
     }
-    let id = (typeof item.id === 'string' && ID_RE.test(item.id)) ? item.id : mintId('s_');
+    let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('s_');
     if (seen.has(id)) id = mintId('s_');
     seen.add(id);
     return { id, name, topic, personaId: item.personaId, mood: item.mood };
@@ -570,7 +612,10 @@ function validateScheduleStrict(raw, shows) {
     }
     for (let h = 0; h < 24; h++) {
       const v = day[h];
-      if (v === null || v === undefined || v === '') { week[d][h] = null; continue; }
+      if (v === null || v === undefined || v === '') {
+        week[d][h] = null;
+        continue;
+      }
       if (typeof v !== 'string' || !showIds.includes(v)) {
         throw new Error(`schedule[${d}][${h}] references an unknown show`);
       }
@@ -589,16 +634,30 @@ export async function update(patch) {
   if ('jingleRatio' in patch) {
     const v = parseInt(patch.jingleRatio, 10);
     if (!Number.isFinite(v) || v < BOUNDS.jingleRatio.min || v > BOUNDS.jingleRatio.max) {
-      throw new Error(`jingleRatio must be int in [${BOUNDS.jingleRatio.min}, ${BOUNDS.jingleRatio.max}]`);
+      throw new Error(
+        `jingleRatio must be int in [${BOUNDS.jingleRatio.min}, ${BOUNDS.jingleRatio.max}]`,
+      );
     }
-    if (v !== cur.jingleRatio) { next.jingleRatio = v; restart = true; }
+    if (v !== cur.jingleRatio) {
+      next.jingleRatio = v;
+      restart = true;
+    }
   }
   if ('crossfadeDuration' in patch) {
     const v = parseFloat(patch.crossfadeDuration);
-    if (!Number.isFinite(v) || v < BOUNDS.crossfadeDuration.min || v > BOUNDS.crossfadeDuration.max) {
-      throw new Error(`crossfadeDuration must be number in [${BOUNDS.crossfadeDuration.min}, ${BOUNDS.crossfadeDuration.max}]`);
+    if (
+      !Number.isFinite(v) ||
+      v < BOUNDS.crossfadeDuration.min ||
+      v > BOUNDS.crossfadeDuration.max
+    ) {
+      throw new Error(
+        `crossfadeDuration must be number in [${BOUNDS.crossfadeDuration.min}, ${BOUNDS.crossfadeDuration.max}]`,
+      );
     }
-    if (v !== cur.crossfadeDuration) { next.crossfadeDuration = v; restart = true; }
+    if (v !== cur.crossfadeDuration) {
+      next.crossfadeDuration = v;
+      restart = true;
+    }
   }
   if ('weather' in patch) {
     const w = patch.weather || {};
@@ -713,7 +772,7 @@ export async function update(patch) {
       if (v && !/^https?:\/\//i.test(v)) {
         throw new Error('llm.ollamaUrl must start with http:// or https://');
       }
-      next.llm.ollamaUrl = v.replace(/\/+$/, '');  // strip trailing slashes
+      next.llm.ollamaUrl = v.replace(/\/+$/, ''); // strip trailing slashes
     }
     if (l.baseUrl !== undefined) {
       const v = String(l.baseUrl).trim();
@@ -721,7 +780,7 @@ export async function update(patch) {
       if (v && !/^https?:\/\//i.test(v)) {
         throw new Error('llm.baseUrl must start with http:// or https://');
       }
-      next.llm.baseUrl = v.replace(/\/+$/, '');  // strip trailing slashes
+      next.llm.baseUrl = v.replace(/\/+$/, ''); // strip trailing slashes
     }
     if (l.reasoning !== undefined) {
       next.llm.reasoning = !!l.reasoning;
@@ -829,13 +888,14 @@ export function getEffectivePersona(date = new Date()) {
 export function renderDjPrompt(persona, ctx = {}) {
   const station = ctx.station || 'SUB/WAVE';
   const location = ctx.location || (cache?.weather?.locationName ?? DEFAULTS.weather.locationName);
-  const tpl = (cache?.djPrompt && cache.djPrompt.trim()) ? cache.djPrompt : DEFAULT_DJ_PROMPT_TEMPLATE;
+  const tpl =
+    cache?.djPrompt && cache.djPrompt.trim() ? cache.djPrompt : DEFAULT_DJ_PROMPT_TEMPLATE;
   const rendered = tpl
     .replaceAll('{name}', persona?.name || 'your host')
     .replaceAll('{soul}', persona?.soul || DJ_SOULS[0])
     .replaceAll('{station}', station)
     .replaceAll('{location}', location);
-  return `${rendered}\n\n${DJ_HUMANNESS_RULES}`;
+  return `${rendered}`;
 }
 
 // Persona prelude shared by every tool-loop agent system prompt — the picker
@@ -859,7 +919,7 @@ export function agentPersonaPreamble(persona, { rules = true } = {}) {
   const name = persona?.name || 'the DJ';
   const soul = persona?.soul || '';
   const opener = `You are ${name}, the on-air DJ for SUB/WAVE, a personal internet radio station. ${soul}`;
-  return rules ? `${opener}\n\n${DJ_HUMANNESS_RULES}` : opener;
+  return rules ? `${opener}` : opener;
 }
 
 // Liquidsoap reads two tiny text files instead of JSON.

--- a/controller/src/skills/_agent.js
+++ b/controller/src/skills/_agent.js
@@ -35,7 +35,7 @@ import { config } from '../config.js';
 import { queue } from '../broadcast/queue.js';
 import * as settings from '../settings.js';
 import { djAgent } from '../llm/sdk.js';
-import { buildContextLines, lengthPhrase } from '../llm/dj.js';
+import { buildContextLines } from '../llm/dj.js';
 import { buildSegmentTools } from '../llm/segment-tools.js';
 import * as sfx from '../broadcast/sfx.js';
 
@@ -86,18 +86,19 @@ const CAPABILITIES = [
 
 const SEGMENT_SCHEMA = z.object({
   segment: z.object({
-    kind: z.enum(['weather', 'news', 'traffic', 'random-facts', 'web-search']),
-    text: z.string().describe('the spoken line — one sentence, in the DJ voice'),
-    sfx: z.string().nullable().describe('the exact name of one sound effect to play under this line, or null for none'),
-  }).nullable().describe('the segment to air, or null to stay silent'),
-  reason: z.string().describe('one short internal sentence on the decision'),
+    kind: z.enum(['weather', 'news', 'traffic', 'random-facts', 'web-search'])
+      .describe('the segment kind — MUST be one offered in the system prompt for this tick'),
+    text: z.string().describe('the spoken line in the DJ voice — typically one short sentence, never more than three'),
+    sfx: z.string().nullable().describe('the exact name of one sound effect from the catalogue in the system prompt to play under this line, or null for no effect (null is usually right — most segments need none)'),
+  }).nullable().describe('the segment to air, or null to stay silent — silence is a perfectly good answer, often the best one, when the data is dull, stale, unchanged, or there is nothing fresh worth a listener\'s attention'),
+  reason: z.string().describe('one short internal sentence on why this segment (or why silent) — never shown to the listener'),
 });
 
 // Operator-override schema: the segment is mandatory, the kind is already
 // known, so the agent only returns the spoken line.
 const FORCED_SCHEMA = z.object({
-  text: z.string().describe('the spoken line — one sentence, in the DJ voice'),
-  sfx: z.string().nullable().describe('the exact name of one sound effect to play under the line, or null for none'),
+  text: z.string().describe('the spoken line in the DJ voice — typically one short sentence, never more than three'),
+  sfx: z.string().nullable().describe('the exact name of one sound effect from the catalogue in the system prompt to play under this line, or null for no effect'),
 });
 
 // The optional sound-effects block appended to the agent's system prompt.
@@ -149,33 +150,26 @@ function availableCapabilities(ctx, now) {
   return out;
 }
 
+// Ultra-minimal — persona + per-tick dynamic context (capability list, station
+// tone, sfx catalog). Everything else (response shape, silent-null option,
+// "call done", length, tool exploration) is conveyed via the AI SDK's
+// channels: the segment-tools.js tool descriptions, the schema field
+// descriptions on SEGMENT_SCHEMA above, the done-tool description in sdk.js,
+// and the buildSituation() user message. Same principle as pickSystem.
 function directorSystem(persona, caps, freq, sfxCatalog) {
-  const name = persona?.name || 'the DJ';
-  const soul = persona?.soul || '';
   const capList = caps.map(c => `- ${c.kind}: ${c.desc}`).join('\n');
   const tone = freq === 'quiet'
-    ? 'This is a quiet station — speak rarely; silence should be your default.'
+    ? 'This is a quiet station — silence is your default.'
     : freq === 'aggressive'
-      ? 'This is a lively station — a more frequent presence is welcome, but never filler for its own sake.'
-      : 'This is a measured station — speak when there is something worth saying, not on a timer.';
+      ? 'This is a lively station — frequent presence welcome, never filler.'
+      : 'This is a measured station — speak only when there is something worth saying.';
 
-  return `You are ${name}, the on-air DJ for SUB/WAVE, a personal internet radio station. ${soul}
+  return `${settings.agentPersonaPreamble(persona)}
 
-${settings.DJ_HUMANNESS_RULES}
+Your job: decide whether to air ONE between-track segment, or stay silent. You are NOT choosing music. ${tone}
 
-YOUR ONLY JOB right now: decide whether to air ONE short spoken segment between tracks, or to stay silent. You are NOT choosing music — track selection is handled by another part of the station. Do not reason about which song should play next; that is not your decision.
-
-Staying silent is a perfectly good — often the best — answer. Only speak when there is something genuinely fresh and worth a listener's attention.
-
-Capabilities available to you this tick (you may air at most ONE):
-${capList}
-
-Use the tools to look at the real data before you decide. If the data is dull, stale, unchanged, or you have nothing fresh to add, return null and stay silent. ${tone}${sfxBlock(sfxCatalog)}
-
-Length: write ${lengthPhrase('segment', persona)} — any "one sentence" length hints in the briefs above are only a floor, not a cap.
-
-Respond with a JSON object only — no prose, no markdown:
-{ "segment": { "kind": "<one of: ${caps.map(c => c.kind).join(', ')}>", "text": "<one spoken sentence in your voice>", "sfx": "<an effect name from the list, or null>" } or null, "reason": "<one short internal sentence about the SEGMENT decision — not about music>" }`;
+Capabilities available this tick (pick one of these kinds, or stay silent):
+${capList}${sfxBlock(sfxCatalog)}`;
 }
 
 // The concrete situation handed to the agent as its single user turn. Built
@@ -265,33 +259,61 @@ export async function agenticTick(ctx) {
       }
     }
   } catch (err) {
-    queue.log('error', `Segment agent failed: ${err.message}`);
+    // Distinguish a model that couldn't produce parseable JSON from a real
+    // outage. The schema explicitly allows {segment: null} as "stay silent",
+    // and the system prompt actively encourages silence — so a model that
+    // emits unparseable output was most likely TRYING to stay silent but
+    // expressing it wrong. The listener-facing outcome is the same either way
+    // (silence), so report it as silence with a parse note instead of
+    // flooding /debug with errors. Real failures (network, model not loaded,
+    // retries exhausted) still log as errors so operators see them.
+    if (isBareNullSilent(err)) {
+      queue.log('scheduler', `Segment agent stayed silent — model emitted bare null (treating as intended silence)`);
+    } else if (isSilentFailure(err)) {
+      queue.log('scheduler', `Segment agent stayed silent — output not parseable (${err.message.slice(0, 80)})`);
+    } else {
+      queue.log('error', `Segment agent failed: ${err.message}`);
+    }
   } finally {
     tickBusy = false;
   }
 }
 
+// True for "the model produced no parseable object" errors thrown by the AI
+// SDK — these usually mean the model wanted to stay silent but botched the
+// JSON, not that the network or provider is broken. Used by agenticTick (not
+// by runCapability — the operator override demands real output, so a parse
+// failure there IS a failure).
+function isSilentFailure(err) {
+  const msg = String(err?.message || err || '').toLowerCase();
+  return msg.includes('no object generated')
+      || msg.includes('no output generated')
+      || msg.includes('did not match schema');
+}
+
+// Detect the specific "model emitted bare `null`" failure pattern (observed on
+// minimax-m2.7:cloud and likely others). The model is trying to say "stay
+// silent" but encoding it at the wrong nesting level — the schema requires
+// {segment: null, reason: "..."} but the model returns top-level null.
+// Treating this as intentional silence is strictly safer than failing the
+// tick: same listener-facing outcome (silence) with cleaner logs.
+function isBareNullSilent(err) {
+  const text = String(err?.text || '').trim();
+  if (text !== 'null') return false;
+  const cause = String(err?.cause?.message || '').toLowerCase();
+  return cause.includes('expected object') && cause.includes('received null');
+}
+
 // Operator-override variant of directorSystem: exactly one capability, and the
 // segment is mandatory — the agent does not get the option to stay silent.
+// Same ultra-minimal treatment as directorSystem — the FORCED_SCHEMA's text
+// description and the segment-tools.js tool descriptions carry the rest.
 function forcedSystem(persona, cap, sfxCatalog) {
-  const name = persona?.name || 'the DJ';
-  const soul = persona?.soul || '';
+  return `${settings.agentPersonaPreamble(persona)}
 
-  return `You are ${name}, the on-air DJ for SUB/WAVE, a personal internet radio station. ${soul}
+The operator asked you to air ONE ${cap.kind} segment now — you must produce a line, silence is not an option. You are NOT choosing music.
 
-${settings.DJ_HUMANNESS_RULES}
-
-The operator has asked you to air ONE ${cap.kind} segment right now. You are NOT choosing music — track selection is handled by another part of the station. Your only job is to write the spoken line.
-
-What this segment is:
-${cap.desc}
-
-Use any tools available to you to look at the real data first, then write the line. You MUST produce a segment — staying silent is not an option here. If the data is thin, do the best you can with what you have.${sfxBlock(sfxCatalog)}
-
-Length: write ${lengthPhrase('segment', persona)} — any "one sentence" length hint in the brief above is only a floor, not a cap.
-
-Respond with a JSON object only — no prose, no markdown:
-{ "text": "<one spoken sentence in your voice>", "sfx": "<an effect name from the list, or null>" }`;
+${cap.desc}${sfxBlock(sfxCatalog)}`;
 }
 
 // Operator override — fire one capability on demand, bypassing cooldowns, the

--- a/docs/agent-picker-investigation.md
+++ b/docs/agent-picker-investigation.md
@@ -1,0 +1,168 @@
+# Agent picker reliability — investigation notes
+
+Late-night session (2026-05-19 → 05-20) that took the DJ agent picker from
+~0/N reliable in live to ~100% in test and ~80% in live, by way of four
+distinct fixes plus a lot of falsified hypotheses. This doc captures what we
+tried, what was actually wrong, and the per-provider operational data we
+gathered, so the next person debugging this doesn't have to repeat the spiral.
+
+## TL;DR
+
+Four real fixes, in order of impact:
+
+1. **Use `provider.chat(id)` for Ollama, not `provider(id)`.** The default
+   callable on `ollama-ai-provider-v2` routes through a broken "responses"
+   interface that mistranslates tools/`toolChoice`/`activeTools`. Symptom:
+   every cloud `:cloud` model emitted prose instead of tool calls regardless
+   of which model we tried. Fix: explicit `.chat()` routes through `/api/chat`
+   where tool calls work natively.
+
+2. **Filter old `kind: 'pick'` user events from `windowMessages()`.** Every
+   prior "Now playing X. Pick the next track" instruction stayed in the
+   session window as a coalesced user message; the model saw 10+ "pick next"
+   requests and got confused about which to answer. Symptom: 60% failures on
+   gemini in long-context, 0% in live (sterile test passed 100%). Fix: keep
+   only the most-recent pick event; older ones get dropped so the agent sees
+   just the current ask.
+
+3. **Conditional structured-output strategy in `sdk.js`.** On Ollama use the
+   "done tool" pattern (Output.object is broken there). On everything else
+   use native `Output.object` (done-tool only adds the "didn't call done"
+   failure mode). One-line gate: `const useDoneTool = schema != null &&
+   needsToolCallObject();`.
+
+4. **Ultra-minimal system prompts.** The AI SDK already conveys tool
+   descriptions, schema field descriptions, the done-tool's role, and per-tick
+   instructions via session messages. Duplicating that in prompt text
+   competes with the structural signals and derails small models. The fix is
+   ~10 lines of persona + editorial criteria; everything else moved into
+   schema `.describe()` calls.
+
+Combined effect: see [Results](#results) at the end.
+
+## The spiral, abridged
+
+Things that looked like the bug but weren't:
+
+- **"Models are flaky on cloud Ollama"** — they all are, until you fix
+  the harness. Same models work fine via `/api/chat` directly with curl.
+- **"`Output.object` is broken"** — only on Ollama. Native on Google /
+  DeepSeek / Anthropic / OpenRouter. We conflated provider behaviour.
+- **"Long context derails the model"** — true, but the root cause was the
+  *shape* of long context (repeated "pick next" instructions), not its
+  length. After filtering, even very long sessions produce ~155 chars of
+  context for the picker.
+- **"Token limits"** — we measured. Picker calls use ~600–2000 input tokens
+  on a 200K-context model. Not the issue. Sub-10s "no output" failures are
+  faster than any plausible output-cap hit.
+- **"Reasoning models need bigger maxOutputTokens"** — checked. Successful
+  picks use 250–600 output tokens against a 1200 cap.
+- **Prompt verbosity didn't help reliability** — every iteration that added
+  "make 2-4 tool calls, then call done with…" reduced reliability vs the
+  minimal version. Small models read instructions as competing with the
+  framework's structural directives.
+- **`prepareStep` activeTools gating helped on Ollama, not elsewhere** —
+  Google/DeepSeek don't honour the constraint the same way; they need
+  Output.object instead.
+
+Things that were the bug:
+
+- The harness wiring (#1 above).
+- The session-window shape (#2 above).
+- Mismatched structured-output strategy per provider (#3 above).
+- Prompt over-specification (#4 above).
+
+## Diagnostic infrastructure built along the way
+
+Most of the investigation was only possible because `sdk.js` now captures
+much more on failure than it used to:
+
+- `recordSuccess()` / `recordFailure()` helpers — every primitive funnels
+  through them, so a new code path can't silently drop a field.
+- `failureDiagnostics(err)` — pulls `err.text` / `err.finishReason` /
+  `err.usage` / `err.cause.message` / partial tool calls off any AI SDK
+  structured-output error. Without this, failures only carried the opaque
+  "could not parse the response" message.
+- `logFailurePreview(kind, err)` — tees a one-line preview of the failed
+  model output to `docker logs`, so `grep "raw model output"` surfaces the
+  actual model behaviour without digging through `/debug` JSON.
+- `via` tracked per attempted strategy (`ai-sdk:tool` / `ai-sdk:agent` /
+  `ai-sdk:recovery` / `ai-sdk`) — so `/stats` attributes failures correctly
+  instead of bucketing everything as `ai-sdk`.
+
+The test harness — `controller/scripts/picker-test.mjs` — runs djAgent in
+isolation against any provider/model with synthetic discovery tools. Two
+modes (`short` / `long`) for context length. Imports live `pickSystem` and
+`PICK_SCHEMA` so changes there flow into the test automatically. Usage:
+
+```bash
+docker exec sub-wave-controller node scripts/picker-test.mjs <provider> <model> [N] [short|long]
+```
+
+## Results
+
+Picker reliability across providers, with all four fixes in place:
+
+| Provider / Model | Path used | n | Success | Median ms | Notes |
+|---|---|---|---|---|---|
+| `ollama:minimax-m2.7:cloud` | done-tool | 10 | 10/10 | 36s | slow but reliable, cloud-proxied |
+| `ollama:kimi-k2.6:cloud` | done-tool | 10 | 1/10 | n/a | bad model fit, both paths fail |
+| `google:gemini-3.5-flash` | Output.object | 5 short / 5 long | 5/5 / 5/5 | 5.3s / 6.7s | best overall |
+| `google:gemini-3.5-flash` | Output.object | 5 live skips | 4/5 | 4–10s | matches test |
+| `deepseek:deepseek-chat` | Output.object | 5 | 5/5 | 3.6s | fastest of all |
+| `openrouter:anthropic/claude-haiku-4-5` | Output.object | 5 | 5/5 | 3.7s | cold-start outliers |
+
+Picks now genuinely come back in seconds with real tool exploration and
+meaningful reasons ("smooth transition from AP Dhillon to Prem Dhillon",
+"flow from Talwiinder to atmospheric Prabh Deep") rather than prose dumps
+or hallucinated IDs.
+
+## Operational guidance
+
+**For the live system right now**: `google:gemini-3.5-flash` and
+`deepseek:deepseek-chat` are the fast, reliable picks. Ollama works (via
+the `.chat()` path) but is slow (~30s per pick on minimax). Pool fallback
+catches any agent failure in 2–5s, so listener-facing reliability is
+effectively 100% regardless of model.
+
+**Avoid `kimi-k2.6:cloud` for the agent picker** — both structured-output
+paths fail on it. Use it for free-text DJ generation (intros, links) where
+it's fine.
+
+**If a new provider breaks the picker**, the diagnostic capture should tell
+you exactly why. Check `/debug` for the failed call's `responseText`,
+`finishReason`, `causeMessage`, and partial `toolCalls`. If the model emits
+prose instead of structured output, suspect the harness (provider wiring).
+If it emits bare `null` or a bare string, suspect the prompt or schema
+nesting. If it never calls tools, suspect the provider's `toolChoice`
+support.
+
+**Don't add prompt guidance that the AI SDK already conveys.** Schema
+descriptions, tool descriptions, the done-tool's role, session event text
+— these are all framework channels the model reads structurally. Prompt
+text that restates them competes with them. The "ultra-minimal" pickSystem
+(~10 lines) consistently outperformed every more-detailed iteration.
+
+## Files touched in this session
+
+- `controller/src/llm/provider.js` — `.chat()` for Ollama
+- `controller/src/llm/sdk.js` — conditional structured-output strategy,
+  done-tool gating, prepareStep discovery gating, failure diagnostics,
+  recordSuccess/recordFailure helpers, repeat_penalty honesty in sampling log
+- `controller/src/llm/dj.js` — dead code removal, narrowed log re-export
+- `controller/src/llm/tools.js` — per-tool result cap 12→8
+- `controller/src/broadcast/dj-agent.js` — ultra-minimal `pickSystem` and
+  `requestSystem`, exports for test harness, PICK_SCHEMA descriptions
+  enriched, `pickViaPool` doesn't record the failure sentinel as a DJ turn
+- `controller/src/broadcast/session.js` — `windowMessages()` filters
+  scenario / play / old-pick-event turns
+- `controller/src/skills/_agent.js` — ultra-minimal `directorSystem` and
+  `forcedSystem`, bare-null silent classification, schema enriched
+- `controller/src/music/subsonic.js` — SONG_PATHS vs OTHER_PATHS split,
+  non-2xx body in error messages
+- `controller/src/music/subsonic-log.js` — log rotation
+- `controller/src/settings.js` — `agentPersonaPreamble` helper, dead constant
+  removal
+- `controller/scripts/picker-test.mjs` — test harness, short/long modes,
+  uses live pickSystem
+- `docs/agent-picker-investigation.md` — this doc

--- a/web/components/admin/AdminShell.jsx
+++ b/web/components/admin/AdminShell.jsx
@@ -3,7 +3,16 @@
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { useCallback, useEffect } from 'react';
-import { Radio, BarChart3, Disc3, CalendarClock, Drama, Sparkles, SlidersHorizontal, Terminal } from 'lucide-react';
+import {
+  Radio,
+  BarChart3,
+  Disc3,
+  CalendarClock,
+  Drama,
+  Sparkles,
+  SlidersHorizontal,
+  Terminal,
+} from 'lucide-react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { useStationFeed } from '../../hooks/useStationFeed';
 import SignInForm from './SignInForm';
@@ -14,25 +23,23 @@ import { Toaster } from '../ui/toaster';
 const NAV_SECTIONS = [
   {
     label: 'Monitor',
-    items: [
-      { href: '/admin/dash', id: 'dash', label: 'Dash', icon: Radio, pill: 'live' },
-    ],
+    items: [{ href: '/admin/dash', id: 'dash', label: 'Dash', icon: Radio, pill: 'live' }],
   },
   {
     label: 'Programming',
     items: [
-      { href: '/admin/library',  id: 'library',  label: 'Library',  icon: Disc3 },
-      { href: '/admin/shows',    id: 'shows',    label: 'Shows',    icon: CalendarClock },
+      { href: '/admin/library', id: 'library', label: 'Library', icon: Disc3 },
+      { href: '/admin/shows', id: 'shows', label: 'Shows', icon: CalendarClock },
       { href: '/admin/personas', id: 'personas', label: 'Personas', icon: Drama },
-      { href: '/admin/skills',   id: 'skills',   label: 'Skills',   icon: Sparkles },
+      { href: '/admin/skills', id: 'skills', label: 'Skills', icon: Sparkles },
     ],
   },
   {
     label: 'System',
     items: [
-      { href: '/admin/stats',    id: 'stats',    label: 'Stats',    icon: BarChart3 },
+      { href: '/admin/stats', id: 'stats', label: 'Stats', icon: BarChart3 },
       { href: '/admin/settings', id: 'settings', label: 'Settings', icon: SlidersHorizontal },
-      { href: '/admin/debug',    id: 'debug',    label: 'Debug',    icon: Terminal },
+      { href: '/admin/debug', id: 'debug', label: 'Debug', icon: Terminal },
     ],
   },
 ];
@@ -47,11 +54,14 @@ export default function AdminShell({ children }) {
   const router = useRouter();
   const { auth, needsAuth, hydrated, signIn, signOut, adminFetch } = useAdminAuth();
 
-  const handleSignIn = useCallback(async (user, pass) => {
-    const res = await signIn(user, pass);
-    if (res?.ok && pathname !== '/admin/dash') router.push('/admin/dash');
-    return res;
-  }, [signIn, pathname, router]);
+  const handleSignIn = useCallback(
+    async (user, pass) => {
+      const res = await signIn(user, pass);
+      if (res?.ok && pathname !== '/admin/dash') router.push('/admin/dash');
+      return res;
+    },
+    [signIn, pathname, router],
+  );
 
   // Probe an admin endpoint on first paint so a revoked token surfaces the
   // sign-in form proactively.
@@ -59,16 +69,23 @@ export default function AdminShell({ children }) {
     if (!hydrated || !auth) return;
     let cancelled = false;
     (async () => {
-      try { await adminFetch('/settings'); } catch {}
+      try {
+        await adminFetch('/settings');
+      } catch {}
       if (cancelled) return;
     })();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hydrated, auth]);
 
   if (!hydrated) {
     return (
-      <div className="admin-root paper" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <div
+        className="admin-root paper"
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
         <span className="caption">loading…</span>
       </div>
     );
@@ -108,8 +125,10 @@ export default function AdminShell({ children }) {
             </div>
           ))}
           <div className="nav-foot">
-            sub / wave<br />
-            admin console<br />
+            sub / wave
+            <br />
+            admin console
+            <br />
             newsprint v3
           </div>
         </nav>
@@ -125,35 +144,55 @@ function ShellHeader({ pathname, signedIn, onSignOut }) {
   const current = NAV.find(n => pathname?.startsWith(n.href))?.label || 'Admin';
   const { nowPlaying, listeners } = useStationFeed();
   const onAir = !!nowPlaying?.title;
-  const count = listeners?.current ?? listeners?.count ?? (typeof listeners === 'number' ? listeners : null);
+  const count =
+    listeners?.current ?? listeners?.count ?? (typeof listeners === 'number' ? listeners : null);
 
   return (
     <header className="shell-header">
       <span className="wordmark">SUB / WAVE</span>
-      <span className="caption" style={{ color: 'var(--muted)' }}>· admin</span>
-      <span className="crumb">/ <b>{current}</b></span>
+      <span className="caption" style={{ color: 'var(--muted)' }}>
+        · admin
+      </span>
+      <span className="crumb">
+        / <b>{current}</b>
+      </span>
       {signedIn && (
         <span className="right">
-          <span className="live-dot" style={{ background: onAir ? 'var(--accent)' : 'var(--muted)' }} />
+          <span
+            className="live-dot"
+            style={{ background: onAir ? 'var(--accent)' : 'var(--muted)' }}
+          />
           <span>{onAir ? 'on air' : 'off air'}</span>
           {count != null && (
             <>
-              <span style={{ width: 1, alignSelf: 'stretch', background: 'var(--separator-strong)' }} />
+              <span
+                style={{ width: 1, alignSelf: 'stretch', background: 'var(--separator-strong)' }}
+              />
               <span>{count} listening</span>
             </>
           )}
-          <Link href="/" className="caption" style={{ color: 'var(--muted)', textDecoration: 'none' }}>
+          <Link
+            href="/"
+            className="caption"
+            style={{ color: 'var(--muted)', textDecoration: 'none' }}
+          >
             ← player
           </Link>
           <ThemeToggle />
           {onSignOut && (
-            <button className="sign-out" onClick={onSignOut}>sign out</button>
+            <button className="sign-out" onClick={onSignOut}>
+              sign out
+            </button>
           )}
         </span>
       )}
       {!signedIn && (
         <span className="right">
-          <Link href="/" className="caption" style={{ color: 'var(--muted)', textDecoration: 'none' }}>
+          <Link
+            href="/"
+            className="caption"
+            style={{ color: 'var(--muted)', textDecoration: 'none' }}
+          >
             ← player
           </Link>
           <ThemeToggle />

--- a/web/components/admin/DashPanel.jsx
+++ b/web/components/admin/DashPanel.jsx
@@ -13,23 +13,23 @@ import { Card, Btn, Pill, Eyebrow, Seg, Toggle } from './ui';
 
 const SAY_KINDS = [
   { id: 'dj-speak', label: 'Solo' },
-  { id: 'link',     label: 'Over' },
+  { id: 'link', label: 'Over' },
 ];
 const SAY_MODES = [
-  { id: 'raw',    label: 'Raw' },
+  { id: 'raw', label: 'Raw' },
   { id: 'styled', label: 'Styled' },
 ];
 const SEGMENTS = [
   { type: 'station-id', label: 'Station ID' },
-  { type: 'hourly',     label: 'Time check' },
-  { type: 'link',       label: 'Track link' },
+  { type: 'hourly', label: 'Time check' },
+  { type: 'link', label: 'Track link' },
 ];
 
 export default function DashPanel() {
   const { adminFetch, needsAuth, hydrated } = useAdminAuth();
-  const [status, setStatus] = useState(null);   // { nowPlaying, context, listeners, dj, queue }
+  const [status, setStatus] = useState(null); // { nowPlaying, context, listeners, dj, queue }
   const [err, setErr] = useState(null);
-  const [busy, setBusy] = useState(null);       // key of the running action
+  const [busy, setBusy] = useState(null); // key of the running action
   const [feedback, setFeedback] = useState(null); // { tone, text }
 
   const [sayText, setSayText] = useState('');
@@ -54,7 +54,11 @@ export default function DashPanel() {
         const np = await npR.json().catch(() => null);
         const st = await stR.json().catch(() => null);
         const se = await seR.json().catch(() => null);
-        setStatus({ ...(np || {}), queue: st || {}, sessionMessages: se?.messages || [] });
+        setStatus({
+          ...(np || {}),
+          queue: st || {},
+          sessionMessages: se?.messages || [],
+        });
         setErr(null);
       } catch (e) {
         if (!cancelled) setErr(e.message);
@@ -62,7 +66,10 @@ export default function DashPanel() {
     };
     tick();
     const id = setInterval(tick, 3000);
-    return () => { cancelled = true; clearInterval(id); };
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hydrated, needsAuth]);
 
@@ -82,7 +89,10 @@ export default function DashPanel() {
       });
       const j = await r.json().catch(() => ({}));
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      setFeedback({ tone: 'ok', text: j.spoken ? `on air: “${j.spoken}”` : `${label} — done` });
+      setFeedback({
+        tone: 'ok',
+        text: j.spoken ? `on air: “${j.spoken}”` : `${label} — done`,
+      });
       return j;
     } catch (e) {
       setFeedback({ tone: 'err', text: `${label}: ${e.message}` });
@@ -119,44 +129,83 @@ export default function DashPanel() {
 
   // 6-cell status strip — real data.
   const strip = [
-    { l: 'dj on air',  v: status?.dj?.name || '—', accent: true },
-    { l: 'show',       v: showName },
-    { l: 'mood',       v: ctx?.dominantMood || '—' },
-    { l: 'listeners',  v: listeners ? String(listeners.current) : '—',
-      sub: listeners ? `peak ${listeners.peak}` : null },
-    { l: 'weather',    v: weatherText },
-    { l: 'picker',     v: q.pickerBusy ? 'thinking' : 'idle', accent: !!q.pickerBusy },
+    { l: 'dj on air', v: status?.dj?.name || '—', accent: true },
+    { l: 'show', v: showName },
+    { l: 'mood', v: ctx?.dominantMood || '—' },
+    {
+      l: 'listeners',
+      v: listeners ? String(listeners.current) : '—',
+      sub: listeners ? `peak ${listeners.peak}` : null,
+    },
+    { l: 'weather', v: weatherText },
+    {
+      l: 'picker',
+      v: q.pickerBusy ? 'thinking' : 'idle',
+      accent: !!q.pickerBusy,
+    },
   ];
 
   return (
     <div style={{ display: 'grid', gap: 16 }}>
       {/* ── HEADER STRIP ───────────────────────────────────────────────── */}
-      <div style={{
-        display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap',
-      }}>
-        <span className="live-dot" style={{ background: err ? 'var(--danger)' : 'var(--accent)' }} />
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          flexWrap: 'wrap',
+        }}
+      >
+        <span
+          className="live-dot"
+          style={{ background: err ? 'var(--danger)' : 'var(--accent)' }}
+        />
         <Eyebrow color={err ? 'var(--danger)' : 'var(--accent)'}>{err ? 'down' : 'live'}</Eyebrow>
         {feedback && (
-          <span style={{
-            marginLeft: 'auto', fontSize: 11,
-            color: feedback.tone === 'err' ? 'var(--danger)' : 'var(--accent)',
-          }}>
+          <span
+            style={{
+              marginLeft: 'auto',
+              fontSize: 11,
+              color: feedback.tone === 'err' ? 'var(--danger)' : 'var(--accent)',
+            }}
+          >
             {feedback.text}
           </span>
         )}
       </div>
 
-      {err && <V3Alert tone="error" title="controller error">{err}</V3Alert>}
+      {err && (
+        <V3Alert tone="error" title="controller error">
+          {err}
+        </V3Alert>
+      )}
 
       {/* ── ON AIR HERO ────────────────────────────────────────────────── */}
       <section className="card" style={{ borderColor: 'var(--ink)' }}>
-        <div className="stack-mobile" style={{
-          padding: 18, display: 'grid', gridTemplateColumns: '1fr auto', gap: 24,
-          alignItems: 'center', borderBottom: '1px solid var(--ink)',
-        }}>
+        <div
+          className="stack-mobile"
+          style={{
+            padding: 18,
+            display: 'grid',
+            gridTemplateColumns: '1fr auto',
+            gap: 24,
+            alignItems: 'center',
+            borderBottom: '1px solid var(--ink)',
+          }}
+        >
           <div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
-              <span className="live-dot" style={{ background: err ? 'var(--danger)' : 'var(--accent)' }} />
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+                marginBottom: 10,
+              }}
+            >
+              <span
+                className="live-dot"
+                style={{ background: err ? 'var(--danger)' : 'var(--accent)' }}
+              />
               <Eyebrow color="var(--accent)">on air</Eyebrow>
               <span className="caption">
                 auto-pick {q.autoPick ? 'on' : 'off'} · auto-link {q.autoLink ? 'on' : 'off'}
@@ -164,11 +213,21 @@ export default function DashPanel() {
             </div>
             {np?.title ? (
               <>
-                <div style={{ fontSize: 30, fontWeight: 800, letterSpacing: '-0.02em', lineHeight: 1.05 }}>
-                  {np.title} <span style={{ color: 'var(--muted)', fontWeight: 600 }}>— {np.artist}</span>
+                <div
+                  style={{
+                    fontSize: 30,
+                    fontWeight: 800,
+                    letterSpacing: '-0.02em',
+                    lineHeight: 1.05,
+                  }}
+                >
+                  {np.title}{' '}
+                  <span style={{ color: 'var(--muted)', fontWeight: 600 }}>— {np.artist}</span>
                 </div>
                 {np.album && (
-                  <div className="caption" style={{ marginTop: 6 }}>album · {np.album}</div>
+                  <div className="caption" style={{ marginTop: 6 }}>
+                    album · {np.album}
+                  </div>
                 )}
               </>
             ) : (
@@ -178,65 +237,112 @@ export default function DashPanel() {
             )}
           </div>
           <div style={{ display: 'flex', gap: 8 }}>
-            <Btn lg tone="danger" disabled={!!busy || !np?.title} onClick={() => setConfirmSkip(true)}>
+            <Btn
+              lg
+              tone="danger"
+              disabled={!!busy || !np?.title}
+              onClick={() => setConfirmSkip(true)}
+            >
               {busy === 'skip' ? 'skipping…' : 'Skip track'}
             </Btn>
           </div>
         </div>
 
         {/* status strip */}
-        <div className="strip-mobile" style={{
-          display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)',
-        }}>
+        <div
+          className="strip-mobile"
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(6, 1fr)',
+          }}
+        >
           {strip.map((c, i) => (
-            <div key={i} style={{
-              padding: '12px 14px',
-              borderLeft: i === 0 ? 'none' : '1px solid var(--separator-strong)',
-              display: 'flex', flexDirection: 'column', gap: 2,
-            }}>
+            <div
+              key={i}
+              style={{
+                padding: '12px 14px',
+                borderLeft: i === 0 ? 'none' : '1px solid var(--separator-strong)',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 2,
+              }}
+            >
               <span className="caption">{c.l}</span>
-              <span style={{
-                fontSize: 14, fontWeight: 600,
-                color: c.accent ? 'var(--accent)' : 'var(--ink)',
-              }}>
+              <span
+                style={{
+                  fontSize: 14,
+                  fontWeight: 600,
+                  color: c.accent ? 'var(--accent)' : 'var(--ink)',
+                }}
+              >
                 {c.v}
               </span>
-              {c.sub && <span className="caption" style={{ fontSize: 9 }}>{c.sub}</span>}
+              {c.sub && (
+                <span className="caption" style={{ fontSize: 9 }}>
+                  {c.sub}
+                </span>
+              )}
             </div>
           ))}
         </div>
       </section>
 
       {/* ── 2-COL OPS ──────────────────────────────────────────────────── */}
-      <div className="stack-mobile" style={{ display: 'grid', gridTemplateColumns: '1.4fr 1fr', gap: 16 }}>
+      <div
+        className="stack-mobile"
+        style={{ display: 'grid', gridTemplateColumns: '1.4fr 1fr', gap: 16 }}
+      >
         {/* LEFT */}
         <div style={{ display: 'grid', gridTemplateRows: 'auto 1fr', gap: 16 }}>
           <Card
             title="Queue"
             sub={`${upcoming.length} upcoming`}
-            right={<>
-              <Pill tone={`accent ${q.autoPick ? 'dot' : ''}`}>auto-pick {q.autoPick ? 'on' : 'off'}</Pill>
-              <Pill tone={`accent ${q.autoLink ? 'dot' : ''}`}>auto-link {q.autoLink ? 'on' : 'off'}</Pill>
-            </>}
+            right={
+              <>
+                <Pill tone={`accent ${q.autoPick ? 'dot' : ''}`}>
+                  auto-pick {q.autoPick ? 'on' : 'off'}
+                </Pill>
+                <Pill tone={`accent ${q.autoLink ? 'dot' : ''}`}>
+                  auto-link {q.autoLink ? 'on' : 'off'}
+                </Pill>
+              </>
+            }
             bodyStyle={{ padding: '4px 14px' }}
           >
             {upcoming.length === 0 ? (
-              <div style={{ padding: '10px 0', fontStyle: 'italic', color: 'var(--muted)' }}>
+              <div
+                style={{
+                  padding: '10px 0',
+                  fontStyle: 'italic',
+                  color: 'var(--muted)',
+                }}
+              >
                 queue empty — auto-playlist fallback
               </div>
             ) : (
               upcoming.slice(0, 8).map((t, i) => (
                 <div className="track-row" key={i}>
                   <span className="idx">{(i + 1).toString().padStart(2, '0')}</span>
-                  <span className="title">{t.title} <span className="artist">— {t.artist}</span></span>
+                  <span className="title">
+                    {t.title} <span className="artist">— {t.artist}</span>
+                  </span>
                   <span className="dur">{t.duration || ''}</span>
                   <span></span>
                   {t.requestedBy ? (
-                    <span style={{
-                      fontSize: 9, letterSpacing: '0.2em', textTransform: 'uppercase',
-                      color: 'var(--accent)', textAlign: 'right',
-                    }}>↳ {t.requestedBy}</span>
-                  ) : <span></span>}
+                    <span
+                      style={{
+                        fontSize: 9,
+                        letterSpacing: '0.2em',
+                        textTransform: 'uppercase',
+                        color: 'var(--accent)',
+                        textAlign: 'right',
+                      }}
+                    >
+                      ↳ {t.requestedBy}
+                    </span>
+                  ) : (
+                    <span></span>
+                  )}
                 </div>
               ))
             )}
@@ -247,15 +353,32 @@ export default function DashPanel() {
             sub={`${booth.length} session turns`}
             right={<Pill>session · live</Pill>}
             style={{ display: 'flex', flexDirection: 'column' }}
-            bodyStyle={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}
+            bodyStyle={{
+              flex: 1,
+              minHeight: 0,
+              display: 'flex',
+              flexDirection: 'column',
+            }}
           >
             {booth.length === 0 ? (
               <div style={{ fontStyle: 'italic', color: 'var(--muted)' }}>no session turns yet</div>
             ) : (
-              <div ref={logRef} style={{ flex: 1, minHeight: 220, maxHeight: 360, overflowY: 'auto' }}>
+              <div
+                ref={logRef}
+                style={{
+                  flex: 1,
+                  minHeight: 220,
+                  maxHeight: 360,
+                  overflowY: 'auto',
+                }}
+              >
                 {booth.map((turn, i) => (
                   <div key={turnKey(turn, i)} className={`log ${classTone(turnClass(turn))}`}>
-                    <span className="t">{new Date(turn.t).toLocaleTimeString('en-GB', { hour12: false })}</span>
+                    <span className="t">
+                      {new Date(turn.t).toLocaleTimeString('en-GB', {
+                        hour12: false,
+                      })}
+                    </span>
                     <span className="k">[{turn.kind}]</span>
                     <span className="msg">{turnText(turn)}</span>
                   </div>
@@ -273,11 +396,21 @@ export default function DashPanel() {
               value={sayText}
               onChange={e => setSayText(e.target.value)}
               maxLength={500}
-              placeholder={sayMode === 'raw'
-                ? 'Exact words the DJ will speak, verbatim…'
-                : 'An instruction or topic — the DJ writes it in persona…'}
+              placeholder={
+                sayMode === 'raw'
+                  ? 'Exact words the DJ will speak, verbatim…'
+                  : 'An instruction or topic — the DJ writes it in persona…'
+              }
             />
-            <div style={{ display: 'flex', gap: 14, alignItems: 'center', marginTop: 10, flexWrap: 'wrap' }}>
+            <div
+              style={{
+                display: 'flex',
+                gap: 14,
+                alignItems: 'center',
+                marginTop: 10,
+                flexWrap: 'wrap',
+              }}
+            >
               <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
                 <span className="caption">mode</span>
                 <Seg value={sayMode} options={SAY_MODES} onChange={setSayMode} />
@@ -298,7 +431,13 @@ export default function DashPanel() {
           </Card>
 
           <Card title="DJ segments" sub="fire on demand">
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8 }}>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr 1fr',
+                gap: 8,
+              }}
+            >
               {SEGMENTS.map(s => {
                 const k = `seg:${s.type}`;
                 return (
@@ -306,21 +445,48 @@ export default function DashPanel() {
                     key={s.type}
                     disabled={!!busy}
                     onClick={() => act(k, '/dj/segment', { type: s.type }, s.label)}
-                    onMouseEnter={e => { if (!busy) e.currentTarget.style.background = 'color-mix(in oklab, var(--accent) 18%, transparent)'; }}
-                    onMouseLeave={e => { e.currentTarget.style.background = 'color-mix(in oklab, var(--accent) 8%, transparent)'; }}
+                    onMouseEnter={e => {
+                      if (!busy)
+                        e.currentTarget.style.background =
+                          'color-mix(in oklab, var(--accent) 18%, transparent)';
+                    }}
+                    onMouseLeave={e => {
+                      e.currentTarget.style.background =
+                        'color-mix(in oklab, var(--accent) 8%, transparent)';
+                    }}
                     style={{
                       border: '1px solid var(--accent)',
                       background: 'color-mix(in oklab, var(--accent) 8%, transparent)',
-                      padding: '12px 10px', textAlign: 'left', fontFamily: 'inherit',
-                      display: 'flex', flexDirection: 'column', gap: 4, color: 'var(--ink)',
-                      cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.4 : 1,
+                      padding: '12px 10px',
+                      textAlign: 'left',
+                      fontFamily: 'inherit',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 4,
+                      color: 'var(--ink)',
+                      cursor: busy ? 'not-allowed' : 'pointer',
+                      opacity: busy ? 0.4 : 1,
                       transition: 'background 0.12s ease',
                     }}
                   >
-                    <span style={{ fontSize: 11, letterSpacing: '0.18em', textTransform: 'uppercase', fontWeight: 700 }}>
+                    <span
+                      style={{
+                        fontSize: 11,
+                        letterSpacing: '0.18em',
+                        textTransform: 'uppercase',
+                        fontWeight: 700,
+                      }}
+                    >
                       {s.label}
                     </span>
-                    <span className="caption" style={{ fontSize: 9, color: 'var(--accent)', fontWeight: 700 }}>
+                    <span
+                      className="caption"
+                      style={{
+                        fontSize: 9,
+                        color: 'var(--accent)',
+                        fontWeight: 700,
+                      }}
+                    >
                       {busy === k ? 'firing…' : 'fire ▸'}
                     </span>
                   </button>
@@ -332,27 +498,40 @@ export default function DashPanel() {
           <Card title="Broadcast">
             <div style={{ display: 'grid', gap: 10 }}>
               <ToggleRow
-                label="Auto-pick" desc="picks next track when queue runs dry"
-                on={!!q.autoPick} disabled={!!busy || !status}
+                label="Auto-pick"
+                desc="picks next track when queue runs dry"
+                on={!!q.autoPick}
+                disabled={!!busy || !status}
                 onToggle={() => act('autopick', '/auto-pick', { on: !q.autoPick }, 'auto-pick')}
               />
               <ToggleRow
-                label="Auto-link" desc="DJ talks between auto-played tracks"
-                on={!!q.autoLink} disabled={!!busy || !status}
+                label="Auto-link"
+                desc="DJ talks between auto-played tracks"
+                on={!!q.autoLink}
+                disabled={!!busy || !status}
                 onToggle={() => act('autolink', '/dj/auto-link', { on: !q.autoLink }, 'auto-link')}
               />
-              <div style={{
-                display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-                paddingTop: 8, borderTop: '1px dashed var(--separator-strong)',
-              }}>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  paddingTop: 8,
+                  borderTop: '1px dashed var(--separator-strong)',
+                }}
+              >
                 <div>
                   <div style={{ fontSize: 12, fontWeight: 700 }}>Auto-playlist</div>
-                  <div style={{ fontSize: 10, color: 'var(--muted)' }}>rebuild liquidsoap fallback</div>
+                  <div style={{ fontSize: 10, color: 'var(--muted)' }}>
+                    rebuild liquidsoap fallback
+                  </div>
                 </div>
                 <Btn
                   sm
                   disabled={!!busy}
-                  onClick={() => act('refresh', '/dj/refresh-playlist', {}, 'auto-playlist refresh')}
+                  onClick={() =>
+                    act('refresh', '/dj/refresh-playlist', {}, 'auto-playlist refresh')
+                  }
                 >
                   {busy === 'refresh' ? 'firing…' : 'Refresh'}
                 </Btn>
@@ -394,7 +573,9 @@ function ToggleRow({ label, desc, on, disabled, onToggle }) {
 function classTone(cls) {
   switch (cls) {
     case 'voice':
-    case 'track': return 'accent';
-    default:      return 'muted';
+    case 'track':
+      return 'accent';
+    default:
+      return 'muted';
   }
 }

--- a/web/components/admin/SettingsPanel.jsx
+++ b/web/components/admin/SettingsPanel.jsx
@@ -877,10 +877,12 @@ function LlmSection({ data, form, setForm, busy, saveMsg, saveSettings }) {
           <div>
             <div style={{ fontSize: 13, fontWeight: 700 }}>Chain-of-thought</div>
             <div style={{ fontSize: 11, color: 'var(--muted)', marginTop: 2, maxWidth: 480, lineHeight: 1.5 }}>
-              When off, reasoning (“thinking”) models are told to skip the
-              &lt;think&gt; block and answer directly. The DJ writes short scripts and
-              structured picks that don’t need reasoning — and an uncapped thought
-              chain on a small model balloons every call. Leave off unless you’re
+              When off, the picker tells the model to skip or minimize its
+              internal thinking step. Wired across providers that expose a
+              thinking knob — Ollama, openai-compatible (Qwen3), Gemini 2.5/3.x,
+              OpenAI o-series and gpt-5, and Claude (adaptive thinking). DJ
+              scripts and structured picks are short, and an uncapped thought
+              chain just balloons latency and cost. Leave off unless you&apos;re
               running a model that genuinely needs it.
             </div>
           </div>


### PR DESCRIPTION
Root cause: provider.js used ollama-ai-provider-v2's default callable (`provider(id)`), which routes through the package's "responses" interface and silently mistranslates tool definitions / toolChoice / activeTools. The visible symptom was every cloud :cloud model (minimax, kimi, deepseek, nemotron) emitting prose or hallucinated ids instead of tool calls — read as "models are flaky," actually a harness wiring bug. `provider.chat(id)` routes through /api/chat where the same models honour tools natively.

Layered on top, several session-window and prompt issues were degrading the agent path independently of the provider. Fixes:

- provider.js: use provider.chat(id) for Ollama (the actual harness fix)
- session.js: filter `kind: 'scenario'` events out of windowMessages so controller-restart noise doesn't fill the agent's context
- dj-agent.js: don't record the "fallback (LLM pick failed)" sentinel as a DJ session turn — it primed the next agent run with a "you failed before" signal that derailed every subsequent pick
- dj-agent.js / _agent.js: strip system prompts to the minimum the AI SDK doesn't already convey via tool descriptions, schema descriptions, the done-tool description, and session event text. Just persona + editorial criteria. Enriched PICK_SCHEMA / REQUEST_SCHEMA / SEGMENT_SCHEMA field descriptions to absorb what the prompts dropped (max-12-word reason, silence-is-valid for segments, etc.)
- sdk.js: switch djAgent to the canonical "done tool" pattern with prepareStep gating discovery on step 0 — converts structured output from "model must emit valid JSON" (which Ollama models botch) into "model must call a tool" (which they handle reliably). Bumped picker maxSteps 4→6 so thorough exploration can still finish with a done call

Observability + diagnostics that fell out of investigating the above:

- sdk.js: recordSuccess / recordFailure helpers, so a new primitive can't silently drop a field. Capture err.text / finishReason / usage / cause / partial toolCalls on every failure (was discarding everything except err.message). Tee a one-line raw-output preview to console for grep-able triage. Thread `lastVia` through both success and failure records so /stats attributes failures to the right sub-strategy (was bucketing all as 'ai-sdk'). Only log `repeat_penalty` in the sampling block when the active provider actually honours it (Ollama only); was always logged regardless
- _agent.js: classify "no object generated" / "did not match schema" errors in agenticTick as silent ("stayed silent — output not parseable") rather than as errors; the schema's null option means parse failures usually represent intended silence expressed wrong. Detect bare-null model output as the same case
- settings.js: agentPersonaPreamble helper, opt-in DJ_HUMANNESS_RULES per caller (off for tool-loop agents — the rules compete with structural tool guidance for smaller models; on for the legacy generateXxx and segment director where output IS prose)

Cleanup that surfaced during the rework:

- dj.js: delete orphan generateWeatherSegment + four unused ANGLES blocks (news/traffic/random_facts/web_search were preemptively added for the segment director but never wired up); narrow log re-export to recentCalls; fix stale "AGENT_INSTRUCTIONS in music/picker.js" comment
- settings.js: delete unused LIQ_SETTINGS_PATH (file never existed); fix misleading djSystem() soul-fallback comment (lives in renderDjPrompt)
- subsonic.js: split ITEM_PATHS into SONG_PATHS (coverage analytics) + OTHER_PATHS (count metric only) so getGenres / searchArtists / etc no longer show count:0 in /debug when they returned real data; include truncated response body in non-2xx error messages
- subsonic-log.js: rotate the durable call log when it exceeds 10 MB — every-1000-write check plus startup check, bounds disk to ~20 MB
- tools.js: per-tool result cap reduced 12→8 to lower per-pick input tokens

Added controller/scripts/picker-test.mjs — a synthetic-tools test harness that drives djAgent in isolation against any provider/model. Used to benchmark picker reliability across ollama / openrouter / deepseek / google (see results in PR description) and confirms the structural fixes work deterministically — separately from whatever cloud Ollama is doing on a given day.