### PR TITLE
fix(app): pointerEvents=none on Dimezis BlurViews so Android 16 stops swallowing taps

### DIFF
--- a/app/src/player/PlayerScreen.tsx
+++ b/app/src/player/PlayerScreen.tsx
@@ -390,6 +390,10 @@ export default function PlayerScreen() {
             intensity={mode === 'light' ? 40 : 26}
             tint={mode === 'light' ? 'light' : 'dark'}
             blurMethod="dimezisBlurView"
+            // Decorative only — on Android 16 the Dimezis BlurView native view
+            // otherwise swallows touches across its bounds, killing the masthead
+            // tabs and (via the transport bar's twin) the whole UI (#…).
+            pointerEvents="none"
             style={StyleSheet.absoluteFill}
           />
           <View pointerEvents="none" style={[StyleSheet.absoluteFill, { backgroundColor: glassFilm }]} />

--- a/app/src/player/TransportBar.tsx
+++ b/app/src/player/TransportBar.tsx
@@ -94,6 +94,10 @@ export default function TransportBar({
           intensity={mode === 'light' ? 40 : 26}
           tint={mode === 'light' ? 'light' : 'dark'}
           blurMethod="dimezisBlurView"
+          // Decorative only — without this the Dimezis BlurView native view
+          // intercepts touches on Android 16, so the tune/play button under it
+          // never fires (works on Android 15, dead on 16).
+          pointerEvents="none"
           style={StyleSheet.absoluteFill}
         />
         <View


### PR DESCRIPTION
## Problem

On **Pixel 7 / 9 / 10 running Android 16** (API 36 — our `targetSdkVersion`), the native player connects and shows the now-playing song, but **the UI registers no touches at all** — nothing is tappable, including the tune/play button. **Pixel 8a (on Android 15) is fine**, so the symptom tracks the OS version, not the hardware.

## Root cause

Both interactive overlays render their controls as siblings *on top of* an `absoluteFill` Dimezis `BlurView`:

- **Masthead / FM dial** — `PlayerScreen.tsx` (`TopBar` + `FreqBand` tabs over the blur)
- **Transport bar** — `TransportBar.tsx` (the `Pressable` tune/play button over the blur)

The decorative film *below* the controls already had `pointerEvents="none"`, but **the `BlurView` itself did not**. On Android 16 the Dimezis BlurView native view starts intercepting touches across its bounds, killing both the masthead tabs and the transport controls — i.e. the entire interactive surface, exactly the reported symptom.

## Fix

The blur is purely decorative, so mark both BlurViews `pointerEvents="none"`. Two-line change, JS-only.

## Rollout

- ✅ Already shipped to **production** via EAS Update — Android runtime `562456b4…` matches the latest Android build `v1.2.0 (9)`, which receives it on the next cold start (two relaunches: download, then apply). Older Android builds need to update to `(9)` first.
- ⚠️ Note: the iOS OTA runtime (`187f73f2…`) did **not** match the latest iOS build `v1.2.0 (10)` (`b4800e12…`), so this didn't reach current iOS installs — Android-only bug so not blocking, but the iOS fingerprint drift is worth investigating separately.

## Testing

- `tsc --noEmit` passes.
- Needs on-device confirmation from an affected Pixel (7/9/10, Android 16) once the OTA applies. If taps are still dead, the next suspect is the native-stack `animation: 'fade'` + transparent `contentStyle` in `_layout.tsx`.

https://claude.ai/code/session_01WQf9wrHWUTeN5QReqDd7Fh