### PR TITLE
feat(stations): no-fork station submissions via issue form (#296)

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-station.yml
+++ b/.github/ISSUE_TEMPLATE/add-station.yml
@@ -1,0 +1,97 @@
+name: 📻 Add my station to the directory
+description: List your SUB/WAVE station on the public /stations map — no fork, no JSON. Fill this in and a pull request is opened for you automatically.
+title: "Add station: "
+labels: ["station-submission"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for putting your station on the map! Fill in the fields below and submit.
+        A bot will turn this into a one-file pull request to the directory — a maintainer
+        just reviews and merges it. **You don't need to fork anything.**
+
+        Only **name** and **URL** are required. Everything else makes your card and map dot nicer.
+  - type: input
+    id: name
+    attributes:
+      label: Station name
+      description: The display name shown on your card.
+      placeholder: Night Owl Radio
+    validations:
+      required: true
+  - type: input
+    id: url
+    attributes:
+      label: Public URL
+      description: >
+        Your station's public origin. The directory probes ‹url›/api/now-playing from
+        the listener's browser to show an ON AIR badge + current track, so this must be
+        reachable and CORS-open (the SUB/WAVE controller is by default).
+      placeholder: https://radio.example.com
+    validations:
+      required: true
+  - type: input
+    id: location
+    attributes:
+      label: Location (City, Country)
+      description: Free text, shown on your card.
+      placeholder: Berlin, Germany
+    validations:
+      required: false
+  - type: input
+    id: country
+    attributes:
+      label: Country
+      description: Used for the "N countries" tally. Falls back to the location above if left blank.
+      placeholder: Germany
+    validations:
+      required: false
+  - type: input
+    id: operator
+    attributes:
+      label: Operator
+      description: Your name or @handle — who runs it.
+      placeholder: "@yourhandle"
+    validations:
+      required: false
+  - type: input
+    id: lat
+    attributes:
+      label: Latitude
+      description: Decimal degrees. Provide BOTH lat and lon to get a dot on the world map. 2–3 decimals is plenty.
+      placeholder: "52.52"
+    validations:
+      required: false
+  - type: input
+    id: lon
+    attributes:
+      label: Longitude
+      description: Decimal degrees. Search your city on any maps site and copy the coordinates.
+      placeholder: "13.405"
+    validations:
+      required: false
+  - type: input
+    id: genre
+    attributes:
+      label: Genre / vibe
+      description: A short label for the kind of music you play.
+      placeholder: ambient / downtempo
+    validations:
+      required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: One or two sentences about your station.
+      placeholder: Late-night ambient for people who keep odd hours.
+    validations:
+      required: false
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Before you submit
+      options:
+        - label: My station URL is public and reachable (visiting it loads the player).
+          required: true
+        - label: I understand a pull request will be opened from this issue and a maintainer will review it.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+# Keep the plain "open a blank issue" option for bug reports / questions, and
+# point would-be station contributors who prefer doing it by hand at the README.
+blank_issues_enabled: true
+contact_links:
+  - name: 📻 Add your station by hand (advanced)
+    url: https://github.com/perminder-klair/subwave/blob/develop/web/content/stations/README.md
+    about: Prefer to open the pull request yourself? Here's the one-file format. Most people should use the "Add my station" form instead — it needs no fork.

--- a/.github/workflows/station-submission.yml
+++ b/.github/workflows/station-submission.yml
@@ -1,0 +1,188 @@
+name: Station submission → PR
+
+# Turns a "📻 Add my station" issue (see .github/ISSUE_TEMPLATE/add-station.yml)
+# into a one-file pull request against develop — so community members can list
+# their station WITHOUT forking the repo or hand-writing JSON. A maintainer then
+# reviews and merges the generated PR; it ships to main on the next release.
+#
+# Security: the issue body is UNTRUSTED user input. It is parsed and written to
+# a file entirely inside actions/github-script via the REST API (Buffer/base64,
+# createOrUpdateFileContents) — it is NEVER interpolated into a shell `run:`
+# step, so there is no command-injection surface. The only file this workflow
+# can write is web/content/stations/<slug>.json (slug is sanitised to
+# [a-z0-9-]). PRs opened by GITHUB_TOKEN don't re-trigger pull_request
+# workflows, which is fine here — the content is generated, and lint runs on the
+# push to develop after merge.
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  # Serialise per-issue so rapid edits don't race on the same branch.
+  group: station-submission-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  build-pr:
+    name: Build station PR from issue
+    runs-on: ubuntu-latest
+    # Only act on issues opened through the station-submission form.
+    if: contains(join(github.event.issue.labels.*.name, ','), 'station-submission')
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const { owner, repo } = context.repo;
+            const BASE = 'develop';
+            const DIR = 'web/content/stations';
+
+            // --- 1. Parse the issue-form body into a { heading: value } map ---
+            // GitHub renders each form field as "### <label>\n\n<value>", with
+            // multi-line values (textareas) spanning several lines. Empty
+            // optional fields render as "_No response_". Walk line-by-line so a
+            // multi-line description isn't truncated.
+            const body = issue.body || '';
+            const fields = {};
+            let curKey = null, buf = [];
+            const flush = () => {
+              if (curKey === null) return;
+              let v = buf.join('\n').trim();
+              if (v === '_No response_') v = '';
+              fields[curKey] = v;
+            };
+            for (const line of body.split(/\r?\n/)) {
+              const h = line.match(/^###\s+(.+?)\s*$/);
+              if (h) { flush(); curKey = h[1].trim(); buf = []; }
+              else if (curKey !== null) { buf.push(line); }
+            }
+            flush();
+            const get = (label) => (fields[label] || '').trim();
+
+            const name = get('Station name');
+            const url = get('Public URL').replace(/\/+$/, '');
+            const location = get('Location (City, Country)');
+            const country = get('Country');
+            const operator = get('Operator');
+            const latRaw = get('Latitude');
+            const lonRaw = get('Longitude');
+            const genre = get('Genre / vibe');
+            const description = get('Description');
+
+            // --- 2. Validate the floor (name + url) ---
+            const problems = [];
+            if (!name) problems.push('**Station name** is required.');
+            if (!url) problems.push('**Public URL** is required.');
+            else if (!/^https?:\/\/.+/i.test(url))
+              problems.push('**Public URL** must start with `http://` or `https://`.');
+
+            const fail = async (lines) => {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issue.number,
+                body: `⚠️ I couldn't build a pull request from this submission:\n\n` +
+                  lines.map((l) => `- ${l}`).join('\n') +
+                  `\n\nEdit the issue to fix it and I'll try again automatically.`,
+              });
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: issue.number, labels: ['needs-info'],
+              }).catch(() => {});
+            };
+
+            if (problems.length) { await fail(problems); return; }
+
+            // --- 3. Build the slug + station JSON ---
+            const slug = name.toLowerCase()
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/^-+|-+$/g, '')
+              .slice(0, 60) || `station-${issue.number}`;
+
+            const station = { name, url };
+            if (operator) station.operator = operator;
+            if (location) station.location = location;
+            if (country) station.country = country;
+            const lat = Number(latRaw), lon = Number(lonRaw);
+            if (latRaw && lonRaw && Number.isFinite(lat) && Number.isFinite(lon)) {
+              station.lat = lat; station.lon = lon;
+            }
+            if (genre) station.genre = genre;
+            if (description) station.description = description;
+            station.featured = false;
+            station.submitted = new Date(issue.created_at).toISOString().slice(0, 10);
+
+            const filePath = `${DIR}/${slug}.json`;
+            const content = JSON.stringify(station, null, 2) + '\n';
+            const contentB64 = Buffer.from(content, 'utf8').toString('base64');
+
+            // --- 4. Ensure a branch off develop ---
+            const branch = `station/${slug}`;
+            const baseRef = await github.rest.git.getRef({
+              owner, repo, ref: `heads/${BASE}`,
+            });
+            const baseSha = baseRef.data.object.sha;
+            try {
+              await github.rest.git.createRef({
+                owner, repo, ref: `refs/heads/${branch}`, sha: baseSha,
+              });
+            } catch (e) {
+              if (e.status !== 422) throw e; // 422 = branch already exists (edited issue)
+            }
+
+            // --- 5. Write/refresh the station file on that branch ---
+            let existingSha;
+            try {
+              const existing = await github.rest.repos.getContent({
+                owner, repo, path: filePath, ref: branch,
+              });
+              existingSha = existing.data.sha;
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
+            await github.rest.repos.createOrUpdateFileContents({
+              owner, repo, path: filePath, branch,
+              message: `feat(stations): add ${name} (from #${issue.number})`,
+              content: contentB64,
+              ...(existingSha ? { sha: existingSha } : {}),
+            });
+
+            // --- 6. Open the PR (or reuse the existing one) ---
+            const open = await github.rest.pulls.list({
+              owner, repo, state: 'open', head: `${owner}:${branch}`,
+            });
+            let pr = open.data[0];
+            const prBody =
+              `Adds **${name}** to the [stations directory](${url}).\n\n` +
+              `Generated automatically from #${issue.number}. Closes #${issue.number}.\n\n` +
+              '```json\n' + content + '```\n';
+            if (!pr) {
+              const created = await github.rest.pulls.create({
+                owner, repo, base: BASE, head: branch,
+                title: `feat(stations): add ${name}`,
+                body: prBody,
+              });
+              pr = created.data;
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: pr.number, labels: ['stations'],
+              }).catch(() => {});
+            } else {
+              await github.rest.pulls.update({
+                owner, repo, pull_number: pr.number, body: prBody,
+              });
+            }
+
+            // --- 7. Tell the contributor ---
+            await github.rest.issues.removeLabel({
+              owner, repo, issue_number: issue.number, name: 'needs-info',
+            }).catch(() => {});
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: issue.number,
+              body: `✅ Opened ${pr.html_url} with your station at \`${filePath}\`.\n\n` +
+                `A maintainer will review and merge it — your station appears on the ` +
+                `map on the next deploy. Need to change something? Just edit this issue ` +
+                `and the PR updates automatically.`,
+            });

--- a/web/app/stations/page.tsx
+++ b/web/app/stations/page.tsx
@@ -13,26 +13,12 @@ export const metadata = pageMeta({
 
 const REPO = 'https://github.com/perminder-klair/subwave';
 
-// Pre-filled "new file" editor on GitHub — clicking opens a ready-to-edit
-// station file, so a submission is fork → tweak → open PR. value= seeds the
-// file body; filename= seeds the path (the contributor renames the slug).
-const SUBMIT_TEMPLATE = `{
-  "name": "Your Station",
-  "url": "https://radio.example.com",
-  "operator": "@yourhandle",
-  "location": "City, Country",
-  "country": "Country",
-  "lat": 0,
-  "lon": 0,
-  "genre": "ambient / downtempo",
-  "description": "One or two sentences about your station.",
-  "featured": false,
-  "submitted": "2026-06-04"
-}
-`;
-const SUBMIT_URL =
-  `${REPO}/new/main?filename=web/content/stations/your-station.json` +
-  `&value=${encodeURIComponent(SUBMIT_TEMPLATE)}`;
+// Submission opens a GitHub Issue Form (no fork, no JSON). A workflow turns the
+// issue into a one-file pull request automatically — see
+// .github/workflows/station-submission.yml. The old new-file editor link forced
+// non-collaborators to fork the repo (discussion #296), so we route through an
+// issue instead: anyone with a GitHub account can submit in one click.
+const SUBMIT_URL = `${REPO}/issues/new?template=add-station.yml`;
 
 export default function StationsIndex() {
   const stations = getAllStations();

--- a/web/content/stations/README.md
+++ b/web/content/stations/README.md
@@ -2,18 +2,29 @@
 
 This folder powers the public **[/stations](https://getsubwave.com/stations)**
 directory — a map and listing of SUB/WAVE installations around the world. Each
-station is **one JSON file** in this directory. To add yours, open a pull
-request that adds a single file. That's the whole process.
+station is **one JSON file** in this directory.
 
-## How to submit
+## How to submit (the easy way — no fork)
 
-1. **Fork** the repo (or use the "Add your station" button on the `/stations`
-   page, which opens a pre-filled new file for you).
+Hit **"Add your station"** on the [`/stations`](https://getsubwave.com/stations)
+page (or open the [station form](https://github.com/perminder-klair/subwave/issues/new?template=add-station.yml)
+directly). Fill in the fields and submit — that's it. A bot turns your issue into
+a one-file pull request, and a maintainer reviews and merges it. **You don't need
+to fork the repo or write any JSON.** Your station appears on the map on the next
+deploy. Edit the issue later and the PR updates itself automatically.
+
+## How to submit (by hand)
+
+Prefer to open the pull request yourself?
+
+1. **Fork** the repo.
 2. Add a file at `web/content/stations/<your-slug>.json` — the filename (minus
    `.json`) becomes the station's slug, so keep it short and kebab-case, e.g.
    `night-owl-radio.json`.
-3. Fill in the fields below and **open a pull request**. A maintainer reviews and
-   merges it; your station then shows up on the next deploy.
+3. Fill in the fields below and **open a pull request against `develop`**. A
+   maintainer reviews and merges it; your station then shows up on the next
+   deploy. (PRs to `main` are blocked by CI — `main` is the release branch and
+   only takes `develop`.)
 
 One file per station keeps pull requests from colliding and makes each entry
 trivial to review or revert.


### PR DESCRIPTION
## Why

[Discussion #296](https://github.com/perminder-klair/subwave/discussions/296) — a community member tried to add their station and GitHub forced them to fork the repo. Two bugs in the "Add your station" flow:

1. **Forced fork** — the link opened GitHub's `/new/main` file editor, which always makes non-collaborators fork. Unavoidable for that link type.
2. **Wrong base branch** — it targeted `main`, but `enforce-main-source.yml` rejects every PR to `main` that isn't from `develop`/release-please. So even a successful fork+PR would fail CI.

## What

Replace the new-file-editor flow with a **no-fork GitHub Issue Form + auto-PR**:

- **`.github/ISSUE_TEMPLATE/add-station.yml`** — structured submission form (name, url, location, country, operator, lat, lon, genre, description). No fork, no JSON.
- **`.github/workflows/station-submission.yml`** — on a `station-submission`-labeled issue, parses the form and opens a one-file PR `station/<slug>` → `develop`, closing the issue. Editing the issue updates the PR.
- **`.github/ISSUE_TEMPLATE/config.yml`** — keeps blank issues enabled; links the by-hand path.
- **`web/app/stations/page.tsx`** — "Add your station" now deep-links to the issue form.
- **`web/content/stations/README.md`** — documents the easy no-fork path first; by-hand path now correctly targets `develop`.

## Security

All file I/O happens through the REST API in `github-script` — the untrusted issue body never touches a shell `run:` step (no command-injection surface). The only writable path is `web/content/stations/<slug>.json` with a `[a-z0-9-]`-sanitised slug.

## Notes

- PRs opened by `GITHUB_TOKEN` don't re-trigger `pull_request` workflows, so lint won't run on the auto-PR; it runs on the push to `develop` after merge. The content is generated valid JSON.
- Submissions land on `develop` and ship to `main` on the next release (inherent to the branch model; README states it).

Closes the friction reported in #296.