### PR TITLE
feat(web): redesign player footer as a console deck with live signal meter

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -712,6 +712,12 @@ body::after {
     .v3-cover-ambient {
         transition: none;
     }
+    /* Console-deck footer: the volume knob pointer and the signal needle glide
+       on a transition — snap them instead so nothing sweeps under reduced motion. */
+    .fz-knob,
+    .fz-scale .fz-needle {
+        transition: none;
+    }
 }
 
 /* Player title — Fraunces display serif (see the type-roles block up top).
@@ -758,6 +764,230 @@ body::after {
 }
 .player-topbar .v3-caption {
     font-size: 12px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+   CONSOLE DECK — the player footer's hardware controls (TransportBar).
+   Ported from docs/footer-options (design A) but recoloured to the app's
+   tokens so it tracks light/dark: --accent (vermilion), --ink, --field, and
+   translucent inks via color-mix. Layout + responsive behaviour live in
+   Tailwind on the JSX; only the analog part internals (rings, ticks, needle,
+   conic knob scale, grille dots) live here where utilities can't reach.
+   ───────────────────────────────────────────────────────────────────────── */
+.fz-deck {
+    /* Divider between compartments + the field/border tints, scoped here so
+       the JSX can reference them as border-[color:var(--fz-line)] etc. */
+    --fz-line: color-mix(in oklab, var(--ink) 22%, transparent);
+    --fz-dim: color-mix(in oklab, var(--ink) 45%, transparent);
+    /* Top edge of the bar — lighter than full ink so it reads as a soft rule. */
+    --fz-edge: color-mix(in oklab, var(--ink) 55%, transparent);
+}
+
+/* Power — circular button, open ring + stem (the power glyph). The ring sits
+   dim until tuned in, lights to vermilion when on air, and pulses while
+   connecting (shared .v3-connecting-pulse on the ring element). */
+.fz-power {
+    position: relative;
+    border-radius: 50%;
+    border: 1px solid var(--ink);
+    background: transparent;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: none;
+    transition: background 0.15s;
+}
+.fz-power:hover {
+    background: color-mix(in srgb, var(--ink) 8%, transparent);
+}
+.fz-power:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+}
+.fz-power:disabled:hover {
+    background: transparent;
+}
+.fz-power .fz-ring {
+    width: 38%;
+    aspect-ratio: 1;
+    border-radius: 50%;
+    border: 2px solid var(--fz-dim);
+    position: relative;
+    transition: border-color 0.2s;
+}
+.fz-power .fz-ring::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: -22%;
+    width: 2px;
+    height: 36%;
+    background: var(--fz-dim);
+    transform: translateX(-50%);
+    transition: background 0.2s;
+}
+.fz-power[data-tuned="true"] .fz-ring {
+    border-color: var(--accent);
+}
+.fz-power[data-tuned="true"] .fz-ring::after {
+    background: var(--accent);
+}
+
+/* Signal — analog scale: faint tick rule masked to the top band, a vermilion
+   needle (triangle head + square grip) positioned by inline left:%, and the
+   0–250 numerals along the bottom. Decorative; the value is read aloud via a
+   label on the section in the JSX. */
+.fz-scale {
+    position: relative;
+    border: 1px solid var(--fz-line);
+    background: var(--field);
+    overflow: hidden;
+    flex: none;
+    min-width: 0;
+    width: 100%;
+}
+.fz-scale .fz-ticks {
+    position: absolute;
+    inset: 0;
+    background-image:
+        repeating-linear-gradient(
+            90deg,
+            color-mix(in oklab, var(--ink) 40%, transparent) 0 1px,
+            transparent 1px 10px
+        ),
+        repeating-linear-gradient(
+            90deg,
+            color-mix(in oklab, var(--ink) 62%, transparent) 0 1.5px,
+            transparent 1.5px 50px
+        );
+    opacity: 0.55;
+    -webkit-mask: linear-gradient(180deg, #000 0 15px, transparent 15px);
+    mask: linear-gradient(180deg, #000 0 15px, transparent 15px);
+}
+.fz-scale .fz-nums {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 5px;
+    display: flex;
+    justify-content: space-between;
+    padding: 0 4px;
+    font-size: 9px;
+    letter-spacing: 0.08em;
+    color: color-mix(in oklab, var(--ink) 40%, transparent);
+}
+.fz-scale .fz-needle {
+    position: absolute;
+    top: 3px;
+    bottom: 3px;
+    /* Driven by the JSX via a ref-set --fz-needle-pos (0–100%), mirroring the
+       progress-bar pattern so we avoid inline styles. */
+    left: var(--fz-needle-pos, 0%);
+    width: 2px;
+    background: var(--accent);
+    transform: translateX(-50%);
+    transition: left 0.35s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+.fz-scale .fz-needle::before {
+    content: "";
+    position: absolute;
+    top: -1px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 5px solid var(--accent);
+}
+.fz-scale .fz-needle .fz-grip {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 9px;
+    height: 9px;
+    transform: translate(-50%, -50%);
+    background: var(--accent);
+}
+
+/* Volume knob — open ring + inner cap + vermilion pointer; the conic ring of
+   ticks behind it reads as a level scale (starts from -135deg, matching the
+   pointer angle the JSX sets inline as -135 + volume*270). */
+.fz-knob-wrap {
+    position: relative;
+    flex: none;
+}
+.fz-knob-ticks {
+    position: absolute;
+    inset: -7px;
+    border-radius: 50%;
+    background: repeating-conic-gradient(
+        from -135deg,
+        color-mix(in oklab, var(--ink) 40%, transparent) 0 1.2deg,
+        transparent 1.2deg 13.5deg
+    );
+    -webkit-mask: radial-gradient(
+        closest-side,
+        transparent calc(100% - 6px),
+        #000 calc(100% - 5px)
+    );
+    mask: radial-gradient(
+        closest-side,
+        transparent calc(100% - 6px),
+        #000 calc(100% - 5px)
+    );
+    opacity: 0.6;
+}
+.fz-knob {
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    background: transparent;
+    border: 1px solid var(--ink);
+    /* Pointer angle driven by the JSX via a ref-set --fz-angle (-135..135deg)
+       from the current volume; matches the conic tick scale's -135deg origin. */
+    transform: rotate(var(--fz-angle, 0deg));
+    transition: transform 0.12s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+.fz-knob .fz-cap {
+    position: absolute;
+    inset: 22%;
+    border-radius: 50%;
+    border: 1px solid var(--fz-line);
+}
+.fz-knob .fz-pointer {
+    position: absolute;
+    left: 50%;
+    top: 8%;
+    width: 2px;
+    height: 28%;
+    background: var(--accent);
+    transform: translateX(-50%);
+}
+
+/* Mute grille — dotted speaker grille; dots go vermilion + the border lights
+   when muted, so the engaged (silenced) state reads at a glance. */
+.fz-grille {
+    flex: none;
+    border: 1px solid var(--fz-line);
+    background-color: transparent;
+    background-image: radial-gradient(
+        color-mix(in oklab, var(--ink) 18%, transparent) 1.3px,
+        transparent 1.5px
+    );
+    background-size: 8px 8px;
+    background-position: center;
+    cursor: pointer;
+    transition:
+        background-color 0.15s,
+        border-color 0.15s;
+}
+.fz-grille:hover {
+    background-color: color-mix(in srgb, var(--ink) 7%, transparent);
+}
+.fz-grille[data-muted="true"] {
+    border-color: var(--accent);
+    background-color: color-mix(in srgb, var(--accent) 10%, transparent);
+    background-image: radial-gradient(var(--accent) 1.3px, transparent 1.5px);
 }
 
 /* ─────────────────────────────────────────────────────────────────────────

--- a/web/components/CenterStage.tsx
+++ b/web/components/CenterStage.tsx
@@ -73,7 +73,7 @@ export default function CenterStage({ nowPlaying, elapsed, feed, djLineOn, onOpe
   useDynamicStyle(coverRef, { '--cover': coverSrc ? `url("${coverSrc}")` : null });
 
   return (
-    <div className="absolute top-1/2 right-24 left-4 flex -translate-y-[58%] flex-col items-start sm:left-8">
+    <div className="absolute top-1/2 right-24 left-4 flex -translate-y-[64%] flex-col items-start sm:left-8">
       <div className="isolate flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-6">
         {coverSrc && (
           <button

--- a/web/components/DotRail.tsx
+++ b/web/components/DotRail.tsx
@@ -28,9 +28,7 @@ export interface DotRailProps {
 export default function DotRail({ counts, active, onSelect }: DotRailProps) {
   return (
     <div
-      className="absolute top-20 right-0 bottom-20 z-20 flex w-24
-        flex-col items-center justify-center gap-1
-        sm:[border-left:1px_solid_var(--ink)]"
+      className="absolute top-20 right-0 bottom-20 z-20 flex w-24 flex-col items-center justify-center gap-1"
     >
       {ITEMS.map(item => {
         const isActive = active === item.k;

--- a/web/components/PlayerApp.tsx
+++ b/web/components/PlayerApp.tsx
@@ -20,6 +20,7 @@ import RequestDrawer from './drawers/RequestDrawer';
 import ScheduleDrawer from './drawers/ScheduleDrawer';
 import { useStationFeed } from '@/hooks/useStationFeed';
 import { usePlayer } from '@/hooks/usePlayer';
+import { useSignal } from '@/hooks/useSignal';
 import { useMediaSession } from '@/hooks/useMediaSession';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { useCoverColors } from '@/hooks/useCoverColors';
@@ -48,6 +49,15 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
   // streamOnline is null until the first poll resolves — only treat an
   // explicit false as offline so the player never flashes "offline" on load.
   const offline = streamOnline === false;
+
+  // Connection-health meter for the footer's signal scale — measured latency
+  // to the controller, probed only while tuned in (see useSignal).
+  const signal = useSignal({ tunedIn, status, offline });
+
+  // Listener count now lives in the footer's signal readout (not the header) —
+  // normalise the feed's number | { current } | null shape to a plain count.
+  const listenerCount =
+    listeners == null ? null : typeof listeners === 'number' ? listeners : (listeners.current ?? null);
 
   // If the station goes off air while someone is tuned in, tear playback down
   // so the <audio> element isn't left retrying a dead mount.
@@ -231,7 +241,6 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
         stationName={typeof dj?.station === 'string' ? dj.station : undefined}
         djName={typeof dj?.name === 'string' ? dj.name : undefined}
         activeShow={activeShow}
-        listeners={listeners}
         onOpenSchedule={() => setDrawer('schedule')}
       />
 
@@ -266,9 +275,13 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
         volume={volume}
         setVolume={setVolume}
         volumePulse={volumePulse}
+        muted={muted}
+        onToggleMute={toggleMute}
+        latencyMs={signal.latencyMs}
+        signalQuality={signal.quality}
+        listeners={listenerCount}
         nowPlaying={nowPlaying}
         elapsed={elapsed}
-        context={context}
       />
 
       <Sheet

--- a/web/components/TopBar.tsx
+++ b/web/components/TopBar.tsx
@@ -1,11 +1,8 @@
 'use client';
 
-import { Headphones } from 'lucide-react';
 import { buildTagline } from '@/lib/tagline';
-import { cn } from '@/lib/cn';
-import OdometerNumber from './OdometerNumber';
 import ThemeSwitcher from './ThemeSwitcher';
-import type { ActiveShow, ListenerCount, StationContext } from '@/lib/types';
+import type { ActiveShow, StationContext } from '@/lib/types';
 
 export interface TopBarProps {
   tunedIn: boolean;
@@ -13,14 +10,9 @@ export interface TopBarProps {
   stationName?: string;
   djName?: string;
   activeShow: ActiveShow | null;
-  listeners: ListenerCount | number | null;
   /** Optional — when provided, the show + host line becomes a button that
    *  opens the Schedule drawer. Omitted on Landing where there's no player. */
   onOpenSchedule?: () => void;
-}
-
-function isListenerObject(l: ListenerCount | number | null): l is ListenerCount {
-  return !!l && typeof l === 'object';
 }
 
 export default function TopBar({
@@ -29,14 +21,12 @@ export default function TopBar({
   stationName,
   djName,
   activeShow,
-  listeners,
   onOpenSchedule,
 }: TopBarProps) {
   const tagline = buildTagline(context);
   // When a programmed show is on air, name it and prefer its host.
   const showName = activeShow?.name || null;
   const onAirName = activeShow?.persona?.name || djName;
-  const listenerObj = isListenerObject(listeners) ? listeners : null;
   return (
     <div
       // viewport-fit=cover lets the header extend under the iPhone notch /
@@ -44,76 +34,72 @@ export default function TopBar({
       // baseline gutter; left/right max() against the gutter so landscape
       // on a notched phone doesn't clip the wordmark, while desktop keeps
       // its wider sm: gutters.
-      className="player-topbar absolute top-0 right-0 left-0 z-30 flex items-center justify-between gap-3 border-b border-ink
-        pt-[calc(env(safe-area-inset-top)_+_0.625rem)] pr-[max(1rem,env(safe-area-inset-right))]
+      className="player-topbar absolute top-0 right-0 left-0 z-30 flex flex-col gap-1 border-b border-ink bg-bg/55 pt-[calc(env(safe-area-inset-top)_+_0.625rem)] pr-[max(1rem,env(safe-area-inset-right))]
         pb-2.5 pl-[max(1rem,env(safe-area-inset-left))]
+        backdrop-blur-xl backdrop-saturate-150
         sm:pt-[calc(env(safe-area-inset-top)_+_0.875rem)] sm:pr-[max(2rem,env(safe-area-inset-right))]
         sm:pb-3.5 sm:pl-[max(2rem,env(safe-area-inset-left))]"
     >
-      <div className="flex min-w-0 items-baseline gap-2 sm:gap-[14px]">
-        <span
-          className="player-mark"
-          data-spinning={tunedIn ? 'true' : undefined}
-          aria-hidden="true"
-        />
-        <span className="v3-eyebrow shrink-0">{stationName?.trim() || 'SUB/WAVE'}</span>
-        {showName && (
-          onOpenSchedule ? (
-            <button
-              type="button"
-              onClick={onOpenSchedule}
-              className="v3-caption v3-focus min-w-0 cursor-pointer truncate border-0 bg-transparent p-0 text-left text-ink hover:underline"
-              title={`${showName} — open schedule`}
-            >
-              ▸ {showName}
-            </button>
-          ) : (
-            <span className="v3-caption min-w-0 truncate text-ink" title={showName}>
-              ▸ {showName}
-            </span>
-          )
-        )}
-        {onAirName && (
-          onOpenSchedule ? (
-            <button
-              type="button"
-              onClick={onOpenSchedule}
-              className="v3-caption v3-focus cursor-pointer truncate border-0 bg-transparent p-0 text-left text-vermilion hover:underline"
-              title="Open schedule"
-            >
-              with {onAirName}
-            </button>
-          ) : (
-            <span className="v3-caption truncate text-vermilion">
-              with {onAirName}
-            </span>
-          )
-        )}
-        {tagline && (
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-baseline gap-2 sm:gap-[14px]">
           <span
-            className="v3-caption hidden truncate text-muted md:inline"
-            title={tagline}
-          >
-            {tagline}
-          </span>
-        )}
+            className="player-mark"
+            data-spinning={tunedIn ? 'true' : undefined}
+            aria-hidden="true"
+          />
+          <span className="v3-eyebrow shrink-0">{stationName?.trim() || 'SUB/WAVE'}</span>
+          {showName && (
+            onOpenSchedule ? (
+              <button
+                type="button"
+                onClick={onOpenSchedule}
+                className="v3-caption v3-focus min-w-0 cursor-pointer truncate border-0 bg-transparent p-0 text-left text-ink hover:underline"
+                title={`${showName} — open schedule`}
+              >
+                ▸ {showName}
+              </button>
+            ) : (
+              <span className="v3-caption min-w-0 truncate text-ink" title={showName}>
+                ▸ {showName}
+              </span>
+            )
+          )}
+          {onAirName && (
+            onOpenSchedule ? (
+              <button
+                type="button"
+                onClick={onOpenSchedule}
+                className="v3-caption v3-focus cursor-pointer truncate border-0 bg-transparent p-0 text-left text-vermilion hover:underline"
+                title="Open schedule"
+              >
+                with {onAirName}
+              </button>
+            ) : (
+              <span className="v3-caption truncate text-vermilion">
+                with {onAirName}
+              </span>
+            )
+          )}
+          {tagline && (
+            <span
+              className="v3-caption hidden min-w-0 truncate text-muted md:inline"
+              title={tagline}
+            >
+              {tagline}
+            </span>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center">
+          <ThemeSwitcher variant="player" />
+        </div>
       </div>
-      <div className="v3-caption flex shrink-0 items-center gap-3 text-muted sm:gap-[18px]">
-        {listenerObj?.current != null && (
-          <span
-            className={cn(
-              'v3-tab-num inline-flex items-center gap-1.5 leading-none font-semibold whitespace-nowrap',
-              listenerObj.current > 0 ? 'text-ink' : 'text-muted',
-            )}
-            title={`${listenerObj.current} listening · peak ${listenerObj.peak ?? 0}`}
-            aria-label={`${listenerObj.current} listening`}
-          >
-            <Headphones className="h-3.5 w-3.5" aria-hidden="true" />
-            <OdometerNumber value={listenerObj.current} />
-          </span>
-        )}
-        <ThemeSwitcher variant="player" />
-      </div>
+      {/* Mobile: the context line is too long to share the masthead row, so it
+          drops to its own line below; from md it sits inline above. */}
+      {tagline && (
+        <span className="v3-caption truncate text-muted md:hidden" title={tagline}>
+          {tagline}
+        </span>
+      )}
     </div>
   );
 }

--- a/web/components/TransportBar.tsx
+++ b/web/components/TransportBar.tsx
@@ -2,10 +2,10 @@
 
 import { useEffect, useRef } from 'react';
 import { animate as motionAnimate, m, useAnimate } from 'motion/react';
-import { buildTagline } from '@/lib/tagline';
 import { cn } from '@/lib/cn';
 import { Slider } from './ui/slider';
-import type { NowPlayingTrack, StationContext } from '@/lib/types';
+import { SCALE_MAX, type SignalQuality } from '@/hooks/useSignal';
+import type { NowPlayingTrack } from '@/lib/types';
 import type { PlayerStatus } from '@/hooks/usePlayer';
 
 export interface TransportBarProps {
@@ -17,12 +17,36 @@ export interface TransportBarProps {
   setVolume: (v: number) => void;
   /** Increments on keyboard-only volume adjusts; slider drags don't tick it. */
   volumePulse?: number;
+  muted: boolean;
+  onToggleMute: () => void;
+  /** Measured round-trip latency in ms (null before the first probe lands). */
+  latencyMs: number | null;
+  signalQuality: SignalQuality;
+  /** Current station listener count — shown as text in the signal readout. */
+  listeners: number | null;
   nowPlaying: NowPlayingTrack | null;
   elapsed: number;
-  context: StationContext | null;
 }
 
-const VOLUME_CELLS = 12;
+const SCALE_NUMS = [0, 50, 100, 150, 200, 250];
+
+const QUALITY_LABEL: Record<SignalQuality, string> = {
+  offline: 'Offline',
+  idle: 'Standby',
+  acquiring: 'Acquiring',
+  good: 'Good',
+  fair: 'Fair',
+  poor: 'Poor',
+};
+
+// Honour reduced-motion for the imperative motion pulses (the CSS transitions
+// are already gated in globals.css). Read at call time so a setting change
+// mid-session is respected.
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
 
 export default function TransportBar({
   tunedIn,
@@ -32,161 +56,198 @@ export default function TransportBar({
   volume,
   setVolume,
   volumePulse,
+  muted,
+  onToggleMute,
+  latencyMs,
+  signalQuality,
+  listeners,
   nowPlaying,
   elapsed,
-  context,
 }: TransportBarProps) {
   // The window between the tune-in gesture and the first audible frame —
-  // surfaced on the button so the player doesn't claim to play while silent.
+  // surfaced on the power ring so the player doesn't claim to play while silent.
   const connecting = status === 'connecting';
   const duration = nowPlaying?.duration ?? 0;
   const progress = duration > 0 ? Math.min(1, elapsed / duration) : 0;
-  const lit = Math.round(volume * VOLUME_CELLS);
 
-  // Track info lives in the CenterStage on desktop, so the footer's centre
-  // slot stays empty there. On mobile it carries the context tagline (the
-  // vibe/weather line the header hides below md).
-  const tagline = buildTagline(context);
+  // Knob pointer sweeps the conic tick scale: -135° (silent) → +135° (full),
+  // matching the scale's `from -135deg` origin in globals.css.
+  const angle = -135 + volume * 270;
 
-  // Pulse all volume cells on keyboard-driven adjusts. Imperative motion
-  // animate is the cleanest fit here — re-keying every cell on each tick
-  // would remount the DOM unnecessarily.
-  const cellsRef = useRef<(HTMLSpanElement | null)[]>([]);
-  const prevLitRef = useRef(lit);
-  const firstPulseRef = useRef(true);
-  const lastVibrateRef = useRef(0);
-  useEffect(() => {
-    if (firstPulseRef.current) {
-      // Skip the initial mount tick — we only want to pulse on real adjusts.
-      firstPulseRef.current = false;
-      return;
-    }
-    if (volumePulse == null) return;
-    const els = cellsRef.current.filter((el): el is HTMLSpanElement => el != null);
-    if (els.length === 0) return;
-    motionAnimate(els, { scale: [1, 1.18, 1] }, { duration: 0.11, ease: [0.2, 0.7, 0.2, 1] });
-    // Keep prevLit in sync so the per-cell effect below doesn't double-pulse
-    // the topmost cell when keyboard adjusts already triggered the full flash.
-    prevLitRef.current = lit;
-  }, [volumePulse, lit]);
+  // Needle maps measured latency onto the 0–SCALE_MAX ms scale; parked at 0%
+  // before the first probe, pegged to the top when a probe outright failed.
+  const needlePct =
+    latencyMs != null
+      ? Math.min(100, (Math.min(latencyMs, SCALE_MAX) / SCALE_MAX) * 100)
+      : signalQuality === 'poor'
+        ? 100
+        : 0;
+  const qualityLabel = QUALITY_LABEL[signalQuality];
+  const latencyText = latencyMs != null ? `${latencyMs} ms` : '—';
+  const qualityTone =
+    signalQuality === 'idle' || signalQuality === 'offline' ? 'text-muted' : 'text-vermilion';
 
-  // Per-cell tactile feedback for drag / click — pulse the cell that just
-  // toggled, plus a throttled haptic tick. Keyboard adjusts go through the
-  // all-cells flash above (and reset prevLit so this effect bails).
-  useEffect(() => {
-    const prev = prevLitRef.current;
-    if (prev === lit) return;
-    prevLitRef.current = lit;
-    const idx = lit > prev ? lit - 1 : prev - 1;
-    const el = cellsRef.current[idx];
-    if (el) motionAnimate(el, { scale: [1, 1.22, 1] }, { duration: 0.13, ease: [0.2, 0.7, 0.2, 1] });
-    const now = Date.now();
-    if (now - lastVibrateRef.current > 70 && typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
-      navigator.vibrate(4);
-      lastVibrateRef.current = now;
-    }
-  }, [lit]);
-
-  // One-shot scale pulse when tunedIn flips, so the button visibly "engages"
-  // even if the user triggered tune via keyboard / media keys.
+  // One-shot scale pulse when tunedIn flips, so the power button visibly
+  // "engages" even when tune was triggered via keyboard / media keys.
   const [tuneScope, animateTune] = useAnimate<HTMLButtonElement>();
   const prevTunedInRef = useRef(tunedIn);
   useEffect(() => {
     if (prevTunedInRef.current === tunedIn) return;
     prevTunedInRef.current = tunedIn;
-    if (!tuneScope.current) return;
-    animateTune(tuneScope.current, { scale: [1, 1.03, 1] }, { duration: 0.25, ease: [0.2, 0.7, 0.2, 1] });
+    if (!tuneScope.current || prefersReducedMotion()) return;
+    animateTune(tuneScope.current, { scale: [1, 1.06, 1] }, { duration: 0.25, ease: [0.2, 0.7, 0.2, 1] });
   }, [tunedIn, animateTune, tuneScope]);
+
+  // Pulse the whole knob assembly on keyboard-driven volume adjusts (the inner
+  // .fz-knob owns the rotate transform, so we scale the wrapper to avoid
+  // clobbering it). Skip the initial mount tick.
+  const knobWrapRef = useRef<HTMLDivElement>(null);
+  const firstPulseRef = useRef(true);
+  useEffect(() => {
+    if (firstPulseRef.current) {
+      firstPulseRef.current = false;
+      return;
+    }
+    if (volumePulse == null) return;
+    const el = knobWrapRef.current;
+    if (el && !prefersReducedMotion()) {
+      motionAnimate(el, { scale: [1, 1.12, 1] }, { duration: 0.12, ease: [0.2, 0.7, 0.2, 1] });
+    }
+  }, [volumePulse]);
+
+  // Throttled haptic tick on any volume change (drag or keyboard).
+  const prevVolumeRef = useRef(volume);
+  const lastVibrateRef = useRef(0);
+  useEffect(() => {
+    if (prevVolumeRef.current === volume) return;
+    prevVolumeRef.current = volume;
+    const now = Date.now();
+    if (now - lastVibrateRef.current > 70 && typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+      navigator.vibrate(4);
+      lastVibrateRef.current = now;
+    }
+  }, [volume]);
 
   const handleTune = () => {
     if (offline) return;
-    // Real haptic on phones; browsers without vibration silently no-op.
     if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
       navigator.vibrate(8);
     }
     onTune();
   };
 
+  const handleMute = () => {
+    if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+      navigator.vibrate(6);
+    }
+    onToggleMute();
+  };
+
   return (
-    <div className="absolute right-0 bottom-0 left-0 z-20 bg-bg [border-top:none] sm:[border-top:1px_solid_var(--ink)]">
-      {/* Hairline progress along the top edge of the bar. */}
-      {duration > 0 && (
-        <div
-          className="pointer-events-none absolute -top-px left-0 h-0.5 w-[var(--progress)] bg-vermilion"
-          data-progress={`${progress * 100}%`}
-          ref={(el) => { if (el) el.style.setProperty('--progress', `${progress * 100}%`); }}
-          aria-hidden="true"
-        />
-      )}
-
-      <div
-        // Bottom inset keeps the Tune In / volume row clear of the iPhone
-        // home indicator when installed (viewport-fit=cover). Side insets
-        // matter for landscape on notched phones; top stays fixed so the
-        // hairline progress bar above this row sits flush.
-        className="flex items-center gap-3 pt-3
-          pr-[max(1rem,env(safe-area-inset-right))] pb-[calc(env(safe-area-inset-bottom)_+_0.75rem)]
-          pl-[max(1rem,env(safe-area-inset-left))] sm:gap-6
-          sm:pt-5 sm:pr-[max(2rem,env(safe-area-inset-right))]
-          sm:pb-[calc(env(safe-area-inset-bottom)_+_1.25rem)] sm:pl-[max(2rem,env(safe-area-inset-left))]"
-      >
-        <m.button
-          ref={tuneScope}
-          onClick={offline ? undefined : handleTune}
-          disabled={offline}
-          aria-disabled={offline}
-          title={offline ? 'The station is currently off air' : undefined}
-          whileTap={offline ? undefined : { scale: 0.97, y: 1 }}
-          transition={{ duration: 0.09, ease: [0.2, 0.7, 0.2, 1] }}
-          className={cn(
-            'v3-eyebrow v3-focus flex shrink-0 items-center gap-[10px] px-4 py-3 transition-shadow duration-150 sm:px-7 sm:py-[14px]',
-            offline
-              ? 'cursor-not-allowed border border-muted bg-bg text-muted'
-              : 'cursor-pointer border-0 bg-ink text-bg [@media(hover:hover)]:hover:shadow-[inset_0_0_0_2px_var(--bg)]',
-          )}
-        >
-          <span
-            className={cn(
-              'inline-block h-2 w-2 rounded-full',
-              connecting && 'v3-connecting-pulse',
-              offline
-                ? 'bg-muted'
-                : tunedIn
-                  ? 'bg-vermilion'
-                  : 'bg-[#5a5048]',
-            )}
+    <div
+      // Full-bleed bar pinned to the very bottom at every width. Bottom +
+      // side safe-area insets live on the deck itself (below) so its own
+      // background fills down to the screen edge — no page bg peeks through.
+      className="absolute inset-x-0 bottom-0 z-20"
+    >
+      <div className="fz-deck relative grid grid-cols-[auto_1fr_auto] items-stretch bg-bg pt-3 pr-[env(safe-area-inset-right)] pb-[calc(env(safe-area-inset-bottom)_+_0.75rem)] pl-[env(safe-area-inset-left)] [border-top:1px_solid_var(--fz-edge)]">
+        {/* Hairline progress along the top edge of the deck. */}
+        {duration > 0 && (
+          <div
+            className="pointer-events-none absolute -top-px left-0 z-10 h-0.5 w-[var(--progress)] bg-vermilion"
+            ref={(el) => { if (el) el.style.setProperty('--progress', `${progress * 100}%`); }}
+            aria-hidden="true"
           />
-          {offline ? 'Stream Offline' : connecting ? 'Connecting…' : tunedIn ? 'Tune Out' : 'Tune In'}
-        </m.button>
+        )}
 
-        {/* Centre slot — empty spacer on desktop, context tagline on mobile. */}
-        <div
-          className="v3-caption flex min-w-0 flex-1 items-center truncate text-muted"
-          title={tagline ?? ''}
-        >
-          {tagline && <span className="truncate sm:hidden">{tagline}</span>}
+        {/* ── POWER ──────────────────────────────────────────────── */}
+        <div className="relative flex flex-col items-center justify-center gap-1.5 px-4 pt-1 pb-2 md:px-5 md:pt-1 md:pb-2.5 lg:gap-2 lg:px-6 lg:pt-1.5 lg:pb-3">
+          <span className="v3-caption hidden text-muted lg:block">Power</span>
+          <m.button
+            ref={tuneScope}
+            onClick={offline ? undefined : handleTune}
+            disabled={offline}
+            aria-disabled={offline}
+            aria-pressed={tunedIn}
+            aria-label={offline ? 'Stream offline' : tunedIn ? 'Tune out' : 'Tune in'}
+            title={offline ? 'The station is currently off air' : tunedIn ? 'Tune out' : 'Tune in'}
+            data-tuned={tunedIn ? 'true' : 'false'}
+            whileTap={offline ? undefined : { scale: 0.95 }}
+            transition={{ duration: 0.09, ease: [0.2, 0.7, 0.2, 1] }}
+            className="fz-power v3-focus h-10 w-10 md:h-11 md:w-11 lg:h-[50px] lg:w-[50px]"
+          >
+            <span className={cn('fz-ring', connecting && 'v3-connecting-pulse')} />
+          </m.button>
         </div>
 
-        <div className="flex shrink-0 items-center gap-2 sm:gap-[10px]">
-          <span className="v3-caption hidden text-muted sm:inline">Vol</span>
-          <div className="relative flex h-[18px] w-[52px] items-center gap-0.5 sm:w-20">
-            {Array.from({ length: VOLUME_CELLS }).map((_, i) => (
+        {/* ── SIGNAL ─────────────────────────────────────────────── */}
+        <div className="relative flex min-w-0 items-center justify-center px-2 [border-left:1px_solid_var(--fz-line)] md:px-5 lg:px-6">
+          {/* The analog signal meter — shown at every width (the context line
+              lives in the header now). */}
+          <div className="flex w-full flex-col justify-center gap-1 font-mono lg:gap-1.5">
+            <div className="flex items-baseline justify-between gap-2 lg:gap-4">
+              <span className="text-[11px] font-semibold tracking-[0.04em] whitespace-nowrap text-ink lg:text-[12px]">
+                Signal · <b className={cn('font-bold', qualityTone)}>{qualityLabel}</b>
+              </span>
               <span
-                key={i}
-                ref={(el) => { cellsRef.current[i] = el; }}
-                className={cn('h-full flex-1 border border-ink', i < lit ? 'bg-ink' : 'bg-transparent')}
+                className="v3-tab-num text-[11px] tracking-[0.06em] whitespace-nowrap text-muted lg:text-[12px] lg:tracking-[0.08em]"
+                title={listeners != null ? `${listeners} listening · ${latencyText}` : latencyText}
+                aria-label={listeners != null ? `${listeners} listening, ${latencyText}` : latencyText}
+              >
+                {listeners != null ? `${listeners} ♪ · ${latencyText}` : latencyText}
+              </span>
+            </div>
+            <div className="fz-scale h-8 lg:h-[42px]" aria-hidden="true">
+              <div className="fz-ticks" />
+              <div
+                className="fz-needle"
+                ref={(el) => { if (el) el.style.setProperty('--fz-needle-pos', `${needlePct}%`); }}
+              >
+                <div className="fz-grip" />
+              </div>
+              <div className="fz-nums">
+                {SCALE_NUMS.map((n) => (
+                  <span key={n}>{n}</span>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* ── VOLUME ─────────────────────────────────────────────── */}
+        <div className="relative flex flex-col items-center justify-center gap-1.5 px-4 pt-1 pb-2 [border-left:1px_solid_var(--fz-line)] md:px-5 md:pt-1 md:pb-2.5 lg:gap-2 lg:px-6 lg:pt-1.5 lg:pb-3">
+          <span className="v3-caption hidden text-muted lg:block">Volume</span>
+          <div className="flex items-center gap-3 lg:gap-4">
+            <div ref={knobWrapRef} className="fz-knob-wrap h-10 w-10 lg:h-[48px] lg:w-[48px]">
+              <div className="fz-knob-ticks" />
+              <div
+                className="fz-knob"
+                ref={(el) => { if (el) el.style.setProperty('--fz-angle', `${angle}deg`); }}
+              >
+                <span className="fz-cap" />
+                <span className="fz-pointer" />
+              </div>
+              {/* Interaction layer only — the rotating knob above is the visible
+                  control, so the accessible Radix Slider is overlaid invisibly. */}
+              <Slider
+                min={0}
+                max={1}
+                step={0.01}
+                value={[volume]}
+                onValueChange={([v]) => setVolume(v ?? 0)}
+                aria-label="Volume"
+                className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
               />
-            ))}
-            {/* Interaction layer only — the lit cells above are the visible
-                control, so the Slider is overlaid invisibly. */}
-            <Slider
-              min={0}
-              max={1}
-              step={0.01}
-              value={[volume]}
-              onValueChange={([v]) => setVolume(v ?? 0)}
-              aria-label="Volume"
-              className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+            </div>
+
+            <button
+              type="button"
+              onClick={handleMute}
+              aria-pressed={muted}
+              aria-label={muted ? 'Unmute' : 'Mute'}
+              title={muted ? 'Unmute' : 'Mute'}
+              data-muted={muted ? 'true' : 'false'}
+              className="fz-grille v3-focus h-9 w-9 lg:h-10 lg:w-10"
             />
           </div>
         </div>

--- a/web/components/Waveform.tsx
+++ b/web/components/Waveform.tsx
@@ -68,7 +68,7 @@ export default function Waveform({ audioRef, tunedIn, progress }: WaveformProps)
   return (
     <div
       ref={containerRef}
-      className="pointer-events-none absolute inset-x-3 bottom-20 flex h-[110px] items-center gap-px px-1 opacity-[0.22] sm:right-24 sm:bottom-[100px] sm:left-0 sm:h-40 sm:gap-0.5 sm:px-8"
+      className="pointer-events-none absolute inset-x-3 bottom-24 flex h-[110px] items-center gap-px px-1 opacity-[0.22] sm:right-24 sm:bottom-[128px] sm:left-0 sm:h-40 sm:gap-0.5 sm:px-8"
       aria-hidden="true"
     >
       {Array.from({ length: BARS }).map((_, i) => {

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -63,6 +63,10 @@ export default defineConfig([
           // outside this allow-list.
           ignore: [
             '^v3-',
+            // .fz-* — the console-deck footer's hardware-part classes
+            // (TransportBar), defined in app/globals.css. Same legacy-CSS deal
+            // as the other prefixes: component CSS not yet promoted to @theme.
+            '^fz-',
             '^bs-',
             '^broadsheet-',
             '^admin-',

--- a/web/hooks/useSignal.ts
+++ b/web/hooks/useSignal.ts
@@ -1,0 +1,92 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import type { PlayerStatus } from '@/hooks/usePlayer';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '/api';
+
+// The signal meter reads round-trip latency to the controller as a proxy for
+// connection health — there's no lower-level stream-jitter signal available in
+// the browser. The needle maps onto a 0–250 ms analog scale (see SCALE_MAX).
+export const SCALE_MAX = 250;
+const PROBE_INTERVAL_MS = 5000; // aligned with useStationFeed's poll cadence
+const PROBE_TIMEOUT_MS = 4000;
+const GOOD_MS = 120; // < this → "good"; up to SCALE_MAX → "fair"; beyond → "poor"
+
+export type SignalQuality =
+  | 'offline' // station off air
+  | 'idle' // not tuned in
+  | 'acquiring' // tuning in / first probe in flight
+  | 'good'
+  | 'fair'
+  | 'poor'; // slow round-trip or a failed probe
+
+export interface Signal {
+  /** Last successful round-trip in ms, or null before the first probe lands. */
+  latencyMs: number | null;
+  quality: SignalQuality;
+}
+
+export interface UseSignalOptions {
+  tunedIn: boolean;
+  status: PlayerStatus;
+  offline: boolean;
+}
+
+// Times a cheap GET to /health every few seconds while tuned in, surfacing a
+// measured latency + a derived quality band for the footer's signal meter.
+// Probes only while tuned in and on air, so the landing page makes no requests.
+export function useSignal({ tunedIn, status, offline }: UseSignalOptions): Signal {
+  const [latencyMs, setLatencyMs] = useState<number | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    // Park the meter (and stop probing) whenever there's nothing live to read.
+    if (!tunedIn || offline) {
+      setLatencyMs(null);
+      setFailed(false);
+      return;
+    }
+
+    let cancelled = false;
+    const probe = async () => {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), PROBE_TIMEOUT_MS);
+      const t0 = performance.now();
+      try {
+        await fetch(`${API_URL}/health`, { cache: 'no-store', signal: ctrl.signal });
+        if (cancelled) return;
+        setLatencyMs(Math.round(performance.now() - t0));
+        setFailed(false);
+      } catch {
+        // Timeout or network error — treat as a degraded signal rather than
+        // surfacing an error; the watchdog in usePlayer owns actual recovery.
+        if (!cancelled) {
+          setLatencyMs(null);
+          setFailed(true);
+        }
+      } finally {
+        clearTimeout(timer);
+      }
+    };
+
+    probe();
+    const id = setInterval(probe, PROBE_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [tunedIn, offline]);
+
+  const quality = useMemo<SignalQuality>(() => {
+    if (offline) return 'offline';
+    if (!tunedIn) return 'idle';
+    if (failed) return 'poor';
+    if (status === 'connecting' || latencyMs == null) return 'acquiring';
+    if (latencyMs < GOOD_MS) return 'good';
+    if (latencyMs <= SCALE_MAX) return 'fair';
+    return 'poor';
+  }, [offline, tunedIn, status, failed, latencyMs]);
+
+  return { latencyMs, quality };
+}


### PR DESCRIPTION
## What

Redesigns the web player's footer as a **"console deck"** — a slim, full-width bar pinned to the bottom with three compartments: **POWER · SIGNAL · VOLUME**, built from on-brand analog parts (power ring, analog signal scale, rotary volume knob, dotted mute grille). Plus a set of related header/layout polish items.

## New features

- **Signal meter** — a new `useSignal` hook probes `/health` while tuned in and maps measured round-trip latency onto a 0–250 ms scale; the footer shows a needle + quality band ("Signal · Good · N ♪ · X ms").
- **Mute** is now a visible control (the dotted grille) — was keyboard/palette only.
- **Volume** is a rotary knob (with an invisible Radix slider overlaid for accessibility + keyboard).
- **Listener count** moved out of the header into the signal readout (`N ♪`).

## Layout / polish

- Footer is full-width, flush to the bottom (its own bg fills the safe-area padding so nothing shows beneath), with a softened top edge.
- Context line (period · show · weather) stays in the **header** at all widths — drops to its own row below the masthead on mobile, inline from `md`.
- **Glassmorphism** header background (themed `bg/55` + backdrop blur).
- Removed the DotRail (drawer buttons) left border.
- Nudged the CenterStage block up so the now-playing/DJ-ticker clears the visualiser.

## Implementation notes

- New `web/hooks/useSignal.ts`; `TransportBar.tsx` rewritten; a scoped `.fz-*` block added to `globals.css` (recoloured to app tokens, not hardcoded hex); `eslint.config.mjs` allowlists the `^fz-` component classes (same pattern as the existing `^v3-`/`^bs-`).
- Responsive across mobile / tablet / desktop; the analog parts respect `prefers-reduced-motion`.

## Verification

- `cd web && npm run lint` (eslint + tsc) — green.
- Manually verified live against the dev stack at mobile (~390px), tablet (~834px), and desktop (~1280px): tune in lights the power ring, the signal needle tracks real measured latency, the volume knob rotates + mute grille toggles, and the layout adapts at each breakpoint.
