### PR TITLE
feat(web): punch up landing feature strip with real capabilities

### DIFF
--- a/web/components/what/ArticleHead.tsx
+++ b/web/components/what/ArticleHead.tsx
@@ -31,9 +31,15 @@ export default function ArticleHead() {
       </div>
 
       <div className="mb-0 flex flex-wrap items-baseline justify-center gap-4 border-t border-separator-strong pt-3 text-[10px] font-bold tracking-[0.24em] text-muted uppercase">
-        <span className="text-ink">A personal radio station</span>
+        <span className="text-ink">An agentic AI DJ</span>
         <span aria-hidden="true">·</span>
-        <span>Broadcasting from a homelab</span>
+        <span>Cloned-voice personas</span>
+        <span aria-hidden="true">·</span>
+        <span>Scheduled shows &amp; skills</span>
+        <span aria-hidden="true">·</span>
+        <span>Bring any LLM</span>
+        <span aria-hidden="true">·</span>
+        <span>Runs in your homelab</span>
         <span aria-hidden="true">·</span>
         <span className="text-vermilion">Open source</span>
       </div>


### PR DESCRIPTION
## What

Rewrites the small tagline strip under the landing hero in `web/components/what/ArticleHead.tsx`.

**Before:** A personal radio station · Broadcasting from a homelab · Open source

**After:** An agentic AI DJ · Cloned-voice personas · Scheduled shows & skills · Bring any LLM · Runs in your homelab · Open source

## Why

The old strip was generic and undersold what SUB/WAVE does. The new tags surface real capabilities a visitor cares about:

- **An agentic AI DJ** *(lead, `text-ink`)* — the tool-loop DJ agent that picks tracks and writes the script
- **Cloned-voice personas** — voice cloning + the persona/souls system
- **Scheduled shows & skills** — scheduler-driven shows and pluggable skills
- **Bring any LLM** — the multi-provider layer (Ollama / OpenAI / Anthropic / Google / …)
- **Runs in your homelab** — self-hosted
- **Open source** *(vermilion closer, unchanged)*

## How

Content-only change. Same editorial styling, `flex-wrap` layout (wraps gracefully on narrow viewports), `·` separators kept `aria-hidden`, and the `text-ink` / `text-vermilion` accent classes preserved on the first and last items. Ampersand encoded as `&amp;` per JSX.

No imports or logic touched.