### PR TITLE
feat(player): show cumulative LLM token count by the now-playing time

### DIFF
--- a/controller/src/llm/internal/telemetry/log.ts
+++ b/controller/src/llm/internal/telemetry/log.ts
@@ -12,9 +12,20 @@ import { logEvent, cap } from '../../../observability/events.js';
 const MAX_CALLS = 120;
 export const recentCalls: any[] = [];
 
+// Monotonic, since-boot sum of tokens reported by successful calls. Unlike the
+// ring buffer above (a rolling window of the last MAX_CALLS calls), this only
+// ever climbs — it backs the listener-facing token ticker on the player. Reset
+// to 0 on restart by design, like every other in-memory stat (see stats.ts).
+let lifetimeTokens = 0;
+export function lifetimeTokenCount() {
+  return lifetimeTokens;
+}
+
 export function record(call: any) {
   recentCalls.unshift(call);
   if (recentCalls.length > MAX_CALLS) recentCalls.length = MAX_CALLS;
+  // Mirror summarizeLlm: only successful calls that report usage contribute.
+  if (call.ok && call.usage?.total) lifetimeTokens += call.usage.total;
 
   // Durable, trace-correlated event. The ring buffer above is lost on restart
   // and uncorrelated; this lands on the unified events.jsonl timeline.

--- a/controller/src/llm/log.ts
+++ b/controller/src/llm/log.ts
@@ -2,4 +2,4 @@
 // in internal/telemetry/log.ts. Barrel so call sites keep importing from
 // `llm/log.js` unchanged.
 
-export { recentCalls, record, recordPick } from './internal/telemetry/log.js';
+export { recentCalls, record, recordPick, lifetimeTokenCount } from './internal/telemetry/log.js';

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -14,6 +14,7 @@ import { getStreamStatus } from '../broadcast/listeners.js';
 import { getSetupStatusSync } from '../setup/firstRun.js';
 import { getStationTimezone } from '../time.js';
 import { listThemes, DEFAULT_THEME_ID } from '../themes.js';
+import { lifetimeTokenCount } from '../llm/log.js';
 
 export const router = express.Router();
 
@@ -193,6 +194,10 @@ router.get('/now-playing', async (req, res) => {
       listeners: stream.listeners,
       streamOnline: stream.online,
       streamBitrate: stream.bitrate,
+      // Cumulative since-boot LLM token total — drives the listener-facing
+      // token ticker next to the now-playing time. Aggregate integer only; no
+      // model/cost breakdown (that stays on the admin-gated /stats surface).
+      llmTokens: lifetimeTokenCount(),
       // The station's IANA zone. The DJ speaks the time in this zone (time.ts),
       // so on-air log timestamps in the UI must be rendered in it too — else an
       // operator/listener viewing from another zone sees stamps that disagree

--- a/web/components/CenterStage.tsx
+++ b/web/components/CenterStage.tsx
@@ -2,11 +2,13 @@
 
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { AnimatePresence, m } from 'motion/react';
+import { Coins } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { fmtTime } from '@/lib/format';
 import { useDynamicStyle } from '@/hooks/useDynamicStyle';
 import { useElapsed } from '@/hooks/useElapsed';
 import DjThinkingLine from './DjThinkingLine';
+import CountUp from './CountUp';
 import { Ripple } from './ui/ripple';
 import { isDjTurn } from '@/lib/sessionFeed';
 import { useStationOrigin } from '@/lib/stationOrigin';
@@ -39,13 +41,15 @@ export interface CenterStageProps {
   nowPlaying: NowPlayingTrack | null;
   /** Epoch ms when the current track started (from useStationFeed). */
   trackStartedAt: number | null;
+  /** Cumulative since-boot LLM token total, or null before the first poll. */
+  llmTokens: number | null;
   feed: SessionTurn[];
   djLineOn: boolean;
   onOpenBooth: () => void;
   onOpenTimeline: () => void;
 }
 
-export default memo(function CenterStage({ nowPlaying, trackStartedAt, feed, djLineOn, onOpenBooth, onOpenTimeline }: CenterStageProps) {
+export default memo(function CenterStage({ nowPlaying, trackStartedAt, llmTokens, feed, djLineOn, onOpenBooth, onOpenTimeline }: CenterStageProps) {
   const { apiUrl } = useStationOrigin();
   // The 1s elapsed tick lives here, in the component that displays it, so it
   // only re-renders this subtree — not the whole player (see useElapsed).
@@ -150,6 +154,19 @@ export default memo(function CenterStage({ nowPlaying, trackStartedAt, feed, djL
         <div className="min-w-0">
           <div className="v3-caption mb-[14px] text-muted">
             Now playing{has && duration ? ` — ${fmtTime(elapsed)} / ${fmtTime(duration)}` : has ? ` — ${fmtTime(elapsed)}` : ''}
+            {llmTokens != null && (
+              <>
+                {' · '}
+                <span
+                  className="inline-flex items-center gap-1 align-middle text-muted"
+                  title="LLM tokens generated since the station booted"
+                  aria-label={`${llmTokens.toLocaleString('en-US')} AI tokens generated`}
+                >
+                  <Coins size={12} strokeWidth={1.75} aria-hidden="true" />
+                  <CountUp value={llmTokens} className="v3-tab-num" />
+                </span>
+              </>
+            )}
           </div>
           <AnimatePresence mode="popLayout" initial={false}>
             <m.div

--- a/web/components/CountUp.tsx
+++ b/web/components/CountUp.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { animate } from 'motion/react';
+
+interface CountUpProps {
+  value: number;
+  className?: string;
+}
+
+// Honour reduced-motion at call time (a mid-session setting change is respected)
+// — matches the pattern in TransportBar.
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+// A number that smoothly climbs from its previous value to the next, rendered
+// with thousands separators (en-US, fixed so it doesn't drift with the
+// browser locale). Unlike OdometerNumber (a whole-value digit swap), this
+// tweens through the in-between integers — the right feel for a large, slowly
+// rising counter like the LLM token total polled every ~5s.
+export default function CountUp({ value, className }: CountUpProps) {
+  const [display, setDisplay] = useState(value);
+  // Seed with the first value so mount snaps to it rather than sweeping 0 → N.
+  const prevRef = useRef(value);
+
+  useEffect(() => {
+    const from = prevRef.current;
+    prevRef.current = value;
+    if (from === value) return;
+    if (prefersReducedMotion()) {
+      setDisplay(value);
+      return;
+    }
+    const controls = animate(from, value, {
+      duration: 0.9,
+      ease: [0.2, 0.7, 0.2, 1],
+      onUpdate: (v) => setDisplay(Math.round(v)),
+    });
+    return () => controls.stop();
+  }, [value]);
+
+  return (
+    <span className={className} aria-live="polite">
+      {display.toLocaleString('en-US')}
+    </span>
+  );
+}

--- a/web/components/PlayerApp.tsx
+++ b/web/components/PlayerApp.tsx
@@ -48,7 +48,7 @@ export interface PlayerAppProps {
 
 export default function PlayerApp({ contained = false }: PlayerAppProps) {
   const { apiUrl } = useStationOrigin();
-  const { nowPlaying, context, dj, activeShow, listeners, streamOnline, state, session, trackStartedAt, timezone } = useStationFeed();
+  const { nowPlaying, context, dj, activeShow, listeners, streamOnline, llmTokens, state, session, trackStartedAt, timezone } = useStationFeed();
   const boothFeed = session.messages;
   const { audioRef, tunedIn, status, volume, setVolume, tune, stop, toggleMute, muted, idleStopped } = usePlayer();
 
@@ -285,6 +285,7 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
       <CenterStage
         nowPlaying={nowPlaying}
         trackStartedAt={trackStartedAt}
+        llmTokens={llmTokens}
         feed={boothFeed}
         djLineOn={tickerOn}
         onOpenBooth={openBooth}

--- a/web/hooks/useStationFeed.ts
+++ b/web/hooks/useStationFeed.ts
@@ -22,6 +22,8 @@ export interface StationFeed {
   listeners: ListenerCount | number | null;
   /** null until the first poll resolves — distinguishes "not yet known" from "offline". */
   streamOnline: boolean | null;
+  /** Cumulative since-boot LLM token total, or null before the first poll. */
+  llmTokens: number | null;
   state: StationState;
   session: SessionPayload;
   /** Epoch ms when the current track was first seen, null before the first
@@ -56,6 +58,7 @@ export function useStationFeed(): StationFeed {
   const [activeShow, setActiveShow] = useState<ActiveShow | null>(null);
   const [listeners, setListeners] = useState<ListenerCount | number | null>(null);
   const [streamOnline, setStreamOnline] = useState<boolean | null>(null);
+  const [llmTokens, setLlmTokens] = useState<number | null>(null);
   const [state, setState] = useState<StationState>(EMPTY_STATE);
   const [session, setSession] = useState<SessionPayload>(EMPTY_SESSION);
   const [trackStartedAt, setTrackStartedAt] = useState<number | null>(null);
@@ -82,6 +85,7 @@ export function useStationFeed(): StationFeed {
         setIfChanged(setActiveShow, npRes.activeShow ?? npRes.context?.activeShow ?? null);
         if (npRes.listeners != null) setIfChanged<ListenerCount | number | null>(setListeners, npRes.listeners);
         if (typeof npRes.streamOnline === 'boolean') setStreamOnline(npRes.streamOnline);
+        if (typeof npRes.llmTokens === 'number') setIfChanged<number | null>(setLlmTokens, npRes.llmTokens);
         if (typeof npRes.timezone === 'string' && npRes.timezone) setTimezone(npRes.timezone);
         setIfChanged(setState, stRes);
         if (seRes && Array.isArray(seRes.messages)) setIfChanged(setSession, seRes);
@@ -90,5 +94,5 @@ export function useStationFeed(): StationFeed {
     return pollWhileVisible(() => { void tick(); }, 5000);
   }, [apiUrl]);
 
-  return { nowPlaying, context, dj, activeShow, listeners, streamOnline, state, session, trackStartedAt, timezone };
+  return { nowPlaying, context, dj, activeShow, listeners, streamOnline, llmTokens, state, session, trackStartedAt, timezone };
 }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -115,6 +115,8 @@ export interface NowPlayingResponse {
   streamOnline?: boolean;
   /** kbps of the first attached broadcast mount; null when offline. */
   streamBitrate?: number | null;
+  /** Cumulative since-boot LLM token total — the player's token ticker. */
+  llmTokens?: number | null;
   /** Station IANA timezone — render on-air timestamps in it (issue #418). */
   timezone?: string;
 }


### PR DESCRIPTION
## What

Surfaces the **LLM token usage** count — previously admin-only on `/admin/stats` — to listeners on the player, as an animated number next to the now-playing timer:

> `NOW PLAYING — 0:24 · 🪙 14,600`

## Why

It's a fun, ambient signal of the AI DJ working in the background. The Stats figure itself isn't usable here: it's `requireAdmin`-gated **and** a rolling window of the last 120 calls (it can *decrease*), which reads badly as a ticker. So this adds a dedicated **cumulative since-boot counter** that only climbs.

## How

**Controller**
- `llm/internal/telemetry/log.ts` — module-level `lifetimeTokens` accumulator, incremented in `record()` on successful calls that report `usage.total` (mirrors `summarizeLlm`); exported as `lifetimeTokenCount()`.
- `llm/log.ts` — re-exported through the barrel.
- `routes/public.ts` — `GET /now-playing` returns `llmTokens` beside `listeners`/`streamOnline`. **Aggregate integer only** — no model names, cost, or per-kind breakdown, so nothing admin-only leaks onto the public surface.

**Web**
- `lib/types.ts` + `hooks/useStationFeed.ts` — `llmTokens` threaded through, mirroring the existing `listeners` pattern (re-render-suppressed via `setIfChanged`).
- `components/CountUp.tsx` (new) — smooth count-up via `motion/react`'s `animate`, reduced-motion aware, comma-grouped with `toLocaleString('en-US')`. Seeds to the first value so it doesn't sweep 0→N on mount. (Distinct from `OdometerNumber`, which is a whole-value digit swap — wrong fit for a large climbing number.)
- `components/CenterStage.tsx` — rendered after the now-playing time with a `Coins` icon in the muted caption tone; `title`/`aria-label` keep "tokens" for hover + screen readers.

## Notes

- Counter is **since-boot** — resets to 0 on controller restart, consistent with the existing in-memory telemetry design (`stats.ts`: "reports activity since boot, nothing durable").
- Native app (`app/`) is out of scope.

## Verification

- `npm run lint` (eslint + `tsc --noEmit`) green in both `controller/` and `web/`.
- Ran the dev stack: `GET /now-playing` returns `llmTokens` and it only increases across polls; the player renders the comma-grouped number next to the timer and animates upward each ~5s feed poll. Previewed a large value (`501,800`) — fits comfortably beside the timer. Reduced-motion snaps instead of tweening.
