### PR TITLE
feat(personas): redesign editor — rotary tone dials, LED voice meter, full-width roster

### DIFF
--- a/docs/superpowers/specs/2026-06-22-personas-panel-refactor-design.md
+++ b/docs/superpowers/specs/2026-06-22-personas-panel-refactor-design.md
@@ -1,0 +1,113 @@
+# Personas panel — component split + roster/full-width redesign
+
+**Date:** 2026-06-22
+**Scope:** `web/components/admin/PersonasPanel.tsx` (admin `/admin/personas`)
+
+## Problem
+
+`PersonasPanel.tsx` has grown to ~1700 lines doing everything: data fetch, state,
+validation, avatar mutations, and the full hero/roster/editor UI. It is hard to
+read and edit. The layout also wastes space: the roster sits in a fixed `280px`
+left column and the editor is squeezed into the remaining `1fr`, so on wide
+screens cards (notably **Voice**) have a large empty right half while their
+content stays in a narrow left strip.
+
+## Goals
+
+1. Split the file into focused, presentational sub-components under a new
+   `web/components/admin/personas/` directory.
+2. Move the roster from the left column to a **full-width selectable card strip**
+   below the hero.
+3. Make the editor (forms) **full width**.
+4. Lay full-width cards out in responsive columns so the horizontal space is
+   used — removing the empty-space problem, including in the Voice card.
+
+## Non-goals
+
+- **No behaviour/data change.** Same `Persona` shape, same `/settings` save
+  payload, same validation rules, same avatar endpoints, same skills logic, same
+  hero copy and system-prompt behaviour.
+- No change to the admin route or its import (`PersonasPanel` default export at
+  the current path stays the public entry point).
+- Keep all accessibility already built (ToneKnob/VoiceMeter `role="slider"` +
+  keyboard, roster items as `<button>`s).
+- No unrelated refactoring beyond what serves this split.
+
+## New layout (top to bottom, full width)
+
+1. **Hero** — eyebrow · "The voices on your station." · `[System prompt]`
+   `[+ Add persona]`; plus the live/active strip. *(unchanged content)*
+2. **System prompt card** — toggled from the hero. *(unchanged)*
+3. **Roster** — full-width band: `roster · N / 12` heading, then a responsive
+   grid of persona cards that wraps as personas are added
+   (`grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5`). Each card:
+   avatar/initials, name, tagline, badges (frequency, `extended`, engine, voice,
+   skill count, `incomplete`). The card being edited gets the vermilion
+   border+outline; the on-air persona shows the dot + `on air` pill. A dashed
+   `+ new persona` card is the last cell. Click selects → editor updates and
+   scrolls into view.
+4. **Editor** — full-width, for the focused persona. Header `Editing · <name>`
+   with `Set on air` / `Remove`. Composed of the cards below + the save bar.
+
+## Full-width card layouts (fill width, stay readable)
+
+The editor is genuinely full width (no hard max-width). Cards use responsive
+2-column splits so content fills the space; individual controls keep sensible
+caps so ultra-wide monitors still look intentional.
+
+- **Identity card** — `lg:grid-cols-2`: left = avatar + name + tagline +
+  language; right = soul textarea (taller). AiFill spans the top.
+- **Behaviour card** — `lg:grid-cols-2`: left = talk frequency + script length +
+  DJ mode; right = tone dials (3 knobs). Knobs already responsive (80px phone /
+  96px `md`+, stacked label on phone).
+- **Voice card** — `lg:grid-cols-2`: left = engine `Seg` + the engine-specific
+  voice selector (+ availability warnings); right = the voice-level meter. This
+  is the empty-space fix, generalised. The `Seg` `w-fit` fix (tabs hug content,
+  no dead bordered cell) stays.
+- **Skills card** — full-width list rows (already fills the width).
+- Long hint/description paragraphs get `max-w-[70ch]`; selects `max-w-[360px]`;
+  the dB meter `max-w-[460px]` within its column.
+
+## Component structure
+
+New directory `web/components/admin/personas/`:
+
+| File | Responsibility |
+|---|---|
+| `types.ts` | `Persona`, `PersonaTts`, `FormState`, `SettingsResponse`, `SkillCatalogEntry`, `VoiceOption` |
+| `constants.ts` | `FREQUENCIES`, `SCRIPT_LENGTHS`, `TONE_DIALS`, `DIAL_NEUTRAL`, `toneBandIndex`, `ENGINES`, `KNOB_ROTATIONS`, `VOICE_CELLS`, regexes, `CB_DEFAULT_VOICE`, `*_MAX`, `PERSONA_MAX`, `AVATAR_TARGET_PX`, `DICEBEAR_STYLES`, `API_BASE` |
+| `helpers.ts` | `clientMintId`, `initialsFor`, `fetchDicebearAvatar`, `fileToAvatarDataUrl`, `personaValid`, `voiceForSave`, `cloudIssue` |
+| `ToneKnob.tsx` | rotary knob (moved as-is) |
+| `VoiceMeter.tsx` | LED meter (moved as-is) |
+| `RadioOption.tsx` | shared radio option (moved as-is) |
+| `PersonaAvatarPicker.tsx` | avatar picker (moved as-is) |
+| `PersonaHero.tsx` | hero + active strip |
+| `SystemPromptCard.tsx` | system-prompt editor card |
+| `PersonaRoster.tsx` | full-width selectable card strip (incl. the card) |
+| `PersonaIdentityCard.tsx` | AiFill + avatar + name + tagline + soul + language |
+| `PersonaBehaviorCard.tsx` | frequency + script length + DJ mode + tone dials |
+| `PersonaVoiceCard.tsx` | engine + voice selector + voice level |
+| `PersonaSkillsCard.tsx` | skills toggles |
+| `PersonaEditor.tsx` | composes the four editor cards + save bar |
+| `PersonasPanel.tsx` *(existing path)* | **container**: state, `/settings` fetch, validation, save, avatar mutations; renders hero + roster + editor |
+
+## State ownership
+
+`PersonasPanel` remains the single stateful container. It owns `form`,
+`focusIdx`, `busy`, `avatarTick`, `uploadingId`, `showPrompt`, all mutators
+(`setPersona`, `setPersonaTts`, `setPersonaSkills`, add/remove), avatar handlers,
+and validation (`canSave`, `personaValid`). Every sub-component is presentational
+— props in, callbacks out — so each can be read and reasoned about on its own.
+
+## Verification
+
+- `npm run lint` (eslint + `tsc --noEmit`) green — the merge gate.
+- Visual check on the running dev stack: roster wraps and selects; editor is
+  full-width; Voice card has no empty right half; knobs 80px on phone / 96px
+  desktop; no horizontal overflow at 390px.
+
+## Risks
+
+- Largest risk is regressions while moving ~1700 lines. Mitigation: move logic
+  verbatim, keep the data/validation/save paths byte-for-byte, lint + visual
+  check after each card is extracted.

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -6,353 +6,22 @@
 // frequency, soul, and full voice (TTS engine + cloud provider + voice).
 // The system prompt is one global template shared by every persona.
 // Everything POSTs to /settings and applies live — no mixer restart.
-import type { ChangeEvent, ReactNode } from 'react';
+//
+// This file is the stateful container: it owns the form, validation, save, and
+// avatar mutations, and composes the presentational pieces in ./personas/*.
 import { useEffect, useRef, useState } from 'react';
 import { useAdminAuth } from '../../lib/adminAuth';
-import { CLOUD_VOICES } from '../../lib/cloudVoices';
 import { notify, errorMessage } from '../../lib/notify';
-import { Input } from '../ui/input';
-import { Textarea } from '../ui/textarea';
-import { Label } from '../ui/label';
+import { Card } from './ui';
+import type { Persona, PersonaTts, FormState, SettingsResponse } from './personas/types';
+import { DIAL_NEUTRAL, PERSONA_MAX, PROMPT_MIN, PROMPT_MAX } from './personas/constants';
 import {
-  Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel,
-} from '../ui/select';
-import { Card, Btn, Pill, Eyebrow, Seg, Toggle } from './ui';
-import { AiFill } from './AiFill';
-import { cn } from '../../lib/cn';
-
-const FREQUENCIES = [
-  { id: 'quiet',      label: 'Quiet',      desc: 'Talks every 8–20 tracks · station ID once an hour · weather hourly on change.' },
-  { id: 'moderate',   label: 'Moderate',   desc: 'Talks every 1–9 tracks · station IDs at :15 and :45 · weather every 30 min on change.' },
-  { id: 'aggressive', label: 'Aggressive', desc: 'Talks every 1–3 tracks · station IDs four times an hour · weather every 15 min on change.' },
-];
-const SCRIPT_LENGTHS = [
-  { id: 'concise',  label: 'Concise',  desc: 'Standard one-to-four sentence segments. The default.' },
-  { id: 'extended', label: 'Extended', desc: 'Longer, storytelling segments — roughly double the length across intros, links, weather and idents.' },
-];
-// Personality dials, 0–10, default 5. They map to three prompt bands server-side
-// (settings.personaToneDirectives): 0–3 low, 7–10 high, 4–6 neutral (nothing
-// injected). Surfacing the band keeps operators from expecting 6 vs 7 to differ.
-const TONE_DIALS = [
-  { id: 'humour',      label: 'Humour',       low: 'play it straight', high: 'playful & dry'  },
-  { id: 'localColour', label: 'Local colour', low: 'universal',        high: 'leans local'    },
-  { id: 'warmth',      label: 'Warmth',       low: 'cool & dry',       high: 'warm & earnest' },
-] as const;
-const DIAL_NEUTRAL = 5;
-const toneBand = (v: number) => (v <= 3 ? 'low' : v >= 7 ? 'high' : 'neutral');
-const ENGINES = [
-  { id: 'piper',  label: 'Piper' },
-  { id: 'kokoro', label: 'Kokoro' },
-  { id: 'chatterbox', label: 'Chatterbox' },
-  { id: 'pocket-tts', label: 'PocketTTS' },
-  { id: 'cloud',  label: 'Cloud' },
-];
-// Chatterbox reference voice files are validated against this in audio/chatterbox.ts
-// — basename only, no path separators, .wav extension, conservative chars.
-const CHATTERBOX_VOICE_RE = /^[A-Za-z0-9_.-]{1,80}\.wav$/;
-// Sentinel for the empty-string "use the built-in voice" choice — Radix Select
-// rejects an empty-string SelectItem value.
-const CB_DEFAULT_VOICE = '__cb_default__';
-// PocketTTS voice ids — lowercase, allow underscores/hyphens (matches the
-// settings-side POCKET_TTS_VOICE_RE).
-const POCKET_TTS_VOICE_RE = /^[a-z][a-z0-9_-]{0,39}$/;
-const NAME_MAX = 40;
-const TAGLINE_MAX = 80;
-const SOUL_MAX = 400;
-const LANGUAGE_MAX = 60;
-const PROMPT_MIN = 50;
-const PROMPT_MAX = 4000;
-const PERSONA_MAX = 12;
-const KOKORO_RE = /^[a-z]{2}_[a-z0-9]+$/;
-
-interface PersonaTts {
-  engine: 'piper' | 'kokoro' | 'chatterbox' | 'pocket-tts' | 'cloud' | string;
-  cloudProvider: string;
-  voice: string;
-  // Per-persona voice-level trim in dB (−12..+12, default 0 = no change). Stacks
-  // on top of the per-engine gain. See controller settings.ts:clampTtsGain.
-  gainDb: number;
-}
-
-interface Persona {
-  id: string;
-  name: string;
-  tagline: string;
-  frequency: string;
-  scriptLength: string;
-  // When true the persona behaves like a working DJ — back-announces AND teases
-  // what's next, runs callbacks across the session, and is more present. Off =
-  // the historical tasteful-narrator behaviour.
-  djMode: boolean;
-  // Tone dials, 0–10, default 5 (neutral). Map to prompt bands server-side.
-  humour: number;
-  localColour: number;
-  warmth: number;
-  soul: string;
-  // Free-text on-air language ("Turkish", "Türkçe"). Empty = English (no
-  // directive injected server-side).
-  language: string;
-  // Stored basename like `p_abc123.png` — empty when no avatar is uploaded.
-  // The actual image is served via /api/persona-avatar/<id>; we keep the
-  // basename in state only so the form round-trips it on save.
-  avatar: string;
-  tts: PersonaTts;
-  skills: string[];
-}
-
-interface FormState {
-  personas: Persona[];
-  activePersonaId: string;
-  useCustomPrompt: boolean;
-  systemPrompt: string;
-}
-
-interface SkillCatalogEntry {
-  name: string;
-  label?: string;
-  description?: string;
-}
-
-interface VoiceOption {
-  id: string;
-  label: string;
-}
-
-interface SettingsResponse {
-  values?: {
-    personas?: Array<Partial<Persona> & { avatar?: string }>;
-    activePersonaId?: string;
-    djPrompt?: string;
-    tts?: { defaultEngine?: string };
-  };
-  defaults?: { djPrompt?: string };
-  skills?: { catalog?: SkillCatalogEntry[] };
-  tts?: {
-    kokoroVoices?: VoiceOption[];
-    piperVoices?: string[];
-    chatterboxVoices?: string[];
-    // `voiceDir` is the new shared name (issue #213). `chatterboxVoiceDir` is
-    // kept as an alias so the UI keeps working against older controllers.
-    voiceDir?: string;
-    chatterboxVoiceDir?: string;
-    pocketTtsVoices?: VoiceOption[];
-    pocketTtsCustomVoices?: string[];
-    available?: Record<string, boolean>;
-    cloudProviders?: string[];
-  };
-  env?: Record<string, unknown>;
-}
-
-
-function clientMintId() {
-  const b = crypto.getRandomValues(new Uint8Array(3));
-  return 'p_' + [...b].map(x => x.toString(16).padStart(2, '0')).join('');
-}
-
-// 512×512 output target. The controller hard-caps the decoded image at 300 KB
-// and the JSON body at 600 KB; a center-cropped 512×512 WebP from a typical
-// phone photo lands in the tens of KB, well under both.
-const AVATAR_TARGET_PX = 512;
-
-// DiceBear styles to roll through when the operator clicks Generate. Each
-// click picks one at random along with a fresh random seed, so re-clicking
-// produces a different face. Lorelei / notionists / personas / open-peeps are
-// illustrated humans; bottts-neutral / micah / fun-emoji add a robot/abstract
-// option so the operator can keep clicking until they land on a vibe that
-// fits the persona. All return PNG at the size we ask for, with permissive
-// CORS — the fetch can run in the browser.
-const DICEBEAR_STYLES = [
-  'lorelei', 'notionists', 'personas', 'open-peeps',
-  'micah', 'bottts-neutral', 'fun-emoji',
-];
-
-async function fetchDicebearAvatar(): Promise<string> {
-  const style = DICEBEAR_STYLES[Math.floor(Math.random() * DICEBEAR_STYLES.length)];
-  // Random seed so two clicks never produce the same face.
-  const seed = Math.random().toString(36).slice(2) + Date.now().toString(36);
-  const url = `https://api.dicebear.com/9.x/${style}/png?seed=${encodeURIComponent(seed)}&size=${AVATAR_TARGET_PX}`;
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`DiceBear fetch failed (${res.status})`);
-  const blob = await res.blob();
-  return await new Promise<string>((resolve, reject) => {
-    const r = new FileReader();
-    r.onload = () => resolve(r.result as string);
-    r.onerror = () => reject(r.error || new Error('failed to read DiceBear PNG'));
-    r.readAsDataURL(blob);
-  });
-}
-
-// Resize + center-crop the operator-picked image to a square, returned as a
-// compressed (WebP, JPEG fallback) data URL ready for POSTing. Done entirely
-// client-side so we never need a server-side image library.
-async function fileToAvatarDataUrl(file: File): Promise<string> {
-  if (!/^image\/(png|jpe?g|webp)$/.test(file.type)) {
-    throw new Error('please pick a PNG, JPEG, or WebP image');
-  }
-  if (file.size > 12 * 1024 * 1024) {
-    throw new Error('image is over 12 MB — pick something smaller');
-  }
-  const bitmap = await createImageBitmap(file);
-  try {
-    const side = Math.min(bitmap.width, bitmap.height);
-    const sx = (bitmap.width - side) / 2;
-    const sy = (bitmap.height - side) / 2;
-    const canvas = document.createElement('canvas');
-    canvas.width = AVATAR_TARGET_PX;
-    canvas.height = AVATAR_TARGET_PX;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) throw new Error('canvas 2d context unavailable');
-    ctx.imageSmoothingEnabled = true;
-    ctx.imageSmoothingQuality = 'high';
-    ctx.drawImage(bitmap, sx, sy, side, side, 0, 0, AVATAR_TARGET_PX, AVATAR_TARGET_PX);
-    // Compressed export — an uncompressed 512×512 PNG is ~1 MB raw / ~1.33 MB
-    // base64, which blows past the controller's 600 KB JSON cap, so only tiny
-    // source images used to get through. WebP keeps a typical avatar in the
-    // tens-of-KB range and preserves transparency; JPEG is the universal
-    // fallback for the rare browser whose canvas can't emit WebP (it silently
-    // returns a data:image/png URL in that case).
-    const webp = canvas.toDataURL('image/webp', 0.85);
-    return webp.startsWith('data:image/webp')
-      ? webp
-      : canvas.toDataURL('image/jpeg', 0.85);
-  } finally {
-    bitmap.close?.();
-  }
-}
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || '/api';
-
-function initialsFor(name: string): string {
-  const parts = name.trim().split(/\s+/).filter(Boolean);
-  if (!parts.length) return '?';
-  const first = parts[0] ?? '';
-  if (parts.length === 1) return first.slice(0, 2).toUpperCase();
-  const last = parts[parts.length - 1] ?? '';
-  return ((first[0] ?? '') + (last[0] ?? '')).toUpperCase() || '?';
-}
-
-function PersonaAvatarPicker(props: {
-  persona: Persona;
-  tick: number;
-  uploading: boolean;
-  onPick: (file: File) => void;
-  onGenerate: () => void;
-  onClear: () => void;
-}) {
-  const { persona, tick, uploading, onPick, onGenerate, onClear } = props;
-  const inputRef = useRef<HTMLInputElement | null>(null);
-  // The public endpoint serves a 1×1 transparent placeholder when no avatar
-  // is set; rather than render that as a tiny grey square, fall back to
-  // initials in the admin UI. The ?v=… buster forces a refetch after upload.
-  const hasAvatar = !!persona.avatar;
-  const src = hasAvatar
-    ? `${API_BASE}/persona-avatar/${encodeURIComponent(persona.id)}?v=${tick}`
-    : null;
-  return (
-    <div className="grid gap-2">
-      <Label>Avatar</Label>
-      <div
-        className="grid h-[96px] w-[96px] place-items-center overflow-hidden border border-ink bg-[var(--ink-softer)]"
-        aria-label={hasAvatar ? `${persona.name} avatar` : 'No avatar set'}
-      >
-        {src ? (
-          <img
-            src={src}
-            alt=""
-            width={96}
-            height={96}
-            className="h-full w-full object-cover"
-          />
-        ) : (
-          <span className="text-[22px] font-extrabold tracking-[-0.02em] text-muted">
-            {initialsFor(persona.name)}
-          </span>
-        )}
-      </div>
-      <input
-        ref={inputRef}
-        type="file"
-        accept="image/png,image/jpeg,image/webp"
-        className="hidden"
-        onChange={e => {
-          const file = e.target.files?.[0];
-          if (file) onPick(file);
-          // Reset so picking the same file twice still fires onChange.
-          e.target.value = '';
-        }}
-      />
-      <div className="grid w-[96px] gap-1.5">
-        <Btn sm className="w-full justify-center" onClick={() => inputRef.current?.click()} disabled={uploading}>
-          {uploading ? '…' : hasAvatar ? 'Replace' : 'Upload'}
-        </Btn>
-        <Btn sm className="w-full justify-center" onClick={onGenerate} disabled={uploading} title="Random DiceBear avatar — click again for a different one">
-          Generate
-        </Btn>
-        {hasAvatar && (
-          <Btn sm tone="danger" className="w-full justify-center" onClick={onClear} disabled={uploading}>
-            Remove
-          </Btn>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function personaValid(p: Persona): boolean {
-  if (p.name.trim().length < 1 || p.name.trim().length > NAME_MAX) return false;
-  if (p.tagline.trim().length > TAGLINE_MAX) return false;
-  if (p.soul.trim().length < 1 || p.soul.trim().length > SOUL_MAX) return false;
-  if (p.language.trim().length > LANGUAGE_MAX) return false;
-  const e = p.tts.engine;
-  if (e === 'kokoro') return KOKORO_RE.test(p.tts.voice.trim());
-  if (e === 'chatterbox') {
-    // Empty = use built-in default voice; otherwise must be a plain .wav filename.
-    const v = p.tts.voice.trim();
-    return v === '' || CHATTERBOX_VOICE_RE.test(v);
-  }
-  if (e === 'pocket-tts') {
-    // Built-in voice id, OR a .wav filename for zero-shot cloning (issue #213),
-    // OR empty for the default — matches the server-side validator in settings.ts.
-    const v = p.tts.voice.trim();
-    return v === '' || POCKET_TTS_VOICE_RE.test(v) || CHATTERBOX_VOICE_RE.test(v);
-  }
-  if (e === 'cloud') {
-    const v = p.tts.voice.trim();
-    return v.length >= 1 && v.length <= 100;
-  }
-  return true; // piper — voice ignored
-}
-
-// Coerce a persona's `voice` to a value the target engine's server-side
-// validator will accept. The `voice` field is shared across engines, so
-// switching engines can leave an incompatible value behind (e.g. a Kokoro id
-// after switching to Chatterbox). This is the last line of defence before the
-// POST — it runs regardless of UI state, so a stale form can't ship a bad save.
-function voiceForSave(engine: string, voice: string): string {
-  if (engine === 'kokoro') return voice || 'bf_isabella';
-  if (engine === 'chatterbox') return CHATTERBOX_VOICE_RE.test(voice) ? voice : '';
-  // Built-in id or a .wav clone filename both pass through; anything else → default.
-  if (engine === 'pocket-tts') return (POCKET_TTS_VOICE_RE.test(voice) || CHATTERBOX_VOICE_RE.test(voice)) ? voice : 'alba';
-  return voice; // piper ignores voice; cloud carries its own
-}
-
-// For a cloud persona: why (if at all) its cloud voice won't actually play —
-// its provider's API key is missing. Returns a human sentence, or null when
-// the cloud voice is good to go. A persona can look fully configured here yet
-// still fall back silently; this surfaces that gap before it airs.
-function cloudIssue(persona: Persona | undefined, data: SettingsResponse | null): string | null {
-  if (persona?.tts?.engine !== 'cloud') return null;
-  // openai-compatible has no env-key convention — the persona's baseUrl +
-  // model live globally on settings.tts.cloud and are validated there. Trust
-  // that the server is configured if the persona picked this provider.
-  if (persona.tts.cloudProvider === 'openai-compatible') return null;
-  const envKey = persona.tts.cloudProvider === 'elevenlabs'
-    ? 'ELEVENLABS_API_KEY' : 'OPENAI_API_KEY';
-  if (data?.env && !data.env[envKey]) {
-    return `${envKey} is not set in .env.`;
-  }
-  return null;
-}
+  clientMintId, fetchDicebearAvatar, fileToAvatarDataUrl, personaValid, voiceForSave, cloudIssue,
+} from './personas/helpers';
+import { PersonaHero } from './personas/PersonaHero';
+import { SystemPromptCard } from './personas/SystemPromptCard';
+import { PersonaRoster } from './personas/PersonaRoster';
+import { PersonaEditor } from './personas/PersonaEditor';
 
 export default function PersonasPanel() {
   const { adminFetch, needsAuth, hydrated } = useAdminAuth();
@@ -360,7 +29,7 @@ export default function PersonasPanel() {
   const [form, setForm] = useState<FormState | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  // index of the persona being edited in the right pane
+  // index of the persona being edited
   const [focusIdx, setFocusIdx] = useState(0);
   // toggles the system-prompt editor card
   const [showPrompt, setShowPrompt] = useState(false);
@@ -371,9 +40,9 @@ export default function PersonasPanel() {
   // Per-persona "uploading" flag — drives the spinner / disables the buttons
   // while the request is in flight.
   const [uploadingId, setUploadingId] = useState<string | null>(null);
-  // The editor column. After adding a persona we scroll it into view so the
-  // operator actually sees the new persona open for editing — on mobile the
-  // editor stacks below the long roster and would otherwise be off-screen.
+  // The editor block. After adding a persona we scroll it into view so the
+  // operator actually sees the new persona open for editing — it stacks below
+  // the roster and would otherwise be off-screen.
   const editorRef = useRef<HTMLDivElement | null>(null);
   // Set true by addPersona so the focus-change effect knows to scroll. A plain
   // roster click changes focus too, but shouldn't yank the page around.
@@ -481,7 +150,7 @@ export default function PersonasPanel() {
     });
     // Open the new persona in the editor (+ scroll it into view) and confirm
     // with a toast — otherwise the add is silent and the operator never notices
-    // the entry tucked at the bottom of the roster.
+    // the entry tucked at the end of the roster.
     scrollToEditorRef.current = true;
     setFocusIdx(newIdx);
     notify.ok('New persona added — fill in its details, then Save persona.');
@@ -514,14 +183,7 @@ export default function PersonasPanel() {
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
       const filename = j.avatar || '';
       setForm(f =>
-        f
-          ? {
-              ...f,
-              personas: f.personas.map(p =>
-                p.id === personaId ? { ...p, avatar: filename } : p,
-              ),
-            }
-          : f,
+        f ? { ...f, personas: f.personas.map(p => (p.id === personaId ? { ...p, avatar: filename } : p)) } : f,
       );
       setAvatarTick(t => t + 1);
       notify.ok('avatar uploaded');
@@ -545,14 +207,7 @@ export default function PersonasPanel() {
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
       const filename = j.avatar || '';
       setForm(f =>
-        f
-          ? {
-              ...f,
-              personas: f.personas.map(p =>
-                p.id === personaId ? { ...p, avatar: filename } : p,
-              ),
-            }
-          : f,
+        f ? { ...f, personas: f.personas.map(p => (p.id === personaId ? { ...p, avatar: filename } : p)) } : f,
       );
       setAvatarTick(t => t + 1);
       notify.ok('avatar generated');
@@ -572,14 +227,7 @@ export default function PersonasPanel() {
       const j = (await r.json().catch(() => ({}))) as { error?: string };
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
       setForm(f =>
-        f
-          ? {
-              ...f,
-              personas: f.personas.map(p =>
-                p.id === personaId ? { ...p, avatar: '' } : p,
-              ),
-            }
-          : f,
+        f ? { ...f, personas: f.personas.map(p => (p.id === personaId ? { ...p, avatar: '' } : p)) } : f,
       );
       setAvatarTick(t => t + 1);
       notify.ok('avatar removed');
@@ -626,10 +274,6 @@ export default function PersonasPanel() {
               // shared across engines, so a leftover value from a previous
               // engine (e.g. a Kokoro id "bm_george" still in state after
               // switching to Chatterbox) would fail the server's validator.
-              // Coerce per-engine here so the save can't ship a bad value:
-              //   kokoro     — needs a non-empty id; fall back to bf_isabella
-              //   chatterbox — must be a .wav filename or empty (built-in)
-              //   piper/cloud — passed through as-is
               voice: voiceForSave(p.tts.engine, p.tts.voice.trim()),
               // Per-persona voice-level trim (dB). Server clamps to ±12.
               gainDb: p.tts.gainDb ?? 0,
@@ -648,11 +292,6 @@ export default function PersonasPanel() {
       notify.err(errorMessage(e));
     } finally { setBusy(false); }
   };
-
-  const kokoroVoices = data?.tts?.kokoroVoices || [];
-  const pocketTtsVoices = data?.tts?.pocketTtsVoices || [];
-  const cloudProviders = data?.tts?.cloudProviders || ['openai', 'elevenlabs'];
-  const skillCatalog = data?.skills?.catalog || [];
 
   if (err) {
     return (
@@ -685,814 +324,78 @@ export default function PersonasPanel() {
       </div>
     );
   }
+
   const activePersona = form.personas.find(p => p.id === form.activePersonaId);
-  const focusedSoulLen = focused.soul.trim().length;
-  const focusedSoulOver = focusedSoulLen > SOUL_MAX;
   const focusedOk = personaValid(focused);
   const focusedCloudIssue = cloudIssue(focused, data);
   const activeCloudIssue = activePersona ? cloudIssue(activePersona, data) : null;
   const defaultEngine = data?.values?.tts?.defaultEngine || 'piper';
-
-  const engineLabel = (p: Persona) => {
-    if (p.tts.engine === 'kokoro') return `kokoro / ${p.tts.voice.trim() || '—'}`;
-    if (p.tts.engine === 'chatterbox') return `chatterbox / ${p.tts.voice.trim() || 'built-in'}`;
-    if (p.tts.engine === 'pocket-tts') return `pocket-tts / ${p.tts.voice.trim() || 'alba'}`;
-    if (p.tts.engine === 'cloud') return `cloud / ${p.tts.cloudProvider} / ${p.tts.voice.trim() || '—'}`;
-    return `piper / ${p.tts.voice.trim() || 'built-in'}`;
-  };
+  const skillCatalog = data?.skills?.catalog || [];
 
   return (
     <div className="grid gap-4">
-      {/* ── HERO ─────────────────────────────────────────────────────────── */}
-      <section className="card">
-        <div className="stack-mobile grid grid-cols-[1fr_auto] items-center gap-4 border-b border-ink p-4">
-          <div>
-            <Eyebrow className="text-vermilion">personas</Eyebrow>
-            <div className="mt-1.5 text-[22px] font-extrabold tracking-[-0.02em]">
-              The voices on your station.
-            </div>
-            <div className="mt-1 text-[11px] leading-[1.6] text-muted">
-              One persona is on air at a time. A scheduled show can hand the hour to a different one.
-              Every change applies live; no mixer restart.
-            </div>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <Btn onClick={() => setShowPrompt(s => !s)}>
-              {showPrompt ? 'Hide system prompt' : 'System prompt'}
-            </Btn>
-            <Btn tone="accent" onClick={addPersona} disabled={form.personas.length >= PERSONA_MAX}>
-              + Add persona
-            </Btn>
-          </div>
-        </div>
+      <PersonaHero
+        activePersona={activePersona}
+        defaultEngine={defaultEngine}
+        activeCloudIssue={activeCloudIssue}
+        personaCount={form.personas.length}
+        showPrompt={showPrompt}
+        onTogglePrompt={() => setShowPrompt(s => !s)}
+        onAdd={addPersona}
+      />
 
-        {/* Active strip */}
-        <div className="flex flex-wrap items-center gap-3 bg-[var(--ink-softer)] p-3.5">
-          <span className="caption text-vermilion">● live</span>
-          <span className="text-[13px] font-bold">
-            {activePersona ? (activePersona.name.trim() || 'Persona') : '—'}
-          </span>
-          {activePersona?.tagline.trim() && (
-            <span className="text-[11px] text-muted">— {activePersona.tagline.trim()}</span>
-          )}
-          <span className="caption ml-4">
-            frequency · {activePersona ? activePersona.frequency : '—'}
-          </span>
-          <span className="caption">voice · {activePersona ? engineLabel(activePersona) : '—'}</span>
-          {activeCloudIssue && (
-            <span className="caption text-[var(--danger)]">
-              ⚠ cloud voice inactive — speaking via {defaultEngine}
-            </span>
-          )}
-          <span className="caption">override · — (a scheduled show may reassign the hour)</span>
-        </div>
-      </section>
-
-      {/* ── SYSTEM PROMPT (folded-in feature, toggled from hero) ─────────── */}
       {showPrompt && (
-        <Card title="System prompt" sub="shared by every persona">
-          <p className="mb-2.5 text-[12px] leading-[1.6] text-muted">
-            One template wrapped around every DJ generation, shared by all personas.
-            Placeholders: <code>{'{name}'}</code> · <code>{'{soul}'}</code> ·{' '}
-            <code>{'{station}'}</code> · <code>{'{location}'}</code> · <code>{'{language}'}</code>.
-            Most stations never touch this.
-          </p>
-          <Seg
-            value={form.useCustomPrompt ? 'custom' : 'default'}
-            options={[{ id: 'default', label: 'Built-in default' }, { id: 'custom', label: 'Custom' }]}
-            onChange={v => setForm(f => f ? ({ ...f, useCustomPrompt: v === 'custom' }) : f)}
-          />
-          {!form.useCustomPrompt ? (
-            <div className="mt-3">
-              <div className="caption mb-1.5">the DJ uses this built-in template</div>
-              <pre className="term max-h-[220px]">
-                {data?.defaults?.djPrompt || '(default unavailable)'}
-              </pre>
-            </div>
-          ) : (
-            <div className="mt-3">
-              <Textarea
-                rows={12}
-                value={form.systemPrompt}
-                maxLength={PROMPT_MAX}
-                onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
-                  setForm(f => f ? ({ ...f, systemPrompt: e.target.value }) : f)
-                }
-                className={cn(
-                  'font-mono text-[12px]',
-                  promptOk ? 'border-ink' : 'border-[var(--danger)]',
-                )}
-              />
-              <div className="mt-2.5 flex flex-wrap items-center gap-3">
-                <Btn
-                  onClick={() => setForm(f => f ? ({ ...f, systemPrompt: data?.defaults?.djPrompt || '' }) : f)}
-                  disabled={busy || !data?.defaults?.djPrompt}
-                >
-                  Restore default text
-                </Btn>
-                <span className={cn('caption', promptOk ? 'text-muted' : 'text-[var(--danger)]')}>
-                  {promptText.length}/{PROMPT_MAX} chars
-                  {!promptText.includes('{name}') && ' · missing {name}'}
-                  {promptText.length > 0 && promptText.length < PROMPT_MIN && ` · min ${PROMPT_MIN}`}
-                </span>
-              </div>
-            </div>
-          )}
-        </Card>
-      )}
-
-      {/* ── 2-COL ───────────────────────────────────────────────────────── */}
-      <div className="stack-mobile grid grid-cols-[280px_1fr] items-start gap-4">
-        {/* ROSTER */}
-        <div className="grid gap-2.5">
-          <span className="caption">roster · {form.personas.length} / {PERSONA_MAX}</span>
-          {form.personas.map((p, i) => {
-            const isActive = p.id === form.activePersonaId;
-            const isFocused = i === safeIdx;
-            const valid = personaValid(p);
-            return (
-              <button
-                key={p.id}
-                type="button"
-                onClick={() => setFocusIdx(i)}
-                className={cn(
-                  'grid cursor-pointer gap-1.5 border p-3 text-left font-[inherit]',
-                  isFocused
-                    ? 'border-[var(--accent)] bg-[var(--card-bg)] outline-2 -outline-offset-4 outline-[var(--accent-soft)]'
-                    : 'border-ink bg-transparent',
-                )}
-              >
-                <div className="flex items-center gap-1.5">
-                  {isActive && <span className="size-1.5 rounded-full bg-[var(--accent)]" />}
-                  <span className="text-[14px] font-extrabold tracking-[-0.01em] text-ink">
-                    {p.name.trim() || `Persona ${i + 1}`}
-                  </span>
-                  {isActive && (
-                    <Pill tone="accent" className="ml-auto text-[8px]">on air</Pill>
-                  )}
-                </div>
-                <div className="text-[11px] text-muted">
-                  {p.tagline.trim() || 'no tagline'}
-                </div>
-                <div className="mt-1 flex flex-wrap gap-1.5">
-                  <Pill className="text-[8px]">{p.frequency}</Pill>
-                  {p.scriptLength === 'extended' && <Pill className="text-[8px]">extended</Pill>}
-                  <Pill className="text-[8px]">{p.tts.engine}</Pill>
-                  {p.tts.engine !== 'piper' && p.tts.voice.trim() && (
-                    <Pill className="text-[8px]">{p.tts.voice.trim()}</Pill>
-                  )}
-                  <Pill className="text-[8px]">
-                    {p.skills.length} skill{p.skills.length === 1 ? '' : 's'}
-                  </Pill>
-                  {!valid && (
-                    <Pill className="border-[var(--danger)] text-[8px] text-[var(--danger)]">incomplete</Pill>
-                  )}
-                </div>
-              </button>
-            );
-          })}
-          <button
-            type="button"
-            onClick={addPersona}
-            disabled={form.personas.length >= PERSONA_MAX}
-            className={cn(
-              'border border-dashed border-muted bg-transparent p-3 font-[inherit] text-[11px] font-bold tracking-[0.18em] text-muted uppercase',
-              form.personas.length >= PERSONA_MAX
-                ? 'cursor-not-allowed opacity-40'
-                : 'cursor-pointer',
-            )}
-          >
-            {form.personas.length >= PERSONA_MAX ? `maximum ${PERSONA_MAX}` : '+ new persona'}
-          </button>
-        </div>
-
-        {/* EDITOR */}
-        <div ref={editorRef} className="grid scroll-mt-4 gap-4">
-          <Card
-            title={`Editing · ${focused.name.trim() || `Persona ${safeIdx + 1}`}`}
-            sub={`persona ${safeIdx + 1} of ${form.personas.length}`}
-            right={
-              <>
-                {focused.id === form.activePersonaId
-                  ? <Pill tone="accent" className="text-[8px]">on air</Pill>
-                  : <Btn sm onClick={() => setForm(f => f ? ({ ...f, activePersonaId: focused.id }) : f)}>Set on air</Btn>}
-                <Btn
-                  sm
-                  tone="danger"
-                  onClick={() => { removePersona(safeIdx); setFocusIdx(i => Math.max(0, i - 1)); }}
-                  disabled={form.personas.length <= 1}
-                  title={form.personas.length <= 1 ? 'At least one persona is required' : 'Remove this persona'}
-                >
-                  Remove
-                </Btn>
-              </>
-            }
-          >
-            <div className="mb-4">
-              <AiFill<Partial<Persona>>
-                endpoint="/generate/persona"
-                resultKey="persona"
-                adminFetch={adminFetch}
-                placeholder="e.g. a late-night jazz host with a dry wit"
-                onApply={(p) => setPersona(safeIdx, p)}
-              />
-            </div>
-            <div className="stack-mobile grid grid-cols-[96px_1fr] items-start gap-4">
-              <PersonaAvatarPicker
-                persona={focused}
-                tick={avatarTick}
-                uploading={uploadingId === focused.id}
-                onPick={file => uploadAvatar(focused.id, file)}
-                onGenerate={() => generateAvatar(focused.id)}
-                onClear={() => clearAvatar(focused.id)}
-              />
-              <div className="grid gap-4">
-                <div className="field">
-                  <Label>On-air name</Label>
-                  <Input
-                    value={focused.name}
-                    maxLength={NAME_MAX}
-                    onChange={(e: ChangeEvent<HTMLInputElement>) => setPersona(safeIdx, { name: e.target.value })}
-                    className={focused.name.trim() ? 'border-ink' : 'border-[var(--danger)]'}
-                  />
-                  <div className="field-hint">
-                    Shown in the player and injected into every prompt as <code>{'{name}'}</code>.
-                    <span className="ml-2 text-muted">{focused.name.trim().length} / {NAME_MAX}</span>
-                  </div>
-                </div>
-                <div className="field">
-                  <Label>Tagline</Label>
-                  <Input
-                    value={focused.tagline}
-                    maxLength={TAGLINE_MAX}
-                    placeholder="e.g. late-night drift"
-                    onChange={(e: ChangeEvent<HTMLInputElement>) => setPersona(safeIdx, { tagline: e.target.value })}
-                  />
-                  <div className="field-hint">
-                    A short line shown alongside the persona. Optional.
-                    <span className="ml-2 text-muted">{focused.tagline.trim().length} / {TAGLINE_MAX}</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div className="rule-label">soul</div>
-
-            <div className="field">
-              <Textarea
-                rows={7}
-                value={focused.soul}
-                placeholder="e.g. warm and dry, never corny — observant, favours one good image over a list"
-                onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setPersona(safeIdx, { soul: e.target.value })}
-                className={focusedSoulOver || focusedSoulLen === 0 ? 'border-[var(--danger)]' : 'border-ink'}
-              />
-              <div className="field-hint">
-                One short personality sketch. Injected into the prompt as <code>{'{soul}'}</code>.
-                <span className={cn('ml-2', focusedSoulOver ? 'text-[var(--danger)]' : 'text-muted')}>
-                  {focusedSoulLen} / {SOUL_MAX}
-                </span>
-              </div>
-            </div>
-
-            <div className="rule-label">language</div>
-
-            <div className="field">
-              <Input
-                value={focused.language}
-                maxLength={LANGUAGE_MAX}
-                placeholder="English (default)"
-                onChange={(e: ChangeEvent<HTMLInputElement>) => setPersona(safeIdx, { language: e.target.value })}
-              />
-              <div className="field-hint">
-                The DJ speaks every on-air line in this language. Leave empty for English.
-                Pick a voice that can actually speak it.
-                <span className="ml-2 text-muted">{focused.language.trim().length} / {LANGUAGE_MAX}</span>
-              </div>
-            </div>
-
-            <div className="rule-label">talk frequency</div>
-
-            <div className="stack-mobile grid grid-cols-[1fr_1fr_1fr] gap-2">
-              {FREQUENCIES.map(f => (
-                <RadioOption
-                  key={f.id}
-                  active={f.id === focused.frequency}
-                  label={f.label}
-                  desc={f.desc}
-                  onSelect={() => setPersona(safeIdx, { frequency: f.id })}
-                />
-              ))}
-            </div>
-
-            <div className="rule-label">script length</div>
-
-            <div className="stack-mobile grid grid-cols-[1fr_1fr] gap-2">
-              {SCRIPT_LENGTHS.map(s => (
-                <RadioOption
-                  key={s.id}
-                  active={s.id === (focused.scriptLength || 'concise')}
-                  label={s.label}
-                  desc={s.desc}
-                  onSelect={() => setPersona(safeIdx, { scriptLength: s.id })}
-                />
-              ))}
-            </div>
-
-            <div className="rule-label">DJ mode</div>
-
-            <div className="grid grid-cols-[1fr_auto] items-center gap-4">
-              <div>
-                <div className="text-[13px] font-bold">Work the desk like a real DJ</div>
-                <div className="mt-0.5 text-[11px] text-muted">
-                  Back-announces and teases what&apos;s coming next, runs callbacks across the
-                  hour, and talks more often. Off keeps this persona a tasteful between-track
-                  narrator.
-                </div>
-              </div>
-              <Toggle
-                on={focused.djMode}
-                onClick={() => setPersona(safeIdx, { djMode: !focused.djMode })}
-              />
-            </div>
-
-            <div className="rule-label">tone dials</div>
-
-            <div className="space-y-3.5">
-              {TONE_DIALS.map(d => {
-                const val = focused[d.id];
-                return (
-                  <div key={d.id}>
-                    <div className="flex items-center justify-between text-[12px]">
-                      <span className="font-bold">{d.label}</span>
-                      <span className="text-muted">{val}/10 · {toneBand(val)}</span>
-                    </div>
-                    <input
-                      type="range"
-                      min={0}
-                      max={10}
-                      step={1}
-                      value={val}
-                      onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                        setPersona(safeIdx, { [d.id]: Number(e.target.value) } as Partial<Persona>)}
-                      className="mt-1 w-full accent-[var(--accent)]"
-                    />
-                    <div className="flex justify-between text-[10px] text-muted">
-                      <span>{d.low}</span>
-                      <span>{d.high}</span>
-                    </div>
-                  </div>
-                );
-              })}
-              <div className="field-hint">
-                Personality on top of the soul. The middle band (4–6) injects nothing, so the
-                default stays exactly as before; push a dial low or high to shift the voice.
-              </div>
-            </div>
-          </Card>
-
-          <Card title="Voice" sub="text-to-speech engine">
-            <div className="field mb-3.5">
-              <Label>Engine</Label>
-              <Seg
-                value={focused.tts.engine}
-                options={ENGINES}
-                onChange={v => {
-                  // The `voice` field is shared across engines but each engine
-                  // validates it differently — a leftover value from the old
-                  // engine (e.g. a Kokoro id like "bm_george") fails the new
-                  // engine's check on save. Normalize voice to something the
-                  // target engine accepts whenever the engine changes.
-                  const patch: Partial<PersonaTts> = { engine: v };
-                  const cur = focused.tts.voice.trim();
-                  if (v === 'cloud') {
-                    const provVoices = CLOUD_VOICES[focused.tts.cloudProvider as keyof typeof CLOUD_VOICES] || [];
-                    if (!provVoices.some(pv => pv.id === cur)) {
-                      patch.voice = provVoices[0]?.id || cur;
-                    }
-                  } else if (v === 'kokoro') {
-                    if (!KOKORO_RE.test(cur)) patch.voice = 'bf_isabella';
-                  } else if (v === 'chatterbox') {
-                    // Empty = built-in voice; a real value must be a .wav filename.
-                    if (cur && !CHATTERBOX_VOICE_RE.test(cur)) patch.voice = '';
-                  } else if (v === 'pocket-tts') {
-                    if (!POCKET_TTS_VOICE_RE.test(cur)) patch.voice = 'alba';
-                  }
-                  setPersonaTts(safeIdx, patch);
-                }}
-              />
-              <div className="field-hint">
-                Piper is local &amp; fast. Kokoro is more natural but slower. Chatterbox
-                clones a voice from a reference clip (local, opt-in). Cloud routes through
-                OpenAI / ElevenLabs.
-              </div>
-            </div>
-
-            {focused.tts.engine === 'piper' && (() => {
-              const piperVoices: string[] = data?.tts?.piperVoices || [];
-              const value = focused.tts.voice || CB_DEFAULT_VOICE;
-              return (
-                <div className="field max-w-[360px]">
-                  <Label>Voice</Label>
-                  <Select
-                    value={value}
-                    onValueChange={val => setPersonaTts(safeIdx, { voice: val === CB_DEFAULT_VOICE ? '' : val })}
-                  >
-                    <SelectTrigger><SelectValue placeholder="Built-in default voice" /></SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        <SelectItem value={CB_DEFAULT_VOICE}>Built-in default voice</SelectItem>
-                        {piperVoices.map(v => <SelectItem key={v} value={v}>{v}</SelectItem>)}
-                        {focused.tts.voice && !piperVoices.includes(focused.tts.voice) && (
-                          <SelectItem value={focused.tts.voice}>{focused.tts.voice} (missing)</SelectItem>
-                        )}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                  <div className="field-hint">
-                    Piper is fast, local, and keyless. Drop a voice’s <code>.onnx</code> and its{' '}
-                    <code>.onnx.json</code> manifest into <code>state/voices/</code> on the host — the
-                    same files Home Assistant uses — and they’ll show up here. Leave on the built-in
-                    default if you don’t have any.
-                  </div>
-                </div>
-              );
-            })()}
-
-            {focused.tts.engine === 'kokoro' && (
-              <div className="field max-w-[320px]">
-                <Label>Kokoro voice</Label>
-                <Select
-                  value={focused.tts.voice}
-                  onValueChange={val => setPersonaTts(safeIdx, { voice: val })}
-                >
-                  <SelectTrigger><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      {!kokoroVoices.some(v => v.id === focused.tts.voice) && (
-                        <SelectItem value={focused.tts.voice}>{focused.tts.voice}</SelectItem>
-                      )}
-                      {kokoroVoices.map(v => <SelectItem key={v.id} value={v.id}>{v.label}</SelectItem>)}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-                <div className="field-hint">The kokoro-onnx voice id for this persona.</div>
-              </div>
-            )}
-
-            {focused.tts.engine === 'chatterbox' && (() => {
-              const cbVoices: string[] = data?.tts?.chatterboxVoices || [];
-              // Shared voice folder (issue #213). Default to state/voices/ when
-              // the controller advertises the new field.
-              const cbDir = 'state/voices/';
-              const cbAvailable = data?.tts?.available?.chatterbox !== false;
-              return (
-                <div className="field max-w-[360px]">
-                  {!cbAvailable && (
-                    <div className="mb-2.5 border border-[var(--danger)] px-3 py-2.5 text-[11px] leading-[1.6] text-[var(--danger)]">
-                      Chatterbox isn’t currently available — it lives in the optional{' '}
-                      <code>tts-heavy</code> sidecar. Start it with{' '}
-                      <code>docker compose --profile tts-heavy up -d</code> (or set{' '}
-                      <code>COMPOSE_PROFILES=tts-heavy</code> in <code>.env</code>).
-                      This persona falls back to <strong>{defaultEngine}</strong> until
-                      it’s up.
-                    </div>
-                  )}
-                  <Label>Reference voice</Label>
-                  <Select
-                    value={focused.tts.voice || CB_DEFAULT_VOICE}
-                    onValueChange={val => setPersonaTts(safeIdx, { voice: val === CB_DEFAULT_VOICE ? '' : val })}
-                  >
-                    <SelectTrigger><SelectValue placeholder="Built-in default voice" /></SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        <SelectItem value={CB_DEFAULT_VOICE}>Built-in default voice</SelectItem>
-                        {cbVoices.map(v => <SelectItem key={v} value={v}>{v}</SelectItem>)}
-                        {focused.tts.voice && !cbVoices.includes(focused.tts.voice) && (
-                          <SelectItem value={focused.tts.voice}>{focused.tts.voice} (missing)</SelectItem>
-                        )}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                  <div className="field-hint">
-                    ~5s of clean speech is enough to clone a voice. Drop WAVs into{' '}
-                    <code>{cbDir}</code> on the host and they’ll show up here.
-                    Chatterbox also voices paralinguistic tags ([laugh], [sigh], …) the
-                    DJ may insert.
-                  </div>
-                </div>
-              );
-            })()}
-
-            {focused.tts.engine === 'pocket-tts' && (() => {
-              const ptAvailable = data?.tts?.available?.['pocket-tts'] !== false;
-              const customVoices: string[] = data?.tts?.pocketTtsCustomVoices || [];
-              const value = focused.tts.voice || 'alba';
-              const isBuiltin = pocketTtsVoices.some(v => v.id === value);
-              const isCustom = customVoices.includes(value);
-              // null/undefined = not yet known (sidecar still booting). Only
-              // false means the engine confirmed it can't clone (issue #238).
-              const ptCloning = data?.tts?.available?.pocketTtsCloning;
-              const usingClone = isCustom || /\.wav$/i.test(value);
-              return (
-                <div className="field max-w-[360px]">
-                  {!ptAvailable && (
-                    <div className="mb-2.5 border border-[var(--danger)] px-3 py-2.5 text-[11px] leading-[1.6] text-[var(--danger)]">
-                      PocketTTS isn’t currently available — it lives in the same optional{' '}
-                      <code>tts-heavy</code> sidecar as Chatterbox. Start it with{' '}
-                      <code>docker compose --profile tts-heavy up -d</code> (or set{' '}
-                      <code>COMPOSE_PROFILES=tts-heavy</code> in <code>.env</code>).
-                      This persona falls back to <strong>{defaultEngine}</strong> until
-                      it’s up.
-                    </div>
-                  )}
-                  {ptAvailable && ptCloning === false && usingClone && (
-                    <div className="mb-2.5 border border-[var(--danger)] px-3 py-2.5 text-[11px] leading-[1.6] text-[var(--danger)]">
-                      Voice <strong>cloning is unavailable</strong> in this build, so this
-                      cloned voice won’t play — PocketTTS reverts to a built-in voice. The
-                      cloning model (<code>kyutai/pocket-tts</code>) is gated on Hugging Face:
-                      accept its terms, then set <code>HF_TOKEN</code> in your <code>.env</code>{' '}
-                      and restart <code>tts-heavy</code>. Built-in voices below work without a token.
-                    </div>
-                  )}
-                  <Label>PocketTTS voice</Label>
-                  {(() => {
-                    return (
-                      <Select
-                        value={value}
-                        onValueChange={val => setPersonaTts(safeIdx, { voice: val })}
-                      >
-                        <SelectTrigger><SelectValue /></SelectTrigger>
-                        <SelectContent>
-                          <SelectGroup>
-                            <SelectLabel>Built-in</SelectLabel>
-                            {pocketTtsVoices.map(v => (
-                              <SelectItem key={v.id} value={v.id}>{v.label}</SelectItem>
-                            ))}
-                          </SelectGroup>
-                          {customVoices.length > 0 && (
-                            <SelectGroup>
-                              <SelectLabel>
-                                Custom (cloned){ptCloning === false ? ' — cloning unavailable' : ''}
-                              </SelectLabel>
-                              {customVoices.map(v => (
-                                <SelectItem key={v} value={v}>{v}</SelectItem>
-                              ))}
-                            </SelectGroup>
-                          )}
-                          {!isBuiltin && !isCustom && focused.tts.voice && (
-                            // Persona references a voice that isn't currently
-                            // present — keep the value visible so a save round-trips
-                            // without rewriting, but flag it so the operator notices.
-                            <SelectGroup>
-                              <SelectLabel>Unknown</SelectLabel>
-                              <SelectItem value={focused.tts.voice}>{focused.tts.voice} (missing)</SelectItem>
-                            </SelectGroup>
-                          )}
-                        </SelectContent>
-                      </Select>
-                    );
-                  })()}
-                  <div className="field-hint">
-                    CPU-only, ~6× real-time. Built-in voices cover English, French, German,
-                    Italian, Spanish and Portuguese. Drop a ~5s WAV into{' '}
-                    <code>state/voices/</code> to clone a voice — it’ll appear under
-                    <em> Custom</em> on next reload (cloning needs <code>HF_TOKEN</code>; see above).
-                  </div>
-                </div>
-              );
-            })()}
-
-            {focused.tts.engine === 'cloud' && (() => {
-              const isCompat = focused.tts.cloudProvider === 'openai-compatible';
-              const provVoices = CLOUD_VOICES[focused.tts.cloudProvider as keyof typeof CLOUD_VOICES] || [];
-              const voice = focused.tts.voice.trim();
-              const isPreset = provVoices.some(v => v.id === voice);
-              return (
-                <>
-                {focusedCloudIssue && (
-                  <div className="mb-3.5 border border-[var(--danger)] px-3 py-2.5 text-[11px] leading-[1.6] text-[var(--danger)]">
-                    <strong>This cloud voice won’t play.</strong> {focusedCloudIssue}{' '}
-                    Until that’s fixed, this persona falls back to <strong>{defaultEngine}</strong>.
-                  </div>
-                )}
-                <div className="stack-mobile grid grid-cols-[1fr_1fr] gap-4">
-                  <div className="field">
-                    <Label>Cloud provider</Label>
-                    <Seg
-                      value={focused.tts.cloudProvider}
-                      options={cloudProviders.map(id => ({ id, label: id }))}
-                      onChange={v => {
-                        // Switching provider invalidates the old voice id.
-                        // openai-compatible has no curated voices — leave the
-                        // field blank so the operator types their own (server
-                        // picks its default when blank).
-                        const next = v === 'openai-compatible'
-                          ? ''
-                          : (CLOUD_VOICES[v as keyof typeof CLOUD_VOICES]?.[0]?.id || focused.tts.voice);
-                        setPersonaTts(safeIdx, { cloudProvider: v, voice: next });
-                      }}
-                    />
-                    <div className="field-hint">
-                      {isCompat
-                        ? 'Uses the shared base URL + model from Settings.'
-                        : 'Uses the shared API key + model from Settings.'}
-                    </div>
-                  </div>
-                  <div className="field">
-                    <Label>Cloud voice</Label>
-                    {isCompat ? (
-                      <>
-                        <Input
-                          value={focused.tts.voice}
-                          maxLength={100}
-                          placeholder="Server-specific (cloning ref or speaker id)"
-                          onChange={(e: ChangeEvent<HTMLInputElement>) => setPersonaTts(safeIdx, { voice: e.target.value })}
-                        />
-                        <div className="field-hint">
-                          Server-specific — Chatterbox cloning ref name, Qwen3
-                          speaker id, etc. Leave blank to let the server pick.
-                        </div>
-                      </>
-                    ) : (
-                      <>
-                        <Select
-                          value={isPreset ? voice : '__custom__'}
-                          onValueChange={val => {
-                            // "Custom voice id…" clears the preset so isPreset flips
-                            // false and the free-text input below appears for entry.
-                            setPersonaTts(safeIdx, { voice: val === '__custom__' ? '' : val });
-                          }}
-                        >
-                          <SelectTrigger><SelectValue /></SelectTrigger>
-                          <SelectContent>
-                            <SelectGroup>
-                              {provVoices.map(v => (
-                                <SelectItem key={v.id} value={v.id}>{v.label}</SelectItem>
-                              ))}
-                              <SelectItem value="__custom__">Custom voice id…</SelectItem>
-                            </SelectGroup>
-                          </SelectContent>
-                        </Select>
-                        {!isPreset && (
-                          <Input
-                            className={cn('mt-2', voice ? 'border-ink' : 'border-[var(--danger)]')}
-                            value={focused.tts.voice}
-                            maxLength={100}
-                            placeholder="Enter a custom voice id"
-                            onChange={(e: ChangeEvent<HTMLInputElement>) => setPersonaTts(safeIdx, { voice: e.target.value })}
-                          />
-                        )}
-                        <div className="field-hint">
-                          Pick a default voice, or choose <em>Custom voice id…</em> to enter your own
-                          (e.g. an OpenAI voice name or an ElevenLabs voice id).
-                        </div>
-                      </>
-                    )}
-                  </div>
-                </div>
-                </>
-              );
-            })()}
-
-            {(() => {
-              const gain = focused.tts.gainDb ?? 0;
-              const label = !gain
-                ? '0 dB'
-                : `${gain > 0 ? '+' : '−'}${Math.abs(gain).toFixed(1)} dB`;
-              return (
-                <div className="field mt-3.5 max-w-[360px]">
-                  <div className="flex items-center justify-between gap-3">
-                    <Label>Voice level (dB)</Label>
-                    <span className="font-mono text-[12px] text-ink tabular-nums">{label}</span>
-                  </div>
-                  <input
-                    type="range"
-                    min={-12}
-                    max={12}
-                    step={0.5}
-                    value={gain}
-                    onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                      setPersonaTts(safeIdx, { gainDb: Number(e.target.value) })
-                    }
-                    aria-label="Persona voice level in decibels"
-                    className="mt-1.5 w-full accent-[var(--accent)]"
-                  />
-                  <div className="field-hint">
-                    Trim this persona’s loudness on top of the engine level. <code>0 dB</code> = no change.
-                  </div>
-                </div>
-              );
-            })()}
-          </Card>
-
-          <Card title="Skills" sub="autonomous segments this persona runs">
-            <p className="mb-2.5 text-[12px] leading-[1.6] text-muted">
-              When this persona is on air, only the skills ticked here can fire. A skill must
-              also be enabled station-wide on the <strong>Skills</strong> page.
-            </p>
-            {skillCatalog.length === 0 ? (
-              <div className="text-[12px] text-muted italic">
-                no skills available
-              </div>
-            ) : (
-              <div className="grid gap-0">
-                {skillCatalog.map(s => {
-                  const on = focused.skills.includes(s.name);
-                  return (
-                    <div
-                      key={s.name}
-                      className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-dashed border-separator-strong py-3"
-                    >
-                      <div>
-                        <div className="text-[13px] font-bold">{s.label || s.name}</div>
-                        <div className="mt-0.5 text-[11px] text-muted">
-                          {s.description}
-                        </div>
-                      </div>
-                      <Toggle
-                        on={on}
-                        onClick={() => setPersonaSkills(
-                          safeIdx,
-                          on
-                            ? focused.skills.filter(n => n !== s.name)
-                            : [...focused.skills, s.name],
-                        )}
-                      />
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </Card>
-
-          {/* Save bar */}
-          <div className="flex flex-wrap items-center gap-3 border border-ink bg-[var(--ink-softer)] p-3">
-            <span
-              className={cn(
-                'size-1.5 flex-none rounded-full',
-                canSave ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
-              )}
-            />
-            <span className="text-[11px] text-muted">
-              {!canSave && !focusedOk
-                ? <span className="text-[var(--danger)]">this persona has a missing or invalid field</span>
-                : !canSave && !allPersonasOk
-                  ? <span className="text-[var(--danger)]">another persona in the roster is incomplete</span>
-                  : !canSave && !promptOk
-                    ? <span className="text-[var(--danger)]">fix the custom system prompt</span>
-                    : 'changes apply on the next spoken line · no mixer restart'}
-            </span>
-            <span className="ml-auto flex gap-2">
-              <Btn onClick={load} disabled={busy}>Discard</Btn>
-              <Btn tone="accent" onClick={save} disabled={busy || !canSave}>
-                {busy ? 'Saving…' : 'Save persona'}
-              </Btn>
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-interface RadioOptionProps {
-  active: boolean;
-  label: ReactNode;
-  desc: ReactNode;
-  onSelect: () => void;
-}
-
-function RadioOption({ active, label, desc, onSelect }: RadioOptionProps) {
-  return (
-    <button
-      type="button"
-      onClick={onSelect}
-      className={cn(
-        'grid cursor-pointer gap-1.5 border p-3 text-left font-[inherit]',
-        active
-          ? 'border-[var(--accent)] bg-[var(--accent-soft)]'
-          : 'border-ink bg-transparent',
-      )}
-    >
-      <div className="flex items-center gap-1.5">
-        <span
-          className={cn(
-            'size-2.5 rounded-full border',
-            active
-              ? 'border-[var(--accent)] bg-[var(--accent)]'
-              : 'border-ink bg-transparent',
-          )}
+        <SystemPromptCard
+          useCustomPrompt={form.useCustomPrompt}
+          systemPrompt={form.systemPrompt}
+          defaultPrompt={data?.defaults?.djPrompt || ''}
+          promptOk={promptOk}
+          promptText={promptText}
+          busy={busy}
+          onSetUseCustom={(custom) => setForm(f => f ? ({ ...f, useCustomPrompt: custom }) : f)}
+          onChangePrompt={(text) => setForm(f => f ? ({ ...f, systemPrompt: text }) : f)}
+          onRestore={() => setForm(f => f ? ({ ...f, systemPrompt: data?.defaults?.djPrompt || '' }) : f)}
         />
-        <span
-          className={cn(
-            'text-[11px] font-bold tracking-[0.2em] uppercase',
-            active ? 'text-vermilion' : 'text-ink',
-          )}
-        >
-          {label}
-        </span>
-      </div>
-      <div className="text-[10px] leading-[1.5] text-muted">{desc}</div>
-    </button>
+      )}
+
+      <PersonaRoster
+        personas={form.personas}
+        activePersonaId={form.activePersonaId}
+        focusedIdx={safeIdx}
+        avatarTick={avatarTick}
+        onSelect={setFocusIdx}
+        onAdd={addPersona}
+      />
+
+      <PersonaEditor
+        persona={focused}
+        index={safeIdx}
+        personaCount={form.personas.length}
+        activePersonaId={form.activePersonaId}
+        data={data}
+        adminFetch={adminFetch}
+        avatarTick={avatarTick}
+        uploadingId={uploadingId}
+        defaultEngine={defaultEngine}
+        cloudIssueText={focusedCloudIssue}
+        skillCatalog={skillCatalog}
+        editorRef={editorRef}
+        setPersona={setPersona}
+        setPersonaTts={setPersonaTts}
+        setPersonaSkills={setPersonaSkills}
+        onUploadAvatar={uploadAvatar}
+        onGenerateAvatar={generateAvatar}
+        onClearAvatar={clearAvatar}
+        onSetActive={() => setForm(f => f ? ({ ...f, activePersonaId: focused.id }) : f)}
+        onRemove={() => { removePersona(safeIdx); setFocusIdx(i => Math.max(0, i - 1)); }}
+        canSave={canSave}
+        focusedOk={focusedOk}
+        allPersonasOk={allPersonasOk}
+        promptOk={promptOk}
+        busy={busy}
+        onSave={save}
+        onDiscard={load}
+      />
+    </div>
   );
 }

--- a/web/components/admin/personas/PersonaAvatarPicker.tsx
+++ b/web/components/admin/personas/PersonaAvatarPicker.tsx
@@ -1,0 +1,76 @@
+'use client';
+// Avatar square + Upload / Generate / Remove buttons for the focused persona.
+import { useRef } from 'react';
+import type { Persona } from './types';
+import { API_BASE } from './constants';
+import { initialsFor } from './helpers';
+import { Btn } from '../ui';
+import { Label } from '../../ui/label';
+
+interface PersonaAvatarPickerProps {
+  persona: Persona;
+  tick: number;
+  uploading: boolean;
+  onPick: (file: File) => void;
+  onGenerate: () => void;
+  onClear: () => void;
+}
+
+export function PersonaAvatarPicker({ persona, tick, uploading, onPick, onGenerate, onClear }: PersonaAvatarPickerProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  // The public endpoint serves a 1×1 transparent placeholder when no avatar
+  // is set; rather than render that as a tiny grey square, fall back to
+  // initials in the admin UI. The ?v=… buster forces a refetch after upload.
+  const hasAvatar = !!persona.avatar;
+  const src = hasAvatar
+    ? `${API_BASE}/persona-avatar/${encodeURIComponent(persona.id)}?v=${tick}`
+    : null;
+  return (
+    <div className="grid gap-2">
+      <Label>Avatar</Label>
+      <div
+        className="relative grid h-[96px] w-[96px] place-items-center overflow-hidden border border-ink bg-[var(--ink-softer)]"
+        aria-label={hasAvatar ? `${persona.name} avatar` : 'No avatar set'}
+      >
+        {/* Initials behind the image so a missing / transparent / broken avatar
+            still shows a readable placeholder. */}
+        <span className="text-[22px] font-extrabold tracking-[-0.02em] text-muted">
+          {initialsFor(persona.name)}
+        </span>
+        {src && (
+          <img
+            src={src}
+            alt=""
+            className="absolute inset-0 h-full w-full object-cover"
+            onError={e => { e.currentTarget.style.visibility = 'hidden'; }}
+          />
+        )}
+      </div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/png,image/jpeg,image/webp"
+        className="hidden"
+        onChange={e => {
+          const file = e.target.files?.[0];
+          if (file) onPick(file);
+          // Reset so picking the same file twice still fires onChange.
+          e.target.value = '';
+        }}
+      />
+      <div className="grid w-[96px] gap-1.5">
+        <Btn sm className="w-full justify-center" onClick={() => inputRef.current?.click()} disabled={uploading}>
+          {uploading ? '…' : hasAvatar ? 'Replace' : 'Upload'}
+        </Btn>
+        <Btn sm className="w-full justify-center" onClick={onGenerate} disabled={uploading} title="Random DiceBear avatar — click again for a different one">
+          Generate
+        </Btn>
+        {hasAvatar && (
+          <Btn sm tone="danger" className="w-full justify-center" onClick={onClear} disabled={uploading}>
+            Remove
+          </Btn>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/components/admin/personas/PersonaBehaviorCard.tsx
+++ b/web/components/admin/personas/PersonaBehaviorCard.tsx
@@ -1,0 +1,92 @@
+'use client';
+// How this persona talks: talk frequency, script length, DJ mode, and the tone
+// dials. Two columns from lg up (settings on the left, dials on the right) so
+// the knobs stay grouped instead of spreading across the full editor width.
+import type { Persona } from './types';
+import { FREQUENCIES, SCRIPT_LENGTHS, TONE_DIALS, toneBandIndex } from './constants';
+import { Card, Toggle } from '../ui';
+import { RadioOption } from './RadioOption';
+import { ToneKnob } from './ToneKnob';
+
+interface PersonaBehaviorCardProps {
+  persona: Persona;
+  update: (patch: Partial<Persona>) => void;
+}
+
+export function PersonaBehaviorCard({ persona, update }: PersonaBehaviorCardProps) {
+  return (
+    <Card title="Behaviour" sub="how this persona talks">
+      <div className="lg:grid lg:grid-cols-2 lg:items-start lg:gap-x-8">
+        {/* LEFT — frequency, script length, DJ mode */}
+        <div>
+          <div className="rule-label">talk frequency</div>
+          <div className="stack-mobile grid grid-cols-3 gap-2">
+            {FREQUENCIES.map(f => (
+              <RadioOption
+                key={f.id}
+                active={f.id === persona.frequency}
+                label={f.label}
+                desc={f.desc}
+                onSelect={() => update({ frequency: f.id })}
+              />
+            ))}
+          </div>
+
+          <div className="rule-label">script length</div>
+          <div className="stack-mobile grid grid-cols-2 gap-2">
+            {SCRIPT_LENGTHS.map(s => (
+              <RadioOption
+                key={s.id}
+                active={s.id === (persona.scriptLength || 'concise')}
+                label={s.label}
+                desc={s.desc}
+                onSelect={() => update({ scriptLength: s.id })}
+              />
+            ))}
+          </div>
+
+          <div className="rule-label">DJ mode</div>
+          <div className="grid grid-cols-[1fr_auto] items-center gap-4">
+            <div>
+              <div className="text-[13px] font-bold">Work the desk like a real DJ</div>
+              <div className="mt-0.5 text-[11px] text-muted">
+                Back-announces and teases what&apos;s coming next, runs callbacks across the
+                hour, and talks more often. Off keeps this persona a tasteful between-track
+                narrator.
+              </div>
+            </div>
+            <Toggle
+              on={persona.djMode}
+              onClick={() => update({ djMode: !persona.djMode })}
+            />
+          </div>
+        </div>
+
+        {/* RIGHT — tone dials */}
+        <div className="mt-4 lg:mt-0">
+          <div className="rule-label">tone dials</div>
+          <div className="grid grid-cols-3 gap-2 sm:gap-4">
+            {TONE_DIALS.map(d => {
+              const val = persona[d.id];
+              return (
+                <ToneKnob
+                  key={d.id}
+                  label={d.label}
+                  value={val}
+                  band={d.words[toneBandIndex(val)]}
+                  low={d.low}
+                  high={d.high}
+                  onChange={v => update({ [d.id]: v } as Partial<Persona>)}
+                />
+              );
+            })}
+          </div>
+          <div className="field-hint mt-3.5">
+            Personality on top of the soul. The middle band (4–6) injects nothing, so the
+            default stays exactly as before; turn a dial low or high to shift the voice.
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/web/components/admin/personas/PersonaEditor.tsx
+++ b/web/components/admin/personas/PersonaEditor.tsx
@@ -1,0 +1,113 @@
+'use client';
+// Full-width editor for the focused persona: identity, behaviour, voice and
+// skills cards plus the save bar. Binds the index-taking mutators down to the
+// focused persona so the cards stay index-agnostic.
+import type { RefObject } from 'react';
+import type { Persona, PersonaTts, SettingsResponse, SkillCatalogEntry } from './types';
+import type { AdminAuth } from '../../../lib/adminAuth';
+import { Btn } from '../ui';
+import { cn } from '../../../lib/cn';
+import { PersonaIdentityCard } from './PersonaIdentityCard';
+import { PersonaBehaviorCard } from './PersonaBehaviorCard';
+import { PersonaVoiceCard } from './PersonaVoiceCard';
+import { PersonaSkillsCard } from './PersonaSkillsCard';
+
+interface PersonaEditorProps {
+  persona: Persona;
+  index: number;
+  personaCount: number;
+  activePersonaId: string;
+  data: SettingsResponse | null;
+  adminFetch: AdminAuth['adminFetch'];
+  avatarTick: number;
+  uploadingId: string | null;
+  defaultEngine: string;
+  cloudIssueText: string | null;
+  skillCatalog: SkillCatalogEntry[];
+  editorRef: RefObject<HTMLDivElement | null>;
+  setPersona: (i: number, patch: Partial<Persona>) => void;
+  setPersonaTts: (i: number, patch: Partial<PersonaTts>) => void;
+  setPersonaSkills: (i: number, skills: string[]) => void;
+  onUploadAvatar: (id: string, file: File) => void;
+  onGenerateAvatar: (id: string) => void;
+  onClearAvatar: (id: string) => void;
+  onSetActive: () => void;
+  onRemove: () => void;
+  canSave: boolean;
+  focusedOk: boolean;
+  allPersonasOk: boolean;
+  promptOk: boolean;
+  busy: boolean;
+  onSave: () => void;
+  onDiscard: () => void;
+}
+
+export function PersonaEditor({
+  persona, index, personaCount, activePersonaId, data, adminFetch, avatarTick, uploadingId,
+  defaultEngine, cloudIssueText, skillCatalog, editorRef,
+  setPersona, setPersonaTts, setPersonaSkills,
+  onUploadAvatar, onGenerateAvatar, onClearAvatar, onSetActive, onRemove,
+  canSave, focusedOk, allPersonasOk, promptOk, busy, onSave, onDiscard,
+}: PersonaEditorProps) {
+  const update = (patch: Partial<Persona>) => setPersona(index, patch);
+  const updateTts = (patch: Partial<PersonaTts>) => setPersonaTts(index, patch);
+  const setSkills = (skills: string[]) => setPersonaSkills(index, skills);
+
+  return (
+    <div ref={editorRef} className="grid scroll-mt-4 gap-4">
+      <PersonaIdentityCard
+        persona={persona}
+        index={index}
+        personaCount={personaCount}
+        isActive={persona.id === activePersonaId}
+        canRemove={personaCount > 1}
+        adminFetch={adminFetch}
+        avatarTick={avatarTick}
+        uploading={uploadingId === persona.id}
+        update={update}
+        onSetActive={onSetActive}
+        onRemove={onRemove}
+        onPickAvatar={(file) => onUploadAvatar(persona.id, file)}
+        onGenerateAvatar={() => onGenerateAvatar(persona.id)}
+        onClearAvatar={() => onClearAvatar(persona.id)}
+      />
+
+      <PersonaBehaviorCard persona={persona} update={update} />
+
+      <PersonaVoiceCard
+        persona={persona}
+        data={data}
+        defaultEngine={defaultEngine}
+        cloudIssueText={cloudIssueText}
+        updateTts={updateTts}
+      />
+
+      <PersonaSkillsCard persona={persona} skillCatalog={skillCatalog} setSkills={setSkills} />
+
+      {/* Save bar */}
+      <div className="flex flex-wrap items-center gap-3 border border-ink bg-[var(--ink-softer)] p-3">
+        <span
+          className={cn(
+            'size-1.5 flex-none rounded-full',
+            canSave ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
+          )}
+        />
+        <span className="text-[11px] text-muted">
+          {!canSave && !focusedOk
+            ? <span className="text-[var(--danger)]">this persona has a missing or invalid field</span>
+            : !canSave && !allPersonasOk
+              ? <span className="text-[var(--danger)]">another persona in the roster is incomplete</span>
+              : !canSave && !promptOk
+                ? <span className="text-[var(--danger)]">fix the custom system prompt</span>
+                : 'changes apply on the next spoken line · no mixer restart'}
+        </span>
+        <span className="ml-auto flex gap-2">
+          <Btn onClick={onDiscard} disabled={busy}>Discard</Btn>
+          <Btn tone="accent" onClick={onSave} disabled={busy || !canSave}>
+            {busy ? 'Saving…' : 'Save persona'}
+          </Btn>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/web/components/admin/personas/PersonaHero.tsx
+++ b/web/components/admin/personas/PersonaHero.tsx
@@ -1,0 +1,66 @@
+'use client';
+// Hero header + live/active strip for /admin/personas.
+import type { Persona } from './types';
+import { PERSONA_MAX } from './constants';
+import { engineLabel } from './helpers';
+import { Btn, Eyebrow } from '../ui';
+
+interface PersonaHeroProps {
+  activePersona: Persona | undefined;
+  defaultEngine: string;
+  activeCloudIssue: string | null;
+  personaCount: number;
+  showPrompt: boolean;
+  onTogglePrompt: () => void;
+  onAdd: () => void;
+}
+
+export function PersonaHero({
+  activePersona, defaultEngine, activeCloudIssue, personaCount, showPrompt, onTogglePrompt, onAdd,
+}: PersonaHeroProps) {
+  return (
+    <section className="card">
+      <div className="stack-mobile grid grid-cols-[1fr_auto] items-center gap-4 border-b border-ink p-4">
+        <div>
+          <Eyebrow className="text-vermilion">personas</Eyebrow>
+          <div className="mt-1.5 text-[22px] font-extrabold tracking-[-0.02em]">
+            The voices on your station.
+          </div>
+          <div className="mt-1 text-[11px] leading-[1.6] text-muted">
+            One persona is on air at a time. A scheduled show can hand the hour to a different one.
+            Every change applies live; no mixer restart.
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Btn onClick={onTogglePrompt}>
+            {showPrompt ? 'Hide system prompt' : 'System prompt'}
+          </Btn>
+          <Btn tone="accent" onClick={onAdd} disabled={personaCount >= PERSONA_MAX}>
+            + Add persona
+          </Btn>
+        </div>
+      </div>
+
+      {/* Active strip */}
+      <div className="flex flex-wrap items-center gap-3 bg-[var(--ink-softer)] p-3.5">
+        <span className="caption text-vermilion">● live</span>
+        <span className="text-[13px] font-bold">
+          {activePersona ? (activePersona.name.trim() || 'Persona') : '—'}
+        </span>
+        {activePersona?.tagline.trim() && (
+          <span className="text-[11px] text-muted">— {activePersona.tagline.trim()}</span>
+        )}
+        <span className="caption ml-4">
+          frequency · {activePersona ? activePersona.frequency : '—'}
+        </span>
+        <span className="caption">voice · {activePersona ? engineLabel(activePersona) : '—'}</span>
+        {activeCloudIssue && (
+          <span className="caption text-[var(--danger)]">
+            ⚠ cloud voice inactive — speaking via {defaultEngine}
+          </span>
+        )}
+        <span className="caption">override · — (a scheduled show may reassign the hour)</span>
+      </div>
+    </section>
+  );
+}

--- a/web/components/admin/personas/PersonaIdentityCard.tsx
+++ b/web/components/admin/personas/PersonaIdentityCard.tsx
@@ -1,0 +1,149 @@
+'use client';
+// "Editing · <name>" card: AI fill, avatar, name, tagline, soul, language.
+// Two columns from lg up so the soul textarea sits beside the identity fields
+// instead of running the full editor width.
+import type { ChangeEvent } from 'react';
+import type { Persona } from './types';
+import type { AdminAuth } from '../../../lib/adminAuth';
+import { NAME_MAX, TAGLINE_MAX, SOUL_MAX, LANGUAGE_MAX } from './constants';
+import { Card, Btn, Pill } from '../ui';
+import { Input } from '../../ui/input';
+import { Textarea } from '../../ui/textarea';
+import { Label } from '../../ui/label';
+import { AiFill } from '../AiFill';
+import { PersonaAvatarPicker } from './PersonaAvatarPicker';
+import { cn } from '../../../lib/cn';
+
+interface PersonaIdentityCardProps {
+  persona: Persona;
+  index: number;        // 0-based, for the "persona X of Y" sub
+  personaCount: number;
+  isActive: boolean;
+  canRemove: boolean;
+  adminFetch: AdminAuth['adminFetch'];
+  avatarTick: number;
+  uploading: boolean;
+  update: (patch: Partial<Persona>) => void;
+  onSetActive: () => void;
+  onRemove: () => void;
+  onPickAvatar: (file: File) => void;
+  onGenerateAvatar: () => void;
+  onClearAvatar: () => void;
+}
+
+export function PersonaIdentityCard({
+  persona, index, personaCount, isActive, canRemove, adminFetch, avatarTick, uploading,
+  update, onSetActive, onRemove, onPickAvatar, onGenerateAvatar, onClearAvatar,
+}: PersonaIdentityCardProps) {
+  const soulLen = persona.soul.trim().length;
+  const soulOver = soulLen > SOUL_MAX;
+  return (
+    <Card
+      title={`Editing · ${persona.name.trim() || `Persona ${index + 1}`}`}
+      sub={`persona ${index + 1} of ${personaCount}`}
+      right={
+        <>
+          {isActive
+            ? <Pill tone="accent" className="text-[8px]">on air</Pill>
+            : <Btn sm onClick={onSetActive}>Set on air</Btn>}
+          <Btn
+            sm
+            tone="danger"
+            onClick={onRemove}
+            disabled={!canRemove}
+            title={canRemove ? 'Remove this persona' : 'At least one persona is required'}
+          >
+            Remove
+          </Btn>
+        </>
+      }
+    >
+      <div className="mb-4">
+        <AiFill<Partial<Persona>>
+          endpoint="/generate/persona"
+          resultKey="persona"
+          adminFetch={adminFetch}
+          placeholder="e.g. a late-night jazz host with a dry wit"
+          onApply={(p) => update(p)}
+        />
+      </div>
+
+      <div className="lg:grid lg:grid-cols-2 lg:items-start lg:gap-x-8">
+        {/* LEFT — avatar, name, tagline, language */}
+        <div className="grid gap-4">
+          <div className="stack-mobile grid grid-cols-[96px_1fr] items-start gap-4">
+            <PersonaAvatarPicker
+              persona={persona}
+              tick={avatarTick}
+              uploading={uploading}
+              onPick={onPickAvatar}
+              onGenerate={onGenerateAvatar}
+              onClear={onClearAvatar}
+            />
+            <div className="grid gap-4">
+              <div className="field">
+                <Label>On-air name</Label>
+                <Input
+                  value={persona.name}
+                  maxLength={NAME_MAX}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => update({ name: e.target.value })}
+                  className={persona.name.trim() ? 'border-ink' : 'border-[var(--danger)]'}
+                />
+                <div className="field-hint">
+                  Shown in the player and injected into every prompt as <code>{'{name}'}</code>.
+                  <span className="ml-2 text-muted">{persona.name.trim().length} / {NAME_MAX}</span>
+                </div>
+              </div>
+              <div className="field">
+                <Label>Tagline</Label>
+                <Input
+                  value={persona.tagline}
+                  maxLength={TAGLINE_MAX}
+                  placeholder="e.g. late-night drift"
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => update({ tagline: e.target.value })}
+                />
+                <div className="field-hint">
+                  A short line shown alongside the persona. Optional.
+                  <span className="ml-2 text-muted">{persona.tagline.trim().length} / {TAGLINE_MAX}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="field">
+            <Label>Language</Label>
+            <Input
+              value={persona.language}
+              maxLength={LANGUAGE_MAX}
+              placeholder="English (default)"
+              onChange={(e: ChangeEvent<HTMLInputElement>) => update({ language: e.target.value })}
+            />
+            <div className="field-hint">
+              The DJ speaks every on-air line in this language. Leave empty for English.
+              Pick a voice that can actually speak it.
+              <span className="ml-2 text-muted">{persona.language.trim().length} / {LANGUAGE_MAX}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* RIGHT — soul */}
+        <div className="field mt-4 lg:mt-0">
+          <Label>Soul</Label>
+          <Textarea
+            rows={9}
+            value={persona.soul}
+            placeholder="e.g. warm and dry, never corny — observant, favours one good image over a list"
+            onChange={(e: ChangeEvent<HTMLTextAreaElement>) => update({ soul: e.target.value })}
+            className={soulOver || soulLen === 0 ? 'border-[var(--danger)]' : 'border-ink'}
+          />
+          <div className="field-hint">
+            One short personality sketch. Injected into the prompt as <code>{'{soul}'}</code>.
+            <span className={cn('ml-2', soulOver ? 'text-[var(--danger)]' : 'text-muted')}>
+              {soulLen} / {SOUL_MAX}
+            </span>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/web/components/admin/personas/PersonaRoster.tsx
+++ b/web/components/admin/personas/PersonaRoster.tsx
@@ -1,0 +1,107 @@
+'use client';
+// Full-width selectable roster — sits below the hero. A responsive grid of
+// persona cards (avatar + name + tagline + badges) that wraps as personas are
+// added; click a card to edit it in the full-width editor below. The last cell
+// is a dashed "+ new persona" add card.
+import type { Persona } from './types';
+import { API_BASE, PERSONA_MAX } from './constants';
+import { initialsFor, personaValid } from './helpers';
+import { Pill } from '../ui';
+import { cn } from '../../../lib/cn';
+
+interface PersonaRosterProps {
+  personas: Persona[];
+  activePersonaId: string;
+  focusedIdx: number;
+  avatarTick: number;
+  onSelect: (idx: number) => void;
+  onAdd: () => void;
+}
+
+export function PersonaRoster({
+  personas, activePersonaId, focusedIdx, avatarTick, onSelect, onAdd,
+}: PersonaRosterProps) {
+  const atMax = personas.length >= PERSONA_MAX;
+  return (
+    <section className="grid gap-2.5">
+      <span className="caption">roster · {personas.length} / {PERSONA_MAX}</span>
+      <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+        {personas.map((p, i) => {
+          const isActive = p.id === activePersonaId;
+          const isFocused = i === focusedIdx;
+          const valid = personaValid(p);
+          const src = p.avatar
+            ? `${API_BASE}/persona-avatar/${encodeURIComponent(p.id)}?v=${avatarTick}`
+            : null;
+          return (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => onSelect(i)}
+              aria-pressed={isFocused}
+              className={cn(
+                'grid min-w-0 cursor-pointer content-start gap-2 border p-3 text-left font-[inherit]',
+                isFocused
+                  ? 'border-[var(--accent)] bg-[var(--accent-soft)]'
+                  : 'border-ink bg-[var(--card-bg)]',
+              )}
+            >
+              <div className="flex min-w-0 items-start gap-2.5">
+                {/* Initials sit behind the image so a missing / transparent /
+                    broken avatar still shows a readable placeholder. */}
+                <span className="relative grid size-10 flex-none place-items-center overflow-hidden border border-ink bg-[var(--ink-softer)]">
+                  <span className="text-[12px] font-extrabold text-muted">{initialsFor(p.name)}</span>
+                  {src && (
+                    <img
+                      src={src}
+                      alt=""
+                      className="absolute inset-0 h-full w-full object-cover"
+                      onError={e => { e.currentTarget.style.visibility = 'hidden'; }}
+                    />
+                  )}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    {isActive && <span className="size-1.5 flex-none rounded-full bg-[var(--accent)]" />}
+                    <span className="min-w-0 truncate text-[14px] font-extrabold tracking-[-0.01em] text-ink">
+                      {p.name.trim() || `Persona ${i + 1}`}
+                    </span>
+                  </div>
+                  <div className="truncate text-[11px] text-muted">
+                    {p.tagline.trim() || 'no tagline'}
+                  </div>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {isActive && <Pill tone="accent" className="text-[8px]">on air</Pill>}
+                <Pill className="text-[8px]">{p.frequency}</Pill>
+                {p.scriptLength === 'extended' && <Pill className="text-[8px]">extended</Pill>}
+                <Pill className="text-[8px]">{p.tts.engine}</Pill>
+                {p.tts.engine !== 'piper' && p.tts.voice.trim() && (
+                  <Pill className="max-w-[120px] truncate text-[8px]">{p.tts.voice.trim()}</Pill>
+                )}
+                <Pill className="text-[8px]">
+                  {p.skills.length} skill{p.skills.length === 1 ? '' : 's'}
+                </Pill>
+                {!valid && (
+                  <Pill className="border-[var(--danger)] text-[8px] text-[var(--danger)]">incomplete</Pill>
+                )}
+              </div>
+            </button>
+          );
+        })}
+        <button
+          type="button"
+          onClick={onAdd}
+          disabled={atMax}
+          className={cn(
+            'grid min-h-[88px] place-items-center border border-dashed border-muted bg-transparent p-3 font-[inherit] text-[11px] font-bold tracking-[0.18em] text-muted uppercase',
+            atMax ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
+          )}
+        >
+          {atMax ? `maximum ${PERSONA_MAX}` : '+ new persona'}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/web/components/admin/personas/PersonaSkillsCard.tsx
+++ b/web/components/admin/personas/PersonaSkillsCard.tsx
@@ -1,0 +1,54 @@
+'use client';
+// Per-persona skill toggles — which autonomous segments may fire when this
+// persona is on air.
+import type { Persona, SkillCatalogEntry } from './types';
+import { Card, Toggle } from '../ui';
+
+interface PersonaSkillsCardProps {
+  persona: Persona;
+  skillCatalog: SkillCatalogEntry[];
+  setSkills: (skills: string[]) => void;
+}
+
+export function PersonaSkillsCard({ persona, skillCatalog, setSkills }: PersonaSkillsCardProps) {
+  return (
+    <Card title="Skills" sub="autonomous segments this persona runs">
+      <p className="mb-2.5 max-w-[70ch] text-[12px] leading-[1.6] text-muted">
+        When this persona is on air, only the skills ticked here can fire. A skill must
+        also be enabled station-wide on the <strong>Skills</strong> page.
+      </p>
+      {skillCatalog.length === 0 ? (
+        <div className="text-[12px] text-muted italic">
+          no skills available
+        </div>
+      ) : (
+        <div className="grid gap-x-8 sm:grid-cols-2">
+          {skillCatalog.map(s => {
+            const on = persona.skills.includes(s.name);
+            return (
+              <div
+                key={s.name}
+                className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-dashed border-separator-strong py-3"
+              >
+                <div>
+                  <div className="text-[13px] font-bold">{s.label || s.name}</div>
+                  <div className="mt-0.5 text-[11px] text-muted">
+                    {s.description}
+                  </div>
+                </div>
+                <Toggle
+                  on={on}
+                  onClick={() => setSkills(
+                    on
+                      ? persona.skills.filter(n => n !== s.name)
+                      : [...persona.skills, s.name],
+                  )}
+                />
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/web/components/admin/personas/PersonaVoiceCard.tsx
+++ b/web/components/admin/personas/PersonaVoiceCard.tsx
@@ -1,0 +1,365 @@
+'use client';
+// Text-to-speech engine, the engine-specific voice selector, and the per-persona
+// voice-level trim. Two columns from lg up (engine + selector on the left, the
+// level meter on the right) so the card fills the editor width instead of
+// stacking in a narrow left strip.
+import type { ChangeEvent } from 'react';
+import type { Persona, PersonaTts, SettingsResponse } from './types';
+import { CLOUD_VOICES } from '../../../lib/cloudVoices';
+import { ENGINES, CB_DEFAULT_VOICE, KOKORO_RE, CHATTERBOX_VOICE_RE, POCKET_TTS_VOICE_RE } from './constants';
+import { Card, Seg } from '../ui';
+import { Input } from '../../ui/input';
+import { Label } from '../../ui/label';
+import {
+  Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel,
+} from '../../ui/select';
+import { VoiceMeter } from './VoiceMeter';
+import { cn } from '../../../lib/cn';
+
+interface PersonaVoiceCardProps {
+  persona: Persona;
+  data: SettingsResponse | null;
+  defaultEngine: string;
+  cloudIssueText: string | null;
+  updateTts: (patch: Partial<PersonaTts>) => void;
+}
+
+export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText, updateTts }: PersonaVoiceCardProps) {
+  const kokoroVoices = data?.tts?.kokoroVoices || [];
+  const pocketTtsVoices = data?.tts?.pocketTtsVoices || [];
+  const cloudProviders = data?.tts?.cloudProviders || ['openai', 'elevenlabs'];
+
+  const gain = persona.tts.gainDb ?? 0;
+  const gainLabel = !gain
+    ? '0 dB'
+    : `${gain > 0 ? '+' : '−'}${Math.abs(gain).toFixed(1)} dB`;
+
+  return (
+    <Card title="Voice" sub="text-to-speech engine">
+      <div className="lg:grid lg:grid-cols-2 lg:items-start lg:gap-x-8">
+        {/* LEFT — engine + the engine-specific voice selector */}
+        <div className="min-w-0">
+          <div className="field mb-3.5">
+            <Label>Engine</Label>
+            <Seg
+              value={persona.tts.engine}
+              options={ENGINES}
+              onChange={v => {
+                // The `voice` field is shared across engines but each engine
+                // validates it differently — a leftover value from the old
+                // engine (e.g. a Kokoro id like "bm_george") fails the new
+                // engine's check on save. Normalize voice to something the
+                // target engine accepts whenever the engine changes.
+                const patch: Partial<PersonaTts> = { engine: v };
+                const cur = persona.tts.voice.trim();
+                if (v === 'cloud') {
+                  const provVoices = CLOUD_VOICES[persona.tts.cloudProvider as keyof typeof CLOUD_VOICES] || [];
+                  if (!provVoices.some(pv => pv.id === cur)) {
+                    patch.voice = provVoices[0]?.id || cur;
+                  }
+                } else if (v === 'kokoro') {
+                  if (!KOKORO_RE.test(cur)) patch.voice = 'bf_isabella';
+                } else if (v === 'chatterbox') {
+                  // Empty = built-in voice; a real value must be a .wav filename.
+                  if (cur && !CHATTERBOX_VOICE_RE.test(cur)) patch.voice = '';
+                } else if (v === 'pocket-tts') {
+                  if (!POCKET_TTS_VOICE_RE.test(cur)) patch.voice = 'alba';
+                }
+                updateTts(patch);
+              }}
+            />
+            <div className="field-hint max-w-[70ch]">
+              Piper is local &amp; fast. Kokoro is more natural but slower. Chatterbox
+              clones a voice from a reference clip (local, opt-in). Cloud routes through
+              OpenAI / ElevenLabs.
+            </div>
+          </div>
+
+          {persona.tts.engine === 'piper' && (() => {
+            const piperVoices: string[] = data?.tts?.piperVoices || [];
+            const value = persona.tts.voice || CB_DEFAULT_VOICE;
+            return (
+              <div className="field max-w-[360px]">
+                <Label>Voice</Label>
+                <Select
+                  value={value}
+                  onValueChange={val => updateTts({ voice: val === CB_DEFAULT_VOICE ? '' : val })}
+                >
+                  <SelectTrigger><SelectValue placeholder="Built-in default voice" /></SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectItem value={CB_DEFAULT_VOICE}>Built-in default voice</SelectItem>
+                      {piperVoices.map(v => <SelectItem key={v} value={v}>{v}</SelectItem>)}
+                      {persona.tts.voice && !piperVoices.includes(persona.tts.voice) && (
+                        <SelectItem value={persona.tts.voice}>{persona.tts.voice} (missing)</SelectItem>
+                      )}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+                <div className="field-hint">
+                  Piper is fast, local, and keyless. Drop a voice’s <code>.onnx</code> and its{' '}
+                  <code>.onnx.json</code> manifest into <code>state/voices/</code> on the host — the
+                  same files Home Assistant uses — and they’ll show up here. Leave on the built-in
+                  default if you don’t have any.
+                </div>
+              </div>
+            );
+          })()}
+
+          {persona.tts.engine === 'kokoro' && (
+            <div className="field max-w-[320px]">
+              <Label>Kokoro voice</Label>
+              <Select
+                value={persona.tts.voice}
+                onValueChange={val => updateTts({ voice: val })}
+              >
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    {!kokoroVoices.some(v => v.id === persona.tts.voice) && (
+                      <SelectItem value={persona.tts.voice}>{persona.tts.voice}</SelectItem>
+                    )}
+                    {kokoroVoices.map(v => <SelectItem key={v.id} value={v.id}>{v.label}</SelectItem>)}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              <div className="field-hint">The kokoro-onnx voice id for this persona.</div>
+            </div>
+          )}
+
+          {persona.tts.engine === 'chatterbox' && (() => {
+            const cbVoices: string[] = data?.tts?.chatterboxVoices || [];
+            // Shared voice folder (issue #213). Default to state/voices/ when
+            // the controller advertises the new field.
+            const cbDir = 'state/voices/';
+            const cbAvailable = data?.tts?.available?.chatterbox !== false;
+            return (
+              <div className="field max-w-[360px]">
+                {!cbAvailable && (
+                  <div className="mb-2.5 border border-[var(--danger)] px-3 py-2.5 text-[11px] leading-[1.6] text-[var(--danger)]">
+                    Chatterbox isn’t currently available — it lives in the optional{' '}
+                    <code>tts-heavy</code> sidecar. Start it with{' '}
+                    <code>docker compose --profile tts-heavy up -d</code> (or set{' '}
+                    <code>COMPOSE_PROFILES=tts-heavy</code> in <code>.env</code>).
+                    This persona falls back to <strong>{defaultEngine}</strong> until
+                    it’s up.
+                  </div>
+                )}
+                <Label>Reference voice</Label>
+                <Select
+                  value={persona.tts.voice || CB_DEFAULT_VOICE}
+                  onValueChange={val => updateTts({ voice: val === CB_DEFAULT_VOICE ? '' : val })}
+                >
+                  <SelectTrigger><SelectValue placeholder="Built-in default voice" /></SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectItem value={CB_DEFAULT_VOICE}>Built-in default voice</SelectItem>
+                      {cbVoices.map(v => <SelectItem key={v} value={v}>{v}</SelectItem>)}
+                      {persona.tts.voice && !cbVoices.includes(persona.tts.voice) && (
+                        <SelectItem value={persona.tts.voice}>{persona.tts.voice} (missing)</SelectItem>
+                      )}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+                <div className="field-hint">
+                  ~5s of clean speech is enough to clone a voice. Drop WAVs into{' '}
+                  <code>{cbDir}</code> on the host and they’ll show up here.
+                  Chatterbox also voices paralinguistic tags ([laugh], [sigh], …) the
+                  DJ may insert.
+                </div>
+              </div>
+            );
+          })()}
+
+          {persona.tts.engine === 'pocket-tts' && (() => {
+            const ptAvailable = data?.tts?.available?.['pocket-tts'] !== false;
+            const customVoices: string[] = data?.tts?.pocketTtsCustomVoices || [];
+            const value = persona.tts.voice || 'alba';
+            const isBuiltin = pocketTtsVoices.some(v => v.id === value);
+            const isCustom = customVoices.includes(value);
+            // null/undefined = not yet known (sidecar still booting). Only
+            // false means the engine confirmed it can't clone (issue #238).
+            const ptCloning = data?.tts?.available?.pocketTtsCloning;
+            const usingClone = isCustom || /\.wav$/i.test(value);
+            return (
+              <div className="field max-w-[360px]">
+                {!ptAvailable && (
+                  <div className="mb-2.5 border border-[var(--danger)] px-3 py-2.5 text-[11px] leading-[1.6] text-[var(--danger)]">
+                    PocketTTS isn’t currently available — it lives in the same optional{' '}
+                    <code>tts-heavy</code> sidecar as Chatterbox. Start it with{' '}
+                    <code>docker compose --profile tts-heavy up -d</code> (or set{' '}
+                    <code>COMPOSE_PROFILES=tts-heavy</code> in <code>.env</code>).
+                    This persona falls back to <strong>{defaultEngine}</strong> until
+                    it’s up.
+                  </div>
+                )}
+                {ptAvailable && ptCloning === false && usingClone && (
+                  <div className="mb-2.5 border border-[var(--danger)] px-3 py-2.5 text-[11px] leading-[1.6] text-[var(--danger)]">
+                    Voice <strong>cloning is unavailable</strong> in this build, so this
+                    cloned voice won’t play — PocketTTS reverts to a built-in voice. The
+                    cloning model (<code>kyutai/pocket-tts</code>) is gated on Hugging Face:
+                    accept its terms, then set <code>HF_TOKEN</code> in your <code>.env</code>{' '}
+                    and restart <code>tts-heavy</code>. Built-in voices below work without a token.
+                  </div>
+                )}
+                <Label>PocketTTS voice</Label>
+                <Select
+                  value={value}
+                  onValueChange={val => updateTts({ voice: val })}
+                >
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>Built-in</SelectLabel>
+                      {pocketTtsVoices.map(v => (
+                        <SelectItem key={v.id} value={v.id}>{v.label}</SelectItem>
+                      ))}
+                    </SelectGroup>
+                    {customVoices.length > 0 && (
+                      <SelectGroup>
+                        <SelectLabel>
+                          Custom (cloned){ptCloning === false ? ' — cloning unavailable' : ''}
+                        </SelectLabel>
+                        {customVoices.map(v => (
+                          <SelectItem key={v} value={v}>{v}</SelectItem>
+                        ))}
+                      </SelectGroup>
+                    )}
+                    {!isBuiltin && !isCustom && persona.tts.voice && (
+                      // Persona references a voice that isn't currently present —
+                      // keep the value visible so a save round-trips without
+                      // rewriting, but flag it so the operator notices.
+                      <SelectGroup>
+                        <SelectLabel>Unknown</SelectLabel>
+                        <SelectItem value={persona.tts.voice}>{persona.tts.voice} (missing)</SelectItem>
+                      </SelectGroup>
+                    )}
+                  </SelectContent>
+                </Select>
+                <div className="field-hint">
+                  CPU-only, ~6× real-time. Built-in voices cover English, French, German,
+                  Italian, Spanish and Portuguese. Drop a ~5s WAV into{' '}
+                  <code>state/voices/</code> to clone a voice — it’ll appear under
+                  <em> Custom</em> on next reload (cloning needs <code>HF_TOKEN</code>; see above).
+                </div>
+              </div>
+            );
+          })()}
+
+          {persona.tts.engine === 'cloud' && (() => {
+            const isCompat = persona.tts.cloudProvider === 'openai-compatible';
+            const provVoices = CLOUD_VOICES[persona.tts.cloudProvider as keyof typeof CLOUD_VOICES] || [];
+            const voice = persona.tts.voice.trim();
+            const isPreset = provVoices.some(v => v.id === voice);
+            return (
+              <>
+                {cloudIssueText && (
+                  <div className="mb-3.5 border border-[var(--danger)] px-3 py-2.5 text-[11px] leading-[1.6] text-[var(--danger)]">
+                    <strong>This cloud voice won’t play.</strong> {cloudIssueText}{' '}
+                    Until that’s fixed, this persona falls back to <strong>{defaultEngine}</strong>.
+                  </div>
+                )}
+                <div className="stack-mobile grid grid-cols-[1fr_1fr] gap-4">
+                  <div className="field">
+                    <Label>Cloud provider</Label>
+                    <Seg
+                      value={persona.tts.cloudProvider}
+                      options={cloudProviders.map(id => ({ id, label: id }))}
+                      onChange={v => {
+                        // Switching provider invalidates the old voice id.
+                        // openai-compatible has no curated voices — leave the
+                        // field blank so the operator types their own (server
+                        // picks its default when blank).
+                        const next = v === 'openai-compatible'
+                          ? ''
+                          : (CLOUD_VOICES[v as keyof typeof CLOUD_VOICES]?.[0]?.id || persona.tts.voice);
+                        updateTts({ cloudProvider: v, voice: next });
+                      }}
+                    />
+                    <div className="field-hint">
+                      {isCompat
+                        ? 'Uses the shared base URL + model from Settings.'
+                        : 'Uses the shared API key + model from Settings.'}
+                    </div>
+                  </div>
+                  <div className="field">
+                    <Label>Cloud voice</Label>
+                    {isCompat ? (
+                      <>
+                        <Input
+                          value={persona.tts.voice}
+                          maxLength={100}
+                          placeholder="Server-specific (cloning ref or speaker id)"
+                          onChange={(e: ChangeEvent<HTMLInputElement>) => updateTts({ voice: e.target.value })}
+                        />
+                        <div className="field-hint">
+                          Server-specific — Chatterbox cloning ref name, Qwen3
+                          speaker id, etc. Leave blank to let the server pick.
+                        </div>
+                      </>
+                    ) : (
+                      <>
+                        <Select
+                          value={isPreset ? voice : '__custom__'}
+                          onValueChange={val => {
+                            // "Custom voice id…" clears the preset so isPreset flips
+                            // false and the free-text input below appears for entry.
+                            updateTts({ voice: val === '__custom__' ? '' : val });
+                          }}
+                        >
+                          <SelectTrigger><SelectValue /></SelectTrigger>
+                          <SelectContent>
+                            <SelectGroup>
+                              {provVoices.map(v => (
+                                <SelectItem key={v.id} value={v.id}>{v.label}</SelectItem>
+                              ))}
+                              <SelectItem value="__custom__">Custom voice id…</SelectItem>
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                        {!isPreset && (
+                          <Input
+                            className={cn('mt-2', voice ? 'border-ink' : 'border-[var(--danger)]')}
+                            value={persona.tts.voice}
+                            maxLength={100}
+                            placeholder="Enter a custom voice id"
+                            onChange={(e: ChangeEvent<HTMLInputElement>) => updateTts({ voice: e.target.value })}
+                          />
+                        )}
+                        <div className="field-hint">
+                          Pick a default voice, or choose <em>Custom voice id…</em> to enter your own
+                          (e.g. an OpenAI voice name or an ElevenLabs voice id).
+                        </div>
+                      </>
+                    )}
+                  </div>
+                </div>
+              </>
+            );
+          })()}
+        </div>
+
+        {/* RIGHT — voice level */}
+        <div className="field mt-3.5 max-w-[360px] lg:mt-0 lg:max-w-[460px]">
+          <div className="flex items-baseline justify-between gap-3">
+            <Label>Voice level (dB)</Label>
+            <span className="font-mono text-[15px] font-extrabold text-[var(--accent)] tabular-nums">{gainLabel}</span>
+          </div>
+          <VoiceMeter
+            value={gain}
+            onChange={v => updateTts({ gainDb: v })}
+          />
+          <div className="mt-1.5 flex justify-between text-[8px] font-bold tracking-[0.1em] text-muted tabular-nums">
+            <span>−12 dB</span>
+            <span className="-translate-x-1/2">0</span>
+            <span>+12 dB</span>
+          </div>
+          <div className="field-hint">
+            Trim this persona’s loudness on top of the engine level. <code>0 dB</code> = no change.
+            Drag the meter or use the arrow keys.
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/web/components/admin/personas/RadioOption.tsx
+++ b/web/components/admin/personas/RadioOption.tsx
@@ -1,0 +1,46 @@
+'use client';
+// Newsprint radio option used for talk-frequency and script-length pickers.
+import type { ReactNode } from 'react';
+import { cn } from '../../../lib/cn';
+
+interface RadioOptionProps {
+  active: boolean;
+  label: ReactNode;
+  desc: ReactNode;
+  onSelect: () => void;
+}
+
+export function RadioOption({ active, label, desc, onSelect }: RadioOptionProps) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        'grid cursor-pointer gap-1.5 border p-3 text-left font-[inherit]',
+        active
+          ? 'border-[var(--accent)] bg-[var(--accent-soft)]'
+          : 'border-ink bg-transparent',
+      )}
+    >
+      <div className="flex items-center gap-1.5">
+        <span
+          className={cn(
+            'size-2.5 rounded-full border',
+            active
+              ? 'border-[var(--accent)] bg-[var(--accent)]'
+              : 'border-ink bg-transparent',
+          )}
+        />
+        <span
+          className={cn(
+            'text-[11px] font-bold tracking-[0.2em] uppercase',
+            active ? 'text-vermilion' : 'text-ink',
+          )}
+        >
+          {label}
+        </span>
+      </div>
+      <div className="text-[10px] leading-[1.5] text-muted">{desc}</div>
+    </button>
+  );
+}

--- a/web/components/admin/personas/SystemPromptCard.tsx
+++ b/web/components/admin/personas/SystemPromptCard.tsx
@@ -1,0 +1,72 @@
+'use client';
+// The global system-prompt editor — one template shared by every persona.
+// Toggled from the hero.
+import type { ChangeEvent } from 'react';
+import { Card, Btn, Seg } from '../ui';
+import { Textarea } from '../../ui/textarea';
+import { cn } from '../../../lib/cn';
+import { PROMPT_MIN, PROMPT_MAX } from './constants';
+
+interface SystemPromptCardProps {
+  useCustomPrompt: boolean;
+  systemPrompt: string;
+  defaultPrompt: string;
+  promptOk: boolean;
+  promptText: string;   // trimmed
+  busy: boolean;
+  onSetUseCustom: (custom: boolean) => void;
+  onChangePrompt: (text: string) => void;
+  onRestore: () => void;
+}
+
+export function SystemPromptCard({
+  useCustomPrompt, systemPrompt, defaultPrompt, promptOk, promptText, busy,
+  onSetUseCustom, onChangePrompt, onRestore,
+}: SystemPromptCardProps) {
+  return (
+    <Card title="System prompt" sub="shared by every persona">
+      <p className="mb-2.5 max-w-[70ch] text-[12px] leading-[1.6] text-muted">
+        One template wrapped around every DJ generation, shared by all personas.
+        Placeholders: <code>{'{name}'}</code> · <code>{'{soul}'}</code> ·{' '}
+        <code>{'{station}'}</code> · <code>{'{location}'}</code> · <code>{'{language}'}</code>.
+        Most stations never touch this.
+      </p>
+      <Seg
+        value={useCustomPrompt ? 'custom' : 'default'}
+        options={[{ id: 'default', label: 'Built-in default' }, { id: 'custom', label: 'Custom' }]}
+        onChange={v => onSetUseCustom(v === 'custom')}
+      />
+      {!useCustomPrompt ? (
+        <div className="mt-3">
+          <div className="caption mb-1.5">the DJ uses this built-in template</div>
+          <pre className="term max-h-[220px]">
+            {defaultPrompt || '(default unavailable)'}
+          </pre>
+        </div>
+      ) : (
+        <div className="mt-3">
+          <Textarea
+            rows={12}
+            value={systemPrompt}
+            maxLength={PROMPT_MAX}
+            onChange={(e: ChangeEvent<HTMLTextAreaElement>) => onChangePrompt(e.target.value)}
+            className={cn(
+              'font-mono text-[12px]',
+              promptOk ? 'border-ink' : 'border-[var(--danger)]',
+            )}
+          />
+          <div className="mt-2.5 flex flex-wrap items-center gap-3">
+            <Btn onClick={onRestore} disabled={busy || !defaultPrompt}>
+              Restore default text
+            </Btn>
+            <span className={cn('caption', promptOk ? 'text-muted' : 'text-[var(--danger)]')}>
+              {promptText.length}/{PROMPT_MAX} chars
+              {!promptText.includes('{name}') && ' · missing {name}'}
+              {promptText.length > 0 && promptText.length < PROMPT_MIN && ` · min ${PROMPT_MIN}`}
+            </span>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/web/components/admin/personas/ToneKnob.tsx
+++ b/web/components/admin/personas/ToneKnob.tsx
@@ -1,0 +1,99 @@
+'use client';
+// Detented rotary knob (0–10). Pointer-draggable AND keyboard-operable
+// (role="slider" with arrow/Home/End/PageUp/Down) so it keeps the accessibility
+// the native range input had. The body is intentionally dark "physical
+// hardware" in both themes; the lit indicator and rings track --accent/--ink so
+// it reads correctly under light and dark palettes. 80px on phones, 96px md+.
+import type {
+  KeyboardEvent as ReactKeyboardEvent,
+  PointerEvent as ReactPointerEvent,
+} from 'react';
+import { cn } from '../../../lib/cn';
+import { KNOB_ROTATIONS } from './constants';
+
+interface ToneKnobProps {
+  label: string;
+  value: number;   // 0–10, integer (detented)
+  band: string;    // one-word readout for the current band
+  low: string;     // caption under the knob's low end
+  high: string;    // caption under the knob's high end
+  onChange: (v: number) => void;
+}
+
+export function ToneKnob({ label, value, band, low, high, onChange }: ToneKnobProps) {
+  const clamp = (v: number) => Math.max(0, Math.min(10, Math.round(v)));
+  const rotation = KNOB_ROTATIONS[clamp(value)] ?? 'rotate-0';
+
+  const startDrag = (e: ReactPointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.currentTarget.focus();
+    const startY = e.clientY;
+    const start = value;
+    let last = value;
+    const SENS = 14; // px of vertical travel per unit
+    const move = (ev: PointerEvent) => {
+      const next = clamp(start + (startY - ev.clientY) / SENS);
+      if (next !== last) { last = next; onChange(next); }
+    };
+    const up = () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+
+  const onKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    let next = value;
+    switch (e.key) {
+      case 'ArrowUp': case 'ArrowRight': next = clamp(value + 1); break;
+      case 'ArrowDown': case 'ArrowLeft': next = clamp(value - 1); break;
+      case 'PageUp':   next = clamp(value + 2); break;
+      case 'PageDown': next = clamp(value - 2); break;
+      case 'Home':     next = 0;  break;
+      case 'End':      next = 10; break;
+      default: return;
+    }
+    e.preventDefault();
+    if (next !== value) onChange(next);
+  };
+
+  return (
+    <div className="flex min-w-0 flex-col items-center gap-2.5">
+      {/* Stacked + centred on phones (the ~80px column can't fit label and
+          value side-by-side without truncating the label to one letter);
+          side-by-side from md up, where the column is wide enough. */}
+      <div className="flex w-full flex-col items-center gap-0.5 text-center md:flex-row md:items-baseline md:justify-between md:gap-1 md:text-left">
+        <span className="text-[12px] leading-tight font-bold md:truncate">{label}</span>
+        <span className="flex-none text-[11px] leading-tight font-bold text-[var(--accent)] tabular-nums">{value}/10 · {band}</span>
+      </div>
+      <div
+        role="slider"
+        tabIndex={0}
+        aria-label={label}
+        aria-valuemin={0}
+        aria-valuemax={10}
+        aria-valuenow={value}
+        aria-valuetext={`${value} of 10, ${band}`}
+        aria-orientation="vertical"
+        onPointerDown={startDrag}
+        onKeyDown={onKeyDown}
+        className="relative size-20 cursor-ns-resize touch-none rounded-full outline-none select-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg)] md:size-24"
+      >
+        <div className="absolute inset-0 rounded-full border border-separator-strong" />
+        <div className="absolute inset-[11px] rounded-full border border-[#0e0c0a] bg-[radial-gradient(circle_at_50%_32%,#2a2420,#161412)] shadow-[inset_0_3px_8px_rgba(0,0,0,0.55),inset_0_-2px_4px_rgba(255,255,255,0.05)] md:inset-[13px]" />
+        <div className={cn('absolute inset-[11px] flex justify-center md:inset-[13px]', rotation)}>
+          <span className="mt-[7px] h-[18px] w-[3px] rounded-[1px] bg-[var(--accent)] shadow-[0_0_6px_color-mix(in_oklab,var(--accent)_60%,transparent)]" />
+        </div>
+        <div className="absolute top-1/2 left-1/2 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#0c0a08] shadow-[inset_0_1px_2px_rgba(0,0,0,0.8)]" />
+      </div>
+      <div className="flex w-20 justify-between text-[8px] font-bold text-muted tabular-nums md:w-24">
+        <span>0</span><span>5</span><span>10</span>
+      </div>
+      <div className="flex w-full justify-between gap-1.5 text-[9px] leading-tight text-muted uppercase">
+        <span className="max-w-[48%]">{low}</span>
+        <span className="max-w-[48%] text-right">{high}</span>
+      </div>
+    </div>
+  );
+}

--- a/web/components/admin/personas/VoiceMeter.tsx
+++ b/web/components/admin/personas/VoiceMeter.tsx
@@ -1,0 +1,91 @@
+'use client';
+// LED output-trim meter (±12 dB). Pointer-draggable AND keyboard-operable
+// (role="slider"), so it keeps the accessibility the native range input had.
+// Lit cells track --accent; off-cells/centre marker track --ink so it reads in
+// both themes.
+import type {
+  KeyboardEvent as ReactKeyboardEvent,
+  PointerEvent as ReactPointerEvent,
+} from 'react';
+import { cn } from '../../../lib/cn';
+import { VOICE_CELLS } from './constants';
+
+interface VoiceMeterProps {
+  value: number;   // gain in dB
+  min?: number;
+  max?: number;
+  step?: number;
+  onChange: (v: number) => void;
+}
+
+export function VoiceMeter({ value, min = -12, max = 12, step = 0.5, onChange }: VoiceMeterProps) {
+  const span = max - min;
+  const lit = Math.round(((value - min) / span) * VOICE_CELLS);
+  const clamp = (v: number) => Math.max(min, Math.min(max, v));
+  const snap = (v: number) => Math.round(clamp(v) / step) * step;
+
+  const startDrag = (e: ReactPointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const el = e.currentTarget;
+    el.focus();
+    const rect = el.getBoundingClientRect();
+    let last = value;
+    const apply = (clientX: number) => {
+      const p = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+      const next = snap(min + p * span);
+      if (next !== last) { last = next; onChange(next); }
+    };
+    apply(e.clientX);
+    const move = (ev: PointerEvent) => apply(ev.clientX);
+    const up = () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+
+  const onKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    let next = value;
+    switch (e.key) {
+      case 'ArrowRight': case 'ArrowUp':   next = snap(value + step); break;
+      case 'ArrowLeft':  case 'ArrowDown': next = snap(value - step); break;
+      case 'PageUp':   next = snap(value + 2); break;
+      case 'PageDown': next = snap(value - 2); break;
+      case 'Home':     next = min; break;
+      case 'End':      next = max; break;
+      default: return;
+    }
+    e.preventDefault();
+    if (next !== value) onChange(next);
+  };
+
+  return (
+    <div
+      role="slider"
+      tabIndex={0}
+      aria-label="Voice level in decibels"
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-valuenow={value}
+      aria-valuetext={`${value > 0 ? '+' : ''}${value.toFixed(1)} dB`}
+      aria-orientation="horizontal"
+      onPointerDown={startDrag}
+      onKeyDown={onKeyDown}
+      className="relative mt-2.5 cursor-ew-resize touch-none py-1.5 outline-none select-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg)]"
+    >
+      <div className="flex h-[34px] items-stretch gap-[2px]">
+        {Array.from({ length: VOICE_CELLS }, (_, i) => (
+          <span
+            key={`cell-${i}`}
+            className={cn(
+              'flex-1 transition-colors',
+              i < lit ? 'bg-[var(--accent)]' : 'bg-[color-mix(in_oklab,var(--ink)_16%,transparent)]',
+            )}
+          />
+        ))}
+      </div>
+      <div className="pointer-events-none absolute top-[1px] bottom-[1px] left-1/2 w-px bg-[color-mix(in_oklab,var(--ink)_45%,transparent)]" />
+    </div>
+  );
+}

--- a/web/components/admin/personas/constants.ts
+++ b/web/components/admin/personas/constants.ts
@@ -1,0 +1,82 @@
+// Static config + tiny pure helpers for the personas editor. No React, no DOM.
+
+export const FREQUENCIES = [
+  { id: 'quiet',      label: 'Quiet',      desc: 'Talks every 8–20 tracks · station ID once an hour · weather hourly on change.' },
+  { id: 'moderate',   label: 'Moderate',   desc: 'Talks every 1–9 tracks · station IDs at :15 and :45 · weather every 30 min on change.' },
+  { id: 'aggressive', label: 'Aggressive', desc: 'Talks every 1–3 tracks · station IDs four times an hour · weather every 15 min on change.' },
+];
+export const SCRIPT_LENGTHS = [
+  { id: 'concise',  label: 'Concise',  desc: 'Standard one-to-four sentence segments. The default.' },
+  { id: 'extended', label: 'Extended', desc: 'Longer, storytelling segments — roughly double the length across intros, links, weather and idents.' },
+];
+// Personality dials, 0–10, default 5. They map to three prompt bands server-side
+// (settings.personaToneDirectives): 0–3 low, 7–10 high, 4–6 neutral (nothing
+// injected). Surfacing the band keeps operators from expecting 6 vs 7 to differ.
+// `words` is the one-word band readout shown next to the knob value, indexed by
+// toneBandIndex (low / neutral / high). The longer `low`/`high` strings caption
+// the knob's travel ends.
+export const TONE_DIALS = [
+  { id: 'humour',      label: 'Humour',       low: 'play it straight', high: 'playful & dry',  words: ['straight',  'neutral', 'playful'] },
+  { id: 'localColour', label: 'Local colour', low: 'universal',        high: 'leans local',    words: ['universal', 'neutral', 'local']   },
+  { id: 'warmth',      label: 'Warmth',       low: 'cool & dry',       high: 'warm & earnest', words: ['cool',      'neutral', 'warm']    },
+] as const;
+export const DIAL_NEUTRAL = 5;
+// Literal 0|1|2 return keeps tuple indexing into `words` precise under
+// noUncheckedIndexedAccess (no `string | undefined`).
+export const toneBandIndex = (v: number): 0 | 1 | 2 => (v <= 3 ? 0 : v >= 7 ? 2 : 1);
+
+// The knob is detented to 11 integer positions, so the rotation is a fixed
+// lookup rather than an inline transform (inline styles are forbidden in admin
+// sources — issue #50). Keeping each class a literal lets Tailwind's JIT emit
+// them. 0 → −135°, 10 → +135°: a 270° sweep.
+export const KNOB_ROTATIONS = [
+  '-rotate-[135deg]', '-rotate-[108deg]', '-rotate-[81deg]', '-rotate-[54deg]', '-rotate-[27deg]',
+  'rotate-0',
+  'rotate-[27deg]', 'rotate-[54deg]', 'rotate-[81deg]', 'rotate-[108deg]', 'rotate-[135deg]',
+] as const;
+export const VOICE_CELLS = 32;
+
+export const ENGINES = [
+  { id: 'piper',  label: 'Piper' },
+  { id: 'kokoro', label: 'Kokoro' },
+  { id: 'chatterbox', label: 'Chatterbox' },
+  { id: 'pocket-tts', label: 'PocketTTS' },
+  { id: 'cloud',  label: 'Cloud' },
+];
+// Chatterbox reference voice files are validated against this in audio/chatterbox.ts
+// — basename only, no path separators, .wav extension, conservative chars.
+export const CHATTERBOX_VOICE_RE = /^[A-Za-z0-9_.-]{1,80}\.wav$/;
+// Sentinel for the empty-string "use the built-in voice" choice — Radix Select
+// rejects an empty-string SelectItem value.
+export const CB_DEFAULT_VOICE = '__cb_default__';
+// PocketTTS voice ids — lowercase, allow underscores/hyphens (matches the
+// settings-side POCKET_TTS_VOICE_RE).
+export const POCKET_TTS_VOICE_RE = /^[a-z][a-z0-9_-]{0,39}$/;
+export const KOKORO_RE = /^[a-z]{2}_[a-z0-9]+$/;
+
+export const NAME_MAX = 40;
+export const TAGLINE_MAX = 80;
+export const SOUL_MAX = 400;
+export const LANGUAGE_MAX = 60;
+export const PROMPT_MIN = 50;
+export const PROMPT_MAX = 4000;
+export const PERSONA_MAX = 12;
+
+// 512×512 output target. The controller hard-caps the decoded image at 300 KB
+// and the JSON body at 600 KB; a center-cropped 512×512 WebP from a typical
+// phone photo lands in the tens of KB, well under both.
+export const AVATAR_TARGET_PX = 512;
+
+// DiceBear styles to roll through when the operator clicks Generate. Each
+// click picks one at random along with a fresh random seed, so re-clicking
+// produces a different face. Lorelei / notionists / personas / open-peeps are
+// illustrated humans; bottts-neutral / micah / fun-emoji add a robot/abstract
+// option so the operator can keep clicking until they land on a vibe that
+// fits the persona. All return PNG at the size we ask for, with permissive
+// CORS — the fetch can run in the browser.
+export const DICEBEAR_STYLES = [
+  'lorelei', 'notionists', 'personas', 'open-peeps',
+  'micah', 'bottts-neutral', 'fun-emoji',
+];
+
+export const API_BASE = process.env.NEXT_PUBLIC_API_URL || '/api';

--- a/web/components/admin/personas/helpers.ts
+++ b/web/components/admin/personas/helpers.ts
@@ -1,0 +1,141 @@
+// Pure-ish helpers for the personas editor: id minting, initials, avatar
+// encoding, and the validation/sanitisation used by the container on save.
+import type { Persona, SettingsResponse } from './types';
+import {
+  AVATAR_TARGET_PX, DICEBEAR_STYLES,
+  NAME_MAX, TAGLINE_MAX, SOUL_MAX, LANGUAGE_MAX,
+  KOKORO_RE, CHATTERBOX_VOICE_RE, POCKET_TTS_VOICE_RE,
+} from './constants';
+
+export function clientMintId() {
+  const b = crypto.getRandomValues(new Uint8Array(3));
+  return 'p_' + [...b].map(x => x.toString(16).padStart(2, '0')).join('');
+}
+
+export function initialsFor(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (!parts.length) return '?';
+  const first = parts[0] ?? '';
+  if (parts.length === 1) return first.slice(0, 2).toUpperCase();
+  const last = parts[parts.length - 1] ?? '';
+  return ((first[0] ?? '') + (last[0] ?? '')).toUpperCase() || '?';
+}
+
+export async function fetchDicebearAvatar(): Promise<string> {
+  const style = DICEBEAR_STYLES[Math.floor(Math.random() * DICEBEAR_STYLES.length)];
+  // Random seed so two clicks never produce the same face.
+  const seed = Math.random().toString(36).slice(2) + Date.now().toString(36);
+  const url = `https://api.dicebear.com/9.x/${style}/png?seed=${encodeURIComponent(seed)}&size=${AVATAR_TARGET_PX}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`DiceBear fetch failed (${res.status})`);
+  const blob = await res.blob();
+  return await new Promise<string>((resolve, reject) => {
+    const r = new FileReader();
+    r.onload = () => resolve(r.result as string);
+    r.onerror = () => reject(r.error || new Error('failed to read DiceBear PNG'));
+    r.readAsDataURL(blob);
+  });
+}
+
+// Resize + center-crop the operator-picked image to a square, returned as a
+// compressed (WebP, JPEG fallback) data URL ready for POSTing. Done entirely
+// client-side so we never need a server-side image library.
+export async function fileToAvatarDataUrl(file: File): Promise<string> {
+  if (!/^image\/(png|jpe?g|webp)$/.test(file.type)) {
+    throw new Error('please pick a PNG, JPEG, or WebP image');
+  }
+  if (file.size > 12 * 1024 * 1024) {
+    throw new Error('image is over 12 MB — pick something smaller');
+  }
+  const bitmap = await createImageBitmap(file);
+  try {
+    const side = Math.min(bitmap.width, bitmap.height);
+    const sx = (bitmap.width - side) / 2;
+    const sy = (bitmap.height - side) / 2;
+    const canvas = document.createElement('canvas');
+    canvas.width = AVATAR_TARGET_PX;
+    canvas.height = AVATAR_TARGET_PX;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('canvas 2d context unavailable');
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
+    ctx.drawImage(bitmap, sx, sy, side, side, 0, 0, AVATAR_TARGET_PX, AVATAR_TARGET_PX);
+    // Compressed export — an uncompressed 512×512 PNG is ~1 MB raw / ~1.33 MB
+    // base64, which blows past the controller's 600 KB JSON cap, so only tiny
+    // source images used to get through. WebP keeps a typical avatar in the
+    // tens-of-KB range and preserves transparency; JPEG is the universal
+    // fallback for the rare browser whose canvas can't emit WebP (it silently
+    // returns a data:image/png URL in that case).
+    const webp = canvas.toDataURL('image/webp', 0.85);
+    return webp.startsWith('data:image/webp')
+      ? webp
+      : canvas.toDataURL('image/jpeg', 0.85);
+  } finally {
+    bitmap.close?.();
+  }
+}
+
+export function personaValid(p: Persona): boolean {
+  if (p.name.trim().length < 1 || p.name.trim().length > NAME_MAX) return false;
+  if (p.tagline.trim().length > TAGLINE_MAX) return false;
+  if (p.soul.trim().length < 1 || p.soul.trim().length > SOUL_MAX) return false;
+  if (p.language.trim().length > LANGUAGE_MAX) return false;
+  const e = p.tts.engine;
+  if (e === 'kokoro') return KOKORO_RE.test(p.tts.voice.trim());
+  if (e === 'chatterbox') {
+    // Empty = use built-in default voice; otherwise must be a plain .wav filename.
+    const v = p.tts.voice.trim();
+    return v === '' || CHATTERBOX_VOICE_RE.test(v);
+  }
+  if (e === 'pocket-tts') {
+    // Built-in voice id, OR a .wav filename for zero-shot cloning (issue #213),
+    // OR empty for the default — matches the server-side validator in settings.ts.
+    const v = p.tts.voice.trim();
+    return v === '' || POCKET_TTS_VOICE_RE.test(v) || CHATTERBOX_VOICE_RE.test(v);
+  }
+  if (e === 'cloud') {
+    const v = p.tts.voice.trim();
+    return v.length >= 1 && v.length <= 100;
+  }
+  return true; // piper — voice ignored
+}
+
+// Coerce a persona's `voice` to a value the target engine's server-side
+// validator will accept. The `voice` field is shared across engines, so
+// switching engines can leave an incompatible value behind (e.g. a Kokoro id
+// after switching to Chatterbox). This is the last line of defence before the
+// POST — it runs regardless of UI state, so a stale form can't ship a bad save.
+export function voiceForSave(engine: string, voice: string): string {
+  if (engine === 'kokoro') return voice || 'bf_isabella';
+  if (engine === 'chatterbox') return CHATTERBOX_VOICE_RE.test(voice) ? voice : '';
+  // Built-in id or a .wav clone filename both pass through; anything else → default.
+  if (engine === 'pocket-tts') return (POCKET_TTS_VOICE_RE.test(voice) || CHATTERBOX_VOICE_RE.test(voice)) ? voice : 'alba';
+  return voice; // piper ignores voice; cloud carries its own
+}
+
+// For a cloud persona: why (if at all) its cloud voice won't actually play —
+// its provider's API key is missing. Returns a human sentence, or null when
+// the cloud voice is good to go. A persona can look fully configured here yet
+// still fall back silently; this surfaces that gap before it airs.
+export function cloudIssue(persona: Persona | undefined, data: SettingsResponse | null): string | null {
+  if (persona?.tts?.engine !== 'cloud') return null;
+  // openai-compatible has no env-key convention — the persona's baseUrl +
+  // model live globally on settings.tts.cloud and are validated there. Trust
+  // that the server is configured if the persona picked this provider.
+  if (persona.tts.cloudProvider === 'openai-compatible') return null;
+  const envKey = persona.tts.cloudProvider === 'elevenlabs'
+    ? 'ELEVENLABS_API_KEY' : 'OPENAI_API_KEY';
+  if (data?.env && !data.env[envKey]) {
+    return `${envKey} is not set in .env.`;
+  }
+  return null;
+}
+
+// One-line voice summary for the active strip / roster cards.
+export function engineLabel(p: Persona): string {
+  if (p.tts.engine === 'kokoro') return `kokoro / ${p.tts.voice.trim() || '—'}`;
+  if (p.tts.engine === 'chatterbox') return `chatterbox / ${p.tts.voice.trim() || 'built-in'}`;
+  if (p.tts.engine === 'pocket-tts') return `pocket-tts / ${p.tts.voice.trim() || 'alba'}`;
+  if (p.tts.engine === 'cloud') return `cloud / ${p.tts.cloudProvider} / ${p.tts.voice.trim() || '—'}`;
+  return `piper / ${p.tts.voice.trim() || 'built-in'}`;
+}

--- a/web/components/admin/personas/types.ts
+++ b/web/components/admin/personas/types.ts
@@ -1,0 +1,80 @@
+// Shared types for the personas editor (/admin/personas). Split out of
+// PersonasPanel so the presentational sub-components can share one shape.
+
+export interface PersonaTts {
+  engine: 'piper' | 'kokoro' | 'chatterbox' | 'pocket-tts' | 'cloud' | string;
+  cloudProvider: string;
+  voice: string;
+  // Per-persona voice-level trim in dB (−12..+12, default 0 = no change). Stacks
+  // on top of the per-engine gain. See controller settings.ts:clampTtsGain.
+  gainDb: number;
+}
+
+export interface Persona {
+  id: string;
+  name: string;
+  tagline: string;
+  frequency: string;
+  scriptLength: string;
+  // When true the persona behaves like a working DJ — back-announces AND teases
+  // what's next, runs callbacks across the session, and is more present. Off =
+  // the historical tasteful-narrator behaviour.
+  djMode: boolean;
+  // Tone dials, 0–10, default 5 (neutral). Map to prompt bands server-side.
+  humour: number;
+  localColour: number;
+  warmth: number;
+  soul: string;
+  // Free-text on-air language ("Turkish", "Türkçe"). Empty = English (no
+  // directive injected server-side).
+  language: string;
+  // Stored basename like `p_abc123.png` — empty when no avatar is uploaded.
+  // The actual image is served via /api/persona-avatar/<id>; we keep the
+  // basename in state only so the form round-trips it on save.
+  avatar: string;
+  tts: PersonaTts;
+  skills: string[];
+}
+
+export interface FormState {
+  personas: Persona[];
+  activePersonaId: string;
+  useCustomPrompt: boolean;
+  systemPrompt: string;
+}
+
+export interface SkillCatalogEntry {
+  name: string;
+  label?: string;
+  description?: string;
+}
+
+export interface VoiceOption {
+  id: string;
+  label: string;
+}
+
+export interface SettingsResponse {
+  values?: {
+    personas?: Array<Partial<Persona> & { avatar?: string }>;
+    activePersonaId?: string;
+    djPrompt?: string;
+    tts?: { defaultEngine?: string };
+  };
+  defaults?: { djPrompt?: string };
+  skills?: { catalog?: SkillCatalogEntry[] };
+  tts?: {
+    kokoroVoices?: VoiceOption[];
+    piperVoices?: string[];
+    chatterboxVoices?: string[];
+    // `voiceDir` is the new shared name (issue #213). `chatterboxVoiceDir` is
+    // kept as an alias so the UI keeps working against older controllers.
+    voiceDir?: string;
+    chatterboxVoiceDir?: string;
+    pocketTtsVoices?: VoiceOption[];
+    pocketTtsCustomVoices?: string[];
+    available?: Record<string, boolean>;
+    cloudProviders?: string[];
+  };
+  env?: Record<string, unknown>;
+}

--- a/web/components/admin/ui.tsx
+++ b/web/components/admin/ui.tsx
@@ -136,7 +136,10 @@ export function Seg({ value, options, accent, onChange }: SegProps) {
       type="single"
       value={value}
       onValueChange={(v: string) => { if (v && onChange) onChange(v); }}
-      className="inline-flex flex-wrap gap-0 border border-ink"
+      // w-fit/max-w-full keep the control hugging its tabs: a parent flex/grid
+      // `.field` (align-items:stretch) would otherwise stretch this inline-flex
+      // to full width, leaving dead bordered space to the right of the tabs.
+      className="inline-flex w-fit max-w-full flex-wrap gap-0 border border-ink"
     >
       {options.map((o, i) => (
         <ToggleGroupItem


### PR DESCRIPTION
## What

A redesign + refactor of the **/admin/personas** editor.

### Refactor
Splits the ~1,700-line `PersonasPanel.tsx` into a slim stateful **container** (401 lines — fetch / form / validation / save / avatar mutations) plus a focused `components/admin/personas/` module:

- data: `types.ts`, `constants.ts`, `helpers.ts`
- controls: `ToneKnob`, `VoiceMeter`, `RadioOption`, `PersonaAvatarPicker`
- UI: `PersonaHero`, `SystemPromptCard`, `PersonaRoster`, `PersonaIdentityCard`, `PersonaBehaviorCard`, `PersonaVoiceCard`, `PersonaSkillsCard`, `PersonaEditor`

Children are presentational (props in, callbacks out); the container is the only stateful piece. Route import path is unchanged.

### Redesign
- **Tone dials → detented rotary knobs**; **per-persona voice level → LED meter**. Both are pointer- and keyboard-operable (`role="slider"` with arrows / Home / End / PageUp-Down) and theme-aware. Knobs shrink to 80px on phones with stacked labels.
- **Roster moved below the hero** as a full-width selectable card strip (avatar + name + tagline + badges, wraps 2→3→4→5 cols). Initials-behind-image avatar placeholders; `min-w-0` + truncation so content never overlaps; light inactive background, accent-soft for the card being edited.
- **Editor is full-width**: Identity / Behaviour / Voice / Skills cards use 2-column layouts on `lg+`, so the wide editor fills the space (fixes the empty right-half of the Voice card).
- `Seg` control hugs its tabs (`w-fit`) instead of stretching with dead bordered space.

## Not changed
No change to the persona **data model, validation, avatar endpoints, or the `/settings` save payload** — logic was moved verbatim. Behaviour is identical; this is a structural + presentational change.

## Verification
- `npm run lint` (eslint + `tsc --noEmit`) green — the merge gate.
- Manually verified on a local dev stack at desktop (1500px) and phone (390px): roster wraps/selects with no overlap, editor full-width with no dead space, knobs 80px on phone, no horizontal overflow, save/validation/avatars work.

Design notes: `docs/superpowers/specs/2026-06-22-personas-panel-refactor-design.md`.