### PR TITLE
feat(controller): support imperial weather units (closes #173)

### DIFF
--- a/controller/src/config.ts
+++ b/controller/src/config.ts
@@ -154,6 +154,9 @@ export const config = {
     lat: 52.5862,
     lng: -2.1288,
     locationName: 'Wolverhampton',
+    // 'metric' → Celsius, 'imperial' → Fahrenheit. Drives Open-Meteo's
+    // temperature_unit query param and what unit the DJ announces on air.
+    units: 'metric' as 'metric' | 'imperial',
   },
   news: {
     feedUrl: process.env.NEWS_FEED_URL || 'http://feeds.bbci.co.uk/news/rss.xml',

--- a/controller/src/context.ts
+++ b/controller/src/context.ts
@@ -63,8 +63,11 @@ export async function getWeather() {
   if (weatherCache.data && Date.now() - weatherCache.fetchedAt < WEATHER_TTL_MS) {
     return weatherCache.data;
   }
+  const imperial = config.weather.units === 'imperial';
+  const tempUnit = imperial ? 'F' : 'C';
   try {
-    const url = `https://api.open-meteo.com/v1/forecast?latitude=${config.weather.lat}&longitude=${config.weather.lng}&current=temperature_2m,weather_code,is_day`;
+    const unitParam = imperial ? '&temperature_unit=fahrenheit' : '';
+    const url = `https://api.open-meteo.com/v1/forecast?latitude=${config.weather.lat}&longitude=${config.weather.lng}&current=temperature_2m,weather_code,is_day${unitParam}`;
     const res = await fetch(url);
     const data = await res.json() as any;
     const code = data.current.weather_code;
@@ -73,13 +76,14 @@ export async function getWeather() {
       condition,
       mood: weatherToMood(condition),
       temp: Math.round(data.current.temperature_2m),
+      tempUnit,
       isDay: data.current.is_day === 1,
       location: config.weather.locationName,
     };
     weatherCache = { data: result, fetchedAt: Date.now() };
     return result;
   } catch {
-    return { condition: 'unknown', mood: null, temp: null, location: config.weather.locationName };
+    return { condition: 'unknown', mood: null, temp: null, tempUnit, location: config.weather.locationName };
   }
 }
 

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -139,7 +139,7 @@ export function buildContextLines(context: any, { recentTracks }: { recentTracks
   }
   if (context?.time) lines.push(`Period: ${context.time.period} (${context.time.vibe})`);
   if (context?.weather && context.weather.condition && context.weather.condition !== 'unknown') {
-    lines.push(`Weather in ${context.weather.location}: ${context.weather.condition}${context.weather.temp != null ? `, ${context.weather.temp}°C` : ''}`);
+    lines.push(`Weather in ${context.weather.location}: ${context.weather.condition}${context.weather.temp != null ? `, ${context.weather.temp}°${context.weather.tempUnit || 'C'}` : ''}`);
   }
   if (context?.festival) lines.push(`Festival: ${context.festival.name}`);
   if (context?.activeShow) {

--- a/controller/src/llm/segment-tools.ts
+++ b/controller/src/llm/segment-tools.ts
@@ -27,7 +27,7 @@ export function buildSegmentTools(ctx: any, state: any, caps: any[]) {
 
   if (kinds.has('weather')) {
     tools.checkWeather = tool({
-      description: 'Get the current weather and whether it has changed since the DJ last spoke about weather on air. Dull or unchanged weather is usually not worth airing.',
+      description: 'Get the current weather and whether it has changed since the DJ last spoke about weather on air. Dull or unchanged weather is usually not worth airing. The temperature is returned in the unit indicated by `tempUnit` ("C" or "F") — read it on air in that unit, do not convert.',
       inputSchema: z.object({}),
       execute: async () => {
         const w = ctx.weather;
@@ -37,6 +37,7 @@ export function buildSegmentTools(ctx: any, state: any, caps: any[]) {
           location: w.location,
           condition: w.condition,
           temp: w.temp ?? null,
+          tempUnit: w.tempUnit || 'C',
           changedSinceLastMention: w.condition !== state.lastWeatherCondition,
         };
       },

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -120,8 +120,12 @@ router.post('/settings', requireAdmin, async (req, res) => {
       config.weather.lat = result.saved.weather.lat;
       config.weather.lng = result.saved.weather.lng;
       config.weather.locationName = result.saved.weather.locationName;
+      config.weather.units = result.saved.weather.units;
       invalidateWeatherCache();
-      queue.log('scheduler', `weather location → ${result.saved.weather.locationName}`);
+      queue.log(
+        'scheduler',
+        `weather location → ${result.saved.weather.locationName} (${result.saved.weather.units})`,
+      );
     }
     if (result.requiresRestart) {
       queue.log('scheduler', `mixer settings changed — Liquidsoap restart required`);

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -99,6 +99,7 @@ app.listen(config.server.port, async () => {
     config.weather.lat = s.weather.lat;
     config.weather.lng = s.weather.lng;
     config.weather.locationName = s.weather.locationName;
+    config.weather.units = s.weather.units;
     await settings.ensureLiquidsoapSettingsFile();
     console.log(
       `[settings] loaded. jingleRatio=${s.jingleRatio} crossfadeDuration=${s.crossfadeDuration} location=${s.weather.locationName}`,

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -242,7 +242,7 @@ const DEFAULTS = {
   // reclaim that headroom (issue #137). Dropping the bitrate (e.g. 128 → 64
   // mono in a future change) also helps for operators who want the tape.
   archive: { enabled: true, bitrate: 128 },
-  weather: { lat: 52.5862, lng: -2.1288, locationName: 'Wolverhampton' },
+  weather: { lat: 52.5862, lng: -2.1288, locationName: 'Wolverhampton', units: 'metric' as 'metric' | 'imperial' },
   // Operator-facing station name. Substituted into the DJ prompt's {station}
   // placeholder and returned by GET /dj for the landing page. The product is
   // still called SUB/WAVE — this is what the operator's station running on it
@@ -599,6 +599,10 @@ export async function load() {
       lat: stored.weather?.lat ?? DEFAULTS.weather.lat,
       lng: stored.weather?.lng ?? DEFAULTS.weather.lng,
       locationName: stored.weather?.locationName ?? DEFAULTS.weather.locationName,
+      units:
+        stored.weather?.units === 'imperial' || stored.weather?.units === 'metric'
+          ? stored.weather.units
+          : DEFAULTS.weather.units,
     },
     djPrompt,
     station:
@@ -1147,6 +1151,12 @@ export async function update(patch) {
     }
     if (typeof w.locationName === 'string' && w.locationName.trim()) {
       next.weather.locationName = w.locationName.trim().slice(0, 80);
+    }
+    if (w.units !== undefined) {
+      if (w.units !== 'metric' && w.units !== 'imperial') {
+        throw new Error("weather.units must be 'metric' or 'imperial'");
+      }
+      next.weather.units = w.units;
     }
   }
   if ('station' in patch) {

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -67,6 +67,7 @@ interface WeatherCfg {
   lat: string;
   lng: string;
   locationName: string;
+  units: 'metric' | 'imperial';
 }
 
 interface CloudTtsCfg {
@@ -185,7 +186,7 @@ interface SettingsData {
     crossfadeDuration?: number;
     archive?: { enabled?: boolean; bitrate?: number };
     station?: string;
-    weather?: { lat?: number; lng?: number; locationName?: string };
+    weather?: { lat?: number; lng?: number; locationName?: string; units?: 'metric' | 'imperial' };
     tts?: {
       defaultEngine?: string;
       kokoro?: { voice?: string };
@@ -295,6 +296,7 @@ export default function SettingsPanel() {
         lat: String(v.weather?.lat ?? ''),
         lng: String(v.weather?.lng ?? ''),
         locationName: v.weather?.locationName ?? '',
+        units: v.weather?.units === 'imperial' ? 'imperial' : 'metric',
       },
       tts: {
         defaultEngine: v.tts?.defaultEngine ?? 'piper',
@@ -2026,6 +2028,7 @@ function StationSection({ data, form, setForm, busy, saveSettings }: SectionProp
       lat: parseFloat(form.weather.lat),
       lng: parseFloat(form.weather.lng),
       locationName: form.weather.locationName,
+      units: form.weather.units,
     },
   });
 
@@ -2094,6 +2097,30 @@ function StationSection({ data, form, setForm, busy, saveSettings }: SectionProp
           <div className="field-hint">
             Where the station broadcasts from — sets the DJ’s {'{location}'} and the Open-Meteo
             weather it reads on air (current: {data.values?.weather?.locationName} @ {data.values?.weather?.lat}, {data.values?.weather?.lng}). Applies live.
+          </div>
+        </div>
+
+        <div className="field">
+          <Label>Weather units</Label>
+          <Select
+            value={form.weather.units}
+            onValueChange={val =>
+              setForm(f => ({
+                ...f,
+                weather: { ...f.weather, units: val === 'imperial' ? 'imperial' : 'metric' },
+              }))
+            }
+          >
+            <SelectTrigger className="w-[240px]"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value="metric">Metric — °C</SelectItem>
+                <SelectItem value="imperial">Imperial — °F</SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <div className="field-hint">
+            What the DJ announces on air (current: {data.values?.weather?.units === 'imperial' ? 'Imperial / °F' : 'Metric / °C'}). Applies live.
           </div>
         </div>
       </Card>


### PR DESCRIPTION
## Summary
- Adds `settings.weather.units` (`'metric' | 'imperial'`, default `metric`), surfaced live via `config.weather.units` like the existing lat/lng/locationName.
- `getWeather()` now asks Open-Meteo for °F when imperial is selected and returns `tempUnit: 'C' | 'F'` alongside `temp`. The DJ prompt context line uses that unit; the segment-director's `checkWeather` tool passes it through with a description that tells the model not to convert.
- Admin Settings → Station gains a units selector (metric/imperial). Saves apply live — no mixer restart, weather cache is invalidated on change.

Closes #173 — operator-reported request to have weather announced in Imperial instead of Metric.

## Test plan
- [x] Set Admin → Station → Weather units to **Imperial**, save. Confirm `state/settings.json` has `weather.units: "imperial"` and `/state` reflects it.
- [x] Hit `GET /now-playing` (or trigger an hourly check) — the controller log should show a Fahrenheit temperature, and the on-air spoken weather line should read in °F.
- [ ] Switch back to **Metric**, save. Confirm the next weather check is in °C (cache should invalidate automatically).
- [ ] Existing installs with no `weather.units` field on disk should keep working — `load()` defaults to `metric`, no migration required.