### PR TITLE
style(web): tighten landing header/footer spacing

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -411,7 +411,7 @@ body::after {
     align-items: center;
     justify-content: center;
     gap: 14px;
-    padding: 12px 0;
+    padding: 12px 0 4px;
     flex-wrap: wrap;
 }
 .bs-masthead-link {

--- a/web/components/landing/StationFooter.tsx
+++ b/web/components/landing/StationFooter.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 
 export default function StationFooter({ djName }: { djName?: string }) {
   return (
-    <footer className="flex flex-col gap-[14px]">
+    <footer className="mt-16 flex flex-col gap-[14px]">
       <div className="bs-rule-double" />
       <div className="flex flex-wrap items-baseline justify-between gap-4 py-5 text-[11px] tracking-[0.18em] text-muted uppercase">
         <span className="font-bold text-ink">SUB/WAVE · EST. 2026</span>


### PR DESCRIPTION
## Summary
- Add `mt-16` to `StationFooter` so the footer has breathing room above its top rule.
- Reduce `.bs-masthead-nav` bottom padding from `12px` to `4px` so the nav row sits closer to the closing double rule.

## Test plan
- [x] Visual check on `/landing` — header bottom feels tighter, footer no longer hugs the preceding section.
- [x] Verify nothing else uses `.bs-masthead-nav` (currently only the landing Masthead).