### PR TITLE
fix(broadcast): soften heavy voice duck from 15% to 22%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ tmp/
 
 # Source screenshots — originals kept local; site uses web/public/screenshots/*.webp
 docs/screenshots/
+
+# Local host-specific compose overrides (CPU caps, etc.)
+docker-compose.override.yml

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -374,7 +374,7 @@ music_bus =
 #
 #   voice_queue (say.txt)  → HEAVY duck. Request intros, station IDs, hourly
 #                            time checks, weather. The voice is the focus;
-#                            music drops well underneath to ~10%.
+#                            music drops well underneath to ~22%.
 #   intro_queue (intro.txt) → LIGHT duck. Between-track auto-DJ links. The
 #                            song that just started should still be audible
 #                            under the voice, so we only dip to ~40%.
@@ -396,7 +396,7 @@ ducked = smooth_add(
                     # clip pushed ahead of the speech (see poll_voice /
                     # poll_intro) so this dip completes BEFORE the DJ starts
                     # talking, and ramps back up after.
-  p={0.15},         # music drops to 15% (~-16 dB) while voice plays
+  p={0.22},         # music drops to 22% (~-13 dB) while voice plays
   normal=music_bus,
   special=voice
 )


### PR DESCRIPTION
## What

Bumps the **heavy voice-duck** ratio in \`liquidsoap/radio.liq\` from \`p={0.15}\` to \`p={0.22}\` (~-16 dB → ~-13 dB).

## Why

\`say.txt\` segments — station IDs, hourly time, weather, and listener-request back-announces — pass through the heavy \`smooth_add\` layer, which ducked the music down to 15%. Under a full-volume TTS voice, 15% is masked enough that the music *sounds* like it stopped entirely. At 22% the bed stays audibly present underneath the voice while the voice remains the focus.

Between-track auto-DJ links (\`intro.txt\`, the light layer at 30%) are intentionally **unchanged**.

## Notes

- \`radio.liq\` is baked into the broadcast image in prod, so deploying this needs \`docker compose up -d --build broadcast\` (a plain restart reruns the same baked-in script).
- Duck depth is a pure tuning knob — easy to nudge further (0.22–0.25 range) if it's still too aggressive or now too present.