### PR TITLE
feat(web): add 'The Stack' landing section — swappable LLMs, TTS & voice cloning

### DIFF
--- a/web/components/Landing.tsx
+++ b/web/components/Landing.tsx
@@ -3,6 +3,7 @@ import StationFooter from './landing/StationFooter';
 import ArticleHead from './what/ArticleHead';
 import OnTheAir from './what/OnTheAir';
 import MeetTheVoices from './what/MeetTheVoices';
+import YourStack from './what/YourStack';
 import MakeARequest from './what/MakeARequest';
 import BehindTheDesk from './what/BehindTheDesk';
 import UnderTheHood from './what/UnderTheHood';
@@ -22,6 +23,7 @@ export default function Landing() {
         <ArticleHead />
         <OnTheAir />
         <MeetTheVoices />
+        <YourStack />
         <MakeARequest />
         <BehindTheDesk />
         <UnderTheHood />

--- a/web/components/what/BehindTheDesk.tsx
+++ b/web/components/what/BehindTheDesk.tsx
@@ -55,7 +55,7 @@ const PANELS = [
 export default function BehindTheDesk() {
   return (
     <EditorialReveal className="bs-section">
-      <p className="bs-eyebrow">PART FOUR · THE CONSOLE</p>
+      <p className="bs-eyebrow">PART FIVE · THE CONSOLE</p>
       <h2>Behind the desk.</h2>
       <p className="text-muted">
         Everything a listener hears is shaped from one place: a gated admin

--- a/web/components/what/MakeARequest.tsx
+++ b/web/components/what/MakeARequest.tsx
@@ -31,7 +31,7 @@ const STEPS = [
 export default function MakeARequest() {
   return (
     <EditorialReveal className="bs-section">
-      <p className="bs-eyebrow">PART THREE · REQUESTS</p>
+      <p className="bs-eyebrow">PART FOUR · REQUESTS</p>
       <h2>Phone the station, like you used to.</h2>
       <p className="text-muted">
         Requests are the one place a listener steers the broadcast. And it

--- a/web/components/what/MeetTheVoices.tsx
+++ b/web/components/what/MeetTheVoices.tsx
@@ -48,11 +48,8 @@ export default function MeetTheVoices() {
       </div>
 
       <p className="mt-2 max-w-[64ch] text-[14px] leading-[1.6] text-muted">
-        The model behind it is the operator’s choice: a local Ollama box, or a
-        hosted provider like Anthropic, OpenAI, or Google. The voice is just as
-        swappable: local engines Piper, Kokoro, and Chatterbox run on-device, or
-        a cloud voice from OpenAI or ElevenLabs. Change either one in the console
-        and the next spoken line uses it. No redeploy.
+        And both the model doing the thinking and the voice doing the talking are
+        the operator’s to choose — that is what comes next.
       </p>
     </EditorialReveal>
   );

--- a/web/components/what/UnderTheHood.tsx
+++ b/web/components/what/UnderTheHood.tsx
@@ -11,7 +11,7 @@ const BOXES = [
 export default function UnderTheHood() {
   return (
     <EditorialReveal className="bs-section">
-      <p className="bs-eyebrow">PART FIVE · UNDER THE HOOD</p>
+      <p className="bs-eyebrow">PART SIX · UNDER THE HOOD</p>
       <h2>Four processes, one box, one stream out.</h2>
 
       <div className="bs-drop-cap max-w-[64ch] text-[15px] leading-[1.6]">

--- a/web/components/what/YourStack.tsx
+++ b/web/components/what/YourStack.tsx
@@ -1,0 +1,109 @@
+import EditorialReveal from '../landing/EditorialReveal';
+import { cn } from '@/lib/cn';
+
+// A small tag chip, matching the broadsheet pill box used in the Navidrome
+// "also works with" row. The accent variant swaps the border + ink to
+// vermilion to flag the headline capability (voice cloning).
+function Pill({ children, accent }: { children: string; accent?: boolean }) {
+  return (
+    <span
+      className={cn(
+        'inline-block border px-[9px] py-[3px] text-[11px] tracking-[0.04em]',
+        accent ? 'border-vermilion text-vermilion' : 'border-separator-strong text-ink',
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+const BRAINS = [
+  'Ollama',
+  'Anthropic',
+  'OpenAI',
+  'Google',
+  'DeepSeek',
+  'OpenRouter',
+  'Vercel Gateway',
+  'OpenAI-compatible',
+];
+
+const VOICES = ['Piper', 'Kokoro', 'Chatterbox', 'PocketTTS', 'OpenAI', 'ElevenLabs'];
+
+export default function YourStack() {
+  return (
+    <EditorialReveal className="bs-section">
+      <p className="bs-eyebrow">PART THREE · THE STACK</p>
+      <h2>Bring your own brain. Bring your own voice.</h2>
+      <p className="text-muted">
+        The mind that picks the tracks and the voice that reads them out are two
+        separate, swappable seams. Choose a language model, choose a speech
+        engine, clone a voice if you want one. Change either in the console and
+        the next line on air uses it. No redeploy.
+      </p>
+
+      <div className="bs-whatis-grid mt-4">
+        <article className="bs-whatis-card">
+          <div className="bs-eyebrow mb-2">THE BRAIN · LLM</div>
+          <h3 className="m-0 mb-[10px] text-[clamp(20px,2.2vw,26px)] leading-[1.15] font-extrabold tracking-[-0.02em]">
+            Any model can run the booth.
+          </h3>
+          <p className="m-0 text-[14px] leading-[1.55] text-muted">
+            Every pick, every intro, every weather read goes through one
+            provider-agnostic seam. The default is a local Ollama box: private,
+            no API key, nothing leaves the house. Prefer a hosted model, an
+            aggregator with one key for every vendor, or your own
+            OpenAI-compatible server (llama.cpp, vLLM, LM Studio)? The call sites
+            never name a provider, so switching is a single dropdown.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-[6px]">
+            {BRAINS.map((b) => (
+              <Pill key={b}>{b}</Pill>
+            ))}
+          </div>
+        </article>
+
+        <article className="bs-whatis-card">
+          <div className="bs-eyebrow mb-2">THE VOICE · TTS</div>
+          <h3 className="m-0 mb-[10px] text-[clamp(20px,2.2vw,26px)] leading-[1.15] font-extrabold tracking-[-0.02em]">
+            And any voice can read it out.
+          </h3>
+          <p className="m-0 text-[14px] leading-[1.55] text-muted">
+            Local engines run on-device: Piper is the fast default and the
+            safety net, Kokoro trades speed for a warmer read. Or stream a cloud
+            voice from OpenAI or ElevenLabs. Every persona carries its own voice,
+            and you can hand a different one to each kind of segment, so the
+            station ID need not sound like the late-night host.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-[6px]">
+            {VOICES.map((v) => (
+              <Pill key={v}>{v}</Pill>
+            ))}
+          </div>
+        </article>
+      </div>
+
+      <div className="bs-whatis-card mt-4">
+        <div className="bs-eyebrow mb-2">VOICE CLONING</div>
+        <h3 className="m-0 mb-[10px] text-[clamp(20px,2.2vw,26px)] leading-[1.15] font-extrabold tracking-[-0.02em]">
+          Give a host a voice of its own.
+        </h3>
+        <p className="m-0 max-w-[64ch] text-[14px] leading-[1.55] text-muted">
+          Drop a short reference clip in the voices folder, point a persona at
+          it, and that DJ speaks in the cloned voice from the next line on.
+          Chatterbox does it zero-shot from a single WAV (and renders
+          paralinguistic cues like a laugh or a sigh); PocketTTS clones from a{' '}
+          <code className="text-[13px]">.wav</code> too; and a custom Piper voice
+          pair drops straight in. The 3am host can sound like anyone you have a
+          clip of, entirely on your own box.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-[6px]">
+          <Pill accent>Zero-shot cloning</Pill>
+          <Pill>Per-persona voices</Pill>
+          <Pill>Per-segment voices</Pill>
+          <Pill>Runs on-device</Pill>
+        </div>
+      </div>
+    </EditorialReveal>
+  );
+}


### PR DESCRIPTION
## What

Adds a new landing-page section — **PART THREE · THE STACK — "Bring your own brain. Bring your own voice."** — placed right after *Meet the Voices*, which already teased that the model and voice are swappable.

The section makes that flexibility concrete:

- **The Brain · LLM** — the provider-agnostic seam, local-Ollama default (private, no key), and a pill row of all 8 supported providers: Ollama, Anthropic, OpenAI, Google, DeepSeek, OpenRouter, Vercel Gateway, OpenAI-compatible (llama.cpp / vLLM / LM Studio).
- **The Voice · TTS** — local engines + cloud, per-persona and per-segment voices. Pills: Piper, Kokoro, Chatterbox, PocketTTS, OpenAI, ElevenLabs.
- **Voice Cloning** — a dedicated callout: drop a reference clip in the voices folder, point a persona at it. Chatterbox zero-shot from a single WAV (with paralinguistic cues), PocketTTS from a `.wav`, and custom Piper voice pairs — all on-device.

## How

- New `web/components/what/YourStack.tsx` section, reusing the existing broadsheet primitives (`bs-section`, `bs-eyebrow`, `bs-whatis-grid`, `bs-whatis-card`) plus a small Tailwind `Pill` that matches the Navidrome "also works with" pill box (no inline styles — uses `cn()`).
- Mounted `<YourStack />` in `Landing.tsx` after `MeetTheVoices`.
- Trimmed the now-redundant provider/engine list from `MeetTheVoices` into a one-line hand-off so the new section owns that content.
- Renumbered the subsequent parts to **FOUR / FIVE / SIX** (Requests / The Console / Under the Hood).

## Why

The bring-your-own LLM + bring-your-own voice (incl. cloning) story is a core differentiator that the landing page only mentioned in passing. This gives it a proper section.

## Verification

- `cd web && npm run lint` (`eslint . && tsc --noEmit`) — passes clean.
- All copy checked against the codebase (`LLM_PROVIDERS`, `TTS_ENGINES`, `TTS_CLOUD_PROVIDERS`, and the cloning paths in CLAUDE.md).