### PR TITLE
docs(manual): recommend Gemma 4 12B as the local sweet spot

### DIFF
--- a/web/app/manual/faq/page.tsx
+++ b/web/app/manual/faq/page.tsx
@@ -19,7 +19,7 @@ const FAQ = [
   },
   {
     q: 'Does it work with a small model?',
-    a: 'Yes. The AI DJ does not need a frontier model; a modest local one is plenty. A 9B-class model such as Qwen3.5 9B comfortably picks tracks and writes the DJ’s lines when run on lean settings: reasoning off, the simpler track-picker, and concise scripts.',
+    a: 'Yes. The AI DJ does not need a frontier model; a modest local one is plenty. A 9B-class model such as Qwen3.5 9B comfortably picks tracks and writes the DJ’s lines when run on lean settings: reasoning off, the simpler track-picker, and concise scripts. A 12B-class model like Gemma 4 12B is the comfortable sweet spot — capable enough to run the full conversational picker agent on your own hardware while still costing nothing per token.',
   },
   {
     q: 'What is mood tagging?',

--- a/web/components/manual/Faq.tsx
+++ b/web/components/manual/Faq.tsx
@@ -33,7 +33,10 @@ export default function Faq() {
           your own hardware is plenty. A 9B-class local model such as Qwen3.5 9B
           comfortably picks tracks and writes the DJ&rsquo;s lines, as long as you run the
           station on its <em>lean</em> settings: reasoning off, the simpler track-picker,
-          concise scripts. The full set of dials, and what to turn which way, is on the{' '}
+          concise scripts. Step up to a 12B-class model like <strong>Gemma 4 12B</strong>{' '}
+          and you can leave the richer dials on &mdash; including the full picker agent
+          &mdash; while still paying nothing per token. The full set of dials, and what to
+          turn which way, is on the{' '}
           <Link href="/manual/llm" className="bs-link">Models &amp; Tokens</Link> page.
         </p>
       </section>

--- a/web/components/manual/ModelsAndTokens.tsx
+++ b/web/components/manual/ModelsAndTokens.tsx
@@ -56,6 +56,16 @@ export default function ModelsAndTokens() {
           below let you match the station to the model: run it <em>lean</em> for a small
           or metered model, or <em>rich</em> for a large capable one.
         </p>
+        <p>
+          If you want a single recommendation, a 12B-class local model such as{' '}
+          <strong>Gemma 4 12B</strong> is the sweet spot — serve it with{' '}
+          <code>locca serve gemma4</code>, or as <code>gemma4:12b</code> on Ollama. It's
+          free and private on your own box, yet capable enough to run the station's{' '}
+          <em>richest</em> setting — the full conversational picker agent — without falling
+          over. A smaller 9B-class model still works on lean settings, and a large hosted
+          model buys you more headroom again; Gemma 4 12B is the comfortable middle that
+          most stations should reach for first.
+        </p>
       </section>
 
       <section className="bs-section">
@@ -68,10 +78,13 @@ export default function ModelsAndTokens() {
         </p>
         <p>
           With these settings in place, a small model runs the whole station
-          comfortably: a 9B-class local model such as{' '}
+          comfortably: even a 9B-class local model such as{' '}
           <strong>Qwen3.5 9B</strong> is plenty for picking tracks and writing the DJ's
           lines. The lean profile keeps each request short and well-shaped, which is
-          exactly what a smaller model needs to stay reliable.
+          exactly what a smaller model needs to stay reliable. Step up one size to a
+          12B-class model like <strong>Gemma 4 12B</strong> and you can leave more of the
+          rich dials on — including the picker agent — while still paying nothing per
+          token.
         </p>
         <ul className="bs-list">
           <li>
@@ -132,7 +145,9 @@ export default function ModelsAndTokens() {
             <strong>Picker agent on</strong> (Admin &rarr; LLM) — the full conversational
             DJ: it remembers the session, reasons about what it has already played, and
             uses tools to dig through the library. Richer and more coherent, but it leans
-            on the model being capable.
+            on the model being capable. You don't need a hosted model for it, though — a
+            tool-capable 12B-class local model like <strong>Gemma 4 12B</strong> runs the
+            agent reliably on your own hardware.
           </li>
           <li>
             <strong>Extended scripts</strong> (Admin &rarr; Personas) — a storytelling DJ

--- a/web/components/setup/Prerequisites.tsx
+++ b/web/components/setup/Prerequisites.tsx
@@ -46,7 +46,8 @@ export default function Prerequisites() {
             <p>
               The DJ's words and track picks come from a language model. The
               homelab default is <strong>Ollama</strong> with a tool-capable model
-              (qwen3.5, qwen3.6, or gemma4 all work). Note the URL and model name.
+              (<code>gemma4:12b</code> is a great pick; qwen3.5 and qwen3.6 also work).
+              Note the URL and model name.
               Prefer a hosted model? Anthropic, OpenAI, Google, OpenRouter, and
               DeepSeek are all supported; you pick the provider and supply its key
               in the admin Settings UI after install, not during setup.{' '}


### PR DESCRIPTION
## What

Recommends **Gemma 4 12B** as the go-to local model for the AI DJ across the docs surface.

## Why

The docs previously framed the picker agent as something to *turn off* for local/small models, with Qwen3.5 9B as the example. In practice a 12B-class local model runs the **full conversational picker agent** reliably on its own hardware — so it bridges the lean/rich split rather than forcing the agent off. Worth calling out as the sweet spot most stations should reach for first.

## Changes

- **`web/components/manual/ModelsAndTokens.tsx`** — added a headline recommendation in the root-choice section; lean section notes stepping up to 12B lets you keep more rich dials on; the "Picker agent on" bullet notes you don't need a hosted model for it.
- **`web/app/manual/faq/page.tsx`** + **`web/components/manual/Faq.tsx`** — the "Does it work with a small model?" answer now names Gemma 4 12B as the sweet spot that handles the full agent locally.
- **`web/components/setup/Prerequisites.tsx`** — bumped `gemma4:12b` to the recommended pick.

Provider-neutral: the headline mentions both `locca serve gemma4` and `gemma4:12b` on Ollama.

## Verification

`npm run lint` (eslint + tsc) passes clean. Docs-only change.

https://claude.ai/code/session_0111i8BrgTTntw9EGhT9MGUu