### PR TITLE
fix(build): publish subwave-aio amd64-only (arm64 webbuild fails under QEMU)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -53,15 +53,16 @@ jobs:
             platforms: linux/amd64,linux/arm64
           # The Unraid one-click image: the whole stack (icecast2 + liquidsoap,
           # controller, web, Caddy) in one container, supervised by
-          # docker/aio/supervisor.sh. Multi-arch like the split-stack images —
-          # amd64 (x86-64, every Unraid box) plus arm64 (ARM servers / Apple
-          # Silicon). Dockerfile.aio selects the matching Piper build via
-          # $TARGETARCH; Kokoro/onnx, node, icecast2 and the liquidsoap base all
-          # have arm64 builds. The arm64 variant cross-builds under QEMU, so this
-          # is the slowest image in the matrix.
+          # docker/aio/supervisor.sh. amd64-only (x86-64 — every Unraid box, the
+          # target for this image). arm64 is deliberately NOT built here: the
+          # bundled Next.js webbuild fails its arm64 cross-build under QEMU
+          # because lightningcss (Tailwind) can't load its native
+          # `lightningcss.linux-arm64-gnu.node` binary in the emulated stage.
+          # Native-arm64 users can still run the split-stack images, which stay
+          # multi-arch. Revisit if the lightningcss/QEMU issue is resolved.
           - image: subwave-aio
             dockerfile: docker/Dockerfile.aio
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
           - image: subwave-tts-heavy
             dockerfile: docker/Dockerfile.tts-heavy
             platforms: linux/amd64

--- a/docs/unraid-ca-submission.md
+++ b/docs/unraid-ca-submission.md
@@ -21,7 +21,9 @@ Icon + screenshots are referenced by raw URL from existing in-repo assets
 ## 1. Publish the `subwave-aio` image
 
 Built by `.github/workflows/publish-images.yml` (matrix entry `subwave-aio`,
-multi-arch amd64+arm64). It publishes on a `v*` tag push:
+amd64-only — that's x86-64, every Unraid box; arm64 is skipped because the
+bundled Next.js webbuild fails its arm64 cross-build under QEMU on
+lightningcss). It publishes on a `v*` tag push:
 
 ```bash
 git tag v<next-version> && git push origin v<next-version>


### PR DESCRIPTION
The v0.26.0 `publish-images` run failed on the **subwave-aio arm64** build — the bundled Next.js webbuild can't load lightningcss's native `lightningcss.linux-arm64-gnu.node` in the emulated arm64 stage (`npm run build` errors). All other images built fine.

amd64 is x86-64 (every Unraid box, this image's target), so this drops arm64 for **subwave-aio only**; the split-stack images stay multi-arch.

Once merged, a v0.26.1 patch release republishes `subwave-aio:latest` (amd64). Separately keep an eye on whether `subwave-web` arm64 hits the same lightningcss issue — that's the main web image, unaffected by this change.