### PR TITLE
feat(admin): audio preview for jingles and sound effects

### DIFF
--- a/controller/src/broadcast/jingles.ts
+++ b/controller/src/broadcast/jingles.ts
@@ -66,6 +66,17 @@ export async function list() {
   return out;
 }
 
+// Absolute path to a jingle's audio file, or null if the filename isn't in
+// the sidecar or the file is missing on disk. Looking it up via the sidecar
+// (instead of joining DIR + the raw param) is what makes path traversal a
+// non-issue — `..` slugs simply won't match a key.
+export async function getPath(filename: string): Promise<string | null> {
+  const meta = await loadMeta();
+  if (!meta.items[filename]) return null;
+  const filePath = `${DIR}/${filename}`;
+  return (await statOrNull(filePath)) ? filePath : null;
+}
+
 export async function create(text: string, { builtin = false }: { builtin?: boolean } = {}) {
   if (!text || !text.trim()) throw new Error('Empty jingle text');
   await mkdir(DIR, { recursive: true });

--- a/controller/src/routes/jingles.ts
+++ b/controller/src/routes/jingles.ts
@@ -40,6 +40,19 @@ router.delete('/jingles/:filename', requireAdmin, async (req, res) => {
   }
 });
 
+// Admin preview — streams the rendered WAV so the operator can audition a
+// jingle before it goes on air. Resolved through jingles.getPath so the
+// filename has to match a sidecar entry (no path traversal).
+router.get('/jingles/:filename/audio', requireAdmin, async (req, res) => {
+  try {
+    const filePath = await jingles.getPath(req.params.filename);
+    if (!filePath) return res.status(404).json({ error: 'unknown jingle' });
+    res.type('audio/wav').sendFile(filePath);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ---------------------------------------------------------------------------
 // TAG-LIBRARY — kick off the tagger as a background child process.
 // Polls /settings to see progress (library.total grows; tagger.running flips).

--- a/controller/src/routes/sfx.ts
+++ b/controller/src/routes/sfx.ts
@@ -40,3 +40,15 @@ router.delete('/sfx/:name', requireAdmin, async (req, res) => {
     res.status(400).json({ error: err.message });
   }
 });
+
+// Admin preview — streams the rendered MP3 so the operator can audition an
+// effect before letting the agent reach for it.
+router.get('/sfx/:name/audio', requireAdmin, async (req, res) => {
+  try {
+    const filePath = await sfx.getPath(req.params.name);
+    if (!filePath) return res.status(404).json({ error: 'unknown sound effect' });
+    res.type('audio/mpeg').sendFile(filePath);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -497,7 +497,7 @@ export default function SettingsPanel() {
                 data={data} form={form} setForm={updateForm} busy={busy}
                 jingleText={jingleText} setJingleText={setJingleText}
                 createJingle={createJingle} saveSettings={saveSettings}
-                onDelete={setConfirmDelete}
+                onDelete={setConfirmDelete} adminFetch={adminFetch}
               />
             )}
             {activeSection === 'scrobble' && (
@@ -513,7 +513,7 @@ export default function SettingsPanel() {
           <SfxSection
             sfxData={sfxData} sfxForm={sfxForm} setSfxForm={setSfxForm}
             busy={busy} createSfx={createSfx} onDelete={setConfirmDeleteSfx}
-            data={data} saveSettings={saveSettings}
+            data={data} saveSettings={saveSettings} adminFetch={adminFetch}
           />
         )}
         {activeSection === 'danger' && (
@@ -1570,6 +1570,76 @@ function StationSection({ data, form, setForm, busy, saveSettings }: SectionProp
   );
 }
 
+/* ── Preview button ──────────────────────────────────────────────────── */
+
+// Module-level "now previewing" handle so a second press anywhere on the
+// admin page stops the first clip — no overlapping audio.
+let currentPreview: { audio: HTMLAudioElement; url: string; stop: () => void } | null = null;
+
+interface PreviewButtonProps {
+  path: string;
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+  label?: string;
+}
+
+// Audio files behind /api/jingles/.../audio and /api/sfx/.../audio are
+// admin-gated (HTTP Basic). A plain <audio src> can't send the header, so
+// we fetch the bytes via adminFetch, hand them to <Audio> as a Blob URL,
+// and revoke the URL when playback ends.
+function PreviewButton({ path, adminFetch, label = 'Play' }: PreviewButtonProps) {
+  const [state, setState] = useState<'idle' | 'loading' | 'playing'>('idle');
+
+  useEffect(() => {
+    return () => {
+      // Unmounting (e.g. row deleted while previewing) — make sure we
+      // don't leak the audio element or the object URL.
+      if (currentPreview && currentPreview.audio.dataset.owner === path) {
+        currentPreview.stop();
+      }
+    };
+  }, [path]);
+
+  const onClick = async () => {
+    if (state === 'playing') {
+      currentPreview?.stop();
+      return;
+    }
+    if (state === 'loading') return;
+    setState('loading');
+    try {
+      const r = await adminFetch(path);
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const blob = await r.blob();
+      const url = URL.createObjectURL(blob);
+      const audio = new Audio(url);
+      audio.dataset.owner = path;
+      const stop = () => {
+        audio.pause();
+        URL.revokeObjectURL(url);
+        if (currentPreview?.audio === audio) currentPreview = null;
+        setState('idle');
+      };
+      audio.addEventListener('ended', stop);
+      audio.addEventListener('error', stop);
+      currentPreview?.stop();
+      currentPreview = { audio, url, stop };
+      await audio.play();
+      setState('playing');
+    } catch (err) {
+      notify.err(`Preview failed: ${errorMessage(err)}`);
+      setState('idle');
+    }
+  };
+
+  const text = state === 'playing' ? 'Stop' : state === 'loading' ? '…' : label;
+
+  return (
+    <Btn sm onClick={onClick} title="Preview audio">
+      {text}
+    </Btn>
+  );
+}
+
 /* ── Jingles ─────────────────────────────────────────────────────────── */
 
 interface JinglesSectionProps extends SectionProps {
@@ -1577,11 +1647,12 @@ interface JinglesSectionProps extends SectionProps {
   setJingleText: (s: string) => void;
   createJingle: () => void;
   onDelete: (filename: string | null) => void;
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
 }
 
 function JinglesSection({
   data, form, setForm, busy, jingleText, setJingleText,
-  createJingle, saveSettings, onDelete,
+  createJingle, saveSettings, onDelete, adminFetch,
 }: JinglesSectionProps) {
   const ratioDirty = form.jingleRatio !== String(data.values?.jingleRatio);
   const jingles = data.jingles || [];
@@ -1672,15 +1743,21 @@ function JinglesSection({
                 {j.builtin && <Pill tone="accent">builtin</Pill>}
               </div>
             </div>
-            <Btn
-              sm
-              tone="danger"
-              onClick={() => onDelete(j.filename)}
-              disabled={busy || j.builtin}
-              title={j.builtin ? "Can't delete the built-in ident" : 'Delete this jingle'}
-            >
-              Delete
-            </Btn>
+            <div className="flex items-center gap-2">
+              <PreviewButton
+                path={`/jingles/${encodeURIComponent(j.filename)}/audio`}
+                adminFetch={adminFetch}
+              />
+              <Btn
+                sm
+                tone="danger"
+                onClick={() => onDelete(j.filename)}
+                disabled={busy || j.builtin}
+                title={j.builtin ? "Can't delete the built-in ident" : 'Delete this jingle'}
+              >
+                Delete
+              </Btn>
+            </div>
           </div>
         ))}
       </Card>
@@ -1699,9 +1776,10 @@ interface SfxSectionProps {
   onDelete: (name: string | null) => void;
   data: SettingsData | null;
   saveSettings: SaveSettings;
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
 }
 
-function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, onDelete, data, saveSettings }: SfxSectionProps) {
+function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, onDelete, data, saveSettings, adminFetch }: SfxSectionProps) {
   if (!sfxData) {
     return <div className="text-[13px] text-muted italic">loading…</div>;
   }
@@ -1838,15 +1916,21 @@ function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, onDelete, d
                 {s.builtin && <Pill tone="accent">builtin</Pill>}
               </div>
             </div>
-            <Btn
-              sm
-              tone="danger"
-              onClick={() => onDelete(s.name)}
-              disabled={busy || s.builtin}
-              title={s.builtin ? "Can't delete a built-in effect" : 'Delete this effect'}
-            >
-              Delete
-            </Btn>
+            <div className="flex items-center gap-2">
+              <PreviewButton
+                path={`/sfx/${encodeURIComponent(s.name)}/audio`}
+                adminFetch={adminFetch}
+              />
+              <Btn
+                sm
+                tone="danger"
+                onClick={() => onDelete(s.name)}
+                disabled={busy || s.builtin}
+                title={s.builtin ? "Can't delete a built-in effect" : 'Delete this effect'}
+              >
+                Delete
+              </Btn>
+            </div>
           </div>
         ))}
       </Card>


### PR DESCRIPTION
## Summary

- Adds a **Play** button next to each row in the admin Jingles and Sound FX panels so operators can audition stingers before they go on air, instead of waiting to catch one on the broadcast.
- Backend exposes the rendered audio over two admin-gated routes (`GET /jingles/:filename/audio`, `GET /sfx/:name/audio`) that resolve the filename through the existing sidecar metadata, so the param can't path-traverse.
- Frontend pulls the bytes through `adminFetch` as a Blob (since `<audio src>` can't carry HTTP Basic) and uses a module-level singleton so a second press anywhere on the page stops the first clip — no overlapping audio.

Closes the jingle/SFX preview half of #136. The persona TTS preview (other half of that issue) is still TODO.

## Test plan

- [x] Open `/admin/settings` → Jingles section, click ▶ on a jingle → audio plays, button flips to **Stop**
- [x] Click ▶ on a different jingle while one is playing → first stops, second starts
- [x] Open Sound FX section, repeat the same checks
- [x] Confirm path-traversal: `curl -u admin:pass http://localhost:7700/api/jingles/..%2Fsettings.json/audio` returns 404
- [x] Confirm gating: hitting the new routes without admin creds returns 401