### PR TITLE
feat(library): simplify tagging panel + structured live tagger progress

### DIFF
--- a/controller/node_modules
+++ b/controller/node_modules
@@ -1,1 +1,0 @@
-/Users/klair/Projects/subwave/web/controller/node_modules

--- a/controller/src/broadcast/tagger.ts
+++ b/controller/src/broadcast/tagger.ts
@@ -4,6 +4,7 @@
 // (/tag-library) and the ones that report on it (/settings).
 import { spawn, ChildProcess } from 'node:child_process';
 import { queue } from './queue.js';
+import { PROGRESS_PREFIX, type TaggerProgress } from '../music/tagger-progress.js';
 
 type TaggerState = {
   running: boolean;
@@ -14,9 +15,16 @@ type TaggerState = {
   // acoustic/audio-embedding pass via analyze-library). Single-flight across
   // both — they contend on the same library DB and analysis backend.
   mode: 'tag' | 'analyze' | null;
+  // Latest structured progress sentinel from the child ([progress] lines on
+  // stdout — see music/tagger-progress.ts). Left in place after exit so the
+  // last payload doubles as a what-just-finished summary; the UI gates its
+  // display on `running`.
+  progress: TaggerProgress | null;
 };
 
-export const tagger: TaggerState = { running: false, startedAt: null, pid: null, lastLog: [], mode: null };
+export const tagger: TaggerState = {
+  running: false, startedAt: null, pid: null, lastLog: [], mode: null, progress: null,
+};
 
 // Live handle for stopTagger() — cleared on the exit handler.
 let activeChild: ChildProcess | null = null;
@@ -87,14 +95,33 @@ function spawnChild(mode: 'tag' | 'analyze', args: string[], detail: string) {
   tagger.pid = child.pid ?? null;
   tagger.lastLog = [];
   tagger.mode = mode;
+  tagger.progress = null;
 
-  const capture = (chunk: Buffer) => {
-    const lines = chunk.toString().split('\n').filter((l: string) => l.trim());
-    tagger.lastLog.push(...lines);
-    if (tagger.lastLog.length > 100) tagger.lastLog = tagger.lastLog.slice(-100);
+  // Per-stream line buffering: a `data` chunk can end mid-line, so each stream
+  // keeps its own remainder. [progress] sentinel lines are parsed into
+  // tagger.progress and kept out of lastLog.
+  const makeCapture = () => {
+    let remainder = '';
+    return (chunk: Buffer) => {
+      remainder += chunk.toString();
+      const lines = remainder.split('\n');
+      remainder = lines.pop() ?? '';
+      for (const raw of lines) {
+        const line = raw.trim();
+        if (!line) continue;
+        if (line.startsWith(PROGRESS_PREFIX)) {
+          try {
+            tagger.progress = JSON.parse(line.slice(PROGRESS_PREFIX.length)) as TaggerProgress;
+          } catch { /* malformed sentinel — drop */ }
+          continue;
+        }
+        tagger.lastLog.push(line);
+      }
+      if (tagger.lastLog.length > 100) tagger.lastLog = tagger.lastLog.slice(-100);
+    };
   };
-  child.stdout.on('data', capture);
-  child.stderr.on('data', capture);
+  child.stdout.on('data', makeCapture());
+  child.stderr.on('data', makeCapture());
   child.on('exit', (code, signal) => {
     tagger.running = false;
     if (activeChild === child) activeChild = null;

--- a/controller/src/music/analyze-library.ts
+++ b/controller/src/music/analyze-library.ts
@@ -31,6 +31,7 @@ import { loadSecretsIntoEnv } from '../setup/secrets.js';
 import { loadSetupConfig } from '../setup/config.js';
 import { runAnalysisPass } from './analyze.js';
 import * as analyzer from './analyzer.js';
+import { reportProgress } from './tagger-progress.js';
 
 function parseIntFlag(args: string[], name: string): number | undefined {
   const idx = args.indexOf(name);
@@ -93,6 +94,7 @@ async function main() {
   }
 
   if (shouldWalk) {
+    reportProgress({ phase: 'walk', label: 'Scanning Navidrome library', done: 0 });
     let walked = 0;
     const liveIds = new Set<string>();
     for await (const song of subsonic.iterateAllSongs()) {
@@ -106,7 +108,10 @@ async function main() {
       });
       liveIds.add(song.id);
       walked += 1;
-      if (walked % 500 === 0) console.log(`[analyze] walked ${walked} tracks`);
+      if (walked % 500 === 0) {
+        console.log(`[analyze] walked ${walked} tracks`);
+        reportProgress({ phase: 'walk', label: 'Scanning Navidrome library', done: walked });
+      }
     }
     console.log(`[analyze] walked ${walked} total tracks`);
 

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -14,6 +14,7 @@ import * as db from './library-db.js';
 import * as analyzer from './analyzer.js';
 import * as settings from '../settings.js';
 import { config } from '../config.js';
+import { reportProgress } from './tagger-progress.js';
 
 export interface AnalyzeOptions {
   limit?: number;        // cap tracks this run (default: all that need it)
@@ -90,6 +91,7 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
     return { available: true, backend, analyzed: 0, failed: 0, scope: 0, audioEmbedded: 0 };
   }
   console.log(`[analyze] ${ids.length} tracks to analyse`);
+  reportProgress({ phase: 'analyze', label: 'Analysing audio', done: 0, total: ids.length });
 
   let analyzed = 0;
   let failed = 0;
@@ -164,6 +166,13 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
     }
     if ((i + 1) % 25 === 0 || i + 1 === ids.length) {
       console.log(`[analyze] ${i + 1}/${ids.length} (ok=${analyzed} fail=${failed})`);
+      reportProgress({
+        phase: 'analyze',
+        label: 'Analysing audio',
+        done: i + 1,
+        total: ids.length,
+        errors: failed || undefined,
+      });
     }
   }
 

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -35,6 +35,7 @@ import { activeModelLabel, primaryLeg, fallbackLeg, probeLegReachable } from '..
 import { isUnreachable } from '../llm/sdk.js';
 import { tagBatch, tagOne, TAGGER_BATCH_SYSTEM, type TagResult } from './tagger-core.js';
 import { runAnalysisPass } from './analyze.js';
+import { reportProgress } from './tagger-progress.js';
 
 // ---------------------------------------------------------------------------
 // CLI arg parsing
@@ -188,6 +189,7 @@ async function main() {
   // Cheap; ensures every Navidrome song is in the tracks table so subsequent
   // phases can operate purely off SQL.
   console.log('[tag] walking Navidrome library...');
+  reportProgress({ phase: 'walk', label: 'Scanning Navidrome library', done: 0 });
   let walked = 0;
   const liveIds = new Set<string>();
   for await (const song of subsonic.iterateAllSongs()) {
@@ -201,7 +203,10 @@ async function main() {
     });
     liveIds.add(song.id);
     walked += 1;
-    if (walked % 500 === 0) console.log(`[tag] walked ${walked} tracks`);
+    if (walked % 500 === 0) {
+      console.log(`[tag] walked ${walked} tracks`);
+      reportProgress({ phase: 'walk', label: 'Scanning Navidrome library', done: walked });
+    }
   }
   console.log(`[tag] walked ${walked} total tracks`);
 
@@ -277,7 +282,9 @@ async function main() {
   let llmCalls = 0;
   let llmTagged = 0;
   if (seedSelection.seeds.length > 0) {
-    const tagged = await llmTagInBatches(seedSelection.seeds, flags.batchSize, promptHash, 'llm', tagConsumers);
+    const tagged = await llmTagInBatches(
+      seedSelection.seeds, flags.batchSize, promptHash, 'llm', tagConsumers, { phase: 'seed' },
+    );
     llmCalls += tagged.callCount;
     llmTagged += tagged.tagged;
     mergeByLeg(tagged.byLeg);
@@ -297,8 +304,16 @@ async function main() {
   // settings.embedding above.
   let propagated = 0;
   let uncertain: string[] = [];
+  let scanned = 0;
 
+  reportProgress({ phase: 'propagate', label: 'Propagating tags to neighbours', done: 0, total: targetUntagged.length });
   for (const id of targetUntagged) {
+    scanned += 1;
+    // The loop is synchronous — emit sparsely so a 30k-track scan doesn't
+    // spam stdout.
+    if (scanned % 500 === 0) {
+      reportProgress({ phase: 'propagate', label: 'Propagating tags to neighbours', done: scanned, total: targetUntagged.length });
+    }
     if (db.hasTags(id)) continue;        // already seeded
     if (!db.hasVector(id)) continue;     // no embedding → can't propagate
     const neighbours = db.knnById(id, knnK);
@@ -330,6 +345,7 @@ async function main() {
     }
   }
   console.log(`[tag] phase-3 propagated ${propagated} tracks; ${uncertain.length} uncertain (in scope)`);
+  reportProgress({ phase: 'propagate', label: 'Propagating tags to neighbours', done: targetUntagged.length, total: targetUntagged.length });
 
   // ---- Phase 4: ACTIVE-LEARN --------------------------------------------
   for (let round = 1; round <= maxRounds; round++) {
@@ -341,6 +357,7 @@ async function main() {
       promptHash,
       'uncertain-llm',
       tagConsumers,
+      { phase: 'learn', round },
     );
     llmCalls += tagged.callCount;
     llmTagged += tagged.tagged;
@@ -420,6 +437,12 @@ function finish(startedAt: number, llmCalls: number, llmTagged: number, byLeg: R
   console.log(
     `\n[tag] done in ${elapsed.toFixed(0)}s. llm_calls=${llmCalls} llm_tagged=${llmTagged}`,
   );
+  reportProgress({
+    phase: 'done',
+    label: 'Finished',
+    done: llmTagged,
+    llm: Object.keys(byLeg).length ? { legs: byLeg } : undefined,
+  });
   const legs = Object.entries(byLeg);
   if (legs.length > 1) {
     console.log(`[tag] per-leg: ${legs.map(([m, n]) => `${m}=${n}`).join(' · ')}`);
@@ -440,6 +463,7 @@ async function phaseEnrich(ids: string[], reEnrich: boolean): Promise<void> {
     console.log('[tag] phase-0 skipped: both lastfmTags and lyrics disabled in settings.embedding.enrichment');
     return;
   }
+  reportProgress({ phase: 'enrich', label: 'Enriching metadata', done: 0, total: ids.length });
   const artistTagCache = new Map<string, string[]>();
   let enrichedTracks = 0;
   let enrichedLyrics = 0;
@@ -489,6 +513,7 @@ async function phaseEnrich(ids: string[], reEnrich: boolean): Promise<void> {
       console.log(
         `[tag] enriched ${enrichedTracks}/${ids.length} (lastfm: ${enrichedTags}, lyrics: ${enrichedLyrics})`,
       );
+      reportProgress({ phase: 'enrich', label: 'Enriching metadata', done: enrichedTracks, total: ids.length });
     }
   }
   console.log(
@@ -519,6 +544,7 @@ async function phaseEmbed(targetIds: string[], batchSize: number): Promise<void>
     return;
   }
   console.log(`[tag] phase-1 embedding ${unique.length} tracks (batch=${batchSize})`);
+  reportProgress({ phase: 'embed', label: 'Embedding tracks', done: 0, total: unique.length });
 
   const embedBatchSize = Math.max(8, Math.min(64, batchSize * 2));
   for (let i = 0; i < unique.length; i += embedBatchSize) {
@@ -542,6 +568,7 @@ async function phaseEmbed(targetIds: string[], batchSize: number): Promise<void>
     }
     if ((i + batch.length) % 500 === 0 || i + batch.length === unique.length) {
       console.log(`[tag] embedded ${i + batch.length}/${unique.length}`);
+      reportProgress({ phase: 'embed', label: 'Embedding tracks', done: i + batch.length, total: unique.length });
     }
   }
 }
@@ -563,7 +590,17 @@ interface TagState {
   tagged: number;
   callCount: number;
   processed: number;
+  // Tracks that came back null from the LLM (batch entry dropped / per-track
+  // salvage failed) — surfaced in the progress channel.
+  errors: number;
   byLeg: Record<string, number>;
+}
+
+// Which pipeline phase a runConsumer() call is tagging for — only used to
+// stamp the progress channel ('seed' = phase 2, 'learn' = phase 4 rounds).
+interface TagPhaseInfo {
+  phase: 'seed' | 'learn';
+  round?: number;
 }
 
 // Tag one batch with one consumer's leg. Returns the count actually tagged.
@@ -619,7 +656,10 @@ async function processBatch(
   let tagged = 0;
   for (let j = 0; j < songs.length; j++) {
     const result = results[j];
-    if (!result) continue;
+    if (!result) {
+      state.errors += 1;
+      continue;
+    }
     const { moods, energy } = result;
     db.upsertTrackTags(songs[j].id, {
       moods,
@@ -645,6 +685,7 @@ async function runConsumer(
   source: db.TagSource,
   total: number,
   state: TagState,
+  phaseInfo: TagPhaseInfo,
   onDrop: (() => number) | null,
 ): Promise<void> {
   for (;;) {
@@ -667,6 +708,15 @@ async function runConsumer(
     if (state.processed % 4 === 0) {
       console.log(`[tag] LLM-tagged ${state.tagged}/${total}`);
     }
+    reportProgress({
+      phase: phaseInfo.phase,
+      label: 'Tagging with LLM',
+      done: state.tagged,
+      total,
+      round: phaseInfo.round,
+      errors: state.errors || undefined,
+      llm: { legs: state.byLeg },
+    });
   }
 }
 
@@ -678,21 +728,29 @@ async function llmTagInBatches(
   promptHash: string,
   source: db.TagSource,
   consumers: TagConsumer[],
+  phaseInfo: TagPhaseInfo,
 ): Promise<{ tagged: number; callCount: number; byLeg: Record<string, number> }> {
   const batches: string[][] = [];
   for (let i = 0; i < ids.length; i += batchSize) batches.push(ids.slice(i, i + batchSize));
 
-  const state: TagState = { tagged: 0, callCount: 0, processed: 0, byLeg: {} };
+  const state: TagState = { tagged: 0, callCount: 0, processed: 0, errors: 0, byLeg: {} };
+  reportProgress({
+    phase: phaseInfo.phase,
+    label: 'Tagging with LLM',
+    done: 0,
+    total: ids.length,
+    round: phaseInfo.round,
+  });
 
   if (consumers.length <= 1) {
     // Single consumer — no requeue/drop; the unpinned call already fails over
     // internally, so an error means the batch is genuinely unworkable this run.
-    await runConsumer(batches, consumers[0], promptHash, source, ids.length, state, null);
+    await runConsumer(batches, consumers[0], promptHash, source, ids.length, state, phaseInfo, null);
   } else {
     let alive = consumers.length;
     await Promise.all(
       consumers.map(c =>
-        runConsumer(batches, c, promptHash, source, ids.length, state, () => --alive)),
+        runConsumer(batches, c, promptHash, source, ids.length, state, phaseInfo, () => --alive)),
     );
     if (batches.length > 0) {
       const abandoned = batches.reduce((n, b) => n + b.length, 0);

--- a/controller/src/music/tagger-progress.ts
+++ b/controller/src/music/tagger-progress.ts
@@ -1,0 +1,38 @@
+// Structured progress channel between the tagger/analyzer child processes and
+// the controller. The children print one sentinel line per update on stdout;
+// broadcast/tagger.ts parses it into `tagger.progress` (and keeps it out of
+// lastLog). Dependency-free on purpose — imported by both CLI scripts and the
+// server.
+export const PROGRESS_PREFIX = '[progress] ';
+
+export type TaggerPhase =
+  | 'walk'
+  | 'enrich'
+  | 'embed'
+  | 'seed'
+  | 'propagate'
+  | 'learn'
+  | 'analyze'
+  | 'done';
+
+export interface TaggerProgress {
+  phase: TaggerPhase;
+  // Human-friendly line authored here (single source of truth) so the UI
+  // needs no phase→label map.
+  label: string;
+  done?: number;
+  // Absent total → indeterminate (e.g. the Navidrome walk, which doesn't
+  // pre-report a count).
+  total?: number;
+  // Active-learning round (phase 'learn' only).
+  round?: number;
+  // Cumulative failures within the current phase.
+  errors?: number;
+  // Per-leg tagged counts when dual-LLM mode is draining the batch queue.
+  llm?: { legs: Record<string, number> };
+  updatedAt: string;
+}
+
+export function reportProgress(p: Omit<TaggerProgress, 'updatedAt'>): void {
+  console.log(PROGRESS_PREFIX + JSON.stringify({ ...p, updatedAt: new Date().toISOString() }));
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2903,6 +2903,12 @@ body::after {
     background: var(--accent);
     transition: width 0.5s cubic-bezier(0.2, 0.7, 0.2, 1);
 }
+/* indeterminate run progress (e.g. library walk — no total known yet) */
+.admin-root .lib-bar.indet > span {
+    width: 30% !important;
+    animation: lib-bar-slide 1.4s ease-in-out infinite alternate;
+}
+@keyframes lib-bar-slide { 0% { margin-left: 0; } 100% { margin-left: 70%; } }
 .admin-root .lib-minibar {
     flex: 1; min-width: 120px; height: 5px;
     background: var(--field);
@@ -3058,6 +3064,7 @@ body::after {
 }
 @media (prefers-reduced-motion: reduce) {
     .admin-root .lib-livedot::after,
+    .admin-root .lib-bar.indet > span,
     .admin-root .lib-row.flash { animation: none; }
 }
 

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -19,13 +19,11 @@
 // so the page renders correctly under every palette — no hardcoded hex.
 
 import type { ChangeEvent, FormEvent, ReactNode } from 'react';
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  Search, RotateCcw, Sparkles, Activity, Play, Square, ChevronDown, ChevronRight,
-  Terminal, RefreshCw, ListPlus, X, Pencil,
+  Search, RotateCcw, Sparkles, RefreshCw, ListPlus, X, Pencil,
 } from 'lucide-react';
 import { useAdminAuth, ADMIN_API_URL } from '../../lib/adminAuth';
-import { useDynamicStyle } from '../../hooks/useDynamicStyle';
 import { notify, errorMessage } from '../../lib/notify';
 import { Input } from '../ui/input';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group';
@@ -34,8 +32,9 @@ import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
 } from '../ui/select';
 import { Card, Btn, Eyebrow, Pill, Seg } from './ui';
-import { V3AlertDialog } from '../ui/alert-dialog';
 import { cn } from '../../lib/cn';
+import TaggingPanel, { num } from './LibraryTaggingPanel';
+import type { Coverage, TaggerState, LibraryStatsLite, Batch, RescanOpts } from './LibraryTaggingPanel';
 
 // ---------------------------------------------------------------------------
 // types
@@ -69,44 +68,8 @@ interface BrowseResponse {
 
 interface UntaggedResponse { rows: Track[]; nextCursor: string | null }
 
-interface Coverage {
-  tagged: number;
-  analysed: number;
-  // Tracks with a CLAP audio (sounds-like) embedding. Same analysis backend,
-  // gated on ANALYZE_AUDIO_EMBEDDING — 0 when that's off even if bpm/key runs.
-  audioEmbedded?: number;
-  total: number | null;
-  percent: number | null;
-  analysedPercent: number | null;
-  audioEmbeddedPercent?: number | null;
-  scannedAt: string | null;
-  scanning: boolean;
-  // null = still probing; false = no analysis backend (sidecar/librosa) running.
-  analysisAvailable?: boolean | null;
-  analysisBackend?: string | null;
-}
-
-interface TaggerState {
-  running?: boolean;
-  pid?: number;
-  startedAt?: string;
-  lastLog?: string[];
-  // 'tag' (tag-library) or 'analyze' (the acoustic/audio-embedding pass) —
-  // both run through the same single-flight child slot.
-  mode?: 'tag' | 'analyze' | null;
-}
-
-// libraryStats rides along on /settings — gives moods-in-use, last-tag time,
-// and withEmbedding (used to nudge a re-embed after a model swap) without an
-// extra request and regardless of which tab is active.
-interface LibraryStatsLite {
-  total: number;
-  byMood: Record<string, number>;
-  byEnergy: Record<string, number>;
-  byGenre: Record<string, number>;
-  withEmbedding: number;
-  updatedAt: string | null;
-}
+// Coverage / TaggerState / LibraryStatsLite / Batch / RescanOpts live in
+// LibraryTaggingPanel.tsx alongside the panel that renders them.
 
 interface SettingsResponse {
   tagger?: TaggerState;
@@ -118,14 +81,6 @@ interface SettingsResponse {
 type Tab = 'recent' | 'browse' | 'search' | 'untagged';
 type Sort = 'artist' | 'title' | 'year' | 'taggedAt';
 type Energy = 'any' | 'low' | 'medium' | 'high';
-type Batch = '100' | '500' | 'all';
-
-type RescanOpts = {
-  reseed?: boolean;
-  reEnrich?: boolean;
-  reAnalyze?: boolean;
-  upgrade?: boolean;
-};
 
 const PAGE_SIZE = 50;
 
@@ -163,10 +118,6 @@ function Thumb({ track }: { track: Track }) {
   );
 }
 
-function num(n: number | null | undefined): string {
-  return n != null ? n.toLocaleString('en-GB') : '—';
-}
-
 // ---------------------------------------------------------------------------
 // panel
 // ---------------------------------------------------------------------------
@@ -193,10 +144,6 @@ export default function LibraryPanel() {
   // Mood vocab, lifted out of the browse response so the editor has it on any
   // tab (browse is the only call that returns it; lazily fetched otherwise).
   const [vocab, setVocab] = useState<string[]>([]);
-
-  // live-run progress baseline (best-effort: coverage delta vs. a captured
-  // target — the backend has no per-run counter). Set when WE start a run.
-  const [runInfo, setRunInfo] = useState<{ baseline: number; target: number | null } | null>(null);
 
   // browse state
   const [moods, setMoods] = useState<string[]>([]);
@@ -272,11 +219,6 @@ export default function LibraryPanel() {
     const id = setInterval(loadCoverage, 3_000);
     return () => clearInterval(id);
   }, [ready, tagger?.running, loadCoverage]);
-
-  // Clear the run baseline once the tagger stops.
-  useEffect(() => {
-    if (!tagger?.running) setRunInfo(null);
-  }, [tagger?.running]);
 
   // -----------------------------------------------------------------------
   // browse fetch — debounced on filter change
@@ -533,7 +475,6 @@ export default function LibraryPanel() {
     setTaggerBusy(true);
     try {
       const limit = batch === 'all' ? null : parseInt(batch, 10);
-      const target = batch === 'all' ? remaining : limit;
       const r = await adminFetch('/tag-library', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -543,7 +484,6 @@ export default function LibraryPanel() {
       if (!r.ok) throw new Error(j.error || `tagger start failed (${r.status})`);
       notify.ok('tagger started');
       setLogOpen(true);
-      setRunInfo({ baseline: coverage?.tagged ?? 0, target: target ?? null });
       await loadTagger();
     } catch (err) {
       notify.err(errorMessage(err));
@@ -679,7 +619,6 @@ export default function LibraryPanel() {
         coverage={coverage}
         libStats={libStats}
         tagger={tagger}
-        runInfo={runInfo}
         batch={batch}
         setBatch={setBatch}
         busy={taggerBusy}
@@ -826,306 +765,6 @@ export default function LibraryPanel() {
         </div>
       )}
     </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// tagging panel — merged coverage + tagger, framed for humans
-// ---------------------------------------------------------------------------
-interface TaggingPanelProps {
-  coverage: Coverage | null;
-  libStats: LibraryStatsLite | null;
-  tagger: TaggerState | null;
-  runInfo: { baseline: number; target: number | null } | null;
-  batch: Batch;
-  setBatch: (b: Batch) => void;
-  busy: boolean;
-  logOpen: boolean;
-  setLogOpen: (fn: (o: boolean) => boolean) => void;
-  onStart: () => void;
-  onStop: () => void;
-  onRescan: (opts: RescanOpts) => void;
-  // sounds-like (CLAP) controls — null until the first settings poll lands.
-  audioEnabled: boolean | null;
-  onToggleAudio: () => void;
-  onAnalyzeAudio: () => void;
-}
-
-function TaggingPanel(p: TaggingPanelProps) {
-  const [maintOpen, setMaintOpen] = useState(false);
-  const [confirmFull, setConfirmFull] = useState(false);
-  const [passes, setPasses] = useState<RescanOpts>({ reseed: false, reEnrich: false, reAnalyze: false, upgrade: false });
-  const logRef = useRef<HTMLPreElement>(null);
-  const moodFillRef = useRef<HTMLSpanElement>(null);
-  const acousticFillRef = useRef<HTMLSpanElement>(null);
-  const audioFillRef = useRef<HTMLSpanElement>(null);
-  const runFillRef = useRef<HTMLSpanElement>(null);
-
-  const tagged = p.coverage?.tagged ?? p.libStats?.total ?? null;
-  const total = p.coverage?.total ?? null;
-  const analysed = p.coverage?.analysed ?? null;
-  const audioEmbedded = p.coverage?.audioEmbedded ?? null;
-  const pct = p.coverage?.percent ?? null;
-  const apct = p.coverage?.analysedPercent ?? null;
-  const audpct = p.coverage?.audioEmbeddedPercent ?? null;
-  // Audio embeddings only exist once at least one is written; until then the
-  // row reads "not enabled" rather than a misleading 0% (CLAP is opt-in).
-  const audioOn = (audioEmbedded ?? 0) > 0;
-  const remaining = total != null && tagged != null ? Math.max(0, total - tagged) : null;
-  const running = !!p.tagger?.running;
-  const analysisOff = p.coverage?.analysisAvailable === false;
-  const moodCount = p.libStats ? Object.keys(p.libStats.byMood || {}).length : 0;
-  const lastTag = p.libStats?.updatedAt ? new Date(p.libStats.updatedAt).toLocaleString('en-GB') : '—';
-  const anySel = !!(passes.reseed || passes.reEnrich || passes.reAnalyze || passes.upgrade);
-
-  // Embeddings present but no vectors → likely a model swap dropped them.
-  const embeddingMissing = (tagged ?? 0) > 0 && p.libStats != null && p.libStats.withEmbedding === 0;
-
-  // live-run progress (best-effort: coverage delta vs. captured target)
-  const processed = p.runInfo && tagged != null ? Math.max(0, tagged - p.runInfo.baseline) : null;
-  const runPct = p.runInfo?.target && processed != null
-    ? Math.min(100, Math.round((processed / p.runInfo.target) * 100)) : null;
-
-  useDynamicStyle(moodFillRef, { width: pct != null ? `${Math.min(100, pct)}%` : '0%' });
-  useDynamicStyle(acousticFillRef, { width: !analysisOff && apct != null ? `${Math.min(100, apct)}%` : '0%' });
-  useDynamicStyle(audioFillRef, { width: audioOn && audpct != null ? `${Math.min(100, audpct)}%` : '0%' });
-  useDynamicStyle(runFillRef, { width: runPct != null ? `${runPct}%` : null });
-
-  useEffect(() => {
-    if (p.logOpen && logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
-  }, [p.logOpen, p.tagger?.lastLog?.length]);
-
-  const togglePass = (k: keyof RescanOpts) => setPasses(prev => ({ ...prev, [k]: !prev[k] }));
-
-  return (
-    <section className="card">
-      {/* headline */}
-      <div className="border-b border-ink p-6">
-        <Eyebrow className="text-vermilion">library · tagging</Eyebrow>
-        <h1 className="lib-hero-title">
-          {pct != null
-            ? <>Your DJ knows <span className="pct mono-num">{pct}%</span> of your library.</>
-            : <>Manage the music your station plays.</>}
-        </h1>
-        <p className="lib-hero-sub">
-          To pick the right track for any moment, the DJ reads the <b>mood</b> and <b>energy</b> of
-          every song. New tracks need tagging before they can go on air — that&rsquo;s what this does.
-        </p>
-      </div>
-
-      {/* coverage — mood primary, acoustic optional */}
-      <div className="border-b border-ink">
-        <div className="p-6">
-          <div className="flex flex-wrap items-baseline justify-between gap-3">
-            <span className="flex items-center gap-2 text-[11px] font-bold tracking-[0.16em] text-ink uppercase">
-              <Sparkles size={14} /> Mood &amp; energy tagged
-            </span>
-            <span className="mono-num text-[13px] font-bold">{pct != null ? `${pct}%` : '—'}</span>
-          </div>
-          <div className="mt-2 flex items-baseline gap-2">
-            <span className="lib-cov-big mono-num">{num(tagged)}</span>
-            <span className="text-[13px] text-muted">/ {total != null ? num(total) : (p.coverage?.scanning ? 'scanning…' : '—')} tracks</span>
-          </div>
-          <div className="lib-bar mt-3"><span ref={moodFillRef} /></div>
-          <div className="mt-2.5 text-[11px] text-muted">
-            {remaining != null && remaining > 0
-              ? <><b className="mono-num text-ink">{num(remaining)}</b> tracks still need tags · <span className="mono-num">{moodCount}</span> moods in use · last tag {lastTag}</>
-              : <>{remaining === 0 ? 'Every track is tagged' : 'Coverage updating…'} · <span className="mono-num">{moodCount}</span> moods in use · last tag {lastTag}</>}
-          </div>
-          {embeddingMissing && (
-            <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 border border-[color-mix(in_oklab,var(--accent)_30%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] text-ink">
-              <span><b>Embeddings missing.</b> Your embedding model may have changed — re-embed to restore similarity-based picks.</span>
-              <button
-                type="button"
-                className="font-bold text-vermilion underline-offset-2 hover:underline"
-                onClick={() => { setMaintOpen(true); setPasses(s => ({ ...s, reseed: true })); }}
-              >
-                Set up a re-embed →
-              </button>
-            </div>
-          )}
-        </div>
-        <div className="flex flex-wrap items-center gap-x-3.5 gap-y-2 border-t border-dashed border-separator-strong px-6 py-3.5">
-          <span className="caption flex items-center gap-2">
-            <Activity size={13} /> Acoustic analysis · bpm / key
-          </span>
-          <span className="lib-opt-tag">optional</span>
-          <span className="lib-minibar"><span ref={acousticFillRef} /></span>
-          <span className="caption mono-num !tracking-[0.04em]">
-            {analysisOff ? 'engine off' : <>{num(analysed)} / {num(total)} · {apct != null ? `${apct}%` : '…'}</>}
-          </span>
-          <span className="caption basis-full !tracking-[0.04em] !normal-case">
-            {analysisOff
-              ? 'No analysis engine running. Start the tts-heavy sidecar (docker compose --profile tts-heavy up -d) or configure a local librosa venv to enable it.'
-              : 'Improves beat-matching between tracks. Tagging works fine without it.'}
-          </span>
-        </div>
-        <div className="flex flex-wrap items-center gap-x-3.5 gap-y-2 border-t border-dashed border-separator-strong px-6 py-3.5">
-          <span className="caption flex items-center gap-2">
-            <Activity size={13} /> Audio fingerprint · sounds-like
-          </span>
-          <span className="lib-opt-tag">optional</span>
-          <span className="lib-minibar"><span ref={audioFillRef} /></span>
-          <span className="caption mono-num !tracking-[0.04em]">
-            {analysisOff
-              ? 'engine off'
-              : audioOn
-                ? <>{num(audioEmbedded)} / {num(total)} · {audpct != null ? `${audpct}%` : '…'}</>
-                : p.audioEnabled ? 'enabled — not yet analysed' : 'off'}
-          </span>
-          {!analysisOff && p.audioEnabled != null && (
-            <span className="flex items-center gap-2">
-              {p.audioEnabled && (
-                <Btn sm tone="accent" onClick={p.onAnalyzeAudio} disabled={running || p.busy}>
-                  <Play size={12} /> {audioOn ? 'Analyze new tracks' : 'Analyze library'}
-                </Btn>
-              )}
-              <Btn sm onClick={p.onToggleAudio} disabled={running || p.busy}>
-                {p.audioEnabled ? 'Disable' : 'Enable'}
-              </Btn>
-            </span>
-          )}
-          <span className="caption basis-full !tracking-[0.04em] !normal-case">
-            {analysisOff
-              ? 'Needs the analysis engine above.'
-              : audioOn
-                ? 'CLAP audio embeddings power “sounds-like” picks and sonic journeys — they catch sonic neighbours that metadata misses.'
-                : p.audioEnabled
-                  ? 'Run the analysis to fingerprint your tracks. The engine needs the CLAP model — if the bar stays at 0 after a run, rebuild the tts-heavy sidecar with WITH_CLAP=1.'
-                  : 'Listens to each track and fingerprints how it actually sounds, enabling “sounds-like” picks and sonic journeys. Adds a one-off analysis pass over your library.'}
-          </span>
-        </div>
-      </div>
-
-      {/* action zone — idle vs running */}
-      {!running ? (
-        <div className="flex flex-wrap items-center gap-4 p-6">
-          <div className="min-w-[220px] flex-1 text-[13px]">
-            {remaining != null && remaining > 0
-              ? <><b>{num(remaining)}</b> tracks are waiting. Tag them and they become DJ-ready.</>
-              : remaining === 0
-                ? <>Library fully tagged. Run a re-scan below if you&rsquo;ve changed the model.</>
-                : <>Start tagging new tracks so the DJ can play them.</>}
-          </div>
-          <div className="flex flex-wrap items-center gap-2.5">
-            <div className="lib-batch">
-              <label htmlFor="lib-batch">Tag</label>
-              <select id="lib-batch" value={p.batch} onChange={e => p.setBatch(e.target.value as Batch)}>
-                <option value="100">next 100</option>
-                <option value="500">next 500</option>
-                <option value="all">all{remaining != null ? ` ${num(remaining)}` : ''} remaining</option>
-              </select>
-            </div>
-            <Btn lg tone="accent" onClick={p.onStart} disabled={p.busy || remaining === 0}>
-              <Play size={13} /> Start tagging
-            </Btn>
-          </div>
-        </div>
-      ) : (
-        <div className="flex flex-col gap-3 p-6">
-          <div className="flex flex-wrap items-center justify-between gap-3.5">
-            <span className="flex items-center gap-2.5 text-[13px] font-bold">
-              <span className="lib-livedot" /> {p.tagger?.mode === 'analyze' ? 'Audio analysis in progress…' : 'Tagging in progress…'}
-            </span>
-            <span className="caption mono-num !tracking-[0.04em]">
-              {processed != null && <>{num(processed)}{p.runInfo?.target ? ` / ${num(p.runInfo.target)}` : ''} this run · </>}
-              {p.tagger?.pid ? `pid ${p.tagger.pid}` : ''}
-              {p.tagger?.startedAt ? ` · started ${new Date(p.tagger.startedAt).toLocaleTimeString('en-GB')}` : ''}
-            </span>
-            <Btn sm tone="danger" onClick={p.onStop} disabled={p.busy}><Square size={11} /> Stop</Btn>
-          </div>
-          {runPct != null && (
-            <div className="lib-bar !h-1.5"><span ref={runFillRef} /></div>
-          )}
-          <div className="caption !tracking-[0.04em] !normal-case">
-            {p.tagger?.mode === 'analyze'
-              ? <>The analysis engine is listening to each track — measuring tempo and key, and fingerprinting how it sounds. You can keep browsing — this runs in the background.</>
-              : <>The DJ is listening to each new track and deciding its mood &amp; energy. You can keep browsing — this runs in the background.</>}
-          </div>
-        </div>
-      )}
-
-      {/* footer — progressive disclosure */}
-      <div className="flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-dashed border-separator-strong px-6 py-3">
-        <button
-          type="button"
-          className={cn('inline-flex items-center gap-1.5 text-[11px] font-bold', maintOpen ? 'text-ink' : 'text-muted hover:text-ink')}
-          onClick={() => setMaintOpen(o => !o)}
-        >
-          {maintOpen ? <ChevronDown size={13} /> : <ChevronRight size={13} />} Maintenance &amp; re-scan
-        </button>
-        <button
-          type="button"
-          className={cn('inline-flex items-center gap-1.5 text-[11px] font-bold', p.logOpen ? 'text-ink' : 'text-muted hover:text-ink')}
-          onClick={() => p.setLogOpen(o => !o)}
-        >
-          <Terminal size={13} /> {p.logOpen ? 'Hide log' : 'View log'}
-        </button>
-      </div>
-
-      {/* maintenance disclosure */}
-      {maintOpen && (
-        <div className="flex flex-col gap-3.5 border-t border-ink bg-[var(--ink-soft)] p-6">
-          <div className="max-w-[64ch] text-[12px] leading-[1.55] text-muted">
-            Re-scanning rebuilds parts of the index from scratch — only needed after you change the
-            LLM, embedding model, or analysis engine. Your existing mood tags are kept as seeds.
-            Pick what to re-run:
-          </div>
-          <div className="grid gap-2.5 sm:grid-cols-2">
-            <Pass on={!!passes.reseed} onClick={() => togglePass('reseed')} name="Re-embed all tracks"
-              hint="Drop & rebuild every vector. Run after changing the embedding model." />
-            <Pass on={!!passes.reEnrich} onClick={() => togglePass('reEnrich')} name="Re-enrich metadata"
-              hint="Re-fetch Last.fm tags + lyrics that feed the tagging." />
-            <Pass on={!!passes.reAnalyze} onClick={() => togglePass('reAnalyze')} name="Re-analyse acoustics"
-              hint="Redo BPM / key detection for every track." />
-            <Pass on={!!passes.upgrade} onClick={() => togglePass('upgrade')} name="Re-decide moods"
-              hint="Re-tag tracks whose prompt or model is now stale." />
-          </div>
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <Btn sm disabled={p.busy || running} onClick={() => setConfirmFull(true)}>
-              <RefreshCw size={12} /> Full re-scan (everything)
-            </Btn>
-            <Btn sm tone="accent" disabled={!anySel || p.busy || running}
-              onClick={() => { p.onRescan(passes); setPasses({ reseed: false, reEnrich: false, reAnalyze: false, upgrade: false }); }}>
-              Run selected passes
-            </Btn>
-          </div>
-        </div>
-      )}
-
-      {/* log drawer — reuses the theme-aware .term surface */}
-      {p.logOpen && (
-        <pre ref={logRef} className="term m-0 max-h-56 overflow-y-auto !border-t !border-l-0 border-separator-strong">
-          {(p.tagger?.lastLog || []).join('\n') || '(no log output yet — start a tagging run to see the booth think)'}
-        </pre>
-      )}
-
-      <V3AlertDialog
-        open={confirmFull}
-        onOpenChange={setConfirmFull}
-        title="Full library re-scan"
-        description="Rebuilds the whole library from scratch: re-embeds every track, re-fetches Last.fm tags + lyrics, and redoes acoustic (bpm/key) analysis. Existing mood tags are kept and reused as seeds — moods are not re-decided. This can take several minutes on a large library and re-spends embedding calls. To re-decide moods too, tick 'Re-decide moods' and use 'Run selected passes'."
-        confirmLabel="full re-scan"
-        danger
-        onConfirm={() => p.onRescan({ reseed: true, reEnrich: true, reAnalyze: true })}
-      />
-    </section>
-  );
-}
-
-function Pass({ on, onClick, name, hint }: { on: boolean; onClick: () => void; name: string; hint: string }) {
-  return (
-    <button type="button" className={cn('lib-pass', on && 'on')} onClick={onClick}>
-      <span className="box">
-        <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
-          <path d="M2.5 6.2L4.8 8.5L9.5 3.5" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      </span>
-      <span>
-        <span className="lib-pass-name">{name}</span>
-        <span className="lib-pass-hint">{hint}</span>
-      </span>
-    </button>
   );
 }
 

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -1,0 +1,425 @@
+'use client';
+
+// The "Your DJ knows X%" tagging panel at the top of /admin/library —
+// coverage hero, the primary Start-tagging action, live structured run
+// progress, and the progressive-disclosure Maintenance & advanced drawer
+// (which also houses the optional acoustic + audio-fingerprint passes).
+// Extracted from LibraryPanel.tsx; the browse/search/untagged experience
+// stays over there.
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  Sparkles, Activity, Play, Square, ChevronDown, ChevronRight, Terminal, RefreshCw,
+} from 'lucide-react';
+import { useDynamicStyle } from '../../hooks/useDynamicStyle';
+import { Btn, Eyebrow } from './ui';
+import { V3AlertDialog } from '../ui/alert-dialog';
+import { cn } from '../../lib/cn';
+
+// ---------------------------------------------------------------------------
+// shared types (also consumed by LibraryPanel)
+// ---------------------------------------------------------------------------
+export interface Coverage {
+  tagged: number;
+  analysed: number;
+  // Tracks with a CLAP audio (sounds-like) embedding. Same analysis backend,
+  // gated on ANALYZE_AUDIO_EMBEDDING — 0 when that's off even if bpm/key runs.
+  audioEmbedded?: number;
+  total: number | null;
+  percent: number | null;
+  analysedPercent: number | null;
+  audioEmbeddedPercent?: number | null;
+  scannedAt: string | null;
+  scanning: boolean;
+  // null = still probing; false = no analysis backend (sidecar/librosa) running.
+  analysisAvailable?: boolean | null;
+  analysisBackend?: string | null;
+}
+
+// Mirrors controller/src/music/tagger-progress.ts — the structured sentinel
+// the tagger child emits and /settings relays.
+export interface TaggerProgress {
+  phase: 'walk' | 'enrich' | 'embed' | 'seed' | 'propagate' | 'learn' | 'analyze' | 'done';
+  label: string;
+  done?: number;
+  total?: number;        // absent → indeterminate (e.g. the Navidrome walk)
+  round?: number;        // active-learn round
+  errors?: number;
+  llm?: { legs: Record<string, number> };
+  updatedAt: string;
+}
+
+export interface TaggerState {
+  running?: boolean;
+  pid?: number;
+  startedAt?: string;
+  lastLog?: string[];
+  // 'tag' (tag-library) or 'analyze' (the acoustic/audio-embedding pass) —
+  // both run through the same single-flight child slot.
+  mode?: 'tag' | 'analyze' | null;
+  progress?: TaggerProgress | null;
+}
+
+// libraryStats rides along on /settings — gives moods-in-use, last-tag time,
+// and withEmbedding (used to nudge a re-embed after a model swap) without an
+// extra request and regardless of which tab is active.
+export interface LibraryStatsLite {
+  total: number;
+  byMood: Record<string, number>;
+  byEnergy: Record<string, number>;
+  byGenre: Record<string, number>;
+  withEmbedding: number;
+  updatedAt: string | null;
+}
+
+export type Batch = '100' | '500' | 'all';
+
+export type RescanOpts = {
+  reseed?: boolean;
+  reEnrich?: boolean;
+  reAnalyze?: boolean;
+  upgrade?: boolean;
+};
+
+export function num(n: number | null | undefined): string {
+  return n != null ? n.toLocaleString('en-GB') : '—';
+}
+
+// ---------------------------------------------------------------------------
+// tagging panel — merged coverage + tagger, framed for humans
+// ---------------------------------------------------------------------------
+interface TaggingPanelProps {
+  coverage: Coverage | null;
+  libStats: LibraryStatsLite | null;
+  tagger: TaggerState | null;
+  batch: Batch;
+  setBatch: (b: Batch) => void;
+  busy: boolean;
+  logOpen: boolean;
+  setLogOpen: (fn: (o: boolean) => boolean) => void;
+  onStart: () => void;
+  onStop: () => void;
+  onRescan: (opts: RescanOpts) => void;
+  // sounds-like (CLAP) controls — null until the first settings poll lands.
+  audioEnabled: boolean | null;
+  onToggleAudio: () => void;
+  onAnalyzeAudio: () => void;
+}
+
+// One friendly sentence per pipeline phase — shown under the live progress so
+// the operator knows what the run is actually doing right now.
+const PHASE_HINT: Record<TaggerProgress['phase'], string> = {
+  walk: 'Reading the track list from Navidrome.',
+  enrich: 'Fetching Last.fm tags and lyrics that help the DJ understand each track.',
+  embed: 'Computing similarity vectors so tags can spread between similar tracks.',
+  seed: 'The DJ is deciding mood & energy for a representative set of tracks.',
+  propagate: 'Spreading tags from tagged tracks to their closest sonic neighbours.',
+  learn: 'The DJ is re-checking tracks the automatic spread wasn’t confident about.',
+  analyze: 'Measuring tempo and key, and fingerprinting how each track sounds.',
+  done: 'Wrapping up.',
+};
+
+export default function TaggingPanel(p: TaggingPanelProps) {
+  const [maintOpen, setMaintOpen] = useState(false);
+  const [confirmFull, setConfirmFull] = useState(false);
+  const [passes, setPasses] = useState<RescanOpts>({ reseed: false, reEnrich: false, reAnalyze: false, upgrade: false });
+  const logRef = useRef<HTMLPreElement>(null);
+  const moodFillRef = useRef<HTMLSpanElement>(null);
+  const acousticFillRef = useRef<HTMLSpanElement>(null);
+  const audioFillRef = useRef<HTMLSpanElement>(null);
+  const runFillRef = useRef<HTMLSpanElement>(null);
+
+  const tagged = p.coverage?.tagged ?? p.libStats?.total ?? null;
+  const total = p.coverage?.total ?? null;
+  const analysed = p.coverage?.analysed ?? null;
+  const audioEmbedded = p.coverage?.audioEmbedded ?? null;
+  const pct = p.coverage?.percent ?? null;
+  const apct = p.coverage?.analysedPercent ?? null;
+  const audpct = p.coverage?.audioEmbeddedPercent ?? null;
+  // Audio embeddings only exist once at least one is written; until then the
+  // row reads "not enabled" rather than a misleading 0% (CLAP is opt-in).
+  const audioOn = (audioEmbedded ?? 0) > 0;
+  const remaining = total != null && tagged != null ? Math.max(0, total - tagged) : null;
+  const running = !!p.tagger?.running;
+  const analysisOff = p.coverage?.analysisAvailable === false;
+  const moodCount = p.libStats ? Object.keys(p.libStats.byMood || {}).length : 0;
+  const lastTag = p.libStats?.updatedAt ? new Date(p.libStats.updatedAt).toLocaleString('en-GB') : '—';
+  const anySel = !!(passes.reseed || passes.reEnrich || passes.reAnalyze || passes.upgrade);
+
+  // Embeddings present but no vectors → likely a model swap dropped them.
+  const embeddingMissing = (tagged ?? 0) > 0 && p.libStats != null && p.libStats.withEmbedding === 0;
+
+  // Structured live-run progress from the tagger child — survives page
+  // reloads and runs started elsewhere (no client-captured baseline). Null
+  // for an old child binary → the running view falls back to generic copy.
+  const progress = running ? (p.tagger?.progress ?? null) : null;
+  const runPct = progress?.total
+    ? Math.min(100, Math.round(((progress.done ?? 0) / progress.total) * 100))
+    : null;
+  const runIndeterminate = !!progress && progress.total == null && progress.phase !== 'done';
+  const legEntries = progress?.llm ? Object.entries(progress.llm.legs) : [];
+
+  useDynamicStyle(moodFillRef, { width: pct != null ? `${Math.min(100, pct)}%` : '0%' });
+  useDynamicStyle(acousticFillRef, { width: !analysisOff && apct != null ? `${Math.min(100, apct)}%` : '0%' });
+  useDynamicStyle(audioFillRef, { width: audioOn && audpct != null ? `${Math.min(100, audpct)}%` : '0%' });
+  useDynamicStyle(runFillRef, { width: runPct != null ? `${runPct}%` : null });
+
+  useEffect(() => {
+    if (p.logOpen && logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
+  }, [p.logOpen, p.tagger?.lastLog?.length]);
+
+  const togglePass = (k: keyof RescanOpts) => setPasses(prev => ({ ...prev, [k]: !prev[k] }));
+
+  return (
+    <section className="card">
+      {/* headline */}
+      <div className="border-b border-ink p-6">
+        <Eyebrow className="text-vermilion">library · tagging</Eyebrow>
+        <h1 className="lib-hero-title">
+          {pct != null
+            ? <>Your DJ knows <span className="pct mono-num">{pct}%</span> of your library.</>
+            : <>Manage the music your station plays.</>}
+        </h1>
+        <p className="lib-hero-sub">
+          The DJ reads each track&rsquo;s <b>mood</b> and <b>energy</b> to pick the right song for
+          the moment — new tracks need tagging before they go on air.
+        </p>
+      </div>
+
+      {/* coverage — the single hero meter */}
+      <div className="border-b border-ink">
+        <div className="p-6">
+          <div className="flex flex-wrap items-baseline justify-between gap-3">
+            <span className="flex items-center gap-2 text-[11px] font-bold tracking-[0.16em] text-ink uppercase">
+              <Sparkles size={14} /> Mood &amp; energy tagged
+            </span>
+            <span className="mono-num text-[13px] font-bold">{pct != null ? `${pct}%` : '—'}</span>
+          </div>
+          <div className="mt-2 flex items-baseline gap-2">
+            <span className="lib-cov-big mono-num">{num(tagged)}</span>
+            <span className="text-[13px] text-muted">/ {total != null ? num(total) : (p.coverage?.scanning ? 'scanning…' : '—')} tracks</span>
+          </div>
+          <div className="lib-bar mt-3"><span ref={moodFillRef} /></div>
+          <div className="mt-2.5 text-[11px] text-muted">
+            {remaining != null && remaining > 0
+              ? <><b className="mono-num text-ink">{num(remaining)}</b> tracks still need tags · <span className="mono-num">{moodCount}</span> moods in use · last tag {lastTag}</>
+              : <>{remaining === 0 ? 'Every track is tagged' : 'Coverage updating…'} · <span className="mono-num">{moodCount}</span> moods in use · last tag {lastTag}</>}
+          </div>
+          {embeddingMissing && (
+            <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 border border-[color-mix(in_oklab,var(--accent)_30%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] text-ink">
+              <span><b>Embeddings missing.</b> Your embedding model may have changed — re-embed to restore similarity-based picks.</span>
+              <button
+                type="button"
+                className="font-bold text-vermilion underline-offset-2 hover:underline"
+                onClick={() => { setMaintOpen(true); setPasses(s => ({ ...s, reseed: true })); }}
+              >
+                Set up a re-embed →
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* action zone — idle vs running */}
+      {!running ? (
+        <div className="flex flex-wrap items-center gap-4 p-6">
+          <div className="min-w-[220px] flex-1 text-[13px]">
+            {remaining != null && remaining > 0
+              ? <><b>{num(remaining)}</b> tracks are waiting. Tag them and they become DJ-ready.</>
+              : remaining === 0
+                ? <>Library fully tagged. Run a re-scan below if you&rsquo;ve changed the model.</>
+                : <>Start tagging new tracks so the DJ can play them.</>}
+          </div>
+          <div className="flex flex-wrap items-center gap-2.5">
+            <div className="lib-batch">
+              <label htmlFor="lib-batch">Tag</label>
+              <select id="lib-batch" value={p.batch} onChange={e => p.setBatch(e.target.value as Batch)}>
+                <option value="100">next 100</option>
+                <option value="500">next 500</option>
+                <option value="all">all{remaining != null ? ` ${num(remaining)}` : ''} remaining</option>
+              </select>
+            </div>
+            <Btn lg tone="accent" onClick={p.onStart} disabled={p.busy || remaining === 0}>
+              <Play size={13} /> Start tagging
+            </Btn>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3 p-6">
+          <div className="flex flex-wrap items-center justify-between gap-3.5">
+            <span className="flex items-center gap-2.5 text-[13px] font-bold">
+              <span className="lib-livedot" />
+              {progress ? (
+                <>
+                  {progress.label}
+                  {progress.round != null && ` · round ${progress.round}`}
+                  {progress.done != null && (
+                    <span className="mono-num">
+                      &nbsp;· {num(progress.done)}{progress.total != null && <> / {num(progress.total)}</>}
+                    </span>
+                  )}
+                </>
+              ) : (
+                p.tagger?.mode === 'analyze' ? 'Audio analysis in progress…' : 'Tagging in progress…'
+              )}
+            </span>
+            <span className="caption mono-num !tracking-[0.04em]">
+              {runPct != null && `${runPct}% · `}
+              {p.tagger?.pid ? `pid ${p.tagger.pid}` : ''}
+              {p.tagger?.startedAt ? ` · started ${new Date(p.tagger.startedAt).toLocaleTimeString('en-GB')}` : ''}
+            </span>
+            <Btn sm tone="danger" onClick={p.onStop} disabled={p.busy}><Square size={11} /> Stop</Btn>
+          </div>
+          {(runPct != null || runIndeterminate) && (
+            <div className={cn('lib-bar !h-1.5', runIndeterminate && 'indet')}><span ref={runFillRef} /></div>
+          )}
+          {(legEntries.length > 1 || (progress?.errors ?? 0) > 0) && (
+            <div className="caption mono-num !tracking-[0.04em]">
+              {legEntries.length > 1 && <>dual-LLM · {legEntries.map(([m, n]) => `${m} ${num(n)}`).join(' · ')}</>}
+              {legEntries.length > 1 && (progress?.errors ?? 0) > 0 && ' · '}
+              {(progress?.errors ?? 0) > 0 && <span className="text-vermilion">{num(progress!.errors)} failed</span>}
+            </div>
+          )}
+          <div className="caption !tracking-[0.04em] !normal-case">
+            {(progress && PHASE_HINT[progress.phase]) ||
+              (p.tagger?.mode === 'analyze'
+                ? 'The analysis engine is listening to each track — measuring tempo and key, and fingerprinting how it sounds.'
+                : 'The DJ is listening to each new track and deciding its mood & energy.')}
+            {' '}You can keep browsing — this runs in the background.
+          </div>
+        </div>
+      )}
+
+      {/* footer — progressive disclosure */}
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-dashed border-separator-strong px-6 py-3">
+        <button
+          type="button"
+          className={cn('inline-flex items-center gap-1.5 text-[11px] font-bold', maintOpen ? 'text-ink' : 'text-muted hover:text-ink')}
+          onClick={() => setMaintOpen(o => !o)}
+        >
+          {maintOpen ? <ChevronDown size={13} /> : <ChevronRight size={13} />} Maintenance &amp; advanced
+        </button>
+        <button
+          type="button"
+          className={cn('inline-flex items-center gap-1.5 text-[11px] font-bold', p.logOpen ? 'text-ink' : 'text-muted hover:text-ink')}
+          onClick={() => p.setLogOpen(o => !o)}
+        >
+          <Terminal size={13} /> {p.logOpen ? 'Hide log' : 'View log'}
+        </button>
+      </div>
+
+      {/* maintenance & advanced disclosure */}
+      {maintOpen && (
+        <div className="flex flex-col gap-3.5 border-t border-ink bg-[var(--ink-soft)] p-6">
+          {/* optional acoustic / audio-fingerprint passes — tucked away here so
+              the default view stays focused on mood & energy */}
+          <div className="flex flex-wrap items-center gap-x-3.5 gap-y-2">
+            <span className="caption flex items-center gap-2">
+              <Activity size={13} /> Acoustic analysis · bpm / key
+            </span>
+            <span className="lib-opt-tag">optional</span>
+            <span className="lib-minibar"><span ref={acousticFillRef} /></span>
+            <span className="caption mono-num !tracking-[0.04em]">
+              {analysisOff ? 'engine off' : <>{num(analysed)} / {num(total)} · {apct != null ? `${apct}%` : '…'}</>}
+            </span>
+            <span className="caption basis-full !tracking-[0.04em] !normal-case">
+              {analysisOff
+                ? 'No analysis engine running — start the tts-heavy sidecar (docker compose --profile tts-heavy up -d) or configure a local librosa venv.'
+                : 'Improves beat-matching between tracks; tagging works fine without it.'}
+            </span>
+          </div>
+          <div className="flex flex-wrap items-center gap-x-3.5 gap-y-2 border-t border-dashed border-separator-strong pt-3.5">
+            <span className="caption flex items-center gap-2">
+              <Activity size={13} /> Audio fingerprint · sounds-like
+            </span>
+            <span className="lib-opt-tag">optional</span>
+            <span className="lib-minibar"><span ref={audioFillRef} /></span>
+            <span className="caption mono-num !tracking-[0.04em]">
+              {analysisOff
+                ? 'engine off'
+                : audioOn
+                  ? <>{num(audioEmbedded)} / {num(total)} · {audpct != null ? `${audpct}%` : '…'}</>
+                  : p.audioEnabled ? 'enabled — not yet analysed' : 'off'}
+            </span>
+            {!analysisOff && p.audioEnabled != null && (
+              <span className="flex items-center gap-2">
+                {p.audioEnabled && (
+                  <Btn sm tone="accent" onClick={p.onAnalyzeAudio} disabled={running || p.busy}>
+                    <Play size={12} /> {audioOn ? 'Analyze new tracks' : 'Analyze library'}
+                  </Btn>
+                )}
+                <Btn sm onClick={p.onToggleAudio} disabled={running || p.busy}>
+                  {p.audioEnabled ? 'Disable' : 'Enable'}
+                </Btn>
+              </span>
+            )}
+            <span className="caption basis-full !tracking-[0.04em] !normal-case">
+              {analysisOff
+                ? 'Needs the analysis engine above.'
+                : audioOn || !p.audioEnabled
+                  ? 'Listens to each track and fingerprints how it sounds, enabling “sounds-like” picks and sonic journeys.'
+                  : 'Run the analysis to fingerprint your tracks — if the bar stays at 0 after a run, rebuild the tts-heavy sidecar with WITH_CLAP=1.'}
+            </span>
+          </div>
+
+          <div className="max-w-[64ch] border-t border-dashed border-separator-strong pt-3.5 text-[12px] leading-[1.55] text-muted">
+            Re-scanning rebuilds parts of the index — only needed after changing the LLM, embedding
+            model, or analysis engine. Existing mood tags are kept as seeds.
+          </div>
+          <div className="grid gap-2.5 sm:grid-cols-2">
+            <Pass on={!!passes.reseed} onClick={() => togglePass('reseed')} name="Re-embed all tracks"
+              hint="Drop & rebuild every vector. Run after changing the embedding model." />
+            <Pass on={!!passes.reEnrich} onClick={() => togglePass('reEnrich')} name="Re-enrich metadata"
+              hint="Re-fetch Last.fm tags + lyrics that feed the tagging." />
+            <Pass on={!!passes.reAnalyze} onClick={() => togglePass('reAnalyze')} name="Re-analyse acoustics"
+              hint="Redo BPM / key detection for every track." />
+            <Pass on={!!passes.upgrade} onClick={() => togglePass('upgrade')} name="Re-decide moods"
+              hint="Re-tag tracks whose prompt or model is now stale." />
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <Btn sm disabled={p.busy || running} onClick={() => setConfirmFull(true)}>
+              <RefreshCw size={12} /> Full re-scan (everything)
+            </Btn>
+            <Btn sm tone="accent" disabled={!anySel || p.busy || running}
+              onClick={() => { p.onRescan(passes); setPasses({ reseed: false, reEnrich: false, reAnalyze: false, upgrade: false }); }}>
+              Run selected passes
+            </Btn>
+          </div>
+        </div>
+      )}
+
+      {/* log drawer — reuses the theme-aware .term surface */}
+      {p.logOpen && (
+        <pre ref={logRef} className="term m-0 max-h-56 overflow-y-auto !border-t !border-l-0 border-separator-strong">
+          {(p.tagger?.lastLog || []).join('\n') || '(no log output yet — start a tagging run to see the booth think)'}
+        </pre>
+      )}
+
+      <V3AlertDialog
+        open={confirmFull}
+        onOpenChange={setConfirmFull}
+        title="Full library re-scan"
+        description="Rebuilds the whole library from scratch: re-embeds every track, re-fetches Last.fm tags + lyrics, and redoes acoustic (bpm/key) analysis. Existing mood tags are kept and reused as seeds — moods are not re-decided. This can take several minutes on a large library and re-spends embedding calls. To re-decide moods too, tick 'Re-decide moods' and use 'Run selected passes'."
+        confirmLabel="full re-scan"
+        danger
+        onConfirm={() => p.onRescan({ reseed: true, reEnrich: true, reAnalyze: true })}
+      />
+    </section>
+  );
+}
+
+function Pass({ on, onClick, name, hint }: { on: boolean; onClick: () => void; name: string; hint: string }) {
+  return (
+    <button type="button" className={cn('lib-pass', on && 'on')} onClick={onClick}>
+      <span className="box">
+        <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
+          <path d="M2.5 6.2L4.8 8.5L9.5 3.5" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </span>
+      <span>
+        <span className="lib-pass-name">{name}</span>
+        <span className="lib-pass-hint">{hint}</span>
+      </span>
+    </button>
+  );
+}

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -129,6 +129,7 @@ export default defineConfig([
             '^on$',
             '^box$',
             '^flash$',
+            '^indet$',
             '^pct$',
             '^h-tags$',
             '^h-album$',


### PR DESCRIPTION
## What

Simplifies the /admin/library tagging panel and replaces the client-side coverage-delta progress guess with a real, structured progress channel from the tagger child process.

## Why

The panel had accreted three stacked progress meters (mood, acoustic bpm/key, audio fingerprint) each with long explainer paragraphs, and the only live-run feedback was a `runInfo` baseline captured client-side when *you* clicked Start — it broke on page reload and showed nothing for runs started elsewhere. Meanwhile `tag-library.ts` already knew its phase, x/y counts, model, and dual-LLM leg stats internally.

## Backend

- **New `music/tagger-progress.ts`** — `[progress]` stdout sentinel + shared `TaggerProgress` type. `reportProgress()` is emitted from every pipeline phase of `tag-library.ts` (walk / enrich / embed / seed / propagate / learn / done) and from the shared analysis pass in `analyze.ts`, which covers the standalone analyzer for free.
- **`broadcast/tagger.ts`** parses sentinels into `tagger.progress` with per-stream line buffering (also fixes a latent bug where chunk-split log lines were logged as halves) and keeps them out of `lastLog` — the log drawer gets cleaner. Rides on the existing `/settings` poll; no route changes.
- LLM phases report per-leg dual-LLM tagged counts and a failed-track count.

## Web

- **Mood & energy is the single hero meter.** Acoustic bpm/key + audio fingerprint rows (meters, Enable/Disable toggle, Analyze button) move into the renamed **Maintenance & advanced** drawer, explainers trimmed to one line. No features removed.
- **Running view shows real progress**: phase label, x/y counts, percent bar (indeterminate pulse during the Navidrome walk), active-learn round, dual-LLM per-leg counts, error count — and survives page reloads / runs started elsewhere, since progress now comes from the server. The `runInfo` hack is deleted.
- Backwards-compatible: when `progress` is absent (stale child, run in flight during deploy) the view falls back to the previous generic copy.
- `TaggingPanel` extracted to `LibraryTaggingPanel.tsx` (mechanical split; `LibraryPanel.tsx` drops from ~1,480 to ~1,100 lines).

Also untracks `controller/node_modules` — an accidentally-committed broken symlink to a macOS-local path that slipped past `.gitignore`'s `node_modules/` dir pattern in #325.

## Verification

- `npm run lint` passes in both `controller/` and `web/`.
- Live-tested on the dev stack: a `limit: 30` run against a 7,093-track library reported walk → embed (30/30) → seed (25/30) → learn round 1 → done (31 tagged, per-leg counts present), exit 0. Browser screenshots confirmed the indeterminate walk bar, determinate embed bar, relocated maintenance rows, and a log drawer free of `[progress]` lines — all in a browser session that never started the run.