### PR TITLE
feat(doctor): catch weak-model structured-output failures + sharpen DJ Doc UX

### DIFF
--- a/controller/src/doctor-knowledge.ts
+++ b/controller/src/doctor-knowledge.ts
@@ -42,6 +42,28 @@ synthesised by a TTS engine; Liquidsoap mixes it and feeds Icecast.
   model to pick one. Cheaper and more forgiving. **Recommend turning the agent OFF**
   for small models (≤9B) or constrained hardware.
 
+## Structured output & model class (the silent feature-breaker)
+- Several features ask the model for **strict JSON** (a fixed shape): the request
+  matcher, the candidate-pool picker, the library mood-tagger, and this very health
+  report. A weak model "responds" but returns the wrong shape, the call fails schema
+  validation, and the feature **silently degrades or falls back** — the station still
+  plays, but requests mis-match, picks get worse, tagging stalls.
+- The report exposes this as an **LLM → "structured output"** finding (a count of
+  recent schema-validation failures). If you see it, the model choice is almost
+  certainly the cause. **Recommend a general instruction-tuned model** (a ~12B+ local
+  or a capable cloud model) and suggest turning **reasoning OFF** — "thinking" tokens
+  can corrupt the JSON.
+- **Code-specialised models** (names containing \`code\`/\`coder\`/\`codestral\`) are tuned
+  for programming, not natural-language DJ links or structured output. They write
+  stiff intros and routinely fail the JSON shape. Steer the operator to a general
+  model even if the code model is "bigger".
+- The report also exposes an **LLM → "model class"** finding when the chosen model
+  looks code-specialised, or is small (≤~9–11B) while the agentic picker is ON. Pair
+  this with the picker-agent and reasoning guidance below.
+- Important: a model broken enough to fail structured output **also breaks this AI
+  review** (it's a structured call too). So when these deterministic findings fire,
+  trust them over the absence of a review — they're the signal that survives.
+
 ## Agent deadline (settings.llm.agentTimeoutMs, default 45000ms)
 - Wall-clock budget for the agentic picker before it gives up and falls back to the
   pool. **Reasoning-heavy or cloud models routinely need 20–40s**, so keep the

--- a/controller/src/doctor.ts
+++ b/controller/src/doctor.ts
@@ -183,6 +183,46 @@ async function checkLlm(s: any): Promise<Finding[]> {
     out.push({ label: 'recent calls', status: 'skip', detail: 'no calls yet' });
   }
 
+  // Structured-output health — the silent failure mode behind "the model
+  // responds but features quietly break". djObject calls (DJ Doc's own AI review,
+  // the request matcher, the pool picker, the library tagger) need the model to
+  // emit JSON matching a strict shape; a weak model returns the wrong shape, the
+  // call fails Zod validation and the feature degrades or falls back unnoticed.
+  // We catch it deterministically here precisely because a model this broken ALSO
+  // breaks the AI review that would otherwise explain it to the operator.
+  const schemaFails = recentCalls.filter(isSchemaFailure);
+  if (schemaFails.length) {
+    const kinds = [...new Set(schemaFails.map((c: any) => c.kind).filter(Boolean))];
+    out.push({
+      label: 'structured output',
+      status: schemaFails.length >= 3 ? 'fail' : 'warn',
+      detail: `${schemaFails.length} schema-validation failure(s)${kinds.length ? ` · ${kinds.join(', ')}` : ''}`,
+      hint:
+        'The model is returning JSON that does not match the required shape, so these features fall back or go silent (DJ Doc’s own AI review is one of them). It’s the classic sign of a model that’s weak at schema-constrained output — usually a code-specialised or very small model. Switch Settings → LLM to a general instruction-tuned model (a ~12B+ local or a capable cloud model), and try turning reasoning OFF — “thinking” output can corrupt the JSON.',
+    });
+  }
+
+  // Model class — weigh the chosen model's *name* against how it's being used.
+  // Heuristic only (name-based), so it never fails, only warns: a code-specialised
+  // model is tuned for programming rather than DJ links / structured picks, and a
+  // small model paired with the agentic picker tends to time out into the pool.
+  const cls = classifyModel(activeModelLabel());
+  if (cls.code) {
+    out.push({
+      label: 'model class',
+      status: 'warn',
+      detail: `${activeModelLabel()} looks code-specialised`,
+      hint: 'Code models are tuned for programming, not natural-language DJ links or schema-constrained JSON — they tend to write stiff intros and fail structured picks (the request matcher, pool picker and this very report). Prefer a general instruction-tuned model in Settings → LLM.',
+    });
+  } else if (cls.sizeB !== null && cls.sizeB < 11 && s?.llm?.pickerAgent !== false) {
+    out.push({
+      label: 'model class',
+      status: 'warn',
+      detail: `~${cls.sizeB}B model with the agentic picker on`,
+      hint: 'The agentic picker wants a ~12B-class (or good cloud) model; smaller models often time out into the pool fallback or fail structured picks. Either pick a larger model, or turn the agentic picker OFF (Settings → LLM) to use the simpler, more forgiving pool picker.',
+    });
+  }
+
   // Picker agent toggle — off is valid (stateless picker) but worth surfacing.
   // DJ Doc weighs this against the model size + host resources in its review.
   out.push({
@@ -612,8 +652,38 @@ export async function reviewReport(report: DoctorReport): Promise<DoctorReview> 
     });
     return { available: true, ...review };
   } catch (err: any) {
-    return { available: false, reason: err?.message || 'review failed' };
+    // A schema/shape mismatch here is itself a diagnosis: the review model can't
+    // do structured output. Say so plainly instead of dumping the Zod error, and
+    // point at the deterministic finding that survives a broken model.
+    const reason = isSchemaErrorMessage(err)
+      ? 'The review model returned output that doesn’t match the required shape — a sign the selected model is weak at structured output. See the LLM → “structured output” finding above; switching to a general instruction-tuned model fixes it.'
+      : err?.message || 'review failed';
+    return { available: false, reason };
   }
+}
+
+// A failed LLM call whose error is a schema/shape mismatch (Zod) rather than a
+// host being unreachable — the fingerprint of a model that can't reliably produce
+// structured output. Matched on message text so it works across providers.
+function isSchemaFailure(c: any): boolean {
+  return !!c && c.ok === false && isSchemaErrorMessage(c.error);
+}
+
+function isSchemaErrorMessage(err: any): boolean {
+  if (!err) return false;
+  const s = typeof err === 'string' ? err : err.message || JSON.stringify(err);
+  return /invalid_type|invalid_value|invalid_enum|unrecognized_keys|Invalid (option|input)|received undefined|No object generated|did not match (the )?schema|Type validation failed/i.test(s);
+}
+
+// Cheap name-based model classification — drives warnings only. `code` flags a
+// code-specialised model (poor at DJ links / structured output); `sizeB` is the
+// parameter count parsed from the tag (e.g. "gemma2:9b" → 9), null when absent.
+function classifyModel(label: string): { code: boolean; sizeB: number | null } {
+  const m = (label || '').toLowerCase();
+  const code = /coder|codestral|\bcode\b|[-_:]code/.test(m);
+  const sizeMatch = m.match(/(\d+(?:\.\d+)?)\s*b(?:[^a-z0-9]|$)/);
+  const sizeB = sizeMatch ? parseFloat(sizeMatch[1]) : null;
+  return { code, sizeB };
 }
 
 // Compact, prompt-friendly rendering of the report — labels/status/detail/hint

--- a/web/components/admin/DoctorPanel.tsx
+++ b/web/components/admin/DoctorPanel.tsx
@@ -283,8 +283,7 @@ export default function DoctorPanel() {
             </span>
           }
         >
-          <div className="flex items-start gap-4">
-            <BoothBuddy mood={buddyMood} size={34} />
+          <div>
             <div className="min-w-0 flex-1">
               <p className="text-[14px] leading-[1.6] text-muted">
                 Full assessment of the station — the LLM, Navidrome &amp; library, the broadcast chain,
@@ -292,11 +291,8 @@ export default function DoctorPanel() {
                 apply it in one click.
               </p>
               <div className="mt-4 flex flex-wrap items-center gap-2">
-                <Btn tone="solid" onClick={run} disabled={running}>
-                  {running ? 'Running…' : 'Re-run Doctor'}
-                </Btn>
-                <Btn tone="accent" onClick={() => askReview()} disabled={reviewing}>
-                  {reviewing ? 'DJ Doc is listening…' : 'Ask DJ Doc to review'}
+                <Btn tone="accent" onClick={letsGo} disabled={running || reviewing}>
+                  {running ? 'Running…' : reviewing ? 'DJ Doc is listening…' : 'Re-run Doctor'}
                 </Btn>
                 <Btn onClick={copyMarkdown}>Copy report as Markdown</Btn>
                 <Btn
@@ -315,8 +311,32 @@ export default function DoctorPanel() {
         </Card>
       )}
 
-      {/* Buddy review — spotlighted so the producer's verdict reads first. */}
-      {review && (
+      {/* Spotlight slot — a live "listening" indicator while DJ Doc runs the
+          report past the LLM (a 20–60s call on a local model), then his verdict.
+          The animated indicator is the primary signal the action is working: a
+          button-label change alone read as stalled on the long call. */}
+      {reviewing ? (
+        <div role="status" aria-live="polite">
+          <Card className="is-spotlight mt-6" title="DJ Doc says" sub="running the levels…">
+            <div className="flex items-start gap-4">
+              <BoothBuddy mood="onair" size={40} />
+              <div className="min-w-0 flex-1">
+                <p className="text-[15px] leading-[1.65] font-bold">DJ Doc is listening…</p>
+                <p className="mt-1 text-[13px] leading-[1.55] text-muted">
+                  Playing your whole health report past the LLM and writing up what&apos;s clean,
+                  what&apos;s muddy, and the one thing to fix first. On a local model this can take
+                  20–60s — hang tight.
+                </p>
+                <div className="mt-4 flex flex-col gap-2.5" aria-hidden="true">
+                  <div className="sw-pulse h-3 w-[90%] rounded bg-[color:var(--separator-strong)]" />
+                  <div className="sw-pulse h-3 w-[76%] rounded bg-[color:var(--separator-strong)]" />
+                  <div className="sw-pulse h-3 w-[60%] rounded bg-[color:var(--separator-strong)]" />
+                </div>
+              </div>
+            </div>
+          </Card>
+        </div>
+      ) : review ? (
         <Card
           className="is-spotlight mt-6"
           title="DJ Doc says"
@@ -366,7 +386,7 @@ export default function DoctorPanel() {
             </p>
           )}
         </Card>
-      )}
+      ) : null}
 
       {/* Findings by section */}
       {report?.sections.map((sec) => (


### PR DESCRIPTION
## Why

Surfaced from a live incident: the station was set to `kimi-k2.7-code:cloud` and every `doctor:review` call failed Zod validation — the model "responded" but returned the wrong JSON shape. The DJ kept playing (the agent tool-loop self-recovers), but several `djObject` features silently degraded, and the one thing that would have *explained* it (DJ Doc's AI review) was itself broken by the same bad model. The doctor should catch this; now it does.

## What

### Controller — `doctor.ts`
- **New "structured output" finding** — scans the recent-LLM ring buffer for schema-validation failures (provider-agnostic, matched on error text). `warn` at 1–2, `fail` at 3+. Deterministic on purpose, because a model this broken also breaks the AI review.
- **New "model class" finding** — name-based heuristic that flags a code-specialised model (`code`/`coder`/`codestral`), or a small (≤~11B) model paired with the agentic picker. Always-on, no ring needed.
- **Friendlier failed-review reason** — `reviewReport()` returns plain English on a schema failure instead of the raw Zod dump, pointing at the finding above.

### Knowledge base — `doctor-knowledge.ts`
- New **"Structured output & model class"** section so DJ Doc's LLM review reasons about these the same way the deterministic checks do (and trusts the deterministic findings when the review can't run).

### Web — `DoctorPanel.tsx`
- **Prominent live "listening" indicator** in the spotlight slot during the 20–60s review call (animated `onair` buddy + shimmer skeleton, `role=status` / `aria-live`) — a button-label change alone read as stalled on the long call. Degrades under `prefers-reduced-motion`.
- Removed the avatar from the **station-health** card.
- Removed the standalone **"Ask DJ Doc to review"** button — **"Re-run Doctor"** now runs the full assess+review flow like **"Let's go"**.

## Test
- `controller`: `npm run lint` (eslint clean; the 3 pre-existing `tsc` errors are a missing `multer` dep in this env, unrelated).
- `web`: `npm run lint` — eslint + tsc both clean (exit 0).