### PR TITLE
fix(controller): dj-agent recovery returns valid ids + pick.rejected observability

### DIFF
--- a/.claude/skills/subwave-log-analysis/scripts/analyze_events.py
+++ b/.claude/skills/subwave-log-analysis/scripts/analyze_events.py
@@ -3,7 +3,7 @@
 
 The controller writes one JSON object per line to state/logs/events-YYYY-MM-DD.jsonl.
 Event types: trace.start, trace.end, llm, tool, navidrome, track.play,
-session.start, session.end. Events made inside a withTrace() scope carry a
+pick.rejected, session.start, session.end. Events made inside a withTrace() scope carry a
 shared traceId, so a DJ decision and the Navidrome/tool calls it triggered can
 be read back as one trace.
 
@@ -163,7 +163,7 @@ def report_overview(events, files_read, skipped):
         print(f"Time span      : {times[0]}  ->  {times[-1]}")
     print(f"Total events   : {len(events)}")
     for t in ("track.play", "trace.start", "llm", "tool", "navidrome",
-              "session.start"):
+              "pick.rejected", "session.start"):
         if by_type.get(t):
             print(f"  {t:<14}: {by_type[t]}")
     sessions = [ev for ev in events if ev.get("type") == "session.start"]
@@ -243,21 +243,29 @@ def report_picker(events, traces):
 
     if pick_traces:
         nav_counts, tool_counts, durations = [], [], []
-        agent_ok = agent_fallback = agent_off = 0
+        agent_ok = agent_fallback = agent_off = agent_rejected = 0
         for tr in pick_traces.values():
             evs = tr["events"]
             nav_counts.append(sum(1 for e in evs if e.get("type") == "navidrome"))
             tool_counts.append(sum(1 for e in evs if e.get("type") == "tool"))
             if tr["ms"] is not None:
                 durations.append(tr["ms"])
+            # The agent's LLM call can succeed (ok:true) yet return a track id
+            # that wasn't in the candidate set — dj-agent then rejects it and
+            # falls back to the pool. That rejection is logged as a distinct
+            # `pick.rejected` event; without checking for it, an invalid-id pick
+            # counts as "agent succeeded" and the success rate is overstated.
+            rejected = any(e.get("type") == "pick.rejected" for e in evs)
             llm_picks = [e for e in evs if e.get("type") == "llm"
                          and e.get("kind") == "djAgentPick"]
             if not llm_picks:
                 agent_off += 1            # pickerAgent disabled — pool picker only
+            elif rejected:
+                agent_rejected += 1       # LLM ok, but returned an unknown id → pool
             elif all(p.get("ok") for p in llm_picks):
                 agent_ok += 1
             else:
-                agent_fallback += 1       # agent ran, failed, fell back to pool
+                agent_fallback += 1       # the LLM call itself errored → pool
         n = len(pick_traces)
         print(f"Track-pick decisions : {n}")
         print(f"  avg Navidrome calls / decision : {avg(nav_counts):.1f}  "
@@ -268,7 +276,9 @@ def report_picker(events, traces):
             print(f"  decision latency               : avg {avg(durations):.0f} ms, "
                   f"p95 {pctl(durations,95):.0f} ms, max {max(durations):.0f} ms")
         print(f"  agent succeeded   : {agent_ok}/{n}   {bar(agent_ok, n)}")
-        print(f"  agent -> fallback : {agent_fallback}/{n}   {bar(agent_fallback, n)}")
+        if agent_rejected:
+            print(f"  agent invalid id  : {agent_rejected}/{n}   {bar(agent_rejected, n)}  (returned an id not in its candidates → pool fallback)")
+        print(f"  agent -> fallback : {agent_fallback}/{n}   {bar(agent_fallback, n)}  (LLM call errored)")
         if agent_off:
             print(f"  pool picker only  : {agent_off}/{n}  (pickerAgent disabled)")
     else:

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -19,7 +19,7 @@ import * as dj from '../llm/dj.js';
 import { defineAgent } from '../llm/agent.js';
 import { buildPickerTools } from '../llm/tools.js';
 import { recordPick } from '../llm/log.js';
-import { withTrace } from '../observability/events.js';
+import { withTrace, logEvent } from '../observability/events.js';
 
 export const PICK_SCHEMA = z.object({
   id: z.string().describe('the exact song id returned by one of the discovery tools — never invent or compose ids'),
@@ -142,7 +142,15 @@ async function pickViaAgent(queue, { wantLink }) {
   });
 
   const song = object?.id ? extras.seen.get(object.id) : null;
-  if (!song) throw new Error(`agent returned unknown id ${object?.id}`);
+  if (!song) {
+    // The agent returned an id that isn't in the candidate set it was shown —
+    // it fabricated one. The trace still ends ok:true (we fall back to the pool
+    // and air a track), so without this explicit event the rejection is
+    // invisible to /debug and the log analyzer, which then over-report agent
+    // health. Emit it inside the live trace so agent-pick reliability is real.
+    logEvent('pick.rejected', { agent: 'pick', id: object?.id ?? null, candidates: extras.seen.size, steps, toolCalls });
+    throw new Error(`agent returned unknown id ${object?.id}`);
+  }
 
   const say = typeof object.say === 'string' ? object.say.trim() : '';
   // Attach the link to the pick so it airs as the pick starts (back-announcing
@@ -251,7 +259,10 @@ export async function runRequest(queue: any, ctx: any, { requester, text: _text 
     });
 
     const song = object?.id ? extras.seen.get(object.id) : null;
-    if (!song) throw new Error(`request agent returned unknown id ${object?.id}`);
+    if (!song) {
+      logEvent('pick.rejected', { agent: 'request', id: object?.id ?? null, candidates: extras.seen.size, toolCalls });
+      throw new Error(`request agent returned unknown id ${object?.id}`);
+    }
 
     const intro = typeof object.intro === 'string' ? object.intro.trim() : '';
     await queue.push({

--- a/controller/src/llm/sdk.ts
+++ b/controller/src/llm/sdk.ts
@@ -593,6 +593,17 @@ export async function djAgent({
     if (useDoneTool && !(result.staticToolCalls || []).some((c: any) => c.toolName === 'done')) {
       console.log(`[${kind}] agent stopped without calling done — retrying with done-only`);
       lastVia = 'ai-sdk:agent:recovery';
+      // Carry the first run's conversation forward — crucially its tool-call +
+      // tool-result messages (the discovery trail). The first run DID surface
+      // candidates into the caller's `seen` map (gated discovery forces a tool
+      // call at step 0); it just never emitted `done`. Replaying only the bare
+      // `messages` here strips those candidates, so a picker/request agent
+      // cornered into done-only has no ids in context and can only fabricate
+      // one — which is why 100% of recovery picks returned an "unknown id".
+      // Feeding the discovery trail back lets the model commit to a REAL
+      // surfaced id. Harmless for free-text recovery (no tool messages to add).
+      const priorMessages = (result as any).response?.messages || [];
+      const recoveryMessages = priorMessages.length ? [...messages, ...priorMessages] : messages;
       const recoveryAgent = new ToolLoopAgent({
         model: languageModel(),
         instructions: system,
@@ -605,7 +616,7 @@ export async function djAgent({
         prepareStep: async () => ({ activeTools: ['done'], toolChoice: 'required' }),
       } as any);
       result = await withTransientRetry(kind, () => recoveryAgent.generate({
-        messages,
+        messages: recoveryMessages,
         ...(timeoutMs ? { timeout: timeoutMs } : {}),
       }));
       steps = result.steps?.length ?? 0;


### PR DESCRIPTION
## Summary

Two related changes to the session DJ picker/request agents: a **root-cause fix** so recovery picks stop falling back to the pool, and **observability** so any residual rejection is visible instead of silent.

### 1. Fix: feed the discovery trail into the done-only recovery
When the model fails to emit a `done` call in the first agent run, `djAgent` (`llm/sdk.ts`) re-runs with `done`-only forced — but it replayed **only the bare session window**, discarding the first run's discovery results. Cornered into `done`-only with zero candidates in context, the model **fabricated an id** (slugs like `brown-munde-…`, Spotify-format strings), which never matched the caller's `seen` map → every recovery pick threw `agent returned unknown id` and fell back to the pool.

**Evidence (live `/debug`, 27 picks):** normal path **10/10** valid id; recovery path **0/17**. Recovery fired ~63% of picks on `glm-5.1:cloud`.

**Fix:** carry the first run's `response.messages` (its tool-call + tool-result messages — the discovery trail) into the recovery `generate()` so the model can commit to a **real surfaced id**.

**Verified live** (driven via `/dj/skip` + diagnostics): `response.messages` carries the tool results with real ids; every recovery now resolves to a valid `ai-pick`; **0 `unknown id` failures** (was 100% of recovery). Remaining rare fallback is a separate "model never called `done`" case — degrades gracefully to the pool, no hallucinated id.

### 2. Observability: `pick.rejected` event
A rejected agent pick was invisible — the LLM call logs `ok:true`, the rejection happens afterward in `dj-agent`, and the trace still ends `ok:true` (pool fallback aired a track). So `/debug` **and** the log analyzer both counted invalid-id picks as "agent succeeded".

- Emit a `pick.rejected` event (inside the live trace) at both rejection sites, carrying the bogus id + candidate count.
- The `subwave-log-analysis` analyzer now classifies a trace with a `pick.rejected` as **"agent invalid id"** rather than "agent succeeded", and counts it in the overview. (Deterministically verified on a crafted trace.)

## Test plan
- [x] `docker compose logs controller`: `agent stopped without calling done — retrying with done-only` is now followed by `ai-pick`, not `agent returned unknown id … — falling back to pool`
- [x] If a rejection does occur, a `pick.rejected` line appears in `state/logs/events-*.jsonl` with the bogus id
- [x] `/subwave-log-analysis` reports an "agent invalid id" line when rejections occur (not a falsely-inflated success rate)
- [x] Free-text segments (station ID / hourly) still work
- [x] `cd controller && npm run lint` passes (0 errors)