### PR TITLE
feat(admin): redo library page with working filters + coverage

### DIFF
--- a/controller/src/broadcast/tagger.ts
+++ b/controller/src/broadcast/tagger.ts
@@ -2,7 +2,7 @@
 // standalone script (music/tag-library.js) spawned as a child process; this
 // module holds the live state shared between the routes that start it
 // (/tag-library) and the ones that report on it (/settings).
-import { spawn } from 'node:child_process';
+import { spawn, ChildProcess } from 'node:child_process';
 import { queue } from './queue.js';
 
 type TaggerState = {
@@ -14,6 +14,9 @@ type TaggerState = {
 
 export const tagger: TaggerState = { running: false, startedAt: null, pid: null, lastLog: [] };
 
+// Live handle for stopTagger() — cleared on the exit handler.
+let activeChild: ChildProcess | null = null;
+
 // Spawn the tagger as a detached-from-our-event-loop child process. Caller is
 // responsible for rejecting the request if `tagger.running` is already true.
 export function startTagger(limit?: number) {
@@ -21,6 +24,7 @@ export function startTagger(limit?: number) {
   if (Number.isFinite(limit) && (limit as number) > 0) args.push('--limit', String(limit));
 
   const child = spawn('npx', ['tsx', ...args], { cwd: '/app', detached: false });
+  activeChild = child;
   tagger.running = true;
   tagger.startedAt = new Date().toISOString();
   tagger.pid = child.pid ?? null;
@@ -33,10 +37,27 @@ export function startTagger(limit?: number) {
   };
   child.stdout.on('data', capture);
   child.stderr.on('data', capture);
-  child.on('exit', (code) => {
+  child.on('exit', (code, signal) => {
     tagger.running = false;
-    tagger.lastLog.push(`[exit ${code}]`);
-    queue.log('scheduler', `tagger finished (exit ${code})`);
+    if (activeChild === child) activeChild = null;
+    tagger.lastLog.push(`[exit ${signal || code}]`);
+    queue.log('scheduler', `tagger finished (${signal ? `signal ${signal}` : `exit ${code}`})`);
   });
   queue.log('scheduler', `tagger started${Number.isFinite(limit) ? ` (limit=${limit})` : ''}`);
+}
+
+// Stop the running tagger by signalling its child. The exit handler above
+// flips `tagger.running` false once the process actually exits.
+// Returns { stopped: true } if a signal was sent, { stopped: false } if no
+// process was running.
+export function stopTagger(): { stopped: boolean } {
+  if (!activeChild || !tagger.running) return { stopped: false };
+  try {
+    activeChild.kill('SIGTERM');
+    queue.log('scheduler', 'tagger stop requested (SIGTERM)');
+    return { stopped: true };
+  } catch (err: any) {
+    queue.log('error', `tagger stop failed: ${err.message}`);
+    return { stopped: false };
+  }
 }

--- a/controller/src/music/library-coverage.ts
+++ b/controller/src/music/library-coverage.ts
@@ -1,0 +1,66 @@
+// Library coverage — total Navidrome song count vs tagged tracks.
+// `total` requires walking iterateAllSongs() once (one Subsonic call per
+// 500-album batch) which is too slow to do per request. We cache the count
+// and refresh in the background; the cache is considered stale after 6 h or
+// after a manual refresh. Concurrent /coverage requests share the in-flight
+// scan via a single promise.
+
+import * as subsonic from './subsonic.js';
+import * as library from './library.js';
+
+const STALE_MS = 6 * 60 * 60 * 1000; // 6 h
+
+interface CoverageCache {
+  total: number;
+  scannedAt: string | null;
+  scanning: boolean;
+}
+
+const cache: CoverageCache = { total: 0, scannedAt: null, scanning: false };
+let inflight: Promise<void> | null = null;
+
+async function doScan() {
+  cache.scanning = true;
+  try {
+    let count = 0;
+    for await (const _song of subsonic.iterateAllSongs()) count++;
+    cache.total = count;
+    cache.scannedAt = new Date().toISOString();
+  } finally {
+    cache.scanning = false;
+    inflight = null;
+  }
+}
+
+// Kick off a scan if one isn't running. Non-blocking — callers read the
+// current snapshot from get() and poll until scanning flips false.
+export function refresh() {
+  if (!inflight) inflight = doScan().catch(err => {
+    console.error('[library-coverage] scan failed:', err.message);
+  });
+  return inflight;
+}
+
+function isStale() {
+  if (!cache.scannedAt) return true;
+  return Date.now() - new Date(cache.scannedAt).getTime() > STALE_MS;
+}
+
+// Snapshot for the API. Triggers a refresh if the cache is stale or empty.
+// Returns total=null/percent=null until the first scan completes — the UI
+// uses that as the "scanning…" cue rather than guessing 100%.
+export async function get() {
+  await library.load();
+  if (isStale() && !cache.scanning) refresh();
+  const tagged = library.allTaggedIds().length;
+  const total = cache.scannedAt ? cache.total : null;
+  const percent =
+    total != null && total > 0 ? Math.round((tagged / total) * 100) : null;
+  return {
+    tagged,
+    total,
+    percent,
+    scannedAt: cache.scannedAt,
+    scanning: cache.scanning,
+  };
+}

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -97,9 +97,105 @@ export function stats() {
   const total = Object.keys(store.tracks).length;
   const byMood: Record<string, number> = {};
   const byEnergy: Record<string, number> = {};
+  const byGenre: Record<string, number> = {};
   for (const t of Object.values(store.tracks) as any[]) {
     for (const m of t.moods || []) byMood[m] = (byMood[m] || 0) + 1;
     if (t.energy) byEnergy[t.energy] = (byEnergy[t.energy] || 0) + 1;
+    if (t.genre) byGenre[t.genre] = (byGenre[t.genre] || 0) + 1;
   }
-  return { total, byMood, byEnergy, updatedAt: store.updatedAt };
+  return { total, byMood, byEnergy, byGenre, updatedAt: store.updatedAt };
+}
+
+// In-memory filter over the tagged track index. Powers the admin Library
+// browse panel — pure JS, no Subsonic calls. AND across facets; multiple
+// moods OR within the mood facet. `q` is a case-insensitive substring match
+// against title + artist + album. Returns paginated rows + the unfiltered
+// match total so the UI can show "1–50 of N".
+export interface FilterOpts {
+  moods?: string[];
+  energy?: string | null;
+  genre?: string | null;
+  yearFrom?: number | null;
+  yearTo?: number | null;
+  q?: string | null;
+  sort?: 'artist' | 'title' | 'taggedAt' | 'year';
+  limit?: number;
+  offset?: number;
+}
+
+export interface FilteredRow {
+  id: string;
+  title?: string;
+  artist?: string;
+  album?: string;
+  year?: number | string | null;
+  genre?: string | null;
+  duration?: number | null;
+  moods: string[];
+  energy: string | null;
+  taggedAt?: string;
+}
+
+export function filter(opts: FilterOpts = {}) {
+  const moods = (opts.moods || []).filter(Boolean);
+  const energy = opts.energy || null;
+  const genre = opts.genre || null;
+  const yearFrom = Number.isFinite(opts.yearFrom as number) ? (opts.yearFrom as number) : null;
+  const yearTo = Number.isFinite(opts.yearTo as number) ? (opts.yearTo as number) : null;
+  const q = (opts.q || '').trim().toLowerCase();
+  const sort = opts.sort || 'artist';
+  const limit = Math.max(1, Math.min(opts.limit ?? 50, 200));
+  const offset = Math.max(0, opts.offset ?? 0);
+
+  const matched: FilteredRow[] = [];
+  for (const [id, t] of Object.entries(store.tracks) as [string, any][]) {
+    if (moods.length && !(t.moods || []).some((m: string) => moods.includes(m))) continue;
+    if (energy && t.energy !== energy) continue;
+    if (genre && t.genre !== genre) continue;
+    const year = numericYear(t.year);
+    if (yearFrom != null && (year === 0 || year < yearFrom)) continue;
+    if (yearTo != null && (year === 0 || year > yearTo)) continue;
+    if (q) {
+      const hay = `${t.title || ''} ${t.artist || ''} ${t.album || ''}`.toLowerCase();
+      if (!hay.includes(q)) continue;
+    }
+    matched.push({
+      id,
+      title: t.title,
+      artist: t.artist,
+      album: t.album,
+      year: t.year ?? null,
+      genre: t.genre ?? null,
+      duration: t.duration ?? null,
+      moods: t.moods || [],
+      energy: t.energy ?? null,
+      taggedAt: t.taggedAt,
+    });
+  }
+
+  const cmp = SORTERS[sort] || SORTERS.artist;
+  matched.sort(cmp);
+
+  return {
+    total: matched.length,
+    rows: matched.slice(offset, offset + limit),
+  };
+}
+
+const SORTERS: Record<string, (a: FilteredRow, b: FilteredRow) => number> = {
+  artist: (a, b) =>
+    cmpStr(a.artist, b.artist) || cmpStr(a.album, b.album) || cmpStr(a.title, b.title),
+  title: (a, b) => cmpStr(a.title, b.title) || cmpStr(a.artist, b.artist),
+  year: (a, b) => numericYear(b.year) - numericYear(a.year) || cmpStr(a.artist, b.artist),
+  taggedAt: (a, b) => cmpStr(b.taggedAt, a.taggedAt),
+};
+
+function cmpStr(a?: string | null, b?: string | null) {
+  return (a || '').localeCompare(b || '', undefined, { sensitivity: 'base' });
+}
+function numericYear(y: number | string | null | undefined): number {
+  if (y == null) return 0;
+  if (typeof y === 'number') return y;
+  const n = parseInt(y, 10);
+  return Number.isFinite(n) ? n : 0;
 }

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -1,64 +1,19 @@
 // One-shot library tagger.
-// Walks the entire Navidrome library, sends each unseen track to Ollama for
+// Walks the entire Navidrome library, sends each unseen track to the LLM for
 // {moods, energy} classification, persists results in state/moods.json.
 // Resumable — already-tagged tracks are skipped, so you can re-run any time.
 //
 // Run:  docker exec sub-wave-controller node src/music/tag-library.js
 //   or  docker exec sub-wave-controller node src/music/tag-library.js --limit 100
+//
+// Per-track classification lives in tagger-core.ts so the inline retag route
+// (controller/src/routes/library.ts → POST /library/retag) can reuse it.
 
-import { z } from 'zod';
 import * as subsonic from './subsonic.js';
 import * as library from './library.js';
 import * as settings from '../settings.js';
-import { SHOW_MOODS as MOOD_VOCAB } from '../settings.js';
-import { djObject } from '../llm/sdk.js';
 import { activeModelLabel } from '../llm/provider.js';
-
-// Tag classification goes through the AI SDK (llm/sdk.js → llm/provider.js)
-// like every other model call, so it follows whatever provider/model the admin
-// Settings UI selects. The result is Zod-validated; moods are filtered against
-// MOOD_VOCAB defensively in case the model drifts off the controlled list.
-const TagSchema = z.object({
-  moods: z.array(z.string()).default([]),
-  energy: z.string().nullable().default(null),
-});
-
-const SYSTEM = `You tag music tracks with mood and energy for a personal radio station.
-
-For each track, output ONLY a JSON object:
-{
-  "moods": [1-3 strings, each from this exact list: ${MOOD_VOCAB.join(', ')}],
-  "energy": "low" | "medium" | "high"
-}
-
-Choose moods that reflect how the track FEELS to listen to, not just its genre.
-A spiritual Punjabi devotional is "spiritual" and "reflective" — not "cultural".
-A high-BPM dance track is "energetic" and "workout" — not "celebratory" unless it sounds festive.
-A slow rainy-day instrumental is "calm" and "rainy" — not "evening" just because it's chill.
-
-If you genuinely cannot tell from the title/artist/album, return {"moods":[],"energy":"medium"}. Do not invent.`;
-
-async function tagOne(song) {
-  const userPrompt =
-    `Title: ${song.title}\n` +
-    `Artist: ${song.artist || '?'}\n` +
-    `Album: ${song.album || '?'}\n` +
-    `Year: ${song.year || '?'}\n` +
-    `Genre: ${song.genre || '?'}`;
-
-  const parsed = await djObject({
-    system: SYSTEM,
-    prompt: userPrompt,
-    schema: TagSchema,
-    temperature: 0.2,
-    kind: 'tag-library',
-  });
-  const moods = Array.isArray(parsed.moods)
-    ? parsed.moods.filter(m => MOOD_VOCAB.includes(m)).slice(0, 3)
-    : [];
-  const energy = ['low', 'medium', 'high'].includes(parsed.energy) ? parsed.energy : null;
-  return { moods, energy };
-}
+import { tagOne } from './tagger-core.js';
 
 async function main() {
   const args = process.argv.slice(2);

--- a/controller/src/music/tagger-core.ts
+++ b/controller/src/music/tagger-core.ts
@@ -1,0 +1,65 @@
+// Shared tagging primitive.
+// One LLM call per track → { moods, energy }, validated against MOOD_VOCAB.
+// Used by the bulk tag-library.ts script and the inline /library/retag route,
+// so a single-track retag produces exactly the same shape as a bulk run.
+
+import { z } from 'zod';
+import { SHOW_MOODS as MOOD_VOCAB } from '../settings.js';
+import { djObject } from '../llm/sdk.js';
+
+export const TagSchema = z.object({
+  moods: z.array(z.string()).default([]),
+  energy: z.string().nullable().default(null),
+});
+
+export const TAGGER_SYSTEM = `You tag music tracks with mood and energy for a personal radio station.
+
+For each track, output ONLY a JSON object:
+{
+  "moods": [1-3 strings, each from this exact list: ${MOOD_VOCAB.join(', ')}],
+  "energy": "low" | "medium" | "high"
+}
+
+Choose moods that reflect how the track FEELS to listen to, not just its genre.
+A spiritual Punjabi devotional is "spiritual" and "reflective" — not "cultural".
+A high-BPM dance track is "energetic" and "workout" — not "celebratory" unless it sounds festive.
+A slow rainy-day instrumental is "calm" and "rainy" — not "evening" just because it's chill.
+
+If you genuinely cannot tell from the title/artist/album, return {"moods":[],"energy":"medium"}. Do not invent.`;
+
+export interface TaggableSong {
+  title?: string;
+  artist?: string;
+  album?: string;
+  year?: number | string | null;
+  genre?: string | null;
+}
+
+export interface TagResult {
+  moods: string[];
+  energy: 'low' | 'medium' | 'high' | null;
+}
+
+export async function tagOne(song: TaggableSong): Promise<TagResult> {
+  const userPrompt =
+    `Title: ${song.title}\n` +
+    `Artist: ${song.artist || '?'}\n` +
+    `Album: ${song.album || '?'}\n` +
+    `Year: ${song.year || '?'}\n` +
+    `Genre: ${song.genre || '?'}`;
+
+  const parsed = await djObject({
+    system: TAGGER_SYSTEM,
+    prompt: userPrompt,
+    schema: TagSchema,
+    temperature: 0.2,
+    kind: 'tag-library',
+  });
+  const moods = Array.isArray(parsed.moods)
+    ? parsed.moods.filter((m: string) => MOOD_VOCAB.includes(m)).slice(0, 3)
+    : [];
+  const energy = ['low', 'medium', 'high'].includes(parsed.energy as string)
+    ? (parsed.energy as 'low' | 'medium' | 'high')
+    : null;
+  return { moods, energy };
+}

--- a/controller/src/routes/jingles.ts
+++ b/controller/src/routes/jingles.ts
@@ -4,7 +4,7 @@ import express from 'express';
 import * as jingles from '../broadcast/jingles.js';
 import { queue } from '../broadcast/queue.js';
 import { requireAdmin } from '../middleware/auth.js';
-import { tagger, startTagger } from '../broadcast/tagger.js';
+import { tagger, startTagger, stopTagger } from '../broadcast/tagger.js';
 
 export const router = express.Router();
 
@@ -49,4 +49,11 @@ router.post('/tag-library', requireAdmin, (req, res) => {
   const limit = parseInt(req.body?.limit, 10);
   startTagger(limit);
   res.json({ ok: true, tagger });
+});
+
+// Stop the running tagger child (SIGTERM). Returns 409 if no run is active.
+router.post('/tag-library/stop', requireAdmin, (req, res) => {
+  if (!tagger.running) return res.status(409).json({ error: 'tagger is not running', tagger });
+  const result = stopTagger();
+  res.json({ ...result, tagger });
 });

--- a/controller/src/routes/library.ts
+++ b/controller/src/routes/library.ts
@@ -1,0 +1,229 @@
+// Admin-gated music-library management surface — backs /admin/library.
+// Browse + filter the tagged index (moods.json), page through untagged
+// tracks, retag a single track inline, and report coverage stats.
+import express from 'express';
+import { requireAdmin } from '../middleware/auth.js';
+import * as library from '../music/library.js';
+import * as coverage from '../music/library-coverage.js';
+import * as subsonic from '../music/subsonic.js';
+import * as settings from '../settings.js';
+import { tagOne } from '../music/tagger-core.js';
+import { queue } from '../broadcast/queue.js';
+
+export const router = express.Router();
+
+// ---------------------------------------------------------------------------
+// GET /library/browse — filter the tagged index.
+// Query: moods=a,b energy=low genre=Rock yearFrom=1990 yearTo=2000
+//        q=foo sort=artist|title|year|taggedAt limit=50 offset=0
+// ---------------------------------------------------------------------------
+router.get('/library/browse', requireAdmin, async (req, res) => {
+  try {
+    await library.load();
+    const q = req.query || {};
+    const moods = parseList(q.moods);
+    const sort = (typeof q.sort === 'string' ? q.sort : 'artist') as
+      | 'artist' | 'title' | 'year' | 'taggedAt';
+    const limit = parseIntSafe(q.limit, 50);
+    const offset = parseIntSafe(q.offset, 0);
+    const yearFrom = parseIntSafe(q.yearFrom, null);
+    const yearTo = parseIntSafe(q.yearTo, null);
+
+    const result = library.filter({
+      moods,
+      energy: typeof q.energy === 'string' && q.energy ? q.energy : null,
+      genre: typeof q.genre === 'string' && q.genre ? q.genre : null,
+      yearFrom,
+      yearTo,
+      q: typeof q.q === 'string' ? q.q : null,
+      sort,
+      limit,
+      offset,
+    });
+    const stats = library.stats();
+    res.json({
+      ...result,
+      moodVocab: settings.SHOW_MOODS,
+      stats: {
+        total: stats.total,
+        byMood: stats.byMood,
+        byEnergy: stats.byEnergy,
+        byGenre: stats.byGenre,
+        updatedAt: stats.updatedAt,
+      },
+    });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /library/genres — distinct genres for the filter dropdown.
+// Merges Navidrome's getGenres() with whatever's already in the tagged index.
+// Cached at the Subsonic layer; cheap enough to hit per page-load.
+// ---------------------------------------------------------------------------
+router.get('/library/genres', requireAdmin, async (req, res) => {
+  try {
+    await library.load();
+    const tagged = library.stats().byGenre || {};
+    let navidromeGenres: { value: string; songCount?: number }[] = [];
+    try { navidromeGenres = await subsonic.getGenres(); } catch {}
+    const merged: Record<string, number> = { ...tagged };
+    for (const g of navidromeGenres || []) {
+      if (!g?.value) continue;
+      if (merged[g.value] == null) merged[g.value] = g.songCount || 0;
+    }
+    const list = Object.entries(merged)
+      .map(([value, songCount]) => ({ value, songCount }))
+      .sort((a, b) => b.songCount - a.songCount);
+    res.json({ genres: list });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /library/untagged?limit=&cursor=
+// Cursor is an opaque base64 of `albumOffset:songIndexInAlbum` so the next
+// request resumes where the last one stopped. Returns up to `limit` untagged
+// rows + a nextCursor (or null if the walk reached the end).
+// ---------------------------------------------------------------------------
+router.get('/library/untagged', requireAdmin, async (req, res) => {
+  await library.load();
+  const limit = Math.min(Math.max(parseIntSafe(req.query?.limit, 50) ?? 50, 1), 100);
+  const cursor = decodeCursor(typeof req.query?.cursor === 'string' ? req.query.cursor : '');
+  const startAlbumOffset = cursor.albumOffset;
+  const startSongIndex = cursor.songIndex;
+
+  const rows: any[] = [];
+  let nextCursor: string | null = null;
+  let visited = 0;
+  const SCAN_BUDGET = 5000; // avoid pathological full-library walks per request
+  const BATCH = 200;
+  let albumOffset = startAlbumOffset;
+  let songIndex = startSongIndex;
+
+  try {
+    outer: while (visited < SCAN_BUDGET) {
+      const albums = await subsonic.getAlbumList(albumOffset, BATCH);
+      if (albums.length === 0) break;
+      for (let i = 0; i < albums.length; i++) {
+        const album = albums[i];
+        let songs: any[] = [];
+        try { songs = await subsonic.getAlbum(album.id); } catch { songs = []; }
+        for (let j = (i === 0 ? songIndex : 0); j < songs.length; j++) {
+          const s = songs[j];
+          visited++;
+          if (library.has(s.id)) continue;
+          rows.push({
+            id: s.id,
+            title: s.title,
+            artist: s.artist,
+            album: s.album,
+            year: s.year ?? null,
+            genre: s.genre ?? null,
+            duration: s.duration ?? null,
+          });
+          if (rows.length >= limit) {
+            // Resume from the next song in this album.
+            nextCursor = encodeCursor({
+              albumOffset: albumOffset + i,
+              songIndex: j + 1,
+            });
+            break outer;
+          }
+        }
+      }
+      if (albums.length < BATCH) break;
+      albumOffset += albums.length;
+      songIndex = 0;
+    }
+    res.json({ rows, nextCursor });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /library/coverage — { tagged, total, percent, scannedAt, scanning }
+// `total` / `percent` are null until the first background scan completes.
+// ---------------------------------------------------------------------------
+router.get('/library/coverage', requireAdmin, async (req, res) => {
+  try {
+    if (req.query?.refresh === '1') coverage.refresh();
+    res.json(await coverage.get());
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /library/retag — inline single-track tag refresh.
+// Body: { id, title?, artist?, album?, year?, genre? }
+// Metadata is taken from the body if present, otherwise we re-fetch via
+// Subsonic search. Writes the new tags into the in-memory store + moods.json.
+// ---------------------------------------------------------------------------
+router.post('/library/retag', requireAdmin, async (req, res) => {
+  const id = req.body?.id;
+  if (!id || typeof id !== 'string') return res.status(400).json({ error: 'id is required' });
+  try {
+    await library.load();
+    let song: any = req.body || {};
+    if (!song.title || !song.artist) {
+      // Reach back to Subsonic to fill metadata when the caller only sent an id.
+      const found = await subsonic.search(`${song.title || ''} ${song.artist || ''}`.trim() || id, { songCount: 25 });
+      const hit = (found || []).find((s: any) => s.id === id);
+      if (hit) song = { ...hit, ...song };
+    }
+    if (!song.title) return res.status(404).json({ error: 'track metadata not found' });
+
+    const { moods, energy } = await tagOne(song);
+    library.set(id, {
+      title: song.title,
+      artist: song.artist,
+      album: song.album,
+      year: song.year,
+      genre: song.genre,
+      moods,
+      energy,
+    });
+    await library.save();
+    const tagged = library.get(id);
+    res.json({ id, moods, energy, taggedAt: tagged?.taggedAt });
+  } catch (err: any) {
+    queue.log('error', `/library/retag failed: ${err.message}`);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+function parseList(v: any): string[] {
+  if (Array.isArray(v)) return v.flatMap((x: any) => parseList(x));
+  if (typeof v === 'string') return v.split(',').map(s => s.trim()).filter(Boolean);
+  return [];
+}
+
+function parseIntSafe<T extends number | null>(v: any, dflt: T): number | T {
+  if (v == null || v === '') return dflt;
+  const n = parseInt(String(v), 10);
+  return Number.isFinite(n) ? n : dflt;
+}
+
+function encodeCursor(c: { albumOffset: number; songIndex: number }) {
+  return Buffer.from(`${c.albumOffset}:${c.songIndex}`, 'utf8').toString('base64url');
+}
+function decodeCursor(s: string): { albumOffset: number; songIndex: number } {
+  if (!s) return { albumOffset: 0, songIndex: 0 };
+  try {
+    const decoded = Buffer.from(s, 'base64url').toString('utf8');
+    const [a, b] = decoded.split(':');
+    const albumOffset = parseInt(a, 10);
+    const songIndex = parseInt(b, 10);
+    if (!Number.isFinite(albumOffset) || !Number.isFinite(songIndex)) return { albumOffset: 0, songIndex: 0 };
+    return { albumOffset, songIndex };
+  } catch {
+    return { albumOffset: 0, songIndex: 0 };
+  }
+}

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -22,6 +22,7 @@ import { router as sfxRoutes } from './routes/sfx.js';
 import { router as debugRoutes } from './routes/debug.js';
 import { router as statsRoutes } from './routes/stats.js';
 import { router as djRoutes } from './routes/dj.js';
+import { router as libraryRoutes } from './routes/library.js';
 import { router as onboardingRoutes } from './routes/onboarding.js';
 import { loadSecretsIntoEnv } from './setup/secrets.js';
 import { loadSetupConfig } from './setup/config.js';
@@ -43,6 +44,7 @@ app.use(sfxRoutes);
 app.use(debugRoutes);
 app.use(statsRoutes);
 app.use(djRoutes);
+app.use(libraryRoutes);
 app.use(onboardingRoutes);
 
 // (manual skip is not implemented in this build — Liquidsoap controls pacing)

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -1,44 +1,70 @@
 'use client';
 
-// Library — /admin/library. The operator searches the Navidrome library and
-// pushes a chosen track straight into the queue (an admin-grade version of
-// the listener request flow, without the LLM matching guesswork). A "Recently
-// added" section surfaces the most recently added music for one-click queuing,
-// and the mood tagger runs the resumable library tagger that classifies tracks.
-import type { ChangeEvent, FormEvent, ReactNode } from 'react';
-import { useCallback, useEffect, useState } from 'react';
-import { Search } from 'lucide-react';
+// Library — /admin/library.
+//
+// Three tabs over the same chrome:
+//   • Browse — filters the tagged moods.json index (mood/energy/genre/year/q).
+//   • Search — Navidrome free-text (the legacy /dj/search path).
+//   • Untagged — paginates through library tracks that haven't been tagged yet.
+//   • Recently added — newest album tracks for quick discovery.
+//
+// Each row supports `Queue` (push to the live queue) and, where applicable,
+// `Retag` / `Tag` (single-track LLM classification via /library/retag).
+// A sticky tagger strip at the bottom owns the background batch job.
+
+import type { ChangeEvent, FormEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Search, RotateCcw } from 'lucide-react';
 import { useAdminAuth } from '../../lib/adminAuth';
+import { useDynamicStyle } from '../../hooks/useDynamicStyle';
 import { notify, errorMessage } from '../../lib/notify';
 import { Input } from '../ui/input';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group';
 import { Field, FieldLabel } from '../ui/field';
+import { Checkbox } from '../ui/checkbox';
+import {
+  Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
+} from '../ui/select';
 import { Card, Btn, Pill, Eyebrow, Seg, Metric } from './ui';
 import { cn } from '../../lib/cn';
 
+// ---------------------------------------------------------------------------
+// types
+// ---------------------------------------------------------------------------
 interface Track {
   id: string;
   title?: string;
   artist?: string;
   album?: string;
-  duration?: number;
+  year?: number | string | null;
+  genre?: string | null;
+  duration?: number | null;
+  moods?: string[];
+  energy?: string | null;
+  taggedAt?: string;
 }
 
-interface QueueTrackResponse {
-  track?: Track;
-  queuePosition?: number;
-  error?: string;
+interface BrowseResponse {
+  rows: Track[];
+  total: number;
+  moodVocab: string[];
+  stats: {
+    total: number;
+    byMood: Record<string, number>;
+    byEnergy: Record<string, number>;
+    byGenre: Record<string, number>;
+    updatedAt: string | null;
+  };
 }
 
-interface SearchResponse {
-  results?: Track[];
-  error?: string;
-}
+interface UntaggedResponse { rows: Track[]; nextCursor: string | null }
 
-interface LibraryStats {
-  total?: number;
-  byMood?: Record<string, number>;
-  updatedAt?: string;
+interface Coverage {
+  tagged: number;
+  total: number | null;
+  percent: number | null;
+  scannedAt: string | null;
+  scanning: boolean;
 }
 
 interface TaggerState {
@@ -48,80 +74,222 @@ interface TaggerState {
   lastLog?: string[];
 }
 
-interface SettingsResponse {
-  libraryStats?: LibraryStats;
-  tagger?: TaggerState;
-}
+interface SettingsResponse { tagger?: TaggerState }
 
+type Tab = 'browse' | 'search' | 'untagged' | 'recent';
+type Sort = 'artist' | 'title' | 'year' | 'taggedAt';
+type Energy = 'any' | 'low' | 'medium' | 'high';
+
+const PAGE_SIZE = 50;
+
+// ---------------------------------------------------------------------------
+// panel
+// ---------------------------------------------------------------------------
 export default function LibraryPanel() {
   const { adminFetch, needsAuth, hydrated } = useAdminAuth();
-  const [query, setQuery] = useState('');
-  const [results, setResults] = useState<Track[] | null>(null);
-  const [searching, setSearching] = useState(false);
-  const [queuing, setQueuing] = useState<string | null>(null);
-  const [recent, setRecent] = useState<Track[] | null>(null);
-  const [loadingRecent, setLoadingRecent] = useState(false);
-  const [tagState, setTagState] = useState<SettingsResponse | null>(null);
-  const [taggerLimit, setTaggerLimit] = useState('50');
-  const [taggerBusy, setTaggerBusy] = useState(false);
-
   const ready = hydrated && !needsAuth;
 
-  const loadRecent = useCallback(async () => {
+  // shared state
+  const [tab, setTab] = useState<Tab>('browse');
+  const [coverage, setCoverage] = useState<Coverage | null>(null);
+  const [tagger, setTagger] = useState<TaggerState | null>(null);
+  const [taggerLimit, setTaggerLimit] = useState('500');
+  const [taggerBusy, setTaggerBusy] = useState(false);
+  const [queuing, setQueuing] = useState<string | null>(null);
+  const [retagging, setRetagging] = useState<string | null>(null);
+
+  // browse state
+  const [moods, setMoods] = useState<string[]>([]);
+  const [energy, setEnergy] = useState<Energy>('any');
+  const [genre, setGenre] = useState<string>('');
+  const [yearFrom, setYearFrom] = useState<string>('');
+  const [yearTo, setYearTo] = useState<string>('');
+  const [q, setQ] = useState<string>('');
+  const [sort, setSort] = useState<Sort>('artist');
+  const [page, setPage] = useState(0);
+  const [browse, setBrowse] = useState<BrowseResponse | null>(null);
+  const [browseLoading, setBrowseLoading] = useState(false);
+
+  // genre list (lazy)
+  const [genreList, setGenreList] = useState<{ value: string; songCount: number }[]>([]);
+
+  // search state
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<Track[] | null>(null);
+  const [searching, setSearching] = useState(false);
+
+  // untagged state
+  const [untagged, setUntagged] = useState<Track[]>([]);
+  const [untaggedCursor, setUntaggedCursor] = useState<string | null>(null);
+  const [untaggedLoading, setUntaggedLoading] = useState(false);
+
+  // recent state
+  const [recent, setRecent] = useState<Track[] | null>(null);
+  const [recentLoading, setRecentLoading] = useState(false);
+
+  // -----------------------------------------------------------------------
+  // polling — coverage (60 s) + tagger status (3 s while running, 10 s idle)
+  // -----------------------------------------------------------------------
+  const loadCoverage = useCallback(async () => {
     if (!ready) return;
-    setLoadingRecent(true);
     try {
-      const r = await adminFetch('/dj/recent?limit=25');
-      const j = (await r.json().catch(() => ({}))) as SearchResponse;
-      if (!r.ok) throw new Error(j.error || `latest tracks failed (${r.status})`);
-      setRecent(Array.isArray(j.results) ? j.results : []);
-    } catch (err) {
-      notify.err(errorMessage(err));
-      setRecent([]);
-    } finally {
-      setLoadingRecent(false);
-    }
+      const r = await adminFetch('/library/coverage');
+      if (!r.ok) return;
+      setCoverage((await r.json()) as Coverage);
+    } catch { /* transient */ }
   }, [adminFetch, ready]);
 
-  useEffect(() => { loadRecent(); }, [loadRecent]);
-
-  // Library stats + tagger progress live on /settings — poll so an in-flight
-  // tagging run reports live progress without a manual refresh.
-  const loadTagState = useCallback(async () => {
+  const loadTagger = useCallback(async () => {
     if (!ready) return;
     try {
       const r = await adminFetch('/settings');
       if (!r.ok) return;
       const j = (await r.json()) as SettingsResponse;
-      setTagState({ libraryStats: j.libraryStats, tagger: j.tagger });
-    } catch { /* transient — next poll retries */ }
+      setTagger(j.tagger || null);
+    } catch { /* transient */ }
   }, [adminFetch, ready]);
 
   useEffect(() => {
     if (!ready) return;
-    loadTagState();
-    const id = setInterval(loadTagState, 3000);
+    loadCoverage();
+    const id = setInterval(loadCoverage, 60_000);
     return () => clearInterval(id);
-  }, [ready, loadTagState]);
+  }, [ready, loadCoverage]);
 
-  const runSearch = async (e?: FormEvent<HTMLFormElement>) => {
-    e?.preventDefault();
-    const q = query.trim();
-    if (!q || !ready) return;
-    setSearching(true);
+  useEffect(() => {
+    if (!ready) return;
+    loadTagger();
+    const interval = tagger?.running ? 3_000 : 10_000;
+    const id = setInterval(loadTagger, interval);
+    return () => clearInterval(id);
+  }, [ready, loadTagger, tagger?.running]);
+
+  // -----------------------------------------------------------------------
+  // browse fetch — debounced on filter change
+  // -----------------------------------------------------------------------
+  const runBrowse = useCallback(async () => {
+    if (!ready) return;
+    setBrowseLoading(true);
     try {
-      const r = await adminFetch(`/dj/search?q=${encodeURIComponent(q)}`);
-      const j = (await r.json().catch(() => ({}))) as SearchResponse;
-      if (!r.ok) throw new Error(j.error || `search failed (${r.status})`);
-      setResults(Array.isArray(j.results) ? j.results : []);
+      const params = new URLSearchParams();
+      if (moods.length) params.set('moods', moods.join(','));
+      if (energy !== 'any') params.set('energy', energy);
+      if (genre) params.set('genre', genre);
+      if (yearFrom) params.set('yearFrom', yearFrom);
+      if (yearTo) params.set('yearTo', yearTo);
+      if (q.trim()) params.set('q', q.trim());
+      params.set('sort', sort);
+      params.set('limit', String(PAGE_SIZE));
+      params.set('offset', String(page * PAGE_SIZE));
+      const r = await adminFetch(`/library/browse?${params}`);
+      if (!r.ok) throw new Error(`browse failed (${r.status})`);
+      setBrowse((await r.json()) as BrowseResponse);
     } catch (err) {
       notify.err(errorMessage(err));
-      setResults([]);
+      setBrowse(null);
+    } finally {
+      setBrowseLoading(false);
+    }
+  }, [adminFetch, ready, moods, energy, genre, yearFrom, yearTo, q, sort, page]);
+
+  useEffect(() => {
+    if (!ready || tab !== 'browse') return;
+    const t = setTimeout(runBrowse, 250);
+    return () => clearTimeout(t);
+  }, [ready, tab, runBrowse]);
+
+  // genre dropdown — fetch once
+  useEffect(() => {
+    if (!ready || genreList.length) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await adminFetch('/library/genres');
+        if (!r.ok) return;
+        const j = await r.json() as { genres: { value: string; songCount: number }[] };
+        if (!cancelled) setGenreList(j.genres || []);
+      } catch { /* skip */ }
+    })();
+    return () => { cancelled = true; };
+  }, [ready, adminFetch, genreList.length]);
+
+  // reset to page 0 when any filter (other than page itself) changes
+  useEffect(() => { setPage(0); }, [moods, energy, genre, yearFrom, yearTo, q, sort]);
+
+  // -----------------------------------------------------------------------
+  // search fetch
+  // -----------------------------------------------------------------------
+  const runSearch = async (e?: FormEvent<HTMLFormElement>) => {
+    e?.preventDefault();
+    const text = searchQuery.trim();
+    if (!text || !ready) return;
+    setSearching(true);
+    try {
+      const r = await adminFetch(`/dj/search?q=${encodeURIComponent(text)}`);
+      const j = await r.json().catch(() => ({})) as { results?: Track[]; error?: string };
+      if (!r.ok) throw new Error(j.error || `search failed (${r.status})`);
+      setSearchResults(j.results || []);
+    } catch (err) {
+      notify.err(errorMessage(err));
+      setSearchResults([]);
     } finally {
       setSearching(false);
     }
   };
 
+  // -----------------------------------------------------------------------
+  // untagged paging
+  // -----------------------------------------------------------------------
+  const loadUntagged = useCallback(async (cursor: string | null, append: boolean) => {
+    if (!ready) return;
+    setUntaggedLoading(true);
+    try {
+      const params = new URLSearchParams({ limit: '50' });
+      if (cursor) params.set('cursor', cursor);
+      const r = await adminFetch(`/library/untagged?${params}`);
+      if (!r.ok) throw new Error(`untagged failed (${r.status})`);
+      const j = await r.json() as UntaggedResponse;
+      setUntagged(prev => (append ? [...prev, ...j.rows] : j.rows));
+      setUntaggedCursor(j.nextCursor);
+    } catch (err) {
+      notify.err(errorMessage(err));
+    } finally {
+      setUntaggedLoading(false);
+    }
+  }, [adminFetch, ready]);
+
+  useEffect(() => {
+    if (tab !== 'untagged' || !ready) return;
+    if (untagged.length === 0) loadUntagged(null, false);
+  }, [tab, ready, untagged.length, loadUntagged]);
+
+  // -----------------------------------------------------------------------
+  // recent fetch
+  // -----------------------------------------------------------------------
+  const loadRecent = useCallback(async () => {
+    if (!ready) return;
+    setRecentLoading(true);
+    try {
+      const r = await adminFetch('/dj/recent?limit=50');
+      if (!r.ok) throw new Error(`recent failed (${r.status})`);
+      const j = await r.json() as { results: Track[] };
+      setRecent(j.results || []);
+    } catch (err) {
+      notify.err(errorMessage(err));
+      setRecent([]);
+    } finally {
+      setRecentLoading(false);
+    }
+  }, [adminFetch, ready]);
+
+  useEffect(() => {
+    if (tab !== 'recent' || !ready) return;
+    if (recent === null) loadRecent();
+  }, [tab, ready, recent, loadRecent]);
+
+  // -----------------------------------------------------------------------
+  // row actions
+  // -----------------------------------------------------------------------
   const queueTrack = async (track: Track) => {
     setQueuing(track.id);
     try {
@@ -130,9 +298,9 @@ export default function LibraryPanel() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(track),
       });
-      const j = (await r.json().catch(() => ({}))) as QueueTrackResponse;
+      const j = await r.json().catch(() => ({})) as { queuePosition?: number; error?: string };
       if (!r.ok) throw new Error(j.error || `queue failed (${r.status})`);
-      notify.ok(`queued “${j.track?.title || track.title}” · position ${j.queuePosition}`);
+      notify.ok(`queued “${track.title}” · position ${j.queuePosition}`);
     } catch (err) {
       notify.err(errorMessage(err));
     } finally {
@@ -140,6 +308,31 @@ export default function LibraryPanel() {
     }
   };
 
+  const retagTrack = async (track: Track) => {
+    setRetagging(track.id);
+    try {
+      const r = await adminFetch('/library/retag', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(track),
+      });
+      const j = await r.json() as { moods?: string[]; energy?: string | null; error?: string };
+      if (!r.ok) throw new Error(j.error || `retag failed (${r.status})`);
+      const tagStr = j.moods?.length ? j.moods.join(', ') : '—';
+      notify.ok(`retagged · ${tagStr} [${j.energy || '?'}]`);
+      if (tab === 'browse') runBrowse();
+      if (tab === 'untagged') setUntagged(prev => prev.filter(t => t.id !== track.id));
+      loadCoverage();
+    } catch (err) {
+      notify.err(errorMessage(err));
+    } finally {
+      setRetagging(null);
+    }
+  };
+
+  // -----------------------------------------------------------------------
+  // tagger controls
+  // -----------------------------------------------------------------------
   const startTagger = async () => {
     setTaggerBusy(true);
     try {
@@ -149,10 +342,10 @@ export default function LibraryPanel() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(Number.isFinite(limit) && limit > 0 ? { limit } : {}),
       });
-      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      const j = await r.json().catch(() => ({})) as { error?: string };
       if (!r.ok) throw new Error(j.error || `tagger start failed (${r.status})`);
       notify.ok('tagger started');
-      await loadTagState();
+      await loadTagger();
     } catch (err) {
       notify.err(errorMessage(err));
     } finally {
@@ -160,314 +353,581 @@ export default function LibraryPanel() {
     }
   };
 
-  const libraryStats = tagState?.libraryStats;
-  const tagger = tagState?.tagger;
+  const stopTagger = async () => {
+    setTaggerBusy(true);
+    try {
+      const r = await adminFetch('/tag-library/stop', { method: 'POST' });
+      const j = await r.json().catch(() => ({})) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `tagger stop failed (${r.status})`);
+      notify.ok('stopping tagger…');
+      await loadTagger();
+    } catch (err) {
+      notify.err(errorMessage(err));
+    } finally {
+      setTaggerBusy(false);
+    }
+  };
 
-  const taggedTotal = libraryStats?.total ?? 0;
-  const moodEntries: [string, number][] = Object.entries(libraryStats?.byMood || {}).sort(
-    (a, b) => b[1] - a[1],
-  );
-  const resultCount = results === null ? null : results.length;
+  // -----------------------------------------------------------------------
+  // derived
+  // -----------------------------------------------------------------------
+  const stats = browse?.stats;
+  const moodVocab = browse?.moodVocab || [];
+  const totalPages = browse ? Math.max(1, Math.ceil(browse.total / PAGE_SIZE)) : 1;
+  const filtersActive =
+    moods.length > 0 || energy !== 'any' || !!genre || !!yearFrom || !!yearTo || !!q.trim();
+
+  const clearFilters = () => {
+    setMoods([]); setEnergy('any'); setGenre(''); setYearFrom(''); setYearTo(''); setQ('');
+    setSort('artist'); setPage(0);
+  };
+
+  const tableRows: Track[] =
+    tab === 'browse' ? (browse?.rows || []) :
+    tab === 'search' ? (searchResults || []) :
+    tab === 'untagged' ? untagged :
+    (recent || []);
+  const tableLoading =
+    tab === 'browse' ? browseLoading :
+    tab === 'search' ? searching :
+    tab === 'untagged' ? untaggedLoading :
+    recentLoading;
 
   return (
-    <div className="grid gap-4">
-      {/* ── HERO SEARCH ─────────────────────────────────────────────────── */}
-      <section className="card">
-        <div className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-ink p-4">
-          <div>
-            <Eyebrow className="text-vermilion">library · search · queue</Eyebrow>
-            <div className="mt-1.5 text-[22px] font-extrabold tracking-[-0.02em]">
-              Find a track. Queue it instantly.
-            </div>
-            <div className="mt-1 text-[11px] text-muted">
-              Search Navidrome by artist, title, or album — no LLM matching.
-            </div>
-          </div>
-          <div className="flex items-center gap-3">
-            <Metric n={taggedTotal.toLocaleString('en-GB')} l="tracks tagged" />
-            <span className="h-8 w-px bg-separator-strong" />
-            <Metric n={moodEntries.length} l="moods" accent />
-          </div>
-        </div>
+    <div className="grid gap-4 pb-24">
+      <KpiStrip coverage={coverage} stats={stats} />
 
-        <div className="p-4">
-          <form onSubmit={runSearch} className="flex gap-2">
-            <InputGroup className="flex-1">
-              <InputGroupAddon>
-                <Search />
-              </InputGroupAddon>
-              <InputGroupInput
-                placeholder="floating points, kingdoms in colour, 2018…"
-                value={query}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => setQuery(e.target.value)}
-              />
-            </InputGroup>
-            <Btn lg tone="accent" type="submit" disabled={searching || !query.trim() || !ready}>
-              {searching ? 'Searching…' : 'Search'}
-            </Btn>
-            <Btn lg type="button" onClick={() => { setQuery(''); setResults(null); }} disabled={searching}>
-              Clear
-            </Btn>
-          </form>
-          <div className="mt-3 flex flex-wrap items-center gap-3.5">
-            <span className="caption">filter</span>
-            <Seg
-              value="any"
-              onChange={(id) => setQuery(id === 'any' ? query : id)}
-              options={[
-                { id: 'any', label: 'Any' },
-                { id: 'ambient', label: 'Ambient' },
-                { id: 'slow', label: 'Slow' },
-                { id: 'driving', label: 'Driving' },
-                { id: 'jazz', label: 'Jazz' },
-                { id: 'deep', label: 'Deep' },
-              ]}
-            />
-            <span className="caption ml-3">energy</span>
-            <Seg
-              value="any"
-              options={[
-                { id: 'any', label: 'Any' },
-                { id: 'low', label: 'Low' },
-                { id: 'mid', label: 'Mid' },
-                { id: 'high', label: 'High' },
-              ]}
-            />
-            <span className="ml-auto text-[11px] text-muted">
-              {resultCount === null
-                ? 'search the library to queue a track'
-                : `${resultCount} result${resultCount === 1 ? '' : 's'} · sorted by relevance`}
-            </span>
-          </div>
-        </div>
-      </section>
-
-      {/* ── 2-COL ─────────────────────────────────────────────────────── */}
-      <div className="stack-mobile grid grid-cols-[1fr_240px] items-start gap-4">
-        {/* RESULTS */}
-        <div className="grid gap-4">
-          <Card
-            title="Results"
-            sub={query.trim() ? `for ‘${query.trim()}’` : 'manual queue'}
-            bodyClass="px-3.5 py-1"
-          >
-            {results === null ? (
-              <Empty>search the library to queue a track</Empty>
-            ) : results.length === 0 ? (
-              <Empty>{searching ? 'searching…' : 'no tracks found'}</Empty>
-            ) : (
-              <TrackTable tracks={results} queuing={queuing} onQueue={queueTrack} />
-            )}
-          </Card>
-
-          <Card
-            title="Recently added"
-            sub="latest tracks"
-            right={
-              <Btn sm onClick={loadRecent} disabled={loadingRecent || !ready}>
-                {loadingRecent ? 'Loading…' : 'Refresh'}
-              </Btn>
-            }
-          >
-            {recent === null ? (
-              <Empty>{loadingRecent ? 'loading latest tracks…' : 'recently added tracks appear here'}</Empty>
-            ) : recent.length === 0 ? (
-              <Empty>no recently added tracks</Empty>
-            ) : (
-              <div className="grid gap-2">
-                {recent.map(r => (
-                  <div
-                    key={r.id}
-                    className="grid grid-cols-[1fr_auto_auto] items-center gap-3 border-b border-dashed border-separator-strong py-1.5"
-                  >
-                    <div className="min-w-0 text-[13px]">
-                      <span className="text-ink">{r.title}</span>
-                      <span className="text-muted"> — {r.artist}</span>
-                      {r.album && <span className="text-muted"> · {r.album}</span>}
-                    </div>
-                    {r.duration != null && (
-                      <span className="mono-num text-[10px] text-muted">{fmtDuration(r.duration)}</span>
-                    )}
-                    <Btn sm onClick={() => queueTrack(r)} disabled={!!queuing}>
-                      {queuing === r.id ? 'Queuing…' : 'Queue'}
-                    </Btn>
-                  </div>
-                ))}
-              </div>
-            )}
-          </Card>
-        </div>
-
-        {/* SIDEBAR */}
+      <div className="stack-mobile grid grid-cols-[260px_1fr] items-start gap-4">
         <aside className="grid gap-4">
-          <Card title="Browse" bodyClass="!p-0">
-            <div className="py-1">
-              {[
-                { l: 'Search results', n: resultCount == null ? '—' : resultCount, a: true },
-                { l: 'Recently added', n: recent == null ? '—' : recent.length },
-                { l: 'Tracks tagged', n: taggedTotal.toLocaleString('en-GB') },
-                { l: 'Moods classified', n: moodEntries.length },
-              ].map(x => (
-                <div
-                  key={x.l}
-                  className={cn(
-                    'flex items-center justify-between px-3.5 py-2 text-[12px]',
-                    x.a
-                      ? 'border-l-2 border-[var(--accent)] bg-[var(--ink-soft)]'
-                      : 'border-l-2 border-transparent',
-                  )}
-                >
-                  <span className={x.a ? 'font-bold' : 'font-medium'}>{x.l}</span>
-                  <span className="mono-num text-[10px] text-muted">{x.n}</span>
-                </div>
-              ))}
-            </div>
-          </Card>
+          <TabRail tab={tab} setTab={setTab} />
 
-          <Card title="By mood">
-            {moodEntries.length === 0 ? (
-              <div className="text-[11px] text-muted italic">
-                run the tagger to classify your library
-              </div>
-            ) : (
-              <div className="flex flex-wrap gap-1.5">
-                {moodEntries.map(([m, n], i) => (
-                  <Pill
-                    key={m}
-                    tone={i === 0 ? 'ink' : 'default'}
-                    onClick={() => setQuery(m)}
-                    title={`search “${m}”`}
-                  >
-                    {m}
-                    <span
-                      className={cn(
-                        'mono-num ml-1',
-                        i === 0 ? 'text-ink' : 'text-muted',
-                      )}
-                    >
-                      {n}
-                    </span>
-                  </Pill>
-                ))}
-              </div>
-            )}
-          </Card>
+          {tab === 'browse' && (
+            <BrowseFilters
+              moodVocab={moodVocab}
+              moodCounts={stats?.byMood || {}}
+              energyCounts={stats?.byEnergy || {}}
+              genreList={genreList}
+              moods={moods} setMoods={setMoods}
+              energy={energy} setEnergy={setEnergy}
+              genre={genre} setGenre={setGenre}
+              yearFrom={yearFrom} setYearFrom={setYearFrom}
+              yearTo={yearTo} setYearTo={setYearTo}
+              sort={sort} setSort={setSort}
+              filtersActive={filtersActive}
+              onClear={clearFilters}
+            />
+          )}
 
-          <Card title="Mood tagger">
-            <div className="text-[12px] font-bold text-ink">
-              {taggedTotal} tracks tagged
-            </div>
-            {libraryStats?.updatedAt && (
-              <div className="mt-0.5 text-[10px] text-muted">
-                last update {new Date(libraryStats.updatedAt).toLocaleString('en-GB')}
+          {tab !== 'browse' && (
+            <Card title="About this view" bodyClass="!py-3">
+              <div className="text-[11px] leading-[1.5] text-muted">
+                {tab === 'search' && 'Free-text search against Navidrome — best for finding a specific track to queue right now.'}
+                {tab === 'untagged' && 'Tracks that don\'t yet have moods/energy classified. Tag them one at a time, or kick off the bulk tagger at the bottom of the page.'}
+                {tab === 'recent' && 'The newest tracks added to your Navidrome library.'}
               </div>
-            )}
-            <div className="mt-1.5 text-[11px] leading-[1.5] text-muted">
-              Walks Navidrome album-by-album, classifies each track via Ollama. Resumable —
-              tagged tracks are skipped.
-            </div>
-
-            <Field className="mt-3">
-              <FieldLabel htmlFor="tagger-limit">limit</FieldLabel>
-              <Input
-                id="tagger-limit"
-                type="number"
-                className="mono-num"
-                value={taggerLimit}
-                onChange={e => setTaggerLimit(e.target.value)}
-                disabled={tagger?.running}
-              />
-            </Field>
-            <Btn
-              tone="accent"
-              onClick={startTagger}
-              disabled={taggerBusy || tagger?.running || !ready}
-              className="mt-2.5 w-full justify-center"
-            >
-              {tagger?.running ? 'Running…' : 'Start tagging'}
-            </Btn>
-            {tagger?.running && tagger.startedAt && (
-              <div className="mt-2 text-[10px] text-muted">
-                pid {tagger.pid} · started {new Date(tagger.startedAt).toLocaleTimeString('en-GB')}
-              </div>
-            )}
-
-            {tagger?.lastLog && tagger.lastLog.length > 0 && (
-              <details className="mt-3 border border-separator-strong">
-                <summary className="caption cursor-pointer px-2.5 py-2">
-                  tagger log ({tagger.lastLog.length} lines)
-                </summary>
-                <pre className="term m-0 max-h-60 border-t border-separator-strong">
-                  {tagger.lastLog.join('\n')}
-                </pre>
-              </details>
-            )}
-          </Card>
+            </Card>
+          )}
         </aside>
+
+        <div className="grid gap-4">
+          {tab === 'browse' && (
+            <Card bodyClass="!py-3">
+              <div className="grid grid-cols-[1fr_auto] gap-2">
+                <InputGroup>
+                  <InputGroupAddon><Search /></InputGroupAddon>
+                  <InputGroupInput
+                    placeholder="filter results by title, artist, or album…"
+                    value={q}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => setQ(e.target.value)}
+                  />
+                </InputGroup>
+                <Btn type="button" onClick={() => runBrowse()} disabled={browseLoading}>
+                  {browseLoading ? 'Loading…' : 'Refresh'}
+                </Btn>
+              </div>
+            </Card>
+          )}
+
+          {tab === 'search' && (
+            <Card bodyClass="!py-3">
+              <form onSubmit={runSearch} className="grid grid-cols-[1fr_auto_auto] gap-2">
+                <InputGroup>
+                  <InputGroupAddon><Search /></InputGroupAddon>
+                  <InputGroupInput
+                    placeholder="floating points, kingdoms in colour, 2018…"
+                    value={searchQuery}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => setSearchQuery(e.target.value)}
+                  />
+                </InputGroup>
+                <Btn tone="accent" type="submit" disabled={searching || !searchQuery.trim() || !ready}>
+                  {searching ? 'Searching…' : 'Search'}
+                </Btn>
+                <Btn type="button" onClick={() => { setSearchQuery(''); setSearchResults(null); }} disabled={searching}>
+                  Clear
+                </Btn>
+              </form>
+            </Card>
+          )}
+
+          <Card
+            title={
+              tab === 'browse' ? 'Tracks' :
+              tab === 'search' ? 'Search results' :
+              tab === 'untagged' ? 'Untagged' :
+              'Recently added'
+            }
+            sub={
+              tab === 'browse'
+                ? (browse ? `${browse.total.toLocaleString('en-GB')} match${browse.total === 1 ? '' : 'es'}` : '')
+                : tab === 'search' ? (searchResults ? `${searchResults.length} result${searchResults.length === 1 ? '' : 's'}` : '')
+                : tab === 'untagged' ? `${untagged.length} loaded`
+                : (recent ? `${recent.length} tracks` : '')
+            }
+            right={
+              tab === 'recent' ? (
+                <Btn sm onClick={loadRecent} disabled={recentLoading}>{recentLoading ? 'Loading…' : 'Refresh'}</Btn>
+              ) : null
+            }
+            bodyClass="!p-0"
+          >
+            <TrackTable
+              tab={tab}
+              rows={tableRows}
+              loading={tableLoading}
+              queuing={queuing}
+              retagging={retagging}
+              onQueue={queueTrack}
+              onRetag={retagTrack}
+            />
+          </Card>
+
+          {tab === 'browse' && browse && browse.total > PAGE_SIZE && (
+            <div className="flex items-center justify-between text-[11px] text-muted">
+              <span className="mono-num">
+                {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, browse.total)} of {browse.total.toLocaleString('en-GB')}
+              </span>
+              <span className="flex items-center gap-2">
+                <Btn sm disabled={page === 0} onClick={() => setPage(p => Math.max(0, p - 1))}>‹ prev</Btn>
+                <span className="mono-num">page {page + 1} of {totalPages}</span>
+                <Btn sm disabled={page + 1 >= totalPages} onClick={() => setPage(p => p + 1)}>next ›</Btn>
+              </span>
+            </div>
+          )}
+
+          {tab === 'untagged' && untaggedCursor && (
+            <div className="flex justify-center">
+              <Btn onClick={() => loadUntagged(untaggedCursor, true)} disabled={untaggedLoading}>
+                {untaggedLoading ? 'Loading…' : 'Load more'}
+              </Btn>
+            </div>
+          )}
+        </div>
       </div>
+
+      <TaggerStrip
+        coverage={coverage}
+        tagger={tagger}
+        limit={taggerLimit}
+        setLimit={setTaggerLimit}
+        busy={taggerBusy}
+        onStart={startTagger}
+        onStop={stopTagger}
+      />
     </div>
   );
 }
 
-interface TrackTableProps {
-  tracks: Track[];
-  queuing: string | null;
-  onQueue: (t: Track) => void;
+// ---------------------------------------------------------------------------
+// KPI strip
+// ---------------------------------------------------------------------------
+function KpiStrip({ coverage, stats }: {
+  coverage: Coverage | null;
+  stats: BrowseResponse['stats'] | undefined;
+}) {
+  const taggedLabel = coverage?.tagged != null
+    ? coverage.tagged.toLocaleString('en-GB')
+    : (stats?.total != null ? stats.total.toLocaleString('en-GB') : '—');
+  const totalLabel = coverage?.total != null
+    ? coverage.total.toLocaleString('en-GB')
+    : (coverage?.scanning ? 'scanning…' : '—');
+  const percentLabel = coverage?.percent != null ? `${coverage.percent}%` : '—';
+  const moodCount = stats ? Object.keys(stats.byMood || {}).length : 0;
+  const lastTag = stats?.updatedAt ? new Date(stats.updatedAt).toLocaleString('en-GB') : '—';
+
+  return (
+    <section className="card">
+      <div className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-ink p-4">
+        <div>
+          <Eyebrow className="text-vermilion">library · browse · tag · queue</Eyebrow>
+          <div className="mt-1.5 text-[22px] font-extrabold tracking-[-0.02em]">
+            Manage the music your station plays.
+          </div>
+          <div className="mt-1 text-[11px] text-muted">
+            Filter the tagged index by mood, energy, genre, year, or artist.
+            Re-tag tracks the AI got wrong. Queue anything on demand.
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <Metric n={taggedLabel} l="tagged" />
+          <span className="h-8 w-px bg-separator-strong" />
+          <Metric n={totalLabel} l="library" />
+          <span className="h-8 w-px bg-separator-strong" />
+          <Metric n={percentLabel} l="coverage" accent />
+          <span className="h-8 w-px bg-separator-strong" />
+          <Metric n={moodCount} l="moods used" />
+        </div>
+      </div>
+      <div className="px-4 py-2 text-[11px] text-muted">last tag {lastTag}</div>
+    </section>
+  );
 }
 
-function TrackTable({ tracks, queuing, onQueue }: TrackTableProps) {
-  const colsClass = 'grid grid-cols-[24px_1fr_150px_56px_70px] gap-3';
+// ---------------------------------------------------------------------------
+// tab rail
+// ---------------------------------------------------------------------------
+function TabRail({ tab, setTab }: { tab: Tab; setTab: (t: Tab) => void }) {
+  const items: { id: Tab; label: string; hint: string }[] = [
+    { id: 'browse', label: 'Browse', hint: 'tagged' },
+    { id: 'search', label: 'Search', hint: 'navidrome' },
+    { id: 'untagged', label: 'Untagged', hint: 'needs tags' },
+    { id: 'recent', label: 'Recently added', hint: '' },
+  ];
+  return (
+    <Card bodyClass="!p-0">
+      <div className="py-1">
+        {items.map(it => (
+          <button
+            key={it.id}
+            type="button"
+            onClick={() => setTab(it.id)}
+            className={cn(
+              'flex w-full items-center justify-between px-3.5 py-2 text-left text-[12px] transition-colors',
+              tab === it.id
+                ? 'border-l-2 border-[var(--accent)] bg-[var(--ink-soft)] font-bold'
+                : 'border-l-2 border-transparent hover:bg-[var(--ink-soft)]/30',
+            )}
+          >
+            <span>{it.label}</span>
+            {it.hint && <span className="caption text-muted">{it.hint}</span>}
+          </button>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// browse filters sidebar
+// ---------------------------------------------------------------------------
+interface BrowseFiltersProps {
+  moodVocab: string[];
+  moodCounts: Record<string, number>;
+  energyCounts: Record<string, number>;
+  genreList: { value: string; songCount: number }[];
+  moods: string[]; setMoods: (m: string[]) => void;
+  energy: Energy; setEnergy: (e: Energy) => void;
+  genre: string; setGenre: (g: string) => void;
+  yearFrom: string; setYearFrom: (s: string) => void;
+  yearTo: string; setYearTo: (s: string) => void;
+  sort: Sort; setSort: (s: Sort) => void;
+  filtersActive: boolean;
+  onClear: () => void;
+}
+
+function BrowseFilters(p: BrowseFiltersProps) {
+  const toggleMood = (m: string) => {
+    p.setMoods(p.moods.includes(m) ? p.moods.filter(x => x !== m) : [...p.moods, m]);
+  };
+  const sortedMoods = useMemo(() => {
+    const ranked = [...p.moodVocab];
+    ranked.sort((a, b) => (p.moodCounts[b] || 0) - (p.moodCounts[a] || 0));
+    return ranked;
+  }, [p.moodVocab, p.moodCounts]);
+
+  return (
+    <Card
+      title="Filters"
+      right={p.filtersActive ? (
+        <Btn sm tone="danger" onClick={p.onClear} title="Clear all filters">
+          <RotateCcw size={11} /> clear
+        </Btn>
+      ) : null}
+    >
+      <div>
+        <div className="caption mb-1.5">mood</div>
+        <div className="grid max-h-56 gap-0.5 overflow-y-auto pr-1">
+          {sortedMoods.map(m => {
+            const n = p.moodCounts[m] || 0;
+            const checked = p.moods.includes(m);
+            return (
+              <label
+                key={m}
+                className={cn(
+                  'flex cursor-pointer items-center justify-between gap-2 px-1 py-1 text-[12px]',
+                  checked ? 'text-ink' : 'text-muted hover:text-ink',
+                )}
+              >
+                <span className="flex items-center gap-2">
+                  <Checkbox checked={checked} onCheckedChange={() => toggleMood(m)} />
+                  <span>{m}</span>
+                </span>
+                <span className="mono-num text-[10px] text-muted">{n.toLocaleString('en-GB')}</span>
+              </label>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <div className="caption mb-1.5">energy</div>
+        <Seg
+          value={p.energy}
+          onChange={id => p.setEnergy(id as Energy)}
+          options={[
+            { id: 'any', label: 'Any' },
+            { id: 'low', label: `Low${p.energyCounts.low ? ` · ${p.energyCounts.low}` : ''}` },
+            { id: 'medium', label: `Mid${p.energyCounts.medium ? ` · ${p.energyCounts.medium}` : ''}` },
+            { id: 'high', label: `High${p.energyCounts.high ? ` · ${p.energyCounts.high}` : ''}` },
+          ]}
+        />
+      </div>
+
+      <div className="mt-4">
+        <Field>
+          <FieldLabel htmlFor="genre">genre</FieldLabel>
+          <Select value={p.genre || '__any'} onValueChange={v => p.setGenre(v === '__any' ? '' : v)}>
+            <SelectTrigger id="genre"><SelectValue placeholder="Any genre" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__any">Any genre</SelectItem>
+              {p.genreList.slice(0, 80).map(g => (
+                <SelectItem key={g.value} value={g.value}>
+                  {g.value}{g.songCount ? ` · ${g.songCount}` : ''}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+      </div>
+
+      <div className="mt-4">
+        <div className="caption mb-1.5">year</div>
+        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+          <Input
+            type="number"
+            inputMode="numeric"
+            placeholder="from"
+            value={p.yearFrom}
+            onChange={e => p.setYearFrom(e.target.value)}
+          />
+          <span className="text-[10px] text-muted">–</span>
+          <Input
+            type="number"
+            inputMode="numeric"
+            placeholder="to"
+            value={p.yearTo}
+            onChange={e => p.setYearTo(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <Field>
+          <FieldLabel htmlFor="sort">sort</FieldLabel>
+          <Select value={p.sort} onValueChange={v => p.setSort(v as Sort)}>
+            <SelectTrigger id="sort"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="artist">Artist / album / title</SelectItem>
+              <SelectItem value="title">Title</SelectItem>
+              <SelectItem value="year">Year (newest first)</SelectItem>
+              <SelectItem value="taggedAt">Recently tagged</SelectItem>
+            </SelectContent>
+          </Select>
+        </Field>
+      </div>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// track table — same chrome across all tabs, action column varies
+// ---------------------------------------------------------------------------
+interface TrackTableProps {
+  tab: Tab;
+  rows: Track[];
+  loading: boolean;
+  queuing: string | null;
+  retagging: string | null;
+  onQueue: (t: Track) => void;
+  onRetag: (t: Track) => void;
+}
+
+function TrackTable(p: TrackTableProps) {
+  const showTags = p.tab === 'browse';
+  const cols = showTags
+    ? 'grid grid-cols-[24px_minmax(0,1.6fr)_minmax(0,1.2fr)_minmax(0,1fr)_56px_140px]'
+    : 'grid grid-cols-[24px_minmax(0,1.6fr)_minmax(0,1.2fr)_60px_60px_140px]';
+
+  if (p.loading && p.rows.length === 0) {
+    return <div className="px-4 py-6 text-[12px] text-muted italic">loading…</div>;
+  }
+  if (p.rows.length === 0) {
+    return (
+      <div className="px-4 py-6 text-[12px] text-muted italic">
+        {p.tab === 'browse' && 'no tracks match — try clearing some filters'}
+        {p.tab === 'search' && 'search the library to queue a track'}
+        {p.tab === 'untagged' && 'no untagged tracks found'}
+        {p.tab === 'recent' && 'nothing here yet'}
+      </div>
+    );
+  }
+
   return (
     <div>
-      <div
-        className={cn(
-          colsClass,
-          'border-b border-ink px-1.5 py-2 text-[9px] font-bold tracking-[0.22em] text-muted uppercase',
-        )}
-      >
+      <div className={cn(cols, 'gap-3 border-b border-ink px-3 py-2 text-[9px] font-bold tracking-[0.22em] text-muted uppercase')}>
         <span>#</span>
         <span>title</span>
         <span>album</span>
+        <span>{showTags ? 'tags' : 'year'}</span>
         <span className="text-right">dur</span>
         <span />
       </div>
-      {tracks.map((t, i) => (
+      {p.rows.map((t, i) => (
         <div
           key={t.id}
-          className={cn(
-            colsClass,
-            'items-center border-b border-dashed border-separator-strong px-1.5 py-2 text-[12px]',
-          )}
+          className={cn(cols, 'items-center gap-3 border-b border-dashed border-separator-strong px-3 py-2 text-[12px]')}
         >
-          <span className="mono-num text-[10px] text-muted">
-            {String(i + 1).padStart(2, '0')}
-          </span>
+          <span className="mono-num text-[10px] text-muted">{String(i + 1).padStart(2, '0')}</span>
           <div className="min-w-0">
-            <div className="overflow-hidden text-ellipsis whitespace-nowrap text-ink">
-              {t.title}
-            </div>
-            <div className="text-[11px] text-muted">{t.artist}</div>
+            <div className="overflow-hidden text-ellipsis whitespace-nowrap text-ink">{t.title || '—'}</div>
+            <div className="overflow-hidden text-[11px] text-ellipsis whitespace-nowrap text-muted">{t.artist || '—'}</div>
           </div>
-          <span className="overflow-hidden text-[11px] text-ellipsis whitespace-nowrap text-muted">
-            {t.album || '—'}
-          </span>
+          <span className="overflow-hidden text-[11px] text-ellipsis whitespace-nowrap text-muted">{t.album || '—'}</span>
+          {showTags ? (
+            <div className="flex min-w-0 flex-wrap items-center gap-1">
+              {(t.moods || []).slice(0, 3).map(m => (
+                <Pill key={m} tone="default" className="text-[10px]">{m}</Pill>
+              ))}
+              {t.energy && <Pill tone="ink" dot className="text-[10px]">{t.energy}</Pill>}
+            </div>
+          ) : (
+            <span className="mono-num text-[11px] text-muted">{t.year || '—'}</span>
+          )}
           <span className="mono-num text-right text-[11px] text-muted">
             {t.duration != null ? fmtDuration(t.duration) : '—'}
           </span>
-          <Btn sm onClick={() => onQueue(t)} disabled={!!queuing}>
-            {queuing === t.id ? 'Queuing…' : 'Queue'}
-          </Btn>
+          <div className="flex items-center justify-end gap-1.5">
+            <Btn sm onClick={() => p.onQueue(t)} disabled={!!p.queuing}>
+              {p.queuing === t.id ? 'Queuing…' : 'Queue'}
+            </Btn>
+            {(p.tab === 'browse' || p.tab === 'untagged') && (
+              <Btn
+                sm
+                tone={p.tab === 'untagged' ? 'accent' : 'solid'}
+                onClick={() => p.onRetag(t)}
+                disabled={!!p.retagging}
+              >
+                {p.retagging === t.id ? '…' : (p.tab === 'untagged' ? 'Tag' : 'Retag')}
+              </Btn>
+            )}
+          </div>
         </div>
       ))}
     </div>
   );
 }
 
+// ---------------------------------------------------------------------------
+// tagger strip (sticky bottom)
+// ---------------------------------------------------------------------------
+interface TaggerStripProps {
+  coverage: Coverage | null;
+  tagger: TaggerState | null;
+  limit: string;
+  setLimit: (s: string) => void;
+  busy: boolean;
+  onStart: () => void;
+  onStop: () => void;
+}
+
+function TaggerStrip(p: TaggerStripProps) {
+  const [expanded, setExpanded] = useState(false);
+  const logRef = useRef<HTMLPreElement>(null);
+  const fillRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (expanded && logRef.current) {
+      logRef.current.scrollTop = logRef.current.scrollHeight;
+    }
+  }, [expanded, p.tagger?.lastLog?.length]);
+
+  const pct = p.coverage?.percent;
+  const running = p.tagger?.running;
+  // Inline width avoided by mutating .style via the dynamic-style hook.
+  useDynamicStyle(fillRef, { width: pct != null ? `${Math.min(100, pct)}%` : null });
+
+  return (
+    <div className="sticky bottom-3 z-30">
+      <section className="card border-ink shadow-[0_4px_24px_rgba(0,0,0,0.18)]">
+        <div className="grid grid-cols-[1fr_auto] items-center gap-3 p-3">
+          <div className="grid gap-1.5">
+            <div className="flex items-center gap-3 text-[12px]">
+              <span className={cn('h-2 w-2 rounded-full', running ? 'animate-pulse bg-vermilion' : 'bg-muted')} />
+              <span className="font-bold">
+                {p.coverage?.tagged?.toLocaleString('en-GB') || '—'}
+                {' / '}
+                {p.coverage?.total != null ? p.coverage.total.toLocaleString('en-GB') : (p.coverage?.scanning ? 'scanning…' : '—')}
+                {' tagged'}
+              </span>
+              {pct != null && <span className="caption text-muted">{pct}%</span>}
+              {running && p.tagger?.startedAt && (
+                <span className="caption text-muted">
+                  pid {p.tagger.pid} · started {new Date(p.tagger.startedAt).toLocaleTimeString('en-GB')}
+                </span>
+              )}
+            </div>
+            {pct != null && (
+              <div className="h-1 w-full overflow-hidden bg-[var(--ink-soft)]">
+                <span ref={fillRef} className="block h-full bg-[var(--accent)]" />
+              </div>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <Input
+              type="number"
+              inputMode="numeric"
+              className="mono-num w-20"
+              value={p.limit}
+              onChange={e => p.setLimit(e.target.value)}
+              disabled={running}
+              title="how many new tracks to tag this run"
+            />
+            {running ? (
+              <Btn tone="danger" onClick={p.onStop} disabled={p.busy}>Stop</Btn>
+            ) : (
+              <Btn tone="accent" onClick={p.onStart} disabled={p.busy}>Start tagging</Btn>
+            )}
+            <Btn sm onClick={() => setExpanded(e => !e)}>
+              {expanded ? 'hide log' : 'log'}
+            </Btn>
+          </div>
+        </div>
+        {expanded && (
+          <pre
+            ref={logRef}
+            className="term m-0 max-h-48 overflow-y-auto border-t border-separator-strong"
+          >
+            {(p.tagger?.lastLog || []).join('\n') || '(no log output yet)'}
+          </pre>
+        )}
+      </section>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
 function fmtDuration(s: number): string {
   const sec = Math.max(0, Math.round(s));
   return `${Math.floor(sec / 60)}:${String(sec % 60).padStart(2, '0')}`;
-}
-
-function Empty({ children }: { children?: ReactNode }) {
-  return <div className="py-2.5 text-[12px] text-muted italic">{children}</div>;
 }


### PR DESCRIPTION
## Summary

The previous `/admin/library` mixed a thin Navidrome search with a tagger control card. The filter UI was broken end-to-end:

- The **energy** `<Seg>` had no `onChange` — completely inert.
- The **mood** `<Seg>` rewrote the search query string instead of filtering, and its chip set was hardcoded to half-fictional moods (`ambient/slow/driving/jazz/deep`) that don't match the real `SHOW_MOODS` vocabulary.
- `GET /dj/search` had no filter parameters server-side at all — only `q`.
- With ~25k tracks, the page couldn't answer "what calm tracks do we have?" or "how much of the library is tagged?".

This PR rebuilds the page as a real library manager.

### New endpoints (all admin-gated)

- `GET /library/browse` — filters the in-memory `moods.json` index by mood (OR within facet, AND across facets), energy, genre, year range, and free-text. Sort + pagination. Returns facet counts so the sidebar shows `n` beside every option.
- `GET /library/genres` — distinct genres for the dropdown, merged from tagged tracks + Navidrome.
- `GET /library/untagged?limit&cursor` — cursor-pages through tracks that don't yet have moods so untagged music is reachable and tag-able one at a time.
- `GET /library/coverage` — background-cached library size; returns `{ tagged, total, percent, scannedAt, scanning }` so the UI can show `X / Y (Z%) tagged` instead of just `X`.
- `POST /library/retag` — single-track inline retag. Reuses `tagOne()` from the bulk tagger via the new shared `music/tagger-core.ts`.
- `POST /tag-library/stop` — SIGTERMs the running tagger child.

### Panel rewrite

- KPI strip: tagged · library · coverage % · moods used.
- Tab rail: Browse / Search / Untagged / Recently added — same chrome, different data source.
- Filter sidebar with **working** controls: mood checkboxes (live counts), energy segmented, genre dropdown, year range, sort.
- Per-row `Queue` everywhere; `Retag` on Browse rows, `Tag` on Untagged rows.
- Sticky tagger strip at the bottom with progress bar, limit input, **Stop** button, and expandable log.

### Files

**New**
- `controller/src/routes/library.ts`
- `controller/src/music/tagger-core.ts` (shared `tagOne()` + schema)
- `controller/src/music/library-coverage.ts` (cached scanner)

**Modified**
- `controller/src/music/library.ts` — `filter()`, `byGenre` added to `stats()`
- `controller/src/music/tag-library.ts` — re-exports from tagger-core
- `controller/src/broadcast/tagger.ts` — `stopTagger()`
- `controller/src/routes/jingles.ts` — `POST /tag-library/stop`
- `controller/src/server.ts` — mount the new router
- `web/components/admin/LibraryPanel.tsx` — full rewrite

## Test plan

- [x] `npm run typecheck` in both `controller/` and `web/` passes
- [x] `npx eslint` clean on the rewritten panel + new controller modules (only consistent `any` warnings matching the existing codebase)
- [x] `library.filter()` smoke-tested against a synthetic moods.json: mood OR-within / AND-across facets, energy, genre, year range, q substring, sort by year (desc), pagination — all return the expected rows
- [x] `tagger-core` and `library-coverage` import cleanly with the exported surface routes/library.ts expects
- [ ] Sign in to `/admin/library`, tick `calm` + `reflective` → table re-fetches via `/library/browse?moods=calm,reflective`, facet counts update
- [ ] Energy=low narrows further; clearing filters restores; sorting by `year` re-orders
- [ ] Paginate 1–50 → 51–100
- [ ] Search tab: free-text → 12 Navidrome results, Queue toast
- [ ] Untagged tab: paginate 50 → `Tag` on a row → row leaves Untagged, coverage `tagged` increments
- [ ] Browse row → `Retag` → moods/energy refresh in place
- [ ] Tagger: limit=10 → Start → log streams; Stop → child exits, log ends with `[exit SIGTERM]`
- [ ] With `moods.json` empty: sidebar shows 0s, Browse shows empty state, Search and Untagged still work