### PR TITLE
fix(controller/llm): route openai-compatible picker through done-tool, not native

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -129,12 +129,13 @@ async function main() {
     assert.deepEqual(providerOptions({ provider: 'locca', model: 'qwen3', reasoning: false }), {});
     assert.deepEqual(providerOptions({ provider: 'locca', model: 'qwen3', reasoning: true }), {});
   });
-  await test('capability flags: tool-object covers ollama + locca; repeat-penalty is Ollama-only', () => {
+  await test('capability flags: tool-object covers ollama + locca + openai-compatible; repeat-penalty is Ollama-only', () => {
     assert.equal(needsToolCallObject({ provider: 'ollama' }), true);
     assert.equal(needsToolCallObject({ provider: 'openai' }), false);
-    // locca serves local GGUF models that don't explore under native Output.object
-    // (32/32 explored=false on gemma-4-12b / qwen3.5-9b) — same as ollama.
+    // locca + openai-compatible serve local GGUF models that don't explore under
+    // native Output.object (explored=false on gemma-4-12b / qwen3.5-9b) — same as ollama.
     assert.equal(needsToolCallObject({ provider: 'locca' }), true);
+    assert.equal(needsToolCallObject({ provider: 'openai-compatible' }), true);
     assert.equal(repeatPenaltyApplies({ provider: 'ollama' }), true);
     assert.equal(repeatPenaltyApplies({ provider: 'deepseek' }), false);
     assert.equal(repeatPenaltyApplies({ provider: 'locca' }), false);
@@ -165,11 +166,13 @@ async function main() {
     assert.equal(agentPlan({ provider: 'ollama' }, {}, 3), 'done-tool');
     assert.equal(agentPlan({ provider: 'openai' }, {}, 0), 'native-no-tools');
     assert.equal(agentPlan({ provider: 'openai' }, {}, 3), 'native-then-done');
-    // locca serves local GGUF models (same class as Ollama), so it takes the
-    // forced tool-object / done-tool path, NOT the native path — local llama.cpp
-    // models emit the object without exploring tools under native Output.object.
+    // locca + openai-compatible serve local GGUF models (same class as Ollama), so
+    // they take the forced tool-object / done-tool path, NOT the native path — local
+    // llama.cpp models emit the object without exploring tools under native Output.object.
     assert.equal(agentPlan({ provider: 'locca' }, {}, 0), 'object-via-tool');
     assert.equal(agentPlan({ provider: 'locca' }, {}, 3), 'done-tool');
+    assert.equal(agentPlan({ provider: 'openai-compatible' }, {}, 0), 'object-via-tool');
+    assert.equal(agentPlan({ provider: 'openai-compatible' }, {}, 3), 'done-tool');
     assert.equal(agentPlan({ provider: 'openai' }, null, 3), 'free-text');
     assert.equal(agentPlan({ provider: 'ollama' }, null, 0), 'free-text');
   });

--- a/controller/src/llm/internal/provider/capabilities.ts
+++ b/controller/src/llm/internal/provider/capabilities.ts
@@ -52,8 +52,13 @@ const CAPS: Record<string, ProviderCapabilities> = {
         ? { openai: { reasoningEffort: reasoning ? 'medium' : 'minimal' } }
         : {},
   },
+  // openai-compatible targets self-hosted llama.cpp / vLLM / LM Studio — the
+  // same local GGUF model class as ollama and locca, which emit a schema-valid
+  // object WITHOUT exploring under native Output.object + auto tool_choice
+  // (verified 8/8 explored=false on gemma-4-12b via this provider). So it takes
+  // the forced done-tool path too, not the dead native leg.
   'openai-compatible': {
-    objectStrategy: 'native',
+    objectStrategy: 'tool',
     repeatPenaltyApplies: false,
     // Thinking suppression is done at the transport layer (noThinkFetch in the
     // registry), not via providerOptions.


### PR DESCRIPTION
## What

Sibling fix to #467 (now merged). Routes the **openai-compatible** provider's picker through the forced **done-tool** path instead of the dead **native** path.

## Why

`openai-compatible` targets self-hosted **llama.cpp / vLLM / LM Studio** — the same local GGUF model class as `ollama` and `locca`, which under native `Output.object` + auto `tool_choice` emit a schema-valid object **without ever calling a discovery tool**. But `capabilities.ts` had it as `objectStrategy: 'native'`, so `agentPlan` routed every pick through `native-then-done`: a native attempt that can never succeed, then a fall-back to the done-tool path that actually produces the pick. One wasted model call per pick — exactly what #467 fixed for locca.

## Confirmed empirically

Benchmarked via `controller/scripts/picker-test.mjs` with `provider=openai-compatible` against a locca-served `gemma-4-12b-it-Q4_K_M` (openai-compatible and locca share the same transport), 8 iterations short:

| state | success | native miss | median | p95 |
|---|---|---|---|---|
| before (`native`) | 8/8 | **8/8 explored=false** | 33.2s | 36.4s |
| after (`tool`) | 8/8 | **0** | **14.7s** | 15.6s |

Reliability unchanged, latency roughly halved (−56%), no more wasted native calls.

## Fix

- `capabilities.ts`: `openai-compatible.objectStrategy` `'native'` → `'tool'` (one line + comment).
- `llm-pure.test.ts`: add `openai-compatible` to the `needsToolCallObject` and `agentPlan` routing assertions (alongside the locca ones from #467).

## Verification

- `npm run test:llm`: all pass, including the new `openai-compatible` routing assertions.
- `npm run lint` (eslint + tsc): 0 errors.

With this, all three local-llama.cpp providers (`ollama`, `locca`, `openai-compatible`) take the done-tool path; only genuine cloud providers use native.
