### PR TITLE
chore(app): bump marketing version to 1.1.0

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "SUB/WAVE",
     "slug": "subwave",
     "scheme": "subwave",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## What

Bumps `expo.version` in `app/app.json` from **1.0.0 → 1.1.0**.

## Why

Both apps are live in production at 1.0.0. After today's **expo-blur** native change (frosted transport bar), a fresh native build is required — and the App Store **rejects a resubmission under the same `CFBundleShortVersionString`**, so the marketing version must increment. A minor bump fits today's user-facing work (frosted transport bar, community stations in Discover, Library Observatory, richer acoustic analysis).

`versionCode` (Android) and `buildNumber` (iOS) continue to auto-increment via EAS — only the marketing version is hand-edited.

## Release status

- iOS 1.1.0 build queued on EAS → auto-submits to TestFlight, then manual App Store Connect promotion.
- Android 1.1.0 `.aab` queued → manual upload to Play Console.