### PR TITLE
fix(unraid): lowercase CA app name to "subwave" + broaden search terms (discoverability)

### DIFF
--- a/templates/subwave.xml
+++ b/templates/subwave.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <Container version="2">
-  <Name>SUB-WAVE</Name>
+  <Name>subwave</Name>
   <Repository>ghcr.io/perminder-klair/subwave-aio:latest</Repository>
   <Registry>https://ghcr.io/perminder-klair/subwave-aio</Registry>
   <Network>bridge</Network>
@@ -41,7 +41,7 @@
   <ReadMe>https://raw.githubusercontent.com/perminder-klair/subwave/main/README.md</ReadMe>
 
   <Category>MediaApp:Music MediaServer:Music</Category>
-  <ExtraSearchTerms>radio internet radio icecast liquidsoap ai dj navidrome subsonic stream ollama station broadcast</ExtraSearchTerms>
+  <ExtraSearchTerms>subwave sub-wave sub/wave subwave-aio radio internet radio icecast liquidsoap ai dj navidrome subsonic stream ollama station broadcast</ExtraSearchTerms>
   <Requires>A reachable Navidrome / Subsonic music server and an LLM provider (Ollama local/cloud or a cloud API key), both configured in the browser at /onboarding after first boot.</Requires>
 
   <Date>2026-06-22</Date>


### PR DESCRIPTION
## Problem

The CA template named the app `SUB-WAVE` (uppercase + dash). This hurt discoverability: the listing only surfaced when searching the exact styled brand, and the plain word "subwave" wasn't a search token. The uppercase + dash also made the auto-generated slug and default container name awkward — and it was the lone naming outlier, while everything else in the project is already clean lowercase (image `subwave-aio`, repo `subwave`, appdata `/mnt/user/appdata/subwave`, the `subwave` CLI).

## Change (single file: `templates/subwave.xml`)

1. `<Name>SUB-WAVE</Name>` → `<Name>subwave</Name>` (lowercase, no dash).
2. Prepend search tokens to `<ExtraSearchTerms>` so any spelling matches:
   `subwave sub-wave sub/wave subwave-aio …` (existing terms retained after).

The styled brand **SUB/WAVE** is untouched everywhere else (Overview, `ca_profile.xml` Profile, README, the app UI) — only the machine-facing CA `<Name>` goes lowercase.

## Re-slug caveat

The CA listing is already published. Changing `<Name>` re-slugs the listing (`sub-wave-…` → `subwave-…`). This is intentional and low-risk: the listing went live the same day, so there are effectively zero installs to disrupt.

## Notes

- Container v2 template; still valid XML (verified).
- No other CA fields needed changes — `TemplateURL` filename is already `templates/subwave.xml`, appdata default is already lowercase `subwave`.
- Only `templates/subwave.xml` changed.