### PR TITLE
fix(controller): harden DJ segments against transient LLM/IPC failures

### DIFF
--- a/controller/package-lock.json
+++ b/controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sub-wave-controller",
-  "version": "0.1.17",
+  "version": "0.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sub-wave-controller",
-      "version": "0.1.17",
+      "version": "0.1.22",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.77",

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -4,6 +4,7 @@
 
 import { writeFile, readFile } from 'node:fs/promises';
 import { existsSync, readFileSync } from 'node:fs';
+import { stat } from 'node:fs/promises';
 import { config } from '../config.js';
 import * as subsonic from '../music/subsonic.js';
 import { speak } from '../audio/tts.js';
@@ -296,7 +297,7 @@ class Queue {
         if (item.introScript) {
           try {
             const wavPath = await speak(item.introScript, { kind: 'dj-speak' });
-            await writeFile(config.liquidsoap.sayFile, wavPath);
+            await writeHandoff(config.liquidsoap.sayFile, wavPath);
             this.log('dj-speak', item.introScript);
             await sleep(250);
           } catch (err: any) {
@@ -305,13 +306,12 @@ class Queue {
         }
 
         const uri = subsonic.getAnnotatedUri(item.track);
-        await writeFile(config.liquidsoap.queueFile, uri);
+        await writeHandoff(config.liquidsoap.queueFile, uri);
         item.sent = true;
         this.persist();  // record the sent flag — these are now live in dj_queue
 
-        // Give Liquidsoap's 1s poll a chance to read + delete the file
-        // before we overwrite it with the next item.
-        await sleep(1500);
+        // writeHandoff already waited for Liquidsoap's poll to consume the
+        // file before returning, so no extra sleep needed here.
       }
     } finally {
       this.senderBusy = false;
@@ -333,7 +333,7 @@ class Queue {
       const targetFile = kind === 'link'
         ? config.liquidsoap.introFile
         : config.liquidsoap.sayFile;
-      await writeFile(targetFile, wavPath);
+      await writeHandoff(targetFile, wavPath);
       this.log(kind, text);
       session.appendTurn({ role: 'segment', kind, text });
       // The auto-DJ link channel is its own event; everything else (station
@@ -359,7 +359,7 @@ class Queue {
         this.log('error', `Unknown sound effect: ${name}`);
         return;
       }
-      await writeFile(config.liquidsoap.sfxFile, path);
+      await writeHandoff(config.liquidsoap.sfxFile, path);
       this.log('sfx', name);
       session.appendTurn({ role: 'segment', kind: 'sfx', text: name });
     } catch (err: any) {
@@ -630,6 +630,54 @@ class Queue {
 
 function sleep(ms: number) {
   return new Promise(r => setTimeout(r, ms));
+}
+
+// Per-target-file write chain. Liquidsoap polls each handoff file (say.txt,
+// intro.txt, sfx.txt, next.txt) on a 0.5-1.0s interval and DELETES the file
+// after reading it (see liquidsoap/radio.liq poll_voice/poll_intro/poll_sfx/
+// poll_queue). Without serialisation, two writes inside one poll window
+// silently lose the first one — exactly the failure in issue #140 where a
+// station ID rendered + logged but never aired.
+//
+// writeHandoff() serialises writes per file and waits for the previous WAV/URI
+// to be consumed (file deleted by liquidsoap) before releasing the lock. If
+// liquidsoap is dead/stuck and never deletes, we time out after maxWaitMs and
+// release anyway — better to overwrite a stuck file than block all future
+// announces forever.
+const _handoffChains: Map<string, Promise<void>> = new Map();
+
+async function waitForConsumed(path: string, maxWaitMs: number) {
+  const start = Date.now();
+  while (Date.now() - start < maxWaitMs) {
+    try {
+      await stat(path);
+    } catch {
+      return; // liquidsoap deleted it — file gone, safe to write next
+    }
+    await sleep(100);
+  }
+  // Timed out — file still on disk. Caller proceeds anyway.
+}
+
+async function writeHandoff(path: string, contents: string, { maxWaitMs = 1500 } = {}) {
+  const prev = _handoffChains.get(path) || Promise.resolve();
+  const next = prev
+    .catch(() => undefined)
+    .then(async () => {
+      // Make sure liquidsoap has already consumed whatever was there. If the
+      // file doesn't exist (the common case — liquidsoap polled in the
+      // meantime, or this is the first write of the session), this returns
+      // immediately.
+      if (existsSync(path)) await waitForConsumed(path, maxWaitMs);
+      await writeFile(path, contents);
+    });
+  // Hold the slot until liquidsoap consumes THIS write too, so the next
+  // queued writer waits for the audio to land, not just for the write call to
+  // return. Errors don't break the chain — the .catch above ensures the next
+  // writer still gets its turn.
+  const release = next.then(() => waitForConsumed(path, maxWaitMs).catch(() => undefined));
+  _handoffChains.set(path, release);
+  return next;
 }
 
 const VOICE_KINDS = new Set(['dj-speak', 'link', 'station-id', 'hourly-check', 'weather', 'news', 'traffic', 'curiosity', 'album-anniversary', 'library-deep-cut', 'web-search']);

--- a/controller/src/llm/sdk.ts
+++ b/controller/src/llm/sdk.ts
@@ -236,6 +236,54 @@ function logFailurePreview(kind: string, err: any) {
   console.log(`[${kind}] raw model output (truncated): ${preview}`);
 }
 
+// Retry transient upstream failures (gateway timeouts, dropped sockets). Local
+// Ollama — and anything proxying it — produces occasional 502/503/504 and TCP
+// resets, especially on slow models with fat prompts. Without retry, one blip
+// kills a station ID or hourly check (see issue #140). Two retries with
+// jittered backoff is enough — beyond that the upstream is genuinely down and
+// the failure should surface.
+//
+// Schema/parse failures and the agent's "did not call done" condition are NOT
+// transient and bubble straight out — they need different recovery paths.
+const TRANSIENT_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+const TRANSIENT_CODE = new Set([
+  'ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EAI_AGAIN',
+  'UND_ERR_SOCKET', 'UND_ERR_CONNECT_TIMEOUT',
+]);
+
+function isTransient(err: any): boolean {
+  if (!err) return false;
+  const status = err.statusCode ?? err.status ?? err.cause?.statusCode ?? err.cause?.status;
+  if (typeof status === 'number' && TRANSIENT_STATUS.has(status)) return true;
+  const code = err.code ?? err.cause?.code;
+  if (typeof code === 'string' && TRANSIENT_CODE.has(code)) return true;
+  const name = err.name ?? err.cause?.name;
+  if (name === 'AbortError' || name === 'TimeoutError') return true;
+  const msg = String(err.message || err.cause?.message || '');
+  if (/\b(408|425|429|500|502|503|504)\b/.test(msg)) return true;
+  if (/socket hang up|fetch failed|network.*(error|timeout)/i.test(msg)) return true;
+  return false;
+}
+
+async function withTransientRetry<T>(kind: string, fn: () => Promise<T>): Promise<T> {
+  const delays = [500, 1500]; // ms — two retries, ~2s total budget
+  let lastErr: any;
+  for (let attempt = 0; attempt <= delays.length; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (!isTransient(err) || attempt === delays.length) throw err;
+      const jitter = Math.floor(Math.random() * 200);
+      const wait = delays[attempt] + jitter;
+      const status = (err as any).statusCode ?? (err as any).status ?? (err as any).cause?.statusCode;
+      console.log(`[${kind}] transient upstream error (${status || (err as any).code || 'unknown'}) — retrying in ${wait}ms (attempt ${attempt + 1}/${delays.length})`);
+      await new Promise(r => setTimeout(r, wait));
+    }
+  }
+  throw lastErr;
+}
+
 // Structured output via a forced tool call. The result schema is presented as
 // an `emit` tool the model MUST call (toolChoice:'required'); we capture and
 // Zod-validate its input. This is the reliable structured-output path for
@@ -277,7 +325,7 @@ export async function djText({
 }: any) {
   const started = Date.now();
   try {
-    const result = await generateText({
+    const result = await withTransientRetry(kind, () => generateText({
       model: languageModel(),
       system,
       prompt,
@@ -286,7 +334,7 @@ export async function djText({
       ...(seed != null ? { seed } : {}),
       maxOutputTokens,
       providerOptions: providerOpts({ repeatPenalty }),
-    });
+    }));
     const out = stripThinking(result.text);
     // Only record sampling knobs that actually reached the model — see
     // repeatPenaltyApplies() and providerOptions handling above.
@@ -344,10 +392,11 @@ export async function djObject({
       let usage;
       if (attempt === 1 && needsToolCallObject()) {
         lastVia = 'ai-sdk:tool';
-        ({ object, usage } = await objectViaToolCall({ system, prompt, schema, temperature, maxOutputTokens }));
+        ({ object, usage } = await withTransientRetry(kind,
+          () => objectViaToolCall({ system, prompt, schema, temperature, maxOutputTokens })));
       } else if (attempt === 1) {
         lastVia = 'ai-sdk';
-        const result = await generateText({
+        const result = await withTransientRetry(kind, () => generateText({
           model: languageModel(),
           system,
           prompt,
@@ -355,19 +404,19 @@ export async function djObject({
           maxOutputTokens,
           output: Output.object({ schema }),
           providerOptions: providerOpts(),
-        });
+        }));
         object = result.output;
         usage = usageOf(result);
       } else {
         lastVia = 'ai-sdk:recovery';
-        const result = await generateText({
+        const result = await withTransientRetry(kind, () => generateText({
           model: languageModel(),
           system,
           prompt: `${prompt}\n\nRespond with a single JSON object only — no prose, no markdown fences.`,
           temperature,
           maxOutputTokens,
           providerOptions: providerOpts(),
-        });
+        }));
         object = schema.parse(JSON.parse(extractJson(stripThinking(result.text))));
         usage = usageOf(result);
       }
@@ -456,7 +505,8 @@ export async function djAgent({
     const toolCount = tools ? Object.keys(tools).length : 0;
     if (schema && toolCount === 0 && needsToolCallObject()) {
       lastVia = 'ai-sdk:tool';
-      const { object, usage } = await objectViaToolCall({ system, prompt: undefined, messages, schema, temperature, maxOutputTokens });
+      const { object, usage } = await withTransientRetry(kind,
+        () => objectViaToolCall({ system, prompt: undefined, messages, schema, temperature, maxOutputTokens }));
       recordSuccess({
         kind, started, via: lastVia,
         sampling: { temperature },
@@ -525,11 +575,41 @@ export async function djAgent({
     // timeoutMs (when set by a caller) is a hard ceiling — a slow/looping run
     // throws, flows through the catch below, and the caller falls back to its
     // stateless path rather than blocking on a pathological model call.
-    const result = await agent.generate({
+    let result = await withTransientRetry(kind, () => agent.generate({
       messages,
       ...(timeoutMs ? { timeout: timeoutMs } : {}),
-    });
-    const steps = result.steps?.length ?? 0;
+    }));
+    let steps = result.steps?.length ?? 0;
+
+    // Recovery for the "agent did not call the done tool" failure mode (issue
+    // #140). Local/cloud Ollama models occasionally ignore toolChoice:'required'
+    // at step 0 — they emit prose instead of any tool call, the loop ends with
+    // zero tool calls, and we'd otherwise throw. Re-run once with prepareStep
+    // pinned to `done`-only at step 0 so `done` is the model's only legal move.
+    // The recovery agent has no discovery tools active, so the answer comes
+    // from prior knowledge / the message history — a worse pick than a
+    // discovery-then-done run, but better than throwing and silencing the
+    // station ID / hourly check / segment entirely.
+    if (useDoneTool && !(result.staticToolCalls || []).some((c: any) => c.toolName === 'done')) {
+      console.log(`[${kind}] agent stopped without calling done — retrying with done-only`);
+      lastVia = 'ai-sdk:agent:recovery';
+      const recoveryAgent = new ToolLoopAgent({
+        model: languageModel(),
+        instructions: system,
+        tools: allTools,
+        stopWhen: [stepCountIs(2), hasToolCall('done')],
+        temperature,
+        maxOutputTokens,
+        providerOptions: providerOpts(),
+        toolChoice: 'required',
+        prepareStep: async () => ({ activeTools: ['done'], toolChoice: 'required' }),
+      } as any);
+      result = await withTransientRetry(kind, () => recoveryAgent.generate({
+        messages,
+        ...(timeoutMs ? { timeout: timeoutMs } : {}),
+      }));
+      steps = result.steps?.length ?? 0;
+    }
 
     let object;
     if (useDoneTool) {


### PR DESCRIPTION
Fixes #140.

The reporter saw three different failure modes within one session:

- `Station ID: failed (502)` / `Time check: failed (504)` — upstream gateway errors from Ollama.
- `/dj/skill news failed: agent did not call the done tool before stopping` and `Segment agent failed: ...` — the tool loop exiting with no `done` call.
- A station ID whose text was generated and logged, but never aired through TTS.

Each is a separate bug, addressed independently.

## Fix 1 — retry transient upstream errors

`controller/src/llm/sdk.ts` now wraps every `generateText` / `objectViaToolCall` / `agent.generate` call in `withTransientRetry()`:

- retries on HTTP `408 / 425 / 429 / 500 / 502 / 503 / 504` and TCP-level errors (`ECONNRESET`, `ETIMEDOUT`, `EAI_AGAIN`, `UND_ERR_*`, AbortError/TimeoutError),
- two attempts at 500ms and 1500ms, with up to 200ms jitter,
- logs each retry to console so operators see it in `docker logs controller`,
- explicitly does NOT retry schema/parse errors or the "did not call done" condition — those need different recovery.

Applied to all three primitives (`djText`, `djObject`, `djAgent`) including the zero-tools fast path and each branch of `djObject`'s 2-attempt loop.

## Fix 2 — recover from "agent did not call the done tool"

The `sdk.ts` header already documents that cloud-style Ollama models occasionally ignore `toolChoice: 'required'` at step 0 and emit prose. `COMMIT_AFTER_STEPS = 1` closed the middle-step window but not the step-0 one.

`djAgent` now checks after the loop whether `done` was actually called. If not, it re-runs once with `prepareStep` pinned to `activeTools: ['done']` so `done` is the model's only legal move. The recovery pass has no discovery tools active, so the answer comes from prior knowledge / message history — a worse pick than discovery-then-done, but strictly better than throwing and silencing the segment. Only throws the original error if the recovery pass also fails to emit `done`.

## Fix 3 — serialise voice-channel writes

Liquidsoap polls `say.txt`, `intro.txt`, `sfx.txt`, and `next.txt` every 0.5–1.0s and **deletes** each file after reading it (see `liquidsoap/radio.liq` `poll_voice` / `poll_intro` / `poll_sfx` / `poll_queue`). Two writes inside one poll window silently lose the first — exactly the symptom in the issue, where a station ID was rendered + logged at 21:45:50 but never aired.

New `writeHandoff()` helper in `controller/src/broadcast/queue.ts`:

- per-path FIFO chain — each file has its own write queue, no cross-file contention,
- waits for liquidsoap to consume (delete) any existing content before the write, and again after, before releasing the slot to the next writer,
- 1.5s timeout per wait — if liquidsoap is dead/stuck, the chain releases instead of permanently blocking announces,
- errors in one writer don't break the chain for the next.

Replaces all four direct `writeFile()` calls to handoff files in `drainToLiquidsoap` / `announce` / `playSfx`. The old `sleep(1500)` at the end of `drainToLiquidsoap`'s inner loop is now redundant and removed.

## Test plan

- [x] `npm run typecheck` in `controller/` — clean.
- [x] `npm run lint` — only pre-existing `scrobble.ts` error, no findings in changed files.
- [x] On a live homelab Ollama box: force a 502 (e.g. block briefly), confirm the next station ID retries instead of failing.
- [x] Trigger `/dj/skill news` repeatedly on a model known to skip the done call, confirm recovery pass fires and a segment airs.
- [x] Fire two announces ~200ms apart (station-ID tick + segment tick collision), confirm both WAVs land on air instead of the first being clobbered.