### PR TITLE
fix(controller): air DJ intros/links when their track starts, not one early (#189)

### DIFF
--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -103,14 +103,19 @@ function trackFields(song) {
   };
 }
 
-async function enqueuePick(queue, song, reason, source) {
+// `link`, when present, is the between-track line to speak as this pick starts
+// playing. It's attached to the queued item so the queue airs it at the
+// transition INTO this track (queue.airIntro), not over whatever is currently
+// on-air when the pick is made — which is one track earlier (issue #189).
+async function enqueuePick(queue, song, reason, source, link: string | null = null) {
   queue.log('ai-pick', `${song.title} — ${song.artist}`, { reason, source });
   recordPick({ song, reason, source });
   await queue.push({
     track: trackFields(song),
     requestedBy: null,
     intent: reason || 'ai pick',
-    introScript: null,
+    introScript: link,
+    introKind: 'link',
     aiPicked: true,
   });
 }
@@ -139,8 +144,10 @@ async function pickViaAgent(queue, { wantLink }) {
   const song = object?.id ? extras.seen.get(object.id) : null;
   if (!song) throw new Error(`agent returned unknown id ${object?.id}`);
 
-  await enqueuePick(queue, song, object.reason, 'agent');
   const say = typeof object.say === 'string' ? object.say.trim() : '';
+  // Attach the link to the pick so it airs as the pick starts (back-announcing
+  // the track on-air now), instead of immediately over that on-air track (#189).
+  await enqueuePick(queue, song, object.reason, 'agent', (wantLink && say) ? say : null);
   session.appendTurn({
     role: 'dj', kind: 'pick',
     text: object.reason || `Selected "${song.title}".`,
@@ -149,16 +156,32 @@ async function pickViaAgent(queue, { wantLink }) {
       steps, toolCalls, say: say || null,
     },
   });
-  if (wantLink && say) await queue.announce(say, 'link');
 }
 
-async function pickViaPool(queue, ctx, { wantLink, previous, current }) {
+async function pickViaPool(queue, ctx, { wantLink, current }) {
   const result = await picker.pickViaPool(queue, ctx);
   if (!result) {
     queue.log('picker', 'pool produced no pick');
     return;
   }
-  await enqueuePick(queue, result.song, result.reason, result.source || 'pool');
+  // Build the between-track link BEFORE enqueueing so it can ride on the queued
+  // item and air when the pick starts. It back-announces the track on-air right
+  // now (`current`) and leads into the pick — because by the time it airs,
+  // `current` will have just ended and the pick will be starting (#189).
+  let link: string | null = null;
+  if (wantLink && current) {
+    try {
+      link = await dj.generateLink({
+        previous: current, current: result.song, context: ctx,
+        recap: queue.getDjRecap(),
+        recentTracks: queue.getRecentTracks(),
+        recentOpeners: queue.getRecentOpeners(),
+      });
+    } catch (err) {
+      queue.log('error', `DJ link failed: ${err.message}`);
+    }
+  }
+  await enqueuePick(queue, result.song, result.reason, result.source || 'pool', link);
   // The reason text is concise on a successful pool pick and useful context for
   // the next turn — but on a failed pool LLM (picker.js returns the sentinel
   // 'fallback (LLM pick failed)'), recording it as the DJ's session turn primes
@@ -174,19 +197,6 @@ async function pickViaPool(queue, ctx, { wantLink, previous, current }) {
     text: sessionText,
     meta: { trackId: result.song.id, title: result.song.title, artist: result.song.artist },
   });
-  if (wantLink && previous) {
-    try {
-      const link = await dj.generateLink({
-        previous, current, context: ctx,
-        recap: queue.getDjRecap(),
-        recentTracks: queue.getRecentTracks(),
-        recentOpeners: queue.getRecentOpeners(),
-      });
-      await queue.announce(link, 'link');
-    } catch (err) {
-      queue.log('error', `DJ link failed: ${err.message}`);
-    }
-  }
 }
 
 // Called by the queue watcher when an autonomous track starts and the queue is
@@ -200,7 +210,9 @@ export async function runTrackEvent(queue, ctx, { wantLink }) {
     const eventText = `Now playing "${current?.title}" by ${current?.artist}`
       + (previous ? ` (after "${previous.title}" by ${previous.artist})` : '')
       + '. Pick the track to play next.'
-      + (wantLink ? ' Also write a short link to speak over this track now.' : ' Stay silent — no link this time.');
+      + (wantLink
+          ? ` Also write a short link that airs as your pick starts: back-announce "${current?.title}" and lead into the track you pick.`
+          : ' Stay silent — no link this time.');
     session.appendTurn({ role: 'event', kind: 'pick', text: eventText });
 
     if (settings.get().llm?.pickerAgent) {
@@ -211,7 +223,7 @@ export async function runTrackEvent(queue, ctx, { wantLink }) {
         queue.log('error', `DJ agent pick failed: ${err.message} — falling back to pool`);
       }
     }
-    await pickViaPool(queue, ctx, { wantLink, previous, current });
+    await pickViaPool(queue, ctx, { wantLink, current });
   });
 }
 
@@ -247,6 +259,7 @@ export async function runRequest(queue: any, ctx: any, { requester, text: _text 
       requestedBy: requester,
       intent: 'listener request',
       introScript: intro || null,
+      introKind: 'dj-speak',
     });
     session.appendTurn({
       role: 'dj', kind: 'request',

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -265,15 +265,25 @@ class Queue {
   }
 
   // Push a listener request. Adds to upcoming and kicks off the Liquidsoap sender.
-  async push({ track, requestedBy = null, intent = null, introScript = null, aiPicked = false }: {
+  // `introScript` is the spoken intro/link tied to THIS track — it is NOT aired
+  // at queue time. drainToLiquidsoap renders it to a WAV ahead of time and
+  // airIntro() writes that WAV to Liquidsoap only when the track actually starts
+  // playing (see onTrackStarted), so the voice always lands over the right song.
+  // `introKind` picks both the TTS engine routing and the duck channel:
+  //   'dj-speak' → say.txt   (HEAVY duck — request intros)
+  //   'link'     → intro.txt (LIGHT duck — between-track auto-DJ links)
+  async push({ track, requestedBy = null, intent = null, introScript = null, introKind = 'dj-speak', aiPicked = false }: {
     track: any;
     requestedBy?: string | null;
     intent?: string | null;
     introScript?: string | null;
+    introKind?: string;
     aiPicked?: boolean;
   }) {
     const item = {
-      track, requestedBy, intent, introScript, aiPicked,
+      track, requestedBy, intent, introScript, introKind, aiPicked,
+      introWav: null as string | null,
+      introAired: false,
       queuedAt: new Date().toISOString(),
       sent: false,
     };
@@ -294,12 +304,13 @@ class Queue {
         const item = this.upcoming.find(i => !i.sent);
         if (!item) break;
 
-        if (item.introScript) {
+        // Render the track's intro/link WAV ahead of time but DON'T air it here
+        // — airing now would play it over whatever's currently on-air, one (or
+        // more) tracks before this one reaches the front of dj_queue (issue
+        // #189). airIntro() writes it to the voice file when the track starts.
+        if (item.introScript && !item.introWav) {
           try {
-            const wavPath = await speak(item.introScript, { kind: 'dj-speak' });
-            await writeHandoff(config.liquidsoap.sayFile, wavPath);
-            this.log('dj-speak', item.introScript);
-            await sleep(250);
+            item.introWav = await speak(item.introScript, { kind: item.introKind || 'dj-speak' });
           } catch (err: any) {
             this.log('error', `TTS failed: ${err.message}`);
           }
@@ -343,6 +354,31 @@ class Queue {
         kind === 'link' ? { text } : { text, kind });
     } catch (err: any) {
       this.log('error', `Announce failed: ${err.message}`);
+    }
+  }
+
+  // Air a queued item's track-tied intro/link. Called from onTrackStarted the
+  // moment the item's track actually starts playing, so the voice lands over
+  // the RIGHT song rather than over whatever was on-air when it was queued
+  // (issue #189). The WAV was rendered ahead of time in drainToLiquidsoap, so
+  // this just writes the path to the duck channel and mirrors the bookkeeping
+  // announce() does (djLog feeds the opener anti-repeat; session + webhook).
+  async airIntro(item: any) {
+    if (!item?.introWav || item.introAired || !existsSync(item.introWav)) return;
+    item.introAired = true;
+    const kind = item.introKind || 'dj-speak';
+    const targetFile = kind === 'link'
+      ? config.liquidsoap.introFile
+      : config.liquidsoap.sayFile;
+    try {
+      await writeHandoff(targetFile, item.introWav);
+      this.persist();
+      this.log(kind, item.introScript);
+      session.appendTurn({ role: 'segment', kind, text: item.introScript });
+      webhooks.notify(kind === 'link' ? 'dj.link' : 'dj.say',
+        kind === 'link' ? { text: item.introScript } : { text: item.introScript, kind });
+    } catch (err: any) {
+      this.log('error', `Air intro failed: ${err.message}`);
     }
   }
 
@@ -429,6 +465,12 @@ class Queue {
       this.current = { ...item, startedAt: new Date().toISOString(), source };
       this.log('playing', `${np.title} — ${np.artist}`, { requestedBy: item.requestedBy, source });
       this._autoMisses = 0;
+      // Air this track's intro/link now that it's actually on-air — deferred
+      // from queue time so the voice lands over the right song (#189). Fire-
+      // and-forget: airIntro's writeHandoff can block up to maxWaitMs and must
+      // not stall the 1.5s watcher tick. Use the live `this.current` so the
+      // introAired flag is set on the tracked object.
+      void this.airIntro(this.current);
     } else {
       // Not a tracked request → auto-playlist or jingle.
       // If we keep seeing untracked plays while `upcoming` is non-empty, those

--- a/controller/src/routes/request.ts
+++ b/controller/src/routes/request.ts
@@ -175,6 +175,7 @@ async function resolveRequest(entry) {
     });
     await queue.push({
       track: pick, requestedBy: requester, intent: 'more_like_this', introScript,
+      introKind: 'dj-speak',
     });
     session.appendTurn({
       role: 'dj', kind: 'request',
@@ -368,6 +369,7 @@ async function resolveRequest(entry) {
     requestedBy: requester,
     intent: matched.intent,
     introScript,
+    introKind: 'dj-speak',
   });
   session.appendTurn({
     role: 'dj', kind: 'request',


### PR DESCRIPTION
## Problem

Closes #189 — DJ announcements were **one song early**. The DJ introduced a track that was *next* in the queue, not the one playing. For listener requests it was worse: the requested-track intro could air two tracks early (e.g. "here's Kim Wilde" while Wham plays, then The Police plays, then Kim Wilde).

## Root cause

Liquidsoap's `voice_queue` (fed by `say.txt`) and `intro_queue` (fed by `intro.txt`) are independent sources mixed over the music bus via `smooth_add`. They air within ~0.5s of the file appearing, **over whatever is currently on-air** — they have no association with track transitions.

But the controller wrote those files *too early*:
- `queue.drainToLiquidsoap()` wrote a request's intro to `say.txt` immediately, even though the track was buffered behind others in `dj_queue`.
- `dj-agent` announced the auto-DJ link the moment it *picked* the next track — which happens when the **current** track starts — so the link aired over the wrong (current) track.

## Fix

Defer every **track-tied** announcement until the track it describes actually starts playing (detected in `onTrackStarted` via the now-playing watcher). The WAV is rendered ahead of time at drain; only the file write moves to the transition.

- **`queue.ts`** — items carry `introKind` + a pre-rendered `introWav` + an `introAired` guard. `drainToLiquidsoap()` renders but no longer airs. New `airIntro()` writes the WAV to the right duck channel (`say.txt` heavy / `intro.txt` light) and is fired fire-and-forget from `onTrackStarted`, mirroring `announce()`'s djLog/session/webhook bookkeeping so opener anti-repeat is preserved.
- **`dj-agent.ts`** — the two auto-DJ links are attached to the *picked* item instead of announced immediately. The pool path's `generateLink` args are corrected (`previous` = now-playing, `current` = the pick) so the back-announce matches the deferred airing moment; the per-turn event text matches. Request intros tagged `introKind: 'dj-speak'`.
- **`request.ts`** — both stateless request push sites tagged `introKind: 'dj-speak'`.

The manual `/dj/segment` link (`scheduler.runLink`) stays immediate — it correctly references the actual now-playing track. Request intros keep heavy duck (`say.txt`), per product decision.

## Notes

- No `radio.liq` change — this is entirely controller-side timing.
- **Dropped items never mis-air:** `recover()` cutoff, the `idx>0` splice, and the `_autoMisses` stale-clear all remove items from `upcoming` before they could become `current`, so `airIntro` never fires on them.
- Behaviour shift in anti-repeat data (djLog written at air time vs pick time, ~1 track later) is immaterial against the 120-min anti-repeat window.

## Verification

- `cd controller && npm run lint` (eslint + `tsc --noEmit`) → **0 errors**.
- Static trace of both issue scenarios confirms the announcement now lands on the track actually starting.
- Live audio smoke test (dev stack, listen for a link/request airing at the right transition) still recommended before merge.