### PR TITLE
feat(personas): Generate button — random DiceBear avatar in admin

### DIFF
--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -122,6 +122,34 @@ function clientMintId() {
 // cropped 512×512 PNG from a typical phone photo lands well under that.
 const AVATAR_TARGET_PX = 512;
 
+// DiceBear styles to roll through when the operator clicks Generate. Each
+// click picks one at random along with a fresh random seed, so re-clicking
+// produces a different face. Lorelei / notionists / personas / open-peeps are
+// illustrated humans; bottts-neutral / micah / fun-emoji add a robot/abstract
+// option so the operator can keep clicking until they land on a vibe that
+// fits the persona. All return PNG at the size we ask for, with permissive
+// CORS — the fetch can run in the browser.
+const DICEBEAR_STYLES = [
+  'lorelei', 'notionists', 'personas', 'open-peeps',
+  'micah', 'bottts-neutral', 'fun-emoji',
+];
+
+async function fetchDicebearAvatar(): Promise<string> {
+  const style = DICEBEAR_STYLES[Math.floor(Math.random() * DICEBEAR_STYLES.length)];
+  // Random seed so two clicks never produce the same face.
+  const seed = Math.random().toString(36).slice(2) + Date.now().toString(36);
+  const url = `https://api.dicebear.com/9.x/${style}/png?seed=${encodeURIComponent(seed)}&size=${AVATAR_TARGET_PX}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`DiceBear fetch failed (${res.status})`);
+  const blob = await res.blob();
+  return await new Promise<string>((resolve, reject) => {
+    const r = new FileReader();
+    r.onload = () => resolve(r.result as string);
+    r.onerror = () => reject(r.error || new Error('failed to read DiceBear PNG'));
+    r.readAsDataURL(blob);
+  });
+}
+
 // Resize + center-crop the operator-picked image to a square PNG, returned as
 // a data URL ready for POSTing. Done entirely client-side so we never need a
 // server-side image library.
@@ -167,9 +195,10 @@ function PersonaAvatarPicker(props: {
   tick: number;
   uploading: boolean;
   onPick: (file: File) => void;
+  onGenerate: () => void;
   onClear: () => void;
 }) {
-  const { persona, tick, uploading, onPick, onClear } = props;
+  const { persona, tick, uploading, onPick, onGenerate, onClear } = props;
   const inputRef = useRef<HTMLInputElement | null>(null);
   // The public endpoint serves a 1×1 transparent placeholder when no avatar
   // is set; rather than render that as a tiny grey square, fall back to
@@ -215,6 +244,9 @@ function PersonaAvatarPicker(props: {
         <Btn sm onClick={() => inputRef.current?.click()} disabled={uploading}>
           {uploading ? '…' : hasAvatar ? 'Replace' : 'Upload'}
         </Btn>
+        <Btn sm onClick={onGenerate} disabled={uploading} title="Random DiceBear avatar — click again for a different one">
+          Generate
+        </Btn>
         {hasAvatar && (
           <Btn sm tone="danger" onClick={onClear} disabled={uploading}>
             Remove
@@ -222,7 +254,7 @@ function PersonaAvatarPicker(props: {
         )}
       </div>
       <div className="text-[10px] leading-[1.4] text-muted">
-        Square crop, 512px. PNG/JPEG/WebP.
+        Upload a square 512px PNG/JPEG/WebP, or click Generate for a random DiceBear avatar.
       </div>
     </div>
   );
@@ -417,6 +449,37 @@ export default function PersonasPanel() {
       );
       setAvatarTick(t => t + 1);
       notify.ok('avatar uploaded');
+    } catch (e) {
+      notify.err(errorMessage(e));
+    } finally {
+      setUploadingId(null);
+    }
+  };
+
+  const generateAvatar = async (personaId: string) => {
+    setUploadingId(personaId);
+    try {
+      const dataUrl = await fetchDicebearAvatar();
+      const r = await adminFetch(`/personas/${encodeURIComponent(personaId)}/avatar`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dataUrl }),
+      });
+      const j = (await r.json().catch(() => ({}))) as { error?: string; avatar?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      const filename = j.avatar || '';
+      setForm(f =>
+        f
+          ? {
+              ...f,
+              personas: f.personas.map(p =>
+                p.id === personaId ? { ...p, avatar: filename } : p,
+              ),
+            }
+          : f,
+      );
+      setAvatarTick(t => t + 1);
+      notify.ok('avatar generated');
     } catch (e) {
       notify.err(errorMessage(e));
     } finally {
@@ -747,6 +810,7 @@ export default function PersonasPanel() {
                 tick={avatarTick}
                 uploading={uploadingId === focused.id}
                 onPick={file => uploadAvatar(focused.id, file)}
+                onGenerate={() => generateAvatar(focused.id)}
                 onClear={() => clearAvatar(focused.id)}
               />
               <div className="field">


### PR DESCRIPTION
## What

Add a **Generate** button next to Upload/Replace in the persona avatar picker on `/admin/personas`. Each click fetches a random PNG from the DiceBear public API and pushes it through the existing `/personas/:id/avatar` route.

## Why

Operators usually don't have an avatar to hand when they're setting up personas. The existing options are *Upload* (need a file) and the *initials fallback* (looks like a placeholder). DiceBear gives a one-click way to land on something distinctive — keep clicking until the face fits the persona — without leaving the admin shell.

DiceBear is free, no-auth, returns PNG, and `access-control-allow-origin: *`, so the fetch can run straight from the browser. No new backend route, no new dependency.

## How

- New helper `fetchDicebearAvatar()` picks a random style from a small curated set (`lorelei`, `notionists`, `personas`, `open-peeps`, `micah`, `bottts-neutral`, `fun-emoji`) plus a random seed, fetches the PNG, returns a `data:image/png;base64,…` URL.
- New `generateAvatar(personaId)` handler in `PersonasPanel` — same shape as `uploadAvatar`: sets the per-persona uploading flag, POSTs to `/personas/:id/avatar`, updates form state, bumps `avatarTick` so the `<img>` cache-buster refetches.
- `PersonaAvatarPicker` gains an `onGenerate` prop and renders the button between Upload/Replace and Remove. Hint text updated to mention the new button.

## How tested

- `npm run lint` in `web/` — clean (warnings pre-existing, none in PersonasPanel).
- Tried the existing upload path end-to-end before this change (DiceBear PNGs went through `/api/personas/:id/avatar` successfully — same route, same payload shape) — see avatars currently set on the live station.

## Notes for reviewers

- Random style + random seed per click is deliberate: easiest UX is "click until you like it." A style dropdown would crowd the 96px avatar column; I'd add one later only if operators ask.
- Seed is `Math.random() + Date.now()` so re-clicking the same persona always produces a different face (no need to mutate the name to re-roll).
- Controller-side payload cap (300 KB after base64) is far above what DiceBear PNGs land at (~12 KB), so no resize step needed — the fetched bytes go through verbatim.