### PR TITLE
docs(news): persona-in-the-prompt dispatch (build-in-public)

### DIFF
--- a/web/content/news/2026-06-20-persona-in-the-prompt.md
+++ b/web/content/news/2026-06-20-persona-in-the-prompt.md
@@ -1,0 +1,23 @@
+---
+title: Why our DJ's personality lives in the prompt, not the model
+date: 2026-06-20
+category: Spotlight
+author: The SUB/WAVE desk
+excerpt: You could fine-tune a DJ's voice into a model's weights. We didn't. The persona is config you can swap in a minute, and stock local models already run the picker well.
+---
+
+There's a clever project called Linden that trains a whole radio-DJ personality straight into a model's weights. One model, one voice, trained in. We looked hard at doing the same for SUB/WAVE, then went the other way. Here's why, and the testing that backed the call.
+
+## Persona is config, not weights
+
+A SUB/WAVE DJ is a set of "souls": short written personalities you edit in admin. Keep up to ten and the DJ picks one at random per turn, so the station never settles into a single note. Change a soul, save, and the next link comes out in the new voice. No training run, no model swap, no redeploy.
+
+Bake a persona into the weights instead and you get exactly one DJ, welded to exactly one model. That cuts against the whole point: pick your own voice, and pick your own brain, separately.
+
+## We tested the cheaper path
+
+Skip the fine-tune and the open question is whether a plain local model is good enough to run the DJ. So we measured it. On locca, two stock models (gemma-4-12b and qwen3.5-9b) both ran the track picker reliably. While benchmarking we also caught a routing quirk that made every pick do one wasted model call, and fixing it cut picker time by roughly half.
+
+## Why it helps
+
+You keep both freedoms. Swap the persona from admin in under a minute, and swap the model underneath it whenever you like, from a local box to a cloud one and back. The DJ you hear is yours to rewrite, not a voice frozen into a download.


### PR DESCRIPTION
## What

A new **Dispatches** post for `/news`: *Why our DJ's personality lives in the prompt, not the model*.

A build-in-public Spotlight on the deliberate bet that the DJ persona is **config** (swappable "souls" in the prompt) rather than fine-tuned into model weights. Contrasts with Linden, which trains one DJ personality into a LoRA. Anchored on the recent locca picker work: two stock local models (gemma-4-12b, qwen3.5-9b) run the picker reliably, and the routing fix in #467 roughly halved pick latency, so we never needed to fine-tune.

## File

```
web/content/news/2026-06-20-persona-in-the-prompt.md  ->  /news/persona-in-the-prompt
```

Category `Spotlight`, ~270 words, matched to the existing dispatch voice. Ran through the humanizer pass (no em-dashes, sentence-case headings, straight quotes, house cadence).

## Verification

- Frontmatter parses as YAML.
- `cd web && npm run build`: exit 0, `/news/persona-in-the-prompt` appears in the prerendered routes.

## Note

Content only, one file. Pairs with #467 (the picker latency fix it references) but is independent of it.
