### PR TITLE
feat(dj): cover 'latest song' + 'more like this' requests

### DIFF
--- a/controller/src/llm/internal/tools/picker-tools.ts
+++ b/controller/src/llm/internal/tools/picker-tools.ts
@@ -164,6 +164,18 @@ export function buildPickerTools({
       },
     }),
 
+    recentByArtist: tool({
+      description: 'A named artist\'s NEWEST releases, latest first — songs from their most recent albums/singles. Use this (not topSongsByArtist) when the listener asks for an artist\'s "latest", "newest", "new", or "most recent" song: topSongsByArtist ranks by popularity, so it cannot answer recency. Returns [] when the artist isn\'t in the library. Note: "latest in the library" — bounded by what has been added, not the artist\'s globally-newest release.',
+      inputSchema: z.object({ artist: z.string() }),
+      execute: async ({ artist }) => {
+        // Keep the pool tight (newest ~6 tracks): collect() shuffles and caps to
+        // MAX_PER_ARTIST per artist, and these are all one artist — a wide pool
+        // would let the shuffle drop the actual-newest tracks, defeating "latest".
+        try { return collect(await subsonic.getRecentSongsByArtist(artist, { albums: 2, count: 6 })); }
+        catch (err) { return { error: err.message }; }
+      },
+    }),
+
     songsByGenre: tool({
       description: 'Songs from a library genre tag, fuzzy-matched ("turkish" finds "Turkish Pop"). Use for language/country/style asks — "play something Turkish" — that searchLibrary cannot reach: genre lives in tags, not titles.',
       inputSchema: z.object({ genre: z.string().describe('a genre, language, or country word, e.g. "jazz", "turkish", "punjabi"') }),

--- a/controller/src/music/subsonic.ts
+++ b/controller/src/music/subsonic.ts
@@ -366,6 +366,47 @@ export async function getTopSongs(artistName, { count = 10 } = {}) {
   return rejectArchive(r.topSongs?.song || []);
 }
 
+// Sortable release timestamp for an album object, preferring the most precise
+// signal Navidrome offers: OpenSubsonic `originalReleaseDate` {year,month,day}
+// → `releaseDate` string → bare `year` → `created` (library-import time) as a
+// last resort. Returns a comparable number (higher = newer); 0 when undated.
+function albumReleaseRank(a: any): number {
+  const ord = a?.originalReleaseDate;
+  if (ord?.year) {
+    return ord.year * 10000 + (ord.month || 0) * 100 + (ord.day || 0);
+  }
+  const rd = Date.parse(a?.releaseDate || '');
+  if (!Number.isNaN(rd)) return Math.floor(rd / 86400000) + 30000000; // keep above year*10000
+  if (a?.year) return a.year * 10000;
+  const cr = Date.parse(a?.created || '');
+  if (!Number.isNaN(cr)) return Math.floor(cr / 86400000);
+  return 0;
+}
+
+// An artist's most recent releases, newest first — for "play their latest /
+// newest" asks that getTopSongs (popularity-ranked) can't answer. Resolves the
+// name to an artist id, pulls their albums, sorts by release date, and returns
+// the songs from the newest `albums` releases (singles are single-track albums,
+// so a brand-new single surfaces too). Empty when the artist isn't in the library.
+export async function getRecentSongsByArtist(
+  artistName: string,
+  { albums = 3, count = 20 }: { albums?: number; count?: number } = {},
+) {
+  const artist = await resolveArtist(artistName);
+  if (!artist?.id) return [];
+  const full = await getArtist(artist.id);
+  const albumList = (full?.album || [])
+    .map((a: any) => ({ ...a, _rank: albumReleaseRank(a) }))
+    .sort((x: any, y: any) => y._rank - x._rank)
+    .slice(0, albums);
+  const songs: any[] = [];
+  for (const a of albumList) {
+    try { songs.push(...(await getAlbum(a.id))); } catch {}
+    if (songs.length >= count) break;
+  }
+  return songs.slice(0, count);
+}
+
 export async function getAlbum(id) {
   const r = await call('getAlbum', { id });
   return rejectArchive(r.album?.song || []);

--- a/controller/src/routes/request.ts
+++ b/controller/src/routes/request.ts
@@ -79,6 +79,36 @@ async function pickByArtistAndSort({ artistName, sort, scope: _scope, recentIds 
   return null;
 }
 
+// Fallback for "more like this" when the currently-playing artist has nothing
+// else in the library (e.g. a one-off collab credit) — find a track that
+// actually RESEMBLES the current one. "more like this" means more like the
+// TRACK, not strictly more by the artist, so this honours the request instead
+// of dead-ending. Prefers the audio-similarity extension ("sounds like this"),
+// then the Last.fm similarity graph. Returns a fresh Subsonic song (same shape
+// as pickByArtistAndSort) or null. Excludes the seed track and recent plays.
+async function pickSimilarToTrack(reference, recentIds: Set<string>) {
+  const id = reference?.track?.id;
+  if (!id) return null;
+  const exclude = new Set(recentIds);
+  exclude.add(id); // never return the song that's playing right now
+  const pickFresh = (songs) => {
+    const list = (songs || []).filter((s) => s?.id && !exclude.has(s.id));
+    if (list.length === 0) return null;
+    return list[Math.floor(Math.random() * list.length)];
+  };
+  try {
+    if (await subsonic.supportsSonicSimilarity()) {
+      const pick = pickFresh(await subsonic.getSonicSimilarTracks(id, { count: 25 }));
+      if (pick) return pick;
+    }
+  } catch (err) { queue.log('error', `more-like-this sonic similar failed: ${err.message}`); }
+  try {
+    const pick = pickFresh(await subsonic.getSimilarSongs(id, { count: 25 }));
+    if (pick) return pick;
+  } catch (err) { queue.log('error', `more-like-this similar songs failed: ${err.message}`); }
+  return null;
+}
+
 // Resolve a listener's free-text genre ("hip hop", "punjabi") to a genre value
 // that actually exists in the library. search3 is a title/artist/album text
 // match and can't query the genre tag, so genre requests must go through
@@ -193,12 +223,23 @@ async function resolveRequest(entry) {
     // Requests stay near-unfiltered — 2h is enough to skip the song still
     // ringing in their ears without blocking a re-request from earlier today.
     const recentIds = queue.recentlyPlayedIds(2);
-    const pick = await pickByArtistAndSort({
+    // Try another track by the same artist first (the cheap, on-the-nose read),
+    // then fall back to real track similarity so a one-off collab credit playing
+    // now doesn't dead-end the request ("Couldn't find more from X in the crates").
+    let pick = await pickByArtistAndSort({
       artistName: refArtist, sort: null, scope: 'song', recentIds,
     });
     if (!pick) {
-      return failed(`Couldn't find more from ${refArtist} in the crates.`);
+      pick = await pickSimilarToTrack(reference, recentIds);
+      if (pick) entry.pickSource = 'more-like-this:similar';
     }
+    if (!pick) {
+      return failed(`Couldn't find anything close to "${reference?.track?.title || refArtist}" in the crates.`);
+    }
+    // The fallback can land on a different artist, so phrase the ack from the
+    // actual pick, not the seed.
+    const sameArtist = !!pick.artist && pick.artist === refArtist;
+    const ackLine = sameArtist ? `More from ${refArtist}, coming up.` : `More like that, coming up.`;
     const introScript = await dj.generateIntro({
       track: pick,
       context: ctx,
@@ -214,13 +255,13 @@ async function resolveRequest(entry) {
     });
     session.appendTurn({
       role: 'dj', kind: 'request',
-      text: introScript || `More from ${refArtist}, coming up.`,
+      text: introScript || ackLine,
       meta: { trackId: pick.id, requester },
     });
     entry.pick = pick;
     entry.introScript = introScript || null;
     return resolved({
-      ack: `More from ${refArtist}, coming up.`,
+      ack: ackLine,
       track: { title: pick.title, artist: pick.artist },
       queuePosition: queue.upcoming.length,
     });


### PR DESCRIPTION
Two related fixes to listener-request resolution, both surfaced by auditing the real request log.

## 1. `recentByArtist` — "play <artist>'s latest song"

The request agent could only reach an artist's catalogue through `topSongsByArtist`, which ranks by **popularity**. So `"play Sidhu's latest song"` resolved to `Never Fold` (the 3rd most *popular* Sidhu track) — the model had no by-release-date tool to reach for and degraded to popularity. (The cascade path already had a recency notion via `sort:latest` → `artist-sort`; only the agent path lacked one.)

- New `subsonic.getRecentSongsByArtist()` — resolve artist → newest albums by release date → their songs. Date sort prefers OpenSubsonic `originalReleaseDate` → `releaseDate` → `year` → `created`.
- New `recentByArtist` tool whose description explicitly steers the model to use it (not `topSongsByArtist`) for *latest / newest / new / most recent*.
- Scoped to the newest ~6 tracks so `collect()`'s shuffle + per-artist cap can't drop the actual-newest.
- **Caveat (in the tool description):** "latest *in the library*", bounded by what's been imported — not the artist's globally-newest release. The web-search path (`identifyRequestedTrack`) covers that but is opt-in and currently off.

## 2. `"more like this"` similarity fallback

`"more like this"` only picked another song **by the playing artist**, so a one-off collab credit with no other library tracks dead-ended — *"Couldn't find more from X in the crates."* This was the only recurring failure in the request log (e.g. "Watan Sahi & Nav Prince", "Sarrb & Starboy X").

- Keeps the same-artist attempt first (the on-the-nose read), then falls back to **actual track similarity**: the audio-similarity extension (`getSonicSimilarTracks`) when available, then the Last.fm graph (`getSimilarSongs`).
- Fallback excludes the seed track + recent plays; ack adapts when the pick is a different artist ("More like that" vs "More from X").
- Tagged `pickSource = more-like-this:similar` for observability.

## Testing

- `npm run lint` (eslint + `tsc --noEmit`) passes clean in `controller/`.
- No prompt or doc hardcodes the tool list — the new tool is self-documenting via its AI-SDK description.
- Not yet exercised on the live stack (needs a controller rebuild to deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)