### PR TITLE
feat(app): Google Cast support for Chromecast / Nest speakers (Phase 0 spike)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -26,7 +26,8 @@
         "NSAppTransportSecurity": {
           "NSAllowsArbitraryLoads": true,
           "NSAllowsLocalNetworking": true
-        }
+        },
+        "NSLocalNetworkUsageDescription": "SUB/WAVE uses your local network to find Chromecast and Google Home speakers to cast to."
       }
     },
     "android": {
@@ -76,6 +77,14 @@
         "./plugins/withGradleVersion",
         {
           "version": "8.14.3"
+        }
+      ],
+      [
+        "react-native-google-cast",
+        {
+          "receiverAppId": "CC1AD845",
+          "iosDisableDiscoveryAutostart": true,
+          "androidPlayServicesCastFrameworkVersion": "21.+"
         }
       ]
     ],

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -36,6 +36,7 @@
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-native-gesture-handler": "~2.31.1",
+        "react-native-google-cast": "^4.9.1",
         "react-native-image-colors": "^2.6.0",
         "react-native-reanimated": "4.3.1",
         "react-native-safe-area-context": "~5.7.0",
@@ -8298,6 +8299,16 @@
         "hoist-non-react-statics": "^3.3.0",
         "invariant": "^2.2.4"
       },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-google-cast": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/react-native-google-cast/-/react-native-google-cast-4.9.1.tgz",
+      "integrity": "sha512-/HvIKAaWHtG6aTNCxrNrqA2ftWGkfH0M/2iN+28pdGUXpKmueb33mgL1m8D4zzwEODQMcmpfoCsym1IwDvugBQ==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/app/package.json
+++ b/app/package.json
@@ -30,6 +30,7 @@
     "react": "19.2.3",
     "react-native": "0.85.3",
     "react-native-gesture-handler": "~2.31.1",
+    "react-native-google-cast": "^4.9.1",
     "react-native-image-colors": "^2.6.0",
     "react-native-reanimated": "4.3.1",
     "react-native-safe-area-context": "~5.7.0",

--- a/app/src/cast/useCast.ts
+++ b/app/src/cast/useCast.ts
@@ -1,0 +1,94 @@
+// Google Cast controller — a thin wrapper over react-native-google-cast's hooks.
+//
+// Why this exists: SUB/WAVE streams plain MP3, and Google Home / Nest are
+// Cast-for-Audio receivers, so casting is just "hand the receiver the
+// /stream.mp3 URL + now-playing metadata and let it pull the stream itself."
+// The phone becomes a remote the listener can walk away from (unlike Bluetooth,
+// which tethers the phone and hijacks all of its audio).
+//
+// The native `CastButton` (see TopBar) owns the device-picker UI and the whole
+// session lifecycle. This hook only surfaces session state and the two actions
+// the app drives imperatively: load the live stream onto a freshly-connected
+// receiver, and end the session. The Cast context itself is initialised
+// natively by the Expo config plugin (receiverAppId in app.json) — there is no
+// JS provider to mount.
+//
+// SPIKE NOTE: this is the Phase-0 validation surface. Local⇄cast playback
+// arbitration (pausing RNTP while casting) lands in Phase 1 via usePlayer.
+
+import { useCallback } from 'react';
+import CastContext, {
+  MediaStreamType,
+  useCastDevice,
+  useCastSession,
+  useRemoteMediaClient,
+} from 'react-native-google-cast';
+
+export interface CastMeta {
+  title?: string;
+  artist?: string;
+  album?: string;
+  artwork?: string;
+}
+
+export interface CastController {
+  /** True while a Cast session is connected to a receiver. */
+  casting: boolean;
+  /** True once the receiver's media client is ready to accept loadMedia(). */
+  ready: boolean;
+  /** Friendly name of the connected device (e.g. "Kitchen speaker"), or null. */
+  deviceName: string | null;
+  /** Hand the receiver the live MP3 URL + now-playing metadata. */
+  castLoad: (streamUrl: string, meta?: CastMeta) => void;
+  /** End the Cast session (stops playback on the receiver). */
+  castStop: () => void;
+}
+
+export function useCast(): CastController {
+  const session = useCastSession();
+  const device = useCastDevice();
+  // null until a session is connected and the receiver's media channel is live.
+  const client = useRemoteMediaClient();
+
+  const castLoad = useCallback(
+    (streamUrl: string, meta?: CastMeta) => {
+      if (!client) return;
+      client
+        .loadMedia({
+          autoplay: true,
+          mediaInfo: {
+            contentUrl: streamUrl,
+            contentType: 'audio/mpeg',
+            // LIVE → the receiver hides the seek bar (mirrors isLiveStream on
+            // the RNTP side); there's no scrubbing a continuous broadcast.
+            streamType: MediaStreamType.LIVE,
+            metadata: {
+              type: 'musicTrack',
+              title: meta?.title || 'SUB/WAVE',
+              artist: meta?.artist,
+              albumTitle: meta?.album,
+              images: meta?.artwork ? [{ url: meta.artwork }] : undefined,
+            },
+          },
+        })
+        .catch(() => {});
+    },
+    [client],
+  );
+
+  const castStop = useCallback(() => {
+    // endCurrentSession(stopCasting=true) stops receiver playback as it
+    // disconnects, rather than leaving the speaker playing orphaned.
+    CastContext.getSessionManager()
+      .endCurrentSession(true)
+      .catch(() => {});
+  }, []);
+
+  return {
+    casting: !!session,
+    ready: !!client,
+    deviceName: device?.friendlyName ?? null,
+    castLoad,
+    castStop,
+  };
+}

--- a/app/src/player/PlayerScreen.tsx
+++ b/app/src/player/PlayerScreen.tsx
@@ -28,6 +28,7 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { type CastMeta, useCast } from '@/cast/useCast';
 import { Sheet } from '@/components/ui/Sheet';
 import { useStation } from '@/config/StationContext';
 import { useConnectivity } from '@/hooks/useConnectivity';
@@ -212,6 +213,33 @@ export default function PlayerScreen() {
   useEffect(() => {
     if (offline && tunedIn) stop();
   }, [offline, tunedIn, stop]);
+
+  // --- Google Cast (Phase-0 spike) ---------------------------------------
+  // SUB/WAVE streams plain MP3 and Google Home / Nest are Cast-for-Audio
+  // receivers, so casting is just handing the receiver the /stream.mp3 URL and
+  // letting it pull the stream itself — the phone becomes a remote you can walk
+  // away from. The native CastButton (TopBar) owns the picker + session; here we
+  // load the live stream once the receiver's media client is ready. Metadata is
+  // a best-effort snapshot at connect time; live metadata sync is Phase 1.
+  const { casting, ready: castReady, castLoad } = useCast();
+  const castMetaRef = useRef<CastMeta>({});
+  castMetaRef.current = {
+    title: nowPlaying?.title,
+    artist: nowPlaying?.artist,
+    album: nowPlaying?.album,
+    artwork: coverSrc ?? undefined,
+  };
+  useEffect(() => {
+    if (!castReady || !api) return;
+    castLoad(api.streamUrl(), castMetaRef.current);
+  }, [castReady, castLoad, api]);
+
+  // Spike-only: avoid double audio (phone + speaker) by stopping local playback
+  // once a Cast session is live. Proper local⇄cast arbitration (and resuming
+  // local on session end) lands in Phase 1 inside usePlayer.
+  useEffect(() => {
+    if (casting && tunedIn) stop();
+  }, [casting, tunedIn, stop]);
 
   // --- swipe pager -------------------------------------------------------
   // Animated.ScrollView forwards its ref to the inner ScrollView (RN ≥0.62),

--- a/app/src/player/TopBar.tsx
+++ b/app/src/player/TopBar.tsx
@@ -7,6 +7,7 @@ import { router } from 'expo-router';
 import { Palette } from 'lucide-react-native';
 import { useMemo } from 'react';
 import { Pressable, Text, View } from 'react-native';
+import { CastButton } from 'react-native-google-cast';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import DiscMark from '@/components/DiscMark';
 import { buildTagline } from '@/lib/tagline';
@@ -68,6 +69,11 @@ export default function TopBar({
           ) : null}
         </Pressable>
         <View className="flex-row items-center" style={{ gap: 18, paddingLeft: 12 }}>
+          {/* Native Cast button — opens the device picker and owns the whole
+              session lifecycle itself. Auto-hides on Android when no receivers
+              are on the network; stays visible on iOS. The stream load on
+              connect is driven from PlayerScreen (useCast). */}
+          <CastButton style={{ width: 22, height: 22, tintColor: colors.muted }} />
           <Pressable onPress={onOpenThemes} hitSlop={10} accessibilityRole="button" accessibilityLabel="Theme">
             <Palette size={18} color={colors.muted} />
           </Pressable>


### PR DESCRIPTION
## What & why

Adds **Google Cast** to the app so listeners can send the broadcast straight to a Chromecast / Google Home / Nest speaker — the speaker pulls the stream itself and the phone becomes a remote you can walk away from. Requested by a listener (Discord → #494): on iPhone the only option today is Bluetooth, which tethers the phone to the speaker and hijacks *all* phone audio (an Instagram clip routes to the Nest too). Casting fixes exactly that.

This is a natural fit because SUB/WAVE already serves a plain HTTP MP3 (`api.streamUrl()` → `…/stream.mp3`), and Google Home / Nest are Cast-for-Audio receivers — so we just hand the Default Media Receiver the URL + now-playing metadata. **No controller / Liquidsoap / backend change.**

> **Scope: Phase 0 spike.** The app is on a bleeding edge (RN 0.85.3, Expo SDK 56, New Architecture mandatory) and the iOS Cast SDK has a `use_frameworks!` history that can collide with Skia/Reanimated. This PR proves the integration *builds and casts at all* before investing in polished UX. Full local⇄cast arbitration, live metadata sync, styled button + device-name chip are **Phase 1**.

## Changes (all in `app/`)

- **`package.json`** — add `react-native-google-cast@^4.9.1` (peer deps are wildcard, no React 19 / RN 0.85 conflict).
- **`app.json`** — bundled Expo config plugin: `receiverAppId: CC1AD845` (Default Media Receiver, zero registration), `iosDisableDiscoveryAutostart` so the Local Network prompt only fires on first Cast tap, + a friendly `NSLocalNetworkUsageDescription`.
- **`src/cast/useCast.ts`** *(new)* — thin controller over the library hooks: `{ casting, ready, deviceName, castLoad, castStop }`. Loads the live MP3 with `streamType: LIVE` + `musicTrack` metadata; ends the session on stop.
- **`src/player/TopBar.tsx`** — native `<CastButton>` in the masthead accessory row (next to the theme icon).
- **`src/player/PlayerScreen.tsx`** — loads the stream onto the receiver when a session connects; stops local RNTP while casting to avoid double audio (spike-only guard; proper arbitration is Phase 1).

## Validated (no device needed)

- ✅ `tsc --noEmit` clean.
- ✅ eslint clean on changed files.
- ✅ `expo config --type introspect` confirms the plugin injects the right native config: iOS `_googlecast._tcp` / `_CC1AD845._googlecast._tcp` Bonjour services + the Local Network string; Android `GoogleCastOptionsProvider`. Existing `postinstall: patch-package` (the track-player new-arch patch) is intact.

## Remaining spike gate (needs a real device + EAS build)

Cast discovery does **not** work in the simulator, so the actual pass criteria are device-only:

```bash
cd app && eas build --profile development-device --platform ios   # and --platform android
```

Watch the two known kill-switches: **iOS CocoaPods `use_frameworks!`** colliding with Skia/Reanimated, and the native **`CastButton` rendering under Fabric**. If either blocks, that's the decision point (pin SDK version / adjust linkage / Android-first).

## Test plan

- [ ] EAS `development-device` build succeeds on **iOS** and **Android**.
- [ ] Cast button discovers a real Nest/Chromecast and the live stream plays through it.
- [ ] **Walk-away test**: while casting, lock the phone / open another app / play Instagram audio → SUB/WAVE keeps playing on the Nest and the other audio stays on the *phone*.
- [ ] Ending the Cast session leaves local playback in a sane state (re-tap to resume).
- [ ] Receiver shows a now-playing card (metadata snapshot at connect; live sync is Phase 1).

Refs #494 (covers the Google Cast half; Alexa is a separate cloud "skill" workstream and is intentionally out of scope here).
