### PR TITLE
fix(requests): sanitize listener request text against prompt injection

### DIFF
--- a/controller/src/routes/request.ts
+++ b/controller/src/routes/request.ts
@@ -23,6 +23,30 @@ export const router = express.Router();
 
 const shuffle = (arr) => [...arr].sort(() => Math.random() - 0.5);
 
+// Neutralize prompt-injection markup in listener-supplied request text before
+// it's stored, logged, displayed, or fed to the LLM. A song request is short
+// natural language ("play Diljit latest", "rainy day vibes") — it never legibly
+// contains instruction-shaped markup, so stripping it can't hurt a real request
+// but defangs attempts to smuggle directives to the DJ agent (the raw text is
+// posted verbatim as a session turn and aired as free-text patter). This is a
+// belt — the prompt framing still treats the text as data — not the only layer.
+function sanitizeRequestText(raw: string): string {
+  return String(raw ?? '')
+    // chat/template role + instruction tokens (Llama/Mistral/ChatML style)
+    .replace(/\[\/?INST\]|<<\/?SYS>>|<\|[^|>]*\|>/gi, ' ')
+    // any HTML/XML-ish tag, e.g. <project_instructions> … </project_instructions>
+    .replace(/<\/?[a-z][^>]*>/gi, ' ')
+    // leading role markers that fake a new turn ("system:", "assistant:")
+    .replace(/^[ \t]*(system|assistant|developer)\s*:/gim, ' ')
+    // the unambiguous "ignore/disregard the previous instructions" family
+    .replace(/\b(ignore|disregard|forget|override)\b[^.!?\n]*\b(previous|prior|above|earlier|all)\b[^.!?\n]*\binstructions?\b/gi, ' ')
+    // double quotes would let the text break out of the "${text}" framing
+    .replace(/"/g, "'")
+    // collapse the multi-line "instruction block" shape into one line
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 // ---------------------------------------------------------------------------
 // In-memory request ledger. Each POST /request mints an entry; the background
 // resolver mutates it; GET /request/:id reads it. Ephemeral by design — a
@@ -550,7 +574,7 @@ router.post('/request', async (req, res) => {
 
   const rawText = typeof req.body?.text === 'string' ? req.body.text : '';
   const rawName = typeof req.body?.name === 'string' ? req.body.name : '';
-  const text = rawText.trim().slice(0, REQUEST_TEXT_MAX);
+  const text = sanitizeRequestText(rawText).slice(0, REQUEST_TEXT_MAX);
   if (!text) {
     return res.status(400).json({ error: 'Empty request' });
   }


### PR DESCRIPTION
## What

Adds `sanitizeRequestText()` to the `POST /request` ingest path so listener-supplied request text is scrubbed of prompt-injection markup before it is stored, logged, displayed, or fed to the LLM.

## Why

A real request came through crafted as a fake `<project_instructions>` block (the ENI/LO jailbreak persona pattern). Listener text is capped at 280 chars but otherwise stored verbatim and posted as a session turn that the DJ agent reads as chat history — and the agent emits free-text patter (`ack`/`introScript`) that airs via TTS and shows in the UI. That request had no effect this time, but the markup reached the agent's message window, which is the surface worth closing.

## How

A single deterministic, model-free scrub applied once at the ingest point (`request.ts`), so it protects every downstream consumer — storage, `requests.log`, the UI, the session turn, and both the `matchRequest` and session-agent paths. It strips:

- chat/template role tokens — `[INST]`/`[/INST]`, `<<SYS>>`, `<|…|>`
- any HTML/XML-ish tag — `<project_instructions>…</project_instructions>` etc.
- fake turn markers at line start — `system:`, `assistant:`, `developer:`
- the unambiguous "ignore/disregard/override the previous instructions" family
- double quotes → single quotes (so text can't break out of the `"${text}"` framing)
- collapses the multi-line "instruction block" shape into one line

Real song requests are short natural language (`play Diljit latest`, `rainy day vibes`, `play "Kundi" by …`) and pass through untouched.

## Scope / non-goals

This is the **markup-layer** defense. It deliberately does not try to semantically detect persona prose ("you are now …"); that residual is handled by the existing data-framing (`Listener "x" requests: "..."`). A prompt-level data-vs-instructions rule was considered and intentionally left out of this PR.

## Test

- `cd controller && npm run lint` — 0 errors (pre-existing `any` warnings only).
- Verified the real attack string is reduced to inert words and that legit requests are unchanged.