### PR TITLE
fix(skill): worktree-dev prep skips onboarding + follows root compose layout

### DIFF
--- a/.claude/skills/subwave-worktree-dev/SKILL.md
+++ b/.claude/skills/subwave-worktree-dev/SKILL.md
@@ -27,17 +27,21 @@ a worktree checkout:
 
 | File | Why the stack needs it |
 |---|---|
-| `controller/.env` | Dev compose declares `env_file: ../controller/.env` — the controller container will not start without it. Holds Navidrome + Ollama config. |
+| `.env` | Root `.env` — `ADMIN_USER` / `ADMIN_PASS` / `SITE_URL`. Dev compose references it as `./.env`; compose refuses to start without it. |
+| `controller/.env` | Dev compose declares `env_file: ./controller/.env` — controller container won't start without it. Navidrome + Ollama config. |
 | `web/.env.local` | Dev API/stream URL overrides (`NEXT_PUBLIC_API_URL` etc.). Without it the web UI defaults to same-origin `/api` and cannot reach the controller. |
-| `docker/.env` | Compose variable substitution. |
+| `docker/.env` | Compose variable substitution (legacy — harmless to copy). |
+| `state/setup-config.json` | Navidrome creds the wizard saved on main. Without this the controller reports `needsSetup: true` and the player redirects to `/onboarding` on every load. |
+| `state/secrets.env` | Cloud LLM / TTS API keys (if main has any). Sourced into the controller's `process.env` on boot. |
 | `web/node_modules` | Needed by `npm run dev`. |
 | `state/` | Bind-mounted into the containers. A worktree's `state/` is empty. |
 
-`state/` is scaffolded **fresh** — directory structure only. Settings, sessions,
-queue, and library mood data are *not* copied, so the worktree station boots
-clean and the controller writes its own defaults. The broadcast container
-generates its own `state/icecast-secrets.env` on first boot, so worktrees no
-longer need to copy any rendered icecast config — there isn't one.
+`state/` is scaffolded **fresh** — directory structure plus the two onboarding-skip
+files (`setup-config.json`, `secrets.env`) so the operator lands directly on the
+player. Settings, sessions, queue, library mood data, and rendered jingles are
+*not* copied — the worktree station boots clean and the controller writes its
+own defaults. The broadcast container generates its own `state/icecast-secrets.env`
+on first boot, so worktrees no longer need to copy any rendered icecast config.
 
 ## Two load-bearing facts
 
@@ -74,8 +78,9 @@ Only one stack can run. Stop whatever is up (it may be the main checkout's):
 WEB_PID=$(lsof -nP -iTCP:7700 -sTCP:LISTEN -t 2>/dev/null | head -1)
 [ -n "$WEB_PID" ] && ps -p "$WEB_PID" -o comm= | grep -qi node && kill "$WEB_PID"
 
-# Bring down whichever dev stack is up (run from any checkout's docker/ dir —
-# same compose project name, so this targets the running containers).
+# Bring down whichever dev stack is up. The compose file lives at the
+# checkout root (not under docker/); container names are global, so any
+# checkout's docker-compose.dev.yml targets the running containers.
 docker compose -f <some-checkout>/docker-compose.dev.yml down
 ```
 
@@ -96,8 +101,10 @@ fills in what is missing.
 
 ### Step 3 — Start the stack from the worktree
 
+Compose files now live at the worktree **root** (not under `docker/`):
+
 ```bash
-cd <worktree-path>/docker && docker compose up -d --build
+cd <worktree-path> && docker compose -f docker-compose.dev.yml up -d --build
 ```
 
 `--build` is required so the worktree's controller source is baked into the
@@ -127,7 +134,7 @@ settings on first boot are expected, not faults.
 
 - **Web/UI change** — nothing to do; `npm run dev` hot-reloads it.
 - **Controller source change** — rebuild just that service:
-  `cd <worktree-path>/docker && docker compose up -d --build controller`.
+  `cd <worktree-path> && docker compose -f docker-compose.dev.yml up -d --build controller`.
 - **`liquidsoap/radio.liq` change** — it is bind-mounted in dev; just
   `docker compose restart broadcast`.
 

--- a/.claude/skills/subwave-worktree-dev/scripts/prep-worktree.sh
+++ b/.claude/skills/subwave-worktree-dev/scripts/prep-worktree.sh
@@ -3,18 +3,23 @@
 #
 # A git worktree checks out every TRACKED file, but the dev stack also needs
 # a handful of gitignored files that do NOT travel with the checkout:
-#   - controller/.env   (Navidrome + Ollama config; dev compose env_file)
-#   - web/.env.local    (dev API/stream URL overrides for the web UI)
-#   - docker/.env       (compose variable substitution)
-#   - web/node_modules  (needed by `npm run dev`)
-#   - state/            (bind-mounted into the containers)
+#   - .env                       (root .env — ADMIN_USER/PASS/SITE_URL; dev compose references it as ./.env)
+#   - controller/.env            (Navidrome + Ollama config; dev compose env_file)
+#   - web/.env.local             (dev API/stream URL overrides for the web UI)
+#   - docker/.env                (compose variable substitution — legacy; harmless to copy if present)
+#   - state/setup-config.json    (Navidrome creds the wizard saved; copying skips /onboarding)
+#   - state/secrets.env          (cloud LLM/TTS API keys, if the main checkout has any)
+#   - web/node_modules           (needed by `npm run dev`)
+#   - state/                     (bind-mounted into the containers)
 #
 # This copies the env files from the main working tree, runs npm install, and
-# scaffolds a FRESH state/ directory — structure only. It deliberately does NOT
+# scaffolds a FRESH state/ directory — structure plus the two onboarding-skip
+# files (setup-config.json + secrets.env, if they exist on main). It does NOT
 # copy settings.json, session.json, queue.json, moods.json, or any archived
 # sessions/jingles/voice files, so the worktree station boots clean and the
-# controller writes its own defaults. The broadcast container generates its
-# own state/icecast-secrets.env on first boot, so there's nothing to copy.
+# controller writes its own defaults — but the operator lands directly on the
+# player instead of /onboarding. The broadcast container generates its own
+# state/icecast-secrets.env on first boot, so there's nothing to copy.
 #
 # Usage:
 #   prep-worktree.sh [worktree-path]   # worktree-path defaults to $PWD
@@ -73,6 +78,7 @@ copy_env() {
   echo "[prep] copied $rel"
 }
 
+copy_env .env
 copy_env controller/.env
 copy_env web/.env.local
 copy_env docker/.env
@@ -91,7 +97,12 @@ mkdir -p "$STATE"/logs "$STATE"/voice "$STATE"/jingles "$STATE"/sessions "$STATE
 # fail with EACCES and crash-loops the container. Widen the tree so every
 # container uid can read+write. (The main checkout ends up 777 the same way
 # after its first container run; this just front-loads it.)
-chmod -R a+rwX "$STATE"
+#
+# `|| true` because re-running prep against an established worktree hits files
+# the container created as root — those are already 0666/0777 from the container's
+# umask, so the chmod is a no-op but bash still errors on the EPERM. Don't bail
+# the whole prep over cosmetic permission warnings on a re-run.
+chmod -R a+rwX "$STATE" 2>/dev/null || true
 
 # icecast-secrets.env — the broadcast container generates this on first boot
 # if it doesn't exist (mode 0644 so liquidsoap inside the same container can
@@ -110,7 +121,35 @@ chmod -R a+rwX "$STATE"
 [ -f "$STATE/auto.m3u" ]    || { : > "$STATE/auto.m3u";    echo "[prep] touched state/auto.m3u (empty — controller refills it)"; }
 [ -f "$STATE/jingles.m3u" ] || { : > "$STATE/jingles.m3u"; echo "[prep] touched state/jingles.m3u (empty — run generate-jingles.sh later if wanted)"; }
 
-echo "[prep] state/ scaffolded fresh — no settings/sessions/queue/moods copied; the controller writes defaults on first boot."
+# setup-config.json carries the Navidrome creds the first-run wizard saved.
+# Without it, controller/src/setup/firstRun.ts reports needsSetup=true and the
+# player redirects to /onboarding on every page load. Copy it from main so the
+# worktree boots straight into the player — the operator already onboarded
+# once in the main checkout, no need to do it again per branch. secrets.env
+# is the matching file for cloud LLM/TTS API keys; copy it too if present.
+copy_state_file() {
+  local rel="$1"
+  local src="$MAIN/state/$rel"
+  local dst="$STATE/$rel"
+  if [ ! -e "$src" ]; then
+    echo "[prep] skip   state/$rel — not present in main"
+    return
+  fi
+  if [ -e "$dst" ]; then
+    echo "[prep] keep   state/$rel — already in worktree (left untouched)"
+    return
+  fi
+  cp "$src" "$dst"
+  # secrets.env is mode 0600 — preserve that. The Navidrome pass in
+  # setup-config.json is plaintext but the file is normal 0644.
+  if [ "$rel" = "secrets.env" ]; then chmod 0600 "$dst"; fi
+  echo "[prep] copied state/$rel"
+}
+
+copy_state_file setup-config.json
+copy_state_file secrets.env
+
+echo "[prep] state/ scaffolded — no settings/sessions/queue/moods copied; the controller writes defaults on first boot."
 
 # ── web dependencies ────────────────────────────────────────────────────────
 if [ "$SKIP_NPM" = 1 ]; then
@@ -126,8 +165,8 @@ fi
 cat <<EOM
 
 [prep] done. Start the dev stack from the worktree:
-  cd "$WORKTREE/docker" && docker compose up -d --build   # --build bakes worktree controller changes into the image
-  cd "$WORKTREE/web"    && npm run dev                     # web hot-reloads — run this in the background
+  cd "$WORKTREE" && docker compose -f docker-compose.dev.yml up -d --build   # --build bakes worktree controller changes into the image
+  cd "$WORKTREE/web" && npm run dev                                           # web hot-reloads — run this in the background
 
 Verify on-air (give Liquidsoap ~5s to connect):
   curl -sf http://localhost:7701/health    # expect {"status":"on-air"}


### PR DESCRIPTION
## Summary
Three fixes to the **subwave-worktree-dev** skill that surfaced while staging the scrobble worktree:

1. **Worktrees were redirecting to `/onboarding` on every page load.** The prep script scaffolded a clean `state/` but never copied `state/setup-config.json` from the main checkout, so `controller/src/setup/firstRun.ts` reported `needsSetup: true`. Now also copies `state/secrets.env` if present (cloud LLM/TTS keys).
2. **`docker compose up` failed with `env file ./.env not found`.** The compose files moved from `docker/` to the repo root some time back; the dev compose now references `./.env` directly. Prep script wasn't copying it. Added.
3. **Re-running prep against an established worktree bailed.** The pre-existing `chmod -R a+rwX state/` step couldn't widen permissions on files the controller container had written as root, exited non-zero under `set -e`, and the rest of prep (state-file copies, npm install, final report) never ran. Made the chmod tolerant — the container-owned files are already 0666/0777 anyway, the chmod is just a fresh-state widen.

Also updated start-the-stack instructions to use the worktree root (`docker compose -f docker-compose.dev.yml up -d --build`) instead of the obsolete `cd worktree/docker && docker compose up`.

## Files
- `.claude/skills/subwave-worktree-dev/scripts/prep-worktree.sh` — copy `.env`, copy `state/setup-config.json` + `state/secrets.env`, tolerant chmod, corrected final instructions
- `.claude/skills/subwave-worktree-dev/SKILL.md` — file-list table + body updated to match

## Test plan
- [x] `bash -n` syntax-check passes
- [x] Idempotent re-run against an established (running-stack) worktree exits 0, all steps print, no false-fatal bail
- [x] Onboarding skipped: `curl http://localhost:7701/state` returns `needsSetup: false` after restarting controller against the copied `setup-config.json`
- [ ] Fresh worktree end-to-end: `git worktree add` → run prep → `docker compose up -d --build` → player loads directly (no redirect)