### PR TITLE
perf(broadcast): toggleable hourly archive + lower log verbosity (closes #137)

### DIFF
--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -197,9 +197,20 @@ export const SEED_PERSONAS = [
   },
 ];
 
+// Allowed archive bitrates. Matches the literal branches in radio.liq —
+// %mp3(bitrate=…) needs a parse-time int, so the encoder is pre-baked for
+// this small set. Add a branch in radio.liq if you add a value here.
+export const ARCHIVE_BITRATES = [64, 96, 128, 160, 192, 320] as const;
+
 const DEFAULTS = {
   jingleRatio: 30, // 1 jingle per N music tracks
   crossfadeDuration: 10.0, // seconds
+  // Hourly archive output. Enabled by default to preserve existing behaviour.
+  // The second MP3 encoder is the largest constant CPU cost in the broadcast
+  // container — operators who don't use the archives can switch this off to
+  // reclaim that headroom (issue #137). Dropping the bitrate (e.g. 128 → 64
+  // mono in a future change) also helps for operators who want the tape.
+  archive: { enabled: true, bitrate: 128 },
   weather: { lat: 52.5862, lng: -2.1288, locationName: 'Wolverhampton' },
   // Operator-facing station name. Substituted into the DJ prompt's {station}
   // placeholder and returned by GET /dj for the landing page. The product is
@@ -314,6 +325,8 @@ const BOUNDS = {
   jingleRatio: { min: 1, max: 1000, type: 'int' },
   crossfadeDuration: { min: 0, max: 30, type: 'float' },
 };
+
+const ARCHIVE_BITRATE_SET = new Set<number>(ARCHIVE_BITRATES);
 
 let cache: any = null;
 
@@ -474,9 +487,21 @@ export async function load() {
     shows.map(s => s.id),
   );
 
+  const archiveBitrate =
+    typeof stored.archive?.bitrate === 'number' && ARCHIVE_BITRATE_SET.has(stored.archive.bitrate)
+      ? stored.archive.bitrate
+      : DEFAULTS.archive.bitrate;
+
   cache = {
     jingleRatio: stored.jingleRatio ?? DEFAULTS.jingleRatio,
     crossfadeDuration: stored.crossfadeDuration ?? DEFAULTS.crossfadeDuration,
+    archive: {
+      enabled:
+        typeof stored.archive?.enabled === 'boolean'
+          ? stored.archive.enabled
+          : DEFAULTS.archive.enabled,
+      bitrate: archiveBitrate,
+    },
     weather: {
       lat: stored.weather?.lat ?? DEFAULTS.weather.lat,
       lng: stored.weather?.lng ?? DEFAULTS.weather.lng,
@@ -925,6 +950,28 @@ export async function update(patch) {
       restart = true;
     }
   }
+  if ('archive' in patch) {
+    const a = patch.archive || {};
+    if (a.enabled !== undefined) {
+      const v = !!a.enabled;
+      if (v !== cur.archive.enabled) {
+        next.archive.enabled = v;
+        restart = true;
+      }
+    }
+    if (a.bitrate !== undefined) {
+      const v = parseInt(a.bitrate, 10);
+      if (!Number.isFinite(v) || !ARCHIVE_BITRATE_SET.has(v)) {
+        throw new Error(
+          `archive.bitrate must be one of: ${ARCHIVE_BITRATES.join(', ')}`,
+        );
+      }
+      if (v !== cur.archive.bitrate) {
+        next.archive.bitrate = v;
+        restart = true;
+      }
+    }
+  }
   if ('weather' in patch) {
     const w = patch.weather || {};
     if (w.lat !== undefined) {
@@ -1288,20 +1335,29 @@ export function agentPersonaPreamble(persona, { rules = true } = {}) {
   return rules ? `${opener}` : opener;
 }
 
-// Liquidsoap reads two tiny text files instead of JSON.
+// Liquidsoap reads tiny text files instead of JSON.
 const LIQ_JINGLE_RATIO_PATH = `${STATE_DIR}/liquidsoap_jingle_ratio.txt`;
 const LIQ_CROSSFADE_PATH = `${STATE_DIR}/liquidsoap_crossfade.txt`;
+const LIQ_ARCHIVE_ENABLED_PATH = `${STATE_DIR}/liquidsoap_archive_enabled.txt`;
+const LIQ_ARCHIVE_BITRATE_PATH = `${STATE_DIR}/liquidsoap_archive_bitrate.txt`;
 
 export async function writeLiquidsoapSettings(s) {
   await writeFile(LIQ_JINGLE_RATIO_PATH, String(s.jingleRatio));
   await writeFile(LIQ_CROSSFADE_PATH, String(s.crossfadeDuration));
+  await writeFile(LIQ_ARCHIVE_ENABLED_PATH, s.archive.enabled ? 'true' : 'false');
+  await writeFile(LIQ_ARCHIVE_BITRATE_PATH, String(s.archive.bitrate));
 }
 
 // Called from server.js startup so the files exist before Liquidsoap reads
 // them on its next start. Idempotent.
 export async function ensureLiquidsoapSettingsFile() {
   const s = await load();
-  if (!existsSync(LIQ_JINGLE_RATIO_PATH) || !existsSync(LIQ_CROSSFADE_PATH)) {
+  if (
+    !existsSync(LIQ_JINGLE_RATIO_PATH) ||
+    !existsSync(LIQ_CROSSFADE_PATH) ||
+    !existsSync(LIQ_ARCHIVE_ENABLED_PATH) ||
+    !existsSync(LIQ_ARCHIVE_BITRATE_PATH)
+  ) {
     await writeLiquidsoapSettings(s);
   }
 }

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -2,7 +2,7 @@
 # Reads a JSON queue file written by the Node.js controller,
 # crossfades, ducks DJ voice over song intros, falls back to autonomous playlist.
 
-settings.log.level := 4
+settings.log.level := 3
 settings.log.file := true
 settings.log.file.path := "/var/log/liquidsoap/radio.log"
 
@@ -20,6 +20,8 @@ settings.server.telnet.port := 1234
 
 jingle_ratio = ref(30)
 crossfade_duration = ref(10.0)
+archive_enabled = ref(true)
+archive_bitrate = ref(128)
 
 if file.exists("/var/sub-wave/liquidsoap_jingle_ratio.txt") then
   raw = string.trim(file.contents("/var/sub-wave/liquidsoap_jingle_ratio.txt"))
@@ -33,7 +35,18 @@ if file.exists("/var/sub-wave/liquidsoap_crossfade.txt") then
   if v >= 0.0 then crossfade_duration := v end
 end
 
-log("settings loaded: jingle_ratio=#{jingle_ratio()} crossfade_duration=#{crossfade_duration()}")
+if file.exists("/var/sub-wave/liquidsoap_archive_enabled.txt") then
+  raw = string.trim(file.contents("/var/sub-wave/liquidsoap_archive_enabled.txt"))
+  archive_enabled := (raw == "true")
+end
+
+if file.exists("/var/sub-wave/liquidsoap_archive_bitrate.txt") then
+  raw = string.trim(file.contents("/var/sub-wave/liquidsoap_archive_bitrate.txt"))
+  v = int_of_string(default=128, raw)
+  if v > 0 then archive_bitrate := v end
+end
+
+log("settings loaded: jingle_ratio=#{jingle_ratio()} crossfade_duration=#{crossfade_duration()} archive_enabled=#{archive_enabled()} archive_bitrate=#{archive_bitrate()}")
 
 # ---------------------------------------------------------------------------
 # HTTP(S) FETCH OVERRIDE — Liquidsoap's built-in http.get.stream returns
@@ -544,14 +557,30 @@ end
 # On air at startup.
 stream_up()
 
-# Optional: also output to local file for archiving / podcast generation
-output.file(
-  %mp3(bitrate=128),
-  fallible=true,
-  reopen_when={0m0s},
-  "/var/sub-wave/archive/%Y-%m-%d/%H-00.mp3",
-  radio
-)
+# Optional: hourly archive to /var/sub-wave/archive/. A second MP3 encoder
+# running 24/7 is the single biggest CPU cost in the broadcast container —
+# guard the entire output so operators who don't use the archives don't pay
+# for the encoder. Bitrate is selected from a fixed set because `%mp3(bitrate=…)`
+# requires a literal int at parse time (we can't pass a ref).
+archive_path = "/var/sub-wave/archive/%Y-%m-%d/%H-00.mp3"
+if archive_enabled() then
+  br = archive_bitrate()
+  if br <= 64 then
+    output.file(%mp3(bitrate=64), fallible=true, reopen_when={0m0s}, archive_path, radio)
+  elsif br <= 96 then
+    output.file(%mp3(bitrate=96), fallible=true, reopen_when={0m0s}, archive_path, radio)
+  elsif br <= 128 then
+    output.file(%mp3(bitrate=128), fallible=true, reopen_when={0m0s}, archive_path, radio)
+  elsif br <= 160 then
+    output.file(%mp3(bitrate=160), fallible=true, reopen_when={0m0s}, archive_path, radio)
+  elsif br <= 192 then
+    output.file(%mp3(bitrate=192), fallible=true, reopen_when={0m0s}, archive_path, radio)
+  else
+    output.file(%mp3(bitrate=320), fallible=true, reopen_when={0m0s}, archive_path, radio)
+  end
+else
+  log("Hourly archive disabled — set archive.enabled=true in settings to re-enable")
+end
 
 # ---------------------------------------------------------------------------
 # CONTROL — custom telnet command for the controller to trigger a restart

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -117,9 +117,19 @@ interface ScrobbleForm {
   listenbrainz: ScrobbleListenbrainzForm;
 }
 
+interface ArchiveForm {
+  enabled: boolean;
+  bitrate: string;
+}
+
+// Keep in sync with ARCHIVE_BITRATES in controller/src/settings.ts — radio.liq
+// has a literal `%mp3(bitrate=…)` branch per value, so this set is fixed.
+const ARCHIVE_BITRATES = [64, 96, 128, 160, 192, 320] as const;
+
 interface FormState {
   jingleRatio: string;
   crossfadeDuration: string;
+  archive: ArchiveForm;
   station: string;
   weather: WeatherCfg;
   tts: TtsForm;
@@ -153,6 +163,7 @@ interface SettingsData {
   values?: {
     jingleRatio?: number;
     crossfadeDuration?: number;
+    archive?: { enabled?: boolean; bitrate?: number };
     station?: string;
     weather?: { lat?: number; lng?: number; locationName?: string };
     tts?: {
@@ -241,6 +252,10 @@ export default function SettingsPanel() {
     setForm({
       jingleRatio: String(v.jingleRatio ?? ''),
       crossfadeDuration: String(v.crossfadeDuration ?? ''),
+      archive: {
+        enabled: v.archive?.enabled ?? true,
+        bitrate: String(v.archive?.bitrate ?? 128),
+      },
       station: v.station ?? '',
       weather: {
         lat: String(v.weather?.lat ?? ''),
@@ -581,6 +596,89 @@ export default function SettingsPanel() {
                   <div className="field-hint">
                     Seconds of overlap between tracks (current: {data?.values?.crossfadeDuration}s).
                     Saving flags a pending restart — apply it with the Mixer card below.
+                  </div>
+                </div>
+              </Card>
+            )}
+
+            {form && (
+              <Card title="Hourly archive" sub="state/archive/%Y-%m-%d/%H-00.mp3">
+                <div className="grid gap-3">
+                  <div className="field">
+                    <div className="flex items-center gap-2">
+                      <Label>Record the broadcast to disk</Label>
+                      <Pill tone="ink">restart required</Pill>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Seg
+                        options={[
+                          { id: 'on', label: 'On' },
+                          { id: 'off', label: 'Off' },
+                        ]}
+                        value={form.archive.enabled ? 'on' : 'off'}
+                        onChange={id =>
+                          setForm(f =>
+                            f ? { ...f, archive: { ...f.archive, enabled: id === 'on' } } : f,
+                          )
+                        }
+                      />
+                      <Btn
+                        sm
+                        onClick={() =>
+                          saveSettings({ archive: { enabled: form.archive.enabled } })
+                        }
+                        disabled={busy}
+                      >
+                        Save
+                      </Btn>
+                    </div>
+                    <div className="field-hint">
+                      The archive runs a second MP3 encoder 24/7 and is the biggest constant
+                      CPU cost in the broadcast container — turn it off if you don't replay
+                      the hourly tapes (issue #137).
+                    </div>
+                  </div>
+
+                  <div className="field">
+                    <div className="flex items-center gap-2">
+                      <Label>Archive bitrate</Label>
+                      <Pill tone="ink">restart required</Pill>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Select
+                        value={form.archive.bitrate}
+                        onValueChange={v =>
+                          setForm(f => (f ? { ...f, archive: { ...f.archive, bitrate: v } } : f))
+                        }
+                      >
+                        <SelectTrigger className="w-32" disabled={!form.archive.enabled}>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {ARCHIVE_BITRATES.map(br => (
+                            <SelectItem key={br} value={String(br)}>
+                              {br} kbps
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Btn
+                        sm
+                        onClick={() =>
+                          saveSettings({
+                            archive: { bitrate: parseInt(form.archive.bitrate, 10) },
+                          })
+                        }
+                        disabled={busy || !form.archive.enabled}
+                      >
+                        Save bitrate
+                      </Btn>
+                    </div>
+                    <div className="field-hint">
+                      Lower bitrate = smaller archives, less encoder CPU
+                      (current: {data?.values?.archive?.bitrate ?? '—'} kbps). 128 kbps is the
+                      original default.
+                    </div>
                   </div>
                 </div>
               </Card>


### PR DESCRIPTION
## Summary

Two CPU-reduction changes for the broadcast container (issue #137):

- **Liquidsoap log level 4 → 3.** Was debug, now info. Same diagnostic signal, far less constant log churn on every poll/metadata event.
- **Hourly archive is now toggleable.** A second MP3 encoder running 24/7 is the largest constant CPU cost in the broadcast container. New settings `archive.enabled` (default `true`) and `archive.bitrate` (default `128`, chosen from `64/96/128/160/192/320 kbps`) let operators who don't use the hourly tapes turn the encoder off — or just drop the bitrate.

Default behaviour is unchanged for existing installs: archive stays on at 128 kbps, no migration needed.

`%mp3(bitrate=…)` needs a literal int at parse time, so `radio.liq` branches across a fixed bitrate set rather than passing a ref. The admin UI exposes the same set.

## Test plan

- [ ] Fresh install: `archive` defaults to `{ enabled: true, bitrate: 128 }`; `state/liquidsoap_archive_*.txt` files exist; hourly archive writes as before.
- [ ] Toggle archive off in admin → restart mixer → `state/archive/` stops accumulating new hours; existing archives still listed in the Archives panel.
- [ ] Change bitrate to 64 → restart mixer → next archive file is encoded at 64 kbps.
- [ ] Verify broadcast container CPU drops measurably with archive off (the actual ask in #137).
- [ ] Log file (`/var/log/liquidsoap/radio.log`) shows info-level entries, no debug spam.

Closes #137.