### PR TITLE
fix(embedding): handle provider-prefixed model names in dim lookup

### DIFF
--- a/controller/src/llm/internal/provider/embedding.ts
+++ b/controller/src/llm/internal/provider/embedding.ts
@@ -68,11 +68,12 @@ function defaultEmbeddingDimFor(model: string): number {
   // live controller adopts whatever dim the tagger recorded (library-db
   // adoptStoredDim). So an unknown / arbitrarily-named embedding model still
   // works — this table just seeds the schema before the first tag run (#319).
-  if (model === 'nomic-embed-text') return 768;
-  if (model === 'mxbai-embed-large') return 1024;
-  if (model === 'text-embedding-3-small') return 1536;
-  if (model === 'text-embedding-3-large') return 3072;
-  if (model === 'text-embedding-004') return 768;
+  const bare = model.includes('/') ? model.split('/').pop()! : model;
+  if (bare === 'nomic-embed-text') return 768;
+  if (bare === 'mxbai-embed-large') return 1024;
+  if (bare === 'text-embedding-3-small') return 1536;
+  if (bare === 'text-embedding-3-large') return 3072;
+  if (bare === 'text-embedding-004') return 768;
   return 768; // homelab default until a probe says otherwise
 }
 


### PR DESCRIPTION

  ## What

  Strip the provider prefix from model names before matching in `defaultEmbeddingDimFor()`
  so that `openai/text-embedding-3-small` correctly resolves to 1536 dimensions instead of
  falling through to 768.

  ## Why

  OpenRouter uses provider-prefixed model names (e.g. `openai/text-embedding-3-small`), but
  the dimension lookup only matched bare names (`text-embedding-3-small`). The mismatch
  caused the controller to create `library.db` at 768 dims on startup, and the tagger then
  crashed with `SqliteError: Dimension mismatch ... Expected 768 dimensions but received
  1536`.

  Fixes #534.

  ## How tested

  - `cd controller && npx eslint src/llm/internal/provider/embedding.ts && npx tsc
  --noEmit` -- 0 errors
  - Will verify against live OpenRouter tagger run after deploy

  ## Notes for reviewers

  Uses `model.split('/').pop()` to strip the prefix rather than adding per-model `if`
  branches. This covers any provider that namespaces models with `/` (OpenRouter, future
  providers). The comment block notes this table is only a fallback seed -- the tagger
  probes the live server for the real dimension -- but a wrong seed causes the crash
  because the controller opens the DB with it before the tagger runs.