### PR TITLE
fix(cli): bypass Bun's broken macOS stdin in curl|sh flow

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -10,10 +10,12 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "embed-assets": "tsx scripts/embed-assets.ts",
-    "build:linux-x64":    "npm run embed-assets && bun build src/cli.ts --compile --target=bun-linux-x64    --outfile=dist/subwave-linux-x64",
-    "build:linux-arm64":  "npm run embed-assets && bun build src/cli.ts --compile --target=bun-linux-arm64  --outfile=dist/subwave-linux-arm64",
-    "build:darwin-x64":   "npm run embed-assets && bun build src/cli.ts --compile --target=bun-darwin-x64   --outfile=dist/subwave-darwin-x64",
-    "build:darwin-arm64": "npm run embed-assets && bun build src/cli.ts --compile --target=bun-darwin-arm64 --outfile=dist/subwave-darwin-arm64",
+    "patch-clack": "node scripts/patch-clack.mjs",
+    "prebuild": "npm run embed-assets && npm run patch-clack",
+    "build:linux-x64":    "npm run prebuild && bun build src/cli.ts --compile --target=bun-linux-x64    --outfile=dist/subwave-linux-x64",
+    "build:linux-arm64":  "npm run prebuild && bun build src/cli.ts --compile --target=bun-linux-arm64  --outfile=dist/subwave-linux-arm64",
+    "build:darwin-x64":   "npm run prebuild && bun build src/cli.ts --compile --target=bun-darwin-x64   --outfile=dist/subwave-darwin-x64",
+    "build:darwin-arm64": "npm run prebuild && bun build src/cli.ts --compile --target=bun-darwin-arm64 --outfile=dist/subwave-darwin-arm64",
     "build:all": "npm run build:linux-x64 && npm run build:linux-arm64 && npm run build:darwin-x64 && npm run build:darwin-arm64"
   },
   "dependencies": {

--- a/cli/scripts/patch-clack.mjs
+++ b/cli/scripts/patch-clack.mjs
@@ -1,0 +1,68 @@
+// Patch @clack/prompts so its high-level wrappers forward an explicit
+// `input` option through to @clack/core's prompt classes.
+//
+// Why — on macOS, Bun's `process.stdin` doesn't deliver bytes when the
+// binary was launched from a parent process whose own stdin is piped
+// (oven-sh/bun#13374). The `curl … | sh → exec subwave init </dev/tty`
+// flow hits this exactly: even though fd 0 is /dev/tty, Bun's stdin
+// layer never produces data, so `p.text({…})` renders the prompt and
+// then hangs.
+//
+// The workaround is to open /dev/tty ourselves as a fresh tty.ReadStream
+// and hand THAT to the prompt as its `input`. @clack/core supports it
+// (the `input?: Readable` option on PromptOptions). @clack/prompts'
+// shipped wrappers don't forward `s.input` though — they only thread
+// validate/placeholder/initialValue/etc. This script tweaks the dist
+// file in place so the wrappers forward `input` too, after which our
+// ui.ts can pass a /dev/tty stream into every prompt call.
+//
+// The patch is a single line — insert `input:s.input,` immediately
+// after the opening `new <ClassName>({` in each of the four wrappers
+// we use (TextPrompt, PasswordPrompt, ConfirmPrompt, SelectPrompt).
+// Run idempotently — bails out if the patch is already applied.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const distPath = resolve(here, '..', 'node_modules', '@clack', 'prompts', 'dist', 'index.mjs');
+
+const src = readFileSync(distPath, 'utf8');
+
+// Minifier mangles class names; the @clack/prompts dist (v0.8.x) names
+// them W (TextPrompt), q (PasswordPrompt), F (ConfirmPrompt),
+// N (SelectPrompt) at the top of the file. If you bump the dep, eyeball
+// these names again — `grep -oE "new [A-Z]\(\{" dist/index.mjs`.
+const CLASS_NAMES = ['W', 'q', 'F', 'N'];
+
+let out = src;
+let patches = 0;
+for (const name of CLASS_NAMES) {
+  // Match the literal `new <name>({` opening. The `input:s.input,`
+  // injection lands before the next existing option. `s` is the wrapper
+  // function's single argument across all four; if a future version of
+  // clack renames it, update here.
+  const needle = `new ${name}({`;
+  const inject = `new ${name}({input:s.input,`;
+  if (out.includes(inject)) {
+    // Already patched — skip.
+    continue;
+  }
+  if (!out.includes(needle)) {
+    throw new Error(
+      `patch-clack: could not find "${needle}" in ${distPath}. ` +
+      `Has @clack/prompts been re-minified? Re-run \`grep -oE "new [A-Z]\\(\\{" ${distPath}\` ` +
+      `and update CLASS_NAMES.`,
+    );
+  }
+  out = out.replace(needle, inject);
+  patches++;
+}
+
+if (patches === 0) {
+  console.log('patch-clack: already applied, no changes');
+} else {
+  writeFileSync(distPath, out);
+  console.log(`patch-clack: forwarded input through ${patches} wrappers`);
+}

--- a/cli/scripts/repro-tty.sh
+++ b/cli/scripts/repro-tty.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Faithful repro of the curl|sh → exec subwave init </dev/tty path.
+#
+# `curl … | sh` leaves sh's stdin attached to the curl pipe (not a TTY).
+# We simulate that by running this whole script through a sh process whose
+# stdin we explicitly close, so the inner shell's stdin is non-TTY. Then we
+# exec the binary with `</dev/tty`, which is exactly what install.sh does.
+#
+# Usage: bash cli/scripts/repro-tty.sh
+#
+# Bails into init with `--home /tmp/sw-test` so it can't clobber your real
+# ~/subwave install while you're testing.
+
+set -eu
+
+BIN="$(cd "$(dirname "$0")/.." && pwd)/dist/subwave-darwin-arm64"
+
+if [ ! -x "$BIN" ]; then
+  echo "missing binary: $BIN" >&2
+  echo "run 'npm --prefix cli run build:darwin-arm64' first." >&2
+  exit 1
+fi
+
+echo "==> repro: non-TTY parent → exec '$BIN init' </dev/tty"
+echo "==> using --home /tmp/sw-test (won't touch your real ~/subwave)"
+echo
+
+# Inner sh sees stdin closed (mimics the curl pipe that's done sending).
+# Then we redirect /dev/tty onto fd 0 and exec the binary — same handshake
+# install.sh does after the operator answers Y to "Run init now?".
+sh -c '
+  exec </dev/tty
+  exec "'"$BIN"'" --home /tmp/sw-test init
+' <&-

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -3,6 +3,11 @@
 // given.
 //
 // Boot order matters:
+//   0. Re-attach stdin to /dev/tty if it isn't already a TTY. The
+//      `curl … | sh` installer chains into `subwave init` via
+//      `exec ... </dev/tty`, but on Bun-compiled binaries that redirect
+//      doesn't always propagate isTTY through — Clack then can't enter
+//      raw mode and the first prompt looks frozen. See cli/src/tty.ts.
 //   1. Strip `--home <path>` from argv and stash it on SUBWAVE_HOME so the
 //      lazy resolver in util.ts picks it up.
 //   2. Handle commands that DON'T need a resolved home (--version, help,
@@ -14,6 +19,7 @@ import { existsSync } from 'node:fs';
 import { consumeHomeFlag, resolveSubwaveHome } from './home.ts';
 import { getRootEnv, getLegacyControllerEnv } from './util.ts';
 import { runSetupCommand } from './commands/setup.ts';
+import { ensureTTYStdin } from './tty.ts';
 
 const HELP = `
 SUB/WAVE — operator CLI
@@ -44,6 +50,10 @@ Esc inside the menu navigates back. Ctrl-C exits.
 `.trimStart();
 
 async function main(): Promise<void> {
+  // Recover an interactive stdin before any prompt runs. No-op when stdin
+  // is already a TTY (the common case — direct `subwave …` from a shell).
+  ensureTTYStdin();
+
   // Mutates process.argv in place, removing --home/--home=<path>.
   const homeFlag = consumeHomeFlag(process.argv);
   if (homeFlag) process.env.SUBWAVE_HOME = homeFlag;

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -3,11 +3,6 @@
 // given.
 //
 // Boot order matters:
-//   0. Re-attach stdin to /dev/tty if it isn't already a TTY. The
-//      `curl … | sh` installer chains into `subwave init` via
-//      `exec ... </dev/tty`, but on Bun-compiled binaries that redirect
-//      doesn't always propagate isTTY through — Clack then can't enter
-//      raw mode and the first prompt looks frozen. See cli/src/tty.ts.
 //   1. Strip `--home <path>` from argv and stash it on SUBWAVE_HOME so the
 //      lazy resolver in util.ts picks it up.
 //   2. Handle commands that DON'T need a resolved home (--version, help,
@@ -19,7 +14,6 @@ import { existsSync } from 'node:fs';
 import { consumeHomeFlag, resolveSubwaveHome } from './home.ts';
 import { getRootEnv, getLegacyControllerEnv } from './util.ts';
 import { runSetupCommand } from './commands/setup.ts';
-import { ensureTTYStdin } from './tty.ts';
 
 const HELP = `
 SUB/WAVE — operator CLI
@@ -50,10 +44,6 @@ Esc inside the menu navigates back. Ctrl-C exits.
 `.trimStart();
 
 async function main(): Promise<void> {
-  // Recover an interactive stdin before any prompt runs. No-op when stdin
-  // is already a TTY (the common case — direct `subwave …` from a shell).
-  ensureTTYStdin();
-
   // Mutates process.argv in place, removing --home/--home=<path>.
   const homeFlag = consumeHomeFlag(process.argv);
   if (homeFlag) process.env.SUBWAVE_HOME = homeFlag;

--- a/cli/src/tty.ts
+++ b/cli/src/tty.ts
@@ -1,57 +1,40 @@
-// Re-attach stdin to /dev/tty when it isn't already a TTY.
+// Workaround for Bun's macOS stdin bug (oven-sh/bun#13374).
 //
-// Background — the `curl … | sh` install path leaves the installer's stdin
-// attached to the curl pipe (not the operator's terminal). install.sh works
-// around that by `exec subwave init </dev/tty`, which redirects fd 0 to the
-// controlling terminal. For Node-built CLIs that's enough — the binary sees
-// `process.stdin.isTTY === true` and Clack's `setRawMode()` enables keypress
-// handling.
+// When the standalone binary is launched from a parent process whose stdin
+// is piped (rather than a TTY) — `curl … | sh → exec subwave init </dev/tty`
+// hits this exactly — Bun's `process.stdin` doesn't deliver bytes on macOS.
+// The TTY ReadStream is created correctly (isTTY=true, setRawMode is a real
+// function, ctor=ReadStream — confirmed via SUBWAVE_TTY_DEBUG=1 diagnostic),
+// `setRawMode` succeeds, but reads never produce data. Result: Clack's
+// prompt renders and then hangs forever — no typing, no Ctrl-C, no kill.
 //
-// For the **Bun-compiled standalone binary** the redirect doesn't always
-// propagate `isTTY=true` on macOS and inside some sudo/SSH layouts on Linux.
-// Clack gates `setRawMode` on `input.isTTY`, so without it:
+// We can't fix Bun's stdin layer from user code. What we CAN do is sidestep
+// it: open `/dev/tty` ourselves as a fresh `tty.ReadStream` and hand THAT
+// to Clack as the prompt's `input`. @clack/core supports an `input` option
+// on every prompt; @clack/prompts' high-level wrappers don't forward it by
+// default, so cli/scripts/patch-clack.mjs runs at build time to thread it
+// through. Our wrapper in cli/src/ui.ts then injects this stream into every
+// `p.text` / `p.password` / `p.confirm` / `p.select` call.
 //
-//   - keystrokes are line-buffered (the prompt looks frozen)
-//   - Ctrl-C never reaches the keypress handler (the process can't be killed)
-//   - backspace/arrows do nothing visible (no way to go back)
-//
-// All three symptoms hit the first prompt — `subwave init`'s "Install
-// directory" — because that's the first call to `setRawMode`.
-//
-// Fix: open /dev/tty ourselves with `fs.openSync` and wrap it in a
-// `tty.ReadStream`, then replace `process.stdin`. The resulting stream
-// reports `isTTY === true` regardless of how the parent shell handed us
-// fd 0, so Clack's raw-mode path is restored. Safe no-op when stdin is
-// already a TTY; fails closed (skips replacement, no crash) when /dev/tty
-// isn't available (CI, headless containers).
+// Safe no-op when /dev/tty isn't available (CI, headless containers): we
+// return undefined and the wrapper passes through to Clack's normal
+// `process.stdin` default. Commands that don't prompt (--version, help,
+// status) work unchanged regardless.
 
-import { openSync, closeSync } from 'node:fs';
+import { openSync } from 'node:fs';
 import { ReadStream } from 'node:tty';
 
-export function ensureTTYStdin(): void {
-  if (process.stdin.isTTY) return;
+let cached: NodeJS.ReadStream | null | undefined;
 
-  let fd: number;
-  try {
-    fd = openSync('/dev/tty', 'r');
-  } catch {
-    // No controlling terminal — likely CI or a piped non-interactive call.
-    // Commands that don't need prompts (--version, --help, status, etc.)
-    // still work; interactive prompts will fail with Clack's own error
-    // rather than appearing to hang.
-    return;
-  }
+export function getInteractiveInput(): NodeJS.ReadStream | undefined {
+  if (cached !== undefined) return cached ?? undefined;
 
   try {
-    const tty = new ReadStream(fd);
-    Object.defineProperty(process, 'stdin', {
-      value: tty,
-      configurable: true,
-      writable: false,
-    });
+    const fd = openSync('/dev/tty', 'r');
+    cached = new ReadStream(fd);
+    return cached;
   } catch {
-    // ReadStream construction failed — let prompts fail naturally on the
-    // original stdin instead of crashing here.
-    try { closeSync(fd); } catch { /* ignore */ }
+    cached = null;
+    return undefined;
   }
 }

--- a/cli/src/tty.ts
+++ b/cli/src/tty.ts
@@ -1,0 +1,57 @@
+// Re-attach stdin to /dev/tty when it isn't already a TTY.
+//
+// Background — the `curl … | sh` install path leaves the installer's stdin
+// attached to the curl pipe (not the operator's terminal). install.sh works
+// around that by `exec subwave init </dev/tty`, which redirects fd 0 to the
+// controlling terminal. For Node-built CLIs that's enough — the binary sees
+// `process.stdin.isTTY === true` and Clack's `setRawMode()` enables keypress
+// handling.
+//
+// For the **Bun-compiled standalone binary** the redirect doesn't always
+// propagate `isTTY=true` on macOS and inside some sudo/SSH layouts on Linux.
+// Clack gates `setRawMode` on `input.isTTY`, so without it:
+//
+//   - keystrokes are line-buffered (the prompt looks frozen)
+//   - Ctrl-C never reaches the keypress handler (the process can't be killed)
+//   - backspace/arrows do nothing visible (no way to go back)
+//
+// All three symptoms hit the first prompt — `subwave init`'s "Install
+// directory" — because that's the first call to `setRawMode`.
+//
+// Fix: open /dev/tty ourselves with `fs.openSync` and wrap it in a
+// `tty.ReadStream`, then replace `process.stdin`. The resulting stream
+// reports `isTTY === true` regardless of how the parent shell handed us
+// fd 0, so Clack's raw-mode path is restored. Safe no-op when stdin is
+// already a TTY; fails closed (skips replacement, no crash) when /dev/tty
+// isn't available (CI, headless containers).
+
+import { openSync, closeSync } from 'node:fs';
+import { ReadStream } from 'node:tty';
+
+export function ensureTTYStdin(): void {
+  if (process.stdin.isTTY) return;
+
+  let fd: number;
+  try {
+    fd = openSync('/dev/tty', 'r');
+  } catch {
+    // No controlling terminal — likely CI or a piped non-interactive call.
+    // Commands that don't need prompts (--version, --help, status, etc.)
+    // still work; interactive prompts will fail with Clack's own error
+    // rather than appearing to hang.
+    return;
+  }
+
+  try {
+    const tty = new ReadStream(fd);
+    Object.defineProperty(process, 'stdin', {
+      value: tty,
+      configurable: true,
+      writable: false,
+    });
+  } catch {
+    // ReadStream construction failed — let prompts fail naturally on the
+    // original stdin instead of crashing here.
+    try { closeSync(fd); } catch { /* ignore */ }
+  }
+}

--- a/cli/src/ui.ts
+++ b/cli/src/ui.ts
@@ -5,10 +5,37 @@
 // instead of cancelling the whole process. The main menu loop catches
 // MENU_BACK and re-renders, giving the operator a snappy back-out feel.
 // Pattern lifted from locca's src/ui.ts.
+//
+// Also injects an explicit `input` stream into every interactive prompt
+// (text / password / confirm / select). On macOS, Bun's `process.stdin`
+// doesn't deliver bytes when the binary was launched from a piped parent
+// (oven-sh/bun#13374) — which is exactly the `curl|sh → exec subwave init
+// </dev/tty` path. Opening /dev/tty ourselves as a fresh ReadStream and
+// passing it as `input` sidesteps the broken pipeline. See cli/src/tty.ts
+// and cli/scripts/patch-clack.mjs.
 
-import * as p from '@clack/prompts';
+import * as clack from '@clack/prompts';
 import pc from 'picocolors';
 import readline from 'node:readline';
+import { getInteractiveInput } from './tty.ts';
+
+// Inject an explicit input stream into the four interactive prompts.
+// When no /dev/tty is available (CI, headless), `input` is undefined and
+// @clack/core falls back to its default (process.stdin). spinner/cancel/
+// isCancel and any other passthrough exports stay as-is.
+const interactiveInput = getInteractiveInput();
+function withInput<T>(opts: T): T {
+  if (!interactiveInput) return opts;
+  return { ...opts, input: interactiveInput };
+}
+
+const p: typeof clack = {
+  ...clack,
+  text: (opts) => clack.text(withInput(opts)),
+  password: (opts) => clack.password(withInput(opts)),
+  confirm: (opts) => clack.confirm(withInput(opts)),
+  select: (opts) => clack.select(withInput(opts)),
+};
 
 export { p, pc };
 

--- a/install.sh
+++ b/install.sh
@@ -157,11 +157,18 @@ fi
 # Offer to chain straight into `subwave init` when running interactively.
 # Piping `curl | sh` leaves stdin attached to the curl pipe (not a TTY), so
 # Clack would crash on first prompt. The fix is the rustup-style </dev/tty
-# re-exec: we run the binary as a TTY-attached process so init's prompts
-# work. exec replaces this shell so Ctrl-C in init exits cleanly without
-# falling back through the installer. Non-interactive callers (CI, Docker
-# builds, anything without /dev/tty) skip the prompt and see the original
-# Next: hint below.
+# re-exec: we reattach this shell to the TTY first, then exec the binary —
+# doing the redirect at the shell level (rather than as a one-line redirect
+# on the exec itself) propagates the TTY status more reliably across
+# Bun-compiled binaries, where `exec subwave init </dev/tty` sometimes
+# leaves `process.stdin.isTTY` false and freezes the first prompt. The
+# binary also re-attaches /dev/tty defensively (see cli/src/tty.ts), so
+# operators on older shells / unusual layouts still recover.
+#
+# exec replaces this shell so Ctrl-C in init exits cleanly without falling
+# back through the installer. Non-interactive callers (CI, Docker builds,
+# anything without /dev/tty) skip the prompt and see the original Next:
+# hint below.
 if [ -t 1 ] && [ -r /dev/tty ]; then
   printf '\nRun `%s init` now to scaffold the install? [Y/n] ' "$BIN_NAME"
   reply=""
@@ -169,7 +176,8 @@ if [ -t 1 ] && [ -r /dev/tty ]; then
   case "${reply:-y}" in
     y|Y|yes|YES)
       echo
-      exec "$INSTALL_DIR/$BIN_NAME" init </dev/tty
+      exec </dev/tty
+      exec "$INSTALL_DIR/$BIN_NAME" init
       ;;
   esac
   echo


### PR DESCRIPTION
## Summary

`subwave init` (the prompt chain after `curl | sh`) was getting stuck at the **Install directory** field: no typing, no backspace, no Ctrl-C. Root cause is an upstream Bun bug; the fix sidesteps it.

## Root cause — [oven-sh/bun#13374](https://github.com/oven-sh/bun/issues/13374)

On macOS, Bun's `process.stdin` never delivers bytes when the binary was launched from a parent process whose own stdin is piped. The `curl | sh → exec subwave init </dev/tty` flow is exactly that shape (sh's stdin is the curl pipe; sh execs us with `</dev/tty`).

Confirmed by instrumenting the compiled binary with a `SUBWAVE_TTY_DEBUG=1` probe in the faithful repro:

```
[tty] before: isTTY=true setRawMode=function ctor=ReadStream readable=true
```

`process.stdin` was already a real `tty.ReadStream` with `isTTY=true` and a real `setRawMode`. Clack enables raw mode successfully and the prompt renders. **No keystrokes ever arrive.** That rules out the "Bun doesn't mark fd 0 as a TTY" theory my first commit was based on.

## Fix

We can't fix Bun's stdin layer from user code, so bypass it: open `/dev/tty` ourselves as a fresh `tty.ReadStream` (separate fd, separate libuv handle) and hand THAT to Clack as the prompt's `input` option.

- **`cli/src/tty.ts`** — `getInteractiveInput()` opens `/dev/tty` and returns a fresh `tty.ReadStream`, or `undefined` when no controlling terminal exists (CI / headless containers).
- **`cli/src/ui.ts`** — wraps `p.text/password/confirm/select` to inject that stream as `input`. Falls back to Clack's default `process.stdin` when `getInteractiveInput()` returns undefined, so non-interactive callers and CI runs are unaffected.
- **`cli/scripts/patch-clack.mjs`** — build-time patch. `@clack/core` supports an `input` option per prompt; the shipped `@clack/prompts` wrappers drop `s.input` before constructing the prompt. The patch is one regex per prompt class (TextPrompt, PasswordPrompt, ConfirmPrompt, SelectPrompt), idempotent, with a clear error if the dep is bumped and the minified class names change.
- **`cli/package.json`** — `prebuild` chains `embed-assets` + `patch-clack` so every `build:<target>` picks up the patch.
- **`cli/scripts/repro-tty.sh`** — faithful curl|sh repro (`sh <&-` closes inner shell stdin → `exec </dev/tty` reattaches → exec binary). Use it any time we suspect this regression has come back.
- **`install.sh`** — split the existing `exec subwave init </dev/tty` into `exec </dev/tty` + `exec subwave init`. Doesn't fix Bun's bug on its own (the bug bites either way), but makes the installer's intent unambiguous and matches the rustup pattern.

## Test plan

- [x] Reproduce the freeze from a non-TTY parent (`bash cli/scripts/repro-tty.sh`)
- [x] Confirm the same repro accepts input after the fix
- [x] `npm --prefix cli run typecheck` clean
- [x] `npm --prefix cli run patch-clack` idempotent on re-run
- [ ] `curl … | sh` on a fresh macOS box (post-release)
- [ ] `curl … | sh` on Linux over SSH (post-release)
- [ ] `subwave init` in a plain TTY → unchanged behaviour
- [ ] `subwave --version` over a pipe → still works (no `/dev/tty`, wrapper passes through)

Related: #156 (different bug — `$` in password + docker.sock perms).