### PR TITLE
feat(player): per-track genre/BPM/key/mood strip in now-playing

### DIFF
--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -14,6 +14,14 @@ export interface NowPlayingTrack {
   year?: number;
   duration?: number;
   subsonic_id?: string;
+  // Analysis/tag data merged in by the controller's /now-playing handler from
+  // the library DB. All optional — a not-yet-tagged track omits them and the
+  // player's metadata strip renders nothing.
+  genre?: string | null;
+  bpm?: number | null;
+  musicalKey?: string | null;
+  moods?: string[];
+  energy?: 'low' | 'medium' | 'high' | null;
 }
 
 export interface WeatherContext {

--- a/app/src/player/CenterStage.tsx
+++ b/app/src/player/CenterStage.tsx
@@ -12,6 +12,28 @@ import { isDjTurn } from '@/lib/sessionFeed';
 import type { NowPlayingTrack, SessionTurn } from '@/lib/types';
 import { useTheme } from '@/theme/ThemeContext';
 
+/** The quiet "music nerd" tokens shown under artist/album: genre · BPM · key.
+ *  Each token is omitted when its field is absent, so an untagged track yields
+ *  an empty array and the strip doesn't render. Mirrors web CenterStage. */
+function buildMetaTokens(t: NowPlayingTrack | null): string[] {
+  if (!t) return [];
+  const tokens: string[] = [];
+  if (t.genre) tokens.push(t.genre.toUpperCase());
+  if (typeof t.bpm === 'number' && t.bpm > 0) tokens.push(`${Math.round(t.bpm)} BPM`);
+  if (t.musicalKey) tokens.push(t.musicalKey);
+  return tokens;
+}
+
+/** The mood/energy phrase, e.g. "MELLOW · LOW ENERGY". Up to two moods plus the
+ *  energy level; empty string when the track carries neither. */
+function buildMoodPhrase(t: NowPlayingTrack | null): string {
+  if (!t) return '';
+  const parts: string[] = [];
+  if (Array.isArray(t.moods)) parts.push(...t.moods.slice(0, 2));
+  if (t.energy) parts.push(`${t.energy} energy`);
+  return parts.join('  ·  ').toUpperCase();
+}
+
 export interface CenterStageProps {
   nowPlaying: NowPlayingTrack | null;
   coverSrc: string | null;
@@ -37,6 +59,9 @@ export default function CenterStage({
   const has = !!nowPlaying?.title;
   const duration = nowPlaying?.duration ?? 0;
   const subsonicId = nowPlaying?.subsonic_id ?? null;
+  const metaTokens = buildMetaTokens(nowPlaying);
+  const moodPhrase = buildMoodPhrase(nowPlaying);
+  const hasMeta = metaTokens.length > 0 || moodPhrase.length > 0;
 
   // Glitch bursts for ~3s on two signals: every track change (subsonic_id flip)
   // and every new DJ turn (voice/dj) landing in the feed — the native analog of
@@ -100,6 +125,19 @@ export default function CenterStage({
             {nowPlaying?.album ? `  ·  ${nowPlaying.album}` : ''}
             {nowPlaying?.year ? `  ·  ${nowPlaying.year}` : ''}
           </Text>
+          {hasMeta ? (
+            <Text
+              className="font-mono mt-2"
+              style={{ fontSize: 11, letterSpacing: 1.5, color: colors.muted }}
+            >
+              {metaTokens.join('  ·  ')}
+              {moodPhrase ? (
+                <Text style={{ color: colors.accent }}>
+                  {metaTokens.length > 0 ? '  ·  ' : ''}↳ {moodPhrase}
+                </Text>
+              ) : null}
+            </Text>
+          ) : null}
         </>
       ) : (
         <Text className="font-display text-muted" style={{ fontSize: 26, lineHeight: 30 }}>

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -5,6 +5,7 @@ import express from 'express';
 import { stat, readFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import * as subsonic from '../music/subsonic.js';
+import * as library from '../music/library.js';
 import * as settings from '../settings.js';
 import { getFullContext } from '../context.js';
 import { queue } from '../broadcast/queue.js';
@@ -143,6 +144,22 @@ router.get('/now-playing', async (req, res) => {
       queue.getNowPlaying(),
       getFullContext(),
     ]);
+    // Enrich the live track with the analysis/tag data the player surfaces in
+    // its minimal metadata strip (genre · BPM · key · mood). All of it lives
+    // in the library DB keyed by subsonic_id; getNowPlaying() stays a pure
+    // reader of now-playing.json. A not-yet-tagged track (or unloaded DB)
+    // yields null here and the fields are simply omitted.
+    if (nowPlaying?.subsonic_id) {
+      const rec = library.get(nowPlaying.subsonic_id);
+      if (rec) {
+        nowPlaying.genre = rec.genre ?? null;
+        nowPlaying.bpm = rec.bpm ?? null;
+        nowPlaying.musicalKey = rec.musicalKey ?? null;
+        nowPlaying.moods = Array.isArray(rec.moods) ? rec.moods : [];
+        nowPlaying.energy = rec.energy ?? null;
+        if (nowPlaying.year == null && rec.year != null) nowPlaying.year = rec.year;
+      }
+    }
     // Served from the 15s listener-monitor cache — no per-request Icecast hit.
     const stream = getStreamStatus();
     const persona = settings.getEffectivePersona();

--- a/web/components/CenterStage.tsx
+++ b/web/components/CenterStage.tsx
@@ -12,6 +12,29 @@ import { isDjTurn } from '@/lib/sessionFeed';
 import { useStationOrigin } from '@/lib/stationOrigin';
 import type { NowPlayingTrack, SessionTurn } from '@/lib/types';
 
+/** The quiet "music nerd" tokens shown under artist/album: genre · BPM · key.
+ *  Returned separately from the mood cluster so the latter can carry the accent
+ *  colour. Each token is omitted when its field is absent, so an untagged track
+ *  yields an empty array and the strip doesn't render at all. */
+function buildMetaTokens(t: NowPlayingTrack | null): string[] {
+  if (!t) return [];
+  const tokens: string[] = [];
+  if (t.genre) tokens.push(t.genre.toUpperCase());
+  if (typeof t.bpm === 'number' && t.bpm > 0) tokens.push(`${Math.round(t.bpm)} BPM`);
+  if (t.musicalKey) tokens.push(t.musicalKey);
+  return tokens;
+}
+
+/** The mood/energy phrase, e.g. "mellow · low energy". Up to two moods plus the
+ *  energy level; empty string when the track carries neither. */
+function buildMoodPhrase(t: NowPlayingTrack | null): string {
+  if (!t) return '';
+  const parts: string[] = [];
+  if (Array.isArray(t.moods)) parts.push(...t.moods.slice(0, 2));
+  if (t.energy) parts.push(`${t.energy} energy`);
+  return parts.join(' · ');
+}
+
 export interface CenterStageProps {
   nowPlaying: NowPlayingTrack | null;
   /** Epoch ms when the current track started (from useStationFeed). */
@@ -28,6 +51,9 @@ export default memo(function CenterStage({ nowPlaying, trackStartedAt, feed, djL
   // only re-renders this subtree — not the whole player (see useElapsed).
   const elapsed = useElapsed(trackStartedAt);
   const has = !!nowPlaying?.title;
+  const metaTokens = buildMetaTokens(nowPlaying);
+  const moodPhrase = buildMoodPhrase(nowPlaying);
+  const hasMeta = metaTokens.length > 0 || moodPhrase.length > 0;
   const duration = nowPlaying?.duration ?? 0;
   const subsonicId = nowPlaying?.subsonic_id ?? null;
   const coverSrc = subsonicId
@@ -143,6 +169,16 @@ export default memo(function CenterStage({ nowPlaying, trackStartedAt, feed, djL
                     {nowPlaying?.album && <span className="ml-[14px]"> · {nowPlaying.album}</span>}
                     {nowPlaying?.year && <span className="ml-[14px]"> · {nowPlaying.year}</span>}
                   </div>
+                  {hasMeta && (
+                    <div className="v3-caption mt-[10px] text-muted">
+                      {metaTokens.join(' · ')}
+                      {moodPhrase && (
+                        <span className="text-vermilion">
+                          {metaTokens.length > 0 ? ' · ' : ''}↳ {moodPhrase}
+                        </span>
+                      )}
+                    </div>
+                  )}
                 </>
               ) : (
                 <h1 className="v3-title m-0 text-muted">

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -13,6 +13,14 @@ export interface NowPlayingTrack {
   year?: number;
   duration?: number;
   subsonic_id?: string;
+  // Analysis/tag data merged in by the controller's /now-playing handler from
+  // the library DB. All optional — a not-yet-tagged track omits them and the
+  // player's metadata strip renders nothing.
+  genre?: string | null;
+  bpm?: number | null;
+  musicalKey?: string | null;
+  moods?: string[];
+  energy?: 'low' | 'medium' | 'high' | null;
 }
 
 export interface WeatherContext {


### PR DESCRIPTION
## What

Surfaces the per-track data SUB/WAVE already captures — **genre, BPM, Camelot key, AI mood tags, energy** — as a quiet inline strip under the artist/album line, on **both the web and native players**.

```
HIP HOP · 100 BPM · 11B · ↳ EUPHORIC · ROMANTIC · HIGH ENERGY
```

The genre/BPM/key tokens sit in muted grey (matching the existing "NOW PLAYING" caption); the mood/energy cluster is in the accent/vermilion colour so it reads as the one warm token.

## How

- **controller** (`routes/public.ts`): `GET /now-playing` now does a `library.get(subsonic_id)` lookup and merges `genre / bpm / musicalKey / moods / energy` onto the live track (and backfills `year`). `getNowPlaying()` stays a pure reader of `now-playing.json`. Guarded so a not-yet-tagged track simply omits the fields.
- **web** (`web/components/CenterStage.tsx`) + **native** (`app/src/player/CenterStage.tsx`): two small helpers build the token list and mood phrase; the strip renders inside the existing now-playing block and **hides entirely** when a track has no analysis data (graceful degrade to today's look). Mood cluster uses `text-vermilion` on web and `colors.accent` (the native theme's vermilion) on native.
- **types**: `NowPlayingTrack` extended in both `web/lib/types.ts` and `app/src/lib/types.ts` (kept in sync per the native copy's header note).

No new endpoint — both apps share the one enriched `/now-playing`.

## Why

We capture a rich analysis surface per track (genre, tempo, key, mood, energy) that listeners never saw. This shows the interesting slice minimally, without turning the player into a dashboard.

## Verification

- `npm run lint` (eslint + `tsc --noEmit`) clean in **web** and **controller**; `tsc --noEmit` + `expo lint` clean in **app**.
- Verified live in the web dev stack: strip renders with enriched data for a tagged track and disappears for an untagged one. (Screenshotted during development.)

## Notes

- Native change is code-complete and typechecks/lints, but was **not** booted in a simulator — it's a direct port of the verified web component sharing the same API.