### PR TITLE
feat(stats): scrollable Stats lists + per-container system resources

### DIFF
--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -123,6 +123,11 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - *state-mount
+      # Read-only Docker socket — lets the admin Stats page report per-container
+      # CPU/memory for the stack (GET /system, via the Docker Engine API; no
+      # docker CLI in the image). Optional: drop this line and the panel just
+      # shows "container stats unavailable" — nothing else depends on it.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
 
   # -------------------------------------------------------------------------
   # WEB — Next.js listener UI
@@ -331,6 +336,11 @@ services:
       - "\${CONTROLLER_PORT:-7701}:7701"
     volumes:
       - *state-mount
+      # Read-only Docker socket — lets the admin Stats page report per-container
+      # CPU/memory for the stack (GET /system, via the Docker Engine API; no
+      # docker CLI in the image). Optional: drop this line and the panel just
+      # shows "container stats unavailable" — nothing else depends on it.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
 
   # -------------------------------------------------------------------------
   # WEB — Next.js listener UI, bound to host for your reverse proxy
@@ -527,6 +537,10 @@ services:
       # /app/node_modules with the (possibly empty) host node_modules.
       - ./controller/src:/app/src
       - ./controller/scripts:/app/scripts
+      # Read-only Docker socket — powers the admin Stats system-resource panel
+      # (GET /system) in dev too. Optional: drop it and the panel shows
+      # "container stats unavailable".
+      - /var/run/docker.sock:/var/run/docker.sock:ro
 
   # -------------------------------------------------------------------------
   # TTS-HEAVY (optional) — sidecar for Chatterbox + PocketTTS

--- a/controller/src/routes/system.ts
+++ b/controller/src/routes/system.ts
@@ -1,0 +1,18 @@
+// Admin-gated GET /system — per-container CPU/memory for the SUB/WAVE stack plus
+// host totals, read from the Docker Engine API (see ../system.ts). Always 200:
+// when the Docker socket isn't mounted the body carries dockerAvailable:false
+// and just the host figures, so the Stats page can show "container stats
+// unavailable" without treating it as a controller error.
+import express from 'express';
+import { requireAdmin } from '../middleware/auth.js';
+import * as system from '../system.js';
+
+export const router = express.Router();
+
+router.get('/system', requireAdmin, async (_req, res) => {
+  try {
+    res.json(await system.summary());
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -32,6 +32,7 @@ import { router as scrobbleRoutes } from './routes/scrobble.js';
 import { router as personasRoutes } from './routes/personas.js';
 import { router as backupRoutes } from './routes/backup.js';
 import { router as audienceRoutes } from './routes/audience.js';
+import { router as systemRoutes } from './routes/system.js';
 import { loadSecretsIntoEnv } from './setup/secrets.js';
 import { loadSetupConfig } from './setup/config.js';
 import { getSetupStatus } from './setup/firstRun.js';
@@ -64,6 +65,7 @@ app.use(scrobbleRoutes);
 app.use(personasRoutes);
 app.use(backupRoutes);
 app.use(audienceRoutes);
+app.use(systemRoutes);
 
 // (manual skip is not implemented in this build — Liquidsoap controls pacing)
 

--- a/controller/src/system.ts
+++ b/controller/src/system.ts
@@ -1,0 +1,248 @@
+// System-resource readout for the admin Stats page.
+//
+// Answers "how much CPU/memory is SUB/WAVE using on this box?" by talking to the
+// Docker Engine API directly over the mounted unix socket (/var/run/docker.sock)
+// — no `docker` CLI in the image, just Node's http over a socketPath. The
+// controller runs as root in its container, so it can read the socket when the
+// compose file mounts it (read-only). When the socket isn't mounted (dev on a
+// Mac, a BYO operator who'd rather not expose it), dockerAvailable() is false
+// and summary() returns just the host figures with an empty container list — the
+// UI degrades to "container stats unavailable" rather than erroring.
+//
+// Container selection: we resolve the controller's own Compose project label and
+// return every running container in that project (caddy, broadcast, controller,
+// web, and the tts-heavy sidecar when enabled). Falls back to the sub-wave-*
+// container-name convention if the project label isn't present.
+
+import http from 'node:http';
+import os from 'node:os';
+import { existsSync } from 'node:fs';
+
+const DOCKER_SOCK = process.env.DOCKER_SOCKET || '/var/run/docker.sock';
+
+// --- Docker API types (only the fields we read) ---------------------------
+
+interface DockerContainer {
+  Id: string;
+  Names?: string[];
+  Labels?: Record<string, string>;
+}
+
+interface DockerCpuUsage {
+  total_usage?: number;
+  percpu_usage?: number[];
+}
+
+interface DockerStat {
+  cpu_stats?: { cpu_usage?: DockerCpuUsage; system_cpu_usage?: number; online_cpus?: number };
+  precpu_stats?: { cpu_usage?: DockerCpuUsage; system_cpu_usage?: number };
+  memory_stats?: { usage?: number; limit?: number; stats?: Record<string, number> };
+}
+
+// --- response shape -------------------------------------------------------
+
+export interface ContainerUsage {
+  name: string;       // friendly container name, leading slash stripped
+  service: string;    // compose service (or name minus the sub-wave- prefix)
+  cpuPct: number;     // 0..(100 × cores)
+  memUsed: number;    // bytes (page cache excluded, matching `docker stats`)
+  memLimit: number;   // bytes (host memory when no per-container limit is set)
+  memPct: number;     // memUsed / memLimit, 0..100
+}
+
+export interface HostUsage {
+  cpus: number;                          // logical cores
+  loadavg: [number, number, number];     // 1 / 5 / 15-minute load (0s on non-Linux)
+  memTotal: number;                      // bytes
+  memUsed: number;                       // bytes (total − free)
+  uptime: number;                        // host uptime, seconds
+}
+
+export interface SystemSummary {
+  t: string;
+  dockerAvailable: boolean;
+  dockerError?: string;
+  host: HostUsage;
+  containers: ContainerUsage[];
+}
+
+// --- helpers --------------------------------------------------------------
+
+export function dockerAvailable(): boolean {
+  try {
+    return existsSync(DOCKER_SOCK);
+  } catch {
+    return false;
+  }
+}
+
+const round = (n: number): number => Math.round(n * 10) / 10;
+
+// One-shot JSON GET over the Docker socket.
+function dockerGetJson<T>(path: string, timeoutMs = 4000): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { socketPath: DOCKER_SOCK, path, method: 'GET', timeout: timeoutMs },
+      res => {
+        const chunks: Buffer[] = [];
+        res.on('data', c => chunks.push(c as Buffer));
+        res.on('end', () => {
+          const body = Buffer.concat(chunks).toString('utf8');
+          if ((res.statusCode || 0) >= 400) {
+            reject(new Error(`docker ${path} → HTTP ${res.statusCode}`));
+            return;
+          }
+          try {
+            resolve(JSON.parse(body) as T);
+          } catch (e) {
+            reject(e as Error);
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.on('timeout', () => req.destroy(new Error(`docker ${path} timed out`)));
+    req.end();
+  });
+}
+
+// Read the container stats stream and resolve with the SECOND frame. Docker's
+// stats stream emits the first frame with an empty precpu_stats (CPU% would be
+// the cumulative-since-start average); the second frame, ~1s later, carries the
+// previous frame as precpu_stats, giving an accurate 1-second CPU window — the
+// same two-sample maths `docker stats` does. We then abort the stream.
+function dockerStats(id: string, timeoutMs = 6000): Promise<DockerStat> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const done = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      fn();
+    };
+    const req = http.request(
+      { socketPath: DOCKER_SOCK, path: `/containers/${id}/stats?stream=true`, method: 'GET', timeout: timeoutMs },
+      res => {
+        let buf = '';
+        const frames: DockerStat[] = [];
+        res.on('data', chunk => {
+          buf += (chunk as Buffer).toString('utf8');
+          let nl: number;
+          while ((nl = buf.indexOf('\n')) >= 0) {
+            const line = buf.slice(0, nl).trim();
+            buf = buf.slice(nl + 1);
+            if (!line) continue;
+            try {
+              frames.push(JSON.parse(line) as DockerStat);
+            } catch {
+              /* partial line — keep buffering */
+            }
+            if (frames.length >= 2) {
+              req.destroy();
+              done(() => resolve(frames[1]));
+              return;
+            }
+          }
+        });
+        res.on('end', () => {
+          if (frames.length) done(() => resolve(frames[frames.length - 1]));
+          else done(() => reject(new Error('no stats frames')));
+        });
+      },
+    );
+    // destroy() above fires an 'error' (aborted) we want to swallow once settled.
+    req.on('error', err => done(() => reject(err)));
+    req.on('timeout', () => req.destroy(new Error('stats timed out')));
+    req.end();
+  });
+}
+
+// CPU% across all cores, matching `docker stats`: cpuDelta / systemDelta × cores.
+function cpuPct(s: DockerStat): number {
+  const cpu = s.cpu_stats;
+  const pre = s.precpu_stats;
+  const cpuDelta = (cpu?.cpu_usage?.total_usage || 0) - (pre?.cpu_usage?.total_usage || 0);
+  const sysDelta = (cpu?.system_cpu_usage || 0) - (pre?.system_cpu_usage || 0);
+  const cores = cpu?.online_cpus || cpu?.cpu_usage?.percpu_usage?.length || os.cpus().length || 1;
+  if (cpuDelta > 0 && sysDelta > 0) return (cpuDelta / sysDelta) * cores * 100;
+  return 0;
+}
+
+// Used memory excluding reclaimable page cache, matching `docker stats`:
+// cgroup v2 subtracts inactive_file, v1 subtracts cache.
+function memUsed(s: DockerStat): number {
+  const m = s.memory_stats;
+  if (!m?.usage) return 0;
+  const cache = m.stats?.inactive_file ?? m.stats?.cache ?? 0;
+  return Math.max(0, m.usage - cache);
+}
+
+function hostUsage(): HostUsage {
+  const total = os.totalmem();
+  const free = os.freemem();
+  const [l1, l5, l15] = os.loadavg();
+  return {
+    cpus: os.cpus().length || 1,
+    loadavg: [l1, l5, l15],
+    memTotal: total,
+    memUsed: Math.max(0, total - free),
+    uptime: os.uptime(),
+  };
+}
+
+// Running containers belonging to the controller's own Compose project (falling
+// back to the sub-wave-* naming convention).
+async function subwaveContainers(): Promise<DockerContainer[]> {
+  const all = await dockerGetJson<DockerContainer[]>('/containers/json');
+  const selfHost = os.hostname(); // short container id unless `hostname:` is set
+  const self = all.find(
+    c => (c.Id || '').startsWith(selfHost) || (c.Names || []).includes('/sub-wave-controller'),
+  );
+  const project = self?.Labels?.['com.docker.compose.project'];
+  return all.filter(c =>
+    project
+      ? c.Labels?.['com.docker.compose.project'] === project
+      : (c.Names || []).some(n => n.startsWith('/sub-wave-')),
+  );
+}
+
+// --- public ---------------------------------------------------------------
+
+export async function summary(): Promise<SystemSummary> {
+  const host = hostUsage();
+  const base = { t: new Date().toISOString(), host, containers: [] as ContainerUsage[] };
+
+  if (!dockerAvailable()) {
+    return { ...base, dockerAvailable: false, dockerError: 'docker socket not mounted' };
+  }
+
+  try {
+    const list = await subwaveContainers();
+    const usage = await Promise.all(
+      list.map(async (c): Promise<ContainerUsage | null> => {
+        try {
+          const s = await dockerStats(c.Id);
+          const name = (c.Names?.[0] || c.Id).replace(/^\//, '');
+          const service = c.Labels?.['com.docker.compose.service'] || name.replace(/^sub-wave-/, '');
+          const used = memUsed(s);
+          const limit = s.memory_stats?.limit || 0;
+          return {
+            name,
+            service,
+            cpuPct: round(cpuPct(s)),
+            memUsed: used,
+            memLimit: limit,
+            memPct: limit ? round((used / limit) * 100) : 0,
+          };
+        } catch {
+          return null; // one container failing shouldn't sink the whole readout
+        }
+      }),
+    );
+    const containers = usage
+      .filter((c): c is ContainerUsage => c !== null)
+      .sort((a, b) => b.cpuPct - a.cpuPct || b.memUsed - a.memUsed);
+    return { ...base, dockerAvailable: true, containers };
+  } catch (err) {
+    return { ...base, dockerAvailable: false, dockerError: (err as Error).message };
+  }
+}

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -88,6 +88,11 @@ services:
       - "${CONTROLLER_PORT:-7701}:7701"
     volumes:
       - *state-mount
+      # Read-only Docker socket — lets the admin Stats page report per-container
+      # CPU/memory for the stack (GET /system, via the Docker Engine API; no
+      # docker CLI in the image). Optional: drop this line and the panel just
+      # shows "container stats unavailable" — nothing else depends on it.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
 
   # -------------------------------------------------------------------------
   # WEB — Next.js listener UI, bound to host for your reverse proxy

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -102,6 +102,10 @@ services:
       # /app/node_modules with the (possibly empty) host node_modules.
       - ./controller/src:/app/src
       - ./controller/scripts:/app/scripts
+      # Read-only Docker socket — powers the admin Stats system-resource panel
+      # (GET /system) in dev too. Optional: drop it and the panel shows
+      # "container stats unavailable".
+      - /var/run/docker.sock:/var/run/docker.sock:ro
 
   # -------------------------------------------------------------------------
   # TTS-HEAVY (optional) — sidecar for Chatterbox + PocketTTS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,11 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - *state-mount
+      # Read-only Docker socket — lets the admin Stats page report per-container
+      # CPU/memory for the stack (GET /system, via the Docker Engine API; no
+      # docker CLI in the image). Optional: drop this line and the panel just
+      # shows "container stats unavailable" — nothing else depends on it.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
 
   # -------------------------------------------------------------------------
   # WEB — Next.js listener UI

--- a/web/components/admin/StatsPanel.tsx
+++ b/web/components/admin/StatsPanel.tsx
@@ -162,6 +162,32 @@ interface AudienceResponse {
   error?: string;
 }
 
+interface ContainerUsage {
+  name: string;
+  service: string;
+  cpuPct: number;
+  memUsed: number;
+  memLimit: number;
+  memPct: number;
+}
+
+interface HostUsage {
+  cpus: number;
+  loadavg: [number, number, number];
+  memTotal: number;
+  memUsed: number;
+  uptime: number;
+}
+
+interface SystemResponse {
+  t?: string;
+  dockerAvailable?: boolean;
+  dockerError?: string;
+  host?: HostUsage;
+  containers?: ContainerUsage[];
+  error?: string;
+}
+
 // --- formatters ---------------------------------------------------------
 
 const fmtInt = (n: number | null | undefined): string =>
@@ -186,6 +212,14 @@ const fmtTokens = (n: number | null | undefined): string => {
 // single decimal reads better than a rounded whole.
 const fmtAvg = (n: number | null | undefined): string =>
   n == null ? '—' : (Math.round(n * 10) / 10).toLocaleString('en-GB');
+
+const fmtBytes = (n: number | null | undefined): string => {
+  if (n == null) return '—';
+  if (n >= 1024 ** 3) return `${(n / 1024 ** 3).toFixed(1)} GB`;
+  if (n >= 1024 ** 2) return `${Math.round(n / 1024 ** 2)} MB`;
+  if (n >= 1024) return `${Math.round(n / 1024)} KB`;
+  return `${n} B`;
+};
 
 // --- small building blocks ---------------------------------------------
 
@@ -274,6 +308,9 @@ function Table<R>({ cols, rows, empty }: TableProps<R>) {
               key={c.key}
               className={cn(
                 'caption border-b border-separator-strong px-2 py-1 whitespace-nowrap',
+                // Sticky so the header stays put when the table is wrapped in a
+                // ScrollBox; the card-bg masks rows scrolling underneath.
+                'sticky top-0 z-[1] bg-[var(--card-bg)]',
                 c.align === 'right' && 'text-right',
                 c.align === 'center' && 'text-center',
               )}
@@ -326,6 +363,15 @@ function BarList({ rows, max }: { rows: BarRow[]; max: number }) {
       ))}
     </div>
   );
+}
+
+// Caps a breakdown list/table to a scrollable area so a long tail (e.g. 40
+// referrers or countries) can't stretch the card down the page. Short lists are
+// untouched — the scrollbar only appears once content exceeds the cap. Uses the
+// house ink-tinted scrollbar (.v3-scroll, globals.css); tables wrapped here keep
+// their header visible via the sticky <thead> in <Table>.
+function ScrollBox({ children }: { children: ReactNode }) {
+  return <div className="v3-scroll max-h-[260px] overflow-y-auto">{children}</div>;
 }
 
 // --- listener trend chart ----------------------------------------------
@@ -406,6 +452,7 @@ export default function StatsPanel() {
   const [paused, setPaused] = useState(false);
   const [listeners, setListeners] = useState<ListenersResponse | null>(null);
   const [audience, setAudience] = useState<AudienceResponse | null>(null);
+  const [systemRes, setSystemRes] = useState<SystemResponse | null>(null);
   const [range, setRange] = useState('1440'); // minutes — 24h default
 
   // /stats — usage rollups, 5s.
@@ -487,6 +534,31 @@ export default function StatsPanel() {
     return () => { cancelled = true; clearInterval(id); };
   }, [paused, needsAuth, hydrated, adminFetch, range]);
 
+  // /system — per-container CPU/memory, 30s (it samples the Docker stats stream
+  // for ~1s per container, so it's heavier than /stats). Soft-fails like the
+  // others. Range-independent — always "right now".
+  useEffect(() => {
+    if (!hydrated || needsAuth) return;
+    let cancelled = false;
+    const tick = async () => {
+      if (paused) return;
+      try {
+        const r = await adminFetch('/system');
+        if (r.status === 401) {
+          if (!cancelled) setSystemRes(null);
+          return;
+        }
+        const j = (await r.json()) as SystemResponse;
+        if (!cancelled && r.ok) setSystemRes(j);
+      } catch {
+        /* leave last reading in place */
+      }
+    };
+    tick();
+    const id = setInterval(tick, 30000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [paused, needsAuth, hydrated, adminFetch]);
+
   const llm = data?.llm;
   const tts = data?.tts;
   const djLog = data?.djLog;
@@ -505,6 +577,10 @@ export default function StatsPanel() {
   const audSessions = audience?.sessions ?? null;
   const audReferrers = audience?.referrers ?? [];
   const audCountries = audience?.countries ?? [];
+
+  // System resources (container CPU/mem + host totals).
+  const sysHost = systemRes?.host ?? null;
+  const sysContainers = systemRes?.containers ?? [];
 
   return (
     <div className="grid gap-4">
@@ -575,10 +651,12 @@ export default function StatsPanel() {
               <div className="border-r border-separator-soft p-3.5">
                 <div className="caption mb-2">top referrers</div>
                 {audReferrers.length ? (
-                  <BarList
-                    rows={audReferrers.map(r => ({ label: r.source, count: r.count }))}
-                    max={audReferrers[0]?.count || 1}
-                  />
+                  <ScrollBox>
+                    <BarList
+                      rows={audReferrers.map(r => ({ label: r.source, count: r.count }))}
+                      max={audReferrers[0]?.count || 1}
+                    />
+                  </ScrollBox>
                 ) : (
                   <span className="field-hint italic">none</span>
                 )}
@@ -586,10 +664,12 @@ export default function StatsPanel() {
               <div className="p-3.5">
                 <div className="caption mb-2">top countries</div>
                 {audCountries.length ? (
-                  <BarList
-                    rows={audCountries.map(c => ({ label: c.country, count: c.count }))}
-                    max={audCountries[0]?.count || 1}
-                  />
+                  <ScrollBox>
+                    <BarList
+                      rows={audCountries.map(c => ({ label: c.country, count: c.count }))}
+                      max={audCountries[0]?.count || 1}
+                    />
+                  </ScrollBox>
                 ) : (
                   <span className="field-hint italic">none</span>
                 )}
@@ -815,14 +895,67 @@ export default function StatsPanel() {
                 no DJ-log events yet
               </span>
             ) : (
-              <BarList
-                max={djLog.byKind[0]?.count || 1}
-                rows={djLog.byKind.map(r => ({ label: r.kind, count: r.count }))}
-              />
+              <ScrollBox>
+                <BarList
+                  max={djLog.byKind[0]?.count || 1}
+                  rows={djLog.byKind.map(r => ({ label: r.kind, count: r.count }))}
+                />
+              </ScrollBox>
             )}
           </Card>
         </>
       )}
+
+      {/* ── SYSTEM RESOURCES ──────────────────────────────────────────── */}
+      <Card
+        title="System resources"
+        sub="CPU + memory for the SUB/WAVE containers on this host"
+      >
+        {systemRes == null ? (
+          <span className="field-hint italic">loading…</span>
+        ) : (
+          <div className="grid gap-0">
+            <MetricStrip>
+              <StatCell label="Host cores" value={fmtInt(sysHost?.cpus)} />
+              <StatCell label="Load (1m)"
+                value={sysHost ? sysHost.loadavg[0].toFixed(2) : '—'}
+                danger={!!sysHost && sysHost.loadavg[0] > sysHost.cpus}
+                sub={sysHost
+                  ? `${sysHost.loadavg[1].toFixed(2)} · ${sysHost.loadavg[2].toFixed(2)} (5m · 15m)`
+                  : undefined} />
+              <StatCell label="Host memory" value={fmtBytes(sysHost?.memUsed)}
+                sub={sysHost ? `of ${fmtBytes(sysHost.memTotal)}` : undefined} />
+              <StatCell label="Containers" value={fmtInt(sysContainers.length)} last />
+            </MetricStrip>
+            <div className="p-3.5">
+              {!systemRes.dockerAvailable ? (
+                <span className="field-hint italic">
+                  container stats unavailable — mount /var/run/docker.sock (read-only)
+                  into the controller to enable
+                </span>
+              ) : sysContainers.length === 0 ? (
+                <span className="field-hint italic">no containers reporting</span>
+              ) : (
+                <ScrollBox>
+                  <Table<ContainerUsage>
+                    empty="no containers"
+                    rows={sysContainers}
+                    cols={[
+                      { key: 'service', label: 'Service' },
+                      { key: 'cpuPct', label: 'CPU', align: 'right',
+                        render: r => <span className="mono-num">{r.cpuPct.toFixed(1)}%</span> },
+                      { key: 'memUsed', label: 'Memory', align: 'right',
+                        render: r => <span className="mono-num">{fmtBytes(r.memUsed)}</span> },
+                      { key: 'memPct', label: 'Mem %', align: 'right',
+                        render: r => <span className="mono-num">{r.memPct.toFixed(1)}%</span> },
+                    ]}
+                  />
+                </ScrollBox>
+              )}
+            </div>
+          </div>
+        )}
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## What

Two changes to the admin **Stats** page:

1. **Scroll boxes for long lists.** The Audience-sources *top referrers* / *top countries* lists are capped server-side at 40 keys each and were stretching the card down the page. They (and the DJ-activity breakdown) are now wrapped in a height-capped scroll box (`max-h-[260px]` + the house `.v3-scroll` ink scrollbar). Short lists are untouched — the scrollbar only engages once content overflows. `<Table>` headers are now `sticky` so a wrapped table keeps its header.

2. **System resources card.** New panel reporting per-container CPU/memory for the SUB/WAVE stack plus host totals (cores, load, memory).

## How

- New `controller/src/system.ts` + admin-gated `GET /system` (`routes/system.ts`, wired in `server.ts`). It talks to the Docker Engine API directly over a **read-only** `/var/run/docker.sock` mount — no `docker` CLI added to the image, just Node `http` over `socketPath`. CPU%/mem use two-frame stats sampling to match `docker stats`; the container set is scoped to the controller's own Compose project (falls back to the `sub-wave-*` name convention).
- Socket mounted read-only in all three compose files (`docker-compose{,.byo,.dev}.yml`); each line is documented as optional.
- Degrades cleanly to *"container stats unavailable"* when the socket isn't mounted (dev-on-Mac, BYO operators who omit it) — nothing else depends on it.

## Security note

Mounting the Docker socket — even read-only — gives the controller broad daemon access. It's gated behind the admin auth and the line is optional/removable; that's the cost of reporting all-container CPU/mem from inside the controller. Flagging for review.

## Verification

- `npm run lint` (eslint + `tsc --noEmit`) clean in both `controller/` and `web/`.
- `GET /system` smoke-tested against the live dev stack: returns host totals + `broadcast`/`controller` rows with CPU/mem matching `docker stats`; scroll boxes verified in-browser with 90 seeded audience beacons (15 referrers / 23 countries).