### PR TITLE
fix(web): disable PWA service worker in dev

### DIFF
--- a/web/components/ServiceWorkerRegister.tsx
+++ b/web/components/ServiceWorkerRegister.tsx
@@ -9,6 +9,25 @@ export default function ServiceWorkerRegister(): null {
   useEffect(() => {
     if (typeof window === 'undefined') return;
     if (!('serviceWorker' in navigator)) return;
+
+    // The PWA service worker is production-only. In dev it precaches hashed
+    // webpack chunks that go stale on every `next dev` restart, surfacing as a
+    // cryptic "Cannot read properties of undefined (reading 'call')" runtime
+    // error. Actively tear down any SW + caches a prior prod/`next start` build
+    // left registered on this origin so the dev server is never handed stale
+    // assets — otherwise the stale SW keeps serving broken chunks and the page
+    // never recovers on its own.
+    if (process.env.NODE_ENV !== 'production') {
+      navigator.serviceWorker
+        .getRegistrations()
+        .then((regs) => regs.forEach((r) => r.unregister()))
+        .catch(() => {});
+      if ('caches' in window) {
+        caches.keys().then((keys) => keys.forEach((k) => caches.delete(k))).catch(() => {});
+      }
+      return;
+    }
+
     if (window.location.protocol !== 'https:' && window.location.hostname !== 'localhost') {
       // Browsers refuse SW over plain HTTP on non-localhost hosts. Skipping
       // the registration call avoids a noisy console error in those setups.


### PR DESCRIPTION
## Summary

The PWA service worker registers on `localhost` and does `cacheFirst` on `/_next/static/*`. That's correct for prod's content-hashed, immutable chunks — but in dev those chunk filenames are mutable and change on every `next dev` restart, so the SW serves a **stale cached chunk forever**, surfacing as a cryptic runtime error at the root layout:

```
Runtime TypeError: Cannot read properties of undefined (reading 'call')
app/layout.tsx @ RootLayout → <ThemeBootstrap>
```

It survives a `.next` wipe + dev-server restart because the poison lives in the SW's Cache Storage, not the build — every page on the origin is affected until the SW is manually unregistered.

## Fix

- Gate SW registration to `NODE_ENV === 'production'`.
- In dev, **actively unregister** any service worker and **clear caches** a prior prod / `next start` build left on the origin — so an already-poisoned dev browser self-heals instead of staying broken (without this, the stale SW keeps serving broken chunks and the new code never even loads).

Production behaviour is unchanged.

## Test plan
- [ ] In dev (`npm run dev`), load any route, restart the dev server, hard-reload — no `reading 'call'` error; DevTools → Application → Service Workers shows none registered on `localhost:7700`.
- [ ] A browser that previously registered the SW on `localhost` self-heals on next load (SW unregistered, `subwave-shell-v2` cache cleared).
- [ ] Production build still registers `/sw.js` and remains installable.