### PR TITLE
feat(admin): DJ Doc — station diagnostics + LLM review

### DIFF
--- a/controller/src/doctor-knowledge.ts
+++ b/controller/src/doctor-knowledge.ts
@@ -1,0 +1,91 @@
+// DJ Doc's knowledge base — the "memory file" the station doctor consults when
+// reviewing a health report. Distilled by hand from the operator manual
+// (/manual, esp. the FAQ + getting-started + voices + llm pages) and the setup
+// pages (/setup, /onboarding), plus the architecture in CLAUDE.md. Kept as a
+// plain string so it drops straight into the review prompt.
+//
+// Editing this file improves DJ Doc's advice without touching the assessment
+// logic. Keep it FACTUAL and ACTIONABLE — it is reference material, not prose.
+
+export const DJ_DOC_KNOWLEDGE = `# SUB/WAVE — operator knowledge base (for the station doctor)
+
+## What it is
+SUB/WAVE is a personal internet radio station: one Icecast stream every listener
+shares, an AI DJ that picks the tracks and reads the links between them. Music
+comes from a Navidrome (Subsonic) library; the DJ is driven by an LLM; voices are
+synthesised by a TTS engine; Liquidsoap mixes it and feeds Icecast.
+
+## What setup actually requires
+- A reachable **Navidrome** library (URL + user + pass) — without it the picker has
+  nothing to play. This is the only hard requirement; if connectivity fails, point
+  the operator at /onboarding (or 'subwave setup').
+- An **LLM** — Ollama is the default and needs no key. Cloud providers (Anthropic,
+  OpenAI, Google, DeepSeek, OpenRouter, Gateway) and self-hosted openai-compatible
+  servers are all supported; pick one in Settings → LLM.
+- Three root .env vars boot the stack: ADMIN_USER, ADMIN_PASS, SITE_URL. Env always
+  wins over wizard/settings.
+
+## Chain-of-thought / reasoning (settings.llm.reasoning)
+- Lets "thinking" models emit a reasoning chain before answering. Costs latency and
+  tokens. **Recommend ON only for** a capable reasoning model the operator chose on
+  purpose and where DJ link quality matters more than speed/cost.
+- **Recommend OFF for** small/local models, structured track-picks (they don't
+  benefit), and anyone watching token cost or wanting snappy transitions. Default OFF.
+
+## Agentic picker vs candidate pool (settings.llm.pickerAgent)
+- **Agentic picker (ON by default):** a small reasoning loop with session memory and
+  tools to search the library itself — choices stay coherent across a run. Wants a
+  ~12B-class model (e.g. Gemma-class 12B) or a good cloud model. It automatically
+  falls back to the candidate pool if it fails or runs slow.
+- **Candidate pool (the fallback / "simpler picker"):** gathers a shortlist (similar
+  songs & artists, mood matches, recently-added & frequent albums), caps it, asks the
+  model to pick one. Cheaper and more forgiving. **Recommend turning the agent OFF**
+  for small models (≤9B) or constrained hardware.
+
+## Agent deadline (settings.llm.agentTimeoutMs, default 45000ms)
+- Wall-clock budget for the agentic picker before it gives up and falls back to the
+  pool. **Reasoning-heavy or cloud models routinely need 20–40s**, so keep the
+  deadline generous (40–60s) for them. **Fast local models** can use a tighter
+  deadline (15–25s) so a stall recovers quickly. If the picker keeps falling back,
+  the deadline is likely too low for the chosen model.
+
+## TTS engines — choose by system resources (settings.tts.defaultEngine / byKind)
+- **piper** — CPU, ~30ms/word, always available, the universal fallback. Best default
+  on any box; recommend it when CPU/RAM is limited.
+- **kokoro** — CPU, ~300–800ms/line, more natural than Piper. Good on a box with CPU
+  headroom and no GPU.
+- **chatterbox / pocket-tts** — heavy PyTorch engines. Need the optional 'tts-heavy'
+  sidecar (\`--profile tts-heavy\`); Chatterbox really wants a **GPU**. Recommend only
+  when the operator has the GPU/RAM for it. If a configured heavy engine is
+  unavailable, the DJ silently falls back to Piper (a warn, not an outage).
+- **cloud** (OpenAI / ElevenLabs) — best quality, needs an API key, costs per
+  character. Recommend for operators who want top quality and don't mind paying.
+- Rule of thumb: tight resources → Piper (maybe Kokoro). GPU box → Chatterbox via the
+  sidecar. Want best quality, happy to pay → Cloud.
+
+## Pause when empty
+Optional setting: when listeners hit zero it stops the AI work (picks, links, IDs)
+while a fallback playlist keeps music flowing, then wakes the DJ when someone tunes
+in. Suggest it to operators worried about token cost on an empty room.
+
+## Mood tagging
+A background tagger labels tracks (calm, energetic, reflective…); the DJ leans on
+those tags to fit the time of day, weather, and show. Untagged tracks still play but
+aren't matched by feel. If coverage is zero/low, recommend running the tagger.
+
+## Web search (settings.search)
+Backs the DJ's artist-news segments. 'duckduckgo' is the keyless default; 'tavily'
+gives richer results but needs a key (SEARCH_API_KEY). If Tavily is selected without
+a key, news segments can't fetch — tell them to add the key or switch to DuckDuckGo.
+
+## Backups
+There is a Backup feature (Admin → Backup) that exports settings, personas, custom
+skills and library tags as a single archive, restorable later. **Proactively suggest
+taking a backup** before big changes (re-tagging, switching providers) and on a
+regular cadence — it's cheap insurance.
+
+## Where to look when things break
+The admin Debug page is a live snapshot (recent AI calls + success, mixer status,
+log tail) — first stop when the stream stalls, the DJ goes quiet, or a voice sounds
+wrong. The 'subwave-log-analysis' skill covers behaviour over time. 'subwave-deploy'
+installs/updates; 'subwave-control' just starts/stops the stack.`;

--- a/controller/src/doctor.ts
+++ b/controller/src/doctor.ts
@@ -1,0 +1,678 @@
+// Station "doctor" — the deeper, controller-side health assessment behind the
+// admin Doctor panel and (later) the CLI's v2 checks. Pure data: runDoctor()
+// returns a structured report; reviewReport() asks the configured LLM to turn
+// that report into a prioritized, plain-English read. No rendering here.
+//
+// The Finding/DoctorReport shape mirrors cli/src/doctor.ts (same ok|warn|fail|
+// skip vocabulary) so the two surfaces stay legible together — extended with an
+// optional `fix` descriptor that the panel maps to an existing admin endpoint.
+// Every check reuses signals the controller already computes (LLM reachability
+// probe, Subsonic ping, listener monitor, TTS routing, library stats); nothing
+// here adds new probing infrastructure.
+
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { z } from 'zod';
+import { config, STATE_DIR } from './config.js';
+import * as settings from './settings.js';
+import * as subsonic from './music/subsonic.js';
+import * as subsonicLog from './music/subsonic-log.js';
+import * as library from './music/library.js';
+import * as tts from './audio/tts.js';
+import { getStreamStatus } from './broadcast/listeners.js';
+import { streamStatus } from './broadcast/liquidsoap-control.js';
+import {
+  primaryLeg,
+  fallbackLeg,
+  probeLegReachable,
+  providerName,
+  activeModelLabel,
+} from './llm/provider.js';
+import { recentCalls } from './llm/log.js';
+import { getSetupStatus } from './setup/firstRun.js';
+import { djObject } from './llm/sdk.js';
+import { searchReady, searchWeb } from './skills/web-search.js';
+import * as system from './system.js';
+import { DJ_DOC_KNOWLEDGE } from './doctor-knowledge.js';
+
+export type Status = 'ok' | 'warn' | 'fail' | 'skip';
+
+// Closed set of safe, already-implemented admin actions a finding may offer as a
+// one-click remediation. The web panel maps each id → the matching POST route.
+export type FixId =
+  | 'refresh-playlist'
+  | 'restart-mixer'
+  | 'generate-jingles'
+  | 'tag-library'
+  | 'subsonic-reset';
+
+export interface FixAction {
+  id: FixId;
+  label: string;
+}
+
+export interface Finding {
+  label: string;
+  status: Status;
+  detail?: string;
+  hint?: string;
+  fix?: FixAction;
+}
+
+export interface DoctorSection {
+  name: string;
+  findings: Finding[];
+}
+
+export interface DoctorReport {
+  t: string;
+  sections: DoctorSection[];
+  counts: { ok: number; warn: number; fail: number; skip: number };
+}
+
+export interface ReviewPriority {
+  title: string;
+  severity: 'low' | 'med' | 'high';
+  why: string;
+  suggestedFix: string;
+}
+
+export interface DoctorReview {
+  available: boolean;
+  reason?: string; // why the review couldn't run (LLM offline / not configured)
+  overall?: 'healthy' | 'attention' | 'critical';
+  summary?: string;
+  priorities?: ReviewPriority[];
+}
+
+// ---------------------------------------------------------------------------
+// runDoctor — assemble all sections.
+// ---------------------------------------------------------------------------
+
+export async function runDoctor(): Promise<DoctorReport> {
+  let s: any = null;
+  try { s = settings.get(); } catch { s = null; }
+
+  const sections: DoctorSection[] = [];
+  // Each check swallows its own errors and degrades to a 'skip'/'fail' finding,
+  // so one failing subsystem never blanks the whole report.
+  sections.push({ name: 'LLM', findings: await safe(() => checkLlm(s)) });
+  sections.push({ name: 'Navidrome & library', findings: await safe(checkNavidrome) });
+  sections.push({ name: 'Broadcast', findings: await safe(checkBroadcast) });
+  sections.push({ name: 'Voice (TTS)', findings: await safe(() => checkTts(s)) });
+  sections.push({ name: 'Capabilities', findings: await safe(() => checkCapabilities(s)) });
+  sections.push({ name: 'Content', findings: await safe(checkContent) });
+  sections.push({ name: 'Resources', findings: await safe(checkResources) });
+  sections.push({ name: 'Storage', findings: await safe(checkStorage) });
+  sections.push({ name: 'Setup', findings: await safe(checkSetup) });
+
+  const counts = { ok: 0, warn: 0, fail: 0, skip: 0 };
+  for (const sec of sections) for (const f of sec.findings) counts[f.status]++;
+
+  return { t: new Date().toISOString(), sections, counts };
+}
+
+// Wrap a check so a thrown error becomes a single fail finding rather than
+// aborting runDoctor.
+async function safe(fn: () => Promise<Finding[]>): Promise<Finding[]> {
+  try {
+    return await fn();
+  } catch (err: any) {
+    return [{ label: 'check failed', status: 'fail', detail: err?.message || String(err) }];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sections
+// ---------------------------------------------------------------------------
+
+async function checkLlm(s: any): Promise<Finding[]> {
+  const out: Finding[] = [];
+
+  // Primary leg. probeLegReachable returns true for cloud providers (no cheap
+  // probe) and only false on a connection failure for local hosts.
+  try {
+    const leg = primaryLeg();
+    const ok = await probeLegReachable(leg);
+    out.push({
+      label: 'provider',
+      status: ok ? 'ok' : 'fail',
+      detail: `${providerName()} · ${activeModelLabel()}${ok ? ' · reachable' : ' · unreachable'}`,
+      hint: ok
+        ? undefined
+        : 'Without the LLM the DJ falls back to a stateless picker and skips spoken links. Check the provider, model and host in Settings → LLM.',
+    });
+  } catch (err: any) {
+    out.push({
+      label: 'provider',
+      status: 'fail',
+      detail: err?.message || 'not configured',
+      hint: 'Pick a provider + model in Settings → LLM.',
+    });
+  }
+
+  // Fallback leg (optional).
+  try {
+    const fb = fallbackLeg();
+    if (fb) {
+      const ok = await probeLegReachable(fb);
+      out.push({
+        label: 'fallback',
+        status: ok ? 'ok' : 'warn',
+        detail: ok ? 'configured · reachable' : 'configured · unreachable',
+      });
+    } else {
+      out.push({ label: 'fallback', status: 'skip', detail: 'none configured (optional)' });
+    }
+  } catch { /* fallback is best-effort */ }
+
+  // Recent error rate from the in-memory ring.
+  const recent = recentCalls.slice(0, 20);
+  if (recent.length) {
+    const fails = recent.filter((c: any) => c && c.ok === false).length;
+    const rate = Math.round((fails / recent.length) * 100);
+    out.push({
+      label: 'recent calls',
+      status: rate === 0 ? 'ok' : rate < 30 ? 'warn' : 'fail',
+      detail: `${fails}/${recent.length} failed (${rate}%)`,
+      hint:
+        rate >= 30
+          ? 'High failure rate. Confirm the model is loaded and the host is responsive (Debug → recent LLM calls has the errors).'
+          : undefined,
+    });
+  } else {
+    out.push({ label: 'recent calls', status: 'skip', detail: 'no calls yet' });
+  }
+
+  // Picker agent toggle — off is valid (stateless picker) but worth surfacing.
+  // DJ Doc weighs this against the model size + host resources in its review.
+  out.push({
+    label: 'picker agent',
+    status: s?.llm?.pickerAgent === false ? 'warn' : 'ok',
+    detail: s?.llm?.pickerAgent === false ? 'off — stateless pool picker' : 'on — session DJ agent (wants ~12B+ / good cloud model)',
+  });
+
+  // Chain-of-thought (reasoning) — on costs latency + tokens; only worth it on a
+  // capable model where link quality beats speed. Surfaced so DJ Doc can advise.
+  out.push({
+    label: 'chain-of-thought',
+    status: 'ok',
+    detail: s?.llm?.reasoning ? 'reasoning ON (thinking models; slower, pricier)' : 'reasoning OFF (faster, cheaper — good for small/local models)',
+  });
+
+  // Agent deadline — the wall-clock budget before the agentic picker falls back
+  // to the pool. Reasoning/cloud models routinely need 20–40s.
+  const deadlineMs = Number(s?.llm?.agentTimeoutMs);
+  if (Number.isFinite(deadlineMs) && deadlineMs > 0) {
+    out.push({
+      label: 'agent deadline',
+      status: 'ok',
+      detail: `${Math.round(deadlineMs / 1000)}s before falling back to the pool`,
+      hint: deadlineMs < 20000
+        ? 'Tight — reasoning-heavy or cloud models routinely need 20–40s, so the agent may keep falling back. Raise it if you run a slow model.'
+        : undefined,
+    });
+  }
+
+  return out;
+}
+
+async function checkNavidrome(): Promise<Finding[]> {
+  const out: Finding[] = [];
+
+  const p = await subsonic.ping();
+  out.push({
+    label: 'connectivity',
+    status: p.ok ? 'ok' : 'fail',
+    detail: p.ok ? `${config.navidrome.url} · authenticated` : p.reason || 'unreachable',
+    hint: p.ok
+      ? undefined
+      : 'The picker has no music source without Navidrome. Check the URL / username / password in setup, and that Navidrome is up.',
+  });
+
+  // Recent call error rate across all endpoints.
+  try {
+    const snap = subsonicLog.snapshot();
+    const calls = snap.endpoints.reduce((n: number, e: any) => n + e.calls, 0);
+    const errs = snap.endpoints.reduce((n: number, e: any) => n + e.errors, 0);
+    if (calls > 0) {
+      const rate = Math.round((errs / calls) * 100);
+      out.push({
+        label: 'call errors',
+        status: rate === 0 ? 'ok' : rate < 10 ? 'warn' : 'fail',
+        detail: `${errs}/${calls} calls errored (${rate}%)`,
+        fix: rate > 0 ? { id: 'subsonic-reset', label: 'Reset stats' } : undefined,
+      });
+    } else {
+      out.push({ label: 'call errors', status: 'skip', detail: 'no calls yet' });
+    }
+  } catch { /* tracker is best-effort */ }
+
+  // Mood-tag coverage — the picker leans on these tags to match the vibe.
+  try {
+    await library.load();
+    const st = library.stats();
+    out.push({
+      label: 'mood-tag coverage',
+      status: st.total > 0 ? 'ok' : 'warn',
+      detail:
+        st.total > 0
+          ? `${st.total} tracks tagged · ${st.distinctArtists} artists`
+          : 'no tracks tagged yet',
+      hint:
+        st.total > 0
+          ? undefined
+          : 'The picker matches tracks to the time-of-day / weather mood via these tags. Tag the library so it has something to work with.',
+      fix: st.total === 0 ? { id: 'tag-library', label: 'Tag library' } : undefined,
+    });
+  } catch (err: any) {
+    out.push({ label: 'mood-tag coverage', status: 'skip', detail: err?.message || 'library unavailable' });
+  }
+
+  return out;
+}
+
+async function checkBroadcast(): Promise<Finding[]> {
+  const out: Finding[] = [];
+
+  // Icecast — is anything actually being served, and to whom.
+  try {
+    const st = getStreamStatus();
+    out.push({
+      label: 'Icecast stream',
+      status: st.online ? 'ok' : 'fail',
+      detail: st.online
+        ? `online · ${st.listeners?.current ?? 0} listening · ${st.bitrate ?? '?'}kbps`
+        : 'offline — nothing on /stream.mp3',
+      hint: st.online
+        ? undefined
+        : 'Liquidsoap may have dropped its Icecast connection. A mixer restart reconnects it.',
+      fix: st.online ? undefined : { id: 'restart-mixer', label: 'Restart mixer' },
+    });
+  } catch (err: any) {
+    out.push({ label: 'Icecast stream', status: 'skip', detail: err?.message || 'status unavailable' });
+  }
+
+  // Liquidsoap telnet — proves the mixer process is alive and reachable.
+  try {
+    const on = await streamStatus();
+    out.push({
+      label: 'mixer (Liquidsoap)',
+      status: on ? 'ok' : 'warn',
+      detail: on ? 'telnet reachable · stream on' : 'telnet reachable · stream off',
+      fix: on ? undefined : { id: 'restart-mixer', label: 'Restart mixer' },
+    });
+  } catch (err: any) {
+    out.push({
+      label: 'mixer (Liquidsoap)',
+      status: 'fail',
+      detail: `telnet unreachable: ${err?.message || 'no response'}`,
+      hint: 'The mixer process may be down or restarting. Check broadcast logs.',
+      fix: { id: 'restart-mixer', label: 'Restart mixer' },
+    });
+  }
+
+  return out;
+}
+
+async function checkTts(s: any): Promise<Finding[]> {
+  const out: Finding[] = [];
+
+  let avail: any = {};
+  try { avail = tts.availableEngines(); } catch { avail = {}; }
+
+  // Which engines the operator wants vs. which are actually available. A
+  // configured-but-unavailable engine silently falls back to Piper.
+  const wanted = new Set<string>();
+  const def = s?.tts?.defaultEngine;
+  if (def) wanted.add(def);
+  for (const v of Object.values(s?.tts?.byKind || {})) {
+    if (typeof v === 'string' && v) wanted.add(v);
+  }
+  if (wanted.size === 0) wanted.add('piper');
+
+  const unavailable = [...wanted].filter((e) => avail[e] === false);
+  out.push({
+    label: 'configured engines',
+    status: unavailable.length === 0 ? 'ok' : 'warn',
+    detail:
+      unavailable.length === 0
+        ? `${[...wanted].join(', ')} — available`
+        : `unavailable: ${unavailable.join(', ')} (will fall back to Piper)`,
+    hint:
+      unavailable.length === 0
+        ? undefined
+        : 'A configured voice engine is unavailable, so the DJ speaks in the Piper fallback voice. Enable the engine (e.g. the tts-heavy profile / cloud key) or pick an available one in Settings.',
+  });
+
+  // Is the current persona's voice silently routing through a fallback?
+  try {
+    const routing: any = tts.describeRouting();
+    const fellBack = routing?.fellBack || routing?.fallback || routing?.requested !== routing?.effective;
+    out.push({
+      label: 'active routing',
+      status: fellBack ? 'warn' : 'ok',
+      detail: fellBack
+        ? `requested ${routing?.requested ?? '?'} → using ${routing?.effective ?? '?'}`
+        : `${routing?.effective ?? routing?.engine ?? 'piper'}`,
+    });
+  } catch { /* routing snapshot is best-effort */ }
+
+  return out;
+}
+
+async function checkCapabilities(s: any): Promise<Finding[]> {
+  const out: Finding[] = [];
+
+  // Web search — backs the DJ's artist-news segments. DuckDuckGo is keyless;
+  // Tavily needs a key. Report config readiness, then do a short live probe so
+  // "is it actually working?" is answered, not just "is it configured?".
+  const provider = s?.search?.provider || 'duckduckgo';
+  let ready = true;
+  try { ready = searchReady(); } catch { ready = true; }
+
+  if (!ready) {
+    out.push({
+      label: 'web search',
+      status: 'warn',
+      detail: `${provider} selected but no API key`,
+      hint: 'Artist-news segments can\'t fetch. Add a Tavily key (SEARCH_API_KEY) or switch to DuckDuckGo (keyless) in Settings → Search.',
+    });
+    return out;
+  }
+
+  // Live probe, raced against a 5s timeout so a hung provider can't stall the run.
+  let okLive = false;
+  let reason = '';
+  try {
+    await Promise.race([
+      searchWeb('SUB-WAVE radio diagnostic ping').then(() => { okLive = true; }),
+      new Promise((_, rej) => setTimeout(() => rej(new Error('timed out')), 5000)),
+    ]);
+  } catch (err: any) {
+    reason = err?.message || 'unreachable';
+  }
+  out.push({
+    label: 'web search',
+    status: okLive ? 'ok' : 'warn',
+    detail: okLive ? `${provider} · reachable` : `${provider} · ${reason}`,
+    hint: okLive
+      ? undefined
+      : 'The artist-news segment needs outbound web access. Check the controller can reach the internet / the search provider.',
+  });
+
+  return out;
+}
+
+async function checkResources(): Promise<Finding[]> {
+  const out: Finding[] = [];
+  try {
+    const sys = await system.summary();
+    const h = sys.host;
+    const gb = (b: number) => (b / (1024 ** 3)).toFixed(1);
+    const memPct = h.memTotal ? Math.round((h.memUsed / h.memTotal) * 100) : 0;
+
+    out.push({
+      label: 'CPU',
+      status: 'ok',
+      detail: `${h.cpus} cores · load ${h.loadavg.map((n) => n.toFixed(2)).join(' / ')}`,
+    });
+    out.push({
+      label: 'memory',
+      status: memPct > 90 ? 'warn' : 'ok',
+      detail: `${gb(h.memUsed)} / ${gb(h.memTotal)} GB used (${memPct}%)`,
+      hint: memPct > 90
+        ? 'Memory is tight — heavy TTS (Chatterbox / PocketTTS) and large local models may struggle. Prefer Piper/Kokoro and a smaller model.'
+        : undefined,
+    });
+    if (sys.dockerAvailable) {
+      const top = sys.containers[0];
+      out.push({
+        label: 'containers',
+        status: 'ok',
+        detail: top
+          ? `${sys.containers.length} running · busiest ${top.service} ${top.cpuPct}% CPU`
+          : `${sys.containers.length} running`,
+      });
+    }
+  } catch (err: any) {
+    out.push({ label: 'host resources', status: 'skip', detail: err?.message || 'unavailable' });
+  }
+  return out;
+}
+
+async function checkContent(): Promise<Finding[]> {
+  const out: Finding[] = [];
+
+  // auto.m3u — the fallback playlist Liquidsoap plays when the queue is empty.
+  const autoPath = `${STATE_DIR}/auto.m3u`;
+  out.push(await m3uFinding(autoPath, {
+    label: 'fallback playlist',
+    emptyHint: 'The autonomous fallback has nothing to play. Refresh it for the current mood.',
+    fix: { id: 'refresh-playlist', label: 'Refresh playlist' },
+  }));
+
+  // jingles.m3u — station idents.
+  out.push(await m3uFinding(`${STATE_DIR}/jingles.m3u`, {
+    label: 'jingles',
+    emptyHint: 'No station idents yet. Generate the defaults to get jingles between tracks.',
+    fix: { id: 'generate-jingles', label: 'Generate jingles' },
+  }));
+
+  return out;
+}
+
+// Shared helper: report an M3U as ok (N entries) / warn (empty or missing).
+async function m3uFinding(
+  path: string,
+  opts: { label: string; emptyHint: string; fix: FixAction },
+): Promise<Finding> {
+  try {
+    const body = await readFile(path, 'utf8');
+    const lines = body.split('\n').filter((l) => l.trim() && !l.startsWith('#'));
+    if (lines.length === 0) {
+      return { label: opts.label, status: 'warn', detail: 'empty', hint: opts.emptyHint, fix: opts.fix };
+    }
+    return { label: opts.label, status: 'ok', detail: `${lines.length} entries` };
+  } catch {
+    return { label: opts.label, status: 'warn', detail: 'missing', hint: opts.emptyHint, fix: opts.fix };
+  }
+}
+
+async function checkStorage(): Promise<Finding[]> {
+  const out: Finding[] = [];
+
+  const archive = await dirSize(`${STATE_DIR}/archive`);
+  const GB = 1024 * 1024 * 1024;
+  out.push({
+    label: 'hourly archive',
+    status: archive.bytes > 20 * GB ? 'warn' : 'ok',
+    detail: `${fmtBytes(archive.bytes)} across ${archive.files} files`,
+    hint:
+      archive.bytes > 20 * GB
+        ? 'The hourly archive is large. Prune old day folders under state/archive if disk is tight.'
+        : undefined,
+  });
+
+  const logs = await dirSize(`${STATE_DIR}/logs`);
+  out.push({
+    label: 'logs',
+    status: 'ok',
+    detail: `${fmtBytes(logs.bytes)} across ${logs.files} files`,
+  });
+
+  return out;
+}
+
+async function checkSetup(): Promise<Finding[]> {
+  const out: Finding[] = [];
+
+  try {
+    const st = await getSetupStatus();
+    out.push({
+      label: 'configuration',
+      status: st.needsSetup ? 'fail' : 'ok',
+      detail: st.needsSetup ? 'incomplete — Navidrome not configured' : `complete (${st.navidromeSource})`,
+      hint: st.needsSetup ? 'Finish the wizard at /onboarding (or run `subwave setup`).' : undefined,
+    });
+  } catch (err: any) {
+    out.push({ label: 'configuration', status: 'skip', detail: err?.message || 'unknown' });
+  }
+
+  // settings.get() throws if settings never loaded — surface that explicitly.
+  try {
+    settings.get();
+    out.push({ label: 'settings', status: 'ok', detail: 'loaded' });
+  } catch (err: any) {
+    out.push({ label: 'settings', status: 'fail', detail: err?.message || 'not loaded' });
+  }
+
+  // Gentle backup reminder — there's no signal to fail on, just good hygiene.
+  out.push({
+    label: 'backups',
+    status: 'skip',
+    detail: 'on demand',
+    hint: 'Export a backup from Admin → Backup so settings, personas, custom skills and library tags can be restored — especially before re-tagging or switching providers.',
+  });
+
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// reviewReport — hand the report to the LLM for a plain-English read.
+// ---------------------------------------------------------------------------
+
+const REVIEW_SCHEMA = z.object({
+  overall: z
+    .enum(['healthy', 'attention', 'critical'])
+    .describe('one-word verdict for the whole station right now'),
+  summary: z
+    .string()
+    .describe('2-4 sentences, plain English: how the station is doing and the single most important thing the operator should know'),
+  priorities: z
+    .array(
+      z.object({
+        title: z.string().describe('short imperative title of the thing to address'),
+        severity: z.enum(['low', 'med', 'high']),
+        why: z.string().describe('one sentence: why it matters for listeners or reliability'),
+        suggestedFix: z.string().describe('the concrete next step the operator should take'),
+      }),
+    )
+    .describe('0-5 items, highest severity first; empty array when everything is healthy'),
+});
+
+const REVIEW_SYSTEM = [
+  'You are DJ Doc — SUB/WAVE\'s resident station doctor. Picture a legendary West-Coast',
+  'hip-hop producer-engineer who has mixed a thousand records: a sharp ear, zero patience for a',
+  'muddy signal, and total confidence. You talk like a producer in the booth — a little swagger,',
+  'the odd studio metaphor ("the low end\'s clean", "that channel\'s clipping", "tighten the mix")',
+  '— but every call you make is technically correct. You review an automated health report for a',
+  'personal internet radio station (Navidrome library, an LLM DJ, Liquidsoap mixer, Icecast stream,',
+  'local/cloud TTS).',
+  'A knowledge base about how SUB/WAVE works is provided below — USE IT. Ground every recommendation',
+  'in it, and tailor model / picker / chain-of-thought / agent-deadline / TTS-engine advice to the',
+  'HOST RESOURCES and CURRENT SETTINGS shown in the report (e.g. don\'t tell a small-CPU box to run',
+  'Chatterbox or the agentic picker on a 9B model).',
+  'Interpret the findings for a non-expert operator: what is fine, what needs attention, what to do',
+  'first. Be concrete and brief — keep the swagger to a light seasoning, no fluff, don\'t restate',
+  'every finding. Prioritise anything that takes the station off air or starves the DJ (stream',
+  'offline, Navidrome unreachable, LLM unreachable) above cosmetic warnings. Where it fits, nudge',
+  'the operator toward good hygiene like taking a backup. If everything is healthy, say so plainly',
+  'and return an empty priorities array.',
+].join(' ');
+
+export async function reviewReport(report: DoctorReport): Promise<DoctorReview> {
+  // Gate on reachability so we never hang the panel on a dead LLM host.
+  try {
+    const leg = primaryLeg();
+    const reachable = await probeLegReachable(leg);
+    if (!reachable) {
+      return { available: false, reason: `LLM host unreachable (${providerName()} · ${activeModelLabel()})` };
+    }
+  } catch (err: any) {
+    return { available: false, reason: err?.message || 'LLM not configured' };
+  }
+
+  try {
+    const review = await djObject({
+      system: REVIEW_SYSTEM,
+      prompt: [
+        DJ_DOC_KNOWLEDGE,
+        '\n---\n',
+        'Here is the latest station health report.',
+        '',
+        renderReportText(report),
+        '',
+        'Review it for the operator. Lean on the knowledge base above, and tailor any model / picker /',
+        'chain-of-thought / agent-deadline / TTS recommendations to the host resources and current',
+        'settings shown in the report.',
+      ].join('\n'),
+      schema: REVIEW_SCHEMA,
+      temperature: 0.5,
+      kind: 'doctor:review',
+    });
+    return { available: true, ...review };
+  } catch (err: any) {
+    return { available: false, reason: err?.message || 'review failed' };
+  }
+}
+
+// Compact, prompt-friendly rendering of the report — labels/status/detail/hint
+// only, no big blobs.
+function renderReportText(report: DoctorReport): string {
+  const lines: string[] = [];
+  lines.push(`Summary: ${report.counts.ok} ok, ${report.counts.warn} warn, ${report.counts.fail} fail, ${report.counts.skip} skip.`);
+  for (const sec of report.sections) {
+    lines.push(`\n## ${sec.name}`);
+    for (const f of sec.findings) {
+      let line = `- [${f.status.toUpperCase()}] ${f.label}`;
+      if (f.detail) line += `: ${f.detail}`;
+      if (f.hint) line += ` — hint: ${f.hint}`;
+      lines.push(line);
+    }
+  }
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Small fs helpers
+// ---------------------------------------------------------------------------
+
+// Recursive directory size, capped so a huge archive can't make the check
+// expensive. Returns bytes + file count visited; missing dir → zeroes.
+async function dirSize(path: string, cap = 5000): Promise<{ bytes: number; files: number }> {
+  let bytes = 0;
+  let files = 0;
+  async function walk(dir: string): Promise<void> {
+    if (files >= cap) return;
+    let entries: any[];
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (files >= cap) return;
+      const full = `${dir}/${e.name}`;
+      if (e.isDirectory()) {
+        await walk(full);
+      } else {
+        try {
+          const s = await stat(full);
+          bytes += s.size;
+          files += 1;
+        } catch { /* file vanished mid-walk */ }
+      }
+    }
+  }
+  await walk(path);
+  return { bytes, files };
+}
+
+function fmtBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+  return `${v.toFixed(1)} ${units[i]}`;
+}

--- a/controller/src/music/subsonic.ts
+++ b/controller/src/music/subsonic.ts
@@ -121,6 +121,21 @@ async function call(endpoint, params = {}) {
   }
 }
 
+// Lightweight connectivity + auth check for the admin Doctor. Hits the cheapest
+// Subsonic endpoint (`ping`) with the controller's own salt+token creds — mirrors
+// the CLI wizard's probeSubsonic but against config.navidrome. Never throws.
+export async function ping(): Promise<{ ok: boolean; reason?: string }> {
+  if (!config.navidrome.url || !config.navidrome.user || !config.navidrome.password) {
+    return { ok: false, reason: 'Navidrome URL / username / password not configured' };
+  }
+  try {
+    await call('ping');
+    return { ok: true };
+  } catch (err: any) {
+    return { ok: false, reason: err?.message || 'unreachable' };
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Station-archive guard
 // ---------------------------------------------------------------------------

--- a/controller/src/routes/doctor.ts
+++ b/controller/src/routes/doctor.ts
@@ -1,0 +1,30 @@
+// Admin-gated Doctor API. GET /doctor runs the health assessment; POST
+// /doctor/review hands a report to the LLM for a plain-English read. Both behind
+// requireAdmin — the diagnostics expose provider/host detail.
+import express from 'express';
+import { requireAdmin } from '../middleware/auth.js';
+import * as doctor from '../doctor.js';
+
+export const router = express.Router();
+
+router.get('/doctor', requireAdmin, async (_req, res) => {
+  try {
+    res.json(await doctor.runDoctor());
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Body: { report: DoctorReport } — the report the panel already has in hand, so
+// the review reflects exactly what the operator is looking at (no re-run race).
+router.post('/doctor/review', requireAdmin, async (req, res) => {
+  try {
+    const report = req.body?.report;
+    if (!report || !Array.isArray(report.sections)) {
+      return res.status(400).json({ error: 'missing report' });
+    }
+    res.json(await doctor.reviewReport(report));
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -34,6 +34,7 @@ import { router as backupRoutes } from './routes/backup.js';
 import { router as audienceRoutes } from './routes/audience.js';
 import { router as systemRoutes } from './routes/system.js';
 import { router as generateRoutes } from './routes/generate.js';
+import { router as doctorRoutes } from './routes/doctor.js';
 import { loadSecretsIntoEnv } from './setup/secrets.js';
 import { loadSetupConfig } from './setup/config.js';
 import { getSetupStatus } from './setup/firstRun.js';
@@ -68,6 +69,7 @@ app.use(backupRoutes);
 app.use(audienceRoutes);
 app.use(systemRoutes);
 app.use(generateRoutes);
+app.use(doctorRoutes);
 
 // (manual skip is not implemented in this build — Liquidsoap controls pacing)
 

--- a/web/app/admin/doctor/page.tsx
+++ b/web/app/admin/doctor/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from 'next';
+import DoctorPanel from '../../../components/admin/DoctorPanel';
+
+export const metadata: Metadata = { title: 'DJ Doc' };
+
+export default function AdminDoctorPage() {
+  return <DoctorPanel />;
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2796,6 +2796,17 @@ body::after {
 .admin-root .card-body.loose {
     padding: 18px;
 }
+/* Spotlight — lifts a card above the plain stack with an accent rail + faint
+   wash. Used for DJ Doc's verdict ("DJ Doc says") so the operator's eye lands
+   on the producer's read before the raw findings. */
+.admin-root .card.is-spotlight {
+    border-color: var(--accent);
+    box-shadow: inset 3px 0 0 0 var(--accent);
+    background: color-mix(in srgb, var(--accent) 4%, var(--card-bg));
+}
+.admin-root .card.is-spotlight > .card-head {
+    border-bottom-color: color-mix(in srgb, var(--accent) 30%, transparent);
+}
 
 /* Buttons, inputs, the segmented control and the toggle are now shadcn/ui
    components (components/ui/*), retuned to this newsprint look — the legacy

--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -19,12 +19,15 @@ import {
   BookOpen,
   Apple,
   Smartphone,
+  Users,
+  Headphones,
 } from 'lucide-react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import type { SignInResult } from '../../lib/adminAuth';
 import { useStationFeed } from '../../hooks/useStationFeed';
 import SignInForm from './SignInForm';
 import OdometerNumber from '../OdometerNumber';
+import BoothBuddy from '../BoothBuddy';
 import ThemeSwitcher from '../ThemeSwitcher';
 import { Toaster } from '../ui/toaster';
 import { animate as motionAnimate } from 'motion/react';
@@ -251,7 +254,11 @@ interface ShellHeaderProps {
 
 // Header — wordmark, breadcrumb, and (when signed in) the live station strip.
 function ShellHeader({ pathname, signedIn, onSignOut }: ShellHeaderProps) {
-  const current = NAV.find(n => pathname?.startsWith(n.href))?.label || 'Admin';
+  // DJ Doc isn't in the sidebar nav (it's reached from the header strip), so the
+  // nav lookup can't resolve its breadcrumb label — special-case it.
+  const current =
+    NAV.find(n => pathname?.startsWith(n.href))?.label ||
+    (pathname?.startsWith('/admin/doctor') ? 'DJ Doc' : 'Admin');
   const { nowPlaying, listeners } = useStationFeed();
   const onAir = !!nowPlaying?.title;
   const listenersObj =
@@ -289,24 +296,48 @@ function ShellHeader({ pathname, signedIn, onSignOut }: ShellHeaderProps) {
       </span>
       {signedIn && (
         <span className="right">
-          <span ref={dotRef} className="live-dot" />
-          <span>{onAir ? 'on air' : 'off air'}</span>
+          {/* Live dot only — the on-air/off-air word is dropped; the dot's colour
+              (accent when live, muted when not) already carries the state. */}
+          <span
+            ref={dotRef}
+            className="live-dot"
+            aria-label={onAir ? 'on air' : 'off air'}
+            title={onAir ? 'on air' : 'off air'}
+          />
           {count != null && (
             <>
               <span className="w-px self-stretch bg-separator-strong" />
-              <span className="inline-flex items-baseline gap-1">
-                <OdometerNumber value={count} /> listening
+              <span
+                className="inline-flex items-center gap-1"
+                aria-label={`${count} listening`}
+                title={`${count} listening`}
+              >
+                <OdometerNumber value={count} />
+                <Users size={13} strokeWidth={2} aria-hidden="true" />
               </span>
             </>
           )}
+          {/* DJ Doc — the primary entry point lives here in the header, right
+              after the listener count, with the booth buddy in its on-air mood. */}
+          <span className="w-px self-stretch bg-separator-strong" />
+          <Link
+            href="/admin/doctor"
+            className="inline-flex items-center gap-1.5 text-[var(--accent)] no-underline"
+            title="DJ Doc — run a station health check and get the producer's review"
+          >
+            <BoothBuddy mood="onair" size={16} />
+            <span className="caption">DJ Doc</span>
+          </Link>
           <ThemeSwitcher variant="admin" />
           <Link
             href="/listen"
             target="_blank"
             rel="noopener noreferrer"
-            className="caption text-muted no-underline"
+            className="caption inline-flex items-center text-muted no-underline"
+            aria-label="Open the player"
+            title="Listen"
           >
-            listen ↗
+            <Headphones size={15} strokeWidth={2} aria-hidden="true" />
           </Link>
           {onSignOut && (
             <button className="sign-out" onClick={onSignOut}>
@@ -322,9 +353,11 @@ function ShellHeader({ pathname, signedIn, onSignOut }: ShellHeaderProps) {
             href="/listen"
             target="_blank"
             rel="noopener noreferrer"
-            className="caption text-muted no-underline"
+            className="caption inline-flex items-center text-muted no-underline"
+            aria-label="Open the player"
+            title="Listen"
           >
-            listen ↗
+            <Headphones size={15} strokeWidth={2} aria-hidden="true" />
           </Link>
         </span>
       )}

--- a/web/components/admin/DoctorPanel.tsx
+++ b/web/components/admin/DoctorPanel.tsx
@@ -1,0 +1,393 @@
+'use client';
+
+// Doctor — /admin/doctor. Runs the controller-side health assessment, offers a
+// one-click fix where a safe action exists, asks the buddy (the LLM) to review
+// the report in plain English, and copies the whole thing as GitHub-ready
+// Markdown. Mirrors DashPanel's adminFetch + act() pattern; primitives from ./ui.
+import { useState } from 'react';
+import { useAdminAuth } from '../../lib/adminAuth';
+import { notify, errorMessage } from '../../lib/notify';
+import { Card, Btn, Pill } from './ui';
+import BoothBuddy, { type BuddyMood } from '../BoothBuddy';
+
+// --- shapes (mirror controller/src/doctor.ts) ------------------------------
+
+type Status = 'ok' | 'warn' | 'fail' | 'skip';
+type FixId = 'refresh-playlist' | 'restart-mixer' | 'generate-jingles' | 'tag-library' | 'subsonic-reset';
+
+interface FixAction {
+  id: FixId;
+  label: string;
+}
+interface Finding {
+  label: string;
+  status: Status;
+  detail?: string;
+  hint?: string;
+  fix?: FixAction;
+}
+interface DoctorSection {
+  name: string;
+  findings: Finding[];
+}
+interface DoctorReport {
+  t: string;
+  sections: DoctorSection[];
+  counts: { ok: number; warn: number; fail: number; skip: number };
+}
+interface ReviewPriority {
+  title: string;
+  severity: 'low' | 'med' | 'high';
+  why: string;
+  suggestedFix: string;
+}
+interface DoctorReview {
+  available: boolean;
+  reason?: string;
+  overall?: 'healthy' | 'attention' | 'critical';
+  summary?: string;
+  priorities?: ReviewPriority[];
+}
+
+// FixId → the existing admin POST endpoint that performs it. All are already
+// implemented + admin-gated and accept an empty body.
+const FIX_ENDPOINTS: Record<FixId, string> = {
+  'refresh-playlist': '/dj/refresh-playlist',
+  'restart-mixer': '/restart-mixer',
+  'generate-jingles': '/onboarding/generate-jingles',
+  'tag-library': '/tag-library',
+  'subsonic-reset': '/debug/subsonic/reset',
+};
+
+// Buddy mood reflects the worst-case verdict, so the operator reads the room at
+// a glance — calm when healthy, startled when something's broken.
+const MOOD_BY_OVERALL: Record<NonNullable<DoctorReview['overall']>, BuddyMood> = {
+  healthy: 'content',
+  attention: 'curious',
+  critical: 'spooked',
+};
+
+export default function DoctorPanel() {
+  const { adminFetch, needsAuth, hydrated } = useAdminAuth();
+  const [report, setReport] = useState<DoctorReport | null>(null);
+  const [review, setReview] = useState<DoctorReview | null>(null);
+  const [running, setRunning] = useState(false);
+  const [reviewing, setReviewing] = useState(false);
+  const [busyFix, setBusyFix] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  const ready = hydrated && !needsAuth;
+
+  const run = async () => {
+    setRunning(true);
+    setErr(null);
+    // A fresh run invalidates the previous review (it described the old report).
+    setReview(null);
+    try {
+      const r = await adminFetch('/doctor');
+      const j = (await r.json().catch(() => null)) as DoctorReport | { error?: string } | null;
+      if (!r.ok || !j || !('sections' in j)) {
+        throw new Error((j as { error?: string })?.error || `failed (${r.status})`);
+      }
+      setReport(j);
+    } catch (e) {
+      setErr(errorMessage(e));
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const askReview = async () => {
+    if (!report) return;
+    setReviewing(true);
+    try {
+      const r = await adminFetch('/doctor/review', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ report }),
+      });
+      const j = (await r.json().catch(() => null)) as DoctorReview | { error?: string } | null;
+      if (!r.ok || !j) throw new Error((j as { error?: string })?.error || `failed (${r.status})`);
+      setReview(j as DoctorReview);
+      if (!(j as DoctorReview).available) {
+        notify.info((j as DoctorReview).reason || 'review unavailable');
+      }
+    } catch (e) {
+      notify.err(`buddy review: ${errorMessage(e)}`);
+    } finally {
+      setReviewing(false);
+    }
+  };
+
+  const runFix = async (fix: FixAction) => {
+    setBusyFix(fix.id);
+    try {
+      const r = await adminFetch(FIX_ENDPOINTS[fix.id], {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      notify.ok(`${fix.label} done`);
+      await run(); // re-assess so the finding clears (or shows what's left)
+    } catch (e) {
+      notify.err(`${fix.label}: ${errorMessage(e)}`);
+    } finally {
+      setBusyFix(null);
+    }
+  };
+
+  const copyMarkdown = async () => {
+    if (!report) return;
+    try {
+      await navigator.clipboard.writeText(toMarkdown(report, review));
+      notify.ok('report copied — paste into a GitHub issue');
+    } catch (e) {
+      notify.err(`copy failed: ${errorMessage(e)}`);
+    }
+  };
+
+  const buddyMood: BuddyMood = review?.available && review.overall ? MOOD_BY_OVERALL[review.overall] : 'content';
+
+  return (
+    <div className="mx-auto max-w-[1100px] px-7 py-8">
+      {/* Intro + controls */}
+      <Card
+        title="DJ Doc"
+        sub="station health"
+        right={
+          report ? (
+            <span className="flex items-center gap-1.5">
+              <Pill tone="ink">{report.counts.ok} ok</Pill>
+              {report.counts.warn > 0 && <Pill tone="accent">{report.counts.warn} warn</Pill>}
+              {report.counts.fail > 0 && (
+                <Pill tone="accent" className="border-[var(--accent)] bg-[var(--accent)] text-white">
+                  {report.counts.fail} fail
+                </Pill>
+              )}
+              {report.counts.skip > 0 && <Pill>{report.counts.skip} skip</Pill>}
+            </span>
+          ) : undefined
+        }
+      >
+        <div className="flex items-start gap-4">
+          <BoothBuddy mood={buddyMood} size={34} />
+          <div className="min-w-0 flex-1">
+            <p className="text-[14px] leading-[1.6] text-muted">
+              Run a full assessment of the station — the LLM, Navidrome &amp; library, the broadcast
+              chain, voices, capabilities, content, resources and storage. Each finding suggests what
+              to do; where a safe fix exists you can apply it in one click. Then let DJ Doc review the
+              mix and call what to fix first.
+            </p>
+            <div className="mt-4 flex flex-wrap items-center gap-2">
+              <Btn tone="solid" onClick={run} disabled={running}>
+                {running ? 'Running…' : report ? 'Re-run Doctor' : 'Run Doctor'}
+              </Btn>
+              <Btn tone="accent" onClick={askReview} disabled={!report || reviewing}>
+                {reviewing ? 'DJ Doc is listening…' : 'Ask DJ Doc to review'}
+              </Btn>
+              <Btn onClick={copyMarkdown} disabled={!report}>
+                Copy report as Markdown
+              </Btn>
+              {report && (
+                <span className="font-mono text-[11px] text-muted">
+                  last run {new Date(report.t).toLocaleTimeString()}
+                </span>
+              )}
+            </div>
+            {err && <p className="mt-3 text-[13px] text-[var(--accent)]">{err}</p>}
+            {!report && !running && !ready && (
+              <p className="mt-3 text-[13px] text-muted">Sign in to run the Doctor.</p>
+            )}
+          </div>
+        </div>
+      </Card>
+
+      {/* Empty state — DJ Doc introduces himself before the first run. */}
+      {ready && !report && !running && (
+        <Card className="mt-6" title="Station health" sub="booth's open">
+          <div className="flex items-start gap-4">
+            <BoothBuddy mood="curious" size={52} />
+            <div className="min-w-0 flex-1">
+              <p className="text-[15px] leading-[1.65]">
+                Yo — DJ Doc here, resident engineer for this station. I sit in the booth and listen to
+                the whole rig like it&apos;s a record: is the low end clean, is anything clipping, is the
+                mix on air or dropping out?
+              </p>
+              <p className="mt-3 text-[13px] tracking-[0.14em] text-muted uppercase">Here&apos;s what I run the levels on</p>
+              <ul className="mt-2 flex flex-col gap-2 text-[14px] leading-[1.5]">
+                <li>
+                  <span className="font-bold">The brain</span>{' '}
+                  <span className="text-muted">— your LLM DJ: reachable, quick enough, dialed to the right settings.</span>
+                </li>
+                <li>
+                  <span className="font-bold">The crate</span>{' '}
+                  <span className="text-muted">— Navidrome + your mood tags: connected, and stocked so the picks aren&apos;t blind.</span>
+                </li>
+                <li>
+                  <span className="font-bold">The mix</span>{' '}
+                  <span className="text-muted">— Liquidsoap &amp; Icecast: on air, clean signal, listeners served.</span>
+                </li>
+                <li>
+                  <span className="font-bold">The voice</span>{' '}
+                  <span className="text-muted">— your TTS engine, and whether it actually fits the machine you&apos;re running on.</span>
+                </li>
+                <li>
+                  <span className="font-bold">The extras</span>{' '}
+                  <span className="text-muted">— web search for artist news, your hardware&apos;s muscle, and your backups.</span>
+                </li>
+              </ul>
+              <p className="mt-4 text-[14px] leading-[1.6]">
+                Hit <span className="font-bold">Run Doctor</span> and I&apos;ll run the levels on all of it —
+                then tell you straight what&apos;s clean, what&apos;s muddy, and the one thing to fix first. No fluff.
+              </p>
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {/* Buddy review */}
+      {review && (
+        <Card
+          className="mt-6"
+          title="DJ Doc says"
+          right={
+            review.available && review.overall ? (
+              <Pill
+                tone={review.overall === 'critical' ? 'accent' : review.overall === 'attention' ? 'accent' : 'ink'}
+                className={review.overall === 'critical' ? 'border-[var(--accent)] bg-[var(--accent)] text-white' : undefined}
+              >
+                {review.overall}
+              </Pill>
+            ) : undefined
+          }
+        >
+          {review.available ? (
+            <div className="flex items-start gap-4">
+              <BoothBuddy mood={buddyMood} size={40} />
+              <div className="min-w-0 flex-1">
+                <p className="text-[15px] leading-[1.65]">{review.summary}</p>
+                {review.priorities && review.priorities.length > 0 && (
+                  <ul className="mt-4 flex flex-col gap-3">
+                    {review.priorities.map((p, i) => (
+                      <li key={i} className="border-l-2 border-[color:var(--separator-strong)] pl-3">
+                        <div className="flex items-center gap-2">
+                          <Pill
+                            tone={p.severity === 'high' ? 'accent' : 'ink'}
+                            className={p.severity === 'high' ? 'border-[var(--accent)] bg-[var(--accent)] text-white' : undefined}
+                          >
+                            {p.severity}
+                          </Pill>
+                          <span className="text-[14px] font-bold">{p.title}</span>
+                        </div>
+                        <p className="mt-1 text-[13px] leading-[1.55] text-muted">{p.why}</p>
+                        <p className="mt-1 text-[13px] leading-[1.55]">
+                          <span className="font-bold">Fix:</span> {p.suggestedFix}
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          ) : (
+            <p className="text-[13px] text-muted">
+              DJ Doc can&apos;t review right now — {review.reason || 'the LLM is offline'}. Fix the LLM
+              connection (Settings → LLM) and try again.
+            </p>
+          )}
+        </Card>
+      )}
+
+      {/* Findings by section */}
+      {report?.sections.map((sec) => (
+        <Card key={sec.name} className="mt-6" title={sec.name}>
+          <ul className="flex flex-col divide-y divide-[color:var(--separator-strong)]">
+            {sec.findings.map((f, i) => (
+              <li key={i} className="flex flex-wrap items-center gap-x-3 gap-y-1.5 py-2.5 first:pt-0 last:pb-0">
+                <StatusPill status={f.status} />
+                <span className="text-[14px] font-bold">{f.label}</span>
+                {f.detail && <span className="font-mono text-[12px] text-muted">{f.detail}</span>}
+                {f.fix && (
+                  <span className="ml-auto">
+                    <Btn sm onClick={() => runFix(f.fix as FixAction)} disabled={busyFix === f.fix.id}>
+                      {busyFix === f.fix.id ? '…' : f.fix.label}
+                    </Btn>
+                  </span>
+                )}
+                {f.hint && <p className="w-full text-[12px] leading-[1.5] text-muted">{f.hint}</p>}
+              </li>
+            ))}
+          </ul>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function StatusPill({ status }: { status: Status }) {
+  if (status === 'fail') {
+    return (
+      <Pill tone="accent" dot className="border-[var(--accent)] bg-[var(--accent)] text-white">
+        fail
+      </Pill>
+    );
+  }
+  if (status === 'warn') {
+    return (
+      <Pill tone="accent" dot>
+        warn
+      </Pill>
+    );
+  }
+  if (status === 'ok') {
+    return (
+      <Pill tone="ink" dot>
+        ok
+      </Pill>
+    );
+  }
+  return <Pill dot>skip</Pill>;
+}
+
+// Build a GitHub-issue-ready Markdown report from the diagnostics (+ review).
+function toMarkdown(report: DoctorReport, review: DoctorReview | null): string {
+  const esc = (s: string) => s.replace(/\|/g, '\\|');
+  const lines: string[] = [];
+  lines.push('## SUB/WAVE diagnostics');
+  lines.push('');
+  lines.push(`Generated ${report.t}`);
+  lines.push('');
+  lines.push(
+    `**${report.counts.ok} ok · ${report.counts.warn} warn · ${report.counts.fail} fail · ${report.counts.skip} skip**`,
+  );
+  for (const sec of report.sections) {
+    lines.push('');
+    lines.push(`### ${sec.name}`);
+    lines.push('');
+    lines.push('| Status | Check | Detail |');
+    lines.push('| --- | --- | --- |');
+    for (const f of sec.findings) {
+      const detail = [f.detail, f.hint].filter((x): x is string => Boolean(x)).map(esc).join(' — ');
+      lines.push(`| ${f.status} | ${esc(f.label)} | ${detail} |`);
+    }
+  }
+  if (review?.available) {
+    lines.push('');
+    lines.push('## Buddy review');
+    lines.push('');
+    if (review.overall) lines.push(`**Overall: ${review.overall}**`);
+    lines.push('');
+    if (review.summary) lines.push(review.summary);
+    if (review.priorities && review.priorities.length > 0) {
+      lines.push('');
+      lines.push('### Priorities');
+      for (const p of review.priorities) {
+        lines.push(`- **[${p.severity}] ${p.title}** — ${p.why} _Fix:_ ${p.suggestedFix}`);
+      }
+    }
+  }
+  lines.push('');
+  return lines.join('\n');
+}

--- a/web/components/admin/DoctorPanel.tsx
+++ b/web/components/admin/DoctorPanel.tsx
@@ -67,6 +67,15 @@ const MOOD_BY_OVERALL: Record<NonNullable<DoctorReview['overall']>, BuddyMood> =
   critical: 'spooked',
 };
 
+// "Headquarters" = the upstream SUB/WAVE repo. Bug reports about the software
+// itself go here regardless of who runs the station, so this is intentionally
+// the project repo, not a per-station setting.
+const HQ_ISSUES_NEW = 'https://github.com/perminder-klair/subwave/issues/new';
+// GitHub's prefilled-issue form is a GET, so the whole report rides in the URL.
+// Past ~8KB the request 414s / silently truncates; stay well under and fall
+// back to the clipboard when the report is too big to prefill safely.
+const HQ_URL_LIMIT = 7000;
+
 export default function DoctorPanel() {
   const { adminFetch, needsAuth, hydrated } = useAdminAuth();
   const [report, setReport] = useState<DoctorReport | null>(null);
@@ -78,7 +87,7 @@ export default function DoctorPanel() {
 
   const ready = hydrated && !needsAuth;
 
-  const run = async () => {
+  const run = async (): Promise<DoctorReport | null> => {
     setRunning(true);
     setErr(null);
     // A fresh run invalidates the previous review (it described the old report).
@@ -90,21 +99,27 @@ export default function DoctorPanel() {
         throw new Error((j as { error?: string })?.error || `failed (${r.status})`);
       }
       setReport(j);
+      return j;
     } catch (e) {
       setErr(errorMessage(e));
+      return null;
     } finally {
       setRunning(false);
     }
   };
 
-  const askReview = async () => {
-    if (!report) return;
+  // `rep` lets a caller pass the just-fetched report directly — `run()` sets it
+  // via setState, which isn't visible in the same tick, so the "Let's go" chain
+  // hands it through rather than reading stale `report` from the closure.
+  const askReview = async (rep?: DoctorReport) => {
+    const target = rep ?? report;
+    if (!target) return;
     setReviewing(true);
     try {
       const r = await adminFetch('/doctor/review', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ report }),
+        body: JSON.stringify({ report: target }),
       });
       const j = (await r.json().catch(() => null)) as DoctorReview | { error?: string } | null;
       if (!r.ok || !j) throw new Error((j as { error?: string })?.error || `failed (${r.status})`);
@@ -117,6 +132,13 @@ export default function DoctorPanel() {
     } finally {
       setReviewing(false);
     }
+  };
+
+  // The one-press init flow: run the full assessment, then immediately hand the
+  // fresh report to DJ Doc for his read — no separate "review" click needed.
+  const letsGo = async () => {
+    const rep = await run();
+    if (rep) await askReview(rep);
   };
 
   const runFix = async (fix: FixAction) => {
@@ -148,65 +170,46 @@ export default function DoctorPanel() {
     }
   };
 
+  // Open a GitHub "new issue" form prefilled with the diagnostics. This only
+  // opens the form — nothing is filed until the operator hits Submit on GitHub.
+  const sendToHQ = async () => {
+    if (!report) return;
+    const title = `Station diagnostics — ${report.counts.fail} fail · ${report.counts.warn} warn · ${report.counts.skip} skip`;
+    const body = `_Filed from DJ Doc (Admin → DJ Doc → station health)._\n\n${toMarkdown(report, review)}`;
+    const full = `${HQ_ISSUES_NEW}?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`;
+    // Too long to ride in the URL — copy the full report and prefill a pointer
+    // so the operator just pastes it into the issue body.
+    if (full.length > HQ_URL_LIMIT) {
+      try {
+        await navigator.clipboard.writeText(body);
+      } catch {
+        /* clipboard may be blocked; the short form still opens */
+      }
+      const note =
+        `_Filed from DJ Doc._\n\n` +
+        `**${report.counts.ok} ok · ${report.counts.warn} warn · ${report.counts.fail} fail · ${report.counts.skip} skip**\n\n` +
+        `> The full report was too long to prefill — it's on your clipboard, paste it below.`;
+      window.open(
+        `${HQ_ISSUES_NEW}?title=${encodeURIComponent(title)}&body=${encodeURIComponent(note)}`,
+        '_blank',
+        'noopener,noreferrer',
+      );
+      notify.info('report copied — paste it into the issue body');
+      return;
+    }
+    window.open(full, '_blank', 'noopener,noreferrer');
+  };
+
   const buddyMood: BuddyMood = review?.available && review.overall ? MOOD_BY_OVERALL[review.overall] : 'content';
 
   return (
     <div className="mx-auto max-w-[1100px] px-7 py-8">
-      {/* Intro + controls */}
-      <Card
-        title="DJ Doc"
-        sub="station health"
-        right={
-          report ? (
-            <span className="flex items-center gap-1.5">
-              <Pill tone="ink">{report.counts.ok} ok</Pill>
-              {report.counts.warn > 0 && <Pill tone="accent">{report.counts.warn} warn</Pill>}
-              {report.counts.fail > 0 && (
-                <Pill tone="accent" className="border-[var(--accent)] bg-[var(--accent)] text-white">
-                  {report.counts.fail} fail
-                </Pill>
-              )}
-              {report.counts.skip > 0 && <Pill>{report.counts.skip} skip</Pill>}
-            </span>
-          ) : undefined
-        }
-      >
-        <div className="flex items-start gap-4">
-          <BoothBuddy mood={buddyMood} size={34} />
-          <div className="min-w-0 flex-1">
-            <p className="text-[14px] leading-[1.6] text-muted">
-              Run a full assessment of the station — the LLM, Navidrome &amp; library, the broadcast
-              chain, voices, capabilities, content, resources and storage. Each finding suggests what
-              to do; where a safe fix exists you can apply it in one click. Then let DJ Doc review the
-              mix and call what to fix first.
-            </p>
-            <div className="mt-4 flex flex-wrap items-center gap-2">
-              <Btn tone="solid" onClick={run} disabled={running}>
-                {running ? 'Running…' : report ? 'Re-run Doctor' : 'Run Doctor'}
-              </Btn>
-              <Btn tone="accent" onClick={askReview} disabled={!report || reviewing}>
-                {reviewing ? 'DJ Doc is listening…' : 'Ask DJ Doc to review'}
-              </Btn>
-              <Btn onClick={copyMarkdown} disabled={!report}>
-                Copy report as Markdown
-              </Btn>
-              {report && (
-                <span className="font-mono text-[11px] text-muted">
-                  last run {new Date(report.t).toLocaleTimeString()}
-                </span>
-              )}
-            </div>
-            {err && <p className="mt-3 text-[13px] text-[var(--accent)]">{err}</p>}
-            {!report && !running && !ready && (
-              <p className="mt-3 text-[13px] text-muted">Sign in to run the Doctor.</p>
-            )}
-          </div>
-        </div>
-      </Card>
-
-      {/* Empty state — DJ Doc introduces himself before the first run. */}
-      {ready && !report && !running && (
-        <Card className="mt-6" title="Station health" sub="booth's open">
+      {/* Init hero — DJ Doc introduces himself and the whole run is one press.
+          The booth's-open pitch is the primary content; "Let's go" runs the
+          full assessment AND his review together. Stays up through the first
+          run so the CTA can show progress. */}
+      {ready && !report && (
+        <Card title="DJ Doc" sub="booth's open">
           <div className="flex items-start gap-4">
             <BoothBuddy mood="curious" size={52} />
             <div className="min-w-0 flex-1">
@@ -239,18 +242,83 @@ export default function DoctorPanel() {
                 </li>
               </ul>
               <p className="mt-4 text-[14px] leading-[1.6]">
-                Hit <span className="font-bold">Run Doctor</span> and I&apos;ll run the levels on all of it —
+                Hit <span className="font-bold">Let&apos;s go</span> and I&apos;ll run the levels on all of it,
                 then tell you straight what&apos;s clean, what&apos;s muddy, and the one thing to fix first. No fluff.
               </p>
+              <div className="mt-5 flex flex-wrap items-center gap-3">
+                <Btn
+                  tone="accent"
+                  lg
+                  onClick={letsGo}
+                  disabled={running || reviewing}
+                  className="px-9 py-3.5 text-[13px]"
+                >
+                  {running ? 'Running the levels…' : reviewing ? 'DJ Doc is listening…' : "Let's go"}
+                </Btn>
+                <span className="text-[12px] leading-[1.5] text-muted">
+                  Runs the full check and gets DJ Doc&apos;s read in one go.
+                </span>
+              </div>
+              {err && <p className="mt-3 text-[13px] text-[var(--accent)]">{err}</p>}
             </div>
           </div>
         </Card>
       )}
 
-      {/* Buddy review */}
+      {/* Controls — once a report exists: counts + re-run / review / copy. */}
+      {report && (
+        <Card
+          title="DJ Doc"
+          sub="station health"
+          right={
+            <span className="flex items-center gap-1.5">
+              <Pill tone="ink">{report.counts.ok} ok</Pill>
+              {report.counts.warn > 0 && <Pill tone="accent">{report.counts.warn} warn</Pill>}
+              {report.counts.fail > 0 && (
+                <Pill tone="accent" className="border-[var(--accent)] bg-[var(--accent)] text-white">
+                  {report.counts.fail} fail
+                </Pill>
+              )}
+              {report.counts.skip > 0 && <Pill>{report.counts.skip} skip</Pill>}
+            </span>
+          }
+        >
+          <div className="flex items-start gap-4">
+            <BoothBuddy mood={buddyMood} size={34} />
+            <div className="min-w-0 flex-1">
+              <p className="text-[14px] leading-[1.6] text-muted">
+                Full assessment of the station — the LLM, Navidrome &amp; library, the broadcast chain,
+                voices, capabilities, content, resources and storage. Where a safe fix exists you can
+                apply it in one click.
+              </p>
+              <div className="mt-4 flex flex-wrap items-center gap-2">
+                <Btn tone="solid" onClick={run} disabled={running}>
+                  {running ? 'Running…' : 'Re-run Doctor'}
+                </Btn>
+                <Btn tone="accent" onClick={() => askReview()} disabled={reviewing}>
+                  {reviewing ? 'DJ Doc is listening…' : 'Ask DJ Doc to review'}
+                </Btn>
+                <Btn onClick={copyMarkdown}>Copy report as Markdown</Btn>
+                <Btn
+                  onClick={sendToHQ}
+                  title="Open a prefilled GitHub issue with this report (you submit it)"
+                >
+                  Send report to Headquarters
+                </Btn>
+                <span className="font-mono text-[11px] text-muted">
+                  last run {new Date(report.t).toLocaleTimeString()}
+                </span>
+              </div>
+              {err && <p className="mt-3 text-[13px] text-[var(--accent)]">{err}</p>}
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {/* Buddy review — spotlighted so the producer's verdict reads first. */}
       {review && (
         <Card
-          className="mt-6"
+          className="is-spotlight mt-6"
           title="DJ Doc says"
           right={
             review.available && review.overall ? (

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -129,6 +129,9 @@ export default defineConfig([
             '^l$',
             '^accent$',
             '^active$',
+            // .is-spotlight — accent-rail card modifier (.admin-root
+            // .card.is-spotlight) used by DJ Doc's verdict card.
+            '^is-spotlight$',
             '^strip-mobile$',
             // bare state / descendant classes used with .lib-* parents
             '^on$',


### PR DESCRIPTION
## What

Adds **DJ Doc** — a one-click station health check in the admin UI, with a producer-engineer persona that reviews the report in plain English and tells the operator what to fix first.

## Why

Operators previously had to read the raw `/admin/debug` blob or run the host-side `subwave doctor` CLI to figure out why the station was misbehaving — neither says, in plain language, *what to fix next*. This is the "v2" the CLI doctor's own comment anticipated ("deeper checks once we've added supporting controller endpoints").

## Backend (`controller/`)

- **`doctor.ts`** — `runDoctor()` assesses **LLM** (primary/fallback reachability, recent error rate, picker agent, chain-of-thought, agent deadline), **Navidrome & library** (connectivity, call errors, mood-tag coverage), **Broadcast** (Icecast + Liquidsoap), **Voice/TTS**, **Capabilities** (live web-search probe), **Content**, **Resources** (host CPU/mem/containers), **Storage**, **Setup** (+ backup reminder). `reviewReport()` asks the LLM (gated on `probeLegReachable`) for a prioritized review in the **DJ Doc persona**, grounded in a knowledge base.
- **`doctor-knowledge.ts`** — a knowledge file distilled from the manual + setup pages: when to use chain-of-thought / the agentic picker / the agent deadline, which TTS engine fits the host's resources, and a nudge to take backups.
- **`subsonic.ping()`** connectivity check; **`routes/doctor.ts`** (`GET /doctor`, `POST /doctor/review`, admin-gated) mounted in `server.ts`.
- Reuses the `Finding`/`DoctorReport` shape from `cli/src/doctor.ts`.

## Frontend (`web/`)

- **`DoctorPanel.tsx`** — run, status pills, safe **one-click fixes** (reuse existing admin endpoints: refresh-playlist, restart-mixer, generate-jingles, tag-library, subsonic-reset), the **"DJ Doc says"** review card with the booth buddy, a fun in-voice **empty state**, and **copy-as-Markdown** (issue-ready).
- Entry point lives in the **admin header** (after the listener count) with the buddy — not the sidebar. Header tidied: listener count → `Users` icon, player link → `Headphones` icon, on-air/off-air word dropped (the live dot carries it).

## Scope notes

- GitHub issue creation deferred (ships copy-as-Markdown instead).
- One-shot review (not a chat).

## Test plan

- [x] `npm run lint` (eslint + `tsc --noEmit`) passes in both `controller/` and `web/`.
- [x] Runtime-verified on the dev stack: `GET /doctor` returns a full report (incl. Capabilities/Resources); auth gate returns 401 without creds; `POST /doctor/review` returns a DJ-Doc-voiced review that uses the knowledge base + host resources (recommended Piper/Kokoro over GPU-only Chatterbox, suggested a backup).
- [x] UI verified: header entry + buddy, empty state, run → findings + fix buttons, review card, copy-markdown.