### PR TITLE
fix(broadcast): expand strftime in hourly archive path

### DIFF
--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -597,7 +597,11 @@ stream_up()
 # guard the entire output so operators who don't use the archives don't pay
 # for the encoder. Bitrate is selected from a fixed set because `%mp3(bitrate=…)`
 # requires a literal int at parse time (we can't pass a ref).
-archive_path = "/var/sub-wave/archive/%Y-%m-%d/%H-00.mp3"
+# Wrap in `{time.string(...)}` so the path is a getter that re-runs strftime
+# each time `output.file` reopens (every hour via reopen_when). Passing the
+# bare string skips strftime entirely and writes everything to one literal
+# "%Y-%m-%d/%H-00.mp3" file that gets truncated at the top of each hour.
+archive_path = {time.string("/var/sub-wave/archive/%Y-%m-%d/%H-00.mp3")}
 if archive_enabled() then
   br = archive_bitrate()
   if br <= 64 then


### PR DESCRIPTION
## Summary
- The hourly archive output in `liquidsoap/radio.liq` passed a bare string `"/var/sub-wave/archive/%Y-%m-%d/%H-00.mp3"` to `output.file`. Liquidsoap 2.2 only runs strftime when the path is a getter — bare strings are taken literally.
- Result: Liquidsoap created one literal `state/archive/%Y-%m-%d/` directory with one `%H-00.mp3` file inside, and `reopen_when={0m0s}` truncated that same file at the top of every hour (no `append`). Only the current ~hour ever existed on disk, so the admin Archives panel always reported "no recordings yet" no matter how long the station had been running.
- Fix: wrap the path in `{time.string(...)}` so it's a getter that re-runs strftime on each reopen, producing the intended `YYYY-MM-DD/HH-00.mp3` layout the `routes/archives.ts` indexer is already looking for.

## Test plan
- [ ] `docker compose up -d --build broadcast` on the prod host
- [ ] Confirm a new dated directory appears under `state/archive/` within the current hour (e.g. `state/archive/2026-05-28/`) with `00-00.mp3`/`01-00.mp3`/… filling in over time
- [ ] Hit `/admin/archives` and verify entries now appear and download
- [ ] Delete the stale `state/archive/%Y-%m-%d/` directory once the new layout is confirmed