### PR TITLE
web: glassy player drawers

### DIFF
--- a/web/components/ui/sheet.tsx
+++ b/web/components/ui/sheet.tsx
@@ -13,7 +13,8 @@ export interface SheetProps {
 }
 
 /* V3 Sheet — right-side drawer between the top and bottom bars (offset 80px
-   each), 460px wide, cream background, 1px ink borders, animates in from the
+   each), 460px wide, glassy cream wash over a backdrop-filter blur so the
+   center-stage art bleeds through, 1px ink borders, animates in from the
    right via v3-drawer-content keyframe in globals.css. No exit animation.
    When `container` is supplied the drawer is scoped to that element (used
    for the embedded player on the landing page); otherwise it covers the
@@ -29,7 +30,10 @@ export function Sheet({ open, onOpenChange, title, children, container }: SheetP
         />
         <Dialog.Content
           className={cn(
-            'v3-drawer-content z-50 flex flex-col border-x border-ink bg-bg text-ink shadow-drawer',
+            'v3-drawer-content z-50 flex flex-col border-x border-ink text-ink shadow-drawer',
+            'bg-[color-mix(in_oklab,var(--bg)_55%,transparent)]',
+            '[backdrop-filter:blur(14px)_saturate(1.6)_brightness(1.04)]',
+            '[-webkit-backdrop-filter:blur(14px)_saturate(1.6)_brightness(1.04)]',
             pos,
             contained
               ? 'top-16 right-4 bottom-16 w-[min(420px,calc(100%-32px))]'

--- a/web/components/ui/sheet.tsx
+++ b/web/components/ui/sheet.tsx
@@ -31,9 +31,9 @@ export function Sheet({ open, onOpenChange, title, children, container }: SheetP
         <Dialog.Content
           className={cn(
             'v3-drawer-content z-50 flex flex-col border-x border-ink text-ink shadow-drawer',
-            'bg-[color-mix(in_oklab,var(--bg)_55%,transparent)]',
-            '[backdrop-filter:blur(14px)_saturate(1.6)_brightness(1.04)]',
-            '[-webkit-backdrop-filter:blur(14px)_saturate(1.6)_brightness(1.04)]',
+            'bg-[color-mix(in_oklab,var(--bg)_30%,transparent)]',
+            '[backdrop-filter:blur(28px)_saturate(1.9)_brightness(1.07)]',
+            '[-webkit-backdrop-filter:blur(28px)_saturate(1.9)_brightness(1.07)]',
             pos,
             contained
               ? 'top-16 right-4 bottom-16 w-[min(420px,calc(100%-32px))]'


### PR DESCRIPTION
## Summary
- Swap the solid cream `bg-bg` on `Sheet` for a `color-mix(... var(--bg) 55%, transparent)` wash with a `backdrop-filter: blur(14px) saturate(1.6) brightness(1.04)` so the timeline / booth / request drawers feel like the Tap-to-Tune-In overlay — the center-stage art bleeds through instead of being hidden.

## Test plan
- [ ] `npm run dev` in `web/`, open the player, hit `1`, `2`, `3` — each drawer should read as glassy cream over the live art, with text still legible.
- [ ] Check in dark mode (`--bg` flips to near-black) that contrast is still fine.
- [ ] Open the embedded player on `/landing` and confirm the contained drawer variant also blurs its frame, not the page behind it.