### PR TITLE
fix(web): personalise homepage link-preview with the operator's station name (#272)

### DIFF
--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -149,6 +149,10 @@ services:
       # share-card tags render per-request. Define SITE_URL once in .env and
       # both build-arg and runtime env pick it up.
       - SITE_URL=\${SITE_URL:-}
+      # Server-side base URL for generateMetadata on the force-dynamic homepage
+      # to read the live station name from the controller. Internal compose
+      # network name — not exposed to the browser (which uses /api via Caddy).
+      - CONTROLLER_INTERNAL_URL=http://controller:7701
 
   # -------------------------------------------------------------------------
   # TTS-HEAVY (optional) — sidecar for Chatterbox + PocketTTS
@@ -315,6 +319,10 @@ services:
       - NODE_ENV=production
       - SUBWAVE_HOMEPAGE=\${SUBWAVE_HOMEPAGE:-player}
       - SITE_URL=\${SITE_URL:-}
+      # Server-side base URL for generateMetadata on the force-dynamic homepage
+      # to read the live station name from the controller. Internal compose
+      # network name — not exposed to the browser (which uses /api via Caddy).
+      - CONTROLLER_INTERNAL_URL=http://controller:7701
     ports:
       - "\${WEB_PORT:-7700}:7700"
     # Same-origin (/api, /stream.mp3) is the default baked into the image.
@@ -572,4 +580,4 @@ SITE_URL=
 
 // cli/package.json#version (embedded so the compiled binary can self-identify
 // — used by `subwave --version` and by the TUI release fetch URL).
-export const CLI_VERSION = `0.4.0`;
+export const CLI_VERSION = `0.7.0`;

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -108,6 +108,10 @@ services:
       - NODE_ENV=production
       - SUBWAVE_HOMEPAGE=${SUBWAVE_HOMEPAGE:-player}
       - SITE_URL=${SITE_URL:-}
+      # Server-side base URL for generateMetadata on the force-dynamic homepage
+      # to read the live station name from the controller. Internal compose
+      # network name — not exposed to the browser (which uses /api via Caddy).
+      - CONTROLLER_INTERNAL_URL=http://controller:7701
     ports:
       - "${WEB_PORT:-7700}:7700"
     # Same-origin (/api, /stream.mp3) is the default baked into the image.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,6 +140,10 @@ services:
       # share-card tags render per-request. Define SITE_URL once in .env and
       # both build-arg and runtime env pick it up.
       - SITE_URL=${SITE_URL:-}
+      # Server-side base URL for generateMetadata on the force-dynamic homepage
+      # to read the live station name from the controller. Internal compose
+      # network name — not exposed to the browser (which uses /api via Caddy).
+      - CONTROLLER_INTERNAL_URL=http://controller:7701
 
   # -------------------------------------------------------------------------
   # TTS-HEAVY (optional) — sidecar for Chatterbox + PocketTTS

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -2,19 +2,65 @@ import type { Metadata, Viewport } from 'next';
 import PlayerApp from '@/components/PlayerApp';
 import Landing from '@/components/Landing';
 import { absoluteUrl } from '@/lib/seo';
+import { fetchStationIdentity } from '@/lib/station';
 
 // Read at request time so a deployment can flip player ↔ landing by just
 // restarting the web container with a different env value, no rebuild.
 export const dynamic = 'force-dynamic';
 
-// Self-canonical for the root. Title/description/social are inherited from the
-// root layout; we only need to pin the canonical + og:url to the absolute
-// origin (the Metadata API leaves absolute strings untouched even though it
-// drops metadataBase on this force-dynamic route).
-export const metadata: Metadata = {
-  alternates: { canonical: absoluteUrl('/') },
-  openGraph: { url: absoluteUrl('/') },
-};
+// The product name — also the default value of the controller's
+// `settings.station`, so an un-personalised install reports this verbatim.
+const DEFAULT_STATION = 'SUB/WAVE';
+
+// Per-request metadata for the root. The baseline (always emitted) pins the
+// canonical + og:url to the absolute origin — the Metadata API leaves absolute
+// strings untouched even though it drops metadataBase on this force-dynamic
+// route. Title/description/social otherwise inherit from the root layout.
+//
+// When the homepage is the player (not the landing broadsheet), we personalise
+// the share-card preview with the operator's station name + DJ tagline read
+// live from the controller (issue #272). On landing mode, a missing/default
+// station, or any controller failure we fall through to the generic SUB/WAVE
+// branding so the preview never breaks.
+export async function generateMetadata(): Promise<Metadata> {
+  const base: Metadata = {
+    alternates: { canonical: absoluteUrl('/') },
+    openGraph: { url: absoluteUrl('/') },
+  };
+
+  const mode = (process.env.SUBWAVE_HOMEPAGE || 'player').toLowerCase();
+  if (mode !== 'player') return base;
+
+  const id = await fetchStationIdentity();
+  const station = id?.station?.trim() || '';
+  const tagline = id?.tagline?.trim() || '';
+
+  // Nothing to personalise: no station (or still the default product name) and
+  // no tagline → behave exactly as an un-personalised install does today.
+  if ((!station || station === DEFAULT_STATION) && !tagline) return base;
+
+  const name = station || DEFAULT_STATION;
+  const description =
+    tagline ||
+    `Tune in to ${name} — one live stream, with an AI DJ picking tracks and talking between them.`;
+
+  // openGraph/twitter are NOT deep-merged across the layout→page chain (see
+  // lib/seo.ts pageMeta), so restate them fully here. The layout's hand-written
+  // og:image/twitter:image <meta> tags are emitted independently and remain.
+  return {
+    title: name,
+    description,
+    alternates: { canonical: absoluteUrl('/') },
+    openGraph: {
+      title: name,
+      description,
+      siteName: name,
+      url: absoluteUrl('/'),
+      type: 'website',
+    },
+    twitter: { title: name, description },
+  };
+}
 
 // Fixed app-shell layouts (both player and landing) — lock out pinch-zoom
 // so they behave like a native app on mobile. Merges with the root viewport.

--- a/web/lib/station.ts
+++ b/web/lib/station.ts
@@ -1,0 +1,39 @@
+// Server-side station identity lookup, used by the force-dynamic homepage's
+// generateMetadata() to personalise the share-card preview (issue #272).
+//
+// This runs in the Next.js server (the `web` container in prod), NOT the
+// browser, so it cannot use NEXT_PUBLIC_API_URL — that resolves to `/api`, a
+// browser-relative path routed through Caddy. Instead reach the controller
+// directly over the internal compose network:
+//   CONTROLLER_INTERNAL_URL (set on the web service in both prod composes)
+//   → http://localhost:7701 (dev fallback: `npm run dev` web runs on the host
+//     and the dev compose binds the controller on 7701).
+const CONTROLLER_BASE = (
+  process.env.CONTROLLER_INTERNAL_URL || 'http://localhost:7701'
+).replace(/\/$/, '');
+
+export interface StationIdentity {
+  station: string;
+  tagline: string;
+}
+
+// Fetch the operator's station name + DJ tagline from the controller's public
+// /dj endpoint. Returns null on any failure (controller down, timeout, non-OK)
+// so the caller can fall back to the generic SUB/WAVE branding — the preview
+// must never break.
+export async function fetchStationIdentity(): Promise<StationIdentity | null> {
+  try {
+    const res = await fetch(`${CONTROLLER_BASE}/dj`, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(1500),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return {
+      station: typeof data?.station === 'string' ? data.station : '',
+      tagline: typeof data?.tagline === 'string' ? data.tagline : '',
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #272.

## Problem

When the homepage URL is shared (WhatsApp, iMessage, Slack, Twitter, …), the link-preview card always showed the **product** branding — title `SUB/WAVE` and the boilerplate description — instead of the operator's configured **station**.

## Fix

The homepage (`/`) is already `force-dynamic`, so it can read the live station name per-request with no rebuild.

- **`web/lib/station.ts`** (new) — server-side fetch of the controller's `/dj` endpoint (`station` + `tagline`) via `CONTROLLER_INTERNAL_URL`. 1.5s timeout, returns `null` on any failure so the preview never breaks.
- **`web/app/page.tsx`** — static `metadata` → async `generateMetadata()`. In player mode: **title = station name**, **description = DJ tagline** (or a station-personalised fallback sentence when no tagline is set). Landing mode, the default `SUB/WAVE` station, or any controller failure all fall through to today's generic branding.
- **`docker-compose.yml` + `docker-compose.byo.yml`** — wire `CONTROLLER_INTERNAL_URL=http://controller:7701` into the web service (server-side code can't use the browser-relative `/api`). Dev uses the `localhost:7701` fallback, so no dev-compose change.

## Behaviour

| Situation | Preview title | Preview text |
|---|---|---|
| Station name + tagline set | station name | tagline |
| Station name, no tagline | station name | "Tune in to … — one live stream, with an AI DJ picking tracks…" |
| Default / unconfigured | `SUB/WAVE` | unchanged |
| Landing homepage mode | `SUB/WAVE` | unchanged |
| Controller down | `SUB/WAVE` | unchanged (safe fallback) |

Scoped to the homepage in player mode only. JSON-LD / share-image branding and `/listen` are intentionally untouched.

## Verification

- `cd web && npm run lint` (eslint + `tsc --noEmit`) passes.
- Integration-tested `fetchStationIdentity` against a stub `/dj` server — all cases pass: personalised parse, non-OK → null, unreachable → null, default-station passthrough.