### PR TITLE
feat(llm): first-class locca provider + constrained pool picks

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -12,6 +12,8 @@ import { withDeadline } from '../src/llm/internal/core/retry.js';
 import { providerOptions, needsToolCallObject, repeatPenaltyApplies, appliedNumCtx } from '../src/llm/internal/provider/capabilities.js';
 import { agentPlan } from '../src/llm/internal/strategy/plan.js';
 import { introBudgetPhrase, enforceIntroBudget } from '../src/llm/internal/prompts/intro-budget.js';
+import { embeddingBaseUrl } from '../src/llm/internal/provider/embedding.js';
+import { DEFAULT_LOCCA_EMBED_BASE_URL } from '../src/llm/internal/provider/registry.js';
 
 let failures = 0;
 function test(name: string, fn: () => void | Promise<void>) {
@@ -107,6 +109,21 @@ async function main() {
     assert.equal(appliedNumCtx({ provider: 'ollama', model: 'qwen3', numCtx: 8192 }), 8192);
     assert.equal(appliedNumCtx({ provider: 'openai', model: 'gpt-4.1-mini', numCtx: 8192 }), null);
     assert.equal(appliedNumCtx({ provider: 'locca', model: 'qwen3', numCtx: 8192 }), null);
+  });
+
+  // ---- embedding base URL (the relative-/embeddings crash, #405 follow-up) ----
+  console.log('embeddingBaseUrl(cfg):');
+  await test('locca blank → dedicated EMBED default, never chat or a relative URL', () => {
+    // Blank locca baseUrl must resolve to the dedicated embed server (8090), NOT
+    // the chat default (8080) and NOT '' (which would make the SDK fetch
+    // "/embeddings" → "Failed to parse URL"). This is what makes locca a
+    // first-class embedding provider with no hand-typed URL.
+    assert.equal(embeddingBaseUrl({ provider: 'locca', baseUrl: '' }), DEFAULT_LOCCA_EMBED_BASE_URL);
+    assert.match(DEFAULT_LOCCA_EMBED_BASE_URL, /:8090\/v1$/);
+    assert.equal(embeddingBaseUrl({ provider: 'locca', baseUrl: 'http://x:9000/v1' }), 'http://x:9000/v1');
+    // openai-compatible has no sane default — blank stays '' so the builder errors.
+    assert.equal(embeddingBaseUrl({ provider: 'openai-compatible', baseUrl: '' }), '');
+    assert.equal(embeddingBaseUrl({ provider: 'openai-compatible', baseUrl: 'http://y:8090/v1' }), 'http://y:8090/v1');
   });
 
   // ---- agent plan routing ----

--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -93,13 +93,20 @@ async function main() {
   await test('openai-compatible: no providerOptions block (transport handles thinking)', () => {
     assert.deepEqual(providerOptions({ provider: 'openai-compatible', model: 'qwen3', reasoning: false }), {});
   });
+  await test('locca: shares the openai-compatible path — no providerOptions block', () => {
+    assert.deepEqual(providerOptions({ provider: 'locca', model: 'qwen3', reasoning: false }), {});
+    assert.deepEqual(providerOptions({ provider: 'locca', model: 'qwen3', reasoning: true }), {});
+  });
   await test('capability flags: tool-object + repeat-penalty are Ollama-only', () => {
     assert.equal(needsToolCallObject({ provider: 'ollama' }), true);
     assert.equal(needsToolCallObject({ provider: 'openai' }), false);
+    assert.equal(needsToolCallObject({ provider: 'locca' }), false);
     assert.equal(repeatPenaltyApplies({ provider: 'ollama' }), true);
     assert.equal(repeatPenaltyApplies({ provider: 'deepseek' }), false);
+    assert.equal(repeatPenaltyApplies({ provider: 'locca' }), false);
     assert.equal(appliedNumCtx({ provider: 'ollama', model: 'qwen3', numCtx: 8192 }), 8192);
     assert.equal(appliedNumCtx({ provider: 'openai', model: 'gpt-4.1-mini', numCtx: 8192 }), null);
+    assert.equal(appliedNumCtx({ provider: 'locca', model: 'qwen3', numCtx: 8192 }), null);
   });
 
   // ---- agent plan routing ----
@@ -109,6 +116,9 @@ async function main() {
     assert.equal(agentPlan({ provider: 'ollama' }, {}, 3), 'done-tool');
     assert.equal(agentPlan({ provider: 'openai' }, {}, 0), 'native-no-tools');
     assert.equal(agentPlan({ provider: 'openai' }, {}, 3), 'native-then-done');
+    // locca routes like any native provider (not the Ollama tool-object path).
+    assert.equal(agentPlan({ provider: 'locca' }, {}, 0), 'native-no-tools');
+    assert.equal(agentPlan({ provider: 'locca' }, {}, 3), 'native-then-done');
     assert.equal(agentPlan({ provider: 'openai' }, null, 3), 'free-text');
     assert.equal(agentPlan({ provider: 'ollama' }, null, 0), 'free-text');
   });

--- a/controller/src/llm/internal/prompts/picker.ts
+++ b/controller/src/llm/internal/prompts/picker.ts
@@ -59,11 +59,28 @@ export async function pickNextTrack({ candidates, recentPlays, context, show = n
     candidates,
   }, null, 2);
 
+  // Constrain the pick to the actual candidate ids. On a local model (llama.cpp
+  // via openai-compatible / locca) this becomes a grammar so the model can only
+  // emit a real id — closing the "agent returned unknown id" hole. On providers
+  // that don't enforce the schema at decode time, Zod still rejects an invalid
+  // id, so the caller's fallback fires instead of a bogus track. Empty pool →
+  // plain string (z.enum needs ≥1 literal); pickViaPool never calls with [].
+  const candidateIds = [
+    ...new Set(
+      (candidates || [])
+        .map((c: any) => c?.id)
+        .filter((id: any): id is string => typeof id === 'string' && id.length > 0),
+    ),
+  ];
+  const idSchema = candidateIds.length
+    ? z.enum(candidateIds as [string, ...string[]]).describe('the exact id of one candidate')
+    : z.string().describe('the exact id of one candidate');
+
   return djObject({
     system: pickerSystem(show),
     prompt: user,
     schema: z.object({
-      id: z.string().describe('the exact id of one candidate'),
+      id: idSchema,
       reason: z.string().describe('one short sentence on why this one'),
     }),
     temperature: 0.5,

--- a/controller/src/llm/internal/provider/capabilities.ts
+++ b/controller/src/llm/internal/provider/capabilities.ts
@@ -59,6 +59,13 @@ const CAPS: Record<string, ProviderCapabilities> = {
     // registry), not via providerOptions.
     thinkingBlock: NONE,
   },
+  // locca is a first-class openai-compatible (llama.cpp) server — same traits:
+  // native objects, no repeat_penalty, no-think handled in transport.
+  locca: {
+    objectStrategy: 'native',
+    repeatPenaltyApplies: false,
+    thinkingBlock: NONE,
+  },
   anthropic: {
     objectStrategy: 'native',
     repeatPenaltyApplies: false,

--- a/controller/src/llm/internal/provider/embedding.ts
+++ b/controller/src/llm/internal/provider/embedding.ts
@@ -46,6 +46,9 @@ function defaultEmbeddingModelFor(provider: string): string {
     case 'anthropic':
       // No first-party Anthropic embedding API. We resolve via openai.
       return 'text-embedding-3-small';
+    case 'locca':
+      // Local llama.cpp embedding server — the homelab default model.
+      return 'nomic-embed-text';
     case 'ollama':
     default:
       return 'nomic-embed-text';
@@ -67,49 +70,76 @@ function defaultEmbeddingDimFor(model: string): number {
   return 768; // homelab default until a probe says otherwise
 }
 
+// Resolved embedding config. `settings.embedding` overrides settings.llm field
+// by field; `overrides` (e.g. unsaved form values from the probe endpoint) win
+// over both. Mirrors the precedence in embeddingCfg().
+export interface EmbeddingCfg {
+  enabled: boolean;
+  provider: string;
+  model: string;
+  apiKey: string;
+  ollamaUrl: string;
+  baseUrl: string;
+}
+
+export function resolveEmbeddingCfg(overrides: Partial<EmbeddingCfg> = {}): EmbeddingCfg {
+  const base = embeddingCfg();
+  return {
+    enabled: overrides.enabled ?? base.enabled,
+    // '' is meaningful for provider (= follow llm), so only override when a
+    // non-empty value is supplied.
+    provider: overrides.provider || base.provider,
+    model: overrides.model ?? base.model,
+    apiKey: overrides.apiKey || base.apiKey,
+    ollamaUrl: overrides.ollamaUrl || base.ollamaUrl,
+    baseUrl: overrides.baseUrl || base.baseUrl,
+  };
+}
+
+// Build an AI SDK text-embedding model from an explicit, already-resolved cfg.
+// No caching (callers that want it wrap, like embeddingModel below) — the probe
+// endpoint deliberately builds a fresh one-off client per test.
+export function buildEmbeddingModel(cfg: EmbeddingCfg) {
+  const id = cfg.model || defaultEmbeddingModelFor(cfg.provider);
+  switch (cfg.provider) {
+    case 'openai':
+    case 'anthropic': {
+      // Anthropic has no first-party embedding model; punt to OpenAI.
+      const provider = createOpenAI(cfg.apiKey ? { apiKey: cfg.apiKey } : {});
+      return provider.textEmbeddingModel(id);
+    }
+    case 'openai-compatible':
+    case 'locca': {
+      // locca = a self-hosted openai-compatible embedding server (run via
+      // `locca embed`); same transport, the operator points baseUrl at it.
+      const provider = createOpenAI({
+        baseURL: cfg.baseUrl,
+        apiKey: cfg.apiKey || 'unused',
+        name: cfg.provider,
+      });
+      return provider.textEmbeddingModel(id);
+    }
+    case 'google': {
+      const provider = createGoogleGenerativeAI(cfg.apiKey ? { apiKey: cfg.apiKey } : {});
+      return provider.textEmbeddingModel(id);
+    }
+    case 'ollama':
+    default: {
+      const provider = createOllama({ baseURL: ollamaBaseUrl(cfg as any) });
+      return provider.textEmbeddingModel(id);
+    }
+  }
+}
+
 export function embeddingModel() {
-  const cfg = embeddingCfg();
+  const cfg = resolveEmbeddingCfg();
   const id = cfg.model || defaultEmbeddingModelFor(cfg.provider);
   const sig = `embed|${cfg.provider}|${id}|${cfg.apiKey || ''}|${cfg.ollamaUrl}|${cfg.baseUrl}`;
 
   const cached = embedCache.get(sig);
   if (cached) return cached;
 
-  let model;
-  switch (cfg.provider) {
-    case 'openai': {
-      const provider = createOpenAI(cfg.apiKey ? { apiKey: cfg.apiKey } : {});
-      model = provider.textEmbeddingModel(id);
-      break;
-    }
-    case 'openai-compatible': {
-      const provider = createOpenAI({
-        baseURL: cfg.baseUrl,
-        apiKey: cfg.apiKey || 'unused',
-        name: 'openai-compatible',
-      });
-      model = provider.textEmbeddingModel(id);
-      break;
-    }
-    case 'google': {
-      const provider = createGoogleGenerativeAI(cfg.apiKey ? { apiKey: cfg.apiKey } : {});
-      model = provider.textEmbeddingModel(id);
-      break;
-    }
-    case 'anthropic': {
-      // Anthropic has no first-party embedding model; punt to OpenAI.
-      const provider = createOpenAI(cfg.apiKey ? { apiKey: cfg.apiKey } : {});
-      model = provider.textEmbeddingModel(id);
-      break;
-    }
-    case 'ollama':
-    default: {
-      const provider = createOllama({ baseURL: ollamaBaseUrl(cfg as any) });
-      model = provider.textEmbeddingModel(id);
-      break;
-    }
-  }
-
+  const model = buildEmbeddingModel(cfg);
   embedCache.set(sig, model);
   return model;
 }
@@ -132,15 +162,25 @@ export function embeddingEnabled(): boolean {
 // Surface enough config for the tagger to (a) write a useful error message
 // and (b) auto-pull a missing model on the Ollama provider. Intentionally
 // just the fields callers need — no secrets, no live SDK clients.
-export function embeddingProviderInfo(): {
+// Display/diagnostic info for an explicit cfg — resolves the model name and the
+// effective Ollama URL. Shared by embeddingProviderInfo() (saved) and the probe
+// endpoint (unsaved overrides) so error messages name the right server.
+export function embeddingInfoOf(cfg: EmbeddingCfg): {
   provider: string;
   model: string;
   ollamaUrl: string;
 } {
-  const cfg = embeddingCfg();
   return {
     provider: cfg.provider,
     model: cfg.model || defaultEmbeddingModelFor(cfg.provider),
     ollamaUrl: cfg.provider === 'ollama' ? ollamaBaseUrl(cfg as any) : '',
   };
+}
+
+export function embeddingProviderInfo(): {
+  provider: string;
+  model: string;
+  ollamaUrl: string;
+} {
+  return embeddingInfoOf(embeddingCfg());
 }

--- a/controller/src/llm/internal/provider/embedding.ts
+++ b/controller/src/llm/internal/provider/embedding.ts
@@ -16,7 +16,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createOllama } from 'ai-sdk-ollama';
 import * as settings from '../../../settings.js';
-import { llmCfg, ollamaBaseUrl } from './registry.js';
+import { llmCfg, ollamaBaseUrl, loccaEmbedBaseUrl } from './registry.js';
 
 // Separate from the registry's language-model cache — the signature is prefixed
 // `embed|` so there's no key overlap, and keeping it local avoids exporting a
@@ -96,6 +96,17 @@ export function resolveEmbeddingCfg(overrides: Partial<EmbeddingCfg> = {}): Embe
   };
 }
 
+// Effective base URL for the openai-compatible embedding transport. `locca`
+// defaults to its dedicated EMBED server (`locca embed`, port 8090) — NOT the
+// chat default — so first-class locca embeddings work with a blank field and
+// never collapse to a relative `/embeddings` URL (fetch rejects that as "Failed
+// to parse URL"). Plain `openai-compatible` has no sane default, so '' here
+// means "no server configured" and the caller errors.
+export function embeddingBaseUrl(cfg: { provider: string; baseUrl?: string }): string {
+  if (cfg.provider === 'locca') return loccaEmbedBaseUrl(cfg);
+  return cfg.baseUrl || '';
+}
+
 // Build an AI SDK text-embedding model from an explicit, already-resolved cfg.
 // No caching (callers that want it wrap, like embeddingModel below) — the probe
 // endpoint deliberately builds a fresh one-off client per test.
@@ -112,8 +123,18 @@ export function buildEmbeddingModel(cfg: EmbeddingCfg) {
     case 'locca': {
       // locca = a self-hosted openai-compatible embedding server (run via
       // `locca embed`); same transport, the operator points baseUrl at it.
+      // Resolve the base URL (locca defaults to the host) and refuse a blank
+      // one with an actionable message — otherwise createOpenAI emits a
+      // relative `/embeddings` URL that fetch can't parse.
+      const baseURL = embeddingBaseUrl(cfg);
+      if (!baseURL) {
+        throw new Error(
+          'No embedding server URL is set. In /admin/settings → Embedding, set ' +
+            'the base URL to your embedding server (e.g. http://host:8090/v1).',
+        );
+      }
       const provider = createOpenAI({
-        baseURL: cfg.baseUrl,
+        baseURL,
         apiKey: cfg.apiKey || 'unused',
         name: cfg.provider,
       });

--- a/controller/src/llm/internal/provider/registry.ts
+++ b/controller/src/llm/internal/provider/registry.ts
@@ -74,6 +74,19 @@ export function loccaBaseUrl(cfg: any): string {
   return cfg.baseUrl || DEFAULT_LOCCA_BASE_URL;
 }
 
+// locca runs embeddings on a SEPARATE server (`locca embed`) on its own port —
+// a chat llama.cpp server can't also serve embeddings. locca's default embed
+// port is 8090, so embeddings get their own host default, distinct from the
+// chat default above. Operator still overrides via settings.embedding.baseUrl.
+export const DEFAULT_LOCCA_EMBED_BASE_URL = 'http://host.docker.internal:8090/v1';
+
+// Effective base URL for a locca EMBEDDING server: the (embedding) settings
+// field if set, else the host embed default. Mirrors loccaBaseUrl but points at
+// the dedicated embed port so a blank field resolves to `locca embed`, not chat.
+export function loccaEmbedBaseUrl(cfg: any): string {
+  return cfg.baseUrl || DEFAULT_LOCCA_EMBED_BASE_URL;
+}
+
 // Build a LanguageModel for any self-hosted OpenAI-compatible server (llama.cpp,
 // vLLM, LM Studio, locca). `.chat()` pins /v1/chat/completions — these servers
 // don't implement the Responses API the default `provider(id)` would target.

--- a/controller/src/llm/internal/provider/registry.ts
+++ b/controller/src/llm/internal/provider/registry.ts
@@ -6,12 +6,12 @@
 // without a redeploy and without touching a single call site.
 //
 // The active provider/model lives in `settings.llm` (see settings.js):
-//   { provider:  'ollama' | 'openai-compatible' | 'anthropic' | 'openai' |
-//                'google' | 'deepseek' | 'openrouter' | 'gateway',
+//   { provider:  'ollama' | 'openai-compatible' | 'locca' | 'anthropic' |
+//                'openai' | 'google' | 'deepseek' | 'openrouter' | 'gateway',
 //     model:     string,   // empty → provider default
 //     apiKey:    string,   // empty → read the provider's env var
 //     ollamaUrl: string,   // empty → config.ollama.url default (Ollama only)
-//     baseUrl:   string,   // OpenAI-compatible server URL (openai-compatible only)
+//     baseUrl:   string,   // server URL (openai-compatible; locca → host default)
 //     reasoning: boolean } // false → suppress <think> chain-of-thought
 //
 // `ollama` is the default and needs no key. The cloud providers are opt-in.
@@ -41,7 +41,7 @@ export function llmCfg() {
 // chat template then omits the <think> priming entirely, so the model
 // never starts a chain-of-thought. Injected via a fetch wrapper because
 // the AI SDK's openai provider has no first-class field for it.
-function noThinkFetch(url: any, init: any) {
+export function noThinkFetch(url: any, init: any) {
   if (init?.body && typeof init.body === 'string') {
     try {
       const body = JSON.parse(init.body);
@@ -61,6 +61,34 @@ export function ollamaBaseUrl(cfg: any): string {
   return cfg.ollamaUrl || config.ollama.url;
 }
 
+// Default base URL for the `locca` provider — a locca-served llama.cpp on the
+// host, reachable from the controller container via host.docker.internal. The
+// operator can still override it (settings `llm.baseUrl`) for a non-default
+// port / remote host; an explicit value always wins.
+export const DEFAULT_LOCCA_BASE_URL = 'http://host.docker.internal:8080/v1';
+
+// Effective base URL for the `locca` provider: the settings field if set, else
+// the host default. Used by the builder and the cache signature so a blank
+// field and the resolved default key to the same client.
+export function loccaBaseUrl(cfg: any): string {
+  return cfg.baseUrl || DEFAULT_LOCCA_BASE_URL;
+}
+
+// Build a LanguageModel for any self-hosted OpenAI-compatible server (llama.cpp,
+// vLLM, LM Studio, locca). `.chat()` pins /v1/chat/completions — these servers
+// don't implement the Responses API the default `provider(id)` would target.
+// Most accept any non-empty key, so fall back to a placeholder. Reasoning off →
+// wrap fetch to force chat_template_kwargs.enable_thinking=false.
+function openAICompatibleModel(cfg: any, id: string, baseURL: string, name: string) {
+  const provider = createOpenAI({
+    baseURL,
+    apiKey: cfg.apiKey || 'unused',
+    name,
+    ...(cfg.reasoning ? {} : { fetch: noThinkFetch }),
+  });
+  return provider.chat(id);
+}
+
 // Resolve the concrete model id. Ollama falls back to the env-configured
 // model; cloud providers must name a model explicitly — guessing a model id
 // that may not exist fails worse than a clear error.
@@ -78,7 +106,8 @@ export function resolveModelId(cfg: any): string {
 // client cache, since the signature below already keys on every field.
 export function languageModel(cfg: any = llmCfg()) {
   const id = resolveModelId(cfg);
-  const sig = `${cfg.provider}|${id}|${cfg.apiKey || ''}|${ollamaBaseUrl(cfg)}|${cfg.baseUrl || ''}|${cfg.reasoning ? 'r1' : 'r0'}`;
+  const baseUrlSig = cfg.provider === 'locca' ? loccaBaseUrl(cfg) : (cfg.baseUrl || '');
+  const sig = `${cfg.provider}|${id}|${cfg.apiKey || ''}|${ollamaBaseUrl(cfg)}|${baseUrlSig}|${cfg.reasoning ? 'r1' : 'r0'}`;
 
   const cached = clientCache.get(sig);
   if (cached) return cached;
@@ -96,18 +125,14 @@ export function languageModel(cfg: any = llmCfg()) {
       break;
     }
     case 'openai-compatible': {
-      // Any self-hosted OpenAI-compatible server (llama.cpp, vLLM, LM Studio…).
-      // `.chat()` pins the /v1/chat/completions endpoint — these servers don't
-      // implement the Responses API the default `provider(id)` would target.
-      // Most accept any non-empty key, so fall back to a placeholder.
-      const provider = createOpenAI({
-        baseURL: cfg.baseUrl,
-        apiKey: cfg.apiKey || 'unused',
-        name: 'openai-compatible',
-        // Reasoning off → wrap fetch to force chat_template_kwargs.enable_thinking=false.
-        ...(cfg.reasoning ? {} : { fetch: noThinkFetch }),
-      });
-      model = provider.chat(id);
+      model = openAICompatibleModel(cfg, id, cfg.baseUrl, 'openai-compatible');
+      break;
+    }
+    case 'locca': {
+      // First-class locca: an openai-compatible llama.cpp server with a sane
+      // default base URL (host.docker.internal:8080) so the operator doesn't
+      // hand-type a URL. Same transport as openai-compatible, incl. no-think.
+      model = openAICompatibleModel(cfg, id, loccaBaseUrl(cfg), 'locca');
       break;
     }
     case 'google': {

--- a/controller/src/llm/provider.ts
+++ b/controller/src/llm/provider.ts
@@ -8,6 +8,9 @@ export {
   activeModelLabel,
   providerName,
   activeOllamaUrl,
+  loccaBaseUrl,
+  DEFAULT_LOCCA_BASE_URL,
+  noThinkFetch,
 } from './internal/provider/registry.js';
 
 export { primaryLeg, fallbackLeg, probeLegReachable } from './internal/provider/legs.js';

--- a/controller/src/llm/provider.ts
+++ b/controller/src/llm/provider.ts
@@ -22,4 +22,8 @@ export {
   activeEmbeddingDim,
   embeddingEnabled,
   embeddingProviderInfo,
+  embeddingInfoOf,
+  resolveEmbeddingCfg,
+  buildEmbeddingModel,
 } from './internal/provider/embedding.js';
+export type { EmbeddingCfg } from './internal/provider/embedding.js';

--- a/controller/src/music/embeddings.ts
+++ b/controller/src/music/embeddings.ts
@@ -190,17 +190,21 @@ function actionableMessage(code: ProbeCode, raw: string): string {
       }
       return `Can't reach provider "${provider}" — check network / baseUrl. (${raw})`;
     case 'not_embedding_model':
-      if (provider === 'openai-compatible') {
+      if (provider === 'openai-compatible' || provider === 'locca') {
+        const startCmd =
+          provider === 'locca'
+            ? `        locca embed nomic     # dedicated embedding server on its own port`
+            : `        llama-server -m nomic-embed-text-v1.5.Q8_0.gguf \\\n` +
+              `          --embeddings --pooling mean --host 0.0.0.0 --port 8090`;
         return (
           `The embedding endpoint is reachable but "${model}" can't produce embeddings —\n` +
           `  it's a chat/generative model, not an embedding model.\n` +
           `  By default settings.embedding inherits settings.llm.baseUrl, so embeddings\n` +
-          `  point at your CHAT server. Run a DEDICATED embedding model on its own\n` +
-          `  llama.cpp server (note --embeddings --pooling mean):\n` +
-          `        llama-server -m nomic-embed-text-v1.5.Q8_0.gguf \\\n` +
-          `          --embeddings --pooling mean --host 0.0.0.0 --port 8090\n` +
+          `  point at your CHAT server. A single llama.cpp/locca server can't do both —\n` +
+          `  run a DEDICATED embedding server (note --embeddings --pooling mean):\n` +
+          startCmd + `\n` +
           `  then in /admin/settings → Embedding set:\n` +
-          `        baseUrl = http://<host>:8090/v1\n` +
+          `        baseUrl = http://<host>:8090/v1   (the embedding server's URL)\n` +
           `        model   = nomic-embed-text\n` +
           `  (server said: ${raw})`
         );

--- a/controller/src/music/embeddings.ts
+++ b/controller/src/music/embeddings.ts
@@ -110,6 +110,7 @@ export type ProbeCode =
   | 'unauthorized'        // 401 — typically cloud-routed Ollama or wrong API key
   | 'unreachable'         // connection refused / DNS / timeout
   | 'not_embedding_model' // server reached, but it's a chat model / no pooling (#319)
+  | 'bad_url'             // baseUrl missing/malformed — fetch can't parse the URL
   | 'unknown';            // anything else — message has the raw error
 
 export interface ProbeResult {
@@ -149,6 +150,15 @@ function classifyEmbeddingError(err: any): { code: ProbeCode; raw: string } {
     txt.includes('fetch failed')
   ) {
     return { code: 'unreachable', raw };
+  }
+  // A missing or malformed base URL makes the SDK build a relative request URL
+  // (e.g. just "/embeddings"), which fetch rejects before any network call.
+  if (
+    txt.includes('failed to parse url') ||
+    txt.includes('invalid url') ||
+    txt.includes('no embedding server url is set')
+  ) {
+    return { code: 'bad_url', raw };
   }
   return { code: 'unknown', raw };
 }
@@ -223,6 +233,26 @@ function actionableMessage(
         `  Point settings.embedding at a real embedding model (e.g. nomic-embed-text),\n` +
         `  served with embeddings enabled and a pooling type other than 'none'.\n` +
         `  (server said: ${raw})`
+      );
+    case 'bad_url':
+      if (provider === 'locca' || provider === 'openai-compatible') {
+        return (
+          `No usable embedding server URL for provider "${provider}".\n` +
+          `  By default settings.embedding inherits settings.llm — but a chat\n` +
+          `  llama.cpp/locca server can't also do embeddings. Run a DEDICATED\n` +
+          `  embedding server and point settings.embedding.baseUrl at it:\n` +
+          `        locca embed nomic     # dedicated embedding server on its own port\n` +
+          `  then in /admin/settings → Embedding set:\n` +
+          `        baseUrl = http://<host>:8090/v1   (full URL, with http:// and /v1)\n` +
+          `        model   = nomic-embed-text\n` +
+          `  (${raw})`
+        );
+      }
+      return (
+        `The embedding server base URL is missing or malformed, so the request\n` +
+        `  couldn't be sent. Set a full URL (with http:// and the /v1 suffix) in\n` +
+        `  /admin/settings → Embedding, e.g. http://host.docker.internal:8090/v1.\n` +
+        `  (${raw})`
       );
     case 'unknown':
     default:

--- a/controller/src/music/embeddings.ts
+++ b/controller/src/music/embeddings.ts
@@ -17,7 +17,11 @@ import {
   activeEmbeddingDim,
   embeddingEnabled,
   embeddingProviderInfo,
+  embeddingInfoOf,
+  resolveEmbeddingCfg,
+  buildEmbeddingModel,
 } from '../llm/provider.js';
+import type { EmbeddingCfg } from '../llm/provider.js';
 import { SHOW_MOODS as MOOD_VOCAB } from '../settings.js';
 import crypto from 'node:crypto';
 
@@ -149,8 +153,12 @@ function classifyEmbeddingError(err: any): { code: ProbeCode; raw: string } {
   return { code: 'unknown', raw };
 }
 
-function actionableMessage(code: ProbeCode, raw: string): string {
-  const { provider, model, ollamaUrl } = embeddingProviderInfo();
+function actionableMessage(
+  code: ProbeCode,
+  raw: string,
+  info: { provider: string; model: string; ollamaUrl: string },
+): string {
+  const { provider, model, ollamaUrl } = info;
   switch (code) {
     case 'not_found':
       if (provider === 'ollama') {
@@ -273,17 +281,31 @@ async function tryOllamaPull(model: string, ollamaUrl: string): Promise<boolean>
   }
 }
 
-async function probeOnce(): Promise<ProbeResult> {
+// Probe an explicit embedding config — builds a one-off model, embeds a short
+// string, and returns the real vector length on success or an actionable
+// message on failure. Shared by probeOnce() (saved config, used by the tagger
+// preflight) and the /settings/embedding/probe endpoint (unsaved form values,
+// passed as overrides) so both classify identically and name the right server.
+export async function probeEmbeddingConfig(
+  overrides: Partial<EmbeddingCfg> = {},
+): Promise<ProbeResult> {
+  const cfg = resolveEmbeddingCfg(overrides);
+  const info = embeddingInfoOf(cfg);
   try {
-    const vecs = await embedTexts(['subwave embedding probe']);
+    const model = buildEmbeddingModel(cfg);
+    const { embeddings } = await embedMany({ model, values: ['subwave embedding probe'] });
     // Measure the real vector length from the live server — authoritative dim,
     // independent of the name→dim guess table (#319).
-    const dim = Array.isArray(vecs[0]) ? vecs[0].length : undefined;
+    const dim = Array.isArray(embeddings?.[0]) ? embeddings[0].length : undefined;
     return { code: 'ok', message: 'ok', dim };
   } catch (err: any) {
     const { code, raw } = classifyEmbeddingError(err);
-    return { code, message: actionableMessage(code, raw) };
+    return { code, message: actionableMessage(code, raw, info) };
   }
+}
+
+function probeOnce(): Promise<ProbeResult> {
+  return probeEmbeddingConfig();
 }
 
 // One-shot readiness check used by the tagger before phase-1. Auto-pulls a

--- a/controller/src/routes/onboarding.ts
+++ b/controller/src/routes/onboarding.ts
@@ -23,6 +23,7 @@ import { createDeepSeek } from '@ai-sdk/deepseek';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 
 import { requireAdmin } from '../middleware/auth.js';
+import { DEFAULT_LOCCA_BASE_URL, noThinkFetch } from '../llm/provider.js';
 import { config } from '../config.js';
 import * as settings from '../settings.js';
 import * as jingles from '../broadcast/jingles.js';
@@ -133,7 +134,18 @@ router.post('/onboarding/test-llm', requireAdmin, async (req, res) => {
         break;
       case 'openai-compatible':
         if (!baseUrl) throw new Error('baseUrl is required for openai-compatible');
-        m = createOpenAI({ baseURL: baseUrl, apiKey: apiKey || 'unused' }).chat(model);
+        // noThinkFetch so a thinking model (Qwen3 etc.) returns visible content
+        // in the test rather than spending its budget in the reasoning channel.
+        m = createOpenAI({ baseURL: baseUrl, apiKey: apiKey || 'unused', fetch: noThinkFetch }).chat(model);
+        break;
+      case 'locca':
+        // First-class locca: openai-compatible llama.cpp, base URL defaults to
+        // the host locca server when not supplied.
+        m = createOpenAI({
+          baseURL: baseUrl || DEFAULT_LOCCA_BASE_URL,
+          apiKey: apiKey || 'unused',
+          fetch: noThinkFetch,
+        }).chat(model);
         break;
       case 'google':
         m = createGoogleGenerativeAI(apiKey ? { apiKey } : {})(model);

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -10,6 +10,7 @@ import * as tts from '../audio/tts.js';
 import * as chatterbox from '../audio/chatterbox.js';
 import * as piper from '../audio/piper.js';
 import * as llmProvider from '../llm/provider.js';
+import { probeEmbeddingConfig } from '../music/embeddings.js';
 import { queue } from '../broadcast/queue.js';
 import { restartLiquidsoap, startStream, stopStream, streamStatus } from '../broadcast/liquidsoap-control.js';
 import { invalidateWeatherCache } from '../context.js';
@@ -186,6 +187,29 @@ router.get('/settings/llm/discover', requireAdmin, async (req, res) => {
     res.json({ reachable: false, models: [], baseUrl, error: err?.message || 'unreachable' });
   } finally {
     clearTimeout(timer);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /settings/embedding/probe — test whether the configured (or supplied)
+// embedding endpoint can actually produce embeddings, surfacing the result
+// in the admin UI BEFORE a long tagging run instead of failing mid-job.
+// Optional query overrides (provider/model/baseUrl/ollamaUrl) test the unsaved
+// form values; omitted fields fall back to saved settings.embedding → llm.
+// Always 200s with { ok, dim, code, message } — a chat-model / unreachable
+// server is a normal, actionable answer, not an error.
+// ---------------------------------------------------------------------------
+router.get('/settings/embedding/probe', requireAdmin, async (req, res) => {
+  const overrides: Record<string, string> = {};
+  for (const k of ['provider', 'model', 'baseUrl', 'ollamaUrl']) {
+    const v = req.query[k];
+    if (typeof v === 'string' && v.trim()) overrides[k] = v.trim();
+  }
+  try {
+    const r = await probeEmbeddingConfig(overrides);
+    res.json({ ok: r.code === 'ok', dim: r.dim ?? null, code: r.code, message: r.message });
+  } catch (err: any) {
+    res.json({ ok: false, dim: null, code: 'unknown', message: err?.message || 'probe failed' });
   }
 });
 

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -159,6 +159,37 @@ router.post('/settings', requireAdmin, async (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
+// GET /settings/llm/discover — probe a locca / openai-compatible server for
+// liveness + its loaded model list, so the onboarding wizard and admin
+// Settings UI can auto-fill the model field with no hand-typing. Non-mutating.
+// `?baseUrl=` overrides; default is the locca host URL (host.docker.internal:8080).
+// Always 200s with { reachable, models, baseUrl } — an unreachable server is a
+// normal answer, not an error.
+// ---------------------------------------------------------------------------
+router.get('/settings/llm/discover', requireAdmin, async (req, res) => {
+  const baseUrl =
+    String(req.query.baseUrl || '').trim().replace(/\/+$/, '') ||
+    llmProvider.DEFAULT_LOCCA_BASE_URL;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 3000);
+  try {
+    const r = await fetch(`${baseUrl}/models`, { signal: ctrl.signal });
+    if (!r.ok) {
+      return res.json({ reachable: false, models: [], baseUrl, error: `HTTP ${r.status}` });
+    }
+    const data: any = await r.json();
+    const models = Array.isArray(data?.data)
+      ? data.data.map((m: any) => m?.id).filter((id: any): id is string => typeof id === 'string')
+      : [];
+    res.json({ reachable: true, models, baseUrl });
+  } catch (err: any) {
+    res.json({ reachable: false, models: [], baseUrl, error: err?.message || 'unreachable' });
+  } finally {
+    clearTimeout(timer);
+  }
+});
+
+// ---------------------------------------------------------------------------
 // POST /restart-mixer — telnet → Liquidsoap → shutdown → container restart
 // Brief gap of dead air covered by Icecast burst buffer + emergency.mp3.
 // ---------------------------------------------------------------------------

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -507,6 +507,13 @@ const DEFAULTS = {
     enabled: true,
     provider: '',         // empty → follow settings.llm.provider
     model: '',            // empty → sensible default per provider
+    // Embeddings often need a DIFFERENT endpoint than chat: one llama.cpp /
+    // locca server can't serve both chat and embeddings, so a dedicated
+    // embedding server runs on its own port. Empty → inherit settings.llm's
+    // baseUrl / ollamaUrl (fine only when the chat server also does embeddings,
+    // e.g. Ollama). See issue #405.
+    baseUrl: '',          // openai-compatible / locca embedding server URL (with /v1)
+    ollamaUrl: '',        // Ollama embedding server URL (ollama provider)
     seedCount: 0,         // 0 → auto max(200, ceil(sqrt(library)))
     knnNeighbours: 5,
     moodVoteThreshold: 0.6,
@@ -981,6 +988,14 @@ export async function load() {
         typeof stored.embedding?.model === 'string'
           ? stored.embedding.model.trim()
           : DEFAULTS.embedding.model,
+      baseUrl:
+        typeof stored.embedding?.baseUrl === 'string'
+          ? stored.embedding.baseUrl.trim()
+          : DEFAULTS.embedding.baseUrl,
+      ollamaUrl:
+        typeof stored.embedding?.ollamaUrl === 'string'
+          ? stored.embedding.ollamaUrl.trim()
+          : DEFAULTS.embedding.ollamaUrl,
       seedCount:
         Number.isFinite(stored.embedding?.seedCount) && stored.embedding.seedCount >= 0
           ? Math.floor(stored.embedding.seedCount)
@@ -1739,6 +1754,23 @@ export async function update(patch) {
       const v = String(e.model).trim();
       if (v.length > 100) throw new Error('embedding.model must be 0-100 chars');
       next.embedding.model = v;
+    }
+    // Dedicated embedding endpoint (issue #405). Empty → inherit settings.llm.
+    if (e.baseUrl !== undefined) {
+      const v = String(e.baseUrl).trim();
+      if (v.length > 200) throw new Error('embedding.baseUrl must be 0-200 chars');
+      if (v && !/^https?:\/\//i.test(v)) {
+        throw new Error('embedding.baseUrl must start with http:// or https://');
+      }
+      next.embedding.baseUrl = v.replace(/\/+$/, ''); // strip trailing slashes
+    }
+    if (e.ollamaUrl !== undefined) {
+      const v = String(e.ollamaUrl).trim();
+      if (v.length > 200) throw new Error('embedding.ollamaUrl must be 0-200 chars');
+      if (v && !/^https?:\/\//i.test(v)) {
+        throw new Error('embedding.ollamaUrl must start with http:// or https://');
+      }
+      next.embedding.ollamaUrl = v.replace(/\/+$/, '');
     }
     if (e.seedCount !== undefined) {
       const v = parseInt(e.seedCount, 10);

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -97,11 +97,11 @@ export const LLM_PROVIDERS = [
   'ollama',
   'openai-compatible',
   'locca',
+  'openrouter',
   'anthropic',
   'openai',
   'google',
   'deepseek',
-  'openrouter',
   'gateway',
 ];
 

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -90,10 +90,13 @@ export const TTS_ENGINES = ['piper', 'kokoro', 'chatterbox', 'pocket-tts', 'clou
 // providers are opt-in and resolved by llm/provider.js. `openrouter` and
 // `gateway` are aggregators — one key, any vendor's models. `openai-compatible`
 // targets any self-hosted OpenAI-compatible server (llama.cpp, vLLM, LM Studio,
-// etc.) via the operator-supplied `llm.baseUrl`.
+// etc.) via the operator-supplied `llm.baseUrl`. `locca` is a first-class local
+// llama.cpp via the locca CLI — same transport as openai-compatible but with a
+// host default base URL (host.docker.internal:8080) and onboarding discovery.
 export const LLM_PROVIDERS = [
   'ollama',
   'openai-compatible',
+  'locca',
   'anthropic',
   'openai',
   'google',

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -275,6 +275,7 @@ interface SettingsData {
   };
   jingles?: JingleEntry[];
   libraryStats?: { total?: number };
+  tagger?: { running?: boolean };
   env?: Record<string, unknown>;
   streamOnAir?: boolean;
   // What timezone '' (Auto) resolves to — the controller's own zone.
@@ -2175,6 +2176,86 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
   // Anthropic has no first-party embedding API — flagged in the hint.
   const providers = data.llm?.providers || ['ollama'];
 
+  // --- Guided setup: probe the endpoint up front, detect a locca embed server,
+  // and kick the tagger from here, instead of failing mid-run (#405 follow-up).
+  const { adminFetch } = useAdminAuth();
+  const [probe, setProbe] = useState<
+    { ok: boolean; dim: number | null; code: string; message: string } | null
+  >(null);
+  const [probing, setProbing] = useState(false);
+  const [detecting, setDetecting] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [tagBusy, setTagBusy] = useState(false);
+  const taggerRunning = !!data.tagger?.running;
+  // Local servers (llama.cpp/locca) need a dedicated embedding endpoint; cloud
+  // and Ollama providers serve embeddings on the same endpoint as chat.
+  const needsServerUrl = effectiveProvider === 'locca' || effectiveProvider === 'openai-compatible';
+
+  const probeQuery = () => {
+    const p = new URLSearchParams();
+    if (e.provider) p.set('provider', e.provider);
+    if (e.model) p.set('model', e.model);
+    if (e.baseUrl) p.set('baseUrl', e.baseUrl);
+    if (e.ollamaUrl) p.set('ollamaUrl', e.ollamaUrl);
+    return p.toString();
+  };
+
+  const runProbe = async () => {
+    setProbing(true);
+    setProbe(null);
+    try {
+      const r = await adminFetch(`/settings/embedding/probe?${probeQuery()}`);
+      setProbe(await r.json());
+    } catch (err) {
+      setProbe({ ok: false, dim: null, code: 'unknown', message: errorMessage(err) });
+    } finally {
+      setProbing(false);
+    }
+  };
+
+  // Find a locca embedding server on its default port (8090), pre-fill the form,
+  // and confirm it actually embeds.
+  const detect = async () => {
+    setDetecting(true);
+    setProbe(null);
+    const url = 'http://host.docker.internal:8090/v1';
+    try {
+      let model = 'nomic-embed-text';
+      try {
+        const d = await (
+          await adminFetch(`/settings/llm/discover?baseUrl=${encodeURIComponent(url)}`)
+        ).json();
+        if (d.reachable && Array.isArray(d.models) && d.models.length) model = d.models[0];
+      } catch {
+        /* discovery is best-effort — fall through and probe with the default model */
+      }
+      const p = new URLSearchParams({ provider: 'locca', baseUrl: url, model });
+      const j = await (await adminFetch(`/settings/embedding/probe?${p.toString()}`)).json();
+      setProbe(j);
+      if (j.ok) {
+        setForm(f => ({ ...f, embedding: { ...f.embedding, provider: 'locca', baseUrl: url, model } }));
+      }
+    } catch (err) {
+      setProbe({ ok: false, dim: null, code: 'unknown', message: errorMessage(err) });
+    } finally {
+      setDetecting(false);
+    }
+  };
+
+  const startTagging = async () => {
+    setTagBusy(true);
+    try {
+      const r = await adminFetch('/tag-library', { method: 'POST' });
+      const j = await r.json().catch(() => ({}));
+      if (r.ok) notify.ok('tagging started — watch progress on the Library tab');
+      else notify.err(j.error || 'could not start the tagger');
+    } catch (err) {
+      notify.err(errorMessage(err));
+    } finally {
+      setTagBusy(false);
+    }
+  };
+
   return (
     <>
       <SectionHeader
@@ -2193,6 +2274,25 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
           },
         ]}
       />
+
+      {/* Plain-language intro + at-a-glance readiness. */}
+      <div className="mb-5 flex flex-wrap items-start justify-between gap-3">
+        <p className="max-w-[560px] text-[12px] leading-[1.6] text-muted">
+          Auto-tagging reads each track once and labels its mood + energy so the DJ
+          picks tracks that fit the room. It needs a small <strong>embedding</strong>{' '}
+          model — separate from your chat LLM. Set it up below, hit{' '}
+          <strong>Test</strong>, then run the tagger.
+        </p>
+        {probing || detecting ? (
+          <Pill tone="default" dot>checking…</Pill>
+        ) : probe?.ok ? (
+          <Pill tone="accent" dot>ready{probe.dim ? ` · ${probe.dim}-dim` : ''}</Pill>
+        ) : probe ? (
+          <Pill tone="ink" dot className="!border-red-400 !text-red-400">needs attention</Pill>
+        ) : (
+          <Pill tone="default">not tested</Pill>
+        )}
+      </div>
 
       <Card title="Tagger" sub="enabled?">
         <div className="grid grid-cols-[1fr_auto] items-center gap-4">
@@ -2218,7 +2318,7 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
         </div>
       </Card>
 
-      <Card title="Embedding provider" sub="vector model">
+      <Card title="Embedding server" sub="where embeddings come from">
         <div className="grid gap-[18px]">
           <div className="field">
             <Label>Provider</Label>
@@ -2321,9 +2421,67 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
               </div>
             </div>
           )}
+
+          {/* Detect a locca embed server + test the endpoint BEFORE a long run. */}
+          <div className="field">
+            <div className="flex flex-wrap items-center gap-2">
+              {needsServerUrl && (
+                <Btn sm onClick={detect} disabled={detecting || probing}>
+                  {detecting ? 'Detecting…' : 'Detect locca server'}
+                </Btn>
+              )}
+              <Btn sm tone="accent" onClick={runProbe} disabled={probing || detecting}>
+                {probing ? 'Testing…' : 'Test embeddings'}
+              </Btn>
+            </div>
+            {probe && (
+              <div
+                className={cn(
+                  'mt-2 max-w-[560px] rounded border px-3 py-2 text-[11px] leading-[1.6] whitespace-pre-wrap',
+                  probe.ok
+                    ? 'border-[var(--accent)] text-[color:var(--accent)]'
+                    : 'border-red-400/50 text-red-300',
+                )}
+              >
+                {probe.ok
+                  ? `✓ Producing embeddings${probe.dim ? ` (${probe.dim}-dim vectors)` : ''} — you're ready to tag.`
+                  : `✗ ${probe.message}`}
+              </div>
+            )}
+          </div>
         </div>
       </Card>
 
+      {/* Run the tagger — gated on a green probe so it can't fail mid-job. */}
+      <Card title="Tag the library" sub="run the bulk tagger">
+        <div className="grid grid-cols-[1fr_auto] items-center gap-4">
+          <div className="max-w-[480px] text-[11px] leading-[1.5] text-muted">
+            {taggerRunning
+              ? 'A tagging run is in progress — watch live progress on the Library tab.'
+              : probe?.ok
+                ? 'Embeddings look good. Start the bulk tagger — it runs in the background; watch progress on the Library tab.'
+                : 'Test the embedding endpoint above first — the tagger needs a working embedding server.'}
+          </div>
+          <Btn
+            tone="accent"
+            onClick={startTagging}
+            disabled={tagBusy || taggerRunning || !probe?.ok}
+          >
+            {taggerRunning ? 'Tagging…' : tagBusy ? 'Starting…' : 'Start tagging'}
+          </Btn>
+        </div>
+      </Card>
+
+      {/* Advanced knobs — collapsed by default so newcomers see only the basics. */}
+      <button
+        type="button"
+        onClick={() => setAdvancedOpen(o => !o)}
+        className="mb-1 w-fit text-[11px] font-bold tracking-[0.14em] text-muted uppercase hover:text-ink"
+      >
+        {advancedOpen ? '▾' : '▸'} Advanced — seed count, propagation, enrichment
+      </button>
+      {advancedOpen && (
+        <>
       <Card title="Seed phase" sub="how many tracks to LLM-tag">
         <div className="grid gap-[18px]">
           <div className="field">
@@ -2508,6 +2666,8 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
           </div>
         </div>
       </Card>
+        </>
+      )}
 
       <SaveBar
         note={`Saved values apply the next time the bulk tagger runs. Current run (if any) keeps its own snapshot.${

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -25,10 +25,10 @@ import BackupPanel from './BackupPanel';
 const SECTIONS = [
   { id: 'station',  label: 'Station', hint: 'name · location · timezone' },
   { id: 'theme',    label: 'Theme', hint: 'station-wide palette' },
-  { id: 'tts',      label: 'TTS voice', hint: 'default engine' },
   { id: 'llm',      label: 'LLM provider', hint: 'model routing' },
-  { id: 'search',   label: 'Web search', hint: 'live-facts backend' },
+  { id: 'tts',      label: 'TTS voice', hint: 'default engine' },
   { id: 'library',  label: 'Library tagger', hint: 'embedding · propagation' },
+  { id: 'search',   label: 'Web search', hint: 'live-facts backend' },
   { id: 'jingles',  label: 'Jingles', hint: 'stingers' },
   { id: 'sfx',      label: 'Sound FX', hint: 'agent stingers' },
   { id: 'scrobble', label: 'Scrobbling', hint: 'last.fm · listenbrainz' },
@@ -51,9 +51,9 @@ const LLM_ENV_VARS: Record<string, string> = {
 };
 
 const LLM_PROVIDER_LABELS: Record<string, string> = {
-  ollama: 'Ollama — local homelab',
+  ollama: 'Ollama — local/cloud',
   locca: 'locca — local llama.cpp (host)',
-  'openai-compatible': 'OpenAI-compatible — self-hosted (llama.cpp, vLLM, LM Studio)',
+  'openai-compatible': 'OpenAI-compatible — llama.cpp, vLLM, LM Studio',
   anthropic: 'Anthropic — Claude',
   openai: 'OpenAI — GPT',
   google: 'Google — Gemini',
@@ -1676,7 +1676,15 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
                 (<code>http://host.docker.internal:8080/v1</code>). Override only
                 for a non-default port or a remote host. Bring a model up with{' '}
                 <code>locca serve &lt;model&gt; --yes</code>; the model id below is
-                what locca reports at <code>/v1/models</code>.
+                what locca reports at <code>/v1/models</code>.{' '}
+                <a
+                  href="https://github.com/perminder-klair/locca"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-bold text-vermilion underline decoration-[1.5px] underline-offset-2"
+                >
+                  locca on GitHub ↗
+                </a>
               </div>
             </div>
           )}
@@ -2360,7 +2368,7 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
                 setForm(f => ({ ...f, embedding: { ...f.embedding, model: ev.target.value } }))
               }
               placeholder={
-                effectiveProvider === 'ollama'
+                effectiveProvider === 'ollama' || effectiveProvider === 'locca'
                   ? 'nomic-embed-text'
                   : effectiveProvider === 'openai' || effectiveProvider === 'openai-compatible'
                     ? 'text-embedding-3-small'
@@ -2392,13 +2400,25 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
               <div className="field-hint">
                 Embeddings need a <strong>dedicated</strong> server — one
                 llama.cpp / locca process can&apos;t serve both chat and
-                embeddings. Leave blank only if this server itself does
-                embeddings; otherwise run a separate embedding server (with locca:{' '}
-                <code>locca embed nomic</code>, or plain{' '}
-                <code>llama-server -m nomic-embed-text-v1.5.Q8_0.gguf --embeddings --pooling mean --port 8090</code>)
-                and point this at it, including the <code>/v1</code> suffix. Must be
-                reachable from the controller container — use the host LAN/Tailscale
-                IP or <code>host.docker.internal</code>, not <code>127.0.0.1</code>.
+                embeddings.{' '}
+                {effectiveProvider === 'locca' ? (
+                  <>
+                    Leave blank to use the locca embed server on its default port
+                    (<code>http://host.docker.internal:8090/v1</code>) — start it
+                    with <code>locca embed nomic</code>. Override only for a
+                    non-default port or remote host.
+                  </>
+                ) : (
+                  <>
+                    Leave blank only if this server itself does embeddings;
+                    otherwise run a separate embedding server (
+                    <code>llama-server -m nomic-embed-text-v1.5.Q8_0.gguf --embeddings --pooling mean --port 8090</code>)
+                    and point this at it, including the <code>/v1</code> suffix.
+                  </>
+                )}
+                {' '}Must be reachable from the controller container — use the host
+                LAN/Tailscale IP or <code>host.docker.internal</code>, not{' '}
+                <code>127.0.0.1</code>.
               </div>
             </div>
           )}

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -134,6 +134,8 @@ interface EmbeddingForm {
   enabled: boolean;
   provider: string;          // empty → follow llm.provider
   model: string;             // empty → sensible default per provider
+  baseUrl: string;           // dedicated embedding server URL (openai-compatible / locca); empty → inherit llm
+  ollamaUrl: string;         // dedicated embedding server URL (ollama); empty → inherit llm
   seedCount: string;         // '0' = auto
   knnNeighbours: string;
   moodVoteThreshold: string;
@@ -233,6 +235,8 @@ interface SettingsData {
       enabled?: boolean;
       provider?: string;
       model?: string;
+      baseUrl?: string;
+      ollamaUrl?: string;
       seedCount?: number;
       knnNeighbours?: number;
       moodVoteThreshold?: number;
@@ -393,6 +397,8 @@ export default function SettingsPanel() {
         enabled: v.embedding?.enabled ?? true,
         provider: v.embedding?.provider ?? '',
         model: v.embedding?.model ?? '',
+        baseUrl: v.embedding?.baseUrl ?? '',
+        ollamaUrl: v.embedding?.ollamaUrl ?? '',
         seedCount: String(v.embedding?.seedCount ?? 0),
         knnNeighbours: String(v.embedding?.knnNeighbours ?? 5),
         moodVoteThreshold: String(v.embedding?.moodVoteThreshold ?? 0.6),
@@ -2147,6 +2153,8 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
       enabled: e.enabled,
       provider: e.provider,
       model: e.model,
+      baseUrl: e.baseUrl,
+      ollamaUrl: e.ollamaUrl,
       seedCount: parseInt(e.seedCount, 10) || 0,
       knnNeighbours: parseInt(e.knnNeighbours, 10) || 5,
       moodVoteThreshold: parseFloat(e.moodVoteThreshold) || 0.6,
@@ -2269,6 +2277,50 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
               <code>--reseed</code>) to drop and rebuild the vectors.
             </div>
           </div>
+
+          {(effectiveProvider === 'openai-compatible' || effectiveProvider === 'locca') && (
+            <div className="field">
+              <Label>Embedding server base URL</Label>
+              <Input
+                value={e.baseUrl}
+                onChange={(ev: ChangeEvent<HTMLInputElement>) =>
+                  setForm(f => ({ ...f, embedding: { ...f.embedding, baseUrl: ev.target.value } }))
+                }
+                placeholder="http://host.docker.internal:8090/v1"
+                className="max-w-[360px]"
+              />
+              <div className="field-hint">
+                Embeddings need a <strong>dedicated</strong> server — one
+                llama.cpp / locca process can&apos;t serve both chat and
+                embeddings. Leave blank only if this server itself does
+                embeddings; otherwise run a separate embedding server (with locca:{' '}
+                <code>locca embed nomic</code>, or plain{' '}
+                <code>llama-server -m nomic-embed-text-v1.5.Q8_0.gguf --embeddings --pooling mean --port 8090</code>)
+                and point this at it, including the <code>/v1</code> suffix. Must be
+                reachable from the controller container — use the host LAN/Tailscale
+                IP or <code>host.docker.internal</code>, not <code>127.0.0.1</code>.
+              </div>
+            </div>
+          )}
+
+          {effectiveProvider === 'ollama' && (
+            <div className="field">
+              <Label>Embedding server URL</Label>
+              <Input
+                value={e.ollamaUrl}
+                onChange={(ev: ChangeEvent<HTMLInputElement>) =>
+                  setForm(f => ({ ...f, embedding: { ...f.embedding, ollamaUrl: ev.target.value } }))
+                }
+                placeholder="http://host.docker.internal:11434"
+                className="max-w-[360px]"
+              />
+              <div className="field-hint">
+                Leave blank to use the same Ollama server as chat (it serves
+                embeddings too). Set this only to run embeddings against a
+                different Ollama host.
+              </div>
+            </div>
+          )}
         </div>
       </Card>
 

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -65,6 +65,25 @@ const LLM_PROVIDER_LABELS: Record<string, string> = {
 const llmProviderLabel = (id: string | undefined): string =>
   (id && LLM_PROVIDER_LABELS[id]) || id || '—';
 
+// Suggested embedding model ids per provider — clickable chips under the Model
+// field so operators don't have to guess a valid name. The #1 trip-up is typing
+// an HF/locca repo id like "nomic-ai/nomic-embed-text-v1.5-GGUF" as an Ollama
+// tag, which 404s; Ollama wants the short tag (nomic-embed-text). dim is shown
+// so you can match the vector length of an already-tagged library.
+const EMBED_MODEL_SUGGESTIONS: Record<string, { id: string; dim: number }[]> = {
+  ollama: [
+    { id: 'nomic-embed-text', dim: 768 },
+    { id: 'mxbai-embed-large', dim: 1024 },
+    { id: 'bge-m3', dim: 1024 },
+    { id: 'all-minilm', dim: 384 },
+  ],
+  openai: [
+    { id: 'text-embedding-3-small', dim: 1536 },
+    { id: 'text-embedding-3-large', dim: 3072 },
+  ],
+  google: [{ id: 'text-embedding-004', dim: 768 }],
+};
+
 const SEARCH_PROVIDER_LABELS: Record<string, string> = {
   duckduckgo: 'DuckDuckGo — free, no key',
   tavily: 'Tavily — paid web search',
@@ -2179,6 +2198,7 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
   const savedEmbedding = data.values?.embedding || {};
   const llmProvider = data.values?.llm?.provider || 'ollama';
   const effectiveProvider = e.provider || llmProvider;
+  const embedSuggestions = EMBED_MODEL_SUGGESTIONS[effectiveProvider] ?? [];
 
   // Provider list comes from /settings.llm.providers (the canonical LLM list).
   // Anthropic has no first-party embedding API — flagged in the hint.
@@ -2384,6 +2404,24 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
               hit <strong>Re-seed</strong> on the Library tab (or run{' '}
               <code>--reseed</code>) to drop and rebuild the vectors.
             </div>
+            {embedSuggestions.length > 0 && (
+              <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                <span className="text-[11px] text-muted">Suggested:</span>
+                {embedSuggestions.map(s => (
+                  <Btn
+                    key={s.id}
+                    sm
+                    onClick={() =>
+                      setForm(f => ({ ...f, embedding: { ...f.embedding, model: s.id } }))
+                    }
+                    title={`Use ${s.id} (${s.dim}-dim)`}
+                  >
+                    {s.id}
+                    <span className="ml-1 text-muted">{s.dim}d</span>
+                  </Btn>
+                ))}
+              </div>
+            )}
           </div>
 
           {(effectiveProvider === 'openai-compatible' || effectiveProvider === 'locca') && (

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -52,6 +52,7 @@ const LLM_ENV_VARS: Record<string, string> = {
 
 const LLM_PROVIDER_LABELS: Record<string, string> = {
   ollama: 'Ollama — local homelab',
+  locca: 'locca — local llama.cpp (host)',
   'openai-compatible': 'OpenAI-compatible — self-hosted (llama.cpp, vLLM, LM Studio)',
   anthropic: 'Anthropic — Claude',
   openai: 'OpenAI — GPT',
@@ -1609,7 +1610,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
                   ? 'nemotron-3-super:cloud'
                   : form.llm.provider === 'deepseek'
                     ? 'deepseek-v4-flash'
-                    : form.llm.provider === 'openai-compatible'
+                    : form.llm.provider === 'openai-compatible' || form.llm.provider === 'locca'
                       ? 'Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf'
                       : 'model id'
               }
@@ -1626,7 +1627,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
                       ? 'Gemini model id, e.g. “gemini-2.5-flash”.'
                       : form.llm.provider === 'deepseek'
                         ? 'DeepSeek model id. Leave blank for the “deepseek-v4-flash” default.'
-                        : form.llm.provider === 'openai-compatible'
+                        : form.llm.provider === 'openai-compatible' || form.llm.provider === 'locca'
                           ? 'Model id exactly as the server reports it at /v1/models — required.'
                           : 'Model id for the chosen provider — required.'}
             </div>
@@ -1648,6 +1649,27 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
                 including the <code>/v1</code> suffix. Must be reachable from the
                 controller container — use the host’s LAN or Tailscale IP, not
                 <code>127.0.0.1</code>.
+              </div>
+            </div>
+          )}
+
+          {form.llm.provider === 'locca' && (
+            <div className="field">
+              <Label>locca server base URL</Label>
+              <Input
+                value={form.llm.baseUrl}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setForm(f => ({ ...f, llm: { ...f.llm, baseUrl: e.target.value } }))
+                }
+                placeholder="http://host.docker.internal:8080/v1"
+                className="max-w-[360px]"
+              />
+              <div className="field-hint">
+                Leave blank to use the locca server on the host
+                (<code>http://host.docker.internal:8080/v1</code>). Override only
+                for a non-default port or a remote host. Bring a model up with{' '}
+                <code>locca serve &lt;model&gt; --yes</code>; the model id below is
+                what locca reports at <code>/v1/models</code>.
               </div>
             </div>
           )}

--- a/web/components/onboarding/steps.tsx
+++ b/web/components/onboarding/steps.tsx
@@ -134,6 +134,7 @@ export function NavidromeStep({ w }: { w: WizardController }) {
 // ─── LLM ───────────────────────────────────────────────────────────────────
 const LLM_PROVIDERS = [
   { id: 'ollama', label: 'Ollama (local, no key)' },
+  { id: 'locca', label: 'locca (local llama.cpp, no key)' },
   { id: 'anthropic', label: 'Anthropic Claude' },
   { id: 'openai', label: 'OpenAI' },
   { id: 'google', label: 'Google Gemini' },
@@ -145,12 +146,23 @@ const LLM_PROVIDERS = [
 
 export function LlmStep({ w }: { w: WizardController }) {
   const [busy, setBusy] = useState(false);
+  const [discovering, setDiscovering] = useState(false);
+  const [discovery, setDiscovery] = useState<
+    { reachable: boolean; models: string[]; error?: string } | null
+  >(null);
   const isOllama = w.data.llm.provider === 'ollama';
+  const isLocca = w.data.llm.provider === 'locca';
   const isCustom = w.data.llm.provider === 'openai-compatible';
   const onTest = async () => {
     setBusy(true);
     await w.testLlm();
     setBusy(false);
+  };
+  const onDiscover = async () => {
+    setDiscovering(true);
+    setDiscovery(null);
+    setDiscovery(await w.discoverLocca());
+    setDiscovering(false);
   };
   return (
     <div>
@@ -199,7 +211,63 @@ export function LlmStep({ w }: { w: WizardController }) {
             />
           </Field>
         )}
-        {!isOllama && (
+        {isLocca && (
+          <Field
+            label="Base URL"
+            hint="Blank → http://host.docker.internal:8080/v1 (the locca server on the host)"
+          >
+            <TextInput
+              value={w.data.llm.baseUrl}
+              placeholder="http://host.docker.internal:8080/v1"
+              onChange={e =>
+                w.patch(d => ({ llm: { ...d.llm, baseUrl: e.target.value }, llmTest: { ok: null } }))
+              }
+            />
+          </Field>
+        )}
+        {isLocca && (
+          <div className="grid gap-2">
+            <button
+              type="button"
+              onClick={onDiscover}
+              disabled={discovering}
+              className="w-fit rounded border border-ink px-3 py-1.5 text-xs font-medium tracking-wide uppercase hover:bg-ink hover:text-bg disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {discovering ? 'Detecting…' : 'Detect locca models'}
+            </button>
+            {discovery && !discovery.reachable && (
+              <p className="text-xs text-amber-300">
+                No locca server reachable{discovery.error ? ` (${discovery.error})` : ''}. Start one
+                with <code>locca serve &lt;model&gt; --yes</code> on the host, then retry.
+              </p>
+            )}
+            {discovery && discovery.reachable && discovery.models.length === 0 && (
+              <p className="text-xs text-amber-300">locca is up but has no model loaded.</p>
+            )}
+            {discovery && discovery.reachable && discovery.models.length > 0 && (
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-xs text-ink/60">✓ locca detected — pick a model:</span>
+                {discovery.models.map(id => (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() =>
+                      w.patch(d => ({ llm: { ...d.llm, model: id }, llmTest: { ok: null } }))
+                    }
+                    className={`rounded border px-2 py-1 text-xs ${
+                      w.data.llm.model === id
+                        ? 'border-ink bg-ink text-bg'
+                        : 'border-ink/40 hover:border-ink'
+                    }`}
+                  >
+                    {id}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+        {!isOllama && !isLocca && (
           <Field label="API key" hint="Stored in state/secrets.env (mode 0600), not in settings.json">
             <TextInput
               type="password"

--- a/web/components/onboarding/useWizard.ts
+++ b/web/components/onboarding/useWizard.ts
@@ -130,6 +130,20 @@ export function useWizard() {
     return result;
   }, [auth, data.llm, patch]);
 
+  // Probe a locca / openai-compatible server for its loaded model list so the
+  // operator can pick the model instead of typing it. Uses data.llm.baseUrl
+  // when set; otherwise the controller defaults to the locca host URL.
+  const discoverLocca = useCallback(async () => {
+    const qs = data.llm.baseUrl ? `?baseUrl=${encodeURIComponent(data.llm.baseUrl)}` : '';
+    const r = await auth.adminFetch(`/settings/llm/discover${qs}`);
+    const j = (await r.json().catch(() => ({}))) as {
+      reachable?: boolean;
+      models?: string[];
+      error?: string;
+    };
+    return { reachable: !!j.reachable, models: j.models || [], error: j.error };
+  }, [auth, data.llm.baseUrl]);
+
   const save = useCallback(async () => {
     // Stitch the apiKeys into the right env-var keys before sending.
     const apiKeys: Record<string, string> = { ...data.apiKeys };
@@ -198,6 +212,7 @@ export function useWizard() {
     goto,
     testNavidrome,
     testLlm,
+    discoverLocca,
     save,
     generateJingles,
   };

--- a/web/content/news/2026-06-17-run-on-locca.md
+++ b/web/content/news/2026-06-17-run-on-locca.md
@@ -1,0 +1,53 @@
+---
+title: Run your DJ and tagger on locca
+date: 2026-06-17
+category: Feature
+author: The SUB/WAVE desk
+excerpt: locca is now a first-class LLM provider. Point SUB/WAVE at a local llama.cpp server for the DJ, and a locca embedding server for the library tagger. No API keys, no cloud.
+---
+
+SUB/WAVE already ran on Ollama or any cloud model. Now it runs on locca too. locca is a small TUI around llama.cpp for local GGUF models, and SUB/WAVE treats it as a first-class provider for both the DJ and the library tagger. No hand-typed server URLs.
+
+## What's new
+
+Pick locca in admin and the DJ writes its links and picks its tracks on a local model. The library tagger can use it too, for the embeddings behind mood tagging.
+
+## Run the locca servers
+
+A chat model and an embedding model need two separate locca servers. One llama.cpp process can't do both.
+
+Start the chat server:
+
+```
+locca serve qwen3
+```
+
+Start the embedding server (set a default embed model and `locca serve` brings it up for you):
+
+```
+locca embed nomic
+```
+
+Chat runs on port 8080, embeddings on 8090.
+
+## Point SUB/WAVE at it
+
+For the DJ, open admin, then Settings, then LLM provider. Choose locca, type the model id locca reports at `/v1/models`, and leave the base URL blank. It defaults to the chat server:
+
+```
+http://host.docker.internal:8080/v1
+```
+
+Hit Save LLM provider.
+
+For the tagger, open Settings, then Library tagger, then Embedding server. Click Detect locca server to fill it in, or leave the provider following your LLM and the base URL blank. It defaults to the embedding server:
+
+```
+http://host.docker.internal:8090/v1
+```
+
+Click Test embeddings, then Start tagging.
+
+## Why it helps
+
+The whole station runs on your own hardware. The DJ thinks on a local model and the tagger embeds your library locally, so nothing leaves the box. Switch providers later from admin with no redeploy.


### PR DESCRIPTION
## What

Makes **locca** (local llama.cpp via the [locca](https://github.com/perminder-klair/locca) CLI) a first-class LLM provider in SUB/WAVE — a dedicated provider with auto-discovery, rather than a hand-typed `openai-compatible` URL — and hardens local-model track picking.

Validated end-to-end against a real locca server (Qwen3-30B-A3B on an iGPU): the DJ picker, track selection, and between-track links all run on the local model.

## Changes

**Provider**
- `'locca'` added to `LLM_PROVIDERS`; shares the openai-compatible capability descriptor (native objects, no `repeat_penalty`, no-think handled in transport via `noThinkFetch`).
- `registry`: `locca` reuses the openai-compatible builder (factored into `openAICompatibleModel`) with a default base URL of `host.docker.internal:8080/v1`, overridable via `llm.baseUrl`. baseUrl is optional for locca.

**Discovery**
- `GET /settings/llm/discover` probes a locca / openai-compatible server's `/v1/models` → `{ reachable, models }`.
- Onboarding step 2 + admin Settings get a `locca` option; onboarding adds a **Detect models** button that auto-fills the model id.
- `onboarding/test-llm` gains a `locca` case and now applies `noThinkFetch` to local servers, so a thinking model (Qwen3 etc.) returns visible content in the test instead of an empty reasoning-only reply.

**Reliability**
- The stateless pool picker constrains the chosen `id` to `z.enum(candidateIds)` built from the pool, so a local model can't hallucinate an id outside the candidate set (closes the "agent returned unknown id → fall back to pool" hole on that path). Empty pool falls back to `z.string()`.

## Out of scope (deferred by design)

- Managed lifecycle (SUB/WAVE starting/stopping locca) — not in this PR.
- Agent-path retry-with-enum — kept today's straight-to-pool fallback.
- A discovery button in admin Settings (onboarding has it); admin shows the locca base-URL field + hints.

## Depends on

- locca headless serve (perminder-klair/locca#11) for the `locca serve <model> --yes` startup the docs reference — runtime-independent (discovery degrades gracefully when no locca server is up).

## Test

- `npm run test` (controller): llm-pure + picker regression pass, incl. new `locca` cases (providerOptions, capability flags, agentPlan routing).
- `npm run lint` clean in `controller/` (eslint + tsc) and `web/`.