### PR TITLE
fix(cli): point TUI download at a real release tag

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subwave-cli",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "description": "SUB/WAVE operator CLI — status, doctor, lifecycle.",

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -572,4 +572,4 @@ SITE_URL=
 
 // cli/package.json#version (embedded so the compiled binary can self-identify
 // — used by `subwave --version` and by the TUI release fetch URL).
-export const CLI_VERSION = `0.1.0`;
+export const CLI_VERSION = `0.4.0`;

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,6 +19,11 @@
           "type": "json",
           "path": "web/package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "cli/package.json",
+          "jsonpath": "$.version"
         }
       ]
     }


### PR DESCRIPTION
## Problem

Running the standalone `subwave` CLI and choosing **play** fails on first launch with a 404:

```
✗ download failed (404 Not Found). ... URL:
https://github.com/perminder-klair/subwave/releases/download/v0.1.0/subwave-tui-darwin-arm64
```

`subwave play` fetches the compiled TUI binary from `releases/download/v${CLI_VERSION}/subwave-tui-<slug>`. `CLI_VERSION` is baked in at build time from **`cli/package.json`** — but `cli/package.json` was never added to release-please's `extra-files`, so it stayed frozen at `0.1.0` while the root/controller/web versions advanced to `0.4.0` with each release. The download URL therefore resolved to **`v0.1.0`, a tag that does not exist**, and every standalone `subwave play` 404'd.

The `subwave-tui-*` assets have existed all along (they're on `v0.4.0`) — the CLI was simply pointing at the wrong tag.

## Fix

- **`release-please-config.json`** — add `cli/package.json` to `extra-files` so its version is bumped in lockstep with the release tag from now on (root/controller/web were already wired this way; the CLI was the lone straggler that caused the drift).
- **`cli/package.json`** — `0.1.0` → `0.4.0`, catching it up to the current release line.
- **`cli/src/assets.generated.ts`** — regenerated so `CLI_VERSION` is `0.4.0`.

The next release's binary will point at its own (existing) tag, which carries the `subwave-tui-*` assets.

## Verification

- `embed-assets` regen is idempotent → the `verify-cli-assets` CI check stays green.
- Only the `CLI_VERSION` line changed in the generated file; compose embeds untouched (regenerated against develop's compose content).
- JSON validity confirmed for both edited config files.

## Note for existing installs

Binaries already in the wild (and the one on the `v0.4.0` release) have `0.1.0` baked in, so `self-update` won't recover them until a new release ships. One-time workaround:

```bash
SUBWAVE_TUI_DOWNLOAD_URL='https://github.com/perminder-klair/subwave/releases/download/v0.4.0/subwave-tui-darwin-arm64' subwave play
```

This caches the real binary; subsequent launches reuse it.