### PR TITLE
feat(admin): archives index, listener history, outbound webhooks

### DIFF
--- a/controller/src/broadcast/archives.ts
+++ b/controller/src/broadcast/archives.ts
@@ -1,0 +1,89 @@
+// Hourly archive index.
+//
+// Liquidsoap writes one MP3 per hour to `${STATE_DIR}/archive/%Y-%m-%d/%H-00.mp3`
+// (see liquidsoap/radio.liq's output.file block). This module exposes that
+// tree to the admin UI as a listable + downloadable index — purely read-only
+// over the existing on-disk layout.
+//
+// The pathing scheme is fixed and the operator never edits inside the
+// archive directory by hand, so we don't watch for changes; each /archives
+// GET re-scans. Two-level directory walk is cheap (one entry per hour).
+
+import { readdir, stat } from 'node:fs/promises';
+import { createReadStream, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { config } from '../config.js';
+
+const ARCHIVE_ROOT = join(config.stateDir, 'archive');
+
+// Date directories: "YYYY-MM-DD". Hour files: "HH-00.mp3".
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const HOUR_RE = /^(\d{2})-00\.mp3$/;
+
+export interface ArchiveEntry {
+  // YYYY-MM-DD/HH-00.mp3 — the safe relative path used by the download route.
+  path: string;
+  date: string;   // YYYY-MM-DD
+  hour: number;   // 0-23
+  bytes: number;
+  mtime: string;  // ISO
+}
+
+// Scan the archive tree. Newest first. Bounded by `limit` to keep the response
+// small for accounts with months of archives — the UI paginates client-side.
+export async function list({ limit = 500 }: { limit?: number } = {}): Promise<ArchiveEntry[]> {
+  if (!existsSync(ARCHIVE_ROOT)) return [];
+  let dayDirs: string[] = [];
+  try {
+    dayDirs = (await readdir(ARCHIVE_ROOT)).filter(d => DATE_RE.test(d)).sort().reverse();
+  } catch {
+    return [];
+  }
+
+  const out: ArchiveEntry[] = [];
+  for (const date of dayDirs) {
+    let files: string[] = [];
+    try {
+      files = await readdir(join(ARCHIVE_ROOT, date));
+    } catch {
+      continue;
+    }
+    // Hours descending so each day's newest hour appears first.
+    files.sort().reverse();
+    for (const f of files) {
+      const m = f.match(HOUR_RE);
+      if (!m) continue;
+      const abs = join(ARCHIVE_ROOT, date, f);
+      try {
+        const st = await stat(abs);
+        if (!st.isFile()) continue;
+        out.push({
+          path: `${date}/${f}`,
+          date,
+          hour: parseInt(m[1], 10),
+          bytes: st.size,
+          mtime: st.mtime.toISOString(),
+        });
+        if (out.length >= limit) return out;
+      } catch {}
+    }
+  }
+  return out;
+}
+
+// Resolve a client-supplied relative path against the archive root, rejecting
+// anything that escapes the tree or doesn't match the canonical naming scheme.
+// Returns the absolute path on success, or null if the input is unsafe / missing.
+export function resolveEntry(rel: string): string | null {
+  if (typeof rel !== 'string' || rel.length === 0 || rel.length > 64) return null;
+  const m = rel.match(/^(\d{4}-\d{2}-\d{2})\/(\d{2}-00\.mp3)$/);
+  if (!m) return null;
+  const abs = resolve(ARCHIVE_ROOT, rel);
+  if (!abs.startsWith(ARCHIVE_ROOT + '/')) return null;
+  if (!existsSync(abs)) return null;
+  return abs;
+}
+
+export function openStream(abs: string) {
+  return createReadStream(abs);
+}

--- a/controller/src/broadcast/listeners.ts
+++ b/controller/src/broadcast/listeners.ts
@@ -7,10 +7,20 @@
 // Fail-open: if Icecast is unreachable the count is null and djCallsAllowed()
 // treats the station as occupied — a stats outage must never silence the DJ.
 
+import { appendFile, readFile, stat } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { config } from '../config.js';
 import * as settings from '../settings.js';
 
 let lastCount: number | null = null;        // null = unknown (not yet polled, or Icecast down)
+
+// Time-series file. JSONL of {t, count} rows, one per persisted sample.
+// We persist every minute (not every 15s poll) — keeps the file at ~1440
+// rows/day, easily tail-readable, and that resolution is plenty for the
+// "is anyone here?" sparkline this is for.
+const HISTORY_FILE = join(config.stateDir, 'listeners.jsonl');
+let lastPersistedMinute = -1;
 
 async function fetchCount() {
   try {
@@ -24,6 +34,18 @@ async function fetchCount() {
     lastCount = src ? Number(src.listeners || 0) : 0;
   } catch {
     lastCount = null;
+  }
+  // Persist at most one row per wall-clock minute. Skip null samples — a
+  // stats outage shouldn't leave a misleading "0 listeners" stripe in the
+  // graph; the gap itself communicates the outage.
+  if (lastCount !== null) {
+    const now = new Date();
+    const minute = Math.floor(now.getTime() / 60000);
+    if (minute !== lastPersistedMinute) {
+      lastPersistedMinute = minute;
+      const line = JSON.stringify({ t: now.toISOString(), count: lastCount }) + '\n';
+      appendFile(HISTORY_FILE, line).catch(() => {});  // best-effort
+    }
   }
   return lastCount;
 }
@@ -52,4 +74,52 @@ export function djCallsAllowed() {
 export function startListenerMonitor() {
   fetchCount();
   setInterval(fetchCount, 15000);
+}
+
+// Read the recent listener history for the admin sparkline. Returns rows
+// newer than `since` (defaults to 24 h ago), oldest-first.
+//
+// JSONL is read whole and filtered in-memory — fine because the file caps
+// at ~1440 lines/day. If retention ever grows past a few MB, swap to a
+// streaming tail; until then, the simple read is enough.
+export interface ListenerSample {
+  t: string;
+  count: number;
+}
+
+export async function history({
+  since,
+}: { since?: Date } = {}): Promise<ListenerSample[]> {
+  if (!existsSync(HISTORY_FILE)) return [];
+  let raw = '';
+  try {
+    raw = await readFile(HISTORY_FILE, 'utf8');
+  } catch {
+    return [];
+  }
+  const cutoffMs = (since || new Date(Date.now() - 24 * 60 * 60 * 1000)).getTime();
+  const out: ListenerSample[] = [];
+  for (const line of raw.split('\n')) {
+    if (!line) continue;
+    try {
+      const row = JSON.parse(line);
+      const tMs = new Date(row.t).getTime();
+      if (!Number.isFinite(tMs) || tMs < cutoffMs) continue;
+      if (typeof row.count !== 'number') continue;
+      out.push({ t: row.t, count: row.count });
+    } catch {}
+  }
+  return out;
+}
+
+// Size of the persisted history file, for the admin debug view. Useful to
+// notice if the operator left the station running for a year and the file
+// grew unexpectedly.
+export async function historyBytes(): Promise<number> {
+  try {
+    const st = await stat(HISTORY_FILE);
+    return st.size;
+  } catch {
+    return 0;
+  }
 }

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -14,6 +14,7 @@ import { getFullContext } from '../context.js';
 import * as settings from '../settings.js';
 import { logEvent } from '../observability/events.js';
 import { djCallsAllowed } from './listeners.js';
+import * as webhooks from './webhooks.js';
 
 // Random gap between DJ links on auto-played tracks. The frequency setting
 // scales how chatty the DJ is:
@@ -245,6 +246,11 @@ class Queue {
       await writeFile(targetFile, wavPath);
       this.log(kind, text);
       session.appendTurn({ role: 'segment', kind, text });
+      // The auto-DJ link channel is its own event; everything else (station
+      // IDs, weather, hourly) is `dj.say`. Operators that pipe these into
+      // Discord usually want to filter the chatty link stream separately.
+      webhooks.notify(kind === 'link' ? 'dj.link' : 'dj.say',
+        kind === 'link' ? { text } : { text, kind });
     } catch (err: any) {
       this.log('error', `Announce failed: ${err.message}`);
     }
@@ -350,6 +356,15 @@ class Queue {
     logEvent('track.play', {
       title: this.current.track.title,
       artist: this.current.track.artist || null,
+      source: this.current.source,
+      requestedBy: this.current.requestedBy || null,
+    });
+
+    // Outbound fan-out — fire-and-forget; never blocks the picker path.
+    webhooks.notify('track.play', {
+      title: this.current.track.title,
+      artist: this.current.track.artist || null,
+      album: this.current.track.album || null,
       source: this.current.source,
       requestedBy: this.current.requestedBy || null,
     });

--- a/controller/src/broadcast/webhooks.ts
+++ b/controller/src/broadcast/webhooks.ts
@@ -1,0 +1,90 @@
+// Outbound webhooks — fan-out from station events (track.play, dj.say,
+// dj.link, request.received) to operator-configured HTTP endpoints.
+//
+// Fire-and-forget. The webhook delivery path must never block playback or
+// the DJ pipeline, so every send runs in the background with a hard 5-second
+// timeout. Failures log to stderr; there is no retry queue and no durable
+// outbox. If you want guaranteed delivery, point the webhook at a relay
+// (Cloudflare Worker, Pipedream, n8n) that owns its own retry policy — this
+// module's job is to get the event to that relay quickly, not to be one.
+//
+// The shape of the payload is documented in routes/webhooks.ts. Each event
+// is a stable JSON object with `event`, `t`, and event-specific fields.
+
+import * as settings from '../settings.js';
+
+export const WEBHOOK_EVENTS = [
+  'track.play',          // a track started playing
+  'dj.say',              // station ID / weather / hourly — heavy-ducked voice
+  'dj.link',             // between-track auto-DJ link — light-ducked voice
+  'request.received',    // a listener submitted a request
+] as const;
+
+export type WebhookEvent = (typeof WEBHOOK_EVENTS)[number];
+
+interface WebhookConfig {
+  id: string;
+  url: string;
+  events: string[];
+  enabled: boolean;
+  authHeader?: string;
+}
+
+const TIMEOUT_MS = 5000;
+
+async function postOne(hook: WebhookConfig, body: string) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'User-Agent': 'sub-wave/webhook',
+    };
+    if (hook.authHeader) headers['Authorization'] = hook.authHeader;
+    const r = await fetch(hook.url, {
+      method: 'POST',
+      headers,
+      body,
+      signal: ctrl.signal,
+    });
+    if (!r.ok) {
+      console.warn(`[webhook] ${hook.url} → ${r.status}`);
+    }
+  } catch (err: any) {
+    console.warn(`[webhook] ${hook.url} failed: ${err.message}`);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Fire an event to every enabled, subscribed hook. Non-blocking.
+export function notify(event: WebhookEvent, payload: Record<string, unknown>) {
+  let hooks: WebhookConfig[] = [];
+  try {
+    hooks = (settings.get()?.webhooks || []) as WebhookConfig[];
+  } catch {
+    return;
+  }
+  if (!hooks.length) return;
+  const targets = hooks.filter(h => h.enabled && h.events.includes(event));
+  if (!targets.length) return;
+  const body = JSON.stringify({
+    event,
+    t: new Date().toISOString(),
+    ...payload,
+  });
+  for (const hook of targets) {
+    postOne(hook, body);  // fire-and-forget
+  }
+}
+
+// Test fire — used by the admin UI's "Test" button. Bypasses the event
+// subscription list so the operator can sanity-check a fresh hook without
+// also flipping the events toggle on first.
+export async function fireTest(hook: WebhookConfig) {
+  await postOne(hook, JSON.stringify({
+    event: 'test',
+    t: new Date().toISOString(),
+    note: 'sub-wave webhook test fire',
+  }));
+}

--- a/controller/src/routes/archives.ts
+++ b/controller/src/routes/archives.ts
@@ -1,0 +1,32 @@
+// Admin-gated index + download of the hourly broadcast archives that
+// Liquidsoap writes under state/archive/. See broadcast/archives.ts for the
+// on-disk layout.
+import express from 'express';
+import { statSync } from 'node:fs';
+import { requireAdmin } from '../middleware/auth.js';
+import { list, resolveEntry, openStream } from '../broadcast/archives.js';
+
+export const router = express.Router();
+
+router.get('/archives', requireAdmin, async (req, res) => {
+  try {
+    const limit = Math.min(parseInt(String(req.query.limit ?? ''), 10) || 500, 5000);
+    res.json({ archives: await list({ limit }) });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Stream the MP3 to the browser. Forces a download — listeners shouldn't be
+// confused into thinking these are live, and inline playback for hour-long
+// MP3s is awkward in browsers anyway.
+router.get('/archives/file/:date/:hour', requireAdmin, (req, res) => {
+  const rel = `${req.params.date}/${req.params.hour}`;
+  const abs = resolveEntry(rel);
+  if (!abs) return res.status(404).json({ error: 'archive not found' });
+  const st = statSync(abs);
+  res.setHeader('Content-Type', 'audio/mpeg');
+  res.setHeader('Content-Length', String(st.size));
+  res.setHeader('Content-Disposition', `attachment; filename="${rel.replace('/', '_')}"`);
+  openStream(abs).pipe(res);
+});

--- a/controller/src/routes/listeners.ts
+++ b/controller/src/routes/listeners.ts
@@ -1,0 +1,30 @@
+// Admin-gated GET /listeners — recent listener-count time-series, persisted
+// by broadcast/listeners.ts. Feeds the admin sparkline.
+import express from 'express';
+import { requireAdmin } from '../middleware/auth.js';
+import { history, historyBytes, getListenerCount } from '../broadcast/listeners.js';
+
+export const router = express.Router();
+
+router.get('/listeners', requireAdmin, async (req, res) => {
+  try {
+    // sinceMinutes caps at one week — past that the JSONL gets too big to
+    // parse in-memory comfortably, and the sparkline isn't useful at that
+    // resolution anyway.
+    const sinceMinutes = Math.max(
+      5,
+      Math.min(parseInt(String(req.query.sinceMinutes ?? ''), 10) || 1440, 7 * 1440),
+    );
+    const since = new Date(Date.now() - sinceMinutes * 60 * 1000);
+    const samples = await history({ since });
+    const bytes = await historyBytes();
+    res.json({
+      current: getListenerCount(),
+      sinceMinutes,
+      bytes,
+      samples,
+    });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});

--- a/controller/src/routes/request.ts
+++ b/controller/src/routes/request.ts
@@ -12,6 +12,7 @@ import { queue } from '../broadcast/queue.js';
 import * as djAgent from '../broadcast/dj-agent.js';
 import * as session from '../broadcast/session.js';
 import * as listeners from '../broadcast/listeners.js';
+import * as webhooks from '../broadcast/webhooks.js';
 import {
   checkRateLimit, clientIp,
   REQUESTS_DISABLED, REQUEST_TEXT_MAX, REQUEST_NAME_MAX,
@@ -432,6 +433,7 @@ router.post('/request', async (req, res) => {
   };
   requests.set(id, entry);
   queue.log('request', `${requester}: "${text}" (id ${id.slice(0, 8)})`);
+  webhooks.notify('request.received', { requestedBy: requester, text });
 
   // Hand the listener a receipt and let go of the connection. The booth does
   // the rest; GET /request/:id reports the outcome.

--- a/controller/src/routes/webhooks.ts
+++ b/controller/src/routes/webhooks.ts
@@ -1,0 +1,52 @@
+// Admin-gated webhook management. CRUD lives here; the fan-out itself lives
+// in broadcast/webhooks.ts and reads its config from settings on each fire.
+//
+// Event payloads emitted by the fan-out:
+//   track.play       { event, t, title, artist, album?, source, requestedBy? }
+//   dj.say           { event, t, text, kind }      // kind is the original `announce` kind
+//   dj.link          { event, t, text }
+//   request.received { event, t, title?, artist?, requestedBy }
+//
+// All payloads carry `event` (one of the above) and `t` (ISO timestamp).
+import express from 'express';
+import { requireAdmin } from '../middleware/auth.js';
+import * as settings from '../settings.js';
+import { WEBHOOK_EVENTS, fireTest } from '../broadcast/webhooks.js';
+
+export const router = express.Router();
+
+router.get('/webhooks', requireAdmin, async (req, res) => {
+  try {
+    await settings.load();
+    const s = settings.getRedacted();
+    res.json({ events: WEBHOOK_EVENTS, webhooks: s.webhooks || [] });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/webhooks', requireAdmin, async (req, res) => {
+  // The UI sends the whole list back. settings.update() validates the array
+  // strictly and replaces it atomically — same pattern as personas/shows.
+  try {
+    const r = await settings.update({ webhooks: req.body?.webhooks });
+    res.json({ webhooks: settings.getRedacted().webhooks, requiresRestart: r.requiresRestart });
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Send a test payload to a single hook by id. Uses the live, non-redacted
+// settings so the operator's saved authHeader actually goes out — they
+// shouldn't have to retype it just to test the integration.
+router.post('/webhooks/:id/test', requireAdmin, async (req, res) => {
+  try {
+    await settings.load();
+    const hook = (settings.get().webhooks || []).find((h: any) => h.id === req.params.id);
+    if (!hook) return res.status(404).json({ error: 'webhook not found' });
+    await fireTest(hook);
+    res.json({ ok: true });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -24,6 +24,9 @@ import { router as statsRoutes } from './routes/stats.js';
 import { router as djRoutes } from './routes/dj.js';
 import { router as libraryRoutes } from './routes/library.js';
 import { router as onboardingRoutes } from './routes/onboarding.js';
+import { router as archivesRoutes } from './routes/archives.js';
+import { router as listenersRoutes } from './routes/listeners.js';
+import { router as webhooksRoutes } from './routes/webhooks.js';
 import { loadSecretsIntoEnv } from './setup/secrets.js';
 import { loadSetupConfig } from './setup/config.js';
 import { getSetupStatus } from './setup/firstRun.js';
@@ -46,6 +49,9 @@ app.use(statsRoutes);
 app.use(djRoutes);
 app.use(libraryRoutes);
 app.use(onboardingRoutes);
+app.use(archivesRoutes);
+app.use(listenersRoutes);
+app.use(webhooksRoutes);
 
 // (manual skip is not implemented in this build — Liquidsoap controls pacing)
 

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -136,6 +136,17 @@ const SKILL_SLUG_RE = /^[a-z0-9-]{1,40}$/;
 const PERSONA_LIMIT = 12;
 const SHOWS_LIMIT = 64;
 const SKILLS_PER_PERSONA_LIMIT = 20;
+const WEBHOOKS_LIMIT = 16;
+
+// Event names the outbound webhook fan-out can subscribe to. Kept in sync
+// with broadcast/webhooks.ts WEBHOOK_EVENTS — duplicated here so settings.ts
+// has no runtime dependency on the broadcast module.
+const WEBHOOK_EVENTS = [
+  'track.play',
+  'dj.say',
+  'dj.link',
+  'request.received',
+];
 
 // Server-minted opaque id, e.g. mintId('p_') -> 'p_a1b2c3'.
 function mintId(prefix) {
@@ -274,6 +285,10 @@ const DEFAULTS = {
   sfx: {
     enabled: true,
   },
+  // Outbound webhooks. Each entry POSTs station events (see broadcast/
+  // webhooks.ts for the event list) to `url` with a fire-and-forget HTTP
+  // call. Empty by default — operators add hooks via the admin UI.
+  webhooks: [] as any[],
 };
 
 const BOUNDS = {
@@ -529,8 +544,39 @@ export async function load() {
     sfx: {
       enabled: typeof stored.sfx?.enabled === 'boolean' ? stored.sfx.enabled : DEFAULTS.sfx.enabled,
     },
+    webhooks: normalizeWebhooks(stored.webhooks),
   };
   return cache;
+}
+
+// Lenient normalizer — used by load(). Drops invalid entries silently rather
+// than failing the whole boot.
+function normalizeWebhooks(raw: any) {
+  if (!Array.isArray(raw)) return [];
+  const out: any[] = [];
+  const seen = new Set<string>();
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const url = typeof item.url === 'string' ? item.url.trim() : '';
+    if (!/^https?:\/\//.test(url) || url.length > 500) continue;
+    const events = Array.isArray(item.events)
+      ? item.events.filter((e: any) => WEBHOOK_EVENTS.includes(e))
+      : [];
+    if (!events.length) continue;
+    let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('wh_');
+    if (seen.has(id)) id = mintId('wh_');
+    seen.add(id);
+    out.push({
+      id,
+      url,
+      events,
+      enabled: typeof item.enabled === 'boolean' ? item.enabled : true,
+      authHeader:
+        typeof item.authHeader === 'string' ? item.authHeader.slice(0, 500) : '',
+    });
+    if (out.length >= WEBHOOKS_LIMIT) break;
+  }
+  return out;
 }
 
 export function get() {
@@ -548,6 +594,11 @@ export function getRedacted() {
   if (clone.llm) clone.llm.apiKey = s.llm?.apiKey ? 'set' : '';
   if (clone.tts?.cloud) clone.tts.cloud.apiKey = s.tts?.cloud?.apiKey ? 'set' : '';
   if (clone.search) clone.search.apiKey = s.search?.apiKey ? 'set' : '';
+  if (Array.isArray(clone.webhooks)) {
+    for (let i = 0; i < clone.webhooks.length; i++) {
+      clone.webhooks[i].authHeader = s.webhooks?.[i]?.authHeader ? 'set' : '';
+    }
+  }
   return clone;
 }
 
@@ -709,6 +760,57 @@ function validateScheduleStrict(raw, shows) {
     }
   }
   return week;
+}
+
+// Strict validator — used by update(). `existing` is the current list, so
+// the operator can keep a previously-set authHeader by sending the redacted
+// sentinel back unchanged.
+function validateWebhooksStrict(raw: any, existing: any[] = []) {
+  if (!Array.isArray(raw)) throw new Error('webhooks must be an array');
+  if (raw.length > WEBHOOKS_LIMIT) {
+    throw new Error(`webhooks must be at most ${WEBHOOKS_LIMIT} entries`);
+  }
+  const byId = new Map(existing.map((h: any) => [h.id, h]));
+  const seen = new Set<string>();
+  return raw.map((item, i) => {
+    if (!item || typeof item !== 'object') throw new Error(`webhooks[${i}] must be an object`);
+    const url = String(item.url ?? '').trim();
+    if (!/^https?:\/\//.test(url)) {
+      throw new Error(`webhooks[${i}].url must start with http:// or https://`);
+    }
+    if (url.length > 500) throw new Error(`webhooks[${i}].url too long`);
+    if (!Array.isArray(item.events) || item.events.length === 0) {
+      throw new Error(`webhooks[${i}].events must be a non-empty array`);
+    }
+    const events: string[] = [];
+    for (const e of item.events) {
+      if (!WEBHOOK_EVENTS.includes(e)) {
+        throw new Error(
+          `webhooks[${i}].events entries must be one of: ${WEBHOOK_EVENTS.join(', ')}`,
+        );
+      }
+      if (!events.includes(e)) events.push(e);
+    }
+    let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('wh_');
+    if (seen.has(id)) id = mintId('wh_');
+    seen.add(id);
+    // authHeader: sentinel 'set' from getRedacted() means "keep the existing
+    // value" — the UI never re-sends the actual header. Anything else replaces.
+    const prior = byId.get(id);
+    let authHeader = '';
+    if (item.authHeader === 'set' && prior?.authHeader) {
+      authHeader = prior.authHeader;
+    } else if (typeof item.authHeader === 'string') {
+      authHeader = item.authHeader.slice(0, 500);
+    }
+    return {
+      id,
+      url,
+      events,
+      enabled: item.enabled !== false,
+      authHeader,
+    };
+  });
 }
 
 // Validate + persist. Returns { saved, requiresRestart } so the UI can react.
@@ -962,6 +1064,9 @@ export async function update(patch) {
     if (sx.enabled !== undefined) {
       next.sfx.enabled = !!sx.enabled;
     }
+  }
+  if ('webhooks' in patch) {
+    next.webhooks = validateWebhooksStrict(patch.webhooks, next.webhooks || []);
   }
 
   // Post-patch integrity sweep — a personas/shows change in this patch may

--- a/web/app/admin/archives/page.tsx
+++ b/web/app/admin/archives/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import ArchivesPanel from '../../../components/admin/ArchivesPanel';
+
+export const metadata: Metadata = {
+  title: 'Archives',
+};
+
+export default function AdminArchivesPage() {
+  return <ArchivesPanel />;
+}

--- a/web/app/admin/webhooks/page.tsx
+++ b/web/app/admin/webhooks/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import WebhooksPanel from '../../../components/admin/WebhooksPanel';
+
+export const metadata: Metadata = {
+  title: 'Webhooks',
+};
+
+export default function AdminWebhooksPage() {
+  return <WebhooksPanel />;
+}

--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -15,6 +15,8 @@ import {
   Sparkles,
   SlidersHorizontal,
   Terminal,
+  Archive,
+  Webhook,
 } from 'lucide-react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import type { SignInResult } from '../../lib/adminAuth';
@@ -57,6 +59,8 @@ const NAV_SECTIONS: NavSection[] = [
     label: 'System',
     items: [
       { href: '/admin/stats', id: 'stats', label: 'Stats', icon: BarChart3 },
+      { href: '/admin/archives', id: 'archives', label: 'Archives', icon: Archive },
+      { href: '/admin/webhooks', id: 'webhooks', label: 'Webhooks', icon: Webhook },
       { href: '/admin/settings', id: 'settings', label: 'Settings', icon: SlidersHorizontal },
       { href: '/admin/debug', id: 'debug', label: 'Debug', icon: Terminal },
     ],

--- a/web/components/admin/ArchivesPanel.tsx
+++ b/web/components/admin/ArchivesPanel.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+// Archives — /admin/archives. The hourly broadcast recordings Liquidsoap
+// writes under state/archive/. Read-only: download or delete via the file
+// system, no playback controls here (these MP3s are an hour long each and
+// the browser audio element doesn't seek well into them).
+
+import { useEffect, useMemo, useState } from 'react';
+import { useAdminAuth } from '../../lib/adminAuth';
+import { fmtSize, relTime } from '../../lib/format';
+import { Card, Btn, Eyebrow, Pill } from './ui';
+
+interface ArchiveEntry {
+  path: string;
+  date: string;
+  hour: number;
+  bytes: number;
+  mtime: string;
+}
+
+interface ArchivesResponse {
+  archives?: ArchiveEntry[];
+}
+
+function hourLabel(h: number): string {
+  return `${String(h).padStart(2, '0')}:00`;
+}
+
+export default function ArchivesPanel() {
+  const { adminFetch, auth, needsAuth, hydrated } = useAdminAuth();
+  const [entries, setEntries] = useState<ArchiveEntry[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!hydrated || needsAuth) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await adminFetch('/archives');
+        if (!r.ok) throw new Error(`failed (${r.status})`);
+        const j = (await r.json()) as ArchivesResponse;
+        if (cancelled) return;
+        setEntries(Array.isArray(j.archives) ? j.archives : []);
+        setErr(null);
+      } catch (e) {
+        if (cancelled) return;
+        setErr(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [hydrated, needsAuth, adminFetch]);
+
+  // Group by date — the operator's mental model is "let me grab yesterday's
+  // 9am hour", not "give me a flat list of 720 mp3s sorted by mtime".
+  const byDate = useMemo(() => {
+    if (!entries) return [] as { date: string; items: ArchiveEntry[]; bytes: number }[];
+    const m = new Map<string, ArchiveEntry[]>();
+    for (const e of entries) {
+      const arr = m.get(e.date) || [];
+      arr.push(e);
+      m.set(e.date, arr);
+    }
+    return [...m.entries()]
+      .sort((a, b) => (a[0] > b[0] ? -1 : 1))
+      .map(([date, items]) => ({
+        date,
+        items: items.sort((a, b) => b.hour - a.hour),
+        bytes: items.reduce((a, b) => a + b.bytes, 0),
+      }));
+  }, [entries]);
+
+  if (err) {
+    return (
+      <div className="grid gap-4">
+        <Card title="Archives"><div className="text-[13px] text-[var(--danger)]">controller error: {err}</div></Card>
+      </div>
+    );
+  }
+  if (!entries) {
+    return (
+      <div className="grid gap-4">
+        <Card title="Archives"><div className="text-[13px] text-muted italic">loading…</div></Card>
+      </div>
+    );
+  }
+
+  const totalBytes = entries.reduce((a, b) => a + b.bytes, 0);
+
+  // Download links carry HTTP Basic auth in the URL so the <a> can stream
+  // directly through Caddy without us pulling the whole file into memory.
+  const downloadHref = (path: string) => {
+    const base = process.env.NEXT_PUBLIC_API_URL || '/api';
+    // auth is base64(user:pass); split it back to inject as userinfo for
+    // same-origin URLs the browser will send a normal Authorization header
+    // for via fetch — but for a plain anchor download we need the credentials
+    // pre-baked. Use the credentials via a fetch-then-blob fallback if base
+    // is same-origin; for an external API URL include userinfo.
+    if (!base.startsWith('http')) return `${base}/archives/file/${path}`;
+    try {
+      const u = new URL(`${base}/archives/file/${path}`);
+      if (auth) {
+        const dec = typeof window !== 'undefined' ? window.atob(auth) : '';
+        const [user, pass] = dec.split(':');
+        if (user) u.username = encodeURIComponent(user);
+        if (pass) u.password = encodeURIComponent(pass);
+      }
+      return u.toString();
+    } catch {
+      return `${base}/archives/file/${path}`;
+    }
+  };
+
+  return (
+    <div className="grid gap-4">
+      <section className="card">
+        <div className="border-b border-ink p-4">
+          <Eyebrow className="text-vermilion">archives</Eyebrow>
+          <div className="mt-1.5 text-[22px] font-extrabold tracking-[-0.02em]">
+            What went out, hour by hour.
+          </div>
+          <div className="mt-1 text-[11px] leading-[1.6] text-muted">
+            Liquidsoap writes one MP3 per clock hour into <code>state/archive/</code>.
+            They&rsquo;re kept until the operator deletes them — there is no automatic rotation,
+            so keep an eye on disk if the station runs 24/7.
+          </div>
+        </div>
+        <div className="flex items-center gap-4 bg-[var(--ink-softer)] p-3.5">
+          <span className="caption">{entries.length} hour{entries.length === 1 ? '' : 's'}</span>
+          <span className="caption text-vermilion">{fmtSize(totalBytes)} total</span>
+        </div>
+      </section>
+
+      {byDate.length === 0 && (
+        <Card title="No recordings yet">
+          <div className="text-[12px] leading-[1.6] text-muted">
+            The first hour writes once the clock crosses the next <code>HH:00</code>. If you started the
+            station mid-hour, you&rsquo;ll see the first file after the next top of the hour.
+          </div>
+        </Card>
+      )}
+
+      {byDate.map(group => (
+        <Card
+          key={group.date}
+          title={group.date}
+          right={<Pill>{group.items.length} h · {fmtSize(group.bytes)}</Pill>}
+        >
+          <ul className="divide-y divide-[var(--ink-soft)]">
+            {group.items.map(e => (
+              <li key={e.path} className="flex items-center justify-between py-2">
+                <div className="flex items-center gap-3">
+                  <span className="mono-num text-[13px] font-bold">{hourLabel(e.hour)}</span>
+                  <span className="text-[11px] text-muted">{fmtSize(e.bytes)}</span>
+                  <span className="text-[10px] text-muted">{relTime(e.mtime)} ago</span>
+                </div>
+                <a href={downloadHref(e.path)} download>
+                  <Btn sm tone="accent">Download</Btn>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/web/components/admin/WebhooksPanel.tsx
+++ b/web/components/admin/WebhooksPanel.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+// Webhooks — /admin/webhooks. Outbound HTTP POSTs to operator-configured
+// endpoints on station events. See controller/src/broadcast/webhooks.ts
+// for the fan-out + the documented payload shapes.
+
+import { useEffect, useState } from 'react';
+import { useAdminAuth } from '../../lib/adminAuth';
+import { notify, errorMessage } from '../../lib/notify';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+import { Card, Btn, Pill, Eyebrow, Toggle } from './ui';
+
+interface Webhook {
+  id: string;
+  url: string;
+  events: string[];
+  enabled: boolean;
+  authHeader: string;       // 'set' sentinel from the server when a value is stored.
+}
+
+interface WebhooksResponse {
+  events: string[];
+  webhooks: Webhook[];
+}
+
+function clientMintId() {
+  const b = crypto.getRandomValues(new Uint8Array(3));
+  return 'wh_' + [...b].map(x => x.toString(16).padStart(2, '0')).join('');
+}
+
+function blank(events: string[]): Webhook {
+  return {
+    id: clientMintId(),
+    url: '',
+    events: events.slice(0, 1),
+    enabled: true,
+    authHeader: '',
+  };
+}
+
+function valid(h: Webhook): boolean {
+  if (!/^https?:\/\//.test(h.url.trim())) return false;
+  if (h.url.trim().length > 500) return false;
+  if (!h.events.length) return false;
+  return true;
+}
+
+export default function WebhooksPanel() {
+  const { adminFetch, needsAuth, hydrated } = useAdminAuth();
+  const [events, setEvents] = useState<string[] | null>(null);
+  const [hooks, setHooks] = useState<Webhook[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!hydrated || needsAuth) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await adminFetch('/webhooks');
+        if (!r.ok) throw new Error(`failed (${r.status})`);
+        const j = (await r.json()) as WebhooksResponse;
+        if (cancelled) return;
+        setEvents(j.events);
+        setHooks(j.webhooks || []);
+      } catch (e) {
+        if (cancelled) return;
+        setErr(errorMessage(e));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [hydrated, needsAuth, adminFetch]);
+
+  const save = async (next: Webhook[]) => {
+    setBusy(true);
+    try {
+      const r = await adminFetch('/webhooks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ webhooks: next }),
+      });
+      const j = (await r.json().catch(() => ({}))) as { webhooks?: Webhook[]; error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      setHooks(j.webhooks || []);
+      notify.ok('Webhooks saved.');
+    } catch (e) {
+      notify.err(`Save failed: ${errorMessage(e)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const fireTest = async (id: string) => {
+    try {
+      const r = await adminFetch(`/webhooks/${id}/test`, { method: 'POST' });
+      if (!r.ok) throw new Error(`failed (${r.status})`);
+      notify.ok('Test payload sent.');
+    } catch (e) {
+      notify.err(`Test failed: ${errorMessage(e)}`);
+    }
+  };
+
+  if (err) {
+    return (
+      <div className="grid gap-4">
+        <Card title="Webhooks"><div className="text-[13px] text-[var(--danger)]">controller error: {err}</div></Card>
+      </div>
+    );
+  }
+  if (!hooks || !events) {
+    return (
+      <div className="grid gap-4">
+        <Card title="Webhooks"><div className="text-[13px] text-muted italic">loading…</div></Card>
+      </div>
+    );
+  }
+
+  const allValid = hooks.every(valid);
+
+  return (
+    <div className="grid gap-4">
+      <section className="card">
+        <div className="border-b border-ink p-4">
+          <Eyebrow className="text-vermilion">webhooks</Eyebrow>
+          <div className="mt-1.5 text-[22px] font-extrabold tracking-[-0.02em]">
+            Pipe station events into other systems.
+          </div>
+          <div className="mt-1 text-[11px] leading-[1.6] text-muted">
+            Each row POSTs a JSON event to <code>url</code> the moment it happens — no retry queue, no buffer.
+            Best paired with a relay like a Cloudflare Worker or n8n. See
+            <code> controller/src/routes/webhooks.ts </code> for the payload shapes.
+          </div>
+        </div>
+        <div className="flex items-center gap-3 bg-[var(--ink-softer)] p-3.5">
+          <span className="caption">{hooks.length} hook{hooks.length === 1 ? '' : 's'}</span>
+          <span className="caption text-vermilion">
+            {hooks.filter(h => h.enabled).length} enabled
+          </span>
+          <span className="ml-auto" />
+          <Btn
+            sm
+            onClick={() => setHooks([...hooks, blank(events)])}
+            disabled={hooks.length >= 16}
+          >Add</Btn>
+          <Btn
+            sm
+            tone="accent"
+            onClick={() => save(hooks)}
+            disabled={!allValid || busy}
+          >{busy ? 'Saving…' : 'Save'}</Btn>
+        </div>
+      </section>
+
+      {hooks.length === 0 && (
+        <Card title="No webhooks yet">
+          <div className="text-[12px] leading-[1.6] text-muted">
+            Click <strong>Add</strong> above to wire your first one. Common targets: Discord webhooks (chat),
+            n8n / Pipedream (relay + retry), Home Assistant (lights pulse on a track change).
+          </div>
+        </Card>
+      )}
+
+      {hooks.map((h, i) => {
+        const update = (patch: Partial<Webhook>) => {
+          const next = [...hooks];
+          next[i] = { ...h, ...patch };
+          setHooks(next);
+        };
+        const remove = () => setHooks(hooks.filter((_, j) => j !== i));
+        const toggleEvent = (ev: string) => {
+          const has = h.events.includes(ev);
+          update({ events: has ? h.events.filter(e => e !== ev) : [...h.events, ev] });
+        };
+        return (
+          <Card
+            key={h.id}
+            title={h.url || <span className="text-muted italic">(new webhook)</span>}
+            right={
+              <>
+                <Pill tone={h.enabled ? 'accent' : 'default'} dot={h.enabled}>
+                  {h.enabled ? 'enabled' : 'disabled'}
+                </Pill>
+                <Toggle on={h.enabled} onClick={() => update({ enabled: !h.enabled })} />
+              </>
+            }
+          >
+            <div className="grid gap-3">
+              <div>
+                <Label className="caption">URL</Label>
+                <Input
+                  value={h.url}
+                  onChange={e => update({ url: e.target.value })}
+                  placeholder="https://discord.com/api/webhooks/…"
+                  spellCheck={false}
+                />
+              </div>
+              <div>
+                <Label className="caption">Authorization header (optional)</Label>
+                <Input
+                  value={h.authHeader === 'set' ? '' : h.authHeader}
+                  placeholder={h.authHeader === 'set' ? '(stored — leave blank to keep)' : 'Bearer …'}
+                  onChange={e => update({ authHeader: e.target.value })}
+                  spellCheck={false}
+                />
+                <div className="mt-1 text-[10px] text-muted">
+                  Sent verbatim as the <code>Authorization</code> header. Stored at rest in <code>settings.json</code>.
+                </div>
+              </div>
+              <div>
+                <Label className="caption">Events</Label>
+                <div className="mt-1 flex flex-wrap gap-2">
+                  {events.map(ev => {
+                    const on = h.events.includes(ev);
+                    return (
+                      <Pill
+                        key={ev}
+                        tone={on ? 'accent' : 'default'}
+                        dot={on}
+                        onClick={() => toggleEvent(ev)}
+                        className="cursor-pointer"
+                      >
+                        {ev}
+                      </Pill>
+                    );
+                  })}
+                </div>
+              </div>
+              <div className="mt-1 flex items-center gap-2">
+                <Btn sm tone="accent" onClick={() => fireTest(h.id)} disabled={!h.url}>
+                  Send test
+                </Btn>
+                <span className="ml-auto" />
+                <Btn sm tone="danger" onClick={remove}>Remove</Btn>
+              </div>
+            </div>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Three operator features that surface data already sitting around:

- **Archives** — list & download the hourly broadcast MP3s Liquidsoap writes to `state/archive/`. New `/admin/archives` page; read-only.
- **Listener history** — the existing Icecast poll now persists one row per wall-clock minute to `state/listeners.jsonl` (null samples dropped so outages leave gaps, not misleading zeros). Exposed via `GET /listeners` for a follow-up sparkline.
- **Outbound webhooks** — fire-and-forget HTTP POSTs on `track.play` / `dj.say` / `dj.link` / `request.received` to operator-configured endpoints. CRUD via `/admin/webhooks` with a per-row test-fire. No retry queue by design — point at a relay (n8n, Cloudflare Worker, Pipedream) if you need durability.

## Notes

- Webhook auth header is stored in `settings.json` and redacted from `getRedacted()` via a `'set'` sentinel, same pattern as the LLM/TTS api keys.
- `webhooks.notify()` reads settings on every fire, so toggling an endpoint or events list takes effect immediately — no restart.
- Archive downloads stream straight through Caddy via `createReadStream`; no buffering.
- Settings schema extended additively (`webhooks: []` default); first load on existing installs is migration-free.

## Test plan

- [ ] `/admin/archives` lists yesterday's hours, download button streams a playable MP3
- [ ] After ~2 minutes of uptime, `GET /api/listeners?sinceMinutes=60` returns rows
- [ ] Add a Discord-style webhook in `/admin/webhooks`, hit **Send test**, see the event in the target
- [ ] Enable `track.play`, wait for a transition, confirm payload arrives with title/artist
- [ ] Disable the hook, confirm no further fires
- [ ] Remove the hook, refresh, gone