### PR TITLE
feat(tts): per-engine + per-persona DJ voice gain dial

### DIFF
--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -80,6 +80,23 @@ function resolveEngine(kind: string, personaTts: any) {
   return chosen;
 }
 
+// Effective voice level trim (dB) for a spoken segment of `kind`: the resolved
+// engine's per-engine gain (settings.tts.gainDb) plus the on-air persona's own
+// trim (persona.tts.gainDb), clamped to ±TTS_GAIN_CLAMP_DB. Applied downstream
+// by broadcast/queue.ts as a Liquidsoap `liq_amplify` annotation on the handoff
+// file — the same mechanism music loudness uses. 0 = unity (no annotation
+// written), i.e. today's behaviour. Uses the *resolved* engine (post
+// availability/key fallback), so the gain matches the engine that will actually
+// speak; the rare runtime-throw fallback inside speak() is an error path.
+export function voiceGainDb(kind: string): number {
+  const personaTts = djPersonaTts(kind);
+  const engine = resolveEngine(kind, personaTts);
+  const tts: any = settings.get().tts || {};
+  const engineGain = settings.clampTtsGain(tts.gainDb?.[engine]);
+  const personaGain = personaTts ? settings.clampTtsGain(personaTts.gainDb) : 0;
+  return settings.clampTtsGain(engineGain + personaGain);
+}
+
 async function speakWith(engine: string, text: string, opts: any, personaTts: any) {
   if (engine === 'kokoro') {
     const voice = (personaTts && personaTts.engine === 'kokoro' && personaTts.voice)

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -9,7 +9,7 @@ import { config } from '../config.js';
 import * as subsonic from '../music/subsonic.js';
 import * as mix from '../music/mix.js';
 import * as library from '../music/library.js';
-import { speak } from '../audio/tts.js';
+import { speak, voiceGainDb } from '../audio/tts.js';
 import * as djAgent from './dj-agent.js';
 import * as sfx from './sfx.js';
 import * as session from './session.js';
@@ -440,7 +440,7 @@ class Queue {
       const targetFile = kind === 'link'
         ? config.liquidsoap.introFile
         : config.liquidsoap.sayFile;
-      await airVoice(targetFile, wavPath, text);
+      await airVoice(targetFile, wavPath, text, voiceGainDb(kind));
       this.log(kind, text);
       session.appendTurn({ role: 'segment', kind, text });
       // The auto-DJ link channel is its own event; everything else (station
@@ -467,7 +467,7 @@ class Queue {
       ? config.liquidsoap.introFile
       : config.liquidsoap.sayFile;
     try {
-      await airVoice(targetFile, item.introWav, item.introScript || '');
+      await airVoice(targetFile, item.introWav, item.introScript || '', voiceGainDb(kind));
       this.persist();
       this.log(kind, item.introScript);
       session.appendTurn({ role: 'segment', kind, text: item.introScript });
@@ -845,14 +845,27 @@ const VOICE_TAIL_MS = 700;     // duck ramp-back + poll/scheduling slack
 // really aired) can't wedge the voice channel for minutes.
 const VOICE_HOLD_MAX_MS = 90_000;
 
-async function airVoice(path: string, wavPath: string, text: string) {
+async function airVoice(path: string, wavPath: string, text: string, gainDb = 0) {
+  // Duration is read from the bare WAV path (header parse), so compute it BEFORE
+  // wrapping — the annotate URI isn't a real file. The wrapped URI is only what
+  // gets written to the handoff file for Liquidsoap to consume.
   const holdMs = Math.min(VOICE_HOLD_MAX_MS, speechDurationMs(wavPath, text));
+  const uri = voiceUriWithGain(wavPath, gainDb);
   const turn = _voiceChain
     .catch(() => undefined)
-    .then(() => writeHandoff(path, wavPath));
+    .then(() => writeHandoff(path, uri));
   // Extend the shared lock until this clip has (about) finished playing.
   _voiceChain = turn.then(() => sleep(holdMs)).then(() => {}, () => {});
   return turn;
+}
+
+// Wrap a rendered voice-clip path in a Liquidsoap `annotate:` URI carrying a
+// liq_amplify gain, so the per-engine/persona voice trim is applied as the clip
+// plays (radio.liq wraps the voice queues in amplify(override="liq_amplify")).
+// 0 dB → the bare path, no annotation — byte-for-byte today's behaviour. Mirrors
+// subsonic.getAnnotatedUri's liq_amplify="<n> dB" form (the music loudness path).
+function voiceUriWithGain(wavPath: string, gainDb: number): string {
+  return gainDb !== 0 ? `annotate:liq_amplify="${gainDb} dB":${wavPath}` : wavPath;
 }
 
 // Best-effort playback duration of a rendered voice clip, plus the lead-in and

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -86,6 +86,34 @@ export function effectiveFrequency(persona: any = getEffectivePersona()) {
 // engine just falls back to Piper).
 export const TTS_ENGINES = ['piper', 'kokoro', 'chatterbox', 'pocket-tts', 'cloud'];
 
+// DJ-voice level trim, in dB. A per-engine gain levels the loudness gap between
+// TTS engines (only PocketTTS self-normalises today, so it sits quieter than
+// raw Piper/Kokoro under the same fixed-threshold mic compressor); a per-persona
+// gain stacks on top as a character trim. Applied via Liquidsoap's `liq_amplify`
+// annotation on say.txt/intro.txt (see audio/tts.ts:voiceGainDb +
+// broadcast/queue.ts) — the same mechanism the music loudness path uses. A
+// manual dial, not auto-normalisation, so the range is generous (±12 dB).
+export const TTS_GAIN_CLAMP_DB = 12;
+
+// Coerce any value to a clean gain: finite number, clamped to ±TTS_GAIN_CLAMP_DB,
+// rounded to 0.1 dB (finer is inaudible and just bloats the annotate string).
+// Garbage / non-finite → 0 (unity, i.e. today's behaviour).
+export function clampTtsGain(v: any): number {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return 0;
+  const c = Math.max(-TTS_GAIN_CLAMP_DB, Math.min(TTS_GAIN_CLAMP_DB, n));
+  return Math.round(c * 10) / 10;
+}
+
+// Normalise a per-engine gain map to exactly one clean gain per known engine
+// (default 0). Drops unknown keys so a hand-edited settings.json can't smuggle
+// arbitrary keys into the annotate path.
+function normalizeTtsGainMap(raw: any): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const e of TTS_ENGINES) out[e] = clampTtsGain(raw?.[e]);
+  return out;
+}
+
 // LLM provider abstraction. `ollama` is the homelab default; the cloud
 // providers are opt-in and resolved by llm/provider.js. `openrouter` and
 // `gateway` are aggregators — one key, any vendor's models. `openai-compatible`
@@ -317,7 +345,7 @@ export const SEED_PERSONAS = [
     soul: DJ_SOULS[0],
     language: '',
     avatar: '',
-    tts: { engine: 'piper', cloudProvider: 'openai', voice: 'bm_george' },
+    tts: { engine: 'piper', cloudProvider: 'openai', voice: 'bm_george', gainDb: 0 },
   },
   {
     id: 'p_default1',
@@ -328,7 +356,7 @@ export const SEED_PERSONAS = [
     soul: DJ_SOULS[1],
     language: '',
     avatar: '',
-    tts: { engine: 'piper', cloudProvider: 'openai', voice: 'bf_alice' },
+    tts: { engine: 'piper', cloudProvider: 'openai', voice: 'bf_alice', gainDb: 0 },
   },
   {
     id: 'p_default2',
@@ -339,7 +367,7 @@ export const SEED_PERSONAS = [
     soul: DJ_SOULS[3],
     language: '',
     avatar: '',
-    tts: { engine: 'piper', cloudProvider: 'openai', voice: 'bm_daniel' },
+    tts: { engine: 'piper', cloudProvider: 'openai', voice: 'bm_daniel', gainDb: 0 },
   },
 ];
 
@@ -424,6 +452,12 @@ const DEFAULTS = {
       // provider === 'openai-compatible'.
       baseUrl: '',
     },
+    // Per-engine voice level trim (dB), applied via Liquidsoap's liq_amplify on
+    // every spoken segment that resolves to that engine. Levels the loudness gap
+    // between engines (e.g. boost PocketTTS to match raw Piper). Stacks with each
+    // persona's own tts.gainDb. All 0 = unity = today's behaviour. See
+    // TTS_GAIN_CLAMP_DB and audio/tts.ts:voiceGainDb().
+    gainDb: { piper: 0, kokoro: 0, chatterbox: 0, 'pocket-tts': 0, cloud: 0 },
   },
   llm: {
     provider: 'ollama',
@@ -668,7 +702,7 @@ function normalizeTts(raw: any) {
   // field and the server picks its own.
   if (!voice && engine === 'cloud' && cloudProvider !== 'openai-compatible') voice = 'alloy';
   if (!voice && engine !== 'cloud' && engine !== 'chatterbox' && engine !== 'piper') voice = 'bf_isabella';
-  return { engine, cloudProvider, voice };
+  return { engine, cloudProvider, voice, gainDb: clampTtsGain(raw?.gainDb) };
 }
 
 function normalizePersona(raw: any) {
@@ -938,6 +972,9 @@ export async function load() {
             ? stored.tts.cloud.baseUrl.trim()
             : DEFAULTS.tts.cloud.baseUrl,
       },
+      // Per-engine gain map — one clean gain per known engine, missing keys → 0,
+      // unknown keys dropped. So an older save (no gainDb) loads at unity.
+      gainDb: normalizeTtsGainMap(stored.tts?.gainDb),
     },
     llm: {
       provider: LLM_PROVIDERS.includes(stored.llm?.provider)
@@ -1237,7 +1274,7 @@ function validateTtsBlock(raw, where) {
       );
     }
   }
-  return { engine: t.engine, cloudProvider: t.cloudProvider, voice };
+  return { engine: t.engine, cloudProvider: t.cloudProvider, voice, gainDb: clampTtsGain(t.gainDb) };
 }
 
 function validatePersonasStrict(raw) {
@@ -1728,6 +1765,17 @@ export async function update(patch) {
       // save the provider without one. Mirrors the LLM-side check below.
       if (next.tts.cloud.provider === 'openai-compatible' && !next.tts.cloud.baseUrl) {
         throw new Error('tts.cloud.baseUrl is required when provider is "openai-compatible"');
+      }
+    }
+    if (t.gainDb !== undefined) {
+      if (typeof t.gainDb !== 'object' || t.gainDb === null || Array.isArray(t.gainDb)) {
+        throw new Error('tts.gainDb must be an object keyed by engine');
+      }
+      for (const key of Object.keys(t.gainDb)) {
+        if (!TTS_ENGINES.includes(key)) {
+          throw new Error(`tts.gainDb has unknown engine "${key}"; must be one of: ${TTS_ENGINES.join(', ')}`);
+        }
+        next.tts.gainDb[key] = clampTtsGain(t.gainDb[key]);
       }
     }
   }

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -338,8 +338,16 @@ def mic_chain(s) =
   s
 end
 
-voice = mic_chain(voice_queue)
-intro = mic_chain(intro_queue)
+# Per-segment voice level trim. The controller stamps `liq_amplify` (in the
+# "<n> dB" form) onto the say.txt/intro.txt URI per spoken clip — a per-engine +
+# per-persona gain that levels the loudness gap between TTS engines (see
+# settings.tts.gainDb + audio/tts.ts:voiceGainDb). `amplify` reads it per
+# request — the same ReplayGain mechanism the music bus uses (line 214). Applied
+# BEFORE mic_chain so the fixed-threshold compressor sees a levelled input. The
+# un-annotated silent lead-in carries no `liq_amplify`, so it plays at the base
+# factor 1. (unity). Un-trimmed clips (gainDb 0) write a bare path → also unity.
+voice = mic_chain(amplify(override="liq_amplify", 1., voice_queue))
+intro = mic_chain(amplify(override="liq_amplify", 1., intro_queue))
 
 # ---------------------------------------------------------------------------
 # STUDIO BED — continuous low-level ambient room tone (Phase 2)

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -58,6 +58,9 @@ interface PersonaTts {
   engine: 'piper' | 'kokoro' | 'chatterbox' | 'pocket-tts' | 'cloud' | string;
   cloudProvider: string;
   voice: string;
+  // Per-persona voice-level trim in dB (−12..+12, default 0 = no change). Stacks
+  // on top of the per-engine gain. See controller settings.ts:clampTtsGain.
+  gainDb: number;
 }
 
 interface Persona {
@@ -403,6 +406,7 @@ export default function PersonasPanel() {
               engine: p.tts?.engine ?? 'piper',
               cloudProvider: p.tts?.cloudProvider ?? 'openai',
               voice: p.tts?.voice ?? 'bf_isabella',
+              gainDb: typeof p.tts?.gainDb === 'number' ? p.tts.gainDb : 0,
             },
             skills: Array.isArray(p.skills) ? p.skills : allSkills,
           })),
@@ -432,7 +436,7 @@ export default function PersonasPanel() {
           frequency: 'moderate', scriptLength: 'concise', djMode: false, soul: '',
           language: '',
           avatar: '',
-          tts: { engine: 'piper', cloudProvider: 'openai', voice: 'bf_isabella' },
+          tts: { engine: 'piper', cloudProvider: 'openai', voice: 'bf_isabella', gainDb: 0 },
           skills: (data?.skills?.catalog || []).map(s => s.name),
         }],
       };
@@ -579,6 +583,8 @@ export default function PersonasPanel() {
               //   chatterbox — must be a .wav filename or empty (built-in)
               //   piper/cloud — passed through as-is
               voice: voiceForSave(p.tts.engine, p.tts.voice.trim()),
+              // Per-persona voice-level trim (dB). Server clamps to ±12.
+              gainDb: p.tts.gainDb ?? 0,
             },
             skills: p.skills,
           })),
@@ -1254,6 +1260,36 @@ export default function PersonasPanel() {
                   </div>
                 </div>
                 </>
+              );
+            })()}
+
+            {(() => {
+              const gain = focused.tts.gainDb ?? 0;
+              const label = !gain
+                ? '0 dB'
+                : `${gain > 0 ? '+' : '−'}${Math.abs(gain).toFixed(1)} dB`;
+              return (
+                <div className="field mt-3.5 max-w-[360px]">
+                  <div className="flex items-center justify-between gap-3">
+                    <Label>Voice level (dB)</Label>
+                    <span className="font-mono text-[12px] text-ink tabular-nums">{label}</span>
+                  </div>
+                  <input
+                    type="range"
+                    min={-12}
+                    max={12}
+                    step={0.5}
+                    value={gain}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                      setPersonaTts(safeIdx, { gainDb: Number(e.target.value) })
+                    }
+                    aria-label="Persona voice level in decibels"
+                    className="mt-1.5 w-full accent-[var(--accent)]"
+                  />
+                  <div className="field-hint">
+                    Trim this persona’s loudness on top of the engine level. <code>0 dB</code> = no change.
+                  </div>
+                </div>
               );
             })()}
           </Card>

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -113,6 +113,9 @@ interface TtsForm {
   chatterbox: { referenceVoice: string };
   pocketTts: { voice: string };
   cloud: CloudTtsCfg;
+  // Per-engine voice-level trim in dB, keyed by engine id (note the hyphen in
+  // `pocket-tts`). Always carries all 5 known engines, 0 = unity = no change.
+  gainDb: Record<string, number>;
 }
 
 interface LlmFallbackForm {
@@ -249,6 +252,7 @@ interface SettingsData {
       chatterbox?: { referenceVoice?: string };
       pocketTts?: { voice?: string };
       cloud?: Partial<CloudTtsCfg>;
+      gainDb?: Record<string, number>;
     };
     llm?: Partial<LlmForm>;
     search?: Partial<SearchForm>;
@@ -386,6 +390,16 @@ export default function SettingsPanel() {
           model: v.tts?.cloud?.model ?? '',
           voice: v.tts?.cloud?.voice ?? '',
           baseUrl: v.tts?.cloud?.baseUrl ?? '',
+        },
+        // Per-engine voice level (dB). Zero default for all 5 engine ids, then
+        // overlay any saved values. Keyed by engine id — `pocket-tts` (hyphen).
+        gainDb: {
+          piper: 0,
+          kokoro: 0,
+          chatterbox: 0,
+          'pocket-tts': 0,
+          cloud: 0,
+          ...(v.tts?.gainDb || {}),
         },
       },
       llm: {
@@ -1117,6 +1131,62 @@ interface SectionProps {
 // rejects an empty-string SelectItem value.
 const CB_DEFAULT_VOICE = '__cb_default__';
 
+// Voice-level (dB) trim. Engine ids match the server contract exactly — note the
+// hyphen in `pocket-tts`. Range mirrors the server clamp (TTS_GAIN_CLAMP_DB=12).
+const TTS_GAIN_ENGINES = ['piper', 'kokoro', 'chatterbox', 'pocket-tts', 'cloud'] as const;
+const TTS_GAIN_MIN = -12;
+const TTS_GAIN_MAX = 12;
+const TTS_GAIN_STEP = 0.5;
+
+// Pretty-print a gain: "0 dB" clean-neutral, otherwise a signed one-decimal value
+// with a real minus sign (e.g. "+3.0 dB", "−2.5 dB").
+function formatGainDb(v: number): string {
+  if (!v) return '0 dB';
+  const sign = v > 0 ? '+' : '−';
+  return `${sign}${Math.abs(v).toFixed(1)} dB`;
+}
+
+// Compact per-engine voice-level control: a labelled range slider + live readout,
+// writing into form.tts.gainDb[engineId]. Dropped into each engine's config panel.
+function TtsGainField({
+  engineId,
+  form,
+  setForm,
+}: {
+  engineId: string;
+  form: FormState;
+  setForm: FormUpdater;
+}) {
+  const value = form.tts.gainDb?.[engineId] ?? 0;
+  return (
+    <div className="field mt-4">
+      <div className="flex items-center justify-between gap-3">
+        <Label>Voice level (dB)</Label>
+        <span className="font-mono text-[12px] text-ink tabular-nums">{formatGainDb(value)}</span>
+      </div>
+      <input
+        type="range"
+        min={TTS_GAIN_MIN}
+        max={TTS_GAIN_MAX}
+        step={TTS_GAIN_STEP}
+        value={value}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => {
+          const next = Number(e.target.value);
+          setForm(f => ({
+            ...f,
+            tts: { ...f.tts, gainDb: { ...f.tts.gainDb, [engineId]: next } },
+          }));
+        }}
+        aria-label="Voice level in decibels"
+        className="mt-1.5 w-full max-w-[360px] accent-[var(--accent)]"
+      />
+      <div className="field-hint">
+        Trim this engine’s loudness to match your other voices. <code>0 dB</code> = no change.
+      </div>
+    </div>
+  );
+}
+
 // Prominent, self-contained "engine not installed" callout with a step-by-step
 // setup guide. Chatterbox and PocketTTS both live in the optional `tts-heavy`
 // sidecar, so the recommended path is identical; only the engine label and the
@@ -1192,6 +1262,9 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
         voice: form.tts.cloud.voice,
         baseUrl: form.tts.cloud.baseUrl,
       },
+      // Per-engine voice-level trim. Always sent (server clamps + drops unknown
+      // keys); keyed by engine id, `pocket-tts` with the hyphen.
+      gainDb: form.tts.gainDb,
     },
   });
 
@@ -1221,6 +1294,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
     chatterbox?: { referenceVoice?: string };
     pocketTts?: { voice?: string };
     cloud?: SavedCloud;
+    gainDb?: Record<string, number>;
   } = data.values?.tts || {};
   const savedEngine: string = savedTts.defaultEngine || 'piper';
   const savedKokoroVoice: string = savedTts.kokoro?.voice || '';
@@ -1230,6 +1304,12 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
   const savedEngineLabel = ENGINE_LABELS[savedEngine] || savedEngine;
   const formEngineLabel = ENGINE_LABELS[form.tts.defaultEngine] || form.tts.defaultEngine;
 
+  const savedGainDb: Record<string, number> = savedTts.gainDb || {};
+  // Any engine whose form gain differs from its saved value (absent → 0 unity).
+  const gainDirty = TTS_GAIN_ENGINES.some(
+    e => (form.tts.gainDb?.[e] ?? 0) !== (savedGainDb[e] ?? 0),
+  );
+
   const ttsDirty =
     form.tts.defaultEngine !== savedEngine
     || (form.tts.kokoro?.voice || '') !== savedKokoroVoice
@@ -1238,7 +1318,8 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
     || form.tts.cloud.provider !== (savedCloud.provider || '')
     || (form.tts.cloud.model || '').trim() !== (savedCloud.model || '').trim()
     || (form.tts.cloud.voice || '').trim() !== (savedCloud.voice || '').trim()
-    || (form.tts.cloud.baseUrl || '').trim() !== (savedCloud.baseUrl || '').trim();
+    || (form.tts.cloud.baseUrl || '').trim() !== (savedCloud.baseUrl || '').trim()
+    || gainDirty;
 
   let activeDetail: ReactNode = null;
   if (savedEngine === 'piper') {
@@ -1316,134 +1397,146 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
           </div>
 
         {form.tts.defaultEngine === 'piper' && (
-          <div className="field mt-4">
-            <div className="field-hint">
-              Piper is bundled with the controller — fast, lightweight, and always
-              available. Nothing to configure.
+          <>
+            <div className="field mt-4">
+              <div className="field-hint">
+                Piper is bundled with the controller — fast, lightweight, and always
+                available. Nothing else to configure.
+              </div>
             </div>
-          </div>
+            <TtsGainField engineId="piper" form={form} setForm={setForm} />
+          </>
         )}
 
         {form.tts.defaultEngine === 'kokoro' && (
-          <div className="field mt-4">
-            <Label>Kokoro voice</Label>
-            {available.kokoro === false && (
-              <div className="field-hint text-[var(--danger)]">
-                Kokoro is not installed in this build — it will fall back to Piper.
-              </div>
-            )}
-            {(data.tts?.kokoroVoices?.length || 0) > 0 ? (
-              <>
-                <Select
-                  value={form.tts.kokoro?.voice ?? 'bf_isabella'}
-                  onValueChange={val => setForm(f => ({
-                    ...f, tts: { ...f.tts, kokoro: { ...f.tts.kokoro, voice: val } },
-                  }))}
-                >
-                  <SelectTrigger><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      {data.tts?.kokoroVoices?.map(v => (
-                        <SelectItem key={v.id} value={v.id}>{v.label} — {v.id}</SelectItem>
-                      ))}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-                <div className="field-hint">British English only. Applies to every kind routed through Kokoro.</div>
-              </>
-            ) : (
-              <div className="field-hint">This build reports no Kokoro voices.</div>
-            )}
-          </div>
+          <>
+            <div className="field mt-4">
+              <Label>Kokoro voice</Label>
+              {available.kokoro === false && (
+                <div className="field-hint text-[var(--danger)]">
+                  Kokoro is not installed in this build — it will fall back to Piper.
+                </div>
+              )}
+              {(data.tts?.kokoroVoices?.length || 0) > 0 ? (
+                <>
+                  <Select
+                    value={form.tts.kokoro?.voice ?? 'bf_isabella'}
+                    onValueChange={val => setForm(f => ({
+                      ...f, tts: { ...f.tts, kokoro: { ...f.tts.kokoro, voice: val } },
+                    }))}
+                  >
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        {data.tts?.kokoroVoices?.map(v => (
+                          <SelectItem key={v.id} value={v.id}>{v.label} — {v.id}</SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                  <div className="field-hint">British English only. Applies to every kind routed through Kokoro.</div>
+                </>
+              ) : (
+                <div className="field-hint">This build reports no Kokoro voices.</div>
+              )}
+            </div>
+            <TtsGainField engineId="kokoro" form={form} setForm={setForm} />
+          </>
         )}
 
         {form.tts.defaultEngine === 'chatterbox' && (
-          <div className="field mt-4">
-            <Label>Chatterbox reference voice</Label>
-            {available.chatterbox === false ? (
-              <HeavyEngineSetupGuide engine="Chatterbox" buildArg="WITH_CHATTERBOX=1" />
-            ) : (data.tts?.chatterboxVoices?.length || 0) > 0 ? (
-              <>
-                <Select
-                  value={form.tts.chatterbox?.referenceVoice || CB_DEFAULT_VOICE}
-                  onValueChange={val => setForm(f => ({
-                    ...f,
-                    tts: { ...f.tts, chatterbox: { ...f.tts.chatterbox, referenceVoice: val === CB_DEFAULT_VOICE ? '' : val } },
-                  }))}
-                >
-                  <SelectTrigger><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      <SelectItem value={CB_DEFAULT_VOICE}>Built-in default voice</SelectItem>
-                      {data.tts?.chatterboxVoices?.map(v => (
-                        <SelectItem key={v} value={v}>{v}</SelectItem>
-                      ))}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-                <div className="field-hint">
-                  ~5 seconds of clean speech is enough to clone a voice. Drop WAVs into{' '}
-                  <code>state/voices/</code>
-                  {' '}on the host (the legacy <code>state/chatterbox-voices/</code> is
-                  still read) and they’ll appear here on next reload. Personas can
-                  override this on the Personas page.
-                </div>
-              </>
-            ) : (
-              <div className="field-hint">
-                No reference voices found in{' '}
-                <code>state/voices/</code>{' '}
-                (legacy <code>state/chatterbox-voices/</code> also empty). The engine will
-                use its built-in default voice — drop a 5-second WAV into that directory
-                to enable cloning.
-              </div>
-            )}
-          </div>
-        )}
-
-        {form.tts.defaultEngine === 'pocket-tts' && (
-          <div className="field mt-4">
-            <Label>PocketTTS voice</Label>
-            {available['pocket-tts'] === false ? (
-              <HeavyEngineSetupGuide engine="PocketTTS" buildArg="WITH_POCKETTTS=1" />
-            ) : (data.tts?.pocketTtsVoices?.length || 0) > 0 ? (
-              <>
-                <Select
-                  value={form.tts.pocketTts?.voice ?? 'alba'}
-                  onValueChange={val => setForm(f => ({
-                    ...f, tts: { ...f.tts, pocketTts: { ...f.tts.pocketTts, voice: val } },
-                  }))}
-                >
-                  <SelectTrigger><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      <SelectLabel>Built-in</SelectLabel>
-                      {data.tts?.pocketTtsVoices?.map(v => (
-                        <SelectItem key={v.id} value={v.id}>{v.label} — {v.id}</SelectItem>
-                      ))}
-                    </SelectGroup>
-                    {(data.tts?.pocketTtsCustomVoices?.length || 0) > 0 && (
+          <>
+            <div className="field mt-4">
+              <Label>Chatterbox reference voice</Label>
+              {available.chatterbox === false ? (
+                <HeavyEngineSetupGuide engine="Chatterbox" buildArg="WITH_CHATTERBOX=1" />
+              ) : (data.tts?.chatterboxVoices?.length || 0) > 0 ? (
+                <>
+                  <Select
+                    value={form.tts.chatterbox?.referenceVoice || CB_DEFAULT_VOICE}
+                    onValueChange={val => setForm(f => ({
+                      ...f,
+                      tts: { ...f.tts, chatterbox: { ...f.tts.chatterbox, referenceVoice: val === CB_DEFAULT_VOICE ? '' : val } },
+                    }))}
+                  >
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
                       <SelectGroup>
-                        <SelectLabel>Custom (cloned)</SelectLabel>
-                        {data.tts?.pocketTtsCustomVoices?.map(v => (
+                        <SelectItem value={CB_DEFAULT_VOICE}>Built-in default voice</SelectItem>
+                        {data.tts?.chatterboxVoices?.map(v => (
                           <SelectItem key={v} value={v}>{v}</SelectItem>
                         ))}
                       </SelectGroup>
-                    )}
-                  </SelectContent>
-                </Select>
+                    </SelectContent>
+                  </Select>
+                  <div className="field-hint">
+                    ~5 seconds of clean speech is enough to clone a voice. Drop WAVs into{' '}
+                    <code>state/voices/</code>
+                    {' '}on the host (the legacy <code>state/chatterbox-voices/</code> is
+                    still read) and they’ll appear here on next reload. Personas can
+                    override this on the Personas page.
+                  </div>
+                </>
+              ) : (
                 <div className="field-hint">
-                  100M-param CPU-only model from kyutai-labs. Built-in voices speak
-                  English, French, German, Italian, Spanish and Portuguese. Drop a
-                  ~5-second WAV into <code>state/voices/</code> to clone a voice and it
-                  will appear under <em>Custom</em> on next reload. Personas can override
-                  this on the Personas page.
+                  No reference voices found in{' '}
+                  <code>state/voices/</code>{' '}
+                  (legacy <code>state/chatterbox-voices/</code> also empty). The engine will
+                  use its built-in default voice — drop a 5-second WAV into that directory
+                  to enable cloning.
                 </div>
-              </>
-            ) : (
-              <div className="field-hint">This build reports no PocketTTS voices.</div>
-            )}
-          </div>
+              )}
+            </div>
+            <TtsGainField engineId="chatterbox" form={form} setForm={setForm} />
+          </>
+        )}
+
+        {form.tts.defaultEngine === 'pocket-tts' && (
+          <>
+            <div className="field mt-4">
+              <Label>PocketTTS voice</Label>
+              {available['pocket-tts'] === false ? (
+                <HeavyEngineSetupGuide engine="PocketTTS" buildArg="WITH_POCKETTTS=1" />
+              ) : (data.tts?.pocketTtsVoices?.length || 0) > 0 ? (
+                <>
+                  <Select
+                    value={form.tts.pocketTts?.voice ?? 'alba'}
+                    onValueChange={val => setForm(f => ({
+                      ...f, tts: { ...f.tts, pocketTts: { ...f.tts.pocketTts, voice: val } },
+                    }))}
+                  >
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        <SelectLabel>Built-in</SelectLabel>
+                        {data.tts?.pocketTtsVoices?.map(v => (
+                          <SelectItem key={v.id} value={v.id}>{v.label} — {v.id}</SelectItem>
+                        ))}
+                      </SelectGroup>
+                      {(data.tts?.pocketTtsCustomVoices?.length || 0) > 0 && (
+                        <SelectGroup>
+                          <SelectLabel>Custom (cloned)</SelectLabel>
+                          {data.tts?.pocketTtsCustomVoices?.map(v => (
+                            <SelectItem key={v} value={v}>{v}</SelectItem>
+                          ))}
+                        </SelectGroup>
+                      )}
+                    </SelectContent>
+                  </Select>
+                  <div className="field-hint">
+                    100M-param CPU-only model from kyutai-labs. Built-in voices speak
+                    English, French, German, Italian, Spanish and Portuguese. Drop a
+                    ~5-second WAV into <code>state/voices/</code> to clone a voice and it
+                    will appear under <em>Custom</em> on next reload. Personas can override
+                    this on the Personas page.
+                  </div>
+                </>
+              ) : (
+                <div className="field-hint">This build reports no PocketTTS voices.</div>
+              )}
+            </div>
+            <TtsGainField engineId="pocket-tts" form={form} setForm={setForm} />
+          </>
         )}
 
         {form.tts.defaultEngine === 'cloud' && (() => {
@@ -1575,6 +1668,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
                 var required.
               </div>
             )}
+            <TtsGainField engineId="cloud" form={form} setForm={setForm} />
           </div>
           );
         })()}


### PR DESCRIPTION
## Why

DJ voice loudness is inconsistent **between TTS engines**. Only PocketTTS self-normalises its output, so it sits noticeably quieter than raw Piper/Kokoro/Chatterbox under the mic chain's fixed-threshold compressor — operators have been baking normalisation into their own TTS Docker images to compensate. This adds a first-class gain dial so they don't have to.

A static gain via Liquidsoap's `liq_amplify` annotation was chosen over an in-controller normaliser because engines emit **mixed formats** (Piper/Kokoro/Chatterbox/PocketTTS + OpenAI → WAV, **ElevenLabs → MP3**) and the controller image has no ffmpeg/decoder. `liq_amplify` is format-agnostic (Liquidsoap decodes everything) and reuses the exact mechanism the music loudness path already uses (`getAnnotatedUri` → `amplify(override="liq_amplify")`).

## What

- **settings**: per-engine `tts.gainDb` map (`piper`/`kokoro`/`chatterbox`/`pocket-tts`/`cloud`) + per-persona `tts.gainDb`, clamped ±12 dB (`TTS_GAIN_CLAMP_DB`/`clampTtsGain`). Old saves load at unity; the two gains **stack**.
- **tts**: `voiceGainDb(kind)` = resolved-engine gain + persona trim, clamped. No change to `speak()`'s contract.
- **queue**: `airVoice` wraps the handoff path as `annotate:liq_amplify="<n> dB":<path>` when non-zero (bare path at 0 → byte-for-byte today's behaviour). Clip duration is still read from the bare WAV header **before** wrapping.
- **radio.liq**: `amplify(override="liq_amplify", 1., …)` on both voice queues before `mic_chain`, mirroring the music line. The un-annotated silent lead-in stays at unity.
- **web**: per-engine "Voice level (dB)" sliders in Settings + a per-persona trim in Personas.

## Test plan

- ✅ `controller`: `npm run lint` (eslint + `tsc --noEmit`) clean — 0 errors.
- ✅ `web`: `npm run lint` (eslint + `tsc --noEmit`) clean.
- ⬜ Live smoke (dev): set PocketTTS `+6 dB` + a persona `+2 dB`, `docker compose -f docker-compose.dev.yml restart broadcast`, confirm broadcast log shows `DJ says: annotate:liq_amplify="8 dB":/…` and the voice is audibly louder vs a Piper persona at 0 dB.
- ⬜ No-op safety: all gains at 0 → `say.txt`/`intro.txt` carry a bare path (no `annotate:`).