### PR TITLE
release: admin archives + listener history + outbound webhooks

### DIFF
--- a/controller/src/broadcast/archives.ts
+++ b/controller/src/broadcast/archives.ts
@@ -1,0 +1,89 @@
+// Hourly archive index.
+//
+// Liquidsoap writes one MP3 per hour to `${STATE_DIR}/archive/%Y-%m-%d/%H-00.mp3`
+// (see liquidsoap/radio.liq's output.file block). This module exposes that
+// tree to the admin UI as a listable + downloadable index — purely read-only
+// over the existing on-disk layout.
+//
+// The pathing scheme is fixed and the operator never edits inside the
+// archive directory by hand, so we don't watch for changes; each /archives
+// GET re-scans. Two-level directory walk is cheap (one entry per hour).
+
+import { readdir, stat } from 'node:fs/promises';
+import { createReadStream, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { config } from '../config.js';
+
+const ARCHIVE_ROOT = join(config.stateDir, 'archive');
+
+// Date directories: "YYYY-MM-DD". Hour files: "HH-00.mp3".
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const HOUR_RE = /^(\d{2})-00\.mp3$/;
+
+export interface ArchiveEntry {
+  // YYYY-MM-DD/HH-00.mp3 — the safe relative path used by the download route.
+  path: string;
+  date: string;   // YYYY-MM-DD
+  hour: number;   // 0-23
+  bytes: number;
+  mtime: string;  // ISO
+}
+
+// Scan the archive tree. Newest first. Bounded by `limit` to keep the response
+// small for accounts with months of archives — the UI paginates client-side.
+export async function list({ limit = 500 }: { limit?: number } = {}): Promise<ArchiveEntry[]> {
+  if (!existsSync(ARCHIVE_ROOT)) return [];
+  let dayDirs: string[] = [];
+  try {
+    dayDirs = (await readdir(ARCHIVE_ROOT)).filter(d => DATE_RE.test(d)).sort().reverse();
+  } catch {
+    return [];
+  }
+
+  const out: ArchiveEntry[] = [];
+  for (const date of dayDirs) {
+    let files: string[] = [];
+    try {
+      files = await readdir(join(ARCHIVE_ROOT, date));
+    } catch {
+      continue;
+    }
+    // Hours descending so each day's newest hour appears first.
+    files.sort().reverse();
+    for (const f of files) {
+      const m = f.match(HOUR_RE);
+      if (!m) continue;
+      const abs = join(ARCHIVE_ROOT, date, f);
+      try {
+        const st = await stat(abs);
+        if (!st.isFile()) continue;
+        out.push({
+          path: `${date}/${f}`,
+          date,
+          hour: parseInt(m[1], 10),
+          bytes: st.size,
+          mtime: st.mtime.toISOString(),
+        });
+        if (out.length >= limit) return out;
+      } catch {}
+    }
+  }
+  return out;
+}
+
+// Resolve a client-supplied relative path against the archive root, rejecting
+// anything that escapes the tree or doesn't match the canonical naming scheme.
+// Returns the absolute path on success, or null if the input is unsafe / missing.
+export function resolveEntry(rel: string): string | null {
+  if (typeof rel !== 'string' || rel.length === 0 || rel.length > 64) return null;
+  const m = rel.match(/^(\d{4}-\d{2}-\d{2})\/(\d{2}-00\.mp3)$/);
+  if (!m) return null;
+  const abs = resolve(ARCHIVE_ROOT, rel);
+  if (!abs.startsWith(ARCHIVE_ROOT + '/')) return null;
+  if (!existsSync(abs)) return null;
+  return abs;
+}
+
+export function openStream(abs: string) {
+  return createReadStream(abs);
+}

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -72,8 +72,8 @@ export const pickerAgent = defineAgent({
   maxSteps: 4,
   timeoutMs: 22000,
   buildSystem: () => pickSystem(),
-  buildTools: ({ recentIds, recentArtists }) => {
-    const { tools, seen } = buildPickerTools({ recentIds, recentArtists });
+  buildTools: ({ recentIds, recentKeys, recentArtists }) => {
+    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, recentArtists });
     return { tools, extras: { seen } };
   },
 });
@@ -120,17 +120,19 @@ async function enqueuePick(queue, song, reason, source) {
 // ---------------------------------------------------------------------------
 
 async function pickViaAgent(queue, { wantLink }) {
-  const recentIds = queue.recentlyPlayedIds(25);
-  // Block the last ~10 distinct artists outright — recentIds alone can't stop a
-  // deep-catalogue artist (e.g. a full discography) reappearing every few
-  // tracks, since each fresh track has an id the agent hasn't seen.
-  const recentArtists = new Set<string>(
-    queue.getRecentArtists(10).map((a: string) => a.toLowerCase().trim()).filter(Boolean),
-  );
+  // 12h catches heavy-rotation tracks that repeat every 5-11h on this library
+  // (the 8h window missed Welcome To Heartbreak at gap 10h 54min). Includes a
+  // title|artist key set so backfilled entries (which lack track ids) still
+  // block repeats after a controller restart.
+  const { ids: recentIds, keys: recentKeys } = queue.recentlyPlayed(12);
+  // Block every artist heard in the last 2h. The old "last 10 distinct" window
+  // was ~30-40 min of airtime — far too short on a library this dense.
+  const recentArtists = queue.recentArtistsSince(2);
 
   const { object, steps, toolCalls, extras } = await pickerAgent.run({
     messages: session.windowMessages(),
     recentIds,
+    recentKeys,
     recentArtists,
   });
 
@@ -226,7 +228,10 @@ export async function runRequest(queue: any, ctx: any, { requester, text: _text 
   if (!settings.get().llm?.pickerAgent) return null;
 
   return withTrace({ kind: 'request', requester }, async () => {
-    const recentIds = queue.recentlyPlayedIds(25);
+    // Requests stay near-unfiltered — listeners must be able to re-request a
+    // song from earlier in the day. 2h covers the "don't repeat the song still
+    // ringing in their ears" case and nothing more.
+    const recentIds = queue.recentlyPlayedIds(2);
 
     const { object, toolCalls, extras } = await requestAgent.run({
       messages: session.windowMessages(),

--- a/controller/src/broadcast/listeners.ts
+++ b/controller/src/broadcast/listeners.ts
@@ -7,10 +7,20 @@
 // Fail-open: if Icecast is unreachable the count is null and djCallsAllowed()
 // treats the station as occupied — a stats outage must never silence the DJ.
 
+import { appendFile, readFile, stat } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { config } from '../config.js';
 import * as settings from '../settings.js';
 
 let lastCount: number | null = null;        // null = unknown (not yet polled, or Icecast down)
+
+// Time-series file. JSONL of {t, count} rows, one per persisted sample.
+// We persist every minute (not every 15s poll) — keeps the file at ~1440
+// rows/day, easily tail-readable, and that resolution is plenty for the
+// "is anyone here?" sparkline this is for.
+const HISTORY_FILE = join(config.stateDir, 'listeners.jsonl');
+let lastPersistedMinute = -1;
 
 async function fetchCount() {
   try {
@@ -24,6 +34,18 @@ async function fetchCount() {
     lastCount = src ? Number(src.listeners || 0) : 0;
   } catch {
     lastCount = null;
+  }
+  // Persist at most one row per wall-clock minute. Skip null samples — a
+  // stats outage shouldn't leave a misleading "0 listeners" stripe in the
+  // graph; the gap itself communicates the outage.
+  if (lastCount !== null) {
+    const now = new Date();
+    const minute = Math.floor(now.getTime() / 60000);
+    if (minute !== lastPersistedMinute) {
+      lastPersistedMinute = minute;
+      const line = JSON.stringify({ t: now.toISOString(), count: lastCount }) + '\n';
+      appendFile(HISTORY_FILE, line).catch(() => {});  // best-effort
+    }
   }
   return lastCount;
 }
@@ -52,4 +74,52 @@ export function djCallsAllowed() {
 export function startListenerMonitor() {
   fetchCount();
   setInterval(fetchCount, 15000);
+}
+
+// Read the recent listener history for the admin sparkline. Returns rows
+// newer than `since` (defaults to 24 h ago), oldest-first.
+//
+// JSONL is read whole and filtered in-memory — fine because the file caps
+// at ~1440 lines/day. If retention ever grows past a few MB, swap to a
+// streaming tail; until then, the simple read is enough.
+export interface ListenerSample {
+  t: string;
+  count: number;
+}
+
+export async function history({
+  since,
+}: { since?: Date } = {}): Promise<ListenerSample[]> {
+  if (!existsSync(HISTORY_FILE)) return [];
+  let raw = '';
+  try {
+    raw = await readFile(HISTORY_FILE, 'utf8');
+  } catch {
+    return [];
+  }
+  const cutoffMs = (since || new Date(Date.now() - 24 * 60 * 60 * 1000)).getTime();
+  const out: ListenerSample[] = [];
+  for (const line of raw.split('\n')) {
+    if (!line) continue;
+    try {
+      const row = JSON.parse(line);
+      const tMs = new Date(row.t).getTime();
+      if (!Number.isFinite(tMs) || tMs < cutoffMs) continue;
+      if (typeof row.count !== 'number') continue;
+      out.push({ t: row.t, count: row.count });
+    } catch {}
+  }
+  return out;
+}
+
+// Size of the persisted history file, for the admin debug view. Useful to
+// notice if the operator left the station running for a year and the file
+// grew unexpectedly.
+export async function historyBytes(): Promise<number> {
+  try {
+    const st = await stat(HISTORY_FILE);
+    return st.size;
+  } catch {
+    return 0;
+  }
 }

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -40,6 +40,8 @@ class Queue {
   autoLink = true;             // toggle: random DJ links between auto tracks
   tracksUntilLink = pickLinkInterval();
   _persistTimer: NodeJS.Timeout | null = null; // debounce for the queue.json snapshot
+  _recentPlaysTimer: NodeJS.Timeout | null = null; // debounce for the recent-plays.json sidecar
+  _recentPlays: { id: string | null; title: string | null; artist: string | null; endedAt: string }[] = [];
   _autoMisses = 0;             // consecutive untracked plays — see onTrackStarted
 
   // Snapshot upcoming/current/history to disk. The queue is otherwise purely
@@ -60,6 +62,22 @@ class Queue {
         }, null, 2));
       } catch (err: any) {
         console.error('[queue] persist failed:', err.message);
+      }
+    }, 500);
+  }
+
+  // Write the rolling recent-plays sidecar. Separate from `persist()` because
+  // it has different shape and a different cap, and we want the heavy-traffic
+  // queue.json writes not to block on this one (and vice versa).
+  persistRecentPlays() {
+    if (this._recentPlaysTimer) return;
+    this._recentPlaysTimer = setTimeout(async () => {
+      this._recentPlaysTimer = null;
+      try {
+        await writeFile(config.queue.recentPlaysFile,
+          JSON.stringify(this._recentPlays, null, 2));
+      } catch (err: any) {
+        console.error('[queue] recent-plays persist failed:', err.message);
       }
     }, 500);
   }
@@ -90,6 +108,77 @@ class Queue {
         `Queue recovered: ${this.upcoming.length} upcoming, ${this.history.length} played`);
     } catch (err: any) {
       console.error('[queue] recover failed:', err.message);
+    }
+    if (existsSync(config.queue.recentPlaysFile)) {
+      try {
+        const arr = JSON.parse(readFileSync(config.queue.recentPlaysFile, 'utf8'));
+        if (Array.isArray(arr)) {
+          // Drop anything older than 48h on boot — keeps the file from
+          // ballooning if the cap was raised between restarts.
+          const cutoff = Date.now() - 48 * 3_600_000;
+          this._recentPlays = arr
+            .filter((p: any) => p && p.endedAt && new Date(p.endedAt).getTime() > cutoff)
+            .slice(0, config.queue.recentPlaysMax);
+        }
+      } catch (err: any) {
+        console.error('[queue] recent-plays recover failed:', err.message);
+      }
+    }
+    // Backfill from the events JSONL log — without this, a controller restart
+    // resets the 12h block window to whatever's in the sidecar file (often
+    // empty or only minutes deep), leaving heavy-rotation tracks free to
+    // repeat right after boot. Observed: "2 AM" by Karan Aujla picked at
+    // 00:19 UTC because its actual last play (23:11 UTC) was outside the
+    // sidecar's reach. The events log has every track.play and is durable.
+    this.backfillRecentPlaysFromEvents();
+    this.log('scheduler',
+      `Recent-plays loaded: ${this._recentPlays.length} entries (last 24h)`);
+  }
+
+  // Read the last 24h of track.play events from state/logs/events-*.jsonl
+  // and merge any missing entries into _recentPlays. Events lack a track id
+  // (only title + artist + t), so backfilled entries rely on the title|artist
+  // key path in tools.ts collect() to block repeats. Cheap: ~24h of plays =
+  // ~500 events, two file reads max.
+  backfillRecentPlaysFromEvents() {
+    try {
+      const cutoff = Date.now() - 24 * 3_600_000;
+      // Dedup by `t|title` against existing sidecar (which records endedAt
+      // close to the play.start time; near-enough that exact equality works).
+      const have = new Set(
+        this._recentPlays.map(p => `${p.endedAt}|${p.title || ''}`),
+      );
+      const filled: typeof this._recentPlays = [];
+      const today = new Date().toISOString().slice(0, 10);
+      const yest = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+      const stateDir = config.queue.file.replace(/\/queue\.json$/, '');
+      for (const day of [today, yest]) {
+        const path = `${stateDir}/logs/events-${day}.jsonl`;
+        if (!existsSync(path)) continue;
+        const text = readFileSync(path, 'utf8');
+        for (const line of text.split('\n')) {
+          if (!line) continue;
+          try {
+            const e = JSON.parse(line);
+            if (e.type !== 'track.play' || !e.t || !e.title) continue;
+            if (new Date(e.t).getTime() < cutoff) continue;
+            if (have.has(`${e.t}|${e.title}`)) continue;
+            filled.push({
+              id: null,
+              title: e.title || null,
+              artist: e.artist || null,
+              endedAt: e.t,
+            });
+          } catch {}
+        }
+      }
+      if (filled.length === 0) return;
+      this._recentPlays = [...this._recentPlays, ...filled]
+        .sort((a, b) => b.endedAt.localeCompare(a.endedAt))
+        .slice(0, config.queue.recentPlaysMax);
+      this.persistRecentPlays();
+    } catch (err: any) {
+      console.error('[queue] backfill from events failed:', err.message);
     }
   }
 
@@ -280,8 +369,23 @@ class Queue {
 
     // Roll previous current into history
     if (this.current) {
-      this.history.unshift({ ...this.current, endedAt: new Date().toISOString() });
+      const endedAt = new Date().toISOString();
+      this.history.unshift({ ...this.current, endedAt });
       this.history = this.history.slice(0, 50);
+      // Append to the rolling 24h sidecar used by the picker's recents window.
+      // history is in-memory only and capped at 50 (~3h of plays) — too short
+      // to catch the 2-3h repeat interval we've seen on the live station.
+      const t = this.current.track;
+      if (t) {
+        this._recentPlays.unshift({
+          id: t.id || null,
+          title: t.title || null,
+          artist: t.artist || null,
+          endedAt,
+        });
+        this._recentPlays = this._recentPlays.slice(0, config.queue.recentPlaysMax);
+        this.persistRecentPlays();
+      }
     }
 
     // Match upcoming by subsonic_id first (reliable), fall back to title+artist
@@ -390,14 +494,50 @@ class Queue {
     }
   }
 
-  // IDs of tracks played in the last N entries — used by scheduler to avoid repeats
-  recentlyPlayedIds(n = 25) {
-    const ids: string[] = [];
-    if (this.current?.track?.id) ids.push(this.current.track.id);
-    for (const h of this.history.slice(0, n)) {
-      if (h.track?.id) ids.push(h.track.id);
+  // Tracks played in the last `hours` hours — used by the picker to block
+  // repeats. Returns BOTH ids and `title|artist` keys, because the boot
+  // backfill (in recover()) reads from events-*.jsonl which lacks track ids;
+  // a key-based fallback lets backfilled entries still block repeats. Walks
+  // the rolling 24h sidecar (`_recentPlays`) newest-first to the cutoff and
+  // also includes the current track so a mid-song pick can't re-pick it.
+  recentlyPlayed(hours = 12) {
+    const cutoff = Date.now() - hours * 3_600_000;
+    const ids = new Set<string>();
+    const keys = new Set<string>();
+    const keyOf = (title: string | null | undefined, artist: string | null | undefined) =>
+      `${(title || '').toLowerCase().trim()}|${(artist || '').toLowerCase().trim()}`;
+    const cur = this.current?.track;
+    if (cur?.id) ids.add(cur.id);
+    if (cur?.title) keys.add(keyOf(cur.title, cur.artist));
+    for (const p of this._recentPlays) {
+      if (new Date(p.endedAt).getTime() < cutoff) break;
+      if (p.id) ids.add(p.id);
+      if (p.title) keys.add(keyOf(p.title, p.artist));
     }
-    return new Set(ids);
+    return { ids, keys };
+  }
+
+  // Backwards-compat shim — callsites that only need ids (e.g. legacy fallback
+  // picker pool path that filters its own results) can keep calling this.
+  recentlyPlayedIds(hours = 12): Set<string> {
+    return this.recentlyPlayed(hours).ids;
+  }
+
+  // Lowercased artist names heard in the last `hours` hours — used by the
+  // picker to block recently-heard artists. 2h is a sane default; raising it
+  // narrows the pool fast on a small library.
+  recentArtistsSince(hours = 2) {
+    const cutoff = Date.now() - hours * 3_600_000;
+    const out = new Set<string>();
+    if (this.current?.track?.artist) {
+      out.add(this.current.track.artist.toLowerCase().trim());
+    }
+    for (const p of this._recentPlays) {
+      if (new Date(p.endedAt).getTime() < cutoff) break;
+      const k = (p.artist || '').toLowerCase().trim();
+      if (k) out.add(k);
+    }
+    return out;
   }
 
   // Poll now-playing.json every 1.5s and dispatch track changes

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -14,6 +14,7 @@ import { getFullContext } from '../context.js';
 import * as settings from '../settings.js';
 import { logEvent } from '../observability/events.js';
 import { djCallsAllowed } from './listeners.js';
+import * as webhooks from './webhooks.js';
 
 // Random gap between DJ links on auto-played tracks. The frequency setting
 // scales how chatty the DJ is:
@@ -334,6 +335,11 @@ class Queue {
       await writeFile(targetFile, wavPath);
       this.log(kind, text);
       session.appendTurn({ role: 'segment', kind, text });
+      // The auto-DJ link channel is its own event; everything else (station
+      // IDs, weather, hourly) is `dj.say`. Operators that pipe these into
+      // Discord usually want to filter the chatty link stream separately.
+      webhooks.notify(kind === 'link' ? 'dj.link' : 'dj.say',
+        kind === 'link' ? { text } : { text, kind });
     } catch (err: any) {
       this.log('error', `Announce failed: ${err.message}`);
     }
@@ -454,6 +460,15 @@ class Queue {
     logEvent('track.play', {
       title: this.current.track.title,
       artist: this.current.track.artist || null,
+      source: this.current.source,
+      requestedBy: this.current.requestedBy || null,
+    });
+
+    // Outbound fan-out — fire-and-forget; never blocks the picker path.
+    webhooks.notify('track.play', {
+      title: this.current.track.title,
+      artist: this.current.track.artist || null,
+      album: this.current.track.album || null,
       source: this.current.source,
       requestedBy: this.current.requestedBy || null,
     });

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -54,7 +54,8 @@ export async function refreshAutoPlaylist() {
 async function refreshAutoPlaylistInner() {
   const ctx = await getFullContext();
   const mood = ctx.dominantMood;
-  const recent = queue.recentlyPlayedIds(25);
+  // Match the auto-DJ picker's window (dj-agent.pickViaAgent) — 12h.
+  const recent = queue.recentlyPlayedIds(12);
 
   const pool: any[] = [];
   const fromSource: Record<string, number> = { mood: 0, playlist: 0, recent: 0, frequent: 0, starred: 0, random: 0 };

--- a/controller/src/broadcast/session.ts
+++ b/controller/src/broadcast/session.ts
@@ -67,12 +67,12 @@ function scenarioText(s: any) {
 }
 
 // One-line summary of a finished session, carried into the next as continuity.
+// Intentionally omits the "recently aired" track list — leaking the previous
+// session's titles into the new picker's prompt window biases it toward
+// re-picking those same tracks (observed cause of 6-8× daily repeats).
+// The picker has its own recents window for blocking repeats.
 function buildHandoff(prev: any) {
   if (!prev) return null;
-  const plays = prev.messages
-    .filter((m: any) => m.kind === 'play')
-    .slice(-3)
-    .map((m: any) => m.text);
   const lastSpoken = [...prev.messages].reverse()
     .find((m: any) => m.role === 'dj' || m.role === 'segment');
   const parts = [
@@ -80,7 +80,6 @@ function buildHandoff(prev: any) {
       ? `the show "${prev.show?.name}"`
       : `a ${prev.scenario.period || ''} block`,
   ];
-  if (plays.length) parts.push(`recently aired ${plays.join('; ')}`);
   if (lastSpoken?.text) parts.push(`you last said: "${lastSpoken.text.slice(0, 120)}"`);
   return parts.join(' — ');
 }

--- a/controller/src/broadcast/webhooks.ts
+++ b/controller/src/broadcast/webhooks.ts
@@ -1,0 +1,90 @@
+// Outbound webhooks — fan-out from station events (track.play, dj.say,
+// dj.link, request.received) to operator-configured HTTP endpoints.
+//
+// Fire-and-forget. The webhook delivery path must never block playback or
+// the DJ pipeline, so every send runs in the background with a hard 5-second
+// timeout. Failures log to stderr; there is no retry queue and no durable
+// outbox. If you want guaranteed delivery, point the webhook at a relay
+// (Cloudflare Worker, Pipedream, n8n) that owns its own retry policy — this
+// module's job is to get the event to that relay quickly, not to be one.
+//
+// The shape of the payload is documented in routes/webhooks.ts. Each event
+// is a stable JSON object with `event`, `t`, and event-specific fields.
+
+import * as settings from '../settings.js';
+
+export const WEBHOOK_EVENTS = [
+  'track.play',          // a track started playing
+  'dj.say',              // station ID / weather / hourly — heavy-ducked voice
+  'dj.link',             // between-track auto-DJ link — light-ducked voice
+  'request.received',    // a listener submitted a request
+] as const;
+
+export type WebhookEvent = (typeof WEBHOOK_EVENTS)[number];
+
+interface WebhookConfig {
+  id: string;
+  url: string;
+  events: string[];
+  enabled: boolean;
+  authHeader?: string;
+}
+
+const TIMEOUT_MS = 5000;
+
+async function postOne(hook: WebhookConfig, body: string) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'User-Agent': 'sub-wave/webhook',
+    };
+    if (hook.authHeader) headers['Authorization'] = hook.authHeader;
+    const r = await fetch(hook.url, {
+      method: 'POST',
+      headers,
+      body,
+      signal: ctrl.signal,
+    });
+    if (!r.ok) {
+      console.warn(`[webhook] ${hook.url} → ${r.status}`);
+    }
+  } catch (err: any) {
+    console.warn(`[webhook] ${hook.url} failed: ${err.message}`);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Fire an event to every enabled, subscribed hook. Non-blocking.
+export function notify(event: WebhookEvent, payload: Record<string, unknown>) {
+  let hooks: WebhookConfig[] = [];
+  try {
+    hooks = (settings.get()?.webhooks || []) as WebhookConfig[];
+  } catch {
+    return;
+  }
+  if (!hooks.length) return;
+  const targets = hooks.filter(h => h.enabled && h.events.includes(event));
+  if (!targets.length) return;
+  const body = JSON.stringify({
+    event,
+    t: new Date().toISOString(),
+    ...payload,
+  });
+  for (const hook of targets) {
+    postOne(hook, body);  // fire-and-forget
+  }
+}
+
+// Test fire — used by the admin UI's "Test" button. Bypasses the event
+// subscription list so the operator can sanity-check a fresh hook without
+// also flipping the events toggle on first.
+export async function fireTest(hook: WebhookConfig) {
+  await postOne(hook, JSON.stringify({
+    event: 'test',
+    t: new Date().toISOString(),
+    note: 'sub-wave webhook test fire',
+  }));
+}

--- a/controller/src/config.ts
+++ b/controller/src/config.ts
@@ -109,6 +109,12 @@ export const config = {
     // The playback queue (upcoming/current/history) snapshotted to disk so a
     // controller restart doesn't lose tracks already handed to Liquidsoap.
     file: `${STATE_DIR}/queue.json`,
+    // Rolling 24h log of (id, artist, endedAt) for each track that aired.
+    // Read by the picker to block tracks/artists played in the last N hours —
+    // queue.history is capped at 50 (~3h) and only lives in-memory, which is
+    // why we keep a separate, longer-lived store.
+    recentPlaysFile: `${STATE_DIR}/recent-plays.json`,
+    recentPlaysMax: 300,
   },
   weather: {
     // Wolverhampton — your home location

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -352,7 +352,7 @@ export async function generateHourlyTime(time: any, weather: any, { recap = null
 export const PICKER_CRITERIA = `Selection criteria, in order:
 1. FLOW — does it transition naturally from what just played (energy, mood, tempo)?
 2. CONTEXT — does it fit the time of day, weather, and dominant mood?
-3. VARIETY — avoid the same artist back-to-back; rotate energy levels; don't be predictable.
+3. VARIETY — avoid the same artist back-to-back; don't repeat tracks you've already played today; rotate energy. Variety over cleverness — never pick a track because its title literally matches the time of day, the weather, or anything else literal.
 4. INTEREST — prefer something that creates a moment, not the most generic option.`;
 
 const PICKER_SYSTEM = `You are the DJ for SUB/WAVE, a personal internet radio station.

--- a/controller/src/llm/tools.ts
+++ b/controller/src/llm/tools.ts
@@ -26,10 +26,23 @@ function artistKey(s: any) {
   return (s.artist || '').toLowerCase().trim();
 }
 
-// Most songs by any one artist allowed across a whole pick, mirroring
-// music/picker.js's MAX_PER_ARTIST — keeps a deep catalogue artist from
-// flooding the candidate pool just because random/search keeps surfacing them.
-const MAX_PER_ARTIST = 3;
+// Navidrome (and library.songsByMood) return results in deterministic order:
+// `tracksByMood("night")` always returns the same first N of 89 night-tagged
+// songs; `topSongsByArtist("Karan Aujla")` always returns the same top-N by
+// play count. With `cap=8` the agent sees the same handful no matter how many
+// times it asks. Shuffling here turns each call into a fresh sample — the same
+// fix `music/picker.js` already applies at pool-build time.
+function shuffle<T>(arr: T[]): T[] {
+  return [...arr].sort(() => Math.random() - 0.5);
+}
+
+// Most songs by any one artist allowed across a whole pick. The recent-artists
+// window (passed by dj-agent.pickViaAgent) already blocks any artist heard in
+// the last 2h, so this cap only matters when multiple tools (searchLibrary +
+// topSongsByArtist + similarSongs) surface the same artist within one pick.
+// 2 is tighter than the previous 3 to reduce in-pool fixation on deep
+// catalogues — per-tool cap=8 still leaves plenty of candidates overall.
+const MAX_PER_ARTIST = 2;
 
 // Builds a fresh tool set scoped to one pick. `recentIds` (recently-played
 // song ids) and `recentArtists` (lowercased recently-played artist names) are
@@ -38,8 +51,13 @@ const MAX_PER_ARTIST = 3;
 // listener-request path so a request for a recent artist still resolves.
 export function buildPickerTools({
   recentIds = new Set<string>(),
+  recentKeys = new Set<string>(),
   recentArtists = new Set<string>(),
-}: { recentIds?: Set<string>; recentArtists?: Set<string> } = {}) {
+}: {
+  recentIds?: Set<string>;
+  recentKeys?: Set<string>;        // lowercased "title|artist" — backfilled entries lack ids
+  recentArtists?: Set<string>;
+} = {}) {
   const seen = new Map<string, any>(); // id → slim song, accumulated across all tool calls
   const artistCounts = new Map<string, number>(); // artist key → songs already accepted into `seen`
 
@@ -50,10 +68,13 @@ export function buildPickerTools({
   // agent — see picker-latency notes in dj-agent.js. The seen map still
   // accumulates across the whole loop, so the agent's id space grows with
   // each tool call regardless.
+  const trackKey = (s: any) =>
+    `${(s.title || '').toLowerCase().trim()}|${(s.artist || '').toLowerCase().trim()}`;
   const collect = (list: any, cap = 8) => {
     const out: any[] = [];
-    for (const s of (list || []) as any[]) {
+    for (const s of shuffle((list || []) as any[])) {
       if (!s?.id || recentIds.has(s.id) || seen.has(s.id)) continue;
+      if (recentKeys.has(trackKey(s))) continue;   // catches backfilled entries (no id)
       const key = artistKey(s);
       if (key && recentArtists.has(key)) continue;
       if (key) {

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -55,7 +55,7 @@ async function tracksFromAlbums(albums: any[], perAlbum: number, max: number) {
   return out;
 }
 
-async function buildCandidates(mood: string | null | undefined, recentIds: Set<string>, currentTrack: any) {
+async function buildCandidates(mood: string | null | undefined, recentIds: Set<string>, recentArtists: Set<string>, currentTrack: any) {
   await library.load();
   const pool: any[] = [];
   const sources: Record<string, number> = {};
@@ -174,6 +174,11 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     .filter((t: any) => {
       if (!t.id || seen.has(t.id)) return false;
       const artistKey = (t.artist || '').toLowerCase().trim();
+      // Drop tracks by an artist heard in the last 2h, mirroring the agent
+      // picker's recentArtistsSince(2) filter. Without this, the fallback
+      // path (~1 in 4-5 picks on the current model) could cluster the same
+      // artist 4× in 90 min, as observed with Prabh Deep on 2026-05-25.
+      if (artistKey && recentArtists.has(artistKey)) return false;
       if (artistKey) {
         const n = perArtist.get(artistKey) || 0;
         if (n >= MAX_PER_ARTIST) return false;
@@ -210,9 +215,12 @@ function summariseRecent(queue: any) {
 // ---------------------------------------------------------------------------
 
 export async function pickViaPool(queue, ctx) {
-  const recentIds = queue.recentlyPlayedIds(25);
+  // Match the agent picker's window (dj-agent.pickViaAgent) — 12h. Anything
+  // shorter and the fallback could pick a track the agent would have rejected.
+  const recentIds = queue.recentlyPlayedIds(12);
+  const recentArtists = queue.recentArtistsSince(2);
   const currentTrack = queue.current?.track || null;
-  const { candidates, sources } = await buildCandidates(ctx.dominantMood, recentIds, currentTrack);
+  const { candidates, sources } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack);
 
   if (candidates.length === 0) {
     queue.log('picker', 'no candidates available, skipping LLM pick');

--- a/controller/src/routes/archives.ts
+++ b/controller/src/routes/archives.ts
@@ -1,0 +1,32 @@
+// Admin-gated index + download of the hourly broadcast archives that
+// Liquidsoap writes under state/archive/. See broadcast/archives.ts for the
+// on-disk layout.
+import express from 'express';
+import { statSync } from 'node:fs';
+import { requireAdmin } from '../middleware/auth.js';
+import { list, resolveEntry, openStream } from '../broadcast/archives.js';
+
+export const router = express.Router();
+
+router.get('/archives', requireAdmin, async (req, res) => {
+  try {
+    const limit = Math.min(parseInt(String(req.query.limit ?? ''), 10) || 500, 5000);
+    res.json({ archives: await list({ limit }) });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Stream the MP3 to the browser. Forces a download — listeners shouldn't be
+// confused into thinking these are live, and inline playback for hour-long
+// MP3s is awkward in browsers anyway.
+router.get('/archives/file/:date/:hour', requireAdmin, (req, res) => {
+  const rel = `${req.params.date}/${req.params.hour}`;
+  const abs = resolveEntry(rel);
+  if (!abs) return res.status(404).json({ error: 'archive not found' });
+  const st = statSync(abs);
+  res.setHeader('Content-Type', 'audio/mpeg');
+  res.setHeader('Content-Length', String(st.size));
+  res.setHeader('Content-Disposition', `attachment; filename="${rel.replace('/', '_')}"`);
+  openStream(abs).pipe(res);
+});

--- a/controller/src/routes/listeners.ts
+++ b/controller/src/routes/listeners.ts
@@ -1,0 +1,30 @@
+// Admin-gated GET /listeners — recent listener-count time-series, persisted
+// by broadcast/listeners.ts. Feeds the admin sparkline.
+import express from 'express';
+import { requireAdmin } from '../middleware/auth.js';
+import { history, historyBytes, getListenerCount } from '../broadcast/listeners.js';
+
+export const router = express.Router();
+
+router.get('/listeners', requireAdmin, async (req, res) => {
+  try {
+    // sinceMinutes caps at one week — past that the JSONL gets too big to
+    // parse in-memory comfortably, and the sparkline isn't useful at that
+    // resolution anyway.
+    const sinceMinutes = Math.max(
+      5,
+      Math.min(parseInt(String(req.query.sinceMinutes ?? ''), 10) || 1440, 7 * 1440),
+    );
+    const since = new Date(Date.now() - sinceMinutes * 60 * 1000);
+    const samples = await history({ since });
+    const bytes = await historyBytes();
+    res.json({
+      current: getListenerCount(),
+      sinceMinutes,
+      bytes,
+      samples,
+    });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});

--- a/controller/src/routes/request.ts
+++ b/controller/src/routes/request.ts
@@ -154,7 +154,9 @@ async function resolveRequest(entry) {
     if (!refArtist) {
       return failed(`Nothing's playing yet — tell me what you're after instead.`);
     }
-    const recentIds = queue.recentlyPlayedIds(25);
+    // Requests stay near-unfiltered — 2h is enough to skip the song still
+    // ringing in their ears without blocking a re-request from earlier today.
+    const recentIds = queue.recentlyPlayedIds(2);
     const pick = await pickByArtistAndSort({
       artistName: refArtist, sort: null, scope: 'song', recentIds,
     });
@@ -219,7 +221,8 @@ async function resolveRequest(entry) {
     searchTerms: matched.search_terms,
   });
 
-  const recentIds = queue.recentlyPlayedIds(25);
+  // Requests stay near-unfiltered — see /more-like-this comment above.
+  const recentIds = queue.recentlyPlayedIds(2);
   await library.load();
 
   // Helper: pick a fresh random item from a pool, preferring non-recents.

--- a/controller/src/routes/request.ts
+++ b/controller/src/routes/request.ts
@@ -12,6 +12,7 @@ import { queue } from '../broadcast/queue.js';
 import * as djAgent from '../broadcast/dj-agent.js';
 import * as session from '../broadcast/session.js';
 import * as listeners from '../broadcast/listeners.js';
+import * as webhooks from '../broadcast/webhooks.js';
 import {
   checkRateLimit, clientIp,
   REQUESTS_DISABLED, REQUEST_TEXT_MAX, REQUEST_NAME_MAX,
@@ -435,6 +436,7 @@ router.post('/request', async (req, res) => {
   };
   requests.set(id, entry);
   queue.log('request', `${requester}: "${text}" (id ${id.slice(0, 8)})`);
+  webhooks.notify('request.received', { requestedBy: requester, text });
 
   // Hand the listener a receipt and let go of the connection. The booth does
   // the rest; GET /request/:id reports the outcome.

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -42,6 +42,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
       values: {
         jingleRatio: s.jingleRatio,
         crossfadeDuration: s.crossfadeDuration,
+        station: s.station,
         weather: s.weather,
         djPrompt: s.djPrompt,
         personas: s.personas,

--- a/controller/src/routes/webhooks.ts
+++ b/controller/src/routes/webhooks.ts
@@ -1,0 +1,52 @@
+// Admin-gated webhook management. CRUD lives here; the fan-out itself lives
+// in broadcast/webhooks.ts and reads its config from settings on each fire.
+//
+// Event payloads emitted by the fan-out:
+//   track.play       { event, t, title, artist, album?, source, requestedBy? }
+//   dj.say           { event, t, text, kind }      // kind is the original `announce` kind
+//   dj.link          { event, t, text }
+//   request.received { event, t, title?, artist?, requestedBy }
+//
+// All payloads carry `event` (one of the above) and `t` (ISO timestamp).
+import express from 'express';
+import { requireAdmin } from '../middleware/auth.js';
+import * as settings from '../settings.js';
+import { WEBHOOK_EVENTS, fireTest } from '../broadcast/webhooks.js';
+
+export const router = express.Router();
+
+router.get('/webhooks', requireAdmin, async (req, res) => {
+  try {
+    await settings.load();
+    const s = settings.getRedacted();
+    res.json({ events: WEBHOOK_EVENTS, webhooks: s.webhooks || [] });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/webhooks', requireAdmin, async (req, res) => {
+  // The UI sends the whole list back. settings.update() validates the array
+  // strictly and replaces it atomically — same pattern as personas/shows.
+  try {
+    const r = await settings.update({ webhooks: req.body?.webhooks });
+    res.json({ webhooks: settings.getRedacted().webhooks, requiresRestart: r.requiresRestart });
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Send a test payload to a single hook by id. Uses the live, non-redacted
+// settings so the operator's saved authHeader actually goes out — they
+// shouldn't have to retype it just to test the integration.
+router.post('/webhooks/:id/test', requireAdmin, async (req, res) => {
+  try {
+    await settings.load();
+    const hook = (settings.get().webhooks || []).find((h: any) => h.id === req.params.id);
+    if (!hook) return res.status(404).json({ error: 'webhook not found' });
+    await fireTest(hook);
+    res.json({ ok: true });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -24,6 +24,9 @@ import { router as statsRoutes } from './routes/stats.js';
 import { router as djRoutes } from './routes/dj.js';
 import { router as libraryRoutes } from './routes/library.js';
 import { router as onboardingRoutes } from './routes/onboarding.js';
+import { router as archivesRoutes } from './routes/archives.js';
+import { router as listenersRoutes } from './routes/listeners.js';
+import { router as webhooksRoutes } from './routes/webhooks.js';
 import { loadSecretsIntoEnv } from './setup/secrets.js';
 import { loadSetupConfig } from './setup/config.js';
 import { getSetupStatus } from './setup/firstRun.js';
@@ -46,6 +49,9 @@ app.use(statsRoutes);
 app.use(djRoutes);
 app.use(libraryRoutes);
 app.use(onboardingRoutes);
+app.use(archivesRoutes);
+app.use(listenersRoutes);
+app.use(webhooksRoutes);
 
 // (manual skip is not implemented in this build — Liquidsoap controls pacing)
 

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -136,6 +136,17 @@ const SKILL_SLUG_RE = /^[a-z0-9-]{1,40}$/;
 const PERSONA_LIMIT = 12;
 const SHOWS_LIMIT = 64;
 const SKILLS_PER_PERSONA_LIMIT = 20;
+const WEBHOOKS_LIMIT = 16;
+
+// Event names the outbound webhook fan-out can subscribe to. Kept in sync
+// with broadcast/webhooks.ts WEBHOOK_EVENTS — duplicated here so settings.ts
+// has no runtime dependency on the broadcast module.
+const WEBHOOK_EVENTS = [
+  'track.play',
+  'dj.say',
+  'dj.link',
+  'request.received',
+];
 
 // Server-minted opaque id, e.g. mintId('p_') -> 'p_a1b2c3'.
 function mintId(prefix) {
@@ -274,6 +285,10 @@ const DEFAULTS = {
   sfx: {
     enabled: true,
   },
+  // Outbound webhooks. Each entry POSTs station events (see broadcast/
+  // webhooks.ts for the event list) to `url` with a fire-and-forget HTTP
+  // call. Empty by default — operators add hooks via the admin UI.
+  webhooks: [] as any[],
 };
 
 const BOUNDS = {
@@ -529,8 +544,39 @@ export async function load() {
     sfx: {
       enabled: typeof stored.sfx?.enabled === 'boolean' ? stored.sfx.enabled : DEFAULTS.sfx.enabled,
     },
+    webhooks: normalizeWebhooks(stored.webhooks),
   };
   return cache;
+}
+
+// Lenient normalizer — used by load(). Drops invalid entries silently rather
+// than failing the whole boot.
+function normalizeWebhooks(raw: any) {
+  if (!Array.isArray(raw)) return [];
+  const out: any[] = [];
+  const seen = new Set<string>();
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const url = typeof item.url === 'string' ? item.url.trim() : '';
+    if (!/^https?:\/\//.test(url) || url.length > 500) continue;
+    const events = Array.isArray(item.events)
+      ? item.events.filter((e: any) => WEBHOOK_EVENTS.includes(e))
+      : [];
+    if (!events.length) continue;
+    let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('wh_');
+    if (seen.has(id)) id = mintId('wh_');
+    seen.add(id);
+    out.push({
+      id,
+      url,
+      events,
+      enabled: typeof item.enabled === 'boolean' ? item.enabled : true,
+      authHeader:
+        typeof item.authHeader === 'string' ? item.authHeader.slice(0, 500) : '',
+    });
+    if (out.length >= WEBHOOKS_LIMIT) break;
+  }
+  return out;
 }
 
 export function get() {
@@ -548,6 +594,11 @@ export function getRedacted() {
   if (clone.llm) clone.llm.apiKey = s.llm?.apiKey ? 'set' : '';
   if (clone.tts?.cloud) clone.tts.cloud.apiKey = s.tts?.cloud?.apiKey ? 'set' : '';
   if (clone.search) clone.search.apiKey = s.search?.apiKey ? 'set' : '';
+  if (Array.isArray(clone.webhooks)) {
+    for (let i = 0; i < clone.webhooks.length; i++) {
+      clone.webhooks[i].authHeader = s.webhooks?.[i]?.authHeader ? 'set' : '';
+    }
+  }
   return clone;
 }
 
@@ -709,6 +760,57 @@ function validateScheduleStrict(raw, shows) {
     }
   }
   return week;
+}
+
+// Strict validator — used by update(). `existing` is the current list, so
+// the operator can keep a previously-set authHeader by sending the redacted
+// sentinel back unchanged.
+function validateWebhooksStrict(raw: any, existing: any[] = []) {
+  if (!Array.isArray(raw)) throw new Error('webhooks must be an array');
+  if (raw.length > WEBHOOKS_LIMIT) {
+    throw new Error(`webhooks must be at most ${WEBHOOKS_LIMIT} entries`);
+  }
+  const byId = new Map(existing.map((h: any) => [h.id, h]));
+  const seen = new Set<string>();
+  return raw.map((item, i) => {
+    if (!item || typeof item !== 'object') throw new Error(`webhooks[${i}] must be an object`);
+    const url = String(item.url ?? '').trim();
+    if (!/^https?:\/\//.test(url)) {
+      throw new Error(`webhooks[${i}].url must start with http:// or https://`);
+    }
+    if (url.length > 500) throw new Error(`webhooks[${i}].url too long`);
+    if (!Array.isArray(item.events) || item.events.length === 0) {
+      throw new Error(`webhooks[${i}].events must be a non-empty array`);
+    }
+    const events: string[] = [];
+    for (const e of item.events) {
+      if (!WEBHOOK_EVENTS.includes(e)) {
+        throw new Error(
+          `webhooks[${i}].events entries must be one of: ${WEBHOOK_EVENTS.join(', ')}`,
+        );
+      }
+      if (!events.includes(e)) events.push(e);
+    }
+    let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('wh_');
+    if (seen.has(id)) id = mintId('wh_');
+    seen.add(id);
+    // authHeader: sentinel 'set' from getRedacted() means "keep the existing
+    // value" — the UI never re-sends the actual header. Anything else replaces.
+    const prior = byId.get(id);
+    let authHeader = '';
+    if (item.authHeader === 'set' && prior?.authHeader) {
+      authHeader = prior.authHeader;
+    } else if (typeof item.authHeader === 'string') {
+      authHeader = item.authHeader.slice(0, 500);
+    }
+    return {
+      id,
+      url,
+      events,
+      enabled: item.enabled !== false,
+      authHeader,
+    };
+  });
 }
 
 // Validate + persist. Returns { saved, requiresRestart } so the UI can react.
@@ -962,6 +1064,9 @@ export async function update(patch) {
     if (sx.enabled !== undefined) {
       next.sfx.enabled = !!sx.enabled;
     }
+  }
+  if ('webhooks' in patch) {
+    next.webhooks = validateWebhooksStrict(patch.webhooks, next.webhooks || []);
   }
 
   // Post-patch integrity sweep — a personas/shows change in this patch may

--- a/web/app/admin/archives/page.tsx
+++ b/web/app/admin/archives/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import ArchivesPanel from '../../../components/admin/ArchivesPanel';
+
+export const metadata: Metadata = {
+  title: 'Archives',
+};
+
+export default function AdminArchivesPage() {
+  return <ArchivesPanel />;
+}

--- a/web/app/admin/webhooks/page.tsx
+++ b/web/app/admin/webhooks/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import WebhooksPanel from '../../../components/admin/WebhooksPanel';
+
+export const metadata: Metadata = {
+  title: 'Webhooks',
+};
+
+export default function AdminWebhooksPage() {
+  return <WebhooksPanel />;
+}

--- a/web/components/PlayerApp.tsx
+++ b/web/components/PlayerApp.tsx
@@ -190,6 +190,7 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
       <TopBar
         tunedIn={tunedIn}
         context={context}
+        stationName={typeof dj?.station === 'string' ? dj.station : undefined}
         djName={typeof dj?.name === 'string' ? dj.name : undefined}
         activeShow={activeShow}
         listeners={listeners}

--- a/web/components/TopBar.tsx
+++ b/web/components/TopBar.tsx
@@ -9,6 +9,7 @@ import type { ActiveShow, ListenerCount, StationContext, ThemeMode } from '@/lib
 export interface TopBarProps {
   tunedIn: boolean;
   context: StationContext | null;
+  stationName?: string;
   djName?: string;
   activeShow: ActiveShow | null;
   listeners: ListenerCount | number | null;
@@ -23,6 +24,7 @@ function isListenerObject(l: ListenerCount | number | null): l is ListenerCount 
 export default function TopBar({
   tunedIn,
   context,
+  stationName,
   djName,
   activeShow,
   listeners,
@@ -53,7 +55,7 @@ export default function TopBar({
           data-spinning={tunedIn ? 'true' : undefined}
           aria-hidden="true"
         />
-        <span className="v3-eyebrow shrink-0">SUB/WAVE</span>
+        <span className="v3-eyebrow shrink-0">{stationName?.trim() || 'SUB/WAVE'}</span>
         {showName && (
           <span className="v3-caption min-w-0 truncate text-ink" title={showName}>
             ▸ {showName}

--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -15,6 +15,8 @@ import {
   Sparkles,
   SlidersHorizontal,
   Terminal,
+  Archive,
+  Webhook,
 } from 'lucide-react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import type { SignInResult } from '../../lib/adminAuth';
@@ -57,6 +59,8 @@ const NAV_SECTIONS: NavSection[] = [
     label: 'System',
     items: [
       { href: '/admin/stats', id: 'stats', label: 'Stats', icon: BarChart3 },
+      { href: '/admin/archives', id: 'archives', label: 'Archives', icon: Archive },
+      { href: '/admin/webhooks', id: 'webhooks', label: 'Webhooks', icon: Webhook },
       { href: '/admin/settings', id: 'settings', label: 'Settings', icon: SlidersHorizontal },
       { href: '/admin/debug', id: 'debug', label: 'Debug', icon: Terminal },
     ],

--- a/web/components/admin/ArchivesPanel.tsx
+++ b/web/components/admin/ArchivesPanel.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+// Archives — /admin/archives. The hourly broadcast recordings Liquidsoap
+// writes under state/archive/. Read-only: download or delete via the file
+// system, no playback controls here (these MP3s are an hour long each and
+// the browser audio element doesn't seek well into them).
+
+import { useEffect, useMemo, useState } from 'react';
+import { useAdminAuth } from '../../lib/adminAuth';
+import { fmtSize, relTime } from '../../lib/format';
+import { Card, Btn, Eyebrow, Pill } from './ui';
+
+interface ArchiveEntry {
+  path: string;
+  date: string;
+  hour: number;
+  bytes: number;
+  mtime: string;
+}
+
+interface ArchivesResponse {
+  archives?: ArchiveEntry[];
+}
+
+function hourLabel(h: number): string {
+  return `${String(h).padStart(2, '0')}:00`;
+}
+
+export default function ArchivesPanel() {
+  const { adminFetch, auth, needsAuth, hydrated } = useAdminAuth();
+  const [entries, setEntries] = useState<ArchiveEntry[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!hydrated || needsAuth) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await adminFetch('/archives');
+        if (!r.ok) throw new Error(`failed (${r.status})`);
+        const j = (await r.json()) as ArchivesResponse;
+        if (cancelled) return;
+        setEntries(Array.isArray(j.archives) ? j.archives : []);
+        setErr(null);
+      } catch (e) {
+        if (cancelled) return;
+        setErr(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [hydrated, needsAuth, adminFetch]);
+
+  // Group by date — the operator's mental model is "let me grab yesterday's
+  // 9am hour", not "give me a flat list of 720 mp3s sorted by mtime".
+  const byDate = useMemo(() => {
+    if (!entries) return [] as { date: string; items: ArchiveEntry[]; bytes: number }[];
+    const m = new Map<string, ArchiveEntry[]>();
+    for (const e of entries) {
+      const arr = m.get(e.date) || [];
+      arr.push(e);
+      m.set(e.date, arr);
+    }
+    return [...m.entries()]
+      .sort((a, b) => (a[0] > b[0] ? -1 : 1))
+      .map(([date, items]) => ({
+        date,
+        items: items.sort((a, b) => b.hour - a.hour),
+        bytes: items.reduce((a, b) => a + b.bytes, 0),
+      }));
+  }, [entries]);
+
+  if (err) {
+    return (
+      <div className="grid gap-4">
+        <Card title="Archives"><div className="text-[13px] text-[var(--danger)]">controller error: {err}</div></Card>
+      </div>
+    );
+  }
+  if (!entries) {
+    return (
+      <div className="grid gap-4">
+        <Card title="Archives"><div className="text-[13px] text-muted italic">loading…</div></Card>
+      </div>
+    );
+  }
+
+  const totalBytes = entries.reduce((a, b) => a + b.bytes, 0);
+
+  // Download links carry HTTP Basic auth in the URL so the <a> can stream
+  // directly through Caddy without us pulling the whole file into memory.
+  const downloadHref = (path: string) => {
+    const base = process.env.NEXT_PUBLIC_API_URL || '/api';
+    // auth is base64(user:pass); split it back to inject as userinfo for
+    // same-origin URLs the browser will send a normal Authorization header
+    // for via fetch — but for a plain anchor download we need the credentials
+    // pre-baked. Use the credentials via a fetch-then-blob fallback if base
+    // is same-origin; for an external API URL include userinfo.
+    if (!base.startsWith('http')) return `${base}/archives/file/${path}`;
+    try {
+      const u = new URL(`${base}/archives/file/${path}`);
+      if (auth) {
+        const dec = typeof window !== 'undefined' ? window.atob(auth) : '';
+        const [user, pass] = dec.split(':');
+        if (user) u.username = encodeURIComponent(user);
+        if (pass) u.password = encodeURIComponent(pass);
+      }
+      return u.toString();
+    } catch {
+      return `${base}/archives/file/${path}`;
+    }
+  };
+
+  return (
+    <div className="grid gap-4">
+      <section className="card">
+        <div className="border-b border-ink p-4">
+          <Eyebrow className="text-vermilion">archives</Eyebrow>
+          <div className="mt-1.5 text-[22px] font-extrabold tracking-[-0.02em]">
+            What went out, hour by hour.
+          </div>
+          <div className="mt-1 text-[11px] leading-[1.6] text-muted">
+            Liquidsoap writes one MP3 per clock hour into <code>state/archive/</code>.
+            They&rsquo;re kept until the operator deletes them — there is no automatic rotation,
+            so keep an eye on disk if the station runs 24/7.
+          </div>
+        </div>
+        <div className="flex items-center gap-4 bg-[var(--ink-softer)] p-3.5">
+          <span className="caption">{entries.length} hour{entries.length === 1 ? '' : 's'}</span>
+          <span className="caption text-vermilion">{fmtSize(totalBytes)} total</span>
+        </div>
+      </section>
+
+      {byDate.length === 0 && (
+        <Card title="No recordings yet">
+          <div className="text-[12px] leading-[1.6] text-muted">
+            The first hour writes once the clock crosses the next <code>HH:00</code>. If you started the
+            station mid-hour, you&rsquo;ll see the first file after the next top of the hour.
+          </div>
+        </Card>
+      )}
+
+      {byDate.map(group => (
+        <Card
+          key={group.date}
+          title={group.date}
+          right={<Pill>{group.items.length} h · {fmtSize(group.bytes)}</Pill>}
+        >
+          <ul className="divide-y divide-[var(--ink-soft)]">
+            {group.items.map(e => (
+              <li key={e.path} className="flex items-center justify-between py-2">
+                <div className="flex items-center gap-3">
+                  <span className="mono-num text-[13px] font-bold">{hourLabel(e.hour)}</span>
+                  <span className="text-[11px] text-muted">{fmtSize(e.bytes)}</span>
+                  <span className="text-[10px] text-muted">{relTime(e.mtime)} ago</span>
+                </div>
+                <a href={downloadHref(e.path)} download>
+                  <Btn sm tone="accent">Download</Btn>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/web/components/admin/WebhooksPanel.tsx
+++ b/web/components/admin/WebhooksPanel.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+// Webhooks — /admin/webhooks. Outbound HTTP POSTs to operator-configured
+// endpoints on station events. See controller/src/broadcast/webhooks.ts
+// for the fan-out + the documented payload shapes.
+
+import { useEffect, useState } from 'react';
+import { useAdminAuth } from '../../lib/adminAuth';
+import { notify, errorMessage } from '../../lib/notify';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+import { Card, Btn, Pill, Eyebrow, Toggle } from './ui';
+
+interface Webhook {
+  id: string;
+  url: string;
+  events: string[];
+  enabled: boolean;
+  authHeader: string;       // 'set' sentinel from the server when a value is stored.
+}
+
+interface WebhooksResponse {
+  events: string[];
+  webhooks: Webhook[];
+}
+
+function clientMintId() {
+  const b = crypto.getRandomValues(new Uint8Array(3));
+  return 'wh_' + [...b].map(x => x.toString(16).padStart(2, '0')).join('');
+}
+
+function blank(events: string[]): Webhook {
+  return {
+    id: clientMintId(),
+    url: '',
+    events: events.slice(0, 1),
+    enabled: true,
+    authHeader: '',
+  };
+}
+
+function valid(h: Webhook): boolean {
+  if (!/^https?:\/\//.test(h.url.trim())) return false;
+  if (h.url.trim().length > 500) return false;
+  if (!h.events.length) return false;
+  return true;
+}
+
+export default function WebhooksPanel() {
+  const { adminFetch, needsAuth, hydrated } = useAdminAuth();
+  const [events, setEvents] = useState<string[] | null>(null);
+  const [hooks, setHooks] = useState<Webhook[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!hydrated || needsAuth) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await adminFetch('/webhooks');
+        if (!r.ok) throw new Error(`failed (${r.status})`);
+        const j = (await r.json()) as WebhooksResponse;
+        if (cancelled) return;
+        setEvents(j.events);
+        setHooks(j.webhooks || []);
+      } catch (e) {
+        if (cancelled) return;
+        setErr(errorMessage(e));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [hydrated, needsAuth, adminFetch]);
+
+  const save = async (next: Webhook[]) => {
+    setBusy(true);
+    try {
+      const r = await adminFetch('/webhooks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ webhooks: next }),
+      });
+      const j = (await r.json().catch(() => ({}))) as { webhooks?: Webhook[]; error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      setHooks(j.webhooks || []);
+      notify.ok('Webhooks saved.');
+    } catch (e) {
+      notify.err(`Save failed: ${errorMessage(e)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const fireTest = async (id: string) => {
+    try {
+      const r = await adminFetch(`/webhooks/${id}/test`, { method: 'POST' });
+      if (!r.ok) throw new Error(`failed (${r.status})`);
+      notify.ok('Test payload sent.');
+    } catch (e) {
+      notify.err(`Test failed: ${errorMessage(e)}`);
+    }
+  };
+
+  if (err) {
+    return (
+      <div className="grid gap-4">
+        <Card title="Webhooks"><div className="text-[13px] text-[var(--danger)]">controller error: {err}</div></Card>
+      </div>
+    );
+  }
+  if (!hooks || !events) {
+    return (
+      <div className="grid gap-4">
+        <Card title="Webhooks"><div className="text-[13px] text-muted italic">loading…</div></Card>
+      </div>
+    );
+  }
+
+  const allValid = hooks.every(valid);
+
+  return (
+    <div className="grid gap-4">
+      <section className="card">
+        <div className="border-b border-ink p-4">
+          <Eyebrow className="text-vermilion">webhooks</Eyebrow>
+          <div className="mt-1.5 text-[22px] font-extrabold tracking-[-0.02em]">
+            Pipe station events into other systems.
+          </div>
+          <div className="mt-1 text-[11px] leading-[1.6] text-muted">
+            Each row POSTs a JSON event to <code>url</code> the moment it happens — no retry queue, no buffer.
+            Best paired with a relay like a Cloudflare Worker or n8n. See
+            <code> controller/src/routes/webhooks.ts </code> for the payload shapes.
+          </div>
+        </div>
+        <div className="flex items-center gap-3 bg-[var(--ink-softer)] p-3.5">
+          <span className="caption">{hooks.length} hook{hooks.length === 1 ? '' : 's'}</span>
+          <span className="caption text-vermilion">
+            {hooks.filter(h => h.enabled).length} enabled
+          </span>
+          <span className="ml-auto" />
+          <Btn
+            sm
+            onClick={() => setHooks([...hooks, blank(events)])}
+            disabled={hooks.length >= 16}
+          >Add</Btn>
+          <Btn
+            sm
+            tone="accent"
+            onClick={() => save(hooks)}
+            disabled={!allValid || busy}
+          >{busy ? 'Saving…' : 'Save'}</Btn>
+        </div>
+      </section>
+
+      {hooks.length === 0 && (
+        <Card title="No webhooks yet">
+          <div className="text-[12px] leading-[1.6] text-muted">
+            Click <strong>Add</strong> above to wire your first one. Common targets: Discord webhooks (chat),
+            n8n / Pipedream (relay + retry), Home Assistant (lights pulse on a track change).
+          </div>
+        </Card>
+      )}
+
+      {hooks.map((h, i) => {
+        const update = (patch: Partial<Webhook>) => {
+          const next = [...hooks];
+          next[i] = { ...h, ...patch };
+          setHooks(next);
+        };
+        const remove = () => setHooks(hooks.filter((_, j) => j !== i));
+        const toggleEvent = (ev: string) => {
+          const has = h.events.includes(ev);
+          update({ events: has ? h.events.filter(e => e !== ev) : [...h.events, ev] });
+        };
+        return (
+          <Card
+            key={h.id}
+            title={h.url || <span className="text-muted italic">(new webhook)</span>}
+            right={
+              <>
+                <Pill tone={h.enabled ? 'accent' : 'default'} dot={h.enabled}>
+                  {h.enabled ? 'enabled' : 'disabled'}
+                </Pill>
+                <Toggle on={h.enabled} onClick={() => update({ enabled: !h.enabled })} />
+              </>
+            }
+          >
+            <div className="grid gap-3">
+              <div>
+                <Label className="caption">URL</Label>
+                <Input
+                  value={h.url}
+                  onChange={e => update({ url: e.target.value })}
+                  placeholder="https://discord.com/api/webhooks/…"
+                  spellCheck={false}
+                />
+              </div>
+              <div>
+                <Label className="caption">Authorization header (optional)</Label>
+                <Input
+                  value={h.authHeader === 'set' ? '' : h.authHeader}
+                  placeholder={h.authHeader === 'set' ? '(stored — leave blank to keep)' : 'Bearer …'}
+                  onChange={e => update({ authHeader: e.target.value })}
+                  spellCheck={false}
+                />
+                <div className="mt-1 text-[10px] text-muted">
+                  Sent verbatim as the <code>Authorization</code> header. Stored at rest in <code>settings.json</code>.
+                </div>
+              </div>
+              <div>
+                <Label className="caption">Events</Label>
+                <div className="mt-1 flex flex-wrap gap-2">
+                  {events.map(ev => {
+                    const on = h.events.includes(ev);
+                    return (
+                      <Pill
+                        key={ev}
+                        tone={on ? 'accent' : 'default'}
+                        dot={on}
+                        onClick={() => toggleEvent(ev)}
+                        className="cursor-pointer"
+                      >
+                        {ev}
+                      </Pill>
+                    );
+                  })}
+                </div>
+              </div>
+              <div className="mt-1 flex items-center gap-2">
+                <Btn sm tone="accent" onClick={() => fireTest(h.id)} disabled={!h.url}>
+                  Send test
+                </Btn>
+                <span className="ml-auto" />
+                <Btn sm tone="danger" onClick={remove}>Remove</Btn>
+              </div>
+            </div>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/components/landing/Navidrome.tsx
+++ b/web/components/landing/Navidrome.tsx
@@ -23,16 +23,16 @@ export default function Navidrome() {
           <p className="text-muted">
             SUB/WAVE is the DJ, the mixer, and the broadcast layer. The music
             comes from <strong className="text-ink">your</strong>{' '}
-            Navidrome — the self-hosted music server with a Subsonic API. Run
+            Navidrome, the self-hosted music server with a Subsonic API. Run
             Navidrome on your homelab, point SUB/WAVE at it, and the DJ
             picks from your collection. Nobody else's algorithm. Nobody else's catalogue.
           </p>
 
           <ul className="bs-navidrome-bullets">
-            <li><strong>Your taste, not a recommendation engine.</strong> The picker reads the metadata you tagged — genres, moods, your own folders — and chooses from there.</li>
+            <li><strong>Your taste, not a recommendation engine.</strong> The picker reads the metadata you tagged (genres, moods, your own folders) and chooses from there.</li>
             <li><strong>No licensing fees.</strong> You already own (or, you know, have on disk) the music. SUB/WAVE doesn't add a streaming bill on top.</li>
             <li><strong>Private by default.</strong> Listeners hit one MP3 stream. Nobody outside your stack ever sees your library, your tags, or who requested what.</li>
-            <li><strong>BYO Subsonic-compatible server.</strong> Subsonic, Airsonic, Gonic, Funkwhale — if it speaks the Subsonic API, it works.</li>
+            <li><strong>BYO Subsonic-compatible server.</strong> Subsonic, Airsonic, Gonic, Funkwhale. If it speaks the Subsonic API, it works.</li>
           </ul>
 
           <div className="bs-navidrome-cta">

--- a/web/components/what/BehindTheDesk.tsx
+++ b/web/components/what/BehindTheDesk.tsx
@@ -6,31 +6,31 @@ const PANELS = [
     eyebrow: 'DASH',
     title: 'The command center.',
     body:
-      'Live status — who is on air, the mood, listener count, weather. See the queue, read the booth log, skip a track, fire a station ID, or send your own words to air as raw or styled voice.',
+      'Live status: who is on air, the mood, listener count, weather. See the queue, read the booth log, skip a track, fire a station ID, or send your own words to air as raw or styled voice.',
   },
   {
     eyebrow: 'PERSONAS',
     title: 'The voices on the station.',
     body:
-      'Up to twelve DJ identities — name, soul, tagline, talk frequency, voice, and which skills each one may use. One persona is on air at a time; a show can hand it the hour.',
+      'Up to twelve DJ identities: name, soul, tagline, talk frequency, voice, and which skills each one may use. One persona is on air at a time; a show can hand it the hour.',
   },
   {
     eyebrow: 'SKILLS',
     title: 'What the DJ does between tracks.',
     body:
-      'Each skill is an autonomous segment — a weather check, a news headline, an absurd traffic update, an oddly-specific fact. Toggle each one on, assign it to a persona, or run any one now as an operator override.',
+      'Each skill is an autonomous segment: a weather check, a news headline, an absurd traffic update, an oddly-specific fact. Toggle each one on, assign it to a persona, or run any one now as an operator override.',
     fig: {
       src: '/screenshots/admin-skills.webp',
       label: 'Admin — Skills',
       caption:
-        'Skills: the autonomous segments the DJ runs between tracks — toggle each, run any one now.',
+        'Skills: the autonomous segments the DJ runs between tracks. Toggle each, run any one now.',
     },
   },
   {
     eyebrow: 'SHOWS',
     title: 'A weekly schedule you paint.',
     body:
-      'A 24×7 grid you brush shows onto. Each show carries a persona, a music mood, and a topic brief — genres, eras, the host’s tone. Autonomous hours fill whatever you leave blank.',
+      'A 24×7 grid you brush shows onto. Each show carries a persona, a music mood, and a topic brief: genres, eras, the host’s tone. Autonomous hours fill whatever you leave blank.',
     fig: {
       src: '/screenshots/admin-shows.webp',
       label: 'Admin — Weekly Schedule',
@@ -48,7 +48,7 @@ const PANELS = [
     eyebrow: 'DEBUG & STATS',
     title: 'Health and diagnostics.',
     body:
-      'Debug and Stats show health, Liquidsoap logs, LLM call history, and usage at a glance. Settings — TTS, LLM, mixer, jingles — and a danger zone that starts, stops, and restarts the broadcast.',
+      'Debug and Stats show health, Liquidsoap logs, LLM call history, and usage at a glance. Settings (TTS, LLM, mixer, jingles) and a danger zone that starts, stops, and restarts the broadcast.',
   },
 ];
 
@@ -58,7 +58,7 @@ export default function BehindTheDesk() {
       <p className="bs-eyebrow">PART FOUR · THE CONSOLE</p>
       <h2>Behind the desk.</h2>
       <p className="text-muted">
-        Everything a listener hears is shaped from one place — a gated admin
+        Everything a listener hears is shaped from one place: a gated admin
         console with eight panels. This is where the operator actually runs the
         station.
       </p>
@@ -105,7 +105,7 @@ export default function BehindTheDesk() {
           src="/screenshots/admin-debug.webp"
           alt="Admin — Debug"
           label="Admin — Debug"
-          caption="Debug: a health strip, Liquidsoap logs, and recent LLM calls — refreshed live."
+          caption="Debug: a health strip, Liquidsoap logs, and recent LLM calls, refreshed live."
         />
       </div>
     </EditorialReveal>

--- a/web/components/what/Coda.tsx
+++ b/web/components/what/Coda.tsx
@@ -7,8 +7,8 @@ export default function Coda() {
       <p className="bs-eyebrow self-center">END OF FEATURE</p>
       <h2 className="max-w-[20ch]">The station is on air right now.</h2>
       <p className="text-center text-muted">
-        There is nothing to scroll and nothing to pick. Tune in and hear what
-        the DJ is playing — or stand up your own frequency from the source.
+        Nothing to scroll, nothing to pick. Tune in and hear what
+        the DJ is playing, or stand up your own frequency from the source.
       </p>
 
       <div className="mt-2 flex flex-wrap items-center justify-center gap-4">

--- a/web/components/what/MakeARequest.tsx
+++ b/web/components/what/MakeARequest.tsx
@@ -6,7 +6,7 @@ const STEPS = [
     n: '01',
     title: 'Ask in plain language.',
     body:
-      'Open the request drawer and type what you want — a song title, an artist, a vibe. No exact spelling, no library browsing. Add your name if you want the DJ to use it on air.',
+      'Open the request drawer and type what you want: a song title, an artist, a vibe. No exact spelling, no library browsing. Add your name if you want the DJ to use it on air.',
   },
   {
     n: '02',
@@ -18,13 +18,13 @@ const STEPS = [
     n: '03',
     title: 'The DJ finds the match.',
     body:
-      'An LLM reads your request, searches the library, and picks the closest real track. Suggestion chips — built from the current artist, the time of day, the weather — give you a head start if you are undecided.',
+      'An LLM reads your request, searches the library, and picks the closest real track. Suggestion chips (built from the current artist, the time of day, the weather) give you a head start if you are undecided.',
   },
   {
     n: '04',
     title: 'It airs, with an intro.',
     body:
-      'When the match lands, the drawer shows the track and the DJ’s spoken intro. Your request joins the one queue everyone is hearing — and the DJ may say your name as it goes out.',
+      'When the match lands, the drawer shows the track and the DJ’s spoken intro. Your request joins the one queue everyone is hearing, and the DJ may say your name as it goes out.',
   },
 ];
 
@@ -34,7 +34,7 @@ export default function MakeARequest() {
       <p className="bs-eyebrow">PART THREE · REQUESTS</p>
       <h2>Phone the station, like you used to.</h2>
       <p className="text-muted">
-        Requests are the one place a listener steers the broadcast — and it
+        Requests are the one place a listener steers the broadcast. And it
         works the way calling a radio station always should have.
       </p>
 

--- a/web/components/what/MeetTheVoices.tsx
+++ b/web/components/what/MeetTheVoices.tsx
@@ -5,7 +5,7 @@ const HABITS = [
   {
     label: 'PICKS THE NEXT TRACK',
     body:
-      'The DJ reads the time, the weather, the season, festivals on the calendar, what just played, and any listener requests — then asks an LLM what should come next and pulls a real song from the library.',
+      'The DJ reads the time, the weather, the season, festivals on the calendar, what just played, and any listener requests, then asks an LLM what should come next and pulls a real song from the library.',
   },
   {
     label: 'TALKS BETWEEN SONGS',
@@ -15,7 +15,7 @@ const HABITS = [
   {
     label: 'CHANGES WITH THE HOUR',
     body:
-      'A scheduled show can hand the hour to a different persona — each with its own name, personality, voice, and how often it speaks. The 3am host is not the 8am host.',
+      'A scheduled show can hand the hour to a different persona, each with its own name, personality, voice, and how often it speaks. The 3am host is not the 8am host.',
   },
 ];
 
@@ -25,8 +25,8 @@ export default function MeetTheVoices() {
       <p className="bs-eyebrow">PART TWO · THE DJ</p>
       <h2>An LLM with a library and a microphone.</h2>
       <p className="text-muted">
-        The voice between the tracks is not air talent. It is a persona — a name,
-        a soul, a voice engine, and a talk frequency — driven by a language model.
+        The voice between the tracks is not air talent. It is a persona (a name,
+        a soul, a voice engine, a talk frequency) driven by a language model.
       </p>
 
       <Figure
@@ -48,7 +48,7 @@ export default function MeetTheVoices() {
       </div>
 
       <p className="mt-2 max-w-[64ch] text-[14px] leading-[1.6] text-muted">
-        The model behind it is the operator’s choice — a local Ollama box, or a
+        The model behind it is the operator’s choice: a local Ollama box, or a
         hosted provider like Anthropic, OpenAI, or Google. The voice is just as
         swappable: local engines Piper, Kokoro, and Chatterbox run on-device, or
         a cloud voice from OpenAI or ElevenLabs. Change either one in the console

--- a/web/components/what/OnTheAir.tsx
+++ b/web/components/what/OnTheAir.tsx
@@ -6,25 +6,25 @@ const POINTS = [
     eyebrow: 'NOW PLAYING',
     title: 'The track, the artist, the booth.',
     body:
-      'The player opens on whatever is on air — cover art pulled straight from your library, title, artist, album, and elapsed time. A waveform tracks the audio underneath. It is not your queue. It is the station’s.',
+      'The player opens on whatever is on air: cover art pulled straight from your library, title, artist, album, and elapsed time. A waveform tracks the audio underneath. It is not your queue. It is the station’s.',
   },
   {
     eyebrow: 'TIMELINE & BOOTH',
     title: 'See what is coming, hear what was said.',
     body:
-      'Two drawers slide out from the side. The Timeline shows tracks queued and recently played; the Booth is a live log of every word the DJ has spoken — station IDs, time checks, weather, the links between songs.',
+      'Two drawers slide out from the side. The Timeline shows tracks queued and recently played; the Booth is a live log of every word the DJ has spoken: station IDs, time checks, weather, the links between songs.',
   },
   {
     eyebrow: 'NO SKIP, ON PURPOSE',
     title: 'A shared broadcast, not a remote control.',
     body:
-      'There is no skip control for listeners — a stray double-tap on someone’s headphones should not change the song for everyone else. Track-end is the only natural transition. It is radio, so it behaves like radio.',
+      'There is no skip control for listeners. A stray double-tap on someone’s headphones should not change the song for everyone else. Track-end is the only natural transition. Radio behaves like radio.',
   },
   {
     eyebrow: 'INSTALL IT',
     title: 'A real app on the lock screen.',
     body:
-      'SUB/WAVE installs as a PWA — a home-screen icon, full-screen, offline-aware. The OS media controls wire straight through, so the lock screen, your headphones, and the car display all show the station and pause it cleanly.',
+      'SUB/WAVE installs as a PWA: a home-screen icon, full-screen, offline-aware. The OS media controls wire straight through, so the lock screen, your headphones, and the car display all show the station and pause it cleanly.',
   },
 ];
 

--- a/web/components/what/UnderTheHood.tsx
+++ b/web/components/what/UnderTheHood.tsx
@@ -15,14 +15,14 @@ export default function UnderTheHood() {
       <h2>Four processes, one box, one stream out.</h2>
 
       <div className="bs-drop-cap max-w-[64ch] text-[15px] leading-[1.6]">
-        SUB/WAVE is not a cloud service. The whole stack — Icecast, Liquidsoap,
-        the Controller, the LLM, the voice engines, and a Caddy edge — runs on a
+        SUB/WAVE is not a cloud service. The whole stack (Icecast, Liquidsoap,
+        the Controller, the LLM, the voice engines, and a Caddy edge) runs on a
         single machine in someone’s home, behind Cloudflare. The Controller is a
         small Node.js process that decides what plays and what gets said.
         Liquidsoap mixes the music, crossfades the tracks, ducks the DJ’s voice
         over the bed, and rotates the jingles. Icecast pushes the one stream out
-        to every browser. The pieces talk through plain files in a shared folder
-        — no socket, no message queue, the Unix way.
+        to every browser. The pieces talk through plain files in a shared folder.
+        No socket, no message queue, the Unix way.
       </div>
 
       <div className="bs-flow">
@@ -44,7 +44,7 @@ export default function UnderTheHood() {
 
       <p className="mt-6 max-w-[64ch] text-[14px] leading-[1.6] text-muted">
         No subscriptions, no round-trip to a data center, no algorithm tuned to
-        keep you scrolling. The whole source is open — so you can run your own
+        keep you scrolling. The whole source is open, so you can run your own
         with a different DJ persona, a different library, and a different city
         on the dateline.
       </p>
@@ -60,11 +60,11 @@ export default function UnderTheHood() {
         <p className="m-0 text-[16px] leading-[1.6]">
           Streaming apps gave everyone their own private channel. A playlist tuned
           to you, shuffled for you, paused the second you look away. SUB/WAVE goes
-          the other direction entirely. It is one Icecast stream — a single
-          broadcast every listener hears at the same moment — picked, announced,
+          the other direction entirely. It is one Icecast stream, a single
+          broadcast every listener hears at the same moment, picked, announced,
           and mixed by software running on a single box in someone&apos;s home.
-          There is no skip button. There is no &ldquo;for you.&rdquo; You tune in,
-          and you hear whatever is on the air right now, the same as everyone else.
+          No skip button. No &ldquo;for you.&rdquo; You tune in, and you hear
+          whatever is on the air right now, the same as everyone else.
         </p>
       </div>
     </EditorialReveal>


### PR DESCRIPTION
## Summary

Ships a meaningful admin surface expansion (archives index, listener history, outbound webhooks) plus a controller fix that stops the picker from clustering tracks deterministically, a small bug where the player header/admin form ignored the configured station name, and a copy pass on the landing page. Full-stack release — controller + web both touched. No env/migration changes; no breaking changes.

**Features**
- `af3ddda` feat(admin): archives index, listener history, outbound webhooks (#114)
  - Three new admin panels backed by new controller modules (`broadcast/archives.ts`, `broadcast/listeners.ts`, `broadcast/webhooks.ts`) and routes (`/archives`, `/listeners`, `/webhooks`). Settings now persist webhook subscriptions; queue/scheduler emit the events.

**Bug Fixes**
- `070bc3d` fix(controller/picker): stop deterministic track/artist clustering (#115)
- `6f13d4a` fix(web,controller): show configured station name in admin form and player header (#117)

**Other**
- `eeb6f19` chore(web/landing): humanize prose, drop AI-style em dashes (#116)

## Test plan
- [ ] `/admin/archives` lists recent hourly MP3s with playable links
- [ ] `/admin/webhooks` lets you add/remove a subscription and the controller fires it on `track.started`
- [ ] Player header and admin settings form both show the configured station name (not a hardcoded fallback)
- [ ] Two consecutive auto-DJ picks aren't from the same artist/collaborator cluster across a normal listening window
- [ ] Landing page reads naturally — no leftover AI-tell em dashes in the prose sections