### PR TITLE
feat(picker): add per-show strict genre lean (hard-filter the pool, soft fallback)

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -15,6 +15,7 @@ import { introBudgetPhrase, enforceIntroBudget } from '../src/llm/internal/promp
 import { embeddingBaseUrl } from '../src/llm/internal/provider/embedding.js';
 import { DEFAULT_LOCCA_EMBED_BASE_URL } from '../src/llm/internal/provider/registry.js';
 import { personaToneDirectives, normalizeDial, DIAL_NEUTRAL, validatePersonasStrict } from '../src/settings.js';
+import { showMusicLean } from '../src/llm/internal/prompts/picker.js';
 
 let failures = 0;
 function test(name: string, fn: () => void | Promise<void>) {
@@ -255,6 +256,45 @@ async function main() {
     assert.equal(bare.humour, DIAL_NEUTRAL);   // absent dials default to neutral
     assert.equal(bare.localColour, DIAL_NEUTRAL);
     assert.equal(bare.warmth, DIAL_NEUTRAL);
+  });
+
+  // ---- showMusicLean: soft lean vs strict genre lock (shared by both pick paths) ----
+  console.log('showMusicLean (soft lean vs strict genre lock):');
+  const SOFT_GENRE_LINE = '\n\nMusic steer for this show — lean toward Jazz. These are preferences, not hard filters: break them only when the flow genuinely demands it.';
+  await test('no show → empty string', () => {
+    assert.equal(showMusicLean(null), '');
+    assert.equal(showMusicLean(undefined), '');
+  });
+  await test('soft genre-only show is byte-for-byte the legacy line', () => {
+    assert.equal(showMusicLean({ name: 'x', topic: 'y', genre: 'Jazz' }), SOFT_GENRE_LINE);
+  });
+  await test('genreStrict=false leaves the soft path unchanged', () => {
+    assert.equal(showMusicLean({ name: 'x', topic: 'y', genre: 'Jazz', genreStrict: false }), SOFT_GENRE_LINE);
+  });
+  await test('strict genre is a hard rule, not a soft lean', () => {
+    const out = showMusicLean({ name: 'x', topic: 'y', genre: 'Hip-Hop', genreStrict: true });
+    assert.match(out, /Genre lock/);
+    assert.match(out, /MUST be Hip-Hop/);
+    assert.match(out, /do not pick other genres/);
+    assert.doesNotMatch(out, /lean toward Hip-Hop/);
+    assert.doesNotMatch(out, /Music steer/);     // no soft line when only the genre is pinned
+  });
+  await test('strict carries the never-starve escape hatch', () => {
+    const out = showMusicLean({ name: 'x', topic: 'y', genre: 'Metal', genreStrict: true });
+    assert.match(out, /no Metal track/i);        // can stray only to avoid dead air
+  });
+  await test('strict needs a genre — genreStrict alone is inert', () => {
+    assert.equal(showMusicLean({ name: 'x', topic: 'y', genreStrict: true }), '');
+    // energy still produces a soft line; no genre lock without a genre
+    const out = showMusicLean({ name: 'x', topic: 'y', energy: 'high', genreStrict: true });
+    assert.doesNotMatch(out, /Genre lock/);
+    assert.match(out, /favour high-energy tracks/);
+  });
+  await test('strict genre coexists with soft era/energy steers', () => {
+    const out = showMusicLean({ name: 'x', topic: 'y', genre: 'Soul', genreStrict: true, fromYear: 1970, toYear: 1979, energy: 'medium' });
+    assert.match(out, /Genre lock for this show/);
+    assert.match(out, /Music steer for this show — prefer tracks from 1970–1979; favour medium-energy tracks/);
+    assert.doesNotMatch(out, /lean toward Soul/);  // genre is the hard rule, not a soft part
   });
 
   console.log(failures === 0 ? '\nAll llm-pure tests passed.' : `\n${failures} test(s) FAILED.`);

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -200,10 +200,12 @@ export function pickSystem() {
   const showLine = activeShow?.topic
     ? `\n\nCurrent show brief — follow this for every pick:\n${activeShow.topic}`
     : '';
-  // The same soft genre/decade/energy lean the pool picker applies — the agent
+  // The same genre/decade/energy steer the pool picker applies — the agent
   // already owns songsByGenre + tracksByMood(energy) tools, so this line is
-  // enough to make it reach for them. Lives in the system prompt for the same
-  // session-window reason as the show brief above.
+  // enough to make it reach for them. showMusicLean reflects the show's
+  // genreStrict here too: a strict show gets a hard "stay within {genre}" rule
+  // instead of a soft lean, so both pick paths honour strict the same way. Lives
+  // in the system prompt for the same session-window reason as the show brief.
   const musicLean = dj.showMusicLean(activeShow);
   return `${settings.agentPersonaPreamble(persona, { rules: false })}
 

--- a/controller/src/llm/internal/prompts/generate.ts
+++ b/controller/src/llm/internal/prompts/generate.ts
@@ -52,6 +52,7 @@ const SHOW_SCHEMA = z.object({
   topic: z.string().max(1000).describe('the brief the AI DJ reads before the slot: genres, eras, moods, artists, time of day, listener type, host tone. 1-4 sentences, max 1000 chars.'),
   mood: z.enum(SHOW_MOODS as [string, ...string[]]).describe('the single closest music mood for this show'),
   genre: z.string().max(64).describe('a music genre lean if one fits (e.g. "jazz", "gospel", "lofi"); "" for no lean. Prefer a genre present in the supplied library list when relevant.'),
+  genreStrict: z.boolean().describe('true ONLY when the description demands genre exclusivity ("only plays hip-hop", "strictly jazz", "nothing but metal") — hard-locks every pick to the genre. false for a normal lean. Requires a genre; leave false when genre is "".'),
   fromYear: z.number().int().nullable().describe('start year of an era window if the show targets a decade (e.g. 1970), else null'),
   toYear: z.number().int().nullable().describe('end year of that era window (e.g. 1979), else null'),
   energy: z.enum(['', ...SHOW_ENERGY] as [string, ...string[]]).describe('soft energy steer: low, medium, high, or "" for any'),
@@ -59,7 +60,7 @@ const SHOW_SCHEMA = z.object({
   themeId: z.string().nullable().describe('the id of a per-show theme override chosen from the supplied theme list, or null for the station default'),
 });
 
-const SHOW_SYSTEM = `You design radio shows for a personal internet radio station. Given a free-text description, produce a single show definition: a name, a DJ brief (topic), a music mood, an optional genre lean and era window, an energy steer, and the best-matching persona and (optional) theme from the supplied lists. Pick personaId / themeId ONLY from the ids given; use null when nothing clearly fits. The mood MUST be one of the listed moods. Keep the topic concrete and useful as a brief — name the kind of music, the moment of day, and the tone.`;
+const SHOW_SYSTEM = `You design radio shows for a personal internet radio station. Given a free-text description, produce a single show definition: a name, a DJ brief (topic), a music mood, an optional genre lean and era window, an energy steer, and the best-matching persona and (optional) theme from the supplied lists. Pick personaId / themeId ONLY from the ids given; use null when nothing clearly fits. The mood MUST be one of the listed moods. Set genreStrict=true only when the description signals genre exclusivity ("only", "strictly", "nothing but", "pure <genre>") — otherwise keep the genre a soft lean (genreStrict=false). Keep the topic concrete and useful as a brief — name the kind of music, the moment of day, and the tone.`;
 
 export async function generateShow(description: string, ctx: ShowCtx = {}) {
   const lines: string[] = [];

--- a/controller/src/llm/internal/prompts/picker.ts
+++ b/controller/src/llm/internal/prompts/picker.ts
@@ -12,24 +12,38 @@ export const PICKER_CRITERIA = `Selection criteria, in order:
 3. VARIETY — avoid the same artist back-to-back; don't repeat tracks you've already played today; rotate energy. Variety over cleverness — never pick a track because its title literally matches the time of day, the weather, or anything else literal.
 4. INTEREST — prefer something that creates a moment, not the most generic option.`;
 
-export type ShowMusic = { name: string; topic: string; genre?: string; fromYear?: number | null; toYear?: number | null; energy?: string };
+export type ShowMusic = { name: string; topic: string; genre?: string; fromYear?: number | null; toYear?: number | null; energy?: string; genreStrict?: boolean };
 
-// A show can pin a genre, decade and/or energy band as a SOFT lean on track
-// selection. Render it as one prompt line shared by both pick paths (the pool
-// picker here and the conversational agent in broadcast/dj-agent.ts). Returns
-// '' when the show pins nothing, so callers can append it unconditionally.
+// A show can pin a genre, decade and/or energy band on track selection. Genre
+// is a SOFT lean by default, or a HARD constraint when `genreStrict` is on;
+// decade and energy are always soft. Render it as one prompt line shared by both
+// pick paths (the pool picker here and the conversational agent in
+// broadcast/dj-agent.ts). Returns '' when the show pins nothing, so callers can
+// append it unconditionally.
 export function showMusicLean(show?: ShowMusic | null): string {
   if (!show) return '';
+  // Strict only bites when there's actually a genre to lock to.
+  const strict = !!(show.genreStrict && show.genre);
+  // Soft preferences (the genre lean is dropped here when strict — it becomes a
+  // hard rule on its own line below).
   const parts: string[] = [];
-  if (show.genre) parts.push(`lean toward ${show.genre}`);
+  if (show.genre && !strict) parts.push(`lean toward ${show.genre}`);
   if (show.fromYear != null || show.toYear != null) {
     const from = show.fromYear != null ? String(show.fromYear) : '';
     const to = show.toYear != null ? String(show.toYear) : '';
     parts.push(from && to ? `prefer tracks from ${from}–${to}` : `prefer tracks ${from ? `from ${from} onward` : `up to ${to}`}`);
   }
   if (show.energy) parts.push(`favour ${show.energy}-energy tracks`);
-  if (!parts.length) return '';
-  return `\n\nMusic steer for this show — ${parts.join('; ')}. These are preferences, not hard filters: break them only when the flow genuinely demands it.`;
+
+  // The hard genre rule, phrased as a constraint rather than a preference. Still
+  // carries the never-starve escape hatch so a thin genre can't strand the show.
+  const lock = strict
+    ? `\n\nGenre lock for this show — every pick MUST be ${show.genre}. Stay within ${show.genre}; do not pick other genres. Only reach outside ${show.genre} if there is genuinely no ${show.genre} track left to play (never leave dead air).`
+    : '';
+  const soft = parts.length
+    ? `\n\nMusic steer for this show — ${parts.join('; ')}. These are preferences, not hard filters: break them only when the flow genuinely demands it.`
+    : '';
+  return `${lock}${soft}`;
 }
 
 function pickerSystem(show?: ShowMusic | null) {

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -30,6 +30,10 @@ const CAP_AUDIO_SIMILAR = 4;
 // contributor (soft lean) and the unrelated discovery sources shrink by this
 // factor so the genre/era actually shows up in the LLM's candidate list.
 const CAP_SHOW_GENRE = 12;
+// In strict mode the show-genre source becomes the dominant contributor: a
+// larger cap than the soft path so genre matches fill most of the final pool
+// (CANDIDATE_CAP) even after dedup / artist-cap / recency trims it.
+const CAP_SHOW_GENRE_STRICT = 24;
 const SHOW_NARROW_FACTOR = 0.5;
 
 // TTL cache for sources that don't change between picks. Without this, every
@@ -83,16 +87,60 @@ function softRankByCompat(pool: any[], current: { bpm: number | null; key: strin
     .map((s) => s.t);
 }
 
-// --- Show music-steering filters (soft lean) -------------------------------
-// A show can pin a genre, a decade (fromYear/toYear) and an energy band. None
-// of these is ever a hard filter: each prefers matching tracks but falls back
-// to the full set when matches are too thin to fill the pool, so a sparse genre
-// or an un-analysed library never starves the stream.
+// --- Show music-steering filters -------------------------------------------
+// A show can pin a genre, a decade (fromYear/toYear) and an energy band. By
+// default none is a hard filter: each prefers matching tracks but falls back to
+// the full set when matches are too thin to fill the pool, so a sparse genre or
+// an un-analysed library never starves the stream.
+//
+// `strict` opts the GENRE (only) into a hard filter: the off-genre discovery
+// sources are genre-filtered before they enter the pool, so the pool is
+// genuinely genre-dominated rather than just shrunk. The same never-starve
+// fallback applies — a genre too thin to fill the pool degrades to off-genre
+// tracks rather than dead air (logged by the caller). Decade and energy stay
+// soft either way.
 
-type ShowFilter = { genre?: string; fromYear?: number | null; toYear?: number | null; energy?: string } | null;
+type ShowFilter = { genre?: string; fromYear?: number | null; toYear?: number | null; energy?: string; strict?: boolean } | null;
 
 function hasMusicFilter(f: ShowFilter): boolean {
   return !!f && (!!f.genre || f.fromYear != null || f.toYear != null);
+}
+
+// Normalised genre token for fuzzy comparison — mirrors subsonic.resolveGenreName
+// so the show's resolved tag and a track's tag compare the same way.
+function normGenre(s: any): string {
+  return String(s ?? '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+// Per-track genre — from the track itself (Subsonic + slimTrack library sources
+// both carry it) or a library lookup. null when the track has no genre tag.
+function trackGenre(t: any): string | null {
+  if (t?.genre) return t.genre;
+  const rec = t?.id ? library.get(t.id) : null;
+  return rec?.genre ?? null;
+}
+
+// True when a track's genre matches the (already library-resolved) target genre.
+// Exact-normalised match, or substring either way — same shape as
+// subsonic.resolveGenreName, so "Hip-Hop" matches a "Hip Hop" tag etc.
+function genreMatches(t: any, targetNorm: string): boolean {
+  const g = trackGenre(t);
+  if (!g) return false;
+  const gn = normGenre(g);
+  return !!gn && (gn === targetNorm || gn.includes(targetNorm) || targetNorm.includes(gn));
+}
+
+// Hard-prefer tracks matching the show's genre (strict mode). Unlike the soft
+// energy/year leans, an untagged or off-genre track does NOT stay eligible —
+// the whole point of strict is a genre-pure pool. But it FALLS BACK to the
+// unfiltered set when no track matches, so a thin genre degrades to off-genre
+// rather than emptying the source (never-starve, mirrors preferEnergy/inYearRange).
+function preferGenre(tracks: any[], genreName?: string | null): any[] {
+  if (!genreName) return tracks;
+  const target = normGenre(genreName);
+  if (!target) return tracks;
+  const match = tracks.filter((t: any) => genreMatches(t, target));
+  return match.length ? match : tracks;
 }
 
 // Per-track energy band — from the track itself (library sources carry it) or a
@@ -164,13 +212,29 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
   const narrow = hasMusicFilter(showFilter);
   const nz = (cap: number) => (narrow ? Math.max(2, Math.ceil(cap * SHOW_NARROW_FACTOR)) : cap);
 
+  // Strict genre: resolve the show's free-text genre to the library's exact tag
+  // ONCE, up front, so the off-genre discovery sources below can be hard-filtered
+  // to it before they enter the pool — making the pool genuinely genre-dominated,
+  // not just shrunk. Soft mode (or no genre) leaves the sources untouched (only
+  // the nz() shrink applies). A resolution failure / absent genre degrades to no
+  // filter so a misspelled genre never strands the show (never-starve).
+  const strict = !!(showFilter?.strict && showFilter?.genre);
+  let strictGenre: string | null = null;
+  if (strict) {
+    try { strictGenre = await subsonic.resolveGenreName(showFilter!.genre!); } catch {}
+  }
+  // Hard-prefer the resolved genre on a discovery source in strict mode; a no-op
+  // otherwise. preferGenre always falls back to the full set when nothing in the
+  // source matches, so leaning a source can only tighten genre, never starve it.
+  const lean = (items: any[]) => (strict && strictGenre ? preferGenre(items, strictGenre) : items);
+
   // 1. Similar-songs from current track — strongest contextual signal.
   if (currentTrack?.id) {
     try {
       const similar = await subsonic.getSimilarSongs(currentTrack.id, {
         count: 20,
       });
-      add('similar', sampleWithRecentFallback(similar, recentIds, nz(CAP_SIMILAR)));
+      add('similar', sampleWithRecentFallback(lean(similar), recentIds, nz(CAP_SIMILAR)));
     } catch {}
   }
 
@@ -183,7 +247,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
   if (currentTrack?.id) {
     try {
       const knn = library.tracksLikeThis(currentTrack.id, 15);
-      add('embedding-similar', sampleWithRecentFallback(knn, recentIds, nz(CAP_EMBEDDING_SIMILAR)));
+      add('embedding-similar', sampleWithRecentFallback(lean(knn), recentIds, nz(CAP_EMBEDDING_SIMILAR)));
     } catch {}
   }
 
@@ -197,7 +261,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     try {
       if (await subsonic.supportsSonicSimilarity()) {
         const sonic = await subsonic.getSonicSimilarTracks(currentTrack.id, { count: 20 });
-        add('sonic-similar', sampleWithRecentFallback(sonic, recentIds, nz(CAP_SONIC_SIMILAR)));
+        add('sonic-similar', sampleWithRecentFallback(lean(sonic), recentIds, nz(CAP_SONIC_SIMILAR)));
       }
     } catch {}
   }
@@ -216,12 +280,12 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
   if (audioWaypoint && audioWaypoint.length) {
     try {
       const knn = library.tracksByAudioVector(audioWaypoint, 15);
-      add('audio-journey', sampleWithRecentFallback(knn, recentIds, nz(CAP_AUDIO_SIMILAR)));
+      add('audio-journey', sampleWithRecentFallback(lean(knn), recentIds, nz(CAP_AUDIO_SIMILAR)));
     } catch {}
   } else if (currentTrack?.id) {
     try {
       const knn = library.tracksLikeThisAudio(currentTrack.id, 15);
-      add('audio-similar', sampleWithRecentFallback(knn, recentIds, nz(CAP_AUDIO_SIMILAR)));
+      add('audio-similar', sampleWithRecentFallback(lean(knn), recentIds, nz(CAP_AUDIO_SIMILAR)));
     } catch {}
   }
 
@@ -232,30 +296,33 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
   // collection is then energy-preferred. Never a hard filter — see helpers.
   if (hasMusicFilter(showFilter)) {
     try {
-      let genreName: string | null = null;
-      if (showFilter!.genre) {
+      // Reuse the strict-resolved tag when we already paid for it above; only
+      // resolve here on the soft path (or if strict resolution came back null).
+      let genreName: string | null = strict ? strictGenre : null;
+      if (!genreName && showFilter!.genre) {
         genreName = await subsonic.resolveGenreName(showFilter!.genre);
       }
       const collected: any[] = [];
       collected.push(...await subsonic.getRandomSongs({
-        size: 40,
+        size: strict ? 60 : 40,
         genre: genreName || undefined,
         fromYear: showFilter!.fromYear ?? undefined,
         toYear: showFilter!.toYear ?? undefined,
       }));
       if (genreName) {
-        const g = await subsonic.getSongsByGenre(genreName, { count: 60 });
+        const g = await subsonic.getSongsByGenre(genreName, { count: strict ? 100 : 60 });
         const ranged = inYearRange(g, showFilter!);
         collected.push(...(ranged.length ? ranged : g));
       }
       const leaned = preferEnergy(collected, showFilter!.energy);
-      add('show-genre', sampleWithRecentFallback(shuffle(leaned), recentIds, CAP_SHOW_GENRE));
+      // Strict bumps the cap so this genre-native source dominates the merged pool.
+      add('show-genre', sampleWithRecentFallback(shuffle(leaned), recentIds, strict ? CAP_SHOW_GENRE_STRICT : CAP_SHOW_GENRE));
     } catch {}
   }
 
   // 2. Mood-tagged library (LLM-built tags, may be sparse).
   if (mood) {
-    const moodHits = shuffle(preferEnergy(library.songsByMood(mood), showFilter?.energy));
+    const moodHits = shuffle(lean(preferEnergy(library.songsByMood(mood), showFilter?.energy)));
     add('mood-library', sampleWithRecentFallback(moodHits, recentIds, CAP_MOOD_LIBRARY));
   }
 
@@ -273,7 +340,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
           plTracks.push(...songs);
         } catch {}
       }
-      add('playlist', sampleWithRecentFallback(shuffle(plTracks), recentIds, nz(CAP_PLAYLIST)));
+      add('playlist', sampleWithRecentFallback(lean(shuffle(plTracks)), recentIds, nz(CAP_PLAYLIST)));
     } catch {}
   }
 
@@ -286,7 +353,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
       const albums = await subsonic.getRecentlyAddedAlbums({ size: 12 });
       return tracksFromAlbums(shuffle(albums), 3, 40);
     });
-    add('recent', sampleWithRecentFallback(shuffle(recentPool), recentIds, nz(CAP_RECENT)));
+    add('recent', sampleWithRecentFallback(lean(shuffle(recentPool)), recentIds, nz(CAP_RECENT)));
   } catch {}
 
   // 5. Frequent albums — scrobble-backed favourites. Same wide-pool-then-
@@ -296,7 +363,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
       const albums = await subsonic.getFrequentAlbums({ size: 12 });
       return tracksFromAlbums(shuffle(albums), 3, 40);
     });
-    add('frequent', sampleWithRecentFallback(shuffle(freqPool), recentIds, nz(CAP_FREQUENT)));
+    add('frequent', sampleWithRecentFallback(lean(shuffle(freqPool)), recentIds, nz(CAP_FREQUENT)));
   } catch {}
 
   // 6. Similar-artist top songs — adjacency through Last.fm artist graph.
@@ -326,7 +393,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
       );
       add(
         'similar-artist',
-        sampleWithRecentFallback(similarArtistTracks, recentIds, nz(CAP_SIMILAR_ARTIST)),
+        sampleWithRecentFallback(lean(similarArtistTracks), recentIds, nz(CAP_SIMILAR_ARTIST)),
       );
     } catch {}
   }
@@ -366,7 +433,21 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     cap: CANDIDATE_CAP,
   });
 
-  return { candidates: final, sources };
+  // Strict-genre diagnostics for the caller's never-starve log: how much of the
+  // final pool actually landed in-genre. `resolved` is null when the show's
+  // genre didn't map to any library tag (strict silently degraded to soft).
+  let strictInfo: { requested: string; resolved: string | null; matched: number; total: number } | null = null;
+  if (strict) {
+    const target = strictGenre ? normGenre(strictGenre) : '';
+    strictInfo = {
+      requested: showFilter!.genre!,
+      resolved: strictGenre,
+      matched: target ? final.filter((t: any) => genreMatches(t, target)).length : 0,
+      total: final.length,
+    };
+  }
+
+  return { candidates: final, sources, strictInfo };
 }
 
 function summariseRecent(queue: any) {
@@ -401,9 +482,9 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   // (below) and its brief steers the LLM pick (further down).
   const activeShow = settings.resolveActiveShow();
   const showFilter: ShowFilter = activeShow
-    ? { genre: activeShow.genre, fromYear: activeShow.fromYear, toYear: activeShow.toYear, energy: activeShow.energy }
+    ? { genre: activeShow.genre, fromYear: activeShow.fromYear, toYear: activeShow.toYear, energy: activeShow.energy, strict: activeShow.genreStrict }
     : null;
-  const { candidates, sources } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack, rankTarget, audioWaypoint, showFilter);
+  const { candidates, sources, strictInfo } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack, rankTarget, audioWaypoint, showFilter);
 
   if (candidates.length === 0) {
     queue.log('picker', 'no candidates available, skipping LLM pick');
@@ -416,6 +497,20 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
       .map(([k, v]) => `${k}=${v}`)
       .join(' ')})`,
   );
+
+  // Strict-genre visibility — make the never-starve fallback audible in the log
+  // so a thin/misspelled genre isn't a silent mystery.
+  if (strictInfo) {
+    if (!strictInfo.resolved) {
+      queue.log('picker', `strict genre "${strictInfo.requested}" not found in library — falling back to unfiltered pool`);
+    } else if (strictInfo.matched === 0) {
+      queue.log('picker', `strict genre ${strictInfo.resolved}: 0 in-genre candidates — falling back to off-genre to keep the stream alive`);
+    } else if (strictInfo.matched < strictInfo.total) {
+      queue.log('picker', `strict genre ${strictInfo.resolved}: ${strictInfo.matched}/${strictInfo.total} in-genre (off-genre allowed as fallback)`);
+    } else {
+      queue.log('picker', `strict genre ${strictInfo.resolved}: ${strictInfo.matched}/${strictInfo.total} in-genre`);
+    }
+  }
 
   const recentPlays = summariseRecent(queue);
 
@@ -432,6 +527,7 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
             fromYear: activeShow.fromYear,
             toYear: activeShow.toYear,
             energy: activeShow.energy,
+            genreStrict: activeShow.genreStrict,
           }
         : null,
       candidates: candidates.map(c => {

--- a/controller/src/routes/generate.ts
+++ b/controller/src/routes/generate.ts
@@ -61,6 +61,8 @@ router.post('/generate/show', requireAdmin, async (req, res) => {
     if (!draft.themeId || !themeIds.has(draft.themeId)) draft.themeId = null;
     if (!settings.SHOW_MOODS.includes(draft.mood)) draft.mood = settings.SHOW_MOODS[0];
     if (draft.energy && !settings.SHOW_ENERGY.includes(draft.energy)) draft.energy = '';
+    // Strict only makes sense with a genre to lock to.
+    if (draft.genreStrict && !draft.genre) draft.genreStrict = false;
 
     res.json({ ok: true, show: draft });
   } catch (err: any) {

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -845,6 +845,10 @@ function normalizeShows(raw: any, personaIds: string[]) {
     const fromYear = Number.isFinite(item.fromYear) ? Math.trunc(item.fromYear) : null;
     const toYear = Number.isFinite(item.toYear) ? Math.trunc(item.toYear) : null;
     const energy = SHOW_ENERGY.includes(item.energy) ? item.energy : '';
+    // Opt-in: hard-filter the pick pool to `genre` instead of the default soft
+    // lean. Only meaningful when a genre is set; defaults off so existing shows
+    // and soft shows are byte-for-byte unchanged.
+    const genreStrict = item.genreStrict === true;
     out.push({
       id,
       name,
@@ -856,6 +860,7 @@ function normalizeShows(raw: any, personaIds: string[]) {
       fromYear,
       toYear,
       energy,
+      genreStrict,
     });
     if (out.length >= SHOWS_LIMIT) break;
   }
@@ -1497,6 +1502,8 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
     if (energy && !SHOW_ENERGY.includes(energy)) {
       throw new Error(`shows[${i}].energy must be one of: ${SHOW_ENERGY.join(', ')}`);
     }
+    // Opt-in hard genre filter (vs the default soft lean). Boolean, defaults off.
+    const genreStrict = item.genreStrict === true;
     const parseYear = (v, field) => {
       if (v == null || v === '') return null;
       const n = Number(v);
@@ -1513,7 +1520,7 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
     let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('s_');
     if (seen.has(id)) id = mintId('s_');
     seen.add(id);
-    return { id, name, topic, personaId: item.personaId, mood: item.mood, themeId, genre, fromYear, toYear, energy };
+    return { id, name, topic, personaId: item.personaId, mood: item.mood, themeId, genre, fromYear, toYear, energy, genreStrict };
   });
 }
 
@@ -2153,6 +2160,10 @@ export function resolveActiveShow(date = new Date(), s = get()) {
     fromYear: Number.isFinite(show.fromYear) ? show.fromYear : null,
     toYear: Number.isFinite(show.toYear) ? show.toYear : null,
     energy: typeof show.energy === 'string' ? show.energy : '',
+    // When true (and a genre is set) the pick pool is hard-filtered to the
+    // genre instead of softly leaned; off-genre tracks only survive as a
+    // never-starve fallback. Defaults off.
+    genreStrict: show.genreStrict === true,
     // Empty string means "fall back to the station-wide default". The route
     // layer is responsible for resolving an empty/stale id against the live
     // theme registry; we just surface what the show declares.

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -24,7 +24,7 @@ import { Field } from '../ui/field';
 import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup,
 } from '../ui/select';
-import { Card, Btn, Pill, Eyebrow, Metric } from './ui';
+import { Card, Btn, Pill, Eyebrow, Metric, Toggle } from './ui';
 import { Modal } from '../ui/modal';
 import { AiFill } from './AiFill';
 import { cn } from '../../lib/cn';
@@ -69,6 +69,10 @@ interface Show {
   fromYear: number | null;
   toYear: number | null;
   energy: string;
+  /** When true (and a genre is set) the genre becomes a HARD filter on the pick
+   *  pool instead of a soft lean — off-genre tracks only play as a last resort
+   *  to avoid silence. Defaults off. */
+  genreStrict: boolean;
 }
 
 // Decade presets for the era dropdown → fromYear/toYear. 'any' clears the window.
@@ -174,9 +178,11 @@ function NowCard({ label, accent, slotHour, show, color, personaLabel }: NowCard
 }
 
 // Compact " · genre · 80s · high" suffix for the show summary lines, omitting
-// whatever the show doesn't pin.
-function showFilterSummary(s: { genre: string; fromYear: number | null; toYear: number | null; energy: string }): string {
-  const bits = [s.genre, decadeLabelOf(s), s.energy].filter(Boolean);
+// whatever the show doesn't pin. A strict genre is flagged inline so the hard
+// lock is visible at a glance.
+function showFilterSummary(s: { genre: string; fromYear: number | null; toYear: number | null; energy: string; genreStrict?: boolean }): string {
+  const genre = s.genre ? (s.genreStrict ? `${s.genre} (strict)` : s.genre) : '';
+  const bits = [genre, decadeLabelOf(s), s.energy].filter(Boolean);
   return bits.length ? ` · ${bits.join(' · ')}` : '';
 }
 
@@ -283,6 +289,7 @@ export default function ShowsPanel() {
           fromYear: s.fromYear ?? null,
           toYear: s.toYear ?? null,
           energy: s.energy ?? '',
+          genreStrict: s.genreStrict ?? false,
         }));
         setForm({ shows, schedule: week });
         // Arm the first valid show as the brush so the grid is paintable at once.
@@ -343,7 +350,7 @@ export default function ShowsPanel() {
       id: '', name: '', topic: '',
       personaId: personas[0]?.id || '', mood: moods[0] || '',
       themeId: '',
-      genre: '', fromYear: null, toYear: null, energy: '',
+      genre: '', fromYear: null, toYear: null, energy: '', genreStrict: false,
     });
   };
   const openEdit = (i: number) => {
@@ -356,6 +363,7 @@ export default function ShowsPanel() {
       personaId: s.personaId, mood: s.mood,
       themeId: s.themeId || '',
       genre: s.genre || '', fromYear: s.fromYear ?? null, toYear: s.toYear ?? null, energy: s.energy || '',
+      genreStrict: s.genreStrict ?? false,
     });
   };
   const closeModal = () => { setEditIndex(null); setDraft(null); };
@@ -367,6 +375,8 @@ export default function ShowsPanel() {
       personaId: draft.personaId, mood: draft.mood,
       themeId: draft.themeId || '',
       genre: draft.genre.trim(), fromYear: draft.fromYear, toYear: draft.toYear, energy: draft.energy || '',
+      // Strict is only meaningful with a genre to lock to — drop it otherwise.
+      genreStrict: !!draft.genre.trim() && draft.genreStrict,
     };
     if (editIndex === -1) {
       const id = clientMintId();
@@ -503,6 +513,7 @@ export default function ShowsPanel() {
             personaId: s.personaId, mood: s.mood,
             themeId: s.themeId || '',
             genre: s.genre.trim(), fromYear: s.fromYear, toYear: s.toYear, energy: s.energy || '',
+            genreStrict: !!s.genre.trim() && s.genreStrict,
           })),
           schedule: form.schedule,
         }),
@@ -897,6 +908,26 @@ export default function ShowsPanel() {
                 </Select>
               </Field>
             </div>
+
+            <div className="flex items-start gap-3">
+              <div className="pt-0.5">
+                <Toggle
+                  on={draft.genreStrict}
+                  disabled={!draft.genre.trim()}
+                  onClick={() => setDraftField({ genreStrict: !draft.genreStrict })}
+                />
+              </div>
+              <div className="grid gap-0.5">
+                <Label className={!draft.genre.trim() ? 'opacity-40' : undefined}>
+                  Strict genre
+                </Label>
+                <span className="field-hint">
+                  Stay strictly within this genre (off-genre tracks only as a last
+                  resort to avoid silence). Needs a genre lean set above.
+                </span>
+              </div>
+            </div>
+
             <span className="field-hint -mt-1.5">
               Optional soft music steer for this show — a genre, an era, an energy
               band, or any mix. The DJ leans toward these but can break them for


### PR DESCRIPTION
## What

Adds an opt-in per-show **Strict genre** toggle. A show's genre is a *soft lean* today — when pinned, the picker adds a dedicated `show-genre` source and shrinks the other discovery sources, but does **not** genre-filter them, so similar / embedding / sonic / audio neighbours and the mood-library keep feeding off-genre tracks. Genre-focused shows drift (e.g. *Energetic Rap → Energetic Metal*, because energy is an independent axis). Strict mode hard-filters the whole pool to the genre while keeping the never-starve guarantee.

Default **OFF** — existing shows and soft shows behave exactly as before (the soft path is byte-for-byte unchanged; verified by a pure test).

## How

- **`music/picker.ts`** — `ShowFilter` gains `strict`. New `trackGenre` / `genreMatches` / `preferGenre` helpers (same fuzzy normalisation as `subsonic.resolveGenreName`, same never-starve fallback as `preferEnergy`/`inYearRange`). In strict mode the genre is resolved once up front and hard-applied to the off-genre discovery sources *before* they enter the pool; the `show-genre` cap is bumped (`CAP_SHOW_GENRE_STRICT`) so genre matches dominate. `starred`/`random` (the anti-starve net) and `show-genre` itself are never re-filtered. The caller logs the in-genre share and any never-starve fallback.
- **`llm/internal/prompts/picker.ts`** — `showMusicLean` phrases strict as a hard rule (*"every pick MUST be {genre}; do not pick other genres"*) with a never-leave-dead-air escape hatch, instead of *"lean toward {genre}"*. Shared by both pick paths.
- **`broadcast/dj-agent.ts`** — the session DJ agent honours strict automatically via `resolveActiveShow` → `showMusicLean` (comment updated).
- **`settings.ts`** — `genreStrict` on the show schema (normalize + strict-validate + `resolveActiveShow`), defaults `false`.
- **`llm/internal/prompts/generate.ts` + `routes/generate.ts`** — the show-designer LLM sets `genreStrict=true` when a free-text description implies exclusivity ("only plays hip-hop"); guarded so it's never set without a genre.
- **`web/components/admin/ShowsPanel.tsx`** — a "Strict genre" toggle in the show editor (disabled until a genre is set); summary line flags `(strict)`.

## Never-starve

Load-bearing: a strict filter that empties the pool must not stall the stream. Every filtered source falls back to its unfiltered set when it has no genre match; an unresolved/misspelled genre degrades to the soft pool; `starred`/`random` are never filtered. All fallbacks are logged via `queue.log('picker', …)`.

## Tests / gate

- `npm run test:llm` (controller) — new `showMusicLean` cases pin the soft path byte-for-byte and the strict hard-rule phrasing. Full `npm test` green.
- `npm run lint` (`eslint . && tsc --noEmit`) passes in **both** `controller/` and `web/`.