### PR TITLE
feat(controller): fetch Last.fm artist tags directly via the Last.fm API

### DIFF
--- a/controller/src/music/lastfm.ts
+++ b/controller/src/music/lastfm.ts
@@ -1,0 +1,93 @@
+// Direct Last.fm tag client (read-only).
+//
+// Library tag enrichment wants Last.fm's crowd tags for an artist. The older
+// path went *through* Navidrome (subsonic.getArtistLastfmTags → getArtistInfo2),
+// but vanilla Navidrome's agent only surfaces bio + images there, never the
+// tag[] array — so tags always came back empty. This module skips Navidrome and
+// hits the Last.fm REST API directly, reusing the api_key the operator already
+// configured for scrobbling (LASTFM_API_KEY / settings.scrobble.lastfm.apiKey).
+//
+// Read methods (artist.getTopTags) are unauthenticated beyond the api_key — no
+// md5 signing, no session key (unlike the write calls in broadcast/scrobble.ts).
+// Every call is fire-and-forget with a 5s timeout and returns [] on any failure
+// so the caller can fall back; no retry (project convention — Last.fm's read
+// API is generous and the tagger loop is already sequential + per-artist cached).
+
+import * as settings from '../settings.js';
+
+const TIMEOUT_MS = 5000;
+const LASTFM_API = 'https://ws.audioscrobbler.com/2.0/';
+
+// artist.getTopTags returns a normalised popularity `count` (0–100, top tag at
+// 100). A count of 0 means essentially nobody applied the tag after
+// normalisation — pure noise — so drop those. Anything with a positive (or
+// missing/non-numeric) count is kept; the slice to `count` handles ordering,
+// since Last.fm returns tags sorted by popularity descending.
+const MIN_TAG_COUNT = 1;
+
+// Resolve the Last.fm api_key. Env wins, then settings.scrobble.lastfm.apiKey.
+// Note: unlike scrobbling, tag fetching does NOT require scrobble.enabled — the
+// key alone is enough to read public tags.
+function resolveKey(): string {
+  const s: any = settings.get()?.scrobble?.lastfm || {};
+  return process.env.LASTFM_API_KEY || s.apiKey || '';
+}
+
+export function hasLastfmKey(): boolean {
+  return !!resolveKey();
+}
+
+// Last.fm crowd tags for an artist, normalised to lowercase trimmed strings and
+// sliced to `count` (default 10, matching the legacy Navidrome path). Returns []
+// when no key is configured, the artist has no Last.fm coverage, or any request
+// failure — the caller treats [] as "no tags" and may fall back.
+export async function getArtistTopTags(
+  artist: string,
+  opts: { count?: number } = {},
+): Promise<string[]> {
+  const count = opts.count ?? 10;
+  const apiKey = resolveKey();
+  if (!apiKey || !artist || !artist.trim()) return [];
+
+  const params = new URLSearchParams({
+    method: 'artist.getTopTags',
+    artist,
+    autocorrect: '1',
+    api_key: apiKey,
+    format: 'json',
+  });
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const r = await fetch(`${LASTFM_API}?${params.toString()}`, {
+      method: 'GET',
+      headers: { 'User-Agent': 'sub-wave/tags' },
+      signal: ctrl.signal,
+    });
+    if (!r.ok) {
+      console.warn(`[lastfm] artist.getTopTags → ${r.status} for "${artist}"`);
+      return [];
+    }
+    const data = (await r.json()) as any;
+    // 200 doesn't guarantee success — Last.fm embeds a JSON `error` field
+    // (e.g. error 6 "no such artist" for obscure releases). Treat as no tags.
+    if (data?.error) return [];
+    const raw = data?.toptags?.tag ?? [];
+    const arr = Array.isArray(raw) ? raw : [raw];
+    return arr
+      .filter((t: any) => {
+        const c = Number(t?.count);
+        return !Number.isFinite(c) || c >= MIN_TAG_COUNT;
+      })
+      .map((t: any) => (typeof t === 'string' ? t : t?.name))
+      .filter((s: any): s is string => typeof s === 'string' && s.trim().length > 0)
+      .map((s: string) => s.toLowerCase().trim())
+      .slice(0, count);
+  } catch (err: any) {
+    console.warn(`[lastfm] artist.getTopTags failed for "${artist}": ${err?.message || err}`);
+    return [];
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -23,6 +23,7 @@
 // tracks table as legacy v1 entries (see library-db.ts).
 
 import * as subsonic from './subsonic.js';
+import * as lastfm from './lastfm.js';
 import * as db from './library-db.js';
 import * as settings from '../settings.js';
 import * as embeddings from './embeddings.js';
@@ -505,11 +506,24 @@ function finish(startedAt: number, llmCalls: number, llmTagged: number, byLeg: R
 async function phaseEnrich(ids: string[], reEnrich: boolean): Promise<void> {
   if (ids.length === 0) return;
   const enrichCfg = (settings.get() as any).embedding?.enrichment ?? {};
-  const lastfmEnabled = enrichCfg.lastfmTags !== false;
+  // A configured Last.fm api_key (LASTFM_API_KEY / scrobble.lastfm.apiKey) lets
+  // us hit the Last.fm API directly (music/lastfm.ts), which actually returns
+  // tag[]. Tri-state gate: explicit `true` always enriches; explicit `false`
+  // never does; the default (null/unset) enriches only when a key is present —
+  // so keyless vanilla-Navidrome installs don't waste a round trip per artist
+  // on the tag-less getArtistInfo2 path.
+  const hasKey = lastfm.hasLastfmKey();
+  const lastfmEnabled =
+    enrichCfg.lastfmTags === true || (enrichCfg.lastfmTags !== false && hasKey);
   const lyricsEnabled = enrichCfg.lyrics !== false;
   if (!lastfmEnabled && !lyricsEnabled) {
     console.log('[tag] phase-0 skipped: both lastfmTags and lyrics disabled in settings.embedding.enrichment');
     return;
+  }
+  if (lastfmEnabled) {
+    console.log(
+      `[tag] phase-0 Last.fm tags via ${hasKey ? 'direct API (artist.getTopTags)' : 'Navidrome getArtistInfo2 (no api_key — likely empty)'}`,
+    );
   }
   reportProgress({ phase: 'enrich', label: 'Enriching metadata', done: 0, total: ids.length });
   const artistTagCache = new Map<string, string[]>();
@@ -529,11 +543,19 @@ async function phaseEnrich(ids: string[], reEnrich: boolean): Promise<void> {
         lastfmTags = artistTagCache.get(cacheKey) ?? null;
       } else {
         try {
-          const matches = await subsonic.searchArtists(t.artist, { artistCount: 1 });
-          const artistId = matches?.[0]?.id;
-          if (artistId) {
-            const tags = await subsonic.getArtistLastfmTags(artistId, { count: 10 });
-            lastfmTags = tags;
+          if (hasKey) {
+            // Direct Last.fm API — reuses the scrobbling api_key and actually
+            // returns crowd tags (artist.getTopTags). Returns [] on miss/error.
+            lastfmTags = await lastfm.getArtistTopTags(t.artist, { count: 10 });
+          } else {
+            // Fallback: route through Navidrome's getArtistInfo2. Only useful on
+            // a custom Navidrome whose agent exposes tag[]; empty on vanilla.
+            const matches = await subsonic.searchArtists(t.artist, { artistCount: 1 });
+            const artistId = matches?.[0]?.id;
+            if (artistId) {
+              const tags = await subsonic.getArtistLastfmTags(artistId, { count: 10 });
+              lastfmTags = tags;
+            }
           }
         } catch { /* ignore */ }
         artistTagCache.set(cacheKey, lastfmTags ?? []);

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -624,12 +624,19 @@ const DEFAULTS = {
     confidenceThreshold: 0.6,
     maxActiveLearningRounds: 3,
     enrichment: {
-      // Vanilla Navidrome's getArtistInfo2 doesn't surface Last.fm crowd
-      // tags (the agent only exposes bio + images). Until SUB/WAVE adds a
-      // direct Last.fm API path, leave this off — enabling it just wastes
-      // an HTTP round trip per artist with empty results. Operators
-      // running a custom Navidrome that does expose tag[] can flip it on.
-      lastfmTags: false,
+      // Last.fm crowd tags. Tri-state: true = always fetch, false = never,
+      // null = auto (fetch only when a Last.fm api_key is configured — see
+      // music/lastfm.ts + the gate in tag-library.ts phaseEnrich).
+      //
+      // Tags now come straight from the Last.fm REST API (artist.getTopTags)
+      // reusing the scrobbling api_key, which actually returns tag[]. The old
+      // path went through Navidrome's getArtistInfo2, where vanilla Navidrome's
+      // agent only surfaces bio + images — never tag[] — so tags always came
+      // back empty. That Navidrome path stays as the fallback when lastfmTags
+      // is forced on (true) but no api_key is set (custom Navidromes that DO
+      // expose tag[]). Default `null` avoids the wasted round trip for keyless
+      // vanilla-Navidrome installs.
+      lastfmTags: null as boolean | null,
       lyrics: true,       // fetch + include lyric excerpt in embed text
     },
   },


### PR DESCRIPTION
## What

Library tag enrichment now fetches Last.fm artist tags **directly from the Last.fm REST API** instead of routing through Navidrome.

- **New `controller/src/music/lastfm.ts`** — read-only client:
  - `getArtistTopTags(artist, { count = 10 })` → `artist.getTopTags` (GET, `autocorrect=1`, `format=json`, `api_key` only — no signing, no session key). Parses `toptags.tag[]`, drops `count:0` noise + empties, lowercases/trims, slices to `count`. 5s `AbortController` timeout; returns `[]` on any failure (no retry, per project convention).
  - `hasLastfmKey()` — resolves `LASTFM_API_KEY || settings.scrobble.lastfm.apiKey`.
- **`music/tag-library.ts` `phaseEnrich`** — prefers the direct path when a key is present; keeps the Navidrome `getArtistInfo2` path as the fallback (custom Navidromes that *do* expose `tag[]`). Per-artist `artistTagCache` preserved.
- **`settings.ts`** — `embedding.enrichment.lastfmTags` default `false` → `null` (tri-state: `true` = always, `false` = never, `null` = auto). Gate: `lastfmTags === true || (lastfmTags !== false && hasLastfmKey())`.

## Why

Pulling tags through Navidrome's `getArtistInfo2` always returned empty on vanilla Navidrome — its agent only surfaces bio + images there, never the `tag[]` array — so the tagger always reported `lastfm: 0` and the feature was off by default. Operators already configure a Last.fm api_key for scrobbling; reusing it for read-only tag lookups actually works.

## Test plan

- `npm run lint` (controller) passes — eslint (0 errors) + `tsc --noEmit` (0 errors).
- Mocked unit smoke test: parsing, `count:0`/empty filtering, lowercase+trim, slice-to-10, read-only params (no `sk=`/`api_sig=`), error-field → `[]`, keyless short-circuit.
- Live request-shape test against the real Last.fm endpoint (invalid key → `403` → `[]`, graceful).
- Success path (real tags for a real artist) pending a valid api_key on the box — no key is currently configured here.
