### PR TITLE
web: mobile header, overflow and footer fixes

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -165,6 +165,11 @@ body {
         "calt" 1,
         "ss01" 1; /* contextual + slashed zero */
     -webkit-font-smoothing: antialiased;
+    /* Catch-all against accidental horizontal overflow on mobile. `clip`
+       (not `hidden`) keeps vertical page scroll intact and still lets inner
+       scrollable areas (e.g. the weekly-schedule grid) scroll horizontally
+       inside their own `overflow-x: auto` wrappers. */
+    overflow-x: clip;
 }
 
 /* Paper grain — fixed full-viewport SVG turbulence at low opacity.

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -411,7 +411,7 @@ body::after {
     align-items: center;
     justify-content: center;
     gap: 14px;
-    padding: 8px 0 2px;
+    padding: 6px 0 0;
     flex-wrap: wrap;
 }
 .bs-masthead-link {
@@ -456,7 +456,7 @@ body::after {
     grid-template-columns: 1fr auto 1fr;
     align-items: end;
     gap: 24px;
-    padding: 24px 0 16px;
+    padding: 24px 0 8px;
 }
 .bs-masthead-meta {
     min-width: 0;
@@ -471,10 +471,15 @@ body::after {
     .bs-masthead-head {
         align-items: center;
         gap: 10px;
+        padding: 16px 0 4px;
     }
-    /* The VOL/NO dateline is dropped on mobile so the theme toggle, the
-       wordmark and the ON AIR status sit together on a single row. */
+    /* The VOL/NO dateline is dropped on mobile so the theme toggle and
+       the wordmark sit together on a single row. The ON AIR status is
+       hidden on mobile to keep the wordmark uncluttered. */
     .bs-masthead-issue {
+        display: none;
+    }
+    .bs-masthead-status {
         display: none;
     }
     .bs-wordmark {
@@ -804,7 +809,7 @@ body::after {
     display: flex;
     flex-direction: column;
     gap: clamp(24px, 4vw, 48px);
-    padding: clamp(24px, 5vw, 56px) 0 clamp(8px, 1.5vw, 16px);
+    padding: clamp(12px, 2.5vw, 28px) 0 clamp(8px, 1.5vw, 16px);
 }
 .bs-hero-head {
     display: flex;

--- a/web/components/TopBar.tsx
+++ b/web/components/TopBar.tsx
@@ -43,9 +43,9 @@ export default function TopBar({
       // its wider sm: gutters.
       className="player-topbar absolute top-0 right-0 left-0 z-20 flex items-baseline justify-between gap-3 border-b border-ink
         pt-[calc(env(safe-area-inset-top)_+_1rem)] pr-[max(1rem,env(safe-area-inset-right))]
-        pb-4 pl-[max(1rem,env(safe-area-inset-left))]
+        pb-2 pl-[max(1rem,env(safe-area-inset-left))]
         sm:pt-[calc(env(safe-area-inset-top)_+_1.5rem)] sm:pr-[max(2rem,env(safe-area-inset-right))]
-        sm:pb-6 sm:pl-[max(2rem,env(safe-area-inset-left))]"
+        sm:pb-3 sm:pl-[max(2rem,env(safe-area-inset-left))]"
     >
       <div className="flex min-w-0 items-baseline gap-2 sm:gap-[14px]">
         <span

--- a/web/components/landing/StationFooter.tsx
+++ b/web/components/landing/StationFooter.tsx
@@ -6,7 +6,10 @@ export default function StationFooter({ djName }: { djName?: string }) {
   return (
     <footer className="mt-16 flex flex-col gap-[14px]">
       <div className="bs-rule-double" />
-      <div className="flex flex-wrap items-baseline justify-between gap-4 py-5 text-[11px] tracking-[0.18em] text-muted uppercase">
+      <div
+        className="flex flex-col items-center gap-2 py-5 text-center text-[11px] tracking-[0.18em] text-muted uppercase
+          sm:flex-row sm:flex-wrap sm:items-baseline sm:justify-between sm:gap-4 sm:text-left"
+      >
         <span className="font-bold text-ink">SUB/WAVE · EST. 2026</span>
         <span>
           Navidrome · Liquidsoap · Icecast · your LLM · your voice
@@ -26,13 +29,13 @@ export default function StationFooter({ djName }: { djName?: string }) {
       <div className="pb-[6px] text-center text-[10px] tracking-[0.3em] text-muted uppercase">
         — End of broadcast page · <Link href="/listen" className="bs-link tracking-[inherit]">open the player</Link> —
       </div>
-      <div className="pb-[6px] text-center text-[10px] tracking-[0.3em] text-muted uppercase">
+      <div className="pb-[6px] text-center text-[10px] tracking-[0.3em] text-balance text-muted uppercase">
         Set in type &amp; sent to press by{' '}
         <a
           href="https://www.klair.co"
           target="_blank"
           rel="noreferrer"
-          className="bs-link tracking-[inherit]"
+          className="bs-link tracking-[inherit] whitespace-nowrap"
         >
           the Klair works ✦ klair.co
         </a>


### PR DESCRIPTION
## Summary
- Hide the masthead `ON AIR` status block below 560px so the SUB/WAVE wordmark sits cleanly on its own, and tighten the masthead head/nav + hero top padding on both mobile and desktop. Player `TopBar` bottom padding tightened to match.
- Add `overflow-x: clip` to `html, body` in `globals.css` as a catch-all against accidental horizontal page scroll on mobile, mirroring the same defense the admin shell already uses via `.admin-root.paper`. `clip` (not `hidden`) keeps vertical scroll intact and still lets inner panes like the weekly-schedule grid scroll horizontally inside their own `overflow-x: auto` wrappers.
- Stack the landing footer's three station-meta lines centred on mobile and only switch to the original `justify-between` row at `sm:` (≥640px). The "Set in type" line gets `text-balance` + `whitespace-nowrap` on the credit link so "the Klair works ✦ klair.co" doesn't strand the glyph on its own line.

## Test plan
- [x] Open `/` on a mobile viewport (≤560px): SUB/WAVE wordmark is alone in the masthead row, no `ON AIR` chip; page no longer scrolls horizontally; footer meta lines stack centred and the credit link stays intact.
- [x] Open `/` on desktop (≥640px): masthead still shows the `ON AIR` status, header bottom padding is visibly tighter than before, footer meta still uses the `justify-between` row.
- [x] Open `/listen` on mobile: player `TopBar` is more compact at the bottom without clipping content.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkexMAwiizY6iYARxp6wPt)_