### PR TITLE
fix(admin): keep /admin/debug expansions from blowing out viewport

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1959,6 +1959,27 @@ body::after {
 .admin-root .card {
     border: 1px solid var(--ink);
     background: var(--card-bg);
+    /* As a grid item, default min-width: auto would let oversized children
+       (long URIs, JSON dumps in /admin/debug expansions) push the column
+       wider and blow out the page. min-width: 0 lets the grid track shrink
+       and forces wrapping inside instead. */
+    min-width: 0;
+}
+.admin-root .card-body {
+    /* Same reason — pre/code content inside expanded <details> needs a
+       width constraint to actually wrap. */
+    min-width: 0;
+    overflow-x: hidden;
+}
+.admin-root details {
+    min-width: 0;
+}
+/* Unbroken strings (annotated track URIs, base64, raw URLs) inside debug
+   expansions would otherwise force the card wider than the viewport.
+   `anywhere` only breaks when the word truly doesn't fit. */
+.admin-root .card pre,
+.admin-root details pre {
+    overflow-wrap: anywhere;
 }
 .admin-root .card-head {
     display: flex;


### PR DESCRIPTION
## Summary
- LLM recent-calls and Subsonic API-calls panels in `/admin/debug` could push the page horizontally wider than the screen when an expanded `<details>` contained an annotated track URI, a long prompt, or a raw JSON dump — the card sat inside a CSS grid with the default `min-width: auto`, so any unbroken string forced the track wider.
- Scope `min-width: 0` to `.admin-root .card`, `.card-body`, and `details` so they shrink inside their grid tracks, clip `card-body` horizontally as a safety net, and apply `overflow-wrap: anywhere` to `<pre>` content so long unbroken tokens (URIs, base64, hashes) wrap to the card width and overflow goes vertical instead.
- Change is one CSS edit, scoped under `.admin-root`, so the player and landing surfaces are unaffected.

## Test plan
- [ ] Open `/admin/debug`, expand an LLM recent call with a long system prompt / tool args — card width stays within the viewport, content wraps, the card scrolls vertically.
- [ ] Expand a Subsonic API call with `songIds` / annotated URI params — same: stays within viewport, wraps.
- [ ] Other admin pages (`/admin/dash`, `/admin/library`, `/admin/settings`, etc.) still render normally — no clipped tooltips/popovers from the new `overflow-x: hidden` on `.card-body`.