### PR TITLE
feat(analysis): richer acoustic analysis (Music Understanding blueprint, phases 1–6)

### DIFF
--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -50,6 +50,17 @@ EMBED_ENABLED = os.environ.get("ANALYZE_AUDIO_EMBEDDING", "").strip().lower() in
 CLAP_SR = 48000
 CLAP_EMBED_DIM = 512
 
+# --- Vocal-activity ranges (optional, opt-in) ------------------------------
+# Off unless ANALYZE_VOCAL_ACTIVITY is truthy. Runs Demucs source separation to
+# isolate the vocal stem, then thresholds its energy envelope into present/
+# absent ranges. Heavy (a real torch model) — gated like CLAP. Demucs wants
+# 44.1 kHz stereo.
+VOCAL_ENABLED = os.environ.get("ANALYZE_VOCAL_ACTIVITY", "").strip().lower() in (
+    "1", "true", "yes",
+)
+DEMUCS_SR = 44100
+DEMUCS_MODEL = os.environ.get("DEMUCS_MODEL", "htdemucs")
+
 # Krumhansl-Kessler key profiles (major/minor), indexed from the tonic.
 MAJOR_PROFILE = [6.35, 2.23, 3.48, 2.33, 4.38, 4.09, 2.52, 5.19, 2.39, 3.66, 2.29, 2.88]
 MINOR_PROFILE = [6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 2.69, 3.34, 3.17]
@@ -292,6 +303,98 @@ def get_embedder(force=False):
     return _embedder
 
 
+# ---------------------------------------------------------------------------
+# Vocal-activity detector — Demucs source separation → vocal energy envelope →
+# present/absent time ranges. All heavy imports (torch, demucs) are lazy so a
+# worker with vocal activity DISABLED never needs them and the librosa-only venv
+# keeps working. Same degrade-never-crash contract as the CLAP embedder.
+# ---------------------------------------------------------------------------
+class VocalActivityDetector:
+    def __init__(self):
+        self.model = None
+        self.sources = None  # stem order, e.g. ['drums','bass','other','vocals']
+
+    def load(self):
+        from demucs.pretrained import get_model
+
+        self.model = get_model(DEMUCS_MODEL)
+        self.model.eval()
+        self.sources = list(self.model.sources)
+        if "vocals" not in self.sources:
+            raise RuntimeError(f"demucs model {DEMUCS_MODEL} has no 'vocals' stem")
+
+    def detect(self, stereo, sr, librosa):
+        """stereo: float32 array shaped (2, N) at DEMUCS_SR. Returns a list of
+        {startMs,endMs} where the isolated vocal stem is active — possibly empty
+        (an instrumental). Raises on failure; the caller degrades to None."""
+        import numpy as np
+        import torch
+
+        wav = torch.from_numpy(np.ascontiguousarray(stereo, dtype=np.float32))
+        if wav.ndim == 1:
+            wav = wav.unsqueeze(0).repeat(2, 1)
+        from demucs.apply import apply_model
+
+        with torch.no_grad():
+            est = apply_model(self.model, wav.unsqueeze(0), device="cpu")[0]
+        vocals = est[self.sources.index("vocals")].mean(dim=0).cpu().numpy()
+
+        # RMS envelope of the vocal stem, thresholded against its own loud level
+        # (40th-pct of the loud half) — robust to overall mix level. Frames where
+        # vocal energy sustains above threshold become "vocal present" ranges,
+        # merging gaps shorter than ~0.4s so a breath doesn't split a phrase.
+        hop = 512
+        rms = librosa.feature.rms(y=vocals, frame_length=2048, hop_length=hop)[0]
+        if rms.size == 0:
+            return []
+        loud = float(np.percentile(rms, 90))
+        if loud <= 0:
+            return []
+        thr = 0.15 * loud
+        times = librosa.frames_to_time(np.arange(rms.size), sr=sr, hop_length=hop)
+        active = rms >= thr
+        ranges = []
+        merge_gap_ms = 400
+        i = 0
+        n = rms.size
+        while i < n:
+            if not active[i]:
+                i += 1
+                continue
+            j = i
+            while j + 1 < n and active[j + 1]:
+                j += 1
+            start_ms = int(round(float(times[i]) * 1000.0))
+            end_ms = int(round(float(times[min(j + 1, n - 1)]) * 1000.0))
+            if ranges and start_ms - ranges[-1]["endMs"] <= merge_gap_ms:
+                ranges[-1]["endMs"] = end_ms
+            else:
+                ranges.append({"startMs": start_ms, "endMs": end_ms})
+            i = j + 1
+        # Drop sub-300ms blips (separation artefacts, not sung lines).
+        return [r for r in ranges if r["endMs"] - r["startMs"] >= 300]
+
+
+_vocal_detector = None
+_vocal_failed = False
+
+
+def get_vocal_detector(force=False):
+    global _vocal_detector, _vocal_failed
+    if _vocal_failed or not (VOCAL_ENABLED or force):
+        return None
+    if _vocal_detector is None:
+        try:
+            d = VocalActivityDetector()
+            d.load()
+            _vocal_detector = d
+        except Exception as ex:  # noqa: BLE001 — degrade, never crash the worker
+            log(f"Demucs load failed ({ex}); vocal activity disabled for this run")
+            _vocal_failed = True
+            return None
+    return _vocal_detector
+
+
 def fetch_audio(url):
     suffix = ".audio"
     fd, path = tempfile.mkstemp(suffix=suffix, prefix="swanalyze_")
@@ -341,7 +444,7 @@ def measure_loudness(y, sr):
         return None, None
 
 
-def analyze(librosa, url=None, path=None, embed=None):
+def analyze(librosa, url=None, path=None, embed=None, vocal=None):
     import numpy as np
 
     # A controller-provided path is pre-fetched onto the shared volume and
@@ -351,6 +454,7 @@ def analyze(librosa, url=None, path=None, embed=None):
     if owned:
         path = fetch_audio(url)
     audio_embedding = None
+    vocal_ranges = None
     try:
         y, sr = librosa.load(path, sr=ANALYZE_SR, mono=True, duration=ANALYZE_SECONDS)
         # CLAP wants 48 kHz mono — decode a second copy at that rate from the
@@ -371,6 +475,23 @@ def analyze(librosa, url=None, path=None, embed=None):
             except Exception as e:  # noqa: BLE001 — embedding is best-effort
                 log(f"audio embedding failed: {e}")
                 audio_embedding = None
+        # Vocal activity — Demucs wants 44.1 kHz stereo; decode a third copy from
+        # the same file. Gated like CLAP (per-request `vocal` forces the load).
+        # Best-effort: a failure leaves vocal_ranges None (field omitted). A
+        # successful run with no detected vocals emits [] — the distinct "empty"
+        # value tells the controller this track WAS analysed (an instrumental),
+        # so the backfill scope doesn't keep re-targeting it.
+        detector = None if vocal is False else get_vocal_detector(force=vocal is True)
+        if detector is not None:
+            try:
+                ys, _srs = librosa.load(
+                    path, sr=DEMUCS_SR, mono=False, duration=ANALYZE_SECONDS
+                )
+                if ys is not None and np.size(ys) > 0:
+                    vocal_ranges = detector.detect(ys, DEMUCS_SR, librosa)
+            except Exception as e:  # noqa: BLE001 — vocal activity is best-effort
+                log(f"vocal activity failed: {e}")
+                vocal_ranges = None
     finally:
         if owned:
             try:
@@ -389,6 +510,13 @@ def analyze(librosa, url=None, path=None, embed=None):
     key, key_sep = estimate_key(chroma_mean)
 
     intro_ms = estimate_intro_ms(y, sr, librosa)
+
+    # When vocal activity was measured, the start of the first vocal range is a
+    # truer intro than the energy heuristic (an instrumental intro is exactly
+    # the vocal-free leading region). Prefer it; fall back to the heuristic for
+    # instrumentals ([] → keep the energy estimate) and un-run tracks.
+    if vocal_ranges:
+        intro_ms = float(vocal_ranges[0]["startMs"])
 
     # Structural sections over the decoded window (intro/leading sections are
     # the reliable part — the outro of a long track is beyond ANALYZE_SECONDS).
@@ -419,6 +547,11 @@ def analyze(librosa, url=None, path=None, embed=None):
     # Structural sections (omit when segmentation produced nothing).
     if sections:
         result["sections"] = sections
+    # Vocal-activity ranges. Emit even when empty ([] = analysed instrumental);
+    # omit only when detection didn't run (None), so the controller can tell
+    # "no vocals" from "not computed".
+    if vocal_ranges is not None:
+        result["vocal_ranges"] = vocal_ranges
     # Only carry the embedding when we actually produced one — its absence is
     # how every downstream consumer knows to behave as today.
     if audio_embedding is not None:
@@ -445,6 +578,9 @@ def main():
     if EMBED_ENABLED:
         log("ANALYZE_AUDIO_EMBEDDING on — loading CLAP model...")
         get_embedder()
+    if VOCAL_ENABLED:
+        log("ANALYZE_VOCAL_ACTIVITY on — loading Demucs model...")
+        get_vocal_detector()
 
     # Tell the controller whether this worker can actually emit "sounds-like"
     # audio embeddings, so the admin UI can warn *before* a fruitless run rather
@@ -455,9 +591,20 @@ def main():
         _embedder is not None
         or all(importlib.util.find_spec(m) is not None for m in ("torch", "transformers"))
     )
+    # Same probe for vocal activity — the demucs + torch libs present (image
+    # built WITH_DEMUCS=1) and no hard load failure yet.
+    vocal_capable = (not _vocal_failed) and (
+        _vocal_detector is not None
+        or all(importlib.util.find_spec(m) is not None for m in ("torch", "demucs"))
+    )
 
     log("ready")
-    emit({"id": None, "ready": True, "audio_embedding_capable": audio_capable})
+    emit({
+        "id": None,
+        "ready": True,
+        "audio_embedding_capable": audio_capable,
+        "vocal_activity_capable": vocal_capable,
+    })
 
     for line in sys.stdin:
         line = line.strip()
@@ -477,7 +624,10 @@ def main():
         try:
             import librosa
 
-            result = analyze(librosa, url=url, path=path, embed=req.get("embed"))
+            result = analyze(
+                librosa, url=url, path=path,
+                embed=req.get("embed"), vocal=req.get("vocal"),
+            )
             emit({"id": rid, "ok": True, **result})
         except Exception as e:
             emit({"id": rid, "ok": False, "error": str(e)})

--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -269,6 +269,34 @@ def fetch_audio(url):
     return path
 
 
+def measure_loudness(y, sr):
+    """Integrated loudness (LUFS, ITU-R BS.1770 / EBU R128) + true-ish peak in
+    dBFS over the decoded window. Best-effort: pyloudnorm is an optional dep, so
+    a missing import or any failure returns (None, None) and the caller simply
+    omits the fields — every consumer treats NULL as "no loudness, behave as
+    today" (same contract as the CLAP embedding)."""
+    import numpy as np
+
+    try:
+        import pyloudnorm as pyln
+    except Exception as e:  # noqa: BLE001 — optional dependency
+        log(f"pyloudnorm unavailable, skipping loudness: {e}")
+        return None, None
+
+    try:
+        meter = pyln.Meter(sr)  # BS.1770 meter at the decode sample rate
+        lufs = float(meter.integrated_loudness(y))
+        peak = float(np.max(np.abs(y))) if len(y) else 0.0
+        peak_db = 20.0 * float(np.log10(peak)) if peak > 0 else None
+        # integrated_loudness returns -inf for digital silence; treat as no signal.
+        if not np.isfinite(lufs):
+            return None, peak_db
+        return round(lufs, 2), (round(peak_db, 2) if peak_db is not None else None)
+    except Exception as e:  # noqa: BLE001 — loudness is best-effort
+        log(f"loudness measurement failed: {e}")
+        return None, None
+
+
 def analyze(librosa, url=None, path=None, embed=None):
     import numpy as np
 
@@ -318,6 +346,11 @@ def analyze(librosa, url=None, path=None, embed=None):
 
     intro_ms = estimate_intro_ms(y, sr, librosa)
 
+    # Perceptual loudness (LUFS) over the decoded window — feeds per-track gain
+    # normalisation toward a target on the playback side. None when pyloudnorm
+    # is absent or measurement fails.
+    loudness_lufs, peak_db = measure_loudness(y, sr)
+
     # Overall confidence: dominated by how cleanly the key resolved, nudged by
     # whether we got a plausible tempo. Kept conservative on purpose.
     confidence = round(0.5 * key_sep + (0.5 if 40 <= bpm <= 220 else 0.0), 3)
@@ -328,6 +361,12 @@ def analyze(librosa, url=None, path=None, embed=None):
         "intro_ms": int(intro_ms) if intro_ms is not None else None,
         "confidence": confidence,
     }
+    # Only carry loudness fields when measured — absence signals "no loudness
+    # this pass", so a worker without pyloudnorm is byte-for-byte today.
+    if loudness_lufs is not None:
+        result["loudness_lufs"] = loudness_lufs
+    if peak_db is not None:
+        result["peak_db"] = peak_db
     # Only carry the embedding when we actually produced one — its absence is
     # how every downstream consumer knows to behave as today.
     if audio_embedding is not None:

--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -121,6 +121,50 @@ def estimate_intro_ms(y, sr, librosa):
     return 0.0
 
 
+def estimate_sections(y, sr, librosa, chroma=None):
+    """Coarse structural segmentation over the DECODED window (the first
+    ANALYZE_SECONDS only — so this is reliable for the intro / leading sections,
+    not a full-song outro). librosa agglomerative clustering on a chroma+MFCC
+    feature stack → a handful of contiguous {startMs,endMs} spans (RangedValue
+    shape). Best-effort: any failure returns None and the field is omitted, so a
+    consumer treats absence as 'no structure, behave as today'. `chroma` may be
+    passed in to avoid recomputing the (expensive) CQT done in analyze()."""
+    import numpy as np
+
+    try:
+        hop = 512  # librosa default for chroma_cqt / mfcc; ties frames→time
+        if chroma is None:
+            chroma = librosa.feature.chroma_cqt(y=y, sr=sr, hop_length=hop)
+        mfcc = librosa.feature.mfcc(y=y, sr=sr, n_mfcc=13, hop_length=hop)
+        # Trim to a common frame count (CQT vs mel framing can differ by one).
+        n_frames = min(chroma.shape[1], mfcc.shape[1])
+        if n_frames < 8:
+            return None
+        feat = np.vstack([
+            librosa.util.normalize(chroma[:, :n_frames], axis=0),
+            librosa.util.normalize(mfcc[:, :n_frames], axis=0),
+        ])
+        dur_s = n_frames * hop / sr
+        # ~1 section per 15s of decoded audio, clamped to a sane 2..8.
+        k = int(max(2, min(8, round(dur_s / 15.0))))
+        if k >= n_frames:
+            return None
+        # Left-boundary frames of each segment; always includes 0.
+        bounds = librosa.segment.agglomerative(feat, k)
+        times = librosa.frames_to_time(bounds, sr=sr, hop_length=hop)
+        edges = [float(t) for t in times] + [dur_s]
+        sections = []
+        for i in range(len(edges) - 1):
+            start_ms = int(round(edges[i] * 1000.0))
+            end_ms = int(round(edges[i + 1] * 1000.0))
+            if end_ms > start_ms:
+                sections.append({"startMs": start_ms, "endMs": end_ms})
+        return sections or None
+    except Exception as e:  # noqa: BLE001 — structure is best-effort
+        log(f"structure segmentation failed: {e}")
+        return None
+
+
 # ---------------------------------------------------------------------------
 # CLAP embedder — two backends, decided at load time:
 #   * ONNX (lean): CLAP_MODEL_PATH points at an exported audio-encoder .onnx;
@@ -346,6 +390,11 @@ def analyze(librosa, url=None, path=None, embed=None):
 
     intro_ms = estimate_intro_ms(y, sr, librosa)
 
+    # Structural sections over the decoded window (intro/leading sections are
+    # the reliable part — the outro of a long track is beyond ANALYZE_SECONDS).
+    # Reuses the chroma already computed for key estimation.
+    sections = estimate_sections(y, sr, librosa, chroma=chroma)
+
     # Perceptual loudness (LUFS) over the decoded window — feeds per-track gain
     # normalisation toward a target on the playback side. None when pyloudnorm
     # is absent or measurement fails.
@@ -367,6 +416,9 @@ def analyze(librosa, url=None, path=None, embed=None):
         result["loudness_lufs"] = loudness_lufs
     if peak_db is not None:
         result["peak_db"] = peak_db
+    # Structural sections (omit when segmentation produced nothing).
+    if sections:
+        result["sections"] = sections
     # Only carry the embedding when we actually produced one — its absence is
     # how every downstream consumer knows to behave as today.
     if audio_embedding is not None:

--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -375,6 +375,39 @@ class VocalActivityDetector:
         return [r for r in ranges if r["endMs"] - r["startMs"] >= 300]
 
 
+def estimate_pace(y, sr, librosa, window_s=5.0):
+    """Perceptual energy/momentum curve over the decoded window, decoupled from
+    BPM (a high-tempo track can read low pace during a sparse breakdown). Mean
+    onset-strength (spectral-flux) energy per ~window_s window, normalised 0..1
+    by the loudest window. RangedValue shape: [{startMs,endMs,value}]. Best-
+    effort: any failure returns None and the field is omitted."""
+    import numpy as np
+
+    try:
+        hop = 512
+        onset_env = librosa.onset.onset_strength(y=y, sr=sr, hop_length=hop)
+        if onset_env.size == 0:
+            return None
+        frames_per_win = max(1, int(round(window_s * sr / hop)))
+        peak = float(np.max(onset_env))
+        if peak <= 0:
+            return None
+        curve = []
+        for start in range(0, onset_env.size, frames_per_win):
+            chunk = onset_env[start : start + frames_per_win]
+            if chunk.size == 0:
+                continue
+            value = round(float(np.mean(chunk)) / peak, 3)
+            start_ms = int(round(start * hop / sr * 1000.0))
+            end_ms = int(round(min(start + frames_per_win, onset_env.size) * hop / sr * 1000.0))
+            if end_ms > start_ms:
+                curve.append({"startMs": start_ms, "endMs": end_ms, "value": value})
+        return curve or None
+    except Exception as e:  # noqa: BLE001 — pace is best-effort
+        log(f"pace estimation failed: {e}")
+        return None
+
+
 _vocal_detector = None
 _vocal_failed = False
 
@@ -523,6 +556,9 @@ def analyze(librosa, url=None, path=None, embed=None, vocal=None):
     # Reuses the chroma already computed for key estimation.
     sections = estimate_sections(y, sr, librosa, chroma=chroma)
 
+    # Perceptual energy/momentum curve (decoupled from BPM).
+    pace = estimate_pace(y, sr, librosa)
+
     # Perceptual loudness (LUFS) over the decoded window — feeds per-track gain
     # normalisation toward a target on the playback side. None when pyloudnorm
     # is absent or measurement fails.
@@ -547,6 +583,9 @@ def analyze(librosa, url=None, path=None, embed=None, vocal=None):
     # Structural sections (omit when segmentation produced nothing).
     if sections:
         result["sections"] = sections
+    # Pace curve (omit when none produced).
+    if pace:
+        result["pace_curve"] = pace
     # Vocal-activity ranges. Emit even when empty ([] = analysed instrumental);
     # omit only when detection didn't run (None), so the controller can tell
     # "no vocals" from "not computed".

--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -535,8 +535,23 @@ def analyze(librosa, url=None, path=None, embed=None, vocal=None):
     if y is None or len(y) == 0:
         raise RuntimeError("decoded empty audio")
 
-    tempo, _ = librosa.beat.beat_track(y=y, sr=sr)
+    tempo, beat_frames = librosa.beat.beat_track(y=y, sr=sr)
     bpm = float(np.atleast_1d(tempo)[0])
+
+    # Per-beat timestamps (ms) — already computed by beat_track, previously
+    # discarded. Downbeats are a 4/4 heuristic (every 4th beat from the first):
+    # librosa gives no true downbeat, but a bar grid is enough to bar-align a
+    # crossfade. Best-effort: an empty/odd grid simply yields fewer/no bars.
+    beats_ms = []
+    bars_ms = []
+    try:
+        bt = librosa.frames_to_time(beat_frames, sr=sr)
+        beats_ms = [int(round(float(t) * 1000.0)) for t in bt]
+        bars_ms = beats_ms[::4]
+    except Exception as e:  # noqa: BLE001 — beat grid is best-effort
+        log(f"beat grid failed: {e}")
+        beats_ms = []
+        bars_ms = []
 
     chroma = librosa.feature.chroma_cqt(y=y, sr=sr)
     chroma_mean = [float(x) for x in np.mean(chroma, axis=1)]
@@ -586,6 +601,11 @@ def analyze(librosa, url=None, path=None, embed=None, vocal=None):
     # Pace curve (omit when none produced).
     if pace:
         result["pace_curve"] = pace
+    # Beat / bar grid (omit when empty).
+    if beats_ms:
+        result["beats"] = beats_ms
+    if bars_ms:
+        result["bars"] = bars_ms
     # Vocal-activity ranges. Emit even when empty ([] = analysed instrumental);
     # omit only when detection didn't run (None), so the controller can tell
     # "no vocals" from "not computed".

--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -92,19 +92,64 @@ def _pearson(a, b):
     return num / (da * db)
 
 
-def estimate_key(chroma_mean):
-    """Krumhansl-Schmuckler: correlate the mean chroma against all 24 keys.
-    Returns (camelot_code, separation) where separation (best - 2nd best
-    correlation, 0..1-ish) is a rough confidence in the key call."""
-    scores = []  # (corr, camelot)
+# Enharmonic-preserving spelling isn't recoverable from chroma; use sharps.
+PITCH_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+
+
+def _score_key(chroma_vec):
+    """Krumhansl-Schmuckler over all 24 keys for one chroma vector. Returns
+    (camelot_code, separation, tonic_pc, mode) — separation (best - 2nd best
+    correlation, 0..1-ish) is a rough confidence; mode is 'major'/'minor'."""
+    scores = []  # (corr, camelot, tonic_pc, mode)
     for tonic in range(12):
-        rotated = [chroma_mean[(tonic + i) % 12] for i in range(12)]
-        scores.append((_pearson(MAJOR_PROFILE, rotated), MAJOR_CAMELOT[tonic]))
-        scores.append((_pearson(MINOR_PROFILE, rotated), MINOR_CAMELOT[tonic]))
+        rotated = [chroma_vec[(tonic + i) % 12] for i in range(12)]
+        scores.append((_pearson(MAJOR_PROFILE, rotated), MAJOR_CAMELOT[tonic], tonic, "major"))
+        scores.append((_pearson(MINOR_PROFILE, rotated), MINOR_CAMELOT[tonic], tonic, "minor"))
     scores.sort(reverse=True, key=lambda s: s[0])
-    best_corr, best_code = scores[0]
+    best_corr, best_code, tonic_pc, mode = scores[0]
     separation = max(0.0, min(1.0, best_corr - scores[1][0]))
-    return best_code, separation
+    return best_code, separation, tonic_pc, mode
+
+
+def estimate_key(chroma_mean):
+    """Whole-window key as (camelot_code, separation), for the scalar field."""
+    code, separation, _tonic, _mode = _score_key(chroma_mean)
+    return code, separation
+
+
+def estimate_key_ranges(chroma, sr, librosa, window_s=10.0):
+    """Per-region key (tonic + mode) over time, mirroring Apple's RangedValue
+    KeySignature. Windows the already-computed chroma (~window_s each), scores
+    each, and merges adjacent windows sharing a key. Returns
+    [{startMs,endMs,tonic,mode}] or None. Best-effort: any failure → None."""
+    import numpy as np
+
+    try:
+        hop = 512
+        n_frames = chroma.shape[1]
+        if n_frames < 8:
+            return None
+        frames_per_win = max(1, int(round(window_s * sr / hop)))
+        ranges = []
+        for start in range(0, n_frames, frames_per_win):
+            chunk = chroma[:, start : start + frames_per_win]
+            if chunk.shape[1] == 0:
+                continue
+            vec = [float(x) for x in np.mean(chunk, axis=1)]
+            _code, _sep, tonic_pc, mode = _score_key(vec)
+            tonic = PITCH_NAMES[tonic_pc]
+            start_ms = int(round(start * hop / sr * 1000.0))
+            end_ms = int(round(min(start + frames_per_win, n_frames) * hop / sr * 1000.0))
+            if end_ms <= start_ms:
+                continue
+            if ranges and ranges[-1]["tonic"] == tonic and ranges[-1]["mode"] == mode:
+                ranges[-1]["endMs"] = end_ms  # merge a run of the same key
+            else:
+                ranges.append({"startMs": start_ms, "endMs": end_ms, "tonic": tonic, "mode": mode})
+        return ranges or None
+    except Exception as e:  # noqa: BLE001 — key ranges are best-effort
+        log(f"key-range estimation failed: {e}")
+        return None
 
 
 def estimate_intro_ms(y, sr, librosa):
@@ -557,6 +602,9 @@ def analyze(librosa, url=None, path=None, embed=None, vocal=None):
     chroma_mean = [float(x) for x in np.mean(chroma, axis=1)]
     key, key_sep = estimate_key(chroma_mean)
 
+    # Per-region key (tonic + mode) over time — reuses the chroma above.
+    key_ranges = estimate_key_ranges(chroma, sr, librosa)
+
     intro_ms = estimate_intro_ms(y, sr, librosa)
 
     # When vocal activity was measured, the start of the first vocal range is a
@@ -606,6 +654,9 @@ def analyze(librosa, url=None, path=None, embed=None, vocal=None):
         result["beats"] = beats_ms
     if bars_ms:
         result["bars"] = bars_ms
+    # Per-region key ranges (omit when none produced).
+    if key_ranges:
+        result["key_ranges"] = key_ranges
     # Vocal-activity ranges. Emit even when empty ([] = analysed instrumental);
     # omit only when detection didn't run (None), so the controller can tell
     # "no vocals" from "not computed".

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -347,10 +347,14 @@ class Queue {
     const cur = this.mixAnalysisFor(prevTrack);
     const next = this.mixAnalysisFor(item.track);
 
-    // Feature 1 — adaptive blend length, with a subtle daypart nudge.
+    // Feature 1 — adaptive blend length, with a subtle daypart nudge and a
+    // structure-aware cap so the incoming fade-in finishes before the song's
+    // vocals (the incoming track's instrumental intro, resolved like analysis).
     let energyDelta = 0;
     try { energyDelta = energyForDaypart().speed - 1; } catch {}
-    const secs = mix.crossSecondsFor(cur, next, { energyDelta });
+    let nextIntroMs = item.track.introMs;
+    if (nextIntroMs == null && item.track.id) nextIntroMs = library.get(item.track.id)?.introMs ?? null;
+    const secs = mix.crossSecondsFor(cur, next, { energyDelta, nextIntroMs });
     if (secs != null) {
       item.track.crossSec = secs;
       this.log('mix', `blend ${secs}s → ${item.track.title}`);

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -310,6 +310,18 @@ class Queue {
     return { bpm: rec?.bpm ?? null, key: rec?.musicalKey ?? null };
   }
 
+  // Resolve a track's integrated loudness (track object first, else a library
+  // lookup) and stash a clamped gain offset toward the loudness target on the
+  // track as `gainDb`. Null measurement → leaves gainDb undefined, so
+  // getAnnotatedUri emits no liq_amplify and the track plays at unity gain.
+  applyLoudnessGain(track: any) {
+    if (!track) return;
+    let lufs = track.loudnessLufs;
+    if (lufs == null && track.id) lufs = library.get(track.id)?.loudnessLufs ?? null;
+    const gain = mix.gainForLoudness(lufs);
+    if (gain != null) track.gainDb = gain;
+  }
+
   // How many transitions must pass between DJ-mode transition-FX, keyed off the
   // chattiness ladder. Infinity for quiet personas → no transition FX at all.
   sfxTransitionGap(): number {
@@ -385,6 +397,13 @@ class Queue {
         // tracks being analysed — a no-op otherwise, so non-DJ stations and
         // un-analysed libraries behave exactly as before.
         this.applyMixTransition(item);
+
+        // Loudness normalisation (feature: LUFS gain) — applies to EVERY track,
+        // not just DJ mode. Resolve the track's integrated loudness (from the
+        // item or a library lookup) and stash a clamped gain offset toward the
+        // target; subsonic.getAnnotatedUri folds it into liq_amplify. Un-measured
+        // tracks resolve to null → no liq_amplify → unity gain, i.e. today.
+        this.applyLoudnessGain(item.track);
 
         const uri = subsonic.getAnnotatedUri(item.track);
         await writeHandoff(config.liquidsoap.queueFile, uri);

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -139,6 +139,7 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
         confidence: a.confidence,
         loudnessLufs: a.loudnessLufs,
         peakDb: a.peakDb,
+        sections: a.sections,
       });
       // Opportunistically store the CLAP audio vector whenever the backend
       // carried one. Independent of the bpm/key write above: a track analysed

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -179,6 +179,8 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
         peakDb: a.peakDb,
         sections: a.sections,
         pace: a.paceCurve,
+        beats: a.beats,
+        bars: a.bars,
         vocalRanges: a.vocalRanges,
       });
       if (a.vocalRanges != null) vocalAnalyzed += 1;

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -137,6 +137,8 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
         musicalKey: a.musicalKey,
         introMs: a.introMs,
         confidence: a.confidence,
+        loudnessLufs: a.loudnessLufs,
+        peakDb: a.peakDb,
       });
       // Opportunistically store the CLAP audio vector whenever the backend
       // carried one. Independent of the bpm/key write above: a track analysed

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -178,6 +178,7 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
         loudnessLufs: a.loudnessLufs,
         peakDb: a.peakDb,
         sections: a.sections,
+        pace: a.paceCurve,
         vocalRanges: a.vocalRanges,
       });
       if (a.vocalRanges != null) vocalAnalyzed += 1;

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -181,6 +181,7 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
         pace: a.paceCurve,
         beats: a.beats,
         bars: a.bars,
+        keyRanges: a.keyRanges,
         vocalRanges: a.vocalRanges,
       });
       if (a.vocalRanges != null) vocalAnalyzed += 1;

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -23,6 +23,10 @@ export interface AnalyzeOptions {
   // (analysed before audio embeddings were enabled). Only meaningful when the
   // backend actually emits embeddings; defaults from ANALYZE_AUDIO_EMBEDDING.
   audioBackfill?: boolean;
+  // Widen the scope to tracks with no vocal-activity ranges yet (vocal_ranges_json
+  // NULL). The Demucs pass is expensive and opt-in; defaults from
+  // ANALYZE_VOCAL_ACTIVITY / settings.audio.vocalActivity.
+  vocalBackfill?: boolean;
 }
 
 // Audio embeddings are on when EITHER the env says so (env wins on, never
@@ -39,6 +43,18 @@ function audioBackfillDefault(): boolean {
   }
 }
 
+// Vocal-activity backfill default — same precedence as audio: env wins on,
+// else the admin toggle (settings.audio.vocalActivity).
+function vocalBackfillDefault(): boolean {
+  const v = (process.env.ANALYZE_VOCAL_ACTIVITY || '').toLowerCase();
+  if (v === '1' || v === 'true' || v === 'yes') return true;
+  try {
+    return settings.get()?.audio?.vocalActivity === true;
+  } catch {
+    return false;
+  }
+}
+
 export interface AnalyzeStats {
   available: boolean;
   backend: string;
@@ -48,6 +64,9 @@ export interface AnalyzeStats {
   // How many of the analysed tracks also got a CLAP audio vector this run.
   // 0 when the backend has no CLAP model loaded (ANALYZE_AUDIO_EMBEDDING off).
   audioEmbedded: number;
+  // How many tracks got vocal-activity ranges this run (incl. instrumentals,
+  // stored as []). 0 when vocal activity is off / demucs absent.
+  vocalAnalyzed: number;
 }
 
 // Model label recorded in audio_embedding_meta for provenance. The worker owns
@@ -58,7 +77,7 @@ const AUDIO_MODEL_LABEL = process.env.CLAP_MODEL || 'laion-clap';
 export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<AnalyzeStats> {
   if (!(await analyzer.isAvailable())) {
     console.log('[analyze] no analysis backend (tts-heavy sidecar / local librosa venv) — skipping');
-    return { available: false, backend: 'none', analyzed: 0, failed: 0, scope: 0, audioEmbedded: 0 };
+    return { available: false, backend: 'none', analyzed: 0, failed: 0, scope: 0, audioEmbedded: 0, vocalAnalyzed: 0 };
   }
   const backend = analyzer.backendLabel();
   console.log(`[analyze] backend: ${backend}`);
@@ -86,9 +105,24 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
     }
   }
 
+  // Vocal backfill: same idea for tracks missing vocal-activity ranges. The
+  // Demucs separation is the expensive part, so this only widens the scope when
+  // the operator opted in (env/admin toggle); the `vocal:true` flag below then
+  // forces the backend to run it for this pass.
+  const vocalBackfill = opts.vocalBackfill ?? vocalBackfillDefault();
+  if (vocalBackfill) {
+    const seen = new Set(ids);
+    const vocalIds = db.needsVocalIds(cap).filter(id => !seen.has(id));
+    const before = ids.length;
+    ids = cap ? [...ids, ...vocalIds].slice(0, cap) : [...ids, ...vocalIds];
+    if (ids.length > before) {
+      console.log(`[analyze] vocal backfill: +${ids.length - before} tracks missing vocal-activity ranges`);
+    }
+  }
+
   if (ids.length === 0) {
     console.log('[analyze] nothing to analyse — all tracks current');
-    return { available: true, backend, analyzed: 0, failed: 0, scope: 0, audioEmbedded: 0 };
+    return { available: true, backend, analyzed: 0, failed: 0, scope: 0, audioEmbedded: 0, vocalAnalyzed: 0 };
   }
   console.log(`[analyze] ${ids.length} tracks to analyse`);
   reportProgress({ phase: 'analyze', label: 'Analysing audio', done: 0, total: ids.length });
@@ -96,6 +130,7 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
   let analyzed = 0;
   let failed = 0;
   let audioEmbedded = 0;
+  let vocalAnalyzed = 0;
   // Stamp the audio-embedding provenance row once, on the first vector written
   // this run. Cheap idempotent guard so we don't touch the meta table per track.
   let audioMetaStamped = false;
@@ -129,9 +164,12 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
       // doesn't have ANALYZE_AUDIO_EMBEDDING (the admin-toggle path); omitted
       // when audio is off so the backend keeps its env-driven default.
       const embed = audioBackfill ? true : undefined;
+      // vocal:true forces the Demucs pass for this track (admin/backfill path),
+      // mirroring embed; omitted when vocal activity is off.
+      const vocal = vocalBackfill ? true : undefined;
       const a = localPath
-        ? await analyzer.analyzePath(localPath, { embed })
-        : await analyzer.analyze(id, { embed });
+        ? await analyzer.analyzePath(localPath, { embed, vocal })
+        : await analyzer.analyze(id, { embed, vocal });
       db.upsertTrackAnalysis(id, {
         bpm: a.bpm,
         musicalKey: a.musicalKey,
@@ -140,7 +178,9 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
         loudnessLufs: a.loudnessLufs,
         peakDb: a.peakDb,
         sections: a.sections,
+        vocalRanges: a.vocalRanges,
       });
+      if (a.vocalRanges != null) vocalAnalyzed += 1;
       // Opportunistically store the CLAP audio vector whenever the backend
       // carried one. Independent of the bpm/key write above: a track analysed
       // before CLAP was enabled simply gets its vector on the next pass once
@@ -185,7 +225,8 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
 
   console.log(
     `[analyze] done — analyzed=${analyzed} failed=${failed}` +
-      (audioEmbedded > 0 ? ` audio-embedded=${audioEmbedded}` : ''),
+      (audioEmbedded > 0 ? ` audio-embedded=${audioEmbedded}` : '') +
+      (vocalAnalyzed > 0 ? ` vocal-analyzed=${vocalAnalyzed}` : ''),
   );
-  return { available: true, backend, analyzed, failed, scope: ids.length, audioEmbedded };
+  return { available: true, backend, analyzed, failed, scope: ids.length, audioEmbedded, vocalAnalyzed };
 }

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -22,11 +22,23 @@ export interface AnalysisResult {
   musicalKey: string | null;
   introMs: number | null;
   confidence: number | null;
+  // Integrated loudness (LUFS, BS.1770) + peak (dBFS) over the analysis window,
+  // when the backend has pyloudnorm. null otherwise — consumers treat null as
+  // "no loudness, play at unity gain", so a backend without pyloudnorm behaves
+  // exactly as today. loudnessLufs feeds per-track gain normalisation.
+  loudnessLufs: number | null;
+  peakDb: number | null;
   // CLAP audio embedding (512 floats) when the backend has the model loaded
   // (ANALYZE_AUDIO_EMBEDDING=1 + CLAP weights). null otherwise — every consumer
   // treats null as "no audio vector this pass", so a backend without CLAP is
   // byte-for-byte today's behaviour.
   audioEmbedding: number[] | null;
+}
+
+// Coerce a worker numeric field to a finite number or null. The worker omits
+// loudness/peak entirely when pyloudnorm is absent or measurement failed.
+function parseFinite(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
 }
 
 // Coerce the worker's audio_embedding field to a clean number[] or null. The
@@ -136,6 +148,8 @@ function localRequest(req: ({ url: string } | { path: string }) & AnalyzeRequest
           musicalKey: msg.key ?? null,
           introMs: msg.intro_ms ?? null,
           confidence: msg.confidence ?? null,
+          loudnessLufs: parseFinite(msg.loudness_lufs),
+          peakDb: parseFinite(msg.peak_db),
           audioEmbedding: parseAudioEmbedding(msg.audio_embedding),
         }),
       reject,
@@ -204,6 +218,8 @@ async function sidecarRequest(body: ({ url: string } | { path: string }) & Analy
       musicalKey: resBody.key ?? null,
       introMs: resBody.intro_ms ?? null,
       confidence: resBody.confidence ?? null,
+      loudnessLufs: parseFinite(resBody.loudness_lufs),
+      peakDb: parseFinite(resBody.peak_db),
       audioEmbedding: parseAudioEmbedding(resBody.audio_embedding),
     };
   } finally {

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -33,6 +33,14 @@ export interface PaceSpan {
   value: number;
 }
 
+// A key over a time range: tonic note (sharps) + mode (RangedValue<KeySignature>).
+export interface KeyRange {
+  startMs: number;
+  endMs: number;
+  tonic: string;
+  mode: 'major' | 'minor';
+}
+
 export interface AnalysisResult {
   bpm: number | null;
   musicalKey: string | null;
@@ -53,6 +61,9 @@ export interface AnalysisResult {
   // none; consumers treat null as "no grid" (today's blind crossfade).
   beats: number[] | null;
   bars: number[] | null;
+  // Per-region key (tonic + mode) over time. null when none computed; the
+  // scalar musicalKey stays the back-compat dominant key.
+  keyRanges: KeyRange[] | null;
   // Integrated loudness (LUFS, BS.1770) + peak (dBFS) over the analysis window,
   // when the backend has pyloudnorm. null otherwise — consumers treat null as
   // "no loudness, play at unity gain", so a backend without pyloudnorm behaves
@@ -99,6 +110,22 @@ function parseSections(v: unknown): Section[] | null {
 function parseVocalRanges(v: unknown): Section[] | null {
   if (!Array.isArray(v)) return null;
   return coerceSpans(v);
+}
+
+// Key ranges: spans carrying tonic + mode. Drops malformed spans; empty → null.
+function parseKeyRanges(v: unknown): KeyRange[] | null {
+  if (!Array.isArray(v)) return null;
+  const out: KeyRange[] = [];
+  for (const s of v) {
+    const startMs = parseFinite((s as any)?.startMs);
+    const endMs = parseFinite((s as any)?.endMs);
+    const tonic = (s as any)?.tonic;
+    const mode = (s as any)?.mode;
+    if (startMs == null || endMs == null || endMs <= startMs) continue;
+    if (typeof tonic !== 'string' || (mode !== 'major' && mode !== 'minor')) continue;
+    out.push({ startMs, endMs, tonic, mode });
+  }
+  return out.length ? out : null;
 }
 
 // A list of ms timestamps → sorted finite number[] or null (empty → null).
@@ -241,6 +268,7 @@ function localRequest(req: ({ url: string } | { path: string }) & AnalyzeRequest
           paceCurve: parsePaceCurve(msg.pace_curve),
           beats: parseMsList(msg.beats),
           bars: parseMsList(msg.bars),
+          keyRanges: parseKeyRanges(msg.key_ranges),
           audioEmbedding: parseAudioEmbedding(msg.audio_embedding),
         }),
       reject,
@@ -324,6 +352,7 @@ async function sidecarRequest(body: ({ url: string } | { path: string }) & Analy
       paceCurve: parsePaceCurve(resBody.pace_curve),
       beats: parseMsList(resBody.beats),
       bars: parseMsList(resBody.bars),
+      keyRanges: parseKeyRanges(resBody.key_ranges),
       audioEmbedding: parseAudioEmbedding(resBody.audio_embedding),
     };
   } finally {

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -17,11 +17,24 @@ import { pipeline } from 'node:stream/promises';
 import { config } from '../config.js';
 import * as subsonic from './subsonic.js';
 
+// A structural span over the track, in milliseconds (RangedValue shape). Spans
+// are contiguous and cover the analysed window; the first is the intro/leading
+// section. `kind` is reserved for a future labelled segmenter.
+export interface Section {
+  startMs: number;
+  endMs: number;
+  kind?: string;
+}
+
 export interface AnalysisResult {
   bpm: number | null;
   musicalKey: string | null;
   introMs: number | null;
   confidence: number | null;
+  // Structural sections over the analysed window (intro/leading sections are
+  // the reliable part — the outro is beyond the decode window). null when the
+  // backend computed none; consumers treat null as "no structure".
+  sections: Section[] | null;
   // Integrated loudness (LUFS, BS.1770) + peak (dBFS) over the analysis window,
   // when the backend has pyloudnorm. null otherwise — consumers treat null as
   // "no loudness, play at unity gain", so a backend without pyloudnorm behaves
@@ -39,6 +52,21 @@ export interface AnalysisResult {
 // loudness/peak entirely when pyloudnorm is absent or measurement failed.
 function parseFinite(v: unknown): number | null {
   return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+// Coerce the worker's sections field to clean Section[] or null. The worker
+// omits it when segmentation produced nothing; defend against malformed spans.
+function parseSections(v: unknown): Section[] | null {
+  if (!Array.isArray(v) || v.length === 0) return null;
+  const out: Section[] = [];
+  for (const s of v) {
+    const startMs = parseFinite((s as any)?.startMs);
+    const endMs = parseFinite((s as any)?.endMs);
+    if (startMs == null || endMs == null || endMs <= startMs) continue;
+    const kind = typeof (s as any)?.kind === 'string' ? (s as any).kind : undefined;
+    out.push(kind ? { startMs, endMs, kind } : { startMs, endMs });
+  }
+  return out.length ? out : null;
 }
 
 // Coerce the worker's audio_embedding field to a clean number[] or null. The
@@ -150,6 +178,7 @@ function localRequest(req: ({ url: string } | { path: string }) & AnalyzeRequest
           confidence: msg.confidence ?? null,
           loudnessLufs: parseFinite(msg.loudness_lufs),
           peakDb: parseFinite(msg.peak_db),
+          sections: parseSections(msg.sections),
           audioEmbedding: parseAudioEmbedding(msg.audio_embedding),
         }),
       reject,
@@ -220,6 +249,7 @@ async function sidecarRequest(body: ({ url: string } | { path: string }) & Analy
       confidence: resBody.confidence ?? null,
       loudnessLufs: parseFinite(resBody.loudness_lufs),
       peakDb: parseFinite(resBody.peak_db),
+      sections: parseSections(resBody.sections),
       audioEmbedding: parseAudioEmbedding(resBody.audio_embedding),
     };
   } finally {

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -26,6 +26,13 @@ export interface Section {
   kind?: string;
 }
 
+// A pace sample: a 0..1 perceptual-energy value over a span (RangedValue).
+export interface PaceSpan {
+  startMs: number;
+  endMs: number;
+  value: number;
+}
+
 export interface AnalysisResult {
   bpm: number | null;
   musicalKey: string | null;
@@ -39,6 +46,9 @@ export interface AnalysisResult {
   // a meaningful value — "analysed, instrumental"; null means not computed (no
   // ANALYZE_VOCAL_ACTIVITY / no demucs). Consumers treat null as "no signal".
   vocalRanges: Section[] | null;
+  // Perceptual energy/momentum curve (decoupled from BPM), 0..1 per span. null
+  // when the backend computed none; consumers treat null as "no signal".
+  paceCurve: PaceSpan[] | null;
   // Integrated loudness (LUFS, BS.1770) + peak (dBFS) over the analysis window,
   // when the backend has pyloudnorm. null otherwise — consumers treat null as
   // "no loudness, play at unity gain", so a backend without pyloudnorm behaves
@@ -85,6 +95,21 @@ function parseSections(v: unknown): Section[] | null {
 function parseVocalRanges(v: unknown): Section[] | null {
   if (!Array.isArray(v)) return null;
   return coerceSpans(v);
+}
+
+// Pace curve: spans carrying a 0..1 value. Drops malformed/zero-length spans;
+// empty collapses to null ("no pace").
+function parsePaceCurve(v: unknown): PaceSpan[] | null {
+  if (!Array.isArray(v)) return null;
+  const out: PaceSpan[] = [];
+  for (const s of v) {
+    const startMs = parseFinite((s as any)?.startMs);
+    const endMs = parseFinite((s as any)?.endMs);
+    const value = parseFinite((s as any)?.value);
+    if (startMs == null || endMs == null || value == null || endMs <= startMs) continue;
+    out.push({ startMs, endMs, value });
+  }
+  return out.length ? out : null;
 }
 
 // Coerce the worker's audio_embedding field to a clean number[] or null. The
@@ -201,6 +226,7 @@ function localRequest(req: ({ url: string } | { path: string }) & AnalyzeRequest
           peakDb: parseFinite(msg.peak_db),
           sections: parseSections(msg.sections),
           vocalRanges: parseVocalRanges(msg.vocal_ranges),
+          paceCurve: parsePaceCurve(msg.pace_curve),
           audioEmbedding: parseAudioEmbedding(msg.audio_embedding),
         }),
       reject,
@@ -281,6 +307,7 @@ async function sidecarRequest(body: ({ url: string } | { path: string }) & Analy
       peakDb: parseFinite(resBody.peak_db),
       sections: parseSections(resBody.sections),
       vocalRanges: parseVocalRanges(resBody.vocal_ranges),
+      paceCurve: parsePaceCurve(resBody.pace_curve),
       audioEmbedding: parseAudioEmbedding(resBody.audio_embedding),
     };
   } finally {

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -35,6 +35,10 @@ export interface AnalysisResult {
   // the reliable part — the outro is beyond the decode window). null when the
   // backend computed none; consumers treat null as "no structure".
   sections: Section[] | null;
+  // Vocal-presence ranges (Demucs) over the analysed window. An empty array is
+  // a meaningful value — "analysed, instrumental"; null means not computed (no
+  // ANALYZE_VOCAL_ACTIVITY / no demucs). Consumers treat null as "no signal".
+  vocalRanges: Section[] | null;
   // Integrated loudness (LUFS, BS.1770) + peak (dBFS) over the analysis window,
   // when the backend has pyloudnorm. null otherwise — consumers treat null as
   // "no loudness, play at unity gain", so a backend without pyloudnorm behaves
@@ -54,10 +58,9 @@ function parseFinite(v: unknown): number | null {
   return typeof v === 'number' && Number.isFinite(v) ? v : null;
 }
 
-// Coerce the worker's sections field to clean Section[] or null. The worker
-// omits it when segmentation produced nothing; defend against malformed spans.
-function parseSections(v: unknown): Section[] | null {
-  if (!Array.isArray(v) || v.length === 0) return null;
+// Coerce a list of spans to clean Section[]. Drops malformed/zero-length spans.
+function coerceSpans(v: unknown): Section[] {
+  if (!Array.isArray(v)) return [];
   const out: Section[] = [];
   for (const s of v) {
     const startMs = parseFinite((s as any)?.startMs);
@@ -66,7 +69,22 @@ function parseSections(v: unknown): Section[] | null {
     const kind = typeof (s as any)?.kind === 'string' ? (s as any).kind : undefined;
     out.push(kind ? { startMs, endMs, kind } : { startMs, endMs });
   }
+  return out;
+}
+
+// Sections: the worker omits the field when segmentation produced nothing, so
+// empty collapses to null ("no structure").
+function parseSections(v: unknown): Section[] | null {
+  if (!Array.isArray(v)) return null;
+  const out = coerceSpans(v);
   return out.length ? out : null;
+}
+
+// Vocal ranges: an empty array is a MEANINGFUL value (analysed instrumental),
+// distinct from null (not computed). Preserve [] when the field is present.
+function parseVocalRanges(v: unknown): Section[] | null {
+  if (!Array.isArray(v)) return null;
+  return coerceSpans(v);
 }
 
 // Coerce the worker's audio_embedding field to a clean number[] or null. The
@@ -158,6 +176,9 @@ function startWorker(): Promise<void> {
 // it — the admin-toggle path. Omitted → the backend's env-driven default.
 export interface AnalyzeRequestOpts {
   embed?: boolean;
+  // Force a (lazy) Demucs load for vocal-activity ranges even when the backend's
+  // ANALYZE_VOCAL_ACTIVITY env is off — the admin/backfill path, mirroring embed.
+  vocal?: boolean;
 }
 
 // Write a request to the local stdio worker and resolve its response. The
@@ -179,6 +200,7 @@ function localRequest(req: ({ url: string } | { path: string }) & AnalyzeRequest
           loudnessLufs: parseFinite(msg.loudness_lufs),
           peakDb: parseFinite(msg.peak_db),
           sections: parseSections(msg.sections),
+          vocalRanges: parseVocalRanges(msg.vocal_ranges),
           audioEmbedding: parseAudioEmbedding(msg.audio_embedding),
         }),
       reject,
@@ -205,6 +227,8 @@ async function analyzeViaLocalPath(path: string, opts: AnalyzeRequestOpts = {}):
 // Last sidecar /health read of the CLAP capability. null = unknown (not yet
 // probed, or the field is absent on an old sidecar); true/false once known.
 let _sidecarAudioCapable: boolean | null = null;
+// Same, for vocal-activity (Demucs) support — null until probed/absent field.
+let _sidecarVocalCapable: boolean | null = null;
 
 async function sidecarReachable(): Promise<boolean> {
   const url = config.ttsHeavy.url;
@@ -215,10 +239,16 @@ async function sidecarReachable(): Promise<boolean> {
     const res = await fetch(`${url}/health`, { signal: ac.signal });
     clearTimeout(t);
     if (!res.ok) return false;
-    const body = (await res.json()) as { ok?: boolean; engines?: string[]; analyze_audio_capable?: boolean | null };
+    const body = (await res.json()) as {
+      ok?: boolean;
+      engines?: string[];
+      analyze_audio_capable?: boolean | null;
+      analyze_vocal_capable?: boolean | null;
+    };
     const reachable = !!body.ok && Array.isArray(body.engines) && body.engines.includes('analyze');
     if (reachable) {
       _sidecarAudioCapable = typeof body.analyze_audio_capable === 'boolean' ? body.analyze_audio_capable : null;
+      _sidecarVocalCapable = typeof body.analyze_vocal_capable === 'boolean' ? body.analyze_vocal_capable : null;
     }
     return reachable;
   } catch {
@@ -250,6 +280,7 @@ async function sidecarRequest(body: ({ url: string } | { path: string }) & Analy
       loudnessLufs: parseFinite(resBody.loudness_lufs),
       peakDb: parseFinite(resBody.peak_db),
       sections: parseSections(resBody.sections),
+      vocalRanges: parseVocalRanges(resBody.vocal_ranges),
       audioEmbedding: parseAudioEmbedding(resBody.audio_embedding),
     };
   } finally {
@@ -295,6 +326,14 @@ export function backendLabel(): string {
 // warning. Only meaningful for the sidecar backend.
 export function audioEmbeddingAvailable(): boolean | null {
   return _backend === 'sidecar' ? _sidecarAudioCapable : null;
+}
+
+// Whether the active backend can emit Demucs vocal-activity ranges right now.
+// Same semantics as audioEmbeddingAvailable: null = unknown (local, or sidecar
+// not yet reached / old sidecar without the field); false = sidecar built
+// without the demucs stack (WITH_DEMUCS=0). Only meaningful for the sidecar.
+export function vocalActivityAvailable(): boolean | null {
+  return _backend === 'sidecar' ? _sidecarVocalCapable : null;
 }
 
 // Re-read sidecar /health so capability reflects a sidecar rebuilt under a

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -49,6 +49,10 @@ export interface AnalysisResult {
   // Perceptual energy/momentum curve (decoupled from BPM), 0..1 per span. null
   // when the backend computed none; consumers treat null as "no signal".
   paceCurve: PaceSpan[] | null;
+  // Beat and downbeat (bar) timestamps in ms. null when the backend computed
+  // none; consumers treat null as "no grid" (today's blind crossfade).
+  beats: number[] | null;
+  bars: number[] | null;
   // Integrated loudness (LUFS, BS.1770) + peak (dBFS) over the analysis window,
   // when the backend has pyloudnorm. null otherwise — consumers treat null as
   // "no loudness, play at unity gain", so a backend without pyloudnorm behaves
@@ -95,6 +99,14 @@ function parseSections(v: unknown): Section[] | null {
 function parseVocalRanges(v: unknown): Section[] | null {
   if (!Array.isArray(v)) return null;
   return coerceSpans(v);
+}
+
+// A list of ms timestamps → sorted finite number[] or null (empty → null).
+function parseMsList(v: unknown): number[] | null {
+  if (!Array.isArray(v)) return null;
+  const out: number[] = [];
+  for (const x of v) if (typeof x === 'number' && Number.isFinite(x)) out.push(x);
+  return out.length ? out : null;
 }
 
 // Pace curve: spans carrying a 0..1 value. Drops malformed/zero-length spans;
@@ -227,6 +239,8 @@ function localRequest(req: ({ url: string } | { path: string }) & AnalyzeRequest
           sections: parseSections(msg.sections),
           vocalRanges: parseVocalRanges(msg.vocal_ranges),
           paceCurve: parsePaceCurve(msg.pace_curve),
+          beats: parseMsList(msg.beats),
+          bars: parseMsList(msg.bars),
           audioEmbedding: parseAudioEmbedding(msg.audio_embedding),
         }),
       reject,
@@ -308,6 +322,8 @@ async function sidecarRequest(body: ({ url: string } | { path: string }) & Analy
       sections: parseSections(resBody.sections),
       vocalRanges: parseVocalRanges(resBody.vocal_ranges),
       paceCurve: parsePaceCurve(resBody.pace_curve),
+      beats: parseMsList(resBody.beats),
+      bars: parseMsList(resBody.bars),
       audioEmbedding: parseAudioEmbedding(resBody.audio_embedding),
     };
   } finally {

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -32,7 +32,8 @@ export const TAGGER_VERSION = 3;
 // tagging and acoustic analysis run separately. Bump when the analysis shape
 // or method changes so `--re-analyze` / staleness checks can target old rows.
 // v2: added integrated loudness (loudness_lufs) + peak (peak_db).
-export const ANALYSIS_VERSION = 2;
+// v3: added structural sections (structure_json).
+export const ANALYSIS_VERSION = 3;
 
 // CLAP audio-embedding dim. Fixed by the model (LAION-CLAP's audio projection
 // is 512-d), so — unlike the text index in track_vectors — there's no per-model
@@ -95,6 +96,15 @@ export interface TrackRecord {
   analysisVersion: number | null;
   loudnessLufs: number | null; // integrated LUFS (BS.1770); null → unity gain
   peakDb: number | null;       // sample peak in dBFS over the analysis window
+  structure: TrackSection[] | null; // structural sections over the analysed window
+}
+
+// A structural span over a track, in milliseconds (RangedValue shape). Kept as
+// a local shape so library-db stays free of higher-layer imports.
+export interface TrackSection {
+  startMs: number;
+  endMs: number;
+  kind?: string;
 }
 
 export interface TrackMeta {
@@ -297,6 +307,13 @@ async function migrate(embeddingDim: number, reseed = false, adoptStoredDim = fa
       ALTER TABLE tracks ADD COLUMN peak_db       REAL;
     `);
     d.pragma('user_version = 4');
+  }
+
+  if (userVersion < 5) {
+    // Structural sections (JSON array of {startMs,endMs[,kind]}) over the
+    // analysed window. Nullable — NULL → no structure, today's behaviour.
+    runDdl(d, `ALTER TABLE tracks ADD COLUMN structure_json TEXT;`);
+    d.pragma('user_version = 5');
   }
 
   // The vec0 virtual table carries the embedding dim in its schema. If the
@@ -599,6 +616,7 @@ export interface TrackAnalysisWrite {
   confidence?: number | null;
   loudnessLufs?: number | null;
   peakDb?: number | null;
+  sections?: TrackSection[] | null;
 }
 
 // Write acoustic-analysis results for a track. Stamps ANALYSIS_VERSION so
@@ -614,6 +632,7 @@ export function upsertTrackAnalysis(id: string, a: TrackAnalysisWrite): void {
         analysis_confidence = ?,
         loudness_lufs       = ?,
         peak_db             = ?,
+        structure_json      = ?,
         analysis_version    = ?
       WHERE id = ?`,
     )
@@ -624,6 +643,7 @@ export function upsertTrackAnalysis(id: string, a: TrackAnalysisWrite): void {
       Number.isFinite(a.confidence as number) ? (a.confidence as number) : null,
       Number.isFinite(a.loudnessLufs as number) ? (a.loudnessLufs as number) : null,
       Number.isFinite(a.peakDb as number) ? (a.peakDb as number) : null,
+      a.sections && a.sections.length ? JSON.stringify(a.sections) : null,
       ANALYSIS_VERSION,
       id,
     );
@@ -645,7 +665,7 @@ export function clearAnalysis(): void {
   d.prepare(
     `UPDATE tracks SET bpm = NULL, musical_key = NULL, intro_ms = NULL,
       analysis_confidence = NULL, loudness_lufs = NULL, peak_db = NULL,
-      analysis_version = NULL`,
+      structure_json = NULL, analysis_version = NULL`,
   ).run();
   // The audio (CLAP) vectors are written in the same pass, so a --re-analyze
   // that redoes bpm/key drops them too — the next pass re-embeds from scratch.
@@ -1091,7 +1111,28 @@ function rowToTrack(row: any): TrackRecord {
     analysisVersion: row.analysis_version ?? null,
     loudnessLufs: row.loudness_lufs ?? null,
     peakDb: row.peak_db ?? null,
+    structure: row.structure_json ? safeParseSections(row.structure_json) : null,
   };
+}
+
+// Parse a structure_json column into clean TrackSection[] or null. Tolerates a
+// malformed/empty column the same way safeParseArray does for tag arrays.
+function safeParseSections(s: string): TrackSection[] | null {
+  try {
+    const v = JSON.parse(s);
+    if (!Array.isArray(v)) return null;
+    const out: TrackSection[] = [];
+    for (const x of v) {
+      const startMs = Number((x as any)?.startMs);
+      const endMs = Number((x as any)?.endMs);
+      if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) continue;
+      const kind = typeof (x as any)?.kind === 'string' ? (x as any).kind : undefined;
+      out.push(kind ? { startMs, endMs, kind } : { startMs, endMs });
+    }
+    return out.length ? out : null;
+  } catch {
+    return null;
+  }
 }
 
 function safeParseArray(s: string): string[] {

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -34,7 +34,8 @@ export const TAGGER_VERSION = 3;
 // v2: added integrated loudness (loudness_lufs) + peak (peak_db).
 // v3: added structural sections (structure_json).
 // v4: added the pace curve (pace_json).
-export const ANALYSIS_VERSION = 4;
+// v5: added the beat/bar grid (beats_json, bars_json).
+export const ANALYSIS_VERSION = 5;
 
 // CLAP audio-embedding dim. Fixed by the model (LAION-CLAP's audio projection
 // is 512-d), so — unlike the text index in track_vectors — there's no per-model
@@ -100,6 +101,8 @@ export interface TrackRecord {
   structure: TrackSection[] | null; // structural sections over the analysed window
   vocalRanges: TrackSection[] | null; // vocal-presence ranges; [] = instrumental, null = not computed
   pace: TrackPaceSpan[] | null;     // perceptual energy curve (0..1 per span)
+  beats: number[] | null;           // per-beat timestamps (ms)
+  bars: number[] | null;            // downbeat (bar) timestamps (ms)
 }
 
 // A structural span over a track, in milliseconds (RangedValue shape). Kept as
@@ -340,6 +343,16 @@ async function migrate(embeddingDim: number, reseed = false, adoptStoredDim = fa
     // time, 0..1. Nullable; NULL → no pace signal, today's behaviour.
     runDdl(d, `ALTER TABLE tracks ADD COLUMN pace_json TEXT;`);
     d.pragma('user_version = 7');
+  }
+
+  if (userVersion < 8) {
+    // Beat / bar grid (JSON arrays of ms timestamps). Nullable; NULL → no grid,
+    // today's blind crossfade.
+    runDdl(d, `
+      ALTER TABLE tracks ADD COLUMN beats_json TEXT;
+      ALTER TABLE tracks ADD COLUMN bars_json  TEXT;
+    `);
+    d.pragma('user_version = 8');
   }
 
   // The vec0 virtual table carries the embedding dim in its schema. If the
@@ -647,6 +660,8 @@ export interface TrackAnalysisWrite {
   // only a non-null array is written, so a vocal-off pass leaves the column be.
   vocalRanges?: TrackSection[] | null;
   pace?: TrackPaceSpan[] | null;
+  beats?: number[] | null;
+  bars?: number[] | null;
 }
 
 // Write acoustic-analysis results for a track. Stamps ANALYSIS_VERSION so
@@ -664,6 +679,8 @@ export function upsertTrackAnalysis(id: string, a: TrackAnalysisWrite): void {
         peak_db             = ?,
         structure_json      = ?,
         pace_json           = ?,
+        beats_json          = ?,
+        bars_json           = ?,
         -- COALESCE: vocal activity is gated separately (ANALYZE_VOCAL_ACTIVITY),
         -- so a normal bpm/key pass passes null here and must NOT wipe an
         -- existing vocal_ranges_json. A non-null value (incl. "[]" for an
@@ -681,6 +698,8 @@ export function upsertTrackAnalysis(id: string, a: TrackAnalysisWrite): void {
       Number.isFinite(a.peakDb as number) ? (a.peakDb as number) : null,
       a.sections && a.sections.length ? JSON.stringify(a.sections) : null,
       a.pace && a.pace.length ? JSON.stringify(a.pace) : null,
+      a.beats && a.beats.length ? JSON.stringify(a.beats) : null,
+      a.bars && a.bars.length ? JSON.stringify(a.bars) : null,
       a.vocalRanges != null ? JSON.stringify(a.vocalRanges) : null,
       ANALYSIS_VERSION,
       id,
@@ -703,8 +722,8 @@ export function clearAnalysis(): void {
   d.prepare(
     `UPDATE tracks SET bpm = NULL, musical_key = NULL, intro_ms = NULL,
       analysis_confidence = NULL, loudness_lufs = NULL, peak_db = NULL,
-      structure_json = NULL, pace_json = NULL, vocal_ranges_json = NULL,
-      analysis_version = NULL`,
+      structure_json = NULL, pace_json = NULL, beats_json = NULL, bars_json = NULL,
+      vocal_ranges_json = NULL, analysis_version = NULL`,
   ).run();
   // The audio (CLAP) vectors are written in the same pass, so a --re-analyze
   // that redoes bpm/key drops them too — the next pass re-embeds from scratch.
@@ -1167,7 +1186,21 @@ function rowToTrack(row: any): TrackRecord {
     // (not computed) maps to null. parseSpans keeps [] intact.
     vocalRanges: row.vocal_ranges_json != null ? parseSpans(row.vocal_ranges_json) : null,
     pace: row.pace_json ? parsePaceSpans(row.pace_json) : null,
+    beats: row.beats_json ? parseMsArray(row.beats_json) : null,
+    bars: row.bars_json ? parseMsArray(row.bars_json) : null,
   };
+}
+
+// Parse a JSON array of ms timestamps → finite number[] or null (empty → null).
+function parseMsArray(s: string): number[] | null {
+  try {
+    const v = JSON.parse(s);
+    if (!Array.isArray(v)) return null;
+    const out = v.filter((x): x is number => typeof x === 'number' && Number.isFinite(x));
+    return out.length ? out : null;
+  } catch {
+    return null;
+  }
 }
 
 // Parse a pace_json column into TrackPaceSpan[] or null. Empty/malformed → null.

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -33,7 +33,8 @@ export const TAGGER_VERSION = 3;
 // or method changes so `--re-analyze` / staleness checks can target old rows.
 // v2: added integrated loudness (loudness_lufs) + peak (peak_db).
 // v3: added structural sections (structure_json).
-export const ANALYSIS_VERSION = 3;
+// v4: added the pace curve (pace_json).
+export const ANALYSIS_VERSION = 4;
 
 // CLAP audio-embedding dim. Fixed by the model (LAION-CLAP's audio projection
 // is 512-d), so — unlike the text index in track_vectors — there's no per-model
@@ -98,6 +99,7 @@ export interface TrackRecord {
   peakDb: number | null;       // sample peak in dBFS over the analysis window
   structure: TrackSection[] | null; // structural sections over the analysed window
   vocalRanges: TrackSection[] | null; // vocal-presence ranges; [] = instrumental, null = not computed
+  pace: TrackPaceSpan[] | null;     // perceptual energy curve (0..1 per span)
 }
 
 // A structural span over a track, in milliseconds (RangedValue shape). Kept as
@@ -106,6 +108,13 @@ export interface TrackSection {
   startMs: number;
   endMs: number;
   kind?: string;
+}
+
+// A pace span: a 0..1 perceptual-energy value over a time range.
+export interface TrackPaceSpan {
+  startMs: number;
+  endMs: number;
+  value: number;
 }
 
 export interface TrackMeta {
@@ -324,6 +333,13 @@ async function migrate(embeddingDim: number, reseed = false, adoptStoredDim = fa
     // (needsVocalIds) skip instrumentals instead of re-separating them forever.
     runDdl(d, `ALTER TABLE tracks ADD COLUMN vocal_ranges_json TEXT;`);
     d.pragma('user_version = 6');
+  }
+
+  if (userVersion < 7) {
+    // Pace curve (JSON array of {startMs,endMs,value}) — perceptual energy over
+    // time, 0..1. Nullable; NULL → no pace signal, today's behaviour.
+    runDdl(d, `ALTER TABLE tracks ADD COLUMN pace_json TEXT;`);
+    d.pragma('user_version = 7');
   }
 
   // The vec0 virtual table carries the embedding dim in its schema. If the
@@ -630,6 +646,7 @@ export interface TrackAnalysisWrite {
   // [] is meaningful (analysed instrumental) vs null/undefined (not computed) —
   // only a non-null array is written, so a vocal-off pass leaves the column be.
   vocalRanges?: TrackSection[] | null;
+  pace?: TrackPaceSpan[] | null;
 }
 
 // Write acoustic-analysis results for a track. Stamps ANALYSIS_VERSION so
@@ -646,6 +663,7 @@ export function upsertTrackAnalysis(id: string, a: TrackAnalysisWrite): void {
         loudness_lufs       = ?,
         peak_db             = ?,
         structure_json      = ?,
+        pace_json           = ?,
         -- COALESCE: vocal activity is gated separately (ANALYZE_VOCAL_ACTIVITY),
         -- so a normal bpm/key pass passes null here and must NOT wipe an
         -- existing vocal_ranges_json. A non-null value (incl. "[]" for an
@@ -662,6 +680,7 @@ export function upsertTrackAnalysis(id: string, a: TrackAnalysisWrite): void {
       Number.isFinite(a.loudnessLufs as number) ? (a.loudnessLufs as number) : null,
       Number.isFinite(a.peakDb as number) ? (a.peakDb as number) : null,
       a.sections && a.sections.length ? JSON.stringify(a.sections) : null,
+      a.pace && a.pace.length ? JSON.stringify(a.pace) : null,
       a.vocalRanges != null ? JSON.stringify(a.vocalRanges) : null,
       ANALYSIS_VERSION,
       id,
@@ -684,7 +703,8 @@ export function clearAnalysis(): void {
   d.prepare(
     `UPDATE tracks SET bpm = NULL, musical_key = NULL, intro_ms = NULL,
       analysis_confidence = NULL, loudness_lufs = NULL, peak_db = NULL,
-      structure_json = NULL, vocal_ranges_json = NULL, analysis_version = NULL`,
+      structure_json = NULL, pace_json = NULL, vocal_ranges_json = NULL,
+      analysis_version = NULL`,
   ).run();
   // The audio (CLAP) vectors are written in the same pass, so a --re-analyze
   // that redoes bpm/key drops them too — the next pass re-embeds from scratch.
@@ -1146,7 +1166,27 @@ function rowToTrack(row: any): TrackRecord {
     // Preserve an empty array ("analysed instrumental"); only a SQL NULL column
     // (not computed) maps to null. parseSpans keeps [] intact.
     vocalRanges: row.vocal_ranges_json != null ? parseSpans(row.vocal_ranges_json) : null,
+    pace: row.pace_json ? parsePaceSpans(row.pace_json) : null,
   };
+}
+
+// Parse a pace_json column into TrackPaceSpan[] or null. Empty/malformed → null.
+function parsePaceSpans(s: string): TrackPaceSpan[] | null {
+  try {
+    const v = JSON.parse(s);
+    if (!Array.isArray(v)) return null;
+    const out: TrackPaceSpan[] = [];
+    for (const x of v) {
+      const startMs = Number((x as any)?.startMs);
+      const endMs = Number((x as any)?.endMs);
+      const value = Number((x as any)?.value);
+      if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || !Number.isFinite(value) || endMs <= startMs) continue;
+      out.push({ startMs, endMs, value });
+    }
+    return out.length ? out : null;
+  } catch {
+    return null;
+  }
 }
 
 // Parse a JSON span column into clean TrackSection[] (possibly empty). Drops

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -97,6 +97,7 @@ export interface TrackRecord {
   loudnessLufs: number | null; // integrated LUFS (BS.1770); null → unity gain
   peakDb: number | null;       // sample peak in dBFS over the analysis window
   structure: TrackSection[] | null; // structural sections over the analysed window
+  vocalRanges: TrackSection[] | null; // vocal-presence ranges; [] = instrumental, null = not computed
 }
 
 // A structural span over a track, in milliseconds (RangedValue shape). Kept as
@@ -314,6 +315,15 @@ async function migrate(embeddingDim: number, reseed = false, adoptStoredDim = fa
     // analysed window. Nullable — NULL → no structure, today's behaviour.
     runDdl(d, `ALTER TABLE tracks ADD COLUMN structure_json TEXT;`);
     d.pragma('user_version = 5');
+  }
+
+  if (userVersion < 6) {
+    // Vocal-presence ranges (Demucs), JSON array of {startMs,endMs}. NULL means
+    // not computed (vocal activity off / no demucs); a stored "[]" means
+    // analysed-and-instrumental. The distinct empty value lets the backfill scan
+    // (needsVocalIds) skip instrumentals instead of re-separating them forever.
+    runDdl(d, `ALTER TABLE tracks ADD COLUMN vocal_ranges_json TEXT;`);
+    d.pragma('user_version = 6');
   }
 
   // The vec0 virtual table carries the embedding dim in its schema. If the
@@ -617,6 +627,9 @@ export interface TrackAnalysisWrite {
   loudnessLufs?: number | null;
   peakDb?: number | null;
   sections?: TrackSection[] | null;
+  // [] is meaningful (analysed instrumental) vs null/undefined (not computed) —
+  // only a non-null array is written, so a vocal-off pass leaves the column be.
+  vocalRanges?: TrackSection[] | null;
 }
 
 // Write acoustic-analysis results for a track. Stamps ANALYSIS_VERSION so
@@ -633,6 +646,11 @@ export function upsertTrackAnalysis(id: string, a: TrackAnalysisWrite): void {
         loudness_lufs       = ?,
         peak_db             = ?,
         structure_json      = ?,
+        -- COALESCE: vocal activity is gated separately (ANALYZE_VOCAL_ACTIVITY),
+        -- so a normal bpm/key pass passes null here and must NOT wipe an
+        -- existing vocal_ranges_json. A non-null value (incl. "[]" for an
+        -- analysed instrumental) overwrites; null keeps what's there.
+        vocal_ranges_json   = COALESCE(?, vocal_ranges_json),
         analysis_version    = ?
       WHERE id = ?`,
     )
@@ -644,6 +662,7 @@ export function upsertTrackAnalysis(id: string, a: TrackAnalysisWrite): void {
       Number.isFinite(a.loudnessLufs as number) ? (a.loudnessLufs as number) : null,
       Number.isFinite(a.peakDb as number) ? (a.peakDb as number) : null,
       a.sections && a.sections.length ? JSON.stringify(a.sections) : null,
+      a.vocalRanges != null ? JSON.stringify(a.vocalRanges) : null,
       ANALYSIS_VERSION,
       id,
     );
@@ -665,7 +684,7 @@ export function clearAnalysis(): void {
   d.prepare(
     `UPDATE tracks SET bpm = NULL, musical_key = NULL, intro_ms = NULL,
       analysis_confidence = NULL, loudness_lufs = NULL, peak_db = NULL,
-      structure_json = NULL, analysis_version = NULL`,
+      structure_json = NULL, vocal_ranges_json = NULL, analysis_version = NULL`,
   ).run();
   // The audio (CLAP) vectors are written in the same pass, so a --re-analyze
   // that redoes bpm/key drops them too — the next pass re-embeds from scratch.
@@ -835,6 +854,18 @@ export function unanalysedAudioIds(limit?: number): string[] {
        WHERE v.id IS NULL ORDER BY t.id LIMIT ${Math.floor(limit)}`
     : `SELECT t.id FROM tracks t LEFT JOIN track_audio_vectors v ON v.id = t.id
        WHERE v.id IS NULL ORDER BY t.id`;
+  const rows = requireDb().prepare(q).all() as Array<{ id: string }>;
+  return rows.map(r => r.id);
+}
+
+// Ids with no vocal-activity analysis yet (vocal_ranges_json IS NULL — a stored
+// "[]" instrumental counts as done and is skipped). Independent of the bpm/key
+// scope, like unanalysedAudioIds, so the (expensive, opt-in) Demucs backfill
+// runs on its own cadence. Ordered for stable resumption.
+export function needsVocalIds(limit?: number): string[] {
+  const q =
+    `SELECT id FROM tracks WHERE vocal_ranges_json IS NULL ORDER BY id` +
+    (limit && limit > 0 ? ` LIMIT ${Math.floor(limit)}` : '');
   const rows = requireDb().prepare(q).all() as Array<{ id: string }>;
   return rows.map(r => r.id);
 }
@@ -1112,15 +1143,18 @@ function rowToTrack(row: any): TrackRecord {
     loudnessLufs: row.loudness_lufs ?? null,
     peakDb: row.peak_db ?? null,
     structure: row.structure_json ? safeParseSections(row.structure_json) : null,
+    // Preserve an empty array ("analysed instrumental"); only a SQL NULL column
+    // (not computed) maps to null. parseSpans keeps [] intact.
+    vocalRanges: row.vocal_ranges_json != null ? parseSpans(row.vocal_ranges_json) : null,
   };
 }
 
-// Parse a structure_json column into clean TrackSection[] or null. Tolerates a
-// malformed/empty column the same way safeParseArray does for tag arrays.
-function safeParseSections(s: string): TrackSection[] | null {
+// Parse a JSON span column into clean TrackSection[] (possibly empty). Drops
+// malformed/zero-length spans; returns [] on any parse error.
+function parseSpans(s: string): TrackSection[] {
   try {
     const v = JSON.parse(s);
-    if (!Array.isArray(v)) return null;
+    if (!Array.isArray(v)) return [];
     const out: TrackSection[] = [];
     for (const x of v) {
       const startMs = Number((x as any)?.startMs);
@@ -1129,10 +1163,16 @@ function safeParseSections(s: string): TrackSection[] | null {
       const kind = typeof (x as any)?.kind === 'string' ? (x as any).kind : undefined;
       out.push(kind ? { startMs, endMs, kind } : { startMs, endMs });
     }
-    return out.length ? out : null;
+    return out;
   } catch {
-    return null;
+    return [];
   }
+}
+
+// structure_json: empty collapses to null ("no structure"), unlike vocal ranges.
+function safeParseSections(s: string): TrackSection[] | null {
+  const out = parseSpans(s);
+  return out.length ? out : null;
 }
 
 function safeParseArray(s: string): string[] {

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -31,7 +31,8 @@ export const TAGGER_VERSION = 3;
 // writes (music/analyze-library.ts). Independent of TAGGER_VERSION — mood
 // tagging and acoustic analysis run separately. Bump when the analysis shape
 // or method changes so `--re-analyze` / staleness checks can target old rows.
-export const ANALYSIS_VERSION = 1;
+// v2: added integrated loudness (loudness_lufs) + peak (peak_db).
+export const ANALYSIS_VERSION = 2;
 
 // CLAP audio-embedding dim. Fixed by the model (LAION-CLAP's audio projection
 // is 512-d), so — unlike the text index in track_vectors — there's no per-model
@@ -92,6 +93,8 @@ export interface TrackRecord {
   introMs: number | null;
   analysisConfidence: number | null;
   analysisVersion: number | null;
+  loudnessLufs: number | null; // integrated LUFS (BS.1770); null → unity gain
+  peakDb: number | null;       // sample peak in dBFS over the analysis window
 }
 
 export interface TrackMeta {
@@ -283,6 +286,17 @@ async function migrate(embeddingDim: number, reseed = false, adoptStoredDim = fa
       );
     `);
     d.pragma('user_version = 3');
+  }
+
+  if (userVersion < 4) {
+    // Perceptual loudness — nullable, back-filled by the analyze pass. LUFS
+    // (integrated, BS.1770) drives per-track gain normalisation on playback;
+    // peak_db is informational. NULL → unity gain, i.e. today's behaviour.
+    runDdl(d, `
+      ALTER TABLE tracks ADD COLUMN loudness_lufs REAL;
+      ALTER TABLE tracks ADD COLUMN peak_db       REAL;
+    `);
+    d.pragma('user_version = 4');
   }
 
   // The vec0 virtual table carries the embedding dim in its schema. If the
@@ -583,6 +597,8 @@ export interface TrackAnalysisWrite {
   musicalKey?: string | null;
   introMs?: number | null;
   confidence?: number | null;
+  loudnessLufs?: number | null;
+  peakDb?: number | null;
 }
 
 // Write acoustic-analysis results for a track. Stamps ANALYSIS_VERSION so
@@ -596,6 +612,8 @@ export function upsertTrackAnalysis(id: string, a: TrackAnalysisWrite): void {
         musical_key         = ?,
         intro_ms            = ?,
         analysis_confidence = ?,
+        loudness_lufs       = ?,
+        peak_db             = ?,
         analysis_version    = ?
       WHERE id = ?`,
     )
@@ -604,6 +622,8 @@ export function upsertTrackAnalysis(id: string, a: TrackAnalysisWrite): void {
       a.musicalKey ?? null,
       Number.isFinite(a.introMs as number) ? Math.round(a.introMs as number) : null,
       Number.isFinite(a.confidence as number) ? (a.confidence as number) : null,
+      Number.isFinite(a.loudnessLufs as number) ? (a.loudnessLufs as number) : null,
+      Number.isFinite(a.peakDb as number) ? (a.peakDb as number) : null,
       ANALYSIS_VERSION,
       id,
     );
@@ -624,7 +644,8 @@ export function clearAnalysis(): void {
   const d = requireDb();
   d.prepare(
     `UPDATE tracks SET bpm = NULL, musical_key = NULL, intro_ms = NULL,
-      analysis_confidence = NULL, analysis_version = NULL`,
+      analysis_confidence = NULL, loudness_lufs = NULL, peak_db = NULL,
+      analysis_version = NULL`,
   ).run();
   // The audio (CLAP) vectors are written in the same pass, so a --re-analyze
   // that redoes bpm/key drops them too — the next pass re-embeds from scratch.
@@ -1068,6 +1089,8 @@ function rowToTrack(row: any): TrackRecord {
     introMs: row.intro_ms ?? null,
     analysisConfidence: row.analysis_confidence ?? null,
     analysisVersion: row.analysis_version ?? null,
+    loudnessLufs: row.loudness_lufs ?? null,
+    peakDb: row.peak_db ?? null,
   };
 }
 

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -35,7 +35,8 @@ export const TAGGER_VERSION = 3;
 // v3: added structural sections (structure_json).
 // v4: added the pace curve (pace_json).
 // v5: added the beat/bar grid (beats_json, bars_json).
-export const ANALYSIS_VERSION = 5;
+// v6: added per-region key ranges (key_ranges_json).
+export const ANALYSIS_VERSION = 6;
 
 // CLAP audio-embedding dim. Fixed by the model (LAION-CLAP's audio projection
 // is 512-d), so — unlike the text index in track_vectors — there's no per-model
@@ -103,6 +104,15 @@ export interface TrackRecord {
   pace: TrackPaceSpan[] | null;     // perceptual energy curve (0..1 per span)
   beats: number[] | null;           // per-beat timestamps (ms)
   bars: number[] | null;            // downbeat (bar) timestamps (ms)
+  keyRanges: TrackKeyRange[] | null; // per-region key (tonic + mode) over time
+}
+
+// A key over a time range: tonic note (sharps) + mode.
+export interface TrackKeyRange {
+  startMs: number;
+  endMs: number;
+  tonic: string;
+  mode: 'major' | 'minor';
 }
 
 // A structural span over a track, in milliseconds (RangedValue shape). Kept as
@@ -353,6 +363,13 @@ async function migrate(embeddingDim: number, reseed = false, adoptStoredDim = fa
       ALTER TABLE tracks ADD COLUMN bars_json  TEXT;
     `);
     d.pragma('user_version = 8');
+  }
+
+  if (userVersion < 9) {
+    // Per-region key ranges (JSON array of {startMs,endMs,tonic,mode}). Nullable;
+    // the scalar musical_key stays the back-compat dominant key.
+    runDdl(d, `ALTER TABLE tracks ADD COLUMN key_ranges_json TEXT;`);
+    d.pragma('user_version = 9');
   }
 
   // The vec0 virtual table carries the embedding dim in its schema. If the
@@ -662,6 +679,7 @@ export interface TrackAnalysisWrite {
   pace?: TrackPaceSpan[] | null;
   beats?: number[] | null;
   bars?: number[] | null;
+  keyRanges?: TrackKeyRange[] | null;
 }
 
 // Write acoustic-analysis results for a track. Stamps ANALYSIS_VERSION so
@@ -681,6 +699,7 @@ export function upsertTrackAnalysis(id: string, a: TrackAnalysisWrite): void {
         pace_json           = ?,
         beats_json          = ?,
         bars_json           = ?,
+        key_ranges_json     = ?,
         -- COALESCE: vocal activity is gated separately (ANALYZE_VOCAL_ACTIVITY),
         -- so a normal bpm/key pass passes null here and must NOT wipe an
         -- existing vocal_ranges_json. A non-null value (incl. "[]" for an
@@ -700,6 +719,7 @@ export function upsertTrackAnalysis(id: string, a: TrackAnalysisWrite): void {
       a.pace && a.pace.length ? JSON.stringify(a.pace) : null,
       a.beats && a.beats.length ? JSON.stringify(a.beats) : null,
       a.bars && a.bars.length ? JSON.stringify(a.bars) : null,
+      a.keyRanges && a.keyRanges.length ? JSON.stringify(a.keyRanges) : null,
       a.vocalRanges != null ? JSON.stringify(a.vocalRanges) : null,
       ANALYSIS_VERSION,
       id,
@@ -723,7 +743,7 @@ export function clearAnalysis(): void {
     `UPDATE tracks SET bpm = NULL, musical_key = NULL, intro_ms = NULL,
       analysis_confidence = NULL, loudness_lufs = NULL, peak_db = NULL,
       structure_json = NULL, pace_json = NULL, beats_json = NULL, bars_json = NULL,
-      vocal_ranges_json = NULL, analysis_version = NULL`,
+      key_ranges_json = NULL, vocal_ranges_json = NULL, analysis_version = NULL`,
   ).run();
   // The audio (CLAP) vectors are written in the same pass, so a --re-analyze
   // that redoes bpm/key drops them too — the next pass re-embeds from scratch.
@@ -1188,7 +1208,29 @@ function rowToTrack(row: any): TrackRecord {
     pace: row.pace_json ? parsePaceSpans(row.pace_json) : null,
     beats: row.beats_json ? parseMsArray(row.beats_json) : null,
     bars: row.bars_json ? parseMsArray(row.bars_json) : null,
+    keyRanges: row.key_ranges_json ? parseKeyRanges(row.key_ranges_json) : null,
   };
+}
+
+// Parse a key_ranges_json column into TrackKeyRange[] or null. Empty/malformed → null.
+function parseKeyRanges(s: string): TrackKeyRange[] | null {
+  try {
+    const v = JSON.parse(s);
+    if (!Array.isArray(v)) return null;
+    const out: TrackKeyRange[] = [];
+    for (const x of v) {
+      const startMs = Number((x as any)?.startMs);
+      const endMs = Number((x as any)?.endMs);
+      const tonic = (x as any)?.tonic;
+      const mode = (x as any)?.mode;
+      if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) continue;
+      if (typeof tonic !== 'string' || (mode !== 'major' && mode !== 'minor')) continue;
+      out.push({ startMs, endMs, tonic, mode });
+    }
+    return out.length ? out : null;
+  } catch {
+    return null;
+  }
 }
 
 // Parse a JSON array of ms timestamps → finite number[] or null (empty → null).

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -164,6 +164,7 @@ function slimTrack(r: db.TrackRecord) {
     introMs: r.introMs,
     loudnessLufs: r.loudnessLufs,
     structure: r.structure,
+    vocalRanges: r.vocalRanges,
   };
 }
 

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -162,6 +162,7 @@ function slimTrack(r: db.TrackRecord) {
     bpm: r.bpm,
     musicalKey: r.musicalKey,
     introMs: r.introMs,
+    loudnessLufs: r.loudnessLufs,
   };
 }
 

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -165,6 +165,11 @@ function slimTrack(r: db.TrackRecord) {
     loudnessLufs: r.loudnessLufs,
     structure: r.structure,
     vocalRanges: r.vocalRanges,
+    // Scalar mean pace (0..1) for the picker/LLM — the full curve stays in the
+    // record for UI/future use. null when un-analysed.
+    paceMean: r.pace && r.pace.length
+      ? Math.round((r.pace.reduce((s, p) => s + p.value, 0) / r.pace.length) * 1000) / 1000
+      : null,
   };
 }
 

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -163,6 +163,7 @@ function slimTrack(r: db.TrackRecord) {
     musicalKey: r.musicalKey,
     introMs: r.introMs,
     loudnessLufs: r.loudnessLufs,
+    structure: r.structure,
   };
 }
 

--- a/controller/src/music/mix.ts
+++ b/controller/src/music/mix.ts
@@ -98,7 +98,7 @@ export function mixCompat(cur: Analysis, next: Analysis): number {
 export function crossSecondsFor(
   cur: Analysis,
   next: Analysis,
-  opts: { energyDelta?: number } = {},
+  opts: { energyDelta?: number; nextIntroMs?: number | null } = {},
 ): number | null {
   if (!analysed(cur) || !analysed(next)) return null;
 
@@ -118,6 +118,17 @@ export function crossSecondsFor(
   // Daypart nudge: lower energy → longer, brisker → shorter. Subtle (±~0.5s).
   const energyDelta = opts.energyDelta ?? 0;
   secs += -energyDelta * 4;
+
+  // Structure-aware cap (feature: song structure): the incoming track plays
+  // from t=0 at the start of the cross buffer and its fade.in spans the whole
+  // buffer, so a buffer longer than the incoming track's instrumental intro
+  // would fade up over the first vocals. Cap the blend to the intro length so
+  // the fade-in completes before the song proper. Absent intro → no cap, i.e.
+  // today's behaviour. Floor at 3s so a near-zero intro still gets a real blend.
+  const introSec = typeof opts.nextIntroMs === 'number' && opts.nextIntroMs > 0
+    ? opts.nextIntroMs / 1000
+    : null;
+  if (introSec != null) secs = Math.min(secs, Math.max(3, introSec));
 
   // Clamp to a sane broadcast range and quantise to 0.1s.
   secs = Math.max(3, Math.min(14, secs));

--- a/controller/src/music/mix.ts
+++ b/controller/src/music/mix.ts
@@ -14,6 +14,25 @@ export interface Analysis {
   key: string | null;
 }
 
+// --- Loudness normalisation ------------------------------------------------
+// Target integrated loudness; streaming-standard −14 LUFS (Spotify/YouTube/
+// Apple Music). Gain is clamped to ±LOUDNESS_GAIN_CLAMP_DB so a mis-measured
+// outlier can't blow up the mix — Liquidsoap's brick-wall limiter still backs
+// us up, but the clamp keeps us well clear of it on normal catalogue audio.
+export const LOUDNESS_TARGET_LUFS = -14;
+export const LOUDNESS_GAIN_CLAMP_DB = 6;
+
+// dB gain to bring a track measured at `lufs` toward the target, clamped.
+// Returns null when the track has no loudness measurement (→ unity gain on the
+// playback side, i.e. today's behaviour). Result is rounded to 0.1 dB — finer
+// is inaudible and just bloats the annotate string.
+export function gainForLoudness(lufs: number | null | undefined): number | null {
+  if (typeof lufs !== 'number' || !Number.isFinite(lufs)) return null;
+  const raw = LOUDNESS_TARGET_LUFS - lufs;
+  const clamped = Math.max(-LOUDNESS_GAIN_CLAMP_DB, Math.min(LOUDNESS_GAIN_CLAMP_DB, raw));
+  return Math.round(clamped * 10) / 10;
+}
+
 // True when a track carries at least one measured value. An un-analysed track
 // (both null) makes every consumer below a no-op, so an un-analysed library
 // behaves exactly as before.

--- a/controller/src/music/mix.ts
+++ b/controller/src/music/mix.ts
@@ -119,6 +119,19 @@ export function crossSecondsFor(
   const energyDelta = opts.energyDelta ?? 0;
   secs += -energyDelta * 4;
 
+  // Beat-grid snap (feature: beat/bar grid): round the blend to a whole number
+  // of the OUTGOING track's bars (4 beats, 4/4) so the fade.out spans a musical
+  // unit instead of an arbitrary count. Only when the outgoing tempo is known
+  // and the snap stays in range; the intro cap below still wins over it.
+  if (cur.bpm && cur.bpm > 0) {
+    const barSec = (4 * 60) / cur.bpm;
+    if (barSec > 0) {
+      const bars = Math.max(1, Math.round(secs / barSec));
+      const snapped = bars * barSec;
+      if (snapped >= 3 && snapped <= 14) secs = snapped;
+    }
+  }
+
   // Structure-aware cap (feature: song structure): the incoming track plays
   // from t=0 at the start of the cross buffer and its fade.in spans the whole
   // buffer, so a buffer longer than the incoming track's instrumental intro

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -353,6 +353,10 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
           // the LLM only sees them when they're real.
           bpm: a.bpm ?? undefined,
           key: a.key ?? undefined,
+          // Perceptual energy 0..1 (mean pace), decoupled from BPM — lets the
+          // pick reason about build/release arcs, not just tempo. Omitted when
+          // un-analysed.
+          pace: c.paceMean ?? undefined,
           source: c._source || null,
           // Cosine similarity to the current track for the KNN sources
           // (embedding-similar / audio-similar). Omitted for the other sources,

--- a/controller/src/music/subsonic.ts
+++ b/controller/src/music/subsonic.ts
@@ -436,5 +436,13 @@ export function getAnnotatedUri(song) {
   // its fades, keeping fade == buffer). Absent → Liquidsoap uses its startup
   // crossfade_duration(), i.e. today's behaviour.
   if (song.crossSec != null) fields.push(`liq_cross_duration="${escAnnotate(song.crossSec)}"`);
+  // Loudness normalisation: the queue stashes a per-track gain offset (dB,
+  // clamped) toward the loudness target when the track has a measured LUFS.
+  // Emitted in the "<n> dB" form Liquidsoap's amplify override parses natively
+  // (the same shape as replaygain_track_gain). radio.liq applies it via
+  // amplify(override="liq_amplify") before the ducking layers so quiet and loud
+  // tracks play at even perceived volume — masters untouched, no bus
+  // normaliser. Absent → no gain applied, i.e. unity / today's behaviour.
+  if (song.gainDb != null) fields.push(`liq_amplify="${escAnnotate(song.gainDb)} dB"`);
   return `annotate:${fields.join(',')}:${getPlayableUri(song)}`;
 }

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -532,6 +532,13 @@ const DEFAULTS = {
   // enables it regardless of this toggle (env wins on, never off).
   audio: {
     embeddings: false,
+    // Demucs vocal-activity ranges — drives content-aware talk timing and a
+    // vocal-absence intro detector. When on, the analysis pass asks the backend
+    // for vocal ranges per track; the backend needs the demucs stack (tts-heavy
+    // built WITH_DEMUCS=1, or a local venv with torch+demucs) — without it the
+    // request is a clean no-op. ANALYZE_VOCAL_ACTIVITY=1 also enables it
+    // regardless of this toggle (env wins on, never off). Expensive — opt-in.
+    vocalActivity: false,
   },
   // Sound-effects library. When disabled, the segment-director agent is never
   // shown the effect catalogue, so it stops garnishing spoken breaks with
@@ -1003,6 +1010,7 @@ export async function load() {
     },
     audio: {
       embeddings: typeof stored.audio?.embeddings === 'boolean' ? stored.audio.embeddings : DEFAULTS.audio.embeddings,
+      vocalActivity: typeof stored.audio?.vocalActivity === 'boolean' ? stored.audio.vocalActivity : DEFAULTS.audio.vocalActivity,
     },
     sfx: {
       enabled: typeof stored.sfx?.enabled === 'boolean' ? stored.sfx.enabled : DEFAULTS.sfx.enabled,
@@ -1778,6 +1786,9 @@ export async function update(patch) {
     const au = patch.audio || {};
     if (au.embeddings !== undefined) {
       next.audio.embeddings = !!au.embeddings;
+    }
+    if (au.vocalActivity !== undefined) {
+      next.audio.vocalActivity = !!au.vocalActivity;
     }
   }
   if ('sfx' in patch) {

--- a/docker/Dockerfile.tts-heavy
+++ b/docker/Dockerfile.tts-heavy
@@ -135,7 +135,14 @@ RUN python3 -m venv /opt/server/venv && \
 # ANALYZE_AUDIO_EMBEDDING=1 is also set; without the build arg that env is a
 # no-op (the model import fails and the worker cleanly emits bpm/key only).
 # CPU-only torch via the download.pytorch.org index, mirroring the venvs above.
+#
+# Vocal-activity ranges (Demucs source separation) are a SECOND opt-in via
+# `--build-arg WITH_DEMUCS=1` — pulls CPU torch + torchaudio + demucs, also
+# ~1.5GB. Runtime-gated by ANALYZE_VOCAL_ACTIVITY=1; without the build arg the
+# model import fails and the worker cleanly omits vocal_ranges. The two flags
+# are independent but share the same CPU-torch index.
 ARG WITH_CLAP=0
+ARG WITH_DEMUCS=0
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ffmpeg libsndfile1 && \
     rm -rf /var/lib/apt/lists/* && \
@@ -148,6 +155,13 @@ RUN apt-get update && \
         --extra-index-url https://pypi.org/simple \
         torch transformers onnxruntime && \
       /opt/analyzer/venv/bin/python -c "import torch, transformers, onnxruntime" ; \
+    fi && \
+    if [ "$WITH_DEMUCS" = "1" ]; then \
+      /opt/analyzer/venv/bin/pip install --no-cache-dir \
+        --index-url https://download.pytorch.org/whl/cpu \
+        --extra-index-url https://pypi.org/simple \
+        torch torchaudio demucs && \
+      /opt/analyzer/venv/bin/python -c "import torch, demucs" ; \
     fi && \
     find /opt/analyzer/venv -depth -type d -name __pycache__ -exec rm -rf {} +
 

--- a/docker/Dockerfile.tts-heavy
+++ b/docker/Dockerfile.tts-heavy
@@ -122,7 +122,7 @@ RUN python3 -m venv /opt/server/venv && \
     /opt/server/venv/bin/pip install --no-cache-dir \
       fastapi "uvicorn[standard]" pydantic
 
-# --- Analyzer venv (librosa — bpm/key/intro; optional CLAP audio embeddings) -
+# --- Analyzer venv (librosa — bpm/key/intro/loudness; optional CLAP embeddings) -
 # Acoustic analysis for the controller's analyze pass. librosa/numba ship as
 # wheels (no g++ needed); ffmpeg + libsndfile1 give it broad codec coverage for
 # the Navidrome stream formats (opus/m4a/mp3). These two are runtime deps and
@@ -141,7 +141,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     python3 -m venv /opt/analyzer/venv && \
     /opt/analyzer/venv/bin/pip install --no-cache-dir --upgrade pip && \
-    /opt/analyzer/venv/bin/pip install --no-cache-dir librosa soundfile && \
+    /opt/analyzer/venv/bin/pip install --no-cache-dir librosa soundfile pyloudnorm && \
     if [ "$WITH_CLAP" = "1" ]; then \
       /opt/analyzer/venv/bin/pip install --no-cache-dir \
         --index-url https://download.pytorch.org/whl/cpu \

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -432,7 +432,7 @@ async def analyze(req: AnalyzeRequest):
     # Optional perceptual loudness + structural sections — present only when the
     # worker computed them. Pass through; omitted otherwise so the client maps
     # them to null (unity gain / no structure).
-    for k in ("loudness_lufs", "peak_db", "sections", "vocal_ranges"):
+    for k in ("loudness_lufs", "peak_db", "sections", "vocal_ranges", "pace_curve"):
         if k in msg:
             out[k] = msg[k]
     # Optional CLAP audio embedding — present only when the worker has the model

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -432,7 +432,7 @@ async def analyze(req: AnalyzeRequest):
     # Optional perceptual loudness + structural sections — present only when the
     # worker computed them. Pass through; omitted otherwise so the client maps
     # them to null (unity gain / no structure).
-    for k in ("loudness_lufs", "peak_db", "sections", "vocal_ranges", "pace_curve"):
+    for k in ("loudness_lufs", "peak_db", "sections", "vocal_ranges", "pace_curve", "beats", "bars"):
         if k in msg:
             out[k] = msg[k]
     # Optional CLAP audio embedding — present only when the worker has the model

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -420,6 +420,11 @@ async def analyze(req: AnalyzeRequest):
         "intro_ms": msg.get("intro_ms"),
         "confidence": msg.get("confidence"),
     }
+    # Optional perceptual loudness — present only when the worker has pyloudnorm.
+    # Pass through; omitted otherwise so the client maps it to null (unity gain).
+    for k in ("loudness_lufs", "peak_db"):
+        if k in msg:
+            out[k] = msg[k]
     # Optional CLAP audio embedding — present only when the worker has the model
     # loaded (ANALYZE_AUDIO_EMBEDDING + CLAP weights). Pass it straight through;
     # omitted otherwise so the controller's analyzer client maps it to null.

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -339,6 +339,11 @@ async def health():
         "analyze_audio_capable": (
             analyzer_worker.ready_meta.get("audio_embedding_capable") if analyzer_worker.ready else None
         ),
+        # Likewise for Demucs vocal-activity ranges — true only when built
+        # WITH_DEMUCS=1. None until the worker is ready.
+        "analyze_vocal_capable": (
+            analyzer_worker.ready_meta.get("vocal_activity_capable") if analyzer_worker.ready else None
+        ),
     }
 
 
@@ -398,6 +403,8 @@ class AnalyzeRequest(BaseModel):
     # worker lazy-load CLAP even without ANALYZE_AUDIO_EMBEDDING in its env;
     # None keeps the worker's env-driven default.
     embed: bool | None = None
+    # Same, for Demucs vocal-activity ranges (ANALYZE_VOCAL_ACTIVITY default).
+    vocal: bool | None = None
 
 
 @app.post("/analyze")
@@ -410,6 +417,8 @@ async def analyze(req: AnalyzeRequest):
         raise HTTPException(400, "missing 'url' or 'path'")
     if req.embed is not None:
         payload["embed"] = req.embed
+    if req.vocal is not None:
+        payload["vocal"] = req.vocal
     msg = await analyzer_worker.request(payload)
     if not msg.get("ok"):
         raise HTTPException(500, msg.get("error") or "analyze failed")
@@ -423,7 +432,7 @@ async def analyze(req: AnalyzeRequest):
     # Optional perceptual loudness + structural sections — present only when the
     # worker computed them. Pass through; omitted otherwise so the client maps
     # them to null (unity gain / no structure).
-    for k in ("loudness_lufs", "peak_db", "sections"):
+    for k in ("loudness_lufs", "peak_db", "sections", "vocal_ranges"):
         if k in msg:
             out[k] = msg[k]
     # Optional CLAP audio embedding — present only when the worker has the model

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -432,7 +432,10 @@ async def analyze(req: AnalyzeRequest):
     # Optional perceptual loudness + structural sections — present only when the
     # worker computed them. Pass through; omitted otherwise so the client maps
     # them to null (unity gain / no structure).
-    for k in ("loudness_lufs", "peak_db", "sections", "vocal_ranges", "pace_curve", "beats", "bars"):
+    for k in (
+        "loudness_lufs", "peak_db", "sections", "vocal_ranges",
+        "pace_curve", "beats", "bars", "key_ranges",
+    ):
         if k in msg:
             out[k] = msg[k]
     # Optional CLAP audio embedding — present only when the worker has the model

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -420,9 +420,10 @@ async def analyze(req: AnalyzeRequest):
         "intro_ms": msg.get("intro_ms"),
         "confidence": msg.get("confidence"),
     }
-    # Optional perceptual loudness — present only when the worker has pyloudnorm.
-    # Pass through; omitted otherwise so the client maps it to null (unity gain).
-    for k in ("loudness_lufs", "peak_db"):
+    # Optional perceptual loudness + structural sections — present only when the
+    # worker computed them. Pass through; omitted otherwise so the client maps
+    # them to null (unity gain / no structure).
+    for k in ("loudness_lufs", "peak_db", "sections"):
         if k in msg:
             out[k] = msg[k]
     # Optional CLAP audio embedding — present only when the worker has the model

--- a/docs/music-understanding-plan.md
+++ b/docs/music-understanding-plan.md
@@ -1,0 +1,196 @@
+# Plan: richer acoustic analysis, modelled on Apple's Music Understanding
+
+## Why
+
+SUB/WAVE's acoustic analysis is **scalar**. `analyze_worker.py` runs librosa and
+emits one `bpm`, one `musicalKey`, one `introMs`, one `confidence`, plus an
+optional CLAP audio vector (`analyzer.ts:20-30`); those land in the tracks table
+and feed the picker's re-rank and the `slimTrack` projection
+(`library.ts:150-166`). Mood/energy come from a *separate*, text-driven pipeline
+(enrich → embed → seed → propagate → active-learn, `tag-library.ts`) and are
+likewise coarse: a handful of mood strings plus a `low/medium/high` energy band.
+
+Apple shipped a framework at WWDC26 —
+[Music Understanding](https://developer.apple.com/documentation/musicunderstanding)
+— that does on-device music analysis, and its **data model** is the opposite of
+ours in exactly the way that matters for a radio station: analysis is
+**time-ranged, not whole-track**. Music changes within a song; collapsing a
+track to a single BPM or key or energy band throws away precisely the signal a
+DJ uses to mix, talk, and sequence.
+
+We can't *call* the framework — it's Swift-only, Apple-platforms-only, OS 27+,
+and our analyzer is a Linux Python sidecar. But its feature set and schema are a
+ready-made blueprint for what to compute in `analyze_worker.py` and how to store
+it. This doc captures that blueprint so development can start later.
+
+### What Music Understanding models (the reference)
+
+One actor, `MusicUnderstandingSession`, analyses an audio source and returns six
+result types — as a single aggregate **or** as a livestream of partial results:
+
+| Analysis | Shape | What it carries |
+|---|---|---|
+| **Rhythm** | `beats: [CMTime]`, `bars: [CMTime]`, `beatsPerMinute: Float?` | per-beat + per-bar timestamps, plus tempo |
+| **Key** | `[RangedValue<KeySignature>]` | tonic (enharmonic-preserving) + mode (major/minor) **over time ranges** |
+| **Loudness** | integrated / momentary[] / shortTerm[] / peak, all `TimedValue<Float>` | perceptual LUFS, ITU-R BS.1770 |
+| **Pace** | `[RangedValue<Double>]` | perceptual energy/momentum, events-per-minute, **decoupled from BPM** |
+| **Structure** | `sections` / `segments` / `phrases`, each `[CMTimeRange]` | intro/verse/chorus-style boundaries, hierarchical |
+| **Instrument activity** | `[Instrument: [TimedValue<Float>]]` + `[Instrument: [CMTimeRange]]` | vocal / drum / bass / other, 0–1 activity + detected ranges |
+
+Two schema primitives are worth stealing verbatim: **`TimedValue`** (a value at
+an instant) vs **`RangedValue`** (a value over a span). Instantaneous things
+(loudness samples, beat hits) are timed; things that hold over a region (key,
+pace, a structural section) are ranged. Both are `Codable`. If we add any of the
+below, mirror that split rather than inventing ad-hoc array shapes — and version
+it with the existing `ANALYSIS_VERSION` discipline.
+
+## Scope
+
+Six candidate features, each independently shippable and each degrading cleanly
+to today's behaviour when its column is NULL (un-analysed library, or a backend
+that doesn't compute it). Ordered by ROI **for radio**, not by closeness to the
+Apple API. Phases 1–3 are the recommended near-term set; 4–6 are follow-ups.
+
+Everything is computed in the existing heavy-DSP path. `analyze.ts` /
+`analyzer.ts` already give us a resumable, batched, two-backend (tts-heavy
+sidecar + local venv) pass with a one-ahead prefetch pipeline; we bolt new
+outputs onto the same decode, exactly as the CLAP work did
+(see `docs/audio-embeddings-plan.md`).
+
+---
+
+## Phase 1 — Integrated loudness (LUFS) → gain normalisation
+
+**Highest ROI, lowest effort.** We have *no* perceptual loudness today, and
+CLAUDE.md records that the Liquidsoap normaliser and bus-compressor were
+deliberately removed because they "reshaped the masters" (broadcast bus is a
+brick-wall limiter only, step 8). LUFS solves that the right way: measure, don't
+reshape.
+
+- **Worker** (`analyze_worker.py`): compute **integrated loudness** over the
+  decoded window with `pyloudnorm` (ITU-R BS.1770 / EBU R128, ~10 lines on the
+  audio we already decode). Emit `loudness_lufs` (a float) and optionally
+  `peak_db`. Gate behind nothing — it's cheap; just add the fields.
+- **Storage** (`library-db.ts`): a nullable `loudness_lufs` column on the tracks
+  table, written alongside bpm/key in `upsertTrackAnalysis`
+  (`analyze.ts:135-140`), under the same `ANALYSIS_VERSION` bump.
+- **Playback** (`subsonic.ts:getAnnotatedUri`): translate LUFS to a per-track
+  **gain offset** toward a target (e.g. −14 LUFS) and fold it into the
+  `annotate:` string Liquidsoap already consumes. Quiet and loud tracks then
+  play at consistent perceived loudness with **zero** changes to the master bus
+  — no normaliser, no compressor, masters untouched. This is the cleanest win on
+  the board and directly retires a known workaround.
+
+**Done when:** a mixed-loudness library plays at even volume and the master bus
+is still just the limiter.
+
+## Phase 2 — Song structure (intro / outro / section boundaries)
+
+We only have `introMs` today. Apple models full structural time-ranges; for
+radio this is the highest-value addition after loudness because it makes two
+existing systems *musical* instead of fixed.
+
+- **Worker**: segment the decoded audio into structural boundaries with
+  `librosa` (recurrence-matrix / spectral-clustering segmentation) or `msaf`.
+  Emit at least `sections: [{startMs, endMs}]`; the leading and trailing
+  sections give a far better intro/outro than the current single `introMs`.
+- **Storage**: a `structure_json` column (typed, mirroring `RangedValue` — an
+  array of `{startMs, endMs, kind?}`), versioned.
+- **Crossfade** (`radio.liq`): the cross is currently a **fixed buffer**
+  (CLAUDE.md step 3). Knowing where the final section/outro begins lets the
+  controller pick a cross length and start point that land on a real boundary
+  instead of blindly. Keep CLAUDE.md's rule — fade duration equals the buffer;
+  vary the *buffer*, never the fade-within-buffer.
+- **Talk timing** (`broadcast/queue.js` `announce()`): schedule station
+  IDs / links to land over the **instrumental** intro/outro, never mid-section.
+
+**Done when:** the DJ talks over intros, not vocals, and crossfades begin at
+section boundaries.
+
+## Phase 3 — Instrument activity (vocal presence)
+
+Apple's `InstrumentActivityResult` splits audio into vocal / drum / bass / other
+activity over time. The single most useful slice for us is **vocal-presence
+ranges**.
+
+- **Worker**: run a source-separation model — **Demucs** (htdemucs) is the
+  standard — and derive per-stem activity envelopes; at minimum a boolean/0–1
+  **vocal-activity** track over time. This is the heaviest lift here (a real
+  model in the sidecar), but it reuses the existing heavy-sidecar pattern and
+  can stay gated behind an env flag like CLAP (`ANALYZE_AUDIO_EMBEDDING`).
+- **Storage**: `vocal_ranges_json` (`[{startMs, endMs}]`), versioned; optionally
+  full per-stem activity if cheap to keep.
+- **Payoff (a):** the two-layer `smooth_add` ducking (CLAUDE.md step 5) gets a
+  *content-aware* partner — talk-up only where there are no vocals.
+- **Payoff (b):** a much better intro/outro detector than `introMs` ("leading
+  region with no vocal activity") — overlaps with and sharpens Phase 2.
+
+**Done when:** the DJ never talks over a vocal line, and intro detection comes
+from vocal absence rather than a heuristic.
+
+## Phase 4 — Pace (tempo-independent energy curve)
+
+`energy` today is a coarse whole-track `low/medium/high` LLM tag
+(`tag-library.ts`). Apple's Pace is a **continuous** perceptual energy curve,
+explicitly decoupled from BPM (their example: a high-BPM track reads *low* pace
+during a sparse breakdown).
+
+- **Worker**: approximate via onset-rate / spectral-flux energy over windows;
+  emit `pace_curve: [{startMs, endMs, value}]` (RangedValue-shaped).
+- **Storage**: `pace_json`, versioned.
+- **Payoff**: energy-aware sequencing in `music/picker.ts` — build/release arcs,
+  avoid stacking two peaks, match transitions on energy not just genre/mood.
+  Complements the sonic-journey idea in `docs/audio-embeddings-plan.md` (audio
+  KNN says "sounds like"; pace says "has the energy shape I want next").
+
+## Phase 5 — Beat / bar grid (beatmatched crossfades)
+
+Apple exposes per-beat and per-bar timestamps, not just BPM — and `librosa.beat`
+already gives us these; we currently **discard** them and keep only the scalar.
+
+- **Worker**: emit `beats: [ms]` and `bars: [ms]` (or downbeat positions)
+  alongside the existing `bpm`.
+- **Storage**: `beats_json` / `bars_json`, versioned.
+- **Payoff**: align a crossfade to land on a **downbeat** and choose a
+  bar-aligned cross length — a beatmatched mix instead of a blind fade. Pairs
+  naturally with Phase 2's boundary-aware crossfade.
+
+## Phase 6 — Structured key (tonic + mode) over time
+
+`musicalKey` is one string today. Apple keeps **tonic** (enharmonic-preserving)
+and **mode** (major/minor) as separate structured fields, *over ranges*.
+
+- **Worker**: chroma over windows → key per region; emit `key_ranges:
+  [{startMs, endMs, tonic, mode}]`.
+- **Storage**: structured columns / `key_ranges_json`, versioned. Keep the
+  legacy scalar `musical_key` populated (dominant key) for back-compat.
+- **Payoff**: harmonic / Camelot-wheel mixing — "mix into a key-compatible
+  track." Lower priority for a personal station, but cheap to store correctly
+  once we're already computing chroma.
+
+---
+
+## Cross-cutting notes
+
+- **Schema discipline.** Every new output is a nullable column written by
+  `upsertTrackAnalysis`, gated by `ANALYSIS_VERSION` so a bump re-targets tracks
+  via `needsAnalysisIds` (`analyze.ts:72`) without a full `--re-analyze`. Same
+  resumability and provenance the pipeline already has.
+- **Graceful degradation is mandatory.** Mirror the CLAP precedent: a backend
+  that doesn't compute a field simply omits it, the column stays NULL, and every
+  consumer treats NULL as "no signal" — byte-for-byte today's behaviour. No new
+  feature may make the analysis pass a hard failure.
+- **TimedValue vs RangedValue.** Adopt the two shapes as the convention for all
+  time-aware columns: `{ms, value}` for instants, `{startMs, endMs, value}` for
+  spans. Keeps the JSON columns self-describing and consistent.
+- **What this is *not*.** We are not porting Apple's API or trying to match it
+  symbol-for-symbol; we're borrowing its model. The deliverables live entirely
+  in `analyze_worker.py`, `library-db.ts`, `subsonic.ts`, and `radio.liq`.
+
+## Suggested order
+
+**1 → 2 → 3** is the recommended near-term track: loudness retires a known
+workaround immediately; structure and vocal-activity then combine to make
+crossfades and talk-timing musical (they share the intro/outro payoff). 4–6 are
+independent follow-ups that sharpen sequencing and mixing once the structural
+foundation exists.

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -197,6 +197,16 @@ end
 # one song behind until the next crossfade.
 music_meta = music
 
+# Per-track loudness normalisation. The controller stamps `liq_amplify` (in the
+# "<n> dB" form, via subsonic.getAnnotatedUri) on any track with a measured LUFS;
+# `amplify` reads it per track — exactly the ReplayGain mechanism. Base factor
+# 1.0 = unity, so a track without the metadata (un-analysed library, or no
+# pyloudnorm) plays untouched. Applied BEFORE the cross so each track carries its
+# own gain into the crossfade, and AFTER the music_meta capture so the
+# on_metadata hook still sees clean pre-cross metadata. No master-bus normaliser
+# is involved — the broadcast bus stays the brick-wall limiter only.
+music = amplify(override="liq_amplify", 1., music)
+
 music = cross(
   duration=crossfade_duration(),
   dj_transition,


### PR DESCRIPTION
## What

Implements all six features from `docs/music-understanding-plan.md` — richer, time-ranged acoustic analysis modelled on Apple's WWDC26 Music Understanding framework. Each feature is computed in the existing heavy-DSP analyze path, stored as a nullable column, and **degrades cleanly to today's behaviour when NULL** (un-analysed library, or a backend without the relevant dependency).

Built as one commit per phase so it can be reviewed incrementally. **Work in progress — to be continued.** Two consumer payoffs are intentionally deferred (see below).

## Phases

| Phase | Feature | Highlights |
|---|---|---|
| 1 | **LUFS gain** | `pyloudnorm` integrated loudness → per-track `liq_amplify` gain toward −14 LUFS (±6 dB clamp), via Liquidsoap's ReplayGain mechanism. Retires the deliberately-removed bus normaliser by measuring, not reshaping. |
| 2 | **Song structure** | librosa agglomerative sections; intro-aware crossfade cap so the incoming fade-in finishes before the vocals. |
| 3 | **Vocal ranges** | Demucs vocal-presence ranges (opt-in: `WITH_DEMUCS` build + `ANALYZE_VOCAL_ACTIVITY` / `settings.audio.vocalActivity`); vocal-onset intro detection; dedicated backfill scope. |
| 4 | **Pace curve** | onset-strength perceptual energy curve (decoupled from BPM); scalar mean pace surfaced to the LLM picker. |
| 5 | **Beat/bar grid** | per-beat + 4/4 downbeat timestamps (previously discarded); bar-aligned crossfade snap. |
| 6 | **Structured key** | per-region tonic + mode over time; scalar `musical_key` kept for back-compat. |

## Design invariants held throughout

- **Uniform write path** every phase: worker emits (omit-on-failure) → `analyzer.ts` coerces both backends → `analyze.ts` forwards → `library-db.ts` migration + `upsertTrackAnalysis` + `rowToTrack` → consumer.
- **NULL-degrades everywhere.** No new feature can turn the analysis pass into a hard failure; the broadcast bus stays the brick-wall limiter only — masters untouched.
- **Schema discipline.** Migrations v4→v9; `ANALYSIS_VERSION` 1→6 (bumped for main-pass outputs). Vocal activity is **not** a version bump — it's opt-in via a backfill scope + a `COALESCE` write so a normal bpm/key pass never wipes existing Demucs data.
- **Heavy deps gated** like CLAP: `pyloudnorm` is base (cheap); Demucs behind a build arg + runtime flag.

## Deferred (good follow-ups, noted in commits)

- Content-aware ducking talk-window scheduling (Phase 3 payoff a).
- Per-section harmonic mixing in the picker (Phase 6 payoff).
- Boundary-aligned **outro** crossfade — the 60s analysis window only reliably yields intro-side structure; the outro side needs a fuller decode.

## Verification

- `tsc --noEmit` clean, eslint 0 errors, both Python workers `py_compile` clean.
- Pure helpers spot-checked via `tsx`: `gainForLoudness` clamp, `crossSecondsFor` intro-cap + bar-snap, vocal null/`[]` semantics.
- **Not yet run on real audio / Liquidsoap** (containerized deps): the worker against a library and a `liquidsoap --check`, plus the live even-loudness / boundary-crossfade checks per the plan's verification section.
