### PR TITLE
feat: import operator-supplied jingles and sound effects

### DIFF
--- a/controller/package-lock.json
+++ b/controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sub-wave-controller",
-  "version": "0.18.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sub-wave-controller",
-      "version": "0.18.0",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.84",
@@ -20,6 +20,7 @@
         "ai-sdk-ollama": "^3.8.7",
         "better-sqlite3": "^11.10.0",
         "express": "^4.21.0",
+        "multer": "^2.0.1",
         "node-cron": "^3.0.3",
         "pino": "^9.5.0",
         "pino-pretty": "^11.3.0",
@@ -30,6 +31,7 @@
       "devDependencies": {
         "@types/adm-zip": "^0.5.7",
         "@types/express": "^5.0.0",
+        "@types/multer": "^1.4.12",
         "@types/node": "^25.9.1",
         "@types/node-cron": "^3.0.11",
         "eslint": "^9.39.4",
@@ -950,6 +952,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.13.tgz",
+      "integrity": "sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
@@ -1047,6 +1059,7 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -1424,6 +1437,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1455,6 +1469,7 @@
       "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.206.tgz",
       "integrity": "sha512-hVdB5PozMMxmkPBfbCxkFOn0eVeCMi/imkfPvk65cxL4O8oIrvjUxDUX8dGkdkWG1No+R7e7D9ti2DHO61Z4YQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@ai-sdk/gateway": "3.0.132",
         "@ai-sdk/provider": "3.0.10",
@@ -1518,6 +1533,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1696,6 +1717,23 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1799,6 +1837,35 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -2062,6 +2129,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2980,6 +3048,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -3181,6 +3268,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3798,6 +3886,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -3978,12 +4074,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4132,6 +4235,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/controller/package.json
+++ b/controller/package.json
@@ -28,6 +28,7 @@
     "ai-sdk-ollama": "^3.8.7",
     "better-sqlite3": "^11.10.0",
     "express": "^4.21.0",
+    "multer": "^2.0.1",
     "node-cron": "^3.0.3",
     "pino": "^9.5.0",
     "pino-pretty": "^11.3.0",
@@ -38,6 +39,7 @@
   "devDependencies": {
     "@types/adm-zip": "^0.5.7",
     "@types/express": "^5.0.0",
+    "@types/multer": "^1.4.12",
     "@types/node": "^25.9.1",
     "@types/node-cron": "^3.0.11",
     "eslint": "^9.39.4",

--- a/controller/src/audio/audio-import.ts
+++ b/controller/src/audio/audio-import.ts
@@ -1,0 +1,108 @@
+// Shared helpers for operator-imported audio (jingles + sound effects).
+//
+// Imported files are run through ffmpeg so the library stays uniform with the
+// generated assets: jingles become WAV (matching Piper TTS output), effects
+// become MP3 (matching ElevenLabs output). ffmpeg also validates the upload —
+// it exits non-zero on anything that isn't decodable audio. When ffmpeg is
+// absent (a bare-host `npm start` dev box rather than the Docker image, which
+// ships ffmpeg) we fall back to storing the raw bytes with their original
+// extension so the feature still works; preview routes pick the content type
+// off the extension either way.
+
+import { spawn } from 'node:child_process';
+import { writeFile, mkdir, unlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+// Container/codec formats Liquidsoap can decode and we accept on import.
+export const ACCEPTED_AUDIO_EXTS = ['mp3', 'wav', 'ogg', 'oga', 'flac', 'm4a', 'aac', 'opus'] as const;
+
+const CONTENT_TYPES: Record<string, string> = {
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  ogg: 'audio/ogg',
+  oga: 'audio/ogg',
+  opus: 'audio/ogg',
+  flac: 'audio/flac',
+  m4a: 'audio/mp4',
+  aac: 'audio/aac',
+};
+
+// Lower-cased extension without the dot, or '' if there isn't one.
+export function extOf(name: string): string {
+  const ext = path.extname(String(name || '')).slice(1).toLowerCase();
+  return ext;
+}
+
+// Filename minus its extension — used as a default jingle label.
+export function baseName(name: string): string {
+  return path.basename(String(name || ''), path.extname(String(name || ''))).trim();
+}
+
+export function isAcceptedAudio(name: string): boolean {
+  return (ACCEPTED_AUDIO_EXTS as readonly string[]).includes(extOf(name));
+}
+
+// Content type for an audio file path, defaulting to a safe generic.
+export function audioContentType(filePath: string): string {
+  return CONTENT_TYPES[extOf(filePath)] || 'application/octet-stream';
+}
+
+// Cached ffmpeg-availability probe. `null` until first checked.
+let ffmpegOk: boolean | null = null;
+
+export async function hasFfmpeg(): Promise<boolean> {
+  if (ffmpegOk !== null) return ffmpegOk;
+  ffmpegOk = await new Promise<boolean>((resolve) => {
+    try {
+      const proc = spawn('ffmpeg', ['-version']);
+      proc.on('error', () => resolve(false));
+      proc.on('close', (code) => resolve(code === 0));
+    } catch {
+      resolve(false);
+    }
+  });
+  return ffmpegOk;
+}
+
+export type TranscodeFormat = 'wav' | 'mp3';
+
+function runFfmpeg(args: string[]): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const proc = spawn('ffmpeg', args);
+    let stderr = '';
+    proc.stderr.on('data', (d) => { stderr += d.toString(); });
+    proc.on('error', reject);
+    proc.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`ffmpeg failed (exit ${code}): ${stderr.trim().slice(-300)}`));
+    });
+  });
+}
+
+// Transcode an in-memory upload to outPath in the given format. The input is
+// written to a temp file (not piped) so seek-dependent containers like m4a/mp4
+// decode correctly. `loudnorm` applies EBU R128 levelling — appropriate for
+// speech-length jingles, left off for short transient effects where a one-pass
+// loudnorm on <2s of audio is unreliable.
+export async function transcodeAudio(
+  input: Buffer,
+  { outPath, format, loudnorm = false }: { outPath: string; format: TranscodeFormat; loudnorm?: boolean },
+): Promise<void> {
+  if (!input?.length) throw new Error('empty audio buffer');
+  await mkdir(path.dirname(outPath), { recursive: true });
+
+  const tmp = path.join(tmpdir(), `subwave-import-${crypto.randomBytes(6).toString('hex')}`);
+  await writeFile(tmp, input);
+  try {
+    const args = ['-hide_banner', '-loglevel', 'error', '-i', tmp];
+    if (loudnorm) args.push('-af', 'loudnorm=I=-16:TP=-1.5:LRA=11');
+    if (format === 'wav') args.push('-c:a', 'pcm_s16le');
+    else args.push('-c:a', 'libmp3lame', '-q:a', '4');
+    args.push('-y', outPath);
+    await runFfmpeg(args);
+  } finally {
+    await unlink(tmp).catch(() => {});
+  }
+}

--- a/controller/src/broadcast/jingles.ts
+++ b/controller/src/broadcast/jingles.ts
@@ -3,13 +3,16 @@
 //
 // Files live at <stateDir>/jingles/<hash>.wav and are referenced from
 // <stateDir>/jingles.m3u (one path per line). A sidecar <stateDir>/
-// jingles.json maps filename → { text, createdAt, builtin }.
+// jingles.json maps filename → { text, createdAt, builtin, source }.
 
 import { readFile, writeFile, unlink, mkdir, stat } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import crypto from 'node:crypto';
 import { speak } from '../audio/tts.js';
 import { STATE_DIR } from '../config.js';
+import {
+  transcodeAudio, hasFfmpeg, extOf, baseName, isAcceptedAudio,
+} from '../audio/audio-import.js';
 
 const DIR = `${STATE_DIR}/jingles`;
 const PLAYLIST = `${STATE_DIR}/jingles.m3u`;
@@ -55,6 +58,7 @@ export async function list() {
       text: info.text,
       createdAt: info.createdAt,
       builtin: !!info.builtin,
+      source: info.source || (info.builtin ? 'builtin' : 'tts'),
       size: s.size,
     });
   }
@@ -96,6 +100,43 @@ export async function create(text: string, { builtin = false }: { builtin?: bool
   await saveMeta(meta);
   await rewritePlaylist(Object.keys(meta.items));
   return { filename, text: text.trim(), outPath };
+}
+
+// Import an operator-supplied audio file as a jingle. The upload is transcoded
+// to WAV + loudness-levelled (matching generated jingles) when ffmpeg is
+// available, otherwise stored as-is with its original extension. `label` is the
+// display text; it defaults to the original file name. Returns { filename, text }.
+export async function importAudio(
+  buffer: Buffer,
+  { label = '', originalName = '' }: { label?: string; originalName?: string } = {},
+) {
+  if (!buffer?.length) throw new Error('Empty audio file');
+  if (originalName && !isAcceptedAudio(originalName)) {
+    throw new Error(`Unsupported audio type: ${originalName}`);
+  }
+  await mkdir(DIR, { recursive: true });
+
+  const id = crypto.randomBytes(4).toString('hex');
+  let filename: string;
+  if (await hasFfmpeg()) {
+    filename = `jingle_${id}.wav`;
+    await transcodeAudio(buffer, { outPath: `${DIR}/${filename}`, format: 'wav', loudnorm: true });
+  } else {
+    filename = `jingle_${id}.${extOf(originalName) || 'mp3'}`;
+    await writeFile(`${DIR}/${filename}`, buffer);
+  }
+
+  const text = (label || '').trim() || baseName(originalName) || 'Imported jingle';
+  const meta = await loadMeta();
+  meta.items[filename] = {
+    text,
+    createdAt: new Date().toISOString(),
+    builtin: false,
+    source: 'upload',
+  };
+  await saveMeta(meta);
+  await rewritePlaylist(Object.keys(meta.items));
+  return { filename, text };
 }
 
 export async function remove(filename: string) {

--- a/controller/src/broadcast/sfx.ts
+++ b/controller/src/broadcast/sfx.ts
@@ -12,6 +12,7 @@
 import { readFile, writeFile, unlink, mkdir, stat, copyFile } from 'node:fs/promises';
 import { STATE_DIR, SOUNDS_DIR } from '../config.js';
 import { generateSfx, isConfigured } from '../audio/sfx-gen.js';
+import { transcodeAudio, hasFfmpeg, extOf, isAcceptedAudio } from '../audio/audio-import.js';
 
 const DIR = `${STATE_DIR}/sfx`;
 const META = `${STATE_DIR}/sfx.json`;
@@ -96,6 +97,7 @@ export async function list() {
       prompt: info.prompt || '',
       durationSec: info.durationSec || null,
       builtin: !!info.builtin,
+      source: info.source || (info.builtin ? 'builtin' : 'generated'),
       createdAt: info.createdAt,
       size: s.size,
     });
@@ -140,6 +142,49 @@ export async function create({ name, description, prompt, durationSec, builtin =
     durationSec: Number(durationSec) || null,
     file,
     builtin,
+    createdAt: new Date().toISOString(),
+  };
+  await saveMeta(meta);
+  return meta.items[slug];
+}
+
+// Import an operator-supplied audio file as a sound effect. Transcoded to MP3
+// (matching generated effects) when ffmpeg is available, otherwise stored as-is
+// with its original extension. No loudnorm — effects are short and a one-pass
+// loudness pass on a transient is unreliable; the broadcast limiter catches
+// peaks. Rejects a name that already exists so a built-in can't be clobbered.
+export async function importAudio(
+  buffer: Buffer,
+  { name, description = '', originalName = '' }: { name: string; description?: string; originalName?: string },
+) {
+  const slug = slugify(name);
+  if (!slug) throw new Error('Sound effect name is required');
+  if (!buffer?.length) throw new Error('Empty audio file');
+  if (originalName && !isAcceptedAudio(originalName)) {
+    throw new Error(`Unsupported audio type: ${originalName}`);
+  }
+  await mkdir(DIR, { recursive: true });
+
+  const meta = await loadMeta();
+  if (meta.items[slug]) throw new Error(`a sound effect named "${slug}" already exists`);
+
+  let file: string;
+  if (await hasFfmpeg()) {
+    file = `${slug}.mp3`;
+    await transcodeAudio(buffer, { outPath: `${DIR}/${file}`, format: 'mp3' });
+  } else {
+    file = `${slug}.${extOf(originalName) || 'mp3'}`;
+    await writeFile(`${DIR}/${file}`, buffer);
+  }
+
+  meta.items[slug] = {
+    name: slug,
+    description: (description || '').trim(),
+    prompt: '',
+    durationSec: null,
+    file,
+    builtin: false,
+    source: 'upload',
     createdAt: new Date().toISOString(),
   };
   await saveMeta(meta);

--- a/controller/src/middleware/upload.ts
+++ b/controller/src/middleware/upload.ts
@@ -1,0 +1,27 @@
+// Multipart single-file upload middleware (in-memory) for operator media
+// imports — jingles and sound effects. Wraps multer so a too-large file or a
+// parse error comes back as a clean JSON 400 instead of Express's default
+// HTML error page. The global express.json() body parser doesn't touch
+// multipart/form-data, so there's no conflict applying this per-route.
+
+import multer from 'multer';
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+const DEFAULT_MAX_BYTES = 25 * 1024 * 1024; // 25 MB — generous for a stinger.
+const storage = multer.memoryStorage();
+
+export function audioUpload(field: string, maxBytes = DEFAULT_MAX_BYTES): RequestHandler {
+  const mw = multer({ storage, limits: { fileSize: maxBytes } }).single(field);
+  return (req: Request, res: Response, next: NextFunction) => {
+    mw(req, res, (err: unknown) => {
+      if (err) {
+        const e = err as { code?: string; message?: string };
+        const msg = e?.code === 'LIMIT_FILE_SIZE'
+          ? `file too large (max ${Math.round(maxBytes / (1024 * 1024))} MB)`
+          : (e?.message || 'upload failed');
+        return res.status(400).json({ error: msg });
+      }
+      next();
+    });
+  };
+}

--- a/controller/src/routes/jingles.ts
+++ b/controller/src/routes/jingles.ts
@@ -4,6 +4,8 @@ import express from 'express';
 import * as jingles from '../broadcast/jingles.js';
 import { queue } from '../broadcast/queue.js';
 import { requireAdmin } from '../middleware/auth.js';
+import { audioUpload } from '../middleware/upload.js';
+import { audioContentType } from '../audio/audio-import.js';
 import { tagger, startTagger, stopTagger } from '../broadcast/tagger.js';
 
 export const router = express.Router();
@@ -32,6 +34,23 @@ router.post('/jingles', requireAdmin, async (req, res) => {
   }
 });
 
+// Import an operator-supplied mp3/wav as a jingle (multipart `file`, optional
+// `label`). Transcoded + level-matched server-side (see broadcast/jingles.js).
+router.post('/jingles/upload', requireAdmin, audioUpload('file'), async (req, res) => {
+  const file = req.file;
+  if (!file) return res.status(400).json({ error: 'file is required' });
+  try {
+    const created = await jingles.importAudio(file.buffer, {
+      label: req.body?.label,
+      originalName: file.originalname,
+    });
+    queue.log('scheduler', `Jingle imported: "${created.text.slice(0, 60)}…"`);
+    res.json(created);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
 router.delete('/jingles/:filename', requireAdmin, async (req, res) => {
   try {
     res.json(await jingles.remove(req.params.filename));
@@ -47,7 +66,7 @@ router.get('/jingles/:filename/audio', requireAdmin, async (req, res) => {
   try {
     const filePath = await jingles.getPath(req.params.filename);
     if (!filePath) return res.status(404).json({ error: 'unknown jingle' });
-    res.type('audio/wav').sendFile(filePath);
+    res.type(audioContentType(filePath)).sendFile(filePath);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/controller/src/routes/sfx.ts
+++ b/controller/src/routes/sfx.ts
@@ -5,6 +5,8 @@ import * as sfx from '../broadcast/sfx.js';
 import { isConfigured } from '../audio/sfx-gen.js';
 import { queue } from '../broadcast/queue.js';
 import { requireAdmin } from '../middleware/auth.js';
+import { audioUpload } from '../middleware/upload.js';
+import { audioContentType } from '../audio/audio-import.js';
 
 export const router = express.Router();
 
@@ -33,6 +35,28 @@ router.post('/sfx', requireAdmin, async (req, res) => {
   }
 });
 
+// Import an operator-supplied audio file as a sound effect (multipart `file`,
+// `name`, optional `description`). No ElevenLabs key needed — this is the
+// upload path that complements prompt-based generation.
+router.post('/sfx/upload', requireAdmin, audioUpload('file'), async (req, res) => {
+  const file = req.file;
+  const name = (req.body?.name || '').trim();
+  const description = (req.body?.description || '').trim();
+  if (!file) return res.status(400).json({ error: 'file is required' });
+  if (!name) return res.status(400).json({ error: 'name is required' });
+  try {
+    const created = await sfx.importAudio(file.buffer, {
+      name,
+      description,
+      originalName: file.originalname,
+    });
+    queue.log('scheduler', `Sound effect imported: "${created.name}"`);
+    res.json(created);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
 router.delete('/sfx/:name', requireAdmin, async (req, res) => {
   try {
     res.json(await sfx.remove(req.params.name));
@@ -47,7 +71,7 @@ router.get('/sfx/:name/audio', requireAdmin, async (req, res) => {
   try {
     const filePath = await sfx.getPath(req.params.name);
     if (!filePath) return res.status(404).json({ error: 'unknown sound effect' });
-    res.type('audio/mpeg').sendFile(filePath);
+    res.type(audioContentType(filePath)).sendFile(filePath);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/docker/Dockerfile.controller
+++ b/docker/Dockerfile.controller
@@ -1,10 +1,12 @@
 FROM node:22-bookworm-slim
 
-# Shared build deps + espeak-ng for Kokoro phonemization (British English)
+# Shared build deps + espeak-ng for Kokoro phonemization (British English).
+# ffmpeg transcodes + level-matches operator-imported jingles/SFX (see
+# audio/audio-import.ts); without it the import path stores raw uploads as-is.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates wget tar \
     python3 python3-venv \
-    espeak-ng libsndfile1 \
+    espeak-ng libsndfile1 ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # Common wget retry policy for the model/binary pulls below. GitHub releases and

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -216,6 +216,7 @@ interface JingleEntry {
   size?: number;
   createdAt?: string;
   builtin?: boolean;
+  source?: string;
 }
 
 interface SfxEntry {
@@ -224,6 +225,7 @@ interface SfxEntry {
   size?: number;
   durationSec?: number;
   builtin?: boolean;
+  source?: string;
 }
 
 interface SfxData {
@@ -540,6 +542,25 @@ export default function SettingsPanel() {
     finally { setBusy(false); }
   };
 
+  // Multipart upload — adminFetch leaves Content-Type unset so the browser
+  // sets the multipart boundary itself. The controller transcodes + levels.
+  const uploadJingle = async (file: File, label: string): Promise<boolean> => {
+    if (busy) return false;
+    setBusy(true);
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      if (label.trim()) fd.append('label', label.trim());
+      const r = await adminFetch('/jingles/upload', { method: 'POST', body: fd });
+      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      await refresh();
+      notify.ok('jingle imported');
+      return true;
+    } catch (e) { notify.err(`Jingle import failed: ${errorMessage(e)}`); return false; }
+    finally { setBusy(false); }
+  };
+
   const createSfx = async () => {
     if (!sfxForm.name.trim() || !sfxForm.prompt.trim() || busy) return;
     setBusy(true);
@@ -570,6 +591,25 @@ export default function SettingsPanel() {
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
       await refreshSfx();
     } catch (e) { notify.err(`Delete failed: ${errorMessage(e)}`); }
+    finally { setBusy(false); }
+  };
+
+  // Upload a ready-made effect — no ElevenLabs key required (unlike createSfx).
+  const uploadSfx = async (file: File, name: string, description: string): Promise<boolean> => {
+    if (busy) return false;
+    setBusy(true);
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      fd.append('name', name.trim());
+      if (description.trim()) fd.append('description', description.trim());
+      const r = await adminFetch('/sfx/upload', { method: 'POST', body: fd });
+      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      await refreshSfx();
+      notify.ok('sound effect imported');
+      return true;
+    } catch (e) { notify.err(`Sound effect import failed: ${errorMessage(e)}`); return false; }
     finally { setBusy(false); }
   };
 
@@ -663,7 +703,8 @@ export default function SettingsPanel() {
               <JinglesSection
                 data={data} form={form} setForm={updateForm} busy={busy}
                 jingleText={jingleText} setJingleText={setJingleText}
-                createJingle={createJingle} saveSettings={saveSettings}
+                createJingle={createJingle} uploadJingle={uploadJingle}
+                saveSettings={saveSettings}
                 onDelete={setConfirmDelete} adminFetch={adminFetch}
               />
             )}
@@ -679,7 +720,8 @@ export default function SettingsPanel() {
         {activeSection === 'sfx' && (
           <SfxSection
             sfxData={sfxData} sfxForm={sfxForm} setSfxForm={setSfxForm}
-            busy={busy} createSfx={createSfx} onDelete={setConfirmDeleteSfx}
+            busy={busy} createSfx={createSfx} uploadSfx={uploadSfx}
+            onDelete={setConfirmDeleteSfx}
             data={data} saveSettings={saveSettings} adminFetch={adminFetch}
           />
         )}
@@ -3192,16 +3234,29 @@ interface JinglesSectionProps extends SectionProps {
   jingleText: string;
   setJingleText: (s: string) => void;
   createJingle: () => void;
+  uploadJingle: (file: File, label: string) => Promise<boolean>;
   onDelete: (filename: string | null) => void;
   adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
 }
 
 function JinglesSection({
   data, form, setForm, busy, jingleText, setJingleText,
-  createJingle, saveSettings, onDelete, adminFetch,
+  createJingle, uploadJingle, saveSettings, onDelete, adminFetch,
 }: JinglesSectionProps) {
   const ratioDirty = form.jingleRatio !== String(data.values?.jingleRatio);
   const jingles = data.jingles || [];
+  const [importFile, setImportFile] = useState<File | null>(null);
+  const [importLabel, setImportLabel] = useState('');
+  const importRef = useRef<HTMLInputElement>(null);
+  const doImport = async () => {
+    if (!importFile) return;
+    const ok = await uploadJingle(importFile, importLabel);
+    if (ok) {
+      setImportFile(null);
+      setImportLabel('');
+      if (importRef.current) importRef.current.value = '';
+    }
+  };
 
   return (
     <>
@@ -3267,6 +3322,44 @@ function JinglesSection({
         </div>
       </Card>
 
+      <Card title="Import jingle" sub="bring your own mp3 / wav">
+        <div className="field">
+          <Label>Audio file</Label>
+          <input
+            ref={importRef}
+            type="file"
+            accept="audio/*,.mp3,.wav,.ogg,.flac,.m4a,.aac,.opus"
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setImportFile(e.target.files?.[0] ?? null)}
+            className="hidden"
+          />
+          <div className="flex flex-wrap items-center gap-2.5">
+            <Btn tone="solid" onClick={() => importRef.current?.click()} disabled={busy}>
+              {importFile ? 'Change file…' : 'Choose audio file…'}
+            </Btn>
+            {importFile && (
+              <span className="text-[12px] text-ink">{importFile.name}</span>
+            )}
+          </div>
+          <div className="field-hint">
+            mp3, wav, ogg, flac, m4a, aac or opus · up to 25 MB · converted and level-matched on import
+          </div>
+        </div>
+        <div className="field mt-3.5">
+          <Label>Label (optional)</Label>
+          <Input
+            value={importLabel}
+            maxLength={200}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setImportLabel(e.target.value)}
+            placeholder="shown in the list — defaults to the file name"
+          />
+        </div>
+        <div className="mt-3.5 flex items-center gap-2.5">
+          <Btn tone="accent" onClick={doImport} disabled={busy || !importFile}>
+            {busy ? 'Importing…' : 'Import jingle'}
+          </Btn>
+        </div>
+      </Card>
+
       <Card title="Jingles" sub={`${jingles.length} file${jingles.length === 1 ? '' : 's'}`}>
         {jingles.length === 0 && (
           <div className="py-2 text-[12px] text-muted italic">
@@ -3287,6 +3380,7 @@ function JinglesSection({
                   <span className="caption">{new Date(j.createdAt).toLocaleString('en-GB')}</span>
                 )}
                 {j.builtin && <Pill tone="accent">builtin</Pill>}
+                {j.source === 'upload' && <Pill tone="ink">uploaded</Pill>}
               </div>
             </div>
             <div className="flex items-center gap-2">
@@ -3319,13 +3413,30 @@ interface SfxSectionProps {
   setSfxForm: (updater: (f: SfxForm) => SfxForm) => void;
   busy: boolean;
   createSfx: () => void;
+  uploadSfx: (file: File, name: string, description: string) => Promise<boolean>;
   onDelete: (name: string | null) => void;
   data: SettingsData | null;
   saveSettings: SaveSettings;
   adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
 }
 
-function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, onDelete, data, saveSettings, adminFetch }: SfxSectionProps) {
+function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uploadSfx, onDelete, data, saveSettings, adminFetch }: SfxSectionProps) {
+  // Hooks must run before the early "loading…" return — keep them at the top.
+  const [importFile, setImportFile] = useState<File | null>(null);
+  const [importName, setImportName] = useState('');
+  const [importDesc, setImportDesc] = useState('');
+  const importRef = useRef<HTMLInputElement>(null);
+  const doImport = async () => {
+    if (!importFile || !importName.trim()) return;
+    const ok = await uploadSfx(importFile, importName, importDesc);
+    if (ok) {
+      setImportFile(null);
+      setImportName('');
+      setImportDesc('');
+      if (importRef.current) importRef.current.value = '';
+    }
+  };
+
   if (!sfxData) {
     return <div className="text-[13px] text-muted italic">loading…</div>;
   }
@@ -3338,7 +3449,7 @@ function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, onDelete, d
       <SectionHeader
         eyebrow="sound effects"
         title="Stingers the DJ agent plays under its voice."
-        sub="The segment-director agent can garnish a spoken break with one of these effects, mixed beneath the voice. Built-in effects ship with the station; new ones are generated by ElevenLabs from a text prompt."
+        sub="The segment-director agent can garnish a spoken break with one of these effects, mixed beneath the voice. Built-in effects ship with the station; add your own by generating one from a text prompt (ElevenLabs) or importing an audio file."
         metrics={[{ n: String(list.length), l: 'effects', accent: true }]}
       />
 
@@ -3438,6 +3549,56 @@ function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, onDelete, d
         </div>
       </Card>
 
+      <Card title="Import sound effect" sub="bring your own mp3 / wav — no ElevenLabs key needed">
+        <div className="field">
+          <Label>Name</Label>
+          <Input
+            value={importName}
+            maxLength={60}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setImportName(e.target.value)}
+            placeholder="e.g. my-stinger"
+            className="max-w-[280px]"
+          />
+          <div className="field-hint">A short slug the agent references — letters, numbers and dashes.</div>
+        </div>
+        <div className="field mt-3.5">
+          <Label>Description</Label>
+          <Input
+            value={importDesc}
+            maxLength={200}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setImportDesc(e.target.value)}
+            placeholder="when the agent should reach for this effect"
+          />
+          <div className="field-hint">The agent reads this to decide when the effect fits a line.</div>
+        </div>
+        <div className="field mt-3.5">
+          <Label>Audio file</Label>
+          <input
+            ref={importRef}
+            type="file"
+            accept="audio/*,.mp3,.wav,.ogg,.flac,.m4a,.aac,.opus"
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setImportFile(e.target.files?.[0] ?? null)}
+            className="hidden"
+          />
+          <div className="flex flex-wrap items-center gap-2.5">
+            <Btn tone="solid" onClick={() => importRef.current?.click()} disabled={busy}>
+              {importFile ? 'Change file…' : 'Choose audio file…'}
+            </Btn>
+            {importFile && <span className="text-[12px] text-ink">{importFile.name}</span>}
+          </div>
+          <div className="field-hint">mp3, wav, ogg, flac, m4a, aac or opus · up to 25 MB · converted to MP3 on import</div>
+        </div>
+        <div className="mt-3.5 flex items-center gap-2.5">
+          <Btn
+            tone="accent"
+            onClick={doImport}
+            disabled={busy || !importFile || !importName.trim()}
+          >
+            {busy ? 'Importing…' : 'Import sound effect'}
+          </Btn>
+        </div>
+      </Card>
+
       <Card title="Effect library" sub={`${list.length} effect${list.length === 1 ? '' : 's'}`}>
         {list.length === 0 && (
           <div className="py-2 text-[12px] text-muted italic">
@@ -3460,6 +3621,7 @@ function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, onDelete, d
                 <span className="caption">{fmtSize(s.size)}</span>
                 {s.durationSec && <span className="caption">{s.durationSec}s</span>}
                 {s.builtin && <Pill tone="accent">builtin</Pill>}
+                {s.source === 'upload' && <Pill tone="ink">uploaded</Pill>}
               </div>
             </div>
             <div className="flex items-center gap-2">

--- a/web/components/manual/AdminSettings.tsx
+++ b/web/components/manual/AdminSettings.tsx
@@ -99,12 +99,13 @@ export default function AdminSettings() {
           </li>
           <li>
             <strong>Jingles</strong> — the short pre-rendered idents the station rotates
-            between music tracks. Add, remove and re-render them through the configured
-            voice; new renders are picked up automatically.
+            between music tracks. Render them through the configured voice, or import your
+            own mp3/wav; new files are picked up automatically.
           </li>
           <li>
             <strong>Sound FX</strong> — the library of stingers the DJ can drop into a
-            spoken break. Toggle the whole library on or off.
+            spoken break. Generate one from a text prompt, or import your own audio file
+            (no ElevenLabs key needed). Toggle the whole library on or off.
           </li>
         </ul>
         <div className="bs-callout">


### PR DESCRIPTION
Closes the request in discussion #443 — operators can now **import their own mp3/wav files** as jingles and as sound effects, alongside the existing TTS / ElevenLabs generation. Same admin Settings UI, reusing the existing library plumbing (sidecar metadata, watched-m3u → Liquidsoap, path-safe preview).

## What's new

**Controller**
- `audio/audio-import.ts` — ffmpeg transcode + format/mime helpers. Imports are converted to the canonical format (jingles → WAV with EBU R128 loudness levelling; effects → MP3, no level processing since loudnorm on sub-2s transients is unreliable). ffmpeg also validates the upload. Falls back to storing the raw file when ffmpeg is absent (bare-host `npm start`).
- `middleware/upload.ts` — multer wrapper (in-memory, 25 MB cap) returning clean JSON 400s.
- `broadcast/jingles.ts` / `broadcast/sfx.ts` — `importAudio()` registering into the existing sidecar + m3u, tagged `source: "upload"`. SFX rejects duplicate names so a built-in can't be clobbered.
- `routes/jingles.ts` / `routes/sfx.ts` — `POST /jingles/upload` and `POST /sfx/upload`; preview routes now serve the correct content-type by extension.

**Web**
- Admin Settings: "Import jingle" / "Import sound effect" cards (file picker + label / name / description), an "uploaded" pill in each list.
- Manual copy updated.

**Build**
- `Dockerfile.controller` adds `ffmpeg`; controller deps add `multer` + `@types/multer`.

## Verification
- Unit test (real ffmpeg): OGG → WAV+MP3 transcode; `importAudio` for both libraries wrote files, updated sidecars, rewrote the m3u; duplicate-name and bad-type rejections fired.
- HTTP integration test: real multipart uploads through multer+routes returned 200; missing-file / missing-name returned 400; listing exposed `source:"upload"`; preview returned `200 audio/wav`.
- Lint gates: controller `eslint` 0 errors + `tsc` clean; web `lint` clean.

## Deploy note
ffmpeg + multer are baked into the controller image, so this needs a controller image rebuild in dev and prod (`docker compose up -d --build controller web`) — a `restart` won't pick it up.