### PR TITLE
feat(admin): station timezone setting driving the DJ clock

### DIFF
--- a/controller/src/broadcast/dj-gate.ts
+++ b/controller/src/broadcast/dj-gate.ts
@@ -11,6 +11,7 @@
 // frequency floor. Lives outside scheduler.js to keep that file lean.
 
 import * as settings from '../settings.js';
+import { zonedParts } from '../time.js';
 
 export function shouldFire(kind, now = new Date()) {
   // effectiveFrequency bumps a DJ-mode persona one rung up the ladder, so it
@@ -29,7 +30,10 @@ export function shouldFire(kind, now = new Date()) {
   }
 
   if (kind === 'hourly') {
-    if (f === 'quiet') return now.getHours() % 2 === 0;
+    // Station-zone hour — the every-other-hour cadence follows the operator's
+    // clock. The minute slots above stay on process time on purpose: they
+    // must align with when the crons actually fire.
+    if (f === 'quiet') return zonedParts(now).hour % 2 === 0;
     return true;
   }
 

--- a/controller/src/context.ts
+++ b/controller/src/context.ts
@@ -4,9 +4,10 @@
 import { config } from './config.js';
 import { resolveActiveShow } from './settings.js';
 import { getListenerCount } from './broadcast/listeners.js';
+import { zonedParts, zonedISODate } from './time.js';
 
 export function getTimeContext(date = new Date()) {
-  const h = date.getHours();
+  const h = zonedParts(date).hour;
   if (h >= 5 && h < 9) return { period: 'early-morning', mood: 'morning', vibe: 'gentle waking', show: 'breakfast' };
   if (h >= 9 && h < 12) return { period: 'morning', mood: 'morning', vibe: 'productive', show: 'morning' };
   if (h >= 12 && h < 14) return { period: 'midday', mood: 'energetic', vibe: 'lunch hour', show: 'midday' };
@@ -38,8 +39,7 @@ const FESTIVALS = [
 ];
 
 export function getFestivalContext(date = new Date()) {
-  const m = date.getMonth() + 1;
-  const d = date.getDate();
+  const { month: m, day: d } = zonedParts(date);
   for (const f of FESTIVALS) {
     const window = f.windowDays || 0;
     if (f.month === m && Math.abs(f.day - d) <= window) {
@@ -126,23 +126,22 @@ function seasonFor(month /* 1-12 */) {
 }
 
 export function getDateContext(date = new Date()) {
-  const dow = date.getDay();
-  const month = date.getMonth() + 1;
+  const { dow, month, day } = zonedParts(date);
   return {
-    iso: date.toISOString().slice(0, 10),
+    // Station-zone date, not UTC — toISOString() was a day off near midnight
+    // for any zone with an offset, even before timezone became configurable.
+    iso: zonedISODate(date),
     dayOfWeek: dow,
     dayLabel: DAY_LABELS[dow],
     monthLabel: MONTH_LABELS[month - 1],
-    dayOfMonth: date.getDate(),
+    dayOfMonth: day,
     season: seasonFor(month),
   };
 }
 
 export function getClockContext(date = new Date()) {
-  const h = date.getHours();
-  const m = date.getMinutes();
+  const { hour: h, minute: m, dow } = zonedParts(date);
   const minutesOfDay = h * 60 + m;
-  const dow = date.getDay();
   return {
     hhmm: `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`,
     isWeekend: dow === 0 || dow === 6,

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -11,6 +11,7 @@ import { queue } from '../broadcast/queue.js';
 import * as session from '../broadcast/session.js';
 import { getStreamStatus } from '../broadcast/listeners.js';
 import { getSetupStatusSync } from '../setup/firstRun.js';
+import { getStationTimezone } from '../time.js';
 import { listThemes, DEFAULT_THEME_ID } from '../themes.js';
 
 export const router = express.Router();
@@ -231,11 +232,12 @@ router.get('/schedule', async (req, res) => {
       personas,
       shows,
       schedule: s.schedule,
-      // The grid is interpreted in the controller's local timezone — the
-      // browser's local DOW/hour may not match, so pass back the offset the
-      // schedule was painted in. The UI can show a small "Times shown in
-      // station local time" hint where needed.
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || null,
+      // The grid is interpreted in the station's timezone (settings.timezone,
+      // falling back to the container TZ) — the browser's local DOW/hour may
+      // not match, so pass back the zone the schedule is painted in. The UI
+      // can show a small "Times shown in station local time" hint where
+      // needed.
+      timezone: getStationTimezone(),
     });
   } catch (err: any) {
     res.status(500).json({ error: err.message });

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -48,12 +48,16 @@ router.get('/settings', requireAdmin, async (req, res) => {
       libraryStats: library.stats(),
       tagger: { ...tagger, lastLog: tagger.lastLog.slice(-30) },
       ollama: { url: config.ollama.url, model: config.ollama.model },
+      // What the configured zone resolves to when timezone is '' (Auto) —
+      // lets the UI label the Auto option with the actual server zone.
+      serverTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
       values: {
         jingleRatio: s.jingleRatio,
         crossfadeDuration: s.crossfadeDuration,
         archive: s.archive,
         stream: s.stream,
         station: s.station,
+        timezone: s.timezone,
         theme: s.theme,
         weather: s.weather,
         djPrompt: s.djPrompt,

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -8,6 +8,7 @@ import { existsSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
 import { STATE_DIR } from './config.js';
 import { DEFAULT_THEME_ID, isValidThemeId, listThemes } from './themes.js';
+import { isValidTimezone, setStationTimezone, zonedParts } from './time.js';
 
 // Where uploaded persona avatars live. One file per persona, basename =
 // `<personaId>.<ext>`. The dedicated upload route is the only writer; the
@@ -352,6 +353,11 @@ const DEFAULTS = {
   // still called SUB/WAVE — this is what the operator's station running on it
   // is called (e.g. "Frequency 88", "Late Shift Radio").
   station: 'SUB/WAVE',
+  // Station clock — IANA zone driving everything with local-time semantics
+  // (time-of-day moods, schedule slots, hourly time checks, festival dates).
+  // Empty = Auto: the container's own TZ, so existing installs are untouched.
+  // Applied live via time.ts setStationTimezone(); no restart.
+  timezone: '',
   // Station-wide visual theme — every listener and the admin UI render with
   // this palette. The id resolves through controller/src/themes.ts, which
   // ships the built-ins and reads optional user JSONs from
@@ -793,6 +799,12 @@ export async function load() {
       typeof stored.station === 'string' && stored.station.trim()
         ? stored.station.trim().slice(0, 80)
         : DEFAULTS.station,
+    // Invalid stored zone (hand-edited file) falls back to Auto — the
+    // station must never crash on a bad zone.
+    timezone:
+      typeof stored.timezone === 'string' && isValidTimezone(stored.timezone.trim())
+        ? stored.timezone.trim()
+        : DEFAULTS.timezone,
     theme: {
       // We only validate the *shape* here. The active id might reference a
       // theme file that's since been removed; the public /themes endpoint
@@ -1016,6 +1028,10 @@ export async function load() {
       },
     },
   };
+  if (typeof stored.timezone === 'string' && stored.timezone.trim() && !cache.timezone) {
+    console.warn(`[settings] ignoring invalid timezone "${stored.timezone.trim()}" — using Auto (container TZ)`);
+  }
+  setStationTimezone(cache.timezone);
   return cache;
 }
 
@@ -1456,6 +1472,15 @@ export async function update(patch) {
     }
     next.station = resolved;
   }
+  if ('timezone' in patch) {
+    const v = String(patch.timezone ?? '').trim();
+    // '' = back to Auto (container TZ). Anything else must be a zone ICU
+    // knows — aliases like Europe/Kiev validate, not just canonical names.
+    if (v !== '' && !isValidTimezone(v)) {
+      throw new Error(`invalid timezone "${v}" — use an IANA name like Europe/Athens`);
+    }
+    next.timezone = v;
+  }
   if ('theme' in patch) {
     const t = patch.theme || {};
     if (t.active !== undefined) {
@@ -1814,6 +1839,9 @@ export async function update(patch) {
   }
 
   cache = next;
+  // Applied-on-save, same pattern as the liquidsoap_*.txt files below —
+  // minus the restart: the next zonedParts() call picks it up.
+  setStationTimezone(next.timezone);
   // shows + schedule are persisted to their own file (schedule.json); strip
   // them from the settings.json payload so legacy installs migrate forward
   // on the first write. The in-memory `cache` keeps the full shape so
@@ -1844,8 +1872,9 @@ export function resolvePersonaById(id) {
 // The show scheduled for `date`'s day-of-week + hour, or null. Self-contained
 // (touches only settings data) so context.js can import it without a cycle.
 export function resolveActiveShow(date = new Date(), s = get()) {
-  const day = date.getDay();
-  const hour = date.getHours();
+  // Station-zone wall clock, not process-local — schedule slots fire at the
+  // hours the operator painted them in (issue #353).
+  const { dow: day, hour } = zonedParts(date);
   const showId = s?.schedule?.[day]?.[hour] ?? null;
   if (!showId) return null;
   const show = s.shows?.find(x => x.id === showId);

--- a/controller/src/skills/curiosity.ts
+++ b/controller/src/skills/curiosity.ts
@@ -17,6 +17,8 @@
 // to pure generation under `cap.desc`. So this file is "what extra context can
 // we put under the DJ's nose this minute?" — never "must we be silent?".
 
+import { zonedParts, zonedISODate } from '../time.js';
+
 const ON_THIS_DAY_TTL_MS = 12 * 60 * 60 * 1000; // 12h — events for a date are stable
 
 // Wikipedia REST asks API consumers to identify themselves. Anonymous calls
@@ -61,10 +63,12 @@ function looksAllowed(text: string, category?: string) {
 }
 
 function mmdd(d: Date) {
+  // Station-zone date — "on this day" should match the day the DJ announces.
+  const { month, day } = zonedParts(d);
   return {
-    mm: String(d.getMonth() + 1).padStart(2, '0'),
-    dd: String(d.getDate()).padStart(2, '0'),
-    iso: d.toISOString().slice(0, 10),
+    mm: String(month).padStart(2, '0'),
+    dd: String(day).padStart(2, '0'),
+    iso: zonedISODate(d),
   };
 }
 

--- a/controller/src/time.ts
+++ b/controller/src/time.ts
@@ -1,0 +1,86 @@
+// Station-zone date math — the single home for "what's the wall clock at the
+// station right now?". The operator can pick an IANA zone in admin →
+// Settings → Station (settings.timezone); empty means Auto, i.e. the
+// container's own TZ. Everything with local-time *semantics* (time-of-day
+// moods, schedule slots, festival dates, the hourly check) goes through
+// zonedParts(); timestamps and durations keep using Date directly.
+//
+// Deliberately imports nothing from the rest of the app so settings.ts can
+// import it without a cycle — settings pushes the configured zone in via
+// setStationTimezone() on load and on every successful update.
+
+let stationZone = '';
+
+// Formatter instances are not cheap and zonedParts runs several times a
+// minute — cache one per zone.
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function formatterFor(timeZone: string) {
+  let fmt = formatterCache.get(timeZone);
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat('en-GB', {
+      timeZone,
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      weekday: 'short',
+      hour12: false,
+    });
+    formatterCache.set(timeZone, fmt);
+  }
+  return fmt;
+}
+
+export function isValidTimezone(tz: string) {
+  // try/catch rather than Intl.supportedValuesOf so aliases (Europe/Kiev,
+  // US/Pacific, …) validate too — the formatter accepts anything ICU knows.
+  try {
+    new Intl.DateTimeFormat('en', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function setStationTimezone(tz: string) {
+  stationZone = typeof tz === 'string' && isValidTimezone(tz.trim()) ? tz.trim() : '';
+}
+
+// The *effective* zone — configured, or whatever the process resolved to.
+export function getStationTimezone() {
+  return stationZone || Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+}
+
+// Sunday-first, matching Date.getDay() — the schedule grid is stored that way.
+const DOW: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+
+export type ZonedParts = {
+  year: number;
+  month: number; // 1-12, matching getMonth() + 1 at the call sites
+  day: number; // 1-31
+  hour: number; // 0-23
+  minute: number; // 0-59
+  dow: number; // 0-6, Sunday = 0
+};
+
+export function zonedParts(date = new Date()): ZonedParts {
+  const parts = formatterFor(getStationTimezone()).formatToParts(date);
+  const out: Record<string, string> = {};
+  for (const p of parts) out[p.type] = p.value;
+  return {
+    year: Number(out.year),
+    month: Number(out.month),
+    day: Number(out.day),
+    // en-GB with hour12:false can render midnight as "24" — normalise.
+    hour: Number(out.hour) % 24,
+    minute: Number(out.minute),
+    dow: DOW[out.weekday] ?? 0,
+  };
+}
+
+export function zonedISODate(date = new Date()) {
+  const { year, month, day } = zonedParts(date);
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}

--- a/docs/superpowers/specs/2026-06-12-station-timezone-design.md
+++ b/docs/superpowers/specs/2026-06-12-station-timezone-design.md
@@ -1,0 +1,170 @@
+# Station timezone setting — design
+
+**Date:** 2026-06-12
+**Issue:** [#353 — Clock is off](https://github.com/perminder-klair/subwave/issues/353)
+
+## Problem
+
+The DJ's clock — time-of-day moods, schedule slots, hourly time checks, festival
+dates — runs on the container's `TZ` env var, which defaults to
+`Europe/London` in every compose file. Operators in other zones who never set
+`TZ` in the root `.env` get a station clock that's hours off (the #353 reporter
+is +2h: "afternoon" auto-playlist at their 6 pm). The setting exists but is
+invisible: the browser onboarding wizard never asks for it, the admin UI never
+shows it, and the coordinates an operator *does* set only drive weather, not
+the clock. Fixing it today means editing `.env` and recreating containers.
+
+## Goal
+
+A **Timezone** field in admin → Settings → Station: pick an IANA zone, applies
+live (no restart), drives everything the DJ derives from wall-clock time.
+Default is "Auto" — the container's own zone — so existing installs behave
+exactly as before.
+
+## Approaches considered
+
+1. **Write `TZ` into `.env` and restart** — rejected. The controller would
+   have to edit a host file outside its mount, and container env is immutable
+   without a recreate. Worst UX of the three.
+2. **Mutate `process.env.TZ` at runtime** — rejected. Node caches the
+   resolved zone inconsistently across Date APIs; behaviour is
+   version-dependent. It would also silently shift log timestamps and
+   everything else, not just DJ-clock logic.
+3. **Settings field + explicit-zone date math** (chosen). Store an IANA zone
+   in `settings.json`; a small helper computes wall-clock parts in that zone
+   via `Intl.DateTimeFormat`. Only the handful of local-time-semantics call
+   sites change; timestamps/durations stay untouched. Applies live, no
+   restart, matches the "weather location applies live" convention already in
+   the Station section.
+
+## Design
+
+### New module: `controller/src/time.ts`
+
+The single home for station-zone date math. No imports from elsewhere in the
+app (so `settings.ts` can import it without a cycle).
+
+- `setStationTimezone(tz: string)` — module-level zone, `''` = auto. Called by
+  `settings.load()` and `settings.update()`.
+- `getStationTimezone(): string` — the *effective* zone: the configured one,
+  or `Intl.DateTimeFormat().resolvedOptions().timeZone` when auto.
+- `zonedParts(date = new Date())` → `{ year, month, day, hour, minute, dow }`
+  (month 1-12, dow 0-6 Sunday-first, matching existing `getDay()`/
+  `getMonth()+1` semantics). One `Intl.DateTimeFormat('en-GB', { timeZone, … })`
+  `formatToParts` call; the formatter instance is cached per zone (these run
+  several times a minute).
+- `zonedISODate(date = new Date())` → `YYYY-MM-DD` in the station zone.
+- `isValidTimezone(tz: string): boolean` — `try { new Intl.DateTimeFormat('en',
+  { timeZone: tz }) }` so aliases (e.g. `Europe/Kiev`) validate, not just the
+  canonical `Intl.supportedValuesOf` list.
+
+When the zone is auto, `zonedParts` still goes through the formatter with the
+process zone — one code path, no drift between auto and explicit modes.
+
+### Settings (`controller/src/settings.ts`)
+
+- `DEFAULTS.timezone = ''` (auto), top-level alongside `station` / `weather`.
+- Load-time normalisation: non-string or invalid stored value → `''` with a
+  console warning (covers hand-edited `settings.json`).
+- `update()`: `if ('timezone' in patch)` — trim; `''` allowed (back to auto);
+  otherwise must pass `isValidTimezone` or throw
+  `invalid timezone — use an IANA name like Europe/Athens`.
+- Both `load()` and a successful `update()` push the value into
+  `setStationTimezone()` — same applied-on-save pattern as the
+  `liquidsoap_*.txt` files, minus the restart.
+- `resolveActiveShow()` (`settings.ts:1847`): `date.getDay()`/`getHours()` →
+  `zonedParts(date)`. This is what makes schedule slots fire at station-local
+  hours.
+
+### Call-site rewiring (controller)
+
+All in the "local-time semantics" class; timestamps (`toISOString` turn logs,
+session `startedAt`, cleanup timers) are untouched.
+
+| Site | Today | Change |
+|---|---|---|
+| `context.ts` `getTimeContext` | `date.getHours()` | `zonedParts(date).hour` |
+| `context.ts` `getFestivalContext` | `getMonth()+1` / `getDate()` | `zonedParts(date)` month/day |
+| `context.ts` `getDateContext` | `getDay()`/`getMonth()`/`getDate()` + `toISOString().slice(0,10)` | `zonedParts(date)`; `iso` via `zonedISODate` (the current `iso` is UTC — wrong near midnight even today; this fixes it) |
+| `context.ts` `getClockContext` | `getHours()`/`getMinutes()`/`getDay()` | `zonedParts(date)` |
+| `broadcast/dj-gate.ts:32` | quiet hourly: `now.getHours() % 2` | `zonedParts(now).hour % 2` |
+| `skills/curiosity.ts:65` | `getMonth()`/`getDate()` for `{mm}`/`{dd}` | `zonedParts(d)` |
+| `routes/public.ts:238` | `Intl.DateTimeFormat().resolvedOptions().timeZone` | `getStationTimezone()` — the schedule grid hint now reflects the configured zone |
+
+**Deliberately unchanged:** `dj-gate.ts` minute slots (`m === 15/30/45`) stay
+on system-TZ minutes — they must align with when the crons actually fire,
+which node-cron schedules in the process zone. `segment-tools.ts`
+album-anniversary year stays on process time (a year-boundary edge case with
+no audible effect).
+
+### API
+
+- `GET /settings` — `timezone` flows out automatically via `getRedacted()`.
+  Additionally expose `serverTimezone:
+  Intl.DateTimeFormat().resolvedOptions().timeZone` in the response so the UI
+  can label the Auto option with what it resolves to.
+- `POST /settings` — `timezone` accepted in the patch like any other field.
+- `GET /schedule` (`routes/public.ts`) — `timezone` field switches to the
+  effective station zone (see table). `ScheduleDrawer.tsx` already consumes
+  it; no web change needed there.
+
+### Admin UI (`web/components/admin/SettingsPanel.tsx`, Station section)
+
+- Form state: `timezone: string` (`''` = auto), loaded from
+  `v.timezone ?? ''`, included in `StationSection`'s `save()` patch.
+- New **Timezone** card between "Station location" and the section's end:
+  - A `Select` (existing component, pattern-matched from the archive bitrate
+    select). First item: `Auto — server timezone (<serverTimezone>)`, value
+    `''`. Then `Intl.supportedValuesOf('timeZone')` grouped with
+    `SelectGroup`/`SelectLabel` by region prefix (`Europe/…`, `America/…`, …)
+    — already imported in this file.
+  - Below the select, a live preview line: current station time computed
+    client-side with the selected zone
+    (`new Date().toLocaleTimeString('en-GB', { timeZone })`) so the operator
+    sees "Station clock: 18:04" *before* saving and can sanity-check the #353
+    symptom directly.
+  - Hint: drives the DJ's clock — time-of-day moods, schedule slots, hourly
+    time checks, festival dates. Applies live. Hourly archive filenames still
+    follow the server's `TZ`.
+- Section nav hint (`line 23`): `'name · location'` → `'name · location ·
+  timezone'`; SectionHeader sub-text extended to mention the timezone.
+
+### Out of scope
+
+- **Onboarding wizard** — explicitly admin-settings-only per the request. The
+  CLI paths already auto-detect `TZ`.
+- **`TZ` env var removal** — it stays the default (Auto resolves to it) and
+  still governs the broadcast container: Liquidsoap's hourly archive paths
+  and the cron *firing* minutes.
+- **node-cron timezone option** — crons keep firing in the process zone.
+  Limitation: if the configured zone is offset from the server zone by
+  :30/:45 (India, Nepal, Chatham), the "top of the hour" check fires at local
+  :30/:45. The announced time is still correct. Mitigation is setting the
+  host `TZ` to match; not worth re-registering cron tasks on settings change
+  for it.
+
+### Edge cases
+
+- **Invalid stored zone** (hand-edited file): normalised to auto on load,
+  warning logged. The station never crashes on a bad zone.
+- **Zone change mid-session**: the next `getFullContext()` reflects it;
+  `session.maybeRoll()` may roll the DJ session when the period/mood key
+  changes — the same thing that happens naturally at a daypart boundary.
+- **DST**: handled by `Intl`; no offset math anywhere in the design.
+- **Weather**: unaffected — driven by coordinates, not the clock.
+
+### Testing
+
+No test runner in this repo; the merge gate is `npm run lint` (eslint +
+`tsc --noEmit`) in both `controller/` and `web/` — both must pass. Manual
+verification on the dev stack: set a zone several hours off the host's in
+admin → Station, then confirm (1) `/state` reports the matching period/mood,
+(2) `/schedule` returns the configured zone and the drawer hint shows it,
+(3) the saved value round-trips through `GET /settings`, (4) Auto restores
+host behaviour.
+
+### Issue closure
+
+After merge, reply on #353: point at the new field (admin → Settings →
+Station → Timezone) and note the immediate workaround for older builds
+(`TZ=<zone>` in root `.env` + `docker compose up -d`).

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -20,7 +20,7 @@ import { Card, Btn, Pill, Eyebrow, Seg, Metric } from './ui';
 import { cn } from '../../lib/cn';
 
 const SECTIONS = [
-  { id: 'station',  label: 'Station', hint: 'name · location' },
+  { id: 'station',  label: 'Station', hint: 'name · location · timezone' },
   { id: 'theme',    label: 'Theme', hint: 'station-wide palette' },
   { id: 'tts',      label: 'TTS voice', hint: 'default engine' },
   { id: 'llm',      label: 'LLM provider', hint: 'model routing' },
@@ -171,6 +171,7 @@ interface FormState {
   archive: ArchiveForm;
   stream: StreamForm;
   station: string;
+  timezone: string;
   weather: WeatherCfg;
   tts: TtsForm;
   llm: LlmForm;
@@ -207,6 +208,7 @@ interface SettingsData {
     archive?: { enabled?: boolean; bitrate?: number };
     stream?: { opusEnabled?: boolean };
     station?: string;
+    timezone?: string;
     theme?: { active?: string };
     weather?: { lat?: number; lng?: number; locationName?: string; units?: 'metric' | 'imperial' };
     tts?: {
@@ -262,6 +264,8 @@ interface SettingsData {
   libraryStats?: { total?: number };
   env?: Record<string, unknown>;
   streamOnAir?: boolean;
+  // What timezone '' (Auto) resolves to — the controller's own zone.
+  serverTimezone?: string;
 }
 
 interface SfxForm {
@@ -321,6 +325,7 @@ export default function SettingsPanel() {
         opusEnabled: v.stream?.opusEnabled ?? true,
       },
       station: v.station ?? '',
+      timezone: v.timezone ?? '',
       weather: {
         lat: String(v.weather?.lat ?? ''),
         lng: String(v.weather?.lng ?? ''),
@@ -2370,9 +2375,36 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
 
 /* ── Station ─────────────────────────────────────────────────────────── */
 
+// IANA zones grouped by region prefix for the timezone select. Built once —
+// Intl.supportedValuesOf exists in every runtime this UI supports, but the
+// guard keeps an exotic browser from crashing the whole settings page.
+const TZ_GROUPS: Array<{ region: string; zones: string[] }> = (() => {
+  let zones: string[] = [];
+  try { zones = Intl.supportedValuesOf('timeZone'); } catch { /* select offers Auto only */ }
+  const byRegion = new Map<string, string[]>();
+  for (const z of zones) {
+    const region = z.includes('/') ? z.slice(0, z.indexOf('/')) : 'Other';
+    if (!byRegion.has(region)) byRegion.set(region, []);
+    byRegion.get(region)!.push(z);
+  }
+  return [...byRegion.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([region, zs]) => ({ region, zones: zs }));
+})();
+
+// Wall-clock preview for a zone, or '' when the zone can't be formatted.
+function clockPreview(timeZone: string) {
+  try {
+    return new Date().toLocaleTimeString('en-GB', { timeZone: timeZone || undefined, hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return '';
+  }
+}
+
 function StationSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
   const save = () => saveSettings({
     station: form.station,
+    timezone: form.timezone,
     weather: {
       lat: parseFloat(form.weather.lat),
       lng: parseFloat(form.weather.lng),
@@ -2381,12 +2413,25 @@ function StationSection({ data, form, setForm, busy, saveSettings }: SectionProp
     },
   });
 
+  // Re-render every 30s so the station-clock preview keeps walking — it's
+  // the operator's sanity check that the selected zone matches their watch.
+  const [, setClockTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setClockTick(t => t + 1), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const serverTz = data.serverTimezone || 'server timezone';
+  // '' = Auto → preview the server's zone, which is what the station runs on.
+  const previewTz = form.timezone || data.serverTimezone || '';
+  const preview = clockPreview(previewTz);
+
   return (
     <>
       <SectionHeader
         eyebrow="station"
         title="How the DJ identifies this radio on air."
-        sub="The station name is substituted into the DJ prompt as {station}. The location sets where the DJ thinks it broadcasts from and drives the Open-Meteo weather it reads on air. Both apply live — no mixer restart."
+        sub="The station name is substituted into the DJ prompt as {station}. The location sets where the DJ thinks it broadcasts from and drives the Open-Meteo weather it reads on air. The timezone sets the clock the DJ lives on. All apply live — no mixer restart."
         metrics={[
           { n: data.values?.station || 'SUB/WAVE', l: 'station', accent: true },
         ]}
@@ -2474,8 +2519,46 @@ function StationSection({ data, form, setForm, busy, saveSettings }: SectionProp
         </div>
       </Card>
 
+      <Card title="Timezone" sub="The station clock the DJ lives on">
+        <div className="field">
+          <Label>Station timezone</Label>
+          <Select
+            // Radix forbids empty-string item values, so Auto rides a sentinel.
+            value={form.timezone || 'auto'}
+            onValueChange={val =>
+              setForm(f => ({ ...f, timezone: val === 'auto' ? '' : val }))
+            }
+          >
+            <SelectTrigger className="w-[300px]"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value="auto">Auto — server timezone ({serverTz})</SelectItem>
+              </SelectGroup>
+              {TZ_GROUPS.map(g => (
+                <SelectGroup key={g.region}>
+                  <SelectLabel>{g.region}</SelectLabel>
+                  {g.zones.map(z => (
+                    <SelectItem key={z} value={z}>{z}</SelectItem>
+                  ))}
+                </SelectGroup>
+              ))}
+            </SelectContent>
+          </Select>
+          {preview && (
+            <div className="field-hint">
+              Station clock: <span className="mono-num">{preview}</span> — if that doesn’t match your watch, pick your zone above.
+            </div>
+          )}
+          <div className="field-hint">
+            Drives everything the DJ derives from the clock — time-of-day moods, schedule slots,
+            hourly time checks, festival dates. Applies live. Hourly archive filenames still follow
+            the server’s TZ.
+          </div>
+        </div>
+      </Card>
+
       <SaveBar
-        note="Station name and location apply live."
+        note="Station name, location, and timezone apply live."
         busy={busy}
         onSave={save}
         saveLabel="Save station settings"


### PR DESCRIPTION
## What

A **Timezone** field in admin → Settings → Station. Pick an IANA zone and the DJ's clock — time-of-day moods, schedule slots, hourly time checks, festival dates — follows it. Applies live, no restart. Default is **Auto** (the container's `TZ`), so existing installs behave exactly as before.

Fixes #353 — the reporter's coordinates only ever drove weather; the clock came from the compose default `Europe/London`, putting their station 2h off with no way to see or fix it from the UI.

## How

- **`controller/src/time.ts`** (new) — single home for station-zone date math: `setStationTimezone` / `getStationTimezone` / `zonedParts` / `zonedISODate` via cached `Intl.DateTimeFormat`, plus `isValidTimezone` (try/catch so aliases like `Europe/Kiev` validate). Imports nothing from the app, so `settings.ts` uses it without a cycle.
- **`settings.ts`** — top-level `timezone` (`''` = Auto): defaults, load-time normalisation (invalid hand-edited zone → Auto + warning), `update()` validation, applied on load/save via `setStationTimezone`. `resolveActiveShow` now resolves day/hour in the station zone.
- **Rewired call sites** — `context.ts` time/festival/date/clock contexts (also fixes `getDateContext.iso`, which was UTC and a day off near midnight), `dj-gate.ts` quiet-mode hourly gate, `skills/curiosity.ts` on-this-day date, `routes/public.ts` `/schedule` now reports the configured zone (the schedule drawer hint picks it up unchanged).
- **Deliberately unchanged** — `dj-gate` minute slots stay on process time (they must align with when crons actually fire); Liquidsoap archive filenames still follow the broadcast container's `TZ`.
- **Admin UI** — Timezone card in the Station section: zones grouped by region, Auto option labelled with the actual server zone (`serverTimezone` added to `GET /settings`), and a live station-clock preview so the operator can sanity-check against their watch before saving.

Design spec: `docs/superpowers/specs/2026-06-12-station-timezone-design.md`. Out of scope per the spec: onboarding wizard, node-cron timezone option (limitation: zones offset :30/:45 from the server get the "top of the hour" check at local :30/:45 — the announced time is still right).

## Verification

- `npm run lint` (eslint + `tsc --noEmit`) clean in both `controller/` and `web/`.
- Functional round-trip against a temp `STATE_DIR`: same instant reads **afternoon** on the London default and **drive-time** after saving `Europe/Athens` (the exact #353 symptom), `requiresRestart: false`, invalid zones rejected with a clear error, `''` restores Auto, invalid stored zone normalises to Auto with a warning on load.
- Zone-math smoke test: day rollover, weekday shift, midnight `24→0` normalisation, alias validation.
- Not browser-tested: the new Select card (pattern-matched from the existing archive-bitrate select; web tsc/eslint clean).