### PR TITLE
fix(onboarding): redirect unconfigured player to wizard, Punjab default + coords, drop jingles

### DIFF
--- a/controller/src/config.ts
+++ b/controller/src/config.ts
@@ -193,10 +193,10 @@ export const config = {
     recentPlaysMax: 300,
   },
   weather: {
-    // Wolverhampton — your home location
-    lat: 52.5862,
-    lng: -2.1288,
-    locationName: 'Wolverhampton',
+    // Punjab (Chandigarh) — your home location
+    lat: 30.7333,
+    lng: 76.7794,
+    locationName: 'Punjab',
     // 'metric' → Celsius, 'imperial' → Fahrenheit. Drives Open-Meteo's
     // temperature_unit query param and what unit the DJ announces on air.
     units: 'metric' as 'metric' | 'imperial',

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -453,7 +453,7 @@ const DEFAULTS = {
   // 44.1→48k resample, so operators opt in rather than pay that CPU unasked.
   // The mandatory /stream.mp3 mount always serves everyone.
   stream: { opusEnabled: false },
-  weather: { lat: 52.5862, lng: -2.1288, locationName: 'Wolverhampton', units: 'metric' as 'metric' | 'imperial' },
+  weather: { lat: 30.7333, lng: 76.7794, locationName: 'Punjab', units: 'metric' as 'metric' | 'imperial' },
   // Operator-facing station name. Substituted into the DJ prompt's {station}
   // placeholder and returned by GET /dj for the landing page. The product is
   // still called SUB/WAVE — this is what the operator's station running on it

--- a/web/components/PlayerApp.tsx
+++ b/web/components/PlayerApp.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { AnimatePresence } from 'motion/react';
 import { toast } from 'sonner';
 import { CalendarClock, History, Mic } from 'lucide-react';
@@ -47,10 +48,28 @@ export interface PlayerAppProps {
 }
 
 export default function PlayerApp({ contained = false }: PlayerAppProps) {
+  const router = useRouter();
   const { apiUrl } = useStationOrigin();
   const { nowPlaying, context, dj, activeShow, listeners, streamOnline, llmTokens, state, session, trackStartedAt, timezone, locale } = useStationFeed();
   const boothFeed = session.messages;
   const { audioRef, tunedIn, status, volume, setVolume, tune, toggleMute, muted, idleStopped } = usePlayer();
+
+  // First-run redirect — if this install hasn't been configured yet (no
+  // Navidrome creds), bounce the operator into the wizard instead of dropping
+  // them on a silent player. Mirrors AdminShell. Only for the full-page player:
+  // `contained` instances embedded in showcases must never redirect, and the
+  // check hits the same-origin controller (/api), not the multi-station origin —
+  // needsSetup is about *this* install, not a remote station.
+  useEffect(() => {
+    if (contained) return;
+    const API = (process.env.NEXT_PUBLIC_API_URL as string | undefined) || '/api';
+    fetch(`${API}/onboarding/status`)
+      .then(r => (r.ok ? r.json() : null))
+      .then((j: { needsSetup?: boolean } | null) => {
+        if (j?.needsSetup) router.push('/onboarding');
+      })
+      .catch(() => {});
+  }, [contained, router]);
 
   // streamOnline is null until the first poll resolves — only treat an
   // explicit false as offline so the player never flashes "offline" on load.

--- a/web/components/onboarding/WizardShell.tsx
+++ b/web/components/onboarding/WizardShell.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import SignInForm from '@/components/admin/SignInForm';
 import { useWizard, STEP_ORDER, STEP_LABELS } from './useWizard';
-import { DjStep, JinglesStep, LlmStep, NavidromeStep, ReviewStep, TtsStep } from './steps';
+import { DjStep, LlmStep, NavidromeStep, ReviewStep, TtsStep } from './steps';
 
 // Outer chrome for the first-run wizard. Sign-in gate (admin creds from .env),
 // step indicator, body, and back/next buttons. The Review step calls `onDone`
@@ -63,7 +63,6 @@ export default function WizardShell() {
     w.step === 'llm' ? <LlmStep w={w} /> :
     w.step === 'tts' ? <TtsStep w={w} /> :
     w.step === 'dj' ? <DjStep w={w} /> :
-    w.step === 'jingles' ? <JinglesStep w={w} /> :
     <ReviewStep w={w} onDone={() => setDone(true)} />;
 
   return (

--- a/web/components/onboarding/steps.tsx
+++ b/web/components/onboarding/steps.tsx
@@ -126,7 +126,7 @@ export function NavidromeStep({ w }: { w: WizardController }) {
           </button>
           <TestPill result={w.data.navidromeTest} />
         </div>
-        <div className="rounded-md border border-amber-400/40 bg-amber-400/10 px-3 py-2 text-xs text-amber-200">
+        <div className="rounded-md border border-amber-400/40 bg-amber-400/10 px-3 py-2 text-xs text-ink/80">
           <strong>Music licensing:</strong> owning these files covers your own
           private listening, not <em>public</em> broadcast. If anyone but you
           can hear the stream, you&apos;re publicly performing copyrighted works
@@ -430,54 +430,23 @@ export function DjStep({ w }: { w: WizardController }) {
             onChange={e => w.patch(d => ({ dj: { ...d.dj, locationName: e.target.value } }))}
           />
         </Field>
-      </div>
-    </div>
-  );
-}
-
-// ─── JINGLES ──────────────────────────────────────────────────────────────
-export function JinglesStep({ w }: { w: WizardController }) {
-  const [busy, setBusy] = useState(false);
-  const [result, setResult] = useState<{ ok: boolean; msg: string } | null>(null);
-  const onGenerate = async () => {
-    setBusy(true);
-    setResult(null);
-    const r = await w.generateJingles();
-    setResult({
-      ok: r.ok,
-      msg: r.ok
-        ? `Rendered ${r.created || 0} new jingle${(r.created || 0) === 1 ? '' : 's'} (${r.total || 0} total).`
-        : r.error || 'failed',
-    });
-    setBusy(false);
-  };
-  return (
-    <div>
-      <StepHeader
-        title="Generate station idents"
-        blurb='5 default jingles, rendered with your chosen TTS engine. Plays between tracks. You can re-run this later in the admin Jingles panel.'
-      />
-      <button
-        type="button"
-        onClick={onGenerate}
-        disabled={busy}
-        className="rounded border border-ink bg-ink px-4 py-2 text-sm font-medium tracking-wide text-bg uppercase hover:opacity-90 disabled:opacity-40"
-      >
-        {busy ? 'Rendering…' : 'Generate now'}
-      </button>
-      <p className="mt-3 text-xs text-ink/60">
-        Or click <strong>Next</strong> to skip — jingles aren&apos;t required for the station to broadcast.
-      </p>
-      {result && (
-        <div
-          className={
-            'mt-3 rounded px-3 py-2 text-sm ' +
-            (result.ok ? 'bg-green-100 text-green-900' : 'bg-red-100 text-red-900')
-          }
-        >
-          {result.msg}
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Latitude" hint="-90 to 90">
+            <TextInput
+              inputMode="decimal"
+              value={w.data.dj.lat}
+              onChange={e => w.patch(d => ({ dj: { ...d.dj, lat: e.target.value } }))}
+            />
+          </Field>
+          <Field label="Longitude" hint="-180 to 180">
+            <TextInput
+              inputMode="decimal"
+              value={w.data.dj.lng}
+              onChange={e => w.patch(d => ({ dj: { ...d.dj, lng: e.target.value } }))}
+            />
+          </Field>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/web/components/onboarding/useWizard.ts
+++ b/web/components/onboarding/useWizard.ts
@@ -36,6 +36,10 @@ export interface WizardData {
   dj: {
     stationName: string;
     locationName: string;
+    // Weather coordinates — strings since they back text inputs; parsed +
+    // range-checked by the controller's settings.update() on save.
+    lat: string;
+    lng: string;
     frequency: 'quiet' | 'moderate' | 'aggressive';
   };
 
@@ -65,22 +69,24 @@ export const DEFAULT_DATA: WizardData = {
   },
   dj: {
     stationName: 'SUB/WAVE',
-    locationName: 'Wolverhampton',
+    // Punjab (Chandigarh) — operator's home region; coordinates drive weather.
+    locationName: 'Punjab',
+    lat: '30.7333',
+    lng: '76.7794',
     frequency: 'moderate',
   },
   apiKeys: {},
 };
 
-export type StepId = 'navidrome' | 'llm' | 'tts' | 'dj' | 'jingles' | 'review';
+export type StepId = 'navidrome' | 'llm' | 'tts' | 'dj' | 'review';
 
-export const STEP_ORDER: StepId[] = ['navidrome', 'llm', 'tts', 'dj', 'jingles', 'review'];
+export const STEP_ORDER: StepId[] = ['navidrome', 'llm', 'tts', 'dj', 'review'];
 
 export const STEP_LABELS: Record<StepId, string> = {
   navidrome: 'Navidrome',
   llm: 'LLM',
   tts: 'TTS',
   dj: 'DJ persona',
-  jingles: 'Jingles',
   review: 'Review',
 };
 
@@ -182,7 +188,7 @@ export function useWizard() {
           ? { enabled: true, provider: data.tts.cloud.provider }
           : { enabled: false },
       },
-      weather: { locationName: data.dj.locationName },
+      weather: { locationName: data.dj.locationName, lat: data.dj.lat, lng: data.dj.lng },
       station: data.dj.stationName,
       apiKeys,
     };
@@ -194,12 +200,6 @@ export function useWizard() {
     const j = (await r.json().catch(() => ({}))) as { ok?: boolean; error?: string };
     return { ok: !!j.ok, error: j.error };
   }, [auth, data]);
-
-  const generateJingles = useCallback(async () => {
-    const r = await auth.adminFetch('/onboarding/generate-jingles', { method: 'POST' });
-    const j = (await r.json().catch(() => ({}))) as { ok?: boolean; created?: number; total?: number; error?: string };
-    return { ok: !!j.ok, created: j.created, total: j.total, error: j.error };
-  }, [auth]);
 
   return {
     auth,
@@ -214,7 +214,6 @@ export function useWizard() {
     testLlm,
     discoverLocca,
     save,
-    generateJingles,
   };
 }
 


### PR DESCRIPTION
## What & why

Four operator-facing fixes to the first-run wizard (`/onboarding`) and the player entry.

1. **Fresh installs could reach a silent player.** A new operator who hadn't configured Navidrome could open the player (`/`, `/listen`) and just see a dead station. `AdminShell` already bounced unconfigured operators to `/onboarding`; the player now does the same.
2. **The music-licensing notice was near-invisible** in the default light theme — it used `text-amber-200` (tuned for dark mode). Switched to the theme-aware `text-ink/80` so it reads in both light and dark.
3. **DJ-persona location** defaulted to Wolverhampton with no way to set coordinates. It now defaults to **Punjab** with editable **latitude/longitude** fields (seeded to Chandigarh, `30.7333` / `76.7794`). Weather is coordinate-driven, so the save now sends `weather.lat/lng`, and the controller fallback defaults (`config.ts`, `settings.ts`) match.
4. **Removed the Jingles step** — jingles aren't required to broadcast and can be generated later from the admin panel. Wizard is now 5 steps; admin-side jingle generation is untouched.

## Changes

- `web/components/PlayerApp.tsx` — first-run redirect effect (guarded on `!contained`, hits same-origin `/api/onboarding/status`).
- `web/components/onboarding/steps.tsx` — darker licensing text; Latitude/Longitude fields in the DJ step; `JinglesStep` removed.
- `web/components/onboarding/useWizard.ts` — `dj.lat`/`dj.lng` in the wizard data + Punjab/Chandigarh defaults; `weather.lat/lng` in the save payload; `'jingles'` dropped from steps; unused `generateJingles` removed.
- `web/components/onboarding/WizardShell.tsx` — drop the jingles branch/import.
- `controller/src/config.ts`, `controller/src/settings.ts` — fallback weather defaults → Punjab/Chandigarh.

No controller endpoint changes: `/onboarding/save` already forwards `weather`, and `settings.update()` already validates `weather.lat/lng`.

## Testing

- `web` lint (`eslint . && tsc --noEmit`) passes clean.
- Verified end-to-end in a browser against a dev stack with a fresh (`needsSetup: true`) state:
  - `/` (player) redirects to `/onboarding`.
  - Licensing notice is dark/readable on the light theme.
  - DJ step shows Punjab + Latitude 30.7333 / Longitude 76.7794; on save, `settings.json` persisted `weather: { lat: 30.7333, lng: 76.7794, locationName: "Punjab" }`.
  - Wizard shows 5 steps, no Jingles.
