### PR TITLE
feat: scrobble to Last.fm and ListenBrainz (#121)

### DIFF
--- a/controller/package.json
+++ b/controller/package.json
@@ -7,6 +7,7 @@
     "start": "tsx src/server.ts",
     "dev": "tsx watch src/server.ts",
     "tag": "tsx src/music/tag-library.ts",
+    "lastfm-session": "tsx scripts/lastfm-session.ts",
     "lint": "eslint . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit"

--- a/controller/scripts/lastfm-session.ts
+++ b/controller/scripts/lastfm-session.ts
@@ -1,0 +1,110 @@
+// CLI helper that walks the operator through Last.fm's web auth flow and
+// prints a long-lived session key they can paste into /admin/settings.
+//
+// Why this exists: SUB/WAVE's scrobbling integration is paste-only (no
+// OAuth callback route, no redirect dance — see broadcast/scrobble.ts).
+// But Last.fm doesn't hand out session keys directly; you still have to
+// trade an auth token for one over auth.getSession. This script does that
+// locally in the terminal so the operator never has to write code or wire
+// up a callback URL on their host just to authorize the integration.
+//
+// Run:
+//   cd controller && npm run lastfm-session
+//
+// You'll need an API account first: https://www.last.fm/api/account/create
+// (any "Application name" / "Callback URL: http://localhost/" is fine — the
+// callback isn't used by this flow.)
+
+import { createHash } from 'node:crypto';
+import { createInterface } from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+
+const API = 'https://ws.audioscrobbler.com/2.0/';
+
+function sign(params: Record<string, string>, secret: string): string {
+  const keys = Object.keys(params).filter(k => k !== 'format' && k !== 'callback').sort();
+  const sigStr = keys.map(k => k + params[k]).join('') + secret;
+  return createHash('md5').update(sigStr, 'utf8').digest('hex');
+}
+
+async function call(method: string, params: Record<string, string>, secret: string): Promise<any> {
+  const all = { ...params, method };
+  (all as any).api_sig = sign(all, secret);
+  (all as any).format = 'json';
+  const url = `${API}?${new URLSearchParams(all).toString()}`;
+  const r = await fetch(url);
+  const text = await r.text();
+  let data: any = {};
+  try { data = JSON.parse(text); } catch {}
+  if (!r.ok || data?.error) {
+    const msg = data?.message || text.slice(0, 200) || `HTTP ${r.status}`;
+    throw new Error(`last.fm ${method}: ${msg}`);
+  }
+  return data;
+}
+
+async function main() {
+  const rl = createInterface({ input, output });
+  try {
+    console.log('SUB/WAVE — Last.fm session key helper');
+    console.log('-------------------------------------');
+    console.log('Get an API account at https://www.last.fm/api/account/create');
+    console.log('(any callback URL works; we will not use it).');
+    console.log('');
+
+    const apiKey = (await rl.question('Last.fm API key:    ')).trim();
+    const apiSecret = (await rl.question('Last.fm API secret: ')).trim();
+    if (!apiKey || !apiSecret) {
+      console.error('Both API key and secret are required.');
+      process.exit(1);
+    }
+
+    console.log('');
+    console.log('Requesting an auth token…');
+    const tokenRes = await call('auth.getToken', { api_key: apiKey }, apiSecret);
+    const token: string = tokenRes?.token;
+    if (!token) {
+      console.error('Last.fm did not return a token. Response:', tokenRes);
+      process.exit(1);
+    }
+
+    const authUrl = `https://www.last.fm/api/auth/?api_key=${encodeURIComponent(apiKey)}&token=${encodeURIComponent(token)}`;
+    console.log('');
+    console.log('Open this URL in a browser and click "Yes, allow access":');
+    console.log('');
+    console.log(`  ${authUrl}`);
+    console.log('');
+    await rl.question('Press Enter once you have authorized…');
+
+    console.log('');
+    console.log('Exchanging token for a session key…');
+    const sessRes = await call(
+      'auth.getSession',
+      { api_key: apiKey, token },
+      apiSecret,
+    );
+    const sk: string | undefined = sessRes?.session?.key;
+    const user: string | undefined = sessRes?.session?.name;
+    if (!sk) {
+      console.error('Last.fm did not return a session key. Response:', sessRes);
+      process.exit(1);
+    }
+
+    console.log('');
+    console.log('Success — paste these into /admin/settings → Scrobbling → Last.fm:');
+    console.log('');
+    console.log(`  API key:     ${apiKey}`);
+    console.log(`  API secret:  ${apiSecret}`);
+    console.log(`  Session key: ${sk}`);
+    console.log(`  Username:    ${user || '(unknown)'}`);
+    console.log('');
+    console.log('The session key does not expire. Keep it secret.');
+  } finally {
+    rl.close();
+  }
+}
+
+main().catch(err => {
+  console.error('Failed:', err?.message || err);
+  process.exit(1);
+});

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -15,6 +15,7 @@ import * as settings from '../settings.js';
 import { logEvent } from '../observability/events.js';
 import { djCallsAllowed } from './listeners.js';
 import * as webhooks from './webhooks.js';
+import * as scrobble from './scrobble.js';
 
 // Random gap between DJ links on auto-played tracks. The frequency setting
 // scales how chatty the DJ is:
@@ -373,6 +374,13 @@ class Queue {
     if (key === this.lastSeenKey) return;
     this.lastSeenKey = key;
 
+    // Snapshot the outgoing track BEFORE the history roll mutates `this.current`
+    // — scrobble.onTrackEvent below needs the previous play + its start time
+    // to compute eligibility against Last.fm's >50% / >4min rule.
+    const outgoingPrev = this.current
+      ? { track: this.current.track, startedAt: this.current.startedAt }
+      : null;
+
     // Roll previous current into history
     if (this.current) {
       const endedAt = new Date().toISOString();
@@ -471,6 +479,28 @@ class Queue {
       album: this.current.track.album || null,
       source: this.current.source,
       requestedBy: this.current.requestedBy || null,
+    });
+
+    // Last.fm / ListenBrainz — also fire-and-forget. Internally gated on
+    // listener count > 0 (fail-closed) and per-backend enable flags.
+    scrobble.onTrackEvent({
+      outgoing: outgoingPrev?.track
+        ? {
+            id: outgoingPrev.track.id || null,
+            title: outgoingPrev.track.title || null,
+            artist: outgoingPrev.track.artist || null,
+            album: outgoingPrev.track.album || null,
+            duration: outgoingPrev.track.duration ?? null,
+          }
+        : null,
+      outgoingStartedAt: outgoingPrev?.startedAt || null,
+      incoming: {
+        id: this.current.track.id || null,
+        title: this.current.track.title || null,
+        artist: this.current.track.artist || null,
+        album: this.current.track.album || null,
+        duration: this.current.track.duration ?? null,
+      },
     });
 
     this.persist();  // upcoming/current/history all just changed

--- a/controller/src/broadcast/scrobble.ts
+++ b/controller/src/broadcast/scrobble.ts
@@ -64,8 +64,12 @@ function isEligibleScrobble(track: ScrobbleTrack | null, elapsed: number): boole
     if (d <= MIN_DURATION_SEC) return false;
     return elapsed >= d / 2 || elapsed >= MIN_ELAPSED_FLOOR_SEC;
   }
-  // Duration unknown — fall back to the 4-minute floor only.
-  return elapsed >= MIN_ELAPSED_FLOOR_SEC;
+  // Duration unknown (auto-playlist tracks don't carry it through the annotation
+  // chain). SUB/WAVE has no skip endpoint — Liquidsoap controls pacing and a
+  // new track replacing the old one means the old one played to natural
+  // completion. Treat elapsed as the effective duration and apply only the
+  // >30s floor (Last.fm's "ignore short clips" rule).
+  return elapsed >= MIN_DURATION_SEC;
 }
 
 function listenersPresent(): boolean {
@@ -261,14 +265,24 @@ async function listenbrainzSubmit(track: ScrobbleTrack, startedAt: string, token
 // side-effects — never throws, never blocks the caller. Fires both backends
 // in parallel (fire-and-forget).
 export function onTrackEvent({ outgoing, outgoingStartedAt, incoming }: TrackEventArgs): void {
-  if (!listenersPresent()) return;
+  const listeners = getListenerCount();
+  if (typeof listeners !== 'number' || listeners <= 0) {
+    console.log(`[scrobble] skip: ${listeners ?? 'null'} listener(s)`);
+    return;
+  }
 
   const lf = lastfmCreds();
   const lb = listenbrainzToken();
-  if (!lf && !lb) return;
+  if (!lf && !lb) {
+    console.log('[scrobble] skip: no backend enabled with credentials');
+    return;
+  }
+
+  const backends = [lf && 'last.fm', lb && 'listenbrainz'].filter(Boolean).join('+');
 
   // Incoming → now-playing ping.
   if (incoming?.title && incoming?.artist) {
+    console.log(`[scrobble] now-playing → ${backends}: "${incoming.title}" — ${incoming.artist}`);
     if (lf) lastfmUpdateNowPlaying(incoming, lf).catch(() => {});
     if (lb) listenbrainzPlayingNow(incoming, lb).catch(() => {});
   }
@@ -277,8 +291,13 @@ export function onTrackEvent({ outgoing, outgoingStartedAt, incoming }: TrackEve
   if (outgoing && outgoingStartedAt) {
     const elapsed = elapsedSeconds(outgoingStartedAt);
     if (isEligibleScrobble(outgoing, elapsed)) {
+      console.log(`[scrobble] submit → ${backends}: "${outgoing.title}" — ${outgoing.artist} (elapsed=${elapsed}s)`);
       if (lf) lastfmScrobble(outgoing, outgoingStartedAt, lf).catch(() => {});
       if (lb) listenbrainzSubmit(outgoing, outgoingStartedAt, lb).catch(() => {});
+    } else {
+      const dur = Number(outgoing.duration);
+      const durDisplay = Number.isFinite(dur) && dur > 0 ? `${dur}s` : 'unknown';
+      console.log(`[scrobble] skip submit (ineligible): "${outgoing.title}" elapsed=${elapsed}s duration=${durDisplay}`);
     }
   }
 }

--- a/controller/src/broadcast/scrobble.ts
+++ b/controller/src/broadcast/scrobble.ts
@@ -1,0 +1,327 @@
+// Station-wide scrobbling — Last.fm + ListenBrainz.
+//
+// Triggered from Queue.onTrackStarted on every real music transition:
+//   - the OUTGOING track (the one that just ended) is submitted as a scrobble
+//     if it passed Last.fm's standard eligibility rule (>30s long, played >50%
+//     OR >240s) AND at least one listener is currently tuned in
+//   - the INCOMING track gets a `track.updateNowPlaying` / `playing_now` ping
+//     so the operator's profile shows "currently playing X" — same listener
+//     gate, no eligibility check
+//
+// Each backend (Last.fm, ListenBrainz) is independent: own enable flag, own
+// credentials, own failure mode. Every network call is fire-and-forget with a
+// 5s timeout — matching broadcast/webhooks.ts. Failures log to stderr; there
+// is no retry queue. If you want guaranteed delivery, point at a relay.
+//
+// Listener gating fails CLOSED (unknown listener count → skip), unlike
+// djCallsAllowed() which fails OPEN. Silencing the DJ during a stats outage
+// is worse than over-talking, but polluting a real Last.fm profile with
+// scrobbles during a monitoring blip is worse than missing a few entries.
+
+import { createHash } from 'node:crypto';
+import * as settings from '../settings.js';
+import { getListenerCount } from './listeners.js';
+
+const TIMEOUT_MS = 5000;
+const LASTFM_API = 'https://ws.audioscrobbler.com/2.0/';
+const LISTENBRAINZ_API = 'https://api.listenbrainz.org/1/submit-listens';
+
+// Last.fm's documented rule for a "valid scrobble":
+//   - the track must be longer than 30 seconds
+//   - and either >50% of the track has been played, or >4 minutes (whichever
+//     comes first)
+// When duration is unknown we can only enforce the 4-minute floor.
+const MIN_DURATION_SEC = 30;
+const MIN_ELAPSED_FLOOR_SEC = 240;
+
+export interface ScrobbleTrack {
+  id?: string | null;
+  title?: string | null;
+  artist?: string | null;
+  album?: string | null;
+  duration?: number | null; // seconds, optional
+}
+
+interface TrackEventArgs {
+  outgoing: ScrobbleTrack | null;        // the track that just ended (may be null on first start)
+  outgoingStartedAt: string | null;      // ISO timestamp the outgoing track started at
+  incoming: ScrobbleTrack | null;        // the track that just started
+}
+
+// ── eligibility ─────────────────────────────────────────────────────────────
+
+function elapsedSeconds(startedAt: string | null | undefined): number {
+  if (!startedAt) return 0;
+  const t = Date.parse(startedAt);
+  if (!Number.isFinite(t)) return 0;
+  return Math.max(0, Math.floor((Date.now() - t) / 1000));
+}
+
+function isEligibleScrobble(track: ScrobbleTrack | null, elapsed: number): boolean {
+  if (!track?.title || !track?.artist) return false;
+  const d = Number(track.duration);
+  if (Number.isFinite(d) && d > 0) {
+    if (d <= MIN_DURATION_SEC) return false;
+    return elapsed >= d / 2 || elapsed >= MIN_ELAPSED_FLOOR_SEC;
+  }
+  // Duration unknown — fall back to the 4-minute floor only.
+  return elapsed >= MIN_ELAPSED_FLOOR_SEC;
+}
+
+function listenersPresent(): boolean {
+  const c = getListenerCount();
+  return typeof c === 'number' && c > 0;
+}
+
+// ── credential helpers ──────────────────────────────────────────────────────
+
+interface LastfmCreds {
+  apiKey: string;
+  apiSecret: string;
+  sessionKey: string;
+}
+
+function lastfmCreds(): LastfmCreds | null {
+  const s: any = settings.get()?.scrobble?.lastfm || {};
+  if (!s.enabled) return null;
+  const apiKey = process.env.LASTFM_API_KEY || s.apiKey || '';
+  const apiSecret = process.env.LASTFM_API_SECRET || s.apiSecret || '';
+  const sessionKey = process.env.LASTFM_SESSION_KEY || s.sessionKey || '';
+  if (!apiKey || !apiSecret || !sessionKey) return null;
+  return { apiKey, apiSecret, sessionKey };
+}
+
+function listenbrainzToken(): string | null {
+  const s: any = settings.get()?.scrobble?.listenbrainz || {};
+  if (!s.enabled) return null;
+  const token = process.env.LISTENBRAINZ_USER_TOKEN || s.userToken || '';
+  return token || null;
+}
+
+// ── Last.fm client ──────────────────────────────────────────────────────────
+
+// Last.fm signs write calls with md5 of every parameter (except `format` and
+// `callback`) sorted alphabetically and concatenated as key+value, then the
+// shared secret appended. See https://www.last.fm/api/authspec.
+function signLastfm(params: Record<string, string>, secret: string): string {
+  const keys = Object.keys(params).filter(k => k !== 'format' && k !== 'callback').sort();
+  const sigStr = keys.map(k => k + params[k]).join('') + secret;
+  return createHash('md5').update(sigStr, 'utf8').digest('hex');
+}
+
+async function callLastfm(method: string, baseParams: Record<string, string>, creds: LastfmCreds): Promise<void> {
+  const params: Record<string, string> = {
+    ...baseParams,
+    method,
+    api_key: creds.apiKey,
+    sk: creds.sessionKey,
+  };
+  params.api_sig = signLastfm(params, creds.apiSecret);
+  params.format = 'json';
+  const body = new URLSearchParams(params).toString();
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const r = await fetch(LASTFM_API, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'User-Agent': 'sub-wave/scrobble',
+      },
+      body,
+      signal: ctrl.signal,
+    });
+    if (!r.ok) {
+      let detail = '';
+      try { detail = (await r.text()).slice(0, 200); } catch {}
+      console.warn(`[scrobble] last.fm ${method} → ${r.status}${detail ? ` — ${detail}` : ''}`);
+      return;
+    }
+    // 200 doesn't guarantee success — Last.fm embeds a JSON `error` field.
+    try {
+      const data = (await r.json()) as any;
+      if (data?.error) {
+        console.warn(`[scrobble] last.fm ${method} error ${data.error}: ${data.message || ''}`);
+      }
+    } catch {
+      // Non-JSON body on 200 — treat as success.
+    }
+  } catch (err: any) {
+    console.warn(`[scrobble] last.fm ${method} failed: ${err?.message || err}`);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function lastfmTrackParams(track: ScrobbleTrack): Record<string, string> {
+  const p: Record<string, string> = {
+    artist: String(track.artist || ''),
+    track: String(track.title || ''),
+  };
+  if (track.album) p.album = String(track.album);
+  const d = Number(track.duration);
+  if (Number.isFinite(d) && d > 0) p.duration = String(Math.round(d));
+  return p;
+}
+
+async function lastfmUpdateNowPlaying(track: ScrobbleTrack, creds: LastfmCreds): Promise<void> {
+  await callLastfm('track.updateNowPlaying', lastfmTrackParams(track), creds);
+}
+
+async function lastfmScrobble(
+  track: ScrobbleTrack,
+  startedAt: string,
+  creds: LastfmCreds,
+): Promise<void> {
+  const ts = Math.floor(Date.parse(startedAt) / 1000);
+  if (!Number.isFinite(ts)) return;
+  await callLastfm(
+    'track.scrobble',
+    { ...lastfmTrackParams(track), timestamp: String(ts) },
+    creds,
+  );
+}
+
+// ── ListenBrainz client ─────────────────────────────────────────────────────
+
+async function postListenbrainz(payload: Record<string, unknown>, token: string, label: string): Promise<void> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const r = await fetch(LISTENBRAINZ_API, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Token ${token}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'sub-wave/scrobble',
+      },
+      body: JSON.stringify(payload),
+      signal: ctrl.signal,
+    });
+    if (!r.ok) {
+      let detail = '';
+      try { detail = (await r.text()).slice(0, 200); } catch {}
+      console.warn(`[scrobble] listenbrainz ${label} → ${r.status}${detail ? ` — ${detail}` : ''}`);
+    }
+  } catch (err: any) {
+    console.warn(`[scrobble] listenbrainz ${label} failed: ${err?.message || err}`);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function listenbrainzTrackMetadata(track: ScrobbleTrack): Record<string, unknown> {
+  const md: Record<string, unknown> = {
+    artist_name: String(track.artist || ''),
+    track_name: String(track.title || ''),
+  };
+  if (track.album) md.release_name = String(track.album);
+  const d = Number(track.duration);
+  const additional: Record<string, unknown> = {};
+  if (Number.isFinite(d) && d > 0) additional.duration = Math.round(d);
+  additional.media_player = 'SUB/WAVE';
+  additional.submission_client = 'sub-wave/scrobble';
+  md.additional_info = additional;
+  return md;
+}
+
+async function listenbrainzPlayingNow(track: ScrobbleTrack, token: string): Promise<void> {
+  await postListenbrainz(
+    {
+      listen_type: 'playing_now',
+      payload: [{ track_metadata: listenbrainzTrackMetadata(track) }],
+    },
+    token,
+    'playing_now',
+  );
+}
+
+async function listenbrainzSubmit(track: ScrobbleTrack, startedAt: string, token: string): Promise<void> {
+  const ts = Math.floor(Date.parse(startedAt) / 1000);
+  if (!Number.isFinite(ts)) return;
+  await postListenbrainz(
+    {
+      listen_type: 'single',
+      payload: [
+        {
+          listened_at: ts,
+          track_metadata: listenbrainzTrackMetadata(track),
+        },
+      ],
+    },
+    token,
+    'submit_listens',
+  );
+}
+
+// ── public surface ──────────────────────────────────────────────────────────
+
+// Called from Queue.onTrackStarted on every real music transition. Pure
+// side-effects — never throws, never blocks the caller. Fires both backends
+// in parallel (fire-and-forget).
+export function onTrackEvent({ outgoing, outgoingStartedAt, incoming }: TrackEventArgs): void {
+  if (!listenersPresent()) return;
+
+  const lf = lastfmCreds();
+  const lb = listenbrainzToken();
+  if (!lf && !lb) return;
+
+  // Incoming → now-playing ping.
+  if (incoming?.title && incoming?.artist) {
+    if (lf) lastfmUpdateNowPlaying(incoming, lf).catch(() => {});
+    if (lb) listenbrainzPlayingNow(incoming, lb).catch(() => {});
+  }
+
+  // Outgoing → scrobble if eligible.
+  if (outgoing && outgoingStartedAt) {
+    const elapsed = elapsedSeconds(outgoingStartedAt);
+    if (isEligibleScrobble(outgoing, elapsed)) {
+      if (lf) lastfmScrobble(outgoing, outgoingStartedAt, lf).catch(() => {});
+      if (lb) listenbrainzSubmit(outgoing, outgoingStartedAt, lb).catch(() => {});
+    }
+  }
+}
+
+// Admin "Test" button — fires a now-playing ping for the supplied track on
+// the named backend. Returns { ok, status, message } so the UI can surface
+// the actual API response. Bypasses the listener gate (operator wants to
+// verify their credentials regardless of who's tuned in) but still respects
+// the per-backend enabled flag, since "disabled but configured" should not
+// surprise-emit.
+export type ScrobbleProvider = 'lastfm' | 'listenbrainz';
+
+export interface TestResult {
+  ok: boolean;
+  message: string;
+}
+
+export async function testNowPlaying(
+  provider: ScrobbleProvider,
+  track: ScrobbleTrack,
+): Promise<TestResult> {
+  if (!track?.title || !track?.artist) {
+    return { ok: false, message: 'no track currently playing — wait for one and try again' };
+  }
+  if (provider === 'lastfm') {
+    const creds = lastfmCreds();
+    if (!creds) return { ok: false, message: 'last.fm not enabled or missing credentials' };
+    try {
+      await lastfmUpdateNowPlaying(track, creds);
+      return { ok: true, message: `sent now-playing to last.fm for "${track.title}"` };
+    } catch (err: any) {
+      return { ok: false, message: err?.message || 'last.fm test failed' };
+    }
+  }
+  if (provider === 'listenbrainz') {
+    const token = listenbrainzToken();
+    if (!token) return { ok: false, message: 'listenbrainz not enabled or missing user token' };
+    try {
+      await listenbrainzPlayingNow(track, token);
+      return { ok: true, message: `sent playing_now to listenbrainz for "${track.title}"` };
+    } catch (err: any) {
+      return { ok: false, message: err?.message || 'listenbrainz test failed' };
+    }
+  }
+  return { ok: false, message: `unknown provider "${provider}"` };
+}

--- a/controller/src/routes/scrobble.ts
+++ b/controller/src/routes/scrobble.ts
@@ -1,0 +1,41 @@
+// Admin-gated scrobble test endpoint.
+//
+// The scrobble fan-out itself lives in broadcast/scrobble.ts and consumes
+// track events from broadcast/queue.ts. This route only exposes the "Test"
+// button in /admin/settings → Scrobbling: fires a now-playing ping at the
+// requested backend using the currently-playing track, reports the result.
+import express from 'express';
+import { requireAdmin } from '../middleware/auth.js';
+import { queue } from '../broadcast/queue.js';
+import { testNowPlaying, type ScrobbleProvider } from '../broadcast/scrobble.js';
+
+export const router = express.Router();
+
+router.post('/scrobble/test', requireAdmin, async (req, res) => {
+  const provider = req.body?.provider as ScrobbleProvider | undefined;
+  if (provider !== 'lastfm' && provider !== 'listenbrainz') {
+    return res.status(400).json({ error: 'provider must be "lastfm" or "listenbrainz"' });
+  }
+  // Use the live track if there is one. Otherwise the test reports back
+  // cleanly — operators tend to click this before anything is on-air, and
+  // a 400 with "no current track" reads better than a silent success.
+  const current: any = queue.current?.track || null;
+  if (!current) {
+    return res.status(409).json({
+      ok: false,
+      message: 'no track is currently playing — wait for the stream to start one and try again',
+    });
+  }
+  try {
+    const result = await testNowPlaying(provider, {
+      id: current.id || null,
+      title: current.title || null,
+      artist: current.artist || null,
+      album: current.album || null,
+      duration: current.duration ?? null,
+    });
+    res.json(result);
+  } catch (err: any) {
+    res.status(500).json({ ok: false, message: err?.message || 'test failed' });
+  }
+});

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -53,6 +53,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
         llm: s.llm,
         search: s.search,
         sfx: s.sfx,
+        scrobble: s.scrobble,
       },
       defaults: {
         // The built-in prompt template — the UI shows this when djPrompt is "".
@@ -91,6 +92,10 @@ router.get('/settings', requireAdmin, async (req, res) => {
         OPENROUTER_API_KEY: !!process.env.OPENROUTER_API_KEY,
         AI_GATEWAY_API_KEY: !!process.env.AI_GATEWAY_API_KEY,
         SEARCH_API_KEY: !!process.env.SEARCH_API_KEY,
+        LASTFM_API_KEY: !!process.env.LASTFM_API_KEY,
+        LASTFM_API_SECRET: !!process.env.LASTFM_API_SECRET,
+        LASTFM_SESSION_KEY: !!process.env.LASTFM_SESSION_KEY,
+        LISTENBRAINZ_USER_TOKEN: !!process.env.LISTENBRAINZ_USER_TOKEN,
       },
       // Skill catalogue — consumed by the Skills page and by Personas for the
       // per-persona skill-assignment checklist.

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -27,6 +27,7 @@ import { router as onboardingRoutes } from './routes/onboarding.js';
 import { router as archivesRoutes } from './routes/archives.js';
 import { router as listenersRoutes } from './routes/listeners.js';
 import { router as webhooksRoutes } from './routes/webhooks.js';
+import { router as scrobbleRoutes } from './routes/scrobble.js';
 import { loadSecretsIntoEnv } from './setup/secrets.js';
 import { loadSetupConfig } from './setup/config.js';
 import { getSetupStatus } from './setup/firstRun.js';
@@ -52,6 +53,7 @@ app.use(onboardingRoutes);
 app.use(archivesRoutes);
 app.use(listenersRoutes);
 app.use(webhooksRoutes);
+app.use(scrobbleRoutes);
 
 // (manual skip is not implemented in this build — Liquidsoap controls pacing)
 

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -289,6 +289,25 @@ const DEFAULTS = {
   // webhooks.ts for the event list) to `url` with a fire-and-forget HTTP
   // call. Empty by default — operators add hooks via the admin UI.
   webhooks: [] as any[],
+  // Station-wide scrobbling. Each backend is independent; both are paste-only
+  // (no OAuth) and both are gated on listener count > 0 at scrobble time (a
+  // null/unknown count is treated as zero — fail closed, see broadcast/
+  // scrobble.ts). API keys/secrets/tokens live here OR in state/secrets.env
+  // (env wins). `username` is display-only.
+  scrobble: {
+    lastfm: {
+      enabled: false,
+      apiKey: '',
+      apiSecret: '',
+      sessionKey: '',
+      username: '',
+    },
+    listenbrainz: {
+      enabled: false,
+      userToken: '',
+      username: '',
+    },
+  },
 };
 
 const BOUNDS = {
@@ -545,6 +564,44 @@ export async function load() {
       enabled: typeof stored.sfx?.enabled === 'boolean' ? stored.sfx.enabled : DEFAULTS.sfx.enabled,
     },
     webhooks: normalizeWebhooks(stored.webhooks),
+    scrobble: {
+      lastfm: {
+        enabled:
+          typeof stored.scrobble?.lastfm?.enabled === 'boolean'
+            ? stored.scrobble.lastfm.enabled
+            : DEFAULTS.scrobble.lastfm.enabled,
+        apiKey:
+          typeof stored.scrobble?.lastfm?.apiKey === 'string'
+            ? stored.scrobble.lastfm.apiKey
+            : '',
+        apiSecret:
+          typeof stored.scrobble?.lastfm?.apiSecret === 'string'
+            ? stored.scrobble.lastfm.apiSecret
+            : '',
+        sessionKey:
+          typeof stored.scrobble?.lastfm?.sessionKey === 'string'
+            ? stored.scrobble.lastfm.sessionKey
+            : '',
+        username:
+          typeof stored.scrobble?.lastfm?.username === 'string'
+            ? stored.scrobble.lastfm.username.trim().slice(0, 40)
+            : '',
+      },
+      listenbrainz: {
+        enabled:
+          typeof stored.scrobble?.listenbrainz?.enabled === 'boolean'
+            ? stored.scrobble.listenbrainz.enabled
+            : DEFAULTS.scrobble.listenbrainz.enabled,
+        userToken:
+          typeof stored.scrobble?.listenbrainz?.userToken === 'string'
+            ? stored.scrobble.listenbrainz.userToken
+            : '',
+        username:
+          typeof stored.scrobble?.listenbrainz?.username === 'string'
+            ? stored.scrobble.listenbrainz.username.trim().slice(0, 40)
+            : '',
+      },
+    },
   };
   return cache;
 }
@@ -598,6 +655,14 @@ export function getRedacted() {
     for (let i = 0; i < clone.webhooks.length; i++) {
       clone.webhooks[i].authHeader = s.webhooks?.[i]?.authHeader ? 'set' : '';
     }
+  }
+  if (clone.scrobble?.lastfm) {
+    clone.scrobble.lastfm.apiKey = s.scrobble?.lastfm?.apiKey ? 'set' : '';
+    clone.scrobble.lastfm.apiSecret = s.scrobble?.lastfm?.apiSecret ? 'set' : '';
+    clone.scrobble.lastfm.sessionKey = s.scrobble?.lastfm?.sessionKey ? 'set' : '';
+  }
+  if (clone.scrobble?.listenbrainz) {
+    clone.scrobble.listenbrainz.userToken = s.scrobble?.listenbrainz?.userToken ? 'set' : '';
   }
   return clone;
 }
@@ -1067,6 +1132,41 @@ export async function update(patch) {
   }
   if ('webhooks' in patch) {
     next.webhooks = validateWebhooksStrict(patch.webhooks, next.webhooks || []);
+  }
+  if ('scrobble' in patch) {
+    const sb = patch.scrobble || {};
+    if (sb.lastfm !== undefined) {
+      const lf = sb.lastfm || {};
+      if (lf.enabled !== undefined) next.scrobble.lastfm.enabled = !!lf.enabled;
+      if (lf.username !== undefined) {
+        const v = String(lf.username ?? '').trim();
+        if (v.length > 40) throw new Error('scrobble.lastfm.username must be 0-40 chars');
+        next.scrobble.lastfm.username = v;
+      }
+      // 'set' is the redaction sentinel from getRedacted() — ignore it so a
+      // round-tripped form doesn't overwrite the stored secret.
+      for (const k of ['apiKey', 'apiSecret', 'sessionKey'] as const) {
+        if (lf[k] !== undefined && lf[k] !== 'set') {
+          const v = String(lf[k] ?? '').trim();
+          if (v.length > 200) throw new Error(`scrobble.lastfm.${k} must be 0-200 chars`);
+          next.scrobble.lastfm[k] = v;
+        }
+      }
+    }
+    if (sb.listenbrainz !== undefined) {
+      const lb = sb.listenbrainz || {};
+      if (lb.enabled !== undefined) next.scrobble.listenbrainz.enabled = !!lb.enabled;
+      if (lb.username !== undefined) {
+        const v = String(lb.username ?? '').trim();
+        if (v.length > 40) throw new Error('scrobble.listenbrainz.username must be 0-40 chars');
+        next.scrobble.listenbrainz.username = v;
+      }
+      if (lb.userToken !== undefined && lb.userToken !== 'set') {
+        const v = String(lb.userToken ?? '').trim();
+        if (v.length > 200) throw new Error('scrobble.listenbrainz.userToken must be 0-200 chars');
+        next.scrobble.listenbrainz.userToken = v;
+      }
+    }
   }
 
   // Post-patch integrity sweep — a personas/shows change in this patch may

--- a/controller/src/setup/secrets.ts
+++ b/controller/src/setup/secrets.ts
@@ -24,6 +24,12 @@ export const SECRET_ENV_KEYS = [
   'AI_GATEWAY_API_KEY',
   'ELEVENLABS_API_KEY',
   'SEARCH_API_KEY',
+  // Scrobbling. See broadcast/scrobble.ts. Env always wins over settings.json,
+  // so a host with these in compose env_file works without ever touching the UI.
+  'LASTFM_API_KEY',
+  'LASTFM_API_SECRET',
+  'LASTFM_SESSION_KEY',
+  'LISTENBRAINZ_USER_TOKEN',
 ];
 
 // Read state/secrets.env and merge into process.env for keys that aren't

--- a/web/components/CenterStage.tsx
+++ b/web/components/CenterStage.tsx
@@ -33,7 +33,10 @@ export default function CenterStage({ nowPlaying, elapsed, feed, djLineOn, onOpe
   // flip), and every new DJ turn (voice/dj) landing in the feed.
   // djLineOn is a listener preference for the ticker, not a "talking now"
   // flag, so it can't gate the ripple.
-  const latestDjTurnT = useMemo<number | null>(() => {
+  // SessionTurn.t is `string | number | undefined` — ISO timestamps from one
+  // path, unix-ms from another. The value is only ever used as a useEffect
+  // dep (Object.is change detection), so any stable identifier works.
+  const latestDjTurnT = useMemo<string | number | null>(() => {
     if (!feed?.length) return null;
     for (let i = feed.length - 1; i >= 0; i--) {
       const turn = feed[i];

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -18,13 +18,14 @@ import { Card, Btn, Pill, Eyebrow, Seg, Metric } from './ui';
 import { cn } from '../../lib/cn';
 
 const SECTIONS = [
-  { id: 'tts',     label: 'TTS voice', hint: 'default engine' },
-  { id: 'llm',     label: 'LLM provider', hint: 'model routing' },
-  { id: 'search',  label: 'Web search', hint: 'live-facts backend' },
-  { id: 'station', label: 'Station', hint: 'name · location' },
-  { id: 'jingles', label: 'Jingles', hint: 'stingers' },
-  { id: 'sfx',     label: 'Sound FX', hint: 'agent stingers' },
-  { id: 'danger',  label: 'Danger zone', hint: 'broadcast control' },
+  { id: 'tts',      label: 'TTS voice', hint: 'default engine' },
+  { id: 'llm',      label: 'LLM provider', hint: 'model routing' },
+  { id: 'search',   label: 'Web search', hint: 'live-facts backend' },
+  { id: 'station',  label: 'Station', hint: 'name · location' },
+  { id: 'jingles',  label: 'Jingles', hint: 'stingers' },
+  { id: 'sfx',      label: 'Sound FX', hint: 'agent stingers' },
+  { id: 'scrobble', label: 'Scrobbling', hint: 'last.fm · listenbrainz' },
+  { id: 'danger',   label: 'Danger zone', hint: 'broadcast control' },
 ] as const;
 
 type SectionId = (typeof SECTIONS)[number]['id'];
@@ -97,6 +98,25 @@ interface SearchForm {
   apiKey: string;
 }
 
+interface ScrobbleLastfmForm {
+  enabled: boolean;
+  apiKey: string;
+  apiSecret: string;
+  sessionKey: string;
+  username: string;
+}
+
+interface ScrobbleListenbrainzForm {
+  enabled: boolean;
+  userToken: string;
+  username: string;
+}
+
+interface ScrobbleForm {
+  lastfm: ScrobbleLastfmForm;
+  listenbrainz: ScrobbleListenbrainzForm;
+}
+
 interface FormState {
   jingleRatio: string;
   crossfadeDuration: string;
@@ -105,6 +125,7 @@ interface FormState {
   tts: TtsForm;
   llm: LlmForm;
   search: SearchForm;
+  scrobble: ScrobbleForm;
 }
 
 interface JingleEntry {
@@ -143,6 +164,10 @@ interface SettingsData {
     llm?: Partial<LlmForm>;
     search?: Partial<SearchForm>;
     sfx?: { enabled?: boolean };
+    scrobble?: {
+      lastfm?: Partial<ScrobbleLastfmForm>;
+      listenbrainz?: Partial<ScrobbleListenbrainzForm>;
+    };
   };
   tts?: {
     engines?: string[];
@@ -248,6 +273,21 @@ export default function SettingsPanel() {
         // GET /settings returns the apiKey redacted to 'set' | '' — that
         // round-trips through POST harmlessly (settings.update ignores 'set').
         apiKey: v.search?.apiKey ?? '',
+      },
+      scrobble: {
+        lastfm: {
+          enabled: !!v.scrobble?.lastfm?.enabled,
+          // 'set' sentinel from getRedacted() — round-trips harmlessly.
+          apiKey: v.scrobble?.lastfm?.apiKey ?? '',
+          apiSecret: v.scrobble?.lastfm?.apiSecret ?? '',
+          sessionKey: v.scrobble?.lastfm?.sessionKey ?? '',
+          username: v.scrobble?.lastfm?.username ?? '',
+        },
+        listenbrainz: {
+          enabled: !!v.scrobble?.listenbrainz?.enabled,
+          userToken: v.scrobble?.listenbrainz?.userToken ?? '',
+          username: v.scrobble?.listenbrainz?.username ?? '',
+        },
       },
     });
   }, [data, form]);
@@ -458,6 +498,12 @@ export default function SettingsPanel() {
                 jingleText={jingleText} setJingleText={setJingleText}
                 createJingle={createJingle} saveSettings={saveSettings}
                 onDelete={setConfirmDelete}
+              />
+            )}
+            {activeSection === 'scrobble' && (
+              <ScrobbleSection
+                data={data} form={form} setForm={updateForm} busy={busy}
+                saveSettings={saveSettings} adminFetch={adminFetch}
               />
             )}
           </>
@@ -1803,6 +1849,293 @@ function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, onDelete, d
             </Btn>
           </div>
         ))}
+      </Card>
+    </>
+  );
+}
+
+/* ── Scrobbling ──────────────────────────────────────────────────────── */
+
+interface ScrobbleSectionProps extends SectionProps {
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+}
+
+function ScrobbleSection({ data, form, setForm, busy, saveSettings, adminFetch }: ScrobbleSectionProps) {
+  const lf = form.scrobble.lastfm;
+  const lb = form.scrobble.listenbrainz;
+  const savedLf = data.values?.scrobble?.lastfm || {};
+  const savedLb = data.values?.scrobble?.listenbrainz || {};
+
+  // Treat 'set' as "stored — leave the input empty unless the operator types
+  // something new". The controller ignores 'set' on POST so a round-trip
+  // won't blank the secret.
+  const inputValue = (v: string) => (v === 'set' ? '' : v);
+  const placeholder = (v: string, fallback: string) =>
+    v === 'set' ? '•••••• (on file)' : fallback;
+  const env = (data.env || {}) as Record<string, unknown>;
+  const lfApiKeySet = lf.apiKey === 'set' || !!env.LASTFM_API_KEY;
+  const lfApiSecretSet = lf.apiSecret === 'set' || !!env.LASTFM_API_SECRET;
+  const lfSessionSet = lf.sessionKey === 'set' || !!env.LASTFM_SESSION_KEY;
+  const lbTokenSet = lb.userToken === 'set' || !!env.LISTENBRAINZ_USER_TOKEN;
+  const lfReady = lf.enabled && lfApiKeySet && lfApiSecretSet && lfSessionSet;
+  const lbReady = lb.enabled && lbTokenSet;
+
+  const saveLastfm = () => {
+    const patch: Partial<ScrobbleLastfmForm> = {
+      enabled: lf.enabled,
+      username: lf.username,
+    };
+    if (lf.apiKey && lf.apiKey !== 'set') patch.apiKey = lf.apiKey;
+    if (lf.apiSecret && lf.apiSecret !== 'set') patch.apiSecret = lf.apiSecret;
+    if (lf.sessionKey && lf.sessionKey !== 'set') patch.sessionKey = lf.sessionKey;
+    saveSettings({ scrobble: { lastfm: patch } });
+  };
+  const saveListenbrainz = () => {
+    const patch: Partial<ScrobbleListenbrainzForm> = {
+      enabled: lb.enabled,
+      username: lb.username,
+    };
+    if (lb.userToken && lb.userToken !== 'set') patch.userToken = lb.userToken;
+    saveSettings({ scrobble: { listenbrainz: patch } });
+  };
+
+  const sendTest = async (provider: 'lastfm' | 'listenbrainz') => {
+    try {
+      const r = await adminFetch('/scrobble/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider }),
+      });
+      const j = (await r.json().catch(() => ({}))) as {
+        ok?: boolean; message?: string; error?: string;
+      };
+      const msg = j.message || j.error || (r.ok ? 'sent' : `failed (${r.status})`);
+      if (r.ok && j.ok) notify.ok(msg);
+      else notify.err(msg);
+    } catch (e) {
+      notify.err(errorMessage(e));
+    }
+  };
+
+  return (
+    <>
+      <SectionHeader
+        eyebrow="scrobbling"
+        title="Station-wide scrobbling to Last.fm and ListenBrainz."
+        sub={<>
+          Each backend is independent — pick one or both. Tracks scrobble only when at
+          least one listener is tuned in to the stream. Paste credentials below; nothing
+          here leaves the controller. See the <code>npm run lastfm-session</code> helper
+          if you don&apos;t already have a Last.fm session key.
+        </>}
+        metrics={[
+          { n: lfReady ? 'on' : 'off', l: 'last.fm', accent: lfReady },
+          { n: lbReady ? 'on' : 'off', l: 'listenbrainz', accent: lbReady },
+        ]}
+      />
+
+      <Card
+        title="Last.fm"
+        sub={lfReady ? `scrobbling as ${savedLf.username || '(unknown)'}` : 'not connected'}
+      >
+        <div className="grid gap-[18px]">
+          <div className="field">
+            <div className="flex items-center gap-2">
+              <Label>Enabled</Label>
+              {lf.enabled !== !!savedLf.enabled && <Pill tone="accent" dot>unsaved</Pill>}
+            </div>
+            <Seg
+              value={lf.enabled ? 'on' : 'off'}
+              onChange={v =>
+                setForm(f => ({
+                  ...f,
+                  scrobble: { ...f.scrobble, lastfm: { ...f.scrobble.lastfm, enabled: v === 'on' } },
+                }))
+              }
+              options={[{ id: 'off', label: 'Off' }, { id: 'on', label: 'On' }]}
+            />
+            <div className="field-hint">
+              When on, every track that plays with at least one listener tuned in is
+              scrobbled to your Last.fm profile.
+            </div>
+          </div>
+
+          <div className="field">
+            <Label>API key</Label>
+            <Input
+              type="password"
+              value={inputValue(lf.apiKey)}
+              placeholder={placeholder(lf.apiKey, 'your last.fm API key')}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setForm(f => ({
+                  ...f,
+                  scrobble: { ...f.scrobble, lastfm: { ...f.scrobble.lastfm, apiKey: e.target.value } },
+                }))
+              }
+              className="max-w-[360px]"
+            />
+            <div className="field-hint">
+              Get one at <code>last.fm/api/account/create</code>. Falls back to
+              <code> LASTFM_API_KEY</code> in <code>.env</code> when blank.
+            </div>
+          </div>
+
+          <div className="field">
+            <Label>API secret</Label>
+            <Input
+              type="password"
+              value={inputValue(lf.apiSecret)}
+              placeholder={placeholder(lf.apiSecret, 'your last.fm API secret')}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setForm(f => ({
+                  ...f,
+                  scrobble: { ...f.scrobble, lastfm: { ...f.scrobble.lastfm, apiSecret: e.target.value } },
+                }))
+              }
+              className="max-w-[360px]"
+            />
+            <div className="field-hint">
+              Paired with the API key. Falls back to <code>LASTFM_API_SECRET</code>.
+            </div>
+          </div>
+
+          <div className="field">
+            <Label>Session key</Label>
+            <Input
+              type="password"
+              value={inputValue(lf.sessionKey)}
+              placeholder={placeholder(lf.sessionKey, 'long-lived session key')}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setForm(f => ({
+                  ...f,
+                  scrobble: { ...f.scrobble, lastfm: { ...f.scrobble.lastfm, sessionKey: e.target.value } },
+                }))
+              }
+              className="max-w-[360px]"
+            />
+            <div className="field-hint">
+              Generated by authorizing your account. Run
+              <code> cd controller &amp;&amp; npm run lastfm-session</code> for a guided
+              flow, or fetch one yourself via <code>auth.getSession</code>. Doesn&apos;t
+              expire. Falls back to <code>LASTFM_SESSION_KEY</code>.
+            </div>
+          </div>
+
+          <div className="field">
+            <Label>Username (display)</Label>
+            <Input
+              value={lf.username}
+              placeholder="your last.fm username"
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setForm(f => ({
+                  ...f,
+                  scrobble: { ...f.scrobble, lastfm: { ...f.scrobble.lastfm, username: e.target.value } },
+                }))
+              }
+              className="max-w-[360px]"
+            />
+            <div className="field-hint">
+              Cosmetic — used to label the &quot;scrobbling as&quot; status line above.
+            </div>
+          </div>
+        </div>
+
+        <SaveBar
+          note="Applies on the next track transition — no restart needed."
+          busy={busy}
+          onSave={saveLastfm}
+          saveLabel="Save Last.fm"
+          extra={
+            <Btn sm onClick={() => sendTest('lastfm')} disabled={busy || !lfReady}>
+              Test
+            </Btn>
+          }
+        />
+      </Card>
+
+      <Card
+        title="ListenBrainz"
+        sub={lbReady ? `submitting as ${savedLb.username || '(unknown)'}` : 'not connected'}
+      >
+        <div className="grid gap-[18px]">
+          <div className="field">
+            <div className="flex items-center gap-2">
+              <Label>Enabled</Label>
+              {lb.enabled !== !!savedLb.enabled && <Pill tone="accent" dot>unsaved</Pill>}
+            </div>
+            <Seg
+              value={lb.enabled ? 'on' : 'off'}
+              onChange={v =>
+                setForm(f => ({
+                  ...f,
+                  scrobble: {
+                    ...f.scrobble,
+                    listenbrainz: { ...f.scrobble.listenbrainz, enabled: v === 'on' },
+                  },
+                }))
+              }
+              options={[{ id: 'off', label: 'Off' }, { id: 'on', label: 'On' }]}
+            />
+            <div className="field-hint">
+              ListenBrainz is the open-source alternative to Last.fm — same listener gate,
+              same eligibility rules.
+            </div>
+          </div>
+
+          <div className="field">
+            <Label>User token</Label>
+            <Input
+              type="password"
+              value={inputValue(lb.userToken)}
+              placeholder={placeholder(lb.userToken, 'your listenbrainz user token')}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setForm(f => ({
+                  ...f,
+                  scrobble: {
+                    ...f.scrobble,
+                    listenbrainz: { ...f.scrobble.listenbrainz, userToken: e.target.value },
+                  },
+                }))
+              }
+              className="max-w-[360px]"
+            />
+            <div className="field-hint">
+              Copy from <code>listenbrainz.org/profile</code>. Falls back to
+              <code> LISTENBRAINZ_USER_TOKEN</code>.
+            </div>
+          </div>
+
+          <div className="field">
+            <Label>Username (display)</Label>
+            <Input
+              value={lb.username}
+              placeholder="your listenbrainz username"
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setForm(f => ({
+                  ...f,
+                  scrobble: {
+                    ...f.scrobble,
+                    listenbrainz: { ...f.scrobble.listenbrainz, username: e.target.value },
+                  },
+                }))
+              }
+              className="max-w-[360px]"
+            />
+            <div className="field-hint">Cosmetic only.</div>
+          </div>
+        </div>
+
+        <SaveBar
+          note="Applies on the next track transition — no restart needed."
+          busy={busy}
+          onSave={saveListenbrainz}
+          saveLabel="Save ListenBrainz"
+          extra={
+            <Btn sm onClick={() => sendTest('listenbrainz')} disabled={busy || !lbReady}>
+              Test
+            </Btn>
+          }
+        />
       </Card>
     </>
   );


### PR DESCRIPTION
Closes #121.

## Summary
- Station-wide scrobbling to **Last.fm** and **ListenBrainz**, each backend independent (own enable flag, own credentials)
- Gated on Icecast listener count > 0 at scrobble time — **fail-closed** (unknown count = skip), unlike `djCallsAllowed()` which fails open. Polluting a real Last.fm profile during a monitoring blip is the worse failure mode
- Paste-only credentials (no OAuth callback). A new `npm run lastfm-session` helper walks operators through Last.fm's auth flow locally and prints a session key to paste into the admin UI
- New "Scrobbling" section in `/admin/settings` with two cards (Last.fm, ListenBrainz), per-card Save + **Test** button that fires a now-playing ping for the live track
- All network calls are fire-and-forget with a 5s timeout, mirroring `broadcast/webhooks.ts`. No retry queue — failures log to stderr

## How it hooks in
`Queue.onTrackStarted` already fires `webhooks.notify('track.play', …)`. The scrobble module piggy-backs on the same event:
1. Snapshots the outgoing track + its `startedAt` **before** the history roll
2. After the new `current` is set, calls `scrobble.onTrackEvent({ outgoing, outgoingStartedAt, incoming })`
3. Incoming track → `updateNowPlaying` / `playing_now`
4. Outgoing track → `track.scrobble` / `submit-listens` if Last.fm's standard eligibility passes (>30s long, played >50% OR >240s; when duration is unknown, the 4-minute floor alone)

## Files
**New**
- `controller/src/broadcast/scrobble.ts` — module (clients, eligibility, listener gate)
- `controller/src/routes/scrobble.ts` — admin-gated `POST /scrobble/test`
- `controller/scripts/lastfm-session.ts` — CLI helper

**Modified**
- `controller/src/broadcast/queue.ts` — snapshot + invoke (purely additive)
- `controller/src/settings.ts` — `scrobble` defaults, load, redaction (`'set'` sentinel), strict validator
- `controller/src/setup/secrets.ts` — `LASTFM_*` + `LISTENBRAINZ_USER_TOKEN` in env allowlist
- `controller/src/server.ts` — mount route
- `controller/package.json` — `lastfm-session` script
- `web/components/admin/SettingsPanel.tsx` — Scrobbling section

## Test plan
- [x] `tsc --noEmit` passes (controller + web)
- [x] ESLint: only pre-existing `no-explicit-any` warnings — no new errors
- [x] Runtime smoke: settings round-trip preserves real secrets when UI sends back the `'set'` sentinel
- [x] Last.fm md5 signing matches the documented `concat sorted(key+value) + secret` shape
- [ ] Live end-to-end against a real Last.fm account (paste session key obtained via `npm run lastfm-session`, play a track with the dev player open, see the scrobble land within ~30s on `last.fm/user/<name>/library`)
- [x] Live end-to-end against a real ListenBrainz account (paste token from `listenbrainz.org/profile`, play a track, see the listen on `listenbrainz.org/user/<name>/`)
- [x] Listener gate: close every player tab, wait for a transition, confirm no outbound POST (controller logs)
- [x] Test button: with creds configured and a track playing, click Test on each card → green toast, profile shows updated "Now playing"

## Out of scope
- OAuth/redirect flows (paste-only was the explicit ask)
- Per-listener client-side scrobblers
- Backfilling historical scrobbles from `events-*.jsonl`
- ListenBrainz MBID enrichment (server handles its own lookup)