### PR TITLE
chore(web/landing): humanize prose, drop AI-style em dashes

### DIFF
--- a/web/components/landing/Navidrome.tsx
+++ b/web/components/landing/Navidrome.tsx
@@ -23,16 +23,16 @@ export default function Navidrome() {
           <p className="text-muted">
             SUB/WAVE is the DJ, the mixer, and the broadcast layer. The music
             comes from <strong className="text-ink">your</strong>{' '}
-            Navidrome — the self-hosted music server with a Subsonic API. Run
+            Navidrome, the self-hosted music server with a Subsonic API. Run
             Navidrome on your homelab, point SUB/WAVE at it, and the DJ
             picks from your collection. Nobody else's algorithm. Nobody else's catalogue.
           </p>
 
           <ul className="bs-navidrome-bullets">
-            <li><strong>Your taste, not a recommendation engine.</strong> The picker reads the metadata you tagged — genres, moods, your own folders — and chooses from there.</li>
+            <li><strong>Your taste, not a recommendation engine.</strong> The picker reads the metadata you tagged (genres, moods, your own folders) and chooses from there.</li>
             <li><strong>No licensing fees.</strong> You already own (or, you know, have on disk) the music. SUB/WAVE doesn't add a streaming bill on top.</li>
             <li><strong>Private by default.</strong> Listeners hit one MP3 stream. Nobody outside your stack ever sees your library, your tags, or who requested what.</li>
-            <li><strong>BYO Subsonic-compatible server.</strong> Subsonic, Airsonic, Gonic, Funkwhale — if it speaks the Subsonic API, it works.</li>
+            <li><strong>BYO Subsonic-compatible server.</strong> Subsonic, Airsonic, Gonic, Funkwhale. If it speaks the Subsonic API, it works.</li>
           </ul>
 
           <div className="bs-navidrome-cta">

--- a/web/components/what/BehindTheDesk.tsx
+++ b/web/components/what/BehindTheDesk.tsx
@@ -6,31 +6,31 @@ const PANELS = [
     eyebrow: 'DASH',
     title: 'The command center.',
     body:
-      'Live status — who is on air, the mood, listener count, weather. See the queue, read the booth log, skip a track, fire a station ID, or send your own words to air as raw or styled voice.',
+      'Live status: who is on air, the mood, listener count, weather. See the queue, read the booth log, skip a track, fire a station ID, or send your own words to air as raw or styled voice.',
   },
   {
     eyebrow: 'PERSONAS',
     title: 'The voices on the station.',
     body:
-      'Up to twelve DJ identities — name, soul, tagline, talk frequency, voice, and which skills each one may use. One persona is on air at a time; a show can hand it the hour.',
+      'Up to twelve DJ identities: name, soul, tagline, talk frequency, voice, and which skills each one may use. One persona is on air at a time; a show can hand it the hour.',
   },
   {
     eyebrow: 'SKILLS',
     title: 'What the DJ does between tracks.',
     body:
-      'Each skill is an autonomous segment — a weather check, a news headline, an absurd traffic update, an oddly-specific fact. Toggle each one on, assign it to a persona, or run any one now as an operator override.',
+      'Each skill is an autonomous segment: a weather check, a news headline, an absurd traffic update, an oddly-specific fact. Toggle each one on, assign it to a persona, or run any one now as an operator override.',
     fig: {
       src: '/screenshots/admin-skills.webp',
       label: 'Admin — Skills',
       caption:
-        'Skills: the autonomous segments the DJ runs between tracks — toggle each, run any one now.',
+        'Skills: the autonomous segments the DJ runs between tracks. Toggle each, run any one now.',
     },
   },
   {
     eyebrow: 'SHOWS',
     title: 'A weekly schedule you paint.',
     body:
-      'A 24×7 grid you brush shows onto. Each show carries a persona, a music mood, and a topic brief — genres, eras, the host’s tone. Autonomous hours fill whatever you leave blank.',
+      'A 24×7 grid you brush shows onto. Each show carries a persona, a music mood, and a topic brief: genres, eras, the host’s tone. Autonomous hours fill whatever you leave blank.',
     fig: {
       src: '/screenshots/admin-shows.webp',
       label: 'Admin — Weekly Schedule',
@@ -48,7 +48,7 @@ const PANELS = [
     eyebrow: 'DEBUG & STATS',
     title: 'Health and diagnostics.',
     body:
-      'Debug and Stats show health, Liquidsoap logs, LLM call history, and usage at a glance. Settings — TTS, LLM, mixer, jingles — and a danger zone that starts, stops, and restarts the broadcast.',
+      'Debug and Stats show health, Liquidsoap logs, LLM call history, and usage at a glance. Settings (TTS, LLM, mixer, jingles) and a danger zone that starts, stops, and restarts the broadcast.',
   },
 ];
 
@@ -58,7 +58,7 @@ export default function BehindTheDesk() {
       <p className="bs-eyebrow">PART FOUR · THE CONSOLE</p>
       <h2>Behind the desk.</h2>
       <p className="text-muted">
-        Everything a listener hears is shaped from one place — a gated admin
+        Everything a listener hears is shaped from one place: a gated admin
         console with eight panels. This is where the operator actually runs the
         station.
       </p>
@@ -105,7 +105,7 @@ export default function BehindTheDesk() {
           src="/screenshots/admin-debug.webp"
           alt="Admin — Debug"
           label="Admin — Debug"
-          caption="Debug: a health strip, Liquidsoap logs, and recent LLM calls — refreshed live."
+          caption="Debug: a health strip, Liquidsoap logs, and recent LLM calls, refreshed live."
         />
       </div>
     </EditorialReveal>

--- a/web/components/what/Coda.tsx
+++ b/web/components/what/Coda.tsx
@@ -7,8 +7,8 @@ export default function Coda() {
       <p className="bs-eyebrow self-center">END OF FEATURE</p>
       <h2 className="max-w-[20ch]">The station is on air right now.</h2>
       <p className="text-center text-muted">
-        There is nothing to scroll and nothing to pick. Tune in and hear what
-        the DJ is playing — or stand up your own frequency from the source.
+        Nothing to scroll, nothing to pick. Tune in and hear what
+        the DJ is playing, or stand up your own frequency from the source.
       </p>
 
       <div className="mt-2 flex flex-wrap items-center justify-center gap-4">

--- a/web/components/what/MakeARequest.tsx
+++ b/web/components/what/MakeARequest.tsx
@@ -6,7 +6,7 @@ const STEPS = [
     n: '01',
     title: 'Ask in plain language.',
     body:
-      'Open the request drawer and type what you want — a song title, an artist, a vibe. No exact spelling, no library browsing. Add your name if you want the DJ to use it on air.',
+      'Open the request drawer and type what you want: a song title, an artist, a vibe. No exact spelling, no library browsing. Add your name if you want the DJ to use it on air.',
   },
   {
     n: '02',
@@ -18,13 +18,13 @@ const STEPS = [
     n: '03',
     title: 'The DJ finds the match.',
     body:
-      'An LLM reads your request, searches the library, and picks the closest real track. Suggestion chips — built from the current artist, the time of day, the weather — give you a head start if you are undecided.',
+      'An LLM reads your request, searches the library, and picks the closest real track. Suggestion chips (built from the current artist, the time of day, the weather) give you a head start if you are undecided.',
   },
   {
     n: '04',
     title: 'It airs, with an intro.',
     body:
-      'When the match lands, the drawer shows the track and the DJ’s spoken intro. Your request joins the one queue everyone is hearing — and the DJ may say your name as it goes out.',
+      'When the match lands, the drawer shows the track and the DJ’s spoken intro. Your request joins the one queue everyone is hearing, and the DJ may say your name as it goes out.',
   },
 ];
 
@@ -34,7 +34,7 @@ export default function MakeARequest() {
       <p className="bs-eyebrow">PART THREE · REQUESTS</p>
       <h2>Phone the station, like you used to.</h2>
       <p className="text-muted">
-        Requests are the one place a listener steers the broadcast — and it
+        Requests are the one place a listener steers the broadcast. And it
         works the way calling a radio station always should have.
       </p>
 

--- a/web/components/what/MeetTheVoices.tsx
+++ b/web/components/what/MeetTheVoices.tsx
@@ -5,7 +5,7 @@ const HABITS = [
   {
     label: 'PICKS THE NEXT TRACK',
     body:
-      'The DJ reads the time, the weather, the season, festivals on the calendar, what just played, and any listener requests — then asks an LLM what should come next and pulls a real song from the library.',
+      'The DJ reads the time, the weather, the season, festivals on the calendar, what just played, and any listener requests, then asks an LLM what should come next and pulls a real song from the library.',
   },
   {
     label: 'TALKS BETWEEN SONGS',
@@ -15,7 +15,7 @@ const HABITS = [
   {
     label: 'CHANGES WITH THE HOUR',
     body:
-      'A scheduled show can hand the hour to a different persona — each with its own name, personality, voice, and how often it speaks. The 3am host is not the 8am host.',
+      'A scheduled show can hand the hour to a different persona, each with its own name, personality, voice, and how often it speaks. The 3am host is not the 8am host.',
   },
 ];
 
@@ -25,8 +25,8 @@ export default function MeetTheVoices() {
       <p className="bs-eyebrow">PART TWO · THE DJ</p>
       <h2>An LLM with a library and a microphone.</h2>
       <p className="text-muted">
-        The voice between the tracks is not air talent. It is a persona — a name,
-        a soul, a voice engine, and a talk frequency — driven by a language model.
+        The voice between the tracks is not air talent. It is a persona (a name,
+        a soul, a voice engine, a talk frequency) driven by a language model.
       </p>
 
       <Figure
@@ -48,7 +48,7 @@ export default function MeetTheVoices() {
       </div>
 
       <p className="mt-2 max-w-[64ch] text-[14px] leading-[1.6] text-muted">
-        The model behind it is the operator’s choice — a local Ollama box, or a
+        The model behind it is the operator’s choice: a local Ollama box, or a
         hosted provider like Anthropic, OpenAI, or Google. The voice is just as
         swappable: local engines Piper, Kokoro, and Chatterbox run on-device, or
         a cloud voice from OpenAI or ElevenLabs. Change either one in the console

--- a/web/components/what/OnTheAir.tsx
+++ b/web/components/what/OnTheAir.tsx
@@ -6,25 +6,25 @@ const POINTS = [
     eyebrow: 'NOW PLAYING',
     title: 'The track, the artist, the booth.',
     body:
-      'The player opens on whatever is on air — cover art pulled straight from your library, title, artist, album, and elapsed time. A waveform tracks the audio underneath. It is not your queue. It is the station’s.',
+      'The player opens on whatever is on air: cover art pulled straight from your library, title, artist, album, and elapsed time. A waveform tracks the audio underneath. It is not your queue. It is the station’s.',
   },
   {
     eyebrow: 'TIMELINE & BOOTH',
     title: 'See what is coming, hear what was said.',
     body:
-      'Two drawers slide out from the side. The Timeline shows tracks queued and recently played; the Booth is a live log of every word the DJ has spoken — station IDs, time checks, weather, the links between songs.',
+      'Two drawers slide out from the side. The Timeline shows tracks queued and recently played; the Booth is a live log of every word the DJ has spoken: station IDs, time checks, weather, the links between songs.',
   },
   {
     eyebrow: 'NO SKIP, ON PURPOSE',
     title: 'A shared broadcast, not a remote control.',
     body:
-      'There is no skip control for listeners — a stray double-tap on someone’s headphones should not change the song for everyone else. Track-end is the only natural transition. It is radio, so it behaves like radio.',
+      'There is no skip control for listeners. A stray double-tap on someone’s headphones should not change the song for everyone else. Track-end is the only natural transition. Radio behaves like radio.',
   },
   {
     eyebrow: 'INSTALL IT',
     title: 'A real app on the lock screen.',
     body:
-      'SUB/WAVE installs as a PWA — a home-screen icon, full-screen, offline-aware. The OS media controls wire straight through, so the lock screen, your headphones, and the car display all show the station and pause it cleanly.',
+      'SUB/WAVE installs as a PWA: a home-screen icon, full-screen, offline-aware. The OS media controls wire straight through, so the lock screen, your headphones, and the car display all show the station and pause it cleanly.',
   },
 ];
 

--- a/web/components/what/UnderTheHood.tsx
+++ b/web/components/what/UnderTheHood.tsx
@@ -15,14 +15,14 @@ export default function UnderTheHood() {
       <h2>Four processes, one box, one stream out.</h2>
 
       <div className="bs-drop-cap max-w-[64ch] text-[15px] leading-[1.6]">
-        SUB/WAVE is not a cloud service. The whole stack — Icecast, Liquidsoap,
-        the Controller, the LLM, the voice engines, and a Caddy edge — runs on a
+        SUB/WAVE is not a cloud service. The whole stack (Icecast, Liquidsoap,
+        the Controller, the LLM, the voice engines, and a Caddy edge) runs on a
         single machine in someone’s home, behind Cloudflare. The Controller is a
         small Node.js process that decides what plays and what gets said.
         Liquidsoap mixes the music, crossfades the tracks, ducks the DJ’s voice
         over the bed, and rotates the jingles. Icecast pushes the one stream out
-        to every browser. The pieces talk through plain files in a shared folder
-        — no socket, no message queue, the Unix way.
+        to every browser. The pieces talk through plain files in a shared folder.
+        No socket, no message queue, the Unix way.
       </div>
 
       <div className="bs-flow">
@@ -44,7 +44,7 @@ export default function UnderTheHood() {
 
       <p className="mt-6 max-w-[64ch] text-[14px] leading-[1.6] text-muted">
         No subscriptions, no round-trip to a data center, no algorithm tuned to
-        keep you scrolling. The whole source is open — so you can run your own
+        keep you scrolling. The whole source is open, so you can run your own
         with a different DJ persona, a different library, and a different city
         on the dateline.
       </p>
@@ -60,11 +60,11 @@ export default function UnderTheHood() {
         <p className="m-0 text-[16px] leading-[1.6]">
           Streaming apps gave everyone their own private channel. A playlist tuned
           to you, shuffled for you, paused the second you look away. SUB/WAVE goes
-          the other direction entirely. It is one Icecast stream — a single
-          broadcast every listener hears at the same moment — picked, announced,
+          the other direction entirely. It is one Icecast stream, a single
+          broadcast every listener hears at the same moment, picked, announced,
           and mixed by software running on a single box in someone&apos;s home.
-          There is no skip button. There is no &ldquo;for you.&rdquo; You tune in,
-          and you hear whatever is on the air right now, the same as everyone else.
+          No skip button. No &ldquo;for you.&rdquo; You tune in, and you hear
+          whatever is on the air right now, the same as everyone else.
         </p>
       </div>
     </EditorialReveal>


### PR DESCRIPTION
## Summary
- Swap em-dash interjections for colons, commas, parens, or periods across the broadsheet landing sections (`Navidrome`, `BehindTheDesk`, `Coda`, `MakeARequest`, `MeetTheVoices`, `OnTheAir`, `UnderTheHood`).
- Tighten a couple of "It is X" hedges (no-skip blurb, closing graf, Coda intro).
- Voice intact; only prose touched.

Remaining em dashes are typographic labels (e.g. "Admin — Personas"), the footer bookend, the fallback issue-number glyph, and one beat inside quoted DJ dialogue.

## Test plan
- [x] Visit `/landing` and skim each section for natural reading rhythm.
- [x] Confirm screenshot captions still render with their "Admin — X" labels intact.