### PR TITLE
docs(skills): capture the live-app version-bump rule

### DIFF
--- a/.claude/skills/subwave-app-android-release/SKILL.md
+++ b/.claude/skills/subwave-app-android-release/SKILL.md
@@ -164,8 +164,16 @@ on EAS; you don't need to rebuild to re-share.
 
 - **Another test build of the same version** (the common case): change nothing
   and rebuild — internal APKs install over each other regardless of build number.
-- **New marketing version** (e.g. `1.0.0` → `1.0.1`, what testers see): edit
+- **New marketing version** (e.g. `1.0.0` → `1.1.0`, what users see): edit
   `expo.version` in `app/app.json` first, commit, then rebuild.
+
+Unlike Apple, **Play won't reject a same-`versionName` upload** — it keys
+releases on `versionCode` (which `autoIncrement` always bumps), so you *can*
+upload a new build under an unchanged marketing version. But when you're cutting a
+real public release alongside iOS (which *does* force a bump — see the iOS skill),
+bump `expo.version` here too so both stores show the same version. Don't pin the
+current version/`versionCode` in this doc — read `expo.version` from
+`app/app.json` and `eas build:list` for the live `versionCode`.
 
 You don't hand-edit `versionCode` — the `production` profile's `autoIncrement`
 owns it (it only matters for the Play Store path; internal APKs don't care).

--- a/.claude/skills/subwave-app-ios-release/SKILL.md
+++ b/.claude/skills/subwave-app-ios-release/SKILL.md
@@ -159,16 +159,33 @@ after the build submits.
 
 Decide which kind of release this is:
 
-- **New TestFlight build of the same app version** (the common case — a fix, a
-  tweak): change nothing. `autoIncrement` gives it a fresh build number. Just run
-  the release command.
-- **New marketing version** (e.g. `1.0.0` → `1.0.1`, what testers see as the
-  version): edit `expo.version` in `app/app.json` first, commit it, then release.
-  The build number still auto-increments under it.
+- **Another TestFlight build of a version Apple hasn't released yet** (a fix, a
+  tweak still in beta): change nothing. `autoIncrement` gives it a fresh build
+  number under the same `expo.version`. Just run the release command.
+- **A new public App Store release** (the live-app case): you **must** bump
+  `expo.version` in `app/app.json` first (e.g. `1.0.0` → `1.1.0`), commit, then
+  release. The build number still auto-increments under it.
+
+**Live-app gotcha — once a marketing version is released on the App Store, you
+can't ship to the public store again under that same version.** `--auto-submit`
+(or `eas submit`) will fail at the submission step with:
+
+```
+You've already submitted this version of the app.
+Versions are identified by CFBundleShortVersionString (expo.version)…
+```
+
+The **build still succeeds** — only the submit is rejected — so the fix is: bump
+`expo.version`, commit, rebuild. SUB/WAVE is **live on the App Store**, so treat a
+version bump as **mandatory for every public release**, not optional. (TestFlight
+alone would take another build under the same version; the public store will
+not.) Don't query/guess the current version — read `expo.version` from
+`app/app.json` and the released version from App Store Connect.
 
 You only hand-edit `app.json`'s `version`. You never set `buildNumber` —
 `appVersionSource: "remote"` means EAS is the source of truth for it, and setting
-it locally would fight EAS.
+it locally would fight EAS. The current build number isn't worth recording here
+either — it auto-increments every build; check `eas build:list` for the live value.
 
 ## When something needs Apple auth again (rare)
 


### PR DESCRIPTION
## What

Follow-up to #377 — that PR was merged before this commit landed in it, so the **version-bump lesson** never made it onto `develop`. Re-landing it.

Adds to both app-release skills the rule we hit during today's 1.1.0 release:

- **iOS:** once a marketing version is released on the App Store, `eas build --auto-submit` (and `eas submit`) **fails at the submit step** with *"You've already submitted this version of the app"* unless `expo.version` is bumped. The **build** succeeds — only the submission is rejected. Documented as **mandatory for every public iOS release**, replacing the old "common case = change nothing" framing (that only holds for TestFlight-only betas).
- **Android:** the contrast — Play keys releases on `versionCode` (always auto-incremented), so it **won't reject** a same-`versionName` upload; but bump `expo.version` anyway to keep both stores on the same version.
- Both: explicit "**don't hardcode** the current version / build number — read `expo.version` from `app.json` and `eas build:list` for the live build number/versionCode."

## Why

Docs-only. Prevents a future release run from blindly `--auto-submit`-ing a live app and hitting the same Apple rejection.