### PR TITLE
feat(broadcast): DJ transition library (Phase 1)

### DIFF
--- a/docs/dj-track-transitions-plan.md
+++ b/docs/dj-track-transitions-plan.md
@@ -1,0 +1,259 @@
+# DJ track transitions — plan
+
+Today there is exactly one move between tracks: a symmetric equal-amplitude
+crossfade, `crossfade_duration` long, the same shape every time. This plan
+gives the station a small **library of DJ-style transitions** in
+`liquidsoap/radio.liq` and then lets the **LLM picker choose one per
+transition**, alongside the track itself, reusing the `annotate:` URI
+that already carries metadata into Liquidsoap. No new IPC channels, no
+new model calls — one extra field on the existing picker output.
+
+## TL;DR
+
+Two phases on the `claude/dj-track-transitions-4zZow` branch:
+
+1. **Phase 1 — instrument.** Add a library of 5–6 named transitions in
+   `radio.liq` (`fade`, `long_blend`, `echo_tail`, `eq_swap`,
+   `filter_sweep`, `hard_cut`). Pick the style randomly per transition,
+   read from `next.metadata["transition"]` if present. Ship it on its
+   own — the station already sounds better than the symmetric fade.
+2. **Phase 2 — let the AI play it.** Add a `transition` field to
+   `pickNextTrack`'s Zod schema in `controller/src/llm/dj.ts`, plumb it
+   through `getAnnotatedUri()` in `controller/src/music/subsonic.ts`
+   into the `annotate:` URI as `transition="…",liq_cross_duration="…"`,
+   and let `dj_transition` in `radio.liq` dispatch off the metadata.
+   The same call that already decides *which* track plays next now also
+   decides *how* it lands.
+
+Build the instrument before letting the AI play it. Phase 1 is shippable
+on its own; phase 2 is a small additive layer on top.
+
+## Why this slots in cleanly
+
+Three properties of the existing pipeline make this almost-free:
+
+- **`annotate:` URI already carries per-track metadata.** Liquidsoap's
+  `cross` callback receives `next.metadata` and Liquidsoap honours
+  `liq_cross_duration` as a per-track override of the cross buffer
+  width. Anything we put into the annotate URI is readable inside
+  `dj_transition(a, b)`.
+- **`getAnnotatedUri()` is one function.** Every track that reaches
+  Liquidsoap goes through `controller/src/music/subsonic.ts:263`. Add
+  two fields there, done.
+- **The picker already has the context.** `dj.pickNextTrack` already
+  sees the outgoing track, mood, time-of-day, recent plays, candidate
+  energy/mood tags. The transition decision is downstream of exactly
+  the same context — energy delta, genre shift, narrative beat — so
+  adding it is one more schema field, not a new agent call.
+
+## Phase 1 — transition library in `radio.liq`
+
+Replace the single `dj_transition` definition (`liquidsoap/radio.liq:149-154`)
+with a dispatcher that picks one of several pre-built transition
+functions. For Phase 1, pick at random; for Phase 2, read from
+`b.metadata["transition"]` and fall through to random when absent.
+
+Proposed styles (all sum to ~unity at midpoint — that invariant is
+non-negotiable, see existing comment at radio.liq:117-129):
+
+| Style          | Duration  | Shape                                                                 |
+| -------------- | --------- | --------------------------------------------------------------------- |
+| `fade`         | 8–10 s    | The current symmetric equal-amplitude fade. The floor.                |
+| `long_blend`   | 12–16 s   | Same shape, longer buffer. For chill→chill, low-energy continuity.    |
+| `quick_fade`   | 3–4 s     | Same shape, shorter buffer. For tight, talky, high-energy stretches.  |
+| `echo_tail`    | 6 s       | Outgoing fades into an `echo(delay=0.25, feedback=0.4)`; incoming clean. |
+| `filter_sweep` | 6 s       | Outgoing low-pass cutoff sweeps 20 kHz → 200 Hz over the fade.        |
+| `hard_cut`     | 0 s       | `cross(duration=0)` for this transition. For "and now…" smash cuts.   |
+
+`reverb_bloom` is a candidate sixth (lush hall on the outgoing tail);
+parking it until we know whether the Phase 1 set covers enough range.
+
+### IIR filter constraint
+
+`filter_sweep` and `echo_tail` involve filters/effects on a
+`request.queue`-backed source — the same pattern that triggered "Early
+computation of source content-type" historically (see radio.liq:140-148
+and the mic chain comment at radio.liq:264-266). Mitigations, in order
+of preference:
+
+1. **Apply the effect on the pre-cross `music_meta` handle** — same
+   trick the on_metadata hook uses to dodge the post-cross
+   double-fire. Run the effect on the full music bus and modulate its
+   wet/dry from `dj_transition` via a getter-controlled ref, instead
+   of instantiating fresh filters per transition.
+2. **Use `chain` / pre-instantiated operators** with a ref-controlled
+   gain rather than building the operator graph inside the transition
+   callback.
+3. If a style still trips the error in practice, drop it from the
+   library and keep the working ones. The picker's enum is the source
+   of truth, so removing a style is a one-line change.
+
+This needs to be tried in the running broadcast container — predicting
+which styles will compile is unreliable, the historical failure was
+runtime, not parse-time.
+
+### Picking randomly in Phase 1
+
+Existing code in `radio.liq` already has `crossfade_duration` as a
+ref, and the controller writes `liquidsoap_crossfade.txt` for the
+default. Phase 1 keeps that as the floor: when no style is selected
+(or the random roll lands on `fade`), behaviour is unchanged.
+
+Random weighting: bias toward `fade` and `long_blend` (~60% combined)
+so the station still feels like a station, with the more characterful
+moves (`echo_tail`, `filter_sweep`, `hard_cut`) at ~10% each. Phase 2
+lets the picker bias smarter.
+
+## Phase 2 — let the picker choose
+
+### Schema change
+
+`controller/src/llm/dj.ts:392-395`, extend the picker's structured-output
+schema:
+
+```ts
+schema: z.object({
+  id: z.string().describe('the exact id of one candidate'),
+  reason: z.string().describe('one short sentence on why this one'),
+  transition: z.enum([
+    'fade', 'long_blend', 'quick_fade',
+    'echo_tail', 'filter_sweep', 'hard_cut',
+  ]).default('fade').describe('how to mix from the outgoing track'),
+  cross_seconds: z.number().min(0).max(16).default(8)
+    .describe('cross buffer length in seconds; ignored for hard_cut'),
+})
+```
+
+System prompt addition (kept short, the picker prompt is already
+long): one paragraph describing when each style fits. Energy delta is
+the load-bearing signal — `hard_cut` for big rises, `long_blend` for
+flat low-energy continuity, `filter_sweep`/`echo_tail` for
+characterful gear-changes.
+
+### Plumbing
+
+`controller/src/music/picker.ts:281-285`, return the transition along
+with the song:
+
+```ts
+return {
+  song: chosen,
+  reason: pickRaw.reason || null,
+  source: chosen._source,
+  transition: pickRaw.transition,
+  crossSeconds: pickRaw.cross_seconds,
+};
+```
+
+`controller/src/broadcast/dj-agent.ts` — pass `transition` /
+`crossSeconds` through into the queue item. `controller/src/broadcast/queue.ts`
+(the queue's track-item shape) carries it onto the item.
+
+`controller/src/music/subsonic.ts:263-273`, extend
+`getAnnotatedUri(song, opts?)`:
+
+```ts
+export function getAnnotatedUri(song, opts: { transition?: string; crossSeconds?: number } = {}) {
+  const fields = [
+    `title="${escAnnotate(song.title)}"`,
+    `artist="${escAnnotate(song.artist)}"`,
+    `album="${escAnnotate(song.album)}"`,
+    `subsonic_id="${escAnnotate(song.id)}"`,
+  ];
+  if (song.year) fields.push(`year="${escAnnotate(song.year)}"`);
+  if (song.genre) fields.push(`genre="${escAnnotate(song.genre)}"`);
+  if (opts.transition) fields.push(`transition="${escAnnotate(opts.transition)}"`);
+  if (opts.crossSeconds != null) fields.push(`liq_cross_duration="${opts.crossSeconds}"`);
+  return `annotate:${fields.join(',')}:${getPlayableUri(song)}`;
+}
+```
+
+`drainToLiquidsoap()` in `queue.ts:307` becomes:
+
+```ts
+const uri = subsonic.getAnnotatedUri(item.track, {
+  transition: item.transition,
+  crossSeconds: item.crossSeconds,
+});
+```
+
+### Liquidsoap dispatcher
+
+In `radio.liq`, `dj_transition(a, b)` reads `b.metadata["transition"]`
+and dispatches. `liq_cross_duration` is honoured by `cross` natively —
+no glue needed for the duration field; the per-track value overrides
+the buffer width for that one transition.
+
+Fallback chain: unknown / missing transition → `fade`. Whatever the
+LLM emits, the station never breaks.
+
+### Fallbacks and validation
+
+- Pool picker's hard fallback path (`controller/src/music/picker.ts:262-267`,
+  the `LLM failed outright` branch) returns no `transition`, which
+  falls through to the random Phase 1 picker. Good — failure mode is
+  "Phase 1 station", not "broken station".
+- Zod default keeps old picker outputs valid even if a provider strips
+  the field. No migration needed.
+- Schema is small (one enum + one number), so the structured-output
+  reliability risk is minimal; this is the same surface area as the
+  request matcher's existing fields.
+
+## What we're explicitly NOT doing
+
+- **Real beatmatching.** Liquidsoap can theoretically time-stretch on
+  BPM metadata, but every track would need pre-analysis (BPM +
+  downbeat), the catalogue isn't mastered for it, and the failure
+  modes are ugly. Not worth it for a one-listener-at-a-time station.
+- **Loudness-aware fade scaling inside a fixed buffer.** Already tried,
+  already in the git log (caused the audible "slap-back echo /
+  doubling" — see radio.liq:117-129). Vary the *buffer length*
+  (`cross_seconds`), never the fade duration inside a fixed buffer.
+- **Adding a second LLM call.** The picker already has the full
+  context. Doubling the LLM cost per transition for a stylistic
+  choice would be wasteful — and worse, would split the decision
+  across two prompts that don't share state.
+- **RMS sidechain ducking.** Killed before (see f38a9af). The
+  voice-ducking layer is untouched by this work — `smooth_add` stays
+  exactly as it is. The transitions are about music-to-music handoff,
+  not voice handoff.
+- **New IPC files.** Everything rides the annotate URI we already
+  write to `next.txt`. The `liquidsoap_crossfade.txt` global still
+  exists as the floor / default; per-transition overrides come in via
+  `liq_cross_duration` annotation, no new poller.
+
+## Open questions
+
+- **Which transition styles compile.** `filter_sweep` and `echo_tail`
+  are the IIR-adjacent ones. Needs to be tried in a running
+  `broadcast` container. Worst case: ship Phase 1 with only the
+  amplitude-based styles (`fade`, `long_blend`, `quick_fade`,
+  `hard_cut`) and add filter-based ones later if the constraint can
+  be worked around.
+- **Whether `hard_cut` is bearable at 0 s without beat alignment.**
+  Probably yes for genre shifts and on `:00`/`:30` boundaries; maybe
+  no inside a coherent mood block. The picker can learn to use it
+  sparingly via prompt tuning; Phase 1 weights it low.
+- **Per-style mic chain interaction.** Voice ducking (`smooth_add`)
+  fires on the music bus regardless of which transition is running.
+  If a DJ link starts mid-`filter_sweep`, the filter is on the music
+  going into the duck, which should be fine — the duck is amplitude,
+  not spectral. Verify in practice.
+
+## Rollout
+
+- **Phase 1 commit on the branch:** transition library + random
+  picker in `radio.liq` only. Test by listening to the dev stack for
+  an hour with a wide mood mix. Adjust style weights, drop any
+  styles that don't compile or sound bad.
+- **Phase 2 commit on the same branch:** schema + plumbing changes,
+  picker prompt update. The dispatcher in `radio.liq` flips from
+  "random" to "read metadata, fall back to random."
+- **Open the PR after both phases land** so the change is reviewable
+  as one DJ-transitions feature, not two half-features.
+
+No DB migration, no settings.json change, no Liquidsoap restart
+mechanism beyond the existing rebuild flow (`docker compose up -d
+--build broadcast` for prod; dev hot-reloads the bind-mounted
+`radio.liq` with `docker compose -f docker-compose.dev.yml restart
+broadcast`).

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -146,11 +146,91 @@ music = fallback(
 # chain does (see comment above mic_chain). The fix would be to put a
 # getter-controlled filter on the music source BEFORE `cross` and modulate
 # its cutoff from a transition trigger. Parked until needed.
-def dj_transition(a, b) =
+
+# ---------------------------------------------------------------------------
+# TRANSITION LIBRARY — small set of named transition shapes
+# ---------------------------------------------------------------------------
+# Each `tx_*` is a (a, b) -> source variant of dj_transition. The dispatcher
+# below picks one per transition. Phase 1: random weighted choice; Phase 2:
+# the controller writes `transition="…"` into the annotate URI and we read
+# `b.metadata["transition"]` instead of rolling.
+#
+# Constraint: the cross BUFFER width is set when `cross(...)` is constructed
+# below (= crossfade_duration()). It can only be varied per-track by writing
+# `liq_cross_duration` metadata on the INCOMING track — which the controller
+# doesn't do yet. So the variants here all vary the fade SHAPE within the
+# existing buffer; `long_blend` (wants 12-16s) and `filter_sweep` (needs the
+# pre-cross IIR mitigation) are deferred to Phase 2.
+
+# Symmetric equal-amplitude fade across the full cross window — the floor.
+# Same shape as the historic single dj_transition; sums to ~unity at midpoint.
+def tx_fade(a, b) =
   d = crossfade_duration()
-  a_source = fade.out(duration=d, initial_metadata=a.metadata, a.source)
-  b_source = fade.in(duration=d, initial_metadata=b.metadata, b.source)
-  add(normalize=false, [a_source, b_source])
+  add(normalize=false, [
+    fade.out(duration=d, initial_metadata=a.metadata, a.source),
+    fade.in(duration=d, initial_metadata=b.metadata, b.source)
+  ])
+end
+
+# Narrower fade in the middle of the buffer. Outgoing dips to 0 in `short` s,
+# incoming reaches full in `short` s; the rest of the buffer is silence from
+# outgoing under full-volume incoming. Sharper handoff for talky / high-energy.
+def tx_quick_fade(a, b) =
+  d = crossfade_duration()
+  short = if d < 4.0 then d else 4.0 end
+  add(normalize=false, [
+    fade.out(duration=short, initial_metadata=a.metadata, a.source),
+    fade.in(duration=short, initial_metadata=b.metadata, b.source)
+  ])
+end
+
+# Outgoing fades out THROUGH a slap-back echo (tap delay with feedback);
+# incoming fades in clean over the full window. `echo` is a delay line, not
+# an `iir_filter` — the request.queue content-type breakage that hit the
+# old low-pass attempt doesn't apply here. If this style ever does trip
+# "Early computation", drop the weight to 0 in the dispatcher.
+def tx_echo_tail(a, b) =
+  d = crossfade_duration()
+  a_echoed = echo(delay=0.25, feedback=0.4, ping_pong=false, a.source)
+  add(normalize=false, [
+    fade.out(duration=d, initial_metadata=a.metadata, a_echoed),
+    fade.in(duration=d, initial_metadata=b.metadata, b.source)
+  ])
+end
+
+# Punchy switch — outgoing fades out in 0.3s, incoming hits full in 0.1s.
+# Not a true 0s cut (cross still buffers `d` seconds), but the audible
+# handover lands in the first ~0.3s of the buffer. Genre-shift smash-cut.
+def tx_hard_cut(a, b) =
+  add(normalize=false, [
+    fade.out(duration=0.3, initial_metadata=a.metadata, a.source),
+    fade.in(duration=0.1, initial_metadata=b.metadata, b.source)
+  ])
+end
+
+# Dispatcher. Reads b.metadata["transition"] first (Phase 2 will write it);
+# otherwise rolls weighted random. Unknown / missing → tx_fade, so the
+# station can never break because the picker emitted an unknown enum value.
+#
+# Weights: fade-family is the floor (75% combined); characterful moves at
+# 15% / 10%. Phase 2 lets the picker bias these per-track.
+def dj_transition(a, b) =
+  chosen = b.metadata["transition"]
+  style =
+    if chosen != "" then chosen
+    else
+      r = random.float(min=0.0, max=1.0)
+      if r < 0.50 then "fade"
+      elsif r < 0.75 then "quick_fade"
+      elsif r < 0.90 then "echo_tail"
+      else "hard_cut" end
+    end
+  source = if chosen != "" then "picker" else "random" end
+  log("dj_transition: style=#{style} source=#{source}")
+  if style == "quick_fade" then tx_quick_fade(a, b)
+  elsif style == "echo_tail" then tx_echo_tail(a, b)
+  elsif style == "hard_cut"  then tx_hard_cut(a, b)
+  else tx_fade(a, b) end
 end
 
 # Keep a handle on the PRE-cross music source so the on_metadata hook


### PR DESCRIPTION
## Summary

Phase 1 of the [DJ track transitions plan](docs/dj-track-transitions-plan.md): replaces the single symmetric crossfade with a small library of named transition shapes, picked randomly per transition. Sets up the dispatcher to read `b.metadata["transition"]` so Phase 2 (LLM-picked transitions) is pure plumbing on top.

**Four shipped styles** (all within the existing cross buffer):

| Style        | Weight | Shape                                                                 |
| ------------ | ------ | --------------------------------------------------------------------- |
| `fade`       | 50%    | Symmetric equal-amplitude across full buffer — the current behaviour. |
| `quick_fade` | 25%    | Narrower fade in the middle of the buffer — sharper handoff.          |
| `echo_tail`  | 15%    | Outgoing fades out through a slap-back echo; incoming clean.          |
| `hard_cut`   | 10%    | Outgoing out in 0.3s, incoming in at 0.1s — punchy switch.            |

## Deviations from the plan

- **`long_blend` deferred** — wants a 12-16s buffer, but the cross buffer width is fixed at construction and can only be varied per-track via `liq_cross_duration` metadata, which the controller doesn't write yet. Belongs in Phase 2 plumbing.
- **`filter_sweep` deferred** — needs the pre-cross `music_meta` wet/dry IIR mitigation described in the plan; that's separate scope.

## Safety

- Unknown / missing `transition` metadata falls through to `tx_fade` — the station can never break on a bad enum.
- All variants use `fade.out`/`fade.in` spanning the same window so the no-loudness-scaling invariant (existing radio.liq:117-129 comment) is preserved.
- `liquidsoap --check` passes against the bundled `ghcr.io/perminder-klair/subwave-broadcast:latest` image.

## Test plan

- [ ] Restart `broadcast` in dev: `docker compose -f docker-compose.dev.yml restart broadcast` (no rebuild — `radio.liq` is bind-mounted).
- [ ] Tail logs: each transition prints `dj_transition: style=<…> source=random`. Confirm all four styles appear over an hour of listening.
- [ ] **Specifically watch for `echo_tail`** — `--check` doesn't catch the runtime "Early computation of source content-type" error that historically hit IIR ops on `request.queue` sources. If `echo_tail` trips it in production, drop its weight to 0 in the dispatcher and it falls through to `tx_fade`.
- [ ] Listen across a mood mix (chill → high-energy, similar-genre → genre-shift) and decide whether the weights feel right before Phase 2 lets the picker bias them.

## Follow-up (Phase 2)

Not included here — schema field on `pickNextTrack` + `PICK_SCHEMA` (per [review notes](docs/dj-track-transitions-plan.md), Phase 2 needs to extend BOTH the pool-picker schema in `controller/src/llm/dj.ts` AND the session-agent schema in `controller/src/broadcast/dj-agent.ts`, not just the former), plus `getAnnotatedUri` plumbing the field into `transition="…"` and `liq_cross_duration="…"`. Hold until Phase 1 has lived for a few days.