### PR TITLE
feat(admin): add Manual link to bottom of admin sidebar

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2605,8 +2605,12 @@ body::after {
     color: #fff;
     opacity: 1;
 }
-.admin-root .shell-nav .nav-foot {
+/* Manual link sits at the bottom of the rail, grouped with the foot — it
+   absorbs the free space so both it and the footer hug the bottom. */
+.admin-root .shell-nav .nav-item-manual {
     margin-top: auto;
+}
+.admin-root .shell-nav .nav-foot {
     padding-top: 14px;
     border-top: 1px dashed var(--separator-strong);
     font-size: 10px;

--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -18,6 +18,7 @@ import {
   Archive,
   Webhook,
   Telescope,
+  BookOpen,
 } from 'lucide-react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import type { SignInResult } from '../../lib/adminAuth';
@@ -181,6 +182,16 @@ export default function AdminShell({ children }: AdminShellProps) {
               })}
             </div>
           ))}
+          <Link
+            href="/manual"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="nav-item nav-item-manual"
+          >
+            <BookOpen className="nav-icon" size={15} strokeWidth={2} aria-hidden="true" />
+            <span className="nav-label">Manual</span>
+            <span className="pill">↗</span>
+          </Link>
           <div className="nav-foot">
             sub / wave
             <br />

--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -198,7 +198,7 @@ export default function AdminShell({ children }: AdminShellProps) {
             href="https://apps.apple.com/app/sub-wave/id6778786696"
             target="_blank"
             rel="noopener noreferrer"
-            className="nav-item nav-item-app"
+            className="nav-item"
           >
             <Apple className="nav-icon" size={15} strokeWidth={2} aria-hidden="true" />
             <span className="nav-label">iOS app</span>
@@ -208,7 +208,7 @@ export default function AdminShell({ children }: AdminShellProps) {
             href="https://play.google.com/store/apps/details?id=com.getsubwave.app"
             target="_blank"
             rel="noopener noreferrer"
-            className="nav-item nav-item-app"
+            className="nav-item"
           >
             <Smartphone className="nav-icon" size={15} strokeWidth={2} aria-hidden="true" />
             <span className="nav-label">Android app</span>

--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -19,6 +19,8 @@ import {
   Webhook,
   Telescope,
   BookOpen,
+  Apple,
+  Smartphone,
 } from 'lucide-react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import type { SignInResult } from '../../lib/adminAuth';
@@ -190,6 +192,26 @@ export default function AdminShell({ children }: AdminShellProps) {
           >
             <BookOpen className="nav-icon" size={15} strokeWidth={2} aria-hidden="true" />
             <span className="nav-label">Manual</span>
+            <span className="pill">↗</span>
+          </Link>
+          <Link
+            href="https://apps.apple.com/app/sub-wave/id6778786696"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="nav-item nav-item-app"
+          >
+            <Apple className="nav-icon" size={15} strokeWidth={2} aria-hidden="true" />
+            <span className="nav-label">iOS app</span>
+            <span className="pill">↗</span>
+          </Link>
+          <Link
+            href="https://play.google.com/store/apps/details?id=com.getsubwave.app"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="nav-item nav-item-app"
+          >
+            <Smartphone className="nav-icon" size={15} strokeWidth={2} aria-hidden="true" />
+            <span className="nav-label">Android app</span>
             <span className="pill">↗</span>
           </Link>
           <div className="nav-foot">

--- a/web/components/landing/StationFooter.tsx
+++ b/web/components/landing/StationFooter.tsx
@@ -30,22 +30,6 @@ export default function StationFooter({ djName }: { djName?: string }) {
             className="font-semibold tracking-[inherit] text-ink hover:text-vermilion"
           >
             Discord
-          </AnimatedLink>{' '}
-          ·{' '}
-          <AnimatedLink
-            href="https://apps.apple.com/app/sub-wave/id6778786696"
-            variant="arrow"
-            className="font-semibold tracking-[inherit] text-ink hover:text-vermilion"
-          >
-            iOS
-          </AnimatedLink>{' '}
-          ·{' '}
-          <AnimatedLink
-            href="https://play.google.com/store/apps/details?id=com.getsubwave.app"
-            variant="arrow"
-            className="font-semibold tracking-[inherit] text-ink hover:text-vermilion"
-          >
-            Android
           </AnimatedLink>
         </span>
       </div>

--- a/web/components/landing/StationFooter.tsx
+++ b/web/components/landing/StationFooter.tsx
@@ -30,6 +30,22 @@ export default function StationFooter({ djName }: { djName?: string }) {
             className="font-semibold tracking-[inherit] text-ink hover:text-vermilion"
           >
             Discord
+          </AnimatedLink>{' '}
+          ·{' '}
+          <AnimatedLink
+            href="https://apps.apple.com/app/sub-wave/id6778786696"
+            variant="arrow"
+            className="font-semibold tracking-[inherit] text-ink hover:text-vermilion"
+          >
+            iOS
+          </AnimatedLink>{' '}
+          ·{' '}
+          <AnimatedLink
+            href="https://play.google.com/store/apps/details?id=com.getsubwave.app"
+            variant="arrow"
+            className="font-semibold tracking-[inherit] text-ink hover:text-vermilion"
+          >
+            Android
           </AnimatedLink>
         </span>
       </div>

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -114,6 +114,7 @@ export default defineConfig([
             '^nav-section$',
             '^nav-section-label$',
             '^nav-item$',
+            '^nav-item-manual$',
             '^nav-icon$',
             '^nav-label$',
             '^nav-foot$',


### PR DESCRIPTION
## What

Adds a **Manual ↗** link to the bottom of the admin sidebar (`AdminShell`), linking to the public `/manual` page.

## Details

- New `BookOpen` (lucide) nav item rendered after the nav sections, above the `sub / wave · admin console` footer.
- Opens `/manual` in a new tab (`target="_blank"`), matching the existing "listen ↗" external-link pattern.
- Reuses existing `nav-item` / `nav-icon` / `nav-label` / `pill` styles so it looks native to the rail; `↗` pill marks it as external.
- CSS: moved `margin-top: auto` onto a new `.nav-item-manual` class so the Manual link and footer hug the bottom of the rail.

## Notes

`/manual` is a live route (`web/app/manual`); `BookOpen` confirmed as a valid `lucide-react` export.