### PR TITLE
feat(rules): selection rules — excludes + force-inserts

### DIFF
--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -346,6 +346,35 @@ class Queue {
     }
   }
 
+  // Rule-engine entry point. Injects a track picked by a minute-counted
+  // force-insert rule into the queue, optionally with a TTS preface written
+  // by the operator. The track is marked `ruleId` so the now-playing watcher
+  // and the session DJ can recognise it (e.g. don't back-announce a sponsor
+  // read like a regular pick).
+  async injectRule(rule: any, track: any) {
+    const introScript =
+      rule?.djBehavior === 'announce' && rule.announceText ? rule.announceText : null;
+    const item: any = {
+      track,
+      requestedBy: null,
+      intent: null,
+      introScript,
+      aiPicked: false,
+      ruleId: rule.id,
+      ruleName: rule.name,
+      queuedAt: new Date().toISOString(),
+      sent: false,
+    };
+    this.upcoming.push(item);
+    this.log('rule-inject', `${track.title} — ${track.artist}`, {
+      rule: rule.name,
+      cadence: rule.cadence,
+    });
+    this.persist();
+    this.drainToLiquidsoap();
+    return this.upcoming.length;
+  }
+
   // Play a pre-rendered sound effect from the library UNDER the DJ voice.
   // Writes the effect's file path straight to sfx.txt — no TTS, the audio is
   // already rendered. Liquidsoap's sfx_queue mixes it beneath the voice

--- a/controller/src/broadcast/rule-engine.ts
+++ b/controller/src/broadcast/rule-engine.ts
@@ -1,0 +1,265 @@
+// Selection rules — runtime engine.
+//
+// Force-insert rules with a track-counted cadence are realised in Liquidsoap
+// via per-slot playlist files (`state/liquidsoap_rule_N.m3u`). This module
+// resolves each enabled track-counted rule's source to a list of songs and
+// rewrites those files; settings.writeLiquidsoapRuleSlots takes care of the
+// per-slot weight files. A periodic refresh keeps the m3u contents current
+// against Navidrome playlist edits.
+//
+// Minute-counted rules run entirely controller-side. On every minute tick we
+// check `lastFiredAt` against the rule's cadence; due rules pick a track from
+// their source and inject it at the head of the queue. Per-rule runtime state
+// (lastFiredAt, least-recently-played bookkeeping) lives in
+// `state/rules-state.json` — kept out of settings.json so it doesn't churn
+// the operator's config file every minute.
+//
+// Exclude rules are NOT handled here. They're applied inline by
+// music/picker.ts and llm/tools.ts at pick time.
+
+import { writeFile, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { STATE_DIR } from '../config.js';
+import * as settings from '../settings.js';
+import * as subsonic from '../music/subsonic.js';
+import { queue } from './queue.js';
+
+const RULES_STATE_PATH = `${STATE_DIR}/rules-state.json`;
+const RULE_M3U_PATH = (slot: number) => `${STATE_DIR}/liquidsoap_rule_${slot}.m3u`;
+
+type RuleSong = {
+  id: string;
+  title: string;
+  artist: string;
+  album?: string;
+  year?: number;
+  genre?: string;
+  path?: string;
+};
+
+type RuleState = {
+  // ISO timestamp the rule last fired (any cadence kind).
+  lastFiredAt?: string;
+  // For pickStrategy: 'least-recently-played' — map of subsonic song id to
+  // ISO timestamp of last pick. Capped to ~200 entries per rule.
+  playedAt?: Record<string, string>;
+};
+
+type RulesStateFile = {
+  rules: Record<string, RuleState>;
+};
+
+let stateCache: RulesStateFile = { rules: {} };
+let stateLoaded = false;
+
+async function loadState(): Promise<RulesStateFile> {
+  if (stateLoaded) return stateCache;
+  stateLoaded = true;
+  if (!existsSync(RULES_STATE_PATH)) {
+    stateCache = { rules: {} };
+    return stateCache;
+  }
+  try {
+    const raw = JSON.parse(await readFile(RULES_STATE_PATH, 'utf8'));
+    stateCache = raw && typeof raw === 'object' && raw.rules ? raw : { rules: {} };
+  } catch {
+    stateCache = { rules: {} };
+  }
+  return stateCache;
+}
+
+let persistTimer: NodeJS.Timeout | null = null;
+function persistState() {
+  if (persistTimer) return;
+  persistTimer = setTimeout(async () => {
+    persistTimer = null;
+    try {
+      await writeFile(RULES_STATE_PATH, JSON.stringify(stateCache, null, 2));
+    } catch (err: any) {
+      queue.log('error', `rule-engine: persist failed: ${err.message}`);
+    }
+  }, 500);
+}
+
+// Source resolution. Returns a (possibly empty) array of subsonic-shaped songs.
+async function resolveSongs(rule: any): Promise<RuleSong[]> {
+  const { kind, ref } = rule.source;
+  try {
+    if (kind === 'playlist') return (await subsonic.getPlaylist(ref)) || [];
+    if (kind === 'album') return (await subsonic.getAlbum(ref)) || [];
+    if (kind === 'genre') return await subsonic.getSongsByGenre(ref, { count: 200 });
+    if (kind === 'artist') {
+      const artist = await subsonic.getArtist(ref);
+      if (!artist) return [];
+      const out: RuleSong[] = [];
+      for (const a of (artist.album || []).slice(0, 20)) {
+        try {
+          const songs = await subsonic.getAlbum(a.id);
+          out.push(...songs);
+        } catch {}
+      }
+      return out;
+    }
+  } catch (err: any) {
+    queue.log('error', `rule-engine: ${rule.id} source resolve failed: ${err.message}`);
+  }
+  return [];
+}
+
+// Materialise the m3u for every enabled track-counted rule, one per slot. The
+// per-slot ratio files are written by settings.writeLiquidsoapRuleSlots; this
+// module handles the playlist contents only.
+async function materialiseTrackSlots(rules: any[]) {
+  const trackRules = rules
+    .filter(
+      (r: any) =>
+        r.enabled &&
+        r.mode === 'force-insert' &&
+        r.cadence?.kind === 'every-n-tracks',
+    )
+    .slice(0, settings.RULES_TRACK_SLOT_CAP);
+  for (let slot = 1; slot <= settings.RULES_TRACK_SLOT_CAP; slot++) {
+    const rule = trackRules[slot - 1];
+    const songs = rule ? await resolveSongs(rule) : [];
+    const lines = songs
+      .filter((s: any) => s?.id)
+      .map((s: any) => subsonic.getAnnotatedUri(s));
+    await writeFile(RULE_M3U_PATH(slot), lines.join('\n') + (lines.length ? '\n' : ''));
+    if (rule && lines.length === 0) {
+      queue.log(
+        'rules',
+        `rule "${rule.name}" resolved to 0 tracks — slot ${slot} inert`,
+      );
+    }
+  }
+}
+
+// Pick one song from a resolved list according to the rule's pickStrategy.
+function pickFromSource(rule: any, songs: RuleSong[], state: RuleState): RuleSong | null {
+  if (!songs.length) return null;
+  if (rule.pickStrategy === 'least-recently-played') {
+    const seen = state.playedAt || {};
+    // Sort by last-played ASC, never-played first.
+    const ranked = [...songs].sort((a, b) => {
+      const ta = seen[a.id] || '';
+      const tb = seen[b.id] || '';
+      if (ta && !tb) return 1;
+      if (!ta && tb) return -1;
+      return ta.localeCompare(tb);
+    });
+    return ranked[0];
+  }
+  return songs[Math.floor(Math.random() * songs.length)];
+}
+
+function recordPlay(state: RuleState, songId: string) {
+  if (!state.playedAt) state.playedAt = {};
+  state.playedAt[songId] = new Date().toISOString();
+  // Cap the played-at map so a long-running station doesn't accumulate
+  // unbounded data. Keep the most recent 200 entries.
+  const entries = Object.entries(state.playedAt);
+  if (entries.length > 200) {
+    entries.sort(([, a], [, b]) => b.localeCompare(a));
+    state.playedAt = Object.fromEntries(entries.slice(0, 200));
+  }
+}
+
+// Effective cadence in milliseconds for a minute-counted rule, with optional
+// jitter applied per fire so back-to-back intervals don't feel mechanical.
+function minuteCadenceMs(rule: any): number {
+  const base = rule.cadence.value * 60_000;
+  const jitter = rule.cadence.jitter || 0;
+  if (!jitter) return base;
+  const factor = 1 + ((Math.random() * 2 - 1) * jitter) / 100;
+  return Math.round(base * factor);
+}
+
+// Fire one minute-counted rule: resolve, pick, optionally TTS-intro, inject.
+async function fireMinuteRule(rule: any, state: RuleState) {
+  const songs = await resolveSongs(rule);
+  if (!songs.length) {
+    queue.log('rules', `rule "${rule.name}" due but source resolved 0 tracks`);
+    return;
+  }
+  const song = pickFromSource(rule, songs, state);
+  if (!song) return;
+  await queue.injectRule(rule, song);
+  recordPlay(state, song.id);
+  state.lastFiredAt = new Date().toISOString();
+  persistState();
+}
+
+// Scheduler entry point — called once per minute. Walks the enabled minute-
+// counted rules and fires any that are due.
+export async function tick() {
+  const all = settings.get().rules || [];
+  const minuteRules = all.filter(
+    (r: any) =>
+      r.enabled &&
+      r.mode === 'force-insert' &&
+      r.cadence?.kind === 'every-n-minutes',
+  );
+  if (!minuteRules.length) return;
+  const state = await loadState();
+  const now = Date.now();
+  for (const rule of minuteRules) {
+    const rs = (state.rules[rule.id] = state.rules[rule.id] || {});
+    if (rs.lastFiredAt) {
+      const elapsed = now - Date.parse(rs.lastFiredAt);
+      if (elapsed < minuteCadenceMs(rule)) continue;
+    }
+    try {
+      await fireMinuteRule(rule, rs);
+    } catch (err: any) {
+      queue.log('error', `rule-engine: rule "${rule.name}" failed: ${err.message}`);
+    }
+  }
+}
+
+// Called from settings.update() (when rules change) and from the scheduler's
+// periodic refresh tick.
+export async function refresh() {
+  const rules = settings.get().rules || [];
+  await materialiseTrackSlots(rules);
+}
+
+// Test endpoint helper. Given a rule (possibly unsaved), report what it would
+// match (excludes) or what it would pick (force-inserts). Used by
+// POST /api/rules/:id/test.
+export async function testRule(rule: any): Promise<{
+  matched?: number;
+  sample?: { id: string; title: string; artist: string }[];
+  picks?: { id: string; title: string; artist: string }[];
+  error?: string;
+}> {
+  if (!rule) return { error: 'no rule supplied' };
+  try {
+    const songs = await resolveSongs(rule);
+    if (rule.mode === 'exclude') {
+      return {
+        matched: songs.length,
+        sample: songs.slice(0, 5).map(s => ({ id: s.id, title: s.title, artist: s.artist })),
+      };
+    }
+    const state = await loadState();
+    const rs = state.rules[rule.id] || {};
+    const picks: RuleSong[] = [];
+    for (let i = 0; i < 3 && songs.length; i++) {
+      const p = pickFromSource(rule, songs, rs);
+      if (!p) break;
+      picks.push(p);
+      // For the preview, mutate a throwaway copy of state so successive picks
+      // under least-recently-played don't repeat. The real state file is
+      // unchanged.
+      if (rule.pickStrategy === 'least-recently-played') {
+        rs.playedAt = { ...(rs.playedAt || {}), [p.id]: new Date().toISOString() };
+      }
+    }
+    return {
+      matched: songs.length,
+      picks: picks.map(s => ({ id: s.id, title: s.title, artist: s.artist })),
+    };
+  } catch (err: any) {
+    return { error: err.message };
+  }
+}

--- a/controller/src/broadcast/rule-weights.ts
+++ b/controller/src/broadcast/rule-weights.ts
@@ -1,0 +1,54 @@
+// Pure math for translating "every N tracks" force-insert cadences into the
+// integer weights Liquidsoap's `random(...)` operator expects.
+//
+// Layered design (see liquidsoap/radio.liq): the existing
+// `rotate(weights=[1, jingle_ratio], [jingles, music])` is wrapped in a top-
+// level `random(...)` whose first slot is the rotate output and whose
+// remaining slots are the rule sources. Each rule's probability per tick is
+// w_rule_i / total, so "every N tracks" → w_rule_i / total = 1/N.
+//
+// WEIGHT_SCALE must match liquidsoap/radio.liq so a slot file storing the
+// cadence N maps to the same integer weight on both sides. 1000 was chosen
+// because all practical N values (1..1000) round to non-zero integers and the
+// base-radio remainder is always positive.
+
+export const WEIGHT_SCALE = 1000;
+
+export type TrackRule = {
+  id: string;
+  everyN: number;
+};
+
+export type RuleWeights = {
+  radio: number;        // weight of the base (jingles + music) source
+  slots: number[];      // length always equals the slot cap; 0 = inactive
+};
+
+export function computeRuleWeights(
+  trackRules: TrackRule[],
+  slotCap: number,
+): RuleWeights {
+  const slots = new Array(slotCap).fill(0);
+  let ruleSum = 0;
+  trackRules.slice(0, slotCap).forEach((r, i) => {
+    if (!r || !Number.isFinite(r.everyN) || r.everyN < 1) return;
+    const w = Math.max(1, Math.round(WEIGHT_SCALE / r.everyN));
+    slots[i] = w;
+    ruleSum += w;
+  });
+  // Radio always keeps at least weight 1 so the base stream is never starved.
+  // Practically `ruleSum` is small (sum of 1/N reciprocals scaled to 1000),
+  // so the clamp only matters if an operator stacks many extremely fast rules.
+  const radio = Math.max(1, WEIGHT_SCALE - ruleSum);
+  return { radio, slots };
+}
+
+// Reverse map: given the weights for a slot, what cadence does that imply at
+// runtime? Used by the admin UI to show "actual ≈ every 7.2 tracks" next to
+// the operator's requested value.
+export function actualCadence(weights: RuleWeights, slotIndex: number): number {
+  const w = weights.slots[slotIndex];
+  if (!w) return 0;
+  const total = weights.radio + weights.slots.reduce((a, b) => a + b, 0);
+  return Math.round((total / w) * 10) / 10; // one decimal place
+}

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -17,6 +17,7 @@ import { cleanupOldVoices } from '../audio/tts.js';
 import { shouldFire } from './dj-gate.js';
 import { djCallsAllowed } from './listeners.js';
 import { agenticTick, skillCatalog } from '../skills/_agent.js';
+import * as ruleEngine from './rule-engine.js';
 import { withTrace } from '../observability/events.js';
 
 const TARGET_POOL = 30;
@@ -266,9 +267,22 @@ async function cleanup() {
 export function startScheduler() {
   // Initial run
   refreshAutoPlaylist().catch(err => queue.log('error', `Initial playlist failed: ${err.message}`));
+  // Materialise rule slot playlists once on boot so liquidsoap has fresh m3us
+  // even if settings haven't been touched recently.
+  ruleEngine.refresh().catch(err => queue.log('error', `Initial rule refresh failed: ${err.message}`));
 
   // Auto-playlist refresh every 10 minutes
   cron.schedule(`*/${config.show.autoQueueRefreshMinutes} * * * *`, refreshAutoPlaylist);
+
+  // Selection rules — minute-counted force-inserts and periodic m3u refresh.
+  // The tick is cheap when no minute rules exist; the refresh re-resolves
+  // Subsonic-side playlists so operator edits flow into the broadcast.
+  cron.schedule('* * * * *', () => {
+    ruleEngine.tick().catch(err => queue.log('error', `rule-engine tick: ${err.message}`));
+  });
+  cron.schedule('*/10 * * * *', () => {
+    ruleEngine.refresh().catch(err => queue.log('error', `rule-engine refresh: ${err.message}`));
+  });
 
   // Top of every hour
   cron.schedule('0 * * * *', hourlyCheck);

--- a/controller/src/llm/tools.ts
+++ b/controller/src/llm/tools.ts
@@ -11,6 +11,7 @@ import { z } from 'zod';
 import * as subsonic from '../music/subsonic.js';
 import * as library from '../music/library.js';
 import * as embeddings from '../music/embeddings.js';
+import * as excludeFilter from '../music/exclude-filter.js';
 
 function slim(s: any) {
   return {
@@ -62,6 +63,12 @@ export function buildPickerTools({
   const seen = new Map<string, any>(); // id → slim song, accumulated across all tool calls
   const artistCounts = new Map<string, number>(); // artist key → songs already accepted into `seen`
 
+  // Exclude filter — resolved once per tool-set lifetime. The filter object
+  // is captured here so every tool invocation re-uses the same expansion of
+  // playlist/album exclusions (cached internally for 30 min anyway).
+  let excludeP: Promise<excludeFilter.ExcludeFilter> | null = null;
+  const getExclude = () => (excludeP ??= excludeFilter.build());
+
   // Filter recents, slim, and record into `seen` so the picker can resolve
   // the agent's final id choice to a full track. Drops songs by an artist that
   // played in the recent window, and caps any one artist's share of the pool.
@@ -71,11 +78,13 @@ export function buildPickerTools({
   // each tool call regardless.
   const trackKey = (s: any) =>
     `${(s.title || '').toLowerCase().trim()}|${(s.artist || '').toLowerCase().trim()}`;
-  const collect = (list: any, cap = 8) => {
+  const collect = async (list: any, cap = 8) => {
     const out: any[] = [];
+    const exclude = await getExclude();
     for (const s of shuffle((list || []) as any[])) {
       if (!s?.id || recentIds.has(s.id) || seen.has(s.id)) continue;
       if (recentKeys.has(trackKey(s))) continue;   // catches backfilled entries (no id)
+      if (excludeFilter.matches(exclude, s)) continue;
       const key = artistKey(s);
       if (key && recentArtists.has(key)) continue;
       if (key) {

--- a/controller/src/music/exclude-filter.ts
+++ b/controller/src/music/exclude-filter.ts
@@ -1,0 +1,108 @@
+// Exclude-rule resolver for the picker pool and the agent tool surface.
+//
+// Resolves every enabled `mode: 'exclude'` rule into concrete sets the
+// candidate-builder + the AI SDK tools can intersect against. Playlist /
+// album exclusions are expanded into song-id sets so the agent can never
+// fetch a blocked track via similarSongs / searchLibrary / etc.
+
+import * as settings from '../settings.js';
+import * as subsonic from './subsonic.js';
+
+export type ExcludeFilter = {
+  ids: Set<string>;
+  genres: Set<string>;
+  artistIds: Set<string>;
+  artistNames: Set<string>;
+  albumIds: Set<string>;
+  // True iff there is at least one active exclude rule. Cheap shortcut so
+  // hot paths can skip the per-candidate matchExclude call entirely.
+  active: boolean;
+};
+
+const EMPTY: ExcludeFilter = {
+  ids: new Set(),
+  genres: new Set(),
+  artistIds: new Set(),
+  artistNames: new Set(),
+  albumIds: new Set(),
+  active: false,
+};
+
+// Memoised expansion of playlist/album sources to song-id sets. Sources change
+// at human pace; refreshing on every pick would be wasteful.
+const EXPAND_TTL_MS = 30 * 60 * 1000;
+const expandCache = new Map<string, { ids: Set<string>; at: number }>();
+
+async function expandPlaylist(ref: string): Promise<Set<string>> {
+  const key = `playlist:${ref}`;
+  const hit = expandCache.get(key);
+  if (hit && Date.now() - hit.at < EXPAND_TTL_MS) return hit.ids;
+  const ids = new Set<string>();
+  try {
+    const songs = (await subsonic.getPlaylist(ref)) || [];
+    for (const s of songs) if (s?.id) ids.add(s.id);
+  } catch {}
+  expandCache.set(key, { ids, at: Date.now() });
+  return ids;
+}
+
+async function expandAlbum(ref: string): Promise<Set<string>> {
+  const key = `album:${ref}`;
+  const hit = expandCache.get(key);
+  if (hit && Date.now() - hit.at < EXPAND_TTL_MS) return hit.ids;
+  const ids = new Set<string>();
+  try {
+    const songs = (await subsonic.getAlbum(ref)) || [];
+    for (const s of songs) if (s?.id) ids.add(s.id);
+  } catch {}
+  expandCache.set(key, { ids, at: Date.now() });
+  return ids;
+}
+
+export async function build(): Promise<ExcludeFilter> {
+  const rules = (settings.get().rules || []).filter(
+    (r: any) => r.enabled && r.mode === 'exclude',
+  );
+  if (!rules.length) return EMPTY;
+  const out: ExcludeFilter = {
+    ids: new Set(),
+    genres: new Set(),
+    artistIds: new Set(),
+    artistNames: new Set(),
+    albumIds: new Set(),
+    active: true,
+  };
+  for (const r of rules) {
+    const { kind, ref } = r.source;
+    if (kind === 'genre') {
+      out.genres.add(ref.toLowerCase().trim());
+    } else if (kind === 'artist') {
+      // Operators pick artists by id from the autocomplete, so ref is normally
+      // an id — but accept a free-text name match too (case-insensitive)
+      // because the genre/artist autocomplete is best-effort.
+      out.artistIds.add(ref);
+      out.artistNames.add(ref.toLowerCase().trim());
+    } else if (kind === 'album') {
+      out.albumIds.add(ref);
+      for (const id of await expandAlbum(ref)) out.ids.add(id);
+    } else if (kind === 'playlist') {
+      for (const id of await expandPlaylist(ref)) out.ids.add(id);
+    }
+  }
+  return out;
+}
+
+// Matches a single candidate against the filter. Songs that match are blocked.
+export function matches(filter: ExcludeFilter, candidate: any): boolean {
+  if (!filter.active) return false;
+  if (candidate?.id && filter.ids.has(candidate.id)) return true;
+  if (candidate?.albumId && filter.albumIds.has(candidate.albumId)) return true;
+  if (candidate?.artistId && filter.artistIds.has(candidate.artistId)) return true;
+  const artistKey = (candidate?.artist || '').toLowerCase().trim();
+  if (artistKey && filter.artistNames.has(artistKey)) return true;
+  const genreKey = (candidate?.genre || '').toLowerCase().trim();
+  if (genreKey && filter.genres.has(genreKey)) return true;
+  return false;
+}
+
+export const EMPTY_FILTER = EMPTY;

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -9,6 +9,7 @@
 import * as subsonic from './subsonic.js';
 import * as library from './library.js';
 import * as dj from '../llm/dj.js';
+import * as excludeFilter from './exclude-filter.js';
 
 const CANDIDATE_CAP = 18;
 const HISTORY_DEPTH = 4;
@@ -58,12 +59,17 @@ async function tracksFromAlbums(albums: any[], perAlbum: number, max: number) {
 
 async function buildCandidates(mood: string | null | undefined, recentIds: Set<string>, recentArtists: Set<string>, currentTrack: any) {
   await library.load();
+  const exclude = await excludeFilter.build();
   const pool: any[] = [];
   const sources: Record<string, number> = {};
   const add = (label: string, items: any[]) => {
     if (!items?.length) return;
-    pool.push(...items.map((t: any) => ({ ...t, _source: label })));
-    sources[label] = (sources[label] || 0) + items.length;
+    const allowed = exclude.active
+      ? items.filter((t: any) => !excludeFilter.matches(exclude, t))
+      : items;
+    if (!allowed.length) return;
+    pool.push(...allowed.map((t: any) => ({ ...t, _source: label })));
+    sources[label] = (sources[label] || 0) + allowed.length;
   };
 
   // 1. Similar-songs from current track — strongest contextual signal.

--- a/controller/src/music/subsonic.ts
+++ b/controller/src/music/subsonic.ts
@@ -190,6 +190,13 @@ export async function searchArtists(query, { artistCount = 5 } = {}) {
   return r.searchResult3?.artist || [];
 }
 
+// Search just the album index and return matching album objects. Used by the
+// admin selection-rules source picker.
+export async function searchAlbums(query, { albumCount = 20 } = {}) {
+  const r = await call('search3', { query, albumCount, artistCount: 0, songCount: 0 });
+  return r.searchResult3?.album || [];
+}
+
 // Last.fm-backed crowd tags for an artist, normalised to lowercase trimmed
 // strings. Used by the embedding-propagated tagger to enrich the embedding
 // text — see music/embeddings.ts formatTrackText. Returns [] if the artist

--- a/controller/src/routes/library.ts
+++ b/controller/src/routes/library.ts
@@ -88,6 +88,67 @@ router.get('/library/genres', requireAdmin, async (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
+// GET /library/playlists — Navidrome playlists, used by the rules form's
+// source picker. Returns { id, name, songCount }.
+// ---------------------------------------------------------------------------
+router.get('/library/playlists', requireAdmin, async (_req, res) => {
+  try {
+    const playlists = await subsonic.getPlaylists();
+    res.json({
+      playlists: (playlists || []).map((p: any) => ({
+        id: p.id,
+        name: p.name,
+        songCount: p.songCount ?? null,
+      })),
+    });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /library/artists?q=foo — artist autocomplete for the rules form. Empty
+// query returns nothing (the dropdown only loads on type).
+// ---------------------------------------------------------------------------
+router.get('/library/artists', requireAdmin, async (req, res) => {
+  const q = typeof req.query?.q === 'string' ? req.query.q.trim() : '';
+  if (q.length < 2) return res.json({ artists: [] });
+  try {
+    const matches = await subsonic.searchArtists(q, { artistCount: 20 });
+    res.json({
+      artists: (matches || []).map((a: any) => ({
+        id: a.id,
+        name: a.name,
+        albumCount: a.albumCount ?? null,
+      })),
+    });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /library/albums?q=foo — album autocomplete via Subsonic search3.
+// ---------------------------------------------------------------------------
+router.get('/library/albums', requireAdmin, async (req, res) => {
+  const q = typeof req.query?.q === 'string' ? req.query.q.trim() : '';
+  if (q.length < 2) return res.json({ albums: [] });
+  try {
+    const albums = await subsonic.searchAlbums(q, { albumCount: 20 });
+    res.json({
+      albums: (albums || []).map((a: any) => ({
+        id: a.id,
+        name: a.name || a.title,
+        artist: a.artist || null,
+        songCount: a.songCount ?? null,
+      })),
+    });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // GET /library/untagged?limit=&cursor=
 // Cursor is an opaque base64 of `albumOffset:songIndexInAlbum` so the next
 // request resumes where the last one stopped. Returns up to `limit` untagged

--- a/controller/src/routes/rules.ts
+++ b/controller/src/routes/rules.ts
@@ -1,0 +1,59 @@
+// Admin-gated selection rules management. The list is round-tripped wholesale
+// — same pattern as webhooks/personas/shows — so settings.update() handles
+// validation atomically and the response always reflects the saved state.
+import express from 'express';
+import { requireAdmin } from '../middleware/auth.js';
+import * as settings from '../settings.js';
+import * as ruleEngine from '../broadcast/rule-engine.js';
+
+export const router = express.Router();
+
+router.get('/rules', requireAdmin, async (_req, res) => {
+  try {
+    await settings.load();
+    const s = settings.get();
+    res.json({
+      rules: s.rules || [],
+      modes: settings.RULE_MODES,
+      sourceKinds: settings.RULE_SOURCE_KINDS,
+      forceInsertSourceKinds: settings.RULE_FORCE_INSERT_SOURCE_KINDS,
+      cadenceKinds: settings.RULE_CADENCE_KINDS,
+      pickStrategies: settings.RULE_PICK_STRATEGIES,
+      djBehaviors: settings.RULE_DJ_BEHAVIORS,
+      limits: {
+        max: settings.RULES_LIMIT,
+        trackSlotCap: settings.RULES_TRACK_SLOT_CAP,
+      },
+    });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/rules', requireAdmin, async (req, res) => {
+  try {
+    const r = await settings.update({ rules: req.body?.rules });
+    // Re-materialise rule-slot m3us against the new rule set. If this fails
+    // (Subsonic hiccup) we still saved successfully — the periodic refresh
+    // tick will retry.
+    ruleEngine.refresh().catch(() => {});
+    res.json({
+      rules: settings.get().rules || [],
+      requiresRestart: r.requiresRestart,
+    });
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Preview what a rule would do. The rule may be unsaved (the UI sends it in
+// the body) so we don't require it to exist in settings yet.
+router.post('/rules/test', requireAdmin, async (req, res) => {
+  try {
+    const out = await ruleEngine.testRule(req.body?.rule);
+    if (out.error) return res.status(400).json(out);
+    res.json(out);
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -28,6 +28,7 @@ import { router as archivesRoutes } from './routes/archives.js';
 import { router as listenersRoutes } from './routes/listeners.js';
 import { router as webhooksRoutes } from './routes/webhooks.js';
 import { router as scrobbleRoutes } from './routes/scrobble.js';
+import { router as rulesRoutes } from './routes/rules.js';
 import { loadSecretsIntoEnv } from './setup/secrets.js';
 import { loadSetupConfig } from './setup/config.js';
 import { getSetupStatus } from './setup/firstRun.js';
@@ -54,6 +55,7 @@ app.use(archivesRoutes);
 app.use(listenersRoutes);
 app.use(webhooksRoutes);
 app.use(scrobbleRoutes);
+app.use(rulesRoutes);
 
 // (manual skip is not implemented in this build — Liquidsoap controls pacing)
 

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -233,6 +233,27 @@ export const SEED_PERSONAS = [
 // this small set. Add a branch in radio.liq if you add a value here.
 export const ARCHIVE_BITRATES = [64, 96, 128, 160, 192, 320] as const;
 
+// Selection rules — programmable filters over the picker's output. Two modes:
+// `exclude` rules filter `buildCandidates()` in music/picker.ts; `force-insert`
+// rules periodically jam a track from a source into the broadcast. Track-
+// counted cadences run in Liquidsoap (radio.liq fixed rule slots);
+// minute-counted cadences run in the controller scheduler (broadcast/
+// rule-engine.ts). See docs/selection-rules-plan.md for design rationale.
+export const RULE_MODES = ['exclude', 'force-insert'] as const;
+export const RULE_SOURCE_KINDS = ['playlist', 'genre', 'artist', 'album'] as const;
+export const RULE_CADENCE_KINDS = ['every-n-tracks', 'every-n-minutes'] as const;
+export const RULE_PICK_STRATEGIES = ['random', 'least-recently-played'] as const;
+export const RULE_DJ_BEHAVIORS = ['silent', 'announce'] as const;
+// Force-insert sources restricted to scopes that resolve to a concrete track
+// list. Genre/artist are valid exclude scopes but as inserts they're really
+// just biasing the picker pool, not periodic-injection material.
+export const RULE_FORCE_INSERT_SOURCE_KINDS = ['playlist', 'album'] as const;
+export const RULES_LIMIT = 32;
+// Maximum number of track-counted force-insert rules. Hard cap because each
+// occupies a fixed slot in radio.liq's rotate chain — widening this requires
+// extending the rule_slots list in liquidsoap/radio.liq.
+export const RULES_TRACK_SLOT_CAP = 6;
+
 const DEFAULTS = {
   jingleRatio: 30, // 1 jingle per N music tracks
   crossfadeDuration: 10.0, // seconds
@@ -372,6 +393,11 @@ const DEFAULTS = {
   // webhooks.ts for the event list) to `url` with a fire-and-forget HTTP
   // call. Empty by default — operators add hooks via the admin UI.
   webhooks: [] as any[],
+  // Selection rules — see RULE_MODES / RULE_SOURCE_KINDS above. Each entry
+  // is either an exclude filter on the picker pool or a periodic force-
+  // insert into the broadcast. Empty by default — operators add them via
+  // /admin/rules.
+  rules: [] as any[],
   // Station-wide scrobbling. Each backend is independent; both are paste-only
   // (no OAuth) and both are gated on listener count > 0 at scrobble time (a
   // null/unknown count is treated as zero — fail closed, see broadcast/
@@ -753,6 +779,7 @@ export async function load() {
       enabled: typeof stored.sfx?.enabled === 'boolean' ? stored.sfx.enabled : DEFAULTS.sfx.enabled,
     },
     webhooks: normalizeWebhooks(stored.webhooks),
+    rules: normalizeRules(stored.rules),
     scrobble: {
       lastfm: {
         enabled:
@@ -821,6 +848,62 @@ function normalizeWebhooks(raw: any) {
         typeof item.authHeader === 'string' ? item.authHeader.slice(0, 500) : '',
     });
     if (out.length >= WEBHOOKS_LIMIT) break;
+  }
+  return out;
+}
+
+// Lenient normalizer — used by load(). Drops invalid entries silently rather
+// than failing the whole boot. The strict validator (validateRulesStrict)
+// throws; this one only filters.
+function normalizeRules(raw: any) {
+  if (!Array.isArray(raw)) return [];
+  const out: any[] = [];
+  const seen = new Set<string>();
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    if (!RULE_MODES.includes(item.mode)) continue;
+    const src = item.source || {};
+    if (!RULE_SOURCE_KINDS.includes(src.kind)) continue;
+    const ref = typeof src.ref === 'string' ? src.ref.trim() : '';
+    if (!ref || ref.length > 200) continue;
+    const name =
+      typeof item.name === 'string' && item.name.trim()
+        ? item.name.trim().slice(0, 80)
+        : `${item.mode} ${src.kind}`;
+    let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('r_');
+    if (seen.has(id)) id = mintId('r_');
+    seen.add(id);
+    const rule: any = {
+      id,
+      name,
+      enabled: typeof item.enabled === 'boolean' ? item.enabled : true,
+      mode: item.mode,
+      source: { kind: src.kind, ref },
+    };
+    if (item.mode === 'force-insert') {
+      if (!RULE_FORCE_INSERT_SOURCE_KINDS.includes(src.kind)) continue;
+      const cad = item.cadence || {};
+      if (!RULE_CADENCE_KINDS.includes(cad.kind)) continue;
+      const value = parseInt(cad.value, 10);
+      if (!Number.isFinite(value) || value < 1) continue;
+      const ceiling = cad.kind === 'every-n-tracks' ? 1000 : 720;
+      if (value > ceiling) continue;
+      rule.cadence = { kind: cad.kind, value };
+      if (cad.kind === 'every-n-minutes' && Number.isFinite(cad.jitter)) {
+        rule.cadence.jitter = Math.max(0, Math.min(100, Math.floor(cad.jitter)));
+      }
+      rule.pickStrategy = RULE_PICK_STRATEGIES.includes(item.pickStrategy)
+        ? item.pickStrategy
+        : 'random';
+      rule.djBehavior = RULE_DJ_BEHAVIORS.includes(item.djBehavior)
+        ? item.djBehavior
+        : 'silent';
+      if (rule.djBehavior === 'announce' && typeof item.announceText === 'string') {
+        rule.announceText = item.announceText.trim().slice(0, 400);
+      }
+    }
+    out.push(rule);
+    if (out.length >= RULES_LIMIT) break;
   }
   return out;
 }
@@ -1074,6 +1157,115 @@ function validateWebhooksStrict(raw: any, existing: any[] = []) {
       enabled: item.enabled !== false,
       authHeader,
     };
+  });
+}
+
+// Strict validator — used by update(). `existing` is the current list, so a
+// caller can omit the id on edits and we'll mint a fresh one. Throws on the
+// first invalid entry.
+function validateRulesStrict(raw: any) {
+  if (!Array.isArray(raw)) throw new Error('rules must be an array');
+  if (raw.length > RULES_LIMIT) {
+    throw new Error(`rules must be at most ${RULES_LIMIT} entries`);
+  }
+  const seen = new Set<string>();
+  let trackSlotCount = 0;
+  return raw.map((item: any, i: number) => {
+    if (!item || typeof item !== 'object') throw new Error(`rules[${i}] must be an object`);
+    if (!RULE_MODES.includes(item.mode)) {
+      throw new Error(`rules[${i}].mode must be one of: ${RULE_MODES.join(', ')}`);
+    }
+    const src = item.source || {};
+    if (!RULE_SOURCE_KINDS.includes(src.kind)) {
+      throw new Error(
+        `rules[${i}].source.kind must be one of: ${RULE_SOURCE_KINDS.join(', ')}`,
+      );
+    }
+    const ref = String(src.ref ?? '').trim();
+    if (ref.length < 1 || ref.length > 200) {
+      throw new Error(`rules[${i}].source.ref must be 1-200 chars`);
+    }
+    const name = String(item.name ?? '').trim() || `${item.mode} ${src.kind}`;
+    if (name.length > 80) throw new Error(`rules[${i}].name must be 0-80 chars`);
+
+    let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('r_');
+    if (seen.has(id)) id = mintId('r_');
+    seen.add(id);
+
+    const rule: any = {
+      id,
+      name,
+      enabled: item.enabled !== false,
+      mode: item.mode,
+      source: { kind: src.kind, ref },
+    };
+
+    if (item.mode === 'force-insert') {
+      if (!RULE_FORCE_INSERT_SOURCE_KINDS.includes(src.kind)) {
+        throw new Error(
+          `rules[${i}]: force-insert sources must be one of: ${RULE_FORCE_INSERT_SOURCE_KINDS.join(', ')} (genre/artist are exclude-only)`,
+        );
+      }
+      const cad = item.cadence || {};
+      if (!RULE_CADENCE_KINDS.includes(cad.kind)) {
+        throw new Error(
+          `rules[${i}].cadence.kind must be one of: ${RULE_CADENCE_KINDS.join(', ')}`,
+        );
+      }
+      const value = parseInt(cad.value, 10);
+      const ceiling = cad.kind === 'every-n-tracks' ? 1000 : 720;
+      if (!Number.isFinite(value) || value < 1 || value > ceiling) {
+        throw new Error(
+          `rules[${i}].cadence.value must be an integer in [1, ${ceiling}]`,
+        );
+      }
+      rule.cadence = { kind: cad.kind, value };
+      if (cad.kind === 'every-n-minutes') {
+        // Default ±10% jitter so periodic inserts don't feel like a bus timetable.
+        // 0 = exact; explicit number overrides.
+        const j =
+          cad.jitter === undefined ? 10 : parseInt(cad.jitter, 10);
+        if (!Number.isFinite(j) || j < 0 || j > 100) {
+          throw new Error(`rules[${i}].cadence.jitter must be 0-100`);
+        }
+        rule.cadence.jitter = j;
+      } else {
+        if (rule.enabled) {
+          trackSlotCount += 1;
+          if (trackSlotCount > RULES_TRACK_SLOT_CAP) {
+            throw new Error(
+              `at most ${RULES_TRACK_SLOT_CAP} enabled track-counted force-insert rules — convert the rest to minute-counted`,
+            );
+          }
+        }
+      }
+      rule.pickStrategy = item.pickStrategy ?? 'random';
+      if (!RULE_PICK_STRATEGIES.includes(rule.pickStrategy)) {
+        throw new Error(
+          `rules[${i}].pickStrategy must be one of: ${RULE_PICK_STRATEGIES.join(', ')}`,
+        );
+      }
+      rule.djBehavior = item.djBehavior ?? 'silent';
+      if (!RULE_DJ_BEHAVIORS.includes(rule.djBehavior)) {
+        throw new Error(
+          `rules[${i}].djBehavior must be one of: ${RULE_DJ_BEHAVIORS.join(', ')}`,
+        );
+      }
+      if (rule.djBehavior === 'announce') {
+        const text = String(item.announceText ?? '').trim();
+        if (text.length < 1 || text.length > 400) {
+          throw new Error(
+            `rules[${i}].announceText must be 1-400 chars when djBehavior is "announce"`,
+          );
+        }
+        rule.announceText = text;
+      }
+    } else {
+      if (item.cadence !== undefined && item.cadence !== null) {
+        throw new Error(`rules[${i}]: exclude rules must not have a cadence`);
+      }
+    }
+    return rule;
   });
 }
 
@@ -1471,6 +1663,18 @@ export async function update(patch) {
     }
   }
 
+  if ('rules' in patch) {
+    const validated = validateRulesStrict(patch.rules);
+    // Any change that touches the track-counted slot population (count,
+    // ratios, slot indices, sources) needs a Liquidsoap restart so the new
+    // rotate weights take effect. Easiest correct heuristic: compare a
+    // canonical signature of the track-counted subset.
+    const prevSig = trackSlotSignature(cur.rules || []);
+    const nextSig = trackSlotSignature(validated);
+    next.rules = validated;
+    if (prevSig !== nextSig) restart = true;
+  }
+
   // Post-patch integrity sweep — a personas/shows change in this patch may
   // have orphaned a show owner, a schedule slot, or the active persona.
   {
@@ -1592,12 +1796,59 @@ const LIQ_JINGLE_RATIO_PATH = `${STATE_DIR}/liquidsoap_jingle_ratio.txt`;
 const LIQ_CROSSFADE_PATH = `${STATE_DIR}/liquidsoap_crossfade.txt`;
 const LIQ_ARCHIVE_ENABLED_PATH = `${STATE_DIR}/liquidsoap_archive_enabled.txt`;
 const LIQ_ARCHIVE_BITRATE_PATH = `${STATE_DIR}/liquidsoap_archive_bitrate.txt`;
+const LIQ_RULE_RATIO_PATH = (slot: number) =>
+  `${STATE_DIR}/liquidsoap_rule_${slot}_ratio.txt`;
+const LIQ_RULE_M3U_PATH = (slot: number) =>
+  `${STATE_DIR}/liquidsoap_rule_${slot}.m3u`;
+// Stable canonical fingerprint of the enabled track-counted rules. Used to
+// decide whether a settings save needs a Liquidsoap restart (the rotate
+// weights are baked in at parse time, so any change to slot occupancy or
+// ratios needs a restart to take effect).
+function trackSlotSignature(rules: any[]) {
+  const trackRules = (rules || [])
+    .filter(
+      (r: any) =>
+        r &&
+        r.enabled &&
+        r.mode === 'force-insert' &&
+        r.cadence?.kind === 'every-n-tracks',
+    )
+    .map((r: any) => `${r.id}:${r.cadence.value}:${r.source.kind}:${r.source.ref}`)
+    .sort();
+  return trackRules.join('|');
+}
+// Per-slot ratio writer for radio.liq's rule_1..rule_N rotate sources. Slot
+// assignment is by stable order of enabled track-counted rules in settings.
+// Ratio "0" or empty m3u = inert slot. Slots beyond the active rule count get
+// "0" written so the file always exists (radio.liq tolerates missing files,
+// but writing "0" keeps things explicit).
+async function writeLiquidsoapRuleSlots(rules: any[]) {
+  const trackRules = (rules || [])
+    .filter(
+      (r: any) =>
+        r &&
+        r.enabled &&
+        r.mode === 'force-insert' &&
+        r.cadence?.kind === 'every-n-tracks',
+    )
+    .slice(0, RULES_TRACK_SLOT_CAP);
+  for (let slot = 1; slot <= RULES_TRACK_SLOT_CAP; slot++) {
+    const rule = trackRules[slot - 1];
+    await writeFile(LIQ_RULE_RATIO_PATH(slot), rule ? String(rule.cadence.value) : '0');
+    // Create empty m3u if missing so radio.liq's `playlist(...)` always finds
+    // a file. The actual contents are written by rule-engine.materialise.
+    if (!existsSync(LIQ_RULE_M3U_PATH(slot))) {
+      await writeFile(LIQ_RULE_M3U_PATH(slot), '');
+    }
+  }
+}
 
 export async function writeLiquidsoapSettings(s) {
   await writeFile(LIQ_JINGLE_RATIO_PATH, String(s.jingleRatio));
   await writeFile(LIQ_CROSSFADE_PATH, String(s.crossfadeDuration));
   await writeFile(LIQ_ARCHIVE_ENABLED_PATH, s.archive.enabled ? 'true' : 'false');
   await writeFile(LIQ_ARCHIVE_BITRATE_PATH, String(s.archive.bitrate));
+  await writeLiquidsoapRuleSlots(s.rules || []);
 }
 
 // Called from server.js startup so the files exist before Liquidsoap reads
@@ -1608,7 +1859,8 @@ export async function ensureLiquidsoapSettingsFile() {
     !existsSync(LIQ_JINGLE_RATIO_PATH) ||
     !existsSync(LIQ_CROSSFADE_PATH) ||
     !existsSync(LIQ_ARCHIVE_ENABLED_PATH) ||
-    !existsSync(LIQ_ARCHIVE_BITRATE_PATH)
+    !existsSync(LIQ_ARCHIVE_BITRATE_PATH) ||
+    !existsSync(LIQ_RULE_RATIO_PATH(1))
   ) {
     await writeLiquidsoapSettings(s);
   }

--- a/docs/selection-rules-plan.md
+++ b/docs/selection-rules-plan.md
@@ -1,0 +1,368 @@
+# Selection rules — plan + spec
+
+Two listener asks landed on the same week and want the same feature, from
+opposite sides:
+
+- **#172 (corvock)** — *exclude* genres/artists/albums from being picked
+  (Christmas, classical). "I love how it's working, just want to exclude
+  some albums."
+- **AzuraCast-style rules (separate feedback)** — *force-insert* a track
+  from a specific Navidrome playlist or folder every N tracks or every Y
+  minutes. Use cases: hourly idents, an SFX clip every 7 tracks, story
+  vignettes for a themed-universe station.
+
+Both are programmable selection rules over the picker's output — one
+subtractive, one additive. We can give the operator a single **Rules**
+surface in admin and back it with two execution paths inside SUB/WAVE.
+
+## TL;DR
+
+One new `settings.rules[]` array. Each rule is either an **exclude** rule
+(filters the picker's candidate pool) or a **force-insert** rule (jams a
+track into the broadcast at a cadence). Force-insert with a track-counted
+cadence runs in Liquidsoap; with a minute-counted cadence it runs in the
+controller scheduler. Admin gets a new `/admin/rules` page. No new
+dependencies. The existing `jingleRatio` knob stays as the simplest case
+of an implicit always-on rule — we don't migrate it.
+
+Estimated work: 1.5 days for v1, mostly UI + the Liquidsoap rotate-slot
+plumbing.
+
+## Data model
+
+`state/settings.json` gains:
+
+```ts
+rules: Rule[]                       // ordered; UI displays + reorders
+
+type Rule = {
+  id: string;                       // uuid
+  name: string;                     // operator-facing label
+  enabled: boolean;
+  mode: 'exclude' | 'force-insert';
+  source: RuleSource;
+  cadence?: RuleCadence;            // force-insert only
+  pickStrategy?: 'random' | 'least-recently-played';  // force-insert only
+  djBehavior?: 'silent' | 'announce';                 // force-insert only
+}
+
+type RuleSource =
+  | { kind: 'playlist'; ref: string }    // Subsonic playlist id
+  | { kind: 'genre'; ref: string }       // genre name
+  | { kind: 'artist'; ref: string }      // artist id
+  | { kind: 'album'; ref: string }       // album id
+  | { kind: 'jingle-tag'; ref: string }  // pre-rendered TTS jingle pool, filtered
+
+type RuleCadence =
+  | { kind: 'every-n-tracks'; value: number }
+  | { kind: 'every-n-minutes'; value: number; jitter?: number }
+```
+
+Why this shape:
+
+- **Single table, two modes** keeps the admin UI coherent — same source
+  pickers, different downstream action.
+- **Source is a union** because Subsonic exposes four natural scopes
+  (playlist / genre / artist / album); `jingle-tag` is the controller-side
+  TTS pool, included so operators can mix custom-tagged ident rotations.
+- **Folder paths are deliberately not a source**. Listeners can already
+  achieve "play from folder X" by saving that folder as a Navidrome
+  playlist, and going through playlists avoids us re-implementing
+  filesystem scanning inside the controller.
+- **No conditionals** (day-of-week, time-of-day, listener count) in v1.
+  They're easy to retrofit by adding a `when?: {...}` field later.
+
+Validation in `controller/src/settings.ts`:
+
+- `rules` is bounded (`max 32` entries) to keep the Liquidsoap rotate
+  chain tractable.
+- `every-n-tracks.value ∈ [1, 1000]`, `every-n-minutes.value ∈ [1, 720]`.
+- For force-insert: `cadence` is required; for exclude: `cadence` must be
+  absent.
+- A force-insert rule pointing at a `genre`/`artist` source is **not
+  allowed** (forcing "play a random rock track" makes no sense as a
+  cadenced insert — it's just biasing the pool). Force-insert sources are
+  restricted to `playlist | album | jingle-tag`.
+
+## Execution paths
+
+### Path A — exclude rules (picker filter)
+
+Single filter pass in `controller/src/music/picker.ts buildCandidates()`,
+just before each `add(...)` call. A candidate is dropped if any
+**enabled, mode='exclude'** rule matches it:
+
+- `genre` → match against `candidate.genre` (case-insensitive)
+- `artist` → match against `candidate.artistId` or `candidate.artist`
+- `album` → match against `candidate.albumId`
+- `playlist` → membership check against a memoised playlist-track-id set
+  (refreshed every 30 min via the existing memo cache pattern)
+
+Same filter is wired into `controller/src/llm/tools.ts` — passed in as
+`excludedIds` / `excludedArtists` / `excludedGenres` alongside the
+existing `recentIds` etc. The agent path then literally cannot fetch
+blocked tracks via `searchLibrary` / `similarSongs` / `topByArtist`.
+
+The picker's `done`-schema prompt gets one extra line:
+
+> Your library has tracks excluded by operator-configured rules
+> (e.g. genres/artists they don't want on air). You will not see those
+> tracks in any tool result. If the pool looks thin, that's why — pick
+> from what's available.
+
+Edge case: if exclude rules wipe out >90% of candidates the picker
+already has a "no candidates available" branch. We add a single
+`queue.log('rules', 'exclude rules removed N candidates from pool')`
+breadcrumb so debugging is easy. We don't auto-disable rules — the
+operator decides.
+
+### Path B — track-counted force-insert (Liquidsoap rotate slots)
+
+This is the same mechanic that already runs the jingles slot. Today
+`radio.liq` has:
+
+```liquidsoap
+radio = rotate(
+  weights=[1, jingle_ratio()],
+  [jingles, radio]
+)
+```
+
+We extend it to N additional rule slots. To avoid regenerating Liquidsoap
+source on every rule change, **`radio.liq` pre-declares a fixed number of
+rule slots (6)** and reads two state files per slot:
+
+- `state/liquidsoap_rule_N.m3u` — empty file means "slot inactive"
+- `state/liquidsoap_rule_N_ratio.txt` — integer; 0 means "slot inactive"
+
+```liquidsoap
+rule_slots = [1, 2, 3, 4, 5, 6]
+rule_sources = list.map(fun (i) ->
+  playlist(id="rule_#{i}", reload_mode="watch",
+           "/var/sub-wave/liquidsoap_rule_#{i}.m3u"),
+  rule_slots
+)
+# weights are read at startup from liquidsoap_rule_N_ratio.txt (0 = skip)
+```
+
+The empty-playlist case is benign — Liquidsoap's `playlist(...)` with no
+items contributes nothing to the rotate output, so unused slots are
+inert.
+
+**Controller side** — when settings save:
+
+1. For each track-counted force-insert rule (up to 6 active), allocate
+   it to a slot index.
+2. Resolve `source.ref` → list of track ids → annotated `subhttp:` URIs
+   (same `getAnnotatedUri` path the queue uses).
+3. Write `state/liquidsoap_rule_N.m3u` and
+   `state/liquidsoap_rule_N_ratio.txt`.
+4. Trigger `restart-mixer` so the new weights take effect. (We can't hot-swap
+   weights — the `rotate(weights=…)` value is read at construction.)
+
+Two thorns:
+
+- **Weight semantics.** Liquidsoap `rotate(weights=[w1, w2, …])` picks
+  source `i` every `(w1+w2+…)/wi`-th track. So "every 7th track from rule
+  R1" alongside jingle-ratio 30 means: `w_radio=1, w_jingles=30,
+  w_R1=K` where `K` satisfies `(1+30+K)/K = 7` → `K = 31/6 ≈ 5.17`. We
+  round to nearest integer (5). Document the rounding in the rule form
+  ("cadence is approximate — actual: every ~7 tracks"). For multiple
+  rules the math compounds; we compute all weights together in
+  `controller/src/broadcast/rule-weights.ts` (new file).
+- **Reload of slot ratios.** Current `radio.liq` only reads
+  `liquidsoap_jingle_ratio.txt` at startup. We follow the same pattern
+  for rule ratios — startup-only, restart-mixer on change. No tighter
+  reactivity needed; rule changes are a deliberate operator action.
+
+If the operator configures >6 track-counted rules, validation fails with
+"max 6 track-counted force-insert rules; the rest must be
+minute-counted." This is a soft cap we can lift later by widening
+`rule_slots` in `radio.liq`.
+
+### Path C — minute-counted force-insert (controller scheduler)
+
+Existing `controller/src/broadcast/scheduler.ts` already ticks on the
+top of every minute. We add a new handler per minute-counted rule:
+
+- On each minute tick, for each enabled minute-counted rule, check
+  `lastFiredAt`. If `now - lastFiredAt >= rule.cadence.value` minutes,
+  the rule is **due**.
+- Resolve `source.ref` → candidate track list, apply `pickStrategy` to
+  pick one.
+- Inject it at the head of `upcoming` via a new
+  `queue.injectRule(rule, track)` method that:
+  - Logs the rule-driven play distinctly so `/debug` shows it.
+  - Optionally writes a TTS intro via `tts.speak()` before the track
+    (`djBehavior: 'announce'`).
+  - Sets `lastFiredAt = now` (persisted to settings — we add a tiny
+    `state/rules-state.json` for ephemeral per-rule timestamps so
+    settings.json doesn't churn).
+- If multiple rules come due in the same tick, sort by `weight` desc and
+  insert in order; they queue back-to-back rather than competing for the
+  same slot.
+- Jitter (`every-n-minutes.jitter`) adds `±jitter%` to the next-due
+  computation, avoiding mechanical-clockwork-feel.
+
+Why a separate `state/rules-state.json` and not settings: settings is
+operator-authored config that flows through validation and triggers
+Liquidsoap restarts. `lastFiredAt` is runtime state — updating settings
+every minute would be wrong, both semantically and because of the
+restart-mixer side-effects on the track-counted path.
+
+## DJ behaviour around forced inserts
+
+The session DJ agent (`broadcast/dj-agent.ts`) sees a "track started"
+event for every track that plays — including rule-injected ones. Today
+that triggers `runTrackEvent`, which picks the *next* track and writes a
+between-track link.
+
+Two behaviours, operator's choice per rule:
+
+- `djBehavior: 'silent'` — the rule-injected track plays cold. The agent
+  still sees the event but we mark the session message with
+  `kind: 'rule-track'` so the prompt knows not to back-announce it.
+- `djBehavior: 'announce'` — controller pre-writes a TTS line *before*
+  the rule track lands ("Quick sponsor message…", "Time for the hourly
+  ident…", or operator-supplied template). The agent then picks the
+  *next* music track as usual.
+
+Both behaviours append a turn to the session so the broader narrative
+stays coherent — the DJ persona can later make passing reference to "the
+sponsor we just heard."
+
+## Admin UI
+
+New `/admin/rules` route under the existing `AdminShell`.
+
+Top-level: table of rules with columns `Enabled | Name | Mode | Source |
+Cadence | Actions`. Row drag-reorders set rule priority (matters for
+`weight` resolution in Path C, and for slot allocation in Path B).
+
+Edit modal:
+
+1. **Mode** segmented control (`Exclude` / `Force-insert`).
+2. **Source** picker — dropdown for kind, autocomplete for ref. The
+   autocomplete hits new helper endpoints under
+   `controller/src/routes/library.ts`:
+   - `GET /api/library/playlists` (existing — reuses `getPlaylists`)
+   - `GET /api/library/genres` (new, thin wrapper over Subsonic
+     `getGenres`)
+   - `GET /api/library/artists?q=` (new, search)
+   - `GET /api/library/albums?q=` (new, search)
+3. **Cadence** controls (only when mode=force-insert). Number input
+   plus unit toggle (`tracks` / `minutes`). Live preview: "≈ every 7
+   tracks — actual rotation: 7.2".
+4. **Pick strategy** + **DJ behaviour** dropdowns.
+5. **Test** button → calls `POST /api/rules/:id/test`:
+   - For exclude rules → returns count of currently-affected tracks +
+     sample of 5 titles.
+   - For force-insert rules → returns next 3 tracks the rule would pick.
+
+Saving any rule POSTs to `/api/rules`, which delegates to
+`settings.update({ rules: [...] })` so all the validation + Liquidsoap
+restart machinery runs through the existing path.
+
+## API surface
+
+- `GET /api/rules` — list (admin-gated, behind `requireAdmin`)
+- `POST /api/rules` — create
+- `PUT /api/rules/:id` — update
+- `DELETE /api/rules/:id` — delete
+- `POST /api/rules/:id/test` — preview matches / picks
+- `GET /api/library/{genres,artists,albums}` — autocomplete sources for
+  the rule form
+
+All admin-gated, all routed through `controller/src/routes/rules.ts` (new)
+and `controller/src/routes/library.ts` (extend existing if any, else new).
+
+## Files touched
+
+New:
+
+- `controller/src/routes/rules.ts` — CRUD + test
+- `controller/src/broadcast/rule-engine.ts` — runtime: tick handler,
+  slot allocation, weight math, scheduler integration
+- `controller/src/broadcast/rule-weights.ts` — pure math, unit-testable
+- `web/app/admin/rules/page.tsx` — rules list
+- `web/components/admin/rules/RuleEditor.tsx` — form
+- `web/components/admin/rules/RulePreview.tsx` — test results
+- `docs/selection-rules-plan.md` — this doc
+
+Modified:
+
+- `controller/src/settings.ts` — `rules` field, validation, persistence
+  side-effects (writing per-slot m3u + ratio files)
+- `controller/src/music/picker.ts` — exclude filter in `buildCandidates`
+- `controller/src/llm/tools.ts` — exclude args threaded through
+- `controller/src/broadcast/queue.ts` — `injectRule()`, new log channel
+- `controller/src/broadcast/scheduler.ts` — call `rule-engine.tick()`
+- `controller/src/server.ts` — mount rules router
+- `liquidsoap/radio.liq` — 6 rule slots wired into the rotate chain
+- `web/components/admin/AdminNav.tsx` — add "Rules" entry
+
+## Testing
+
+- **Unit (controller, vitest)**
+  - `rule-weights.ts` — given `{jingleRatio: 30, rules: [...]}`, expected
+    Liquidsoap weights. Cover: zero rules, one rule, six rules, weight
+    rounding, ratio=0 edge cases.
+  - `picker.ts buildCandidates` — exclude filters drop the right tracks
+    from each of the 7 candidate sources.
+  - `rule-engine.ts tick()` — minute-counted rules fire at the right
+    minute, jitter math stays inside bounds, multiple-due rules sort by
+    weight.
+- **Integration (manual on the dev stack)**
+  - Track-counted rule with cadence 5 → actually fires every ~5 tracks
+    across a 30-track session.
+  - Minute-counted rule with cadence 10min → fires within ±jitter%.
+  - Exclude rule on a genre that 30% of the library carries — pool
+    builds correctly, no broken queues.
+  - Exclude rule that hits all candidates — gracefully empty queue,
+    Liquidsoap falls back to its `emergency` source.
+- **No tests around Liquidsoap itself** beyond a smoke listen — same
+  posture as the existing crossfade/ducking code.
+
+## Migration & rollout
+
+`settings.rules` defaults to `[]` on first load. Existing operators see
+no change in behaviour until they create a rule.
+
+`jingleRatio` stays in settings as-is. We don't migrate it into a rule
+because (a) it predates this surface and works fine, (b) it has its own
+admin control already, (c) it would complicate the slot-allocation math.
+A future cleanup could fold it in but isn't required.
+
+For the production deploy: the Liquidsoap change adds 6 inert playlist
+sources, which means broadcast container needs a rebuild + recreate
+(`docker compose up -d --build broadcast`). Document this in the
+release notes alongside the controller/web rebuilds.
+
+## Out of scope (v1)
+
+- Per-show rules (rules are station-wide; shows still pick their own
+  music inside their schedule)
+- Conditional rules (day/time/listener-count gates)
+- Folder-path sources (operators use playlists)
+- Rule-driven exclusions of *currently-playing* tracks (skip is
+  intentionally not supported by SUB/WAVE — track-end is the only
+  transition)
+- Multi-listener / per-listener exclusions
+- Operator-side analytics ("how often did each rule fire") — `/debug`
+  log entries are enough for v1; a real dashboard can come later
+
+## Open questions for you
+
+1. **Slot cap of 6** — is that enough, or do you want a bigger number
+   pre-baked into `radio.liq`? Going wider is free at parse time but
+   muddies the operator UX ("which slot does this rule live in?").
+2. **`every-n-minutes` jitter default** — I'd default to `±10%`. Yes
+   to default-on, or only when the operator explicitly sets it?
+3. **DJ behaviour: `announce` template** — should the announce text be
+   operator-authored per-rule ("Time for the sponsor break") or
+   generated by the DJ persona on the fly with a hint ("introduce a
+   sponsor segment")? I lean operator-authored for v1 since these are
+   typically scripted moments; persona-generated is harder to control.
+4. **Discussion reply** — do you want me to post a summary on #172
+   now (pointing corvock at this plan + the Navidrome library-split
+   workaround), or wait until the feature ships?

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -407,6 +407,71 @@ radio = rotate(
 )
 
 # ---------------------------------------------------------------------------
+# SELECTION RULES — force-insert slots
+# ---------------------------------------------------------------------------
+# Track-counted force-insert rules occupy fixed slots wrapped around the
+# (jingles + music) source. Each slot reads two state files written by the
+# controller: a playlist m3u and a cadence integer (the operator's "every N
+# tracks" value). When the cadence is 0 the slot is inert. We layer with
+# `random(...)` rather than nesting rotates so each rule's probability is
+# independent — adding a rule with cadence 7 doesn't drift the jingles math.
+#
+# WEIGHT_SCALE must match controller/src/broadcast/rule-weights.ts so the
+# admin UI preview ("actual ≈ every X tracks") matches reality.
+rule_weight_scale = 1000
+
+def read_rule_cadence(slot) =
+  path = "/var/sub-wave/liquidsoap_rule_#{slot}_ratio.txt"
+  if file.exists(path) then
+    raw = string.trim(file.contents(path))
+    int_of_string(default=0, raw)
+  else
+    0
+  end
+end
+
+def make_rule_source(slot) =
+  playlist(
+    id="rule_#{slot}",
+    mode="randomize",
+    reload_mode="watch",
+    "/var/sub-wave/liquidsoap_rule_#{slot}.m3u"
+  )
+end
+
+rule_slot_indices = [1, 2, 3, 4, 5, 6]
+rule_pairs =
+  list.map(
+    fun (slot) ->
+      begin
+        n = read_rule_cadence(slot)
+        w = if n > 0 then int_of_float(float_of_int(rule_weight_scale) / float_of_int(n)) else 0 end
+        (w, make_rule_source(slot))
+      end,
+    rule_slot_indices
+  )
+rule_active = list.filter(fun (p) -> fst(p) > 0, rule_pairs)
+rule_weights = list.map(fst, rule_active)
+rule_sources = list.map(snd, rule_active)
+rule_sum = list.fold(fun (acc, w) -> acc + w, 0, rule_weights)
+base_weight = max(1, rule_weight_scale - rule_sum)
+
+# Only wrap the radio in `random(...)` if at least one slot is active; the
+# unwrapped fast path avoids the random-selector overhead in the common case
+# of no force-insert rules configured.
+radio =
+  if list.length(rule_active) > 0 then
+    log("rules: #{list.length(rule_active)} active slot(s), weights=#{rule_weights} base=#{base_weight}")
+    random(
+      weights=list.append([base_weight], rule_weights),
+      list.append([radio], rule_sources)
+    )
+  else
+    log("rules: no active force-insert slots")
+    radio
+  end
+
+# ---------------------------------------------------------------------------
 # SAFETY — blank detection, fallback to silence-killer playlist
 # ---------------------------------------------------------------------------
 

--- a/web/app/admin/rules/page.tsx
+++ b/web/app/admin/rules/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import RulesPanel from '../../../components/admin/RulesPanel';
+
+export const metadata: Metadata = {
+  title: 'Rules',
+};
+
+export default function AdminRulesPage() {
+  return <RulesPanel />;
+}

--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -17,6 +17,7 @@ import {
   Terminal,
   Archive,
   Webhook,
+  Filter,
 } from 'lucide-react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import type { SignInResult } from '../../lib/adminAuth';
@@ -53,6 +54,7 @@ const NAV_SECTIONS: NavSection[] = [
       { href: '/admin/shows', id: 'shows', label: 'Shows', icon: CalendarClock },
       { href: '/admin/personas', id: 'personas', label: 'Personas', icon: Drama },
       { href: '/admin/skills', id: 'skills', label: 'Skills', icon: Sparkles },
+      { href: '/admin/rules', id: 'rules', label: 'Rules', icon: Filter },
     ],
   },
   {

--- a/web/components/admin/RulesPanel.tsx
+++ b/web/components/admin/RulesPanel.tsx
@@ -1,0 +1,497 @@
+'use client';
+
+// Selection rules — /admin/rules. Two modes share one list:
+//   exclude       — filters the picker's candidate pool by genre/artist/
+//                   album/playlist source.
+//   force-insert  — periodically jams a track from a Navidrome playlist or
+//                   album into the broadcast, either every N tracks
+//                   (Liquidsoap-side, deterministic) or every N minutes
+//                   (controller-side, with optional jitter).
+// See controller/src/broadcast/rule-engine.ts + liquidsoap/radio.liq for the
+// execution paths.
+
+import { useEffect, useMemo, useState } from 'react';
+import { useAdminAuth } from '../../lib/adminAuth';
+import { notify, errorMessage } from '../../lib/notify';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+import { Card, Btn, Pill, Eyebrow, Toggle } from './ui';
+
+type Mode = 'exclude' | 'force-insert';
+type SourceKind = 'playlist' | 'genre' | 'artist' | 'album';
+type CadenceKind = 'every-n-tracks' | 'every-n-minutes';
+type PickStrategy = 'random' | 'least-recently-played';
+type DjBehavior = 'silent' | 'announce';
+
+interface Cadence {
+  kind: CadenceKind;
+  value: number;
+  jitter?: number;
+}
+
+interface Rule {
+  id: string;
+  name: string;
+  enabled: boolean;
+  mode: Mode;
+  source: { kind: SourceKind; ref: string };
+  cadence?: Cadence;
+  pickStrategy?: PickStrategy;
+  djBehavior?: DjBehavior;
+  announceText?: string;
+}
+
+interface RulesResponse {
+  rules: Rule[];
+  modes: Mode[];
+  sourceKinds: SourceKind[];
+  forceInsertSourceKinds: SourceKind[];
+  cadenceKinds: CadenceKind[];
+  pickStrategies: PickStrategy[];
+  djBehaviors: DjBehavior[];
+  limits: { max: number; trackSlotCap: number };
+}
+
+const WEIGHT_SCALE = 1000;
+
+function clientMintId() {
+  const b = crypto.getRandomValues(new Uint8Array(3));
+  return 'r_' + [...b].map(x => x.toString(16).padStart(2, '0')).join('');
+}
+
+function blankExclude(): Rule {
+  return {
+    id: clientMintId(),
+    name: 'Exclude genre',
+    enabled: true,
+    mode: 'exclude',
+    source: { kind: 'genre', ref: '' },
+  };
+}
+
+function blankForceInsert(): Rule {
+  return {
+    id: clientMintId(),
+    name: 'Hourly insert',
+    enabled: true,
+    mode: 'force-insert',
+    source: { kind: 'playlist', ref: '' },
+    cadence: { kind: 'every-n-minutes', value: 60, jitter: 10 },
+    pickStrategy: 'random',
+    djBehavior: 'silent',
+  };
+}
+
+function valid(r: Rule): boolean {
+  if (!r.source?.ref) return false;
+  if (r.mode === 'force-insert') {
+    if (!r.cadence?.kind) return false;
+    if (!Number.isFinite(r.cadence.value) || r.cadence.value < 1) return false;
+    if (r.djBehavior === 'announce' && !(r.announceText || '').trim()) return false;
+  }
+  return true;
+}
+
+function trackSlotCount(rules: Rule[]): number {
+  return rules.filter(
+    r => r.enabled && r.mode === 'force-insert' && r.cadence?.kind === 'every-n-tracks',
+  ).length;
+}
+
+function actualCadenceLabel(rules: Rule[], rule: Rule): string | null {
+  if (rule.mode !== 'force-insert' || rule.cadence?.kind !== 'every-n-tracks') return null;
+  // Mirrors controller/src/broadcast/rule-weights.ts: compute integer weights
+  // for all enabled track-counted rules; total = base + Σweights; per-rule
+  // cadence ≈ total / w.
+  const trackRules = rules.filter(
+    r => r.enabled && r.mode === 'force-insert' && r.cadence?.kind === 'every-n-tracks',
+  );
+  const weights = trackRules.map(r => Math.max(1, Math.round(WEIGHT_SCALE / (r.cadence?.value || 1))));
+  const sum = weights.reduce((a, b) => a + b, 0);
+  const base = Math.max(1, WEIGHT_SCALE - sum);
+  const idx = trackRules.findIndex(r => r.id === rule.id);
+  if (idx < 0) return null;
+  const w = weights[idx];
+  if (!w) return null;
+  const total = base + sum;
+  const actual = Math.round((total / w) * 10) / 10;
+  return `≈ every ${actual} tracks`;
+}
+
+export default function RulesPanel() {
+  const { adminFetch, needsAuth, hydrated } = useAdminAuth();
+  const [meta, setMeta] = useState<RulesResponse | null>(null);
+  const [rules, setRules] = useState<Rule[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Autocomplete data — fetched lazily per source kind. Stored as a lookup
+  // table so reopens reuse the prior fetch.
+  const [genres, setGenres] = useState<{ value: string; songCount?: number }[] | null>(null);
+  const [playlists, setPlaylists] = useState<{ id: string; name: string }[] | null>(null);
+
+  useEffect(() => {
+    if (!hydrated || needsAuth) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await adminFetch('/rules');
+        if (!r.ok) throw new Error(`failed (${r.status})`);
+        const j = (await r.json()) as RulesResponse;
+        if (cancelled) return;
+        setMeta(j);
+        setRules(j.rules || []);
+      } catch (e) {
+        if (!cancelled) setErr(errorMessage(e));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [hydrated, needsAuth, adminFetch]);
+
+  const loadGenres = async () => {
+    if (genres) return;
+    try {
+      const r = await adminFetch('/library/genres');
+      const j = await r.json();
+      setGenres(j.genres || []);
+    } catch (e) {
+      notify.err(`Genres: ${errorMessage(e)}`);
+    }
+  };
+  const loadPlaylists = async () => {
+    if (playlists) return;
+    try {
+      const r = await adminFetch('/library/playlists');
+      const j = await r.json();
+      setPlaylists(j.playlists || []);
+    } catch (e) {
+      notify.err(`Playlists: ${errorMessage(e)}`);
+    }
+  };
+
+  const save = async (next: Rule[]) => {
+    setBusy(true);
+    try {
+      const r = await adminFetch('/rules', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rules: next }),
+      });
+      const j = (await r.json().catch(() => ({}))) as { rules?: Rule[]; error?: string; requiresRestart?: boolean };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      setRules(j.rules || []);
+      notify.ok(j.requiresRestart ? 'Rules saved — mixer will restart.' : 'Rules saved.');
+    } catch (e) {
+      notify.err(`Save failed: ${errorMessage(e)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const testRule = async (rule: Rule) => {
+    try {
+      const r = await adminFetch('/rules/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rule }),
+      });
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      if (rule.mode === 'exclude') {
+        notify.ok(`Matches ${j.matched} tracks${j.sample?.length ? ` — e.g. ${j.sample.slice(0, 3).map((s: any) => `${s.title} (${s.artist})`).join(', ')}` : ''}.`);
+      } else {
+        const picks = (j.picks || []).map((p: any) => `${p.title} (${p.artist})`).join(', ');
+        notify.ok(picks ? `Next picks: ${picks}` : 'Source resolved to 0 tracks.');
+      }
+    } catch (e) {
+      notify.err(`Test failed: ${errorMessage(e)}`);
+    }
+  };
+
+  const allValid = useMemo(() => (rules || []).every(valid), [rules]);
+
+  if (err) {
+    return (
+      <div className="grid gap-4">
+        <Card title="Rules"><div className="text-[13px] text-[var(--danger)]">controller error: {err}</div></Card>
+      </div>
+    );
+  }
+  if (!rules || !meta) {
+    return (
+      <div className="grid gap-4">
+        <Card title="Rules"><div className="text-[13px] text-muted italic">loading…</div></Card>
+      </div>
+    );
+  }
+
+  const trackSlots = trackSlotCount(rules);
+  const trackCapReached = trackSlots >= meta.limits.trackSlotCap;
+
+  return (
+    <div className="grid gap-4">
+      <section className="card">
+        <div className="border-b border-ink p-4">
+          <Eyebrow className="text-vermilion">selection rules</Eyebrow>
+          <div className="mt-1.5 text-[22px] font-extrabold tracking-[-0.02em]">
+            Filter the picker pool or force tracks in on a cadence.
+          </div>
+          <div className="mt-1 text-[11px] leading-[1.6] text-muted">
+            <strong>Exclude</strong> rules drop tracks from the picker before it can choose them (e.g. block Christmas / classical).{' '}
+            <strong>Force-insert</strong> rules play a track from a Navidrome playlist or album every N tracks or every N minutes —
+            for hourly idents, sponsor reads, story vignettes. Up to {meta.limits.trackSlotCap} track-counted force-insert rules
+            can be active at once; minute-counted rules are unlimited.
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-3 bg-[var(--ink-softer)] p-3.5">
+          <span className="caption">{rules.length} rule{rules.length === 1 ? '' : 's'}</span>
+          <span className="caption text-vermilion">
+            {rules.filter(r => r.enabled).length} enabled
+          </span>
+          <span className="caption">
+            track slots: {trackSlots}/{meta.limits.trackSlotCap}
+          </span>
+          <span className="ml-auto" />
+          <Btn sm onClick={() => setRules([...rules, blankExclude()])} disabled={rules.length >= meta.limits.max}>
+            + Exclude
+          </Btn>
+          <Btn sm onClick={() => setRules([...rules, blankForceInsert()])} disabled={rules.length >= meta.limits.max}>
+            + Force-insert
+          </Btn>
+          <Btn sm tone="accent" onClick={() => save(rules)} disabled={!allValid || busy}>
+            {busy ? 'Saving…' : 'Save'}
+          </Btn>
+        </div>
+      </section>
+
+      {rules.length === 0 && (
+        <Card title="No rules yet">
+          <div className="text-[12px] leading-[1.6] text-muted">
+            Add an exclude rule to drop a genre or artist from rotation, or a force-insert to schedule
+            periodic clips from a Navidrome playlist.
+          </div>
+        </Card>
+      )}
+
+      {rules.map((r, i) => {
+        const update = (patch: Partial<Rule>) => {
+          const next = [...rules];
+          next[i] = { ...r, ...patch };
+          setRules(next);
+        };
+        const remove = () => setRules(rules.filter((_, j) => j !== i));
+        const cadenceLabel = actualCadenceLabel(rules, r);
+
+        const sourceKinds = r.mode === 'force-insert'
+          ? meta.forceInsertSourceKinds
+          : meta.sourceKinds;
+
+        return (
+          <Card
+            key={r.id}
+            title={r.name || <span className="text-muted italic">(new rule)</span>}
+            right={
+              <>
+                <Pill tone={r.mode === 'exclude' ? 'default' : 'accent'} dot>
+                  {r.mode}
+                </Pill>
+                <Toggle on={r.enabled} onClick={() => update({ enabled: !r.enabled })} />
+              </>
+            }
+          >
+            <div className="grid gap-3">
+              <div>
+                <Label className="caption">Name</Label>
+                <Input
+                  value={r.name}
+                  onChange={e => update({ name: e.target.value })}
+                  maxLength={80}
+                />
+              </div>
+
+              <div className="grid gap-2 sm:grid-cols-[140px_1fr]">
+                <div>
+                  <Label className="caption">Source</Label>
+                  <select
+                    className="mt-1 w-full rounded border border-ink bg-[var(--ink-softer)] px-2 py-1.5 text-[12px]"
+                    value={r.source.kind}
+                    onChange={e => {
+                      const kind = e.target.value as SourceKind;
+                      update({ source: { kind, ref: '' } });
+                      if (kind === 'genre') loadGenres();
+                      if (kind === 'playlist') loadPlaylists();
+                    }}
+                  >
+                    {sourceKinds.map(k => <option key={k} value={k}>{k}</option>)}
+                  </select>
+                </div>
+                <div>
+                  <Label className="caption">
+                    {r.source.kind === 'genre' ? 'Genre name' :
+                     r.source.kind === 'playlist' ? 'Playlist' :
+                     r.source.kind === 'artist' ? 'Artist id or name' :
+                     'Album id'}
+                  </Label>
+                  {r.source.kind === 'genre' && genres ? (
+                    <select
+                      className="mt-1 w-full rounded border border-ink bg-[var(--ink-softer)] px-2 py-1.5 text-[12px]"
+                      value={r.source.ref}
+                      onChange={e => update({ source: { ...r.source, ref: e.target.value } })}
+                    >
+                      <option value="">— pick a genre —</option>
+                      {genres.map(g => (
+                        <option key={g.value} value={g.value}>
+                          {g.value}{g.songCount ? ` (${g.songCount})` : ''}
+                        </option>
+                      ))}
+                    </select>
+                  ) : r.source.kind === 'playlist' && playlists ? (
+                    <select
+                      className="mt-1 w-full rounded border border-ink bg-[var(--ink-softer)] px-2 py-1.5 text-[12px]"
+                      value={r.source.ref}
+                      onChange={e => update({ source: { ...r.source, ref: e.target.value } })}
+                    >
+                      <option value="">— pick a playlist —</option>
+                      {playlists.map(p => (
+                        <option key={p.id} value={p.id}>{p.name}</option>
+                      ))}
+                    </select>
+                  ) : (
+                    <Input
+                      value={r.source.ref}
+                      placeholder={
+                        r.source.kind === 'artist' ? 'e.g. Karan Aujla or AR-1234' :
+                        r.source.kind === 'album' ? 'e.g. AL-9001' :
+                        ''
+                      }
+                      onFocus={() => {
+                        if (r.source.kind === 'genre') loadGenres();
+                        if (r.source.kind === 'playlist') loadPlaylists();
+                      }}
+                      onChange={e => update({ source: { ...r.source, ref: e.target.value } })}
+                    />
+                  )}
+                </div>
+              </div>
+
+              {r.mode === 'force-insert' && r.cadence && (
+                <>
+                  <div className="grid gap-2 sm:grid-cols-[160px_140px_1fr]">
+                    <div>
+                      <Label className="caption">Cadence</Label>
+                      <select
+                        className="mt-1 w-full rounded border border-ink bg-[var(--ink-softer)] px-2 py-1.5 text-[12px]"
+                        value={r.cadence.kind}
+                        onChange={e => {
+                          const kind = e.target.value as CadenceKind;
+                          const value = kind === 'every-n-tracks' ? 7 : 60;
+                          const jitter = kind === 'every-n-minutes' ? 10 : undefined;
+                          update({ cadence: { kind, value, jitter } });
+                        }}
+                      >
+                        {meta.cadenceKinds.map(k => <option key={k} value={k}>{k}</option>)}
+                      </select>
+                    </div>
+                    <div>
+                      <Label className="caption">Every</Label>
+                      <Input
+                        type="number"
+                        min={1}
+                        max={r.cadence.kind === 'every-n-tracks' ? 1000 : 720}
+                        value={r.cadence.value}
+                        onChange={e => update({
+                          cadence: { ...r.cadence!, value: parseInt(e.target.value, 10) || 1 },
+                        })}
+                      />
+                    </div>
+                    <div className="self-end pb-1.5">
+                      <span className="text-[11px] text-muted">
+                        {r.cadence.kind === 'every-n-tracks' ? 'music tracks' : 'minutes'}
+                        {cadenceLabel && <> · <span className="text-vermilion">{cadenceLabel}</span></>}
+                      </span>
+                    </div>
+                  </div>
+
+                  {r.cadence.kind === 'every-n-minutes' && (
+                    <div className="grid gap-2 sm:grid-cols-[160px_140px_1fr]">
+                      <div className="sm:col-start-2">
+                        <Label className="caption">Jitter ±%</Label>
+                        <Input
+                          type="number"
+                          min={0}
+                          max={100}
+                          value={r.cadence.jitter ?? 10}
+                          onChange={e => update({
+                            cadence: { ...r.cadence!, jitter: parseInt(e.target.value, 10) || 0 },
+                          })}
+                        />
+                      </div>
+                      <div className="self-end pb-1.5 text-[11px] text-muted">
+                        0 = exact clockwork; 10% smooths a bus-timetable feel.
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <div>
+                      <Label className="caption">Pick strategy</Label>
+                      <select
+                        className="mt-1 w-full rounded border border-ink bg-[var(--ink-softer)] px-2 py-1.5 text-[12px]"
+                        value={r.pickStrategy || 'random'}
+                        onChange={e => update({ pickStrategy: e.target.value as PickStrategy })}
+                      >
+                        {meta.pickStrategies.map(s => <option key={s} value={s}>{s}</option>)}
+                      </select>
+                    </div>
+                    <div>
+                      <Label className="caption">DJ behaviour</Label>
+                      <select
+                        className="mt-1 w-full rounded border border-ink bg-[var(--ink-softer)] px-2 py-1.5 text-[12px]"
+                        value={r.djBehavior || 'silent'}
+                        onChange={e => update({ djBehavior: e.target.value as DjBehavior })}
+                      >
+                        {meta.djBehaviors.map(s => <option key={s} value={s}>{s}</option>)}
+                      </select>
+                    </div>
+                  </div>
+
+                  {r.djBehavior === 'announce' && (
+                    <div>
+                      <Label className="caption">Announce text</Label>
+                      <Input
+                        value={r.announceText || ''}
+                        placeholder='e.g. "Quick word from our sponsors."'
+                        maxLength={400}
+                        onChange={e => update({ announceText: e.target.value })}
+                      />
+                      <div className="mt-1 text-[10px] text-muted">
+                        Spoken verbatim before the rule track lands. Persona voice; no LLM ad-lib.
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
+
+              <div className="mt-1 flex items-center gap-2">
+                <Btn sm tone="accent" onClick={() => testRule(r)} disabled={!valid(r)}>
+                  Test
+                </Btn>
+                <span className="ml-auto" />
+                <Btn sm tone="danger" onClick={remove}>Remove</Btn>
+              </div>
+            </div>
+          </Card>
+        );
+      })}
+
+      {trackCapReached && (
+        <Card title="Track-slot cap reached">
+          <div className="text-[11px] leading-[1.6] text-muted">
+            You've used all {meta.limits.trackSlotCap} track-counted slots. Convert another to
+            minute-counted, or disable one, to add more.
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Plan + spec for a selection rules system that addresses two listener asks landing on the same week:

- **#172 (corvock)** — exclude genres/artists/albums from being picked (Christmas, classical).
- **AzuraCast-style rules** (separate feedback) — periodically force-insert a track from a Navidrome playlist or folder, for hourly idents, SFX clips, story vignettes, etc.

Both are programmable selection rules over the picker's output. One subtractive, one additive. The plan unifies them into one `settings.rules[]` surface with two execution paths:

- **Exclude rules** — filter `buildCandidates()` in `controller/src/music/picker.ts` and thread the block list through `controller/src/llm/tools.ts` so the agent can't fetch them either.
- **Force-insert, track-counted** — six fixed slots in `radio.liq` reading `liquidsoap_rule_N.m3u` + `liquidsoap_rule_N_ratio.txt`, same mechanic as the existing jingles slot.
- **Force-insert, minute-counted** — handler in `controller/src/broadcast/scheduler.ts` that injects via a new `queue.injectRule()`.

New admin surface at `/admin/rules`. No new dependencies. `jingleRatio` stays as a separate setting (not migrated into the new shape).

Estimated work for v1: ~1.5 days.

## Open questions (answered in PR discussion)

1. Slot cap of 6 — keep at 6, widen later if needed.
2. Jitter default — on at ±10%.
3. Announce text — operator-authored per rule.
4. Reply on #172 — yes, now, with workaround + link here.

## Test plan

This is a docs-only PR. Nothing to test until implementation lands.

- [x] Plan reviewed
- [ ] Open questions resolved (4/4 answered)
- [ ] Implementation PR opened against develop