### PR TITLE
feat(auth): replace plaintext ADMIN_PASS with scrypt-hashed credentials

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -10,7 +10,7 @@
 // After init, the operator runs `subwave start` (which brings docker up)
 // and `subwave setup` (the full wizard for Navidrome / LLM / TTS / DJ).
 
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync, chmodSync, renameSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { homedir } from 'node:os';
 import crypto from 'node:crypto';
@@ -219,6 +219,31 @@ async function scaffold(a: InitAnswers): Promise<void> {
   mkdirSync(resolve(a.home, 'state', 'logs'), { recursive: true });
   ok(`created ${a.home}/ (state/, state/logs/)`);
 
+  // Hash admin password directly to state/admin-hash.json so plaintext
+  // never touches .env. The controller reads this on boot.
+  const { scrypt: scryptCb, randomBytes: rb } = await import('node:crypto');
+  const salt = rb(16).toString('hex');
+  const SCRYPT_MAXMEM = 256 * 1024 * 1024;
+  const hash: string = await new Promise((res, rej) => {
+    scryptCb(a.adminPass, salt, 64, { N: 131072, r: 8, p: 1, maxmem: SCRYPT_MAXMEM }, (e, d) => {
+      if (e) return rej(e);
+      res(d.toString('hex'));
+    });
+  });
+  const hashData = {
+    user: a.adminUser,
+    hash,
+    salt,
+    scryptParams: { N: 131072, r: 8, p: 1, keyLen: 64, maxmem: SCRYPT_MAXMEM },
+    changedAt: new Date().toISOString(),
+  };
+  const hashPath = resolve(a.home, 'state', 'admin-hash.json');
+  const hashTmp = `${hashPath}.tmp`;
+  writeFileSync(hashTmp, JSON.stringify(hashData, null, 2) + '\n');
+  chmodSync(hashTmp, 0o600);
+  renameSync(hashTmp, hashPath);
+  ok('wrote state/admin-hash.json (scrypt-hashed admin password)');
+
   // 2. Write the compose file the operator chose. Both modes get a copy of
   // docker-compose.byo.yml alongside the default so operators can switch
   // later without re-running init.
@@ -242,12 +267,11 @@ async function scaffold(a: InitAnswers): Promise<void> {
   writeFileSync(envExamplePath, ENV_EXAMPLE);
   const envValues: Record<string, string> = {
     ADMIN_USER: a.adminUser,
-    ADMIN_PASS: a.adminPass,
     TZ: a.tz,
   };
   if (a.siteUrl) envValues.SITE_URL = a.siteUrl;
   writeEnvFileAt(resolve(a.home, '.env'), envValues, envExamplePath);
-  ok(`wrote .env (ADMIN_USER, ADMIN_PASS, TZ=${a.tz}${a.siteUrl ? ', SITE_URL' : ''})`);
+  ok(`wrote .env (ADMIN_USER, TZ=${a.tz}${a.siteUrl ? ', SITE_URL' : ''})`);
 
   // 4. Persist the home in ~/.config/subwave/config.json so subsequent
   // `subwave …` commands resolve to this directory without --home or
@@ -267,7 +291,7 @@ async function scaffold(a: InitAnswers): Promise<void> {
     console.log();
     info(`admin user: ${pc.bold(a.adminUser)}`);
     info(`admin pass: ${pc.bold(a.adminPass)}`);
-    muted('Stored in .env at the install dir. Visible to anyone with shell access — protect accordingly.');
+    muted('Hashed in state/admin-hash.json. The plaintext is not stored on disk.');
   }
 }
 

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -230,16 +230,21 @@ async function scaffold(a: InitAnswers): Promise<void> {
       res(d.toString('hex'));
     });
   });
+  // maxmem is a Node runtime cap, not a scrypt cost parameter, so it is
+  // intentionally omitted from the persisted schema; the controller backfills
+  // a default at read time when computing the verifier.
   const hashData = {
     user: a.adminUser,
     hash,
     salt,
-    scryptParams: { N: 131072, r: 8, p: 1, keyLen: 64, maxmem: SCRYPT_MAXMEM },
+    scryptParams: { N: 131072, r: 8, p: 1, keyLen: 64 },
     changedAt: new Date().toISOString(),
   };
   const hashPath = resolve(a.home, 'state', 'admin-hash.json');
   const hashTmp = `${hashPath}.tmp`;
-  writeFileSync(hashTmp, JSON.stringify(hashData, null, 2) + '\n');
+  // Create with 0600 up front so the tmp file is never world-readable even
+  // under a permissive umask. chmodSync stays as belt-and-suspenders.
+  writeFileSync(hashTmp, JSON.stringify(hashData, null, 2) + '\n', { mode: 0o600 });
   chmodSync(hashTmp, 0o600);
   renameSync(hashTmp, hashPath);
   ok('wrote state/admin-hash.json (scrypt-hashed admin password)');

--- a/controller/src/middleware/admin-credentials.ts
+++ b/controller/src/middleware/admin-credentials.ts
@@ -1,0 +1,98 @@
+import { randomBytes, scrypt, timingSafeEqual } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync, renameSync, chmodSync } from 'node:fs';
+import { STATE_DIR } from '../config.js';
+
+export interface ScryptParams {
+  N: number;
+  r: number;
+  p: number;
+  keyLen: number;
+  maxmem: number;
+}
+
+export interface AdminCredentials {
+  user: string;
+  hash: string;
+  salt: string;
+  scryptParams: ScryptParams;
+  changedAt: string;
+}
+
+// N=2^17 with r=8 needs ~128 MiB. Node's default maxmem is 32 MiB, which
+// causes ERR_CRYPTO_INVALID_SCRYPT_PARAMS. Set maxmem to 256 MiB.
+export const SCRYPT_PARAMS: ScryptParams = {
+  N: 131072, r: 8, p: 1, keyLen: 64, maxmem: 256 * 1024 * 1024,
+};
+export const MIN_PASSWORD_LENGTH = 12;
+
+const HASH_PATH = `${STATE_DIR}/admin-hash.json`;
+
+export function loadCredentials(): AdminCredentials | null {
+  if (!existsSync(HASH_PATH)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(HASH_PATH, 'utf8'));
+    // Back-compat: files written before maxmem was stored still work --
+    // verifyPassword reads params from the file and falls back to the default.
+    if (raw.scryptParams && raw.scryptParams.maxmem == null) {
+      raw.scryptParams.maxmem = SCRYPT_PARAMS.maxmem;
+    }
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveCredentials(user: string, hash: string, salt: string): Promise<void> {
+  const data: AdminCredentials = {
+    user,
+    hash,
+    salt,
+    scryptParams: SCRYPT_PARAMS,
+    changedAt: new Date().toISOString(),
+  };
+  const tmp = `${HASH_PATH}.tmp`;
+  writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n');
+  chmodSync(tmp, 0o600);
+  renameSync(tmp, HASH_PATH);
+}
+
+export function hashPassword(password: string): Promise<{ hash: string; salt: string }> {
+  return new Promise((resolve, reject) => {
+    const salt = randomBytes(16).toString('hex');
+    scrypt(password, salt, SCRYPT_PARAMS.keyLen, {
+      N: SCRYPT_PARAMS.N,
+      r: SCRYPT_PARAMS.r,
+      p: SCRYPT_PARAMS.p,
+      maxmem: SCRYPT_PARAMS.maxmem,
+    }, (err, derived) => {
+      if (err) return reject(err);
+      resolve({ hash: derived.toString('hex'), salt });
+    });
+  });
+}
+
+export function verifyPassword(
+  password: string,
+  storedHash: string,
+  storedSalt: string,
+  params: ScryptParams,
+): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    scrypt(password, storedSalt, params.keyLen, {
+      N: params.N,
+      r: params.r,
+      p: params.p,
+      maxmem: params.maxmem ?? SCRYPT_PARAMS.maxmem,
+    }, (err, derived) => {
+      if (err) return reject(err);
+      const a = Buffer.from(derived.toString('hex'));
+      const b = Buffer.from(storedHash);
+      if (a.length !== b.length) {
+        timingSafeEqual(a, a);
+        resolve(false);
+        return;
+      }
+      resolve(timingSafeEqual(a, b));
+    });
+  });
+}

--- a/controller/src/middleware/admin-credentials.ts
+++ b/controller/src/middleware/admin-credentials.ts
@@ -7,7 +7,10 @@ export interface ScryptParams {
   r: number;
   p: number;
   keyLen: number;
-  maxmem: number;
+  // Node runtime cap, not a cost parameter. Kept on the in-memory shape for
+  // crypto.scrypt() calls but intentionally OMITTED from the on-disk JSON so
+  // the persisted schema only carries actual scrypt cost parameters.
+  maxmem?: number;
 }
 
 export interface AdminCredentials {
@@ -43,15 +46,22 @@ export function loadCredentials(): AdminCredentials | null {
 }
 
 export async function saveCredentials(user: string, hash: string, salt: string): Promise<void> {
+  // Persist only the actual scrypt cost parameters - maxmem is a Node runtime
+  // cap, not part of the hashing function's parameterisation, so it does not
+  // belong in the on-disk schema. loadCredentials() backfills it at read time.
+  const { N, r, p, keyLen } = SCRYPT_PARAMS;
   const data: AdminCredentials = {
     user,
     hash,
     salt,
-    scryptParams: SCRYPT_PARAMS,
+    scryptParams: { N, r, p, keyLen },
     changedAt: new Date().toISOString(),
   };
   const tmp = `${HASH_PATH}.tmp`;
-  writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n');
+  // Create the tmp file with 0600 up front so there is no umask window where
+  // the file is briefly world-readable before chmodSync tightens it. chmodSync
+  // is retained as belt-and-suspenders for platforms that ignore the mode arg.
+  writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 });
   chmodSync(tmp, 0o600);
   renameSync(tmp, HASH_PATH);
 }

--- a/controller/src/middleware/auth.ts
+++ b/controller/src/middleware/auth.ts
@@ -1,15 +1,10 @@
 import { timingSafeEqual } from 'node:crypto';
 import { clientIp } from './ratelimit.js';
+import {
+  loadCredentials, saveCredentials, hashPassword, verifyPassword,
+  type AdminCredentials,
+} from './admin-credentials.js';
 
-// Admin basic auth. In production (NODE_ENV=production) ADMIN_USER and
-// ADMIN_PASS are MANDATORY — the controller refuses to start without them,
-// because /debug, /settings, and the jingle/tagger endpoints expose enough
-// internals (queue, recent LLM calls, library stats, hostnames) that a
-// public deploy without auth is effectively an open admin console. In dev
-// the gate stays opt-in so local iteration is frictionless.
-const ADMIN_USER = process.env.ADMIN_USER || '';
-const ADMIN_PASS = process.env.ADMIN_PASS || '';
-export const ADMIN_AUTH_REQUIRED = Boolean(ADMIN_USER && ADMIN_PASS);
 const IS_PROD = process.env.NODE_ENV === 'production';
 // 10 strikes before a temporary lockout: brute-forcing a real password in 10
 // tries is implausible, while an operator (or a household behind one NAT IP)
@@ -17,6 +12,10 @@ const IS_PROD = process.env.NODE_ENV === 'production';
 const MAX_AUTH_FAILURES = 10;
 const AUTH_LOCKOUT_MS = 15 * 60 * 1000;
 const authAttempts = new Map<string, { failures: number; lockedUntil: number }>();
+
+let adminUser = '';
+let cachedCreds: AdminCredentials | null = null;
+export let ADMIN_AUTH_REQUIRED = false;
 
 function safeEqual(a: string, b: string): boolean {
   const bufA = Buffer.from(a);
@@ -28,24 +27,72 @@ function safeEqual(a: string, b: string): boolean {
   return timingSafeEqual(bufA, bufB);
 }
 
-// Called once at startup. Exits the process if a production deploy is missing
-// admin credentials, then logs the resolved gate state.
+// Called once at startup, before initAdminCredentials. Exits the process if a
+// production deploy has no credentials at all (neither hash file nor env vars).
 export function assertAdminConfigured() {
-  if (IS_PROD && !ADMIN_AUTH_REQUIRED) {
+  const envUser = process.env.ADMIN_USER || '';
+  const envPass = process.env.ADMIN_PASS || '';
+  const hasEnv = Boolean(envUser && envPass);
+  const hasCreds = loadCredentials() !== null;
+
+  if (IS_PROD && !hasEnv && !hasCreds) {
     console.error(
-      '[auth] FATAL: NODE_ENV=production but ADMIN_USER and ADMIN_PASS are not set.\n' +
-      '       /debug, /settings and admin endpoints would be publicly readable.\n' +
-      '       Set ADMIN_USER and ADMIN_PASS in controller/.env, then rebuild the controller.'
+      '[auth] FATAL: NODE_ENV=production but no admin credentials found.\n' +
+      '       Either set ADMIN_USER and ADMIN_PASS in .env, or ensure\n' +
+      '       state/admin-hash.json exists from a prior boot.'
     );
     process.exit(1);
   }
-  console.log(`[auth] admin gate ${ADMIN_AUTH_REQUIRED ? 'ENABLED' : 'disabled (set ADMIN_USER+ADMIN_PASS to enable)'}`);
+}
+
+// Loads (or migrates) admin credentials into memory. Call after secrets are
+// loaded but before any admin route can fire.
+export async function initAdminCredentials(): Promise<void> {
+  const envUser = process.env.ADMIN_USER || '';
+  const envPass = process.env.ADMIN_PASS || '';
+  const existing = loadCredentials();
+
+  if (existing) {
+    cachedCreds = existing;
+    adminUser = existing.user;
+    ADMIN_AUTH_REQUIRED = true;
+
+    if (envPass) {
+      console.warn(
+        '[auth] ADMIN_PASS found in .env but hashed credentials exist. ' +
+        'Remove ADMIN_PASS from .env for security.'
+      );
+    }
+    console.log('[auth] admin gate ENABLED (hashed credentials)');
+    return;
+  }
+
+  if (envUser && envPass) {
+    adminUser = envUser;
+    const { hash, salt } = await hashPassword(envPass);
+    await saveCredentials(envUser, hash, salt);
+    cachedCreds = loadCredentials();
+    ADMIN_AUTH_REQUIRED = true;
+
+    // Do NOT try to strip ADMIN_PASS from .env -- in Docker the container
+    // can't write the host file (it arrives via env_file, not a bind mount).
+    // Warn the operator to remove it manually.
+    console.log('[auth] migrated ADMIN_PASS to hashed storage (state/admin-hash.json)');
+    console.warn(
+      '[auth] ADMIN_PASS is still in .env. Remove it manually for security -- ' +
+      'the hash file is now the sole credential source.'
+    );
+    return;
+  }
+
+  ADMIN_AUTH_REQUIRED = false;
+  console.log('[auth] admin gate disabled (set ADMIN_USER+ADMIN_PASS to enable)');
 }
 
 export function requireAdmin(req, res, next) {
   if (!ADMIN_AUTH_REQUIRED) return next();
 
-  // Lockout keys on clientIp() — the left-most X-Forwarded-For — which is
+  // Lockout keys on clientIp() -- the left-most X-Forwarded-For -- which is
   // client-controlled and therefore spoofable: an attacker can rotate the
   // header per request to dodge this counter. So this is defense-in-depth that
   // slows casual brute-forcing from a single source, not a hard guarantee. For
@@ -58,7 +105,7 @@ export function requireAdmin(req, res, next) {
   // Once a lockout window has elapsed, clear the counter so the operator gets a
   // fresh set of MAX_AUTH_FAILURES attempts. Without this, failures stays >=
   // MAX_AUTH_FAILURES after the first lockout, so the very next wrong attempt
-  // immediately re-locks for another window — effectively one try every 15 min.
+  // immediately re-locks for another window -- effectively one try every 15 min.
   if (rec && rec.lockedUntil > 0 && rec.lockedUntil <= now) {
     rec.failures = 0;
     rec.lockedUntil = 0;
@@ -71,22 +118,54 @@ export function requireAdmin(req, res, next) {
   }
 
   const header = req.headers.authorization || '';
-  if (header.startsWith('Basic ')) {
-    try {
-      // Split on the FIRST colon only: per RFC 7617 the userid can't contain a
-      // colon but the password can, so split(':') would truncate any password
-      // with a ':' in it and reject otherwise-correct credentials.
-      const decoded = Buffer.from(header.slice(6), 'base64').toString('utf8');
-      const sep = decoded.indexOf(':');
-      const u = sep === -1 ? decoded : decoded.slice(0, sep);
-      const p = sep === -1 ? '' : decoded.slice(sep + 1);
-      if (safeEqual(u, ADMIN_USER) && safeEqual(p, ADMIN_PASS)) {
+  if (!header.startsWith('Basic ')) {
+    res.setHeader('WWW-Authenticate', 'Basic realm="SUB/WAVE admin"');
+    return res.status(401).json({ error: 'admin auth required' });
+  }
+
+  // Split on the FIRST colon only: per RFC 7617 the userid can't contain a
+  // colon but the password can, so split(':') would truncate any password
+  // with a ':' in it and reject otherwise-correct credentials.
+  let u: string, p: string;
+  try {
+    const decoded = Buffer.from(header.slice(6), 'base64').toString('utf8');
+    const sep = decoded.indexOf(':');
+    u = sep === -1 ? decoded : decoded.slice(0, sep);
+    p = sep === -1 ? '' : decoded.slice(sep + 1);
+  } catch {
+    res.setHeader('WWW-Authenticate', 'Basic realm="SUB/WAVE admin"');
+    return res.status(401).json({ error: 'admin auth required' });
+  }
+
+  if (!safeEqual(u, adminUser)) {
+    failAuth(ip, now, rec, res);
+    return;
+  }
+
+  if (!cachedCreds) {
+    res.setHeader('WWW-Authenticate', 'Basic realm="SUB/WAVE admin"');
+    return res.status(401).json({ error: 'admin auth required' });
+  }
+
+  verifyPassword(p, cachedCreds.hash, cachedCreds.salt, cachedCreds.scryptParams)
+    .then(valid => {
+      if (valid) {
         if (rec) authAttempts.delete(ip);
         return next();
       }
-    } catch {}
-  }
+      failAuth(ip, now, rec, res);
+    })
+    .catch(() => {
+      res.status(500).json({ error: 'auth verification failed' });
+    });
+}
 
+function failAuth(
+  ip: string,
+  now: number,
+  rec: { failures: number; lockedUntil: number } | undefined,
+  res,
+) {
   const entry = rec || { failures: 0, lockedUntil: 0 };
   entry.failures += 1;
   if (entry.failures >= MAX_AUTH_FAILURES) {

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -14,7 +14,7 @@ import { startScheduler } from './broadcast/scheduler.js';
 import { startListenerMonitor } from './broadcast/listeners.js';
 import { startAudienceMonitor } from './broadcast/audience.js';
 import { cors } from './middleware/cors.js';
-import { assertAdminConfigured } from './middleware/auth.js';
+import { assertAdminConfigured, initAdminCredentials } from './middleware/auth.js';
 import { router as publicRoutes } from './routes/public.js';
 import { router as requestRoutes } from './routes/request.js';
 import { router as settingsRoutes } from './routes/settings.js';
@@ -90,6 +90,14 @@ app.listen(config.server.port, async () => {
     }
   } catch (err: any) {
     console.error('[secrets] load failed:', err.message);
+  }
+
+  // Load or migrate admin credentials (env -> scrypt hash file).
+  // Must run after secrets are loaded but before any admin route can fire.
+  try {
+    await initAdminCredentials();
+  } catch (err: any) {
+    console.error('[admin-credentials] init failed:', err.message);
   }
 
   // Wizard overlay — Navidrome creds the operator typed in. Env wins; this

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -41,6 +41,33 @@ import { getSetupStatus } from './setup/firstRun.js';
 // Fail fast in production if the admin gate isn't configured.
 assertAdminConfigured();
 
+// Source the wizard-managed secrets file (state/secrets.env) into process.env
+// before anything else touches the AI SDK. Real env vars (from compose
+// env_file) always win - secrets.env is the persistence layer for keys the
+// operator typed into the first-run wizard. Must run before the server starts
+// accepting requests so any code that reads process.env at request time sees
+// the merged view.
+try {
+  const { loaded, skipped } = await loadSecretsIntoEnv();
+  if (loaded.length || skipped.length) {
+    console.log(
+      `[secrets] state/secrets.env: loaded=${loaded.length} skipped(env-already-set)=${skipped.length}`,
+    );
+  }
+} catch (err: any) {
+  console.error('[secrets] load failed:', err.message);
+}
+
+// Load or migrate admin credentials (env -> scrypt hash file).
+// Must run after secrets are loaded but BEFORE app.listen() - otherwise there
+// is a boot-time bypass window where requireAdmin sees ADMIN_AUTH_REQUIRED=false
+// and waves admin routes through between socket-bind and init-complete.
+try {
+  await initAdminCredentials();
+} catch (err: any) {
+  console.error('[admin-credentials] init failed:', err.message);
+}
+
 const app = express();
 // Global cap covers small JSON payloads everywhere; the persona-avatar route
 // re-applies its own (slightly larger) cap on top via per-route json middleware.
@@ -76,29 +103,6 @@ app.use(generateRoutes);
 // ---------------------------------------------------------------------------
 app.listen(config.server.port, async () => {
   console.log(`SUB/WAVE controller on :${config.server.port}`);
-
-  // Source the wizard-managed secrets file (state/secrets.env) into process.env
-  // before anything else touches the AI SDK. Real env vars (from compose
-  // env_file) always win — secrets.env is the persistence layer for keys the
-  // operator typed into the first-run wizard.
-  try {
-    const { loaded, skipped } = await loadSecretsIntoEnv();
-    if (loaded.length || skipped.length) {
-      console.log(
-        `[secrets] state/secrets.env: loaded=${loaded.length} skipped(env-already-set)=${skipped.length}`,
-      );
-    }
-  } catch (err: any) {
-    console.error('[secrets] load failed:', err.message);
-  }
-
-  // Load or migrate admin credentials (env -> scrypt hash file).
-  // Must run after secrets are loaded but before any admin route can fire.
-  try {
-    await initAdminCredentials();
-  } catch (err: any) {
-    console.error('[admin-credentials] init failed:', err.message);
-  }
 
   // Wizard overlay — Navidrome creds the operator typed in. Env wins; this
   // only fills in fields that env didn't already provide.


### PR DESCRIPTION
## What

Replace plaintext `ADMIN_PASS` comparison with scrypt-hashed credentials stored in `state/admin-hash.json`. Existing installs auto-migrate on first boot.

## Why

Closes #488 (items 2 and 3).

A leaked `.env` currently exposes usable admin credentials. Hashing removes the plaintext from the runtime auth path.

Scoped to hashing only per maintainer feedback. Change-password UI/endpoint and default-deny guard are separate PRs.

## How tested

* `cd controller && npm run lint` - 0 errors
* `cd cli && npx tsc --noEmit` - clean
* Verified scrypt params (`N=2^17`, `r=8`, `p=1`, `maxmem=256 MiB`) don't throw `ERR_CRYPTO_INVALID_SCRYPT_PARAMS`
* Checked migration path: hash file absent + `ADMIN_PASS` in env triggers hash-and-write, logs warning to remove env var manually
* Checked boot ordering: `initAdminCredentials()` runs before `app.listen()` so admin routes are never exposed during the boot window

## Notes for reviewers

* `maxmem: 256 * 1024 * 1024` is passed explicitly to all `scrypt()` calls (Node's default 32 MiB is too small for `N=2^17`, as you flagged)
* Migration does **not** auto-strip `ADMIN_PASS` from `.env`. It warns the operator to remove it manually. CLI `init` never writes it in the first place.
* `setup.sh` is intentionally unchanged. Pure bash can't hash with scrypt, and the controller auto-migrates on first boot.
* `maxmem` is omitted from on-disk `scryptParams` in `admin-hash.json` because it's a Node runtime cap, not a cost parameter.
* Change-password endpoint/UI and default-deny guard are deferred to follow-up PRs.
