### PR TITLE
fix(tts-heavy): stop baking models at build, persist HF cache across recreates

### DIFF
--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -202,10 +202,18 @@ services:
       # Same shared mount as the controller — the sidecar writes WAVs into
       # /var/sub-wave/voice/* and the controller hands the path to Liquidsoap.
       - *state-mount
+      # Persist the per-engine Hugging Face caches across container recreates.
+      # Weights download at boot (the workers load the model before reporting
+      # ready) — without these volumes that multi-GB fetch repeats on every
+      # \`up -d --build\` / image pull / update. With them it happens once.
+      - tts-heavy-chatterbox-cache:/opt/chatterbox/hf-cache
+      - tts-heavy-pocket-cache:/opt/pocket-tts/hf-cache
 
 volumes:
   caddy-data:
   caddy-config:
+  tts-heavy-chatterbox-cache:
+  tts-heavy-pocket-cache:
 `;
 
 // docker-compose.byo.yml
@@ -361,6 +369,16 @@ services:
       - HF_TOKEN=\${HF_TOKEN:-}
     volumes:
       - *state-mount
+      # Persist the per-engine Hugging Face caches across container recreates.
+      # Weights download at boot (the workers load the model before reporting
+      # ready) — without these volumes that multi-GB fetch repeats on every
+      # \`up -d --build\` / image pull / update. With them it happens once.
+      - tts-heavy-chatterbox-cache:/opt/chatterbox/hf-cache
+      - tts-heavy-pocket-cache:/opt/pocket-tts/hf-cache
+
+volumes:
+  tts-heavy-chatterbox-cache:
+  tts-heavy-pocket-cache:
 `;
 
 // docker-compose.dev.yml
@@ -497,6 +515,16 @@ services:
       - HF_TOKEN=\${HF_TOKEN:-}
     volumes:
       - *state-mount
+      # Persist the per-engine Hugging Face caches across container recreates.
+      # Weights download at boot (the workers load the model before reporting
+      # ready) — without these volumes that multi-GB fetch repeats on every
+      # recreate. With them it happens once.
+      - tts-heavy-chatterbox-cache:/opt/chatterbox/hf-cache
+      - tts-heavy-pocket-cache:/opt/pocket-tts/hf-cache
+
+volumes:
+  tts-heavy-chatterbox-cache:
+  tts-heavy-pocket-cache:
 `;
 
 // .env.example

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -150,3 +150,13 @@ services:
       - HF_TOKEN=${HF_TOKEN:-}
     volumes:
       - *state-mount
+      # Persist the per-engine Hugging Face caches across container recreates.
+      # Weights download at boot (the workers load the model before reporting
+      # ready) — without these volumes that multi-GB fetch repeats on every
+      # `up -d --build` / image pull / update. With them it happens once.
+      - tts-heavy-chatterbox-cache:/opt/chatterbox/hf-cache
+      - tts-heavy-pocket-cache:/opt/pocket-tts/hf-cache
+
+volumes:
+  tts-heavy-chatterbox-cache:
+  tts-heavy-pocket-cache:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -131,3 +131,13 @@ services:
       - HF_TOKEN=${HF_TOKEN:-}
     volumes:
       - *state-mount
+      # Persist the per-engine Hugging Face caches across container recreates.
+      # Weights download at boot (the workers load the model before reporting
+      # ready) — without these volumes that multi-GB fetch repeats on every
+      # recreate. With them it happens once.
+      - tts-heavy-chatterbox-cache:/opt/chatterbox/hf-cache
+      - tts-heavy-pocket-cache:/opt/pocket-tts/hf-cache
+
+volumes:
+  tts-heavy-chatterbox-cache:
+  tts-heavy-pocket-cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,7 +193,15 @@ services:
       # Same shared mount as the controller — the sidecar writes WAVs into
       # /var/sub-wave/voice/* and the controller hands the path to Liquidsoap.
       - *state-mount
+      # Persist the per-engine Hugging Face caches across container recreates.
+      # Weights download at boot (the workers load the model before reporting
+      # ready) — without these volumes that multi-GB fetch repeats on every
+      # `up -d --build` / image pull / update. With them it happens once.
+      - tts-heavy-chatterbox-cache:/opt/chatterbox/hf-cache
+      - tts-heavy-pocket-cache:/opt/pocket-tts/hf-cache
 
 volumes:
   caddy-data:
   caddy-config:
+  tts-heavy-chatterbox-cache:
+  tts-heavy-pocket-cache:

--- a/docker/Dockerfile.tts-heavy
+++ b/docker/Dockerfile.tts-heavy
@@ -26,13 +26,20 @@
 #
 # Image size: ~5-6GB. CPU-only torch wheels (mirror of the index-url trick in
 # docker/Dockerfile.controller:72-87) to avoid the 3.6GB CUDA build. Models are
-# NOT baked at build time — the workers download them lazily into the HF cache
-# (HF_HOME, set per-engine by server.py) on the first /speak after container
-# start. We used to pre-warm them here with a from_pretrained() smoke test, but
-# that pulled several GB from the Hugging Face Hub *inside CI* over an
-# unauthenticated, heavily rate-limited connection, making the image build slow
-# (20+ min) and flaky (HF 429s / timeouts). The build now only does an
-# import-only smoke test (no network); the multi-GB fetch moves to first run.
+# NOT baked at build time — each worker downloads its weights into the HF cache
+# (HF_HOME, set per-engine by server.py) the first time it boots, before it
+# reports ready (server.py's lifespan starts the workers at container start, so
+# the fetch happens on container boot, not on the first /speak). We used to
+# pre-warm them here with a from_pretrained() smoke test, but that pulled
+# several GB from the Hugging Face Hub *inside CI* over an unauthenticated,
+# heavily rate-limited connection, making the image build slow (20+ min) and
+# flaky (HF 429s / timeouts). The build now only does an import-only smoke test
+# (no network); the multi-GB fetch moves to runtime.
+#
+# The compose files mount a named volume over each HF cache dir
+# (tts-heavy-{chatterbox,pocket}-cache → /opt/{chatterbox,pocket-tts}/hf-cache)
+# so that boot-time download survives container recreates — otherwise it would
+# repeat on every `up -d --build` / image pull / update.
 
 FROM python:3.11-slim-bookworm
 

--- a/docker/Dockerfile.tts-heavy
+++ b/docker/Dockerfile.tts-heavy
@@ -25,9 +25,14 @@
 # legacy in-process WITH_* build args.
 #
 # Image size: ~5-6GB. CPU-only torch wheels (mirror of the index-url trick in
-# docker/Dockerfile.controller:72-87) to avoid the 3.6GB CUDA build. Models
-# are pre-loaded at build time as a smoke test + HF cache warm so the first
-# /speak after container start isn't waiting on a multi-GB download.
+# docker/Dockerfile.controller:72-87) to avoid the 3.6GB CUDA build. Models are
+# NOT baked at build time — the workers download them lazily into the HF cache
+# (HF_HOME, set per-engine by server.py) on the first /speak after container
+# start. We used to pre-warm them here with a from_pretrained() smoke test, but
+# that pulled several GB from the Hugging Face Hub *inside CI* over an
+# unauthenticated, heavily rate-limited connection, making the image build slow
+# (20+ min) and flaky (HF 429s / timeouts). The build now only does an
+# import-only smoke test (no network); the multi-GB fetch moves to first run.
 
 FROM python:3.11-slim-bookworm
 
@@ -45,9 +50,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # --- Chatterbox venv -------------------------------------------------------
 # Mirrors the WITH_CHATTERBOX block in docker/Dockerfile.controller — same
-# CPU-only torch trick, same Hugging Face cache pre-warm. numpy + Cython are
-# pre-installed so pkuseg's source build (no wheel for py3.11) can find
-# them; --no-build-isolation makes them visible to setup.py.
+# CPU-only torch trick. numpy + Cython are pre-installed so pkuseg's source
+# build (no wheel for py3.11) can find them; --no-build-isolation makes them
+# visible to setup.py. The model weights are downloaded lazily at runtime (see
+# the header note) — the build only imports the package to validate the venv.
 #
 # onnxruntime is a hidden hard requirement of chatterbox-tts >= 0.1.7 — the
 # perth watermarker uses ONNX models.
@@ -66,8 +72,8 @@ RUN python3 -m venv /opt/chatterbox/venv && \
       --index-url https://download.pytorch.org/whl/cpu \
       --extra-index-url https://pypi.org/simple \
       torch torchaudio onnxruntime chatterbox-tts && \
-    HF_HOME=$CHATTERBOX_HF_HOME /opt/chatterbox/venv/bin/python -c \
-      "from chatterbox.tts_turbo import ChatterboxTurboTTS; ChatterboxTurboTTS.from_pretrained(device='cpu')" && \
+    /opt/chatterbox/venv/bin/python -c \
+      "from chatterbox.tts_turbo import ChatterboxTurboTTS" && \
     find /opt/chatterbox/venv -depth -type d -name __pycache__ -exec rm -rf {} + && \
     SP=/opt/chatterbox/venv/lib/python3.11/site-packages && \
     rm -rf "$SP/torch/include" "$SP/torch/test"
@@ -79,14 +85,14 @@ RUN python3 -m venv /opt/chatterbox/venv && \
 #
 # HF_TOKEN (optional) unlocks PocketTTS voice cloning (issue #238). The
 # cloning weights (kyutai/pocket-tts) are GATED on Hugging Face; without a
-# token the pre-warm below loads the open "without-voice-cloning" weights and
-# cloned .wav voices silently revert to a built-in. Pass it to BAKE the gated
-# weights into the image: `docker compose build --build-arg HF_TOKEN=hf_...`
-# (you must first accept the model terms on huggingface.co/kyutai/pocket-tts).
-# Setting HF_TOKEN at RUNTIME (compose env) is enough on its own — the worker
-# downloads the gated weights lazily on first load — so baking is only for
-# offline / faster-first-call setups. NOTE: a build-arg token lands in the
-# image's build history; prefer the runtime env unless you control the image.
+# token the worker loads the open "without-voice-cloning" weights and cloned
+# .wav voices silently revert to a built-in. Set HF_TOKEN at RUNTIME (compose
+# env) — the worker downloads the gated weights lazily into the HF cache on
+# first /speak — after accepting the model terms on
+# huggingface.co/kyutai/pocket-tts. (We no longer bake weights at build time;
+# see the header note on why the build-time pre-warm was removed.) ARG HF_TOKEN
+# stays declared so the compose files' `build.args: HF_TOKEN` pass-through
+# doesn't warn — it's unused by the build now, but a token there does nothing.
 ARG HF_TOKEN=""
 ENV POCKET_HF_HOME=/opt/pocket-tts/hf-cache
 RUN python3 -m venv /opt/pocket-tts/venv && \
@@ -95,9 +101,8 @@ RUN python3 -m venv /opt/pocket-tts/venv && \
       --index-url https://download.pytorch.org/whl/cpu \
       --extra-index-url https://pypi.org/simple \
       torch scipy pocket-tts && \
-    HF_HOME=$POCKET_HF_HOME HF_TOKEN="$HF_TOKEN" HUGGING_FACE_HUB_TOKEN="$HF_TOKEN" \
-      /opt/pocket-tts/venv/bin/python -c \
-      "from pocket_tts import TTSModel; m = TTSModel.load_model(); print('voice_cloning=' + str(getattr(m, 'has_voice_cloning', None)))" && \
+    /opt/pocket-tts/venv/bin/python -c \
+      "from pocket_tts import TTSModel" && \
     find /opt/pocket-tts/venv -depth -type d -name __pycache__ -exec rm -rf {} + && \
     SP=/opt/pocket-tts/venv/lib/python3.11/site-packages && \
     rm -rf "$SP/torch/include" "$SP/torch/test"

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -49,8 +49,10 @@ DEVICE = os.environ.get("TTS_HEAVY_DEVICE", "cpu").lower()
 POCKET_TTS_DEFAULT_VOICE = os.environ.get("POCKET_TTS_VOICE", "alba")
 
 # Per-worker HF cache homes so the two engines don't fight over the same
-# directory. The Dockerfile pre-warms each cache; the env vars below tell
-# huggingface_hub where to look at runtime.
+# directory. Each is a named volume in the compose files, so the weights a
+# worker downloads on its first boot survive container recreates. The env vars
+# below tell huggingface_hub where to look at runtime (and are passed into each
+# worker's env via env_extra below).
 CHATTERBOX_HF_HOME = os.environ.get("CHATTERBOX_HF_HOME", "/opt/chatterbox/hf-cache")
 POCKET_HF_HOME = os.environ.get("POCKET_HF_HOME", "/opt/pocket-tts/hf-cache")
 


### PR DESCRIPTION
## What
Stop baking the tts-heavy model weights at build time, and persist the Hugging Face cache across container recreates.

## Why
The `subwave-tts-heavy` build pre-warmed Chatterbox + PocketTTS weights via `from_pretrained()`/`load_model()` during the Docker build, pulling several GB from the HF Hub inside CI over an unauthenticated, rate-limited connection — slow (20+ min) and flaky (HF 429s/timeouts).

Dropping that alone moves the multi-GB fetch to runtime, but the per-engine HF caches (`/opt/{chatterbox,pocket-tts}/hf-cache`) live in the container's ephemeral layer — so the download would repeat on **every** `up -d --build` / image pull / update. This adds a named volume over each cache dir so the boot-time fetch happens once and survives recreates.

Note: the download already happens at container **boot** (server.py's lifespan starts the workers, which load the model before reporting ready), not on first `/speak` — the Dockerfile/server.py comments are corrected to match.

## How tested
- `docker compose [-f docker-compose.{,byo.,dev.}yml] --profile tts-heavy config` validates clean on all three; the named volumes render mounted at the per-engine cache dirs.

## Notes for reviewers
Supersedes #286 (same first commit, now targeting `develop`); #286 closed in favour of this.
