### PR TITLE
chore: bump features to minor pre-1.0 (feat → minor)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": false,
   "packages": {
     ".": {
       "package-name": "subwave",


### PR DESCRIPTION
## Summary

Sets `bump-patch-for-minor-pre-major: false` in `release-please-config.json` so pre-1.0 `feat:` commits bump the **minor** version instead of the patch.

Right now (`bump-patch-for-minor-pre-major: true`) every release — even ones carrying `feat:` work — only bumps the patch, which is why we've been climbing `0.1.28 → 0.1.29 → 0.1.30` indefinitely. With this flipped:

- The next release (**PR #218**, which carries `feat:` commits) lands as **`0.2.0`**.
- Future feature releases move `0.3.0`, `0.4.0`, …
- Fix-only releases still bump the patch (`0.2.1`).

`bump-minor-pre-major: true` is left as-is, so breaking changes still bump minor (not major) while we're pre-1.0.

## Test plan
- [x] Merge this into `develop`, then merge the release PR (#218) into `main` with a merge commit
- [x] Confirm release-please opens a `chore(main): release 0.2.0` PR (not `0.1.31`)