### PR TITLE
Feat/api key test button

### DIFF
--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -262,7 +262,7 @@ async function probeKey(
       try {
         const model = activeModel('anthropic') || 'claude-haiku-4-5-20251001';
         const m = createAnthropic({ apiKey: value })(model);
-        const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
+        await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
         return { ok: true, message: `✓ Anthropic key valid · model responded` };
       } catch (err) { return { ok: false, message: briefLlmError(err) }; }
     }
@@ -270,7 +270,7 @@ async function probeKey(
       try {
         const model = activeModel('openai') || 'gpt-4o-mini';
         const m = createOpenAI({ apiKey: value })(model);
-        const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
+        await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
         return { ok: true, message: `✓ OpenAI key valid · model responded` };
       } catch (err) { return { ok: false, message: briefLlmError(err) }; }
     }
@@ -278,7 +278,7 @@ async function probeKey(
       try {
         const model = activeModel('google') || 'gemini-1.5-flash';
         const m = createGoogleGenerativeAI({ apiKey: value })(model);
-        const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
+        await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
         return { ok: true, message: `✓ Google key valid · model responded` };
       } catch (err) { return { ok: false, message: briefLlmError(err) }; }
     }
@@ -286,7 +286,7 @@ async function probeKey(
       try {
         const model = activeModel('deepseek') || 'deepseek-chat';
         const m = createDeepSeek({ apiKey: value })(model);
-        const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
+        await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
         return { ok: true, message: `✓ DeepSeek key valid · model responded` };
       } catch (err) { return { ok: false, message: briefLlmError(err) }; }
     }
@@ -294,7 +294,7 @@ async function probeKey(
       try {
         const model = activeModel('openrouter') || 'openai/gpt-4o-mini';
         const m = createOpenRouter({ apiKey: value })(model);
-        const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
+        await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
         return { ok: true, message: `✓ OpenRouter key valid · model responded` };
       } catch (err) { return { ok: false, message: briefLlmError(err) }; }
     }

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -16,6 +16,12 @@ import { restartLiquidsoap, startStream, stopStream, streamStatus } from '../bro
 import { invalidateWeatherCache } from '../context.js';
 import { requireAdmin } from '../middleware/auth.js';
 import { saveSecrets, SECRET_ENV_KEYS } from '../setup/secrets.js';
+import { generateText } from 'ai';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { createOpenAI } from '@ai-sdk/openai';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { createDeepSeek } from '@ai-sdk/deepseek';
+import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 import { tagger } from '../broadcast/tagger.js';
 import { skillCatalog } from '../skills/_agent.js';
 import { clearUserThemeCache, loadUserThemes, listThemes, saveUserTheme } from '../themes.js';
@@ -211,6 +217,140 @@ router.post('/settings/secrets', requireAdmin, async (req, res) => {
     res.json({ saved: Object.keys(patch) });
   } catch (err: any) {
     res.status(400).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// probeKey — non-mutating live probe for a single secret key.
+// Builds a one-off provider client using the supplied value; never writes to
+// process.env or secrets.env. Always resolves (never rejects).
+// ---------------------------------------------------------------------------
+async function probeKey(
+  key: (typeof SECRET_ENV_KEYS)[number],
+  value: string,
+): Promise<{ ok: boolean; message: string }> {
+  const cfg = settings.get().llm || {};
+  const activeModel = (provider: string) =>
+    cfg.provider === provider ? (cfg.model || '') : '';
+
+  switch (key) {
+    case 'ANTHROPIC_API_KEY': {
+      const model = activeModel('anthropic') || 'claude-haiku-4-5-20251001';
+      const m = createAnthropic({ apiKey: value })(model);
+      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8 });
+      return { ok: true, message: `✓ Anthropic responded · "${(out.text || '').trim().slice(0, 40)}"` };
+    }
+    case 'OPENAI_API_KEY': {
+      const model = activeModel('openai') || 'gpt-4o-mini';
+      const m = createOpenAI({ apiKey: value })(model);
+      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8 });
+      return { ok: true, message: `✓ OpenAI responded · "${(out.text || '').trim().slice(0, 40)}"` };
+    }
+    case 'GOOGLE_GENERATIVE_AI_API_KEY': {
+      const model = activeModel('google') || 'gemini-1.5-flash';
+      const m = createGoogleGenerativeAI({ apiKey: value })(model);
+      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8 });
+      return { ok: true, message: `✓ Google responded · "${(out.text || '').trim().slice(0, 40)}"` };
+    }
+    case 'DEEPSEEK_API_KEY': {
+      const model = activeModel('deepseek') || 'deepseek-chat';
+      const m = createDeepSeek({ apiKey: value })(model);
+      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8 });
+      return { ok: true, message: `✓ DeepSeek responded · "${(out.text || '').trim().slice(0, 40)}"` };
+    }
+    case 'OPENROUTER_API_KEY': {
+      const model = activeModel('openrouter') || 'openai/gpt-4o-mini';
+      const m = createOpenRouter({ apiKey: value })(model);
+      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8 });
+      return { ok: true, message: `✓ OpenRouter responded · "${(out.text || '').trim().slice(0, 40)}"` };
+    }
+    case 'AI_GATEWAY_API_KEY': {
+      return { ok: false, message: 'AI Gateway key cannot be tested without a model URL — save and test via an LLM call.' };
+    }
+    case 'ELEVENLABS_API_KEY': {
+      const r = await fetch('https://api.elevenlabs.io/v1/user', {
+        headers: { 'xi-api-key': value },
+        signal: AbortSignal.timeout(8000),
+      });
+      if (!r.ok) {
+        const j = await r.json().catch(() => ({})) as { detail?: { message?: string } | string };
+        const msg = typeof j?.detail === 'string' ? j.detail : (j?.detail as any)?.message || `HTTP ${r.status}`;
+        return { ok: false, message: `ElevenLabs: ${msg}` };
+      }
+      const u = await r.json() as { first_name?: string };
+      return { ok: true, message: `✓ ElevenLabs account verified${u.first_name ? ` (${u.first_name})` : ''}` };
+    }
+    case 'SEARCH_API_KEY': {
+      const r = await fetch('https://api.tavily.com/search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ api_key: value, query: 'test', max_results: 1 }),
+        signal: AbortSignal.timeout(10000),
+      });
+      if (!r.ok) {
+        const j = await r.json().catch(() => ({})) as { detail?: string | { message?: string } };
+        const detail = typeof j?.detail === 'string' ? j.detail : (j?.detail as any)?.message || '';
+        return { ok: false, message: `Tavily: ${detail || `HTTP ${r.status}`}` };
+      }
+      return { ok: true, message: '✓ Tavily API key valid' };
+    }
+    case 'EMBEDDING_API_KEY': {
+      const r = await probeEmbeddingConfig({ apiKey: value } as any);
+      return {
+        ok: r.code === 'ok',
+        message: r.code === 'ok'
+          ? `✓ Embeddings working${r.dim ? ` (${r.dim}-dim)` : ''}`
+          : r.message,
+      };
+    }
+    case 'LASTFM_API_KEY': {
+      const url = `https://ws.audioscrobbler.com/2.0/?method=artist.getinfo&artist=Radiohead&api_key=${encodeURIComponent(value)}&format=json`;
+      const r = await fetch(url, { signal: AbortSignal.timeout(8000) });
+      const j = await r.json().catch(() => null) as { error?: number; message?: string } | null;
+      if (!r.ok || j?.error) {
+        return { ok: false, message: `Last.fm: ${j?.message || `HTTP ${r.status}`}` };
+      }
+      return { ok: true, message: '✓ Last.fm API key valid' };
+    }
+    case 'LISTENBRAINZ_USER_TOKEN': {
+      const r = await fetch('https://api.listenbrainz.org/1/validate-token', {
+        headers: { Authorization: `Token ${value}` },
+        signal: AbortSignal.timeout(8000),
+      });
+      const j = await r.json().catch(() => ({})) as { valid?: boolean; user_name?: string; message?: string };
+      if (!j.valid) {
+        return { ok: false, message: `ListenBrainz: ${j.message || 'token not valid'}` };
+      }
+      return { ok: true, message: `✓ ListenBrainz token valid${j.user_name ? ` (${j.user_name})` : ''}` };
+    }
+    default:
+      return { ok: false, message: `No probe defined for ${key}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POST /settings/secrets/test — probe a key against its provider WITHOUT
+// saving. Body: { key: string, value: string }. Always 200s with
+// { ok, message, latencyMs } — a bad key is a normal, actionable answer.
+// ---------------------------------------------------------------------------
+router.post('/settings/secrets/test', requireAdmin, async (req, res) => {
+  const { key, value } = req.body || {};
+  if (!key || !value || typeof key !== 'string' || typeof value !== 'string') {
+    return res.status(400).json({ ok: false, message: 'key and value are required', latencyMs: 0 });
+  }
+  if (!SECRET_ENV_KEYS.includes(key as any)) {
+    return res.status(400).json({ ok: false, message: `Unknown key: ${key}`, latencyMs: 0 });
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return res.status(400).json({ ok: false, message: 'value must not be blank', latencyMs: 0 });
+  }
+  const t0 = Date.now();
+  try {
+    const result = await probeKey(key as (typeof SECRET_ENV_KEYS)[number], trimmed);
+    res.json({ ok: result.ok, message: result.message, latencyMs: Date.now() - t0 });
+  } catch (err: any) {
+    res.json({ ok: false, message: err?.message || 'probe failed', latencyMs: Date.now() - t0 });
   }
 });
 

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -225,6 +225,30 @@ router.post('/settings/secrets', requireAdmin, async (req, res) => {
 // Builds a one-off provider client using the supplied value; never writes to
 // process.env or secrets.env. Always resolves (never rejects).
 // ---------------------------------------------------------------------------
+// Distill a raw provider/SDK error into a one-line actionable message.
+function briefLlmError(err: any): string {
+  const msg: string = (err?.message || err?.toString() || '').toLowerCase();
+  if (msg.includes('401') || msg.includes('unauthorized') || msg.includes('invalid') && msg.includes('key') || msg.includes('incorrect api key')) {
+    return 'Key rejected — check it\'s correct and hasn\'t expired';
+  }
+  if (msg.includes('403') || msg.includes('forbidden')) {
+    return 'Access denied — your key may not have permission for this model';
+  }
+  if (msg.includes('429') || msg.includes('rate limit') || msg.includes('quota')) {
+    return 'Rate limited or quota exceeded — try again shortly';
+  }
+  if (msg.includes('model') && (msg.includes('not found') || msg.includes('does not exist'))) {
+    return 'Model not found — switch to a supported model in LLM settings';
+  }
+  if (msg.includes('timeout') || msg.includes('timed out') || msg.includes('aborted')) {
+    return 'Timed out — provider may be slow or unreachable';
+  }
+  // Fallback: first sentence or first 80 chars of the original message
+  const raw: string = (err?.message || '').trim();
+  const sentence = raw.split(/[.\n]/)[0].trim();
+  return sentence.slice(0, 80) || 'Request failed';
+}
+
 async function probeKey(
   key: (typeof SECRET_ENV_KEYS)[number],
   value: string,
@@ -235,37 +259,47 @@ async function probeKey(
 
   switch (key) {
     case 'ANTHROPIC_API_KEY': {
-      const model = activeModel('anthropic') || 'claude-haiku-4-5-20251001';
-      const m = createAnthropic({ apiKey: value })(model);
-      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
-      return { ok: true, message: `✓ Anthropic responded · "${(out.text || '').trim().slice(0, 40)}"` };
+      try {
+        const model = activeModel('anthropic') || 'claude-haiku-4-5-20251001';
+        const m = createAnthropic({ apiKey: value })(model);
+        const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
+        return { ok: true, message: `✓ Anthropic key valid · model responded` };
+      } catch (err) { return { ok: false, message: briefLlmError(err) }; }
     }
     case 'OPENAI_API_KEY': {
-      const model = activeModel('openai') || 'gpt-4o-mini';
-      const m = createOpenAI({ apiKey: value })(model);
-      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
-      return { ok: true, message: `✓ OpenAI responded · "${(out.text || '').trim().slice(0, 40)}"` };
+      try {
+        const model = activeModel('openai') || 'gpt-4o-mini';
+        const m = createOpenAI({ apiKey: value })(model);
+        const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
+        return { ok: true, message: `✓ OpenAI key valid · model responded` };
+      } catch (err) { return { ok: false, message: briefLlmError(err) }; }
     }
     case 'GOOGLE_GENERATIVE_AI_API_KEY': {
-      const model = activeModel('google') || 'gemini-1.5-flash';
-      const m = createGoogleGenerativeAI({ apiKey: value })(model);
-      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
-      return { ok: true, message: `✓ Google responded · "${(out.text || '').trim().slice(0, 40)}"` };
+      try {
+        const model = activeModel('google') || 'gemini-1.5-flash';
+        const m = createGoogleGenerativeAI({ apiKey: value })(model);
+        const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
+        return { ok: true, message: `✓ Google key valid · model responded` };
+      } catch (err) { return { ok: false, message: briefLlmError(err) }; }
     }
     case 'DEEPSEEK_API_KEY': {
-      const model = activeModel('deepseek') || 'deepseek-chat';
-      const m = createDeepSeek({ apiKey: value })(model);
-      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
-      return { ok: true, message: `✓ DeepSeek responded · "${(out.text || '').trim().slice(0, 40)}"` };
+      try {
+        const model = activeModel('deepseek') || 'deepseek-chat';
+        const m = createDeepSeek({ apiKey: value })(model);
+        const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
+        return { ok: true, message: `✓ DeepSeek key valid · model responded` };
+      } catch (err) { return { ok: false, message: briefLlmError(err) }; }
     }
     case 'OPENROUTER_API_KEY': {
-      const model = activeModel('openrouter') || 'openai/gpt-4o-mini';
-      const m = createOpenRouter({ apiKey: value })(model);
-      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
-      return { ok: true, message: `✓ OpenRouter responded · "${(out.text || '').trim().slice(0, 40)}"` };
+      try {
+        const model = activeModel('openrouter') || 'openai/gpt-4o-mini';
+        const m = createOpenRouter({ apiKey: value })(model);
+        const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
+        return { ok: true, message: `✓ OpenRouter key valid · model responded` };
+      } catch (err) { return { ok: false, message: briefLlmError(err) }; }
     }
     case 'AI_GATEWAY_API_KEY': {
-      return { ok: true, message: 'ℹ AI Gateway key saved format looks valid — test via an LLM call to confirm it works.' };
+      return { ok: true, message: 'Key format looks valid — confirm via a live LLM call' };
     }
     case 'ELEVENLABS_API_KEY': {
       const r = await fetch('https://api.elevenlabs.io/v1/user', {
@@ -274,28 +308,23 @@ async function probeKey(
       });
       if (!r.ok) {
         const j = await r.json().catch(() => ({})) as { detail?: { message?: string } | string };
-        const msg = typeof j?.detail === 'string' ? j.detail : (j?.detail as any)?.message || `HTTP ${r.status}`;
-        return { ok: false, message: `ElevenLabs: ${msg}` };
+        const msg = typeof j?.detail === 'string' ? j.detail : (j?.detail as any)?.message || '';
+        return { ok: false, message: r.status === 401 ? 'Key rejected — check it\'s correct and active' : (msg || `Request failed (${r.status})`) };
       }
       const u = await r.json() as { first_name?: string };
-      return { ok: true, message: `✓ ElevenLabs account verified${u.first_name ? ` (${u.first_name})` : ''}` };
+      return { ok: true, message: `✓ ElevenLabs key valid${u.first_name ? ` · account: ${u.first_name}` : ''}` };
     }
     case 'SEARCH_API_KEY': {
       const r = await fetch('https://api.tavily.com/search', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${value}`,
-        },
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${value}` },
         body: JSON.stringify({ query: 'test', max_results: 1 }),
         signal: AbortSignal.timeout(10000),
       });
       if (!r.ok) {
-        const j = await r.json().catch(() => ({})) as { detail?: string | { message?: string } };
-        const detail = typeof j?.detail === 'string' ? j.detail : (j?.detail as any)?.message || '';
-        return { ok: false, message: `Tavily: ${detail || `HTTP ${r.status}`}` };
+        return { ok: false, message: r.status === 401 || r.status === 403 ? 'Key rejected — check it\'s correct and active' : `Request failed (${r.status})` };
       }
-      return { ok: true, message: '✓ Tavily API key valid' };
+      return { ok: true, message: '✓ Tavily key valid' };
     }
     case 'EMBEDDING_API_KEY': {
       const embCfg = settings.get().embedding || {};
@@ -318,7 +347,7 @@ async function probeKey(
       const r = await fetch(url, { signal: AbortSignal.timeout(8000) });
       const j = await r.json().catch(() => null) as { error?: number; message?: string } | null;
       if (!r.ok || j?.error) {
-        return { ok: false, message: `Last.fm: ${j?.message || `HTTP ${r.status}`}` };
+        return { ok: false, message: j?.error === 10 ? 'Invalid API key — check your Last.fm developer credentials' : (j?.message || `Request failed (${r.status})`) };
       }
       return { ok: true, message: '✓ Last.fm API key valid' };
     }
@@ -329,9 +358,9 @@ async function probeKey(
       });
       const j = await r.json().catch(() => ({})) as { valid?: boolean; user_name?: string; message?: string };
       if (!j.valid) {
-        return { ok: false, message: `ListenBrainz: ${j.message || 'token not valid'}` };
+        return { ok: false, message: 'Token not valid — check your ListenBrainz user token' };
       }
-      return { ok: true, message: `✓ ListenBrainz token valid${j.user_name ? ` (${j.user_name})` : ''}` };
+      return { ok: true, message: `✓ ListenBrainz token valid${j.user_name ? ` · user: ${j.user_name}` : ''}` };
     }
     default:
       return { ok: false, message: `No probe defined for ${key}` };

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -237,35 +237,35 @@ async function probeKey(
     case 'ANTHROPIC_API_KEY': {
       const model = activeModel('anthropic') || 'claude-haiku-4-5-20251001';
       const m = createAnthropic({ apiKey: value })(model);
-      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8 });
+      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
       return { ok: true, message: `✓ Anthropic responded · "${(out.text || '').trim().slice(0, 40)}"` };
     }
     case 'OPENAI_API_KEY': {
       const model = activeModel('openai') || 'gpt-4o-mini';
       const m = createOpenAI({ apiKey: value })(model);
-      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8 });
+      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
       return { ok: true, message: `✓ OpenAI responded · "${(out.text || '').trim().slice(0, 40)}"` };
     }
     case 'GOOGLE_GENERATIVE_AI_API_KEY': {
       const model = activeModel('google') || 'gemini-1.5-flash';
       const m = createGoogleGenerativeAI({ apiKey: value })(model);
-      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8 });
+      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
       return { ok: true, message: `✓ Google responded · "${(out.text || '').trim().slice(0, 40)}"` };
     }
     case 'DEEPSEEK_API_KEY': {
       const model = activeModel('deepseek') || 'deepseek-chat';
       const m = createDeepSeek({ apiKey: value })(model);
-      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8 });
+      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
       return { ok: true, message: `✓ DeepSeek responded · "${(out.text || '').trim().slice(0, 40)}"` };
     }
     case 'OPENROUTER_API_KEY': {
       const model = activeModel('openrouter') || 'openai/gpt-4o-mini';
       const m = createOpenRouter({ apiKey: value })(model);
-      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8 });
+      const out = await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
       return { ok: true, message: `✓ OpenRouter responded · "${(out.text || '').trim().slice(0, 40)}"` };
     }
     case 'AI_GATEWAY_API_KEY': {
-      return { ok: false, message: 'AI Gateway key cannot be tested without a model URL — save and test via an LLM call.' };
+      return { ok: true, message: 'ℹ AI Gateway key saved format looks valid — test via an LLM call to confirm it works.' };
     }
     case 'ELEVENLABS_API_KEY': {
       const r = await fetch('https://api.elevenlabs.io/v1/user', {
@@ -283,8 +283,11 @@ async function probeKey(
     case 'SEARCH_API_KEY': {
       const r = await fetch('https://api.tavily.com/search', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ api_key: value, query: 'test', max_results: 1 }),
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${value}`,
+        },
+        body: JSON.stringify({ query: 'test', max_results: 1 }),
         signal: AbortSignal.timeout(10000),
       });
       if (!r.ok) {
@@ -295,7 +298,14 @@ async function probeKey(
       return { ok: true, message: '✓ Tavily API key valid' };
     }
     case 'EMBEDDING_API_KEY': {
-      const r = await probeEmbeddingConfig({ apiKey: value } as any);
+      const embCfg = settings.get().embedding || {};
+      const r = await probeEmbeddingConfig({
+        provider: embCfg.provider || undefined,
+        model: embCfg.model || undefined,
+        baseUrl: embCfg.baseUrl || undefined,
+        ollamaUrl: embCfg.ollamaUrl || undefined,
+        apiKey: value,
+      });
       return {
         ok: r.code === 'ok',
         message: r.code === 'ok'

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -15,6 +15,7 @@ import { queue } from '../broadcast/queue.js';
 import { restartLiquidsoap, startStream, stopStream, streamStatus } from '../broadcast/liquidsoap-control.js';
 import { invalidateWeatherCache } from '../context.js';
 import { requireAdmin } from '../middleware/auth.js';
+import { saveSecrets, SECRET_ENV_KEYS } from '../setup/secrets.js';
 import { tagger } from '../broadcast/tagger.js';
 import { skillCatalog } from '../skills/_agent.js';
 import { clearUserThemeCache, loadUserThemes, listThemes, saveUserTheme } from '../themes.js';
@@ -140,6 +141,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
         OPENROUTER_API_KEY: !!process.env.OPENROUTER_API_KEY,
         AI_GATEWAY_API_KEY: !!process.env.AI_GATEWAY_API_KEY,
         SEARCH_API_KEY: !!process.env.SEARCH_API_KEY,
+        EMBEDDING_API_KEY: !!process.env.EMBEDDING_API_KEY,
         LASTFM_API_KEY: !!process.env.LASTFM_API_KEY,
         LASTFM_API_SECRET: !!process.env.LASTFM_API_SECRET,
         LASTFM_SESSION_KEY: !!process.env.LASTFM_SESSION_KEY,
@@ -178,6 +180,36 @@ router.post('/settings', requireAdmin, async (req, res) => {
     }
     res.json(result);
   } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /settings/secrets — write one or more API keys to state/secrets.env.
+// Only keys listed in SECRET_ENV_KEYS are accepted; blank values are skipped
+// (blank = "leave existing key in place"). Takes effect in-process immediately
+// via saveSecrets(); no controller restart needed.
+// ---------------------------------------------------------------------------
+router.post('/settings/secrets', requireAdmin, async (req, res) => {
+  try {
+    const body = req.body || {};
+    if (typeof body !== 'object' || Array.isArray(body)) {
+      return res.status(400).json({ error: 'Body must be a key-value object' });
+    }
+    const patch: Record<string, string> = {};
+    for (const [key, value] of Object.entries(body)) {
+      if (!SECRET_ENV_KEYS.includes(key as any)) continue;
+      if (typeof value !== 'string') continue;
+      const trimmed = value.trim();
+      if (!trimmed) continue;
+      patch[key] = trimmed;
+    }
+    if (Object.keys(patch).length === 0) {
+      return res.json({ saved: [] });
+    }
+    await saveSecrets(patch);
+    res.json({ saved: Object.keys(patch) });
+  } catch (err: any) {
     res.status(400).json({ error: err.message });
   }
 });

--- a/controller/src/setup/secrets.ts
+++ b/controller/src/setup/secrets.ts
@@ -85,7 +85,17 @@ export async function saveSecrets(patch: Record<string, string>): Promise<void> 
       const eq = line.indexOf('=');
       if (eq < 0) continue;
       const key = line.slice(0, eq).trim();
-      if (SECRET_ENV_KEYS.includes(key)) current[key] = line.slice(eq + 1);
+      if (SECRET_ENV_KEYS.includes(key)) {
+        let value = line.slice(eq + 1).trim();
+        if (
+          value.length >= 2 &&
+          ((value.startsWith('"') && value.endsWith('"')) ||
+            (value.startsWith("'") && value.endsWith("'")))
+        ) {
+          value = value.slice(1, -1);
+        }
+        current[key] = value;
+      }
     }
   }
   for (const [key, value] of Object.entries(patch)) {

--- a/controller/src/skills/web-search.ts
+++ b/controller/src/skills/web-search.ts
@@ -44,7 +44,7 @@ async function memo(
 }
 
 export async function tavilySearch(query: string): Promise<SearchResponse> {
-  const apiKey = settings.get().search?.apiKey || config.search.apiKey;
+  const apiKey = settings.get().search?.apiKey || process.env.SEARCH_API_KEY || config.search.apiKey;
   const res = await fetch(TAVILY_ENDPOINT, {
     method: 'POST',
     headers: {
@@ -141,5 +141,5 @@ export async function searchWeb(query: string): Promise<SearchResponse> {
 export function searchReady(): boolean {
   const s = settings.get().search;
   if (!s || s.provider === 'duckduckgo') return true;
-  return !!(s.apiKey || config.search.apiKey);
+  return !!(s.apiKey || process.env.SEARCH_API_KEY || config.search.apiKey);
 }

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -1721,6 +1721,9 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
   const [primaryKeyInput, setPrimaryKeyInput] = useState('');
   const [fallbackKeyInput, setFallbackKeyInput] = useState('');
 
+  useEffect(() => { setPrimaryKeyInput(''); }, [form.llm.provider]);
+  useEffect(() => { setFallbackKeyInput(''); }, [form.llm.fallback.provider]);
+
   const saveKey = async (envVar: string, value: string): Promise<boolean> => {
     if (!value.trim()) return true;
     try {
@@ -1742,7 +1745,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
   };
 
   const save = async () => {
-    saveSettings({
+    await saveSettings({
       llm: {
         provider: form.llm.provider,
         model: form.llm.model,

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -704,7 +704,7 @@ export default function SettingsPanel() {
             {activeSection === 'tts' && data.tts && (
               <TtsSection
                 data={data} form={form} setForm={updateForm} busy={busy}
-                saveSettings={saveSettings}
+                saveSettings={saveSettings} adminFetch={adminFetch} refresh={refresh}
               />
             )}
             {activeSection === 'llm' && data.llm && (
@@ -722,7 +722,7 @@ export default function SettingsPanel() {
             {activeSection === 'library' && (
               <LibrarySection
                 data={data} form={form} setForm={updateForm} busy={busy}
-                saveSettings={saveSettings}
+                saveSettings={saveSettings} adminFetch={adminFetch} refresh={refresh}
               />
             )}
             {activeSection === 'station' && (
@@ -1267,30 +1267,67 @@ function HeavyEngineSetupGuide({ engine, buildArg }: { engine: 'Chatterbox' | 'P
   );
 }
 
-function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
+interface TtsSectionProps extends SectionProps {
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+  refresh: () => void;
+}
+
+function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refresh }: TtsSectionProps) {
+  const [cloudKeyInput, setCloudKeyInput] = useState('');
+
+  useEffect(() => { setCloudKeyInput(''); }, [form.tts.cloud.provider]);
+
+  const saveKey = async (envVar: string, value: string): Promise<boolean> => {
+    if (!value.trim()) return true;
+    try {
+      const r = await adminFetch('/settings/secrets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ [envVar]: value.trim() }),
+      });
+      if (!r.ok) {
+        const j = await r.json().catch(() => ({})) as { error?: string };
+        notify.err(j.error || `Key save failed (${r.status})`);
+        return false;
+      }
+      return true;
+    } catch (e) {
+      notify.err(errorMessage(e));
+      return false;
+    }
+  };
   const engines = data.tts?.engines || ['piper'];
   const available = data.tts?.available || {};
   const ENGINE_LABELS: Record<string, string> = { piper: 'Piper', kokoro: 'Kokoro', chatterbox: 'Chatterbox', 'pocket-tts': 'PocketTTS', cloud: 'Cloud' };
   const engineOptions = engines.map(e => ({ id: e, label: ENGINE_LABELS[e] || e }));
 
-  const save = () => saveSettings({
-    tts: {
-      defaultEngine: form.tts.defaultEngine,
-      kokoro: { voice: form.tts.kokoro?.voice },
-      chatterbox: { referenceVoice: form.tts.chatterbox?.referenceVoice ?? '' },
-      pocketTts: { voice: form.tts.pocketTts?.voice ?? 'alba' },
-      cloud: {
-        enabled: true,
-        provider: form.tts.cloud.provider,
-        model: form.tts.cloud.model,
-        voice: form.tts.cloud.voice,
-        baseUrl: form.tts.cloud.baseUrl,
+  const save = async () => {
+    await saveSettings({
+      tts: {
+        defaultEngine: form.tts.defaultEngine,
+        kokoro: { voice: form.tts.kokoro?.voice },
+        chatterbox: { referenceVoice: form.tts.chatterbox?.referenceVoice ?? '' },
+        pocketTts: { voice: form.tts.pocketTts?.voice ?? 'alba' },
+        cloud: {
+          enabled: true,
+          provider: form.tts.cloud.provider,
+          model: form.tts.cloud.model,
+          voice: form.tts.cloud.voice,
+          baseUrl: form.tts.cloud.baseUrl,
+        },
+        // Per-engine voice-level trim. Always sent (server clamps + drops unknown
+        // keys); keyed by engine id, `pocket-tts` with the hyphen.
+        gainDb: form.tts.gainDb,
       },
-      // Per-engine voice-level trim. Always sent (server clamps + drops unknown
-      // keys); keyed by engine id, `pocket-tts` with the hyphen.
-      gainDb: form.tts.gainDb,
-    },
-  });
+    });
+    // Save cloud API key if typed -- goes to secrets.env, not settings.json
+    const isCompat = form.tts.cloud.provider === 'openai-compatible';
+    if (!isCompat && cloudKeyInput.trim()) {
+      const cloudKeyVar = form.tts.cloud.provider === 'elevenlabs' ? 'ELEVENLABS_API_KEY' : 'OPENAI_API_KEY';
+      const ok = await saveKey(cloudKeyVar, cloudKeyInput);
+      if (ok) { notify.ok('API key saved'); setCloudKeyInput(''); refresh(); }
+    }
+  };
 
   const selectCloudProvider = (f: FormState, provider: string): FormState => {
     const provVoices = CLOUD_VOICES[provider as keyof typeof CLOUD_VOICES] || [];
@@ -1680,12 +1717,27 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
                 );
               })()}
             </div>
-            {!isCompat && (
-              <KeyStatus
-                envVar={form.tts.cloud.provider === 'elevenlabs' ? 'ELEVENLABS_API_KEY' : 'OPENAI_API_KEY'}
-                present={!!data.env?.[form.tts.cloud.provider === 'elevenlabs' ? 'ELEVENLABS_API_KEY' : 'OPENAI_API_KEY']}
-              />
-            )}
+            {!isCompat && (() => {
+              const cloudKeyVar = form.tts.cloud.provider === 'elevenlabs' ? 'ELEVENLABS_API_KEY' : 'OPENAI_API_KEY';
+              return (
+                <>
+                  <KeyStatus envVar={cloudKeyVar} present={!!data.env?.[cloudKeyVar]} />
+                  <div className="field">
+                    <Label>{form.tts.cloud.provider === 'elevenlabs' ? 'ElevenLabs' : 'OpenAI'} API key</Label>
+                    <Input
+                      type="password"
+                      value={cloudKeyInput}
+                      placeholder={data.env?.[cloudKeyVar] ? '•••••• (on file)' : (KEY_HINTS[cloudKeyVar] ?? '')}
+                      onChange={(e: ChangeEvent<HTMLInputElement>) => setCloudKeyInput(e.target.value)}
+                      className="max-w-[360px]"
+                    />
+                    <div className="field-hint">
+                      Stored in <code>state/secrets.env</code>, takes effect immediately. Leave blank to keep the existing key.
+                    </div>
+                  </div>
+                </>
+              );
+            })()}
             {isCompat && (
               <div className="field-hint mt-3.5">
                 Most self-hosted servers accept any non-empty API key, so no env
@@ -2420,26 +2472,64 @@ function SearchSection({ data, form, setForm, busy, saveSettings }: SectionProps
 
 /* ── Library tagger ──────────────────────────────────────────────────── */
 
-function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProps) {
+interface LibrarySectionProps extends SectionProps {
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+  refresh: () => void;
+}
+
+function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, refresh }: LibrarySectionProps) {
   const e = form.embedding;
-  const save = () => saveSettings({
-    embedding: {
-      enabled: e.enabled,
-      provider: e.provider,
-      model: e.model,
-      baseUrl: e.baseUrl,
-      ollamaUrl: e.ollamaUrl,
-      seedCount: parseInt(e.seedCount, 10) || 0,
-      knnNeighbours: parseInt(e.knnNeighbours, 10) || 5,
-      moodVoteThreshold: parseFloat(e.moodVoteThreshold) || 0.6,
-      confidenceThreshold: parseFloat(e.confidenceThreshold) || 0.6,
-      maxActiveLearningRounds: parseInt(e.maxActiveLearningRounds, 10) || 0,
-      enrichment: {
-        lastfmTags: e.enrichment.lastfmTags,
-        lyrics: e.enrichment.lyrics,
+  const [embeddingKeyInput, setEmbeddingKeyInput] = useState('');
+
+  useEffect(() => { setEmbeddingKeyInput(''); }, [form.embedding.provider]);
+
+  const saveKey = async (envVar: string, value: string): Promise<boolean> => {
+    if (!value.trim()) return true;
+    try {
+      const r = await adminFetch('/settings/secrets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ [envVar]: value.trim() }),
+      });
+      if (!r.ok) {
+        const j = await r.json().catch(() => ({})) as { error?: string };
+        notify.err(j.error || `Key save failed (${r.status})`);
+        return false;
+      }
+      return true;
+    } catch (e) {
+      notify.err(errorMessage(e));
+      return false;
+    }
+  };
+
+  const save = async () => {
+    await saveSettings({
+      embedding: {
+        enabled: e.enabled,
+        provider: e.provider,
+        model: e.model,
+        baseUrl: e.baseUrl,
+        ollamaUrl: e.ollamaUrl,
+        seedCount: parseInt(e.seedCount, 10) || 0,
+        knnNeighbours: parseInt(e.knnNeighbours, 10) || 5,
+        moodVoteThreshold: parseFloat(e.moodVoteThreshold) || 0.6,
+        confidenceThreshold: parseFloat(e.confidenceThreshold) || 0.6,
+        maxActiveLearningRounds: parseInt(e.maxActiveLearningRounds, 10) || 0,
+        enrichment: {
+          lastfmTags: e.enrichment.lastfmTags,
+          lyrics: e.enrichment.lyrics,
+        },
       },
-    },
-  });
+    });
+    // Save embedding API key if typed
+    const embeddingNeedsKey = e.provider &&
+      !['', 'ollama', 'openai-compatible', 'locca'].includes(e.provider);
+    if (embeddingNeedsKey && embeddingKeyInput.trim()) {
+      const ok = await saveKey('EMBEDDING_API_KEY', embeddingKeyInput);
+      if (ok) { notify.ok('API key saved'); setEmbeddingKeyInput(''); refresh(); }
+    }
+  };
 
   const savedEmbedding = data.values?.embedding || {};
   const llmProvider = data.values?.llm?.provider || 'ollama';
@@ -2464,7 +2554,6 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
 
   // --- Guided setup: probe the endpoint up front, detect a locca embed server,
   // and kick the tagger from here, instead of failing mid-run (#405 follow-up).
-  const { adminFetch } = useAdminAuth();
   const [probe, setProbe] = useState<
     { ok: boolean; dim: number | null; code: string; message: string } | null
   >(null);
@@ -2664,6 +2753,27 @@ function LibrarySection({ data, form, setForm, busy, saveSettings }: SectionProp
               </div>
             )}
           </div>
+
+          {/* Embedding API key override -- only for cloud providers that need one */}
+          {e.provider && !['', 'ollama', 'openai-compatible', 'locca'].includes(e.provider) && (
+            <>
+              <div className="field">
+                <Label>Embedding API key override</Label>
+                <Input
+                  type="password"
+                  value={embeddingKeyInput}
+                  placeholder={data.env?.['EMBEDDING_API_KEY'] ? '•••••• (on file)' : 'optional -- defaults to chat key'}
+                  onChange={(ev: ChangeEvent<HTMLInputElement>) => setEmbeddingKeyInput(ev.target.value)}
+                  className="max-w-[360px]"
+                />
+                <div className="field-hint">
+                  Only needed when the embedding provider uses a different API key than the chat provider.
+                  Stored in <code>state/secrets.env</code>.
+                </div>
+              </div>
+              <KeyStatus envVar="EMBEDDING_API_KEY" present={!!data.env?.['EMBEDDING_API_KEY']} />
+            </>
+          )}
 
           <div className="field">
             <Label>Model</Label>

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -1144,21 +1144,18 @@ interface KeyTestResultProps {
 }
 
 function KeyTestResult({ result }: KeyTestResultProps) {
-  const toneClass = result.ok
-    ? 'border-[var(--accent)] text-[color:var(--accent)]'
-    : 'border-[var(--danger)] text-[var(--danger)]';
   return (
-    <div className={cn('field mt-2 flex items-start gap-2.5 border bg-[var(--ink-softer)] p-3', toneClass)}>
-      <span className={cn('mt-1 size-1.5 flex-none rounded-full', result.ok ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]')} />
-      <div className="grid gap-0.5">
-        <span className={cn('text-[11px] font-bold tracking-[0.12em] uppercase', toneClass)}>
-          {result.ok ? 'Key valid' : 'Key test failed'}
-        </span>
-        <span className="text-[11px] leading-[1.5] text-muted">
-          {result.message}
-          {result.ok && result.latencyMs > 0 && ` · ${result.latencyMs}ms`}
-        </span>
-      </div>
+    <div
+      className={cn(
+        'mt-2 max-w-[560px] rounded border bg-[var(--ink-softer)] px-3 py-2 text-[11px] leading-[1.6]',
+        result.ok
+          ? 'border-[var(--accent)] text-[color:var(--accent)]'
+          : 'border-[var(--danger)] text-[var(--danger)]',
+      )}
+    >
+      {result.ok
+        ? `${result.message}${result.latencyMs > 0 ? ` · ${result.latencyMs}ms` : ''}`
+        : result.message}
     </div>
   );
 }

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -2464,6 +2464,9 @@ interface SearchSectionProps extends SectionProps {
   adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
 }
 function SearchSection({ data, form, setForm, busy, saveSettings, adminFetch }: SearchSectionProps) {
+  const [tavilyKeyTest, setTavilyKeyTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
+  const [tavilyKeyTesting, setTavilyKeyTesting] = useState(false);
+
   const save = () => saveSettings({
     search: {
       provider: form.search.provider,
@@ -2484,8 +2487,6 @@ function SearchSection({ data, form, setForm, busy, saveSettings, adminFetch }: 
         && form.search.apiKey !== 'set'
         && form.search.apiKey !== (savedSearch.apiKey || ''));
   const tavilyKeySet = form.search.apiKey === 'set' || !!data.env?.SEARCH_API_KEY;
-  const [tavilyKeyTest, setTavilyKeyTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
-  const [tavilyKeyTesting, setTavilyKeyTesting] = useState(false);
 
   const testTavilyKey = async () => {
     const value = form.search.apiKey === 'set' ? '' : form.search.apiKey;

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -32,7 +32,6 @@ const SECTIONS = [
   { id: 'search',   label: 'Web search', hint: 'live-facts backend' },
   { id: 'jingles',  label: 'Jingles', hint: 'stingers' },
   { id: 'sfx',      label: 'Sound FX', hint: 'agent stingers' },
-  { id: 'api-keys', label: 'API Keys', hint: 'provider credentials' },
   { id: 'scrobble', label: 'Scrobbling', hint: 'last.fm · listenbrainz' },
   { id: 'archives', label: 'Archives', hint: 'hourly recordings' },
   { id: 'webhooks', label: 'Webhooks', hint: 'outbound events' },
@@ -50,6 +49,17 @@ const LLM_ENV_VARS: Record<string, string> = {
   deepseek: 'DEEPSEEK_API_KEY',
   openrouter: 'OPENROUTER_API_KEY',
   gateway: 'AI_GATEWAY_API_KEY',
+};
+
+const KEY_HINTS: Record<string, string> = {
+  ANTHROPIC_API_KEY: 'sk-ant-...',
+  OPENAI_API_KEY: 'sk-...',
+  GOOGLE_GENERATIVE_AI_API_KEY: 'AIza...',
+  DEEPSEEK_API_KEY: 'sk-...',
+  OPENROUTER_API_KEY: 'sk-or-v1-...',
+  AI_GATEWAY_API_KEY: 'gateway API key',
+  ELEVENLABS_API_KEY: 'el_...',
+  EMBEDDING_API_KEY: 'optional — defaults to chat key',
 };
 
 const LLM_PROVIDER_LABELS: Record<string, string> = {
@@ -700,7 +710,7 @@ export default function SettingsPanel() {
             {activeSection === 'llm' && data.llm && (
               <LlmSection
                 data={data} form={form} setForm={updateForm} busy={busy}
-                saveSettings={saveSettings}
+                saveSettings={saveSettings} adminFetch={adminFetch} refresh={refresh}
               />
             )}
             {activeSection === 'search' && (
@@ -734,13 +744,6 @@ export default function SettingsPanel() {
                 createJingle={createJingle} uploadJingle={uploadJingle}
                 saveSettings={saveSettings}
                 onDelete={setConfirmDelete} adminFetch={adminFetch}
-              />
-            )}
-            {activeSection === 'api-keys' && data && (
-              <ApiKeysSection
-                data={data}
-                adminFetch={adminFetch}
-                onSaved={refresh}
               />
             )}
             {activeSection === 'scrobble' && (
@@ -1710,30 +1713,70 @@ function TtsSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
 
 /* ── LLM ─────────────────────────────────────────────────────────────── */
 
-function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
-  const save = () => saveSettings({
-    llm: {
-      provider: form.llm.provider,
-      model: form.llm.model,
-      ollamaUrl: form.llm.ollamaUrl,
-      numCtx: form.llm.numCtx,
-      baseUrl: form.llm.baseUrl,
-      reasoning: form.llm.reasoning,
-      pickerAgent: form.llm.pickerAgent,
-      requestWebResolve: form.llm.requestWebResolve,
-      agentTimeoutMs: form.llm.agentTimeoutMs,
-      pauseWhenEmpty: form.llm.pauseWhenEmpty,
-      fallback: {
-        enabled: form.llm.fallback.enabled,
-        provider: form.llm.fallback.provider,
-        model: form.llm.fallback.model,
-        ollamaUrl: form.llm.fallback.ollamaUrl,
-        numCtx: form.llm.fallback.numCtx,
-        baseUrl: form.llm.fallback.baseUrl,
-        reasoning: form.llm.fallback.reasoning,
+interface LlmSectionProps extends SectionProps {
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+  refresh: () => void;
+}
+function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refresh }: LlmSectionProps) {
+  const [primaryKeyInput, setPrimaryKeyInput] = useState('');
+  const [fallbackKeyInput, setFallbackKeyInput] = useState('');
+
+  const saveKey = async (envVar: string, value: string): Promise<boolean> => {
+    if (!value.trim()) return true;
+    try {
+      const r = await adminFetch('/settings/secrets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ [envVar]: value.trim() }),
+      });
+      if (!r.ok) {
+        const j = await r.json().catch(() => ({})) as { error?: string };
+        notify.err(j.error || `Key save failed (${r.status})`);
+        return false;
+      }
+      return true;
+    } catch (e) {
+      notify.err(errorMessage(e));
+      return false;
+    }
+  };
+
+  const save = async () => {
+    saveSettings({
+      llm: {
+        provider: form.llm.provider,
+        model: form.llm.model,
+        ollamaUrl: form.llm.ollamaUrl,
+        numCtx: form.llm.numCtx,
+        baseUrl: form.llm.baseUrl,
+        reasoning: form.llm.reasoning,
+        pickerAgent: form.llm.pickerAgent,
+        requestWebResolve: form.llm.requestWebResolve,
+        agentTimeoutMs: form.llm.agentTimeoutMs,
+        pauseWhenEmpty: form.llm.pauseWhenEmpty,
+        fallback: {
+          enabled: form.llm.fallback.enabled,
+          provider: form.llm.fallback.provider,
+          model: form.llm.fallback.model,
+          ollamaUrl: form.llm.fallback.ollamaUrl,
+          numCtx: form.llm.fallback.numCtx,
+          baseUrl: form.llm.fallback.baseUrl,
+          reasoning: form.llm.fallback.reasoning,
+        },
       },
-    },
-  });
+    });
+    // Save API keys if typed — these go to secrets.env, not settings.json
+    const primaryKeyVar = LLM_ENV_VARS[form.llm.provider];
+    if (primaryKeyVar && primaryKeyInput.trim()) {
+      const ok = await saveKey(primaryKeyVar, primaryKeyInput);
+      if (ok) { setPrimaryKeyInput(''); refresh(); }
+    }
+    const fallbackKeyVar = LLM_ENV_VARS[form.llm.fallback.provider];
+    if (fallbackKeyVar && fallbackKeyInput.trim()) {
+      const ok = await saveKey(fallbackKeyVar, fallbackKeyInput);
+      if (ok) { setFallbackKeyInput(''); refresh(); }
+    }
+  };
 
   const savedLlm = data.values?.llm || {};
   const activeLabel = data.llm?.active || '';
@@ -1922,12 +1965,27 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
             </div>
           )}
 
-          {LLM_ENV_VARS[form.llm.provider] && (
-            <KeyStatus
-              envVar={LLM_ENV_VARS[form.llm.provider]!}
-              present={!!data.env?.[LLM_ENV_VARS[form.llm.provider]!]}
-            />
-          )}
+          {LLM_ENV_VARS[form.llm.provider] && (() => {
+            const keyVar = LLM_ENV_VARS[form.llm.provider]!;
+            return (
+              <>
+                <KeyStatus envVar={keyVar} present={!!data.env?.[keyVar]} />
+                <div className="field">
+                  <Label>{llmProviderLabel(form.llm.provider)} API key</Label>
+                  <Input
+                    type="password"
+                    value={primaryKeyInput}
+                    placeholder={data.env?.[keyVar] ? '•••••• (on file)' : (KEY_HINTS[keyVar] ?? '')}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => setPrimaryKeyInput(e.target.value)}
+                    className="max-w-[360px]"
+                  />
+                  <div className="field-hint">
+                    Stored in <code>state/secrets.env</code>, takes effect immediately. Leave blank to keep the existing key.
+                  </div>
+                </div>
+              </>
+            );
+          })()}
         </div>
       </Card>
 
@@ -2085,12 +2143,27 @@ function LlmSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
                 />
               </div>
 
-              {LLM_ENV_VARS[form.llm.fallback.provider] && (
-                <KeyStatus
-                  envVar={LLM_ENV_VARS[form.llm.fallback.provider]!}
-                  present={!!data.env?.[LLM_ENV_VARS[form.llm.fallback.provider]!]}
-                />
-              )}
+              {LLM_ENV_VARS[form.llm.fallback.provider] && (() => {
+                const keyVar = LLM_ENV_VARS[form.llm.fallback.provider]!;
+                return (
+                  <>
+                    <KeyStatus envVar={keyVar} present={!!data.env?.[keyVar]} />
+                    <div className="field">
+                      <Label>{llmProviderLabel(form.llm.fallback.provider)} API key</Label>
+                      <Input
+                        type="password"
+                        value={fallbackKeyInput}
+                        placeholder={data.env?.[keyVar] ? '•••••• (on file)' : (KEY_HINTS[keyVar] ?? '')}
+                        onChange={(e: ChangeEvent<HTMLInputElement>) => setFallbackKeyInput(e.target.value)}
+                        className="max-w-[360px]"
+                      />
+                      <div className="field-hint">
+                        Stored in <code>state/secrets.env</code>, takes effect immediately. Leave blank to keep the existing key.
+                      </div>
+                    </div>
+                  </>
+                );
+              })()}
             </>
           )}
         </div>
@@ -3958,112 +4031,6 @@ function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uploadSfx, 
             </div>
           </div>
         ))}
-      </Card>
-    </>
-  );
-}
-
-/* ── API Keys ────────────────────────────────────────────────────────── */
-// Write provider keys to state/secrets.env via POST /settings/secrets.
-// Values are never read back; only presence is shown via data.env booleans.
-// Pattern mirrors ScrobbleSection exactly: password inputs, blank = no-op,
-// KeyStatus badge, save clears the typed values and refreshes presence flags.
-
-interface ApiKeysSectionProps {
-  data: SettingsData;
-  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
-  onSaved: () => void;
-}
-
-const API_KEY_DEFS: { key: string; label: string; hint: string }[] = [
-  { key: 'ANTHROPIC_API_KEY',            label: 'Anthropic (Claude)',          hint: 'sk-ant-...' },
-  { key: 'OPENAI_API_KEY',               label: 'OpenAI',                      hint: 'sk-...' },
-  { key: 'GOOGLE_GENERATIVE_AI_API_KEY', label: 'Google Generative AI (Gemini)', hint: 'AIza...' },
-  { key: 'OPENROUTER_API_KEY',           label: 'OpenRouter',                  hint: 'sk-or-v1-...' },
-  { key: 'DEEPSEEK_API_KEY',             label: 'DeepSeek',                    hint: 'sk-...' },
-  { key: 'AI_GATEWAY_API_KEY',           label: 'AI Gateway',                  hint: 'gateway API key' },
-  { key: 'ELEVENLABS_API_KEY',           label: 'ElevenLabs (TTS)',            hint: 'el_...' },
-  { key: 'SEARCH_API_KEY',               label: 'Tavily (web search)',         hint: 'tvly-...' },
-  { key: 'EMBEDDING_API_KEY',            label: 'Embedding (override)',        hint: 'optional — defaults to chat key' },
-];
-
-function ApiKeysSection({ data, adminFetch, onSaved }: ApiKeysSectionProps) {
-  const env = (data.env || {}) as Record<string, unknown>;
-  const [form, setForm] = useState<Record<string, string>>({});
-  const [saving, setSaving] = useState(false);
-
-  const inputValue = (key: string) => form[key] || '';
-  const placeholder = (key: string, hint: string) =>
-    env[key] ? '•••••• (on file)' : hint;
-
-  const keysSet = API_KEY_DEFS.filter(d => !!env[d.key]).length;
-  const hasInput = API_KEY_DEFS.some(d => (form[d.key] || '').trim().length > 0);
-
-  const save = async () => {
-    const patch: Record<string, string> = {};
-    for (const { key } of API_KEY_DEFS) {
-      const v = (form[key] || '').trim();
-      if (v) patch[key] = v;
-    }
-    if (Object.keys(patch).length === 0) return;
-    setSaving(true);
-    try {
-      const r = await adminFetch('/settings/secrets', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(patch),
-      });
-      const j = (await r.json().catch(() => ({}))) as { saved?: string[]; error?: string };
-      if (!r.ok) throw new Error(j.error || `Save failed (${r.status})`);
-      setForm({});
-      onSaved();
-      notify.ok(`Saved ${(j.saved || []).length} key(s)`);
-    } catch (e) {
-      notify.err(errorMessage(e));
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <>
-      <SectionHeader
-        eyebrow="api keys"
-        title="Provider credentials — stored securely in state/secrets.env."
-        sub={<>
-          Paste a key to store it. Stored values are never shown — only whether a key
-          is present. Leave a field blank to keep the existing key unchanged.
-          Keys set via <code>.env</code> or Docker <code>env_file</code> always take
-          precedence over values stored here. Last.fm and ListenBrainz tokens are
-          managed in the <strong>Scrobbling</strong> section.
-        </>}
-        metrics={[
-          { n: `${keysSet}/${API_KEY_DEFS.length}`, l: 'configured', accent: keysSet > 0 },
-        ]}
-      />
-      <Card title="Provider keys">
-        <div className="grid gap-[18px]">
-          {API_KEY_DEFS.map(({ key, label, hint }) => (
-            <div key={key} className="field">
-              <Label>{label}</Label>
-              <Input
-                type="password"
-                value={inputValue(key)}
-                placeholder={placeholder(key, hint)}
-                onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                  setForm(f => ({ ...f, [key]: e.target.value }))
-                }
-                className="max-w-[360px]"
-              />
-              <KeyStatus envVar={key} present={!!env[key]} />
-            </div>
-          ))}
-          <div className="mt-1">
-            <Btn tone="accent" onClick={save} disabled={saving || !hasInput}>
-              {saving ? 'Saving…' : 'Save keys'}
-            </Btn>
-          </div>
-        </div>
       </Card>
     </>
   );

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -1105,7 +1105,7 @@ interface KeyStatusProps {
 
 function KeyStatus({ envVar, present }: KeyStatusProps) {
   const toneClass = present
-    ? 'border-[var(--accent)] text-vermilion'
+    ? 'border-[var(--accent)] text-[color:var(--accent)]'
     : 'border-[var(--danger)] text-[var(--danger)]';
   return (
     <div
@@ -1117,7 +1117,7 @@ function KeyStatus({ envVar, present }: KeyStatusProps) {
       <span
         className={cn(
           'mt-1 size-1.5 flex-none rounded-full',
-          present ? 'bg-vermilion' : 'bg-[var(--danger)]',
+          present ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
         )}
       />
       <div className="grid gap-0.5">
@@ -1147,10 +1147,10 @@ function KeyTestResult({ result }: KeyTestResultProps) {
   return (
     <div
       className={cn(
-        'mt-2 max-w-[560px] rounded border px-3 py-2 text-[11px] leading-[1.6]',
+        'mt-2 max-w-[560px] rounded border bg-[var(--ink-softer)] px-3 py-2 text-[11px] leading-[1.6]',
         result.ok
           ? 'border-[var(--accent)] text-[color:var(--accent)]'
-          : 'border-red-400/50 text-red-300',
+          : 'border-[var(--danger)] text-[var(--danger)]',
       )}
     >
       {result.message}
@@ -3064,10 +3064,10 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
             {probe && (
               <div
                 className={cn(
-                  'mt-2 max-w-[560px] rounded border px-3 py-2 text-[11px] leading-[1.6] whitespace-pre-wrap',
+                  'mt-2 max-w-[560px] rounded border bg-[var(--ink-softer)] px-3 py-2 text-[11px] leading-[1.6] whitespace-pre-wrap',
                   probe.ok
                     ? 'border-[var(--accent)] text-[color:var(--accent)]'
-                    : 'border-red-400/50 text-red-300',
+                    : 'border-[var(--danger)] text-[var(--danger)]',
                 )}
               >
                 {probe.ok

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -1792,9 +1792,15 @@ interface LlmSectionProps extends SectionProps {
 function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refresh }: LlmSectionProps) {
   const [primaryKeyInput, setPrimaryKeyInput] = useState('');
   const [fallbackKeyInput, setFallbackKeyInput] = useState('');
+  const [primaryKeyTest, setPrimaryKeyTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
+  const [primaryKeyTesting, setPrimaryKeyTesting] = useState(false);
+  const [fallbackKeyTest, setFallbackKeyTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
+  const [fallbackKeyTesting, setFallbackKeyTesting] = useState(false);
 
   useEffect(() => { setPrimaryKeyInput(''); }, [form.llm.provider]);
   useEffect(() => { setFallbackKeyInput(''); }, [form.llm.fallback.provider]);
+  useEffect(() => { setPrimaryKeyTest(null); }, [form.llm.provider]);
+  useEffect(() => { setFallbackKeyTest(null); }, [form.llm.fallback.provider]);
 
   const saveKey = async (envVar: string, value: string): Promise<boolean> => {
     if (!value.trim()) return true;
@@ -1813,6 +1819,30 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
     } catch (e) {
       notify.err(errorMessage(e));
       return false;
+    }
+  };
+
+  const testKey = async (
+    envVar: string,
+    value: string,
+    setTesting: (v: boolean) => void,
+    setResult: (r: { ok: boolean; message: string; latencyMs: number } | null) => void,
+  ) => {
+    if (!value.trim()) return;
+    setTesting(true);
+    setResult(null);
+    try {
+      const r = await adminFetch('/settings/secrets/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: envVar, value: value.trim() }),
+      });
+      const j = await r.json() as { ok: boolean; message: string; latencyMs: number };
+      setResult(j);
+    } catch (e) {
+      setResult({ ok: false, message: errorMessage(e), latencyMs: 0 });
+    } finally {
+      setTesting(false);
     }
   };
 
@@ -2058,6 +2088,16 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                   </div>
                 </div>
                 <KeyStatus envVar={keyVar} present={!!data.env?.[keyVar]} />
+                <div className="mt-2 flex items-center gap-2">
+                  <Btn
+                    sm
+                    onClick={() => testKey(keyVar, primaryKeyInput, setPrimaryKeyTesting, setPrimaryKeyTest)}
+                    disabled={primaryKeyTesting || !primaryKeyInput.trim()}
+                  >
+                    {primaryKeyTesting ? 'Testing…' : 'Test key'}
+                  </Btn>
+                </div>
+                {primaryKeyTest && <KeyTestResult result={primaryKeyTest} />}
               </>
             );
           })()}
@@ -2236,6 +2276,16 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                       </div>
                     </div>
                     <KeyStatus envVar={keyVar} present={!!data.env?.[keyVar]} />
+                    <div className="mt-2 flex items-center gap-2">
+                      <Btn
+                        sm
+                        onClick={() => testKey(keyVar, fallbackKeyInput, setFallbackKeyTesting, setFallbackKeyTest)}
+                        disabled={fallbackKeyTesting || !fallbackKeyInput.trim()}
+                      >
+                        {fallbackKeyTesting ? 'Testing…' : 'Test key'}
+                      </Btn>
+                    </div>
+                    {fallbackKeyTest && <KeyTestResult result={fallbackKeyTest} />}
                   </>
                 );
               })()}

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -32,6 +32,7 @@ const SECTIONS = [
   { id: 'search',   label: 'Web search', hint: 'live-facts backend' },
   { id: 'jingles',  label: 'Jingles', hint: 'stingers' },
   { id: 'sfx',      label: 'Sound FX', hint: 'agent stingers' },
+  { id: 'api-keys', label: 'API Keys', hint: 'provider credentials' },
   { id: 'scrobble', label: 'Scrobbling', hint: 'last.fm · listenbrainz' },
   { id: 'archives', label: 'Archives', hint: 'hourly recordings' },
   { id: 'webhooks', label: 'Webhooks', hint: 'outbound events' },
@@ -733,6 +734,13 @@ export default function SettingsPanel() {
                 createJingle={createJingle} uploadJingle={uploadJingle}
                 saveSettings={saveSettings}
                 onDelete={setConfirmDelete} adminFetch={adminFetch}
+              />
+            )}
+            {activeSection === 'api-keys' && data && (
+              <ApiKeysSection
+                data={data}
+                adminFetch={adminFetch}
+                onSaved={refresh}
               />
             )}
             {activeSection === 'scrobble' && (
@@ -3950,6 +3958,112 @@ function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uploadSfx, 
             </div>
           </div>
         ))}
+      </Card>
+    </>
+  );
+}
+
+/* ── API Keys ────────────────────────────────────────────────────────── */
+// Write provider keys to state/secrets.env via POST /settings/secrets.
+// Values are never read back; only presence is shown via data.env booleans.
+// Pattern mirrors ScrobbleSection exactly: password inputs, blank = no-op,
+// KeyStatus badge, save clears the typed values and refreshes presence flags.
+
+interface ApiKeysSectionProps {
+  data: SettingsData;
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+  onSaved: () => void;
+}
+
+const API_KEY_DEFS: { key: string; label: string; hint: string }[] = [
+  { key: 'ANTHROPIC_API_KEY',            label: 'Anthropic (Claude)',          hint: 'sk-ant-...' },
+  { key: 'OPENAI_API_KEY',               label: 'OpenAI',                      hint: 'sk-...' },
+  { key: 'GOOGLE_GENERATIVE_AI_API_KEY', label: 'Google Generative AI',        hint: 'AIza...' },
+  { key: 'OPENROUTER_API_KEY',           label: 'OpenRouter',                  hint: 'sk-or-v1-...' },
+  { key: 'DEEPSEEK_API_KEY',             label: 'DeepSeek',                    hint: 'sk-...' },
+  { key: 'AI_GATEWAY_API_KEY',           label: 'AI Gateway',                  hint: 'gateway API key' },
+  { key: 'ELEVENLABS_API_KEY',           label: 'ElevenLabs (TTS)',            hint: 'el_...' },
+  { key: 'SEARCH_API_KEY',               label: 'Tavily (web search)',         hint: 'tvly-...' },
+  { key: 'EMBEDDING_API_KEY',            label: 'Embedding (override)',        hint: 'optional — defaults to chat key' },
+];
+
+function ApiKeysSection({ data, adminFetch, onSaved }: ApiKeysSectionProps) {
+  const env = (data.env || {}) as Record<string, boolean>;
+  const [form, setForm] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+
+  const inputValue = (key: string) => form[key] || '';
+  const placeholder = (key: string, hint: string) =>
+    env[key] ? '•••••• (on file)' : hint;
+
+  const keysSet = API_KEY_DEFS.filter(d => !!env[d.key]).length;
+  const hasInput = API_KEY_DEFS.some(d => (form[d.key] || '').trim().length > 0);
+
+  const save = async () => {
+    const patch: Record<string, string> = {};
+    for (const { key } of API_KEY_DEFS) {
+      const v = (form[key] || '').trim();
+      if (v) patch[key] = v;
+    }
+    if (Object.keys(patch).length === 0) return;
+    setSaving(true);
+    try {
+      const r = await adminFetch('/settings/secrets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      });
+      const j = (await r.json().catch(() => ({}))) as { saved?: string[]; error?: string };
+      if (!r.ok) throw new Error(j.error || `Save failed (${r.status})`);
+      setForm({});
+      onSaved();
+      notify.ok(`Saved ${(j.saved || []).length} key(s)`);
+    } catch (e) {
+      notify.err(errorMessage(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <>
+      <SectionHeader
+        eyebrow="api keys"
+        title="Provider credentials — stored securely in state/secrets.env."
+        sub={<>
+          Paste a key to store it. Stored values are never shown — only whether a key
+          is present. Leave a field blank to keep the existing key unchanged.
+          Keys set via <code>.env</code> or Docker <code>env_file</code> always take
+          precedence over values stored here. Last.fm and ListenBrainz tokens are
+          managed in the <strong>Scrobbling</strong> section.
+        </>}
+        metrics={[
+          { n: `${keysSet}/${API_KEY_DEFS.length}`, l: 'configured', accent: keysSet > 0 },
+        ]}
+      />
+      <Card title="Provider keys">
+        <div className="grid gap-[18px]">
+          {API_KEY_DEFS.map(({ key, label, hint }) => (
+            <div key={key} className="field">
+              <Label>{label}</Label>
+              <Input
+                type="password"
+                value={inputValue(key)}
+                placeholder={placeholder(key, hint)}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setForm(f => ({ ...f, [key]: e.target.value }))
+                }
+                className="max-w-[360px]"
+              />
+              <KeyStatus envVar={key} present={!!env[key]} />
+            </div>
+          ))}
+          <div className="mt-1">
+            <Btn tone="accent" onClick={save} disabled={saving || !hasInput}>
+              {saving ? 'Saving…' : 'Save keys'}
+            </Btn>
+          </div>
+        </div>
       </Card>
     </>
   );

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -1294,8 +1294,11 @@ interface TtsSectionProps extends SectionProps {
 
 function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refresh }: TtsSectionProps) {
   const [cloudKeyInput, setCloudKeyInput] = useState('');
+  const [cloudKeyTest, setCloudKeyTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
+  const [cloudKeyTesting, setCloudKeyTesting] = useState(false);
 
   useEffect(() => { setCloudKeyInput(''); }, [form.tts.cloud.provider]);
+  useEffect(() => { setCloudKeyTest(null); }, [form.tts.cloud.provider]);
 
   const saveKey = async (envVar: string, value: string): Promise<boolean> => {
     if (!value.trim()) return true;
@@ -1314,6 +1317,25 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
     } catch (e) {
       notify.err(errorMessage(e));
       return false;
+    }
+  };
+  const testCloudKey = async () => {
+    const cloudKeyVar = form.tts.cloud.provider === 'elevenlabs' ? 'ELEVENLABS_API_KEY' : 'OPENAI_API_KEY';
+    if (!cloudKeyInput.trim()) return;
+    setCloudKeyTesting(true);
+    setCloudKeyTest(null);
+    try {
+      const r = await adminFetch('/settings/secrets/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: cloudKeyVar, value: cloudKeyInput.trim() }),
+      });
+      const j = await r.json() as { ok: boolean; message: string; latencyMs: number };
+      setCloudKeyTest(j);
+    } catch (e) {
+      setCloudKeyTest({ ok: false, message: errorMessage(e), latencyMs: 0 });
+    } finally {
+      setCloudKeyTesting(false);
     }
   };
   const engines = data.tts?.engines || ['piper'];
@@ -1755,6 +1777,16 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                     </div>
                   </div>
                   <KeyStatus envVar={cloudKeyVar} present={!!data.env?.[cloudKeyVar]} />
+                  <div className="mt-2 flex items-center gap-2">
+                    <Btn
+                      sm
+                      onClick={testCloudKey}
+                      disabled={cloudKeyTesting || !cloudKeyInput.trim()}
+                    >
+                      {cloudKeyTesting ? 'Testing…' : 'Test key'}
+                    </Btn>
+                  </div>
+                  {cloudKeyTest && <KeyTestResult result={cloudKeyTest} />}
                 </>
               );
             })()}

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -1721,7 +1721,6 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
               const cloudKeyVar = form.tts.cloud.provider === 'elevenlabs' ? 'ELEVENLABS_API_KEY' : 'OPENAI_API_KEY';
               return (
                 <>
-                  <KeyStatus envVar={cloudKeyVar} present={!!data.env?.[cloudKeyVar]} />
                   <div className="field">
                     <Label>{form.tts.cloud.provider === 'elevenlabs' ? 'ElevenLabs' : 'OpenAI'} API key</Label>
                     <Input
@@ -1735,6 +1734,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                       Stored in <code>state/secrets.env</code>, takes effect immediately. Leave blank to keep the existing key.
                     </div>
                   </div>
+                  <KeyStatus envVar={cloudKeyVar} present={!!data.env?.[cloudKeyVar]} />
                 </>
               );
             })()}
@@ -2024,7 +2024,6 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
             const keyVar = LLM_ENV_VARS[form.llm.provider]!;
             return (
               <>
-                <KeyStatus envVar={keyVar} present={!!data.env?.[keyVar]} />
                 <div className="field">
                   <Label>{llmProviderLabel(form.llm.provider)} API key</Label>
                   <Input
@@ -2038,6 +2037,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                     Stored in <code>state/secrets.env</code>, takes effect immediately. Leave blank to keep the existing key.
                   </div>
                 </div>
+                <KeyStatus envVar={keyVar} present={!!data.env?.[keyVar]} />
               </>
             );
           })()}
@@ -2202,7 +2202,6 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                 const keyVar = LLM_ENV_VARS[form.llm.fallback.provider]!;
                 return (
                   <>
-                    <KeyStatus envVar={keyVar} present={!!data.env?.[keyVar]} />
                     <div className="field">
                       <Label>{llmProviderLabel(form.llm.fallback.provider)} API key</Label>
                       <Input
@@ -2216,6 +2215,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                         Stored in <code>state/secrets.env</code>, takes effect immediately. Leave blank to keep the existing key.
                       </div>
                     </div>
+                    <KeyStatus envVar={keyVar} present={!!data.env?.[keyVar]} />
                   </>
                 );
               })()}

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -2622,11 +2622,8 @@ interface LibrarySectionProps extends SectionProps {
 function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, refresh }: LibrarySectionProps) {
   const e = form.embedding;
   const [embeddingKeyInput, setEmbeddingKeyInput] = useState('');
-  const [embeddingKeyTest, setEmbeddingKeyTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
-  const [embeddingKeyTesting, setEmbeddingKeyTesting] = useState(false);
 
   useEffect(() => { setEmbeddingKeyInput(''); }, [form.embedding.provider]);
-  useEffect(() => { setEmbeddingKeyTest(null); }, [form.embedding.provider]);
 
   const saveKey = async (envVar: string, value: string): Promise<boolean> => {
     if (!value.trim()) return true;
@@ -2645,25 +2642,6 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
     } catch (e) {
       notify.err(errorMessage(e));
       return false;
-    }
-  };
-
-  const testEmbeddingKey = async () => {
-    if (!embeddingKeyInput.trim()) return;
-    setEmbeddingKeyTesting(true);
-    setEmbeddingKeyTest(null);
-    try {
-      const r = await adminFetch('/settings/secrets/test', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ key: 'EMBEDDING_API_KEY', value: embeddingKeyInput.trim() }),
-      });
-      const j = await r.json() as { ok: boolean; message: string; latencyMs: number };
-      setEmbeddingKeyTest(j);
-    } catch (e) {
-      setEmbeddingKeyTest({ ok: false, message: errorMessage(e), latencyMs: 0 });
-    } finally {
-      setEmbeddingKeyTesting(false);
     }
   };
 
@@ -3036,16 +3014,6 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
                 </div>
               </div>
               <KeyStatus envVar="EMBEDDING_API_KEY" present={!!data.env?.['EMBEDDING_API_KEY']} />
-              <div className="mt-2 flex items-center gap-2">
-                <Btn
-                  sm
-                  onClick={testEmbeddingKey}
-                  disabled={embeddingKeyTesting || !embeddingKeyInput.trim()}
-                >
-                  {embeddingKeyTesting ? 'Testing…' : 'Test key'}
-                </Btn>
-              </div>
-              {embeddingKeyTest && <KeyTestResult result={embeddingKeyTest} />}
             </>
           )}
 

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -2582,8 +2582,11 @@ interface LibrarySectionProps extends SectionProps {
 function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, refresh }: LibrarySectionProps) {
   const e = form.embedding;
   const [embeddingKeyInput, setEmbeddingKeyInput] = useState('');
+  const [embeddingKeyTest, setEmbeddingKeyTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
+  const [embeddingKeyTesting, setEmbeddingKeyTesting] = useState(false);
 
   useEffect(() => { setEmbeddingKeyInput(''); }, [form.embedding.provider]);
+  useEffect(() => { setEmbeddingKeyTest(null); }, [form.embedding.provider]);
 
   const saveKey = async (envVar: string, value: string): Promise<boolean> => {
     if (!value.trim()) return true;
@@ -2602,6 +2605,25 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
     } catch (e) {
       notify.err(errorMessage(e));
       return false;
+    }
+  };
+
+  const testEmbeddingKey = async () => {
+    if (!embeddingKeyInput.trim()) return;
+    setEmbeddingKeyTesting(true);
+    setEmbeddingKeyTest(null);
+    try {
+      const r = await adminFetch('/settings/secrets/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: 'EMBEDDING_API_KEY', value: embeddingKeyInput.trim() }),
+      });
+      const j = await r.json() as { ok: boolean; message: string; latencyMs: number };
+      setEmbeddingKeyTest(j);
+    } catch (e) {
+      setEmbeddingKeyTest({ ok: false, message: errorMessage(e), latencyMs: 0 });
+    } finally {
+      setEmbeddingKeyTesting(false);
     }
   };
 
@@ -2974,6 +2996,16 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
                 </div>
               </div>
               <KeyStatus envVar="EMBEDDING_API_KEY" present={!!data.env?.['EMBEDDING_API_KEY']} />
+              <div className="mt-2 flex items-center gap-2">
+                <Btn
+                  sm
+                  onClick={testEmbeddingKey}
+                  disabled={embeddingKeyTesting || !embeddingKeyInput.trim()}
+                >
+                  {embeddingKeyTesting ? 'Testing…' : 'Test key'}
+                </Btn>
+              </div>
+              {embeddingKeyTest && <KeyTestResult result={embeddingKeyTest} />}
             </>
           )}
 

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -2754,27 +2754,6 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
             )}
           </div>
 
-          {/* Embedding API key override -- only for cloud providers that need one */}
-          {e.provider && !['', 'ollama', 'openai-compatible', 'locca'].includes(e.provider) && (
-            <>
-              <div className="field">
-                <Label>Embedding API key override</Label>
-                <Input
-                  type="password"
-                  value={embeddingKeyInput}
-                  placeholder={data.env?.['EMBEDDING_API_KEY'] ? '•••••• (on file)' : 'optional -- defaults to chat key'}
-                  onChange={(ev: ChangeEvent<HTMLInputElement>) => setEmbeddingKeyInput(ev.target.value)}
-                  className="max-w-[360px]"
-                />
-                <div className="field-hint">
-                  Only needed when the embedding provider uses a different API key than the chat provider.
-                  Stored in <code>state/secrets.env</code>.
-                </div>
-              </div>
-              <KeyStatus envVar="EMBEDDING_API_KEY" present={!!data.env?.['EMBEDDING_API_KEY']} />
-            </>
-          )}
-
           <div className="field">
             <Label>Model</Label>
             <Input
@@ -2873,6 +2852,27 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
                 different Ollama host.
               </div>
             </div>
+          )}
+
+          {/* Embedding API key override -- only for cloud providers that need one */}
+          {e.provider && !['', 'ollama', 'openai-compatible', 'locca'].includes(e.provider) && (
+            <>
+              <div className="field">
+                <Label>Embedding API key override</Label>
+                <Input
+                  type="password"
+                  value={embeddingKeyInput}
+                  placeholder={data.env?.['EMBEDDING_API_KEY'] ? '•••••• (on file)' : 'optional -- defaults to chat key'}
+                  onChange={(ev: ChangeEvent<HTMLInputElement>) => setEmbeddingKeyInput(ev.target.value)}
+                  className="max-w-[360px]"
+                />
+                <div className="field-hint">
+                  Only needed when the embedding provider uses a different API key than the chat provider.
+                  Stored in <code>state/secrets.env</code>.
+                </div>
+              </div>
+              <KeyStatus envVar="EMBEDDING_API_KEY" present={!!data.env?.['EMBEDDING_API_KEY']} />
+            </>
           )}
 
           {/* Detect a locca embed server + test the endpoint BEFORE a long run. */}

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -716,7 +716,7 @@ export default function SettingsPanel() {
             {activeSection === 'search' && (
               <SearchSection
                 data={data} form={form} setForm={updateForm} busy={busy}
-                saveSettings={saveSettings}
+                saveSettings={saveSettings} adminFetch={adminFetch}
               />
             )}
             {activeSection === 'library' && (
@@ -2460,7 +2460,10 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
 
 /* ── Web search ──────────────────────────────────────────────────────── */
 
-function SearchSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
+interface SearchSectionProps extends SectionProps {
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+}
+function SearchSection({ data, form, setForm, busy, saveSettings, adminFetch }: SearchSectionProps) {
   const save = () => saveSettings({
     search: {
       provider: form.search.provider,
@@ -2481,6 +2484,28 @@ function SearchSection({ data, form, setForm, busy, saveSettings }: SectionProps
         && form.search.apiKey !== 'set'
         && form.search.apiKey !== (savedSearch.apiKey || ''));
   const tavilyKeySet = form.search.apiKey === 'set' || !!data.env?.SEARCH_API_KEY;
+  const [tavilyKeyTest, setTavilyKeyTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
+  const [tavilyKeyTesting, setTavilyKeyTesting] = useState(false);
+
+  const testTavilyKey = async () => {
+    const value = form.search.apiKey === 'set' ? '' : form.search.apiKey;
+    if (!value.trim()) return;
+    setTavilyKeyTesting(true);
+    setTavilyKeyTest(null);
+    try {
+      const r = await adminFetch('/settings/secrets/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: 'SEARCH_API_KEY', value: value.trim() }),
+      });
+      const j = await r.json() as { ok: boolean; message: string; latencyMs: number };
+      setTavilyKeyTest(j);
+    } catch (e) {
+      setTavilyKeyTest({ ok: false, message: errorMessage(e), latencyMs: 0 });
+    } finally {
+      setTavilyKeyTesting(false);
+    }
+  };
 
   return (
     <>
@@ -2557,6 +2582,20 @@ function SearchSection({ data, form, setForm, busy, saveSettings }: SectionProps
                 </div>
               </div>
               <KeyStatus envVar="SEARCH_API_KEY" present={tavilyKeySet} />
+              <div className="mt-2 flex items-center gap-2">
+                <Btn
+                  sm
+                  onClick={testTavilyKey}
+                  disabled={
+                    tavilyKeyTesting ||
+                    !form.search.apiKey.trim() ||
+                    form.search.apiKey === 'set'
+                  }
+                >
+                  {tavilyKeyTesting ? 'Testing…' : 'Test key'}
+                </Btn>
+              </div>
+              {tavilyKeyTest && <KeyTestResult result={tavilyKeyTest} />}
             </>
           )}
         </div>

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -1139,6 +1139,26 @@ function KeyStatus({ envVar, present }: KeyStatusProps) {
   );
 }
 
+interface KeyTestResultProps {
+  result: { ok: boolean; message: string; latencyMs: number };
+}
+
+function KeyTestResult({ result }: KeyTestResultProps) {
+  return (
+    <div
+      className={cn(
+        'mt-2 max-w-[560px] rounded border px-3 py-2 text-[11px] leading-[1.6]',
+        result.ok
+          ? 'border-[var(--accent)] text-[color:var(--accent)]'
+          : 'border-red-400/50 text-red-300',
+      )}
+    >
+      {result.message}
+      {result.ok && result.latencyMs > 0 && ` · ${result.latencyMs}ms`}
+    </div>
+  );
+}
+
 /* ── TTS ─────────────────────────────────────────────────────────────── */
 
 type FormUpdater = (updater: (f: FormState) => FormState) => void;

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -1144,17 +1144,21 @@ interface KeyTestResultProps {
 }
 
 function KeyTestResult({ result }: KeyTestResultProps) {
+  const toneClass = result.ok
+    ? 'border-[var(--accent)] text-[color:var(--accent)]'
+    : 'border-[var(--danger)] text-[var(--danger)]';
   return (
-    <div
-      className={cn(
-        'mt-2 max-w-[560px] rounded border bg-[var(--ink-softer)] px-3 py-2 text-[11px] leading-[1.6]',
-        result.ok
-          ? 'border-[var(--accent)] text-[color:var(--accent)]'
-          : 'border-[var(--danger)] text-[var(--danger)]',
-      )}
-    >
-      {result.message}
-      {result.ok && result.latencyMs > 0 && ` · ${result.latencyMs}ms`}
+    <div className={cn('field mt-2 flex items-start gap-2.5 border bg-[var(--ink-softer)] p-3', toneClass)}>
+      <span className={cn('mt-1 size-1.5 flex-none rounded-full', result.ok ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]')} />
+      <div className="grid gap-0.5">
+        <span className={cn('text-[11px] font-bold tracking-[0.12em] uppercase', toneClass)}>
+          {result.ok ? 'Key valid' : 'Key test failed'}
+        </span>
+        <span className="text-[11px] leading-[1.5] text-muted">
+          {result.message}
+          {result.ok && result.latencyMs > 0 && ` · ${result.latencyMs}ms`}
+        </span>
+      </div>
     </div>
   );
 }

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -3978,7 +3978,7 @@ interface ApiKeysSectionProps {
 const API_KEY_DEFS: { key: string; label: string; hint: string }[] = [
   { key: 'ANTHROPIC_API_KEY',            label: 'Anthropic (Claude)',          hint: 'sk-ant-...' },
   { key: 'OPENAI_API_KEY',               label: 'OpenAI',                      hint: 'sk-...' },
-  { key: 'GOOGLE_GENERATIVE_AI_API_KEY', label: 'Google Generative AI',        hint: 'AIza...' },
+  { key: 'GOOGLE_GENERATIVE_AI_API_KEY', label: 'Google Generative AI (Gemini)', hint: 'AIza...' },
   { key: 'OPENROUTER_API_KEY',           label: 'OpenRouter',                  hint: 'sk-or-v1-...' },
   { key: 'DEEPSEEK_API_KEY',             label: 'DeepSeek',                    hint: 'sk-...' },
   { key: 'AI_GATEWAY_API_KEY',           label: 'AI Gateway',                  hint: 'gateway API key' },
@@ -3988,7 +3988,7 @@ const API_KEY_DEFS: { key: string; label: string; hint: string }[] = [
 ];
 
 function ApiKeysSection({ data, adminFetch, onSaved }: ApiKeysSectionProps) {
-  const env = (data.env || {}) as Record<string, boolean>;
+  const env = (data.env || {}) as Record<string, unknown>;
   const [form, setForm] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
 

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -1772,12 +1772,12 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
     const primaryKeyVar = LLM_ENV_VARS[form.llm.provider];
     if (primaryKeyVar && primaryKeyInput.trim()) {
       const ok = await saveKey(primaryKeyVar, primaryKeyInput);
-      if (ok) { setPrimaryKeyInput(''); refresh(); }
+      if (ok) { notify.ok('API key saved'); setPrimaryKeyInput(''); refresh(); }
     }
     const fallbackKeyVar = LLM_ENV_VARS[form.llm.fallback.provider];
     if (fallbackKeyVar && fallbackKeyInput.trim()) {
       const ok = await saveKey(fallbackKeyVar, fallbackKeyInput);
-      if (ok) { setFallbackKeyInput(''); refresh(); }
+      if (ok) { notify.ok('API key saved'); setFallbackKeyInput(''); refresh(); }
     }
   };
 

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -1129,8 +1129,8 @@ function KeyStatus({ envVar, present }: KeyStatusProps) {
             <>The controller has <code>{envVar}</code> set, so this provider is ready to use.</>
           ) : (
             <>
-              Set <code>{envVar}</code> in <code>.env</code> and restart the controller.
-              API keys are configured through the environment, not the admin UI.
+              <code>{envVar}</code> is not set. Paste the key in the field above and save,
+              or set it in <code>.env</code> and restart.
             </>
           )}
         </span>


### PR DESCRIPTION

  ## What

  Adds a "Test key" button beside every cloud API key input in the admin Settings panel. Operators can verify a key works against its provider before or after saving it.

  Closes #574

  ## Why

  There was no validation feedback for API keys. The first sign of a bad key was a broken LLM/TTS/search call at runtime. The inline inputs from  #573 made key entry easy, but operators still had no way to confirm a key works without triggering a real DJ call.

  ## How tested

  - Deployed to test LXC  with rebuilt controller + web images
  - Tested bad keys for Anthropic, ElevenLabs, Tavily: all return friendly error messages ("Key rejected", "Rate limited", "Timed out") instead of raw SDK stack traces
  - Tested valid Anthropic key: returns "Anthropic key valid, model responded" with latency
  - Verified Test button is disabled when input is empty
  - Verified test result clears when provider changes
  - Verified result box follows custom theme colours (var(--accent) / var(--danger))
  - Verified embedding section has no Test key button (existing "Test embeddings" covers it)
  - Verified endpoint returns 401 without admin auth
  - Controller and web lint clean (0 errors)

  ## Notes for reviewers

  - `POST /settings/secrets/test` is non-mutating: it builds a one-off provider client with the typed value, never writes to process.env or secrets.env
  - Each LLM probe uses a 1-token generateText call with a 15s AbortSignal timeout to prevent hangs
  - Tavily probe uses `Authorization: Bearer` header (matches the production call path in web-search.ts)
  - Embedding key test was removed from the frontend because LibrarySection already has "Test embeddings" which probes the full embedding pipeline
  - `briefLlmError()` distils raw AI SDK errors into one-line actionable messages (maps HTTP status codes and common error patterns to plain
  English)
  - AI Gateway key returns ok:true with an informational message since there is no standalone probe for it
  - KeyTestResult uses the same compact rounded-box style as the embedding probe result, themed via CSS variables