### PR TITLE
fix(personas): mark "on air" by the effective persona, not the default

### DIFF
--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -34,6 +34,19 @@ router.get('/settings', requireAdmin, async (req, res) => {
     // On-air status — a telnet failure must not 500 the whole settings load.
     let streamOnAir: boolean | null = null;
     try { streamOnAir = await streamStatus(); } catch {}
+    // The persona actually on air right now — the same resolution the listener
+    // side uses (getEffectivePersona): a scheduled show's owner when a show is
+    // live this hour, otherwise the admin-selected default. The roster marks
+    // "on air" by THIS, not by activePersonaId, so a show override surfaces the
+    // real voice instead of the static default.
+    const onAirPersona = settings.getEffectivePersona();
+    const activeShow = settings.resolveActiveShow();
+    const onAir = {
+      personaId: onAirPersona?.id || '',
+      // The show reassigning the hour, present only when a show actually owns a
+      // persona this hour — null means the default persona is on air.
+      show: activeShow?.persona?.id ? { id: activeShow.id, name: activeShow.name } : null,
+    };
     // Reference-WAV voices are shared by chatterbox + pocket-tts (issue #213);
     // read once and reuse for both dropdowns.
     const customVoices = await chatterbox.listReferenceVoices();
@@ -45,6 +58,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
       autoPick: queue.autoPick,
       pickerBusy: queue.pickerBusy,
       streamOnAir,
+      onAir,
       jingles: await jingles.list(),
       libraryStats: library.stats(),
       tagger: { ...tagger, lastLog: tagger.lastLog.slice(-30) },

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -326,18 +326,26 @@ export default function PersonasPanel() {
   }
 
   const activePersona = form.personas.find(p => p.id === form.activePersonaId);
+  // Who's actually on air now: the controller's effective persona (a scheduled
+  // show can override the default). Fall back to the default selection when the
+  // controller predates the onAir field.
+  const onAirPersonaId = data?.onAir?.personaId || form.activePersonaId;
+  const onAirPersona = form.personas.find(p => p.id === onAirPersonaId) || activePersona;
+  const onAirShow = data?.onAir?.show || null;
   const focusedOk = personaValid(focused);
   const focusedCloudIssue = cloudIssue(focused, data);
-  const activeCloudIssue = activePersona ? cloudIssue(activePersona, data) : null;
+  const onAirCloudIssue = onAirPersona ? cloudIssue(onAirPersona, data) : null;
   const defaultEngine = data?.values?.tts?.defaultEngine || 'piper';
   const skillCatalog = data?.skills?.catalog || [];
 
   return (
     <div className="grid gap-4">
       <PersonaHero
-        activePersona={activePersona}
+        onAirPersona={onAirPersona}
+        defaultPersona={activePersona}
+        onAirShow={onAirShow}
         defaultEngine={defaultEngine}
-        activeCloudIssue={activeCloudIssue}
+        onAirCloudIssue={onAirCloudIssue}
         personaCount={form.personas.length}
         showPrompt={showPrompt}
         onTogglePrompt={() => setShowPrompt(s => !s)}
@@ -361,6 +369,7 @@ export default function PersonasPanel() {
       <PersonaRoster
         personas={form.personas}
         activePersonaId={form.activePersonaId}
+        onAirPersonaId={onAirPersonaId}
         focusedIdx={safeIdx}
         avatarTick={avatarTick}
         onSelect={setFocusIdx}
@@ -372,6 +381,7 @@ export default function PersonasPanel() {
         index={safeIdx}
         personaCount={form.personas.length}
         activePersonaId={form.activePersonaId}
+        onAirPersonaId={onAirPersonaId}
         data={data}
         adminFetch={adminFetch}
         avatarTick={avatarTick}

--- a/web/components/admin/personas/PersonaEditor.tsx
+++ b/web/components/admin/personas/PersonaEditor.tsx
@@ -17,6 +17,7 @@ interface PersonaEditorProps {
   index: number;
   personaCount: number;
   activePersonaId: string;
+  onAirPersonaId: string;
   data: SettingsResponse | null;
   adminFetch: AdminAuth['adminFetch'];
   avatarTick: number;
@@ -43,7 +44,7 @@ interface PersonaEditorProps {
 }
 
 export function PersonaEditor({
-  persona, index, personaCount, activePersonaId, data, adminFetch, avatarTick, uploadingId,
+  persona, index, personaCount, activePersonaId, onAirPersonaId, data, adminFetch, avatarTick, uploadingId,
   defaultEngine, cloudIssueText, skillCatalog, editorRef,
   setPersona, setPersonaTts, setPersonaSkills,
   onUploadAvatar, onGenerateAvatar, onClearAvatar, onSetActive, onRemove,
@@ -60,6 +61,7 @@ export function PersonaEditor({
         index={index}
         personaCount={personaCount}
         isActive={persona.id === activePersonaId}
+        isOnAir={persona.id === onAirPersonaId}
         canRemove={personaCount > 1}
         adminFetch={adminFetch}
         avatarTick={avatarTick}

--- a/web/components/admin/personas/PersonaHero.tsx
+++ b/web/components/admin/personas/PersonaHero.tsx
@@ -6,9 +6,16 @@ import { engineLabel } from './helpers';
 import { Btn, Eyebrow } from '../ui';
 
 interface PersonaHeroProps {
-  activePersona: Persona | undefined;
+  // The persona actually broadcasting (show override aware) — what the live
+  // strip describes. Distinct from the default below.
+  onAirPersona: Persona | undefined;
+  // The admin-selected default — shown only when a show has overridden it, so
+  // the operator can see who'd be on air without the show.
+  defaultPersona: Persona | undefined;
+  // The show reassigning the hour, or null when the default is on air.
+  onAirShow: { id: string; name: string } | null;
   defaultEngine: string;
-  activeCloudIssue: string | null;
+  onAirCloudIssue: string | null;
   personaCount: number;
   showPrompt: boolean;
   onTogglePrompt: () => void;
@@ -16,8 +23,10 @@ interface PersonaHeroProps {
 }
 
 export function PersonaHero({
-  activePersona, defaultEngine, activeCloudIssue, personaCount, showPrompt, onTogglePrompt, onAdd,
+  onAirPersona, defaultPersona, onAirShow, defaultEngine, onAirCloudIssue,
+  personaCount, showPrompt, onTogglePrompt, onAdd,
 }: PersonaHeroProps) {
+  const overridden = !!onAirShow && defaultPersona?.id !== onAirPersona?.id;
   return (
     <section className="card">
       <div className="stack-mobile grid grid-cols-[1fr_auto] items-center gap-4 border-b border-ink p-4">
@@ -41,25 +50,30 @@ export function PersonaHero({
         </div>
       </div>
 
-      {/* Active strip */}
+      {/* On-air strip — describes the persona actually broadcasting now, which
+          a scheduled show can make different from the default selection. */}
       <div className="flex flex-wrap items-center gap-3 bg-[var(--ink-softer)] p-3.5">
-        <span className="caption text-vermilion">● live</span>
+        <span className="caption text-vermilion">● on air</span>
         <span className="text-[13px] font-bold">
-          {activePersona ? (activePersona.name.trim() || 'Persona') : '—'}
+          {onAirPersona ? (onAirPersona.name.trim() || 'Persona') : '—'}
         </span>
-        {activePersona?.tagline.trim() && (
-          <span className="text-[11px] text-muted">— {activePersona.tagline.trim()}</span>
+        {onAirPersona?.tagline.trim() && (
+          <span className="text-[11px] text-muted">— {onAirPersona.tagline.trim()}</span>
         )}
         <span className="caption ml-4">
-          frequency · {activePersona ? activePersona.frequency : '—'}
+          frequency · {onAirPersona ? onAirPersona.frequency : '—'}
         </span>
-        <span className="caption">voice · {activePersona ? engineLabel(activePersona) : '—'}</span>
-        {activeCloudIssue && (
+        <span className="caption">voice · {onAirPersona ? engineLabel(onAirPersona) : '—'}</span>
+        {onAirCloudIssue && (
           <span className="caption text-[var(--danger)]">
             ⚠ cloud voice inactive, speaking via {defaultEngine}
           </span>
         )}
-        <span className="caption">override · — (a scheduled show may reassign the hour)</span>
+        <span className="caption">
+          {overridden
+            ? `override · “${onAirShow!.name}” owns this hour · default ${defaultPersona ? (defaultPersona.name.trim() || 'Persona') : '—'}`
+            : 'override · none · default persona on air'}
+        </span>
       </div>
     </section>
   );

--- a/web/components/admin/personas/PersonaIdentityCard.tsx
+++ b/web/components/admin/personas/PersonaIdentityCard.tsx
@@ -18,7 +18,10 @@ interface PersonaIdentityCardProps {
   persona: Persona;
   index: number;        // 0-based, for the "persona X of Y" sub
   personaCount: number;
+  // The admin-selected default. `isOnAir` is whether this persona is the one
+  // actually broadcasting right now (a scheduled show can override the default).
   isActive: boolean;
+  isOnAir: boolean;
   canRemove: boolean;
   adminFetch: AdminAuth['adminFetch'];
   avatarTick: number;
@@ -32,7 +35,7 @@ interface PersonaIdentityCardProps {
 }
 
 export function PersonaIdentityCard({
-  persona, index, personaCount, isActive, canRemove, adminFetch, avatarTick, uploading,
+  persona, index, personaCount, isActive, isOnAir, canRemove, adminFetch, avatarTick, uploading,
   update, onSetActive, onRemove, onPickAvatar, onGenerateAvatar, onClearAvatar,
 }: PersonaIdentityCardProps) {
   const soulLen = persona.soul.trim().length;
@@ -43,9 +46,10 @@ export function PersonaIdentityCard({
       sub={`persona ${index + 1} of ${personaCount}`}
       right={
         <>
+          {isOnAir && <Pill tone="accent" className="text-[8px]">on air</Pill>}
           {isActive
-            ? <Pill tone="accent" className="text-[8px]">on air</Pill>
-            : <Btn sm onClick={onSetActive}>Set on air</Btn>}
+            ? <Pill className="text-[8px]">default</Pill>
+            : <Btn sm onClick={onSetActive}>Set as default</Btn>}
           <Btn
             sm
             tone="danger"

--- a/web/components/admin/personas/PersonaRoster.tsx
+++ b/web/components/admin/personas/PersonaRoster.tsx
@@ -11,7 +11,11 @@ import { cn } from '../../../lib/cn';
 
 interface PersonaRosterProps {
   personas: Persona[];
+  // The admin-selected default — gets the "default" pill.
   activePersonaId: string;
+  // The persona actually broadcasting now (show override aware) — gets the
+  // accent dot + "on air" pill. Equals activePersonaId unless a show overrides.
+  onAirPersonaId: string;
   focusedIdx: number;
   avatarTick: number;
   onSelect: (idx: number) => void;
@@ -19,7 +23,7 @@ interface PersonaRosterProps {
 }
 
 export function PersonaRoster({
-  personas, activePersonaId, focusedIdx, avatarTick, onSelect, onAdd,
+  personas, activePersonaId, onAirPersonaId, focusedIdx, avatarTick, onSelect, onAdd,
 }: PersonaRosterProps) {
   const atMax = personas.length >= PERSONA_MAX;
   return (
@@ -27,7 +31,8 @@ export function PersonaRoster({
       <span className="caption">roster · {personas.length} / {PERSONA_MAX}</span>
       <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
         {personas.map((p, i) => {
-          const isActive = p.id === activePersonaId;
+          const isOnAir = p.id === onAirPersonaId;
+          const isDefault = p.id === activePersonaId;
           const isFocused = i === focusedIdx;
           const valid = personaValid(p);
           const src = p.avatar
@@ -62,7 +67,7 @@ export function PersonaRoster({
                 </span>
                 <div className="min-w-0 flex-1">
                   <div className="flex min-w-0 items-center gap-1.5">
-                    {isActive && <span className="size-1.5 flex-none rounded-full bg-[var(--accent)]" />}
+                    {isOnAir && <span className="size-1.5 flex-none rounded-full bg-[var(--accent)]" />}
                     <span className="min-w-0 truncate text-[14px] font-extrabold tracking-[-0.01em] text-ink">
                       {p.name.trim() || `Persona ${i + 1}`}
                     </span>
@@ -73,7 +78,8 @@ export function PersonaRoster({
                 </div>
               </div>
               <div className="flex flex-wrap gap-1.5">
-                {isActive && <Pill tone="accent" className="text-[8px]">on air</Pill>}
+                {isOnAir && <Pill tone="accent" className="text-[8px]">on air</Pill>}
+                {isDefault && !isOnAir && <Pill className="text-[8px]">default</Pill>}
                 <Pill className="text-[8px]">{p.frequency}</Pill>
                 {p.scriptLength === 'extended' && <Pill className="text-[8px]">extended</Pill>}
                 <Pill className="text-[8px]">{p.tts.engine}</Pill>

--- a/web/components/admin/personas/types.ts
+++ b/web/components/admin/personas/types.ts
@@ -55,6 +55,14 @@ export interface VoiceOption {
 }
 
 export interface SettingsResponse {
+  // The persona actually on air right now — resolves a scheduled show's owner
+  // when a show is live this hour, otherwise the admin-selected default. The
+  // roster/hero mark "on air" by this; `values.activePersonaId` is only the
+  // default. Optional so the UI degrades against older controllers.
+  onAir?: {
+    personaId?: string;
+    show?: { id: string; name: string } | null;
+  };
   values?: {
     personas?: Array<Partial<Persona> & { avatar?: string }>;
     activePersonaId?: string;


### PR DESCRIPTION
## Problem

On `/admin/personas`, the roster and hero marked the **live** persona by `activePersonaId` — the admin-selected *default*. When a scheduled show reassigns the hour to a different persona, that's wrong: the listener side (`/now-playing`, `/dj`) correctly reports the show's persona via `getEffectivePersona()`, but the admin page kept showing the default.

Reproduced live: show **The Long Road** (`s_road`, persona **Jagga**) was on air, listeners saw Jagga, but the personas page marked **Heer** (the default) as on air.

Root cause: the personas UI conflated *"selected default"* with *"on air"*. They only coincide when no show is overriding.

## Fix

**Controller** — `/settings` now returns `onAir: { personaId, show }`, computed from `getEffectivePersona()` + `resolveActiveShow()` (the same resolution the listener side uses), so admin and listener agree.

**Web** — `"on air"` now tracks the effective persona everywhere; `activePersonaId` is relabelled the **default**:
- **Roster**: accent dot + `on air` pill follow the broadcasting persona; the default gets a muted `default` pill when a show has overridden it.
- **Hero**: live strip describes who's actually on air; the previously-dead `override · —` line is wired up to name the show owning the hour (e.g. `override · "The Long Road" owns this hour · default Heer`).
- **Editor**: `on air`/`Set on air` → `default`/`Set as default`, plus a separate `on air` pill when the focused persona is broadcasting now.

Degrades gracefully against older controllers (falls back to `activePersonaId` when `onAir` is absent).

## Test plan
- [x] `web`: `eslint` + `tsc --noEmit` pass clean
- [x] `controller`: edited `settings.ts` typechecks clean (other `tsc` errors are the pre-existing missing-`multer` dev-dep gap, unrelated)
- [ ] Manual: with a show overriding the hour, confirm the roster `on air` pill + hero strip name the show's persona, and the default persona carries a `default` pill

Prod needs a rebuild of `controller` + `web` to take effect (`docker compose up -d --build controller web`).