### PR TITLE
feat(cli): subwave uninstall + version-mismatch warning

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -8,7 +8,7 @@
       "name": "subwave-cli",
       "version": "0.1.0",
       "dependencies": {
-        "@clack/prompts": "^0.8.2",
+        "@clack/prompts": "0.8.2",
         "picocolors": "^1.1.1"
       },
       "devDependencies": {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -34,6 +34,7 @@ Usage:
   subwave listen [dev|prod] open the web player in a browser
   subwave admin [dev|prod] open the admin console in a browser
   subwave self-update      replace the installed binary with the latest release
+  subwave uninstall        tear down the stack + remove the install (keeps state/)
 
 Flags:
   --home <path>            override SUBWAVE_HOME for this invocation
@@ -46,6 +47,12 @@ init flags:
   --admin-user <user>      admin username (default: admin)
   --admin-pass <pass>      admin password (default: randomly generated)
   --site-url <url>         public site URL (default: none)
+
+uninstall flags:
+  --purge                  also remove the whole install dir (incl. state/) + volumes
+  --images                 also remove the pulled ghcr images
+  --binary                 also remove the subwave binary
+  --yes, -y                skip the confirmation prompt
 
   subwave help             show this message
   subwave --version        print version
@@ -105,6 +112,19 @@ async function main(): Promise<void> {
       version = a.startsWith('--version=') ? a.slice('--version='.length) : rest[versionFlagIdx + 1];
     }
     await runSelfUpdateCommand({ version });
+    return;
+  }
+  if (cmd === 'uninstall') {
+    // Handled before the resolved-home gate: uninstall must work even when the
+    // install is half-broken (no .env, stale stack), and can still clean up
+    // CLI config + binary when there's no home at all.
+    const { runUninstallCommand } = await import('./commands/uninstall.ts');
+    await runUninstallCommand({
+      yes: rest.includes('--yes') || rest.includes('-y'),
+      purge: rest.includes('--purge'),
+      images: rest.includes('--images'),
+      binary: rest.includes('--binary'),
+    });
     return;
   }
 

--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -16,6 +16,7 @@ import {
   getComposeFiles,
   detectCompose,
   inferEnvFromFilesystem,
+  runningImageRefs,
   webBaseFor,
   type ComposeEnv,
   type ComposeFile,
@@ -23,6 +24,7 @@ import {
 import { composeUp, dockerSocketPermissionDenied } from '../docker.ts';
 import { waitForHealth, checkNeedsSetup } from '../api.ts';
 import { loadConfig, saveConfig } from '../config.ts';
+import { parseEnvFile, getRootEnv } from '../util.ts';
 import { ok, warn, err, info, muted, p, pc, pauseForEnter, header } from '../ui.ts';
 import { maybeStartWebDev } from '../web-dev.ts';
 
@@ -39,6 +41,7 @@ export async function runStartCommand(opts: StartOpts = {}): Promise<void> {
   if (current.env !== 'down') {
     header('Already running');
     info(`stack is already up — env=${current.env}`);
+    warnIfVersionMismatch(current.file);
     muted('→ use `subwave restart` to bounce a service, or `subwave stop` first.');
     await pauseForEnter();
     return;
@@ -179,4 +182,32 @@ function resolveEnv(arg?: StartableEnv): ComposeFile | null {
   err('could not resolve env from install state');
   muted('→ pass `subwave start dev|prod|prod-byo` explicitly, or run `subwave init` to scaffold a fresh install.');
   return null;
+}
+
+// When a stack is already up, flag if its image tags don't match the version
+// this install expects (process.env.SUBWAVE_VERSION → root .env → 'latest').
+// Catches a stale or different-version stack — e.g. a leftover `:pocket`
+// build — silently occupying the container names a fresh install reuses, so
+// the operator doesn't mistake it for their new install (see the v0.1.30
+// install where a 44-min-old `:pocket` stack masked a fresh scaffold).
+function warnIfVersionMismatch(file: ComposeFile | null): void {
+  if (!file) return;
+  let expected = process.env.SUBWAVE_VERSION?.trim();
+  if (!expected) {
+    try { expected = parseEnvFile(getRootEnv()).SUBWAVE_VERSION?.trim(); } catch { /* no .env yet */ }
+  }
+  expected = expected || 'latest';
+
+  const tags = new Set(
+    runningImageRefs(file)
+      .filter((r) => r.includes('subwave-'))
+      .map((r) => r.slice(r.lastIndexOf(':') + 1))
+      .filter(Boolean),
+  );
+  const mismatched = [...tags].filter((t) => t !== expected);
+  if (mismatched.length === 0) return;
+
+  warn(`running images are tagged ${[...tags].map((t) => `:${t}`).join(', ')}, but this install expects :${expected}.`);
+  muted('  Looks like a stale or different-version stack. To replace it:');
+  muted('    subwave stop   (then)   subwave start');
 }

--- a/cli/src/commands/uninstall.ts
+++ b/cli/src/commands/uninstall.ts
@@ -1,0 +1,175 @@
+// `subwave uninstall` — tear down the stack and remove the install.
+//
+// The inverse of `init` + `start`. Tiered so the common case is safe:
+//
+//   subwave uninstall            down the stack, remove the install's compose
+//                                files + .env + CLI config — but KEEP state/
+//                                (settings, secrets, sessions, jingles, tags).
+//   subwave uninstall --purge    also remove the whole install dir (incl.
+//                                state/) and named volumes. Irreversible.
+//   subwave uninstall --images   also remove the pulled ghcr images.
+//   subwave uninstall --binary   also remove the subwave binary itself.
+//   subwave uninstall --yes      skip the confirmation prompt.
+//
+// Everything destructive is confirmed unless --yes. On a cloned repo
+// (clone-mode home) we never delete files — that's the operator's source
+// tree, not a scaffolded install; we only bring the stack down.
+
+import { existsSync, rmSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+
+import { resolveSubwaveHome, isCloneMode, HOME_CONFIG_PATH } from '../home.ts';
+import { configPath } from '../config.ts';
+import { detectCompose, getComposeFiles, isProdEnv, type ComposeFile } from '../compose.ts';
+import { composeDownFull } from '../docker.ts';
+import { banner, header, ok, warn, err, info, muted, p, pc, exitIfCancelled } from '../ui.ts';
+
+export interface UninstallOptions {
+  yes?: boolean;
+  purge?: boolean;
+  images?: boolean;
+  binary?: boolean;
+}
+
+// Generated install artifacts `init` writes into the home. Removed on a
+// default uninstall; state/ is deliberately NOT in this list.
+const GENERATED_FILES = [
+  'docker-compose.yml',
+  'docker-compose.byo.yml',
+  'docker-compose.dev.yml',
+  '.env',
+  '.env.example',
+];
+
+export async function runUninstallCommand(opts: UninstallOptions = {}): Promise<void> {
+  banner('uninstall');
+
+  const resolved = resolveSubwaveHome();
+  const home = resolved?.home ?? null;
+  const clone = home ? isCloneMode(home) : false;
+
+  // Which compose file to bring down: prefer the one Docker says is running,
+  // else the first one that exists in the home (so we still clean up a
+  // stopped-but-present stack). Only meaningful with a resolved home.
+  let target: ComposeFile | null = null;
+  let runningEnv = 'down';
+  if (home) {
+    const status = detectCompose();
+    runningEnv = status.env;
+    target = status.file ?? getComposeFiles().find((f) => existsSync(f.abs)) ?? null;
+  }
+
+  // Nothing to do at all?
+  const haveConfig = existsSync(HOME_CONFIG_PATH) || existsSync(configPath());
+  if (!home && !haveConfig) {
+    header('Nothing to uninstall');
+    info('No SUB/WAVE install found (no home, no CLI config).');
+    return;
+  }
+
+  // --- plan summary ---------------------------------------------------------
+  header('This will');
+  if (target) {
+    muted(`• docker compose down${opts.purge ? ' -v' : ''}${opts.images ? ' --rmi all' : ''}` +
+      `  (${runningEnv === 'down' ? 'stack not running' : `${runningEnv} stack`})`);
+  } else {
+    muted('• (no compose file found to bring down)');
+  }
+  if (clone) {
+    muted(`• ${pc.dim('clone-mode home — leaving source files untouched')} (${home})`);
+  } else if (opts.purge && home) {
+    muted(`• ${pc.red('remove the entire install dir')} ${home} ${pc.red('(incl. state/ — settings, secrets, jingles, tags)')}`);
+  } else if (home) {
+    muted(`• remove compose files + .env from ${home} ${pc.dim('(keeps state/)')}`);
+  }
+  muted('• remove CLI config (~/.config/subwave)');
+  if (opts.binary) muted(`• remove the subwave binary (${binaryPath() ?? 'n/a'})`);
+  console.log();
+
+  // --- confirm --------------------------------------------------------------
+  if (!opts.yes) {
+    const yes = exitIfCancelled(await p.confirm({
+      message: opts.purge
+        ? `${pc.red('Purge')} this SUB/WAVE install — including all state — permanently?`
+        : (isProdEnv(runningEnv as never)
+          ? 'Uninstall SUB/WAVE? Listeners will hear silence.'
+          : 'Uninstall SUB/WAVE?'),
+      initialValue: false,
+    }), { backOnCancel: false });
+    if (!yes) {
+      muted('cancelled — nothing changed.');
+      return;
+    }
+  }
+
+  // --- execute --------------------------------------------------------------
+  header('Uninstalling');
+
+  if (target) {
+    muted(`docker compose -f ${target.file} down${opts.purge ? ' -v' : ''}${opts.images ? ' --rmi all' : ''}`);
+    const code = await composeDownFull(target, { volumes: opts.purge, rmi: opts.images });
+    if (code !== 0) warn(`docker compose exited ${code} — continuing with file cleanup`);
+    else ok('stack down');
+  }
+
+  if (home && !clone) {
+    if (opts.purge) {
+      try {
+        rmSync(home, { recursive: true, force: true });
+        ok(`removed install dir ${home}`);
+      } catch (e) {
+        err(`could not remove ${home}: ${(e as Error).message}`);
+      }
+    } else {
+      for (const f of GENERATED_FILES) {
+        const p2 = resolve(home, f);
+        if (existsSync(p2)) rmSync(p2, { force: true });
+      }
+      ok(`removed compose files + .env (kept ${resolve(home, 'state')})`);
+    }
+  } else if (clone) {
+    info('clone-mode home — left your source checkout untouched.');
+  }
+
+  // CLI config pointers (home config.json + preferences cli.json).
+  for (const cfg of [HOME_CONFIG_PATH, configPath()]) {
+    if (existsSync(cfg)) rmSync(cfg, { force: true });
+  }
+  ok('removed CLI config');
+
+  if (opts.binary) removeBinary();
+
+  console.log();
+  if (!opts.purge && home && !clone) {
+    muted(`State preserved at ${resolve(home, 'state')} — reinstall with \`subwave init\` to reuse it, or remove it manually.`);
+  } else {
+    muted('Done. To reinstall: curl -fsSL https://cli.getsubwave.com | sh');
+  }
+}
+
+// Resolve the running binary's own path, unless we're running from source
+// (tsx/node/bun dev), where there's nothing for the operator to delete.
+function binaryPath(): string | null {
+  const p2 = process.execPath;
+  const base = basename(p2).toLowerCase();
+  if (base.startsWith('node') || base.startsWith('bun') || base.startsWith('tsx') || p2.includes('node_modules')) {
+    return null;
+  }
+  return p2;
+}
+
+function removeBinary(): void {
+  const p2 = binaryPath();
+  if (!p2) {
+    muted('skipped --binary: running from source, not a compiled binary.');
+    return;
+  }
+  try {
+    rmSync(p2, { force: true });
+    ok(`removed binary ${p2}`);
+  } catch (e) {
+    // Almost always EACCES: installed under /usr/local/bin via sudo.
+    warn(`couldn't remove ${p2}: ${(e as Error).message}`);
+    muted(`  remove it yourself: sudo rm ${p2}`);
+  }
+}

--- a/cli/src/compose.ts
+++ b/cli/src/compose.ts
@@ -146,6 +146,28 @@ function listServices(f: ComposeFile): Record<string, string> {
   return out;
 }
 
+// Image refs (repo:tag) of the project's containers — running or stopped.
+// `start` uses this to warn when an already-up stack is a different version
+// than the install expects (e.g. a stale locally-tagged build, or a
+// :pocket/dev image, masking the release the .env pins).
+export function runningImageRefs(file: ComposeFile): string[] {
+  const r = spawnSync(
+    'docker',
+    ['compose', '-f', file.file, 'ps', '--format', 'json', '--all'],
+    { cwd: getSubwaveHome(), encoding: 'utf8' },
+  );
+  if (r.status !== 0) return [];
+  const refs = new Set<string>();
+  for (const line of r.stdout.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const row = JSON.parse(line) as { Image?: string };
+      if (row.Image) refs.add(row.Image);
+    } catch { /* skip bad lines */ }
+  }
+  return [...refs];
+}
+
 // BYO mode honours the same WEB_PORT / CONTROLLER_PORT / ICECAST_PORT env
 // vars the byo-proxy compose file uses, so the operator can override host
 // bindings without the CLI losing track of where the services actually live.

--- a/cli/src/docker.ts
+++ b/cli/src/docker.ts
@@ -38,6 +38,20 @@ export function composeDown(file: ComposeFile): Promise<number> {
   return run(file, ['down']);
 }
 
+// `docker compose down` with optional `-v` (remove named volumes) and
+// `--rmi all` (remove the service images). Only `subwave uninstall` reaches
+// for these — the command layer gates them behind explicit flags + a confirm,
+// because `-v` is destructive and `--rmi all` forces a re-pull next install.
+export function composeDownFull(
+  file: ComposeFile,
+  opts: { volumes?: boolean; rmi?: boolean } = {},
+): Promise<number> {
+  const a = ['down', '--remove-orphans'];
+  if (opts.volumes) a.push('-v');
+  if (opts.rmi) a.push('--rmi', 'all');
+  return run(file, a);
+}
+
 export function composeRestart(file: ComposeFile, service: string): Promise<number> {
   return run(file, ['restart', service]);
 }


### PR DESCRIPTION
## Why

Follow-up to the v0.1.30 install session. Two gaps surfaced:

1. **No uninstall path.** There was no clean way to tear an install down — operators had to `docker compose down` by hand and manually delete `~/subwave` + `~/.config/subwave`.
2. **Stale stack masked a fresh install.** A 44-min-old `:pocket` stack (same fixed `container_name`s) made `subwave start`/`init` report "already up", so the new v0.1.30 stack never started — and `subwave setup` then 401'd against the stale controller (different admin password).

## `subwave uninstall`

Tiered so the common case is safe:

| command | effect |
|---|---|
| `subwave uninstall` | `docker compose down`, remove compose files + `.env` + CLI config — **keeps `state/`** (settings, secrets, sessions, jingles, tags) |
| `--purge` | also remove the whole install dir (incl. `state/`) + named volumes |
| `--images` | also remove the pulled ghcr images (`down --rmi all`) |
| `--binary` | also remove the `subwave` binary (skipped from source; sudo hint on EACCES) |
| `--yes` | skip the confirmation |

- **Clone-mode homes are never file-deleted** — only the stack is brought down (won't nuke a dev checkout).
- Handled before the resolved-home gate, so it works on a half-broken install and can still clean up CLI config/binary when there's no home.

## Version-mismatch warning

`subwave start`'s "already running" branch now compares the running images' tags against the expected version (`SUBWAVE_VERSION` env → root `.env` → `latest`) and warns on mismatch, pointing at `subwave stop` → `start`. This is exactly the signal that would have flagged the `:pocket` situation immediately.

## Verification (local, isolated HOME)

- Help lists `uninstall` + flags.
- Default uninstall: removes compose/`.env`/config, **keeps `state/`** ✓
- `--purge`: removes the whole install dir ✓
- Clone-mode: source files left untouched, only stack down + config removed ✓
- Version warning: silent when running `:latest` matches expected `latest`; fires when `SUBWAVE_VERSION` is pinned to a different tag ✓
- `tsc --noEmit` clean; arm64 binary builds.