### PR TITLE
fix: persist station name from setup wizard (#102) + admin polish

### DIFF
--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -137,6 +137,9 @@ export async function runSetupCommand(): Promise<void> {
   // --- 5. Timezone ---------------------------------------------------------
   const tz = await promptTimezone();
 
+  // --- 5b. Station name ----------------------------------------------------
+  const station = await promptStationName();
+
   // --- 6. Write the root .env ---------------------------------------------
   // Setup only owns TZ and (one-time) SUBWAVE_HOMEPAGE. Admin creds and
   // SITE_URL come from init and are preserved by writeEnvFile's
@@ -155,7 +158,7 @@ export async function runSetupCommand(): Promise<void> {
   // refreshAutoPlaylist() that un-sticks the picker after a fresh install.
   // Bypassing the endpoint (the old "write files from host" flow) left the
   // controller's in-memory state stale until the next restart.
-  await pushOnboardingSave(mode, navidrome, llm);
+  await pushOnboardingSave(mode, navidrome, llm, station);
 
   // --- 8. State dir perms (standalone install only) -----------------------
   // Idempotent — safe even when running setup against an already-configured
@@ -470,6 +473,18 @@ async function promptTimezone(): Promise<string> {
   }), { backOnCancel: false });
 }
 
+// What the DJ calls the station on air — substituted into the {station}
+// placeholder in renderDjPrompt() and returned by GET /dj. Defaulting to
+// 'SUB/WAVE' matches the wizard and the historical hardcoded value.
+async function promptStationName(): Promise<string> {
+  return exitIfCancelled(await p.text({
+    message: 'Station name (what the DJ calls this radio)',
+    initialValue: 'SUB/WAVE',
+    placeholder: 'SUB/WAVE',
+    validate: (v) => (v.length > 80 ? 'Keep it to 80 characters or fewer.' : undefined),
+  }), { backOnCancel: false });
+}
+
 // ---------------------------------------------------------------------------
 // Shell-outs
 // ---------------------------------------------------------------------------
@@ -555,11 +570,12 @@ async function renderJingles(composeFile: string, env: NodeJS.ProcessEnv): Promi
 // Bypassing this endpoint (the previous "write files from the host" path)
 // left the running controller's in-memory state stale, requiring an explicit
 // `subwave restart controller` for setup to take effect.
-async function pushOnboardingSave(env: ComposeEnv, navidrome: NavidromeCreds, llm: LlmChoice): Promise<void> {
+async function pushOnboardingSave(env: ComposeEnv, navidrome: NavidromeCreds, llm: LlmChoice, station: string): Promise<void> {
   header('Saving via /onboarding/save');
 
   const body: Record<string, unknown> = {
     navidrome: { url: navidrome.url, user: navidrome.user, pass: navidrome.pass },
+    station,
   };
 
   if (llm.provider) {

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -28,9 +28,10 @@ const CHATTERBOX_TAG_HINT =
 // otherwise the admin-selected active persona — see settings.getEffectivePersona.
 export function djSystem() {
   const persona = settings.getEffectivePersona();
+  const s = settings.get();
   const base = settings.renderDjPrompt(persona, {
-    station: 'SUB/WAVE',
-    location: settings.get().weather?.locationName,
+    station: s.station,
+    location: s.weather?.locationName,
   });
   if (persona?.tts?.engine === 'chatterbox') return base + CHATTERBOX_TAG_HINT;
   return base;

--- a/controller/src/routes/onboarding.ts
+++ b/controller/src/routes/onboarding.ts
@@ -172,7 +172,7 @@ router.post('/onboarding/test-llm', requireAdmin, async (req, res) => {
 //     llm:      { provider, model, apiKey, ... },     // → settings.update()
 //     tts:      { defaultEngine, ... },               // → settings.update()
 //     dj:       { djPrompt, ... },                    // → settings.update()
-//     stationName: string,                            // → settings.update()
+//     station:  string,                               // → settings.update()
 //     apiKeys:  { ANTHROPIC_API_KEY, ... },           // → state/secrets.env
 //   }
 //
@@ -216,6 +216,7 @@ router.post('/onboarding/save', requireAdmin, async (req, res) => {
     if (typeof b.djPrompt === 'string') settingsPatch.djPrompt = b.djPrompt;
     if (Array.isArray(b.personas)) settingsPatch.personas = b.personas;
     if (b.weather && typeof b.weather === 'object') settingsPatch.weather = b.weather;
+    if (typeof b.station === 'string') settingsPatch.station = b.station;
     if (Object.keys(settingsPatch).length) await settings.update(settingsPatch);
 
     // Mark setup complete so the wizard exits even if Navidrome was skipped.

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -107,7 +107,7 @@ router.get('/dj', async (req, res) => {
       tagline: persona?.tagline || '',
       soul: persona?.soul || '',
       frequency: persona?.frequency || 'moderate',
-      station: 'SUB/WAVE',
+      station: s.station,
       location: s.weather?.locationName || '',
     });
   } catch (err) {

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -190,6 +190,11 @@ const DEFAULTS = {
   jingleRatio: 30, // 1 jingle per N music tracks
   crossfadeDuration: 10.0, // seconds
   weather: { lat: 52.5862, lng: -2.1288, locationName: 'Wolverhampton' },
+  // Operator-facing station name. Substituted into the DJ prompt's {station}
+  // placeholder and returned by GET /dj for the landing page. The product is
+  // still called SUB/WAVE — this is what the operator's station running on it
+  // is called (e.g. "Frequency 88", "Late Shift Radio").
+  station: 'SUB/WAVE',
   // Global DJ prompt template. '' means "use DEFAULT_DJ_PROMPT_TEMPLATE".
   djPrompt: '',
   // The persona roster. One persona is "active" at a time (activePersonaId);
@@ -435,6 +440,10 @@ export async function load() {
       locationName: stored.weather?.locationName ?? DEFAULTS.weather.locationName,
     },
     djPrompt,
+    station:
+      typeof stored.station === 'string' && stored.station.trim()
+        ? stored.station.trim().slice(0, 80)
+        : DEFAULTS.station,
     personas,
     activePersonaId,
     shows,
@@ -752,6 +761,15 @@ export async function update(patch) {
       next.weather.locationName = w.locationName.trim().slice(0, 80);
     }
   }
+  if ('station' in patch) {
+    const v = String(patch.station ?? '').trim();
+    if (v === '') {
+      next.station = DEFAULTS.station;
+    } else {
+      if (v.length > 80) throw new Error('station name must be 80 chars or fewer');
+      next.station = v;
+    }
+  }
   if ('djPrompt' in patch) {
     const v = String(patch.djPrompt ?? '').trim();
     if (v === '') {
@@ -1015,7 +1033,7 @@ export function getEffectivePersona(date: Date = new Date()) {
 // {location}. {name}/{soul} come from the supplied persona; the template is
 // the global djPrompt (falling back to DEFAULT_DJ_PROMPT_TEMPLATE).
 export function renderDjPrompt(persona: any, ctx: any = {}) {
-  const station = ctx.station || 'SUB/WAVE';
+  const station = ctx.station || cache?.station || DEFAULTS.station;
   const location = ctx.location || (cache?.weather?.locationName ?? DEFAULTS.weather.locationName);
   const tpl =
     cache?.djPrompt && cache.djPrompt.trim() ? cache.djPrompt : DEFAULT_DJ_PROMPT_TEMPLATE;
@@ -1047,7 +1065,8 @@ export function renderDjPrompt(persona: any, ctx: any = {}) {
 export function agentPersonaPreamble(persona, { rules = true } = {}) {
   const name = persona?.name || 'the DJ';
   const soul = persona?.soul || '';
-  const opener = `You are ${name}, the on-air DJ for SUB/WAVE, a personal internet radio station. ${soul}`;
+  const station = cache?.station || DEFAULTS.station;
+  const opener = `You are ${name}, the on-air DJ for ${station}, a personal internet radio station. ${soul}`;
   return rules ? `${opener}` : opener;
 }
 

--- a/web/components/admin/DashPanel.tsx
+++ b/web/components/admin/DashPanel.tsx
@@ -165,7 +165,6 @@ export default function DashPanel() {
   const strip: StripCell[] = [
     { l: 'dj on air', v: djName, accent: true },
     { l: 'show', v: showName },
-    { l: 'mood', v: ctx?.dominantMood || '—' },
     {
       l: 'listeners',
       v: listenersObj?.current != null ? String(listenersObj.current) : '—',
@@ -407,7 +406,7 @@ function HeroSection({ err, np, q, busy, onSkip, strip }: HeroSectionProps) {
           </div>
           {np?.title ? (
             <>
-              <div className="text-[30px] leading-[1.05] font-extrabold tracking-[-0.02em]">
+              <div className="text-[18px] leading-[1.2] font-bold tracking-[-0.01em]">
                 {np.title}{' '}
                 <span className="font-semibold text-muted">— {np.artist}</span>
               </div>

--- a/web/components/admin/DebugPanel.tsx
+++ b/web/components/admin/DebugPanel.tsx
@@ -23,8 +23,6 @@ interface DebugIcecast {
 interface DebugLibrary {
   total?: number;
   updatedAt?: string;
-  byMood?: Record<string, number>;
-  byEnergy?: Record<string, number>;
 }
 
 interface DebugQueueEntry {
@@ -300,7 +298,7 @@ export default function DebugPanel() {
           </Card>
 
           {/* ── ROW 3 ───────────────────────────────────────── */}
-          <div className="stack-mobile grid grid-cols-[1fr_1fr_1.2fr] gap-4">
+          <div className="stack-mobile grid grid-cols-2 gap-4">
             <Card title="State dir" sub="/var/sub-wave" bodyClass="max-h-80 overflow-y-auto">
               <FilesTable files={data.stateFiles} />
             </Card>
@@ -311,42 +309,6 @@ export default function DebugPanel() {
               bodyClass="max-h-80 overflow-y-auto"
             >
               <FilesTable files={data.voiceFiles} />
-            </Card>
-
-            <Card
-              title="Library tags"
-              sub={`${data.library?.total ?? 0} tracks${data.library?.updatedAt ? ' · ' + new Date(data.library.updatedAt).toLocaleString('en-GB') : ''}`}
-            >
-              {!data.library?.total ? (
-                <span className="field-hint italic">
-                  not tagged yet — start tagger from settings
-                </span>
-              ) : (
-                <div className="grid gap-2.5">
-                  <div>
-                    <div className="caption mb-1.5">by mood</div>
-                    <div className="flex flex-wrap gap-1">
-                      {Object.entries(data.library.byMood || {})
-                        .sort((a, b) => b[1] - a[1])
-                        .map(([m, n]) => (
-                          <Pill key={m}>
-                            {m} <span className="mono-num ml-1 text-muted">{n}</span>
-                          </Pill>
-                        ))}
-                    </div>
-                  </div>
-                  <div>
-                    <div className="caption mb-1.5">by energy</div>
-                    <div className="flex flex-wrap gap-1">
-                      {Object.entries(data.library.byEnergy || {}).map(([e, n]) => (
-                        <Pill key={e}>
-                          {e} <span className="mono-num ml-1 text-muted">{n}</span>
-                        </Pill>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              )}
             </Card>
           </div>
 

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -24,6 +24,7 @@ const SECTIONS = [
   { id: 'mixer',   label: 'Mixer', hint: 'crossfade · weather' },
   { id: 'jingles', label: 'Jingles', hint: 'stingers' },
   { id: 'sfx',     label: 'Sound FX', hint: 'agent stingers' },
+  { id: 'danger',  label: 'Danger zone', hint: 'broadcast control' },
 ] as const;
 
 type SectionId = (typeof SECTIONS)[number]['id'];
@@ -99,6 +100,7 @@ interface SearchForm {
 interface FormState {
   jingleRatio: string;
   crossfadeDuration: string;
+  station: string;
   weather: WeatherCfg;
   tts: TtsForm;
   llm: LlmForm;
@@ -130,6 +132,7 @@ interface SettingsData {
   values?: {
     jingleRatio?: number;
     crossfadeDuration?: number;
+    station?: string;
     weather?: { lat?: number; lng?: number; locationName?: string };
     tts?: {
       defaultEngine?: string;
@@ -213,6 +216,7 @@ export default function SettingsPanel() {
     setForm({
       jingleRatio: String(v.jingleRatio ?? ''),
       crossfadeDuration: String(v.crossfadeDuration ?? ''),
+      station: v.station ?? '',
       weather: {
         lat: String(v.weather?.lat ?? ''),
         lng: String(v.weather?.lng ?? ''),
@@ -403,49 +407,6 @@ export default function SettingsPanel() {
             </button>
           );
         })}
-
-        <div className="mt-4 grid gap-2 border border-dashed border-separator-strong p-3">
-          <span className="caption">danger zone</span>
-
-          <div className="flex items-center gap-1.5 text-[10px] tracking-[0.1em] uppercase">
-            <span className="text-muted">broadcast</span>
-            <strong
-              className={cn(
-                data?.streamOnAir === false
-                  ? 'text-[var(--danger)]'
-                  : data?.streamOnAir
-                    ? 'text-vermilion'
-                    : 'text-muted',
-              )}
-            >
-              {data?.streamOnAir == null ? '—' : data.streamOnAir ? 'on air' : 'off air'}
-            </strong>
-          </div>
-          {data?.streamOnAir === false ? (
-            <Btn sm tone="accent" onClick={startStream} disabled={busy || !data}>
-              Start stream
-            </Btn>
-          ) : (
-            <Btn sm tone="danger" onClick={() => setConfirmStop(true)} disabled={busy || !data || data?.streamOnAir == null}>
-              Stop stream
-            </Btn>
-          )}
-          <div className="text-[10px] leading-[1.4] text-muted">
-            Takes the station off air by disconnecting the Icecast mount. A mixer restart brings it back on air.
-          </div>
-
-          <Btn sm tone="danger" onClick={() => setConfirmRestart(true)} disabled={busy || !data}>
-            Restart mixer
-          </Btn>
-          <div className="text-[10px] leading-[1.4] text-muted">
-            Drops the broadcast for ~3–5s. Use after crossfade or jingle frequency changes.
-            {pendingRestart && (
-              <strong className="mt-1 block text-vermilion">
-                Pending settings need a restart to apply.
-              </strong>
-            )}
-          </div>
-        </div>
       </aside>
 
       {/* Active section */}
@@ -508,6 +469,55 @@ export default function SettingsPanel() {
             busy={busy} createSfx={createSfx} onDelete={setConfirmDeleteSfx}
             data={data} saveSettings={saveSettings}
           />
+        )}
+        {activeSection === 'danger' && (
+          <>
+            <SectionHeader
+              eyebrow="danger zone"
+              title="Stop the stream or restart the mixer."
+              sub="Both actions affect every current listener. Restart the mixer after changing crossfade or jingle frequency; stop the stream to take the station off air entirely."
+              metrics={[
+                {
+                  n: data?.streamOnAir == null ? '—' : data.streamOnAir ? 'on air' : 'off air',
+                  l: 'broadcast',
+                  accent: data?.streamOnAir === true,
+                },
+              ]}
+            />
+
+            <Card title="Broadcast" sub={data?.streamOnAir === false ? 'currently off air' : 'currently on air'}>
+              <div className="grid gap-2">
+                {data?.streamOnAir === false ? (
+                  <Btn sm tone="accent" onClick={startStream} disabled={busy || !data}>
+                    Start stream
+                  </Btn>
+                ) : (
+                  <Btn sm tone="danger" onClick={() => setConfirmStop(true)} disabled={busy || !data || data?.streamOnAir == null}>
+                    Stop stream
+                  </Btn>
+                )}
+                <div className="field-hint">
+                  Takes the station off air by disconnecting the Icecast mount. A mixer restart brings it back on air.
+                </div>
+              </div>
+            </Card>
+
+            <Card title="Mixer" sub="apply pending Liquidsoap-level settings">
+              <div className="grid gap-2">
+                <Btn sm tone="danger" onClick={() => setConfirmRestart(true)} disabled={busy || !data}>
+                  Restart mixer
+                </Btn>
+                <div className="field-hint">
+                  Drops the broadcast for ~3–5s. Use after crossfade or jingle frequency changes.
+                  {pendingRestart && (
+                    <strong className="mt-1 block text-vermilion">
+                      Pending settings need a restart to apply.
+                    </strong>
+                  )}
+                </div>
+              </div>
+            </Card>
+          </>
         )}
       </div>
 
@@ -1390,6 +1400,7 @@ function SearchSection({ data, form, setForm, busy, saveSettings }: SectionProps
 function MixerSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
   const save = () => saveSettings({
     crossfadeDuration: parseFloat(form.crossfadeDuration),
+    station: form.station,
     weather: {
       lat: parseFloat(form.weather.lat),
       lng: parseFloat(form.weather.lng),
@@ -1430,6 +1441,24 @@ function MixerSection({ data, form, setForm, busy, saveSettings }: SectionProps)
           <div className="field-hint">
             Seconds of overlap between tracks (current: {data.values?.crossfadeDuration}s).
             Requires a mixer restart to apply.
+          </div>
+        </div>
+      </Card>
+
+      <Card title="Station name" sub="What the DJ calls this radio on air">
+        <div className="field">
+          <Label>Station name</Label>
+          <Input
+            placeholder="SUB/WAVE"
+            value={form.station}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setForm(f => ({ ...f, station: e.target.value }))
+            }
+            className="w-[260px]"
+            maxLength={80}
+          />
+          <div className="field-hint">
+            Substituted into the DJ prompt’s {'{station}'} placeholder (current: {data.values?.station || 'SUB/WAVE'}). Applies live.
           </div>
         </div>
       </Card>

--- a/web/components/onboarding/useWizard.ts
+++ b/web/components/onboarding/useWizard.ts
@@ -160,6 +160,7 @@ export function useWizard() {
           : { enabled: false },
       },
       weather: { locationName: data.dj.locationName },
+      station: data.dj.stationName,
       apiKeys,
     };
     const r = await auth.adminFetch('/onboarding/save', {


### PR DESCRIPTION
Fixes #102.

## Summary

### Bug fix — station name now actually persists end-to-end
The onboarding wizard prompted for a station name but every layer dropped it:
- frontend wizard collected `stationName` but never sent it in the POST,
- the onboarding handler had it in a comment but no code path,
- `settings.ts` had no `station` field in `DEFAULTS` or `update()`,
- and `djSystem()`, `agentPersonaPreamble()`, and `GET /dj` all hardcoded the literal string `'SUB/WAVE'`.

The fix wires the value through the layers that already existed (`renderDjPrompt` already accepted `ctx.station` and the default template already used `{station}`), adds a station-name field to the admin Mixer panel so it can be edited later, and adds parity in the CLI wizard so `npm run setup` also asks for it.

### Admin polish (separate commit)
- Settings sidebar: danger zone (stop stream / restart mixer) moved out of the cramped sidebar block into a dedicated section after **Sound FX**.
- Dashboard: now-playing title dropped from 30 px extrabold to 18 px bold so it sits in scale with the rest of the row; removed the **mood** pill from the status strip.
- Debug: removed the **Library tags** Card (mood/energy pill counts); Row 3 collapses to a 2-column grid.

## Test plan
- [x] `npm run typecheck` clean in `controller/`, `cli/`, and `web/` (verified locally).
- [x] Fresh onboarding round-trip: `/onboarding` → enter a station name → `cat state/settings.json | jq .station` matches.
- [ ] `curl /api/dj | jq .station` returns the configured name.
- [ ] Trigger a spoken DJ segment, confirm `/admin/debug` LLM call log shows the new name in the system prompt instead of `SUB/WAVE`.
- [ ] Edit station name in `/admin/settings` (Mixer section) — saves and applies live.
- [ ] CLI: wipe `state/settings.json` and `state/setup-config.json`, run `npm run setup`, enter station name, confirm it lands in `state/settings.json`.
- [x] `/admin/settings` — confirm "Danger zone" is now its own section after Sound FX.
- [x] `/admin/dash` — confirm smaller title and no mood pill.
- [x] `/admin/debug` — confirm Library tags Card is gone.