### PR TITLE
feat(stats): audience sources (referrers, geo, sessions) on admin Stats

### DIFF
--- a/controller/src/broadcast/audience.ts
+++ b/controller/src/broadcast/audience.ts
@@ -1,0 +1,244 @@
+// Audience-source analytics — durable, aggregate-only.
+//
+// Answers "where do the listeners come from, and roughly where are they?" for
+// the admin Stats page, without retaining any raw PII. Data arrives two ways,
+// both off the same Cloudflare-fronted edge:
+//   - the player POSTs a one-shot /beacon on first load carrying
+//     document.referrer + any UTM param. The external referrer is ONLY visible
+//     on the initial HTML navigation (which hits `web`, not the controller —
+//     the API polls only ever see a same-origin referrer), so the browser has
+//     to hand it to us.
+//   - that same beacon request carries Cloudflare's Cf-Connecting-Ip +
+//     Cf-Ipcountry, giving us geography and a distinct-session estimate.
+//
+// Privacy: a raw IP is NEVER stored. The IP is salted+hashed (the salt is
+// process-random and never persisted) only to dedupe sessions within a day; we
+// persist the resulting *count*, not the set. Everything written to disk is an
+// aggregate count.
+//
+// Mirrors broadcast/listeners.ts: in-memory aggregate + periodic flush to a
+// JSON file under config.stateDir, loaded on boot.
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { createHash, randomBytes } from 'node:crypto';
+import { join } from 'node:path';
+import { config } from '../config.js';
+
+const STORE_FILE = join(config.stateDir, 'audience.json');
+const RETAIN_DAYS = 60;          // how many day-buckets we keep on disk
+const LIST_CAP = 40;             // max distinct keys kept per map (top by count)
+const FLUSH_MS = 20_000;         // dirty-flag flush cadence
+
+// Per-day (UTC) aggregate. `_seen` is the in-memory dedupe set — stripped on
+// serialize (underscore key), so it never reaches disk.
+interface DayBucket {
+  date: string;                          // YYYY-MM-DD (UTC)
+  sessions: number;                      // distinct hashed IPs counted that day
+  referrers: Record<string, number>;     // normalized source → count
+  countries: Record<string, number>;     // ISO country → count
+  paths: Record<string, number>;         // landing path → count
+  _seen: Set<string>;                    // hashed IPs — NOT persisted
+}
+
+const buckets = new Map<string, DayBucket>();
+// Process-random salt: stable within a run (enough for same-day dedupe), never
+// written anywhere, so a stored count can't be reversed to an IP.
+const SALT = randomBytes(16).toString('hex');
+let dirty = false;
+let loaded = false;
+
+function todayUtc(d = new Date()): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function bucketFor(date: string): DayBucket {
+  let b = buckets.get(date);
+  if (!b) {
+    b = { date, sessions: 0, referrers: {}, countries: {}, paths: {}, _seen: new Set() };
+    buckets.set(date, b);
+  }
+  return b;
+}
+
+function hashIp(ip: string, date: string): string {
+  return createHash('sha256').update(`${SALT}|${date}|${ip}`).digest('hex').slice(0, 24);
+}
+
+function inc(map: Record<string, number>, key: string | undefined | null) {
+  if (!key) return;
+  map[key] = (map[key] || 0) + 1;
+}
+
+// Collapse a raw document.referrer (+ optional UTM) into a single source label.
+// UTM wins when present; multi-host sources (Reddit web/app/old/android-app) are
+// grouped; our own host and empty referrers are "direct".
+export function normalizeReferrer(rawReferrer?: string, utmSource?: string): string {
+  if (utmSource) return utmSource.toLowerCase().slice(0, 40);
+  const raw = (rawReferrer || '').trim();
+  if (!raw) return 'direct';
+
+  // Reddit's Android app reports an android-app:// referrer that the URL parser
+  // mangles — catch it before parsing.
+  if (/^android-app:\/\/com\.reddit/i.test(raw)) return 'reddit';
+
+  let host = '';
+  try {
+    host = new URL(raw).hostname.toLowerCase();
+  } catch {
+    return 'direct';
+  }
+  if (!host) return 'direct';
+  host = host.replace(/^www\./, '');
+
+  if (host === 'reddit.com' || host.endsWith('.reddit.com')) return 'reddit';
+  if (host === 'getsubwave.com' || host.endsWith('.getsubwave.com')) return 'direct';
+  return host.slice(0, 60);
+}
+
+export interface RecordInput {
+  ip?: string;
+  country?: string;
+  referrer?: string;
+  utmSource?: string;
+  path?: string;
+}
+
+// Record one beacon. First-touch dedupe: the first beacon from a given IP on a
+// given day is counted; later ones (refreshes, retries, spam) are ignored. That
+// bounds abuse and gives clean "distinct sessions" + first-touch attribution.
+export function record(input: RecordInput): void {
+  const ip = (input.ip || '').trim();
+  if (!ip) return;
+  const date = todayUtc();
+  const b = bucketFor(date);
+  const h = hashIp(ip, date);
+  if (b._seen.has(h)) return;
+  b._seen.add(h);
+
+  b.sessions += 1;
+  inc(b.referrers, normalizeReferrer(input.referrer, input.utmSource));
+  const country = (input.country || '').toUpperCase().slice(0, 4);
+  if (country && country !== 'XX') inc(b.countries, country);
+  if (input.path) inc(b.paths, input.path.slice(0, 80));
+  dirty = true;
+}
+
+// Sort a count map desc and cap to the top `n` as a {key,count}[] list.
+function topList<K extends string>(
+  map: Record<string, number>,
+  keyName: K,
+  n = LIST_CAP,
+): (Record<K, string> & { count: number })[] {
+  return Object.entries(map)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n)
+    .map(([k, count]) => ({ [keyName]: k, count }) as Record<K, string> & { count: number });
+}
+
+export interface AudienceSummary {
+  sinceMinutes: number;
+  sessions: number;
+  referrers: { source: string; count: number }[];
+  countries: { country: string; count: number }[];
+  paths: { path: string; count: number }[];
+  days: { date: string; sessions: number }[];
+}
+
+// Aggregate the day-buckets within the window into a single rollup.
+export function summary({ sinceMinutes = 1440 }: { sinceMinutes?: number } = {}): AudienceSummary {
+  const cutoff = new Date(Date.now() - sinceMinutes * 60 * 1000);
+  const cutoffDate = todayUtc(cutoff);
+  const referrers: Record<string, number> = {};
+  const countries: Record<string, number> = {};
+  const paths: Record<string, number> = {};
+  let sessions = 0;
+  const days: { date: string; sessions: number }[] = [];
+
+  for (const b of [...buckets.values()].sort((a, b) => a.date.localeCompare(b.date))) {
+    if (b.date < cutoffDate) continue;
+    sessions += b.sessions;
+    for (const [k, v] of Object.entries(b.referrers)) referrers[k] = (referrers[k] || 0) + v;
+    for (const [k, v] of Object.entries(b.countries)) countries[k] = (countries[k] || 0) + v;
+    for (const [k, v] of Object.entries(b.paths)) paths[k] = (paths[k] || 0) + v;
+    days.push({ date: b.date, sessions: b.sessions });
+  }
+
+  return {
+    sinceMinutes,
+    sessions,
+    referrers: topList(referrers, 'source'),
+    countries: topList(countries, 'country'),
+    paths: topList(paths, 'path'),
+    days,
+  };
+}
+
+// --- persistence -----------------------------------------------------------
+
+interface StoredBucket {
+  date: string;
+  sessions: number;
+  referrers: Record<string, number>;
+  countries: Record<string, number>;
+  paths: Record<string, number>;
+}
+
+// Trim a map to its top LIST_CAP keys so the file can't grow unbounded if an
+// odd referrer/country long-tail accumulates.
+function capMap(map: Record<string, number>): Record<string, number> {
+  const entries = Object.entries(map).sort((a, b) => b[1] - a[1]).slice(0, LIST_CAP);
+  return Object.fromEntries(entries);
+}
+
+async function flush(): Promise<void> {
+  if (!dirty) return;
+  dirty = false;
+  // Keep only the most recent RETAIN_DAYS buckets.
+  const kept = [...buckets.values()]
+    .sort((a, b) => a.date.localeCompare(b.date))
+    .slice(-RETAIN_DAYS);
+  const days: StoredBucket[] = kept.map(b => ({
+    date: b.date,
+    sessions: b.sessions,
+    referrers: capMap(b.referrers),
+    countries: capMap(b.countries),
+    paths: capMap(b.paths),
+  }));
+  try {
+    await writeFile(STORE_FILE, JSON.stringify({ days }, null, 2));
+  } catch {
+    dirty = true; // retry on the next tick
+  }
+}
+
+async function load(): Promise<void> {
+  if (loaded) return;
+  loaded = true;
+  if (!existsSync(STORE_FILE)) return;
+  try {
+    const raw = await readFile(STORE_FILE, 'utf8');
+    const parsed = JSON.parse(raw) as { days?: StoredBucket[] };
+    for (const d of parsed.days || []) {
+      if (!d?.date) continue;
+      // _seen starts empty on load: an IP already counted earlier today can be
+      // re-counted once after a restart. Acceptable session over-count; never
+      // resurrected because nothing reverses the hash.
+      buckets.set(d.date, {
+        date: d.date,
+        sessions: d.sessions || 0,
+        referrers: d.referrers || {},
+        countries: d.countries || {},
+        paths: d.paths || {},
+        _seen: new Set(),
+      });
+    }
+  } catch {
+    /* corrupt file — start fresh, the next flush overwrites it */
+  }
+}
+
+export async function startAudienceMonitor(): Promise<void> {
+  await load();
+  setInterval(() => { flush().catch(() => {}); }, FLUSH_MS);
+}

--- a/controller/src/routes/audience.ts
+++ b/controller/src/routes/audience.ts
@@ -1,0 +1,40 @@
+// Audience-source analytics routes.
+//
+// POST /beacon — public, one-shot per session from the player. Carries the
+// external referrer + UTM (browser-only knowledge) in the body, and Cloudflare's
+// real client IP + country in the headers. Feeds broadcast/audience.ts.
+//
+// GET /audience — admin-gated rollup for the Stats page.
+import express from 'express';
+import { requireAdmin } from '../middleware/auth.js';
+import { clientIp } from '../middleware/ratelimit.js';
+import * as audience from '../broadcast/audience.js';
+
+export const router = express.Router();
+
+router.post('/beacon', (req, res) => {
+  // Analytics must never break a listener — swallow everything, always 204.
+  try {
+    const body = (req.body || {}) as Record<string, unknown>;
+    const cfIp = String(req.headers['cf-connecting-ip'] || '').trim();
+    audience.record({
+      ip: cfIp || clientIp(req),
+      country: String(req.headers['cf-ipcountry'] || '').slice(0, 4) || undefined,
+      referrer: typeof body.referrer === 'string' ? body.referrer.slice(0, 500) : undefined,
+      utmSource: typeof body.utmSource === 'string' ? body.utmSource.slice(0, 60) : undefined,
+      path: typeof body.path === 'string' ? body.path.slice(0, 200) : undefined,
+    });
+  } catch {
+    /* ignore */
+  }
+  res.status(204).end();
+});
+
+router.get('/audience', requireAdmin, (req, res) => {
+  // Window clamps to 60 min … 90 days; day-bucket resolution past that is moot.
+  const sinceMinutes = Math.max(
+    60,
+    Math.min(parseInt(String(req.query.sinceMinutes ?? ''), 10) || 1440, 90 * 1440),
+  );
+  res.json(audience.summary({ sinceMinutes }));
+});

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -12,6 +12,7 @@ import * as session from './broadcast/session.js';
 import { getFullContext } from './context.js';
 import { startScheduler } from './broadcast/scheduler.js';
 import { startListenerMonitor } from './broadcast/listeners.js';
+import { startAudienceMonitor } from './broadcast/audience.js';
 import { cors } from './middleware/cors.js';
 import { assertAdminConfigured } from './middleware/auth.js';
 import { router as publicRoutes } from './routes/public.js';
@@ -30,6 +31,7 @@ import { router as webhooksRoutes } from './routes/webhooks.js';
 import { router as scrobbleRoutes } from './routes/scrobble.js';
 import { router as personasRoutes } from './routes/personas.js';
 import { router as backupRoutes } from './routes/backup.js';
+import { router as audienceRoutes } from './routes/audience.js';
 import { loadSecretsIntoEnv } from './setup/secrets.js';
 import { loadSetupConfig } from './setup/config.js';
 import { getSetupStatus } from './setup/firstRun.js';
@@ -61,6 +63,7 @@ app.use(webhooksRoutes);
 app.use(scrobbleRoutes);
 app.use(personasRoutes);
 app.use(backupRoutes);
+app.use(audienceRoutes);
 
 // (manual skip is not implemented in this build — Liquidsoap controls pacing)
 
@@ -166,6 +169,7 @@ app.listen(config.server.port, async () => {
 
   queue.startWatcher();
   startListenerMonitor();
+  startAudienceMonitor().catch(err => console.error('[audience] init failed:', err.message));
   startScheduler();
   jingles
     .ensureDefaultIdent()

--- a/web/components/PlayerApp.tsx
+++ b/web/components/PlayerApp.tsx
@@ -71,6 +71,33 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
     if (offline && tunedIn) stop();
   }, [offline, tunedIn, stop]);
 
+  // One-shot audience beacon: hand the controller the external referrer + any
+  // UTM tag on first load. The referrer is browser-only knowledge — by the time
+  // the API polls run, it's same-origin — so we report document.referrer here.
+  // Guarded by a per-tab sessionStorage flag so refreshes/remounts don't double
+  // count; the controller also dedupes by IP. Best-effort, never blocks.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      if (sessionStorage.getItem('sw_beacon')) return;
+      sessionStorage.setItem('sw_beacon', '1');
+    } catch {
+      /* private mode: no storage — proceed, the server dedupes by IP */
+    }
+    const q = new URLSearchParams(window.location.search);
+    const utmSource = q.get('utm_source') || q.get('ref') || q.get('source') || undefined;
+    fetch(`${apiUrl}/beacon`, {
+      method: 'POST',
+      keepalive: true,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        referrer: document.referrer || '',
+        path: window.location.pathname,
+        utmSource,
+      }),
+    }).catch(() => {});
+  }, [apiUrl]);
+
   // Persona avatar to surface on the OS lock screen while the DJ is talking.
   // Prefer the on-air show's persona (a scheduled show can hand the hour to a
   // different DJ); fall back to the global "active" persona from /now-playing.

--- a/web/components/admin/StatsPanel.tsx
+++ b/web/components/admin/StatsPanel.tsx
@@ -153,6 +153,15 @@ interface ListenersResponse {
   error?: string;
 }
 
+interface AudienceResponse {
+  sinceMinutes?: number;
+  sessions?: number;
+  referrers?: { source: string; count: number }[];
+  countries?: { country: string; count: number }[];
+  paths?: { path: string; count: number }[];
+  error?: string;
+}
+
 // --- formatters ---------------------------------------------------------
 
 const fmtInt = (n: number | null | undefined): string =>
@@ -396,6 +405,7 @@ export default function StatsPanel() {
   const [err, setErr] = useState<string | null>(null);
   const [paused, setPaused] = useState(false);
   const [listeners, setListeners] = useState<ListenersResponse | null>(null);
+  const [audience, setAudience] = useState<AudienceResponse | null>(null);
   const [range, setRange] = useState('1440'); // minutes — 24h default
 
   // /stats — usage rollups, 5s.
@@ -453,6 +463,30 @@ export default function StatsPanel() {
     return () => { cancelled = true; clearInterval(id); };
   }, [paused, needsAuth, hydrated, adminFetch, range]);
 
+  // /audience — durable referral/geo rollup, 30s, soft-fail (same cadence and
+  // failure handling as /listeners).
+  useEffect(() => {
+    if (!hydrated || needsAuth) return;
+    let cancelled = false;
+    const tick = async () => {
+      if (paused) return;
+      try {
+        const r = await adminFetch(`/audience?sinceMinutes=${range}`);
+        if (r.status === 401) {
+          if (!cancelled) setAudience(null);
+          return;
+        }
+        const j = (await r.json()) as AudienceResponse;
+        if (!cancelled && r.ok) setAudience(j);
+      } catch {
+        /* leave last reading in place */
+      }
+    };
+    tick();
+    const id = setInterval(tick, 30000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [paused, needsAuth, hydrated, adminFetch, range]);
+
   const llm = data?.llm;
   const tts = data?.tts;
   const djLog = data?.djLog;
@@ -466,6 +500,11 @@ export default function StatsPanel() {
   const lMin = counts.length ? Math.min(...counts) : null;
   const lAvg = counts.length ? counts.reduce((a, b) => a + b, 0) / counts.length : null;
   const rangeLabel = range === '10080' ? '7d' : '24h';
+
+  // Audience-source rollup (referrers / countries / distinct sessions).
+  const audSessions = audience?.sessions ?? null;
+  const audReferrers = audience?.referrers ?? [];
+  const audCountries = audience?.countries ?? [];
 
   return (
     <div className="grid gap-4">
@@ -510,6 +549,54 @@ export default function StatsPanel() {
             )}
           </div>
         </div>
+      </Card>
+
+      {/* ── AUDIENCE SOURCES ─────────────────────────────────────────────── */}
+      <Card
+        title="Audience sources"
+        sub={`where listeners came from · last ${rangeLabel}`}
+      >
+        {audience == null ? (
+          <span className="field-hint italic">loading…</span>
+        ) : (audSessions ?? 0) === 0 ? (
+          <span className="field-hint italic">
+            no sessions recorded yet — sources appear as listeners arrive
+          </span>
+        ) : (
+          <div className="grid gap-0">
+            <MetricStrip>
+              <StatCell label="Sessions" value={fmtInt(audSessions)} accent
+                sub={`distinct, last ${rangeLabel}`} />
+              <StatCell label="Sources" value={fmtInt(audReferrers.length)} />
+              <StatCell label="Countries" value={fmtInt(audCountries.length)} last />
+            </MetricStrip>
+
+            <div className="stack-mobile grid grid-cols-[1fr_1fr] gap-0">
+              <div className="border-r border-separator-soft p-3.5">
+                <div className="caption mb-2">top referrers</div>
+                {audReferrers.length ? (
+                  <BarList
+                    rows={audReferrers.map(r => ({ label: r.source, count: r.count }))}
+                    max={audReferrers[0]?.count || 1}
+                  />
+                ) : (
+                  <span className="field-hint italic">none</span>
+                )}
+              </div>
+              <div className="p-3.5">
+                <div className="caption mb-2">top countries</div>
+                {audCountries.length ? (
+                  <BarList
+                    rows={audCountries.map(c => ({ label: c.country, count: c.count }))}
+                    max={audCountries[0]?.count || 1}
+                  />
+                ) : (
+                  <span className="field-hint italic">none</span>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
       </Card>
 
       {!data && !err && (


### PR DESCRIPTION
## What

Adds an **Audience sources** card to `/admin/stats` showing where listeners come from (top referrers), roughly where they are (top countries), and distinct session count — over a 24h/7d window. This data was previously only recoverable by hand-parsing Caddy's ephemeral access logs.

Motivation: a recent listener spike (a Reddit r/LocalLLM thread + the selfh.st directory + GitHub) was only diagnosable by grepping `docker logs caddy`. This makes it a permanent, durable view.

## How

Capture is split by what's visible where:

- **Geo + distinct sessions** — read from Cloudflare's `Cf-Connecting-Ip` / `Cf-Ipcountry`, which the controller already receives on requests (it trusts the proxy chain — see `clientIp()`).
- **External referrers** (Reddit/selfh.st/GitHub) are **not** visible to the controller — they only appear on the *initial HTML navigation* served by `web`; by the time the browser polls `/api`, the referrer is same-origin. So the player POSTs a **one-shot `/beacon`** with `document.referrer` + UTM on first load (sessionStorage-guarded, `keepalive`, best-effort).

We deliberately do **not** parse Caddy logs (ephemeral stdout, fragile, couples controller to the edge).

### New
- `controller/src/broadcast/audience.ts` — durable, aggregate-only analytics. Per-day UTC buckets persisted to `state/audience.json` (60-day retention, top-40 cap per map), loaded on boot, mirroring the `broadcast/listeners.ts` pattern.
- `controller/src/routes/audience.ts` — `POST /beacon` (public, always 204) + `GET /audience` (admin-gated rollup).

### Changed
- `controller/src/server.ts` — register route + `startAudienceMonitor()`.
- `web/components/PlayerApp.tsx` — fire the one-shot beacon on load.
- `web/components/admin/StatsPanel.tsx` — new card, reusing existing `BarList`/`MetricStrip`/`StatCell` primitives; no new deps.

## Privacy
No raw IP is ever written to disk or returned by the API. IPs are salted-hashed **in memory** (process-random salt, never persisted) solely for same-day session dedupe; only aggregate counts persist. First-touch dedupe (one session per IP per day) also bounds `/beacon` abuse.

## Verification
- `controller` lint/tsc: 0 errors. `web` lint/tsc: clean.
- Unit-checked in isolation (temp state dir): referrer normalization (Reddit web/app/old → `reddit`, UTM precedence, own-host/empty → `direct`), same-day IP dedupe (3 sessions from 4 records), and country aggregation all pass.
- Post-merge, deploy is `docker compose up -d --build controller web`; broadcast/audio container is untouched (no on-air gap).