### PR TITLE
feat(web): ripple effect behind now-playing artwork

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -256,6 +256,21 @@ body::after {
     }
 }
 
+/* Magic UI ripple — concentric ink rings expanding behind the now-playing
+   artwork. Each circle inherits its own --i so the breathing is staggered. */
+@keyframes sw-ripple {
+    0%,
+    100% {
+        transform: translate(-50%, -50%) scale(1);
+    }
+    50% {
+        transform: translate(-50%, -50%) scale(0.9);
+    }
+}
+.sw-ripple-circle {
+    animation: sw-ripple 2s ease calc(var(--i, 0) * 0.2s) infinite;
+}
+
 @keyframes sw-success-in {
     from {
         opacity: 0;

--- a/web/components/CenterStage.tsx
+++ b/web/components/CenterStage.tsx
@@ -1,8 +1,11 @@
 'use client';
 
+import { useEffect, useMemo, useState } from 'react';
 import { AnimatePresence, m } from 'motion/react';
 import { fmtTime } from '@/lib/format';
 import DjThinkingLine from './DjThinkingLine';
+import { Ripple } from './ui/ripple';
+import { isDjTurn } from '@/lib/sessionFeed';
 import type { NowPlayingTrack, SessionTurn } from '@/lib/types';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || '/api';
@@ -18,31 +21,72 @@ export interface CenterStageProps {
 export default function CenterStage({ nowPlaying, elapsed, feed, djLineOn, onOpenBooth }: CenterStageProps) {
   const has = !!nowPlaying?.title;
   const duration = nowPlaying?.duration ?? 0;
-  const coverSrc = nowPlaying?.subsonic_id
-    ? `${API_URL}/cover/${encodeURIComponent(nowPlaying.subsonic_id)}`
+  const subsonicId = nowPlaying?.subsonic_id ?? null;
+  const coverSrc = subsonicId
+    ? `${API_URL}/cover/${encodeURIComponent(subsonicId)}`
     : null;
   // Title key keeps placeholder + real titles in the same AnimatePresence so
   // the first-track-arrives transition cross-dissolves the "scanning" line out.
   const titleKey = has ? `t:${nowPlaying?.title}` : 'placeholder';
 
+  // Ripple bursts for ~3s on two signals: every track change (subsonic_id
+  // flip), and every new DJ turn (voice/dj) landing in the feed.
+  // djLineOn is a listener preference for the ticker, not a "talking now"
+  // flag, so it can't gate the ripple.
+  const latestDjTurnT = useMemo<number | null>(() => {
+    if (!feed?.length) return null;
+    for (let i = feed.length - 1; i >= 0; i--) {
+      const turn = feed[i];
+      if (turn && isDjTurn(turn) && turn.text) return turn.t ?? i;
+    }
+    return null;
+  }, [feed]);
+
+  const [trackBurst, setTrackBurst] = useState(false);
+  useEffect(() => {
+    if (!subsonicId) return;
+    setTrackBurst(true);
+    const t = setTimeout(() => setTrackBurst(false), 3000);
+    return () => clearTimeout(t);
+  }, [subsonicId]);
+
+  const [djBurst, setDjBurst] = useState(false);
+  useEffect(() => {
+    if (latestDjTurnT == null) return;
+    setDjBurst(true);
+    const t = setTimeout(() => setDjBurst(false), 3000);
+    return () => clearTimeout(t);
+  }, [latestDjTurnT]);
+
+  const rippleActive = trackBurst || djBurst;
+
   return (
     <div className="absolute top-1/2 right-24 left-4 flex -translate-y-[58%] flex-col items-start sm:left-8">
-      <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-6">
+      <div className="isolate flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-6">
         {coverSrc && (
-          <div className="relative h-[clamp(72px,14vw,160px)] w-[clamp(72px,14vw,160px)] shrink-0 overflow-hidden rounded-sm border border-muted">
-            <AnimatePresence mode="popLayout" initial={false}>
-              <m.img
-                key={coverSrc}
-                src={coverSrc}
-                alt=""
-                initial={{ opacity: 0, scale: 1.02 }}
-                animate={{ opacity: 1, scale: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.28, ease: [0.2, 0.7, 0.2, 1] }}
-                className="absolute inset-0 h-full w-full object-cover"
-                onError={(e) => { e.currentTarget.style.display = 'none'; }}
-              />
-            </AnimatePresence>
+          <div className="relative h-[clamp(72px,14vw,160px)] w-[clamp(72px,14vw,160px)] shrink-0">
+            <Ripple
+              active={rippleActive}
+              mainCircleSize={140}
+              mainCircleOpacity={0.28}
+              numCircles={6}
+              className="-inset-[220px] -z-10"
+            />
+            <div className="relative h-full w-full overflow-hidden rounded-sm border border-muted">
+              <AnimatePresence mode="popLayout" initial={false}>
+                <m.img
+                  key={coverSrc}
+                  src={coverSrc}
+                  alt=""
+                  initial={{ opacity: 0, scale: 1.02 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.28, ease: [0.2, 0.7, 0.2, 1] }}
+                  className="absolute inset-0 h-full w-full object-cover"
+                  onError={(e) => { e.currentTarget.style.display = 'none'; }}
+                />
+              </AnimatePresence>
+            </div>
           </div>
         )}
         <div className="min-w-0">

--- a/web/components/ui/ripple.tsx
+++ b/web/components/ui/ripple.tsx
@@ -1,0 +1,62 @@
+import React, { type ComponentPropsWithoutRef, type CSSProperties } from 'react';
+
+import { cn } from '@/lib/cn';
+
+interface RippleProps extends ComponentPropsWithoutRef<'div'> {
+  mainCircleSize?: number;
+  mainCircleOpacity?: number;
+  numCircles?: number;
+  active?: boolean;
+}
+
+export const Ripple = React.memo(function Ripple({
+  mainCircleSize = 210,
+  mainCircleOpacity = 0.24,
+  numCircles = 8,
+  active = true,
+  className,
+  ...props
+}: RippleProps) {
+  return (
+    <div
+      className={cn(
+        'pointer-events-none absolute inset-0 select-none [mask-image:linear-gradient(to_bottom,white,transparent)]',
+        'transition-opacity duration-500',
+        active ? 'opacity-100' : 'opacity-0',
+        className,
+      )}
+      {...props}
+    >
+      {Array.from({ length: numCircles }, (_, i) => {
+        const size = mainCircleSize + i * 70;
+        const opacity = mainCircleOpacity - i * 0.03;
+        const animationDelay = `${i * 0.06}s`;
+
+        return (
+          <div
+            key={i}
+            className={cn(
+              'absolute rounded-full border border-solid shadow-xl',
+              active && 'sw-ripple-circle',
+            )}
+            style={
+              {
+                '--i': i,
+                width: `${size}px`,
+                height: `${size}px`,
+                opacity,
+                animationDelay,
+                borderColor: 'var(--ink)',
+                top: '50%',
+                left: '50%',
+                transform: 'translate(-50%, -50%) scale(1)',
+              } as CSSProperties
+            }
+          />
+        );
+      })}
+    </div>
+  );
+});
+
+Ripple.displayName = 'Ripple';


### PR DESCRIPTION
## Summary
- Adds a Magic UI `Ripple` component behind the cover art on the player, themed with `--ink` so it works in both newsprint light + dark.
- Ripple fires in **3s bursts** on two signals — every track change (`subsonic_id` flip) and every new DJ turn (`voice`/`dj`) landing in the session feed — then idles invisible. Punctuates moments instead of looping continuously.
- Flex row is `isolate`d so the ripple's `-z-10` stays scoped behind the artwork and never bleeds onto the title text on the right.

## Files
- `web/components/ui/ripple.tsx` *(new)* — component, takes an `active` prop that fades the wrapper + gates the animation.
- `web/app/globals.css` — `@keyframes sw-ripple` + `.sw-ripple-circle` utility (kept alongside existing keyframes, outside `@theme` to avoid token-map collisions).
- `web/components/CenterStage.tsx` — wraps the cover, two `useEffect` burst timers driven off `subsonic_id` and the latest dj-turn timestamp.

## Test plan
- [x] Open `/listen`, wait for first track — ripple bursts briefly when the track first appears.
- [x] Wait for the DJ to talk (or trigger a request) — ripple bursts on the new turn.
- [x] Idle period between events — no ripple visible, no CPU/GPU spin.
- [x] Light + dark theme — ring color follows `--ink`.