### PR TITLE
fix(web): admin UI polish — Library default tab + tagger strip, Dash & Personas layout

### DIFF
--- a/web/components/admin/DashPanel.tsx
+++ b/web/components/admin/DashPanel.tsx
@@ -9,7 +9,14 @@ import { useAdminAuth } from '../../lib/adminAuth';
 import { notify, errorMessage } from '../../lib/notify';
 import { turnClass, turnKey, turnText } from '../../lib/sessionFeed';
 import type { SessionTurn } from '../../lib/types';
-import type { NowPlayingTrack, StationContext, ActiveShow, DjState, ListenerCount, QueueEntry } from '../../lib/types';
+import type {
+  NowPlayingTrack,
+  StationContext,
+  ActiveShow,
+  DjState,
+  ListenerCount,
+  QueueEntry,
+} from '../../lib/types';
 import { V3AlertDialog } from '../ui/alert-dialog';
 import { V3Alert } from '../ui/alert';
 import { Textarea } from '../ui/textarea';
@@ -106,7 +113,12 @@ export default function DashPanel() {
   }, [status?.sessionMessages?.length]);
 
   // Generic POST helper — drives the busy state; result goes to the toast.
-  const act = async (key: string, path: string, body: Record<string, unknown> | null, label: string): Promise<ActResponse | null> => {
+  const act = async (
+    key: string,
+    path: string,
+    body: Record<string, unknown> | null,
+    label: string,
+  ): Promise<ActResponse | null> => {
     setBusy(key);
     try {
       const r = await adminFetch(path, {
@@ -159,9 +171,10 @@ export default function DashPanel() {
     sub?: ReactNode;
     accent?: boolean;
   }
-  const djName = status?.dj && typeof status.dj === 'object' && 'name' in status.dj
-    ? String((status.dj as { name?: unknown }).name ?? '—')
-    : '—';
+  const djName =
+    status?.dj && typeof status.dj === 'object' && 'name' in status.dj
+      ? String((status.dj as { name?: unknown }).name ?? '—')
+      : '—';
   const strip: StripCell[] = [
     { l: 'dj on air', v: djName, accent: true },
     { l: 'show', v: showName },
@@ -200,25 +213,9 @@ export default function DashPanel() {
       <div className="stack-mobile grid grid-cols-[1.4fr_1fr] gap-4">
         {/* LEFT */}
         <div className="grid grid-rows-[auto_1fr] gap-4">
-          <Card
-            title="Queue"
-            sub={`${upcoming.length} upcoming`}
-            right={
-              <>
-                <Pill tone="accent" dot={!!q.autoPick}>
-                  auto-pick {q.autoPick ? 'on' : 'off'}
-                </Pill>
-                <Pill tone="accent" dot={!!q.autoLink}>
-                  auto-link {q.autoLink ? 'on' : 'off'}
-                </Pill>
-              </>
-            }
-            bodyClass="px-3.5 py-1"
-          >
+          <Card title="Queue" sub={`${upcoming.length} upcoming`} bodyClass="px-3.5 py-1">
             {upcoming.length === 0 ? (
-              <div className="py-2.5 text-muted italic">
-                queue empty — auto-playlist fallback
-              </div>
+              <div className="py-2.5 text-muted italic">queue empty — auto-playlist fallback</div>
             ) : (
               upcoming.slice(0, 8).map((t, i) => (
                 <div className="track-row" key={i}>
@@ -254,10 +251,7 @@ export default function DashPanel() {
             {booth.length === 0 ? (
               <div className="text-muted italic">no session turns yet</div>
             ) : (
-              <div
-                ref={logRef}
-                className="max-h-[360px] min-h-[220px] flex-1 overflow-y-auto"
-              >
+              <div ref={logRef} className="max-h-[420px] min-h-[220px] flex-1 overflow-y-auto">
                 {booth.map((turn, i) => (
                   <div key={turnKey(turn, i)} className={`log ${classTone(turnClass(turn))}`}>
                     <span className="t">
@@ -344,9 +338,7 @@ export default function DashPanel() {
               <div className="flex items-center justify-between border-t border-dashed border-separator-strong pt-2">
                 <div>
                   <div className="text-[12px] font-bold">Auto-playlist</div>
-                  <div className="text-[10px] text-muted">
-                    rebuild liquidsoap fallback
-                  </div>
+                  <div className="text-[10px] text-muted">rebuild liquidsoap fallback</div>
                 </div>
                 <Btn
                   sm
@@ -363,9 +355,7 @@ export default function DashPanel() {
         </div>
       </div>
 
-      {!status && !err && (
-        <div className="text-muted italic">connecting…</div>
-      )}
+      {!status && !err && <div className="text-muted italic">connecting…</div>}
 
       <V3AlertDialog
         open={confirmSkip}
@@ -407,35 +397,23 @@ function HeroSection({ err, np, q, busy, onSkip, strip }: HeroSectionProps) {
           {np?.title ? (
             <>
               <div className="text-[18px] leading-[1.2] font-bold tracking-[-0.01em]">
-                {np.title}{' '}
-                <span className="font-semibold text-muted">— {np.artist}</span>
+                {np.title} <span className="font-semibold text-muted">— {np.artist}</span>
               </div>
-              {np.album && (
-                <div className="caption mt-1.5">
-                  album · {np.album}
-                </div>
-              )}
+              {np.album && <div className="caption mt-1.5">album · {np.album}</div>}
             </>
           ) : (
-            <div className="text-[22px] font-bold text-muted">
-              nothing reported playing
-            </div>
+            <div className="text-[22px] font-bold text-muted">nothing reported playing</div>
           )}
         </div>
         <div className="flex gap-2">
-          <Btn
-            lg
-            tone="danger"
-            disabled={!!busy || !np?.title}
-            onClick={onSkip}
-          >
+          <Btn lg tone="danger" disabled={!!busy || !np?.title} onClick={onSkip}>
             {busy === 'skip' ? 'skipping…' : 'Skip track'}
           </Btn>
         </div>
       </div>
 
       {/* status strip */}
-      <div className="strip-mobile grid grid-cols-6">
+      <div className="strip-mobile grid grid-cols-5">
         {strip.map((c, i) => (
           <div
             key={i}
@@ -446,18 +424,11 @@ function HeroSection({ err, np, q, busy, onSkip, strip }: HeroSectionProps) {
           >
             <span className="caption">{c.l}</span>
             <span
-              className={cn(
-                'text-[14px] font-semibold',
-                c.accent ? 'text-vermilion' : 'text-ink',
-              )}
+              className={cn('text-[14px] font-semibold', c.accent ? 'text-vermilion' : 'text-ink')}
             >
               {c.v}
             </span>
-            {c.sub && (
-              <span className="caption text-[9px]">
-                {c.sub}
-              </span>
-            )}
+            {c.sub && <span className="caption text-[9px]">{c.sub}</span>}
           </div>
         ))}
       </div>
@@ -486,7 +457,8 @@ interface SegmentButtonProps {
 
 function SegmentButton({ label, busyHere, anyBusy, onFire }: SegmentButtonProps) {
   const onEnter = (e: MouseEvent<HTMLButtonElement>) => {
-    if (!anyBusy) e.currentTarget.style.background = 'color-mix(in oklab, var(--accent) 18%, transparent)';
+    if (!anyBusy)
+      e.currentTarget.style.background = 'color-mix(in oklab, var(--accent) 18%, transparent)';
   };
   const onLeave = (e: MouseEvent<HTMLButtonElement>) => {
     e.currentTarget.style.background = 'color-mix(in oklab, var(--accent) 8%, transparent)';

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -90,7 +90,7 @@ export default function LibraryPanel() {
   const ready = hydrated && !needsAuth;
 
   // shared state
-  const [tab, setTab] = useState<Tab>('browse');
+  const [tab, setTab] = useState<Tab>('recent');
   const [coverage, setCoverage] = useState<Coverage | null>(null);
   const [tagger, setTagger] = useState<TaggerState | null>(null);
   const [taggerLimit, setTaggerLimit] = useState('500');
@@ -590,10 +590,10 @@ function KpiStrip({ coverage, stats }: {
 // ---------------------------------------------------------------------------
 function TabRail({ tab, setTab }: { tab: Tab; setTab: (t: Tab) => void }) {
   const items: { id: Tab; label: string; hint: string }[] = [
+    { id: 'recent', label: 'Recently added', hint: '' },
     { id: 'browse', label: 'Browse', hint: 'tagged' },
     { id: 'search', label: 'Search', hint: 'navidrome' },
     { id: 'untagged', label: 'Untagged', hint: 'needs tags' },
-    { id: 'recent', label: 'Recently added', hint: '' },
   ];
   return (
     <Card bodyClass="!p-0">

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -10,7 +10,7 @@
 //
 // Each row supports `Queue` (push to the live queue) and, where applicable,
 // `Retag` / `Tag` (single-track LLM classification via /library/retag).
-// A sticky tagger strip at the bottom owns the background batch job.
+// A tagger strip below the header owns the background batch job.
 
 import type { ChangeEvent, FormEvent } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -394,8 +394,18 @@ export default function LibraryPanel() {
     recentLoading;
 
   return (
-    <div className="grid gap-4 pb-24">
+    <div className="grid gap-4">
       <KpiStrip coverage={coverage} stats={stats} />
+
+      <TaggerStrip
+        coverage={coverage}
+        tagger={tagger}
+        limit={taggerLimit}
+        setLimit={setTaggerLimit}
+        busy={taggerBusy}
+        onStart={startTagger}
+        onStop={stopTagger}
+      />
 
       <div className="stack-mobile grid grid-cols-[260px_1fr] items-start gap-4">
         <aside className="grid gap-4">
@@ -422,7 +432,7 @@ export default function LibraryPanel() {
             <Card title="About this view" bodyClass="!py-3">
               <div className="text-[11px] leading-[1.5] text-muted">
                 {tab === 'search' && 'Free-text search against Navidrome — best for finding a specific track to queue right now.'}
-                {tab === 'untagged' && 'Tracks that don\'t yet have moods/energy classified. Tag them one at a time, or kick off the bulk tagger at the bottom of the page.'}
+                {tab === 'untagged' && 'Tracks that don\'t yet have moods/energy classified. Tag them one at a time, or kick off the bulk tagger at the top of the page.'}
                 {tab === 'recent' && 'The newest tracks added to your Navidrome library.'}
               </div>
             </Card>
@@ -523,16 +533,6 @@ export default function LibraryPanel() {
           )}
         </div>
       </div>
-
-      <TaggerStrip
-        coverage={coverage}
-        tagger={tagger}
-        limit={taggerLimit}
-        setLimit={setTaggerLimit}
-        busy={taggerBusy}
-        onStart={startTagger}
-        onStop={stopTagger}
-      />
     </div>
   );
 }
@@ -849,7 +849,7 @@ function TaggerStrip(p: TaggerStripProps) {
   useDynamicStyle(fillRef, { width: pct != null ? `${Math.min(100, pct)}%` : null });
 
   return (
-    <div className="sticky bottom-3 z-30">
+    <div>
       <section className="card border-ink shadow-[0_4px_24px_rgba(0,0,0,0.18)]">
         <div className="stack-mobile grid grid-cols-[1fr_auto] items-center gap-3 p-3">
           <div className="grid gap-1.5">

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -250,21 +250,18 @@ function PersonaAvatarPicker(props: {
           e.target.value = '';
         }}
       />
-      <div className="flex flex-wrap gap-1.5">
-        <Btn sm onClick={() => inputRef.current?.click()} disabled={uploading}>
+      <div className="grid w-[96px] gap-1.5">
+        <Btn sm className="w-full justify-center" onClick={() => inputRef.current?.click()} disabled={uploading}>
           {uploading ? '…' : hasAvatar ? 'Replace' : 'Upload'}
         </Btn>
-        <Btn sm onClick={onGenerate} disabled={uploading} title="Random DiceBear avatar — click again for a different one">
+        <Btn sm className="w-full justify-center" onClick={onGenerate} disabled={uploading} title="Random DiceBear avatar — click again for a different one">
           Generate
         </Btn>
         {hasAvatar && (
-          <Btn sm tone="danger" onClick={onClear} disabled={uploading}>
+          <Btn sm tone="danger" className="w-full justify-center" onClick={onClear} disabled={uploading}>
             Remove
           </Btn>
         )}
-      </div>
-      <div className="text-[10px] leading-[1.4] text-muted">
-        Upload a square 512px PNG/JPEG/WebP, or click Generate for a random DiceBear avatar.
       </div>
     </div>
   );
@@ -814,7 +811,7 @@ export default function PersonasPanel() {
               </>
             }
           >
-            <div className="stack-mobile grid grid-cols-[96px_1fr_1fr] items-start gap-4">
+            <div className="stack-mobile grid grid-cols-[96px_1fr] items-start gap-4">
               <PersonaAvatarPicker
                 persona={focused}
                 tick={avatarTick}
@@ -823,30 +820,32 @@ export default function PersonasPanel() {
                 onGenerate={() => generateAvatar(focused.id)}
                 onClear={() => clearAvatar(focused.id)}
               />
-              <div className="field">
-                <Label>On-air name</Label>
-                <Input
-                  value={focused.name}
-                  maxLength={NAME_MAX}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => setPersona(safeIdx, { name: e.target.value })}
-                  className={focused.name.trim() ? 'border-ink' : 'border-[var(--danger)]'}
-                />
-                <div className="field-hint">
-                  Shown in the player and injected into every prompt as <code>{'{name}'}</code>.
-                  <span className="ml-2 text-muted">{focused.name.trim().length} / {NAME_MAX}</span>
+              <div className="grid gap-4">
+                <div className="field">
+                  <Label>On-air name</Label>
+                  <Input
+                    value={focused.name}
+                    maxLength={NAME_MAX}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => setPersona(safeIdx, { name: e.target.value })}
+                    className={focused.name.trim() ? 'border-ink' : 'border-[var(--danger)]'}
+                  />
+                  <div className="field-hint">
+                    Shown in the player and injected into every prompt as <code>{'{name}'}</code>.
+                    <span className="ml-2 text-muted">{focused.name.trim().length} / {NAME_MAX}</span>
+                  </div>
                 </div>
-              </div>
-              <div className="field">
-                <Label>Tagline</Label>
-                <Input
-                  value={focused.tagline}
-                  maxLength={TAGLINE_MAX}
-                  placeholder="e.g. late-night drift"
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => setPersona(safeIdx, { tagline: e.target.value })}
-                />
-                <div className="field-hint">
-                  A short line shown alongside the persona. Optional.
-                  <span className="ml-2 text-muted">{focused.tagline.trim().length} / {TAGLINE_MAX}</span>
+                <div className="field">
+                  <Label>Tagline</Label>
+                  <Input
+                    value={focused.tagline}
+                    maxLength={TAGLINE_MAX}
+                    placeholder="e.g. late-night drift"
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => setPersona(safeIdx, { tagline: e.target.value })}
+                  />
+                  <div className="field-hint">
+                    A short line shown alongside the persona. Optional.
+                    <span className="ml-2 text-muted">{focused.tagline.trim().length} / {TAGLINE_MAX}</span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -972,12 +972,19 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
     return { ...base, tts: { ...base.tts, defaultEngine: engine } };
   });
 
-  const savedTts: any = data.values?.tts || {};
+  type SavedCloud = { provider?: string; voice?: string; model?: string; baseUrl?: string };
+  const savedTts: {
+    defaultEngine?: string;
+    kokoro?: { voice?: string };
+    chatterbox?: { referenceVoice?: string };
+    pocketTts?: { voice?: string };
+    cloud?: SavedCloud;
+  } = data.values?.tts || {};
   const savedEngine: string = savedTts.defaultEngine || 'piper';
   const savedKokoroVoice: string = savedTts.kokoro?.voice || '';
   const savedChatterboxVoice: string = savedTts.chatterbox?.referenceVoice || '';
   const savedPocketTtsVoice: string = savedTts.pocketTts?.voice || '';
-  const savedCloud: any = savedTts.cloud || {};
+  const savedCloud: SavedCloud = savedTts.cloud || {};
   const savedEngineLabel = ENGINE_LABELS[savedEngine] || savedEngine;
   const formEngineLabel = ENGINE_LABELS[form.tts.defaultEngine] || form.tts.defaultEngine;
 

--- a/web/components/onboarding/steps.tsx
+++ b/web/components/onboarding/steps.tsx
@@ -243,7 +243,7 @@ export function TtsStep({ w }: { w: WizardController }) {
             value={w.data.tts.defaultEngine}
             onChange={e =>
               w.patch(d => ({
-                tts: { ...d.tts, defaultEngine: e.target.value as any },
+                tts: { ...d.tts, defaultEngine: e.target.value as typeof d.tts.defaultEngine },
               }))
             }
           >

--- a/web/components/onboarding/useWizard.ts
+++ b/web/components/onboarding/useWizard.ts
@@ -112,7 +112,7 @@ export function useWizard() {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(data.navidrome),
     });
-    const j: any = await r.json().catch(() => ({}));
+    const j = (await r.json().catch(() => ({}))) as { ok?: boolean; serverType?: string; serverVersion?: string; error?: string };
     const result = { ok: !!j.ok, msg: j.ok ? `${j.serverType || 'Subsonic'} v${j.serverVersion || ''}` : j.error };
     patch({ navidromeTest: result });
     return result;
@@ -124,7 +124,7 @@ export function useWizard() {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(data.llm),
     });
-    const j: any = await r.json().catch(() => ({}));
+    const j = (await r.json().catch(() => ({}))) as { ok?: boolean; sample?: string; error?: string };
     const result = { ok: !!j.ok, msg: j.ok ? `responded: "${j.sample}"` : j.error };
     patch({ llmTest: result });
     return result;
@@ -177,13 +177,13 @@ export function useWizard() {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body),
     });
-    const j: any = await r.json().catch(() => ({}));
+    const j = (await r.json().catch(() => ({}))) as { ok?: boolean; error?: string };
     return { ok: !!j.ok, error: j.error };
   }, [auth, data]);
 
   const generateJingles = useCallback(async () => {
     const r = await auth.adminFetch('/onboarding/generate-jingles', { method: 'POST' });
-    const j: any = await r.json().catch(() => ({}));
+    const j = (await r.json().catch(() => ({}))) as { ok?: boolean; created?: number; total?: number; error?: string };
     return { ok: !!j.ok, created: j.created, total: j.total, error: j.error };
   }, [auth]);
 


### PR DESCRIPTION
## Summary

Web-only admin UI polish, batched. No backend or behavioral logic changes.

**Bug Fixes**
- `c2c2335` Default the Library admin to **Recently added** (and list it first). Browse reads the tagged `moods.json` index, so on a low/zero-coverage library it lands on an empty view; Recently added gives operators a populated list immediately.
- `3439614` Move the Library **bulk-tagger strip** from a floating sticky bar at the bottom to a static strip directly under the "Manage the music…" header, beside the coverage stats it acts on.
- `f2bcf6a` Tidy the **Dash** layout — drop the auto-pick/auto-link pills from the Queue header, trim the status strip to five cells, taller booth log, markup reflow.
- `180522a` Tidy the **Personas** avatar editor — stack On-air name over Tagline beside the avatar, make Replace/Generate/Remove a uniform full-width stack, drop the redundant upload hint.

## Test plan
- [x] `/admin/library` opens on Recently added (populated); Recently added is first in the rail; Browse/Search/Untagged still work
- [x] Library tagger strip sits under the header, not floating at the bottom; Start/Stop/log still work
- [x] `/admin` Dash renders cleanly; Queue card, 5-cell status strip, booth log all correct
- [x] `/admin/personas` shows name-over-tagline beside the avatar; the three avatar buttons are even and full-width; no hint text
- [x] `cd web && npm run lint` passes (0 errors)