### PR TITLE
feat(dj): spoken DJ handoffs at persona changeovers (#247)

### DIFF
--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -136,10 +136,15 @@ function normalizeForSpeech(text: string) {
 // admin Stats page can show per-engine usage, latency, and the fallback rate.
 export async function speak(
   text: string,
-  { kind = 'default', outPath, speedScale }: { kind?: string; outPath?: string; speedScale?: number } = {},
+  { kind = 'default', outPath, speedScale, persona }:
+    { kind?: string; outPath?: string; speedScale?: number; persona?: any } = {},
 ) {
   const speakText = normalizeForSpeech(text);
-  const personaTts = djPersonaTts(kind);
+  // An explicit persona always wins — this is how the DJ-handoff path voices the
+  // OUTGOING persona's sign-off, which is no longer the effective persona once
+  // the session has rolled. Without an override we fall back to the on-air
+  // persona for this kind (the historical behaviour).
+  const personaTts = persona ? (persona.tts || null) : djPersonaTts(kind);
   const primary = resolveEngine(kind, personaTts);
   // Delivery pace tracks the daypart for live, persona-voiced segments.
   // `speedScale` is a MULTIPLIER on the engine's configured speech rate (1.0 =

--- a/controller/src/broadcast/handoff.ts
+++ b/controller/src/broadcast/handoff.ts
@@ -1,0 +1,61 @@
+// DJ handoffs (discussion #247) — air a spoken changeover when one persona
+// signs off and a different one takes the shift.
+//
+// session.maybeRoll() detects the changeover (a hard roll whose incoming
+// persona differs from the outgoing one) and stashes a pendingHandoff on the
+// session. This module drains it at the next clean between-tracks moment — the
+// queue watcher calls maybeAir() right after maybeRoll(), before it picks the
+// next track. Two lines air back to back on the heavy-duck voice channel: the
+// outgoing DJ passes the mic by name, then the incoming DJ acknowledges. Each
+// line is voiced by its OWN persona (queue.announce's `persona` override), not
+// the now-effective one.
+//
+// Decoupling detection from airing is deliberate: a roll can be triggered by
+// the scheduler or a listener request between watcher ticks, but the handoff
+// should only ever land between songs. takePendingHandoff() returns the pair
+// exactly once, so a deferred handoff airs at the next transition and never
+// twice.
+
+import * as settings from '../settings.js';
+import * as session from './session.js';
+import * as dj from '../llm/dj.js';
+import { withTrace, logEvent } from '../observability/events.js';
+
+// Air a pending DJ handoff, if one is queued and the feature is on. Best-effort:
+// any failure is swallowed so a flaky LLM/TTS call never blocks the track pick
+// that follows in the watcher.
+export async function maybeAir(queue: any, ctx: any): Promise<void> {
+  if (!settings.get().llm?.handoffs) return;
+  const pending = session.takePendingHandoff();
+  if (!pending) return;
+
+  // Re-resolve full persona objects — takePendingHandoff only carries {id,name},
+  // and we need each persona's `tts` config to voice its line. If a persona was
+  // deleted between the roll and now, fall back to the stored stub (no tts →
+  // announce voices it with the engine default rather than going silent).
+  const outgoing = settings.resolvePersonaById(pending.outgoing?.id) || pending.outgoing;
+  const incoming = settings.resolvePersonaById(pending.incoming?.id) || pending.incoming;
+  if (!outgoing?.name || !incoming?.name) return;
+
+  // Best-effort: a flaky LLM/TTS call must not bubble up and skip the track pick
+  // that runs next in the watcher. The handoff is already claimed, so a failure
+  // simply means this one changeover goes unspoken — never a missed pick.
+  try {
+    await withTrace({ kind: 'handoff', from: outgoing.name, to: incoming.name }, async () => {
+      const slotLabel = dj.handoffSlotLabel(ctx);
+
+      // Outgoing DJ signs off — in the outgoing voice.
+      const signoff = await dj.generateHandoff({ outgoing, incoming, context: ctx, slotLabel });
+      await queue.announce(signoff, 'handoff', { persona: outgoing });
+
+      // Incoming DJ acknowledges — in the incoming voice. writeHandoff serialises
+      // the two say.txt writes, so this lands only after the sign-off has aired.
+      const ack = await dj.generateHandoffAck({ incoming, outgoing, context: ctx, slotLabel });
+      await queue.announce(ack, 'handoff', { persona: incoming });
+
+      logEvent('handoff.aired', { from: outgoing.name, to: incoming.name, slot: slotLabel });
+    });
+  } catch (err: any) {
+    queue.log('error', `DJ handoff failed: ${err?.message ?? err}`);
+  }
+}

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -11,6 +11,7 @@ import * as mix from '../music/mix.js';
 import * as library from '../music/library.js';
 import { speak } from '../audio/tts.js';
 import * as djAgent from './dj-agent.js';
+import * as handoff from './handoff.js';
 import * as sfx from './sfx.js';
 import * as session from './session.js';
 import { getFullContext, energyForDaypart } from '../context.js';
@@ -407,10 +408,13 @@ class Queue {
   //              song that just started stays audible underneath the voice)
   //   - everything else → say.txt → voice_queue → HEAVY duck (solo voice
   //              dominates; used for station ID / hourly / weather)
-  async announce(text, kind = 'announcement') {
+  // `persona` overrides the voice — used by the DJ-handoff path to air the
+  // outgoing persona's sign-off in their own voice (not the now-effective
+  // incoming one). Omitted everywhere else, so the on-air persona voices it.
+  async announce(text, kind = 'announcement', { persona }: { persona?: any } = {}) {
     if (!text || !text.trim()) return;
     try {
-      const wavPath = await speak(text, { kind });
+      const wavPath = await speak(text, { kind, persona });
       const targetFile = kind === 'link'
         ? config.liquidsoap.introFile
         : config.liquidsoap.sayFile;
@@ -641,6 +645,9 @@ class Queue {
         try {
           const ctx = await getFullContext();
           await session.maybeRoll(ctx);
+          // If that roll (or one a non-watcher caller queued) brought a new DJ
+          // on air, air the changeover here — between tracks, before the pick.
+          await handoff.maybeAir(this, ctx);
           await djAgent.runTrackEvent(this, ctx, { wantLink });
         } catch (err: any) {
           this.log('error', `DJ track event failed: ${err.message}`);

--- a/controller/src/broadcast/session.ts
+++ b/controller/src/broadcast/session.ts
@@ -115,6 +115,17 @@ export function getSession() {
   return _session;
 }
 
+// Claim-and-clear a pending DJ handoff (set by maybeRoll on a persona change).
+// Returns { outgoing, incoming } once, then null — so a deferred handoff airs
+// exactly one time even though the queue watcher polls every transition.
+export function takePendingHandoff(): { outgoing: any; incoming: any } | null {
+  if (!_session?.pendingHandoff) return null;
+  const pending = _session.pendingHandoff;
+  delete _session.pendingHandoff;
+  schedulePersist();
+  return pending;
+}
+
 // Append a turn. `role` ∈ event|dj|track|segment; `kind` names the turn type
 // (scenario|pick|request|play|link|station-id|hourly|weather|...).
 export function appendTurn({ role, kind, text, meta = {} }: { role: string; kind: string; text?: string; meta?: any }) {
@@ -181,7 +192,21 @@ export async function maybeRoll(ctx: any): Promise<any> {
 
   const prev = _session;
   await end();
-  return start(ctx, buildHandoff(prev));
+  const next = start(ctx, buildHandoff(prev));
+
+  // DJ handoff (discussion #247): a hard roll that brings a DIFFERENT persona
+  // on air is a real changeover — stash the outgoing/incoming pair so the queue
+  // watcher can air a spoken sign-off + acknowledgement at the next clean
+  // between-tracks moment (see broadcast/handoff.ts). Same-persona rolls (the
+  // 4h cap on a one-persona station, or a show owned by the persona already on
+  // air) produce no pointless self-handoff. Stored on the session so it rides
+  // through persistence and isn't lost if a non-watcher caller triggered the
+  // roll; the watcher clears it once aired.
+  if (prev?.persona?.id && next.persona?.id && prev.persona.id !== next.persona.id) {
+    next.pendingHandoff = { outgoing: prev.persona, incoming: next.persona };
+    schedulePersist();
+  }
+  return next;
 }
 
 // Soft continuation across an autonomous daypart/mood turnover: same session id,
@@ -249,6 +274,7 @@ export function windowMessages() {
     const m = recent[i];
     if (!m.text) continue;
     if (m.kind === 'scenario') continue;  // infra noise
+    if (m.kind === 'handoff') continue;    // changeover ceremony, not DJ conversation (one line is the OUTGOING voice)
     if (m.kind === 'play') continue;       // redundant — current track is in the pick event
     if (m.role === 'event' && m.kind === 'pick' && i !== lastPickEventIdx) continue;  // old pick asks
     const role = (m.role === 'dj' || m.role === 'segment') ? 'assistant' : 'user';

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -24,11 +24,11 @@ export { recentCalls };
 const CHATTERBOX_TAG_HINT =
   '\n\nYou may sparingly insert non-verbal cues in square brackets: [laugh], [chuckle], [sigh], [cough]. Use them only where genuinely natural — at most one per segment, and never as filler.';
 
-// Resolve the DJ system prompt for the persona on air right now. The effective
-// persona is the current show's owner if a show is scheduled for this hour,
-// otherwise the admin-selected active persona — see settings.getEffectivePersona.
-export function djSystem() {
-  const persona = settings.getEffectivePersona();
+// Resolve the DJ system prompt for a SPECIFIC persona. Most callers want the
+// persona on air right now (djSystem below); the DJ-handoff path renders one
+// line in the outgoing persona's voice and one in the incoming's, so it needs
+// to name the persona explicitly rather than read the effective one.
+export function djSystemFor(persona: any) {
   const s = settings.get();
   const base = settings.renderDjPrompt(persona, {
     station: s.station,
@@ -36,6 +36,13 @@ export function djSystem() {
   });
   if (persona?.tts?.engine === 'chatterbox') return base + CHATTERBOX_TAG_HINT;
   return base;
+}
+
+// Resolve the DJ system prompt for the persona on air right now. The effective
+// persona is the current show's owner if a show is scheduled for this hour,
+// otherwise the admin-selected active persona — see settings.getEffectivePersona.
+export function djSystem() {
+  return djSystemFor(settings.getEffectivePersona());
 }
 
 // Persona-driven verbosity. 'concise' reproduces the historical one-liner
@@ -416,6 +423,59 @@ export async function generateHourlyTime(time: any, weather: any, { recap = null
     prompt: decoratePrompt(ctxLines.join('\n'), { kind: 'hourly', recap, recentOpeners }),
     temperature: 0.9, topP: 0.95, repeatPenalty: 1.15, seed: randomSeed(),
     kind: 'generateHourlyTime',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// DJ HANDOFFS (discussion #247) — one persona signs off, the next takes over
+// ---------------------------------------------------------------------------
+// At a genuine changeover the outgoing DJ passes the mic and the incoming DJ
+// acknowledges. Each line is rendered in its OWN persona's voice via
+// djSystemFor(persona); broadcast/handoff.ts airs them in order, voicing each
+// with the matching persona's TTS config.
+
+// A human label for the slot the incoming DJ is taking — the show's name
+// (with its theme when set), else the daypart. Drives lines like
+// "…passing the mic over to Cool Hand Luke for your Afternoon Drive."
+export function handoffSlotLabel(context: any): string {
+  if (context?.activeShow?.name) {
+    return context.activeShow.topic
+      ? `${context.activeShow.name} (${context.activeShow.topic})`
+      : context.activeShow.name;
+  }
+  const t = context?.time;
+  if (t?.period) return t.vibe ? `the ${t.period} (${t.vibe})` : `the ${t.period}`;
+  return 'the next stretch';
+}
+
+// Outgoing persona's sign-off — names the incoming DJ and the slot they're
+// taking. Rendered in the OUTGOING voice.
+export async function generateHandoff({ outgoing, incoming, context, slotLabel }: any) {
+  const ctxLines = buildContextLines(context);
+  ctxLines.push(
+    `Task: you are ${outgoing?.name || 'the host'}, wrapping up your time on air and handing the mic to ${incoming?.name || 'the next DJ'}, who is taking over for ${slotLabel}. Sign off warmly and pass the mic to ${incoming?.name || 'them'} by name. ${lengthPhrase('link', outgoing)}, in character — no track talk, just the handover.`,
+  );
+  return djText({
+    system: djSystemFor(outgoing),
+    prompt: decoratePrompt(ctxLines.join('\n'), { kind: 'handoff' }),
+    temperature: 0.95, topP: 0.92, repeatPenalty: 1.2, seed: randomSeed(),
+    kind: 'generateHandoff',
+  });
+}
+
+// Incoming persona's acknowledgement — greets the outgoing DJ by name and steps
+// up to the mic. Rendered in the INCOMING voice. Kept to a single line so the
+// changeover lands quickly and the music gets going.
+export async function generateHandoffAck({ incoming, outgoing, context, slotLabel }: any) {
+  const ctxLines = buildContextLines(context);
+  ctxLines.push(
+    `Task: you are ${incoming?.name || 'the next DJ'}, just taking over the mic from ${outgoing?.name || 'the previous DJ'} for ${slotLabel}. Acknowledge ${outgoing?.name || 'them'} by name and greet the room in one short sentence, in character — then you're ready to roll. No track talk.`,
+  );
+  return djText({
+    system: djSystemFor(incoming),
+    prompt: decoratePrompt(ctxLines.join('\n'), { kind: 'handoff-ack' }),
+    temperature: 0.95, topP: 0.92, repeatPenalty: 1.2, seed: randomSeed(),
+    kind: 'generateHandoffAck',
   });
 }
 

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -368,6 +368,12 @@ const DEFAULTS = {
     // reports zero listeners — the stream coasts on the auto playlist — and
     // resume as soon as someone tunes in. Off by default.
     pauseWhenEmpty: false,
+    // When on, a real DJ changeover (one persona signs off, a different one
+    // takes the shift at a show boundary or the 4h session cap) airs a spoken
+    // handoff: the outgoing DJ passes the mic by name and the incoming DJ
+    // acknowledges (discussion #247). On by default; only ever fires when the
+    // persona actually changes, so a single-persona station never hears it.
+    handoffs: true,
   },
   // Embedding-propagated library tagger (music/tag-library.ts).
   //
@@ -785,6 +791,10 @@ export async function load() {
         typeof stored.llm?.pauseWhenEmpty === 'boolean'
           ? stored.llm.pauseWhenEmpty
           : DEFAULTS.llm.pauseWhenEmpty,
+      handoffs:
+        typeof stored.llm?.handoffs === 'boolean'
+          ? stored.llm.handoffs
+          : DEFAULTS.llm.handoffs,
     },
     search: {
       provider: SEARCH_PROVIDERS.includes(stored.search?.provider)
@@ -1502,6 +1512,9 @@ export async function update(patch) {
     }
     if (l.pauseWhenEmpty !== undefined) {
       next.llm.pauseWhenEmpty = !!l.pauseWhenEmpty;
+    }
+    if (l.handoffs !== undefined) {
+      next.llm.handoffs = !!l.handoffs;
     }
     // An OpenAI-compatible provider is useless without a server to talk to.
     if (next.llm.provider === 'openai-compatible' && !next.llm.baseUrl) {

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -97,6 +97,7 @@ interface LlmForm {
   reasoning: boolean;
   pickerAgent: boolean;
   pauseWhenEmpty: boolean;
+  handoffs: boolean;
 }
 
 interface SearchForm {
@@ -336,6 +337,7 @@ export default function SettingsPanel() {
         reasoning: !!v.llm?.reasoning,
         pickerAgent: !!v.llm?.pickerAgent,
         pauseWhenEmpty: !!v.llm?.pauseWhenEmpty,
+        handoffs: v.llm?.handoffs !== false,  // default on
       },
       search: {
         provider: v.search?.provider ?? 'duckduckgo',
@@ -1474,6 +1476,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
       reasoning: form.llm.reasoning,
       pickerAgent: form.llm.pickerAgent,
       pauseWhenEmpty: form.llm.pauseWhenEmpty,
+      handoffs: form.llm.handoffs,
     },
   });
 
@@ -1684,6 +1687,31 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
               { id: 'on', label: 'On' },
             ]}
             onChange={v => setForm(f => ({ ...f, llm: { ...f.llm, pauseWhenEmpty: v === 'on' } }))}
+          />
+        </div>
+      </Card>
+
+      <Card title="DJ handoffs" sub="when the persona on air changes">
+        <div className="grid grid-cols-[1fr_auto] items-center gap-4">
+          <div>
+            <div className="text-[13px] font-bold">Spoken changeover</div>
+            <div className="mt-0.5 max-w-[480px] text-[11px] leading-[1.5] text-muted">
+              When on, a real DJ changeover — one persona signing off as a
+              different one takes the shift (a scheduled show starting or ending,
+              or the long-session reset) — airs a short handoff: the outgoing DJ
+              passes the mic by name and the incoming DJ acknowledges. Only fires
+              when the persona actually changes, so a single-persona station
+              never hears it.
+            </div>
+          </div>
+          <Seg
+            accent
+            value={form.llm.handoffs ? 'on' : 'off'}
+            options={[
+              { id: 'off', label: 'Off' },
+              { id: 'on', label: 'On' },
+            ]}
+            onChange={v => setForm(f => ({ ...f, llm: { ...f.llm, handoffs: v === 'on' } }))}
           />
         </div>
       </Card>


### PR DESCRIPTION
Closes the [#247](https://github.com/perminder-klair/subwave/discussions/247) idea: when a show ends and a different DJ takes over, the outgoing persona signs off and passes the mic — and the incoming persona acknowledges.

> "This is Johnny Fever signing off for now, passing the mic over to Cool Hand Luke for your Afternoon Drive time" — and Cool Hand Luke gets to answer back.

## How it works

The changeover already exists in the session machinery — `session.maybeRoll()` hard-rolls to a fresh session at a show boundary or the 4h cap, and the new session's persona is whatever `getEffectivePersona()` resolves (the new show's owner, or the active persona). This builds on that:

1. **Detect** — in `maybeRoll`, when a hard roll brings an incoming persona whose id differs from the outgoing one, stash `{ outgoing, incoming }` as `pendingHandoff` on the session. Same-persona rolls (a one-persona station, or a show owned by the DJ already on air) produce nothing. It rides on the persisted session, so a roll triggered by the scheduler or a listener request between watcher ticks isn't lost.
2. **Air** — the queue watcher calls `handoff.maybeAir()` right after `maybeRoll()`, at the genuine between-tracks moment, before it picks the next track. Two lines air back to back on the heavy-duck voice channel (`writeHandoff` serialises the writes so the ack lands after the sign-off). Best-effort: a flaky LLM/TTS call is swallowed and never blocks the pick.
3. **Voice** — each line is spoken by its **own** persona. `tts.speak` / `queue.announce` gain an optional `persona` override, so the sign-off uses the *outgoing* voice even though that persona is no longer effective after the roll.

## Changes

- `broadcast/session.ts` — stash `pendingHandoff` on a persona-changing hard roll; `takePendingHandoff()` claim-and-clear (fires once); filter `handoff` turns from the DJ agent window (changeover ceremony, not conversation — same treatment as `scenario` turns).
- `broadcast/handoff.ts` *(new)* — orchestrates: re-resolve full personas, generate + air both lines, trace + `handoff.aired` event.
- `broadcast/queue.ts` — `announce(text, kind, { persona })` pass-through; call `handoff.maybeAir()` in the watcher.
- `audio/tts.ts` — optional `persona` voice override on `speak()`.
- `llm/dj.ts` — `djSystem()` → `djSystemFor(persona)`; new `generateHandoff` / `generateHandoffAck`; `handoffSlotLabel()` for "…for your Afternoon Drive" slot naming.
- `settings.ts` — `llm.handoffs` toggle (default **on**) with persistence + validation.
- `web/components/admin/SettingsPanel.tsx` — "DJ handoffs" toggle card under LLM settings.

## Testing

- `controller`: `npm run lint` (eslint + `tsc --noEmit`) — 0 errors.
- `web`: `npm run lint` — clean.

No test runner in the repo. Manual smoke: schedule two back-to-back shows with different personas (or change the active persona across a roll) and watch the controller log for the two `handoff` segments, each voiced by the right persona. Single-persona stations never trigger it.