### PR TITLE
fix(auth): reset brute-force counter after lockout window expires

### DIFF
--- a/controller/src/middleware/auth.ts
+++ b/controller/src/middleware/auth.ts
@@ -55,6 +55,15 @@ export function requireAdmin(req, res, next) {
   const now = Date.now();
   const rec = authAttempts.get(ip);
 
+  // Once a lockout window has elapsed, clear the counter so the operator gets a
+  // fresh set of MAX_AUTH_FAILURES attempts. Without this, failures stays >=
+  // MAX_AUTH_FAILURES after the first lockout, so the very next wrong attempt
+  // immediately re-locks for another window — effectively one try every 15 min.
+  if (rec && rec.lockedUntil > 0 && rec.lockedUntil <= now) {
+    rec.failures = 0;
+    rec.lockedUntil = 0;
+  }
+
   if (rec && rec.lockedUntil > now) {
     const retryAfter = Math.ceil((rec.lockedUntil - now) / 1000);
     res.setHeader('Retry-After', String(retryAfter));


### PR DESCRIPTION
## What
Follow-up to #491. When an admin brute-force lockout expires, reset the per-IP failure counter so the operator gets a fresh set of attempts.

## Why
The lockout added in #491 never cleared `failures` once the 15-minute window elapsed, so it stayed `>= MAX_AUTH_FAILURES`. The first wrong attempt after the window then re-locked immediately — the operator effectively got **one try every 15 minutes** instead of another batch of 10.

This was caught in review by @geekylakshya on #491 (after merge). The fix is his proposed approach: reset `failures`/`lockedUntil` to `0` the moment an expired lockout is observed, before the 429 gate.

```ts
if (rec && rec.lockedUntil > 0 && rec.lockedUntil <= now) {
  rec.failures = 0;
  rec.lockedUntil = 0;
}
```

A correct password still recovers immediately (`authAttempts.delete(ip)`), unchanged.

## How tested
- `cd controller && npm run lint` — 0 errors.
- Traced: 10 failures → lockout → window elapses → counter resets to 0 → next wrong attempt starts a fresh count rather than instant re-lock.

## Note
While here I also checked the admin shell's first call (the non-blocking concern from #491): the first-paint probe in `AdminShell.tsx` is gated on a cached token being present, and `signIn` makes exactly one `/settings` call per submit, so the normal login flow can't nibble the counter down. Only a *stale* cached token fires a couple of failures before the gate re-renders — well within the budget. No change needed there.