### PR TITLE
fix(docker): retry controller model/binary downloads (transient HF/GitHub 5xx)

### DIFF
--- a/docker/Dockerfile.controller
+++ b/docker/Dockerfile.controller
@@ -7,6 +7,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     espeak-ng libsndfile1 \
     && rm -rf /var/lib/apt/lists/*
 
+# Common wget retry policy for the model/binary pulls below. GitHub releases and
+# HuggingFace's xet bridge intermittently return 429/5xx in CI; without retries
+# a single transient blip fails the whole release build (wget exit code 8).
+# --retry-on-http-error needs GNU wget >= 1.20 (bookworm ships 1.21).
+# ARG (not ENV) so it stays a build-time detail and isn't baked into the image.
+ARG WGET_RETRY="--tries=5 --retry-connrefused --waitretry=10 --timeout=60 --retry-on-http-error=429,500,502,503,504"
+
 # --- Piper -----------------------------------------------------------------
 # CPU-only, ~30ms/word. Default engine; remains the fast path even after Kokoro.
 # TARGETARCH is provided automatically by buildx (amd64 / arm64); map it to the
@@ -19,16 +26,16 @@ RUN cd /tmp && \
       arm64)    piper_arch=aarch64 ;; \
       *) echo "unsupported TARGETARCH=${TARGETARCH} for Piper" >&2; exit 1 ;; \
     esac && \
-    wget -q https://github.com/rhasspy/piper/releases/download/${PIPER_VERSION}/piper_linux_${piper_arch}.tar.gz && \
+    wget -q ${WGET_RETRY} https://github.com/rhasspy/piper/releases/download/${PIPER_VERSION}/piper_linux_${piper_arch}.tar.gz && \
     tar -xzf piper_linux_${piper_arch}.tar.gz -C /opt && \
     ln -s /opt/piper/piper /usr/local/bin/piper && \
     rm piper_linux_${piper_arch}.tar.gz
 
 # British English voice — lift the same one you use in Kaze
 RUN mkdir -p /opt/piper/voices && \
-    wget -q -O /opt/piper/voices/en_GB-alan-medium.onnx \
+    wget -q ${WGET_RETRY} -O /opt/piper/voices/en_GB-alan-medium.onnx \
       https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/alan/medium/en_GB-alan-medium.onnx && \
-    wget -q -O /opt/piper/voices/en_GB-alan-medium.onnx.json \
+    wget -q ${WGET_RETRY} -O /opt/piper/voices/en_GB-alan-medium.onnx.json \
       https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/alan/medium/en_GB-alan-medium.onnx.json
 
 # --- Kokoro ---------------------------------------------------------------
@@ -42,9 +49,9 @@ RUN python3 -m venv /opt/kokoro/venv && \
       kokoro-onnx==0.4.9 soundfile==0.12.1
 
 RUN mkdir -p /opt/kokoro/models && \
-    wget -q -O /opt/kokoro/models/kokoro-v1.0.onnx \
+    wget -q ${WGET_RETRY} -O /opt/kokoro/models/kokoro-v1.0.onnx \
       https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx && \
-    wget -q -O /opt/kokoro/models/voices-v1.0.bin \
+    wget -q ${WGET_RETRY} -O /opt/kokoro/models/voices-v1.0.bin \
       https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/voices-v1.0.bin
 
 ENV KOKORO_MODEL=/opt/kokoro/models/kokoro-v1.0.onnx \


### PR DESCRIPTION
## What

The v0.6.0 `publish-images` run [failed](https://github.com/perminder-klair/subwave/actions/runs/26813145927/job/79048079966) building `subwave-controller`. The failing step:

\`\`\`
wget -O /opt/piper/voices/en_GB-alan-medium.onnx https://huggingface.co/.../en_GB-alan-medium.onnx
→ exit code 8
\`\`\`

wget exit code **8** = "server issued an error response." The URL is fine (returns `200` now) — this was a **transient 429/5xx from HuggingFace's xet bridge**, which is flaky under CI load. caddy/broadcast/web/tts-heavy all passed; only controller drew the bad roll.

## How

None of the model/binary downloads in `docker/Dockerfile.controller` had retry logic, so a single blip fails the whole release. This adds a shared retry policy and applies it to all four remote pulls (Piper binary, Piper voice, both Kokoro models):

\`\`\`dockerfile
ARG WGET_RETRY="--tries=5 --retry-connrefused --waitretry=10 --timeout=60 --retry-on-http-error=429,500,502,503,504"
\`\`\`

- `--retry-on-http-error` (GNU wget ≥1.20; bookworm ships 1.21) is the key flag — it makes wget retry 429/5xx instead of bailing with exit code 8.
- `ARG` (not `ENV`) so it stays a build-time detail and isn't baked into the runtime image.

## Why

Protects future release builds from transient registry/CDN blips. Does **not** affect the current v0.6.0 build (that builds from the tag's checkout) — that was unblocked by re-running the job.