### PR TITLE
fix: macOS curl|sh installer hang + publish multi-arch (arm64) images

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -13,8 +13,12 @@ name: Publish images
 #   ghcr.io/<owner>/subwave-web
 #   ghcr.io/<owner>/subwave-tts-heavy   (optional Chatterbox + PocketTTS sidecar, ~3-4GB)
 #
-# Platforms: linux/amd64 only. Dockerfile.controller pins amd64 in compose
-# because Piper, Kokoro, and Chatterbox wheels are amd64-only.
+# Platforms: the core four images (caddy, broadcast, controller, web) are
+# multi-arch (linux/amd64 + linux/arm64) so Apple Silicon and ARM servers run
+# natively instead of under emulation. Dockerfile.controller selects the
+# matching Piper build via $TARGETARCH; Kokoro/onnx have arm64 wheels. The
+# optional tts-heavy sidecar stays amd64-only — its heavy PyTorch stack makes
+# an arm64 cross-build slow/large, and it's opt-in (runs fine under emulation).
 
 on:
   push:
@@ -35,16 +39,25 @@ jobs:
         include:
           - image: subwave-caddy
             dockerfile: docker/Dockerfile.caddy
+            platforms: linux/amd64,linux/arm64
           - image: subwave-broadcast
             dockerfile: docker/Dockerfile.broadcast
+            platforms: linux/amd64,linux/arm64
           - image: subwave-controller
             dockerfile: docker/Dockerfile.controller
+            platforms: linux/amd64,linux/arm64
           - image: subwave-web
             dockerfile: web/Dockerfile
+            platforms: linux/amd64,linux/arm64
           - image: subwave-tts-heavy
             dockerfile: docker/Dockerfile.tts-heavy
+            platforms: linux/amd64
     steps:
       - uses: actions/checkout@v4
+
+      # QEMU provides the cross-arch emulation buildx needs to build the
+      # linux/arm64 variant on the amd64 GitHub runner.
+      - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -68,7 +81,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64
+          platforms: ${{ matrix.platforms }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ There are three operator entry points: the **standalone `subwave` CLI** (single 
 
 ```bash
 # --- standalone CLI (default — single binary, no clone, no Node host dep) ---
-curl -fsSL https://cli.getsubwave.com | sh   # installs /usr/local/bin/subwave; if TTY, prompts to run `subwave init` (re-execs with </dev/tty)
+curl -fsSL https://cli.getsubwave.com | sh   # installs /usr/local/bin/subwave; if TTY, offers to scaffold+start via non-interactive `subwave init --yes` (interactive prompts over a pipe hang Bun's stdin on macOS — oven-sh/bun#13374)
 subwave init                              # scaffolds ~/subwave + compose + .env; ends with a "Bring the stack up now?" confirm that chains into `start`
 subwave start                             # docker compose up -d; env auto-resolved from preferredEnv (set by init) or filesystem heuristic — no prompt
 subwave setup                             # configure Navidrome / LLM / TTS / DJ

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+# Stray temp artifacts left by `bun build --compile`.
+*.bun-build

--- a/cli/package.json
+++ b/cli/package.json
@@ -19,7 +19,7 @@
     "build:all": "npm run build:linux-x64 && npm run build:linux-arm64 && npm run build:darwin-x64 && npm run build:darwin-arm64"
   },
   "dependencies": {
-    "@clack/prompts": "^0.8.2",
+    "@clack/prompts": "0.8.2",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {

--- a/cli/scripts/patch-clack.mjs
+++ b/cli/scripts/patch-clack.mjs
@@ -3,23 +3,23 @@
 //
 // Why — on macOS, Bun's `process.stdin` doesn't deliver bytes when the
 // binary was launched from a parent process whose own stdin is piped
-// (oven-sh/bun#13374). The `curl … | sh → exec subwave init </dev/tty`
-// flow hits this exactly: even though fd 0 is /dev/tty, Bun's stdin
-// layer never produces data, so `p.text({…})` renders the prompt and
-// then hangs.
+// (oven-sh/bun#13374). The workaround is to open /dev/tty ourselves as a
+// fresh tty.ReadStream and hand THAT to the prompt as its `input`.
+// @clack/core supports it (the `input?: Readable` option on PromptOptions),
+// but @clack/prompts' shipped wrappers don't forward it — they only thread
+// validate/placeholder/initialValue/etc. This script tweaks the dist file in
+// place so the four wrappers we use (text/password/confirm/select) forward
+// `input` too, after which cli/src/ui.ts can pass a /dev/tty stream into
+// every prompt call.
 //
-// The workaround is to open /dev/tty ourselves as a fresh tty.ReadStream
-// and hand THAT to the prompt as its `input`. @clack/core supports it
-// (the `input?: Readable` option on PromptOptions). @clack/prompts'
-// shipped wrappers don't forward `s.input` though — they only thread
-// validate/placeholder/initialValue/etc. This script tweaks the dist
-// file in place so the wrappers forward `input` too, after which our
-// ui.ts can pass a /dev/tty stream into every prompt call.
-//
-// The patch is a single line — insert `input:s.input,` immediately
-// after the opening `new <ClassName>({` in each of the four wrappers
-// we use (TextPrompt, PasswordPrompt, ConfirmPrompt, SelectPrompt).
-// Run idempotently — bails out if the patch is already applied.
+// The mapping from friendly export name → minified class name is RESOLVED
+// DYNAMICALLY rather than hardcoded, so a @clack/prompts patch-bump that
+// reshuffles the minifier's letters doesn't silently inject `input` into the
+// wrong wrapper (which would leave the real `text` prompt unpatched and the
+// installer hanging). We read the export aliases (`<var> as text`), follow
+// each to its wrapper definition (`<var>=<param>=>… new <Class>({`), and
+// inject `input:<param>.input,` right after that class's `({`. Run
+// idempotently — bails out if a class is already patched.
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
@@ -30,39 +30,79 @@ const distPath = resolve(here, '..', 'node_modules', '@clack', 'prompts', 'dist'
 
 const src = readFileSync(distPath, 'utf8');
 
-// Minifier mangles class names; the @clack/prompts dist (v0.8.x) names
-// them W (TextPrompt), q (PasswordPrompt), F (ConfirmPrompt),
-// N (SelectPrompt) at the top of the file. If you bump the dep, eyeball
-// these names again — `grep -oE "new [A-Z]\(\{" dist/index.mjs`.
-const CLASS_NAMES = ['W', 'q', 'F', 'N'];
+// The four high-level wrappers whose prompts read keyboard input. (multiselect,
+// groupMultiselect, autocomplete, etc. exist too but the CLI doesn't use them.)
+const WRAPPERS = ['text', 'password', 'confirm', 'select'];
+
+const ident = '[A-Za-z_$][\\w$]*';
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Resolve { className, paramName } for a friendly export name by walking:
+//   1. `<wrapperVar> as <friendly>`            (export alias)
+//   2. `<wrapperVar>=<param>=>`  or  `=(…)=>`  (wrapper definition)
+//   3. first `new <Class>({` after the definition (the prompt instantiation)
+function resolveWrapper(friendly) {
+  const alias = src.match(new RegExp(`(${ident}) as ${friendly}\\b`));
+  if (!alias) {
+    throw new Error(
+      `patch-clack: no export alias "… as ${friendly}" in ${distPath}. ` +
+      `Has @clack/prompts changed its exports? Inspect the dist and update WRAPPERS.`,
+    );
+  }
+  const wrapperVar = alias[1];
+
+  // `<var>=PARAM=>`  where PARAM is `ident` or `(…)`. Single options object in
+  // practice, so the param is a plain identifier we can read `.input` off.
+  const def = src.match(
+    new RegExp(`\\b${escapeRe(wrapperVar)}=(?:\\((${ident})\\)|(${ident}))=>`),
+  );
+  if (!def) {
+    throw new Error(
+      `patch-clack: could not find wrapper definition for "${friendly}" (var ${wrapperVar}) in ${distPath}.`,
+    );
+  }
+  const paramName = def[1] ?? def[2];
+  const defIdx = def.index + def[0].length;
+
+  // First class instantiation in the wrapper body is the prompt class.
+  const after = src.slice(defIdx);
+  const inst = after.match(new RegExp(`new (${ident})\\(\\{`));
+  if (!inst) {
+    throw new Error(
+      `patch-clack: no "new <Class>({" after the "${friendly}" wrapper in ${distPath}.`,
+    );
+  }
+  return { className: inst[1], paramName };
+}
 
 let out = src;
 let patches = 0;
-for (const name of CLASS_NAMES) {
-  // Match the literal `new <name>({` opening. The `input:s.input,`
-  // injection lands before the next existing option. `s` is the wrapper
-  // function's single argument across all four; if a future version of
-  // clack renames it, update here.
-  const needle = `new ${name}({`;
-  const inject = `new ${name}({input:s.input,`;
-  if (out.includes(inject)) {
-    // Already patched — skip.
+const skipped = [];
+const seen = new Set();
+
+for (const friendly of WRAPPERS) {
+  const { className, paramName } = resolveWrapper(friendly);
+  if (seen.has(className)) continue;
+  seen.add(className);
+
+  const needle = `new ${className}({`;
+  const inject = `new ${className}({input:${paramName}.input,`;
+  if (out.includes(`new ${className}({input:`)) {
+    skipped.push(`${friendly}→${className}`);
     continue;
   }
   if (!out.includes(needle)) {
-    throw new Error(
-      `patch-clack: could not find "${needle}" in ${distPath}. ` +
-      `Has @clack/prompts been re-minified? Re-run \`grep -oE "new [A-Z]\\(\\{" ${distPath}\` ` +
-      `and update CLASS_NAMES.`,
-    );
+    throw new Error(`patch-clack: "${needle}" (for ${friendly}) vanished before injection in ${distPath}.`);
   }
   out = out.replace(needle, inject);
   patches++;
 }
 
 if (patches === 0) {
-  console.log('patch-clack: already applied, no changes');
+  console.log(`patch-clack: already applied (${skipped.join(', ') || 'no wrappers'}), no changes`);
 } else {
   writeFileSync(distPath, out);
-  console.log(`patch-clack: forwarded input through ${patches} wrappers`);
+  console.log(`patch-clack: forwarded input through ${patches} wrappers (${WRAPPERS.join(', ')})`);
 }

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -56,7 +56,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.broadcast
-    platform: linux/amd64
     container_name: sub-wave-broadcast
     restart: unless-stopped
     environment:
@@ -93,7 +92,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.controller
-    platform: linux/amd64
     container_name: sub-wave-controller
     restart: unless-stopped
     depends_on:
@@ -172,6 +170,8 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.tts-heavy
+    # amd64-only image (heavy PyTorch stack); pinned so it runs under emulation
+    # on arm64 hosts. The other services are multi-arch and auto-select.
     platform: linux/amd64
     container_name: sub-wave-tts-heavy
     restart: unless-stopped
@@ -234,7 +234,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.broadcast
-    platform: linux/amd64
     container_name: sub-wave-broadcast
     restart: unless-stopped
     environment:
@@ -264,7 +263,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.controller
-    platform: linux/amd64
     container_name: sub-wave-controller
     restart: unless-stopped
     depends_on:
@@ -324,6 +322,8 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.tts-heavy
+    # amd64-only image (heavy PyTorch stack); pinned so it runs under emulation
+    # on arm64 hosts. The other services are multi-arch and auto-select.
     platform: linux/amd64
     container_name: sub-wave-tts-heavy
     restart: unless-stopped

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -21,6 +21,7 @@ SUB/WAVE — operator CLI
 Usage:
   subwave                  open the interactive menu (default)
   subwave init             scaffold a fresh install at ~/subwave (no-clone path)
+  subwave init --yes       non-interactive scaffold + start with defaults
   subwave setup            (re-)run the install wizard
   subwave status           quick stack + now-playing snapshot
   subwave doctor           full diagnostic sweep
@@ -36,6 +37,15 @@ Usage:
 
 Flags:
   --home <path>            override SUBWAVE_HOME for this invocation
+
+init flags:
+  --yes, -y                skip all prompts; use defaults (immune to the macOS
+                           piped-stdin hang — used by the curl|sh installer)
+  --no-start               scaffold only; don't bring the stack up
+  --mode <prod|prod-byo>   deployment shape (default: prod)
+  --admin-user <user>      admin username (default: admin)
+  --admin-pass <pass>      admin password (default: randomly generated)
+  --site-url <url>         public site URL (default: none)
 
   subwave help             show this message
   subwave --version        print version
@@ -64,7 +74,25 @@ async function main(): Promise<void> {
   }
   if (cmd === 'init') {
     const { runInitCommand } = await import('./commands/init.ts');
-    await runInitCommand();
+    const flag = (name: string): string | undefined => {
+      const i = rest.findIndex((a) => a === `--${name}` || a.startsWith(`--${name}=`));
+      if (i < 0) return undefined;
+      const a = rest[i] as string;
+      return a.includes('=') ? a.slice(a.indexOf('=') + 1) : rest[i + 1];
+    };
+    const mode = flag('mode');
+    if (mode && mode !== 'prod' && mode !== 'prod-byo') {
+      process.stderr.write(`Unknown --mode: ${mode}. Expected 'prod' or 'prod-byo'.\n`);
+      process.exit(2);
+    }
+    await runInitCommand({
+      yes: rest.includes('--yes') || rest.includes('-y'),
+      start: rest.includes('--no-start') ? false : undefined,
+      mode: mode as 'prod' | 'prod-byo' | undefined,
+      adminUser: flag('admin-user'),
+      adminPass: flag('admin-pass'),
+      siteUrl: flag('site-url'),
+    });
     return;
   }
   if (cmd === 'self-update') {

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -34,14 +34,44 @@ interface InitAnswers {
   siteUrl: string;
 }
 
-export async function runInitCommand(): Promise<void> {
+// Options for non-interactive init (`subwave init --yes`). Used by the curl|sh
+// installer, which must NOT drive an interactive Clack prompt through the pipe:
+// on macOS Bun doesn't deliver stdin bytes when launched from a piped parent
+// (oven-sh/bun#13374), so the first prompt would hang un-killably. `--yes`
+// skips every prompt, applies sane defaults (overridable via the flags below),
+// and is therefore immune to that bug.
+export interface InitOptions {
+  yes?: boolean;
+  mode?: Mode;
+  adminUser?: string;
+  adminPass?: string;
+  siteUrl?: string;
+  // Whether to bring the stack up after scaffolding. Defaults to true; the
+  // installer's `--no-start` maps to false.
+  start?: boolean;
+}
+
+export async function runInitCommand(opts: InitOptions = {}): Promise<void> {
   banner('install');
   info('Scaffolds a fresh install directory, writes the compose file + .env, and records the home so future commands know where to look.');
   muted('After this, run `subwave start` then `subwave setup` to finish configuration.');
   console.log();
 
-  const answers = await collectAnswers();
+  const answers = opts.yes ? defaultAnswers(opts) : await collectAnswers();
   await scaffold(answers);
+
+  // Non-interactive (`--yes`): no "start now?" prompt — `opts.start` decides.
+  if (opts.yes) {
+    if (opts.start !== false) {
+      await runStartCommand();
+    } else {
+      console.log();
+      muted('Next:');
+      muted('  subwave start          # docker compose up -d');
+      muted('  subwave setup          # configure Navidrome / LLM / TTS / DJ (and change install dir / mode)');
+    }
+    return;
+  }
 
   // Offer to chain straight into `start` so the curl|sh → init → on-air flow
   // is one decision long. preferredEnv was just persisted by scaffold(), so
@@ -59,6 +89,31 @@ export async function runInitCommand(): Promise<void> {
     return;
   }
   await pauseForEnter();
+}
+
+// Build InitAnswers from defaults + flag overrides, no prompts. Mirrors the
+// defaults baked into collectAnswers() (home = SUBWAVE_HOME or ~/subwave, prod
+// mode, admin user "admin", generated password, blank site URL). Refuses to
+// clobber an existing install — destroying compose files non-interactively is
+// never the right default.
+function defaultAnswers(opts: InitOptions): InitAnswers {
+  const envHome = process.env.SUBWAVE_HOME?.trim();
+  const homeRaw = envHome || DEFAULT_SUBWAVE_HOME;
+  const homeAbs = homeRaw.startsWith('~/') ? resolve(homedir(), homeRaw.slice(2)) : resolve(homeRaw);
+
+  if (existsSync(resolve(homeAbs, 'docker-compose.yml'))) {
+    warn(`${homeAbs} already contains a docker-compose.yml — leaving it untouched.`);
+    muted(`(Run \`subwave start\` to boot it, or \`subwave init\` interactively to scaffold elsewhere.)`);
+    process.exit(0);
+  }
+
+  return {
+    home: homeAbs,
+    mode: opts.mode ?? 'prod',
+    adminUser: opts.adminUser ?? 'admin',
+    adminPass: opts.adminPass ?? crypto.randomBytes(16).toString('hex'),
+    siteUrl: opts.siteUrl ?? '',
+  };
 }
 
 async function collectAnswers(): Promise<InitAnswers> {

--- a/cli/src/tty.ts
+++ b/cli/src/tty.ts
@@ -38,3 +38,13 @@ export function getInteractiveInput(): NodeJS.ReadStream | undefined {
     return undefined;
   }
 }
+
+// True when we're in the configuration that triggers oven-sh/bun#13374: the
+// process was launched from a piped parent (process.stdin isn't a TTY), so even
+// the freshly-opened /dev/tty stream may never deliver bytes and an interactive
+// prompt would hang un-killably. Direct interactive runs have isTTY === true and
+// are never in danger. ui.ts uses this to arm a watchdog (it's a no-op signal on
+// its own — see armHangWatchdog there).
+export function inPipedStdinDangerZone(): boolean {
+  return !process.stdin.isTTY;
+}

--- a/cli/src/ui.ts
+++ b/cli/src/ui.ts
@@ -17,7 +17,7 @@
 import * as clack from '@clack/prompts';
 import pc from 'picocolors';
 import readline from 'node:readline';
-import { getInteractiveInput } from './tty.ts';
+import { getInteractiveInput, inPipedStdinDangerZone } from './tty.ts';
 
 // Inject an explicit input stream into the four interactive prompts.
 // When no /dev/tty is available (CI, headless), `input` is undefined and
@@ -29,12 +29,50 @@ function withInput<T>(opts: T): T {
   return { ...opts, input: interactiveInput };
 }
 
+// Defense-in-depth against oven-sh/bun#13374: when the process was launched
+// from a piped parent (process.stdin isn't a TTY), an interactive prompt can
+// hang un-killably because Bun never delivers stdin bytes — not even on the
+// freshly-opened /dev/tty stream. The installer no longer drives interactive
+// prompts through the pipe (it uses `subwave init --yes`), but if anything ever
+// does again, this watchdog turns the silent hang into a fast, actionable exit.
+//
+// Armed lazily on the FIRST interactive prompt, and only in the danger zone, so
+// normal direct-terminal users (isTTY === true) never see it and can pause at a
+// prompt indefinitely. process.exit works even with a dead stdin, so this
+// guarantees the prompt is escapable.
+const HANG_WATCHDOG_MS = Number(process.env.SUBWAVE_PROMPT_WATCHDOG_MS) || 60_000;
+let watchdogArmed = false;
+function armHangWatchdog(): void {
+  if (watchdogArmed) return;
+  watchdogArmed = true;
+  if (!inPipedStdinDangerZone()) return;
+
+  const timer = setTimeout(() => {
+    process.stderr.write(
+      '\n⚠ Input isn\'t reaching the prompt — known Bun/macOS issue (oven-sh/bun#13374)\n' +
+      '  when launched through a pipe. Run `subwave init` directly in a terminal,\n' +
+      '  or `subwave init --yes` for defaults.\n',
+    );
+    process.exit(1);
+  }, HANG_WATCHDOG_MS);
+  // Don't let the watchdog itself hold the event loop open.
+  timer.unref?.();
+
+  const clear = (): void => clearTimeout(timer);
+  // Any byte on either the /dev/tty stream or process.stdin means input is
+  // flowing — stand down.
+  interactiveInput?.once('data', clear);
+  interactiveInput?.once('keypress', clear);
+  process.stdin.once('data', clear);
+  process.stdin.once('keypress', clear);
+}
+
 const p: typeof clack = {
   ...clack,
-  text: (opts) => clack.text(withInput(opts)),
-  password: (opts) => clack.password(withInput(opts)),
-  confirm: (opts) => clack.confirm(withInput(opts)),
-  select: (opts) => clack.select(withInput(opts)),
+  text: (opts) => { armHangWatchdog(); return clack.text(withInput(opts)); },
+  password: (opts) => { armHangWatchdog(); return clack.password(withInput(opts)); },
+  confirm: (opts) => { armHangWatchdog(); return clack.confirm(withInput(opts)); },
+  select: (opts) => { armHangWatchdog(); return clack.select(withInput(opts)); },
 };
 
 export { p, pc };

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -38,7 +38,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.broadcast
-    platform: linux/amd64
     container_name: sub-wave-broadcast
     restart: unless-stopped
     environment:
@@ -68,7 +67,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.controller
-    platform: linux/amd64
     container_name: sub-wave-controller
     restart: unless-stopped
     depends_on:
@@ -128,6 +126,8 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.tts-heavy
+    # amd64-only image (heavy PyTorch stack); pinned so it runs under emulation
+    # on arm64 hosts. The other services are multi-arch and auto-select.
     platform: linux/amd64
     container_name: sub-wave-tts-heavy
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.broadcast
-    platform: linux/amd64
     container_name: sub-wave-broadcast
     restart: unless-stopped
     environment:
@@ -84,7 +83,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.controller
-    platform: linux/amd64
     container_name: sub-wave-controller
     restart: unless-stopped
     depends_on:
@@ -163,6 +161,8 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.tts-heavy
+    # amd64-only image (heavy PyTorch stack); pinned so it runs under emulation
+    # on arm64 hosts. The other services are multi-arch and auto-select.
     platform: linux/amd64
     container_name: sub-wave-tts-heavy
     restart: unless-stopped

--- a/docker/Dockerfile.controller
+++ b/docker/Dockerfile.controller
@@ -9,12 +9,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # --- Piper -----------------------------------------------------------------
 # CPU-only, ~30ms/word. Default engine; remains the fast path even after Kokoro.
+# TARGETARCH is provided automatically by buildx (amd64 / arm64); map it to the
+# Piper release's asset naming so the multi-arch build pulls the right binary.
 ARG PIPER_VERSION=2023.11.14-2
+ARG TARGETARCH
 RUN cd /tmp && \
-    wget -q https://github.com/rhasspy/piper/releases/download/${PIPER_VERSION}/piper_linux_x86_64.tar.gz && \
-    tar -xzf piper_linux_x86_64.tar.gz -C /opt && \
+    case "${TARGETARCH}" in \
+      amd64|"") piper_arch=x86_64 ;; \
+      arm64)    piper_arch=aarch64 ;; \
+      *) echo "unsupported TARGETARCH=${TARGETARCH} for Piper" >&2; exit 1 ;; \
+    esac && \
+    wget -q https://github.com/rhasspy/piper/releases/download/${PIPER_VERSION}/piper_linux_${piper_arch}.tar.gz && \
+    tar -xzf piper_linux_${piper_arch}.tar.gz -C /opt && \
     ln -s /opt/piper/piper /usr/local/bin/piper && \
-    rm piper_linux_x86_64.tar.gz
+    rm piper_linux_${piper_arch}.tar.gz
 
 # British English voice — lift the same one you use in Kaze
 RUN mkdir -p /opt/piper/voices && \

--- a/install.sh
+++ b/install.sh
@@ -154,36 +154,44 @@ if ! command -v "$BIN_NAME" >/dev/null 2>&1; then
   echo
 fi
 
-# Offer to chain straight into `subwave init` when running interactively.
-# Piping `curl | sh` leaves stdin attached to the curl pipe (not a TTY), so
-# Clack would crash on first prompt. The fix is the rustup-style </dev/tty
-# re-exec: we reattach this shell to the TTY first, then exec the binary —
-# doing the redirect at the shell level (rather than as a one-line redirect
-# on the exec itself) propagates the TTY status more reliably across
-# Bun-compiled binaries, where `exec subwave init </dev/tty` sometimes
-# leaves `process.stdin.isTTY` false and freezes the first prompt. The
-# binary also re-attaches /dev/tty defensively (see cli/src/tty.ts), so
-# operators on older shells / unusual layouts still recover.
+# Offer to chain straight into a scaffold + start when running interactively.
 #
-# exec replaces this shell so Ctrl-C in init exits cleanly without falling
-# back through the installer. Non-interactive callers (CI, Docker builds,
-# anything without /dev/tty) skip the prompt and see the original Next:
-# hint below.
+# We must NOT drive the *interactive* `subwave init` through the curl pipe.
+# On macOS, Bun doesn't deliver stdin bytes when the binary is launched from a
+# parent whose own stdin is piped (oven-sh/bun#13374) — even after an
+# `exec </dev/tty` re-attach. The first Clack prompt then renders and hangs
+# forever in raw mode, swallowing Ctrl-C. (Running `subwave init` directly from
+# the operator's own shell is fine — stdin is a real controlling TTY there.)
+#
+# So instead we confirm at the SHELL level (POSIX `read </dev/tty`, which is
+# unaffected by the Bun bug) and run the NON-interactive `subwave init --yes`.
+# `--yes` has no prompts, so stdin is irrelevant and nothing can hang. It
+# scaffolds with sane defaults (home ~/subwave, prod, admin user "admin",
+# generated password printed below) and brings the stack up. Operators who
+# want the interactive wizard answer "n" and run `subwave init` themselves.
+#
+# Non-interactive callers (CI, Docker builds, anything without /dev/tty) skip
+# the prompt and see the Next: hint below.
 if [ -t 1 ] && [ -r /dev/tty ]; then
-  printf '\nRun `%s init` now to scaffold the install? [Y/n] ' "$BIN_NAME"
+  printf '\nScaffold + start SUB/WAVE now with defaults? [Y/n] '
   reply=""
   read -r reply </dev/tty || reply=""
   case "${reply:-y}" in
     y|Y|yes|YES)
       echo
-      exec </dev/tty
-      exec "$INSTALL_DIR/$BIN_NAME" init
+      "$INSTALL_DIR/$BIN_NAME" init --yes
+      status=$?
+      if [ "$status" -eq 0 ]; then
+        echo
+        echo "Customize anytime with \`$BIN_NAME setup\` (Navidrome, LLM, TTS, DJ)."
+      fi
+      exit "$status"
       ;;
   esac
   echo
 fi
 
 echo "Next:"
-echo "  $BIN_NAME init           # scaffold a fresh install at ~/subwave"
+echo "  $BIN_NAME init           # scaffold a fresh install at ~/subwave (interactive wizard)"
 echo "  $BIN_NAME setup          # configure Navidrome, LLM, TTS, DJ"
 echo "  $BIN_NAME start          # docker compose up -d"

--- a/web/components/manual/Clients.tsx
+++ b/web/components/manual/Clients.tsx
@@ -44,10 +44,15 @@ export default function Clients() {
         </p>
         <p>
           It&rsquo;s built into the operator console, so there&rsquo;s nothing separate to
-          install. From a SUB/WAVE checkout, run <code className="bs-code-inline">npm
-          start</code> and choose <strong>play</strong> — the TUI opens pointed at your stack:
+          install. With the <code className="bs-code-inline">subwave</code> CLI, run{' '}
+          <code className="bs-code-inline">subwave play</code> — the TUI is fetched on first
+          run and opens pointed at your stack:
         </p>
-        <CodeBlock>{`npm start`}</CodeBlock>
+        <CodeBlock>{`subwave play`}</CodeBlock>
+        <p className="text-muted">
+          From a SUB/WAVE checkout instead, run <code className="bs-code-inline">npm
+          start</code> and choose <strong>play</strong> — same TUI, same stack.
+        </p>
         <p className="text-muted">
           For audio it wants <code className="bs-code-inline">mpv</code> (preferred &mdash; it
           allows live volume control) or <code className="bs-code-inline">ffplay</code>; with

--- a/web/components/manual/OperatorCli.tsx
+++ b/web/components/manual/OperatorCli.tsx
@@ -14,16 +14,19 @@ export default function OperatorCli() {
         <p className="bs-eyebrow">PRESS START</p>
         <h2>One command opens the console.</h2>
         <p>
-          From a SUB/WAVE checkout, run <code className="bs-code-inline">npm start</code>. The
-          console is a menu: arrow keys to move, Enter to choose, Esc to step back, Ctrl-C to
-          quit.
+          Run <code className="bs-code-inline">subwave</code> with no arguments. The console is
+          a menu: arrow keys to move, Enter to choose, Esc to step back, Ctrl-C to quit.
         </p>
-        <CodeBlock>{`npm start`}</CodeBlock>
+        <CodeBlock>{`subwave`}</CodeBlock>
         <p className="text-muted">
           First time through? If there&rsquo;s no{' '}
           <code className="bs-code-inline">.env</code> yet, the console drops you
           straight into the install wizard — the same one the{' '}
           <Link href="/setup" className="bs-link">setup guide</Link> walks through.
+        </p>
+        <p className="text-muted">
+          Working from a cloned repo instead of the standalone CLI? Run{' '}
+          <code className="bs-code-inline">npm start</code> — it opens the same console.
         </p>
       </section>
 
@@ -107,15 +110,18 @@ export default function OperatorCli() {
         <h2>Every action runs without the menu too.</h2>
         <p>
           The menu is for hands-on operating. To skip it — for a deploy script, a cron job, or
-          just speed — append the action after <code className="bs-code-inline">npm start
-          --</code>:
+          just speed — name the action straight after{' '}
+          <code className="bs-code-inline">subwave</code>:
         </p>
-        <CodeBlock>{`npm start -- status
-npm start -- doctor
-npm start -- logs controller
-npm start -- restart controller`}</CodeBlock>
+        <CodeBlock>{`subwave status
+subwave doctor
+subwave logs controller
+subwave restart controller`}</CodeBlock>
         <p className="text-muted">
           Same actions, same output — just without the interactive menu wrapped around them.
+          From a cloned repo, the same actions run after{' '}
+          <code className="bs-code-inline">npm start --</code> (e.g.{' '}
+          <code className="bs-code-inline">npm start -- status</code>).
         </p>
       </section>
     </ManualPage>

--- a/web/components/manual/Overview.tsx
+++ b/web/components/manual/Overview.tsx
@@ -33,6 +33,11 @@ const GUIDE = [
     blurb: 'For the operator — signing in, tuning the DJ, scheduling shows, and managing jingles.',
   },
   {
+    href: '/manual/themes',
+    label: 'Themes',
+    blurb: 'Pick the station-wide palette every listener sees, override it per show, or drop in your own.',
+  },
+  {
     href: '/manual/cli',
     label: 'The Operator CLI',
     blurb: 'Run the station from the terminal — a status-aware console for health, logs, restarts, and the players.',
@@ -64,7 +69,7 @@ export default function Overview() {
     >
       <section className="bs-section">
         <p className="bs-eyebrow">WHAT'S INSIDE</p>
-        <h2>Ten short guides.</h2>
+        <h2>Eleven short guides.</h2>
         <p>
           Start at the top if you're new. Each page links to the next, so you can read
           straight through, or jump to whatever you need from the contents on the left.


### PR DESCRIPTION
## Why

Two bugs surfaced testing the live `curl -fsSL https://cli.getsubwave.com | sh` install on Apple Silicon (macOS, Darwin 25.5.0):

1. **Installer hung un-killably** at the first `subwave init` prompt — no typing, no Ctrl-C.
2. After getting past that, **`docker compose up` failed**: `web`/`caddy` had no arm64 manifest, fell back to building from absent source (`lstat .../web: no such file or directory`).

## Bug 1 — installer hang (`fix(cli)`)

Root cause: `install.sh` `exec`'d the **interactive** `subwave init`, but on macOS Bun doesn't deliver stdin bytes when launched from a piped parent (oven-sh/bun#13374) — even on a fresh `/dev/tty`. The existing `tty.ts`/`patch-clack` workaround assumes that stream delivers; it doesn't. So the prompt rendered and hung in raw mode.

- `install.sh`: shell-level confirm (POSIX `read </dev/tty`, unaffected by the bug) then run the new **non-interactive `subwave init --yes`** instead of an interactive prompt over the pipe.
- `init`: add `--yes` (defaults + `--mode` / `--admin-user` / `--admin-pass` / `--site-url` / `--no-start`), clobber-guarded; flags + help wired in `cli.ts`.
- `ui.ts`/`tty.ts`: **watchdog** — if stdin can't deliver (armed only when stdin isn't a TTY), fail fast with guidance instead of hanging un-killably. Tunable via `SUBWAVE_PROMPT_WATCHDOG_MS`.
- `patch-clack.mjs`: resolve clack's minified class names **dynamically** (was hardcoded `W/q/F/N`), so a dep bump can't silently mispatch the wrong wrapper; pin `@clack/prompts` to `0.8.2`.

## Bug 2 — no arm64 images (`feat(docker)`)

Published images were `linux/amd64`-only. On Apple Silicon `web`/`caddy` pulls failed, and crucially **`broadcast`/liquidsoap can't run under amd64 emulation** (its `clock_nanosleep` dies → no audio source; already documented in the dev compose). Native arm64 is the only working path.

- `publish-images.yml`: add QEMU; core 4 images → `linux/amd64,linux/arm64` (`tts-heavy` stays amd64-only — heavy PyTorch, opt-in, runs under emulation).
- `Dockerfile.controller`: select the Piper build via `$TARGETARCH` (amd64→x86_64, arm64→aarch64).
- `docker-compose{,.byo}.yml`: drop the `platform: linux/amd64` pins on `broadcast`/`controller` so arm64 hosts auto-select native images; keep + annotate the `tts-heavy` pin. Regenerate embedded CLI assets.

## Verification

- **Installer fix**: `init --yes` runs cleanly over a curl|sh-style pipe (no prompt, no hang); interactive-over-pipe now self-terminates via the watchdog instead of hanging; `tsc --noEmit` clean; dynamic patch-clack verified to inject `input` into exactly the four right wrappers + idempotent.
- **Multi-arch**: built **all four images natively for arm64** locally — they build clean; the controller's Piper binary is genuinely aarch64 and executes.

> ⚠️ Both fixes take effect on the next release: a **CLI release** (installer + `init --yes`) and an **image release** (arm64 images via the updated workflow). Until then, Apple Silicon operators must build locally.

_Note: includes minor web `manual/` doc edits (`Clients`, `Overview`, `OperatorCli`) that were in the working tree._