### PR TITLE
feat(dj): resolve described track requests via web search (request agent only)

### DIFF
--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -284,9 +284,14 @@ export const requestAgent = defineAgent({
   timeoutMs: agentDeadline,
   buildSystem: () => requestSystem(),
   // recentArtists deliberately empty — a request for a recently-played artist
-  // must still resolve.
+  // must still resolve. resolveReferences adds the web-backed reference resolver
+  // (request path only; no-op without a search provider) when the operator opts
+  // in via settings.llm.requestWebResolve.
   buildTools: ({ recentIds }) => {
-    const { tools, seen } = buildPickerTools({ recentIds });
+    const { tools, seen } = buildPickerTools({
+      recentIds,
+      resolveReferences: settings.get().llm?.requestWebResolve ?? false,
+    });
     return { tools, extras: { seen } };
   },
 });

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -11,7 +11,7 @@ export {
   decoratePrompt,
 } from './internal/prompts/context.js';
 export { introBudgetPhrase, enforceIntroBudget } from './internal/prompts/intro-budget.js';
-export { matchRequest } from './internal/prompts/request.js';
+export { matchRequest, identifyTrackFromText } from './internal/prompts/request.js';
 export {
   generateIntro,
   generateStationId,

--- a/controller/src/llm/internal/prompts/request.ts
+++ b/controller/src/llm/internal/prompts/request.ts
@@ -101,3 +101,29 @@ export async function matchRequest(
     kind: 'matchRequest',
   });
 }
+
+// Map a vague listener DESCRIPTION of a track ("the song from the new Dune
+// movie", "the one all over TikTok") to a concrete {title, artist}, using web
+// snippets as the only evidence. Returns null when the snippets don't pin down
+// a single song — a wrong guess sends the library search confidently in the
+// wrong direction, so we never guess. Backs the request-only
+// `identifyRequestedTrack` tool (llm/internal/tools/picker-tools.ts), which then
+// resolves the result against the LOCAL library — this never returns a track id.
+const IDENTIFY_SCHEMA = z.object({
+  title: z.string().nullable().describe('the one specific song title the description points to, or null if the web text does not pin down a single song'),
+  artist: z.string().nullable().describe('the primary performing artist for that song, or null if the text does not make it clear'),
+});
+
+export async function identifyTrackFromText(
+  reference: string,
+  webText: string,
+): Promise<{ title: string; artist: string | null } | null> {
+  const out = await djObject({
+    system: 'You map a vague description of a song to the ONE specific track it refers to, using only the web snippets provided. Return the exact song title and primary performing artist. If the snippets do not clearly point to a single song, return nulls — never guess.',
+    prompt: `Listener's description: "${reference}"\n\nWeb context:\n${webText}\n\nWhich single song does this most likely mean?`,
+    schema: IDENTIFY_SCHEMA,
+    temperature: 0.2,
+    kind: 'identifyRequest',
+  });
+  return out?.title ? { title: String(out.title), artist: out.artist ? String(out.artist) : null } : null;
+}

--- a/controller/src/llm/internal/tools/picker-tools.ts
+++ b/controller/src/llm/internal/tools/picker-tools.ts
@@ -12,6 +12,8 @@ import * as subsonic from '../../../music/subsonic.js';
 import * as library from '../../../music/library.js';
 import * as embeddings from '../../../music/embeddings.js';
 import { filterPickerCandidates } from '../../../music/recency.js';
+import { searchWeb, searchReady } from '../../../skills/web-search.js';
+import { identifyTrackFromText } from '../prompts/request.js';
 
 function slim(s: any) {
   const base = {
@@ -69,6 +71,7 @@ export function buildPickerTools({
   recentKeys = new Set<string>(),
   recentArtists = new Set<string>(),
   audioWaypoint = null,
+  resolveReferences = false,
 }: {
   recentIds?: Set<string>;
   recentKeys?: Set<string>;        // lowercased "title|artist" — backfilled entries lack ids
@@ -77,6 +80,11 @@ export function buildPickerTools({
   // When present, the tracksTowardJourney tool below is registered, closing
   // over it — the agent never sees the raw vector, only the tracks near it.
   audioWaypoint?: number[] | null;
+  // Request path only (djAgentRequest): registers identifyRequestedTrack, which
+  // resolves a DESCRIBED track via web search and matches it to the LOCAL
+  // library. No-op unless a web-search provider is ready (searchReady()). Never
+  // set on the per-track picker — see the gating note on the tool below.
+  resolveReferences?: boolean;
 } = {}) {
   const seen = new Map<string, any>(); // id → slim song, accumulated across all tool calls
   const artistCounts = new Map<string, number>(); // artist key → songs already accepted into `seen`
@@ -282,6 +290,44 @@ export function buildPickerTools({
         execute: async () => {
           try { await library.load(); return collect(library.tracksByAudioVector(audioWaypoint, 20)); }
           catch (err) { return { error: err.message }; }
+        },
+      }),
+    } : {}),
+
+    // Request path only, and only when a web-search provider is ready. Resolves a
+    // listener's DESCRIPTION of a track (not a name) to songs in the LOCAL
+    // library: it looks the description up on the web, identifies the most likely
+    // single song, then searches Navidrome for it. Every returned candidate goes
+    // through collect() like any other tool, so the chosen id is always real —
+    // web text only steers which library tracks surface, never the id space.
+    ...(resolveReferences && searchReady() ? {
+      identifyRequestedTrack: tool({
+        description: 'LAST RESORT for a request that DESCRIBES a track instead of naming it — "the song from the new Dune movie", "the one all over TikTok", "this year\'s World Cup anthem". Looks the description up on the web, identifies the most likely song, then returns the matching tracks FROM THIS LIBRARY (or none if we do not have it). Do NOT use when the listener already gives an artist or a title — use searchLibrary for that. Returns { identified, candidates }: even when candidates is empty, `identified` tells you what the reference meant so you can pivot (e.g. topSongsByArtist) or tell the listener it is not in the library.',
+        inputSchema: z.object({
+          reference: z.string().min(3).describe("the listener's description of the track, verbatim"),
+        }),
+        execute: async ({ reference }) => {
+          try {
+            const web = await searchWeb(reference); // cached 30 min
+            const blob = [web.answer, ...web.results.map((r) => `${r.title}: ${r.content}`)]
+              .filter(Boolean).join('\n').slice(0, 2000);
+            if (!blob) return { error: 'no web result for that reference' };
+
+            const guess = await identifyTrackFromText(reference, blob);
+            if (!guess) return { error: 'could not identify a specific song from that description' };
+
+            // Resolve LOCALLY via the same path searchLibrary uses, so every id
+            // lands in `seen`. Try "artist title", then a resolved-artist retry
+            // (spelling/transliteration), then title-only.
+            const q = [guess.artist, guess.title].filter(Boolean).join(' ');
+            let songs = await subsonic.search(q, { songCount: 25 });
+            if (songs.length === 0 && guess.artist) {
+              const a = await subsonic.resolveArtist(guess.artist);
+              if (a) songs = await subsonic.search(`${a.name} ${guess.title}`, { songCount: 25 });
+            }
+            if (songs.length === 0) songs = await subsonic.search(guess.title, { songCount: 25 });
+            return { identified: guess, candidates: collect(songs) };
+          } catch (err) { return { error: err.message }; }
         },
       }),
     } : {}),

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -450,6 +450,13 @@ const DEFAULTS = {
     // dj-agent.js). When off, the stateless pool picker runs instead — still
     // inside a session, still logged, just without the conversational loop.
     pickerAgent: true,
+    // When on, the listener-request agent (djAgentRequest only — never the
+    // per-track picker) gets an extra `identifyRequestedTrack` tool that resolves
+    // a DESCRIBED track ("the song from the new Dune movie") via web search, then
+    // matches it against the local library. Off by default: it needs a web-search
+    // provider (settings.search) and costs a web round-trip + a small extraction
+    // call per use. No-op unless searchReady() — see llm/internal/tools/picker-tools.ts.
+    requestWebResolve: false,
     // Hard wall-clock ceiling (ms) on a single DJ-agent generation (track
     // picks and listener requests). Enforced by withDeadline in llm/sdk.ts;
     // the main and recovery runs each get the full budget, so worst case per
@@ -921,6 +928,10 @@ export async function load() {
         typeof stored.llm?.pickerAgent === 'boolean'
           ? stored.llm.pickerAgent
           : DEFAULTS.llm.pickerAgent,
+      requestWebResolve:
+        typeof stored.llm?.requestWebResolve === 'boolean'
+          ? stored.llm.requestWebResolve
+          : DEFAULTS.llm.requestWebResolve,
       // Clamped to [5s, 180s]; settings.json files from before the field
       // existed pick up the default.
       agentTimeoutMs: clampAgentTimeout(stored.llm?.agentTimeoutMs, DEFAULTS.llm.agentTimeoutMs),
@@ -1658,6 +1669,9 @@ export async function update(patch) {
     applyLlmLegPatch(next.llm, l, 'llm');
     if (l.pickerAgent !== undefined) {
       next.llm.pickerAgent = !!l.pickerAgent;
+    }
+    if (l.requestWebResolve !== undefined) {
+      next.llm.requestWebResolve = !!l.requestWebResolve;
     }
     if (l.agentTimeoutMs !== undefined) {
       next.llm.agentTimeoutMs = clampAgentTimeout(Number(l.agentTimeoutMs), next.llm.agentTimeoutMs);

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -113,6 +113,7 @@ interface LlmForm {
   baseUrl: string;
   reasoning: boolean;
   pickerAgent: boolean;
+  requestWebResolve: boolean;
   agentTimeoutMs: number;
   pauseWhenEmpty: boolean;
   fallback: LlmFallbackForm;
@@ -368,6 +369,7 @@ export default function SettingsPanel() {
         baseUrl: v.llm?.baseUrl ?? '',
         reasoning: !!v.llm?.reasoning,
         pickerAgent: !!v.llm?.pickerAgent,
+        requestWebResolve: !!v.llm?.requestWebResolve,
         agentTimeoutMs: typeof v.llm?.agentTimeoutMs === 'number' ? v.llm.agentTimeoutMs : 45000,
         pauseWhenEmpty: !!v.llm?.pauseWhenEmpty,
         fallback: {
@@ -1522,6 +1524,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
       baseUrl: form.llm.baseUrl,
       reasoning: form.llm.reasoning,
       pickerAgent: form.llm.pickerAgent,
+      requestWebResolve: form.llm.requestWebResolve,
       agentTimeoutMs: form.llm.agentTimeoutMs,
       pauseWhenEmpty: form.llm.pauseWhenEmpty,
       fallback: {
@@ -1939,6 +1942,29 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
               20&ndash;40s per pick; lower it for snappier fallbacks on a fast
               model. 5&ndash;180s.
             </div>
+          </div>
+        )}
+
+        {form.llm.pickerAgent && (
+          <div className="mt-4 grid grid-cols-[1fr_auto] items-center gap-4">
+            <div>
+              <div className="text-[13px] font-bold">Resolve described requests via web</div>
+              <div className="mt-0.5 max-w-[480px] text-[11px] leading-[1.5] text-muted">
+                When on, a listener who <em>describes</em> a track instead of naming it
+                (&ldquo;the song from the new Dune movie&rdquo;) gets it looked up on the
+                web, then matched against your library. Needs a web-search provider
+                configured under Web search; otherwise it has no effect.
+              </div>
+            </div>
+            <Seg
+              accent
+              value={form.llm.requestWebResolve ? 'on' : 'off'}
+              options={[
+                { id: 'off', label: 'Off' },
+                { id: 'on', label: 'On' },
+              ]}
+              onChange={v => setForm(f => ({ ...f, llm: { ...f.llm, requestWebResolve: v === 'on' } }))}
+            />
           </div>
         )}
       </Card>


### PR DESCRIPTION
## What

Adds an **opt-in** `identifyRequestedTrack` tool to the listener-request agent (`djAgentRequest`) that resolves a track a listener *describes* rather than names — *"the song from the new Dune movie"*, *"the one all over TikTok"* — by looking the description up on the web, identifying the most likely single song, then matching it against the **local** library.

The per-track picker (`djAgentPick`) deliberately **never** gets this tool.

## Why request-only

- Web search can't expand what's playable (the pick universe is the local library), so it adds nothing to track selection.
- It adds a web round-trip + an extraction call — unacceptable on the every-track pick loop (`agentTimeoutMs`, commit-at-step-1), fine on rare requests where a listener is actively waiting.
- Extra tools whose results can't yield a valid pick risk derailing smaller models (the circuit breaker already exists for this).

## How

- **`seen` invariant preserved.** The tool returns *only* local library songs via `collect()`, so the agent's chosen id is always real — web text steers *which library tracks surface*, never the id space. No new id-rejection failure mode.
- **Double-gated**, so it's invisible unless explicitly wanted: `settings.llm.requestWebResolve` (default **off**) **and** `searchReady()`. A no-op without a web-search provider.
- New prompt-layer helper `dj.identifyTrackFromText()` does the `prose → {title, artist}` extraction via `djObject`; returns `null` rather than guessing.
- Admin toggle under **Settings → Next-track picker** (shown when the agentic picker is on).

## Files
- `controller/src/llm/internal/prompts/request.ts` — `identifyTrackFromText()`
- `controller/src/llm/dj.ts` — barrel export
- `controller/src/llm/internal/tools/picker-tools.ts` — `resolveReferences` option + `identifyRequestedTrack` tool
- `controller/src/broadcast/dj-agent.ts` — wire on the request agent only
- `controller/src/settings.ts` — `requestWebResolve` default + load-merge + update handler
- `web/components/admin/SettingsPanel.tsx` — admin toggle

## Caveat
The default keyless **DuckDuckGo** provider is sparse for song-description queries and usually returns nothing (the tool degrades gracefully to an error, no crash). The feature earns its keep with **Tavily** configured under admin → Web search.

## Testing
Ran against a live station (Ollama `glm-5.1:cloud`, DuckDuckGo, Navidrome) with an isolated `settings.json` copy:
- **Gating: 6/6** — pick path never gets it; request path needs the flag; flag needs a usable provider.
- **Wiring** — request agent gets exactly 13 tools (12 discovery + `identifyRequestedTrack`).
- **Happy path** — *"that AP Dhillon track everyone knows — the brown munde one"* → `{title: "Brown Munde", artist: "AP Dhillon"}` → matched **"Brown Munde — AP Dhillon, Gminxr, Gurinder Gill & Shinda Kahlon"** in the real library.
- **Real DuckDuckGo** — described-track queries returned no result, as expected.

Lint gates pass: `controller` and `web` both `eslint && tsc --noEmit` clean.