### PR TITLE
release: web image build hotfix (ripple.tsx eslint)

### DIFF
--- a/web/components/ui/ripple.tsx
+++ b/web/components/ui/ripple.tsx
@@ -20,7 +20,7 @@ export const Ripple = React.memo(function Ripple({
   return (
     <div
       className={cn(
-        'pointer-events-none absolute inset-0 select-none [mask-image:linear-gradient(to_bottom,white,transparent)]',
+        'pointer-events-none absolute inset-0 [mask-image:linear-gradient(to_bottom,white,transparent)] select-none',
         'transition-opacity duration-500',
         active ? 'opacity-100' : 'opacity-0',
         className,
@@ -39,6 +39,7 @@ export const Ripple = React.memo(function Ripple({
               'absolute rounded-full border border-solid shadow-xl',
               active && 'sw-ripple-circle',
             )}
+            // eslint-disable-next-line react/forbid-dom-props -- per-circle size/delay/opacity are loop-index-derived; --i is a CSS custom property
             style={
               {
                 '--i': i,


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge with "Create a merge commit"** — not "Squash and merge". Squash collapses the individual `fix:` commit, and release-please then sees no conventional-commit signal and skips the version bump.

## Summary

Hotfix for the broken `publish-images` run on tag v0.1.21 ([job 77729072641](https://github.com/perminder-klair/subwave/actions/runs/26405909306/job/77729072641)). The new ripple component (PR #129) tripped two lint rules that only fire under the prod Docker build (`next build` runs `next lint` and treats errors as fatal — `npm run dev` doesn't): a Tailwind class-order violation and the project-wide ban on inline styles. v0.1.21 published the `caddy`/`controller`/`broadcast` images successfully but `subwave-web` failed, so no v0.1.21 web image exists on ghcr.io.

**Bug Fixes**
- `b5b4dea` fix(web): unblock image build — ripple.tsx tailwind order + inline-style lint

## Test plan
- [ ] `publish-images` workflow on the new release tag (v0.1.22) succeeds on all four images, including `subwave-web`.
- [ ] Visual: ripple effect behind now-playing artwork still renders identically — same per-circle sizes, opacities, animation delays. (Only an `eslint-disable-next-line` comment + class reorder; no runtime behaviour change.)