### PR TITLE
feat(admin): anchor the dash latency redline to the DJ-agent deadline

### DIFF
--- a/controller/src/routes/stats.ts
+++ b/controller/src/routes/stats.ts
@@ -8,6 +8,7 @@ import express from 'express';
 import { requireAdmin } from '../middleware/auth.js';
 import { recentCalls } from '../llm/log.js';
 import * as llmProvider from '../llm/provider.js';
+import * as settings from '../settings.js';
 import { ttsCalls, summarizeLlm, summarizeTts, summarizeDjLog } from '../stats.js';
 import { queue } from '../broadcast/queue.js';
 
@@ -18,6 +19,11 @@ router.get('/stats', requireAdmin, (req, res) => {
     const llm: any = summarizeLlm(recentCalls);
     llm.provider = llmProvider.providerName();
     llm.activeModel = llmProvider.activeModelLabel();
+    // The DJ-agent deadline (admin-tunable, default 45s): past it the agent is
+    // killed and falls back to the stateless pool picker. The dash latency gauge
+    // anchors its redline to this so "red" means "hitting fallbacks", not an
+    // arbitrary ceiling. Mirror of agentDeadline() in broadcast/dj-agent.ts.
+    llm.agentTimeoutMs = settings.get().llm?.agentTimeoutMs ?? 45000;
 
     res.json({
       t: new Date().toISOString(),

--- a/web/components/admin/DashPanel.tsx
+++ b/web/components/admin/DashPanel.tsx
@@ -63,7 +63,7 @@ interface DashStatus {
 // fallback rate, both since-boot rollups. Polled slower than live status since
 // they move slowly and the endpoint is heavier.
 interface HealthStats {
-  llm?: { count?: number; latency?: { p95?: number } };
+  llm?: { count?: number; latency?: { p95?: number }; agentTimeoutMs?: number };
   tts?: { count?: number; fallbackRate?: number | null };
 }
 
@@ -398,6 +398,10 @@ export default function DashPanel() {
     listeners: lCurrent,
     listenersPeak: lPeak,
     latencyMs: stats?.llm?.count ? (stats.llm.latency?.p95 ?? null) : null,
+    // Redline at the DJ-agent deadline (the fallback threshold), so the gauge
+    // tracks the model in use instead of a fixed ceiling. Null until /stats
+    // loads → StationHeader falls back to its built-in default scale.
+    latencyDeadlineMs: stats?.llm?.agentTimeoutMs ?? null,
     ttsFallbackPct: stats?.tts?.count ? Math.round((stats.tts.fallbackRate ?? 0) * 1000) / 10 : null,
     online: status?.streamOnline ?? null,
     bitrateKbps: status?.streamBitrate ?? null,

--- a/web/components/admin/StationHeader.tsx
+++ b/web/components/admin/StationHeader.tsx
@@ -29,6 +29,12 @@ export interface HealthMetrics {
   listenersPeak: number;
   /** DJ think→speak p95 latency in ms, or null when unknown (stats not loaded) */
   latencyMs: number | null;
+  /**
+   * The live DJ-agent deadline in ms — the redline anchor. Past it the agent
+   * times out and falls back to the pool picker. Null until /stats loads, in
+   * which case the gauge uses its built-in default scale.
+   */
+  latencyDeadlineMs: number | null;
   /** TTS fallback rate as a percentage, or null when unknown */
   ttsFallbackPct: number | null;
   /** broadcast online? null before the first poll resolves */
@@ -39,11 +45,22 @@ export interface HealthMetrics {
 
 const SCALE = {
   listenersMax: 50,
-  latencyMax: 5000,
-  latencyRedline: 3000, // needle goes red past this
   ttsMidPct: 12, // fallback above this = caution (muted)
   ttsBadPct: 25, // fallback above this = redline
 } as const;
+
+// DJ-latency gauge scale. The redline anchors to the live DJ-agent deadline
+// (metrics.latencyDeadlineMs) — past it the agent times out and falls back to
+// the pool picker, so a redlined needle means "hitting fallbacks", not an
+// arbitrary ceiling. The band always sits at a fixed fraction of the sweep, so
+// only the numbers track the model in use, never the gauge geometry. Falls back
+// to 3 s until /stats reports the deadline.
+const DEFAULT_LATENCY_REDLINE_MS = 3000;
+const LATENCY_REDLINE_FRACTION = 0.6; // redline begins at 60% of the dial
+function latencyScale(deadlineMs: number | null): { redline: number; max: number } {
+  const redline = deadlineMs && deadlineMs > 0 ? deadlineMs : DEFAULT_LATENCY_REDLINE_MS;
+  return { redline, max: Math.round(redline / LATENCY_REDLINE_FRACTION) };
+}
 
 // ── geometry: a gauge sweeps the TOP semicircle, t=0→left, t=1→right ──
 const SVGNS = 'http://www.w3.org/2000/svg';
@@ -194,7 +211,7 @@ export default function StationHeader({
 
     const lG = listenersSvg.current ? buildGauge(listenersSvg.current, { withPeak: true }) : null;
     const aG = latencySvg.current
-      ? buildGauge(latencySvg.current, { redlineFrom: SCALE.latencyRedline / SCALE.latencyMax })
+      ? buildGauge(latencySvg.current, { redlineFrom: LATENCY_REDLINE_FRACTION })
       : null;
 
     // needles power up from zero on load (instrument warm-up)
@@ -215,9 +232,10 @@ export default function StationHeader({
       if (listenersV.current) listenersV.current.textContent = String(Math.round(sListeners.x));
       if (peakV.current) peakV.current.textContent = String(Math.round(sPeak.x));
 
-      // latency
-      aG?.setNeedle(sLatency.x / SCALE.latencyMax);
-      const redlined = sLatency.x >= SCALE.latencyRedline;
+      // latency — scale (redline + full-scale) tracks the live agent deadline
+      const { redline: latRedline, max: latMax } = latencyScale(t.latencyDeadlineMs);
+      aG?.setNeedle(sLatency.x / latMax);
+      const redlined = sLatency.x >= latRedline;
       if (latencyV.current) latencyV.current.textContent = t.latencyMs == null ? '—' : String(Math.round(sLatency.x));
       latencyRead.current?.classList.toggle('warn', redlined);
       if (zone.current) {
@@ -226,7 +244,7 @@ export default function StationHeader({
             ? 'no data'
             : redlined
               ? 'redline'
-              : sLatency.x > SCALE.latencyRedline * 0.8
+              : sLatency.x > latRedline * 0.8
                 ? 'rising'
                 : 'nominal';
       }
@@ -333,7 +351,7 @@ export default function StationHeader({
             </span>
             <span className="hs-u">ms</span>
             <span className="hs-x">
-              redline <b>{SCALE.latencyRedline / 1000}k</b>
+              redline <b>{Math.round(latencyScale(metrics.latencyDeadlineMs).redline / 1000)}k</b>
             </span>
           </div>
         </div>


### PR DESCRIPTION
## What

The station-health strip's **DJ Latency** gauge on `/admin/dash` hardcoded a **3 s redline / 5 s full-scale**, tuned for fast cloud models. On a slow local model (e.g. Ollama, p95 ~40 s) the needle pins permanently off the end of the dial — the gauge reads "redline" forever and tells you nothing.

This anchors the redline to the **live DJ-agent deadline** instead. Past that deadline the agent is killed and falls back to the stateless pool picker (`broadcast/dj-agent.ts` `agentDeadline()`), so a redlined needle now means *"the DJ is hitting fallbacks"* — a real, actionable threshold — rather than an arbitrary ceiling.

## How

- **Controller** (`routes/stats.ts`): `/stats` now emits `llm.agentTimeoutMs` (`settings.llm.agentTimeoutMs ?? 45000`) — the same value the agent times out on.
- **Web** (`DashPanel.tsx` → `StationHeader.tsx`): the latency gauge derives its scale from that value:
  - `redline = deadline`
  - `full-scale = deadline / 0.6` → the redline band stays at a fixed **60 % of the sweep**, identical geometry to the old static gauge. Only the *numbers* track the model in use, so the SVG never needs rebuilding when the deadline arrives or changes.
  - Falls back to the original **3 s / 5 s** scale until `/stats` reports the deadline (and on `null`).
  - The `redline Nk` label is now computed from the deadline.

## Why this beats hardcoding 45 s

Correct for **any** station: an 8 s-deadline cloud model redlines at 8 s, a 45 s local model at 45 s — the gauge means the same thing regardless of model, and it follows the operator's admin-tuned `agentTimeoutMs` automatically instead of drifting.

## Testing

- `controller` + `web` `npm run lint` (eslint + `tsc --noEmit`): **0 errors**.
- Deployed to the live prod stack and verified: `/stats` returns `agentTimeoutMs: 45000`; `/admin/dash` DJ Latency needle now sits in-band with a `45k` redline; stream audio non-silent (−13.3 dB), `/api/health` on-air.