### PR TITLE
fix(controller): set Ollama num_ctx so the DJ agent stops truncating its prompt

### DIFF
--- a/controller/src/llm/sdk.ts
+++ b/controller/src/llm/sdk.ts
@@ -123,7 +123,19 @@ function providerOpts({ repeatPenalty = null }: { repeatPenalty?: number | null 
   const opts: any = {};
 
   const ollama: any = { think: reasoning };
-  if (repeatPenalty != null) ollama.options = { repeat_penalty: repeatPenalty };
+  const ollamaOptions: any = {};
+  if (repeatPenalty != null) ollamaOptions.repeat_penalty = repeatPenalty;
+  // num_ctx for LOCAL Ollama only. Ollama's default window is 4096, but the DJ
+  // agent feeds ~8k+ per turn (40-turn session window + tool schemas + discovery
+  // results); the default truncates the front of the prompt — dropping the
+  // system instructions and tool defs — so the model never calls `done` (issue
+  // #291). `:cloud` models run on Ollama's servers and manage their own context,
+  // so skip them. 0 → don't send it (use Ollama's default).
+  const numCtx = Number(llm.numCtx);
+  if (providerName() === 'ollama' && !/:cloud$/i.test(model) && Number.isFinite(numCtx) && numCtx > 0) {
+    ollamaOptions.num_ctx = numCtx;
+  }
+  if (Object.keys(ollamaOptions).length > 0) ollama.options = ollamaOptions;
   opts.ollama = ollama;
 
   if (!reasoning) {

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -358,6 +358,16 @@ const DEFAULTS = {
     // <think> block on a small model balloons every call (see llm/sdk.js
     // token caps + llm/provider.js no-think fetch).
     reasoning: false,
+    // Ollama context window (num_ctx), local Ollama only. Ollama's own default
+    // is 4096, but the session DJ agent feeds ~8k+ (the 40-turn session window
+    // + tool schemas + discovery results), so the default silently truncates
+    // the front of the prompt — dropping the system instructions and tool
+    // defs — and the model never calls `done` ("agent did not call the done
+    // tool", issue #291). 16384 holds a full picker turn comfortably on a 7–9B
+    // model / 12GB GPU. Reasoning models burn more of it on <think>, so bump it
+    // if you run those. Ignored for `:cloud` models and every other provider
+    // (they manage their own context). 0 → don't send num_ctx (Ollama default).
+    numCtx: 16384,
     // When on, the session DJ agent drives track-picking, links and listener
     // requests as a tool-loop over the session chat history (broadcast/
     // dj-agent.js). When off, the stateless pool picker runs instead — still
@@ -777,6 +787,14 @@ export async function load() {
         typeof stored.llm?.baseUrl === 'string' ? stored.llm.baseUrl.trim() : DEFAULTS.llm.baseUrl,
       reasoning:
         typeof stored.llm?.reasoning === 'boolean' ? stored.llm.reasoning : DEFAULTS.llm.reasoning,
+      // Clamp to a sane band: 0 disables (Ollama default), else [2048, 131072].
+      // Non-numeric/NaN falls back to the default. Floored to an integer.
+      numCtx: (() => {
+        const raw = stored.llm?.numCtx;
+        if (typeof raw !== 'number' || !Number.isFinite(raw)) return DEFAULTS.llm.numCtx;
+        if (raw <= 0) return 0;
+        return Math.min(131072, Math.max(2048, Math.floor(raw)));
+      })(),
       pickerAgent:
         typeof stored.llm?.pickerAgent === 'boolean'
           ? stored.llm.pickerAgent

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -93,6 +93,7 @@ interface LlmForm {
   provider: string;
   model: string;
   ollamaUrl: string;
+  numCtx: number;
   baseUrl: string;
   reasoning: boolean;
   pickerAgent: boolean;
@@ -332,6 +333,7 @@ export default function SettingsPanel() {
         provider: v.llm?.provider ?? 'ollama',
         model: v.llm?.model ?? '',
         ollamaUrl: v.llm?.ollamaUrl ?? '',
+        numCtx: typeof v.llm?.numCtx === 'number' ? v.llm.numCtx : 16384,
         baseUrl: v.llm?.baseUrl ?? '',
         reasoning: !!v.llm?.reasoning,
         pickerAgent: !!v.llm?.pickerAgent,
@@ -1470,6 +1472,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
       provider: form.llm.provider,
       model: form.llm.model,
       ollamaUrl: form.llm.ollamaUrl,
+      numCtx: form.llm.numCtx,
       baseUrl: form.llm.baseUrl,
       reasoning: form.llm.reasoning,
       pickerAgent: form.llm.pickerAgent,
@@ -1604,6 +1607,32 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
               <div className="field-hint">
                 Where the Ollama server runs. Leave blank for the default
                 (<code>http://localhost:11434</code>).
+              </div>
+            </div>
+          )}
+
+          {form.llm.provider === 'ollama' && (
+            <div className="field">
+              <Label>Context window (num_ctx)</Label>
+              <Input
+                type="number"
+                min={0}
+                step={1024}
+                value={form.llm.numCtx}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setForm(f => ({ ...f, llm: { ...f.llm, numCtx: Number(e.target.value) } }))
+                }
+                placeholder="16384"
+                className="max-w-[200px]"
+              />
+              <div className="field-hint">
+                Tokens of context for <strong>local</strong> Ollama models.
+                Ollama&apos;s own default is 4096, which is too small for the DJ
+                agent — the prompt gets truncated and the model fails to pick a
+                track (the &ldquo;agent did not call the done tool&rdquo; error).
+                16384 is a safe default for a 7&ndash;9B model on a 12GB GPU;
+                raise it for reasoning models, lower it on tight VRAM. Set 0 to
+                use Ollama&apos;s default. Ignored for <code>:cloud</code> models.
               </div>
             </div>
           )}


### PR DESCRIPTION
## Problem — #291

The DJ picker agent fails with **"agent did not call the done tool before stopping"** on any local Ollama model other than `qwen2.5:7b`. Reported by an operator on a 4070/12GB; reasoning models (`qwen3`) fail every time.

## Root cause

`providerOpts()` in `controller/src/llm/sdk.ts` never set `num_ctx`, so local Ollama used its **4096-token default window**. But `djAgent` feeds ~8k+ per turn:

- the operator system prompt + a random soul,
- `session.windowMessages()` — the last **40 session turns** (`session.ts:26`),
- the full JSON schemas for every discovery tool + the `done` tool,
- the discovery tool **results** (song/album lists).

The repo's own `docs/agent-picker-investigation.md` assumes "~8K of agent context for the picker." Feeding 8k into a 4096 window makes Ollama silently truncate the **front** of the prompt — exactly where the system instructions and `done`-tool definition live. The model loses the instruction to call `done`, emits prose, the loop ends with zero tool calls, the one-shot recovery (still truncated) also fails, and we throw at `sdk.ts:630`.

`qwen2.5:7b` survives because it's the model everything was tuned against and is an unusually obedient tool-caller under a battered context. Reasoning models burn the tiny window on `<think>` tokens before they ever reach the tool call, so they fail far more easily.

## Fix

Set `num_ctx` for **local** Ollama via a new `settings.llm.numCtx`:

- **Default 16384** — holds a full picker turn comfortably on a 7–9B model / 12GB GPU.
- Configurable in **admin → LLM → Context window (num_ctx)**; clamped to `[2048, 131072]`; `0` falls back to Ollama's default.
- Applied **only** to the local `ollama` provider — `:cloud` models and every other provider manage their own context, so they're skipped.
- Read fresh per call in `providerOpts()`, so no provider-cache invalidation; existing operators pick up 16384 automatically via `DEFAULTS`.

## Test plan

- `controller` lint + `tsc --noEmit`: ✅ 0 errors.
- `web` lint + `tsc --noEmit`: ✅ 0 errors.
- Manual: set a non-tuned local model (e.g. `qwen3:8b`), confirm picks succeed where they previously threw. Interim equivalent for verification: a Modelfile `PARAMETER num_ctx 16384`.

Closes #291