### PR TITLE
feat(controller): operator-configurable DJ-agent deadline (default 45s)

### DIFF
--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -254,14 +254,22 @@ function breakerFailure(queue: any) {
 // without drifting. The hard timeout is what fails fast into the stateless
 // fallback below instead of dragging on a pathological model call — enforced
 // by withDeadline in llm/sdk.ts (main + recovery runs each get the full
-// budget, so worst case per agent call is ~2× this).
+// budget, so worst case per agent call is ~2× this). It comes from
+// settings.llm.agentTimeoutMs (default 45s, admin-tunable) — slow
+// reasoning-heavy cloud models routinely need 20-40s per pick, and a pick has
+// a whole track length of slack; the deadline exists to contain the unbounded
+// 60s+ stalls (#352), not to demand snappy answers.
+function agentDeadline(): number {
+  return settings.get().llm?.agentTimeoutMs ?? 45000;
+}
+
 export const pickerAgent = defineAgent({
   kind: 'djAgentPick',
   schema: PICK_SCHEMA,
   // The done-tool path ends the loop at step 1 (COMMIT_AFTER_STEPS in sdk.js)
   // on every provider now; maxSteps is just the backstop.
   maxSteps: 4,
-  timeoutMs: 22000,
+  timeoutMs: agentDeadline,
   buildSystem: () => pickSystem(),
   buildTools: ({ recentIds, recentKeys, recentArtists, audioWaypoint }) => {
     const { tools, seen } = buildPickerTools({ recentIds, recentKeys, recentArtists, audioWaypoint });
@@ -273,7 +281,7 @@ export const requestAgent = defineAgent({
   kind: 'djAgentRequest',
   schema: REQUEST_SCHEMA,
   maxSteps: 4,
-  timeoutMs: 22000,
+  timeoutMs: agentDeadline,
   buildSystem: () => requestSystem(),
   // recentArtists deliberately empty — a request for a recently-played artist
   // must still resolve.

--- a/controller/src/llm/agent.ts
+++ b/controller/src/llm/agent.ts
@@ -27,7 +27,10 @@ export interface AgentDefinition {
   buildSystem: (args: any) => string;
   buildTools?: (args: any) => { tools: any; extras?: any };
   maxSteps?: number;
-  timeoutMs?: number;
+  // A function form is resolved at each run, so the deadline can follow a
+  // live setting (settings.llm.agentTimeoutMs) instead of being frozen at
+  // module load.
+  timeoutMs?: number | (() => number);
   temperature?: number;
   maxOutputTokens?: number;
 }
@@ -49,12 +52,20 @@ export interface DjAgentInstance {
   run(args: { messages: any[] } & Record<string, any>): Promise<AgentRunResult>;
 }
 
+function resolveTimeout(t: number | (() => number) | undefined): number | undefined {
+  return typeof t === 'function' ? t() : t;
+}
+
 export function defineAgent(def: AgentDefinition): DjAgentInstance {
   return {
     kind: def.kind,
     schema: def.schema,
     maxSteps: def.maxSteps,
-    timeoutMs: def.timeoutMs,
+    // Resolved on read so consumers (picker-test.mjs) always see a number
+    // matching what the next run would use.
+    get timeoutMs() {
+      return resolveTimeout(def.timeoutMs);
+    },
     temperature: def.temperature,
     maxOutputTokens: def.maxOutputTokens,
     async run({ messages, ...toolArgs }) {
@@ -66,7 +77,7 @@ export function defineAgent(def: AgentDefinition): DjAgentInstance {
         tools: built.tools,
         schema: def.schema,
         maxSteps: def.maxSteps,
-        timeoutMs: def.timeoutMs,
+        timeoutMs: resolveTimeout(def.timeoutMs),
         temperature: def.temperature,
         maxOutputTokens: def.maxOutputTokens,
         kind: def.kind,

--- a/controller/src/llm/sdk.ts
+++ b/controller/src/llm/sdk.ts
@@ -607,7 +607,8 @@ export async function djObject({
 //   openrouter:claude-haiku-4.5  Output.object 0/n  "No output generated" (#300)
 // (An earlier table here recorded these models passing 5/5 on Output.object;
 // that no longer reproduces on ai@6 — an SDK-version drift, per #300.)
-// The Ollama latency p95s exceed the picker's 22s `timeoutMs` ceiling;
+// The Ollama latency p95s can exceed the picker's `timeoutMs` ceiling
+// (settings.llm.agentTimeoutMs, default 45s);
 // agent.generate({ timeout }) is not honoured by the ai-sdk-ollama transport,
 // so the ceiling is enforced here via withDeadline (Promise.race + abort
 // signal) around each generation — main run and recovery run each get the

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -111,6 +111,15 @@ function clampNumCtx(raw: any, def: number): number {
   return Math.min(131072, Math.max(2048, Math.floor(raw)));
 }
 
+// Coerce a stored agent-deadline value (ms). Clamped to [5s, 180s] and floored
+// to an integer; non-numeric/NaN falls back to `def`. The lower bound keeps a
+// fat-fingered save from making every agent pick fail instantly; the upper
+// bound keeps a stalling model from tying up an inference slot for minutes.
+function clampAgentTimeout(raw: any, def: number): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return def;
+  return Math.min(180_000, Math.max(5_000, Math.floor(raw)));
+}
+
 // Validate + apply the connection fields shared by the primary LLM leg and its
 // optional fallback (provider/model/apiKey/ollamaUrl/baseUrl/reasoning/numCtx).
 // `target` is the live settings sub-object to mutate; `patch` is the incoming
@@ -435,6 +444,13 @@ const DEFAULTS = {
     // dj-agent.js). When off, the stateless pool picker runs instead — still
     // inside a session, still logged, just without the conversational loop.
     pickerAgent: true,
+    // Hard wall-clock ceiling (ms) on a single DJ-agent generation (track
+    // picks and listener requests). Enforced by withDeadline in llm/sdk.ts;
+    // the main and recovery runs each get the full budget, so worst case per
+    // pick is ~2× this before the stateless fallback takes over. Raise it for
+    // slow models (reasoning-heavy cloud models routinely need 20-40s per
+    // pick); lower it if you want snappier fallbacks.
+    agentTimeoutMs: 45000,
     // When on, autonomous DJ LLM work (track picks, links, station IDs,
     // hourly checks, segments) and listener requests pause whenever Icecast
     // reports zero listeners — the stream coasts on the auto playlist — and
@@ -886,6 +902,9 @@ export async function load() {
         typeof stored.llm?.pickerAgent === 'boolean'
           ? stored.llm.pickerAgent
           : DEFAULTS.llm.pickerAgent,
+      // Clamped to [5s, 180s]; settings.json files from before the field
+      // existed pick up the default.
+      agentTimeoutMs: clampAgentTimeout(stored.llm?.agentTimeoutMs, DEFAULTS.llm.agentTimeoutMs),
       pauseWhenEmpty:
         typeof stored.llm?.pauseWhenEmpty === 'boolean'
           ? stored.llm.pauseWhenEmpty
@@ -1606,6 +1625,9 @@ export async function update(patch) {
     applyLlmLegPatch(next.llm, l, 'llm');
     if (l.pickerAgent !== undefined) {
       next.llm.pickerAgent = !!l.pickerAgent;
+    }
+    if (l.agentTimeoutMs !== undefined) {
+      next.llm.agentTimeoutMs = clampAgentTimeout(Number(l.agentTimeoutMs), next.llm.agentTimeoutMs);
     }
     if (l.pauseWhenEmpty !== undefined) {
       next.llm.pauseWhenEmpty = !!l.pauseWhenEmpty;

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -107,6 +107,7 @@ interface LlmForm {
   baseUrl: string;
   reasoning: boolean;
   pickerAgent: boolean;
+  agentTimeoutMs: number;
   pauseWhenEmpty: boolean;
   fallback: LlmFallbackForm;
 }
@@ -348,6 +349,7 @@ export default function SettingsPanel() {
         baseUrl: v.llm?.baseUrl ?? '',
         reasoning: !!v.llm?.reasoning,
         pickerAgent: !!v.llm?.pickerAgent,
+        agentTimeoutMs: typeof v.llm?.agentTimeoutMs === 'number' ? v.llm.agentTimeoutMs : 45000,
         pauseWhenEmpty: !!v.llm?.pauseWhenEmpty,
         fallback: {
           enabled: !!v.llm?.fallback?.enabled,
@@ -1496,6 +1498,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
       baseUrl: form.llm.baseUrl,
       reasoning: form.llm.reasoning,
       pickerAgent: form.llm.pickerAgent,
+      agentTimeoutMs: form.llm.agentTimeoutMs,
       pauseWhenEmpty: form.llm.pauseWhenEmpty,
       fallback: {
         enabled: form.llm.fallback.enabled,
@@ -1886,6 +1889,30 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
             onChange={v => setForm(f => ({ ...f, llm: { ...f.llm, pickerAgent: v === 'agent' } }))}
           />
         </div>
+
+        {form.llm.pickerAgent && (
+          <div className="field mt-4">
+            <Label>Agent deadline (seconds)</Label>
+            <Input
+              type="number"
+              min={5}
+              max={180}
+              step={5}
+              value={Math.round(form.llm.agentTimeoutMs / 1000)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setForm(f => ({ ...f, llm: { ...f.llm, agentTimeoutMs: Number(e.target.value) * 1000 } }))
+              }
+              placeholder="45"
+              className="max-w-[200px]"
+            />
+            <div className="field-hint">
+              How long an agent pick or listener request may run before falling
+              back to the stateless picker. Slow reasoning models often need
+              20&ndash;40s per pick; lower it for snappier fallbacks on a fast
+              model. 5&ndash;180s.
+            </div>
+          </div>
+        )}
       </Card>
 
       <Card title="Idle behaviour" sub="when no one's listening">


### PR DESCRIPTION
## Why

The agent deadline shipped in #352 hard-coded 22s. Slow reasoning-heavy cloud models (`minimax-m2.7:cloud` observed live) routinely need 20–45s per pick: in one day **23 of 28 agent picks died on the 22s deadline**, even successful picks had a median of 21.7s, and the circuit breaker tripped 6× in 6h — keeping the session-aware picker effectively offline while the model would have completed fine with a little more room.

A pick has a whole track length of slack before it's needed. The deadline exists to contain the unbounded 60s+ stalls #352 was written for, not to demand snappy answers — so make the budget operator-tunable instead of fixed.

## What

- **settings**: new `llm.agentTimeoutMs` — default **45000ms**, clamped to [5s, 180s] (`clampAgentTimeout`), validated in `update()`, defaulted on `load()` so existing `settings.json` files pick it up automatically. Station-level like `pickerAgent`, not per-leg.
- **llm/agent**: `defineAgent`'s `timeoutMs` accepts `number | (() => number)`, resolved at each run — setting changes apply live, no restart. Exposed as a resolving getter so `picker-test.mjs`'s `pickerAgent.timeoutMs` read keeps working unchanged.
- **dj-agent**: `pickerAgent` and `requestAgent` share the setting via `agentDeadline()` (they run the same model through the same harness and feed the same breaker).
- **admin UI**: "Agent deadline (seconds)" number input in the Agentic picker card, shown when agent mode is on, stored as ms.

Worst case per agent call remains ~2× the deadline (main + recovery runs each get the full budget), and deadline errors still deliberately don't look host-unreachable, so they fall back to the stateless pool rather than failing over to the backup LLM leg.

## Verified on the live station

- `npm run lint` clean in `controller/` and `web/`
- API round-trip: save 60000 → persisted; save 1000 → clamped to 5000; `GET /settings` shows the value in both `values.llm` and `defaults.llm`
- First live pick after deploy completed at **21.3s, ok** — a coin flip under the old 22s ceiling, comfortable under 45s