### PR TITLE
fix(player): tie the DJ thinking line to the on-air track (#546)

### DIFF
--- a/app/src/lib/sessionFeed.ts
+++ b/app/src/lib/sessionFeed.ts
@@ -36,3 +36,25 @@ export function turnText(turn: SessionTurn | null | undefined): string {
   if (turnClass(turn) === 'track') return text.replace(/^▶\s*/, '');
   return text;
 }
+
+// The single voice/dj turn to surface as the DJ "thinking" line under the
+// now-playing block. Skips `dj`/pick turns whose meta.trackId is for a track
+// other than what's on air — a pick turn is written at the previous track's
+// start, so its trackId is the NEXT track, not the one playing now (#546).
+// Voice turns carry no trackId, so the aired back-announce link wins, falling
+// back to this track's own pick reason on a silent transition.
+export function selectThinkingTurn(
+  feed: SessionTurn[] | null | undefined,
+  currentTrackId: string | null = null,
+): SessionTurn | null {
+  if (!feed?.length) return null;
+  for (let i = feed.length - 1; i >= 0; i--) {
+    const turn = feed[i];
+    const cls = turnClass(turn);
+    if (!turn?.text || (cls !== 'voice' && cls !== 'dj')) continue;
+    const trackId = turn.meta?.trackId as string | undefined;
+    if (cls === 'dj' && trackId && trackId !== currentTrackId) continue;
+    return turn;
+  }
+  return null;
+}

--- a/app/src/player/CenterStage.tsx
+++ b/app/src/player/CenterStage.tsx
@@ -146,7 +146,7 @@ export default function CenterStage({
       )}
 
       {has ? (
-        <DjThinkingLine feed={feed} enabled={djLineOn} onOpenBooth={onOpenBooth} />
+        <DjThinkingLine feed={feed} enabled={djLineOn} currentTrackId={subsonicId} onOpenBooth={onOpenBooth} />
       ) : null}
     </View>
   );

--- a/app/src/player/DjThinkingLine.tsx
+++ b/app/src/player/DjThinkingLine.tsx
@@ -4,29 +4,29 @@
 
 import { useMemo } from 'react';
 import { Pressable, Text } from 'react-native';
-import { turnClass, turnText, type TurnDisplayClass } from '@/lib/sessionFeed';
+import { selectThinkingTurn, turnClass, turnText } from '@/lib/sessionFeed';
 import type { SessionTurn } from '@/lib/types';
 import { useTheme } from '@/theme/ThemeContext';
 
-const THINKING_CLASSES = new Set<TurnDisplayClass>(['voice', 'dj']);
 const MARKER: Record<string, string> = { voice: '♪', dj: '◇' };
 
 export interface DjThinkingLineProps {
   feed: SessionTurn[] | undefined;
   enabled: boolean;
+  // Subsonic id of the track on air. A `dj`/pick turn's `meta.trackId` is the
+  // *picked* (next) song, so we skip pick reasoning that isn't about the
+  // current track — otherwise the line shows the upcoming pick (#546).
+  currentTrackId?: string | null;
   onOpenBooth: () => void;
 }
 
-export default function DjThinkingLine({ feed, enabled, onOpenBooth }: DjThinkingLineProps) {
+export default function DjThinkingLine({ feed, enabled, currentTrackId = null, onOpenBooth }: DjThinkingLineProps) {
   const { colors } = useTheme();
-  const latest = useMemo<SessionTurn | null>(() => {
-    if (!feed?.length) return null;
-    for (let i = feed.length - 1; i >= 0; i--) {
-      const turn = feed[i];
-      if (turn && THINKING_CLASSES.has(turnClass(turn)) && turn.text) return turn;
-    }
-    return null;
-  }, [feed]);
+  // The DJ turn relevant to what's ON AIR now — see selectThinkingTurn (#546).
+  const latest = useMemo<SessionTurn | null>(
+    () => selectThinkingTurn(feed, currentTrackId),
+    [feed, currentTrackId],
+  );
 
   if (!enabled || !latest) return null;
 

--- a/web/components/CenterStage.tsx
+++ b/web/components/CenterStage.tsx
@@ -219,7 +219,7 @@ export default memo(function CenterStage({ nowPlaying, trackStartedAt, llmTokens
       </div>
 
       {has && (
-        <DjThinkingLine feed={feed} enabled={djLineOn} buddyOn={boothBuddyOn} onOpenBooth={onOpenBooth} />
+        <DjThinkingLine feed={feed} enabled={djLineOn} currentTrackId={subsonicId} buddyOn={boothBuddyOn} onOpenBooth={onOpenBooth} />
       )}
     </div>
   );

--- a/web/components/DjThinkingLine.tsx
+++ b/web/components/DjThinkingLine.tsx
@@ -2,16 +2,15 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AnimatePresence, m } from 'motion/react';
-import { turnClass, turnText, type TurnDisplayClass } from '@/lib/sessionFeed';
+import { selectThinkingTurn, turnClass, turnText } from '@/lib/sessionFeed';
 import BoothBuddy, { type BuddyMood } from './BoothBuddy';
 import type { SessionTurn } from '@/lib/types';
 
 // Shows only the DJ's "thinking" — the latest thing said on-air ("voice") or
-// the latest pick/request reasoning ("dj"). Aired tracks and system turns
-// stay out. Renders under the track info as a small typed line; tapping it
-// opens the Booth drawer with the full transcript. The Booth Sprite leads the
-// line, its mood reacting to DJ activity (see useBuddyMood).
-const THINKING_CLASSES = new Set<TurnDisplayClass>(['voice', 'dj']);
+// the pick/request reasoning ("dj") for the track ON AIR. Aired tracks and
+// system turns stay out. Renders under the track info as a small typed line;
+// tapping it opens the Booth drawer with the full transcript. The Booth Sprite
+// leads the line, its mood reacting to DJ activity (see useBuddyMood).
 
 // Booth-buddy mood loop, driven by the newest DJ turn: it perks up when the DJ
 // speaks ('onair') or picks ('curious'), settles back to 'content', then dozes
@@ -85,6 +84,11 @@ export interface DjThinkingLineProps {
   /** Live session messages, oldest first. */
   feed: SessionTurn[] | undefined;
   enabled: boolean;
+  /** Subsonic id of the track on air. A `dj`/pick turn's `meta.trackId` is the
+   *  *picked* song — which, because picks run at the previous track's start, is
+   *  the track to play NEXT, not the one playing now. Used to skip pick
+   *  reasoning that isn't about the current track (#546). */
+  currentTrackId?: string | null;
   /** Station-wide Booth Sprite toggle; falls back to the classic marker when
    *  false. Defaults off (operator opts in). */
   buddyOn?: boolean;
@@ -93,16 +97,12 @@ export interface DjThinkingLineProps {
 
 // `feed` is the live session's `messages` array — turns of
 // { t, role, kind, text, meta }, oldest first.
-export default function DjThinkingLine({ feed, enabled, buddyOn = false, onOpenBooth }: DjThinkingLineProps) {
-  // The newest voice/dj turn — what the DJ is currently "thinking".
-  const latest = useMemo<SessionTurn | null>(() => {
-    if (!feed?.length) return null;
-    for (let i = feed.length - 1; i >= 0; i--) {
-      const turn = feed[i];
-      if (turn && THINKING_CLASSES.has(turnClass(turn)) && turn.text) return turn;
-    }
-    return null;
-  }, [feed]);
+export default function DjThinkingLine({ feed, enabled, currentTrackId = null, buddyOn = false, onOpenBooth }: DjThinkingLineProps) {
+  // The DJ turn relevant to what's ON AIR now — see selectThinkingTurn (#546).
+  const latest = useMemo<SessionTurn | null>(
+    () => selectThinkingTurn(feed, currentTrackId),
+    [feed, currentTrackId],
+  );
 
   const [mood, poke] = useBuddyMood(latest);
   // Hit-test taps against the buddy so poking it startles the sprite in place,

--- a/web/lib/sessionFeed.ts
+++ b/web/lib/sessionFeed.ts
@@ -46,3 +46,30 @@ export function turnText(turn: SessionTurn | null | undefined): string {
   if (turnClass(turn) === 'track') return text.replace(/^▶\s*/, '');
   return text;
 }
+
+// The single voice/dj turn to surface as the DJ "thinking" line under the
+// now-playing block. Walk newest→oldest and skip `dj`/pick turns whose
+// `meta.trackId` is for a track other than what's on air: a pick turn is
+// written at the *previous* track's start, so its trackId is the track to play
+// NEXT, not the one playing now — showing it under now-playing reads as "this
+// song's reasoning" when it isn't (#546). Voice/segment turns (aired links,
+// station IDs, weather) carry no trackId and are whatever was last spoken on
+// air, so they always qualify — meaning the back-announce link that aired as
+// this track started wins, falling back to this track's own pick reason on a
+// silent transition. A null/unknown currentTrackId yields the latest voice turn
+// (no pick can be confirmed as "this song").
+export function selectThinkingTurn(
+  feed: SessionTurn[] | null | undefined,
+  currentTrackId: string | null = null,
+): SessionTurn | null {
+  if (!feed?.length) return null;
+  for (let i = feed.length - 1; i >= 0; i--) {
+    const turn = feed[i];
+    const cls = turnClass(turn);
+    if (!turn?.text || (cls !== 'voice' && cls !== 'dj')) continue;
+    const trackId = turn.meta?.trackId as string | undefined;
+    if (cls === 'dj' && trackId && trackId !== currentTrackId) continue;
+    return turn;
+  }
+  return null;
+}


### PR DESCRIPTION
Closes #546.

## Problem
The ◇ "thinking" line under now-playing showed the **latest** dj/voice turn without checking which track it was about. Because the picker chooses the *next* track at the current track's start, the most recent `dj`/pick turn is for the **upcoming** track — so for most of a song the line described the wrong track (e.g. now-playing "Caliente" while the line read `Selected "Knightridah"`).

## Fix
Extract a pure `selectThinkingTurn(feed, currentTrackId)` into the shared `sessionFeed` module (web source of truth + native mirror) and have both players call it. It walks newest→oldest and skips `dj`/pick turns whose `meta.trackId` isn't the on-air track. Voice/segment turns (aired links, station IDs, weather) carry no `trackId` and always qualify — so the back-announce link that aired as this track started wins, falling back to this track's own pick reason on a silent transition.

This also removes the previously duplicated inline selector from the two `DjThinkingLine` components.

- **web**: `DjThinkingLine` + `CenterStage` thread `currentTrackId`
- **native**: same change in `app/src/player/*`
- **no controller changes** — `meta.trackId` and `/now-playing` already carry the data

## Testing
- 9/9 unit tests on the pure selector (the #546 scenario + an old-behavior regression contrast + edge cases)
- web `tsc --noEmit` + `eslint` clean
- verified live in the running dev player: the rendered line tracked the on-air track, not the next pick