### PR TITLE
docs(manual): locca + embeddings, and admin→manual deep-links

### DIFF
--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -955,9 +955,11 @@ interface SectionHeaderProps {
   title: ReactNode;
   sub: ReactNode;
   metrics?: MetricSpec[];
+  manualHref?: string;
+  manualLabel?: ReactNode;
 }
 
-function SectionHeader({ eyebrow, title, sub, metrics }: SectionHeaderProps) {
+function SectionHeader({ eyebrow, title, sub, metrics, manualHref, manualLabel }: SectionHeaderProps) {
   return (
     <div className="flex flex-wrap items-start gap-4 border border-ink p-4">
       <div className="min-w-[240px] flex-1">
@@ -968,6 +970,16 @@ function SectionHeader({ eyebrow, title, sub, metrics }: SectionHeaderProps) {
         <div className="mt-1.5 max-w-[540px] text-[12px] leading-[1.5] text-muted">
           {sub}
         </div>
+        {manualHref && (
+          <a
+            href={manualHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-2 inline-block text-[12px] font-bold text-vermilion underline decoration-[1.5px] underline-offset-2"
+          >
+            {manualLabel || 'Read this in the manual'} ↗
+          </a>
+        )}
       </div>
       {metrics && metrics.length > 0 && (
         <div className="grid grid-flow-col gap-[18px] pt-1">
@@ -1581,6 +1593,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
         title="The model that writes scripts and picks tracks."
         sub="Ollama runs on the homelab box and needs no key; the cloud providers are opt-in. Switching here reroutes every LLM call — no redeploy."
         metrics={[{ n: String((data.llm?.providers || []).length), l: 'providers' }]}
+        manualHref="/manual/llm"
       />
 
       <Card title="Provider" sub="active routing">
@@ -2301,6 +2314,8 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
             l: 'tagged',
           },
         ]}
+        manualHref="/manual/llm"
+        manualLabel="How embeddings work"
       />
 
       {/* Plain-language intro + at-a-glance readiness. */}
@@ -3032,6 +3047,7 @@ function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSectionProp
             accent: true,
           },
         ]}
+        manualHref="/manual/themes"
       />
 
       <Card title="Picker" sub="active station theme">

--- a/web/components/admin/SkillsPanel.tsx
+++ b/web/components/admin/SkillsPanel.tsx
@@ -278,6 +278,14 @@ export default function SkillsPanel() {
             <strong> Rescan</strong>. Custom skills arrive <strong>disabled</strong> — review,
             then enable them before they can air.
           </div>
+          <a
+            href="/manual/skills"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-2 inline-block text-[11px] font-bold text-vermilion underline decoration-[1.5px] underline-offset-2"
+          >
+            Read this in the manual ↗
+          </a>
         </div>
         <div className="flex items-center gap-4 bg-[var(--ink-softer)] p-3.5">
           <span className="caption">{skills.length} skill{skills.length === 1 ? '' : 's'}</span>

--- a/web/components/manual/ModelsAndTokens.tsx
+++ b/web/components/manual/ModelsAndTokens.tsx
@@ -20,6 +20,37 @@ export default function ModelsAndTokens() {
           Switching reroutes every call immediately, with no redeploy.
         </p>
         <p>
+          &ldquo;On your own hardware&rdquo; isn't only Ollama — there are three local
+          paths, all keyless and all private to your box:
+        </p>
+        <ul className="bs-list">
+          <li>
+            <strong>Ollama</strong> — the default. One install, pull a model, done.
+          </li>
+          <li>
+            <strong>locca</strong> — a first-class, one-command local model server
+            (<code>locca serve &lt;model&gt;</code>) built on llama.cpp. No key, a sensible
+            host default, and the onboarding wizard can detect it for you.{' '}
+            <a
+              href="https://github.com/perminder-klair/locca"
+              className="bs-link"
+              target="_blank"
+              rel="noreferrer"
+            >
+              locca on GitHub ↗
+            </a>
+          </li>
+          <li>
+            <strong>OpenAI-compatible</strong> — any self-hosted server that speaks the
+            OpenAI API (llama.cpp, vLLM, LM Studio); you supply its URL.
+          </li>
+        </ul>
+        <p>
+          Thinking models are handled for you: with <strong>Reasoning off</strong> the
+          station tells a local model to skip its internal monologue, so a small model
+          stays fast and on-task (more on that below).
+        </p>
+        <p>
           Big hosted models are more capable but cost money per token; small local models
           are free to run but need a lighter workload to stay coherent. The settings
           below let you match the station to the model: run it <em>lean</em> for a small
@@ -123,6 +154,47 @@ export default function ModelsAndTokens() {
           lighter path the default rather than the exception.
         </p>
       </div>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">A SECOND, SMALLER MODEL</p>
+        <h2>How the DJ knows each track's mood.</h2>
+        <p>
+          The DJ picks partly by <em>mood</em> — mellow mornings, brighter afternoons, a
+          wind-down late at night. To know each track's mood it leans on the{' '}
+          <strong>library tagger</strong>, which uses a second, much smaller{' '}
+          <strong>embedding model</strong> — not the chat model that writes the show.
+        </p>
+        <p>
+          Rather than ask the chat model about every track (slow and expensive on a big
+          library), the tagger embeds each track once, has the chat model tag a small,
+          representative <strong>seed set</strong>, then <strong>propagates</strong> moods
+          and energy out to everything else by similarity. That's roughly ten times fewer
+          model calls than tagging track by track.
+        </p>
+        <p>
+          By default the embedding model <strong>follows your LLM provider</strong>, so
+          there's usually nothing extra to set up — an Ollama-local station gets{' '}
+          <code>nomic-embed-text</code> for free. Two things are worth knowing if you
+          stray from that:
+        </p>
+        <ul className="bs-list">
+          <li>
+            <strong>Anthropic has no embedding model</strong> — if your DJ runs on Claude,
+            point embeddings at Ollama or OpenAI instead.
+          </li>
+          <li>
+            <strong>locca and OpenAI-compatible need a dedicated embedding server</strong> —
+            one llama.cpp process can't serve chat and embeddings at once. With locca that's
+            a second command, <code>locca embed</code>, on its own port; the console can
+            detect it for you.
+          </li>
+        </ul>
+        <p>
+          It all lives under <strong>Admin &rarr; Library tagger</strong>, and you can see
+          the tagged library laid out in{' '}
+          <Link href="/manual/observatory" className="bs-link">Library Observatory</Link>.
+        </p>
+      </section>
 
       <section className="bs-section">
         <p className="bs-eyebrow">WHERE TO SET THEM</p>


### PR DESCRIPTION
## What

The manual's **Models & tokens** page (`/manual/llm`) was out of date and the admin screens had no contextual way back into the manual. This fixes both.

### Manual (`web/components/manual/ModelsAndTokens.tsx`)
- **locca + local options**: "The root choice" now spells out the three local-model paths — **Ollama** (default), **locca** (`locca serve <model>`, one command, onboarding-detectable, links to locca on GitHub), and **OpenAI-compatible** (you supply the URL) — plus a note that reasoning-off makes local models skip their `<think>` step.
- **New "A second, smaller model" section** on embeddings / the library tagger: that it uses a separate small embedding model (not the chat model), how embed-once → seed-tag → KNN-propagate works (~10× fewer model calls), that it follows the LLM provider by default (`nomic-embed-text` free on Ollama), and the two gotchas — Anthropic has no embedding model, and locca/OpenAI-compatible need a dedicated embed server (`locca embed`, separate port).

### Admin → manual deep-links
Contextual "read this in the manual" links that open in a **new tab** (so unsaved form state survives), reusing the existing inline link style:
- `SettingsPanel.tsx`: optional `manualHref`/`manualLabel` on the shared `SectionHeader` → **LLM provider** & **Library tagger** to `/manual/llm`, **Theme** to `/manual/themes`.
- `SkillsPanel.tsx`: Skills hero → `/manual/skills`.

## Why
Operators configuring locca or the embedding-based library tagger had no in-product explanation; the facts only lived in code + field hints. The manual now documents every way to run the brain and how tagging works, and each admin screen points to the matching page.

## Verification
- `cd web && npm run lint` (eslint + `tsc --noEmit`) passes — exit 0.
- Content-only JSX additions matching existing manual/admin patterns; no controller changes.