### PR TITLE
feat(web): surface 'engine off' on the acoustic-analysis meter

### DIFF
--- a/controller/src/music/library-coverage.ts
+++ b/controller/src/music/library-coverage.ts
@@ -10,8 +10,13 @@
 import * as subsonic from './subsonic.js';
 import * as library from './library.js';
 import * as db from './library-db.js';
+import * as analyzer from './analyzer.js';
 
 const STALE_MS = 6 * 60 * 60 * 1000; // 6 h
+// Acoustic-analysis backend availability is probed separately: analyzer
+// .isAvailable() can do a 5 s sidecar HTTP probe and doesn't cache a negative
+// result, so we memoise it on a short TTL rather than re-probe on every poll.
+const ANALYSIS_PROBE_TTL_MS = 60 * 1000; // 1 min
 
 interface CoverageCache {
   total: number;
@@ -21,6 +26,29 @@ interface CoverageCache {
 
 const cache: CoverageCache = { total: 0, scannedAt: null, scanning: false };
 let inflight: Promise<void> | null = null;
+
+// Last known acoustic-analysis backend state. `null` until first probed.
+let analysisAvail: { available: boolean; backend: string; checkedAt: number } | null = null;
+let analysisProbeInflight: Promise<void> | null = null;
+
+function refreshAnalysisAvail() {
+  if (analysisProbeInflight) return analysisProbeInflight;
+  analysisProbeInflight = (async () => {
+    try {
+      const available = await analyzer.isAvailable();
+      analysisAvail = { available, backend: analyzer.backendLabel(), checkedAt: Date.now() };
+    } catch {
+      analysisAvail = { available: false, backend: 'none', checkedAt: Date.now() };
+    } finally {
+      analysisProbeInflight = null;
+    }
+  })();
+  return analysisProbeInflight;
+}
+
+function analysisAvailStale() {
+  return !analysisAvail || Date.now() - analysisAvail.checkedAt > ANALYSIS_PROBE_TTL_MS;
+}
 
 async function doScan() {
   cache.scanning = true;
@@ -55,6 +83,11 @@ function isStale() {
 export async function get() {
   await library.load();
   if (isStale() && !cache.scanning) refresh();
+  // First call: probe definitively (≤5 s) so the UI gets a real answer rather
+  // than "checking…" for a whole poll cycle. Later calls refresh in the
+  // background and serve the last-known value.
+  if (analysisAvail == null) await refreshAnalysisAvail();
+  else if (analysisAvailStale() && !analysisProbeInflight) refreshAnalysisAvail();
   const tagged = library.allTaggedIds().length;
   const analysed = db.analysedCount();
   const total = cache.scannedAt ? cache.total : null;
@@ -70,5 +103,10 @@ export async function get() {
     analysedPercent,
     scannedAt: cache.scannedAt,
     scanning: cache.scanning,
+    // Whether an acoustic-analysis backend (tts-heavy sidecar / local librosa
+    // venv) is reachable. When false, acoustic coverage stays 0 by design —
+    // the UI surfaces this rather than showing a misleading 0%.
+    analysisAvailable: analysisAvail ? analysisAvail.available : null,
+    analysisBackend: analysisAvail ? analysisAvail.backend : null,
   };
 }

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -67,6 +67,9 @@ interface Coverage {
   analysedPercent: number | null;
   scannedAt: string | null;
   scanning: boolean;
+  // null = still probing; false = no analysis backend (sidecar/librosa) running.
+  analysisAvailable?: boolean | null;
+  analysisBackend?: string | null;
 }
 
 interface TaggerState {
@@ -545,16 +548,21 @@ export default function LibraryPanel() {
 // One labelled progress meter: a headline count (done / total), a fill bar,
 // and a trailing percent. The done count comes straight from the library DB
 // so it shows immediately; only the denominator waits on the Subsonic scan.
-function Meter({ label, done, total, percent, scanning, onStart }: {
+function Meter({ label, done, total, percent, scanning, onStart, unavailable, note }: {
   label: string;
   done: number | null;
   total: number | null;
   percent: number | null;
   scanning: boolean;
   onStart?: () => void;
+  // When true, the meter reads "engine off" instead of a misleading 0% — the
+  // pass can't run because no backend is installed.
+  unavailable?: boolean;
+  // Explanatory line shown under the bar (e.g. how to enable the engine).
+  note?: string;
 }) {
   const fillRef = useRef<HTMLSpanElement>(null);
-  useDynamicStyle(fillRef, { width: percent != null ? `${Math.min(100, percent)}%` : '0%' });
+  useDynamicStyle(fillRef, { width: !unavailable && percent != null ? `${Math.min(100, percent)}%` : '0%' });
 
   const doneNum = done != null ? done.toLocaleString('en-GB') : '—';
   const totalNum = total != null
@@ -568,21 +576,29 @@ function Meter({ label, done, total, percent, scanning, onStart }: {
       <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
         <span className="text-[10px] font-bold tracking-[0.1em] text-muted uppercase">{label}</span>
         <span className="caption text-muted">
-          {complete
-            ? '✓ complete'
-            : percent != null
-              ? `${percent}%`
-              : (empty && onStart ? '' : '…')}
+          {unavailable
+            ? 'engine off'
+            : complete
+              ? '✓ complete'
+              : percent != null
+                ? `${percent}%`
+                : (empty && onStart ? '' : '…')}
         </span>
       </div>
       <div className="flex items-baseline gap-2">
-        <span className="mono-num text-[22px] leading-none font-extrabold tracking-[-0.02em]">{doneNum}</span>
+        <span className={cn(
+          'mono-num text-[22px] leading-none font-extrabold tracking-[-0.02em]',
+          unavailable && 'text-muted',
+        )}>{doneNum}</span>
         <span className="caption text-muted">/ {totalNum}</span>
       </div>
-      <div className="h-1.5 w-full overflow-hidden bg-[var(--ink-soft)]">
+      <div className={cn('h-1.5 w-full overflow-hidden bg-[var(--ink-soft)]', unavailable && 'opacity-50')}>
         <span ref={fillRef} className="block h-full bg-[var(--accent)]" />
       </div>
-      {empty && onStart && (
+      {note && (
+        <div className="mt-0.5 text-[11px] leading-[1.45] text-muted">{note}</div>
+      )}
+      {empty && onStart && !unavailable && (
         <button
           type="button"
           onClick={onStart}
@@ -639,6 +655,10 @@ function KpiStrip({ coverage, stats, onStartTag }: {
             total={total}
             percent={coverage?.analysedPercent ?? null}
             scanning={scanning}
+            unavailable={coverage?.analysisAvailable === false}
+            note={coverage?.analysisAvailable === false
+              ? 'No analysis engine running. Start the tts-heavy sidecar (docker compose --profile tts-heavy up -d) or configure a local librosa venv to enable BPM/key detection — tagging runs will then fill this in.'
+              : undefined}
           />
         </div>
       </div>


### PR DESCRIPTION
## Why

On the admin **Library** page, the *acoustic analysis · bpm/key* meter showed a bare **0%** even when there's no analysis backend installed at all. To an operator that looks like a stalled or failed job — when the truth is "nothing here can run." This came up in practice: mood-tagging runs worked fine (coverage climbed), but acoustic analysis stayed pinned at `0 / 6,806` with no explanation, because the box runs neither the `tts-heavy` sidecar nor a local librosa venv.

The two passes are independent:
- **mood tagging** — LLM, always available.
- **acoustic analysis (bpm/key/intro)** — needs a DSP backend (`tts-heavy` sidecar *or* a local librosa venv). When neither is reachable, `runAnalysisPass()` is a clean no-op, so the count can never move.

## What

Thread the analyzer's availability through the coverage API and render an explicit state instead of a misleading percentage.

- **`controller/src/music/library-coverage.ts`** — `get()` now probes `analyzer.isAvailable()` and returns `analysisAvailable` + `analysisBackend`. Because that probe can make a 5 s sidecar HTTP call and `resolveBackend()` doesn't cache a negative result, it's memoised on a 60 s TTL — awaited once on the first call (definitive first paint, ≤5 s) and refreshed in the background thereafter, so the 60 s coverage poll never pays the probe cost repeatedly.
- **`web/components/admin/LibraryPanel.tsx`** — the generic `Meter` gains `unavailable` + `note` props. When `analysisAvailable === false` the acoustic meter reads **"engine off"** (dimmed bar/count) with a one-line hint:
  > No analysis engine running. Start the tts-heavy sidecar (`docker compose --profile tts-heavy up -d`) or configure a local librosa venv to enable BPM/key detection — tagging runs will then fill this in.

  When the backend *is* present, behaviour is unchanged (real percent + fill). While availability is still being probed (`null`/`undefined`), it falls through to the existing `…` state.

## Notes

- No change to the mood-tagging meter.
- Coverage payload only gains fields; existing consumers are unaffected.

## Test plan

- `controller`: `npm run lint` → 0 errors; `tsc --noEmit` → exit 0.
- `web`: `npm run lint` (eslint + tsc) → exit 0.
- Manual: with no backend, `/library/coverage` returns `analysisAvailable: false` and the meter renders "engine off" + hint; bringing up `--profile tts-heavy` flips it back to a live percent on the next poll.