### PR TITLE
Fix transient stream status from stopping playback

### DIFF
--- a/controller/src/broadcast/listeners.ts
+++ b/controller/src/broadcast/listeners.ts
@@ -91,7 +91,14 @@ async function fetchCount() {
     lastStatus = { online, listeners: { current, peak: peakSeen }, bitrate };
   } catch {
     lastCount = null;
-    lastStatus = { online: false, listeners: { current: 0, peak: 0 }, bitrate: null };
+    // Treat Icecast status fetch failures as "unknown", not as proof the
+    // broadcast went offline. The listener UI polls this cached status and
+    // should not tear down a healthy audio element because the stats endpoint
+    // had a transient timeout.
+    lastStatus = {
+      ...lastStatus,
+      listeners: { current: 0, peak: peakSeen },
+    };
   }
   // Persist at most one row per wall-clock minute. Skip null samples — a
   // stats outage shouldn't leave a misleading "0 listeners" stripe in the

--- a/web/components/PlayerApp.tsx
+++ b/web/components/PlayerApp.tsx
@@ -50,7 +50,7 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
   const { apiUrl } = useStationOrigin();
   const { nowPlaying, context, dj, activeShow, listeners, streamOnline, llmTokens, state, session, trackStartedAt, timezone } = useStationFeed();
   const boothFeed = session.messages;
-  const { audioRef, tunedIn, status, volume, setVolume, tune, stop, toggleMute, muted, idleStopped } = usePlayer();
+  const { audioRef, tunedIn, status, volume, setVolume, tune, toggleMute, muted, idleStopped } = usePlayer();
 
   // streamOnline is null until the first poll resolves — only treat an
   // explicit false as offline so the player never flashes "offline" on load.
@@ -64,12 +64,6 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
   // normalise the feed's number | { current } | null shape to a plain count.
   const listenerCount =
     listeners == null ? null : typeof listeners === 'number' ? listeners : (listeners.current ?? null);
-
-  // If the station goes off air while someone is tuned in, tear playback down
-  // so the <audio> element isn't left retrying a dead mount.
-  useEffect(() => {
-    if (offline && tunedIn) stop();
-  }, [offline, tunedIn, stop]);
 
   // One-shot audience beacon: hand the controller the external referrer + any
   // UTM tag on first load. The referrer is browser-only knowledge — by the time

--- a/web/hooks/useStationFeed.ts
+++ b/web/hooks/useStationFeed.ts
@@ -38,6 +38,7 @@ export interface StationFeed {
 
 const EMPTY_STATE: StationState = { upcoming: [], history: [], djLog: [] };
 const EMPTY_SESSION: SessionPayload = { session: null, messages: [] };
+const OFFLINE_CONFIRM_POLLS = 4;
 
 // Only commit a freshly-parsed payload when it differs from what's already in
 // state — returning `prev` from the updater skips the re-render, so a quiet
@@ -64,6 +65,7 @@ export function useStationFeed(): StationFeed {
   const [trackStartedAt, setTrackStartedAt] = useState<number | null>(null);
   const [timezone, setTimezone] = useState<string | null>(null);
   const lastTrackKeyRef = useRef<string | null>(null);
+  const offlinePollsRef = useRef(0);
 
   useEffect(() => {
     const tick = async () => {
@@ -84,7 +86,15 @@ export function useStationFeed(): StationFeed {
         if (npRes.dj) setIfChanged<DjState | null>(setDj, npRes.dj);
         setIfChanged(setActiveShow, npRes.activeShow ?? npRes.context?.activeShow ?? null);
         if (npRes.listeners != null) setIfChanged<ListenerCount | number | null>(setListeners, npRes.listeners);
-        if (typeof npRes.streamOnline === 'boolean') setStreamOnline(npRes.streamOnline);
+        if (typeof npRes.streamOnline === 'boolean') {
+          if (npRes.streamOnline) {
+            offlinePollsRef.current = 0;
+            setStreamOnline(true);
+          } else {
+            offlinePollsRef.current += 1;
+            if (offlinePollsRef.current >= OFFLINE_CONFIRM_POLLS) setStreamOnline(false);
+          }
+        }
         if (typeof npRes.llmTokens === 'number') setIfChanged<number | null>(setLlmTokens, npRes.llmTokens);
         if (typeof npRes.timezone === 'string' && npRes.timezone) setTimezone(npRes.timezone);
         setIfChanged(setState, stRes);


### PR DESCRIPTION
## Summary

This PR makes the public listener player more tolerant of transient stream-status failures so a healthy audio element is not stopped by a short-lived `/api/now-playing` / Icecast status mismatch.

## Background

While investigating #461 on a local Docker deployment, I found that the direct Icecast mount (`/stream.mp3`) could keep playing reliably, while the React listener UI would stop after a short time. Instrumenting the player showed that the UI was not being disconnected by Icecast directly. Instead, one transient `streamOnline: false` update from the cached listener/status monitor caused `PlayerApp` to call `stop()`, which paused and cleared the active `<audio>` element.

That makes the status probe a single point of failure for playback, even when the actual audio stream is still alive.

## Changes

- Treat Icecast status fetch failures as unknown rather than proof that the stream is offline.
  - The listener monitor keeps the previous `online` / `bitrate` values and resets the current listener count when the status endpoint cannot be read.
- Debounce `streamOnline: false` in the listener UI.
  - The UI now requires several consecutive offline polls before presenting the station as offline.
- Remove the automatic `stop()` side effect from `PlayerApp` when `streamOnline === false`.
  - The audio element's own `waiting` / `stalled` / `error` handling remains responsible for actual stream recovery.
  - The status flag still informs UI state, but it no longer tears down active playback by itself.

## Why this should be safe

A transient status-probe failure is not equivalent to the broadcast source being gone. Keeping playback alive avoids false-positive disconnects, while real stream failures still surface through the browser media element and the existing player watchdog/error path.

## Verification

Tested on a local SUB/WAVE Docker deployment where the issue was reproducible:

- Confirmed `/stream.mp3` stayed alive while the UI stopped before this patch.
- Added temporary instrumentation and confirmed `offline-effect-stop` was the stop trigger.
- Applied this patch and verified listener UI playback stayed active for 90+ seconds:
  - `paused=false`
  - `readyState=4`
  - `currentTime` advanced continuously
- Ran `docker build -f web/Dockerfile ...` successfully with this change included.
- Ran controller checks locally:
  - `npm --prefix controller run lint` (passes with existing warnings)
  - `npm --prefix controller run test`

Fixes #461
