### PR TITLE
fix: apply excludePatterns to auto-playlist and stream MP3 from Navidrome

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -16,9 +16,17 @@ name: Publish images
 # Platforms: the core four images (caddy, broadcast, controller, web) are
 # multi-arch (linux/amd64 + linux/arm64) so Apple Silicon and ARM servers run
 # natively instead of under emulation. Dockerfile.controller selects the
-# matching Piper build via $TARGETARCH; Kokoro/onnx have arm64 wheels. The
-# optional tts-heavy sidecar stays amd64-only — its heavy PyTorch stack makes
-# an arm64 cross-build slow/large, and it's opt-in (runs fine under emulation).
+# matching Piper build via $TARGETARCH; Kokoro/onnx have arm64 wheels.
+#
+# fork-local change: tts-heavy is ALSO built for linux/arm64 here (upstream
+# keeps it amd64-only — see perminder-klair/subwave#206 — citing heavy-PyTorch
+# cross-build cost for an opt-in image). Nothing in Dockerfile.tts-heavy is
+# actually amd64-specific: torch/torchaudio/onnxruntime/chatterbox-tts/
+# pocket-tts/librosa all publish aarch64 wheels (verified against
+# download.pytorch.org/whl/cpu and PyPI). We run it persistently on an arm64
+# node (Apple Silicon Mac mini) and want native performance — no QEMU tax —
+# for the librosa acoustic-analysis pass over a large library plus Chatterbox/
+# PocketTTS voice synthesis.
 
 on:
   push:
@@ -51,7 +59,7 @@ jobs:
             platforms: linux/amd64,linux/arm64
           - image: subwave-tts-heavy
             dockerfile: docker/Dockerfile.tts-heavy
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64
     steps:
       - uses: actions/checkout@v4
 

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -123,17 +123,9 @@ export function pickSystem() {
   const showLine = activeShow?.topic
     ? `\n\nCurrent show brief — follow this for every pick:\n${activeShow.topic}`
     : '';
-  // Hour plan: generated at the top of each hour by the scheduler; gives the
-  // picker specific directional guidance based on what's been in rotation this
-  // show (e.g. "avoid CamelPhat this hour, rotate through X/Y/Z"). Absent for
-  // the first hour until the first hourly check fires.
-  const hourPlan = session.getSession()?.hourPlan;
-  const hourPlanLine = hourPlan
-    ? `\n\nThis hour's editorial direction (based on recent rotation):\n${hourPlan}`
-    : '';
   return `${settings.agentPersonaPreamble(persona, { rules: false })}
 
-You run the station as one continuous shift. The messages above are the live session.${djModeLine}${showLine}${hourPlanLine}
+You run the station as one continuous shift. The messages above are the live session.${djModeLine}${showLine}
 
 ${dj.PICKER_CRITERIA}`;
 }

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -123,9 +123,17 @@ export function pickSystem() {
   const showLine = activeShow?.topic
     ? `\n\nCurrent show brief — follow this for every pick:\n${activeShow.topic}`
     : '';
+  // Hour plan: generated at the top of each hour by the scheduler; gives the
+  // picker specific directional guidance based on what's been in rotation this
+  // show (e.g. "avoid CamelPhat this hour, rotate through X/Y/Z"). Absent for
+  // the first hour until the first hourly check fires.
+  const hourPlan = session.getSession()?.hourPlan;
+  const hourPlanLine = hourPlan
+    ? `\n\nThis hour's editorial direction (based on recent rotation):\n${hourPlan}`
+    : '';
   return `${settings.agentPersonaPreamble(persona, { rules: false })}
 
-You run the station as one continuous shift. The messages above are the live session.${djModeLine}${showLine}
+You run the station as one continuous shift. The messages above are the live session.${djModeLine}${showLine}${hourPlanLine}
 
 ${dj.PICKER_CRITERIA}`;
 }

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -152,7 +152,9 @@ export const pickerAgent = defineAgent({
   timeoutMs: 22000,
   buildSystem: () => pickSystem(),
   buildTools: ({ recentIds, recentKeys, recentArtists }) => {
-    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, recentArtists });
+    const activeShow = settings.resolveActiveShow();
+    const { maxDurationSec, excludePatterns } = settings.getPickerConfig(activeShow);
+    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, recentArtists, maxDurationSec, excludePatterns });
     return { tools, extras: { seen } };
   },
 });
@@ -166,7 +168,9 @@ export const requestAgent = defineAgent({
   // recentArtists deliberately empty — a request for a recently-played artist
   // must still resolve.
   buildTools: ({ recentIds }) => {
-    const { tools, seen } = buildPickerTools({ recentIds });
+    const activeShow = settings.resolveActiveShow();
+    const { maxDurationSec, excludePatterns } = settings.getPickerConfig(activeShow);
+    const { tools, seen } = buildPickerTools({ recentIds, maxDurationSec, excludePatterns });
     return { tools, extras: { seen } };
   },
 });

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -114,9 +114,18 @@ export function pickSystem() {
   const djModeLine = persona?.djMode
     ? `\n\nYou're in full DJ mode — keep the thread alive across tracks: call back to something you played or said earlier in this session when it fits, and build a little momentum rather than treating each pick as isolated.`
     : '';
+  // The show topic is the authoritative brief for every pick this hour. It
+  // belongs in the system prompt — not only in the session-opening message —
+  // because the session window (WINDOW_TURNS=40) scrolls past the opening
+  // message within the first hour. Without this, the picker loses all show
+  // constraints mid-session and reverts to recency-biased picks.
+  const activeShow = settings.resolveActiveShow();
+  const showLine = activeShow?.topic
+    ? `\n\nCurrent show brief — follow this for every pick:\n${activeShow.topic}`
+    : '';
   return `${settings.agentPersonaPreamble(persona, { rules: false })}
 
-You run the station as one continuous shift. The messages above are the live session.${djModeLine}
+You run the station as one continuous shift. The messages above are the live session.${djModeLine}${showLine}
 
 ${dj.PICKER_CRITERIA}`;
 }

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -18,6 +18,8 @@ import { shouldFire } from './dj-gate.js';
 import { djCallsAllowed } from './listeners.js';
 import { agenticTick, skillCatalog } from '../skills/_agent.js';
 import { withTrace } from '../observability/events.js';
+import { isRadioPickable } from '../llm/tools.js';
+import * as settings from '../settings.js';
 
 const TARGET_POOL = 30;
 const MOOD_WEIGHT = 12;          // up to this many mood-tagged tracks per pool
@@ -56,6 +58,9 @@ async function refreshAutoPlaylistInner() {
   const mood = ctx.dominantMood;
   // Match the auto-DJ picker's window (dj-agent.pickViaAgent) — 12h.
   const recent = queue.recentlyPlayedIds(12);
+  // Apply the same hard excludes as the DJ agent — station-wide patterns
+  // (e.g. christmas, live, demo) must never appear in the fallback pool.
+  const { excludePatterns } = settings.getPickerConfig(ctx.activeShow);
 
   const pool: any[] = [];
   const fromSource: Record<string, number> = { mood: 0, playlist: 0, recent: 0, frequent: 0, starred: 0, random: 0 };
@@ -64,6 +69,7 @@ async function refreshAutoPlaylistInner() {
     for (const t of items) {
       if (n >= cap || pool.length >= TARGET_POOL) break;
       if (!t?.id || recent.has(t.id) || pool.find((p: any) => p.id === t.id)) continue;
+      if (!isRadioPickable(t.title ?? '', t.album, excludePatterns)) continue;
       pool.push({ ...t, _source: label });
       fromSource[label]++;
       n++;

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -148,22 +148,6 @@ async function refreshAutoPlaylistInner() {
 export async function runHourlyCheck() {
   return withTrace({ kind: 'hourly' }, async () => {
     const ctx = await getFullContext();
-
-    // When a show is running, generate an hour-plan in parallel with the time
-    // check so it's ready before the next pick. The plan considers what's been
-    // heavy in rotation and sets fresh directional constraints for the next
-    // hour — preventing single-artist flooding when the picker loses show
-    // context mid-session.
-    if (ctx.activeShow?.topic) {
-      const recentTracks = queue.getRecentTracks(30);
-      dj.generateHourPlan(ctx.activeShow, recentTracks)
-        .then(plan => {
-          session.setHourPlan(plan);
-          queue.log('scheduler', `[hour-plan] ${plan.slice(0, 160)}…`);
-        })
-        .catch((err: Error) => queue.log('error', `Hour plan failed: ${err.message}`));
-    }
-
     const script = await dj.generateHourlyTime(ctx.time, ctx.weather, {
       recap: queue.getDjRecap(),
       context: ctx,

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -148,6 +148,22 @@ async function refreshAutoPlaylistInner() {
 export async function runHourlyCheck() {
   return withTrace({ kind: 'hourly' }, async () => {
     const ctx = await getFullContext();
+
+    // When a show is running, generate an hour-plan in parallel with the time
+    // check so it's ready before the next pick. The plan considers what's been
+    // heavy in rotation and sets fresh directional constraints for the next
+    // hour — preventing single-artist flooding when the picker loses show
+    // context mid-session.
+    if (ctx.activeShow?.topic) {
+      const recentTracks = queue.getRecentTracks(30);
+      dj.generateHourPlan(ctx.activeShow, recentTracks)
+        .then(plan => {
+          session.setHourPlan(plan);
+          queue.log('scheduler', `[hour-plan] ${plan.slice(0, 160)}…`);
+        })
+        .catch((err: Error) => queue.log('error', `Hour plan failed: ${err.message}`));
+    }
+
     const script = await dj.generateHourlyTime(ctx.time, ctx.weather, {
       recap: queue.getDjRecap(),
       context: ctx,

--- a/controller/src/broadcast/session.ts
+++ b/controller/src/broadcast/session.ts
@@ -115,6 +115,20 @@ export function getSession() {
   return _session;
 }
 
+// Store an editorial hour-plan for the active show. Generated at the top of
+// each hour by the scheduler; read by pickSystem() and included in every
+// picker system prompt for the duration of that hour. Cleared on session start
+// (new show or 4h cap) so a stale plan never bleeds across shows.
+export function setHourPlan(plan: string | null) {
+  if (!_session) return;
+  if (plan) {
+    _session.hourPlan = plan;
+  } else {
+    delete _session.hourPlan;
+  }
+  schedulePersist();
+}
+
 // Append a turn. `role` ∈ event|dj|track|segment; `kind` names the turn type
 // (scenario|pick|request|play|link|station-id|hourly|weather|...).
 export function appendTurn({ role, kind, text, meta = {} }: { role: string; kind: string; text?: string; meta?: any }) {

--- a/controller/src/broadcast/session.ts
+++ b/controller/src/broadcast/session.ts
@@ -115,20 +115,6 @@ export function getSession() {
   return _session;
 }
 
-// Store an editorial hour-plan for the active show. Generated at the top of
-// each hour by the scheduler; read by pickSystem() and included in every
-// picker system prompt for the duration of that hour. Cleared on session start
-// (new show or 4h cap) so a stale plan never bleeds across shows.
-export function setHourPlan(plan: string | null) {
-  if (!_session) return;
-  if (plan) {
-    _session.hourPlan = plan;
-  } else {
-    delete _session.hourPlan;
-  }
-  schedulePersist();
-}
-
 // Append a turn. `role` ∈ event|dj|track|segment; `kind` names the turn type
 // (scenario|pick|request|play|link|station-id|hourly|weather|...).
 export function appendTurn({ role, kind, text, meta = {} }: { role: string; kind: string; text?: string; meta?: any }) {

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -407,6 +407,44 @@ export async function generateLink({ previous, current, context, recap = null, r
   });
 }
 
+// Generate a short editorial brief for the next hour of a scheduled show.
+// Called at the top of each hour; the result is stored on the session and
+// injected into every picker system prompt so the picker has fresh directional
+// guidance regardless of how far the session window has scrolled.
+//
+// Input: the active show (name + topic) and a snapshot of recent plays so the
+// planner can see what's been heavy in rotation and correct for it.
+export async function generateHourPlan(
+  show: { name: string; topic: string },
+  recentTracks: Array<{ title: string; artist: string | null }>,
+): Promise<string> {
+  const recentList = recentTracks.length > 0
+    ? recentTracks.map(t => `${t.artist || 'Unknown'} — ${t.title}`).join('\n')
+    : '(none yet — this is the opening hour)';
+  const prompt = `You are planning the next hour of "${show.name}".
+
+Show brief:
+${show.topic}
+
+Tracks played so far this show (most recent first):
+${recentList}
+
+Write a 2-3 sentence editorial brief for the NEXT HOUR of picks. Be specific and actionable:
+- Which artists or styles to lean into or deliberately avoid given the recent rotation
+- The energy arc for this hour (build, cruise, wind down, etc.)
+- Any variety callout if one act or style has dominated
+
+This brief is used directly by the track picker — be direct, no preamble.`;
+
+  return djText({
+    system: `You are the editorial director for "${show.name}". Your job is programme planning, not on-air performance. No DJ voice, no fluff — write a concise internal brief.`,
+    prompt,
+    temperature: 0.65,
+    topP: 0.9,
+    kind: 'generateHourPlan',
+  });
+}
+
 export async function generateHourlyTime(time: any, weather: any, { recap = null, context = null, recentOpeners = null }: any = {}) {
   const ctx = context || { time, weather };
   const ctxLines = buildContextLines(ctx);

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -426,10 +426,7 @@ export async function generateHourlyTime(time: any, weather: any, { recap = null
 // Shared selection criteria — used by both the pool picker (pickerSystem
 // below) and the conversational agent picker (pickSystem in broadcast/
 // dj-agent.js) so the two strategies can't drift apart on selection rules.
-export const PICKER_CRITERIA = `Hard rules (non-negotiable):
-- Never pick live recordings, live albums, demos, or rehearsal versions — look for "Live", "Live at", "Demo", "Rehearsal", "Bootleg" in the title and avoid them.
-
-Selection criteria, in order:
+export const PICKER_CRITERIA = `Selection criteria, in order:
 1. FLOW — does it transition naturally from what just played (energy, mood, tempo)? When a candidate shows a "bpm" and/or Camelot "key", those are MEASURED — prefer a next track whose tempo sits near the current one (or steps it deliberately for the daypart) and whose key is harmonically close. Treat them as a tie-breaker, never a hard rule; many tracks won't have them.
 2. CONTEXT — does it fit the time of day, weather, and dominant mood?
 3. VARIETY — avoid the same artist back-to-back; don't repeat tracks you've already played today; rotate energy. Mix well-known tracks with deeper cuts — don't cluster obvious global hits back to back. Variety over cleverness — never pick a track because its title literally matches the time of day, the weather, or anything else literal.

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -407,44 +407,6 @@ export async function generateLink({ previous, current, context, recap = null, r
   });
 }
 
-// Generate a short editorial brief for the next hour of a scheduled show.
-// Called at the top of each hour; the result is stored on the session and
-// injected into every picker system prompt so the picker has fresh directional
-// guidance regardless of how far the session window has scrolled.
-//
-// Input: the active show (name + topic) and a snapshot of recent plays so the
-// planner can see what's been heavy in rotation and correct for it.
-export async function generateHourPlan(
-  show: { name: string; topic: string },
-  recentTracks: Array<{ title: string; artist: string | null }>,
-): Promise<string> {
-  const recentList = recentTracks.length > 0
-    ? recentTracks.map(t => `${t.artist || 'Unknown'} — ${t.title}`).join('\n')
-    : '(none yet — this is the opening hour)';
-  const prompt = `You are planning the next hour of "${show.name}".
-
-Show brief:
-${show.topic}
-
-Tracks played so far this show (most recent first):
-${recentList}
-
-Write a 2-3 sentence editorial brief for the NEXT HOUR of picks. Be specific and actionable:
-- Which artists or styles to lean into or deliberately avoid given the recent rotation
-- The energy arc for this hour (build, cruise, wind down, etc.)
-- Any variety callout if one act or style has dominated
-
-This brief is used directly by the track picker — be direct, no preamble.`;
-
-  return djText({
-    system: `You are the editorial director for "${show.name}". Your job is programme planning, not on-air performance. No DJ voice, no fluff — write a concise internal brief.`,
-    prompt,
-    temperature: 0.65,
-    topP: 0.9,
-    kind: 'generateHourPlan',
-  });
-}
-
 export async function generateHourlyTime(time: any, weather: any, { recap = null, context = null, recentOpeners = null }: any = {}) {
   const ctx = context || { time, weather };
   const ctxLines = buildContextLines(ctx);
@@ -470,16 +432,13 @@ export const PICKER_CRITERIA = `Selection criteria, in order:
 3. VARIETY — avoid the same artist back-to-back; don't repeat tracks you've already played today; rotate energy. Variety over cleverness — never pick a track because its title literally matches the time of day, the weather, or anything else literal.
 4. INTEREST — prefer something that creates a moment, not the most generic option.`;
 
-function pickerSystem(show?: { name: string; topic: string } | null, hourPlan?: string | null) {
+function pickerSystem(show?: { name: string; topic: string } | null) {
   const stationName = settings.get().station;
   const showLine = show?.topic
     ? `\n\nCurrent show brief — follow this for every pick:\n${show.topic}`
     : '';
-  const hourPlanLine = hourPlan
-    ? `\n\nThis hour's editorial direction (based on recent rotation):\n${hourPlan}`
-    : '';
   return `You are the DJ for ${stationName}, a personal internet radio station.
-Pick the single best NEXT track from the candidate pool, given recent plays and the current context.${showLine}${hourPlanLine}
+Pick the single best NEXT track from the candidate pool, given recent plays and the current context.${showLine}
 
 ${PICKER_CRITERIA}
 
@@ -497,12 +456,11 @@ unplayed, so you never need to reject one for being recent.
 Pick exactly one candidate.`;
 }
 
-export async function pickNextTrack({ candidates, recentPlays, context, show = null, hourPlan = null }: {
+export async function pickNextTrack({ candidates, recentPlays, context, show = null }: {
   candidates: any[];
   recentPlays: any;
   context: any;
   show?: { name: string; topic: string } | null;
-  hourPlan?: string | null;
 }) {
   const user = JSON.stringify({
     now: {
@@ -517,7 +475,7 @@ export async function pickNextTrack({ candidates, recentPlays, context, show = n
   }, null, 2);
 
   return djObject({
-    system: pickerSystem(show, hourPlan),
+    system: pickerSystem(show),
     prompt: user,
     schema: z.object({
       id: z.string().describe('the exact id of one candidate'),

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -470,10 +470,16 @@ export const PICKER_CRITERIA = `Selection criteria, in order:
 3. VARIETY — avoid the same artist back-to-back; don't repeat tracks you've already played today; rotate energy. Variety over cleverness — never pick a track because its title literally matches the time of day, the weather, or anything else literal.
 4. INTEREST — prefer something that creates a moment, not the most generic option.`;
 
-function pickerSystem() {
+function pickerSystem(show?: { name: string; topic: string } | null, hourPlan?: string | null) {
   const stationName = settings.get().station;
+  const showLine = show?.topic
+    ? `\n\nCurrent show brief — follow this for every pick:\n${show.topic}`
+    : '';
+  const hourPlanLine = hourPlan
+    ? `\n\nThis hour's editorial direction (based on recent rotation):\n${hourPlan}`
+    : '';
   return `You are the DJ for ${stationName}, a personal internet radio station.
-Pick the single best NEXT track from the candidate pool, given recent plays and the current context.
+Pick the single best NEXT track from the candidate pool, given recent plays and the current context.${showLine}${hourPlanLine}
 
 ${PICKER_CRITERIA}
 
@@ -491,7 +497,13 @@ unplayed, so you never need to reject one for being recent.
 Pick exactly one candidate.`;
 }
 
-export async function pickNextTrack({ candidates, recentPlays, context }) {
+export async function pickNextTrack({ candidates, recentPlays, context, show = null, hourPlan = null }: {
+  candidates: any[];
+  recentPlays: any;
+  context: any;
+  show?: { name: string; topic: string } | null;
+  hourPlan?: string | null;
+}) {
   const user = JSON.stringify({
     now: {
       time: context.time?.period,
@@ -505,7 +517,7 @@ export async function pickNextTrack({ candidates, recentPlays, context }) {
   }, null, 2);
 
   return djObject({
-    system: pickerSystem(),
+    system: pickerSystem(show, hourPlan),
     prompt: user,
     schema: z.object({
       id: z.string().describe('the exact id of one candidate'),

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -428,12 +428,11 @@ export async function generateHourlyTime(time: any, weather: any, { recap = null
 // dj-agent.js) so the two strategies can't drift apart on selection rules.
 export const PICKER_CRITERIA = `Hard rules (non-negotiable):
 - Never pick live recordings, live albums, demos, or rehearsal versions — look for "Live", "Live at", "Demo", "Rehearsal", "Bootleg" in the title and avoid them.
-- Prefer deeper cuts, album tracks, and lesser-known works over obvious global hits. This is not a mainstream pop station — if a track is the first thing anyone would play by that artist, look for a better choice.
 
 Selection criteria, in order:
 1. FLOW — does it transition naturally from what just played (energy, mood, tempo)? When a candidate shows a "bpm" and/or Camelot "key", those are MEASURED — prefer a next track whose tempo sits near the current one (or steps it deliberately for the daypart) and whose key is harmonically close. Treat them as a tie-breaker, never a hard rule; many tracks won't have them.
 2. CONTEXT — does it fit the time of day, weather, and dominant mood?
-3. VARIETY — avoid the same artist back-to-back; don't repeat tracks you've already played today; rotate energy. Variety over cleverness — never pick a track because its title literally matches the time of day, the weather, or anything else literal.
+3. VARIETY — avoid the same artist back-to-back; don't repeat tracks you've already played today; rotate energy. Mix well-known tracks with deeper cuts — don't cluster obvious global hits back to back. Variety over cleverness — never pick a track because its title literally matches the time of day, the weather, or anything else literal.
 4. INTEREST — prefer something that creates a moment, not the most generic option.`;
 
 function pickerSystem(show?: { name: string; topic: string } | null) {

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -426,7 +426,11 @@ export async function generateHourlyTime(time: any, weather: any, { recap = null
 // Shared selection criteria — used by both the pool picker (pickerSystem
 // below) and the conversational agent picker (pickSystem in broadcast/
 // dj-agent.js) so the two strategies can't drift apart on selection rules.
-export const PICKER_CRITERIA = `Selection criteria, in order:
+export const PICKER_CRITERIA = `Hard rules (non-negotiable):
+- Never pick live recordings, live albums, demos, or rehearsal versions — look for "Live", "Live at", "Demo", "Rehearsal", "Bootleg" in the title and avoid them.
+- Prefer deeper cuts, album tracks, and lesser-known works over obvious global hits. This is not a mainstream pop station — if a track is the first thing anyone would play by that artist, look for a better choice.
+
+Selection criteria, in order:
 1. FLOW — does it transition naturally from what just played (energy, mood, tempo)? When a candidate shows a "bpm" and/or Camelot "key", those are MEASURED — prefer a next track whose tempo sits near the current one (or steps it deliberately for the daypart) and whose key is harmonically close. Treat them as a tie-breaker, never a hard rule; many tracks won't have them.
 2. CONTEXT — does it fit the time of day, weather, and dominant mood?
 3. VARIETY — avoid the same artist back-to-back; don't repeat tracks you've already played today; rotate energy. Variety over cleverness — never pick a track because its title literally matches the time of day, the weather, or anything else literal.

--- a/controller/src/llm/tools.ts
+++ b/controller/src/llm/tools.ts
@@ -15,13 +15,20 @@ import { filterPickerCandidates } from '../music/recency.js';
 
 const MAX_DURATION_SEC = 600; // 10 min — epics are fine on an album, not on radio
 
-// Patterns in track titles that identify non-studio versions. Checked
-// case-insensitively. LLM text rules aren't reliable enough for this — a hard
-// filter is the only way to keep live/demo tracks off a radio stream.
+// Hard excludes applied to every candidate before the LLM sees it.
+// LLM text rules are not reliable for structural constraints — enforce in code.
+//
+// NON_STUDIO_RE: live recordings, demos, bootlegs — checked against title.
+// SOUNDTRACK_RE: film/TV/game scores — checked against album (primary) and
+//   title. These are background-music contexts that don't suit radio rotation.
 const NON_STUDIO_RE = /\b(live(?: at| from| in|$)|\(live\)|acoustic(?: version)?|demo(?: version)?|rehearsal|bootleg|unplugged)\b/i;
+const SOUNDTRACK_RE = /\b(soundtrack|original score|original motion picture|motion picture|ost|from the (?:film|movie|series|show))\b/i;
 
-export function isStudioTrack(title: string): boolean {
-  return !NON_STUDIO_RE.test(title ?? '');
+export function isRadioPickable(title: string, album?: string | null): boolean {
+  if (NON_STUDIO_RE.test(title ?? '')) return false;
+  if (SOUNDTRACK_RE.test(title ?? '')) return false;
+  if (album && SOUNDTRACK_RE.test(album)) return false;
+  return true;
 }
 
 function slim(s: any) {
@@ -93,7 +100,7 @@ export function buildPickerTools({
   // each tool call regardless.
   const collect = (list: any, cap = 8) => {
     const withinLength = (list || []).filter((s: any) =>
-      (!s.duration || s.duration <= MAX_DURATION_SEC) && isStudioTrack(s.title ?? ''));
+      (!s.duration || s.duration <= MAX_DURATION_SEC) && isRadioPickable(s.title ?? '', s.album));
     const accepted = filterPickerCandidates(shuffle(withinLength as any[]), {
       recentIds,
       recentKeys,

--- a/controller/src/llm/tools.ts
+++ b/controller/src/llm/tools.ts
@@ -13,6 +13,8 @@ import * as library from '../music/library.js';
 import * as embeddings from '../music/embeddings.js';
 import { filterPickerCandidates } from '../music/recency.js';
 
+const MAX_DURATION_SEC = 600; // 10 min — epics are fine on an album, not on radio
+
 function slim(s: any) {
   const base = {
     id: s.id,
@@ -21,6 +23,7 @@ function slim(s: any) {
     album: s.album || null,
     year: s.year || null,
     genre: s.genre || null,
+    ...(s.duration != null ? { duration: Math.round(s.duration) } : {}),
   };
   // Surface measured tempo/key when known — from the song itself (library
   // sources) or a library lookup (Subsonic sources). Omitted when un-analysed
@@ -80,7 +83,8 @@ export function buildPickerTools({
   // accumulates across the whole loop, so the agent's id space grows with
   // each tool call regardless.
   const collect = (list: any, cap = 8) => {
-    const accepted = filterPickerCandidates(shuffle((list || []) as any[]), {
+    const withinLength = (list || []).filter((s: any) => !s.duration || s.duration <= MAX_DURATION_SEC);
+    const accepted = filterPickerCandidates(shuffle(withinLength as any[]), {
       recentIds,
       recentKeys,
       recentArtists,

--- a/controller/src/llm/tools.ts
+++ b/controller/src/llm/tools.ts
@@ -13,22 +13,30 @@ import * as library from '../music/library.js';
 import * as embeddings from '../music/embeddings.js';
 import { filterPickerCandidates } from '../music/recency.js';
 
-const MAX_DURATION_SEC = 600; // 10 min — epics are fine on an album, not on radio
+// Compile a list of user-supplied exclude patterns into regexes. Each pattern
+// is treated as a case-insensitive phrase; word boundaries are added on
+// word-char edges (so "live" won't match "alive", but "(live)" matches
+// literally). Called at filter time (once per pick) so settings changes take
+// effect without restart; the overhead is negligible.
+function buildExcludeRegexes(patterns: string[]): RegExp[] {
+  return patterns.map(pattern => {
+    const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const prefix = /^\w/.test(pattern) ? '\\b' : '';
+    const suffix = /\w$/.test(pattern) ? '\\b' : '';
+    return new RegExp(prefix + escaped + suffix, 'i');
+  });
+}
 
-// Hard excludes applied to every candidate before the LLM sees it.
-// LLM text rules are not reliable for structural constraints — enforce in code.
-//
-// NON_STUDIO_RE: live recordings, demos, bootlegs — checked against title.
-// SOUNDTRACK_RE: film/TV/game scores — checked against album (primary) and
-//   title. These are background-music contexts that don't suit radio rotation.
-const NON_STUDIO_RE = /\b(live(?: at| from| in|$)|\(live\)|acoustic(?: version)?|demo(?: version)?|rehearsal|bootleg|unplugged)\b/i;
-const SOUNDTRACK_RE = /\b(soundtrack|original score|original motion picture|motion picture|ost|from the (?:film|movie|series|show))\b/i;
-
-export function isRadioPickable(title: string, album?: string | null): boolean {
-  if (NON_STUDIO_RE.test(title ?? '')) return false;
-  if (SOUNDTRACK_RE.test(title ?? '')) return false;
-  if (album && SOUNDTRACK_RE.test(album)) return false;
-  return true;
+// Returns true if the track passes the current picker exclude filters.
+// `patterns` is the effective list from settings.getPickerConfig() — pass it
+// explicitly so callers can resolve the correct station/show context once and
+// reuse across a whole candidate list rather than hitting settings N times.
+export function isRadioPickable(title: string, album: string | null | undefined, patterns: string[]): boolean {
+  if (!patterns.length) return true;
+  const regexes = buildExcludeRegexes(patterns);
+  const t = title ?? '';
+  const a = album ?? '';
+  return !regexes.some(re => re.test(t) || re.test(a));
 }
 
 function slim(s: any) {
@@ -79,14 +87,22 @@ const MAX_PER_ARTIST = 2;
 // filtered out inside every tool so the agent never has to be told "avoid
 // these" — it simply can't see them. `recentArtists` is left empty on the
 // listener-request path so a request for a recent artist still resolves.
+//
+// `maxDurationSec` and `excludePatterns` come from settings.getPickerConfig()
+// (station-wide or per-show override). Callers should resolve these once and
+// pass them in; defaults are applied here if absent for call-site safety.
 export function buildPickerTools({
   recentIds = new Set<string>(),
   recentKeys = new Set<string>(),
   recentArtists = new Set<string>(),
+  maxDurationSec = 600,
+  excludePatterns = [] as string[],
 }: {
   recentIds?: Set<string>;
   recentKeys?: Set<string>;        // lowercased "title|artist" — backfilled entries lack ids
   recentArtists?: Set<string>;
+  maxDurationSec?: number;
+  excludePatterns?: string[];
 } = {}) {
   const seen = new Map<string, any>(); // id → slim song, accumulated across all tool calls
   const artistCounts = new Map<string, number>(); // artist key → songs already accepted into `seen`
@@ -100,7 +116,7 @@ export function buildPickerTools({
   // each tool call regardless.
   const collect = (list: any, cap = 8) => {
     const withinLength = (list || []).filter((s: any) =>
-      (!s.duration || s.duration <= MAX_DURATION_SEC) && isRadioPickable(s.title ?? '', s.album));
+      (!s.duration || s.duration <= maxDurationSec) && isRadioPickable(s.title ?? '', s.album, excludePatterns));
     const accepted = filterPickerCandidates(shuffle(withinLength as any[]), {
       recentIds,
       recentKeys,

--- a/controller/src/llm/tools.ts
+++ b/controller/src/llm/tools.ts
@@ -15,6 +15,15 @@ import { filterPickerCandidates } from '../music/recency.js';
 
 const MAX_DURATION_SEC = 600; // 10 min — epics are fine on an album, not on radio
 
+// Patterns in track titles that identify non-studio versions. Checked
+// case-insensitively. LLM text rules aren't reliable enough for this — a hard
+// filter is the only way to keep live/demo tracks off a radio stream.
+const NON_STUDIO_RE = /\b(live(?: at| from| in|$)|\(live\)|acoustic(?: version)?|demo(?: version)?|rehearsal|bootleg|unplugged)\b/i;
+
+export function isStudioTrack(title: string): boolean {
+  return !NON_STUDIO_RE.test(title ?? '');
+}
+
 function slim(s: any) {
   const base = {
     id: s.id,
@@ -83,7 +92,8 @@ export function buildPickerTools({
   // accumulates across the whole loop, so the agent's id space grows with
   // each tool call regardless.
   const collect = (list: any, cap = 8) => {
-    const withinLength = (list || []).filter((s: any) => !s.duration || s.duration <= MAX_DURATION_SEC);
+    const withinLength = (list || []).filter((s: any) =>
+      (!s.duration || s.duration <= MAX_DURATION_SEC) && isStudioTrack(s.title ?? ''));
     const accepted = filterPickerCandidates(shuffle(withinLength as any[]), {
       recentIds,
       recentKeys,

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -55,24 +55,35 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
   // The backend stays single-threaded — we only hide fetch latency. Each
   // download resolves to a temp path on the shared volume; on download failure
   // we fall back to the url path for that one id so it still gets analysed.
+  //
+  // SIDECAR EXCEPTION: the sidecar (tts-heavy) runs on talos-macmini-01, which
+  // has no access to the controller's Longhorn state volume where analyze-tmp
+  // lives (macmini has no Longhorn CSI). Prefetching to a local file and then
+  // handing the path to tts-heavy always yields a 500 "No such file or
+  // directory". Skip the prefetch entirely for sidecar — tts-heavy fetches the
+  // audio from Navidrome itself when given a URL, so the network cost is
+  // equivalent (tts-heavy's download overlaps its own DSP anyway).
+  const usePrefetch = backend !== 'sidecar';
   type Prefetch = Promise<string>;
-  let inflight: Prefetch | null = ids.length > 0 ? analyzer.downloadCapped(ids[0]) : null;
+  let inflight: Prefetch | null = usePrefetch && ids.length > 0 ? analyzer.downloadCapped(ids[0]) : null;
 
   for (let i = 0; i < ids.length; i++) {
     const id = ids[i];
     const downloadPromise = inflight;
     // Kick off the NEXT download before awaiting this one's analysis so the
-    // fetch overlaps the compute.
-    inflight = i + 1 < ids.length ? analyzer.downloadCapped(ids[i + 1]) : null;
+    // fetch overlaps the compute (local backend only).
+    inflight = usePrefetch && i + 1 < ids.length ? analyzer.downloadCapped(ids[i + 1]) : null;
 
     let localPath: string | null = null;
     try {
-      try {
-        localPath = downloadPromise ? await downloadPromise : null;
-      } catch (err: any) {
-        // Prefetch failed — fall back to the url path for this one track.
-        console.error(`[analyze] ${id} prefetch failed (${err?.message || err}); using url path`);
-        localPath = null;
+      if (usePrefetch) {
+        try {
+          localPath = downloadPromise ? await downloadPromise : null;
+        } catch (err: any) {
+          // Prefetch failed — fall back to the url path for this one track.
+          console.error(`[analyze] ${id} prefetch failed (${err?.message || err}); using url path`);
+          localPath = null;
+        }
       }
       const a = localPath ? await analyzer.analyzePath(localPath) : await analyzer.analyze(id);
       db.upsertTrackAnalysis(id, {

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -215,11 +215,14 @@ export async function analyze(songId: string): Promise<AnalysisResult> {
 }
 
 // Download a track's audio to a capped temp file on the shared state volume
-// and return the absolute path. The controller does this AHEAD of the
-// backend's compute so network fetch (controller) overlaps DSP (backend) —
-// the path is valid in both containers because the shared dir mounts at the
-// same location. Caps bytes + applies the analyzer request timeout. Throws
-// on any error; the caller falls back to the url path for that one track.
+// and return the absolute path. The controller does this AHEAD of the local
+// backend's compute so network fetch (controller) overlaps DSP (backend).
+// NOTE: only valid for the 'local' backend — the 'sidecar' (tts-heavy on
+// talos-macmini-01) cannot access the controller's Longhorn state volume where
+// analyze-tmp lives. The analyze pass (analyze.ts) skips prefetch entirely
+// when backend === 'sidecar'; see the comment there. Caps bytes + applies the
+// analyzer request timeout. Throws on any error; the caller falls back to the
+// url path for that one track.
 export async function downloadCapped(songId: string): Promise<string> {
   mkdirSync(ANALYZE_TMP_DIR, { recursive: true });
   const dest = `${ANALYZE_TMP_DIR}/${encodeURIComponent(songId)}.audio`;

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -9,6 +9,8 @@
 import * as subsonic from './subsonic.js';
 import * as library from './library.js';
 import * as dj from '../llm/dj.js';
+import * as settings from '../settings.js';
+import * as session from '../broadcast/session.js';
 import { bpmCompat, keyCompat } from './mix.js';
 import { filterPickerCandidates, recencyWindowsForLibrary } from './recency.js';
 
@@ -292,7 +294,11 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
 
   let pickRaw;
   try {
+    const activeShow = settings.resolveActiveShow();
+    const hourPlan = session.getSession()?.hourPlan ?? null;
     pickRaw = await dj.pickNextTrack({
+      show: activeShow ? { name: activeShow.name, topic: activeShow.topic } : null,
+      hourPlan,
       candidates: candidates.map(c => {
         const a = analysisFor(c);
         return {

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -10,7 +10,6 @@ import * as subsonic from './subsonic.js';
 import * as library from './library.js';
 import * as dj from '../llm/dj.js';
 import * as settings from '../settings.js';
-import * as session from '../broadcast/session.js';
 import { bpmCompat, keyCompat } from './mix.js';
 import { filterPickerCandidates, recencyWindowsForLibrary } from './recency.js';
 
@@ -295,10 +294,8 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   let pickRaw;
   try {
     const activeShow = settings.resolveActiveShow();
-    const hourPlan = session.getSession()?.hourPlan ?? null;
     pickRaw = await dj.pickNextTrack({
       show: activeShow ? { name: activeShow.name, topic: activeShow.topic } : null,
-      hourPlan,
       candidates: candidates.map(c => {
         const a = analysisFor(c);
         return {

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -10,6 +10,7 @@ import * as subsonic from './subsonic.js';
 import * as library from './library.js';
 import * as dj from '../llm/dj.js';
 import * as settings from '../settings.js';
+import { isStudioTrack } from '../llm/tools.js';
 import { bpmCompat, keyCompat } from './mix.js';
 import { filterPickerCandidates, recencyWindowsForLibrary } from './recency.js';
 
@@ -282,10 +283,11 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   // filter would empty the pool entirely, keep the originals (better than
   // dead air) and log a warning.
   const MAX_DURATION_SEC = 600;
-  const durationFiltered = rawCandidates.filter(c => !c.duration || c.duration <= MAX_DURATION_SEC);
+  const durationFiltered = rawCandidates.filter(c =>
+    (!c.duration || c.duration <= MAX_DURATION_SEC) && isStudioTrack(c.title ?? ''));
   const candidates = durationFiltered.length > 0 ? durationFiltered : rawCandidates;
   if (durationFiltered.length < rawCandidates.length) {
-    queue.log('picker', `dropped ${rawCandidates.length - durationFiltered.length} track(s) over ${MAX_DURATION_SEC / 60}min`);
+    queue.log('picker', `dropped ${rawCandidates.length - durationFiltered.length} track(s) over ${MAX_DURATION_SEC / 60}min or non-studio`);
   }
 
   if (candidates.length === 0) {

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -10,7 +10,7 @@ import * as subsonic from './subsonic.js';
 import * as library from './library.js';
 import * as dj from '../llm/dj.js';
 import * as settings from '../settings.js';
-import { isStudioTrack } from '../llm/tools.js';
+import { isRadioPickable } from '../llm/tools.js';
 import { bpmCompat, keyCompat } from './mix.js';
 import { filterPickerCandidates, recencyWindowsForLibrary } from './recency.js';
 
@@ -284,7 +284,7 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   // dead air) and log a warning.
   const MAX_DURATION_SEC = 600;
   const durationFiltered = rawCandidates.filter(c =>
-    (!c.duration || c.duration <= MAX_DURATION_SEC) && isStudioTrack(c.title ?? ''));
+    (!c.duration || c.duration <= MAX_DURATION_SEC) && isRadioPickable(c.title ?? '', c.album));
   const candidates = durationFiltered.length > 0 ? durationFiltered : rawCandidates;
   if (durationFiltered.length < rawCandidates.length) {
     queue.log('picker', `dropped ${rawCandidates.length - durationFiltered.length} track(s) over ${MAX_DURATION_SEC / 60}min or non-studio`);

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -278,16 +278,16 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   const currentTrack = queue.current?.track || null;
   const { candidates: rawCandidates, sources } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack, rankTarget);
 
-  // Hard cap: drop anything over 10 minutes. Epics are fine on an album; a
-  // 15-minute track playing unannounced on a radio stream is not. If the
-  // filter would empty the pool entirely, keep the originals (better than
-  // dead air) and log a warning.
-  const MAX_DURATION_SEC = 600;
-  const durationFiltered = rawCandidates.filter(c =>
-    (!c.duration || c.duration <= MAX_DURATION_SEC) && isRadioPickable(c.title ?? '', c.album));
-  const candidates = durationFiltered.length > 0 ? durationFiltered : rawCandidates;
-  if (durationFiltered.length < rawCandidates.length) {
-    queue.log('picker', `dropped ${rawCandidates.length - durationFiltered.length} track(s) over ${MAX_DURATION_SEC / 60}min or non-studio`);
+  // Apply picker constraints from settings — duration cap and exclude patterns.
+  // Per-show overrides apply here: a live-sets show can set excludePatterns=[]
+  // to clear all station-wide filters for that hour.
+  const activeShow = settings.resolveActiveShow();
+  const { maxDurationSec, excludePatterns } = settings.getPickerConfig(activeShow);
+  const filtered = rawCandidates.filter(c =>
+    (!c.duration || c.duration <= maxDurationSec) && isRadioPickable(c.title ?? '', c.album, excludePatterns));
+  const candidates = filtered.length > 0 ? filtered : rawCandidates;
+  if (filtered.length < rawCandidates.length) {
+    queue.log('picker', `dropped ${rawCandidates.length - filtered.length} track(s) over ${maxDurationSec / 60}min or matching exclude patterns`);
   }
 
   if (candidates.length === 0) {

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -275,7 +275,18 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   const recentIds = queue.recentlyPlayedIds(windows.trackHours);
   const recentArtists = queue.recentArtistsSince(windows.artistHours);
   const currentTrack = queue.current?.track || null;
-  const { candidates, sources } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack, rankTarget);
+  const { candidates: rawCandidates, sources } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack, rankTarget);
+
+  // Hard cap: drop anything over 10 minutes. Epics are fine on an album; a
+  // 15-minute track playing unannounced on a radio stream is not. If the
+  // filter would empty the pool entirely, keep the originals (better than
+  // dead air) and log a warning.
+  const MAX_DURATION_SEC = 600;
+  const durationFiltered = rawCandidates.filter(c => !c.duration || c.duration <= MAX_DURATION_SEC);
+  const candidates = durationFiltered.length > 0 ? durationFiltered : rawCandidates;
+  if (durationFiltered.length < rawCandidates.length) {
+    queue.log('picker', `dropped ${rawCandidates.length - durationFiltered.length} track(s) over ${MAX_DURATION_SEC / 60}min`);
+  }
 
   if (candidates.length === 0) {
     queue.log('picker', 'no candidates available, skipping LLM pick');
@@ -311,6 +322,7 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
           // the LLM only sees them when they're real.
           bpm: a.bpm ?? undefined,
           key: a.key ?? undefined,
+          duration: c.duration ? Math.round(c.duration) : undefined,
           source: c._source || null,
         };
       }),

--- a/controller/src/music/subsonic.ts
+++ b/controller/src/music/subsonic.ts
@@ -307,12 +307,11 @@ export function getCoverArtUrl(id, size = 512) {
 // instead of its built-in http.get.stream (which returns spurious 522s
 // against the Cloudflare-fronted Navidrome origin).
 //
-// format=raw asks Navidrome to stream the original file bytes (no transcode).
-// Library is AAC 256 kbps m4a from gamdl; without `raw`, Navidrome would
-// transcode to ~192 kbps MP3 on the way out, adding a lossy generation before
-// Liquidsoap's own MP3 re-encode. Liquidsoap decodes m4a/AAC via ffmpeg.
+// format=mp3&maxBitRate=128 transcodes to 128 kbps MP3 matching Icecast
+// output. format=raw serves the original file (FLAC/AAC, 30-60 MB+) which
+// curl-times-out mid-download, causing audible gaps between tracks.
 export function getStreamUrl(songId) {
-  return `subhttp:${buildUrl('stream', { id: songId, format: 'raw' })}`;
+  return `subhttp:${buildUrl('stream', { id: songId, format: 'mp3', maxBitRate: 128 })}`;
 }
 
 // Plain HTTP stream URL (no `subhttp:` prefix) with auth baked into the query

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -250,17 +250,14 @@ async function main() {
     // to seedCount tracks from outside the window. Bulk runs (no --limit)
     // pass undefined to keep the full library in play.
     untaggedPool: limited ? new Set(targetUntagged) : undefined,
-    embeddingForId: (id) => {
-      // For k-means clustering, hand a Float32Array if we have it (we may
-      // not in the very first run; that's fine — the selector falls back
-      // to random sampling within the unembedded pool).
-      const hits = db.knnById(id, 1);
-      if (hits.length === 0) return null;
-      // We don't have a direct vector-read API on library-db today; in v1
-      // the k-means fallback is good enough and we can add one later. For
-      // now: returning null routes seed-selector to its non-k-means path.
-      return null;
-    },
+    // NOTE: do NOT pass embeddingForId here. library-db has no direct
+    // vector-read API (only knnById which does a full O(n) scan per call),
+    // so passing any function — even one that always returns null — causes
+    // kmeansSeedPicks to call it for every candidate before realising the
+    // vectors array is empty. On a 37k+ library that's 37k full-table KNN
+    // scans and will hang for hours. The selector's `else` branch (no
+    // embeddingForId → random shuffle) is the correct fallback until a
+    // cheap bulk-read API exists.
   });
   console.log(
     `[tag] seeds: ${seedSelection.seeds.length} new ` +

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -67,6 +67,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
         embedding: s.embedding,
         sfx: s.sfx,
         scrobble: s.scrobble,
+        picker: s.picker,
       },
       defaults: {
         // The built-in prompt template — the UI shows this when djPrompt is "".

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -504,6 +504,25 @@ const DEFAULTS = {
   sfx: {
     enabled: true,
   },
+  // Track picker constraints. These are editorial decisions, not technical
+  // ones — hardcoding them prevents valid programming choices like a live-sets
+  // show or a film-scores hour. The defaults reflect sensible radio behaviour
+  // but the operator can clear or replace them per-station and per-show.
+  //
+  // maxDurationSec: hard cap on track length before the LLM sees a candidate.
+  // excludePatterns: case-insensitive word/phrase patterns matched against
+  //   track title and album name. Any match removes the candidate from the
+  //   pool. Word-boundary matching applied on word-char edges (so "live" won't
+  //   match "alive", but "(live)" will match literally).
+  picker: {
+    maxDurationSec: 600,
+    excludePatterns: [
+      'live at', 'live from', 'live in', '(live)',
+      'acoustic version', 'demo version', 'rehearsal', 'bootleg', 'unplugged',
+      'soundtrack', 'original score', 'original motion picture', 'motion picture', 'ost',
+      'from the film', 'from the movie', 'from the series', 'from the show',
+    ],
+  },
   // Outbound webhooks. Each entry POSTs station events (see broadcast/
   // webhooks.ts for the event list) to `url` with a fire-and-forget HTTP
   // call. Empty by default — operators add hooks via the admin UI.
@@ -664,6 +683,15 @@ function normalizeShows(raw: any, personaIds: string[]) {
       typeof item.themeId === 'string' && item.themeId.trim()
         ? item.themeId.trim().slice(0, 64)
         : '';
+    // excludePatterns: null = inherit station-wide; [] = no excludes (e.g.
+    // a live-sets show); [...] = show-specific list that replaces station-wide.
+    let excludePatterns: string[] | null = null;
+    if (Array.isArray(item.excludePatterns)) {
+      excludePatterns = item.excludePatterns
+        .filter((p: any) => typeof p === 'string' && p.trim().length > 0)
+        .map((p: any) => p.trim().slice(0, 100))
+        .slice(0, 50);
+    }
     out.push({
       id,
       name,
@@ -671,6 +699,7 @@ function normalizeShows(raw: any, personaIds: string[]) {
       personaId: item.personaId,
       mood: item.mood,
       themeId,
+      excludePatterns,
     });
     if (out.length >= SHOWS_LIMIT) break;
   }
@@ -958,6 +987,21 @@ export async function load() {
     },
     sfx: {
       enabled: typeof stored.sfx?.enabled === 'boolean' ? stored.sfx.enabled : DEFAULTS.sfx.enabled,
+    },
+    picker: {
+      maxDurationSec: (() => {
+        const v = stored.picker?.maxDurationSec;
+        if (typeof v !== 'number' || !Number.isFinite(v) || v <= 0) {
+          return DEFAULTS.picker.maxDurationSec;
+        }
+        return Math.max(60, Math.min(3600, Math.floor(v)));
+      })(),
+      excludePatterns: Array.isArray(stored.picker?.excludePatterns)
+        ? stored.picker.excludePatterns
+            .filter((p: any) => typeof p === 'string' && p.trim().length > 0)
+            .map((p: any) => (p as string).trim().slice(0, 100))
+            .slice(0, 50)
+        : [...DEFAULTS.picker.excludePatterns],
     },
     webhooks: normalizeWebhooks(stored.webhooks),
     scrobble: {
@@ -1251,7 +1295,25 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
     let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('s_');
     if (seen.has(id)) id = mintId('s_');
     seen.add(id);
-    return { id, name, topic, personaId: item.personaId, mood: item.mood, themeId };
+    // excludePatterns: optional. null/absent = use station-wide; [] = no
+    // excludes (e.g. a live-sets show); [...] = show-specific replacement.
+    let excludePatterns: string[] | null = null;
+    if (item.excludePatterns !== undefined && item.excludePatterns !== null) {
+      if (!Array.isArray(item.excludePatterns)) {
+        throw new Error(`shows[${i}].excludePatterns must be an array or null`);
+      }
+      if (item.excludePatterns.length > 50) {
+        throw new Error(`shows[${i}].excludePatterns must be at most 50 entries`);
+      }
+      excludePatterns = item.excludePatterns.map((p: any, pi: number) => {
+        const v = String(p ?? '').trim();
+        if (v.length === 0 || v.length > 100) {
+          throw new Error(`shows[${i}].excludePatterns[${pi}] must be 1-100 chars`);
+        }
+        return v;
+      });
+    }
+    return { id, name, topic, personaId: item.personaId, mood: item.mood, themeId, excludePatterns };
   });
 }
 
@@ -1705,6 +1767,32 @@ export async function update(patch) {
       next.sfx.enabled = !!sx.enabled;
     }
   }
+  if ('picker' in patch) {
+    const p = patch.picker || {};
+    if (!next.picker) next.picker = { ...DEFAULTS.picker, excludePatterns: [...DEFAULTS.picker.excludePatterns] };
+    if (p.maxDurationSec !== undefined) {
+      const v = parseInt(p.maxDurationSec, 10);
+      if (!Number.isFinite(v) || v < 60 || v > 3600) {
+        throw new Error('picker.maxDurationSec must be an integer between 60 and 3600');
+      }
+      next.picker.maxDurationSec = v;
+    }
+    if (p.excludePatterns !== undefined) {
+      if (!Array.isArray(p.excludePatterns)) {
+        throw new Error('picker.excludePatterns must be an array of strings');
+      }
+      if (p.excludePatterns.length > 50) {
+        throw new Error('picker.excludePatterns must be at most 50 entries');
+      }
+      next.picker.excludePatterns = p.excludePatterns.map((item: any, i: number) => {
+        const v = String(item ?? '').trim();
+        if (v.length === 0 || v.length > 100) {
+          throw new Error(`picker.excludePatterns[${i}] must be 1-100 chars`);
+        }
+        return v;
+      });
+    }
+  }
   if ('webhooks' in patch) {
     next.webhooks = validateWebhooksStrict(patch.webhooks, next.webhooks || []);
   }
@@ -1826,9 +1914,36 @@ export function resolveActiveShow(date = new Date(), s = get()) {
     // layer is responsible for resolving an empty/stale id against the live
     // theme registry; we just surface what the show declares.
     themeId: typeof show.themeId === 'string' ? show.themeId : '',
+    // null = use station-wide picker.excludePatterns; [] = no excludes for
+    // this show (e.g. a live-sets hour); [...] = show-specific override list.
+    excludePatterns: Array.isArray(show.excludePatterns) ? show.excludePatterns : null,
     persona: persona
       ? { id: persona.id, name: persona.name, avatar: persona.avatar || '' }
       : null,
+  };
+}
+
+// Effective picker config for the current show (or station-wide when no show
+// is active, or when the show has no override). Call at pick time — reads from
+// the in-memory cache so no await needed.
+//
+// show.excludePatterns is the resolved value from resolveActiveShow():
+//   null   → show has no override; use station-wide list
+//   []     → show explicitly has no excludes (e.g. a live-sets show)
+//   [...]  → show-specific list that REPLACES station-wide
+export function getPickerConfig(show?: { excludePatterns?: string[] | null } | null): {
+  maxDurationSec: number;
+  excludePatterns: string[];
+} {
+  const s: any = get();
+  const stationWide = s.picker ?? DEFAULTS.picker;
+  const patterns =
+    show?.excludePatterns !== null && show?.excludePatterns !== undefined
+      ? show.excludePatterns       // show overrides (incl. [] to clear all)
+      : stationWide.excludePatterns ?? [...DEFAULTS.picker.excludePatterns];
+  return {
+    maxDurationSec: stationWide.maxDurationSec ?? DEFAULTS.picker.maxDurationSec,
+    excludePatterns: patterns,
   };
 }
 

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -48,6 +48,15 @@ ANALYZE_SECONDS = os.environ.get("ANALYZE_SECONDS", "60")
 DEVICE = os.environ.get("TTS_HEAVY_DEVICE", "cpu").lower()
 POCKET_TTS_DEFAULT_VOICE = os.environ.get("POCKET_TTS_VOICE", "alba")
 
+# Set DISABLE_CHATTERBOX=1 or DISABLE_POCKET_TTS=1 to skip loading those
+# workers entirely. The /health endpoint only advertises engines whose workers
+# are running, so the controller's probe will see neither engine as available
+# and TTS falls back to Piper. Useful when the host has insufficient CPU/GPU
+# for real-time synthesis but the acoustic analyzer is still wanted.
+_truthy = {"1", "true", "yes"}
+DISABLE_CHATTERBOX = os.environ.get("DISABLE_CHATTERBOX", "").lower() in _truthy
+DISABLE_POCKET_TTS = os.environ.get("DISABLE_POCKET_TTS", "").lower() in _truthy
+
 # Per-worker HF cache homes so the two engines don't fight over the same
 # directory. Each is a named volume in the compose files, so the weights a
 # worker downloads on its first boot survive container recreates. The env vars
@@ -267,11 +276,16 @@ async def lifespan(_app: FastAPI):
     # the port bind and the controller's probe would see "connection refused"
     # for the entire boot — leading operators to think the sidecar is broken
     # when it's just still loading.
-    tasks = [
-        asyncio.create_task(chatterbox_worker.run(), name="chatterbox-run"),
-        asyncio.create_task(pocket_worker.run(), name="pocket-tts-run"),
-        asyncio.create_task(analyzer_worker.run(), name="analyze-run"),
-    ]
+    tasks = []
+    if not DISABLE_CHATTERBOX:
+        tasks.append(asyncio.create_task(chatterbox_worker.run(), name="chatterbox-run"))
+    else:
+        log.info("[chatterbox] disabled via DISABLE_CHATTERBOX — skipping worker")
+    if not DISABLE_POCKET_TTS:
+        tasks.append(asyncio.create_task(pocket_worker.run(), name="pocket-tts-run"))
+    else:
+        log.info("[pocket-tts] disabled via DISABLE_POCKET_TTS — skipping worker")
+    tasks.append(asyncio.create_task(analyzer_worker.run(), name="analyze-run"))
     try:
         yield
     finally:

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -2172,7 +2172,7 @@ function PickerSection({ data, form, setForm, busy, saveSettings }: SectionProps
 
           <div className="field">
             <Label>Excluded — click × to remove</Label>
-            <div className="flex flex-wrap gap-1.5 border border-ink bg-[var(--field)] p-2.5 min-h-[40px]">
+            <div className="flex min-h-[40px] flex-wrap gap-1.5 border border-ink bg-[var(--field)] p-2.5">
               {form.picker.excludePatterns.length === 0 && (
                 <span className="text-[11px] text-muted italic">
                   No patterns — all tracks eligible.

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -24,6 +24,7 @@ const SECTIONS = [
   { id: 'theme',    label: 'Theme', hint: 'station-wide palette' },
   { id: 'tts',      label: 'TTS voice', hint: 'default engine' },
   { id: 'llm',      label: 'LLM provider', hint: 'model routing' },
+  { id: 'picker',   label: 'Track filters', hint: 'duration · excludes' },
   { id: 'search',   label: 'Web search', hint: 'live-facts backend' },
   { id: 'library',  label: 'Library tagger', hint: 'embedding · propagation' },
   { id: 'jingles',  label: 'Jingles', hint: 'stingers' },
@@ -152,6 +153,11 @@ interface ScrobbleForm {
   listenbrainz: ScrobbleListenbrainzForm;
 }
 
+interface PickerForm {
+  maxDurationSec: string;
+  excludePatterns: string[];
+}
+
 interface ArchiveForm {
   enabled: boolean;
   bitrate: string;
@@ -165,6 +171,14 @@ interface StreamForm {
 // has a literal `%mp3(bitrate=…)` branch per value, so this set is fixed.
 const ARCHIVE_BITRATES = [64, 96, 128, 160, 192, 320] as const;
 
+// Mirrors DEFAULTS.picker.excludePatterns in controller/src/settings.ts.
+const DEFAULT_EXCLUDE_PATTERNS: string[] = [
+  'live at', 'live from', 'live in', '(live)',
+  'acoustic version', 'demo version', 'rehearsal', 'bootleg', 'unplugged',
+  'soundtrack', 'original score', 'original motion picture', 'motion picture', 'ost',
+  'from the film', 'from the movie', 'from the series', 'from the show',
+];
+
 interface FormState {
   jingleRatio: string;
   crossfadeDuration: string;
@@ -174,6 +188,7 @@ interface FormState {
   weather: WeatherCfg;
   tts: TtsForm;
   llm: LlmForm;
+  picker: PickerForm;
   search: SearchForm;
   embedding: EmbeddingForm;
   scrobble: ScrobbleForm;
@@ -229,6 +244,7 @@ interface SettingsData {
       maxActiveLearningRounds?: number;
       enrichment?: Partial<EmbeddingEnrichmentForm>;
     };
+    picker?: { maxDurationSec?: number; excludePatterns?: string[] };
     sfx?: { enabled?: boolean };
     scrobble?: {
       lastfm?: Partial<ScrobbleLastfmForm>;
@@ -358,6 +374,12 @@ export default function SettingsPanel() {
           baseUrl: v.llm?.fallback?.baseUrl ?? '',
           reasoning: !!v.llm?.fallback?.reasoning,
         },
+      },
+      picker: {
+        maxDurationSec: String(v.picker?.maxDurationSec ?? 600),
+        excludePatterns: Array.isArray(v.picker?.excludePatterns)
+          ? [...v.picker.excludePatterns]
+          : [...DEFAULT_EXCLUDE_PATTERNS],
       },
       search: {
         provider: v.search?.provider ?? 'duckduckgo',
@@ -581,6 +603,12 @@ export default function SettingsPanel() {
             )}
             {activeSection === 'llm' && data.llm && (
               <LlmSection
+                data={data} form={form} setForm={updateForm} busy={busy}
+                saveSettings={saveSettings}
+              />
+            )}
+            {activeSection === 'picker' && (
+              <PickerSection
                 data={data} form={form} setForm={updateForm} busy={busy}
                 saveSettings={saveSettings}
               />
@@ -2030,6 +2058,186 @@ function SearchSection({ data, form, setForm, busy, saveSettings }: SectionProps
         busy={busy}
         onSave={save}
         saveLabel="Save web search"
+      />
+    </>
+  );
+}
+
+/* ── Track filters (picker config) ──────────────────────────────────── */
+
+function PickerSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
+  const [patternInput, setPatternInput] = useState('');
+
+  const savedPicker = data.values?.picker;
+  const savedMaxDuration = savedPicker?.maxDurationSec ?? 600;
+  const savedPatterns = savedPicker?.excludePatterns ?? DEFAULT_EXCLUDE_PATTERNS;
+
+  const durationSec = parseInt(form.picker.maxDurationSec, 10) || 600;
+  const durationMin = durationSec % 60 === 0
+    ? `${durationSec / 60} min`
+    : `${(durationSec / 60).toFixed(1)} min`;
+
+  const pickerDirty =
+    durationSec !== savedMaxDuration ||
+    JSON.stringify(form.picker.excludePatterns) !== JSON.stringify(savedPatterns);
+
+  const save = () => saveSettings({
+    picker: {
+      maxDurationSec: durationSec,
+      excludePatterns: form.picker.excludePatterns,
+    },
+  });
+
+  const addPattern = () => {
+    const p = patternInput.trim().toLowerCase();
+    if (!p || p.length > 100 || form.picker.excludePatterns.length >= 50
+        || form.picker.excludePatterns.includes(p)) return;
+    setForm(f => ({ ...f, picker: { ...f.picker, excludePatterns: [...f.picker.excludePatterns, p] } }));
+    setPatternInput('');
+  };
+
+  const removePattern = (p: string) =>
+    setForm(f => ({ ...f, picker: { ...f.picker, excludePatterns: f.picker.excludePatterns.filter(x => x !== p) } }));
+
+  const resetDefaults = () =>
+    setForm(f => ({ ...f, picker: { ...f.picker, excludePatterns: [...DEFAULT_EXCLUDE_PATTERNS] } }));
+
+  return (
+    <>
+      <SectionHeader
+        eyebrow="track filters"
+        title="What the picker will and won't queue."
+        sub={<>
+          Hard filters applied before the LLM sees any candidates — neither picker
+          path can queue a track that fails these. Defaults are sensible radio rules,
+          but you control them: a live-sets show can clear all excludes, a film-scores
+          hour can remove the soundtrack pattern. Per-show overrides are set in{' '}
+          <strong>Admin → Shows</strong>.
+        </>}
+        metrics={[
+          { n: String(durationSec), l: 'max sec', accent: true },
+          { n: String(form.picker.excludePatterns.length), l: 'patterns' },
+        ]}
+      />
+
+      <Card title="Track duration cap" sub="hard limit before LLM sees candidates">
+        <div className="field">
+          <Label>Maximum track duration</Label>
+          <div className="flex items-center gap-2">
+            <Input
+              type="number"
+              min={60}
+              max={3600}
+              step={30}
+              className="mono-num w-28"
+              value={form.picker.maxDurationSec}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setForm(f => ({ ...f, picker: { ...f.picker, maxDurationSec: e.target.value } }))
+              }
+            />
+            <span className="text-[12px] text-muted">sec</span>
+            <span className="text-[12px] text-muted">= {durationMin}</span>
+          </div>
+          <div className="field-hint">
+            Candidates longer than this are dropped before the LLM call —{' '}
+            {savedMaxDuration} s ({savedMaxDuration / 60} min) is the saved value.
+            If the entire pool would be dropped, the cap is ignored and a warning
+            is logged. Set higher for long-form ambient shows; lower to keep tracks
+            punchy. Range: 60–3600 s.
+          </div>
+        </div>
+      </Card>
+
+      <Card
+        title="Exclude patterns"
+        sub="matched against track title and album"
+        right={<Pill tone="ink">station-wide default</Pill>}
+      >
+        <div className="grid gap-4">
+          <div className="flex items-start gap-2.5 border border-[var(--accent)] bg-[var(--ink-softer)] p-3">
+            <span className="mt-1 size-1.5 flex-none rounded-full bg-vermilion" />
+            <div className="grid min-w-0 gap-0.5">
+              <span className="text-[11px] font-bold tracking-[0.12em] text-vermilion uppercase">
+                {form.picker.excludePatterns.length} exclusions active
+              </span>
+              <span className="text-[11px] leading-[1.5] text-muted">
+                Applied by both the agent picker and the pool picker before any LLM
+                call. Each pattern is matched case-insensitively against track{' '}
+                <strong>title</strong> and <strong>album</strong>. Word boundaries are
+                applied on word-char edges — <code>live</code> won&apos;t match{' '}
+                <code>alive</code>, but <code>(live)</code> matches literally.
+              </span>
+            </div>
+          </div>
+
+          <div className="field">
+            <Label>Excluded — click × to remove</Label>
+            <div className="flex flex-wrap gap-1.5 border border-ink bg-[var(--field)] p-2.5 min-h-[40px]">
+              {form.picker.excludePatterns.length === 0 && (
+                <span className="text-[11px] text-muted italic">
+                  No patterns — all tracks eligible.
+                </span>
+              )}
+              {form.picker.excludePatterns.map(p => (
+                <button
+                  key={p}
+                  type="button"
+                  onClick={() => removePattern(p)}
+                  className="inline-flex cursor-pointer items-center gap-1 border border-separator-strong bg-transparent px-2 py-0.5 font-[inherit] text-[11px] text-ink hover:border-[var(--danger)] hover:text-[var(--danger)]"
+                >
+                  <code>{p}</code>
+                  <span className="text-[10px] opacity-60">×</span>
+                </button>
+              ))}
+            </div>
+            <div className="field-hint">
+              Any track whose title or album contains a pattern is dropped from the
+              candidate pool — the LLM never sees it. Empty list = no filtering (all
+              tracks eligible). Per-show overrides can replace this list entirely for
+              a single hour — set them in <strong>Admin → Shows</strong>.
+            </div>
+          </div>
+
+          <div className="field">
+            <Label>Add pattern</Label>
+            <div className="flex items-center gap-2">
+              <Input
+                value={patternInput}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setPatternInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') { e.preventDefault(); addPattern(); }
+                }}
+                placeholder="e.g. karaoke"
+                className="max-w-[260px]"
+                maxLength={100}
+                disabled={form.picker.excludePatterns.length >= 50}
+              />
+              <Btn sm onClick={addPattern}
+                disabled={!patternInput.trim() || form.picker.excludePatterns.length >= 50}>
+                Add
+              </Btn>
+              <Btn sm onClick={resetDefaults}>Reset defaults</Btn>
+            </div>
+            <div className="field-hint">
+              Case-insensitive phrase — matched as a word/phrase boundary. Avoid
+              overly short patterns (<code>mix</code> would drop &ldquo;Remixed
+              Version&rdquo; but also &ldquo;Mixtape&rdquo; — be specific).
+              {form.picker.excludePatterns.length >= 50 && (
+                <span className="text-[var(--danger)]"> Maximum 50 patterns.</span>
+              )}
+            </div>
+          </div>
+        </div>
+      </Card>
+
+      <SaveBar
+        note={pickerDirty
+          ? 'Unsaved changes — applies to the next pick, no restart needed.'
+          : 'Applies to the next pick — no restart needed. Per-show overrides are managed in Admin → Shows.'}
+        busy={busy}
+        onSave={save}
+        saveLabel="Save track filters"
+        extra={pickerDirty ? <Pill tone="accent" dot>unsaved</Pill> : undefined}
       />
     </>
   );

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -809,7 +809,7 @@ export default function ShowsPanel() {
                 </span>
               ) : (
                 <div className="grid gap-2">
-                  <div className="flex flex-wrap gap-1.5 border border-ink bg-[var(--field)] p-2 min-h-[36px]">
+                  <div className="flex min-h-[36px] flex-wrap gap-1.5 border border-ink bg-[var(--field)] p-2">
                     {draft.excludePatterns.length === 0 && (
                       <span className="text-[11px] text-muted italic">
                         No patterns — all tracks eligible for this show.

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -22,7 +22,7 @@ import { Field } from '../ui/field';
 import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup,
 } from '../ui/select';
-import { Card, Btn, Pill, Eyebrow, Metric } from './ui';
+import { Card, Btn, Pill, Eyebrow, Metric, Seg } from './ui';
 import { Modal } from '../ui/modal';
 import { cn } from '../../lib/cn';
 
@@ -58,6 +58,9 @@ interface Show {
    *  default while this show is on air". Validated against the live theme
    *  registry by the controller; a stale id silently falls back too. */
   themeId: string;
+  /** null = inherit station-wide excludePatterns; [] = no filters for this
+   *  show; [...] = this show's own replacement list. */
+  excludePatterns: string[] | null;
 }
 
 // Slim view of a theme returned by GET /themes — only the bits the picker
@@ -167,6 +170,8 @@ export default function ShowsPanel() {
   // Modal state: `editIndex` is null (closed), -1 (new show), or a show index.
   const [editIndex, setEditIndex] = useState<number | null>(null);
   const [draft, setDraft] = useState<Show | null>(null);
+  // Input for adding per-show exclude patterns in the editor modal.
+  const [excludePatternInput, setExcludePatternInput] = useState('');
   // Theme list for the per-show override dropdown. Public endpoint, no auth
   // needed — same source the player ThemeBootstrap reads.
   const [themes, setThemes] = useState<ThemeOption[]>([]);
@@ -225,6 +230,7 @@ export default function ShowsPanel() {
           personaId: s.personaId ?? '',
           mood: s.mood ?? '',
           themeId: s.themeId ?? '',
+          excludePatterns: Array.isArray(s.excludePatterns) ? s.excludePatterns : null,
         }));
         setForm({ shows, schedule: week });
         // Arm the first valid show as the brush so the grid is paintable at once.
@@ -270,6 +276,7 @@ export default function ShowsPanel() {
       id: '', name: '', topic: '',
       personaId: personas[0]?.id || '', mood: moods[0] || '',
       themeId: '',
+      excludePatterns: null,
     });
   };
   const openEdit = (i: number) => {
@@ -281,9 +288,10 @@ export default function ShowsPanel() {
       id: s.id, name: s.name, topic: s.topic,
       personaId: s.personaId, mood: s.mood,
       themeId: s.themeId || '',
+      excludePatterns: s.excludePatterns ?? null,
     });
   };
-  const closeModal = () => { setEditIndex(null); setDraft(null); };
+  const closeModal = () => { setEditIndex(null); setDraft(null); setExcludePatternInput(''); };
   const setDraftField = (patch: Partial<Show>) => setDraft(d => d ? ({ ...d, ...patch }) : d);
   const commitDraft = () => {
     if (!draft || !showValid(draft)) return;
@@ -291,6 +299,7 @@ export default function ShowsPanel() {
       name: draft.name.trim(), topic: draft.topic.trim(),
       personaId: draft.personaId, mood: draft.mood,
       themeId: draft.themeId || '',
+      excludePatterns: draft.excludePatterns,
     };
     if (editIndex === -1) {
       const id = clientMintId();
@@ -426,6 +435,7 @@ export default function ShowsPanel() {
             id: s.id, name: s.name.trim(), topic: s.topic.trim(),
             personaId: s.personaId, mood: s.mood,
             themeId: s.themeId || '',
+            excludePatterns: s.excludePatterns ?? null,
           })),
           schedule: form.schedule,
         }),
@@ -772,6 +782,101 @@ export default function ShowsPanel() {
                 placeholder="e.g. Slow ambient, modern classical and downtempo for the late shift. Think Nils Frahm, Hammock, Bonobo's quieter side — nothing with a hard beat. Keep the host calm and unhurried, like a friend talking you down at 1am."
               />
               <span className="field-hint">{draft.topic.trim().length}/{TOPIC_MAX}</span>
+            </Field>
+
+            <Field>
+              <Label>exclude patterns — picker hard-filters for this show</Label>
+              <div className="flex items-center gap-2 pb-1">
+                <Seg
+                  options={[
+                    { id: 'inherit', label: 'Inherit' },
+                    { id: 'override', label: 'Override' },
+                  ]}
+                  value={draft.excludePatterns === null ? 'inherit' : 'override'}
+                  onChange={id =>
+                    setDraftField({
+                      excludePatterns: id === 'inherit' ? null : (draft.excludePatterns ?? []),
+                    })
+                  }
+                />
+              </div>
+              {draft.excludePatterns === null ? (
+                <span className="field-hint">
+                  Inheriting station-wide defaults from{' '}
+                  <strong>Settings → Track filters</strong>. Override to replace
+                  them for this show's hours — set an empty list to allow all tracks
+                  (e.g. a live-sets hour).
+                </span>
+              ) : (
+                <div className="grid gap-2">
+                  <div className="flex flex-wrap gap-1.5 border border-ink bg-[var(--field)] p-2 min-h-[36px]">
+                    {draft.excludePatterns.length === 0 && (
+                      <span className="text-[11px] text-muted italic">
+                        No patterns — all tracks eligible for this show.
+                      </span>
+                    )}
+                    {draft.excludePatterns.map(p => (
+                      <button
+                        key={p}
+                        type="button"
+                        onClick={() =>
+                          setDraftField({
+                            excludePatterns: (draft.excludePatterns ?? []).filter(x => x !== p),
+                          })
+                        }
+                        className="inline-flex cursor-pointer items-center gap-1 border border-separator-strong bg-transparent px-2 py-0.5 font-[inherit] text-[11px] text-ink hover:border-[var(--danger)] hover:text-[var(--danger)]"
+                      >
+                        <code>{p}</code>
+                        <span className="text-[10px] opacity-60">×</span>
+                      </button>
+                    ))}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      value={excludePatternInput}
+                      onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                        setExcludePatternInput(e.target.value)
+                      }
+                      onKeyDown={(e) => {
+                        if (e.key !== 'Enter') return;
+                        e.preventDefault();
+                        const p = excludePatternInput.trim().toLowerCase();
+                        if (!p || p.length > 100 || (draft.excludePatterns?.length ?? 0) >= 50
+                            || draft.excludePatterns?.includes(p)) return;
+                        setDraftField({ excludePatterns: [...(draft.excludePatterns ?? []), p] });
+                        setExcludePatternInput('');
+                      }}
+                      placeholder="add pattern, press Enter"
+                      className="max-w-[240px] text-[12px]"
+                      maxLength={100}
+                      disabled={(draft.excludePatterns?.length ?? 0) >= 50}
+                    />
+                    <Btn
+                      sm
+                      onClick={() => {
+                        const p = excludePatternInput.trim().toLowerCase();
+                        if (!p || p.length > 100 || (draft.excludePatterns?.length ?? 0) >= 50
+                            || draft.excludePatterns?.includes(p)) return;
+                        setDraftField({ excludePatterns: [...(draft.excludePatterns ?? []), p] });
+                        setExcludePatternInput('');
+                      }}
+                      disabled={!excludePatternInput.trim() || (draft.excludePatterns?.length ?? 0) >= 50}
+                    >
+                      Add
+                    </Btn>
+                    {(draft.excludePatterns?.length ?? 0) > 0 && (
+                      <Btn sm tone="danger" onClick={() => setDraftField({ excludePatterns: [] })}>
+                        Clear all
+                      </Btn>
+                    )}
+                  </div>
+                  <span className="field-hint">
+                    Replaces the station-wide list for this show's hours. Empty = no
+                    filtering. Patterns match track title and album (case-insensitive,
+                    word boundaries).
+                  </span>
+                </div>
+              )}
             </Field>
 
             {!draftValid && (


### PR DESCRIPTION
## Summary

Two independent fixes in this PR:

**1. Excluded tracks leaking through the auto-playlist fallback**

Station-wide `excludePatterns` (christmas, live, demo, etc.) were only applied to DJ agent picks. The Liquidsoap fallback auto-playlist (`auto.m3u`) was built without filtering, so excluded tracks could still play when the DJ queue was empty.

Fix: `refreshAutoPlaylistInner()` in `scheduler.ts` now calls `isRadioPickable()` on each candidate using the same `getPickerConfig()` patterns as the DJ agent.

**2. Audible gaps between tracks (curl timeout on large files)**

`getStreamUrl()` used `format=raw`, which asks Navidrome to serve the original file bytes. For FLAC/AAC files (30-60 MB+) Liquidsoap's `subhttp:` curl download timed out mid-fetch, causing a silence gap before the next track started.

Fix: switched to `format=mp3&maxBitRate=128`. Navidrome transcodes to 128 kbps MP3 on the way out — progressive, small stream that never times out. 128 kbps matches the Icecast broadcast bitrate so there's no quality difference at the listener end.

## Files changed

- `controller/src/broadcast/scheduler.ts` — add `isRadioPickable` filter to auto-playlist pool
- `controller/src/music/subsonic.ts` — `getStreamUrl` uses `format=mp3&maxBitRate=128`