### PR TITLE
fix(stats): read container metrics via docker-socket-proxy, not the raw socket

### DIFF
--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -114,6 +114,10 @@ services:
       # unreachable and audio/chatterbox.ts + audio/pocketTts.ts silently
       # fall back to Piper (same behaviour as the default image today).
       - TTS_HEAVY_URL=\${TTS_HEAVY_URL:-http://tts-heavy:8080}
+      # Per-container CPU/memory for the admin Stats page (GET /system) is read
+      # from the docker-socket-proxy sidecar over TCP — the controller never
+      # touches the raw Docker socket. Unset this to disable the panel.
+      - DOCKER_HOST=tcp://docker-socket-proxy:2375
     env_file:
       # All controller config (Navidrome creds, LLM keys, ADMIN_*, etc.) lives
       # in the root .env. Vars not set are simply absent — settings.json takes
@@ -123,10 +127,24 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - *state-mount
-      # Read-only Docker socket — lets the admin Stats page report per-container
-      # CPU/memory for the stack (GET /system, via the Docker Engine API; no
-      # docker CLI in the image). Optional: drop this line and the panel just
-      # shows "container stats unavailable" — nothing else depends on it.
+
+  # -------------------------------------------------------------------------
+  # DOCKER-SOCKET-PROXY — locked-down Docker API for the Stats system panel
+  # -------------------------------------------------------------------------
+  # Owns the real /var/run/docker.sock and exposes a read-only, GET-only slice
+  # of the Docker Engine API over TCP (CONTAINERS section only; POST and every
+  # other section refused by default). The controller reads per-container
+  # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
+  # controller image itself never holds the socket. No host port — only
+  # reachable on the internal compose network. Optional: remove this service
+  # (and the controller's DOCKER_HOST above) to drop the Stats system panel.
+  docker-socket-proxy:
+    image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
+    container_name: sub-wave-docker-proxy
+    restart: unless-stopped
+    environment:
+      - CONTAINERS=1
+    volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
   # -------------------------------------------------------------------------
@@ -328,6 +346,10 @@ services:
       # Optional sidecar for Chatterbox + PocketTTS. Gated by --profile tts-heavy
       # below; unreachable URL → fall back to Piper (no harm done).
       - TTS_HEAVY_URL=\${TTS_HEAVY_URL:-http://tts-heavy:8080}
+      # Per-container CPU/memory for the admin Stats page (GET /system) is read
+      # from the docker-socket-proxy sidecar over TCP — the controller never
+      # touches the raw Docker socket. Unset this to disable the panel.
+      - DOCKER_HOST=tcp://docker-socket-proxy:2375
     env_file:
       - ./.env
     extra_hosts:
@@ -336,10 +358,24 @@ services:
       - "\${CONTROLLER_PORT:-7701}:7701"
     volumes:
       - *state-mount
-      # Read-only Docker socket — lets the admin Stats page report per-container
-      # CPU/memory for the stack (GET /system, via the Docker Engine API; no
-      # docker CLI in the image). Optional: drop this line and the panel just
-      # shows "container stats unavailable" — nothing else depends on it.
+
+  # -------------------------------------------------------------------------
+  # DOCKER-SOCKET-PROXY — locked-down Docker API for the Stats system panel
+  # -------------------------------------------------------------------------
+  # Owns the real /var/run/docker.sock and exposes a read-only, GET-only slice
+  # of the Docker Engine API over TCP (CONTAINERS section only; POST and every
+  # other section refused by default). The controller reads per-container
+  # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
+  # controller image itself never holds the socket. No host port — only
+  # reachable on the internal compose network. Optional: remove this service
+  # (and the controller's DOCKER_HOST above) to drop the Stats system panel.
+  docker-socket-proxy:
+    image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
+    container_name: sub-wave-docker-proxy
+    restart: unless-stopped
+    environment:
+      - CONTAINERS=1
+    volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
   # -------------------------------------------------------------------------
@@ -513,6 +549,10 @@ services:
       # below; unreachable URL → fall back to Piper. Dev usage:
       #   docker compose -f docker-compose.dev.yml --profile tts-heavy up -d
       - TTS_HEAVY_URL=\${TTS_HEAVY_URL:-http://tts-heavy:8080}
+      # Per-container CPU/memory for the admin Stats page (GET /system) is read
+      # from the docker-socket-proxy sidecar over TCP — the controller never
+      # touches the raw Docker socket. Unset this to disable the panel.
+      - DOCKER_HOST=tcp://docker-socket-proxy:2375
     ports:
       - "7701:7701"
     env_file:
@@ -537,9 +577,23 @@ services:
       # /app/node_modules with the (possibly empty) host node_modules.
       - ./controller/src:/app/src
       - ./controller/scripts:/app/scripts
-      # Read-only Docker socket — powers the admin Stats system-resource panel
-      # (GET /system) in dev too. Optional: drop it and the panel shows
-      # "container stats unavailable".
+
+  # -------------------------------------------------------------------------
+  # DOCKER-SOCKET-PROXY — locked-down Docker API for the Stats system panel
+  # -------------------------------------------------------------------------
+  # Owns the real /var/run/docker.sock and exposes a read-only, GET-only slice
+  # of the Docker Engine API over TCP (CONTAINERS section only; POST and every
+  # other section refused by default). The controller reads per-container
+  # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
+  # controller never holds the socket. No host port. Optional: remove this
+  # service (and the controller's DOCKER_HOST above) to drop the Stats panel.
+  docker-socket-proxy:
+    image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
+    container_name: sub-wave-docker-proxy
+    restart: unless-stopped
+    environment:
+      - CONTAINERS=1
+    volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
   # -------------------------------------------------------------------------

--- a/controller/src/system.ts
+++ b/controller/src/system.ts
@@ -1,24 +1,48 @@
 // System-resource readout for the admin Stats page.
 //
 // Answers "how much CPU/memory is SUB/WAVE using on this box?" by talking to the
-// Docker Engine API directly over the mounted unix socket (/var/run/docker.sock)
-// — no `docker` CLI in the image, just Node's http over a socketPath. The
-// controller runs as root in its container, so it can read the socket when the
-// compose file mounts it (read-only). When the socket isn't mounted (dev on a
-// Mac, a BYO operator who'd rather not expose it), dockerAvailable() is false
-// and summary() returns just the host figures with an empty container list — the
-// UI degrades to "container stats unavailable" rather than erroring.
+// Docker Engine API — no `docker` CLI in the image, just Node's http. The
+// controller never holds the raw Docker socket: the compose files run a
+// `docker-socket-proxy` sidecar that owns /var/run/docker.sock and exposes a
+// read-only, GET-only slice of the API over TCP (CONTAINERS only; all POST/
+// mutating calls refused). The controller reaches it via DOCKER_HOST
+// (tcp://docker-socket-proxy:2375). A direct unix-socket path is still supported
+// for ad-hoc use (DOCKER_HOST=unix:///path or DOCKER_SOCKET), but the shipped
+// composes never mount the socket into the controller.
+//
+// When neither transport is reachable (dev on a Mac without the proxy, a BYO
+// operator who dropped it), summary() returns just the host figures with an
+// empty container list — the UI degrades to "container stats unavailable"
+// rather than erroring.
 //
 // Container selection: we resolve the controller's own Compose project label and
 // return every running container in that project (caddy, broadcast, controller,
-// web, and the tts-heavy sidecar when enabled). Falls back to the sub-wave-*
-// container-name convention if the project label isn't present.
+// web, the proxy, and the tts-heavy sidecar when enabled). Falls back to the
+// sub-wave-* container-name convention if the project label isn't present.
 
 import http from 'node:http';
 import os from 'node:os';
 import { existsSync } from 'node:fs';
 
+// Resolve the Docker API transport from DOCKER_HOST (Docker's own convention),
+// falling back to a local unix socket. tcp:// → talk to the socket-proxy; unix://
+// or unset → a socketPath (only used for ad-hoc direct runs).
+const DOCKER_HOST = process.env.DOCKER_HOST || '';
 const DOCKER_SOCK = process.env.DOCKER_SOCKET || '/var/run/docker.sock';
+
+interface DockerTransport {
+  socketPath?: string;
+  host?: string;
+  port?: number;
+}
+
+function transport(): DockerTransport {
+  const tcp = /^tcp:\/\/([^:/]+):(\d+)/.exec(DOCKER_HOST);
+  if (tcp) return { host: tcp[1], port: Number(tcp[2]) };
+  const unix = /^unix:\/\/(.+)/.exec(DOCKER_HOST);
+  if (unix) return { socketPath: unix[1] };
+  return { socketPath: DOCKER_SOCK };
+}
 
 // --- Docker API types (only the fields we read) ---------------------------
 
@@ -69,8 +93,10 @@ export interface SystemSummary {
 // --- helpers --------------------------------------------------------------
 
 export function dockerAvailable(): boolean {
+  const t = transport();
+  if (t.host) return true; // TCP proxy — reachability is confirmed at request time
   try {
-    return existsSync(DOCKER_SOCK);
+    return existsSync(t.socketPath!);
   } catch {
     return false;
   }
@@ -82,7 +108,7 @@ const round = (n: number): number => Math.round(n * 10) / 10;
 function dockerGetJson<T>(path: string, timeoutMs = 4000): Promise<T> {
   return new Promise((resolve, reject) => {
     const req = http.request(
-      { socketPath: DOCKER_SOCK, path, method: 'GET', timeout: timeoutMs },
+      { ...transport(), path, method: 'GET', timeout: timeoutMs },
       res => {
         const chunks: Buffer[] = [];
         res.on('data', c => chunks.push(c as Buffer));
@@ -120,7 +146,7 @@ function dockerStats(id: string, timeoutMs = 6000): Promise<DockerStat> {
       fn();
     };
     const req = http.request(
-      { socketPath: DOCKER_SOCK, path: `/containers/${id}/stats?stream=true`, method: 'GET', timeout: timeoutMs },
+      { ...transport(), path: `/containers/${id}/stats?stream=true`, method: 'GET', timeout: timeoutMs },
       res => {
         let buf = '';
         const frames: DockerStat[] = [];
@@ -212,7 +238,7 @@ export async function summary(): Promise<SystemSummary> {
   const base = { t: new Date().toISOString(), host, containers: [] as ContainerUsage[] };
 
   if (!dockerAvailable()) {
-    return { ...base, dockerAvailable: false, dockerError: 'docker socket not mounted' };
+    return { ...base, dockerAvailable: false, dockerError: 'docker socket-proxy not reachable' };
   }
 
   try {

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -80,6 +80,10 @@ services:
       # Optional sidecar for Chatterbox + PocketTTS. Gated by --profile tts-heavy
       # below; unreachable URL → fall back to Piper (no harm done).
       - TTS_HEAVY_URL=${TTS_HEAVY_URL:-http://tts-heavy:8080}
+      # Per-container CPU/memory for the admin Stats page (GET /system) is read
+      # from the docker-socket-proxy sidecar over TCP — the controller never
+      # touches the raw Docker socket. Unset this to disable the panel.
+      - DOCKER_HOST=tcp://docker-socket-proxy:2375
     env_file:
       - ./.env
     extra_hosts:
@@ -88,10 +92,24 @@ services:
       - "${CONTROLLER_PORT:-7701}:7701"
     volumes:
       - *state-mount
-      # Read-only Docker socket — lets the admin Stats page report per-container
-      # CPU/memory for the stack (GET /system, via the Docker Engine API; no
-      # docker CLI in the image). Optional: drop this line and the panel just
-      # shows "container stats unavailable" — nothing else depends on it.
+
+  # -------------------------------------------------------------------------
+  # DOCKER-SOCKET-PROXY — locked-down Docker API for the Stats system panel
+  # -------------------------------------------------------------------------
+  # Owns the real /var/run/docker.sock and exposes a read-only, GET-only slice
+  # of the Docker Engine API over TCP (CONTAINERS section only; POST and every
+  # other section refused by default). The controller reads per-container
+  # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
+  # controller image itself never holds the socket. No host port — only
+  # reachable on the internal compose network. Optional: remove this service
+  # (and the controller's DOCKER_HOST above) to drop the Stats system panel.
+  docker-socket-proxy:
+    image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
+    container_name: sub-wave-docker-proxy
+    restart: unless-stopped
+    environment:
+      - CONTAINERS=1
+    volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
   # -------------------------------------------------------------------------

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -78,6 +78,10 @@ services:
       # below; unreachable URL → fall back to Piper. Dev usage:
       #   docker compose -f docker-compose.dev.yml --profile tts-heavy up -d
       - TTS_HEAVY_URL=${TTS_HEAVY_URL:-http://tts-heavy:8080}
+      # Per-container CPU/memory for the admin Stats page (GET /system) is read
+      # from the docker-socket-proxy sidecar over TCP — the controller never
+      # touches the raw Docker socket. Unset this to disable the panel.
+      - DOCKER_HOST=tcp://docker-socket-proxy:2375
     ports:
       - "7701:7701"
     env_file:
@@ -102,9 +106,23 @@ services:
       # /app/node_modules with the (possibly empty) host node_modules.
       - ./controller/src:/app/src
       - ./controller/scripts:/app/scripts
-      # Read-only Docker socket — powers the admin Stats system-resource panel
-      # (GET /system) in dev too. Optional: drop it and the panel shows
-      # "container stats unavailable".
+
+  # -------------------------------------------------------------------------
+  # DOCKER-SOCKET-PROXY — locked-down Docker API for the Stats system panel
+  # -------------------------------------------------------------------------
+  # Owns the real /var/run/docker.sock and exposes a read-only, GET-only slice
+  # of the Docker Engine API over TCP (CONTAINERS section only; POST and every
+  # other section refused by default). The controller reads per-container
+  # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
+  # controller never holds the socket. No host port. Optional: remove this
+  # service (and the controller's DOCKER_HOST above) to drop the Stats panel.
+  docker-socket-proxy:
+    image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
+    container_name: sub-wave-docker-proxy
+    restart: unless-stopped
+    environment:
+      - CONTAINERS=1
+    volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
   # -------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,10 @@ services:
       # unreachable and audio/chatterbox.ts + audio/pocketTts.ts silently
       # fall back to Piper (same behaviour as the default image today).
       - TTS_HEAVY_URL=${TTS_HEAVY_URL:-http://tts-heavy:8080}
+      # Per-container CPU/memory for the admin Stats page (GET /system) is read
+      # from the docker-socket-proxy sidecar over TCP — the controller never
+      # touches the raw Docker socket. Unset this to disable the panel.
+      - DOCKER_HOST=tcp://docker-socket-proxy:2375
     env_file:
       # All controller config (Navidrome creds, LLM keys, ADMIN_*, etc.) lives
       # in the root .env. Vars not set are simply absent — settings.json takes
@@ -114,10 +118,24 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - *state-mount
-      # Read-only Docker socket — lets the admin Stats page report per-container
-      # CPU/memory for the stack (GET /system, via the Docker Engine API; no
-      # docker CLI in the image). Optional: drop this line and the panel just
-      # shows "container stats unavailable" — nothing else depends on it.
+
+  # -------------------------------------------------------------------------
+  # DOCKER-SOCKET-PROXY — locked-down Docker API for the Stats system panel
+  # -------------------------------------------------------------------------
+  # Owns the real /var/run/docker.sock and exposes a read-only, GET-only slice
+  # of the Docker Engine API over TCP (CONTAINERS section only; POST and every
+  # other section refused by default). The controller reads per-container
+  # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
+  # controller image itself never holds the socket. No host port — only
+  # reachable on the internal compose network. Optional: remove this service
+  # (and the controller's DOCKER_HOST above) to drop the Stats system panel.
+  docker-socket-proxy:
+    image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
+    container_name: sub-wave-docker-proxy
+    restart: unless-stopped
+    environment:
+      - CONTAINERS=1
+    volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
   # -------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up hardening for the Stats **System resources** panel shipped in #480.

## Why

#480 mounted `/var/run/docker.sock` (`:ro`) into the controller. The read-only flag only protects the **socket file** — the Docker API behind it stays fully writable, so the controller could in principle create/exec containers. That's effectively root-on-host, and was flagged HIGH by automated security review.

## What

Replace the direct socket mount with a **`docker-socket-proxy`** sidecar (`ghcr.io/tecnativa/docker-socket-proxy:0.3.0`) that owns the socket and exposes a **GET-only, CONTAINERS-only** slice of the Docker Engine API over TCP. POST/mutating calls and every other API section are refused by default. The controller reaches it via `DOCKER_HOST=tcp://docker-socket-proxy:2375` and never holds the socket itself.

- **`controller/src/system.ts`**: resolve the Docker API transport from `DOCKER_HOST` (`tcp://host:port` → proxy; `unix://…`/`DOCKER_SOCKET` → socketPath fallback for ad-hoc direct runs). `http.request` options spread the transport; everything else (two-frame CPU sampling, project scoping, graceful degrade) is unchanged.
- **compose (×3)**: drop the controller's `docker.sock` mount, add `DOCKER_HOST` + the `docker-socket-proxy` service (`CONTAINERS=1`, no host port — internal network only). Both documented as optional; remove them to drop the panel.
- **cli**: re-embed compose assets (`assets.generated.ts`), verified deterministic.

## Verification

- `tsc --noEmit` clean (controller).
- Throwaway proxy: `GET /containers/json` → 200, `POST /containers/create` → 403, `GET /info` → 403 (only the whitelisted reads pass).
- `system.summary()` over `DOCKER_HOST=tcp://…` returns host totals + the running `sub-wave-*` container rows with CPU/mem.
- `embed-assets` re-run produces no diff (assets in sync).