### PR TITLE
feat(personas+player): persona avatars + listener Schedule drawer

### DIFF
--- a/controller/src/routes/personas.ts
+++ b/controller/src/routes/personas.ts
@@ -1,0 +1,164 @@
+// Admin-gated persona avatar upload + delete.
+//
+// Avatars are written to ${STATE_DIR}/persona-avatars/<personaId>.<ext>. The
+// browser resizes/crops the source image to 512×512 before POSTing it as a
+// data URL, so we only ever accept small (~50–300 KB) PNG/JPEG/WebP payloads.
+//
+// The dedicated upload route is the single writer; the basename is recorded on
+// the persona's `avatar` field via settings.update(), and the public
+// /persona-avatar/:id endpoint reads from that field. Magic-byte sniffing
+// rejects payloads whose decoded bytes don't match a supported image format,
+// so an operator can't smuggle anything else past the data-URL header.
+
+import express from 'express';
+import { mkdir, readdir, unlink, writeFile } from 'node:fs/promises';
+import * as settings from '../settings.js';
+import { requireAdmin } from '../middleware/auth.js';
+
+export const router = express.Router();
+
+// Match the persona id regex used in settings.ts — kept local to avoid widening
+// settings.ts's export surface for a 24-char regex.
+const PERSONA_ID_RE = /^[a-z0-9_]{3,32}$/;
+// Hard cap on the decoded image. The browser-side resize lands us comfortably
+// below this for any reasonable source. Anything bigger almost certainly means
+// the operator bypassed the picker.
+const MAX_AVATAR_BYTES = 300 * 1024;
+// JSON payload cap is set per-route — the base64 body inflates the raw bytes
+// by ~33%, plus the data-URL prefix. 600 KB is plenty for a 300 KB image.
+const JSON_BODY_LIMIT = '600kb';
+
+// Quick magic-byte sniff. The data-URL prefix is operator-supplied and easy
+// to fake; this checks the decoded bytes against the canonical signatures.
+function sniffMime(buf: Buffer): 'image/png' | 'image/jpeg' | 'image/webp' | null {
+  if (buf.length < 12) return null;
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (
+    buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47 &&
+    buf[4] === 0x0d && buf[5] === 0x0a && buf[6] === 0x1a && buf[7] === 0x0a
+  ) return 'image/png';
+  // JPEG: FF D8 FF
+  if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'image/jpeg';
+  // WebP: 'RIFF' .... 'WEBP'
+  if (
+    buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
+    buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
+  ) return 'image/webp';
+  return null;
+}
+
+function extForMime(mime: string): 'png' | 'jpg' | 'webp' {
+  if (mime === 'image/jpeg') return 'jpg';
+  if (mime === 'image/webp') return 'webp';
+  return 'png';
+}
+
+// Removes any existing avatar file for this persona, regardless of extension —
+// re-uploading a JPEG over a previous PNG would otherwise leave the PNG
+// behind and the persona.avatar field would (correctly) only point at the
+// newer one, so the orphan would just waste disk.
+async function removeExisting(personaId: string) {
+  try {
+    const entries = await readdir(settings.PERSONA_AVATAR_DIR);
+    await Promise.all(
+      entries
+        .filter(e => e.startsWith(`${personaId}.`))
+        .map(e => unlink(`${settings.PERSONA_AVATAR_DIR}/${e}`).catch(() => {})),
+    );
+  } catch {
+    // Directory doesn't exist yet — nothing to remove.
+  }
+}
+
+async function writeAvatar(personaId: string, dataUrl: string) {
+  if (!PERSONA_ID_RE.test(personaId)) {
+    throw new Error('invalid persona id');
+  }
+  // settings.load() may not have run yet if this is the first request; the
+  // server boot block does run it, but be defensive.
+  await settings.load();
+  const personas = settings.get().personas || [];
+  if (!personas.some((p: any) => p.id === personaId)) {
+    throw new Error('unknown persona');
+  }
+
+  const m = /^data:(image\/(?:png|jpeg|webp));base64,(.+)$/.exec(dataUrl);
+  if (!m) {
+    throw new Error('body.dataUrl must be a data:image/(png|jpeg|webp);base64,… URL');
+  }
+  const declaredMime = m[1];
+  const buf = Buffer.from(m[2], 'base64');
+  if (!buf.length) throw new Error('decoded image is empty');
+  if (buf.length > MAX_AVATAR_BYTES) {
+    throw new Error(`image too large (max ${MAX_AVATAR_BYTES} bytes, got ${buf.length})`);
+  }
+  const sniffed = sniffMime(buf);
+  if (!sniffed) throw new Error('decoded image is not a PNG/JPEG/WebP');
+  if (sniffed !== declaredMime) {
+    throw new Error(`declared ${declaredMime} but bytes look like ${sniffed}`);
+  }
+
+  await mkdir(settings.PERSONA_AVATAR_DIR, { recursive: true });
+  await removeExisting(personaId);
+  const filename = `${personaId}.${extForMime(sniffed)}`;
+  await writeFile(`${settings.PERSONA_AVATAR_DIR}/${filename}`, buf);
+
+  // Record the basename on the persona so /persona-avatar/:id and the
+  // /now-playing payload pick it up immediately. We resend the full personas
+  // array because settings.update() validates the whole list — the orphan
+  // sweep inside update() is what keeps the on-disk files consistent.
+  const nextPersonas = personas.map((p: any) =>
+    p.id === personaId ? { ...p, avatar: filename } : p,
+  );
+  await settings.update({ personas: nextPersonas });
+  return { ok: true, avatar: filename };
+}
+
+async function clearAvatar(personaId: string) {
+  if (!PERSONA_ID_RE.test(personaId)) {
+    throw new Error('invalid persona id');
+  }
+  await settings.load();
+  const personas = settings.get().personas || [];
+  if (!personas.some((p: any) => p.id === personaId)) {
+    throw new Error('unknown persona');
+  }
+  await removeExisting(personaId);
+  const nextPersonas = personas.map((p: any) =>
+    p.id === personaId ? { ...p, avatar: '' } : p,
+  );
+  await settings.update({ personas: nextPersonas });
+  return { ok: true, avatar: '' };
+}
+
+const writeHandler = async (req: express.Request, res: express.Response) => {
+  try {
+    const dataUrl = String(req.body?.dataUrl ?? '');
+    const result = await writeAvatar(String(req.params.id), dataUrl);
+    res.json(result);
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+};
+
+router.post(
+  '/personas/:id/avatar',
+  requireAdmin,
+  express.json({ limit: JSON_BODY_LIMIT }),
+  writeHandler,
+);
+router.put(
+  '/personas/:id/avatar',
+  requireAdmin,
+  express.json({ limit: JSON_BODY_LIMIT }),
+  writeHandler,
+);
+
+router.delete('/personas/:id/avatar', requireAdmin, async (req, res) => {
+  try {
+    const result = await clearAvatar(String(req.params.id));
+    res.json(result);
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+});

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -1,6 +1,9 @@
 // Public, unauthenticated endpoints: liveness, now-playing, station/DJ info,
-// queue state, and the cover-art proxy.
+// queue state, the cover-art proxy, the persona-avatar proxy, and the
+// listener-facing weekly schedule.
 import express from 'express';
+import { stat, readFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import { config } from '../config.js';
 import * as subsonic from '../music/subsonic.js';
 import * as settings from '../settings.js';
@@ -10,6 +13,29 @@ import * as session from '../broadcast/session.js';
 import { getSetupStatusSync } from '../setup/firstRun.js';
 
 export const router = express.Router();
+
+// 1×1 transparent PNG — served when a persona has no avatar so the listener
+// UI can render an <img> tag without a broken-image icon. Cheap, no shipped
+// asset required.
+const TRANSPARENT_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+  'base64',
+);
+
+function mimeForAvatar(filename: string): string {
+  if (filename.endsWith('.png')) return 'image/png';
+  if (filename.endsWith('.webp')) return 'image/webp';
+  return 'image/jpeg';
+}
+
+// Relative path (no `/api` prefix) the listener UI uses for a persona's
+// avatar. The web app prepends its NEXT_PUBLIC_API_URL (`/api` in prod via
+// Caddy, an absolute origin in dev), mirroring how `/cover/:id` is consumed.
+// Always returns a string — the endpoint serves a 1×1 placeholder when no
+// avatar is set, so callers don't need to check for "is it set".
+function avatarUrlFor(personaId?: string | null): string {
+  return personaId ? `/persona-avatar/${encodeURIComponent(personaId)}` : '';
+}
 
 // Icecast stream status + listener count — used by /now-playing. Cheap local
 // fetch with a hard 1.5s timeout so a slow Icecast can never wedge the
@@ -69,6 +95,48 @@ router.get('/cover/:id', async (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
+// GET /persona-avatar/:id — operator-uploaded DJ persona portrait. Returns a
+// 1×1 transparent PNG (cached briefly) when no avatar is set, so listener UIs
+// can use this URL directly without first checking whether one exists.
+// ---------------------------------------------------------------------------
+router.get('/persona-avatar/:id', async (req, res) => {
+  const { id } = req.params;
+  // Persona ids reuse settings.ID_RE — keep this regex local so a hand-edited
+  // URL can never escape the persona-avatars directory.
+  if (!/^[a-z0-9_]{3,32}$/.test(id)) return res.status(400).end();
+  try {
+    await settings.load();
+    const persona = settings.get().personas?.find((p: any) => p.id === id);
+    const filename: string = persona?.avatar || '';
+    if (!filename) {
+      // No avatar set yet (or unknown persona). Serve the transparent
+      // placeholder with a short cache so the UI swaps once one's uploaded.
+      res.setHeader('Content-Type', 'image/png');
+      res.setHeader('Cache-Control', 'public, max-age=60');
+      return res.send(TRANSPARENT_PNG);
+    }
+    const path = `${settings.PERSONA_AVATAR_DIR}/${filename}`;
+    const st = await stat(path);
+    // ETag derived from filename + mtime so re-uploads invalidate cached
+    // copies immediately (the filename can stay the same when the operator
+    // replaces a PNG with another PNG).
+    const etag = `"${createHash('sha1').update(`${filename}:${st.mtimeMs}`).digest('hex').slice(0, 16)}"`;
+    res.setHeader('ETag', etag);
+    if (req.headers['if-none-match'] === etag) return res.status(304).end();
+    res.setHeader('Content-Type', mimeForAvatar(filename));
+    res.setHeader('Cache-Control', 'public, max-age=3600');
+    const buf = await readFile(path);
+    res.send(buf);
+  } catch {
+    // File missing or stat failed — fall back to the placeholder rather than
+    // letting the listener UI see a broken-image icon.
+    res.setHeader('Content-Type', 'image/png');
+    res.setHeader('Cache-Control', 'public, max-age=60');
+    res.send(TRANSPARENT_PNG);
+  }
+});
+
+// ---------------------------------------------------------------------------
 // GET /now-playing — current track + context snapshot
 // ---------------------------------------------------------------------------
 router.get('/now-playing', async (req, res) => {
@@ -79,15 +147,30 @@ router.get('/now-playing', async (req, res) => {
       getStreamStatus(),
     ]);
     const persona = settings.getEffectivePersona();
-    // activeShow is { name, persona:{ name } } | null — surfaced to listeners.
+    // activeShow is { name, persona:{ id, name, avatar } } | null — the
+    // persona block is reshaped here to include the public avatar URL so the
+    // player UI doesn't need to know about the basename convention.
     const activeShow = ctx.activeShow
-      ? { name: ctx.activeShow.name, persona: ctx.activeShow.persona }
+      ? {
+          name: ctx.activeShow.name,
+          persona: ctx.activeShow.persona
+            ? {
+                id: ctx.activeShow.persona.id,
+                name: ctx.activeShow.persona.name,
+                avatar: avatarUrlFor(ctx.activeShow.persona.id),
+              }
+            : null,
+        }
       : null;
     const s = session.getSession();
     res.json({
       nowPlaying,
       context: ctx,
-      dj: { name: persona?.name || 'Frequency', tagline: persona?.tagline || '' },
+      dj: {
+        name: persona?.name || 'Frequency',
+        tagline: persona?.tagline || '',
+        avatar: avatarUrlFor(persona?.id),
+      },
       activeShow,
       session: s ? { id: s.id, kind: s.kind, startedAt: s.startedAt, show: s.show?.name || null } : null,
       listeners: stream.listeners,
@@ -112,10 +195,49 @@ router.get('/dj', async (req, res) => {
       tagline: persona?.tagline || '',
       soul: persona?.soul || '',
       frequency: persona?.frequency || 'moderate',
+      avatar: avatarUrlFor(persona?.id),
       station: s.station,
       location: s.weather?.locationName || '',
     });
   } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /schedule — listener-facing week view. Returns the show definitions,
+// the 7×24 grid, and a lightweight persona index ({ id, name, avatar }) so
+// the player can paint host names + avatars without a separate lookup. No
+// souls, no TTS config, no admin-only fields — anything the DJ already says
+// on air or signals via on-air persona identity.
+// ---------------------------------------------------------------------------
+router.get('/schedule', async (req, res) => {
+  try {
+    await settings.load();
+    const s = settings.get();
+    const personas = (s.personas || []).map((p: any) => ({
+      id: p.id,
+      name: p.name,
+      avatar: avatarUrlFor(p.id),
+    }));
+    const shows = (s.shows || []).map((show: any) => ({
+      id: show.id,
+      name: show.name,
+      topic: show.topic,
+      mood: show.mood,
+      personaId: show.personaId,
+    }));
+    res.json({
+      personas,
+      shows,
+      schedule: s.schedule,
+      // The grid is interpreted in the controller's local timezone — the
+      // browser's local DOW/hour may not match, so pass back the offset the
+      // schedule was painted in. The UI can show a small "Times shown in
+      // station local time" hint where needed.
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || null,
+    });
+  } catch (err: any) {
     res.status(500).json({ error: err.message });
   }
 });

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -28,6 +28,7 @@ import { router as archivesRoutes } from './routes/archives.js';
 import { router as listenersRoutes } from './routes/listeners.js';
 import { router as webhooksRoutes } from './routes/webhooks.js';
 import { router as scrobbleRoutes } from './routes/scrobble.js';
+import { router as personasRoutes } from './routes/personas.js';
 import { loadSecretsIntoEnv } from './setup/secrets.js';
 import { loadSetupConfig } from './setup/config.js';
 import { getSetupStatus } from './setup/firstRun.js';
@@ -54,6 +55,7 @@ app.use(archivesRoutes);
 app.use(listenersRoutes);
 app.use(webhooksRoutes);
 app.use(scrobbleRoutes);
+app.use(personasRoutes);
 
 // (manual skip is not implemented in this build — Liquidsoap controls pacing)
 

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -3,10 +3,15 @@
 // DJ personas, shows); others require a Liquidsoap restart (jingle frequency,
 // crossfade duration).
 
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, writeFile, unlink, readdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
 import { STATE_DIR } from './config.js';
+
+// Where uploaded persona avatars live. One file per persona, basename =
+// `<personaId>.<ext>`. The dedicated upload route is the only writer; the
+// post-update orphan sweep below is the only place that deletes by id.
+export const PERSONA_AVATAR_DIR = `${STATE_DIR}/persona-avatars`;
 
 const SETTINGS_PATH = `${STATE_DIR}/settings.json`;
 // `shows` (reusable show definitions) and `schedule` (the 7×24 grid) live in
@@ -153,6 +158,11 @@ const POCKET_TTS_VOICE_RE = /^[a-z][a-z0-9_-]{0,39}$/;
 // valid (means "use the built-in default voice").
 const CHATTERBOX_VOICE_RE = /^[A-Za-z0-9_.-]{1,80}\.wav$/;
 const ID_RE = /^[a-z0-9_]{3,32}$/;
+// Persona avatar filename — `<personaId>.(png|jpg|jpeg|webp)`. The id segment
+// reuses ID_RE's shape so an avatar field can never reference a basename
+// outside the persona-avatars directory. Empty is also valid (no avatar set).
+export const AVATAR_FILENAME_RE = /^[a-z0-9_]{3,32}\.(png|jpe?g|webp)$/;
+export const AVATAR_EXTENSIONS = ['png', 'jpg', 'jpeg', 'webp'] as const;
 // Skill slugs (e.g. 'weather', 'random-facts'). The skills registry is the
 // source of truth for which slugs exist; settings only checks the shape.
 const SKILL_SLUG_RE = /^[a-z0-9-]{1,40}$/;
@@ -206,6 +216,7 @@ export const SEED_PERSONAS = [
     frequency: 'moderate',
     scriptLength: 'concise',
     soul: DJ_SOULS[0],
+    avatar: '',
     tts: { engine: 'piper', cloudProvider: 'openai', voice: 'bm_george' },
   },
   {
@@ -215,6 +226,7 @@ export const SEED_PERSONAS = [
     frequency: 'quiet',
     scriptLength: 'concise',
     soul: DJ_SOULS[1],
+    avatar: '',
     tts: { engine: 'piper', cloudProvider: 'openai', voice: 'bf_alice' },
   },
   {
@@ -224,6 +236,7 @@ export const SEED_PERSONAS = [
     frequency: 'moderate',
     scriptLength: 'concise',
     soul: DJ_SOULS[3],
+    avatar: '',
     tts: { engine: 'piper', cloudProvider: 'openai', voice: 'bm_daniel' },
   },
 ];
@@ -461,6 +474,11 @@ function normalizePersona(raw: any) {
   const name = typeof raw.name === 'string' ? raw.name.trim().slice(0, 40) : '';
   const soul = typeof raw.soul === 'string' ? raw.soul.trim().slice(0, 400) : '';
   if (!name || !soul) return null;
+  // Avatar — stored as a bare basename. Reset to '' if the persisted value
+  // doesn't match the strict basename shape, so a hand-edited settings.json
+  // can never point /persona-avatar/:id at an arbitrary path.
+  const rawAvatar = typeof raw.avatar === 'string' ? raw.avatar.trim() : '';
+  const avatar = rawAvatar && AVATAR_FILENAME_RE.test(rawAvatar) ? rawAvatar : '';
   return {
     id: typeof raw.id === 'string' && ID_RE.test(raw.id) ? raw.id : mintId('p_'),
     name,
@@ -468,6 +486,7 @@ function normalizePersona(raw: any) {
     frequency: FREQUENCIES.includes(raw.frequency) ? raw.frequency : 'moderate',
     scriptLength: SCRIPT_LENGTHS.includes(raw.scriptLength) ? raw.scriptLength : 'concise',
     soul,
+    avatar,
     tts: normalizeTts(raw.tts),
     skills: normalizeSkills(raw.skills),
   };
@@ -964,6 +983,21 @@ function validatePersonasStrict(raw) {
     let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('p_');
     if (seen.has(id)) id = mintId('p_');
     seen.add(id);
+    // Avatar — optional. Absent/empty → '' (no avatar). Present must be a
+    // bare basename matching AVATAR_FILENAME_RE. The dedicated upload route
+    // is the only writer that creates the file on disk; this validator just
+    // checks the persisted string. The post-patch sweep below garbage-
+    // collects orphaned files when the persona itself is removed.
+    let avatar = '';
+    if (item.avatar !== undefined && item.avatar !== null && item.avatar !== '') {
+      const a = String(item.avatar).trim();
+      if (!AVATAR_FILENAME_RE.test(a)) {
+        throw new Error(
+          `personas[${i}].avatar must be a basename like <id>.png|jpg|jpeg|webp`,
+        );
+      }
+      avatar = a;
+    }
     return {
       id,
       name,
@@ -971,6 +1005,7 @@ function validatePersonasStrict(raw) {
       frequency: item.frequency,
       scriptLength,
       soul,
+      avatar,
       tts,
       skills,
     };
@@ -1485,6 +1520,25 @@ export async function update(patch) {
       }
     }
     if (!personaIds.includes(next.activePersonaId)) next.activePersonaId = personaIds[0];
+
+    // Garbage-collect avatar files for personas that no longer exist. Best
+    // effort — a missing directory or a vanished file is fine, this just
+    // keeps the on-disk state from accumulating dead images.
+    const removedIds = (cur.personas || [])
+      .map((p: any) => p.id)
+      .filter((id: string) => !personaIds.includes(id));
+    if (removedIds.length) {
+      try {
+        const entries = await readdir(PERSONA_AVATAR_DIR);
+        await Promise.all(
+          entries
+            .filter(e => removedIds.some(id => e.startsWith(`${id}.`)))
+            .map(e => unlink(`${PERSONA_AVATAR_DIR}/${e}`).catch(() => {})),
+        );
+      } catch {
+        // Directory doesn't exist yet — nothing to clean.
+      }
+    }
   }
 
   cache = next;
@@ -1530,7 +1584,9 @@ export function resolveActiveShow(date = new Date(), s = get()) {
     name: show.name,
     topic: show.topic,
     mood: show.mood,
-    persona: persona ? { id: persona.id, name: persona.name } : null,
+    persona: persona
+      ? { id: persona.id, name: persona.name, avatar: persona.avatar || '' }
+      : null,
   };
 }
 

--- a/web/components/CommandPalette.tsx
+++ b/web/components/CommandPalette.tsx
@@ -11,7 +11,7 @@ import {
 import { Kbd } from './ui/kbd';
 import type { ThemeMode } from '@/lib/types';
 
-export type PlayerDrawer = 'timeline' | 'booth' | 'request';
+export type PlayerDrawer = 'timeline' | 'booth' | 'request' | 'schedule';
 
 export interface CommandPaletteProps {
   open: boolean;
@@ -59,6 +59,7 @@ export default function CommandPalette({
     { label: 'Open Timeline', hint: '1', onSelect: run(() => onOpenDrawer('timeline')) },
     { label: 'Open Booth feed', hint: '2', onSelect: run(() => onOpenDrawer('booth')) },
     { label: 'Make a request', hint: '3', onSelect: run(() => onOpenDrawer('request')) },
+    { label: 'Open Schedule', hint: '4', onSelect: run(() => onOpenDrawer('schedule')) },
     {
       label: theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme',
       hint: 'T',

--- a/web/components/DotRail.tsx
+++ b/web/components/DotRail.tsx
@@ -15,6 +15,7 @@ const ITEMS: readonly RailItem[] = [
   { k: 'timeline', l: 'Timeline' },
   { k: 'booth',    l: 'Booth' },
   { k: 'request',  l: 'Request' },
+  { k: 'schedule', l: 'Schedule' },
 ];
 
 export interface DotRailProps {

--- a/web/components/PlayerApp.tsx
+++ b/web/components/PlayerApp.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { AnimatePresence } from 'motion/react';
 import { toast } from 'sonner';
-import { History, Mic } from 'lucide-react';
+import { CalendarClock, History, Mic } from 'lucide-react';
 import TopBar from './TopBar';
 import CenterStage from './CenterStage';
 import Waveform from './Waveform';
@@ -17,6 +17,7 @@ import { Toaster } from './ui/toaster';
 import TimelineDrawer from './drawers/TimelineDrawer';
 import BoothDrawer from './drawers/BoothDrawer';
 import RequestDrawer from './drawers/RequestDrawer';
+import ScheduleDrawer from './drawers/ScheduleDrawer';
 import { useStationFeed } from '@/hooks/useStationFeed';
 import { usePlayer } from '@/hooks/usePlayer';
 import { useMediaSession } from '@/hooks/useMediaSession';
@@ -31,6 +32,7 @@ const DRAWER_TITLES: Record<PlayerDrawer, string> = {
   timeline: 'Timeline',
   booth: 'Booth feed',
   request: 'Make a request',
+  schedule: 'Schedule',
 };
 
 export interface PlayerAppProps {
@@ -52,10 +54,33 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
     if (offline && tunedIn) stop();
   }, [offline, tunedIn, stop]);
 
+  // Persona avatar to surface on the OS lock screen while the DJ is talking.
+  // Prefer the on-air show's persona (a scheduled show can hand the hour to a
+  // different DJ); fall back to the global "active" persona from /now-playing.
+  // The controller emits a path without the `/api` prefix; prepend API_URL
+  // so this resolves the same way in prod (via Caddy) and dev (direct origin).
+  const avatarPath =
+    (typeof activeShow?.persona?.avatar === 'string' && activeShow.persona.avatar) ||
+    (typeof dj?.avatar === 'string' ? dj.avatar : '') ||
+    '';
+  const personaAvatarUrl = avatarPath ? `${API_URL}${avatarPath}` : null;
+  const personaName =
+    (typeof activeShow?.persona?.name === 'string' && activeShow.persona.name) ||
+    (typeof dj?.name === 'string' ? dj.name : '') ||
+    null;
+
   // Wire OS-level media controls (lock screen, headphones, car display).
   // No onSkip on the public listener — a stray AirPods double-tap shouldn't
   // skip the song for every other listener on the station.
-  useMediaSession({ tunedIn, nowPlaying, audioRef, onTune: tune });
+  useMediaSession({
+    tunedIn,
+    nowPlaying,
+    audioRef,
+    onTune: tune,
+    boothFeed,
+    personaAvatarUrl,
+    personaName,
+  });
 
   const rootRef = useRef<HTMLDivElement | null>(null);
   // Drawers/dialogs portal here when contained so they stay inside the frame.
@@ -152,6 +177,7 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
       '1': () => setDrawer('timeline'),
       '2': () => setDrawer('booth'),
       '3': () => setDrawer('request'),
+      '4': () => setDrawer('schedule'),
       r: () => setDrawer('request'),
       '?': () => setShortcutsOpen(true),
       'mod+k': () => setPaletteOpen(o => !o),
@@ -210,6 +236,7 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
         listeners={listeners}
         theme={theme}
         onToggleTheme={toggleTheme}
+        onOpenSchedule={() => setDrawer('schedule')}
       />
 
       <CenterStage
@@ -228,6 +255,7 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
             ? state.upcoming.length
             : <History size={18} strokeWidth={1.5} />,
           booth: <Mic size={18} strokeWidth={1.5} />,
+          schedule: <CalendarClock size={18} strokeWidth={1.5} />,
         }}
         active={drawer}
         onSelect={setDrawer}
@@ -268,6 +296,7 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
             context={context}
           />
         )}
+        {drawer === 'schedule' && <ScheduleDrawer activeShow={activeShow} />}
       </Sheet>
 
       <AnimatePresence>

--- a/web/components/TopBar.tsx
+++ b/web/components/TopBar.tsx
@@ -15,6 +15,9 @@ export interface TopBarProps {
   listeners: ListenerCount | number | null;
   theme: ThemeMode | 'light' | 'dark';
   onToggleTheme?: () => void;
+  /** Optional — when provided, the show + host line becomes a button that
+   *  opens the Schedule drawer. Omitted on Landing where there's no player. */
+  onOpenSchedule?: () => void;
 }
 
 function isListenerObject(l: ListenerCount | number | null): l is ListenerCount {
@@ -30,6 +33,7 @@ export default function TopBar({
   listeners,
   theme,
   onToggleTheme,
+  onOpenSchedule,
 }: TopBarProps) {
   const tagline = buildTagline(context);
   // When a programmed show is on air, name it and prefer its host.
@@ -57,14 +61,36 @@ export default function TopBar({
         />
         <span className="v3-eyebrow shrink-0">{stationName?.trim() || 'SUB/WAVE'}</span>
         {showName && (
-          <span className="v3-caption min-w-0 truncate text-ink" title={showName}>
-            ▸ {showName}
-          </span>
+          onOpenSchedule ? (
+            <button
+              type="button"
+              onClick={onOpenSchedule}
+              className="v3-caption v3-focus min-w-0 cursor-pointer truncate border-0 bg-transparent p-0 text-left text-ink hover:underline"
+              title={`${showName} — open schedule`}
+            >
+              ▸ {showName}
+            </button>
+          ) : (
+            <span className="v3-caption min-w-0 truncate text-ink" title={showName}>
+              ▸ {showName}
+            </span>
+          )
         )}
         {onAirName && (
-          <span className="v3-caption truncate text-vermilion">
-            with {onAirName}
-          </span>
+          onOpenSchedule ? (
+            <button
+              type="button"
+              onClick={onOpenSchedule}
+              className="v3-caption v3-focus cursor-pointer truncate border-0 bg-transparent p-0 text-left text-vermilion hover:underline"
+              title="Open schedule"
+            >
+              with {onAirName}
+            </button>
+          ) : (
+            <span className="v3-caption truncate text-vermilion">
+              with {onAirName}
+            </span>
+          )
         )}
         {tagline && (
           <span

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -7,7 +7,7 @@
 // The system prompt is one global template shared by every persona.
 // Everything POSTs to /settings and applies live — no mixer restart.
 import type { ChangeEvent, ReactNode } from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { CLOUD_VOICES } from '../../lib/cloudVoices';
 import { notify, errorMessage } from '../../lib/notify';
@@ -66,6 +66,10 @@ interface Persona {
   frequency: string;
   scriptLength: string;
   soul: string;
+  // Stored basename like `p_abc123.png` — empty when no avatar is uploaded.
+  // The actual image is served via /api/persona-avatar/<id>; we keep the
+  // basename in state only so the form round-trips it on save.
+  avatar: string;
   tts: PersonaTts;
   skills: string[];
 }
@@ -90,7 +94,7 @@ interface VoiceOption {
 
 interface SettingsResponse {
   values?: {
-    personas?: Array<Partial<Persona>>;
+    personas?: Array<Partial<Persona> & { avatar?: string }>;
     activePersonaId?: string;
     djPrompt?: string;
     tts?: { defaultEngine?: string };
@@ -112,6 +116,116 @@ interface SettingsResponse {
 function clientMintId() {
   const b = crypto.getRandomValues(new Uint8Array(3));
   return 'p_' + [...b].map(x => x.toString(16).padStart(2, '0')).join('');
+}
+
+// 512×512 PNG output target. The controller hard-caps at 300 KB; a center-
+// cropped 512×512 PNG from a typical phone photo lands well under that.
+const AVATAR_TARGET_PX = 512;
+
+// Resize + center-crop the operator-picked image to a square PNG, returned as
+// a data URL ready for POSTing. Done entirely client-side so we never need a
+// server-side image library.
+async function fileToAvatarDataUrl(file: File): Promise<string> {
+  if (!/^image\/(png|jpe?g|webp)$/.test(file.type)) {
+    throw new Error('please pick a PNG, JPEG, or WebP image');
+  }
+  if (file.size > 12 * 1024 * 1024) {
+    throw new Error('image is over 12 MB — pick something smaller');
+  }
+  const bitmap = await createImageBitmap(file);
+  try {
+    const side = Math.min(bitmap.width, bitmap.height);
+    const sx = (bitmap.width - side) / 2;
+    const sy = (bitmap.height - side) / 2;
+    const canvas = document.createElement('canvas');
+    canvas.width = AVATAR_TARGET_PX;
+    canvas.height = AVATAR_TARGET_PX;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('canvas 2d context unavailable');
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
+    ctx.drawImage(bitmap, sx, sy, side, side, 0, 0, AVATAR_TARGET_PX, AVATAR_TARGET_PX);
+    return canvas.toDataURL('image/png');
+  } finally {
+    bitmap.close?.();
+  }
+}
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || '/api';
+
+function initialsFor(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (!parts.length) return '?';
+  const first = parts[0] ?? '';
+  if (parts.length === 1) return first.slice(0, 2).toUpperCase();
+  const last = parts[parts.length - 1] ?? '';
+  return ((first[0] ?? '') + (last[0] ?? '')).toUpperCase() || '?';
+}
+
+function PersonaAvatarPicker(props: {
+  persona: Persona;
+  tick: number;
+  uploading: boolean;
+  onPick: (file: File) => void;
+  onClear: () => void;
+}) {
+  const { persona, tick, uploading, onPick, onClear } = props;
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  // The public endpoint serves a 1×1 transparent placeholder when no avatar
+  // is set; rather than render that as a tiny grey square, fall back to
+  // initials in the admin UI. The ?v=… buster forces a refetch after upload.
+  const hasAvatar = !!persona.avatar;
+  const src = hasAvatar
+    ? `${API_BASE}/persona-avatar/${encodeURIComponent(persona.id)}?v=${tick}`
+    : null;
+  return (
+    <div className="grid gap-2">
+      <Label>Avatar</Label>
+      <div
+        className="grid h-[96px] w-[96px] place-items-center overflow-hidden border border-ink bg-[var(--ink-softer)]"
+        aria-label={hasAvatar ? `${persona.name} avatar` : 'No avatar set'}
+      >
+        {src ? (
+          <img
+            src={src}
+            alt=""
+            width={96}
+            height={96}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <span className="text-[22px] font-extrabold tracking-[-0.02em] text-muted">
+            {initialsFor(persona.name)}
+          </span>
+        )}
+      </div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/png,image/jpeg,image/webp"
+        className="hidden"
+        onChange={e => {
+          const file = e.target.files?.[0];
+          if (file) onPick(file);
+          // Reset so picking the same file twice still fires onChange.
+          e.target.value = '';
+        }}
+      />
+      <div className="flex flex-wrap gap-1.5">
+        <Btn sm onClick={() => inputRef.current?.click()} disabled={uploading}>
+          {uploading ? '…' : hasAvatar ? 'Replace' : 'Upload'}
+        </Btn>
+        {hasAvatar && (
+          <Btn sm tone="danger" onClick={onClear} disabled={uploading}>
+            Remove
+          </Btn>
+        )}
+      </div>
+      <div className="text-[10px] leading-[1.4] text-muted">
+        Square crop, 512px. PNG/JPEG/WebP.
+      </div>
+    </div>
+  );
 }
 
 function personaValid(p: Persona): boolean {
@@ -176,6 +290,13 @@ export default function PersonasPanel() {
   const [focusIdx, setFocusIdx] = useState(0);
   // toggles the system-prompt editor card
   const [showPrompt, setShowPrompt] = useState(false);
+  // Bumped on every avatar mutation. Appended as ?v=… so the admin <img>
+  // refetches even though the public endpoint caches for an hour — the cache
+  // is right for listeners, wrong for the operator who just uploaded.
+  const [avatarTick, setAvatarTick] = useState(0);
+  // Per-persona "uploading" flag — drives the spinner / disables the buttons
+  // while the request is in flight.
+  const [uploadingId, setUploadingId] = useState<string | null>(null);
 
   const load = async () => {
     try {
@@ -219,6 +340,7 @@ export default function PersonasPanel() {
             frequency: p.frequency ?? 'moderate',
             scriptLength: p.scriptLength ?? 'concise',
             soul: p.soul ?? '',
+            avatar: typeof p.avatar === 'string' ? p.avatar : '',
             tts: {
               engine: p.tts?.engine ?? 'piper',
               cloudProvider: p.tts?.cloudProvider ?? 'openai',
@@ -250,6 +372,7 @@ export default function PersonasPanel() {
         personas: [...f.personas, {
           id: clientMintId(), name: 'New persona', tagline: '',
           frequency: 'moderate', scriptLength: 'concise', soul: '',
+          avatar: '',
           tts: { engine: 'piper', cloudProvider: 'openai', voice: 'bf_isabella' },
           skills: (data?.skills?.catalog || []).map(s => s.name),
         }],
@@ -266,6 +389,67 @@ export default function PersonasPanel() {
       const activePersonaId = target.id === f.activePersonaId ? fallback : f.activePersonaId;
       return { ...f, personas, activePersonaId };
     });
+
+  // Avatar mutations talk to the dedicated upload endpoints, then update the
+  // local form so the basename round-trips through any subsequent save. Each
+  // mutation bumps avatarTick so the <img> cache-buster query string flips.
+  const uploadAvatar = async (personaId: string, file: File) => {
+    setUploadingId(personaId);
+    try {
+      const dataUrl = await fileToAvatarDataUrl(file);
+      const r = await adminFetch(`/personas/${encodeURIComponent(personaId)}/avatar`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dataUrl }),
+      });
+      const j = (await r.json().catch(() => ({}))) as { error?: string; avatar?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      const filename = j.avatar || '';
+      setForm(f =>
+        f
+          ? {
+              ...f,
+              personas: f.personas.map(p =>
+                p.id === personaId ? { ...p, avatar: filename } : p,
+              ),
+            }
+          : f,
+      );
+      setAvatarTick(t => t + 1);
+      notify.ok('avatar uploaded');
+    } catch (e) {
+      notify.err(errorMessage(e));
+    } finally {
+      setUploadingId(null);
+    }
+  };
+
+  const clearAvatar = async (personaId: string) => {
+    setUploadingId(personaId);
+    try {
+      const r = await adminFetch(`/personas/${encodeURIComponent(personaId)}/avatar`, {
+        method: 'DELETE',
+      });
+      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      setForm(f =>
+        f
+          ? {
+              ...f,
+              personas: f.personas.map(p =>
+                p.id === personaId ? { ...p, avatar: '' } : p,
+              ),
+            }
+          : f,
+      );
+      setAvatarTick(t => t + 1);
+      notify.ok('avatar removed');
+    } catch (e) {
+      notify.err(errorMessage(e));
+    } finally {
+      setUploadingId(null);
+    }
+  };
 
   // ── validation ───────────────────────────────────────────────────────────
   const promptText = form ? form.systemPrompt.trim() : '';
@@ -290,6 +474,7 @@ export default function PersonasPanel() {
             frequency: p.frequency,
             scriptLength: p.scriptLength,
             soul: p.soul.trim(),
+            avatar: p.avatar || '',
             tts: {
               engine: p.tts.engine,
               cloudProvider: p.tts.cloudProvider,
@@ -556,7 +741,14 @@ export default function PersonasPanel() {
               </>
             }
           >
-            <div className="stack-mobile grid grid-cols-[1fr_1fr] gap-4">
+            <div className="stack-mobile grid grid-cols-[96px_1fr_1fr] items-start gap-4">
+              <PersonaAvatarPicker
+                persona={focused}
+                tick={avatarTick}
+                uploading={uploadingId === focused.id}
+                onPick={file => uploadAvatar(focused.id, file)}
+                onClear={() => clearAvatar(focused.id)}
+              />
               <div className="field">
                 <Label>On-air name</Label>
                 <Input

--- a/web/components/drawers/ScheduleDrawer.tsx
+++ b/web/components/drawers/ScheduleDrawer.tsx
@@ -1,0 +1,351 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { cn } from '@/lib/cn';
+import type {
+  ActiveShow,
+  ScheduleGrid,
+  SchedulePayload,
+  SchedulePersona,
+  ScheduleShow,
+} from '@/lib/types';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '/api';
+
+const DAY_LABELS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
+
+// Controller emits avatar paths without the `/api` prefix (e.g.
+// `/persona-avatar/p_default0`) so each surface can prepend whichever origin
+// matches its environment — Caddy strips `/api` in production, the dev web
+// process talks to the controller on a different port. Empty input stays
+// empty so `<img>` falls back to the initials placeholder.
+function resolveAvatar(path: string | undefined | null): string {
+  if (!path) return '';
+  return `${API_URL}${path}`;
+}
+
+export interface ScheduleDrawerProps {
+  /** What's on right now, fed from `useStationFeed` so the on-now card stays
+   *  fresh without re-fetching `/schedule`. */
+  activeShow: ActiveShow | null;
+}
+
+interface Slot {
+  hour: number;
+  show: ScheduleShow | null;
+  persona: SchedulePersona | null;
+  /** Last hour of this run (inclusive) — used to render block ranges like
+   *  `02:00–04:00`. Filled in during the dedupe pass. */
+  endHour: number;
+}
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+function fmtHourRange(start: number, end: number): string {
+  return `${pad2(start)}:00 – ${pad2((end + 1) % 24)}:00`;
+}
+
+function fmtHour(start: number): string {
+  return `${pad2(start)}:00`;
+}
+
+/** Collapse adjacent same-show hours into a single row so a 4-hour block reads
+ *  as one entry. Autonomous (null) hours are also collapsed. */
+function collapseSlots(dayGrid: Array<string | null>, shows: ScheduleShow[], personas: SchedulePersona[]): Slot[] {
+  const showById = new Map(shows.map(s => [s.id, s]));
+  const personaById = new Map(personas.map(p => [p.id, p]));
+  const out: Slot[] = [];
+  let i = 0;
+  while (i < 24) {
+    const id = dayGrid[i] ?? null;
+    let j = i;
+    while (j + 1 < 24 && (dayGrid[j + 1] ?? null) === id) j++;
+    const show = id ? showById.get(id) || null : null;
+    const persona = show ? personaById.get(show.personaId) || null : null;
+    out.push({ hour: i, endHour: j, show, persona });
+    i = j + 1;
+  }
+  return out;
+}
+
+function endHourForCurrentBlock(grid: ScheduleGrid, day: number, hour: number): number {
+  const dayGrid = grid[day];
+  if (!Array.isArray(dayGrid)) return hour;
+  const current = dayGrid[hour] ?? null;
+  let h = hour;
+  while (h + 1 < 24 && (dayGrid[h + 1] ?? null) === current) h++;
+  return h;
+}
+
+export default function ScheduleDrawer({ activeShow }: ScheduleDrawerProps) {
+  const [data, setData] = useState<SchedulePayload | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [now, setNow] = useState(() => new Date());
+  // Defaults to today; tapping a day tab flips this without refetching.
+  const [viewDay, setViewDay] = useState<number>(() => new Date().getDay());
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch(`${API_URL}/schedule`);
+        if (!r.ok) throw new Error(`schedule fetch ${r.status}`);
+        const j = (await r.json()) as SchedulePayload;
+        if (!cancelled) setData(j);
+      } catch (e) {
+        if (!cancelled) setErr(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Keep the on-now indicator honest as time passes — bumps every 60s, which is
+  // fine since the grid resolution is 1 h. No setState churn during transitions.
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(new Date()), 60_000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const today = now.getDay();
+  const currentHour = now.getHours();
+
+  const daySlots = useMemo(() => {
+    if (!data) return [];
+    return collapseSlots(data.schedule[viewDay] ?? Array(24).fill(null), data.shows, data.personas);
+  }, [data, viewDay]);
+
+  // For "Coming up today", drop everything before the *next* slot. If we're
+  // mid-block, advance past this block; if today is a future day, show the
+  // full day from the top.
+  const upcomingSlots = useMemo(() => {
+    if (!data || viewDay !== today) return daySlots;
+    const blockEnd = endHourForCurrentBlock(data.schedule, today, currentHour);
+    return daySlots.filter(s => s.hour > blockEnd);
+  }, [data, daySlots, viewDay, today, currentHour]);
+
+  const onNow = useMemo(() => {
+    if (!data) return null;
+    const todayGrid = data.schedule[today];
+    if (!Array.isArray(todayGrid)) return null;
+    const id = todayGrid[currentHour] ?? null;
+    if (!id) return null;
+    const show = data.shows.find(s => s.id === id) || null;
+    if (!show) return null;
+    const persona = data.personas.find(p => p.id === show.personaId) || null;
+    const endHour = endHourForCurrentBlock(data.schedule, today, currentHour);
+    return { show, persona, endHour };
+  }, [data, today, currentHour]);
+
+  if (err) {
+    return (
+      <div className="text-[13px] leading-relaxed text-[var(--danger)]">
+        couldn’t load schedule: {err}
+      </div>
+    );
+  }
+  if (!data) {
+    return <div className="text-[13px] text-muted italic">loading…</div>;
+  }
+
+  const hasAnyShow = data.shows.length > 0;
+  if (!hasAnyShow) {
+    return (
+      <div className="text-[13px] leading-relaxed text-muted">
+        No shows scheduled — the station is running autonomously. The DJ picks
+        tracks by the time of day, the weather, and any festival on the
+        calendar.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-6">
+      <OnNowCard onNow={onNow} activeShow={activeShow} />
+
+      <section>
+        <SectionLabel>
+          {viewDay === today ? 'Coming up today' : `${DAY_LABELS[viewDay]} schedule`}
+        </SectionLabel>
+        {upcomingSlots.length === 0 ? (
+          <div className="text-[13px] text-muted">
+            Nothing more scheduled today.
+          </div>
+        ) : (
+          <ul className="grid">
+            {upcomingSlots.map(slot => (
+              <ScheduleRow
+                key={`${viewDay}-${slot.hour}`}
+                slot={slot}
+                isNow={viewDay === today && slot.hour <= currentHour && currentHour <= slot.endHour}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <DayTabs value={viewDay} today={today} onChange={setViewDay} />
+    </div>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="pb-[10px] text-[9px] tracking-[0.3em] text-muted uppercase">
+      {children}
+    </div>
+  );
+}
+
+function AvatarThumb({ avatar, name, tier }: { avatar: string; name: string; tier: 'lg' | 'sm' }) {
+  // `avatar` is always a URL (the public endpoint serves a placeholder when no
+  // image is set), so this is safe to render unconditionally. Initials sit
+  // underneath as a fallback while the network image loads. Two fixed sizes
+  // — large for the On-now card, small for schedule rows — keeps Tailwind's
+  // class generator happy without a `style={…}` escape hatch.
+  const initials = name
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(p => p[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+  const px = tier === 'lg' ? 64 : 36;
+  return (
+    <div
+      className={cn(
+        'relative shrink-0 overflow-hidden border border-ink bg-[var(--ink-softer)]',
+        tier === 'lg' ? 'h-16 w-16' : 'h-9 w-9',
+      )}
+    >
+      <span
+        className={cn(
+          'absolute inset-0 grid place-items-center font-extrabold text-muted',
+          tier === 'lg' ? 'text-[16px]' : 'text-[12px]',
+        )}
+      >
+        {initials || '?'}
+      </span>
+      {avatar && (
+        <img
+          src={avatar}
+          alt=""
+          width={px}
+          height={px}
+          className="relative h-full w-full object-cover"
+        />
+      )}
+    </div>
+  );
+}
+
+function OnNowCard(props: {
+  onNow: { show: ScheduleShow; persona: SchedulePersona | null; endHour: number } | null;
+  activeShow: ActiveShow | null;
+}) {
+  const { onNow, activeShow } = props;
+  if (!onNow) {
+    return (
+      <section>
+        <SectionLabel>On now</SectionLabel>
+        <div className="border border-separator-strong p-4">
+          <div className="text-[15px] leading-tight font-semibold">Autonomous</div>
+          <div className="mt-1 text-xs leading-relaxed text-muted">
+            No host scheduled for this hour — the station is picking tracks on
+            its own based on the time of day and the weather.
+          </div>
+        </div>
+      </section>
+    );
+  }
+  const personaName = onNow.persona?.name || activeShow?.persona?.name || 'Host';
+  const avatar = resolveAvatar(onNow.persona?.avatar || activeShow?.persona?.avatar || '');
+  return (
+    <section>
+      <SectionLabel>On now · until {fmtHour((onNow.endHour + 1) % 24)}</SectionLabel>
+      <div className="flex gap-4 border border-separator-strong p-4">
+        <AvatarThumb avatar={avatar} name={personaName} tier="lg" />
+        <div className="min-w-0 flex-1">
+          <div className="text-[10px] tracking-[0.3em] text-vermilion uppercase">
+            {personaName}
+          </div>
+          <div className="mt-0.5 text-lg leading-tight font-semibold">
+            {onNow.show.name}
+          </div>
+          {onNow.show.topic && (
+            <div className="mt-1.5 line-clamp-3 text-xs leading-relaxed text-muted">
+              {onNow.show.topic}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ScheduleRow({ slot, isNow }: { slot: Slot; isNow: boolean }) {
+  const personaName = slot.persona?.name || (slot.show ? 'Host' : null);
+  const avatar = resolveAvatar(slot.persona?.avatar || '');
+  const time = slot.hour === slot.endHour ? fmtHour(slot.hour) : fmtHourRange(slot.hour, slot.endHour);
+  return (
+    <li
+      className={cn(
+        'flex items-center gap-3 border-b border-separator-soft py-[11px]',
+        isNow && 'bg-[var(--ink-softer)]',
+      )}
+    >
+      <span className="v3-tab-num w-[88px] shrink-0 text-[11px] tracking-[0.2em] text-muted uppercase">
+        {time}
+      </span>
+      {slot.show ? (
+        <>
+          <AvatarThumb avatar={avatar} name={personaName || '?'} tier="sm" />
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm leading-tight text-ink">
+              {slot.show.name}
+            </div>
+            {personaName && (
+              <div className="truncate text-[11px] text-muted">{personaName}</div>
+            )}
+          </div>
+        </>
+      ) : (
+        <span className="text-[11px] tracking-[0.2em] text-muted uppercase">
+          autonomous
+        </span>
+      )}
+    </li>
+  );
+}
+
+function DayTabs({ value, today, onChange }: { value: number; today: number; onChange: (d: number) => void }) {
+  return (
+    <nav aria-label="Schedule day" className="grid grid-cols-7 gap-1 border-t border-ink pt-3">
+      {DAY_LABELS.map((label, i) => {
+        const isActive = i === value;
+        const isToday = i === today;
+        return (
+          <button
+            key={label}
+            type="button"
+            onClick={() => onChange(i)}
+            className={cn(
+              'v3-focus py-2 text-[10px] tracking-[0.25em] uppercase',
+              isActive
+                ? 'border border-ink bg-ink text-bg'
+                : 'border border-transparent text-muted hover:text-ink',
+            )}
+            aria-pressed={isActive}
+          >
+            {label}
+            {isToday && !isActive && <span className="ml-1 text-vermilion">·</span>}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/web/hooks/useMediaSession.ts
+++ b/web/hooks/useMediaSession.ts
@@ -1,9 +1,15 @@
 'use client';
 
-import { useEffect, type RefObject } from 'react';
-import type { NowPlayingTrack } from '@/lib/types';
+import { useEffect, useMemo, useState, type RefObject } from 'react';
+import type { NowPlayingTrack, SessionTurn } from '@/lib/types';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || '/api';
+
+// How long after the last spoken turn we keep showing the DJ avatar on the
+// lock screen. Match this to typical voice-segment length plus a small tail —
+// 15 s feels right for a station ID, a link, or a weather update; longer
+// segments naturally extend it because each new turn resets the timer.
+const TALKING_LINGER_MS = 15_000;
 
 export interface UseMediaSessionParams {
   tunedIn: boolean;
@@ -11,6 +17,57 @@ export interface UseMediaSessionParams {
   audioRef: RefObject<HTMLAudioElement | null>;
   onTune?: () => void;
   onSkip?: () => void;
+  /** Booth-feed messages, most recent last. We look at the tail to decide
+   *  whether the DJ is talking right now. Optional — when omitted, the
+   *  hook never swaps in the persona avatar. */
+  boothFeed?: SessionTurn[];
+  /** Public avatar URL for the on-air persona (the `/api/persona-avatar/:id`
+   *  endpoint). When the DJ is talking and this is set, we swap it into the
+   *  MediaSession artwork; otherwise the track cover wins. */
+  personaAvatarUrl?: string | null;
+  /** Display name for the on-air host — shown as the metadata "artist" while
+   *  the DJ is talking, so the lock screen reads "Late-night ramble · Marlowe"
+   *  instead of pretending Track Artist is speaking. */
+  personaName?: string | null;
+}
+
+// Turn kinds that map to "the DJ is on the mic". Tracks and request acks fire
+// the same booth-feed channel but aren't actually voiced over the music bus,
+// so they shouldn't trigger the avatar swap.
+const VOICE_TURN_KINDS = new Set([
+  'voice',
+  'segment',
+  'link',
+  'intro',
+  'station-id',
+  'weather',
+  'hourly',
+  'say',
+]);
+
+function isVoiceTurn(turn: SessionTurn | undefined): boolean {
+  if (!turn) return false;
+  const kind = (turn.kind || '').toLowerCase();
+  if (VOICE_TURN_KINDS.has(kind)) return true;
+  const role = (turn.role || '').toLowerCase();
+  return role === 'voice' || role === 'segment';
+}
+
+function lastVoiceTurnTime(feed: SessionTurn[] | undefined): number | null {
+  if (!feed?.length) return null;
+  // Walk from the tail back — voice turns near the end are the only ones that
+  // matter for "is the DJ talking *now*".
+  for (let i = feed.length - 1; i >= 0; i--) {
+    const turn = feed[i];
+    if (!isVoiceTurn(turn)) continue;
+    const t = typeof turn?.t === 'number'
+      ? turn.t
+      : typeof turn?.t === 'string'
+        ? Date.parse(turn.t)
+        : NaN;
+    return Number.isFinite(t) ? t : null;
+  }
+  return null;
 }
 
 // Wires the browser's Media Session API to the controller's now-playing feed.
@@ -39,7 +96,31 @@ export function useMediaSession({
   audioRef,
   onTune,
   onSkip,
+  boothFeed,
+  personaAvatarUrl,
+  personaName,
 }: UseMediaSessionParams): void {
+  // `talking` is a derived bit — true for TALKING_LINGER_MS after the most
+  // recent voice turn lands in the booth feed. We hold it in state (rather
+  // than recomputing on every render) so a setTimeout can flip it back off
+  // without a feed update.
+  const [talking, setTalking] = useState(false);
+  const lastVoiceTs = useMemo(() => lastVoiceTurnTime(boothFeed), [boothFeed]);
+
+  useEffect(() => {
+    if (lastVoiceTs == null) {
+      setTalking(false);
+      return;
+    }
+    const remaining = TALKING_LINGER_MS - (Date.now() - lastVoiceTs);
+    if (remaining <= 0) {
+      setTalking(false);
+      return;
+    }
+    setTalking(true);
+    const id = window.setTimeout(() => setTalking(false), remaining);
+    return () => window.clearTimeout(id);
+  }, [lastVoiceTs]);
   // Reflect tune-in / out into the system playback state. The browser uses
   // this to render the play/pause glyph on the lock screen correctly even
   // if the <audio> readyState is still loading.
@@ -58,27 +139,46 @@ export function useMediaSession({
     if (typeof navigator === 'undefined' || !('mediaSession' in navigator)) return;
     if (!('MediaMetadata' in window)) return;
 
-    const title = nowPlaying?.title || 'SUB/WAVE';
-    const artist = nowPlaying?.artist || 'Live broadcast';
-    const album = nowPlaying?.album || 'SUB/WAVE';
     const subsonicId = nowPlaying?.subsonic_id;
+    const coverArt: MediaImage | null = subsonicId
+      ? {
+          src: `${API_URL}/cover/${encodeURIComponent(subsonicId)}`,
+          sizes: '512x512',
+          type: 'image/jpeg',
+        }
+      : null;
+    const personaArt: MediaImage | null = personaAvatarUrl
+      ? {
+          src: personaAvatarUrl,
+          sizes: '512x512',
+          type: 'image/png',
+        }
+      : null;
+    const appIcon: MediaImage = { src: '/icons/192', sizes: '192x192', type: 'image/png' };
+    const appIconLg: MediaImage = { src: '/icons/512', sizes: '512x512', type: 'image/png' };
 
-    const artwork: MediaImage[] = subsonicId
-      ? [
-          // Real cover first; the app icon trails as a fallback in case the
-          // Subsonic fetch errors or the track has no embedded art (some
-          // browsers will try the next artwork entry when one fails).
-          {
-            src: `${API_URL}/cover/${encodeURIComponent(subsonicId)}`,
-            sizes: '512x512',
-            type: 'image/jpeg',
-          },
-          { src: '/icons/192', sizes: '192x192', type: 'image/png' },
-        ]
-      : [
-          { src: '/icons/192', sizes: '192x192', type: 'image/png' },
-          { src: '/icons/512', sizes: '512x512', type: 'image/png' },
-        ];
+    // While the DJ is talking and we have an avatar, lead with the persona —
+    // the lock screen, CarPlay etc. picks the first usable entry, so the
+    // avatar wins. The cover stays in the fallback chain so the moment the
+    // DJ stops talking and the linger expires, the next metadata push reverts
+    // cleanly. Title/artist also retarget so the lock-screen text matches.
+    const useAvatar = talking && !!personaArt;
+    const title = useAvatar
+      ? (nowPlaying?.title || 'SUB/WAVE')
+      : (nowPlaying?.title || 'SUB/WAVE');
+    const artist = useAvatar
+      ? (personaName || nowPlaying?.artist || 'Live broadcast')
+      : (nowPlaying?.artist || 'Live broadcast');
+    const album = nowPlaying?.album || 'SUB/WAVE';
+
+    let artwork: MediaImage[];
+    if (useAvatar && personaArt) {
+      artwork = [personaArt, ...(coverArt ? [coverArt] : []), appIcon];
+    } else if (coverArt) {
+      artwork = [coverArt, appIcon];
+    } else {
+      artwork = [appIcon, appIconLg];
+    }
 
     navigator.mediaSession.metadata = new window.MediaMetadata({
       title,
@@ -86,7 +186,15 @@ export function useMediaSession({
       album,
       artwork,
     });
-  }, [nowPlaying?.title, nowPlaying?.artist, nowPlaying?.album, nowPlaying?.subsonic_id]);
+  }, [
+    nowPlaying?.title,
+    nowPlaying?.artist,
+    nowPlaying?.album,
+    nowPlaying?.subsonic_id,
+    talking,
+    personaAvatarUrl,
+    personaName,
+  ]);
 
   // Action handlers. These are bound once per change to the dependencies so
   // they always close over the latest tune / skip callbacks.

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -32,7 +32,44 @@ export interface TimeContext {
 
 export interface ActiveShow {
   name?: string;
-  persona?: { name?: string };
+  /** `id` and `avatar` are surfaced so the player can paint the on-air host
+   *  next to the now-playing card and on the lock screen. `avatar` is the
+   *  full public URL (e.g. `/api/persona-avatar/p_default0`) — the controller
+   *  serves a transparent 1×1 placeholder when no avatar is set. */
+  persona?: { id?: string; name?: string; avatar?: string };
+}
+
+/** `/dj` response used by Landing + lock-screen artwork. */
+export interface DjPublic {
+  name?: string;
+  tagline?: string;
+  soul?: string;
+  frequency?: string;
+  avatar?: string;
+  station?: string;
+  location?: string;
+}
+
+/** `/schedule` response — listener-safe view of the week. */
+export interface SchedulePersona {
+  id: string;
+  name: string;
+  avatar: string;
+}
+export interface ScheduleShow {
+  id: string;
+  name: string;
+  topic: string;
+  mood: string;
+  personaId: string;
+}
+/** 7 entries (Sun=0..Sat=6), each a 24-slot array of showId|null. */
+export type ScheduleGrid = Record<number, Array<string | null>>;
+export interface SchedulePayload {
+  personas: SchedulePersona[];
+  shows: ScheduleShow[];
+  schedule: ScheduleGrid;
+  timezone?: string | null;
 }
 
 /** Context envelope returned by `/now-playing` — driven by controller's


### PR DESCRIPTION
## Summary

- Operators can attach an avatar image to each DJ persona via `/admin/personas`. Browser resizes/crops to 512×512, controller stores under `state/persona-avatars/<personaId>.<ext>` and serves it via a new public `/persona-avatar/:id` endpoint (ETag-aware, 1×1 transparent fallback so no broken-image icons).
- Listener player gets a new **Schedule** drawer (4th alongside Timeline / Booth / Request — DotRail dot 4, keyboard `4`, also opens when the show or host name in the TopBar is tapped). Shows "On now" + "Coming up today" with persona avatars, plus a day-tab strip for the rest of the week. Adjacent same-show hours collapse into block ranges.
- OS lock screen / CarPlay artwork swaps to the on-air persona's avatar while the DJ is talking (15 s linger after the last booth-feed voice turn), then reverts to the track cover.

## Implementation notes

- `persona.avatar` is a basename like `p_default0.png`. Validated against a strict regex in both the normalizer and the strict `update()` validator; the post-patch sweep garbage-collects orphaned avatar files when a persona is removed.
- Upload endpoint POSTs a `data:image/(png|jpeg|webp);base64,…` URL. Magic-byte sniffing of the decoded buffer rejects anything that doesn't match the declared MIME, so the data-URL header can't be used to smuggle other formats. Hard cap 300 KB after decode; the browser resizes upstream so this is plenty.
- `GET /schedule` is a listener-safe slice of the admin schedule (shows + 7×24 grid + persona index with `{ id, name, avatar }`) — no souls, no TTS config.
- Avatar URLs from the controller are emitted *without* the `/api` prefix (just `/persona-avatar/<id>`), matching how `/cover/:id` is consumed: the web app prepends `NEXT_PUBLIC_API_URL` so it resolves cleanly in prod (Caddy strips `/api`) and dev (direct origin).
- No new npm dependencies on either side.

## Test plan

- [ ] `docker compose -f docker-compose.dev.yml up -d` and `cd web && npm run dev`.
- [ ] Upload an avatar via `/admin/personas` → confirm the avatar appears in the editor (with a remove option) and persists across a controller restart.
- [ ] `curl http://localhost:7701/persona-avatar/p_default0` → 200 + correct `Content-Type` + 3600 s cache header; `curl -I` with `If-None-Match` returns 304 on the second hit.
- [ ] `curl http://localhost:7701/now-playing | jq '.dj.avatar, .activeShow.persona.avatar'` returns paths.
- [ ] Open `/listen`, tap DotRail dot 4 (or press `4`, or click the show name in the header) → Schedule drawer opens with "On now" + "Coming up today" + day tabs.
- [ ] With a show scheduled, trigger a voice segment via the booth feed and confirm the OS lock screen / Chrome MediaSession devtools swaps artwork to the persona avatar, then reverts within ~15 s of the last voice turn.
- [ ] Delete a persona that had an avatar → confirm `state/persona-avatars/<id>.*` is gone.
- [ ] `cd controller && npm run lint` + `cd web && npm run lint` (both already pass with 0 errors at this commit).