### PR TITLE
docs(unraid): CA listing live, humanized Overview + setup pages, news dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,9 @@ the canonical path: `curl` two files, fill in three vars, `docker compose
 up -d`, finish setup in the browser. See **[`DEPLOY.md`](DEPLOY.md)** for host
 prerequisites, Cloudflare setup, updates, and backup.
 
-**On Unraid?** Run it through the Compose Manager Plus plugin — see
-**[`docs/unraid.md`](docs/unraid.md)**.
+**On Unraid?** One-click install from **[Community Applications](https://ca.unraid.net/apps/sub-wave-073qgwu0ch9rtu)**
+(search **SUB/WAVE** in the Apps tab) — or run the full split-container stack via
+the Compose Manager Plus plugin. Both in **[`docs/unraid.md`](docs/unraid.md)**.
 
 **Bring your own reverse proxy.** If you already run Traefik, nginx, or your
 own Caddy in your homelab, swap the bundled-Caddy compose for the BYO variant:
@@ -250,7 +251,7 @@ bin/subwave        Operator CLI entry: setup, status, doctor, lifecycle, play
 ## Documentation
 
 - **[`DEPLOY.md`](DEPLOY.md):** production deployment, updates, backup.
-- **[`docs/unraid.md`](docs/unraid.md):** running on Unraid via the Compose Manager Plus plugin.
+- **[`docs/unraid.md`](docs/unraid.md):** running on Unraid — one-click from Community Applications, or the Compose Manager Plus stack.
 - **[`CLAUDE.md`](CLAUDE.md):** deep architecture reference and the
   non-obvious constraints behind each subsystem.
 - **[`CONTRIBUTING.md`](CONTRIBUTING.md):** how to contribute.

--- a/docs/unraid-ca-submission.md
+++ b/docs/unraid-ca-submission.md
@@ -1,5 +1,10 @@
 # Submitting SUB/WAVE to Unraid Community Applications
 
+> **Status: published.** SUB/WAVE is live in Community Applications —
+> [ca.unraid.net/apps/sub-wave](https://ca.unraid.net/apps/sub-wave-073qgwu0ch9rtu).
+> This runbook now applies to *re-scanning after changes* and to anyone forking
+> the listing.
+
 Maintainer runbook. The CA submission files live at the **root of this repo** —
 `ca_profile.xml` + `templates/subwave.xml` — so the app and its store listing
 stay versioned together. The runnable artifact is the `subwave-aio` image

--- a/docs/unraid.md
+++ b/docs/unraid.md
@@ -17,6 +17,9 @@ five minutes either way.
 
 ## Option 1 — One-click (Community Applications)
 
+SUB/WAVE is **live in Community Applications** —
+[ca.unraid.net/apps/sub-wave](https://ca.unraid.net/apps/sub-wave-073qgwu0ch9rtu).
+
 The Apps store catalogue is one container per template, so the one-click image
 (`subwave-aio`) bundles the whole stack — icecast2 + liquidsoap, the controller,
 the web UI and a Caddy edge — into a single container behind one port. It's the
@@ -43,11 +46,11 @@ same images as the Compose stack, just packaged together.
 > grows — hourly archives, the library cache, rendered voices — so point it at
 > `/mnt/user/appdata/subwave`, never `/boot/...`.
 
-### Not in the store yet? Install by Template URL
+### Install a pre-release by Template URL
 
-Until the Community Applications listing is approved (or to try a pre-release),
-add it directly: **Docker** tab → **Add Container** → paste this into
-**Template URL**, then fill the same fields:
+To run a build before it propagates into the Apps catalogue (e.g. testing a
+new tag), add the template directly instead of searching: **Docker** tab →
+**Add Container** → paste this into **Template URL**, then fill the same fields:
 
 ```
 https://raw.githubusercontent.com/perminder-klair/subwave/main/templates/subwave.xml

--- a/templates/subwave.xml
+++ b/templates/subwave.xml
@@ -16,25 +16,23 @@
   <WebUI>http://[IP]:[PORT:80]</WebUI>
 
   <Overview>
-    SUB/WAVE is a personal internet radio station: one Icecast stream every
-    listener hears together, with an AI DJ that picks tracks from your own
-    Navidrome / Subsonic library and reads scripts between them (station IDs,
-    the time, the weather, listener requests).
+    SUB/WAVE is a personal internet radio station. One Icecast stream, everyone
+    hears the same thing at once, and an AI DJ pulls the tracks from your own
+    Navidrome (or any Subsonic) library and talks between them: station IDs, the
+    time, the weather, song requests.
 
-    This is the all-in-one image — icecast2 + liquidsoap, the controller, the
-    Next.js web UI and a Caddy edge all run in this one container behind a
-    single port. Everything persists under the Appdata path.
+    This is the all-in-one build. Icecast, Liquidsoap, the DJ controller, the web
+    player and a Caddy front-end all run in this single container on one port.
+    Your settings, library cache and recordings live under the Appdata path.
 
-    [b]After it starts, open the WebUI and go to /onboarding[/b] (sign in with
-    the admin user/password you set here) to point it at your Navidrome server,
-    pick an LLM provider (Ollama local or cloud, or a cloud API key) and a
-    voice, and shape the DJ persona. The bundled Piper voice means the DJ can
-    talk out of the box with no extra setup.
+    Once it's up, open the WebUI and go to /onboarding. Sign in with the admin
+    login you set here, point it at your Navidrome server, choose an LLM provider
+    and a voice, and give the DJ a personality. There's a built-in Piper voice,
+    so it can talk straight away with nothing else to install.
 
-    Needs: a reachable Navidrome / Subsonic music server, and an LLM provider.
-    Most Unraid boxes have no big GPU, so Ollama cloud models are the easiest
-    path — install the official ollama container, run "ollama signin" in its
-    console, then set the provider to "Ollama - local/cloud" with a :cloud model.
+    No big GPU? That's most Unraid boxes. Install the official ollama container,
+    run "ollama signin" in its console, and pick an Ollama cloud model. A small
+    local model works too if you'd rather keep everything on the box.
   </Overview>
 
   <Support>https://github.com/perminder-klair/subwave/issues</Support>

--- a/web/components/setup/Development.tsx
+++ b/web/components/setup/Development.tsx
@@ -6,7 +6,7 @@ export default function Development() {
     <SetupPage
       eyebrow="SETUP · 04"
       title="Hacking on SUB/WAVE."
-      intro="Three compose files, three deployment shapes. Icecast and Liquidsoap live together in a single broadcast container in every shape. Dev mode runs the radio backend in Docker and the Next.js UI on the host with hot reload, so you can iterate on the web without a rebuild. The two prod variants differ only at the edge. One bundles Caddy, the other binds host ports for your own reverse proxy."
+      intro="Three compose files, three deployment shapes. In every one, Icecast and Liquidsoap share a single broadcast container. Dev mode runs the radio backend in Docker and the Next.js UI on the host with hot reload, so you can work on the web without a rebuild. The two prod variants differ only at the edge: one bundles Caddy, the other binds host ports for your own reverse proxy."
       current="/setup/development"
     >
       <section className="bs-section">
@@ -23,12 +23,12 @@ export default function Development() {
           <tbody>
             <tr>
               <td><code className="bs-code-inline">docker-compose.yml</code></td>
-              <td>prod — broadcast · controller · web · caddy edge on <code className="bs-code-inline">:7700</code></td>
+              <td>prod: broadcast · controller · web · caddy edge on <code className="bs-code-inline">:7700</code></td>
               <td><code className="bs-code-inline">${'{STATE_DIR:-<repo>/state}'}</code></td>
             </tr>
             <tr>
               <td><code className="bs-code-inline">docker-compose.byo.yml</code></td>
-              <td>same as prod minus caddy — web, controller, broadcast on host ports{' '}
+              <td>same as prod minus caddy: web, controller, broadcast on host ports{' '}
                 <code className="bs-code-inline">:7700</code> /{' '}
                 <code className="bs-code-inline">:7701</code> /{' '}
                 <code className="bs-code-inline">:7702</code> for your own reverse proxy
@@ -37,7 +37,7 @@ export default function Development() {
             </tr>
             <tr>
               <td><code className="bs-code-inline">docker-compose.dev.yml</code></td>
-              <td>dev — broadcast · controller with <code className="bs-code-inline">tsx watch</code> hot-reload (web runs separately on host)</td>
+              <td>dev: broadcast · controller with <code className="bs-code-inline">tsx watch</code> hot-reload (web runs separately on host)</td>
               <td><code className="bs-code-inline">./state</code></td>
             </tr>
           </tbody>
@@ -64,7 +64,7 @@ export default function Development() {
           <div className="bs-cmd">
             <CodeBlock>{`npm run dev:docker`}</CodeBlock>
             <p>
-              <code className="bs-code-inline">docker compose up -d</code> — radio
+              <code className="bs-code-inline">docker compose up -d</code>, radio
               backend only.
             </p>
           </div>
@@ -72,14 +72,14 @@ export default function Development() {
             <CodeBlock>{`npm run dev:web`}</CodeBlock>
             <p>
               <code className="bs-code-inline">next dev</code> on{' '}
-              <code className="bs-code-inline">:7700</code> — hot-reloaded UI.
+              <code className="bs-code-inline">:7700</code>, the hot-reloaded UI.
             </p>
           </div>
           <div className="bs-cmd">
             <CodeBlock>{`npm run rebuild`}</CodeBlock>
             <p>
-              <code className="bs-code-inline">docker compose up -d --build</code> —
-              rarely needed in dev, since <code className="bs-code-inline">controller/src</code>{' '}
+              <code className="bs-code-inline">docker compose up -d --build</code>.
+              Rarely needed in dev, since <code className="bs-code-inline">controller/src</code>{' '}
               and <code className="bs-code-inline">radio.liq</code> are bind-mounted.
             </p>
           </div>
@@ -105,11 +105,11 @@ export default function Development() {
         <div className="bs-cmd-list">
           <div className="bs-cmd">
             <CodeBlock>{`npm run dev:docker`}</CodeBlock>
-            <p>Terminal 1 — radio backend (broadcast + controller).</p>
+            <p>Terminal 1, radio backend (broadcast + controller).</p>
           </div>
           <div className="bs-cmd">
             <CodeBlock>{`npm run dev:web`}</CodeBlock>
-            <p>Terminal 2 — Next.js on http://localhost:7700.</p>
+            <p>Terminal 2, Next.js on http://localhost:7700.</p>
           </div>
         </div>
         <p>

--- a/web/components/setup/ManualInstall.tsx
+++ b/web/components/setup/ManualInstall.tsx
@@ -16,24 +16,24 @@ export default function ManualInstall() {
     <SetupPage
       eyebrow="SETUP · 03"
       title="Run the commands yourself."
-      intro="The no-CLI alternative: same outcome, no `subwave` binary on your host. Useful if you'd rather not run an installer, are scripting the deploy, want a non-standard layout, or just prefer running each command by hand. These four steps land at a public-facing single-host deploy: Caddy on the edge, Cloudflare in front, internal-only Icecast, Controller, and Web."
+      intro="The no-CLI route: same result, no `subwave` binary on your host. Reach for it if you'd rather not run an installer, you're scripting the deploy, or you just like typing the commands yourself. Four steps get you a public single-host deploy: Caddy on the edge, Cloudflare in front, and Icecast, Controller, and Web kept internal."
       current="/setup/manual"
     >
       <section className="bs-section">
         <div className="bs-callout">
           <div className="bs-eyebrow">PREFER THE CLI?</div>
           <p>
-            If you don&apos;t mind a single binary on your host, the standalone
-            CLI collapses these four steps into{' '}
+            If a single binary on your host doesn&apos;t bother you, the standalone
+            CLI folds these four steps into{' '}
             <code className="bs-code-inline">curl … | sh</code> (which chains{' '}
             <code className="bs-code-inline">init</code> and{' '}
             <code className="bs-code-inline">start</code> behind two Enter
             prompts) followed by{' '}
-            <code className="bs-code-inline">subwave setup</code>; see{' '}
-            <Link href="/setup/quick-start">Quick Start</Link>. It uses the
+            <code className="bs-code-inline">subwave setup</code>. See{' '}
+            <Link href="/setup/quick-start">Quick Start</Link>. It pulls the
             same compose images and writes to the same{' '}
-            <code className="bs-code-inline">state/</code> layout; nothing is
-            locked in.
+            <code className="bs-code-inline">state/</code> layout, so you can switch
+            between the two whenever you like.
           </p>
         </div>
         <div className="bs-step">
@@ -51,20 +51,20 @@ curl -O https://raw.githubusercontent.com/perminder-klair/subwave/main/.env.exam
 mv .env.example .env
 $EDITOR .env`}</CodeBlock>
             <p>
-              Only three keys are required to boot the stack. The rest are collected by the
-              first-run wizard at <code className="bs-code-inline">/onboarding</code>{' '}
-              after the containers come up.
+              Three keys boot the stack. The first-run wizard at{' '}
+              <code className="bs-code-inline">/onboarding</code> collects the rest once
+              the containers come up.
             </p>
             <CodeBlock lang="env">{ROOT_ENV_TEMPLATE}</CodeBlock>
             <div className="bs-callout">
               <div className="bs-eyebrow">PREFER A CLONE?</div>
               <p>
                 Clone the repo and run{' '}
-                <code className="bs-code-inline">./scripts/setup.sh</code>; it scaffolds
-                the same <code className="bs-code-inline">.env</code> + sets state-dir
-                perms. Or run <code className="bs-code-inline">npm run setup</code> for
-                an interactive terminal wizard that does the equivalent of the browser
-                flow without ever opening a browser.
+                <code className="bs-code-inline">./scripts/setup.sh</code>. It scaffolds
+                the same <code className="bs-code-inline">.env</code> and sets the
+                state-dir permissions. Or run{' '}
+                <code className="bs-code-inline">npm run setup</code> for a terminal
+                wizard that does the same thing the browser flow does, no browser needed.
               </p>
             </div>
           </div>
@@ -79,14 +79,14 @@ $EDITOR .env`}</CodeBlock>
             <ul className="bs-list">
               <li>
                 <strong>broadcast</strong> — icecast2 and liquidsoap together in one
-                container. Generates three random Icecast passwords on first boot,
-                persisted to{' '}
+                container. On first boot it generates three random Icecast passwords and
+                saves them to{' '}
                 <code className="bs-code-inline">state/icecast-secrets.env</code>{' '}
                 (no <code className="bs-code-inline">scripts/setup.sh</code> step
-                needed for this); the entrypoint sources them before exec-ing
-                liquidsoap. Internal-only.
+                needed). The entrypoint sources them before it execs liquidsoap.
+                Internal-only.
               </li>
-              <li><strong>controller</strong> — the DJ brain; the one talking to
+              <li><strong>controller</strong> — the DJ brain. This is the one that talks to
               Navidrome and your LLM.</li>
               <li><strong>web</strong> — Next.js UI, internal-only</li>
               <li>
@@ -97,13 +97,14 @@ $EDITOR .env`}</CodeBlock>
             <div className="bs-callout">
               <div className="bs-eyebrow">PIN A VERSION</div>
               <p>
+                By default,{' '}
                 <code className="bs-code-inline">docker-compose.yml</code> pulls{' '}
-                <code className="bs-code-inline">ghcr.io/perminder-klair/subwave-*:latest</code>{' '}
-                by default. Pin a specific release with{' '}
+                <code className="bs-code-inline">ghcr.io/perminder-klair/subwave-*:latest</code>.
+                To pin a release, set{' '}
                 <code className="bs-code-inline">SUBWAVE_VERSION=v1.2.3</code> in your
-                root <code className="bs-code-inline">.env</code>. Add{' '}
-                <code className="bs-code-inline">--build</code> to the up command to
-                build from a local clone instead.
+                root <code className="bs-code-inline">.env</code>. To build from a local
+                clone instead, add{' '}
+                <code className="bs-code-inline">--build</code> to the up command.
               </p>
             </div>
             <div className="bs-callout">
@@ -117,14 +118,15 @@ $EDITOR .env`}</CodeBlock>
                 <code className="bs-code-inline">:7702</code>.
               </p>
               <p>
-                <strong>You must front this with a reverse proxy.</strong> The web
+                <strong>You have to front this with a reverse proxy.</strong> The web
                 UI calls <code className="bs-code-inline">/api/*</code>,{' '}
                 <code className="bs-code-inline">/stream.mp3</code>, and{' '}
-                <code className="bs-code-inline">/stream.opus</code> same-origin
-                (those paths are baked into the image at build time). Without a
+                <code className="bs-code-inline">/stream.opus</code> same-origin,
+                and those paths are baked into the image at build time. Without a
                 proxy routing them to the controller and Icecast, the page loads
-                but the player is dead: no metadata, no audio. Route table to
-                replicate (mirrors <code className="bs-code-inline">docker/Caddyfile</code>):
+                but the player is dead: no metadata, no audio. Here&apos;s the route table
+                to replicate (it mirrors{' '}
+                <code className="bs-code-inline">docker/Caddyfile</code>):
               </p>
               <CodeBlock>{`/stream.mp3   →  host:7702           # disable proxy buffering for live audio
 /stream.opus  →  host:7702           # ditto — Ogg-Opus mount served from same Icecast
@@ -153,8 +155,8 @@ $EDITOR .env`}</CodeBlock>
               Sign in with the{' '}
               <code className="bs-code-inline">ADMIN_USER</code> /{' '}
               <code className="bs-code-inline">ADMIN_PASS</code> you set in{' '}
-              <code className="bs-code-inline">.env</code>. The wizard collects, probes
-              live, and persists:
+              <code className="bs-code-inline">.env</code>. The wizard collects each of
+              these, tests them against the live service, and saves them:
             </p>
             <ul className="bs-list">
               <li><strong>Navidrome</strong> — URL + user + pass. Saved to{' '}
@@ -182,9 +184,8 @@ $EDITOR .env`}</CodeBlock>
               <div className="bs-eyebrow">PREFER THE TERMINAL?</div>
               <p>
                 <code className="bs-code-inline">npm run setup</code> walks the same flow
-                without a browser. Same probes, same persistence, same end state. Need
-                <code className="bs-code-inline"> git clone</code> + Node 20+ for that
-                path.
+                in the terminal. Same checks, same saved config, same end state. That path
+                needs a <code className="bs-code-inline"> git clone</code> and Node 20+.
               </p>
             </div>
           </div>
@@ -195,7 +196,7 @@ $EDITOR .env`}</CodeBlock>
           <div className="bs-step-body">
             <h3>Verify the broadcast</h3>
             <p>
-              The repo ships a health probe that checks the containers, hits{' '}
+              The repo ships a health probe. It checks the containers, hits{' '}
               <code className="bs-code-inline">/api/health</code> and{' '}
               <code className="bs-code-inline">/api/now-playing</code>, and scans recent logs
               for errors. Run it after any deploy:
@@ -210,7 +211,7 @@ $EDITOR .env`}</CodeBlock>
               <p>
                 <code className="bs-code-inline">npm start</code> opens the operator console:
                 a menu for stack status, a diagnostic sweep, logs, restart, and the terminal
-                player. The everyday way to run the station once it's installed.
+                player. It&apos;s how you&apos;ll run the station day to day once it&apos;s installed.
               </p>
             </div>
           </div>
@@ -223,7 +224,7 @@ $EDITOR .env`}</CodeBlock>
         <p>
           The stack is on the air. When a new version lands, head to{' '}
           <Link href="/setup/updates" className="bs-link">Updates &amp; Help</Link> for the
-          rebuild-only-what-changed workflow and the troubleshooting checklist.
+          rebuild-only-what-changed workflow and a troubleshooting checklist.
         </p>
       </section>
     </SetupPage>

--- a/web/components/setup/Prerequisites.tsx
+++ b/web/components/setup/Prerequisites.tsx
@@ -6,7 +6,7 @@ export default function Prerequisites() {
     <SetupPage
       eyebrow="SETUP · 01"
       title="Have these ready."
-      intro="SUB/WAVE doesn't ship Navidrome or Ollama; it talks to yours. Get them running first if they aren't already, and note the URLs and credentials. The install wizard will ask for them."
+      intro="SUB/WAVE doesn't ship Navidrome or Ollama; it talks to yours. Get them running first if they aren't already, and write down the URLs and credentials. The install wizard asks for them."
       current="/setup/prerequisites"
     >
       <section className="bs-section">
@@ -46,10 +46,10 @@ export default function Prerequisites() {
             <p>
               The DJ's words and track picks come from a language model. The
               homelab default is <strong>Ollama</strong> with a tool-capable model
-              (<code>gemma4:12b</code> is a great pick; qwen3.5 and qwen3.6 also work).
+              (<code>gemma4:12b</code> works well; so do qwen3.5 and qwen3.6).
               Note the URL and model name.
               Prefer a hosted model? Anthropic, OpenAI, Google, OpenRouter, and
-              DeepSeek are all supported; you pick the provider and supply its key
+              DeepSeek all work. You pick the provider and supply its key
               in the admin Settings UI after install, not during setup.{' '}
               <a
                 href="https://ollama.com/"

--- a/web/components/setup/QuickStart.tsx
+++ b/web/components/setup/QuickStart.tsx
@@ -6,7 +6,7 @@ export default function QuickStart() {
     <SetupPage
       eyebrow="SETUP · 02"
       title="The easy way in."
-      intro="Two hands-off paths to a running stack. The interactive wizard asks a few questions and does the rest; the agent skill does the same from one sentence in your AI coding tool. Either one ends with the radio on the air."
+      intro="Two hands-off paths to a running stack. The wizard asks a few questions and does the rest. The agent skill does the same from one sentence in your AI coding tool. Either way, the radio ends up on the air."
       current="/setup/quick-start"
     >
       <section className="bs-section">
@@ -17,9 +17,9 @@ export default function QuickStart() {
           host (no Node required), then chains straight into{' '}
           <code className="bs-code-inline">init</code> and{' '}
           <code className="bs-code-inline">start</code>. By the time the
-          installer finishes, Docker is up and the controller is reporting
-          on-air; <code className="bs-code-inline">setup</code> is the only
-          step left, and it covers configuration, not lifecycle.
+          installer finishes, Docker is up and the controller reports on-air.
+          That leaves <code className="bs-code-inline">setup</code>, which
+          handles configuration rather than lifecycle.
         </p>
         <div className="bs-faststart">
           <p className="bs-eyebrow">TWO COMMANDS</p>
@@ -34,8 +34,8 @@ export default function QuickStart() {
             <code className="bs-code-inline">subwave start</code> runs silently
             against the env <code className="bs-code-inline">init</code> just
             picked. After that,{' '}
-            <code className="bs-code-inline">setup</code> prompts for Navidrome +
-            LLM + DJ persona and renders jingles. Then{' '}
+            <code className="bs-code-inline">setup</code> asks for your Navidrome,
+            LLM, and DJ persona settings and renders jingles. From then on,{' '}
             <code className="bs-code-inline">subwave start / stop / logs / doctor</code>{' '}
             run the station from anywhere on your shell.
           </p>
@@ -77,8 +77,8 @@ export default function QuickStart() {
         <div className="bs-callout">
           <div className="bs-eyebrow">SAFE TO RE-RUN</div>
           <p>
-            Existing env values are kept unless you explicitly ask to reconfigure, so the
-            wizard doubles as a way to bring an existing stack back up.
+            Existing env values stay put unless you ask to reconfigure, so the
+            wizard also works for bringing an existing stack back up.
           </p>
         </div>
       </section>
@@ -87,8 +87,8 @@ export default function QuickStart() {
         <p className="bs-eyebrow">PATH B · AI CODING AGENT</p>
         <h2>One sentence in your coding agent.</h2>
         <p>
-          The repo ships an agent skill that handles setup, deploy, and update: it pings
-          Navidrome and Ollama, boots the stack, generates jingles, and verifies the stream is
+          The repo ships an agent skill that handles setup, deploy, and update. It pings
+          Navidrome and Ollama, boots the stack, generates jingles, and checks that the stream is
           on-air. It works with <strong>Claude Code</strong>, <strong>Codex</strong>,{' '}
           <strong>Cursor</strong>, or anything else that reads{' '}
           <code className="bs-code-inline">AGENTS.md</code>.
@@ -104,10 +104,10 @@ cd subwave`}</CodeBlock>
         <div className="bs-callout">
           <div className="bs-eyebrow">WHY USE THE SKILL</div>
           <p>
-            On updates the same skill detects which services actually changed and rebuilds
+            On updates the same skill works out which services actually changed and rebuilds
             only those. Liquidsoap and the Controller <em>COPY</em> their source at build
             time, so a plain <code className="bs-code-inline">docker compose restart</code>{' '}
-            silently runs stale code; the skill won't make that mistake.
+            quietly runs stale code. The skill won&apos;t make that mistake.
           </p>
         </div>
       </section>
@@ -117,15 +117,15 @@ cd subwave`}</CodeBlock>
         <h2>Run the station from the CLI.</h2>
         <p>
           The setup wizard is one screen of the operator console. Run{' '}
-          <code className="bs-code-inline">npm start</code> from the repo any time to open it:
-          a menu to check the stack, run a diagnostic sweep, tail logs, restart a service,
+          <code className="bs-code-inline">npm start</code> from the repo any time to open it.
+          From the menu you can check the stack, run diagnostics, tail logs, restart a service,
           or open the terminal player.
         </p>
         <CodeBlock>{`npm start`}</CodeBlock>
         <div className="bs-callout">
           <div className="bs-eyebrow">LISTEN FROM THE TERMINAL</div>
           <p>
-            The console's <strong>play</strong> option launches the TUI player: now-playing,
+            The console&apos;s <strong>play</strong> option launches the TUI player: now-playing,
             the timeline, the live booth feed, and track requests, right in your terminal. It
             needs <code className="bs-code-inline">mpv</code> or{' '}
             <code className="bs-code-inline">ffplay</code> for audio, and runs as a read-only

--- a/web/components/setup/SetupOverview.tsx
+++ b/web/components/setup/SetupOverview.tsx
@@ -6,17 +6,17 @@ const PATHS = [
   {
     href: '/setup/quick-start',
     label: 'Quick Start',
-    blurb: 'The standalone CLI — install once, init / setup / start, done.',
+    blurb: 'The standalone CLI. Install once, then init / setup / start.',
   },
   {
     href: '/setup/manual',
     label: 'Manual Install',
-    blurb: 'No CLI on your host — pure docker compose, same outcome.',
+    blurb: 'No CLI on your host: plain docker compose, same result.',
   },
   {
     href: '/setup/development',
     label: 'Development',
-    blurb: 'Hacking on SUB/WAVE itself — the three compose files and hot reload.',
+    blurb: 'Working on SUB/WAVE itself: the three compose files and hot reload.',
   },
 ];
 
@@ -26,7 +26,7 @@ export default function SetupOverview() {
       eyebrow="SELF-HOSTED · OPEN SOURCE"
       title="Run your own SUB/WAVE."
       meta="≈ 10 min · 4 commands · needs Navidrome + an LLM"
-      intro="SUB/WAVE points at your Navidrome library and your LLM: a local Ollama box by default, or any hosted provider you prefer. Once it's running, the AI DJ broadcasts from your homelab, plays from your music collection, and answers requests from anyone with the URL."
+      intro="SUB/WAVE points at your Navidrome library and your LLM, which is a local Ollama box by default, or any hosted provider you like. Once it's running, the AI DJ broadcasts from your homelab, picks tracks from your own collection, and takes requests from anyone you share the URL with."
       current="/setup"
       heroAside={
         <div className="bs-dj-glyph" aria-hidden="true">
@@ -63,9 +63,9 @@ export default function SetupOverview() {
           <p className="text-muted">
             After that,{' '}
             <code className="bs-code-inline">subwave status / logs / doctor / restart / update</code>{' '}
-            drive the station from anywhere on your shell, with no{' '}
+            run the station from any shell. No{' '}
             <code className="bs-code-inline">cd</code> into a project dir, no clone
-            required. Prefer pure <code className="bs-code-inline">docker compose</code>?{' '}
+            needed. Prefer plain <code className="bs-code-inline">docker compose</code>?{' '}
             <Link href="/setup/manual" className="bs-link">Manual Install</Link>{' '}
             covers that path.
           </p>
@@ -79,16 +79,16 @@ export default function SetupOverview() {
           SUB/WAVE talks to services it doesn't ship, so a couple of things need
           to be running first.{' '}
           <Link href="/setup/prerequisites" className="bs-link">Prerequisites</Link>{' '}
-          covers them, then pick whichever install path suits you — they all land
-          at the same place:
+          covers them. Then pick whichever install path suits you. They all end
+          up at the same place:
         </p>
         <ul className="bs-list">
           {PATHS.map((p) => (
             <li key={p.href}>
               <Link href={p.href} className="bs-link">
                 <strong>{p.label}</strong>
-              </Link>{' '}
-              — {p.blurb}
+              </Link>
+              {`: ${p.blurb}`}
             </li>
           ))}
         </ul>

--- a/web/components/setup/Unraid.tsx
+++ b/web/components/setup/Unraid.tsx
@@ -20,21 +20,22 @@ export default function Unraid() {
     <SetupPage
       eyebrow="SETUP · UNRAID"
       title="Run it on Unraid."
-      intro="Two supported paths. The easy one: install the one-click all-in-one container from Community Applications. The flexible one: run the full Compose stack via Compose Manager Plus (separate containers, BYO reverse proxy, optional heavy-TTS sidecar). Both finish in the same browser wizard. Start to on-air is about five minutes."
+      intro="Two supported paths. The easy one: install the one-click all-in-one container from Community Applications. The flexible one: run the full Compose stack via Compose Manager Plus, which gives you separate containers, your own reverse proxy, and an optional heavy-TTS sidecar. Both finish in the same browser wizard, and start to on-air takes about five minutes."
       current="/setup/unraid"
     >
       <section className="bs-section">
         <div className="bs-callout">
           <div className="bs-eyebrow">TWO WAYS TO RUN IT</div>
           <p>
-            <strong>One-click (Community Applications)</strong> — the all-in-one
+            <strong>One-click (Community Applications)</strong>: the all-in-one
             image bundles the whole stack into a single container behind one
-            port. Easiest; recommended for most people.{' '}
-            <strong>Full Compose stack (Compose Manager Plus)</strong> — the
+            port. It&apos;s the easiest path, and the right one for most people.{' '}
+            <strong>Full Compose stack (Compose Manager Plus)</strong>: the
             maintained{' '}
-            <code className="bs-code-inline">docker-compose.yml</code> as
-            separate broadcast / controller / web / Caddy services. Pick it for
-            isolated containers, your own proxy, or the heavy-TTS sidecar.
+            <code className="bs-code-inline">docker-compose.yml</code> run as
+            separate broadcast, controller, web, and Caddy services. Pick it if
+            you want isolated containers, your own proxy, or the heavy-TTS
+            sidecar.
           </p>
         </div>
       </section>
@@ -43,10 +44,18 @@ export default function Unraid() {
         <p className="bs-eyebrow">OPTION 1 — ONE-CLICK</p>
         <h2>Community Applications.</h2>
         <p>
-          The Apps catalogue is one container per template, so the{' '}
+          SUB/WAVE is{' '}
+          <Link
+            href="https://ca.unraid.net/apps/sub-wave-073qgwu0ch9rtu"
+            className="bs-link"
+          >
+            live in Community Applications
+          </Link>
+          . The Apps catalogue is one container per template, so the{' '}
           <code className="bs-code-inline">subwave-aio</code> image bundles
-          icecast2 + liquidsoap, the controller, the web UI and a Caddy edge
-          together. Same images as the Compose stack — just packaged into one.
+          icecast2 + liquidsoap, the controller, the web UI, and a Caddy edge
+          together. These are the same images the Compose stack uses, just
+          packaged into one.
         </p>
 
         <div className="bs-step">
@@ -59,30 +68,30 @@ export default function Unraid() {
             </p>
             <ul className="bs-list">
               <li>
-                <strong>WebUI Port</strong> — host port for the UI + stream
+                <strong>WebUI Port</strong>: host port for the UI and stream
                 (default <code className="bs-code-inline">7700</code>).
               </li>
               <li>
-                <strong>Appdata</strong> —{' '}
+                <strong>Appdata</strong>:{' '}
                 <code className="bs-code-inline">/mnt/user/appdata/subwave</code>,
-                on the array/pool (<em>not</em> the flash).
+                on the array or pool (<em>not</em> the flash).
               </li>
               <li>
-                <strong>ADMIN_USER</strong> / <strong>ADMIN_PASS</strong> — your
-                admin login; the password is <strong>required</strong>.
+                <strong>ADMIN_USER</strong> / <strong>ADMIN_PASS</strong>: your
+                admin login. The password is <strong>required</strong>.
               </li>
               <li>
-                <strong>SITE_URL</strong> —{' '}
+                <strong>SITE_URL</strong>:{' '}
                 <code className="bs-code-inline">http://YOUR-UNRAID-IP:7700</code>.
               </li>
             </ul>
             <div className="bs-callout">
               <div className="bs-eyebrow">KEEP APPDATA OFF THE FLASH</div>
               <p>
-                SUB/WAVE&apos;s state grows — hourly archives, the library cache,
-                rendered voices. Point <strong>Appdata</strong> at{' '}
+                SUB/WAVE&apos;s state grows over time: hourly archives, the
+                library cache, rendered voices. Point <strong>Appdata</strong> at{' '}
                 <code className="bs-code-inline">/mnt/user/appdata/subwave</code>{' '}
-                on your pool/array, never{' '}
+                on your pool or array, never{' '}
                 <code className="bs-code-inline">/boot/…</code>.
               </p>
             </div>
@@ -98,19 +107,19 @@ export default function Unraid() {
               Sign in with the{' '}
               <code className="bs-code-inline">ADMIN_USER</code> /{' '}
               <code className="bs-code-inline">ADMIN_PASS</code> you set, and the
-              wizard collects the rest — Navidrome, the LLM provider, TTS, the DJ
-              persona. The player is at{' '}
+              wizard collects the rest: Navidrome, the LLM provider, TTS, and the
+              DJ persona. The player lives at{' '}
               <code className="bs-code-inline">http://YOUR-UNRAID-IP:7700</code>.
             </p>
           </div>
         </div>
 
         <div className="bs-callout">
-          <div className="bs-eyebrow">NOT IN THE STORE YET?</div>
+          <div className="bs-eyebrow">PRE-RELEASE? TEMPLATE URL</div>
           <p>
-            Until the listing is approved (or to try a pre-release), add it
-            directly: <strong>Docker</strong> tab &rarr;{' '}
-            <strong>Add Container</strong> &rarr; paste this into{' '}
+            To run a build before it propagates into the Apps catalogue, say
+            you&apos;re testing a new tag, add it directly: <strong>Docker</strong>{' '}
+            tab &rarr; <strong>Add Container</strong> &rarr; paste this into{' '}
             <strong>Template URL</strong>, then fill the same fields.
           </p>
           <CodeBlock>{TEMPLATE_URL}</CodeBlock>
@@ -123,8 +132,9 @@ export default function Unraid() {
         <p>
           Run the maintained{' '}
           <code className="bs-code-inline">docker-compose.yml</code> as separate
-          services — good for isolated containers, your own Traefik/SWAG/NPM in
-          front, or the optional Chatterbox/PocketTTS sidecar.
+          services. It&apos;s a good fit for isolated containers, your own
+          Traefik/SWAG/NPM in front, or the optional Chatterbox/PocketTTS
+          sidecar.
         </p>
 
         <div className="bs-step">
@@ -137,7 +147,8 @@ export default function Unraid() {
               <code className="bs-code-inline">mstrhakr</code>) and install the
               stable release. It adds a <strong>Compose</strong> section to the{' '}
               <strong>Docker</strong> tab. You&apos;ll also want Docker enabled and
-              the array (or a pool) started so there&apos;s somewhere for appdata.
+              the array (or a pool) started so there&apos;s somewhere for appdata
+              to live.
             </p>
           </div>
         </div>
@@ -154,21 +165,21 @@ export default function Unraid() {
             </p>
             <ul className="bs-list">
               <li>
-                <strong>Compose</strong> tab — paste the contents of the default{' '}
+                <strong>Compose</strong> tab: paste the contents of the default{' '}
                 <Link
                   href="https://raw.githubusercontent.com/perminder-klair/subwave/main/docker-compose.yml"
                   className="bs-link"
                 >
                   docker-compose.yml
                 </Link>
-                . Five containers; only Caddy binds a host port (
+                . There are five containers, and only Caddy binds a host port (
                 <code className="bs-code-inline">:7700</code>). The optional{' '}
                 <code className="bs-code-inline">tts-heavy</code> sidecar is
-                profile-gated and won&apos;t start — the DJ falls back to the
+                profile-gated and won&apos;t start, so the DJ falls back to the
                 built-in Piper voice.
               </li>
               <li>
-                <strong>.env</strong> tab — the three required keys plus two
+                <strong>.env</strong> tab: the three required keys plus two
                 Unraid-specific ones:
               </li>
             </ul>
@@ -179,12 +190,12 @@ export default function Unraid() {
                 Compose Manager&apos;s project directory lives on the USB flash
                 (<code className="bs-code-inline">/boot/…</code>), so the compose
                 default of <code className="bs-code-inline">./state</code> would
-                write SUB/WAVE&apos;s growing state — hourly archives, the library
-                cache, rendered voices — onto the boot stick. Set{' '}
+                write SUB/WAVE&apos;s growing state (hourly archives, the library
+                cache, rendered voices) onto the boot stick. Set{' '}
                 <code className="bs-code-inline">STATE_DIR</code> to an absolute
-                appdata path on your pool/array (
+                appdata path on your pool or array (
                 <code className="bs-code-inline">/mnt/user/appdata/subwave/state</code>
-                ); Docker creates it on first start.
+                ), and Docker creates it on first start.
               </p>
             </div>
           </div>
@@ -205,11 +216,11 @@ export default function Unraid() {
                 The compose file carries{' '}
                 <code className="bs-code-inline">build:</code> blocks so a source
                 checkout can rebuild locally. The Unraid project directory has no
-                source, so a plain <em>up</em> would try to build and fail.{' '}
+                source, so a plain <em>up</em> tries to build and fails.{' '}
                 <strong>Pull &amp; Up</strong> fetches the prebuilt images from
-                GHCR first, then starts them. (Alternatively, delete the{' '}
+                GHCR first, then starts them. If you&apos;d rather, delete the{' '}
                 <code className="bs-code-inline">build:</code> blocks and plain{' '}
-                <em>up</em> works too.)
+                <em>up</em> works too.
               </p>
             </div>
           </div>
@@ -221,8 +232,8 @@ export default function Unraid() {
             <h3>Finish setup in the browser</h3>
             <CodeBlock>{`open http://YOUR-UNRAID-IP:7700/onboarding`}</CodeBlock>
             <p>
-              Same wizard as the one-click path — Navidrome, the LLM provider,
-              TTS, the DJ persona.
+              Same wizard as the one-click path: Navidrome, the LLM provider,
+              TTS, and the DJ persona.
             </p>
           </div>
         </div>
@@ -234,9 +245,9 @@ export default function Unraid() {
           <p>
             Applies to both options. SUB/WAVE ships a first-class{' '}
             <strong>&ldquo;Ollama — local/cloud&rdquo;</strong> provider. Most
-            Unraid boxes lack a big GPU, so the nicest path is Ollama&apos;s{' '}
-            <strong>cloud models</strong>, which offload inference — even a
-            low-power box (e.g. an Intel N95) handles them fine:
+            Unraid boxes don&apos;t have a big GPU, so the nicest path is
+            Ollama&apos;s <strong>cloud models</strong>, which offload inference.
+            Even a low-power box like an Intel N95 handles them fine:
           </p>
           <ul className="bs-list">
             <li>
@@ -254,9 +265,9 @@ export default function Unraid() {
               In <strong>admin &rarr; Settings &rarr; LLM Provider</strong>: set
               provider <strong>Ollama — local/cloud</strong>, server URL{' '}
               <code className="bs-code-inline">http://host.docker.internal:11434</code>
-              , and a <code className="bs-code-inline">:cloud</code> model tag (e.g.{' '}
-              <code className="bs-code-inline">glm-5.2:cloud</code>) — or a small
-              local tag like{' '}
+              , and a <code className="bs-code-inline">:cloud</code> model tag such
+              as <code className="bs-code-inline">glm-5.2:cloud</code>. Or pick a
+              small local tag like{' '}
               <code className="bs-code-inline">llama3.2:3b</code> to run on CPU.
             </li>
           </ul>
@@ -265,22 +276,22 @@ export default function Unraid() {
           <div className="bs-eyebrow">GOOD TO KNOW</div>
           <ul className="bs-list">
             <li>
-              <strong>No reverse proxy needed</strong> for LAN use — Caddy fronts{' '}
+              <strong>No reverse proxy needed</strong> for LAN use. Caddy fronts{' '}
               <code className="bs-code-inline">/</code>,{' '}
               <code className="bs-code-inline">/api</code>, and{' '}
               <code className="bs-code-inline">/stream.mp3</code> on the single
-              host port. Want TLS + a hostname behind SWAG / NPM / Traefik? Front
-              that port with it, or (Compose stack) use{' '}
+              host port. Want TLS and a hostname behind SWAG / NPM / Traefik?
+              Front that port with it, or on the Compose stack use{' '}
               <code className="bs-code-inline">docker-compose.byo.yml</code>.
             </li>
             <li>
-              <strong>Updates:</strong> one-click &rarr; Unraid&apos;s normal{' '}
-              <strong>Check for Updates</strong>. Compose stack &rarr; stack menu
-              &rarr; <strong>Pull &amp; Up</strong>.
+              <strong>Updates:</strong> for one-click, use Unraid&apos;s normal{' '}
+              <strong>Check for Updates</strong>. For the Compose stack, open the
+              stack menu &rarr; <strong>Pull &amp; Up</strong>.
             </li>
             <li>
-              <strong>Backups:</strong> everything lives under the appdata path —
-              settings, library cache, archives, voices. Back up{' '}
+              <strong>Backups:</strong> everything lives under the appdata path,
+              settings, library cache, archives, and voices included. Back up{' '}
               <code className="bs-code-inline">/mnt/user/appdata/subwave</code>.
             </li>
           </ul>
@@ -293,7 +304,7 @@ export default function Unraid() {
         <p>
           The station is on the air. When a new version lands, head to{' '}
           <Link href="/setup/updates" className="bs-link">Updates &amp; Help</Link>{' '}
-          for the update workflow and the troubleshooting checklist.
+          for the update workflow and a troubleshooting checklist.
         </p>
       </section>
     </SetupPage>

--- a/web/components/setup/Updates.tsx
+++ b/web/components/setup/Updates.tsx
@@ -7,7 +7,7 @@ export default function Updates() {
     <SetupPage
       eyebrow="SETUP · 05"
       title="Updates & help."
-      intro="Pulling a new version, rebuilding only what changed, and what to check when the stream goes quiet. Liquidsoap and the Controller COPY source at build time, so docker compose restart does not pick up code changes. You need up -d --build."
+      intro="How to pull a new version, rebuild only what changed, and what to check when the stream goes quiet. Liquidsoap and the Controller COPY source at build time, so docker compose restart does not pick up code changes. You need up -d --build."
       current="/setup/updates"
     >
       <section className="bs-section">
@@ -31,8 +31,8 @@ export default function Updates() {
         </table>
 
         <p className="mt-4">
-          Typical manual deploy: pull, rebuild only what changed (here, controller
-          + web), then verify:
+          A manual deploy usually looks like this: pull, rebuild what changed
+          (controller and web here), then check the stream is back.
         </p>
         <CodeBlock>{`git pull --ff-only
 docker compose up -d --build controller web
@@ -43,13 +43,13 @@ docker compose up -d --build controller web
           <p>
             If you installed via{' '}
             <code className="bs-code-inline">curl cli.getsubwave.com | sh</code>, two
-            commands cover both update axes:
+            commands cover the two things you might want to update:
           </p>
           <CodeBlock>{`subwave update`}</CodeBlock>
           <CodeBlock>{`subwave self-update`}</CodeBlock>
           <p className="text-muted">
-            <code className="bs-code-inline">subwave update</code> is a docker
-            pull + up -d wrapper that knows which compose file is live;{' '}
+            <code className="bs-code-inline">subwave update</code> wraps docker
+            pull + up -d and knows which compose file is live.{' '}
             <code className="bs-code-inline">self-update</code> re-runs the
             installer in place.
           </p>
@@ -67,7 +67,7 @@ docker compose up -d --build controller web
           <CodeBlock>{`docker compose pull
 docker compose up -d`}</CodeBlock>
           <p className="text-muted">
-            Same flow if you&apos;re on{' '}
+            Same flow on{' '}
             <code className="bs-code-inline">docker-compose.byo.yml</code>, just
             swap the file flag.
           </p>
@@ -77,10 +77,10 @@ docker compose up -d`}</CodeBlock>
           <div className="bs-eyebrow">OR LET CLAUDE CODE DO IT</div>
           <p>
             The <code className="bs-code-inline">subwave-deploy</code> skill at{' '}
-            <code className="bs-code-inline">.claude/skills/subwave-deploy/</code> automates
-            the whole "pull, detect what changed, rebuild only the affected services, verify
-            health" loop. Open a Claude Code session in the repo and say{' '}
-            <em>"deploy subwave"</em> or <em>"pull and restart"</em>.
+            <code className="bs-code-inline">.claude/skills/subwave-deploy/</code> does the
+            whole loop for you: pull, work out what changed, rebuild only the affected
+            services, and confirm the stream is healthy. Open a Claude Code session in the
+            repo and say <em>"deploy subwave"</em> or <em>"pull and restart"</em>.
           </p>
         </div>
       </section>
@@ -99,15 +99,15 @@ docker compose up -d`}</CodeBlock>
           </li>
           <li>
             <strong>Operator console</strong> —{' '}
-            <code className="bs-code-inline">npm start</code> opens a menu whose{' '}
-            <strong>doctor</strong> option runs a full diagnostic sweep and{' '}
+            <code className="bs-code-inline">npm start</code> opens a menu. Its{' '}
+            <strong>doctor</strong> option runs a diagnostic sweep, and{' '}
             <strong>logs</strong> tails any service without the long compose flags.
           </li>
           <li>
             <strong>Built-in diagnostics</strong> — open{' '}
             <Link href="/admin/debug" className="bs-link">/admin/debug</Link> for a live
-            snapshot of every state file, recent LLM calls, Icecast status, and the most
-            recent 100 lines of Liquidsoap.
+            look at every state file, recent LLM calls, Icecast status, and the last 100
+            lines of Liquidsoap.
           </li>
           <li>
             <strong>Source code</strong> —{' '}
@@ -123,8 +123,8 @@ docker compose up -d`}</CodeBlock>
         <p className="bs-eyebrow">RUNNING THE STATION</p>
         <h2>Now shape the DJ.</h2>
         <p>
-          Installation is the start. Tuning the personas, scheduling shows, choosing the LLM
-          provider, and managing jingles all happen in the admin console; that's covered in{' '}
+          Installation is just the start. Tuning personas, scheduling shows, picking an LLM
+          provider, and managing jingles all happen in the admin console. That's covered in{' '}
           <Link href="/manual/admin" className="bs-link">the manual's Admin &amp; Settings
           page</Link>.
         </p>

--- a/web/content/news/2026-06-22-one-click-on-unraid.md
+++ b/web/content/news/2026-06-22-one-click-on-unraid.md
@@ -1,0 +1,31 @@
+---
+title: One-click install on Unraid
+date: 2026-06-22
+category: Announcement
+version: v0.26.1
+author: The SUB/WAVE desk
+excerpt: SUB/WAVE is now in the Unraid Community Applications store. Search it in the Apps tab, fill in four fields, and the whole station runs from a single container.
+---
+
+SUB/WAVE is now in the Unraid Community Applications store. If you run Unraid, you can install the whole station from the Apps tab the same way you'd add any other container. No compose file to paste, no .env to hand-edit.
+
+## What's new
+
+There's a new all-in-one image. Icecast, Liquidsoap, the DJ controller, the web player and the Caddy front-end all run inside one container on one port. The Apps store only lists single-container apps, so this image is what makes a one-click listing possible. It's the same code as the multi-container setup, just packed together.
+
+## How to use it
+
+Open the Apps tab, search for SUB/WAVE, and hit Install. Four fields to fill in:
+
+- WebUI Port, the host port for the player and stream (7700 by default)
+- Appdata, a path on your array or pool like `/mnt/user/appdata/subwave`
+- ADMIN_USER and ADMIN_PASS, your admin login
+- SITE_URL, set to `http://YOUR-UNRAID-IP:7700`
+
+Apply, then open the WebUI and go to `/onboarding` to point it at your Navidrome server and pick a voice and an LLM. Keep Appdata on your array or pool, not the USB flash. The station's recordings and library cache grow over time, and the flash is the wrong place for that.
+
+No big GPU? That's most Unraid boxes. Install the official ollama container, run `ollama signin` in its console, and pick a cloud model. A small local model works too if you'd rather keep everything on the box.
+
+## Why it helps
+
+Running SUB/WAVE on Unraid used to mean the Compose Manager Plus plugin: paste a compose file, set an .env, pick the right pull option. That route still works, and it's still the one to use if you want the split containers or your own reverse proxy. For everyone else, a search and four fields is a much shorter trip from "I heard about this" to a DJ on the air.


### PR DESCRIPTION
SUB/WAVE is live in the Unraid Community Applications store — [ca.unraid.net/apps/sub-wave](https://ca.unraid.net/apps/sub-wave-073qgwu0ch9rtu). This updates the docs to match and cleans up the prose.

## Changes

**CA listing is live**
- `docs/unraid.md`, `README.md`, `docs/unraid-ca-submission.md`: note the listing is live; reframe the old "not in the store yet" Template-URL section as a pre-release install path; README's Unraid line now leads with the one-click install.

**Humanized the CA template Overview** (`templates/subwave.xml`)
- Dropped the `[b]…[/b]` tags (Unraid's Overview doesn't render them), cut the em-dashes and the `Needs:` list that duplicated the `<Requires>` field, tightened the text, added a bit of voice.

**Humanized all 7 `/setup` doc pages** (`web/components/setup/*.tsx`)
- Ran each through the humanizer skill: removed em-dash overuse, AI-vocab, rule-of-three padding and promotional tone. Every technical fact, code block, link and JSX prop left intact.

**News dispatch** (`web/content/news/2026-06-22-one-click-on-unraid.md`)
- "One-click install on Unraid" for the `/news` page.

## Verification
- `npm run lint` (eslint + tsc) passes.
- `npm run build` passes; `/news/one-click-on-unraid` and all `/setup/*` pages prerender.

## Note
The live CA Overview won't change until the template is re-scanned at ca.unraid.net (or the feed re-pulls). Doc-only PR — no app/runtime changes.