### PR TITLE
feat(library): CLAP capability warning + fix analyzer download hang

### DIFF
--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -28,6 +28,7 @@ into the query string) to a temp file, then only the first ANALYZE_SECONDS are
 decoded — enough for tempo/key and the intro estimate, a fraction of the bytes.
 """
 
+import importlib.util
 import json
 import os
 import sys
@@ -354,8 +355,18 @@ def main():
         log("ANALYZE_AUDIO_EMBEDDING on — loading CLAP model...")
         get_embedder()
 
+    # Tell the controller whether this worker can actually emit "sounds-like"
+    # audio embeddings, so the admin UI can warn *before* a fruitless run rather
+    # than after the fingerprint bar stays at 0. Capable = the CLAP libs are
+    # present (image built WITH_CLAP=1) and we haven't already hit a hard load
+    # failure. find_spec avoids importing torch when embeddings are off.
+    audio_capable = (not _embed_failed) and (
+        _embedder is not None
+        or all(importlib.util.find_spec(m) is not None for m in ("torch", "transformers"))
+    )
+
     log("ready")
-    emit({"id": None, "ready": True})
+    emit({"id": None, "ready": True, "audio_embedding_capable": audio_capable})
 
     for line in sys.stdin:
         line = line.strip()

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -13,7 +13,6 @@
 
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { existsSync, mkdirSync, createWriteStream } from 'node:fs';
-import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { config } from '../config.js';
 import * as subsonic from './subsonic.js';
@@ -160,6 +159,10 @@ async function analyzeViaLocalPath(path: string, opts: AnalyzeRequestOpts = {}):
 // Sidecar backend
 // ---------------------------------------------------------------------------
 
+// Last sidecar /health read of the CLAP capability. null = unknown (not yet
+// probed, or the field is absent on an old sidecar); true/false once known.
+let _sidecarAudioCapable: boolean | null = null;
+
 async function sidecarReachable(): Promise<boolean> {
   const url = config.ttsHeavy.url;
   if (!url) return false;
@@ -169,8 +172,12 @@ async function sidecarReachable(): Promise<boolean> {
     const res = await fetch(`${url}/health`, { signal: ac.signal });
     clearTimeout(t);
     if (!res.ok) return false;
-    const body = (await res.json()) as { ok?: boolean; engines?: string[] };
-    return !!body.ok && Array.isArray(body.engines) && body.engines.includes('analyze');
+    const body = (await res.json()) as { ok?: boolean; engines?: string[]; analyze_audio_capable?: boolean | null };
+    const reachable = !!body.ok && Array.isArray(body.engines) && body.engines.includes('analyze');
+    if (reachable) {
+      _sidecarAudioCapable = typeof body.analyze_audio_capable === 'boolean' ? body.analyze_audio_capable : null;
+    }
+    return reachable;
   } catch {
     return false;
   }
@@ -235,6 +242,23 @@ export function backendLabel(): string {
   return _backend || 'none';
 }
 
+// Whether the active backend can emit CLAP "sounds-like" audio embeddings right
+// now. null = unknown (local backend — we don't probe its venv; or sidecar not
+// yet reached); false = sidecar reachable but built without the CLAP stack
+// (WITH_CLAP=0) — the signal the admin UI turns into a "rebuild the sidecar"
+// warning. Only meaningful for the sidecar backend.
+export function audioEmbeddingAvailable(): boolean | null {
+  return _backend === 'sidecar' ? _sidecarAudioCapable : null;
+}
+
+// Re-read sidecar /health so capability reflects a sidecar rebuilt under a
+// long-lived controller (resolveBackend caches the backend *choice* forever,
+// but CLAP support flips when the operator rebuilds with WITH_CLAP=1). Cheap;
+// driven on the coverage staleness cadence.
+export async function refreshCapabilities(): Promise<void> {
+  if ((await resolveBackend()) === 'sidecar') await sidecarReachable();
+}
+
 // Analyse one track by id. Throws on failure — the caller (analyze pass) logs
 // and moves on, leaving the row NULL so it's retried on the next run. This is
 // the URL path: the backend fetches the audio itself. Kept as the fallback
@@ -266,25 +290,22 @@ export async function downloadCapped(songId: string): Promise<string> {
     if (!res.ok || !res.body) {
       throw new Error(`download ${res.status}: ${await res.text().catch(() => '')}`);
     }
-    // Stream the body to disk, aborting once we've pulled the byte cap — a few
-    // MB covers the analysis window for any common codec.
+    // Stream the body to disk, stopping once we've pulled the byte cap — a few
+    // MB covers the analysis window for any common codec. A capped async
+    // generator feeds pipeline (which handles backpressure and tears the source
+    // down when we return early). The previous approach — a `data` listener
+    // that called src.destroy() alongside pipeline — deadlocked: attaching the
+    // listener flips the web-backed Readable into flowing mode and races the
+    // pipe, so pipeline() never resolves and every download hangs.
     let read = 0;
-    const out = createWriteStream(dest);
-    const src = Readable.fromWeb(res.body as any);
-    src.on('data', (chunk: Buffer) => {
-      read += chunk.length;
-      if (read >= ANALYZE_MAX_BYTES) {
-        src.destroy();
-        ac.abort();
+    async function* capped() {
+      for await (const chunk of res.body as any) {
+        read += chunk.length;
+        yield chunk;
+        if (read >= ANALYZE_MAX_BYTES) return; // enough audio for the window
       }
-    });
-    try {
-      await pipeline(src, out);
-    } catch (err: any) {
-      // A deliberate cap-abort closes the stream mid-flight; that's not a
-      // failure as long as we wrote some bytes.
-      if (read === 0) throw err;
     }
+    await pipeline(capped(), createWriteStream(dest));
     if (read === 0) throw new Error('downloaded empty audio');
     return dest;
   } finally {

--- a/controller/src/music/library-coverage.ts
+++ b/controller/src/music/library-coverage.ts
@@ -28,7 +28,9 @@ const cache: CoverageCache = { total: 0, scannedAt: null, scanning: false };
 let inflight: Promise<void> | null = null;
 
 // Last known acoustic-analysis backend state. `null` until first probed.
-let analysisAvail: { available: boolean; backend: string; checkedAt: number } | null = null;
+// `audioCapable` mirrors analyzer.audioEmbeddingAvailable() — whether the
+// backend can emit CLAP "sounds-like" embeddings (null = unknown).
+let analysisAvail: { available: boolean; backend: string; audioCapable: boolean | null; checkedAt: number } | null = null;
 let analysisProbeInflight: Promise<void> | null = null;
 
 function refreshAnalysisAvail() {
@@ -36,9 +38,15 @@ function refreshAnalysisAvail() {
   analysisProbeInflight = (async () => {
     try {
       const available = await analyzer.isAvailable();
-      analysisAvail = { available, backend: analyzer.backendLabel(), checkedAt: Date.now() };
+      await analyzer.refreshCapabilities();
+      analysisAvail = {
+        available,
+        backend: analyzer.backendLabel(),
+        audioCapable: analyzer.audioEmbeddingAvailable(),
+        checkedAt: Date.now(),
+      };
     } catch {
-      analysisAvail = { available: false, backend: 'none', checkedAt: Date.now() };
+      analysisAvail = { available: false, backend: 'none', audioCapable: null, checkedAt: Date.now() };
     } finally {
       analysisProbeInflight = null;
     }
@@ -113,5 +121,9 @@ export async function get() {
     // the UI surfaces this rather than showing a misleading 0%.
     analysisAvailable: analysisAvail ? analysisAvail.available : null,
     analysisBackend: analysisAvail ? analysisAvail.backend : null,
+    // Whether the backend can emit CLAP "sounds-like" embeddings. false here
+    // with sounds-like enabled means the sidecar was built without CLAP — the
+    // UI turns this into a "rebuild with WITH_CLAP=1" warning. null = unknown.
+    audioAnalysisAvailable: analysisAvail ? analysisAvail.audioCapable : null,
   };
 }

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -330,6 +330,15 @@ async def health():
             pocket_worker.ready_meta.get("voice_cloning") if pocket_worker.ready else None
         ),
         "analyze_loaded": analyzer_worker.ready,
+        # Whether the analyze worker can emit CLAP "sounds-like" audio
+        # embeddings — true only when the image was built WITH_CLAP=1 (the torch
+        # + transformers stack is present). The controller surfaces this so the
+        # admin UI warns to rebuild the sidecar *before* a fruitless run rather
+        # than after the fingerprint bar stays at 0. None until the worker is
+        # ready and has reported its capability.
+        "analyze_audio_capable": (
+            analyzer_worker.ready_meta.get("audio_embedding_capable") if analyzer_worker.ready else None
+        ),
     }
 
 

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -34,6 +34,10 @@ export interface Coverage {
   // null = still probing; false = no analysis backend (sidecar/librosa) running.
   analysisAvailable?: boolean | null;
   analysisBackend?: string | null;
+  // Whether the backend can emit CLAP "sounds-like" embeddings. false = engine
+  // is up but built without the CLAP stack (sidecar WITH_CLAP=0) — drives the
+  // active "rebuild with WITH_CLAP=1" warning. null = unknown / still probing.
+  audioAnalysisAvailable?: boolean | null;
 }
 
 // Mirrors controller/src/music/tagger-progress.ts — the structured sentinel
@@ -121,7 +125,7 @@ const PHASE_HINT: Record<TaggerProgress['phase'], string> = {
 
 export default function TaggingPanel(p: TaggingPanelProps) {
   const [maintOpen, setMaintOpen] = useState(false);
-  const [confirmFull, setConfirmFull] = useState(false);
+  const [confirmRescan, setConfirmRescan] = useState(false);
   const [passes, setPasses] = useState<RescanOpts>({ reseed: false, reEnrich: false, reAnalyze: false, upgrade: false });
   const logRef = useRef<HTMLPreElement>(null);
   const moodFillRef = useRef<HTMLSpanElement>(null);
@@ -142,6 +146,10 @@ export default function TaggingPanel(p: TaggingPanelProps) {
   const remaining = total != null && tagged != null ? Math.max(0, total - tagged) : null;
   const running = !!p.tagger?.running;
   const analysisOff = p.coverage?.analysisAvailable === false;
+  // Engine is up but built without the CLAP stack — "sounds-like" fingerprints
+  // can't be produced until the sidecar is rebuilt with WITH_CLAP=1. We warn
+  // actively rather than letting a run finish with the bar stuck at 0.
+  const audioIncapable = !analysisOff && p.coverage?.audioAnalysisAvailable === false;
   const moodCount = p.libStats ? Object.keys(p.libStats.byMood || {}).length : 0;
   const lastTag = p.libStats?.updatedAt ? new Date(p.libStats.updatedAt).toLocaleString('en-GB') : '—';
   const anySel = !!(passes.reseed || passes.reEnrich || passes.reAnalyze || passes.upgrade);
@@ -169,6 +177,19 @@ export default function TaggingPanel(p: TaggingPanelProps) {
   }, [p.logOpen, p.tagger?.lastLog?.length]);
 
   const togglePass = (k: keyof RescanOpts) => setPasses(prev => ({ ...prev, [k]: !prev[k] }));
+  const allSelected = !!(passes.reseed && passes.reEnrich && passes.reAnalyze && passes.upgrade);
+  const toggleAll = () => {
+    const on = !allSelected;
+    setPasses({ reseed: on, reEnrich: on, reAnalyze: on, upgrade: on });
+  };
+  const clearPasses = () => setPasses({ reseed: false, reEnrich: false, reAnalyze: false, upgrade: false });
+  // Re-embedding re-spends embedding calls — guard those runs behind a confirm;
+  // the lighter passes (re-enrich / re-analyse / re-decide) run straight away.
+  const runRescan = () => {
+    if (passes.reseed) { setConfirmRescan(true); return; }
+    p.onRescan(passes);
+    clearPasses();
+  };
 
   return (
     <section className="card">
@@ -337,14 +358,16 @@ export default function TaggingPanel(p: TaggingPanelProps) {
             <span className="caption mono-num !tracking-[0.04em]">
               {analysisOff
                 ? 'engine off'
-                : audioOn
-                  ? <>{num(audioEmbedded)} / {num(total)} · {audpct != null ? `${audpct}%` : '…'}</>
-                  : p.audioEnabled ? 'enabled — not yet analysed' : 'off'}
+                : audioIncapable
+                  ? 'engine missing CLAP'
+                  : audioOn
+                    ? <>{num(audioEmbedded)} / {num(total)} · {audpct != null ? `${audpct}%` : '…'}</>
+                    : p.audioEnabled ? 'enabled — not yet analysed' : 'off'}
             </span>
             {!analysisOff && p.audioEnabled != null && (
               <span className="flex items-center gap-2">
                 {p.audioEnabled && (
-                  <Btn sm tone="accent" onClick={p.onAnalyzeAudio} disabled={running || p.busy}>
+                  <Btn sm tone="accent" onClick={p.onAnalyzeAudio} disabled={running || p.busy || audioIncapable}>
                     <Play size={12} /> {audioOn ? 'Analyze new tracks' : 'Analyze library'}
                   </Btn>
                 )}
@@ -353,18 +376,35 @@ export default function TaggingPanel(p: TaggingPanelProps) {
                 </Btn>
               </span>
             )}
-            <span className="caption basis-full !tracking-[0.04em] !normal-case">
-              {analysisOff
-                ? 'Needs the analysis engine above.'
-                : audioOn || !p.audioEnabled
-                  ? 'Listens to each track and fingerprints how it sounds, enabling “sounds-like” picks and sonic journeys.'
-                  : 'Run the analysis to fingerprint your tracks — if the bar stays at 0 after a run, rebuild the tts-heavy sidecar with WITH_CLAP=1.'}
-            </span>
+            {audioIncapable && p.audioEnabled ? (
+              <span className="basis-full border border-[color-mix(in_oklab,var(--accent)_35%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] leading-[1.5] text-ink !normal-case">
+                <b>Sounds-like is on, but the analysis engine can’t fingerprint audio.</b> The
+                tts-heavy sidecar was built without the CLAP model, so a run would only fill bpm/key
+                and leave this at 0. Rebuild it with the CLAP stack, then run the analysis:
+                <code className="mt-1 block font-mono text-[10.5px] text-muted">WITH_CLAP=1 docker compose build tts-heavy &amp;&amp; docker compose --profile tts-heavy up -d tts-heavy</code>
+              </span>
+            ) : (
+              <span className="caption basis-full !tracking-[0.04em] !normal-case">
+                {analysisOff
+                  ? 'Needs the analysis engine above.'
+                  : 'Listens to each track and fingerprints how it sounds, enabling “sounds-like” picks and sonic journeys.'}
+              </span>
+            )}
           </div>
 
-          <div className="max-w-[64ch] border-t border-dashed border-separator-strong pt-3.5 text-[12px] leading-[1.55] text-muted">
-            Re-scanning rebuilds parts of the index — only needed after changing the LLM, embedding
-            model, or analysis engine. Existing mood tags are kept as seeds.
+          <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1.5 border-t border-dashed border-separator-strong pt-3.5">
+            <span className="max-w-[64ch] text-[12px] leading-[1.55] text-muted">
+              <b className="text-ink">Re-scan</b> — only needed after changing the LLM, embedding model, or analysis
+              engine. Pick the passes to redo (tick all for a full rebuild); existing mood tags are kept as seeds.
+            </span>
+            <button
+              type="button"
+              className="shrink-0 text-[11px] font-bold text-vermilion underline-offset-2 hover:underline disabled:opacity-40"
+              disabled={p.busy || running}
+              onClick={allSelected ? clearPasses : toggleAll}
+            >
+              {allSelected ? 'Clear all' : 'Select all'}
+            </button>
           </div>
           <div className="grid gap-2.5 sm:grid-cols-2">
             <Pass on={!!passes.reseed} onClick={() => togglePass('reseed')} name="Re-embed all tracks"
@@ -372,17 +412,13 @@ export default function TaggingPanel(p: TaggingPanelProps) {
             <Pass on={!!passes.reEnrich} onClick={() => togglePass('reEnrich')} name="Re-enrich metadata"
               hint="Re-fetch Last.fm tags + lyrics that feed the tagging." />
             <Pass on={!!passes.reAnalyze} onClick={() => togglePass('reAnalyze')} name="Re-analyse acoustics"
-              hint="Redo BPM / key detection for every track." />
+              hint="Redo BPM / key for every track — also refreshes sounds-like fingerprints when enabled." />
             <Pass on={!!passes.upgrade} onClick={() => togglePass('upgrade')} name="Re-decide moods"
               hint="Re-tag tracks whose prompt or model is now stale." />
           </div>
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <Btn sm disabled={p.busy || running} onClick={() => setConfirmFull(true)}>
-              <RefreshCw size={12} /> Full re-scan (everything)
-            </Btn>
-            <Btn sm tone="accent" disabled={!anySel || p.busy || running}
-              onClick={() => { p.onRescan(passes); setPasses({ reseed: false, reEnrich: false, reAnalyze: false, upgrade: false }); }}>
-              Run selected passes
+          <div className="flex flex-wrap items-center justify-end gap-3">
+            <Btn sm tone="accent" disabled={!anySel || p.busy || running} onClick={runRescan}>
+              <RefreshCw size={12} /> {allSelected ? 'Run full re-scan' : 'Run re-scan'}
             </Btn>
           </div>
         </div>
@@ -396,13 +432,13 @@ export default function TaggingPanel(p: TaggingPanelProps) {
       )}
 
       <V3AlertDialog
-        open={confirmFull}
-        onOpenChange={setConfirmFull}
-        title="Full library re-scan"
-        description="Rebuilds the whole library from scratch: re-embeds every track, re-fetches Last.fm tags + lyrics, and redoes acoustic (bpm/key) analysis. Existing mood tags are kept and reused as seeds — moods are not re-decided. This can take several minutes on a large library and re-spends embedding calls. To re-decide moods too, tick 'Re-decide moods' and use 'Run selected passes'."
-        confirmLabel="full re-scan"
+        open={confirmRescan}
+        onOpenChange={setConfirmRescan}
+        title="Re-embed the whole library?"
+        description="This pass drops and rebuilds every similarity vector from scratch, which re-spends embedding calls and can take several minutes on a large library. Existing mood tags are kept and reused as seeds. Only needed after changing the embedding model."
+        confirmLabel="re-scan"
         danger
-        onConfirm={() => p.onRescan({ reseed: true, reEnrich: true, reAnalyze: true })}
+        onConfirm={() => { p.onRescan(passes); clearPasses(); }}
       />
     </section>
   );


### PR DESCRIPTION
## Summary

Completes the `/admin/library` sounds-like (CLAP audio fingerprint) path and fixes a pre-existing bug that was silently blocking *all* acoustic + fingerprint analysis.

### 🐛 Fix: `downloadCapped` hung on every track
`downloadCapped` attached a `'data'` listener to the web-backed `Readable` **and** fed it to `pipeline()`. The listener flips the stream into flowing mode and races the pipe, so `pipeline()` never resolves — the analyze pass hung on the first download and never progressed (the picker kept working, which masked it). Replaced with a capped async generator feeding `pipeline()`: correct backpressure, clean teardown on early cap, no flowing-mode race.

Verified end-to-end: download ~95 ms, analysis returns bpm/key **and** a 512-dim CLAP vector; full-library run sustains ~40 tracks/min.

### ✨ Feature: active warning when sounds-like is on but the sidecar lacks CLAP
Replaces the passive *"if the bar stays at 0 after a run, rebuild with WITH_CLAP=1"* hint with a real backend-capability signal:

- `analyze_worker.py` emits `audio_embedding_capable` in its ready message
- tts-heavy `/health` exposes it as `analyze_audio_capable`
- controller threads it through `library-coverage` as `audioAnalysisAvailable`
- the admin panel shows an **active warning** (with the rebuild command), **disables** the Analyze button, and reads *"engine missing CLAP"* when sounds-like is enabled but the engine can't fingerprint

### 🧹 UI: consolidate the re-scan controls
The four pass toggles now sit behind a single **Run re-scan** action with a **Select all / Clear all** link, replacing the separate **Full re-scan** button (whose preset confusingly skipped *re-decide moods*). The confirm dialog now fires only for the heavy re-embed pass.

## Test plan
- [x] `controller` lint (eslint + tsc) — 0 errors
- [x] `web` lint (eslint + tsc) — 0 errors
- [x] Python syntax check (`py_compile`) on worker + server
- [x] Verified on the live prod host: `downloadCapped` + `analyzePath` succeed; bpm/key + audioEmbedded counts climb 1:1; `audioAnalysisAvailable: true` once CLAP is present; stream uninterrupted throughout

> Note: enabling fingerprints in prod also needs the sidecar built with `WITH_CLAP=1` (image-side, not in this diff).