### PR TITLE
feat(tts): pass persona soul to OpenAI TTS instructions (#579)

### DIFF
--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -167,6 +167,14 @@ export async function speak(
   const language = GLOBAL_VOICE_KINDS.has(kind)
     ? ''
     : String(settings.getEffectivePersona()?.language || '').trim();
+  // The persona's soul (e.g. "thoughtful and a little wistful") rides the same
+  // path so the voice delivery carries the same character as the writing (issue
+  // #579). DJ-voiced kinds only, like `language`; only the OpenAI gpt-4o*-tts
+  // path in cloud-speech.ts reads it (its free-text `instructions` field), every
+  // other engine ignores it.
+  const soul = GLOBAL_VOICE_KINDS.has(kind)
+    ? ''
+    : String(settings.getEffectivePersona()?.soul || '').trim();
   // Delivery pace tracks the daypart for live, persona-voiced segments.
   // `speedScale` is a MULTIPLIER on the engine's configured speech rate (1.0 =
   // unchanged), so it composes with — rather than overrides — an operator's
@@ -182,7 +190,7 @@ export async function speak(
   const started = Date.now();
   const chars = (speakText || '').length;
   try {
-    const result = await speakWith(primary, speakText, { outPath, speedScale: scale, language }, personaTts);
+    const result = await speakWith(primary, speakText, { outPath, speedScale: scale, language, soul }, personaTts);
     recordTts({
       kind, engine: primary, requested: primary, fellBack: false,
       ok: true, ms: Date.now() - started, chars, t: new Date().toISOString(),
@@ -203,7 +211,7 @@ export async function speak(
     }
     console.error(`[tts] ${primary} failed for kind=${kind}: ${err.message} — falling back to ${fallback}`);
     try {
-      const result = await speakWith(fallback, speakText, { outPath, speedScale: scale, language }, personaTts);
+      const result = await speakWith(fallback, speakText, { outPath, speedScale: scale, language, soul }, personaTts);
       recordTts({
         kind, engine: fallback, requested: primary, fellBack: true,
         ok: true, ms: Date.now() - started, chars, t: new Date().toISOString(),

--- a/controller/src/llm/internal/speech/cloud-speech.ts
+++ b/controller/src/llm/internal/speech/cloud-speech.ts
@@ -64,22 +64,32 @@ function isoCodeFor(name: string): string | null {
   return LANG_ISO[last] || null;
 }
 
-// Per-provider pronunciation hint from the persona's on-air language, so a
-// non-English script isn't read with English phonetics (issue #558). OpenAI's
-// gpt-4o-mini-tts honours a free-text `instructions` field (tts-1 / tts-1-hd
-// ignore it harmlessly); ElevenLabs honours an ISO `language` code. Both are
-// top-level generateSpeech params. openai-compatible servers vary on which
-// fields they accept (the same reason `speed` is skipped for them), so they get
-// no hint. Empty language → {} so the default English path stays byte-identical.
-function languageHint(language: string | undefined, provider: string, model: string): { instructions?: string; language?: string } {
+// Per-provider delivery hint built from the on-air persona's character (`soul`)
+// and language. OpenAI's gpt-4o*-tts honours a free-text `instructions` field
+// (tts-1 / tts-1-hd ignore or reject it): the soul shapes vocal tone/pacing the
+// same way it shapes the writing (issue #579), and the language is layered on as
+// a pronunciation directive so a non-English script isn't read with English
+// phonetics (issue #558). ElevenLabs has no free-text field — it honours only an
+// ISO `language` code, so the soul can't ride there. openai-compatible servers
+// vary on which fields they accept (the same reason `speed` is skipped for
+// them), so they get no hint. No soul and no language → {} so the bare default
+// path stays byte-identical.
+function deliveryHint(
+  { language, soul }: { language?: string; soul?: string },
+  provider: string,
+  model: string,
+): { instructions?: string; language?: string } {
   const lang = String(language || '').trim();
-  if (!lang) return {};
+  const character = String(soul || '').trim();
   if (provider === 'openai') {
     // `instructions` only steers gpt-4o*-tts models; tts-1 / tts-1-hd ignore or
     // reject it, so don't send it there (a 400 would drop us to an English
     // local fallback — worse than no hint).
     if (!/gpt-4o.*tts/i.test(String(model || ''))) return {};
-    return { instructions: `Speak entirely in ${lang}, using natural, native ${lang} pronunciation and accent. Do not read the text with an English accent.` };
+    const parts: string[] = [];
+    if (character) parts.push(`Convey this character in your tone and delivery: ${character}.`);
+    if (lang) parts.push(`Speak entirely in ${lang}, using natural, native ${lang} pronunciation and accent. Do not read the text with an English accent.`);
+    return parts.length ? { instructions: parts.join(' ') } : {};
   }
   if (provider === 'elevenlabs') {
     const iso = isoCodeFor(lang);
@@ -155,7 +165,7 @@ export function isConfigured(providerOverride: string | null = null) {
 // provider + voice while still sharing the global model + apiKey from Settings.
 export async function speak(
   text: string,
-  { outPath, cloudOverride = null, speedScale, language }: { outPath?: string; cloudOverride?: any; speedScale?: number; language?: string } = {},
+  { outPath, cloudOverride = null, speedScale, language, soul }: { outPath?: string; cloudOverride?: any; speedScale?: number; language?: string; soul?: string } = {},
 ) {
   if (!text || !text.trim()) throw new Error('Empty TTS text');
   const base = cloudCfg();
@@ -190,8 +200,9 @@ export async function speak(
     text,
     voice: c.voice || undefined,
     ...(speed !== 1.0 ? { speed } : {}),
-    // Persona on-air language → provider-native pronunciation hint (issue #558).
-    ...languageHint(language, c.provider, c.model),
+    // Persona character (soul) + language → provider-native delivery hint
+    // (issues #579 / #558).
+    ...deliveryHint({ language, soul }, c.provider, c.model),
     // ElevenLabs gates 44.1 kHz PCM/WAV behind paid tiers — a free/lower-tier
     // key 403s ("Forbidden") on pcm_44100. mp3 is allowed on every tier and
     // OpenAI honours it too, so it's the safe cross-provider request.


### PR DESCRIPTION
Closes #579.

Follow-up to #564 — the persona's `soul` already shapes everything the DJ writes; this lets it shape the **voice delivery** too. It rides the exact path `language` already uses (#558): read from `getEffectivePersona()` in `audio/tts.ts`, threaded through `speak()` into `cloud-speech.ts`'s instructions builder.

### What changed
- **`audio/tts.ts`** — compute `soul` from the effective persona alongside `language` (DJ-voiced kinds only; `''` for persona-agnostic jingles) and pass it through both the primary and fallback `speakWith` calls.
- **`cloud-speech.ts`** — `languageHint` → `deliveryHint`, now folding soul + language. For OpenAI `gpt-4o*-tts` it builds `instructions` from the soul (delivery character) plus the existing language directive.

### Scope is naturally tight
- **OpenAI `gpt-4o*-tts` only** — the only engine with a free-text `instructions` field (already guarded so `tts-1`/`tts-1-hd` never receive it and 400).
- **ElevenLabs** takes only an ISO `language` code (no free-text), so soul can't ride there — unchanged.
- **Local engines** (piper/kokoro/pocket-tts) ignore `instructions` entirely. Non-breaking.
- **Jingles** (persona-agnostic, pre-rendered) are excluded.

### One intended behavior change
Unlike the language-only path, the soul rides even for **English** personas — so an English OpenAI-tts station now carries its persona's character in the voice. Blast radius is limited to OpenAI-gpt-4o-tts stations (opt-in cloud setup, not the Piper default). The bare no-soul/no-language path still returns `{}`, so any station without a soul/language stays byte-identical.

### Verification
- `npm run lint` (eslint + `tsc --noEmit`) in `controller/` — 0 errors.
- Behavior spot-checked across cases: English+soul → soul-only instructions; French+soul → soul then language; `tts-1` → `{}`; jingle/no-soul → `{}`.

Thanks @cedhuf for the clean code-tracing in the issue.