### PR TITLE
fix(web): compress persona avatar to WebP so normal images upload

### DIFF
--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -118,8 +118,9 @@ function clientMintId() {
   return 'p_' + [...b].map(x => x.toString(16).padStart(2, '0')).join('');
 }
 
-// 512×512 PNG output target. The controller hard-caps at 300 KB; a center-
-// cropped 512×512 PNG from a typical phone photo lands well under that.
+// 512×512 output target. The controller hard-caps the decoded image at 300 KB
+// and the JSON body at 600 KB; a center-cropped 512×512 WebP from a typical
+// phone photo lands in the tens of KB, well under both.
 const AVATAR_TARGET_PX = 512;
 
 // DiceBear styles to roll through when the operator clicks Generate. Each
@@ -150,9 +151,9 @@ async function fetchDicebearAvatar(): Promise<string> {
   });
 }
 
-// Resize + center-crop the operator-picked image to a square PNG, returned as
-// a data URL ready for POSTing. Done entirely client-side so we never need a
-// server-side image library.
+// Resize + center-crop the operator-picked image to a square, returned as a
+// compressed (WebP, JPEG fallback) data URL ready for POSTing. Done entirely
+// client-side so we never need a server-side image library.
 async function fileToAvatarDataUrl(file: File): Promise<string> {
   if (!/^image\/(png|jpe?g|webp)$/.test(file.type)) {
     throw new Error('please pick a PNG, JPEG, or WebP image');
@@ -173,7 +174,16 @@ async function fileToAvatarDataUrl(file: File): Promise<string> {
     ctx.imageSmoothingEnabled = true;
     ctx.imageSmoothingQuality = 'high';
     ctx.drawImage(bitmap, sx, sy, side, side, 0, 0, AVATAR_TARGET_PX, AVATAR_TARGET_PX);
-    return canvas.toDataURL('image/png');
+    // Compressed export — an uncompressed 512×512 PNG is ~1 MB raw / ~1.33 MB
+    // base64, which blows past the controller's 600 KB JSON cap, so only tiny
+    // source images used to get through. WebP keeps a typical avatar in the
+    // tens-of-KB range and preserves transparency; JPEG is the universal
+    // fallback for the rare browser whose canvas can't emit WebP (it silently
+    // returns a data:image/png URL in that case).
+    const webp = canvas.toDataURL('image/webp', 0.85);
+    return webp.startsWith('data:image/webp')
+      ? webp
+      : canvas.toDataURL('image/jpeg', 0.85);
   } finally {
     bitmap.close?.();
   }


### PR DESCRIPTION
## Problem

Uploading a persona avatar in the admin Personas panel fails unless the source image is tiny (~20 KB). Operators have to repeatedly resample a JPG down before it's accepted.

## Root cause

The client-side resizer exported the 512×512 canvas as an **uncompressed** PNG:

```js
return canvas.toDataURL('image/png');
```

A 512×512 RGBA PNG with no compression is ~1 MB raw → ~1.33 MB once base64-encoded for the JSON POST. The controller's avatar route caps the JSON body at **600 KB** (`controller/src/routes/personas.ts` `JSON_BODY_LIMIT`), so only source images small enough to keep the re-encoded payload under 600 KB got through — roughly the ~20 KB observed.

The backend was never the problem: it already accepts PNG/JPEG/WebP, sniffs magic bytes, cross-checks declared vs. actual MIME, and maps each to the right extension. No server change needed.

## Fix

Export the canvas as compressed **WebP at quality 0.85**, falling back to JPEG for the rare browser whose canvas can't emit WebP (in that case `toDataURL('image/webp', …)` silently returns a `data:image/png` URL, which we detect by prefix). A typical 512×512 avatar now lands in the tens of KB — comfortably under both the 600 KB JSON cap and the 300 KB decoded cap. WebP also preserves transparency.

Single file: `web/components/admin/PersonasPanel.tsx` (`fileToAvatarDataUrl`), plus the two stale PNG comments refreshed.

## Verification

- `npm run lint` (eslint + `tsc --noEmit`) in `web/` passes — 0 errors.
- Manual end-to-end (upload a full-size JPG/PNG via the admin Personas panel) still to be done against a running stack.