### PR TITLE
feat(tts-heavy): bake CLAP + Demucs into the published image (#393)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -52,6 +52,16 @@ jobs:
           - image: subwave-tts-heavy
             dockerfile: docker/Dockerfile.tts-heavy
             platforms: linux/amd64
+            # Bake the CLAP audio-embedding stack ("sounds-like" similarity +
+            # sonic journeys) and Demucs vocal-activity ranges into the published
+            # image. Both are lazy-loaded at runtime (only when the analyze pass
+            # is actually run), so this costs pull/disk size only — no RAM/CPU
+            # for operators who never enable them. Baking them in is what lets
+            # `--profile tts-heavy` users pull a ready image instead of having to
+            # rebuild from source (issue #393).
+            build_args: |
+              WITH_CLAP=1
+              WITH_DEMUCS=1
     steps:
       - uses: actions/checkout@v4
 
@@ -82,6 +92,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           platforms: ${{ matrix.platforms }}
+          build-args: ${{ matrix.build_args }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -179,11 +179,17 @@ services:
         # build time. Usually unnecessary: setting HF_TOKEN in \`environment\`
         # below enables cloning at runtime (lazy download) without it.
         HF_TOKEN: \${HF_TOKEN:-}
-        # Optional — install the CLAP audio-embedding stack (torch +
-        # transformers + onnxruntime, ~1.5GB) into the analyzer venv. Needed
-        # for the "sounds-like" audio similarity + sonic journeys; pair with
-        # ANALYZE_AUDIO_EMBEDDING=1 below. Default off keeps the image lean.
-        WITH_CLAP: \${WITH_CLAP:-0}
+        # Install the CLAP audio-embedding stack (torch + transformers +
+        # onnxruntime, ~1.5GB) into the analyzer venv — powers "sounds-like"
+        # audio similarity + sonic journeys. Only consulted on a source build
+        # (\`docker compose build\`); the published image already bakes CLAP in,
+        # so a plain pull gets it for free. Lazy-loaded at runtime, so it costs
+        # disk only until the analyze pass actually runs.
+        WITH_CLAP: \${WITH_CLAP:-1}
+        # Demucs vocal-activity ranges — same story as WITH_CLAP: baked into the
+        # published image, defaulted on for source builds so they match. Source
+        # build only; lazy-loaded at runtime.
+        WITH_DEMUCS: \${WITH_DEMUCS:-1}
     # amd64-only image (heavy PyTorch stack); pinned so it runs under emulation
     # on arm64 hosts. The other services are multi-arch and auto-select.
     platform: linux/amd64
@@ -203,11 +209,12 @@ services:
       # a built-in. Accept the model terms on huggingface.co/kyutai/pocket-tts,
       # then put HF_TOKEN=hf_... in your root .env. Built-in voices need no token.
       - HF_TOKEN=\${HF_TOKEN:-}
-      # Optional — compute CLAP audio embeddings in the analyze pass (needs an
-      # image built with WITH_CLAP=1 above; without it this is a clean no-op
-      # and the worker emits bpm/key only). Set ANALYZE_AUDIO_EMBEDDING=1 in
-      # your root .env to enable. CLAP_MODEL picks the transformers checkpoint;
-      # CLAP_MODEL_PATH points at a pre-exported ONNX audio encoder instead.
+      # Optional — force CLAP audio embeddings on for the whole analyze pass.
+      # Usually unnecessary: the admin "sounds-like" toggle drives this per
+      # request, and the published image already carries CLAP. Set
+      # ANALYZE_AUDIO_EMBEDDING=1 in your root .env only to always-on it.
+      # CLAP_MODEL picks the transformers checkpoint; CLAP_MODEL_PATH points at
+      # a pre-exported ONNX audio encoder instead.
       - ANALYZE_AUDIO_EMBEDDING=\${ANALYZE_AUDIO_EMBEDDING:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
@@ -370,9 +377,12 @@ services:
         # Optional — bake the gated PocketTTS cloning weights in at build time.
         # Runtime HF_TOKEN (below) enables cloning without it.
         HF_TOKEN: \${HF_TOKEN:-}
-        # Optional — CLAP audio-embedding stack for the analyzer (~1.5GB);
-        # pair with ANALYZE_AUDIO_EMBEDDING=1 below.
-        WITH_CLAP: \${WITH_CLAP:-0}
+        # CLAP audio-embedding stack for the analyzer ("sounds-like", ~1.5GB)
+        # and Demucs vocal-activity ranges. Baked into the published image, so a
+        # plain pull gets them; these only apply to a source build, defaulted on
+        # so it matches. Both lazy-load at runtime (disk cost only).
+        WITH_CLAP: \${WITH_CLAP:-1}
+        WITH_DEMUCS: \${WITH_DEMUCS:-1}
     # amd64-only image (heavy PyTorch stack); pinned so it runs under emulation
     # on arm64 hosts. The other services are multi-arch and auto-select.
     platform: linux/amd64
@@ -387,9 +397,10 @@ services:
       # huggingface.co/kyutai/pocket-tts and set HF_TOKEN in your root .env.
       # Built-in voices need no token.
       - HF_TOKEN=\${HF_TOKEN:-}
-      # Optional — CLAP audio embeddings in the analyze pass (needs an image
-      # built with WITH_CLAP=1 above; clean no-op otherwise). Set
-      # ANALYZE_AUDIO_EMBEDDING=1 in your root .env to enable.
+      # Optional — force CLAP audio embeddings on for the whole analyze pass.
+      # Usually unnecessary: the admin "sounds-like" toggle drives this per
+      # request, and the published image already carries CLAP. Set
+      # ANALYZE_AUDIO_EMBEDDING=1 in your root .env only to always-on it.
       - ANALYZE_AUDIO_EMBEDDING=\${ANALYZE_AUDIO_EMBEDDING:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
@@ -532,9 +543,11 @@ services:
       args:
         # Optional — bake the gated PocketTTS cloning weights in at build time.
         HF_TOKEN: \${HF_TOKEN:-}
-        # Optional — CLAP audio-embedding stack for the analyzer (~1.5GB);
-        # pair with ANALYZE_AUDIO_EMBEDDING=1 below.
-        WITH_CLAP: \${WITH_CLAP:-0}
+        # CLAP audio-embedding stack ("sounds-like", ~1.5GB) + Demucs vocal
+        # ranges. Baked into the published image; these apply to a source build
+        # only, defaulted on to match. Both lazy-load at runtime (disk cost only).
+        WITH_CLAP: \${WITH_CLAP:-1}
+        WITH_DEMUCS: \${WITH_DEMUCS:-1}
     platform: linux/amd64
     container_name: sub-wave-tts-heavy
     restart: unless-stopped
@@ -546,8 +559,9 @@ services:
       # are gated; accept terms at huggingface.co/kyutai/pocket-tts and set
       # HF_TOKEN in your .env. Built-in voices need no token.
       - HF_TOKEN=\${HF_TOKEN:-}
-      # Optional — CLAP audio embeddings in the analyze pass (needs an image
-      # built with WITH_CLAP=1 above; clean no-op otherwise).
+      # Optional — force CLAP embeddings on for the whole analyze pass. Usually
+      # unnecessary: the admin "sounds-like" toggle drives this per request and
+      # the published image already carries CLAP.
       - ANALYZE_AUDIO_EMBEDDING=\${ANALYZE_AUDIO_EMBEDDING:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
@@ -677,4 +691,4 @@ SITE_URL=
 
 // cli/package.json#version (embedded so the compiled binary can self-identify
 // — used by `subwave --version` and by the TUI release fetch URL).
-export const CLI_VERSION = `0.15.0`;
+export const CLI_VERSION = `0.16.0`;

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -134,9 +134,12 @@ services:
         # Optional — bake the gated PocketTTS cloning weights in at build time.
         # Runtime HF_TOKEN (below) enables cloning without it.
         HF_TOKEN: ${HF_TOKEN:-}
-        # Optional — CLAP audio-embedding stack for the analyzer (~1.5GB);
-        # pair with ANALYZE_AUDIO_EMBEDDING=1 below.
-        WITH_CLAP: ${WITH_CLAP:-0}
+        # CLAP audio-embedding stack for the analyzer ("sounds-like", ~1.5GB)
+        # and Demucs vocal-activity ranges. Baked into the published image, so a
+        # plain pull gets them; these only apply to a source build, defaulted on
+        # so it matches. Both lazy-load at runtime (disk cost only).
+        WITH_CLAP: ${WITH_CLAP:-1}
+        WITH_DEMUCS: ${WITH_DEMUCS:-1}
     # amd64-only image (heavy PyTorch stack); pinned so it runs under emulation
     # on arm64 hosts. The other services are multi-arch and auto-select.
     platform: linux/amd64
@@ -151,9 +154,10 @@ services:
       # huggingface.co/kyutai/pocket-tts and set HF_TOKEN in your root .env.
       # Built-in voices need no token.
       - HF_TOKEN=${HF_TOKEN:-}
-      # Optional — CLAP audio embeddings in the analyze pass (needs an image
-      # built with WITH_CLAP=1 above; clean no-op otherwise). Set
-      # ANALYZE_AUDIO_EMBEDDING=1 in your root .env to enable.
+      # Optional — force CLAP audio embeddings on for the whole analyze pass.
+      # Usually unnecessary: the admin "sounds-like" toggle drives this per
+      # request, and the published image already carries CLAP. Set
+      # ANALYZE_AUDIO_EMBEDDING=1 in your root .env only to always-on it.
       - ANALYZE_AUDIO_EMBEDDING=${ANALYZE_AUDIO_EMBEDDING:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -118,9 +118,11 @@ services:
       args:
         # Optional — bake the gated PocketTTS cloning weights in at build time.
         HF_TOKEN: ${HF_TOKEN:-}
-        # Optional — CLAP audio-embedding stack for the analyzer (~1.5GB);
-        # pair with ANALYZE_AUDIO_EMBEDDING=1 below.
-        WITH_CLAP: ${WITH_CLAP:-0}
+        # CLAP audio-embedding stack ("sounds-like", ~1.5GB) + Demucs vocal
+        # ranges. Baked into the published image; these apply to a source build
+        # only, defaulted on to match. Both lazy-load at runtime (disk cost only).
+        WITH_CLAP: ${WITH_CLAP:-1}
+        WITH_DEMUCS: ${WITH_DEMUCS:-1}
     platform: linux/amd64
     container_name: sub-wave-tts-heavy
     restart: unless-stopped
@@ -132,8 +134,9 @@ services:
       # are gated; accept terms at huggingface.co/kyutai/pocket-tts and set
       # HF_TOKEN in your .env. Built-in voices need no token.
       - HF_TOKEN=${HF_TOKEN:-}
-      # Optional — CLAP audio embeddings in the analyze pass (needs an image
-      # built with WITH_CLAP=1 above; clean no-op otherwise).
+      # Optional — force CLAP embeddings on for the whole analyze pass. Usually
+      # unnecessary: the admin "sounds-like" toggle drives this per request and
+      # the published image already carries CLAP.
       - ANALYZE_AUDIO_EMBEDDING=${ANALYZE_AUDIO_EMBEDDING:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,11 +170,17 @@ services:
         # build time. Usually unnecessary: setting HF_TOKEN in `environment`
         # below enables cloning at runtime (lazy download) without it.
         HF_TOKEN: ${HF_TOKEN:-}
-        # Optional — install the CLAP audio-embedding stack (torch +
-        # transformers + onnxruntime, ~1.5GB) into the analyzer venv. Needed
-        # for the "sounds-like" audio similarity + sonic journeys; pair with
-        # ANALYZE_AUDIO_EMBEDDING=1 below. Default off keeps the image lean.
-        WITH_CLAP: ${WITH_CLAP:-0}
+        # Install the CLAP audio-embedding stack (torch + transformers +
+        # onnxruntime, ~1.5GB) into the analyzer venv — powers "sounds-like"
+        # audio similarity + sonic journeys. Only consulted on a source build
+        # (`docker compose build`); the published image already bakes CLAP in,
+        # so a plain pull gets it for free. Lazy-loaded at runtime, so it costs
+        # disk only until the analyze pass actually runs.
+        WITH_CLAP: ${WITH_CLAP:-1}
+        # Demucs vocal-activity ranges — same story as WITH_CLAP: baked into the
+        # published image, defaulted on for source builds so they match. Source
+        # build only; lazy-loaded at runtime.
+        WITH_DEMUCS: ${WITH_DEMUCS:-1}
     # amd64-only image (heavy PyTorch stack); pinned so it runs under emulation
     # on arm64 hosts. The other services are multi-arch and auto-select.
     platform: linux/amd64
@@ -194,11 +200,12 @@ services:
       # a built-in. Accept the model terms on huggingface.co/kyutai/pocket-tts,
       # then put HF_TOKEN=hf_... in your root .env. Built-in voices need no token.
       - HF_TOKEN=${HF_TOKEN:-}
-      # Optional — compute CLAP audio embeddings in the analyze pass (needs an
-      # image built with WITH_CLAP=1 above; without it this is a clean no-op
-      # and the worker emits bpm/key only). Set ANALYZE_AUDIO_EMBEDDING=1 in
-      # your root .env to enable. CLAP_MODEL picks the transformers checkpoint;
-      # CLAP_MODEL_PATH points at a pre-exported ONNX audio encoder instead.
+      # Optional — force CLAP audio embeddings on for the whole analyze pass.
+      # Usually unnecessary: the admin "sounds-like" toggle drives this per
+      # request, and the published image already carries CLAP. Set
+      # ANALYZE_AUDIO_EMBEDDING=1 in your root .env only to always-on it.
+      # CLAP_MODEL picks the transformers checkpoint; CLAP_MODEL_PATH points at
+      # a pre-exported ONNX audio encoder instead.
       - ANALYZE_AUDIO_EMBEDDING=${ANALYZE_AUDIO_EMBEDDING:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -35,8 +35,8 @@ export interface Coverage {
   analysisAvailable?: boolean | null;
   analysisBackend?: string | null;
   // Whether the backend can emit CLAP "sounds-like" embeddings. false = engine
-  // is up but built without the CLAP stack (sidecar WITH_CLAP=0) — drives the
-  // active "rebuild with WITH_CLAP=1" warning. null = unknown / still probing.
+  // is up but on an image without the CLAP stack (an older tts-heavy) — drives
+  // the active "pull the latest image" warning. null = unknown / still probing.
   audioAnalysisAvailable?: boolean | null;
   // Whether the backend can emit Demucs vocal-activity ranges. false = engine
   // up but built without the Demucs stack (sidecar WITH_DEMUCS=0) — drives the
@@ -154,9 +154,10 @@ export default function TaggingPanel(p: TaggingPanelProps) {
   const remaining = total != null && tagged != null ? Math.max(0, total - tagged) : null;
   const running = !!p.tagger?.running;
   const analysisOff = p.coverage?.analysisAvailable === false;
-  // Engine is up but built without the CLAP stack — "sounds-like" fingerprints
-  // can't be produced until the sidecar is rebuilt with WITH_CLAP=1. We warn
-  // actively rather than letting a run finish with the bar stuck at 0.
+  // Engine is up but on an image without the CLAP stack (an older tts-heavy
+  // predating baked-in fingerprinting) — "sounds-like" can't be produced until
+  // the sidecar is pulled fresh. We warn actively rather than letting a run
+  // finish with the bar stuck at 0.
   const audioIncapable = !analysisOff && p.coverage?.audioAnalysisAvailable === false;
   // Vocal activity is on but the engine was built without Demucs — the analysis
   // pass would skip vocal backfill (no-op), so warn rather than silently never
@@ -390,10 +391,10 @@ export default function TaggingPanel(p: TaggingPanelProps) {
             )}
             {audioIncapable && p.audioEnabled ? (
               <span className="basis-full border border-[color-mix(in_oklab,var(--accent)_35%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] leading-[1.5] text-ink !normal-case">
-                <b>Sounds-like is on, but the analysis engine can’t fingerprint audio.</b> The
-                tts-heavy sidecar was built without the CLAP model, so a run would only fill bpm/key
-                and leave this at 0. Rebuild it with the CLAP stack, then run the analysis:
-                <code className="mt-1 block font-mono text-[10.5px] text-muted">WITH_CLAP=1 docker compose build tts-heavy &amp;&amp; docker compose --profile tts-heavy up -d tts-heavy</code>
+                <b>Sounds-like is on, but the analysis engine can’t fingerprint audio.</b> Your
+                tts-heavy image predates audio fingerprinting, so a run would only fill bpm/key and
+                leave this at 0. Pull the latest image and recreate the sidecar, then run the analysis:
+                <code className="mt-1 block font-mono text-[10.5px] text-muted">docker compose pull tts-heavy &amp;&amp; docker compose --profile tts-heavy up -d tts-heavy</code>
               </span>
             ) : (
               <span className="caption basis-full !tracking-[0.04em] !normal-case">
@@ -406,10 +407,10 @@ export default function TaggingPanel(p: TaggingPanelProps) {
 
           {vocalIncapable && p.vocalEnabled ? (
             <div className="border border-[color-mix(in_oklab,var(--accent)_35%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] leading-[1.5] text-ink !normal-case">
-              <b>Vocal-activity is on, but the analysis engine can’t separate vocals.</b> The
-              tts-heavy sidecar was built without the Demucs stack, so the pass skips vocal ranges
-              (it won’t re-scan the whole library chasing them). Rebuild it with Demucs, then run the analysis:
-              <code className="mt-1 block font-mono text-[10.5px] text-muted">WITH_DEMUCS=1 docker compose build tts-heavy &amp;&amp; docker compose --profile tts-heavy up -d tts-heavy</code>
+              <b>Vocal-activity is on, but the analysis engine can’t separate vocals.</b> Your
+              tts-heavy image predates vocal separation, so the pass skips vocal ranges (it won’t
+              re-scan the whole library chasing them). Pull the latest image and recreate the sidecar, then run the analysis:
+              <code className="mt-1 block font-mono text-[10.5px] text-muted">docker compose pull tts-heavy &amp;&amp; docker compose --profile tts-heavy up -d tts-heavy</code>
             </div>
           ) : null}
 


### PR DESCRIPTION
## Why

The published `subwave-tts-heavy` image was built with **no build args**, so `WITH_CLAP`/`WITH_DEMUCS` defaulted to `0`. That meant **"sounds-like" audio fingerprinting** (CLAP) and **vocal-activity ranges** (Demucs) were only available to operators who rebuilt the sidecar *from source* — contradicting the pull-not-build distribution model and leaving prebuilt-image users stuck.

Reported in #393: the admin UI told the operator to run `WITH_CLAP=1 docker compose build tts-heavy`, which is a no-op on a prebuilt install (no build context).

## What

CI now publishes the image with both stacks baked in. Both **lazy-load at runtime** (only when an analyze pass actually runs), so this costs **pull/disk size only** — no RAM/CPU for operators who never enable them.

- **`publish-images.yml`** — new `build_args` matrix field, wired into `build-push-action`; sets `WITH_CLAP=1` + `WITH_DEMUCS=1` for the tts-heavy build.
- **compose (default / byo / dev)** — `WITH_CLAP`/`WITH_DEMUCS` now default to `1` so a source build matches the published image; corrected the stale "needs an image built with WITH_CLAP=1" comments (the admin toggle already drives CLAP per-request).
- **`web/components/admin/LibraryTaggingPanel.tsx`** — the sounds-like / vocal warnings now tell operators to `docker compose pull tts-heavy` and recreate, **not** build from source.

## Caveat

Takes effect on the **next image publish** (tag push triggers the workflow). The current `:latest` on GHCR predates this and still lacks CLAP, so #393's warning persists until a release goes out.

Closes #393