### PR TITLE
fix(app): remove Dimezis BlurView that kills touch input on Android (New Arch)

### DIFF
--- a/app/src/player/PlayerScreen.tsx
+++ b/app/src/player/PlayerScreen.tsx
@@ -14,7 +14,6 @@
 // re-render the pages whose data actually changed (useStationFeed keeps
 // unchanged payloads reference-stable for exactly this reason).
 
-import { BlurView } from 'expo-blur';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as Haptics from 'expo-haptics';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -382,16 +381,21 @@ export default function PlayerScreen() {
 
         {/* Frosted masthead + FM dial — floated as an absolute overlay at the
             head of every band stop so page content scrolls under the glass,
-            mirroring the transport bar. The BlurView picks up the cover-art
-            ambient wash + scrolling content behind it; a thin mode-aware film
-            keeps the wordmark and dial legible. */}
+            mirroring the transport bar. A thin mode-aware film keeps the
+            wordmark and dial legible.
+
+            NB: do NOT put an expo-blur <BlurView> here. On the New Architecture
+            (Fabric) the Dimezis BlurView is a custom *native* view; Fabric routes
+            touches to the new/old-arch event emitter by target-view id parity,
+            and the BlurView's internal Android views get ids that break that
+            resolution ("Cannot find EventEmitter for receivedTouches"), silently
+            dropping every tap on the controls layered over it. It's device/ROM
+            -flaky (dead on some Pixels, fine on others) and pointerEvents="none"
+            does NOT fix it — the hazard is the native view's mere presence, not
+            touch capture. The blur was already inert under expo-blur ≥55 anyway
+            (the bare dimezisBlurView method now needs a BlurTargetView), so this
+            is a touch-only fix with no visual change. See issue #458. */}
         <View style={{ position: 'absolute', top: 0, left: 0, right: 0 }} onLayout={onHeaderLayout}>
-          <BlurView
-            intensity={mode === 'light' ? 40 : 26}
-            tint={mode === 'light' ? 'light' : 'dark'}
-            blurMethod="dimezisBlurView"
-            style={StyleSheet.absoluteFill}
-          />
           <View pointerEvents="none" style={[StyleSheet.absoluteFill, { backgroundColor: glassFilm }]} />
           <TopBar
             tunedIn={tunedIn}

--- a/app/src/player/TransportBar.tsx
+++ b/app/src/player/TransportBar.tsx
@@ -4,7 +4,6 @@
 // grip, and a 0–250 latency ruler), and Volume (rotary knob + dot-grille mute).
 // Docked below the FM-dial pager, so it stays at the foot of every band stop.
 
-import { BlurView } from 'expo-blur';
 import * as Haptics from 'expo-haptics';
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -85,17 +84,20 @@ export default function TransportBar({
 
   return (
     <View style={{ marginHorizontal: 16, marginBottom: insets.bottom + 12 }}>
-      {/* Frosted-glass console: a real backdrop blur picks up the cover-art
-          ambient wash behind the bar, with a thin translucent film over it and
-          a softened glass edge — so the deck reads as transparent glass rather
-          than a flat panel. The controls render on top, unblurred. */}
+      {/* Frosted-glass console: a thin translucent film + softened glass edge so
+          the deck reads as transparent glass rather than a flat panel. The
+          controls render on top.
+
+          NB: do NOT put an expo-blur <BlurView> here. On the New Architecture
+          (Fabric) the Dimezis BlurView is a custom *native* view, and its
+          presence under the controls breaks Fabric's touch-event dispatch
+          ("Cannot find EventEmitter for receivedTouches") — device/ROM-flaky,
+          and the symptom is the whole transport bar going dead to taps on some
+          Pixels while fine on others. pointerEvents="none" does NOT fix it. The
+          blur was already inert under expo-blur ≥55 (the bare dimezisBlurView
+          method now needs a BlurTargetView), so dropping it is a touch-only fix
+          with no visual change. See issue #458. */}
       <View style={{ borderWidth: 1, borderColor: `${colors.ink}59`, overflow: 'hidden' }}>
-        <BlurView
-          intensity={mode === 'light' ? 40 : 26}
-          tint={mode === 'light' ? 'light' : 'dark'}
-          blurMethod="dimezisBlurView"
-          style={StyleSheet.absoluteFill}
-        />
         <View
           pointerEvents="none"
           style={[


### PR DESCRIPTION
## Problem

On the native player, the **entire UI goes dead to touch** — nothing is tappable (tune, volume, station switcher, FM-dial tabs), though the screen renders and now-playing updates. It's **device/ROM-flaky and OS-version-independent**: dead on a Pixel 7 Pro and Pixel 10, fine on a Pixel 8a and a OnePlus Pad 3 — same app build, same Android version, same station. (#458)

PR #490's `pointerEvents="none"` on the BlurViews was shipped as a **native** build and did **not** fix it.

## Root cause

The app forces the **New Architecture (Fabric)**. Fabric resolves whether a touch routes through the new- or old-arch event emitter by the **target view's id parity**. `expo-blur`'s `dimezisBlurView` is a custom **native** Android view whose internal Android-created child views get ids that break that resolution, throwing `Cannot find EventEmitter for receivedTouches` and **silently dropping the tap** (facebook/react-native#47218, RN ≥ 0.75.2 + New Arch). Whether it fires depends on which ids get allocated → device/ROM-flaky.

`pointerEvents="none"` can't fix it: the bug is event **routing**, not touch **capture** — the hazard is the native view's mere presence in the tree.

The two BlurViews were `absoluteFill` behind the **masthead** (station switcher + FM dial) and the **transport bar** (tune + volume) — i.e. *every* primary control — so the whole surface went dead.

## Fix

Remove both `BlurView`s; keep the existing translucent glass film. Since `expo-blur` ≥ 55 the bare `blurMethod="dimezisBlurView"` (no `BlurTargetView`) renders **no blur at all** (expo/expo#44165), so the frost has already been inert since the SDK 56 upgrade — **this is a touch-only fix with no visual change** from what's shipped. An in-code `NB` comment documents why a `BlurView` must not go back here.

## Verify

`tsc`/lint locally not run (Expo app has no `node_modules` on the build host); change is JS-only, deletes two JSX elements + one now-unused import per file (`StyleSheet`/`mode` still used). Confirm on an affected device via logcat while tapping a dead control:

```
adb logcat | grep -iE "receivedTouches|EventEmitter|SoftException"
```

`Cannot find EventEmitter for receivedTouches` on the current build = root cause confirmed; gone after this build = fixed.

Fixes #458. Supersedes #490.
