### PR TITLE
feat(dj): per-skill context allow-lists; stop weather dominating DJ patter (#471)

### DIFF
--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -9,6 +9,8 @@ export {
   randomSeed,
   buildContextLines,
   decoratePrompt,
+  CONTEXT_FIELDS,
+  normalizeContextFields,
 } from './internal/prompts/context.js';
 export { introBudgetPhrase, enforceIntroBudget } from './internal/prompts/intro-budget.js';
 export { matchRequest, identifyTrackFromText } from './internal/prompts/request.js';

--- a/controller/src/llm/internal/prompts/context.ts
+++ b/controller/src/llm/internal/prompts/context.ts
@@ -9,18 +9,18 @@
 // more variety here, the less the DJ repeats itself.
 export const ANGLES = {
   intro: [
-    'Open with one specific image from right now (weather, time, day, season) and slide into the track.',
+    'Open with one specific image from right now (the time, the day, the season, the light) and slide into the track.',
     'Mention the artist in passing — one detail (era, scene, mood) — not a full title-and-artist back-announce.',
     'Skip the introduction entirely and start mid-thought, as if continuing a conversation.',
     'React to the request itself — what kind of request it is, what mood it suggests — before mentioning the track.',
-    'Use a short personal observation about the moment (Tuesday energy, the rain holding off, etc.) as the doorway.',
-    'Lean into contrast: how this track sits against the time of day, the weather, or the mood of the moment.',
+    'Use a short personal observation about the moment (Tuesday energy, the slow drift of the afternoon, etc.) as the doorway.',
+    'Lean into contrast: how this track sits against the time of day or the mood of the moment.',
     'Just say one true sentence and let the music start.',
   ],
   link: [
     'Comment on a contrast or similarity between the two tracks (era, mood, instrumentation, tempo).',
-    'Tie the next track to the time of day, weather, or season — specifically, not generically.',
-    'Mention something small and tactile about right now (the rain, the dark, the smell of coffee, the day of the week).',
+    'Tie the next track to the time of day or the season — specifically, not generically.',
+    'Mention something small and tactile about right now (the dark, the smell of coffee, the day of the week).',
     'Reference the previous artist or song obliquely — one detail, no full back-announce.',
     'Skip the back-announce entirely and just open a small thought about what is next.',
     'Acknowledge a listener-shaped moment (commute, late shift, weekend, midweek lull) without naming any listener.',
@@ -28,9 +28,9 @@ export const ANGLES = {
   ],
   station_id: [
     'Plain ident — say the station name and the DJ name, nothing else.',
-    'Anchor the ident to the current moment (a Tuesday afternoon, a foggy evening, the slow part of Sunday).',
+    'Anchor the ident to the current moment (a Tuesday afternoon, a quiet evening, the slow part of Sunday).',
     'Make it a near-aside: like someone reminding themselves where they are.',
-    'Open with the time or weather, then drop the station name in the middle of the sentence.',
+    'Open with the time of day, then drop the station name in the middle of the sentence.',
     'A single observation about broadcasting from a homelab, with the station name woven in.',
   ],
   hourly: [
@@ -52,28 +52,59 @@ export function randomSeed() {
   return Math.floor(Math.random() * 1_000_000_000);
 }
 
-export function buildContextLines(context: any, { recentTracks }: { recentTracks?: any[] } = {}) {
+// The "right now" fields buildContextLines can emit — the vocabulary every
+// per-skill / per-generator context allowlist is drawn from (issue #471). Order
+// is the order the lines are emitted in. Keep in sync with the guards below.
+export const CONTEXT_FIELDS = ['date', 'clock', 'time', 'weather', 'festival', 'show', 'listeners'] as const;
+export type ContextField = (typeof CONTEXT_FIELDS)[number];
+
+// Normalise a contextFields spec (array | comma-string | null/undefined) to a
+// Set of known field keys, or `null` meaning "every field" — the back-compat
+// default for callers that pass nothing. `all` / `*` is an explicit "every
+// field" too. Unknown tokens are dropped silently, so a typo in a SKILL.md
+// just narrows the block rather than crashing the tick.
+export function normalizeContextFields(spec?: string | readonly string[] | null): Set<string> | null {
+  if (spec == null) return null;
+  const raw = Array.isArray(spec) ? spec : String(spec).split(',');
+  const out = new Set<string>();
+  for (const tok of raw as readonly string[]) {
+    const k = String(tok).trim().toLowerCase();
+    if (!k) continue;
+    if (k === 'all' || k === '*') return null;
+    if ((CONTEXT_FIELDS as readonly string[]).includes(k)) out.add(k);
+  }
+  return out;
+}
+
+export function buildContextLines(
+  context: any,
+  { recentTracks, contextFields }: { recentTracks?: any[]; contextFields?: string | readonly string[] | null } = {},
+) {
+  // `allow === null` means no gating (every field) — the historical behaviour
+  // for callers that don't pass contextFields.
+  const allow = normalizeContextFields(contextFields);
+  const on = (f: ContextField) => allow === null || allow.has(f);
   const lines: string[] = [];
-  if (context?.date) {
+  if (on('date') && context?.date) {
     lines.push(`Day: ${context.date.dayLabel}, ${context.date.dayOfMonth} ${context.date.monthLabel} (${context.date.season})`);
   }
-  if (context?.clock) {
+  if (on('clock') && context?.clock) {
     const tags: string[] = [];
     if (context.clock.isWeekend) tags.push('weekend');
     if (context.clock.isLateNight) tags.push('late night');
     if (context.clock.isCommute) tags.push('commute hour');
     lines.push(`Local time: ${context.clock.hhmm}${tags.length ? ' · ' + tags.join(' · ') : ''}`);
   }
-  if (context?.time) lines.push(`Period: ${context.time.period} (${context.time.vibe})`);
-  if (context?.weather && context.weather.condition && context.weather.condition !== 'unknown') {
+  if (on('time') && context?.time) lines.push(`Period: ${context.time.period} (${context.time.vibe})`);
+  if (on('weather') && context?.weather && context.weather.condition && context.weather.condition !== 'unknown') {
     lines.push(`Weather in ${context.weather.location}: ${context.weather.condition}${context.weather.temp != null ? `, ${context.weather.temp}°${context.weather.tempUnit || 'C'}` : ''}`);
   }
-  if (context?.festival) lines.push(`Festival: ${context.festival.name}`);
-  if (context?.activeShow) {
+  if (on('festival') && context?.festival) lines.push(`Festival: ${context.festival.name}`);
+  if (on('show') && context?.activeShow) {
     const topic = context.activeShow.topic ? ` — ${context.activeShow.topic}` : '';
     lines.push(`On now: the show "${context.activeShow.name}"${topic}. Stay loosely on its theme.`);
   }
-  if (context?.listeners?.count != null) {
+  if (on('listeners') && context?.listeners?.count != null) {
     const n = context.listeners.count;
     lines.push(n === 0
       ? `No one is tuned in right now.`

--- a/controller/src/llm/internal/prompts/scripts.ts
+++ b/controller/src/llm/internal/prompts/scripts.ts
@@ -9,8 +9,17 @@ import { djSystem, lengthPhrase } from './system.js';
 import { buildContextLines, decoratePrompt, randomSeed } from './context.js';
 import { introBudgetPhrase, introMsFor, bpmKeyFor } from './intro-budget.js';
 
+// Real-world context the generic between-track generators are allowed to weave
+// in. Weather is deliberately EXCLUDED (issue #471): ambient weather stapled to
+// every intro/link/ident/time-check made the DJ comically weather-heavy (~50%
+// of all quips). Weather now reaches air only through the dedicated `weather`
+// segment skill, which is cooldown- and change-gated. The weather-pushing
+// narrative angles were trimmed to match — without the weather line in front of
+// it, a model told to "mention the weather" would only invent it.
+const SCRIPT_CONTEXT_FIELDS = ['date', 'clock', 'time', 'festival', 'show', 'listeners'];
+
 export async function generateIntro({ track, context, requestedBy = null, requestText = null, artistMiss = null, recap = null, recentTracks = null, recentOpeners = null }: any) {
-  const ctxLines = buildContextLines(context, { recentTracks });
+  const ctxLines = buildContextLines(context, { recentTracks, contextFields: SCRIPT_CONTEXT_FIELDS });
   if (requestedBy) ctxLines.push(`Requested by: ${requestedBy}`);
   if (requestText) {
     // Clip and sanitise so a long request can't dominate the prompt or break formatting.
@@ -46,7 +55,7 @@ export async function generateIntro({ track, context, requestedBy = null, reques
 export async function generateStationId({ recap = null, context = null, recentOpeners = null }: any = {}) {
   const djName = settings.getEffectivePersona()?.name || 'your host';
   const stationName = settings.get().station;
-  const ctxLines = buildContextLines(context);
+  const ctxLines = buildContextLines(context, { contextFields: SCRIPT_CONTEXT_FIELDS });
   ctxLines.push(`Task: ${lengthPhrase('stationId')} for ${stationName} with ${djName}. A little understated.`);
   return djText({
     system: djSystem(),
@@ -60,7 +69,7 @@ export async function generateStationId({ recap = null, context = null, recentOp
 // Takes a free-text instruction/topic and performs it in character, rather
 // than reading it verbatim (that's what raw mode is for).
 export async function generateAdLib({ instruction, context = null, recap = null, recentOpeners = null }: any) {
-  const ctxLines = buildContextLines(context);
+  const ctxLines = buildContextLines(context, { contextFields: SCRIPT_CONTEXT_FIELDS });
   const clipped = String(instruction || '').replace(/\s+/g, ' ').trim().slice(0, 300);
   ctxLines.push(`Task: the station operator wants you to say something on-air. Their instruction: "${clipped}". Deliver it in character as a natural spoken line — don't read the instruction back verbatim, perform it. ${lengthPhrase('adlib')}.`);
   return djText({
@@ -72,7 +81,7 @@ export async function generateAdLib({ instruction, context = null, recap = null,
 }
 
 export async function generateLink({ previous, current, context, recap = null, recentTracks = null, recentOpeners = null }: any) {
-  const ctxLines = buildContextLines(context, { recentTracks });
+  const ctxLines = buildContextLines(context, { recentTracks, contextFields: SCRIPT_CONTEXT_FIELDS });
   if (previous?.title) ctxLines.push(`Just played: "${previous.title}" by ${previous.artist || 'unknown'}`);
   if (current?.title) ctxLines.push(`Now playing: "${current.title}" by ${current.artist || 'unknown'}`);
 
@@ -103,7 +112,7 @@ export async function generateLink({ previous, current, context, recap = null, r
 
 export async function generateHourlyTime(time: any, weather: any, { recap = null, context = null, recentOpeners = null }: any = {}) {
   const ctx = context || { time, weather };
-  const ctxLines = buildContextLines(ctx);
+  const ctxLines = buildContextLines(ctx, { contextFields: SCRIPT_CONTEXT_FIELDS });
   ctxLines.push(`Task: a brief top-of-the-hour time check, in character. ${lengthPhrase('hourly')}.`);
   return djText({
     system: djSystem(),

--- a/controller/src/routes/dj.ts
+++ b/controller/src/routes/dj.ts
@@ -72,6 +72,10 @@ router.get('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
       isNews: kind === 'news',
       label: data.label || cat?.label || kind,
       cooldown: data.cooldown || msToCooldownStr(cat?.cooldownMs || 0),
+      // Comma-separated "right now" fields this segment may weave in (#471).
+      // Prefer the file's own value; fall back to the live effective set.
+      context: (data.context ?? data.contextFields)?.trim() || (cat?.contextFields || []).join(', '),
+      knownContextFields: [...dj.CONTEXT_FIELDS],
       feed: data.feed || cat?.feed || null,
       feedMaxItems: data.feedMaxItems ? parseInt(data.feedMaxItems, 10) : (cat?.feedMaxItems || null),
       brief: body || cat?.description || '',
@@ -84,6 +88,8 @@ router.get('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
       isNews: kind === 'news',
       label: cat?.label || kind,
       cooldown: msToCooldownStr(cat?.cooldownMs || 0),
+      context: (cat?.contextFields || []).join(', '),
+      knownContextFields: [...dj.CONTEXT_FIELDS],
       feed: cat?.feed || null,
       feedMaxItems: cat?.feedMaxItems || null,
       brief: cat?.description || '',
@@ -113,6 +119,21 @@ router.put('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
   const label = typeof b.label === 'string' && b.label.trim() ? b.label.trim() : undefined;
 
   const fields: any = { kind, label, cooldown: cooldown || undefined, brief };
+
+  // Context fields — the "right now" lines this segment may weave in (#471).
+  // Accept a comma string or an array; validate every token against the known
+  // vocabulary so a typo fails loudly here instead of silently narrowing the
+  // block. An empty selection resets the skill to the default profile.
+  if (b.context !== undefined) {
+    const raw = Array.isArray(b.context) ? b.context : String(b.context).split(',');
+    const toks = raw.map((s: any) => String(s).trim().toLowerCase()).filter(Boolean);
+    const known = new Set<string>(dj.CONTEXT_FIELDS as readonly string[]);
+    const bad = toks.filter((t: string) => !known.has(t));
+    if (bad.length) {
+      return res.status(400).json({ error: `unknown context field(s): ${bad.join(', ')} — valid: ${[...known].join(', ')}` });
+    }
+    if (toks.length) fields.contextFields = toks;
+  }
 
   // Feed is news-only. Validate it parses as an http(s) URL.
   if (kind === 'news') {

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -34,7 +34,7 @@ import { z } from 'zod';
 import { queue } from '../broadcast/queue.js';
 import * as settings from '../settings.js';
 import { defineAgent } from '../llm/agent.js';
-import { buildContextLines } from '../llm/dj.js';
+import { buildContextLines, CONTEXT_FIELDS } from '../llm/dj.js';
 import { buildSegmentTools } from '../llm/segment-tools.js';
 import { searchReady } from './web-search.js';
 import { customCapabilities, getBuiltinOverrides } from './loader.js';
@@ -49,6 +49,11 @@ import * as sfx from '../broadcast/sfx.js';
 //   desc        — the one-line briefing shown BOTH to the agent (per-capability
 //                 guidance — for traffic, which has no data tool, this is the
 //                 agent's ONLY brief) and to the admin UI
+//   contextFields — (optional) the "right now" fields (CONTEXT_FIELDS) this
+//                 capability's situation block may include. Unset → the default
+//                 profile (everything EXCEPT weather), so a segment only sees
+//                 weather if it opts in. `weather` opts back in below; an
+//                 operator opts any skill in with `context:` in its SKILL.md.
 //   requiresKey — (optional) env key the capability needs
 //   keyUrl      — (optional) where the operator obtains that key
 //   ready       — (optional) () => boolean; false when the env key is missing
@@ -60,6 +65,11 @@ export const CAPABILITIES: any[] = [
   {
     kind: 'weather', skill: 'weather', label: 'Weather',
     cooldownMs: 25 * 60 * 1000,
+    // The one built-in that opts the weather line into its situation block — it
+    // is literally the weather segment. Everything else falls back to the
+    // default profile (no weather), so weather stops bleeding into news,
+    // curiosity, deep cuts, etc. (issue #471).
+    contextFields: [...CONTEXT_FIELDS],
     desc: 'A short weather check, in character — one or two sentences. Only worth airing when conditions have genuinely changed.',
   },
   {
@@ -117,6 +127,35 @@ function allCapabilities(): any[] {
 function builtinCapabilities(): any[] {
   const ov = getBuiltinOverrides();
   return CAPABILITIES.map(c => (ov[c.kind] ? { ...c, ...ov[c.kind] } : c));
+}
+
+// The default per-skill context profile: every "right now" field EXCEPT
+// weather. A capability sees weather only when it (or its SKILL.md `context:`
+// override) explicitly asks for it — see issue #471.
+const DEFAULT_SEGMENT_CONTEXT = (CONTEXT_FIELDS as readonly string[]).filter(f => f !== 'weather');
+
+// The context fields a single capability's situation block should carry.
+// cap.contextFields may be an array (built-ins) or a comma-string (custom
+// skills / built-in overrides, straight from SKILL.md frontmatter). Absent or
+// empty → the default profile (no weather).
+export function effectiveContextFields(cap: any): string[] {
+  const raw = cap?.contextFields;
+  if (raw == null) return DEFAULT_SEGMENT_CONTEXT;
+  const list = Array.isArray(raw)
+    ? raw.map((s: any) => String(s).trim()).filter(Boolean)
+    : String(raw).split(',').map(s => s.trim()).filter(Boolean);
+  return list.length ? list : DEFAULT_SEGMENT_CONTEXT;
+}
+
+// Union of the context fields across the capabilities on offer this tick. The
+// autonomous director makes ONE decision over many capabilities, so it sees a
+// field if ANY offered capability wants it: when the weather skill is
+// off-cooldown weather shows up, but on the (many) ticks it isn't eligible the
+// director never sees weather and can't tempt a news/curiosity line into it.
+function unionContextFields(caps: any[]): string[] {
+  const out = new Set<string>();
+  for (const c of caps) for (const f of effectiveContextFields(c)) out.add(f);
+  return [...out];
 }
 
 const SEGMENT_SCHEMA = z.object({
@@ -233,9 +272,9 @@ export const directorAgent = defineAgent({
 // The concrete situation handed to the agent as its single user turn. Built
 // from what is on air and queue.getDjRecap() (what actually aired recently) —
 // NOT the track-pick session history, which derails small models.
-function buildSituation(ctx: any, { forced = false }: { forced?: boolean } = {}) {
+function buildSituation(ctx: any, { forced = false, contextFields }: { forced?: boolean; contextFields?: string[] } = {}) {
   const lines = ['The current moment:'];
-  const ctxLines = buildContextLines(ctx);
+  const ctxLines = buildContextLines(ctx, { contextFields });
   if (ctxLines.length) lines.push(...ctxLines);
   const cur = queue.current?.track;
   if (cur) lines.push(`On air now: "${cur.title}" by ${cur.artist || 'unknown'}`);
@@ -278,7 +317,7 @@ export async function agenticTick(ctx) {
     // Empty catalogue when SFX are disabled — the agent is never offered effects.
     const sfxCatalog = settings.get().sfx?.enabled === false ? [] : await sfx.catalog();
     const { object } = await directorAgent.run({
-      messages: [{ role: 'user', content: buildSituation(ctx) }],
+      messages: [{ role: 'user', content: buildSituation(ctx, { contextFields: unionContextFields(caps) }) }],
       persona, caps, freq, sfxCatalog,
       ctx, segmentState,
     });
@@ -407,7 +446,7 @@ export async function runCapability(which, ctx) {
   // Empty catalogue when SFX are disabled — the agent is never offered effects.
   const sfxCatalog = settings.get().sfx?.enabled === false ? [] : await sfx.catalog();
   const { object } = await forcedDirectorAgent.run({
-    messages: [{ role: 'user', content: buildSituation(ctx, { forced: true }) }],
+    messages: [{ role: 'user', content: buildSituation(ctx, { forced: true, contextFields: effectiveContextFields(cap) }) }],
     persona, cap, sfxCatalog,
     ctx, segmentState,
   });
@@ -479,6 +518,10 @@ export function skillCatalog() {
       // without a second fetch. Undefined on every other capability.
       feed: c.feed || null,
       feedMaxItems: c.feedMaxItems || null,
+      // The "right now" fields this segment's situation may include (issue
+      // #471). Resolved to the default profile (no weather) when unset, so the
+      // admin UI can render the current tick-box selection without guessing.
+      contextFields: effectiveContextFields(c),
     };
   });
 }

--- a/controller/src/skills/loader.ts
+++ b/controller/src/skills/loader.ts
@@ -21,10 +21,16 @@
 //   window           "any" (default) | "commute" — only offered during commute hours
 //   requiresKey      env var the skill needs; absent → never offered
 //   toolDescription  description shown to the agent for the tool.mjs data tool
+//   context          comma-separated "right now" fields the segment may weave in
+//                    — any of: date, clock, time, weather, festival, show,
+//                    listeners. Absent → the default profile (everything EXCEPT
+//                    weather), so a skill only mentions weather when it opts in
+//                    (issue #471). e.g. `context: time, weather` for a commute-
+//                    conditions skill where weather is genuinely topical.
 //
 // EDITING BUILT-INS: a folder named after a built-in kind (weather, news, …;
 // see BUILTIN_KINDS) is treated as an OVERRIDE — it edits the shipped built-in's
-// brief/cooldown/label in place (and, for `news`, its `feed:` RSS URL +
+// brief/cooldown/label/context in place (and, for `news`, its `feed:` RSS URL +
 // `feedMaxItems`) rather than being rejected as a clash. Built-in overrides may
 // leave the body empty (= keep the default brief) and never load a tool.mjs.
 // These files are scaffolded on first boot (see skills/scaffold.js).
@@ -123,6 +129,16 @@ function titleCase(slug: string): string {
   return slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
+// Parse a `context:` (or `contextFields:`) frontmatter value — a comma list of
+// "right now" field names — into lowercase tokens, or undefined when absent or
+// empty. Unknown tokens are kept here and dropped downstream (buildContextLines
+// validates against CONTEXT_FIELDS), so the loader stays dependency-free.
+function parseContextFields(raw: string | undefined): string[] | undefined {
+  if (raw == null) return undefined;
+  const list = String(raw).split(',').map(s => s.trim().toLowerCase()).filter(Boolean);
+  return list.length ? list : undefined;
+}
+
 // Dynamically import a skill's optional tool.mjs and return its data function,
 // or null. The function is invoked per tick with the moment's context; the
 // call itself is timeout-guarded at the call site (segment-tools.js).
@@ -171,6 +187,8 @@ async function loadOne(slug: string): Promise<any | null> {
     if (body) override.desc = body;
     if (data.cooldown) override.cooldownMs = parseCooldownMs(data.cooldown);
     if (data.label) override.label = data.label.trim();
+    const ovContext = parseContextFields(data.context ?? data.contextFields);
+    if (ovContext) override.contextFields = ovContext;
     if (data.feed) override.feed = data.feed.trim();
     if (data.feedMaxItems) {
       const n = parseInt(data.feedMaxItems, 10);
@@ -207,6 +225,9 @@ async function loadOne(slug: string): Promise<any | null> {
     custom: true,
     window,
     requiresKey,
+    // Absent → effectiveContextFields() falls back to the default profile (no
+    // weather). A skill opts weather (or any field) in via `context:` (#471).
+    contextFields: parseContextFields(data.context ?? data.contextFields),
     // A keyed skill is only ready when its env var is set. Keyless skills are
     // always ready. Mirrors the built-in `ready()` convention.
     ready: requiresKey ? () => !!process.env[requiresKey] : undefined,

--- a/controller/src/skills/scaffold.ts
+++ b/controller/src/skills/scaffold.ts
@@ -14,7 +14,7 @@ import { mkdir, stat, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { STATE_DIR, config } from '../config.js';
 import { queue } from '../broadcast/queue.js';
-import { CAPABILITIES } from './_agent.js';
+import { CAPABILITIES, effectiveContextFields } from './_agent.js';
 
 const SKILLS_DIR = resolve(STATE_DIR, 'skills');
 
@@ -31,6 +31,7 @@ interface SkillFileFields {
   kind: string;
   label?: string;
   cooldown?: string;
+  contextFields?: string[]; // "right now" fields the segment may mention (#471)
   feed?: string;        // news only
   feedMaxItems?: number; // news only
   brief?: string;
@@ -45,6 +46,10 @@ export async function writeBuiltinSkillFile(fields: SkillFileFields): Promise<vo
   const lines = ['---', `name: ${kind}`];
   if (fields.label) lines.push(`label: ${fields.label}`);
   if (fields.cooldown) lines.push(`cooldown: ${fields.cooldown}`);
+  // The "right now" fields this segment may weave in (issue #471). Seeded so
+  // the knob is visible+editable in every scaffolded SKILL.md; add or drop
+  // tokens (e.g. `weather`) to change what the segment is allowed to mention.
+  if (fields.contextFields && fields.contextFields.length) lines.push(`context: ${fields.contextFields.join(', ')}`);
   if (fields.feed) lines.push(`feed: ${fields.feed}`);
   if (fields.feedMaxItems) lines.push(`feedMaxItems: ${fields.feedMaxItems}`);
   lines.push('---', (fields.brief || '').trim(), '');
@@ -74,6 +79,7 @@ export async function scaffoldBuiltinSkills(): Promise<void> {
         kind: cap.kind,
         label: cap.label,
         cooldown: msToCooldownStr(cap.cooldownMs),
+        contextFields: effectiveContextFields(cap),
         brief: cap.desc,
       };
       if (cap.kind === 'news') {

--- a/docs/custom-skills.md
+++ b/docs/custom-skills.md
@@ -37,6 +37,7 @@ name: moon-phase          # the slug / "kind" (defaults to the folder name)
 label: Moon phase         # human label in /admin/skills (defaults to title-cased name)
 cooldown: 6h              # hard min gap between autonomous firings — "90m" | "6h" | "2d" | "45" (bare = minutes)
 window: any               # "any" (default) | "commute" — only offered during commute hours
+context: time, festival   # OPTIONAL: which "right now" fields this segment may mention (see below)
 requiresKey: SOME_API_KEY # OPTIONAL: env var the skill needs; if unset, the skill stays inert
 toolDescription: ...      # OPTIONAL: how the DJ-facing tool is described (only matters with tool.mjs)
 ---
@@ -49,6 +50,44 @@ Only a **non-empty body** is required; every frontmatter key has a default. The
 body becomes the per-segment briefing the DJ agent follows (the same role the
 inline `desc:` strings play for built-in skills) and the description shown in the
 admin UI.
+
+### `context:` — what the segment is allowed to mention
+
+`context:` is a comma-separated allow-list of the "right now" fields the DJ may
+weave into this segment. Valid fields:
+
+| field | what it surfaces |
+| --- | --- |
+| `date` | day of week, date, season |
+| `clock` | local clock time, plus weekend / late-night / commute tags |
+| `time` | the daypart and its vibe (e.g. "morning, productive") |
+| `weather` | current condition, temperature, location |
+| `festival` | the named festival, if today is one |
+| `show` | the scheduled show on air, if any |
+| `listeners` | how many people are tuned in |
+
+**Leave `context:` off and the segment gets the default profile: everything
+*except* `weather`.** This is deliberate — ambient weather stapled to every
+break made the DJ comically weather-heavy ([#471](https://github.com/perminder-klair/subwave/issues/471)).
+Weather now reaches air through the dedicated **weather** skill, which is
+cooldown- and change-gated, rather than as filler everywhere.
+
+Tick `weather` back on for a skill where it's genuinely topical — e.g. a
+commute-conditions segment:
+
+```yaml
+---
+name: commute-conditions
+label: Commute conditions
+window: commute
+context: time, clock, weather
+---
+A quick word on what the drive looks like right now — lean on the weather and
+the hour. One sentence; skip it if nothing's notable.
+```
+
+You can also set this from the admin UI: **/admin/skills → Edit** shows a
+tick-box per field. An empty selection resets the skill to the default profile.
 
 For a **new** skill the `name` must be a lowercase slug that isn't a built-in kind
 (`weather`, `news`, `traffic`, `curiosity`, `album-anniversary`, `library-deep-cut`,
@@ -86,9 +125,11 @@ writes from the brief alone.
 The 7 built-ins — `weather`, `news`, `traffic`, `curiosity`, `album-anniversary`,
 `library-deep-cut`, `web-search` — are written into `state/skills/<kind>/SKILL.md`
 the first time the controller boots. A file **named after a built-in kind** is an
-**override**: it edits that skill's brief / cooldown / label in place rather than
-being rejected as a name clash. (For everything else, a built-in kind in `name:` is
-still off-limits.)
+**override**: it edits that skill's brief / cooldown / label / `context:` in place
+rather than being rejected as a name clash. (For everything else, a built-in kind in
+`name:` is still off-limits.) The scaffolded files already carry a `context:` line
+showing each built-in's current fields — `weather` ships with weather ticked on, the
+rest with the default (no-weather) profile.
 
 Differences from a custom skill:
 

--- a/web/components/admin/SkillsPanel.tsx
+++ b/web/components/admin/SkillsPanel.tsx
@@ -52,6 +52,8 @@ interface SkillFileResponse {
   isNews?: boolean;
   label?: string;
   cooldown?: string;
+  context?: string;                 // comma-separated "right now" fields (#471)
+  knownContextFields?: string[];    // the full vocabulary, for the tick-boxes
   feed?: string | null;
   feedMaxItems?: number | null;
   brief?: string;
@@ -64,9 +66,29 @@ interface EditForm {
   isNews: boolean;
   label: string;
   cooldown: string;
+  context: string[];          // selected "right now" fields the segment may mention
+  knownContext: string[];     // the full vocabulary to render tick-boxes from
   feed: string;
   feedMaxItems: string;
   brief: string;
+}
+
+// Friendly labels for the context fields (#471). Keys are the controller's
+// CONTEXT_FIELDS vocabulary; anything not listed falls back to the raw key.
+const CONTEXT_FIELD_LABELS: Record<string, string> = {
+  date: 'Date & season',
+  clock: 'Clock time',
+  time: 'Daypart',
+  weather: 'Weather',
+  festival: 'Festival',
+  show: 'Current show',
+  listeners: 'Listener count',
+};
+// Fallback vocabulary if the controller doesn't send knownContextFields.
+const CONTEXT_FIELDS_FALLBACK = ['date', 'clock', 'time', 'weather', 'festival', 'show', 'listeners'];
+
+function splitContext(s?: string): string[] {
+  return typeof s === 'string' ? s.split(',').map(t => t.trim()).filter(Boolean) : [];
 }
 
 function cooldownLabel(ms?: number): string {
@@ -178,6 +200,10 @@ export default function SkillsPanel() {
         isNews: !!j.isNews,
         label: j.label || '',
         cooldown: j.cooldown || '',
+        context: splitContext(j.context),
+        knownContext: Array.isArray(j.knownContextFields) && j.knownContextFields.length
+          ? j.knownContextFields
+          : CONTEXT_FIELDS_FALLBACK,
         feed: j.feed || '',
         feedMaxItems: j.feedMaxItems != null ? String(j.feedMaxItems) : '',
         brief: j.brief || '',
@@ -196,6 +222,9 @@ export default function SkillsPanel() {
         brief: editForm.brief,
         cooldown: editForm.cooldown,
         label: editForm.label,
+        // Sent as an array; an empty list resets the skill to the default
+        // profile (everything except weather). See issue #471.
+        context: editForm.context,
       };
       if (editForm.isNews) {
         body.feed = editForm.feed;
@@ -270,7 +299,8 @@ export default function SkillsPanel() {
           </div>
           <div className="mt-1 text-[11px] leading-[1.6] text-muted">
             The built-in skills are editable too — hit <strong>Edit</strong> to change a skill&apos;s
-            brief or cooldown (and, for News, its feed URL). Edits are saved to
+            brief, cooldown, or which real-world context (time, weather…) it may mention
+            (and, for News, its feed URL). Edits are saved to
             <code> state/skills/&lt;kind&gt;/SKILL.md</code>.
           </div>
           <div className="mt-1 text-[11px] leading-[1.6] text-muted">
@@ -414,6 +444,34 @@ export default function SkillsPanel() {
                     />
                     <span className="text-[10px] text-muted">e.g. <code>45m</code>, <code>6h</code>, <code>2d</code>, or a bare number (minutes)</span>
                   </label>
+                  <div className="grid gap-1">
+                    <span className="caption">Context this segment may mention</span>
+                    <div className="flex flex-wrap gap-x-4 gap-y-1.5">
+                      {editForm.knownContext.map(field => {
+                        const checked = editForm.context.includes(field);
+                        return (
+                          <label key={field} className="flex items-center gap-1.5 text-[12px]">
+                            <input
+                              type="checkbox"
+                              checked={checked}
+                              onChange={() => setEditForm({
+                                ...editForm,
+                                context: checked
+                                  ? editForm.context.filter(f => f !== field)
+                                  : [...editForm.context, field],
+                              })}
+                              className="accent-vermilion"
+                            />
+                            {CONTEXT_FIELD_LABELS[field] || field}
+                          </label>
+                        );
+                      })}
+                    </div>
+                    <span className="text-[10px] text-muted">
+                      Tick only what&apos;s topical for this segment. Leaving <strong>Weather</strong> off keeps it
+                      out of the prompt, so the DJ stops mentioning it on every break.
+                    </span>
+                  </div>
                   <label className="grid gap-1">
                     <span className="caption">Brief (what the DJ says, and when to stay silent)</span>
                     <textarea


### PR DESCRIPTION
Closes #471.

## Problem

The AI DJ leaned on weather in roughly **half** of all quips — often comically
unnecessary. Two compounding causes:

1. `buildContextLines` appended the weather line to **every** generator prompt
   (intro, link, station-id, hourly, ad-lib), and the narrative `ANGLES`
   actively told the model to reach for weather (~6 of 19 angles).
2. The segment director's situation block also carried weather into **every**
   between-track decision — tempting a news / curiosity / deep-cut segment to
   mention it.

The original request was for per-skill "tick-boxes" so each skill only gets the
context it needs. That's implemented here — but the bulk of the spam came from
the generic generators (which aren't skills), so those are fixed too.

## Approach

A `contextFields` allow-list threaded through the single chokepoint,
`buildContextLines`:

- **Mechanism** — `buildContextLines(context, { contextFields })` gates each
  "right now" line against an allow-list drawn from a new `CONTEXT_FIELDS`
  vocabulary (`date, clock, time, weather, festival, show, listeners`).
  Omitted ⇒ all fields, so existing callers are unchanged; `all`/`*` is
  explicit-everything; unknown tokens are dropped.
- **Generators** run on an all-minus-weather profile, and the weather-pushing
  angles were trimmed (otherwise the model would invent weather it can no
  longer see).
- **Skills** declare their fields via a `context:` `SKILL.md` frontmatter key —
  parsed by the loader, seeded into every scaffolded built-in, validated +
  round-tripped by the admin route, and editable as **per-field checkboxes** in
  `/admin/skills`. Default profile excludes weather; only the dedicated
  **weather** skill opts it in. The autonomous director sees the *union* of the
  fields of the skills on offer, so weather appears only when the weather skill
  is actually eligible.

Weather still reaches air through the cooldown- and change-gated weather skill —
it's just no longer stapled to every break.

## Files

- `llm/internal/prompts/context.ts` — `CONTEXT_FIELDS` + `normalizeContextFields`; gate `buildContextLines`; trim weather from `ANGLES`
- `llm/internal/prompts/scripts.ts` — generators use an all-minus-weather profile
- `skills/_agent.ts` — weather capability opts weather in; default profile; `effectiveContextFields`/union; `buildSituation` gating; `skillCatalog` exposure
- `skills/loader.ts` — parse `context:` frontmatter
- `skills/scaffold.ts` — seed the `context:` line into built-in `SKILL.md`
- `routes/dj.ts` — GET/PUT round-trip + validate `context`
- `web/components/admin/SkillsPanel.tsx` — per-field context checkboxes in the skill editor
- `docs/custom-skills.md` — document `context:` with a commute-conditions example

## Testing

- Controller `npm run lint` (eslint + `tsc --noEmit`) clean; web lint clean; controller test suite green.
- Booted the dev stack and verified end-to-end with live weather present (`cloudy, 20C, Birmingham`):
  - Scaffolder seeds `context:` correctly (weather includes weather; others exclude it).
  - `GET /dj/skills` catalog + `GET/PUT …/file` round-trip; PUT rejects unknown fields (400) and merges valid edits live.
  - The autonomous segment director carried **no** weather line despite real weather, because the weather skill wasn't on offer that tick — the core anti-bleed fix.
  - Generators produced no weather report (hourly painted "the sun is climbing high" while it was actually cloudy — proof the model wasn't fed the weather).
  - Forced weather situation verified to include the weather line via the real shipped functions (`effectiveContextFields` → `buildContextLines`).
