### PR TITLE
fix(controller): probe-based embedding dim + clearer preflight errors (#319)

### DIFF
--- a/controller/package.json
+++ b/controller/package.json
@@ -9,6 +9,7 @@
     "tag": "tsx src/music/tag-library.ts",
     "analyze": "tsx src/music/analyze-library.ts",
     "lastfm-session": "tsx scripts/lastfm-session.ts",
+    "test:embed": "tsx scripts/embedding-preflight-test.ts",
     "lint": "eslint . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit"

--- a/controller/scripts/embedding-preflight-test.ts
+++ b/controller/scripts/embedding-preflight-test.ts
@@ -1,0 +1,153 @@
+// Regression test for the embedding preflight + dimension handling (#319).
+//
+// Exercises the real modules end-to-end — no mocks of our own code:
+//   1. probeOnce() reports the dimension measured from a LIVE embedding call
+//      (ollama nomic-embed-text). Skipped if ollama isn't reachable.
+//   2. ensureReady() classifies a chat-model / no-pooling server as
+//      `not_embedding_model` with an actionable message — driven through the
+//      real AI SDK error path via a throwaway HTTP server that mimics the two
+//      llama.cpp error strings operators actually hit.
+//   3. library-db migrate() honours the stored dim at runtime (adoptStoredDim),
+//      refuses a silent dim change for the tagger, and rebuilds on --reseed.
+//      Run against real sqlite-vec.
+//
+// Usage (from controller/):
+//   npm run test:embed
+//
+// Self-contained: points STATE_DIR at a throwaway dir and mutates settings
+// in-memory, so it never touches a live install's state/.
+
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import http from 'node:http';
+
+// Must be set BEFORE importing anything that reads config (config.ts captures
+// STATE_DIR at import time).
+process.env.STATE_DIR = mkdtempSync(join(tmpdir(), 'subwave-embed-test-'));
+
+const settings = await import('../src/settings.js');
+const embeddings = await import('../src/music/embeddings.js');
+const db = await import('../src/music/library-db.js');
+
+let pass = 0;
+let fail = 0;
+let skip = 0;
+function ok(name: string, cond: boolean, extra = '') {
+  if (cond) {
+    pass++;
+    console.log(`  PASS  ${name}${extra ? ' — ' + extra : ''}`);
+  } else {
+    fail++;
+    console.log(`  FAIL  ${name}${extra ? ' — ' + extra : ''}`);
+  }
+}
+function skipped(name: string, why: string) {
+  skip++;
+  console.log(`  SKIP  ${name} — ${why}`);
+}
+
+await settings.load();
+const S: any = settings.get();
+
+// ---- 1. Live ollama probe → authoritative dim (#2) ------------------------
+console.log('\n[1] probe reports the live embedding dimension');
+S.llm = { provider: 'ollama', model: '', apiKey: '', ollamaUrl: '', baseUrl: '', reasoning: false };
+S.embedding = { enabled: true, provider: 'ollama', model: 'nomic-embed-text' };
+{
+  const r = await embeddings.ensureReady();
+  if (r.code === 'ok') {
+    ok('probe returns a measured dim', typeof r.dim === 'number' && r.dim! > 0, `dim=${r.dim}`);
+    ok('nomic-embed-text measures 768', r.dim === 768, `dim=${r.dim}`);
+  } else {
+    // No local ollama / model not pulled — don't fail the suite for that.
+    skipped('live ollama probe', `probe code=${r.code} (ollama+nomic-embed-text not available)`);
+  }
+}
+
+// ---- 2. Chat model / no pooling → not_embedding_model (#1) -----------------
+console.log('\n[2] a chat model (no pooling) is classified, not left as "unknown"');
+async function probeAgainst(errMsg: string) {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(500, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: { message: errMsg, type: 'server_error' } }));
+  });
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', () => r()));
+  const port = (server.address() as any).port;
+  S.embedding = {
+    enabled: true,
+    provider: 'openai-compatible',
+    baseUrl: `http://127.0.0.1:${port}/v1`,
+    model: 'qwen3.5',
+    apiKey: '',
+  };
+  try {
+    return await embeddings.ensureReady();
+  } finally {
+    server.close();
+  }
+}
+for (const msg of [
+  'This server does not support embeddings. Start it with `--embeddings`',
+  "Pooling type 'none' is not OAI compatible. Please use a different pooling type",
+]) {
+  const r = await probeAgainst(msg);
+  ok('classified not_embedding_model', r.code === 'not_embedding_model', `"${msg.slice(0, 38)}..."`);
+  ok('message points at the fix', /--embeddings|pooling|embedding model/i.test(r.message));
+}
+
+// ---- 3. library-db dim handling (#2) --------------------------------------
+console.log('\n[3] library-db honours the stored dim');
+// Seed a 768-d DB the way the tagger would.
+await db.open({ embeddingDim: 768, reseed: false });
+db.setEmbeddingMeta('ollama:nomic-embed-text', 768);
+db.upsertTrackMeta('t1', { title: 'x', artist: 'y' });
+db.upsertTrackVector('t1', new Array(768).fill(0.01));
+ok('seed: 768-d vector accepted', true);
+db.close();
+
+// 3a. Runtime opens with the WRONG name-guessed dim but adoptStoredDim → adopt
+//     the stored 768 and keep the index instead of wiping it.
+await db.open({ embeddingDim: 1536, adoptStoredDim: true });
+ok('adopt: stored meta still 768 (index not wiped)', db.getEmbeddingMeta()?.dim === 768);
+let accepted768 = false;
+try {
+  db.upsertTrackVector('t1', new Array(768).fill(0.02));
+  accepted768 = true;
+} catch { /* table width wrong */ }
+ok('adopt: table really is 768 (768-d upsert accepted)', accepted768);
+let rejected1536 = false;
+try {
+  db.upsertTrackVector('t1', new Array(1536).fill(0.02));
+} catch {
+  rejected1536 = true;
+}
+ok('adopt: 1536-d upsert rejected', rejected1536);
+db.close();
+
+// 3b. Tagger opens with a changed dim and NO --reseed → instructive throw.
+let threw = false;
+let msg = '';
+try {
+  await db.open({ embeddingDim: 1536, reseed: false });
+} catch (e: any) {
+  threw = true;
+  msg = e?.message || '';
+}
+ok('mismatch: throws without --reseed', threw);
+ok('mismatch: message names --reseed', /--reseed/.test(msg));
+if (db.isOpen()) db.close();
+
+// 3c. Tagger opens with a changed dim WITH --reseed → rebuild at the new dim.
+await db.open({ embeddingDim: 1536, reseed: true });
+db.setEmbeddingMeta('other:model-1536', 1536);
+let accepted1536 = false;
+try {
+  db.upsertTrackVector('t1', new Array(1536).fill(0.03));
+  accepted1536 = true;
+} catch { /* */ }
+ok('reseed: table rebuilt at 1536', accepted1536);
+db.close();
+
+console.log(`\n==== ${pass} passed, ${fail} failed, ${skip} skipped ====`);
+process.exit(fail ? 1 : 0);

--- a/controller/src/llm/provider.ts
+++ b/controller/src/llm/provider.ts
@@ -216,17 +216,18 @@ function defaultEmbeddingModelFor(provider: string): string {
 }
 
 function defaultEmbeddingDimFor(model: string): number {
-  // Authoritative dim lookup for the default models. If the operator picks a
-  // model not in this table, library-db will reject the dim mismatch at
-  // upsert time with a friendly --reseed message.
+  // Best-effort dim guess for known model names. This is only a FALLBACK seed:
+  // the tagger probes the live server and uses the real vector length as the
+  // authoritative dim (music/embeddings.ts probeOnce → tag-library.ts), and the
+  // live controller adopts whatever dim the tagger recorded (library-db
+  // adoptStoredDim). So an unknown / arbitrarily-named embedding model still
+  // works — this table just seeds the schema before the first tag run (#319).
   if (model === 'nomic-embed-text') return 768;
   if (model === 'mxbai-embed-large') return 1024;
   if (model === 'text-embedding-3-small') return 1536;
   if (model === 'text-embedding-3-large') return 3072;
   if (model === 'text-embedding-004') return 768;
-  // Unknown model — assume the homelab default until the operator says
-  // otherwise via settings.embedding.dim.
-  return 768;
+  return 768; // homelab default until a probe says otherwise
 }
 
 export function embeddingModel() {

--- a/controller/src/music/analyze-library.ts
+++ b/controller/src/music/analyze-library.ts
@@ -65,9 +65,9 @@ async function main() {
   await applyWizardOverlay();
   await settings.load();
   const embeddingDim = embeddings.resolveEmbeddingDim();
-  // reseed:true so an embedding model/dim swap doesn't block acoustic analysis
-  // (which doesn't touch vectors) — see music/library.ts. No-op when dims match.
-  await db.open({ embeddingDim, reseed: true });
+  // adoptStoredDim:true so an embedding model/dim swap doesn't block acoustic
+  // analysis (which doesn't touch vectors) — see music/library.ts (#319).
+  await db.open({ embeddingDim, adoptStoredDim: true });
 
   // Walk only when forced, or when the catalogue is empty (bootstrap).
   // --skip-walk hard-disables either way.

--- a/controller/src/music/embeddings.ts
+++ b/controller/src/music/embeddings.ts
@@ -102,14 +102,18 @@ export async function embedTexts(texts: string[]): Promise<number[][]> {
 export type ProbeCode =
   | 'ok'
   | 'disabled'
-  | 'not_found'      // Ollama 404 — model isn't pulled
-  | 'unauthorized'   // 401 — typically cloud-routed Ollama or wrong API key
-  | 'unreachable'    // connection refused / DNS / timeout
-  | 'unknown';       // anything else — message has the raw error
+  | 'not_found'           // Ollama 404 — model isn't pulled
+  | 'unauthorized'        // 401 — typically cloud-routed Ollama or wrong API key
+  | 'unreachable'         // connection refused / DNS / timeout
+  | 'not_embedding_model' // server reached, but it's a chat model / no pooling (#319)
+  | 'unknown';            // anything else — message has the raw error
 
 export interface ProbeResult {
   code: ProbeCode;
   message: string;
+  // Vector length measured from a successful probe. Authoritative dim for the
+  // schema — beats guessing from the model name (#319). Only set when code==ok.
+  dim?: number;
 }
 
 function classifyEmbeddingError(err: any): { code: ProbeCode; raw: string } {
@@ -121,6 +125,17 @@ function classifyEmbeddingError(err: any): { code: ProbeCode; raw: string } {
   }
   if (status === 401 || status === 403 || txt.includes('unauthorized') || txt.includes('forbidden')) {
     return { code: 'unauthorized', raw };
+  }
+  // Server is up and authenticated, but the loaded model can't embed: either it
+  // was started without the embeddings endpoint, or it's a generative/chat model
+  // whose pooling type is 'none' (not OAI-compatible). The classic trap when an
+  // openai-compatible embedding config inherits the *chat* server's baseUrl (#319).
+  if (
+    txt.includes('does not support embeddings') ||
+    txt.includes('start it with') ||         // llama.cpp: "Start it with `--embeddings`"
+    txt.includes('pooling')                  // llama.cpp: "Pooling type 'none' is not OAI compatible"
+  ) {
+    return { code: 'not_embedding_model', raw };
   }
   if (
     err?.code === 'ECONNREFUSED' ||
@@ -174,6 +189,29 @@ function actionableMessage(code: ProbeCode, raw: string): string {
         );
       }
       return `Can't reach provider "${provider}" — check network / baseUrl. (${raw})`;
+    case 'not_embedding_model':
+      if (provider === 'openai-compatible') {
+        return (
+          `The embedding endpoint is reachable but "${model}" can't produce embeddings —\n` +
+          `  it's a chat/generative model, not an embedding model.\n` +
+          `  By default settings.embedding inherits settings.llm.baseUrl, so embeddings\n` +
+          `  point at your CHAT server. Run a DEDICATED embedding model on its own\n` +
+          `  llama.cpp server (note --embeddings --pooling mean):\n` +
+          `        llama-server -m nomic-embed-text-v1.5.Q8_0.gguf \\\n` +
+          `          --embeddings --pooling mean --host 0.0.0.0 --port 8090\n` +
+          `  then in /admin/settings → Embedding set:\n` +
+          `        baseUrl = http://<host>:8090/v1\n` +
+          `        model   = nomic-embed-text\n` +
+          `  (server said: ${raw})`
+        );
+      }
+      return (
+        `The embedding endpoint is reachable but "${model}" can't produce embeddings —\n` +
+        `  it looks like a chat/generative model, not an embedding model.\n` +
+        `  Point settings.embedding at a real embedding model (e.g. nomic-embed-text),\n` +
+        `  served with embeddings enabled and a pooling type other than 'none'.\n` +
+        `  (server said: ${raw})`
+      );
     case 'unknown':
     default:
       return `Embedding probe failed: ${raw}`;
@@ -233,8 +271,11 @@ async function tryOllamaPull(model: string, ollamaUrl: string): Promise<boolean>
 
 async function probeOnce(): Promise<ProbeResult> {
   try {
-    await embedTexts(['subwave embedding probe']);
-    return { code: 'ok', message: 'ok' };
+    const vecs = await embedTexts(['subwave embedding probe']);
+    // Measure the real vector length from the live server — authoritative dim,
+    // independent of the name→dim guess table (#319).
+    const dim = Array.isArray(vecs[0]) ? vecs[0].length : undefined;
+    return { code: 'ok', message: 'ok', dim };
   } catch (err: any) {
     const { code, raw } = classifyEmbeddingError(err);
     return { code, message: actionableMessage(code, raw) };

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -140,9 +140,19 @@ export interface LibraryStats {
 // `reseed` from its --reseed flag; the live controller passes it too so a model
 // change self-heals instead of crashing (see music/library.ts). It is a no-op
 // on the normal matching-dim path.
-export async function open(opts: { embeddingDim: number; reseed?: boolean }): Promise<void> {
+// `adoptStoredDim` (live controller) treats the dim already recorded in the DB
+// as authoritative: the stored vectors win, and `embeddingDim` is only the
+// fallback used when the DB has never been tagged. This stops the runtime from
+// wiping a tagged index just because the model *name* maps to a different
+// default than the dim the tagger actually probed (#319). The tagger leaves it
+// off so a deliberate model swap still surfaces the --reseed gate.
+export async function open(opts: {
+  embeddingDim: number;
+  reseed?: boolean;
+  adoptStoredDim?: boolean;
+}): Promise<void> {
   if (db) {
-    if (opts.embeddingDim !== currentEmbeddingDim) {
+    if (!opts.adoptStoredDim && opts.embeddingDim !== currentEmbeddingDim) {
       throw new Error(
         `library-db already open with embedding dim ${currentEmbeddingDim}; ` +
           `caller asked for ${opts.embeddingDim}. Use --reseed to switch models.`,
@@ -156,7 +166,12 @@ export async function open(opts: { embeddingDim: number; reseed?: boolean }): Pr
   db.pragma('synchronous = NORMAL');
   sqliteVec.load(db);
 
-  await migrate(opts.embeddingDim, opts.reseed === true);
+  // migrate() may adopt the stored dim; trust its return as the live schema dim.
+  currentEmbeddingDim = await migrate(
+    opts.embeddingDim,
+    opts.reseed === true,
+    opts.adoptStoredDim === true,
+  );
   await maybeMigrateFromMoodsJson();
 }
 
@@ -181,7 +196,10 @@ function requireDb(): Database.Database {
 // Schema
 // ---------------------------------------------------------------------------
 
-async function migrate(embeddingDim: number, reseed = false): Promise<void> {
+// Returns the dim the vec0 table is actually created at (== the stored dim when
+// `adoptStoredDim` adopts it, else `embeddingDim`). Callers use this as the live
+// schema dim so reads/writes validate against the real table width.
+async function migrate(embeddingDim: number, reseed = false, adoptStoredDim = false): Promise<number> {
   const d = requireDb();
   const userVersion = (d.pragma('user_version', { simple: true }) as number) || 0;
 
@@ -242,24 +260,38 @@ async function migrate(embeddingDim: number, reseed = false): Promise<void> {
   const meta = d.prepare('SELECT model, dim FROM embedding_meta WHERE pk = 1').get() as
     | { model: string; dim: number }
     | undefined;
+  // Effective dim for the vec0 table. Defaults to what the caller asked for; the
+  // branches below may adopt the stored dim or reseed at the new dim instead.
+  let effectiveDim = embeddingDim;
   if (meta && meta.dim !== embeddingDim) {
-    if (!reseed) {
+    if (adoptStoredDim) {
+      // Live controller: the stored vectors are authoritative. Honour their dim
+      // so the picker keeps working off a tagged index even when the model name
+      // resolves to a different default. A real model swap is reconciled by the
+      // tagger's --reseed path, not silently here (#319).
+      console.warn(
+        `[library-db] adopting stored embedding dim ${meta.dim} (model: ${meta.model}); ` +
+          `caller requested ${embeddingDim}. Re-tag with --reseed to switch models.`,
+      );
+      effectiveDim = meta.dim;
+    } else if (!reseed) {
       throw new Error(
         `embedding dim mismatch: state/library.db has ${meta.dim}-d vectors (model: ${meta.model}), ` +
           `but the current settings ask for ${embeddingDim}-d. ` +
           `Run \`npm run tag -- --reseed\` to re-embed.`,
       );
+    } else {
+      // Reseed across a model/dim change: the stored vectors are unusable at the
+      // new dim, so drop them (the table is recreated at `effectiveDim` just
+      // below) and clear the stale meta row so a later setEmbeddingMeta() seeds
+      // it fresh and the next open() sees a matching (or absent) dim.
+      console.warn(
+        `[library-db] reseed: embedding dim ${meta.dim}→${embeddingDim} ` +
+          `(model: ${meta.model}); dropping vectors for re-embed`,
+      );
+      runDdl(d, 'DROP TABLE IF EXISTS track_vectors');
+      d.prepare('DELETE FROM embedding_meta WHERE pk = 1').run();
     }
-    // Reseed across a model/dim change: the stored vectors are unusable at the
-    // new dim, so drop them (the table is recreated at `embeddingDim` just
-    // below) and clear the stale meta row so a later setEmbeddingMeta() seeds
-    // it fresh and the next open() sees a matching (or absent) dim.
-    console.warn(
-      `[library-db] reseed: embedding dim ${meta.dim}→${embeddingDim} ` +
-        `(model: ${meta.model}); dropping vectors for re-embed`,
-    );
-    runDdl(d, 'DROP TABLE IF EXISTS track_vectors');
-    d.prepare('DELETE FROM embedding_meta WHERE pk = 1').run();
   }
 
   const hasVecTable = d
@@ -268,9 +300,10 @@ async function migrate(embeddingDim: number, reseed = false): Promise<void> {
   if (!hasVecTable) {
     runDdl(d,
       `CREATE VIRTUAL TABLE track_vectors USING vec0(` +
-        `id TEXT PRIMARY KEY, embedding FLOAT[${embeddingDim}] distance_metric=cosine)`,
+        `id TEXT PRIMARY KEY, embedding FLOAT[${effectiveDim}] distance_metric=cosine)`,
     );
   }
+  return effectiveDim;
 }
 
 // Wrapper so we keep the SQL "exec" verb out of the source text and dodge a

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -16,12 +16,14 @@ let loaded = false;
 
 export async function load() {
   if (loaded) return;
-  // reseed:true makes a model/dim swap self-heal instead of crashing the whole
-  // controller library subsystem (browse/picker/retag). On a mismatch the
-  // vector table is rebuilt empty at the new dim — KNN degrades gracefully
-  // until a tag re-embed refills it, while tagged-row browse/retag (moods live
-  // in `tracks`, not vectors) keep working. It is a no-op when dims match.
-  await db.open({ embeddingDim: resolveEmbeddingDim(), reseed: true });
+  // adoptStoredDim:true makes the live controller honour whatever dim the tagger
+  // actually probed and recorded, instead of trusting the name→dim guess. A
+  // model whose name resolves to a different default than its real vector width
+  // (e.g. a custom embedding model named like an OpenAI one) no longer makes the
+  // controller wipe a populated index on boot (#319). resolveEmbeddingDim() is
+  // only the fallback used when the DB has never been tagged. A deliberate model
+  // swap is reconciled by the tagger's --reseed path, not here.
+  await db.open({ embeddingDim: resolveEmbeddingDim(), adoptStoredDim: true });
   loaded = true;
 }
 

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -119,7 +119,24 @@ async function main() {
   await applyWizardOverlay();
   await settings.load();
 
-  const embeddingDim = embeddings.resolveEmbeddingDim();
+  if (!embeddings.isAvailable()) {
+    console.error('[tag] embeddings not available — set settings.embedding.enabled / provider');
+    process.exit(1);
+  }
+
+  // Preflight FIRST — catch the common misconfigurations (model not pulled,
+  // cloud Ollama 401, server unreachable, a chat model that can't embed) BEFORE
+  // we open the DB or walk Navidrome and burn through a 28k-track embed loop
+  // only to die on the first batch (issues #174, #319). The probe also reports
+  // the embedding dimension measured from a real vector — authoritative over the
+  // name→dim guess, so an arbitrarily-named embedding model just works.
+  const probe = await embeddings.ensureReady();
+  if (probe.code !== 'ok') {
+    console.error(`[tag] embedding preflight failed (${probe.code}):\n${probe.message}`);
+    process.exit(1);
+  }
+  const embeddingDim = probe.dim ?? embeddings.resolveEmbeddingDim();
+
   // Pass reseed so open() can recover from an embedding model/dim swap instead
   // of throwing the dim-mismatch error before the --reseed logic below ever
   // runs (the bug in #307). On a same-dim run this is a no-op.
@@ -150,20 +167,6 @@ async function main() {
   if (flags.reseed) {
     console.log('[tag] --reseed: dropping track_vectors, re-embedding from scratch');
     db.dropVectors();
-  }
-
-  if (!embeddings.isAvailable()) {
-    console.error('[tag] embeddings not available — set settings.embedding.enabled / provider');
-    process.exit(1);
-  }
-
-  // Preflight — catch the common misconfigurations (model not pulled, cloud
-  // Ollama 401, server unreachable) BEFORE we walk Navidrome and burn through
-  // a 28k-track embed loop only to die on the first batch. Issue #174.
-  const probe = await embeddings.ensureReady();
-  if (probe.code !== 'ok') {
-    console.error(`[tag] embedding preflight failed (${probe.code}):\n${probe.message}`);
-    process.exit(1);
   }
 
   const promptHash = embeddings.promptVocabHash(TAGGER_BATCH_SYSTEM);


### PR DESCRIPTION
## Why

Closes #319 — but the underlying trap will hit **every** self-hosted (`openai-compatible`) operator, not just one user.

The library tagger needs text embeddings for KNN mood-propagation. It had two failure modes that produced opaque errors for self-hosted setups (llama.cpp / locca, vLLM, LM Studio):

1. **Chat model used for embeddings.** `settings.embedding` inherits `settings.llm.baseUrl` by default, so embeddings point at the operator's *chat* server. llama.cpp then returns `This server does not support embeddings. Start it with --embeddings` or, once that's added, `Pooling type 'none' is not OAI compatible`. Both fell through to the `unknown` classifier and surfaced as a raw, unactionable string.
2. **Dimension guessed from the model name.** `defaultEmbeddingDimFor()` mapped a handful of known names → dim and assumed 768 otherwise. A correctly-served embedding model with an unrecognised name (or, as in #319, a misleading name like `text-embedding-3-small` pointed at a 768-d server) tripped a `vector dim X != schema dim Y` mismatch even when the server was emitting a perfectly good vector.

## What

**#1 — Clearer preflight errors.** New `not_embedding_model` probe code classifies the "reached but can't embed" case (`does not support embeddings` / `pooling` / `start it with`) with an actionable message: run a dedicated embedding model with `--embeddings --pooling mean`, and set a separate `settings.embedding.baseUrl`/`model`. For `openai-compatible` it spells out the inheritance trap explicitly.

**#2 — Probe-based dimension (authoritative).**
- `probeOnce()` now measures the real vector length from the live server and returns it on the `ProbeResult`.
- The tagger **probes before opening the DB** and uses the probed dim, so an arbitrarily-named embedding model just works.
- The live controller **adopts the dim the tagger recorded** (`library-db` `adoptStoredDim`) instead of guessing from the name — so it never wipes a populated index on boot when the name resolves to a different default. The name→dim table is now just a fallback seed before the first tag run.

**#3 — folded into #1.** The separate "warn when silently inheriting `baseUrl`" idea is subsumed: the probe runs regardless of config source and now yields a precise, self-explaining error, so no extra pre-probe control flow was added.

Also fixes a stale comment in `provider.ts` that promised a `settings.embedding.dim` override which was never wired up.

## Behaviour change

- `library.ts` / `analyze-library.ts` now open with `adoptStoredDim: true` instead of `reseed: true`. A model/dim swap is reconciled by the tagger's `--reseed` path (unchanged), not by silently wiping vectors at runtime — runtime degrades gracefully (KNN returns `[]` until re-tagged) rather than nuking the index.
- A deliberate model swap at tag time still surfaces the `--reseed` gate exactly as before.

## Testing

- `npm run lint` (eslint + tsc) passes in `controller/` — 0 errors.
- Logic traced through all four open() callers (tagger, runtime library, analyze, reseed) for same-dim, changed-dim, fresh-DB, and adopt paths.

> Note: no automated test runner in this repo (per CLAUDE.md); lint is the merge gate. A live run against a dedicated llama.cpp embedding server would be the final confirmation.
