### PR TITLE
docs(news): dispatch on running Chatterbox on an nvidia GPU

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "SUB/WAVE",
     "slug": "subwave",
     "scheme": "subwave",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/web/content/news/2026-06-21-chatterbox-on-the-gpu.md
+++ b/web/content/news/2026-06-21-chatterbox-on-the-gpu.md
@@ -1,0 +1,55 @@
+---
+title: Run Chatterbox on your nvidia card
+date: 2026-06-21
+category: Spotlight
+author: The SUB/WAVE desk
+excerpt: The tts-heavy sidecar ships CPU-only, but with a small rebuild you can move Chatterbox onto an nvidia card for faster voice synthesis. Here is the index swap, the compose change, and the one caveat.
+---
+
+The heavy TTS sidecar ships CPU-only on purpose. The PyTorch wheels inside it are the CPU build, which keeps the image from ballooning by several gigabytes. That is the right default for most boxes. But if you just moved your Docker host to a machine with a real nvidia card, you can put Chatterbox on it and get faster voice synthesis. It takes a small rebuild.
+
+## What you're changing
+
+The image installs CPU PyTorch from a pinned wheel index. To use the card you swap that index for a CUDA one, pass the GPU into the container, and flip one env var. There is already a `TTS_HEAVY_DEVICE` switch waiting for this. On the stock image it falls back to CPU, because the torch inside has no CUDA, so the rebuild is what makes the switch real.
+
+## Build a CUDA image
+
+Open `docker/Dockerfile.tts-heavy` and find the Chatterbox venv block. Change its torch index from the CPU wheels to a CUDA build that matches your driver, for example CUDA 12.4:
+
+```
+--index-url https://download.pytorch.org/whl/cu124 \
+```
+
+That is the only line in that block you need to touch. PocketTTS and the analyzer can stay on CPU.
+
+## Pass the GPU into the container
+
+Install the nvidia-container-toolkit on the host so Docker can see the card. Then give the `tts-heavy` service a GPU reservation in your compose file:
+
+```yaml
+deploy:
+  resources:
+    reservations:
+      devices:
+        - driver: nvidia
+          count: all
+          capabilities: [gpu]
+```
+
+Set the device to cuda in your root `.env`:
+
+```
+TTS_HEAVY_DEVICE=cuda
+```
+
+Rebuild and bring the sidecar back up:
+
+```
+docker compose --profile tts-heavy up -d --build tts-heavy
+```
+
+The worker logs which device it loaded on. Look for `loading ChatterboxTurboTTS on device=cuda` in the container logs. If CUDA is not actually reachable it logs `cpu` instead and keeps working, so you never lose the voice while you sort the card out.
+
+## One caveat
+
+Only Chatterbox follows `TTS_HEAVY_DEVICE`. PocketTTS and the audio analyzer stay on the CPU no matter what. So this is worth doing if Chatterbox is your DJ voice, where it is the heaviest of the engines and the card buys you the most. On PocketTTS it changes nothing.


### PR DESCRIPTION
## What

Adds a Dispatches article: **Run Chatterbox on your nvidia card** (`/news/chatterbox-on-the-gpu`).

Prompted by a Discord question: someone moved their Docker host to a machine with a better nvidia card and noticed the `-cpu` in the tts-heavy build, asking if there's a GPU version.

The post documents the **manual path** as it works today, since GPU support isn't a clean shipped feature yet:
- Why the sidecar ships CPU-only (the pinned `whl/cpu` PyTorch index, to avoid the multi-GB CUDA build).
- Swap the Chatterbox venv's torch index to a CUDA build (e.g. `whl/cu124`).
- Pass the GPU through: nvidia-container-toolkit on the host + a `deploy.resources.reservations.devices` reservation on the `tts-heavy` service.
- Set `TTS_HEAVY_DEVICE=cuda`, rebuild, and check the worker log for `device=cuda`.
- Caveat: **only Chatterbox** honors `TTS_HEAVY_DEVICE`; PocketTTS and the analyzer stay on CPU.

## Notes

- Content-only change. New page picked up automatically by `/news` (newest first) and the sitemap via `getNewsSlugs()`.
- Ran through the `humanizer` skill (no em-dashes, no inflated-significance / rule-of-three padding).
- `cd web && npm run lint && npm run build` both pass; `/news/chatterbox-on-the-gpu` prerenders.

## Follow-up (not in this PR)

If we'd rather make this a supported feature than a fork, a `WITH_CUDA=1` build arg + a commented-out compose GPU reservation would let us rewrite this dispatch into a "no fork needed" version.