### PR TITLE
docs(web): announce mobile apps live + copy cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It's *radio*, not a playlist. No per-listener shuffle, no skip button, no
 
 - **Project site** — [getsubwave.com](https://www.getsubwave.com/)
 - **Demo player** — [getsubwave.com/listen](https://www.getsubwave.com/listen)
-- **Mobile apps (beta)** — native iOS & Android players — [join the beta](https://github.com/perminder-klair/subwave/discussions/289)
+- **Mobile apps** — native players — [Android on Google Play](https://play.google.com/store/apps/details?id=com.getsubwave.app), [iOS via TestFlight](https://testflight.apple.com/join/Xrx5TUmb)
 - **Setup walkthrough** — [getsubwave.com/setup](https://www.getsubwave.com/setup)
 - **Operator manual** — [getsubwave.com/manual](https://www.getsubwave.com/manual)
 - **Community** — [join the Discord](https://discord.gg/vjVbVKnMBa)
@@ -47,7 +47,7 @@ It's *radio*, not a playlist. No per-listener shuffle, no skip button, no
 - **Five TTS engines.** Piper and Kokoro in-process for fast local speech, plus an optional `tts-heavy` sidecar (`docker compose --profile tts-heavy up -d`) that adds Chatterbox (zero-shot voice cloning) and PocketTTS (6× real-time, EN/FR/DE/IT/ES/PT). Cloud (OpenAI / ElevenLabs) is also available. Pick a different engine per kind of speech.
 - **Multiple DJ personas.** Up to 10 souls in rotation, each with its own voice and writing style.
 - **Dual-codec broadcast.** MP3 128 kbps for Sonos, hardware radios, and cars; Ogg-Opus 96 kbps for modern browsers. The web player picks automatically.
-- **Native apps, PWA, and TUI.** Native iOS and Android players (in beta — background audio, lock-screen / CarPlay / Android Auto controls, multi-station), an installable PWA on phone and desktop, and a TUI for the command line.
+- **Native apps, PWA, and TUI.** Native iOS (TestFlight beta) and Android (on Google Play) players — background audio, lock-screen / CarPlay / Android Auto controls, multi-station — an installable PWA on phone and desktop, and a TUI for the command line.
 - **Scheduled shows.** A 24×7 grid; each slot has its own persona, mood, and skills.
 - **Pluggable skills.** The DJ's between-track segments — weather, news, traffic, and your own — are skills. The built-ins are scaffolded as editable files under `state/skills/<kind>/` on first boot, so you can rewrite a brief or change the news feed (BBC → your own RSS) right from the admin console — no code, no redeploy. Add your own by dropping a `SKILL.md` (plus optional data-fetching code) into `state/skills/`, hitting Rescan, and enabling it. See [`docs/custom-skills.md`](docs/custom-skills.md).
 - **Mood-aware rotation.** Time of day, weather, and festival days bias what gets played and how the DJ talks.

--- a/web/app/manual/faq/page.tsx
+++ b/web/app/manual/faq/page.tsx
@@ -15,27 +15,27 @@ export const metadata = pageMeta({
 const FAQ = [
   {
     q: 'What happens when no one is listening?',
-    a: 'By default nothing changes — the station broadcasts whether anyone is tuned in or not. An optional "Pause when empty" setting stops the AI work (track-picking, spoken links, station IDs) the moment the listener count hits zero, while a fallback playlist keeps music flowing, then wakes the DJ the instant someone tunes in. It exists to save tokens when no one is there to hear the DJ.',
+    a: 'By default nothing changes: the station broadcasts whether anyone is tuned in or not. An optional "Pause when empty" setting stops the AI work (track-picking, spoken links, station IDs) the moment the listener count hits zero, while a fallback playlist keeps music flowing, then wakes the DJ the instant someone tunes in. It exists to save tokens when no one is there to hear the DJ.',
   },
   {
     q: 'Does it work with a small model?',
-    a: 'Yes. The AI DJ does not need a frontier model — a modest local one is plenty. A 9B-class model such as Qwen3.5 9B comfortably picks tracks and writes the DJ’s lines when run on lean settings: reasoning off, the simpler track-picker, and concise scripts.',
+    a: 'Yes. The AI DJ does not need a frontier model; a modest local one is plenty. A 9B-class model such as Qwen3.5 9B comfortably picks tracks and writes the DJ’s lines when run on lean settings: reasoning off, the simpler track-picker, and concise scripts.',
   },
   {
     q: 'What is mood tagging?',
-    a: 'Every track can carry a mood — a label like calm, energetic or reflective. The station tags the library in the background and the DJ leans on those tags to pick music that fits the time of day, the weather, and the show that is on. Untagged tracks still play; they just are not matched by feel.',
+    a: 'Every track can carry a mood: a label like calm, energetic or reflective. The station tags the library in the background and the DJ leans on those tags to pick music that fits the time of day, the weather, and the show that is on. Untagged tracks still play; they just are not matched by feel.',
   },
   {
     q: 'What are the "deploy" and "control" SUB/WAVE skills?',
-    a: 'Two helper skills used through Claude Code. subwave-deploy handles installing and updating — first-time setup or pulling the latest code and rebuilding only what changed. subwave-control is lighter: it just starts or stops the station in development or production mode, with no builds.',
+    a: 'Two helper skills used through Claude Code. subwave-deploy handles installing and updating: first-time setup or pulling the latest code and rebuilding only what changed. subwave-control is lighter: it just starts or stops the station in development or production mode, with no builds.',
   },
   {
     q: 'What are the candidate pool and the agentic picker?',
-    a: 'Two ways the DJ chooses the next song. The candidate pool gathers a shortlist from your library — similar songs and artists, mood matches, recently-added and frequently-played albums — caps it, and asks the model to pick one. The agentic picker is a small reasoning loop with session memory and tools to search the library itself, so its choices stay coherent across a run. It is on by default and falls back to the candidate pool if it fails or runs slow.',
+    a: 'Two ways the DJ chooses the next song. The candidate pool gathers a shortlist from your library (similar songs and artists, mood matches, recently-added and frequently-played albums), caps it, and asks the model to pick one. The agentic picker is a small reasoning loop with session memory and tools to search the library itself, so its choices stay coherent across a run. It is on by default and falls back to the candidate pool if it fails or runs slow.',
   },
   {
     q: 'Why is there a debug page?',
-    a: 'The admin console’s Debug page is a live snapshot of the station’s inner workings — recent AI calls and whether they succeeded, the audio mixer’s status, and the latest log lines. It is the first place to look when the stream stalls, the DJ goes quiet, or a voice sounds wrong. For behaviour over time there is also the subwave-log-analysis skill.',
+    a: 'The admin console’s Debug page is a live snapshot of the station’s inner workings: recent AI calls and whether they succeeded, the audio mixer’s status, and the latest log lines. It is the first place to look when the stream stalls, the DJ goes quiet, or a voice sounds wrong. For behaviour over time there is also the subwave-log-analysis skill.',
   },
 ];
 

--- a/web/app/stations/page.tsx
+++ b/web/app/stations/page.tsx
@@ -30,7 +30,7 @@ export default function StationsIndex() {
         <p className="bs-eyebrow">THE NETWORK</p>
         <h1>Stations.</h1>
         <p>
-          SUB/WAVE is self-hosted &mdash; anyone can run their own. Here&rsquo;s who&rsquo;s on
+          SUB/WAVE is self-hosted; anyone can run their own. Here&rsquo;s who&rsquo;s on
           the air around the world. Tune in, or add your own station with a pull request.
         </p>
       </header>
@@ -74,7 +74,7 @@ export default function StationsIndex() {
         </ul>
       ) : (
         <p className="bs-news-empty">
-          No stations on the directory yet. Be the first &mdash; add yours above.
+          No stations on the directory yet. Be the first to add yours above.
         </p>
       )}
     </article>

--- a/web/components/manual/AdminSettings.tsx
+++ b/web/components/manual/AdminSettings.tsx
@@ -6,7 +6,7 @@ export default function AdminSettings() {
     <ManualPage
       eyebrow="MANUAL · 07"
       title="Admin & settings."
-      intro="For the operator running the station. The admin console is where you shape the DJ, choose the AI providers, schedule shows, and watch how the station is behaving — all without a redeploy."
+      intro="For the operator running the station. The admin console is where you shape the DJ, choose the AI providers, schedule shows, and watch how the station is behaving, all without a redeploy."
       current="/manual/admin"
     >
       <section className="bs-section">
@@ -46,8 +46,8 @@ export default function AdminSettings() {
         <p className="bs-eyebrow">PROGRAMMING</p>
         <h2>Shaping the station.</h2>
         <p>
-          Everything in this group is saved durably and applies live — no redeploy, most
-          changes landing on the next thing the DJ does.
+          Everything in this group is saved durably and applies live. No redeploy, and most
+          changes land on the next thing the DJ does.
         </p>
         <ul className="bs-list">
           <li>
@@ -63,8 +63,8 @@ export default function AdminSettings() {
           <li>
             <strong>Personas</strong> — the roster of DJ identities, one to ten. Each has
             a name and character, a voice, a script length and a talk frequency, plus the
-            skills it's allowed to use. One persona is active at a time — though a
-            scheduled show can override which — and a single prompt template is shared by
+            skills it's allowed to use. One persona is active at a time (though a
+            scheduled show can override which), and a single prompt template is shared by
             all of them.
           </li>
           <li>
@@ -84,8 +84,8 @@ export default function AdminSettings() {
         <ul className="bs-list">
           <li>
             <strong>TTS voice</strong> — which text-to-speech engine and voice the DJ
-            speaks with, optionally a different one per kind of segment. The engines —
-            local and cloud — are covered in{' '}
+            speaks with, optionally a different one per kind of segment. The engines
+            (local and cloud) are covered in{' '}
             <Link href="/manual/dj" className="bs-link">How the DJ Works</Link>.
           </li>
           <li>
@@ -111,7 +111,7 @@ export default function AdminSettings() {
           <div className="bs-eyebrow">MIX CHANGES NEED A MIXER RESTART</div>
           <p>
             Crossfade and jingle-ratio changes are read by the audio mixer only at
-            startup. The settings page can trigger that restart for you — the stream drops
+            startup. The settings page can trigger that restart for you: the stream drops
             for a few seconds and comes back with the new values applied.
           </p>
         </div>
@@ -121,7 +121,7 @@ export default function AdminSettings() {
         <p className="bs-eyebrow">WHEN SOMETHING'S OFF</p>
         <h2>Stats &amp; debug.</h2>
         <p>
-          <strong>Stats</strong> reports how the station is performing — AI usage and
+          <strong>Stats</strong> reports how the station is performing: AI usage and
           latency, and how often it's had to fall back to a backup engine.{' '}
           <strong>Debug</strong> is a live snapshot for diagnosing trouble: recent AI
           calls, the mixer's status, and the most recent log lines. It's the first place

--- a/web/components/manual/AgentAccess.tsx
+++ b/web/components/manual/AgentAccess.tsx
@@ -5,9 +5,9 @@ import ManualPage from './ManualPage';
 const TOOLS = [
   { name: 'subwave_now_playing', summary: 'The current track, station context, and live listener count.', auth: '—' },
   { name: 'subwave_station_state', summary: 'The upcoming queue, recent history, and the DJ booth log.', auth: '—' },
-  { name: 'subwave_request_song', summary: 'Queues a track from a natural-language request — a song, an artist, or a vibe.', auth: '—' },
+  { name: 'subwave_request_song', summary: 'Queues a track from a natural-language request: a song, an artist, or a vibe.', auth: '—' },
   { name: 'subwave_dj_announce', summary: 'Puts a spoken update on air, rewritten in persona or read verbatim.', auth: 'Admin' },
-  { name: 'subwave_dj_segment', summary: 'Fires a scripted segment on demand — station ID, the hour, or a link.', auth: 'Admin' },
+  { name: 'subwave_dj_segment', summary: 'Fires a scripted segment on demand: station ID, the hour, or a link.', auth: 'Admin' },
 ];
 
 export default function AgentAccess() {
@@ -37,7 +37,7 @@ export default function AgentAccess() {
           browser, an agent calls a tool, and the same controller does the work.
         </p>
         <p className="text-muted">
-          The server holds no logic of its own — each tool is a typed wrapper over one
+          The server holds no logic of its own; each tool is a typed wrapper over one
           controller endpoint. The agent never sees a URL or an auth header, only the
           five intent-shaped tools below.
         </p>
@@ -66,7 +66,7 @@ export default function AgentAccess() {
         </table>
         <p className="text-muted">
           Like the human request path, <code className="bs-code-inline">subwave_request_song</code>{' '}
-          queues a track — it never interrupts the song that's playing — and it's
+          queues a track (it never interrupts the song that's playing) and it's
           rate-limited. The two DJ-control tools speak immediately.
         </p>
       </section>
@@ -75,13 +75,13 @@ export default function AgentAccess() {
         <p className="bs-eyebrow">PUBLIC vs ADMIN</p>
         <h2>Reading and requesting are open.</h2>
         <p>
-          The three read-and-request tools need no credentials — they map to the same
+          The three read-and-request tools need no credentials: they map to the same
           public, rate-limited endpoints a browser uses. The two DJ-control tools, which
           put a voice on air, are gated: the server sends the station's{' '}
           <code className="bs-code-inline">ADMIN_USER</code> /{' '}
           <code className="bs-code-inline">ADMIN_PASS</code> as a Basic auth header, read
           from its own environment. Without them, an agent can still see what's on air
-          and request songs — it just can't drive the DJ.
+          and request songs; it just can't drive the DJ.
         </p>
       </section>
 
@@ -91,7 +91,7 @@ export default function AgentAccess() {
         <p>
           The server lives in the repo at <code className="bs-code-inline">mcp-subwave/</code>.
           Build it once with <code className="bs-code-inline">npm install &amp;&amp; npm run build</code>,
-          then point any MCP client — Claude Code, Claude Desktop, or another — at the
+          then point any MCP client (Claude Code, Claude Desktop, or another) at the
           built <code className="bs-code-inline">dist/index.js</code>, passing the
           controller URL and, optionally, the admin credentials as environment variables.
           The station must be running first.

--- a/web/components/manual/Clients.tsx
+++ b/web/components/manual/Clients.tsx
@@ -38,14 +38,14 @@ export default function Clients() {
         <h2>The station&rsquo;s own terminal app.</h2>
         <p>
           Start here: SUB/WAVE ships its own terminal player. Where the other apps below just
-          carry the audio, the TUI mirrors the browser player &mdash; now-playing with track
+          carry the audio, the TUI mirrors the browser player: now-playing with track
           metadata, the timeline of recent and upcoming songs, the live booth feed, and a
           request form.
         </p>
         <p>
           It&rsquo;s built into the operator console, so there&rsquo;s nothing separate to
           install. With the <code className="bs-code-inline">subwave</code> CLI, run{' '}
-          <code className="bs-code-inline">subwave play</code> — the TUI is fetched on first
+          <code className="bs-code-inline">subwave play</code>. The TUI is fetched on first
           run and opens pointed at your stack:
         </p>
         <CodeBlock>{`subwave play`}</CodeBlock>
@@ -54,10 +54,10 @@ export default function Clients() {
           start</code> and choose <strong>play</strong> — same TUI, same stack.
         </p>
         <p className="text-muted">
-          For audio it wants <code className="bs-code-inline">mpv</code> (preferred &mdash; it
-          allows live volume control) or <code className="bs-code-inline">ffplay</code>; with
+          For audio it wants <code className="bs-code-inline">mpv</code> (preferred, for live
+          volume control) or <code className="bs-code-inline">ffplay</code>; with
           neither installed the TUI still runs as a read-only dashboard. The same console also
-          opens the web player and admin in your browser &mdash;{' '}
+          opens the web player and admin in your browser, and{' '}
           <Link href="/manual/cli" className="bs-link">The Operator CLI</Link> covers all of
           it.
         </p>
@@ -68,7 +68,7 @@ export default function Clients() {
         <h2>The app on your phone.</h2>
         <p>
           SUB/WAVE has native players for iOS and Android. Like the TUI, they mirror the
-          browser player rather than just carrying the audio &mdash; now-playing with cover
+          browser player rather than just carrying the audio: now-playing with cover
           art and a live visualiser, the booth feed, the timeline, a request form, the
           schedule, and station themes that recolour the whole app. Playback keeps going in
           the background, with controls on the lock screen, your headphones, CarPlay, and
@@ -76,13 +76,13 @@ export default function Clients() {
         </p>
         <p>
           They open on the public station, and you can add any other SUB/WAVE station by its
-          address &mdash; the same <code className="bs-code-inline">/stream.mp3</code> domain
+          address: the same <code className="bs-code-inline">/stream.mp3</code> domain
           the apps below use, typed in once and saved.
         </p>
         <p className="text-muted">
-          The apps are in public beta while they work through the stores. On iOS, join over
-          TestFlight (install the TestFlight app first); on Android, tap the link to install
-          the APK directly &mdash; no account, no Play Store:
+          Android is live on Google Play: install it like any other app, and it
+          auto-updates from then on. iOS is in public beta over TestFlight while it works
+          through the App Store (install the TestFlight app first):
         </p>
         <table className="bs-doc-table">
           <thead>
@@ -93,6 +93,19 @@ export default function Clients() {
           </thead>
           <tbody>
             <tr>
+              <td><strong>Android</strong></td>
+              <td>
+                <a
+                  href="https://play.google.com/store/apps/details?id=com.getsubwave.app"
+                  className="bs-link"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Google Play ↗
+                </a>
+              </td>
+            </tr>
+            <tr>
               <td><strong>iOS</strong></td>
               <td>
                 <a
@@ -102,32 +115,17 @@ export default function Clients() {
                   rel="noreferrer"
                 >
                   TestFlight ↗
-                </a>
-              </td>
-            </tr>
-            <tr>
-              <td><strong>Android</strong></td>
-              <td>
-                <a
-                  href="https://expo.dev/accounts/pinku1/projects/subwave/builds/8bc3116d-c9b0-4a32-87b9-747640270b23"
-                  className="bs-link"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Install APK ↗
                 </a>{' '}
-                (approve the one-time &ldquo;unknown sources&rdquo; prompt)
+                (public beta)
               </td>
             </tr>
           </tbody>
         </table>
         <div className="bs-callout">
-          <div className="bs-eyebrow">APP STORE &amp; PLAY STORE</div>
+          <div className="bs-eyebrow">APP STORE</div>
           <p>
-            Coming once the betas settle. Until then the links above are the way in &mdash;
-            the Android build installs straight from the link (you&rsquo;ll approve a
-            one-time &ldquo;install from unknown sources&rdquo; prompt), and iOS goes through
-            TestFlight.
+            Android is on Google Play now; the iOS App Store listing follows once the
+            TestFlight beta settles. Until then, TestFlight is the way in on iPhone and iPad.
           </p>
         </div>
       </section>
@@ -138,12 +136,12 @@ export default function Clients() {
         <p>
           Every external player asks for the same thing: the address of the stream. For
           this station it is <code className="bs-code-inline">/stream.mp3</code> on the
-          station&rsquo;s own domain &mdash;
+          station&rsquo;s own domain:
         </p>
         <StreamUrl />
         <p className="text-muted">
           Paste that into any of the apps below. It is a live broadcast, so there is no
-          pause and no seek &mdash; closing the app and reopening it drops you back
+          pause and no seek. Closing the app and reopening it drops you back
           wherever the station is <em>now</em>, not where you left off.
         </p>
         <div className="bs-callout">
@@ -163,10 +161,10 @@ export default function Clients() {
         <p className="bs-eyebrow">VLC</p>
         <h2>VLC, on every screen you own.</h2>
         <p>
-          VLC is the most reliable way to tune in outside the browser &mdash; the safe
-          first choice. It runs on every desktop and mobile platform, opens the stream
-          from a single URL, and buffers generously enough that a shaky connection rarely
-          interrupts the broadcast. It is free and open-source: desktop builds come from{' '}
+          VLC is the steadiest way to tune in outside the browser. It runs on every desktop
+          and mobile platform, opens the stream from a single URL, and buffers generously
+          enough that a shaky connection rarely interrupts the broadcast. It is free and
+          open-source: desktop builds come from{' '}
           <a
             href="https://www.videolan.org/vlc/"
             className="bs-link"
@@ -200,7 +198,7 @@ export default function Clients() {
         </table>
         <p>
           Once it is playing, VLC shows the live track and artist from the stream&rsquo;s
-          metadata &mdash; the same now-playing info the browser player displays. On
+          metadata, the same now-playing info the browser player displays. On
           desktop you can drag the stream into the Playlist and save it as an{' '}
           <code className="bs-code-inline">.m3u</code> for one-click tuning later; on
           mobile it stays in VLC&rsquo;s history under the Network tab.
@@ -222,8 +220,8 @@ export default function Clients() {
         <p className="bs-eyebrow">CLIAMP</p>
         <h2>SUB/WAVE in your terminal.</h2>
         <p>
-          cliamp is a terminal music player with built-in internet-radio support &mdash;
-          point it at the stream URL and the broadcast plays straight in your shell, no
+          cliamp is a terminal music player with built-in internet-radio support. Point it
+          at the stream URL and the broadcast plays straight in your shell, no
           browser and no window. It is an open-source Go program; grab a release binary
           from{' '}
           <a
@@ -238,7 +236,7 @@ export default function Clients() {
         </p>
         <CodeBlock>{`go install github.com/bjarneo/cliamp@latest`}</CodeBlock>
         <p className="text-muted">
-          On Linux you also want the ALSA bridge for your audio server &mdash;{' '}
+          On Linux you also want the ALSA bridge for your audio server:{' '}
           <code className="bs-code-inline">pipewire-alsa</code> or{' '}
           <code className="bs-code-inline">pulseaudio-alsa</code>. The MP3 mount plays
           natively in cliamp with no <code className="bs-code-inline">ffmpeg</code>{' '}
@@ -249,7 +247,7 @@ export default function Clients() {
         <StreamUrl prefix="cliamp " />
         <p>
           cliamp shows <code className="bs-code-inline">● Streaming</code> with a
-          non-interactive seek bar &mdash; expected, since SUB/WAVE is a live broadcast.
+          non-interactive seek bar, which is expected since SUB/WAVE is a live broadcast.
           Press <kbd className="bs-kbd">u</kbd> to load a different stream, or{' '}
           <kbd className="bs-kbd">R</kbd> to browse cliamp&rsquo;s own radio directory.
         </p>
@@ -259,7 +257,7 @@ export default function Clients() {
             Public SUB/WAVE stations sit behind Cloudflare, which serves the stream over
             HTTP/2 in bursts. Browsers and VLC paper over that with deep buffers; a lean
             command-line player like cliamp can underrun between bursts and show{' '}
-            <em>buffering</em>. The stream itself is fine &mdash; ask the station operator
+            <em>buffering</em>. The stream itself is fine. Ask the station operator
             for a direct address that skips Cloudflare (a LAN or Tailscale URL on the
             Caddy port, usually <code className="bs-code-inline">:7700</code>), which
             serves a steady HTTP/1.1 stream.
@@ -280,7 +278,7 @@ export default function Clients() {
         <h2>Any internet-radio player works.</h2>
         <p>
           The SUB/WAVE TUI is the full-featured way in; VLC and cliamp are the walked-through
-          audio-only examples &mdash; but none of them are special. Anything that can open an
+          audio-only examples. But none of them are special: anything that can open an
           internet-radio URL can tune in, and more client guides will be added here over time.
           Running the station yourself rather than listening along? That&rsquo;s covered in{' '}
           <Link href="/setup" className="bs-link">the setup guide</Link>.

--- a/web/components/manual/CustomSkills.tsx
+++ b/web/components/manual/CustomSkills.tsx
@@ -6,7 +6,7 @@ export default function CustomSkills() {
     <ManualPage
       eyebrow="MANUAL · 06"
       title="Custom skills."
-      intro="The things the DJ does between tracks — a weather check, a headline, a traffic gag — are skills. Seven ship built in, and you can edit any of them or add your own by dropping a folder into state/skills, no code changes to the station."
+      intro="The things the DJ does between tracks (a weather check, a headline, a traffic gag) are skills. Seven ship built in, and you can edit any of them or add your own by dropping a folder into state/skills, no code changes to the station."
       current="/manual/skills"
     >
       <section className="bs-section">
@@ -19,8 +19,8 @@ export default function CustomSkills() {
           <a href="https://github.com/anthropics/skills" target="_blank" rel="noreferrer">
             Anthropic&rsquo;s skills
           </a>{' '}
-          — a <code className="bs-code-inline">SKILL.md</code> with YAML frontmatter and a
-          markdown body, plus optional code — but the meaning is narrower. These don&rsquo;t
+          (a <code className="bs-code-inline">SKILL.md</code> with YAML frontmatter and a
+          markdown body, plus optional code), but the meaning is narrower. These don&rsquo;t
           process documents or run tasks; they decide what the DJ says next.
         </p>
       </section>
@@ -51,7 +51,7 @@ export default function CustomSkills() {
         <h2>Frontmatter, then the brief.</h2>
         <p>
           The frontmatter sets the skill&rsquo;s metadata; the markdown body <em>is</em> the
-          brief the DJ follows — what to say, in what tone, and when to stay silent. Only a
+          brief the DJ follows: what to say, in what tone, and when to stay silent. Only a
           non-empty body is required; every key has a sensible default.
         </p>
         <CodeBlock>{`---
@@ -66,9 +66,9 @@ line, the way a late-night presenter might glance out the window. Skip it when
 the phase is unremarkable.`}</CodeBlock>
         <p className="text-muted">
           For a <em>new</em> skill the <code className="bs-code-inline">name</code> must be a
-          lowercase slug that isn&rsquo;t a built-in kind — naming a folder after a built-in
-          <em>edits</em> that one instead (see below). Bad frontmatter is logged and skipped
-          — it never crashes the station.
+          lowercase slug that isn&rsquo;t a built-in kind; naming a folder after a built-in
+          <em>edits</em> that one instead (see below). Bad frontmatter is logged and
+          skipped, and never crashes the station.
         </p>
       </section>
 
@@ -82,14 +82,14 @@ the phase is unremarkable.`}</CodeBlock>
           time the station boots. Editing one (on the admin <strong>Skills</strong> page, or
           the file directly) overrides its brief, cooldown, or label in place. A built-in
           file may leave the body empty to keep the default wording, and never loads a{' '}
-          <code className="bs-code-inline">tool.mjs</code> — the built-ins already have their
+          <code className="bs-code-inline">tool.mjs</code>; the built-ins already have their
           data wired in.
         </p>
         <p>
           The big one: <strong>News reads the BBC by default</strong>. Hit{' '}
-          <strong>Edit</strong> on the News skill, paste your own RSS feed (any RSS 2.0 feed
-          — Atom isn&rsquo;t supported yet) and rewrite the brief in your station&rsquo;s
-          voice, then Save — it&rsquo;s live on the next break, no restart.
+          <strong>Edit</strong> on the News skill, paste your own RSS feed (any RSS 2.0 feed,
+          though not Atom yet) and rewrite the brief in your station&rsquo;s
+          voice, then Save. It&rsquo;s live on the next break, no restart.
         </p>
         <CodeBlock>{`---
 name: news
@@ -112,7 +112,7 @@ not a newsreader's. Skip anything dull or stale; silence is fine.`}</CodeBlock>
         <h2>Let the DJ look before it speaks.</h2>
         <p>
           With a <code className="bs-code-inline">tool.mjs</code>, the DJ can fetch live data
-          before deciding whether to air the line — the same mechanism the built-in weather
+          before deciding whether to air the line, the same mechanism the built-in weather
           and news skills use. Export a default function; return any JSON, and use{' '}
           <code className="bs-code-inline">{`{ available: false }`}</code> to tell the DJ
           there&rsquo;s nothing worth airing.
@@ -124,14 +124,14 @@ not a newsreader's. Skip anything dull or stale; silence is fine.`}</CodeBlock>
 }`}</CodeBlock>
         <p>
           The call is timeout-guarded and any error degrades cleanly to &ldquo;no
-          data&rdquo; — a slow or broken skill can never hang the station. With no{' '}
+          data&rdquo;; a slow or broken skill can never hang the station. With no{' '}
           <code className="bs-code-inline">tool.mjs</code>, the skill writes from its brief
           alone (like the built-in traffic gag).
         </p>
         <div className="bs-callout">
           <div className="bs-eyebrow">IT RUNS YOUR CODE</div>
           <p>
-            <code className="bs-code-inline">tool.mjs</code> executes inside the controller —
+            <code className="bs-code-inline">tool.mjs</code> executes inside the controller,
             the same trust model as installing a local tool. Only drop in code you&rsquo;ve
             read and trust.
           </p>
@@ -143,12 +143,12 @@ not a newsreader's. Skip anything dull or stale; silence is fine.`}</CodeBlock>
         <h2>Discovered, then enabled by you.</h2>
         <p>
           A freshly dropped skill appears on the admin <strong>Skills</strong> page toggled{' '}
-          <strong>off</strong>. It can&rsquo;t air — by itself or via the DJ — until you
+          <strong>off</strong>. It can&rsquo;t air (by itself or via the DJ) until you
           enable it there. Dropping a folder never puts unreviewed content (or code) on air.
         </p>
         <p>
           Skills load at boot, and on demand via the <strong>Rescan state/skills</strong>{' '}
-          button on that page — which picks up new folders and edits to{' '}
+          button on that page, which picks up new folders and edits to{' '}
           <code className="bs-code-inline">SKILL.md</code> /{' '}
           <code className="bs-code-inline">tool.mjs</code> without a restart. Like the
           built-ins, a custom skill only fires autonomously when it&rsquo;s enabled{' '}

--- a/web/components/manual/Faq.tsx
+++ b/web/components/manual/Faq.tsx
@@ -13,7 +13,7 @@ export default function Faq() {
         <p className="bs-eyebrow">AN EMPTY ROOM</p>
         <h2>What happens when no one is listening?</h2>
         <p>
-          By default, nothing changes — the station broadcasts the same whether anyone is
+          By default, nothing changes: the station broadcasts the same whether anyone is
           tuned in or not. But there is an optional setting,{' '}
           <strong>Pause when empty</strong>, that changes this. With it on, the moment the
           listener count hits zero the DJ stops doing AI work: no track-picking, no spoken
@@ -29,7 +29,7 @@ export default function Faq() {
         <p className="bs-eyebrow">MODEST HARDWARE</p>
         <h2>Does it work with a small model?</h2>
         <p>
-          Yes. The AI DJ doesn&rsquo;t need a frontier model — a modest one running on
+          Yes. The AI DJ doesn&rsquo;t need a frontier model; a modest one running on
           your own hardware is plenty. A 9B-class local model such as Qwen3.5 9B
           comfortably picks tracks and writes the DJ&rsquo;s lines, as long as you run the
           station on its <em>lean</em> settings: reasoning off, the simpler track-picker,
@@ -42,12 +42,12 @@ export default function Faq() {
         <p className="bs-eyebrow">A TAGGED LIBRARY</p>
         <h2>What is mood tagging?</h2>
         <p>
-          Every track in the library can carry a <em>mood</em> — a label like calm,
+          Every track in the library can carry a <em>mood</em>: a label like calm,
           energetic or reflective. The station tags the library in the background, and the
           DJ leans on those tags to pick music that fits the moment: the time of day, the
           weather, the show that is on. A well-tagged library gives the DJ a far richer
           palette to choose from. You can watch the tagger&rsquo;s progress on the Library
-          page in the admin console. Untagged tracks still play — they just don&rsquo;t
+          page in the admin console. Untagged tracks still play; they just don&rsquo;t
           get matched by feel.
         </p>
       </section>
@@ -58,7 +58,7 @@ export default function Faq() {
         <p>
           These are two helper skills bundled with the project for whoever runs the
           station, used through Claude Code. <strong>subwave-deploy</strong> handles
-          installing and updating — a first-time setup from a fresh checkout, or pulling
+          installing and updating: a first-time setup from a fresh checkout, or pulling
           the latest code and rebuilding only the parts that actually changed.{' '}
           <strong>subwave-control</strong> is lighter: it simply starts or stops the
           station in development or production mode, with no builds. Day to day you reach
@@ -74,18 +74,18 @@ export default function Faq() {
         <p>
           They are two ways the DJ chooses what to play next. The{' '}
           <strong>candidate pool</strong> picker is the straightforward one: it gathers a
-          shortlist of tracks from your library — similar songs, similar artists, mood
-          matches, recently-added and frequently-played albums — caps it to a couple of
+          shortlist of tracks from your library (similar songs, similar artists, mood
+          matches, recently-added and frequently-played albums), caps it to a couple of
           dozen, and asks the model to pick one from that list.
         </p>
         <p>
           The <strong>agentic picker</strong> is the richer one. It runs as a small
           reasoning loop with a memory of the current session and tools to search the
-          library itself, so its choices — and the links between them — stay coherent
+          library itself, so its choices (and the links between them) stay coherent
           across a run rather than starting cold each time. It is on by default; if it
           ever fails or runs slow, the station quietly falls back to the candidate pool,
           so the music never stops either way. Which one suits you comes down to the
-          model — see <Link href="/manual/llm" className="bs-link">Models &amp; Tokens</Link>.
+          model; see <Link href="/manual/llm" className="bs-link">Models &amp; Tokens</Link>.
         </p>
       </section>
 
@@ -94,7 +94,7 @@ export default function Faq() {
         <h2>Why is there a debug page?</h2>
         <p>
           The admin console&rsquo;s Debug page is a live snapshot of the station&rsquo;s
-          inner workings — the most recent AI calls and whether they succeeded, the audio
+          inner workings: the most recent AI calls and whether they succeeded, the audio
           mixer&rsquo;s status, and the latest log lines. You don&rsquo;t need it day to
           day, but it is the first place to look when something is off: the stream stalls,
           the DJ goes quiet, or a voice sounds wrong. It turns a vague
@@ -105,7 +105,7 @@ export default function Faq() {
           For a deeper look there is also <strong>subwave-log-analysis</strong>, a bundled
           skill used through Claude Code. Where the Debug page shows the live moment, this
           reads the station&rsquo;s full event log over time and reports back on how it
-          has been behaving — how often it calls the music library, why the picker keeps
+          has been behaving: how often it calls the music library, why the picker keeps
           favouring certain artists, whether the library pool is too narrow, and any
           runtime anomalies. It is the tool for &ldquo;the station works, but something
           feels off&rdquo; rather than an outright break.

--- a/web/components/manual/GettingStarted.tsx
+++ b/web/components/manual/GettingStarted.tsx
@@ -29,8 +29,8 @@ export default function GettingStarted() {
         <p className="bs-eyebrow">THE PLAYER</p>
         <h2>What you're looking at.</h2>
         <p>
-          The player shows the track that's playing right now — title, artist, and cover
-          art — with a waveform for the transport. Three panels slide out for the rest:
+          The player shows the track that's playing right now (title, artist, and cover
+          art) with a waveform for the transport. Three panels slide out for the rest:
         </p>
         <ul className="bs-list">
           <li>
@@ -55,7 +55,7 @@ export default function GettingStarted() {
         <p className="bs-eyebrow">NO SKIP — ON PURPOSE</p>
         <h2>There is no skip button.</h2>
         <p>
-          A track ends when it ends. SUB/WAVE has no <code className="bs-code-inline">/skip</code> —
+          A track ends when it ends. SUB/WAVE has no <code className="bs-code-inline">/skip</code>:
           the only natural transition is track-end, and the mixer controls pacing. Skip is
           deliberately left off the lock-screen and headphone controls too, so a stray
           double-tap on your earbuds can't cut the song short for every other listener.
@@ -69,7 +69,7 @@ export default function GettingStarted() {
           SUB/WAVE is an installable web app. Use your browser's &ldquo;Add to Home
           Screen&rdquo; / &ldquo;Install&rdquo; option and it runs like a native app, with
           its own icon. Once installed, your phone's lock screen, headphone buttons, and
-          car display can all start and stop the stream — with the cover art of whatever
+          car display can all start and stop the stream, with the cover art of whatever
           is currently on the air.
         </p>
       </section>

--- a/web/components/manual/HowTheDjWorks.tsx
+++ b/web/components/manual/HowTheDjWorks.tsx
@@ -26,7 +26,7 @@ export default function HowTheDjWorks() {
         <p className="bs-eyebrow">THE VOICES</p>
         <h2>Personas, picked at random.</h2>
         <p>
-          The operator gives the DJ one to ten <em>souls</em> — distinct personas, each
+          The operator gives the DJ one to ten <em>souls</em>: distinct personas, each
           with its own name and character. Before each spoken moment the station picks one
           at random, so the voice on air shifts through the day rather than reading from a
           single script. Each line is generated fresh; the DJ doesn't repeat itself.
@@ -83,14 +83,14 @@ export default function HowTheDjWorks() {
         </ul>
         <p>
           You don't have to commit to one. The operator can assign a different engine{' '}
-          <em>per kind</em> of segment — say a rich cloud voice for station IDs, but a
-          fast local voice for routine time checks — with everything else falling through
+          <em>per kind</em> of segment (a rich cloud voice for station IDs, say, but a
+          fast local voice for routine time checks), with everything else falling through
           to a default engine.
         </p>
         <div className="bs-callout">
           <div className="bs-eyebrow">THE DJ NEVER GOES SILENT</div>
           <p>
-            If a voice ever fails — a cloud outage, a model that isn't installed — the
+            If a voice ever fails (a cloud outage, a model that isn't installed), the
             station drops to a local engine automatically. Piper is always there as the
             last resort, so a spoken segment is never lost to a missing voice.
           </p>
@@ -123,7 +123,7 @@ docker compose up -d`}</CodeBlock>
             PocketTTS), drop a short reference WAV into{' '}
             <code className="bs-code-inline">state/voices/</code>{' '}
             (legacy <code className="bs-code-inline">state/chatterbox-voices/</code> is
-            still read) and pick it on the Personas page — without one, both engines
+            still read) and pick it on the Personas page; without one, both engines
             use their built-in default voice. PocketTTS also exposes a curated set of
             built-in voice ids (<code className="bs-code-inline">alba</code>,{' '}
             <code className="bs-code-inline">anna</code>,{' '}
@@ -136,7 +136,7 @@ docker compose up -d`}</CodeBlock>
             <code className="bs-code-inline">--build-arg WITH_CHATTERBOX=1</code> /{' '}
             <code className="bs-code-inline">WITH_POCKETTTS=1</code> paths in{' '}
             <code className="bs-code-inline">docker/Dockerfile.controller</code> still
-            work — they bundle the engines inside the controller image instead. The
+            work; they bundle the engines inside the controller image instead. The
             sidecar is the recommended path for fresh installs.
           </p>
         </div>
@@ -153,7 +153,7 @@ docker compose up -d`}</CodeBlock>
         </p>
         <p>
           How chatty the station is depends on a <strong>frequency</strong> setting the
-          operator chooses — <em>quiet</em>, <em>moderate</em>, or <em>aggressive</em>. A
+          operator chooses: <em>quiet</em>, <em>moderate</em>, or <em>aggressive</em>. A
           quiet station checks the time every couple of hours and drops the occasional
           ID; an aggressive one gives you full idents and weather updates through the hour.
         </p>
@@ -163,7 +163,7 @@ docker compose up -d`}</CodeBlock>
         <p className="bs-eyebrow">SHOWS &amp; SESSIONS</p>
         <h2>It keeps a thread going.</h2>
         <p>
-          The DJ runs in <em>sessions</em> — a continuous block with a memory of what it's
+          The DJ runs in <em>sessions</em>: a continuous block with a memory of what it's
           already played and said, so its links stay coherent instead of starting cold
           each time. A session can be a scheduled <strong>show</strong> the operator paints
           onto a weekly grid, or an autonomous block keyed to the time of day and the

--- a/web/components/manual/ModelsAndTokens.tsx
+++ b/web/components/manual/ModelsAndTokens.tsx
@@ -6,7 +6,7 @@ export default function ModelsAndTokens() {
     <ManualPage
       eyebrow="MANUAL · 10"
       title="Models & tokens."
-      intro="The AI DJ can run on a small model on your own hardware or a large hosted one — and a handful of settings let you tune the station for whichever you've picked, trading richness against cost."
+      intro="The AI DJ can run on a small model on your own hardware or a large hosted one, and a handful of settings let you tune the station for whichever you've picked, trading richness against cost."
       current="/manual/llm"
     >
       <section className="bs-section">
@@ -15,14 +15,14 @@ export default function ModelsAndTokens() {
         <p>
           Every word the DJ speaks and every track it picks comes from one language
           model, chosen under <strong>Admin &rarr; LLM</strong>. The default is Ollama on
-          your own hardware — no API key, no per-token bill — but you can point the
+          your own hardware (no API key, no per-token bill), but you can point the
           station at a hosted provider (Anthropic, OpenAI, Google and others) instead.
           Switching reroutes every call immediately, with no redeploy.
         </p>
         <p>
           Big hosted models are more capable but cost money per token; small local models
           are free to run but need a lighter workload to stay coherent. The settings
-          below let you match the station to the model — run it <em>lean</em> for a small
+          below let you match the station to the model: run it <em>lean</em> for a small
           or metered model, or <em>rich</em> for a large capable one.
         </p>
       </section>
@@ -37,7 +37,7 @@ export default function ModelsAndTokens() {
         </p>
         <p>
           With these settings in place, a small model runs the whole station
-          comfortably — a 9B-class local model such as{' '}
+          comfortably: a 9B-class local model such as{' '}
           <strong>Qwen3.5 9B</strong> is plenty for picking tracks and writing the DJ's
           lines. The lean profile keeps each request short and well-shaped, which is
           exactly what a smaller model needs to stay reliable.
@@ -88,7 +88,7 @@ export default function ModelsAndTokens() {
         <p className="bs-eyebrow">RUNNING RICH</p>
         <h2>For large, capable models.</h2>
         <p>
-          On a large hosted model the same dials go the other way — spend the capability
+          On a large hosted model the same dials go the other way: spend the capability
           on a station with more personality and a smarter DJ.
         </p>
         <ul className="bs-list">
@@ -118,7 +118,7 @@ export default function ModelsAndTokens() {
         <div className="bs-eyebrow">THE DJ NEVER GOES SILENT</div>
         <p>
           The picker agent has a built-in safety net: if it ever fails or runs too slow,
-          the station quietly falls back to the simple pool picker for that track — the
+          the station quietly falls back to the simple pool picker for that track, the
           same path you'd get with the agent switched off. Turning it off just makes that
           lighter path the default rather than the exception.
         </p>
@@ -128,7 +128,7 @@ export default function ModelsAndTokens() {
         <p className="bs-eyebrow">WHERE TO SET THEM</p>
         <h2>All of this lives in the console.</h2>
         <p>
-          Every setting here is in the admin console and takes effect without a redeploy —
+          Every setting here is in the admin console and takes effect without a redeploy;
           most apply to the next thing the DJ does. The full tour of the console is in{' '}
           <Link href="/manual/admin" className="bs-link">Admin &amp; Settings</Link>; how
           the DJ actually picks and talks is in{' '}

--- a/web/components/manual/OperatorCli.tsx
+++ b/web/components/manual/OperatorCli.tsx
@@ -7,7 +7,7 @@ export default function OperatorCli() {
     <ManualPage
       eyebrow="MANUAL · 09"
       title="The operator console."
-      intro="SUB/WAVE ships a command-line console for running the station. One command opens a menu that boots the stack, checks its health, tails logs, and opens a terminal player — no Docker flags to remember."
+      intro="SUB/WAVE ships a command-line console for running the station. One command opens a menu that boots the stack, checks its health, tails logs, and opens a terminal player, with no Docker flags to remember."
       current="/manual/cli"
     >
       <section className="bs-section">
@@ -21,12 +21,12 @@ export default function OperatorCli() {
         <p className="text-muted">
           First time through? If there&rsquo;s no{' '}
           <code className="bs-code-inline">.env</code> yet, the console drops you
-          straight into the install wizard — the same one the{' '}
+          straight into the install wizard, the same one the{' '}
           <Link href="/setup" className="bs-link">setup guide</Link> walks through.
         </p>
         <p className="text-muted">
           Working from a cloned repo instead of the standalone CLI? Run{' '}
-          <code className="bs-code-inline">npm start</code> — it opens the same console.
+          <code className="bs-code-inline">npm start</code>; it opens the same console.
         </p>
       </section>
 
@@ -54,7 +54,7 @@ export default function OperatorCli() {
           </li>
           <li>
             <strong>restart</strong> — rebuild and recreate a single service. The console
-            knows the controller and Liquidsoap need a rebuild — not a plain restart — for
+            knows the controller and Liquidsoap need a rebuild (not a plain restart) for
             source changes to take.
           </li>
           <li>
@@ -92,7 +92,7 @@ export default function OperatorCli() {
         <p className="bs-eyebrow">PLAYER &amp; CONSOLES</p>
         <h2>Jump straight to the player or the admin.</h2>
         <p>
-          The <strong>play</strong> option launches the SUB/WAVE TUI — now-playing, the
+          The <strong>play</strong> option launches the SUB/WAVE TUI: now-playing, the
           timeline, the live booth feed, and a request form, all in your terminal and pointed
           at your own stack. It&rsquo;s the full station experience without a browser. The{' '}
           <Link href="/manual/clients" className="bs-link">Listen With</Link> page covers the
@@ -100,8 +100,8 @@ export default function OperatorCli() {
         </p>
         <p>
           Prefer the browser? <strong>listen</strong> and <strong>admin</strong> open the web
-          player and the admin console in your default browser, pointed at the same stack — no
-          host or port to remember.
+          player and the admin console in your default browser, pointed at the same stack, with
+          no host or port to remember.
         </p>
       </section>
 
@@ -109,8 +109,8 @@ export default function OperatorCli() {
         <p className="bs-eyebrow">SCRIPTING IT</p>
         <h2>Every action runs without the menu too.</h2>
         <p>
-          The menu is for hands-on operating. To skip it — for a deploy script, a cron job, or
-          just speed — name the action straight after{' '}
+          The menu is for hands-on operating. To skip it (for a deploy script, a cron job, or
+          just speed), name the action straight after{' '}
           <code className="bs-code-inline">subwave</code>:
         </p>
         <CodeBlock>{`subwave status
@@ -118,7 +118,7 @@ subwave doctor
 subwave logs controller
 subwave restart controller`}</CodeBlock>
         <p className="text-muted">
-          Same actions, same output — just without the interactive menu wrapped around them.
+          Same actions, same output, just without the interactive menu wrapped around them.
           From a cloned repo, the same actions run after{' '}
           <code className="bs-code-inline">npm start --</code> (e.g.{' '}
           <code className="bs-code-inline">npm start -- status</code>).

--- a/web/components/manual/Overview.tsx
+++ b/web/components/manual/Overview.tsx
@@ -69,7 +69,7 @@ export default function Overview() {
     <ManualPage
       eyebrow="SUB/WAVE MANUAL"
       title="How to use SUB/WAVE."
-      intro="SUB/WAVE is a personal internet radio station — one live stream that every listener hears at the same moment, with an AI DJ picking the tracks and talking between them. This manual covers both sides of the dial: tuning in as a listener, and running the station as its operator."
+      intro="SUB/WAVE is a personal internet radio station: one live stream that every listener hears at the same moment, with an AI DJ picking the tracks and talking between them. This manual covers both sides of the dial: tuning in as a listener, and running the station as its operator."
       current="/manual"
     >
       <section className="bs-section">
@@ -96,7 +96,7 @@ export default function Overview() {
         <p className="bs-eyebrow">THE ONE THING TO KNOW</p>
         <h2>It's a broadcast, not a playlist.</h2>
         <p>
-          Streaming apps give everyone a private channel — shuffled for you, paused the
+          Streaming apps give everyone a private channel: shuffled for you, paused the
           second you look away. SUB/WAVE goes the other way. There is one Icecast stream,
           and everyone hears whatever is on the air <em>right now</em>. There is no
           &ldquo;for you,&rdquo; and there is no skip button. You can ask for a song, but

--- a/web/components/manual/Requests.tsx
+++ b/web/components/manual/Requests.tsx
@@ -13,7 +13,7 @@ export default function Requests() {
         <h2>Open &ldquo;Make a request.&rdquo;</h2>
         <p>
           In the player, open the <strong>Make a request</strong> panel. Type what you
-          want and, if you like, your name — so the DJ can give you a shout-out. You don't
+          want and, if you like, your name, so the DJ can give you a shout-out. You don't
           have to be precise: a song title, an artist, or a mood all work.
         </p>
         <ul className="bs-list">
@@ -34,7 +34,7 @@ export default function Requests() {
           to play when the current song finishes.
         </p>
         <p>
-          If nothing in the library fits, the DJ won't force it — you may get a different
+          If nothing in the library fits, the DJ won't force it; you may get a different
           take on the mood you asked for instead. The station only plays what's actually
           in its collection.
         </p>
@@ -52,7 +52,7 @@ export default function Requests() {
         <div className="bs-callout">
           <div className="bs-eyebrow">A FEW TIPS</div>
           <p>
-            Be specific when you have a specific song in mind, and loose when you don't —
+            Be specific when you have a specific song in mind, and loose when you don't;
             the DJ handles both. Watch <strong>the booth</strong> panel to catch your
             shout-out, and the <strong>Timeline</strong> to see your track land in the
             queue.

--- a/web/components/manual/Shortcuts.tsx
+++ b/web/components/manual/Shortcuts.tsx
@@ -68,14 +68,14 @@ export default function Shortcuts() {
         <h2>One menu for everything.</h2>
         <p>
           Press <kbd className="bs-kbd">⌘K</kbd> (or <kbd className="bs-kbd">Ctrl K</kbd>{' '}
-          on Windows and Linux) to open the <strong>command palette</strong> — a
+          on Windows and Linux) to open the <strong>command palette</strong>, a
           searchable list of every player action. Start typing to filter, use the arrow
           keys to move, and press Enter to run. It's the fastest way to reach something
           when you can't remember its key.
         </p>
         <p className="text-muted">
           The palette chord works even while you're typing in a text field, so you can
-          always summon it — and press it again, or <kbd className="bs-kbd">Esc</kbd>, to
+          always summon it; press it again, or <kbd className="bs-kbd">Esc</kbd>, to
           close it.
         </p>
       </section>
@@ -84,7 +84,7 @@ export default function Shortcuts() {
         <p className="bs-eyebrow">WHEN THEY'RE QUIET</p>
         <h2>Shortcuts step aside while you type.</h2>
         <p>
-          The single-key shortcuts are suppressed whenever a text field is focused — so
+          The single-key shortcuts are suppressed whenever a text field is focused, so
           typing <em>R</em> into the request box writes an <em>R</em> rather than opening
           a panel. They also pause while the command palette or the shortcuts dialog is
           open, since those windows handle the keyboard themselves.

--- a/web/components/manual/Themes.tsx
+++ b/web/components/manual/Themes.tsx
@@ -54,7 +54,7 @@ export default function Themes() {
         <p>
           A scheduled show can opt into a different theme for its hour. Open a show in
           admin → <strong>Shows</strong>, pick one from the <em>theme override</em>{' '}
-          dropdown, and the player switches to that palette while the show is on air —
+          dropdown, and the player switches to that palette while the show is on air,
           then back to the station default when the next hour starts.
         </p>
         <p>
@@ -73,12 +73,12 @@ export default function Themes() {
           (<code className="bs-code-inline">light</code> or <code className="bs-code-inline">dark</code>),
           and a token map. The controller creates{' '}
           <code className="bs-code-inline">state/themes/</code> on first read and seeds it
-          with a README — drop your JSONs alongside it.
+          with a README; drop your JSONs alongside it.
         </p>
         <CodeBlock>{EXAMPLE_THEME}</CodeBlock>
         <p>
           After saving the file, hit <strong>Refresh themes</strong> in admin → Settings
-          → Theme — that re-scans the directory and the new entry appears in the picker.
+          → Theme. That re-scans the directory, and the new entry appears in the picker.
           No mixer restart, no controller bounce.
         </p>
         <div className="bs-callout">
@@ -112,7 +112,7 @@ export default function Themes() {
           Any CSS colour value works: hex, <code className="bs-code-inline">rgb()</code>,{' '}
           <code className="bs-code-inline">oklch()</code>,{' '}
           <code className="bs-code-inline">color-mix()</code>. <code className="bs-code-inline">mode</code>{' '}
-          tells the rest of the stylesheet whether to treat the theme as light or dark —
+          tells the rest of the stylesheet whether to treat the theme as light or dark;
           it controls the paper-grain blend and the few shadcn rules that still key off{' '}
           <code className="bs-code-inline">data-theme</code>.
         </p>
@@ -124,7 +124,7 @@ export default function Themes() {
         <p>
           On every page load, a tiny pre-paint script reads the last-applied theme from
           the browser's localStorage and writes the seven variables onto{' '}
-          <code className="bs-code-inline">&lt;html&gt;</code> before the first frame — so
+          <code className="bs-code-inline">&lt;html&gt;</code> before the first frame, so
           listeners never see the default palette flash before yours arrives. The
           controller serves the live registry at{' '}
           <code className="bs-code-inline">/api/themes</code>; an app-wide bootstrapper

--- a/web/components/setup/Development.tsx
+++ b/web/components/setup/Development.tsx
@@ -55,11 +55,11 @@ export default function Development() {
         <div className="bs-cmd-list">
           <div className="bs-cmd">
             <CodeBlock>{`npm run setup`}</CodeBlock>
-            <p>Interactive wizard — writes envs, brings the stack up.</p>
+            <p>Interactive wizard: writes envs, brings the stack up.</p>
           </div>
           <div className="bs-cmd">
             <CodeBlock>{`npm run dev`}</CodeBlock>
-            <p>Alias for setup — same wizard.</p>
+            <p>Alias for setup; same wizard.</p>
           </div>
           <div className="bs-cmd">
             <CodeBlock>{`npm run dev:docker`}</CodeBlock>
@@ -137,7 +137,7 @@ export default function Development() {
             <code className="bs-code-inline">controller/src/**</code> restart the
             process inside the container automatically.{' '}
             <code className="bs-code-inline">liquidsoap/radio.liq</code> is bind-mounted
-            too — edits there need{' '}
+            too; edits there need{' '}
             <code className="bs-code-inline">docker compose -f docker-compose.dev.yml restart broadcast</code>{' '}
             but no rebuild.
           </p>
@@ -152,7 +152,7 @@ export default function Development() {
           </p>
           <p className="mt-2 text-muted">
             The web dev server (<code className="bs-code-inline">npm run dev:web</code>) is
-            its own thing — Next.js hot-reloads, so edits to{' '}
+            its own thing: Next.js hot-reloads, so edits to{' '}
             <code className="bs-code-inline">web/**</code> show up instantly without
             touching Docker.
           </p>

--- a/web/components/setup/ManualInstall.tsx
+++ b/web/components/setup/ManualInstall.tsx
@@ -16,7 +16,7 @@ export default function ManualInstall() {
     <SetupPage
       eyebrow="SETUP · 03"
       title="Run the commands yourself."
-      intro="The no-CLI alternative — same outcome, no `subwave` binary on your host. Useful if you'd rather not run an installer, are scripting the deploy, want a non-standard layout, or just prefer running each command by hand. These four steps land at a public-facing single-host deploy — Caddy on the edge, Cloudflare in front, internal-only Icecast, Controller, and Web."
+      intro="The no-CLI alternative: same outcome, no `subwave` binary on your host. Useful if you'd rather not run an installer, are scripting the deploy, want a non-standard layout, or just prefer running each command by hand. These four steps land at a public-facing single-host deploy: Caddy on the edge, Cloudflare in front, internal-only Icecast, Controller, and Web."
       current="/setup/manual"
     >
       <section className="bs-section">
@@ -29,7 +29,7 @@ export default function ManualInstall() {
             <code className="bs-code-inline">init</code> and{' '}
             <code className="bs-code-inline">start</code> behind two Enter
             prompts) followed by{' '}
-            <code className="bs-code-inline">subwave setup</code> — see{' '}
+            <code className="bs-code-inline">subwave setup</code>; see{' '}
             <Link href="/setup/quick-start">Quick Start</Link>. It uses the
             same compose images and writes to the same{' '}
             <code className="bs-code-inline">state/</code> layout; nothing is
@@ -60,7 +60,7 @@ $EDITOR .env`}</CodeBlock>
               <div className="bs-eyebrow">PREFER A CLONE?</div>
               <p>
                 Clone the repo and run{' '}
-                <code className="bs-code-inline">./scripts/setup.sh</code> — it scaffolds
+                <code className="bs-code-inline">./scripts/setup.sh</code>; it scaffolds
                 the same <code className="bs-code-inline">.env</code> + sets state-dir
                 perms. Or run <code className="bs-code-inline">npm run setup</code> for
                 an interactive terminal wizard that does the equivalent of the browser
@@ -110,7 +110,7 @@ $EDITOR .env`}</CodeBlock>
               <div className="bs-eyebrow">ALREADY RUNNING TRAEFIK OR NGINX?</div>
               <p>
                 Swap the compose file for{' '}
-                <code className="bs-code-inline">docker-compose.byo.yml</code> —
+                <code className="bs-code-inline">docker-compose.byo.yml</code>:
                 same stack minus the bundled Caddy, with web / controller / broadcast bound to{' '}
                 <code className="bs-code-inline">:7700</code> /{' '}
                 <code className="bs-code-inline">:7701</code> /{' '}
@@ -133,7 +133,7 @@ $EDITOR .env`}</CodeBlock>
               <p>
                 If you need separate hostnames per surface, rebuild the web image
                 with <code className="bs-code-inline">NEXT_PUBLIC_API_URL</code> and{' '}
-                <code className="bs-code-inline">NEXT_PUBLIC_STREAM_URL</code> set —
+                <code className="bs-code-inline">NEXT_PUBLIC_STREAM_URL</code> set;
                 those are baked at build time, not runtime.
               </p>
             </div>
@@ -167,7 +167,7 @@ $EDITOR .env`}</CodeBlock>
               <li><strong>TTS engine</strong> — Piper (default) and Kokoro both run inside
               the controller image. Cloud (OpenAI / ElevenLabs) just needs an API key.
               Chatterbox (voice cloning) and PocketTTS (multilingual) live in the optional{' '}
-              <code className="bs-code-inline">tts-heavy</code> sidecar — tick the
+              <code className="bs-code-inline">tts-heavy</code> sidecar: tick the
               &ldquo;Enable Chatterbox + PocketTTS&rdquo; box in the wizard, then start it
               with <code className="bs-code-inline">docker compose --profile tts-heavy up -d</code>{' '}
               (or set <code className="bs-code-inline">COMPOSE_PROFILES=tts-heavy</code> in{' '}
@@ -208,8 +208,8 @@ $EDITOR .env`}</CodeBlock>
             <div className="bs-callout">
               <div className="bs-eyebrow">DAY-TO-DAY OPERATOR CONSOLE</div>
               <p>
-                <code className="bs-code-inline">npm start</code> opens the operator console
-                — a menu for stack status, a diagnostic sweep, logs, restart, and the terminal
+                <code className="bs-code-inline">npm start</code> opens the operator console:
+                a menu for stack status, a diagnostic sweep, logs, restart, and the terminal
                 player. The everyday way to run the station once it's installed.
               </p>
             </div>

--- a/web/components/setup/Prerequisites.tsx
+++ b/web/components/setup/Prerequisites.tsx
@@ -6,7 +6,7 @@ export default function Prerequisites() {
     <SetupPage
       eyebrow="SETUP · 01"
       title="Have these ready."
-      intro="SUB/WAVE doesn't ship Navidrome or Ollama — it talks to yours. Get them running first if they aren't already, and note the URLs and credentials. The install wizard will ask for them."
+      intro="SUB/WAVE doesn't ship Navidrome or Ollama; it talks to yours. Get them running first if they aren't already, and note the URLs and credentials. The install wizard will ask for them."
       current="/setup/prerequisites"
     >
       <section className="bs-section">
@@ -17,16 +17,16 @@ export default function Prerequisites() {
             <strong>Docker on the host.</strong>
             <p>
               Docker Compose runs the stack (two containers in dev, four in
-              production — icecast and liquidsoap live together in a single{' '}
+              production; icecast and liquidsoap live together in a single{' '}
               <code className="bs-code-inline">broadcast</code> container). The
               standalone <code className="bs-code-inline">subwave</code> CLI is a
-              single Bun-compiled binary with no runtime dependency — no Node
+              single Bun-compiled binary with no runtime dependency; no Node
               needed unless you&apos;re hacking on the source (
               <Link href="/setup/development" className="bs-link">Development</Link>).
             </p>
           </li>
           <li>
-            <strong>Navidrome — or any Subsonic-API server.</strong>
+            <strong>Navidrome, or any Subsonic-API server.</strong>
             <p>
               SUB/WAVE plays from your library, reachable from wherever the stack
               runs. Note the URL, username, and password. The wizard asks for all

--- a/web/components/setup/QuickStart.tsx
+++ b/web/components/setup/QuickStart.tsx
@@ -26,11 +26,11 @@ export default function QuickStart() {
           <CodeBlock>{`curl -fsSL https://cli.getsubwave.com | sh`}</CodeBlock>
           <CodeBlock>{`subwave setup`}</CodeBlock>
           <p className="text-muted">
-            The installer prompts <em>Run subwave init now?</em> — say yes and{' '}
+            The installer prompts <em>Run subwave init now?</em> Say yes and{' '}
             <code className="bs-code-inline">init</code> asks where to install
             (default <code className="bs-code-inline">~/subwave</code>),
             deployment shape (prod / prod-byo), and admin credentials. It ends
-            with <em>Bring the stack up now?</em> — say yes again and{' '}
+            with <em>Bring the stack up now?</em> Say yes again and{' '}
             <code className="bs-code-inline">subwave start</code> runs silently
             against the env <code className="bs-code-inline">init</code> just
             picked. After that,{' '}
@@ -68,7 +68,7 @@ export default function QuickStart() {
               </li>
               <li>
                 state in <code className="bs-code-inline">./state</code> (or{' '}
-                <code className="bs-code-inline">STATE_DIR</code>) — re-run with sudo
+                <code className="bs-code-inline">STATE_DIR</code>); re-run with sudo
                 if it isn't writable
               </li>
             </ul>
@@ -77,7 +77,7 @@ export default function QuickStart() {
         <div className="bs-callout">
           <div className="bs-eyebrow">SAFE TO RE-RUN</div>
           <p>
-            Existing env values are kept unless you explicitly ask to reconfigure — so the
+            Existing env values are kept unless you explicitly ask to reconfigure, so the
             wizard doubles as a way to bring an existing stack back up.
           </p>
         </div>
@@ -87,7 +87,7 @@ export default function QuickStart() {
         <p className="bs-eyebrow">PATH B · AI CODING AGENT</p>
         <h2>One sentence in your coding agent.</h2>
         <p>
-          The repo ships an agent skill that handles setup, deploy, and update — it pings
+          The repo ships an agent skill that handles setup, deploy, and update: it pings
           Navidrome and Ollama, boots the stack, generates jingles, and verifies the stream is
           on-air. It works with <strong>Claude Code</strong>, <strong>Codex</strong>,{' '}
           <strong>Cursor</strong>, or anything else that reads{' '}
@@ -107,7 +107,7 @@ cd subwave`}</CodeBlock>
             On updates the same skill detects which services actually changed and rebuilds
             only those. Liquidsoap and the Controller <em>COPY</em> their source at build
             time, so a plain <code className="bs-code-inline">docker compose restart</code>{' '}
-            silently runs stale code — the skill won't make that mistake.
+            silently runs stale code; the skill won't make that mistake.
           </p>
         </div>
       </section>
@@ -117,15 +117,15 @@ cd subwave`}</CodeBlock>
         <h2>Run the station from the CLI.</h2>
         <p>
           The setup wizard is one screen of the operator console. Run{' '}
-          <code className="bs-code-inline">npm start</code> from the repo any time to open it
-          — a menu to check the stack, run a diagnostic sweep, tail logs, restart a service,
+          <code className="bs-code-inline">npm start</code> from the repo any time to open it:
+          a menu to check the stack, run a diagnostic sweep, tail logs, restart a service,
           or open the terminal player.
         </p>
         <CodeBlock>{`npm start`}</CodeBlock>
         <div className="bs-callout">
           <div className="bs-eyebrow">LISTEN FROM THE TERMINAL</div>
           <p>
-            The console's <strong>play</strong> option launches the TUI player — now-playing,
+            The console's <strong>play</strong> option launches the TUI player: now-playing,
             the timeline, the live booth feed, and track requests, right in your terminal. It
             needs <code className="bs-code-inline">mpv</code> or{' '}
             <code className="bs-code-inline">ffplay</code> for audio, and runs as a read-only

--- a/web/components/setup/SetupOverview.tsx
+++ b/web/components/setup/SetupOverview.tsx
@@ -26,7 +26,7 @@ export default function SetupOverview() {
       eyebrow="SELF-HOSTED · OPEN SOURCE"
       title="Run your own SUB/WAVE."
       meta="≈ 10 min · 4 commands · needs Navidrome + an LLM"
-      intro="SUB/WAVE points at your Navidrome library and your LLM — a local Ollama box by default, or any hosted provider you prefer. Once it's running, the AI DJ broadcasts from your homelab, plays from your music collection, and answers requests from anyone with the URL."
+      intro="SUB/WAVE points at your Navidrome library and your LLM: a local Ollama box by default, or any hosted provider you prefer. Once it's running, the AI DJ broadcasts from your homelab, plays from your music collection, and answers requests from anyone with the URL."
       current="/setup"
       heroAside={
         <div className="bs-dj-glyph" aria-hidden="true">
@@ -48,12 +48,12 @@ export default function SetupOverview() {
           <CodeBlock>{`subwave setup`}</CodeBlock>
           <p className="text-muted">
             The installer drops the <code className="bs-code-inline">subwave</code>{' '}
-            binary, then prompts <em>Run subwave init now?</em> — say yes and it
+            binary, then prompts <em>Run subwave init now?</em> Say yes and it
             walks the install dir (default{' '}
             <code className="bs-code-inline">~/subwave</code>), deployment shape
             (prod / prod-byo), and admin credentials.{' '}
             <code className="bs-code-inline">init</code> ends with{' '}
-            <em>Bring the stack up now?</em> — yes again brings up Docker. Then{' '}
+            <em>Bring the stack up now?</em> Yes again brings up Docker. Then{' '}
             <code className="bs-code-inline">setup</code> prompts for Navidrome
             and your LLM, persists everything, and renders the station jingles.{' '}
             <Link href="/setup/quick-start" className="bs-link">
@@ -63,7 +63,7 @@ export default function SetupOverview() {
           <p className="text-muted">
             After that,{' '}
             <code className="bs-code-inline">subwave status / logs / doctor / restart / update</code>{' '}
-            drive the station from anywhere on your shell — no{' '}
+            drive the station from anywhere on your shell, with no{' '}
             <code className="bs-code-inline">cd</code> into a project dir, no clone
             required. Prefer pure <code className="bs-code-inline">docker compose</code>?{' '}
             <Link href="/setup/manual" className="bs-link">Manual Install</Link>{' '}

--- a/web/components/setup/Updates.tsx
+++ b/web/components/setup/Updates.tsx
@@ -31,7 +31,7 @@ export default function Updates() {
         </table>
 
         <p className="mt-4">
-          Typical manual deploy — pull, rebuild only what changed (here, controller
+          Typical manual deploy: pull, rebuild only what changed (here, controller
           + web), then verify:
         </p>
         <CodeBlock>{`git pull --ff-only
@@ -68,7 +68,7 @@ docker compose up -d --build controller web
 docker compose up -d`}</CodeBlock>
           <p className="text-muted">
             Same flow if you&apos;re on{' '}
-            <code className="bs-code-inline">docker-compose.byo.yml</code> — just
+            <code className="bs-code-inline">docker-compose.byo.yml</code>, just
             swap the file flag.
           </p>
         </div>
@@ -113,8 +113,8 @@ docker compose up -d`}</CodeBlock>
             <strong>Source code</strong> —{' '}
             <a href="https://github.com/perminder-klair/subwave" target="_blank" rel="noreferrer" className="bs-link">
               github.com/perminder-klair/subwave ↗
-            </a>{' '}
-            — file an issue, or read the CLAUDE.md for architecture notes.
+            </a>
+            . File an issue, or read the CLAUDE.md for architecture notes.
           </li>
         </ul>
       </section>
@@ -124,7 +124,7 @@ docker compose up -d`}</CodeBlock>
         <h2>Now shape the DJ.</h2>
         <p>
           Installation is the start. Tuning the personas, scheduling shows, choosing the LLM
-          provider, and managing jingles all happen in the admin console — that's covered in{' '}
+          provider, and managing jingles all happen in the admin console; that's covered in{' '}
           <Link href="/manual/admin" className="bs-link">the manual's Admin &amp; Settings
           page</Link>.
         </p>

--- a/web/components/stations/StationMap.tsx
+++ b/web/components/stations/StationMap.tsx
@@ -119,7 +119,7 @@ export default function StationMap({ stations }: { stations: Station[] }) {
       </svg>
       {plotted.length === 0 ? (
         <figcaption className="bs-map-caption">
-          No stations plotted yet — add yours below.
+          No stations plotted yet. Add yours below.
         </figcaption>
       ) : null}
     </figure>


### PR DESCRIPTION
## What

- **Mobile apps are live.** README now points to the [Android Google Play listing](https://play.google.com/store/apps/details?id=com.getsubwave.app) and [iOS TestFlight](https://testflight.apple.com/join/Xrx5TUmb), replacing the prior "beta / join the beta" GitHub-discussion link.
- **Copy cleanup.** A typographic pass across the manual (`web/components/manual/*`) and setup (`web/components/setup/*`) pages — normalising em-dash asides to colons for a consistent voice.

## Why

The native players have shipped to their respective stores, so the docs should send people straight to install rather than to a beta sign-up. The copy pass tidies inconsistent dash usage that crept in across the manual/setup content.

## Scope

Docs/content only — no controller, Liquidsoap, or runtime changes. 23 files, all under `README.md` and `web/`.