### PR TITLE
feat(admin): "Reconcile with Navidrome" — prune deleted tracks from the library

### DIFF
--- a/controller/src/broadcast/tagger.ts
+++ b/controller/src/broadcast/tagger.ts
@@ -11,10 +11,11 @@ type TaggerState = {
   startedAt: string | null;
   pid: number | null;
   lastLog: string[];
-  // Which script the live child is: 'tag' (tag-library) or 'analyze' (the
-  // acoustic/audio-embedding pass via analyze-library). Single-flight across
-  // both — they contend on the same library DB and analysis backend.
-  mode: 'tag' | 'analyze' | null;
+  // Which script the live child is: 'tag' (tag-library), 'analyze' (the
+  // acoustic/audio-embedding pass via analyze-library), or 'reconcile' (the
+  // tag-library --reconcile-only walk+prune). Single-flight across all three —
+  // they contend on the same library DB and analysis backend.
+  mode: 'tag' | 'analyze' | 'reconcile' | null;
   // Latest structured progress sentinel from the child ([progress] lines on
   // stdout — see music/tagger-progress.ts). Left in place after exit so the
   // last payload doubles as a what-just-finished summary; the UI gates its
@@ -86,8 +87,16 @@ export function startAnalyzer(opts: { limit?: number; audio?: boolean } = {}) {
   spawnChild('analyze', args, detail);
 }
 
-function spawnChild(mode: 'tag' | 'analyze', args: string[], detail: string) {
-  const label = mode === 'tag' ? 'tagger' : 'analyzer';
+// Spawn the standalone reconcile pass: walk Navidrome and prune library rows
+// for tracks it no longer contains. No embeddings, no LLM — the cheap "clear
+// orphaned entries" path behind the admin "Reconcile with Navidrome" button.
+// Same single-flight slot as the tagger/analyzer; caller rejects when running.
+export function startReconcile() {
+  spawnChild('reconcile', ['src/music/tag-library.ts', '--reconcile-only'], '');
+}
+
+function spawnChild(mode: 'tag' | 'analyze' | 'reconcile', args: string[], detail: string) {
+  const label = mode === 'tag' ? 'tagger' : mode === 'analyze' ? 'analyzer' : 'reconcile';
   const child = spawn('npx', ['tsx', ...args], { cwd: '/app', detached: false });
   activeChild = child;
   tagger.running = true;

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -67,6 +67,7 @@ interface CliFlags {
   upgrade: boolean;
   skipAnalyze: boolean;
   reAnalyze: boolean;
+  reconcileOnly: boolean;
 }
 
 function parseFlags(): CliFlags {
@@ -87,7 +88,66 @@ function parseFlags(): CliFlags {
     upgrade: args.includes('--upgrade'),
     skipAnalyze: args.includes('--skip-analyze'),
     reAnalyze: args.includes('--re-analyze'),
+    // Walk Navidrome and prune library rows for tracks it no longer contains,
+    // then exit — no embeddings, no LLM. The admin "Reconcile with Navidrome"
+    // button drives this so orphaned entries can be cleared without paying for
+    // a full tag/analyze pass (works even at 100% coverage).
+    reconcileOnly: args.includes('--reconcile-only'),
   };
+}
+
+// Walk the entire Navidrome catalogue, upserting each song's metadata into the
+// tracks table and collecting the live id set. Shared by the full tagger run
+// (Phase A) and the standalone --reconcile-only path. Cheap: metadata only, no
+// embeddings or LLM calls.
+async function walkNavidrome(): Promise<{ walked: number; liveIds: Set<string> }> {
+  reportProgress({ phase: 'walk', label: 'Scanning Navidrome library', done: 0 });
+  let walked = 0;
+  const liveIds = new Set<string>();
+  for await (const song of subsonic.iterateAllSongs()) {
+    db.upsertTrackMeta(song.id, {
+      title: song.title,
+      artist: song.artist,
+      album: song.album,
+      year: song.year,
+      genre: song.genre,
+      duration: song.duration,
+    });
+    liveIds.add(song.id);
+    walked += 1;
+    if (walked % 500 === 0) {
+      console.log(`[tag] walked ${walked} tracks`);
+      reportProgress({ phase: 'walk', label: 'Scanning Navidrome library', done: walked });
+    }
+  }
+  console.log(`[tag] walked ${walked} total tracks`);
+  return { walked, liveIds };
+}
+
+// Standalone reconcile: diff library-db against the live Navidrome catalogue and
+// drop rows (and their vectors) for tracks that are gone. No embedding preflight
+// and no LLM — opens the existing DB at its stored dim so vectors are untouched.
+async function reconcileOnly() {
+  await db.open({ embeddingDim: embeddings.resolveEmbeddingDim(), adoptStoredDim: true });
+  console.log('[tag] reconcile-only: walking Navidrome to prune orphaned rows');
+  const { walked, liveIds } = await walkNavidrome();
+  let pruned = 0;
+  if (walked > 0) {
+    pruned = db.pruneMissingTracks(liveIds);
+    console.log(`[tag] reconcile pruned ${pruned} orphaned tracks no longer in Navidrome`);
+  } else {
+    // A transient empty Navidrome response must never wipe the DB.
+    console.warn('[tag] reconcile: Navidrome returned 0 tracks — skipping prune');
+  }
+  reportProgress({
+    phase: 'done',
+    label: pruned > 0
+      ? `Removed ${pruned} track${pruned === 1 ? '' : 's'} no longer in Navidrome`
+      : 'Library is in sync with Navidrome',
+    done: pruned,
+  });
+  console.log(`[tag] reconcile complete (walked ${walked}, pruned ${pruned})`);
+  process.exit(0);
 }
 
 // Mirrors server.ts boot: cloud API keys from secrets.env, Navidrome creds
@@ -123,6 +183,13 @@ async function main() {
 
   await applyWizardOverlay();
   await settings.load();
+
+  // Reconcile is a pure catalogue diff — short-circuit before any embedding /
+  // LLM setup so it runs even when embeddings are disabled or unconfigured.
+  if (flags.reconcileOnly) {
+    await reconcileOnly();
+    return;
+  }
 
   if (!embeddings.isAvailable()) {
     console.error('[tag] embeddings not available — set settings.embedding.enabled / provider');
@@ -189,26 +256,7 @@ async function main() {
   // Cheap; ensures every Navidrome song is in the tracks table so subsequent
   // phases can operate purely off SQL.
   console.log('[tag] walking Navidrome library...');
-  reportProgress({ phase: 'walk', label: 'Scanning Navidrome library', done: 0 });
-  let walked = 0;
-  const liveIds = new Set<string>();
-  for await (const song of subsonic.iterateAllSongs()) {
-    db.upsertTrackMeta(song.id, {
-      title: song.title,
-      artist: song.artist,
-      album: song.album,
-      year: song.year,
-      genre: song.genre,
-      duration: song.duration,
-    });
-    liveIds.add(song.id);
-    walked += 1;
-    if (walked % 500 === 0) {
-      console.log(`[tag] walked ${walked} tracks`);
-      reportProgress({ phase: 'walk', label: 'Scanning Navidrome library', done: walked });
-    }
-  }
-  console.log(`[tag] walked ${walked} total tracks`);
+  const { walked, liveIds } = await walkNavidrome();
 
   // Reconcile against the live catalogue. The walk above is complete and
   // authoritative, so any track row it didn't see is gone from Navidrome

--- a/controller/src/routes/library.ts
+++ b/controller/src/routes/library.ts
@@ -14,7 +14,7 @@ import { tagBatch, TAGGER_BATCH_SYSTEM } from '../music/tagger-core.js';
 import { promptVocabHash } from '../music/embeddings.js';
 import { activeModelLabel } from '../llm/provider.js';
 import { queue } from '../broadcast/queue.js';
-import { tagger, startAnalyzer } from '../broadcast/tagger.js';
+import { tagger, startAnalyzer, startReconcile } from '../broadcast/tagger.js';
 
 export const router = express.Router();
 
@@ -341,6 +341,20 @@ router.post('/library/analyze', requireAdmin, (req, res) => {
   if (tagger.running) return res.status(409).json({ error: 'a tagger/analyzer run is already active', tagger });
   const limit = parseIntSafe(req.body?.limit, null);
   startAnalyzer({ limit: limit ?? undefined, audio: true });
+  res.json({ ok: true, tagger });
+});
+
+// ---------------------------------------------------------------------------
+// POST /library/reconcile — walk Navidrome and prune library rows for tracks
+// that no longer exist there (deleted files, or IDs re-minted by a full
+// rescan). No LLM, no embeddings — the cheap "clear orphaned entries" path,
+// usable even at 100% coverage where Start tagging is disabled. Shares the
+// tagger's single-flight slot: poll /settings (tagger.running / tagger.mode ===
+// 'reconcile') for progress, stop via /tag-library/stop.
+// ---------------------------------------------------------------------------
+router.post('/library/reconcile', requireAdmin, (req, res) => {
+  if (tagger.running) return res.status(409).json({ error: 'a tagger/analyzer run is already active', tagger });
+  startReconcile();
   res.json({ ok: true, tagger });
 });
 

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -571,6 +571,31 @@ export default function LibraryPanel() {
     }
   };
 
+  // Reconcile with Navidrome — walk the catalogue and prune library entries
+  // for tracks that no longer exist (deleted files, or IDs re-minted by a full
+  // rescan). No LLM/embedding cost; reuses the tagger's single-flight slot, so
+  // the running view + stop button below cover it. Usable at 100% coverage,
+  // where Start tagging is disabled.
+  const reconcile = async () => {
+    setTaggerBusy(true);
+    try {
+      const r = await adminFetch('/library/reconcile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      const j = await r.json().catch(() => ({})) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `reconcile failed (${r.status})`);
+      notify.ok('reconcile started — scanning Navidrome');
+      setLogOpen(true);
+      await loadTagger();
+    } catch (err) {
+      notify.err(errorMessage(err));
+    } finally {
+      setTaggerBusy(false);
+    }
+  };
+
   // Run the analysis pass (bpm/key + audio fingerprints) as a background
   // child — same single-flight state as the tagger, so the running view and
   // stop button below cover it too.
@@ -641,6 +666,7 @@ export default function LibraryPanel() {
         onStart={startTagger}
         onStop={stopTagger}
         onRescan={rescanTagger}
+        onReconcile={reconcile}
         audioEnabled={audioEnabled}
         onToggleAudio={toggleAudio}
         onAnalyzeAudio={analyzeAudio}

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -62,9 +62,10 @@ export interface TaggerState {
   pid?: number;
   startedAt?: string;
   lastLog?: string[];
-  // 'tag' (tag-library) or 'analyze' (the acoustic/audio-embedding pass) —
-  // both run through the same single-flight child slot.
-  mode?: 'tag' | 'analyze' | null;
+  // 'tag' (tag-library), 'analyze' (the acoustic/audio-embedding pass), or
+  // 'reconcile' (walk Navidrome + prune orphaned rows) — all run through the
+  // same single-flight child slot.
+  mode?: 'tag' | 'analyze' | 'reconcile' | null;
   progress?: TaggerProgress | null;
 }
 
@@ -108,6 +109,8 @@ interface TaggingPanelProps {
   onStart: () => void;
   onStop: () => void;
   onRescan: (opts: RescanOpts) => void;
+  // Walk Navidrome and prune library entries for tracks that no longer exist.
+  onReconcile: () => void;
   // sounds-like (CLAP) controls — null until the first settings poll lands.
   audioEnabled: boolean | null;
   onToggleAudio: () => void;
@@ -276,6 +279,14 @@ export default function TaggingPanel(p: TaggingPanelProps) {
             <Btn lg tone="accent" onClick={p.onStart} disabled={p.busy || remaining === 0}>
               <Play size={13} /> Start tagging
             </Btn>
+            <Btn
+              lg
+              onClick={p.onReconcile}
+              disabled={p.busy}
+              title="Walk Navidrome and remove library entries for tracks that no longer exist (deleted files or IDs changed by a full rescan). No tagging cost."
+            >
+              <RefreshCw size={13} /> Reconcile with Navidrome
+            </Btn>
           </div>
         </div>
       ) : (
@@ -294,7 +305,9 @@ export default function TaggingPanel(p: TaggingPanelProps) {
                   )}
                 </>
               ) : (
-                p.tagger?.mode === 'analyze' ? 'Audio analysis in progress…' : 'Tagging in progress…'
+                p.tagger?.mode === 'analyze' ? 'Audio analysis in progress…'
+                  : p.tagger?.mode === 'reconcile' ? 'Reconciling with Navidrome…'
+                  : 'Tagging in progress…'
               )}
             </span>
             <span className="caption mono-num !tracking-[0.04em]">
@@ -318,7 +331,9 @@ export default function TaggingPanel(p: TaggingPanelProps) {
             {(progress && PHASE_HINT[progress.phase]) ||
               (p.tagger?.mode === 'analyze'
                 ? 'The analysis engine is listening to each track — measuring tempo and key, and fingerprinting how it sounds.'
-                : 'The DJ is listening to each new track and deciding its mood & energy.')}
+                : p.tagger?.mode === 'reconcile'
+                  ? 'Checking every track against Navidrome and removing entries for files that no longer exist.'
+                  : 'The DJ is listening to each new track and deciding its mood & energy.')}
             {' '}You can keep browsing — this runs in the background.
           </div>
         </div>


### PR DESCRIPTION
## What

Adds a **Reconcile with Navidrome** button to `/admin/library`, next to **Start tagging**. It walks the Navidrome catalogue and prunes library-db rows (and their text/audio vectors) for tracks that no longer exist there.

## Why

The tagged library (`state/library.db`) is keyed by Navidrome song IDs but has no way to learn when a track is removed. Orphaned rows are pruned today only as a side effect of a full `npm run tag` / analyze walk — and **not at all** at 100% coverage, since Start tagging is disabled then. Stale rows let the picker select dead URIs that fail on-air (and a Navidrome full rescan can re-mint IDs, orphaning rows for files that still exist).

This gives operators a cheap, explicit "clear orphaned entries" action: **no LLM, no embeddings**, usable at any coverage.

## How

**Backend**
- `tag-library.ts` — new `--reconcile-only` flag; extracted the Navidrome walk into a shared `walkNavidrome()` helper (used by both Phase A and reconcile); `reconcileOnly()` opens the DB at its stored embedding dim (vectors untouched), walks, prunes via the existing `db.pruneMissingTracks(liveIds)`, and exits. Short-circuits **before** the embedding preflight so it runs even with embeddings off. Keeps the `walked > 0` guard so a transient empty Navidrome response can't wipe the DB.
- `broadcast/tagger.ts` — new `'reconcile'` single-flight mode + `startReconcile()`.
- `routes/library.ts` — `POST /library/reconcile` (admin-gated, 409 if a tagger/analyzer run is already active).

**Frontend**
- `LibraryTaggingPanel.tsx` — the button + `onReconcile` prop + `'reconcile'` mode in the type + reconcile-specific running copy ("Reconciling with Navidrome…").
- `LibraryPanel.tsx` — the `reconcile()` handler wired to the panel.

Reuses the tagger's single-flight slot, so the live progress view, log drawer, and Stop button cover it automatically.

## Testing

- `npm run lint` passes clean in both `controller/` and `web/` (0 errors).
- Rebuilt + recreated `controller` + `web` locally; stack on-air, `POST /api/library/reconcile` returns 401 unauthenticated (route present + admin gate enforced).