### PR TITLE
Feat/OpenAI compat api key

### DIFF
--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -443,7 +443,7 @@ router.post('/settings/llm/probe-compat', requireAdmin, async (req, res) => {
     const m = createOpenAI({
       apiKey: (typeof apiKey === 'string' && apiKey.trim()) ? apiKey.trim() : 'no-key',
       baseURL: baseUrl.trim().replace(/\/+$/, ''),
-    })(model.trim());
+    }).chat(model.trim());
     await generateText({
       model: m,
       prompt: 'Reply with the single word OK.',

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -426,6 +426,37 @@ router.get('/settings/llm/discover', requireAdmin, async (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
+// POST /settings/llm/probe-compat — live probe for an openai-compatible key.
+// Body: { apiKey: string, baseUrl: string, model: string }
+// Always 200s with { ok, message, latencyMs }. The key is NOT saved.
+// ---------------------------------------------------------------------------
+router.post('/settings/llm/probe-compat', requireAdmin, async (req, res) => {
+  const { apiKey, baseUrl, model } = req.body || {};
+  if (!baseUrl || typeof baseUrl !== 'string' || !baseUrl.trim()) {
+    return res.status(400).json({ ok: false, message: 'baseUrl is required', latencyMs: 0 });
+  }
+  if (!model || typeof model !== 'string' || !model.trim()) {
+    return res.status(400).json({ ok: false, message: 'model is required', latencyMs: 0 });
+  }
+  const t0 = Date.now();
+  try {
+    const m = createOpenAI({
+      apiKey: (typeof apiKey === 'string' && apiKey.trim()) ? apiKey.trim() : 'no-key',
+      baseURL: baseUrl.trim().replace(/\/+$/, ''),
+    })(model.trim());
+    await generateText({
+      model: m,
+      prompt: 'Reply with the single word OK.',
+      maxOutputTokens: 8,
+      abortSignal: AbortSignal.timeout(15000),
+    });
+    res.json({ ok: true, message: '✓ Bearer token accepted · model responded', latencyMs: Date.now() - t0 });
+  } catch (err: any) {
+    res.json({ ok: false, message: briefLlmError(err), latencyMs: Date.now() - t0 });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // GET /settings/embedding/probe — test whether the configured (or supplied)
 // embedding endpoint can actually produce embeddings, surfacing the result
 // in the admin UI BEFORE a long tagging run instead of failing mid-job.

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -147,7 +147,6 @@ interface LlmFallbackForm {
   ollamaUrl: string;
   numCtx: number;
   baseUrl: string;
-  apiKey: string;
   reasoning: boolean;
 }
 
@@ -157,7 +156,6 @@ interface LlmForm {
   ollamaUrl: string;
   numCtx: number;
   baseUrl: string;
-  apiKey: string;
   reasoning: boolean;
   toolChoice: string;
   pickerAgent: boolean;
@@ -441,7 +439,6 @@ export default function SettingsPanel() {
         ollamaUrl: v.llm?.ollamaUrl ?? '',
         numCtx: typeof v.llm?.numCtx === 'number' ? v.llm.numCtx : 16384,
         baseUrl: v.llm?.baseUrl ?? '',
-        apiKey: v.llm?.apiKey ?? '',
         reasoning: !!v.llm?.reasoning,
         toolChoice: v.llm?.toolChoice === 'auto' ? 'auto' : 'required',
         pickerAgent: !!v.llm?.pickerAgent,
@@ -455,7 +452,6 @@ export default function SettingsPanel() {
           ollamaUrl: v.llm?.fallback?.ollamaUrl ?? '',
           numCtx: typeof v.llm?.fallback?.numCtx === 'number' ? v.llm.fallback.numCtx : 16384,
           baseUrl: v.llm?.fallback?.baseUrl ?? '',
-          apiKey: v.llm?.fallback?.apiKey ?? '',
           reasoning: !!v.llm?.fallback?.reasoning,
         },
       },
@@ -2100,7 +2096,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                   type="password"
                   value={compatKeyInput}
                   onChange={(e: ChangeEvent<HTMLInputElement>) => setCompatKeyInput(e.target.value)}
-                  placeholder={data.values?.llm?.apiKey === 'set' ? '•••••• (on file)' : 'Bearer token (optional)'}
+                  placeholder={(data.values?.llm as Record<string, unknown>)?.apiKey === 'set' ? '•••••• (on file)' : 'Bearer token (optional)'}
                   className="max-w-[360px]"
                 />
                 <div className="field-hint">
@@ -2363,7 +2359,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                       type="password"
                       value={compatFallbackKeyInput}
                       onChange={(e: ChangeEvent<HTMLInputElement>) => setCompatFallbackKeyInput(e.target.value)}
-                      placeholder={data.values?.llm?.fallback?.apiKey === 'set' ? '•••••• (on file)' : 'Bearer token (optional)'}
+                      placeholder={(data.values?.llm?.fallback as unknown as Record<string, unknown>)?.apiKey === 'set' ? '•••••• (on file)' : 'Bearer token (optional)'}
                       className="max-w-[360px]"
                     />
                     <div className="field-hint">

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -147,6 +147,7 @@ interface LlmFallbackForm {
   ollamaUrl: string;
   numCtx: number;
   baseUrl: string;
+  apiKey: string;
   reasoning: boolean;
 }
 
@@ -156,6 +157,7 @@ interface LlmForm {
   ollamaUrl: string;
   numCtx: number;
   baseUrl: string;
+  apiKey: string;
   reasoning: boolean;
   toolChoice: string;
   pickerAgent: boolean;
@@ -439,6 +441,7 @@ export default function SettingsPanel() {
         ollamaUrl: v.llm?.ollamaUrl ?? '',
         numCtx: typeof v.llm?.numCtx === 'number' ? v.llm.numCtx : 16384,
         baseUrl: v.llm?.baseUrl ?? '',
+        apiKey: v.llm?.apiKey ?? '',
         reasoning: !!v.llm?.reasoning,
         toolChoice: v.llm?.toolChoice === 'auto' ? 'auto' : 'required',
         pickerAgent: !!v.llm?.pickerAgent,
@@ -452,6 +455,7 @@ export default function SettingsPanel() {
           ollamaUrl: v.llm?.fallback?.ollamaUrl ?? '',
           numCtx: typeof v.llm?.fallback?.numCtx === 'number' ? v.llm.fallback.numCtx : 16384,
           baseUrl: v.llm?.fallback?.baseUrl ?? '',
+          apiKey: v.llm?.fallback?.apiKey ?? '',
           reasoning: !!v.llm?.fallback?.reasoning,
         },
       },
@@ -1845,12 +1849,10 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
 
   const [compatKeyInput, setCompatKeyInput] = useState('');
   const [compatFallbackKeyInput, setCompatFallbackKeyInput] = useState('');
-  const [_compatKeyTest, setCompatKeyTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
-  const [_compatFallbackKeyTest, setCompatFallbackKeyTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [_compatKeyTesting, setCompatKeyTesting] = useState(false);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [_compatFallbackKeyTesting, setCompatFallbackKeyTesting] = useState(false);
+  const [compatKeyTest, setCompatKeyTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
+  const [compatFallbackKeyTest, setCompatFallbackKeyTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
+  const [compatKeyTesting, setCompatKeyTesting] = useState(false);
+  const [compatFallbackKeyTesting, setCompatFallbackKeyTesting] = useState(false);
   useEffect(() => { setCompatKeyInput(''); setCompatKeyTest(null); }, [form.llm.provider]);
   useEffect(() => { setCompatFallbackKeyInput(''); setCompatFallbackKeyTest(null); }, [form.llm.fallback.provider]);
 
@@ -1898,7 +1900,6 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
     }
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const testCompatKey = async (
     apiKey: string,
     baseUrl: string,
@@ -2089,6 +2090,43 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                 <code>127.0.0.1</code>.
               </div>
             </div>
+          )}
+
+          {form.llm.provider === 'openai-compatible' && (
+            <>
+              <div className="field">
+                <Label>Bearer token</Label>
+                <Input
+                  type="password"
+                  value={compatKeyInput}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => setCompatKeyInput(e.target.value)}
+                  placeholder={data.values?.llm?.apiKey === 'set' ? '•••••• (on file)' : 'Bearer token (optional)'}
+                  className="max-w-[360px]"
+                />
+                <div className="field-hint">
+                  Optional — only needed when the server requires bearer authentication.
+                  Saved to <code>settings.json</code>, takes effect on next save.
+                </div>
+              </div>
+              <div className="mt-2 flex items-center gap-2">
+                <Btn
+                  sm
+                  onClick={() =>
+                    testCompatKey(
+                      compatKeyInput || '',
+                      form.llm.baseUrl,
+                      form.llm.model,
+                      setCompatKeyTesting,
+                      setCompatKeyTest,
+                    )
+                  }
+                  disabled={compatKeyTesting || !form.llm.baseUrl.trim()}
+                >
+                  {compatKeyTesting ? 'Testing…' : 'Test connection'}
+                </Btn>
+              </div>
+              {compatKeyTest && <KeyTestResult result={compatKeyTest} />}
+            </>
           )}
 
           {form.llm.provider === 'openai-compatible' && (
@@ -2315,6 +2353,44 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                     suffix, required for this provider.
                   </div>
                 </div>
+              )}
+
+              {form.llm.fallback.provider === 'openai-compatible' && (
+                <>
+                  <div className="field">
+                    <Label>Bearer token</Label>
+                    <Input
+                      type="password"
+                      value={compatFallbackKeyInput}
+                      onChange={(e: ChangeEvent<HTMLInputElement>) => setCompatFallbackKeyInput(e.target.value)}
+                      placeholder={data.values?.llm?.fallback?.apiKey === 'set' ? '•••••• (on file)' : 'Bearer token (optional)'}
+                      className="max-w-[360px]"
+                    />
+                    <div className="field-hint">
+                      Optional — only needed when the backup server requires bearer
+                      authentication. Saved to <code>settings.json</code>, takes effect on
+                      next save.
+                    </div>
+                  </div>
+                  <div className="mt-2 flex items-center gap-2">
+                    <Btn
+                      sm
+                      onClick={() =>
+                        testCompatKey(
+                          compatFallbackKeyInput || '',
+                          form.llm.fallback.baseUrl,
+                          form.llm.fallback.model,
+                          setCompatFallbackKeyTesting,
+                          setCompatFallbackKeyTest,
+                        )
+                      }
+                      disabled={compatFallbackKeyTesting || !form.llm.fallback.baseUrl.trim()}
+                    >
+                      {compatFallbackKeyTesting ? 'Testing…' : 'Test connection'}
+                    </Btn>
+                  </div>
+                  {compatFallbackKeyTest && <KeyTestResult result={compatFallbackKeyTest} />}
+                </>
               )}
 
               {form.llm.fallback.provider === 'ollama' && (

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -1843,6 +1843,17 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
   useEffect(() => { setPrimaryKeyTest(null); }, [form.llm.provider]);
   useEffect(() => { setFallbackKeyTest(null); }, [form.llm.fallback.provider]);
 
+  const [compatKeyInput, setCompatKeyInput] = useState('');
+  const [compatFallbackKeyInput, setCompatFallbackKeyInput] = useState('');
+  const [_compatKeyTest, setCompatKeyTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
+  const [_compatFallbackKeyTest, setCompatFallbackKeyTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [_compatKeyTesting, setCompatKeyTesting] = useState(false);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [_compatFallbackKeyTesting, setCompatFallbackKeyTesting] = useState(false);
+  useEffect(() => { setCompatKeyInput(''); setCompatKeyTest(null); }, [form.llm.provider]);
+  useEffect(() => { setCompatFallbackKeyInput(''); setCompatFallbackKeyTest(null); }, [form.llm.fallback.provider]);
+
   const saveKey = async (envVar: string, value: string): Promise<boolean> => {
     if (!value.trim()) return true;
     try {
@@ -1887,6 +1898,33 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const testCompatKey = async (
+    apiKey: string,
+    baseUrl: string,
+    model: string,
+    setTesting: (v: boolean) => void,
+    setResult: (r: { ok: boolean; message: string; latencyMs: number } | null) => void,
+  ) => {
+    if (!baseUrl.trim()) { setResult({ ok: false, message: 'Set a Base URL first', latencyMs: 0 }); return; }
+    if (!model.trim()) { setResult({ ok: false, message: 'Set a Model first', latencyMs: 0 }); return; }
+    setTesting(true);
+    setResult(null);
+    try {
+      const r = await adminFetch('/settings/llm/probe-compat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ apiKey: apiKey.trim(), baseUrl: baseUrl.trim(), model: model.trim() }),
+      });
+      const j = await r.json() as { ok: boolean; message: string; latencyMs: number };
+      setResult(j);
+    } catch (e) {
+      setResult({ ok: false, message: errorMessage(e), latencyMs: 0 });
+    } finally {
+      setTesting(false);
+    }
+  };
+
   const save = async () => {
     await saveSettings({
       llm: {
@@ -1901,6 +1939,9 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
         requestWebResolve: form.llm.requestWebResolve,
         agentTimeoutMs: form.llm.agentTimeoutMs,
         pauseWhenEmpty: form.llm.pauseWhenEmpty,
+        ...(form.llm.provider === 'openai-compatible' && compatKeyInput.trim()
+          ? { apiKey: compatKeyInput.trim() }
+          : {}),
         fallback: {
           enabled: form.llm.fallback.enabled,
           provider: form.llm.fallback.provider,
@@ -1909,6 +1950,9 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
           numCtx: form.llm.fallback.numCtx,
           baseUrl: form.llm.fallback.baseUrl,
           reasoning: form.llm.fallback.reasoning,
+          ...(form.llm.fallback.provider === 'openai-compatible' && compatFallbackKeyInput.trim()
+            ? { apiKey: compatFallbackKeyInput.trim() }
+            : {}),
         },
       },
     });
@@ -1922,6 +1966,12 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
     if (fallbackKeyVar && fallbackKeyInput.trim()) {
       const ok = await saveKey(fallbackKeyVar, fallbackKeyInput);
       if (ok) { notify.ok('API key saved'); setFallbackKeyInput(''); refresh(); }
+    }
+    if (form.llm.provider === 'openai-compatible' && compatKeyInput.trim()) {
+      setCompatKeyInput('');
+    }
+    if (form.llm.fallback.provider === 'openai-compatible' && compatFallbackKeyInput.trim()) {
+      setCompatFallbackKeyInput('');
     }
   };
 


### PR DESCRIPTION
  What

  Add a bearer token (API key) field and "Test connection" button to the admin Settings UI when openai-compatible is selected as the LLM provider, for both primary and
  fallback configurations.

  Why

  Operators using OpenAI-compatible endpoints that require bearer authentication (CLIProxyAPI, LiteLLM, Azure OpenAI proxies, etc.) had no way to configure credentials
  through the UI. The key had to be manually added to settings.json. Every other keyed provider already had an inline key field and test workflow.

  Closes #594

  How tested

  - Deployed to test LXC  with docker compose up -d --build
  - Switched LLM provider to openai-compatible in the admin UI
  - Verified bearer token field appears below Server base URL with correct placeholder
  - Verified "Test connection" button probes the endpoint live without saving
  - Verified key persists to settings.json on save (not secrets.env)
  - Verified placeholder shows "on file" after save + page reload
  - Verified switching provider clears the input and test result
  - Verified fallback section shows the same field when fallback provider is openai-compatible
  - npm run lint (controller + web) passes clean

  Notes for reviewers

  - The compat key is intentionally stored in settings.json (not secrets.env) -- consistent with how baseUrl and model already work for this provider. The existing
  LLM_ENV_VARS / SECRET_ENV_KEYS / saveKey() path is not touched.
  - The "Test connection" button is enabled when a base URL is set, even without a key -- many self-hosted servers don't require auth, and the probe confirms reachability
  either way.
  - KeyStatus component is not used (that's for env-var-backed keys). Instead the Input placeholder shows "on file" when a key is already saved, matching the redaction from
  getRedacted().