### PR TITLE
feat: parallel dual-LLM library tagging + num_ctx debug visibility

### DIFF
--- a/controller/src/llm/provider.ts
+++ b/controller/src/llm/provider.ts
@@ -217,6 +217,34 @@ export function activeOllamaUrl() {
   return ollamaBaseUrl(llmCfg());
 }
 
+// Cheap liveness check for a leg's host, used by the dual-LLM tagger to decide
+// whether to spin up a second consumer before committing a long run to it
+// (discussion #320). A self-hosted box that's switched off should fail fast here
+// rather than after a batch of connect timeouts. Any HTTP answer — even 401/404
+// — means the host is up; only a connection/DNS/timeout failure is "down". Cloud
+// providers can't be cheaply probed and are assumed reachable; an outage there
+// surfaces mid-run and the consumer is dropped then.
+export async function probeLegReachable(leg: Leg, timeoutMs = 3000): Promise<boolean> {
+  const cfg = leg?.cfg;
+  if (!cfg) return false;
+  let url: string;
+  if (cfg.provider === 'ollama') {
+    url = `${ollamaBaseUrl(cfg).replace(/\/$/, '')}/api/version`;
+  } else if (cfg.provider === 'openai-compatible') {
+    if (!cfg.baseUrl) return false;
+    url = `${cfg.baseUrl.replace(/\/$/, '')}/models`;
+  } else {
+    // Hosted provider — no cheap local probe; assume up.
+    return true;
+  }
+  try {
+    await fetch(url, { method: 'GET', signal: AbortSignal.timeout(timeoutMs) });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Embedding models
 // ---------------------------------------------------------------------------

--- a/controller/src/llm/sdk.ts
+++ b/controller/src/llm/sdk.ts
@@ -125,6 +125,35 @@ function usageOf(result) {
 // - DeepSeek / OpenRouter / Gateway: no first-class knob. DeepSeek picks
 //   reasoning by model variant (deepseek-reasoner vs -chat); OpenRouter and
 //   Gateway pass through to the underlying provider's defaults.
+// The num_ctx that will actually be sent for this leg, or null when none is.
+// num_ctx is for LOCAL Ollama only: Ollama's default window is 4096, but the DJ
+// agent feeds ~8k+ per turn (40-turn session window + tool schemas + discovery
+// results); the default truncates the front of the prompt — dropping the system
+// instructions and tool defs — so the model never calls `done` (issue #291).
+// `:cloud` models run on Ollama's servers and manage their own context, so skip
+// them. 0 → don't send it (use Ollama's default). One source of truth so the
+// value sent (providerOpts) and the value recorded (samplingWithNumCtx) can't
+// drift — a per-leg report, so a primary→fallback switch is attributed honestly
+// (discussion #320).
+function appliedNumCtx(cfg: any): number | null {
+  const llm = cfg || {};
+  const model = llm.model || '';
+  const numCtx = Number(llm.numCtx);
+  if (llm.provider === 'ollama' && !/:cloud$/i.test(model) && Number.isFinite(numCtx) && numCtx > 0) {
+    return numCtx;
+  }
+  return null;
+}
+
+// Add the leg's effective num_ctx to a sampling record when one was sent, so
+// /admin/debug shows the context window each call actually ran with. Mirrors how
+// repeat_penalty is conditionally recorded.
+function samplingWithNumCtx(cfg: any, sampling: any): any {
+  const n = appliedNumCtx(cfg);
+  if (n != null) sampling.num_ctx = n;
+  return sampling;
+}
+
 function providerOpts(cfg: any, { repeatPenalty = null }: { repeatPenalty?: number | null } = {}) {
   const llm = cfg || {};
   const reasoning = llm.reasoning === true;
@@ -134,16 +163,8 @@ function providerOpts(cfg: any, { repeatPenalty = null }: { repeatPenalty?: numb
   const ollama: any = { think: reasoning };
   const ollamaOptions: any = {};
   if (repeatPenalty != null) ollamaOptions.repeat_penalty = repeatPenalty;
-  // num_ctx for LOCAL Ollama only. Ollama's default window is 4096, but the DJ
-  // agent feeds ~8k+ per turn (40-turn session window + tool schemas + discovery
-  // results); the default truncates the front of the prompt — dropping the
-  // system instructions and tool defs — so the model never calls `done` (issue
-  // #291). `:cloud` models run on Ollama's servers and manage their own context,
-  // so skip them. 0 → don't send it (use Ollama's default).
-  const numCtx = Number(llm.numCtx);
-  if (llm.provider === 'ollama' && !/:cloud$/i.test(model) && Number.isFinite(numCtx) && numCtx > 0) {
-    ollamaOptions.num_ctx = numCtx;
-  }
+  const numCtx = appliedNumCtx(llm);
+  if (numCtx != null) ollamaOptions.num_ctx = numCtx;
   if (Object.keys(ollamaOptions).length > 0) ollama.options = ollamaOptions;
   opts.ollama = ollama;
 
@@ -347,7 +368,7 @@ function withDeadline<T>(ms: number | undefined, label: string, fn: (signal?: Ab
 const UNREACHABLE_CODE = new Set([
   'ECONNREFUSED', 'ENOTFOUND', 'EAI_AGAIN', 'ETIMEDOUT', 'UND_ERR_CONNECT_TIMEOUT',
 ]);
-function isUnreachable(err: any): boolean {
+export function isUnreachable(err: any): boolean {
   if (!err) return false;
   const code = err.code ?? err.cause?.code;
   if (typeof code === 'string' && UNREACHABLE_CODE.has(code)) return true;
@@ -370,11 +391,32 @@ function isUnreachable(err: any): boolean {
 // written exactly once per primitive with the leg that actually ran. On a
 // failover the primary's failure is also recorded (via `…:failover→<backup>`)
 // so /debug shows the switch happened.
+// `pin` overrides leg selection: instead of trying the primary and failing over,
+// the call runs exactly once against the named leg with NO cross-leg failover —
+// any error propagates so the caller can manage its own leg (the library tagger
+// pins one consumer per leg, discussion #320). Records carry a `…:pinned` via
+// suffix so /stats' exact-match buckets stay untouched. Unpinned calls are the
+// untouched primary→fallback path.
 async function withFailover<T>(
   kind: string,
   failExtra: (err: any) => any,
   attempt: (leg: any) => Promise<{ value: T; via: string; sampling?: any; usage?: any; extra?: any }>,
+  pin?: 'primary' | 'fallback',
 ): Promise<T> {
+  if (pin) {
+    const leg = pin === 'fallback' ? fallbackLeg() : primaryLeg();
+    if (!leg) throw new Error(`withFailover: pinned leg "${pin}" is not configured`);
+    const started = Date.now();
+    try {
+      const r = await attempt(leg);
+      recordSuccess({ kind, started, via: `${r.via}:pinned`, model: leg.label, sampling: r.sampling, usage: r.usage, extra: r.extra });
+      return r.value;
+    } catch (err: any) {
+      logFailurePreview(kind, err);
+      recordFailure({ kind, started, via: `${err?.__via || 'ai-sdk'}:pinned`, model: leg.label, error: err?.message, extra: failExtra(err) });
+      throw err;
+    }
+  }
   const primary = primaryLeg();
   const primaryStarted = Date.now();
   try {
@@ -462,6 +504,7 @@ export async function djText({
       // repeatPenaltyApplies() and providerOptions handling above.
       const sampling: any = { temperature, top_p: topP, seed };
       if (repeatPenaltyApplies(leg.cfg)) sampling.repeat_penalty = repeatPenalty;
+      samplingWithNumCtx(leg.cfg, sampling);
       return {
         value: out,
         via: 'ai-sdk',
@@ -494,11 +537,12 @@ export async function djObject({
   temperature = 0.4,
   maxOutputTokens = MAX_TOKENS_OBJECT,
   kind = 'sdk.djObject',
+  leg = undefined,
 }: any) {
   return withFailover(
     kind,
     (err) => ({ user: prompt, ...failureDiagnostics(err) }),
-    async (leg) => {
+    async (l) => {
       let lastErr;
       // Track the strategy actually attempted so a failure record attributes to
       // the right sub-path — bucketing every failure as 'ai-sdk' hides which
@@ -508,32 +552,32 @@ export async function djObject({
         try {
           let object;
           let usage;
-          if (attempt === 1 && needsToolCallObject(leg.cfg)) {
+          if (attempt === 1 && needsToolCallObject(l.cfg)) {
             lastVia = 'ai-sdk:tool';
             ({ object, usage } = await withTransientRetry(kind,
-              () => objectViaToolCall(leg, { system, prompt, schema, temperature, maxOutputTokens })));
+              () => objectViaToolCall(l, { system, prompt, schema, temperature, maxOutputTokens })));
           } else if (attempt === 1) {
             lastVia = 'ai-sdk';
             const result = await withTransientRetry(kind, () => generateText({
-              model: leg.model,
+              model: l.model,
               system,
               prompt,
               temperature,
               maxOutputTokens,
               output: Output.object({ schema }),
-              providerOptions: providerOpts(leg.cfg),
+              providerOptions: providerOpts(l.cfg),
             }));
             object = result.output;
             usage = usageOf(result);
           } else {
             lastVia = 'ai-sdk:recovery';
             const result = await withTransientRetry(kind, () => generateText({
-              model: leg.model,
+              model: l.model,
               system,
               prompt: `${prompt}\n\nRespond with a single JSON object only — no prose, no markdown fences.`,
               temperature,
               maxOutputTokens,
-              providerOptions: providerOpts(leg.cfg),
+              providerOptions: providerOpts(l.cfg),
             }));
             object = schema.parse(JSON.parse(extractJson(stripThinking(result.text))));
             usage = usageOf(result);
@@ -541,7 +585,7 @@ export async function djObject({
           return {
             value: object,
             via: lastVia,
-            sampling: { temperature },
+            sampling: samplingWithNumCtx(l.cfg, { temperature }),
             usage,
             // Full, untruncated — the /debug surface shows the whole system prompt.
             extra: { system, user: prompt, response: JSON.stringify(object).slice(0, 500) },
@@ -556,6 +600,7 @@ export async function djObject({
       (lastErr as any).__via = lastVia;
       throw lastErr;
     },
+    leg,
   );
 }
 
@@ -645,7 +690,7 @@ export async function djAgent({
         return {
           value: { object, steps: 0, toolCalls: [] },
           via: lastVia,
-          sampling: { temperature },
+          sampling: samplingWithNumCtx(leg.cfg, { temperature }),
           usage,
           extra: { system, messages, toolCalls: [], steps: 0, response: JSON.stringify(object, null, 2) },
         };
@@ -789,7 +834,7 @@ export async function djAgent({
       return {
         value: { object, steps, toolCalls },
         via: lastVia,
-        sampling: { temperature },
+        sampling: samplingWithNumCtx(leg.cfg, { temperature }),
         usage: usageOf(result),
         // Full, untruncated — the agent's entire input and trail.
         extra: {

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -31,7 +31,8 @@ import { vote } from './tag-propagator.js';
 import { config } from '../config.js';
 import { loadSecretsIntoEnv } from '../setup/secrets.js';
 import { loadSetupConfig } from '../setup/config.js';
-import { activeModelLabel } from '../llm/provider.js';
+import { activeModelLabel, primaryLeg, fallbackLeg, probeLegReachable } from '../llm/provider.js';
+import { isUnreachable } from '../llm/sdk.js';
 import { tagBatch, tagOne, TAGGER_BATCH_SYSTEM, type TagResult } from './tagger-core.js';
 import { runAnalysisPass } from './analyze.js';
 
@@ -172,6 +173,14 @@ async function main() {
   const promptHash = embeddings.promptVocabHash(TAGGER_BATCH_SYSTEM);
   const modelLabel = activeModelLabel();
 
+  // Single- vs dual-LLM tagging. Decided once and shared by the seed + active-
+  // learn phases. Probed here (not per phase) so the banner prints once.
+  const tagConsumers = await resolveTagConsumers();
+  const byLeg: Record<string, number> = {};
+  const mergeByLeg = (m: Record<string, number>) => {
+    for (const [k, v] of Object.entries(m)) byLeg[k] = (byLeg[k] || 0) + v;
+  };
+
   // ---- Phase A: iterate Navidrome and upsert track metadata into DB ------
   // Cheap; ensures every Navidrome song is in the tracks table so subsequent
   // phases can operate purely off SQL.
@@ -265,15 +274,16 @@ async function main() {
   let llmCalls = 0;
   let llmTagged = 0;
   if (seedSelection.seeds.length > 0) {
-    const tagged = await llmTagInBatches(seedSelection.seeds, flags.batchSize, promptHash, modelLabel, 'llm');
+    const tagged = await llmTagInBatches(seedSelection.seeds, flags.batchSize, promptHash, 'llm', tagConsumers);
     llmCalls += tagged.callCount;
     llmTagged += tagged.tagged;
+    mergeByLeg(tagged.byLeg);
     console.log(`[tag] phase-2 done: ${tagged.tagged}/${seedSelection.seeds.length} seeded`);
   }
 
   if (flags.noPropagate) {
     console.log('[tag] --no-propagate: stopping after seed phase');
-    return finish(startedAt, llmCalls, llmTagged);
+    return finish(startedAt, llmCalls, llmTagged, byLeg);
   }
 
   // ---- Phase 3: PROPAGATE ------------------------------------------------
@@ -326,11 +336,12 @@ async function main() {
       uncertain,
       flags.batchSize,
       promptHash,
-      modelLabel,
       'uncertain-llm',
+      tagConsumers,
     );
     llmCalls += tagged.callCount;
     llmTagged += tagged.tagged;
+    mergeByLeg(tagged.byLeg);
 
     // Re-propagate over any tracks in scope still untagged after this LLM round.
     let extra = 0;
@@ -394,18 +405,22 @@ async function main() {
     }
   }
 
-  finish(startedAt, llmCalls, llmTagged);
+  finish(startedAt, llmCalls, llmTagged, byLeg);
 }
 
 function autoSeedCount(librarySize: number): number {
   return Math.max(200, Math.ceil(Math.sqrt(librarySize)));
 }
 
-function finish(startedAt: number, llmCalls: number, llmTagged: number) {
+function finish(startedAt: number, llmCalls: number, llmTagged: number, byLeg: Record<string, number>) {
   const elapsed = (Date.now() - startedAt) / 1000;
   console.log(
     `\n[tag] done in ${elapsed.toFixed(0)}s. llm_calls=${llmCalls} llm_tagged=${llmTagged}`,
   );
+  const legs = Object.entries(byLeg);
+  if (legs.length > 1) {
+    console.log(`[tag] per-leg: ${legs.map(([m, n]) => `${m}=${n}`).join(' · ')}`);
+  }
   console.log('[stats]', JSON.stringify(db.stats(), null, 2));
 }
 
@@ -532,69 +547,185 @@ async function phaseEmbed(targetIds: string[], batchSize: number): Promise<void>
 // LLM tagging helper (reused by phase 2 + phase 4)
 // ---------------------------------------------------------------------------
 
+// A single LLM worker the batch loop pulls through. `pin` selects which leg
+// each call targets (undefined → normal primary→fallback failover, used in
+// single-LLM mode); `label` is stamped on every track this consumer tags so the
+// per-track provenance is honest across two different models (discussion #320).
+interface TagConsumer {
+  pin?: 'primary' | 'fallback';
+  label: string;
+}
+
+interface TagState {
+  tagged: number;
+  callCount: number;
+  processed: number;
+  byLeg: Record<string, number>;
+}
+
+// Tag one batch with one consumer's leg. Returns the count actually tagged.
+// Throws ONLY when a pinned leg's host is unreachable — the caller requeues the
+// whole batch and drops the consumer. Upserts happen only after the batch fully
+// resolves, so a rethrow mid-batch persists nothing: the requeue is lossless.
+// Non-unreachable failures (small models dropping list entries) salvage per
+// track exactly as before, so one bad line never sinks 25 tracks.
+async function processBatch(
+  batch: string[],
+  consumer: TagConsumer,
+  promptHash: string,
+  source: db.TagSource,
+  state: TagState,
+): Promise<number> {
+  const songs = batch.map(id => db.getTrack(id)).filter((t): t is db.TrackRecord => !!t);
+  if (songs.length === 0) return 0;
+  const input = songs.map(t => ({
+    title: t.title ?? undefined,
+    artist: t.artist ?? undefined,
+    album: t.album ?? undefined,
+    year: t.year ?? undefined,
+    genre: t.genre ?? undefined,
+  }));
+  const opts = consumer.pin ? { leg: consumer.pin } : {};
+
+  let results: Array<TagResult | null>;
+  try {
+    results = await tagBatch(input, opts);
+    state.callCount += 1;
+  } catch (err: any) {
+    // A pinned leg whose host went down: rethrow BEFORE the per-track salvage,
+    // otherwise we'd grind 25 serial connect-timeouts against a dead box. The
+    // surviving consumer redoes the requeued batch.
+    if (consumer.pin && isUnreachable(err)) throw err;
+    console.error(
+      `[tag] LLM batch failed (${songs.length} tracks) on ${consumer.label}: ${err.message} — falling back to per-track`,
+    );
+    results = [];
+    for (const song of input) {
+      try {
+        results.push(await tagOne(song, opts));
+        state.callCount += 1;
+      } catch (oneErr: any) {
+        // Host died mid-salvage — bail the whole batch (nothing upserted yet).
+        if (consumer.pin && isUnreachable(oneErr)) throw oneErr;
+        console.error(`[tag] per-track tag failed on ${consumer.label}: ${oneErr.message}`);
+        results.push(null);
+      }
+    }
+  }
+
+  let tagged = 0;
+  for (let j = 0; j < songs.length; j++) {
+    const result = results[j];
+    if (!result) continue;
+    const { moods, energy } = result;
+    db.upsertTrackTags(songs[j].id, {
+      moods,
+      energy,
+      source,
+      confidence: null,
+      promptHash,
+      model: consumer.label,
+    });
+    tagged += 1;
+  }
+  return tagged;
+}
+
+// Drain the shared `batches` queue with one consumer. `shift()` between awaits
+// is atomic (single-threaded event loop), so two consumers never pull the same
+// batch. In dual mode a pinned consumer whose host dies requeues its batch and
+// returns; `onDrop` reports how many legs remain.
+async function runConsumer(
+  batches: string[][],
+  consumer: TagConsumer,
+  promptHash: string,
+  source: db.TagSource,
+  total: number,
+  state: TagState,
+  onDrop: (() => number) | null,
+): Promise<void> {
+  for (;;) {
+    const batch = batches.shift();
+    if (!batch) return;
+    try {
+      const n = await processBatch(batch, consumer, promptHash, source, state);
+      state.tagged += n;
+      state.byLeg[consumer.label] = (state.byLeg[consumer.label] || 0) + n;
+    } catch {
+      // processBatch only throws on a pinned-leg host outage.
+      batches.unshift(batch);
+      const remaining = onDrop ? onDrop() : 0;
+      console.log(
+        `[tag] LLM leg ${consumer.label} unreachable — dropping it (${remaining} leg(s) left)`,
+      );
+      return;
+    }
+    state.processed += 1;
+    if (state.processed % 4 === 0) {
+      console.log(`[tag] LLM-tagged ${state.tagged}/${total}`);
+    }
+  }
+}
+
+// Phase 2 + phase 4 LLM tagging. One consumer (single-LLM mode, failover-capable
+// calls) or two (dual-LLM mode, one pinned per leg) drain a shared batch queue.
 async function llmTagInBatches(
   ids: string[],
   batchSize: number,
   promptHash: string,
-  modelLabel: string,
   source: db.TagSource,
-): Promise<{ tagged: number; callCount: number }> {
-  let tagged = 0;
-  let callCount = 0;
-  for (let i = 0; i < ids.length; i += batchSize) {
-    const batch = ids.slice(i, i + batchSize);
-    const songs = batch.map(id => db.getTrack(id)).filter((t): t is db.TrackRecord => !!t);
-    if (songs.length === 0) continue;
-    const input = songs.map(t => ({
-      title: t.title ?? undefined,
-      artist: t.artist ?? undefined,
-      album: t.album ?? undefined,
-      year: t.year ?? undefined,
-      genre: t.genre ?? undefined,
-    }));
-    let results: Array<TagResult | null>;
-    try {
-      results = await tagBatch(input);
-      callCount += 1;
-    } catch (err: any) {
-      // Smaller local models routinely drop entries from a 25-track list, so
-      // the batch comes back the wrong length and tagBatch throws. Don't
-      // discard the whole batch over one missing line — salvage it one track
-      // at a time. A track that still fails individually is left null (skipped
-      // below) so the next run retries it rather than stamping empty moods.
-      console.error(
-        `[tag] LLM batch failed (${songs.length} tracks): ${err.message} — falling back to per-track`,
-      );
-      results = [];
-      for (const song of input) {
-        try {
-          results.push(await tagOne(song));
-          callCount += 1;
-        } catch (oneErr: any) {
-          console.error(`[tag] per-track tag failed: ${oneErr.message}`);
-          results.push(null);
-        }
-      }
-    }
-    for (let j = 0; j < songs.length; j++) {
-      const result = results[j];
-      if (!result) continue;
-      const { moods, energy } = result;
-      db.upsertTrackTags(songs[j].id, {
-        moods,
-        energy,
-        source,
-        confidence: null,
-        promptHash,
-        model: modelLabel,
-      });
-      tagged += 1;
-    }
-    if (i % (batchSize * 4) === 0) {
-      console.log(`[tag] LLM-tagged ${tagged}/${ids.length}`);
+  consumers: TagConsumer[],
+): Promise<{ tagged: number; callCount: number; byLeg: Record<string, number> }> {
+  const batches: string[][] = [];
+  for (let i = 0; i < ids.length; i += batchSize) batches.push(ids.slice(i, i + batchSize));
+
+  const state: TagState = { tagged: 0, callCount: 0, processed: 0, byLeg: {} };
+
+  if (consumers.length <= 1) {
+    // Single consumer — no requeue/drop; the unpinned call already fails over
+    // internally, so an error means the batch is genuinely unworkable this run.
+    await runConsumer(batches, consumers[0], promptHash, source, ids.length, state, null);
+  } else {
+    let alive = consumers.length;
+    await Promise.all(
+      consumers.map(c =>
+        runConsumer(batches, c, promptHash, source, ids.length, state, () => --alive)),
+    );
+    if (batches.length > 0) {
+      const abandoned = batches.reduce((n, b) => n + b.length, 0);
+      console.log(`[tag] all LLM legs unreachable — ${abandoned} tracks left for next run`);
     }
   }
-  return { tagged, callCount };
+  return { tagged: state.tagged, callCount: state.callCount, byLeg: state.byLeg };
+}
+
+// Decide the LLM consumers for this run. Dual-LLM mode activates automatically
+// when a fallback is configured, distinct from the primary, and its host answers
+// a cheap probe — then both boxes tag in parallel off a shared queue. Otherwise a
+// single failover-capable consumer (discussion #320).
+async function resolveTagConsumers(): Promise<TagConsumer[]> {
+  const primary = primaryLeg();
+  const fb = fallbackLeg();
+  if (!fb) return [{ label: primary.label }];
+
+  const sameHost =
+    (primary.cfg.ollamaUrl || '') === (fb.cfg.ollamaUrl || '') &&
+    (primary.cfg.baseUrl || '') === (fb.cfg.baseUrl || '');
+  if (fb.label === primary.label && sameHost) {
+    console.log('[tag] fallback LLM identical to primary — single-LLM mode');
+    return [{ label: primary.label }];
+  }
+
+  if (!(await probeLegReachable(fb))) {
+    console.log(`[tag] fallback LLM (${fb.label}) unreachable — single-LLM mode`);
+    return [{ label: primary.label }];
+  }
+
+  console.log(`[tag] dual-LLM mode active: primary=${primary.label} + fallback=${fb.label}`);
+  return [
+    { pin: 'primary', label: primary.label },
+    { pin: 'fallback', label: fb.label },
+  ];
 }
 
 main().catch(err => { console.error(err); process.exit(1); });

--- a/controller/src/music/tagger-core.ts
+++ b/controller/src/music/tagger-core.ts
@@ -90,7 +90,14 @@ function formatSong(song: TaggableSong): string {
   );
 }
 
-export async function tagOne(song: TaggableSong): Promise<TagResult> {
+// `leg` pins the call to a specific LLM leg ('primary' | 'fallback') with no
+// cross-leg failover — the dual-LLM tagger runs one consumer per leg and manages
+// failover itself (discussion #320). Omitted → normal primary→fallback path.
+export interface TagOpts {
+  leg?: 'primary' | 'fallback';
+}
+
+export async function tagOne(song: TaggableSong, opts: TagOpts = {}): Promise<TagResult> {
   const userPrompt =
     `Title: ${song.title}\n` +
     `Artist: ${song.artist || '?'}\n` +
@@ -104,11 +111,12 @@ export async function tagOne(song: TaggableSong): Promise<TagResult> {
     schema: TagSchema,
     temperature: 0.2,
     kind: 'tag-library',
+    leg: opts.leg,
   });
   return sanitizeTag(parsed);
 }
 
-export async function tagBatch(songs: TaggableSong[]): Promise<TagResult[]> {
+export async function tagBatch(songs: TaggableSong[], opts: TagOpts = {}): Promise<TagResult[]> {
   if (songs.length === 0) return [];
   const lines = songs.map((s, i) => `${i + 1}. ${formatSong(s)}`).join('\n');
   const userPrompt =
@@ -120,6 +128,7 @@ export async function tagBatch(songs: TaggableSong[]): Promise<TagResult[]> {
     schema: BatchTagSchema,
     temperature: 0.2,
     kind: 'tag-library-batch',
+    leg: opts.leg,
   });
   const results = Array.isArray(parsed.results) ? parsed.results : [];
   if (results.length !== songs.length) {


### PR DESCRIPTION
## What & why

Follow-ups from [discussion #320](https://github.com/perminder-klair/subwave/discussions/320) after the failover feature (#326) shipped.

**1. Parallel tagging across both LLMs.** The operator asked whether tagging could be farmed out to *both* his LLM hosts (a desktop running Qwen3.5-9B + a 3050 box running a smaller model) — tagging is his throughput bottleneck (14% of library tagged). When a backup LLM is enabled, distinct from the primary, and its host answers a cheap probe, the tagger's seed + active-learning phases now run **two consumers over one shared batch queue**, one pinned to each leg. Both boxes tag concurrently; the faster card naturally pulls more batches. Auto-activates — zero new config; quietly stays single-LLM (failover-capable, as today) when there's no usable backup.

**2. num_ctx debug visibility.** The operator suspected the backup wasn't getting a context window. It does have its own independent `numCtx` (it doesn't inherit the primary's), but nothing surfaced the value, so it wasn't verifiable. Every call's `sampling` record now includes the effective Ollama `num_ctx`, visible in `/admin/debug`.

## How it works

- **`withFailover` gains an optional `pin`** (`'primary' | 'fallback'`) that runs exactly one leg with **no cross-leg failover** — the tagger drives both legs and manages failover itself. `djObject` exposes it as a `leg` option. Pinned records carry a `…:pinned` via suffix so `/stats`' exact-match buckets are untouched. Unpinned calls are the existing primary→fallback path, unchanged.
- **`provider.probeLegReachable()`** — Ollama `/api/version`, openai-compatible `/models`, hosted providers assumed up. Lets the tagger decide up front rather than after a batch of connect timeouts.
- **Shared-cursor consumers** — `batches.shift()` between awaits is atomic on the single-threaded loop, so two consumers never pull the same batch. A pinned leg whose host dies **requeues its in-flight batch** (upserts happen only after a batch fully resolves → lossless) and drops out; the survivor drains the rest. Both down → remaining tracks logged and left for the next run (non-fatal).
- Each track is stamped with the **model that tagged it**; the run prints a per-leg breakdown.
- One `appliedNumCtx()` source of truth feeds both what's *sent* (providerOpts) and what's *recorded* (sampling), so they can't drift.

## Edge cases

- Backup with a `:cloud` model — `num_ctx` correctly omitted for it, sent for a local primary, each recorded honestly per leg.
- Backup identical to primary (same label + host) — detected, stays single-LLM.
- "agent didn't reply with done" on the backup is a *validation* failure, never a host-down one, so it never triggered failover — those are the smaller model itself, not a missing num_ctx.

## Testing

- `controller` lint (eslint + `tsc --noEmit`) passes — 0 errors.
- No `web/` changes (the debug panel renders records as raw JSON, so `num_ctx` shows with no UI change).
- Manual tagger smoke (dual banner, interleaved per-leg logs, per-leg totals, two distinct `model` stamps) needs a live Navidrome + two LLM hosts — left for the operator who has the two-box setup.
