### PR TITLE
feat(web): switch type to Fraunces + Plus Jakarta Sans for a softer, premium feel

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -59,7 +59,11 @@
   /* Recurring eyebrow letterspacing — used everywhere caps headers appear. */
   --tracking-eyebrow: 0.2em;
 
-  /* Mono font — set in body inline; promoted so `font-mono` works. */
+  /* Type families — promoted so `font-sans` / `font-display` / `font-mono`
+     utilities resolve to the next/font variables set on <html>. Inter is the
+     UI/body default, Fraunces the display serif, JetBrains Mono the data face. */
+  --font-sans: var(--font-sans);
+  --font-display: var(--font-display);
   --font-mono: var(--font-mono);
 }
 
@@ -158,18 +162,79 @@ html,
 body {
     background: var(--bg);
     color: var(--ink);
+    /* Inter is the body/UI default now. Fraunces (--font-display) is applied to
+       headings + the masthead, JetBrains Mono (--font-mono) is re-asserted on
+       data (timestamps, code, kbd) in the type-roles block below. */
     font-family:
-        var(--font-mono), ui-monospace, "JetBrains Mono", "SF Mono", Menlo,
-        Consolas, monospace;
-    font-feature-settings:
-        "calt" 1,
-        "ss01" 1; /* contextual + slashed zero */
+        var(--font-sans), ui-sans-serif, system-ui, -apple-system,
+        "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-feature-settings: "calt" 1; /* contextual alternates */
     -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
     /* Catch-all against accidental horizontal overflow on mobile. `clip`
        (not `hidden`) keeps vertical page scroll intact and still lets inner
        scrollable areas (e.g. the weekly-schedule grid) scroll horizontally
        inside their own `overflow-x: auto` wrappers. */
     overflow-x: clip;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+   TYPE ROLES — the premium editorial split layered over the cascade above.
+   Body defaults to Inter (set on <html,body>). Here we promote headlines to
+   Fraunces (the soft display serif) and pull data — timestamps, durations,
+   code, terminal, keycaps — back to JetBrains Mono so numbers stay tabular and
+   read like hi-fi gear. Keep these two lists in sync when adding headings or
+   numeric/code surfaces.
+   ───────────────────────────────────────────────────────────────────────── */
+
+/* Display serif — every headline + the masthead wordmark + the now-playing
+   title. font-optical-sizing:auto lets Fraunces' opsz axis tune contrast to the
+   rendered size (delicate at body, dramatic at the masthead). */
+.bs-wordmark,
+.bs-hero-title,
+.bs-section h2,
+.bs-setup-hero h1,
+.bs-step-body h3,
+.bs-navidrome-copy h2,
+.bs-news-hero h1,
+.bs-news-lead-headline,
+.bs-news-headline,
+.bs-article-head h1,
+.bs-prose h2,
+.bs-prose h3,
+.v3-title {
+    font-family: var(--font-display), Georgia, "Times New Roman", serif;
+    font-optical-sizing: auto;
+}
+
+/* Note: the masthead wordmark + news-hero H1 relax their letter-spacing at
+   their own definitions below (those rules win the cascade), since the tight
+   tracking tuned for mono crowds Fraunces' serifs. */
+
+/* Data face — JetBrains Mono kept for anything that benefits from tabular,
+   fixed-advance glyphs: clocks, durations, indices, version strings, code,
+   terminal output and keycaps. */
+.v3-tab-num,
+.admin-root .mono-num,
+.admin-root .metric .n,
+.admin-root .track-row .idx,
+.admin-root .track-row .dur,
+.admin-root .log .t,
+.admin-root .term,
+.bs-news-ver,
+.bs-frame-url,
+.bs-code,
+.bs-code-inline,
+.bs-code-lang,
+.bs-copy,
+.bs-kbd,
+.bs-prose code,
+.bs-prose pre {
+    font-family: var(--font-mono), ui-monospace, "SF Mono", Menlo, Consolas,
+        monospace;
+    font-feature-settings:
+        "calt" 1,
+        "ss01" 1; /* contextual + slashed zero */
 }
 
 /* Paper grain — fixed full-viewport SVG turbulence at low opacity.
@@ -507,12 +572,14 @@ body::after {
     }
 }
 
-/* Masthead wordmark — outsized mono, extreme weight, tight tracking. */
+/* Masthead wordmark — outsized Fraunces nameplate. Black weight for the
+   broadsheet-masthead punch; tracking relaxed from the old mono -0.04em so the
+   serifs don't collide at display size. */
 .bs-wordmark {
     font-size: clamp(48px, 9vw, 128px);
     line-height: 0.85;
-    letter-spacing: -0.04em;
-    font-weight: 800;
+    letter-spacing: -0.015em;
+    font-weight: 900;
     text-transform: uppercase;
 }
 
@@ -2260,8 +2327,9 @@ body::after {
     margin: 0;
     font-size: clamp(40px, 7vw, 88px);
     line-height: 0.9;
-    letter-spacing: -0.035em;
-    font-weight: 800;
+    /* relaxed from -0.035em (mono) so the uppercase serif doesn't crowd */
+    letter-spacing: -0.01em;
+    font-weight: 900;
     text-transform: uppercase;
 }
 .bs-news-hero p {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -56,7 +56,7 @@
   /* Drawer / dialog shadow used by the right-side drawer + modal-pop. */
   --shadow-drawer: var(--drawer-shadow);
 
-  /* Recurring eyebrow letterspacing — used everywhere caps headers appear. */
+  /* Uppercase-label letterspacing, exposed as the `tracking-eyebrow` utility. */
   --tracking-eyebrow: 0.2em;
 
   /* Type families — promoted so `font-sans` / `font-display` / `font-mono`
@@ -446,35 +446,34 @@ body::after {
     }
 }
 
-/* Mono title block — JetBrains Mono advance width is ~60% em, so the title
-   clamp tops out lower than the proportional version (the same character
-   count fills more horizontal space). Tracking goes to zero — mono cells
-   already provide their own rhythm and negative tracking collides glyphs. */
+/* Player title — Fraunces display serif (see the type-roles block up top).
+   A hair of negative tracking tightens the big serif; opsz handles contrast. */
 .v3-title {
-    font-size: clamp(20px, 4.5vw, 52px);
-    line-height: 0.95;
-    letter-spacing: 0;
+    font-size: clamp(22px, 4.6vw, 56px);
+    line-height: 1;
+    letter-spacing: -0.01em;
     font-weight: 800;
     text-wrap: balance;
 }
 .v3-subtitle {
     font-size: clamp(16px, 2vw, 28px);
-    letter-spacing: 0;
+    letter-spacing: 0; /* Inter needs no tracking at body/subhead sizes */
     font-weight: 500;
 }
 .v3-eyebrow {
     font-size: 11px;
-    letter-spacing: 0.25em; /* mono cells already spread, so tighten the tracking */
+    letter-spacing: 0.18em; /* tracked uppercase label (Inter) */
     text-transform: uppercase;
     font-weight: 700;
 }
 .v3-caption {
     font-size: 10px;
-    letter-spacing: 0.18em;
+    letter-spacing: 0.16em;
     text-transform: uppercase;
     font-weight: 500;
 }
-/* Mono is already tabular by design, but keep the class as a no-op alias. */
+/* Numerals stay mono (set in the type-roles block); this just turns on tabular
+   figures so columns of times/durations line up. */
 .v3-tab-num {
     font-variant-numeric: tabular-nums;
 }
@@ -907,7 +906,7 @@ body::after {
     margin: 0;
     font-size: clamp(36px, 5.4vw, 76px);
     line-height: 0.98;
-    letter-spacing: -0.035em;
+    letter-spacing: -0.02em; /* display serif — relaxed from mono-era -0.035em */
     font-weight: 800;
     text-wrap: balance;
 }
@@ -932,7 +931,7 @@ body::after {
     margin: 0;
     font-size: clamp(28px, 3.4vw, 44px);
     line-height: 1.05;
-    letter-spacing: -0.025em;
+    letter-spacing: -0.015em; /* mid heading */
     font-weight: 800;
     text-wrap: balance;
     max-width: 32ch;
@@ -1086,7 +1085,7 @@ body::after {
     margin: 0;
     font-size: clamp(36px, 5vw, 64px);
     line-height: 0.98;
-    letter-spacing: -0.03em;
+    letter-spacing: -0.02em; /* display serif */
     font-weight: 800;
     text-wrap: balance;
 }
@@ -1122,7 +1121,7 @@ body::after {
     margin: 0;
     font-size: clamp(22px, 2.4vw, 30px);
     line-height: 1.15;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.01em; /* small heading */
     font-weight: 800;
 }
 .bs-step-body p {
@@ -1619,7 +1618,7 @@ body::after {
     margin: 0;
     font-size: clamp(28px, 3.4vw, 44px);
     line-height: 1.05;
-    letter-spacing: -0.025em;
+    letter-spacing: -0.015em; /* mid heading */
     font-weight: 800;
     max-width: 18ch;
 }
@@ -2196,7 +2195,8 @@ body::after {
 .admin-root .metric .n {
     font-size: 32px;
     font-weight: 800;
-    letter-spacing: -0.02em;
+    /* mono numerals (set in type-roles) — zero tracking so digits don't collide */
+    letter-spacing: 0;
     line-height: 1;
     font-variant-numeric: tabular-nums;
 }
@@ -2385,7 +2385,7 @@ body::after {
     margin: 0;
     font-size: clamp(30px, 4.6vw, 56px);
     line-height: 1.02;
-    letter-spacing: -0.03em;
+    letter-spacing: -0.02em; /* display serif */
     font-weight: 800;
     text-wrap: balance;
     max-width: 20ch;
@@ -2435,7 +2435,7 @@ body::after {
     margin: 0;
     font-size: clamp(20px, 2.2vw, 26px);
     line-height: 1.12;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.01em; /* small heading */
     font-weight: 800;
     text-wrap: balance;
 }
@@ -2488,7 +2488,7 @@ body::after {
     margin: 0;
     font-size: clamp(34px, 5.2vw, 68px);
     line-height: 0.98;
-    letter-spacing: -0.035em;
+    letter-spacing: -0.02em; /* display serif — relaxed from mono-era -0.035em */
     font-weight: 800;
     text-wrap: balance;
 }
@@ -2542,7 +2542,7 @@ body::after {
     margin: 1.8em 0 0.6em;
     font-size: clamp(20px, 2.2vw, 26px);
     line-height: 1.15;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.015em; /* mid heading */
     font-weight: 800;
     padding-top: 0.6em;
     border-top: 1px solid var(--separator-strong);

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -60,8 +60,9 @@
   --tracking-eyebrow: 0.2em;
 
   /* Type families — promoted so `font-sans` / `font-display` / `font-mono`
-     utilities resolve to the next/font variables set on <html>. Inter is the
-     UI/body default, Fraunces the display serif, JetBrains Mono the data face. */
+     utilities resolve to the next/font variables set on <html>. Plus Jakarta
+     Sans is the UI/body default, Fraunces the display serif, JetBrains Mono the
+     data face. */
   --font-sans: var(--font-sans);
   --font-display: var(--font-display);
   --font-mono: var(--font-mono);
@@ -162,9 +163,9 @@ html,
 body {
     background: var(--bg);
     color: var(--ink);
-    /* Inter is the body/UI default now. Fraunces (--font-display) is applied to
-       headings + the masthead, JetBrains Mono (--font-mono) is re-asserted on
-       data (timestamps, code, kbd) in the type-roles block below. */
+    /* Plus Jakarta Sans is the body/UI default now. Fraunces (--font-display) is
+       applied to headings + the masthead, JetBrains Mono (--font-mono) is
+       re-asserted on data (timestamps, code, kbd) in the type-roles block. */
     font-family:
         var(--font-sans), ui-sans-serif, system-ui, -apple-system,
         "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -180,7 +181,7 @@ body {
 
 /* ─────────────────────────────────────────────────────────────────────────
    TYPE ROLES — the premium editorial split layered over the cascade above.
-   Body defaults to Inter (set on <html,body>). Here we promote headlines to
+   Body defaults to Plus Jakarta Sans (set on <html,body>). Here we promote headlines to
    Fraunces (the soft display serif) and pull data — timestamps, durations,
    code, terminal, keycaps — back to JetBrains Mono so numbers stay tabular and
    read like hi-fi gear. Keep these two lists in sync when adding headings or
@@ -457,12 +458,12 @@ body::after {
 }
 .v3-subtitle {
     font-size: clamp(16px, 2vw, 28px);
-    letter-spacing: 0; /* Inter needs no tracking at body/subhead sizes */
+    letter-spacing: 0; /* sans needs no tracking at body/subhead sizes */
     font-weight: 500;
 }
 .v3-eyebrow {
     font-size: 11px;
-    letter-spacing: 0.18em; /* tracked uppercase label (Inter) */
+    letter-spacing: 0.18em; /* tracked uppercase label (sans) */
     text-transform: uppercase;
     font-weight: 700;
 }

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,7 +1,7 @@
 import './globals.css';
 import type { Metadata, Viewport } from 'next';
 import type { ReactNode } from 'react';
-import { JetBrains_Mono } from 'next/font/google';
+import { Fraunces, Inter, JetBrains_Mono } from 'next/font/google';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import { THEME_INIT_SCRIPT } from '@/lib/theme';
 import { SITE_URL } from '@/lib/site';
@@ -13,6 +13,23 @@ import JsonLd from '@/components/JsonLd';
 // Visitor tracking. The gtag.js script only loads when a Measurement ID is
 // configured, so dev and un-instrumented deploys stay analytics-free.
 const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+
+// Fraunces — the display serif. Soft, optical-axis editorial face used for
+// every headline + the masthead wordmark; opsz makes it self-tune contrast to
+// the rendered size. Inter carries body/UI; JetBrains Mono stays for data
+// (timestamps, durations, code, kbd) so numbers read like hi-fi gear.
+const fraunces = Fraunces({
+  subsets: ['latin'],
+  axes: ['opsz'],
+  display: 'swap',
+  variable: '--font-display',
+});
+
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-sans',
+});
 
 const jetbrainsMono = JetBrains_Mono({
   subsets: ['latin', 'latin-ext'],
@@ -94,7 +111,11 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className={jetbrainsMono.variable} suppressHydrationWarning>
+    <html
+      lang="en"
+      className={`${fraunces.variable} ${inter.variable} ${jetbrainsMono.variable}`}
+      suppressHydrationWarning
+    >
       <head>
         {/* Apply stored theme before paint to avoid flash of wrong palette.
             Script body is a static constant from lib/theme — no untrusted input. */}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,7 +1,7 @@
 import './globals.css';
 import type { Metadata, Viewport } from 'next';
 import type { ReactNode } from 'react';
-import { Fraunces, Inter, JetBrains_Mono } from 'next/font/google';
+import { Fraunces, Plus_Jakarta_Sans, JetBrains_Mono } from 'next/font/google';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import { THEME_INIT_SCRIPT } from '@/lib/theme';
 import { SITE_URL } from '@/lib/site';
@@ -16,7 +16,7 @@ const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
 
 // Fraunces — the display serif. Soft, optical-axis editorial face used for
 // every headline + the masthead wordmark; opsz makes it self-tune contrast to
-// the rendered size. Inter carries body/UI; JetBrains Mono stays for data
+// the rendered size. Plus Jakarta Sans carries body/UI; JetBrains Mono is data
 // (timestamps, durations, code, kbd) so numbers read like hi-fi gear.
 const fraunces = Fraunces({
   subsets: ['latin'],
@@ -25,7 +25,7 @@ const fraunces = Fraunces({
   variable: '--font-display',
 });
 
-const inter = Inter({
+const plusJakarta = Plus_Jakarta_Sans({
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-sans',
@@ -113,7 +113,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html
       lang="en"
-      className={`${fraunces.variable} ${inter.variable} ${jetbrainsMono.variable}`}
+      className={`${fraunces.variable} ${plusJakarta.variable} ${jetbrainsMono.variable}`}
       suppressHydrationWarning
     >
       <head>


### PR DESCRIPTION
## What

Moves the site off its all-mono **JetBrains Mono** identity toward a softer, premium **editorial broadsheet** pairing:

- **Fraunces** (soft display serif, optical-sizing axis) → every headline + the masthead wordmark + the now-playing title
- **Inter** → body / UI
- **JetBrains Mono** → kept only for *data* (timestamps, durations, indices, code, terminal, keycaps) so numbers stay tabular and read like hi-fi gear

## Why

The all-mono type read as "sharp" / terminal-y. The brief was softer and more premium without losing the broadsheet/ink identity. Fraunces + Inter keeps the newspaper soul while shedding the harsh edge. Numbers staying mono is a deliberate accent (and a thread back to the old identity).

## How

- `app/layout.tsx` — load Fraunces (`--font-display`, `opsz` axis) + Inter (`--font-sans`) via `next/font`; all three font vars on `<html>`.
- `app/globals.css` — `body` default flips mono → Inter; a new **type-roles block** promotes headlines to Fraunces and re-asserts mono on numeric/code surfaces. Masthead + news-hero `letter-spacing` relaxed from `-0.04em`/`-0.035em` (tuned for mono, crowds serifs) and bumped to Fraunces Black for nameplate weight.

## Verification

- ✅ Lint gate green — `eslint . && tsc --noEmit`
- ✅ All three `@font-face` families load; all three variable classes on `<html>`
- ✅ Rendered against the live dev stack with real now-playing data — landing masthead, hero headline, and player title all in Fraunces; nav/body in Inter; timestamps mono

## Scope notes

- Components using `font-[inherit]` now inherit Inter; explicit `font-mono` (kbd, DJ thinking line, prompt templates) unchanged.
- OG / social-card routes (`app/og`, `app/screenshots`) still use Satori `monospace` — separate from site CSS, left as-is (can follow up for consistent share cards).