### PR TITLE
fix(web): mobile layout regressions in admin panels

### DIFF
--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -851,9 +851,9 @@ function TaggerStrip(p: TaggerStripProps) {
   return (
     <div className="sticky bottom-3 z-30">
       <section className="card border-ink shadow-[0_4px_24px_rgba(0,0,0,0.18)]">
-        <div className="grid grid-cols-[1fr_auto] items-center gap-3 p-3">
+        <div className="stack-mobile grid grid-cols-[1fr_auto] items-center gap-3 p-3">
           <div className="grid gap-1.5">
-            <div className="flex items-center gap-3 text-[12px]">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[12px]">
               <span className={cn('h-2 w-2 rounded-full', running ? 'animate-pulse bg-vermilion' : 'bg-muted')} />
               <span className="font-bold">
                 {p.coverage?.tagged?.toLocaleString('en-GB') || '—'}
@@ -874,7 +874,7 @@ function TaggerStrip(p: TaggerStripProps) {
               </div>
             )}
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <Input
               type="number"
               inputMode="numeric"

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -374,7 +374,7 @@ export default function PersonasPanel() {
     <div className="grid gap-4">
       {/* ── HERO ─────────────────────────────────────────────────────────── */}
       <section className="card">
-        <div className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-ink p-4">
+        <div className="stack-mobile grid grid-cols-[1fr_auto] items-center gap-4 border-b border-ink p-4">
           <div>
             <Eyebrow className="text-vermilion">personas</Eyebrow>
             <div className="mt-1.5 text-[22px] font-extrabold tracking-[-0.02em]">
@@ -385,7 +385,7 @@ export default function PersonasPanel() {
               Every change applies live; no mixer restart.
             </div>
           </div>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             <Btn onClick={() => setShowPrompt(s => !s)}>
               {showPrompt ? 'Hide system prompt' : 'System prompt'}
             </Btn>

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -485,7 +485,7 @@ export default function SettingsPanel() {
   return (
     <div className="stack-mobile grid grid-cols-[240px_1fr] items-start gap-6">
       {/* Section rail */}
-      <aside className="sticky top-6 grid gap-1">
+      <aside className="grid gap-1 sm:sticky sm:top-6">
         <span className="caption pb-2">settings</span>
         {SECTIONS.map(s => {
           const isActive = activeSection === s.id;


### PR DESCRIPTION
## Summary

Three small fixes to the `/admin` UI on mobile (≤640px), spotted in screenshots from the live site:

- **Settings** — section rail (`TTS VOICE`, `LLM PROVIDER`, …) was `sticky top-6` even after `stack-mobile` collapsed the layout to one column, so the rail's full-height stack of cards stayed pinned over the active section content as the user scrolled. Move to `sm:sticky sm:top-6` so sticky only kicks in once the two-column layout is back.
- **Personas** — hero `grid-cols-[1fr_auto]` left the `+ Add persona` button clipped by the right edge on ~360px screens. Add `stack-mobile` + `flex-wrap` so the button row drops under the heading on narrow viewports.
- **Library** — sticky tagger strip (limit input + Start tagging + log) was cramped on mobile. Same `stack-mobile` + `flex-wrap` treatment.

## Test plan

- [ ] Visit `/admin/settings` on a phone-width viewport, scroll: section rail should scroll with the page, not overlap the active section card.
- [ ] Visit `/admin/personas` on a phone-width viewport: `+ Add persona` and `System prompt` buttons should sit under the heading, fully inside the viewport.
- [ ] Visit `/admin/library` on a phone-width viewport: tagger strip controls should wrap cleanly, including while a tag run is active (the `pid … started …` caption no longer overflows).
- [ ] Sanity-check the same three pages on desktop — no visual change above 640px.

https://claude.ai/code/session_01Hcc5qVDf5m8tMFqT4uCX7L

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hcc5qVDf5m8tMFqT4uCX7L)_