### PR TITLE
feat(web): show app version in admin console footer

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2676,6 +2676,10 @@ body::after {
     text-transform: uppercase;
     line-height: 1.7;
 }
+.admin-root .shell-nav .nav-foot .nav-foot-version {
+    opacity: 0.7;
+    letter-spacing: 0.12em;
+}
 
 @media (max-width: 860px) {
     .admin-root .shell-body {

--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -219,6 +219,14 @@ export default function AdminShell({ children }: AdminShellProps) {
             sub / wave
             <br />
             admin console
+            {process.env.NEXT_PUBLIC_APP_VERSION ? (
+              <>
+                <br />
+                <span className="nav-foot-version">
+                  v{process.env.NEXT_PUBLIC_APP_VERSION}
+                </span>
+              </>
+            ) : null}
           </div>
         </nav>
         <main className="min-w-0">

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -118,6 +118,7 @@ export default defineConfig([
             '^nav-icon$',
             '^nav-label$',
             '^nav-foot$',
+            '^nav-foot-version$',
             '^pill$',
             '^paper$',
             '^danger$',

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,7 +1,16 @@
+// Surface the package version (release-please bumps all three package.json
+// files in lockstep, so the web build version is the deployed station
+// version) to the client bundle for the admin console footer.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { version } = require('./package.json');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
   reactStrictMode: true,
+  env: {
+    NEXT_PUBLIC_APP_VERSION: version,
+  },
   // The repo root carries its own package.json/package-lock.json (the
   // `sub-wave` CLI), so Next would otherwise infer the repo root as the
   // workspace root — destabilising module resolution and crashing the dev


### PR DESCRIPTION
## What

Adds the current SUB/WAVE version under the **sub / wave → admin console** wordmark in the admin left-nav footer, e.g. `v0.28.0`.

## How

- `web/next.config.js` reads the package version and exposes it to the client bundle as `NEXT_PUBLIC_APP_VERSION` (build-time inline via the `env` config). Release-please bumps all three `package.json` files in lockstep, so the web build version equals the deployed station version — no API roundtrip or loading state needed.
- `web/components/admin/AdminShell.tsx` renders `v{version}` on a new line in the existing `.nav-foot` block, guarded so it's a no-op if the var is absent.
- `web/app/globals.css` adds a small `.nav-foot-version` rule (opacity 0.7) so the version reads as a subtle footer detail.
- `web/eslint.config.mjs` adds `nav-foot-version` to the Tailwind `no-unknown-classes` allow-list, matching how the other legacy admin classes are listed.

## Verification

- `npm run lint` (eslint + `tsc --noEmit`) passes clean.
- Production `next build` succeeds; the compiled `app/admin/layout` chunk contains both the version string and `nav-foot-version`, confirming the value reaches the rendered footer.