### PR TITLE
chore: harden node_modules gitignore to catch stray symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 .env.*.local
 
 # Node
-node_modules/
+# No trailing slash: also catches a stray file/symlink named node_modules
+# (a broken macOS-local symlink slipped past the dir-only pattern in #325).
+node_modules
 
 # Next.js
 .next/


### PR DESCRIPTION
## What

Drop the trailing slash on the `node_modules` ignore pattern (`node_modules/` → `node_modules`).

## Why

The `node_modules/` pattern matches **directories only**. A broken macOS-local symlink named `controller/node_modules` (→ `/Users/klair/Projects/subwave/web/controller/node_modules`) slipped past it and got committed in #325. It was untracked on `develop` in #363, but `main` still carries it until the next release PR.

Without the trailing slash the pattern matches both directories **and** a stray file/symlink named `node_modules`, so this can't recur.

## Verification

```
$ ln -s /tmp/fake controller/node_modules && git check-ignore -v controller/node_modules
.gitignore:9:node_modules\tcontroller/node_modules   # now ignored
```
Normal `web/node_modules` dirs remain ignored.