### PR TITLE
fix(web): keep Firefox on MP3 mount (Opus goes silent on track change)

### DIFF
--- a/web/hooks/usePlayer.ts
+++ b/web/hooks/usePlayer.ts
@@ -83,23 +83,30 @@ export function usePlayer({ initialVolume = 1 }: UsePlayerOptions = {}): Player 
     if (audioRef.current) audioRef.current.volume = volume;
   }, [volume]);
 
-  // Pick Opus on browsers that *definitively* decode it (Chrome, Firefox,
-  // Edge — they return 'probably' for Ogg-Opus). Safari iOS/iPadOS returns
-  // 'maybe' but its AVFoundation Opus decoder doesn't handle live Ogg over
-  // Icecast — the first crossfade hits an Ogg page-chain boundary it can't
-  // tolerate and decoding silently stops with no error event for the
-  // watchdog to catch. Two layers of defence: require 'probably' (drops
-  // Safari's optimistic 'maybe' answer), and skip the upgrade entirely on
-  // iOS-family devices (iPad on iPadOS 13+ reports the desktop Macintosh UA
-  // so we also check maxTouchPoints to identify it). Everyone falling
-  // through stays on the universal MP3 192 kbps mount.
+  // Pick Opus on browsers that *definitively* decode it (Chrome, Edge — they
+  // return 'probably' for Ogg-Opus). Two browser families say they can decode
+  // Opus but choke on the live chained Ogg stream Icecast emits at a crossfade
+  // boundary, going silent at the first track change with no error/stalled
+  // event for the watchdog to catch — so we keep both on the universal MP3
+  // 192 kbps mount instead:
+  //   • Safari iOS/iPadOS — returns the optimistic 'maybe', and its
+  //     AVFoundation Opus decoder can't tolerate the Ogg page-chain boundary.
+  //   • Firefox/Gecko — returns 'probably', decodes Opus fine in general, but
+  //     its media stack can't follow the chained Ogg stream either (issue #212).
+  // Three layers of defence: require 'probably' (drops Safari's 'maybe'), skip
+  // iOS-family devices (iPad on iPadOS 13+ reports the desktop Macintosh UA so
+  // we also check maxTouchPoints), and skip Firefox by UA.
   useEffect(() => {
     if (!OPUS_STREAM_URL) return;
     const ua = navigator.userAgent;
     const isIOS =
       /iPad|iPhone|iPod/.test(ua) ||
       (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1);
-    if (isIOS) return;
+    // Desktop/Android Firefox + Gecko forks (LibreWolf, Waterfox) carry
+    // "Firefox" in the UA; Firefox-for-iOS reports "FxiOS" and is already
+    // caught by isIOS above, so /firefox/i doesn't double-handle it.
+    const isFirefox = /firefox/i.test(ua);
+    if (isIOS || isFirefox) return;
     const tester = document.createElement('audio');
     const opusOk = tester.canPlayType('audio/ogg; codecs=opus');
     if (opusOk === 'probably') {


### PR DESCRIPTION
## Problem

Closes #212. On Firefox, the Opus Icecast stream keeps flowing (bytes visible in the devtools Network tab) but audio goes **silent the moment the song changes** — "only works for one song".

This is the same class of bug already fixed for Safari iOS/iPadOS in `861b68f`. The player upgrades any browser whose `canPlayType('audio/ogg; codecs=opus')` returns `'probably'` onto the `/stream.opus` mount. Firefox returns `'probably'`, so it gets Opus — but Firefox's media stack can't follow the **chained Ogg-Opus stream** Liquidsoap/Icecast emits at a crossfade boundary. Decoding silently stops with no `error`/`waiting`/`stalled` event, so the existing stall watchdog never fires. The break is structural (every crossfade, starting with the first), so a reconnect-on-stall watchdog would only force an audible reload on every single song.

## Fix

Mirror the iOS/Safari remedy: exclude Firefox/Gecko from the Opus upgrade so it stays on the universal MP3 192 kbps mount. Single effect in `web/hooks/usePlayer.ts`:

```ts
const isFirefox = /firefox/i.test(ua);
if (isIOS || isFirefox) return;
```

- `/firefox/i` matches desktop & Android Firefox plus Gecko forks (LibreWolf, Waterfox) — all share the same media stack and bug.
- Firefox-for-iOS reports `FxiOS` (not `Firefox`) and is already caught by the existing `isIOS` check, so there's no double-handling.
- Chrome / Edge / Brave / Opera (Chromium, no "firefox" in UA) keep the Opus path unchanged.

## Verification

- `cd web && npm run lint` (eslint + `tsc --noEmit`, the CI merge gate) — passes clean.
- Manual smoke test to do post-merge: Firefox should request `stream.mp3` and survive a track change; Chrome should still request `stream.opus`.