### PR TITLE
fix(app): consent before silent https→http downgrade in onboarding

### DIFF
--- a/app/src/app/onboarding.tsx
+++ b/app/src/app/onboarding.tsx
@@ -33,6 +33,24 @@ const STEPS = ['Resolving host', 'Controller · /health', 'Icecast · /stream', 
 type StepState = 'wait' | 'run' | 'ok' | 'fail';
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const stripProto = (u: string) => u.replace(/^https?:\/\//, '');
+// Bare host (no scheme, port, or path), lowercased. Best-effort for hostnames
+// and IPv4 — an IPv6 literal isn't a realistic station address here.
+const hostOf = (u: string) => stripProto(u).split('/')[0].split(':')[0].toLowerCase();
+// Private/reserved TLDs that never resolve on the public internet, so a
+// cleartext station behind one is a LAN box, not an exposed origin.
+const PRIVATE_TLDS = /\.(local|lan|home|internal|corp|intranet|localdomain)$|\.home\.arpa$/;
+// A host where falling back to cleartext carries bounded MITM risk: loopback, a
+// single-label LAN name (http://nas), *.local mDNS, an RFC1918 address, or a
+// private TLD. These skip the insecure-downgrade consent prompt. Anything that
+// looks like a public domain does NOT — it takes the one-tap consent path.
+const isLocalHost = (h: string) =>
+  h === 'localhost' ||
+  !h.includes('.') ||
+  PRIVATE_TLDS.test(h) ||
+  /^127\./.test(h) ||
+  /^10\./.test(h) ||
+  /^192\.168\./.test(h) ||
+  /^172\.(1[6-9]|2\d|3[01])\./.test(h);
 
 interface Target {
   base: string;
@@ -55,6 +73,9 @@ export default function Onboarding() {
   const [target, setTarget] = useState<Target | null>(null);
   const [done, setDone] = useState(false);
   const [failed, setFailed] = useState(false);
+  // True when the probe silently fell back from https to cleartext http on a
+  // non-local host — gates "Tune in" behind an explicit consent button.
+  const [insecure, setInsecure] = useState(false);
   const [directory, setDirectory] = useState<DirectoryStation[]>([]);
   const runId = useRef(0);
 
@@ -93,6 +114,7 @@ export default function Onboarding() {
     setSteps(['wait', 'wait', 'wait', 'wait']);
     setDone(false);
     setFailed(false);
+    setInsecure(false);
     setPhase('check');
 
     const set = (i: number, s: StepState) =>
@@ -140,6 +162,15 @@ export default function Onboarding() {
       // Re-point the target at the candidate that actually answered.
       const fallbackName = presetName || stripProto(base);
       setTarget({ base, url: stripProto(base), name: fallbackName });
+      // Flag a silent https→http downgrade: the probe tried https first and
+      // ended up on cleartext, which an on-path attacker could have forced by
+      // blocking the https attempt. Local hosts carry bounded risk and skip
+      // this; a public-looking host requires explicit consent before tuning in.
+      setInsecure(
+        base.startsWith('http://') &&
+          candidates.some((c) => c.startsWith('https://')) &&
+          !isLocalHost(hostOf(base)),
+      );
       set(1, 'ok');
 
       // 3 · Icecast /stream (cosmetic — controller answered, mount assumed up)
@@ -355,6 +386,7 @@ export default function Onboarding() {
               steps={steps}
               done={done}
               failed={failed}
+              insecure={insecure}
               onTuneIn={tuneIn}
               onBack={backToEntry}
               onRetry={() => target && runCheck(target.url, target.name)}
@@ -371,6 +403,7 @@ function HealthCheck({
   steps,
   done,
   failed,
+  insecure,
   onTuneIn,
   onBack,
   onRetry,
@@ -379,6 +412,7 @@ function HealthCheck({
   steps: StepState[];
   done: boolean;
   failed: boolean;
+  insecure: boolean;
   onTuneIn: () => void;
   onBack: () => void;
   onRetry: () => void;
@@ -442,9 +476,27 @@ function HealthCheck({
               {target.url}
             </Text>
           </View>
-          <Pressable onPress={onTuneIn} accessibilityRole="button" accessibilityLabel={`Tune in to ${target.name}`} className="items-center justify-center" style={{ backgroundColor: colors.accent, paddingVertical: 15 }}>
+          {insecure ? (
+            <View style={{ borderWidth: 1, borderColor: destructive, padding: 14, gap: 6 }}>
+              <Text className="font-body-semibold text-ink" style={{ fontSize: 13 }}>
+                Insecure connection
+              </Text>
+              <Text className="font-body text-muted" style={{ fontSize: 12.5, lineHeight: 20 }}>
+                This station answered over plain HTTP, not HTTPS, so anyone on your network can
+                see and tamper with the traffic. Only continue if it&apos;s your own box, or a
+                station you trust on a network you trust.
+              </Text>
+            </View>
+          ) : null}
+          <Pressable
+            onPress={onTuneIn}
+            accessibilityRole="button"
+            accessibilityLabel={insecure ? 'Continue over insecure HTTP' : `Tune in to ${target.name}`}
+            className="items-center justify-center"
+            style={{ backgroundColor: insecure ? destructive : colors.accent, paddingVertical: 15 }}
+          >
             <Text className="font-body-semibold" style={{ color: '#fff', fontSize: 14 }}>
-              Tune in to {target.name}
+              {insecure ? 'Continue over insecure HTTP' : `Tune in to ${target.name}`}
             </Text>
           </Pressable>
         </View>


### PR DESCRIPTION
## What

Removes the **silent** `https→http` downgrade in the app's station onboarding probe. Addresses the push security review finding on #464 (the cleartext-stations feature).

## The problem

`runCheck` probes `https://<host>` first, then silently falls back to `http://<host>` for any bare hostname — and "fails" includes *being blocked*. An on-path attacker (coffee-shop wifi, a compromised router) can drop the https attempt to force the whole session onto cleartext it can read and modify. The user is never told. Classic SSL-strip.

## The fix: consent, not a host allowlist

An earlier idea — only allow http for RFC1918 hosts — was wrong: it would lock out people running HTTP-only stations behind a **custom private domain** (`radio.home`, or a real domain pointed at a LAN box). The actual defect is the *silence*, so we fix that:

- A fallback to http on a **non-local** host now surfaces an "Insecure connection" warning and gates Tune in behind an explicit red **"Continue over insecure HTTP"** button. Informed consent, no silent downgrade.
- **Local hosts skip the prompt** and connect in one tap: loopback, RFC1918 (`10.`/`192.168.`/`172.16–31.`), single-label names (`http://nas`), `*.local`, and private TLDs (`.home`/`.lan`/`.internal`/`.corp`/`.home.arpa`). So a homelab box or a custom private domain is unaffected.
- An **explicitly typed `http://` URL** is unchanged — that's already the user's choice, no fallback happened.

Net: #464's HTTP-station support stays fully intact; only the silent auto-downgrade on public hosts now asks first.

## Files

- `app/src/app/onboarding.tsx` — `hostOf`/`isLocalHost` helpers, an `insecure` flag set when the probe downgrades on a non-local host, and the consent warning + button in the result card.

## Verification

- `npm run typecheck` (tsc --noEmit): exit 0.
- The app is not in the controller/web CI lint, and the project doesn't pin `eslint` as a dependency, so `expo lint` can't run here; typecheck + the change following the file's existing JSX patterns is the gate.
