### PR TITLE
feat(web): add Re-seed embeddings button to admin Library tab

### DIFF
--- a/controller/src/broadcast/tagger.ts
+++ b/controller/src/broadcast/tagger.ts
@@ -19,9 +19,13 @@ let activeChild: ChildProcess | null = null;
 
 // Spawn the tagger as a detached-from-our-event-loop child process. Caller is
 // responsible for rejecting the request if `tagger.running` is already true.
-export function startTagger(limit?: number) {
+// `reseed` drops + rebuilds track_vectors and re-embeds from scratch (the
+// embedding-model-swap recovery path; see music/tag-library.ts --reseed).
+export function startTagger(opts: { limit?: number; reseed?: boolean } = {}) {
+  const { limit, reseed } = opts;
   const args = ['src/music/tag-library.ts'];
   if (Number.isFinite(limit) && (limit as number) > 0) args.push('--limit', String(limit));
+  if (reseed) args.push('--reseed');
 
   const child = spawn('npx', ['tsx', ...args], { cwd: '/app', detached: false });
   activeChild = child;
@@ -43,7 +47,13 @@ export function startTagger(limit?: number) {
     tagger.lastLog.push(`[exit ${signal || code}]`);
     queue.log('scheduler', `tagger finished (${signal ? `signal ${signal}` : `exit ${code}`})`);
   });
-  queue.log('scheduler', `tagger started${Number.isFinite(limit) ? ` (limit=${limit})` : ''}`);
+  const detail = [
+    Number.isFinite(limit) && (limit as number) > 0 ? `limit=${limit}` : null,
+    reseed ? 'reseed' : null,
+  ]
+    .filter(Boolean)
+    .join(', ');
+  queue.log('scheduler', `tagger started${detail ? ` (${detail})` : ''}`);
 }
 
 // Stop the running tagger by signalling its child. The exit handler above

--- a/controller/src/routes/jingles.ts
+++ b/controller/src/routes/jingles.ts
@@ -60,7 +60,8 @@ router.get('/jingles/:filename/audio', requireAdmin, async (req, res) => {
 router.post('/tag-library', requireAdmin, (req, res) => {
   if (tagger.running) return res.status(409).json({ error: 'tagger already running', tagger });
   const limit = parseInt(req.body?.limit, 10);
-  startTagger(limit);
+  const reseed = req.body?.reseed === true;
+  startTagger({ limit: Number.isFinite(limit) ? limit : undefined, reseed });
   res.json({ ok: true, tagger });
 });
 

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -26,6 +26,7 @@ import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
 } from '../ui/select';
 import { Card, Btn, Eyebrow, Seg } from './ui';
+import { V3AlertDialog } from '../ui/alert-dialog';
 import { cn } from '../../lib/cn';
 
 // ---------------------------------------------------------------------------
@@ -373,6 +374,30 @@ export default function LibraryPanel() {
     }
   };
 
+  // Full re-embed: drops + rebuilds the vector table from scratch. The recovery
+  // path after changing the embedding model (its dim no longer matches the
+  // stored vectors). Sends no limit — a partial reseed leaves the library in a
+  // mixed state KNN propagation can't use. Existing mood/energy tags survive as
+  // seeds, so this only re-spends embedding calls, not the LLM tag budget.
+  const reseedTagger = async () => {
+    setTaggerBusy(true);
+    try {
+      const r = await adminFetch('/tag-library', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reseed: true }),
+      });
+      const j = await r.json().catch(() => ({})) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `re-seed failed (${r.status})`);
+      notify.ok('re-seeding embeddings…');
+      await loadTagger();
+    } catch (err) {
+      notify.err(errorMessage(err));
+    } finally {
+      setTaggerBusy(false);
+    }
+  };
+
   // -----------------------------------------------------------------------
   // derived
   // -----------------------------------------------------------------------
@@ -410,6 +435,7 @@ export default function LibraryPanel() {
         busy={taggerBusy}
         onStart={startTagger}
         onStop={stopTagger}
+        onReseed={reseedTagger}
       />
 
       <div className="stack-mobile grid grid-cols-[260px_1fr] items-start gap-4">
@@ -920,10 +946,12 @@ interface TaggerStripProps {
   busy: boolean;
   onStart: () => void;
   onStop: () => void;
+  onReseed: () => void;
 }
 
 function TaggerStrip(p: TaggerStripProps) {
   const [expanded, setExpanded] = useState(false);
+  const [confirmReseed, setConfirmReseed] = useState(false);
   const logRef = useRef<HTMLPreElement>(null);
   const fillRef = useRef<HTMLSpanElement>(null);
 
@@ -977,7 +1005,17 @@ function TaggerStrip(p: TaggerStripProps) {
             {running ? (
               <Btn tone="danger" onClick={p.onStop} disabled={p.busy}>Stop</Btn>
             ) : (
-              <Btn tone="accent" onClick={p.onStart} disabled={p.busy}>Start tagging</Btn>
+              <>
+                <Btn tone="accent" onClick={p.onStart} disabled={p.busy}>Start tagging</Btn>
+                <Btn
+                  sm
+                  onClick={() => setConfirmReseed(true)}
+                  disabled={p.busy}
+                  title="Drop + rebuild every embedding from scratch — run after changing the embedding model"
+                >
+                  Re-seed
+                </Btn>
+              </>
             )}
             <Btn sm onClick={() => setExpanded(e => !e)}>
               {expanded ? 'hide log' : 'log'}
@@ -993,6 +1031,15 @@ function TaggerStrip(p: TaggerStripProps) {
           </pre>
         )}
       </section>
+      <V3AlertDialog
+        open={confirmReseed}
+        onOpenChange={setConfirmReseed}
+        title="Re-seed embeddings"
+        description="Drops the vector table and re-embeds every track from scratch. Do this after changing the embedding model — the new model's dimensions no longer match the stored vectors. Existing mood/energy tags are kept and reused as seeds (no LLM re-tagging), but a full re-embed can take several minutes on a large library."
+        confirmLabel="re-seed"
+        danger
+        onConfirm={p.onReseed}
+      />
     </div>
   );
 }

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -1888,7 +1888,8 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
             <div className="field-hint">
               Leave blank for the sensible default per provider. If you change
               this on a tagged library, the next run will reject the new dim —
-              re-run with <code>--reseed</code> to drop existing vectors.
+              hit <strong>Re-seed</strong> on the Library tab (or run{' '}
+              <code>--reseed</code>) to drop and rebuild the vectors.
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What

Adds a **Re-seed embeddings** button to the admin **Library** tab so operators can drop + rebuild the vector table from the UI, instead of shelling into the controller container.

Closes #237.

## Why

When you change the embedding model, its vector dimension no longer matches the stored vectors, and the tagger refuses to run with a `Run \`npm run tag -- --reseed\`` error. That `--reseed` flag was **CLI-only** — there was no UI surface for it, even though the Settings → Embeddings hint told operators to run it. The reporter (on 0.4.0) hit exactly this: changed the model, got told to `--reseed`, and had no button to press.

## What changed

- **`controller/src/broadcast/tagger.ts`** — `startTagger` now takes `{ limit?, reseed? }` and appends `--reseed` when set (the log line reports it). Backward-compatible.
- **`controller/src/routes/jingles.ts`** — `POST /tag-library` reads `reseed: true` from the body and forwards it. Existing `{ limit }` callers unchanged.
- **`web/components/admin/LibraryPanel.tsx`** — confirm-gated **Re-seed** button next to *Start tagging*. Posts `{ reseed: true }` with **no limit** (a partial reseed leaves the library half-embedded, which KNN propagation can't use). Reuses the existing tagger progress/log strip. The confirm dialog notes it's the model-swap recovery path and that mood/energy tags survive as seeds (no LLM re-tag cost).
- **`web/components/admin/SettingsPanel.tsx`** — embedding-model field hint now points at the new button.

## Notes

- `--reseed` drops only `track_vectors` and re-embeds from scratch; the `tracks` rows (moods/energy) survive and act as seeds, so this only re-spends embedding calls, not the LLM tag budget.
- Existing `--limit` tagging behaviour is untouched.

## Testing

- `controller` `npm run lint` (eslint + `tsc --noEmit`): clean, 0 errors.
- Changed `web` files are eslint-clean with no new `tsc` errors. (Pre-existing `lib/news.ts` module-resolution errors from a stale local `node_modules` are unrelated and don't occur on CI's fresh `npm ci`.)
