### PR TITLE
fix(auth): harden admin auth with timing-safe comparison and brute-force lockoutFix/admin auth timing bruteforce

### DIFF
--- a/controller/src/middleware/auth.ts
+++ b/controller/src/middleware/auth.ts
@@ -11,7 +11,10 @@ const ADMIN_USER = process.env.ADMIN_USER || '';
 const ADMIN_PASS = process.env.ADMIN_PASS || '';
 export const ADMIN_AUTH_REQUIRED = Boolean(ADMIN_USER && ADMIN_PASS);
 const IS_PROD = process.env.NODE_ENV === 'production';
-const MAX_AUTH_FAILURES = 5;
+// 10 strikes before a temporary lockout: brute-forcing a real password in 10
+// tries is implausible, while an operator (or a household behind one NAT IP)
+// fat-fingering the password a few times shouldn't get locked out for 15 min.
+const MAX_AUTH_FAILURES = 10;
 const AUTH_LOCKOUT_MS = 15 * 60 * 1000;
 const authAttempts = new Map<string, { failures: number; lockedUntil: number }>();
 
@@ -42,6 +45,12 @@ export function assertAdminConfigured() {
 export function requireAdmin(req, res, next) {
   if (!ADMIN_AUTH_REQUIRED) return next();
 
+  // Lockout keys on clientIp() — the left-most X-Forwarded-For — which is
+  // client-controlled and therefore spoofable: an attacker can rotate the
+  // header per request to dodge this counter. So this is defense-in-depth that
+  // slows casual brute-forcing from a single source, not a hard guarantee. For
+  // durable enforcement put a real rate limit at the edge (Caddy/Cloudflare),
+  // where the connecting IP is known before it gets flattened into a header.
   const ip = clientIp(req);
   const now = Date.now();
   const rec = authAttempts.get(ip);

--- a/controller/src/middleware/auth.ts
+++ b/controller/src/middleware/auth.ts
@@ -1,3 +1,5 @@
+import { timingSafeEqual } from 'node:crypto';
+
 // Admin basic auth. In production (NODE_ENV=production) ADMIN_USER and
 // ADMIN_PASS are MANDATORY — the controller refuses to start without them,
 // because /debug, /settings, and the jingle/tagger endpoints expose enough
@@ -8,6 +10,16 @@ const ADMIN_USER = process.env.ADMIN_USER || '';
 const ADMIN_PASS = process.env.ADMIN_PASS || '';
 export const ADMIN_AUTH_REQUIRED = Boolean(ADMIN_USER && ADMIN_PASS);
 const IS_PROD = process.env.NODE_ENV === 'production';
+
+function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
 
 // Called once at startup. Exits the process if a production deploy is missing
 // admin credentials, then logs the resolved gate state.
@@ -29,7 +41,7 @@ export function requireAdmin(req, res, next) {
   if (header.startsWith('Basic ')) {
     try {
       const [u, p] = Buffer.from(header.slice(6), 'base64').toString('utf8').split(':');
-      if (u === ADMIN_USER && p === ADMIN_PASS) return next();
+      if (safeEqual(u, ADMIN_USER) && safeEqual(p, ADMIN_PASS)) return next();
     } catch {}
   }
   res.setHeader('WWW-Authenticate', 'Basic realm="SUB/WAVE admin"');

--- a/controller/src/middleware/auth.ts
+++ b/controller/src/middleware/auth.ts
@@ -64,7 +64,13 @@ export function requireAdmin(req, res, next) {
   const header = req.headers.authorization || '';
   if (header.startsWith('Basic ')) {
     try {
-      const [u, p] = Buffer.from(header.slice(6), 'base64').toString('utf8').split(':');
+      // Split on the FIRST colon only: per RFC 7617 the userid can't contain a
+      // colon but the password can, so split(':') would truncate any password
+      // with a ':' in it and reject otherwise-correct credentials.
+      const decoded = Buffer.from(header.slice(6), 'base64').toString('utf8');
+      const sep = decoded.indexOf(':');
+      const u = sep === -1 ? decoded : decoded.slice(0, sep);
+      const p = sep === -1 ? '' : decoded.slice(sep + 1);
       if (safeEqual(u, ADMIN_USER) && safeEqual(p, ADMIN_PASS)) {
         if (rec) authAttempts.delete(ip);
         return next();

--- a/controller/src/middleware/auth.ts
+++ b/controller/src/middleware/auth.ts
@@ -1,4 +1,5 @@
 import { timingSafeEqual } from 'node:crypto';
+import { clientIp } from './ratelimit.js';
 
 // Admin basic auth. In production (NODE_ENV=production) ADMIN_USER and
 // ADMIN_PASS are MANDATORY — the controller refuses to start without them,
@@ -10,6 +11,9 @@ const ADMIN_USER = process.env.ADMIN_USER || '';
 const ADMIN_PASS = process.env.ADMIN_PASS || '';
 export const ADMIN_AUTH_REQUIRED = Boolean(ADMIN_USER && ADMIN_PASS);
 const IS_PROD = process.env.NODE_ENV === 'production';
+const MAX_AUTH_FAILURES = 5;
+const AUTH_LOCKOUT_MS = 15 * 60 * 1000;
+const authAttempts = new Map<string, { failures: number; lockedUntil: number }>();
 
 function safeEqual(a: string, b: string): boolean {
   const bufA = Buffer.from(a);
@@ -37,13 +41,41 @@ export function assertAdminConfigured() {
 
 export function requireAdmin(req, res, next) {
   if (!ADMIN_AUTH_REQUIRED) return next();
+
+  const ip = clientIp(req);
+  const now = Date.now();
+  const rec = authAttempts.get(ip);
+
+  if (rec && rec.lockedUntil > now) {
+    const retryAfter = Math.ceil((rec.lockedUntil - now) / 1000);
+    res.setHeader('Retry-After', String(retryAfter));
+    return res.status(429).json({ error: 'too many failed attempts, try again later' });
+  }
+
   const header = req.headers.authorization || '';
   if (header.startsWith('Basic ')) {
     try {
       const [u, p] = Buffer.from(header.slice(6), 'base64').toString('utf8').split(':');
-      if (safeEqual(u, ADMIN_USER) && safeEqual(p, ADMIN_PASS)) return next();
+      if (safeEqual(u, ADMIN_USER) && safeEqual(p, ADMIN_PASS)) {
+        if (rec) authAttempts.delete(ip);
+        return next();
+      }
     } catch {}
   }
+
+  const entry = rec || { failures: 0, lockedUntil: 0 };
+  entry.failures += 1;
+  if (entry.failures >= MAX_AUTH_FAILURES) {
+    entry.lockedUntil = now + AUTH_LOCKOUT_MS;
+  }
+  authAttempts.set(ip, entry);
+
+  if (authAttempts.size > 500) {
+    for (const [k, v] of authAttempts) {
+      if (v.lockedUntil < now && now - v.lockedUntil > AUTH_LOCKOUT_MS) authAttempts.delete(k);
+    }
+  }
+
   res.setHeader('WWW-Authenticate', 'Basic realm="SUB/WAVE admin"');
   return res.status(401).json({ error: 'admin auth required' });
 }


### PR DESCRIPTION
## What 
Replace plain `===` string comparison in admin auth with `crypto.timingSafeEqual` and add per-IP brute-force lockout after 5 consecutive failed attempts.

## Why
The `requireAdmin` middleware was vulnerable to timing side-channel attacks (plain string comparison leaks credential info via response timing) and had no protection against brute-force attempts. Any attacker with curl could enumerate credentials with no rate limiting.

Fixes #488 (partial)

## How tested
  - `cd controller && npm run lint` - 0 errors, 554 pre-existing warnings
  - Code review: timing-safe helper handles length mismatch with dummy comparison to
  prevent length leaking
  - Code review: lockout map follows same in-memory pattern as existing `ratelimit.ts`

## Notes for reviewers
  - This is PR 1 of a potential series for #488. Scope is intentionally narrow: timing-safe
  compare + brute-force lockout only.
  - Reuses the existing `clientIp()` helper from `ratelimit.ts` for IP extraction.
  - Lockout state is in-memory (resets on container restart), matching the existing rate
  limiter pattern.
  - Map cleanup triggers at 500 entries to prevent unbounded growth.
  - The web UI admin login doesn't currently handle 429 responses with a specific message.
  A follow-up could add that, but the lockout works correctly regardless.