### PR TITLE
fix(broadcast): fatten Icecast burst + queue buffers to cut mobile stalls

### DIFF
--- a/docker/icecast.xml.template
+++ b/docker/icecast.xml.template
@@ -5,12 +5,19 @@
     <limits>
         <clients>100</clients>
         <sources>4</sources>
-        <queue-size>524288</queue-size>
+        <!-- queue-size: per-client backlog before Icecast drops a lagging
+             listener. 1 MB ≈ 43s of MP3 / 85s of Opus — gives jittery mobile
+             and Cloudflare-proxied clients more rope before they're kicked. -->
+        <queue-size>1048576</queue-size>
         <client-timeout>30</client-timeout>
         <header-timeout>15</header-timeout>
         <source-timeout>10</source-timeout>
         <burst-on-connect>1</burst-on-connect>
-        <burst-size>65535</burst-size>
+        <!-- burst-size: audio bursted to a client on connect to prime its
+             buffer. 256 KB ≈ 10s of MP3 / 20s of Opus (was 64 KB ≈ 2.6s/5s),
+             so a brief mobile network blip drains the buffer instead of
+             stalling and forcing the player's watchdog to reconnect. -->
+        <burst-size>262144</burst-size>
     </limits>
 
     <authentication>


### PR DESCRIPTION
## What

Bump the Icecast buffer limits in \`docker/icecast.xml.template\`:
- \`burst-size\` 64 KB → **256 KB** (~10s MP3 / ~20s Opus primed on connect, was ~2.6s/5s)
- \`queue-size\` 512 KB → **1 MB** (per-client backlog before a lagging listener is dropped)

## Why

Mobile/Cloudflare-proxied listeners were getting intermittent ~2s dropouts. Diagnosis from the live Icecast access log showed listener sessions ending mid-song in near-identical duration pairs — the web player's stall watchdog (\`web/hooks/usePlayer.ts\`) firing on \`waiting\`/\`stalled\` and reconnecting with a fresh \`?t=\` URL. Each reconnect logs as a "disconnect".

Crucially, the **server bus was clean throughout** — no Liquidsoap underruns, no source switches during the gaps. So this is purely a *client-buffer cushion* problem: the thin 64 KB burst (~5s of Opus) drained on jittery mobile networks before the player could refill, triggering a stall. A deeper burst gives clients enough pre-buffered audio to ride out the jitter.

## Testing

- Rebuilt the broadcast image and recreated the container on the live host
- Confirmed the loaded config (\`/etc/icecast2/icecast.xml\`, launched via \`-c\`) carries the new values
- Both mounts back on-air (MP3 192 + Opus), Liquidsoap log clean on restart
- Operator confirmed mobile playback is stable after the change

## Deploy note

The template is baked into the broadcast image, so this needs \`docker compose up -d --build broadcast\` (or a published-image bump) to take effect — a plain restart reuses the old baked template.