### PR TITLE
feat(llm): opt-in tool_choice knob for forced-tool servers (#570)

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -9,7 +9,7 @@
 import assert from 'node:assert/strict';
 import { stripThinking, extractJson, usageOf, isUnreachable, isTransient, isQuotaOrAuthError } from '../src/llm/internal/core/pure.js';
 import { withDeadline } from '../src/llm/internal/core/retry.js';
-import { providerOptions, needsToolCallObject, repeatPenaltyApplies, appliedNumCtx } from '../src/llm/internal/provider/capabilities.js';
+import { providerOptions, needsToolCallObject, repeatPenaltyApplies, appliedNumCtx, forcedToolChoice } from '../src/llm/internal/provider/capabilities.js';
 import { agentPlan } from '../src/llm/internal/strategy/plan.js';
 import { introBudgetPhrase, enforceIntroBudget } from '../src/llm/internal/prompts/intro-budget.js';
 import { embeddingBaseUrl } from '../src/llm/internal/provider/embedding.js';
@@ -144,6 +144,20 @@ async function main() {
     assert.equal(appliedNumCtx({ provider: 'ollama', model: 'qwen3', numCtx: 8192 }), 8192);
     assert.equal(appliedNumCtx({ provider: 'openai', model: 'gpt-4.1-mini', numCtx: 8192 }), null);
     assert.equal(appliedNumCtx({ provider: 'locca', model: 'qwen3', numCtx: 8192 }), null);
+  });
+
+  await test('forcedToolChoice: only the literal "auto" downgrades; everything else is "required" (issue #570)', () => {
+    // Opt-in downgrade for crash-prone forced-tool servers (newer Intel vLLM).
+    assert.equal(forcedToolChoice({ provider: 'openai-compatible', toolChoice: 'auto' }), 'auto');
+    // Default + explicit 'required' both force the tool call.
+    assert.equal(forcedToolChoice({ provider: 'openai-compatible', toolChoice: 'required' }), 'required');
+    assert.equal(forcedToolChoice({ provider: 'openai-compatible' }), 'required');
+    // Provider-agnostic: it's a per-leg knob, not a per-provider trait.
+    assert.equal(forcedToolChoice({ provider: 'ollama', toolChoice: 'auto' }), 'auto');
+    assert.equal(forcedToolChoice({ provider: 'anthropic' }), 'required');
+    // Garbage / missing cfg never accidentally weakens the default.
+    assert.equal(forcedToolChoice({ toolChoice: 'whatever' }), 'required');
+    assert.equal(forcedToolChoice(undefined), 'required');
   });
 
   // ---- embedding base URL (the relative-/embeddings crash, #405 follow-up) ----

--- a/controller/src/llm/internal/provider/capabilities.ts
+++ b/controller/src/llm/internal/provider/capabilities.ts
@@ -134,6 +134,21 @@ export function needsToolCallObject(cfg: any): boolean {
   return capabilitiesFor(cfg?.provider).objectStrategy === 'tool';
 }
 
+// The tool_choice value to send when SUB/WAVE wants to FORCE a tool call (the
+// structured-output emit/done paths). Defaults to 'required' — every local-model
+// structured-output path depends on it, and forced tool calling is the AI SDK's
+// documented pattern for it. An operator can set llm.toolChoice = 'auto' per leg
+// to downgrade it: recent vLLM implements tool_choice:"required" via a
+// guided-decoding backend that some images (newer Intel/XPU builds) crash on,
+// while "auto" never engages it (issue #570). On 'auto' the done-tool harness
+// keeps its prepareStep activeTools pinning + explicit instructions, so a capable
+// model usually still calls the single visible tool; misses fall through to the
+// stateless pool picker. Reads cfg.toolChoice (primary or fallback leg); any
+// value other than the literal 'auto' is treated as 'required'.
+export function forcedToolChoice(cfg: any): 'required' | 'auto' {
+  return cfg?.toolChoice === 'auto' ? 'auto' : 'required';
+}
+
 // True when repeat_penalty actually reaches the model — gates the sampling log
 // so /debug doesn't claim the value was applied when the provider dropped it.
 export function repeatPenaltyApplies(cfg: any): boolean {

--- a/controller/src/llm/internal/strategy/agent.ts
+++ b/controller/src/llm/internal/strategy/agent.ts
@@ -30,7 +30,7 @@ import { Output, stepCountIs, hasToolCall, ToolLoopAgent, tool } from 'ai';
 import { withFailover } from '../core/failover.js';
 import { withTransientRetry, withDeadline } from '../core/retry.js';
 import { stripThinking, extractJson, usageOf, flattenToolCalls, failureDiagnostics } from '../core/pure.js';
-import { needsToolCallObject, providerOptions, samplingWithNumCtx } from '../provider/capabilities.js';
+import { needsToolCallObject, providerOptions, samplingWithNumCtx, forcedToolChoice } from '../provider/capabilities.js';
 import { objectViaToolCall } from './object-via-tool.js';
 import { agentPlan } from './plan.js';
 
@@ -59,13 +59,16 @@ function buildDoneTool(schema: any) {
 // hallucinated id before seeing any library results. Step >= COMMIT_AFTER_STEPS
 // forces `done`: with only `done` active the model cannot keep exploring and
 // must emit its final answer, guaranteeing a `done` call before the step cap.
-function gatedDiscoveryPrepareStep(discoveryToolNames: string[]) {
+// `toolChoice` is the leg's forced value ('required', or 'auto' when the operator
+// downgrades it for a crash-prone server — issue #570); the activeTools pinning
+// holds either way, so on 'auto' the single visible tool is still the strong nudge.
+function gatedDiscoveryPrepareStep(discoveryToolNames: string[], toolChoice: 'required' | 'auto') {
   return async ({ stepNumber }: { stepNumber: number }) => {
     if (stepNumber === 0) {
-      return { activeTools: discoveryToolNames, toolChoice: 'required' };
+      return { activeTools: discoveryToolNames, toolChoice };
     }
     if (stepNumber >= COMMIT_AFTER_STEPS) {
-      return { activeTools: ['done'], toolChoice: 'required' };
+      return { activeTools: ['done'], toolChoice };
     }
     return {};
   };
@@ -172,10 +175,14 @@ export async function djAgent({
         // free-text (no schema). useDoneTool is the original predicate, kept verbatim.
         const useDoneTool = schema != null && (needsToolCallObject(leg.cfg) || toolCount > 0);
         const allTools = useDoneTool ? { ...tools, done: buildDoneTool(schema) } : tools;
+        // 'required' by default; 'auto' when the operator downgrades this leg for
+        // a server whose forced-tool backend crashes (issue #570). Applies to the
+        // agent-level choice, the gated prepareStep, and the recovery run below.
+        const forcedChoice = forcedToolChoice(leg.cfg);
 
         const discoveryToolNames = tools ? Object.keys(tools) : [];
         const useGatedDiscovery = useDoneTool && discoveryToolNames.length > 0;
-        const prepareStep = useGatedDiscovery ? gatedDiscoveryPrepareStep(discoveryToolNames) : undefined;
+        const prepareStep = useGatedDiscovery ? gatedDiscoveryPrepareStep(discoveryToolNames, forcedChoice) : undefined;
 
         const agent = new ToolLoopAgent({
           model: leg.model,
@@ -190,7 +197,7 @@ export async function djAgent({
           // useDoneTool forces tool calls every step — suppress thinking on the
           // providers that reject forced tools mid-reasoning (Anthropic/DeepSeek).
           providerOptions: providerOptions(leg.cfg, { forceNoThink: useDoneTool }),
-          ...(useDoneTool ? { toolChoice: 'required' } : {}),
+          ...(useDoneTool ? { toolChoice: forcedChoice } : {}),
           ...(prepareStep ? { prepareStep } : {}),
           // Native path: structured output via Output.object. Done-tool path: the
           // schema lives on the `done` tool, so no agent-level output.
@@ -237,8 +244,8 @@ export async function djAgent({
             // Recovery forces done-only every step, so it has the same
             // Anthropic/DeepSeek thinking conflict as the main run — suppress here too.
             providerOptions: providerOptions(leg.cfg, { forceNoThink: true }),
-            toolChoice: 'required',
-            prepareStep: async () => ({ activeTools: ['done'], toolChoice: 'required' }),
+            toolChoice: forcedChoice,
+            prepareStep: async () => ({ activeTools: ['done'], toolChoice: forcedChoice }),
           } as any);
           result = await runDeadlined(timeoutMs, kind, 'agent recovery', recoveryAgent, recoveryMessages);
           steps = result.steps?.length ?? 0;

--- a/controller/src/llm/internal/strategy/object-via-tool.ts
+++ b/controller/src/llm/internal/strategy/object-via-tool.ts
@@ -8,7 +8,7 @@
 
 import { generateText, tool, stepCountIs } from 'ai';
 import { usageOf } from '../core/pure.js';
-import { providerOptions } from '../provider/capabilities.js';
+import { providerOptions, forcedToolChoice } from '../provider/capabilities.js';
 
 export async function objectViaToolCall(
   leg: any,
@@ -27,7 +27,11 @@ export async function objectViaToolCall(
     temperature,
     maxOutputTokens,
     tools: { emit },
-    toolChoice: 'required',
+    // 'required' by default; an operator can downgrade to 'auto' per leg for a
+    // server whose forced-tool backend crashes (issue #570). With one tool
+    // visible + the "call it exactly once" instruction, a capable model still
+    // emits via the tool; a miss throws below → caller's fallback.
+    toolChoice: forcedToolChoice(leg.cfg),
     stopWhen: stepCountIs(1),
     providerOptions: providerOptions(leg.cfg, { forceNoThink: true }),
   } as any);

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -266,6 +266,15 @@ function applyLlmLegPatch(target: any, patch: any, label: string): void {
   if (l.numCtx !== undefined) {
     target.numCtx = clampNumCtx(Number(l.numCtx), target.numCtx);
   }
+  // Forced-tool tool_choice: 'required' (default) or 'auto'. Only those two are
+  // legal; anything else is a config error. See forcedToolChoice() / issue #570.
+  if (l.toolChoice !== undefined) {
+    const v = String(l.toolChoice).trim();
+    if (v !== 'required' && v !== 'auto') {
+      throw new Error(`${label}.toolChoice must be "required" or "auto"`);
+    }
+    target.toolChoice = v;
+  }
 }
 
 // Cloud TTS vendors usable by the `cloud` engine. `openai-compatible` targets
@@ -552,6 +561,16 @@ const DEFAULTS = {
     // <think> block on a small model balloons every call (see llm/sdk.js
     // token caps + llm/provider.js no-think fetch).
     reasoning: false,
+    // How SUB/WAVE forces a tool call in the structured-output paths (the emit /
+    // done-tool harness). 'required' (default) makes the model call the tool —
+    // the reliable path for local models that ignore JSON mode. Switch to 'auto'
+    // ONLY if your server crashes on tool_choice:"required": recent vLLM
+    // implements it via a guided-decoding backend that some images (newer
+    // Intel/XPU builds) mishandle, while "auto" never engages it (issue #570).
+    // On 'auto' the done-tool path keeps its activeTools pinning + instructions,
+    // so a capable model still calls the tool; misses fall back to the pool
+    // picker. Leave on 'required' unless you hit that crash.
+    toolChoice: 'required',
     // Ollama context window (num_ctx), local Ollama only. Ollama's own default
     // is 4096, but the session DJ agent feeds ~8k+ (the 40-turn session window
     // + tool schemas + discovery results), so the default silently truncates
@@ -611,6 +630,7 @@ const DEFAULTS = {
       ollamaUrl: '',
       baseUrl: '',
       reasoning: false,
+      toolChoice: 'required',
       numCtx: 16384,
     },
   },
@@ -1100,6 +1120,9 @@ export async function load() {
         typeof stored.llm?.baseUrl === 'string' ? stored.llm.baseUrl.trim() : DEFAULTS.llm.baseUrl,
       reasoning:
         typeof stored.llm?.reasoning === 'boolean' ? stored.llm.reasoning : DEFAULTS.llm.reasoning,
+      // Only 'auto' downgrades the forced tool_choice; anything else (incl. a
+      // pre-field settings.json) lands on the 'required' default. See issue #570.
+      toolChoice: stored.llm?.toolChoice === 'auto' ? 'auto' : DEFAULTS.llm.toolChoice,
       // Clamp to a sane band: 0 disables (Ollama default), else [2048, 131072].
       // Non-numeric/NaN falls back to the default. Floored to an integer.
       numCtx: clampNumCtx(stored.llm?.numCtx, DEFAULTS.llm.numCtx),
@@ -1138,6 +1161,7 @@ export async function load() {
             typeof fb.baseUrl === 'string' ? fb.baseUrl.trim() : DEFAULTS.llm.fallback.baseUrl,
           reasoning:
             typeof fb.reasoning === 'boolean' ? fb.reasoning : DEFAULTS.llm.fallback.reasoning,
+          toolChoice: fb.toolChoice === 'auto' ? 'auto' : DEFAULTS.llm.fallback.toolChoice,
           numCtx: clampNumCtx(fb.numCtx, DEFAULTS.llm.fallback.numCtx),
         };
       })(),

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -157,6 +157,7 @@ interface LlmForm {
   numCtx: number;
   baseUrl: string;
   reasoning: boolean;
+  toolChoice: string;
   pickerAgent: boolean;
   requestWebResolve: boolean;
   agentTimeoutMs: number;
@@ -439,6 +440,7 @@ export default function SettingsPanel() {
         numCtx: typeof v.llm?.numCtx === 'number' ? v.llm.numCtx : 16384,
         baseUrl: v.llm?.baseUrl ?? '',
         reasoning: !!v.llm?.reasoning,
+        toolChoice: v.llm?.toolChoice === 'auto' ? 'auto' : 'required',
         pickerAgent: !!v.llm?.pickerAgent,
         requestWebResolve: !!v.llm?.requestWebResolve,
         agentTimeoutMs: typeof v.llm?.agentTimeoutMs === 'number' ? v.llm.agentTimeoutMs : 45000,
@@ -1894,6 +1896,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
         numCtx: form.llm.numCtx,
         baseUrl: form.llm.baseUrl,
         reasoning: form.llm.reasoning,
+        toolChoice: form.llm.toolChoice,
         pickerAgent: form.llm.pickerAgent,
         requestWebResolve: form.llm.requestWebResolve,
         agentTimeoutMs: form.llm.agentTimeoutMs,
@@ -2034,6 +2037,32 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                 including the <code>/v1</code> suffix. Must be reachable from the
                 controller container. Use the host’s LAN or Tailscale IP, not
                 <code>127.0.0.1</code>.
+              </div>
+            </div>
+          )}
+
+          {form.llm.provider === 'openai-compatible' && (
+            <div className="field">
+              <Label>Forced tool calls</Label>
+              <Seg
+                accent
+                value={form.llm.toolChoice === 'auto' ? 'auto' : 'required'}
+                options={[
+                  { id: 'required', label: 'Required' },
+                  { id: 'auto', label: 'Auto' },
+                ]}
+                onChange={v => setForm(f => ({ ...f, llm: { ...f.llm, toolChoice: v } }))}
+              />
+              <div className="field-hint">
+                How the picker forces the model to return a structured pick.
+                <code>Required</code> (default) sends{' '}
+                <code>tool_choice:&quot;required&quot;</code> — the reliable path for
+                local models. Switch to <code>Auto</code> only if your server
+                <strong> crashes</strong> on a tool call: some newer vLLM images
+                (notably Intel/XPU builds) mishandle the guided-decoding backend
+                that <code>required</code> engages, while <code>auto</code> never
+                does. On <code>Auto</code> a capable model still calls the tool;
+                misses fall back to the stateless picker.
               </div>
             </div>
           )}


### PR DESCRIPTION
## What

Adds a per-leg `llm.toolChoice` setting — `'required'` (default, unchanged) or `'auto'` — that controls how SUB/WAVE forces a tool call in its structured-output paths.

Closes #570.

## Why

SUB/WAVE sends `tool_choice:"required"` in the `emit` / done-tool harness because local GGUF-class models (Ollama, llama.cpp, vLLM, LM Studio) ignore JSON mode and need forcing — it's the AI SDK's documented forced-tool pattern and is load-bearing for picker reliability.

But recent **vLLM** implements `required` via a guided-decoding backend that some images — notably newer **Intel/XPU** builds — mishandle and **crash** on. `auto` never engages that backend, so it runs cleanly (reported in #570; the reporter is also filing upstream with Intel).

Flipping the default to `auto` would regress every other local backend (the whole done-tool / `prepareStep` / recovery design exists precisely because these models emit prose instead of calling tools under `auto`). So this is an **opt-in** escape hatch, not a default change.

## How

- **`capabilities.ts`** — new pure `forcedToolChoice(cfg)` returning `'required'` (default) | `'auto'`. Single chokepoint, matching the "per-provider/leg quirks live in capabilities.ts" charter.
- **`object-via-tool.ts` + `agent.ts`** — every runtime site that sent `tool_choice:"required"` (the `emit` call, the done-tool agent, the gated `prepareStep`, the recovery run) now routes through it. The `activeTools` pinning + "call the tool" instructions are preserved on `auto`, so a capable model still calls the single visible tool; a miss falls through to the stateless pool picker (graceful degradation, not a hard failure).
- **`settings.ts`** — `llm.toolChoice` + `llm.fallback.toolChoice`, validated to `'required'|'auto'`, defaulted to `'required'`, coerced on load (any pre-field `settings.json` lands on `required`). Per-leg, so a vLLM fallback can be downgraded independently of the primary.
- **`SettingsPanel.tsx`** — a "Forced tool calls" Required/Auto segmented control, shown only for the `openai-compatible` provider, with a hint pointing at the Intel/XPU guided-decoding crash.

## Testing

- `controller/scripts/llm-pure.test.ts` — added a `forcedToolChoice` case (only the literal `'auto'` downgrades; missing/garbage/explicit `required` all stay `required`). `npm run test:llm` passes.
- `controller` lint + `tsc --noEmit` clean (pre-existing `any` warnings only).
- `web` lint (eslint + tsc) clean.

Default behaviour is unchanged for every existing install.