### PR TITLE
feat(admin): fold Archives/Webhooks/Backup into Settings + tighten app links

### DIFF
--- a/web/app/admin/archives/page.tsx
+++ b/web/app/admin/archives/page.tsx
@@ -1,10 +1,6 @@
-import type { Metadata } from 'next';
-import ArchivesPanel from '../../../components/admin/ArchivesPanel';
+import { redirect } from 'next/navigation';
 
-export const metadata: Metadata = {
-  title: 'Archives',
-};
-
+// Archives moved into Settings → Archives. Redirect old bookmarks/links.
 export default function AdminArchivesPage() {
-  return <ArchivesPanel />;
+  redirect('/admin/settings?section=archives');
 }

--- a/web/app/admin/backup/page.tsx
+++ b/web/app/admin/backup/page.tsx
@@ -1,10 +1,6 @@
-import type { Metadata } from 'next';
-import BackupPanel from '../../../components/admin/BackupPanel';
+import { redirect } from 'next/navigation';
 
-export const metadata: Metadata = {
-  title: 'Backup',
-};
-
+// Backup moved into Settings → Backup. Redirect old bookmarks/links.
 export default function AdminBackupPage() {
-  return <BackupPanel />;
+  redirect('/admin/settings?section=backup');
 }

--- a/web/app/admin/webhooks/page.tsx
+++ b/web/app/admin/webhooks/page.tsx
@@ -1,10 +1,6 @@
-import type { Metadata } from 'next';
-import WebhooksPanel from '../../../components/admin/WebhooksPanel';
+import { redirect } from 'next/navigation';
 
-export const metadata: Metadata = {
-  title: 'Webhooks',
-};
-
+// Webhooks moved into Settings → Webhooks. Redirect old bookmarks/links.
 export default function AdminWebhooksPage() {
-  return <WebhooksPanel />;
+  redirect('/admin/settings?section=webhooks');
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2605,9 +2605,10 @@ body::after {
     color: #fff;
     opacity: 1;
 }
-/* Manual link sits at the bottom of the rail, grouped with the foot — it
-   absorbs the free space so both it and the footer hug the bottom. */
-.admin-root .shell-nav .nav-item-manual {
+/* External links (Manual / app stores) sit at the bottom of the rail, grouped
+   with the foot — margin-top:auto absorbs the free space so the group and the
+   footer hug the bottom. .nav-section gives them the tight 3px intra-group gap. */
+.admin-root .shell-nav .nav-ext {
     margin-top: auto;
 }
 .admin-root .shell-nav .nav-foot {

--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -15,10 +15,7 @@ import {
   Sparkles,
   SlidersHorizontal,
   Terminal,
-  Archive,
-  Webhook,
   Telescope,
-  DatabaseBackup,
   BookOpen,
   Apple,
   Smartphone,
@@ -70,9 +67,6 @@ const NAV_SECTIONS: NavSection[] = [
     label: 'System',
     items: [
       { href: '/admin/stats', id: 'stats', label: 'Stats', icon: BarChart3 },
-      { href: '/admin/archives', id: 'archives', label: 'Archives', icon: Archive },
-      { href: '/admin/webhooks', id: 'webhooks', label: 'Webhooks', icon: Webhook },
-      { href: '/admin/backup', id: 'backup', label: 'Backup', icon: DatabaseBackup },
       { href: '/admin/settings', id: 'settings', label: 'Settings', icon: SlidersHorizontal },
       { href: '/admin/debug', id: 'debug', label: 'Debug', icon: Terminal },
     ],
@@ -186,36 +180,41 @@ export default function AdminShell({ children }: AdminShellProps) {
               })}
             </div>
           ))}
-          <Link
-            href="/manual"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="nav-item nav-item-manual"
-          >
-            <BookOpen className="nav-icon" size={15} strokeWidth={2} aria-hidden="true" />
-            <span className="nav-label">Manual</span>
-            <span className="pill">↗</span>
-          </Link>
-          <Link
-            href="https://apps.apple.com/app/sub-wave/id6778786696"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="nav-item"
-          >
-            <Apple className="nav-icon" size={15} strokeWidth={2} aria-hidden="true" />
-            <span className="nav-label">iOS app</span>
-            <span className="pill">↗</span>
-          </Link>
-          <Link
-            href="https://play.google.com/store/apps/details?id=com.getsubwave.app"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="nav-item"
-          >
-            <Smartphone className="nav-icon" size={15} strokeWidth={2} aria-hidden="true" />
-            <span className="nav-label">Android app</span>
-            <span className="pill">↗</span>
-          </Link>
+          {/* External links — grouped like a nav-section so they sit tight
+              together (3px) rather than the rail's 18px; nav-ext pins the
+              group to the bottom. */}
+          <div className="nav-section nav-ext">
+            <Link
+              href="/manual"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="nav-item"
+            >
+              <BookOpen className="nav-icon" size={15} strokeWidth={2} aria-hidden="true" />
+              <span className="nav-label">Manual</span>
+              <span className="pill">↗</span>
+            </Link>
+            <Link
+              href="https://apps.apple.com/app/sub-wave/id6778786696"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="nav-item"
+            >
+              <Apple className="nav-icon" size={15} strokeWidth={2} aria-hidden="true" />
+              <span className="nav-label">iOS app</span>
+              <span className="pill">↗</span>
+            </Link>
+            <Link
+              href="https://play.google.com/store/apps/details?id=com.getsubwave.app"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="nav-item"
+            >
+              <Smartphone className="nav-icon" size={15} strokeWidth={2} aria-hidden="true" />
+              <span className="nav-label">Android app</span>
+              <span className="pill">↗</span>
+            </Link>
+          </div>
           <div className="nav-foot">
             sub / wave
             <br />

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -18,6 +18,9 @@ import {
 } from '../ui/select';
 import { Card, Btn, Pill, Eyebrow, Seg, Metric } from './ui';
 import { cn } from '../../lib/cn';
+import ArchivesPanel from './ArchivesPanel';
+import WebhooksPanel from './WebhooksPanel';
+import BackupPanel from './BackupPanel';
 
 const SECTIONS = [
   { id: 'station',  label: 'Station', hint: 'name · location · timezone' },
@@ -29,6 +32,9 @@ const SECTIONS = [
   { id: 'jingles',  label: 'Jingles', hint: 'stingers' },
   { id: 'sfx',      label: 'Sound FX', hint: 'agent stingers' },
   { id: 'scrobble', label: 'Scrobbling', hint: 'last.fm · listenbrainz' },
+  { id: 'archives', label: 'Archives', hint: 'hourly recordings' },
+  { id: 'webhooks', label: 'Webhooks', hint: 'outbound events' },
+  { id: 'backup',   label: 'Backup', hint: 'export · restore' },
   { id: 'danger',   label: 'Danger zone', hint: 'broadcast control' },
 ] as const;
 
@@ -311,6 +317,14 @@ export default function SettingsPanel() {
       setSfxData((await r.json()) as SfxData);
     } catch { /* non-fatal */ }
   };
+
+  // Deep-link: /admin/settings?section=webhooks opens that rail directly. The
+  // old standalone /admin/{archives,webhooks,backup} routes redirect here, so
+  // existing bookmarks keep working after the move into Settings.
+  useEffect(() => {
+    const s = new URLSearchParams(window.location.search).get('section');
+    if (s && SECTIONS.some(x => x.id === s)) setActiveSection(s as SectionId);
+  }, []);
 
   useEffect(() => {
     if (!data?.values || form) return;
@@ -640,6 +654,11 @@ export default function SettingsPanel() {
             data={data} saveSettings={saveSettings} adminFetch={adminFetch}
           />
         )}
+        {/* Self-contained panels — each re-calls useAdminAuth and owns its
+            own data fetch, so they render outside the data && form guard. */}
+        {activeSection === 'archives' && <ArchivesPanel />}
+        {activeSection === 'webhooks' && <WebhooksPanel />}
+        {activeSection === 'backup' && <BackupPanel />}
         {activeSection === 'danger' && (
           <>
             <SectionHeader

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -114,7 +114,7 @@ export default defineConfig([
             '^nav-section$',
             '^nav-section-label$',
             '^nav-item$',
-            '^nav-item-manual$',
+            '^nav-ext$',
             '^nav-icon$',
             '^nav-label$',
             '^nav-foot$',


### PR DESCRIPTION
## What

Consolidates three admin areas into **Settings** and tightens the sidebar's app links.

### Archives / Webhooks / Backup → Settings
- Removed **Archives**, **Webhooks**, **Backup** from the admin sidebar (`AdminShell`); the System group is now Stats · Settings · Debug.
- Added them as sections in the Settings rail, after *Scrobbling* and before *Danger zone*. The existing `ArchivesPanel` / `WebhooksPanel` / `BackupPanel` are reused unchanged — they're self-contained (own `useAdminAuth` + data fetch), so they render outside the `data && form` guard.
- The old `/admin/{archives,webhooks,backup}` routes now **redirect** to `/admin/settings?section=…`, and `SettingsPanel` reads `?section=` on mount, so existing bookmarks/links land on the right rail instead of 404ing.

### Sidebar app links
- Grouped the bottom-rail external links (**Manual / iOS app / Android app**) into a `nav-section` so they sit at the tight 3px intra-group gap instead of the rail's 18px. The bottom-pin (`margin-top:auto`) moved from the old `.nav-item-manual` to a `.nav-ext` wrapper (eslint allow-list updated to match).

## Verification
- `tsc --noEmit` clean; `eslint` clean on all changed files.
- Ran the dev stack from a worktree and verified in-browser: each new rail section renders its panel inside Settings (Archives "What went out, hour by hour", Webhooks "Pipe station events…", Backup), and the three app links now sit tightly grouped above the admin-console footer.

## Notes
Pure frontend reorganization — no controller/API or behavior changes to the panels themselves.
