### PR TITLE
chore(admin): humanize panel copy

### DIFF
--- a/web/components/admin/AiFill.tsx
+++ b/web/components/admin/AiFill.tsx
@@ -61,7 +61,7 @@ export function AiFill<T = unknown>({
   return (
     <div className="flex flex-col gap-2 border border-soft-border bg-overlay/40 p-3">
       <span className="field-hint">
-        Describe what you want — we&apos;ll draft the fields, then you can edit before saving.
+        Describe what you want. We&apos;ll draft the fields, then you can edit before saving.
       </span>
       <Textarea
         rows={2}

--- a/web/components/admin/ArchivesPanel.tsx
+++ b/web/components/admin/ArchivesPanel.tsx
@@ -127,7 +127,7 @@ export default function ArchivesPanel() {
           </div>
           <div className="mt-1 text-[11px] leading-[1.6] text-muted">
             Liquidsoap writes one MP3 per clock hour into <code>state/archive/</code>.
-            They&rsquo;re kept until the operator deletes them — there is no automatic rotation,
+            They&rsquo;re kept until the operator deletes them. There is no automatic rotation,
             so keep an eye on disk if the station runs 24/7.
           </div>
         </div>

--- a/web/components/admin/BackupPanel.tsx
+++ b/web/components/admin/BackupPanel.tsx
@@ -113,7 +113,7 @@ export default function BackupPanel() {
           <div className="mt-1 text-[11px] leading-[1.6] text-muted">
             One zip with your personas, DJ prompt, LLM/TTS settings, shows &amp; schedule,
             the mood/tag database, and operator media (jingles, SFX, voices, themes, skills).
-            API keys are <strong>redacted</strong> — the file is safe to store and share, and a
+            API keys are <strong>redacted</strong>, so the file is safe to store and share, and a
             restore never wipes the keys already set on the target station. Navidrome
             credentials and Icecast secrets are host-specific and stay put.
           </div>
@@ -148,7 +148,7 @@ export default function BackupPanel() {
             {result.restored?.length ? result.restored.join(', ') : '(nothing)'}
             {result.requiresRestart && (
               <div className="mt-2 flex items-center gap-2">
-                <span className="text-muted">Mixer settings changed — restart to apply.</span>
+                <span className="text-muted">Mixer settings changed. Restart to apply.</span>
                 <Btn sm tone="danger" onClick={restartMixer} disabled={restarting}>
                   {restarting ? 'Restarting…' : 'Restart mixer'}
                 </Btn>

--- a/web/components/admin/DashPanel.tsx
+++ b/web/components/admin/DashPanel.tsx
@@ -359,7 +359,7 @@ export default function DashPanel() {
       });
       const j = (await r.json().catch(() => ({}))) as ActResponse;
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      notify.ok(j.spoken ? `on air: “${j.spoken}”` : `${label} — done`);
+      notify.ok(j.spoken ? `on air: “${j.spoken}”` : `${label} done`);
       return j;
     } catch (e) {
       notify.err(`${label}: ${errorMessage(e)}`);
@@ -450,7 +450,7 @@ export default function DashPanel() {
         <div className="grid grid-rows-[auto_1fr] gap-4">
           <Card title="Queue" sub={`${upcoming.length} upcoming`} bodyClass="px-3.5 py-1">
             {upcoming.length === 0 ? (
-              <div className="py-2.5 text-muted italic">queue empty — auto-playlist fallback</div>
+              <div className="py-2.5 text-muted italic">queue empty, auto-playlist fallback</div>
             ) : (
               upcoming.slice(0, 8).map((t, i) => (
                 <div className="track-row" key={i}>
@@ -512,7 +512,7 @@ export default function DashPanel() {
               placeholder={
                 sayMode === 'raw'
                   ? 'Exact words the DJ will speak, verbatim…'
-                  : 'An instruction or topic — the DJ writes it in persona…'
+                  : 'An instruction or topic. The DJ writes it in persona…'
               }
             />
             <div className="mt-2.5 flex flex-wrap items-center gap-3.5">
@@ -607,7 +607,7 @@ export default function DashPanel() {
         }
       >
         {connErr ? (
-          <div className="text-muted italic">can’t reach Icecast admin — {connErr}</div>
+          <div className="text-muted italic">can’t reach Icecast admin: {connErr}</div>
         ) : !conns ? (
           <div className="text-muted italic">loading…</div>
         ) : conns.connections.length === 0 ? (
@@ -647,7 +647,7 @@ export default function DashPanel() {
                       {c.connections && c.connections > 1 ? (
                         <span
                           className="ml-1.5 text-[10px] font-bold text-muted"
-                          title={`${c.connections} connections — Safari opens 2 sockets per listener`}
+                          title={`${c.connections} connections (Safari opens 2 sockets per listener)`}
                         >
                           ×{c.connections}
                         </span>
@@ -818,7 +818,7 @@ function RequestsCard({
       }
     >
       {err ? (
-        <div className="text-muted italic">can’t load requests — {err}</div>
+        <div className="text-muted italic">can’t load requests: {err}</div>
       ) : !requests ? (
         <div className="text-muted italic">loading…</div>
       ) : requests.length === 0 ? (

--- a/web/components/admin/DebugPanel.tsx
+++ b/web/components/admin/DebugPanel.tsx
@@ -463,7 +463,7 @@ function TtsRouting({ tts }: { tts: DebugTts }) {
         </span>
       </div>
       {fellBack && (
-        <V3Alert tone="error" title={`Cloud voice unavailable — speaking via ${s.engine}`}>
+        <V3Alert tone="error" title={`Cloud voice unavailable, speaking via ${s.engine}`}>
           This persona is set to <strong>{s.requested}</strong> TTS, but it isn’t usable
           (switched off, or the provider’s API key is missing). Spoken segments are coming
           out of <strong>{s.engine}</strong> instead. Fix it in Settings → TTS voice.
@@ -673,7 +673,7 @@ function DjContext({ ctx }: { ctx?: DebugContext | null }) {
             {activeShow.persona?.name ? <span className="text-muted"> · {activeShow.persona.name}</span> : null}
           </>
         ) : (
-          <span className="text-muted italic">autonomous — no show scheduled</span>
+          <span className="text-muted italic">autonomous, no show scheduled</span>
         )}
       </dd>
       <dt>Listeners</dt>

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -586,7 +586,7 @@ export default function LibraryPanel() {
       });
       const j = await r.json().catch(() => ({})) as { error?: string };
       if (!r.ok) throw new Error(j.error || `reconcile failed (${r.status})`);
-      notify.ok('reconcile started — scanning Navidrome');
+      notify.ok('reconcile started, scanning Navidrome');
       setLogOpen(true);
       await loadTagger();
     } catch (err) {
@@ -1036,9 +1036,9 @@ function TrackTable(p: TrackTableProps) {
   if (p.rows.length === 0) {
     return (
       <div className="px-4 py-10 text-center text-[12px] text-muted italic">
-        {p.tab === 'browse' && 'no tracks match — try clearing some filters'}
+        {p.tab === 'browse' && 'no tracks match, try clearing some filters'}
         {p.tab === 'search' && 'search your library to queue a track on demand'}
-        {p.tab === 'untagged' && 'every track is tagged — nice'}
+        {p.tab === 'untagged' && 'every track is tagged, nice'}
         {p.tab === 'recent' && 'nothing here yet'}
       </div>
     );

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -219,7 +219,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
         </h1>
         <p className="lib-hero-sub">
           The DJ reads each track&rsquo;s <b>mood</b> and <b>energy</b> to pick the right song for
-          the moment — new tracks need tagging before they go on air.
+          the moment. New tracks need tagging before they go on air.
         </p>
       </div>
 
@@ -244,7 +244,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
           </div>
           {embeddingMissing && (
             <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 border border-[color-mix(in_oklab,var(--accent)_30%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] text-ink">
-              <span><b>Embeddings missing.</b> Your embedding model may have changed — re-embed to restore similarity-based picks.</span>
+              <span><b>Embeddings missing.</b> Your embedding model may have changed. Re-embed to restore similarity-based picks.</span>
               <button
                 type="button"
                 className="font-bold text-vermilion underline-offset-2 hover:underline"
@@ -330,11 +330,11 @@ export default function TaggingPanel(p: TaggingPanelProps) {
           <div className="caption !tracking-[0.04em] !normal-case">
             {(progress && PHASE_HINT[progress.phase]) ||
               (p.tagger?.mode === 'analyze'
-                ? 'The analysis engine is listening to each track — measuring tempo and key, and fingerprinting how it sounds.'
+                ? 'The analysis engine is listening to each track: measuring tempo and key, and fingerprinting how it sounds.'
                 : p.tagger?.mode === 'reconcile'
                   ? 'Checking every track against Navidrome and removing entries for files that no longer exist.'
                   : 'The DJ is listening to each new track and deciding its mood & energy.')}
-            {' '}You can keep browsing — this runs in the background.
+            {' '}You can keep browsing. This runs in the background.
           </div>
         </div>
       )}
@@ -373,7 +373,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
             </span>
             <span className="caption basis-full !tracking-[0.04em] !normal-case">
               {analysisOff
-                ? 'No analysis engine running — start the tts-heavy sidecar (docker compose --profile tts-heavy up -d) or configure a local librosa venv.'
+                ? 'No analysis engine running. Start the tts-heavy sidecar (docker compose --profile tts-heavy up -d) or configure a local librosa venv.'
                 : 'Improves beat-matching between tracks; tagging works fine without it.'}
             </span>
           </div>
@@ -390,7 +390,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
                   ? 'engine missing CLAP'
                   : audioOn
                     ? <>{num(audioEmbedded)} / {num(total)} · {audpct != null ? `${audpct}%` : '…'}</>
-                    : p.audioEnabled ? 'enabled — not yet analysed' : 'off'}
+                    : p.audioEnabled ? 'enabled, not yet analysed' : 'off'}
             </span>
             {!analysisOff && p.audioEnabled != null && (
               <span className="flex items-center gap-2">
@@ -431,7 +431,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
 
           <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1.5 border-t border-dashed border-separator-strong pt-3.5">
             <span className="max-w-[64ch] text-[12px] leading-[1.55] text-muted">
-              <b className="text-ink">Re-scan</b> — only needed after changing the LLM, embedding model, or analysis
+              <b className="text-ink">Re-scan.</b> Only needed after changing the LLM, embedding model, or analysis
               engine. Pick the passes to redo (tick all for a full rebuild); existing mood tags are kept as seeds.
             </span>
             <button
@@ -449,7 +449,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
             <Pass on={!!passes.reEnrich} onClick={() => togglePass('reEnrich')} name="Re-enrich metadata"
               hint="Re-fetch Last.fm tags + lyrics that feed the tagging." />
             <Pass on={!!passes.reAnalyze} onClick={() => togglePass('reAnalyze')} name="Re-analyse acoustics"
-              hint="Redo BPM / key for every track — also refreshes sounds-like fingerprints when enabled." />
+              hint="Redo BPM / key for every track. Also refreshes sounds-like fingerprints when enabled." />
             <Pass on={!!passes.upgrade} onClick={() => togglePass('upgrade')} name="Re-decide moods"
               hint="Re-tag tracks whose prompt or model is now stale." />
           </div>
@@ -464,7 +464,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
       {/* log drawer — reuses the theme-aware .term surface */}
       {p.logOpen && (
         <pre ref={logRef} className="term m-0 max-h-56 overflow-y-auto !border-t !border-l-0 border-separator-strong">
-          {(p.tagger?.lastLog || []).join('\n') || '(no log output yet — start a tagging run to see the booth think)'}
+          {(p.tagger?.lastLog || []).join('\n') || '(no log output yet, start a tagging run to see the booth think)'}
         </pre>
       )}
 

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -153,7 +153,7 @@ export default function PersonasPanel() {
     // the entry tucked at the end of the roster.
     scrollToEditorRef.current = true;
     setFocusIdx(newIdx);
-    notify.ok('New persona added — fill in its details, then Save persona.');
+    notify.ok('New persona added. Fill in its details, then Save persona.');
   };
   const removePersona = (i: number) =>
     setForm(f => {
@@ -286,7 +286,7 @@ export default function PersonasPanel() {
       });
       const j = (await r.json().catch(() => ({}))) as { error?: string };
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      notify.ok('personas saved — applies on the next spoken line');
+      notify.ok('personas saved, applies on the next spoken line');
       await load();
     } catch (e) {
       notify.err(errorMessage(e));

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -52,15 +52,15 @@ const LLM_ENV_VARS: Record<string, string> = {
 };
 
 const LLM_PROVIDER_LABELS: Record<string, string> = {
-  ollama: 'Ollama — local/cloud',
-  locca: 'locca — local llama.cpp (host)',
-  'openai-compatible': 'OpenAI-compatible — llama.cpp, vLLM, LM Studio',
-  anthropic: 'Anthropic — Claude',
-  openai: 'OpenAI — GPT',
-  google: 'Google — Gemini',
+  ollama: 'Ollama (local/cloud)',
+  locca: 'locca (local llama.cpp, host)',
+  'openai-compatible': 'OpenAI-compatible (llama.cpp, vLLM, LM Studio)',
+  anthropic: 'Anthropic (Claude)',
+  openai: 'OpenAI (GPT)',
+  google: 'Google (Gemini)',
   deepseek: 'DeepSeek',
-  openrouter: 'OpenRouter — multi-vendor aggregator',
-  gateway: 'Vercel AI Gateway — multi-vendor aggregator',
+  openrouter: 'OpenRouter (multi-vendor aggregator)',
+  gateway: 'Vercel AI Gateway (multi-vendor aggregator)',
 };
 
 const llmProviderLabel = (id: string | undefined): string =>
@@ -90,8 +90,8 @@ const EMBED_MODEL_SUGGESTIONS: Record<string, { id: string; dim: number }[]> = {
 };
 
 const SEARCH_PROVIDER_LABELS: Record<string, string> = {
-  duckduckgo: 'DuckDuckGo — free, no key',
-  tavily: 'Tavily — paid web search',
+  duckduckgo: 'DuckDuckGo (free, no key)',
+  tavily: 'Tavily (paid web search)',
 };
 
 const searchProviderLabel = (id: string | undefined): string =>
@@ -494,7 +494,7 @@ export default function SettingsPanel() {
       const j = (await r.json().catch(() => ({}))) as { error?: string; requiresRestart?: boolean };
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
       if (j.requiresRestart) setPendingRestart(true);
-      notify.ok(j.requiresRestart ? 'saved — restart the mixer to apply' : 'saved');
+      notify.ok(j.requiresRestart ? 'saved, restart the mixer to apply' : 'saved');
       await refresh();
     } catch (e) {
       notify.err(errorMessage(e));
@@ -508,7 +508,7 @@ export default function SettingsPanel() {
       const j = (await r.json().catch(() => ({}))) as { error?: string };
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
       setPendingRestart(false);
-      notify.ok('mixer restarting — give it a few seconds');
+      notify.ok('mixer restarting, give it a few seconds');
     } catch (e) {
       notify.err(errorMessage(e));
     } finally { setBusy(false); }
@@ -520,7 +520,7 @@ export default function SettingsPanel() {
       const r = await adminFetch('/stream-stop', { method: 'POST' });
       const j = (await r.json().catch(() => ({}))) as { error?: string };
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      notify.ok('stream stopped — station is off air');
+      notify.ok('stream stopped, station is off air');
       await refresh();
     } catch (e) {
       notify.err(errorMessage(e));
@@ -533,7 +533,7 @@ export default function SettingsPanel() {
       const r = await adminFetch('/stream-start', { method: 'POST' });
       const j = (await r.json().catch(() => ({}))) as { error?: string };
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      notify.ok('stream started — station is on air');
+      notify.ok('stream started, station is on air');
       await refresh();
     } catch (e) {
       notify.err(errorMessage(e));
@@ -820,7 +820,7 @@ export default function SettingsPanel() {
                   </div>
                   <div className="field-hint">
                     Seconds of overlap between tracks (current: {data?.values?.crossfadeDuration}s).
-                    Saving flags a pending restart — apply it with the Mixer card below.
+                    Saving flags a pending restart. Apply it with the Mixer card below.
                   </div>
                 </div>
               </Card>
@@ -859,7 +859,7 @@ export default function SettingsPanel() {
                     </div>
                     <div className="field-hint">
                       The archive runs a second MP3 encoder 24/7 and is the biggest constant
-                      CPU cost in the broadcast container — turn it off if you don't replay
+                      CPU cost in the broadcast container. Turn it off if you don't replay
                       the hourly tapes (issue #137).
                     </div>
                   </div>
@@ -910,7 +910,7 @@ export default function SettingsPanel() {
             )}
 
             {form && (
-              <Card title="Opus stream" sub="/stream.opus — Ogg-Opus 96 kbps">
+              <Card title="Opus stream" sub="/stream.opus (Ogg-Opus 96 kbps)">
                 <div className="field">
                   <div className="flex items-center gap-2">
                     <Label>Serve the secondary Opus mount</Label>
@@ -944,7 +944,7 @@ export default function SettingsPanel() {
                     Firefox stay on the universal MP3 mount); for them it&apos;s equal-or-better
                     quality at ~half the bandwidth, but it adds a continuous second encoder + a
                     44.1→48 kHz resample. Turn it on if you have Chrome/Edge listeners and want
-                    the bandwidth saving — the mandatory <code>/stream.mp3</code> mount serves
+                    the bandwidth saving. The mandatory <code>/stream.mp3</code> mount serves
                     everyone either way.
                   </div>
                 </div>
@@ -983,7 +983,7 @@ export default function SettingsPanel() {
         open={confirmStop}
         onOpenChange={setConfirmStop}
         title="Stop stream"
-        description="Take the station off air? The Icecast mount disconnects — every current listener is dropped and new listeners get nothing until you start the stream again."
+        description="Take the station off air? The Icecast mount disconnects. Every current listener is dropped and new listeners get nothing until you start the stream again."
         confirmLabel="stop stream"
         danger
         onConfirm={stopStream}
@@ -1114,7 +1114,7 @@ function KeyStatus({ envVar, present }: KeyStatusProps) {
         </span>
         <span className="text-[11px] leading-[1.5] text-muted">
           {present ? (
-            <>The controller has <code>{envVar}</code> set — this provider is ready to use.</>
+            <>The controller has <code>{envVar}</code> set, so this provider is ready to use.</>
           ) : (
             <>
               Set <code>{envVar}</code> in <code>.env</code> and restart the controller.
@@ -1219,7 +1219,7 @@ function HeavyEngineSetupGuide({ engine, buildArg }: { engine: 'Chatterbox' | 'P
       <p className="mt-2 text-[11px] leading-[1.55] text-muted">
         {engine} is a heavy PyTorch engine, so the controller image doesn’t carry it.
         It ships in the optional <code>tts-heavy</code> sidecar. Until that’s running,
-        every segment routed here <strong>falls back to Piper</strong> — the DJ never
+        every segment routed here <strong>falls back to Piper</strong>. The DJ never
         goes silent, it just won’t use this voice.
       </p>
 
@@ -1242,7 +1242,7 @@ function HeavyEngineSetupGuide({ engine, buildArg }: { engine: 'Chatterbox' | 'P
         </li>
         <li>
           Give it ~30 s to pull the model and pass its health check, then reload this
-          page — the warning clears once the controller can reach the sidecar.
+          page. The warning clears once the controller can reach the sidecar.
         </li>
       </ol>
 
@@ -1335,21 +1335,21 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
 
   let activeDetail: ReactNode = null;
   if (savedEngine === 'piper') {
-    activeDetail = <>Bundled — no key, no config. Always the safe fallback.</>;
+    activeDetail = <>Bundled, no key, no config. Always the safe fallback.</>;
   } else if (savedEngine === 'kokoro') {
     activeDetail = <>Voice <code>{savedKokoroVoice || '—'}</code>. Falls back to Piper if the model isn’t loaded.</>;
   } else if (savedEngine === 'chatterbox') {
     activeDetail = <>
-      Reference <code>{savedChatterboxVoice || 'built-in'}</code> — voice cloning + paralinguistic tags. Falls back to Piper if the worker isn’t installed.
+      Reference <code>{savedChatterboxVoice || 'built-in'}</code>, with voice cloning + paralinguistic tags. Falls back to Piper if the worker isn’t installed.
     </>;
   } else if (savedEngine === 'pocket-tts') {
     activeDetail = <>
-      Voice <code>{savedPocketTtsVoice || 'alba'}</code> — CPU-only, ~6× real-time, multilingual built-in voices. Falls back to Piper if the worker isn’t installed.
+      Voice <code>{savedPocketTtsVoice || 'alba'}</code>. CPU-only, ~6× real-time, multilingual built-in voices. Falls back to Piper if the worker isn’t installed.
     </>;
   } else if (savedEngine === 'cloud') {
     activeDetail = <>
       {savedCloud.provider || '—'} · model <code>{savedCloud.model || '—'}</code>
-      {savedCloud.voice ? <> · voice <code>{savedCloud.voice}</code></> : null}
+      {savedCloud.voice ? <> · voice <code>{savedCloud.voice}</code></> : null}.
     </>;
   }
   const savedEngineMissing = available[savedEngine] === false;
@@ -1360,7 +1360,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
         eyebrow="tts voice"
         title="Pick a voice engine, then configure it."
         sub={<>
-          Every spoken segment is voiced by the <strong>persona on air</strong> — set each
+          Every spoken segment is voiced by the <strong>persona on air</strong>. Set each
           persona’s engine and voice on the Personas page. Here you pick the station’s
           default engine (used for jingles and as the fallback) and configure whichever
           one you choose.
@@ -1382,9 +1382,9 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
                 Default engine now · {savedEngineLabel}
               </span>
               <span className="text-[11px] leading-[1.5] text-muted">
-                {activeDetail} — {ttsDirty ? 'Your edits below aren’t live until you Save.' : 'This is the saved, running config.'}
+                {activeDetail} {ttsDirty ? 'Your edits below aren’t live until you Save.' : 'This is the saved, running config.'}
                 {savedEngineMissing && (
-                  <span className="text-[var(--danger)]"> This engine isn’t installed in this build — segments fall back to Piper. See the setup steps below.</span>
+                  <span className="text-[var(--danger)]"> This engine isn’t installed in this build, so segments fall back to Piper. See the setup steps below.</span>
                 )}
               </span>
             </div>
@@ -1403,8 +1403,8 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
             />
             <div className="field-hint">
               {ttsDirty
-                ? <>Engine changed — hit “Save TTS settings” below to make <strong>{formEngineLabel}</strong> the new default.</>
-                : <>The station default — renders jingles and is the fallback when a persona’s own engine fails. Per-segment voice still comes from the persona on air.</>}
+                ? <>Engine changed. Hit “Save TTS settings” below to make <strong>{formEngineLabel}</strong> the new default.</>
+                : <>The station default. Renders jingles and is the fallback when a persona’s own engine fails. Per-segment voice still comes from the persona on air.</>}
             </div>
           </div>
 
@@ -1412,7 +1412,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
           <>
             <div className="field mt-4">
               <div className="field-hint">
-                Piper is bundled with the controller — fast, lightweight, and always
+                Piper is bundled with the controller: fast, lightweight, and always
                 available. Nothing else to configure.
               </div>
             </div>
@@ -1426,7 +1426,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
               <Label>Kokoro voice</Label>
               {available.kokoro === false && (
                 <div className="field-hint text-[var(--danger)]">
-                  Kokoro is not installed in this build — it will fall back to Piper.
+                  Kokoro is not installed in this build, so it will fall back to Piper.
                 </div>
               )}
               {(data.tts?.kokoroVoices?.length || 0) > 0 ? (
@@ -1494,7 +1494,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
                   No reference voices found in{' '}
                   <code>state/voices/</code>{' '}
                   (legacy <code>state/chatterbox-voices/</code> also empty). The engine will
-                  use its built-in default voice — drop a 5-second WAV into that directory
+                  use its built-in default voice. Drop a 5-second WAV into that directory
                   to enable cloning.
                 </div>
               )}
@@ -1579,7 +1579,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
                   Any OpenAI-compatible TTS server (Chatterbox, Qwen3 TTS,
                   VibeVoice, …) that exposes <code>/v1/audio/speech</code>,
                   including the <code>/v1</code> suffix. Must be reachable from the
-                  controller container — use the host’s LAN or Tailscale IP, not
+                  controller container. Use the host’s LAN or Tailscale IP, not
                   <code>127.0.0.1</code>.
                 </div>
               </div>
@@ -1600,7 +1600,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
                 />
                 <div className="field-hint">
                   {isCompat
-                    ? <>Model id exactly as the server reports it at <code>/v1/models</code> — required.</>
+                    ? <>Model id exactly as the server reports it at <code>/v1/models</code>, required.</>
                     : <>e.g. “gpt-4o-mini-tts” (OpenAI) or “eleven_flash_v2_5” (ElevenLabs).</>}
                 </div>
               </div>
@@ -1621,7 +1621,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
                         }
                       />
                       <div className="field-hint">
-                        Server-specific — Chatterbox cloning ref name, Qwen3
+                        Server-specific: Chatterbox cloning ref name, Qwen3
                         speaker id, etc. Leave blank to let the server pick its
                         own default.
                       </div>
@@ -1676,8 +1676,8 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
             )}
             {isCompat && (
               <div className="field-hint mt-3.5">
-                Most self-hosted servers accept any non-empty API key — no env
-                var required.
+                Most self-hosted servers accept any non-empty API key, so no env
+                var is required.
               </div>
             )}
             <TtsGainField engineId="cloud" form={form} setForm={setForm} />
@@ -1739,7 +1739,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
       <SectionHeader
         eyebrow="llm provider"
         title="The model that writes scripts and picks tracks."
-        sub="Ollama runs on the homelab box and needs no key; the cloud providers are opt-in. Switching here reroutes every LLM call — no redeploy."
+        sub="Ollama runs on the homelab box and needs no key; the cloud providers are opt-in. Switching here reroutes every LLM call, no redeploy."
         metrics={[{ n: String((data.llm?.providers || []).length), l: 'providers' }]}
         manualHref="/manual/llm"
       />
@@ -1754,7 +1754,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
               </span>
               <span className="text-[11px] leading-[1.5] text-muted">
                 {activeModel
-                  ? <>Model <code>{activeModel}</code> — every LLM call goes here. {llmDirty ? 'Your edits below aren’t live until you Save.' : 'This is the saved, running config.'}</>
+                  ? <>Model <code>{activeModel}</code>, every LLM call goes here. {llmDirty ? 'Your edits below aren’t live until you Save.' : 'This is the saved, running config.'}</>
                   : <>No model is set for this provider yet.</>}
               </span>
             </div>
@@ -1780,8 +1780,8 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
             </Select>
             <div className="field-hint">
               {llmDirty
-                ? 'Provider changed — hit “Save LLM provider” below to route every call here.'
-                : 'The provider every LLM call routes through. Switching reroutes instantly on save — no redeploy.'}
+                ? 'Provider changed. Hit “Save LLM provider” below to route every call here.'
+                : 'The provider every LLM call routes through. Switching reroutes instantly on save, no redeploy.'}
             </div>
           </div>
 
@@ -1815,8 +1815,8 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
                       : form.llm.provider === 'deepseek'
                         ? 'DeepSeek model id. Leave blank for the “deepseek-v4-flash” default.'
                         : form.llm.provider === 'openai-compatible' || form.llm.provider === 'locca'
-                          ? 'Model id exactly as the server reports it at /v1/models — required.'
-                          : 'Model id for the chosen provider — required.'}
+                          ? 'Model id exactly as the server reports it at /v1/models, required.'
+                          : 'Model id for the chosen provider, required.'}
             </div>
           </div>
 
@@ -1834,7 +1834,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
               <div className="field-hint">
                 Any OpenAI-compatible server (llama.cpp, vLLM, LM Studio…),
                 including the <code>/v1</code> suffix. Must be reachable from the
-                controller container — use the host’s LAN or Tailscale IP, not
+                controller container. Use the host’s LAN or Tailscale IP, not
                 <code>127.0.0.1</code>.
               </div>
             </div>
@@ -1904,7 +1904,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
               <div className="field-hint">
                 Tokens of context for <strong>local</strong> Ollama models.
                 Ollama&apos;s own default is 4096, which is too small for the DJ
-                agent — the prompt gets truncated and the model fails to pick a
+                agent: the prompt gets truncated and the model fails to pick a
                 track (the &ldquo;agent did not call the done tool&rdquo; error).
                 16384 is a safe default for a 7&ndash;9B model on a 12GB GPU;
                 raise it for reasoning models, lower it on tight VRAM. Set 0 to
@@ -1928,8 +1928,8 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
             <div>
               <div className="text-[13px] font-bold">Use a backup LLM</div>
               <div className="mt-0.5 max-w-[480px] text-[11px] leading-[1.5] text-muted">
-                When the primary host can&apos;t be reached — connection refused,
-                DNS failure, timeout (e.g. a GPU box that&apos;s powered off) — the
+                When the primary host can&apos;t be reached (connection refused,
+                DNS failure, timeout, e.g. a GPU box that&apos;s powered off), the
                 call is retried once against this backup, then routes straight back
                 to the primary on the next call. A primary that&apos;s up but busy
                 (rate-limited or erroring) is <em>not</em> failed over. Heavy work
@@ -1970,7 +1970,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
                   </SelectContent>
                 </Select>
                 <div className="field-hint">
-                  The provider to fall back to. Can differ from the primary — e.g.
+                  The provider to fall back to. Can differ from the primary, e.g.
                   primary on a self-hosted box, backup on always-on Ollama.
                 </div>
               </div>
@@ -2010,7 +2010,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
                   />
                   <div className="field-hint">
                     OpenAI-compatible server URL including the <code>/v1</code>
-                    suffix — required for this provider.
+                    suffix, required for this provider.
                   </div>
                 </div>
               )}
@@ -2094,14 +2094,14 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
             <div className="mt-0.5 max-w-[480px] text-[11px] leading-[1.5] text-muted">
               When off, the picker tells the model to skip or minimize its
               internal thinking step. Wired across providers that expose a
-              thinking knob — Ollama, openai-compatible (Qwen3), Gemini 2.5/3.x,
+              thinking knob: Ollama, openai-compatible (Qwen3), Gemini 2.5/3.x,
               OpenAI o-series and gpt-5, Claude (adaptive thinking) and DeepSeek
               V4. DJ scripts and structured picks are short, and an uncapped
               thought chain just balloons latency and cost. Leave off unless
               you&apos;re running a model that genuinely needs it. Note: on
               Claude and DeepSeek the picker always suppresses thinking for its
-              structured/tool calls — those APIs reject forced tool calls while
-              thinking — so there this toggle affects only the free-text DJ
+              structured/tool calls, since those APIs reject forced tool calls while
+              thinking, so there this toggle affects only the free-text DJ
               lines.
             </div>
           </div>
@@ -2123,7 +2123,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
             <div className="text-[13px] font-bold">Agentic picker</div>
             <div className="mt-0.5 max-w-[480px] text-[11px] leading-[1.5] text-muted">
               When on, the next-track picker is a tool-using agent that explores the library
-              itself. Needs a model that handles multi-step tool calls well — leave off for
+              itself. Needs a model that handles multi-step tool calls well. Leave off for
               small local models.
             </div>
           </div>
@@ -2191,8 +2191,8 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
           <div>
             <div className="text-[13px] font-bold">Pause DJ when empty</div>
             <div className="mt-0.5 max-w-[480px] text-[11px] leading-[1.5] text-muted">
-              When on, the DJ stops making LLM calls — track picks, links, station
-              IDs, hourly checks, segments and listener requests — whenever Icecast
+              When on, the DJ stops making LLM calls (track picks, links, station
+              IDs, hourly checks, segments and listener requests) whenever Icecast
               reports zero listeners. The stream keeps playing from the auto
               playlist, and the DJ resumes the moment someone tunes back in.
             </div>
@@ -2210,7 +2210,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
       </Card>
 
       <SaveBar
-        note={`Active model: ${data.llm?.active}. Applies to the next LLM call — no restart needed.`}
+        note={`Active model: ${data.llm?.active}. Applies to the next LLM call, no restart needed.`}
         busy={busy}
         onSave={save}
         saveLabel="Save LLM provider"
@@ -2250,9 +2250,9 @@ function SearchSection({ data, form, setForm, busy, saveSettings }: SectionProps
         title="Where the DJ gets live facts about the artist on air."
         sub={<>
           The segment director can air a single line of recent artist context between
-          tracks — when the active backend returns something worth saying. DuckDuckGo
+          tracks, when the active backend returns something worth saying. DuckDuckGo
           is free and keyless; Tavily is paid but returns full web results. Switching
-          here reroutes the next call — no restart.
+          here reroutes the next call, no restart.
         </>}
         metrics={[{ n: String(providers.length), l: 'providers' }]}
       />
@@ -2293,8 +2293,8 @@ function SearchSection({ data, form, setForm, busy, saveSettings }: SectionProps
             </Select>
             <div className="field-hint">
               {provider === 'duckduckgo'
-                ? 'DuckDuckGo Instant Answer — free, no key. Useful for definitions and well-known entities; silent otherwise. The segment director treats silence as a valid outcome.'
-                : 'Tavily — paid web search with full results and an answer summary. Needs an API key.'}
+                ? 'DuckDuckGo Instant Answer, free and keyless. Useful for definitions and well-known entities; silent otherwise. The segment director treats silence as a valid outcome.'
+                : 'Tavily, paid web search with full results and an answer summary. Needs an API key.'}
             </div>
           </div>
 
@@ -2313,7 +2313,7 @@ function SearchSection({ data, form, setForm, busy, saveSettings }: SectionProps
                 />
                 <div className="field-hint">
                   Stored alongside the other admin settings. Falls back to
-                  <code> SEARCH_API_KEY</code> in <code>.env</code> when blank — set
+                  <code> SEARCH_API_KEY</code> in <code>.env</code> when blank. Set
                   one or the other, not both.
                 </div>
               </div>
@@ -2324,7 +2324,7 @@ function SearchSection({ data, form, setForm, busy, saveSettings }: SectionProps
       </Card>
 
       <SaveBar
-        note="Applies to the next web-search call — no restart needed."
+        note="Applies to the next web-search call, no restart needed."
         busy={busy}
         onSave={save}
         saveLabel="Save web search"
@@ -2448,7 +2448,7 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
     try {
       const r = await adminFetch('/tag-library', { method: 'POST' });
       const j = await r.json().catch(() => ({}));
-      if (r.ok) notify.ok('tagging started — watch progress on the Library tab');
+      if (r.ok) notify.ok('tagging started, watch progress on the Library tab');
       else notify.err(j.error || 'could not start the tagger');
     } catch (err) {
       notify.err(errorMessage(err));
@@ -2483,7 +2483,7 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
         <p className="max-w-[560px] text-[12px] leading-[1.6] text-muted">
           Auto-tagging reads each track once and labels its mood + energy so the DJ
           picks tracks that fit the room. It needs a small <strong>embedding</strong>{' '}
-          model — separate from your chat LLM. Set it up below, hit{' '}
+          model, separate from your chat LLM. Set it up below, hit{' '}
           <strong>Test</strong>, then run the tagger.
         </p>
         {probing || detecting ? (
@@ -2548,7 +2548,7 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
             </Select>
             <div className="field-hint">
               Where the text embeddings come from. Default follows your LLM
-              provider — Ollama-local users get <code>nomic-embed-text</code> free.
+              provider, so Ollama-local users get <code>nomic-embed-text</code> free.
               Anthropic has no first-party embedding API; if your LLM is Anthropic,
               pick OpenAI here (needs <code>OPENAI_API_KEY</code>).
               {' '}Effective: <code>{llmProviderLabel(effectiveProvider)}</code>.
@@ -2567,11 +2567,11 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
                 </div>
                 <p className="mt-2 text-[11px] leading-[1.55] text-muted">
                   {e.provider ? (
-                    <><code>{llmProviderLabel(effectiveProvider)}</code> is a chat-only provider — it has no embeddings endpoint, so the tagger can’t use it.</>
+                    <><code>{llmProviderLabel(effectiveProvider)}</code> is a chat-only provider, with no embeddings endpoint, so the tagger can’t use it.</>
                   ) : (
                     <>“Follow LLM provider” resolves to <code>{llmProviderLabel(llmProvider)}</code>, which is chat-only and has no embeddings endpoint.</>
                   )}{' '}
-                  Pick a real embedding provider above — <strong>Ollama</strong> is local
+                  Pick a real embedding provider above. <strong>Ollama</strong> is local
                   and free (<code>nomic-embed-text</code>, auto-pulled on first run), or
                   use OpenAI / Google / locca. Your DJ stays on{' '}
                   <code>{llmProviderLabel(llmProvider)}</code>.
@@ -2600,8 +2600,8 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
             />
             <div className="field-hint">
               Leave blank for the sensible default per provider. If you change
-              this on a tagged library, the next run will reject the new dim —
-              hit <strong>Re-seed</strong> on the Library tab (or run{' '}
+              this on a tagged library, the next run will reject the new dim.
+              Hit <strong>Re-seed</strong> on the Library tab (or run{' '}
               <code>--reseed</code>) to drop and rebuild the vectors.
             </div>
             {embedSuggestions.length > 0 && (
@@ -2636,13 +2636,13 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
                 className="max-w-[360px]"
               />
               <div className="field-hint">
-                Embeddings need a <strong>dedicated</strong> server — one
+                Embeddings need a <strong>dedicated</strong> server: one
                 llama.cpp / locca process can&apos;t serve both chat and
                 embeddings.{' '}
                 {effectiveProvider === 'locca' ? (
                   <>
                     Leave blank to use the locca embed server on its default port
-                    (<code>http://host.docker.internal:8090/v1</code>) — start it
+                    (<code>http://host.docker.internal:8090/v1</code>). Start it
                     with <code>locca embed nomic</code>. Override only for a
                     non-default port or remote host.
                   </>
@@ -2654,7 +2654,7 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
                     and point this at it, including the <code>/v1</code> suffix.
                   </>
                 )}
-                {' '}Must be reachable from the controller container — use the host
+                {' '}Must be reachable from the controller container. Use the host
                 LAN/Tailscale IP or <code>host.docker.internal</code>, not{' '}
                 <code>127.0.0.1</code>.
               </div>
@@ -2702,7 +2702,7 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
                 )}
               >
                 {probe.ok
-                  ? `✓ Producing embeddings${probe.dim ? ` (${probe.dim}-dim vectors)` : ''} — you're ready to tag.`
+                  ? `✓ Producing embeddings${probe.dim ? ` (${probe.dim}-dim vectors)` : ''}, you're ready to tag.`
                   : `✗ ${probe.message}`}
               </div>
             )}
@@ -2715,10 +2715,10 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
         <div className="grid grid-cols-[1fr_auto] items-center gap-4">
           <div className="max-w-[480px] text-[11px] leading-[1.5] text-muted">
             {taggerRunning
-              ? 'A tagging run is in progress — watch live progress on the Library tab.'
+              ? 'A tagging run is in progress, watch live progress on the Library tab.'
               : probe?.ok
-                ? 'Embeddings look good. Start the bulk tagger — it runs in the background; watch progress on the Library tab.'
-                : 'Test the embedding endpoint above first — the tagger needs a working embedding server.'}
+                ? 'Embeddings look good. Start the bulk tagger; it runs in the background, and you can watch progress on the Library tab.'
+                : 'Test the embedding endpoint above first. The tagger needs a working embedding server.'}
           </div>
           <Btn
             tone="accent"
@@ -2736,7 +2736,7 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
         onClick={() => setAdvancedOpen(o => !o)}
         className="mb-1 w-fit text-[11px] font-bold tracking-[0.14em] text-muted uppercase hover:text-ink"
       >
-        {advancedOpen ? '▾' : '▸'} Advanced — seed count, propagation, enrichment
+        {advancedOpen ? '▾' : '▸'} Advanced: seed count, propagation, enrichment
       </button>
       {advancedOpen && (
         <>
@@ -2871,7 +2871,7 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
               <div className="mt-0.5 max-w-[480px] text-[11px] leading-[1.5] text-muted">
                 Vanilla Navidrome&apos;s <code>getArtistInfo2</code> doesn&apos;t
                 surface crowd tags. Leave off unless you&apos;re running a
-                custom Navidrome that does — otherwise this just burns an HTTP
+                custom Navidrome that does. Otherwise this just burns an HTTP
                 round trip per artist for nothing.
               </div>
             </div>
@@ -2997,7 +2997,7 @@ function StationSection({ data, form, setForm, busy, saveSettings }: SectionProp
       <SectionHeader
         eyebrow="station"
         title="How the DJ identifies this radio on air."
-        sub="The station name is substituted into the DJ prompt as {station}. The location sets where the DJ thinks it broadcasts from and drives the Open-Meteo weather it reads on air. The timezone sets the clock the DJ lives on; locale controls how station times are displayed. All apply live — no mixer restart."
+        sub="The station name is substituted into the DJ prompt as {station}. The location sets where the DJ thinks it broadcasts from and drives the Open-Meteo weather it reads on air. The timezone sets the clock the DJ lives on; locale controls how station times are displayed. All apply live, no mixer restart."
         metrics={[
           { n: data.values?.station || 'SUB/WAVE', l: 'station', accent: true },
         ]}
@@ -3055,7 +3055,7 @@ function StationSection({ data, form, setForm, busy, saveSettings }: SectionProp
             />
           </div>
           <div className="field-hint">
-            Where the station broadcasts from — sets the DJ’s {'{location}'} and the Open-Meteo
+            Where the station broadcasts from. Sets the DJ’s {'{location}'} and the Open-Meteo
             weather it reads on air (current: {data.values?.weather?.locationName} @ {data.values?.weather?.lat}, {data.values?.weather?.lng}). Applies live.
           </div>
         </div>
@@ -3074,8 +3074,8 @@ function StationSection({ data, form, setForm, busy, saveSettings }: SectionProp
             <SelectTrigger className="w-[240px]"><SelectValue /></SelectTrigger>
             <SelectContent>
               <SelectGroup>
-                <SelectItem value="metric">Metric — °C</SelectItem>
-                <SelectItem value="imperial">Imperial — °F</SelectItem>
+                <SelectItem value="metric">Metric (°C)</SelectItem>
+                <SelectItem value="imperial">Imperial (°F)</SelectItem>
               </SelectGroup>
             </SelectContent>
           </Select>
@@ -3098,7 +3098,7 @@ function StationSection({ data, form, setForm, busy, saveSettings }: SectionProp
             <SelectTrigger className="w-[300px]"><SelectValue /></SelectTrigger>
             <SelectContent>
               <SelectGroup>
-                <SelectItem value="auto">Auto — server timezone ({serverTz})</SelectItem>
+                <SelectItem value="auto">Auto, server timezone ({serverTz})</SelectItem>
               </SelectGroup>
               {TZ_GROUPS.map(g => (
                 <SelectGroup key={g.region}>
@@ -3112,11 +3112,11 @@ function StationSection({ data, form, setForm, busy, saveSettings }: SectionProp
           </Select>
           {preview && (
             <div className="field-hint">
-              Station clock: <span className="mono-num">{preview}</span> in {localeLabel} — if that doesn’t match your watch, pick your zone above.
+              Station clock: <span className="mono-num">{preview}</span> in {localeLabel}. If that doesn’t match your watch, pick your zone above.
             </div>
           )}
           <div className="field-hint">
-            Drives everything the DJ derives from the clock — time-of-day moods, schedule slots,
+            Drives everything the DJ derives from the clock: time-of-day moods, schedule slots,
             hourly time checks, festival dates. Applies live. Hourly archive filenames still follow
             the server’s TZ.
           </div>
@@ -3135,8 +3135,8 @@ function StationSection({ data, form, setForm, busy, saveSettings }: SectionProp
             <SelectTrigger className="w-[260px]"><SelectValue /></SelectTrigger>
             <SelectContent>
               <SelectGroup>
-                <SelectItem value="en-GB">English (UK) — 24-hour</SelectItem>
-                <SelectItem value="en-US">English (US) — AM/PM</SelectItem>
+                <SelectItem value="en-GB">English (UK), 24-hour</SelectItem>
+                <SelectItem value="en-US">English (US), AM/PM</SelectItem>
               </SelectGroup>
             </SelectContent>
           </Select>
@@ -3342,7 +3342,7 @@ function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSectionProp
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
       const next = j.themes ?? [];
       setThemes(next);
-      notify.ok(`reloaded — ${next.length} theme${next.length === 1 ? '' : 's'}`);
+      notify.ok(`reloaded, ${next.length} theme${next.length === 1 ? '' : 's'}`);
     } catch (e) {
       notify.err(`Refresh failed: ${errorMessage(e)}`);
     } finally {
@@ -3433,7 +3433,7 @@ function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSectionProp
           </div>
           <div className="field-hint">
             Describe a look above and we&apos;ll draft the palette, or drop a JSON
-            theme file in <code>state/themes/</code> and click <em>Refresh</em> —
+            theme file in <code>state/themes/</code> and click <em>Refresh</em>,
             no controller restart needed. The folder includes a
             <code>README.md</code> with the format and the allowed token keys.
           </div>
@@ -3635,7 +3635,7 @@ function JinglesSection({
             value={importLabel}
             maxLength={200}
             onChange={(e: ChangeEvent<HTMLInputElement>) => setImportLabel(e.target.value)}
-            placeholder="shown in the list — defaults to the file name"
+            placeholder="shown in the list, defaults to the file name"
           />
         </div>
         <div className="mt-3.5 flex items-center gap-2.5">
@@ -3785,7 +3785,7 @@ function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uploadSfx, 
             placeholder="e.g. record-scratch"
             className="max-w-[280px]"
           />
-          <div className="field-hint">A short slug the agent references — letters, numbers and dashes.</div>
+          <div className="field-hint">A short slug the agent references: letters, numbers and dashes.</div>
         </div>
         <div className="field mt-3.5">
           <Label>Description</Label>
@@ -3805,7 +3805,7 @@ function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uploadSfx, 
             onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setSfxForm(f => ({ ...f, prompt: e.target.value }))}
             placeholder='e.g. "abrupt vinyl record scratch, short and sharp"'
           />
-          <div className="field-hint">{sfxForm.prompt.length}/500 chars — describe the sound for ElevenLabs.</div>
+          <div className="field-hint">{sfxForm.prompt.length}/500 chars. Describe the sound for ElevenLabs.</div>
         </div>
         <div className="field mt-3.5">
           <Label>Duration (optional)</Label>
@@ -3834,7 +3834,7 @@ function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uploadSfx, 
         </div>
       </Card>
 
-      <Card title="Import sound effect" sub="bring your own mp3 / wav — no ElevenLabs key needed">
+      <Card title="Import sound effect" sub="bring your own mp3 / wav, no ElevenLabs key needed">
         <div className="field">
           <Label>Name</Label>
           <Input
@@ -3844,7 +3844,7 @@ function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uploadSfx, 
             placeholder="e.g. my-stinger"
             className="max-w-[280px]"
           />
-          <div className="field-hint">A short slug the agent references — letters, numbers and dashes.</div>
+          <div className="field-hint">A short slug the agent references: letters, numbers and dashes.</div>
         </div>
         <div className="field mt-3.5">
           <Label>Description</Label>
@@ -4000,7 +4000,7 @@ function ScrobbleSection({ data, form, setForm, busy, saveSettings, adminFetch }
         eyebrow="scrobbling"
         title="Station-wide scrobbling to Last.fm and ListenBrainz."
         sub={<>
-          Each backend is independent — pick one or both. Tracks scrobble only when at
+          Each backend is independent, pick one or both. Tracks scrobble only when at
           least one listener is tuned in to the stream. Paste credentials below; nothing
           here leaves the controller. See the <code>npm run lastfm-session</code> helper
           if you don&apos;t already have a Last.fm session key.
@@ -4112,13 +4112,13 @@ function ScrobbleSection({ data, form, setForm, busy, saveSettings, adminFetch }
               className="max-w-[360px]"
             />
             <div className="field-hint">
-              Cosmetic — used to label the &quot;scrobbling as&quot; status line above.
+              Cosmetic, used to label the &quot;scrobbling as&quot; status line above.
             </div>
           </div>
         </div>
 
         <SaveBar
-          note="Applies on the next track transition — no restart needed."
+          note="Applies on the next track transition, no restart needed."
           busy={busy}
           onSave={saveLastfm}
           saveLabel="Save Last.fm"
@@ -4154,8 +4154,8 @@ function ScrobbleSection({ data, form, setForm, busy, saveSettings, adminFetch }
               options={[{ id: 'off', label: 'Off' }, { id: 'on', label: 'On' }]}
             />
             <div className="field-hint">
-              ListenBrainz is the open-source alternative to Last.fm — same listener gate,
-              same eligibility rules.
+              ListenBrainz is the open-source alternative to Last.fm, with the same listener gate
+              and eligibility rules.
             </div>
           </div>
 
@@ -4203,7 +4203,7 @@ function ScrobbleSection({ data, form, setForm, busy, saveSettings, adminFetch }
         </div>
 
         <SaveBar
-          note="Applies on the next track transition — no restart needed."
+          note="Applies on the next track transition, no restart needed."
           busy={busy}
           onSave={saveListenbrainz}
           saveLabel="Save ListenBrainz"

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -165,7 +165,7 @@ function NowCard({ label, accent, slotHour, show, color, personaLabel }: NowCard
             show ? 'text-ink' : 'text-muted',
           )}
         >
-          {show ? show.name : '(no show — autonomous)'}
+          {show ? show.name : '(no show, autonomous)'}
         </span>
       </div>
       <div className="text-[11px] text-muted">
@@ -520,7 +520,7 @@ export default function ShowsPanel() {
       });
       const j = (await r.json().catch(() => ({}))) as { error?: string };
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      notify.ok('schedule saved — the current hour applies on the next pick');
+      notify.ok('schedule saved, the current hour applies on the next pick');
       await load();
     } catch (e) {
       notify.err(errorMessage(e));
@@ -605,7 +605,7 @@ export default function ShowsPanel() {
       {personas.length === 0 && (
         <Card title="Personas required" sub="setup">
           <div className="text-[13px] text-[var(--danger)]">
-            No personas defined — create one under Personas first.
+            No personas defined. Create one under Personas first.
           </div>
         </Card>
       )}
@@ -715,7 +715,7 @@ export default function ShowsPanel() {
       >
         {form.shows.length === 0 && (
           <p className="text-[12px] text-muted">
-            No shows yet — add one to start programming the week.
+            No shows yet. Add one to start programming the week.
           </p>
         )}
         <div className="grid gap-2">
@@ -829,7 +829,7 @@ export default function ShowsPanel() {
             </div>
 
             <Field>
-              <Label>theme override — applied while this show is on air</Label>
+              <Label>theme override (applied while this show is on air)</Label>
               <Select
                 value={draft.themeId || THEME_DEFAULT_SENTINEL}
                 onValueChange={val =>
@@ -929,16 +929,16 @@ export default function ShowsPanel() {
             </div>
 
             <span className="field-hint -mt-1.5">
-              Optional soft music steer for this show — a genre, an era, an energy
+              Optional soft music steer for this show: a genre, an era, an energy
               band, or any mix. The DJ leans toward these but can break them for
               flow; leave blank to let the topic and mood drive selection.
             </span>
 
             <Field>
-              <Label htmlFor="show-topic">topic — fed to the DJ as the show theme</Label>
+              <Label htmlFor="show-topic">topic (fed to the DJ as the show theme)</Label>
               <span className="field-hint">
                 This is the brief the AI DJ works from. The more you describe,
-                the better it picks music and writes links — name genres, eras,
+                the better it picks music and writes links: name genres, eras,
                 moods, artists to lean into or avoid, the time of day, the kind
                 of listener, and how the host should sound. Write it like
                 you&apos;re briefing a real DJ before their slot.
@@ -947,7 +947,7 @@ export default function ShowsPanel() {
                 id="show-topic"
                 rows={7} value={draft.topic} maxLength={TOPIC_MAX}
                 onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setDraftField({ topic: e.target.value })}
-                placeholder="e.g. Slow ambient, modern classical and downtempo for the late shift. Think Nils Frahm, Hammock, Bonobo's quieter side — nothing with a hard beat. Keep the host calm and unhurried, like a friend talking you down at 1am."
+                placeholder="e.g. Slow ambient, modern classical and downtempo for the late shift. Think Nils Frahm, Hammock, Bonobo's quieter side, nothing with a hard beat. Keep the host calm and unhurried, like a friend talking you down at 1am."
               />
               <span className="field-hint">{draft.topic.trim().length}/{TOPIC_MAX}</span>
             </Field>
@@ -1121,7 +1121,7 @@ function GridCell({
       onMouseEnter={onMouseEnter}
       onTouchStart={onTouchStart}
       title={
-        (show ? `${show.name} (${show.mood})` : `${label} ${String(hour).padStart(2, '0')}:00 — empty`)
+        (show ? `${show.name} (${show.mood})` : `${label} ${String(hour).padStart(2, '0')}:00, empty`)
         + (isNow ? ' · on air now' : '')
       }
       className={cn(

--- a/web/components/admin/SkillsPanel.tsx
+++ b/web/components/admin/SkillsPanel.tsx
@@ -178,7 +178,7 @@ export default function SkillsPanel() {
       const j = (await r.json().catch(() => ({}))) as SkillToggleResponse & { custom?: number };
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
       if (Array.isArray(j.skills)) setSkills(j.skills);
-      notify.ok(`Rescanned — ${j.custom ?? 0} custom skill${j.custom === 1 ? '' : 's'} loaded`);
+      notify.ok(`Rescanned, ${j.custom ?? 0} custom skill${j.custom === 1 ? '' : 's'} loaded`);
     } catch (e) {
       notify.err(`Rescan failed: ${errorMessage(e)}`);
     } finally { setRescanning(false); }
@@ -294,19 +294,19 @@ export default function SkillsPanel() {
           </div>
           <div className="mt-1 text-[11px] leading-[1.6] text-muted">
             Each skill is an autonomous segment. A skill fires only when it is enabled here
-            <strong> and</strong> assigned to the persona on air — set per-persona assignments
+            <strong> and</strong> assigned to the persona on air. Set per-persona assignments
             on the Personas page. “Run now” is an operator override and ignores both.
           </div>
           <div className="mt-1 text-[11px] leading-[1.6] text-muted">
-            The built-in skills are editable too — hit <strong>Edit</strong> to change a skill&apos;s
+            The built-in skills are editable too. Hit <strong>Edit</strong> to change a skill&apos;s
             brief, cooldown, or which real-world context (time, weather…) it may mention
             (and, for News, its feed URL). Edits are saved to
             <code> state/skills/&lt;kind&gt;/SKILL.md</code>.
           </div>
           <div className="mt-1 text-[11px] leading-[1.6] text-muted">
             Drop your own skills into <code>state/skills/&lt;name&gt;/SKILL.md</code> and hit
-            <strong> Rescan</strong>. Custom skills arrive <strong>disabled</strong> — review,
-            then enable them before they can air.
+            <strong> Rescan</strong>. Custom skills arrive <strong>disabled</strong>, so review
+            them, then enable them before they can air.
           </div>
           <a
             href="/manual/skills"
@@ -353,7 +353,7 @@ export default function SkillsPanel() {
               <V3Alert tone="error" title="API key not set">
                 This skill needs the <code>{s.requiresKey || 'required API key'}</code> environment
                 variable set in <code>.env</code>. Until then it stays inert and never
-                fires autonomously — even when enabled.
+                fires autonomously, even when enabled.
                 {s.keyUrl && (
                   <>
                     {' '}

--- a/web/components/admin/StatsPanel.tsx
+++ b/web/components/admin/StatsPanel.tsx
@@ -636,7 +636,7 @@ export default function StatsPanel() {
           <span className="field-hint italic">loading…</span>
         ) : (audSessions ?? 0) === 0 ? (
           <span className="field-hint italic">
-            no sessions recorded yet — sources appear as listeners arrive
+            no sessions recorded yet, sources appear as listeners arrive
           </span>
         ) : (
           <div className="grid gap-0">
@@ -930,7 +930,7 @@ export default function StatsPanel() {
             <div className="p-3.5">
               {!systemRes.dockerAvailable ? (
                 <span className="field-hint italic">
-                  container stats unavailable — mount /var/run/docker.sock (read-only)
+                  container stats unavailable, mount /var/run/docker.sock (read-only)
                   into the controller to enable
                 </span>
               ) : sysContainers.length === 0 ? (

--- a/web/components/admin/WebhooksPanel.tsx
+++ b/web/components/admin/WebhooksPanel.tsx
@@ -74,7 +74,7 @@ const PAYLOADS: PayloadDoc[] = [
   },
   {
     event: 'dj.link',
-    blurb: 'A between-track auto-DJ link (the light-ducked voice). The chattiest stream — most relays filter this one out.',
+    blurb: 'A between-track auto-DJ link (the light-ducked voice). The chattiest stream, so most relays filter this one out.',
     json: `{
   "event": "dj.link",
   "t": "2026-06-02T19:07:55.020Z",
@@ -103,7 +103,7 @@ const PAYLOADS: PayloadDoc[] = [
   },
   {
     event: 'test',
-    blurb: 'What the "Send test" button fires — ignores the event subscriptions so you can sanity-check a fresh hook.',
+    blurb: 'What the "Send test" button fires. It ignores the event subscriptions so you can sanity-check a fresh hook.',
     json: `{
   "event": "test",
   "t": "2026-06-02T19:00:00.000Z",
@@ -121,7 +121,7 @@ interface RecipeDoc {
 
 const RECIPES: RecipeDoc[] = [
   {
-    title: 'Discord — “now playing” via a Cloudflare Worker',
+    title: 'Discord: “now playing” via a Cloudflare Worker',
     blurb: <>Discord expects <code>{'{ content }'}</code>, not sub-wave&apos;s shape, so reshape in a tiny relay. Point a <code>track.play</code> hook at the Worker; it forwards a message to your Discord webhook.</>,
     lang: 'js',
     code: `export default {
@@ -140,7 +140,7 @@ const RECIPES: RecipeDoc[] = [
 };`,
   },
   {
-    title: 'Home Assistant — pulse a light on every track',
+    title: 'Home Assistant: pulse a light on every track',
     blurb: <>HA webhook triggers accept any JSON. Subscribe <code>track.play</code> and set the hook URL to your HA webhook (<code>…/api/webhook/&lt;id&gt;</code>).</>,
     lang: 'yaml',
     code: `# automation
@@ -154,7 +154,7 @@ action:
     data: { flash: short }`,
   },
   {
-    title: 'n8n / Pipedream — durable relay with retries',
+    title: 'n8n / Pipedream: durable relay with retries',
     blurb: <>sub-wave fires once with no retry queue. When delivery matters, put a workflow in front: add a Webhook node, subscribe the events you need, and branch on the event name.</>,
     lang: 'text',
     code: `Webhook node  →  Switch on {{ $json.event }}
@@ -179,12 +179,12 @@ function ExamplesSection() {
   return (
     <Card
       title="Payloads & recipes"
-      sub="reference — what each event sends, and how to wire it"
+      sub="reference: what each event sends, and how to wire it"
     >
       <div className="text-[12px] leading-[1.6] text-muted">
         Every payload is JSON, fire-and-forget, with <code>event</code> and an ISO <code>t</code> timestamp.
         Most targets want a different shape than sub-wave emits, so point hooks at a relay that reshapes
-        the body — these examples do exactly that.
+        the body. The examples below do exactly that.
       </div>
 
       <div className="caption mt-4 mb-1.5">Event payloads</div>
@@ -291,7 +291,7 @@ export default function WebhooksPanel() {
             Pipe station events into other systems.
           </div>
           <div className="mt-1 text-[11px] leading-[1.6] text-muted">
-            Each row POSTs a JSON event to <code>url</code> the moment it happens — no retry queue, no buffer.
+            Each row POSTs a JSON event to <code>url</code> the moment it happens. No retry queue, no buffer.
             Best paired with a relay like a Cloudflare Worker or n8n. See
             <code> controller/src/routes/webhooks.ts </code> for the payload shapes.
           </div>
@@ -363,7 +363,7 @@ export default function WebhooksPanel() {
                 <Label className="caption">Authorization header (optional)</Label>
                 <Input
                   value={h.authHeader === 'set' ? '' : h.authHeader}
-                  placeholder={h.authHeader === 'set' ? '(stored — leave blank to keep)' : 'Bearer …'}
+                  placeholder={h.authHeader === 'set' ? '(stored, leave blank to keep)' : 'Bearer …'}
                   onChange={e => update({ authHeader: e.target.value })}
                   spellCheck={false}
                 />

--- a/web/components/admin/personas/PersonaAvatarPicker.tsx
+++ b/web/components/admin/personas/PersonaAvatarPicker.tsx
@@ -62,7 +62,7 @@ export function PersonaAvatarPicker({ persona, tick, uploading, onPick, onGenera
         <Btn sm className="w-full justify-center" onClick={() => inputRef.current?.click()} disabled={uploading}>
           {uploading ? '…' : hasAvatar ? 'Replace' : 'Upload'}
         </Btn>
-        <Btn sm className="w-full justify-center" onClick={onGenerate} disabled={uploading} title="Random DiceBear avatar — click again for a different one">
+        <Btn sm className="w-full justify-center" onClick={onGenerate} disabled={uploading} title="Random DiceBear avatar. Click again for a different one">
           Generate
         </Btn>
         {hasAvatar && (

--- a/web/components/admin/personas/PersonaHero.tsx
+++ b/web/components/admin/personas/PersonaHero.tsx
@@ -56,7 +56,7 @@ export function PersonaHero({
         <span className="caption">voice · {activePersona ? engineLabel(activePersona) : '—'}</span>
         {activeCloudIssue && (
           <span className="caption text-[var(--danger)]">
-            ⚠ cloud voice inactive — speaking via {defaultEngine}
+            ⚠ cloud voice inactive, speaking via {defaultEngine}
           </span>
         )}
         <span className="caption">override · — (a scheduled show may reassign the hour)</span>

--- a/web/components/admin/personas/PersonaIdentityCard.tsx
+++ b/web/components/admin/personas/PersonaIdentityCard.tsx
@@ -132,7 +132,7 @@ export function PersonaIdentityCard({
           <Textarea
             rows={9}
             value={persona.soul}
-            placeholder="e.g. warm and dry, never corny — observant, favours one good image over a list"
+            placeholder="e.g. warm and dry, never corny, observant, favours one good image over a list"
             onChange={(e: ChangeEvent<HTMLTextAreaElement>) => update({ soul: e.target.value })}
             className={soulOver || soulLen === 0 ? 'border-[var(--danger)]' : 'border-ink'}
           />

--- a/web/components/admin/personas/PersonaVoiceCard.tsx
+++ b/web/components/admin/personas/PersonaVoiceCard.tsx
@@ -98,8 +98,8 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
                 </Select>
                 <div className="field-hint">
                   Piper is fast, local, and keyless. Drop a voice’s <code>.onnx</code> and its{' '}
-                  <code>.onnx.json</code> manifest into <code>state/voices/</code> on the host — the
-                  same files Home Assistant uses — and they’ll show up here. Leave on the built-in
+                  <code>.onnx.json</code> manifest into <code>state/voices/</code> on the host (the
+                  same files Home Assistant uses) and they’ll show up here. Leave on the built-in
                   default if you don’t have any.
                 </div>
               </div>
@@ -137,7 +137,7 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
               <div className="field max-w-[360px]">
                 {!cbAvailable && (
                   <div className="mb-2.5 border border-[var(--danger)] px-3 py-2.5 text-[11px] leading-[1.6] text-[var(--danger)]">
-                    Chatterbox isn’t currently available — it lives in the optional{' '}
+                    Chatterbox isn’t currently available. It lives in the optional{' '}
                     <code>tts-heavy</code> sidecar. Start it with{' '}
                     <code>docker compose --profile tts-heavy up -d</code> (or set{' '}
                     <code>COMPOSE_PROFILES=tts-heavy</code> in <code>.env</code>).
@@ -185,7 +185,7 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
               <div className="field max-w-[360px]">
                 {!ptAvailable && (
                   <div className="mb-2.5 border border-[var(--danger)] px-3 py-2.5 text-[11px] leading-[1.6] text-[var(--danger)]">
-                    PocketTTS isn’t currently available — it lives in the same optional{' '}
+                    PocketTTS isn’t currently available. It lives in the same optional{' '}
                     <code>tts-heavy</code> sidecar as Chatterbox. Start it with{' '}
                     <code>docker compose --profile tts-heavy up -d</code> (or set{' '}
                     <code>COMPOSE_PROFILES=tts-heavy</code> in <code>.env</code>).
@@ -196,7 +196,7 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
                 {ptAvailable && ptCloning === false && usingClone && (
                   <div className="mb-2.5 border border-[var(--danger)] px-3 py-2.5 text-[11px] leading-[1.6] text-[var(--danger)]">
                     Voice <strong>cloning is unavailable</strong> in this build, so this
-                    cloned voice won’t play — PocketTTS reverts to a built-in voice. The
+                    cloned voice won’t play; PocketTTS reverts to a built-in voice. The
                     cloning model (<code>kyutai/pocket-tts</code>) is gated on Hugging Face:
                     accept its terms, then set <code>HF_TOKEN</code> in your <code>.env</code>{' '}
                     and restart <code>tts-heavy</code>. Built-in voices below work without a token.
@@ -218,7 +218,7 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
                     {customVoices.length > 0 && (
                       <SelectGroup>
                         <SelectLabel>
-                          Custom (cloned){ptCloning === false ? ' — cloning unavailable' : ''}
+                          Custom (cloned){ptCloning === false ? ', cloning unavailable' : ''}
                         </SelectLabel>
                         {customVoices.map(v => (
                           <SelectItem key={v} value={v}>{v}</SelectItem>
@@ -239,7 +239,7 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
                 <div className="field-hint">
                   CPU-only, ~6× real-time. Built-in voices cover English, French, German,
                   Italian, Spanish and Portuguese. Drop a ~5s WAV into{' '}
-                  <code>state/voices/</code> to clone a voice — it’ll appear under
+                  <code>state/voices/</code> to clone a voice; it’ll appear under
                   <em> Custom</em> on next reload (cloning needs <code>HF_TOKEN</code>; see above).
                 </div>
               </div>
@@ -293,7 +293,7 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
                           onChange={(e: ChangeEvent<HTMLInputElement>) => updateTts({ voice: e.target.value })}
                         />
                         <div className="field-hint">
-                          Server-specific — Chatterbox cloning ref name, Qwen3
+                          Server-specific: Chatterbox cloning ref name, Qwen3
                           speaker id, etc. Leave blank to let the server pick.
                         </div>
                       </>

--- a/web/components/admin/personas/constants.ts
+++ b/web/components/admin/personas/constants.ts
@@ -7,7 +7,7 @@ export const FREQUENCIES = [
 ];
 export const SCRIPT_LENGTHS = [
   { id: 'concise',  label: 'Concise',  desc: 'Standard one-to-four sentence segments. The default.' },
-  { id: 'extended', label: 'Extended', desc: 'Longer, storytelling segments — roughly double the length across intros, links, weather and idents.' },
+  { id: 'extended', label: 'Extended', desc: 'Longer, storytelling segments. Roughly double the length across intros, links, weather and idents.' },
 ];
 // Personality dials, 0–10, default 5. They map to three prompt bands server-side
 // (settings.personaToneDirectives): 0–3 low, 7–10 high, 4–6 neutral (nothing

--- a/web/components/admin/personas/helpers.ts
+++ b/web/components/admin/personas/helpers.ts
@@ -45,7 +45,7 @@ export async function fileToAvatarDataUrl(file: File): Promise<string> {
     throw new Error('please pick a PNG, JPEG, or WebP image');
   }
   if (file.size > 12 * 1024 * 1024) {
-    throw new Error('image is over 12 MB — pick something smaller');
+    throw new Error('image is over 12 MB, pick something smaller');
   }
   const bitmap = await createImageBitmap(file);
   try {


### PR DESCRIPTION
## What

Humanizes the admin UI copy so it reads less "AI-generated" — focused on em-dash overuse and the helper texts under inputs and form fields.

Across every admin panel (and the redesigned personas editor from #526), prose em-dashes become natural punctuation:

- Name/label asides → parentheses: `Ollama — local/cloud` → `Ollama (local/cloud)`, `Metric — °C` → `Metric (°C)`
- Lowercase toasts/status → commas: `saved — restart the mixer to apply` → `saved, restart the mixer to apply`
- Full-sentence hints → period + capital: `…controller — fast, lightweight` → `…controller. Fast, lightweight`
- Lists after a dash → colons: `topic — fed to the DJ as the show theme` → `topic (fed to the DJ as the show theme)`
- Double-em-dash sentences (the real AI tell) restructured into clean sentences/parentheticals (LLM failover, thinking toggle, pause-when-empty, voice-cloning hints)

## Left untouched on purpose

- Code comments
- The `'—'` "no value" placeholder convention
- `Title — Artist` data separators
- `&ndash;` numeric ranges (e.g. `7–9B`)
- Decorative select placeholders (`— pick persona —`)

## Verification

`npm run lint` (eslint + `tsc --noEmit`, the CI merge gate) passes clean. Copy-only changes — no logic touched.
