### PR TITLE
fix(release): bump embedded CLI_VERSION via release-please generic updater

### DIFF
--- a/cli/scripts/embed-assets.ts
+++ b/cli/scripts/embed-assets.ts
@@ -67,10 +67,17 @@ function main(): void {
   // Bake the string in at embed time — release-please bumps this in lockstep
   // with the git tag, so the embedded version always matches the release the
   // binary came from.
+  //
+  // The trailing `x-release-please-version` marker lets release-please bump
+  // this line itself during the release PR (this file is a `generic`
+  // extra-file in release-please-config.json). Without it the committed copy
+  // would lag the version bump in cli/package.json until someone re-ran this
+  // script, and the verify-cli-assets check would fail on the next PR. Keep
+  // the marker on the same line as the version.
   const pkg = JSON.parse(readFileSync(resolve(REPO_ROOT, 'cli', 'package.json'), 'utf8')) as { version: string };
   parts.push('// cli/package.json#version (embedded so the compiled binary can self-identify');
   parts.push('// — used by `subwave --version` and by the TUI release fetch URL).');
-  parts.push(`export const CLI_VERSION = \`${encode(pkg.version)}\`;`);
+  parts.push(`export const CLI_VERSION = \`${encode(pkg.version)}\`; // x-release-please-version`);
   parts.push('');
 
   writeFileSync(OUT_FILE, parts.join('\n'));

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -691,4 +691,4 @@ SITE_URL=
 
 // cli/package.json#version (embedded so the compiled binary can self-identify
 // — used by `subwave --version` and by the TUI release fetch URL).
-export const CLI_VERSION = `0.18.0`;
+export const CLI_VERSION = `0.18.0`; // x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -24,6 +24,10 @@
           "type": "json",
           "path": "cli/package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "generic",
+          "path": "cli/src/assets.generated.ts"
         }
       ]
     }


### PR DESCRIPTION
## Why

Twice this week the `verify` (Verify CLI assets) check failed on a release-related PR with `cli/src/assets.generated.ts is out of sync`. Root cause: release-please bumps the `package.json` versions on every release but never updates `assets.generated.ts`, which embeds `CLI_VERSION`. So after each release the committed copy lags (e.g. `package.json` → `0.18.0`, embedded → `0.17.0`), and the *next* release PR's verify check fails. We've been papering over it with a manual `npm --prefix cli run embed-assets` in each back-merge.

## What

Let release-please own that one line:

- **`cli/scripts/embed-assets.ts`** — emits a trailing `// x-release-please-version` marker on the `CLI_VERSION` line. The script stays deterministic (always emits the marker), so the verify check is unaffected.
- **`release-please-config.json`** — registers `cli/src/assets.generated.ts` as a `generic` extra-file. release-please now rewrites that single annotated line in lockstep with `cli/package.json` during the release PR.
- **`cli/src/assets.generated.ts`** — regenerated to carry the marker.

The generic updater only touches lines with the annotation, so the embedded compose content is left untouched. Verified the script is idempotent (two runs → no diff).

## Effect

The `0.19.0` release PR (and every one after) will carry a consistent embedded version with no manual re-embed and no verify failure.

## Test plan
- [ ] On the next release, release-please's `chore(main): release 0.19.0` PR shows `cli/src/assets.generated.ts` changing the `CLI_VERSION` line from `0.18.0` → `0.19.0`.
- [ ] `verify` passes on that release PR with no manual re-embed.
- [ ] `subwave --version` on the published binary reports the release version.