### PR TITLE
fix(controller): persist curiosity dedup across restarts (#577)

### DIFF
--- a/controller/src/config.ts
+++ b/controller/src/config.ts
@@ -192,6 +192,16 @@ export const config = {
     recentPlaysFile: `${STATE_DIR}/recent-plays.json`,
     recentPlaysMax: 300,
   },
+  curiosity: {
+    // Durable dedup ledger for the `curiosity` segment capability. Holds every
+    // "on this day" item surfaced to the agent and every curiosity line aired,
+    // so a controller restart no longer wipes the in-memory dedup set and
+    // re-airs the same fact (issue #577). Pruned to `maxAgeDays` on load.
+    seenFile: `${STATE_DIR}/seen-curiosity.json`,
+    maxAgeDays: 7,
+    // Hard cap on persisted entries — a belt to the 7-day prune.
+    maxEntries: 400,
+  },
   weather: {
     // Punjab (Chandigarh) — your home location
     lat: 30.7333,

--- a/controller/src/llm/internal/tools/segment-tools.ts
+++ b/controller/src/llm/internal/tools/segment-tools.ts
@@ -14,7 +14,7 @@ import { z } from 'zod';
 import { queue } from '../../../broadcast/queue.js';
 import { fetchHeadlines, hashHeadline } from '../../../skills/news.js';
 import { searchWeb, searchReady } from '../../../skills/web-search.js';
-import { fetchOnThisDay, hashCuriosity } from '../../../skills/curiosity.js';
+import { fetchOnThisDay, curiositySeen, recordCuriosity } from '../../../skills/curiosity.js';
 import { getArtist, searchArtists } from '../../../music/subsonic.js';
 
 // `caps` is the list of capabilities offered this tick (see skills/_agent.js).
@@ -78,13 +78,13 @@ export function buildSegmentTools(ctx: any, state: any, caps: any[]) {
       execute: async () => {
         try {
           const items = await fetchOnThisDay();
-          const fresh = items.filter((it: any) => !state.seenCuriosity.has(hashCuriosity(it.text)));
+          const fresh = items.filter((it: any) => !curiositySeen(it.text));
           if (!fresh.length) return { available: false };
-          // Burn-on-read: claim what we surface so a later tick doesn't re-offer it.
-          for (const it of fresh.slice(0, 3) as any[]) state.seenCuriosity.add(hashCuriosity(it.text));
-          if (state.seenCuriosity.size > 200) {
-            state.seenCuriosity = new Set(Array.from(state.seenCuriosity).slice(-100));
-          }
+          // Burn-on-read into the durable ledger so a later tick — or a tick
+          // after a controller restart — doesn't re-offer the same Wikipedia
+          // event (issue #577). Recorded as aired=false: surfaced, not yet
+          // spoken. The aired line is recorded separately when it airs.
+          for (const it of fresh.slice(0, 3) as any[]) recordCuriosity(it.text);
           return {
             available: true,
             items: fresh.slice(0, 3).map((it: any) => ({ year: it.year, text: it.text })),

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -10,6 +10,7 @@ import * as sfx from './broadcast/sfx.js';
 import { queue } from './broadcast/queue.js';
 import * as session from './broadcast/session.js';
 import { getFullContext } from './context.js';
+import { loadCuriosityLedger } from './skills/curiosity.js';
 import { startScheduler } from './broadcast/scheduler.js';
 import { startListenerMonitor } from './broadcast/listeners.js';
 import { startAudienceMonitor } from './broadcast/audience.js';
@@ -170,6 +171,15 @@ app.listen(config.server.port, async () => {
   // Reload the persisted queue before the watcher starts so tracks already
   // handed to Liquidsoap stay tracked across a controller restart.
   queue.recover();
+
+  // Reload the durable curiosity dedup ledger so a restart doesn't re-air the
+  // same "on this day" fact (issue #577).
+  try {
+    const n = loadCuriosityLedger();
+    console.log(`[curiosity] ledger loaded: ${n} entries`);
+  } catch (err: any) {
+    console.error('[curiosity] ledger load failed:', err.message);
+  }
 
   queue.startWatcher();
   startListenerMonitor();

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -37,6 +37,7 @@ import { defineAgent } from '../llm/agent.js';
 import { buildContextLines, CONTEXT_FIELDS } from '../llm/dj.js';
 import { buildSegmentTools } from '../llm/segment-tools.js';
 import { searchReady } from './web-search.js';
+import { recordCuriosity, recentAiredCuriosity } from './curiosity.js';
 import { customCapabilities, getBuiltinOverrides } from './loader.js';
 import * as sfx from '../broadcast/sfx.js';
 
@@ -194,9 +195,10 @@ let tickBusy = false;
 const lastFired = new Map<string, number>(); // kind → ms timestamp of last aired segment
 
 // Dedup memory carried across ticks — passed straight into the segment tools.
+// Curiosity dedup is NOT here anymore: it lives in the durable ledger in
+// skills/curiosity.js (issue #577) so it survives a controller restart.
 const segmentState: any = {
   seenHeadlines: new Set<string>(),
-  seenCuriosity: new Set<string>(),
   lastWeatherCondition: null,
   lastSearchedArtist: null,
   lastAnySegment: 0,
@@ -284,7 +286,7 @@ export const directorAgent = defineAgent({
 // The concrete situation handed to the agent as its single user turn. Built
 // from what is on air and queue.getDjRecap() (what actually aired recently) —
 // NOT the track-pick session history, which derails small models.
-function buildSituation(ctx: any, { forced = false, contextFields }: { forced?: boolean; contextFields?: string[] } = {}) {
+function buildSituation(ctx: any, { forced = false, contextFields, recentCuriosity }: { forced?: boolean; contextFields?: string[]; recentCuriosity?: string[] } = {}) {
   const lines = ['The current moment:'];
   const ctxLines = buildContextLines(ctx, { contextFields });
   if (ctxLines.length) lines.push(...ctxLines);
@@ -293,6 +295,14 @@ function buildSituation(ctx: any, { forced = false, contextFields }: { forced?: 
   const recap = queue.getDjRecap();
   if (recap) {
     lines.push(`\nWhat you have already said on air recently (do NOT repeat these topics or phrasing):\n${recap}`);
+  }
+  // Durable curiosity history (issue #577) — when the Wikipedia pool is
+  // exhausted the agent falls back to free generation, which otherwise has no
+  // memory of what it already aired and repeats the same factoid (sometimes
+  // reworded). Surface the recent aired curiosity lines so it steers clear.
+  if (recentCuriosity && recentCuriosity.length) {
+    const list = recentCuriosity.map(t => `- ${t}`).join('\n');
+    lines.push(`\nCuriosity facts already aired in the last few days (if you air a curiosity segment, pick something genuinely different — do NOT repeat any of these, even reworded):\n${list}`);
   }
   lines.push(forced
     ? '\nWrite the segment the operator has asked for now.'
@@ -328,8 +338,11 @@ export async function agenticTick(ctx) {
   try {
     // Empty catalogue when SFX are disabled — the agent is never offered effects.
     const sfxCatalog = settings.get().sfx?.enabled === false ? [] : await sfx.catalog();
+    // When curiosity is on offer, brief the agent with what it already aired so
+    // a pool-exhausted fallback doesn't repeat itself (issue #577).
+    const recentCuriosity = caps.some(c => c.kind === 'curiosity') ? recentAiredCuriosity() : undefined;
     const { object } = await directorAgent.run({
-      messages: [{ role: 'user', content: buildSituation(ctx, { contextFields: unionContextFields(caps) }) }],
+      messages: [{ role: 'user', content: buildSituation(ctx, { contextFields: unionContextFields(caps), recentCuriosity }) }],
       persona, caps, freq, sfxCatalog,
       ctx, segmentState,
     });
@@ -355,6 +368,10 @@ export async function agenticTick(ctx) {
 
     // queue.announce appends the segment turn into the live session.
     await queue.announce(seg.text.trim(), seg.kind);
+
+    // Record what actually aired so the durable ledger can keep both the tool
+    // and the fallback path from repeating it after a restart (issue #577).
+    if (seg.kind === 'curiosity') recordCuriosity(seg.text.trim(), { aired: true });
 
     // Optional sound effect mixed under the voice. Only honour a name the
     // agent was actually offered — anything else is dropped, like an
@@ -468,8 +485,9 @@ export async function runCapability(which, ctx) {
   const persona = settings.getEffectivePersona(new Date());
   // Empty catalogue when SFX are disabled — the agent is never offered effects.
   const sfxCatalog = settings.get().sfx?.enabled === false ? [] : await sfx.catalog();
+  const recentCuriosity = cap.kind === 'curiosity' ? recentAiredCuriosity() : undefined;
   const { object } = await forcedDirectorAgent.run({
-    messages: [{ role: 'user', content: buildSituation(ctx, { forced: true, contextFields: effectiveContextFields(cap) }) }],
+    messages: [{ role: 'user', content: buildSituation(ctx, { forced: true, contextFields: effectiveContextFields(cap), recentCuriosity }) }],
     persona, cap, sfxCatalog,
     ctx, segmentState,
   });
@@ -486,6 +504,10 @@ export async function runCapability(which, ctx) {
   }
 
   await queue.announce(text, cap.kind);
+
+  // Record an operator-fired curiosity line in the durable ledger too, so a
+  // later autonomous tick doesn't repeat it (issue #577).
+  if (cap.kind === 'curiosity') recordCuriosity(text, { aired: true });
 
   // Optional sound effect under the voice — only a name the agent was offered.
   const pick = object?.sfx;

--- a/controller/src/skills/curiosity.ts
+++ b/controller/src/skills/curiosity.ts
@@ -17,6 +17,9 @@
 // to pure generation under `cap.desc`. So this file is "what extra context can
 // we put under the DJ's nose this minute?" — never "must we be silent?".
 
+import { existsSync, readFileSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { config } from '../config.js';
 import { zonedParts, zonedISODate } from '../time.js';
 
 const ON_THIS_DAY_TTL_MS = 12 * 60 * 60 * 1000; // 12h — events for a date are stable
@@ -99,10 +102,128 @@ export async function fetchOnThisDay(date = new Date()): Promise<CuriosityItem[]
   return items;
 }
 
-// Stable hash for the dedup set in segmentState. Same shape as
-// hashHeadline() in news.ts.
+// Stable hash for the dedup ledger. Same shape as hashHeadline() in news.ts.
 export function hashCuriosity(text: string) {
   let h = 0;
   for (let i = 0; i < text.length; i++) h = ((h << 5) - h + text.charCodeAt(i)) | 0;
   return h.toString(36);
+}
+
+// ---------------------------------------------------------------------------
+// Durable curiosity dedup ledger (issue #577)
+//
+// Two failure modes the ledger closes:
+//   1. The dedup set used to be an in-memory `Set` (skills/_agent.ts), wiped on
+//      every controller restart. Wikipedia returns the same "on this day" items
+//      for a date all day, so a restart re-aired the same fact hours later.
+//   2. When the small Wikipedia pool exhausts, the agent free-generates a
+//      factoid under the capability brief with no record of what it already
+//      said — so it regenerated the same one (reworded).
+//
+// The ledger persists BOTH the items surfaced to the agent (so the tool stops
+// re-offering the same Wikipedia event across a restart — the surfaced item's
+// hash matches on the next fetch, the reworded aired line would not) AND the
+// lines actually aired (so fallback generation can be told what to avoid).
+// Surviving a restart, pruned to `config.curiosity.maxAgeDays`.
+// ---------------------------------------------------------------------------
+
+type CuriosityLedgerEntry = { hash: string; text: string; at: string; aired: boolean };
+
+let ledger: CuriosityLedgerEntry[] = [];
+let seenHashes = new Set<string>();
+let persistTimer: NodeJS.Timeout | null = null;
+
+// Pure: drop entries older than `maxAgeMs` and keep at most `maxEntries`
+// (newest first). Side-effect-free so it can be reasoned about / unit-pinned.
+export function pruneCuriosityLedger(
+  entries: CuriosityLedgerEntry[],
+  now: number,
+  maxAgeMs: number,
+  maxEntries: number,
+): CuriosityLedgerEntry[] {
+  const cutoff = now - maxAgeMs;
+  return entries
+    .filter(e => e && e.hash && e.at && new Date(e.at).getTime() > cutoff)
+    .sort((a, b) => b.at.localeCompare(a.at))
+    .slice(0, maxEntries);
+}
+
+function rebuildHashes() {
+  seenHashes = new Set(ledger.map(e => e.hash));
+}
+
+// Boot recovery — read the ledger, prune stale entries, prime the dedup set.
+// Never throws: a missing or corrupt file just starts an empty ledger.
+export function loadCuriosityLedger() {
+  ledger = [];
+  try {
+    if (existsSync(config.curiosity.seenFile)) {
+      const raw = JSON.parse(readFileSync(config.curiosity.seenFile, 'utf8'));
+      if (Array.isArray(raw)) {
+        ledger = pruneCuriosityLedger(
+          raw,
+          Date.now(),
+          config.curiosity.maxAgeDays * 86_400_000,
+          config.curiosity.maxEntries,
+        );
+      }
+    }
+  } catch (err: any) {
+    console.error('[curiosity] ledger load failed:', err.message);
+    ledger = [];
+  }
+  rebuildHashes();
+  return ledger.length;
+}
+
+function schedulePersist() {
+  if (persistTimer) return;
+  persistTimer = setTimeout(async () => {
+    persistTimer = null;
+    try {
+      await writeFile(config.curiosity.seenFile, JSON.stringify(ledger, null, 2));
+    } catch (err: any) {
+      console.error('[curiosity] ledger persist failed:', err.message);
+    }
+  }, 500);
+}
+
+// Has this exact curiosity text already been surfaced or aired? Used by the
+// segment tool to filter the Wikipedia pool.
+export function curiositySeen(text: string) {
+  return seenHashes.has(hashCuriosity(text));
+}
+
+// Record a curiosity text in the ledger. `aired` marks lines the listener
+// actually heard (fed back into fallback generation); surfaced-but-not-aired
+// Wikipedia items are recorded with aired=false purely for tool dedup. A repeat
+// hash refreshes the timestamp (and promotes to aired) rather than duplicating.
+export function recordCuriosity(text: string, { aired = false }: { aired?: boolean } = {}) {
+  const clean = (text || '').trim();
+  if (!clean) return;
+  const hash = hashCuriosity(clean);
+  const at = new Date().toISOString();
+  const existing = ledger.find(e => e.hash === hash);
+  if (existing) {
+    existing.at = at;
+    if (aired) existing.aired = true;
+  } else {
+    ledger.unshift({ hash, text: clean, at, aired });
+    seenHashes.add(hash);
+  }
+  if (ledger.length > config.curiosity.maxEntries) {
+    ledger = ledger.slice(0, config.curiosity.maxEntries);
+    rebuildHashes();
+  }
+  schedulePersist();
+}
+
+// The most recent curiosity lines actually aired (newest first), for the
+// fallback brief — so the agent's free generation avoids repeating them.
+export function recentAiredCuriosity(limit = 8): string[] {
+  return ledger
+    .filter(e => e.aired)
+    .sort((a, b) => b.at.localeCompare(a.at))
+    .slice(0, limit)
+    .map(e => e.text);
 }


### PR DESCRIPTION
Fixes #577.

## Problem
Listeners hear the same curiosity ("on this day") facts repeated, sometimes within a day. Three root causes, all confirmed against the code:

1. **Dedup was in-memory only** — `seenCuriosity` was a plain `Set` rebuilt on every controller restart (deploy/crash/Docker restart). Wikipedia returns the same items for a date all day, so the same event re-aired after a restart (the *Kenneth Arnold* case).
2. **The Wikipedia pool is small** (~8 allowed items/day) and the tool burns 3 per call, exhausting it after ~3 segments.
3. **The fallback path had no dedup** — once the pool returns `available: false`, the agent free-generates under the capability brief with no record of what it already said, so it regenerated the same factoid, reworded (the *Nintendo 64* case).

## Fix
A durable dedup ledger at `state/seen-curiosity.json`, loaded and 7-day-pruned on boot, mirroring the existing `recent-plays.json` pattern.

- **Tool dedup (fixes restart repeats):** `getCuriosityItem` now filters against the persisted ledger and records the Wikipedia items it surfaces. After a restart the same event won't be re-offered.
- **Fallback brief (fixes reword repeats):** the line *actually aired* is recorded (`aired: true`) on both the autonomous tick and the operator override, and the last ~8 aired lines are fed into the generation prompt ("don't repeat these, even reworded").

**Design note:** the tool keys dedup on *surfaced item* hashes (the only thing that matches on a re-fetch across a restart), while the fallback brief uses *aired* lines. Hashing only the reworded aired text would have missed the restart case, so the ledger tracks both with an `aired` flag.

## Files
- `skills/curiosity.ts` — the ledger (`loadCuriosityLedger`, `recordCuriosity`, `curiositySeen`, `recentAiredCuriosity`, pure `pruneCuriosityLedger`); debounced persist, capped at 400 entries.
- `llm/internal/tools/segment-tools.ts` — tool dedups against the ledger instead of the wiped-on-restart `Set`.
- `skills/_agent.ts` — removed the in-memory `seenCuriosity`; records aired lines; feeds the fallback brief on both paths.
- `server.ts` — loads the ledger on boot.
- `config.ts` — `curiosity.seenFile` / `maxAgeDays` / `maxEntries`.

## Verification
- `npm run lint` (eslint + `tsc --noEmit`) — 0 errors.
- `npm run test:llm` — passes (untouched, sanity check).
- Ledger smoke test (8 cases incl. simulated restart) — all pass: a surfaced item stays `curiositySeen` after reload, and the aired brief survives.