### PR TITLE
fix(web): widen session-chat kind column to fit longest label

### DIFF
--- a/web/components/admin/DebugPanel.tsx
+++ b/web/components/admin/DebugPanel.tsx
@@ -478,7 +478,7 @@ function SessionChat({ session }: { session: DebugSession }) {
         <div
           key={i}
           className={cn(
-            'grid grid-cols-[auto_64px_1fr] items-baseline gap-2 py-0.5 text-[12px]',
+            'grid grid-cols-[auto_178px_1fr] items-baseline gap-2 py-0.5 text-[12px]',
             i < msgs.length - 1 && 'border-b border-dashed border-separator-strong',
           )}
         >

--- a/web/components/admin/DebugPanel.tsx
+++ b/web/components/admin/DebugPanel.tsx
@@ -478,6 +478,10 @@ function SessionChat({ session }: { session: DebugSession }) {
         <div
           key={i}
           className={cn(
+            // 178px fits the widest role·kind label, 'segment·album-anniversary'
+            // (~170px at text-[9px]/tracking-[0.12em]/uppercase) + breathing room.
+            // Each row is its own grid, so a fixed width is needed to keep the
+            // kind column aligned across rows — bump it if a longer kind is added.
             'grid grid-cols-[auto_178px_1fr] items-baseline gap-2 py-0.5 text-[12px]',
             i < msgs.length - 1 && 'border-b border-dashed border-separator-strong',
           )}


### PR DESCRIPTION
## Problem

The `SessionChat` kind column (`grid-cols-[auto_64px_1fr]`) was 64px — too narrow for the longest possible `role·kind` labels. Labels overflowed their grid track and collided with the message column.

The complete set of `segment·*` kinds (`VOICE_KINDS` in `queue.ts`) includes `segment·album-anniversary` and `segment·library-deep-cut`, which are the longest possible values. At 9px / uppercase / `tracking-[0.12em]`, `segment·album-anniversary` measures **170px** in the live font.

## Fix

Widened the kind column from `64px` to `178px` (170px measured + 8px breathing room).

Measurement method: injected a hidden probe span with matching styles into the live page and read `getBoundingClientRect().width` for `segment·album-anniversary`.

## Change

`web/components/admin/DebugPanel.tsx` — one token, `SessionChat` grid:

```
- 'grid grid-cols-[auto_64px_1fr] items-baseline gap-2 py-0.5 text-[12px]',
+ 'grid grid-cols-[auto_178px_1fr] items-baseline gap-2 py-0.5 text-[12px]',
```

## Examples

### Before
<img width="1207" height="467" alt="Screenshot 2026-06-05 at 11 45 17" src="https://github.com/user-attachments/assets/d23ed4c3-29f1-44aa-9016-61107d1b21bb" />


### After
<img width="1201" height="469" alt="Screenshot 2026-06-05 at 11 45 39" src="https://github.com/user-attachments/assets/f0447521-b565-42a5-b910-d4667b7e258b" />

(Note: it's made long enough to absorb the longest type which I believe to be the `segment·album-anniversary`)