### PR TITLE
fix(admin): make "Custom voice id…" selectable for cloud TTS voices

### DIFF
--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -1221,9 +1221,9 @@ export default function PersonasPanel() {
                         <Select
                           value={isPreset ? voice : '__custom__'}
                           onValueChange={val => {
-                            if (val !== '__custom__') {
-                              setPersonaTts(safeIdx, { voice: val });
-                            }
+                            // "Custom voice id…" clears the preset so isPreset flips
+                            // false and the free-text input below appears for entry.
+                            setPersonaTts(safeIdx, { voice: val === '__custom__' ? '' : val });
                           }}
                         >
                           <SelectTrigger><SelectValue /></SelectTrigger>

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -1487,9 +1487,9 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
                     <Select
                       value={isPreset ? voice : '__custom__'}
                       onValueChange={val => {
-                        if (val !== '__custom__') {
-                          setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, voice: val } } }));
-                        }
+                        // "Custom voice id…" clears the preset so isPreset flips
+                        // false and the free-text input below appears for entry.
+                        setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, voice: val === '__custom__' ? '' : val } } }));
                       }}
                     >
                       <SelectTrigger><SelectValue /></SelectTrigger>


### PR DESCRIPTION
## What

The cloud TTS **Default voice** (Settings → TTS Voice) and **Cloud voice** (Personas) dropdowns offered a **"Custom voice id…"** option, but clicking it did nothing — operators couldn't enter their own ElevenLabs/OpenAI voice ids.

## Why it was broken

The `<Select>`'s `onValueChange` explicitly ignored the `__custom__` value:

```js
onValueChange={val => { if (val !== '__custom__') { setVoice(val); } }}
```

The free-text input only renders when the current voice isn't a curated preset (`!isPreset`). But the default voice is *always* a preset, so selecting "Custom voice id…" was a no-op: `voice` never changed, `isPreset` stayed `true`, and the input never appeared.

## Fix

Selecting "Custom voice id…" now clears the voice to `''`, flipping it out of preset mode so the already-built, red-bordered "Enter a custom voice id" input appears for entry. Applied in both:

- `web/components/admin/SettingsPanel.tsx` — global Cloud-engine default voice
- `web/components/admin/PersonasPanel.tsx` — per-persona voice

Covers both ElevenLabs and OpenAI (shared dropdown). The backend already accepted any 1–100 char voice id, so no controller changes were needed.

## Verification

- `npm run lint` (`eslint . && tsc --noEmit`) passes clean.
- Tested live in a worktree dev stack: selecting "Custom voice id…" reveals the input, typing a custom id saves, and it persists to `state/settings.json` (`tts.cloud.voice`).