### PR TITLE
feat: journey-steered agent picks + admin toggle for sounds-like analysis

### DIFF
--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -227,9 +227,13 @@ _embedder = None
 _embed_failed = False
 
 
-def get_embedder():
+def get_embedder(force=False):
     global _embedder, _embed_failed
-    if not EMBED_ENABLED or _embed_failed:
+    # `force` is the per-request opt-in (the controller's admin toggle sends
+    # "embed": true) — it lazy-loads CLAP even when ANALYZE_AUDIO_EMBEDDING
+    # isn't in this process's env. A previous load failure still wins: one bad
+    # model can't make every subsequent track retry the load.
+    if _embed_failed or not (EMBED_ENABLED or force):
         return None
     if _embedder is None:
         try:
@@ -264,7 +268,7 @@ def fetch_audio(url):
     return path
 
 
-def analyze(librosa, url=None, path=None):
+def analyze(librosa, url=None, path=None, embed=None):
     import numpy as np
 
     # A controller-provided path is pre-fetched onto the shared volume and
@@ -280,7 +284,10 @@ def analyze(librosa, url=None, path=None):
         # SAME file (still present here, before the finally removes owned temps).
         # A model/feature failure on one track never fails the whole analyze:
         # we log and emit bpm/key without the embedding.
-        embedder = get_embedder()
+        # Per-request `embed` wins over the env default in the ON direction
+        # only: True forces a (lazy) CLAP load, None/absent keeps the env-driven
+        # behaviour. False is never sent by the controller today.
+        embedder = None if embed is False else get_embedder(force=embed is True)
         if embedder is not None:
             try:
                 y48, _sr48 = librosa.load(
@@ -368,7 +375,7 @@ def main():
         try:
             import librosa
 
-            result = analyze(librosa, url=url, path=path)
+            result = analyze(librosa, url=url, path=path, embed=req.get("embed"))
             emit({"id": rid, "ok": True, **result})
         except Exception as e:
             emit({"id": rid, "ok": False, "error": str(e)})

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -228,8 +228,8 @@ export const pickerAgent = defineAgent({
   maxSteps: 4,
   timeoutMs: 22000,
   buildSystem: () => pickSystem(),
-  buildTools: ({ recentIds, recentKeys, recentArtists }) => {
-    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, recentArtists });
+  buildTools: ({ recentIds, recentKeys, recentArtists, audioWaypoint }) => {
+    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, recentArtists, audioWaypoint });
     return { tools, extras: { seen } };
   },
 });
@@ -280,7 +280,7 @@ async function enqueuePick(queue, song, reason, source, link: string | null = nu
 // Track event — a track started; pick the next one and maybe air a link.
 // ---------------------------------------------------------------------------
 
-async function pickViaAgent(queue, { wantLink }) {
+async function pickViaAgent(queue, { wantLink, audioWaypoint = null }: { wantLink: boolean; audioWaypoint?: number[] | null }) {
   await library.load();
   const windows = recencyWindowsForLibrary(library.stats().distinctArtists);
   // Scale the recency windows to the tagged library's artist diversity: dense
@@ -294,6 +294,10 @@ async function pickViaAgent(queue, { wantLink }) {
     recentIds,
     recentKeys,
     recentArtists,
+    // Sonic journey (Phase 2): registers the tracksTowardJourney tool, closed
+    // over the run's current waypoint, so the agent path drifts the sound the
+    // same way the pool path does. The event text tells the agent to use it.
+    audioWaypoint,
   });
 
   const song = object?.id ? extras.seen.get(object.id) : null;
@@ -393,6 +397,12 @@ export async function runTrackEvent(queue, ctx, { wantLink }) {
     const runClause = inRun
       ? ` You're mid-run — keep the energy moving in the same direction (a touch ${energyForDaypart().speed >= 1 ? 'brisker' : 'mellower'}) and you may nod to it in the link, but never say tempo numbers.`
       : '';
+    // Gated on the waypoint itself, not inRun: on a run's final pick the run
+    // state is already cleared (advanceRun) but the last waypoint — the
+    // destination itself — is still the one to land on.
+    const journeyClause = audioWaypoint && audioWaypoint.length
+      ? ' A sonic journey is active: call tracksTowardJourney and strongly prefer one of its tracks — each one carries the sound a step toward where this arc is heading. Never mention the journey on air.'
+      : '';
     const linkClause = wantLink
       ? (djMode
           ? ` Also write a short link that airs as your pick starts: back-announce "${current?.title}", then tease what's next — name the artist or capture the feel of the track you pick so listeners know what's coming. If the track you pick shows an intro_ms, keep the link short enough to finish before then, so you land just as the vocals come in.`
@@ -407,12 +417,13 @@ export async function runTrackEvent(queue, ctx, { wantLink }) {
       + (previous ? ` (after "${previous.title}" by ${previous.artist})` : '')
       + '. Pick the track to play next.'
       + linkClause
-      + runClause;
+      + runClause
+      + journeyClause;
     session.appendTurn({ role: 'event', kind: 'pick', text: eventText });
 
     if (settings.get().llm?.pickerAgent) {
       try {
-        await pickViaAgent(queue, { wantLink });
+        await pickViaAgent(queue, { wantLink, audioWaypoint });
         return;
       } catch (err) {
         queue.log('error', `DJ agent pick failed: ${err.message} — falling back to pool`);

--- a/controller/src/broadcast/tagger.ts
+++ b/controller/src/broadcast/tagger.ts
@@ -10,9 +10,13 @@ type TaggerState = {
   startedAt: string | null;
   pid: number | null;
   lastLog: string[];
+  // Which script the live child is: 'tag' (tag-library) or 'analyze' (the
+  // acoustic/audio-embedding pass via analyze-library). Single-flight across
+  // both — they contend on the same library DB and analysis backend.
+  mode: 'tag' | 'analyze' | null;
 };
 
-export const tagger: TaggerState = { running: false, startedAt: null, pid: null, lastLog: [] };
+export const tagger: TaggerState = { running: false, startedAt: null, pid: null, lastLog: [], mode: null };
 
 // Live handle for stopTagger() — cleared on the exit handler.
 let activeChild: ChildProcess | null = null;
@@ -41,12 +45,48 @@ export function startTagger(
   if (reAnalyze) args.push('--re-analyze');
   if (upgrade) args.push('--upgrade');
 
+  const detail = [
+    Number.isFinite(limit) && (limit as number) > 0 ? `limit=${limit}` : null,
+    reseed ? 'reseed' : null,
+    reEnrich ? 're-enrich' : null,
+    reAnalyze ? 're-analyze' : null,
+    upgrade ? 'upgrade' : null,
+  ]
+    .filter(Boolean)
+    .join(', ');
+  spawnChild('tag', args, detail);
+}
+
+// Spawn the standalone analysis pass (bpm/key/intro + CLAP audio embeddings
+// when settings.audio.embeddings / ANALYZE_AUDIO_EMBEDDING is on). `audio`
+// forces the --audio backfill scope so already-analysed tracks that lack an
+// audio vector are re-targeted — what the admin "Analyze audio" button wants.
+// Same single-flight state as the tagger; caller rejects when tagger.running.
+export function startAnalyzer(opts: { limit?: number; audio?: boolean } = {}) {
+  // No --skip-walk: the script's default policy (walk Navidrome only when the
+  // catalogue is empty) is the right bootstrap for a first-ever run.
+  const { limit, audio } = opts;
+  const args = ['src/music/analyze-library.ts'];
+  if (Number.isFinite(limit) && (limit as number) > 0) args.push('--limit', String(limit));
+  if (audio) args.push('--audio');
+  const detail = [
+    Number.isFinite(limit) && (limit as number) > 0 ? `limit=${limit}` : null,
+    audio ? 'audio' : null,
+  ]
+    .filter(Boolean)
+    .join(', ');
+  spawnChild('analyze', args, detail);
+}
+
+function spawnChild(mode: 'tag' | 'analyze', args: string[], detail: string) {
+  const label = mode === 'tag' ? 'tagger' : 'analyzer';
   const child = spawn('npx', ['tsx', ...args], { cwd: '/app', detached: false });
   activeChild = child;
   tagger.running = true;
   tagger.startedAt = new Date().toISOString();
   tagger.pid = child.pid ?? null;
   tagger.lastLog = [];
+  tagger.mode = mode;
 
   const capture = (chunk: Buffer) => {
     const lines = chunk.toString().split('\n').filter((l: string) => l.trim());
@@ -59,18 +99,9 @@ export function startTagger(
     tagger.running = false;
     if (activeChild === child) activeChild = null;
     tagger.lastLog.push(`[exit ${signal || code}]`);
-    queue.log('scheduler', `tagger finished (${signal ? `signal ${signal}` : `exit ${code}`})`);
+    queue.log('scheduler', `${label} finished (${signal ? `signal ${signal}` : `exit ${code}`})`);
   });
-  const detail = [
-    Number.isFinite(limit) && (limit as number) > 0 ? `limit=${limit}` : null,
-    reseed ? 'reseed' : null,
-    reEnrich ? 're-enrich' : null,
-    reAnalyze ? 're-analyze' : null,
-    upgrade ? 'upgrade' : null,
-  ]
-    .filter(Boolean)
-    .join(', ');
-  queue.log('scheduler', `tagger started${detail ? ` (${detail})` : ''}`);
+  queue.log('scheduler', `${label} started${detail ? ` (${detail})` : ''}`);
 }
 
 // Stop the running tagger by signalling its child. The exit handler above

--- a/controller/src/llm/tools.ts
+++ b/controller/src/llm/tools.ts
@@ -64,10 +64,15 @@ export function buildPickerTools({
   recentIds = new Set<string>(),
   recentKeys = new Set<string>(),
   recentArtists = new Set<string>(),
+  audioWaypoint = null,
 }: {
   recentIds?: Set<string>;
   recentKeys?: Set<string>;        // lowercased "title|artist" — backfilled entries lack ids
   recentArtists?: Set<string>;
+  // The active sonic journey's current waypoint vector (broadcast/dj-agent.ts).
+  // When present, the tracksTowardJourney tool below is registered, closing
+  // over it — the agent never sees the raw vector, only the tracks near it.
+  audioWaypoint?: number[] | null;
 } = {}) {
   const seen = new Map<string, any>(); // id → slim song, accumulated across all tool calls
   const artistCounts = new Map<string, number>(); // artist key → songs already accepted into `seen`
@@ -253,6 +258,21 @@ export function buildPickerTools({
         catch (err) { return { error: err.message }; }
       },
     }),
+
+    // Only registered while a sonic journey is active (the event message tells
+    // the agent when that is). Closes over the journey's current waypoint, so
+    // calling it returns the tracks that carry the sound one step along the
+    // arc toward the destination vibe.
+    ...(audioWaypoint && audioWaypoint.length ? {
+      tracksTowardJourney: tool({
+        description: 'Tracks nearest the active sonic journey\'s CURRENT waypoint — the station is mid-arc, drifting its sound toward a destination vibe over the next few picks. When the event says a journey is active, call this and strongly prefer one of its tracks: each one moves the sound a step along the arc. Takes no input.',
+        inputSchema: z.object({}),
+        execute: async () => {
+          try { await library.load(); return collect(library.tracksByAudioVector(audioWaypoint, 20)); }
+          catch (err) { return { error: err.message }; }
+        },
+      }),
+    } : {}),
   };
 
   return { tools, seen };

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -12,6 +12,7 @@
 import { rm } from 'node:fs/promises';
 import * as db from './library-db.js';
 import * as analyzer from './analyzer.js';
+import * as settings from '../settings.js';
 import { config } from '../config.js';
 
 export interface AnalyzeOptions {
@@ -23,9 +24,18 @@ export interface AnalyzeOptions {
   audioBackfill?: boolean;
 }
 
+// Audio embeddings are on when EITHER the env says so (env wins on, never
+// off) or the operator flipped the admin toggle (settings.audio.embeddings —
+// the discoverable path; see /admin/library). Both entry points (server-spawned
+// runs and the standalone CLIs) call settings.load() before this runs.
 function audioBackfillDefault(): boolean {
   const v = (process.env.ANALYZE_AUDIO_EMBEDDING || '').toLowerCase();
-  return v === '1' || v === 'true' || v === 'yes';
+  if (v === '1' || v === 'true' || v === 'yes') return true;
+  try {
+    return settings.get()?.audio?.embeddings === true;
+  } catch {
+    return false;
+  }
 }
 
 export interface AnalyzeStats {
@@ -113,7 +123,13 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
         console.error(`[analyze] ${id} prefetch failed (${err?.message || err}); using url path`);
         localPath = null;
       }
-      const a = localPath ? await analyzer.analyzePath(localPath) : await analyzer.analyze(id);
+      // embed:true makes the backend lazy-load CLAP even when its own env
+      // doesn't have ANALYZE_AUDIO_EMBEDDING (the admin-toggle path); omitted
+      // when audio is off so the backend keeps its env-driven default.
+      const embed = audioBackfill ? true : undefined;
+      const a = localPath
+        ? await analyzer.analyzePath(localPath, { embed })
+        : await analyzer.analyze(id, { embed });
       db.upsertTrackAnalysis(id, {
         bpm: a.bpm,
         musicalKey: a.musicalKey,

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -114,9 +114,16 @@ function startWorker(): Promise<void> {
   return booting;
 }
 
+// Per-request analysis options. `embed: true` asks the backend to (lazy-load
+// and) run CLAP for this track even when the backend's own env doesn't enable
+// it — the admin-toggle path. Omitted → the backend's env-driven default.
+export interface AnalyzeRequestOpts {
+  embed?: boolean;
+}
+
 // Write a request to the local stdio worker and resolve its response. The
 // request carries either `url` (worker downloads) or `path` (already-local).
-function localRequest(req: { url: string } | { path: string }): Promise<AnalysisResult> {
+function localRequest(req: ({ url: string } | { path: string }) & AnalyzeRequestOpts): Promise<AnalysisResult> {
   const id = `a${++reqSeq}`;
   return new Promise<AnalysisResult>((resolve, reject) => {
     const timer = setTimeout(() => {
@@ -139,14 +146,14 @@ function localRequest(req: { url: string } | { path: string }): Promise<Analysis
   });
 }
 
-async function analyzeViaLocal(url: string): Promise<AnalysisResult> {
+async function analyzeViaLocal(url: string, opts: AnalyzeRequestOpts = {}): Promise<AnalysisResult> {
   if (!ready) await startWorker();
-  return localRequest({ url });
+  return localRequest({ url, ...opts });
 }
 
-async function analyzeViaLocalPath(path: string): Promise<AnalysisResult> {
+async function analyzeViaLocalPath(path: string, opts: AnalyzeRequestOpts = {}): Promise<AnalysisResult> {
   if (!ready) await startWorker();
-  return localRequest({ path });
+  return localRequest({ path, ...opts });
 }
 
 // ---------------------------------------------------------------------------
@@ -171,7 +178,7 @@ async function sidecarReachable(): Promise<boolean> {
 
 // POST the sidecar a request body of either {url} (it downloads) or {path}
 // (a file on the shared volume the controller pre-fetched).
-async function sidecarRequest(body: { url: string } | { path: string }): Promise<AnalysisResult> {
+async function sidecarRequest(body: ({ url: string } | { path: string }) & AnalyzeRequestOpts): Promise<AnalysisResult> {
   const base = config.ttsHeavy.url;
   const ac = new AbortController();
   const t = setTimeout(() => ac.abort(), config.analyzer.requestTimeoutMs);
@@ -197,12 +204,12 @@ async function sidecarRequest(body: { url: string } | { path: string }): Promise
   }
 }
 
-function analyzeViaSidecar(url: string): Promise<AnalysisResult> {
-  return sidecarRequest({ url });
+function analyzeViaSidecar(url: string, opts: AnalyzeRequestOpts = {}): Promise<AnalysisResult> {
+  return sidecarRequest({ url, ...opts });
 }
 
-function analyzeViaSidecarPath(path: string): Promise<AnalysisResult> {
-  return sidecarRequest({ path });
+function analyzeViaSidecarPath(path: string, opts: AnalyzeRequestOpts = {}): Promise<AnalysisResult> {
+  return sidecarRequest({ path, ...opts });
 }
 
 // ---------------------------------------------------------------------------
@@ -232,11 +239,11 @@ export function backendLabel(): string {
 // and moves on, leaving the row NULL so it's retried on the next run. This is
 // the URL path: the backend fetches the audio itself. Kept as the fallback
 // for the prefetch pipeline (see analyzePath / downloadCapped below).
-export async function analyze(songId: string): Promise<AnalysisResult> {
+export async function analyze(songId: string, opts: AnalyzeRequestOpts = {}): Promise<AnalysisResult> {
   const backend = await resolveBackend();
   if (!backend) throw new Error('no analysis backend available');
   const url = subsonic.getRawStreamUrl(songId);
-  return backend === 'sidecar' ? analyzeViaSidecar(url) : analyzeViaLocal(url);
+  return backend === 'sidecar' ? analyzeViaSidecar(url, opts) : analyzeViaLocal(url, opts);
 }
 
 // Download a track's audio to a capped temp file on the shared state volume
@@ -288,10 +295,10 @@ export async function downloadCapped(songId: string): Promise<string> {
 // Analyse a track from an already-local file on the shared volume (produced
 // by downloadCapped). Same backend resolution as analyze(), but hands the
 // path over instead of a url so the backend skips its own fetch.
-export async function analyzePath(localPath: string): Promise<AnalysisResult> {
+export async function analyzePath(localPath: string, opts: AnalyzeRequestOpts = {}): Promise<AnalysisResult> {
   const backend = await resolveBackend();
   if (!backend) throw new Error('no analysis backend available');
-  return backend === 'sidecar' ? analyzeViaSidecarPath(localPath) : analyzeViaLocalPath(localPath);
+  return backend === 'sidecar' ? analyzeViaSidecarPath(localPath, opts) : analyzeViaLocalPath(localPath, opts);
 }
 
 export function shutdown(): void {

--- a/controller/src/routes/library.ts
+++ b/controller/src/routes/library.ts
@@ -14,6 +14,7 @@ import { tagBatch, TAGGER_BATCH_SYSTEM } from '../music/tagger-core.js';
 import { promptVocabHash } from '../music/embeddings.js';
 import { activeModelLabel } from '../llm/provider.js';
 import { queue } from '../broadcast/queue.js';
+import { tagger, startAnalyzer } from '../broadcast/tagger.js';
 
 export const router = express.Router();
 
@@ -169,6 +170,21 @@ router.get('/library/coverage', requireAdmin, async (req, res) => {
   } catch (err: any) {
     res.status(500).json({ error: err.message });
   }
+});
+
+// ---------------------------------------------------------------------------
+// POST /library/analyze — kick off the standalone analysis pass as a
+// background child (the admin "Analyze audio" button). Runs bpm/key/intro for
+// un-analysed tracks and — when audio embeddings are enabled via the settings
+// toggle or ANALYZE_AUDIO_EMBEDDING — backfills CLAP vectors for tracks that
+// lack one (--audio). Shares the tagger's single-flight state: poll /settings
+// (tagger.running / tagger.mode) for progress, stop via /tag-library/stop.
+// ---------------------------------------------------------------------------
+router.post('/library/analyze', requireAdmin, (req, res) => {
+  if (tagger.running) return res.status(409).json({ error: 'a tagger/analyzer run is already active', tagger });
+  const limit = parseIntSafe(req.body?.limit, null);
+  startAnalyzer({ limit: limit ?? undefined, audio: true });
+  res.json({ ok: true, tagger });
 });
 
 // ---------------------------------------------------------------------------

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -65,6 +65,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
         llm: s.llm,
         search: s.search,
         embedding: s.embedding,
+        audio: s.audio,
         sfx: s.sfx,
         scrobble: s.scrobble,
       },

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -501,6 +501,16 @@ const DEFAULTS = {
   skills: {
     enabled: {},
   },
+  // Audio (CLAP) "sounds-like" embeddings — drive the audio-similar picker
+  // source, the tracksThatSoundLikeThis tool and sonic journeys. When on, the
+  // analysis pass asks the backend for an embedding per track; the backend
+  // needs the CLAP stack (tts-heavy built with WITH_CLAP=1, or a local venv
+  // with torch+transformers) — without it the request is a clean no-op and
+  // the pass still fills bpm/key. ANALYZE_AUDIO_EMBEDDING=1 in the env also
+  // enables it regardless of this toggle (env wins on, never off).
+  audio: {
+    embeddings: false,
+  },
   // Sound-effects library. When disabled, the segment-director agent is never
   // shown the effect catalogue, so it stops garnishing spoken breaks with
   // stingers. The library files themselves stay on disk either way.
@@ -959,6 +969,9 @@ export async function load() {
           // existing `random-facts: false` carries forward as `curiosity: false`.
           .map(([k, v]) => [SKILL_RENAMES[k] || k, v]),
       ),
+    },
+    audio: {
+      embeddings: typeof stored.audio?.embeddings === 'boolean' ? stored.audio.embeddings : DEFAULTS.audio.embeddings,
     },
     sfx: {
       enabled: typeof stored.sfx?.enabled === 'boolean' ? stored.sfx.enabled : DEFAULTS.sfx.enabled,
@@ -1712,6 +1725,12 @@ export async function update(patch) {
         }
         next.skills.enabled[name] = on;
       }
+    }
+  }
+  if ('audio' in patch) {
+    const au = patch.audio || {};
+    if (au.embeddings !== undefined) {
+      next.audio.embeddings = !!au.embeddings;
     }
   }
   if ('sfx' in patch) {

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -385,6 +385,10 @@ class AnalyzeRequest(BaseModel):
     # the sidecar's single-threaded compute; `url` stays as the fallback.
     url: str | None = None
     path: str | None = None
+    # Per-request CLAP opt-in (the controller's admin toggle). True makes the
+    # worker lazy-load CLAP even without ANALYZE_AUDIO_EMBEDDING in its env;
+    # None keeps the worker's env-driven default.
+    embed: bool | None = None
 
 
 @app.post("/analyze")
@@ -395,6 +399,8 @@ async def analyze(req: AnalyzeRequest):
         payload = {"id": "1", "url": req.url}
     else:
         raise HTTPException(400, "missing 'url' or 'path'")
+    if req.embed is not None:
+        payload["embed"] = req.embed
     msg = await analyzer_worker.request(payload)
     if not msg.get("ok"):
         raise HTTPException(500, msg.get("error") or "analyze failed")

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -90,6 +90,9 @@ interface TaggerState {
   pid?: number;
   startedAt?: string;
   lastLog?: string[];
+  // 'tag' (tag-library) or 'analyze' (the acoustic/audio-embedding pass) —
+  // both run through the same single-flight child slot.
+  mode?: 'tag' | 'analyze' | null;
 }
 
 // libraryStats rides along on /settings — gives moods-in-use, last-tag time,
@@ -104,7 +107,12 @@ interface LibraryStatsLite {
   updatedAt: string | null;
 }
 
-interface SettingsResponse { tagger?: TaggerState; libraryStats?: LibraryStatsLite }
+interface SettingsResponse {
+  tagger?: TaggerState;
+  libraryStats?: LibraryStatsLite;
+  // Only the slice this panel needs from the full settings payload.
+  values?: { audio?: { embeddings?: boolean } };
+}
 
 type Tab = 'recent' | 'browse' | 'search' | 'untagged';
 type Sort = 'artist' | 'title' | 'year' | 'taggedAt';
@@ -172,6 +180,8 @@ export default function LibraryPanel() {
   const [libStats, setLibStats] = useState<LibraryStatsLite | null>(null);
   const [batch, setBatch] = useState<Batch>('500');
   const [taggerBusy, setTaggerBusy] = useState(false);
+  // settings.audio.embeddings — null until the first /settings poll lands.
+  const [audioEnabled, setAudioEnabled] = useState<boolean | null>(null);
   const [logOpen, setLogOpen] = useState(false);
   const [queuing, setQueuing] = useState<string | null>(null);
   const [retagging, setRetagging] = useState<string | null>(null);
@@ -230,6 +240,7 @@ export default function LibraryPanel() {
       const j = (await r.json()) as SettingsResponse;
       setTagger(j.tagger || null);
       if (j.libraryStats) setLibStats(j.libraryStats);
+      if (j.values?.audio) setAudioEnabled(!!j.values.audio.embeddings);
     } catch { /* transient */ }
   }, [adminFetch, ready]);
 
@@ -499,6 +510,51 @@ export default function LibraryPanel() {
     }
   };
 
+  // Flip settings.audio.embeddings — the "sounds-like" (CLAP) opt-in. The
+  // toggle only persists the setting; vectors appear after an analysis run.
+  const toggleAudio = async () => {
+    if (audioEnabled == null) return;
+    setTaggerBusy(true);
+    try {
+      const r = await adminFetch('/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ audio: { embeddings: !audioEnabled } }),
+      });
+      const j = await r.json().catch(() => ({})) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `save failed (${r.status})`);
+      setAudioEnabled(!audioEnabled);
+      notify.ok(!audioEnabled ? 'sounds-like analysis enabled' : 'sounds-like analysis disabled');
+    } catch (err) {
+      notify.err(errorMessage(err));
+    } finally {
+      setTaggerBusy(false);
+    }
+  };
+
+  // Run the analysis pass (bpm/key + audio fingerprints) as a background
+  // child — same single-flight state as the tagger, so the running view and
+  // stop button below cover it too.
+  const analyzeAudio = async () => {
+    setTaggerBusy(true);
+    try {
+      const r = await adminFetch('/library/analyze', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      const j = await r.json().catch(() => ({})) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `analysis start failed (${r.status})`);
+      notify.ok('audio analysis started');
+      setLogOpen(true);
+      await loadTagger();
+    } catch (err) {
+      notify.err(errorMessage(err));
+    } finally {
+      setTaggerBusy(false);
+    }
+  };
+
   // -----------------------------------------------------------------------
   // derived
   // -----------------------------------------------------------------------
@@ -547,6 +603,9 @@ export default function LibraryPanel() {
         onStart={startTagger}
         onStop={stopTagger}
         onRescan={rescanTagger}
+        audioEnabled={audioEnabled}
+        onToggleAudio={toggleAudio}
+        onAnalyzeAudio={analyzeAudio}
       />
 
       <Tabs tab={tab} setTab={setTab} counts={counts} />
@@ -695,6 +754,10 @@ interface TaggingPanelProps {
   onStart: () => void;
   onStop: () => void;
   onRescan: (opts: RescanOpts) => void;
+  // sounds-like (CLAP) controls — null until the first settings poll lands.
+  audioEnabled: boolean | null;
+  onToggleAudio: () => void;
+  onAnalyzeAudio: () => void;
 }
 
 function TaggingPanel(p: TaggingPanelProps) {
@@ -813,14 +876,32 @@ function TaggingPanel(p: TaggingPanelProps) {
           <span className="lib-opt-tag">optional</span>
           <span className="lib-minibar"><span ref={audioFillRef} /></span>
           <span className="caption mono-num !tracking-[0.04em]">
-            {analysisOff ? 'engine off' : audioOn ? <>{num(audioEmbedded)} / {num(total)} · {audpct != null ? `${audpct}%` : '…'}</> : 'not enabled'}
+            {analysisOff
+              ? 'engine off'
+              : audioOn
+                ? <>{num(audioEmbedded)} / {num(total)} · {audpct != null ? `${audpct}%` : '…'}</>
+                : p.audioEnabled ? 'enabled — not yet analysed' : 'off'}
           </span>
+          {!analysisOff && p.audioEnabled != null && (
+            <span className="flex items-center gap-2">
+              {p.audioEnabled && (
+                <Btn sm tone="accent" onClick={p.onAnalyzeAudio} disabled={running || p.busy}>
+                  <Play size={12} /> {audioOn ? 'Analyze new tracks' : 'Analyze library'}
+                </Btn>
+              )}
+              <Btn sm onClick={p.onToggleAudio} disabled={running || p.busy}>
+                {p.audioEnabled ? 'Disable' : 'Enable'}
+              </Btn>
+            </span>
+          )}
           <span className="caption basis-full !tracking-[0.04em] !normal-case">
             {analysisOff
               ? 'Needs the analysis engine above.'
               : audioOn
-                ? 'CLAP audio embeddings power “sounds-like” picks — catches sonic neighbours that metadata misses.'
-                : 'Set ANALYZE_AUDIO_EMBEDDING=1 on the analysis backend, then re-run analysis with --audio to add CLAP “sounds-like” embeddings.'}
+                ? 'CLAP audio embeddings power “sounds-like” picks and sonic journeys — they catch sonic neighbours that metadata misses.'
+                : p.audioEnabled
+                  ? 'Run the analysis to fingerprint your tracks. The engine needs the CLAP model — if the bar stays at 0 after a run, rebuild the tts-heavy sidecar with WITH_CLAP=1.'
+                  : 'Listens to each track and fingerprints how it actually sounds, enabling “sounds-like” picks and sonic journeys. Adds a one-off analysis pass over your library.'}
           </span>
         </div>
       </div>
@@ -853,7 +934,7 @@ function TaggingPanel(p: TaggingPanelProps) {
         <div className="flex flex-col gap-3 p-6">
           <div className="flex flex-wrap items-center justify-between gap-3.5">
             <span className="flex items-center gap-2.5 text-[13px] font-bold">
-              <span className="lib-livedot" /> Tagging in progress…
+              <span className="lib-livedot" /> {p.tagger?.mode === 'analyze' ? 'Audio analysis in progress…' : 'Tagging in progress…'}
             </span>
             <span className="caption mono-num !tracking-[0.04em]">
               {processed != null && <>{num(processed)}{p.runInfo?.target ? ` / ${num(p.runInfo.target)}` : ''} this run · </>}
@@ -866,8 +947,9 @@ function TaggingPanel(p: TaggingPanelProps) {
             <div className="lib-bar !h-1.5"><span ref={runFillRef} /></div>
           )}
           <div className="caption !tracking-[0.04em] !normal-case">
-            The DJ is listening to each new track and deciding its mood &amp; energy. You can keep
-            browsing — this runs in the background.
+            {p.tagger?.mode === 'analyze'
+              ? <>The analysis engine is listening to each track — measuring tempo and key, and fingerprinting how it sounds. You can keep browsing — this runs in the background.</>
+              : <>The DJ is listening to each new track and deciding its mood &amp; energy. You can keep browsing — this runs in the background.</>}
           </div>
         </div>
       )}


### PR DESCRIPTION
## What

Two follow-ups that finish #337 for a default config — stacked on `claude/subwave-audio-embeddings-lhq00w`, so the diff here is just these commits.

### 1. Sonic journeys now steer the agent picker

#337 computed the journey waypoint but only the pool fallback consumed it — with `pickerAgent` on (the default), `advanceRun` burned a run step per track while steering nothing. The agent can't read a 512-d vector from prose, so the waypoint now registers a **`tracksTowardJourney` tool** closed over it: the agent calls it, gets the tracks nearest the arc's current step, and the pick event instructs it to strongly prefer one while a journey is active ("never mention the journey on air"). The clause is gated on the waypoint rather than `runActive()` because the final pick's waypoint — the destination itself — arrives after the run state clears.

### 2. Audio embeddings become an admin-discoverable feature

Enabling was operator-only: edit `.env`, rebuild, run a CLI. Now the **Audio fingerprint · sounds-like** row in `/admin/library` carries:

- an **Enable/Disable toggle** → `settings.audio.embeddings` (new settings group, default off, `ANALYZE_AUDIO_EMBEDDING` env still wins in the ON direction);
- an **Analyze library / Analyze new tracks** button → `POST /library/analyze`, which runs `analyze-library --audio` as a background child through the tagger's existing single-flight slot (`tagger.mode: 'tag' | 'analyze'` labels the running view; the same Stop button and log viewer cover it);
- honest status copy for every state: engine off / feature off / enabled-but-unanalysed (including "rebuild the sidecar with `WITH_CLAP=1`" when a run produces 0 vectors).

The toggle works without touching the backend's env: the controller sends `embed: true` per analyze request and the worker **lazy-loads CLAP on demand** (`get_embedder(force=…)`); a `WITH_CLAP` image is still required for the deps — without them the load fails cleanly and the pass still fills bpm/key.

## Notes

- The first toggle-driven request can exceed the analyze request timeout while the model downloads; per-track failures are already retryable and the HF cache volume (added on #337) makes the download one-time.
- The analyzer child reuses the tagger's single-flight state on purpose — both contend on the library DB and the same analysis backend.

## Testing

- `npm run lint` passes for controller and web (0 errors); both Python files compile.
- Not yet exercised against live CLAP weights — same caveat as #337; first real check is toggling on in admin, hitting Analyze, and watching the fingerprint bar climb.
