### PR TITLE
feat(unraid): all-in-one image + Community Applications one-click install

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,6 +1,6 @@
 name: Publish images
 
-# Builds and pushes the five first-party SUB/WAVE images to GHCR.
+# Builds and pushes the first-party SUB/WAVE images to GHCR.
 #
 # Triggers:
 #   - push of a tag like v1.2.3 → versioned release (also tagged :latest)
@@ -11,6 +11,8 @@ name: Publish images
 #   ghcr.io/<owner>/subwave-broadcast   (icecast2 + liquidsoap + radio.liq + sounds/)
 #   ghcr.io/<owner>/subwave-controller
 #   ghcr.io/<owner>/subwave-web
+#   ghcr.io/<owner>/subwave-aio         (whole stack in one container — the Unraid
+#                                        Community Applications one-click image)
 #   ghcr.io/<owner>/subwave-tts-heavy   (optional Chatterbox + PocketTTS sidecar, ~3-4GB)
 #
 # Platforms: the core four images (caddy, broadcast, controller, web) are
@@ -48,6 +50,17 @@ jobs:
             platforms: linux/amd64,linux/arm64
           - image: subwave-web
             dockerfile: web/Dockerfile
+            platforms: linux/amd64,linux/arm64
+          # The Unraid one-click image: the whole stack (icecast2 + liquidsoap,
+          # controller, web, Caddy) in one container, supervised by
+          # docker/aio/supervisor.sh. Multi-arch like the split-stack images —
+          # amd64 (x86-64, every Unraid box) plus arm64 (ARM servers / Apple
+          # Silicon). Dockerfile.aio selects the matching Piper build via
+          # $TARGETARCH; Kokoro/onnx, node, icecast2 and the liquidsoap base all
+          # have arm64 builds. The arm64 variant cross-builds under QEMU, so this
+          # is the slowest image in the matrix.
+          - image: subwave-aio
+            dockerfile: docker/Dockerfile.aio
             platforms: linux/amd64,linux/arm64
           - image: subwave-tts-heavy
             dockerfile: docker/Dockerfile.tts-heavy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Open an issue with:
 
 ## Pull requests
 
-- Branch off `main` and keep PRs focused on one change.
+- Branch off `develop` (the integration branch) and target it in your PR — keep PRs focused on one change.
 - Explain the *why*, not just the *what*, in the description.
 - If you touch the queue/playback path, `radio.liq`, the crossfade, ducking, or
   the LLM layer, read the relevant note in `CLAUDE.md` first — those areas have
@@ -54,12 +54,13 @@ A scope in parens (`fix(ui): …`, `feat(controller): …`) is optional but help
 when skimming the changelog. Use `!` after the type, or a `BREAKING CHANGE:`
 footer, for anything that breaks compatibility.
 
-PR titles follow the same convention — squash-merging then produces a clean
-commit on `main` that release-please can read.
+PR titles follow the same convention — squash-merging keeps history clean, and
+the commit carries through `develop` → `main`, where release-please reads it.
 
 ## Releases
 
-You don't cut releases by hand. On every push to `main`, the **Release Please**
+You don't cut releases by hand. Maintainers merge `develop` into `main` to ship;
+on every push to `main`, the **Release Please**
 workflow opens (or updates) a release PR that bumps `package.json` +
 `CHANGELOG.md` based on the Conventional Commits since the last tag. Merging
 that PR creates a `vX.Y.Z` tag and a GitHub Release, which triggers

--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ the canonical path: `curl` two files, fill in three vars, `docker compose
 up -d`, finish setup in the browser. See **[`DEPLOY.md`](DEPLOY.md)** for host
 prerequisites, Cloudflare setup, updates, and backup.
 
+**On Unraid?** Run it through the Compose Manager Plus plugin — see
+**[`docs/unraid.md`](docs/unraid.md)**.
+
 **Bring your own reverse proxy.** If you already run Traefik, nginx, or your
 own Caddy in your homelab, swap the bundled-Caddy compose for the BYO variant:
 
@@ -247,6 +250,7 @@ bin/subwave        Operator CLI entry: setup, status, doctor, lifecycle, play
 ## Documentation
 
 - **[`DEPLOY.md`](DEPLOY.md):** production deployment, updates, backup.
+- **[`docs/unraid.md`](docs/unraid.md):** running on Unraid via the Compose Manager Plus plugin.
 - **[`CLAUDE.md`](CLAUDE.md):** deep architecture reference and the
   non-obvious constraints behind each subsystem.
 - **[`CONTRIBUTING.md`](CONTRIBUTING.md):** how to contribute.

--- a/ca_profile.xml
+++ b/ca_profile.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<CommunityApplications>
+  <!-- Maintainer profile shown on the SUB/WAVE author page in Community Apps.
+       This repo IS the SUB/WAVE source repo; the CA submission files live at the
+       root alongside it (ca_profile.xml + templates/). See
+       docs/unraid-ca-submission.md. -->
+  <Profile>
+## SUB/WAVE
+
+A personal internet radio station: **one Icecast stream that every listener
+hears together**, with an **AI DJ** that picks tracks from your own
+Navidrome / Subsonic library and reads scripts between them — station IDs,
+the time, the weather, listener requests.
+
+This template installs the **one-click all-in-one image** (`subwave-aio`): the
+entire stack — icecast2 + liquidsoap, the controller (the DJ brain), the
+Next.js web UI, and a Caddy edge — runs in a **single container** exposing one
+port. After installing, finish setup in your browser at `/onboarding`
+(Navidrome, the LLM provider, the voice, the DJ persona).
+
+- **Project &amp; full docs:** https://github.com/perminder-klair/subwave
+- **Support / issues:** https://github.com/perminder-klair/subwave/issues
+
+> Prefer the full split-container deployment (separate broadcast / controller /
+> web / Caddy services, BYO reverse proxy)? Run the maintained
+> `docker-compose.yml` via the Compose Manager Plus plugin instead — see
+> docs/unraid.md.
+  </Profile>
+  <Icon>https://raw.githubusercontent.com/perminder-klair/subwave/main/app/assets/icon.png</Icon>
+  <WebPage>https://github.com/perminder-klair/subwave</WebPage>
+</CommunityApplications>

--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -1,0 +1,141 @@
+# SUB/WAVE all-in-one image — the entire stack in a single container.
+#
+# Why this exists: Unraid's Community Applications catalogue is strictly one
+# container per template, so the five-service compose stack can't be listed
+# there directly. This image collapses icecast2 + liquidsoap (broadcast), the
+# controller, the Next.js web UI, and Caddy into one container supervised by
+# docker/aio/supervisor.sh, exposing a single port (80, fronted by Caddy). It's
+# also handy anywhere you'd rather run `docker run` once than orchestrate five
+# services (Synology, a plain VPS, Portainer one-shot).
+#
+# The split-stack images (subwave-{caddy,broadcast,controller,web}) remain the
+# canonical deployment. This is an additional packaging of the same source —
+# nothing here forks app behaviour; it only repoints internal URLs at loopback
+# (see docker/aio/supervisor.sh) and bakes in a loopback Caddyfile.
+#
+# NOT bundled (to keep the image lean): the optional tts-heavy engines
+# (Chatterbox / PocketTTS) and the docker-socket-proxy Stats panel. Both degrade
+# gracefully — TTS falls back to the bundled Piper voice, the Stats system panel
+# simply hides. Piper + Kokoro are included, so the DJ has a natural voice.
+
+# ---- web build: Next.js standalone (mirrors web/Dockerfile) ----------------
+FROM node:22-bookworm-slim AS webbuild
+WORKDIR /web
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+COPY web/ ./
+ENV NEXT_TELEMETRY_DISABLED=1
+# SITE_URL is frozen into statically-rendered routes (robots, sitemap, OG cards)
+# at build time. For the AIO it's unknown until the operator sets it, so we bake
+# the localhost fallback; the force-dynamic homepage still reads the runtime
+# SITE_URL env for live share-card tags.
+ARG SITE_URL
+ENV SITE_URL=${SITE_URL}
+RUN npm run build
+
+# ---- caddy binary: lift the glibc build from the official Debian image ------
+FROM caddy:2 AS caddybin
+
+# ---- final: everything under the liquidsoap (Debian bookworm) base ----------
+FROM savonet/liquidsoap:v2.2.5
+
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System packages:
+#  - icecast2: the broadcast server (apt also creates the icecast2 user)
+#  - sudo: lets the supervisor drop privileges to icecast2 / liquidsoap
+#  - openssl: first-boot icecast secret generation
+#  - curl/ca-certificates: liquidsoap's HTTPS Subsonic fetch + health probes
+#  - espeak-ng/libsndfile1: Kokoro phonemisation + audio I/O
+#  - ffmpeg: jingle/SFX transcode on import (audio/audio-import.ts)
+#  - python3/python3-venv: the Kokoro worker venv
+#  - wget/tar/xz-utils: Piper + Kokoro model/binary pulls
+#  - gnupg: NodeSource apt key
+RUN apt-get update -qq \
+ && apt-get install -y --no-install-recommends \
+        icecast2 sudo openssl curl ca-certificates \
+        espeak-ng libsndfile1 ffmpeg \
+        python3 python3-venv \
+        wget tar xz-utils gnupg \
+ && rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 (NodeSource) — runs both the controller (tsx) and the web server.
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/*
+
+# Caddy — the loopback edge.
+COPY --from=caddybin /usr/bin/caddy /usr/local/bin/caddy
+
+ARG WGET_RETRY="--tries=5 --retry-connrefused --waitretry=10 --timeout=60 --retry-on-http-error=429,500,502,503,504"
+
+# --- Piper (default TTS, ~30ms/word) ---------------------------------------
+# TARGETARCH is set by buildx; empty on a plain `docker build` → treat as amd64.
+ARG PIPER_VERSION=2023.11.14-2
+ARG TARGETARCH
+RUN cd /tmp && \
+    case "${TARGETARCH}" in \
+      amd64|"") piper_arch=x86_64 ;; \
+      arm64)    piper_arch=aarch64 ;; \
+      *) echo "unsupported TARGETARCH=${TARGETARCH} for Piper" >&2; exit 1 ;; \
+    esac && \
+    wget -q ${WGET_RETRY} https://github.com/rhasspy/piper/releases/download/${PIPER_VERSION}/piper_linux_${piper_arch}.tar.gz && \
+    tar -xzf piper_linux_${piper_arch}.tar.gz -C /opt && \
+    ln -s /opt/piper/piper /usr/local/bin/piper && \
+    rm piper_linux_${piper_arch}.tar.gz
+RUN mkdir -p /opt/piper/voices && \
+    wget -q ${WGET_RETRY} -O /opt/piper/voices/en_GB-alan-medium.onnx \
+      https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/alan/medium/en_GB-alan-medium.onnx && \
+    wget -q ${WGET_RETRY} -O /opt/piper/voices/en_GB-alan-medium.onnx.json \
+      https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/alan/medium/en_GB-alan-medium.onnx.json
+
+# --- Kokoro (optional second TTS, more natural) ----------------------------
+RUN python3 -m venv /opt/kokoro/venv && \
+    /opt/kokoro/venv/bin/pip install --no-cache-dir --upgrade pip && \
+    /opt/kokoro/venv/bin/pip install --no-cache-dir \
+      kokoro-onnx==0.4.9 soundfile==0.12.1
+RUN mkdir -p /opt/kokoro/models && \
+    wget -q ${WGET_RETRY} -O /opt/kokoro/models/kokoro-v1.0.onnx \
+      https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx && \
+    wget -q ${WGET_RETRY} -O /opt/kokoro/models/voices-v1.0.bin \
+      https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/voices-v1.0.bin
+ENV KOKORO_MODEL=/opt/kokoro/models/kokoro-v1.0.onnx \
+    KOKORO_VOICES=/opt/kokoro/models/voices-v1.0.bin \
+    KOKORO_PYTHON=/opt/kokoro/venv/bin/python
+
+# --- Controller app ---------------------------------------------------------
+WORKDIR /app
+COPY controller/package*.json ./
+RUN npm install --omit=dev
+COPY controller/src ./src
+COPY controller/scripts ./scripts
+
+# --- Web app (standalone build from the webbuild stage) ---------------------
+# Mirrors web/Dockerfile's runner layout, rooted at /web instead of /app.
+COPY --from=webbuild /web/.next/standalone /web
+COPY --from=webbuild /web/.next/static /web/.next/static
+COPY --from=webbuild /web/public /web/public
+
+# --- Broadcast + edge config + bundled audio --------------------------------
+COPY docker/icecast.xml.template /etc/icecast2/icecast.xml.template
+COPY liquidsoap/radio.liq /etc/liquidsoap/radio.liq
+COPY sounds /sounds
+COPY docker/aio/Caddyfile /etc/caddy/Caddyfile
+COPY docker/aio/supervisor.sh /usr/local/bin/subwave-supervisor
+RUN chmod +x /usr/local/bin/subwave-supervisor
+
+# Shared state dir (the supervisor re-asserts perms on every boot).
+RUN mkdir -p /var/sub-wave && chmod 777 /var/sub-wave
+
+ENV NODE_ENV=production \
+    STATE_DIR=/var/sub-wave \
+    SOUNDS_DIR=/sounds
+
+# Single public port: Caddy on :80. Health = the controller's liveness via the
+# edge, which only answers once web + controller are both up.
+EXPOSE 80
+HEALTHCHECK --interval=15s --timeout=5s --start-period=40s --retries=6 \
+    CMD curl -fsS http://localhost:80/api/health > /dev/null || exit 1
+
+ENTRYPOINT ["/usr/local/bin/subwave-supervisor"]

--- a/docker/aio/Caddyfile
+++ b/docker/aio/Caddyfile
@@ -1,0 +1,47 @@
+# Caddy edge router for the SUB/WAVE all-in-one image (docker/Dockerfile.aio).
+#
+# Unlike the split-stack docker/Caddyfile, every backend lives in THIS SAME
+# container, so the upstreams are loopback addresses rather than compose service
+# names. The route table is otherwise identical: one origin on :80, split by URL
+# prefix. The single host port the Unraid template maps points here.
+#
+# No Cloudflare trusted_proxies block — the AIO is aimed at LAN / self-hosted
+# use behind whatever reverse proxy the operator already runs (or none at all).
+{
+	auto_https off
+}
+
+:80 {
+	# /stream.mp3 + /stream.opus — Icecast (served by liquidsoap → icecast on
+	# 7702). flush_interval -1 keeps the never-ending audio body live.
+	@streams path /stream.mp3 /stream.opus
+	handle @streams {
+		reverse_proxy 127.0.0.1:7702 {
+			flush_interval -1
+			transport http {
+				read_buffer 16KB
+				response_header_timeout 30s
+				dial_timeout 5s
+			}
+		}
+	}
+
+	# /api/* — controller REST API (prefix stripped so its routes stay at root).
+	handle_path /api/* {
+		reverse_proxy 127.0.0.1:7701
+	}
+
+	# Everything else → Next.js web UI.
+	handle {
+		reverse_proxy 127.0.0.1:7700
+	}
+
+	# Don't gzip the already-compressed live audio mounts.
+	@compressible not path /stream.mp3 /stream.opus
+	encode @compressible gzip zstd
+
+	log {
+		output stdout
+		format console
+	}
+}

--- a/docker/aio/supervisor.sh
+++ b/docker/aio/supervisor.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# SUB/WAVE all-in-one supervisor.
+#
+# Runs the whole stack — icecast2 + liquidsoap (the broadcast pair), the
+# controller, the Next.js web UI, and Caddy — inside ONE container for the
+# Unraid Community Applications one-click image (docker/Dockerfile.aio).
+#
+# The split-stack deployment runs these as five compose services wired over an
+# internal network; here they all share localhost and the /var/sub-wave volume,
+# so the file-based IPC (next.txt / say.txt / now-playing.json …) works exactly
+# as before with no code changes — only a handful of *_HOST/*_URL env overrides
+# repoint the controller at loopback.
+#
+# Each service runs in its own restart loop, so a web or controller crash does
+# NOT take the station off the air. The icecast+liquidsoap pair is launched as a
+# unit (mirroring docker/broadcast-entrypoint.sh): if either dies the pair is
+# bounced together, because liquidsoap is useless without its icecast sink.
+#
+# Bash (not /bin/sh) for `wait -n`; the savonet/liquidsoap base ships bash.
+set -u
+
+SECRETS=/var/sub-wave/icecast-secrets.env
+TEMPLATE=/etc/icecast2/icecast.xml.template
+RENDERED=/etc/icecast2/icecast.xml
+
+log() { echo "[subwave-aio] $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# One-time state bootstrap — shared dirs, watch-mode m3u stubs, archive ignore.
+# Same responsibilities as docker/broadcast-entrypoint.sh, minus launching the
+# audio processes (the supervisor does that in a restart loop below). Mode 777
+# because the services run under different uids (icecast2 / liquidsoap / root).
+# ---------------------------------------------------------------------------
+init_state() {
+	mkdir -p /var/sub-wave \
+	         /var/sub-wave/voice \
+	         /var/sub-wave/voices \
+	         /var/sub-wave/archive \
+	         /var/sub-wave/jingles \
+	         /var/sub-wave/logs \
+	         /var/sub-wave/sessions \
+	         /var/sub-wave/sfx
+	chmod 777 /var/sub-wave \
+	          /var/sub-wave/voice \
+	          /var/sub-wave/voices \
+	          /var/sub-wave/archive \
+	          /var/sub-wave/jingles \
+	          /var/sub-wave/logs \
+	          /var/sub-wave/sessions \
+	          /var/sub-wave/sfx
+
+	# Liquidsoap's reload_mode="watch" playlists need the files to exist.
+	touch /var/sub-wave/auto.m3u /var/sub-wave/jingles.m3u
+	chmod 666 /var/sub-wave/auto.m3u /var/sub-wave/jingles.m3u
+
+	# Keep a co-located Navidrome from scanning the station's own hourly
+	# archive mixdowns as junk "HH-00" tracks (issue #273).
+	touch /var/sub-wave/archive/.ndignore
+
+	# Liquidsoap writes radio.log here as the liquidsoap user.
+	mkdir -p /var/log/liquidsoap
+	chown -R liquidsoap:liquidsoap /var/log/liquidsoap 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Resolve the three ICECAST_*_PASSWORD values and render icecast.xml.
+# Precedence (unchanged from broadcast-entrypoint): env override > persisted
+# state/icecast-secrets.env > freshly generated. Resolved values are exported
+# (liquidsoap reads ICECAST_SOURCE_PASSWORD from the environment) and written
+# back to the secrets file for operator visibility + the documented rotate path.
+# ---------------------------------------------------------------------------
+init_secrets() {
+	local ENV_SRC="${ICECAST_SOURCE_PASSWORD:-}"
+	local ENV_ADM="${ICECAST_ADMIN_PASSWORD:-}"
+	local ENV_REL="${ICECAST_RELAY_PASSWORD:-}"
+
+	if [ -f "$SECRETS" ]; then
+		# shellcheck disable=SC1090
+		. "$SECRETS"
+	fi
+
+	[ -n "$ENV_SRC" ] && ICECAST_SOURCE_PASSWORD="$ENV_SRC"
+	[ -n "$ENV_ADM" ] && ICECAST_ADMIN_PASSWORD="$ENV_ADM"
+	[ -n "$ENV_REL" ] && ICECAST_RELAY_PASSWORD="$ENV_REL"
+
+	[ -z "${ICECAST_SOURCE_PASSWORD:-}" ] && ICECAST_SOURCE_PASSWORD="$(openssl rand -hex 16)"
+	[ -z "${ICECAST_ADMIN_PASSWORD:-}"  ] && ICECAST_ADMIN_PASSWORD="$(openssl rand -hex 16)"
+	[ -z "${ICECAST_RELAY_PASSWORD:-}"  ] && ICECAST_RELAY_PASSWORD="$(openssl rand -hex 16)"
+
+	cat > "$SECRETS" <<-EOF
+		ICECAST_SOURCE_PASSWORD=$ICECAST_SOURCE_PASSWORD
+		ICECAST_ADMIN_PASSWORD=$ICECAST_ADMIN_PASSWORD
+		ICECAST_RELAY_PASSWORD=$ICECAST_RELAY_PASSWORD
+	EOF
+	chmod 644 "$SECRETS"
+
+	export ICECAST_SOURCE_PASSWORD ICECAST_ADMIN_PASSWORD ICECAST_RELAY_PASSWORD
+	# Liquidsoap connects to icecast over loopback inside this container;
+	# radio.liq reads ICECAST_HOST (default "icecast").
+	export ICECAST_HOST=localhost
+
+	sed \
+		-e "s|\${ICECAST_SOURCE_PASSWORD}|$ICECAST_SOURCE_PASSWORD|g" \
+		-e "s|\${ICECAST_ADMIN_PASSWORD}|$ICECAST_ADMIN_PASSWORD|g" \
+		-e "s|\${ICECAST_RELAY_PASSWORD}|$ICECAST_RELAY_PASSWORD|g" \
+		"$TEMPLATE" > "$RENDERED"
+	chown icecast2 "$RENDERED" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Service launchers. Each blocks until its process exits, so the supervise()
+# loop can restart it. Do NOT `exec` — that would replace the loop.
+# ---------------------------------------------------------------------------
+
+# icecast2 + liquidsoap as a unit. Returns when either dies (the loop bounces
+# the pair). icecast runs as the icecast2 user; liquidsoap as the liquidsoap
+# user (uid 10000). `sudo -E` preserves the resolved ICECAST_* env.
+run_broadcast() {
+	log "starting icecast2"
+	sudo -E -u icecast2 icecast2 -n -c "$RENDERED" &
+	local ic=$!
+
+	# Give icecast a moment to accept HTTP so liquidsoap's first source
+	# connect doesn't bail with "Cannot connect to remote host".
+	local i
+	for i in 1 2 3 4 5 6 7 8 9 10; do
+		if curl -fsS http://localhost:7702/ >/dev/null 2>&1; then
+			log "icecast accepting connections after ${i}s"
+			break
+		fi
+		sleep 1
+	done
+
+	log "starting liquidsoap"
+	sudo -E -u liquidsoap liquidsoap /etc/liquidsoap/radio.liq &
+	local lq=$!
+
+	wait -n "$ic" "$lq"
+	local code=$?
+	log "broadcast pair: a child exited ($code) — taking the other down"
+	kill -TERM "$ic" "$lq" 2>/dev/null || true
+	wait "$ic" "$lq" 2>/dev/null || true
+	return "$code"
+}
+
+# Controller — the AI DJ brain. The *_HOST/*_URL overrides repoint it from the
+# compose service names (broadcast:7702 / 1234) at loopback. DOCKER_HOST and
+# TTS_HEAVY_URL are intentionally unset: the Stats system panel degrades
+# gracefully and TTS falls back to the bundled Piper voice. All other config
+# (Navidrome, LLM, ADMIN_*, SITE_URL, TZ) is inherited from the container env
+# and the first-run wizard's settings.json.
+run_controller() {
+	cd /app || return 1
+	export NODE_ENV=production \
+	       STATE_DIR=/var/sub-wave \
+	       SOUNDS_DIR=/sounds \
+	       LIQUIDSOAP_HOST=127.0.0.1 \
+	       ICECAST_STATUS_URL=http://127.0.0.1:7702/status-json.xsl \
+	       ICECAST_ADMIN_URL=http://127.0.0.1:7702/admin/listclients
+	node_modules/.bin/tsx src/server.ts
+}
+
+# Web — Next.js listener UI (standalone build).
+run_web() {
+	cd /web || return 1
+	export NODE_ENV=production \
+	       PORT=7700 \
+	       HOSTNAME=0.0.0.0 \
+	       CONTROLLER_INTERNAL_URL=http://127.0.0.1:7701 \
+	       SUBWAVE_HOMEPAGE="${SUBWAVE_HOMEPAGE:-player}"
+	node server.js
+}
+
+# Caddy — the single-origin edge that fronts all three on :80.
+run_caddy() {
+	caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
+}
+
+# ---------------------------------------------------------------------------
+# supervise <name> <launcher-fn> — restart loop with backoff.
+# ---------------------------------------------------------------------------
+supervise() {
+	local name="$1"; shift
+	while true; do
+		log "starting $name"
+		"$@"
+		local code=$?
+		log "$name exited ($code) — restarting in 3s"
+		sleep 3
+	done
+}
+
+# ---------------------------------------------------------------------------
+# Boot.
+# ---------------------------------------------------------------------------
+init_state
+init_secrets
+
+# On stop, signal the whole process group once and bail (reset the trap first
+# so the kill doesn't re-enter this handler).
+trap 'trap "" TERM INT; log "shutting down"; kill -TERM 0 2>/dev/null; exit 0' TERM INT
+
+supervise broadcast  run_broadcast  &
+supervise controller run_controller &
+supervise web        run_web        &
+supervise caddy      run_caddy      &
+
+wait

--- a/docs/unraid-ca-submission.md
+++ b/docs/unraid-ca-submission.md
@@ -1,0 +1,78 @@
+# Submitting SUB/WAVE to Unraid Community Applications
+
+Maintainer runbook. The CA submission files live at the **root of this repo** —
+`ca_profile.xml` + `templates/subwave.xml` — so the app and its store listing
+stay versioned together. The runnable artifact is the `subwave-aio` image
+(`docker/Dockerfile.aio`), published from this same repo.
+
+## What the scanner reads
+
+```
+subwave/
+├── ca_profile.xml          # maintainer profile (overview, icon, web page)
+├── LICENSE                 # MIT (already here)
+├── README.md               # used as the listing's "readme first"
+└── templates/subwave.xml   # the single Container v2 template (one image)
+```
+
+Icon + screenshots are referenced by raw URL from existing in-repo assets
+(`app/assets/icon.png`, `web/public/screenshots/*.webp`) — nothing duplicated.
+
+## 1. Publish the `subwave-aio` image
+
+Built by `.github/workflows/publish-images.yml` (matrix entry `subwave-aio`,
+multi-arch amd64+arm64). It publishes on a `v*` tag push:
+
+```bash
+git tag v<next-version> && git push origin v<next-version>
+```
+
+Then confirm `ghcr.io/perminder-klair/subwave-aio:latest` exists and is
+**public** (GHCR → package → Package settings → Change visibility → Public). CA
+pulls it anonymously, so a private package fails install.
+
+> Ad-hoc rebuild without a release: run the **Publish images** workflow via
+> *workflow_dispatch* — it rebuilds every image (including `subwave-aio`) from
+> the chosen ref.
+
+## 2. Smoke-test the image (before submitting)
+
+CA moderation expects a working app. Locally:
+
+```bash
+docker run -d --name subwave-aio-test -p 7790:80 \
+  -e ADMIN_USER=admin -e ADMIN_PASS=test123 -e SITE_URL=http://localhost:7790 \
+  -v /tmp/subwave-aio-state:/var/sub-wave \
+  ghcr.io/perminder-klair/subwave-aio:latest
+
+curl -fsS http://localhost:7790/api/health                                   # {"status":"on-air"}
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:7790/onboarding    # 200
+curl -s --max-time 4 -w 'type=%{content_type}\n' http://localhost:7790/stream.mp3  # audio/mpeg
+docker rm -f subwave-aio-test
+```
+
+Better still: install it on a real Unraid box first via **Add Container →
+Template URL** →
+`https://raw.githubusercontent.com/perminder-klair/subwave/main/templates/subwave.xml`,
+then finish `/onboarding` against a real Navidrome.
+
+## 3. Submit at ca.unraid.net
+
+1. Go to <https://ca.unraid.net/submit> and sign in with GitHub.
+2. Point it at `perminder-klair/subwave`.
+3. Run **Validate** and **Scan** — fix anything flagged, push, re-scan.
+4. **Preview** the listing, then **Submit**. A moderator reviews before it
+   appears in the Apps tab.
+
+> The scanner crawls the whole repo. If it ever mis-detects unrelated XML (it
+> keys off `<Container>` files under `templates/`, so it shouldn't), the
+> fallback is to split these files into a small dedicated `subwave-unraid` repo
+> and submit that instead — same files, different home.
+
+## Updating later
+
+- **App behaviour / image:** change the repo, cut a new `v*` tag → CA's normal
+  "Check for Updates" picks up the new `:latest` digest.
+- **Listing metadata** (description, screenshots, port defaults): edit
+  `ca_profile.xml` / `templates/subwave.xml`, push, re-run Validate/Scan. Bump
+  `<Date>` and add a `<Changes>` note in the template.

--- a/docs/unraid.md
+++ b/docs/unraid.md
@@ -1,0 +1,107 @@
+# Running SUB/WAVE on Unraid
+
+SUB/WAVE is a multi-container Compose stack, so on Unraid it runs through the
+**Compose Manager Plus** plugin rather than as individual Community Applications
+templates. Start to on-air is about five minutes.
+
+> Community Applications is a single-container catalogue — it can't one-click a
+> Compose stack. Compose Manager Plus is the supported way to run one, and it
+> uses the exact same `docker-compose.yml` as every other host, so you stay on
+> the maintained file with nothing Unraid-specific to drift.
+
+## Prerequisites
+
+- Unraid 7.x with **Docker enabled** and the array (or a pool) started, so you
+  have somewhere on disk for appdata.
+- The **Community Applications** plugin (ships with Unraid).
+
+## 1. Install Compose Manager Plus
+
+**Apps** tab → search **Compose Manager Plus** (by `mstrhakr`) → **Install** the
+stable release. It adds a **Compose** section to the **Docker** tab.
+
+## 2. Create the stack
+
+**Docker** tab → **Compose** → **Add New Stack** → name it `subwave` → **Create**
+→ **Edit Stack**.
+
+- **Compose** tab: paste the contents of the default
+  [`docker-compose.yml`](https://raw.githubusercontent.com/perminder-klair/subwave/main/docker-compose.yml).
+  It brings up five containers; only Caddy binds a host port (`:7700`),
+  everything else is internal. The optional `tts-heavy` sidecar is
+  profile-gated and won't start — the DJ falls back to the built-in Piper voice.
+- **.env** tab: paste the three required vars plus the two Unraid-specific ones:
+
+```ini
+# Required
+ADMIN_USER=admin
+ADMIN_PASS=change-me            # generate one: openssl rand -hex 16
+SITE_URL=http://YOUR-UNRAID-IP:7700
+
+# Unraid-specific — keep state OFF the flash drive
+STATE_DIR=/mnt/user/appdata/subwave/state
+CADDY_PORT=7700
+TZ=Europe/London
+```
+
+**Save.**
+
+> ⚠️ **Set `STATE_DIR` to an absolute appdata path.** Compose Manager's project
+> directory lives on the USB flash (`/boot/...`), so the compose default of
+> `./state` would write SUB/WAVE's growing state — hourly archives, the library
+> cache, rendered voices — onto the boot stick. Point it at your pool/array
+> (`/mnt/user/appdata/subwave/state`) instead. Docker creates the folder on
+> first start.
+
+## 3. Pull and start
+
+From the stack's action menu pick **Pull & Up** (not plain *Compose Up*).
+
+> The compose file carries `build:` blocks so a source checkout can rebuild
+> locally. The Unraid project directory has no source, so a plain *up* would try
+> to build and fail. **Pull & Up** fetches the prebuilt images from GHCR first,
+> then starts them — no build. (Alternatively, delete the `build:` blocks and a
+> plain *up* works too.)
+
+First pull is ~1–2 GB. When it finishes you'll have five running containers.
+Flip the stack's **Autostart → ON** so it comes back after a reboot.
+
+## 4. Finish setup
+
+Open `http://YOUR-UNRAID-IP:7700/onboarding`, sign in with the `ADMIN_USER` /
+`ADMIN_PASS` you set, and the wizard collects everything else — Navidrome, the
+LLM provider, TTS, the DJ persona. The player is at `http://YOUR-UNRAID-IP:7700`.
+
+## The AI DJ on Unraid: Ollama (local **or** cloud)
+
+SUB/WAVE ships a first-class **"Ollama — local/cloud"** provider. Most Unraid
+boxes don't have a big GPU, so the nicest path is Ollama's **cloud models**,
+which offload inference — even a low-power box (e.g. an Intel N95) handles them
+fine:
+
+1. **Apps** tab → install the official **ollama** container (defaults are right:
+   port `11434`, appdata `/mnt/user/appdata/ollama`, `OLLAMA_HOST=0.0.0.0:11434`).
+2. Open the ollama container's **Console** and run `ollama signin`; approve the
+   printed link in your browser (needs an Ollama account; `:cloud` models need a
+   cloud subscription). Auth persists in the appdata volume.
+3. In SUB/WAVE: **admin → Settings → LLM Provider** → provider
+   **Ollama — local/cloud**, server URL `http://host.docker.internal:11434`,
+   model a `:cloud` tag (e.g. `glm-5.2:cloud`) — or a small local tag like
+   `llama3.2:3b` if you'd rather run on CPU. **Save LLM provider**.
+
+`host.docker.internal` resolves from SUB/WAVE's containers to the Unraid host,
+where the ollama container publishes `11434`.
+
+## Notes
+
+- **No reverse proxy needed** for LAN use — Caddy fronts `/`, `/api`, and
+  `/stream.mp3` on the single `CADDY_PORT`. If you already run SWAG / NPM /
+  Traefik and want TLS + a hostname, front `CADDY_PORT` with it, or switch to
+  [`docker-compose.byo.yml`](https://raw.githubusercontent.com/perminder-klair/subwave/main/docker-compose.byo.yml).
+- **Updates:** stack menu → **Pull & Up** (or **Check for Updates**).
+- **Backups:** everything lives under `STATE_DIR`
+  (`/mnt/user/appdata/subwave`) — settings, library cache, archives, voices.
+  Back that path up (it's already on your pool/array).
+
+See [`deployment.md`](deployment.md) for the full cross-platform deploy matrix
+and [`../DEPLOY.md`](../DEPLOY.md) for Cloudflare, updates, and operations.

--- a/docs/unraid.md
+++ b/docs/unraid.md
@@ -1,26 +1,77 @@
 # Running SUB/WAVE on Unraid
 
-SUB/WAVE is a multi-container Compose stack, so on Unraid it runs through the
-**Compose Manager Plus** plugin rather than as individual Community Applications
-templates. Start to on-air is about five minutes.
+Two supported ways, depending on how much you want to manage:
 
-> Community Applications is a single-container catalogue — it can't one-click a
-> Compose stack. Compose Manager Plus is the supported way to run one, and it
-> uses the exact same `docker-compose.yml` as every other host, so you stay on
-> the maintained file with nothing Unraid-specific to drift.
+1. **One-click from Community Applications** — install the single all-in-one
+   container, set a few fields, done. Easiest; recommended for most people.
+2. **The full Compose stack via Compose Manager Plus** — run the maintained
+   `docker-compose.yml` as separate broadcast / controller / web / Caddy
+   services. Pick this if you want split containers, your own reverse proxy, or
+   the optional `tts-heavy` sidecar.
 
-## Prerequisites
+Both end at the same place: a browser wizard at `/onboarding` that collects
+Navidrome, the LLM provider, TTS and the DJ persona. Start to on-air is about
+five minutes either way.
 
-- Unraid 7.x with **Docker enabled** and the array (or a pool) started, so you
-  have somewhere on disk for appdata.
+---
+
+## Option 1 — One-click (Community Applications)
+
+The Apps store catalogue is one container per template, so the one-click image
+(`subwave-aio`) bundles the whole stack — icecast2 + liquidsoap, the controller,
+the web UI and a Caddy edge — into a single container behind one port. It's the
+same images as the Compose stack, just packaged together.
+
+### Install
+
+1. **Apps** tab → search **SUB/WAVE** → **Install**.
+2. Set the template fields:
+
+   | Field | Value |
+   |---|---|
+   | **WebUI Port** | host port for the UI + stream (default `7700`) |
+   | **Appdata** | `/mnt/user/appdata/subwave` — on the array/pool, **not** the flash |
+   | **ADMIN_USER** | your admin username (e.g. `admin`) |
+   | **ADMIN_PASS** | a strong password — **required** (`openssl rand -hex 16`) |
+   | **SITE_URL** | `http://YOUR-UNRAID-IP:7700` |
+   | **TZ** | your timezone (advanced; default `Europe/London`) |
+
+3. **Apply.** First pull is a few GB. When it's up, open the WebUI and finish at
+   `http://YOUR-UNRAID-IP:7700/onboarding`.
+
+> ⚠️ **Keep Appdata on the array/pool, not the flash drive.** SUB/WAVE's state
+> grows — hourly archives, the library cache, rendered voices — so point it at
+> `/mnt/user/appdata/subwave`, never `/boot/...`.
+
+### Not in the store yet? Install by Template URL
+
+Until the Community Applications listing is approved (or to try a pre-release),
+add it directly: **Docker** tab → **Add Container** → paste this into
+**Template URL**, then fill the same fields:
+
+```
+https://raw.githubusercontent.com/perminder-klair/subwave/main/templates/subwave.xml
+```
+
+---
+
+## Option 2 — Full Compose stack (Compose Manager Plus)
+
+Run the maintained `docker-compose.yml` (the same file every other host uses) as
+separate services. Good if you want each service isolated, your own
+Traefik/SWAG/NPM in front, or the optional Chatterbox/PocketTTS sidecar.
+
+### Prerequisites
+
+- Unraid 7.x with **Docker enabled** and the array (or a pool) started.
 - The **Community Applications** plugin (ships with Unraid).
 
-## 1. Install Compose Manager Plus
+### 1. Install Compose Manager Plus
 
 **Apps** tab → search **Compose Manager Plus** (by `mstrhakr`) → **Install** the
 stable release. It adds a **Compose** section to the **Docker** tab.
 
-## 2. Create the stack
+### 2. Create the stack
 
 **Docker** tab → **Compose** → **Add New Stack** → name it `subwave` → **Create**
 → **Edit Stack**.
@@ -48,12 +99,10 @@ TZ=Europe/London
 
 > ⚠️ **Set `STATE_DIR` to an absolute appdata path.** Compose Manager's project
 > directory lives on the USB flash (`/boot/...`), so the compose default of
-> `./state` would write SUB/WAVE's growing state — hourly archives, the library
-> cache, rendered voices — onto the boot stick. Point it at your pool/array
-> (`/mnt/user/appdata/subwave/state`) instead. Docker creates the folder on
-> first start.
+> `./state` would write SUB/WAVE's growing state onto the boot stick. Point it
+> at your pool/array (`/mnt/user/appdata/subwave/state`) instead.
 
-## 3. Pull and start
+### 3. Pull and start
 
 From the stack's action menu pick **Pull & Up** (not plain *Compose Up*).
 
@@ -64,20 +113,17 @@ From the stack's action menu pick **Pull & Up** (not plain *Compose Up*).
 > plain *up* works too.)
 
 First pull is ~1–2 GB. When it finishes you'll have five running containers.
-Flip the stack's **Autostart → ON** so it comes back after a reboot.
+Flip the stack's **Autostart → ON** so it comes back after a reboot. Then finish
+at `http://YOUR-UNRAID-IP:7700/onboarding`.
 
-## 4. Finish setup
-
-Open `http://YOUR-UNRAID-IP:7700/onboarding`, sign in with the `ADMIN_USER` /
-`ADMIN_PASS` you set, and the wizard collects everything else — Navidrome, the
-LLM provider, TTS, the DJ persona. The player is at `http://YOUR-UNRAID-IP:7700`.
+---
 
 ## The AI DJ on Unraid: Ollama (local **or** cloud)
 
-SUB/WAVE ships a first-class **"Ollama — local/cloud"** provider. Most Unraid
-boxes don't have a big GPU, so the nicest path is Ollama's **cloud models**,
-which offload inference — even a low-power box (e.g. an Intel N95) handles them
-fine:
+Applies to both options. SUB/WAVE ships a first-class **"Ollama — local/cloud"**
+provider. Most Unraid boxes don't have a big GPU, so the nicest path is Ollama's
+**cloud models**, which offload inference — even a low-power box (e.g. an Intel
+N95) handles them fine:
 
 1. **Apps** tab → install the official **ollama** container (defaults are right:
    port `11434`, appdata `/mnt/user/appdata/ollama`, `OLLAMA_HOST=0.0.0.0:11434`).
@@ -89,17 +135,20 @@ fine:
    model a `:cloud` tag (e.g. `glm-5.2:cloud`) — or a small local tag like
    `llama3.2:3b` if you'd rather run on CPU. **Save LLM provider**.
 
-`host.docker.internal` resolves from SUB/WAVE's containers to the Unraid host,
-where the ollama container publishes `11434`.
+`host.docker.internal` resolves from SUB/WAVE's container(s) to the Unraid host,
+where the ollama container publishes `11434`. (The one-click template adds the
+`host-gateway` mapping for you; the Compose stack sets it via `extra_hosts`.)
 
 ## Notes
 
 - **No reverse proxy needed** for LAN use — Caddy fronts `/`, `/api`, and
-  `/stream.mp3` on the single `CADDY_PORT`. If you already run SWAG / NPM /
-  Traefik and want TLS + a hostname, front `CADDY_PORT` with it, or switch to
+  `/stream.mp3` on the single host port. If you already run SWAG / NPM /
+  Traefik and want TLS + a hostname, front that port with it, or (Compose stack)
+  switch to
   [`docker-compose.byo.yml`](https://raw.githubusercontent.com/perminder-klair/subwave/main/docker-compose.byo.yml).
-- **Updates:** stack menu → **Pull & Up** (or **Check for Updates**).
-- **Backups:** everything lives under `STATE_DIR`
+- **Updates:** one-click → Unraid's normal **Check for Updates** / **Apply
+  Update**. Compose stack → stack menu → **Pull & Up**.
+- **Backups:** everything lives under the appdata path
   (`/mnt/user/appdata/subwave`) — settings, library cache, archives, voices.
   Back that path up (it's already on your pool/array).
 

--- a/templates/subwave.xml
+++ b/templates/subwave.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>SUB-WAVE</Name>
+  <Repository>ghcr.io/perminder-klair/subwave-aio:latest</Repository>
+  <Registry>https://ghcr.io/perminder-klair/subwave-aio</Registry>
+  <Network>bridge</Network>
+  <Shell>bash</Shell>
+  <Privileged>false</Privileged>
+
+  <!-- Lets the in-container controller reach an Ollama (or Navidrome) running
+       on the Unraid host itself via http://host.docker.internal:PORT on the
+       default bridge network. Harmless when those services live elsewhere. -->
+  <ExtraParams>--add-host host.docker.internal:host-gateway</ExtraParams>
+
+  <Icon>https://raw.githubusercontent.com/perminder-klair/subwave/main/app/assets/icon.png</Icon>
+  <WebUI>http://[IP]:[PORT:80]</WebUI>
+
+  <Overview>
+    SUB/WAVE is a personal internet radio station: one Icecast stream every
+    listener hears together, with an AI DJ that picks tracks from your own
+    Navidrome / Subsonic library and reads scripts between them (station IDs,
+    the time, the weather, listener requests).
+
+    This is the all-in-one image — icecast2 + liquidsoap, the controller, the
+    Next.js web UI and a Caddy edge all run in this one container behind a
+    single port. Everything persists under the Appdata path.
+
+    [b]After it starts, open the WebUI and go to /onboarding[/b] (sign in with
+    the admin user/password you set here) to point it at your Navidrome server,
+    pick an LLM provider (Ollama local or cloud, or a cloud API key) and a
+    voice, and shape the DJ persona. The bundled Piper voice means the DJ can
+    talk out of the box with no extra setup.
+
+    Needs: a reachable Navidrome / Subsonic music server, and an LLM provider.
+    Most Unraid boxes have no big GPU, so Ollama cloud models are the easiest
+    path — install the official ollama container, run "ollama signin" in its
+    console, then set the provider to "Ollama - local/cloud" with a :cloud model.
+  </Overview>
+
+  <Support>https://github.com/perminder-klair/subwave/issues</Support>
+  <Project>https://github.com/perminder-klair/subwave</Project>
+  <TemplateURL>https://raw.githubusercontent.com/perminder-klair/subwave/main/templates/subwave.xml</TemplateURL>
+  <ReadMe>https://raw.githubusercontent.com/perminder-klair/subwave/main/README.md</ReadMe>
+
+  <Category>MediaApp:Music MediaServer:Music</Category>
+  <ExtraSearchTerms>radio internet radio icecast liquidsoap ai dj navidrome subsonic stream ollama station broadcast</ExtraSearchTerms>
+  <Requires>A reachable Navidrome / Subsonic music server and an LLM provider (Ollama local/cloud or a cloud API key), both configured in the browser at /onboarding after first boot.</Requires>
+
+  <Date>2026-06-22</Date>
+  <Changes>
+### 2026-06-22
+- Initial release: SUB/WAVE all-in-one image on Community Applications.
+  </Changes>
+
+  <License>MIT</License>
+  <MinVer>6.12</MinVer>
+
+  <!-- Reuse the screenshots already maintained in the main repo. -->
+  <Screenshot>https://raw.githubusercontent.com/perminder-klair/subwave/main/web/public/screenshots/listen.webp</Screenshot>
+  <Screenshot>https://raw.githubusercontent.com/perminder-klair/subwave/main/web/public/screenshots/observatory.webp</Screenshot>
+  <Screenshot>https://raw.githubusercontent.com/perminder-klair/subwave/main/web/public/screenshots/admin-dash.webp</Screenshot>
+
+  <!-- ports / paths / variables (v2 Config entries) -->
+
+  <!-- Host port mapped to Caddy's :80. The web UI, /api and /stream.mp3 are all
+       served from this single port. -->
+  <Config Name="WebUI Port" Target="80" Default="7700" Mode="tcp"
+          Description="Host port for the SUB/WAVE web UI + audio stream."
+          Type="Port" Display="always" Required="true" Mask="false">7700</Config>
+
+  <!-- Persistent state. Keep this on the array/pool, NOT the flash drive —
+       it grows (hourly archives, library cache, rendered voices). -->
+  <Config Name="Appdata" Target="/var/sub-wave" Default="/mnt/user/appdata/subwave" Mode="rw"
+          Description="Persistent state: settings, library cache, rendered voices, hourly archives."
+          Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/subwave</Config>
+
+  <Config Name="ADMIN_USER" Target="ADMIN_USER" Default="admin"
+          Description="Admin username for /admin and the /onboarding wizard."
+          Type="Variable" Display="always" Required="true" Mask="false">admin</Config>
+
+  <Config Name="ADMIN_PASS" Target="ADMIN_PASS" Default=""
+          Description="Admin password (required — the station refuses to start without it). Generate one, e.g. 'openssl rand -hex 16'."
+          Type="Variable" Display="always" Required="true" Mask="true"/>
+
+  <Config Name="SITE_URL" Target="SITE_URL" Default=""
+          Description="Public base URL of this station, e.g. http://YOUR-UNRAID-IP:7700 — used for share cards and absolute links."
+          Type="Variable" Display="always" Required="true" Mask="false"/>
+
+  <Config Name="TZ" Target="TZ" Default="Europe/London"
+          Description="Timezone — keeps scheduled shows and hourly-archive timestamps on local time."
+          Type="Variable" Display="advanced" Required="false" Mask="false">Europe/London</Config>
+</Container>

--- a/web/app/setup/unraid/page.tsx
+++ b/web/app/setup/unraid/page.tsx
@@ -1,0 +1,13 @@
+import Unraid from "@/components/setup/Unraid";
+import { pageMeta } from '@/lib/seo';
+
+export const metadata = pageMeta({
+  title: 'SUB/WAVE — Setup · Unraid',
+  description:
+    'Run SUB/WAVE on Unraid via the Compose Manager Plus plugin — stack setup, keeping state off the flash, Pull & Up, and the Ollama (local/cloud) AI DJ.',
+  path: '/setup/unraid',
+});
+
+export default function UnraidSetupPage() {
+  return <Unraid />;
+}

--- a/web/components/setup/Unraid.tsx
+++ b/web/components/setup/Unraid.tsx
@@ -12,25 +12,120 @@ STATE_DIR=/mnt/user/appdata/subwave/state
 CADDY_PORT=7700
 TZ=Europe/London`;
 
+const TEMPLATE_URL =
+  'https://raw.githubusercontent.com/perminder-klair/subwave/main/templates/subwave.xml';
+
 export default function Unraid() {
   return (
     <SetupPage
       eyebrow="SETUP · UNRAID"
       title="Run it on Unraid."
-      intro="SUB/WAVE is a multi-container Compose stack, so on Unraid it runs through the Compose Manager Plus plugin — not as individual Community Applications templates. It uses the same docker-compose.yml as every other host, so there's nothing Unraid-specific to drift. Start to on-air is about five minutes."
+      intro="Two supported paths. The easy one: install the one-click all-in-one container from Community Applications. The flexible one: run the full Compose stack via Compose Manager Plus (separate containers, BYO reverse proxy, optional heavy-TTS sidecar). Both finish in the same browser wizard. Start to on-air is about five minutes."
       current="/setup/unraid"
     >
       <section className="bs-section">
         <div className="bs-callout">
-          <div className="bs-eyebrow">WHY NOT THE APPS STORE?</div>
+          <div className="bs-eyebrow">TWO WAYS TO RUN IT</div>
           <p>
-            Community Applications is a single-container catalogue — it can&apos;t
-            one-click a Compose stack. <strong>Compose Manager Plus</strong> is the
-            supported way to run one, and because it reuses the maintained{' '}
-            <code className="bs-code-inline">docker-compose.yml</code>, you stay on
-            the same images and upgrade path as everyone else.
+            <strong>One-click (Community Applications)</strong> — the all-in-one
+            image bundles the whole stack into a single container behind one
+            port. Easiest; recommended for most people.{' '}
+            <strong>Full Compose stack (Compose Manager Plus)</strong> — the
+            maintained{' '}
+            <code className="bs-code-inline">docker-compose.yml</code> as
+            separate broadcast / controller / web / Caddy services. Pick it for
+            isolated containers, your own proxy, or the heavy-TTS sidecar.
           </p>
         </div>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">OPTION 1 — ONE-CLICK</p>
+        <h2>Community Applications.</h2>
+        <p>
+          The Apps catalogue is one container per template, so the{' '}
+          <code className="bs-code-inline">subwave-aio</code> image bundles
+          icecast2 + liquidsoap, the controller, the web UI and a Caddy edge
+          together. Same images as the Compose stack — just packaged into one.
+        </p>
+
+        <div className="bs-step">
+          <div className="bs-step-num">01</div>
+          <div className="bs-step-body">
+            <h3>Install &amp; fill the fields</h3>
+            <p>
+              <strong>Apps</strong> tab &rarr; search{' '}
+              <strong>SUB/WAVE</strong> &rarr; <strong>Install</strong>, then set:
+            </p>
+            <ul className="bs-list">
+              <li>
+                <strong>WebUI Port</strong> — host port for the UI + stream
+                (default <code className="bs-code-inline">7700</code>).
+              </li>
+              <li>
+                <strong>Appdata</strong> —{' '}
+                <code className="bs-code-inline">/mnt/user/appdata/subwave</code>,
+                on the array/pool (<em>not</em> the flash).
+              </li>
+              <li>
+                <strong>ADMIN_USER</strong> / <strong>ADMIN_PASS</strong> — your
+                admin login; the password is <strong>required</strong>.
+              </li>
+              <li>
+                <strong>SITE_URL</strong> —{' '}
+                <code className="bs-code-inline">http://YOUR-UNRAID-IP:7700</code>.
+              </li>
+            </ul>
+            <div className="bs-callout">
+              <div className="bs-eyebrow">KEEP APPDATA OFF THE FLASH</div>
+              <p>
+                SUB/WAVE&apos;s state grows — hourly archives, the library cache,
+                rendered voices. Point <strong>Appdata</strong> at{' '}
+                <code className="bs-code-inline">/mnt/user/appdata/subwave</code>{' '}
+                on your pool/array, never{' '}
+                <code className="bs-code-inline">/boot/…</code>.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="bs-step">
+          <div className="bs-step-num">02</div>
+          <div className="bs-step-body">
+            <h3>Finish setup in the browser</h3>
+            <CodeBlock>{`open http://YOUR-UNRAID-IP:7700/onboarding`}</CodeBlock>
+            <p>
+              Sign in with the{' '}
+              <code className="bs-code-inline">ADMIN_USER</code> /{' '}
+              <code className="bs-code-inline">ADMIN_PASS</code> you set, and the
+              wizard collects the rest — Navidrome, the LLM provider, TTS, the DJ
+              persona. The player is at{' '}
+              <code className="bs-code-inline">http://YOUR-UNRAID-IP:7700</code>.
+            </p>
+          </div>
+        </div>
+
+        <div className="bs-callout">
+          <div className="bs-eyebrow">NOT IN THE STORE YET?</div>
+          <p>
+            Until the listing is approved (or to try a pre-release), add it
+            directly: <strong>Docker</strong> tab &rarr;{' '}
+            <strong>Add Container</strong> &rarr; paste this into{' '}
+            <strong>Template URL</strong>, then fill the same fields.
+          </p>
+          <CodeBlock>{TEMPLATE_URL}</CodeBlock>
+        </div>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">OPTION 2 — FULL COMPOSE STACK</p>
+        <h2>Compose Manager Plus.</h2>
+        <p>
+          Run the maintained{' '}
+          <code className="bs-code-inline">docker-compose.yml</code> as separate
+          services — good for isolated containers, your own Traefik/SWAG/NPM in
+          front, or the optional Chatterbox/PocketTTS sidecar.
+        </p>
 
         <div className="bs-step">
           <div className="bs-step-num">01</div>
@@ -126,12 +221,8 @@ export default function Unraid() {
             <h3>Finish setup in the browser</h3>
             <CodeBlock>{`open http://YOUR-UNRAID-IP:7700/onboarding`}</CodeBlock>
             <p>
-              Sign in with the{' '}
-              <code className="bs-code-inline">ADMIN_USER</code> /{' '}
-              <code className="bs-code-inline">ADMIN_PASS</code> you set, and the
-              wizard collects the rest — Navidrome, the LLM provider, TTS, the DJ
-              persona. The player is at{' '}
-              <code className="bs-code-inline">http://YOUR-UNRAID-IP:7700</code>.
+              Same wizard as the one-click path — Navidrome, the LLM provider,
+              TTS, the DJ persona.
             </p>
           </div>
         </div>
@@ -141,7 +232,7 @@ export default function Unraid() {
         <div className="bs-callout">
           <div className="bs-eyebrow">THE AI DJ — OLLAMA, LOCAL OR CLOUD</div>
           <p>
-            SUB/WAVE ships a first-class{' '}
+            Applies to both options. SUB/WAVE ships a first-class{' '}
             <strong>&ldquo;Ollama — local/cloud&rdquo;</strong> provider. Most
             Unraid boxes lack a big GPU, so the nicest path is Ollama&apos;s{' '}
             <strong>cloud models</strong>, which offload inference — even a
@@ -177,19 +268,18 @@ export default function Unraid() {
               <strong>No reverse proxy needed</strong> for LAN use — Caddy fronts{' '}
               <code className="bs-code-inline">/</code>,{' '}
               <code className="bs-code-inline">/api</code>, and{' '}
-              <code className="bs-code-inline">/stream.mp3</code> on the single{' '}
-              <code className="bs-code-inline">CADDY_PORT</code>. Want TLS + a
-              hostname behind SWAG / NPM / Traefik? Front{' '}
-              <code className="bs-code-inline">CADDY_PORT</code> with it, or use{' '}
+              <code className="bs-code-inline">/stream.mp3</code> on the single
+              host port. Want TLS + a hostname behind SWAG / NPM / Traefik? Front
+              that port with it, or (Compose stack) use{' '}
               <code className="bs-code-inline">docker-compose.byo.yml</code>.
             </li>
             <li>
-              <strong>Updates:</strong> stack menu &rarr; <strong>Pull &amp; Up</strong>{' '}
-              (or <strong>Check for Updates</strong>).
+              <strong>Updates:</strong> one-click &rarr; Unraid&apos;s normal{' '}
+              <strong>Check for Updates</strong>. Compose stack &rarr; stack menu
+              &rarr; <strong>Pull &amp; Up</strong>.
             </li>
             <li>
-              <strong>Backups:</strong> everything lives under{' '}
-              <code className="bs-code-inline">STATE_DIR</code> —
+              <strong>Backups:</strong> everything lives under the appdata path —
               settings, library cache, archives, voices. Back up{' '}
               <code className="bs-code-inline">/mnt/user/appdata/subwave</code>.
             </li>
@@ -201,7 +291,7 @@ export default function Unraid() {
         <p className="bs-eyebrow">WHAT&apos;S NEXT</p>
         <h2>Keep it running.</h2>
         <p>
-          The stack is on the air. When a new version lands, head to{' '}
+          The station is on the air. When a new version lands, head to{' '}
           <Link href="/setup/updates" className="bs-link">Updates &amp; Help</Link>{' '}
           for the update workflow and the troubleshooting checklist.
         </p>

--- a/web/components/setup/Unraid.tsx
+++ b/web/components/setup/Unraid.tsx
@@ -1,0 +1,211 @@
+import Link from 'next/link';
+import SetupPage from './SetupPage';
+import CodeBlock from "@/components/CodeBlock";
+
+const UNRAID_ENV_TEMPLATE = `# Required — the three boot keys
+ADMIN_USER=admin
+ADMIN_PASS=replace-me-with-a-strong-string   # openssl rand -hex 16
+SITE_URL=http://YOUR-UNRAID-IP:7700
+
+# Unraid-specific — keep state OFF the flash drive
+STATE_DIR=/mnt/user/appdata/subwave/state
+CADDY_PORT=7700
+TZ=Europe/London`;
+
+export default function Unraid() {
+  return (
+    <SetupPage
+      eyebrow="SETUP · UNRAID"
+      title="Run it on Unraid."
+      intro="SUB/WAVE is a multi-container Compose stack, so on Unraid it runs through the Compose Manager Plus plugin — not as individual Community Applications templates. It uses the same docker-compose.yml as every other host, so there's nothing Unraid-specific to drift. Start to on-air is about five minutes."
+      current="/setup/unraid"
+    >
+      <section className="bs-section">
+        <div className="bs-callout">
+          <div className="bs-eyebrow">WHY NOT THE APPS STORE?</div>
+          <p>
+            Community Applications is a single-container catalogue — it can&apos;t
+            one-click a Compose stack. <strong>Compose Manager Plus</strong> is the
+            supported way to run one, and because it reuses the maintained{' '}
+            <code className="bs-code-inline">docker-compose.yml</code>, you stay on
+            the same images and upgrade path as everyone else.
+          </p>
+        </div>
+
+        <div className="bs-step">
+          <div className="bs-step-num">01</div>
+          <div className="bs-step-body">
+            <h3>Install Compose Manager Plus</h3>
+            <p>
+              On the <strong>Apps</strong> tab, search{' '}
+              <code className="bs-code-inline">Compose Manager Plus</code> (by{' '}
+              <code className="bs-code-inline">mstrhakr</code>) and install the
+              stable release. It adds a <strong>Compose</strong> section to the{' '}
+              <strong>Docker</strong> tab. You&apos;ll also want Docker enabled and
+              the array (or a pool) started so there&apos;s somewhere for appdata.
+            </p>
+          </div>
+        </div>
+
+        <div className="bs-step">
+          <div className="bs-step-num">02</div>
+          <div className="bs-step-body">
+            <h3>Create the stack</h3>
+            <p>
+              <strong>Docker</strong> tab &rarr; <strong>Compose</strong> &rarr;{' '}
+              <strong>Add New Stack</strong> &rarr; name it{' '}
+              <code className="bs-code-inline">subwave</code> &rarr;{' '}
+              <strong>Edit Stack</strong>.
+            </p>
+            <ul className="bs-list">
+              <li>
+                <strong>Compose</strong> tab — paste the contents of the default{' '}
+                <Link
+                  href="https://raw.githubusercontent.com/perminder-klair/subwave/main/docker-compose.yml"
+                  className="bs-link"
+                >
+                  docker-compose.yml
+                </Link>
+                . Five containers; only Caddy binds a host port (
+                <code className="bs-code-inline">:7700</code>). The optional{' '}
+                <code className="bs-code-inline">tts-heavy</code> sidecar is
+                profile-gated and won&apos;t start — the DJ falls back to the
+                built-in Piper voice.
+              </li>
+              <li>
+                <strong>.env</strong> tab — the three required keys plus two
+                Unraid-specific ones:
+              </li>
+            </ul>
+            <CodeBlock lang="env">{UNRAID_ENV_TEMPLATE}</CodeBlock>
+            <div className="bs-callout">
+              <div className="bs-eyebrow">KEEP STATE OFF THE FLASH</div>
+              <p>
+                Compose Manager&apos;s project directory lives on the USB flash
+                (<code className="bs-code-inline">/boot/…</code>), so the compose
+                default of <code className="bs-code-inline">./state</code> would
+                write SUB/WAVE&apos;s growing state — hourly archives, the library
+                cache, rendered voices — onto the boot stick. Set{' '}
+                <code className="bs-code-inline">STATE_DIR</code> to an absolute
+                appdata path on your pool/array (
+                <code className="bs-code-inline">/mnt/user/appdata/subwave/state</code>
+                ); Docker creates it on first start.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="bs-step">
+          <div className="bs-step-num">03</div>
+          <div className="bs-step-body">
+            <h3>Pull &amp; Up</h3>
+            <p>
+              From the stack&apos;s action menu pick <strong>Pull &amp; Up</strong>{' '}
+              (not plain <em>Compose Up</em>), then flip the stack&apos;s{' '}
+              <strong>Autostart &rarr; ON</strong> so it survives reboots.
+            </p>
+            <div className="bs-callout">
+              <div className="bs-eyebrow">WHY PULL &amp; UP</div>
+              <p>
+                The compose file carries{' '}
+                <code className="bs-code-inline">build:</code> blocks so a source
+                checkout can rebuild locally. The Unraid project directory has no
+                source, so a plain <em>up</em> would try to build and fail.{' '}
+                <strong>Pull &amp; Up</strong> fetches the prebuilt images from
+                GHCR first, then starts them. (Alternatively, delete the{' '}
+                <code className="bs-code-inline">build:</code> blocks and plain{' '}
+                <em>up</em> works too.)
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="bs-step">
+          <div className="bs-step-num">04</div>
+          <div className="bs-step-body">
+            <h3>Finish setup in the browser</h3>
+            <CodeBlock>{`open http://YOUR-UNRAID-IP:7700/onboarding`}</CodeBlock>
+            <p>
+              Sign in with the{' '}
+              <code className="bs-code-inline">ADMIN_USER</code> /{' '}
+              <code className="bs-code-inline">ADMIN_PASS</code> you set, and the
+              wizard collects the rest — Navidrome, the LLM provider, TTS, the DJ
+              persona. The player is at{' '}
+              <code className="bs-code-inline">http://YOUR-UNRAID-IP:7700</code>.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="bs-section">
+        <div className="bs-callout">
+          <div className="bs-eyebrow">THE AI DJ — OLLAMA, LOCAL OR CLOUD</div>
+          <p>
+            SUB/WAVE ships a first-class{' '}
+            <strong>&ldquo;Ollama — local/cloud&rdquo;</strong> provider. Most
+            Unraid boxes lack a big GPU, so the nicest path is Ollama&apos;s{' '}
+            <strong>cloud models</strong>, which offload inference — even a
+            low-power box (e.g. an Intel N95) handles them fine:
+          </p>
+          <ul className="bs-list">
+            <li>
+              Install the official <code className="bs-code-inline">ollama</code>{' '}
+              container from the Apps tab (defaults are right: port{' '}
+              <code className="bs-code-inline">11434</code>, appdata{' '}
+              <code className="bs-code-inline">/mnt/user/appdata/ollama</code>).
+            </li>
+            <li>
+              Open its <strong>Console</strong> and run{' '}
+              <code className="bs-code-inline">ollama signin</code>; approve the
+              printed link in your browser (cloud models need a subscription).
+            </li>
+            <li>
+              In <strong>admin &rarr; Settings &rarr; LLM Provider</strong>: set
+              provider <strong>Ollama — local/cloud</strong>, server URL{' '}
+              <code className="bs-code-inline">http://host.docker.internal:11434</code>
+              , and a <code className="bs-code-inline">:cloud</code> model tag (e.g.{' '}
+              <code className="bs-code-inline">glm-5.2:cloud</code>) — or a small
+              local tag like{' '}
+              <code className="bs-code-inline">llama3.2:3b</code> to run on CPU.
+            </li>
+          </ul>
+        </div>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">GOOD TO KNOW</div>
+          <ul className="bs-list">
+            <li>
+              <strong>No reverse proxy needed</strong> for LAN use — Caddy fronts{' '}
+              <code className="bs-code-inline">/</code>,{' '}
+              <code className="bs-code-inline">/api</code>, and{' '}
+              <code className="bs-code-inline">/stream.mp3</code> on the single{' '}
+              <code className="bs-code-inline">CADDY_PORT</code>. Want TLS + a
+              hostname behind SWAG / NPM / Traefik? Front{' '}
+              <code className="bs-code-inline">CADDY_PORT</code> with it, or use{' '}
+              <code className="bs-code-inline">docker-compose.byo.yml</code>.
+            </li>
+            <li>
+              <strong>Updates:</strong> stack menu &rarr; <strong>Pull &amp; Up</strong>{' '}
+              (or <strong>Check for Updates</strong>).
+            </li>
+            <li>
+              <strong>Backups:</strong> everything lives under{' '}
+              <code className="bs-code-inline">STATE_DIR</code> —
+              settings, library cache, archives, voices. Back up{' '}
+              <code className="bs-code-inline">/mnt/user/appdata/subwave</code>.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">WHAT&apos;S NEXT</p>
+        <h2>Keep it running.</h2>
+        <p>
+          The stack is on the air. When a new version lands, head to{' '}
+          <Link href="/setup/updates" className="bs-link">Updates &amp; Help</Link>{' '}
+          for the update workflow and the troubleshooting checklist.
+        </p>
+      </section>
+    </SetupPage>
+  );
+}

--- a/web/components/setup/pages.ts
+++ b/web/components/setup/pages.ts
@@ -15,6 +15,7 @@ export const SETUP_PAGES: SetupPageEntry[] = [
   { href: '/setup/prerequisites', label: 'Prerequisites' },
   { href: '/setup/quick-start', label: 'Quick Start' },
   { href: '/setup/manual', label: 'Manual Install' },
+  { href: '/setup/unraid', label: 'Unraid' },
   { href: '/setup/development', label: 'Development' },
   { href: '/setup/updates', label: 'Updates & Help' },
 ];


### PR DESCRIPTION
Adds the Unraid deployment story end to end — docs plus a one-click Apps-store install.

## Docs (original scope)
- `docs/unraid.md` + `/setup/unraid` page: running SUB/WAVE on Unraid.
- CONTRIBUTING base-branch fix (develop).

## One-click Apps-store install (new)
- **`docker/Dockerfile.aio`** — a single `subwave-aio` image running the whole stack (icecast2 + liquidsoap, the controller, the Next.js web UI, Caddy) under one bash supervisor (`docker/aio/supervisor.sh`), exposing one port. Internal URLs are repointed at loopback via env; no app behaviour forks. **Multi-arch amd64 + arm64.**
- **`ca_profile.xml` + `templates/subwave.xml`** at the repo root — the Community Applications submission files, versioned with the app. Icon + screenshots reuse existing in-repo assets.
- **`publish-images.yml`** now builds + pushes `subwave-aio` on `v*` tags.
- **Docs reframed to two paths** — one-click from the Apps store (new), or the Compose Manager Plus split-container stack (kept as the advanced path). Drops the old "can't be in the Apps store" framing.
- **`docs/unraid-ca-submission.md`** — maintainer runbook for publishing the image + submitting at ca.unraid.net.

## Verified
- AIO image built + ran locally (amd64): `/api/health` → on-air, all routes `200`, `/stream.mp3` serving live audio, all 5 services up under the supervisor, no crash loops.
- `ca_profile.xml` + `templates/subwave.xml` pass `xmllint`; web + controller lint green.

## After merge
The develop → main release tags `vX.Y.Z` → `publish-images.yml` publishes `subwave-aio:latest` (multi-arch). Then make the GHCR package public and submit at ca.unraid.net — see `docs/unraid-ca-submission.md`.
