### PR TITLE
revert(web): restore pseudo-random waveform fallback for iOS Safari

### DIFF
--- a/web/components/Waveform.tsx
+++ b/web/components/Waveform.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useRef, type RefObject } from 'react';
-import { useAnalyser } from '@/lib/hooks';
+import { useEffect, useRef, useState, type RefObject } from 'react';
+import { useAnalyser, useSpectrum } from '@/lib/hooks';
 import { cn } from '@/lib/cn';
 
 const BARS = 120;
@@ -16,25 +16,16 @@ export default function Waveform({ audioRef, tunedIn, progress }: WaveformProps)
   const { ready, read } = useAnalyser(audioRef, tunedIn);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const rafRef = useRef<number | null>(null);
+  const fallback = useSpectrum(BARS, tunedIn && !ready, 60);
+  const [, force] = useState(0);
 
-  // Drive bars via rAF when the real analyser is attached. When it isn't —
-  // notably iOS Safari, where createMediaElementSource on a streaming MP3
-  // returns silence — bars stay at their default static height rather than
-  // running a pseudo-random animation that misleads listeners into thinking
-  // the visualisation tracks the music.
+  // Drive real-analyser bars via rAF when available; otherwise the fallback
+  // effect below paints heights from the pseudo-random spectrum. Bar heights
+  // are written via DOM mutation in both paths so the component stays free of
+  // inline style props (issue #50).
   useEffect(() => {
-    const clearHeights = () => {
-      const container = containerRef.current;
-      if (!container) return;
-      const spans = container.querySelectorAll<HTMLSpanElement>('[data-bar]');
-      for (let i = 0; i < spans.length; i++) {
-        const span = spans[i];
-        if (span) span.style.height = '';
-      }
-    };
     if (!ready || !tunedIn) {
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
-      clearHeights();
       return;
     }
     const tick = () => {
@@ -54,6 +45,23 @@ export default function Waveform({ audioRef, tunedIn, progress }: WaveformProps)
     tick();
     return () => { if (rafRef.current) cancelAnimationFrame(rafRef.current); };
   }, [ready, tunedIn, read]);
+
+  // Fallback: paint pseudo-random bar heights when the real analyser hasn't
+  // attached yet (CORS, iOS Safari, paused stream, etc.).
+  useEffect(() => {
+    if (ready && tunedIn) return;
+    const container = containerRef.current;
+    if (!container) return;
+    const spans = container.querySelectorAll<HTMLSpanElement>('[data-bar]');
+    for (let i = 0; i < spans.length; i++) {
+      const span = spans[i];
+      if (span) span.style.height = `${10 + Math.pow(fallback[i] ?? 0.1, 0.7) * 95}%`;
+    }
+  }, [fallback, ready, tunedIn]);
+
+  // When the real analyser is in charge, suppress the fallback array influence;
+  // we still need a single re-render to flip data attributes on mount.
+  useEffect(() => { force(x => x + 1); }, [ready, tunedIn]);
 
   const usingReal = ready && tunedIn;
 

--- a/web/lib/hooks.ts
+++ b/web/lib/hooks.ts
@@ -12,6 +12,25 @@ export function useClock(): Date | null {
   return t;
 }
 
+// Pseudo-random animated spectrum used as a fallback when the real analyser
+// can't attach — notably iOS Safari, where createMediaElementSource on a live
+// HTTP MP3 stream returns silence (WebKit limitation with no app-level
+// workaround short of shipping a WASM MP3 decoder). Values in [0, 1].
+export function useSpectrum(bins = 120, active = true, speed = 60): number[] {
+  const [arr, setArr] = useState<number[]>(() => Array(bins).fill(0.1));
+  useEffect(() => {
+    if (!active) return;
+    const id = setInterval(() => {
+      setArr(prev => prev.map((v, i) => {
+        const target = Math.pow(Math.random(), 1.4) * (1 - i / (bins * 2.2));
+        return v + (target - v) * 0.45;
+      }));
+    }, speed);
+    return () => clearInterval(id);
+  }, [active, bins, speed]);
+  return arr;
+}
+
 export interface Analyser {
   ready: boolean;
   read: () => Uint8Array<ArrayBuffer> | null;
@@ -27,7 +46,7 @@ interface WebkitWindow {
 // the first time `active` flips true, then writes per-frame frequency bytes
 // into an internal ref read via `read()`. Returns `{ ready, read }`. If CORS
 // or anything else blocks attachment, `ready` stays false and `read()` returns
-// null — callers should render static bars (no fake reactive animation).
+// null — callers should fall back to `useSpectrum`.
 export function useAnalyser(
   audioRef: RefObject<HTMLAudioElement | null> | null | undefined,
   active: boolean,
@@ -67,10 +86,9 @@ export function useAnalyser(
         setReady(true);
 
         // iOS Safari quirk: createMediaElementSource() on a live HTTP MP3 stream
-        // wires up cleanly but the analyser only ever returns zeros (WebKit
-        // limitation, no app-level workaround for live streams). Probe once
-        // after playback starts — if no samples land in ~600 ms, flip
-        // ready=false so callers render static bars instead.
+        // wires up cleanly but the analyser only ever returns zeros. Probe once
+        // after playback actually starts — if no samples land in ~600 ms, flip
+        // ready=false so the pseudo-random useSpectrum fallback takes over.
         if (probedRef.current) return;
         onPlaying = () => {
           if (probedRef.current || cancelled) return;


### PR DESCRIPTION
## Summary
- Reverts the visual half of #80. On iOS Safari, `createMediaElementSource` on the live MP3 stream returns zeros (WebKit limitation), so the analyser's 600 ms zeros-probe correctly flips `ready=false`. With #80, that left the bars frozen — which iOS listeners reasonably read as a broken player.
- Brings back `useSpectrum` and the fallback effect in `Waveform.tsx` so iOS gets the pseudo-random animation again. Chrome/Firefox are unchanged: the real analyser still drives bar heights via rAF.

## Notes on real iOS support
There is no clean app-level fix for actual spectrum analysis of a live HTTP MP3 stream on iOS Safari, even with `crossOrigin="anonymous"` and CORS configured. The realistic paths are: ship a WASM MP3 decoder + `AudioWorklet`, switch transport (HLS/WebRTC), or drive the fallback from track BPM/energy metadata. All are bigger than this revert.

## Test plan
- [ ] iOS Safari → bars animate (pseudo-random) while tuned in, freeze on stop.
- [ ] Desktop Chrome/Firefox → bars track the FFT as before.
- [ ] Tune out → tune in: no leftover heights from the previous session.