### PR TITLE
release: app 1.3.0 (marketing version + Android build fix)

### DIFF
--- a/.claude/skills/subwave-app-android-release/SKILL.md
+++ b/.claude/skills/subwave-app-android-release/SKILL.md
@@ -112,6 +112,57 @@ on its own.
 > `eas submit --platform android --profile production --non-interactive` pushes to
 > the `internal` track as a `draft`. Until that file exists, upload manually.
 
+## Local build — when the EAS cloud Android quota is exhausted (`--local`)
+
+The EAS **Free plan caps Android cloud builds per calendar month** (resets on the
+1st; iOS has a separate quota). When it's used up, `eas build -p android --profile
+production` fails at queue time with *"used its Android builds from the Free
+plan this month."* Build the `.aab` **locally** instead — it bypasses the cloud
+quota entirely and still signs with the EAS-managed keystore, so the bundle is
+Play-valid. Same artifact, same signing, just compiled on this Mac.
+
+```bash
+cd "$APP"
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+export JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home  # JDK 17 (Expo SDK 56)
+export PATH="$JAVA_HOME/bin:$PATH"
+eas build --platform android --profile production --local --non-interactive \
+  --output "$APP/build/subwave-android-<ver>.aab"
+```
+
+`versionCode` still auto-increments remotely. When it finishes, verify and upload
+exactly as in the Play Store section above:
+
+```bash
+"$JAVA_HOME/bin/jarsigner" -verify "$APP/build/subwave-android-<ver>.aab"   # expect: "jar verified."
+```
+
+**Prereqs on this machine** (all in place as of the 1.3.0 release): Android SDK at
+`~/Library/Android/sdk` (build-tools 35/36, platform-tools), JDK 17 via Homebrew
+(`brew install openjdk@17`), and a logged-in `eas whoami`. The `withGradleMemory`
+config plugin (`app/plugins/`) raises the Gradle/Kotlin JVM metaspace during
+prebuild, so the local build no longer needs a manual `~/.gradle/gradle.properties`
+tweak.
+
+**Three failure modes, each fixed once** (learned cutting 1.3.0):
+
+1. **Disk.** Needs **~15+ GB free** — native compile across ABIs is hungry. A run
+   that dies on `ENOSPC` leaves a ~2 GB stale temp at
+   `$TMPDIR/eas-build-local-nodejs`; `rm -rf` it before retrying.
+2. **Corrupt NDK.** A disk-interrupted NDK download leaves a partial
+   `~/Library/Android/sdk/ndk/27.0.12077973` with no `source.properties`, and the
+   next run dies with `[CXX1101] … did not have a source.properties file`. Fix:
+   `rm -rf` that NDK dir so Gradle re-downloads it clean.
+3. **KSP Metaspace OOM** (only if the `withGradleMemory` plugin is somehow absent).
+   `:expo-updates:kspReleaseKotlin` throws `OutOfMemoryError: Metaspace` and the
+   Gradle daemon dies. The plugin fixes this in-repo; the manual fallback is a
+   `~/.gradle/gradle.properties` with `org.gradle.jvmargs=-Xmx3072m
+   -XX:MaxMetaspaceSize=1536m` + `kotlin.daemon.jvmargs=-Xmx2048m
+   -XX:MaxMetaspaceSize=1024m` (user-home wins over the regenerated project file).
+
+A full clean local build is ~20 min. If the cloud quota has reset, prefer the
+plain cloud `production` build above — it's simpler and offloads the compile.
+
 ## Quick sideload test (skip the store) — `preview`
 
 For handing a build straight to a tester without the Play Store:

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -42,3 +42,6 @@ secrets/
 # generated native folders
 /ios
 /android
+
+# local EAS build output (eas build --local --output)
+/build/

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "SUB/WAVE",
     "slug": "subwave",
     "scheme": "subwave",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -78,7 +78,8 @@
           "version": "8.14.3"
         }
       ],
-      "./plugins/withAndroidUserCaTrust"
+      "./plugins/withAndroidUserCaTrust",
+      "./plugins/withGradleMemory"
     ],
     "experiments": {
       "typedRoutes": true

--- a/app/plugins/withGradleMemory.js
+++ b/app/plugins/withGradleMemory.js
@@ -1,0 +1,36 @@
+// Expo config plugin: raise the Gradle/Kotlin JVM memory for the Android build.
+//
+// `expo prebuild` bakes `org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m`
+// into android/gradle.properties. 512m of Metaspace is too small for this
+// module set: the KSP/Kotlin step (`:expo-updates:kspReleaseKotlin`) throws
+// `OutOfMemoryError: Metaspace` and crashes the Gradle daemon. It bites hardest
+// on a local `eas build --local` (EAS cloud workers have more headroom), but the
+// ceiling is too low everywhere. We raise the metaspace ceiling and give the
+// Kotlin daemon its own budget. This is build-time only — it does not change the
+// app binary. expo-build-properties has no setting for JVM args, so we edit
+// gradle.properties via withGradleProperties.
+//
+// Usage in app.json plugins: "./plugins/withGradleMemory"
+
+const { withGradleProperties } = require('@expo/config-plugins');
+
+const PROPS = {
+  'org.gradle.jvmargs': '-Xmx3072m -XX:MaxMetaspaceSize=1536m -Dfile.encoding=UTF-8',
+  'kotlin.daemon.jvmargs': '-Xmx2048m -XX:MaxMetaspaceSize=1024m',
+};
+
+module.exports = function withGradleMemory(config) {
+  return withGradleProperties(config, (cfg) => {
+    for (const [key, value] of Object.entries(PROPS)) {
+      const existing = cfg.modResults.find(
+        (item) => item.type === 'property' && item.key === key,
+      );
+      if (existing) {
+        existing.value = value;
+      } else {
+        cfg.modResults.push({ type: 'property', key, value });
+      }
+    }
+    return cfg;
+  });
+};


### PR DESCRIPTION
Promotes the **SUB/WAVE app 1.3.0** release to `main`.

The user-facing 1.3.0 changes (Android dead-touch fix, user-installed CA trust, connection-failure diagnostics + HTTP/HTTPS onboarding toggle, request-drawer fix) already landed on `main` in prior release PRs. This PR carries the remaining release pieces:

## Other
- `chore(app): bump marketing version to 1.3.0` — `app.json` `expo.version` `1.2.0` → `1.3.0` (the App Store / Play marketing version; EAS owns build number / versionCode).
- `chore(app): raise Gradle/Kotlin JVM memory to fix Android KSP Metaspace OOM` — new `app/plugins/withGradleMemory` config plugin. Expo's baked-in `MaxMetaspaceSize=512m` is too small for this module set; `:expo-updates:kspReleaseKotlin` OOMs and crashes the Gradle daemon. Build-time only; does not change the app binary.
- `docs(skill)` — documents the local Android build fallback for when the EAS cloud quota is exhausted; ignores `/build/`.

## Release state
1.3.0 binaries are already cut from these changes:
- **iOS 1.3.0** — submitted, in App Store review.
- **Android 1.3.0** (versionCode 16) — `.aab` built locally (EAS keystore-signed), pending Play Console upload.

## Notes for the merger
- `develop` is 6 commits behind `main` on **release-please bookkeeping only** (`chore(main): release 0.27.0`/`0.28.0` version bumps) — no real source is missing; the merge 3-way-resolves and `main`'s versions/CHANGELOG survive. A back-merge `main → develop` should follow once this lands to close the gap.
- These are `chore`/`docs` commits, so release-please won't compute a new project version from this PR — expected; the app carries its own marketing version.