### PR TITLE
feat(skills): operator-pluggable custom skills via state/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ It's *radio*, not a playlist. No per-listener shuffle, no skip button, no
 - **Dual-codec broadcast.** MP3 192 kbps for Sonos, hardware radios, and cars; Ogg-Opus 96 kbps for modern browsers. The web player picks automatically.
 - **PWA + terminal player.** Installable on phone and desktop with lock-screen controls, plus a TUI for the command line.
 - **Scheduled shows.** A 24×7 grid; each slot has its own persona, mood, and skills.
+- **Pluggable skills.** The DJ's between-track segments — weather, news, traffic, and your own — are skills. Drop a `SKILL.md` (plus optional data-fetching code) into `state/skills/`, hit Rescan in the admin console, and enable it. See [`docs/custom-skills.md`](docs/custom-skills.md).
 - **Mood-aware rotation.** Time of day, weather, and festival days bias what gets played and how the DJ talks.
 - **Hourly archives.** Every hour saved as MP3 for later replay.
 - **Crossfade + voice ducking.** Tracks blend smoothly; the music ducks under DJ speech and lifts back up.

--- a/controller/src/llm/segment-tools.ts
+++ b/controller/src/llm/segment-tools.ts
@@ -184,5 +184,33 @@ export function buildSegmentTools(ctx: any, state: any, caps: any[]) {
     });
   }
 
+  // Operator-dropped custom skills (state/skills) that ship a tool.mjs get
+  // their data fetcher wrapped as a tool here. The fetcher runs operator-
+  // supplied code, so it is fenced behind a hard timeout + try/catch — a slow
+  // or throwing skill degrades to "no data" rather than hanging the tick.
+  for (const cap of caps as any[]) {
+    if (!cap.custom || typeof cap.toolFn !== 'function') continue;
+    tools[cap.toolName] = tool({
+      description: cap.toolDesc,
+      inputSchema: z.object({}),
+      execute: async () => {
+        try {
+          return await withTimeout(Promise.resolve(cap.toolFn(ctx, state)), 8000);
+        } catch (err: any) {
+          return { error: err?.message || String(err) };
+        }
+      },
+    });
+  }
+
   return tools;
+}
+
+// Resolve `p`, or reject after `ms` — keeps an operator skill's tool.mjs from
+// stalling the segment tick indefinitely.
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((res, rej) => {
+    const t = setTimeout(() => rej(new Error(`tool timed out after ${ms}ms`)), ms);
+    p.then(v => { clearTimeout(t); res(v); }, e => { clearTimeout(t); rej(e); });
+  });
 }

--- a/controller/src/routes/dj.ts
+++ b/controller/src/routes/dj.ts
@@ -11,6 +11,7 @@ import * as subsonic from '../music/subsonic.js';
 import * as settings from '../settings.js';
 import { runStationId, runHourlyCheck, runLink, refreshAutoPlaylist } from '../broadcast/scheduler.js';
 import { skillCatalog, runCapability } from '../skills/_agent.js';
+import { loadCustomSkills } from '../skills/loader.js';
 import { skipTrack } from '../broadcast/liquidsoap-control.js';
 import { getFullContext } from '../context.js';
 
@@ -26,6 +27,22 @@ const SAY_KINDS = ['dj-speak', 'link'];
 // ---------------------------------------------------------------------------
 router.get('/dj/skills', requireAdmin, (req, res) => {
   res.json({ skills: skillCatalog() });
+});
+
+// ---------------------------------------------------------------------------
+// POST /dj/skills/rescan — reload operator-dropped custom skills from
+// state/skills (picks up new folders and edited SKILL.md / tool.mjs files
+// without a controller restart). Returns the refreshed catalogue.
+// ---------------------------------------------------------------------------
+router.post('/dj/skills/rescan', requireAdmin, async (req, res) => {
+  try {
+    const caps = await loadCustomSkills();
+    queue.log('scheduler', `[skills] rescanned — ${caps.length} custom skill(s) loaded`);
+    res.json({ skills: skillCatalog(), custom: caps.length });
+  } catch (err) {
+    queue.log('error', `/dj/skills/rescan failed: ${err.message}`);
+    res.status(500).json({ error: err.message });
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -113,6 +113,16 @@ app.listen(config.server.port, async () => {
     console.error('[settings] load failed:', err.message);
   }
 
+  // Load operator-dropped custom skills from state/skills — merged into the
+  // segment director's capability set (see skills/loader.js). Never fatal.
+  try {
+    const { loadCustomSkills } = await import('./skills/loader.js');
+    const caps = await loadCustomSkills();
+    if (caps.length) console.log(`[skills] ${caps.length} custom skill(s): ${caps.map((c: any) => c.kind).join(', ')}`);
+  } catch (err: any) {
+    console.error('[skills] custom load failed:', err.message);
+  }
+
   // First-run banner — operators glancing at `docker compose logs` should
   // immediately see where to finish setup.
   try {

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -37,6 +37,7 @@ import { defineAgent } from '../llm/agent.js';
 import { buildContextLines } from '../llm/dj.js';
 import { buildSegmentTools } from '../llm/segment-tools.js';
 import { searchReady } from './web-search.js';
+import { customCapabilities } from './loader.js';
 import * as sfx from '../broadcast/sfx.js';
 
 // Capability table — the single source of truth for the DJ's between-track
@@ -96,10 +97,23 @@ const CAPABILITIES: any[] = [
   },
 ];
 
+// The full capability set the segment director operates over: the built-in
+// CAPABILITIES above plus operator-dropped custom skills loaded from
+// state/skills (see skills/loader.js). Everything downstream — the autonomous
+// tick, runCapability, skillCatalog, the admin toggles — iterates THIS, so a
+// dropped skill lights up the whole chain. Custom caps carry { custom: true }
+// and are gated more conservatively (disabled until the operator enables them).
+function allCapabilities(): any[] {
+  return [...CAPABILITIES, ...customCapabilities()];
+}
+
 const SEGMENT_SCHEMA = z.object({
   segment: z.object({
-    kind: z.enum(['weather', 'news', 'traffic', 'curiosity', 'album-anniversary', 'library-deep-cut', 'web-search'])
-      .describe('the segment kind — MUST be one offered in the system prompt for this tick'),
+    // Kept as a free string (not a fixed enum) so operator-dropped custom
+    // skills get valid kinds too. The agent is told which kinds are on offer in
+    // the system prompt, and agenticTick drops any kind it wasn't offered.
+    kind: z.string()
+      .describe('the segment kind — MUST be one of the kinds offered in the system prompt for this tick'),
     text: z.string().describe('the spoken line in the DJ voice — typically one short sentence, never more than three'),
     sfx: z.string().nullable().describe('the exact name of one sound effect from the catalogue in the system prompt to play under this line, or null for no effect (null is usually right — most segments need none)'),
   }).nullable().describe('the segment to air, or null to stay silent — silence is a perfectly good answer, often the best one, when the data is dull, stale, unchanged, or there is nothing fresh worth a listener\'s attention'),
@@ -152,11 +166,17 @@ function availableCapabilities(ctx: any, now: Date) {
   const enabled = s.skills?.enabled || {};
   const persona = settings.getEffectivePersona(now);
   const out: any[] = [];
-  for (const cap of CAPABILITIES) {
-    if (enabled[cap.skill] === false) continue;
+  for (const cap of allCapabilities()) {
+    // Built-ins are enabled unless explicitly turned off; custom skills are
+    // DISCOVERED-BUT-DISABLED — they must be explicitly enabled before they
+    // can air, so dropping a folder never auto-airs unreviewed content/code.
+    const isEnabled = cap.custom ? enabled[cap.skill] === true : enabled[cap.skill] !== false;
+    if (!isEnabled) continue;
     if (persona?.skills && !persona.skills.includes(cap.skill)) continue;
     if (now.getTime() - (lastFired.get(cap.kind) || 0) < cap.cooldownMs) continue;
-    if (cap.kind === 'traffic' && !ctx.clock?.isCommute) continue;
+    // Window gating: built-in traffic is commute-only; custom skills opt in via
+    // `window: commute` in their SKILL.md frontmatter.
+    if ((cap.kind === 'traffic' || cap.window === 'commute') && !ctx.clock?.isCommute) continue;
     if (cap.ready && !cap.ready()) continue;
     out.push(cap);
   }
@@ -355,7 +375,7 @@ export const forcedDirectorAgent = defineAgent({
 // /dj/skill. `which` is a kind or skill slug (kept identical). Returns the
 // spoken text; throws on an unknown/unready capability or empty output.
 export async function runCapability(which, ctx) {
-  const cap = CAPABILITIES.find(c => c.kind === which || c.skill === which);
+  const cap = allCapabilities().find(c => c.kind === which || c.skill === which);
   if (!cap) throw new Error(`unknown skill: ${which}`);
   if (cap.ready && !cap.ready()) {
     // Hint at the missing key when the capability is keyed. web-search is the
@@ -409,7 +429,7 @@ export function skillCatalog() {
   const s = settings.get();
   const enabledMap = s.skills?.enabled || {};
   const searchProvider = s.search?.provider || 'duckduckgo';
-  return CAPABILITIES.map(c => {
+  return allCapabilities().map(c => {
     // web-search's key requirement depends on the active search provider:
     // Tavily needs SEARCH_API_KEY, DuckDuckGo needs nothing. Other capabilities
     // carry their requiresKey/keyUrl statically in CAPABILITIES (none today).
@@ -430,7 +450,12 @@ export function skillCatalog() {
       description: c.desc || '',
       kind: c.kind,
       cooldownMs: c.cooldownMs || 0,
-      enabled: enabledMap[c.skill] !== false,
+      // Built-ins default on; custom skills are discovered-but-disabled and
+      // only count as enabled once the operator explicitly flips them on.
+      enabled: c.custom ? enabledMap[c.skill] === true : enabledMap[c.skill] !== false,
+      // Marks an operator-dropped skill (state/skills) vs a built-in, so the
+      // admin UI can badge it and explain the off-by-default behaviour.
+      custom: !!c.custom,
       // `ready` is false when the capability needs an env key that isn't set;
       // `requiresKey` names it and `keyUrl` links the operator to its source.
       ready: typeof c.ready === 'function' ? !!c.ready() : true,

--- a/controller/src/skills/loader.ts
+++ b/controller/src/skills/loader.ts
@@ -1,0 +1,217 @@
+// Operator-pluggable skills — load custom between-track segment capabilities
+// from `${STATE_DIR}/skills/<slug>/SKILL.md` at boot (and on demand via the
+// admin "rescan" button), and merge them into the segment director's
+// CAPABILITIES table (see skills/_agent.js).
+//
+// This adopts the *format* of Anthropic's skills (a SKILL.md with YAML
+// frontmatter + a markdown body, plus optional code) — NOT their semantics.
+// A SUB/WAVE skill is one thing: a between-track spoken segment. The
+// frontmatter supplies the capability metadata; the markdown body IS the
+// agent's brief for that segment; an optional `tool.mjs` is wrapped as an AI
+// SDK tool so the segment can look at live data before the DJ speaks.
+//
+//   state/skills/on-this-day-music/
+//     SKILL.md     frontmatter (→ metadata) + body (→ the agent's brief)
+//     tool.mjs     OPTIONAL: `export default async (ctx) => ({...})`
+//
+// SKILL.md frontmatter keys (all optional except a non-empty body):
+//   name             slug == kind (defaults to the folder name)
+//   label            human label for /admin/skills (defaults to a title-cased name)
+//   cooldown         hard min gap between autonomous firings — "90m" | "6h" | "45" (minutes)
+//   window           "any" (default) | "commute" — only offered during commute hours
+//   requiresKey      env var the skill needs; absent → never offered
+//   toolDescription  description shown to the agent for the tool.mjs data tool
+//
+// Safety posture (the operator is dropping code into their own controller, same
+// trust model as Claude Code skills, but we still fence it):
+//   - malformed skills are skipped with a logged warning, never crash boot
+//   - custom skills are DISCOVERED-BUT-DISABLED — they appear in /admin/skills
+//     toggled off and cannot air until the operator enables them (see
+//     skillCatalog/availableCapabilities in _agent.js); merely dropping a
+//     folder never auto-airs unreviewed content or runs its code on a tick
+//   - tool.mjs execution is wrapped in a timeout + try/catch at the call site
+//     (llm/segment-tools.js) so a slow or throwing skill can't hang the tick
+
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { STATE_DIR } from '../config.js';
+import { queue } from '../broadcast/queue.js';
+
+// Built-in capability kinds — custom skills may not shadow these.
+const RESERVED_KINDS = new Set([
+  'weather', 'news', 'traffic', 'curiosity',
+  'album-anniversary', 'library-deep-cut', 'web-search',
+  // queue.announce reserves 'link' for the light-ducked intro channel.
+  'link', 'dj-speak', 'announcement', 'station-id', 'hourly',
+]);
+
+const SKILLS_DIR = resolve(STATE_DIR, 'skills');
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,48}$/;
+
+// Loaded custom capabilities, in the same shape as _agent.js CAPABILITIES,
+// plus { custom: true } and an optional wrapped data tool. Rebuilt on reload.
+let loaded: any[] = [];
+let importCounter = 0; // cache-buster for re-importing edited tool.mjs modules
+
+export function customCapabilities(): any[] {
+  return loaded;
+}
+
+// Minimal flat-YAML frontmatter parser. The frontmatter we accept is a small,
+// flat key: value block — no nesting, lists, or multiline scalars — so a tiny
+// parser keeps the dependency surface at zero (no gray-matter). Returns
+// { data, body }; body is everything after the closing `---`.
+function parseFrontmatter(raw: string): { data: Record<string, string>; body: string } {
+  const text = raw.replace(/^﻿/, '');
+  const m = /^---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/.exec(text);
+  if (!m) return { data: {}, body: text.trim() };
+  const data: Record<string, string> = {};
+  for (const line of m[1].split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const idx = trimmed.indexOf(':');
+    if (idx === -1) continue;
+    const key = trimmed.slice(0, idx).trim();
+    let val = trimmed.slice(idx + 1).trim();
+    // Strip surrounding quotes if present.
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    if (key) data[key] = val;
+  }
+  return { data, body: m[2].trim() };
+}
+
+// "90m" | "6h" | "2d" | "45s" | "45" (bare = minutes) → ms. Defaults to 60 min.
+function parseCooldownMs(raw: string | undefined): number {
+  const def = 60 * 60 * 1000;
+  if (!raw) return def;
+  const m = /^(\d+)\s*([smhd]?)$/.exec(String(raw).trim());
+  if (!m) return def;
+  const n = Number(m[1]);
+  const unit = m[2] || 'm';
+  const mult = unit === 's' ? 1000 : unit === 'h' ? 3600_000 : unit === 'd' ? 86_400_000 : 60_000;
+  return n * mult;
+}
+
+function titleCase(slug: string): string {
+  return slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+// Dynamically import a skill's optional tool.mjs and return its data function,
+// or null. The function is invoked per tick with the moment's context; the
+// call itself is timeout-guarded at the call site (segment-tools.js).
+async function loadToolFn(dir: string): Promise<((ctx: any, state: any) => any) | null> {
+  const file = join(dir, 'tool.mjs');
+  try {
+    await stat(file);
+  } catch {
+    return null; // no tool.mjs — pure-generation skill, that's fine
+  }
+  // Cache-bust so a rescan picks up an edited module (ESM caches by URL).
+  const url = `${pathToFileURL(file).href}?v=${++importCounter}`;
+  const mod = await import(url);
+  const fn = mod.default || mod.fetchData || mod.tool;
+  if (typeof fn !== 'function') {
+    throw new Error('tool.mjs must export a default async function (ctx) => data');
+  }
+  return fn;
+}
+
+async function loadOne(slug: string): Promise<any | null> {
+  const dir = join(SKILLS_DIR, slug);
+  const skillFile = join(dir, 'SKILL.md');
+  let raw: string;
+  try {
+    raw = await readFile(skillFile, 'utf8');
+  } catch {
+    return null; // directory without a SKILL.md — not a skill
+  }
+
+  const { data, body } = parseFrontmatter(raw);
+  const name = (data.name || slug).trim();
+
+  if (!SLUG_RE.test(name)) {
+    queue.log('error', `[skills] "${slug}" rejected — name "${name}" must be a lowercase slug`);
+    return null;
+  }
+  if (RESERVED_KINDS.has(name)) {
+    queue.log('error', `[skills] "${slug}" rejected — "${name}" shadows a built-in capability`);
+    return null;
+  }
+  if (!body) {
+    queue.log('error', `[skills] "${slug}" rejected — SKILL.md body (the agent's brief) is empty`);
+    return null;
+  }
+
+  const window = data.window === 'commute' ? 'commute' : 'any';
+  const requiresKey = data.requiresKey ? String(data.requiresKey).trim() : null;
+
+  let toolFn: any = null;
+  try {
+    toolFn = await loadToolFn(dir);
+  } catch (err: any) {
+    queue.log('error', `[skills] "${slug}" tool.mjs failed to load — running prompt-only: ${err.message}`);
+    toolFn = null;
+  }
+
+  const cap: any = {
+    kind: name,
+    skill: name,
+    label: (data.label || titleCase(name)).trim(),
+    cooldownMs: parseCooldownMs(data.cooldown),
+    desc: body,
+    custom: true,
+    window,
+    requiresKey,
+    // A keyed skill is only ready when its env var is set. Keyless skills are
+    // always ready. Mirrors the built-in `ready()` convention.
+    ready: requiresKey ? () => !!process.env[requiresKey] : undefined,
+  };
+
+  if (toolFn) {
+    cap.toolName = `skill_${name.replace(/-/g, '_')}`;
+    cap.toolDesc = (data.toolDescription || '').trim()
+      || `Fetch live data for the ${cap.label} segment before speaking. Returns { available: false } when there is nothing fresh worth airing.`;
+    cap.toolFn = toolFn;
+  }
+
+  return cap;
+}
+
+// Scan state/skills and rebuild the loaded capability list. Never throws —
+// a broken skill folder is logged and skipped. Returns the loaded caps.
+export async function loadCustomSkills(): Promise<any[]> {
+  let entries: string[] = [];
+  try {
+    const dirents = await readdir(SKILLS_DIR, { withFileTypes: true });
+    entries = dirents.filter(d => d.isDirectory()).map(d => d.name);
+  } catch {
+    loaded = []; // no state/skills dir → nothing to load (the common case)
+    return loaded;
+  }
+
+  const out: any[] = [];
+  const seen = new Set<string>();
+  for (const slug of entries) {
+    try {
+      const cap = await loadOne(slug);
+      if (!cap) continue;
+      if (seen.has(cap.kind)) {
+        queue.log('error', `[skills] duplicate skill kind "${cap.kind}" — keeping the first`);
+        continue;
+      }
+      seen.add(cap.kind);
+      out.push(cap);
+    } catch (err: any) {
+      queue.log('error', `[skills] "${slug}" failed to load: ${err.message}`);
+    }
+  }
+
+  loaded = out;
+  if (out.length) {
+    queue.log('scheduler', `[skills] loaded ${out.length} custom skill(s): ${out.map(c => c.kind).join(', ')}`);
+  }
+  return loaded;
+}

--- a/docs/custom-skills.md
+++ b/docs/custom-skills.md
@@ -1,0 +1,89 @@
+# Custom skills
+
+SUB/WAVE's **skills** are the things the AI DJ does *between* tracks — a weather
+check, a headline, a tongue-in-cheek traffic gag. The built-in ones live in
+`controller/src/skills/_agent.ts`. You can add your own without touching the
+codebase by dropping a folder into `state/skills/`.
+
+This borrows the *format* of [Anthropic's skills](https://github.com/anthropics/skills)
+— a `SKILL.md` with YAML frontmatter and a markdown body, plus optional code —
+but **not** their meaning. A SUB/WAVE skill is exactly one thing: a between-track
+**spoken segment**. (You can't drop in `anthropics/skills/pdf` and have it do
+anything — those manipulate documents.)
+
+## Layout
+
+```
+state/skills/
+  moon-phase/
+    SKILL.md      # frontmatter (→ metadata) + body (→ the DJ's brief)
+    tool.mjs      # OPTIONAL: a data fetcher, wrapped as a tool the DJ can call
+```
+
+A copy-ready example lives in [`docs/examples/skills/moon-phase`](./examples/skills/moon-phase).
+Copy that folder into `state/skills/` and hit **Rescan** in the admin Skills page.
+
+## SKILL.md
+
+```yaml
+---
+name: moon-phase          # the slug / "kind" (defaults to the folder name)
+label: Moon phase         # human label in /admin/skills (defaults to title-cased name)
+cooldown: 6h              # hard min gap between autonomous firings — "90m" | "6h" | "2d" | "45" (bare = minutes)
+window: any               # "any" (default) | "commute" — only offered during commute hours
+requiresKey: SOME_API_KEY # OPTIONAL: env var the skill needs; if unset, the skill stays inert
+toolDescription: ...      # OPTIONAL: how the DJ-facing tool is described (only matters with tool.mjs)
+---
+The markdown body is the DJ's brief for this segment. Keep it tight: what to
+say, in what tone, and — importantly — when to stay silent. The agent reads
+this verbatim. One short sentence on air is the norm.
+```
+
+Only a **non-empty body** is required; every frontmatter key has a default. The
+body becomes the per-segment briefing the DJ agent follows (the same role the
+inline `desc:` strings play for built-in skills) and the description shown in the
+admin UI.
+
+The `name` must be a lowercase slug and must not shadow a built-in kind
+(`weather`, `news`, `traffic`, `curiosity`, `album-anniversary`,
+`library-deep-cut`, `web-search`, …). Bad frontmatter is logged and skipped — it
+never crashes the controller.
+
+## tool.mjs (optional)
+
+If present, the default export is wrapped as an [AI SDK](https://sdk.vercel.ai)
+tool the segment director can call **before** writing the line — the same
+mechanism the built-in weather/news skills use to look at real data.
+
+```js
+export default async function (ctx, state) {
+  // ctx   — the moment: { time, weather, festival, dominantMood, clock }
+  // state — cross-tick dedup memory (persists between firings)
+  // Return any JSON-serialisable object. The `{ available: false }` convention
+  // tells the agent there's nothing worth airing right now.
+  return { available: true, foo: 'bar' };
+}
+```
+
+The call is **timeout-guarded (8 s)** and any throw degrades cleanly to "no
+data" — a slow or broken skill can never hang the between-track tick. With no
+`tool.mjs`, the skill is pure generation (like the built-in `traffic`): the DJ
+writes from the brief alone.
+
+> **Security.** `tool.mjs` runs operator-supplied code inside the controller
+> container — the same trust model as a locally-installed Claude Code skill.
+> Only drop in code you've read and trust.
+
+## Lifecycle
+
+- **Discovered but disabled.** A freshly dropped skill shows up in
+  `/admin/skills` toggled **off**. It cannot air — autonomously or otherwise —
+  until you enable it there. Merely dropping a folder never puts unreviewed
+  content (or code) on air.
+- **Loaded at boot**, and on demand via the **Rescan state/skills** button on
+  the admin Skills page (`POST /api/dj/skills/rescan`). Rescan picks up new
+  folders and edits to `SKILL.md` / `tool.mjs` without a controller restart.
+- **Persona ownership still applies.** Like built-in skills, a custom skill only
+  fires autonomously when it's enabled *and* assigned to the persona on air
+  (Personas page). **Run now** is an operator override that bypasses the toggle,
+  the persona assignment, the frequency gate, and the cooldown.

--- a/docs/examples/skills/moon-phase/SKILL.md
+++ b/docs/examples/skills/moon-phase/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: moon-phase
+label: Moon phase
+cooldown: 6h
+window: any
+toolDescription: Get tonight's moon phase and illumination percentage. Returns { available, phase, illumination }. A full or new moon is worth a mention; an unremarkable gibbous usually is not.
+---
+If tonight's moon is at a notable phase — full, new, or a sharp crescent — work it into one short, in-character line, the way a late-night presenter might glance out the window. Skip it when the phase is unremarkable. Never recite the illumination percentage like a forecast; just colour the line with it.

--- a/docs/examples/skills/moon-phase/tool.mjs
+++ b/docs/examples/skills/moon-phase/tool.mjs
@@ -1,0 +1,36 @@
+// Example custom-skill data tool for SUB/WAVE.
+//
+// The default export is wrapped as an AI SDK tool the segment director can call
+// before deciding whether to air this skill's line. It is invoked with the
+// moment's context (`ctx` — the same shape as getFullContext(): time, weather,
+// festival, dominantMood, clock) and the cross-tick dedup `state`. Return any
+// JSON-serialisable object; a `{ available: false }` convention tells the agent
+// there is nothing worth airing. Keep it fast — the call is timeout-guarded at
+// 8s and any throw degrades cleanly to "no data".
+//
+// This one needs no API key and no network: it computes the lunar phase from
+// the current date with a simple synodic-month approximation.
+
+const SYNODIC = 29.530588853; // mean length of a lunar month, days
+const KNOWN_NEW_MOON = Date.UTC(2000, 0, 6, 18, 14); // 2000-01-06 18:14 UTC
+
+const PHASES = [
+  'new moon', 'waxing crescent', 'first quarter', 'waxing gibbous',
+  'full moon', 'waning gibbous', 'last quarter', 'waning crescent',
+];
+
+export default async function moonPhase() {
+  const daysSince = (Date.now() - KNOWN_NEW_MOON) / 86_400_000;
+  const age = ((daysSince % SYNODIC) + SYNODIC) % SYNODIC; // 0..29.53, days into the cycle
+  const fraction = age / SYNODIC;                          // 0..1 through the cycle
+  const index = Math.round(fraction * 8) % 8;
+  const phase = PHASES[index];
+  // Illumination: 0 at new, 1 at full, back to 0 — a cosine over the cycle.
+  const illumination = Math.round((1 - Math.cos(fraction * 2 * Math.PI)) / 2 * 100);
+
+  // Only the headline phases are really worth a mention; tell the agent so.
+  const notable = phase === 'full moon' || phase === 'new moon'
+    || phase === 'waxing crescent' || phase === 'waning crescent';
+
+  return { available: notable, phase, illumination };
+}

--- a/docs/superpowers/specs/2026-05-30-news-as-pluggable-skill-design.md
+++ b/docs/superpowers/specs/2026-05-30-news-as-pluggable-skill-design.md
@@ -1,0 +1,259 @@
+# News as a pluggable skill
+
+**Status:** design — not yet implemented
+**Branch:** `worktree-pluggable-skills`
+**Prerequisite:** the pluggable-skills loader (`cb5220d`) is already on this branch. This design builds on it.
+**Issue motivating the work:** [#193 — News/RSS feed changes not taking effect](https://github.com/perminder-klair/subwave/issues/193)
+
+---
+
+## Context
+
+Issue #193 reports that an operator changed the news feed URL but the on-air news segments still pulled from BBC. The reproduction is mundane — `NEWS_FEED_URL` is env-only (`controller/src/config.ts:161`), it's not in `settings.json`, not in the admin UI, and not in the onboarding wizard. The operator either edited a file the running container doesn't read (`controller/.env` instead of the root `./.env` that `docker-compose.yml:112` loads as `env_file`), or edited the right file but didn't recreate the container. Either way: the surface is wrong for the kind of change operators want to make.
+
+The obvious fix is "add a multi-feed schema to `state/settings.json` and an admin UI to manage it." That fix was drafted and rejected after looking at this branch.
+
+The pluggable-skills loader already provides every primitive a multi-feed news system would need:
+
+| What a `settings.news.feeds[]` schema would have to invent | What the loader already gives us |
+|---|---|
+| Per-feed enable toggle | Per-skill toggle in `/admin/skills` |
+| Per-feed cooldown | `cooldown:` frontmatter (parsed) |
+| Persona allowlist per feed | Persona `skills[]` already binds by slug |
+| Fallback when a feed breaks | `requiresKey` / `ready()` → unready skill is not offered; other skills tick |
+| Hot-reload after edit | `POST /dj/skills/rescan` |
+| "Discovered but off" safety | Enforced by `loadCustomSkills()` |
+| Per-skill data fetch with timeout | `tool.mjs` wrapped at 8s in `segment-tools.ts` |
+
+The bespoke schema route would re-invent every row. The one genuinely new concept we considered — *categories* — collapses into "the persona's existing skill allowlist," which already does the same job.
+
+**Direction:** news is not a special-case capability. It becomes the flagship example of the pluggable-skills primitive. The built-in `news` entry in `CAPABILITIES` goes away. Each feed is a skill. Most operators add a feed through a small UI shortcut; power users drop a folder.
+
+### Scope slices (all in)
+
+After scoping in conversation, four slices are in scope for this design — all four collapse out of the primitive:
+
+1. **Multi-feed library + admin UI** — operator manages a named list of feeds without editing `.env`.
+2. **Persona binding** — different personas read different subsets of feeds.
+3. **Robust fetcher + visibility** — Atom support, real User-Agent, persistent dedup, `<pubDate>` freshness, per-feed health surface.
+4. **Smart rotation + fallback** — broken feed doesn't silence the news kind; healthy feeds keep ticking.
+
+### Explicit non-goals
+
+- **No `settings.news.categories[]`.** The persona's existing `skills[]` allowlist *is* the categorisation mechanism. A "tech persona" lists the tech feed slugs in `skills[]`. A station-wide "tech" concept would duplicate that.
+- **No `/admin/news` route.** Everything lives in `/admin/skills`.
+- **No separate rotation algorithm.** Rotation is emergent from independent skills with independent cooldowns.
+- **No listener "what's in the news?" request channel.** Orthogonal — deferred to a follow-up that wires `/request` intents to direct-tool-call paths across any skill.
+- **No bespoke `settings.news` block.** Everything that would have lived there now lives in `state/skills/news-*/SKILL.md`.
+
+---
+
+## Design
+
+### 1. Default news skill replaces the built-in capability
+
+After this lands, the built-in `news` entry in `CAPABILITIES` (`controller/src/skills/_agent.ts`) is deleted. The `getHeadlines` tool branch in `controller/src/llm/segment-tools.ts` (lines 47–67 on `develop`) is deleted with it.
+
+The current implementation in `controller/src/skills/news.ts` — `fetchHeadlines()` and `hashHeadline()` — is **not** deleted. It moves into the templated RSS helper described in §2.
+
+A first-party news skill ships with the install:
+
+```yaml
+# state/skills/news-bbc/SKILL.md
+---
+name: news-bbc
+label: BBC News
+cooldown: 45m
+feed: http://feeds.bbci.co.uk/news/rss.xml
+feedMaxItems: 10
+feedFreshnessHours: 24
+---
+Read one fresh headline in a single sentence — half-distracted BBC 6 Music tone,
+never an anchor voice, no editorialising, no "in other news".
+```
+
+No `tool.mjs` is needed — the loader sees `feed:` in frontmatter and substitutes the RSS helper (§2). The cooldown and brief are exactly today's values, so an out-of-the-box install behaves identically.
+
+This file is scaffolded at boot if no `news-*` skill is present (see §6).
+
+### 2. Loader extension: `feed:` frontmatter triggers the RSS helper
+
+Goal: the common case (just an RSS URL) is a single-line SKILL.md change. No `tool.mjs` to write.
+
+**Loader change** (`controller/src/skills/loader.ts`):
+
+In `loadOne()`, after `parseFrontmatter()` and after the existing `loadToolFn()` call:
+
+```ts
+if (!toolFn && data.feed) {
+  toolFn = makeRssFetcher({
+    url: data.feed,
+    maxItems: parseInt(data.feedMaxItems || '10', 10),
+    freshnessHours: parseInt(data.feedFreshnessHours || '24', 10),
+    slug: name,
+  });
+}
+```
+
+Precedence: if both `tool.mjs` and `feed:` exist, `tool.mjs` wins (operator override). Three new flat frontmatter keys (`feed`, `feedMaxItems`, `feedFreshnessHours`). All flat so the existing minimal YAML parser doesn't need to grow.
+
+**The RSS helper** (`controller/src/skills/_rss-helper.ts` — new file):
+
+A factory that returns the same `(ctx, state) => result` shape a `tool.mjs` would. Responsibilities:
+
+- Accept both RSS 2.0 `<item>` and Atom `<entry>`.
+- Add Atom title (often namespaced, often with attributes) and Atom `<summary>` / `<content>` fallback to title/description.
+- Send `User-Agent: SUB/WAVE/<version> (+https://getsubwave.com)`.
+- Parse `<pubDate>` (RSS) and `<updated>` (Atom); if `freshnessHours > 0`, drop items older than that.
+- Read/write per-skill dedup state via the new state slot (§4): `state.seenHeadlines[hash] = airedMs`. LRU-cap at 200 entries.
+- On `!res.ok` or unparseable body: return `{ available: false, error: <string> }` AND record the failure into `state.health` (§5).
+- On success: return `{ available: true, headlines: [{ title, detail }, ...] }`. Same shape today's `getHeadlines` tool returns.
+
+The helper reads its config (`url`, `maxItems`, `freshnessHours`) once at factory-call time. The `tool.mjs` wrapper in `segment-tools.ts` (existing) supplies the 8s timeout — no special treatment needed.
+
+**Why not extend YAML to nested objects?** The existing parser is intentionally tiny (flat key/value, zero deps). Three new prefixed keys is a smaller blast radius than parser changes that every future skill author has to learn.
+
+### 3. The "Add news feed" UI shortcut
+
+Goal: an operator who couldn't get past `.env` editing can add a feed without ever leaving the browser.
+
+**Backend** (`controller/src/routes/dj.ts` — the same file that holds `/dj/skills/rescan`):
+
+- `POST /dj/skills/news/scaffold`
+  - Body: `{ name, url, cooldown?: string, brief?: string }`
+  - Validates: `name` non-empty, `url` parses as `http(s)://…`, optional `cooldown` matches the loader's pattern, optional `brief` non-empty.
+  - Derives `slug = "news-" + kebab(name)`; rejects with 409 if `state/skills/<slug>/` exists.
+  - Writes `state/skills/<slug>/SKILL.md` (template below).
+  - Calls `loadCustomSkills()` directly (no `/rescan` round-trip).
+  - Returns the freshly loaded skill row so the UI can render it without a refetch.
+
+- `DELETE /dj/skills/:slug`
+  - Guard: only allowed when `slug` starts with `news-`. Custom non-news skills are removed by the operator on the filesystem and a Rescan — the UI shortcut is opinionated about news only, so destructive UI actions stay scoped.
+  - Removes `state/skills/<slug>/` (recursive) and calls `loadCustomSkills()`.
+
+- `PUT /dj/skills/news/:slug`
+  - Same body as POST. Overwrites the existing SKILL.md (preserves anything else in the folder, e.g. a `tool.mjs` an operator added later — but that overrides `feed:` per §2, so the UI shows the form in read-only mode in that case).
+
+SKILL.md template the scaffold endpoint writes:
+
+```yaml
+---
+name: {slug}
+label: {name}
+cooldown: {cooldown or "45m"}
+feed: {url}
+feedMaxItems: 10
+feedFreshnessHours: 24
+---
+{brief or "Read one fresh headline in a single sentence — keep it conversational, in the station's voice. Skip a headline that is dull or stale; silence is fine."}
+```
+
+**Frontend** (`web/components/admin/SkillsPanel.tsx`):
+
+Add an "Add news feed" button next to the existing **Rescan** button (already on this branch). It opens a modal — fields: `Display name`, `Feed URL`, `Cooldown` (default `45m`), `Brief` (textarea, prefilled with the default brief). On submit → POST → close on success / show error inline on failure.
+
+Each existing `news-*` skill row gets two extras:
+- A small **Edit** affordance opening the same modal in update mode (PUT).
+- A small **Remove** affordance (only on `news-*` rows) with a confirm prompt → DELETE.
+
+For non-news custom skills, the row stays as today (toggle + Run now + Rescan).
+
+### 4. Per-skill persistent state slot
+
+Currently `state` (a.k.a. `segmentState` in `controller/src/skills/_agent.ts`) is in-memory + module-scoped + shared across all skills. The RSS helper, the in-tree weather/curiosity/news-dedup logic, and any custom `tool.mjs` all read and write the same object.
+
+Two changes in `_agent.ts`:
+
+- Initialise lazily: `segmentState.skills = segmentState.skills || {}`. Each capability's tool — built-in or custom — receives `state.skills[name]` as its own scratch object. The loader's call site (`segment-tools.ts`) passes `state.skills[cap.kind]` (creating-if-absent) into the wrapped `tool.mjs`. No cross-skill collisions.
+
+- Add a debounced (500ms) writer that persists `segmentState.skills` to `state/skill-state.json` on every mutation, and loads it once at boot. Truncate-on-load if the file is corrupt or unparseable — never fatal. Cap the on-disk file at 256 KB; if it grows past that, drop the largest skill slot with a logged warning (none of these slots should be large; this is a safety valve, not a feature).
+
+The RSS helper uses this slot for `{ seenHeadlines: { hash: airedMs, ... }, health: {...} }`. After this, restart no longer re-burns headlines — the original loose end from issue #193 closes by itself.
+
+The built-in `seenCuriosity`, `lastWeatherCondition`, `lastSearchedArtist` slots on `segmentState` (`_agent.ts:132-138`) stay where they are — the migration is opt-in per skill, not a forced relocation. Built-ins can adopt the slot later when their owners feel like it.
+
+### 5. Per-skill health surface
+
+Generic, not news-specific. The RSS helper happens to be the first user.
+
+**Data shape** — every tool invocation writes:
+
+```ts
+state.skills[name].health = {
+  lastInvokedAt: <unixMs>,
+  lastOk: boolean,
+  lastError: string | null,         // first 200 chars
+  lastItemCount: number | null,     // null for non-data skills
+  consecutiveFailures: number,
+}
+```
+
+**Surface in the admin Skills response** — extend whatever `GET /dj/skills` returns on this branch with a `health` field on each skill row. Source: `segmentState.skills[name]?.health` if present.
+
+**Surface in `/admin/skills`** — render a small status dot per row:
+- grey: never invoked
+- green: `lastOk && consecutiveFailures === 0`
+- amber: `lastOk && consecutiveFailures >= 1` (last call was ok but earlier failures recent)
+- red: `consecutiveFailures >= 3`
+
+Hovering the dot shows `lastError` and the relative time of `lastInvokedAt`.
+
+**Surface in `/debug`** — already exposes per-skill state in the catalog. Same fields rendered as JSON for power users.
+
+### 6. Migration and env compatibility
+
+On controller boot, *after* the pluggable-skills loader has finished its initial scan:
+
+- **No `news-*` skill loaded AND `process.env.NEWS_FEED_URL` is set** → scaffold `state/skills/news-env/` from the env var's value (and `NEWS_MAX_ITEMS` if present). This preserves the 12-factor / GitOps story.
+- **No `news-*` skill loaded AND no `NEWS_FEED_URL`** → scaffold `state/skills/news-bbc/` (the default in §1). Fresh installs are never silent on news.
+
+Both scaffolds are idempotent — they check for the folder's existence first and do nothing if present. Operators who later delete or rename the folder won't have it re-created until they restart with no `news-*` skill at all, which matches "operator intent" semantics: if you've actively curated your skills, we stop second-guessing you.
+
+**`.env.example`** keeps `NEWS_FEED_URL` documented but reframes the surrounding comment: *"convenience — seeds a default news skill named `news-env` if you haven't added a feed via the admin UI."*
+
+**`CLAUDE.md` updates** — the "What this is" / commands section and the LLM/skills section both mention the built-in `news` capability. Both get a one-line update pointing at the pluggable-skills doc.
+
+### 7. Out of scope (with reasons)
+
+- **Listener "what's in the news?" `/request` channel.** Orthogonal: it's about routing listener intents to a *direct* tool call on a specific skill, not about how news airs autonomously. Belongs in a separate plan that touches `controller/src/routes/request.ts` and the matcher in `controller/src/llm/dj.ts`.
+- **Schedule windows per feed (e.g. "tech news only Mon-Fri 7-9am").** The existing `window: commute` frontmatter on the branch is the precedent. Real cron windows are a fair follow-up — add `window:` as a tagged union (`any | commute | <cron>`) when there's an operator who actually wants it. YAGNI for now.
+- **Feed categories as a station-wide concept.** Personas already serve this role.
+- **Cross-feed dedup.** Each feed-skill dedupes itself; identical headlines across feeds (rare; usually wire copy) will each fire once, max. Trying to dedup across feeds means a global hash table, which adds coordination cost without a concrete operator complaint behind it.
+
+---
+
+## What changes, by file
+
+The build order matters less than the dependency graph below — operators can split this across PRs if useful, but §4 is a precondition for §2's helper to persist dedup, and §1 depends on §6 (otherwise booting the new code on an existing install with no `news-*` folder yet silences news mid-flight).
+
+| File | Change |
+|---|---|
+| `controller/src/skills/_agent.ts` | Delete `news` entry from `CAPABILITIES`. Initialise `segmentState.skills = {}`. Add debounced persist + boot-load for `state/skill-state.json`. Migration scaffolder (§6) called after `loadCustomSkills()`. |
+| `controller/src/llm/segment-tools.ts` | Delete the `kinds.has('news')` branch. Wrap each custom tool with `state.skills[cap.kind]` slot (replacing the shared `state` arg). |
+| `controller/src/skills/loader.ts` | Add `feed:` branch in `loadOne()` that calls the RSS helper factory when `tool.mjs` is absent. Pass through new `feedMaxItems` / `feedFreshnessHours`. |
+| `controller/src/skills/_rss-helper.ts` | **New.** Factory returning a `tool.mjs`-shaped function. RSS 2.0 + Atom, User-Agent, freshness filter, persistent dedup via state slot, health record. |
+| `controller/src/skills/news.ts` | Delete file (its logic is now inside `_rss-helper.ts`). |
+| `controller/src/routes/dj.ts` | Add `POST /dj/skills/news/scaffold`, `PUT /dj/skills/news/:slug`, `DELETE /dj/skills/:slug` (guarded to `news-*`). |
+| `web/components/admin/SkillsPanel.tsx` | Add "Add news feed" button + modal. Add Edit/Remove buttons on `news-*` rows. Health dot per row. |
+| `state/skills/news-bbc/SKILL.md` | New default skill, scaffolded by §6 migrator at boot rather than committed. Documented in `docs/custom-skills.md` as an example. |
+| `docs/custom-skills.md` | Document the `feed:` frontmatter key and the news scaffolding path. |
+| `.env.example` | Re-comment `NEWS_FEED_URL` to mention the `news-env` scaffolding semantic. |
+| `CLAUDE.md` | One-line update where the built-in `news` capability is described. |
+
+## Verification (when this is implemented)
+
+1. **Fresh install, no env.** Boot. `state/skills/news-bbc/` is auto-created; `/admin/skills` shows it enabled. Next segment tick fires a BBC headline.
+2. **Fresh install with `NEWS_FEED_URL=https://www.eurogamer.net/feed/news`.** Boot. `state/skills/news-env/` is auto-created with that URL; `/admin/skills` shows it; first tick fires an Eurogamer headline.
+3. **Add second feed via UI.** With BBC already running, click "Add news feed" → name "Guardian Tech" → URL `https://www.theguardian.com/uk/technology/rss`. Save. Row appears, enabled. Within one tick cycle, fires Guardian headlines too.
+4. **Atom feed works.** Add a GitHub releases atom feed (or any known Atom URL). Health dot is green; `/debug` shows `lastItemCount > 0`.
+5. **Broken URL surfaces.** Add `https://example.com/not-a-feed`. Within 5 min, the row's health dot turns red; hover shows the parse error. Other news skills keep ticking.
+6. **Persona allowlist filters feeds.** Configure two personas — `breakfast` lists `news-bbc`, `late-night` lists `news-guardian-tech`. Confirm in the listener UI that the on-air persona controls which feed is read.
+7. **Restart doesn't re-burn headlines.** Note `state.skills["news-bbc"].seenHeadlines` size in `/debug`. Restart the controller. `/debug` shows the same size (loaded from `state/skill-state.json`). The next news tick does not re-read recently-aired headlines.
+8. **Delete a feed via UI.** Click Remove on `news-guardian-tech`. Row vanishes; on-disk folder gone. Boot again — it stays gone (the migrator only seeds defaults when *no* `news-*` skill exists).
+9. **Lint clean.** `cd controller && npm run lint` and `cd web && npm run lint` both pass.
+
+## Open questions
+
+- **Per-skill state slot scope creep.** §4 introduces a new contract (`state.skills[name]` + on-disk persistence). It's strictly additive and lands cleanly, but it's also a feature every future custom-skill author has to know about. Worth a short paragraph in `docs/custom-skills.md` as part of this work — not a separate plan.
+- **Health dot semantics on never-invoked skills.** Currently "grey." Could be "amber" to nudge the operator that an enabled skill isn't being picked up by the agent (e.g. wrong persona allowlist). Probably grey is fine; revisit when there's an operator confused by silence.
+- **What happens if the operator hand-edits `state/skills/news-bbc/SKILL.md` *and* uses the UI Edit form?** UI Edit overwrites. We could detect divergence (read the file, compare to the previous template, refuse to overwrite if it's been hand-edited), but that's more cleverness than the wider operator base wants. Document it: "Edit through the UI overwrites the whole file. If you've made manual changes, edit the file directly and hit Rescan."

--- a/web/app/manual/skills/page.tsx
+++ b/web/app/manual/skills/page.tsx
@@ -1,0 +1,7 @@
+import CustomSkills from '../../../components/manual/CustomSkills';
+
+export const metadata = { title: 'SUB/WAVE — Manual · Custom Skills' };
+
+export default function CustomSkillsPage() {
+  return <CustomSkills />;
+}

--- a/web/components/admin/SkillsPanel.tsx
+++ b/web/components/admin/SkillsPanel.tsx
@@ -25,6 +25,7 @@ interface Skill {
   requiresKey?: string;
   keyUrl?: string;
   cooldownMs?: number;
+  custom?: boolean;
 }
 
 interface SkillsResponse {
@@ -81,6 +82,7 @@ export default function SkillsPanel() {
   const [skills, setSkills] = useState<Skill[] | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);   // skill name currently mutating, or null
+  const [rescanning, setRescanning] = useState(false);
 
   useEffect(() => {
     if (!hydrated || needsAuth) return;
@@ -115,6 +117,19 @@ export default function SkillsPanel() {
     } catch (e) {
       notify.err(`Toggle failed: ${errorMessage(e)}`);
     } finally { setBusy(null); }
+  };
+
+  const rescan = async () => {
+    setRescanning(true);
+    try {
+      const r = await adminFetch('/dj/skills/rescan', { method: 'POST' });
+      const j = (await r.json().catch(() => ({}))) as SkillToggleResponse & { custom?: number };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      if (Array.isArray(j.skills)) setSkills(j.skills);
+      notify.ok(`Rescanned — ${j.custom ?? 0} custom skill${j.custom === 1 ? '' : 's'} loaded`);
+    } catch (e) {
+      notify.err(`Rescan failed: ${errorMessage(e)}`);
+    } finally { setRescanning(false); }
   };
 
   const runNow = async (name: string) => {
@@ -168,10 +183,20 @@ export default function SkillsPanel() {
             <strong> and</strong> assigned to the persona on air — set per-persona assignments
             on the Personas page. “Run now” is an operator override and ignores both.
           </div>
+          <div className="mt-1 text-[11px] leading-[1.6] text-muted">
+            Drop your own skills into <code>state/skills/&lt;name&gt;/SKILL.md</code> and hit
+            <strong> Rescan</strong>. Custom skills arrive <strong>disabled</strong> — review,
+            then enable them before they can air.
+          </div>
         </div>
         <div className="flex items-center gap-4 bg-[var(--ink-softer)] p-3.5">
           <span className="caption">{skills.length} skill{skills.length === 1 ? '' : 's'}</span>
           <span className="caption text-vermilion">{enabledCount} enabled</span>
+          <div className="ml-auto">
+            <Btn onClick={rescan} disabled={rescanning}>
+              {rescanning ? 'Rescanning…' : 'Rescan state/skills'}
+            </Btn>
+          </div>
         </div>
       </section>
 
@@ -183,6 +208,7 @@ export default function SkillsPanel() {
           sub={s.kind}
           right={
             <>
+              {s.custom && <Pill>custom</Pill>}
               <Pill tone={s.enabled ? 'accent' : 'default'} dot={s.enabled}>
                 {s.enabled ? 'enabled' : 'disabled'}
               </Pill>

--- a/web/components/manual/AdminSettings.tsx
+++ b/web/components/manual/AdminSettings.tsx
@@ -4,7 +4,7 @@ import ManualPage from './ManualPage';
 export default function AdminSettings() {
   return (
     <ManualPage
-      eyebrow="MANUAL · 06"
+      eyebrow="MANUAL · 07"
       title="Admin & settings."
       intro="For the operator running the station. The admin console is where you shape the DJ, choose the AI providers, schedule shows, and watch how the station is behaving — all without a redeploy."
       current="/manual/admin"

--- a/web/components/manual/AgentAccess.tsx
+++ b/web/components/manual/AgentAccess.tsx
@@ -13,7 +13,7 @@ const TOOLS = [
 export default function AgentAccess() {
   return (
     <ManualPage
-      eyebrow="MANUAL · 10"
+      eyebrow="MANUAL · 11"
       title="Agent access."
       intro="SUB/WAVE isn't only for human listeners. An AI agent can read what's on air and put songs and DJ segments onto the broadcast through the station's MCP server."
       current="/manual/mcp"

--- a/web/components/manual/CustomSkills.tsx
+++ b/web/components/manual/CustomSkills.tsx
@@ -1,0 +1,130 @@
+import ManualPage from './ManualPage';
+import CodeBlock from "@/components/CodeBlock";
+
+export default function CustomSkills() {
+  return (
+    <ManualPage
+      eyebrow="MANUAL · 06"
+      title="Custom skills."
+      intro="The things the DJ does between tracks — a weather check, a headline, a traffic gag — are skills. A handful ship built in. You can add your own by dropping a folder into state/skills, no code changes to the station."
+      current="/manual/skills"
+    >
+      <section className="bs-section">
+        <p className="bs-eyebrow">WHAT A SKILL IS</p>
+        <h2>One thing: a between-track line.</h2>
+        <p>
+          A SUB/WAVE skill is a single between-track <em>spoken segment</em> — the DJ
+          glances at something, then either says one short line over the music or stays
+          quiet. The format borrows from{' '}
+          <a href="https://github.com/anthropics/skills" target="_blank" rel="noreferrer">
+            Anthropic&rsquo;s skills
+          </a>{' '}
+          — a <code className="bs-code-inline">SKILL.md</code> with YAML frontmatter and a
+          markdown body, plus optional code — but the meaning is narrower. These don&rsquo;t
+          process documents or run tasks; they decide what the DJ says next.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">THE LAYOUT</p>
+        <h2>A folder under state/skills.</h2>
+        <p>
+          Drop a folder into <code className="bs-code-inline">state/skills/</code>. It needs a{' '}
+          <code className="bs-code-inline">SKILL.md</code>; an optional{' '}
+          <code className="bs-code-inline">tool.mjs</code> lets the segment look at live data
+          before the DJ speaks.
+        </p>
+        <CodeBlock>{`state/skills/
+  moon-phase/
+    SKILL.md      # frontmatter (→ settings) + body (→ the DJ's brief)
+    tool.mjs      # OPTIONAL: a data fetcher the DJ can call`}</CodeBlock>
+        <p>
+          A ready-to-copy example ships in the repo at{' '}
+          <code className="bs-code-inline">docs/examples/skills/moon-phase</code>. Copy it
+          into <code className="bs-code-inline">state/skills/</code> and hit{' '}
+          <strong>Rescan</strong> on the admin Skills page.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">SKILL.md</p>
+        <h2>Frontmatter, then the brief.</h2>
+        <p>
+          The frontmatter sets the skill&rsquo;s metadata; the markdown body <em>is</em> the
+          brief the DJ follows — what to say, in what tone, and when to stay silent. Only a
+          non-empty body is required; every key has a sensible default.
+        </p>
+        <CodeBlock>{`---
+name: moon-phase          # the slug (defaults to the folder name)
+label: Moon phase         # label shown in admin (defaults to a title-cased name)
+cooldown: 6h              # min gap between auto firings — "90m" | "6h" | "2d" | "45" (minutes)
+window: any               # "any" (default) | "commute" — commute hours only
+requiresKey: SOME_API_KEY # OPTIONAL: env var the skill needs; unset → stays inert
+---
+If tonight's moon is at a notable phase, work it into one short, in-character
+line, the way a late-night presenter might glance out the window. Skip it when
+the phase is unremarkable.`}</CodeBlock>
+        <p className="text-muted">
+          The <code className="bs-code-inline">name</code> must be a lowercase slug and
+          can&rsquo;t shadow a built-in skill. Bad frontmatter is logged and skipped — it
+          never crashes the station.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">tool.mjs — OPTIONAL</p>
+        <h2>Let the DJ look before it speaks.</h2>
+        <p>
+          With a <code className="bs-code-inline">tool.mjs</code>, the DJ can fetch live data
+          before deciding whether to air the line — the same mechanism the built-in weather
+          and news skills use. Export a default function; return any JSON, and use{' '}
+          <code className="bs-code-inline">{`{ available: false }`}</code> to tell the DJ
+          there&rsquo;s nothing worth airing.
+        </p>
+        <CodeBlock>{`export default async function (ctx, state) {
+  // ctx   — the moment: { time, weather, festival, dominantMood, clock }
+  // state — cross-tick memory (persists between firings)
+  return { available: true, phase: 'full moon', illumination: 100 };
+}`}</CodeBlock>
+        <p>
+          The call is timeout-guarded and any error degrades cleanly to &ldquo;no
+          data&rdquo; — a slow or broken skill can never hang the station. With no{' '}
+          <code className="bs-code-inline">tool.mjs</code>, the skill writes from its brief
+          alone (like the built-in traffic gag).
+        </p>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">IT RUNS YOUR CODE</div>
+          <p>
+            <code className="bs-code-inline">tool.mjs</code> executes inside the controller —
+            the same trust model as installing a local tool. Only drop in code you&rsquo;ve
+            read and trust.
+          </p>
+        </div>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">GOING LIVE</p>
+        <h2>Discovered, then enabled by you.</h2>
+        <p>
+          A freshly dropped skill appears on the admin <strong>Skills</strong> page toggled{' '}
+          <strong>off</strong>. It can&rsquo;t air — by itself or via the DJ — until you
+          enable it there. Dropping a folder never puts unreviewed content (or code) on air.
+        </p>
+        <p>
+          Skills load at boot, and on demand via the <strong>Rescan state/skills</strong>{' '}
+          button on that page — which picks up new folders and edits to{' '}
+          <code className="bs-code-inline">SKILL.md</code> /{' '}
+          <code className="bs-code-inline">tool.mjs</code> without a restart. Like the
+          built-ins, a custom skill only fires autonomously when it&rsquo;s enabled{' '}
+          <em>and</em> assigned to the persona on air (Personas page). <strong>Run now</strong>{' '}
+          is an operator override that ignores the toggle, the persona, the frequency gate,
+          and the cooldown.
+        </p>
+        <p className="text-muted">
+          Full reference, including the example skill, lives in{' '}
+          <code className="bs-code-inline">docs/custom-skills.md</code>.
+        </p>
+      </section>
+    </ManualPage>
+  );
+}

--- a/web/components/manual/Faq.tsx
+++ b/web/components/manual/Faq.tsx
@@ -4,7 +4,7 @@ import ManualPage from './ManualPage';
 export default function Faq() {
   return (
     <ManualPage
-      eyebrow="MANUAL · 11"
+      eyebrow="MANUAL · 12"
       title="Questions & answers."
       intro="The things people ask most about how SUB/WAVE behaves — how it copes with an empty room, what it needs from a model, and what the moving parts behind the DJ actually do."
       current="/manual/faq"

--- a/web/components/manual/ModelsAndTokens.tsx
+++ b/web/components/manual/ModelsAndTokens.tsx
@@ -4,7 +4,7 @@ import ManualPage from './ManualPage';
 export default function ModelsAndTokens() {
   return (
     <ManualPage
-      eyebrow="MANUAL · 09"
+      eyebrow="MANUAL · 10"
       title="Models & tokens."
       intro="The AI DJ can run on a small model on your own hardware or a large hosted one — and a handful of settings let you tune the station for whichever you've picked, trading richness against cost."
       current="/manual/llm"

--- a/web/components/manual/OperatorCli.tsx
+++ b/web/components/manual/OperatorCli.tsx
@@ -5,7 +5,7 @@ import CodeBlock from "@/components/CodeBlock";
 export default function OperatorCli() {
   return (
     <ManualPage
-      eyebrow="MANUAL · 08"
+      eyebrow="MANUAL · 09"
       title="The operator console."
       intro="SUB/WAVE ships a command-line console for running the station. One command opens a menu that boots the stack, checks its health, tails logs, and opens a terminal player — no Docker flags to remember."
       current="/manual/cli"

--- a/web/components/manual/Overview.tsx
+++ b/web/components/manual/Overview.tsx
@@ -28,6 +28,11 @@ const GUIDE = [
     blurb: 'The AI behind the desk: how it picks songs, when it talks, and who it sounds like.',
   },
   {
+    href: '/manual/skills',
+    label: 'Custom Skills',
+    blurb: 'Add your own between-track segments — drop a SKILL.md into state/skills and the DJ can run it.',
+  },
+  {
     href: '/manual/admin',
     label: 'Admin & Settings',
     blurb: 'For the operator — signing in, tuning the DJ, scheduling shows, and managing jingles.',
@@ -64,7 +69,7 @@ export default function Overview() {
     >
       <section className="bs-section">
         <p className="bs-eyebrow">WHAT'S INSIDE</p>
-        <h2>Ten short guides.</h2>
+        <h2>Eleven short guides.</h2>
         <p>
           Start at the top if you're new. Each page links to the next, so you can read
           straight through, or jump to whatever you need from the contents on the left.

--- a/web/components/manual/Themes.tsx
+++ b/web/components/manual/Themes.tsx
@@ -21,7 +21,7 @@ const EXAMPLE_THEME = `{
 export default function Themes() {
   return (
     <ManualPage
-      eyebrow="MANUAL · 07"
+      eyebrow="MANUAL · 08"
       title="Themes."
       intro="SUB/WAVE renders the player and the admin console through one shared palette. You pick the station's theme; everyone listening sees the same look. Built-ins ship with the controller, and you can drop your own JSONs in to extend the menu."
       current="/manual/themes"

--- a/web/components/manual/pages.ts
+++ b/web/components/manual/pages.ts
@@ -13,6 +13,7 @@ export const MANUAL_PAGES: ManualPageEntry[] = [
   { href: '/manual/clients', label: 'Listen With' },
   { href: '/manual/shortcuts', label: 'Keyboard Shortcuts' },
   { href: '/manual/dj', label: 'How the DJ Works' },
+  { href: '/manual/skills', label: 'Custom Skills' },
   { href: '/manual/admin', label: 'Admin & Settings' },
   { href: '/manual/themes', label: 'Themes' },
   { href: '/manual/cli', label: 'The Operator CLI' },


### PR DESCRIPTION
## What

Makes SUB/WAVE's between-track **skills** pluggable by operators. Drop a folder into `state/skills/<name>/` with a `SKILL.md` (YAML frontmatter + a markdown brief) and an optional `tool.mjs` data fetcher, hit **Rescan** in the admin console, and enable it.

This adopts the *format* of [Anthropic's skills](https://github.com/anthropics/skills) — `SKILL.md` frontmatter + body + optional code — scoped to the one thing a SUB/WAVE skill can be: a between-track spoken segment.

## How

The segment director's capability table was already the single source of truth for the autonomous tick, the `/dj/skill` override, the admin toggles, and the catalogue. This makes that table extensible rather than rebuilding any of it.

- **`controller/src/skills/loader.ts`** (new) — scans `state/skills`, parses frontmatter with a zero-dependency flat-YAML parser, dynamically imports `tool.mjs`. Malformed skills (bad slug, reserved-name shadowing, empty body) are logged and skipped — never fatal.
- **`controller/src/skills/_agent.ts`** — `allCapabilities()` merges built-ins + custom. Custom skills are **discovered-but-disabled**, support `window: commute` gating and `requiresKey` readiness. The segment schema `kind` changes from `z.enum` → `z.string()` so custom kinds validate (already drop-checked against offered caps).
- **`controller/src/llm/segment-tools.ts`** — wraps each `tool.mjs` as an AI SDK tool behind an 8s timeout + try/catch, so a slow/broken skill can't hang the tick.
- **`controller/src/routes/dj.ts`** — `POST /dj/skills/rescan` reloads without a restart; **`server.ts`** loads at boot.

## UI & docs

- `/admin/skills`: **Rescan** button, a `custom` badge, and disabled-by-default copy.
- New **Custom Skills** manual page (`/manual/skills`), wired into `pages.ts` + the Overview "What's inside" list; trailing eyebrows renumbered 06→12.
- `README.md` feature bullet, `docs/custom-skills.md` reference, and a runnable example at `docs/examples/skills/moon-phase` (keyless — computes lunar phase from the date).

## Safety

`tool.mjs` runs operator-supplied code in the controller (same trust model as a local tool). Mitigations: discovered-but-disabled by default, 8s timeout + error isolation on every custom tool call, and frontmatter validation that skips bad skills.

## Verification

- `controller` `eslint . && tsc --noEmit` — exit 0
- `web` `eslint . && tsc --noEmit` — exit 0
- Runtime smoke test: the example skill loaded with the correct 6h cooldown and a working `skill_moon_phase` tool; a malformed (no body) folder and a reserved-name (`weather`) folder were both correctly rejected.

No test runner is configured in this repo; lint is the merge gate.