### PR TITLE
release: Unraid one-click install, DJ persona dials + fixes

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,6 +1,6 @@
 name: Publish images
 
-# Builds and pushes the five first-party SUB/WAVE images to GHCR.
+# Builds and pushes the first-party SUB/WAVE images to GHCR.
 #
 # Triggers:
 #   - push of a tag like v1.2.3 → versioned release (also tagged :latest)
@@ -11,6 +11,8 @@ name: Publish images
 #   ghcr.io/<owner>/subwave-broadcast   (icecast2 + liquidsoap + radio.liq + sounds/)
 #   ghcr.io/<owner>/subwave-controller
 #   ghcr.io/<owner>/subwave-web
+#   ghcr.io/<owner>/subwave-aio         (whole stack in one container — the Unraid
+#                                        Community Applications one-click image)
 #   ghcr.io/<owner>/subwave-tts-heavy   (optional Chatterbox + PocketTTS sidecar, ~3-4GB)
 #
 # Platforms: the core four images (caddy, broadcast, controller, web) are
@@ -48,6 +50,17 @@ jobs:
             platforms: linux/amd64,linux/arm64
           - image: subwave-web
             dockerfile: web/Dockerfile
+            platforms: linux/amd64,linux/arm64
+          # The Unraid one-click image: the whole stack (icecast2 + liquidsoap,
+          # controller, web, Caddy) in one container, supervised by
+          # docker/aio/supervisor.sh. Multi-arch like the split-stack images —
+          # amd64 (x86-64, every Unraid box) plus arm64 (ARM servers / Apple
+          # Silicon). Dockerfile.aio selects the matching Piper build via
+          # $TARGETARCH; Kokoro/onnx, node, icecast2 and the liquidsoap base all
+          # have arm64 builds. The arm64 variant cross-builds under QEMU, so this
+          # is the slowest image in the matrix.
+          - image: subwave-aio
+            dockerfile: docker/Dockerfile.aio
             platforms: linux/amd64,linux/arm64
           - image: subwave-tts-heavy
             dockerfile: docker/Dockerfile.tts-heavy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Open an issue with:
 
 ## Pull requests
 
-- Branch off `main` and keep PRs focused on one change.
+- Branch off `develop` (the integration branch) and target it in your PR — keep PRs focused on one change.
 - Explain the *why*, not just the *what*, in the description.
 - If you touch the queue/playback path, `radio.liq`, the crossfade, ducking, or
   the LLM layer, read the relevant note in `CLAUDE.md` first — those areas have
@@ -54,12 +54,13 @@ A scope in parens (`fix(ui): …`, `feat(controller): …`) is optional but help
 when skimming the changelog. Use `!` after the type, or a `BREAKING CHANGE:`
 footer, for anything that breaks compatibility.
 
-PR titles follow the same convention — squash-merging then produces a clean
-commit on `main` that release-please can read.
+PR titles follow the same convention — squash-merging keeps history clean, and
+the commit carries through `develop` → `main`, where release-please reads it.
 
 ## Releases
 
-You don't cut releases by hand. On every push to `main`, the **Release Please**
+You don't cut releases by hand. Maintainers merge `develop` into `main` to ship;
+on every push to `main`, the **Release Please**
 workflow opens (or updates) a release PR that bumps `package.json` +
 `CHANGELOG.md` based on the Conventional Commits since the last tag. Merging
 that PR creates a `vX.Y.Z` tag and a GitHub Release, which triggers

--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ the canonical path: `curl` two files, fill in three vars, `docker compose
 up -d`, finish setup in the browser. See **[`DEPLOY.md`](DEPLOY.md)** for host
 prerequisites, Cloudflare setup, updates, and backup.
 
+**On Unraid?** Run it through the Compose Manager Plus plugin — see
+**[`docs/unraid.md`](docs/unraid.md)**.
+
 **Bring your own reverse proxy.** If you already run Traefik, nginx, or your
 own Caddy in your homelab, swap the bundled-Caddy compose for the BYO variant:
 
@@ -247,6 +250,7 @@ bin/subwave        Operator CLI entry: setup, status, doctor, lifecycle, play
 ## Documentation
 
 - **[`DEPLOY.md`](DEPLOY.md):** production deployment, updates, backup.
+- **[`docs/unraid.md`](docs/unraid.md):** running on Unraid via the Compose Manager Plus plugin.
 - **[`CLAUDE.md`](CLAUDE.md):** deep architecture reference and the
   non-obvious constraints behind each subsystem.
 - **[`CONTRIBUTING.md`](CONTRIBUTING.md):** how to contribute.

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "SUB/WAVE",
     "slug": "subwave",
     "scheme": "subwave",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/ca_profile.xml
+++ b/ca_profile.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<CommunityApplications>
+  <!-- Maintainer profile shown on the SUB/WAVE author page in Community Apps.
+       This repo IS the SUB/WAVE source repo; the CA submission files live at the
+       root alongside it (ca_profile.xml + templates/). See
+       docs/unraid-ca-submission.md. -->
+  <Profile>
+## SUB/WAVE
+
+A personal internet radio station: **one Icecast stream that every listener
+hears together**, with an **AI DJ** that picks tracks from your own
+Navidrome / Subsonic library and reads scripts between them — station IDs,
+the time, the weather, listener requests.
+
+This template installs the **one-click all-in-one image** (`subwave-aio`): the
+entire stack — icecast2 + liquidsoap, the controller (the DJ brain), the
+Next.js web UI, and a Caddy edge — runs in a **single container** exposing one
+port. After installing, finish setup in your browser at `/onboarding`
+(Navidrome, the LLM provider, the voice, the DJ persona).
+
+- **Project &amp; full docs:** https://github.com/perminder-klair/subwave
+- **Support / issues:** https://github.com/perminder-klair/subwave/issues
+
+> Prefer the full split-container deployment (separate broadcast / controller /
+> web / Caddy services, BYO reverse proxy)? Run the maintained
+> `docker-compose.yml` via the Compose Manager Plus plugin instead — see
+> docs/unraid.md.
+  </Profile>
+  <Icon>https://raw.githubusercontent.com/perminder-klair/subwave/main/app/assets/icon.png</Icon>
+  <WebPage>https://github.com/perminder-klair/subwave</WebPage>
+</CommunityApplications>

--- a/controller/scripts/embedding-preflight-test.ts
+++ b/controller/scripts/embedding-preflight-test.ts
@@ -96,8 +96,19 @@ for (const msg of [
   ok('message points at the fix', /--embeddings|pooling|embedding model/i.test(r.message));
 }
 
-// ---- 3. library-db dim handling (#2) --------------------------------------
-console.log('\n[3] library-db honours the stored dim');
+// ---- 3. chat-only provider → no_embeddings (#493) -------------------------
+// openrouter / deepseek / gateway have no embeddings endpoint; buildEmbeddingModel
+// throws synchronously (no network), so this is classified offline.
+console.log('\n[3] a chat-only provider is classified no_embeddings (offline)');
+for (const provider of ['openrouter', 'deepseek', 'gateway']) {
+  S.embedding = { enabled: true, provider, model: '', apiKey: '', baseUrl: '', ollamaUrl: '' };
+  const r = await embeddings.ensureReady();
+  ok(`${provider} → no_embeddings`, r.code === 'no_embeddings', `code=${r.code}`);
+  ok(`${provider} message names the real fix`, /chat-only|embedding-capable|Ollama/i.test(r.message));
+}
+
+// ---- 4. library-db dim handling (#2) --------------------------------------
+console.log('\n[4] library-db honours the stored dim');
 // Seed a 768-d DB the way the tagger would.
 await db.open({ embeddingDim: 768, reseed: false });
 db.setEmbeddingMeta('ollama:nomic-embed-text', 768);

--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -14,6 +14,7 @@ import { agentPlan } from '../src/llm/internal/strategy/plan.js';
 import { introBudgetPhrase, enforceIntroBudget } from '../src/llm/internal/prompts/intro-budget.js';
 import { embeddingBaseUrl } from '../src/llm/internal/provider/embedding.js';
 import { DEFAULT_LOCCA_EMBED_BASE_URL } from '../src/llm/internal/provider/registry.js';
+import { personaToneDirectives, normalizeDial, DIAL_NEUTRAL, validatePersonasStrict } from '../src/settings.js';
 
 let failures = 0;
 function test(name: string, fn: () => void | Promise<void>) {
@@ -213,6 +214,47 @@ async function main() {
     assert.ok(sentences.endsWith('.') && sentences.split(/\s+/).length <= 10);        // last full sentence
     const hardcut = enforceIntroBudget('a b c d e f g h i j k l m n o p q r s t', 4000);
     assert.ok(hardcut.endsWith('…') && hardcut.split(/\s+/).length <= 11);            // ellipsis fallback
+  });
+
+  // ---- persona tone dials (humour / local colour / warmth) ----
+  console.log('personaToneDirectives / normalizeDial:');
+  await test('normalizeDial clamps to 0-10 int, neutral on garbage', () => {
+    assert.equal(normalizeDial(7), 7);
+    assert.equal(normalizeDial(-3), 0);
+    assert.equal(normalizeDial(99), 10);
+    assert.equal(normalizeDial(6.7), 7);
+    assert.equal(normalizeDial('abc'), DIAL_NEUTRAL);
+    assert.equal(normalizeDial(undefined), DIAL_NEUTRAL);
+  });
+  await test('neutral / missing dials append nothing (prompt stays byte-identical)', () => {
+    assert.equal(personaToneDirectives({ humour: 5, localColour: 5, warmth: 5 }), '');
+    assert.equal(personaToneDirectives({}), '');
+    assert.equal(personaToneDirectives(null), '');
+    assert.equal(personaToneDirectives({ humour: 4, localColour: 6 }), '');
+  });
+  await test('low/high bands append the matching directive, in dial order', () => {
+    assert.match(personaToneDirectives({ humour: 9 }), /playful wit/);
+    assert.match(personaToneDirectives({ humour: 1 }), /Play it straight/);
+    assert.match(personaToneDirectives({ localColour: 10 }), /local setting/);
+    assert.match(personaToneDirectives({ warmth: 0 }), /cool, dry distance/);
+    const both = personaToneDirectives({ humour: 8, warmth: 8 });
+    assert.ok(both.startsWith('\n\nTone:\n- '));
+    assert.equal(both.split('\n- ').length, 3); // header + 2 bullets
+  });
+  // The save path (validatePersonasStrict) rebuilds each persona from a field
+  // whitelist; if the dials aren't in it they are silently dropped on every
+  // save and the feature is dead end-to-end. Pin that they round-trip.
+  await test('validatePersonasStrict carries the dials through the save path', () => {
+    const base = { name: 'Nova', soul: 'late-night', frequency: 'moderate',
+      tts: { engine: 'piper', cloudProvider: 'openai', voice: '' } };
+    const [saved] = validatePersonasStrict([{ ...base, humour: 9, localColour: 0, warmth: 99 }]);
+    assert.equal(saved.humour, 9);
+    assert.equal(saved.localColour, 0);
+    assert.equal(saved.warmth, 10);            // clamped, same as normalizeDial
+    const [bare] = validatePersonasStrict([base]);
+    assert.equal(bare.humour, DIAL_NEUTRAL);   // absent dials default to neutral
+    assert.equal(bare.localColour, DIAL_NEUTRAL);
+    assert.equal(bare.warmth, DIAL_NEUTRAL);
   });
 
   console.log(failures === 0 ? '\nAll llm-pure tests passed.' : `\n${failures} test(s) FAILED.`);

--- a/controller/src/config.ts
+++ b/controller/src/config.ts
@@ -193,10 +193,10 @@ export const config = {
     recentPlaysMax: 300,
   },
   weather: {
-    // Wolverhampton — your home location
-    lat: 52.5862,
-    lng: -2.1288,
-    locationName: 'Wolverhampton',
+    // Punjab (Chandigarh) — your home location
+    lat: 30.7333,
+    lng: 76.7794,
+    locationName: 'Punjab',
     // 'metric' → Celsius, 'imperial' → Fahrenheit. Drives Open-Meteo's
     // temperature_unit query param and what unit the DJ announces on air.
     units: 'metric' as 'metric' | 'imperial',

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -22,6 +22,7 @@ export {
   generateHourlyTime,
 } from './internal/prompts/scripts.js';
 export { PICKER_CRITERIA, pickNextTrack, showMusicLean } from './internal/prompts/picker.js';
+export { generatePersona, generateShow, generateTheme } from './internal/prompts/generate.js';
 
 // Re-exported so routes/debug.js can read the LLM call ring buffer through the
 // same module that produces the calls.

--- a/controller/src/llm/internal/prompts/generate.ts
+++ b/controller/src/llm/internal/prompts/generate.ts
@@ -1,0 +1,121 @@
+// Create-form auto-fill — turns a free-text description ("a late-night jazz host
+// with a dry wit", "a Sunday-morning gospel show", "a warm sepia newspaper
+// theme") into a draft persona / show / theme the admin UI pre-fills for review.
+// Same structured-output path as matchRequest (djObject → Zod), so it rides the
+// operator's configured station LLM with no extra keys. The schemas are
+// constrained to the SAME enums the settings/theme validators enforce, so a
+// generated draft round-trips through Save without surprises.
+
+import { z } from 'zod';
+import { FREQUENCIES, SCRIPT_LENGTHS, SHOW_MOODS, SHOW_ENERGY } from '../../../settings.js';
+import { THEME_TOKEN_KEYS } from '../../../themes.js';
+import { djObject } from '../strategy/object.js';
+
+// ---------------------------------------------------------------------------
+// Persona
+// ---------------------------------------------------------------------------
+
+const PERSONA_SCHEMA = z.object({
+  name: z.string().min(1).max(40).describe('the DJ name shown in the player — 1-3 words, evocative, never generic like "DJ" or "Host"'),
+  tagline: z.string().max(80).describe('a short one-line descriptor shown next to the name (e.g. "atmospheric & immersive"), 0-80 chars; "" if none fits'),
+  soul: z.string().min(1).max(400).describe('the personality/voice sketch the DJ speaks with — tone, sensibility, quirks, the kind of imagery they reach for. 1-3 sentences, max 400 chars. Concrete and specific, not a list of adjectives.'),
+  frequency: z.enum(FREQUENCIES as [string, ...string[]]).describe('how chatty: quiet (rarely talks), moderate, or aggressive (talks a lot)'),
+  scriptLength: z.enum(SCRIPT_LENGTHS as [string, ...string[]]).describe('concise (one or two lines) or extended (longer riffs)'),
+  djMode: z.boolean().describe('true if this host works the desk like a real radio DJ — back-announces tracks, teases what is coming, more present; false for a quieter selector'),
+  language: z.string().max(60).describe('the language the DJ speaks on air if the description implies a non-English host (e.g. "Turkish", "Punjabi"); "" for English'),
+});
+
+const PERSONA_SYSTEM = `You design on-air radio DJ personalities for a personal internet radio station. Given a free-text description, produce a single coherent DJ persona: a memorable name, a short tagline, and a vivid "soul" (the voice and sensibility they present with). Match the requested vibe, era, and language. Keep the soul specific and human — no corporate filler, no "your number one source for hits". If the description names or implies a non-English host, set language to that language (in English, e.g. "Turkish"); otherwise leave it "".`;
+
+export async function generatePersona(description: string) {
+  return djObject({
+    system: PERSONA_SYSTEM,
+    prompt: `Description of the DJ the operator wants:\n"${description}"\n\nDesign the persona.`,
+    schema: PERSONA_SCHEMA,
+    temperature: 0.8,
+    kind: 'generatePersona',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Show
+// ---------------------------------------------------------------------------
+
+interface ShowCtx {
+  personas?: { id: string; name: string }[];
+  themes?: { id: string; name: string }[];
+  genres?: string[];
+}
+
+const SHOW_SCHEMA = z.object({
+  name: z.string().min(1).max(60).describe('the show name shown in the schedule — punchy, 1-4 words'),
+  topic: z.string().max(1000).describe('the brief the AI DJ reads before the slot: genres, eras, moods, artists, time of day, listener type, host tone. 1-4 sentences, max 1000 chars.'),
+  mood: z.enum(SHOW_MOODS as [string, ...string[]]).describe('the single closest music mood for this show'),
+  genre: z.string().max(64).describe('a music genre lean if one fits (e.g. "jazz", "gospel", "lofi"); "" for no lean. Prefer a genre present in the supplied library list when relevant.'),
+  fromYear: z.number().int().nullable().describe('start year of an era window if the show targets a decade (e.g. 1970), else null'),
+  toYear: z.number().int().nullable().describe('end year of that era window (e.g. 1979), else null'),
+  energy: z.enum(['', ...SHOW_ENERGY] as [string, ...string[]]).describe('soft energy steer: low, medium, high, or "" for any'),
+  personaId: z.string().nullable().describe('the id of the persona that best fits this show, chosen from the supplied persona list, or null if unsure'),
+  themeId: z.string().nullable().describe('the id of a per-show theme override chosen from the supplied theme list, or null for the station default'),
+});
+
+const SHOW_SYSTEM = `You design radio shows for a personal internet radio station. Given a free-text description, produce a single show definition: a name, a DJ brief (topic), a music mood, an optional genre lean and era window, an energy steer, and the best-matching persona and (optional) theme from the supplied lists. Pick personaId / themeId ONLY from the ids given; use null when nothing clearly fits. The mood MUST be one of the listed moods. Keep the topic concrete and useful as a brief — name the kind of music, the moment of day, and the tone.`;
+
+export async function generateShow(description: string, ctx: ShowCtx = {}) {
+  const lines: string[] = [];
+  if (ctx.personas?.length) {
+    lines.push('Available personas (id — name):');
+    for (const p of ctx.personas) lines.push(`  ${p.id} — ${p.name}`);
+  }
+  if (ctx.themes?.length) {
+    lines.push('Available themes (id — name):');
+    for (const t of ctx.themes) lines.push(`  ${t.id} — ${t.name}`);
+  }
+  if (ctx.genres?.length) {
+    lines.push(`Genres present in the library (sample): ${ctx.genres.slice(0, 40).join(', ')}`);
+  }
+  lines.push(`Allowed moods: ${SHOW_MOODS.join(', ')}`);
+
+  return djObject({
+    system: SHOW_SYSTEM,
+    prompt: `Description of the show the operator wants:\n"${description}"\n\n${lines.join('\n')}\n\nDesign the show.`,
+    schema: SHOW_SCHEMA,
+    temperature: 0.7,
+    kind: 'generateShow',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Theme
+// ---------------------------------------------------------------------------
+
+// CSS color value the theme validator (themes.ts TOKEN_VAL_RE) will accept:
+// hex, rgb()/rgba(), or a plain named color. No semicolons/braces/angle
+// brackets, ≤100 chars. We keep the model on hex/rgb to stay safely inside it.
+const COLOR = z.string().regex(/^[^;{}<>]{1,100}$/);
+
+const THEME_SCHEMA = z.object({
+  name: z.string().min(1).max(60).describe('a short human theme name (e.g. "Sepia Press")'),
+  description: z.string().max(200).describe('a one-line blurb describing the look, "" if none'),
+  tokens: z.object({
+    '--bg': COLOR.describe('page background'),
+    '--ink': COLOR.describe('primary text — MUST contrast strongly with --bg for readability'),
+    '--muted': COLOR.describe('secondary/muted text — lower contrast than --ink but still legible on --bg'),
+    '--accent': COLOR.describe('accent / interactive highlight color'),
+    '--overlay': COLOR.describe('subtle wash used for hover/overlay — an rgba() with low alpha works well'),
+    '--soft-border': COLOR.describe('hairline border color, close to --bg'),
+    '--field': COLOR.describe('input/field surface, slightly off from --bg'),
+  }).describe('the 7 CSS custom-property color values for the theme'),
+});
+
+const THEME_SYSTEM = `You are a UI color designer. Given a free-text vibe and a light/dark mode, produce a coherent, accessible color theme as 7 CSS custom properties. Use hex (#rrggbb) or rgb()/rgba() values only — never named colors, gradients, or anything with semicolons or braces. Ensure --ink reads clearly against --bg (strong contrast); --muted is a softer but still legible version; --accent stands out; --overlay is a low-alpha rgba wash; --soft-border and --field sit close to --bg. Respect the requested mode: a dark theme has a dark --bg and light text, a light theme the reverse.`;
+
+export async function generateTheme(description: string, mode: 'light' | 'dark') {
+  return djObject({
+    system: THEME_SYSTEM,
+    prompt: `Requested look: "${description}"\nMode: ${mode}\n\nThe token keys to fill are exactly: ${THEME_TOKEN_KEYS.join(', ')}.\n\nDesign the theme.`,
+    schema: THEME_SCHEMA,
+    temperature: 0.7,
+    kind: 'generateTheme',
+  });
+}

--- a/controller/src/llm/internal/provider/embedding.ts
+++ b/controller/src/llm/internal/provider/embedding.ts
@@ -144,11 +144,22 @@ export function buildEmbeddingModel(cfg: EmbeddingCfg) {
       const provider = createGoogleGenerativeAI(cfg.apiKey ? { apiKey: cfg.apiKey } : {});
       return provider.textEmbeddingModel(id);
     }
-    case 'ollama':
-    default: {
+    case 'ollama': {
       const provider = createOllama({ baseURL: ollamaBaseUrl(cfg as any) });
       return provider.textEmbeddingModel(id);
     }
+    default:
+      // openrouter / deepseek / gateway (and any future chat-only provider) have
+      // no embeddings endpoint. Previously these fell through to the ollama
+      // branch, silently pointed at a local Ollama, and failed with a misleading
+      // "can't reach <provider>" (#493). Throw an honest error so the probe +
+      // tagger preflight name the real problem. The picker already hides these
+      // (settings.EMBEDDING_PROVIDERS) — this guards the API/JSON path.
+      throw new Error(
+        `Provider "${cfg.provider}" has no text-embedding support. Pick an ` +
+          `embedding-capable provider in Settings → Library tagger → Embedding ` +
+          `(ollama, openai, google, locca, or openai-compatible).`,
+      );
   }
 }
 

--- a/controller/src/music/embeddings.ts
+++ b/controller/src/music/embeddings.ts
@@ -110,6 +110,7 @@ export type ProbeCode =
   | 'unauthorized'        // 401 — typically cloud-routed Ollama or wrong API key
   | 'unreachable'         // connection refused / DNS / timeout
   | 'not_embedding_model' // server reached, but it's a chat model / no pooling (#319)
+  | 'no_embeddings'       // provider is chat-only — no embeddings endpoint at all (#493)
   | 'bad_url'             // baseUrl missing/malformed — fetch can't parse the URL
   | 'unknown';            // anything else — message has the raw error
 
@@ -125,6 +126,12 @@ function classifyEmbeddingError(err: any): { code: ProbeCode; raw: string } {
   const raw = err?.message || String(err);
   const status = err?.cause?.status_code ?? err?.statusCode ?? err?.status;
   const txt = raw.toLowerCase();
+  // buildEmbeddingModel throws this for chat-only providers (openrouter /
+  // deepseek / gateway) that have no embeddings endpoint at all (#493). Check
+  // before the network-shaped codes — it's a config error, not a reachability one.
+  if (txt.includes('has no text-embedding support')) {
+    return { code: 'no_embeddings', raw };
+  }
   if (status === 404 || txt.includes('not found') || txt.includes('try pulling')) {
     return { code: 'not_found', raw };
   }
@@ -207,6 +214,15 @@ function actionableMessage(
         );
       }
       return `Can't reach provider "${provider}" — check network / baseUrl. (${raw})`;
+    case 'no_embeddings':
+      return (
+        `Provider "${provider}" is chat-only — it has no embeddings endpoint, so the\n` +
+        `  library tagger can't use it. (The DJ still works on "${provider}".)\n` +
+        `  Pick an embedding-capable provider in /admin/settings → Embedding:\n` +
+        `    • Ollama   — local + free (ollama pull nomic-embed-text; auto-pulled)\n` +
+        `    • OpenAI / Google — cloud (needs the matching API key)\n` +
+        `    • locca / openai-compatible — your own embedding server`
+      );
     case 'not_embedding_model':
       if (provider === 'openai-compatible' || provider === 'locca') {
         const startCmd =

--- a/controller/src/routes/generate.ts
+++ b/controller/src/routes/generate.ts
@@ -1,0 +1,83 @@
+// Admin-gated "describe it → draft it" endpoints. Each takes a free-text
+// description and returns a draft entity (persona / show / theme) for the create
+// forms to pre-fill. Nothing is persisted here — the operator reviews, edits,
+// and saves through the normal /settings (or /themes) path. Generation rides the
+// operator's configured station LLM via the llm/dj generate* wrappers.
+import express from 'express';
+import { requireAdmin } from '../middleware/auth.js';
+import * as dj from '../llm/dj.js';
+import * as settings from '../settings.js';
+import * as library from '../music/library.js';
+import { listThemes } from '../themes.js';
+
+export const router = express.Router();
+
+const DESC_MAX = 400;
+
+function readDescription(req: express.Request): string {
+  return (typeof req.body?.description === 'string' ? req.body.description : '')
+    .trim()
+    .slice(0, DESC_MAX);
+}
+
+// POST /generate/persona — { description } → { ok, persona }
+router.post('/generate/persona', requireAdmin, async (req, res) => {
+  const description = readDescription(req);
+  if (!description) return res.status(400).json({ error: 'description is required' });
+  try {
+    const out = await dj.generatePersona(description);
+    res.json({ ok: true, persona: out });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /generate/show — { description } → { ok, show }
+// The route assembles the persona/theme/mood/genre context itself so the client
+// only sends a description.
+router.post('/generate/show', requireAdmin, async (req, res) => {
+  const description = readDescription(req);
+  if (!description) return res.status(400).json({ error: 'description is required' });
+  try {
+    const s = settings.get();
+    const personas = (s.personas || []).map((p: any) => ({ id: p.id, name: p.name }));
+    const themes = (await listThemes()).map(t => ({ id: t.id, name: t.name }));
+    let genres: string[] = [];
+    try {
+      await library.load();
+      genres = Object.keys(library.stats().byGenre || {});
+    } catch {}
+
+    const out = await dj.generateShow(description, { personas, themes, genres });
+    const draft = { ...out };
+
+    // Soft-normalise against the real lists — a near-miss from a weaker model
+    // becomes null/default rather than an invalid id the Save would reject.
+    const personaIds = new Set(personas.map(p => p.id));
+    if (!draft.personaId || !personaIds.has(draft.personaId)) {
+      draft.personaId = personas[0]?.id ?? null;
+    }
+    const themeIds = new Set(themes.map(t => t.id));
+    if (!draft.themeId || !themeIds.has(draft.themeId)) draft.themeId = null;
+    if (!settings.SHOW_MOODS.includes(draft.mood)) draft.mood = settings.SHOW_MOODS[0];
+    if (draft.energy && !settings.SHOW_ENERGY.includes(draft.energy)) draft.energy = '';
+
+    res.json({ ok: true, show: draft });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /generate/theme — { description, mode } → { ok, theme }
+// Returns tokens for review; persisting is POST /themes.
+router.post('/generate/theme', requireAdmin, async (req, res) => {
+  const description = readDescription(req);
+  if (!description) return res.status(400).json({ error: 'description is required' });
+  const mode = req.body?.mode === 'light' ? 'light' : 'dark';
+  try {
+    const out = await dj.generateTheme(description, mode);
+    res.json({ ok: true, theme: { ...out, mode } });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -17,7 +17,7 @@ import { invalidateWeatherCache } from '../context.js';
 import { requireAdmin } from '../middleware/auth.js';
 import { tagger } from '../broadcast/tagger.js';
 import { skillCatalog } from '../skills/_agent.js';
-import { clearUserThemeCache, loadUserThemes, listThemes } from '../themes.js';
+import { clearUserThemeCache, loadUserThemes, listThemes, saveUserTheme } from '../themes.js';
 
 export const router = express.Router();
 
@@ -279,5 +279,20 @@ router.post('/themes/refresh', requireAdmin, async (req, res) => {
     res.json({ ok: true, themes });
   } catch (err) {
     res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /themes — create/overwrite a user theme as ${STATE_DIR}/themes/<id>.json.
+// Body: { id?, name, description?, mode, tokens }. The id is derived from the
+// name when absent. Validated by the shared ThemeSchema (token security regex);
+// reserved built-in ids are rejected. Returns the refreshed registry.
+// ---------------------------------------------------------------------------
+router.post('/themes', requireAdmin, async (req, res) => {
+  try {
+    const themes = await saveUserTheme(req.body || {});
+    res.json({ ok: true, themes });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
   }
 });

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -104,6 +104,12 @@ router.get('/settings', requireAdmin, async (req, res) => {
         providers: settings.LLM_PROVIDERS,
         active: llmProvider.activeModelLabel(),
       },
+      embedding: {
+        // Embedding-capable providers only — a strict subset of llm.providers.
+        // The picker maps over this so chat-only providers (openrouter, deepseek,
+        // gateway) can't be chosen as an embedding source (#493).
+        providers: settings.EMBEDDING_PROVIDERS,
+      },
       search: {
         providers: settings.SEARCH_PROVIDERS,
       },

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -33,6 +33,7 @@ import { router as personasRoutes } from './routes/personas.js';
 import { router as backupRoutes } from './routes/backup.js';
 import { router as audienceRoutes } from './routes/audience.js';
 import { router as systemRoutes } from './routes/system.js';
+import { router as generateRoutes } from './routes/generate.js';
 import { loadSecretsIntoEnv } from './setup/secrets.js';
 import { loadSetupConfig } from './setup/config.js';
 import { getSetupStatus } from './setup/firstRun.js';
@@ -66,6 +67,7 @@ app.use(personasRoutes);
 app.use(backupRoutes);
 app.use(audienceRoutes);
 app.use(systemRoutes);
+app.use(generateRoutes);
 
 // (manual skip is not implemented in this build — Liquidsoap controls pacing)
 

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -178,6 +178,23 @@ export const LLM_PROVIDERS = [
   'gateway',
 ];
 
+// Subset of LLM_PROVIDERS that can actually produce text embeddings — the
+// library tagger embeds every track (music/embeddings.ts), and several chat
+// providers route chat ONLY: openrouter, deepseek and the Vercel AI gateway
+// have no embeddings endpoint. Offering them in the embedding-provider picker
+// silently fell through to a local Ollama and failed with a misleading
+// "can't reach <provider>" error (#493). `anthropic` stays in — it has no
+// first-party embedding model, but llm/internal/provider/embedding.ts routes it
+// to OpenAI (needs OPENAI_API_KEY), as the picker hint already explains.
+export const EMBEDDING_PROVIDERS = [
+  'ollama',
+  'openai-compatible',
+  'locca',
+  'anthropic',
+  'openai',
+  'google',
+];
+
 // Coerce a stored Ollama context-window value. 0 disables (use Ollama's own
 // default); any other number is clamped to a sane [2048, 131072] band and
 // floored to an integer. Non-numeric/NaN falls back to `def`. Shared by the

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -31,7 +31,7 @@ export const DEFAULT_DJ_PROMPT_TEMPLATE = `You are {name}, the on-air DJ for {st
 Hard rules:
 - Output ONLY the words to be spoken aloud. No stage directions, no asterisks, no quotes around your dialogue.
 - Keep it to 2-4 sentences unless asked for longer.
-- Never say "and now", "next up", "coming up next" — those are tells. Be more natural.
+- Never use radio-cliché tells: "and now", "next up", "coming up next", "and that was", or back-announcing with "that was [song] by [artist]". Be more natural.
 - Don't repeat the artist and title robotically. Reference them in passing if at all.
 - Reference the actual context (time, weather, what's coming) naturally.
 - Vary your opener and shape every time — never start the same way twice in a row, never use the same metaphor or framing as your last few lines.`;
@@ -55,6 +55,51 @@ export const FREQUENCIES = ['quiet', 'moderate', 'aggressive'];
 // 'extended' roughly doubles every spoken segment for a storytelling DJ.
 // See llm/dj.js LENGTH_PHRASES for the actual length directives.
 export const SCRIPT_LENGTHS = ['concise', 'extended'];
+
+// Per-persona tone dials. Each is 0-10 with 5 (DIAL_NEUTRAL) the default. A
+// model can't distinguish humour=6 from 7, so rather than inject a raw "7/10"
+// the dial maps to three bands: 0-3 low, 7-10 high, 4-6 neutral. Only a band
+// away from neutral appends a style directive (personaToneDirectives below), so
+// a persona left at the defaults renders a byte-identical prompt to before.
+export const TONE_DIALS = ['humour', 'localColour', 'warmth'] as const;
+export const DIAL_NEUTRAL = 5;
+
+const TONE_DIAL_PHRASES: Record<string, { low: string; high: string }> = {
+  humour: {
+    low: 'Play it straight; keep any wit rare and understated.',
+    high: 'Lean into dry, playful wit; an aside or a wink is welcome.',
+  },
+  localColour: {
+    low: 'Keep it universal; skip local references and place-specific colour.',
+    high: 'Lean on the local setting (the town, the weather, the hour) as texture.',
+  },
+  warmth: {
+    low: 'Keep a cool, dry distance; let the music carry the warmth.',
+    high: 'Be warm and earnest; speak to the listener like a friend.',
+  },
+};
+
+// Clamp any input to an integer 0-10, defaulting to neutral when unparseable.
+// The single chokepoint used by both normalizePersona and the seed roster.
+export function normalizeDial(v: any): number {
+  const n = Math.round(Number(v));
+  return Number.isFinite(n) ? Math.min(10, Math.max(0, n)) : DIAL_NEUTRAL;
+}
+
+// Pure: persona in, prompt fragment out. Returns '' when every dial sits in the
+// neutral band, so renderDjPrompt appends nothing and the default prompt is
+// unchanged. Unit-pinned in controller/scripts/llm-pure.test.ts.
+export function personaToneDirectives(persona: any): string {
+  if (!persona || typeof persona !== 'object') return '';
+  const lines: string[] = [];
+  for (const key of TONE_DIALS) {
+    const v = Number((persona as any)[key]);
+    if (!Number.isFinite(v)) continue;
+    if (v <= 3) lines.push(TONE_DIAL_PHRASES[key].low);
+    else if (v >= 7) lines.push(TONE_DIAL_PHRASES[key].high);
+  }
+  return lines.length ? `\n\nTone:\n- ${lines.join('\n- ')}` : '';
+}
 
 // DJ mode makes a persona behave like a working radio DJ rather than a
 // between-track narrator: it back-announces AND teases what's next, runs
@@ -726,6 +771,9 @@ function normalizePersona(raw: any) {
     frequency: FREQUENCIES.includes(raw.frequency) ? raw.frequency : 'moderate',
     scriptLength: SCRIPT_LENGTHS.includes(raw.scriptLength) ? raw.scriptLength : 'concise',
     djMode: raw.djMode === true,
+    humour: normalizeDial(raw.humour),
+    localColour: normalizeDial(raw.localColour),
+    warmth: normalizeDial(raw.warmth),
     soul,
     language: typeof raw.language === 'string' ? raw.language.trim().slice(0, 60) : '',
     avatar,
@@ -1285,7 +1333,7 @@ function validateTtsBlock(raw, where) {
   return { engine: t.engine, cloudProvider: t.cloudProvider, voice, gainDb: clampTtsGain(t.gainDb) };
 }
 
-function validatePersonasStrict(raw) {
+export function validatePersonasStrict(raw) {
   if (!Array.isArray(raw) || raw.length < 1 || raw.length > PERSONA_LIMIT) {
     throw new Error(`personas must be an array of 1-${PERSONA_LIMIT} entries`);
   }
@@ -1383,6 +1431,9 @@ function validatePersonasStrict(raw) {
       frequency: item.frequency,
       scriptLength,
       djMode,
+      humour: normalizeDial(item.humour),
+      localColour: normalizeDial(item.localColour),
+      warmth: normalizeDial(item.warmth),
       soul,
       language,
       avatar,
@@ -2133,11 +2184,12 @@ export function renderDjPrompt(persona: any, ctx: any = {}) {
     .replaceAll('{soul}', persona?.soul || DJ_SOULS[0])
     .replaceAll('{station}', station)
     .replaceAll('{location}', location);
+  const tone = personaToneDirectives(persona);
   if (tpl.includes('{language}')) {
     const lang = String(persona?.language || '').trim();
-    return rendered.replaceAll('{language}', lang || 'English');
+    return rendered.replaceAll('{language}', lang || 'English') + tone;
   }
-  return rendered + languageDirective(persona);
+  return rendered + languageDirective(persona) + tone;
 }
 
 // Persona prelude shared by every tool-loop agent system prompt — the picker

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -453,7 +453,7 @@ const DEFAULTS = {
   // 44.1→48k resample, so operators opt in rather than pay that CPU unasked.
   // The mandatory /stream.mp3 mount always serves everyone.
   stream: { opusEnabled: false },
-  weather: { lat: 52.5862, lng: -2.1288, locationName: 'Wolverhampton', units: 'metric' as 'metric' | 'imperial' },
+  weather: { lat: 30.7333, lng: 76.7794, locationName: 'Punjab', units: 'metric' as 'metric' | 'imperial' },
   // Operator-facing station name. Substituted into the DJ prompt's {station}
   // placeholder and returned by GET /dj for the landing page. The product is
   // still called SUB/WAVE — this is what the operator's station running on it

--- a/controller/src/themes.ts
+++ b/controller/src/themes.ts
@@ -206,3 +206,36 @@ export async function isValidThemeId(id: string): Promise<boolean> {
   const all = await listThemes();
   return all.some(t => t.id === id);
 }
+
+// Turn a human name into a valid theme id (lowercase, dash-separated, ≤32
+// chars, leading alphanumeric) so the create form can derive one when the
+// operator doesn't supply it. Falls back to "theme" if nothing survives.
+export function slugifyThemeId(name: string): string {
+  const slug = String(name || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 32)
+    .replace(/-+$/g, '');
+  return /^[a-z0-9]/.test(slug) ? slug : `t-${slug}`.slice(0, 32) || 'theme';
+}
+
+// Persist an operator-created theme as ${STATE_DIR}/themes/<id>.json, the same
+// shape the file-drop convention uses. Validates with the shared ThemeSchema
+// (so the token security regex applies), refuses reserved built-in ids, then
+// refreshes the user cache and returns the full registry.
+export async function saveUserTheme(input: any): Promise<Theme[]> {
+  const id = (typeof input?.id === 'string' && input.id.trim())
+    ? slugifyThemeId(input.id)
+    : slugifyThemeId(input?.name || '');
+  const theme = ThemeSchema.parse({ ...input, id });
+  if (BUILTIN_IDS.has(theme.id)) {
+    throw new Error(`"${theme.id}" is a reserved built-in theme id — pick another name`);
+  }
+  const dir = userThemesDir();
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(join(dir, `${theme.id}.json`), JSON.stringify(theme, null, 2), 'utf8');
+  clearUserThemeCache();
+  await loadUserThemes(true);
+  return listThemes();
+}

--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -1,0 +1,141 @@
+# SUB/WAVE all-in-one image — the entire stack in a single container.
+#
+# Why this exists: Unraid's Community Applications catalogue is strictly one
+# container per template, so the five-service compose stack can't be listed
+# there directly. This image collapses icecast2 + liquidsoap (broadcast), the
+# controller, the Next.js web UI, and Caddy into one container supervised by
+# docker/aio/supervisor.sh, exposing a single port (80, fronted by Caddy). It's
+# also handy anywhere you'd rather run `docker run` once than orchestrate five
+# services (Synology, a plain VPS, Portainer one-shot).
+#
+# The split-stack images (subwave-{caddy,broadcast,controller,web}) remain the
+# canonical deployment. This is an additional packaging of the same source —
+# nothing here forks app behaviour; it only repoints internal URLs at loopback
+# (see docker/aio/supervisor.sh) and bakes in a loopback Caddyfile.
+#
+# NOT bundled (to keep the image lean): the optional tts-heavy engines
+# (Chatterbox / PocketTTS) and the docker-socket-proxy Stats panel. Both degrade
+# gracefully — TTS falls back to the bundled Piper voice, the Stats system panel
+# simply hides. Piper + Kokoro are included, so the DJ has a natural voice.
+
+# ---- web build: Next.js standalone (mirrors web/Dockerfile) ----------------
+FROM node:22-bookworm-slim AS webbuild
+WORKDIR /web
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+COPY web/ ./
+ENV NEXT_TELEMETRY_DISABLED=1
+# SITE_URL is frozen into statically-rendered routes (robots, sitemap, OG cards)
+# at build time. For the AIO it's unknown until the operator sets it, so we bake
+# the localhost fallback; the force-dynamic homepage still reads the runtime
+# SITE_URL env for live share-card tags.
+ARG SITE_URL
+ENV SITE_URL=${SITE_URL}
+RUN npm run build
+
+# ---- caddy binary: lift the glibc build from the official Debian image ------
+FROM caddy:2 AS caddybin
+
+# ---- final: everything under the liquidsoap (Debian bookworm) base ----------
+FROM savonet/liquidsoap:v2.2.5
+
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System packages:
+#  - icecast2: the broadcast server (apt also creates the icecast2 user)
+#  - sudo: lets the supervisor drop privileges to icecast2 / liquidsoap
+#  - openssl: first-boot icecast secret generation
+#  - curl/ca-certificates: liquidsoap's HTTPS Subsonic fetch + health probes
+#  - espeak-ng/libsndfile1: Kokoro phonemisation + audio I/O
+#  - ffmpeg: jingle/SFX transcode on import (audio/audio-import.ts)
+#  - python3/python3-venv: the Kokoro worker venv
+#  - wget/tar/xz-utils: Piper + Kokoro model/binary pulls
+#  - gnupg: NodeSource apt key
+RUN apt-get update -qq \
+ && apt-get install -y --no-install-recommends \
+        icecast2 sudo openssl curl ca-certificates \
+        espeak-ng libsndfile1 ffmpeg \
+        python3 python3-venv \
+        wget tar xz-utils gnupg \
+ && rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 (NodeSource) — runs both the controller (tsx) and the web server.
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/*
+
+# Caddy — the loopback edge.
+COPY --from=caddybin /usr/bin/caddy /usr/local/bin/caddy
+
+ARG WGET_RETRY="--tries=5 --retry-connrefused --waitretry=10 --timeout=60 --retry-on-http-error=429,500,502,503,504"
+
+# --- Piper (default TTS, ~30ms/word) ---------------------------------------
+# TARGETARCH is set by buildx; empty on a plain `docker build` → treat as amd64.
+ARG PIPER_VERSION=2023.11.14-2
+ARG TARGETARCH
+RUN cd /tmp && \
+    case "${TARGETARCH}" in \
+      amd64|"") piper_arch=x86_64 ;; \
+      arm64)    piper_arch=aarch64 ;; \
+      *) echo "unsupported TARGETARCH=${TARGETARCH} for Piper" >&2; exit 1 ;; \
+    esac && \
+    wget -q ${WGET_RETRY} https://github.com/rhasspy/piper/releases/download/${PIPER_VERSION}/piper_linux_${piper_arch}.tar.gz && \
+    tar -xzf piper_linux_${piper_arch}.tar.gz -C /opt && \
+    ln -s /opt/piper/piper /usr/local/bin/piper && \
+    rm piper_linux_${piper_arch}.tar.gz
+RUN mkdir -p /opt/piper/voices && \
+    wget -q ${WGET_RETRY} -O /opt/piper/voices/en_GB-alan-medium.onnx \
+      https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/alan/medium/en_GB-alan-medium.onnx && \
+    wget -q ${WGET_RETRY} -O /opt/piper/voices/en_GB-alan-medium.onnx.json \
+      https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/alan/medium/en_GB-alan-medium.onnx.json
+
+# --- Kokoro (optional second TTS, more natural) ----------------------------
+RUN python3 -m venv /opt/kokoro/venv && \
+    /opt/kokoro/venv/bin/pip install --no-cache-dir --upgrade pip && \
+    /opt/kokoro/venv/bin/pip install --no-cache-dir \
+      kokoro-onnx==0.4.9 soundfile==0.12.1
+RUN mkdir -p /opt/kokoro/models && \
+    wget -q ${WGET_RETRY} -O /opt/kokoro/models/kokoro-v1.0.onnx \
+      https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx && \
+    wget -q ${WGET_RETRY} -O /opt/kokoro/models/voices-v1.0.bin \
+      https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/voices-v1.0.bin
+ENV KOKORO_MODEL=/opt/kokoro/models/kokoro-v1.0.onnx \
+    KOKORO_VOICES=/opt/kokoro/models/voices-v1.0.bin \
+    KOKORO_PYTHON=/opt/kokoro/venv/bin/python
+
+# --- Controller app ---------------------------------------------------------
+WORKDIR /app
+COPY controller/package*.json ./
+RUN npm install --omit=dev
+COPY controller/src ./src
+COPY controller/scripts ./scripts
+
+# --- Web app (standalone build from the webbuild stage) ---------------------
+# Mirrors web/Dockerfile's runner layout, rooted at /web instead of /app.
+COPY --from=webbuild /web/.next/standalone /web
+COPY --from=webbuild /web/.next/static /web/.next/static
+COPY --from=webbuild /web/public /web/public
+
+# --- Broadcast + edge config + bundled audio --------------------------------
+COPY docker/icecast.xml.template /etc/icecast2/icecast.xml.template
+COPY liquidsoap/radio.liq /etc/liquidsoap/radio.liq
+COPY sounds /sounds
+COPY docker/aio/Caddyfile /etc/caddy/Caddyfile
+COPY docker/aio/supervisor.sh /usr/local/bin/subwave-supervisor
+RUN chmod +x /usr/local/bin/subwave-supervisor
+
+# Shared state dir (the supervisor re-asserts perms on every boot).
+RUN mkdir -p /var/sub-wave && chmod 777 /var/sub-wave
+
+ENV NODE_ENV=production \
+    STATE_DIR=/var/sub-wave \
+    SOUNDS_DIR=/sounds
+
+# Single public port: Caddy on :80. Health = the controller's liveness via the
+# edge, which only answers once web + controller are both up.
+EXPOSE 80
+HEALTHCHECK --interval=15s --timeout=5s --start-period=40s --retries=6 \
+    CMD curl -fsS http://localhost:80/api/health > /dev/null || exit 1
+
+ENTRYPOINT ["/usr/local/bin/subwave-supervisor"]

--- a/docker/aio/Caddyfile
+++ b/docker/aio/Caddyfile
@@ -1,0 +1,47 @@
+# Caddy edge router for the SUB/WAVE all-in-one image (docker/Dockerfile.aio).
+#
+# Unlike the split-stack docker/Caddyfile, every backend lives in THIS SAME
+# container, so the upstreams are loopback addresses rather than compose service
+# names. The route table is otherwise identical: one origin on :80, split by URL
+# prefix. The single host port the Unraid template maps points here.
+#
+# No Cloudflare trusted_proxies block — the AIO is aimed at LAN / self-hosted
+# use behind whatever reverse proxy the operator already runs (or none at all).
+{
+	auto_https off
+}
+
+:80 {
+	# /stream.mp3 + /stream.opus — Icecast (served by liquidsoap → icecast on
+	# 7702). flush_interval -1 keeps the never-ending audio body live.
+	@streams path /stream.mp3 /stream.opus
+	handle @streams {
+		reverse_proxy 127.0.0.1:7702 {
+			flush_interval -1
+			transport http {
+				read_buffer 16KB
+				response_header_timeout 30s
+				dial_timeout 5s
+			}
+		}
+	}
+
+	# /api/* — controller REST API (prefix stripped so its routes stay at root).
+	handle_path /api/* {
+		reverse_proxy 127.0.0.1:7701
+	}
+
+	# Everything else → Next.js web UI.
+	handle {
+		reverse_proxy 127.0.0.1:7700
+	}
+
+	# Don't gzip the already-compressed live audio mounts.
+	@compressible not path /stream.mp3 /stream.opus
+	encode @compressible gzip zstd
+
+	log {
+		output stdout
+		format console
+	}
+}

--- a/docker/aio/supervisor.sh
+++ b/docker/aio/supervisor.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# SUB/WAVE all-in-one supervisor.
+#
+# Runs the whole stack — icecast2 + liquidsoap (the broadcast pair), the
+# controller, the Next.js web UI, and Caddy — inside ONE container for the
+# Unraid Community Applications one-click image (docker/Dockerfile.aio).
+#
+# The split-stack deployment runs these as five compose services wired over an
+# internal network; here they all share localhost and the /var/sub-wave volume,
+# so the file-based IPC (next.txt / say.txt / now-playing.json …) works exactly
+# as before with no code changes — only a handful of *_HOST/*_URL env overrides
+# repoint the controller at loopback.
+#
+# Each service runs in its own restart loop, so a web or controller crash does
+# NOT take the station off the air. The icecast+liquidsoap pair is launched as a
+# unit (mirroring docker/broadcast-entrypoint.sh): if either dies the pair is
+# bounced together, because liquidsoap is useless without its icecast sink.
+#
+# Bash (not /bin/sh) for `wait -n`; the savonet/liquidsoap base ships bash.
+set -u
+
+SECRETS=/var/sub-wave/icecast-secrets.env
+TEMPLATE=/etc/icecast2/icecast.xml.template
+RENDERED=/etc/icecast2/icecast.xml
+
+log() { echo "[subwave-aio] $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# One-time state bootstrap — shared dirs, watch-mode m3u stubs, archive ignore.
+# Same responsibilities as docker/broadcast-entrypoint.sh, minus launching the
+# audio processes (the supervisor does that in a restart loop below). Mode 777
+# because the services run under different uids (icecast2 / liquidsoap / root).
+# ---------------------------------------------------------------------------
+init_state() {
+	mkdir -p /var/sub-wave \
+	         /var/sub-wave/voice \
+	         /var/sub-wave/voices \
+	         /var/sub-wave/archive \
+	         /var/sub-wave/jingles \
+	         /var/sub-wave/logs \
+	         /var/sub-wave/sessions \
+	         /var/sub-wave/sfx
+	chmod 777 /var/sub-wave \
+	          /var/sub-wave/voice \
+	          /var/sub-wave/voices \
+	          /var/sub-wave/archive \
+	          /var/sub-wave/jingles \
+	          /var/sub-wave/logs \
+	          /var/sub-wave/sessions \
+	          /var/sub-wave/sfx
+
+	# Liquidsoap's reload_mode="watch" playlists need the files to exist.
+	touch /var/sub-wave/auto.m3u /var/sub-wave/jingles.m3u
+	chmod 666 /var/sub-wave/auto.m3u /var/sub-wave/jingles.m3u
+
+	# Keep a co-located Navidrome from scanning the station's own hourly
+	# archive mixdowns as junk "HH-00" tracks (issue #273).
+	touch /var/sub-wave/archive/.ndignore
+
+	# Liquidsoap writes radio.log here as the liquidsoap user.
+	mkdir -p /var/log/liquidsoap
+	chown -R liquidsoap:liquidsoap /var/log/liquidsoap 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Resolve the three ICECAST_*_PASSWORD values and render icecast.xml.
+# Precedence (unchanged from broadcast-entrypoint): env override > persisted
+# state/icecast-secrets.env > freshly generated. Resolved values are exported
+# (liquidsoap reads ICECAST_SOURCE_PASSWORD from the environment) and written
+# back to the secrets file for operator visibility + the documented rotate path.
+# ---------------------------------------------------------------------------
+init_secrets() {
+	local ENV_SRC="${ICECAST_SOURCE_PASSWORD:-}"
+	local ENV_ADM="${ICECAST_ADMIN_PASSWORD:-}"
+	local ENV_REL="${ICECAST_RELAY_PASSWORD:-}"
+
+	if [ -f "$SECRETS" ]; then
+		# shellcheck disable=SC1090
+		. "$SECRETS"
+	fi
+
+	[ -n "$ENV_SRC" ] && ICECAST_SOURCE_PASSWORD="$ENV_SRC"
+	[ -n "$ENV_ADM" ] && ICECAST_ADMIN_PASSWORD="$ENV_ADM"
+	[ -n "$ENV_REL" ] && ICECAST_RELAY_PASSWORD="$ENV_REL"
+
+	[ -z "${ICECAST_SOURCE_PASSWORD:-}" ] && ICECAST_SOURCE_PASSWORD="$(openssl rand -hex 16)"
+	[ -z "${ICECAST_ADMIN_PASSWORD:-}"  ] && ICECAST_ADMIN_PASSWORD="$(openssl rand -hex 16)"
+	[ -z "${ICECAST_RELAY_PASSWORD:-}"  ] && ICECAST_RELAY_PASSWORD="$(openssl rand -hex 16)"
+
+	cat > "$SECRETS" <<-EOF
+		ICECAST_SOURCE_PASSWORD=$ICECAST_SOURCE_PASSWORD
+		ICECAST_ADMIN_PASSWORD=$ICECAST_ADMIN_PASSWORD
+		ICECAST_RELAY_PASSWORD=$ICECAST_RELAY_PASSWORD
+	EOF
+	chmod 644 "$SECRETS"
+
+	export ICECAST_SOURCE_PASSWORD ICECAST_ADMIN_PASSWORD ICECAST_RELAY_PASSWORD
+	# Liquidsoap connects to icecast over loopback inside this container;
+	# radio.liq reads ICECAST_HOST (default "icecast").
+	export ICECAST_HOST=localhost
+
+	sed \
+		-e "s|\${ICECAST_SOURCE_PASSWORD}|$ICECAST_SOURCE_PASSWORD|g" \
+		-e "s|\${ICECAST_ADMIN_PASSWORD}|$ICECAST_ADMIN_PASSWORD|g" \
+		-e "s|\${ICECAST_RELAY_PASSWORD}|$ICECAST_RELAY_PASSWORD|g" \
+		"$TEMPLATE" > "$RENDERED"
+	chown icecast2 "$RENDERED" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Service launchers. Each blocks until its process exits, so the supervise()
+# loop can restart it. Do NOT `exec` — that would replace the loop.
+# ---------------------------------------------------------------------------
+
+# icecast2 + liquidsoap as a unit. Returns when either dies (the loop bounces
+# the pair). icecast runs as the icecast2 user; liquidsoap as the liquidsoap
+# user (uid 10000). `sudo -E` preserves the resolved ICECAST_* env.
+run_broadcast() {
+	log "starting icecast2"
+	sudo -E -u icecast2 icecast2 -n -c "$RENDERED" &
+	local ic=$!
+
+	# Give icecast a moment to accept HTTP so liquidsoap's first source
+	# connect doesn't bail with "Cannot connect to remote host".
+	local i
+	for i in 1 2 3 4 5 6 7 8 9 10; do
+		if curl -fsS http://localhost:7702/ >/dev/null 2>&1; then
+			log "icecast accepting connections after ${i}s"
+			break
+		fi
+		sleep 1
+	done
+
+	log "starting liquidsoap"
+	sudo -E -u liquidsoap liquidsoap /etc/liquidsoap/radio.liq &
+	local lq=$!
+
+	wait -n "$ic" "$lq"
+	local code=$?
+	log "broadcast pair: a child exited ($code) — taking the other down"
+	kill -TERM "$ic" "$lq" 2>/dev/null || true
+	wait "$ic" "$lq" 2>/dev/null || true
+	return "$code"
+}
+
+# Controller — the AI DJ brain. The *_HOST/*_URL overrides repoint it from the
+# compose service names (broadcast:7702 / 1234) at loopback. DOCKER_HOST and
+# TTS_HEAVY_URL are intentionally unset: the Stats system panel degrades
+# gracefully and TTS falls back to the bundled Piper voice. All other config
+# (Navidrome, LLM, ADMIN_*, SITE_URL, TZ) is inherited from the container env
+# and the first-run wizard's settings.json.
+run_controller() {
+	cd /app || return 1
+	export NODE_ENV=production \
+	       STATE_DIR=/var/sub-wave \
+	       SOUNDS_DIR=/sounds \
+	       LIQUIDSOAP_HOST=127.0.0.1 \
+	       ICECAST_STATUS_URL=http://127.0.0.1:7702/status-json.xsl \
+	       ICECAST_ADMIN_URL=http://127.0.0.1:7702/admin/listclients
+	node_modules/.bin/tsx src/server.ts
+}
+
+# Web — Next.js listener UI (standalone build).
+run_web() {
+	cd /web || return 1
+	export NODE_ENV=production \
+	       PORT=7700 \
+	       HOSTNAME=0.0.0.0 \
+	       CONTROLLER_INTERNAL_URL=http://127.0.0.1:7701 \
+	       SUBWAVE_HOMEPAGE="${SUBWAVE_HOMEPAGE:-player}"
+	node server.js
+}
+
+# Caddy — the single-origin edge that fronts all three on :80.
+run_caddy() {
+	caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
+}
+
+# ---------------------------------------------------------------------------
+# supervise <name> <launcher-fn> — restart loop with backoff.
+# ---------------------------------------------------------------------------
+supervise() {
+	local name="$1"; shift
+	while true; do
+		log "starting $name"
+		"$@"
+		local code=$?
+		log "$name exited ($code) — restarting in 3s"
+		sleep 3
+	done
+}
+
+# ---------------------------------------------------------------------------
+# Boot.
+# ---------------------------------------------------------------------------
+init_state
+init_secrets
+
+# On stop, signal the whole process group once and bail (reset the trap first
+# so the kill doesn't re-enter this handler).
+trap 'trap "" TERM INT; log "shutting down"; kill -TERM 0 2>/dev/null; exit 0' TERM INT
+
+supervise broadcast  run_broadcast  &
+supervise controller run_controller &
+supervise web        run_web        &
+supervise caddy      run_caddy      &
+
+wait

--- a/docs/unraid-ca-submission.md
+++ b/docs/unraid-ca-submission.md
@@ -1,0 +1,78 @@
+# Submitting SUB/WAVE to Unraid Community Applications
+
+Maintainer runbook. The CA submission files live at the **root of this repo** —
+`ca_profile.xml` + `templates/subwave.xml` — so the app and its store listing
+stay versioned together. The runnable artifact is the `subwave-aio` image
+(`docker/Dockerfile.aio`), published from this same repo.
+
+## What the scanner reads
+
+```
+subwave/
+├── ca_profile.xml          # maintainer profile (overview, icon, web page)
+├── LICENSE                 # MIT (already here)
+├── README.md               # used as the listing's "readme first"
+└── templates/subwave.xml   # the single Container v2 template (one image)
+```
+
+Icon + screenshots are referenced by raw URL from existing in-repo assets
+(`app/assets/icon.png`, `web/public/screenshots/*.webp`) — nothing duplicated.
+
+## 1. Publish the `subwave-aio` image
+
+Built by `.github/workflows/publish-images.yml` (matrix entry `subwave-aio`,
+multi-arch amd64+arm64). It publishes on a `v*` tag push:
+
+```bash
+git tag v<next-version> && git push origin v<next-version>
+```
+
+Then confirm `ghcr.io/perminder-klair/subwave-aio:latest` exists and is
+**public** (GHCR → package → Package settings → Change visibility → Public). CA
+pulls it anonymously, so a private package fails install.
+
+> Ad-hoc rebuild without a release: run the **Publish images** workflow via
+> *workflow_dispatch* — it rebuilds every image (including `subwave-aio`) from
+> the chosen ref.
+
+## 2. Smoke-test the image (before submitting)
+
+CA moderation expects a working app. Locally:
+
+```bash
+docker run -d --name subwave-aio-test -p 7790:80 \
+  -e ADMIN_USER=admin -e ADMIN_PASS=test123 -e SITE_URL=http://localhost:7790 \
+  -v /tmp/subwave-aio-state:/var/sub-wave \
+  ghcr.io/perminder-klair/subwave-aio:latest
+
+curl -fsS http://localhost:7790/api/health                                   # {"status":"on-air"}
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:7790/onboarding    # 200
+curl -s --max-time 4 -w 'type=%{content_type}\n' http://localhost:7790/stream.mp3  # audio/mpeg
+docker rm -f subwave-aio-test
+```
+
+Better still: install it on a real Unraid box first via **Add Container →
+Template URL** →
+`https://raw.githubusercontent.com/perminder-klair/subwave/main/templates/subwave.xml`,
+then finish `/onboarding` against a real Navidrome.
+
+## 3. Submit at ca.unraid.net
+
+1. Go to <https://ca.unraid.net/submit> and sign in with GitHub.
+2. Point it at `perminder-klair/subwave`.
+3. Run **Validate** and **Scan** — fix anything flagged, push, re-scan.
+4. **Preview** the listing, then **Submit**. A moderator reviews before it
+   appears in the Apps tab.
+
+> The scanner crawls the whole repo. If it ever mis-detects unrelated XML (it
+> keys off `<Container>` files under `templates/`, so it shouldn't), the
+> fallback is to split these files into a small dedicated `subwave-unraid` repo
+> and submit that instead — same files, different home.
+
+## Updating later
+
+- **App behaviour / image:** change the repo, cut a new `v*` tag → CA's normal
+  "Check for Updates" picks up the new `:latest` digest.
+- **Listing metadata** (description, screenshots, port defaults): edit
+  `ca_profile.xml` / `templates/subwave.xml`, push, re-run Validate/Scan. Bump
+  `<Date>` and add a `<Changes>` note in the template.

--- a/docs/unraid.md
+++ b/docs/unraid.md
@@ -1,0 +1,156 @@
+# Running SUB/WAVE on Unraid
+
+Two supported ways, depending on how much you want to manage:
+
+1. **One-click from Community Applications** — install the single all-in-one
+   container, set a few fields, done. Easiest; recommended for most people.
+2. **The full Compose stack via Compose Manager Plus** — run the maintained
+   `docker-compose.yml` as separate broadcast / controller / web / Caddy
+   services. Pick this if you want split containers, your own reverse proxy, or
+   the optional `tts-heavy` sidecar.
+
+Both end at the same place: a browser wizard at `/onboarding` that collects
+Navidrome, the LLM provider, TTS and the DJ persona. Start to on-air is about
+five minutes either way.
+
+---
+
+## Option 1 — One-click (Community Applications)
+
+The Apps store catalogue is one container per template, so the one-click image
+(`subwave-aio`) bundles the whole stack — icecast2 + liquidsoap, the controller,
+the web UI and a Caddy edge — into a single container behind one port. It's the
+same images as the Compose stack, just packaged together.
+
+### Install
+
+1. **Apps** tab → search **SUB/WAVE** → **Install**.
+2. Set the template fields:
+
+   | Field | Value |
+   |---|---|
+   | **WebUI Port** | host port for the UI + stream (default `7700`) |
+   | **Appdata** | `/mnt/user/appdata/subwave` — on the array/pool, **not** the flash |
+   | **ADMIN_USER** | your admin username (e.g. `admin`) |
+   | **ADMIN_PASS** | a strong password — **required** (`openssl rand -hex 16`) |
+   | **SITE_URL** | `http://YOUR-UNRAID-IP:7700` |
+   | **TZ** | your timezone (advanced; default `Europe/London`) |
+
+3. **Apply.** First pull is a few GB. When it's up, open the WebUI and finish at
+   `http://YOUR-UNRAID-IP:7700/onboarding`.
+
+> ⚠️ **Keep Appdata on the array/pool, not the flash drive.** SUB/WAVE's state
+> grows — hourly archives, the library cache, rendered voices — so point it at
+> `/mnt/user/appdata/subwave`, never `/boot/...`.
+
+### Not in the store yet? Install by Template URL
+
+Until the Community Applications listing is approved (or to try a pre-release),
+add it directly: **Docker** tab → **Add Container** → paste this into
+**Template URL**, then fill the same fields:
+
+```
+https://raw.githubusercontent.com/perminder-klair/subwave/main/templates/subwave.xml
+```
+
+---
+
+## Option 2 — Full Compose stack (Compose Manager Plus)
+
+Run the maintained `docker-compose.yml` (the same file every other host uses) as
+separate services. Good if you want each service isolated, your own
+Traefik/SWAG/NPM in front, or the optional Chatterbox/PocketTTS sidecar.
+
+### Prerequisites
+
+- Unraid 7.x with **Docker enabled** and the array (or a pool) started.
+- The **Community Applications** plugin (ships with Unraid).
+
+### 1. Install Compose Manager Plus
+
+**Apps** tab → search **Compose Manager Plus** (by `mstrhakr`) → **Install** the
+stable release. It adds a **Compose** section to the **Docker** tab.
+
+### 2. Create the stack
+
+**Docker** tab → **Compose** → **Add New Stack** → name it `subwave` → **Create**
+→ **Edit Stack**.
+
+- **Compose** tab: paste the contents of the default
+  [`docker-compose.yml`](https://raw.githubusercontent.com/perminder-klair/subwave/main/docker-compose.yml).
+  It brings up five containers; only Caddy binds a host port (`:7700`),
+  everything else is internal. The optional `tts-heavy` sidecar is
+  profile-gated and won't start — the DJ falls back to the built-in Piper voice.
+- **.env** tab: paste the three required vars plus the two Unraid-specific ones:
+
+```ini
+# Required
+ADMIN_USER=admin
+ADMIN_PASS=change-me            # generate one: openssl rand -hex 16
+SITE_URL=http://YOUR-UNRAID-IP:7700
+
+# Unraid-specific — keep state OFF the flash drive
+STATE_DIR=/mnt/user/appdata/subwave/state
+CADDY_PORT=7700
+TZ=Europe/London
+```
+
+**Save.**
+
+> ⚠️ **Set `STATE_DIR` to an absolute appdata path.** Compose Manager's project
+> directory lives on the USB flash (`/boot/...`), so the compose default of
+> `./state` would write SUB/WAVE's growing state onto the boot stick. Point it
+> at your pool/array (`/mnt/user/appdata/subwave/state`) instead.
+
+### 3. Pull and start
+
+From the stack's action menu pick **Pull & Up** (not plain *Compose Up*).
+
+> The compose file carries `build:` blocks so a source checkout can rebuild
+> locally. The Unraid project directory has no source, so a plain *up* would try
+> to build and fail. **Pull & Up** fetches the prebuilt images from GHCR first,
+> then starts them — no build. (Alternatively, delete the `build:` blocks and a
+> plain *up* works too.)
+
+First pull is ~1–2 GB. When it finishes you'll have five running containers.
+Flip the stack's **Autostart → ON** so it comes back after a reboot. Then finish
+at `http://YOUR-UNRAID-IP:7700/onboarding`.
+
+---
+
+## The AI DJ on Unraid: Ollama (local **or** cloud)
+
+Applies to both options. SUB/WAVE ships a first-class **"Ollama — local/cloud"**
+provider. Most Unraid boxes don't have a big GPU, so the nicest path is Ollama's
+**cloud models**, which offload inference — even a low-power box (e.g. an Intel
+N95) handles them fine:
+
+1. **Apps** tab → install the official **ollama** container (defaults are right:
+   port `11434`, appdata `/mnt/user/appdata/ollama`, `OLLAMA_HOST=0.0.0.0:11434`).
+2. Open the ollama container's **Console** and run `ollama signin`; approve the
+   printed link in your browser (needs an Ollama account; `:cloud` models need a
+   cloud subscription). Auth persists in the appdata volume.
+3. In SUB/WAVE: **admin → Settings → LLM Provider** → provider
+   **Ollama — local/cloud**, server URL `http://host.docker.internal:11434`,
+   model a `:cloud` tag (e.g. `glm-5.2:cloud`) — or a small local tag like
+   `llama3.2:3b` if you'd rather run on CPU. **Save LLM provider**.
+
+`host.docker.internal` resolves from SUB/WAVE's container(s) to the Unraid host,
+where the ollama container publishes `11434`. (The one-click template adds the
+`host-gateway` mapping for you; the Compose stack sets it via `extra_hosts`.)
+
+## Notes
+
+- **No reverse proxy needed** for LAN use — Caddy fronts `/`, `/api`, and
+  `/stream.mp3` on the single host port. If you already run SWAG / NPM /
+  Traefik and want TLS + a hostname, front that port with it, or (Compose stack)
+  switch to
+  [`docker-compose.byo.yml`](https://raw.githubusercontent.com/perminder-klair/subwave/main/docker-compose.byo.yml).
+- **Updates:** one-click → Unraid's normal **Check for Updates** / **Apply
+  Update**. Compose stack → stack menu → **Pull & Up**.
+- **Backups:** everything lives under the appdata path
+  (`/mnt/user/appdata/subwave`) — settings, library cache, archives, voices.
+  Back that path up (it's already on your pool/array).
+
+See [`deployment.md`](deployment.md) for the full cross-platform deploy matrix
+and [`../DEPLOY.md`](../DEPLOY.md) for Cloudflare, updates, and operations.

--- a/templates/subwave.xml
+++ b/templates/subwave.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>SUB-WAVE</Name>
+  <Repository>ghcr.io/perminder-klair/subwave-aio:latest</Repository>
+  <Registry>https://ghcr.io/perminder-klair/subwave-aio</Registry>
+  <Network>bridge</Network>
+  <Shell>bash</Shell>
+  <Privileged>false</Privileged>
+
+  <!-- Lets the in-container controller reach an Ollama (or Navidrome) running
+       on the Unraid host itself via http://host.docker.internal:PORT on the
+       default bridge network. Harmless when those services live elsewhere. -->
+  <ExtraParams>--add-host host.docker.internal:host-gateway</ExtraParams>
+
+  <Icon>https://raw.githubusercontent.com/perminder-klair/subwave/main/app/assets/icon.png</Icon>
+  <WebUI>http://[IP]:[PORT:80]</WebUI>
+
+  <Overview>
+    SUB/WAVE is a personal internet radio station: one Icecast stream every
+    listener hears together, with an AI DJ that picks tracks from your own
+    Navidrome / Subsonic library and reads scripts between them (station IDs,
+    the time, the weather, listener requests).
+
+    This is the all-in-one image — icecast2 + liquidsoap, the controller, the
+    Next.js web UI and a Caddy edge all run in this one container behind a
+    single port. Everything persists under the Appdata path.
+
+    [b]After it starts, open the WebUI and go to /onboarding[/b] (sign in with
+    the admin user/password you set here) to point it at your Navidrome server,
+    pick an LLM provider (Ollama local or cloud, or a cloud API key) and a
+    voice, and shape the DJ persona. The bundled Piper voice means the DJ can
+    talk out of the box with no extra setup.
+
+    Needs: a reachable Navidrome / Subsonic music server, and an LLM provider.
+    Most Unraid boxes have no big GPU, so Ollama cloud models are the easiest
+    path — install the official ollama container, run "ollama signin" in its
+    console, then set the provider to "Ollama - local/cloud" with a :cloud model.
+  </Overview>
+
+  <Support>https://github.com/perminder-klair/subwave/issues</Support>
+  <Project>https://github.com/perminder-klair/subwave</Project>
+  <TemplateURL>https://raw.githubusercontent.com/perminder-klair/subwave/main/templates/subwave.xml</TemplateURL>
+  <ReadMe>https://raw.githubusercontent.com/perminder-klair/subwave/main/README.md</ReadMe>
+
+  <Category>MediaApp:Music MediaServer:Music</Category>
+  <ExtraSearchTerms>radio internet radio icecast liquidsoap ai dj navidrome subsonic stream ollama station broadcast</ExtraSearchTerms>
+  <Requires>A reachable Navidrome / Subsonic music server and an LLM provider (Ollama local/cloud or a cloud API key), both configured in the browser at /onboarding after first boot.</Requires>
+
+  <Date>2026-06-22</Date>
+  <Changes>
+### 2026-06-22
+- Initial release: SUB/WAVE all-in-one image on Community Applications.
+  </Changes>
+
+  <License>MIT</License>
+  <MinVer>6.12</MinVer>
+
+  <!-- Reuse the screenshots already maintained in the main repo. -->
+  <Screenshot>https://raw.githubusercontent.com/perminder-klair/subwave/main/web/public/screenshots/listen.webp</Screenshot>
+  <Screenshot>https://raw.githubusercontent.com/perminder-klair/subwave/main/web/public/screenshots/observatory.webp</Screenshot>
+  <Screenshot>https://raw.githubusercontent.com/perminder-klair/subwave/main/web/public/screenshots/admin-dash.webp</Screenshot>
+
+  <!-- ports / paths / variables (v2 Config entries) -->
+
+  <!-- Host port mapped to Caddy's :80. The web UI, /api and /stream.mp3 are all
+       served from this single port. -->
+  <Config Name="WebUI Port" Target="80" Default="7700" Mode="tcp"
+          Description="Host port for the SUB/WAVE web UI + audio stream."
+          Type="Port" Display="always" Required="true" Mask="false">7700</Config>
+
+  <!-- Persistent state. Keep this on the array/pool, NOT the flash drive —
+       it grows (hourly archives, library cache, rendered voices). -->
+  <Config Name="Appdata" Target="/var/sub-wave" Default="/mnt/user/appdata/subwave" Mode="rw"
+          Description="Persistent state: settings, library cache, rendered voices, hourly archives."
+          Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/subwave</Config>
+
+  <Config Name="ADMIN_USER" Target="ADMIN_USER" Default="admin"
+          Description="Admin username for /admin and the /onboarding wizard."
+          Type="Variable" Display="always" Required="true" Mask="false">admin</Config>
+
+  <Config Name="ADMIN_PASS" Target="ADMIN_PASS" Default=""
+          Description="Admin password (required — the station refuses to start without it). Generate one, e.g. 'openssl rand -hex 16'."
+          Type="Variable" Display="always" Required="true" Mask="true"/>
+
+  <Config Name="SITE_URL" Target="SITE_URL" Default=""
+          Description="Public base URL of this station, e.g. http://YOUR-UNRAID-IP:7700 — used for share cards and absolute links."
+          Type="Variable" Display="always" Required="true" Mask="false"/>
+
+  <Config Name="TZ" Target="TZ" Default="Europe/London"
+          Description="Timezone — keeps scheduled shows and hourly-archive timestamps on local time."
+          Type="Variable" Display="advanced" Required="false" Mask="false">Europe/London</Config>
+</Container>

--- a/web/app/setup/unraid/page.tsx
+++ b/web/app/setup/unraid/page.tsx
@@ -1,0 +1,13 @@
+import Unraid from "@/components/setup/Unraid";
+import { pageMeta } from '@/lib/seo';
+
+export const metadata = pageMeta({
+  title: 'SUB/WAVE — Setup · Unraid',
+  description:
+    'Run SUB/WAVE on Unraid via the Compose Manager Plus plugin — stack setup, keeping state off the flash, Pull & Up, and the Ollama (local/cloud) AI DJ.',
+  path: '/setup/unraid',
+});
+
+export default function UnraidSetupPage() {
+  return <Unraid />;
+}

--- a/web/components/DjThinkingLine.tsx
+++ b/web/components/DjThinkingLine.tsx
@@ -76,7 +76,10 @@ export default function DjThinkingLine({ feed, enabled, onOpenBooth }: DjThinkin
       <span className="opacity-70" aria-hidden="true">
         {MARKER[cls] || '·'}
       </span>
-      <span className="[overflow-wrap:anywhere]">
+      {/* Clamp the inline teaser so the long "extended" scripts can't grow the
+          column and shove the artwork/title up under the header on mobile.
+          The full text stays one tap away in the Booth (and in aria-label). */}
+      <span className="line-clamp-5 min-w-0 flex-1 [overflow-wrap:anywhere] sm:line-clamp-10">
         <AnimatePresence mode="wait">
           <m.span
             key={turnId}

--- a/web/components/PlayerApp.tsx
+++ b/web/components/PlayerApp.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { AnimatePresence } from 'motion/react';
 import { toast } from 'sonner';
 import { CalendarClock, History, Mic } from 'lucide-react';
@@ -47,10 +48,28 @@ export interface PlayerAppProps {
 }
 
 export default function PlayerApp({ contained = false }: PlayerAppProps) {
+  const router = useRouter();
   const { apiUrl } = useStationOrigin();
   const { nowPlaying, context, dj, activeShow, listeners, streamOnline, llmTokens, state, session, trackStartedAt, timezone, locale } = useStationFeed();
   const boothFeed = session.messages;
   const { audioRef, tunedIn, status, volume, setVolume, tune, toggleMute, muted, idleStopped } = usePlayer();
+
+  // First-run redirect — if this install hasn't been configured yet (no
+  // Navidrome creds), bounce the operator into the wizard instead of dropping
+  // them on a silent player. Mirrors AdminShell. Only for the full-page player:
+  // `contained` instances embedded in showcases must never redirect, and the
+  // check hits the same-origin controller (/api), not the multi-station origin —
+  // needsSetup is about *this* install, not a remote station.
+  useEffect(() => {
+    if (contained) return;
+    const API = (process.env.NEXT_PUBLIC_API_URL as string | undefined) || '/api';
+    fetch(`${API}/onboarding/status`)
+      .then(r => (r.ok ? r.json() : null))
+      .then((j: { needsSetup?: boolean } | null) => {
+        if (j?.needsSetup) router.push('/onboarding');
+      })
+      .catch(() => {});
+  }, [contained, router]);
 
   // streamOnline is null until the first poll resolves — only treat an
   // explicit false as offline so the player never flashes "offline" on load.

--- a/web/components/admin/AiFill.tsx
+++ b/web/components/admin/AiFill.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+// Shared "describe it → draft it" block for the create/edit forms. The operator
+// types what they want, hits Generate, and the parent merges the returned draft
+// into its form fields for review (nothing is saved here). Backed by the
+// admin-gated /generate/* endpoints, which ride the station's configured LLM.
+import { useState } from 'react';
+import { Textarea } from '../ui/textarea';
+import { Btn } from './ui';
+import { errorMessage } from '../../lib/notify';
+
+interface AiFillProps<T> {
+  // e.g. '/generate/persona' — the admin-gated generator endpoint.
+  endpoint: string;
+  // The key the entity is returned under (e.g. 'persona' for { ok, persona }).
+  resultKey: string;
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+  onApply: (value: T) => void;
+  placeholder?: string;
+  // Extra body fields sent alongside { description } (e.g. theme { mode }).
+  extra?: Record<string, unknown>;
+  disabled?: boolean;
+}
+
+export function AiFill<T = unknown>({
+  endpoint,
+  resultKey,
+  adminFetch,
+  onApply,
+  placeholder,
+  extra,
+  disabled,
+}: AiFillProps<T>) {
+  const [desc, setDesc] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const generate = async () => {
+    const description = desc.trim();
+    if (!description || busy) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const r = await adminFetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description, ...(extra || {}) }),
+      });
+      const j = (await r.json().catch(() => ({}))) as Record<string, unknown> & { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      const value = j[resultKey] as T | undefined;
+      if (!value) throw new Error('no draft returned');
+      onApply(value);
+    } catch (e) {
+      setErr(errorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2 border border-soft-border bg-overlay/40 p-3">
+      <span className="field-hint">
+        Describe what you want — we&apos;ll draft the fields, then you can edit before saving.
+      </span>
+      <Textarea
+        rows={2}
+        value={desc}
+        onChange={(e) => setDesc(e.target.value)}
+        maxLength={400}
+        placeholder={placeholder || 'e.g. a late-night jazz host with a dry wit'}
+        disabled={busy || disabled}
+        onKeyDown={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') generate();
+        }}
+      />
+      <div className="flex items-center gap-3">
+        <Btn tone="accent" sm onClick={generate} disabled={busy || disabled || !desc.trim()}>
+          {busy ? 'Generating…' : 'Generate'}
+        </Btn>
+        {err && <span className="text-[12px] text-destructive">{err}</span>}
+      </div>
+    </div>
+  );
+}

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -18,6 +18,7 @@ import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel,
 } from '../ui/select';
 import { Card, Btn, Pill, Eyebrow, Seg, Toggle } from './ui';
+import { AiFill } from './AiFill';
 import { cn } from '../../lib/cn';
 
 const FREQUENCIES = [
@@ -840,6 +841,15 @@ export default function PersonasPanel() {
               </>
             }
           >
+            <div className="mb-4">
+              <AiFill<Partial<Persona>>
+                endpoint="/generate/persona"
+                resultKey="persona"
+                adminFetch={adminFetch}
+                placeholder="e.g. a late-night jazz host with a dry wit"
+                onApply={(p) => setPersona(safeIdx, p)}
+              />
+            </div>
             <div className="stack-mobile grid grid-cols-[96px_1fr] items-start gap-4">
               <PersonaAvatarPicker
                 persona={focused}

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -30,6 +30,16 @@ const SCRIPT_LENGTHS = [
   { id: 'concise',  label: 'Concise',  desc: 'Standard one-to-four sentence segments. The default.' },
   { id: 'extended', label: 'Extended', desc: 'Longer, storytelling segments — roughly double the length across intros, links, weather and idents.' },
 ];
+// Personality dials, 0–10, default 5. They map to three prompt bands server-side
+// (settings.personaToneDirectives): 0–3 low, 7–10 high, 4–6 neutral (nothing
+// injected). Surfacing the band keeps operators from expecting 6 vs 7 to differ.
+const TONE_DIALS = [
+  { id: 'humour',      label: 'Humour',       low: 'play it straight', high: 'playful & dry'  },
+  { id: 'localColour', label: 'Local colour', low: 'universal',        high: 'leans local'    },
+  { id: 'warmth',      label: 'Warmth',       low: 'cool & dry',       high: 'warm & earnest' },
+] as const;
+const DIAL_NEUTRAL = 5;
+const toneBand = (v: number) => (v <= 3 ? 'low' : v >= 7 ? 'high' : 'neutral');
 const ENGINES = [
   { id: 'piper',  label: 'Piper' },
   { id: 'kokoro', label: 'Kokoro' },
@@ -74,6 +84,10 @@ interface Persona {
   // what's next, runs callbacks across the session, and is more present. Off =
   // the historical tasteful-narrator behaviour.
   djMode: boolean;
+  // Tone dials, 0–10, default 5 (neutral). Map to prompt bands server-side.
+  humour: number;
+  localColour: number;
+  warmth: number;
   soul: string;
   // Free-text on-air language ("Turkish", "Türkçe"). Empty = English (no
   // directive injected server-side).
@@ -400,6 +414,9 @@ export default function PersonasPanel() {
             frequency: p.frequency ?? 'moderate',
             scriptLength: p.scriptLength ?? 'concise',
             djMode: p.djMode === true,
+            humour: typeof p.humour === 'number' ? p.humour : DIAL_NEUTRAL,
+            localColour: typeof p.localColour === 'number' ? p.localColour : DIAL_NEUTRAL,
+            warmth: typeof p.warmth === 'number' ? p.warmth : DIAL_NEUTRAL,
             soul: p.soul ?? '',
             language: typeof p.language === 'string' ? p.language : '',
             avatar: typeof p.avatar === 'string' ? p.avatar : '',
@@ -434,7 +451,8 @@ export default function PersonasPanel() {
         ...f,
         personas: [...f.personas, {
           id: clientMintId(), name: 'New persona', tagline: '',
-          frequency: 'moderate', scriptLength: 'concise', djMode: false, soul: '',
+          frequency: 'moderate', scriptLength: 'concise', djMode: false,
+          humour: DIAL_NEUTRAL, localColour: DIAL_NEUTRAL, warmth: DIAL_NEUTRAL, soul: '',
           language: '',
           avatar: '',
           tts: { engine: 'piper', cloudProvider: 'openai', voice: 'bf_isabella', gainDb: 0 },
@@ -569,6 +587,9 @@ export default function PersonasPanel() {
             frequency: p.frequency,
             scriptLength: p.scriptLength,
             djMode: p.djMode,
+            humour: p.humour,
+            localColour: p.localColour,
+            warmth: p.warmth,
             soul: p.soul.trim(),
             language: p.language.trim(),
             avatar: p.avatar || '',
@@ -966,6 +987,40 @@ export default function PersonasPanel() {
                 on={focused.djMode}
                 onClick={() => setPersona(safeIdx, { djMode: !focused.djMode })}
               />
+            </div>
+
+            <div className="rule-label">tone dials</div>
+
+            <div className="space-y-3.5">
+              {TONE_DIALS.map(d => {
+                const val = focused[d.id];
+                return (
+                  <div key={d.id}>
+                    <div className="flex items-center justify-between text-[12px]">
+                      <span className="font-bold">{d.label}</span>
+                      <span className="text-muted">{val}/10 · {toneBand(val)}</span>
+                    </div>
+                    <input
+                      type="range"
+                      min={0}
+                      max={10}
+                      step={1}
+                      value={val}
+                      onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                        setPersona(safeIdx, { [d.id]: Number(e.target.value) } as Partial<Persona>)}
+                      className="mt-1 w-full accent-[var(--accent)]"
+                    />
+                    <div className="flex justify-between text-[10px] text-muted">
+                      <span>{d.low}</span>
+                      <span>{d.high}</span>
+                    </div>
+                  </div>
+                );
+              })}
+              <div className="field-hint">
+                Personality on top of the soul. The middle band (4–6) injects nothing, so the
+                default stays exactly as before; push a dial low or high to shift the voice.
+              </div>
             </div>
           </Card>
 

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -17,6 +17,7 @@ import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel,
 } from '../ui/select';
 import { Card, Btn, Pill, Eyebrow, Seg, Metric } from './ui';
+import { AiFill } from './AiFill';
 import { cn } from '../../lib/cn';
 import ArchivesPanel from './ArchivesPanel';
 import WebhooksPanel from './WebhooksPanel';
@@ -3143,6 +3144,126 @@ function Swatch({ color }: { color?: string }) {
   return <span ref={ref} className="h-7 w-7" aria-hidden="true" />;
 }
 
+// The 7 themable tokens (mirrors controller THEME_TOKEN_KEYS) with human
+// labels for the create form. Generated drafts and manual edits both fill these.
+const THEME_TOKENS: { key: string; label: string }[] = [
+  { key: '--bg', label: 'background' },
+  { key: '--ink', label: 'text' },
+  { key: '--muted', label: 'muted text' },
+  { key: '--accent', label: 'accent' },
+  { key: '--overlay', label: 'overlay' },
+  { key: '--soft-border', label: 'border' },
+  { key: '--field', label: 'field' },
+];
+
+// Create a custom theme from a description (AI-drafted) or by hand, then save it
+// as state/themes/<id>.json via POST /themes. Tokens are editable before save so
+// the operator reviews the palette first.
+function ThemeCreator({
+  adminFetch,
+  onSaved,
+}: {
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+  onSaved: (themes: ThemeDef[]) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [mode, setMode] = useState<'light' | 'dark'>('dark');
+  const [tokens, setTokens] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const applyDraft = (t: {
+    name?: string;
+    description?: string;
+    mode?: 'light' | 'dark';
+    tokens?: Record<string, string>;
+  }) => {
+    if (t.name && !name.trim()) setName(t.name);
+    if (t.description) setDescription(t.description);
+    if (t.mode) setMode(t.mode);
+    if (t.tokens) setTokens(prev => ({ ...prev, ...t.tokens }));
+  };
+
+  const reset = () => {
+    setName(''); setDescription(''); setTokens({}); setErr(null); setOpen(false);
+  };
+
+  const save = async () => {
+    if (!name.trim() || saving) return;
+    setSaving(true); setErr(null);
+    try {
+      const r = await adminFetch('/themes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: name.trim(), description: description.trim(), mode, tokens }),
+      });
+      const j = (await r.json().catch(() => ({}))) as { error?: string; themes?: ThemeDef[] };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      onSaved(j.themes ?? []);
+      notify.ok(`saved "${name.trim()}"`);
+      reset();
+    } catch (e) {
+      setErr(errorMessage(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <Btn sm tone="accent" onClick={() => setOpen(true)}>Create theme with AI</Btn>
+    );
+  }
+
+  return (
+    <div className="grid gap-3 border border-ink p-3">
+      <AiFill<{ name?: string; description?: string; mode?: 'light' | 'dark'; tokens?: Record<string, string> }>
+        endpoint="/generate/theme"
+        resultKey="theme"
+        adminFetch={adminFetch}
+        placeholder="e.g. a warm sepia newspaper, easy on the eyes"
+        extra={{ mode }}
+        onApply={applyDraft}
+      />
+      <div className="grid grid-cols-[1fr_auto] items-end gap-3">
+        <div className="field">
+          <Label>theme name</Label>
+          <Input value={name} maxLength={60} onChange={(e: ChangeEvent<HTMLInputElement>) => setName(e.target.value)} placeholder="e.g. Sepia Press" />
+        </div>
+        <Seg
+          value={mode}
+          onChange={(v) => setMode(v as 'light' | 'dark')}
+          options={[{ id: 'dark', label: 'Dark' }, { id: 'light', label: 'Light' }]}
+        />
+      </div>
+      <div className="grid gap-1.5">
+        {THEME_TOKENS.map(({ key, label }) => (
+          <div key={key} className="grid grid-cols-[auto_5.5rem_1fr] items-center gap-2">
+            <span className="inline-flex shrink-0 border border-ink"><Swatch color={tokens[key]} /></span>
+            <span className="text-[11px] tracking-[0.12em] text-muted uppercase">{label}</span>
+            <Input
+              value={tokens[key] || ''}
+              maxLength={100}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setTokens(prev => ({ ...prev, [key]: e.target.value }))}
+              placeholder="#000000 or rgba(…)"
+              className="font-mono text-[12px]"
+            />
+          </div>
+        ))}
+      </div>
+      {err && <span className="text-[12px] text-[var(--danger)]">{err}</span>}
+      <div className="flex gap-2">
+        <Btn sm tone="accent" onClick={save} disabled={saving || !name.trim()}>
+          {saving ? 'Saving…' : 'Save theme'}
+        </Btn>
+        <Btn sm onClick={reset} disabled={saving}>Cancel</Btn>
+      </div>
+    </div>
+  );
+}
+
 function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSectionProps) {
   const [themes, setThemes] = useState<ThemeDef[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -3260,16 +3381,17 @@ function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSectionProp
 
       <Card title="Custom themes" sub="state/themes/*.json">
         <div className="grid gap-3">
+          <ThemeCreator adminFetch={adminFetch} onSaved={setThemes} />
           <div>
             <Btn sm onClick={refresh} disabled={refreshing || busy}>
               {refreshing ? 'Refreshing…' : 'Refresh themes'}
             </Btn>
           </div>
           <div className="field-hint">
-            Drop a JSON theme file in <code>state/themes/</code> and click <em>Refresh</em> to
-            add it to the picker — no controller restart needed. The folder
-            includes a <code>README.md</code> with the format and the allowed
-            token keys.
+            Describe a look above and we&apos;ll draft the palette, or drop a JSON
+            theme file in <code>state/themes/</code> and click <em>Refresh</em> —
+            no controller restart needed. The folder includes a
+            <code>README.md</code> with the format and the allowed token keys.
           </div>
         </div>
       </Card>

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -295,6 +295,9 @@ interface SettingsData {
     providers?: string[];
     active?: string;
   };
+  embedding?: {
+    providers?: string[];
+  };
   search?: {
     providers?: string[];
   };
@@ -2354,9 +2357,20 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
   const effectiveProvider = e.provider || llmProvider;
   const embedSuggestions = EMBED_MODEL_SUGGESTIONS[effectiveProvider] ?? [];
 
-  // Provider list comes from /settings.llm.providers (the canonical LLM list).
-  // Anthropic has no first-party embedding API — flagged in the hint.
-  const providers = data.llm?.providers || ['ollama'];
+  // Provider list is the embedding-capable subset (/settings.embedding.providers),
+  // NOT the full LLM list — chat-only providers (openrouter, deepseek, gateway)
+  // have no embeddings endpoint and can't be picked here (#493). Anthropic stays
+  // in; it routes to OpenAI, flagged in the hint.
+  const embedProviders = data.embedding?.providers ||
+    ['ollama', 'openai-compatible', 'locca', 'anthropic', 'openai', 'google'];
+  // Keep a stale explicit choice (a chat-only provider saved before this list
+  // shrank) visible so the Select isn't blank and the warning below makes sense.
+  const providers = e.provider && !embedProviders.includes(e.provider)
+    ? [e.provider, ...embedProviders]
+    : embedProviders;
+  // The effective provider can't embed when "Follow LLM provider" resolves to a
+  // chat-only LLM, or a stale config still names one. Drives the warning below.
+  const canEmbed = embedProviders.includes(effectiveProvider);
 
   // --- Guided setup: probe the endpoint up front, detect a locca embed server,
   // and kick the tagger from here, instead of failing mid-run (#405 follow-up).
@@ -2534,6 +2548,31 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
               pick OpenAI here (needs <code>OPENAI_API_KEY</code>).
               {' '}Effective: <code>{llmProviderLabel(effectiveProvider)}</code>.
             </div>
+
+            {!canEmbed && (
+              <div
+                role="alert"
+                className="mt-2 max-w-[480px] border border-l-[3px] border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger)_7%,transparent)] p-3"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-[13px] leading-none text-[var(--danger)]">⚠</span>
+                  <span className="text-[11px] font-bold tracking-[0.14em] text-[var(--danger)] uppercase">
+                    {llmProviderLabel(effectiveProvider)} can’t make embeddings
+                  </span>
+                </div>
+                <p className="mt-2 text-[11px] leading-[1.55] text-muted">
+                  {e.provider ? (
+                    <><code>{llmProviderLabel(effectiveProvider)}</code> is a chat-only provider — it has no embeddings endpoint, so the tagger can’t use it.</>
+                  ) : (
+                    <>“Follow LLM provider” resolves to <code>{llmProviderLabel(llmProvider)}</code>, which is chat-only and has no embeddings endpoint.</>
+                  )}{' '}
+                  Pick a real embedding provider above — <strong>Ollama</strong> is local
+                  and free (<code>nomic-embed-text</code>, auto-pulled on first run), or
+                  use OpenAI / Google / locca. Your DJ stays on{' '}
+                  <code>{llmProviderLabel(llmProvider)}</code>.
+                </p>
+              </div>
+            )}
           </div>
 
           <div className="field">

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -26,6 +26,7 @@ import {
 } from '../ui/select';
 import { Card, Btn, Pill, Eyebrow, Metric } from './ui';
 import { Modal } from '../ui/modal';
+import { AiFill } from './AiFill';
 import { cn } from '../../lib/cn';
 
 const NAME_MAX = 60;
@@ -757,6 +758,17 @@ export default function ShowsPanel() {
       >
         {draft && (
           <div className="grid gap-3.5">
+            <AiFill<Partial<Omit<Show, 'personaId' | 'themeId'>> & { personaId?: string | null; themeId?: string | null }>
+              endpoint="/generate/show"
+              resultKey="show"
+              adminFetch={adminFetch}
+              placeholder="e.g. a Sunday-morning gospel hour, warm and uplifting"
+              onApply={(s) => setDraftField({
+                ...s,
+                personaId: s.personaId ?? draft.personaId ?? '',
+                themeId: s.themeId ?? '',
+              })}
+            />
             <Field>
               <Label htmlFor="show-name">show name</Label>
               <Input

--- a/web/components/manual/ModelsAndTokens.tsx
+++ b/web/components/manual/ModelsAndTokens.tsx
@@ -198,6 +198,15 @@ export default function ModelsAndTokens() {
             point embeddings at Ollama or OpenAI instead.
           </li>
           <li>
+            <strong>Some providers do chat only</strong> — OpenRouter, DeepSeek and the
+            Vercel AI gateway have no embeddings endpoint at all. A DJ on one of those works
+            fine, but the tagger can't follow it, so the console only lists{' '}
+            <em>embedding-capable</em> providers in the tagger dropdown (Ollama, OpenAI,
+            Google, locca, OpenAI-compatible). If you don't see your chat provider there,
+            that's why — pick Ollama (local and free) for the embedding step and leave the
+            DJ where it is.
+          </li>
+          <li>
             <strong>locca and OpenAI-compatible need a dedicated embedding server</strong> —
             one llama.cpp process can't serve chat and embeddings at once. With locca that's
             a second command, <code>locca embed</code>, on its own port; the console can

--- a/web/components/onboarding/WizardShell.tsx
+++ b/web/components/onboarding/WizardShell.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import SignInForm from '@/components/admin/SignInForm';
 import { useWizard, STEP_ORDER, STEP_LABELS } from './useWizard';
-import { DjStep, JinglesStep, LlmStep, NavidromeStep, ReviewStep, TtsStep } from './steps';
+import { DjStep, LlmStep, NavidromeStep, ReviewStep, TtsStep } from './steps';
 
 // Outer chrome for the first-run wizard. Sign-in gate (admin creds from .env),
 // step indicator, body, and back/next buttons. The Review step calls `onDone`
@@ -63,7 +63,6 @@ export default function WizardShell() {
     w.step === 'llm' ? <LlmStep w={w} /> :
     w.step === 'tts' ? <TtsStep w={w} /> :
     w.step === 'dj' ? <DjStep w={w} /> :
-    w.step === 'jingles' ? <JinglesStep w={w} /> :
     <ReviewStep w={w} onDone={() => setDone(true)} />;
 
   return (

--- a/web/components/onboarding/steps.tsx
+++ b/web/components/onboarding/steps.tsx
@@ -126,7 +126,7 @@ export function NavidromeStep({ w }: { w: WizardController }) {
           </button>
           <TestPill result={w.data.navidromeTest} />
         </div>
-        <div className="rounded-md border border-amber-400/40 bg-amber-400/10 px-3 py-2 text-xs text-amber-200">
+        <div className="rounded-md border border-amber-400/40 bg-amber-400/10 px-3 py-2 text-xs text-ink/80">
           <strong>Music licensing:</strong> owning these files covers your own
           private listening, not <em>public</em> broadcast. If anyone but you
           can hear the stream, you&apos;re publicly performing copyrighted works
@@ -430,54 +430,23 @@ export function DjStep({ w }: { w: WizardController }) {
             onChange={e => w.patch(d => ({ dj: { ...d.dj, locationName: e.target.value } }))}
           />
         </Field>
-      </div>
-    </div>
-  );
-}
-
-// ─── JINGLES ──────────────────────────────────────────────────────────────
-export function JinglesStep({ w }: { w: WizardController }) {
-  const [busy, setBusy] = useState(false);
-  const [result, setResult] = useState<{ ok: boolean; msg: string } | null>(null);
-  const onGenerate = async () => {
-    setBusy(true);
-    setResult(null);
-    const r = await w.generateJingles();
-    setResult({
-      ok: r.ok,
-      msg: r.ok
-        ? `Rendered ${r.created || 0} new jingle${(r.created || 0) === 1 ? '' : 's'} (${r.total || 0} total).`
-        : r.error || 'failed',
-    });
-    setBusy(false);
-  };
-  return (
-    <div>
-      <StepHeader
-        title="Generate station idents"
-        blurb='5 default jingles, rendered with your chosen TTS engine. Plays between tracks. You can re-run this later in the admin Jingles panel.'
-      />
-      <button
-        type="button"
-        onClick={onGenerate}
-        disabled={busy}
-        className="rounded border border-ink bg-ink px-4 py-2 text-sm font-medium tracking-wide text-bg uppercase hover:opacity-90 disabled:opacity-40"
-      >
-        {busy ? 'Rendering…' : 'Generate now'}
-      </button>
-      <p className="mt-3 text-xs text-ink/60">
-        Or click <strong>Next</strong> to skip — jingles aren&apos;t required for the station to broadcast.
-      </p>
-      {result && (
-        <div
-          className={
-            'mt-3 rounded px-3 py-2 text-sm ' +
-            (result.ok ? 'bg-green-100 text-green-900' : 'bg-red-100 text-red-900')
-          }
-        >
-          {result.msg}
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Latitude" hint="-90 to 90">
+            <TextInput
+              inputMode="decimal"
+              value={w.data.dj.lat}
+              onChange={e => w.patch(d => ({ dj: { ...d.dj, lat: e.target.value } }))}
+            />
+          </Field>
+          <Field label="Longitude" hint="-180 to 180">
+            <TextInput
+              inputMode="decimal"
+              value={w.data.dj.lng}
+              onChange={e => w.patch(d => ({ dj: { ...d.dj, lng: e.target.value } }))}
+            />
+          </Field>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/web/components/onboarding/useWizard.ts
+++ b/web/components/onboarding/useWizard.ts
@@ -36,6 +36,10 @@ export interface WizardData {
   dj: {
     stationName: string;
     locationName: string;
+    // Weather coordinates — strings since they back text inputs; parsed +
+    // range-checked by the controller's settings.update() on save.
+    lat: string;
+    lng: string;
     frequency: 'quiet' | 'moderate' | 'aggressive';
   };
 
@@ -65,22 +69,24 @@ export const DEFAULT_DATA: WizardData = {
   },
   dj: {
     stationName: 'SUB/WAVE',
-    locationName: 'Wolverhampton',
+    // Punjab (Chandigarh) — operator's home region; coordinates drive weather.
+    locationName: 'Punjab',
+    lat: '30.7333',
+    lng: '76.7794',
     frequency: 'moderate',
   },
   apiKeys: {},
 };
 
-export type StepId = 'navidrome' | 'llm' | 'tts' | 'dj' | 'jingles' | 'review';
+export type StepId = 'navidrome' | 'llm' | 'tts' | 'dj' | 'review';
 
-export const STEP_ORDER: StepId[] = ['navidrome', 'llm', 'tts', 'dj', 'jingles', 'review'];
+export const STEP_ORDER: StepId[] = ['navidrome', 'llm', 'tts', 'dj', 'review'];
 
 export const STEP_LABELS: Record<StepId, string> = {
   navidrome: 'Navidrome',
   llm: 'LLM',
   tts: 'TTS',
   dj: 'DJ persona',
-  jingles: 'Jingles',
   review: 'Review',
 };
 
@@ -182,7 +188,7 @@ export function useWizard() {
           ? { enabled: true, provider: data.tts.cloud.provider }
           : { enabled: false },
       },
-      weather: { locationName: data.dj.locationName },
+      weather: { locationName: data.dj.locationName, lat: data.dj.lat, lng: data.dj.lng },
       station: data.dj.stationName,
       apiKeys,
     };
@@ -194,12 +200,6 @@ export function useWizard() {
     const j = (await r.json().catch(() => ({}))) as { ok?: boolean; error?: string };
     return { ok: !!j.ok, error: j.error };
   }, [auth, data]);
-
-  const generateJingles = useCallback(async () => {
-    const r = await auth.adminFetch('/onboarding/generate-jingles', { method: 'POST' });
-    const j = (await r.json().catch(() => ({}))) as { ok?: boolean; created?: number; total?: number; error?: string };
-    return { ok: !!j.ok, created: j.created, total: j.total, error: j.error };
-  }, [auth]);
 
   return {
     auth,
@@ -214,7 +214,6 @@ export function useWizard() {
     testLlm,
     discoverLocca,
     save,
-    generateJingles,
   };
 }
 

--- a/web/components/setup/Unraid.tsx
+++ b/web/components/setup/Unraid.tsx
@@ -1,0 +1,301 @@
+import Link from 'next/link';
+import SetupPage from './SetupPage';
+import CodeBlock from "@/components/CodeBlock";
+
+const UNRAID_ENV_TEMPLATE = `# Required — the three boot keys
+ADMIN_USER=admin
+ADMIN_PASS=replace-me-with-a-strong-string   # openssl rand -hex 16
+SITE_URL=http://YOUR-UNRAID-IP:7700
+
+# Unraid-specific — keep state OFF the flash drive
+STATE_DIR=/mnt/user/appdata/subwave/state
+CADDY_PORT=7700
+TZ=Europe/London`;
+
+const TEMPLATE_URL =
+  'https://raw.githubusercontent.com/perminder-klair/subwave/main/templates/subwave.xml';
+
+export default function Unraid() {
+  return (
+    <SetupPage
+      eyebrow="SETUP · UNRAID"
+      title="Run it on Unraid."
+      intro="Two supported paths. The easy one: install the one-click all-in-one container from Community Applications. The flexible one: run the full Compose stack via Compose Manager Plus (separate containers, BYO reverse proxy, optional heavy-TTS sidecar). Both finish in the same browser wizard. Start to on-air is about five minutes."
+      current="/setup/unraid"
+    >
+      <section className="bs-section">
+        <div className="bs-callout">
+          <div className="bs-eyebrow">TWO WAYS TO RUN IT</div>
+          <p>
+            <strong>One-click (Community Applications)</strong> — the all-in-one
+            image bundles the whole stack into a single container behind one
+            port. Easiest; recommended for most people.{' '}
+            <strong>Full Compose stack (Compose Manager Plus)</strong> — the
+            maintained{' '}
+            <code className="bs-code-inline">docker-compose.yml</code> as
+            separate broadcast / controller / web / Caddy services. Pick it for
+            isolated containers, your own proxy, or the heavy-TTS sidecar.
+          </p>
+        </div>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">OPTION 1 — ONE-CLICK</p>
+        <h2>Community Applications.</h2>
+        <p>
+          The Apps catalogue is one container per template, so the{' '}
+          <code className="bs-code-inline">subwave-aio</code> image bundles
+          icecast2 + liquidsoap, the controller, the web UI and a Caddy edge
+          together. Same images as the Compose stack — just packaged into one.
+        </p>
+
+        <div className="bs-step">
+          <div className="bs-step-num">01</div>
+          <div className="bs-step-body">
+            <h3>Install &amp; fill the fields</h3>
+            <p>
+              <strong>Apps</strong> tab &rarr; search{' '}
+              <strong>SUB/WAVE</strong> &rarr; <strong>Install</strong>, then set:
+            </p>
+            <ul className="bs-list">
+              <li>
+                <strong>WebUI Port</strong> — host port for the UI + stream
+                (default <code className="bs-code-inline">7700</code>).
+              </li>
+              <li>
+                <strong>Appdata</strong> —{' '}
+                <code className="bs-code-inline">/mnt/user/appdata/subwave</code>,
+                on the array/pool (<em>not</em> the flash).
+              </li>
+              <li>
+                <strong>ADMIN_USER</strong> / <strong>ADMIN_PASS</strong> — your
+                admin login; the password is <strong>required</strong>.
+              </li>
+              <li>
+                <strong>SITE_URL</strong> —{' '}
+                <code className="bs-code-inline">http://YOUR-UNRAID-IP:7700</code>.
+              </li>
+            </ul>
+            <div className="bs-callout">
+              <div className="bs-eyebrow">KEEP APPDATA OFF THE FLASH</div>
+              <p>
+                SUB/WAVE&apos;s state grows — hourly archives, the library cache,
+                rendered voices. Point <strong>Appdata</strong> at{' '}
+                <code className="bs-code-inline">/mnt/user/appdata/subwave</code>{' '}
+                on your pool/array, never{' '}
+                <code className="bs-code-inline">/boot/…</code>.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="bs-step">
+          <div className="bs-step-num">02</div>
+          <div className="bs-step-body">
+            <h3>Finish setup in the browser</h3>
+            <CodeBlock>{`open http://YOUR-UNRAID-IP:7700/onboarding`}</CodeBlock>
+            <p>
+              Sign in with the{' '}
+              <code className="bs-code-inline">ADMIN_USER</code> /{' '}
+              <code className="bs-code-inline">ADMIN_PASS</code> you set, and the
+              wizard collects the rest — Navidrome, the LLM provider, TTS, the DJ
+              persona. The player is at{' '}
+              <code className="bs-code-inline">http://YOUR-UNRAID-IP:7700</code>.
+            </p>
+          </div>
+        </div>
+
+        <div className="bs-callout">
+          <div className="bs-eyebrow">NOT IN THE STORE YET?</div>
+          <p>
+            Until the listing is approved (or to try a pre-release), add it
+            directly: <strong>Docker</strong> tab &rarr;{' '}
+            <strong>Add Container</strong> &rarr; paste this into{' '}
+            <strong>Template URL</strong>, then fill the same fields.
+          </p>
+          <CodeBlock>{TEMPLATE_URL}</CodeBlock>
+        </div>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">OPTION 2 — FULL COMPOSE STACK</p>
+        <h2>Compose Manager Plus.</h2>
+        <p>
+          Run the maintained{' '}
+          <code className="bs-code-inline">docker-compose.yml</code> as separate
+          services — good for isolated containers, your own Traefik/SWAG/NPM in
+          front, or the optional Chatterbox/PocketTTS sidecar.
+        </p>
+
+        <div className="bs-step">
+          <div className="bs-step-num">01</div>
+          <div className="bs-step-body">
+            <h3>Install Compose Manager Plus</h3>
+            <p>
+              On the <strong>Apps</strong> tab, search{' '}
+              <code className="bs-code-inline">Compose Manager Plus</code> (by{' '}
+              <code className="bs-code-inline">mstrhakr</code>) and install the
+              stable release. It adds a <strong>Compose</strong> section to the{' '}
+              <strong>Docker</strong> tab. You&apos;ll also want Docker enabled and
+              the array (or a pool) started so there&apos;s somewhere for appdata.
+            </p>
+          </div>
+        </div>
+
+        <div className="bs-step">
+          <div className="bs-step-num">02</div>
+          <div className="bs-step-body">
+            <h3>Create the stack</h3>
+            <p>
+              <strong>Docker</strong> tab &rarr; <strong>Compose</strong> &rarr;{' '}
+              <strong>Add New Stack</strong> &rarr; name it{' '}
+              <code className="bs-code-inline">subwave</code> &rarr;{' '}
+              <strong>Edit Stack</strong>.
+            </p>
+            <ul className="bs-list">
+              <li>
+                <strong>Compose</strong> tab — paste the contents of the default{' '}
+                <Link
+                  href="https://raw.githubusercontent.com/perminder-klair/subwave/main/docker-compose.yml"
+                  className="bs-link"
+                >
+                  docker-compose.yml
+                </Link>
+                . Five containers; only Caddy binds a host port (
+                <code className="bs-code-inline">:7700</code>). The optional{' '}
+                <code className="bs-code-inline">tts-heavy</code> sidecar is
+                profile-gated and won&apos;t start — the DJ falls back to the
+                built-in Piper voice.
+              </li>
+              <li>
+                <strong>.env</strong> tab — the three required keys plus two
+                Unraid-specific ones:
+              </li>
+            </ul>
+            <CodeBlock lang="env">{UNRAID_ENV_TEMPLATE}</CodeBlock>
+            <div className="bs-callout">
+              <div className="bs-eyebrow">KEEP STATE OFF THE FLASH</div>
+              <p>
+                Compose Manager&apos;s project directory lives on the USB flash
+                (<code className="bs-code-inline">/boot/…</code>), so the compose
+                default of <code className="bs-code-inline">./state</code> would
+                write SUB/WAVE&apos;s growing state — hourly archives, the library
+                cache, rendered voices — onto the boot stick. Set{' '}
+                <code className="bs-code-inline">STATE_DIR</code> to an absolute
+                appdata path on your pool/array (
+                <code className="bs-code-inline">/mnt/user/appdata/subwave/state</code>
+                ); Docker creates it on first start.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="bs-step">
+          <div className="bs-step-num">03</div>
+          <div className="bs-step-body">
+            <h3>Pull &amp; Up</h3>
+            <p>
+              From the stack&apos;s action menu pick <strong>Pull &amp; Up</strong>{' '}
+              (not plain <em>Compose Up</em>), then flip the stack&apos;s{' '}
+              <strong>Autostart &rarr; ON</strong> so it survives reboots.
+            </p>
+            <div className="bs-callout">
+              <div className="bs-eyebrow">WHY PULL &amp; UP</div>
+              <p>
+                The compose file carries{' '}
+                <code className="bs-code-inline">build:</code> blocks so a source
+                checkout can rebuild locally. The Unraid project directory has no
+                source, so a plain <em>up</em> would try to build and fail.{' '}
+                <strong>Pull &amp; Up</strong> fetches the prebuilt images from
+                GHCR first, then starts them. (Alternatively, delete the{' '}
+                <code className="bs-code-inline">build:</code> blocks and plain{' '}
+                <em>up</em> works too.)
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="bs-step">
+          <div className="bs-step-num">04</div>
+          <div className="bs-step-body">
+            <h3>Finish setup in the browser</h3>
+            <CodeBlock>{`open http://YOUR-UNRAID-IP:7700/onboarding`}</CodeBlock>
+            <p>
+              Same wizard as the one-click path — Navidrome, the LLM provider,
+              TTS, the DJ persona.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="bs-section">
+        <div className="bs-callout">
+          <div className="bs-eyebrow">THE AI DJ — OLLAMA, LOCAL OR CLOUD</div>
+          <p>
+            Applies to both options. SUB/WAVE ships a first-class{' '}
+            <strong>&ldquo;Ollama — local/cloud&rdquo;</strong> provider. Most
+            Unraid boxes lack a big GPU, so the nicest path is Ollama&apos;s{' '}
+            <strong>cloud models</strong>, which offload inference — even a
+            low-power box (e.g. an Intel N95) handles them fine:
+          </p>
+          <ul className="bs-list">
+            <li>
+              Install the official <code className="bs-code-inline">ollama</code>{' '}
+              container from the Apps tab (defaults are right: port{' '}
+              <code className="bs-code-inline">11434</code>, appdata{' '}
+              <code className="bs-code-inline">/mnt/user/appdata/ollama</code>).
+            </li>
+            <li>
+              Open its <strong>Console</strong> and run{' '}
+              <code className="bs-code-inline">ollama signin</code>; approve the
+              printed link in your browser (cloud models need a subscription).
+            </li>
+            <li>
+              In <strong>admin &rarr; Settings &rarr; LLM Provider</strong>: set
+              provider <strong>Ollama — local/cloud</strong>, server URL{' '}
+              <code className="bs-code-inline">http://host.docker.internal:11434</code>
+              , and a <code className="bs-code-inline">:cloud</code> model tag (e.g.{' '}
+              <code className="bs-code-inline">glm-5.2:cloud</code>) — or a small
+              local tag like{' '}
+              <code className="bs-code-inline">llama3.2:3b</code> to run on CPU.
+            </li>
+          </ul>
+        </div>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">GOOD TO KNOW</div>
+          <ul className="bs-list">
+            <li>
+              <strong>No reverse proxy needed</strong> for LAN use — Caddy fronts{' '}
+              <code className="bs-code-inline">/</code>,{' '}
+              <code className="bs-code-inline">/api</code>, and{' '}
+              <code className="bs-code-inline">/stream.mp3</code> on the single
+              host port. Want TLS + a hostname behind SWAG / NPM / Traefik? Front
+              that port with it, or (Compose stack) use{' '}
+              <code className="bs-code-inline">docker-compose.byo.yml</code>.
+            </li>
+            <li>
+              <strong>Updates:</strong> one-click &rarr; Unraid&apos;s normal{' '}
+              <strong>Check for Updates</strong>. Compose stack &rarr; stack menu
+              &rarr; <strong>Pull &amp; Up</strong>.
+            </li>
+            <li>
+              <strong>Backups:</strong> everything lives under the appdata path —
+              settings, library cache, archives, voices. Back up{' '}
+              <code className="bs-code-inline">/mnt/user/appdata/subwave</code>.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">WHAT&apos;S NEXT</p>
+        <h2>Keep it running.</h2>
+        <p>
+          The station is on the air. When a new version lands, head to{' '}
+          <Link href="/setup/updates" className="bs-link">Updates &amp; Help</Link>{' '}
+          for the update workflow and the troubleshooting checklist.
+        </p>
+      </section>
+    </SetupPage>
+  );
+}

--- a/web/components/setup/pages.ts
+++ b/web/components/setup/pages.ts
@@ -15,6 +15,7 @@ export const SETUP_PAGES: SetupPageEntry[] = [
   { href: '/setup/prerequisites', label: 'Prerequisites' },
   { href: '/setup/quick-start', label: 'Quick Start' },
   { href: '/setup/manual', label: 'Manual Install' },
+  { href: '/setup/unraid', label: 'Unraid' },
   { href: '/setup/development', label: 'Development' },
   { href: '/setup/updates', label: 'Updates & Help' },
 ];

--- a/web/content/news/2026-06-21-chatterbox-on-the-gpu.md
+++ b/web/content/news/2026-06-21-chatterbox-on-the-gpu.md
@@ -1,0 +1,55 @@
+---
+title: Run Chatterbox on your nvidia card
+date: 2026-06-21
+category: Spotlight
+author: The SUB/WAVE desk
+excerpt: The tts-heavy sidecar ships CPU-only, but with a small rebuild you can move Chatterbox onto an nvidia card for faster voice synthesis. Here is the index swap, the compose change, and the one caveat.
+---
+
+The heavy TTS sidecar ships CPU-only on purpose. The PyTorch wheels inside it are the CPU build, which keeps the image from ballooning by several gigabytes. That is the right default for most boxes. But if you just moved your Docker host to a machine with a real nvidia card, you can put Chatterbox on it and get faster voice synthesis. It takes a small rebuild.
+
+## What you're changing
+
+The image installs CPU PyTorch from a pinned wheel index. To use the card you swap that index for a CUDA one, pass the GPU into the container, and flip one env var. There is already a `TTS_HEAVY_DEVICE` switch waiting for this. On the stock image it falls back to CPU, because the torch inside has no CUDA, so the rebuild is what makes the switch real.
+
+## Build a CUDA image
+
+Open `docker/Dockerfile.tts-heavy` and find the Chatterbox venv block. Change its torch index from the CPU wheels to a CUDA build that matches your driver, for example CUDA 12.4:
+
+```
+--index-url https://download.pytorch.org/whl/cu124 \
+```
+
+That is the only line in that block you need to touch. PocketTTS and the analyzer can stay on CPU.
+
+## Pass the GPU into the container
+
+Install the nvidia-container-toolkit on the host so Docker can see the card. Then give the `tts-heavy` service a GPU reservation in your compose file:
+
+```yaml
+deploy:
+  resources:
+    reservations:
+      devices:
+        - driver: nvidia
+          count: all
+          capabilities: [gpu]
+```
+
+Set the device to cuda in your root `.env`:
+
+```
+TTS_HEAVY_DEVICE=cuda
+```
+
+Rebuild and bring the sidecar back up:
+
+```
+docker compose --profile tts-heavy up -d --build tts-heavy
+```
+
+The worker logs which device it loaded on. Look for `loading ChatterboxTurboTTS on device=cuda` in the container logs. If CUDA is not actually reachable it logs `cpu` instead and keeps working, so you never lose the voice while you sort the card out.
+
+## One caveat
+
+Only Chatterbox follows `TTS_HEAVY_DEVICE`. PocketTTS and the audio analyzer stay on the CPU no matter what. So this is worth doing if Chatterbox is your DJ voice, where it is the heaviest of the engines and the card buys you the most. On PocketTTS it changes nothing.


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge with "Create a merge commit"** — not "Squash and merge". Squash collapses the individual `feat:` / `fix:` / `chore:` commits into one `release: …` commit, and release-please then sees no conventional-commit signal and skips the version bump.

## Summary

Full-stack batch queued on develop since 0.25.0. Headline is a new **Unraid one-click install**: a single `subwave-aio` all-in-one image plus a Community Applications template, so the whole stack installs from the Apps store and finishes in the browser. Also ships **DJ persona depth** (per-persona humour / local-colour / warmth tone dials + an AI "describe it → auto-fill" for personas, shows and themes) and a set of onboarding / tagger / player fixes. No migrations, env-var changes, or breaking changes.

**Features**
- `29332e0` feat(unraid): all-in-one image + Community Applications one-click install (#499)
  - new `subwave-aio` image (icecast2 + liquidsoap, controller, web, Caddy under one supervisor), multi-arch; `ca_profile.xml` + `templates/subwave.xml` at the repo root; docs reframed to two paths (Apps store / Compose Manager Plus).
- `1d9e586` feat(dj): per-persona tone dials (humour, local colour, warmth) + anti-cliché (#470)
- `7e77451` feat(admin): AI "describe it → auto-fill" for personas, shows & themes (#492)

**Bug Fixes**
- `1fde280` fix(onboarding): redirect unconfigured player to wizard, Punjab default + coords, drop jingles (#498)
- `678bf7f` fix(tagger): hide chat-only providers from the embedding picker (#493) (#497)
- `2540fc3` fix(web): clamp DJ thinking line so long scripts don't shove artwork under the header (#486)

**Documentation**
- `aebfa7f` docs(news): dispatch on running Chatterbox on an nvidia GPU (#487)

## Test plan
- [ ] Unraid one-click: install the `subwave-aio` template (or Add Container → its Template URL), set port / appdata / ADMIN_* / SITE_URL, reach the player on the host port and finish `/onboarding`.
- [ ] AIO runtime: `/stream.mp3` plays live and `/api/health` returns on-air with web + controller + broadcast all up.
- [x] DJ persona tone dials (humour / local colour / warmth) visibly shape on-air scripts; admin "describe it → auto-fill" populates persona / show / theme fields.
- [x] Onboarding: an unconfigured player redirects to the wizard; Punjab default + coords are set.
- [x] Tagger embedding picker no longer lists chat-only providers; a long DJ thinking line no longer pushes artwork under the header.
