### PR TITLE
fix(web): keep the DJ announcement clear of the visualizer (#576)

### DIFF
--- a/web/components/CenterStage.tsx
+++ b/web/components/CenterStage.tsx
@@ -111,7 +111,14 @@ export default memo(function CenterStage({ nowPlaying, trackStartedAt, llmTokens
   useDynamicStyle(coverRef, { '--cover': coverSrc ? `url("${coverSrc}")` : null });
 
   return (
-    <div className="absolute top-1/2 right-24 left-4 flex -translate-y-[64%] flex-col items-start sm:left-8">
+    // Bounded region between the header and the waveform band, with the content
+    // centred inside it (justify-center). Previously this was centred in the
+    // whole viewport (top-1/2 -translate-y-[64%]) and grew downward freely, so a
+    // long DJ line — or any line on a short/wide window — spilled over the
+    // bottom-pinned Waveform (issue #576). The bottom reserve clears the
+    // compact waveform (top ≈ 206px from bottom); on tall desktop windows the
+    // waveform grows to its full band, so the reserve grows to match it.
+    <div className="absolute top-[72px] right-24 bottom-[220px] left-4 flex flex-col items-start justify-center sm:left-8 [@media(min-width:640px)_and_(min-height:760px)]:bottom-[300px]">
       <div className="isolate flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-6">
         {coverSrc && (
           <button

--- a/web/components/DjThinkingLine.tsx
+++ b/web/components/DjThinkingLine.tsx
@@ -152,9 +152,11 @@ export default function DjThinkingLine({ feed, enabled, buddyOn = false, onOpenB
         </span>
       )}
       {/* Clamp the inline teaser so the long "extended" scripts can't grow the
-          column and shove the artwork/title up under the header on mobile.
-          The full text stays one tap away in the Booth (and in aria-label). */}
-      <span className="line-clamp-5 min-w-0 flex-1 [overflow-wrap:anywhere] sm:line-clamp-10">
+          column and shove the artwork/title up under the header, or spill the
+          line down over the waveform (issue #576). The clamp is tighter on
+          short windows; the full text stays one tap away in the Booth (and in
+          aria-label). */}
+      <span className="line-clamp-2 min-w-0 flex-1 [overflow-wrap:anywhere] [@media(min-height:760px)]:line-clamp-6">
         <AnimatePresence mode="wait">
           <m.span
             key={turnId}

--- a/web/components/Waveform.tsx
+++ b/web/components/Waveform.tsx
@@ -90,7 +90,12 @@ export default memo(function Waveform({ audioRef, tunedIn, trackStartedAt, durat
   return (
     <div
       ref={containerRef}
-      className="pointer-events-none absolute inset-x-3 bottom-24 flex h-[110px] items-center gap-px px-1 opacity-[0.22] sm:right-24 sm:bottom-[128px] sm:left-0 sm:h-40 sm:gap-0.5 sm:px-8"
+      // Horizontal footprint is width-based (sm:). The tall band, however, is
+      // gated on viewport HEIGHT too — a short/wide window kept the full-height
+      // band and left no room above it, so the now-playing block overlapped it
+      // (issue #576). Below 760px tall we fall back to the compact band so the
+      // CenterStage region has room to clear it.
+      className="pointer-events-none absolute inset-x-3 bottom-24 flex h-[110px] items-center gap-px px-1 opacity-[0.22] sm:right-24 sm:left-0 sm:gap-0.5 sm:px-8 [@media(min-width:640px)_and_(min-height:760px)]:bottom-[128px] [@media(min-width:640px)_and_(min-height:760px)]:h-40"
       aria-hidden="true"
     >
       {Array.from({ length: BARS }).map((_, i) => {


### PR DESCRIPTION
Fixes #576.

## Problem

The player stacked three independent absolutely-positioned layers with no vertical coordination: `CenterStage` was centred in the whole viewport (`top-1/2 -translate-y-[64%]`) and grew downward freely, while `Waveform` was pinned to the bottom. On short/wide windows the two bands overlapped, so a long — or even moderate — DJ announcement painted over the visualizer bars.

## Fix

- **`CenterStage.tsx`** — now occupies a bounded region between the header and a bottom reserve that clears the waveform, centring its content with `justify-center` so it stays balanced when it fits and never reaches the waveform.
- **`Waveform.tsx`** — the tall band is gated on viewport **height** as well as width (`min-width:640px and min-height:760px`), so a short/wide window falls back to the compact band and leaves room above it.
- **`DjThinkingLine.tsx`** — the teaser clamp is tighter on short windows (`line-clamp-2`, rising to `line-clamp-6` when there's vertical room; was `sm:line-clamp-10`). The full script stays one tap away in the Booth.

## Verification

Measured bounding rects in a real browser against live station data, with a maximal injected script. The now-playing block clears the waveform with **zero overlap** at every size:

| Viewport | Waveform band | Teaser clamp | DJ → waveform overlap |
|---|---|---|---|
| 1335×564 (reported case) | compact 110px | 2 lines | 0px |
| 1920×1080 | full 160px | 6 lines | 0px |
| 390×844 (phone) | compact 110px | 6 lines | 0px |

`npm run lint` (eslint + tsc) passes.