### PR TITLE
fix(dj): apply persona language to agent segments + cloud TTS (#558)

### DIFF
--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -158,6 +158,15 @@ export async function speak(
   const speakText = normalizeForSpeech(text);
   const personaTts = djPersonaTts(kind);
   const primary = resolveEngine(kind, personaTts);
+  // Persona on-air language (e.g. "French") rides along to the cloud engine as a
+  // pronunciation hint so a non-English script isn't read with English phonetics
+  // (issue #558). DJ-voiced kinds only — never jingles — and '' (ignored) for
+  // the default English persona. Local engines ignore the field; only
+  // cloud-speech.ts reads it (the voice model carries the language for piper /
+  // kokoro / pocket-tts).
+  const language = GLOBAL_VOICE_KINDS.has(kind)
+    ? ''
+    : String(settings.getEffectivePersona()?.language || '').trim();
   // Delivery pace tracks the daypart for live, persona-voiced segments.
   // `speedScale` is a MULTIPLIER on the engine's configured speech rate (1.0 =
   // unchanged), so it composes with — rather than overrides — an operator's
@@ -173,7 +182,7 @@ export async function speak(
   const started = Date.now();
   const chars = (speakText || '').length;
   try {
-    const result = await speakWith(primary, speakText, { outPath, speedScale: scale }, personaTts);
+    const result = await speakWith(primary, speakText, { outPath, speedScale: scale, language }, personaTts);
     recordTts({
       kind, engine: primary, requested: primary, fellBack: false,
       ok: true, ms: Date.now() - started, chars, t: new Date().toISOString(),
@@ -194,7 +203,7 @@ export async function speak(
     }
     console.error(`[tts] ${primary} failed for kind=${kind}: ${err.message} — falling back to ${fallback}`);
     try {
-      const result = await speakWith(fallback, speakText, { outPath, speedScale: scale }, personaTts);
+      const result = await speakWith(fallback, speakText, { outPath, speedScale: scale, language }, personaTts);
       recordTts({
         kind, engine: fallback, requested: primary, fellBack: true,
         ok: true, ms: Date.now() - started, chars, t: new Date().toISOString(),

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -211,13 +211,14 @@ export function pickSystem() {
 
 You run the station as one continuous shift. The messages above are the live session.${djModeLine}${showLine}${musicLean}
 
-${dj.PICKER_CRITERIA}`;
+${dj.PICKER_CRITERIA}${settings.agentLanguageReminder(persona, 'the "say" link')}`;
 }
 
 function requestSystem() {
-  return `${settings.agentPersonaPreamble(settings.getEffectivePersona(), { rules: false })}
+  const persona = settings.getEffectivePersona();
+  return `${settings.agentPersonaPreamble(persona, { rules: false })}
 
-The messages above are the live session — the last user turn is a listener request.`;
+The messages above are the live session — the last user turn is a listener request.${settings.agentLanguageReminder(persona, 'the "ack" and "intro" lines')}`;
 }
 
 // --- Agent circuit breaker ---------------------------------------------------

--- a/controller/src/llm/internal/speech/cloud-speech.ts
+++ b/controller/src/llm/internal/speech/cloud-speech.ts
@@ -40,6 +40,54 @@ function clampSpeed(speed: any, provider: string) {
   return Math.min(hi, Math.max(lo, n));
 }
 
+// Minimal language-name → ISO 639-1 map for the ElevenLabs `language` param
+// (its language_code). OpenAI's gpt-4o-mini-tts takes a free-text instruction
+// instead, so it needs no map. Best-effort — an unknown name falls through to
+// no code (the script text still carries the language); extend as needed.
+const LANG_ISO: Record<string, string> = {
+  english: 'en', french: 'fr', spanish: 'es', german: 'de', italian: 'it',
+  portuguese: 'pt', dutch: 'nl', polish: 'pl', russian: 'ru', turkish: 'tr',
+  arabic: 'ar', hindi: 'hi', japanese: 'ja', korean: 'ko', chinese: 'zh',
+  mandarin: 'zh', cantonese: 'zh', swedish: 'sv', norwegian: 'no',
+  danish: 'da', finnish: 'fi', greek: 'el', czech: 'cs', romanian: 'ro',
+  hungarian: 'hu', ukrainian: 'uk', indonesian: 'id', malay: 'ms',
+  filipino: 'fil', tagalog: 'tl', vietnamese: 'vi', thai: 'th', hebrew: 'he',
+  bulgarian: 'bg', croatian: 'hr', slovak: 'sk', tamil: 'ta', punjabi: 'pa',
+  bengali: 'bn', urdu: 'ur', persian: 'fa', farsi: 'fa',
+};
+
+function isoCodeFor(name: string): string | null {
+  const key = name.trim().toLowerCase();
+  if (LANG_ISO[key]) return LANG_ISO[key];
+  // "brazilian portuguese" / "latin american spanish" → match the last word.
+  const last = key.split(/\s+/).pop() || '';
+  return LANG_ISO[last] || null;
+}
+
+// Per-provider pronunciation hint from the persona's on-air language, so a
+// non-English script isn't read with English phonetics (issue #558). OpenAI's
+// gpt-4o-mini-tts honours a free-text `instructions` field (tts-1 / tts-1-hd
+// ignore it harmlessly); ElevenLabs honours an ISO `language` code. Both are
+// top-level generateSpeech params. openai-compatible servers vary on which
+// fields they accept (the same reason `speed` is skipped for them), so they get
+// no hint. Empty language → {} so the default English path stays byte-identical.
+function languageHint(language: string | undefined, provider: string, model: string): { instructions?: string; language?: string } {
+  const lang = String(language || '').trim();
+  if (!lang) return {};
+  if (provider === 'openai') {
+    // `instructions` only steers gpt-4o*-tts models; tts-1 / tts-1-hd ignore or
+    // reject it, so don't send it there (a 400 would drop us to an English
+    // local fallback — worse than no hint).
+    if (!/gpt-4o.*tts/i.test(String(model || ''))) return {};
+    return { instructions: `Speak entirely in ${lang}, using natural, native ${lang} pronunciation and accent. Do not read the text with an English accent.` };
+  }
+  if (provider === 'elevenlabs') {
+    const iso = isoCodeFor(lang);
+    return iso ? { language: iso } : {};
+  }
+  return {};
+}
+
 function cloudCfg() {
   return settings.get().tts?.cloud || {};
 }
@@ -107,7 +155,7 @@ export function isConfigured(providerOverride: string | null = null) {
 // provider + voice while still sharing the global model + apiKey from Settings.
 export async function speak(
   text: string,
-  { outPath, cloudOverride = null, speedScale }: { outPath?: string; cloudOverride?: any; speedScale?: number } = {},
+  { outPath, cloudOverride = null, speedScale, language }: { outPath?: string; cloudOverride?: any; speedScale?: number; language?: string } = {},
 ) {
   if (!text || !text.trim()) throw new Error('Empty TTS text');
   const base = cloudCfg();
@@ -142,6 +190,8 @@ export async function speak(
     text,
     voice: c.voice || undefined,
     ...(speed !== 1.0 ? { speed } : {}),
+    // Persona on-air language → provider-native pronunciation hint (issue #558).
+    ...languageHint(language, c.provider, c.model),
     // ElevenLabs gates 44.1 kHz PCM/WAV behind paid tiers — a free/lower-tier
     // key 403s ("Forbidden") on pcm_44100. mp3 is allowed on every tier and
     // OpenAI honours it too, so it's the safe cross-provider request.

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -2249,6 +2249,25 @@ export function languageDirective(persona: any) {
   return `\n\nIMPORTANT: You speak and write exclusively in ${lang}. Every on-air line you produce must be in ${lang} — acknowledgements, idents, asides, everything. Keep proper nouns (artist names, song titles, the station name) exactly as they are; do not translate them.`;
 }
 
+// A SECOND language reminder, anchored at the END of a tool-loop agent's system
+// prompt and naming the exact spoken output field(s). The preamble's
+// languageDirective sits at the TOP of a long, English-dominated tool-loop
+// prompt (tool descriptions, picker criteria, capability lists), and small /
+// cloud models drop it in favour of the English Zod field descriptions sitting
+// right next to the actual spoken output — so the picker `say`, request
+// `ack`/`intro`, and segment `text` came out English even with the directive
+// present (issue #558). Repeating the language LAST, by field name, is what
+// makes it stick — the same trick the request matcher already uses for its
+// `ack` field (see llm/internal/prompts/request.ts). Returns '' for English
+// personas so those prompts stay byte-identical. `fields` is a human phrase
+// naming the spoken field(s), e.g. 'the "say" link' or 'the "ack" and "intro"
+// lines'.
+export function agentLanguageReminder(persona: any, fields: string) {
+  const lang = String(persona?.language || '').trim();
+  if (!lang) return '';
+  return `\n\nLANGUAGE — this overrides the field descriptions below: you speak ${lang}. Write ${fields} entirely in ${lang}; that is the text the listener hears on air. Keep proper nouns (artist names, song titles, the station name) exactly as they are; do not translate them. Internal fields (ids, reasons, kinds) stay in English.`;
+}
+
 // Render the DJ system prompt by substituting {name}, {soul}, {station},
 // {location}, {language}. {name}/{soul} come from the supplied persona; the
 // template is the global djPrompt (falling back to DEFAULT_DJ_PROMPT_TEMPLATE).

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -253,7 +253,7 @@ function directorSystem(persona: any, caps: any[], freq: string, sfxCatalog: any
 Your job: decide whether to air ONE between-track segment, or stay silent. You are NOT choosing music. ${tone}
 
 Capabilities available this tick (pick one of these kinds, or stay silent):
-${capList}${sfxBlock(sfxCatalog)}`;
+${capList}${sfxBlock(sfxCatalog)}${settings.agentLanguageReminder(persona, 'the "text" line')}`;
 }
 
 // Wall-clock ceiling for a single segment-director run, resolved live so it
@@ -430,7 +430,7 @@ function forcedSystem(persona, cap, sfxCatalog) {
 
 The operator asked you to air ONE ${cap.kind} segment now — you must produce a line, silence is not an option. You are NOT choosing music.
 
-${cap.desc}${sfxBlock(sfxCatalog)}`;
+${cap.desc}${sfxBlock(sfxCatalog)}${settings.agentLanguageReminder(persona, 'the "text" line')}`;
 }
 
 // The operator-override variant of directorAgent — exactly one capability,


### PR DESCRIPTION
## Problem (#558)

The per-persona `language` field reached every spoken prompt path via the agent preamble, but in the **tool-loop agents** the directive sat at the top of a long, English-dominated prompt and lost to the English Zod field descriptions sitting right next to the output. So the **auto-segment director**, **picker `say` links**, and **request `ack`/`intro`** stayed in English, while the single-shot booth path (which the directive dominates) worked. Additionally, **cloud TTS received no language hint**, so a non-English script could be read with English phonetics.

## Fix

**LLM side** — add `settings.agentLanguageReminder()`: a second, output-anchored language line appended to the picker, request, segment-director, and forced-segment system prompts, naming the spoken field explicitly (mirrors the request matcher's existing `ack` reinforcement in `llm/internal/prompts/request.ts`). No-op for English personas, so default prompts stay byte-identical.

**Cloud TTS side** — thread the persona language through `tts.speak` → `cloud.speak` and emit a provider-native pronunciation hint:
- OpenAI `gpt-4o*-tts` → free-text `instructions` (gated off `tts-1`/`tts-1-hd`, which would 400 and drop to an English local fallback)
- ElevenLabs → ISO `language` code via a small name→ISO map
- `openai-compatible` skipped (servers vary, same as `speed`)
- Local engines carry language via the voice model and ignore the field.

## Testing

- Wiring verified live: the reminder is present in the real picker + segment prompts (`reminder in fixed: true | in shipped: false`).
- Picker + segment A/B on `gemma4:31b-cloud` (the same Gemma family as the affected setups): clean French output, with **no regression** from the reminder.
- Cloud TTS exercised end-to-end against real ElevenLabs `eleven_flash_v2_5`: `language='fr'` threads through and the provider accepts it (output differs vs. no-hint).
- `npm run lint` (eslint + tsc) passes.

## Scope

Partial fix for #558 — covers the two code-fixable parts (LLM agent paths + cloud TTS hint). The remaining TTS gap is engine-level: PocketTTS (kyutai, English-centric) and Piper (language-baked-into-voice) need a language-appropriate voice selected, which is operator config rather than a code change.