### PR TITLE
fix(requests): honest intro/ack when requested artist isn't in the library

### DIFF
--- a/controller/src/llm/internal/prompts/context.ts
+++ b/controller/src/llm/internal/prompts/context.ts
@@ -14,7 +14,7 @@ export const ANGLES = {
     'Skip the introduction entirely and start mid-thought, as if continuing a conversation.',
     'React to the request itself — what kind of request it is, what mood it suggests — before mentioning the track.',
     'Use a short personal observation about the moment (Tuesday energy, the rain holding off, etc.) as the doorway.',
-    'Lean into contrast: how this track sits against what came before, or against the time of day.',
+    'Lean into contrast: how this track sits against the time of day, the weather, or the mood of the moment.',
     'Just say one true sentence and let the music start.',
   ],
   link: [

--- a/controller/src/llm/internal/prompts/scripts.ts
+++ b/controller/src/llm/internal/prompts/scripts.ts
@@ -33,7 +33,7 @@ export async function generateIntro({ track, context, requestedBy = null, reques
   const missClause = artistMiss
     ? ` The listener asked for "${artistMiss}", but we don't have them — briefly own that ("no ${artistMiss} in the crates", or similar), then introduce what's actually coming up as a worthy stand-in. Never pretend the track is by "${artistMiss}".`
     : '';
-  const prompt = `Write an intro for this track. ${lengthPhrase('intro')}${budget ? ' ' + budget : ''} If the listener said something specific, acknowledge their words naturally — don't quote them verbatim, but weave the gist in. Never read the request out loud as-is.${missClause}\n\n${ctxLines.join('\n')}`;
+  const prompt = `Write an intro for this track. ${lengthPhrase('intro')}${budget ? ' ' + budget : ''} If the listener said something specific, acknowledge their words naturally — don't quote them verbatim, but weave the gist in. Never read the request out loud as-is. This is a listener request — keep the focus on what they asked for and the track coming up; don't back-announce or talk about the track that was just playing.${missClause}\n\n${ctxLines.join('\n')}`;
 
   return djText({
     system: djSystem(),

--- a/controller/src/llm/internal/prompts/scripts.ts
+++ b/controller/src/llm/internal/prompts/scripts.ts
@@ -9,7 +9,7 @@ import { djSystem, lengthPhrase } from './system.js';
 import { buildContextLines, decoratePrompt, randomSeed } from './context.js';
 import { introBudgetPhrase, introMsFor, bpmKeyFor } from './intro-budget.js';
 
-export async function generateIntro({ track, context, requestedBy = null, requestText = null, recap = null, recentTracks = null, recentOpeners = null }: any) {
+export async function generateIntro({ track, context, requestedBy = null, requestText = null, artistMiss = null, recap = null, recentTracks = null, recentOpeners = null }: any) {
   const ctxLines = buildContextLines(context, { recentTracks });
   if (requestedBy) ctxLines.push(`Requested by: ${requestedBy}`);
   if (requestText) {
@@ -17,13 +17,23 @@ export async function generateIntro({ track, context, requestedBy = null, reques
     const clipped = String(requestText).replace(/\s+/g, ' ').trim().slice(0, 200);
     if (clipped) ctxLines.push(`Listener asked: "${clipped}"`);
   }
+  // Substitution: the listener named an artist we don't have, so the cascade
+  // fell through to filler. Flag it so the intro stays HONEST instead of
+  // pretending the track is by the requested artist (issue: "asked for Katy
+  // Perry, got Daft Punk, intro still said Katy Perry").
+  if (artistMiss) {
+    ctxLines.push(`IMPORTANT: We do NOT have "${artistMiss}" in the library. The track coming up is NOT by them — it's a fitting substitute for the moment. Do not imply or claim the track is by "${artistMiss}".`);
+  }
   ctxLines.push(`Coming up: "${track.title}" by ${track.artist}${track.album ? ` from ${track.album}` : ''}${track.year ? ` (${track.year})` : ''}`);
 
   // Talk-within-the-intro (A.3 phase 1): when the track's intro runway is
   // known, budget the line to land before the vocals. Advisory + additive —
   // empty for un-analysed tracks, so behaviour is unchanged there.
   const budget = introBudgetPhrase(introMsFor(track));
-  const prompt = `Write an intro for this track. ${lengthPhrase('intro')}${budget ? ' ' + budget : ''} If the listener said something specific, acknowledge their words naturally — don't quote them verbatim, but weave the gist in. Never read the request out loud as-is.\n\n${ctxLines.join('\n')}`;
+  const missClause = artistMiss
+    ? ` The listener asked for "${artistMiss}", but we don't have them — briefly own that ("no ${artistMiss} in the crates", or similar), then introduce what's actually coming up as a worthy stand-in. Never pretend the track is by "${artistMiss}".`
+    : '';
+  const prompt = `Write an intro for this track. ${lengthPhrase('intro')}${budget ? ' ' + budget : ''} If the listener said something specific, acknowledge their words naturally — don't quote them verbatim, but weave the gist in. Never read the request out loud as-is.${missClause}\n\n${ctxLines.join('\n')}`;
 
   return djText({
     system: djSystem(),

--- a/controller/src/routes/request.ts
+++ b/controller/src/routes/request.ts
@@ -516,12 +516,22 @@ async function resolveRequest(entry) {
 
   queue.log('request', `resolved via ${pickSource}: ${pick.title} — ${pick.artist}`);
 
-  // 3. Generate DJ intro that mentions the request
+  // On an artist miss the up-front `ack` (written by matchRequest before the
+  // cascade knew it would miss) is a lie — "Got some Katy Perry coming up!"
+  // over a Daft Punk track. Replace it with an honest stand-in line.
+  const ack = entry.artistMiss
+    ? `No ${entry.artistMiss} in the crates — here's something that fits the moment instead.`
+    : matched.ack;
+
+  // 3. Generate DJ intro that mentions the request. On a miss, pass the
+  // requested-but-absent artist so the spoken intro owns the substitution
+  // instead of pretending the track is by them.
   const introScript = await dj.generateIntro({
     track: pick,
     context: ctx,
     requestedBy: requester,
     requestText: text,
+    artistMiss: entry.artistMiss || null,
     recap: queue.getDjRecap(),
     recentTracks: queue.getRecentTracks(),
     recentOpeners: queue.getRecentOpeners(),
@@ -537,7 +547,7 @@ async function resolveRequest(entry) {
   });
   session.appendTurn({
     role: 'dj', kind: 'request',
-    text: introScript || matched.ack || `Queued "${pick.title}".`,
+    text: introScript || ack || `Queued "${pick.title}".`,
     meta: { trackId: pick.id, requester },
   });
 
@@ -545,7 +555,7 @@ async function resolveRequest(entry) {
   entry.pickSource = pickSource;
   entry.introScript = introScript || null;
   return resolved({
-    ack: matched.ack,
+    ack,
     track: { title: pick.title, artist: pick.artist },
     queuePosition: queue.upcoming.length,
   });


### PR DESCRIPTION
## What

When a listener requests an artist that isn't in the Navidrome library, the DJ now **owns the substitution** instead of pretending the filler track is by the requested artist.

## Why

Real example from the request log:

| field | value |
|---|---|
| request | "Do you have something from Kate Perry?" |
| artist (parsed) | Katy Perry |
| `artistMiss` | Katy Perry |
| pickSource | `library-mood:evening(context)` |
| aired track | **"The Game of Love" — Daft Punk** |
| intro read on air | *"…Katy Perry, stepping into the golden hour."* |

The matcher parsed the request correctly, but Katy Perry isn't in the library, so the stateless cascade fell through to the dominant-mood (`evening`) filler pick — **by design, the station never refuses**. The bug was that both:

- the up-front `ack` (written by `matchRequest` *before* the cascade knew it would miss), and
- the generated `introScript` (`generateIntro` was never told about the miss)

confidently announced Katy Perry over a Daft Punk track — even though the cascade had already detected and recorded `entry.artistMiss`.

## How

- **`routes/request.ts`** — on a miss, replace the lying `ack` with an honest stand-in line, and pass `artistMiss` into `generateIntro`.
- **`llm/internal/prompts/scripts.ts`** — `generateIntro` gains an `artistMiss` param; when set it adds a hard context line + prompt clause telling the DJ to briefly own the miss and never imply the track is by the requested artist.

The hit case (`artistMiss` null) is byte-for-byte unchanged. This brings the stateless cascade in line with the **agent path**, which already handles misses honestly (e.g. *"no Baile Inolvidable in the SUB/WAVE vault, but…"*).

## Test

`npm run lint` (eslint + `tsc --noEmit`) passes with 0 errors in `controller/`.