### PR TITLE
web: add Google Analytics visitor tracking

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -123,6 +123,9 @@ services:
         # statically-rendered routes (robots, sitemap, /listen, /landing,
         # /manual, /setup) — Next bakes their metadata at build.
         - SITE_URL=${SITE_URL:-}
+        # Google Analytics Measurement ID (e.g. G-XXXXXXXXXX). NEXT_PUBLIC_*
+        # is inlined into the client bundle at BUILD time. Unset → no tracking.
+        - NEXT_PUBLIC_GA_ID=${NEXT_PUBLIC_GA_ID:-}
     container_name: sub-wave-web
     restart: unless-stopped
     depends_on:

--- a/web/.env.example
+++ b/web/.env.example
@@ -12,6 +12,13 @@
 # unset and everything falls back to the localhost origin, which is correct.
 # SITE_URL=https://radio.example.com
 
+# Google Analytics 4 Measurement ID for visitor tracking. When set, the
+# gtag.js script loads on every page and pageviews are captured automatically.
+# Leave unset to disable analytics entirely. In production set it in
+# docker/.env — compose passes it as a build arg (NEXT_PUBLIC_* is baked into
+# the client bundle at build time, so a runtime env var alone has no effect).
+# NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
+
 # What renders at /. `landing` shows the marketing broadsheet with the live
 # player embedded inline. `player` shows the existing fullscreen listener UI.
 # Default: player. Set to `landing` on the public marketing host

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -19,6 +19,11 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # (docker-compose.prod.yml → web.build.args). Unset → localhost fallback.
 ARG SITE_URL
 ENV SITE_URL=${SITE_URL}
+# Google Analytics Measurement ID. NEXT_PUBLIC_* vars are inlined into the
+# client bundle at build time, so this must be present here, not at runtime.
+# Unset → no analytics script is emitted.
+ARG NEXT_PUBLIC_GA_ID
+ENV NEXT_PUBLIC_GA_ID=${NEXT_PUBLIC_GA_ID}
 RUN npm run build
 
 # ---- runner ----

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -2,9 +2,14 @@ import './globals.css';
 import type { Metadata, Viewport } from 'next';
 import type { ReactNode } from 'react';
 import { JetBrains_Mono } from 'next/font/google';
+import { GoogleAnalytics } from '@next/third-parties/google';
 import { THEME_INIT_SCRIPT } from '@/lib/theme';
 import { SITE_URL } from '@/lib/site';
 import ServiceWorkerRegister from '@/components/ServiceWorkerRegister';
+
+// Visitor tracking. The gtag.js script only loads when a Measurement ID is
+// configured, so dev and un-instrumented deploys stay analytics-free.
+const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
 
 const jetbrainsMono = JetBrains_Mono({
   subsets: ['latin', 'latin-ext'],
@@ -88,6 +93,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <ServiceWorkerRegister />
         {children}
       </body>
+      {GA_ID ? <GoogleAnalytics gaId={GA_ID} /> : null}
     </html>
   );
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@next/third-parties": "^16.2.6",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -1334,6 +1335,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.2.6.tgz",
+      "integrity": "sha512-PDPIPVj1NX6Taxsl8OJteAUJ7iwR+QrokwWig68eh0cOmuNjC6MBL+ZzBjO8Bv0n/HOSqjGArZpM5KMSUxm+MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7508,6 +7522,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@next/third-parties": "^16.2.6",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",


### PR DESCRIPTION
## What

Adds Google Analytics 4 visitor tracking to the web app via Next.js's official `@next/third-parties` integration, wired into the root layout so every route is covered.

## Changes

- **`web/app/layout.tsx`** — renders `<GoogleAnalytics gaId={GA_ID} />` when `NEXT_PUBLIC_GA_ID` is set; emits nothing otherwise.
- **`web/package.json`** — adds `@next/third-parties`.
- **`web/Dockerfile`** — adds `NEXT_PUBLIC_GA_ID` build arg (`NEXT_PUBLIC_*` vars are inlined into the client bundle at build time, not runtime).
- **`docker/docker-compose.prod.yml`** — passes `NEXT_PUBLIC_GA_ID` through to the web build.
- **`web/.env.example`** — documents the variable.

## How to enable

1. Create a GA4 property and copy the Measurement ID (`G-XXXXXXXXXX`).
2. **Production:** add `NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX` to `docker/.env`, then rebuild the web image (`docker compose -f docker/docker-compose.prod.yml up -d --build web`) — a restart won't pick it up since the ID is baked into the bundle.
3. **Dev:** add it to `web/.env.local` and restart `npm run dev`.

Pageviews (including App Router client-side navigations) are captured automatically. The `gtag.js` script only loads when the ID is present, so dev and un-instrumented deploys stay tracking-free.

## Testing

- `npm run build` passes with `NEXT_PUBLIC_GA_ID` set.