### PR TITLE
fix(web): keep masthead nav on one row on mobile

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -575,6 +575,26 @@ body::after {
     .bs-wordmark {
         font-size: clamp(38px, 13vw, 64px);
     }
+    /* Tighten the nav so all five items stay on one row on narrow phones —
+       the · separators already carry the visual break, so the flex gap and
+       the wide tracking can both relax without the row reading as cramped. */
+    .bs-masthead-nav {
+        gap: 7px;
+    }
+    .bs-masthead-link {
+        letter-spacing: 0.12em;
+    }
+}
+
+/* Smallest phones (iPhone-SE class, ~320px) need a tighter step still or the
+   GitHub link drops to a second row — squeeze the gap and tracking further. */
+@media (max-width: 360px) {
+    .bs-masthead-nav {
+        gap: 5px;
+    }
+    .bs-masthead-link {
+        letter-spacing: 0.06em;
+    }
 }
 
 /* Masthead wordmark — outsized Fraunces nameplate. Black weight for the


### PR DESCRIPTION
## What

The landing-page broadsheet nav (`.bs-masthead-nav`) wrapped the **GitHub** link onto a second line on phones.

## Why

Five links + four `·` separators, with a 14px flex `gap` and `0.3em` letter-spacing, overflowed narrow viewports — so the last item dropped to a new row.

## How

Tighten the gap and tracking in two mobile steps (desktop untouched — rules are `max-width` gated):

| breakpoint | `gap` | link `letter-spacing` |
|---|---|---|
| `≤ 560px` | `14px → 7px` | `0.3em → 0.12em` |
| `≤ 360px` | `→ 5px` | `→ 0.06em` |

The `·` separators already carry the visual break, so the relaxed spacing doesn't read as cramped.

## Verification

Ran the web dev server and tested with real device-viewport emulation:
- **Reproduced** the bug: at 375px the old values wrap to 2 rows (nav height 69px).
- **Confirmed** the fix: 320 / 360 / 375 / 390px all render the nav as a single row (height 31px).

```
- gap: 14px;  letter-spacing: 0.3em   (wrapped < ~400px)
+ gap: 7px;   letter-spacing: 0.12em  (≤560px)
+ gap: 5px;   letter-spacing: 0.06em  (≤360px)
```