### PR TITLE
fix(embedding): honour EMBEDDING_API_KEY across providers (completes #535)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,10 @@ SITE_URL=
 # AI_GATEWAY_API_KEY=
 # ELEVENLABS_API_KEY=
 # SEARCH_API_KEY=tvly-...
+# Embedding key — only when embeddings use a different provider/key than chat
+# (e.g. OpenRouter for embeddings, a local proxy for chat). Blank → inherit the
+# chat key. OpenRouter embeddings also fall back to OPENROUTER_API_KEY above.
+# EMBEDDING_API_KEY=
 
 # ───────── Acoustic analysis (CLAP audio-similarity + Demucs vocals) ─────────
 # The analysis pass (npm run analyze / admin "Analyze audio") computes bpm, key,

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -731,6 +731,10 @@ SITE_URL=
 # AI_GATEWAY_API_KEY=
 # ELEVENLABS_API_KEY=
 # SEARCH_API_KEY=tvly-...
+# Embedding key — only when embeddings use a different provider/key than chat
+# (e.g. OpenRouter for embeddings, a local proxy for chat). Blank → inherit the
+# chat key. OpenRouter embeddings also fall back to OPENROUTER_API_KEY above.
+# EMBEDDING_API_KEY=
 
 # ───────── Acoustic analysis (CLAP audio-similarity + Demucs vocals) ─────────
 # The analysis pass (npm run analyze / admin "Analyze audio") computes bpm, key,

--- a/cli/src/util.ts
+++ b/cli/src/util.ts
@@ -231,6 +231,7 @@ export const WIZARD_SECRET_KEYS = [
   'AI_GATEWAY_API_KEY',
   'ELEVENLABS_API_KEY',
   'SEARCH_API_KEY',
+  'EMBEDDING_API_KEY',
 ] as const;
 
 // Merge a batch of API keys into state/secrets.env (mode 0600), preserving

--- a/controller/src/llm/internal/provider/embedding.ts
+++ b/controller/src/llm/internal/provider/embedding.ts
@@ -32,7 +32,15 @@ function embeddingCfg() {
     enabled: s.enabled !== false,
     provider: s.provider || llm.provider || 'ollama',
     model: s.model || '',
-    apiKey: s.apiKey || llm.apiKey || '',
+    // Key precedence: the saved settings field wins, then a dedicated
+    // `EMBEDDING_API_KEY` env var (the env path most installs use -- keys live in
+    // state/secrets.env, not settings.json), then the chat key. This is a
+    // runtime env read like config.ts does for SEARCH_API_KEY, so the env value
+    // never gets baked into the persisted settings.json. It covers every
+    // provider uniformly -- including openai-compatible/locca, which can't safely
+    // grab a provider-conventional env var (createOpenAI would otherwise reach
+    // for OPENAI_API_KEY against an arbitrary self-hosted server).
+    apiKey: s.apiKey || process.env.EMBEDDING_API_KEY || llm.apiKey || '',
     ollamaUrl: s.ollamaUrl || llm.ollamaUrl || '',
     baseUrl: s.baseUrl || llm.baseUrl || '',
   };

--- a/controller/src/llm/internal/provider/embedding.ts
+++ b/controller/src/llm/internal/provider/embedding.ts
@@ -160,7 +160,7 @@ export function buildEmbeddingModel(cfg: EmbeddingCfg) {
       // key is required — a missing one 401s with the 'unauthorized' message.
       const provider = createOpenAI({
         baseURL: 'https://openrouter.ai/api/v1',
-        apiKey: cfg.apiKey || 'unused',
+        apiKey: cfg.apiKey || process.env.OPENROUTER_API_KEY || 'unused',
         name: 'openrouter',
       });
       return provider.textEmbeddingModel(id);

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -629,6 +629,7 @@ const DEFAULTS = {
     // e.g. Ollama). See issue #405.
     baseUrl: '',          // openai-compatible / locca embedding server URL (with /v1)
     ollamaUrl: '',        // Ollama embedding server URL (ollama provider)
+    apiKey: '',           // empty -> inherit settings.llm.apiKey
     seedCount: 0,         // 0 → auto max(200, ceil(sqrt(library)))
     knnNeighbours: 5,
     moodVoteThreshold: 0.6,
@@ -1155,6 +1156,10 @@ export async function load() {
         typeof stored.embedding?.ollamaUrl === 'string'
           ? stored.embedding.ollamaUrl.trim()
           : DEFAULTS.embedding.ollamaUrl,
+      apiKey:
+        typeof stored.embedding?.apiKey === 'string'
+          ? stored.embedding.apiKey.trim()
+          : DEFAULTS.embedding.apiKey,
       seedCount:
         Number.isFinite(stored.embedding?.seedCount) && stored.embedding.seedCount >= 0
           ? Math.floor(stored.embedding.seedCount)
@@ -1296,6 +1301,7 @@ export function getRedacted() {
   if (clone.llm?.fallback) clone.llm.fallback.apiKey = s.llm?.fallback?.apiKey ? 'set' : '';
   if (clone.tts?.cloud) clone.tts.cloud.apiKey = s.tts?.cloud?.apiKey ? 'set' : '';
   if (clone.search) clone.search.apiKey = s.search?.apiKey ? 'set' : '';
+  if (clone.embedding) clone.embedding.apiKey = s.embedding?.apiKey ? 'set' : '';
   if (Array.isArray(clone.webhooks)) {
     for (let i = 0; i < clone.webhooks.length; i++) {
       clone.webhooks[i].authHeader = s.webhooks?.[i]?.authHeader ? 'set' : '';
@@ -1983,6 +1989,11 @@ export async function update(patch) {
         throw new Error('embedding.ollamaUrl must start with http:// or https://');
       }
       next.embedding.ollamaUrl = v.replace(/\/+$/, '');
+    }
+    if (e.apiKey !== undefined && e.apiKey !== 'set') {
+      const v = String(e.apiKey).trim();
+      if (v.length > 200) throw new Error('embedding.apiKey must be 0-200 chars');
+      next.embedding.apiKey = v;
     }
     if (e.seedCount !== undefined) {
       const v = parseInt(e.seedCount, 10);

--- a/controller/src/setup/secrets.ts
+++ b/controller/src/setup/secrets.ts
@@ -24,6 +24,10 @@ export const SECRET_ENV_KEYS = [
   'AI_GATEWAY_API_KEY',
   'ELEVENLABS_API_KEY',
   'SEARCH_API_KEY',
+  // Embeddings. Only needed when the embedding provider uses a different key
+  // than chat (e.g. OpenRouter for embeddings, a local proxy for chat) — see
+  // embedding.ts embeddingCfg(). Blank → embeddings inherit settings.llm.apiKey.
+  'EMBEDDING_API_KEY',
   // Scrobbling. See broadcast/scrobble.ts. Env always wins over settings.json,
   // so a host with these in compose env_file works without ever touching the UI.
   'LASTFM_API_KEY',


### PR DESCRIPTION
## What

Make the embedding layer honour a dedicated `EMBEDDING_API_KEY` for every provider, sourced from `state/secrets.env` the same way `SEARCH_API_KEY` is.

Builds directly on @geekylakshya's work in #535 — his three commits are preserved here (settings loader for `embedding.apiKey`, `OPENROUTER_API_KEY` fallback, and the `embeddingCfg()` env read). This adds the remaining piece so the env path actually works end to end.

## Why

#535 added `process.env.EMBEDDING_API_KEY` to `embeddingCfg()`, but for the install shape most operators use — keys in `state/secrets.env`, not pasted into the admin UI — that var was never sourced. `loadSecretsIntoEnv()` only sources keys on the `SECRET_ENV_KEYS` allowlist, and `EMBEDDING_API_KEY` wasn't on it, so it was silently dropped and the embedding request still went out as `Bearer unused` → 401. This closes that gap.

The key now resolves uniformly for openai-compatible, locca, openai and google (not just OpenRouter), without the implicit `OPENAI_API_KEY` grab we deliberately avoided.

## Changes on top of #535

- `controller/src/setup/secrets.ts` — add `EMBEDDING_API_KEY` to `SECRET_ENV_KEYS` (the load-bearing fix).
- `cli/src/util.ts` — mirror it in `WIZARD_SECRET_KEYS` (the two lists are kept in sync).
- `.env.example` + `cli/src/assets.generated.ts` — document it; embedded CLI asset regenerated to match.

## How tested

Verified end to end in the dev stack against a local mock embedding server that logs the `Authorization` header:

| Allowlist has `EMBEDDING_API_KEY`? | Key on the wire |
|---|---|
| Yes (this PR) | `Authorization: Bearer <key from secrets.env>` |
| No (#535 as-is) | `Authorization: Bearer unused` (the 401) |

Same `secrets.env`, same probe — only the allowlist entry differs. `controller` and `cli` `tsc --noEmit` clean; controller eslint 0 errors; `npm --prefix cli run embed-assets` regenerates with no extra diff.

Supersedes #535.
