### PR TITLE
chore: add PR template and main-source enforcement workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,10 @@
 <!--
+Target branch: please open this PR against `develop`, not `main`.
+
+`main` is the release branch — only `develop` (and the automated release-please
+PR) can merge into it. PRs targeting `main` from any other branch will be
+blocked by CI. Use the "base" dropdown above to switch to `develop`.
+
 Thanks for the PR! Keep this short — the description is for reviewers, not
 for the changelog (release-please builds that from your Conventional Commit
 messages, e.g. `feat: …`, `fix(ui): …`).

--- a/.github/workflows/enforce-main-source.yml
+++ b/.github/workflows/enforce-main-source.yml
@@ -1,0 +1,27 @@
+name: Enforce main PR source
+
+# main is the release branch. The only PRs allowed into it are:
+#   - develop → main (release cuts)
+#   - release-please's automated release PR
+# Anything else is a contributor who picked the wrong base branch.
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source-branch:
+    name: PR must come from develop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check head branch
+        env:
+          HEAD: ${{ github.head_ref }}
+        run: |
+          if [[ "$HEAD" == "develop" ]] || [[ "$HEAD" == release-please--* ]]; then
+            echo "Source branch '$HEAD' is allowed."
+            exit 0
+          fi
+          echo "::error::PRs to main must come from 'develop' (or release-please). This PR's head is '$HEAD'."
+          echo "Open this PR against 'develop' instead — use the base-branch dropdown at the top of the PR page."
+          exit 1


### PR DESCRIPTION
## Summary
- Adds `.github/PULL_REQUEST_TEMPLATE.md` for consistent PR descriptions
- Adds `.github/workflows/enforce-main-source.yml` CI guard

## Test plan
- [ ] CI required checks pass on this PR