### PR TITLE
feat: DJ mode + daypart energy + cross-hour memory (#216 stages 1–3)

### DIFF
--- a/controller/src/audio/kokoro.ts
+++ b/controller/src/audio/kokoro.ts
@@ -152,7 +152,7 @@ async function ensureWorker(): Promise<KokoroWorker> {
 
 export async function speak(
   text: string,
-  { outPath: customPath, voice }: { outPath?: string; voice?: string } = {},
+  { outPath: customPath, voice, speedScale }: { outPath?: string; voice?: string; speedScale?: number } = {},
 ): Promise<string> {
   if (!text || !text.trim()) throw new Error('Empty TTS text');
   await mkdir(config.piper.outDir, { recursive: true });
@@ -166,7 +166,8 @@ export async function speak(
     text: text.trim(),
     voice: voice || config.kokoro.voice,
     lang: config.kokoro.lang,
-    speed: config.kokoro.speed,
+    // Per-call speedScale (daypart energy) composes on top of the config speed.
+    speed: config.kokoro.speed * (speedScale != null ? speedScale : 1),
     out: outPath,
   });
   return msg.path;

--- a/controller/src/audio/piper.ts
+++ b/controller/src/audio/piper.ts
@@ -9,7 +9,10 @@ import { config } from '../config.js';
 
 await mkdir(config.piper.outDir, { recursive: true });
 
-export async function speak(text: string, { outPath: customPath }: { outPath?: string } = {}): Promise<string> {
+export async function speak(
+  text: string,
+  { outPath: customPath, speedScale }: { outPath?: string; speedScale?: number } = {},
+): Promise<string> {
   if (!text || !text.trim()) throw new Error('Empty TTS text');
 
   const id = crypto.randomBytes(6).toString('hex');
@@ -27,9 +30,11 @@ export async function speak(text: string, { outPath: customPath }: { outPath?: s
   ];
   // Piper expresses speech rate as length_scale — the per-phoneme duration
   // multiplier, where HIGHER is slower. We carry a "speed" multiplier
-  // everywhere (lower = slower), so invert it here. Only passed when it
-  // actually differs from default so unchanged stations behave identically.
-  const speed = config.piper.speed;
+  // everywhere (lower = slower), so invert it here. The per-call speedScale
+  // (daypart energy) composes on top of the configured speed; only passed to
+  // Piper when the result differs from 1.0 so unchanged stations behave
+  // identically.
+  const speed = config.piper.speed * (speedScale != null ? speedScale : 1);
   if (speed && speed > 0 && speed !== 1.0) {
     args.push('--length_scale', String(1 / speed));
   }

--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -11,6 +11,7 @@ import * as pocketTts from './pocketTts.js';
 import * as cloud from '../llm/speech.js';
 import * as settings from '../settings.js';
 import { recordTts } from '../stats.js';
+import { energyForDaypart } from '../context.js';
 
 export const ENGINES = ['piper', 'kokoro', 'chatterbox', 'pocket-tts', 'cloud'];
 
@@ -128,14 +129,29 @@ function normalizeForSpeech(text: string) {
 //
 // Every call is timed and recorded into the TTS ring buffer (stats.js) so the
 // admin Stats page can show per-engine usage, latency, and the fallback rate.
-export async function speak(text: string, { kind = 'default', outPath }: { kind?: string; outPath?: string } = {}) {
+export async function speak(
+  text: string,
+  { kind = 'default', outPath, speedScale }: { kind?: string; outPath?: string; speedScale?: number } = {},
+) {
   const speakText = normalizeForSpeech(text);
   const personaTts = djPersonaTts(kind);
   const primary = resolveEngine(kind, personaTts);
+  // Delivery pace tracks the daypart for live, persona-voiced segments.
+  // `speedScale` is a MULTIPLIER on the engine's configured speech rate (1.0 =
+  // unchanged), so it composes with — rather than overrides — an operator's
+  // global PIPER_SPEED/KOKORO_SPEED/CLOUD_TTS_SPEED. An explicit scale (e.g. a
+  // future talk-up-to-post line budget) always wins; otherwise persona-voiced
+  // kinds inherit the daypart energy. Persona-agnostic kinds (jingle/default)
+  // are skipped — jingles are pre-rendered offline, so a jingle cut at 2am must
+  // not carry 2am pacing into a noon playout. A daypart scale of 1.0
+  // (afternoon) composes to the config default, so the station is unchanged.
+  const scale = speedScale != null
+    ? speedScale
+    : (GLOBAL_VOICE_KINDS.has(kind) ? undefined : energyForDaypart().speed);
   const started = Date.now();
   const chars = (speakText || '').length;
   try {
-    const result = await speakWith(primary, speakText, { outPath }, personaTts);
+    const result = await speakWith(primary, speakText, { outPath, speedScale: scale }, personaTts);
     recordTts({
       kind, engine: primary, requested: primary, fellBack: false,
       ok: true, ms: Date.now() - started, chars, t: new Date().toISOString(),
@@ -156,7 +172,7 @@ export async function speak(text: string, { kind = 'default', outPath }: { kind?
     }
     console.error(`[tts] ${primary} failed for kind=${kind}: ${err.message} — falling back to ${fallback}`);
     try {
-      const result = await speakWith(fallback, speakText, { outPath }, personaTts);
+      const result = await speakWith(fallback, speakText, { outPath, speedScale: scale }, personaTts);
       recordTts({
         kind, engine: fallback, requested: primary, fellBack: true,
         ok: true, ms: Date.now() - started, chars, t: new Date().toISOString(),

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -43,9 +43,17 @@ const REQUEST_SCHEMA = z.object({
 // models. PICKER_CRITERIA stays because it's editorial preference (flow,
 // context, variety, interest) — that's not in any tool or schema.
 export function pickSystem() {
-  return `${settings.agentPersonaPreamble(settings.getEffectivePersona(), { rules: false })}
+  const persona = settings.getEffectivePersona();
+  // In DJ mode, lean on the live session history: a working DJ runs threads
+  // and calls back to a track or a remark from earlier in the shift. This pairs
+  // with the cross-hour memory in broadcast/session.ts, which now keeps that
+  // history alive across daypart turnovers.
+  const djModeLine = persona?.djMode
+    ? `\n\nYou're in full DJ mode — keep the thread alive across tracks: call back to something you played or said earlier in this session when it fits, and build a little momentum rather than treating each pick as isolated.`
+    : '';
+  return `${settings.agentPersonaPreamble(persona, { rules: false })}
 
-You run the station as one continuous shift. The messages above are the live session.
+You run the station as one continuous shift. The messages above are the live session.${djModeLine}
 
 ${dj.PICKER_CRITERIA}`;
 }
@@ -214,13 +222,21 @@ export async function runTrackEvent(queue, ctx, { wantLink }) {
   return withTrace({ kind: 'track-event', wantLink }, async () => {
     const current = queue.current?.track || null;
     const previous = queue.history[0]?.track || null;
+    const djMode = !!settings.getEffectivePersona()?.djMode;
 
+    // The link clause differs in DJ mode: a working DJ doesn't just ease into
+    // the next track, they TEASE it — name the artist or capture its feel so
+    // listeners know what's coming. The agent already knows its own pick when
+    // it writes `say`, so this costs nothing extra.
+    const linkClause = wantLink
+      ? (djMode
+          ? ` Also write a short link that airs as your pick starts: back-announce "${current?.title}", then tease what's next — name the artist or capture the feel of the track you pick so listeners know what's coming.`
+          : ` Also write a short link that airs as your pick starts: back-announce "${current?.title}" and lead into the track you pick.`)
+      : ' Stay silent — no link this time.';
     const eventText = `Now playing "${current?.title}" by ${current?.artist}`
       + (previous ? ` (after "${previous.title}" by ${previous.artist})` : '')
       + '. Pick the track to play next.'
-      + (wantLink
-          ? ` Also write a short link that airs as your pick starts: back-announce "${current?.title}" and lead into the track you pick.`
-          : ' Stay silent — no link this time.');
+      + linkClause;
     session.appendTurn({ role: 'event', kind: 'pick', text: eventText });
 
     if (settings.get().llm?.pickerAgent) {

--- a/controller/src/broadcast/dj-gate.ts
+++ b/controller/src/broadcast/dj-gate.ts
@@ -13,7 +13,9 @@
 import * as settings from '../settings.js';
 
 export function shouldFire(kind, now = new Date()) {
-  const f = settings.getEffectivePersona(now)?.frequency || 'moderate';
+  // effectiveFrequency bumps a DJ-mode persona one rung up the ladder, so it
+  // drops more idents / time checks — a working DJ marks the clock more often.
+  const f = settings.effectiveFrequency(settings.getEffectivePersona(now));
   const m = now.getMinutes();
 
   if (kind === 'stationId') {

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -23,8 +23,10 @@ import * as scrobble from './scrobble.js';
 //   quiet      → uniform 8-20 tracks between links
 //   moderate   → current behaviour (1-9 85% of the time, 10-15 the other 15%)
 //   aggressive → uniform 1-3 tracks
+// A DJ-mode persona reads one rung chattier (effectiveFrequency), so it links
+// transitions far more often — a working DJ talks across most of them.
 function pickLinkInterval() {
-  const f = settings.getEffectivePersona()?.frequency || 'moderate';
+  const f = settings.effectiveFrequency();
   if (f === 'quiet')      return 8 + Math.floor(Math.random() * 13);
   if (f === 'aggressive') return 1 + Math.floor(Math.random() * 3);
   if (Math.random() < 0.15) return 10 + Math.floor(Math.random() * 6);

--- a/controller/src/broadcast/session.ts
+++ b/controller/src/broadcast/session.ts
@@ -66,11 +66,16 @@ function scenarioText(s: any) {
   return `Autonomous block begins — ${bits.join(', ')}.`;
 }
 
-// One-line summary of a finished session, carried into the next as continuity.
-// Intentionally omits the "recently aired" track list — leaking the previous
-// session's titles into the new picker's prompt window biases it toward
-// re-picking those same tracks (observed cause of 6-8× daily repeats).
-// The picker has its own recents window for blocking repeats.
+// Compact continuity summary of a finished session, carried into the next one
+// (only on a HARD roll now — a show boundary or the 4h cap; daypart turnovers
+// keep the live session instead, see maybeRoll). Enriched with the prior
+// persona + mood so a new program still opens with a sense of where the station
+// just was.
+//
+// STILL intentionally omits the "recently aired" track list — leaking the
+// previous session's titles into the new picker's prompt window biases it
+// toward re-picking those same tracks (observed cause of 6-8× daily repeats).
+// The picker has its own recents window for blocking repeats. Do not add titles.
 function buildHandoff(prev: any) {
   if (!prev) return null;
   const lastSpoken = [...prev.messages].reverse()
@@ -78,8 +83,10 @@ function buildHandoff(prev: any) {
   const parts = [
     prev.kind === 'show'
       ? `the show "${prev.show?.name}"`
-      : `a ${prev.scenario.period || ''} block`,
+      : `a ${prev.scenario?.period || ''} block`,
   ];
+  if (prev.persona?.name) parts.push(`hosted as ${prev.persona.name}`);
+  if (prev.scenario?.mood) parts.push(`mood ${prev.scenario.mood}`);
   if (lastSpoken?.text) parts.push(`you last said: "${lastSpoken.text.slice(0, 120)}"`);
   return parts.join(' — ');
 }
@@ -154,14 +161,47 @@ async function end() {
   logEvent('session.end', { sessionId: _session.id, key: _session.key });
 }
 
-// End + restart if the context no longer matches the live session.
+// Decide whether to keep the live session or roll to a fresh one.
+//
+// A daypart/mood turnover *within* an autonomous run is NOT a program change —
+// it's the same DJ on the same shift, so the session (and its chat history)
+// continues across it via a soft shift. That's what lets the DJ run a thread or
+// call back to a track from earlier in the hour. Only two things hard-roll to a
+// clean slate (with a handoff line): a genuine show boundary (a scheduled
+// program begins, ends, or changes — `show:<id>` in the old or new key) and the
+// 4h MAX_SESSION_MS safety cap.
 export async function maybeRoll(ctx: any): Promise<any> {
   if (!_session) return start(ctx);
+  const nextKey = sessionKeyFor(ctx);
   const aged = Date.now() - new Date(_session.startedAt).getTime() > MAX_SESSION_MS;
-  if (_session.key === sessionKeyFor(ctx) && !aged) return _session;
+  if (_session.key === nextKey && !aged) return _session;
+
+  const bothAuto = _session.key.startsWith('auto:') && nextKey.startsWith('auto:');
+  if (bothAuto && !aged) return softShift(ctx, nextKey);
+
   const prev = _session;
   await end();
   return start(ctx, buildHandoff(prev));
+}
+
+// Soft continuation across an autonomous daypart/mood turnover: same session id,
+// same messages, refreshed identity + scenario. The shift is marked on the
+// timeline as a `scenario` turn (filtered out of the agent window like other
+// scenario turns, so it adds no prompt noise). No archive, no handoff — the
+// running history simply carries forward and the existing WINDOW_TURNS window
+// now spans the boundary.
+function softShift(ctx: any, nextKey: string): any {
+  _session.key = nextKey;
+  _session.scenario = scenarioOf(ctx);
+  const sc = _session.scenario;
+  const label = [
+    sc.period,
+    sc.mood ? `mood ${sc.mood}` : null,
+    sc.weather ? `weather ${sc.weather}` : null,
+  ].filter(Boolean).join(', ');
+  appendTurn({ role: 'event', kind: 'scenario', text: `Shift continues — now ${label}.` });
+  logEvent('session.shift', { sessionId: _session.id, key: _session.key });
+  return _session;
 }
 
 // The bounded chat window fed to the DJ agent — handoff + the last N turns,

--- a/controller/src/context.ts
+++ b/controller/src/context.ts
@@ -152,6 +152,39 @@ export function getClockContext(date = new Date()) {
   };
 }
 
+// Vocal energy for the moment — how the DJ should *sound*, not what it says.
+// `speed` is a multiplier on the engine's default speech rate (>1 brisker,
+// <1 slower); higher is faster on every engine that supports it (piper,
+// kokoro, cloud). `register` is a coarse delivery label carried forward for
+// future style/emotion hints (cloud/chatterbox) — Stage 1 only acts on speed.
+//
+// Pure function of the existing daypart + clock so there's a single source of
+// truth and it's trivially testable. A daypart that maps to speed 1.0
+// (afternoon) yields no change at all, so a station with the default
+// afternoon profile behaves exactly as before.
+const DAYPART_ENERGY: Record<string, { speed: number; register: string }> = {
+  'early-morning': { speed: 0.98, register: 'warm' },      // gentle waking
+  morning:         { speed: 1.02, register: 'even' },      // productive
+  midday:          { speed: 1.06, register: 'up' },        // lunch-hour lift
+  afternoon:       { speed: 1.0,  register: 'even' },       // neutral baseline
+  'drive-time':    { speed: 1.06, register: 'up' },        // drive-home energy
+  evening:         { speed: 0.97, register: 'warm' },      // wind down
+  'late-evening':  { speed: 0.94, register: 'intimate' },  // late hours
+  'after-hours':   { speed: 0.92, register: 'intimate' },  // graveyard
+};
+
+export function energyForDaypart(date = new Date()) {
+  const { period } = getTimeContext(date);
+  const { isLateNight, isCommute } = getClockContext(date);
+  const base = DAYPART_ENERGY[period] || { speed: 1.0, register: 'even' };
+  // The small hours pull the pace down regardless of which daypart label the
+  // hour technically falls under (e.g. the 00:00–01:00 tail of 'late-evening').
+  if (isLateNight) return { speed: Math.min(base.speed, 0.92), register: 'intimate' };
+  // Commute windows get a touch more push than their daypart baseline.
+  if (isCommute) return { speed: Math.max(base.speed, 1.05), register: 'up' };
+  return base;
+}
+
 // Combined snapshot — what's the vibe right now?
 export async function getFullContext() {
   const now = new Date();

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -321,7 +321,12 @@ export async function generateLink({ previous, current, context, recap = null, r
   if (previous?.title) ctxLines.push(`Just played: "${previous.title}" by ${previous.artist || 'unknown'}`);
   if (current?.title) ctxLines.push(`Now playing: "${current.title}" by ${current.artist || 'unknown'}`);
 
-  const prompt = `Write a DJ link between tracks. Back-announce what just played and ease into what's playing now. ${lengthPhrase('link')}, conversational, don't list both titles like a robot — pick one to mention specifically and treat the other lightly.\n\n${ctxLines.join('\n')}`;
+  // DJ-mode personas tease what's coming, not just back-announce — mirrors the
+  // agent path in broadcast/dj-agent.ts so both pickers feel like the same DJ.
+  const teaseClause = settings.getEffectivePersona()?.djMode
+    ? ` Tease what's coming — name the artist or capture the feel so listeners know what's next.`
+    : '';
+  const prompt = `Write a DJ link between tracks. Back-announce what just played and ease into what's playing now.${teaseClause} ${lengthPhrase('link')}, conversational, don't list both titles like a robot — pick one to mention specifically and treat the other lightly.\n\n${ctxLines.join('\n')}`;
 
   return djText({
     system: djSystem(),

--- a/controller/src/llm/speech.ts
+++ b/controller/src/llm/speech.ts
@@ -107,7 +107,7 @@ export function isConfigured(providerOverride: string | null = null) {
 // provider + voice while still sharing the global model + apiKey from Settings.
 export async function speak(
   text: string,
-  { outPath, cloudOverride = null }: { outPath?: string; cloudOverride?: any } = {},
+  { outPath, cloudOverride = null, speedScale }: { outPath?: string; cloudOverride?: any; speedScale?: number } = {},
 ) {
   if (!text || !text.trim()) throw new Error('Empty TTS text');
   const base = cloudCfg();
@@ -127,12 +127,15 @@ export async function speak(
     c.apiKey = base.apiKey;
   }
 
-  // Speech rate (CLOUD_TTS_SPEED / TTS_SPEED), clamped to the provider's
-  // range. Only sent when it differs from default so default stations are
-  // unaffected and providers that ignore the field never see it. Skipped for
-  // openai-compatible — local engines vary on whether they accept `speed`.
+  // Speech rate — the per-call speedScale (daypart energy) composes on top of
+  // CLOUD_TTS_SPEED / TTS_SPEED, then clamped to the provider's range. Only
+  // sent when it differs from default so default stations are unaffected and
+  // providers that ignore the field never see it. Skipped for openai-compatible
+  // — local engines vary on whether they accept `speed`.
   const isCompat = c.provider === 'openai-compatible';
-  const speed = isCompat ? 1.0 : clampSpeed(config.tts.cloudSpeed, c.provider);
+  const speed = isCompat
+    ? 1.0
+    : clampSpeed(config.tts.cloudSpeed * (speedScale != null ? speedScale : 1), c.provider);
 
   const result = await generateSpeech({
     model: speechModel(c),

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -197,6 +197,7 @@ router.get('/dj', async (req, res) => {
       tagline: persona?.tagline || '',
       soul: persona?.soul || '',
       frequency: persona?.frequency || 'moderate',
+      djMode: persona?.djMode === true,
       avatar: avatarUrlFor(persona?.id),
       station: s.station,
       location: s.weather?.locationName || '',

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -47,12 +47,29 @@ export const DJ_SOULS = [
   'quietly enthusiastic; treats every track like a small recommendation to a friend; specific over poetic',
 ];
 
+// Ordered ascending in chattiness — effectiveFrequency() steps up this ladder.
 export const FREQUENCIES = ['quiet', 'moderate', 'aggressive'];
 
 // Per-persona verbosity. 'concise' is the historical one-liner behaviour;
 // 'extended' roughly doubles every spoken segment for a storytelling DJ.
 // See llm/dj.js LENGTH_PHRASES for the actual length directives.
 export const SCRIPT_LENGTHS = ['concise', 'extended'];
+
+// DJ mode makes a persona behave like a working radio DJ rather than a
+// between-track narrator: it back-announces AND teases what's next, runs
+// threads/callbacks across the session (paired with the cross-hour memory in
+// broadcast/session.ts), and is generally more present. The "more present"
+// part is expressed here as a one-rung bump up the FREQUENCIES ladder, reused
+// by ident cadence (broadcast/dj-gate.ts), between-track segment floors
+// (skills/_agent.ts), and auto-link spacing (broadcast/queue.ts). A persona
+// with djMode off returns its base frequency unchanged, so a default station
+// behaves exactly as before.
+export function effectiveFrequency(persona: any = getEffectivePersona()) {
+  const base = FREQUENCIES.includes(persona?.frequency) ? persona.frequency : 'moderate';
+  if (!persona?.djMode) return base;
+  const i = FREQUENCIES.indexOf(base);
+  return FREQUENCIES[Math.min(i + 1, FREQUENCIES.length - 1)];
+}
 
 // TTS engines. Every spoken segment is voiced by the on-air persona's own
 // `tts` config (see audio/tts.js); only jingle rendering falls back to the
@@ -499,6 +516,7 @@ function normalizePersona(raw: any) {
     tagline: typeof raw.tagline === 'string' ? raw.tagline.trim().slice(0, 80) : '',
     frequency: FREQUENCIES.includes(raw.frequency) ? raw.frequency : 'moderate',
     scriptLength: SCRIPT_LENGTHS.includes(raw.scriptLength) ? raw.scriptLength : 'concise',
+    djMode: raw.djMode === true,
     soul,
     avatar,
     tts: normalizeTts(raw.tts),
@@ -996,6 +1014,16 @@ function validatePersonasStrict(raw) {
       }
       scriptLength = item.scriptLength;
     }
+    // djMode — optional boolean. Absent → false (a plain narrator persona, the
+    // historical behaviour). When true the persona behaves like a working DJ
+    // (forward-tease, callbacks, more presence) — see effectiveFrequency above.
+    let djMode = false;
+    if (item.djMode !== undefined && item.djMode !== null) {
+      if (typeof item.djMode !== 'boolean') {
+        throw new Error(`personas[${i}].djMode must be a boolean`);
+      }
+      djMode = item.djMode;
+    }
     const tts = validateTtsBlock(item.tts, `personas[${i}]`);
     // skills — optional. Absent → null ("all skills", legacy/default). Present
     // → an explicit slug array (the UI always sends one once edited).
@@ -1046,6 +1074,7 @@ function validatePersonasStrict(raw) {
       tagline,
       frequency: item.frequency,
       scriptLength,
+      djMode,
       soul,
       avatar,
       tts,

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -244,7 +244,9 @@ export async function agenticTick(ctx) {
 
   const now = new Date();
   const persona = settings.getEffectivePersona(now);
-  const freq = persona?.frequency || 'moderate';
+  // DJ-mode personas read one rung chattier, lowering the floor so more
+  // between-track segments (weather, curiosity, deep cuts) get through.
+  const freq = settings.effectiveFrequency(persona);
 
   // Floor on the gap between any two segments.
   if (now.getTime() - segmentState.lastAnySegment < frequencyFloorMs(freq)) return;

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -65,6 +65,10 @@ interface Persona {
   tagline: string;
   frequency: string;
   scriptLength: string;
+  // When true the persona behaves like a working DJ — back-announces AND teases
+  // what's next, runs callbacks across the session, and is more present. Off =
+  // the historical tasteful-narrator behaviour.
+  djMode: boolean;
   soul: string;
   // Stored basename like `p_abc123.png` — empty when no avatar is uploaded.
   // The actual image is served via /api/persona-avatar/<id>; we keep the
@@ -382,6 +386,7 @@ export default function PersonasPanel() {
             tagline: p.tagline ?? '',
             frequency: p.frequency ?? 'moderate',
             scriptLength: p.scriptLength ?? 'concise',
+            djMode: p.djMode === true,
             soul: p.soul ?? '',
             avatar: typeof p.avatar === 'string' ? p.avatar : '',
             tts: {
@@ -414,7 +419,7 @@ export default function PersonasPanel() {
         ...f,
         personas: [...f.personas, {
           id: clientMintId(), name: 'New persona', tagline: '',
-          frequency: 'moderate', scriptLength: 'concise', soul: '',
+          frequency: 'moderate', scriptLength: 'concise', djMode: false, soul: '',
           avatar: '',
           tts: { engine: 'piper', cloudProvider: 'openai', voice: 'bf_isabella' },
           skills: (data?.skills?.catalog || []).map(s => s.name),
@@ -547,6 +552,7 @@ export default function PersonasPanel() {
             tagline: p.tagline.trim(),
             frequency: p.frequency,
             scriptLength: p.scriptLength,
+            djMode: p.djMode,
             soul: p.soul.trim(),
             avatar: p.avatar || '',
             tts: {
@@ -898,6 +904,23 @@ export default function PersonasPanel() {
                   onSelect={() => setPersona(safeIdx, { scriptLength: s.id })}
                 />
               ))}
+            </div>
+
+            <div className="rule-label">DJ mode</div>
+
+            <div className="grid grid-cols-[1fr_auto] items-center gap-4">
+              <div>
+                <div className="text-[13px] font-bold">Work the desk like a real DJ</div>
+                <div className="mt-0.5 text-[11px] text-muted">
+                  Back-announces and teases what&apos;s coming next, runs callbacks across the
+                  hour, and talks more often. Off keeps this persona a tasteful between-track
+                  narrator.
+                </div>
+              </div>
+              <Toggle
+                on={focused.djMode}
+                onClick={() => setPersona(safeIdx, { djMode: !focused.djMode })}
+              />
             </div>
           </Card>
 


### PR DESCRIPTION
Implements the first three (dependency-free) stages of the AI-DJ upgrades scoped in #216, plus a per-persona **DJ mode** that orchestrates them.

Everything degrades to today's behaviour when its input is absent — a `djMode:false` persona, a daypart that maps to neutral pace, or an operator's custom TTS speed. **No broadcast-bus changes**; no new dependencies.

## Stage 1 — Daypart vocal energy (global)
Speech *delivery* now tracks the daypart the DJ already knows: brisker at midday/drive-time, slower and more intimate in the small hours.
- `context.ts`: pure `energyForDaypart()` → `{ speed, register }` from the existing dayparts + late-night/commute flags.
- `tts.speak()` resolves a per-call `speedScale` for live persona-voiced segments (jingles excluded) and threads it to Piper/Kokoro/cloud. It's a **multiplier** on the engine's configured speed, so it *composes* with `PIPER_SPEED`/`KOKORO_SPEED`/`CLOUD_TTS_SPEED` rather than overriding them. Afternoon = 1.0 → byte-identical to today.

## Stage 2 — Cross-hour memory (global)
The session used to wipe its whole chat history every time the auto key flipped (~hourly), so the DJ couldn't call back across the hour.
- `session.ts` `maybeRoll()`: a daypart/mood turnover within an autonomous run is now a **soft shift** — same session id + messages — so the existing window spans the boundary.
- Only a real show boundary (`show:<id>`) or the 4h cap still hard-rolls. `buildHandoff()` enriched (persona + mood) but still deliberately title-free.

## Stage 3 — Per-persona DJ mode
A `djMode` toggle that turns a persona from a tasteful narrator into a working DJ. Off by default.
- **Forward-tease** (the missing primitive): the agent back-announces *and* teases the track it's about to play.
- **Callbacks**: picker prompt leans on the now-preserved session history.
- **Presence**: shared `settings.effectiveFrequency()` bumps a DJ-mode persona one rung up the chattiness ladder — reused by auto-link spacing, ident cadence, and the segment floor.
- Web persona-editor toggle; surfaced on `/dj`.

## Verification
- `npm run lint` (eslint + `tsc --noEmit`) green in **both** `controller/` and `web/`.
- `energyForDaypart` checked across all 8 dayparts + late-night/commute overrides; engine compose math confirmed (default×afternoon = 1.0 → nothing passed).
- `maybeRoll` behaviourally tested: auto→auto keeps id + history; auto→show hard-rolls with an enriched, title-free handoff.
- `effectiveFrequency` ladder verified (caps at aggressive; returns base unchanged when off).

Not verified in-sandbox: actual rendered-WAV pace (needs Piper/Kokoro models) and live on-air behaviour — that's the live-stack check.

## Not in this PR (the dependency-heavy back half of #216)
Stage 4 (offline track-analysis pass: bpm/key/intro_ms via the `tts-heavy` sidecar + new `library-db` columns), Stage 5 (tempo/harmonic-aware selection), Stage 6 (talk-up-to-the-post). DJ mode deepens further once those land, but stands on its own today.
