### PR TITLE
fix: show station name from settings in player TopBar and landing Masthead

### DIFF
--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -74,6 +74,7 @@ router.get('/now-playing', async (req, res) => {
       getStreamStatus(),
     ]);
     const persona = settings.getEffectivePersona();
+    const sett = settings.get();
     // activeShow is { name, persona:{ name } } | null — surfaced to listeners.
     const activeShow = ctx.activeShow
       ? { name: ctx.activeShow.name, persona: ctx.activeShow.persona }
@@ -82,7 +83,7 @@ router.get('/now-playing', async (req, res) => {
     res.json({
       nowPlaying,
       context: ctx,
-      dj: { name: persona?.name || 'Frequency', tagline: persona?.tagline || '' },
+      dj: { name: persona?.name || 'Frequency', tagline: persona?.tagline || '', station: sett.station },
       activeShow,
       session: s ? { id: s.id, kind: s.kind, startedAt: s.startedAt, show: s.show?.name || null } : null,
       listeners: stream.listeners,

--- a/web/components/landing/Masthead.tsx
+++ b/web/components/landing/Masthead.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { useClock } from '../../lib/hooks';
 import ThemeToggle from './ThemeToggle';
 
 const LAUNCH_DATE = new Date('2026-01-01T00:00:00Z');
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '/api';
 
 function issueNo(d: Date): number {
   return Math.max(1, Math.floor((d.getTime() - LAUNCH_DATE.getTime()) / 86400000));
@@ -18,6 +20,14 @@ function issueNo(d: Date): number {
 // reference frame should feel like print, not a performance.
 export default function Masthead() {
   const now = useClock();
+  const [stationName, setStationName] = useState<string>('SUB/WAVE');
+
+  useEffect(() => {
+    fetch(`${API_URL}/dj`)
+      .then(r => r.json())
+      .then(d => { if (typeof d?.station === 'string' && d.station.trim()) setStationName(d.station.trim()); })
+      .catch(() => {});
+  }, []);
 
   return (
     <header className="bs-paper pt-7 pb-0">
@@ -33,10 +43,10 @@ export default function Masthead() {
 
         <Link
           href="/"
-          aria-label="SUB/WAVE home"
+          aria-label={`${stationName} home`}
           className="bs-wordmark bs-masthead-mark text-ink no-underline"
         >
-          SUB/WAVE
+          {stationName}
         </Link>
 
         <div className="bs-masthead-status flex items-center gap-2 text-[11px] font-bold tracking-[0.3em] uppercase">


### PR DESCRIPTION
## Problem

The station name configured in Settings → Station Name was never shown in the UI. Two hardcoded occurrences of `'SUB/WAVE'`:

1. **Player TopBar** (`web/components/TopBar.tsx`) already accepted a `stationName` prop and had a correct fallback, but `PlayerApp` passes `dj?.station` from `useStationFeed` → `GET /now-playing`. That endpoint's `dj` object was missing the `station` field, so `dj?.station` was always `undefined` and the fallback string was always shown.

2. **Broadsheet landing Masthead** (`web/components/landing/Masthead.tsx`) had `'SUB/WAVE'` hardcoded in the wordmark with no data fetch at all.

## Fix

- **`controller/src/routes/public.ts`**: add `station: sett.station` to the `dj` object returned by `GET /now-playing`. TopBar already had the wiring — it just had no data.
- **`web/components/landing/Masthead.tsx`**: fetch `GET /dj` on mount; use the returned `station` as the wordmark text. Falls back to `'SUB/WAVE'` if the API is unreachable (same as before, but now only as a genuine fallback).

## Test plan

- [ ] Set a custom station name in admin Settings
- [ ] Player TopBar shows the custom name (not `SUB/WAVE`)
- [ ] Broadsheet landing page (`/landing`) wordmark shows the custom name after hydration
- [ ] Fallback still reads `SUB/WAVE` when the controller is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)