### PR TITLE
World-context overrides for themed stations

### DIFF
--- a/controller/src/context.ts
+++ b/controller/src/context.ts
@@ -2,7 +2,7 @@
 // Used by the autonomous scheduler to pick mood-appropriate tracks.
 
 import { config } from './config.js';
-import { resolveActiveShow } from './settings.js';
+import { resolveActiveShow, get as getSettings } from './settings.js';
 import { getListenerCount } from './broadcast/listeners.js';
 
 export function getTimeContext(date = new Date()) {
@@ -37,16 +37,24 @@ const FESTIVALS = [
   { month: 12, day: 31, name: "New Year's Eve", mood: 'celebratory' },
 ];
 
-export function getFestivalContext(date = new Date()) {
+// Match a single date against a festival list. Shared by the hardcoded
+// Earth calendar (getFestivalContext) and operator-supplied custom lists
+// (settings.world.festivals.custom).
+function matchFestival(list: any[], date: Date) {
+  if (!Array.isArray(list) || !list.length) return null;
   const m = date.getMonth() + 1;
   const d = date.getDate();
-  for (const f of FESTIVALS) {
+  for (const f of list) {
     const window = f.windowDays || 0;
     if (f.month === m && Math.abs(f.day - d) <= window) {
       return { name: f.name, mood: f.mood };
     }
   }
   return null;
+}
+
+export function getFestivalContext(date = new Date()) {
+  return matchFestival(FESTIVALS, date);
 }
 
 // Weather via Open-Meteo (no API key required)
@@ -152,10 +160,43 @@ export function getClockContext(date = new Date()) {
 export async function getFullContext() {
   const now = new Date();
   const time = getTimeContext(now);
-  const weather = await getWeather();
-  const festival = getFestivalContext(now);
+  const rawWeather = await getWeather();
+  const rawFestival = getFestivalContext(now);
   const date = getDateContext(now);
   const clock = getClockContext(now);
+
+  // Themed-station overrides: rewrite what the DJ *thinks* the world looks
+  // like, before mood derivation, so every downstream consumer (DJ prompts,
+  // picker, scheduler, segment director) sees the rewritten world.
+  const world = (getSettings() as any)?.world || {};
+  const themedLocation =
+    typeof world.location === 'string' && world.location.trim() ? world.location.trim() : null;
+
+  let weather = themedLocation
+    ? { ...rawWeather, location: themedLocation }
+    : rawWeather;
+
+  if (world.weather?.enabled) {
+    const text = typeof world.weather.text === 'string' ? world.weather.text.trim() : '';
+    weather = {
+      condition: text || 'unknown', // 'unknown' suppresses the weather line in buildContextLines
+      mood: null,
+      temp: null,
+      location: themedLocation || rawWeather.location,
+      override: true,
+    } as any;
+  }
+
+  // Festivals: when disabled, hardcoded list is silenced; custom list (if any)
+  // still applies. When enabled, custom entries layer on top of the hardcoded
+  // calendar (hardcoded wins on a tie because matchFestival short-circuits).
+  let festival = rawFestival;
+  const customFestivals = Array.isArray(world.festivals?.custom) ? world.festivals.custom : [];
+  if (world.festivals?.enabled === false) {
+    festival = matchFestival(customFestivals, now);
+  } else if (customFestivals.length) {
+    festival = rawFestival || matchFestival(customFestivals, now);
+  }
 
   // A scheduled show for this hour, if any. Its mood wins everything below —
   // an empty hour leaves the station running autonomously.

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -21,10 +21,9 @@ export { recentCalls };
 // otherwise the admin-selected active persona — see settings.getEffectivePersona.
 export function djSystem() {
   const persona = settings.getEffectivePersona();
-  return settings.renderDjPrompt(persona, {
-    station: 'SUB/WAVE',
-    location: settings.get().weather?.locationName,
-  });
+  // No explicit location passed — renderDjPrompt resolves world.location
+  // (themed override) before falling back to the real weather.locationName.
+  return settings.renderDjPrompt(persona, { station: 'SUB/WAVE' });
 }
 
 // Persona-driven verbosity. 'concise' reproduces the historical one-liner

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -232,6 +232,30 @@ const DEFAULTS = {
   sfx: {
     enabled: true,
   },
+  // Themed-station overrides. Real lat/lng + weather.locationName still drive
+  // Open-Meteo; these reshape what the DJ *thinks* the world looks like so
+  // operators can run themed stations (deep space, fantasy kingdom, etc.)
+  // without the DJ breaking character with real Earth weather/holidays.
+  world: {
+    // Free-text location, e.g. "deep space, year 2387". Empty = use the real
+    // weather.locationName for {location} substitution.
+    location: '',
+    weather: {
+      // When true, real Open-Meteo conditions are suppressed in the DJ context.
+      enabled: false,
+      // Verbatim flavour string read on air ("solar wind quiet, magnetosphere
+      // stable"). Empty + enabled = weather line dropped entirely.
+      text: '',
+    },
+    festivals: {
+      // When false, the hardcoded Western/UK FESTIVALS list is ignored.
+      enabled: true,
+      // Operator-supplied custom calendar entries. Same shape as the hardcoded
+      // list: { month: 1-12, day: 1-31, name, mood, windowDays? }. Layered on
+      // top of the built-in list when enabled; replaces it when not.
+      custom: [],
+    },
+  },
 };
 
 const BOUNDS = {
@@ -457,8 +481,56 @@ export async function load() {
     sfx: {
       enabled: typeof stored.sfx?.enabled === 'boolean' ? stored.sfx.enabled : DEFAULTS.sfx.enabled,
     },
+    world: normalizeWorld(stored.world),
   };
   return cache;
+}
+
+// Lenient on load: clamp/coerce, never throw. The strict counterpart
+// validateWorldStrict() runs from update() with the operator's edits.
+function normalizeWorld(raw: any) {
+  const r = raw && typeof raw === 'object' ? raw : {};
+  const w = r.weather && typeof r.weather === 'object' ? r.weather : {};
+  const f = r.festivals && typeof r.festivals === 'object' ? r.festivals : {};
+  return {
+    location: typeof r.location === 'string' ? r.location.trim().slice(0, 120) : '',
+    weather: {
+      enabled: typeof w.enabled === 'boolean' ? w.enabled : false,
+      text: typeof w.text === 'string' ? w.text.trim().slice(0, 200) : '',
+    },
+    festivals: {
+      enabled: typeof f.enabled === 'boolean' ? f.enabled : true,
+      custom: normalizeCustomFestivals(f.custom),
+    },
+  };
+}
+
+function normalizeCustomFestivals(raw: any) {
+  if (!Array.isArray(raw)) return [];
+  const out: any[] = [];
+  for (const item of raw) {
+    const f = normalizeCustomFestival(item);
+    if (f) out.push(f);
+    if (out.length >= 60) break;
+  }
+  return out;
+}
+
+function normalizeCustomFestival(raw: any) {
+  if (!raw || typeof raw !== 'object') return null;
+  const month = Number.parseInt(raw.month, 10);
+  const day = Number.parseInt(raw.day, 10);
+  if (!Number.isFinite(month) || month < 1 || month > 12) return null;
+  if (!Number.isFinite(day) || day < 1 || day > 31) return null;
+  const name = typeof raw.name === 'string' ? raw.name.trim().slice(0, 60) : '';
+  if (!name) return null;
+  const mood = typeof raw.mood === 'string' && SHOW_MOODS.includes(raw.mood) ? raw.mood : 'celebratory';
+  const out: any = { month, day, name, mood };
+  if (raw.windowDays !== undefined && raw.windowDays !== null && raw.windowDays !== '') {
+    const wd = Number.parseInt(raw.windowDays, 10);
+    if (Number.isFinite(wd) && wd >= 0 && wd <= 14) out.windowDays = wd;
+  }
+  return out;
 }
 
 export function get() {
@@ -598,6 +670,80 @@ function validateShowsStrict(raw, personas) {
     seen.add(id);
     return { id, name, topic, personaId: item.personaId, mood: item.mood };
   });
+}
+
+function validateWorldStrict(raw, cur) {
+  const r = raw && typeof raw === 'object' ? raw : {};
+  const out = JSON.parse(JSON.stringify(cur));
+
+  if (r.location !== undefined) {
+    const v = String(r.location ?? '').trim();
+    if (v.length > 120) throw new Error('world.location must be 0-120 chars');
+    out.location = v;
+  }
+
+  if (r.weather !== undefined) {
+    const w = r.weather && typeof r.weather === 'object' ? r.weather : {};
+    if (w.enabled !== undefined) out.weather.enabled = !!w.enabled;
+    if (w.text !== undefined) {
+      const v = String(w.text ?? '').trim();
+      if (v.length > 200) throw new Error('world.weather.text must be 0-200 chars');
+      out.weather.text = v;
+    }
+  }
+
+  if (r.festivals !== undefined) {
+    const f = r.festivals && typeof r.festivals === 'object' ? r.festivals : {};
+    if (f.enabled !== undefined) out.festivals.enabled = !!f.enabled;
+    if (f.custom !== undefined) {
+      if (!Array.isArray(f.custom)) {
+        throw new Error('world.festivals.custom must be an array');
+      }
+      if (f.custom.length > 60) {
+        throw new Error('world.festivals.custom must be at most 60 entries');
+      }
+      const seen = new Set<string>();
+      out.festivals.custom = f.custom.map((item: any, i: number) => {
+        if (!item || typeof item !== 'object') {
+          throw new Error(`world.festivals.custom[${i}] must be an object`);
+        }
+        const month = Number.parseInt(item.month, 10);
+        if (!Number.isFinite(month) || month < 1 || month > 12) {
+          throw new Error(`world.festivals.custom[${i}].month must be 1-12`);
+        }
+        const day = Number.parseInt(item.day, 10);
+        if (!Number.isFinite(day) || day < 1 || day > 31) {
+          throw new Error(`world.festivals.custom[${i}].day must be 1-31`);
+        }
+        const name = String(item.name ?? '').trim();
+        if (name.length < 1 || name.length > 60) {
+          throw new Error(`world.festivals.custom[${i}].name must be 1-60 chars`);
+        }
+        const moodRaw = String(item.mood ?? 'celebratory').trim();
+        if (!SHOW_MOODS.includes(moodRaw)) {
+          throw new Error(
+            `world.festivals.custom[${i}].mood must be one of: ${SHOW_MOODS.join(', ')}`,
+          );
+        }
+        const key = `${month}-${day}-${name.toLowerCase()}`;
+        if (seen.has(key)) {
+          throw new Error(`world.festivals.custom[${i}] duplicates an earlier entry`);
+        }
+        seen.add(key);
+        const entry: any = { month, day, name, mood: moodRaw };
+        if (item.windowDays !== undefined && item.windowDays !== null && item.windowDays !== '') {
+          const wd = Number.parseInt(item.windowDays, 10);
+          if (!Number.isFinite(wd) || wd < 0 || wd > 14) {
+            throw new Error(`world.festivals.custom[${i}].windowDays must be 0-14`);
+          }
+          entry.windowDays = wd;
+        }
+        return entry;
+      });
+    }
+  }
+
+  return out;
 }
 
 function validateScheduleStrict(raw, shows) {
@@ -816,6 +962,9 @@ export async function update(patch) {
       next.sfx.enabled = !!sx.enabled;
     }
   }
+  if ('world' in patch) {
+    next.world = validateWorldStrict(patch.world, next.world);
+  }
 
   // Post-patch integrity sweep — a personas/shows change in this patch may
   // have orphaned a show owner, a schedule slot, or the active persona.
@@ -887,7 +1036,11 @@ export function getEffectivePersona(date: Date = new Date()) {
 // the global djPrompt (falling back to DEFAULT_DJ_PROMPT_TEMPLATE).
 export function renderDjPrompt(persona: any, ctx: any = {}) {
   const station = ctx.station || 'SUB/WAVE';
-  const location = ctx.location || (cache?.weather?.locationName ?? DEFAULTS.weather.locationName);
+  const worldLocation = cache?.world?.location?.trim?.() || '';
+  const location =
+    ctx.location ||
+    worldLocation ||
+    (cache?.weather?.locationName ?? DEFAULTS.weather.locationName);
   const tpl =
     cache?.djPrompt && cache.djPrompt.trim() ? cache.djPrompt : DEFAULT_DJ_PROMPT_TEMPLATE;
   const rendered = tpl

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -20,6 +20,7 @@ const SECTIONS = [
   { id: 'tts',     label: 'TTS voice', hint: 'default engine' },
   { id: 'llm',     label: 'LLM provider', hint: 'model routing' },
   { id: 'mixer',   label: 'Mixer', hint: 'crossfade · weather' },
+  { id: 'world',   label: 'World', hint: 'themed overrides' },
   { id: 'jingles', label: 'Jingles', hint: 'stingers' },
   { id: 'sfx',     label: 'Sound FX', hint: 'agent stingers' },
 ] as const;
@@ -79,12 +80,27 @@ interface LlmForm {
   pauseWhenEmpty: boolean;
 }
 
+interface CustomFestival {
+  month: string;
+  day: string;
+  name: string;
+  mood: string;
+  windowDays: string;
+}
+
+interface WorldForm {
+  location: string;
+  weather: { enabled: boolean; text: string };
+  festivals: { enabled: boolean; custom: CustomFestival[] };
+}
+
 interface FormState {
   jingleRatio: string;
   crossfadeDuration: string;
   weather: WeatherCfg;
   tts: TtsForm;
   llm: LlmForm;
+  world: WorldForm;
 }
 
 interface JingleEntry {
@@ -120,6 +136,14 @@ interface SettingsData {
     };
     llm?: Partial<LlmForm>;
     sfx?: { enabled?: boolean };
+    world?: {
+      location?: string;
+      weather?: { enabled?: boolean; text?: string };
+      festivals?: {
+        enabled?: boolean;
+        custom?: Array<{ month?: number; day?: number; name?: string; mood?: string; windowDays?: number }>;
+      };
+    };
   };
   tts?: {
     engines?: string[];
@@ -214,6 +238,23 @@ export default function SettingsPanel() {
         reasoning: !!v.llm?.reasoning,
         pickerAgent: !!v.llm?.pickerAgent,
         pauseWhenEmpty: !!v.llm?.pauseWhenEmpty,
+      },
+      world: {
+        location: v.world?.location ?? '',
+        weather: {
+          enabled: !!v.world?.weather?.enabled,
+          text: v.world?.weather?.text ?? '',
+        },
+        festivals: {
+          enabled: v.world?.festivals?.enabled !== false,
+          custom: (v.world?.festivals?.custom ?? []).map(c => ({
+            month: c.month != null ? String(c.month) : '',
+            day: c.day != null ? String(c.day) : '',
+            name: c.name ?? '',
+            mood: c.mood ?? 'celebratory',
+            windowDays: c.windowDays != null ? String(c.windowDays) : '',
+          })),
+        },
       },
     });
   }, [data, form]);
@@ -451,6 +492,12 @@ export default function SettingsPanel() {
             )}
             {activeSection === 'mixer' && (
               <MixerSection
+                data={data} form={form} setForm={updateForm} busy={busy}
+                saveMsg={saveMsg} saveSettings={saveSettings}
+              />
+            )}
+            {activeSection === 'world' && (
+              <WorldSection
                 data={data} form={form} setForm={updateForm} busy={busy}
                 saveMsg={saveMsg} saveSettings={saveSettings}
               />
@@ -1160,6 +1207,8 @@ function MixerSection({ data, form, setForm, busy, saveMsg, saveSettings }: Sect
           <div className="field-hint">
             Where the station broadcasts from — sets the DJ’s {'{location}'} and the Open-Meteo
             weather it reads on air (current: {data.values?.weather?.locationName} @ {data.values?.weather?.lat}, {data.values?.weather?.lng}). Applies live.
+            For themed stations (deep space, fantasy kingdom, etc.) use the <strong>World</strong>{' '}
+            tab to override what the DJ <em>thinks</em> these values are.
           </div>
         </div>
       </Card>
@@ -1170,6 +1219,306 @@ function MixerSection({ data, form, setForm, busy, saveMsg, saveSettings }: Sect
         saveMsg={saveMsg}
         onSave={save}
         saveLabel="Save mixer settings"
+      />
+    </>
+  );
+}
+
+/* ── World ───────────────────────────────────────────────────────────── */
+
+const WORLD_MOODS = [
+  'celebratory',
+  'reflective',
+  'festival',
+  'cultural',
+  'spiritual',
+  'romantic',
+  'energetic',
+  'calm',
+  'night',
+  'morning',
+  'evening',
+  'rainy',
+  'sunny',
+  'focus',
+  'workout',
+  'driving',
+  'cooking',
+];
+
+function emptyCustomFestival(): CustomFestival {
+  return { month: '', day: '', name: '', mood: 'celebratory', windowDays: '' };
+}
+
+function WorldSection({ data, form, setForm, busy, saveMsg, saveSettings }: SectionProps) {
+  const w = form.world;
+
+  const save = () => {
+    // Strict-side wants numeric month/day; trim out blank rows entirely.
+    const custom = w.festivals.custom
+      .map(c => ({
+        month: c.month.trim(),
+        day: c.day.trim(),
+        name: c.name.trim(),
+        mood: c.mood,
+        windowDays: c.windowDays.trim(),
+      }))
+      .filter(c => c.month || c.day || c.name)
+      .map(c => {
+        const entry: Record<string, unknown> = {
+          month: Number.parseInt(c.month, 10),
+          day: Number.parseInt(c.day, 10),
+          name: c.name,
+          mood: c.mood,
+        };
+        if (c.windowDays) entry.windowDays = Number.parseInt(c.windowDays, 10);
+        return entry;
+      });
+    saveSettings({
+      world: {
+        location: w.location,
+        weather: { enabled: w.weather.enabled, text: w.weather.text },
+        festivals: { enabled: w.festivals.enabled, custom },
+      },
+    });
+  };
+
+  const setWorld = (mut: (curr: WorldForm) => WorldForm) =>
+    setForm(f => ({ ...f, world: mut(f.world) }));
+
+  const addFestival = () => setWorld(curr => ({
+    ...curr,
+    festivals: { ...curr.festivals, custom: [...curr.festivals.custom, emptyCustomFestival()] },
+  }));
+
+  const removeFestival = (i: number) => setWorld(curr => ({
+    ...curr,
+    festivals: { ...curr.festivals, custom: curr.festivals.custom.filter((_, j) => j !== i) },
+  }));
+
+  const updateFestival = (i: number, patch: Partial<CustomFestival>) => setWorld(curr => ({
+    ...curr,
+    festivals: {
+      ...curr.festivals,
+      custom: curr.festivals.custom.map((c, j) => (j === i ? { ...c, ...patch } : c)),
+    },
+  }));
+
+  const realLocation = data.values?.weather?.locationName ?? '—';
+  const themedActive = !!data.values?.world?.location?.trim();
+  const weatherActive = !!data.values?.world?.weather?.enabled;
+  const festivalsHardcodedOff = data.values?.world?.festivals?.enabled === false;
+
+  return (
+    <>
+      <SectionHeader
+        eyebrow="world"
+        title="Themed-station overrides."
+        sub={<>
+          Reshape what the DJ <em>thinks</em> the world looks like, without
+          touching the real station location. Useful for themed stations
+          (deep space, fantasy kingdom, post-apocalyptic city) where the DJ
+          shouldn’t break character by reading real Earth weather or wishing
+          listeners a happy Bonfire Night. The Mixer tab still owns the real
+          lat/lng that Open-Meteo queries — these settings change how the
+          fetched values are presented to the DJ.
+        </>}
+        metrics={[
+          { n: themedActive ? 'on' : 'off', l: 'location', accent: themedActive },
+          { n: weatherActive ? 'on' : 'off', l: 'weather', accent: weatherActive },
+          { n: festivalsHardcodedOff ? 'off' : 'on', l: 'earth fests', accent: !festivalsHardcodedOff },
+        ]}
+      />
+
+      <Card title="Themed location" sub="overrides {location} in DJ prompts">
+        <div className="field">
+          <Label>Themed location</Label>
+          <Input
+            placeholder="e.g. deep space, year 2387"
+            value={w.location}
+            maxLength={120}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setWorld(curr => ({ ...curr, location: e.target.value }))
+            }
+          />
+          <div className="field-hint">
+            Replaces the {'{location}'} placeholder in DJ prompts. Leave empty
+            to use the Mixer station name (currently <strong>{realLocation}</strong>).
+            The Mixer lat/lng still drive Open-Meteo regardless. Applies live.
+          </div>
+        </div>
+      </Card>
+
+      <Card title="Weather override" sub="silence or rewrite the on-air weather line">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="text-[13px] font-bold">Override real weather</div>
+            <div className="mt-0.5 max-w-[480px] text-[11px] leading-[1.5] text-muted">
+              When on, the DJ stops reading the real Open-Meteo conditions and
+              uses the text below instead. Empty text + on = the weather line
+              is dropped entirely.
+            </div>
+          </div>
+          <Seg
+            accent
+            value={w.weather.enabled ? 'on' : 'off'}
+            options={[
+              { id: 'off', label: 'Off' },
+              { id: 'on', label: 'On' },
+            ]}
+            onChange={v => setWorld(curr => ({
+              ...curr,
+              weather: { ...curr.weather, enabled: v === 'on' },
+            }))}
+          />
+        </div>
+
+        <div className="field mt-4">
+          <Label>Weather flavour</Label>
+          <Input
+            placeholder="e.g. solar wind quiet, magnetosphere stable"
+            value={w.weather.text}
+            maxLength={200}
+            disabled={!w.weather.enabled}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setWorld(curr => ({ ...curr, weather: { ...curr.weather, text: e.target.value } }))
+            }
+          />
+          <div className="field-hint">
+            The DJ reads this verbatim as the current conditions. Keep it short
+            — one clause works best. {w.weather.text.length}/200.
+          </div>
+        </div>
+      </Card>
+
+      <Card title="Festivals" sub="hardcoded Earth calendar + custom entries">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="text-[13px] font-bold">Use built-in Earth holiday calendar</div>
+            <div className="mt-0.5 max-w-[480px] text-[11px] leading-[1.5] text-muted">
+              When off, the hardcoded Western/UK calendar (Christmas, Halloween,
+              Diwali, etc.) is silenced. Any custom entries below still apply.
+            </div>
+          </div>
+          <Seg
+            accent
+            value={w.festivals.enabled ? 'on' : 'off'}
+            options={[
+              { id: 'off', label: 'Off' },
+              { id: 'on', label: 'On' },
+            ]}
+            onChange={v => setWorld(curr => ({
+              ...curr,
+              festivals: { ...curr.festivals, enabled: v === 'on' },
+            }))}
+          />
+        </div>
+
+        <div className="field mt-4">
+          <Label>Custom festivals</Label>
+          <div className="field-hint mb-2">
+            Operator-supplied fixed-date entries. Month 1–12, day 1–31. Window
+            days widens the match around the date (e.g. 1 = also fires the day
+            before and after). Mood drives the autonomous track picker.
+          </div>
+
+          {w.festivals.custom.length === 0 && (
+            <div className="text-[11px] text-muted italic">
+              No custom festivals yet.
+            </div>
+          )}
+
+          <div className="grid gap-2">
+            {w.festivals.custom.map((c, i) => (
+              <div
+                key={i}
+                className="flex flex-wrap items-end gap-2 border border-separator-strong p-2"
+              >
+                <div className="grid gap-1">
+                  <span className="text-[9px] tracking-[0.18em] text-muted uppercase">month</span>
+                  <Input
+                    className="mono-num w-[72px]"
+                    type="number"
+                    min={1}
+                    max={12}
+                    value={c.month}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => updateFestival(i, { month: e.target.value })}
+                  />
+                </div>
+                <div className="grid gap-1">
+                  <span className="text-[9px] tracking-[0.18em] text-muted uppercase">day</span>
+                  <Input
+                    className="mono-num w-[72px]"
+                    type="number"
+                    min={1}
+                    max={31}
+                    value={c.day}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => updateFestival(i, { day: e.target.value })}
+                  />
+                </div>
+                <div className="grid min-w-[180px] flex-1 gap-1">
+                  <span className="text-[9px] tracking-[0.18em] text-muted uppercase">name</span>
+                  <Input
+                    placeholder="e.g. Stardate Eve"
+                    value={c.name}
+                    maxLength={60}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => updateFestival(i, { name: e.target.value })}
+                  />
+                </div>
+                <div className="grid gap-1">
+                  <span className="text-[9px] tracking-[0.18em] text-muted uppercase">mood</span>
+                  <Select
+                    value={c.mood}
+                    onValueChange={(v) => updateFestival(i, { mood: v })}
+                  >
+                    <SelectTrigger className="w-[160px]">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        {WORLD_MOODS.map(m => (
+                          <SelectItem key={m} value={m}>{m}</SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="grid gap-1">
+                  <span className="text-[9px] tracking-[0.18em] text-muted uppercase">window</span>
+                  <Input
+                    className="mono-num w-[72px]"
+                    type="number"
+                    min={0}
+                    max={14}
+                    placeholder="0"
+                    value={c.windowDays}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => updateFestival(i, { windowDays: e.target.value })}
+                  />
+                </div>
+                <Btn sm tone="danger" onClick={() => removeFestival(i)}>
+                  Remove
+                </Btn>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-3">
+            <Btn sm onClick={addFestival} disabled={w.festivals.custom.length >= 60}>
+              Add festival
+            </Btn>
+            <span className="ml-3 text-[10px] tracking-[0.14em] text-muted uppercase">
+              {w.festivals.custom.length}/60
+            </span>
+          </div>
+        </div>
+      </Card>
+
+      <SaveBar
+        note="World overrides apply live · no mixer restart needed."
+        busy={busy}
+        saveMsg={saveMsg}
+        onSave={save}
+        saveLabel="Save world settings"
       />
     </>
   );


### PR DESCRIPTION
Closes #48.

Lets operators reshape what the DJ *thinks* the world looks like — location, weather, and festivals — without touching the real Open-Meteo coordinates. Useful for themed stations (deep space, fantasy kingdom, post-apocalyptic) where the DJ shouldn't break character with real Earth weather or wish listeners a happy Bonfire Night.

## Summary

- New `settings.world` namespace (`controller/src/settings.ts`):
  - `world.location` — free-text override for the `{location}` placeholder in DJ prompts. Empty = real `weather.locationName`.
  - `world.weather.enabled` + `world.weather.text` — when on, suppresses real Open-Meteo conditions; with text, the DJ reads that string verbatim; empty + on drops the weather line entirely.
  - `world.festivals.enabled` — toggle for the hardcoded Western/UK calendar.
  - `world.festivals.custom` — operator-supplied fixed-date entries `{ month, day, name, mood, windowDays? }`. Layered on top of the built-in list when enabled; replaces it when not.
- Overrides applied inside `getFullContext()` (`controller/src/context.ts`) so every downstream consumer (DJ prompts, picker, scheduler, segment director, session keying) sees the rewritten world with zero call-site changes. Festival matcher extracted into a small helper reused by hardcoded + custom lists.
- `renderDjPrompt` now consults `world.location` between the explicit `ctx.location` and the real `weather.locationName` fallback. `djSystem()` no longer passes `location` explicitly so the new precedence applies.
- New **World** admin tab (`web/components/admin/SettingsPanel.tsx`) between Mixer and Jingles with three cards: themed location, weather override (toggle + text), festivals (toggle + custom-list editor with month/day/name/mood/window). Mixer "Station location" card stays intact; its hint now points to the World tab for themed stations.

Time-style override (stardate / 24h / 12h) is **deferred** — the issue marks it lower priority and it can be added later in isolation.

## Test plan

- [ ] Default behaviour unchanged — leave World tab pristine, controller still reads real location + real weather. Check `/debug`.
- [ ] Location-only override — set `world.location = "deep space, year 2387"`, confirm `{location}` substitution and the `Weather in …` line both use it.
- [ ] Weather override on + text — confirm DJ uses the verbatim string and temperature clause is dropped.
- [ ] Weather override on + empty text — confirm the weather line is absent from `buildContextLines`.
- [ ] Festivals off on a real festival date — confirm `context.festival` is null.
- [ ] Custom festival on today's date — confirm it appears in `context.festival` and the picker pulls mood-tagged tracks.
- [ ] Settings persist across controller restart (`state/settings.json` round-trip).
- [ ] No mixer restart required for any of the above (only crossfade still needs one).