### PR TITLE
fix(web): resolve schedule "On now" in station timezone

### DIFF
--- a/web/components/drawers/ScheduleDrawer.tsx
+++ b/web/components/drawers/ScheduleDrawer.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { cn } from '@/lib/cn';
-import { fmtClockMinute, normalizeStationLocale } from '@/lib/format';
+import { fmtClockMinute, normalizeStationLocale, zonedDayHour } from '@/lib/format';
 import type {
   ActiveShow,
   ScheduleGrid,
@@ -96,6 +96,9 @@ export default function ScheduleDrawer({ activeShow, context }: ScheduleDrawerPr
   const [now, setNow] = useState(() => new Date());
   // Defaults to today; tapping a day tab flips this without refetching.
   const [viewDay, setViewDay] = useState<number>(() => new Date().getDay());
+  // Once set, stop auto-syncing viewDay to the station's today so a manual day
+  // pick sticks across re-renders/ticks.
+  const [userPickedDay, setUserPickedDay] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -123,8 +126,20 @@ export default function ScheduleDrawer({ activeShow, context }: ScheduleDrawerPr
     return () => window.clearInterval(id);
   }, []);
 
-  const today = now.getDay();
-  const currentHour = now.getHours();
+  // The initial viewDay seeds from the browser's day; once the schedule loads
+  // (and its station timezone with it), snap the default selection to the
+  // station's today — unless the listener has already tapped a day tab.
+  useEffect(() => {
+    if (!data || userPickedDay) return;
+    setViewDay(zonedDayHour(new Date(), data.timezone ?? null).dow);
+  }, [data, userPickedDay]);
+
+  // Resolve "now" in the *station's* timezone, not the viewer's browser zone —
+  // the controller resolves the active show with the same wall clock, so this
+  // keeps the on-now card naming the same show that's actually on air (#418).
+  // Safe before `data` loads: zonedDayHour falls back to local time when tz is
+  // nullish, and every consumer below is guarded on `data`.
+  const { dow: today, hour: currentHour } = zonedDayHour(now, data?.timezone ?? null);
 
   const daySlots = useMemo(() => {
     if (!data) return [];
@@ -219,7 +234,14 @@ export default function ScheduleDrawer({ activeShow, context }: ScheduleDrawerPr
         )}
       </section>
 
-      <DayTabs value={viewDay} today={today} onChange={setViewDay} />
+      <DayTabs
+        value={viewDay}
+        today={today}
+        onChange={d => {
+          setUserPickedDay(true);
+          setViewDay(d);
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Problem

On the **Schedule** tab at `/listen`, the *On now* card named the wrong show — e.g. `On now · until 15:00 — Jazz Deep Cuts at High Sun` while *The Long Road* was actually on air. The **native app player showed it correctly**, which pinned the bug to the web drawer.

The controller resolves the active show in the **station timezone** (`resolveActiveShow` → `zonedParts`, `Europe/London` by default), and `/schedule` already returns that `timezone`. But `web/components/drawers/ScheduleDrawer.tsx` computed "now" from the **viewer's browser clock** (`now.getDay()` / `now.getHours()`), ignoring the payload. When the listener's zone differed from the station's (or near a DST/midnight boundary), the drawer indexed the wrong `schedule[day][hour]` cell.

## Fix

Adopt the existing `zonedDayHour(date, tz)` helper in `web/lib/format.ts` — written for this exact class of bug (#418) but never wired into this component — using the `timezone` the `/schedule` API already returns.

- `today` / `currentHour` now derive from `zonedDayHour(now, data?.timezone)` (drives the *On now* card, *Coming up today*, and the `isNow` row highlight).
- Default `viewDay` snaps to the station's today on load, guarded by a `userPickedDay` flag so a manual day-tab pick sticks.

No controller, API, or native-app changes — they already resolve in station time. The top-of-drawer **Station time** clock was already correct and is untouched.

## Verification

- `cd web && npm run lint` (`eslint . && tsc --noEmit`) — passes.
- Open the Schedule tab: *On now* matches the booth/now-playing show.
- Decisive test: run with a non-station zone (`TZ=America/New_York npm run dev`) and confirm *On now* still tracks the station hour (Europe/London), not the browser's.

> Note: prod serves a baked web image, so shipping to the live site needs `docker compose up -d --build web`.