### PR TITLE
feat(app): dock player bar across all screens + slim live now-playing

### DIFF
--- a/app/src/player/CenterStage.tsx
+++ b/app/src/player/CenterStage.tsx
@@ -78,8 +78,8 @@ export default function CenterStage({
   return (
     <View className="flex-1 justify-center px-5">
       {coverSrc ? (
-        <View className="mb-8" style={{ alignItems: 'flex-start' }}>
-          <CoverArt uri={coverSrc} live={live} burst={burst} size={160} onPress={onOpenTimeline} />
+        <View style={{ alignItems: 'flex-start', marginBottom: 14 }}>
+          <CoverArt uri={coverSrc} live={live} burst={burst} size={120} onPress={onOpenTimeline} />
         </View>
       ) : null}
 
@@ -92,7 +92,7 @@ export default function CenterStage({
 
       {has ? (
         <>
-          <Text className="font-display text-ink" style={{ fontSize: 34, lineHeight: 38 }}>
+          <Text className="font-display text-ink" style={{ fontSize: 26, lineHeight: 30 }}>
             {nowPlaying?.title}
           </Text>
           <Text className="font-body-medium mt-3" style={{ fontSize: 15, color: colors.muted }}>
@@ -102,7 +102,7 @@ export default function CenterStage({
           </Text>
         </>
       ) : (
-        <Text className="font-display text-muted" style={{ fontSize: 32, lineHeight: 36 }}>
+        <Text className="font-display text-muted" style={{ fontSize: 26, lineHeight: 30 }}>
           scanning the dial_
         </Text>
       )}

--- a/app/src/player/PlayerScreen.tsx
+++ b/app/src/player/PlayerScreen.tsx
@@ -4,7 +4,9 @@
 // FreqBand tuner above a horizontal pager whose five "stations" are
 // Shows / Timeline / LIVE / Booth / Request, with LIVE dead-centre as home.
 // Swipe (or tap a band stop) to tune across sections; the needle tracks the
-// scroll. Themes open in a bottom sheet from the palette icon, off-band.
+// scroll. The TransportBar is docked below the pager so the player stays
+// visible on every band stop, bottom-nav style. Themes open in a bottom sheet
+// from the palette icon, off-band.
 //
 // Render-path notes: the pager's scroll drives the FreqBand needle through a
 // native-driver Animated.Value (no per-frame React state), and the four
@@ -310,19 +312,6 @@ export default function PlayerScreen() {
                     onOpenTimeline={openTimeline}
                   />
                   <Waveform tunedIn={tunedIn} progress={progress} visible={active === HOME_INDEX} />
-                  <TransportBar
-                    tunedIn={tunedIn}
-                    status={status}
-                    onTune={tune}
-                    offline={offline}
-                    volume={volume}
-                    setVolume={setVolume}
-                    muted={muted}
-                    onToggleMute={toggleMute}
-                    latencyMs={signal.latencyMs}
-                    signalQuality={signal.quality}
-                    listeners={listenerCount}
-                  />
                 </View>
               </View>
               <View style={{ width: pagerW }}>
@@ -336,6 +325,22 @@ export default function PlayerScreen() {
             </Animated.ScrollView>
           ) : null}
         </View>
+
+        {/* Persistent transport — lives below the pager so the player stays
+            docked at the foot of every band stop, like a bottom nav. */}
+        <TransportBar
+          tunedIn={tunedIn}
+          status={status}
+          onTune={tune}
+          offline={offline}
+          volume={volume}
+          setVolume={setVolume}
+          muted={muted}
+          onToggleMute={toggleMute}
+          latencyMs={signal.latencyMs}
+          signalQuality={signal.quality}
+          listeners={listenerCount}
+        />
       </SafeAreaView>
 
       <Sheet open={themesOpen} onClose={() => setThemesOpen(false)} title="Theme">

--- a/app/src/player/TransportBar.tsx
+++ b/app/src/player/TransportBar.tsx
@@ -2,7 +2,7 @@
 // three-cell box — Power (hollow ring that lights accent on air), the analog
 // Signal meter (label + listener/latency read, a 26-tick scale with a vermilion
 // grip, and a 0–250 latency ruler), and Volume (rotary knob + dot-grille mute).
-// Sits at the foot of the LIVE page in the FM-dial pager.
+// Docked below the FM-dial pager, so it stays at the foot of every band stop.
 
 import * as Haptics from 'expo-haptics';
 import { ActivityIndicator, Pressable, Text, View } from 'react-native';


### PR DESCRIPTION
## What

Two changes to the native iOS/Android player (`app/`):

1. **Persistent player bar.** The `TransportBar` (power / signal meter / volume) lived *inside* the LIVE page of the FM-dial swipe pager, so it scrolled away when you swiped to Shows / Timeline / Booth / Request. It's now lifted out and rendered once below the pager, so the player stays docked at the foot of **every** band stop — like a bottom nav.

2. **Slimmer LIVE now-playing card.** Reduced visual weight on the LIVE screen:
   - Artwork `160 → 120`
   - Track title `34/38 → 26/30` (and the "scanning the dial_" placeholder to match)
   - `14px` gap below the cover

## Why

The player controls were only visible on the LIVE screen; users browsing other sections lost the transport. Docking it makes playback control reachable everywhere. The card resize gives the live screen a tidier, less cramped layout now that the bar is always present.

## How it works

`TransportBar` was already fully prop-driven at the `PlayerScreen` level and brings its own bottom safe-area inset + margins, so it dropped straight in as a sibling of the pager — the pager's `flex: 1` area shrinks to fit. `PagePanel` already pads `insets.bottom + 18` at the foot of its scroll content, which doubles as clearance above the docked bar. No new state or props.

## Testing

- `tsc --noEmit` clean.
- Verified in the iOS simulator (iPhone 17 Pro): player stays docked on LIVE, Shows, and other band stops; artwork + title render at the reduced sizes.

(`app/` has no local eslint install; the CI lint gate covers `controller/` + `web/`.)