### PR TITLE
fix(tagger): load wizard config in tag-library CLI

### DIFF
--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -12,14 +12,41 @@
 import * as subsonic from './subsonic.js';
 import * as library from './library.js';
 import * as settings from '../settings.js';
+import { config } from '../config.js';
+import { loadSecretsIntoEnv } from '../setup/secrets.js';
+import { loadSetupConfig } from '../setup/config.js';
 import { activeModelLabel } from '../llm/provider.js';
 import { tagOne } from './tagger-core.js';
+
+// Mirrors server.ts boot: cloud API keys from secrets.env, Navidrome creds
+// from setup-config.json. Standalone CLIs skip server.ts, so without this
+// they fall back to the hardcoded `http://navidrome:4533` and ENOTFOUND on
+// any install with a custom Navidrome host (issue #122).
+async function applyWizardOverlay() {
+  try {
+    await loadSecretsIntoEnv();
+  } catch (err: any) {
+    console.error('[secrets] load failed:', err.message);
+  }
+  try {
+    const sc = await loadSetupConfig();
+    if (sc.navidrome) {
+      if (!process.env.NAVIDROME_URL && sc.navidrome.url) config.navidrome.url = sc.navidrome.url;
+      if (!process.env.NAVIDROME_USER && sc.navidrome.user) config.navidrome.user = sc.navidrome.user;
+      if (!process.env.NAVIDROME_PASS && sc.navidrome.pass)
+        config.navidrome.password = sc.navidrome.pass;
+    }
+  } catch (err: any) {
+    console.error('[setup-config] load failed:', err.message);
+  }
+}
 
 async function main() {
   const args = process.argv.slice(2);
   const limitIdx = args.indexOf('--limit');
   const limit = limitIdx >= 0 ? parseInt(args[limitIdx + 1], 10) : Infinity;
 
+  await applyWizardOverlay();
   await library.load();
   await settings.load();
   console.log(`[tag] starting. ${library.allTaggedIds().length} tracks already tagged.`);


### PR DESCRIPTION
## Summary
- Bulk tagging (`scripts/tag-library.sh` → `node src/music/tag-library.js`) was failing with `getaddrinfo ENOTFOUND navidrome` on every install that doesn't use the literal `navidrome` hostname.
- Root cause: the standalone CLI bypasses `server.ts`, so it never sourced `state/secrets.env` or applied the `state/setup-config.json` overlay. `config.navidrome.url` stayed at its default `http://navidrome:4533`, and the LLM key from the wizard never reached `process.env` either.
- Fix: mirror the same boot overlay locally in `tag-library.ts` before iterating the library.

Fixes #122

## Verified

Reproduced the bug and tested the fix end-to-end inside the dev stack running from this branch.

| Phase | Result |
|---|---|
| Fresh worktree, **no** `state/setup-config.json` | `ENOTFOUND navidrome` — overlay correctly does nothing, default URL kicks in (matches issue #122 environment where wizard config was missing/ignored) |
| After dropping a real `state/setup-config.json` in | Subsonic calls succeed against the wizard-configured host; `iterateAllSongs` streams real song IDs from the library |
| `grep -E 'navidrome\|ENOTFOUND\|getaddrinfo'` on stderr | Zero hits |

Remaining `[tag] FAIL … fetch failed` entries in the dev test were the LLM call (default `http://localhost:11434` from inside the container with no Ollama reachable in the scaffolded dev state) — separate from #122 and unrelated to this change.

## Test plan
- [x] Run `docker exec sub-wave-controller npm run tag -- --limit N` against a host with custom `NAVIDROME_URL` set only via the wizard (not env). Confirm it reaches Navidrome.
- [x] Run with `NAVIDROME_URL` exported in the env and confirm env still wins (overlay only fills blanks).
- [ ] Verify a cloud-LLM tag run (e.g. `openrouter:*`) works without `OPENROUTER_API_KEY` in the root `.env` — it should be picked up from `state/secrets.env`.