### PR TITLE
docs(readme): embed showreel video

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ language; the DJ works out what you meant and slots it in.
 It's *radio*, not a playlist. No per-listener shuffle, no skip button, no
 "up next for you." You tune in and hear whatever is on.
 
+## Showreel
+
+https://github.com/user-attachments/assets/fac7b723-c54f-438d-8440-bad1e0471e85
+
+A 24.5s tour of SUB/WAVE — music, voiceover, and SFX, rendered at 60fps.
+Also available in [1080p / 4K](https://github.com/perminder-klair/subwave/releases/tag/showreel-v1).
+
 ## Live demo
 
 - **Project site** — [getsubwave.com](https://www.getsubwave.com/)

--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ It's *radio*, not a playlist. No per-listener shuffle, no skip button, no
 
 https://github.com/user-attachments/assets/fac7b723-c54f-438d-8440-bad1e0471e85
 
-A 24.5s tour of SUB/WAVE — music, voiceover, and SFX, rendered at 60fps.
-Also available in [1080p / 4K](https://github.com/perminder-klair/subwave/releases/tag/showreel-v1).
-
 ## Live demo
 
 - **Project site** — [getsubwave.com](https://www.getsubwave.com/)


### PR DESCRIPTION
Adds a **Showreel** section to the README that embeds the GitHub-hosted showreel video as an inline player (the `user-attachments` URL from discussion #402, which GitHub auto-renders as a video player), with a link to the 1080p/4K downloads on the `showreel-v1` release.