### PR TITLE
feat(shows): steer per-show music by genre, decade, and energy

### DIFF
--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -200,9 +200,14 @@ export function pickSystem() {
   const showLine = activeShow?.topic
     ? `\n\nCurrent show brief — follow this for every pick:\n${activeShow.topic}`
     : '';
+  // The same soft genre/decade/energy lean the pool picker applies — the agent
+  // already owns songsByGenre + tracksByMood(energy) tools, so this line is
+  // enough to make it reach for them. Lives in the system prompt for the same
+  // session-window reason as the show brief above.
+  const musicLean = dj.showMusicLean(activeShow);
   return `${settings.agentPersonaPreamble(persona, { rules: false })}
 
-You run the station as one continuous shift. The messages above are the live session.${djModeLine}${showLine}
+You run the station as one continuous shift. The messages above are the live session.${djModeLine}${showLine}${musicLean}
 
 ${dj.PICKER_CRITERIA}`;
 }

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -19,7 +19,7 @@ export {
   generateLink,
   generateHourlyTime,
 } from './internal/prompts/scripts.js';
-export { PICKER_CRITERIA, pickNextTrack } from './internal/prompts/picker.js';
+export { PICKER_CRITERIA, pickNextTrack, showMusicLean } from './internal/prompts/picker.js';
 
 // Re-exported so routes/debug.js can read the LLM call ring buffer through the
 // same module that produces the calls.

--- a/controller/src/llm/internal/prompts/picker.ts
+++ b/controller/src/llm/internal/prompts/picker.ts
@@ -12,13 +12,33 @@ export const PICKER_CRITERIA = `Selection criteria, in order:
 3. VARIETY — avoid the same artist back-to-back; don't repeat tracks you've already played today; rotate energy. Variety over cleverness — never pick a track because its title literally matches the time of day, the weather, or anything else literal.
 4. INTEREST — prefer something that creates a moment, not the most generic option.`;
 
-function pickerSystem(show?: { name: string; topic: string } | null) {
+export type ShowMusic = { name: string; topic: string; genre?: string; fromYear?: number | null; toYear?: number | null; energy?: string };
+
+// A show can pin a genre, decade and/or energy band as a SOFT lean on track
+// selection. Render it as one prompt line shared by both pick paths (the pool
+// picker here and the conversational agent in broadcast/dj-agent.ts). Returns
+// '' when the show pins nothing, so callers can append it unconditionally.
+export function showMusicLean(show?: ShowMusic | null): string {
+  if (!show) return '';
+  const parts: string[] = [];
+  if (show.genre) parts.push(`lean toward ${show.genre}`);
+  if (show.fromYear != null || show.toYear != null) {
+    const from = show.fromYear != null ? String(show.fromYear) : '';
+    const to = show.toYear != null ? String(show.toYear) : '';
+    parts.push(from && to ? `prefer tracks from ${from}–${to}` : `prefer tracks ${from ? `from ${from} onward` : `up to ${to}`}`);
+  }
+  if (show.energy) parts.push(`favour ${show.energy}-energy tracks`);
+  if (!parts.length) return '';
+  return `\n\nMusic steer for this show — ${parts.join('; ')}. These are preferences, not hard filters: break them only when the flow genuinely demands it.`;
+}
+
+function pickerSystem(show?: ShowMusic | null) {
   const stationName = settings.get().station;
   const showLine = show?.topic
     ? `\n\nCurrent show brief — follow this for every pick:\n${show.topic}`
     : '';
   return `You are the DJ for ${stationName}, a personal internet radio station.
-Pick the single best NEXT track from the candidate pool, given recent plays and the current context.${showLine}
+Pick the single best NEXT track from the candidate pool, given recent plays and the current context.${showLine}${showMusicLean(show)}
 
 ${PICKER_CRITERIA}
 
@@ -45,7 +65,7 @@ export async function pickNextTrack({ candidates, recentPlays, context, show = n
   candidates: any[];
   recentPlays: any;
   context: any;
-  show?: { name: string; topic: string } | null;
+  show?: ShowMusic | null;
 }) {
   const user = JSON.stringify({
     now: {

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -26,6 +26,11 @@ const CAP_SIMILAR_ARTIST = 4;
 const CAP_EMBEDDING_SIMILAR = 4;
 const CAP_SONIC_SIMILAR = 4;
 const CAP_AUDIO_SIMILAR = 4;
+// When a show pins a genre/decade, its dedicated source is the dominant pool
+// contributor (soft lean) and the unrelated discovery sources shrink by this
+// factor so the genre/era actually shows up in the LLM's candidate list.
+const CAP_SHOW_GENRE = 12;
+const SHOW_NARROW_FACTOR = 0.5;
 
 // TTL cache for sources that don't change between picks. Without this, every
 // pick would re-fetch playlists, recent/frequent album lists and re-walk their
@@ -78,6 +83,51 @@ function softRankByCompat(pool: any[], current: { bpm: number | null; key: strin
     .map((s) => s.t);
 }
 
+// --- Show music-steering filters (soft lean) -------------------------------
+// A show can pin a genre, a decade (fromYear/toYear) and an energy band. None
+// of these is ever a hard filter: each prefers matching tracks but falls back
+// to the full set when matches are too thin to fill the pool, so a sparse genre
+// or an un-analysed library never starves the stream.
+
+type ShowFilter = { genre?: string; fromYear?: number | null; toYear?: number | null; energy?: string } | null;
+
+function hasMusicFilter(f: ShowFilter): boolean {
+  return !!f && (!!f.genre || f.fromYear != null || f.toYear != null);
+}
+
+// Per-track energy band — from the track itself (library sources carry it) or a
+// library lookup (Subsonic sources don't). null when un-analysed.
+function trackEnergy(t: any): string | null {
+  if (t?.energy) return t.energy;
+  const rec = t?.id ? library.get(t.id) : null;
+  return rec?.energy ?? null;
+}
+
+// Soft-prefer tracks within [fromYear, toYear]. Unknown-year tracks are treated
+// as out-of-range here, but the caller falls back to the full set when the
+// in-range slice is empty, so it never hard-drops everything.
+function inYearRange(tracks: any[], f: { fromYear?: number | null; toYear?: number | null }): any[] {
+  if (f.fromYear == null && f.toYear == null) return tracks;
+  return tracks.filter((t: any) => {
+    const y = Number(t?.year);
+    if (!Number.isFinite(y)) return false;
+    if (f.fromYear != null && y < f.fromYear) return false;
+    if (f.toYear != null && y > f.toYear) return false;
+    return true;
+  });
+}
+
+// Soft-prefer tracks matching the show's energy band; unknown-energy tracks
+// stay eligible. Falls back to the full set when no track matches.
+function preferEnergy(tracks: any[], energy?: string): any[] {
+  if (!energy) return tracks;
+  const match = tracks.filter((t: any) => {
+    const e = trackEnergy(t);
+    return e == null || e === energy;
+  });
+  return match.length ? match : tracks;
+}
+
 function notRecent(recentIds: Set<string>) {
   return (t: any) => t && t.id && !recentIds.has(t.id);
 }
@@ -100,7 +150,7 @@ async function tracksFromAlbums(albums: any[], perAlbum: number, max: number) {
   return out;
 }
 
-async function buildCandidates(mood: string | null | undefined, recentIds: Set<string>, recentArtists: Set<string>, currentTrack: any, rankTarget: { bpm: number | null; key: string | null } | null = null, audioWaypoint: number[] | null = null) {
+async function buildCandidates(mood: string | null | undefined, recentIds: Set<string>, recentArtists: Set<string>, currentTrack: any, rankTarget: { bpm: number | null; key: string | null } | null = null, audioWaypoint: number[] | null = null, showFilter: ShowFilter = null) {
   await library.load();
   const pool: any[] = [];
   const sources: Record<string, number> = {};
@@ -109,6 +159,10 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     pool.push(...items.map((t: any) => ({ ...t, _source: label })));
     sources[label] = (sources[label] || 0) + items.length;
   };
+  // When a show pins a genre/decade, shrink the unrelated discovery sources so
+  // the dedicated show-genre source dominates the candidate list (soft lean).
+  const narrow = hasMusicFilter(showFilter);
+  const nz = (cap: number) => (narrow ? Math.max(2, Math.ceil(cap * SHOW_NARROW_FACTOR)) : cap);
 
   // 1. Similar-songs from current track — strongest contextual signal.
   if (currentTrack?.id) {
@@ -116,7 +170,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
       const similar = await subsonic.getSimilarSongs(currentTrack.id, {
         count: 20,
       });
-      add('similar', sampleWithRecentFallback(similar, recentIds, CAP_SIMILAR));
+      add('similar', sampleWithRecentFallback(similar, recentIds, nz(CAP_SIMILAR)));
     } catch {}
   }
 
@@ -129,7 +183,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
   if (currentTrack?.id) {
     try {
       const knn = library.tracksLikeThis(currentTrack.id, 15);
-      add('embedding-similar', sampleWithRecentFallback(knn, recentIds, CAP_EMBEDDING_SIMILAR));
+      add('embedding-similar', sampleWithRecentFallback(knn, recentIds, nz(CAP_EMBEDDING_SIMILAR)));
     } catch {}
   }
 
@@ -143,7 +197,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     try {
       if (await subsonic.supportsSonicSimilarity()) {
         const sonic = await subsonic.getSonicSimilarTracks(currentTrack.id, { count: 20 });
-        add('sonic-similar', sampleWithRecentFallback(sonic, recentIds, CAP_SONIC_SIMILAR));
+        add('sonic-similar', sampleWithRecentFallback(sonic, recentIds, nz(CAP_SONIC_SIMILAR)));
       }
     } catch {}
   }
@@ -162,18 +216,46 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
   if (audioWaypoint && audioWaypoint.length) {
     try {
       const knn = library.tracksByAudioVector(audioWaypoint, 15);
-      add('audio-journey', sampleWithRecentFallback(knn, recentIds, CAP_AUDIO_SIMILAR));
+      add('audio-journey', sampleWithRecentFallback(knn, recentIds, nz(CAP_AUDIO_SIMILAR)));
     } catch {}
   } else if (currentTrack?.id) {
     try {
       const knn = library.tracksLikeThisAudio(currentTrack.id, 15);
-      add('audio-similar', sampleWithRecentFallback(knn, recentIds, CAP_AUDIO_SIMILAR));
+      add('audio-similar', sampleWithRecentFallback(knn, recentIds, nz(CAP_AUDIO_SIMILAR)));
+    } catch {}
+  }
+
+  // 1e. Show genre / decade — the soft-dominant source when a show pins a
+  // genre or a year range. getRandomSongs takes genre + year-range natively in
+  // one call; when a genre is set we also pull the full genre-tagged set
+  // (broader than a random sample) and soft-filter it to the decade. The whole
+  // collection is then energy-preferred. Never a hard filter — see helpers.
+  if (hasMusicFilter(showFilter)) {
+    try {
+      let genreName: string | null = null;
+      if (showFilter!.genre) {
+        genreName = await subsonic.resolveGenreName(showFilter!.genre);
+      }
+      const collected: any[] = [];
+      collected.push(...await subsonic.getRandomSongs({
+        size: 40,
+        genre: genreName || undefined,
+        fromYear: showFilter!.fromYear ?? undefined,
+        toYear: showFilter!.toYear ?? undefined,
+      }));
+      if (genreName) {
+        const g = await subsonic.getSongsByGenre(genreName, { count: 60 });
+        const ranged = inYearRange(g, showFilter!);
+        collected.push(...(ranged.length ? ranged : g));
+      }
+      const leaned = preferEnergy(collected, showFilter!.energy);
+      add('show-genre', sampleWithRecentFallback(shuffle(leaned), recentIds, CAP_SHOW_GENRE));
     } catch {}
   }
 
   // 2. Mood-tagged library (LLM-built tags, may be sparse).
   if (mood) {
-    const moodHits = shuffle(library.songsByMood(mood));
+    const moodHits = shuffle(preferEnergy(library.songsByMood(mood), showFilter?.energy));
     add('mood-library', sampleWithRecentFallback(moodHits, recentIds, CAP_MOOD_LIBRARY));
   }
 
@@ -191,7 +273,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
           plTracks.push(...songs);
         } catch {}
       }
-      add('playlist', sampleWithRecentFallback(shuffle(plTracks), recentIds, CAP_PLAYLIST));
+      add('playlist', sampleWithRecentFallback(shuffle(plTracks), recentIds, nz(CAP_PLAYLIST)));
     } catch {}
   }
 
@@ -204,7 +286,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
       const albums = await subsonic.getRecentlyAddedAlbums({ size: 12 });
       return tracksFromAlbums(shuffle(albums), 3, 40);
     });
-    add('recent', sampleWithRecentFallback(shuffle(recentPool), recentIds, CAP_RECENT));
+    add('recent', sampleWithRecentFallback(shuffle(recentPool), recentIds, nz(CAP_RECENT)));
   } catch {}
 
   // 5. Frequent albums — scrobble-backed favourites. Same wide-pool-then-
@@ -214,7 +296,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
       const albums = await subsonic.getFrequentAlbums({ size: 12 });
       return tracksFromAlbums(shuffle(albums), 3, 40);
     });
-    add('frequent', sampleWithRecentFallback(shuffle(freqPool), recentIds, CAP_FREQUENT));
+    add('frequent', sampleWithRecentFallback(shuffle(freqPool), recentIds, nz(CAP_FREQUENT)));
   } catch {}
 
   // 6. Similar-artist top songs — adjacency through Last.fm artist graph.
@@ -244,7 +326,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
       );
       add(
         'similar-artist',
-        sampleWithRecentFallback(similarArtistTracks, recentIds, CAP_SIMILAR_ARTIST),
+        sampleWithRecentFallback(similarArtistTracks, recentIds, nz(CAP_SIMILAR_ARTIST)),
       );
     } catch {}
   }
@@ -315,7 +397,13 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   const recentIds = queue.recentlyPlayedIds(windows.trackHours);
   const recentArtists = queue.recentArtistsSince(windows.artistHours);
   const currentTrack = queue.current?.track || null;
-  const { candidates, sources } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack, rankTarget, audioWaypoint);
+  // Resolve the active show once: its music-steering filters shape the pool
+  // (below) and its brief steers the LLM pick (further down).
+  const activeShow = settings.resolveActiveShow();
+  const showFilter: ShowFilter = activeShow
+    ? { genre: activeShow.genre, fromYear: activeShow.fromYear, toYear: activeShow.toYear, energy: activeShow.energy }
+    : null;
+  const { candidates, sources } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack, rankTarget, audioWaypoint, showFilter);
 
   if (candidates.length === 0) {
     queue.log('picker', 'no candidates available, skipping LLM pick');
@@ -335,9 +423,17 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   try {
     // Same show-brief plumbing as the agent picker (dj-agent.pickSystem) —
     // this is its fallback, so it must honour the brief too.
-    const activeShow = settings.resolveActiveShow();
     pickRaw = await dj.pickNextTrack({
-      show: activeShow ? { name: activeShow.name, topic: activeShow.topic } : null,
+      show: activeShow
+        ? {
+            name: activeShow.name,
+            topic: activeShow.topic,
+            genre: activeShow.genre,
+            fromYear: activeShow.fromYear,
+            toYear: activeShow.toYear,
+            energy: activeShow.energy,
+          }
+        : null,
       candidates: candidates.map(c => {
         const a = analysisFor(c);
         return {

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -210,6 +210,10 @@ export const SHOW_MOODS = [
   'cultural',
 ];
 
+// Energy bands a show can pin as a soft music-steering filter. Mirrors the
+// tagger's per-track energy classes and the `tracksByMood` agent-tool filter.
+export const SHOW_ENERGY = ['low', 'medium', 'high'];
+
 // British English Kokoro voices — the ones that fit a BBC 6 Music tone. The
 // underlying model ships 54 voices total; we expose only the British subset to
 // keep the UI tidy. Any voice matching KOKORO_VOICE_RE still passes validation.
@@ -724,6 +728,15 @@ function normalizeShows(raw: any, personaIds: string[]) {
       typeof item.themeId === 'string' && item.themeId.trim()
         ? item.themeId.trim().slice(0, 64)
         : '';
+    // Optional music-steering filters (soft lean, applied at pick time). Genre
+    // is stored as free text and resolved fuzzily against the live library when
+    // a pick is made (mirrors the listener-request path) — never validated
+    // against Subsonic here. fromYear/toYear are a decade window. energy is one
+    // of the tagger's three bands. All default to "no constraint".
+    const genre = typeof item.genre === 'string' ? item.genre.trim().slice(0, 64) : '';
+    const fromYear = Number.isFinite(item.fromYear) ? Math.trunc(item.fromYear) : null;
+    const toYear = Number.isFinite(item.toYear) ? Math.trunc(item.toYear) : null;
+    const energy = SHOW_ENERGY.includes(item.energy) ? item.energy : '';
     out.push({
       id,
       name,
@@ -731,6 +744,10 @@ function normalizeShows(raw: any, personaIds: string[]) {
       personaId: item.personaId,
       mood: item.mood,
       themeId,
+      genre,
+      fromYear,
+      toYear,
+      energy,
     });
     if (out.length >= SHOWS_LIMIT) break;
   }
@@ -1348,10 +1365,32 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
       }
       themeId = v;
     }
+    // Optional music-steering filters — all default to "no constraint". Genre
+    // is free text resolved fuzzily at pick time, so it isn't checked against
+    // the live library here.
+    const genre = String(item.genre ?? '').trim();
+    if (genre.length > 64) throw new Error(`shows[${i}].genre must be 0-64 chars`);
+    const energy = item.energy == null || item.energy === '' ? '' : String(item.energy);
+    if (energy && !SHOW_ENERGY.includes(energy)) {
+      throw new Error(`shows[${i}].energy must be one of: ${SHOW_ENERGY.join(', ')}`);
+    }
+    const parseYear = (v, field) => {
+      if (v == null || v === '') return null;
+      const n = Number(v);
+      if (!Number.isInteger(n) || n < 1900 || n > 2100) {
+        throw new Error(`shows[${i}].${field} must be an integer between 1900 and 2100`);
+      }
+      return n;
+    };
+    const fromYear = parseYear(item.fromYear, 'fromYear');
+    const toYear = parseYear(item.toYear, 'toYear');
+    if (fromYear != null && toYear != null && fromYear > toYear) {
+      throw new Error(`shows[${i}].fromYear must be <= toYear`);
+    }
     let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('s_');
     if (seen.has(id)) id = mintId('s_');
     seen.add(id);
-    return { id, name, topic, personaId: item.personaId, mood: item.mood, themeId };
+    return { id, name, topic, personaId: item.personaId, mood: item.mood, themeId, genre, fromYear, toYear, energy };
   });
 }
 
@@ -1967,6 +2006,12 @@ export function resolveActiveShow(date = new Date(), s = get()) {
     name: show.name,
     topic: show.topic,
     mood: show.mood,
+    // Optional music-steering filters (soft lean). Surfaced for the picker and
+    // DJ agent; empty string / null means "no constraint".
+    genre: typeof show.genre === 'string' ? show.genre : '',
+    fromYear: Number.isFinite(show.fromYear) ? show.fromYear : null,
+    toYear: Number.isFinite(show.toYear) ? show.toYear : null,
+    energy: typeof show.energy === 'string' ? show.energy : '',
     // Empty string means "fall back to the station-wide default". The route
     // layer is responsible for resolving an empty/stale id against the live
     // theme registry; we just surface what the show declares.

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -59,6 +59,38 @@ interface Show {
    *  default while this show is on air". Validated against the live theme
    *  registry by the controller; a stale id silently falls back too. */
   themeId: string;
+  /** Optional music-steering filters — soft lean applied at pick time. Empty
+   *  string / null means "no constraint". Genre is free text resolved fuzzily
+   *  against the library; fromYear/toYear are a decade window; energy is one of
+   *  low|medium|high. */
+  genre: string;
+  fromYear: number | null;
+  toYear: number | null;
+  energy: string;
+}
+
+// Decade presets for the era dropdown → fromYear/toYear. 'any' clears the window.
+const DECADES: { key: string; label: string; from: number | null; to: number | null }[] = [
+  { key: 'any', label: 'Any era', from: null, to: null },
+  { key: '2020', label: '2020s', from: 2020, to: 2029 },
+  { key: '2010', label: '2010s', from: 2010, to: 2019 },
+  { key: '2000', label: '2000s', from: 2000, to: 2009 },
+  { key: '1990', label: '90s', from: 1990, to: 1999 },
+  { key: '1980', label: '80s', from: 1980, to: 1989 },
+  { key: '1970', label: '70s', from: 1970, to: 1979 },
+  { key: '1960', label: '60s', from: 1960, to: 1969 },
+  { key: '1950', label: '50s', from: 1950, to: 1959 },
+];
+const ENERGY_OPTIONS = ['low', 'medium', 'high'];
+const ANY_SENTINEL = '__any__';
+
+function decadeKeyOf(s: { fromYear: number | null; toYear: number | null }): string {
+  const hit = DECADES.find(d => d.from === s.fromYear && d.to === s.toYear);
+  return hit ? hit.key : 'any';
+}
+function decadeLabelOf(s: { fromYear: number | null; toYear: number | null }): string | null {
+  const hit = DECADES.find(d => d.from === s.fromYear && d.to === s.toYear);
+  return hit && hit.from != null ? hit.label : null;
 }
 
 // Slim view of a theme returned by GET /themes — only the bits the picker
@@ -131,11 +163,18 @@ function NowCard({ label, accent, slotHour, show, color, personaLabel }: NowCard
       </div>
       <div className="text-[11px] text-muted">
         {show
-          ? <>persona · {personaLabel} · mood · {show.mood}</>
+          ? <>persona · {personaLabel} · mood · {show.mood}{showFilterSummary(show)}</>
           : 'station runs on its own picker'}
       </div>
     </div>
   );
+}
+
+// Compact " · genre · 80s · high" suffix for the show summary lines, omitting
+// whatever the show doesn't pin.
+function showFilterSummary(s: { genre: string; fromYear: number | null; toYear: number | null; energy: string }): string {
+  const bits = [s.genre, decadeLabelOf(s), s.energy].filter(Boolean);
+  return bits.length ? ` · ${bits.join(' · ')}` : '';
 }
 
 function clientMintId() {
@@ -175,6 +214,9 @@ export default function ShowsPanel() {
   // Theme list for the per-show override dropdown. Public endpoint, no auth
   // needed — same source the player ThemeBootstrap reads.
   const [themes, setThemes] = useState<ThemeOption[]>([]);
+  // Library genres for the show genre autocomplete. Admin-gated endpoint, so it
+  // runs after sign-in; failures are silent (the field still accepts free text).
+  const [genres, setGenres] = useState<string[]>([]);
 
   // Drag-paint stroke: { active, value } — value is the showId/null painted
   // for the whole stroke, decided on mousedown so a drag doesn't flicker.
@@ -233,6 +275,10 @@ export default function ShowsPanel() {
           personaId: s.personaId ?? '',
           mood: s.mood ?? '',
           themeId: s.themeId ?? '',
+          genre: s.genre ?? '',
+          fromYear: s.fromYear ?? null,
+          toYear: s.toYear ?? null,
+          energy: s.energy ?? '',
         }));
         setForm({ shows, schedule: week });
         // Arm the first valid show as the brush so the grid is paintable at once.
@@ -260,6 +306,21 @@ export default function ShowsPanel() {
     return () => { cancelled = true; };
   }, [hydrated]);
 
+  // Fetch library genres once for the show genre autocomplete (admin-gated).
+  useEffect(() => {
+    if (!hydrated || needsAuth) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await adminFetch('/library/genres');
+        if (!r.ok || cancelled) return;
+        const j = (await r.json()) as { genres?: { value: string }[] };
+        if (Array.isArray(j.genres)) setGenres(j.genres.map(g => g.value).filter(Boolean));
+      } catch {}
+    })();
+    return () => { cancelled = true; };
+  }, [hydrated, needsAuth]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const personas: Persona[] = data?.values?.personas || [];
   const moods: string[] = data?.tts?.moods || [];
   const colorOf = (showId: string | null | undefined): string => {
@@ -278,6 +339,7 @@ export default function ShowsPanel() {
       id: '', name: '', topic: '',
       personaId: personas[0]?.id || '', mood: moods[0] || '',
       themeId: '',
+      genre: '', fromYear: null, toYear: null, energy: '',
     });
   };
   const openEdit = (i: number) => {
@@ -289,6 +351,7 @@ export default function ShowsPanel() {
       id: s.id, name: s.name, topic: s.topic,
       personaId: s.personaId, mood: s.mood,
       themeId: s.themeId || '',
+      genre: s.genre || '', fromYear: s.fromYear ?? null, toYear: s.toYear ?? null, energy: s.energy || '',
     });
   };
   const closeModal = () => { setEditIndex(null); setDraft(null); };
@@ -299,6 +362,7 @@ export default function ShowsPanel() {
       name: draft.name.trim(), topic: draft.topic.trim(),
       personaId: draft.personaId, mood: draft.mood,
       themeId: draft.themeId || '',
+      genre: draft.genre.trim(), fromYear: draft.fromYear, toYear: draft.toYear, energy: draft.energy || '',
     };
     if (editIndex === -1) {
       const id = clientMintId();
@@ -434,6 +498,7 @@ export default function ShowsPanel() {
             id: s.id, name: s.name.trim(), topic: s.topic.trim(),
             personaId: s.personaId, mood: s.mood,
             themeId: s.themeId || '',
+            genre: s.genre.trim(), fromYear: s.fromYear, toYear: s.toYear, energy: s.energy || '',
           })),
           schedule: form.schedule,
         }),
@@ -766,6 +831,63 @@ export default function ShowsPanel() {
               </span>
             </Field>
 
+            <div className="stack-mobile grid grid-cols-[1.2fr_1fr_1fr] gap-3">
+              <Field>
+                <Label htmlFor="show-genre">genre lean</Label>
+                <Input
+                  id="show-genre"
+                  type="text" value={draft.genre} maxLength={64}
+                  list="show-genre-options"
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => setDraftField({ genre: e.target.value })}
+                  placeholder="e.g. Jazz (optional)"
+                />
+                <datalist id="show-genre-options">
+                  {genres.map(g => <option key={g} value={g} />)}
+                </datalist>
+              </Field>
+              <Field>
+                <Label>era</Label>
+                <Select
+                  value={decadeKeyOf(draft)}
+                  onValueChange={val => {
+                    const d = DECADES.find(x => x.key === val);
+                    setDraftField({ fromYear: d?.from ?? null, toYear: d?.to ?? null });
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      {DECADES.map(d => <SelectItem key={d.key} value={d.key}>{d.label}</SelectItem>)}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              </Field>
+              <Field>
+                <Label>energy</Label>
+                <Select
+                  value={draft.energy || ANY_SENTINEL}
+                  onValueChange={val => setDraftField({ energy: val === ANY_SENTINEL ? '' : val })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectItem value={ANY_SENTINEL}>Any</SelectItem>
+                      {ENERGY_OPTIONS.map(e => <SelectItem key={e} value={e}>{e}</SelectItem>)}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              </Field>
+            </div>
+            <span className="field-hint -mt-1.5">
+              Optional soft music steer for this show — a genre, an era, an energy
+              band, or any mix. The DJ leans toward these but can break them for
+              flow; leave blank to let the topic and mood drive selection.
+            </span>
+
             <Field>
               <Label htmlFor="show-topic">topic — fed to the DJ as the show theme</Label>
               <span className="field-hint">
@@ -1001,7 +1123,7 @@ function ShowDefRow({ show: s, index: i, ok, hrs, personaLabel, onEdit, onRemove
           {s.name.trim() || 'untitled'}
         </div>
         <div className="text-[11px] text-muted">
-          persona · {personaLabel} · mood · {s.mood || '—'}
+          persona · {personaLabel} · mood · {s.mood || '—'}{showFilterSummary(s)}
         </div>
         {s.topic.trim() && (
           <div className="overflow-hidden text-[11px] text-ellipsis whitespace-nowrap text-muted italic">


### PR DESCRIPTION
## What & why

Shows could only steer track selection via a single coarse `mood` (from the 17-value `SHOW_MOODS` enum). You couldn't define a "Jazz hour", an "80s drive-time", or an "upbeat electronic" block. This adds optional per-show **genre**, **decade** (year range), and **energy band** filters.

The whole genre/era pipeline already existed (`getSongsByGenre`, `resolveGenreName`, `getRandomSongs({genre,fromYear,toYear})`) and was used for listener requests — it just wasn't wired to shows. This routes it through the show model.

## How it works (soft lean, not a hard filter)

When a show is on air, every next-track pick:
1. **Stacks the candidate pool** — a soft-dominant `show-genre` source becomes the biggest chunk of the ~18-candidate pool while the unrelated discovery sources shrink; year/energy are soft-filters (prefer matches, fall back to full set).
2. **Tells the DJ** — a one-line preference is appended to the prompt: *"lean toward Jazz; prefer tracks from 1980–1989; favour high-energy tracks — preferences, not hard filters."*

Never hard-drops candidates, so a sparse genre or un-analysed library never starves the stream. Genre is resolved fuzzily, so "turkish" → "Turkish Pop". Wired into **both** pick paths — the conversational DJ agent and the stateless pool-picker fallback.

## Changes
- **`controller/src/settings.ts`** — Show model gains `genre` / `fromYear` / `toYear` / `energy`; lenient + strict validators; `SHOW_ENERGY` constant; surfaced via `resolveActiveShow`.
- **`controller/src/music/picker.ts`** — new `show-genre` source + discovery-source narrowing + `inYearRange`/`preferEnergy` soft-filter helpers; show filter threaded through `buildCandidates`/`pickNextTrack`.
- **`controller/src/llm/internal/prompts/picker.ts`** + **`llm/dj.ts`** — shared `showMusicLean(show)` helper, re-exported via the barrel.
- **`controller/src/broadcast/dj-agent.ts`** — injects the lean line into `pickSystem` (reuses existing `songsByGenre`/`tracksByMood(energy)` tools, no new tools).
- **`web/components/admin/ShowsPanel.tsx`** — genre autocomplete (reusing admin `/library/genres`), era + energy dropdowns; all optional; summary lines show `· jazz · 80s · high`.

Leaving the fields blank keeps shows behaving exactly as before.

## Verification
- `controller` and `web` `npm run lint` (eslint + `tsc --noEmit`) both pass clean — 0 errors.
- Remaining manual check (needs live stack + Navidrome): create a jazz/80s/high show, confirm `state/schedule.json` persists the fields, and watch the controller `picker pool` log show the genre source dominating with `pickerAgent` both on and off.