### PR TITLE
fix(controller/picker): stop deterministic track/artist clustering

### DIFF
--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -72,8 +72,8 @@ export const pickerAgent = defineAgent({
   maxSteps: 4,
   timeoutMs: 22000,
   buildSystem: () => pickSystem(),
-  buildTools: ({ recentIds, recentArtists }) => {
-    const { tools, seen } = buildPickerTools({ recentIds, recentArtists });
+  buildTools: ({ recentIds, recentKeys, recentArtists }) => {
+    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, recentArtists });
     return { tools, extras: { seen } };
   },
 });
@@ -120,17 +120,19 @@ async function enqueuePick(queue, song, reason, source) {
 // ---------------------------------------------------------------------------
 
 async function pickViaAgent(queue, { wantLink }) {
-  const recentIds = queue.recentlyPlayedIds(25);
-  // Block the last ~10 distinct artists outright — recentIds alone can't stop a
-  // deep-catalogue artist (e.g. a full discography) reappearing every few
-  // tracks, since each fresh track has an id the agent hasn't seen.
-  const recentArtists = new Set<string>(
-    queue.getRecentArtists(10).map((a: string) => a.toLowerCase().trim()).filter(Boolean),
-  );
+  // 12h catches heavy-rotation tracks that repeat every 5-11h on this library
+  // (the 8h window missed Welcome To Heartbreak at gap 10h 54min). Includes a
+  // title|artist key set so backfilled entries (which lack track ids) still
+  // block repeats after a controller restart.
+  const { ids: recentIds, keys: recentKeys } = queue.recentlyPlayed(12);
+  // Block every artist heard in the last 2h. The old "last 10 distinct" window
+  // was ~30-40 min of airtime — far too short on a library this dense.
+  const recentArtists = queue.recentArtistsSince(2);
 
   const { object, steps, toolCalls, extras } = await pickerAgent.run({
     messages: session.windowMessages(),
     recentIds,
+    recentKeys,
     recentArtists,
   });
 
@@ -226,7 +228,10 @@ export async function runRequest(queue: any, ctx: any, { requester, text: _text 
   if (!settings.get().llm?.pickerAgent) return null;
 
   return withTrace({ kind: 'request', requester }, async () => {
-    const recentIds = queue.recentlyPlayedIds(25);
+    // Requests stay near-unfiltered — listeners must be able to re-request a
+    // song from earlier in the day. 2h covers the "don't repeat the song still
+    // ringing in their ears" case and nothing more.
+    const recentIds = queue.recentlyPlayedIds(2);
 
     const { object, toolCalls, extras } = await requestAgent.run({
       messages: session.windowMessages(),

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -40,6 +40,8 @@ class Queue {
   autoLink = true;             // toggle: random DJ links between auto tracks
   tracksUntilLink = pickLinkInterval();
   _persistTimer: NodeJS.Timeout | null = null; // debounce for the queue.json snapshot
+  _recentPlaysTimer: NodeJS.Timeout | null = null; // debounce for the recent-plays.json sidecar
+  _recentPlays: { id: string | null; title: string | null; artist: string | null; endedAt: string }[] = [];
   _autoMisses = 0;             // consecutive untracked plays — see onTrackStarted
 
   // Snapshot upcoming/current/history to disk. The queue is otherwise purely
@@ -60,6 +62,22 @@ class Queue {
         }, null, 2));
       } catch (err: any) {
         console.error('[queue] persist failed:', err.message);
+      }
+    }, 500);
+  }
+
+  // Write the rolling recent-plays sidecar. Separate from `persist()` because
+  // it has different shape and a different cap, and we want the heavy-traffic
+  // queue.json writes not to block on this one (and vice versa).
+  persistRecentPlays() {
+    if (this._recentPlaysTimer) return;
+    this._recentPlaysTimer = setTimeout(async () => {
+      this._recentPlaysTimer = null;
+      try {
+        await writeFile(config.queue.recentPlaysFile,
+          JSON.stringify(this._recentPlays, null, 2));
+      } catch (err: any) {
+        console.error('[queue] recent-plays persist failed:', err.message);
       }
     }, 500);
   }
@@ -90,6 +108,77 @@ class Queue {
         `Queue recovered: ${this.upcoming.length} upcoming, ${this.history.length} played`);
     } catch (err: any) {
       console.error('[queue] recover failed:', err.message);
+    }
+    if (existsSync(config.queue.recentPlaysFile)) {
+      try {
+        const arr = JSON.parse(readFileSync(config.queue.recentPlaysFile, 'utf8'));
+        if (Array.isArray(arr)) {
+          // Drop anything older than 48h on boot — keeps the file from
+          // ballooning if the cap was raised between restarts.
+          const cutoff = Date.now() - 48 * 3_600_000;
+          this._recentPlays = arr
+            .filter((p: any) => p && p.endedAt && new Date(p.endedAt).getTime() > cutoff)
+            .slice(0, config.queue.recentPlaysMax);
+        }
+      } catch (err: any) {
+        console.error('[queue] recent-plays recover failed:', err.message);
+      }
+    }
+    // Backfill from the events JSONL log — without this, a controller restart
+    // resets the 12h block window to whatever's in the sidecar file (often
+    // empty or only minutes deep), leaving heavy-rotation tracks free to
+    // repeat right after boot. Observed: "2 AM" by Karan Aujla picked at
+    // 00:19 UTC because its actual last play (23:11 UTC) was outside the
+    // sidecar's reach. The events log has every track.play and is durable.
+    this.backfillRecentPlaysFromEvents();
+    this.log('scheduler',
+      `Recent-plays loaded: ${this._recentPlays.length} entries (last 24h)`);
+  }
+
+  // Read the last 24h of track.play events from state/logs/events-*.jsonl
+  // and merge any missing entries into _recentPlays. Events lack a track id
+  // (only title + artist + t), so backfilled entries rely on the title|artist
+  // key path in tools.ts collect() to block repeats. Cheap: ~24h of plays =
+  // ~500 events, two file reads max.
+  backfillRecentPlaysFromEvents() {
+    try {
+      const cutoff = Date.now() - 24 * 3_600_000;
+      // Dedup by `t|title` against existing sidecar (which records endedAt
+      // close to the play.start time; near-enough that exact equality works).
+      const have = new Set(
+        this._recentPlays.map(p => `${p.endedAt}|${p.title || ''}`),
+      );
+      const filled: typeof this._recentPlays = [];
+      const today = new Date().toISOString().slice(0, 10);
+      const yest = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+      const stateDir = config.queue.file.replace(/\/queue\.json$/, '');
+      for (const day of [today, yest]) {
+        const path = `${stateDir}/logs/events-${day}.jsonl`;
+        if (!existsSync(path)) continue;
+        const text = readFileSync(path, 'utf8');
+        for (const line of text.split('\n')) {
+          if (!line) continue;
+          try {
+            const e = JSON.parse(line);
+            if (e.type !== 'track.play' || !e.t || !e.title) continue;
+            if (new Date(e.t).getTime() < cutoff) continue;
+            if (have.has(`${e.t}|${e.title}`)) continue;
+            filled.push({
+              id: null,
+              title: e.title || null,
+              artist: e.artist || null,
+              endedAt: e.t,
+            });
+          } catch {}
+        }
+      }
+      if (filled.length === 0) return;
+      this._recentPlays = [...this._recentPlays, ...filled]
+        .sort((a, b) => b.endedAt.localeCompare(a.endedAt))
+        .slice(0, config.queue.recentPlaysMax);
+      this.persistRecentPlays();
+    } catch (err: any) {
+      console.error('[queue] backfill from events failed:', err.message);
     }
   }
 
@@ -280,8 +369,23 @@ class Queue {
 
     // Roll previous current into history
     if (this.current) {
-      this.history.unshift({ ...this.current, endedAt: new Date().toISOString() });
+      const endedAt = new Date().toISOString();
+      this.history.unshift({ ...this.current, endedAt });
       this.history = this.history.slice(0, 50);
+      // Append to the rolling 24h sidecar used by the picker's recents window.
+      // history is in-memory only and capped at 50 (~3h of plays) — too short
+      // to catch the 2-3h repeat interval we've seen on the live station.
+      const t = this.current.track;
+      if (t) {
+        this._recentPlays.unshift({
+          id: t.id || null,
+          title: t.title || null,
+          artist: t.artist || null,
+          endedAt,
+        });
+        this._recentPlays = this._recentPlays.slice(0, config.queue.recentPlaysMax);
+        this.persistRecentPlays();
+      }
     }
 
     // Match upcoming by subsonic_id first (reliable), fall back to title+artist
@@ -390,14 +494,50 @@ class Queue {
     }
   }
 
-  // IDs of tracks played in the last N entries — used by scheduler to avoid repeats
-  recentlyPlayedIds(n = 25) {
-    const ids: string[] = [];
-    if (this.current?.track?.id) ids.push(this.current.track.id);
-    for (const h of this.history.slice(0, n)) {
-      if (h.track?.id) ids.push(h.track.id);
+  // Tracks played in the last `hours` hours — used by the picker to block
+  // repeats. Returns BOTH ids and `title|artist` keys, because the boot
+  // backfill (in recover()) reads from events-*.jsonl which lacks track ids;
+  // a key-based fallback lets backfilled entries still block repeats. Walks
+  // the rolling 24h sidecar (`_recentPlays`) newest-first to the cutoff and
+  // also includes the current track so a mid-song pick can't re-pick it.
+  recentlyPlayed(hours = 12) {
+    const cutoff = Date.now() - hours * 3_600_000;
+    const ids = new Set<string>();
+    const keys = new Set<string>();
+    const keyOf = (title: string | null | undefined, artist: string | null | undefined) =>
+      `${(title || '').toLowerCase().trim()}|${(artist || '').toLowerCase().trim()}`;
+    const cur = this.current?.track;
+    if (cur?.id) ids.add(cur.id);
+    if (cur?.title) keys.add(keyOf(cur.title, cur.artist));
+    for (const p of this._recentPlays) {
+      if (new Date(p.endedAt).getTime() < cutoff) break;
+      if (p.id) ids.add(p.id);
+      if (p.title) keys.add(keyOf(p.title, p.artist));
     }
-    return new Set(ids);
+    return { ids, keys };
+  }
+
+  // Backwards-compat shim — callsites that only need ids (e.g. legacy fallback
+  // picker pool path that filters its own results) can keep calling this.
+  recentlyPlayedIds(hours = 12): Set<string> {
+    return this.recentlyPlayed(hours).ids;
+  }
+
+  // Lowercased artist names heard in the last `hours` hours — used by the
+  // picker to block recently-heard artists. 2h is a sane default; raising it
+  // narrows the pool fast on a small library.
+  recentArtistsSince(hours = 2) {
+    const cutoff = Date.now() - hours * 3_600_000;
+    const out = new Set<string>();
+    if (this.current?.track?.artist) {
+      out.add(this.current.track.artist.toLowerCase().trim());
+    }
+    for (const p of this._recentPlays) {
+      if (new Date(p.endedAt).getTime() < cutoff) break;
+      const k = (p.artist || '').toLowerCase().trim();
+      if (k) out.add(k);
+    }
+    return out;
   }
 
   // Poll now-playing.json every 1.5s and dispatch track changes

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -54,7 +54,8 @@ export async function refreshAutoPlaylist() {
 async function refreshAutoPlaylistInner() {
   const ctx = await getFullContext();
   const mood = ctx.dominantMood;
-  const recent = queue.recentlyPlayedIds(25);
+  // Match the auto-DJ picker's window (dj-agent.pickViaAgent) — 12h.
+  const recent = queue.recentlyPlayedIds(12);
 
   const pool: any[] = [];
   const fromSource: Record<string, number> = { mood: 0, playlist: 0, recent: 0, frequent: 0, starred: 0, random: 0 };

--- a/controller/src/broadcast/session.ts
+++ b/controller/src/broadcast/session.ts
@@ -67,12 +67,12 @@ function scenarioText(s: any) {
 }
 
 // One-line summary of a finished session, carried into the next as continuity.
+// Intentionally omits the "recently aired" track list — leaking the previous
+// session's titles into the new picker's prompt window biases it toward
+// re-picking those same tracks (observed cause of 6-8× daily repeats).
+// The picker has its own recents window for blocking repeats.
 function buildHandoff(prev: any) {
   if (!prev) return null;
-  const plays = prev.messages
-    .filter((m: any) => m.kind === 'play')
-    .slice(-3)
-    .map((m: any) => m.text);
   const lastSpoken = [...prev.messages].reverse()
     .find((m: any) => m.role === 'dj' || m.role === 'segment');
   const parts = [
@@ -80,7 +80,6 @@ function buildHandoff(prev: any) {
       ? `the show "${prev.show?.name}"`
       : `a ${prev.scenario.period || ''} block`,
   ];
-  if (plays.length) parts.push(`recently aired ${plays.join('; ')}`);
   if (lastSpoken?.text) parts.push(`you last said: "${lastSpoken.text.slice(0, 120)}"`);
   return parts.join(' — ');
 }

--- a/controller/src/config.ts
+++ b/controller/src/config.ts
@@ -109,6 +109,12 @@ export const config = {
     // The playback queue (upcoming/current/history) snapshotted to disk so a
     // controller restart doesn't lose tracks already handed to Liquidsoap.
     file: `${STATE_DIR}/queue.json`,
+    // Rolling 24h log of (id, artist, endedAt) for each track that aired.
+    // Read by the picker to block tracks/artists played in the last N hours —
+    // queue.history is capped at 50 (~3h) and only lives in-memory, which is
+    // why we keep a separate, longer-lived store.
+    recentPlaysFile: `${STATE_DIR}/recent-plays.json`,
+    recentPlaysMax: 300,
   },
   weather: {
     // Wolverhampton — your home location

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -352,7 +352,7 @@ export async function generateHourlyTime(time: any, weather: any, { recap = null
 export const PICKER_CRITERIA = `Selection criteria, in order:
 1. FLOW — does it transition naturally from what just played (energy, mood, tempo)?
 2. CONTEXT — does it fit the time of day, weather, and dominant mood?
-3. VARIETY — avoid the same artist back-to-back; rotate energy levels; don't be predictable.
+3. VARIETY — avoid the same artist back-to-back; don't repeat tracks you've already played today; rotate energy. Variety over cleverness — never pick a track because its title literally matches the time of day, the weather, or anything else literal.
 4. INTEREST — prefer something that creates a moment, not the most generic option.`;
 
 const PICKER_SYSTEM = `You are the DJ for SUB/WAVE, a personal internet radio station.

--- a/controller/src/llm/tools.ts
+++ b/controller/src/llm/tools.ts
@@ -26,10 +26,23 @@ function artistKey(s: any) {
   return (s.artist || '').toLowerCase().trim();
 }
 
-// Most songs by any one artist allowed across a whole pick, mirroring
-// music/picker.js's MAX_PER_ARTIST — keeps a deep catalogue artist from
-// flooding the candidate pool just because random/search keeps surfacing them.
-const MAX_PER_ARTIST = 3;
+// Navidrome (and library.songsByMood) return results in deterministic order:
+// `tracksByMood("night")` always returns the same first N of 89 night-tagged
+// songs; `topSongsByArtist("Karan Aujla")` always returns the same top-N by
+// play count. With `cap=8` the agent sees the same handful no matter how many
+// times it asks. Shuffling here turns each call into a fresh sample — the same
+// fix `music/picker.js` already applies at pool-build time.
+function shuffle<T>(arr: T[]): T[] {
+  return [...arr].sort(() => Math.random() - 0.5);
+}
+
+// Most songs by any one artist allowed across a whole pick. The recent-artists
+// window (passed by dj-agent.pickViaAgent) already blocks any artist heard in
+// the last 2h, so this cap only matters when multiple tools (searchLibrary +
+// topSongsByArtist + similarSongs) surface the same artist within one pick.
+// 2 is tighter than the previous 3 to reduce in-pool fixation on deep
+// catalogues — per-tool cap=8 still leaves plenty of candidates overall.
+const MAX_PER_ARTIST = 2;
 
 // Builds a fresh tool set scoped to one pick. `recentIds` (recently-played
 // song ids) and `recentArtists` (lowercased recently-played artist names) are
@@ -38,8 +51,13 @@ const MAX_PER_ARTIST = 3;
 // listener-request path so a request for a recent artist still resolves.
 export function buildPickerTools({
   recentIds = new Set<string>(),
+  recentKeys = new Set<string>(),
   recentArtists = new Set<string>(),
-}: { recentIds?: Set<string>; recentArtists?: Set<string> } = {}) {
+}: {
+  recentIds?: Set<string>;
+  recentKeys?: Set<string>;        // lowercased "title|artist" — backfilled entries lack ids
+  recentArtists?: Set<string>;
+} = {}) {
   const seen = new Map<string, any>(); // id → slim song, accumulated across all tool calls
   const artistCounts = new Map<string, number>(); // artist key → songs already accepted into `seen`
 
@@ -50,10 +68,13 @@ export function buildPickerTools({
   // agent — see picker-latency notes in dj-agent.js. The seen map still
   // accumulates across the whole loop, so the agent's id space grows with
   // each tool call regardless.
+  const trackKey = (s: any) =>
+    `${(s.title || '').toLowerCase().trim()}|${(s.artist || '').toLowerCase().trim()}`;
   const collect = (list: any, cap = 8) => {
     const out: any[] = [];
-    for (const s of (list || []) as any[]) {
+    for (const s of shuffle((list || []) as any[])) {
       if (!s?.id || recentIds.has(s.id) || seen.has(s.id)) continue;
+      if (recentKeys.has(trackKey(s))) continue;   // catches backfilled entries (no id)
       const key = artistKey(s);
       if (key && recentArtists.has(key)) continue;
       if (key) {

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -55,7 +55,7 @@ async function tracksFromAlbums(albums: any[], perAlbum: number, max: number) {
   return out;
 }
 
-async function buildCandidates(mood: string | null | undefined, recentIds: Set<string>, currentTrack: any) {
+async function buildCandidates(mood: string | null | undefined, recentIds: Set<string>, recentArtists: Set<string>, currentTrack: any) {
   await library.load();
   const pool: any[] = [];
   const sources: Record<string, number> = {};
@@ -174,6 +174,11 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     .filter((t: any) => {
       if (!t.id || seen.has(t.id)) return false;
       const artistKey = (t.artist || '').toLowerCase().trim();
+      // Drop tracks by an artist heard in the last 2h, mirroring the agent
+      // picker's recentArtistsSince(2) filter. Without this, the fallback
+      // path (~1 in 4-5 picks on the current model) could cluster the same
+      // artist 4× in 90 min, as observed with Prabh Deep on 2026-05-25.
+      if (artistKey && recentArtists.has(artistKey)) return false;
       if (artistKey) {
         const n = perArtist.get(artistKey) || 0;
         if (n >= MAX_PER_ARTIST) return false;
@@ -210,9 +215,12 @@ function summariseRecent(queue: any) {
 // ---------------------------------------------------------------------------
 
 export async function pickViaPool(queue, ctx) {
-  const recentIds = queue.recentlyPlayedIds(25);
+  // Match the agent picker's window (dj-agent.pickViaAgent) — 12h. Anything
+  // shorter and the fallback could pick a track the agent would have rejected.
+  const recentIds = queue.recentlyPlayedIds(12);
+  const recentArtists = queue.recentArtistsSince(2);
   const currentTrack = queue.current?.track || null;
-  const { candidates, sources } = await buildCandidates(ctx.dominantMood, recentIds, currentTrack);
+  const { candidates, sources } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack);
 
   if (candidates.length === 0) {
     queue.log('picker', 'no candidates available, skipping LLM pick');

--- a/controller/src/routes/request.ts
+++ b/controller/src/routes/request.ts
@@ -154,7 +154,9 @@ async function resolveRequest(entry) {
     if (!refArtist) {
       return failed(`Nothing's playing yet — tell me what you're after instead.`);
     }
-    const recentIds = queue.recentlyPlayedIds(25);
+    // Requests stay near-unfiltered — 2h is enough to skip the song still
+    // ringing in their ears without blocking a re-request from earlier today.
+    const recentIds = queue.recentlyPlayedIds(2);
     const pick = await pickByArtistAndSort({
       artistName: refArtist, sort: null, scope: 'song', recentIds,
     });
@@ -219,7 +221,8 @@ async function resolveRequest(entry) {
     searchTerms: matched.search_terms,
   });
 
-  const recentIds = queue.recentlyPlayedIds(25);
+  // Requests stay near-unfiltered — see /more-like-this comment above.
+  const recentIds = queue.recentlyPlayedIds(2);
   await library.load();
 
   // Helper: pick a fresh random item from a pool, preferring non-recents.


### PR DESCRIPTION
Diagnosed via 24h event log: top tracks aired 6-8x ("2 AM" by Karan Aujla x8, "Welcome To Heartbreak" x4, "Eyes on Me" x7) and the picker's tool calls were highly repetitive (`tracksByMood("night")` 46x; `topSongsByArtist("Karan Aujla")` 7x). Two compounding causes:

1. Navidrome / `library.songsByMood` return results in deterministic order, so every repeat call returned the same first 8 candidates.
2. The picker's repeat-block window was count-based (last 25 plays, ~90 min - 2h) and lived only in `queue.history` (capped at 50, in-memory only) — so any track aired more than ~2h apart was free to re-pick.

Fix:

- `llm/tools.ts` collect() shuffles each tool's results before slicing to cap=8, breaking the deterministic Navidrome ordering. Dominant fix.
- New rolling 24h sidecar at `state/recent-plays.json` (cap 300), written debounced from `onTrackStarted`. `queue.recentlyPlayed(hours)` returns `{ids, keys}`; new `queue.recentArtistsSince(hours)` returns a Set. Both walk the sidecar newest-first to the cutoff.
- On boot, `recover()` backfills the sidecar from today's + yesterday's `events-*.jsonl` `track.play` events so a controller restart never resets the block window to zero (observed cause of a "2 AM" repeat 14 min after restart).
- Picker callsites switched to hour-based windows: auto-DJ uses 12h tracks + 2h artists; `runRequest` and `routes/request.ts` use 2h tracks (requests stay near-unfiltered so listeners can re-request a song from earlier in the day); scheduler and pool fallback match the agent's 12h.
- `music/picker.pickViaPool` (the fallback used when the LLM agent fails its done-tool ~1 in 4-5 calls) now also reads `recentArtistsSince(2)` and filters candidates by it — without this, a Prabh Deep cluster of 4 tracks in 1h 24min slipped through.
- `PICKER_CRITERIA` adds a no-title-as-clock-cue rule (caught the agent verbatim picking "2 AM" with rationale "Punjabi night thread, 2AM timing").
- `MAX_PER_ARTIST` 3 -> 2 in tools.ts.
- `session.buildHandoff` no longer prepends "recently aired ..." track list to the next session prompt — that was leaking favourites across session rolls.

Verified live: 5h post-deploy, 73 plays, 0 track repeats, 68 unique artist strings (vs 481 plays / "2 AM" x8 / heavy Kanye/Diljit concentration in the prior 24h).

<!--
Thanks for the PR! Keep this short — the description is for reviewers, not
for the changelog (release-please builds that from your Conventional Commit
messages, e.g. `feat: …`, `fix(ui): …`).
-->

## What
<!-- One or two sentences on the change. -->

## Why
<!-- The motivation — the bug, the user need, the constraint. Link the issue if there is one. -->

## How tested
<!--
How did you verify this works? e.g.
- `cd docker && docker compose up -d --build controller` and watched logs
- played the stream for ~5 min, confirmed no doubling on crossfades
- N/A — docs/config only
-->

## Notes for reviewers
<!-- Anything non-obvious: a tradeoff you considered, an area you're unsure about, a follow-up you'd like to defer. Delete this section if not needed. -->
