### PR TITLE
docs(web): thin em-dash density in manual and setup pages

### DIFF
--- a/web/components/manual/AdminSettings.tsx
+++ b/web/components/manual/AdminSettings.tsx
@@ -14,7 +14,7 @@ export default function AdminSettings() {
         <h2>The admin console.</h2>
         <p>
           The console lives at <code className="bs-code-inline">/admin</code>. It's gated
-          by a single sign-in — the <code className="bs-code-inline">ADMIN_USER</code> and{' '}
+          by a single sign-in: the <code className="bs-code-inline">ADMIN_USER</code> and{' '}
           <code className="bs-code-inline">ADMIN_PASS</code> set when the station was
           installed. In production those credentials are mandatory: the station won't
           start without them, because the admin surface reveals too much to leave open.

--- a/web/components/manual/AgentAccess.tsx
+++ b/web/components/manual/AgentAccess.tsx
@@ -31,8 +31,8 @@ export default function AgentAccess() {
             rel="noreferrer"
           >
             Model Context Protocol
-          </a>{' '}
-          — the standard way an AI agent like Claude reaches an external tool. It is the
+          </a>,{' '}
+          the standard way an AI agent like Claude reaches an external tool. It is the
           agent-facing twin of the listener request panel: where a human types into the
           browser, an agent calls a tool, and the same controller does the work.
         </p>

--- a/web/components/manual/Clients.tsx
+++ b/web/components/manual/Clients.tsx
@@ -105,8 +105,8 @@ export default function Clients() {
           and <strong>VLC</strong> on Google Play.
         </p>
         <p>
-          Whichever device you are on, point VLC at its <em>network stream</em> option
-          &mdash; not <em>open file</em> &mdash; and give it the URL above:
+          Whichever device you are on, point VLC at its <em>network stream</em> option,
+          not <em>open file</em>, and give it the URL above:
         </p>
         <table className="bs-doc-table">
           <thead>

--- a/web/components/manual/Faq.tsx
+++ b/web/components/manual/Faq.tsx
@@ -19,7 +19,7 @@ export default function Faq() {
           listener count hits zero the DJ stops doing AI work: no track-picking, no spoken
           links, no station IDs. The music keeps flowing from a fallback playlist so the
           stream never goes silent, and the DJ wakes straight back up the instant someone
-          tunes in. It exists to save tokens — and money, on a paid model — when there is
+          tunes in. It exists to save tokens, and money on a paid model, when there is
           no one there to hear the DJ anyway. See{' '}
           <Link href="/manual/llm" className="bs-link">Models &amp; Tokens</Link>.
         </p>

--- a/web/components/manual/GettingStarted.tsx
+++ b/web/components/manual/GettingStarted.tsx
@@ -14,13 +14,13 @@ export default function GettingStarted() {
         <h2>Open the player and you're on the air.</h2>
         <p>
           The station lives at the home page, and always at{' '}
-          <Link href="/listen" className="bs-link">/listen</Link>. Open it and press play —
-          the stream connects and you hear the broadcast already in progress. There's
+          <Link href="/listen" className="bs-link">/listen</Link>. Open it and press play.
+          The stream connects and you hear the broadcast already in progress. There's
           nothing to pick first; the DJ is already mid-show.
         </p>
         <p>
           Because it's a live stream, pressing pause and playing again doesn't resume
-          where you left off — it drops you back into the broadcast as it is now, the same
+          where you left off. It drops you back into the broadcast as it is now, the same
           as everyone else listening.
         </p>
       </section>

--- a/web/components/manual/HowTheDjWorks.tsx
+++ b/web/components/manual/HowTheDjWorks.tsx
@@ -51,7 +51,7 @@ export default function HowTheDjWorks() {
             <strong>Piper</strong> — a local engine, and the default. It's compact, runs
             on practically any hardware, and renders speech faster than real time. The
             voice is clear but a little synthetic. Piper is also the station's safety
-            net — see below.
+            net; see below.
           </li>
           <li>
             <strong>Kokoro</strong> — a local neural model that sounds markedly more
@@ -64,7 +64,7 @@ export default function HowTheDjWorks() {
             <strong>Chatterbox</strong> — a local model that clones a voice from a short
             reference clip, so each persona can have its own distinct sound, and voices
             paralinguistic cues like <em>[laugh]</em> and <em>[sigh]</em> as real sounds.
-            The most capable local engine and the heaviest — comfortable on a GPU, slow
+            The most capable local engine, and the heaviest: comfortable on a GPU, slow
             on CPU. Lives in the optional <code className="bs-code-inline">tts-heavy</code>{' '}
             sidecar.
           </li>

--- a/web/components/manual/ModelsAndTokens.tsx
+++ b/web/components/manual/ModelsAndTokens.tsx
@@ -32,7 +32,7 @@ export default function ModelsAndTokens() {
         <h2>For small models &amp; saving tokens.</h2>
         <p>
           If you're on a modest local model, or paying per token and want the bill low,
-          these are the dials to turn down. None of them take the DJ off the air — they
+          these are the dials to turn down. None of them take the DJ off the air. They
           just make it do less work per moment.
         </p>
         <p>
@@ -61,7 +61,7 @@ export default function ModelsAndTokens() {
             <strong>Pause when empty on</strong> (Admin &rarr; LLM) — when nobody is
             listening, the DJ stops picking, talking and writing IDs entirely; the stream
             coasts on the fallback playlist and the DJ wakes up the moment someone tunes
-            in. This one is a pure saving — there's no quality cost, since there's no one
+            in. This one is a pure saving: there's no quality cost, since there's no one
             there to hear it.
           </li>
           <li>

--- a/web/components/manual/OperatorCli.tsx
+++ b/web/components/manual/OperatorCli.tsx
@@ -15,7 +15,7 @@ export default function OperatorCli() {
         <h2>One command opens the console.</h2>
         <p>
           From a SUB/WAVE checkout, run <code className="bs-code-inline">npm start</code>. The
-          console is a menu — arrow keys to move, Enter to choose, Esc to step back, Ctrl-C to
+          console is a menu: arrow keys to move, Enter to choose, Esc to step back, Ctrl-C to
           quit.
         </p>
         <CodeBlock>{`npm start`}</CodeBlock>
@@ -31,7 +31,7 @@ export default function OperatorCli() {
         <p className="bs-eyebrow">WHAT THE MENU OFFERS</p>
         <h2>Everything you need to run the station.</h2>
         <p>
-          The menu adapts to what&rsquo;s running — when the stack is down you only see{' '}
+          The menu adapts to what&rsquo;s running. When the stack is down you only see{' '}
           <strong>start</strong>; when it&rsquo;s up, the running-stack actions take its
           place.
         </p>
@@ -78,7 +78,7 @@ export default function OperatorCli() {
         <h2>Status for a glance, doctor for a deploy.</h2>
         <p>
           <strong>status</strong> is the two-second &ldquo;is it on the air?&rdquo; check.{' '}
-          <strong>doctor</strong> is the deeper sweep — run it after a deploy, or when
+          <strong>doctor</strong> is the deeper sweep. Run it after a deploy, or when
           something looks off. It&rsquo;s the console&rsquo;s equivalent of{' '}
           <code className="bs-code-inline">scripts/health-check.sh</code>, and it ends with an
           ok / warn / fail tally plus a hint at the first thing that&rsquo;s unhappy.

--- a/web/components/manual/Overview.tsx
+++ b/web/components/manual/Overview.tsx
@@ -90,7 +90,7 @@ export default function Overview() {
           second you look away. SUB/WAVE goes the other way. There is one Icecast stream,
           and everyone hears whatever is on the air <em>right now</em>. There is no
           &ldquo;for you,&rdquo; and there is no skip button. You can ask for a song, but
-          it joins the broadcast for every listener — it doesn't jump the current track.
+          it joins the broadcast for every listener. It doesn't jump the current track.
         </p>
         <p>
           Want to run your own station instead of just listening?{' '}

--- a/web/components/manual/Requests.tsx
+++ b/web/components/manual/Requests.tsx
@@ -30,7 +30,7 @@ export default function Requests() {
           Your request is accepted instantly, and the panel then waits for the outcome.
           Behind the desk, the AI DJ interprets what you asked for and searches the
           station's music library for the best match. If it finds one, it usually records
-          a short spoken intro — acknowledging your request by name — and queues the track
+          a short spoken intro, acknowledging your request by name, and queues the track
           to play when the current song finishes.
         </p>
         <p>
@@ -44,7 +44,7 @@ export default function Requests() {
         <p className="bs-eyebrow">IT'S STILL A BROADCAST</p>
         <h2>Your request plays for everyone.</h2>
         <p>
-          A request doesn't cut in front of the song that's already playing — there's no
+          A request doesn't cut in front of the song that's already playing. There's no
           skip. It joins the broadcast as the next natural transition, and when it airs,
           <em> every</em> listener hears it, not just you. That's the point: it's one
           shared station, and you just put something on it.

--- a/web/components/manual/Shortcuts.tsx
+++ b/web/components/manual/Shortcuts.tsx
@@ -93,7 +93,7 @@ export default function Shortcuts() {
           <div className="bs-eyebrow">REMEMBER</div>
           <p>
             There is no skip. <kbd className="bs-kbd">Space</kbd> tunes you in and out of
-            the broadcast — it doesn't jump the track. See{' '}
+            the broadcast. It doesn't jump the track. See{' '}
             <Link href="/manual/getting-started" className="bs-link">Getting Started</Link>{' '}
             for why the station works that way.
           </p>

--- a/web/components/manual/Themes.tsx
+++ b/web/components/manual/Themes.tsx
@@ -34,7 +34,7 @@ export default function Themes() {
           <strong>Theme</strong>. Each entry is a card with a four-swatch row (paper, ink,
           accent, overlay) so you can read the palette without leaving Settings. Click a
           card and the change applies immediately for you, then propagates to every open
-          player within about thirty seconds — no controller restart, no listener reload.
+          player within about thirty seconds: no controller restart, no listener reload.
         </p>
         <p>
           Five palettes ship with the box:
@@ -95,8 +95,8 @@ export default function Themes() {
         <p className="bs-eyebrow">THE TOKEN MAP</p>
         <h2>Seven knobs, no surprises.</h2>
         <p>
-          A theme writes a fixed set of CSS variables onto <code className="bs-code-inline">&lt;html&gt;</code>{' '}
-          — any other key in your JSON is silently dropped, so a malformed theme can't
+          A theme writes a fixed set of CSS variables onto <code className="bs-code-inline">&lt;html&gt;</code>.
+          Any other key in your JSON is silently dropped, so a malformed theme can't
           inject styles or break out into other parts of the page.
         </p>
         <ul className="bs-list">
@@ -132,7 +132,7 @@ export default function Themes() {
         </p>
         <p>
           The "active id" is the per-show override if one is set and resolves, otherwise
-          the station default. Built-in ids are reserved — a user JSON that claims{' '}
+          the station default. Built-in ids are reserved. A user JSON that claims{' '}
           <code className="bs-code-inline">classic-light</code> is logged and skipped.
         </p>
       </section>

--- a/web/components/setup/Development.tsx
+++ b/web/components/setup/Development.tsx
@@ -6,7 +6,7 @@ export default function Development() {
     <SetupPage
       eyebrow="SETUP · 04"
       title="Hacking on SUB/WAVE."
-      intro="Three compose files, three deployment shapes. Icecast and Liquidsoap live together in a single broadcast container in every shape. Dev mode runs the radio backend in Docker and the Next.js UI on the host with hot reload, so you can iterate on the web without a rebuild. The two prod variants differ only at the edge — one bundles Caddy, the other binds host ports for your own reverse proxy."
+      intro="Three compose files, three deployment shapes. Icecast and Liquidsoap live together in a single broadcast container in every shape. Dev mode runs the radio backend in Docker and the Next.js UI on the host with hot reload, so you can iterate on the web without a rebuild. The two prod variants differ only at the edge. One bundles Caddy, the other binds host ports for your own reverse proxy."
       current="/setup/development"
     >
       <section className="bs-section">

--- a/web/components/setup/ManualInstall.tsx
+++ b/web/components/setup/ManualInstall.tsx
@@ -123,7 +123,7 @@ $EDITOR .env`}</CodeBlock>
                 <code className="bs-code-inline">/stream.opus</code> same-origin
                 (those paths are baked into the image at build time). Without a
                 proxy routing them to the controller and Icecast, the page loads
-                but the player is dead — no metadata, no audio. Route table to
+                but the player is dead: no metadata, no audio. Route table to
                 replicate (mirrors <code className="bs-code-inline">docker/Caddyfile</code>):
               </p>
               <CodeBlock>{`/stream.mp3   →  host:7702           # disable proxy buffering for live audio

--- a/web/components/setup/Prerequisites.tsx
+++ b/web/components/setup/Prerequisites.tsx
@@ -29,7 +29,7 @@ export default function Prerequisites() {
             <strong>Navidrome — or any Subsonic-API server.</strong>
             <p>
               SUB/WAVE plays from your library, reachable from wherever the stack
-              runs. Note the URL, username, and password — the wizard asks for all
+              runs. Note the URL, username, and password. The wizard asks for all
               three.{' '}
               <a
                 href="https://www.navidrome.org/"
@@ -46,7 +46,7 @@ export default function Prerequisites() {
             <p>
               The DJ's words and track picks come from a language model. The
               homelab default is <strong>Ollama</strong> with a tool-capable model
-              (qwen3.5, qwen3.6, or gemma4 all work) — note the URL and model name.
+              (qwen3.5, qwen3.6, or gemma4 all work). Note the URL and model name.
               Prefer a hosted model? Anthropic, OpenAI, Google, OpenRouter, and
               DeepSeek are all supported; you pick the provider and supply its key
               in the admin Settings UI after install, not during setup.{' '}

--- a/web/components/setup/QuickStart.tsx
+++ b/web/components/setup/QuickStart.tsx
@@ -18,8 +18,8 @@ export default function QuickStart() {
           <code className="bs-code-inline">init</code> and{' '}
           <code className="bs-code-inline">start</code>. By the time the
           installer finishes, Docker is up and the controller is reporting
-          on-air — <code className="bs-code-inline">setup</code> is the only
-          step left and it covers configuration, not lifecycle.
+          on-air; <code className="bs-code-inline">setup</code> is the only
+          step left, and it covers configuration, not lifecycle.
         </p>
         <div className="bs-faststart">
           <p className="bs-eyebrow">TWO COMMANDS</p>

--- a/web/components/setup/SetupOverview.tsx
+++ b/web/components/setup/SetupOverview.tsx
@@ -39,7 +39,7 @@ export default function SetupOverview() {
           <p className="bs-eyebrow">THE FAST PATH</p>
           <p>
             Already have Docker, Navidrome, and an LLM reachable? One curl, two
-            Enters, and the station is on the air — the installer chains
+            Enters, and the station is on the air. The installer chains
             straight into <code className="bs-code-inline">init</code> and{' '}
             <code className="bs-code-inline">start</code>, then{' '}
             <code className="bs-code-inline">setup</code> finishes the configuration.

--- a/web/components/setup/Updates.tsx
+++ b/web/components/setup/Updates.tsx
@@ -7,7 +7,7 @@ export default function Updates() {
     <SetupPage
       eyebrow="SETUP · 05"
       title="Updates & help."
-      intro="Pulling a new version, rebuilding only what changed, and what to check when the stream goes quiet. Liquidsoap and the Controller COPY source at build time, so docker compose restart does not pick up code changes — you need up -d --build."
+      intro="Pulling a new version, rebuilding only what changed, and what to check when the stream goes quiet. Liquidsoap and the Controller COPY source at build time, so docker compose restart does not pick up code changes. You need up -d --build."
       current="/setup/updates"
     >
       <section className="bs-section">


### PR DESCRIPTION
## What

A light humanizer pass over the manual (`/manual/*`) and setup (`/setup/*`) doc pages — 11 manual + 5 setup components.

## Why

Ran the pages against the "signs of AI writing" checklist. They were already clean and human (no AI vocabulary, no weasel attributions, no inflated significance, no fake -ing depth, real opinions and varied rhythm). The one flaggable pattern was **em-dash density** (~20 per page).

Rather than purge the dashes — they're a deliberate broadsheet voice, and most are legitimate appositives — this thins only the **stacked or punch-pause** dashes where a comma, colon, or period reads cleaner.

## Changes

- 23 dashes converted to commas / colons / periods, e.g.:
  - *"press play — the stream connects"* → *"press play. The stream connects"*
  - *"a single sign-in — the `ADMIN_USER`"* → *"a single sign-in: the `ADMIN_USER`"*
  - VLC *"option — not open file — and"* → *"option, not open file, and"*
- Left every appositive dash that carries the voice (*"if a voice ever fails — … — the station drops to a local engine"*).
- Curly quotes / `&mdash;` entities untouched (correct web typography, not the paste tell).

Prose-only: 18 files, 32 insertions / 32 deletions. No structural or copy-meaning changes; the two edits touching tag boundaries (`</a>,` and `</code>.`) render as valid JSX.