### PR TITLE
fix(landing): tighten masthead nav bottom padding

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -411,7 +411,7 @@ body::after {
     align-items: center;
     justify-content: center;
     gap: 14px;
-    padding: 12px 0 4px;
+    padding: 8px 0 2px;
     flex-wrap: wrap;
 }
 .bs-masthead-link {


### PR DESCRIPTION
## Summary
- Decrease `.bs-masthead-nav` padding from `12px 0 4px` to `8px 0 2px` so the bottom of the shared masthead sits closer to the closing double-rule.
- Affects all pages that render `Masthead`: `/landing`, `/manual`, `/setup`.

## Test plan
- [x] Run `cd web && npm run dev` and confirm the bottom of the header on `/landing`, `/manual`, and `/setup` is visibly tighter against the lower double-rule.
- [x] Spot-check at <560px width — masthead-head collapses but nav still renders with reduced spacing.