### PR TITLE
docs: music licensing disclaimer, FAQ, Terms page + private-station guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-station.yml
+++ b/.github/ISSUE_TEMPLATE/add-station.yml
@@ -86,6 +86,25 @@ body:
       placeholder: Late-night ambient for people who keep odd hours.
     validations:
       required: false
+  - type: markdown
+    attributes:
+      value: |
+        ### Listing terms
+
+        By listing a station you agree:
+
+        - You're responsible for any licensing or permissions needed for whatever
+          your station streams.
+        - You either hold the necessary rights/licence, or you're streaming music
+          that's cleared for it (your own, Creative Commons, royalty-free, or public
+          domain).
+        - SUB/WAVE provides the software and the directory listing only. It grants no
+          music rights and is not the broadcaster of your station.
+        - Your station may be removed from the directory on a valid complaint or at
+          the maintainer's discretion.
+        - You'll handle any rights complaints directed at your station.
+
+        This isn't legal advice.
   - type: checkboxes
     id: confirm
     attributes:
@@ -94,4 +113,6 @@ body:
         - label: My station URL is public and reachable (visiting it loads the player).
           required: true
         - label: I understand a pull request will be opened from this issue and a maintainer will review it.
+          required: true
+        - label: I agree to the listing terms above — licensing for what my station streams is my responsibility.
           required: true

--- a/.github/ISSUE_TEMPLATE/report-station.yml
+++ b/.github/ISSUE_TEMPLATE/report-station.yml
@@ -1,0 +1,69 @@
+name: 🚩 Report a station / takedown request
+description: Report a listed station for a rights complaint, unlawful content, or because it's offline. Used to request removal from the public /stations directory.
+title: "Report station: "
+labels: ["station-report"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this to flag a station listed on the public **/stations** directory.
+
+        SUB/WAVE lists stations and provides the software; it is **not** the broadcaster
+        of any station. A listing may be removed on a valid complaint or at the
+        maintainer's discretion. For a **copyright / rights complaint**, the listing here
+        only links to the station — you may also need to contact the station operator and
+        the host actually serving the audio.
+  - type: input
+    id: station
+    attributes:
+      label: Station name
+      description: The name of the station as it appears on the directory.
+      placeholder: Night Owl Radio
+    validations:
+      required: true
+  - type: input
+    id: url
+    attributes:
+      label: Station URL
+      description: The public URL of the listed station.
+      placeholder: https://radio.example.com
+    validations:
+      required: true
+  - type: dropdown
+    id: reason
+    attributes:
+      label: Reason for the report
+      options:
+        - Copyright / rights complaint (I hold or represent the rights)
+        - Unlawful, harmful, or abusive content
+        - Station is offline / broken / no longer a SUB/WAVE station
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: >
+        What's the problem? For a rights complaint, identify the specific work(s) and the
+        rights you hold or represent, and where on the station they appear if you can.
+      placeholder: e.g. The station is broadcasting "Track Title" by Artist, to which I own the recording rights, without a licence.
+    validations:
+      required: true
+  - type: input
+    id: contact
+    attributes:
+      label: Contact (optional)
+      description: An email or handle we can reach you at if we need to follow up. Leave blank to stay anonymous.
+      placeholder: you@example.com
+    validations:
+      required: false
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Before you submit
+      options:
+        - label: The information in this report is accurate to the best of my knowledge and I'm acting in good faith.
+          required: true
+        - label: I understand SUB/WAVE lists and provides software only, and is not the broadcaster of the reported station.
+          required: true

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -148,6 +148,37 @@ any inbound ports. Same end result, no firewall fiddling.
 The Caddyfile already trusts Cloudflare's IP ranges so `X-Forwarded-For`
 gives you real listener IPs in logs.
 
+### Make the station private (Cloudflare Access)
+
+SUB/WAVE has no built-in listener password — the player, stream, and API are
+all public by default. The simplest way to lock a station down is **Cloudflare
+Access** (Zero Trust), which gates the whole hostname at the edge with **zero
+code**. A private station is also the cleanest way to stay clear of
+public-performance licensing (see the README "Music licensing" section).
+
+1. Cloudflare dashboard → **Zero Trust → Access → Applications → Add a
+   self-hosted application**.
+2. Application domain: `subwave.<your-domain>` (cover all paths — this protects
+   `/`, `/stream.mp3`, and `/api/*` in one policy).
+3. Add a policy: **Allow** by emails (one-time PIN), a Google/GitHub identity
+   provider, or a shared **service token**.
+
+Notes:
+
+- **Browser listeners** authenticate once via Cloudflare's login page; a
+  session cookie then rides along to the `<audio>` stream request. No SUB/WAVE
+  change needed.
+- **Native apps / hardware radios** can't do the interactive login. Issue a
+  **service token** and send `CF-Access-Client-Id` / `CF-Access-Client-Secret`
+  headers (the native player passes them via the track-player `headers`
+  option). Pure-URL devices (Sonos, car receivers) can't authenticate — keep
+  one bypass path or accept they won't connect on a locked station.
+- This sits in front of the origin, so it composes with the firewall / Tunnel
+  setup above — no ports change.
+
+For a self-hosted alternative (no Cloudflare), put the stack behind a VPN such
+as Tailscale and don't expose `:80` publicly.
+
 ## 7. Updates
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -253,6 +253,32 @@ bin/subwave        Operator CLI entry: setup, status, doctor, lifecycle, play
 - **[`SECURITY.md`](SECURITY.md):** reporting security issues.
 - **[`mcp-subwave/README.md`](mcp-subwave/README.md):** the MCP server.
 
+## Music licensing
+
+SUB/WAVE is playback and automation software. It does **not** grant you any
+rights to the music you broadcast through it, and it ships with no licensed
+content.
+
+Owning a file — a purchased download, a CD you ripped, anything in your
+Navidrome library — covers your own private listening. It does **not** cover
+**public performance**. The moment SUB/WAVE streams to anyone but you, you are
+publicly performing copyrighted works, which in most countries requires
+licences for *two* separate rights:
+
+- the **musical composition** (songwriting) — e.g. PRS for Music (UK),
+  ASCAP / BMI / SESAC (US);
+- the **sound recording** (the master) — e.g. PPL (UK), SoundExchange (US,
+  under the statutory webcasting licence and its DMCA §114 conditions).
+
+You are the broadcaster and you are solely responsible for clearing those
+rights. If you don't want to obtain licences, run the station privately (don't
+expose the stream publicly), or broadcast only content you're cleared to use —
+music you created or own the rights to, Creative-Commons-licensed tracks,
+royalty-free libraries, or public-domain recordings.
+
+This is general information, not legal advice. If you run a public station,
+talk to a media/IP lawyer in your jurisdiction.
+
 ## License
 
 [MIT](LICENSE).

--- a/README.md
+++ b/README.md
@@ -271,10 +271,11 @@ licences for *two* separate rights:
   under the statutory webcasting licence and its DMCA §114 conditions).
 
 You are the broadcaster and you are solely responsible for clearing those
-rights. If you don't want to obtain licences, run the station privately (don't
-expose the stream publicly), or broadcast only content you're cleared to use —
-music you created or own the rights to, Creative-Commons-licensed tracks,
-royalty-free libraries, or public-domain recordings.
+rights. If you don't want to obtain licences, run the station privately (see
+[DEPLOY.md → Make the station private](DEPLOY.md#make-the-station-private-cloudflare-access)),
+or broadcast only content you're cleared to use — music you created or own the
+rights to, Creative-Commons-licensed tracks, royalty-free libraries, or
+public-domain recordings.
 
 This is general information, not legal advice. If you run a public station,
 talk to a media/IP lawyer in your jurisdiction.

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3861,6 +3861,11 @@ body::after {
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     gap: clamp(24px, 3vw, 44px);
 }
+.bs-stations-report {
+    margin: clamp(32px, 5vw, 56px) 0 0;
+    font-size: 13px;
+    color: var(--muted);
+}
 .bs-station-card {
     display: flex;
     flex-direction: column;

--- a/web/app/stations/page.tsx
+++ b/web/app/stations/page.tsx
@@ -19,6 +19,8 @@ const REPO = 'https://github.com/perminder-klair/subwave';
 // non-collaborators to fork the repo (discussion #296), so we route through an
 // issue instead: anyone with a GitHub account can submit in one click.
 const SUBMIT_URL = `${REPO}/issues/new?template=add-station.yml`;
+// Report / takedown for a listed station — opens the report-station issue form.
+const REPORT_URL = `${REPO}/issues/new?template=report-station.yml`;
 
 export default function StationsIndex() {
   const stations = getAllStations();
@@ -77,6 +79,14 @@ export default function StationsIndex() {
           No stations on the directory yet. Be the first to add yours above.
         </p>
       )}
+
+      <p className="bs-stations-report">
+        Stations are run by their operators, not by SUB/WAVE.{' '}
+        <AnimatedLink href={REPORT_URL} className="bs-link">
+          Report a station or request a takedown
+        </AnimatedLink>
+        .
+      </p>
     </article>
   );
 }

--- a/web/app/terms/page.tsx
+++ b/web/app/terms/page.tsx
@@ -1,0 +1,107 @@
+import { pageMeta } from '@/lib/seo';
+
+export const metadata = pageMeta({
+  title: 'SUB/WAVE — Terms of Use',
+  description:
+    'The plain terms for using the SUB/WAVE apps and the public station: the software is provided as is, and each station operator is responsible for the music they broadcast and any licences it needs.',
+  path: '/terms',
+});
+
+export default function TermsPage() {
+  return (
+    <article className="bs-article">
+      <header className="bs-article-head">
+        <p className="bs-eyebrow">Legal</p>
+        <h1>Terms of Use</h1>
+        <p className="bs-article-deck">
+          SUB/WAVE is open-source software and a player for SUB/WAVE internet
+          radio stations. These terms are short and plain. The one that matters
+          most: whoever runs a station is responsible for the music on it.
+        </p>
+        <p className="bs-article-byline">
+          <time dateTime="2026-06-19">Last updated 19 June 2026</time>
+        </p>
+      </header>
+
+      <div className="bs-rule" />
+
+      <div className="bs-prose">
+        <h2>What SUB/WAVE is</h2>
+        <p>
+          SUB/WAVE is software for running and listening to a personal internet
+          radio station. The code is open source under the MIT licence. Anyone
+          can self-host a station; the apps let you listen to the public station
+          at getsubwave.com or any other SUB/WAVE station by address. Using the
+          apps or the software means you accept these terms.
+        </p>
+
+        <h2>Provided &ldquo;as is&rdquo;</h2>
+        <p>
+          The software and the apps are provided as is, without warranties of
+          any kind. We don&apos;t promise the stream is always up, that any
+          feature keeps working, or that the AI DJ behaves a particular way. To
+          the fullest extent the law allows, we&apos;re not liable for any loss
+          arising from using &mdash; or being unable to use &mdash; SUB/WAVE.
+        </p>
+
+        <h2>Your station, your responsibility</h2>
+        <p>
+          SUB/WAVE is a broadcast tool, like the Liquidsoap and Icecast it runs
+          on. It grants no rights to any music and clears nothing on your
+          behalf. If you run a station, you are the broadcaster: you are
+          responsible for the music you play and for obtaining any licences that
+          broadcasting it requires in your country. Broadcasting music to people
+          who can tune in can count as public performance, which is licensed in
+          most places.
+        </p>
+        <p>
+          If you don&apos;t want to arrange licences, keep your station private
+          to people you intend, or broadcast only content that&apos;s cleared
+          for it &mdash; your own recordings, Creative Commons, royalty-free
+          libraries, or public domain. This is general information, not legal
+          advice; if you run a public station, check your local rules or talk to
+          a lawyer.
+        </p>
+
+        <h2>Acceptable use</h2>
+        <ul>
+          <li>Don&apos;t use SUB/WAVE to broadcast content you have no right to broadcast.</li>
+          <li>Don&apos;t use it for anything unlawful, or to harass or harm others.</li>
+          <li>
+            Don&apos;t abuse the song-request feature &mdash; no spam, and no
+            attempts to manipulate or attack the DJ or the station.
+          </li>
+        </ul>
+
+        <h2>Listening to stations</h2>
+        <p>
+          Stations other than the public one are run by their own operators. We
+          don&apos;t control, endorse, or take responsibility for what a
+          third-party station plays or says. When you tune in to a station, you
+          connect directly to that operator&apos;s server; what it broadcasts is
+          on them, not on us.
+        </p>
+
+        <h2>Song requests</h2>
+        <p>
+          If you send a song request, the text and any name you add go to the
+          station you&apos;re tuned to so the DJ can answer it on air. Keep
+          requests civil and lawful. An operator can ignore or decline any
+          request, and there&apos;s no guarantee a request is played.
+        </p>
+
+        <h2>Changes</h2>
+        <p>
+          If these terms change, the date at the top will change with them.
+          Continuing to use SUB/WAVE after a change means you accept the updated
+          terms.
+        </p>
+
+        <h2>Contact</h2>
+        <p>
+          Questions about these terms: <a href="mailto:p.klair25@gmail.com">p.klair25@gmail.com</a>
+        </p>
+      </div>
+    </article>
+  );
+}

--- a/web/components/landing/StationFooter.tsx
+++ b/web/components/landing/StationFooter.tsx
@@ -50,6 +50,10 @@ export default function StationFooter({ djName }: { djName?: string }) {
         <AnimatedLink href="/privacy" className="font-semibold tracking-[inherit] text-ink hover:text-vermilion">
           privacy
         </AnimatedLink>{' '}
+        ·{' '}
+        <AnimatedLink href="/terms" className="font-semibold tracking-[inherit] text-ink hover:text-vermilion">
+          terms
+        </AnimatedLink>{' '}
         —
       </div>
       <div className="pb-[6px] text-center text-[10px] tracking-[0.3em] text-balance text-muted uppercase">

--- a/web/components/manual/Faq.tsx
+++ b/web/components/manual/Faq.tsx
@@ -114,6 +114,61 @@ export default function Faq() {
           feels off&rdquo; rather than an outright break.
         </p>
       </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">MUSIC LICENSING</p>
+        <h2>Do I need a licence to run a SUB/WAVE station?</h2>
+        <p>
+          Maybe &mdash; it depends on what you stream and who can hear it. SUB/WAVE is
+          software; it grants no rights to any music. Listening privately to music you
+          own is one thing. Broadcasting it where other people can tune in can count as
+          public performance, which is licensed in most countries. Whether you need a
+          licence is on you, the operator. <em>(Not legal advice.)</em>
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">WHO&rsquo;S RESPONSIBLE</p>
+        <h2>Does SUB/WAVE handle licensing for me?</h2>
+        <p>
+          No. It&rsquo;s a broadcast tool, like the Liquidsoap and Icecast it runs on. It
+          doesn&rsquo;t clear, pay, or report anything to any rights body. If your station
+          needs a licence, arranging it is the operator&rsquo;s responsibility.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">THE TWO RIGHTS</p>
+        <h2>What rights are involved?</h2>
+        <p>
+          Usually two: the composition (songwriting) and the sound recording. In the UK
+          that&rsquo;s PRS for Music and PPL. In the US it&rsquo;s ASCAP/BMI/SESAC for
+          compositions and SoundExchange for recordings. Other countries have their own
+          bodies. A public station can touch both.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">SMALL AND PRIVATE</p>
+        <h2>It&rsquo;s just me and a few friends and I&rsquo;m not making money &mdash; am I fine?</h2>
+        <p>
+          Non-commercial and small doesn&rsquo;t automatically mean licence-free; public
+          performance rules don&rsquo;t always care whether money changes hands. A private
+          stream only you can reach is lower risk than a public URL you&rsquo;ve shared
+          around. <em>(Not legal advice &mdash; check your local rules.)</em>
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">THE SAFE SIDE</p>
+        <h2>How do I keep a station clearly on the safe side?</h2>
+        <p>
+          Keep it private to people you intend, or build it from music that&rsquo;s cleared
+          for this: your own recordings, Creative Commons, royalty-free libraries, or
+          public domain. SUB/WAVE saves hourly archives, which is the kind of
+          record-keeping a licensed station usually wants if you go that route.
+        </p>
+      </section>
     </ManualPage>
   );
 }

--- a/web/components/onboarding/steps.tsx
+++ b/web/components/onboarding/steps.tsx
@@ -126,6 +126,16 @@ export function NavidromeStep({ w }: { w: WizardController }) {
           </button>
           <TestPill result={w.data.navidromeTest} />
         </div>
+        <div className="rounded-md border border-amber-400/40 bg-amber-400/10 px-3 py-2 text-xs text-amber-200">
+          <strong>Music licensing:</strong> owning these files covers your own
+          private listening, not <em>public</em> broadcast. If anyone but you
+          can hear the stream, you&apos;re publicly performing copyrighted works
+          and need the relevant licences (PRS&nbsp;+&nbsp;PPL in the UK,
+          ASCAP/BMI&nbsp;+&nbsp;SoundExchange in the US) — or broadcast only
+          content you&apos;re cleared to use (your own, Creative Commons,
+          royalty-free, public domain). You are the broadcaster and are
+          responsible for clearing these rights. Not legal advice.
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Adds clear, consistent music-licensing messaging across the project so neither operators nor the project imply that owning music files grants the right to broadcast it publicly. The throughline: **the station operator is responsible for content and any licences.**

## Changes

- **README** — new "Music licensing" section (software grants no rights; private listening ≠ public performance; names composition + recording rights for UK/US; lists cleared-content routes; "not legal advice"). The "run privately" route links to the deploy guide below.
- **DEPLOY.md** — new "Make the station private (Cloudflare Access)" subsection: gate the whole hostname at the edge (zero code), browser listeners auto-authenticate, native apps use a service token; Tailscale noted as the non-Cloudflare alternative.
- **Onboarding** — licensing callout on the Navidrome step, seen by every operator at the moment they point at their library.
- **FAQ** (`/manual/faq`) — five "Music licensing" Q&As, doubling as ready answers when licensing comes up publicly. "Not legal advice" caveats preserved.
- **Terms of Use** (`/terms`) — new public page in the privacy page's plain voice: provided "as is", operator-responsibility/licensing front and centre, acceptable use, third-party stations, song requests. Linked from the landing footer next to privacy.

## Verification

- `web` typechecks clean for every touched/added file (eslint + tsc).
- Docs/content + one static page; no runtime logic touched.

## Note

Branch was rebuilt on top of `develop` (originally cut from `main`) so the diff is exactly the intended files — no release-please noise.