### PR TITLE
docs(app): mark iOS app live on the App Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It's *radio*, not a playlist. No per-listener shuffle, no skip button, no
 
 - **Project site** — [getsubwave.com](https://www.getsubwave.com/)
 - **Demo player** — [getsubwave.com/listen](https://www.getsubwave.com/listen)
-- **Mobile apps** — native players — [Android on Google Play](https://play.google.com/store/apps/details?id=com.getsubwave.app), [iOS via TestFlight](https://testflight.apple.com/join/Xrx5TUmb)
+- **Mobile apps** — native players — [iOS on the App Store](https://apps.apple.com/app/sub-wave/id6778786696), [Android on Google Play](https://play.google.com/store/apps/details?id=com.getsubwave.app)
 - **Setup walkthrough** — [getsubwave.com/setup](https://www.getsubwave.com/setup)
 - **Operator manual** — [getsubwave.com/manual](https://www.getsubwave.com/manual)
 - **Community** — [join the Discord](https://discord.gg/vjVbVKnMBa)
@@ -47,7 +47,7 @@ It's *radio*, not a playlist. No per-listener shuffle, no skip button, no
 - **Five TTS engines.** Piper and Kokoro in-process for fast local speech, plus an optional `tts-heavy` sidecar (`docker compose --profile tts-heavy up -d`) that adds Chatterbox (zero-shot voice cloning) and PocketTTS (6× real-time, EN/FR/DE/IT/ES/PT). Cloud (OpenAI / ElevenLabs) is also available. Pick a different engine per kind of speech.
 - **Multiple DJ personas.** Up to 10 souls in rotation, each with its own voice and writing style.
 - **Dual-codec broadcast.** MP3 128 kbps for Sonos, hardware radios, and cars; Ogg-Opus 96 kbps for modern browsers. The web player picks automatically.
-- **Native apps, PWA, and TUI.** Native iOS (TestFlight beta) and Android (on Google Play) players — background audio, lock-screen / CarPlay / Android Auto controls, multi-station — an installable PWA on phone and desktop, and a TUI for the command line.
+- **Native apps, PWA, and TUI.** Native iOS (on the App Store) and Android (on Google Play) players — background audio, lock-screen / CarPlay / Android Auto controls, multi-station — an installable PWA on phone and desktop, and a TUI for the command line.
 - **Scheduled shows.** A 24×7 grid; each slot has its own persona, mood, and skills.
 - **Pluggable skills.** The DJ's between-track segments — weather, news, traffic, and your own — are skills. The built-ins are scaffolded as editable files under `state/skills/<kind>/` on first boot, so you can rewrite a brief or change the news feed (BBC → your own RSS) right from the admin console — no code, no redeploy. Add your own by dropping a `SKILL.md` (plus optional data-fetching code) into `state/skills/`, hitting Rescan, and enabling it. See [`docs/custom-skills.md`](docs/custom-skills.md).
 - **Mood-aware rotation.** Time of day, weather, and festival days bias what gets played and how the DJ talks.

--- a/web/components/manual/Clients.tsx
+++ b/web/components/manual/Clients.tsx
@@ -80,9 +80,9 @@ export default function Clients() {
           the apps below use, typed in once and saved.
         </p>
         <p className="text-muted">
-          Android is live on Google Play: install it like any other app, and it
-          auto-updates from then on. iOS is in public beta over TestFlight while it works
-          through the App Store (install the TestFlight app first):
+          Both are live in their stores: download from the App Store on iPhone and
+          iPad, or Google Play on Android. Install it like any other app, and it
+          auto-updates from then on.
         </p>
         <table className="bs-doc-table">
           <thead>
@@ -109,23 +109,24 @@ export default function Clients() {
               <td><strong>iOS</strong></td>
               <td>
                 <a
-                  href="https://testflight.apple.com/join/Xrx5TUmb"
+                  href="https://apps.apple.com/app/sub-wave/id6778786696"
                   className="bs-link"
                   target="_blank"
                   rel="noreferrer"
                 >
-                  TestFlight ↗
-                </a>{' '}
-                (public beta)
+                  App Store ↗
+                </a>
               </td>
             </tr>
           </tbody>
         </table>
         <div className="bs-callout">
-          <div className="bs-eyebrow">APP STORE</div>
+          <div className="bs-eyebrow">NOT JUST THIS STATION</div>
           <p>
-            Android is on Google Play now; the iOS App Store listing follows once the
-            TestFlight beta settles. Until then, TestFlight is the way in on iPhone and iPad.
+            The apps default to the public station, but they aren&rsquo;t tied to it. Add
+            any other SUB/WAVE instance by its address and switch between saved stations
+            from inside the app &mdash; the same way you&rsquo;d point the audio-only
+            players below at a stream URL.
           </p>
         </div>
       </section>


### PR DESCRIPTION
The iOS app is now published on the App Store — no longer TestFlight-only:
https://apps.apple.com/app/sub-wave/id6778786696

## Changes

- **`README.md`** — "Live demo" links now lead with **iOS on the App Store**; the "Native apps" feature bullet changed from "iOS (TestFlight beta)" → "iOS (on the App Store)".
- **`web/components/manual/Clients.tsx`** — iOS prose rewritten ("Both are live in their stores…"), the table's iOS row points to the App Store (`App Store ↗` instead of `TestFlight ↗`), and the now-obsolete "App Store listing follows" callout was replaced with a "not tied to one station — add any instance" note.

The unrelated VLC-for-Mobile App Store mention on the Clients page is left intact.

## Also done outside this PR
- GitHub discussion #289 body + comment #17251126 updated to point at the App Store.

## Notes
- Pure content/link edits inside existing valid JSX. Not lint-checked locally (worktree had no `node_modules`); CI lint covers it.