### PR TITLE
fix(web): drop misleading pseudo-random visualiser fallback

### DIFF
--- a/web/components/Waveform.tsx
+++ b/web/components/Waveform.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useRef, useState, type RefObject } from 'react';
-import { useAnalyser, useSpectrum } from '@/lib/hooks';
+import { useEffect, useRef, type RefObject } from 'react';
+import { useAnalyser } from '@/lib/hooks';
 import { cn } from '@/lib/cn';
 
 const BARS = 120;
@@ -16,16 +16,25 @@ export default function Waveform({ audioRef, tunedIn, progress }: WaveformProps)
   const { ready, read } = useAnalyser(audioRef, tunedIn);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const rafRef = useRef<number | null>(null);
-  const fallback = useSpectrum(BARS, tunedIn && !ready, 60);
-  const [, force] = useState(0);
 
-  // Drive real-analyser bars via rAF when available; otherwise the fallback
-  // effect below paints heights from the pseudo-random spectrum. Bar heights
-  // are written via DOM mutation in both paths so the component stays free of
-  // inline style props (issue #50).
+  // Drive bars via rAF when the real analyser is attached. When it isn't —
+  // notably iOS Safari, where createMediaElementSource on a streaming MP3
+  // returns silence — bars stay at their default static height rather than
+  // running a pseudo-random animation that misleads listeners into thinking
+  // the visualisation tracks the music.
   useEffect(() => {
+    const clearHeights = () => {
+      const container = containerRef.current;
+      if (!container) return;
+      const spans = container.querySelectorAll<HTMLSpanElement>('[data-bar]');
+      for (let i = 0; i < spans.length; i++) {
+        const span = spans[i];
+        if (span) span.style.height = '';
+      }
+    };
     if (!ready || !tunedIn) {
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      clearHeights();
       return;
     }
     const tick = () => {
@@ -45,23 +54,6 @@ export default function Waveform({ audioRef, tunedIn, progress }: WaveformProps)
     tick();
     return () => { if (rafRef.current) cancelAnimationFrame(rafRef.current); };
   }, [ready, tunedIn, read]);
-
-  // Fallback: paint pseudo-random bar heights when the real analyser hasn't
-  // attached yet (CORS, iOS Safari, paused stream, etc.).
-  useEffect(() => {
-    if (ready && tunedIn) return;
-    const container = containerRef.current;
-    if (!container) return;
-    const spans = container.querySelectorAll<HTMLSpanElement>('[data-bar]');
-    for (let i = 0; i < spans.length; i++) {
-      const span = spans[i];
-      if (span) span.style.height = `${10 + Math.pow(fallback[i] ?? 0.1, 0.7) * 95}%`;
-    }
-  }, [fallback, ready, tunedIn]);
-
-  // When the real analyser is in charge, suppress the fallback array influence;
-  // we still need a single re-render to flip data attributes on mount.
-  useEffect(() => { force(x => x + 1); }, [ready, tunedIn]);
 
   const usingReal = ready && tunedIn;
 

--- a/web/lib/hooks.ts
+++ b/web/lib/hooks.ts
@@ -12,23 +12,6 @@ export function useClock(): Date | null {
   return t;
 }
 
-// Pseudo-random animated spectrum used as fallback when the real analyser
-// can't attach (CORS, paused, no AudioContext, etc.). Values in [0, 1].
-export function useSpectrum(bins = 120, active = true, speed = 60): number[] {
-  const [arr, setArr] = useState<number[]>(() => Array(bins).fill(0.1));
-  useEffect(() => {
-    if (!active) return;
-    const id = setInterval(() => {
-      setArr(prev => prev.map((v, i) => {
-        const target = Math.pow(Math.random(), 1.4) * (1 - i / (bins * 2.2));
-        return v + (target - v) * 0.45;
-      }));
-    }, speed);
-    return () => clearInterval(id);
-  }, [active, bins, speed]);
-  return arr;
-}
-
 export interface Analyser {
   ready: boolean;
   read: () => Uint8Array<ArrayBuffer> | null;
@@ -44,7 +27,7 @@ interface WebkitWindow {
 // the first time `active` flips true, then writes per-frame frequency bytes
 // into an internal ref read via `read()`. Returns `{ ready, read }`. If CORS
 // or anything else blocks attachment, `ready` stays false and `read()` returns
-// null — callers should fall back to `useSpectrum`.
+// null — callers should render static bars (no fake reactive animation).
 export function useAnalyser(
   audioRef: RefObject<HTMLAudioElement | null> | null | undefined,
   active: boolean,
@@ -84,9 +67,10 @@ export function useAnalyser(
         setReady(true);
 
         // iOS Safari quirk: createMediaElementSource() on a live HTTP MP3 stream
-        // wires up cleanly but the analyser only ever returns zeros. Probe once
-        // after playback actually starts — if no samples land in ~600 ms, flip
-        // ready=false so the pseudo-random useSpectrum fallback takes over.
+        // wires up cleanly but the analyser only ever returns zeros (WebKit
+        // limitation, no app-level workaround for live streams). Probe once
+        // after playback starts — if no samples land in ~600 ms, flip
+        // ready=false so callers render static bars instead.
         if (probedRef.current) return;
         onPlaying = () => {
           if (probedRef.current || cancelled) return;


### PR DESCRIPTION
## Summary
- iOS Safari's `createMediaElementSource` on a streaming HTTP MP3 returns all zeros from the analyser — a WebKit limitation with no app-level workaround for live streams. The existing 600 ms zeros-probe correctly detected this and flipped `ready=false`, but `Waveform` then switched to a `Math.random()`-driven `useSpectrum` animation that had no relationship to the audio. iOS listeners reasonably read the "random wobble that doesn't track the song" as a bug.
- Drop the `useSpectrum` fallback entirely. When the real analyser isn't available, clear any stale inline heights so bars sit at the Tailwind default `h-[10%]` — honest static bars instead of fake reactive ones. Progress colouring (vermilion vs ink) still moves through the bars.
- Chrome/Firefox paths are unchanged: the real analyser still drives bar heights via rAF.

## Test plan
- [ ] Tune in on iOS Safari → bars sit static at ~10% height; progress fill still advances.
- [ ] Tune in on desktop Chrome/Firefox → bars react to FFT data as before.
- [ ] Tune out and tune back in on iOS → no leftover heights from a previous session; bars remain static.