### PR TITLE
fix(app): replace gorhom sheet + drop gesture-handler stack to fix Android dead-touch (New Arch)

### DIFF
--- a/app/src/app/_layout.tsx
+++ b/app/src/app/_layout.tsx
@@ -18,8 +18,13 @@ import { Stack, type ErrorBoundaryProps } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect } from 'react';
-import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
+import { View } from 'react-native';
+// No GestureHandlerRootView / BottomSheetModalProvider: that gesture-handler +
+// bottom-sheet stack installed a root touch interceptor that swallowed every tap
+// across the app on the New Architecture on some Android devices (issue #458).
+// It existed only for the Themes sheet, which is now a core <Modal> (see
+// components/ui/Sheet.tsx). Bisection confirmed on-device: removing this stack
+// is what restores touch.
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import ErrorScreen from '@/components/ErrorScreen';
 import { StationProvider, useStation } from '@/config/StationContext';
@@ -62,29 +67,27 @@ export default function RootLayout() {
   if (!fontsLoaded) return null;
 
   return (
-    <GestureHandlerRootView style={{ flex: 1 }}>
+    <View style={{ flex: 1 }}>
       <SafeAreaProvider>
         <StationProvider>
           <ThemeProvider>
-            <BottomSheetModalProvider>
-              <SplashGate>
-                <StatusBar style="auto" />
-                <Stack
-                  screenOptions={{
-                    headerShown: false,
-                    animation: 'fade',
-                    contentStyle: { backgroundColor: 'transparent' },
-                  }}
-                >
-                  <Stack.Screen name="index" />
-                  <Stack.Screen name="onboarding" />
-                  <Stack.Screen name="stations" options={{ presentation: 'modal' }} />
-                </Stack>
-              </SplashGate>
-            </BottomSheetModalProvider>
+            <SplashGate>
+              <StatusBar style="auto" />
+              <Stack
+                screenOptions={{
+                  headerShown: false,
+                  animation: 'fade',
+                  contentStyle: { backgroundColor: 'transparent' },
+                }}
+              >
+                <Stack.Screen name="index" />
+                <Stack.Screen name="onboarding" />
+                <Stack.Screen name="stations" options={{ presentation: 'modal' }} />
+              </Stack>
+            </SplashGate>
           </ThemeProvider>
         </StationProvider>
       </SafeAreaProvider>
-    </GestureHandlerRootView>
+    </View>
   );
 }

--- a/app/src/components/ui/Sheet.tsx
+++ b/app/src/components/ui/Sheet.tsx
@@ -1,19 +1,16 @@
 // One bottom sheet, content switched by the active drawer — mirrors the single
 // <Sheet> in web PlayerApp.
 //
-// Driven declaratively by a controlled `index` (0 = open, -1 = closed) rather
-// than imperative present()/dismiss() on a modal ref. The modal+ref+effect
-// approach proved flaky here (the sheet's state and the present() call could
-// race, so it took multiple taps to open); a controlled non-modal BottomSheet
-// animates straight to the target index and is reliable on the first tap.
+// Built on React Native's core <Modal>, NOT @gorhom/bottom-sheet. gorhom (and
+// the react-native-gesture-handler it rides on) installed a root touch
+// interceptor that swallowed every tap across the whole app on the New
+// Architecture on some Android devices — renders fine, no crash, just dead to
+// touch (issue #458). A core <Modal> renders in its own native window and
+// nothing at all when closed, so it can't intercept the app's touches. We lose
+// drag-to-dismiss; tap-the-scrim or the back button closes it.
 
-import BottomSheet, {
-  BottomSheetBackdrop,
-  BottomSheetScrollView,
-  type BottomSheetBackdropProps,
-} from '@gorhom/bottom-sheet';
-import { useCallback, useMemo, useRef } from 'react';
-import { Text, View } from 'react-native';
+import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '@/theme/ThemeContext';
 
 export interface SheetProps {
@@ -24,59 +21,52 @@ export interface SheetProps {
 }
 
 export function Sheet({ open, onClose, title, children }: SheetProps) {
-  const ref = useRef<BottomSheet>(null);
   const { colors } = useTheme();
-  const snapPoints = useMemo(() => ['60%', '92%'], []);
-
-  const renderBackdrop = useCallback(
-    (props: BottomSheetBackdropProps) => (
-      <BottomSheetBackdrop
-        {...props}
-        appearsOnIndex={0}
-        disappearsOnIndex={-1}
-        pressBehavior="close"
-        opacity={0.5}
-      />
-    ),
-    [],
-  );
-
-  // onClose() is the single source of truth for "user dismissed it" — fired
-  // when the sheet animates to index -1 (pan-down or backdrop press).
-  const handleChange = useCallback(
-    (index: number) => {
-      if (index === -1 && open) onClose();
-    },
-    [open, onClose],
-  );
+  const insets = useSafeAreaInsets();
 
   return (
-    <BottomSheet
-      ref={ref}
-      index={open ? 0 : -1}
-      snapPoints={snapPoints}
-      // Explicit snapPoints → dynamic content sizing must be OFF, or the first
-      // layout mis-measures the scroll view height.
-      enableDynamicSizing={false}
-      enablePanDownToClose
-      onChange={handleChange}
-      backdropComponent={renderBackdrop}
-      handleIndicatorStyle={{ backgroundColor: colors.muted }}
-      backgroundStyle={{ backgroundColor: colors.bg }}
+    <Modal
+      visible={open}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+      statusBarTranslucent
+      navigationBarTranslucent
     >
-      <BottomSheetScrollView
-        contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 48 }}
-      >
-        {title ? (
-          <Text
-            className="font-display text-ink"
-            style={{ fontSize: 22, marginTop: 4, marginBottom: 16 }}
-          >
-            {title}
-          </Text>
-        ) : null}
-        <View>{children}</View>
-      </BottomSheetScrollView>
-    </BottomSheet>
+      <View style={{ flex: 1, justifyContent: 'flex-end' }}>
+        {/* Dimmed scrim — tap to dismiss. Sits behind the panel. */}
+        <Pressable
+          style={[StyleSheet.absoluteFill, { backgroundColor: 'rgba(0,0,0,0.5)' }]}
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel="Close"
+        />
+        <View
+          style={{
+            maxHeight: '88%',
+            backgroundColor: colors.bg,
+            borderTopLeftRadius: 16,
+            borderTopRightRadius: 16,
+            paddingBottom: insets.bottom + 8,
+          }}
+        >
+          {/* Grabber */}
+          <View style={{ alignItems: 'center', paddingTop: 10, paddingBottom: 4 }}>
+            <View style={{ width: 40, height: 4, borderRadius: 2, backgroundColor: colors.muted }} />
+          </View>
+          <ScrollView contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 48 }}>
+            {title ? (
+              <Text
+                className="font-display text-ink"
+                style={{ fontSize: 22, marginTop: 4, marginBottom: 16 }}
+              >
+                {title}
+              </Text>
+            ) : null}
+            <View>{children}</View>
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
   );
 }

--- a/app/src/player/drawers/ScheduleDrawer.tsx
+++ b/app/src/player/drawers/ScheduleDrawer.tsx
@@ -2,7 +2,7 @@
 // persona avatars. Ported from web ScheduleDrawer — same slot-collapsing logic.
 
 import { Image } from 'expo-image';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Pressable, ScrollView, Text, View } from 'react-native';
 import { useAppActive } from '@/hooks/useAppActive';
 import type { StationApi } from '@/lib/api';
@@ -19,6 +19,32 @@ const DAY_LABELS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
 
 function pad2(n: number): string {
   return n < 10 ? `0${n}` : String(n);
+}
+
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+// Day-of-week (0=Sun) and hour (0–23) in the station's IANA timezone, so the
+// "now" highlight matches the station clock shown in the header rather than the
+// viewer's local time. Falls back to the device's local time when no tz is set
+// or Hermes' Intl lacks timeZone support (same guard as the time formatter).
+function tzNow(now: Date, tz?: string | null): { day: number; hour: number } {
+  if (tz) {
+    try {
+      const parts = new Intl.DateTimeFormat('en-US', {
+        timeZone: tz,
+        weekday: 'short',
+        hour: '2-digit',
+        hour12: false,
+      }).formatToParts(now);
+      const day = WEEKDAYS.indexOf(parts.find((p) => p.type === 'weekday')?.value ?? '');
+      let hour = parseInt(parts.find((p) => p.type === 'hour')?.value ?? '', 10);
+      if (hour === 24) hour = 0; // some engines emit "24" at midnight
+      if (day >= 0 && Number.isFinite(hour)) return { day, hour };
+    } catch {
+      /* fall through to device-local */
+    }
+  }
+  return { day: now.getDay(), hour: now.getHours() };
 }
 
 interface Slot {
@@ -60,9 +86,9 @@ export default function ScheduleDrawer({ api, activeShow, context }: ScheduleDra
   const appActive = useAppActive();
   const [data, setData] = useState<SchedulePayload | null>(null);
   const [err, setErr] = useState<string | null>(null);
-  const today = useMemo(() => new Date().getDay(), []);
-  const [day, setDay] = useState(today);
-  const currentHour = useMemo(() => new Date().getHours(), []);
+  // null until the user taps a day tab; before that the view follows the
+  // station's "today" (see todayTz below), so it's correct across timezones.
+  const [pickedDay, setPickedDay] = useState<number | null>(null);
   const [now, setNow] = useState(() => new Date());
   const location = context?.weather?.location ?? null;
 
@@ -88,6 +114,11 @@ export default function ScheduleDrawer({ api, activeShow, context }: ScheduleDra
   if (!data) {
     return <Text className="font-body text-muted" style={{ fontSize: 13 }}>Loading schedule…</Text>;
   }
+
+  // "Today" and the current hour in the station's timezone — what drives the
+  // NOW highlight and the today marker, matching the station-time clock above.
+  const { day: todayTz, hour: currentHour } = tzNow(now, data.timezone);
+  const day = pickedDay ?? todayTz;
 
   const slots = collapseSlots(data.schedule?.[day] ?? [], data.shows || [], data.personas || []);
 
@@ -149,7 +180,7 @@ export default function ScheduleDrawer({ api, activeShow, context }: ScheduleDra
             return (
               <Pressable
                 key={label}
-                onPress={() => setDay(d)}
+                onPress={() => setPickedDay(d)}
                 accessibilityRole="button"
                 accessibilityLabel={`Day ${label}`}
                 accessibilityState={{ selected: active }}
@@ -166,7 +197,7 @@ export default function ScheduleDrawer({ api, activeShow, context }: ScheduleDra
                   style={{ fontSize: 10, letterSpacing: 1, color: active ? colors.bg : colors.muted }}
                 >
                   {label}
-                  {d === today ? ' ·' : ''}
+                  {d === todayTz ? ' ·' : ''}
                 </Text>
               </Pressable>
             );
@@ -175,7 +206,7 @@ export default function ScheduleDrawer({ api, activeShow, context }: ScheduleDra
       </ScrollView>
 
       {slots.map((slot) => {
-        const isNow = day === today && currentHour >= slot.hour && currentHour <= slot.endHour;
+        const isNow = day === todayTz && currentHour >= slot.hour && currentHour <= slot.endHour;
         const range = `${pad2(slot.hour)}:00 – ${pad2((slot.endHour + 1) % 24)}:00`;
         return (
           <View


### PR DESCRIPTION
## Problem

On the native Android player the UI rendered and kept live-updating (now-playing, DJ lines) but was **completely dead to touch** — no control responded, no crash, no ANR. Device/ROM-flaky and independent of OS version and GPU: dead on Pixel 7 Pro, Pixel 10, Galaxy S22 Ultra; fine on Pixel 8a, Pixel 9 Pro XL, OnePlus Pad 3 — same build, same Android version. (#458)

## Root cause

The `@gorhom/bottom-sheet` + `react-native-gesture-handler` stack — `GestureHandlerRootView` + `BottomSheetModalProvider` wrapping the whole app in `_layout.tsx`, plus the always-mounted non-modal `<BottomSheet>` — installed a root touch interceptor that swallowed every tap across the app on the **New Architecture** on some Android devices. The JS thread kept running (hence: renders fine, feed keeps updating, no crash), the taps just never arrived. It existed only for the Themes sheet.

## Fix

Rebuild the Themes sheet on React Native's core `<Modal>` (no gorhom, no gesture-handler) and drop `GestureHandlerRootView` + `BottomSheetModalProvider` from the root. A core `<Modal>` renders in its own native window and **nothing at all when closed**, so it can't intercept the app's touches. Trade-off: the sheet loses drag-to-dismiss (scrim-tap / back-button close it). The two now-unused deps are left installed; can be pruned in a follow-up.

## How it was found (on-device bisection)

Each suspect was ruled in/out with an EAS preview APK on affected devices:

| Build | Change | Result |
|---|---|---|
| BlurView `pointerEvents` / removal | — | still dead |
| Skia visualiser off | — | still dead |
| nav `animation:none` + opaque bg | — | still dead |
| **whole gesture/bottom-sheet stack removed** | — | **touch restored** (R0ckGam3r) |
| only `BottomSheetModalProvider` removed | — | still dead, and flaky enough to pass a first-try test |
| **this PR** — RN Modal sheet + stack dropped | — | **confirmed holding across relaunches + station switches** (R0ckGam3r) |

The bug is flaky, so "works once" was not trusted — this was confirmed across multiple force-close/relaunch cycles on a previously-dead Pixel 7 Pro.

## Testing

- Device-confirmed on a previously-dead Pixel 7 Pro across multiple relaunches and station switches; Themes sheet works.
- `tsc --noEmit` clean.

Fixes #458.
