### PR TITLE
fix(broadcast): fix crossfade buffer/fade mismatch causing gaps

### DIFF
--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -354,7 +354,10 @@ class Queue {
     try { energyDelta = energyForDaypart().speed - 1; } catch {}
     let nextIntroMs = item.track.introMs;
     if (nextIntroMs == null && item.track.id) nextIntroMs = library.get(item.track.id)?.introMs ?? null;
-    const secs = mix.crossSecondsFor(cur, next, { energyDelta, nextIntroMs });
+    // Cap the adaptive blend at the operator's configured crossfade length so the
+    // admin slider acts as a real ceiling on DJ-mode transitions too.
+    const maxSec = settings.get()?.crossfadeDuration ?? null;
+    const secs = mix.crossSecondsFor(cur, next, { energyDelta, nextIntroMs, maxSec });
     if (secs != null) {
       item.track.crossSec = secs;
       this.log('mix', `blend ${secs}s → ${item.track.title}`);

--- a/controller/src/music/mix.ts
+++ b/controller/src/music/mix.ts
@@ -40,6 +40,11 @@ function analysed(a: Analysis): boolean {
   return a.bpm != null || a.key != null;
 }
 
+// Broadcast crossfade bounds (seconds). The floor keeps every blend audible —
+// shorter than this and a transition reads as a hard cut / "no crossfade".
+export const CROSS_MIN_SECONDS = 6;
+export const CROSS_MAX_SECONDS = 14;
+
 // 0..1 — how close two tempos are, folding half/double time (70 ≈ 140).
 export function bpmCompat(a: number | null, b: number | null): number {
   if (!a || !b || a <= 0 || b <= 0) return 0;
@@ -98,7 +103,7 @@ export function mixCompat(cur: Analysis, next: Analysis): number {
 export function crossSecondsFor(
   cur: Analysis,
   next: Analysis,
-  opts: { energyDelta?: number; nextIntroMs?: number | null } = {},
+  opts: { energyDelta?: number; nextIntroMs?: number | null; maxSec?: number | null } = {},
 ): number | null {
   if (!analysed(cur) || !analysed(next)) return null;
 
@@ -137,14 +142,23 @@ export function crossSecondsFor(
   // buffer, so a buffer longer than the incoming track's instrumental intro
   // would fade up over the first vocals. Cap the blend to the intro length so
   // the fade-in completes before the song proper. Absent intro → no cap, i.e.
-  // today's behaviour. Floor at 3s so a near-zero intro still gets a real blend.
+  // today's behaviour. Floor at CROSS_MIN_SECONDS so a short intro still leaves
+  // an audible blend — a tighter cap collapsed most transitions to ~3s and read
+  // as "no crossfade".
   const introSec = typeof opts.nextIntroMs === 'number' && opts.nextIntroMs > 0
     ? opts.nextIntroMs / 1000
     : null;
-  if (introSec != null) secs = Math.min(secs, Math.max(3, introSec));
+  if (introSec != null) secs = Math.min(secs, Math.max(CROSS_MIN_SECONDS, introSec));
 
-  // Clamp to a sane broadcast range and quantise to 0.1s.
-  secs = Math.max(3, Math.min(14, secs));
+  // Clamp to the broadcast range and quantise to 0.1s. The upper bound is the
+  // operator's admin crossfade length (settings.crossfadeDuration, passed as
+  // opts.maxSec) so the adaptive blend never exceeds what they configured;
+  // falls back to CROSS_MAX_SECONDS when unset. An admin value below the audible
+  // floor wins as the ceiling — an explicit short crossfade is the operator's
+  // call — so the floor yields to it.
+  const maxSec = typeof opts.maxSec === 'number' && opts.maxSec > 0 ? opts.maxSec : CROSS_MAX_SECONDS;
+  const minSec = Math.min(CROSS_MIN_SECONDS, maxSec);
+  secs = Math.max(minSec, Math.min(maxSec, secs));
   return Math.round(secs * 10) / 10;
 }
 

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -176,14 +176,20 @@ music = fallback(
 # chain does (see comment above mic_chain). The fix would be to put a
 # getter-controlled filter on the music source BEFORE `cross` and modulate
 # its cutoff from a transition trigger. Parked until needed.
-# DJ-mode adaptive blend: the controller may stamp `liq_cross_duration` on the
-# incoming track (annotate:, via subsonic.getAnnotatedUri) to size THIS
-# transition from the two tracks' tempo/harmonic compatibility. `cross` honours
-# the same metadata to size its buffer, so reading it here for the fades keeps
-# fade == buffer — the invariant that avoids the +6 dB doubling described above.
+# DJ-mode adaptive blend: the controller may stamp `liq_cross_duration` on a
+# track (annotate:, via subsonic.getAnnotatedUri) to size its transition from
+# tempo/harmonic compatibility. CRITICAL: `cross` reads `liq_cross_duration` to
+# size its buffer from the OUTGOING track's metadata — the value registered when
+# that track started controls the crossfade at its END (see liquidsoap docs).
+# So the buffer for THIS transition equals `a`'s override (the outgoing track),
+# NOT `b`'s. The fade therefore must read `a.metadata` too, or fade != buffer:
+# a fade longer than the buffer gets truncated → the outgoing track is cut
+# mid-fade and the incoming jumps to full (audible gaps / "no crossfade"); a
+# fade shorter than the buffer sums to +6 dB (doubling). Reading `a` keeps
+# fade == buffer — the invariant the whole section depends on.
 # Absent / unparseable → crossfade_duration(), i.e. the global startup default.
 def dj_transition(a, b) =
-  d = float_of_string(default=crossfade_duration(), b.metadata["liq_cross_duration"])
+  d = float_of_string(default=crossfade_duration(), a.metadata["liq_cross_duration"])
   a_source = fade.out(duration=d, initial_metadata=a.metadata, a.source)
   b_source = fade.in(duration=d, initial_metadata=b.metadata, b.source)
   add(normalize=false, [a_source, b_source])


### PR DESCRIPTION
## Problem

Since #372 (richer acoustic analysis), some track transitions had **almost no crossfade or tiny gaps**.

Two contributing causes, both introduced/exposed by that PR:

1. **Buffer/fade mismatch (the gaps).** Liquidsoap's `cross` sizes its buffer from the **outgoing** track's `liq_cross_duration` metadata (the value registered when a track starts governs the crossfade at its *end*). But `dj_transition` read the fade duration from the **incoming** track (`b.metadata`). The two were assumed equal — they aren't; they're two different tracks' values. #372's intro-cap + bar-snap made the per-track value swing widely (3–14s), so the values diverged often:
   - fade **longer** than buffer → fade truncated, outgoing cut mid-fade, incoming jumps to full → **audible gaps / "no crossfade"**
   - fade **shorter** than buffer → sums to **+6 dB doubling**
2. **Over-aggressive shortening.** The structure-aware intro cap floored at 3s, collapsing most transitions of short-intro (vocal) tracks to ~3s — inaudibly short.

## Fix

- **`radio.liq`** — `dj_transition` reads the fade from `a.metadata` (outgoing), the track `cross` actually sizes the buffer from → restores the `fade == buffer` invariant the whole section depends on.
- **`mix.ts`** — add `CROSS_MIN_SECONDS = 6` / `CROSS_MAX_SECONDS = 14`; the 6s floor (intro cap + final clamp) keeps a short intro from collapsing the blend to ~3s.
- **`mix.ts` / `queue.ts`** — `crossSecondsFor` takes `opts.maxSec`; `applyMixTransition` passes `settings.crossfadeDuration`, so the **admin crossfade slider now acts as a real ceiling on DJ-mode transitions** too (previously the adaptive logic ignored it entirely). An admin value below the audible floor wins as the ceiling.

## Effect

| Mode | Before | After |
|------|--------|-------|
| DJ off / un-analysed | admin value (global default) | unchanged |
| DJ on, analysed | adaptive 3–14s, admin ignored, gaps/doubling | adaptive `6 … crossfadeDuration`, no gaps |

## Test

- `controller` lint clean (`eslint . && tsc --noEmit`, exit 0).
- Rebuilt + recreated `broadcast` + `controller` locally; broadcast healthy, `/stream.mp3` serving audio, no controller boot errors. Liquidsoap parsed the new `radio.liq` (broadcast healthcheck passes).