### PR TITLE
fix(stations): plot 2618 Home Radio + correct Millennial FM pin

### DIFF
--- a/web/content/stations/2618-home-radio.json
+++ b/web/content/stations/2618-home-radio.json
@@ -2,6 +2,10 @@
   "name": "2618 Home Radio",
   "url": "https://radio.nirachetahomelab.org",
   "operator": "@_veteris",
+  "location": "Texas, United States",
+  "country": "United States",
+  "lat": 30.2672,
+  "lon": -97.7431,
   "genre": "rock / techno",
   "featured": false,
   "submitted": "2026-06-18"

--- a/web/content/stations/millennial-fm.json
+++ b/web/content/stations/millennial-fm.json
@@ -5,7 +5,7 @@
   "location": "Miami, FL",
   "country": "United States",
   "lat": 25.7617,
-  "lon": 80.1918,
+  "lon": -80.1918,
   "genre": "Millennial Mixed Hits",
   "description": "Mixed genre hits of the late 70's through 2010 served for the millennial looking for a nostalgic trip down memory lane",
   "featured": false,


### PR DESCRIPTION
## What

Two fixes to the stations directory so the map plots every station correctly.

- **2618 Home Radio** — had no `lat`/`lon`, so it showed in the directory list but was never plotted (the map filters to stations with finite coordinates). Added coordinates (Austin, central Texas) plus `location` and `country`.
- **Millennial FM** — longitude was `80.1918` (positive), which placed its pin in the Indian Ocean off India. Flipped to `-80.1918` so it sits in Miami.

## Why

The directory showed 5 stations but the map only rendered 4 (2618 missing coords), and Millennial FM's pin was in the wrong hemisphere.

## Result

All 5 stations now plot in the right place.

## Note

2618 Home Radio's submission only said "Texas" with no city, so I used Austin's coordinates as a central, recognizable point and labelled it "Texas, United States". Easy to refine to a specific city if the operator (@_veteris) has one.