### PR TITLE
feat(player): active-track data readouts (track shape band + footer timeline)

### DIFF
--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -159,6 +159,83 @@ export function paceMeanOf(pace: Array<{ value: number }> | null | undefined): n
     : null;
 }
 
+// ---------------------------------------------------------------------------
+// Now-playing readout — the per-track analysis the listener player surfaces in
+// the active-track band + footer timeline (the "Track Data" design). Distinct
+// from slimTrack (picker projection): this is the UI shape, with keyRanges
+// resolved to Camelot labels and time spans kept in ms for the playhead math.
+// Every acoustic field is null on an un-analysed track; the client gates on
+// presence and falls back to the plain waveform.
+// ---------------------------------------------------------------------------
+
+// tonic (sharp spelling, as the analyzer emits) + mode → Camelot code.
+const CAMELOT_BY_KEY: Record<string, string> = {
+  'G# minor': '1A', 'D# minor': '2A', 'A# minor': '3A', 'F minor': '4A',
+  'C minor': '5A', 'G minor': '6A', 'D minor': '7A', 'A minor': '8A',
+  'E minor': '9A', 'B minor': '10A', 'F# minor': '11A', 'C# minor': '12A',
+  'B major': '1B', 'F# major': '2B', 'C# major': '3B', 'G# major': '4B',
+  'D# major': '5B', 'A# major': '6B', 'F major': '7B', 'C major': '8B',
+  'G major': '9B', 'D major': '10B', 'A major': '11B', 'E major': '12B',
+};
+// Camelot code → human key name (flat spelling, the conventional DJ reading).
+const KEYNAME_BY_CAMELOT: Record<string, string> = {
+  '1A': 'Ab minor', '2A': 'Eb minor', '3A': 'Bb minor', '4A': 'F minor',
+  '5A': 'C minor', '6A': 'G minor', '7A': 'D minor', '8A': 'A minor',
+  '9A': 'E minor', '10A': 'B minor', '11A': 'F# minor', '12A': 'Db minor',
+  '1B': 'B major', '2B': 'F# major', '3B': 'Db major', '4B': 'Ab major',
+  '5B': 'Eb major', '6B': 'Bb major', '7B': 'F major', '8B': 'C major',
+  '9B': 'G major', '10B': 'D major', '11B': 'A major', '12B': 'E major',
+};
+
+export interface TrackReadout {
+  durationSec: number | null;
+  bpm: number | null;
+  key: string | null;        // dominant Camelot code, e.g. '8A'
+  keyName: string | null;    // e.g. 'A minor'
+  loudnessLufs: number | null;
+  peakDb: number | null;
+  energy: string | null;
+  moods: string[];
+  // Time spans in ms (matches the DB), so the client maps against the playhead.
+  structure: Array<{ startMs: number; endMs: number; kind?: string }> | null;
+  vocals: Array<{ startMs: number; endMs: number }> | null;
+  pace: Array<{ startMs: number; endMs: number; value: number }> | null;
+  keyRanges: Array<{ startMs: number; endMs: number; key: string }> | null;
+}
+
+export function getReadout(songId: string): TrackReadout | null {
+  if (!loaded) return null;
+  const t = db.getTrack(songId);
+  if (!t) return null;
+  const key = t.musicalKey ?? null;
+  return {
+    durationSec: t.durationSec ?? null,
+    bpm: t.bpm ?? null,
+    key,
+    keyName: key ? (KEYNAME_BY_CAMELOT[key] ?? null) : null,
+    loudnessLufs: t.loudnessLufs ?? null,
+    peakDb: t.peakDb ?? null,
+    energy: t.energy ?? null,
+    moods: Array.isArray(t.moods) ? t.moods : [],
+    structure: t.structure && t.structure.length
+      ? t.structure.map(s => ({ startMs: s.startMs, endMs: s.endMs, kind: s.kind }))
+      : null,
+    vocals: t.vocalRanges && t.vocalRanges.length
+      ? t.vocalRanges.map(s => ({ startMs: s.startMs, endMs: s.endMs }))
+      : null,
+    pace: t.pace && t.pace.length
+      ? t.pace.map(s => ({ startMs: s.startMs, endMs: s.endMs, value: s.value }))
+      : null,
+    keyRanges: t.keyRanges && t.keyRanges.length
+      ? t.keyRanges.map(r => ({
+          startMs: r.startMs,
+          endMs: r.endMs,
+          key: CAMELOT_BY_KEY[`${r.tonic} ${r.mode}`] ?? key ?? '',
+        }))
+      : null,
+  };
+}
+
 // plus the two tagger axes. Matches what songsByMood returns above; pulled
 // out so the new embedding-similar helpers can share the same projection.
 function slimTrack(r: db.TrackRecord) {

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -5,6 +5,7 @@ import express from 'express';
 import { stat, readFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import * as subsonic from '../music/subsonic.js';
+import * as library from '../music/library.js';
 import * as settings from '../settings.js';
 import { getFullContext } from '../context.js';
 import { queue } from '../broadcast/queue.js';
@@ -139,10 +140,33 @@ router.get('/persona-avatar/:id', async (req, res) => {
 // ---------------------------------------------------------------------------
 router.get('/now-playing', async (req, res) => {
   try {
-    const [nowPlaying, ctx] = await Promise.all([
+    const [rawNowPlaying, ctx] = await Promise.all([
       queue.getNowPlaying(),
       getFullContext(),
     ]);
+    // Enrich the airing track with its library.db analysis row (pace curve,
+    // structure, vocal-presence, bpm/key/LUFS, mood/energy) so the listener
+    // player can render the active-track readouts. Best-effort: any failure
+    // (db not yet loaded, track absent, jingle with no id) leaves nowPlaying
+    // exactly as Liquidsoap wrote it and the UI falls back to the waveform.
+    let nowPlaying = rawNowPlaying;
+    if (rawNowPlaying?.subsonic_id) {
+      try {
+        await library.load();
+        const analysis = library.getReadout(rawNowPlaying.subsonic_id);
+        if (analysis) {
+          nowPlaying = {
+            ...rawNowPlaying,
+            // Liquidsoap's now-playing.json carries no duration; backfill it
+            // from the library row so the progress bar + playhead work.
+            duration: rawNowPlaying.duration ?? analysis.durationSec ?? undefined,
+            analysis,
+          };
+        }
+      } catch {
+        // keep rawNowPlaying
+      }
+    }
     // Served from the 15s listener-monitor cache — no per-request Icecast hit.
     const stream = getStreamStatus();
     const persona = settings.getEffectivePersona();

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -915,6 +915,178 @@ body::after {
     background: var(--accent);
 }
 
+/* ── Active-track readout band (Track Shape) ──────────────────────────────
+   The song's real pace/energy curve becomes the ambient band: it fills ink
+   behind the playhead, structure boundaries are hairline small-caps labels
+   that glow vermilion as you enter them, and a thin VOX lane shows where the
+   voice is. Theme-aware — all inks derive from --ink/--accent, so it flips
+   with the station palette. Falls back to <Waveform> on un-analysed tracks. */
+.tr-band {
+    /* token scope: alpha steps off the theme ink */
+    --tr-ink2: color-mix(in oklab, var(--ink) 62%, transparent);
+    --tr-ink3: color-mix(in oklab, var(--ink) 40%, transparent);
+    --tr-ink4: color-mix(in oklab, var(--ink) 18%, transparent);
+    --tr-brd: color-mix(in oklab, var(--ink) 12%, transparent);
+}
+.tr-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 2px 6px;
+    font-size: 9px;
+    letter-spacing: 0.26em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: var(--tr-ink3);
+}
+.tr-head-meta {
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.08em;
+}
+.tr-shape {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+}
+.tr-curve {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 14px;
+    bottom: 22px;
+    width: 100%;
+    height: calc(100% - 36px);
+}
+.tr-area-faint { fill: color-mix(in oklab, var(--ink) 7%, transparent); }
+.tr-area { fill: color-mix(in oklab, var(--ink) 20%, transparent); }
+.tr-line {
+    fill: none;
+    stroke: var(--tr-ink2);
+    stroke-width: 1.4;
+    vector-effect: non-scaling-stroke;
+}
+.tr-div {
+    position: absolute;
+    top: 12px;
+    bottom: 20px;
+    width: 1px;
+    background: var(--tr-brd);
+    z-index: 3;
+}
+.tr-seclbl {
+    position: absolute;
+    top: 0;
+    transform: translateX(-50%);
+    font-size: 8.5px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: var(--tr-ink3);
+    white-space: nowrap;
+    transition: color 0.2s;
+}
+.tr-seclbl[data-on="true"] { color: var(--accent); }
+.tr-vlane {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 14px;
+}
+.tr-vlbl {
+    position: absolute;
+    left: 0;
+    bottom: 1px;
+    font-size: 8px;
+    letter-spacing: 0.16em;
+    font-weight: 700;
+    color: var(--tr-ink4);
+}
+.tr-vseg {
+    position: absolute;
+    bottom: 3px;
+    height: 3px;
+    background: var(--tr-ink4);
+    transition: background 0.2s, height 0.2s;
+}
+.tr-vseg[data-on="true"] {
+    background: var(--accent);
+    height: 4px;
+}
+.tr-ph {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1.5px;
+    background: var(--accent);
+    z-index: 6;
+    box-shadow: 0 0 0 0.5px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+.tr-ph::before {
+    content: "";
+    position: absolute;
+    top: -1px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 5px solid var(--accent);
+}
+.tr-time {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    font-size: 10px;
+    font-weight: 700;
+    color: var(--tr-ink2);
+    letter-spacing: 0.04em;
+    font-variant-numeric: tabular-nums;
+}
+.tr-time span {
+    color: var(--tr-ink3);
+    font-weight: 500;
+}
+
+/* Footer song-timeline (#7) — the analog signal scale re-skinned to read the
+   song: section boundaries + small-caps labels, a vocal-presence lane, and the
+   existing .fz-needle as the playhead. Builds on .fz-scale chrome (border, bg,
+   ticks); only the song-specific overlays live here. */
+.fz-song .fz-song-bound {
+    position: absolute;
+    top: 0;
+    bottom: 14px;
+    width: 1px;
+    background: color-mix(in oklab, var(--ink) 40%, transparent);
+    opacity: 0.7;
+}
+.fz-song .fz-song-lbl {
+    position: absolute;
+    top: 3px;
+    transform: translateX(-50%);
+    font-size: 7.5px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: color-mix(in oklab, var(--ink) 40%, transparent);
+    white-space: nowrap;
+    transition: color 0.2s;
+    pointer-events: none;
+}
+.fz-song .fz-song-lbl[data-on="true"] { color: var(--accent); }
+.fz-song .fz-song-vox {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 3px;
+    height: 3px;
+}
+.fz-song .fz-song-vox span {
+    position: absolute;
+    bottom: 0;
+    height: 3px;
+    background: color-mix(in oklab, var(--ink) 18%, transparent);
+}
+
 /* Volume knob — open ring + inner cap + vermilion pointer; the conic ring of
    ticks behind it reads as a level scale (starts from -135deg, matching the
    pointer angle the JSX sets inline as -135 + volume*270). */

--- a/web/components/PlayerApp.tsx
+++ b/web/components/PlayerApp.tsx
@@ -7,6 +7,7 @@ import { CalendarClock, History, Mic } from 'lucide-react';
 import TopBar from './TopBar';
 import CenterStage from './CenterStage';
 import Waveform from './Waveform';
+import TrackShape, { hasTrackShape } from './TrackShape';
 import TransportBar from './TransportBar';
 import TuneInOverlay from './TuneInOverlay';
 import DotRail from './DotRail';
@@ -291,12 +292,24 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
         onOpenTimeline={openTimeline}
       />
 
-      <Waveform
-        audioRef={audioRef}
-        tunedIn={tunedIn}
-        trackStartedAt={trackStartedAt}
-        duration={nowPlaying?.duration ?? 0}
-      />
+      {/* The song's real analysis becomes the ambient band when available;
+          otherwise the reactive waveform. The waveform still owns the audio
+          analyser, so it stays the fallback for un-analysed tracks + jingles. */}
+      {hasTrackShape(nowPlaying?.analysis) ? (
+        <TrackShape
+          analysis={nowPlaying!.analysis!}
+          tunedIn={tunedIn}
+          trackStartedAt={trackStartedAt}
+          duration={nowPlaying?.duration ?? 0}
+        />
+      ) : (
+        <Waveform
+          audioRef={audioRef}
+          tunedIn={tunedIn}
+          trackStartedAt={trackStartedAt}
+          duration={nowPlaying?.duration ?? 0}
+        />
+      )}
 
       <DotRail counts={dotRailCounts} active={drawer} onSelect={setDrawer} />
 

--- a/web/components/TrackShape.tsx
+++ b/web/components/TrackShape.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { pollWhileVisible } from '@/lib/poll';
+import type { TrackAnalysis } from '@/lib/types';
+
+// SVG user space for the pace curve (preserveAspectRatio: none, so it stretches
+// to the band width). Mirrors the "Track shape" design concept.
+const W = 1000;
+const H = 100;
+const PAD = 8;
+
+const fmt = (s: number) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, '0')}`;
+
+export interface TrackShapeProps {
+  analysis: TrackAnalysis;
+  tunedIn: boolean;
+  /** Epoch ms when the current track started (from useStationFeed). */
+  trackStartedAt: number | null;
+  /** Track length in seconds (0/undefined falls back to the analysis window). */
+  duration: number;
+}
+
+/** True when there's enough acoustic data to draw the band (a curve or
+ *  sections). bpm/key/LUFS alone don't make a band — the caller falls back to
+ *  the plain waveform in that case. */
+export function hasTrackShape(a?: TrackAnalysis | null): boolean {
+  return !!(a && ((a.pace && a.pace.length) || (a.structure && a.structure.length)));
+}
+
+const yOf = (v: number) => H - PAD - v * (H - PAD * 2);
+
+// Build the pace polyline + filled-area path from the analysis spans. Each
+// span contributes a point at its midpoint; the curve is anchored to the
+// baseline at both ends so the area fill closes cleanly.
+function buildCurve(
+  pace: TrackAnalysis['pace'],
+  durMs: number,
+): { line: string; area: string } {
+  if (!pace || !pace.length) return { line: '', area: '' };
+  const pts = pace.map((p) => {
+    const x = ((p.startMs + p.endMs) / 2 / durMs) * W;
+    return { x: Math.max(0, Math.min(W, x)), y: yOf(Math.max(0, Math.min(1, p.value))) };
+  });
+  // clamp endpoints to the band edges
+  const first = pts[0]!;
+  const last = pts[pts.length - 1]!;
+  const seq = [{ x: 0, y: first.y }, ...pts, { x: W, y: last.y }];
+  const line = seq.map((p, i) => `${i ? 'L' : 'M'}${p.x.toFixed(1)} ${p.y.toFixed(1)}`).join(' ');
+  const area = `M0 ${H} ${seq.map((p) => `L${p.x.toFixed(1)} ${p.y.toFixed(1)}`).join(' ')} L${W} ${H} Z`;
+  return { line, area };
+}
+
+function sectionIndexAt(structure: TrackAnalysis['structure'], tMs: number): number {
+  if (!structure || !structure.length) return -1;
+  const i = structure.findIndex((s) => tMs >= s.startMs && tMs < s.endMs);
+  return i >= 0 ? i : structure.length - 1;
+}
+
+function keyAt(analysis: TrackAnalysis, tMs: number): string | null {
+  const ranges = analysis.keyRanges;
+  if (ranges && ranges.length) {
+    const r = ranges.find((x) => tMs >= x.startMs && tMs < x.endMs) ?? ranges[0];
+    if (r?.key) return r.key;
+  }
+  return analysis.key;
+}
+
+export default memo(function TrackShape({ analysis, tunedIn, trackStartedAt, duration }: TrackShapeProps) {
+  // Analysis-window length: the largest endMs across all spans, falling back to
+  // the track duration. Everything (spans + playhead) positions against this
+  // single scale so the structure labels and the needle stay aligned.
+  const durMs = useMemo(() => {
+    let m = duration > 0 ? duration * 1000 : 0;
+    for (const s of analysis.structure ?? []) m = Math.max(m, s.endMs);
+    for (const p of analysis.pace ?? []) m = Math.max(m, p.endMs);
+    for (const v of analysis.vocals ?? []) m = Math.max(m, v.endMs);
+    return m || 1;
+  }, [analysis, duration]);
+  const durSec = durMs / 1000;
+
+  const { line, area } = useMemo(() => buildCurve(analysis.pace, durMs), [analysis.pace, durMs]);
+
+  // Sparse state tick (~2 Hz) for the discrete bits: which section glows, the
+  // live key, the clock text. The continuously-moving visuals (playhead + fill
+  // clip) run on rAF below with zero React renders.
+  const [tMs, setTMs] = useState(0);
+  useEffect(() => {
+    if (!tunedIn || trackStartedAt == null) {
+      setTMs(0);
+      return;
+    }
+    return pollWhileVisible(() => {
+      setTMs(Math.min(durMs, Date.now() - trackStartedAt));
+    }, 500);
+  }, [tunedIn, trackStartedAt, durMs]);
+
+  // Smooth playhead + area-fill clip, driven imperatively so the band animates
+  // at frame rate without re-rendering the SVG (the Waveform pattern).
+  const phRef = useRef<HTMLSpanElement>(null);
+  const clipRef = useRef<SVGRectElement>(null);
+  const timeRef = useRef<HTMLSpanElement>(null);
+  useEffect(() => {
+    const park = () => {
+      if (phRef.current) phRef.current.style.left = '0%';
+      if (clipRef.current) clipRef.current.setAttribute('width', '0');
+    };
+    if (!tunedIn || trackStartedAt == null) {
+      park();
+      return;
+    }
+    let raf = 0;
+    const tick = () => {
+      const sec = (Date.now() - trackStartedAt) / 1000;
+      const p = Math.min(1, Math.max(0, sec / durSec));
+      if (phRef.current) phRef.current.style.left = `${(p * 100).toFixed(2)}%`;
+      if (clipRef.current) clipRef.current.setAttribute('width', (p * W).toFixed(1));
+      if (timeRef.current?.firstChild) timeRef.current.firstChild.textContent = `${fmt(Math.min(durSec, sec))} `;
+      raf = requestAnimationFrame(tick);
+    };
+    tick();
+    return () => cancelAnimationFrame(raf);
+  }, [tunedIn, trackStartedAt, durSec]);
+
+  const curIdx = sectionIndexAt(analysis.structure, tMs);
+  const keyLabel = keyAt(analysis, tMs);
+  const meta = [
+    analysis.bpm != null ? `${Math.round(analysis.bpm)} BPM` : null,
+    keyLabel,
+    analysis.loudnessLufs != null ? `${analysis.loudnessLufs} LUFS` : null,
+  ].filter(Boolean).join('  ·  ');
+
+  return (
+    <div
+      className="tr-band pointer-events-none absolute inset-x-3 bottom-24 flex h-[118px] flex-col font-mono sm:right-24 sm:bottom-[128px] sm:left-0 sm:h-[150px]"
+      aria-hidden="true"
+    >
+      <div className="tr-head">
+        <span>Track shape</span>
+        <span className="tr-head-meta">{meta}</span>
+      </div>
+      <div className="tr-shape">
+        <svg className="tr-curve" viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none">
+          <defs>
+            <clipPath id="tr-ph-clip">
+              <rect ref={clipRef} x="0" y="0" width="0" height={H} />
+            </clipPath>
+          </defs>
+          {area && <path d={area} className="tr-area-faint" />}
+          {area && <path d={area} className="tr-area" clipPath="url(#tr-ph-clip)" />}
+          {line && <path d={line} className="tr-line" />}
+        </svg>
+
+        {/* structure dividers + small-caps labels (current glows) */}
+        {(analysis.structure ?? []).map((s, i) => (
+          <span key={`d${i}`}>
+            {i > 0 && (
+              <span
+                className="tr-div"
+                ref={(el) => { if (el) el.style.setProperty('left', `${(s.startMs / durMs) * 100}%`); }}
+              />
+            )}
+            {s.kind && (
+              <span
+                className="tr-seclbl"
+                data-on={i === curIdx ? 'true' : undefined}
+                ref={(el) => { if (el) el.style.setProperty('left', `${((s.startMs + s.endMs) / 2 / durMs) * 100}%`); }}
+              >
+                {s.kind}
+              </span>
+            )}
+          </span>
+        ))}
+
+        {/* vocal-presence lane */}
+        {analysis.vocals && analysis.vocals.length > 0 && (
+          <div className="tr-vlane">
+            <span className="tr-vlbl">VOX</span>
+            {analysis.vocals.map((v, i) => (
+              <span
+                key={`v${i}`}
+                className="tr-vseg"
+                data-on={tMs >= v.startMs && tMs < v.endMs ? 'true' : undefined}
+                ref={(el) => {
+                  if (!el) return;
+                  el.style.setProperty('left', `${(v.startMs / durMs) * 100}%`);
+                  el.style.setProperty('width', `${((v.endMs - v.startMs) / durMs) * 100}%`);
+                }}
+              />
+            ))}
+          </div>
+        )}
+
+        <span className="tr-ph" ref={phRef} />
+        <span className="tr-time" ref={timeRef}>
+          {fmt(0)} <span> / {fmt(durSec)}</span>
+        </span>
+      </div>
+    </div>
+  );
+});

--- a/web/components/TransportBar.tsx
+++ b/web/components/TransportBar.tsx
@@ -83,6 +83,30 @@ export default memo(function TransportBar({
   const duration = nowPlaying?.duration ?? 0;
   const progress = duration > 0 ? Math.min(1, elapsed / duration) : 0;
 
+  // Footer song-timeline (#7): when tuned in and the airing track has structural
+  // analysis, the analog signal scale re-skins into the song itself — section
+  // boundaries + labels, a vocal-presence lane, and the needle as the playhead.
+  // Otherwise the latency meter stays. The signal stays readable either way:
+  // listeners + latency live in the right-hand readout regardless.
+  const analysis = nowPlaying?.analysis ?? null;
+  const sections = analysis?.structure ?? [];
+  const showTimeline = tunedIn && sections.length > 0;
+  // Position scale: largest endMs across spans, else the track duration.
+  const songDurMs = (() => {
+    if (!showTimeline) return 0;
+    let m = duration > 0 ? duration * 1000 : 0;
+    for (const s of sections) m = Math.max(m, s.endMs);
+    for (const v of analysis?.vocals ?? []) m = Math.max(m, v.endMs);
+    return m || 1;
+  })();
+  const elapsedMs = elapsed * 1000;
+  const curSection = showTimeline
+    ? (sections.find((s) => elapsedMs >= s.startMs && elapsedMs < s.endMs) ?? sections[sections.length - 1])
+    : null;
+  // The needle rides real progress; reuse the same 0–100% position the latency
+  // needle uses, but driven by the playhead instead of round-trip latency.
+  const songNeedlePct = songDurMs > 0 ? Math.min(100, (elapsedMs / songDurMs) * 100) : 0;
+
   // Knob pointer sweeps the conic tick scale: -135° (silent) → +135° (full),
   // matching the scale's `from -135deg` origin in globals.css.
   const angle = -135 + volume * 270;
@@ -200,7 +224,11 @@ export default memo(function TransportBar({
           <div className="flex w-full flex-col justify-center gap-1 font-mono lg:gap-1.5">
             <div className="flex items-baseline justify-between gap-2 lg:gap-4">
               <span className="text-[11px] font-semibold tracking-[0.04em] whitespace-nowrap text-ink lg:text-[12px]">
-                Signal · <b className={cn('font-bold', qualityTone)}>{qualityLabel}</b>
+                {showTimeline ? (
+                  <>On air · <b className="font-bold text-vermilion">{curSection?.kind ?? 'Live'}</b></>
+                ) : (
+                  <>Signal · <b className={cn('font-bold', qualityTone)}>{qualityLabel}</b></>
+                )}
               </span>
               <span
                 className="v3-tab-num text-[11px] tracking-[0.06em] whitespace-nowrap text-muted lg:text-[12px] lg:tracking-[0.08em]"
@@ -210,20 +238,65 @@ export default memo(function TransportBar({
                 {listeners != null ? `${listeners} ♪ · ${latencyText}` : latencyText}
               </span>
             </div>
-            <div className="fz-scale h-8 lg:h-[42px]" aria-hidden="true">
-              <div className="fz-ticks" />
-              <div
-                className="fz-needle"
-                ref={(el) => { if (el) el.style.setProperty('--fz-needle-pos', `${needlePct}%`); }}
-              >
-                <div className="fz-grip" />
-              </div>
-              <div className="fz-nums">
-                {SCALE_NUMS.map((n) => (
-                  <span key={n}>{n}</span>
+            {showTimeline ? (
+              <div className="fz-scale fz-song h-8 lg:h-[42px]" aria-hidden="true">
+                <div className="fz-ticks" />
+                {sections.map((s, i) => (
+                  <span key={`b${i}`}>
+                    {i > 0 && (
+                      <span
+                        className="fz-song-bound"
+                        ref={(el) => { if (el) el.style.setProperty('left', `${(s.startMs / songDurMs) * 100}%`); }}
+                      />
+                    )}
+                    {s.kind && (
+                      <span
+                        className="fz-song-lbl"
+                        data-on={s === curSection ? 'true' : undefined}
+                        ref={(el) => { if (el) el.style.setProperty('left', `${((s.startMs + s.endMs) / 2 / songDurMs) * 100}%`); }}
+                      >
+                        {s.kind}
+                      </span>
+                    )}
+                  </span>
                 ))}
+                {analysis?.vocals && analysis.vocals.length > 0 && (
+                  <div className="fz-song-vox">
+                    {analysis.vocals.map((v, i) => (
+                      <span
+                        key={`fv${i}`}
+                        ref={(el) => {
+                          if (!el) return;
+                          el.style.setProperty('left', `${(v.startMs / songDurMs) * 100}%`);
+                          el.style.setProperty('width', `${((v.endMs - v.startMs) / songDurMs) * 100}%`);
+                        }}
+                      />
+                    ))}
+                  </div>
+                )}
+                <div
+                  className="fz-needle"
+                  ref={(el) => { if (el) el.style.setProperty('--fz-needle-pos', `${songNeedlePct}%`); }}
+                >
+                  <div className="fz-grip" />
+                </div>
               </div>
-            </div>
+            ) : (
+              <div className="fz-scale h-8 lg:h-[42px]" aria-hidden="true">
+                <div className="fz-ticks" />
+                <div
+                  className="fz-needle"
+                  ref={(el) => { if (el) el.style.setProperty('--fz-needle-pos', `${needlePct}%`); }}
+                >
+                  <div className="fz-grip" />
+                </div>
+                <div className="fz-nums">
+                  {SCALE_NUMS.map((n) => (
+                    <span key={n}>{n}</span>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         </div>
 

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -67,6 +67,9 @@ export default defineConfig([
             // (TransportBar), defined in app/globals.css. Same legacy-CSS deal
             // as the other prefixes: component CSS not yet promoted to @theme.
             '^fz-',
+            // .tr-* — the active-track readout band (TrackShape), defined in
+            // app/globals.css. Same legacy-CSS deal as .fz-* above.
+            '^tr-',
             '^bs-',
             '^broadsheet-',
             '^admin-',

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -6,6 +6,30 @@
 /** A track currently airing. `subsonic_id` is present for library tracks and
  *  drives MediaSession artwork via the `/api/cover/:id` proxy. Jingles +
  *  scanning have no id. */
+/** A time span in milliseconds (matches the controller's library.db shape). */
+export interface AnalysisSpan {
+  startMs: number;
+  endMs: number;
+}
+
+/** Per-track acoustic + tag analysis surfaced for the active-track readouts.
+ *  Every acoustic field is null on an un-analysed track; the player gates on
+ *  presence and falls back to the plain waveform band. */
+export interface TrackAnalysis {
+  durationSec: number | null;
+  bpm: number | null;
+  key: string | null;        // dominant Camelot code, e.g. '8A'
+  keyName: string | null;    // e.g. 'A minor'
+  loudnessLufs: number | null;
+  peakDb: number | null;
+  energy: string | null;
+  moods: string[];
+  structure: Array<AnalysisSpan & { kind?: string }> | null;
+  vocals: AnalysisSpan[] | null;
+  pace: Array<AnalysisSpan & { value: number }> | null;
+  keyRanges: Array<AnalysisSpan & { key: string }> | null;
+}
+
 export interface NowPlayingTrack {
   title?: string;
   artist?: string;
@@ -13,6 +37,8 @@ export interface NowPlayingTrack {
   year?: number;
   duration?: number;
   subsonic_id?: string;
+  /** Present only for library tracks found in library.db (see TrackAnalysis). */
+  analysis?: TrackAnalysis | null;
 }
 
 export interface WeatherContext {


### PR DESCRIPTION
## What

Surfaces the per-track analysis the station already computes in the listener player — implementing **#1 Track Shape** (the hero band) and **#7 footer song-timeline** from the track-data design handoff.

The data was already there per-track in `library.db` (`TrackRecord`: bpm, Camelot key, LUFS/peak, energy, moods, structure, vocal-presence, pace, keyRanges). This PR is the plumbing + UI to put it on screen.

## Changes

**Controller**
- `library.getReadout(songId)` — projects the analysis row into a UI shape (keyRanges resolved tonic+mode → Camelot codes; key name derived from the Camelot scalar).
- `/now-playing` enriches the airing track with that readout when it has a `subsonic_id`, and **backfills `duration`** from the library row (`now-playing.json` carries none) — which also un-parks the existing progress bar. Best-effort: any miss (jingle, un-analysed track, db not loaded) leaves the payload untouched.

**Web**
- `TrackShape.tsx` — pace curve filling behind a riding playhead, structure dividers + small-caps labels that glow vermilion per section, a VOX presence lane, `BPM · key · LUFS` meta. rAF drives the playhead/fill (no per-frame renders); section glow + clock tick sparsely — the existing `Waveform` discipline.
- `TransportBar.tsx` — the analog signal scale re-skins into the song timeline (boundaries, labels, vocal blips, needle-as-playhead) when tuned in + the track has structure; latency meter stays otherwise. Listeners + latency remain in the right-hand readout either way.
- `PlayerApp.tsx` renders `TrackShape` when analysis is present, else `Waveform` (which keeps the audio analyser, so it's the fallback for un-analysed tracks + jingles).
- Theme-aware: the design's hardcoded inks map to `--ink`/`--accent`, so the band flips with the station palette.

## Graceful degradation

The band only draws when there's a pace curve or sections; each lane renders only if its data exists. On a library with no acoustic analysis, the player shows the existing waveform + latency meter unchanged — verified live (DB migrated v3→v9, `analysis` block present but null, waveform fallback rendered, duration backfill working).

## Notes

- The new readouts stay dormant until tracks are run through `analyze-library.ts`; they light up automatically once `pace`/`structure` exist — no further code change.
- Lint gate: `web` clean (eslint + tsc); `controller` 0 errors + `tsc` passes.