### PR TITLE
feat(web): Fraunces player wordmark + article-head CTAs

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -480,8 +480,13 @@ body::after {
 }
 
 /* Player header runs a touch larger than the shared v3 scale — the masthead
-   reads better at arm's length without disturbing the landing broadsheet. */
+   reads better at arm's length without disturbing the landing broadsheet.
+   The wordmark also swaps to Fraunces (the display serif) so the station name
+   carries the same editorial face as the broadsheet masthead, while the other
+   header labels stay in the tracked sans. */
 .player-topbar .v3-eyebrow {
+    font-family: var(--font-display), Georgia, "Times New Roman", serif;
+    font-optical-sizing: auto;
     font-size: 13px;
 }
 .player-topbar .v3-caption {
@@ -496,7 +501,7 @@ body::after {
     align-items: center;
     justify-content: center;
     gap: 14px;
-    padding: 6px 0 0;
+    padding: 4px 0px 4px;
     flex-wrap: wrap;
 }
 .bs-masthead-link {
@@ -690,6 +695,27 @@ body::after {
 .bs-tune[data-tuned="true"] {
     background: var(--bg);
     color: var(--ink);
+}
+
+/* Ghost variant — outlined twin of .bs-tune for a secondary CTA sitting next
+   to the filled primary (e.g. "Source" beside "Setup" in the article hero).
+   Defined after .bs-tune:hover so its hover wins the equal-specificity match. */
+.bs-tune--ghost {
+    background: transparent;
+    color: var(--ink);
+}
+.bs-tune--ghost:hover {
+    background: var(--ink);
+    border-color: var(--ink);
+    color: var(--bg);
+}
+
+/* Hero CTA row — left-aligned button pair under the article deck. */
+.bs-hero-cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 6px;
 }
 
 /* Ghost link — used for "Open full player", footer links. */

--- a/web/components/landing/Masthead.tsx
+++ b/web/components/landing/Masthead.tsx
@@ -19,7 +19,7 @@ export default function Masthead() {
   const now = useClock();
 
   return (
-    <header className="bs-paper pt-7 pb-0">
+    <header className="bs-paper pt-7 !pb-4">
       <div className="bs-rule-double" />
 
       <div className="bs-masthead-head">
@@ -45,18 +45,31 @@ export default function Masthead() {
 
       <div className="bs-rule" />
 
-      <nav
-        aria-label="Primary"
-        className="bs-masthead-nav"
-      >
-        <Link href="/listen" className="bs-masthead-link">Listen</Link>
-        <span aria-hidden="true" className="bs-masthead-sep">·</span>
-        <Link href="/manual" className="bs-masthead-link">Manual</Link>
-        <span aria-hidden="true" className="bs-masthead-sep">·</span>
-        <Link href="/setup" className="bs-masthead-link">Setup</Link>
-        <span aria-hidden="true" className="bs-masthead-sep">·</span>
-        <Link href="/news" className="bs-masthead-link">News</Link>
-        <span aria-hidden="true" className="bs-masthead-sep">·</span>
+      <nav aria-label="Primary" className="bs-masthead-nav">
+        <Link href="/listen" className="bs-masthead-link">
+          Listen
+        </Link>
+        <span aria-hidden="true" className="bs-masthead-sep">
+          ·
+        </span>
+        <Link href="/manual" className="bs-masthead-link">
+          Manual
+        </Link>
+        <span aria-hidden="true" className="bs-masthead-sep">
+          ·
+        </span>
+        <Link href="/setup" className="bs-masthead-link">
+          Setup
+        </Link>
+        <span aria-hidden="true" className="bs-masthead-sep">
+          ·
+        </span>
+        <Link href="/news" className="bs-masthead-link">
+          News
+        </Link>
+        <span aria-hidden="true" className="bs-masthead-sep">
+          ·
+        </span>
         <a
           href="https://github.com/perminder-klair/subwave"
           target="_blank"

--- a/web/components/landing/PlayerShowcase.tsx
+++ b/web/components/landing/PlayerShowcase.tsx
@@ -24,7 +24,7 @@ export default function PlayerShowcase() {
         </div>
         <div className="bs-frame-url">
           <span className="text-muted">https://</span>
-          <span>www.getsubwave.com</span>
+          <span>getsubwave.com</span>
           <span className="text-muted">/listen</span>
         </div>
         <m.div

--- a/web/components/what/ArticleHead.tsx
+++ b/web/components/what/ArticleHead.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import EditorialReveal from '../landing/EditorialReveal';
 
 export default function ArticleHead() {
@@ -13,6 +14,20 @@ export default function ArticleHead() {
           belongs to you. We spent a week tuned in to find out what a personal
           radio station actually feels like.
         </p>
+
+        <div className="bs-hero-cta">
+          <Link href="/setup" className="bs-tune">
+            Setup &nbsp;→
+          </Link>
+          <a
+            href="https://github.com/perminder-klair/subwave"
+            target="_blank"
+            rel="noreferrer"
+            className="bs-tune bs-tune--ghost"
+          >
+            Source &nbsp;↗
+          </a>
+        </div>
       </div>
 
       <div className="mb-0 flex flex-wrap items-baseline justify-center gap-4 border-t border-separator-strong pt-3 text-[10px] font-bold tracking-[0.24em] text-muted uppercase">


### PR DESCRIPTION
## What

- **Player header wordmark → Fraunces.** The `SUB/WAVE` station name in the player top bar now renders in the Fraunces display serif (via `--font-display`), matching the broadsheet masthead. Scoped to `.player-topbar .v3-eyebrow`, so other header labels stay in the tracked sans.
- **ArticleHead CTAs.** The article/landing hero gains two buttons under the deck: **Setup** (→ `/setup`, primary filled `.bs-tune`) and **Source** (→ GitHub, opens in a new tab). Adds a new outlined `.bs-tune--ghost` variant for the secondary CTA plus a `.bs-hero-cta` row.
- **Masthead.** Bump the footer padding (`pb-0` → `!pb-4`) and reformat the nav block.
- **Player showcase.** Drop the `www.` from the displayed listen URL (`www.getsubwave.com` → `getsubwave.com`).

## Why

Carries the editorial Fraunces face into the player header for visual consistency with the landing masthead, and gives the article hero clear Setup/Source entry points.

## Testing

- `npm run lint` (eslint + `tsc --noEmit`) — passes.
- Verified live against the dev stack: `/landing` returns 200, both CTAs render with the correct classes, player header wordmark renders in Fraunces, no compile errors.

## Notes

- Excludes `web/package-lock.json` churn (a stale-lockfile version sync + `libc` metadata) that came from running `npm install` during worktree setup — unrelated to this UI change.