### PR TITLE
fix(web): tune out abandoned player tabs + back off reconnects

### DIFF
--- a/web/components/PlayerApp.tsx
+++ b/web/components/PlayerApp.tsx
@@ -50,7 +50,7 @@ export interface PlayerAppProps {
 export default function PlayerApp({ contained = false }: PlayerAppProps) {
   const { nowPlaying, context, dj, activeShow, listeners, streamOnline, state, session, trackStartedAt } = useStationFeed();
   const boothFeed = session.messages;
-  const { audioRef, tunedIn, status, volume, setVolume, tune, stop, toggleMute, muted } = usePlayer();
+  const { audioRef, tunedIn, status, volume, setVolume, tune, stop, toggleMute, muted, idleStopped } = usePlayer();
 
   // streamOnline is null until the first poll resolves — only treat an
   // explicit false as offline so the player never flashes "offline" on load.
@@ -163,6 +163,22 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
     setShowTuneIn(false);
     tune();
   };
+
+  // Idle cutoff fired (usePlayer tuned the abandoned tab out, issue #343):
+  // bring the tune-in gate back as the one-tap resume and say why playback
+  // stopped. Lock-screen Play also resumes, via useMediaSession's onTune.
+  useEffect(() => {
+    if (!idleStopped) return;
+    setShowTuneIn(true);
+    toast('Tuned out after a few hours without activity — tap to keep listening.');
+  }, [idleStopped]);
+
+  // Whenever playback is actually running, the gate has done its job — drop
+  // it. Covers resume paths that bypass the overlay tap (lock-screen Play
+  // after an idle cutoff goes straight through tune()).
+  useEffect(() => {
+    if (tunedIn) setShowTuneIn(false);
+  }, [tunedIn]);
 
   // Hydrate ticker preference from localStorage (avoids SSR hydration mismatch).
   useEffect(() => {

--- a/web/components/PlayerApp.tsx
+++ b/web/components/PlayerApp.tsx
@@ -170,7 +170,7 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
   useEffect(() => {
     if (!idleStopped) return;
     setShowTuneIn(true);
-    toast('Tuned out after a few hours without activity — tap to keep listening.');
+    toast('Tuned out while you were away — tap to keep listening.');
   }, [idleStopped]);
 
   // Whenever playback is actually running, the gate has done its job — drop

--- a/web/hooks/usePlayer.ts
+++ b/web/hooks/usePlayer.ts
@@ -27,6 +27,21 @@ function resolveStreamUrls(): { mp3: string; opus: string | null } {
 
 const { mp3: MP3_STREAM_URL, opus: OPUS_STREAM_URL } = resolveStreamUrls();
 
+// Reconnect backoff for the watchdog's error path. The first retry stays
+// quick (a blip mid-broadcast should recover in half a second), but repeated
+// failures double the delay up to a minute — an abandoned tab pointed at a
+// downed station must not hammer reconnects twice a second all night.
+const RECONNECT_BASE_MS = 500;
+const RECONNECT_MAX_MS = 60_000;
+
+// Idle cutoff (issue #343). A forgotten tab/PWA stays connected to the live
+// mount forever, counting as a listener and keeping the DJ's pause-when-empty
+// gate open 24/7. After this long with zero listener activity (no pointer,
+// no key, no tab focus) we tune out; the consumer surfaces a one-tap resume
+// via `idleStopped`.
+const IDLE_TUNE_OUT_MS = 4 * 60 * 60 * 1000;
+const IDLE_CHECK_INTERVAL_MS = 60_000;
+
 export type PlayerStatus = 'idle' | 'connecting' | 'playing';
 
 export interface Player {
@@ -39,6 +54,10 @@ export interface Player {
   stop: () => void;
   toggleMute: () => void;
   muted: boolean;
+  // True when the idle cutoff (not the listener) tore playback down — the
+  // consumer should explain why and offer a one-tap resume. Cleared on the
+  // next tune().
+  idleStopped: boolean;
 }
 
 export interface UsePlayerOptions {
@@ -60,6 +79,7 @@ export function usePlayer({ initialVolume = 1 }: UsePlayerOptions = {}): Player 
   // surfaced in the UI so the player doesn't claim to be playing while silent.
   const [status, setStatus] = useState<PlayerStatus>('idle');
   const [volume, setVolume] = useState(initialVolume);
+  const [idleStopped, setIdleStopped] = useState(false);
   const preMuteVolume = useRef(initialVolume || 1);
 
   // play() resolves asynchronously; pausing before it settles rejects the
@@ -76,6 +96,16 @@ export function usePlayer({ initialVolume = 1 }: UsePlayerOptions = {}): Player 
   const streamUrlRef = useRef(streamUrl);
   const volumeRef = useRef(volume);
   const watchdogTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Consecutive failed reconnects since the last successful 'playing' —
+  // drives the exponential backoff in onError.
+  const retryCount = useRef(0);
+  // Last listener activity (pointer/key/tab-focus/tune), read by the idle
+  // sweep. Seeded by the sweep effect at mount (not here — render must stay
+  // pure) so a fresh tab gets the full idle window.
+  const lastActivityAt = useRef(0);
+  // The idle sweep mounts once but must call the latest stop() (defined
+  // below, recreated per render) — bridge with a ref.
+  const stopRef = useRef<() => void>(() => {});
   // Set once if the optional Opus mount fails to load — pins us to MP3 so the
   // watchdog stops retrying a dead Opus URL (e.g. an operator who disabled the
   // server-side Opus encoder, so /stream.opus 404s).
@@ -122,7 +152,8 @@ export function usePlayer({ initialVolume = 1 }: UsePlayerOptions = {}): Player 
   // recovers from, because nothing in here was forcing the dead element back
   // onto the live mount). 'playing' clears the watchdog; 'waiting'/'stalled'
   // arm a 5s timer that re-sets src if 'playing' hasn't fired by then;
-  // 'error' bypasses the timer and reconnects after 500 ms.
+  // 'error' reconnects with exponential backoff (500 ms doubling to a 60 s
+  // ceiling, reset on the next successful 'playing').
   useEffect(() => {
     const el = audioRef.current;
     if (!el) return;
@@ -160,6 +191,7 @@ export function usePlayer({ initialVolume = 1 }: UsePlayerOptions = {}): Player 
 
     const onPlaying = () => {
       clearWatchdog();
+      retryCount.current = 0;
       setStatus('playing');
     };
     const onWaiting = () => {
@@ -176,7 +208,9 @@ export function usePlayer({ initialVolume = 1 }: UsePlayerOptions = {}): Player 
         streamUrlRef.current = MP3_STREAM_URL;
         setStreamUrl(MP3_STREAM_URL);
       }
-      armWatchdog(500);
+      const delay = Math.min(RECONNECT_BASE_MS * 2 ** retryCount.current, RECONNECT_MAX_MS);
+      retryCount.current += 1;
+      armWatchdog(delay);
     };
     el.addEventListener('playing', onPlaying);
     el.addEventListener('waiting', onWaiting);
@@ -188,6 +222,36 @@ export function usePlayer({ initialVolume = 1 }: UsePlayerOptions = {}): Player 
       el.removeEventListener('waiting', onWaiting);
       el.removeEventListener('stalled', onWaiting);
       el.removeEventListener('error', onError);
+    };
+  }, []);
+
+  // Idle cutoff (issue #343): a tab left tuned in with no listener activity
+  // for IDLE_TUNE_OUT_MS gets tuned out, so an abandoned browser doesn't sit
+  // on the mount as a phantom listener (keeping pause-when-empty's DJ gate
+  // open around the clock). Activity = pointer, key, or the tab becoming
+  // visible; the listener-driven entry points (tune, the consumer's controls)
+  // all arrive as pointer/key events anyway. The sweep runs once a minute —
+  // hour-scale cutoff, minute-scale precision is plenty.
+  useEffect(() => {
+    const markActivity = () => { lastActivityAt.current = Date.now(); };
+    markActivity(); // seed: mount counts as the start of the idle window
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') markActivity();
+    };
+    window.addEventListener('pointerdown', markActivity);
+    window.addEventListener('keydown', markActivity);
+    document.addEventListener('visibilitychange', onVisibility);
+    const sweep = setInterval(() => {
+      if (!tunedInRef.current) return;
+      if (Date.now() - lastActivityAt.current < IDLE_TUNE_OUT_MS) return;
+      setIdleStopped(true);
+      stopRef.current();
+    }, IDLE_CHECK_INTERVAL_MS);
+    return () => {
+      clearInterval(sweep);
+      window.removeEventListener('pointerdown', markActivity);
+      window.removeEventListener('keydown', markActivity);
+      document.removeEventListener('visibilitychange', onVisibility);
     };
   }, []);
 
@@ -214,6 +278,7 @@ export function usePlayer({ initialVolume = 1 }: UsePlayerOptions = {}): Player 
         el.src = '';
       });
   };
+  stopRef.current = stop;
 
   const tune = () => {
     if (!audioRef.current) return;
@@ -223,6 +288,11 @@ export function usePlayer({ initialVolume = 1 }: UsePlayerOptions = {}): Player 
     }
     const el = audioRef.current;
     const myGen = ++gen.current;
+    // A fresh tune-in is listener activity: restart the idle window, clear
+    // any pending idle prompt, and let the reconnect backoff start small.
+    lastActivityAt.current = Date.now();
+    setIdleStopped(false);
+    retryCount.current = 0;
     el.src = `${streamUrl}?t=${Date.now()}`;
     el.volume = volume;
     setTunedIn(true);
@@ -249,5 +319,5 @@ export function usePlayer({ initialVolume = 1 }: UsePlayerOptions = {}): Player 
     }
   };
 
-  return { audioRef, tunedIn, status, volume, setVolume, tune, stop, toggleMute, muted: volume === 0 };
+  return { audioRef, tunedIn, status, volume, setVolume, tune, stop, toggleMute, muted: volume === 0, idleStopped };
 }

--- a/web/hooks/usePlayer.ts
+++ b/web/hooks/usePlayer.ts
@@ -38,8 +38,9 @@ const RECONNECT_MAX_MS = 60_000;
 // mount forever, counting as a listener and keeping the DJ's pause-when-empty
 // gate open 24/7. After this long with zero listener activity (no pointer,
 // no key, no tab focus) we tune out; the consumer surfaces a one-tap resume
-// via `idleStopped`.
-const IDLE_TUNE_OUT_MS = 4 * 60 * 60 * 1000;
+// via `idleStopped`. 8h clears a full untouched workday of listening while
+// still catching an abandoned tab on its first evening.
+const IDLE_TUNE_OUT_MS = 8 * 60 * 60 * 1000;
 const IDLE_CHECK_INTERVAL_MS = 60_000;
 
 export type PlayerStatus = 'idle' | 'connecting' | 'playing';


### PR DESCRIPTION
Fixes #343.

## The ghost listener

A player tab left tuned in stays connected to the Icecast mount indefinitely — a real browser, counted as a real listener (we reproduced one connected for ~7h on production). Two consequences:

1. With **pause when empty** enabled, one phantom listener keeps the DJ burning LLM/TTS calls around the clock — the "unnecessary processing" in #343.
2. The reconnect watchdog retried every 500ms with no ceiling, so an abandoned tab hammered a downed station twice a second all night and re-attached seconds after every reboot ("the listener inevitably returns").

## The fix

**Idle cutoff (`usePlayer`)** — while tuned in, pointer/key events and the tab becoming visible mark listener activity. After 8 hours with zero activity, playback is torn down and the hook exposes `idleStopped`. A minute-resolution sweep drives it.

**Resume UX (`PlayerApp`)** — on idle cutoff the existing tune-in overlay comes back as the one-tap resume, with a toast explaining why playback stopped. Lock-screen Play also resumes (media session `onTune`), and the overlay now drops whenever playback is actually running so that path doesn't strand it.

**Reconnect backoff (`usePlayer`)** — the watchdog's error path now backs off exponentially (500ms doubling to a 60s ceiling), reset on successful playback or a fresh tune-in. Mid-broadcast blips still recover in half a second; a downed station no longer gets hammered.

## Trade-off

A listener who genuinely plays the stream in a background tab for 4+ hours without touching anything gets tuned out once and has to tap resume — the standard "are you still listening?" pattern. The 8h window is a constant (`IDLE_TUNE_OUT_MS`) if we want to tune it.

The native app has the same class of behaviour via react-native-track-player's retry; left for a follow-up since its retry semantics live in RNTP, not our code.

`npm run lint` (eslint + tsc) passes in `web/`.

