### PR TITLE
feat(dj): per-persona tone dials (humour, local colour, warmth) + anti-cliché

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -14,7 +14,7 @@ import { agentPlan } from '../src/llm/internal/strategy/plan.js';
 import { introBudgetPhrase, enforceIntroBudget } from '../src/llm/internal/prompts/intro-budget.js';
 import { embeddingBaseUrl } from '../src/llm/internal/provider/embedding.js';
 import { DEFAULT_LOCCA_EMBED_BASE_URL } from '../src/llm/internal/provider/registry.js';
-import { personaToneDirectives, normalizeDial, DIAL_NEUTRAL } from '../src/settings.js';
+import { personaToneDirectives, normalizeDial, DIAL_NEUTRAL, validatePersonasStrict } from '../src/settings.js';
 
 let failures = 0;
 function test(name: string, fn: () => void | Promise<void>) {
@@ -237,6 +237,21 @@ async function main() {
     const both = personaToneDirectives({ humour: 8, warmth: 8 });
     assert.ok(both.startsWith('\n\nTone:\n- '));
     assert.equal(both.split('\n- ').length, 3); // header + 2 bullets
+  });
+  // The save path (validatePersonasStrict) rebuilds each persona from a field
+  // whitelist; if the dials aren't in it they are silently dropped on every
+  // save and the feature is dead end-to-end. Pin that they round-trip.
+  await test('validatePersonasStrict carries the dials through the save path', () => {
+    const base = { name: 'Nova', soul: 'late-night', frequency: 'moderate',
+      tts: { engine: 'piper', cloudProvider: 'openai', voice: '' } };
+    const [saved] = validatePersonasStrict([{ ...base, humour: 9, localColour: 0, warmth: 99 }]);
+    assert.equal(saved.humour, 9);
+    assert.equal(saved.localColour, 0);
+    assert.equal(saved.warmth, 10);            // clamped, same as normalizeDial
+    const [bare] = validatePersonasStrict([base]);
+    assert.equal(bare.humour, DIAL_NEUTRAL);   // absent dials default to neutral
+    assert.equal(bare.localColour, DIAL_NEUTRAL);
+    assert.equal(bare.warmth, DIAL_NEUTRAL);
   });
 
   console.log(failures === 0 ? '\nAll llm-pure tests passed.' : `\n${failures} test(s) FAILED.`);

--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -14,6 +14,7 @@ import { agentPlan } from '../src/llm/internal/strategy/plan.js';
 import { introBudgetPhrase, enforceIntroBudget } from '../src/llm/internal/prompts/intro-budget.js';
 import { embeddingBaseUrl } from '../src/llm/internal/provider/embedding.js';
 import { DEFAULT_LOCCA_EMBED_BASE_URL } from '../src/llm/internal/provider/registry.js';
+import { personaToneDirectives, normalizeDial, DIAL_NEUTRAL } from '../src/settings.js';
 
 let failures = 0;
 function test(name: string, fn: () => void | Promise<void>) {
@@ -210,6 +211,32 @@ async function main() {
     assert.ok(sentences.endsWith('.') && sentences.split(/\s+/).length <= 10);        // last full sentence
     const hardcut = enforceIntroBudget('a b c d e f g h i j k l m n o p q r s t', 4000);
     assert.ok(hardcut.endsWith('…') && hardcut.split(/\s+/).length <= 11);            // ellipsis fallback
+  });
+
+  // ---- persona tone dials (humour / local colour / warmth) ----
+  console.log('personaToneDirectives / normalizeDial:');
+  await test('normalizeDial clamps to 0-10 int, neutral on garbage', () => {
+    assert.equal(normalizeDial(7), 7);
+    assert.equal(normalizeDial(-3), 0);
+    assert.equal(normalizeDial(99), 10);
+    assert.equal(normalizeDial(6.7), 7);
+    assert.equal(normalizeDial('abc'), DIAL_NEUTRAL);
+    assert.equal(normalizeDial(undefined), DIAL_NEUTRAL);
+  });
+  await test('neutral / missing dials append nothing (prompt stays byte-identical)', () => {
+    assert.equal(personaToneDirectives({ humour: 5, localColour: 5, warmth: 5 }), '');
+    assert.equal(personaToneDirectives({}), '');
+    assert.equal(personaToneDirectives(null), '');
+    assert.equal(personaToneDirectives({ humour: 4, localColour: 6 }), '');
+  });
+  await test('low/high bands append the matching directive, in dial order', () => {
+    assert.match(personaToneDirectives({ humour: 9 }), /playful wit/);
+    assert.match(personaToneDirectives({ humour: 1 }), /Play it straight/);
+    assert.match(personaToneDirectives({ localColour: 10 }), /local setting/);
+    assert.match(personaToneDirectives({ warmth: 0 }), /cool, dry distance/);
+    const both = personaToneDirectives({ humour: 8, warmth: 8 });
+    assert.ok(both.startsWith('\n\nTone:\n- '));
+    assert.equal(both.split('\n- ').length, 3); // header + 2 bullets
   });
 
   console.log(failures === 0 ? '\nAll llm-pure tests passed.' : `\n${failures} test(s) FAILED.`);

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -1288,7 +1288,7 @@ function validateTtsBlock(raw, where) {
   return { engine: t.engine, cloudProvider: t.cloudProvider, voice };
 }
 
-function validatePersonasStrict(raw) {
+export function validatePersonasStrict(raw) {
   if (!Array.isArray(raw) || raw.length < 1 || raw.length > PERSONA_LIMIT) {
     throw new Error(`personas must be an array of 1-${PERSONA_LIMIT} entries`);
   }
@@ -1386,6 +1386,9 @@ function validatePersonasStrict(raw) {
       frequency: item.frequency,
       scriptLength,
       djMode,
+      humour: normalizeDial(item.humour),
+      localColour: normalizeDial(item.localColour),
+      warmth: normalizeDial(item.warmth),
       soul,
       language,
       avatar,

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -31,7 +31,7 @@ export const DEFAULT_DJ_PROMPT_TEMPLATE = `You are {name}, the on-air DJ for {st
 Hard rules:
 - Output ONLY the words to be spoken aloud. No stage directions, no asterisks, no quotes around your dialogue.
 - Keep it to 2-4 sentences unless asked for longer.
-- Never say "and now", "next up", "coming up next" — those are tells. Be more natural.
+- Never use radio-cliché tells: "and now", "next up", "coming up next", "and that was", or back-announcing with "that was [song] by [artist]". Be more natural.
 - Don't repeat the artist and title robotically. Reference them in passing if at all.
 - Reference the actual context (time, weather, what's coming) naturally.
 - Vary your opener and shape every time — never start the same way twice in a row, never use the same metaphor or framing as your last few lines.`;
@@ -55,6 +55,51 @@ export const FREQUENCIES = ['quiet', 'moderate', 'aggressive'];
 // 'extended' roughly doubles every spoken segment for a storytelling DJ.
 // See llm/dj.js LENGTH_PHRASES for the actual length directives.
 export const SCRIPT_LENGTHS = ['concise', 'extended'];
+
+// Per-persona tone dials. Each is 0-10 with 5 (DIAL_NEUTRAL) the default. A
+// model can't distinguish humour=6 from 7, so rather than inject a raw "7/10"
+// the dial maps to three bands: 0-3 low, 7-10 high, 4-6 neutral. Only a band
+// away from neutral appends a style directive (personaToneDirectives below), so
+// a persona left at the defaults renders a byte-identical prompt to before.
+export const TONE_DIALS = ['humour', 'localColour', 'warmth'] as const;
+export const DIAL_NEUTRAL = 5;
+
+const TONE_DIAL_PHRASES: Record<string, { low: string; high: string }> = {
+  humour: {
+    low: 'Play it straight; keep any wit rare and understated.',
+    high: 'Lean into dry, playful wit; an aside or a wink is welcome.',
+  },
+  localColour: {
+    low: 'Keep it universal; skip local references and place-specific colour.',
+    high: 'Lean on the local setting (the town, the weather, the hour) as texture.',
+  },
+  warmth: {
+    low: 'Keep a cool, dry distance; let the music carry the warmth.',
+    high: 'Be warm and earnest; speak to the listener like a friend.',
+  },
+};
+
+// Clamp any input to an integer 0-10, defaulting to neutral when unparseable.
+// The single chokepoint used by both normalizePersona and the seed roster.
+export function normalizeDial(v: any): number {
+  const n = Math.round(Number(v));
+  return Number.isFinite(n) ? Math.min(10, Math.max(0, n)) : DIAL_NEUTRAL;
+}
+
+// Pure: persona in, prompt fragment out. Returns '' when every dial sits in the
+// neutral band, so renderDjPrompt appends nothing and the default prompt is
+// unchanged. Unit-pinned in controller/scripts/llm-pure.test.ts.
+export function personaToneDirectives(persona: any): string {
+  if (!persona || typeof persona !== 'object') return '';
+  const lines: string[] = [];
+  for (const key of TONE_DIALS) {
+    const v = Number((persona as any)[key]);
+    if (!Number.isFinite(v)) continue;
+    if (v <= 3) lines.push(TONE_DIAL_PHRASES[key].low);
+    else if (v >= 7) lines.push(TONE_DIAL_PHRASES[key].high);
+  }
+  return lines.length ? `\n\nTone:\n- ${lines.join('\n- ')}` : '';
+}
 
 // DJ mode makes a persona behave like a working radio DJ rather than a
 // between-track narrator: it back-announces AND teases what's next, runs
@@ -688,6 +733,9 @@ function normalizePersona(raw: any) {
     frequency: FREQUENCIES.includes(raw.frequency) ? raw.frequency : 'moderate',
     scriptLength: SCRIPT_LENGTHS.includes(raw.scriptLength) ? raw.scriptLength : 'concise',
     djMode: raw.djMode === true,
+    humour: normalizeDial(raw.humour),
+    localColour: normalizeDial(raw.localColour),
+    warmth: normalizeDial(raw.warmth),
     soul,
     language: typeof raw.language === 'string' ? raw.language.trim().slice(0, 60) : '',
     avatar,
@@ -2070,11 +2118,12 @@ export function renderDjPrompt(persona: any, ctx: any = {}) {
     .replaceAll('{soul}', persona?.soul || DJ_SOULS[0])
     .replaceAll('{station}', station)
     .replaceAll('{location}', location);
+  const tone = personaToneDirectives(persona);
   if (tpl.includes('{language}')) {
     const lang = String(persona?.language || '').trim();
-    return rendered.replaceAll('{language}', lang || 'English');
+    return rendered.replaceAll('{language}', lang || 'English') + tone;
   }
-  return rendered + languageDirective(persona);
+  return rendered + languageDirective(persona) + tone;
 }
 
 // Persona prelude shared by every tool-loop agent system prompt — the picker

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -29,6 +29,16 @@ const SCRIPT_LENGTHS = [
   { id: 'concise',  label: 'Concise',  desc: 'Standard one-to-four sentence segments. The default.' },
   { id: 'extended', label: 'Extended', desc: 'Longer, storytelling segments — roughly double the length across intros, links, weather and idents.' },
 ];
+// Personality dials, 0–10, default 5. They map to three prompt bands server-side
+// (settings.personaToneDirectives): 0–3 low, 7–10 high, 4–6 neutral (nothing
+// injected). Surfacing the band keeps operators from expecting 6 vs 7 to differ.
+const TONE_DIALS = [
+  { id: 'humour',      label: 'Humour',       low: 'play it straight', high: 'playful & dry'  },
+  { id: 'localColour', label: 'Local colour', low: 'universal',        high: 'leans local'    },
+  { id: 'warmth',      label: 'Warmth',       low: 'cool & dry',       high: 'warm & earnest' },
+] as const;
+const DIAL_NEUTRAL = 5;
+const toneBand = (v: number) => (v <= 3 ? 'low' : v >= 7 ? 'high' : 'neutral');
 const ENGINES = [
   { id: 'piper',  label: 'Piper' },
   { id: 'kokoro', label: 'Kokoro' },
@@ -70,6 +80,10 @@ interface Persona {
   // what's next, runs callbacks across the session, and is more present. Off =
   // the historical tasteful-narrator behaviour.
   djMode: boolean;
+  // Tone dials, 0–10, default 5 (neutral). Map to prompt bands server-side.
+  humour: number;
+  localColour: number;
+  warmth: number;
   soul: string;
   // Free-text on-air language ("Turkish", "Türkçe"). Empty = English (no
   // directive injected server-side).
@@ -396,6 +410,9 @@ export default function PersonasPanel() {
             frequency: p.frequency ?? 'moderate',
             scriptLength: p.scriptLength ?? 'concise',
             djMode: p.djMode === true,
+            humour: typeof p.humour === 'number' ? p.humour : DIAL_NEUTRAL,
+            localColour: typeof p.localColour === 'number' ? p.localColour : DIAL_NEUTRAL,
+            warmth: typeof p.warmth === 'number' ? p.warmth : DIAL_NEUTRAL,
             soul: p.soul ?? '',
             language: typeof p.language === 'string' ? p.language : '',
             avatar: typeof p.avatar === 'string' ? p.avatar : '',
@@ -429,7 +446,8 @@ export default function PersonasPanel() {
         ...f,
         personas: [...f.personas, {
           id: clientMintId(), name: 'New persona', tagline: '',
-          frequency: 'moderate', scriptLength: 'concise', djMode: false, soul: '',
+          frequency: 'moderate', scriptLength: 'concise', djMode: false,
+          humour: DIAL_NEUTRAL, localColour: DIAL_NEUTRAL, warmth: DIAL_NEUTRAL, soul: '',
           language: '',
           avatar: '',
           tts: { engine: 'piper', cloudProvider: 'openai', voice: 'bf_isabella' },
@@ -564,6 +582,9 @@ export default function PersonasPanel() {
             frequency: p.frequency,
             scriptLength: p.scriptLength,
             djMode: p.djMode,
+            humour: p.humour,
+            localColour: p.localColour,
+            warmth: p.warmth,
             soul: p.soul.trim(),
             language: p.language.trim(),
             avatar: p.avatar || '',
@@ -950,6 +971,40 @@ export default function PersonasPanel() {
                 on={focused.djMode}
                 onClick={() => setPersona(safeIdx, { djMode: !focused.djMode })}
               />
+            </div>
+
+            <div className="rule-label">tone dials</div>
+
+            <div className="space-y-3.5">
+              {TONE_DIALS.map(d => {
+                const val = focused[d.id];
+                return (
+                  <div key={d.id}>
+                    <div className="flex items-center justify-between text-[12px]">
+                      <span className="font-bold">{d.label}</span>
+                      <span className="text-muted">{val}/10 · {toneBand(val)}</span>
+                    </div>
+                    <input
+                      type="range"
+                      min={0}
+                      max={10}
+                      step={1}
+                      value={val}
+                      onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                        setPersona(safeIdx, { [d.id]: Number(e.target.value) } as Partial<Persona>)}
+                      className="mt-1 w-full accent-[var(--accent)]"
+                    />
+                    <div className="flex justify-between text-[10px] text-muted">
+                      <span>{d.low}</span>
+                      <span>{d.high}</span>
+                    </div>
+                  </div>
+                );
+              })}
+              <div className="field-hint">
+                Personality on top of the soul. The middle band (4–6) injects nothing, so the
+                default stays exactly as before; push a dial low or high to shift the voice.
+              </div>
             </div>
           </Card>
 


### PR DESCRIPTION
## What

Adds three per-persona **tone dials** — humour, local colour, warmth — to the DJ persona, plus extends the default prompt's anti-cliché rule. The prompt-layer "persona settings" upgrade discussed alongside the locca picker work.

## Sliders

Each dial is **0–10, default 5 (neutral)**, sitting next to the existing talk-frequency / script-length / dj-mode knobs. They map to **three prompt bands**: 0–3 low, 7–10 high, 4–6 neutral. Only a band away from neutral appends a one-line directive (e.g. humour-high → "Lean into dry, playful wit; an aside or a wink is welcome").

- A persona left at the default **5/5/5 renders a byte-identical system prompt** — existing stations are unchanged, no migration.
- A model can't tell humour=6 from 7, so the 3-band mapping is the honest one; the editor surfaces the active band so operators don't expect fine gradations to matter.

## Why these three 

Dropped `news /10` (news is a dedicated between-track skill with its own cadence, not patter) and `intro style /10` (`scriptLength` already owns verbosity). Kept the three that are genuinely new personality axes with no overlap.

## Scope boundary (deliberate)

Tone is appended in `renderDjPrompt` (the free-text DJ voice: intros, links, idents, weather) and **kept off the tool-loop agent preamble** (picker / request / segment director). That preamble already warns that extra persona text derails small models — it's why its `rules` block is opt-out — so loading tone there would risk the picker. The spoken-voice path is where these dials belong.

## Anti-cliché

Extended the default template's existing rule to also ban back-announce tells (`"and that was"`, `"that was [song] by [artist]"`). Affects the default template; custom templates keep their own wording.

## Files

- `controller/src/settings.ts` — `TONE_DIALS`, pure `personaToneDirectives()` / `normalizeDial()`, wired into `normalizePersona()` + `renderDjPrompt()`; anti-cliché line.
- `controller/scripts/llm-pure.test.ts` — pins the band mapping and clamp.
- `web/components/admin/PersonasPanel.tsx` — three range sliders in the persona editor (load / default / save wiring).

## Verification

- `npm run test:llm`: all pass, including new `normalizeDial` / `personaToneDirectives` band tests.
- Controller `npm run lint` (eslint + tsc): 0 errors.
- Web `npm run lint` (eslint + tsc): 0 errors. `npm run build`: exit 0, `/admin/personas` compiles.
