### PR TITLE
fix(controller/llm): route locca picker through done-tool, not native

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -129,10 +129,12 @@ async function main() {
     assert.deepEqual(providerOptions({ provider: 'locca', model: 'qwen3', reasoning: false }), {});
     assert.deepEqual(providerOptions({ provider: 'locca', model: 'qwen3', reasoning: true }), {});
   });
-  await test('capability flags: tool-object + repeat-penalty are Ollama-only', () => {
+  await test('capability flags: tool-object covers ollama + locca; repeat-penalty is Ollama-only', () => {
     assert.equal(needsToolCallObject({ provider: 'ollama' }), true);
     assert.equal(needsToolCallObject({ provider: 'openai' }), false);
-    assert.equal(needsToolCallObject({ provider: 'locca' }), false);
+    // locca serves local GGUF models that don't explore under native Output.object
+    // (32/32 explored=false on gemma-4-12b / qwen3.5-9b) — same as ollama.
+    assert.equal(needsToolCallObject({ provider: 'locca' }), true);
     assert.equal(repeatPenaltyApplies({ provider: 'ollama' }), true);
     assert.equal(repeatPenaltyApplies({ provider: 'deepseek' }), false);
     assert.equal(repeatPenaltyApplies({ provider: 'locca' }), false);
@@ -163,9 +165,11 @@ async function main() {
     assert.equal(agentPlan({ provider: 'ollama' }, {}, 3), 'done-tool');
     assert.equal(agentPlan({ provider: 'openai' }, {}, 0), 'native-no-tools');
     assert.equal(agentPlan({ provider: 'openai' }, {}, 3), 'native-then-done');
-    // locca routes like any native provider (not the Ollama tool-object path).
-    assert.equal(agentPlan({ provider: 'locca' }, {}, 0), 'native-no-tools');
-    assert.equal(agentPlan({ provider: 'locca' }, {}, 3), 'native-then-done');
+    // locca serves local GGUF models (same class as Ollama), so it takes the
+    // forced tool-object / done-tool path, NOT the native path — local llama.cpp
+    // models emit the object without exploring tools under native Output.object.
+    assert.equal(agentPlan({ provider: 'locca' }, {}, 0), 'object-via-tool');
+    assert.equal(agentPlan({ provider: 'locca' }, {}, 3), 'done-tool');
     assert.equal(agentPlan({ provider: 'openai' }, null, 3), 'free-text');
     assert.equal(agentPlan({ provider: 'ollama' }, null, 0), 'free-text');
   });

--- a/controller/src/llm/internal/provider/capabilities.ts
+++ b/controller/src/llm/internal/provider/capabilities.ts
@@ -59,10 +59,14 @@ const CAPS: Record<string, ProviderCapabilities> = {
     // registry), not via providerOptions.
     thinkingBlock: NONE,
   },
-  // locca is a first-class openai-compatible (llama.cpp) server — same traits:
-  // native objects, no repeat_penalty, no-think handled in transport.
+  // locca serves local llama.cpp GGUF models — the SAME model class as Ollama,
+  // not a cloud endpoint. Under native Output.object + auto tool_choice they emit
+  // a schema-valid object WITHOUT calling any discovery tool (verified 32/32
+  // explored=false on gemma-4-12b / qwen3.5-9b), so the native-then-done path
+  // wastes a model call before falling back. Use the forced done-tool path like
+  // ollama. No repeat_penalty, no-think handled in transport.
   locca: {
-    objectStrategy: 'native',
+    objectStrategy: 'tool',
     repeatPenaltyApplies: false,
     thinkingBlock: NONE,
   },


### PR DESCRIPTION
## What

Routes the **locca** provider's picker agent through the forced **done-tool** path instead of the **native** `Output.object` path.

## Why

`capabilities.ts` classified `locca` as `objectStrategy: 'native'` on the assumption it behaves like a cloud openai-compatible endpoint. But locca serves **local llama.cpp GGUF models** — the same class Ollama serves — which under native `Output.object` + auto `tool_choice` emit a schema-valid object **without ever calling a discovery tool** (`explored=false`). So `agentPlan` routed every locca pick through `native-then-done`: a native attempt that can never succeed, then a fall-back to the done-tool path that actually produces the pick. One wasted model call per pick — pure latency tax.

Ollama already avoids this by being `objectStrategy: 'tool'`. locca serves the same models, so it should too.

## Fix

- `capabilities.ts`: `locca.objectStrategy` `'native'` → `'tool'` (one line + corrected comment).
- `llm-pure.test.ts`: update the routing assertions that pinned the old native assumption.

## Measured impact

Via `controller/scripts/picker-test.mjs` against a real locca server (8 iters × short+long), `gemma-4-12b-it-Q4_K_M` on Strix Halo / Vulkan:

| mode | success | median before | median after | p95 before | p95 after |
|---|---|---|---|---|---|
| short | 100% → 100% | 35.3s | **15.3s** (−57%) | 38.3s | 26.1s |
| long  | 100% → 100% | 40.5s | **22.4s** (−45%) | 46.5s | 26.0s |

32/32 calls previously logged `native output produced no usable pick (explored=false)`; now **zero**. Reliability unchanged, latency roughly halved.

## Verification

- `npm run lint` (eslint + tsc): **0 errors** (pre-existing `no-explicit-any` warnings only).
- `npm run test:llm`: all pass, including the updated routing assertions.
- Re-benchmarked end-to-end against the live locca server.

## Follow-up (not in this PR)

`openai-compatible` (capabilities.ts:55) is still `objectStrategy: 'native'` and very likely has the same problem — it also targets local llama.cpp servers. Left unchanged because it wasn't benchmarked here; worth a follow-up for anyone running the picker through a raw openai-compatible llama.cpp endpoint.
