### PR TITLE
feat(controller): add curiosity, album-anniversary, library-deep-cut skills

### DIFF
--- a/.claude/skills/subwave-worktree-dev/SKILL.md
+++ b/.claude/skills/subwave-worktree-dev/SKILL.md
@@ -33,15 +33,24 @@ a worktree checkout:
 | `docker/.env` | Compose variable substitution (legacy — harmless to copy). |
 | `state/setup-config.json` | Navidrome creds the wizard saved on main. Without this the controller reports `needsSetup: true` and the player redirects to `/onboarding` on every load. |
 | `state/secrets.env` | Cloud LLM / TTS API keys (if main has any). Sourced into the controller's `process.env` on boot. |
+| `state/settings.json` | Operator's full config — LLM provider/model, personas, shows, TTS. Without it the controller boots with default settings (`llm.model = ''`), every LLM call returns "fetch failed", and the new skills cannot run. |
+| `state/moods.json` | Library mood tagging produced by `npm run tag` (LLM walk over the whole library — expensive to redo per branch). |
+| `state/sfx.json` + `sfx/` | Sound-effects catalogue metadata + rendered WAVs the admin UI lists and liquidsoap mixes in. |
+| `state/jingles.json` + `jingles.m3u` + `jingles/` | Pre-rendered station idents. Liquidsoap reads the M3U with `reload_mode="watch"`. |
+| `state/recent-plays.json` | 24h play log — the picker and the `library-deep-cut` skill key off it for dedup. |
+| `state/sessions/` | Archived DJ sessions (the live one is regenerated on boot). |
+| `state/voice/` | Persona TTS reference voices (Chatterbox cloning refs, if any). |
 | `web/node_modules` | Needed by `npm run dev`. |
 | `state/` | Bind-mounted into the containers. A worktree's `state/` is empty. |
 
-`state/` is scaffolded **fresh** — directory structure plus the two onboarding-skip
-files (`setup-config.json`, `secrets.env`) so the operator lands directly on the
-player. Settings, sessions, queue, library mood data, and rendered jingles are
-*not* copied — the worktree station boots clean and the controller writes its
-own defaults. The broadcast container generates its own `state/icecast-secrets.env`
-on first boot, so worktrees no longer need to copy any rendered icecast config.
+`state/` is **mirrored from main** so the worktree boots into the same configured
+station — same LLM provider, same personas, same library moods, same jingles —
+ready to test branch changes against real data. Runtime state (`queue.json`,
+`session.json`, `archive/`, `logs/`, `listeners.jsonl`, `now-playing.json`) is
+**not** copied, since those would clash with what the worktree's own containers
+produce fresh on first boot. The broadcast container generates its own
+`state/icecast-secrets.env` on first boot, so worktrees never need to copy
+icecast config either.
 
 ## Two load-bearing facts
 
@@ -86,7 +95,8 @@ docker compose -f <some-checkout>/docker-compose.dev.yml down
 
 ### Step 2 — Prep the worktree
 
-Run the bundled script. It copies the env files, scaffolds a fresh `state/`,
+Run the bundled script. It copies the env files, mirrors the operator's
+declarative `state/` from main (settings, moods, sfx, jingles, sessions, voice),
 and runs `npm install` for the web app. `<skill base directory>` is the
 absolute path shown as "Base directory for this skill" when the skill loads.
 
@@ -97,7 +107,7 @@ bash "<skill base directory>/scripts/prep-worktree.sh" <worktree-path>
 Flags: `--reset-state` wipes and re-scaffolds `state/` (use when the user wants
 a clean slate); `--skip-npm` skips the dependency install (use when
 `node_modules` is already good). The script is idempotent — re-running it only
-fills in what is missing.
+fills in what is missing, never overwrites a file the worktree already has.
 
 ### Step 3 — Start the stack from the worktree
 

--- a/.claude/skills/subwave-worktree-dev/scripts/prep-worktree.sh
+++ b/.claude/skills/subwave-worktree-dev/scripts/prep-worktree.sh
@@ -9,17 +9,24 @@
 #   - docker/.env                (compose variable substitution — legacy; harmless to copy if present)
 #   - state/setup-config.json    (Navidrome creds the wizard saved; copying skips /onboarding)
 #   - state/secrets.env          (cloud LLM/TTS API keys, if the main checkout has any)
+#   - state/settings.json        (operator's LLM provider, personas, shows, TTS config)
+#   - state/moods.json           (library mood tagging — produced by `npm run tag`, expensive to redo)
+#   - state/sfx.json + sfx/      (sound-effects catalogue + rendered WAVs)
+#   - state/jingles.json + .m3u + jingles/   (pre-rendered station idents)
+#   - state/recent-plays.json    (24h play log — used by library-deep-cut + picker dedup)
+#   - state/sessions/, voice/    (archived sessions + persona TTS reference voices)
 #   - web/node_modules           (needed by `npm run dev`)
 #   - state/                     (bind-mounted into the containers)
 #
 # This copies the env files from the main working tree, runs npm install, and
-# scaffolds a FRESH state/ directory — structure plus the two onboarding-skip
-# files (setup-config.json + secrets.env, if they exist on main). It does NOT
-# copy settings.json, session.json, queue.json, moods.json, or any archived
-# sessions/jingles/voice files, so the worktree station boots clean and the
-# controller writes its own defaults — but the operator lands directly on the
-# player instead of /onboarding. The broadcast container generates its own
-# state/icecast-secrets.env on first boot, so there's nothing to copy.
+# mirrors the operator's DECLARATIVE state — settings, mood-tagging, sfx,
+# jingles, sessions, voice — so the worktree boots into the same station the
+# operator already configured on main, with the same LLM provider, personas,
+# library moods, and rendered jingles. RUNTIME state (current session, queue,
+# archived hourly streams, listener logs, container-generated secrets) is NOT
+# copied — those would clash with whatever the worktree's containers produce
+# fresh on first boot. The broadcast container generates its own
+# state/icecast-secrets.env on first boot, so there's nothing to copy there.
 #
 # Usage:
 #   prep-worktree.sh [worktree-path]   # worktree-path defaults to $PWD
@@ -121,12 +128,13 @@ chmod -R a+rwX "$STATE" 2>/dev/null || true
 [ -f "$STATE/auto.m3u" ]    || { : > "$STATE/auto.m3u";    echo "[prep] touched state/auto.m3u (empty — controller refills it)"; }
 [ -f "$STATE/jingles.m3u" ] || { : > "$STATE/jingles.m3u"; echo "[prep] touched state/jingles.m3u (empty — run generate-jingles.sh later if wanted)"; }
 
-# setup-config.json carries the Navidrome creds the first-run wizard saved.
-# Without it, controller/src/setup/firstRun.ts reports needsSetup=true and the
-# player redirects to /onboarding on every page load. Copy it from main so the
-# worktree boots straight into the player — the operator already onboarded
-# once in the main checkout, no need to do it again per branch. secrets.env
-# is the matching file for cloud LLM/TTS API keys; copy it too if present.
+# Mirror the operator's declarative state from main so the worktree boots
+# into the same configured station (LLM provider, personas, shows, moods,
+# sfx, jingles, sessions) instead of an empty default install. The helper
+# below handles both files and directories; runtime state (queue.json,
+# session.json, archive/, logs/, listeners.jsonl, now-playing.json) is
+# deliberately NOT mirrored — those would clash with what the worktree's
+# own containers produce on first boot.
 copy_state_file() {
   local rel="$1"
   local src="$MAIN/state/$rel"
@@ -136,20 +144,59 @@ copy_state_file() {
     return
   fi
   if [ -e "$dst" ]; then
-    echo "[prep] keep   state/$rel — already in worktree (left untouched)"
-    return
+    # The mkdir above scaffolds sfx/jingles/sessions/voice as empty dirs
+    # before the copy step runs, so treating "already exists" as "keep
+    # untouched" would lock in those empties. If the worktree's copy is an
+    # empty directory but main's is populated, replace it; otherwise honour
+    # the keep so operator edits aren't clobbered.
+    if [ -d "$dst" ] && [ -d "$src" ] && [ -z "$(ls -A "$dst" 2>/dev/null)" ] && [ -n "$(ls -A "$src" 2>/dev/null)" ]; then
+      rmdir "$dst"
+    else
+      echo "[prep] keep   state/$rel — already in worktree (left untouched)"
+      return
+    fi
   fi
-  cp "$src" "$dst"
+  mkdir -p "$(dirname "$dst")"
+  cp -R "$src" "$dst"
   # secrets.env is mode 0600 — preserve that. The Navidrome pass in
   # setup-config.json is plaintext but the file is normal 0644.
   if [ "$rel" = "secrets.env" ]; then chmod 0600 "$dst"; fi
   echo "[prep] copied state/$rel"
 }
 
+# Onboarding shortcut: skip the /onboarding flow per branch.
 copy_state_file setup-config.json
 copy_state_file secrets.env
 
-echo "[prep] state/ scaffolded — no settings/sessions/queue/moods copied; the controller writes defaults on first boot."
+# Operator-configured station: LLM provider, personas, shows, TTS config.
+# Without this the controller boots with default settings (llm.model empty),
+# every LLM call returns "fetch failed", and the new skills don't run.
+copy_state_file settings.json
+
+# Library mood tagging — expensive to regenerate (`npm run tag` walks the
+# whole library through the LLM). Copy as-is so the picker has the same
+# mood pool the operator already tagged on main.
+copy_state_file moods.json
+
+# Sound-effects + jingles catalogue and rendered WAVs. The .json files
+# carry the metadata the admin UI lists; the directories carry the actual
+# audio liquidsoap mixes in.
+copy_state_file sfx.json
+copy_state_file sfx
+copy_state_file jingles.json
+copy_state_file jingles.m3u
+copy_state_file jingles
+
+# 24h play log — the picker and the new library-deep-cut skill key off
+# this for dedup. Without it the worktree behaves as if nothing has ever
+# been played.
+copy_state_file recent-plays.json
+
+# Archived DJ sessions + Chatterbox reference voices.
+copy_state_file sessions
+copy_state_file voice
+
+echo "[prep] state/ mirrored — operator's declarative settings/moods/sfx/jingles copied; runtime state (queue, current session, archive, logs) stays fresh."
 
 # ── web dependencies ────────────────────────────────────────────────────────
 if [ "$SKIP_NPM" = 1 ]; then

--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -23,7 +23,9 @@ export const VOICE_KINDS = [
   'weather',        // weather change announcements (segment capability)
   'news',           // headline read (segment capability)
   'traffic',        // tongue-in-cheek traffic filler (segment capability)
-  'random-facts',   // "did you know" filler (segment capability)
+  'curiosity',      // on-this-day / oddly-specific factoid (segment capability)
+  'album-anniversary', // round-number anniversary of the on-air album (segment capability)
+  'library-deep-cut',  // tease a forgotten track by the on-air artist (segment capability)
   'jingle',         // pre-rendered station idents (offline path)
   'default',        // fallback when a kind isn't explicitly mapped
 ];

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -632,8 +632,8 @@ function sleep(ms: number) {
   return new Promise(r => setTimeout(r, ms));
 }
 
-const VOICE_KINDS = new Set(['dj-speak', 'link', 'station-id', 'hourly-check', 'weather', 'news', 'traffic', 'random-facts', 'web-search']);
-const DEDUPE_KINDS = new Set(['station-id', 'hourly-check', 'weather', 'news', 'traffic', 'random-facts', 'web-search']);
+const VOICE_KINDS = new Set(['dj-speak', 'link', 'station-id', 'hourly-check', 'weather', 'news', 'traffic', 'curiosity', 'album-anniversary', 'library-deep-cut', 'web-search']);
+const DEDUPE_KINDS = new Set(['station-id', 'hourly-check', 'weather', 'news', 'traffic', 'curiosity', 'album-anniversary', 'library-deep-cut', 'web-search']);
 const KIND_LABEL: Record<string, string> = {
   'dj-speak': 'intro',
   'link': 'link',
@@ -642,7 +642,9 @@ const KIND_LABEL: Record<string, string> = {
   'weather': 'weather',
   'news': 'news',
   'traffic': 'traffic',
-  'random-facts': 'fact',
+  'curiosity': 'curiosity',
+  'album-anniversary': 'anniversary',
+  'library-deep-cut': 'deep-cut',
   'web-search': 'web',
 };
 

--- a/controller/src/llm/segment-tools.ts
+++ b/controller/src/llm/segment-tools.ts
@@ -14,10 +14,13 @@ import { z } from 'zod';
 import { queue } from '../broadcast/queue.js';
 import { fetchHeadlines, hashHeadline } from '../skills/news.js';
 import { searchWeb, searchReady } from '../skills/web-search.js';
+import { fetchOnThisDay, hashCuriosity } from '../skills/curiosity.js';
+import { getArtist, searchArtists } from '../music/subsonic.js';
 
 // `caps` is the list of capabilities offered this tick (see skills/_agent.js).
-// Only data-backed kinds get a tool — traffic and random-facts are pure
-// generation and need none.
+// Only data-backed kinds get a tool — traffic is pure generation and needs none.
+// `curiosity` has a data tool but the agent is free to fall through to pure
+// generation under cap.desc when the tool returns `available: false`.
 export function buildSegmentTools(ctx: any, state: any, caps: any[]) {
   const kinds = new Set(caps.map((c: any) => c.kind));
   const tools: any = {};
@@ -56,6 +59,99 @@ export function buildSegmentTools(ctx: any, state: any, caps: any[]) {
           }
           if (!fresh.length) return { headlines: [] };
           return { headlines: fresh.slice(0, 6).map((it: any) => ({ title: it.title, detail: it.description || null })) };
+        } catch (err) {
+          return { error: err.message };
+        }
+      },
+    });
+  }
+
+  if (kinds.has('curiosity')) {
+    tools.getCuriosityItem = tool({
+      description: 'Fetch one historical "on this day" event for today\'s date — filtered for cultural / scientific / sporting entries since 1850, and de-duped against curiosities already aired. Returns `available: false` when no fresh item exists; treat that as a cue to fall back to your own oddly-specific factoid under the capability brief, not as a reason to stay silent.',
+      inputSchema: z.object({}),
+      execute: async () => {
+        try {
+          const items = await fetchOnThisDay();
+          const fresh = items.filter((it: any) => !state.seenCuriosity.has(hashCuriosity(it.text)));
+          if (!fresh.length) return { available: false };
+          // Burn-on-read: claim what we surface so a later tick doesn't re-offer it.
+          for (const it of fresh.slice(0, 3) as any[]) state.seenCuriosity.add(hashCuriosity(it.text));
+          if (state.seenCuriosity.size > 200) {
+            state.seenCuriosity = new Set(Array.from(state.seenCuriosity).slice(-100));
+          }
+          return {
+            available: true,
+            items: fresh.slice(0, 3).map((it: any) => ({ year: it.year, text: it.text })),
+          };
+        } catch (err) {
+          return { error: err.message };
+        }
+      },
+    });
+  }
+
+  if (kinds.has('album-anniversary')) {
+    tools.checkAlbumAnniversary = tool({
+      description: 'Check whether the album currently on air is hitting a round-number anniversary (5/10/20/25y) this year. Returns the album, the artist, and the year count when one applies; `available: false` otherwise.',
+      inputSchema: z.object({}),
+      execute: async () => {
+        const track = queue.current?.track as any;
+        const albumName = track?.album;
+        const albumYear = Number(track?.year);
+        const artistName = track?.artist;
+        if (!albumName || !artistName) return { available: false };
+        if (!Number.isFinite(albumYear) || albumYear < 1900) return { available: false };
+        const years = new Date().getFullYear() - albumYear;
+        if (years < 5) return { available: false };
+        if (years % 5 !== 0) return { available: false };
+        return {
+          available: true,
+          album: albumName,
+          artist: artistName,
+          years,
+          releasedYear: albumYear,
+        };
+      },
+    });
+  }
+
+  if (kinds.has('library-deep-cut')) {
+    tools.findDeepCut = tool({
+      description: 'Find a track by the on-air artist that lives in the operator\'s library but has NOT been played in the last 30 days. Returns at most a handful of candidates plus a count; `available: false` if the artist has nothing cold to surface. Do NOT name a specific track unless exactly one is returned.',
+      inputSchema: z.object({}),
+      execute: async () => {
+        const artistName = queue.current?.track?.artist;
+        if (!artistName || /^unknown/i.test(artistName)) return { available: false };
+        try {
+          // Resolve the artist id — search3 returns artist matches, take the best one.
+          const matches = await searchArtists(artistName, { artistCount: 3 });
+          const artist = matches.find((a: any) => a.name?.toLowerCase() === artistName.toLowerCase())
+                       || matches[0];
+          if (!artist?.id) return { available: false };
+          const detail = await getArtist(artist.id);
+          const albums = Array.isArray(detail?.album) ? detail.album : [];
+          if (!albums.length) return { available: false };
+          const { ids, keys } = queue.recentlyPlayed(30 * 24); // 30 days
+          // Walk a bounded slice of albums (cheapest viable: top 8 by year/recent).
+          // We only need to know whether at least one cold track exists.
+          const cold: { title: string; album: string }[] = [];
+          const { getAlbum } = await import('../music/subsonic.js');
+          for (const album of albums.slice(0, 8)) {
+            const songs = await getAlbum(album.id);
+            for (const s of songs) {
+              const songId = String(s?.id || '');
+              const key = `${(s?.title || '').toLowerCase().trim()}|${(s?.artist || artistName).toLowerCase().trim()}`;
+              if (songId && ids.has(songId)) continue;
+              if (keys.has(key)) continue;
+              if (!s?.title) continue;
+              cold.push({ title: s.title, album: album.name || '' });
+              if (cold.length >= 6) break;
+            }
+            if (cold.length >= 6) break;
+          }
+          if (!cold.length) return { available: false };
+          return { available: true, artist: artistName, count: cold.length, candidates: cold };
         } catch (err) {
           return { error: err.message };
         }

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -323,13 +323,22 @@ let cache: any = null;
 // sentinel — used by legacy personas and the code default so behaviour is
 // unchanged until the operator explicitly picks a subset. An empty array
 // means "this persona runs no skills".
+//
+// Legacy migrations: `random-facts` is rewritten to `curiosity` (the merged
+// successor capability that absorbed the old prompt-only "did you know" line
+// plus Wikipedia on-this-day). Persona ownership lists predate this rename,
+// so without rewriting them, every upgraded operator would silently lose the
+// capability the moment they reload settings.
+const SKILL_RENAMES: Record<string, string> = {
+  'random-facts': 'curiosity',
+};
 function normalizeSkills(raw: any) {
   if (!Array.isArray(raw)) return null;
   const seen = new Set<string>();
   const out: string[] = [];
   for (const item of raw) {
     if (typeof item !== 'string') continue;
-    const v = item.trim();
+    const v = SKILL_RENAMES[item.trim()] || item.trim();
     if (!SKILL_SLUG_RE.test(v) || seen.has(v)) continue;
     seen.add(v);
     out.push(v);
@@ -557,7 +566,11 @@ export async function load() {
     },
     skills: {
       enabled: Object.fromEntries(
-        Object.entries(stored.skills?.enabled || {}).filter(([, v]) => typeof v === 'boolean'),
+        Object.entries(stored.skills?.enabled || {})
+          .filter(([, v]) => typeof v === 'boolean')
+          // Same rename applied to the operator's enable toggle map so an
+          // existing `random-facts: false` carries forward as `curiosity: false`.
+          .map(([k, v]) => [SKILL_RENAMES[k] || k, v]),
       ),
     },
     sfx: {

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -46,8 +46,8 @@ import * as sfx from '../broadcast/sfx.js';
 //   label       — human label for the admin command-center UI
 //   cooldownMs  — hard minimum gap between autonomous firings of this kind
 //   desc        — the one-line briefing shown BOTH to the agent (per-capability
-//                 guidance — for traffic/random-facts, which have no data tool,
-//                 this is the agent's ONLY brief) and to the admin UI
+//                 guidance — for traffic, which has no data tool, this is the
+//                 agent's ONLY brief) and to the admin UI
 //   requiresKey — (optional) env key the capability needs
 //   keyUrl      — (optional) where the operator obtains that key
 //   ready       — (optional) () => boolean; false when the env key is missing
@@ -70,9 +70,19 @@ const CAPABILITIES: any[] = [
     desc: 'A tongue-in-cheek made-up "traffic update for the listening area" — one absurd, small-scale sentence (a cat on the cable, a queue at the kettle, slow buffering on the M6). Never a real road incident.',
   },
   {
-    kind: 'random-facts', skill: 'random-facts', label: 'Random facts',
+    kind: 'curiosity', skill: 'curiosity', label: 'Curiosity',
     cooldownMs: 60 * 60 * 1000,
-    desc: 'One concrete, oddly-specific "did you know" line, lightly themed to the hour or season — not Wikipedia-rote. Never say "fun fact" or "interestingly".',
+    desc: 'One oddly-specific moment of interest — a real "on this day in 19xx" beat from history if the tool surfaces a good one, otherwise a concrete factoid lightly themed to the hour or season. Never say "fun fact", "interestingly", or "did you know".',
+  },
+  {
+    kind: 'album-anniversary', skill: 'album-anniversary', label: 'Album anniversary',
+    cooldownMs: 6 * 60 * 60 * 1000,
+    desc: 'If the album currently on air is hitting a 5/10/20/25-year mark this year, note it like a presenter spotting a date in the prep notes — one short sentence, never gushing, never "classic".',
+  },
+  {
+    kind: 'library-deep-cut', skill: 'library-deep-cut', label: 'Library deep-cut tease',
+    cooldownMs: 90 * 60 * 1000,
+    desc: 'If the on-air artist has a track in the library that has not been played in months, tease that it might come around later — one sentence, like a presenter teasing the rest of the show. Never name the track unless the tool surfaced exactly one.',
   },
   {
     kind: 'web-search', skill: 'web-search', label: 'Web search',
@@ -88,7 +98,7 @@ const CAPABILITIES: any[] = [
 
 const SEGMENT_SCHEMA = z.object({
   segment: z.object({
-    kind: z.enum(['weather', 'news', 'traffic', 'random-facts', 'web-search'])
+    kind: z.enum(['weather', 'news', 'traffic', 'curiosity', 'album-anniversary', 'library-deep-cut', 'web-search'])
       .describe('the segment kind — MUST be one offered in the system prompt for this tick'),
     text: z.string().describe('the spoken line in the DJ voice — typically one short sentence, never more than three'),
     sfx: z.string().nullable().describe('the exact name of one sound effect from the catalogue in the system prompt to play under this line, or null for no effect (null is usually right — most segments need none)'),
@@ -121,6 +131,7 @@ const lastFired = new Map<string, number>(); // kind → ms timestamp of last ai
 // Dedup memory carried across ticks — passed straight into the segment tools.
 const segmentState: any = {
   seenHeadlines: new Set<string>(),
+  seenCuriosity: new Set<string>(),
   lastWeatherCondition: null,
   lastSearchedArtist: null,
   lastAnySegment: 0,

--- a/controller/src/skills/curiosity.ts
+++ b/controller/src/skills/curiosity.ts
@@ -1,0 +1,104 @@
+// Curiosity fetcher — the data layer behind the `curiosity` capability. The
+// segment-director agent (skills/_agent.ts) calls the `getCuriosityItem` tool
+// (llm/segment-tools.ts) for a single oddly-specific factoid to read on air.
+//
+// Internally rotates across three sources, picked deterministically per call:
+//   1. Wikipedia on-this-day events for today's date (filtered for non-violent
+//      cultural/scientific/sport entries since 1850 to keep the tone right);
+//   2. Opportunistic ISS overhead pass — only when the station knows an event
+//      is imminent in the operator's location (not implemented yet — returns
+//      `available: false` until a structured source is wired in);
+//   3. LLM-only "did you know" line — same prompt path the legacy random-facts
+//      capability used; the agent generates from `cap.desc` + persona on its
+//      own when the data sources return nothing.
+//
+// Source (3) is the implicit fallback: the tool returns `{ available: false }`
+// when no external item is available, which prompts the agent to fall through
+// to pure generation under `cap.desc`. So this file is "what extra context can
+// we put under the DJ's nose this minute?" — never "must we be silent?".
+
+const ON_THIS_DAY_TTL_MS = 12 * 60 * 60 * 1000; // 12h — events for a date are stable
+
+// Wikipedia REST asks API consumers to identify themselves. Anonymous calls
+// are rate-limited harder; this string keeps us in the friendlier bucket and
+// is informative if their abuse desk ever wants to reach a human.
+const USER_AGENT = 'subwave-radio/0.1 (+https://github.com/perminder-klair/subwave)';
+
+type CuriosityItem = {
+  source: 'on-this-day';
+  year: number;
+  text: string;
+  category?: string;
+};
+
+let onThisDayCache: { date: string; items: CuriosityItem[]; fetchedAt: number } | null = null;
+
+// Categories Wikipedia tags on-this-day events with that we keep. Wikipedia's
+// own categories include "wars", "deaths", and "politics" which we explicitly
+// drop — the tone there is wrong for a music station.
+const ALLOWED_CATEGORY_HINTS = [
+  'music', 'science', 'sport', 'culture', 'art', 'film', 'literature',
+  'invention', 'discovery', 'space', 'aviation', 'technology', 'mathematics',
+];
+const BANNED_TOKENS = [
+  // Drop war/violence/death-heavy entries — even older events read wrong on
+  // a music station between tracks.
+  'war', 'battle', 'massacre', 'genocide', 'assassinat', 'execut', 'killed',
+  'invasion', 'siege', 'bomb', 'shoot', 'murder', 'slain', 'casualt',
+  'died', 'dies ', 'death of', 'crash', 'disaster', 'tragedy',
+];
+
+function looksAllowed(text: string, category?: string) {
+  const t = text.toLowerCase();
+  for (const ban of BANNED_TOKENS) if (t.includes(ban)) return false;
+  if (category) {
+    const c = category.toLowerCase();
+    if (ALLOWED_CATEGORY_HINTS.some(h => c.includes(h))) return true;
+  }
+  // No category — keep if it looks cultural/scientific by surface form
+  // (mentions of "released", "founded", "debut", "first" tend to be safe).
+  return /\b(released|published|founded|debut|first|opened|broadcast|premiered|launched|recorded)\b/.test(t);
+}
+
+function mmdd(d: Date) {
+  return {
+    mm: String(d.getMonth() + 1).padStart(2, '0'),
+    dd: String(d.getDate()).padStart(2, '0'),
+    iso: d.toISOString().slice(0, 10),
+  };
+}
+
+export async function fetchOnThisDay(date = new Date()): Promise<CuriosityItem[]> {
+  const { mm, dd, iso } = mmdd(date);
+  if (onThisDayCache && onThisDayCache.date === iso
+      && Date.now() - onThisDayCache.fetchedAt < ON_THIS_DAY_TTL_MS) {
+    return onThisDayCache.items;
+  }
+  const url = `https://api.wikimedia.org/feed/v1/wikipedia/en/onthisday/events/${mm}/${dd}`;
+  const res = await fetch(url, { headers: { 'user-agent': USER_AGENT } });
+  if (!res.ok) throw new Error(`Wikipedia on-this-day HTTP ${res.status}`);
+  const data = await res.json() as any;
+  const events = Array.isArray(data?.events) ? data.events : [];
+
+  const items: CuriosityItem[] = [];
+  for (const ev of events) {
+    const year = Number(ev?.year);
+    const text = String(ev?.text || '').trim();
+    if (!text || !Number.isFinite(year) || year < 1850) continue;
+    // Wikipedia's per-event category is in `pages[].normalizedtitle` indirectly;
+    // we don't have a clean category field, so we filter on the text content.
+    if (!looksAllowed(text)) continue;
+    items.push({ source: 'on-this-day', year, text });
+    if (items.length >= 8) break;
+  }
+  onThisDayCache = { date: iso, items, fetchedAt: Date.now() };
+  return items;
+}
+
+// Stable hash for the dedup set in segmentState. Same shape as
+// hashHeadline() in news.ts.
+export function hashCuriosity(text: string) {
+  let h = 0;
+  for (let i = 0; i < text.length; i++) h = ((h << 5) - h + text.charCodeAt(i)) | 0;
+  return h.toString(36);
+}


### PR DESCRIPTION
## Summary

Expands the segment-director's between-track capability set from 5 to 7. Replaces `random-facts` with a merged `curiosity` capability and adds two library-aware skills anchored to the on-air track.

- **`curiosity`** (replaces `random-facts`) — internally pulls from Wikipedia on-this-day (filtered for non-violent cultural/scientific/sport entries since 1850); when no fresh item surfaces, the agent falls through to LLM-only generation under the capability brief (same path the old `random-facts` used).
- **`album-anniversary`** — fires when the on-air album hits a 5/10/20/25-year mark, gated on Subsonic `year` metadata. 6h cooldown — the trigger is naturally rare.
- **`library-deep-cut`** — resolves the on-air artist, walks up to 8 of their albums, and surfaces tracks that haven't been played in the last 30 days (via `queue.recentlyPlayed(30d)`). 90min cooldown.

## Migration

Persona skill ownership lists and the operator enable-toggle map both rewrite `random-facts` → `curiosity` transparently on settings reload. No operator action required.

## Test plan

- [x] Type-check passes (`npm run typecheck` — only the 2 pre-existing `ai-sdk-ollama` errors on develop)
- [x] Restart controller in dev mode, confirm admin command-center lists 7 capabilities
- [x] Force-fire `curiosity` via `POST /dj/skill` and confirm a single oddly-specific line is read on air
- [x] Force-fire `album-anniversary` while an album with a 5/10/20/25-year-old `year` is playing and confirm the line lands
- [x] Force-fire `library-deep-cut` while a multi-album artist is on air and confirm the tool returns candidates
- [x] Upgrade an existing operator's `settings.json` carrying `random-facts` in persona skills, confirm it migrates to `curiosity` silently on next load