### PR TITLE
fix(controller): stop DJ tools returning empty for titles & vibe queries

### DIFF
--- a/controller/src/llm/tools.ts
+++ b/controller/src/llm/tools.ts
@@ -106,12 +106,23 @@ export function buildPickerTools({
 
   const tools = {
     searchLibrary: tool({
-      description: 'Search the music library by artist name, song title, or real genre (e.g. "jazz", "punjabi"). Returns matching songs.',
+      description: 'Search the music library. Matches a literal artist name, song title, or real genre (e.g. "jazz", "punjabi") first; if nothing matches it falls back to semantic / vibe search, so descriptive multi-word queries like "punjabi r&b romantic" also work. Returns matching songs.',
       inputSchema: z.object({
-        query: z.string().describe('an artist name, song title, or genre'),
+        query: z.string().describe('an artist name, song title, genre, or vibe'),
       }),
       execute: async ({ query }) => {
-        try { return collect(await subsonic.search(query, { songCount: 25 })); }
+        try {
+          const out = collect(await subsonic.search(query, { songCount: 25 }));
+          if (out.length > 0) return out;
+          // Lexical search3 found nothing — fall back to semantic embedding
+          // search over the library (same path as searchByLyrics) so vibe
+          // queries still return tracks. No-op when embeddings aren't set up.
+          if (!embeddings.isAvailable()) return out;
+          await library.load();
+          const [vec] = await embeddings.embedTexts([query.trim()]);
+          if (!vec) return out;
+          return collect(library.tracksByVector(vec, 20));
+        }
         catch (err) { return { error: err.message }; }
       },
     }),
@@ -162,9 +173,9 @@ export function buildPickerTools({
     }),
 
     tracksLikeThis: tool({
-      description: 'Tracks whose mood + lyrics + metadata embed closest to a given song id — the controller\'s own semantic similarity over the actual library. Prefer this to similarSongs when "more of this vibe" matters more than "more by this artist". Pass the currently-playing song id to keep the flow going. Returns [] if the seed track has no embedding (rare — only fresh imports before the next tagger run).',
+      description: 'Tracks whose mood + lyrics + metadata embed closest to a seed track — the controller\'s own semantic similarity over the actual library. Prefer this to similarSongs when "more of this vibe" matters more than "more by this artist". Pass the currently-playing song id (best) OR a track title — a title is resolved to the matching track. Returns [] only if neither a song id nor a title match anything embedded.',
       inputSchema: z.object({
-        songId: z.string(),
+        songId: z.string().describe('a song id (preferred) or a track title'),
         k: z.number().int().min(1).max(50).default(20),
       }),
       execute: async ({ songId, k }) => {

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -167,10 +167,24 @@ export function songsByEnergy(energy: string | null | undefined): any[] {
 // KNN over the embedding space — finds tracks whose metadata + lyrics +
 // (optional) Last.fm tags embed close to the seed track's. Used by the picker's
 // embedding-similar pool source and the agent's tracksLikeThis tool.
-// Tracks without an embedding return []; callers fall back to other sources.
-export function tracksLikeThis(songId: string, k: number): any[] {
-  if (!loaded || !songId) return [];
-  const hits = db.knnById(songId, k);
+//
+// `seed` is normally a real track id, but the picker agent often passes a track
+// *title* instead (e.g. "Be Mine"). When the id lookup finds no embedding, we
+// resolve the string as a title via db.filter (LIKE over title/artist/album,
+// scoped to tagged tracks — the same set that carries embeddings) and KNN from
+// the first candidate that has one. Tracks with no embedding and no title match
+// return []; callers fall back to other sources.
+export function tracksLikeThis(seed: string, k: number): any[] {
+  if (!loaded || !seed) return [];
+  let hits = db.knnById(seed, k);
+  if (hits.length === 0) {
+    // Treat `seed` as a title — find the best embedded match and KNN from it.
+    for (const row of db.filter({ q: seed, limit: 8 }).rows) {
+      if (row.id === seed) continue;            // already tried as an id above
+      hits = db.knnById(row.id, k);
+      if (hits.length) break;
+    }
+  }
   const out: any[] = [];
   for (const hit of hits) {
     const t = db.getTrack(hit.id);


### PR DESCRIPTION
## Problem

Reviewing recent LLM calls surfaced two picker-agent music-discovery tools (`controller/src/llm/tools.ts`) consistently returning `[]` for the way the model actually calls them:

- `tracksLikeThis({songId:"Be Mine"})` → `[]`
- `searchLibrary({query:"Indian R&B Punjabi Pop 2024"})` → `[]`

### Root causes

1. **`tracksLikeThis`** — the agent passes track **titles** as `songId`, but `library.tracksLikeThis()` → `db.knnById()` does a primary-key lookup (`SELECT embedding FROM track_vectors WHERE id = ?`). A title never matches a row, so it returns `[]`. The schema (`songId: z.string()`) accepts any string, so the mistake fails silently.
2. **`searchLibrary`** — calls Subsonic `search3`, which is **lexical token matching** over artist/title/album tags, not semantic search. A descriptive vibe query needs every token to literally appear in a track's tags, so it almost always returns nothing — even though the codebase already has semantic search (`searchByLyrics`).

## Changes

- **`library.ts` — `tracksLikeThis` tolerates titles.** When the id lookup finds no embedding, the seed is resolved as a title via `db.filter({ q, limit: 8 })` (LIKE over title/artist/album, scoped to tagged/embedded tracks) and we KNN from the first candidate that has an embedding. The picker pool source passes real IDs, so its behaviour is unchanged.
- **`tools.ts` — `searchLibrary` semantic fallback.** Lexical `search3` first; if it returns nothing **and** embeddings are configured, embed the query and KNN over the library (the `searchByLyrics` path). Literal artist/genre lookups keep their single fast call; degrades to `[]` gracefully when embeddings aren't set up.
- Updated both tool descriptions so the model knows `searchLibrary` handles vibe queries and `tracksLikeThis` accepts a title or an id.

## Verification

- `npm run lint` in `controller/` — 0 errors (`tsc --noEmit` exit 0).
- Runtime: bring up dev, trigger a pick, and confirm via `/admin/debug`'s LLM ring buffer that a title-shaped `tracksLikeThis` call and a descriptive `searchLibrary` query now return tracks.

> Note: prod bakes source into the image — needs `up -d --build controller` to take effect.