### PR TITLE
fix(web): theme picker opacity + schedule time/location in autonomous mode

### DIFF
--- a/web/components/ThemeSwitcher.tsx
+++ b/web/components/ThemeSwitcher.tsx
@@ -112,7 +112,13 @@ export default function ThemeSwitcher({ variant = 'player' }: ThemeSwitcherProps
           role="menu"
           aria-label="Themes"
           className={cn(
-            'absolute z-30 mt-1 grid w-[min(280px,calc(100vw-2rem))] gap-1 border border-ink bg-bg p-2 shadow-drawer',
+            // bg-[var(--field)] (not bg-bg) lifts the panel off the page: the
+            // page background is exactly --bg, so a bg-bg panel reads as
+            // transparent — content and chrome show across it. --field is the
+            // per-theme "raised surface" nudge, so the menu stays opaque and
+            // distinct in every theme. A real drop shadow + ring seal the edge.
+            'absolute z-50 mt-1 grid w-[min(280px,calc(100vw-2rem))] gap-1 border border-ink bg-[var(--field)] p-2',
+            'shadow-[0_16px_44px_-12px_rgba(0,0,0,0.7)] ring-1 ring-black/10',
             // Anchor the popover to the trigger; pull it left so the right
             // edge lines up with the icon — keeps the panel inside the
             // viewport when the trigger sits flush with the right gutter.

--- a/web/components/TopBar.tsx
+++ b/web/components/TopBar.tsx
@@ -44,7 +44,7 @@ export default function TopBar({
       // baseline gutter; left/right max() against the gutter so landscape
       // on a notched phone doesn't clip the wordmark, while desktop keeps
       // its wider sm: gutters.
-      className="player-topbar absolute top-0 right-0 left-0 z-20 flex items-baseline justify-between gap-3 border-b border-ink
+      className="player-topbar absolute top-0 right-0 left-0 z-30 flex items-baseline justify-between gap-3 border-b border-ink
         pt-[calc(env(safe-area-inset-top)_+_1rem)] pr-[max(1rem,env(safe-area-inset-right))]
         pb-2 pl-[max(1rem,env(safe-area-inset-left))]
         sm:pt-[calc(env(safe-area-inset-top)_+_1.5rem)] sm:pr-[max(2rem,env(safe-area-inset-right))]

--- a/web/components/drawers/ScheduleDrawer.tsx
+++ b/web/components/drawers/ScheduleDrawer.tsx
@@ -159,11 +159,21 @@ export default function ScheduleDrawer({ activeShow, context }: ScheduleDrawerPr
 
   const hasAnyShow = data.shows.length > 0;
   if (!hasAnyShow) {
+    // Autonomous mode (no scheduled shows) is the common state for a personal
+    // station, so still surface the station time + location here — that's
+    // exactly the context an always-on autonomous station benefits from.
     return (
-      <div className="text-[13px] leading-relaxed text-muted">
-        No shows scheduled — the station is running autonomously. The DJ picks
-        tracks by the time of day, the weather, and any festival on the
-        calendar.
+      <div className="grid gap-6">
+        <StationHeader
+          now={now}
+          timezone={data.timezone ?? null}
+          location={context?.weather?.location ?? null}
+        />
+        <div className="text-[13px] leading-relaxed text-muted">
+          No shows scheduled — the station is running autonomously. The DJ picks
+          tracks by the time of day, the weather, and any festival on the
+          calendar.
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

Two polish fixes on top of the per-listener theme switcher (#188) and Schedule time/location (#187) that are queued in release PR #192. Web-only, no migrations or env changes.

**Bug Fixes**
- `3dee65e` fix(web): make theme picker opaque and clear of player chrome — the dropdown used `bg-bg` (identical to the page background) so it read as transparent; player chrome bled across it. Now uses the per-theme `--field` raised surface + a real drop shadow, and the player TopBar is lifted to `z-30` so the popover paints above the `z-20` right rail instead of being cut by its divider.
- `c65c316` fix(web): show station time and location when no shows are scheduled — the no-shows guard returned early and skipped the `StationHeader` from #187. Autonomous mode (zero shows) is the common state for a personal station, so the time + location header now renders there too.

## Test plan
- [x] Open the player theme picker on a dark theme (e.g. Cyberpunk): panel is fully opaque, no rail line or content showing through
- [x] Same check in the admin header theme picker
- [x] Open Schedule with no shows scheduled: station time (live, ticking) and location render above the "running autonomously" message
- [x] Open Schedule with at least one show scheduled: header still renders, grid unaffected
- [x] `cd web && npm run lint` passes