### PR TITLE
release: library tagging UI, mobile player dock + docs refresh

### DIFF
--- a/.claude/skills/subwave-app-ota-update/SKILL.md
+++ b/.claude/skills/subwave-app-ota-update/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: subwave-app-ota-update
+description: Ship a JS/TS-only change to the already-installed SUB/WAVE app (the Expo project in `app/`) over-the-air via EAS Update — no new TestFlight/Play build, no store round-trip. Use this skill whenever the user wants to "send an OTA update", "push this over the air", "ship these changes without a new build", "eas update", "hotfix the app", "do we need a build or can we OTA this?", "publish to the preview/production channel", "get my last commit out to testers", or asks "will my TestFlight / Android beta build get this update?". Trigger it even when the user doesn't say "OTA" or "EAS" by name — if they changed app code and want it on people's phones quickly, this is the path. The skill judges OTA-eligibility (JS/asset change vs. a native change that needs a real build), publishes to a channel, and verifies which installed builds will actually receive it. Do NOT use this when native inputs changed (a dependency add/upgrade, anything under `app/patches/` or `plugins/`, or `app.json` native sections) — that needs a binary, which is `subwave-app-ios-release` / `subwave-app-android-release`. Also not for local dev/USB runs.
+---
+
+# SUB/WAVE app — OTA update (EAS Update)
+
+Push a **JS/TS-only** change to the app binaries already on people's phones,
+without building or submitting anything. The app ships `expo-updates`; an
+`eas update` bundles the current JS + Metro assets and serves them to matching
+installs, who pick them up on next launch. Most changes (UI, hooks, copy, logic,
+styles) go out this way in ~1 minute instead of a 15-min build + store round-trip.
+
+This skill covers the **whole OTA loop**: decide if the change is even
+OTA-eligible, publish it to the right channel, and confirm which installed builds
+will actually receive it (the question that always comes up — "will my TestFlight
+build get this?").
+
+The authoritative reference with the full decision table and fingerprint
+debugging is [`app/docs/RELEASE.md`](../../../app/docs/RELEASE.md). This skill is
+the hands-on OTA path; for a **binary** build read the release skills instead
+(see "When you actually need a build" below).
+
+## Fixed facts
+
+Derive the repo root; don't hardcode paths. `eas.json` + `app.json` live in
+`app/`, and **every `eas` command must run from there.**
+
+```bash
+REPO=$(git -C "<this skill's base directory>" rev-parse --show-toplevel)
+APP="$REPO/app"   # cd here before any eas command
+```
+
+| Thing | Value |
+|---|---|
+| EAS project | `@pinku1/subwave` (Expo account `pinku1`) |
+| Updates URL | `https://u.expo.dev/b834b64c-f694-4f45-b3fa-0f2c0a4df5ba` (in `app.json`) |
+| Channels | `preview` (tester builds) and `production` (TestFlight / Play) |
+| Runtime version | `fingerprint` policy — an OTA only reaches builds whose native fingerprint matches (see below) |
+| Apply behaviour | `checkAutomatically: ON_LOAD` + `fallbackToCacheTimeout: 0` — fetches in background, applies on the **next** cold start |
+
+## The one decision: can this go OTA, or does it need a build?
+
+An OTA can only carry **JS, TS, and Metro-bundled assets**. It cannot carry
+native code. EAS enforces this with the `fingerprint` runtime policy: it hashes
+the native inputs, and an update only installs on a binary whose hash matches — so
+you physically *can't* ship mismatched native code, but you also can't sneak a
+native change out via OTA.
+
+Judge it from what the change actually touched:
+
+```bash
+cd "$APP"
+git log -1 --stat        # or: git diff --stat <base>..HEAD
+```
+
+| The change touched… | Ship via |
+|---|---|
+| **`app/src/**` only** — components, hooks, styles, copy, business logic, JS/TS assets | ✅ **OTA** (this skill) |
+| `package.json` deps (ran `npx expo install …`), anything under `app/patches/` or `plugins/`, `app.json` `ios`/`android`/`infoPlist`/`plugins`/`expo-build-properties` | ❌ **New build** — fingerprint shifts; old binaries can't receive it. Use the release skills. |
+
+Rule of thumb: **only `src/**` (and other Metro-bundled assets) changed → OTA.
+Ran `expo install` or edited `patches/`/`plugins`/native `app.json` → build.** When
+unsure, the stat output is the tell — if every changed path is under `app/src/`,
+it's OTA.
+
+## Preflight (10 seconds)
+
+```bash
+cd "$APP"
+eas whoami        # expect: pinku1   (if not: eas login)
+```
+
+Optionally typecheck before shipping — `tsc --noEmit` is the project gate and an
+OTA pushes whatever's in the working tree's bundle:
+
+```bash
+npm run typecheck
+```
+
+## Publish
+
+**Recommended flow: preview first, then production.** Push to `preview`, sanity-
+check it on a preview build, then promote the same change to `production`. Ship
+straight to `production` only when the user explicitly asks or the change is
+already verified locally.
+
+### The command — and the non-interactive gotcha
+
+From a real terminal (TTY) the simple form prompts as needed:
+
+```bash
+cd "$APP"
+eas update --channel preview --message "fix: …"
+```
+
+But when running **non-interactively** (this agent, CI), `eas update` has two
+quirks worth knowing — both learned the hard way:
+
+- It **requires `--environment <name>`** in non-interactive mode, or it aborts
+  with *"The `--environment` flag must be set when running in `--non-interactive`
+  mode."* Pass the environment matching the channel (`preview` / `production`).
+- It does **not** accept `--non-interactive` (the inner expo-cli prints
+  *"`--non-interactive` is not supported, use `$CI=1` instead"*). Use the `CI=1`
+  env var to force non-interactive instead of the flag.
+
+So the form that reliably works headlessly:
+
+```bash
+cd "$APP"
+CI=1 eas update --channel preview --environment preview --message "fix: …"
+# promote later:
+CI=1 eas update --channel production --environment production --message "fix: …"
+```
+
+A line like *"No environment variables with visibility … found for the
+'production' environment"* is **harmless** — it just means EAS has no stored
+build-time env vars for that environment. The app reads its config at runtime, so
+nothing is missing.
+
+`eas update` publishes **per platform** and, under the `fingerprint` policy,
+**per runtime version** (iOS and Android have different native graphs, so you'll
+see two update groups). Capture from the output, for each platform: the **branch
+(= channel)**, the **runtime version**, and the **update group ID** — you need the
+runtime version for the verification step.
+
+## Verify who will actually receive it
+
+An installed build gets an OTA only if **both** match the published update:
+
+1. **Channel** — baked into the build at build time (`eas.json`
+   `build.<profile>.channel`).
+2. **Runtime version (fingerprint)** — must equal the update's runtime.
+
+List the builds and compare against the runtime(s) `eas update` just printed.
+`scripts/ota-delivery-check.sh [channel]` does this for you (defaults to
+`production`):
+
+```bash
+"$REPO/.claude/skills/subwave-app-ota-update/scripts/ota-delivery-check.sh" production
+```
+
+It prints recent finished builds with their channel + runtime and flags the ones
+on the target channel. Match those runtimes to the update's runtime: equal →
+that build receives it.
+
+**The trap: old builds with `channel=None` / `runtime=None`.** Early binaries
+built before OTA/channels were wired in (e.g. SUB/WAVE's pre-`1.0.0 (7)` iOS /
+pre-`(5)` Android builds) have no channel and no runtime — they can **never**
+receive an OTA, no matter the fingerprint. Anyone on one of those needs a fresh
+install from TestFlight / the Android link. Builds that show a real channel +
+runtime are the ones an update can reach.
+
+## When testers actually see it
+
+Not instantly, by design. With `checkAutomatically: ON_LOAD` and
+`fallbackToCacheTimeout: 0`, launch **never blocks** on the update fetch (critical
+for a radio app opened in a dead zone). The app runs the cached bundle, downloads
+the new one in the background, and applies it on the **next** cold start. So to
+confirm an update applied: **kill the app and relaunch twice** — first relaunch
+downloads, second shows the change. Tell testers the same.
+
+## When you actually need a build instead
+
+If the decision above lands on "native change", an OTA won't reach the old
+binaries and you need a fresh binary that carries the new native code + a new
+fingerprint:
+
+- **iOS** → `subwave-app-ios-release` (EAS build → TestFlight)
+- **Android** → `subwave-app-android-release` (EAS build → internal link / Play)
+
+After that build is out, OTAs target the new fingerprint and the loop resumes.
+
+## Things that bite
+
+- **Wrong directory.** `eas` reads `eas.json` in `app/`. Always `cd "$APP"` first.
+- **Non-interactive needs `--environment` + `CI=1`** — not `--non-interactive`. See
+  the publish section.
+- **Native change snuck in.** If the diff touched deps / `patches/` / `plugins` /
+  native `app.json`, the fingerprint shifted: the OTA won't reach existing builds
+  and you've shipped a no-op to them. Build instead.
+- **`channel=None` builds never update.** Pre-OTA binaries are dead to `eas
+  update`; they need a reinstall.
+- **The two-relaunch apply** is expected, not a bug — it's the price of an instant,
+  non-blocking launch. Verify by killing + relaunching twice.
+
+## Quick reference
+
+| Want | Do (`cd "$APP"` first) |
+|---|---|
+| Is this OTA-able? | `git log -1 --stat` — only `app/src/**`? → OTA. deps/`patches`/native `app.json`? → build |
+| Push to testers | `CI=1 eas update --channel preview --environment preview --message "…"` |
+| Promote to production | `CI=1 eas update --channel production --environment production --message "…"` |
+| Who receives it? | `scripts/ota-delivery-check.sh <channel>`, match runtimes to the update |
+| See live updates | `eas update:list` / the EAS dashboard link in the publish output |
+| Need a native build | `subwave-app-ios-release` / `subwave-app-android-release` |
+| Confirm login | `eas whoami` (expect `pinku1`) |

--- a/.claude/skills/subwave-app-ota-update/scripts/ota-delivery-check.sh
+++ b/.claude/skills/subwave-app-ota-update/scripts/ota-delivery-check.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Which installed builds can an OTA on <channel> reach?
+#
+# A build receives an EAS Update only if BOTH match the published update:
+#   1. channel  — baked into the build at build time
+#   2. runtime version (fingerprint) — must equal the update's runtime
+#
+# This lists recent FINISHED builds with their channel + runtime so you can
+# eyeball which ones are on the target channel, then compare their runtime to
+# the runtime `eas update` printed when you published. Equal runtime + matching
+# channel => that build gets the update. channel=None / runtime=None builds are
+# pre-OTA and never receive updates.
+#
+# Usage: ota-delivery-check.sh [channel]   (default: production)
+set -euo pipefail
+
+CHANNEL="${1:-production}"
+APP="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)/app"
+cd "$APP"
+
+echo "Builds (FINISHED). A build gets an OTA on '$CHANNEL' only if channel='$CHANNEL' AND its"
+echo "runtime equals the runtime 'eas update' printed for that platform."
+echo
+
+eas build:list --limit 12 --non-interactive --json 2>/dev/null | python3 -c "
+import json, sys
+target = '$CHANNEL'
+builds = json.load(sys.stdin)
+for b in builds:
+    if b.get('status') != 'FINISHED':
+        continue
+    ch = b.get('channel')
+    rt = b.get('runtimeVersion')
+    plat = b.get('platform', '?')
+    ver = f\"v{b.get('appVersion')} ({b.get('appBuildVersion')})\"
+    if ch is None or rt is None:
+        mark = '   pre-OTA — never updates'
+    elif ch == target:
+        mark = f'   <- on {target}: gets OTA if runtime matches'
+    else:
+        mark = ''
+    print(f\"  {plat:8} channel={str(ch):12} runtime={str(rt):42} {ver}{mark}\")
+"
+
+echo
+echo "Compare the runtime above to what 'eas update --channel $CHANNEL' printed."
+echo "Builds marked 'pre-OTA' need a fresh install from TestFlight / the Android link."

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 .env.*.local
 
 # Node
-node_modules/
+# No trailing slash: also catches a stray file/symlink named node_modules
+# (a broken macOS-local symlink slipped past the dir-only pattern in #325).
+node_modules
 
 # Next.js
 .next/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It's *radio*, not a playlist. No per-listener shuffle, no skip button, no
 
 - **Project site** — [getsubwave.com](https://www.getsubwave.com/)
 - **Demo player** — [getsubwave.com/listen](https://www.getsubwave.com/listen)
-- **Mobile apps (beta)** — native iOS & Android players — [join the beta](https://github.com/perminder-klair/subwave/discussions/289)
+- **Mobile apps** — native players — [Android on Google Play](https://play.google.com/store/apps/details?id=com.getsubwave.app), [iOS via TestFlight](https://testflight.apple.com/join/Xrx5TUmb)
 - **Setup walkthrough** — [getsubwave.com/setup](https://www.getsubwave.com/setup)
 - **Operator manual** — [getsubwave.com/manual](https://www.getsubwave.com/manual)
 - **Community** — [join the Discord](https://discord.gg/vjVbVKnMBa)
@@ -47,7 +47,7 @@ It's *radio*, not a playlist. No per-listener shuffle, no skip button, no
 - **Five TTS engines.** Piper and Kokoro in-process for fast local speech, plus an optional `tts-heavy` sidecar (`docker compose --profile tts-heavy up -d`) that adds Chatterbox (zero-shot voice cloning) and PocketTTS (6× real-time, EN/FR/DE/IT/ES/PT). Cloud (OpenAI / ElevenLabs) is also available. Pick a different engine per kind of speech.
 - **Multiple DJ personas.** Up to 10 souls in rotation, each with its own voice and writing style.
 - **Dual-codec broadcast.** MP3 128 kbps for Sonos, hardware radios, and cars; Ogg-Opus 96 kbps for modern browsers. The web player picks automatically.
-- **Native apps, PWA, and TUI.** Native iOS and Android players (in beta — background audio, lock-screen / CarPlay / Android Auto controls, multi-station), an installable PWA on phone and desktop, and a TUI for the command line.
+- **Native apps, PWA, and TUI.** Native iOS (TestFlight beta) and Android (on Google Play) players — background audio, lock-screen / CarPlay / Android Auto controls, multi-station — an installable PWA on phone and desktop, and a TUI for the command line.
 - **Scheduled shows.** A 24×7 grid; each slot has its own persona, mood, and skills.
 - **Pluggable skills.** The DJ's between-track segments — weather, news, traffic, and your own — are skills. The built-ins are scaffolded as editable files under `state/skills/<kind>/` on first boot, so you can rewrite a brief or change the news feed (BBC → your own RSS) right from the admin console — no code, no redeploy. Add your own by dropping a `SKILL.md` (plus optional data-fetching code) into `state/skills/`, hitting Rescan, and enabling it. See [`docs/custom-skills.md`](docs/custom-skills.md).
 - **Mood-aware rotation.** Time of day, weather, and festival days bias what gets played and how the DJ talks.

--- a/app/src/player/CenterStage.tsx
+++ b/app/src/player/CenterStage.tsx
@@ -78,8 +78,8 @@ export default function CenterStage({
   return (
     <View className="flex-1 justify-center px-5">
       {coverSrc ? (
-        <View className="mb-8" style={{ alignItems: 'flex-start' }}>
-          <CoverArt uri={coverSrc} live={live} burst={burst} size={160} onPress={onOpenTimeline} />
+        <View style={{ alignItems: 'flex-start', marginBottom: 14 }}>
+          <CoverArt uri={coverSrc} live={live} burst={burst} size={120} onPress={onOpenTimeline} />
         </View>
       ) : null}
 
@@ -92,7 +92,7 @@ export default function CenterStage({
 
       {has ? (
         <>
-          <Text className="font-display text-ink" style={{ fontSize: 34, lineHeight: 38 }}>
+          <Text className="font-display text-ink" style={{ fontSize: 26, lineHeight: 30 }}>
             {nowPlaying?.title}
           </Text>
           <Text className="font-body-medium mt-3" style={{ fontSize: 15, color: colors.muted }}>
@@ -102,7 +102,7 @@ export default function CenterStage({
           </Text>
         </>
       ) : (
-        <Text className="font-display text-muted" style={{ fontSize: 32, lineHeight: 36 }}>
+        <Text className="font-display text-muted" style={{ fontSize: 26, lineHeight: 30 }}>
           scanning the dial_
         </Text>
       )}

--- a/app/src/player/PlayerScreen.tsx
+++ b/app/src/player/PlayerScreen.tsx
@@ -4,7 +4,9 @@
 // FreqBand tuner above a horizontal pager whose five "stations" are
 // Shows / Timeline / LIVE / Booth / Request, with LIVE dead-centre as home.
 // Swipe (or tap a band stop) to tune across sections; the needle tracks the
-// scroll. Themes open in a bottom sheet from the palette icon, off-band.
+// scroll. The TransportBar is docked below the pager so the player stays
+// visible on every band stop, bottom-nav style. Themes open in a bottom sheet
+// from the palette icon, off-band.
 //
 // Render-path notes: the pager's scroll drives the FreqBand needle through a
 // native-driver Animated.Value (no per-frame React state), and the four
@@ -310,19 +312,6 @@ export default function PlayerScreen() {
                     onOpenTimeline={openTimeline}
                   />
                   <Waveform tunedIn={tunedIn} progress={progress} visible={active === HOME_INDEX} />
-                  <TransportBar
-                    tunedIn={tunedIn}
-                    status={status}
-                    onTune={tune}
-                    offline={offline}
-                    volume={volume}
-                    setVolume={setVolume}
-                    muted={muted}
-                    onToggleMute={toggleMute}
-                    latencyMs={signal.latencyMs}
-                    signalQuality={signal.quality}
-                    listeners={listenerCount}
-                  />
                 </View>
               </View>
               <View style={{ width: pagerW }}>
@@ -336,6 +325,22 @@ export default function PlayerScreen() {
             </Animated.ScrollView>
           ) : null}
         </View>
+
+        {/* Persistent transport — lives below the pager so the player stays
+            docked at the foot of every band stop, like a bottom nav. */}
+        <TransportBar
+          tunedIn={tunedIn}
+          status={status}
+          onTune={tune}
+          offline={offline}
+          volume={volume}
+          setVolume={setVolume}
+          muted={muted}
+          onToggleMute={toggleMute}
+          latencyMs={signal.latencyMs}
+          signalQuality={signal.quality}
+          listeners={listenerCount}
+        />
       </SafeAreaView>
 
       <Sheet open={themesOpen} onClose={() => setThemesOpen(false)} title="Theme">

--- a/app/src/player/TransportBar.tsx
+++ b/app/src/player/TransportBar.tsx
@@ -2,7 +2,7 @@
 // three-cell box — Power (hollow ring that lights accent on air), the analog
 // Signal meter (label + listener/latency read, a 26-tick scale with a vermilion
 // grip, and a 0–250 latency ruler), and Volume (rotary knob + dot-grille mute).
-// Sits at the foot of the LIVE page in the FM-dial pager.
+// Docked below the FM-dial pager, so it stays at the foot of every band stop.
 
 import * as Haptics from 'expo-haptics';
 import { ActivityIndicator, Pressable, Text, View } from 'react-native';

--- a/controller/node_modules
+++ b/controller/node_modules
@@ -1,1 +1,0 @@
-/Users/klair/Projects/subwave/web/controller/node_modules

--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -28,6 +28,7 @@ into the query string) to a temp file, then only the first ANALYZE_SECONDS are
 decoded — enough for tempo/key and the intro estimate, a fraction of the bytes.
 """
 
+import importlib.util
 import json
 import os
 import sys
@@ -354,8 +355,18 @@ def main():
         log("ANALYZE_AUDIO_EMBEDDING on — loading CLAP model...")
         get_embedder()
 
+    # Tell the controller whether this worker can actually emit "sounds-like"
+    # audio embeddings, so the admin UI can warn *before* a fruitless run rather
+    # than after the fingerprint bar stays at 0. Capable = the CLAP libs are
+    # present (image built WITH_CLAP=1) and we haven't already hit a hard load
+    # failure. find_spec avoids importing torch when embeddings are off.
+    audio_capable = (not _embed_failed) and (
+        _embedder is not None
+        or all(importlib.util.find_spec(m) is not None for m in ("torch", "transformers"))
+    )
+
     log("ready")
-    emit({"id": None, "ready": True})
+    emit({"id": None, "ready": True, "audio_embedding_capable": audio_capable})
 
     for line in sys.stdin:
         line = line.strip()

--- a/controller/src/broadcast/tagger.ts
+++ b/controller/src/broadcast/tagger.ts
@@ -4,6 +4,7 @@
 // (/tag-library) and the ones that report on it (/settings).
 import { spawn, ChildProcess } from 'node:child_process';
 import { queue } from './queue.js';
+import { PROGRESS_PREFIX, type TaggerProgress } from '../music/tagger-progress.js';
 
 type TaggerState = {
   running: boolean;
@@ -14,9 +15,16 @@ type TaggerState = {
   // acoustic/audio-embedding pass via analyze-library). Single-flight across
   // both — they contend on the same library DB and analysis backend.
   mode: 'tag' | 'analyze' | null;
+  // Latest structured progress sentinel from the child ([progress] lines on
+  // stdout — see music/tagger-progress.ts). Left in place after exit so the
+  // last payload doubles as a what-just-finished summary; the UI gates its
+  // display on `running`.
+  progress: TaggerProgress | null;
 };
 
-export const tagger: TaggerState = { running: false, startedAt: null, pid: null, lastLog: [], mode: null };
+export const tagger: TaggerState = {
+  running: false, startedAt: null, pid: null, lastLog: [], mode: null, progress: null,
+};
 
 // Live handle for stopTagger() — cleared on the exit handler.
 let activeChild: ChildProcess | null = null;
@@ -87,14 +95,33 @@ function spawnChild(mode: 'tag' | 'analyze', args: string[], detail: string) {
   tagger.pid = child.pid ?? null;
   tagger.lastLog = [];
   tagger.mode = mode;
+  tagger.progress = null;
 
-  const capture = (chunk: Buffer) => {
-    const lines = chunk.toString().split('\n').filter((l: string) => l.trim());
-    tagger.lastLog.push(...lines);
-    if (tagger.lastLog.length > 100) tagger.lastLog = tagger.lastLog.slice(-100);
+  // Per-stream line buffering: a `data` chunk can end mid-line, so each stream
+  // keeps its own remainder. [progress] sentinel lines are parsed into
+  // tagger.progress and kept out of lastLog.
+  const makeCapture = () => {
+    let remainder = '';
+    return (chunk: Buffer) => {
+      remainder += chunk.toString();
+      const lines = remainder.split('\n');
+      remainder = lines.pop() ?? '';
+      for (const raw of lines) {
+        const line = raw.trim();
+        if (!line) continue;
+        if (line.startsWith(PROGRESS_PREFIX)) {
+          try {
+            tagger.progress = JSON.parse(line.slice(PROGRESS_PREFIX.length)) as TaggerProgress;
+          } catch { /* malformed sentinel — drop */ }
+          continue;
+        }
+        tagger.lastLog.push(line);
+      }
+      if (tagger.lastLog.length > 100) tagger.lastLog = tagger.lastLog.slice(-100);
+    };
   };
-  child.stdout.on('data', capture);
-  child.stderr.on('data', capture);
+  child.stdout.on('data', makeCapture());
+  child.stderr.on('data', makeCapture());
   child.on('exit', (code, signal) => {
     tagger.running = false;
     if (activeChild === child) activeChild = null;

--- a/controller/src/music/analyze-library.ts
+++ b/controller/src/music/analyze-library.ts
@@ -31,6 +31,7 @@ import { loadSecretsIntoEnv } from '../setup/secrets.js';
 import { loadSetupConfig } from '../setup/config.js';
 import { runAnalysisPass } from './analyze.js';
 import * as analyzer from './analyzer.js';
+import { reportProgress } from './tagger-progress.js';
 
 function parseIntFlag(args: string[], name: string): number | undefined {
   const idx = args.indexOf(name);
@@ -93,6 +94,7 @@ async function main() {
   }
 
   if (shouldWalk) {
+    reportProgress({ phase: 'walk', label: 'Scanning Navidrome library', done: 0 });
     let walked = 0;
     const liveIds = new Set<string>();
     for await (const song of subsonic.iterateAllSongs()) {
@@ -106,7 +108,10 @@ async function main() {
       });
       liveIds.add(song.id);
       walked += 1;
-      if (walked % 500 === 0) console.log(`[analyze] walked ${walked} tracks`);
+      if (walked % 500 === 0) {
+        console.log(`[analyze] walked ${walked} tracks`);
+        reportProgress({ phase: 'walk', label: 'Scanning Navidrome library', done: walked });
+      }
     }
     console.log(`[analyze] walked ${walked} total tracks`);
 

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -14,6 +14,7 @@ import * as db from './library-db.js';
 import * as analyzer from './analyzer.js';
 import * as settings from '../settings.js';
 import { config } from '../config.js';
+import { reportProgress } from './tagger-progress.js';
 
 export interface AnalyzeOptions {
   limit?: number;        // cap tracks this run (default: all that need it)
@@ -90,6 +91,7 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
     return { available: true, backend, analyzed: 0, failed: 0, scope: 0, audioEmbedded: 0 };
   }
   console.log(`[analyze] ${ids.length} tracks to analyse`);
+  reportProgress({ phase: 'analyze', label: 'Analysing audio', done: 0, total: ids.length });
 
   let analyzed = 0;
   let failed = 0;
@@ -164,6 +166,13 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
     }
     if ((i + 1) % 25 === 0 || i + 1 === ids.length) {
       console.log(`[analyze] ${i + 1}/${ids.length} (ok=${analyzed} fail=${failed})`);
+      reportProgress({
+        phase: 'analyze',
+        label: 'Analysing audio',
+        done: i + 1,
+        total: ids.length,
+        errors: failed || undefined,
+      });
     }
   }
 

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -13,7 +13,6 @@
 
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { existsSync, mkdirSync, createWriteStream } from 'node:fs';
-import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { config } from '../config.js';
 import * as subsonic from './subsonic.js';
@@ -160,6 +159,10 @@ async function analyzeViaLocalPath(path: string, opts: AnalyzeRequestOpts = {}):
 // Sidecar backend
 // ---------------------------------------------------------------------------
 
+// Last sidecar /health read of the CLAP capability. null = unknown (not yet
+// probed, or the field is absent on an old sidecar); true/false once known.
+let _sidecarAudioCapable: boolean | null = null;
+
 async function sidecarReachable(): Promise<boolean> {
   const url = config.ttsHeavy.url;
   if (!url) return false;
@@ -169,8 +172,12 @@ async function sidecarReachable(): Promise<boolean> {
     const res = await fetch(`${url}/health`, { signal: ac.signal });
     clearTimeout(t);
     if (!res.ok) return false;
-    const body = (await res.json()) as { ok?: boolean; engines?: string[] };
-    return !!body.ok && Array.isArray(body.engines) && body.engines.includes('analyze');
+    const body = (await res.json()) as { ok?: boolean; engines?: string[]; analyze_audio_capable?: boolean | null };
+    const reachable = !!body.ok && Array.isArray(body.engines) && body.engines.includes('analyze');
+    if (reachable) {
+      _sidecarAudioCapable = typeof body.analyze_audio_capable === 'boolean' ? body.analyze_audio_capable : null;
+    }
+    return reachable;
   } catch {
     return false;
   }
@@ -235,6 +242,23 @@ export function backendLabel(): string {
   return _backend || 'none';
 }
 
+// Whether the active backend can emit CLAP "sounds-like" audio embeddings right
+// now. null = unknown (local backend — we don't probe its venv; or sidecar not
+// yet reached); false = sidecar reachable but built without the CLAP stack
+// (WITH_CLAP=0) — the signal the admin UI turns into a "rebuild the sidecar"
+// warning. Only meaningful for the sidecar backend.
+export function audioEmbeddingAvailable(): boolean | null {
+  return _backend === 'sidecar' ? _sidecarAudioCapable : null;
+}
+
+// Re-read sidecar /health so capability reflects a sidecar rebuilt under a
+// long-lived controller (resolveBackend caches the backend *choice* forever,
+// but CLAP support flips when the operator rebuilds with WITH_CLAP=1). Cheap;
+// driven on the coverage staleness cadence.
+export async function refreshCapabilities(): Promise<void> {
+  if ((await resolveBackend()) === 'sidecar') await sidecarReachable();
+}
+
 // Analyse one track by id. Throws on failure — the caller (analyze pass) logs
 // and moves on, leaving the row NULL so it's retried on the next run. This is
 // the URL path: the backend fetches the audio itself. Kept as the fallback
@@ -266,25 +290,22 @@ export async function downloadCapped(songId: string): Promise<string> {
     if (!res.ok || !res.body) {
       throw new Error(`download ${res.status}: ${await res.text().catch(() => '')}`);
     }
-    // Stream the body to disk, aborting once we've pulled the byte cap — a few
-    // MB covers the analysis window for any common codec.
+    // Stream the body to disk, stopping once we've pulled the byte cap — a few
+    // MB covers the analysis window for any common codec. A capped async
+    // generator feeds pipeline (which handles backpressure and tears the source
+    // down when we return early). The previous approach — a `data` listener
+    // that called src.destroy() alongside pipeline — deadlocked: attaching the
+    // listener flips the web-backed Readable into flowing mode and races the
+    // pipe, so pipeline() never resolves and every download hangs.
     let read = 0;
-    const out = createWriteStream(dest);
-    const src = Readable.fromWeb(res.body as any);
-    src.on('data', (chunk: Buffer) => {
-      read += chunk.length;
-      if (read >= ANALYZE_MAX_BYTES) {
-        src.destroy();
-        ac.abort();
+    async function* capped() {
+      for await (const chunk of res.body as any) {
+        read += chunk.length;
+        yield chunk;
+        if (read >= ANALYZE_MAX_BYTES) return; // enough audio for the window
       }
-    });
-    try {
-      await pipeline(src, out);
-    } catch (err: any) {
-      // A deliberate cap-abort closes the stream mid-flight; that's not a
-      // failure as long as we wrote some bytes.
-      if (read === 0) throw err;
     }
+    await pipeline(capped(), createWriteStream(dest));
     if (read === 0) throw new Error('downloaded empty audio');
     return dest;
   } finally {

--- a/controller/src/music/library-coverage.ts
+++ b/controller/src/music/library-coverage.ts
@@ -28,7 +28,9 @@ const cache: CoverageCache = { total: 0, scannedAt: null, scanning: false };
 let inflight: Promise<void> | null = null;
 
 // Last known acoustic-analysis backend state. `null` until first probed.
-let analysisAvail: { available: boolean; backend: string; checkedAt: number } | null = null;
+// `audioCapable` mirrors analyzer.audioEmbeddingAvailable() — whether the
+// backend can emit CLAP "sounds-like" embeddings (null = unknown).
+let analysisAvail: { available: boolean; backend: string; audioCapable: boolean | null; checkedAt: number } | null = null;
 let analysisProbeInflight: Promise<void> | null = null;
 
 function refreshAnalysisAvail() {
@@ -36,9 +38,15 @@ function refreshAnalysisAvail() {
   analysisProbeInflight = (async () => {
     try {
       const available = await analyzer.isAvailable();
-      analysisAvail = { available, backend: analyzer.backendLabel(), checkedAt: Date.now() };
+      await analyzer.refreshCapabilities();
+      analysisAvail = {
+        available,
+        backend: analyzer.backendLabel(),
+        audioCapable: analyzer.audioEmbeddingAvailable(),
+        checkedAt: Date.now(),
+      };
     } catch {
-      analysisAvail = { available: false, backend: 'none', checkedAt: Date.now() };
+      analysisAvail = { available: false, backend: 'none', audioCapable: null, checkedAt: Date.now() };
     } finally {
       analysisProbeInflight = null;
     }
@@ -113,5 +121,9 @@ export async function get() {
     // the UI surfaces this rather than showing a misleading 0%.
     analysisAvailable: analysisAvail ? analysisAvail.available : null,
     analysisBackend: analysisAvail ? analysisAvail.backend : null,
+    // Whether the backend can emit CLAP "sounds-like" embeddings. false here
+    // with sounds-like enabled means the sidecar was built without CLAP — the
+    // UI turns this into a "rebuild with WITH_CLAP=1" warning. null = unknown.
+    audioAnalysisAvailable: analysisAvail ? analysisAvail.audioCapable : null,
   };
 }

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -35,6 +35,7 @@ import { activeModelLabel, primaryLeg, fallbackLeg, probeLegReachable } from '..
 import { isUnreachable } from '../llm/sdk.js';
 import { tagBatch, tagOne, TAGGER_BATCH_SYSTEM, type TagResult } from './tagger-core.js';
 import { runAnalysisPass } from './analyze.js';
+import { reportProgress } from './tagger-progress.js';
 
 // ---------------------------------------------------------------------------
 // CLI arg parsing
@@ -188,6 +189,7 @@ async function main() {
   // Cheap; ensures every Navidrome song is in the tracks table so subsequent
   // phases can operate purely off SQL.
   console.log('[tag] walking Navidrome library...');
+  reportProgress({ phase: 'walk', label: 'Scanning Navidrome library', done: 0 });
   let walked = 0;
   const liveIds = new Set<string>();
   for await (const song of subsonic.iterateAllSongs()) {
@@ -201,7 +203,10 @@ async function main() {
     });
     liveIds.add(song.id);
     walked += 1;
-    if (walked % 500 === 0) console.log(`[tag] walked ${walked} tracks`);
+    if (walked % 500 === 0) {
+      console.log(`[tag] walked ${walked} tracks`);
+      reportProgress({ phase: 'walk', label: 'Scanning Navidrome library', done: walked });
+    }
   }
   console.log(`[tag] walked ${walked} total tracks`);
 
@@ -277,7 +282,9 @@ async function main() {
   let llmCalls = 0;
   let llmTagged = 0;
   if (seedSelection.seeds.length > 0) {
-    const tagged = await llmTagInBatches(seedSelection.seeds, flags.batchSize, promptHash, 'llm', tagConsumers);
+    const tagged = await llmTagInBatches(
+      seedSelection.seeds, flags.batchSize, promptHash, 'llm', tagConsumers, { phase: 'seed' },
+    );
     llmCalls += tagged.callCount;
     llmTagged += tagged.tagged;
     mergeByLeg(tagged.byLeg);
@@ -297,8 +304,16 @@ async function main() {
   // settings.embedding above.
   let propagated = 0;
   let uncertain: string[] = [];
+  let scanned = 0;
 
+  reportProgress({ phase: 'propagate', label: 'Propagating tags to neighbours', done: 0, total: targetUntagged.length });
   for (const id of targetUntagged) {
+    scanned += 1;
+    // The loop is synchronous — emit sparsely so a 30k-track scan doesn't
+    // spam stdout.
+    if (scanned % 500 === 0) {
+      reportProgress({ phase: 'propagate', label: 'Propagating tags to neighbours', done: scanned, total: targetUntagged.length });
+    }
     if (db.hasTags(id)) continue;        // already seeded
     if (!db.hasVector(id)) continue;     // no embedding → can't propagate
     const neighbours = db.knnById(id, knnK);
@@ -330,6 +345,7 @@ async function main() {
     }
   }
   console.log(`[tag] phase-3 propagated ${propagated} tracks; ${uncertain.length} uncertain (in scope)`);
+  reportProgress({ phase: 'propagate', label: 'Propagating tags to neighbours', done: targetUntagged.length, total: targetUntagged.length });
 
   // ---- Phase 4: ACTIVE-LEARN --------------------------------------------
   for (let round = 1; round <= maxRounds; round++) {
@@ -341,6 +357,7 @@ async function main() {
       promptHash,
       'uncertain-llm',
       tagConsumers,
+      { phase: 'learn', round },
     );
     llmCalls += tagged.callCount;
     llmTagged += tagged.tagged;
@@ -420,6 +437,12 @@ function finish(startedAt: number, llmCalls: number, llmTagged: number, byLeg: R
   console.log(
     `\n[tag] done in ${elapsed.toFixed(0)}s. llm_calls=${llmCalls} llm_tagged=${llmTagged}`,
   );
+  reportProgress({
+    phase: 'done',
+    label: 'Finished',
+    done: llmTagged,
+    llm: Object.keys(byLeg).length ? { legs: byLeg } : undefined,
+  });
   const legs = Object.entries(byLeg);
   if (legs.length > 1) {
     console.log(`[tag] per-leg: ${legs.map(([m, n]) => `${m}=${n}`).join(' · ')}`);
@@ -440,6 +463,7 @@ async function phaseEnrich(ids: string[], reEnrich: boolean): Promise<void> {
     console.log('[tag] phase-0 skipped: both lastfmTags and lyrics disabled in settings.embedding.enrichment');
     return;
   }
+  reportProgress({ phase: 'enrich', label: 'Enriching metadata', done: 0, total: ids.length });
   const artistTagCache = new Map<string, string[]>();
   let enrichedTracks = 0;
   let enrichedLyrics = 0;
@@ -489,6 +513,7 @@ async function phaseEnrich(ids: string[], reEnrich: boolean): Promise<void> {
       console.log(
         `[tag] enriched ${enrichedTracks}/${ids.length} (lastfm: ${enrichedTags}, lyrics: ${enrichedLyrics})`,
       );
+      reportProgress({ phase: 'enrich', label: 'Enriching metadata', done: enrichedTracks, total: ids.length });
     }
   }
   console.log(
@@ -519,6 +544,7 @@ async function phaseEmbed(targetIds: string[], batchSize: number): Promise<void>
     return;
   }
   console.log(`[tag] phase-1 embedding ${unique.length} tracks (batch=${batchSize})`);
+  reportProgress({ phase: 'embed', label: 'Embedding tracks', done: 0, total: unique.length });
 
   const embedBatchSize = Math.max(8, Math.min(64, batchSize * 2));
   for (let i = 0; i < unique.length; i += embedBatchSize) {
@@ -542,6 +568,7 @@ async function phaseEmbed(targetIds: string[], batchSize: number): Promise<void>
     }
     if ((i + batch.length) % 500 === 0 || i + batch.length === unique.length) {
       console.log(`[tag] embedded ${i + batch.length}/${unique.length}`);
+      reportProgress({ phase: 'embed', label: 'Embedding tracks', done: i + batch.length, total: unique.length });
     }
   }
 }
@@ -563,7 +590,17 @@ interface TagState {
   tagged: number;
   callCount: number;
   processed: number;
+  // Tracks that came back null from the LLM (batch entry dropped / per-track
+  // salvage failed) — surfaced in the progress channel.
+  errors: number;
   byLeg: Record<string, number>;
+}
+
+// Which pipeline phase a runConsumer() call is tagging for — only used to
+// stamp the progress channel ('seed' = phase 2, 'learn' = phase 4 rounds).
+interface TagPhaseInfo {
+  phase: 'seed' | 'learn';
+  round?: number;
 }
 
 // Tag one batch with one consumer's leg. Returns the count actually tagged.
@@ -619,7 +656,10 @@ async function processBatch(
   let tagged = 0;
   for (let j = 0; j < songs.length; j++) {
     const result = results[j];
-    if (!result) continue;
+    if (!result) {
+      state.errors += 1;
+      continue;
+    }
     const { moods, energy } = result;
     db.upsertTrackTags(songs[j].id, {
       moods,
@@ -645,6 +685,7 @@ async function runConsumer(
   source: db.TagSource,
   total: number,
   state: TagState,
+  phaseInfo: TagPhaseInfo,
   onDrop: (() => number) | null,
 ): Promise<void> {
   for (;;) {
@@ -667,6 +708,15 @@ async function runConsumer(
     if (state.processed % 4 === 0) {
       console.log(`[tag] LLM-tagged ${state.tagged}/${total}`);
     }
+    reportProgress({
+      phase: phaseInfo.phase,
+      label: 'Tagging with LLM',
+      done: state.tagged,
+      total,
+      round: phaseInfo.round,
+      errors: state.errors || undefined,
+      llm: { legs: state.byLeg },
+    });
   }
 }
 
@@ -678,21 +728,29 @@ async function llmTagInBatches(
   promptHash: string,
   source: db.TagSource,
   consumers: TagConsumer[],
+  phaseInfo: TagPhaseInfo,
 ): Promise<{ tagged: number; callCount: number; byLeg: Record<string, number> }> {
   const batches: string[][] = [];
   for (let i = 0; i < ids.length; i += batchSize) batches.push(ids.slice(i, i + batchSize));
 
-  const state: TagState = { tagged: 0, callCount: 0, processed: 0, byLeg: {} };
+  const state: TagState = { tagged: 0, callCount: 0, processed: 0, errors: 0, byLeg: {} };
+  reportProgress({
+    phase: phaseInfo.phase,
+    label: 'Tagging with LLM',
+    done: 0,
+    total: ids.length,
+    round: phaseInfo.round,
+  });
 
   if (consumers.length <= 1) {
     // Single consumer — no requeue/drop; the unpinned call already fails over
     // internally, so an error means the batch is genuinely unworkable this run.
-    await runConsumer(batches, consumers[0], promptHash, source, ids.length, state, null);
+    await runConsumer(batches, consumers[0], promptHash, source, ids.length, state, phaseInfo, null);
   } else {
     let alive = consumers.length;
     await Promise.all(
       consumers.map(c =>
-        runConsumer(batches, c, promptHash, source, ids.length, state, () => --alive)),
+        runConsumer(batches, c, promptHash, source, ids.length, state, phaseInfo, () => --alive)),
     );
     if (batches.length > 0) {
       const abandoned = batches.reduce((n, b) => n + b.length, 0);

--- a/controller/src/music/tagger-progress.ts
+++ b/controller/src/music/tagger-progress.ts
@@ -1,0 +1,38 @@
+// Structured progress channel between the tagger/analyzer child processes and
+// the controller. The children print one sentinel line per update on stdout;
+// broadcast/tagger.ts parses it into `tagger.progress` (and keeps it out of
+// lastLog). Dependency-free on purpose — imported by both CLI scripts and the
+// server.
+export const PROGRESS_PREFIX = '[progress] ';
+
+export type TaggerPhase =
+  | 'walk'
+  | 'enrich'
+  | 'embed'
+  | 'seed'
+  | 'propagate'
+  | 'learn'
+  | 'analyze'
+  | 'done';
+
+export interface TaggerProgress {
+  phase: TaggerPhase;
+  // Human-friendly line authored here (single source of truth) so the UI
+  // needs no phase→label map.
+  label: string;
+  done?: number;
+  // Absent total → indeterminate (e.g. the Navidrome walk, which doesn't
+  // pre-report a count).
+  total?: number;
+  // Active-learning round (phase 'learn' only).
+  round?: number;
+  // Cumulative failures within the current phase.
+  errors?: number;
+  // Per-leg tagged counts when dual-LLM mode is draining the batch queue.
+  llm?: { legs: Record<string, number> };
+  updatedAt: string;
+}
+
+export function reportProgress(p: Omit<TaggerProgress, 'updatedAt'>): void {
+  console.log(PROGRESS_PREFIX + JSON.stringify({ ...p, updatedAt: new Date().toISOString() }));
+}

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -330,6 +330,15 @@ async def health():
             pocket_worker.ready_meta.get("voice_cloning") if pocket_worker.ready else None
         ),
         "analyze_loaded": analyzer_worker.ready,
+        # Whether the analyze worker can emit CLAP "sounds-like" audio
+        # embeddings — true only when the image was built WITH_CLAP=1 (the torch
+        # + transformers stack is present). The controller surfaces this so the
+        # admin UI warns to rebuild the sidecar *before* a fruitless run rather
+        # than after the fingerprint bar stays at 0. None until the worker is
+        # ready and has reported its capability.
+        "analyze_audio_capable": (
+            analyzer_worker.ready_meta.get("audio_embedding_capable") if analyzer_worker.ready else None
+        ),
     }
 
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2903,6 +2903,12 @@ body::after {
     background: var(--accent);
     transition: width 0.5s cubic-bezier(0.2, 0.7, 0.2, 1);
 }
+/* indeterminate run progress (e.g. library walk — no total known yet) */
+.admin-root .lib-bar.indet > span {
+    width: 30% !important;
+    animation: lib-bar-slide 1.4s ease-in-out infinite alternate;
+}
+@keyframes lib-bar-slide { 0% { margin-left: 0; } 100% { margin-left: 70%; } }
 .admin-root .lib-minibar {
     flex: 1; min-width: 120px; height: 5px;
     background: var(--field);
@@ -3058,6 +3064,7 @@ body::after {
 }
 @media (prefers-reduced-motion: reduce) {
     .admin-root .lib-livedot::after,
+    .admin-root .lib-bar.indet > span,
     .admin-root .lib-row.flash { animation: none; }
 }
 

--- a/web/app/manual/faq/page.tsx
+++ b/web/app/manual/faq/page.tsx
@@ -15,27 +15,27 @@ export const metadata = pageMeta({
 const FAQ = [
   {
     q: 'What happens when no one is listening?',
-    a: 'By default nothing changes — the station broadcasts whether anyone is tuned in or not. An optional "Pause when empty" setting stops the AI work (track-picking, spoken links, station IDs) the moment the listener count hits zero, while a fallback playlist keeps music flowing, then wakes the DJ the instant someone tunes in. It exists to save tokens when no one is there to hear the DJ.',
+    a: 'By default nothing changes: the station broadcasts whether anyone is tuned in or not. An optional "Pause when empty" setting stops the AI work (track-picking, spoken links, station IDs) the moment the listener count hits zero, while a fallback playlist keeps music flowing, then wakes the DJ the instant someone tunes in. It exists to save tokens when no one is there to hear the DJ.',
   },
   {
     q: 'Does it work with a small model?',
-    a: 'Yes. The AI DJ does not need a frontier model — a modest local one is plenty. A 9B-class model such as Qwen3.5 9B comfortably picks tracks and writes the DJ’s lines when run on lean settings: reasoning off, the simpler track-picker, and concise scripts.',
+    a: 'Yes. The AI DJ does not need a frontier model; a modest local one is plenty. A 9B-class model such as Qwen3.5 9B comfortably picks tracks and writes the DJ’s lines when run on lean settings: reasoning off, the simpler track-picker, and concise scripts.',
   },
   {
     q: 'What is mood tagging?',
-    a: 'Every track can carry a mood — a label like calm, energetic or reflective. The station tags the library in the background and the DJ leans on those tags to pick music that fits the time of day, the weather, and the show that is on. Untagged tracks still play; they just are not matched by feel.',
+    a: 'Every track can carry a mood: a label like calm, energetic or reflective. The station tags the library in the background and the DJ leans on those tags to pick music that fits the time of day, the weather, and the show that is on. Untagged tracks still play; they just are not matched by feel.',
   },
   {
     q: 'What are the "deploy" and "control" SUB/WAVE skills?',
-    a: 'Two helper skills used through Claude Code. subwave-deploy handles installing and updating — first-time setup or pulling the latest code and rebuilding only what changed. subwave-control is lighter: it just starts or stops the station in development or production mode, with no builds.',
+    a: 'Two helper skills used through Claude Code. subwave-deploy handles installing and updating: first-time setup or pulling the latest code and rebuilding only what changed. subwave-control is lighter: it just starts or stops the station in development or production mode, with no builds.',
   },
   {
     q: 'What are the candidate pool and the agentic picker?',
-    a: 'Two ways the DJ chooses the next song. The candidate pool gathers a shortlist from your library — similar songs and artists, mood matches, recently-added and frequently-played albums — caps it, and asks the model to pick one. The agentic picker is a small reasoning loop with session memory and tools to search the library itself, so its choices stay coherent across a run. It is on by default and falls back to the candidate pool if it fails or runs slow.',
+    a: 'Two ways the DJ chooses the next song. The candidate pool gathers a shortlist from your library (similar songs and artists, mood matches, recently-added and frequently-played albums), caps it, and asks the model to pick one. The agentic picker is a small reasoning loop with session memory and tools to search the library itself, so its choices stay coherent across a run. It is on by default and falls back to the candidate pool if it fails or runs slow.',
   },
   {
     q: 'Why is there a debug page?',
-    a: 'The admin console’s Debug page is a live snapshot of the station’s inner workings — recent AI calls and whether they succeeded, the audio mixer’s status, and the latest log lines. It is the first place to look when the stream stalls, the DJ goes quiet, or a voice sounds wrong. For behaviour over time there is also the subwave-log-analysis skill.',
+    a: 'The admin console’s Debug page is a live snapshot of the station’s inner workings: recent AI calls and whether they succeeded, the audio mixer’s status, and the latest log lines. It is the first place to look when the stream stalls, the DJ goes quiet, or a voice sounds wrong. For behaviour over time there is also the subwave-log-analysis skill.',
   },
 ];
 

--- a/web/app/stations/page.tsx
+++ b/web/app/stations/page.tsx
@@ -30,7 +30,7 @@ export default function StationsIndex() {
         <p className="bs-eyebrow">THE NETWORK</p>
         <h1>Stations.</h1>
         <p>
-          SUB/WAVE is self-hosted &mdash; anyone can run their own. Here&rsquo;s who&rsquo;s on
+          SUB/WAVE is self-hosted; anyone can run their own. Here&rsquo;s who&rsquo;s on
           the air around the world. Tune in, or add your own station with a pull request.
         </p>
       </header>
@@ -74,7 +74,7 @@ export default function StationsIndex() {
         </ul>
       ) : (
         <p className="bs-news-empty">
-          No stations on the directory yet. Be the first &mdash; add yours above.
+          No stations on the directory yet. Be the first to add yours above.
         </p>
       )}
     </article>

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -19,13 +19,11 @@
 // so the page renders correctly under every palette — no hardcoded hex.
 
 import type { ChangeEvent, FormEvent, ReactNode } from 'react';
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  Search, RotateCcw, Sparkles, Activity, Play, Square, ChevronDown, ChevronRight,
-  Terminal, RefreshCw, ListPlus, X, Pencil,
+  Search, RotateCcw, Sparkles, RefreshCw, ListPlus, X, Pencil,
 } from 'lucide-react';
 import { useAdminAuth, ADMIN_API_URL } from '../../lib/adminAuth';
-import { useDynamicStyle } from '../../hooks/useDynamicStyle';
 import { notify, errorMessage } from '../../lib/notify';
 import { Input } from '../ui/input';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group';
@@ -34,8 +32,9 @@ import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
 } from '../ui/select';
 import { Card, Btn, Eyebrow, Pill, Seg } from './ui';
-import { V3AlertDialog } from '../ui/alert-dialog';
 import { cn } from '../../lib/cn';
+import TaggingPanel, { num } from './LibraryTaggingPanel';
+import type { Coverage, TaggerState, LibraryStatsLite, Batch, RescanOpts } from './LibraryTaggingPanel';
 
 // ---------------------------------------------------------------------------
 // types
@@ -69,44 +68,8 @@ interface BrowseResponse {
 
 interface UntaggedResponse { rows: Track[]; nextCursor: string | null }
 
-interface Coverage {
-  tagged: number;
-  analysed: number;
-  // Tracks with a CLAP audio (sounds-like) embedding. Same analysis backend,
-  // gated on ANALYZE_AUDIO_EMBEDDING — 0 when that's off even if bpm/key runs.
-  audioEmbedded?: number;
-  total: number | null;
-  percent: number | null;
-  analysedPercent: number | null;
-  audioEmbeddedPercent?: number | null;
-  scannedAt: string | null;
-  scanning: boolean;
-  // null = still probing; false = no analysis backend (sidecar/librosa) running.
-  analysisAvailable?: boolean | null;
-  analysisBackend?: string | null;
-}
-
-interface TaggerState {
-  running?: boolean;
-  pid?: number;
-  startedAt?: string;
-  lastLog?: string[];
-  // 'tag' (tag-library) or 'analyze' (the acoustic/audio-embedding pass) —
-  // both run through the same single-flight child slot.
-  mode?: 'tag' | 'analyze' | null;
-}
-
-// libraryStats rides along on /settings — gives moods-in-use, last-tag time,
-// and withEmbedding (used to nudge a re-embed after a model swap) without an
-// extra request and regardless of which tab is active.
-interface LibraryStatsLite {
-  total: number;
-  byMood: Record<string, number>;
-  byEnergy: Record<string, number>;
-  byGenre: Record<string, number>;
-  withEmbedding: number;
-  updatedAt: string | null;
-}
+// Coverage / TaggerState / LibraryStatsLite / Batch / RescanOpts live in
+// LibraryTaggingPanel.tsx alongside the panel that renders them.
 
 interface SettingsResponse {
   tagger?: TaggerState;
@@ -118,14 +81,6 @@ interface SettingsResponse {
 type Tab = 'recent' | 'browse' | 'search' | 'untagged';
 type Sort = 'artist' | 'title' | 'year' | 'taggedAt';
 type Energy = 'any' | 'low' | 'medium' | 'high';
-type Batch = '100' | '500' | 'all';
-
-type RescanOpts = {
-  reseed?: boolean;
-  reEnrich?: boolean;
-  reAnalyze?: boolean;
-  upgrade?: boolean;
-};
 
 const PAGE_SIZE = 50;
 
@@ -163,10 +118,6 @@ function Thumb({ track }: { track: Track }) {
   );
 }
 
-function num(n: number | null | undefined): string {
-  return n != null ? n.toLocaleString('en-GB') : '—';
-}
-
 // ---------------------------------------------------------------------------
 // panel
 // ---------------------------------------------------------------------------
@@ -193,10 +144,6 @@ export default function LibraryPanel() {
   // Mood vocab, lifted out of the browse response so the editor has it on any
   // tab (browse is the only call that returns it; lazily fetched otherwise).
   const [vocab, setVocab] = useState<string[]>([]);
-
-  // live-run progress baseline (best-effort: coverage delta vs. a captured
-  // target — the backend has no per-run counter). Set when WE start a run.
-  const [runInfo, setRunInfo] = useState<{ baseline: number; target: number | null } | null>(null);
 
   // browse state
   const [moods, setMoods] = useState<string[]>([]);
@@ -272,11 +219,6 @@ export default function LibraryPanel() {
     const id = setInterval(loadCoverage, 3_000);
     return () => clearInterval(id);
   }, [ready, tagger?.running, loadCoverage]);
-
-  // Clear the run baseline once the tagger stops.
-  useEffect(() => {
-    if (!tagger?.running) setRunInfo(null);
-  }, [tagger?.running]);
 
   // -----------------------------------------------------------------------
   // browse fetch — debounced on filter change
@@ -533,7 +475,6 @@ export default function LibraryPanel() {
     setTaggerBusy(true);
     try {
       const limit = batch === 'all' ? null : parseInt(batch, 10);
-      const target = batch === 'all' ? remaining : limit;
       const r = await adminFetch('/tag-library', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -543,7 +484,6 @@ export default function LibraryPanel() {
       if (!r.ok) throw new Error(j.error || `tagger start failed (${r.status})`);
       notify.ok('tagger started');
       setLogOpen(true);
-      setRunInfo({ baseline: coverage?.tagged ?? 0, target: target ?? null });
       await loadTagger();
     } catch (err) {
       notify.err(errorMessage(err));
@@ -679,7 +619,6 @@ export default function LibraryPanel() {
         coverage={coverage}
         libStats={libStats}
         tagger={tagger}
-        runInfo={runInfo}
         batch={batch}
         setBatch={setBatch}
         busy={taggerBusy}
@@ -826,306 +765,6 @@ export default function LibraryPanel() {
         </div>
       )}
     </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// tagging panel — merged coverage + tagger, framed for humans
-// ---------------------------------------------------------------------------
-interface TaggingPanelProps {
-  coverage: Coverage | null;
-  libStats: LibraryStatsLite | null;
-  tagger: TaggerState | null;
-  runInfo: { baseline: number; target: number | null } | null;
-  batch: Batch;
-  setBatch: (b: Batch) => void;
-  busy: boolean;
-  logOpen: boolean;
-  setLogOpen: (fn: (o: boolean) => boolean) => void;
-  onStart: () => void;
-  onStop: () => void;
-  onRescan: (opts: RescanOpts) => void;
-  // sounds-like (CLAP) controls — null until the first settings poll lands.
-  audioEnabled: boolean | null;
-  onToggleAudio: () => void;
-  onAnalyzeAudio: () => void;
-}
-
-function TaggingPanel(p: TaggingPanelProps) {
-  const [maintOpen, setMaintOpen] = useState(false);
-  const [confirmFull, setConfirmFull] = useState(false);
-  const [passes, setPasses] = useState<RescanOpts>({ reseed: false, reEnrich: false, reAnalyze: false, upgrade: false });
-  const logRef = useRef<HTMLPreElement>(null);
-  const moodFillRef = useRef<HTMLSpanElement>(null);
-  const acousticFillRef = useRef<HTMLSpanElement>(null);
-  const audioFillRef = useRef<HTMLSpanElement>(null);
-  const runFillRef = useRef<HTMLSpanElement>(null);
-
-  const tagged = p.coverage?.tagged ?? p.libStats?.total ?? null;
-  const total = p.coverage?.total ?? null;
-  const analysed = p.coverage?.analysed ?? null;
-  const audioEmbedded = p.coverage?.audioEmbedded ?? null;
-  const pct = p.coverage?.percent ?? null;
-  const apct = p.coverage?.analysedPercent ?? null;
-  const audpct = p.coverage?.audioEmbeddedPercent ?? null;
-  // Audio embeddings only exist once at least one is written; until then the
-  // row reads "not enabled" rather than a misleading 0% (CLAP is opt-in).
-  const audioOn = (audioEmbedded ?? 0) > 0;
-  const remaining = total != null && tagged != null ? Math.max(0, total - tagged) : null;
-  const running = !!p.tagger?.running;
-  const analysisOff = p.coverage?.analysisAvailable === false;
-  const moodCount = p.libStats ? Object.keys(p.libStats.byMood || {}).length : 0;
-  const lastTag = p.libStats?.updatedAt ? new Date(p.libStats.updatedAt).toLocaleString('en-GB') : '—';
-  const anySel = !!(passes.reseed || passes.reEnrich || passes.reAnalyze || passes.upgrade);
-
-  // Embeddings present but no vectors → likely a model swap dropped them.
-  const embeddingMissing = (tagged ?? 0) > 0 && p.libStats != null && p.libStats.withEmbedding === 0;
-
-  // live-run progress (best-effort: coverage delta vs. captured target)
-  const processed = p.runInfo && tagged != null ? Math.max(0, tagged - p.runInfo.baseline) : null;
-  const runPct = p.runInfo?.target && processed != null
-    ? Math.min(100, Math.round((processed / p.runInfo.target) * 100)) : null;
-
-  useDynamicStyle(moodFillRef, { width: pct != null ? `${Math.min(100, pct)}%` : '0%' });
-  useDynamicStyle(acousticFillRef, { width: !analysisOff && apct != null ? `${Math.min(100, apct)}%` : '0%' });
-  useDynamicStyle(audioFillRef, { width: audioOn && audpct != null ? `${Math.min(100, audpct)}%` : '0%' });
-  useDynamicStyle(runFillRef, { width: runPct != null ? `${runPct}%` : null });
-
-  useEffect(() => {
-    if (p.logOpen && logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
-  }, [p.logOpen, p.tagger?.lastLog?.length]);
-
-  const togglePass = (k: keyof RescanOpts) => setPasses(prev => ({ ...prev, [k]: !prev[k] }));
-
-  return (
-    <section className="card">
-      {/* headline */}
-      <div className="border-b border-ink p-6">
-        <Eyebrow className="text-vermilion">library · tagging</Eyebrow>
-        <h1 className="lib-hero-title">
-          {pct != null
-            ? <>Your DJ knows <span className="pct mono-num">{pct}%</span> of your library.</>
-            : <>Manage the music your station plays.</>}
-        </h1>
-        <p className="lib-hero-sub">
-          To pick the right track for any moment, the DJ reads the <b>mood</b> and <b>energy</b> of
-          every song. New tracks need tagging before they can go on air — that&rsquo;s what this does.
-        </p>
-      </div>
-
-      {/* coverage — mood primary, acoustic optional */}
-      <div className="border-b border-ink">
-        <div className="p-6">
-          <div className="flex flex-wrap items-baseline justify-between gap-3">
-            <span className="flex items-center gap-2 text-[11px] font-bold tracking-[0.16em] text-ink uppercase">
-              <Sparkles size={14} /> Mood &amp; energy tagged
-            </span>
-            <span className="mono-num text-[13px] font-bold">{pct != null ? `${pct}%` : '—'}</span>
-          </div>
-          <div className="mt-2 flex items-baseline gap-2">
-            <span className="lib-cov-big mono-num">{num(tagged)}</span>
-            <span className="text-[13px] text-muted">/ {total != null ? num(total) : (p.coverage?.scanning ? 'scanning…' : '—')} tracks</span>
-          </div>
-          <div className="lib-bar mt-3"><span ref={moodFillRef} /></div>
-          <div className="mt-2.5 text-[11px] text-muted">
-            {remaining != null && remaining > 0
-              ? <><b className="mono-num text-ink">{num(remaining)}</b> tracks still need tags · <span className="mono-num">{moodCount}</span> moods in use · last tag {lastTag}</>
-              : <>{remaining === 0 ? 'Every track is tagged' : 'Coverage updating…'} · <span className="mono-num">{moodCount}</span> moods in use · last tag {lastTag}</>}
-          </div>
-          {embeddingMissing && (
-            <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 border border-[color-mix(in_oklab,var(--accent)_30%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] text-ink">
-              <span><b>Embeddings missing.</b> Your embedding model may have changed — re-embed to restore similarity-based picks.</span>
-              <button
-                type="button"
-                className="font-bold text-vermilion underline-offset-2 hover:underline"
-                onClick={() => { setMaintOpen(true); setPasses(s => ({ ...s, reseed: true })); }}
-              >
-                Set up a re-embed →
-              </button>
-            </div>
-          )}
-        </div>
-        <div className="flex flex-wrap items-center gap-x-3.5 gap-y-2 border-t border-dashed border-separator-strong px-6 py-3.5">
-          <span className="caption flex items-center gap-2">
-            <Activity size={13} /> Acoustic analysis · bpm / key
-          </span>
-          <span className="lib-opt-tag">optional</span>
-          <span className="lib-minibar"><span ref={acousticFillRef} /></span>
-          <span className="caption mono-num !tracking-[0.04em]">
-            {analysisOff ? 'engine off' : <>{num(analysed)} / {num(total)} · {apct != null ? `${apct}%` : '…'}</>}
-          </span>
-          <span className="caption basis-full !tracking-[0.04em] !normal-case">
-            {analysisOff
-              ? 'No analysis engine running. Start the tts-heavy sidecar (docker compose --profile tts-heavy up -d) or configure a local librosa venv to enable it.'
-              : 'Improves beat-matching between tracks. Tagging works fine without it.'}
-          </span>
-        </div>
-        <div className="flex flex-wrap items-center gap-x-3.5 gap-y-2 border-t border-dashed border-separator-strong px-6 py-3.5">
-          <span className="caption flex items-center gap-2">
-            <Activity size={13} /> Audio fingerprint · sounds-like
-          </span>
-          <span className="lib-opt-tag">optional</span>
-          <span className="lib-minibar"><span ref={audioFillRef} /></span>
-          <span className="caption mono-num !tracking-[0.04em]">
-            {analysisOff
-              ? 'engine off'
-              : audioOn
-                ? <>{num(audioEmbedded)} / {num(total)} · {audpct != null ? `${audpct}%` : '…'}</>
-                : p.audioEnabled ? 'enabled — not yet analysed' : 'off'}
-          </span>
-          {!analysisOff && p.audioEnabled != null && (
-            <span className="flex items-center gap-2">
-              {p.audioEnabled && (
-                <Btn sm tone="accent" onClick={p.onAnalyzeAudio} disabled={running || p.busy}>
-                  <Play size={12} /> {audioOn ? 'Analyze new tracks' : 'Analyze library'}
-                </Btn>
-              )}
-              <Btn sm onClick={p.onToggleAudio} disabled={running || p.busy}>
-                {p.audioEnabled ? 'Disable' : 'Enable'}
-              </Btn>
-            </span>
-          )}
-          <span className="caption basis-full !tracking-[0.04em] !normal-case">
-            {analysisOff
-              ? 'Needs the analysis engine above.'
-              : audioOn
-                ? 'CLAP audio embeddings power “sounds-like” picks and sonic journeys — they catch sonic neighbours that metadata misses.'
-                : p.audioEnabled
-                  ? 'Run the analysis to fingerprint your tracks. The engine needs the CLAP model — if the bar stays at 0 after a run, rebuild the tts-heavy sidecar with WITH_CLAP=1.'
-                  : 'Listens to each track and fingerprints how it actually sounds, enabling “sounds-like” picks and sonic journeys. Adds a one-off analysis pass over your library.'}
-          </span>
-        </div>
-      </div>
-
-      {/* action zone — idle vs running */}
-      {!running ? (
-        <div className="flex flex-wrap items-center gap-4 p-6">
-          <div className="min-w-[220px] flex-1 text-[13px]">
-            {remaining != null && remaining > 0
-              ? <><b>{num(remaining)}</b> tracks are waiting. Tag them and they become DJ-ready.</>
-              : remaining === 0
-                ? <>Library fully tagged. Run a re-scan below if you&rsquo;ve changed the model.</>
-                : <>Start tagging new tracks so the DJ can play them.</>}
-          </div>
-          <div className="flex flex-wrap items-center gap-2.5">
-            <div className="lib-batch">
-              <label htmlFor="lib-batch">Tag</label>
-              <select id="lib-batch" value={p.batch} onChange={e => p.setBatch(e.target.value as Batch)}>
-                <option value="100">next 100</option>
-                <option value="500">next 500</option>
-                <option value="all">all{remaining != null ? ` ${num(remaining)}` : ''} remaining</option>
-              </select>
-            </div>
-            <Btn lg tone="accent" onClick={p.onStart} disabled={p.busy || remaining === 0}>
-              <Play size={13} /> Start tagging
-            </Btn>
-          </div>
-        </div>
-      ) : (
-        <div className="flex flex-col gap-3 p-6">
-          <div className="flex flex-wrap items-center justify-between gap-3.5">
-            <span className="flex items-center gap-2.5 text-[13px] font-bold">
-              <span className="lib-livedot" /> {p.tagger?.mode === 'analyze' ? 'Audio analysis in progress…' : 'Tagging in progress…'}
-            </span>
-            <span className="caption mono-num !tracking-[0.04em]">
-              {processed != null && <>{num(processed)}{p.runInfo?.target ? ` / ${num(p.runInfo.target)}` : ''} this run · </>}
-              {p.tagger?.pid ? `pid ${p.tagger.pid}` : ''}
-              {p.tagger?.startedAt ? ` · started ${new Date(p.tagger.startedAt).toLocaleTimeString('en-GB')}` : ''}
-            </span>
-            <Btn sm tone="danger" onClick={p.onStop} disabled={p.busy}><Square size={11} /> Stop</Btn>
-          </div>
-          {runPct != null && (
-            <div className="lib-bar !h-1.5"><span ref={runFillRef} /></div>
-          )}
-          <div className="caption !tracking-[0.04em] !normal-case">
-            {p.tagger?.mode === 'analyze'
-              ? <>The analysis engine is listening to each track — measuring tempo and key, and fingerprinting how it sounds. You can keep browsing — this runs in the background.</>
-              : <>The DJ is listening to each new track and deciding its mood &amp; energy. You can keep browsing — this runs in the background.</>}
-          </div>
-        </div>
-      )}
-
-      {/* footer — progressive disclosure */}
-      <div className="flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-dashed border-separator-strong px-6 py-3">
-        <button
-          type="button"
-          className={cn('inline-flex items-center gap-1.5 text-[11px] font-bold', maintOpen ? 'text-ink' : 'text-muted hover:text-ink')}
-          onClick={() => setMaintOpen(o => !o)}
-        >
-          {maintOpen ? <ChevronDown size={13} /> : <ChevronRight size={13} />} Maintenance &amp; re-scan
-        </button>
-        <button
-          type="button"
-          className={cn('inline-flex items-center gap-1.5 text-[11px] font-bold', p.logOpen ? 'text-ink' : 'text-muted hover:text-ink')}
-          onClick={() => p.setLogOpen(o => !o)}
-        >
-          <Terminal size={13} /> {p.logOpen ? 'Hide log' : 'View log'}
-        </button>
-      </div>
-
-      {/* maintenance disclosure */}
-      {maintOpen && (
-        <div className="flex flex-col gap-3.5 border-t border-ink bg-[var(--ink-soft)] p-6">
-          <div className="max-w-[64ch] text-[12px] leading-[1.55] text-muted">
-            Re-scanning rebuilds parts of the index from scratch — only needed after you change the
-            LLM, embedding model, or analysis engine. Your existing mood tags are kept as seeds.
-            Pick what to re-run:
-          </div>
-          <div className="grid gap-2.5 sm:grid-cols-2">
-            <Pass on={!!passes.reseed} onClick={() => togglePass('reseed')} name="Re-embed all tracks"
-              hint="Drop & rebuild every vector. Run after changing the embedding model." />
-            <Pass on={!!passes.reEnrich} onClick={() => togglePass('reEnrich')} name="Re-enrich metadata"
-              hint="Re-fetch Last.fm tags + lyrics that feed the tagging." />
-            <Pass on={!!passes.reAnalyze} onClick={() => togglePass('reAnalyze')} name="Re-analyse acoustics"
-              hint="Redo BPM / key detection for every track." />
-            <Pass on={!!passes.upgrade} onClick={() => togglePass('upgrade')} name="Re-decide moods"
-              hint="Re-tag tracks whose prompt or model is now stale." />
-          </div>
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <Btn sm disabled={p.busy || running} onClick={() => setConfirmFull(true)}>
-              <RefreshCw size={12} /> Full re-scan (everything)
-            </Btn>
-            <Btn sm tone="accent" disabled={!anySel || p.busy || running}
-              onClick={() => { p.onRescan(passes); setPasses({ reseed: false, reEnrich: false, reAnalyze: false, upgrade: false }); }}>
-              Run selected passes
-            </Btn>
-          </div>
-        </div>
-      )}
-
-      {/* log drawer — reuses the theme-aware .term surface */}
-      {p.logOpen && (
-        <pre ref={logRef} className="term m-0 max-h-56 overflow-y-auto !border-t !border-l-0 border-separator-strong">
-          {(p.tagger?.lastLog || []).join('\n') || '(no log output yet — start a tagging run to see the booth think)'}
-        </pre>
-      )}
-
-      <V3AlertDialog
-        open={confirmFull}
-        onOpenChange={setConfirmFull}
-        title="Full library re-scan"
-        description="Rebuilds the whole library from scratch: re-embeds every track, re-fetches Last.fm tags + lyrics, and redoes acoustic (bpm/key) analysis. Existing mood tags are kept and reused as seeds — moods are not re-decided. This can take several minutes on a large library and re-spends embedding calls. To re-decide moods too, tick 'Re-decide moods' and use 'Run selected passes'."
-        confirmLabel="full re-scan"
-        danger
-        onConfirm={() => p.onRescan({ reseed: true, reEnrich: true, reAnalyze: true })}
-      />
-    </section>
-  );
-}
-
-function Pass({ on, onClick, name, hint }: { on: boolean; onClick: () => void; name: string; hint: string }) {
-  return (
-    <button type="button" className={cn('lib-pass', on && 'on')} onClick={onClick}>
-      <span className="box">
-        <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
-          <path d="M2.5 6.2L4.8 8.5L9.5 3.5" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      </span>
-      <span>
-        <span className="lib-pass-name">{name}</span>
-        <span className="lib-pass-hint">{hint}</span>
-      </span>
-    </button>
   );
 }
 

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -1,0 +1,425 @@
+'use client';
+
+// The "Your DJ knows X%" tagging panel at the top of /admin/library —
+// coverage hero, the primary Start-tagging action, live structured run
+// progress, and the progressive-disclosure Maintenance & advanced drawer
+// (which also houses the optional acoustic + audio-fingerprint passes).
+// Extracted from LibraryPanel.tsx; the browse/search/untagged experience
+// stays over there.
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  Sparkles, Activity, Play, Square, ChevronDown, ChevronRight, Terminal, RefreshCw,
+} from 'lucide-react';
+import { useDynamicStyle } from '../../hooks/useDynamicStyle';
+import { Btn, Eyebrow } from './ui';
+import { V3AlertDialog } from '../ui/alert-dialog';
+import { cn } from '../../lib/cn';
+
+// ---------------------------------------------------------------------------
+// shared types (also consumed by LibraryPanel)
+// ---------------------------------------------------------------------------
+export interface Coverage {
+  tagged: number;
+  analysed: number;
+  // Tracks with a CLAP audio (sounds-like) embedding. Same analysis backend,
+  // gated on ANALYZE_AUDIO_EMBEDDING — 0 when that's off even if bpm/key runs.
+  audioEmbedded?: number;
+  total: number | null;
+  percent: number | null;
+  analysedPercent: number | null;
+  audioEmbeddedPercent?: number | null;
+  scannedAt: string | null;
+  scanning: boolean;
+  // null = still probing; false = no analysis backend (sidecar/librosa) running.
+  analysisAvailable?: boolean | null;
+  analysisBackend?: string | null;
+}
+
+// Mirrors controller/src/music/tagger-progress.ts — the structured sentinel
+// the tagger child emits and /settings relays.
+export interface TaggerProgress {
+  phase: 'walk' | 'enrich' | 'embed' | 'seed' | 'propagate' | 'learn' | 'analyze' | 'done';
+  label: string;
+  done?: number;
+  total?: number;        // absent → indeterminate (e.g. the Navidrome walk)
+  round?: number;        // active-learn round
+  errors?: number;
+  llm?: { legs: Record<string, number> };
+  updatedAt: string;
+}
+
+export interface TaggerState {
+  running?: boolean;
+  pid?: number;
+  startedAt?: string;
+  lastLog?: string[];
+  // 'tag' (tag-library) or 'analyze' (the acoustic/audio-embedding pass) —
+  // both run through the same single-flight child slot.
+  mode?: 'tag' | 'analyze' | null;
+  progress?: TaggerProgress | null;
+}
+
+// libraryStats rides along on /settings — gives moods-in-use, last-tag time,
+// and withEmbedding (used to nudge a re-embed after a model swap) without an
+// extra request and regardless of which tab is active.
+export interface LibraryStatsLite {
+  total: number;
+  byMood: Record<string, number>;
+  byEnergy: Record<string, number>;
+  byGenre: Record<string, number>;
+  withEmbedding: number;
+  updatedAt: string | null;
+}
+
+export type Batch = '100' | '500' | 'all';
+
+export type RescanOpts = {
+  reseed?: boolean;
+  reEnrich?: boolean;
+  reAnalyze?: boolean;
+  upgrade?: boolean;
+};
+
+export function num(n: number | null | undefined): string {
+  return n != null ? n.toLocaleString('en-GB') : '—';
+}
+
+// ---------------------------------------------------------------------------
+// tagging panel — merged coverage + tagger, framed for humans
+// ---------------------------------------------------------------------------
+interface TaggingPanelProps {
+  coverage: Coverage | null;
+  libStats: LibraryStatsLite | null;
+  tagger: TaggerState | null;
+  batch: Batch;
+  setBatch: (b: Batch) => void;
+  busy: boolean;
+  logOpen: boolean;
+  setLogOpen: (fn: (o: boolean) => boolean) => void;
+  onStart: () => void;
+  onStop: () => void;
+  onRescan: (opts: RescanOpts) => void;
+  // sounds-like (CLAP) controls — null until the first settings poll lands.
+  audioEnabled: boolean | null;
+  onToggleAudio: () => void;
+  onAnalyzeAudio: () => void;
+}
+
+// One friendly sentence per pipeline phase — shown under the live progress so
+// the operator knows what the run is actually doing right now.
+const PHASE_HINT: Record<TaggerProgress['phase'], string> = {
+  walk: 'Reading the track list from Navidrome.',
+  enrich: 'Fetching Last.fm tags and lyrics that help the DJ understand each track.',
+  embed: 'Computing similarity vectors so tags can spread between similar tracks.',
+  seed: 'The DJ is deciding mood & energy for a representative set of tracks.',
+  propagate: 'Spreading tags from tagged tracks to their closest sonic neighbours.',
+  learn: 'The DJ is re-checking tracks the automatic spread wasn’t confident about.',
+  analyze: 'Measuring tempo and key, and fingerprinting how each track sounds.',
+  done: 'Wrapping up.',
+};
+
+export default function TaggingPanel(p: TaggingPanelProps) {
+  const [maintOpen, setMaintOpen] = useState(false);
+  const [confirmFull, setConfirmFull] = useState(false);
+  const [passes, setPasses] = useState<RescanOpts>({ reseed: false, reEnrich: false, reAnalyze: false, upgrade: false });
+  const logRef = useRef<HTMLPreElement>(null);
+  const moodFillRef = useRef<HTMLSpanElement>(null);
+  const acousticFillRef = useRef<HTMLSpanElement>(null);
+  const audioFillRef = useRef<HTMLSpanElement>(null);
+  const runFillRef = useRef<HTMLSpanElement>(null);
+
+  const tagged = p.coverage?.tagged ?? p.libStats?.total ?? null;
+  const total = p.coverage?.total ?? null;
+  const analysed = p.coverage?.analysed ?? null;
+  const audioEmbedded = p.coverage?.audioEmbedded ?? null;
+  const pct = p.coverage?.percent ?? null;
+  const apct = p.coverage?.analysedPercent ?? null;
+  const audpct = p.coverage?.audioEmbeddedPercent ?? null;
+  // Audio embeddings only exist once at least one is written; until then the
+  // row reads "not enabled" rather than a misleading 0% (CLAP is opt-in).
+  const audioOn = (audioEmbedded ?? 0) > 0;
+  const remaining = total != null && tagged != null ? Math.max(0, total - tagged) : null;
+  const running = !!p.tagger?.running;
+  const analysisOff = p.coverage?.analysisAvailable === false;
+  const moodCount = p.libStats ? Object.keys(p.libStats.byMood || {}).length : 0;
+  const lastTag = p.libStats?.updatedAt ? new Date(p.libStats.updatedAt).toLocaleString('en-GB') : '—';
+  const anySel = !!(passes.reseed || passes.reEnrich || passes.reAnalyze || passes.upgrade);
+
+  // Embeddings present but no vectors → likely a model swap dropped them.
+  const embeddingMissing = (tagged ?? 0) > 0 && p.libStats != null && p.libStats.withEmbedding === 0;
+
+  // Structured live-run progress from the tagger child — survives page
+  // reloads and runs started elsewhere (no client-captured baseline). Null
+  // for an old child binary → the running view falls back to generic copy.
+  const progress = running ? (p.tagger?.progress ?? null) : null;
+  const runPct = progress?.total
+    ? Math.min(100, Math.round(((progress.done ?? 0) / progress.total) * 100))
+    : null;
+  const runIndeterminate = !!progress && progress.total == null && progress.phase !== 'done';
+  const legEntries = progress?.llm ? Object.entries(progress.llm.legs) : [];
+
+  useDynamicStyle(moodFillRef, { width: pct != null ? `${Math.min(100, pct)}%` : '0%' });
+  useDynamicStyle(acousticFillRef, { width: !analysisOff && apct != null ? `${Math.min(100, apct)}%` : '0%' });
+  useDynamicStyle(audioFillRef, { width: audioOn && audpct != null ? `${Math.min(100, audpct)}%` : '0%' });
+  useDynamicStyle(runFillRef, { width: runPct != null ? `${runPct}%` : null });
+
+  useEffect(() => {
+    if (p.logOpen && logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
+  }, [p.logOpen, p.tagger?.lastLog?.length]);
+
+  const togglePass = (k: keyof RescanOpts) => setPasses(prev => ({ ...prev, [k]: !prev[k] }));
+
+  return (
+    <section className="card">
+      {/* headline */}
+      <div className="border-b border-ink p-6">
+        <Eyebrow className="text-vermilion">library · tagging</Eyebrow>
+        <h1 className="lib-hero-title">
+          {pct != null
+            ? <>Your DJ knows <span className="pct mono-num">{pct}%</span> of your library.</>
+            : <>Manage the music your station plays.</>}
+        </h1>
+        <p className="lib-hero-sub">
+          The DJ reads each track&rsquo;s <b>mood</b> and <b>energy</b> to pick the right song for
+          the moment — new tracks need tagging before they go on air.
+        </p>
+      </div>
+
+      {/* coverage — the single hero meter */}
+      <div className="border-b border-ink">
+        <div className="p-6">
+          <div className="flex flex-wrap items-baseline justify-between gap-3">
+            <span className="flex items-center gap-2 text-[11px] font-bold tracking-[0.16em] text-ink uppercase">
+              <Sparkles size={14} /> Mood &amp; energy tagged
+            </span>
+            <span className="mono-num text-[13px] font-bold">{pct != null ? `${pct}%` : '—'}</span>
+          </div>
+          <div className="mt-2 flex items-baseline gap-2">
+            <span className="lib-cov-big mono-num">{num(tagged)}</span>
+            <span className="text-[13px] text-muted">/ {total != null ? num(total) : (p.coverage?.scanning ? 'scanning…' : '—')} tracks</span>
+          </div>
+          <div className="lib-bar mt-3"><span ref={moodFillRef} /></div>
+          <div className="mt-2.5 text-[11px] text-muted">
+            {remaining != null && remaining > 0
+              ? <><b className="mono-num text-ink">{num(remaining)}</b> tracks still need tags · <span className="mono-num">{moodCount}</span> moods in use · last tag {lastTag}</>
+              : <>{remaining === 0 ? 'Every track is tagged' : 'Coverage updating…'} · <span className="mono-num">{moodCount}</span> moods in use · last tag {lastTag}</>}
+          </div>
+          {embeddingMissing && (
+            <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 border border-[color-mix(in_oklab,var(--accent)_30%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] text-ink">
+              <span><b>Embeddings missing.</b> Your embedding model may have changed — re-embed to restore similarity-based picks.</span>
+              <button
+                type="button"
+                className="font-bold text-vermilion underline-offset-2 hover:underline"
+                onClick={() => { setMaintOpen(true); setPasses(s => ({ ...s, reseed: true })); }}
+              >
+                Set up a re-embed →
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* action zone — idle vs running */}
+      {!running ? (
+        <div className="flex flex-wrap items-center gap-4 p-6">
+          <div className="min-w-[220px] flex-1 text-[13px]">
+            {remaining != null && remaining > 0
+              ? <><b>{num(remaining)}</b> tracks are waiting. Tag them and they become DJ-ready.</>
+              : remaining === 0
+                ? <>Library fully tagged. Run a re-scan below if you&rsquo;ve changed the model.</>
+                : <>Start tagging new tracks so the DJ can play them.</>}
+          </div>
+          <div className="flex flex-wrap items-center gap-2.5">
+            <div className="lib-batch">
+              <label htmlFor="lib-batch">Tag</label>
+              <select id="lib-batch" value={p.batch} onChange={e => p.setBatch(e.target.value as Batch)}>
+                <option value="100">next 100</option>
+                <option value="500">next 500</option>
+                <option value="all">all{remaining != null ? ` ${num(remaining)}` : ''} remaining</option>
+              </select>
+            </div>
+            <Btn lg tone="accent" onClick={p.onStart} disabled={p.busy || remaining === 0}>
+              <Play size={13} /> Start tagging
+            </Btn>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3 p-6">
+          <div className="flex flex-wrap items-center justify-between gap-3.5">
+            <span className="flex items-center gap-2.5 text-[13px] font-bold">
+              <span className="lib-livedot" />
+              {progress ? (
+                <>
+                  {progress.label}
+                  {progress.round != null && ` · round ${progress.round}`}
+                  {progress.done != null && (
+                    <span className="mono-num">
+                      &nbsp;· {num(progress.done)}{progress.total != null && <> / {num(progress.total)}</>}
+                    </span>
+                  )}
+                </>
+              ) : (
+                p.tagger?.mode === 'analyze' ? 'Audio analysis in progress…' : 'Tagging in progress…'
+              )}
+            </span>
+            <span className="caption mono-num !tracking-[0.04em]">
+              {runPct != null && `${runPct}% · `}
+              {p.tagger?.pid ? `pid ${p.tagger.pid}` : ''}
+              {p.tagger?.startedAt ? ` · started ${new Date(p.tagger.startedAt).toLocaleTimeString('en-GB')}` : ''}
+            </span>
+            <Btn sm tone="danger" onClick={p.onStop} disabled={p.busy}><Square size={11} /> Stop</Btn>
+          </div>
+          {(runPct != null || runIndeterminate) && (
+            <div className={cn('lib-bar !h-1.5', runIndeterminate && 'indet')}><span ref={runFillRef} /></div>
+          )}
+          {(legEntries.length > 1 || (progress?.errors ?? 0) > 0) && (
+            <div className="caption mono-num !tracking-[0.04em]">
+              {legEntries.length > 1 && <>dual-LLM · {legEntries.map(([m, n]) => `${m} ${num(n)}`).join(' · ')}</>}
+              {legEntries.length > 1 && (progress?.errors ?? 0) > 0 && ' · '}
+              {(progress?.errors ?? 0) > 0 && <span className="text-vermilion">{num(progress!.errors)} failed</span>}
+            </div>
+          )}
+          <div className="caption !tracking-[0.04em] !normal-case">
+            {(progress && PHASE_HINT[progress.phase]) ||
+              (p.tagger?.mode === 'analyze'
+                ? 'The analysis engine is listening to each track — measuring tempo and key, and fingerprinting how it sounds.'
+                : 'The DJ is listening to each new track and deciding its mood & energy.')}
+            {' '}You can keep browsing — this runs in the background.
+          </div>
+        </div>
+      )}
+
+      {/* footer — progressive disclosure */}
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-dashed border-separator-strong px-6 py-3">
+        <button
+          type="button"
+          className={cn('inline-flex items-center gap-1.5 text-[11px] font-bold', maintOpen ? 'text-ink' : 'text-muted hover:text-ink')}
+          onClick={() => setMaintOpen(o => !o)}
+        >
+          {maintOpen ? <ChevronDown size={13} /> : <ChevronRight size={13} />} Maintenance &amp; advanced
+        </button>
+        <button
+          type="button"
+          className={cn('inline-flex items-center gap-1.5 text-[11px] font-bold', p.logOpen ? 'text-ink' : 'text-muted hover:text-ink')}
+          onClick={() => p.setLogOpen(o => !o)}
+        >
+          <Terminal size={13} /> {p.logOpen ? 'Hide log' : 'View log'}
+        </button>
+      </div>
+
+      {/* maintenance & advanced disclosure */}
+      {maintOpen && (
+        <div className="flex flex-col gap-3.5 border-t border-ink bg-[var(--ink-soft)] p-6">
+          {/* optional acoustic / audio-fingerprint passes — tucked away here so
+              the default view stays focused on mood & energy */}
+          <div className="flex flex-wrap items-center gap-x-3.5 gap-y-2">
+            <span className="caption flex items-center gap-2">
+              <Activity size={13} /> Acoustic analysis · bpm / key
+            </span>
+            <span className="lib-opt-tag">optional</span>
+            <span className="lib-minibar"><span ref={acousticFillRef} /></span>
+            <span className="caption mono-num !tracking-[0.04em]">
+              {analysisOff ? 'engine off' : <>{num(analysed)} / {num(total)} · {apct != null ? `${apct}%` : '…'}</>}
+            </span>
+            <span className="caption basis-full !tracking-[0.04em] !normal-case">
+              {analysisOff
+                ? 'No analysis engine running — start the tts-heavy sidecar (docker compose --profile tts-heavy up -d) or configure a local librosa venv.'
+                : 'Improves beat-matching between tracks; tagging works fine without it.'}
+            </span>
+          </div>
+          <div className="flex flex-wrap items-center gap-x-3.5 gap-y-2 border-t border-dashed border-separator-strong pt-3.5">
+            <span className="caption flex items-center gap-2">
+              <Activity size={13} /> Audio fingerprint · sounds-like
+            </span>
+            <span className="lib-opt-tag">optional</span>
+            <span className="lib-minibar"><span ref={audioFillRef} /></span>
+            <span className="caption mono-num !tracking-[0.04em]">
+              {analysisOff
+                ? 'engine off'
+                : audioOn
+                  ? <>{num(audioEmbedded)} / {num(total)} · {audpct != null ? `${audpct}%` : '…'}</>
+                  : p.audioEnabled ? 'enabled — not yet analysed' : 'off'}
+            </span>
+            {!analysisOff && p.audioEnabled != null && (
+              <span className="flex items-center gap-2">
+                {p.audioEnabled && (
+                  <Btn sm tone="accent" onClick={p.onAnalyzeAudio} disabled={running || p.busy}>
+                    <Play size={12} /> {audioOn ? 'Analyze new tracks' : 'Analyze library'}
+                  </Btn>
+                )}
+                <Btn sm onClick={p.onToggleAudio} disabled={running || p.busy}>
+                  {p.audioEnabled ? 'Disable' : 'Enable'}
+                </Btn>
+              </span>
+            )}
+            <span className="caption basis-full !tracking-[0.04em] !normal-case">
+              {analysisOff
+                ? 'Needs the analysis engine above.'
+                : audioOn || !p.audioEnabled
+                  ? 'Listens to each track and fingerprints how it sounds, enabling “sounds-like” picks and sonic journeys.'
+                  : 'Run the analysis to fingerprint your tracks — if the bar stays at 0 after a run, rebuild the tts-heavy sidecar with WITH_CLAP=1.'}
+            </span>
+          </div>
+
+          <div className="max-w-[64ch] border-t border-dashed border-separator-strong pt-3.5 text-[12px] leading-[1.55] text-muted">
+            Re-scanning rebuilds parts of the index — only needed after changing the LLM, embedding
+            model, or analysis engine. Existing mood tags are kept as seeds.
+          </div>
+          <div className="grid gap-2.5 sm:grid-cols-2">
+            <Pass on={!!passes.reseed} onClick={() => togglePass('reseed')} name="Re-embed all tracks"
+              hint="Drop & rebuild every vector. Run after changing the embedding model." />
+            <Pass on={!!passes.reEnrich} onClick={() => togglePass('reEnrich')} name="Re-enrich metadata"
+              hint="Re-fetch Last.fm tags + lyrics that feed the tagging." />
+            <Pass on={!!passes.reAnalyze} onClick={() => togglePass('reAnalyze')} name="Re-analyse acoustics"
+              hint="Redo BPM / key detection for every track." />
+            <Pass on={!!passes.upgrade} onClick={() => togglePass('upgrade')} name="Re-decide moods"
+              hint="Re-tag tracks whose prompt or model is now stale." />
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <Btn sm disabled={p.busy || running} onClick={() => setConfirmFull(true)}>
+              <RefreshCw size={12} /> Full re-scan (everything)
+            </Btn>
+            <Btn sm tone="accent" disabled={!anySel || p.busy || running}
+              onClick={() => { p.onRescan(passes); setPasses({ reseed: false, reEnrich: false, reAnalyze: false, upgrade: false }); }}>
+              Run selected passes
+            </Btn>
+          </div>
+        </div>
+      )}
+
+      {/* log drawer — reuses the theme-aware .term surface */}
+      {p.logOpen && (
+        <pre ref={logRef} className="term m-0 max-h-56 overflow-y-auto !border-t !border-l-0 border-separator-strong">
+          {(p.tagger?.lastLog || []).join('\n') || '(no log output yet — start a tagging run to see the booth think)'}
+        </pre>
+      )}
+
+      <V3AlertDialog
+        open={confirmFull}
+        onOpenChange={setConfirmFull}
+        title="Full library re-scan"
+        description="Rebuilds the whole library from scratch: re-embeds every track, re-fetches Last.fm tags + lyrics, and redoes acoustic (bpm/key) analysis. Existing mood tags are kept and reused as seeds — moods are not re-decided. This can take several minutes on a large library and re-spends embedding calls. To re-decide moods too, tick 'Re-decide moods' and use 'Run selected passes'."
+        confirmLabel="full re-scan"
+        danger
+        onConfirm={() => p.onRescan({ reseed: true, reEnrich: true, reAnalyze: true })}
+      />
+    </section>
+  );
+}
+
+function Pass({ on, onClick, name, hint }: { on: boolean; onClick: () => void; name: string; hint: string }) {
+  return (
+    <button type="button" className={cn('lib-pass', on && 'on')} onClick={onClick}>
+      <span className="box">
+        <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
+          <path d="M2.5 6.2L4.8 8.5L9.5 3.5" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </span>
+      <span>
+        <span className="lib-pass-name">{name}</span>
+        <span className="lib-pass-hint">{hint}</span>
+      </span>
+    </button>
+  );
+}

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -34,6 +34,10 @@ export interface Coverage {
   // null = still probing; false = no analysis backend (sidecar/librosa) running.
   analysisAvailable?: boolean | null;
   analysisBackend?: string | null;
+  // Whether the backend can emit CLAP "sounds-like" embeddings. false = engine
+  // is up but built without the CLAP stack (sidecar WITH_CLAP=0) — drives the
+  // active "rebuild with WITH_CLAP=1" warning. null = unknown / still probing.
+  audioAnalysisAvailable?: boolean | null;
 }
 
 // Mirrors controller/src/music/tagger-progress.ts — the structured sentinel
@@ -121,7 +125,7 @@ const PHASE_HINT: Record<TaggerProgress['phase'], string> = {
 
 export default function TaggingPanel(p: TaggingPanelProps) {
   const [maintOpen, setMaintOpen] = useState(false);
-  const [confirmFull, setConfirmFull] = useState(false);
+  const [confirmRescan, setConfirmRescan] = useState(false);
   const [passes, setPasses] = useState<RescanOpts>({ reseed: false, reEnrich: false, reAnalyze: false, upgrade: false });
   const logRef = useRef<HTMLPreElement>(null);
   const moodFillRef = useRef<HTMLSpanElement>(null);
@@ -142,6 +146,10 @@ export default function TaggingPanel(p: TaggingPanelProps) {
   const remaining = total != null && tagged != null ? Math.max(0, total - tagged) : null;
   const running = !!p.tagger?.running;
   const analysisOff = p.coverage?.analysisAvailable === false;
+  // Engine is up but built without the CLAP stack — "sounds-like" fingerprints
+  // can't be produced until the sidecar is rebuilt with WITH_CLAP=1. We warn
+  // actively rather than letting a run finish with the bar stuck at 0.
+  const audioIncapable = !analysisOff && p.coverage?.audioAnalysisAvailable === false;
   const moodCount = p.libStats ? Object.keys(p.libStats.byMood || {}).length : 0;
   const lastTag = p.libStats?.updatedAt ? new Date(p.libStats.updatedAt).toLocaleString('en-GB') : '—';
   const anySel = !!(passes.reseed || passes.reEnrich || passes.reAnalyze || passes.upgrade);
@@ -169,6 +177,19 @@ export default function TaggingPanel(p: TaggingPanelProps) {
   }, [p.logOpen, p.tagger?.lastLog?.length]);
 
   const togglePass = (k: keyof RescanOpts) => setPasses(prev => ({ ...prev, [k]: !prev[k] }));
+  const allSelected = !!(passes.reseed && passes.reEnrich && passes.reAnalyze && passes.upgrade);
+  const toggleAll = () => {
+    const on = !allSelected;
+    setPasses({ reseed: on, reEnrich: on, reAnalyze: on, upgrade: on });
+  };
+  const clearPasses = () => setPasses({ reseed: false, reEnrich: false, reAnalyze: false, upgrade: false });
+  // Re-embedding re-spends embedding calls — guard those runs behind a confirm;
+  // the lighter passes (re-enrich / re-analyse / re-decide) run straight away.
+  const runRescan = () => {
+    if (passes.reseed) { setConfirmRescan(true); return; }
+    p.onRescan(passes);
+    clearPasses();
+  };
 
   return (
     <section className="card">
@@ -337,14 +358,16 @@ export default function TaggingPanel(p: TaggingPanelProps) {
             <span className="caption mono-num !tracking-[0.04em]">
               {analysisOff
                 ? 'engine off'
-                : audioOn
-                  ? <>{num(audioEmbedded)} / {num(total)} · {audpct != null ? `${audpct}%` : '…'}</>
-                  : p.audioEnabled ? 'enabled — not yet analysed' : 'off'}
+                : audioIncapable
+                  ? 'engine missing CLAP'
+                  : audioOn
+                    ? <>{num(audioEmbedded)} / {num(total)} · {audpct != null ? `${audpct}%` : '…'}</>
+                    : p.audioEnabled ? 'enabled — not yet analysed' : 'off'}
             </span>
             {!analysisOff && p.audioEnabled != null && (
               <span className="flex items-center gap-2">
                 {p.audioEnabled && (
-                  <Btn sm tone="accent" onClick={p.onAnalyzeAudio} disabled={running || p.busy}>
+                  <Btn sm tone="accent" onClick={p.onAnalyzeAudio} disabled={running || p.busy || audioIncapable}>
                     <Play size={12} /> {audioOn ? 'Analyze new tracks' : 'Analyze library'}
                   </Btn>
                 )}
@@ -353,18 +376,35 @@ export default function TaggingPanel(p: TaggingPanelProps) {
                 </Btn>
               </span>
             )}
-            <span className="caption basis-full !tracking-[0.04em] !normal-case">
-              {analysisOff
-                ? 'Needs the analysis engine above.'
-                : audioOn || !p.audioEnabled
-                  ? 'Listens to each track and fingerprints how it sounds, enabling “sounds-like” picks and sonic journeys.'
-                  : 'Run the analysis to fingerprint your tracks — if the bar stays at 0 after a run, rebuild the tts-heavy sidecar with WITH_CLAP=1.'}
-            </span>
+            {audioIncapable && p.audioEnabled ? (
+              <span className="basis-full border border-[color-mix(in_oklab,var(--accent)_35%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] leading-[1.5] text-ink !normal-case">
+                <b>Sounds-like is on, but the analysis engine can’t fingerprint audio.</b> The
+                tts-heavy sidecar was built without the CLAP model, so a run would only fill bpm/key
+                and leave this at 0. Rebuild it with the CLAP stack, then run the analysis:
+                <code className="mt-1 block font-mono text-[10.5px] text-muted">WITH_CLAP=1 docker compose build tts-heavy &amp;&amp; docker compose --profile tts-heavy up -d tts-heavy</code>
+              </span>
+            ) : (
+              <span className="caption basis-full !tracking-[0.04em] !normal-case">
+                {analysisOff
+                  ? 'Needs the analysis engine above.'
+                  : 'Listens to each track and fingerprints how it sounds, enabling “sounds-like” picks and sonic journeys.'}
+              </span>
+            )}
           </div>
 
-          <div className="max-w-[64ch] border-t border-dashed border-separator-strong pt-3.5 text-[12px] leading-[1.55] text-muted">
-            Re-scanning rebuilds parts of the index — only needed after changing the LLM, embedding
-            model, or analysis engine. Existing mood tags are kept as seeds.
+          <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1.5 border-t border-dashed border-separator-strong pt-3.5">
+            <span className="max-w-[64ch] text-[12px] leading-[1.55] text-muted">
+              <b className="text-ink">Re-scan</b> — only needed after changing the LLM, embedding model, or analysis
+              engine. Pick the passes to redo (tick all for a full rebuild); existing mood tags are kept as seeds.
+            </span>
+            <button
+              type="button"
+              className="shrink-0 text-[11px] font-bold text-vermilion underline-offset-2 hover:underline disabled:opacity-40"
+              disabled={p.busy || running}
+              onClick={allSelected ? clearPasses : toggleAll}
+            >
+              {allSelected ? 'Clear all' : 'Select all'}
+            </button>
           </div>
           <div className="grid gap-2.5 sm:grid-cols-2">
             <Pass on={!!passes.reseed} onClick={() => togglePass('reseed')} name="Re-embed all tracks"
@@ -372,17 +412,13 @@ export default function TaggingPanel(p: TaggingPanelProps) {
             <Pass on={!!passes.reEnrich} onClick={() => togglePass('reEnrich')} name="Re-enrich metadata"
               hint="Re-fetch Last.fm tags + lyrics that feed the tagging." />
             <Pass on={!!passes.reAnalyze} onClick={() => togglePass('reAnalyze')} name="Re-analyse acoustics"
-              hint="Redo BPM / key detection for every track." />
+              hint="Redo BPM / key for every track — also refreshes sounds-like fingerprints when enabled." />
             <Pass on={!!passes.upgrade} onClick={() => togglePass('upgrade')} name="Re-decide moods"
               hint="Re-tag tracks whose prompt or model is now stale." />
           </div>
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <Btn sm disabled={p.busy || running} onClick={() => setConfirmFull(true)}>
-              <RefreshCw size={12} /> Full re-scan (everything)
-            </Btn>
-            <Btn sm tone="accent" disabled={!anySel || p.busy || running}
-              onClick={() => { p.onRescan(passes); setPasses({ reseed: false, reEnrich: false, reAnalyze: false, upgrade: false }); }}>
-              Run selected passes
+          <div className="flex flex-wrap items-center justify-end gap-3">
+            <Btn sm tone="accent" disabled={!anySel || p.busy || running} onClick={runRescan}>
+              <RefreshCw size={12} /> {allSelected ? 'Run full re-scan' : 'Run re-scan'}
             </Btn>
           </div>
         </div>
@@ -396,13 +432,13 @@ export default function TaggingPanel(p: TaggingPanelProps) {
       )}
 
       <V3AlertDialog
-        open={confirmFull}
-        onOpenChange={setConfirmFull}
-        title="Full library re-scan"
-        description="Rebuilds the whole library from scratch: re-embeds every track, re-fetches Last.fm tags + lyrics, and redoes acoustic (bpm/key) analysis. Existing mood tags are kept and reused as seeds — moods are not re-decided. This can take several minutes on a large library and re-spends embedding calls. To re-decide moods too, tick 'Re-decide moods' and use 'Run selected passes'."
-        confirmLabel="full re-scan"
+        open={confirmRescan}
+        onOpenChange={setConfirmRescan}
+        title="Re-embed the whole library?"
+        description="This pass drops and rebuilds every similarity vector from scratch, which re-spends embedding calls and can take several minutes on a large library. Existing mood tags are kept and reused as seeds. Only needed after changing the embedding model."
+        confirmLabel="re-scan"
         danger
-        onConfirm={() => p.onRescan({ reseed: true, reEnrich: true, reAnalyze: true })}
+        onConfirm={() => { p.onRescan(passes); clearPasses(); }}
       />
     </section>
   );

--- a/web/components/manual/AdminSettings.tsx
+++ b/web/components/manual/AdminSettings.tsx
@@ -6,7 +6,7 @@ export default function AdminSettings() {
     <ManualPage
       eyebrow="MANUAL · 07"
       title="Admin & settings."
-      intro="For the operator running the station. The admin console is where you shape the DJ, choose the AI providers, schedule shows, and watch how the station is behaving — all without a redeploy."
+      intro="For the operator running the station. The admin console is where you shape the DJ, choose the AI providers, schedule shows, and watch how the station is behaving, all without a redeploy."
       current="/manual/admin"
     >
       <section className="bs-section">
@@ -46,8 +46,8 @@ export default function AdminSettings() {
         <p className="bs-eyebrow">PROGRAMMING</p>
         <h2>Shaping the station.</h2>
         <p>
-          Everything in this group is saved durably and applies live — no redeploy, most
-          changes landing on the next thing the DJ does.
+          Everything in this group is saved durably and applies live. No redeploy, and most
+          changes land on the next thing the DJ does.
         </p>
         <ul className="bs-list">
           <li>
@@ -63,8 +63,8 @@ export default function AdminSettings() {
           <li>
             <strong>Personas</strong> — the roster of DJ identities, one to ten. Each has
             a name and character, a voice, a script length and a talk frequency, plus the
-            skills it's allowed to use. One persona is active at a time — though a
-            scheduled show can override which — and a single prompt template is shared by
+            skills it's allowed to use. One persona is active at a time (though a
+            scheduled show can override which), and a single prompt template is shared by
             all of them.
           </li>
           <li>
@@ -84,8 +84,8 @@ export default function AdminSettings() {
         <ul className="bs-list">
           <li>
             <strong>TTS voice</strong> — which text-to-speech engine and voice the DJ
-            speaks with, optionally a different one per kind of segment. The engines —
-            local and cloud — are covered in{' '}
+            speaks with, optionally a different one per kind of segment. The engines
+            (local and cloud) are covered in{' '}
             <Link href="/manual/dj" className="bs-link">How the DJ Works</Link>.
           </li>
           <li>
@@ -111,7 +111,7 @@ export default function AdminSettings() {
           <div className="bs-eyebrow">MIX CHANGES NEED A MIXER RESTART</div>
           <p>
             Crossfade and jingle-ratio changes are read by the audio mixer only at
-            startup. The settings page can trigger that restart for you — the stream drops
+            startup. The settings page can trigger that restart for you: the stream drops
             for a few seconds and comes back with the new values applied.
           </p>
         </div>
@@ -121,7 +121,7 @@ export default function AdminSettings() {
         <p className="bs-eyebrow">WHEN SOMETHING'S OFF</p>
         <h2>Stats &amp; debug.</h2>
         <p>
-          <strong>Stats</strong> reports how the station is performing — AI usage and
+          <strong>Stats</strong> reports how the station is performing: AI usage and
           latency, and how often it's had to fall back to a backup engine.{' '}
           <strong>Debug</strong> is a live snapshot for diagnosing trouble: recent AI
           calls, the mixer's status, and the most recent log lines. It's the first place

--- a/web/components/manual/AgentAccess.tsx
+++ b/web/components/manual/AgentAccess.tsx
@@ -5,9 +5,9 @@ import ManualPage from './ManualPage';
 const TOOLS = [
   { name: 'subwave_now_playing', summary: 'The current track, station context, and live listener count.', auth: '—' },
   { name: 'subwave_station_state', summary: 'The upcoming queue, recent history, and the DJ booth log.', auth: '—' },
-  { name: 'subwave_request_song', summary: 'Queues a track from a natural-language request — a song, an artist, or a vibe.', auth: '—' },
+  { name: 'subwave_request_song', summary: 'Queues a track from a natural-language request: a song, an artist, or a vibe.', auth: '—' },
   { name: 'subwave_dj_announce', summary: 'Puts a spoken update on air, rewritten in persona or read verbatim.', auth: 'Admin' },
-  { name: 'subwave_dj_segment', summary: 'Fires a scripted segment on demand — station ID, the hour, or a link.', auth: 'Admin' },
+  { name: 'subwave_dj_segment', summary: 'Fires a scripted segment on demand: station ID, the hour, or a link.', auth: 'Admin' },
 ];
 
 export default function AgentAccess() {
@@ -37,7 +37,7 @@ export default function AgentAccess() {
           browser, an agent calls a tool, and the same controller does the work.
         </p>
         <p className="text-muted">
-          The server holds no logic of its own — each tool is a typed wrapper over one
+          The server holds no logic of its own; each tool is a typed wrapper over one
           controller endpoint. The agent never sees a URL or an auth header, only the
           five intent-shaped tools below.
         </p>
@@ -66,7 +66,7 @@ export default function AgentAccess() {
         </table>
         <p className="text-muted">
           Like the human request path, <code className="bs-code-inline">subwave_request_song</code>{' '}
-          queues a track — it never interrupts the song that's playing — and it's
+          queues a track (it never interrupts the song that's playing) and it's
           rate-limited. The two DJ-control tools speak immediately.
         </p>
       </section>
@@ -75,13 +75,13 @@ export default function AgentAccess() {
         <p className="bs-eyebrow">PUBLIC vs ADMIN</p>
         <h2>Reading and requesting are open.</h2>
         <p>
-          The three read-and-request tools need no credentials — they map to the same
+          The three read-and-request tools need no credentials: they map to the same
           public, rate-limited endpoints a browser uses. The two DJ-control tools, which
           put a voice on air, are gated: the server sends the station's{' '}
           <code className="bs-code-inline">ADMIN_USER</code> /{' '}
           <code className="bs-code-inline">ADMIN_PASS</code> as a Basic auth header, read
           from its own environment. Without them, an agent can still see what's on air
-          and request songs — it just can't drive the DJ.
+          and request songs; it just can't drive the DJ.
         </p>
       </section>
 
@@ -91,7 +91,7 @@ export default function AgentAccess() {
         <p>
           The server lives in the repo at <code className="bs-code-inline">mcp-subwave/</code>.
           Build it once with <code className="bs-code-inline">npm install &amp;&amp; npm run build</code>,
-          then point any MCP client — Claude Code, Claude Desktop, or another — at the
+          then point any MCP client (Claude Code, Claude Desktop, or another) at the
           built <code className="bs-code-inline">dist/index.js</code>, passing the
           controller URL and, optionally, the admin credentials as environment variables.
           The station must be running first.

--- a/web/components/manual/Clients.tsx
+++ b/web/components/manual/Clients.tsx
@@ -38,14 +38,14 @@ export default function Clients() {
         <h2>The station&rsquo;s own terminal app.</h2>
         <p>
           Start here: SUB/WAVE ships its own terminal player. Where the other apps below just
-          carry the audio, the TUI mirrors the browser player &mdash; now-playing with track
+          carry the audio, the TUI mirrors the browser player: now-playing with track
           metadata, the timeline of recent and upcoming songs, the live booth feed, and a
           request form.
         </p>
         <p>
           It&rsquo;s built into the operator console, so there&rsquo;s nothing separate to
           install. With the <code className="bs-code-inline">subwave</code> CLI, run{' '}
-          <code className="bs-code-inline">subwave play</code> — the TUI is fetched on first
+          <code className="bs-code-inline">subwave play</code>. The TUI is fetched on first
           run and opens pointed at your stack:
         </p>
         <CodeBlock>{`subwave play`}</CodeBlock>
@@ -54,10 +54,10 @@ export default function Clients() {
           start</code> and choose <strong>play</strong> — same TUI, same stack.
         </p>
         <p className="text-muted">
-          For audio it wants <code className="bs-code-inline">mpv</code> (preferred &mdash; it
-          allows live volume control) or <code className="bs-code-inline">ffplay</code>; with
+          For audio it wants <code className="bs-code-inline">mpv</code> (preferred, for live
+          volume control) or <code className="bs-code-inline">ffplay</code>; with
           neither installed the TUI still runs as a read-only dashboard. The same console also
-          opens the web player and admin in your browser &mdash;{' '}
+          opens the web player and admin in your browser, and{' '}
           <Link href="/manual/cli" className="bs-link">The Operator CLI</Link> covers all of
           it.
         </p>
@@ -68,7 +68,7 @@ export default function Clients() {
         <h2>The app on your phone.</h2>
         <p>
           SUB/WAVE has native players for iOS and Android. Like the TUI, they mirror the
-          browser player rather than just carrying the audio &mdash; now-playing with cover
+          browser player rather than just carrying the audio: now-playing with cover
           art and a live visualiser, the booth feed, the timeline, a request form, the
           schedule, and station themes that recolour the whole app. Playback keeps going in
           the background, with controls on the lock screen, your headphones, CarPlay, and
@@ -76,13 +76,13 @@ export default function Clients() {
         </p>
         <p>
           They open on the public station, and you can add any other SUB/WAVE station by its
-          address &mdash; the same <code className="bs-code-inline">/stream.mp3</code> domain
+          address: the same <code className="bs-code-inline">/stream.mp3</code> domain
           the apps below use, typed in once and saved.
         </p>
         <p className="text-muted">
-          The apps are in public beta while they work through the stores. On iOS, join over
-          TestFlight (install the TestFlight app first); on Android, tap the link to install
-          the APK directly &mdash; no account, no Play Store:
+          Android is live on Google Play: install it like any other app, and it
+          auto-updates from then on. iOS is in public beta over TestFlight while it works
+          through the App Store (install the TestFlight app first):
         </p>
         <table className="bs-doc-table">
           <thead>
@@ -93,6 +93,19 @@ export default function Clients() {
           </thead>
           <tbody>
             <tr>
+              <td><strong>Android</strong></td>
+              <td>
+                <a
+                  href="https://play.google.com/store/apps/details?id=com.getsubwave.app"
+                  className="bs-link"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Google Play ↗
+                </a>
+              </td>
+            </tr>
+            <tr>
               <td><strong>iOS</strong></td>
               <td>
                 <a
@@ -102,32 +115,17 @@ export default function Clients() {
                   rel="noreferrer"
                 >
                   TestFlight ↗
-                </a>
-              </td>
-            </tr>
-            <tr>
-              <td><strong>Android</strong></td>
-              <td>
-                <a
-                  href="https://expo.dev/accounts/pinku1/projects/subwave/builds/8bc3116d-c9b0-4a32-87b9-747640270b23"
-                  className="bs-link"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Install APK ↗
                 </a>{' '}
-                (approve the one-time &ldquo;unknown sources&rdquo; prompt)
+                (public beta)
               </td>
             </tr>
           </tbody>
         </table>
         <div className="bs-callout">
-          <div className="bs-eyebrow">APP STORE &amp; PLAY STORE</div>
+          <div className="bs-eyebrow">APP STORE</div>
           <p>
-            Coming once the betas settle. Until then the links above are the way in &mdash;
-            the Android build installs straight from the link (you&rsquo;ll approve a
-            one-time &ldquo;install from unknown sources&rdquo; prompt), and iOS goes through
-            TestFlight.
+            Android is on Google Play now; the iOS App Store listing follows once the
+            TestFlight beta settles. Until then, TestFlight is the way in on iPhone and iPad.
           </p>
         </div>
       </section>
@@ -138,12 +136,12 @@ export default function Clients() {
         <p>
           Every external player asks for the same thing: the address of the stream. For
           this station it is <code className="bs-code-inline">/stream.mp3</code> on the
-          station&rsquo;s own domain &mdash;
+          station&rsquo;s own domain:
         </p>
         <StreamUrl />
         <p className="text-muted">
           Paste that into any of the apps below. It is a live broadcast, so there is no
-          pause and no seek &mdash; closing the app and reopening it drops you back
+          pause and no seek. Closing the app and reopening it drops you back
           wherever the station is <em>now</em>, not where you left off.
         </p>
         <div className="bs-callout">
@@ -163,10 +161,10 @@ export default function Clients() {
         <p className="bs-eyebrow">VLC</p>
         <h2>VLC, on every screen you own.</h2>
         <p>
-          VLC is the most reliable way to tune in outside the browser &mdash; the safe
-          first choice. It runs on every desktop and mobile platform, opens the stream
-          from a single URL, and buffers generously enough that a shaky connection rarely
-          interrupts the broadcast. It is free and open-source: desktop builds come from{' '}
+          VLC is the steadiest way to tune in outside the browser. It runs on every desktop
+          and mobile platform, opens the stream from a single URL, and buffers generously
+          enough that a shaky connection rarely interrupts the broadcast. It is free and
+          open-source: desktop builds come from{' '}
           <a
             href="https://www.videolan.org/vlc/"
             className="bs-link"
@@ -200,7 +198,7 @@ export default function Clients() {
         </table>
         <p>
           Once it is playing, VLC shows the live track and artist from the stream&rsquo;s
-          metadata &mdash; the same now-playing info the browser player displays. On
+          metadata, the same now-playing info the browser player displays. On
           desktop you can drag the stream into the Playlist and save it as an{' '}
           <code className="bs-code-inline">.m3u</code> for one-click tuning later; on
           mobile it stays in VLC&rsquo;s history under the Network tab.
@@ -222,8 +220,8 @@ export default function Clients() {
         <p className="bs-eyebrow">CLIAMP</p>
         <h2>SUB/WAVE in your terminal.</h2>
         <p>
-          cliamp is a terminal music player with built-in internet-radio support &mdash;
-          point it at the stream URL and the broadcast plays straight in your shell, no
+          cliamp is a terminal music player with built-in internet-radio support. Point it
+          at the stream URL and the broadcast plays straight in your shell, no
           browser and no window. It is an open-source Go program; grab a release binary
           from{' '}
           <a
@@ -238,7 +236,7 @@ export default function Clients() {
         </p>
         <CodeBlock>{`go install github.com/bjarneo/cliamp@latest`}</CodeBlock>
         <p className="text-muted">
-          On Linux you also want the ALSA bridge for your audio server &mdash;{' '}
+          On Linux you also want the ALSA bridge for your audio server:{' '}
           <code className="bs-code-inline">pipewire-alsa</code> or{' '}
           <code className="bs-code-inline">pulseaudio-alsa</code>. The MP3 mount plays
           natively in cliamp with no <code className="bs-code-inline">ffmpeg</code>{' '}
@@ -249,7 +247,7 @@ export default function Clients() {
         <StreamUrl prefix="cliamp " />
         <p>
           cliamp shows <code className="bs-code-inline">● Streaming</code> with a
-          non-interactive seek bar &mdash; expected, since SUB/WAVE is a live broadcast.
+          non-interactive seek bar, which is expected since SUB/WAVE is a live broadcast.
           Press <kbd className="bs-kbd">u</kbd> to load a different stream, or{' '}
           <kbd className="bs-kbd">R</kbd> to browse cliamp&rsquo;s own radio directory.
         </p>
@@ -259,7 +257,7 @@ export default function Clients() {
             Public SUB/WAVE stations sit behind Cloudflare, which serves the stream over
             HTTP/2 in bursts. Browsers and VLC paper over that with deep buffers; a lean
             command-line player like cliamp can underrun between bursts and show{' '}
-            <em>buffering</em>. The stream itself is fine &mdash; ask the station operator
+            <em>buffering</em>. The stream itself is fine. Ask the station operator
             for a direct address that skips Cloudflare (a LAN or Tailscale URL on the
             Caddy port, usually <code className="bs-code-inline">:7700</code>), which
             serves a steady HTTP/1.1 stream.
@@ -280,7 +278,7 @@ export default function Clients() {
         <h2>Any internet-radio player works.</h2>
         <p>
           The SUB/WAVE TUI is the full-featured way in; VLC and cliamp are the walked-through
-          audio-only examples &mdash; but none of them are special. Anything that can open an
+          audio-only examples. But none of them are special: anything that can open an
           internet-radio URL can tune in, and more client guides will be added here over time.
           Running the station yourself rather than listening along? That&rsquo;s covered in{' '}
           <Link href="/setup" className="bs-link">the setup guide</Link>.

--- a/web/components/manual/CustomSkills.tsx
+++ b/web/components/manual/CustomSkills.tsx
@@ -6,7 +6,7 @@ export default function CustomSkills() {
     <ManualPage
       eyebrow="MANUAL · 06"
       title="Custom skills."
-      intro="The things the DJ does between tracks — a weather check, a headline, a traffic gag — are skills. Seven ship built in, and you can edit any of them or add your own by dropping a folder into state/skills, no code changes to the station."
+      intro="The things the DJ does between tracks (a weather check, a headline, a traffic gag) are skills. Seven ship built in, and you can edit any of them or add your own by dropping a folder into state/skills, no code changes to the station."
       current="/manual/skills"
     >
       <section className="bs-section">
@@ -19,8 +19,8 @@ export default function CustomSkills() {
           <a href="https://github.com/anthropics/skills" target="_blank" rel="noreferrer">
             Anthropic&rsquo;s skills
           </a>{' '}
-          — a <code className="bs-code-inline">SKILL.md</code> with YAML frontmatter and a
-          markdown body, plus optional code — but the meaning is narrower. These don&rsquo;t
+          (a <code className="bs-code-inline">SKILL.md</code> with YAML frontmatter and a
+          markdown body, plus optional code), but the meaning is narrower. These don&rsquo;t
           process documents or run tasks; they decide what the DJ says next.
         </p>
       </section>
@@ -51,7 +51,7 @@ export default function CustomSkills() {
         <h2>Frontmatter, then the brief.</h2>
         <p>
           The frontmatter sets the skill&rsquo;s metadata; the markdown body <em>is</em> the
-          brief the DJ follows — what to say, in what tone, and when to stay silent. Only a
+          brief the DJ follows: what to say, in what tone, and when to stay silent. Only a
           non-empty body is required; every key has a sensible default.
         </p>
         <CodeBlock>{`---
@@ -66,9 +66,9 @@ line, the way a late-night presenter might glance out the window. Skip it when
 the phase is unremarkable.`}</CodeBlock>
         <p className="text-muted">
           For a <em>new</em> skill the <code className="bs-code-inline">name</code> must be a
-          lowercase slug that isn&rsquo;t a built-in kind — naming a folder after a built-in
-          <em>edits</em> that one instead (see below). Bad frontmatter is logged and skipped
-          — it never crashes the station.
+          lowercase slug that isn&rsquo;t a built-in kind; naming a folder after a built-in
+          <em>edits</em> that one instead (see below). Bad frontmatter is logged and
+          skipped, and never crashes the station.
         </p>
       </section>
 
@@ -82,14 +82,14 @@ the phase is unremarkable.`}</CodeBlock>
           time the station boots. Editing one (on the admin <strong>Skills</strong> page, or
           the file directly) overrides its brief, cooldown, or label in place. A built-in
           file may leave the body empty to keep the default wording, and never loads a{' '}
-          <code className="bs-code-inline">tool.mjs</code> — the built-ins already have their
+          <code className="bs-code-inline">tool.mjs</code>; the built-ins already have their
           data wired in.
         </p>
         <p>
           The big one: <strong>News reads the BBC by default</strong>. Hit{' '}
-          <strong>Edit</strong> on the News skill, paste your own RSS feed (any RSS 2.0 feed
-          — Atom isn&rsquo;t supported yet) and rewrite the brief in your station&rsquo;s
-          voice, then Save — it&rsquo;s live on the next break, no restart.
+          <strong>Edit</strong> on the News skill, paste your own RSS feed (any RSS 2.0 feed,
+          though not Atom yet) and rewrite the brief in your station&rsquo;s
+          voice, then Save. It&rsquo;s live on the next break, no restart.
         </p>
         <CodeBlock>{`---
 name: news
@@ -112,7 +112,7 @@ not a newsreader's. Skip anything dull or stale; silence is fine.`}</CodeBlock>
         <h2>Let the DJ look before it speaks.</h2>
         <p>
           With a <code className="bs-code-inline">tool.mjs</code>, the DJ can fetch live data
-          before deciding whether to air the line — the same mechanism the built-in weather
+          before deciding whether to air the line, the same mechanism the built-in weather
           and news skills use. Export a default function; return any JSON, and use{' '}
           <code className="bs-code-inline">{`{ available: false }`}</code> to tell the DJ
           there&rsquo;s nothing worth airing.
@@ -124,14 +124,14 @@ not a newsreader's. Skip anything dull or stale; silence is fine.`}</CodeBlock>
 }`}</CodeBlock>
         <p>
           The call is timeout-guarded and any error degrades cleanly to &ldquo;no
-          data&rdquo; — a slow or broken skill can never hang the station. With no{' '}
+          data&rdquo;; a slow or broken skill can never hang the station. With no{' '}
           <code className="bs-code-inline">tool.mjs</code>, the skill writes from its brief
           alone (like the built-in traffic gag).
         </p>
         <div className="bs-callout">
           <div className="bs-eyebrow">IT RUNS YOUR CODE</div>
           <p>
-            <code className="bs-code-inline">tool.mjs</code> executes inside the controller —
+            <code className="bs-code-inline">tool.mjs</code> executes inside the controller,
             the same trust model as installing a local tool. Only drop in code you&rsquo;ve
             read and trust.
           </p>
@@ -143,12 +143,12 @@ not a newsreader's. Skip anything dull or stale; silence is fine.`}</CodeBlock>
         <h2>Discovered, then enabled by you.</h2>
         <p>
           A freshly dropped skill appears on the admin <strong>Skills</strong> page toggled{' '}
-          <strong>off</strong>. It can&rsquo;t air — by itself or via the DJ — until you
+          <strong>off</strong>. It can&rsquo;t air (by itself or via the DJ) until you
           enable it there. Dropping a folder never puts unreviewed content (or code) on air.
         </p>
         <p>
           Skills load at boot, and on demand via the <strong>Rescan state/skills</strong>{' '}
-          button on that page — which picks up new folders and edits to{' '}
+          button on that page, which picks up new folders and edits to{' '}
           <code className="bs-code-inline">SKILL.md</code> /{' '}
           <code className="bs-code-inline">tool.mjs</code> without a restart. Like the
           built-ins, a custom skill only fires autonomously when it&rsquo;s enabled{' '}

--- a/web/components/manual/Faq.tsx
+++ b/web/components/manual/Faq.tsx
@@ -13,7 +13,7 @@ export default function Faq() {
         <p className="bs-eyebrow">AN EMPTY ROOM</p>
         <h2>What happens when no one is listening?</h2>
         <p>
-          By default, nothing changes — the station broadcasts the same whether anyone is
+          By default, nothing changes: the station broadcasts the same whether anyone is
           tuned in or not. But there is an optional setting,{' '}
           <strong>Pause when empty</strong>, that changes this. With it on, the moment the
           listener count hits zero the DJ stops doing AI work: no track-picking, no spoken
@@ -29,7 +29,7 @@ export default function Faq() {
         <p className="bs-eyebrow">MODEST HARDWARE</p>
         <h2>Does it work with a small model?</h2>
         <p>
-          Yes. The AI DJ doesn&rsquo;t need a frontier model — a modest one running on
+          Yes. The AI DJ doesn&rsquo;t need a frontier model; a modest one running on
           your own hardware is plenty. A 9B-class local model such as Qwen3.5 9B
           comfortably picks tracks and writes the DJ&rsquo;s lines, as long as you run the
           station on its <em>lean</em> settings: reasoning off, the simpler track-picker,
@@ -42,12 +42,12 @@ export default function Faq() {
         <p className="bs-eyebrow">A TAGGED LIBRARY</p>
         <h2>What is mood tagging?</h2>
         <p>
-          Every track in the library can carry a <em>mood</em> — a label like calm,
+          Every track in the library can carry a <em>mood</em>: a label like calm,
           energetic or reflective. The station tags the library in the background, and the
           DJ leans on those tags to pick music that fits the moment: the time of day, the
           weather, the show that is on. A well-tagged library gives the DJ a far richer
           palette to choose from. You can watch the tagger&rsquo;s progress on the Library
-          page in the admin console. Untagged tracks still play — they just don&rsquo;t
+          page in the admin console. Untagged tracks still play; they just don&rsquo;t
           get matched by feel.
         </p>
       </section>
@@ -58,7 +58,7 @@ export default function Faq() {
         <p>
           These are two helper skills bundled with the project for whoever runs the
           station, used through Claude Code. <strong>subwave-deploy</strong> handles
-          installing and updating — a first-time setup from a fresh checkout, or pulling
+          installing and updating: a first-time setup from a fresh checkout, or pulling
           the latest code and rebuilding only the parts that actually changed.{' '}
           <strong>subwave-control</strong> is lighter: it simply starts or stops the
           station in development or production mode, with no builds. Day to day you reach
@@ -74,18 +74,18 @@ export default function Faq() {
         <p>
           They are two ways the DJ chooses what to play next. The{' '}
           <strong>candidate pool</strong> picker is the straightforward one: it gathers a
-          shortlist of tracks from your library — similar songs, similar artists, mood
-          matches, recently-added and frequently-played albums — caps it to a couple of
+          shortlist of tracks from your library (similar songs, similar artists, mood
+          matches, recently-added and frequently-played albums), caps it to a couple of
           dozen, and asks the model to pick one from that list.
         </p>
         <p>
           The <strong>agentic picker</strong> is the richer one. It runs as a small
           reasoning loop with a memory of the current session and tools to search the
-          library itself, so its choices — and the links between them — stay coherent
+          library itself, so its choices (and the links between them) stay coherent
           across a run rather than starting cold each time. It is on by default; if it
           ever fails or runs slow, the station quietly falls back to the candidate pool,
           so the music never stops either way. Which one suits you comes down to the
-          model — see <Link href="/manual/llm" className="bs-link">Models &amp; Tokens</Link>.
+          model; see <Link href="/manual/llm" className="bs-link">Models &amp; Tokens</Link>.
         </p>
       </section>
 
@@ -94,7 +94,7 @@ export default function Faq() {
         <h2>Why is there a debug page?</h2>
         <p>
           The admin console&rsquo;s Debug page is a live snapshot of the station&rsquo;s
-          inner workings — the most recent AI calls and whether they succeeded, the audio
+          inner workings: the most recent AI calls and whether they succeeded, the audio
           mixer&rsquo;s status, and the latest log lines. You don&rsquo;t need it day to
           day, but it is the first place to look when something is off: the stream stalls,
           the DJ goes quiet, or a voice sounds wrong. It turns a vague
@@ -105,7 +105,7 @@ export default function Faq() {
           For a deeper look there is also <strong>subwave-log-analysis</strong>, a bundled
           skill used through Claude Code. Where the Debug page shows the live moment, this
           reads the station&rsquo;s full event log over time and reports back on how it
-          has been behaving — how often it calls the music library, why the picker keeps
+          has been behaving: how often it calls the music library, why the picker keeps
           favouring certain artists, whether the library pool is too narrow, and any
           runtime anomalies. It is the tool for &ldquo;the station works, but something
           feels off&rdquo; rather than an outright break.

--- a/web/components/manual/GettingStarted.tsx
+++ b/web/components/manual/GettingStarted.tsx
@@ -29,8 +29,8 @@ export default function GettingStarted() {
         <p className="bs-eyebrow">THE PLAYER</p>
         <h2>What you're looking at.</h2>
         <p>
-          The player shows the track that's playing right now — title, artist, and cover
-          art — with a waveform for the transport. Three panels slide out for the rest:
+          The player shows the track that's playing right now (title, artist, and cover
+          art) with a waveform for the transport. Three panels slide out for the rest:
         </p>
         <ul className="bs-list">
           <li>
@@ -55,7 +55,7 @@ export default function GettingStarted() {
         <p className="bs-eyebrow">NO SKIP — ON PURPOSE</p>
         <h2>There is no skip button.</h2>
         <p>
-          A track ends when it ends. SUB/WAVE has no <code className="bs-code-inline">/skip</code> —
+          A track ends when it ends. SUB/WAVE has no <code className="bs-code-inline">/skip</code>:
           the only natural transition is track-end, and the mixer controls pacing. Skip is
           deliberately left off the lock-screen and headphone controls too, so a stray
           double-tap on your earbuds can't cut the song short for every other listener.
@@ -69,7 +69,7 @@ export default function GettingStarted() {
           SUB/WAVE is an installable web app. Use your browser's &ldquo;Add to Home
           Screen&rdquo; / &ldquo;Install&rdquo; option and it runs like a native app, with
           its own icon. Once installed, your phone's lock screen, headphone buttons, and
-          car display can all start and stop the stream — with the cover art of whatever
+          car display can all start and stop the stream, with the cover art of whatever
           is currently on the air.
         </p>
       </section>

--- a/web/components/manual/HowTheDjWorks.tsx
+++ b/web/components/manual/HowTheDjWorks.tsx
@@ -26,7 +26,7 @@ export default function HowTheDjWorks() {
         <p className="bs-eyebrow">THE VOICES</p>
         <h2>Personas, picked at random.</h2>
         <p>
-          The operator gives the DJ one to ten <em>souls</em> — distinct personas, each
+          The operator gives the DJ one to ten <em>souls</em>: distinct personas, each
           with its own name and character. Before each spoken moment the station picks one
           at random, so the voice on air shifts through the day rather than reading from a
           single script. Each line is generated fresh; the DJ doesn't repeat itself.
@@ -83,14 +83,14 @@ export default function HowTheDjWorks() {
         </ul>
         <p>
           You don't have to commit to one. The operator can assign a different engine{' '}
-          <em>per kind</em> of segment — say a rich cloud voice for station IDs, but a
-          fast local voice for routine time checks — with everything else falling through
+          <em>per kind</em> of segment (a rich cloud voice for station IDs, say, but a
+          fast local voice for routine time checks), with everything else falling through
           to a default engine.
         </p>
         <div className="bs-callout">
           <div className="bs-eyebrow">THE DJ NEVER GOES SILENT</div>
           <p>
-            If a voice ever fails — a cloud outage, a model that isn't installed — the
+            If a voice ever fails (a cloud outage, a model that isn't installed), the
             station drops to a local engine automatically. Piper is always there as the
             last resort, so a spoken segment is never lost to a missing voice.
           </p>
@@ -123,7 +123,7 @@ docker compose up -d`}</CodeBlock>
             PocketTTS), drop a short reference WAV into{' '}
             <code className="bs-code-inline">state/voices/</code>{' '}
             (legacy <code className="bs-code-inline">state/chatterbox-voices/</code> is
-            still read) and pick it on the Personas page — without one, both engines
+            still read) and pick it on the Personas page; without one, both engines
             use their built-in default voice. PocketTTS also exposes a curated set of
             built-in voice ids (<code className="bs-code-inline">alba</code>,{' '}
             <code className="bs-code-inline">anna</code>,{' '}
@@ -136,7 +136,7 @@ docker compose up -d`}</CodeBlock>
             <code className="bs-code-inline">--build-arg WITH_CHATTERBOX=1</code> /{' '}
             <code className="bs-code-inline">WITH_POCKETTTS=1</code> paths in{' '}
             <code className="bs-code-inline">docker/Dockerfile.controller</code> still
-            work — they bundle the engines inside the controller image instead. The
+            work; they bundle the engines inside the controller image instead. The
             sidecar is the recommended path for fresh installs.
           </p>
         </div>
@@ -153,7 +153,7 @@ docker compose up -d`}</CodeBlock>
         </p>
         <p>
           How chatty the station is depends on a <strong>frequency</strong> setting the
-          operator chooses — <em>quiet</em>, <em>moderate</em>, or <em>aggressive</em>. A
+          operator chooses: <em>quiet</em>, <em>moderate</em>, or <em>aggressive</em>. A
           quiet station checks the time every couple of hours and drops the occasional
           ID; an aggressive one gives you full idents and weather updates through the hour.
         </p>
@@ -163,7 +163,7 @@ docker compose up -d`}</CodeBlock>
         <p className="bs-eyebrow">SHOWS &amp; SESSIONS</p>
         <h2>It keeps a thread going.</h2>
         <p>
-          The DJ runs in <em>sessions</em> — a continuous block with a memory of what it's
+          The DJ runs in <em>sessions</em>: a continuous block with a memory of what it's
           already played and said, so its links stay coherent instead of starting cold
           each time. A session can be a scheduled <strong>show</strong> the operator paints
           onto a weekly grid, or an autonomous block keyed to the time of day and the

--- a/web/components/manual/ModelsAndTokens.tsx
+++ b/web/components/manual/ModelsAndTokens.tsx
@@ -6,7 +6,7 @@ export default function ModelsAndTokens() {
     <ManualPage
       eyebrow="MANUAL · 10"
       title="Models & tokens."
-      intro="The AI DJ can run on a small model on your own hardware or a large hosted one — and a handful of settings let you tune the station for whichever you've picked, trading richness against cost."
+      intro="The AI DJ can run on a small model on your own hardware or a large hosted one, and a handful of settings let you tune the station for whichever you've picked, trading richness against cost."
       current="/manual/llm"
     >
       <section className="bs-section">
@@ -15,14 +15,14 @@ export default function ModelsAndTokens() {
         <p>
           Every word the DJ speaks and every track it picks comes from one language
           model, chosen under <strong>Admin &rarr; LLM</strong>. The default is Ollama on
-          your own hardware — no API key, no per-token bill — but you can point the
+          your own hardware (no API key, no per-token bill), but you can point the
           station at a hosted provider (Anthropic, OpenAI, Google and others) instead.
           Switching reroutes every call immediately, with no redeploy.
         </p>
         <p>
           Big hosted models are more capable but cost money per token; small local models
           are free to run but need a lighter workload to stay coherent. The settings
-          below let you match the station to the model — run it <em>lean</em> for a small
+          below let you match the station to the model: run it <em>lean</em> for a small
           or metered model, or <em>rich</em> for a large capable one.
         </p>
       </section>
@@ -37,7 +37,7 @@ export default function ModelsAndTokens() {
         </p>
         <p>
           With these settings in place, a small model runs the whole station
-          comfortably — a 9B-class local model such as{' '}
+          comfortably: a 9B-class local model such as{' '}
           <strong>Qwen3.5 9B</strong> is plenty for picking tracks and writing the DJ's
           lines. The lean profile keeps each request short and well-shaped, which is
           exactly what a smaller model needs to stay reliable.
@@ -88,7 +88,7 @@ export default function ModelsAndTokens() {
         <p className="bs-eyebrow">RUNNING RICH</p>
         <h2>For large, capable models.</h2>
         <p>
-          On a large hosted model the same dials go the other way — spend the capability
+          On a large hosted model the same dials go the other way: spend the capability
           on a station with more personality and a smarter DJ.
         </p>
         <ul className="bs-list">
@@ -118,7 +118,7 @@ export default function ModelsAndTokens() {
         <div className="bs-eyebrow">THE DJ NEVER GOES SILENT</div>
         <p>
           The picker agent has a built-in safety net: if it ever fails or runs too slow,
-          the station quietly falls back to the simple pool picker for that track — the
+          the station quietly falls back to the simple pool picker for that track, the
           same path you'd get with the agent switched off. Turning it off just makes that
           lighter path the default rather than the exception.
         </p>
@@ -128,7 +128,7 @@ export default function ModelsAndTokens() {
         <p className="bs-eyebrow">WHERE TO SET THEM</p>
         <h2>All of this lives in the console.</h2>
         <p>
-          Every setting here is in the admin console and takes effect without a redeploy —
+          Every setting here is in the admin console and takes effect without a redeploy;
           most apply to the next thing the DJ does. The full tour of the console is in{' '}
           <Link href="/manual/admin" className="bs-link">Admin &amp; Settings</Link>; how
           the DJ actually picks and talks is in{' '}

--- a/web/components/manual/OperatorCli.tsx
+++ b/web/components/manual/OperatorCli.tsx
@@ -7,7 +7,7 @@ export default function OperatorCli() {
     <ManualPage
       eyebrow="MANUAL · 09"
       title="The operator console."
-      intro="SUB/WAVE ships a command-line console for running the station. One command opens a menu that boots the stack, checks its health, tails logs, and opens a terminal player — no Docker flags to remember."
+      intro="SUB/WAVE ships a command-line console for running the station. One command opens a menu that boots the stack, checks its health, tails logs, and opens a terminal player, with no Docker flags to remember."
       current="/manual/cli"
     >
       <section className="bs-section">
@@ -21,12 +21,12 @@ export default function OperatorCli() {
         <p className="text-muted">
           First time through? If there&rsquo;s no{' '}
           <code className="bs-code-inline">.env</code> yet, the console drops you
-          straight into the install wizard — the same one the{' '}
+          straight into the install wizard, the same one the{' '}
           <Link href="/setup" className="bs-link">setup guide</Link> walks through.
         </p>
         <p className="text-muted">
           Working from a cloned repo instead of the standalone CLI? Run{' '}
-          <code className="bs-code-inline">npm start</code> — it opens the same console.
+          <code className="bs-code-inline">npm start</code>; it opens the same console.
         </p>
       </section>
 
@@ -54,7 +54,7 @@ export default function OperatorCli() {
           </li>
           <li>
             <strong>restart</strong> — rebuild and recreate a single service. The console
-            knows the controller and Liquidsoap need a rebuild — not a plain restart — for
+            knows the controller and Liquidsoap need a rebuild (not a plain restart) for
             source changes to take.
           </li>
           <li>
@@ -92,7 +92,7 @@ export default function OperatorCli() {
         <p className="bs-eyebrow">PLAYER &amp; CONSOLES</p>
         <h2>Jump straight to the player or the admin.</h2>
         <p>
-          The <strong>play</strong> option launches the SUB/WAVE TUI — now-playing, the
+          The <strong>play</strong> option launches the SUB/WAVE TUI: now-playing, the
           timeline, the live booth feed, and a request form, all in your terminal and pointed
           at your own stack. It&rsquo;s the full station experience without a browser. The{' '}
           <Link href="/manual/clients" className="bs-link">Listen With</Link> page covers the
@@ -100,8 +100,8 @@ export default function OperatorCli() {
         </p>
         <p>
           Prefer the browser? <strong>listen</strong> and <strong>admin</strong> open the web
-          player and the admin console in your default browser, pointed at the same stack — no
-          host or port to remember.
+          player and the admin console in your default browser, pointed at the same stack, with
+          no host or port to remember.
         </p>
       </section>
 
@@ -109,8 +109,8 @@ export default function OperatorCli() {
         <p className="bs-eyebrow">SCRIPTING IT</p>
         <h2>Every action runs without the menu too.</h2>
         <p>
-          The menu is for hands-on operating. To skip it — for a deploy script, a cron job, or
-          just speed — name the action straight after{' '}
+          The menu is for hands-on operating. To skip it (for a deploy script, a cron job, or
+          just speed), name the action straight after{' '}
           <code className="bs-code-inline">subwave</code>:
         </p>
         <CodeBlock>{`subwave status
@@ -118,7 +118,7 @@ subwave doctor
 subwave logs controller
 subwave restart controller`}</CodeBlock>
         <p className="text-muted">
-          Same actions, same output — just without the interactive menu wrapped around them.
+          Same actions, same output, just without the interactive menu wrapped around them.
           From a cloned repo, the same actions run after{' '}
           <code className="bs-code-inline">npm start --</code> (e.g.{' '}
           <code className="bs-code-inline">npm start -- status</code>).

--- a/web/components/manual/Overview.tsx
+++ b/web/components/manual/Overview.tsx
@@ -69,7 +69,7 @@ export default function Overview() {
     <ManualPage
       eyebrow="SUB/WAVE MANUAL"
       title="How to use SUB/WAVE."
-      intro="SUB/WAVE is a personal internet radio station — one live stream that every listener hears at the same moment, with an AI DJ picking the tracks and talking between them. This manual covers both sides of the dial: tuning in as a listener, and running the station as its operator."
+      intro="SUB/WAVE is a personal internet radio station: one live stream that every listener hears at the same moment, with an AI DJ picking the tracks and talking between them. This manual covers both sides of the dial: tuning in as a listener, and running the station as its operator."
       current="/manual"
     >
       <section className="bs-section">
@@ -96,7 +96,7 @@ export default function Overview() {
         <p className="bs-eyebrow">THE ONE THING TO KNOW</p>
         <h2>It's a broadcast, not a playlist.</h2>
         <p>
-          Streaming apps give everyone a private channel — shuffled for you, paused the
+          Streaming apps give everyone a private channel: shuffled for you, paused the
           second you look away. SUB/WAVE goes the other way. There is one Icecast stream,
           and everyone hears whatever is on the air <em>right now</em>. There is no
           &ldquo;for you,&rdquo; and there is no skip button. You can ask for a song, but

--- a/web/components/manual/Requests.tsx
+++ b/web/components/manual/Requests.tsx
@@ -13,7 +13,7 @@ export default function Requests() {
         <h2>Open &ldquo;Make a request.&rdquo;</h2>
         <p>
           In the player, open the <strong>Make a request</strong> panel. Type what you
-          want and, if you like, your name — so the DJ can give you a shout-out. You don't
+          want and, if you like, your name, so the DJ can give you a shout-out. You don't
           have to be precise: a song title, an artist, or a mood all work.
         </p>
         <ul className="bs-list">
@@ -34,7 +34,7 @@ export default function Requests() {
           to play when the current song finishes.
         </p>
         <p>
-          If nothing in the library fits, the DJ won't force it — you may get a different
+          If nothing in the library fits, the DJ won't force it; you may get a different
           take on the mood you asked for instead. The station only plays what's actually
           in its collection.
         </p>
@@ -52,7 +52,7 @@ export default function Requests() {
         <div className="bs-callout">
           <div className="bs-eyebrow">A FEW TIPS</div>
           <p>
-            Be specific when you have a specific song in mind, and loose when you don't —
+            Be specific when you have a specific song in mind, and loose when you don't;
             the DJ handles both. Watch <strong>the booth</strong> panel to catch your
             shout-out, and the <strong>Timeline</strong> to see your track land in the
             queue.

--- a/web/components/manual/Shortcuts.tsx
+++ b/web/components/manual/Shortcuts.tsx
@@ -68,14 +68,14 @@ export default function Shortcuts() {
         <h2>One menu for everything.</h2>
         <p>
           Press <kbd className="bs-kbd">⌘K</kbd> (or <kbd className="bs-kbd">Ctrl K</kbd>{' '}
-          on Windows and Linux) to open the <strong>command palette</strong> — a
+          on Windows and Linux) to open the <strong>command palette</strong>, a
           searchable list of every player action. Start typing to filter, use the arrow
           keys to move, and press Enter to run. It's the fastest way to reach something
           when you can't remember its key.
         </p>
         <p className="text-muted">
           The palette chord works even while you're typing in a text field, so you can
-          always summon it — and press it again, or <kbd className="bs-kbd">Esc</kbd>, to
+          always summon it; press it again, or <kbd className="bs-kbd">Esc</kbd>, to
           close it.
         </p>
       </section>
@@ -84,7 +84,7 @@ export default function Shortcuts() {
         <p className="bs-eyebrow">WHEN THEY'RE QUIET</p>
         <h2>Shortcuts step aside while you type.</h2>
         <p>
-          The single-key shortcuts are suppressed whenever a text field is focused — so
+          The single-key shortcuts are suppressed whenever a text field is focused, so
           typing <em>R</em> into the request box writes an <em>R</em> rather than opening
           a panel. They also pause while the command palette or the shortcuts dialog is
           open, since those windows handle the keyboard themselves.

--- a/web/components/manual/Themes.tsx
+++ b/web/components/manual/Themes.tsx
@@ -54,7 +54,7 @@ export default function Themes() {
         <p>
           A scheduled show can opt into a different theme for its hour. Open a show in
           admin → <strong>Shows</strong>, pick one from the <em>theme override</em>{' '}
-          dropdown, and the player switches to that palette while the show is on air —
+          dropdown, and the player switches to that palette while the show is on air,
           then back to the station default when the next hour starts.
         </p>
         <p>
@@ -73,12 +73,12 @@ export default function Themes() {
           (<code className="bs-code-inline">light</code> or <code className="bs-code-inline">dark</code>),
           and a token map. The controller creates{' '}
           <code className="bs-code-inline">state/themes/</code> on first read and seeds it
-          with a README — drop your JSONs alongside it.
+          with a README; drop your JSONs alongside it.
         </p>
         <CodeBlock>{EXAMPLE_THEME}</CodeBlock>
         <p>
           After saving the file, hit <strong>Refresh themes</strong> in admin → Settings
-          → Theme — that re-scans the directory and the new entry appears in the picker.
+          → Theme. That re-scans the directory, and the new entry appears in the picker.
           No mixer restart, no controller bounce.
         </p>
         <div className="bs-callout">
@@ -112,7 +112,7 @@ export default function Themes() {
           Any CSS colour value works: hex, <code className="bs-code-inline">rgb()</code>,{' '}
           <code className="bs-code-inline">oklch()</code>,{' '}
           <code className="bs-code-inline">color-mix()</code>. <code className="bs-code-inline">mode</code>{' '}
-          tells the rest of the stylesheet whether to treat the theme as light or dark —
+          tells the rest of the stylesheet whether to treat the theme as light or dark;
           it controls the paper-grain blend and the few shadcn rules that still key off{' '}
           <code className="bs-code-inline">data-theme</code>.
         </p>
@@ -124,7 +124,7 @@ export default function Themes() {
         <p>
           On every page load, a tiny pre-paint script reads the last-applied theme from
           the browser's localStorage and writes the seven variables onto{' '}
-          <code className="bs-code-inline">&lt;html&gt;</code> before the first frame — so
+          <code className="bs-code-inline">&lt;html&gt;</code> before the first frame, so
           listeners never see the default palette flash before yours arrives. The
           controller serves the live registry at{' '}
           <code className="bs-code-inline">/api/themes</code>; an app-wide bootstrapper

--- a/web/components/setup/Development.tsx
+++ b/web/components/setup/Development.tsx
@@ -55,11 +55,11 @@ export default function Development() {
         <div className="bs-cmd-list">
           <div className="bs-cmd">
             <CodeBlock>{`npm run setup`}</CodeBlock>
-            <p>Interactive wizard — writes envs, brings the stack up.</p>
+            <p>Interactive wizard: writes envs, brings the stack up.</p>
           </div>
           <div className="bs-cmd">
             <CodeBlock>{`npm run dev`}</CodeBlock>
-            <p>Alias for setup — same wizard.</p>
+            <p>Alias for setup; same wizard.</p>
           </div>
           <div className="bs-cmd">
             <CodeBlock>{`npm run dev:docker`}</CodeBlock>
@@ -137,7 +137,7 @@ export default function Development() {
             <code className="bs-code-inline">controller/src/**</code> restart the
             process inside the container automatically.{' '}
             <code className="bs-code-inline">liquidsoap/radio.liq</code> is bind-mounted
-            too — edits there need{' '}
+            too; edits there need{' '}
             <code className="bs-code-inline">docker compose -f docker-compose.dev.yml restart broadcast</code>{' '}
             but no rebuild.
           </p>
@@ -152,7 +152,7 @@ export default function Development() {
           </p>
           <p className="mt-2 text-muted">
             The web dev server (<code className="bs-code-inline">npm run dev:web</code>) is
-            its own thing — Next.js hot-reloads, so edits to{' '}
+            its own thing: Next.js hot-reloads, so edits to{' '}
             <code className="bs-code-inline">web/**</code> show up instantly without
             touching Docker.
           </p>

--- a/web/components/setup/ManualInstall.tsx
+++ b/web/components/setup/ManualInstall.tsx
@@ -16,7 +16,7 @@ export default function ManualInstall() {
     <SetupPage
       eyebrow="SETUP · 03"
       title="Run the commands yourself."
-      intro="The no-CLI alternative — same outcome, no `subwave` binary on your host. Useful if you'd rather not run an installer, are scripting the deploy, want a non-standard layout, or just prefer running each command by hand. These four steps land at a public-facing single-host deploy — Caddy on the edge, Cloudflare in front, internal-only Icecast, Controller, and Web."
+      intro="The no-CLI alternative: same outcome, no `subwave` binary on your host. Useful if you'd rather not run an installer, are scripting the deploy, want a non-standard layout, or just prefer running each command by hand. These four steps land at a public-facing single-host deploy: Caddy on the edge, Cloudflare in front, internal-only Icecast, Controller, and Web."
       current="/setup/manual"
     >
       <section className="bs-section">
@@ -29,7 +29,7 @@ export default function ManualInstall() {
             <code className="bs-code-inline">init</code> and{' '}
             <code className="bs-code-inline">start</code> behind two Enter
             prompts) followed by{' '}
-            <code className="bs-code-inline">subwave setup</code> — see{' '}
+            <code className="bs-code-inline">subwave setup</code>; see{' '}
             <Link href="/setup/quick-start">Quick Start</Link>. It uses the
             same compose images and writes to the same{' '}
             <code className="bs-code-inline">state/</code> layout; nothing is
@@ -60,7 +60,7 @@ $EDITOR .env`}</CodeBlock>
               <div className="bs-eyebrow">PREFER A CLONE?</div>
               <p>
                 Clone the repo and run{' '}
-                <code className="bs-code-inline">./scripts/setup.sh</code> — it scaffolds
+                <code className="bs-code-inline">./scripts/setup.sh</code>; it scaffolds
                 the same <code className="bs-code-inline">.env</code> + sets state-dir
                 perms. Or run <code className="bs-code-inline">npm run setup</code> for
                 an interactive terminal wizard that does the equivalent of the browser
@@ -110,7 +110,7 @@ $EDITOR .env`}</CodeBlock>
               <div className="bs-eyebrow">ALREADY RUNNING TRAEFIK OR NGINX?</div>
               <p>
                 Swap the compose file for{' '}
-                <code className="bs-code-inline">docker-compose.byo.yml</code> —
+                <code className="bs-code-inline">docker-compose.byo.yml</code>:
                 same stack minus the bundled Caddy, with web / controller / broadcast bound to{' '}
                 <code className="bs-code-inline">:7700</code> /{' '}
                 <code className="bs-code-inline">:7701</code> /{' '}
@@ -133,7 +133,7 @@ $EDITOR .env`}</CodeBlock>
               <p>
                 If you need separate hostnames per surface, rebuild the web image
                 with <code className="bs-code-inline">NEXT_PUBLIC_API_URL</code> and{' '}
-                <code className="bs-code-inline">NEXT_PUBLIC_STREAM_URL</code> set —
+                <code className="bs-code-inline">NEXT_PUBLIC_STREAM_URL</code> set;
                 those are baked at build time, not runtime.
               </p>
             </div>
@@ -167,7 +167,7 @@ $EDITOR .env`}</CodeBlock>
               <li><strong>TTS engine</strong> — Piper (default) and Kokoro both run inside
               the controller image. Cloud (OpenAI / ElevenLabs) just needs an API key.
               Chatterbox (voice cloning) and PocketTTS (multilingual) live in the optional{' '}
-              <code className="bs-code-inline">tts-heavy</code> sidecar — tick the
+              <code className="bs-code-inline">tts-heavy</code> sidecar: tick the
               &ldquo;Enable Chatterbox + PocketTTS&rdquo; box in the wizard, then start it
               with <code className="bs-code-inline">docker compose --profile tts-heavy up -d</code>{' '}
               (or set <code className="bs-code-inline">COMPOSE_PROFILES=tts-heavy</code> in{' '}
@@ -208,8 +208,8 @@ $EDITOR .env`}</CodeBlock>
             <div className="bs-callout">
               <div className="bs-eyebrow">DAY-TO-DAY OPERATOR CONSOLE</div>
               <p>
-                <code className="bs-code-inline">npm start</code> opens the operator console
-                — a menu for stack status, a diagnostic sweep, logs, restart, and the terminal
+                <code className="bs-code-inline">npm start</code> opens the operator console:
+                a menu for stack status, a diagnostic sweep, logs, restart, and the terminal
                 player. The everyday way to run the station once it's installed.
               </p>
             </div>

--- a/web/components/setup/Prerequisites.tsx
+++ b/web/components/setup/Prerequisites.tsx
@@ -6,7 +6,7 @@ export default function Prerequisites() {
     <SetupPage
       eyebrow="SETUP · 01"
       title="Have these ready."
-      intro="SUB/WAVE doesn't ship Navidrome or Ollama — it talks to yours. Get them running first if they aren't already, and note the URLs and credentials. The install wizard will ask for them."
+      intro="SUB/WAVE doesn't ship Navidrome or Ollama; it talks to yours. Get them running first if they aren't already, and note the URLs and credentials. The install wizard will ask for them."
       current="/setup/prerequisites"
     >
       <section className="bs-section">
@@ -17,16 +17,16 @@ export default function Prerequisites() {
             <strong>Docker on the host.</strong>
             <p>
               Docker Compose runs the stack (two containers in dev, four in
-              production — icecast and liquidsoap live together in a single{' '}
+              production; icecast and liquidsoap live together in a single{' '}
               <code className="bs-code-inline">broadcast</code> container). The
               standalone <code className="bs-code-inline">subwave</code> CLI is a
-              single Bun-compiled binary with no runtime dependency — no Node
+              single Bun-compiled binary with no runtime dependency; no Node
               needed unless you&apos;re hacking on the source (
               <Link href="/setup/development" className="bs-link">Development</Link>).
             </p>
           </li>
           <li>
-            <strong>Navidrome — or any Subsonic-API server.</strong>
+            <strong>Navidrome, or any Subsonic-API server.</strong>
             <p>
               SUB/WAVE plays from your library, reachable from wherever the stack
               runs. Note the URL, username, and password. The wizard asks for all

--- a/web/components/setup/QuickStart.tsx
+++ b/web/components/setup/QuickStart.tsx
@@ -26,11 +26,11 @@ export default function QuickStart() {
           <CodeBlock>{`curl -fsSL https://cli.getsubwave.com | sh`}</CodeBlock>
           <CodeBlock>{`subwave setup`}</CodeBlock>
           <p className="text-muted">
-            The installer prompts <em>Run subwave init now?</em> — say yes and{' '}
+            The installer prompts <em>Run subwave init now?</em> Say yes and{' '}
             <code className="bs-code-inline">init</code> asks where to install
             (default <code className="bs-code-inline">~/subwave</code>),
             deployment shape (prod / prod-byo), and admin credentials. It ends
-            with <em>Bring the stack up now?</em> — say yes again and{' '}
+            with <em>Bring the stack up now?</em> Say yes again and{' '}
             <code className="bs-code-inline">subwave start</code> runs silently
             against the env <code className="bs-code-inline">init</code> just
             picked. After that,{' '}
@@ -68,7 +68,7 @@ export default function QuickStart() {
               </li>
               <li>
                 state in <code className="bs-code-inline">./state</code> (or{' '}
-                <code className="bs-code-inline">STATE_DIR</code>) — re-run with sudo
+                <code className="bs-code-inline">STATE_DIR</code>); re-run with sudo
                 if it isn't writable
               </li>
             </ul>
@@ -77,7 +77,7 @@ export default function QuickStart() {
         <div className="bs-callout">
           <div className="bs-eyebrow">SAFE TO RE-RUN</div>
           <p>
-            Existing env values are kept unless you explicitly ask to reconfigure — so the
+            Existing env values are kept unless you explicitly ask to reconfigure, so the
             wizard doubles as a way to bring an existing stack back up.
           </p>
         </div>
@@ -87,7 +87,7 @@ export default function QuickStart() {
         <p className="bs-eyebrow">PATH B · AI CODING AGENT</p>
         <h2>One sentence in your coding agent.</h2>
         <p>
-          The repo ships an agent skill that handles setup, deploy, and update — it pings
+          The repo ships an agent skill that handles setup, deploy, and update: it pings
           Navidrome and Ollama, boots the stack, generates jingles, and verifies the stream is
           on-air. It works with <strong>Claude Code</strong>, <strong>Codex</strong>,{' '}
           <strong>Cursor</strong>, or anything else that reads{' '}
@@ -107,7 +107,7 @@ cd subwave`}</CodeBlock>
             On updates the same skill detects which services actually changed and rebuilds
             only those. Liquidsoap and the Controller <em>COPY</em> their source at build
             time, so a plain <code className="bs-code-inline">docker compose restart</code>{' '}
-            silently runs stale code — the skill won't make that mistake.
+            silently runs stale code; the skill won't make that mistake.
           </p>
         </div>
       </section>
@@ -117,15 +117,15 @@ cd subwave`}</CodeBlock>
         <h2>Run the station from the CLI.</h2>
         <p>
           The setup wizard is one screen of the operator console. Run{' '}
-          <code className="bs-code-inline">npm start</code> from the repo any time to open it
-          — a menu to check the stack, run a diagnostic sweep, tail logs, restart a service,
+          <code className="bs-code-inline">npm start</code> from the repo any time to open it:
+          a menu to check the stack, run a diagnostic sweep, tail logs, restart a service,
           or open the terminal player.
         </p>
         <CodeBlock>{`npm start`}</CodeBlock>
         <div className="bs-callout">
           <div className="bs-eyebrow">LISTEN FROM THE TERMINAL</div>
           <p>
-            The console's <strong>play</strong> option launches the TUI player — now-playing,
+            The console's <strong>play</strong> option launches the TUI player: now-playing,
             the timeline, the live booth feed, and track requests, right in your terminal. It
             needs <code className="bs-code-inline">mpv</code> or{' '}
             <code className="bs-code-inline">ffplay</code> for audio, and runs as a read-only

--- a/web/components/setup/SetupOverview.tsx
+++ b/web/components/setup/SetupOverview.tsx
@@ -26,7 +26,7 @@ export default function SetupOverview() {
       eyebrow="SELF-HOSTED · OPEN SOURCE"
       title="Run your own SUB/WAVE."
       meta="≈ 10 min · 4 commands · needs Navidrome + an LLM"
-      intro="SUB/WAVE points at your Navidrome library and your LLM — a local Ollama box by default, or any hosted provider you prefer. Once it's running, the AI DJ broadcasts from your homelab, plays from your music collection, and answers requests from anyone with the URL."
+      intro="SUB/WAVE points at your Navidrome library and your LLM: a local Ollama box by default, or any hosted provider you prefer. Once it's running, the AI DJ broadcasts from your homelab, plays from your music collection, and answers requests from anyone with the URL."
       current="/setup"
       heroAside={
         <div className="bs-dj-glyph" aria-hidden="true">
@@ -48,12 +48,12 @@ export default function SetupOverview() {
           <CodeBlock>{`subwave setup`}</CodeBlock>
           <p className="text-muted">
             The installer drops the <code className="bs-code-inline">subwave</code>{' '}
-            binary, then prompts <em>Run subwave init now?</em> — say yes and it
+            binary, then prompts <em>Run subwave init now?</em> Say yes and it
             walks the install dir (default{' '}
             <code className="bs-code-inline">~/subwave</code>), deployment shape
             (prod / prod-byo), and admin credentials.{' '}
             <code className="bs-code-inline">init</code> ends with{' '}
-            <em>Bring the stack up now?</em> — yes again brings up Docker. Then{' '}
+            <em>Bring the stack up now?</em> Yes again brings up Docker. Then{' '}
             <code className="bs-code-inline">setup</code> prompts for Navidrome
             and your LLM, persists everything, and renders the station jingles.{' '}
             <Link href="/setup/quick-start" className="bs-link">
@@ -63,7 +63,7 @@ export default function SetupOverview() {
           <p className="text-muted">
             After that,{' '}
             <code className="bs-code-inline">subwave status / logs / doctor / restart / update</code>{' '}
-            drive the station from anywhere on your shell — no{' '}
+            drive the station from anywhere on your shell, with no{' '}
             <code className="bs-code-inline">cd</code> into a project dir, no clone
             required. Prefer pure <code className="bs-code-inline">docker compose</code>?{' '}
             <Link href="/setup/manual" className="bs-link">Manual Install</Link>{' '}

--- a/web/components/setup/Updates.tsx
+++ b/web/components/setup/Updates.tsx
@@ -31,7 +31,7 @@ export default function Updates() {
         </table>
 
         <p className="mt-4">
-          Typical manual deploy — pull, rebuild only what changed (here, controller
+          Typical manual deploy: pull, rebuild only what changed (here, controller
           + web), then verify:
         </p>
         <CodeBlock>{`git pull --ff-only
@@ -68,7 +68,7 @@ docker compose up -d --build controller web
 docker compose up -d`}</CodeBlock>
           <p className="text-muted">
             Same flow if you&apos;re on{' '}
-            <code className="bs-code-inline">docker-compose.byo.yml</code> — just
+            <code className="bs-code-inline">docker-compose.byo.yml</code>, just
             swap the file flag.
           </p>
         </div>
@@ -113,8 +113,8 @@ docker compose up -d`}</CodeBlock>
             <strong>Source code</strong> —{' '}
             <a href="https://github.com/perminder-klair/subwave" target="_blank" rel="noreferrer" className="bs-link">
               github.com/perminder-klair/subwave ↗
-            </a>{' '}
-            — file an issue, or read the CLAUDE.md for architecture notes.
+            </a>
+            . File an issue, or read the CLAUDE.md for architecture notes.
           </li>
         </ul>
       </section>
@@ -124,7 +124,7 @@ docker compose up -d`}</CodeBlock>
         <h2>Now shape the DJ.</h2>
         <p>
           Installation is the start. Tuning the personas, scheduling shows, choosing the LLM
-          provider, and managing jingles all happen in the admin console — that's covered in{' '}
+          provider, and managing jingles all happen in the admin console; that's covered in{' '}
           <Link href="/manual/admin" className="bs-link">the manual's Admin &amp; Settings
           page</Link>.
         </p>

--- a/web/components/stations/StationMap.tsx
+++ b/web/components/stations/StationMap.tsx
@@ -119,7 +119,7 @@ export default function StationMap({ stations }: { stations: Station[] }) {
       </svg>
       {plotted.length === 0 ? (
         <figcaption className="bs-map-caption">
-          No stations plotted yet — add yours below.
+          No stations plotted yet. Add yours below.
         </figcaption>
       ) : null}
     </figure>

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -129,6 +129,7 @@ export default defineConfig([
             '^on$',
             '^box$',
             '^flash$',
+            '^indet$',
             '^pct$',
             '^h-tags$',
             '^h-album$',


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge with "Create a merge commit"** — not "Squash and merge". Squash collapses the individual `feat:` / `fix:` / `chore:` commits into one `release: …` commit, and release-please then sees no conventional-commit signal and skips the version bump. See the merge note below for the why.

## Summary

Full-stack batch (web admin + native app + docs + skills). The admin library page splits into a dedicated tagging panel with structured live tagger progress, and adds a CLAP capability warning plus a fix for the analyzer download hang. The native app gets a docked player bar across all screens with a slimmed live now-playing. Rounded out with a docs/copy refresh announcing the mobile apps and the new OTA-update skill. No migrations, env-var changes, or breaking changes.

**Features**
- \`8decd10\` feat(library): simplify tagging panel + structured live tagger progress (#363)
- \`f330155\` feat(app): dock player bar across all screens + slim live now-playing (#366)
- \`7afdf95\` feat(library): CLAP capability warning + fix analyzer download hang (#367)

**Documentation**
- \`60ddd5a\` docs(web): announce mobile apps live + copy cleanup (#364)

**Other**
- \`c718b80\` chore: harden node_modules gitignore to catch stray symlinks (#365)
- \`533a332\` chore(skills): add subwave-app-ota-update skill (#368)

## Test plan
- [x] Admin → Library shows the new tagging panel with live progress that updates as the tagger runs
- [x] CLAP capability warning surfaces when expected; analyzer download completes instead of hanging
- [x] Native app: player bar stays docked across every screen and the live now-playing renders in its slim form
- [x] /manual and setup docs read correctly with the mobile-apps announcement and refreshed copy