### PR TITLE
fix: show configured station name in admin form and player header

### DIFF
--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -42,6 +42,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
       values: {
         jingleRatio: s.jingleRatio,
         crossfadeDuration: s.crossfadeDuration,
+        station: s.station,
         weather: s.weather,
         djPrompt: s.djPrompt,
         personas: s.personas,

--- a/web/components/PlayerApp.tsx
+++ b/web/components/PlayerApp.tsx
@@ -190,6 +190,7 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
       <TopBar
         tunedIn={tunedIn}
         context={context}
+        stationName={typeof dj?.station === 'string' ? dj.station : undefined}
         djName={typeof dj?.name === 'string' ? dj.name : undefined}
         activeShow={activeShow}
         listeners={listeners}

--- a/web/components/TopBar.tsx
+++ b/web/components/TopBar.tsx
@@ -9,6 +9,7 @@ import type { ActiveShow, ListenerCount, StationContext, ThemeMode } from '@/lib
 export interface TopBarProps {
   tunedIn: boolean;
   context: StationContext | null;
+  stationName?: string;
   djName?: string;
   activeShow: ActiveShow | null;
   listeners: ListenerCount | number | null;
@@ -23,6 +24,7 @@ function isListenerObject(l: ListenerCount | number | null): l is ListenerCount 
 export default function TopBar({
   tunedIn,
   context,
+  stationName,
   djName,
   activeShow,
   listeners,
@@ -53,7 +55,7 @@ export default function TopBar({
           data-spinning={tunedIn ? 'true' : undefined}
           aria-hidden="true"
         />
-        <span className="v3-eyebrow shrink-0">SUB/WAVE</span>
+        <span className="v3-eyebrow shrink-0">{stationName?.trim() || 'SUB/WAVE'}</span>
         {showName && (
           <span className="v3-caption min-w-0 truncate text-ink" title={showName}>
             ▸ {showName}


### PR DESCRIPTION
Closes #102.

The follow-up report on #102: after setting the station name on the dash, `/api/dj` showed it, but the admin form reverted to the placeholder on reload and the player header still said SUB/WAVE.

## Summary

- **Admin form persistence**: `GET /settings` was returning `values.{jingleRatio,crossfadeDuration,weather,djPrompt,…}` but had never been updated to include `station`. The save round-tripped fine (`POST /settings` accepts it, `/api/dj` reads it), but the form's hydration step in `SettingsPanel.tsx` read `data.values.station`, found `undefined`, and rendered the `SUB/WAVE` placeholder — looking to the operator like the save had silently failed. One line added to the route.
- **Player header**: `TopBar.tsx` hardcoded the `SUB/WAVE` wordmark. The component now takes an optional `stationName` prop, falling back to `SUB/WAVE` when unset; `PlayerApp` threads `dj.station` from the existing `/api/dj` payload through `useStationFeed`.

Project branding surfaces (OG image, `/landing` masthead, document title, install screenshots) are intentionally left as `SUB/WAVE` — those are the project name, not the operator's station.

## Test plan

- [x] On a fresh `develop` checkout, set Station name in `/admin/settings` to something other than `SUB/WAVE` → reload the page → field still shows the chosen name.
- [x] Visit `/` → wordmark in the top-left shows the chosen name (used to say `SUB/WAVE`).
- [x] `GET /api/settings` (with admin auth) returns `values.station` matching the saved value.
- [x] With `station` cleared/never set, both the form placeholder and the player wordmark fall back to `SUB/WAVE`.