### PR TITLE
fix(controller): raise global JSON body limit so persona avatar uploads work

### DIFF
--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -37,7 +37,10 @@ import { getSetupStatus } from './setup/firstRun.js';
 assertAdminConfigured();
 
 const app = express();
-app.use(express.json());
+// Global cap covers small JSON payloads everywhere; the persona-avatar route
+// re-applies its own (slightly larger) cap on top via per-route json middleware.
+// The default 100 KB was below the 50–300 KB data URLs the avatar picker posts.
+app.use(express.json({ limit: '600kb' }));
 app.use(cors);
 
 // Routes. `requireAdmin` is applied per-route inside the admin modules.


### PR DESCRIPTION
## Summary

The persona avatar route mounts its own `express.json({ limit: '600kb' })` per-route, expecting it to override the global parser. But Express body-parser stops at the first match — the global `app.use(express.json())` ran first with the default 100 KB cap and rejected every avatar before the per-route limit could apply.

Browser-resized 512×512 PNG/JPEG/WebP data URLs land at 50–300 KB, so the upload reliably failed with `PayloadTooLargeError`. Raises the global cap to match the avatar route's intent.

Caught during pre-release smoke testing for #182.

## Test plan
- [ ] Admin → Personas → upload a 512×512 avatar succeeds (no "upload failed" toast).
- [ ] Existing routes that POST small JSON (settings, requests, jingles) still work normally.