### PR TITLE
feat(admin): AI "describe it → auto-fill" for personas, shows & themes

### DIFF
--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -22,6 +22,7 @@ export {
   generateHourlyTime,
 } from './internal/prompts/scripts.js';
 export { PICKER_CRITERIA, pickNextTrack, showMusicLean } from './internal/prompts/picker.js';
+export { generatePersona, generateShow, generateTheme } from './internal/prompts/generate.js';
 
 // Re-exported so routes/debug.js can read the LLM call ring buffer through the
 // same module that produces the calls.

--- a/controller/src/llm/internal/prompts/generate.ts
+++ b/controller/src/llm/internal/prompts/generate.ts
@@ -1,0 +1,121 @@
+// Create-form auto-fill — turns a free-text description ("a late-night jazz host
+// with a dry wit", "a Sunday-morning gospel show", "a warm sepia newspaper
+// theme") into a draft persona / show / theme the admin UI pre-fills for review.
+// Same structured-output path as matchRequest (djObject → Zod), so it rides the
+// operator's configured station LLM with no extra keys. The schemas are
+// constrained to the SAME enums the settings/theme validators enforce, so a
+// generated draft round-trips through Save without surprises.
+
+import { z } from 'zod';
+import { FREQUENCIES, SCRIPT_LENGTHS, SHOW_MOODS, SHOW_ENERGY } from '../../../settings.js';
+import { THEME_TOKEN_KEYS } from '../../../themes.js';
+import { djObject } from '../strategy/object.js';
+
+// ---------------------------------------------------------------------------
+// Persona
+// ---------------------------------------------------------------------------
+
+const PERSONA_SCHEMA = z.object({
+  name: z.string().min(1).max(40).describe('the DJ name shown in the player — 1-3 words, evocative, never generic like "DJ" or "Host"'),
+  tagline: z.string().max(80).describe('a short one-line descriptor shown next to the name (e.g. "atmospheric & immersive"), 0-80 chars; "" if none fits'),
+  soul: z.string().min(1).max(400).describe('the personality/voice sketch the DJ speaks with — tone, sensibility, quirks, the kind of imagery they reach for. 1-3 sentences, max 400 chars. Concrete and specific, not a list of adjectives.'),
+  frequency: z.enum(FREQUENCIES as [string, ...string[]]).describe('how chatty: quiet (rarely talks), moderate, or aggressive (talks a lot)'),
+  scriptLength: z.enum(SCRIPT_LENGTHS as [string, ...string[]]).describe('concise (one or two lines) or extended (longer riffs)'),
+  djMode: z.boolean().describe('true if this host works the desk like a real radio DJ — back-announces tracks, teases what is coming, more present; false for a quieter selector'),
+  language: z.string().max(60).describe('the language the DJ speaks on air if the description implies a non-English host (e.g. "Turkish", "Punjabi"); "" for English'),
+});
+
+const PERSONA_SYSTEM = `You design on-air radio DJ personalities for a personal internet radio station. Given a free-text description, produce a single coherent DJ persona: a memorable name, a short tagline, and a vivid "soul" (the voice and sensibility they present with). Match the requested vibe, era, and language. Keep the soul specific and human — no corporate filler, no "your number one source for hits". If the description names or implies a non-English host, set language to that language (in English, e.g. "Turkish"); otherwise leave it "".`;
+
+export async function generatePersona(description: string) {
+  return djObject({
+    system: PERSONA_SYSTEM,
+    prompt: `Description of the DJ the operator wants:\n"${description}"\n\nDesign the persona.`,
+    schema: PERSONA_SCHEMA,
+    temperature: 0.8,
+    kind: 'generatePersona',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Show
+// ---------------------------------------------------------------------------
+
+interface ShowCtx {
+  personas?: { id: string; name: string }[];
+  themes?: { id: string; name: string }[];
+  genres?: string[];
+}
+
+const SHOW_SCHEMA = z.object({
+  name: z.string().min(1).max(60).describe('the show name shown in the schedule — punchy, 1-4 words'),
+  topic: z.string().max(1000).describe('the brief the AI DJ reads before the slot: genres, eras, moods, artists, time of day, listener type, host tone. 1-4 sentences, max 1000 chars.'),
+  mood: z.enum(SHOW_MOODS as [string, ...string[]]).describe('the single closest music mood for this show'),
+  genre: z.string().max(64).describe('a music genre lean if one fits (e.g. "jazz", "gospel", "lofi"); "" for no lean. Prefer a genre present in the supplied library list when relevant.'),
+  fromYear: z.number().int().nullable().describe('start year of an era window if the show targets a decade (e.g. 1970), else null'),
+  toYear: z.number().int().nullable().describe('end year of that era window (e.g. 1979), else null'),
+  energy: z.enum(['', ...SHOW_ENERGY] as [string, ...string[]]).describe('soft energy steer: low, medium, high, or "" for any'),
+  personaId: z.string().nullable().describe('the id of the persona that best fits this show, chosen from the supplied persona list, or null if unsure'),
+  themeId: z.string().nullable().describe('the id of a per-show theme override chosen from the supplied theme list, or null for the station default'),
+});
+
+const SHOW_SYSTEM = `You design radio shows for a personal internet radio station. Given a free-text description, produce a single show definition: a name, a DJ brief (topic), a music mood, an optional genre lean and era window, an energy steer, and the best-matching persona and (optional) theme from the supplied lists. Pick personaId / themeId ONLY from the ids given; use null when nothing clearly fits. The mood MUST be one of the listed moods. Keep the topic concrete and useful as a brief — name the kind of music, the moment of day, and the tone.`;
+
+export async function generateShow(description: string, ctx: ShowCtx = {}) {
+  const lines: string[] = [];
+  if (ctx.personas?.length) {
+    lines.push('Available personas (id — name):');
+    for (const p of ctx.personas) lines.push(`  ${p.id} — ${p.name}`);
+  }
+  if (ctx.themes?.length) {
+    lines.push('Available themes (id — name):');
+    for (const t of ctx.themes) lines.push(`  ${t.id} — ${t.name}`);
+  }
+  if (ctx.genres?.length) {
+    lines.push(`Genres present in the library (sample): ${ctx.genres.slice(0, 40).join(', ')}`);
+  }
+  lines.push(`Allowed moods: ${SHOW_MOODS.join(', ')}`);
+
+  return djObject({
+    system: SHOW_SYSTEM,
+    prompt: `Description of the show the operator wants:\n"${description}"\n\n${lines.join('\n')}\n\nDesign the show.`,
+    schema: SHOW_SCHEMA,
+    temperature: 0.7,
+    kind: 'generateShow',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Theme
+// ---------------------------------------------------------------------------
+
+// CSS color value the theme validator (themes.ts TOKEN_VAL_RE) will accept:
+// hex, rgb()/rgba(), or a plain named color. No semicolons/braces/angle
+// brackets, ≤100 chars. We keep the model on hex/rgb to stay safely inside it.
+const COLOR = z.string().regex(/^[^;{}<>]{1,100}$/);
+
+const THEME_SCHEMA = z.object({
+  name: z.string().min(1).max(60).describe('a short human theme name (e.g. "Sepia Press")'),
+  description: z.string().max(200).describe('a one-line blurb describing the look, "" if none'),
+  tokens: z.object({
+    '--bg': COLOR.describe('page background'),
+    '--ink': COLOR.describe('primary text — MUST contrast strongly with --bg for readability'),
+    '--muted': COLOR.describe('secondary/muted text — lower contrast than --ink but still legible on --bg'),
+    '--accent': COLOR.describe('accent / interactive highlight color'),
+    '--overlay': COLOR.describe('subtle wash used for hover/overlay — an rgba() with low alpha works well'),
+    '--soft-border': COLOR.describe('hairline border color, close to --bg'),
+    '--field': COLOR.describe('input/field surface, slightly off from --bg'),
+  }).describe('the 7 CSS custom-property color values for the theme'),
+});
+
+const THEME_SYSTEM = `You are a UI color designer. Given a free-text vibe and a light/dark mode, produce a coherent, accessible color theme as 7 CSS custom properties. Use hex (#rrggbb) or rgb()/rgba() values only — never named colors, gradients, or anything with semicolons or braces. Ensure --ink reads clearly against --bg (strong contrast); --muted is a softer but still legible version; --accent stands out; --overlay is a low-alpha rgba wash; --soft-border and --field sit close to --bg. Respect the requested mode: a dark theme has a dark --bg and light text, a light theme the reverse.`;
+
+export async function generateTheme(description: string, mode: 'light' | 'dark') {
+  return djObject({
+    system: THEME_SYSTEM,
+    prompt: `Requested look: "${description}"\nMode: ${mode}\n\nThe token keys to fill are exactly: ${THEME_TOKEN_KEYS.join(', ')}.\n\nDesign the theme.`,
+    schema: THEME_SCHEMA,
+    temperature: 0.7,
+    kind: 'generateTheme',
+  });
+}

--- a/controller/src/routes/generate.ts
+++ b/controller/src/routes/generate.ts
@@ -1,0 +1,83 @@
+// Admin-gated "describe it → draft it" endpoints. Each takes a free-text
+// description and returns a draft entity (persona / show / theme) for the create
+// forms to pre-fill. Nothing is persisted here — the operator reviews, edits,
+// and saves through the normal /settings (or /themes) path. Generation rides the
+// operator's configured station LLM via the llm/dj generate* wrappers.
+import express from 'express';
+import { requireAdmin } from '../middleware/auth.js';
+import * as dj from '../llm/dj.js';
+import * as settings from '../settings.js';
+import * as library from '../music/library.js';
+import { listThemes } from '../themes.js';
+
+export const router = express.Router();
+
+const DESC_MAX = 400;
+
+function readDescription(req: express.Request): string {
+  return (typeof req.body?.description === 'string' ? req.body.description : '')
+    .trim()
+    .slice(0, DESC_MAX);
+}
+
+// POST /generate/persona — { description } → { ok, persona }
+router.post('/generate/persona', requireAdmin, async (req, res) => {
+  const description = readDescription(req);
+  if (!description) return res.status(400).json({ error: 'description is required' });
+  try {
+    const out = await dj.generatePersona(description);
+    res.json({ ok: true, persona: out.value });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /generate/show — { description } → { ok, show }
+// The route assembles the persona/theme/mood/genre context itself so the client
+// only sends a description.
+router.post('/generate/show', requireAdmin, async (req, res) => {
+  const description = readDescription(req);
+  if (!description) return res.status(400).json({ error: 'description is required' });
+  try {
+    const s = settings.get();
+    const personas = (s.personas || []).map((p: any) => ({ id: p.id, name: p.name }));
+    const themes = (await listThemes()).map(t => ({ id: t.id, name: t.name }));
+    let genres: string[] = [];
+    try {
+      await library.load();
+      genres = Object.keys(library.stats().byGenre || {});
+    } catch {}
+
+    const out = await dj.generateShow(description, { personas, themes, genres });
+    const draft = { ...out.value };
+
+    // Soft-normalise against the real lists — a near-miss from a weaker model
+    // becomes null/default rather than an invalid id the Save would reject.
+    const personaIds = new Set(personas.map(p => p.id));
+    if (!draft.personaId || !personaIds.has(draft.personaId)) {
+      draft.personaId = personas[0]?.id ?? null;
+    }
+    const themeIds = new Set(themes.map(t => t.id));
+    if (!draft.themeId || !themeIds.has(draft.themeId)) draft.themeId = null;
+    if (!settings.SHOW_MOODS.includes(draft.mood)) draft.mood = settings.SHOW_MOODS[0];
+    if (draft.energy && !settings.SHOW_ENERGY.includes(draft.energy)) draft.energy = '';
+
+    res.json({ ok: true, show: draft });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /generate/theme — { description, mode } → { ok, theme }
+// Returns tokens for review; persisting is POST /themes.
+router.post('/generate/theme', requireAdmin, async (req, res) => {
+  const description = readDescription(req);
+  if (!description) return res.status(400).json({ error: 'description is required' });
+  const mode = req.body?.mode === 'light' ? 'light' : 'dark';
+  try {
+    const out = await dj.generateTheme(description, mode);
+    res.json({ ok: true, theme: { ...out.value, mode } });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});

--- a/controller/src/routes/generate.ts
+++ b/controller/src/routes/generate.ts
@@ -26,7 +26,7 @@ router.post('/generate/persona', requireAdmin, async (req, res) => {
   if (!description) return res.status(400).json({ error: 'description is required' });
   try {
     const out = await dj.generatePersona(description);
-    res.json({ ok: true, persona: out.value });
+    res.json({ ok: true, persona: out });
   } catch (err: any) {
     res.status(500).json({ error: err.message });
   }
@@ -49,7 +49,7 @@ router.post('/generate/show', requireAdmin, async (req, res) => {
     } catch {}
 
     const out = await dj.generateShow(description, { personas, themes, genres });
-    const draft = { ...out.value };
+    const draft = { ...out };
 
     // Soft-normalise against the real lists — a near-miss from a weaker model
     // becomes null/default rather than an invalid id the Save would reject.
@@ -76,7 +76,7 @@ router.post('/generate/theme', requireAdmin, async (req, res) => {
   const mode = req.body?.mode === 'light' ? 'light' : 'dark';
   try {
     const out = await dj.generateTheme(description, mode);
-    res.json({ ok: true, theme: { ...out.value, mode } });
+    res.json({ ok: true, theme: { ...out, mode } });
   } catch (err: any) {
     res.status(500).json({ error: err.message });
   }

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -17,7 +17,7 @@ import { invalidateWeatherCache } from '../context.js';
 import { requireAdmin } from '../middleware/auth.js';
 import { tagger } from '../broadcast/tagger.js';
 import { skillCatalog } from '../skills/_agent.js';
-import { clearUserThemeCache, loadUserThemes, listThemes } from '../themes.js';
+import { clearUserThemeCache, loadUserThemes, listThemes, saveUserTheme } from '../themes.js';
 
 export const router = express.Router();
 
@@ -279,5 +279,20 @@ router.post('/themes/refresh', requireAdmin, async (req, res) => {
     res.json({ ok: true, themes });
   } catch (err) {
     res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /themes — create/overwrite a user theme as ${STATE_DIR}/themes/<id>.json.
+// Body: { id?, name, description?, mode, tokens }. The id is derived from the
+// name when absent. Validated by the shared ThemeSchema (token security regex);
+// reserved built-in ids are rejected. Returns the refreshed registry.
+// ---------------------------------------------------------------------------
+router.post('/themes', requireAdmin, async (req, res) => {
+  try {
+    const themes = await saveUserTheme(req.body || {});
+    res.json({ ok: true, themes });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
   }
 });

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -33,6 +33,7 @@ import { router as personasRoutes } from './routes/personas.js';
 import { router as backupRoutes } from './routes/backup.js';
 import { router as audienceRoutes } from './routes/audience.js';
 import { router as systemRoutes } from './routes/system.js';
+import { router as generateRoutes } from './routes/generate.js';
 import { loadSecretsIntoEnv } from './setup/secrets.js';
 import { loadSetupConfig } from './setup/config.js';
 import { getSetupStatus } from './setup/firstRun.js';
@@ -66,6 +67,7 @@ app.use(personasRoutes);
 app.use(backupRoutes);
 app.use(audienceRoutes);
 app.use(systemRoutes);
+app.use(generateRoutes);
 
 // (manual skip is not implemented in this build — Liquidsoap controls pacing)
 

--- a/controller/src/themes.ts
+++ b/controller/src/themes.ts
@@ -206,3 +206,36 @@ export async function isValidThemeId(id: string): Promise<boolean> {
   const all = await listThemes();
   return all.some(t => t.id === id);
 }
+
+// Turn a human name into a valid theme id (lowercase, dash-separated, ≤32
+// chars, leading alphanumeric) so the create form can derive one when the
+// operator doesn't supply it. Falls back to "theme" if nothing survives.
+export function slugifyThemeId(name: string): string {
+  const slug = String(name || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 32)
+    .replace(/-+$/g, '');
+  return /^[a-z0-9]/.test(slug) ? slug : `t-${slug}`.slice(0, 32) || 'theme';
+}
+
+// Persist an operator-created theme as ${STATE_DIR}/themes/<id>.json, the same
+// shape the file-drop convention uses. Validates with the shared ThemeSchema
+// (so the token security regex applies), refuses reserved built-in ids, then
+// refreshes the user cache and returns the full registry.
+export async function saveUserTheme(input: any): Promise<Theme[]> {
+  const id = (typeof input?.id === 'string' && input.id.trim())
+    ? slugifyThemeId(input.id)
+    : slugifyThemeId(input?.name || '');
+  const theme = ThemeSchema.parse({ ...input, id });
+  if (BUILTIN_IDS.has(theme.id)) {
+    throw new Error(`"${theme.id}" is a reserved built-in theme id — pick another name`);
+  }
+  const dir = userThemesDir();
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(join(dir, `${theme.id}.json`), JSON.stringify(theme, null, 2), 'utf8');
+  clearUserThemeCache();
+  await loadUserThemes(true);
+  return listThemes();
+}

--- a/web/components/admin/AiFill.tsx
+++ b/web/components/admin/AiFill.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+// Shared "describe it → draft it" block for the create/edit forms. The operator
+// types what they want, hits Generate, and the parent merges the returned draft
+// into its form fields for review (nothing is saved here). Backed by the
+// admin-gated /generate/* endpoints, which ride the station's configured LLM.
+import { useState } from 'react';
+import { Textarea } from '../ui/textarea';
+import { Btn } from './ui';
+import { errorMessage } from '../../lib/notify';
+
+interface AiFillProps<T> {
+  // e.g. '/generate/persona' — the admin-gated generator endpoint.
+  endpoint: string;
+  // The key the entity is returned under (e.g. 'persona' for { ok, persona }).
+  resultKey: string;
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+  onApply: (value: T) => void;
+  placeholder?: string;
+  // Extra body fields sent alongside { description } (e.g. theme { mode }).
+  extra?: Record<string, unknown>;
+  disabled?: boolean;
+}
+
+export function AiFill<T = unknown>({
+  endpoint,
+  resultKey,
+  adminFetch,
+  onApply,
+  placeholder,
+  extra,
+  disabled,
+}: AiFillProps<T>) {
+  const [desc, setDesc] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const generate = async () => {
+    const description = desc.trim();
+    if (!description || busy) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const r = await adminFetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description, ...(extra || {}) }),
+      });
+      const j = (await r.json().catch(() => ({}))) as Record<string, unknown> & { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      const value = j[resultKey] as T | undefined;
+      if (!value) throw new Error('no draft returned');
+      onApply(value);
+    } catch (e) {
+      setErr(errorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2 border border-soft-border bg-overlay/40 p-3">
+      <span className="field-hint">
+        Describe what you want — we&apos;ll draft the fields, then you can edit before saving.
+      </span>
+      <Textarea
+        rows={2}
+        value={desc}
+        onChange={(e) => setDesc(e.target.value)}
+        maxLength={400}
+        placeholder={placeholder || 'e.g. a late-night jazz host with a dry wit'}
+        disabled={busy || disabled}
+        onKeyDown={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') generate();
+        }}
+      />
+      <div className="flex items-center gap-3">
+        <Btn tone="accent" sm onClick={generate} disabled={busy || disabled || !desc.trim()}>
+          {busy ? 'Generating…' : 'Generate'}
+        </Btn>
+        {err && <span className="text-[12px] text-destructive">{err}</span>}
+      </div>
+    </div>
+  );
+}

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -18,6 +18,7 @@ import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel,
 } from '../ui/select';
 import { Card, Btn, Pill, Eyebrow, Seg, Toggle } from './ui';
+import { AiFill } from './AiFill';
 import { cn } from '../../lib/cn';
 
 const FREQUENCIES = [
@@ -840,6 +841,15 @@ export default function PersonasPanel() {
               </>
             }
           >
+            <div className="mb-4">
+              <AiFill<Partial<Persona>>
+                endpoint="/generate/persona"
+                resultKey="persona"
+                adminFetch={adminFetch}
+                placeholder="e.g. a late-night jazz host with a dry wit"
+                onApply={(p) => setPersona(safeIdx, p)}
+              />
+            </div>
             <div className="stack-mobile grid grid-cols-[96px_1fr] items-start gap-4">
               <PersonaAvatarPicker
                 persona={focused}

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -17,6 +17,7 @@ import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel,
 } from '../ui/select';
 import { Card, Btn, Pill, Eyebrow, Seg, Metric } from './ui';
+import { AiFill } from './AiFill';
 import { cn } from '../../lib/cn';
 import ArchivesPanel from './ArchivesPanel';
 import WebhooksPanel from './WebhooksPanel';
@@ -3143,6 +3144,126 @@ function Swatch({ color }: { color?: string }) {
   return <span ref={ref} className="h-7 w-7" aria-hidden="true" />;
 }
 
+// The 7 themable tokens (mirrors controller THEME_TOKEN_KEYS) with human
+// labels for the create form. Generated drafts and manual edits both fill these.
+const THEME_TOKENS: { key: string; label: string }[] = [
+  { key: '--bg', label: 'background' },
+  { key: '--ink', label: 'text' },
+  { key: '--muted', label: 'muted text' },
+  { key: '--accent', label: 'accent' },
+  { key: '--overlay', label: 'overlay' },
+  { key: '--soft-border', label: 'border' },
+  { key: '--field', label: 'field' },
+];
+
+// Create a custom theme from a description (AI-drafted) or by hand, then save it
+// as state/themes/<id>.json via POST /themes. Tokens are editable before save so
+// the operator reviews the palette first.
+function ThemeCreator({
+  adminFetch,
+  onSaved,
+}: {
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+  onSaved: (themes: ThemeDef[]) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [mode, setMode] = useState<'light' | 'dark'>('dark');
+  const [tokens, setTokens] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const applyDraft = (t: {
+    name?: string;
+    description?: string;
+    mode?: 'light' | 'dark';
+    tokens?: Record<string, string>;
+  }) => {
+    if (t.name && !name.trim()) setName(t.name);
+    if (t.description) setDescription(t.description);
+    if (t.mode) setMode(t.mode);
+    if (t.tokens) setTokens(prev => ({ ...prev, ...t.tokens }));
+  };
+
+  const reset = () => {
+    setName(''); setDescription(''); setTokens({}); setErr(null); setOpen(false);
+  };
+
+  const save = async () => {
+    if (!name.trim() || saving) return;
+    setSaving(true); setErr(null);
+    try {
+      const r = await adminFetch('/themes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: name.trim(), description: description.trim(), mode, tokens }),
+      });
+      const j = (await r.json().catch(() => ({}))) as { error?: string; themes?: ThemeDef[] };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      onSaved(j.themes ?? []);
+      notify.ok(`saved "${name.trim()}"`);
+      reset();
+    } catch (e) {
+      setErr(errorMessage(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <Btn sm tone="accent" onClick={() => setOpen(true)}>Create theme with AI</Btn>
+    );
+  }
+
+  return (
+    <div className="grid gap-3 border border-ink p-3">
+      <AiFill<{ name?: string; description?: string; mode?: 'light' | 'dark'; tokens?: Record<string, string> }>
+        endpoint="/generate/theme"
+        resultKey="theme"
+        adminFetch={adminFetch}
+        placeholder="e.g. a warm sepia newspaper, easy on the eyes"
+        extra={{ mode }}
+        onApply={applyDraft}
+      />
+      <div className="grid grid-cols-[1fr_auto] items-end gap-3">
+        <div className="field">
+          <Label>theme name</Label>
+          <Input value={name} maxLength={60} onChange={(e: ChangeEvent<HTMLInputElement>) => setName(e.target.value)} placeholder="e.g. Sepia Press" />
+        </div>
+        <Seg
+          value={mode}
+          onChange={(v) => setMode(v as 'light' | 'dark')}
+          options={[{ id: 'dark', label: 'Dark' }, { id: 'light', label: 'Light' }]}
+        />
+      </div>
+      <div className="grid gap-1.5">
+        {THEME_TOKENS.map(({ key, label }) => (
+          <div key={key} className="grid grid-cols-[auto_5.5rem_1fr] items-center gap-2">
+            <span className="inline-flex shrink-0 border border-ink"><Swatch color={tokens[key]} /></span>
+            <span className="text-[11px] tracking-[0.12em] text-muted uppercase">{label}</span>
+            <Input
+              value={tokens[key] || ''}
+              maxLength={100}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setTokens(prev => ({ ...prev, [key]: e.target.value }))}
+              placeholder="#000000 or rgba(…)"
+              className="font-mono text-[12px]"
+            />
+          </div>
+        ))}
+      </div>
+      {err && <span className="text-[12px] text-[var(--danger)]">{err}</span>}
+      <div className="flex gap-2">
+        <Btn sm tone="accent" onClick={save} disabled={saving || !name.trim()}>
+          {saving ? 'Saving…' : 'Save theme'}
+        </Btn>
+        <Btn sm onClick={reset} disabled={saving}>Cancel</Btn>
+      </div>
+    </div>
+  );
+}
+
 function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSectionProps) {
   const [themes, setThemes] = useState<ThemeDef[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -3260,16 +3381,17 @@ function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSectionProp
 
       <Card title="Custom themes" sub="state/themes/*.json">
         <div className="grid gap-3">
+          <ThemeCreator adminFetch={adminFetch} onSaved={setThemes} />
           <div>
             <Btn sm onClick={refresh} disabled={refreshing || busy}>
               {refreshing ? 'Refreshing…' : 'Refresh themes'}
             </Btn>
           </div>
           <div className="field-hint">
-            Drop a JSON theme file in <code>state/themes/</code> and click <em>Refresh</em> to
-            add it to the picker — no controller restart needed. The folder
-            includes a <code>README.md</code> with the format and the allowed
-            token keys.
+            Describe a look above and we&apos;ll draft the palette, or drop a JSON
+            theme file in <code>state/themes/</code> and click <em>Refresh</em> —
+            no controller restart needed. The folder includes a
+            <code>README.md</code> with the format and the allowed token keys.
           </div>
         </div>
       </Card>

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -26,6 +26,7 @@ import {
 } from '../ui/select';
 import { Card, Btn, Pill, Eyebrow, Metric } from './ui';
 import { Modal } from '../ui/modal';
+import { AiFill } from './AiFill';
 import { cn } from '../../lib/cn';
 
 const NAME_MAX = 60;
@@ -757,6 +758,17 @@ export default function ShowsPanel() {
       >
         {draft && (
           <div className="grid gap-3.5">
+            <AiFill<Partial<Omit<Show, 'personaId' | 'themeId'>> & { personaId?: string | null; themeId?: string | null }>
+              endpoint="/generate/show"
+              resultKey="show"
+              adminFetch={adminFetch}
+              placeholder="e.g. a Sunday-morning gospel hour, warm and uplifting"
+              onApply={(s) => setDraftField({
+                ...s,
+                personaId: s.personaId ?? draft.personaId ?? '',
+                themeId: s.themeId ?? '',
+              })}
+            />
             <Field>
               <Label htmlFor="show-name">show name</Label>
               <Input


### PR DESCRIPTION
## What

Adds a free-text **"describe it → auto-fill"** box to the persona, show, and theme create/edit forms. The operator describes what they want (e.g. *"a late-night jazz host with a dry wit"*), hits **Generate**, and the LLM drafts the field values **for review** — nothing auto-saves. Brings the "go to ChatGPT for ideas, paste back in" loop in-house.

Runs on the operator's **configured station LLM** (existing `djObject` structured-output path) — no new API keys, works offline with Ollama.

## Scope

| Entity | Status |
|---|---|
| Personas | ✅ fills name, tagline, soul, frequency, scriptLength, djMode, language |
| Shows | ✅ fills name, topic, mood, genre, era, energy + suggests persona/theme |
| Themes | ✅ generates light/dark color tokens — **gains a new create form** (was file-drop only) |
| Schedule/timings | ⛔ intentionally out of scope |

## Server (controller)

- **`llm/internal/prompts/generate.ts`** (new) — `generatePersona` / `generateShow` / `generateTheme` `djObject` wrappers. Zod schemas constrained to the **same enums the settings/theme validators enforce** (`FREQUENCIES`, `SCRIPT_LENGTHS`, `SHOW_MOODS`, `SHOW_ENERGY`, `THEME_TOKEN_KEYS`) so drafts round-trip cleanly through Save. Exported via the `llm/dj.ts` barrel.
- **`routes/generate.ts`** (new) — admin-gated `POST /generate/{persona,show,theme}`. The show route assembles persona/theme/mood/genre context itself and soft-normalises out-of-list ids/moods to safe defaults. Mounted in `server.ts`.
- **`themes.ts`** — `saveUserTheme()` + `slugifyThemeId()`: validates with the existing `ThemeSchema` (reuses the token security regex), rejects reserved built-in ids, writes `state/themes/<id>.json`, refreshes cache. Exposed via new **`POST /themes`** in `routes/settings.ts` (themes had no write path before).

## Web (admin)

- **`AiFill.tsx`** (new) — shared describe→generate block (textarea + Generate, ⌘/Ctrl+Enter, inline busy/error). Wired into **PersonasPanel**, **ShowsPanel**, and a new **`ThemeCreator`** in SettingsPanel with editable tokens + live swatches.

## Testing

Not yet manually tested — `eslint` + `tsc --noEmit` pass clean for all changed files. End-to-end smoke (dev stack + configured LLM) to follow:
- Persona / Show / Theme: describe → Generate → fields populate → Save persists.
- `/generate/*` and `POST /themes` return 401 without admin auth.
- LLM-down path surfaces an inline error, form stays editable.

https://claude.ai/code/session_01EFWKUTfQ3p7pzhvDs7Ufyp