### PR TITLE
skill: add subwave-worktree-dev for running the dev stack from a worktree

### DIFF
--- a/.claude/skills/subwave-worktree-dev/SKILL.md
+++ b/.claude/skills/subwave-worktree-dev/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: subwave-worktree-dev
+description: >-
+  Stage a SUB/WAVE git worktree so the dev stack can run from it, then start it.
+  A git worktree only checks out tracked files — the dev stack also needs
+  gitignored files (controller/.env, web/.env.local, docker/.env, web/node_modules,
+  and a state/ directory) that this skill copies or scaffolds from the main
+  working tree. Use this skill whenever the user wants to test branch changes in
+  a worktree, run subwave from a worktree, "prep"/"set up" a worktree for dev
+  mode, or asks to copy env files / node_modules / state into a worktree —
+  phrases like "test this worktree in dev mode", "start subwave from the
+  worktree", "prep the worktree", "run my branch locally", "copy the required
+  files into the worktree". Do NOT use it for the main checkout (that's
+  subwave-control) or for production.
+---
+
+# SUB/WAVE worktree dev setup
+
+Get the SUB/WAVE dev stack running from inside a **git worktree** so branch
+changes can be tested without touching the main checkout.
+
+## Why a worktree needs prep
+
+A worktree checks out every **tracked** file, so all source is already there.
+But the dev stack also depends on **gitignored** files that do not travel with
+a worktree checkout:
+
+| File | Why the stack needs it |
+|---|---|
+| `controller/.env` | Dev compose declares `env_file: ../controller/.env` — the controller container will not start without it. Holds Navidrome + Ollama config. |
+| `web/.env.local` | Dev API/stream URL overrides (`NEXT_PUBLIC_API_URL` etc.). Without it the web UI defaults to same-origin `/api` and cannot reach the controller. |
+| `docker/.env` | Compose variable substitution. |
+| `web/node_modules` | Needed by `npm run dev`. |
+| `state/` | Bind-mounted into the containers; `state/icecast.xml` is mounted straight into the icecast container. A worktree's `state/` is empty. |
+
+`state/` is scaffolded **fresh** — directory structure only. Settings, sessions,
+queue, and library mood data are *not* copied, so the worktree station boots
+clean and the controller writes its own defaults. The sole copied file is
+`state/icecast.xml`: it is a rendered config carrying the Icecast passwords and
+cannot be regenerated without the operator's inputs.
+
+## Two load-bearing facts
+
+1. **One stack at a time.** Both compose files use fixed container names
+   (`sub-wave-icecast`, …) and host ports (Web `7700`, Controller `7701`,
+   Icecast `7702`). A worktree stack and the main-checkout stack collide — stop
+   whatever is running before starting another.
+2. **Controller changes need `--build`, web changes do not.** The `controller`
+   image `COPY`s its source at build time, so testing worktree controller code
+   requires `docker compose up -d --build`. The web dev server (`npm run dev`)
+   hot-reloads from the worktree filesystem, so UI changes appear with no build.
+
+## Workflow
+
+### Step 0 — Identify the worktree
+
+The target worktree is usually the session's current directory. Confirm it is a
+linked worktree and not the main checkout:
+
+```bash
+git rev-parse --absolute-git-dir          # a worktree's is <main>/.git/worktrees/<name>
+git worktree list                         # shows the main tree + every linked worktree
+```
+
+If the user named a specific worktree path, use that.
+
+### Step 1 — Stop any running stack
+
+Only one stack can run. Stop whatever is up (it may be the main checkout's):
+
+```bash
+# Kill the web dev server if it holds :7700 — but only if it is `node`,
+# never macOS ControlCenter/AirPlay.
+WEB_PID=$(lsof -nP -iTCP:7700 -sTCP:LISTEN -t 2>/dev/null | head -1)
+[ -n "$WEB_PID" ] && ps -p "$WEB_PID" -o comm= | grep -qi node && kill "$WEB_PID"
+
+# Bring down whichever dev stack is up (run from any checkout's docker/ dir —
+# same compose project name, so this targets the running containers).
+docker compose -f <some-checkout>/docker/docker-compose.yml down
+```
+
+### Step 2 — Prep the worktree
+
+Run the bundled script. It copies the env files, scaffolds a fresh `state/`,
+and runs `npm install` for the web app. `<skill base directory>` is the
+absolute path shown as "Base directory for this skill" when the skill loads.
+
+```bash
+bash "<skill base directory>/scripts/prep-worktree.sh" <worktree-path>
+```
+
+Flags: `--reset-state` wipes and re-scaffolds `state/` (use when the user wants
+a clean slate); `--skip-npm` skips the dependency install (use when
+`node_modules` is already good). The script is idempotent — re-running it only
+fills in what is missing.
+
+### Step 3 — Start the stack from the worktree
+
+```bash
+cd <worktree-path>/docker && docker compose up -d --build
+```
+
+`--build` is required so the worktree's controller source is baked into the
+image. The first build is slow (all services); later builds only rebuild
+changed layers. Then start the web dev server **in the background** (it is a
+long-running foreground process):
+
+```bash
+cd <worktree-path>/web && npm run dev
+```
+
+### Step 4 — Verify on-air
+
+Give Liquidsoap ~5s to connect to Icecast, then probe the controller:
+
+```bash
+sleep 5
+curl -sf http://localhost:7701/health                               # expect {"status":"on-air"}
+curl -sf -o /dev/null -w '%{http_code}\n' http://localhost:7700      # expect 200
+```
+
+If `/health` fails, peek at `docker compose logs --tail=30 controller liquidsoap`
+and surface the error. A fresh `state/` is normal — an empty queue and default
+settings on first boot are expected, not faults.
+
+## Iterating
+
+- **Web/UI change** — nothing to do; `npm run dev` hot-reloads it.
+- **Controller source change** — rebuild just that service:
+  `cd <worktree-path>/docker && docker compose up -d --build controller`.
+- **`liquidsoap/radio.liq` change** — it is bind-mounted; just
+  `docker compose restart liquidsoap`.
+
+## Allowed without confirmation
+
+- Running `scripts/prep-worktree.sh` (copies env files, scaffolds `state/`, `npm install`)
+- `docker compose up -d --build` / `down` against a worktree's dev compose file
+- `npm run dev` / killing a `node` process on `:7700`
+- Reading logs, `curl` health probes
+
+## Confirm before running
+
+- `--reset-state` when `state/` already has real data the user may want
+- `docker compose down -v` (wipes volumes)
+- Killing a non-`node` process on `:7700`
+- Touching the **main checkout's** `controller/.env`, `state/`, or config
+
+## When NOT to use this skill / hand off
+
+- **Main checkout**, not a worktree → use `subwave-control` to start/stop.
+- **Production** (`docker-compose.prod.yml`) → use `subwave-control`.
+- First-time repo setup, `git pull` + rebuild, jingle generation, config
+  changes → use `subwave-deploy`.

--- a/.claude/skills/subwave-worktree-dev/scripts/prep-worktree.sh
+++ b/.claude/skills/subwave-worktree-dev/scripts/prep-worktree.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# prep-worktree.sh — stage a SUB/WAVE git worktree so it can run the dev stack.
+#
+# A git worktree checks out every TRACKED file, but the dev stack also needs
+# a handful of gitignored files that do NOT travel with the checkout:
+#   - controller/.env   (Navidrome + Ollama config; dev compose env_file)
+#   - web/.env.local    (dev API/stream URL overrides for the web UI)
+#   - docker/.env       (compose variable substitution)
+#   - web/node_modules  (needed by `npm run dev`)
+#   - state/            (bind-mounted into the containers)
+#
+# This copies the env files from the main working tree, runs npm install, and
+# scaffolds a FRESH state/ directory — structure only. It deliberately does NOT
+# copy settings.json, session.json, queue.json, moods.json, or any archived
+# sessions/jingles/voice files, so the worktree station boots clean and the
+# controller writes its own defaults. The one exception is state/icecast.xml:
+# that is a rendered config (carries the Icecast passwords) and cannot be
+# regenerated without the operator's inputs, so it is copied as-is.
+#
+# Usage:
+#   prep-worktree.sh [worktree-path]   # worktree-path defaults to $PWD
+#   prep-worktree.sh --reset-state     # wipe + re-scaffold state/ first
+#   prep-worktree.sh --skip-npm        # skip the npm install step
+
+set -euo pipefail
+
+WORKTREE=""
+RESET_STATE=0
+SKIP_NPM=0
+for arg in "$@"; do
+  case "$arg" in
+    --reset-state) RESET_STATE=1 ;;
+    --skip-npm)    SKIP_NPM=1 ;;
+    -h|--help)     grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*)            echo "unknown flag: $arg" >&2; exit 2 ;;
+    *)             WORKTREE="$arg" ;;
+  esac
+done
+
+WORKTREE="${WORKTREE:-$PWD}"
+[ -d "$WORKTREE" ] || { echo "error: no such directory: $WORKTREE" >&2; exit 1; }
+WORKTREE="$(cd "$WORKTREE" && pwd)"
+
+# The main working tree is the parent of the shared (common) .git directory.
+# For a linked worktree, --git-common-dir points back at the main repo's .git.
+GIT_COMMON="$(git -C "$WORKTREE" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || {
+  echo "error: $WORKTREE is not inside a git repository" >&2; exit 1; }
+MAIN="$(cd "$(dirname "$GIT_COMMON")" && pwd)"
+
+if [ "$MAIN" = "$WORKTREE" ]; then
+  echo "error: $WORKTREE IS the main working tree — there is nothing to prep." >&2
+  echo "       Use the subwave-control skill to start the stack directly." >&2
+  exit 1
+fi
+
+echo "[prep] main working tree: $MAIN"
+echo "[prep] target worktree:   $WORKTREE"
+
+# ── env files ───────────────────────────────────────────────────────────────
+copy_env() {
+  local rel="$1"
+  local src="$MAIN/$rel"
+  local dst="$WORKTREE/$rel"
+  if [ ! -e "$src" ]; then
+    echo "[prep] skip   $rel — not present in main; the stack may not work without it"
+    return
+  fi
+  if [ -e "$dst" ]; then
+    echo "[prep] keep   $rel — already in worktree (left untouched)"
+    return
+  fi
+  mkdir -p "$(dirname "$dst")"
+  cp "$src" "$dst"
+  echo "[prep] copied $rel"
+}
+
+copy_env controller/.env
+copy_env web/.env.local
+copy_env docker/.env
+
+# ── fresh state/ scaffold ───────────────────────────────────────────────────
+STATE="$WORKTREE/state"
+if [ "$RESET_STATE" = 1 ] && [ -d "$STATE" ]; then
+  echo "[prep] --reset-state: removing $STATE"
+  rm -rf "$STATE"
+fi
+
+mkdir -p "$STATE"/logs "$STATE"/voice "$STATE"/jingles "$STATE"/sessions "$STATE"/archive "$STATE"/sfx
+
+# icecast.xml — rendered config with the Icecast source/admin passwords.
+# Regenerating it needs the operator's password inputs (subwave-deploy /
+# setup.sh territory), so copy main's. The icecast container bind-mounts this
+# file directly; if it is missing the container cannot boot.
+if [ ! -f "$STATE/icecast.xml" ]; then
+  if [ -f "$MAIN/state/icecast.xml" ]; then
+    cp "$MAIN/state/icecast.xml" "$STATE/icecast.xml"
+    echo "[prep] copied state/icecast.xml (rendered config — required by the icecast container)"
+  else
+    echo "[prep] WARNING: $MAIN/state/icecast.xml is missing — run setup.sh in main first (subwave-deploy)" >&2
+  fi
+fi
+
+# Liquidsoap starts BEFORE the controller, so these must exist at boot or
+# radio.liq errors on the missing read. The controller would otherwise write
+# them on startup (see controller/src/settings.ts). Values are the code
+# defaults: jingleRatio 30, crossfadeDuration 10.0.
+[ -f "$STATE/liquidsoap_jingle_ratio.txt" ] || { echo 30   > "$STATE/liquidsoap_jingle_ratio.txt"; echo "[prep] wrote state/liquidsoap_jingle_ratio.txt (30)"; }
+[ -f "$STATE/liquidsoap_crossfade.txt" ]    || { echo 10.0 > "$STATE/liquidsoap_crossfade.txt";    echo "[prep] wrote state/liquidsoap_crossfade.txt (10.0)"; }
+
+# Playlists liquidsoap watches with reload_mode="watch" — must exist as files.
+[ -f "$STATE/auto.m3u" ]    || { : > "$STATE/auto.m3u";    echo "[prep] touched state/auto.m3u (empty — controller refills it)"; }
+[ -f "$STATE/jingles.m3u" ] || { : > "$STATE/jingles.m3u"; echo "[prep] touched state/jingles.m3u (empty — run generate-jingles.sh later if wanted)"; }
+
+echo "[prep] state/ scaffolded fresh — no settings/sessions/queue/moods copied; the controller writes defaults on first boot."
+
+# ── web dependencies ────────────────────────────────────────────────────────
+if [ "$SKIP_NPM" = 1 ]; then
+  echo "[prep] --skip-npm: leaving web/node_modules as-is"
+elif [ -d "$WORKTREE/web/node_modules" ]; then
+  echo "[prep] web/node_modules already present — skipping npm install"
+else
+  echo "[prep] installing web dependencies (npm install — can take a few minutes)…"
+  ( cd "$WORKTREE/web" && npm install )
+  echo "[prep] web dependencies installed"
+fi
+
+cat <<EOM
+
+[prep] done. Start the dev stack from the worktree:
+  cd "$WORKTREE/docker" && docker compose up -d --build   # --build bakes worktree controller changes into the image
+  cd "$WORKTREE/web"    && npm run dev                     # web hot-reloads — run this in the background
+
+Verify on-air (give Liquidsoap ~5s to connect):
+  curl -sf http://localhost:7701/health    # expect {"status":"on-air"}
+  curl -sf -o /dev/null -w '%{http_code}\\n' http://localhost:7700   # expect 200
+EOM


### PR DESCRIPTION
## Summary

- New `.claude/skills/subwave-worktree-dev` skill — stages a git worktree so the SUB/WAVE dev stack can run from it
- A worktree only checks out tracked files; this copies the gitignored ones the stack needs (`controller/.env`, `web/.env.local`, `docker/.env`), runs `npm install`, and scaffolds a **fresh** `state/` (structure only — no settings/sessions/queue/moods, so the worktree station boots clean). `state/icecast.xml` is the one copied file since it's a rendered config carrying the Icecast passwords.
- Bundles `scripts/prep-worktree.sh` (idempotent; `--reset-state` / `--skip-npm` flags); SKILL.md covers stopping a colliding stack, the controller `--build` requirement, and health verification.

Separate from PR #58 (Chatterbox) on purpose — this is dev infrastructure, not part of the feature.

## Test plan

- [ ] From a linked worktree, run `prep-worktree.sh` → confirms env files copied, `state/` scaffolded, `node_modules` installed
- [ ] `docker compose up -d --build` from the worktree → controller builds from worktree source; `/health` returns `{"status":"on-air"}`
- [ ] Re-run `prep-worktree.sh` → idempotent, only fills missing pieces
- [ ] Run against the main checkout → script exits with the "nothing to prep" error