### PR TITLE
fix(web): clamp DJ thinking line so long scripts don't shove artwork under the header

### DIFF
--- a/web/components/DjThinkingLine.tsx
+++ b/web/components/DjThinkingLine.tsx
@@ -76,7 +76,10 @@ export default function DjThinkingLine({ feed, enabled, onOpenBooth }: DjThinkin
       <span className="opacity-70" aria-hidden="true">
         {MARKER[cls] || '·'}
       </span>
-      <span className="[overflow-wrap:anywhere]">
+      {/* Clamp the inline teaser so the long "extended" scripts can't grow the
+          column and shove the artwork/title up under the header on mobile.
+          The full text stays one tap away in the Booth (and in aria-label). */}
+      <span className="line-clamp-5 min-w-0 flex-1 [overflow-wrap:anywhere] sm:line-clamp-10">
         <AnimatePresence mode="wait">
           <m.span
             key={turnId}


### PR DESCRIPTION
## What

The DJ "what's being said" teaser under the now-playing block (`DjThinkingLine`) is now line-clamped so the long *extended* scripts can't grow the column.

## Why

That column (caption → title → artist → meta → DJ line) lives in a vertically-centered container pinned by `-translate-y-[64%]` (`CenterStage.tsx`), not anchored to the top. When the DJ line was the long extended variant it wrapped to many rows, the column grew downward, and the translate pushed everything — artwork and title included — up under the header on mobile.

## How

Clamped the inline teaser to a fixed number of lines:

- **5 lines on mobile** (`<640px`, artwork stacked on top, tightest vertical budget)
- **10 lines from `sm` up** (artwork moves beside the text, more room)

Nothing is lost — the line is already tappable to open the **Booth** drawer with the full transcript, and the complete text stays in `aria-label` for screen readers.

CSS/layout-only change. Lint + `tsc` pass clean.