### PR TITLE
fix: transient stream-status no longer tears down playback (#463, rebased to develop)

### DIFF
--- a/controller/package.json
+++ b/controller/package.json
@@ -11,7 +11,7 @@
     "lastfm-session": "tsx scripts/lastfm-session.ts",
     "test:embed": "tsx scripts/embedding-preflight-test.ts",
     "test:llm": "tsx scripts/llm-pure.test.ts",
-    "test": "tsx scripts/llm-pure.test.ts && tsx scripts/picker-recency-regression.ts",
+    "test": "tsx scripts/llm-pure.test.ts && tsx scripts/picker-recency-regression.ts && tsx scripts/listeners-status.test.ts",
     "lint": "eslint . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit"

--- a/controller/scripts/listeners-status.test.ts
+++ b/controller/scripts/listeners-status.test.ts
@@ -1,0 +1,79 @@
+// Unit tests for the pure stream-status transition helper in
+// broadcast/listeners.ts. Run: `tsx scripts/listeners-status.test.ts` (folded
+// into `npm run test`).
+//
+// statusAfterFailure decides the cached StreamStatus after a status-fetch
+// failure. The branching is regression-critical: too eager and a transient
+// stats-endpoint timeout flips the station "offline" and tears down a healthy
+// listener (issue #461); too lax and a genuinely-down Icecast is pinned
+// "online" forever. node:assert-via-tsx style, matching llm-pure.test.ts.
+
+import assert from 'node:assert/strict';
+import { statusAfterFailure, type StreamStatus } from '../src/broadcast/listeners.js';
+
+let failures = 0;
+function test(name: string, fn: () => void | Promise<void>) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => console.log(`  ✓ ${name}`))
+    .catch((err) => { failures++; console.error(`  ✗ ${name}\n      ${err?.message || err}`); });
+}
+
+const LIMIT = 4;
+const online: StreamStatus = { online: true, listeners: { current: 3, peak: 5 }, bitrate: 192 };
+
+async function main() {
+  console.log('statusAfterFailure (transient vs sustained outage):');
+
+  await test('1st transient failure holds the last known online status', () => {
+    const next = statusAfterFailure(online, 1, LIMIT, 5);
+    assert.equal(next.online, true);              // not torn offline by one blip
+    assert.equal(next.bitrate, 192);              // last known bitrate kept
+    assert.equal(next.listeners.current, 3);      // last known count, NOT a flashed 0
+    assert.equal(next.listeners.peak, 5);
+  });
+
+  await test('failures just below the limit still hold online', () => {
+    const next = statusAfterFailure(online, LIMIT - 1, LIMIT, 5);
+    assert.equal(next.online, true);
+    assert.equal(next.listeners.current, 3);
+  });
+
+  await test('at the limit, a sustained outage reports offline', () => {
+    const next = statusAfterFailure(online, LIMIT, LIMIT, 5);
+    assert.equal(next.online, false);             // genuinely-down Icecast surfaces
+    assert.equal(next.bitrate, null);
+    assert.equal(next.listeners.current, 0);      // nobody's listening to a dead mount
+    assert.equal(next.listeners.peak, 5);         // run's peak preserved
+  });
+
+  await test('past the limit stays offline', () => {
+    const next = statusAfterFailure(online, LIMIT + 10, LIMIT, 5);
+    assert.equal(next.online, false);
+    assert.equal(next.listeners.current, 0);
+  });
+
+  await test('an already-offline prior status stays offline while transient', () => {
+    const offline: StreamStatus = { online: false, listeners: { current: 0, peak: 2 }, bitrate: null };
+    const next = statusAfterFailure(offline, 1, LIMIT, 2);
+    assert.equal(next.online, false);             // never flips a cold start "online"
+    assert.equal(next.listeners.peak, 2);
+  });
+
+  await test('peak is carried through (monotonic), not reset, on a transient hold', () => {
+    const next = statusAfterFailure(online, 1, LIMIT, 9);
+    assert.equal(next.listeners.peak, 9);
+  });
+
+  await test('does not mutate the previous status object', () => {
+    const prev: StreamStatus = { online: true, listeners: { current: 3, peak: 5 }, bitrate: 192 };
+    statusAfterFailure(prev, 1, LIMIT, 7);
+    assert.equal(prev.listeners.peak, 5);         // input untouched
+    assert.equal(prev.listeners.current, 3);
+  });
+
+  console.log(failures === 0 ? '\nAll listeners-status tests passed.' : `\n${failures} test(s) FAILED.`);
+  if (failures > 0) process.exit(1);
+}
+
+main();

--- a/controller/src/broadcast/listeners.ts
+++ b/controller/src/broadcast/listeners.ts
@@ -26,6 +26,7 @@ import * as settings from '../settings.js';
 
 let lastCount: number | null = null;        // null = unknown (not yet polled, or Icecast down)
 let peakSeen = 0;                            // running max of the deduped count this process run
+let consecutiveStatusFailures = 0;          // resets to 0 on every successful poll
 
 // Full cached stream status, refreshed by the same poll that maintains
 // lastCount. `online` is true when at least one broadcast mount has a source
@@ -41,6 +42,34 @@ export interface StreamStatus {
   bitrate: number | null;
 }
 let lastStatus: StreamStatus = { online: false, listeners: { current: 0, peak: 0 }, bitrate: null };
+
+// How many *consecutive* failed status polls before we stop trusting the last
+// known `online` and report the broadcast as offline. Below this we hold the
+// last good status so a transient stats-endpoint timeout never tears down a
+// healthy listener (issue #461); at or above it a genuinely unreachable Icecast
+// still surfaces as offline instead of being pinned "online" forever. 4 polls
+// × 15s ≈ 1 min of sustained failure.
+const STALE_STATUS_LIMIT = 4;
+
+// Next cached status after a status-fetch failure. Pure (no I/O) so the
+// transient-vs-sustained branching is unit-tested in isolation
+// (scripts/listeners-status.test.ts).
+//   • transient (failures < limit): hold the last known status — the count is
+//     stale-but-best-known, not a freshly-observed 0. Keeps a healthy player
+//     alive through a momentary stats blip.
+//   • sustained (failures ≥ limit): the broadcast really looks gone — report
+//     offline, zero the current count, drop bitrate; keep the run's peak.
+export function statusAfterFailure(
+  prev: StreamStatus,
+  consecutiveFailures: number,
+  limit: number,
+  peak: number,
+): StreamStatus {
+  if (consecutiveFailures >= limit) {
+    return { online: false, listeners: { current: 0, peak }, bitrate: null };
+  }
+  return { ...prev, listeners: { ...prev.listeners, peak } };
+}
 
 // Time-series file. JSONL of {t, count} rows, one per persisted sample.
 // We persist every minute (not every 15s poll) — keeps the file at ~1440
@@ -89,16 +118,16 @@ async function fetchCount() {
     lastCount = current;
     peakSeen = Math.max(peakSeen, current);
     lastStatus = { online, listeners: { current, peak: peakSeen }, bitrate };
+    consecutiveStatusFailures = 0;
   } catch {
     lastCount = null;
-    // Treat Icecast status fetch failures as "unknown", not as proof the
-    // broadcast went offline. The listener UI polls this cached status and
-    // should not tear down a healthy audio element because the stats endpoint
-    // had a transient timeout.
-    lastStatus = {
-      ...lastStatus,
-      listeners: { current: 0, peak: peakSeen },
-    };
+    // Treat a transient Icecast status fetch failure as "unknown", not as proof
+    // the broadcast went offline: hold the last known status so the listener UI
+    // doesn't tear down a healthy audio element over a momentary stats timeout
+    // (issue #461). Only once failures persist (STALE_STATUS_LIMIT) do we report
+    // offline — a genuinely unreachable Icecast must still surface eventually.
+    consecutiveStatusFailures += 1;
+    lastStatus = statusAfterFailure(lastStatus, consecutiveStatusFailures, STALE_STATUS_LIMIT, peakSeen);
   }
   // Persist at most one row per wall-clock minute. Skip null samples — a
   // stats outage shouldn't leave a misleading "0 listeners" stripe in the

--- a/controller/src/broadcast/listeners.ts
+++ b/controller/src/broadcast/listeners.ts
@@ -91,7 +91,14 @@ async function fetchCount() {
     lastStatus = { online, listeners: { current, peak: peakSeen }, bitrate };
   } catch {
     lastCount = null;
-    lastStatus = { online: false, listeners: { current: 0, peak: 0 }, bitrate: null };
+    // Treat Icecast status fetch failures as "unknown", not as proof the
+    // broadcast went offline. The listener UI polls this cached status and
+    // should not tear down a healthy audio element because the stats endpoint
+    // had a transient timeout.
+    lastStatus = {
+      ...lastStatus,
+      listeners: { current: 0, peak: peakSeen },
+    };
   }
   // Persist at most one row per wall-clock minute. Skip null samples — a
   // stats outage shouldn't leave a misleading "0 listeners" stripe in the

--- a/web/components/PlayerApp.tsx
+++ b/web/components/PlayerApp.tsx
@@ -50,7 +50,7 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
   const { apiUrl } = useStationOrigin();
   const { nowPlaying, context, dj, activeShow, listeners, streamOnline, llmTokens, state, session, trackStartedAt, timezone } = useStationFeed();
   const boothFeed = session.messages;
-  const { audioRef, tunedIn, status, volume, setVolume, tune, stop, toggleMute, muted, idleStopped } = usePlayer();
+  const { audioRef, tunedIn, status, volume, setVolume, tune, toggleMute, muted, idleStopped } = usePlayer();
 
   // streamOnline is null until the first poll resolves — only treat an
   // explicit false as offline so the player never flashes "offline" on load.
@@ -64,12 +64,6 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
   // normalise the feed's number | { current } | null shape to a plain count.
   const listenerCount =
     listeners == null ? null : typeof listeners === 'number' ? listeners : (listeners.current ?? null);
-
-  // If the station goes off air while someone is tuned in, tear playback down
-  // so the <audio> element isn't left retrying a dead mount.
-  useEffect(() => {
-    if (offline && tunedIn) stop();
-  }, [offline, tunedIn, stop]);
 
   // One-shot audience beacon: hand the controller the external referrer + any
   // UTM tag on first load. The referrer is browser-only knowledge — by the time

--- a/web/hooks/useStationFeed.ts
+++ b/web/hooks/useStationFeed.ts
@@ -38,6 +38,7 @@ export interface StationFeed {
 
 const EMPTY_STATE: StationState = { upcoming: [], history: [], djLog: [] };
 const EMPTY_SESSION: SessionPayload = { session: null, messages: [] };
+const OFFLINE_CONFIRM_POLLS = 4;
 
 // Only commit a freshly-parsed payload when it differs from what's already in
 // state — returning `prev` from the updater skips the re-render, so a quiet
@@ -64,6 +65,7 @@ export function useStationFeed(): StationFeed {
   const [trackStartedAt, setTrackStartedAt] = useState<number | null>(null);
   const [timezone, setTimezone] = useState<string | null>(null);
   const lastTrackKeyRef = useRef<string | null>(null);
+  const offlinePollsRef = useRef(0);
 
   useEffect(() => {
     const tick = async () => {
@@ -84,7 +86,15 @@ export function useStationFeed(): StationFeed {
         if (npRes.dj) setIfChanged<DjState | null>(setDj, npRes.dj);
         setIfChanged(setActiveShow, npRes.activeShow ?? npRes.context?.activeShow ?? null);
         if (npRes.listeners != null) setIfChanged<ListenerCount | number | null>(setListeners, npRes.listeners);
-        if (typeof npRes.streamOnline === 'boolean') setStreamOnline(npRes.streamOnline);
+        if (typeof npRes.streamOnline === 'boolean') {
+          if (npRes.streamOnline) {
+            offlinePollsRef.current = 0;
+            setStreamOnline(true);
+          } else {
+            offlinePollsRef.current += 1;
+            if (offlinePollsRef.current >= OFFLINE_CONFIRM_POLLS) setStreamOnline(false);
+          }
+        }
         if (typeof npRes.llmTokens === 'number') setIfChanged<number | null>(setLlmTokens, npRes.llmTokens);
         if (typeof npRes.timezone === 'string' && npRes.timezone) setTimezone(npRes.timezone);
         setIfChanged(setState, stRes);


### PR DESCRIPTION
Rebases **#463** by @kamjin3086 onto `develop` (the repo's integration branch — `main` is owned by release-please) and adds two follow-up refinements + a unit test. The contributor's original commit is preserved with their authorship.

Fixes #461. Supersedes #463.

## What #463 fixed

A single transient `/api/now-playing` status blip was a single point of failure for playback: one `streamOnline: false` made `PlayerApp` call `stop()`, pausing and clearing the live `<audio>` element even though `/stream.mp3` was still healthy (the symptom in #461 — UI goes silent, refresh recovers, Caddy logs the client cancelling the mount, listener count flaps 1→0). The fix decouples the status probe from playback:

- `listeners.ts` — a status-fetch failure is treated as *unknown* rather than proof the broadcast is gone.
- `useStationFeed.ts` — debounces `streamOnline: false` over 4 consecutive polls (~20s) before the UI believes it.
- `PlayerApp.tsx` — drops the `stop()` side effect; the `<audio>` element's own `waiting`/`stalled`/`error` watchdog (exponential backoff to 60s) owns real recovery.

## Follow-up refinements in this PR

1. **A genuinely-down Icecast still reads offline.** With #463 alone, if the Icecast status endpoint is *fully* unreachable (fetch throws every poll) `online` was held at its last value forever, so the offline indicator could be pinned "online" for a dead station. This now holds the last known status only for a bounded run of consecutive failures (`STALE_STATUS_LIMIT`, ~1 min at the 15s poll); past that it reports offline again. Fail-open is preserved for the DJ gate (`lastCount` stays `null` → `djCallsAllowed()` still treats the station as occupied).
2. **No flashed `0` on a transient blip.** The cached listener count now holds its last known value during a transient outage instead of resetting to `0`; it only zeroes once the outage is confirmed sustained.

The transition logic is extracted into a pure `statusAfterFailure()` helper and unit-tested (`controller/scripts/listeners-status.test.ts`, wired into `npm run test`).

## Verification

- `npm --prefix controller run test` — passes (incl. the new `statusAfterFailure` suite).
- `npm --prefix controller run lint` — 0 errors (pre-existing `no-explicit-any` warnings only).
- `npm --prefix web run lint` — clean.

Thanks @kamjin3086 for the diagnosis and original fix.