### PR TITLE
fix(app): drop unused BottomSheetModalProvider that killed touch on Android (New Arch)

### DIFF
--- a/app/src/app/_layout.tsx
+++ b/app/src/app/_layout.tsx
@@ -19,7 +19,6 @@ import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import ErrorScreen from '@/components/ErrorScreen';
 import { StationProvider, useStation } from '@/config/StationContext';
@@ -66,22 +65,26 @@ export default function RootLayout() {
       <SafeAreaProvider>
         <StationProvider>
           <ThemeProvider>
-            <BottomSheetModalProvider>
-              <SplashGate>
-                <StatusBar style="auto" />
-                <Stack
-                  screenOptions={{
-                    headerShown: false,
-                    animation: 'fade',
-                    contentStyle: { backgroundColor: 'transparent' },
-                  }}
-                >
-                  <Stack.Screen name="index" />
-                  <Stack.Screen name="onboarding" />
-                  <Stack.Screen name="stations" options={{ presentation: 'modal' }} />
-                </Stack>
-              </SplashGate>
-            </BottomSheetModalProvider>
+            {/* No BottomSheetModalProvider: the app's only sheet (Themes) uses
+                the *non-modal* <BottomSheet>, which doesn't need it. Wrapping the
+                whole tree in it left an Android touch-interceptor over the app on
+                the New Architecture and killed every tap (device-specific, no
+                crash) — see issue #458. GestureHandlerRootView stays (the
+                non-modal sheet's pan needs it). */}
+            <SplashGate>
+              <StatusBar style="auto" />
+              <Stack
+                screenOptions={{
+                  headerShown: false,
+                  animation: 'fade',
+                  contentStyle: { backgroundColor: 'transparent' },
+                }}
+              >
+                <Stack.Screen name="index" />
+                <Stack.Screen name="onboarding" />
+                <Stack.Screen name="stations" options={{ presentation: 'modal' }} />
+              </Stack>
+            </SplashGate>
           </ThemeProvider>
         </StationProvider>
       </SafeAreaProvider>


### PR DESCRIPTION
## Problem

On the native Android player, the UI rendered and kept live-updating (now-playing, DJ lines) but was **completely dead to touch** — no control responded. It was **device-specific and independent of OS version and GPU**: dead on Pixel 7 Pro, Pixel 10, and Galaxy S22 Ultra; fine on Pixel 8a, Pixel 9 Pro XL, and OnePlus Pad 3 — same app build, same Android version. No crash, no ANR. (#458)

## Root cause

`BottomSheetModalProvider` (`@gorhom/bottom-sheet`) wrapped the entire app in `_layout.tsx`. On the **New Architecture** it leaves an Android touch-interceptor over the whole tree on some devices, swallowing every tap before it reaches the controls while the JS thread keeps running (hence: renders fine, updates fine, no crash). Whether it triggers depends on device/ROM timing, which is why it tracked neither the Android version nor the GPU vendor.

Critically, the app's **only** sheet (the Themes picker) uses gorhom's **non-modal** `<BottomSheet>`, which does **not** require `BottomSheetModalProvider`. The provider was dead weight that only added the touch hazard.

## Fix

Remove the unused `BottomSheetModalProvider`. `GestureHandlerRootView` stays (the non-modal sheet's pan-to-dismiss needs it) and the Themes sheet is unchanged — so there's **no functional or visual loss**.

## How it was found (bisection on real devices)

Blur, the Skia visualiser, and the nav transition were each ruled out by on-device test builds. Then:

- A build with the **whole** gesture-handler + bottom-sheet stack removed → **touch restored** on an affected Pixel 7 Pro (confirmed by @R0ckGam3r).
- This build, removing **only** `BottomSheetModalProvider` (sheet + gestures kept) → **confirmed working** by @R0ckGam3r and @diablo581 ("works on the first try"), Themes sheet included.

## Testing

- Device-confirmed on a previously-dead Pixel 7 Pro and another affected device.
- `tsc --noEmit` clean.

Fixes #458.
