### PR TITLE
release: player LLM token counter + listener/request hardening

### DIFF
--- a/controller/src/broadcast/listeners.ts
+++ b/controller/src/broadcast/listeners.ts
@@ -4,10 +4,15 @@
 // broadcast mounts (/stream.mp3 + /stream.opus), so the DJ gates can ask "is
 // anyone listening?" without each one hitting Icecast.
 //
-// The count is *deduped by IP+user-agent* (see dedupeListeners): Safari opens
-// two identical connections per client, so a raw sum double-counts every Apple
-// listener. That dedup needs the per-connection admin feed (/admin/listclients);
-// the public status-json.xsl still supplies online/bitrate and the fallback sum
+// The count *folds Safari's double connection* into one (see groupConnections /
+// dedupeListeners): iOS/macOS Safari opens two identical sockets per client, so
+// a raw sum double-counts every Apple listener. We can't key on IP — behind a
+// reverse proxy (Caddy → Icecast) every connection carries the proxy's IP, not
+// the listener's, and icecast-KH ignores X-Forwarded-For, so the real client IP
+// never reaches Icecast. Instead we count every non-Safari socket as a listener
+// and pair Safari's two near-simultaneous sockets by user-agent + connect-time.
+// That dedup needs the per-connection admin feed (/admin/listclients); the
+// public status-json.xsl still supplies online/bitrate and the fallback sum
 // when the admin endpoint is unavailable.
 //
 // Fail-open: if Icecast is unreachable the count is null and djCallsAllowed()
@@ -257,39 +262,72 @@ function parseListClients(xml: string, mount: string): ListenerConnection[] {
   return out;
 }
 
-// Collapse Safari/AppleCoreMedia's duplicate connections into one listener.
-// iOS and macOS Safari open *two* identical sockets to a live Icecast mount per
-// client (a fundamental AppleCoreMedia behaviour, confirmed upstream with no
-// client-side fix — see react-native-track-player #2096), which Icecast counts
-// as two listeners. Counting distinct IP+user-agent pairs folds those back into
-// one. Two genuinely-distinct devices sharing both a public IP *and* an
-// identical UA collapse too — rare, and a better failure mode than every Apple
-// visitor doubling the tally.
-export function dedupeListeners(conns: ListenerConnection[]): number {
-  const seen = new Set<string>();
-  for (const c of conns) seen.add(`${c.ip} ${c.userAgent}`);
-  return seen.size;
+// Max gap (seconds) between Safari's two sockets' Connected times for them to be
+// treated as the same listener's double. They open within the same second and
+// stay within ~1s of each other for the connection's life; 6s absorbs poll
+// jitter without bridging two genuinely separate joins.
+const DOUBLE_WINDOW_S = 6;
+
+// True when the user-agent is real Safari / AppleCoreMedia — the only clients
+// that open *two* identical sockets per listener (a fundamental AppleCoreMedia
+// behaviour, no client-side fix — see react-native-track-player #2096).
+// Chrome-on-Mac also carries the "Safari/537.36" token but is Blink and opens a
+// single socket, so it must NOT match: gate on "Version/" + "Safari" and exclude
+// the Chromium-family tokens.
+function isSafariDouble(ua: string): boolean {
+  if (/AppleCoreMedia/i.test(ua)) return true;
+  if (!/Safari/i.test(ua) || !/Version\//i.test(ua)) return false;
+  return !/(Chrome|CriOS|Chromium|Android|Edg|OPR)/i.test(ua);
 }
 
-// One row per distinct listener (IP+UA), matching the deduped count — for the
-// admin connections table, so Safari's duplicate socket shows as a single
-// listener rather than two rows. `connections` records how many raw sockets
-// folded in (Safari → 2); connectedSeconds is the longest-held of the group and
-// mount lists every mount the listener holds.
+// Number of distinct listeners — the headline count. Folds Safari's double
+// back into one (see groupConnections) without keying on IP, which is useless
+// behind a reverse proxy (every socket carries the proxy's IP). Single source of
+// truth with the admin table: both derive from groupConnections so they can't
+// drift apart.
+export function dedupeListeners(conns: ListenerConnection[]): number {
+  return groupConnections(conns).length;
+}
+
+// One row per distinct listener — for the admin connections table and the
+// headline count. Every non-Safari socket is its own listener (Chrome, Firefox,
+// Android, Sonos and hardware radios open exactly one socket each, so two
+// distinct listeners sharing the proxy IP — and even the same UA — both
+// count). Safari's two near-simultaneous sockets are paired into one row by
+// user-agent + connect-time. `connections` records how many raw sockets folded
+// in (Safari → 2); connectedSeconds is the longest-held of the group and mount
+// lists every mount the listener holds.
 export function groupConnections(conns: ListenerConnection[]): ListenerConnection[] {
-  const groups = new Map<string, ListenerConnection>();
-  for (const c of conns) {
-    const key = `${c.ip} ${c.userAgent}`;
-    const g = groups.get(key);
-    if (!g) {
-      groups.set(key, { ...c, connections: 1 });
-    } else {
-      g.connections = (g.connections ?? 1) + 1;
-      g.connectedSeconds = Math.max(g.connectedSeconds, c.connectedSeconds);
-      if (!g.mount.split(', ').includes(c.mount)) g.mount = `${g.mount}, ${c.mount}`;
+  const singles: ListenerConnection[] = [];
+  const safari: ListenerConnection[] = [];
+  for (const c of conns) (isSafariDouble(c.userAgent) ? safari : singles).push(c);
+
+  const out: ListenerConnection[] = singles.map(c => ({ ...c, connections: 1 }));
+
+  // Pair Safari sockets per mount: sort by Connected, greedily merge an adjacent
+  // socket within the window. Each real Apple listener is exactly two sockets, so
+  // for any even count this yields N/2 listeners regardless of pairing order; an
+  // odd leftover stands alone. Cap each group at 2 — Safari only ever doubles.
+  const byMount = new Map<string, ListenerConnection[]>();
+  for (const c of safari) {
+    const arr = byMount.get(c.mount) ?? [];
+    arr.push(c);
+    byMount.set(c.mount, arr);
+  }
+  for (const arr of byMount.values()) {
+    arr.sort((a, b) => b.connectedSeconds - a.connectedSeconds);
+    for (let i = 0; i < arr.length; i++) {
+      const cur = arr[i];
+      const next = arr[i + 1];
+      if (next && cur.connectedSeconds - next.connectedSeconds <= DOUBLE_WINDOW_S) {
+        out.push({ ...cur, connections: 2 });
+        i++; // consume the paired socket
+      } else {
+        out.push({ ...cur, connections: 1 });
+      }
     }
   }
-  return [...groups.values()];
+  return out;
 }
 
 // Live per-listener connections across both broadcast mounts. Returns [] when

--- a/controller/src/llm/internal/telemetry/log.ts
+++ b/controller/src/llm/internal/telemetry/log.ts
@@ -12,9 +12,20 @@ import { logEvent, cap } from '../../../observability/events.js';
 const MAX_CALLS = 120;
 export const recentCalls: any[] = [];
 
+// Monotonic, since-boot sum of tokens reported by successful calls. Unlike the
+// ring buffer above (a rolling window of the last MAX_CALLS calls), this only
+// ever climbs — it backs the listener-facing token ticker on the player. Reset
+// to 0 on restart by design, like every other in-memory stat (see stats.ts).
+let lifetimeTokens = 0;
+export function lifetimeTokenCount() {
+  return lifetimeTokens;
+}
+
 export function record(call: any) {
   recentCalls.unshift(call);
   if (recentCalls.length > MAX_CALLS) recentCalls.length = MAX_CALLS;
+  // Mirror summarizeLlm: only successful calls that report usage contribute.
+  if (call.ok && call.usage?.total) lifetimeTokens += call.usage.total;
 
   // Durable, trace-correlated event. The ring buffer above is lost on restart
   // and uncorrelated; this lands on the unified events.jsonl timeline.

--- a/controller/src/llm/log.ts
+++ b/controller/src/llm/log.ts
@@ -2,4 +2,4 @@
 // in internal/telemetry/log.ts. Barrel so call sites keep importing from
 // `llm/log.js` unchanged.
 
-export { recentCalls, record, recordPick } from './internal/telemetry/log.js';
+export { recentCalls, record, recordPick, lifetimeTokenCount } from './internal/telemetry/log.js';

--- a/controller/src/routes/dj.ts
+++ b/controller/src/routes/dj.ts
@@ -8,6 +8,7 @@ import { requireAdmin } from '../middleware/auth.js';
 import { queue } from '../broadcast/queue.js';
 import * as dj from '../llm/dj.js';
 import * as subsonic from '../music/subsonic.js';
+import * as library from '../music/library.js';
 import * as settings from '../settings.js';
 import { runStationId, runHourlyCheck, runLink, refreshAutoPlaylist } from '../broadcast/scheduler.js';
 import { skillCatalog, runCapability } from '../skills/_agent.js';
@@ -259,19 +260,29 @@ router.get('/dj/search', requireAdmin, async (req, res) => {
   const q = (typeof req.query?.q === 'string' ? req.query.q : '').trim();
   if (!q) return res.status(400).json({ error: 'q is required' });
   try {
+    await library.load();
     const songs = await subsonic.search(q, { songCount: 12 });
-    const results = songs.map(s => ({
-      id: s.id,
-      title: s.title,
-      artist: s.artist,
-      album: s.album,
-      year: s.year ?? null,
-      genre: s.genre ?? null,
-      duration: s.duration ?? null,
-      // path lets getLocalPath() use the on-disk file when MUSIC_LIBRARY_PATH
-      // is mounted, matching how listener-requested tracks are queued.
-      path: s.path ?? null,
-    }));
+    const results = songs.map(s => {
+      const tag = library.get(s.id);
+      return {
+        id: s.id,
+        title: s.title,
+        artist: s.artist,
+        album: s.album,
+        year: s.year ?? null,
+        genre: s.genre ?? null,
+        duration: s.duration ?? null,
+        // path lets getLocalPath() use the on-disk file when MUSIC_LIBRARY_PATH
+        // is mounted, matching how listener-requested tracks are queued.
+        path: s.path ?? null,
+        // Merge stored tags so the admin table shows real mood/energy status
+        // instead of "needs tags" for every row (the index is the only other
+        // source of tags — Subsonic metadata carries none).
+        moods: tag?.moods ?? [],
+        energy: tag?.energy ?? null,
+        source: tag?.source ?? null,
+      };
+    });
     res.json({ results });
   } catch (err) {
     queue.log('error', `/dj/search failed: ${err.message}`);
@@ -287,20 +298,29 @@ router.get('/dj/search', requireAdmin, async (req, res) => {
 router.get('/dj/recent', requireAdmin, async (req, res) => {
   const limit = Math.min(Math.max(parseInt(String(req.query?.limit || ''), 10) || 20, 1), 50);
   try {
+    await library.load();
     const albums = await subsonic.getRecentlyAddedAlbums({ size: limit });
     const songLists = await Promise.all(
       albums.map((a: any) => subsonic.getAlbum(a.id).catch(() => [])),
     );
-    const results = songLists.flat().slice(0, limit).map((s: any) => ({
-      id: s.id,
-      title: s.title,
-      artist: s.artist,
-      album: s.album,
-      year: s.year ?? null,
-      genre: s.genre ?? null,
-      duration: s.duration ?? null,
-      path: s.path ?? null,
-    }));
+    const results = songLists.flat().slice(0, limit).map((s: any) => {
+      const tag = library.get(s.id);
+      return {
+        id: s.id,
+        title: s.title,
+        artist: s.artist,
+        album: s.album,
+        year: s.year ?? null,
+        genre: s.genre ?? null,
+        duration: s.duration ?? null,
+        path: s.path ?? null,
+        // Merge stored tags so recently-added tracks that are already tagged
+        // show their mood/energy instead of a misleading "needs tags".
+        moods: tag?.moods ?? [],
+        energy: tag?.energy ?? null,
+        source: tag?.source ?? null,
+      };
+    });
     res.json({ results });
   } catch (err) {
     queue.log('error', `/dj/recent failed: ${err.message}`);

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -14,6 +14,7 @@ import { getStreamStatus } from '../broadcast/listeners.js';
 import { getSetupStatusSync } from '../setup/firstRun.js';
 import { getStationTimezone } from '../time.js';
 import { listThemes, DEFAULT_THEME_ID } from '../themes.js';
+import { lifetimeTokenCount } from '../llm/log.js';
 
 export const router = express.Router();
 
@@ -193,6 +194,10 @@ router.get('/now-playing', async (req, res) => {
       listeners: stream.listeners,
       streamOnline: stream.online,
       streamBitrate: stream.bitrate,
+      // Cumulative since-boot LLM token total — drives the listener-facing
+      // token ticker next to the now-playing time. Aggregate integer only; no
+      // model/cost breakdown (that stays on the admin-gated /stats surface).
+      llmTokens: lifetimeTokenCount(),
       // The station's IANA zone. The DJ speaks the time in this zone (time.ts),
       // so on-air log timestamps in the UI must be rendered in it too — else an
       // operator/listener viewing from another zone sees stamps that disagree

--- a/controller/src/routes/request.ts
+++ b/controller/src/routes/request.ts
@@ -23,6 +23,30 @@ export const router = express.Router();
 
 const shuffle = (arr) => [...arr].sort(() => Math.random() - 0.5);
 
+// Neutralize prompt-injection markup in listener-supplied request text before
+// it's stored, logged, displayed, or fed to the LLM. A song request is short
+// natural language ("play Diljit latest", "rainy day vibes") — it never legibly
+// contains instruction-shaped markup, so stripping it can't hurt a real request
+// but defangs attempts to smuggle directives to the DJ agent (the raw text is
+// posted verbatim as a session turn and aired as free-text patter). This is a
+// belt — the prompt framing still treats the text as data — not the only layer.
+function sanitizeRequestText(raw: string): string {
+  return String(raw ?? '')
+    // chat/template role + instruction tokens (Llama/Mistral/ChatML style)
+    .replace(/\[\/?INST\]|<<\/?SYS>>|<\|[^|>]*\|>/gi, ' ')
+    // any HTML/XML-ish tag, e.g. <project_instructions> … </project_instructions>
+    .replace(/<\/?[a-z][^>]*>/gi, ' ')
+    // leading role markers that fake a new turn ("system:", "assistant:")
+    .replace(/^[ \t]*(system|assistant|developer)\s*:/gim, ' ')
+    // the unambiguous "ignore/disregard the previous instructions" family
+    .replace(/\b(ignore|disregard|forget|override)\b[^.!?\n]*\b(previous|prior|above|earlier|all)\b[^.!?\n]*\binstructions?\b/gi, ' ')
+    // double quotes would let the text break out of the "${text}" framing
+    .replace(/"/g, "'")
+    // collapse the multi-line "instruction block" shape into one line
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 // ---------------------------------------------------------------------------
 // In-memory request ledger. Each POST /request mints an entry; the background
 // resolver mutates it; GET /request/:id reads it. Ephemeral by design — a
@@ -550,7 +574,7 @@ router.post('/request', async (req, res) => {
 
   const rawText = typeof req.body?.text === 'string' ? req.body.text : '';
   const rawName = typeof req.body?.name === 'string' ? req.body.name : '';
-  const text = rawText.trim().slice(0, REQUEST_TEXT_MAX);
+  const text = sanitizeRequestText(rawText).slice(0, REQUEST_TEXT_MAX);
   if (!text) {
     return res.status(400).json({ error: 'Empty request' });
   }

--- a/web/components/CenterStage.tsx
+++ b/web/components/CenterStage.tsx
@@ -2,11 +2,13 @@
 
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { AnimatePresence, m } from 'motion/react';
+import { Coins } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { fmtTime } from '@/lib/format';
 import { useDynamicStyle } from '@/hooks/useDynamicStyle';
 import { useElapsed } from '@/hooks/useElapsed';
 import DjThinkingLine from './DjThinkingLine';
+import CountUp from './CountUp';
 import { Ripple } from './ui/ripple';
 import { isDjTurn } from '@/lib/sessionFeed';
 import { useStationOrigin } from '@/lib/stationOrigin';
@@ -39,13 +41,15 @@ export interface CenterStageProps {
   nowPlaying: NowPlayingTrack | null;
   /** Epoch ms when the current track started (from useStationFeed). */
   trackStartedAt: number | null;
+  /** Cumulative since-boot LLM token total, or null before the first poll. */
+  llmTokens: number | null;
   feed: SessionTurn[];
   djLineOn: boolean;
   onOpenBooth: () => void;
   onOpenTimeline: () => void;
 }
 
-export default memo(function CenterStage({ nowPlaying, trackStartedAt, feed, djLineOn, onOpenBooth, onOpenTimeline }: CenterStageProps) {
+export default memo(function CenterStage({ nowPlaying, trackStartedAt, llmTokens, feed, djLineOn, onOpenBooth, onOpenTimeline }: CenterStageProps) {
   const { apiUrl } = useStationOrigin();
   // The 1s elapsed tick lives here, in the component that displays it, so it
   // only re-renders this subtree — not the whole player (see useElapsed).
@@ -150,6 +154,19 @@ export default memo(function CenterStage({ nowPlaying, trackStartedAt, feed, djL
         <div className="min-w-0">
           <div className="v3-caption mb-[14px] text-muted">
             Now playing{has && duration ? ` — ${fmtTime(elapsed)} / ${fmtTime(duration)}` : has ? ` — ${fmtTime(elapsed)}` : ''}
+            {llmTokens != null && (
+              <>
+                {' · '}
+                <span
+                  className="inline-flex items-center gap-1 align-middle text-muted"
+                  title="LLM tokens generated since the station booted"
+                  aria-label={`${llmTokens.toLocaleString('en-US')} AI tokens generated`}
+                >
+                  <Coins size={12} strokeWidth={1.75} aria-hidden="true" />
+                  <CountUp value={llmTokens} className="v3-tab-num" />
+                </span>
+              </>
+            )}
           </div>
           <AnimatePresence mode="popLayout" initial={false}>
             <m.div

--- a/web/components/CountUp.tsx
+++ b/web/components/CountUp.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { animate } from 'motion/react';
+
+interface CountUpProps {
+  value: number;
+  className?: string;
+}
+
+// Honour reduced-motion at call time (a mid-session setting change is respected)
+// — matches the pattern in TransportBar.
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+// A number that smoothly climbs from its previous value to the next, rendered
+// with thousands separators (en-US, fixed so it doesn't drift with the
+// browser locale). Unlike OdometerNumber (a whole-value digit swap), this
+// tweens through the in-between integers — the right feel for a large, slowly
+// rising counter like the LLM token total polled every ~5s.
+export default function CountUp({ value, className }: CountUpProps) {
+  const [display, setDisplay] = useState(value);
+  // Seed with the first value so mount snaps to it rather than sweeping 0 → N.
+  const prevRef = useRef(value);
+
+  useEffect(() => {
+    const from = prevRef.current;
+    prevRef.current = value;
+    if (from === value) return;
+    if (prefersReducedMotion()) {
+      setDisplay(value);
+      return;
+    }
+    const controls = animate(from, value, {
+      duration: 0.9,
+      ease: [0.2, 0.7, 0.2, 1],
+      onUpdate: (v) => setDisplay(Math.round(v)),
+    });
+    return () => controls.stop();
+  }, [value]);
+
+  return (
+    <span className={className} aria-live="polite">
+      {display.toLocaleString('en-US')}
+    </span>
+  );
+}

--- a/web/components/PlayerApp.tsx
+++ b/web/components/PlayerApp.tsx
@@ -48,7 +48,7 @@ export interface PlayerAppProps {
 
 export default function PlayerApp({ contained = false }: PlayerAppProps) {
   const { apiUrl } = useStationOrigin();
-  const { nowPlaying, context, dj, activeShow, listeners, streamOnline, state, session, trackStartedAt, timezone } = useStationFeed();
+  const { nowPlaying, context, dj, activeShow, listeners, streamOnline, llmTokens, state, session, trackStartedAt, timezone } = useStationFeed();
   const boothFeed = session.messages;
   const { audioRef, tunedIn, status, volume, setVolume, tune, stop, toggleMute, muted, idleStopped } = usePlayer();
 
@@ -285,6 +285,7 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
       <CenterStage
         nowPlaying={nowPlaying}
         trackStartedAt={trackStartedAt}
+        llmTokens={llmTokens}
         feed={boothFeed}
         djLineOn={tickerOn}
         onOpenBooth={openBooth}

--- a/web/hooks/useStationFeed.ts
+++ b/web/hooks/useStationFeed.ts
@@ -22,6 +22,8 @@ export interface StationFeed {
   listeners: ListenerCount | number | null;
   /** null until the first poll resolves — distinguishes "not yet known" from "offline". */
   streamOnline: boolean | null;
+  /** Cumulative since-boot LLM token total, or null before the first poll. */
+  llmTokens: number | null;
   state: StationState;
   session: SessionPayload;
   /** Epoch ms when the current track was first seen, null before the first
@@ -56,6 +58,7 @@ export function useStationFeed(): StationFeed {
   const [activeShow, setActiveShow] = useState<ActiveShow | null>(null);
   const [listeners, setListeners] = useState<ListenerCount | number | null>(null);
   const [streamOnline, setStreamOnline] = useState<boolean | null>(null);
+  const [llmTokens, setLlmTokens] = useState<number | null>(null);
   const [state, setState] = useState<StationState>(EMPTY_STATE);
   const [session, setSession] = useState<SessionPayload>(EMPTY_SESSION);
   const [trackStartedAt, setTrackStartedAt] = useState<number | null>(null);
@@ -82,6 +85,7 @@ export function useStationFeed(): StationFeed {
         setIfChanged(setActiveShow, npRes.activeShow ?? npRes.context?.activeShow ?? null);
         if (npRes.listeners != null) setIfChanged<ListenerCount | number | null>(setListeners, npRes.listeners);
         if (typeof npRes.streamOnline === 'boolean') setStreamOnline(npRes.streamOnline);
+        if (typeof npRes.llmTokens === 'number') setIfChanged<number | null>(setLlmTokens, npRes.llmTokens);
         if (typeof npRes.timezone === 'string' && npRes.timezone) setTimezone(npRes.timezone);
         setIfChanged(setState, stRes);
         if (seRes && Array.isArray(seRes.messages)) setIfChanged(setSession, seRes);
@@ -90,5 +94,5 @@ export function useStationFeed(): StationFeed {
     return pollWhileVisible(() => { void tick(); }, 5000);
   }, [apiUrl]);
 
-  return { nowPlaying, context, dj, activeShow, listeners, streamOnline, state, session, trackStartedAt, timezone };
+  return { nowPlaying, context, dj, activeShow, listeners, streamOnline, llmTokens, state, session, trackStartedAt, timezone };
 }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -115,6 +115,8 @@ export interface NowPlayingResponse {
   streamOnline?: boolean;
   /** kbps of the first attached broadcast mount; null when offline. */
   streamBitrate?: number | null;
+  /** Cumulative since-boot LLM token total — the player's token ticker. */
+  llmTokens?: number | null;
   /** Station IANA timezone — render on-air timestamps in it (issue #418). */
   timezone?: string;
 }


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge with "Create a merge commit"** — not "Squash and merge". Squash collapses the individual `feat:` / `fix:` / `chore:` commits into one `release: …` commit, and release-please then sees no conventional-commit signal and skips the version bump. See [Step 7](#step-7--how-to-merge-this-pr) for the why.

## Summary

Full-stack batch: one player feature plus three correctness/security fixes. The player now surfaces a live, cumulative LLM token count next to the now-playing time; the admin library reports accurate tag status in the Recently-added & Search tabs; listener counting is corrected behind a reverse proxy; and listener request text is sanitized against prompt injection before it reaches the DJ. No migrations, no env-var changes, no breaking changes.

**Features**
- `b222b79` feat(player): show cumulative LLM token count by the now-playing time (#449)
  - Adds a `CountUp` component (`web/components/CountUp.tsx`), surfaces the token total through `useStationFeed` + `/state`, and animates it next to the now-playing time in `CenterStage`.

**Bug Fixes**
- `a9b313b` fix(library): show real tag status in Recently-added & Search tabs (#448)
- `a16f641` fix(listeners): count distinct listeners behind a reverse proxy (#445)
- `6a57792` fix(requests): sanitize listener request text against prompt injection (#446)

## Test plan
- [x] Player shows a running LLM token count beside the now-playing time that counts up as the session progresses
- [x] Admin library Recently-added & Search tabs show the correct tagged/untagged status for each track (not stale or wrong)
- [x] Distinct listener count is accurate when the station is served behind a reverse proxy (not collapsed to 1, not inflated)
- [x] Submitting a listener request containing prompt-injection-style text does not manipulate the DJ; the text is sanitized