### PR TITLE
fix: honour configured station name in DJ speech + Icecast mounts

### DIFF
--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -290,8 +290,9 @@ export async function generateIntro({ track, context, requestedBy = null, reques
 
 export async function generateStationId({ recap = null, context = null, recentOpeners = null }: any = {}) {
   const djName = settings.getEffectivePersona()?.name || 'your host';
+  const stationName = settings.get().station;
   const ctxLines = buildContextLines(context);
-  ctxLines.push(`Task: ${lengthPhrase('stationId')} for SUB/WAVE with ${djName}. A little understated.`);
+  ctxLines.push(`Task: ${lengthPhrase('stationId')} for ${stationName} with ${djName}. A little understated.`);
   return djText({
     system: djSystem(),
     prompt: decoratePrompt(ctxLines.join('\n'), { kind: 'station_id', recap, recentOpeners }),
@@ -346,7 +347,7 @@ export async function generateHourlyTime(time: any, weather: any, { recap = null
 // LLM PICKER — choose the next track from a candidate pool
 // ---------------------------------------------------------------------------
 
-// Shared selection criteria — used by both the pool picker (PICKER_SYSTEM
+// Shared selection criteria — used by both the pool picker (pickerSystem
 // below) and the conversational agent picker (pickSystem in broadcast/
 // dj-agent.js) so the two strategies can't drift apart on selection rules.
 export const PICKER_CRITERIA = `Selection criteria, in order:
@@ -355,7 +356,9 @@ export const PICKER_CRITERIA = `Selection criteria, in order:
 3. VARIETY — avoid the same artist back-to-back; don't repeat tracks you've already played today; rotate energy. Variety over cleverness — never pick a track because its title literally matches the time of day, the weather, or anything else literal.
 4. INTEREST — prefer something that creates a moment, not the most generic option.`;
 
-const PICKER_SYSTEM = `You are the DJ for SUB/WAVE, a personal internet radio station.
+function pickerSystem() {
+  const stationName = settings.get().station;
+  return `You are the DJ for ${stationName}, a personal internet radio station.
 Pick the single best NEXT track from the candidate pool, given recent plays and the current context.
 
 ${PICKER_CRITERIA}
@@ -372,6 +375,7 @@ recentPlays is context for judging flow — every candidate is already guarantee
 unplayed, so you never need to reject one for being recent.
 
 Pick exactly one candidate.`;
+}
 
 export async function pickNextTrack({ candidates, recentPlays, context }) {
   const user = JSON.stringify({
@@ -387,7 +391,7 @@ export async function pickNextTrack({ candidates, recentPlays, context }) {
   }, null, 2);
 
   return djObject({
-    system: PICKER_SYSTEM,
+    system: pickerSystem(),
     prompt: user,
     schema: z.object({
       id: z.string().describe('the exact id of one candidate'),

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -1151,12 +1151,12 @@ export async function update(patch) {
   }
   if ('station' in patch) {
     const v = String(patch.station ?? '').trim();
-    if (v === '') {
-      next.station = DEFAULTS.station;
-    } else {
-      if (v.length > 80) throw new Error('station name must be 80 chars or fewer');
-      next.station = v;
+    if (v.length > 80) throw new Error('station name must be 80 chars or fewer');
+    const resolved = v === '' ? DEFAULTS.station : v;
+    if (resolved !== cur.station) {
+      restart = true;
     }
+    next.station = resolved;
   }
   if ('djPrompt' in patch) {
     const v = String(patch.djPrompt ?? '').trim();
@@ -1592,12 +1592,14 @@ const LIQ_JINGLE_RATIO_PATH = `${STATE_DIR}/liquidsoap_jingle_ratio.txt`;
 const LIQ_CROSSFADE_PATH = `${STATE_DIR}/liquidsoap_crossfade.txt`;
 const LIQ_ARCHIVE_ENABLED_PATH = `${STATE_DIR}/liquidsoap_archive_enabled.txt`;
 const LIQ_ARCHIVE_BITRATE_PATH = `${STATE_DIR}/liquidsoap_archive_bitrate.txt`;
+const LIQ_STATION_NAME_PATH = `${STATE_DIR}/liquidsoap_station_name.txt`;
 
 export async function writeLiquidsoapSettings(s) {
   await writeFile(LIQ_JINGLE_RATIO_PATH, String(s.jingleRatio));
   await writeFile(LIQ_CROSSFADE_PATH, String(s.crossfadeDuration));
   await writeFile(LIQ_ARCHIVE_ENABLED_PATH, s.archive.enabled ? 'true' : 'false');
   await writeFile(LIQ_ARCHIVE_BITRATE_PATH, String(s.archive.bitrate));
+  await writeFile(LIQ_STATION_NAME_PATH, s.station || DEFAULTS.station);
 }
 
 // Called from server.js startup so the files exist before Liquidsoap reads

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -22,6 +22,7 @@ jingle_ratio = ref(30)
 crossfade_duration = ref(10.0)
 archive_enabled = ref(true)
 archive_bitrate = ref(128)
+station_name = ref("SUB/WAVE")
 
 if file.exists("/var/sub-wave/liquidsoap_jingle_ratio.txt") then
   raw = string.trim(file.contents("/var/sub-wave/liquidsoap_jingle_ratio.txt"))
@@ -46,7 +47,12 @@ if file.exists("/var/sub-wave/liquidsoap_archive_bitrate.txt") then
   if v > 0 then archive_bitrate := v end
 end
 
-log("settings loaded: jingle_ratio=#{jingle_ratio()} crossfade_duration=#{crossfade_duration()} archive_enabled=#{archive_enabled()} archive_bitrate=#{archive_bitrate()}")
+if file.exists("/var/sub-wave/liquidsoap_station_name.txt") then
+  raw = string.trim(file.contents("/var/sub-wave/liquidsoap_station_name.txt"))
+  if raw != "" then station_name := raw end
+end
+
+log("settings loaded: jingle_ratio=#{jingle_ratio()} crossfade_duration=#{crossfade_duration()} archive_enabled=#{archive_enabled()} archive_bitrate=#{archive_bitrate()} station_name=#{station_name()}")
 
 # ---------------------------------------------------------------------------
 # HTTP(S) FETCH OVERRIDE — Liquidsoap's built-in http.get.stream returns
@@ -536,7 +542,7 @@ def make_stream_outputs() =
     port=7702,
     password=environment.get("ICECAST_SOURCE_PASSWORD"),
     mount="/stream.mp3",
-    name="SUB/WAVE",
+    name=station_name(),
     description="Personal frequency from the homelab",
     genre="Various",
     url="http://localhost:7700",
@@ -559,7 +565,7 @@ def make_stream_outputs() =
     port=7702,
     password=environment.get("ICECAST_SOURCE_PASSWORD"),
     mount="/stream.opus",
-    name="SUB/WAVE",
+    name=station_name(),
     description="Personal frequency from the homelab",
     genre="Various",
     url="http://localhost:7700",


### PR DESCRIPTION
## Summary
- DJ's `generateStationId` and the pool `pickerSystem` now read `settings.get().station` instead of the hardcoded `SUB/WAVE`, so spoken station IDs use the operator's chosen name.
- Liquidsoap `/stream.mp3` and `/stream.opus` Icecast mounts now read `name=` from `liquidsoap_station_name.txt`, so Sonos / hardware radios / Icecast directories show the operator's chosen name.
- `settings.update()` writes the new Liquidsoap file and flags `requiresRestart` when the station name changes, so the admin UI prompts the operator to restart the mixer.

Closes #178. Follow-on to #102 (the original station-rename bug, fixed for the player/admin UI but missed for spoken DJ segments and the public Icecast mount).

## Test plan
- [x] Rename the station in admin, restart the mixer, listen for a station ID — DJ should say the new name, not "SUB/WAVE".
- [x] After restart, point a Sonos / VLC at the stream and verify the displayed station name matches the new value.
- [x] Confirm the admin UI shows "restart required" after the rename and clears after restart.