### PR TITLE
docs: add Discord invite to README and landing footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It's *radio*, not a playlist. No per-listener shuffle, no skip button, no
 - **Mobile apps (beta)** — native iOS & Android players — [join the beta](https://github.com/perminder-klair/subwave/discussions/289)
 - **Setup walkthrough** — [getsubwave.com/setup](https://www.getsubwave.com/setup)
 - **Operator manual** — [getsubwave.com/manual](https://www.getsubwave.com/manual)
+- **Community** — [join the Discord](https://discord.gg/vjVbVKnMBa)
 
 ## Screenshots
 

--- a/web/components/landing/StationFooter.tsx
+++ b/web/components/landing/StationFooter.tsx
@@ -22,6 +22,14 @@ export default function StationFooter({ djName }: { djName?: string }) {
             className="font-semibold tracking-[inherit] text-ink hover:text-vermilion"
           >
             GitHub
+          </AnimatedLink>{' '}
+          ·{' '}
+          <AnimatedLink
+            href="https://discord.gg/vjVbVKnMBa"
+            variant="arrow"
+            className="font-semibold tracking-[inherit] text-ink hover:text-vermilion"
+          >
+            Discord
           </AnimatedLink>
         </span>
       </div>


### PR DESCRIPTION
Adds the new SUB/WAVE Discord invite (https://discord.gg/vjVbVKnMBa) in two places:

- **README.md** — a "Community — join the Discord" entry in the Live demo links list.
- **Landing footer** (`web/components/landing/StationFooter.tsx`) — a "Discord" link after the existing "GitHub" link, using the same `AnimatedLink` arrow style.

See discussion #346 for context.