### PR TITLE
feat(cli): fetch TUI binary on demand for standalone installs

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,16 +1,18 @@
-name: Publish CLI binaries
+name: Publish CLI + TUI binaries
 
-# Builds the standalone `subwave` CLI for linux + macOS (x64 + arm64) and
-# attaches the binaries to the GitHub Release matching the tag.
+# Builds the standalone `subwave` CLI and the terminal-player TUI for
+# linux + macOS (x64 + arm64) and attaches both sets of binaries to the
+# GitHub Release matching the tag.
 #
 # Triggers:
 #   - push of a tag like v1.2.3 → builds + uploads
 #   - manual workflow_dispatch → builds without uploading (smoke test)
 #
 # The install script at install.sh (served from cli.getsubwave.com → raw
-# GitHub URL → this repo) downloads the matching binary from the latest
-# release, so an operator running `curl cli.getsubwave.com | sh` lands on
-# whatever this workflow last produced.
+# GitHub URL → this repo) downloads the matching CLI binary from the latest
+# release. The TUI binary is fetched on demand by `subwave play` from the
+# same release tag (version-pinned to the CLI's own version), so standalone
+# installs get a working terminal player without ever needing Node + npm.
 #
 # Inputs are all matrix-controlled — no user-supplied data flows into
 # `run:` steps, so the standard command-injection vectors don't apply.
@@ -85,4 +87,61 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: cli/dist/${{ matrix.asset }}
+          fail_on_unmatched_files: true
+
+  build-tui:
+    # Same matrix as the CLI: one bun --compile per platform/arch, one
+    # release asset per binary. Runs in parallel with `build` — both jobs
+    # upload to the same release tag.
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: bun-linux-x64
+            asset:  subwave-tui-linux-x64
+          - target: bun-linux-arm64
+            asset:  subwave-tui-linux-arm64
+          - target: bun-darwin-x64
+            asset:  subwave-tui-darwin-x64
+          - target: bun-darwin-arm64
+            asset:  subwave-tui-darwin-arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install TUI deps
+        working-directory: tui
+        run: bun install --frozen-lockfile || bun install
+
+      - name: Compile TUI binary
+        working-directory: tui
+        env:
+          TARGET: ${{ matrix.target }}
+          ASSET: ${{ matrix.asset }}
+        run: |
+          mkdir -p dist
+          bun build src/main.tsx \
+            --compile \
+            --target="$TARGET" \
+            --outfile="dist/$ASSET"
+
+      - name: Smoke test
+        # Only the linux-x64 binary runs on the GH runner. --help exits
+        # before Ink takes the TTY, so it's safe in a non-TTY job.
+        if: matrix.target == 'bun-linux-x64'
+        env:
+          ASSET: ${{ matrix.asset }}
+        run: |
+          chmod +x "tui/dist/$ASSET"
+          "tui/dist/$ASSET" --help
+
+      - name: Upload to release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: tui/dist/${{ matrix.asset }}
           fail_on_unmatched_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ cli/tsconfig.tsbuildinfo
 # Distributed via the publish-cli GitHub workflow as release assets.
 cli/dist/
 
+# Compiled TUI binaries (produced by `bun run --cwd tui build:all`).
+# Distributed alongside CLI binaries as release assets; standalone CLI
+# installs fetch them on demand from the GitHub release.
+tui/dist/
+
 # Runtime state — file-based IPC, TTS output, archives, logs
 state/voice/
 state/archive/

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "tsx": "^4.19.2",
         "typescript": "^5.4.0"
       },
       "engines": {
@@ -40,6 +41,448 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
@@ -48,6 +491,63 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/picocolors": {
@@ -61,6 +561,25 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/cli/package.json
+++ b/cli/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "tsx": "^4.19.2",
     "typescript": "^5.4.0"
   }
 }

--- a/cli/scripts/embed-assets.ts
+++ b/cli/scripts/embed-assets.ts
@@ -61,12 +61,24 @@ function main(): void {
     parts.push(`export const ${a.name} = \`${encode(body)}\`;`);
     parts.push('');
   }
+  // Embed cli/package.json's version. The runtime readFileSync trick in
+  // cli.ts doesn't survive `bun build --compile` (the bundled binary has no
+  // package.json at runtime), so `--version` previously printed "unknown".
+  // Bake the string in at embed time — release-please bumps this in lockstep
+  // with the git tag, so the embedded version always matches the release the
+  // binary came from.
+  const pkg = JSON.parse(readFileSync(resolve(REPO_ROOT, 'cli', 'package.json'), 'utf8')) as { version: string };
+  parts.push('// cli/package.json#version (embedded so the compiled binary can self-identify');
+  parts.push('// — used by `subwave --version` and by the TUI release fetch URL).');
+  parts.push(`export const CLI_VERSION = \`${encode(pkg.version)}\`;`);
+  parts.push('');
+
   writeFileSync(OUT_FILE, parts.join('\n'));
   const sizes = ASSETS.map((a) => {
     const abs = resolve(REPO_ROOT, a.source);
     return `${a.source} (${readFileSync(abs, 'utf8').length} bytes)`;
   });
-  process.stdout.write(`embedded ${ASSETS.length} files → ${OUT_FILE}\n`);
+  process.stdout.write(`embedded ${ASSETS.length} files + CLI_VERSION=${pkg.version} → ${OUT_FILE}\n`);
   for (const s of sizes) process.stdout.write(`  ${s}\n`);
 }
 

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -491,3 +491,7 @@ SITE_URL=
 # ELEVENLABS_API_KEY=
 # SEARCH_API_KEY=tvly-...
 `;
+
+// cli/package.json#version (embedded so the compiled binary can self-identify
+// — used by `subwave --version` and by the TUI release fetch URL).
+export const CLI_VERSION = `0.1.0`;

--- a/cli/src/assets.ts
+++ b/cli/src/assets.ts
@@ -4,4 +4,4 @@
 // strategies later (raw imports, Bun --embed, fetched from GHCR release
 // assets) without touching every caller.
 
-export { COMPOSE_YML, COMPOSE_BYO_YML, COMPOSE_DEV_YML, ENV_EXAMPLE } from './assets.generated.ts';
+export { COMPOSE_YML, COMPOSE_BYO_YML, COMPOSE_DEV_YML, ENV_EXAMPLE, CLI_VERSION } from './assets.generated.ts';

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -29,7 +29,7 @@ Usage:
   subwave restart [svc]    rebuild / restart a service (dev adds \`web-dev\`)
   subwave logs [svc|all]   tail docker compose logs (dev adds \`web-dev\`)
   subwave update           pull new images + recreate changed services
-  subwave play [dev|prod]  open the terminal player (TUI, cloned-repo only)
+  subwave play [dev|prod]  open the terminal player (TUI; auto-fetched on first run)
   subwave listen [dev|prod] open the web player in a browser
   subwave admin [dev|prod] open the admin console in a browser
   subwave self-update      replace the installed binary with the latest release
@@ -55,18 +55,11 @@ async function main(): Promise<void> {
     return;
   }
   if (cmd === '--version' || cmd === '-v') {
-    // Read package.json next to this file's directory at runtime so the
-    // version stays accurate without a build step. Doesn't touch SUBWAVE_HOME.
-    const { readFileSync } = await import('node:fs');
-    const { resolve } = await import('node:path');
-    const { fileURLToPath } = await import('node:url');
-    const here = resolve(fileURLToPath(import.meta.url), '..', '..');
-    try {
-      const pkg = JSON.parse(readFileSync(resolve(here, 'package.json'), 'utf8'));
-      process.stdout.write(`${pkg.version}\n`);
-    } catch {
-      process.stdout.write('unknown\n');
-    }
+    // Embedded at build time by cli/scripts/embed-assets.ts (release-please
+    // bumps cli/package.json in lockstep with the git tag, so this stays
+    // accurate across releases). Doesn't touch SUBWAVE_HOME.
+    const { CLI_VERSION } = await import('./assets.ts');
+    process.stdout.write(`${CLI_VERSION}\n`);
     return;
   }
   if (cmd === 'init') {

--- a/cli/src/commands/play.ts
+++ b/cli/src/commands/play.ts
@@ -1,14 +1,25 @@
 // `subwave play [dev|prod]` — launch the terminal player (TUI) pointed at
-// the running stack. The TUI is its own package under /tui/; this command
-// resolves the right controller + Icecast URLs for the live compose env
-// and hands off to `tui/bin/subwave-tui.js`.
+// the running stack.
 //
-// The TUI is a full-screen Ink app — once spawned it owns the terminal
-// until the listener quits, then control returns here (or to the menu).
+// Two backends, picked by what's actually on disk:
+//
+//  - Clone-mode (contributors): `<home>/tui/package.json` is present, the
+//    TUI source tree is checked out. Run it the old way — `node
+//    bin/subwave-tui.js` under the tsx loader, hot edits to src/ take
+//    effect on the next launch.
+//
+//  - Standalone (operators who installed via `curl … | sh`): no tui/ dir.
+//    Fetch the version-pinned `subwave-tui-<platform>-<arch>` binary from
+//    the matching GitHub release into `<home>/tui/bin/subwave-tui` and
+//    spawn it. Cached forever; redownloaded when the operator runs
+//    `subwave self-update` (which bumps CLI_VERSION → the cached path
+//    points at the old version and miss-then-fetch fires again).
 
-import { existsSync } from 'node:fs';
-import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, chmodSync, createWriteStream, statSync, renameSync, unlinkSync } from 'node:fs';
+import { spawn } from 'node:child_process';
 import { resolve } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { Readable } from 'node:stream';
 import {
   detectCompose,
   apiBaseFor,
@@ -16,6 +27,7 @@ import {
   type ComposeEnv,
 } from '../compose.ts';
 import { getSubwaveHome } from '../util.ts';
+import { CLI_VERSION } from '../assets.ts';
 import {
   exitIfCancelled,
   header,
@@ -29,23 +41,139 @@ import {
   setMenuMode,
 } from '../ui.ts';
 
-// TUI lives in the cloned-repo `tui/` dir. Lazy so importing this file
-// doesn't trigger home resolution (e.g. when cli.ts dispatches a non-play
-// command). Standalone-CLI installs don't have the TUI — runPlayCommand
-// checks isCloneMode() and surfaces a helpful error.
+// Owner/repo for the GitHub release that holds the compiled TUI binaries.
+// Same release tag as the CLI binary that this code is bundled into.
+const RELEASE_REPO = 'perminder-klair/subwave';
+
 function tuiDir(): string { return resolve(getSubwaveHome(), 'tui'); }
-function tuiBin(): string { return resolve(tuiDir(), 'bin', 'subwave-tui.js'); }
+function tuiBinDir(): string { return resolve(tuiDir(), 'bin'); }
+function tuiCloneEntry(): string { return resolve(tuiBinDir(), 'subwave-tui.js'); }
+function tuiCompiledBin(): string { return resolve(tuiBinDir(), 'subwave-tui'); }
+
+// Clone-mode = the operator is running from a `git clone` checkout. The
+// `tui/package.json` (alongside controller/ and web/) is what distinguishes
+// it from a standalone install, mirroring isCloneMode() in home.ts.
+function isCloneTui(): boolean {
+  return existsSync(resolve(tuiDir(), 'package.json')) && existsSync(tuiCloneEntry());
+}
+
+// node_modules check — only relevant for clone-mode. Standalone installs
+// run the bundled binary which carries its own deps.
+function cloneNodeModulesPresent(): boolean {
+  return existsSync(resolve(tuiDir(), 'node_modules'));
+}
+
+// Resolve the platform/arch slug bun --compile uses for asset names. The
+// CLI binary that's running was itself built for one of these; assume the
+// TUI binary follows the same convention. Returns null on unsupported
+// host platforms (Windows, BSDs, …) so the caller can surface a clear
+// error instead of fetching a 404.
+function resolveAssetSlug(): string | null {
+  const plat = process.platform;
+  const arch = process.arch;
+  if (plat === 'linux'  && arch === 'x64')   return 'linux-x64';
+  if (plat === 'linux'  && arch === 'arm64') return 'linux-arm64';
+  if (plat === 'darwin' && arch === 'x64')   return 'darwin-x64';
+  if (plat === 'darwin' && arch === 'arm64') return 'darwin-arm64';
+  return null;
+}
+
+function releaseAssetUrl(slug: string): string {
+  // Escape hatch for local testing — point at any HTTP-reachable binary
+  // (e.g. `python3 -m http.server` serving tui/dist) before the release
+  // workflow has actually published a v<CLI_VERSION> asset. The substituted
+  // value can be a full URL or a template containing {slug}.
+  const override = process.env.SUBWAVE_TUI_DOWNLOAD_URL;
+  if (override) return override.replace('{slug}', slug);
+  return `https://github.com/${RELEASE_REPO}/releases/download/v${CLI_VERSION}/subwave-tui-${slug}`;
+}
+
+// Download the matching TUI binary from the GitHub release into
+// `<home>/tui/bin/subwave-tui`. Streamed to a `.partial` file first so a
+// killed download doesn't leave a half-written executable behind that
+// looks valid on the next run.
+async function fetchTuiBinary(slug: string): Promise<void> {
+  const url = releaseAssetUrl(slug);
+  const out = tuiCompiledBin();
+  const partial = `${out}.partial`;
+
+  mkdirSync(tuiBinDir(), { recursive: true });
+  if (existsSync(partial)) unlinkSync(partial);
+
+  info(`fetching subwave-tui-${slug} from release v${CLI_VERSION}`);
+  muted(url);
+
+  const res = await fetch(url, { redirect: 'follow' });
+  if (!res.ok || !res.body) {
+    throw new Error(
+      `download failed (${res.status} ${res.statusText}). ` +
+      `Either v${CLI_VERSION} hasn't been released yet, or the matching TUI ` +
+      `asset is missing. URL: ${url}`,
+    );
+  }
+
+  await pipeline(Readable.fromWeb(res.body as never), createWriteStream(partial));
+
+  // Sanity check — Bun-compiled binaries are tens of MB. Anything under 1MB
+  // is almost certainly a 404 HTML page that slipped through with a 200 (or
+  // a release asset redirect we mishandled).
+  const size = statSync(partial).size;
+  if (size < 1_000_000) {
+    unlinkSync(partial);
+    throw new Error(`downloaded asset is suspiciously small (${size} bytes) — refusing to install`);
+  }
+
+  renameSync(partial, out);
+  chmodSync(out, 0o755);
+  info(`installed → ${out}  (${(size / (1024 * 1024)).toFixed(1)} MB)`);
+}
 
 export interface PlayOpts {
   envArg?: Exclude<ComposeEnv, 'down'>;
 }
 
 export async function runPlayCommand(opts: PlayOpts = {}): Promise<void> {
-  if (!existsSync(tuiBin())) {
-    header('TUI not found');
-    err(`expected the terminal player at ${tuiBin()}`);
-    await pauseForEnter();
-    return;
+  // Decide which on-disk TUI we'll launch. Clone-mode wins so contributors
+  // editing src/ get their changes; standalone falls through to the fetched
+  // binary (downloading it first if needed).
+  type Backend =
+    | { kind: 'clone' }
+    | { kind: 'compiled'; path: string };
+  let backend: Backend;
+
+  if (isCloneTui()) {
+    backend = { kind: 'clone' };
+  } else {
+    const slug = resolveAssetSlug();
+    if (!slug) {
+      header('TUI not available on this platform');
+      err(`compiled binaries exist only for linux/macOS on x64/arm64 — detected ${process.platform}/${process.arch}.`);
+      muted('clone the repo and run the Node-based TUI manually, or run subwave from a supported host.');
+      await pauseForEnter();
+      return;
+    }
+    if (!existsSync(tuiCompiledBin())) {
+      header('Terminal player needs a one-time download');
+      info(`Subwave will fetch the TUI binary (~60–100 MB) into ${tuiBinDir()}.`);
+      muted('subsequent launches are instant; rerun `subwave self-update` to refresh.');
+      const proceed = exitIfCancelled(await p.confirm({
+        message: 'Download it now?',
+      }));
+      if (!proceed) {
+        muted('skipped — `subwave play` is unavailable until the download completes.');
+        await pauseForEnter();
+        return;
+      }
+      try {
+        await fetchTuiBinary(slug);
+      } catch (e) {
+        err(e instanceof Error ? e.message : String(e));
+        muted('check your internet connection, then try `subwave play` again.');
+        await pauseForEnter();
+        return;
+      }
+    }
+    backend = { kind: 'compiled', path: tuiCompiledBin() };
   }
 
   // Which stack are we listening to? Explicit arg wins; otherwise follow
@@ -71,9 +199,10 @@ export async function runPlayCommand(opts: PlayOpts = {}): Promise<void> {
     }
   }
 
-  // The TUI carries its own dependency tree (ink, react). It's a separate
-  // package, so a fresh checkout won't have node_modules until installed.
-  if (!existsSync(resolve(tuiDir(), 'node_modules'))) {
+  // Clone-mode TUI carries its own dep tree. A fresh checkout has no
+  // node_modules until installed — offer to do it. Standalone binary
+  // skips this entirely.
+  if (backend.kind === 'clone' && !cloneNodeModulesPresent()) {
     warn('the terminal player has no node_modules yet — it needs `npm install` first.');
     const doInstall = exitIfCancelled(await p.confirm({
       message: 'Run `npm install` in tui/ now?',
@@ -83,6 +212,7 @@ export async function runPlayCommand(opts: PlayOpts = {}): Promise<void> {
       await pauseForEnter();
       return;
     }
+    const { spawnSync } = await import('node:child_process');
     const r = spawnSync('npm', ['install'], { cwd: tuiDir(), stdio: 'inherit' });
     if (r.status !== 0) {
       err('npm install failed — see output above.');
@@ -96,6 +226,7 @@ export async function runPlayCommand(opts: PlayOpts = {}): Promise<void> {
 
   header('Terminal player');
   info(`env=${env} · api=${apiUrl}`);
+  if (backend.kind === 'compiled') muted(`binary: ${backend.path}`);
   muted('q / Ctrl-C inside the player returns here.');
   console.log();
 
@@ -106,12 +237,15 @@ export async function runPlayCommand(opts: PlayOpts = {}): Promise<void> {
   if (wasMenu) setMenuMode(false);
   try {
     await new Promise<void>((resolveP) => {
-      const child = spawn(
-        'node',
-        [tuiBin(), '--api', apiUrl, '--stream', streamUrl],
-        { cwd: tuiDir(), stdio: 'inherit' },
-      );
+      const [cmd, args]: [string, string[]] = backend.kind === 'clone'
+        ? ['node', [tuiCloneEntry(), '--api', apiUrl, '--stream', streamUrl]]
+        : [backend.path, ['--api', apiUrl, '--stream', streamUrl]];
+      const child = spawn(cmd, args, { cwd: tuiDir(), stdio: 'inherit' });
       child.on('exit', () => resolveP());
+      child.on('error', (e) => {
+        err(`failed to launch TUI: ${e.message}`);
+        resolveP();
+      });
     });
   } finally {
     if (wasMenu) setMenuMode(true);

--- a/cli/src/commands/self-update.ts
+++ b/cli/src/commands/self-update.ts
@@ -65,6 +65,26 @@ export async function runSelfUpdateCommand(args: { version?: string } = {}): Pro
     });
   });
 
+  // Drop the cached TUI binary so the next `subwave play` re-fetches a
+  // version-matched copy from the new release. We can't do this from inside
+  // the new binary (it has no opinion about "what was here before"), so it
+  // happens here, before the in-place replacement returns control.
+  try {
+    const { existsSync, unlinkSync } = await import('node:fs');
+    const { resolveSubwaveHome } = await import('../home.ts');
+    const { resolve } = await import('node:path');
+    const home = resolveSubwaveHome();
+    if (home) {
+      const cachedTui = resolve(home.home, 'tui', 'bin', 'subwave-tui');
+      if (existsSync(cachedTui)) {
+        unlinkSync(cachedTui);
+        muted('cleared cached TUI binary — `subwave play` will re-fetch on next launch.');
+      }
+    }
+  } catch {
+    // Non-fatal — the stale binary will still run; user can delete it manually.
+  }
+
   console.log();
   muted('The running process is still the old binary — next invocation picks up the new one.');
   await pauseForEnter();

--- a/tui/README.md
+++ b/tui/README.md
@@ -49,6 +49,28 @@ SUBWAVE_STREAM_URL=https://your.host/stream.mp3 \
 
 In the request panel, `Enter` advances fields and sends; `Esc` closes it.
 
+## Building a standalone binary
+
+For shipping with the `subwave` CLI to operators who don't have Node, the TUI
+also compiles to a single Bun binary (no Node, no `node_modules`, ~100MB).
+Same matrix as the CLI; binaries land in `tui/dist/`:
+
+```bash
+cd tui
+bun install
+bun run build:all          # all 4 platforms
+bun run build:linux-x64    # single target
+```
+
+The compiled binary is what `subwave play` fetches on demand from GitHub
+releases for standalone-CLI installs; the cloned-repo path still runs the
+`tsx`-loader version directly via `node bin/subwave-tui.js`.
+
+`react-devtools-core` lives in `dependencies` only because Ink statically
+imports it from `build/reconciler.js`; the import is gated by `DEV=true` at
+runtime, but `bun build --compile` eagerly resolves the path, so the dep
+must be installable to produce a working binary. ~1MB cost, no runtime effect.
+
 ## Notes
 
 - Audio is played by an external `mpv`/`ffplay` child process pointed at the
@@ -56,7 +78,8 @@ In the request panel, `Enter` advances fields and sends; `Esc` closes it.
 - No waveform or cover art — a child-process player exposes no PCM, and
   terminal image protocols are inconsistent. A progress bar stands in.
 - The JSX modules under `src/` are transformed at import time by the `tsx`
-  loader, so there is no build step.
+  loader, so there is no build step for the Node entry point. The compiled
+  Bun binary bundles them at build time instead.
 - The classic-Winamp visuals are intentionally **static** (no animation
   tick) to avoid frame-flash in Ink — the marquee and faux spectrum
   refresh on the 5s station-feed poll, in lockstep with the elapsed

--- a/tui/package.json
+++ b/tui/package.json
@@ -11,7 +11,12 @@
     "start": "node bin/subwave-tui.js",
     "lint": "eslint . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "build:linux-x64":    "bun build src/main.tsx --compile --target=bun-linux-x64    --outfile=dist/subwave-tui-linux-x64",
+    "build:linux-arm64":  "bun build src/main.tsx --compile --target=bun-linux-arm64  --outfile=dist/subwave-tui-linux-arm64",
+    "build:darwin-x64":   "bun build src/main.tsx --compile --target=bun-darwin-x64   --outfile=dist/subwave-tui-darwin-x64",
+    "build:darwin-arm64": "bun build src/main.tsx --compile --target=bun-darwin-arm64 --outfile=dist/subwave-tui-darwin-arm64",
+    "build:all": "npm run build:linux-x64 && npm run build:linux-arm64 && npm run build:darwin-x64 && npm run build:darwin-arm64"
   },
   "engines": {
     "node": ">=18"
@@ -21,6 +26,7 @@
     "ink-text-input": "^6.0.0",
     "meow": "^13.2.0",
     "react": "^19.2.0",
+    "react-devtools-core": "^7.0.1",
     "tsx": "^4.19.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Standalone `curl … | sh` installs don't ship the tui/ source tree, so `subwave play` used to error with "TUI not found". This wires up a fetch-on-demand path that downloads a version-pinned, Bun-compiled `subwave-tui` binary from the matching GitHub release on first invocation.
- The TUI now compiles to a 4-platform binary matrix (linux/macOS × x64/arm64) under `bun --compile`, published as release assets alongside the CLI binaries. Clone-mode (developer checkout) still runs the tsx-loader version for hot reloads.
- Drive-by: `subwave --version` was printing `unknown` because the `readFileSync(package.json)` trick doesn't survive `bun --compile`. Now embedded into `assets.generated.ts` at build time and prints the real version.

## How it works
1. `subwave play` checks for `<home>/tui/package.json` (clone) → runs `node bin/subwave-tui.js`.
2. Otherwise checks for `<home>/tui/bin/subwave-tui` (cached binary) → spawns it directly.
3. Otherwise prompts "Download it now?" and streams `https://github.com/perminder-klair/subwave/releases/download/v<CLI_VERSION>/subwave-tui-<platform>-<arch>` into a `.partial` file, sanity-checks size (>1MB), atomic-renames into place, `chmod +x`.
4. `subwave self-update` clears the cached binary so the next launch re-fetches a version-matched copy.

`SUBWAVE_TUI_DOWNLOAD_URL` env var overrides the release URL for local testing before a release exists.

## Test plan
- [x] `bun run typecheck` passes for cli/ and tui/
- [x] `bun run build:all` produces 4 working TUI binaries (61–102MB each)
- [x] Compiled TUI binary renders Ink at full fidelity against the live stack (banner, spectrum animation, panels)
- [x] Compiled CLI binary `--version` prints `0.1.0` instead of `unknown`
- [x] `subwave play` against a standalone install (no tui/) shows the "Terminal player needs a one-time download" prompt
- [x] `subwave play` with a pre-placed cached binary spawns it and renders against the live stack
- [x] `embed-assets` regeneration is stable (no drift on rerun)
- [ ] First real release after merge: confirm publish-cli.yml uploads all 8 binaries (4 CLI + 4 TUI)
- [ ] After release: run `subwave play` on a fresh standalone install end-to-end to exercise the live download