### PR TITLE
fix(tagger): hide chat-only providers from the embedding picker (#493)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "SUB/WAVE",
     "slug": "subwave",
     "scheme": "subwave",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/controller/scripts/embedding-preflight-test.ts
+++ b/controller/scripts/embedding-preflight-test.ts
@@ -96,8 +96,19 @@ for (const msg of [
   ok('message points at the fix', /--embeddings|pooling|embedding model/i.test(r.message));
 }
 
-// ---- 3. library-db dim handling (#2) --------------------------------------
-console.log('\n[3] library-db honours the stored dim');
+// ---- 3. chat-only provider → no_embeddings (#493) -------------------------
+// openrouter / deepseek / gateway have no embeddings endpoint; buildEmbeddingModel
+// throws synchronously (no network), so this is classified offline.
+console.log('\n[3] a chat-only provider is classified no_embeddings (offline)');
+for (const provider of ['openrouter', 'deepseek', 'gateway']) {
+  S.embedding = { enabled: true, provider, model: '', apiKey: '', baseUrl: '', ollamaUrl: '' };
+  const r = await embeddings.ensureReady();
+  ok(`${provider} → no_embeddings`, r.code === 'no_embeddings', `code=${r.code}`);
+  ok(`${provider} message names the real fix`, /chat-only|embedding-capable|Ollama/i.test(r.message));
+}
+
+// ---- 4. library-db dim handling (#2) --------------------------------------
+console.log('\n[4] library-db honours the stored dim');
 // Seed a 768-d DB the way the tagger would.
 await db.open({ embeddingDim: 768, reseed: false });
 db.setEmbeddingMeta('ollama:nomic-embed-text', 768);

--- a/controller/src/llm/internal/provider/embedding.ts
+++ b/controller/src/llm/internal/provider/embedding.ts
@@ -144,11 +144,22 @@ export function buildEmbeddingModel(cfg: EmbeddingCfg) {
       const provider = createGoogleGenerativeAI(cfg.apiKey ? { apiKey: cfg.apiKey } : {});
       return provider.textEmbeddingModel(id);
     }
-    case 'ollama':
-    default: {
+    case 'ollama': {
       const provider = createOllama({ baseURL: ollamaBaseUrl(cfg as any) });
       return provider.textEmbeddingModel(id);
     }
+    default:
+      // openrouter / deepseek / gateway (and any future chat-only provider) have
+      // no embeddings endpoint. Previously these fell through to the ollama
+      // branch, silently pointed at a local Ollama, and failed with a misleading
+      // "can't reach <provider>" (#493). Throw an honest error so the probe +
+      // tagger preflight name the real problem. The picker already hides these
+      // (settings.EMBEDDING_PROVIDERS) — this guards the API/JSON path.
+      throw new Error(
+        `Provider "${cfg.provider}" has no text-embedding support. Pick an ` +
+          `embedding-capable provider in Settings → Library tagger → Embedding ` +
+          `(ollama, openai, google, locca, or openai-compatible).`,
+      );
   }
 }
 

--- a/controller/src/music/embeddings.ts
+++ b/controller/src/music/embeddings.ts
@@ -110,6 +110,7 @@ export type ProbeCode =
   | 'unauthorized'        // 401 — typically cloud-routed Ollama or wrong API key
   | 'unreachable'         // connection refused / DNS / timeout
   | 'not_embedding_model' // server reached, but it's a chat model / no pooling (#319)
+  | 'no_embeddings'       // provider is chat-only — no embeddings endpoint at all (#493)
   | 'bad_url'             // baseUrl missing/malformed — fetch can't parse the URL
   | 'unknown';            // anything else — message has the raw error
 
@@ -125,6 +126,12 @@ function classifyEmbeddingError(err: any): { code: ProbeCode; raw: string } {
   const raw = err?.message || String(err);
   const status = err?.cause?.status_code ?? err?.statusCode ?? err?.status;
   const txt = raw.toLowerCase();
+  // buildEmbeddingModel throws this for chat-only providers (openrouter /
+  // deepseek / gateway) that have no embeddings endpoint at all (#493). Check
+  // before the network-shaped codes — it's a config error, not a reachability one.
+  if (txt.includes('has no text-embedding support')) {
+    return { code: 'no_embeddings', raw };
+  }
   if (status === 404 || txt.includes('not found') || txt.includes('try pulling')) {
     return { code: 'not_found', raw };
   }
@@ -207,6 +214,15 @@ function actionableMessage(
         );
       }
       return `Can't reach provider "${provider}" — check network / baseUrl. (${raw})`;
+    case 'no_embeddings':
+      return (
+        `Provider "${provider}" is chat-only — it has no embeddings endpoint, so the\n` +
+        `  library tagger can't use it. (The DJ still works on "${provider}".)\n` +
+        `  Pick an embedding-capable provider in /admin/settings → Embedding:\n` +
+        `    • Ollama   — local + free (ollama pull nomic-embed-text; auto-pulled)\n` +
+        `    • OpenAI / Google — cloud (needs the matching API key)\n` +
+        `    • locca / openai-compatible — your own embedding server`
+      );
     case 'not_embedding_model':
       if (provider === 'openai-compatible' || provider === 'locca') {
         const startCmd =

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -104,6 +104,12 @@ router.get('/settings', requireAdmin, async (req, res) => {
         providers: settings.LLM_PROVIDERS,
         active: llmProvider.activeModelLabel(),
       },
+      embedding: {
+        // Embedding-capable providers only — a strict subset of llm.providers.
+        // The picker maps over this so chat-only providers (openrouter, deepseek,
+        // gateway) can't be chosen as an embedding source (#493).
+        providers: settings.EMBEDDING_PROVIDERS,
+      },
       search: {
         providers: settings.SEARCH_PROVIDERS,
       },

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -133,6 +133,23 @@ export const LLM_PROVIDERS = [
   'gateway',
 ];
 
+// Subset of LLM_PROVIDERS that can actually produce text embeddings — the
+// library tagger embeds every track (music/embeddings.ts), and several chat
+// providers route chat ONLY: openrouter, deepseek and the Vercel AI gateway
+// have no embeddings endpoint. Offering them in the embedding-provider picker
+// silently fell through to a local Ollama and failed with a misleading
+// "can't reach <provider>" error (#493). `anthropic` stays in — it has no
+// first-party embedding model, but llm/internal/provider/embedding.ts routes it
+// to OpenAI (needs OPENAI_API_KEY), as the picker hint already explains.
+export const EMBEDDING_PROVIDERS = [
+  'ollama',
+  'openai-compatible',
+  'locca',
+  'anthropic',
+  'openai',
+  'google',
+];
+
 // Coerce a stored Ollama context-window value. 0 disables (use Ollama's own
 // default); any other number is clamped to a sane [2048, 131072] band and
 // floored to an integer. Non-numeric/NaN falls back to `def`. Shared by the

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -294,6 +294,9 @@ interface SettingsData {
     providers?: string[];
     active?: string;
   };
+  embedding?: {
+    providers?: string[];
+  };
   search?: {
     providers?: string[];
   };
@@ -2353,9 +2356,20 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
   const effectiveProvider = e.provider || llmProvider;
   const embedSuggestions = EMBED_MODEL_SUGGESTIONS[effectiveProvider] ?? [];
 
-  // Provider list comes from /settings.llm.providers (the canonical LLM list).
-  // Anthropic has no first-party embedding API — flagged in the hint.
-  const providers = data.llm?.providers || ['ollama'];
+  // Provider list is the embedding-capable subset (/settings.embedding.providers),
+  // NOT the full LLM list — chat-only providers (openrouter, deepseek, gateway)
+  // have no embeddings endpoint and can't be picked here (#493). Anthropic stays
+  // in; it routes to OpenAI, flagged in the hint.
+  const embedProviders = data.embedding?.providers ||
+    ['ollama', 'openai-compatible', 'locca', 'anthropic', 'openai', 'google'];
+  // Keep a stale explicit choice (a chat-only provider saved before this list
+  // shrank) visible so the Select isn't blank and the warning below makes sense.
+  const providers = e.provider && !embedProviders.includes(e.provider)
+    ? [e.provider, ...embedProviders]
+    : embedProviders;
+  // The effective provider can't embed when "Follow LLM provider" resolves to a
+  // chat-only LLM, or a stale config still names one. Drives the warning below.
+  const canEmbed = embedProviders.includes(effectiveProvider);
 
   // --- Guided setup: probe the endpoint up front, detect a locca embed server,
   // and kick the tagger from here, instead of failing mid-run (#405 follow-up).
@@ -2533,6 +2547,31 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
               pick OpenAI here (needs <code>OPENAI_API_KEY</code>).
               {' '}Effective: <code>{llmProviderLabel(effectiveProvider)}</code>.
             </div>
+
+            {!canEmbed && (
+              <div
+                role="alert"
+                className="mt-2 max-w-[480px] border border-l-[3px] border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger)_7%,transparent)] p-3"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-[13px] leading-none text-[var(--danger)]">⚠</span>
+                  <span className="text-[11px] font-bold tracking-[0.14em] text-[var(--danger)] uppercase">
+                    {llmProviderLabel(effectiveProvider)} can’t make embeddings
+                  </span>
+                </div>
+                <p className="mt-2 text-[11px] leading-[1.55] text-muted">
+                  {e.provider ? (
+                    <><code>{llmProviderLabel(effectiveProvider)}</code> is a chat-only provider — it has no embeddings endpoint, so the tagger can’t use it.</>
+                  ) : (
+                    <>“Follow LLM provider” resolves to <code>{llmProviderLabel(llmProvider)}</code>, which is chat-only and has no embeddings endpoint.</>
+                  )}{' '}
+                  Pick a real embedding provider above — <strong>Ollama</strong> is local
+                  and free (<code>nomic-embed-text</code>, auto-pulled on first run), or
+                  use OpenAI / Google / locca. Your DJ stays on{' '}
+                  <code>{llmProviderLabel(llmProvider)}</code>.
+                </p>
+              </div>
+            )}
           </div>
 
           <div className="field">

--- a/web/components/manual/ModelsAndTokens.tsx
+++ b/web/components/manual/ModelsAndTokens.tsx
@@ -198,6 +198,15 @@ export default function ModelsAndTokens() {
             point embeddings at Ollama or OpenAI instead.
           </li>
           <li>
+            <strong>Some providers do chat only</strong> — OpenRouter, DeepSeek and the
+            Vercel AI gateway have no embeddings endpoint at all. A DJ on one of those works
+            fine, but the tagger can't follow it, so the console only lists{' '}
+            <em>embedding-capable</em> providers in the tagger dropdown (Ollama, OpenAI,
+            Google, locca, OpenAI-compatible). If you don't see your chat provider there,
+            that's why — pick Ollama (local and free) for the embedding step and leave the
+            DJ where it is.
+          </li>
+          <li>
             <strong>locca and OpenAI-compatible need a dedicated embedding server</strong> —
             one llama.cpp process can't serve chat and embeddings at once. With locca that's
             a second command, <code>locca embed</code>, on its own port; the console can


### PR DESCRIPTION
Fixes #493.

## Problem

OpenRouter (and DeepSeek, and the Vercel AI gateway) have **no embeddings endpoint** — they route chat only. But the embedding-provider dropdown in **Admin → Library tagger** reused the full `LLM_PROVIDERS` list, so those chat-only providers were selectable as an embedding source. Picking one — or leaving "Follow LLM provider" while the DJ runs on one — silently fell through to a local Ollama client in `buildEmbeddingModel` and failed the bulk-tagger preflight with a misleading `Can't reach provider "openrouter" … fetch failed`. That's exactly the symptom in #493: the DJ works (chat), but bulk tagging dies in the embedding preflight.

## Changes

1. **Filter the picker.** New `EMBEDDING_PROVIDERS` subset in `settings.ts` (ollama, openai-compatible, locca, anthropic, openai, google), exposed on `GET /settings` as `embedding.providers`. The panel maps the dropdown over that subset, so openrouter/deepseek/gateway can no longer be chosen for embeddings. A stale explicit choice stays visible so the Select never goes blank.
2. **Warn on the "Follow LLM provider" trap.** When the effective embedding provider can't embed (including "follow" resolving to a chat-only DJ provider), an inline alert explains it and points at Ollama/OpenAI/Google/locca, noting the DJ stays on its current provider.
3. **Honest backend error.** `buildEmbeddingModel` now throws for chat-only providers instead of silently building an Ollama client; classified as a new `no_embeddings` probe code with an actionable message. Guards the API/JSON path even if the UI is bypassed.
4. **Docs.** `manual/llm` gains a bullet explaining that some providers are chat-only and won't appear in the tagger dropdown.

`anthropic` stays in the list — it has no first-party embedding model but `llm/internal/provider/embedding.ts` routes it to OpenAI, as the picker hint already explains.

## Testing

- `controller`: `npm run lint` (eslint + tsc) — 0 errors.
- `web`: `npm run lint` (eslint + tsc) — clean.
- `controller`: `npm run test:embed` — 19/19 pass, including 3 new offline cases asserting openrouter/deepseek/gateway classify as `no_embeddings`.
