### PR TITLE
fix(cli): sync embedded CLI_VERSION to package version (0.9.0)

### DIFF
--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -608,4 +608,4 @@ SITE_URL=
 
 // cli/package.json#version (embedded so the compiled binary can self-identify
 // — used by `subwave --version` and by the TUI release fetch URL).
-export const CLI_VERSION = `0.7.0`;
+export const CLI_VERSION = `0.9.0`;


### PR DESCRIPTION
## Summary

The `verify-cli-assets` check failed on the release PR (#303): `cli/src/assets.generated.ts` was out of sync.

`assets.generated.ts` embeds `CLI_VERSION` from `cli/package.json` so the compiled binary can self-identify (`subwave --version`, TUI release-fetch URL). `cli/package.json` is at **0.9.0**, but the committed generated copy still read **0.7.0** — so the binary self-reported a stale version, and CI's regenerate-and-diff check rejected it.

Regenerated with `npm --prefix cli run embed-assets`. **Only the `CLI_VERSION` line changes** — the 4 embedded compose/`.env` files are already in sync (last regenerated in #294).

> [!NOTE]
> Root cause is broader: release-please bumps `cli/package.json` directly on `main` but never regenerates the embedded asset, so `CLI_VERSION` silently drifts each release (the same 0.7.0/0.9.0 mismatch currently exists on `main` too). A durable fix — regenerate as part of the release bump, or read the version at build time instead of embedding — is worth a follow-up. This PR just unblocks the release.

## Test plan
- [ ] `verify-cli-assets` passes (regenerate → diff is clean).
- [ ] `npm --prefix cli run embed-assets` produces no diff after this lands.
- [ ] `subwave --version` reports `0.9.0`.