### PR TITLE
fix(caddy): use named matcher for multi-path stream handle

### DIFF
--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -26,7 +26,8 @@
 	# encodes the same source bus into MP3 192 kbps and Ogg-Opus 96 kbps in
 	# parallel). flush_interval -1 disables buffering so the audio stays live.
 	# Query strings (e.g. ?t=12345 cache-busters) pass through automatically.
-	handle /stream.mp3 /stream.opus {
+	@streams path /stream.mp3 /stream.opus
+	handle @streams {
 		reverse_proxy broadcast:7702 {
 			flush_interval -1
 			transport http {


### PR DESCRIPTION
## Summary

The Caddyfile from #142 uses `handle /stream.mp3 /stream.opus { ... }`, but `handle` only accepts a single path matcher argument. Caddy rejects the config on parse and enters a restart loop, taking down the prod edge on :7700 (broadcast itself stays healthy — only the proxy in front breaks).

Switch to a named matcher (`@streams path /stream.mp3 /stream.opus`) so both Icecast mounts route through one `reverse_proxy` block. Already verified working on prod by patching the running container.

## Test plan
- [ ] `caddy validate --config docker/Caddyfile --adapter caddyfile` returns no errors
- [ ] `docker compose up -d --build caddy` brings caddy up without restart-looping
- [ ] `curl -I http://localhost:7700/stream.mp3` returns 200 with audio/mpeg
- [ ] `curl -I http://localhost:7700/stream.opus` returns 200 with application/ogg