### PR TITLE
feat(controller): rolling raw-LLM-request debug log file

### DIFF
--- a/controller/src/llm/internal/provider/registry.ts
+++ b/controller/src/llm/internal/provider/registry.ts
@@ -16,7 +16,7 @@
 //
 // `ollama` is the default and needs no key. The cloud providers are opt-in.
 
-import { gateway, createGateway } from 'ai';
+import { createGateway } from 'ai';
 import { createOllama } from 'ai-sdk-ollama';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
@@ -25,6 +25,7 @@ import { createDeepSeek } from '@ai-sdk/deepseek';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 import { config } from '../../../config.js';
 import * as settings from '../../../settings.js';
+import { recordRawRequest, rawDebugEnabled } from '../telemetry/raw-debug.js';
 
 // Memoise built clients so we don't reconstruct a provider on every call.
 // Keyed by a signature that changes whenever provider/model/key changes, so a
@@ -36,12 +37,37 @@ export function llmCfg() {
     || { provider: 'ollama', model: '', apiKey: '', ollamaUrl: '', baseUrl: '', reasoning: false };
 }
 
+// When raw-request debug capture is enabled (LLM_DEBUG_RAW env flag or the
+// settings.llm.debugRawRequests admin toggle), record the exact outbound body —
+// verbatim, the JSON string as actually sent — before delegating to the real
+// fetch. This is the single capture point: it's wired into EVERY provider's
+// `fetch` option in languageModel() below, so capture is provider-agnostic.
+// Gated at call time, so when disabled it's one boolean check then a plain
+// passthrough — zero behavioural change, no file writes. Only method + URL +
+// body are recorded; Authorization and other headers are never touched.
+export function debugFetch(url: any, init: any) {
+  if (rawDebugEnabled()) {
+    try {
+      const body = init?.body;
+      if (typeof body === 'string') {
+        const method = init?.method || 'POST';
+        const target = typeof url === 'string' ? url : (url?.url ?? String(url));
+        recordRawRequest(method, target, body);
+      }
+    } catch { /* capture must never break a model call */ }
+  }
+  return fetch(url, init);
+}
+
 // When reasoning is disabled, llama.cpp / vLLM / LM Studio honour
 // chat_template_kwargs.enable_thinking=false — the Qwen3 (and similar)
 // chat template then omits the <think> priming entirely, so the model
 // never starts a chain-of-thought. Injected via a fetch wrapper because
-// the AI SDK's openai provider has no first-class field for it.
-export function noThinkFetch(url: any, init: any) {
+// the AI SDK's openai provider has no first-class field for it. `baseFetch`
+// is the transport to delegate to once the body is rewritten — debugFetch in
+// languageModel() (so the captured body is the post-injection one as sent),
+// global fetch for callers that don't compose it (e.g. onboarding probes).
+export function noThinkFetch(url: any, init: any, baseFetch: any = fetch) {
   if (init?.body && typeof init.body === 'string') {
     try {
       const body = JSON.parse(init.body);
@@ -52,7 +78,7 @@ export function noThinkFetch(url: any, init: any) {
       init = { ...init, body: JSON.stringify(body) };
     } catch { /* not JSON — leave the request untouched */ }
   }
-  return fetch(url, init);
+  return baseFetch(url, init);
 }
 
 // Ollama server URL — from settings (admin UI), falling back to the config
@@ -93,11 +119,17 @@ export function loccaEmbedBaseUrl(cfg: any): string {
 // Most accept any non-empty key, so fall back to a placeholder. Reasoning off →
 // wrap fetch to force chat_template_kwargs.enable_thinking=false.
 function openAICompatibleModel(cfg: any, id: string, baseURL: string, name: string) {
+  // Reasoning off → force enable_thinking=false (noThinkFetch) THEN capture;
+  // reasoning on → capture only. debugFetch is the inner transport in both
+  // cases, so what's recorded is the body exactly as sent (post no-think).
+  const fetchImpl = cfg.reasoning
+    ? debugFetch
+    : (url: any, init: any) => noThinkFetch(url, init, debugFetch);
   const provider = createOpenAI({
     baseURL,
     apiKey: cfg.apiKey || 'unused',
     name,
-    ...(cfg.reasoning ? {} : { fetch: noThinkFetch }),
+    fetch: fetchImpl,
   });
   return provider.chat(id);
 }
@@ -128,12 +160,12 @@ export function languageModel(cfg: any = llmCfg()) {
   let model;
   switch (cfg.provider) {
     case 'anthropic': {
-      const provider = createAnthropic(cfg.apiKey ? { apiKey: cfg.apiKey } : {});
+      const provider = createAnthropic({ fetch: debugFetch, ...(cfg.apiKey ? { apiKey: cfg.apiKey } : {}) });
       model = provider(id);
       break;
     }
     case 'openai': {
-      const provider = createOpenAI(cfg.apiKey ? { apiKey: cfg.apiKey } : {});
+      const provider = createOpenAI({ fetch: debugFetch, ...(cfg.apiKey ? { apiKey: cfg.apiKey } : {}) });
       model = provider(id);
       break;
     }
@@ -149,22 +181,25 @@ export function languageModel(cfg: any = llmCfg()) {
       break;
     }
     case 'google': {
-      const provider = createGoogleGenerativeAI(cfg.apiKey ? { apiKey: cfg.apiKey } : {});
+      const provider = createGoogleGenerativeAI({ fetch: debugFetch, ...(cfg.apiKey ? { apiKey: cfg.apiKey } : {}) });
       model = provider(id);
       break;
     }
     case 'deepseek': {
-      const provider = createDeepSeek(cfg.apiKey ? { apiKey: cfg.apiKey } : {});
+      const provider = createDeepSeek({ fetch: debugFetch, ...(cfg.apiKey ? { apiKey: cfg.apiKey } : {}) });
       model = provider(id);
       break;
     }
     case 'openrouter': {
-      const provider = createOpenRouter(cfg.apiKey ? { apiKey: cfg.apiKey } : {});
+      const provider = createOpenRouter({ fetch: debugFetch, ...(cfg.apiKey ? { apiKey: cfg.apiKey } : {}) });
       model = provider(id);
       break;
     }
     case 'gateway': {
-      const provider = cfg.apiKey ? createGateway({ apiKey: cfg.apiKey }) : gateway;
+      // Always go through createGateway so debugFetch can be wired in; with no
+      // apiKey it resolves the same env / OIDC credentials the bare `gateway`
+      // default instance would.
+      const provider = createGateway({ fetch: debugFetch, ...(cfg.apiKey ? { apiKey: cfg.apiKey } : {}) });
       model = provider(id);
       break;
     }
@@ -175,7 +210,7 @@ export function languageModel(cfg: any = llmCfg()) {
       // returns a LanguageModelV3 that translates tools / toolChoice / activeTools
       // correctly — no `.chat(id)` override required. `baseURL` is the bare
       // Ollama host (no `/api` suffix); the package appends the path itself.
-      const provider = createOllama({ baseURL: ollamaBaseUrl(cfg) });
+      const provider = createOllama({ baseURL: ollamaBaseUrl(cfg), fetch: debugFetch });
       model = provider(id);
       break;
     }

--- a/controller/src/llm/internal/telemetry/raw-debug.ts
+++ b/controller/src/llm/internal/telemetry/raw-debug.ts
@@ -1,0 +1,121 @@
+// Rolling raw-LLM-request debug log.
+//
+// When capture is enabled, every outbound model request's exact body — the JSON
+// string as actually sent (no re-parse/re-stringify) — is kept in a small
+// in-memory ring AND mirrored to a bounded file in the shared state dir
+// (${STATE_DIR}/logs/llm-debug.log, last LLM_DEBUG_MAX, newest first), as well
+// as dumped to stderr. The file is the better primary UX for operators (esp.
+// Unraid, where state == appdata): they just open it instead of trawling
+// container logs. The capture point is a single fetch wrapper in the provider
+// registry (debugFetch), applied to every provider, so this is provider-agnostic.
+//
+// Gated two ways (either turns it on): the LLM_DEBUG_RAW env flag, or the
+// admin-toggleable settings.llm.debugRawRequests — so a one-click (no-CLI)
+// operator can flip it from the admin UI without editing env. Off by default:
+// when disabled nothing here runs (the registry never calls in), so there are
+// no file writes and no overhead.
+//
+// Best-effort throughout — mirrors recordPick()/PICKS_LOG in log.ts: a write
+// failure must never break (or block) a model call. Authorization/headers are
+// never recorded; only method + URL + body (and key-bearing URL query params
+// are masked, since e.g. Google carries the key as ?key=…).
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { STATE_DIR } from '../../../config.js';
+import * as settings from '../../../settings.js';
+
+// Keep only the last N raw requests (in memory + on disk), newest first.
+export const LLM_DEBUG_MAX = 10;
+// Generous per-body cap so one huge request can't run the file away.
+const BODY_CAP = 32 * 1024;
+// Where operators look. Surfaced in the /debug UI so it's findable.
+export const LLM_DEBUG_LOG = `${STATE_DIR}/logs/llm-debug.log`;
+
+// Process-level env flag, read once at startup. The settings toggle is read
+// live (so it can be flipped from the admin UI without a restart); the env flag
+// can only force capture ON, never off.
+const ENV_ENABLED = /^(1|true|yes|on)$/i.test(process.env.LLM_DEBUG_RAW || '');
+
+export function rawDebugEnabledViaEnv(): boolean {
+  return ENV_ENABLED;
+}
+
+// Is capture on right now? Env flag OR the live settings toggle. Cheap: a cached
+// boolean plus an in-memory settings read — safe to call on every request.
+export function rawDebugEnabled(): boolean {
+  if (ENV_ENABLED) return true;
+  try {
+    return settings.get()?.llm?.debugRawRequests === true;
+  } catch {
+    return false;
+  }
+}
+
+// Mask key-bearing query params so the URL (which we deliberately record) can't
+// leak a secret some providers pass in the query string (e.g. Google's ?key=).
+const SECRET_QUERY_KEYS = new Set(['key', 'api_key', 'apikey', 'access_token', 'token']);
+function redactUrl(raw: string): string {
+  try {
+    const u = new URL(raw);
+    let touched = false;
+    for (const k of [...u.searchParams.keys()]) {
+      if (SECRET_QUERY_KEYS.has(k.toLowerCase())) {
+        u.searchParams.set(k, 'REDACTED');
+        touched = true;
+      }
+    }
+    return touched ? u.toString() : raw;
+  } catch {
+    return raw; // not a parseable absolute URL — leave it as-is
+  }
+}
+
+// In-memory ring of the last LLM_DEBUG_MAX formatted entries, newest first.
+const entries: string[] = [];
+
+function format(method: string, url: string, body: string): string {
+  const trimmed =
+    body.length > BODY_CAP
+      ? `${body.slice(0, BODY_CAP)}\n…[truncated ${body.length - BODY_CAP} chars]`
+      : body;
+  return [
+    `===== ${new Date().toISOString()}  ${method} ${redactUrl(url)}`,
+    '-----------------------------------------------------------------------------',
+    trimmed,
+    '',
+  ].join('\n');
+}
+
+let dirReady = false;
+async function ensureDir(): Promise<void> {
+  if (dirReady) return;
+  await mkdir(`${STATE_DIR}/logs`, { recursive: true });
+  dirReady = true;
+}
+
+// Serialise file writes so the newest-enqueued snapshot is the one that lands on
+// disk (out-of-order writeFile completions would otherwise leave a stale view).
+let writeChain: Promise<void> = Promise.resolve();
+
+// Capture one raw request. Fire-and-forget: callers MUST NOT await this — it
+// rewrites the whole (bounded) file off the request's critical path. A full
+// rewrite keeps the file at exactly LLM_DEBUG_MAX entries (no unbounded append).
+export function recordRawRequest(method: string, url: string, body: string): void {
+  const entry = format(method || 'POST', url || '', body || '');
+  entries.unshift(entry);
+  if (entries.length > LLM_DEBUG_MAX) entries.length = LLM_DEBUG_MAX;
+
+  // Keep the legacy "dump to stderr" behaviour too, for operators already
+  // grepping container logs.
+  try {
+    process.stderr.write(`[llm-debug-raw] ${entry}`);
+  } catch { /* never break a model call */ }
+
+  const snapshot = entries.join('\n');
+  writeChain = writeChain.then(async () => {
+    try {
+      await ensureDir();
+      await writeFile(LLM_DEBUG_LOG, snapshot);
+    } catch { /* best-effort: never break a model call */ }
+  });
+}

--- a/controller/src/llm/log.ts
+++ b/controller/src/llm/log.ts
@@ -3,3 +3,14 @@
 // `llm/log.js` unchanged.
 
 export { recentCalls, record, recordPick, lifetimeTokenCount } from './internal/telemetry/log.js';
+
+// Raw-request debug log status (the rolling ${STATE_DIR}/logs/llm-debug.log).
+// Re-exported here so the /debug route can report the toggle state + file path
+// without reaching into internal/. The capture itself lives in the provider
+// registry's debugFetch.
+export {
+  rawDebugEnabled,
+  rawDebugEnabledViaEnv,
+  LLM_DEBUG_LOG,
+  LLM_DEBUG_MAX,
+} from './internal/telemetry/raw-debug.js';

--- a/controller/src/routes/debug.ts
+++ b/controller/src/routes/debug.ts
@@ -4,6 +4,12 @@ import { readFile, readdir, stat } from 'node:fs/promises';
 import { config } from '../config.js';
 import * as dj from '../llm/dj.js';
 import * as llmProvider from '../llm/provider.js';
+import {
+  rawDebugEnabled,
+  rawDebugEnabledViaEnv,
+  LLM_DEBUG_LOG,
+  LLM_DEBUG_MAX,
+} from '../llm/log.js';
 import * as tts from '../audio/tts.js';
 import * as library from '../music/library.js';
 import * as subsonicLog from '../music/subsonic-log.js';
@@ -127,6 +133,15 @@ router.get('/debug', requireAdmin, async (req, res) => {
     activeModel: llmProvider.activeModelLabel(),
     ollamaUrl: llmProvider.activeOllamaUrl(),
     recentCalls: dj.recentCalls,
+    // Raw-request capture status — the admin UI shows the toggle + the file path
+    // so operators know where to look. `viaEnv` means LLM_DEBUG_RAW forces it on
+    // (the UI toggle can't turn it off in that case).
+    debug: {
+      enabled: rawDebugEnabled(),
+      viaEnv: rawDebugEnabledViaEnv(),
+      file: LLM_DEBUG_LOG,
+      max: LLM_DEBUG_MAX,
+    },
   };
 
   // 6c. TTS routing — which engine/voice the effective persona resolves to,

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -576,6 +576,14 @@ const DEFAULTS = {
     // reports zero listeners — the stream coasts on the auto playlist — and
     // resume as soon as someone tunes in. Off by default.
     pauseWhenEmpty: false,
+    // When on (or when LLM_DEBUG_RAW is set in the env), every outbound model
+    // request's exact body is captured to ${STATE_DIR}/logs/llm-debug.log (the
+    // last 10, newest first) and dumped to stderr — a copy-pasteable view of
+    // exactly what SUB/WAVE sends the provider, for debugging odd model
+    // behaviour. The admin toggle (admin → Debug) means no-CLI operators can
+    // flip it without editing env; the env flag can only force it on. Off by
+    // default: zero file writes / overhead when disabled.
+    debugRawRequests: false,
     // Optional backup LLM. When `enabled`, any LLM call whose primary host is
     // unreachable (connection refused / DNS / timeout — NOT a 429/5xx from a
     // host that's up) is retried once against this leg, then routed straight
@@ -1081,6 +1089,10 @@ export async function load() {
         typeof stored.llm?.pauseWhenEmpty === 'boolean'
           ? stored.llm.pauseWhenEmpty
           : DEFAULTS.llm.pauseWhenEmpty,
+      debugRawRequests:
+        typeof stored.llm?.debugRawRequests === 'boolean'
+          ? stored.llm.debugRawRequests
+          : DEFAULTS.llm.debugRawRequests,
       // Backup leg — same connection fields as the primary, coerced identically.
       fallback: (() => {
         const fb = stored.llm?.fallback || {};
@@ -1876,6 +1888,9 @@ export async function update(patch) {
     }
     if (l.pauseWhenEmpty !== undefined) {
       next.llm.pauseWhenEmpty = !!l.pauseWhenEmpty;
+    }
+    if (l.debugRawRequests !== undefined) {
+      next.llm.debugRawRequests = !!l.debugRawRequests;
     }
     // An OpenAI-compatible provider is useless without a server to talk to.
     if (next.llm.provider === 'openai-compatible' && !next.llm.baseUrl) {

--- a/web/components/admin/DebugPanel.tsx
+++ b/web/components/admin/DebugPanel.tsx
@@ -98,6 +98,13 @@ interface DebugLlm {
   activeModel?: string;
   provider?: string;
   recentCalls?: LlmCall[];
+  /** Raw-request capture status — drives the toggle + file-path hint. */
+  debug?: {
+    enabled?: boolean;
+    viaEnv?: boolean;
+    file?: string;
+    max?: number;
+  };
 }
 
 interface SubsonicEndpoint {
@@ -831,10 +838,34 @@ function FilterChip({ active, onClick, children }: FilterChipProps) {
 }
 
 function LlmCalls({ llm }: { llm: DebugLlm | undefined }) {
+  const { adminFetch } = useAdminAuth();
   const calls = llm?.recentCalls || [];
   const [filter, setFilter] = useState('all');
   const kinds = Array.from(new Set(calls.map(c => c.kind).filter(Boolean) as string[]));
   const shown = filter === 'all' ? calls : calls.filter(c => c.kind === filter);
+
+  const dbg = llm?.debug;
+  const viaEnv = !!dbg?.viaEnv;
+  // Optimistic local view so the checkbox responds instantly; the 2s /debug poll
+  // reconciles it. Cleared whenever the server-reported value changes (below).
+  const [override, setOverride] = useState<boolean | null>(null);
+  const enabled = override ?? !!dbg?.enabled;
+  useEffect(() => { setOverride(null); }, [dbg?.enabled]);
+
+  const toggleRaw = async (next: boolean) => {
+    if (viaEnv) return; // LLM_DEBUG_RAW forces it on — can't change from here
+    setOverride(next);
+    try {
+      await adminFetch('/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ llm: { debugRawRequests: next } }),
+      });
+    } catch {
+      setOverride(null);
+    }
+  };
+
   return (
     <Card
       title="LLM recent calls"
@@ -852,6 +883,23 @@ function LlmCalls({ llm }: { llm: DebugLlm | undefined }) {
         </div>
       }
     >
+      {/* Raw-request capture — writes the last N exact request bodies to a file
+          operators can open. Toggle here, or set LLM_DEBUG_RAW in the env. */}
+      <div className="mb-2 grid gap-1 border border-separator-strong p-2.5">
+        <Label className="flex cursor-pointer items-center gap-2 text-[11px] tracking-[0.12em] text-muted uppercase">
+          <Checkbox
+            checked={enabled}
+            disabled={viaEnv}
+            onCheckedChange={v => toggleRaw(v === true)}
+          />
+          Raw request capture {enabled ? 'on' : 'off'}
+          {viaEnv && <span className="normal-case">· forced on by LLM_DEBUG_RAW</span>}
+        </Label>
+        <span className="field-hint">
+          last {dbg?.max ?? 10} raw request bodies (newest first) →{' '}
+          <code className="break-all">{dbg?.file || `${'…'}/logs/llm-debug.log`}</code>
+        </span>
+      </div>
       <div className="grid max-h-[600px] gap-1.5 overflow-y-auto">
         {shown.length === 0 && (
           <span className="field-hint italic">


### PR DESCRIPTION
## What

Adds a rolling **raw-LLM-request debug log**. When enabled, every outbound model request's exact body (verbatim — the JSON string as actually sent) is captured to `${STATE_DIR}/logs/llm-debug.log`, keeping the **last 10, newest-first**. The existing stderr dump is kept too — the file is just the better primary UX for operators (especially Unraid, where `state` == appdata) who would otherwise have to trawl container logs.

## How

- **Capture point:** a single `debugFetch` wrapper in `llm/internal/provider/registry.ts`, wired into the `fetch` option of **every** provider (ollama, openai-compatible, locca, anthropic, openai, google, deepseek, openrouter, gateway). Provider-agnostic by construction. `noThinkFetch` now composes with it so the captured body is the post-`enable_thinking=false` JSON exactly as sent.
- **Rolling file:** `llm/internal/telemetry/raw-debug.ts` mirrors `recordPick()`/`PICKS_LOG` — module-level ring of the last `LLM_DEBUG_MAX=10`, `mkdir -p` the logs dir, serialized full-rewrite (bounded to exactly N, never appended), fire-and-forget try/catch (never awaited, never throws).
- **Gating:** the `LLM_DEBUG_RAW` env flag **or** an admin-toggleable `settings.llm.debugRawRequests` — either turns it on (env can only force on). Surfaced in **admin → Debug**: a toggle + the file path, with the toggle disabled and labelled "forced on by LLM_DEBUG_RAW" when env wins.
- **Safety:** off by default → zero file writes / overhead. Bodies capped at 32k chars. Authorization/headers are never recorded; key-bearing URL query params (e.g. Google's `?key=`) are masked so the URL can't leak a secret.

## Testing

- `npm run lint` (eslint + tsc) passes in **controller/** and **web/**; `npm run test:llm` passes.
- Behavioral test against the real `debugFetch` + rolling code:
  - **disabled** → file never written, fetch still passes through;
  - **enabled** → exactly 10 entries, newest-first, capped across 25 calls, for both openai-compatible (`/v1/chat/completions`) and Ollama (`/api/chat`) bodies, stderr dump retained;
  - **redaction** → `?key=SECRET` masked while the body stays verbatim.
