### PR TITLE
controller: double LLM max-output-token caps

### DIFF
--- a/controller/src/llm/sdk.ts
+++ b/controller/src/llm/sdk.ts
@@ -25,9 +25,9 @@ import * as settings from '../settings.js';
 // when `llm.reasoning` is off, but provider coverage isn't complete — so the
 // caps stay generous enough to survive a thinking model even when we can't
 // turn its thinking off.
-const MAX_TOKENS_TEXT   = 2000;
-const MAX_TOKENS_OBJECT = 4000;
-const MAX_TOKENS_AGENT  = 4000;
+const MAX_TOKENS_TEXT   = 4000;
+const MAX_TOKENS_OBJECT = 8000;
+const MAX_TOKENS_AGENT  = 8000;
 
 // Some models (Qwen 3, DeepSeek R1, etc.) emit a <think>…</think> reasoning
 // block before the answer. Reasoning is suppressed at the provider layer when


### PR DESCRIPTION
## Summary
- Reasoning models (Gemini 3.x, Claude extended thinking, GPT o-series) burn output budget on internal thinking before emitting the answer, causing the agent loop to stop mid-way with no usable output.
- Bumps the three caps in `controller/src/llm/sdk.ts`: `MAX_TOKENS_TEXT` 2k→4k, `MAX_TOKENS_OBJECT` 4k→8k, `MAX_TOKENS_AGENT` 4k→8k.

## Test plan
- [x] Rebuild controller (`docker compose up -d --build controller`) — source is baked in, restart alone won't pick this up.
- [x] Trigger a track transition and confirm the DJ agent emits a link / picks a track without truncation.
- [x] Send a `/request` to exercise `djObject` + tool-call paths on the active provider.
- [x] Spot-check `/debug` to confirm no `finishReason: 'length'` records on recent LLM calls.