### PR TITLE
docs(unraid): make BYO reverse-proxy (NPM/SWAG/Traefik) guidance front-and-center

### DIFF
--- a/docs/unraid.md
+++ b/docs/unraid.md
@@ -46,6 +46,11 @@ same images as the Compose stack, just packaged together.
 > grows — hourly archives, the library cache, rendered voices — so point it at
 > `/mnt/user/appdata/subwave`, never `/boot/...`.
 
+Fronting this with your own NPM / SWAG / Traefik for TLS + a hostname? See
+[Putting it behind your own reverse
+proxy](#putting-it-behind-your-own-reverse-proxy) — it's one upstream, with a
+single stream-buffering gotcha to mind.
+
 ### Install a pre-release by Template URL
 
 To run a build before it propagates into the Apps catalogue (e.g. testing a
@@ -142,13 +147,93 @@ N95) handles them fine:
 where the ollama container publishes `11434`. (The one-click template adds the
 `host-gateway` mapping for you; the Compose stack sets it via `extra_hosts`.)
 
+---
+
+## Putting it behind your own reverse proxy
+
+Most Unraid boxes already run a reverse proxy — **Nginx Proxy Manager (NPM)**,
+**SWAG**, **Traefik** or **Caddy** — for TLS and a tidy hostname. Putting
+SUB/WAVE behind yours is the common path, and it's a *single upstream*, not a
+pile of per-path rules. This applies to both options above.
+
+### One upstream, not per-path rules
+
+The one-click AIO image (and the Compose stack's bundled Caddy) already does all
+the same-origin routing internally — `/` → web UI, `/api/*` → controller,
+`/stream.mp3` → the Icecast stream — on the one host port. So your front proxy
+points at a **single** target:
+
+```
+http://YOUR-UNRAID-IP:7700
+```
+
+No separate backends, no per-path forwarding. Map your hostname to that one
+address and the bundled Caddy sorts out the rest.
+
+### Set SITE_URL to the public https URL
+
+Once a hostname fronts the box, set **`SITE_URL`** to the public `https://`
+address — not the `IP:port`:
+
+```ini
+SITE_URL=https://radio.example.com
+```
+
+`SITE_URL` backs share cards and absolute links, so it has to be the address
+listeners actually use. **TLS terminates at your proxy**; SUB/WAVE speaks plain
+HTTP behind it (exactly as the bundled Caddy does behind Cloudflare in the
+reference setup). One-click → edit the **SITE_URL** template field; Compose
+stack → edit `.env` and **Pull & Up**.
+
+### ⚠️ The one gotcha: don't buffer the audio stream
+
+> ⚠️ **Turn response buffering OFF for `/stream.mp3`.** The bundled Caddy serves
+> the stream unbuffered (`flush_interval -1`). A front proxy that buffers — and
+> **NPM buffers by default** — holds the live audio back, adding latency and
+> stutter or stalling playback outright. Exempt the stream path; leave everything
+> else on the proxy's normal settings.
+
+**Nginx Proxy Manager** — open the proxy host → **Advanced** tab and add a
+location block for the stream (the rest of the site keeps NPM's normal proxying
+from the main tab):
+
+```nginx
+location /stream.mp3 {
+    proxy_pass http://YOUR-UNRAID-IP:7700;
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_read_timeout 1h;   # the stream never ends — don't time it out
+}
+```
+
+The same one knob in the other proxies:
+
+| Proxy | What to set on `/stream.mp3` |
+|---|---|
+| **raw nginx** | `proxy_buffering off;` (+ a long `proxy_read_timeout`) in a `location /stream.mp3` block |
+| **Caddy** | `reverse_proxy … { flush_interval -1 }` on the stream path |
+| **Traefik** | nothing — Traefik doesn't buffer responses by default |
+
+### Prefer to drop the bundled Caddy entirely?
+
+If you'd rather your proxy talk to each service directly instead of through the
+AIO's internal Caddy, run the split-container stack (Option 2) with
+[`docker-compose.byo.yml`](https://raw.githubusercontent.com/perminder-klair/subwave/main/docker-compose.byo.yml).
+There `web` / `controller` / `broadcast` bind host ports themselves
+(`7700` / `7701` / `7702`) — but the web image is still baked for same-origin
+`/api` + `/stream.mp3`, so **your proxy then has to replicate the route table**
+(`/` → web, `/api/*` → controller, `/stream.mp3` → broadcast, unbuffered) on one
+hostname. That's more proxy config, not less — only worth it if you specifically
+want the bundled Caddy out of the path. For most people the single-upstream setup
+above is the easier win.
+
 ## Notes
 
 - **No reverse proxy needed** for LAN use — Caddy fronts `/`, `/api`, and
-  `/stream.mp3` on the single host port. If you already run SWAG / NPM /
-  Traefik and want TLS + a hostname, front that port with it, or (Compose stack)
-  switch to
-  [`docker-compose.byo.yml`](https://raw.githubusercontent.com/perminder-klair/subwave/main/docker-compose.byo.yml).
+  `/stream.mp3` on the single host port. Already run SWAG / NPM / Traefik and
+  want TLS + a hostname? See [Putting it behind your own reverse
+  proxy](#putting-it-behind-your-own-reverse-proxy) above — one upstream, plus
+  the one stream-buffering gotcha.
 - **Updates:** one-click → Unraid's normal **Check for Updates** / **Apply
   Update**. Compose stack → stack menu → **Pull & Up**.
 - **Backups:** everything lives under the appdata path

--- a/web/components/setup/Unraid.tsx
+++ b/web/components/setup/Unraid.tsx
@@ -272,6 +272,105 @@ export default function Unraid() {
             </li>
           </ul>
         </div>
+      </section>
+
+      <section className="bs-section" id="reverse-proxy">
+        <p className="bs-eyebrow">BEHIND YOUR OWN PROXY</p>
+        <h2>Putting it behind your reverse proxy.</h2>
+        <p>
+          Most Unraid boxes already run a reverse proxy, NPM / SWAG / Traefik /
+          Caddy, for TLS and a tidy hostname. Putting SUB/WAVE behind yours is
+          the common path, and it&apos;s a <em>single upstream</em>, not a pile
+          of per-path rules. This applies to both options above.
+        </p>
+        <p>
+          The one-click AIO image (and the Compose stack&apos;s bundled Caddy)
+          already does the same-origin routing internally:{' '}
+          <code className="bs-code-inline">/</code> &rarr; web UI,{' '}
+          <code className="bs-code-inline">/api/*</code> &rarr; controller,{' '}
+          <code className="bs-code-inline">/stream.mp3</code> &rarr; the Icecast
+          stream, all on the one host port. So your front proxy points at a
+          single target, with no separate backends and no per-path forwarding.
+        </p>
+        <CodeBlock>{`http://YOUR-UNRAID-IP:7700`}</CodeBlock>
+        <p>
+          Once a hostname fronts the box, set{' '}
+          <code className="bs-code-inline">SITE_URL</code> to the public{' '}
+          <code className="bs-code-inline">https://</code> address, not the{' '}
+          <code className="bs-code-inline">IP:port</code>. It backs share cards
+          and absolute links, so it has to be the address listeners actually
+          use. TLS terminates at your proxy; SUB/WAVE speaks plain HTTP behind
+          it, exactly as the bundled Caddy does behind Cloudflare in the
+          reference setup.
+        </p>
+        <CodeBlock lang="env">{`SITE_URL=https://radio.example.com`}</CodeBlock>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">THE ONE GOTCHA: DON&apos;T BUFFER THE STREAM</div>
+          <p>
+            Turn response buffering <strong>off</strong> for{' '}
+            <code className="bs-code-inline">/stream.mp3</code>. The bundled
+            Caddy serves the stream unbuffered (
+            <code className="bs-code-inline">flush_interval -1</code>). A front
+            proxy that buffers, and <strong>NPM buffers by default</strong>,
+            holds the live audio back: latency and stutter, or stalled playback
+            outright. Exempt the stream path and leave everything else on the
+            proxy&apos;s normal settings.
+          </p>
+          <p>
+            <strong>Nginx Proxy Manager</strong>: open the proxy host &rarr;{' '}
+            <strong>Advanced</strong> tab and add a location block for the
+            stream. The rest of the site keeps NPM&apos;s normal proxying from
+            the main tab.
+          </p>
+          <CodeBlock lang="nginx">{`location /stream.mp3 {
+    proxy_pass http://YOUR-UNRAID-IP:7700;
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_read_timeout 1h;   # the stream never ends, don't time it out
+}`}</CodeBlock>
+          <p>The same one knob in the other proxies:</p>
+          <ul className="bs-list">
+            <li>
+              <strong>raw nginx</strong>:{' '}
+              <code className="bs-code-inline">proxy_buffering off;</code> plus a
+              long <code className="bs-code-inline">proxy_read_timeout</code> in a{' '}
+              <code className="bs-code-inline">location /stream.mp3</code> block.
+            </li>
+            <li>
+              <strong>Caddy</strong>:{' '}
+              <code className="bs-code-inline">{'reverse_proxy … { flush_interval -1 }'}</code>{' '}
+              on the stream path.
+            </li>
+            <li>
+              <strong>Traefik</strong>: nothing, it doesn&apos;t buffer responses
+              by default.
+            </li>
+          </ul>
+        </div>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">PREFER TO DROP THE BUNDLED CADDY?</div>
+          <p>
+            If you&apos;d rather your proxy talk to each service directly, run
+            the split-container stack (Option 2) with{' '}
+            <code className="bs-code-inline">docker-compose.byo.yml</code>. There{' '}
+            <code className="bs-code-inline">web</code> /{' '}
+            <code className="bs-code-inline">controller</code> /{' '}
+            <code className="bs-code-inline">broadcast</code> bind host ports
+            themselves (<code className="bs-code-inline">7700</code> /{' '}
+            <code className="bs-code-inline">7701</code> /{' '}
+            <code className="bs-code-inline">7702</code>), but the web image is
+            still baked for same-origin{' '}
+            <code className="bs-code-inline">/api</code> +{' '}
+            <code className="bs-code-inline">/stream.mp3</code>, so your proxy
+            then has to replicate the whole route table on one hostname.
+            That&apos;s more proxy config, not less, and only worth it if you
+            specifically want the bundled Caddy out of the path. For most people
+            the single-upstream setup above is the easier win.
+          </p>
+        </div>
+      </section>
+
+      <section className="bs-section">
         <div className="bs-callout">
           <div className="bs-eyebrow">GOOD TO KNOW</div>
           <ul className="bs-list">
@@ -280,9 +379,11 @@ export default function Unraid() {
               <code className="bs-code-inline">/</code>,{' '}
               <code className="bs-code-inline">/api</code>, and{' '}
               <code className="bs-code-inline">/stream.mp3</code> on the single
-              host port. Want TLS and a hostname behind SWAG / NPM / Traefik?
-              Front that port with it, or on the Compose stack use{' '}
-              <code className="bs-code-inline">docker-compose.byo.yml</code>.
+              host port. Want TLS and a hostname behind SWAG / NPM / Traefik? See{' '}
+              <Link href="#reverse-proxy" className="bs-link">
+                Putting it behind your reverse proxy
+              </Link>{' '}
+              above: one upstream, plus the one stream-buffering gotcha.
             </li>
             <li>
               <strong>Updates:</strong> for one-click, use Unraid&apos;s normal{' '}


### PR DESCRIPTION
## Problem

The Unraid docs only mentioned running your own reverse proxy as a single bullet buried at the bottom of the Notes / "Good to know" list. Community feedback: most Unraid users already run NPM / SWAG / Traefik / Caddy, so this should be prominent, not an afterthought.

This was duplicated in two places, so both are updated to stay in sync:
- `docs/unraid.md` (the repo doc)
- `web/components/setup/Unraid.tsx` (the `/setup/unraid` web manual page)

## What changed (docs only)

Added a dedicated **"Putting it behind your own reverse proxy"** section, placed before the Notes / "Good to know" wrap-up in both files, covering:

- **One upstream, not per-path rules** — point your proxy at `http://YOUR-UNRAID-IP:7700`; the bundled Caddy already does the same-origin routing (`/`, `/api/*`, `/stream.mp3`) internally.
- **`SITE_URL`** — set it to the public `https://` URL (backs share cards / absolute links); TLS terminates at the user's proxy.
- **The gotcha: don't buffer the audio stream** — the bundled Caddy serves `/stream.mp3` unbuffered (`flush_interval -1`); a buffering front proxy (NPM's default) adds latency/stutter. Concrete NPM **Advanced** snippet (`proxy_buffering off; proxy_cache off;` + long read timeout) plus a one-line list for raw nginx / Caddy / Traefik.
- **Drop the bundled Caddy entirely** — pointer to the split-container `docker-compose.byo.yml` (Option 2) and an honest note that the proxy then has to replicate the route table.

Also:
- Cross-linked the new section from the one-click install steps (docs) and added an `id="reverse-proxy"` anchor on the web page.
- Rewrote the old buried bullet in both files to link to the new section instead of duplicating the guidance.

Claims kept accurate to the AIO architecture (single host port 7700, bundled Caddy fronts `/`, `/api`, `/stream.mp3`; byo binds 7700/7701/7702). No new ports or paths invented. Matches existing voice/formatting (markdown tables/callouts in the doc; `bs-section`/`bs-callout`/`CodeBlock` idiom on the web page). `web` lint (`eslint . && tsc --noEmit`) passes.
