### PR TITLE
fix(controller): make liquidsoap reachable from a natively-run controller

### DIFF
--- a/controller/.env.example
+++ b/controller/.env.example
@@ -46,6 +46,14 @@ TTS_SPEED=0.85
 # Icecast — must match docker-compose
 ICECAST_SOURCE_PASSWORD=changeme
 
+# Liquidsoap telnet — only override when running the controller OUTSIDE the
+# docker-compose network (e.g. `npm run dev` natively while liquidsoap stays
+# in docker). The dev compose binds 127.0.0.1:1234 for this case. When the
+# controller runs inside compose, leave this unset — the default 'liquidsoap'
+# service hostname resolves over the compose network.
+# LIQUIDSOAP_HOST=localhost
+# LIQUIDSOAP_PORT=1234
+
 # Server
 PORT=7701
 

--- a/controller/src/broadcast/liquidsoap-control.ts
+++ b/controller/src/broadcast/liquidsoap-control.ts
@@ -24,7 +24,20 @@ export function sendCommand(cmd: string, timeoutMs = 3000): Promise<string> {
 
     sock.setTimeout(timeoutMs);
     sock.on('timeout', () => finish(new Error('liquidsoap telnet timeout')));
-    sock.on('error', err => finish(err));
+    sock.on('error', err => {
+      // ENOTFOUND means the controller can't resolve the liquidsoap hostname —
+      // almost always because it's running outside the compose network. Surface
+      // a hint instead of the raw DNS error so the next operator doesn't have
+      // to dig (see issue #62).
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOTFOUND' || code === 'EAI_AGAIN') {
+        finish(new Error(
+          `liquidsoap host "${HOST}:${PORT}" did not resolve — set LIQUIDSOAP_HOST=localhost in controller/.env if the controller is running outside docker-compose (and ensure liquidsoap's port 1234 is exposed on the host)`
+        ));
+        return;
+      }
+      finish(err);
+    });
     sock.on('connect', () => sock.write(`${cmd}\n`));
     sock.on('data', (chunk: Buffer) => {
       buf += chunk.toString();

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -45,6 +45,12 @@ services:
       # (e.g. NAVIDROME_URL=http://host.docker.internal:4533) without leaking
       # the lookup to public DNS.
       - "host.docker.internal:host-gateway"
+    # Telnet control port — bound to loopback only so a natively-run controller
+    # (`npm run dev` outside compose) can reach it via LIQUIDSOAP_HOST=localhost.
+    # In-compose controllers reach liquidsoap over the default network and
+    # don't need this; this exposure is dev-only.
+    ports:
+      - "127.0.0.1:1234:1234"
     volumes:
       - ../liquidsoap/radio.liq:/etc/liquidsoap/radio.liq:ro
       - ../sounds:/sounds:ro


### PR DESCRIPTION
## Summary
- Dev `docker-compose.yml` now binds liquidsoap telnet on `127.0.0.1:1234` so a controller running natively (`npm run dev`) outside the compose network can reach it. Prod / byo-proxy stay internal-only.
- `controller/.env.example` documents `LIQUIDSOAP_HOST` / `LIQUIDSOAP_PORT` and when to use them (only when controller is outside compose).
- `liquidsoap-control.ts` catches `ENOTFOUND` / `EAI_AGAIN` from the telnet socket and rethrows with a hint pointing at the env var, instead of the raw DNS error.

## Why
The controller's `LIQUIDSOAP_HOST` defaults to the compose service name `liquidsoap`, which only resolves on the compose network. Users running the controller natively (Mac smoke-test workflow in CLAUDE.md) hit `getaddrinfo ENOTFOUND liquidsoap` on every skip / restart / stream control call. Telnet port 1234 was also internal-only in the dev compose, so even the `LIQUIDSOAP_HOST=localhost` workaround in #62 wouldn't reach anything without manually editing the compose file.

Refs #62.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `docker compose -f docker/docker-compose.yml config` validates
- [ ] Native `npm run dev` controller can skip a track with `LIQUIDSOAP_HOST=localhost`
- [ ] In-compose controller still works with no env override (default `liquidsoap` hostname)
- [ ] Bad host produces the new hint message instead of raw ENOTFOUND