### PR TITLE
fix(web): correct player keyboard shortcut help

### DIFF
--- a/web/components/ShortcutsDialog.tsx
+++ b/web/components/ShortcutsDialog.tsx
@@ -17,6 +17,7 @@ const SHORTCUTS: readonly Shortcut[] = [
   { keys: ['1'], label: 'Open Timeline' },
   { keys: ['2'], label: 'Open Booth feed' },
   { keys: ['3', 'R'], label: 'Make a request' },
+  { keys: ['4'], label: 'Open Schedule' },
   { keys: ['?'], label: 'This shortcuts list' },
   { keys: ['⌘K'], label: 'Command palette' },
   { keys: ['Esc'], label: 'Close drawer / dialog' },

--- a/web/components/manual/Shortcuts.tsx
+++ b/web/components/manual/Shortcuts.tsx
@@ -8,10 +8,10 @@ const SHORTCUTS = [
   { keys: ['↑'], action: 'Volume up', note: 'Raises the volume in 5% steps.' },
   { keys: ['↓'], action: 'Volume down', note: 'Lowers the volume in 5% steps.' },
   { keys: ['M'], action: 'Mute / unmute', note: 'Drops to silence, then back to your last level.' },
-  { keys: ['T'], action: 'Toggle theme', note: 'Switches between the light and dark broadsheet.' },
   { keys: ['1'], action: 'Open Timeline', note: 'The upcoming queue and recent history.' },
   { keys: ['2'], action: 'Open Booth feed', note: 'What the DJ has been saying on air.' },
   { keys: ['3', 'R'], action: 'Make a request', note: 'Opens the request panel.' },
+  { keys: ['4'], action: 'Open Schedule', note: 'The lineup of upcoming and recent shows.' },
   { keys: ['?'], action: 'Shortcuts help', note: 'The in-player list of every shortcut.' },
   { keys: ['⌘K', 'Ctrl K'], action: 'Command palette', note: 'A searchable menu of every player action.' },
   { keys: ['Esc'], action: 'Close', note: 'Dismisses the open drawer or dialog.' },
@@ -35,7 +35,7 @@ export default function Shortcuts() {
     <ManualPage
       eyebrow="MANUAL · 04"
       title="Keyboard shortcuts."
-      intro="The player can be driven entirely from the keyboard — tune in, change the volume, open the panels, and switch themes without reaching for the mouse."
+      intro="The player can be driven entirely from the keyboard — tune in, change the volume, and open the panels without reaching for the mouse."
       current="/manual/shortcuts"
     >
       <section className="bs-section">


### PR DESCRIPTION
## What

The player's keyboard-shortcut documentation drifted from the actual handler:

- **Removed the dead `T → Toggle theme` shortcut.** It no longer exists — the per-listener `ThemeSwitcher` replaced the old toggle, but the manual still advertised `T`. Confirmed no `t` binding remains in `useKeyboardShortcuts`/`PlayerApp`.
- **Documented `4 → Open Schedule`.** The Schedule drawer's `4` key was already wired in `PlayerApp.tsx` and listed in the command palette, but missing from the in-player `?` dialog and the manual shortcuts page.

## Changes

- `web/components/ShortcutsDialog.tsx` — add `4 → Open Schedule` to the in-player `?` list.
- `web/components/manual/Shortcuts.tsx` — remove the `T` row, add the Schedule row, and drop "and switch themes" from the intro.

Docs-only; no code-path changes (the `4` binding and palette entry already existed). `npm run lint` (eslint + tsc) passes clean.