### PR TITLE
controller: add DuckDuckGo as a free web-search provider

### DIFF
--- a/controller/src/llm/segment-tools.ts
+++ b/controller/src/llm/segment-tools.ts
@@ -11,10 +11,9 @@
 
 import { tool } from 'ai';
 import { z } from 'zod';
-import { config } from '../config.js';
 import { queue } from '../broadcast/queue.js';
 import { fetchHeadlines, hashHeadline } from '../skills/news.js';
-import { tavilySearch } from '../skills/web-search.js';
+import { searchWeb, searchReady } from '../skills/web-search.js';
 
 // `caps` is the list of capabilities offered this tick (see skills/_agent.js).
 // Only data-backed kinds get a tool — traffic and random-facts are pure
@@ -64,7 +63,7 @@ export function buildSegmentTools(ctx: any, state: any, caps: any[]) {
     });
   }
 
-  if (kinds.has('web-search') && config.search.apiKey) {
+  if (kinds.has('web-search') && searchReady()) {
     tools.searchArtistNews = tool({
       description: 'Search the web for something recent about the artist currently on air.',
       inputSchema: z.object({}),
@@ -73,12 +72,12 @@ export function buildSegmentTools(ctx: any, state: any, caps: any[]) {
         if (!artist || /^unknown/i.test(artist)) return { available: false };
         const alreadySearched = artist === state.lastSearchedArtist;
         try {
-          const data: any = await tavilySearch(`${artist} musician latest news`);
+          const data = await searchWeb(`${artist} musician latest news`);
           state.lastSearchedArtist = artist;
           const answer = (data.answer || '').trim();
           const sources = (data.results || [])
             .slice(0, 3)
-            .map((r: any) => `${r.title}: ${(r.content || '').replace(/\s+/g, ' ').trim().slice(0, 240)}`);
+            .map(r => `${r.title}: ${(r.content || '').replace(/\s+/g, ' ').trim().slice(0, 240)}`);
           if (!answer && sources.length === 0) return { available: false };
           return { artist, alreadySearched, answer, sources };
         } catch (err) {

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -49,6 +49,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
         schedule: s.schedule,
         tts: s.tts,
         llm: s.llm,
+        search: s.search,
         sfx: s.sfx,
       },
       defaults: {
@@ -57,6 +58,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
         personas: settings.getDefaults().personas,
         tts: settings.getDefaults().tts,
         llm: settings.getDefaults().llm,
+        search: settings.getDefaults().search,
       },
       tts: {
         engines: tts.ENGINES,
@@ -70,6 +72,9 @@ router.get('/settings', requireAdmin, async (req, res) => {
         providers: settings.LLM_PROVIDERS,
         active: llmProvider.activeModelLabel(),
       },
+      search: {
+        providers: settings.SEARCH_PROVIDERS,
+      },
       // Which provider API keys are present in the controller's environment.
       // The UI keys its "key missing" alerts off this — keys are configured
       // via controller/.env, never typed into the admin surface.
@@ -81,6 +86,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
         DEEPSEEK_API_KEY: !!process.env.DEEPSEEK_API_KEY,
         OPENROUTER_API_KEY: !!process.env.OPENROUTER_API_KEY,
         AI_GATEWAY_API_KEY: !!process.env.AI_GATEWAY_API_KEY,
+        SEARCH_API_KEY: !!process.env.SEARCH_API_KEY,
       },
       // Skill catalogue — consumed by the Skills page and by Personas for the
       // per-persona skill-assignment checklist.

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -69,6 +69,14 @@ export const LLM_PROVIDERS = [
 // Cloud TTS vendors usable by the `cloud` engine.
 export const TTS_CLOUD_PROVIDERS = ['openai', 'elevenlabs'];
 
+// Web-search backends for the segment director's `web-search` capability.
+// `duckduckgo` is the homelab default — DuckDuckGo's Instant Answer API is free
+// and keyless, returns useful results only for entity / definition queries, and
+// silence otherwise (which the segment director already treats as a valid
+// outcome). `tavily` is the paid option for operators who want richer web
+// results; it reads its key from SEARCH_API_KEY.
+export const SEARCH_PROVIDERS = ['duckduckgo', 'tavily'];
+
 // Canonical mood vocabulary. Shared by the library tagger (music/tag-library.js
 // imports this as MOOD_VOCAB) and the Shows scheduler — a show's `mood`
 // overrides the autonomous dominantMood, so it must come from this list.
@@ -222,6 +230,14 @@ const DEFAULTS = {
     // reports zero listeners — the stream coasts on the auto playlist — and
     // resume as soon as someone tunes in. Off by default.
     pauseWhenEmpty: false,
+  },
+  // Web-search backend for the segment director's web-search capability.
+  // Default `duckduckgo` works out of the box with no key; `tavily` reads its
+  // key from SEARCH_API_KEY (or the optional override below). `apiKey` is
+  // only meaningful for Tavily.
+  search: {
+    provider: 'duckduckgo',
+    apiKey: '',
   },
   skills: {
     enabled: {},
@@ -449,6 +465,12 @@ export async function load() {
           ? stored.llm.pauseWhenEmpty
           : DEFAULTS.llm.pauseWhenEmpty,
     },
+    search: {
+      provider: SEARCH_PROVIDERS.includes(stored.search?.provider)
+        ? stored.search.provider
+        : DEFAULTS.search.provider,
+      apiKey: typeof stored.search?.apiKey === 'string' ? stored.search.apiKey : '',
+    },
     skills: {
       enabled: Object.fromEntries(
         Object.entries(stored.skills?.enabled || {}).filter(([, v]) => typeof v === 'boolean'),
@@ -475,6 +497,7 @@ export function getRedacted() {
   const clone = JSON.parse(JSON.stringify(s));
   if (clone.llm) clone.llm.apiKey = s.llm?.apiKey ? 'set' : '';
   if (clone.tts?.cloud) clone.tts.cloud.apiKey = s.tts?.cloud?.apiKey ? 'set' : '';
+  if (clone.search) clone.search.apiKey = s.search?.apiKey ? 'set' : '';
   return clone;
 }
 
@@ -794,6 +817,22 @@ export async function update(patch) {
     // An OpenAI-compatible provider is useless without a server to talk to.
     if (next.llm.provider === 'openai-compatible' && !next.llm.baseUrl) {
       throw new Error('llm.baseUrl is required when provider is "openai-compatible"');
+    }
+  }
+  if ('search' in patch) {
+    const sr = patch.search || {};
+    if (sr.provider !== undefined) {
+      if (!SEARCH_PROVIDERS.includes(sr.provider)) {
+        throw new Error(`search.provider must be one of: ${SEARCH_PROVIDERS.join(', ')}`);
+      }
+      next.search.provider = sr.provider;
+    }
+    // 'set' is the redaction sentinel from getRedacted() — ignore it so a
+    // round-tripped form doesn't overwrite the real key.
+    if (sr.apiKey !== undefined && sr.apiKey !== 'set') {
+      const v = String(sr.apiKey);
+      if (v.length > 200) throw new Error('search.apiKey must be 0-200 chars');
+      next.search.apiKey = v;
     }
   }
   if ('skills' in patch) {

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -31,12 +31,12 @@
 //   - traffic is only offered during commute hours; web-search only with a key
 
 import { z } from 'zod';
-import { config } from '../config.js';
 import { queue } from '../broadcast/queue.js';
 import * as settings from '../settings.js';
 import { djAgent } from '../llm/sdk.js';
 import { buildContextLines } from '../llm/dj.js';
 import { buildSegmentTools } from '../llm/segment-tools.js';
+import { searchReady } from './web-search.js';
 import * as sfx from '../broadcast/sfx.js';
 
 // Capability table — the single source of truth for the DJ's between-track
@@ -77,9 +77,11 @@ const CAPABILITIES: any[] = [
   {
     kind: 'web-search', skill: 'web-search', label: 'Web search',
     cooldownMs: 60 * 60 * 1000,
-    requiresKey: 'SEARCH_API_KEY',
-    keyUrl: 'https://app.tavily.com/home',
-    ready: () => !!config.search.apiKey,
+    // requiresKey/keyUrl depend on the active search provider — see
+    // skillCatalog() below, which derives them from settings.search.provider.
+    // DuckDuckGo (the default) needs no key; Tavily needs SEARCH_API_KEY (or a
+    // key pasted into the admin UI). searchReady() encapsulates both.
+    ready: () => searchReady(),
     desc: 'Work one genuine, recent detail about the artist on air into a single conversational line — no "I read online", no URLs, no list.',
   },
 ];
@@ -324,7 +326,15 @@ export async function runCapability(which, ctx) {
   const cap = CAPABILITIES.find(c => c.kind === which || c.skill === which);
   if (!cap) throw new Error(`unknown skill: ${which}`);
   if (cap.ready && !cap.ready()) {
-    throw new Error(`skill "${cap.skill}" is not ready${cap.requiresKey ? ` — set ${cap.requiresKey}` : ''}`);
+    // Hint at the missing key when the capability is keyed. web-search is the
+    // only such capability today, and only when Tavily is the active provider.
+    let hint = '';
+    if (cap.kind === 'web-search' && settings.get().search?.provider === 'tavily') {
+      hint = ' — set SEARCH_API_KEY or paste a Tavily key into the admin UI';
+    } else if (cap.requiresKey) {
+      hint = ` — set ${cap.requiresKey}`;
+    }
+    throw new Error(`skill "${cap.skill}" is not ready${hint}`);
   }
 
   const persona = settings.getEffectivePersona(new Date());
@@ -367,18 +377,36 @@ export async function runCapability(which, ctx) {
 // Skill metadata for the admin command-center UI — derived straight from
 // CAPABILITIES. Previously lived in the now-deleted skills/_registry.js.
 export function skillCatalog() {
-  const enabledMap = settings.get().skills?.enabled || {};
-  return CAPABILITIES.map(c => ({
-    name: c.skill,
-    label: c.label || c.skill,
-    description: c.desc || '',
-    kind: c.kind,
-    cooldownMs: c.cooldownMs || 0,
-    enabled: enabledMap[c.skill] !== false,
-    // `ready` is false when the capability needs an env key that isn't set;
-    // `requiresKey` names it and `keyUrl` links the operator to its source.
-    ready: typeof c.ready === 'function' ? !!c.ready() : true,
-    requiresKey: c.requiresKey || null,
-    keyUrl: c.keyUrl || null,
-  }));
+  const s = settings.get();
+  const enabledMap = s.skills?.enabled || {};
+  const searchProvider = s.search?.provider || 'duckduckgo';
+  return CAPABILITIES.map(c => {
+    // web-search's key requirement depends on the active search provider:
+    // Tavily needs SEARCH_API_KEY, DuckDuckGo needs nothing. Other capabilities
+    // carry their requiresKey/keyUrl statically in CAPABILITIES (none today).
+    let requiresKey = c.requiresKey || null;
+    let keyUrl = c.keyUrl || null;
+    if (c.kind === 'web-search') {
+      if (searchProvider === 'tavily') {
+        requiresKey = 'SEARCH_API_KEY';
+        keyUrl = 'https://app.tavily.com/home';
+      } else {
+        requiresKey = null;
+        keyUrl = null;
+      }
+    }
+    return {
+      name: c.skill,
+      label: c.label || c.skill,
+      description: c.desc || '',
+      kind: c.kind,
+      cooldownMs: c.cooldownMs || 0,
+      enabled: enabledMap[c.skill] !== false,
+      // `ready` is false when the capability needs an env key that isn't set;
+      // `requiresKey` names it and `keyUrl` links the operator to its source.
+      ready: typeof c.ready === 'function' ? !!c.ready() : true,
+      requiresKey,
+      keyUrl,
+    };
+  });
 }

--- a/controller/src/skills/web-search.ts
+++ b/controller/src/skills/web-search.ts
@@ -1,22 +1,55 @@
-// Web search helper — queries the Tavily API. Backs the `searchArtistNews`
-// segment tool (llm/segment-tools.js); there is no standalone "web-search
-// skill" object — the segment-director agent (skills/_agent.js) decides when
-// artist news airs.
+// Web search helper — backs the `searchArtistNews` segment tool (llm/
+// segment-tools.js). There is no standalone "web-search skill" object — the
+// segment-director agent (skills/_agent.js) decides when artist news airs.
 //
-// Needs a Tavily key (SEARCH_API_KEY). The agent only offers the web-search
-// capability — and only builds the searchArtistNews tool — when the key is
-// set (see CAPABILITIES.ready in skills/_agent.js).
+// Two backends, chosen via settings.search.provider:
+//   - duckduckgo (default) — DuckDuckGo's Instant Answer API. Free, no key,
+//     officially documented. Returns useful results only for entity / definition
+//     queries; for most artist queries it returns nothing, which the segment
+//     director already treats as a valid (silent) outcome.
+//   - tavily — paid API for richer web results. Reads its key from
+//     settings.search.apiKey, falling back to config.search.apiKey
+//     (SEARCH_API_KEY env var) for back-compat with earlier installs.
+//
+// Both backends return the same shape — { answer, results: [{ title, content }] }
+// — so callers don't have to branch. searchWeb() wraps every call in a 30-min
+// memo to keep the homelab polite under DDG's unofficial fair-use limits and
+// to avoid burning Tavily credits on duplicate ticks.
 
 import { config } from '../config.js';
+import * as settings from '../settings.js';
 
 const TAVILY_ENDPOINT = 'https://api.tavily.com/search';
+const DDG_ENDPOINT = 'https://api.duckduckgo.com/';
 
-export async function tavilySearch(query) {
+type SearchResult = { title: string; content: string };
+type SearchResponse = { answer: string; results: SearchResult[] };
+
+// 30-min TTL cache keyed by `${provider}:${query}`. Same shape as music/picker.js
+// — Map + { val, at }, no LRU eviction (search queries are bounded by the
+// artists actually on rotation, so the Map stays small).
+const CACHE_TTL_MS = 30 * 60 * 1000;
+const cache = new Map<string, { val: SearchResponse; at: number }>();
+
+async function memo(
+  key: string,
+  ttl: number,
+  fn: () => Promise<SearchResponse>,
+): Promise<SearchResponse> {
+  const hit = cache.get(key);
+  if (hit && Date.now() - hit.at < ttl) return hit.val;
+  const val = await fn();
+  cache.set(key, { val, at: Date.now() });
+  return val;
+}
+
+export async function tavilySearch(query: string): Promise<SearchResponse> {
+  const apiKey = settings.get().search?.apiKey || config.search.apiKey;
   const res = await fetch(TAVILY_ENDPOINT, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${config.search.apiKey}`,
+      Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
       query,
@@ -27,5 +60,86 @@ export async function tavilySearch(query) {
     }),
   });
   if (!res.ok) throw new Error(`Tavily HTTP ${res.status}`);
-  return res.json();
+  const data: any = await res.json();
+  return {
+    answer: String(data.answer || '').trim(),
+    results: Array.isArray(data.results)
+      ? data.results.map((r: any) => ({
+          title: String(r.title || ''),
+          content: String(r.content || ''),
+        }))
+      : [],
+  };
+}
+
+// DuckDuckGo Instant Answer API. Returns sparse results — useful for well-known
+// entities (artists with a Wikipedia infobox, common nouns) and silent for most
+// other queries. We map `AbstractText` to the answer slot, and prefer
+// `RelatedTopics[*].Text` for sources.
+//
+// Setting `no_html=1` strips HTML from AbstractText/RelatedTopics; `skip_disambig=1`
+// avoids the "did you mean…" disambiguation pages, which never contain useful
+// detail. We send a real User-Agent — DDG silently 200s with an empty body
+// otherwise.
+export async function duckduckgoSearch(query: string): Promise<SearchResponse> {
+  const url = new URL(DDG_ENDPOINT);
+  url.searchParams.set('q', query);
+  url.searchParams.set('format', 'json');
+  url.searchParams.set('no_html', '1');
+  url.searchParams.set('skip_disambig', '1');
+  url.searchParams.set('no_redirect', '1');
+  const res = await fetch(url, {
+    headers: {
+      'User-Agent': 'SUB-WAVE radio controller (https://github.com/perminder-klair/subwave)',
+    },
+  });
+  if (!res.ok) throw new Error(`DuckDuckGo HTTP ${res.status}`);
+  const data: any = await res.json();
+  const answer = String(data.AbstractText || data.Abstract || '').trim();
+  const topics = Array.isArray(data.RelatedTopics) ? data.RelatedTopics : [];
+  const results: SearchResult[] = [];
+  for (const t of topics) {
+    if (!t) continue;
+    if (Array.isArray(t.Topics)) {
+      // Grouped category — flatten one level deep.
+      for (const sub of t.Topics) {
+        if (sub && typeof sub.Text === 'string' && sub.Text.trim()) {
+          results.push({
+            title: String(sub.Name || data.Heading || ''),
+            content: sub.Text.trim(),
+          });
+        }
+        if (results.length >= 5) break;
+      }
+    } else if (typeof t.Text === 'string' && t.Text.trim()) {
+      results.push({
+        title: String(t.Name || data.Heading || ''),
+        content: t.Text.trim(),
+      });
+    }
+    if (results.length >= 5) break;
+  }
+  return { answer, results: results.slice(0, 5) };
+}
+
+// Provider dispatcher — reads the active provider from live settings on every
+// call so admin-UI changes take effect immediately. Wraps the backend in a
+// 30-min memo so two ticks on the same artist don't issue two outbound calls.
+export async function searchWeb(query: string): Promise<SearchResponse> {
+  const provider = settings.get().search?.provider || 'duckduckgo';
+  const key = `${provider}:${query.toLowerCase()}`;
+  return memo(key, CACHE_TTL_MS, () => {
+    if (provider === 'tavily') return tavilySearch(query);
+    return duckduckgoSearch(query);
+  });
+}
+
+// True when the active search provider is usable right now. DDG always is;
+// Tavily needs a key (settings.search.apiKey, falling back to SEARCH_API_KEY).
+// Imported by the capability gate in skills/_agent.js and the tool registration
+// gate in llm/segment-tools.js so they agree on a single source of truth.
+export function searchReady(): boolean {
+  const s = settings.get().search;
+  if (!s || s.provider === 'duckduckgo') return true;
+  return !!(s.apiKey || config.search.apiKey);
 }

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -19,6 +19,7 @@ import { cn } from '../../lib/cn';
 const SECTIONS = [
   { id: 'tts',     label: 'TTS voice', hint: 'default engine' },
   { id: 'llm',     label: 'LLM provider', hint: 'model routing' },
+  { id: 'search',  label: 'Web search', hint: 'live-facts backend' },
   { id: 'mixer',   label: 'Mixer', hint: 'crossfade · weather' },
   { id: 'jingles', label: 'Jingles', hint: 'stingers' },
   { id: 'sfx',     label: 'Sound FX', hint: 'agent stingers' },
@@ -50,6 +51,14 @@ const LLM_PROVIDER_LABELS: Record<string, string> = {
 const llmProviderLabel = (id: string | undefined): string =>
   (id && LLM_PROVIDER_LABELS[id]) || id || '—';
 
+const SEARCH_PROVIDER_LABELS: Record<string, string> = {
+  duckduckgo: 'DuckDuckGo — free, no key',
+  tavily: 'Tavily — paid web search',
+};
+
+const searchProviderLabel = (id: string | undefined): string =>
+  (id && SEARCH_PROVIDER_LABELS[id]) || id || '—';
+
 interface WeatherCfg {
   lat: string;
   lng: string;
@@ -79,12 +88,18 @@ interface LlmForm {
   pauseWhenEmpty: boolean;
 }
 
+interface SearchForm {
+  provider: string;
+  apiKey: string;
+}
+
 interface FormState {
   jingleRatio: string;
   crossfadeDuration: string;
   weather: WeatherCfg;
   tts: TtsForm;
   llm: LlmForm;
+  search: SearchForm;
 }
 
 interface JingleEntry {
@@ -119,6 +134,7 @@ interface SettingsData {
       cloud?: Partial<CloudTtsCfg>;
     };
     llm?: Partial<LlmForm>;
+    search?: Partial<SearchForm>;
     sfx?: { enabled?: boolean };
   };
   tts?: {
@@ -130,6 +146,12 @@ interface SettingsData {
   llm?: {
     providers?: string[];
     active?: string;
+  };
+  search?: {
+    providers?: string[];
+  };
+  defaults?: {
+    search?: Partial<SearchForm>;
   };
   jingles?: JingleEntry[];
   env?: Record<string, unknown>;
@@ -214,6 +236,12 @@ export default function SettingsPanel() {
         reasoning: !!v.llm?.reasoning,
         pickerAgent: !!v.llm?.pickerAgent,
         pauseWhenEmpty: !!v.llm?.pauseWhenEmpty,
+      },
+      search: {
+        provider: v.search?.provider ?? 'duckduckgo',
+        // GET /settings returns the apiKey redacted to 'set' | '' — that
+        // round-trips through POST harmlessly (settings.update ignores 'set').
+        apiKey: v.search?.apiKey ?? '',
       },
     });
   }, [data, form]);
@@ -445,6 +473,12 @@ export default function SettingsPanel() {
             )}
             {activeSection === 'llm' && data.llm && (
               <LlmSection
+                data={data} form={form} setForm={updateForm} busy={busy}
+                saveMsg={saveMsg} saveSettings={saveSettings}
+              />
+            )}
+            {activeSection === 'search' && (
+              <SearchSection
                 data={data} form={form} setForm={updateForm} busy={busy}
                 saveMsg={saveMsg} saveSettings={saveSettings}
               />
@@ -1070,6 +1104,121 @@ function LlmSection({ data, form, setForm, busy, saveMsg, saveSettings }: Sectio
         saveMsg={saveMsg}
         onSave={save}
         saveLabel="Save LLM provider"
+      />
+    </>
+  );
+}
+
+/* ── Web search ──────────────────────────────────────────────────────── */
+
+function SearchSection({ data, form, setForm, busy, saveMsg, saveSettings }: SectionProps) {
+  const save = () => saveSettings({
+    search: {
+      provider: form.search.provider,
+      // Don't echo back 'set' — that's the redaction sentinel from getRedacted().
+      // The controller's update() ignores it, but skipping it keeps the patch tidy.
+      ...(form.search.apiKey && form.search.apiKey !== 'set'
+        ? { apiKey: form.search.apiKey }
+        : {}),
+    },
+  });
+
+  const savedSearch = data.values?.search || {};
+  const providers = data.search?.providers || ['duckduckgo', 'tavily'];
+  const provider = form.search.provider;
+  const searchDirty = provider !== savedSearch.provider
+    || (provider === 'tavily'
+        && form.search.apiKey
+        && form.search.apiKey !== 'set'
+        && form.search.apiKey !== (savedSearch.apiKey || ''));
+  const tavilyKeySet = form.search.apiKey === 'set' || !!data.env?.SEARCH_API_KEY;
+
+  return (
+    <>
+      <SectionHeader
+        eyebrow="web search"
+        title="Where the DJ gets live facts about the artist on air."
+        sub={<>
+          The segment director can air a single line of recent artist context between
+          tracks — when the active backend returns something worth saying. DuckDuckGo
+          is free and keyless; Tavily is paid but returns full web results. Switching
+          here reroutes the next call — no restart.
+        </>}
+        metrics={[{ n: String(providers.length), l: 'providers' }]}
+      />
+
+      <Card title="Provider" sub="active backend">
+        <div className="grid gap-[18px]">
+          <div className="flex items-start gap-2.5 border border-[var(--accent)] bg-[var(--ink-softer)] p-3">
+            <span className="mt-1 size-1.5 flex-none rounded-full bg-vermilion" />
+            <div className="grid min-w-0 gap-0.5">
+              <span className="text-[11px] font-bold tracking-[0.12em] text-vermilion uppercase">
+                Routing now · {searchProviderLabel(savedSearch.provider || 'duckduckgo')}
+              </span>
+              <span className="text-[11px] leading-[1.5] text-muted">
+                {searchDirty
+                  ? <>Your edits below aren&apos;t live until you Save.</>
+                  : <>This is the saved, running config.</>}
+              </span>
+            </div>
+          </div>
+
+          <div className="field">
+            <div className="flex items-center gap-2">
+              <Label>Provider</Label>
+              {searchDirty && <Pill tone="accent" dot>unsaved</Pill>}
+            </div>
+            <Select
+              value={provider}
+              onValueChange={v => setForm(f => ({ ...f, search: { ...f.search, provider: v } }))}
+            >
+              <SelectTrigger className="max-w-[360px]"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {providers.map(p => (
+                    <SelectItem key={p} value={p}>{searchProviderLabel(p)}</SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+            <div className="field-hint">
+              {provider === 'duckduckgo'
+                ? 'DuckDuckGo Instant Answer — free, no key. Useful for definitions and well-known entities; silent otherwise. The segment director treats silence as a valid outcome.'
+                : 'Tavily — paid web search with full results and an answer summary. Needs an API key.'}
+            </div>
+          </div>
+
+          {provider === 'tavily' && (
+            <>
+              <div className="field">
+                <Label>Tavily API key</Label>
+                <Input
+                  type="password"
+                  value={form.search.apiKey === 'set' ? '' : form.search.apiKey}
+                  placeholder={form.search.apiKey === 'set' ? '•••••• (key on file)' : 'tvly-…'}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                    setForm(f => ({ ...f, search: { ...f.search, apiKey: e.target.value } }))
+                  }
+                  className="max-w-[360px]"
+                />
+                <div className="field-hint">
+                  Stored alongside the other admin settings. Falls back to
+                  <code> SEARCH_API_KEY</code> in <code>controller/.env</code> when blank — set
+                  one or the other, not both.
+                </div>
+              </div>
+              <KeyStatus envVar="SEARCH_API_KEY" present={tavilyKeySet} />
+            </>
+          )}
+        </div>
+      </Card>
+
+      <SaveBar
+        note="Applies to the next web-search call — no restart needed."
+        busy={busy}
+        saveMsg={saveMsg}
+        onSave={save}
+        saveLabel="Save web search"
       />
     </>
   );


### PR DESCRIPTION
## Summary

The `web-search` skill needed a paid Tavily key (`SEARCH_API_KEY`); without it the segment-director agent never aired artist-news beats. Adds DuckDuckGo's keyless **Instant Answer API** as a second backend behind a `tavily | duckduckgo` provider registry, defaulting to DDG so a fresh install gets live artist context out of the box.

- New backend module behaviour in `controller/src/skills/web-search.ts`:
  - `duckduckgoSearch(query)` — `GET https://api.duckduckgo.com/?…` with `format=json&no_html=1&skip_disambig=1`, no auth, real User-Agent, parses `AbstractText` + `RelatedTopics[*].Text` into the same `{ answer, results }` shape Tavily returns.
  - `searchWeb(query)` — dispatcher that reads the active provider from live settings on every call, wrapped in a 30-min memo cache keyed by `${provider}:${query.toLowerCase()}`.
  - `searchReady()` — central gate so the capability and the tool registration agree on a single source of truth.
- `controller/src/settings.ts` — `SEARCH_PROVIDERS = ['duckduckgo','tavily']`, `DEFAULTS.search = { provider: 'duckduckgo', apiKey: '' }`, validator on `update()`, `getRedacted()` masks `search.apiKey` to `'set'|''`.
- `controller/src/skills/_agent.ts` and `controller/src/llm/segment-tools.ts` — `web-search` capability and `searchArtistNews` tool registration now both key off `searchReady()`. `requiresKey`/`keyUrl` are computed in `skillCatalog()` from the active provider (Tavily → `SEARCH_API_KEY` + Tavily console URL, DDG → null).
- `controller/src/routes/settings.ts` — `GET /settings` surfaces `values.search`, `defaults.search`, `search.providers`, and `env.SEARCH_API_KEY`.
- `web/components/admin/SettingsPanel.tsx` — new **Web search** admin section with the provider dropdown; the Tavily API-key field + `KeyStatus` indicator only render when Tavily is the active provider. Saved key falls back to `SEARCH_API_KEY` env when blank.

DDG returns useful results only for entity / definition queries; silence on miss is the default and the segment director already treats silence as a valid (often preferred) outcome — so the tool returns `{ available: false }` and the agent either fires another capability or stays quiet.

Resolves #46.

## Test plan

- [ ] `cd docker && docker compose up -d --build controller` (source is baked at build time — restart isn't enough).
- [ ] `curl http://localhost:7701/settings | jq '.skills.catalog[] | select(.name=="web-search")'` → with no Tavily key set, `ready: true`, `requiresKey: null` (DDG default).
- [ ] Trigger the web-search capability via `POST /dj/skill` with `{ "which": "web-search" }` for a well-known artist (e.g. The Beatles) — DDG returns an AbstractText, the DJ airs one line.
- [ ] Trigger the same for an obscure artist — DDG returns nothing, tool returns `{ available: false }`, no 500 in the controller log, fallback flow takes over.
- [ ] Open `http://localhost:7700/admin/settings` → **Web search** section appears. Switch to Tavily without a key → capability flips to `ready: false`; paste a key + save → `ready: true`, no controller restart needed. Switch back to DuckDuckGo → ready immediately.
- [ ] Hit the same artist twice within 30 min — second call is served from the memo cache (no second outbound `fetch` to `api.duckduckgo.com`).
- [ ] `npm run lint` in `controller/` and `web/` — both 0 errors (matches `main` baseline of `no-explicit-any` warnings only).