### PR TITLE
fix(player): show configured station name + lead DotRail with Schedule

### DIFF
--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -171,6 +171,7 @@ router.get('/now-playing', async (req, res) => {
         name: persona?.name || 'Frequency',
         tagline: persona?.tagline || '',
         avatar: avatarUrlFor(persona?.id),
+        station: settings.get().station,
       },
       activeShow,
       session: s ? { id: s.id, kind: s.kind, startedAt: s.startedAt, show: s.show?.name || null } : null,

--- a/web/components/DotRail.tsx
+++ b/web/components/DotRail.tsx
@@ -12,10 +12,10 @@ interface RailItem {
 }
 
 const ITEMS: readonly RailItem[] = [
+  { k: 'schedule', l: 'Schedule' },
   { k: 'timeline', l: 'Timeline' },
   { k: 'booth',    l: 'Booth' },
   { k: 'request',  l: 'Request' },
-  { k: 'schedule', l: 'Schedule' },
 ];
 
 export interface DotRailProps {


### PR DESCRIPTION
## Summary

Two small fixes caught while smoke-testing #182:

1. **Station name** — TopBar reads `dj.station` from `/now-playing` to label the header, but the endpoint only emitted `{ name, tagline, avatar }`. The player fell back to the literal `SUB/WAVE` wordmark after the operator renamed the station. `/dj` already included it correctly; `/now-playing` was the only gap.
2. **DotRail order** — Schedule was the last tab in the rail. Moved to the top so it leads the reading order.

**Bug Fixes**
- \`d1a1b01\` fix(controller): include station in /now-playing dj block so player header shows it
- \`e99d581\` fix(web): move Schedule above Timeline in the player DotRail

## Test plan
- [ ] Rename the station via Admin → Settings → the player header reflects the new name on next poll (no manual refresh required beyond the 5 s feed interval).
- [ ] DotRail renders Schedule, Timeline, Booth, Request from top to bottom; the keyboard shortcut for Schedule (\`4\`) still opens the Schedule drawer.