### PR TITLE
feat(stations): add 2618 Home Radio to the directory

### DIFF
--- a/web/content/stations/2618-home-radio.json
+++ b/web/content/stations/2618-home-radio.json
@@ -1,0 +1,8 @@
+{
+  "name": "2618 Home Radio",
+  "url": "https://radio.nirachetahomelab.org",
+  "operator": "@_veteris",
+  "genre": "rock / techno",
+  "featured": false,
+  "submitted": "2026-06-18"
+}


### PR DESCRIPTION
Adds **2618 Home Radio** — a self-hosted SUB/WAVE station operated by `@_veteris` — to the public `/stations` directory.

- **URL:** https://radio.nirachetahomelab.org (live, on-air, CORS-open — the directory's `/api/now-playing` probe will show the ON AIR badge + current track)
- **Operator:** `@_veteris`
- **Genre:** rock / techno

One new file: `web/content/stations/2618-home-radio.json` (slug `2618-home-radio`).

Location / coordinates intentionally left blank — the station still lists, it just won't be plotted on the world map until a city + lat/lon are added.