### PR TITLE
feat: cap max track length for autonomous picks (#447)

### DIFF
--- a/controller/scripts/picker-recency-regression.ts
+++ b/controller/scripts/picker-recency-regression.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import {
   DEFAULT_ARTIST_RECENCY_HOURS,
   DEFAULT_TRACK_RECENCY_HOURS,
+  durationSeconds,
   filterPickerCandidates,
   recencyWindowsForLibrary,
 } from '../src/music/recency.js';
@@ -52,5 +53,46 @@ assert(
   recentlyPlayedSongs.length > 0,
   'expected picker filtering to relax recent tracks when every candidate is otherwise excluded',
 );
+
+// ── max-track-length cap (issue #447) ──────────────────────────────────────
+
+// durationSeconds reads whichever length field the source carries, and treats
+// missing / zero / non-finite as "unknown" (null) rather than 0.
+assert.equal(durationSeconds({ id: 'x', duration: 240 }), 240);
+assert.equal(durationSeconds({ id: 'x', durationSec: 180 }), 180);
+assert.equal(durationSeconds({ id: 'x' }), null);
+assert.equal(durationSeconds({ id: 'x', duration: 0 }), null);
+
+const mixedLengths = [
+  { id: 'short-1', title: 'Short', artist: 'A', duration: 200 },   // ~3m20
+  { id: 'long-1', title: 'Hour Mix', artist: 'B', duration: 3600 }, // 1h album mix
+  { id: 'unknown-1', title: 'No Meta', artist: 'C' },               // unknown length
+  { id: 'short-2', title: 'Brief', artist: 'D', durationSec: 250 }, // library-shaped field
+];
+
+// Cap at 10 minutes (600s): the hour-long mix is dropped, the short tracks and
+// the unknown-length track survive.
+const capped = filterPickerCandidates(mixedLengths, { maxDurationSec: 600 });
+assert.deepEqual(
+  capped.map((s) => s.id).sort(),
+  ['short-1', 'short-2', 'unknown-1'],
+  'expected the over-length track to be dropped while unknown-length is kept',
+);
+
+// The cap must survive the recency relaxation: even when every short track is
+// excluded as recently-played and the filter relaxes recency, the long track
+// must still never come back.
+const cappedUnderStarvation = filterPickerCandidates(mixedLengths, {
+  maxDurationSec: 600,
+  recentIds: new Set(['short-1', 'short-2', 'unknown-1']),
+});
+assert(
+  !cappedUnderStarvation.some((s) => s.id === 'long-1'),
+  'expected the over-length track to stay dropped even when the pool relaxes recency',
+);
+
+// No cap (null / 0) leaves every track — default behaviour is unchanged.
+assert.equal(filterPickerCandidates(mixedLengths, { maxDurationSec: null }).length, 4);
+assert.equal(filterPickerCandidates(mixedLengths, { maxDurationSec: 0 }).length, 4);
 
 console.log('picker-recency regression checks passed');

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -280,7 +280,11 @@ export const pickerAgent = defineAgent({
   timeoutMs: agentDeadline,
   buildSystem: () => pickSystem(),
   buildTools: ({ recentIds, recentKeys, recentArtists, audioWaypoint }) => {
-    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, recentArtists, audioWaypoint });
+    // Length cap for autonomous picks: the active show's override or the
+    // station default (issue #447), resolved live at run time so a show that
+    // just came on air takes effect. null = no cap.
+    const maxDurationSec = settings.effectiveMaxTrackSec();
+    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, recentArtists, audioWaypoint, maxDurationSec });
     return { tools, extras: { seen } };
   },
 });

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -10,6 +10,8 @@ import { config } from '../config.js';
 import * as subsonic from '../music/subsonic.js';
 import * as dj from '../llm/dj.js';
 import * as library from '../music/library.js';
+import * as settings from '../settings.js';
+import { durationSeconds } from '../music/recency.js';
 import { getFullContext } from '../context.js';
 import { queue } from './queue.js';
 import * as session from './session.js';
@@ -57,6 +59,11 @@ async function refreshAutoPlaylistInner() {
   // Match the auto-DJ picker's window (dj-agent.pickViaAgent) — 12h.
   const recent = queue.recentlyPlayedIds(12);
 
+  // Station-level length cap (issue #447). The auto playlist is the coarse,
+  // slow-refreshing Liquidsoap fallback that airs whenever the live queue runs
+  // dry — show overrides don't apply here, so we use the station default only.
+  const maxDurationSec = settings.effectiveMaxTrackSec(null);
+
   const pool: any[] = [];
   const fromSource: Record<string, number> = { mood: 0, playlist: 0, recent: 0, frequent: 0, starred: 0, random: 0 };
   const take = (label: string, items: any[], cap: number) => {
@@ -64,6 +71,10 @@ async function refreshAutoPlaylistInner() {
     for (const t of items) {
       if (n >= cap || pool.length >= TARGET_POOL) break;
       if (!t?.id || recent.has(t.id) || pool.find((p: any) => p.id === t.id)) continue;
+      if (maxDurationSec) {
+        const d = durationSeconds(t);
+        if (d != null && d > maxDurationSec) continue;
+      }
       pool.push({ ...t, _source: label });
       fromSource[label]++;
       n++;

--- a/controller/src/llm/internal/tools/picker-tools.ts
+++ b/controller/src/llm/internal/tools/picker-tools.ts
@@ -72,10 +72,16 @@ export function buildPickerTools({
   recentArtists = new Set<string>(),
   audioWaypoint = null,
   resolveReferences = false,
+  maxDurationSec = null,
 }: {
   recentIds?: Set<string>;
   recentKeys?: Set<string>;        // lowercased "title|artist" — backfilled entries lack ids
   recentArtists?: Set<string>;
+  // Hard length cap (seconds) for autonomous picks — the active show's override
+  // or the station default (issue #447). null = no cap. Deliberately NOT set on
+  // the request path (djAgentRequest) so an explicit listener ask for a long
+  // mix still plays.
+  maxDurationSec?: number | null;
   // The active sonic journey's current waypoint vector (broadcast/dj-agent.ts).
   // When present, the tracksTowardJourney tool below is registered, closing
   // over it — the agent never sees the raw vector, only the tracks near it.
@@ -105,6 +111,7 @@ export function buildPickerTools({
       artistCounts,
       maxPerArtist: MAX_PER_ARTIST,
       cap,
+      maxDurationSec,
     });
     const out: any[] = [];
     for (const s of accepted) {

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -141,6 +141,10 @@ export function songsByMood(mood: string | null | undefined): any[] {
       genre: r.genre,
       moods: r.moods,
       energy: r.energy,
+      // Length (seconds) for the max-track-length cap (issue #447) — without it
+      // a locally mood-tagged long mix would read as "unknown length" and slip
+      // past the cap.
+      durationSec: r.durationSec,
     }));
 
   const exact = flatten(db.songsByMood(mood));
@@ -180,6 +184,10 @@ function slimTrack(r: db.TrackRecord) {
     genre: r.genre,
     moods: r.moods,
     energy: r.energy,
+    // Track length (seconds) so the max-track-length cap (issue #447) can act on
+    // library-sourced candidates too — keeps them symmetric with Subsonic's
+    // `duration`. null on rows without it; the cap treats null as "unknown".
+    durationSec: r.durationSec,
     // Acoustic analysis — null on un-analysed tracks. Consumers (picker
     // re-rank, LLM candidate surface) treat null as "no signal".
     bpm: r.bpm,

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -198,7 +198,7 @@ async function tracksFromAlbums(albums: any[], perAlbum: number, max: number) {
   return out;
 }
 
-async function buildCandidates(mood: string | null | undefined, recentIds: Set<string>, recentArtists: Set<string>, currentTrack: any, rankTarget: { bpm: number | null; key: string | null } | null = null, audioWaypoint: number[] | null = null, showFilter: ShowFilter = null) {
+async function buildCandidates(mood: string | null | undefined, recentIds: Set<string>, recentArtists: Set<string>, currentTrack: any, rankTarget: { bpm: number | null; key: string | null } | null = null, audioWaypoint: number[] | null = null, showFilter: ShowFilter = null, maxDurationSec: number | null = null) {
   await library.load();
   const pool: any[] = [];
   const sources: Record<string, number> = {};
@@ -431,6 +431,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     artistCounts: perArtist,
     maxPerArtist: MAX_PER_ARTIST,
     cap: CANDIDATE_CAP,
+    maxDurationSec,
   });
 
   // Strict-genre diagnostics for the caller's never-starve log: how much of the
@@ -484,7 +485,10 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   const showFilter: ShowFilter = activeShow
     ? { genre: activeShow.genre, fromYear: activeShow.fromYear, toYear: activeShow.toYear, energy: activeShow.energy, strict: activeShow.genreStrict }
     : null;
-  const { candidates, sources, strictInfo } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack, rankTarget, audioWaypoint, showFilter);
+  // Length cap for this pick: the active show's override or the station default
+  // (issue #447), resolved in seconds. null = no cap.
+  const maxDurationSec = settings.effectiveMaxTrackSec(activeShow);
+  const { candidates, sources, strictInfo } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack, rankTarget, audioWaypoint, showFilter, maxDurationSec);
 
   if (candidates.length === 0) {
     queue.log('picker', 'no candidates available, skipping LLM pick');

--- a/controller/src/music/recency.ts
+++ b/controller/src/music/recency.ts
@@ -13,6 +13,10 @@ export interface CandidateLike {
   id?: string | null;
   title?: string | null;
   artist?: string | null;
+  // Track length. Subsonic songs carry `duration`; library-db rows carry
+  // `durationSec`. Both optional — unknown length is never grounds to drop.
+  duration?: number | null;
+  durationSec?: number | null;
 }
 
 export interface CandidateFilterState {
@@ -23,6 +27,20 @@ export interface CandidateFilterState {
   artistCounts?: Map<string, number>;
   maxPerArtist?: number;
   cap?: number;
+  // Hard length cap in seconds (station/show max-track-length, issue #447).
+  // null / 0 means "no cap". Tracks longer than this are dropped before the
+  // recency relaxation below, so an over-length track never airs even when the
+  // pool is starved.
+  maxDurationSec?: number | null;
+}
+
+// Track length in seconds from whichever field the source carries, or null when
+// unknown. Zero/negative/non-finite all read as unknown — we only ever act on a
+// positive, trustworthy duration (the hour-long album mixes #447 targets report
+// one reliably).
+export function durationSeconds(song: CandidateLike): number | null {
+  const d = song?.duration ?? song?.durationSec;
+  return Number.isFinite(d) && (d as number) > 0 ? Number(d) : null;
 }
 
 export function artistKey(song: CandidateLike): string {
@@ -66,8 +84,19 @@ export function filterPickerCandidates<T extends CandidateLike>(
     artistCounts = new Map<string, number>(),
     maxPerArtist = Infinity,
     cap = Infinity,
+    maxDurationSec = null,
   }: CandidateFilterState = {},
 ): T[] {
+  // Length cap first, outside the recency loop: a too-long track is never an
+  // acceptable autonomous pick, so it must not survive even the fully-relaxed
+  // third mode. Unknown-duration tracks pass through untouched.
+  const pool = maxDurationSec && maxDurationSec > 0
+    ? (list || []).filter((s) => {
+        const d = durationSeconds(s);
+        return d == null || d <= maxDurationSec;
+      })
+    : (list || []);
+
   const modes = [
     { recentTracks: true, recentArtists: true },
     { recentTracks: true, recentArtists: false },
@@ -79,7 +108,7 @@ export function filterPickerCandidates<T extends CandidateLike>(
     const nextArtistCounts = new Map(artistCounts);
     const out: T[] = [];
 
-    for (const song of list || []) {
+    for (const song of pool) {
       if (!song?.id || nextSeen.has(song.id)) continue;
       if (mode.recentTracks && recentIds.has(song.id)) continue;
       if (mode.recentTracks && recentKeys.has(trackKey(song))) continue;

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -69,6 +69,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
       values: {
         jingleRatio: s.jingleRatio,
         crossfadeDuration: s.crossfadeDuration,
+        maxTrackMinutes: s.maxTrackMinutes,
         archive: s.archive,
         stream: s.stream,
         station: s.station,

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -382,6 +382,35 @@ function clamp01(n: number): number {
   return n;
 }
 
+// Coerce a stored/per-show max-track-length to a clean integer minute count.
+// `allowNull` distinguishes the two callers: the station default has no "unset"
+// state (missing → 0 = off), whereas a per-show value uses null to mean "inherit
+// the station default" (vs 0 = "unlimited override"). Out-of-band values clamp
+// into [0, max] rather than throw — load() stays lenient.
+function coerceMaxTrackMinutes(raw: any, allowNull: boolean): number | null {
+  if (raw == null || raw === '') return allowNull ? null : 0;
+  const n = Math.round(Number(raw));
+  if (!Number.isFinite(n)) return allowNull ? null : 0;
+  return Math.min(BOUNDS.maxTrackMinutes.max, Math.max(0, n));
+}
+
+// Effective track-length cap in SECONDS for the moment a pick is made, or null
+// for "no cap". A scheduled show's maxTrackMinutes (when set) overrides the
+// station default; 0 at the winning level means unlimited. This is the single
+// resolver both picker paths and the auto-playlist call so the precedence rule
+// lives in exactly one place.
+export function effectiveMaxTrackSec(
+  show: any = resolveActiveShow(),
+  s: any = get(),
+): number | null {
+  const station = coerceMaxTrackMinutes(s?.maxTrackMinutes, false) ?? 0;
+  const showMin = show && show.maxTrackMinutes != null
+    ? coerceMaxTrackMinutes(show.maxTrackMinutes, false)
+    : null;
+  const mins = showMin != null ? showMin : station;
+  return mins && mins > 0 ? mins * 60 : null;
+}
+
 function mintId(prefix) {
   return prefix + randomBytes(3).toString('hex');
 }
@@ -444,6 +473,13 @@ export const ARCHIVE_BITRATES = [64, 96, 128, 160, 192, 320] as const;
 const DEFAULTS = {
   jingleRatio: 30, // 1 jingle per N music tracks
   crossfadeDuration: 10.0, // seconds
+  // Station-wide cap (minutes) on how long a single autonomously-picked track
+  // may be — keeps hour-long album mixes and DJ sets out of normal rotation
+  // (issue #447). 0 = no cap (default, unchanged behaviour). A scheduled show
+  // can override this with its own `maxTrackMinutes` (0 there = "unlimited",
+  // i.e. opt back out of the station cap for a long-form show). Listener
+  // requests bypass the cap entirely — an explicit ask always plays.
+  maxTrackMinutes: 0,
   // Hourly archive output. Enabled by default to preserve existing behaviour.
   // The second MP3 encoder is the largest constant CPU cost in the broadcast
   // container — operators who don't use the archives can switch this off to
@@ -719,6 +755,9 @@ const DEFAULTS = {
 const BOUNDS = {
   jingleRatio: { min: 1, max: 1000, type: 'int' },
   crossfadeDuration: { min: 0, max: 30, type: 'float' },
+  // 0 = off; 600 min (10h) is a generous ceiling that still leaves room for
+  // long-form mix shows without letting a typo set an absurd value.
+  maxTrackMinutes: { min: 0, max: 600, type: 'int' },
 };
 
 const ARCHIVE_BITRATE_SET = new Set<number>(ARCHIVE_BITRATES);
@@ -873,6 +912,10 @@ function normalizeShows(raw: any, personaIds: string[]) {
     // lean. Only meaningful when a genre is set; defaults off so existing shows
     // and soft shows are byte-for-byte unchanged.
     const genreStrict = item.genreStrict === true;
+    // Per-show track-length override (minutes). null = inherit the station-wide
+    // maxTrackMinutes; 0 = unlimited (opt this show back out of the cap so a
+    // long-form mix show can air hour-long sets); >0 = this show's own cap.
+    const maxTrackMinutes = coerceMaxTrackMinutes(item.maxTrackMinutes, true);
     out.push({
       id,
       name,
@@ -885,6 +928,7 @@ function normalizeShows(raw: any, personaIds: string[]) {
       toYear,
       energy,
       genreStrict,
+      maxTrackMinutes,
     });
     if (out.length >= SHOWS_LIMIT) break;
   }
@@ -966,6 +1010,7 @@ export async function load() {
   cache = {
     jingleRatio: stored.jingleRatio ?? DEFAULTS.jingleRatio,
     crossfadeDuration: stored.crossfadeDuration ?? DEFAULTS.crossfadeDuration,
+    maxTrackMinutes: coerceMaxTrackMinutes(stored.maxTrackMinutes, false) ?? DEFAULTS.maxTrackMinutes,
     archive: {
       enabled:
         typeof stored.archive?.enabled === 'boolean'
@@ -1556,10 +1601,22 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
     if (fromYear != null && toYear != null && fromYear > toYear) {
       throw new Error(`shows[${i}].fromYear must be <= toYear`);
     }
+    // Per-show track-length override (minutes): null = inherit station default,
+    // 0 = unlimited, >0 = own cap. Empty/missing → inherit.
+    let maxTrackMinutes: number | null = null;
+    if (item.maxTrackMinutes != null && item.maxTrackMinutes !== '') {
+      const n = Number(item.maxTrackMinutes);
+      if (!Number.isInteger(n) || n < BOUNDS.maxTrackMinutes.min || n > BOUNDS.maxTrackMinutes.max) {
+        throw new Error(
+          `shows[${i}].maxTrackMinutes must be an integer between ${BOUNDS.maxTrackMinutes.min} and ${BOUNDS.maxTrackMinutes.max}`,
+        );
+      }
+      maxTrackMinutes = n;
+    }
     let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('s_');
     if (seen.has(id)) id = mintId('s_');
     seen.add(id);
-    return { id, name, topic, personaId: item.personaId, mood: item.mood, themeId, genre, fromYear, toYear, energy, genreStrict };
+    return { id, name, topic, personaId: item.personaId, mood: item.mood, themeId, genre, fromYear, toYear, energy, genreStrict, maxTrackMinutes };
   });
 }
 
@@ -1672,6 +1729,17 @@ export async function update(patch) {
       next.crossfadeDuration = v;
       restart = true;
     }
+  }
+  if ('maxTrackMinutes' in patch) {
+    const v = parseInt(patch.maxTrackMinutes, 10);
+    if (!Number.isFinite(v) || v < BOUNDS.maxTrackMinutes.min || v > BOUNDS.maxTrackMinutes.max) {
+      throw new Error(
+        `maxTrackMinutes must be int in [${BOUNDS.maxTrackMinutes.min}, ${BOUNDS.maxTrackMinutes.max}]`,
+      );
+    }
+    // Picker-only knob (read live by music/picker + the auto-playlist refresh);
+    // no Liquidsoap file is written, so no restart.
+    next.maxTrackMinutes = v;
   }
   if ('archive' in patch) {
     const a = patch.archive || {};
@@ -2217,6 +2285,9 @@ export function resolveActiveShow(date = new Date(), s = get()) {
     // genre instead of softly leaned; off-genre tracks only survive as a
     // never-starve fallback. Defaults off.
     genreStrict: show.genreStrict === true,
+    // Per-show track-length cap override (minutes). null = inherit the station
+    // default; 0 = unlimited; >0 = own cap. See effectiveMaxTrackSec().
+    maxTrackMinutes: show.maxTrackMinutes != null ? show.maxTrackMinutes : null,
     // Empty string means "fall back to the station-wide default". The route
     // layer is responsible for resolving an empty/stale id against the live
     // theme registry; we just surface what the show declares.

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -206,6 +206,7 @@ const ARCHIVE_BITRATES = [64, 96, 128, 160, 192, 320] as const;
 interface FormState {
   jingleRatio: string;
   crossfadeDuration: string;
+  maxTrackMinutes: string;
   archive: ArchiveForm;
   stream: StreamForm;
   station: string;
@@ -246,6 +247,7 @@ interface SettingsData {
   values?: {
     jingleRatio?: number;
     crossfadeDuration?: number;
+    maxTrackMinutes?: number;
     archive?: { enabled?: boolean; bitrate?: number };
     stream?: { opusEnabled?: boolean };
     station?: string;
@@ -376,6 +378,7 @@ export default function SettingsPanel() {
     setForm({
       jingleRatio: String(v.jingleRatio ?? ''),
       crossfadeDuration: String(v.crossfadeDuration ?? ''),
+      maxTrackMinutes: String(v.maxTrackMinutes ?? 0),
       archive: {
         enabled: v.archive?.enabled ?? true,
         bitrate: String(v.archive?.bitrate ?? 128),
@@ -822,6 +825,43 @@ export default function SettingsPanel() {
                   <div className="field-hint">
                     Seconds of overlap between tracks (current: {data?.values?.crossfadeDuration}s).
                     Saving flags a pending restart. Apply it with the Mixer card below.
+                  </div>
+                </div>
+              </Card>
+            )}
+
+            {form && (
+              <Card title="Max track length" sub="keep long mixes out of rotation">
+                <div className="field">
+                  <Label>Maximum track length</Label>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      className="mono-num w-28"
+                      type="number"
+                      step={1}
+                      min={0}
+                      max={600}
+                      value={form.maxTrackMinutes}
+                      onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                        setForm(f => (f ? { ...f, maxTrackMinutes: e.target.value } : f))
+                      }
+                    />
+                    <span className="text-[12px] text-muted">min (0 = no limit)</span>
+                    <Btn
+                      sm
+                      onClick={() =>
+                        saveSettings({ maxTrackMinutes: parseInt(form.maxTrackMinutes, 10) || 0 })
+                      }
+                      disabled={busy}
+                    >
+                      Save limit
+                    </Btn>
+                  </div>
+                  <div className="field-hint">
+                    The DJ won&rsquo;t auto-pick tracks longer than this — handy for hour-long
+                    album mixes or DJ sets that keep landing in rotation. Listener requests still
+                    play any length, and a show can override this with its own limit (0 there means
+                    unlimited). Applies on the next pick; no restart needed.
                   </div>
                 </div>
               </Card>

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -917,20 +917,6 @@ export default function ShowsPanel() {
                   </SelectContent>
                 </Select>
               </Field>
-              <Field>
-                <Label>max length</Label>
-                <Input
-                  type="number"
-                  min={0}
-                  max={600}
-                  placeholder="inherit"
-                  value={draft.maxTrackMinutes ?? ''}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                    const raw = e.target.value.trim();
-                    setDraftField({ maxTrackMinutes: raw === '' ? null : Math.max(0, parseInt(raw, 10) || 0) });
-                  }}
-                />
-              </Field>
             </div>
 
             <div className="flex items-start gap-3">
@@ -956,10 +942,31 @@ export default function ShowsPanel() {
               Optional soft music steer for this show: a genre, an era, an energy
               band, or any mix. The DJ leans toward these but can break them for
               flow; leave blank to let the topic and mood drive selection.
-              {' '}<b>Max length</b> (minutes) caps how long a picked track can be —
-              leave blank to inherit the station limit, set 0 to allow any length
-              (e.g. a long-form mix show), or a number for this show&rsquo;s own cap.
             </span>
+
+            <Field>
+              <Label htmlFor="show-maxlen">max track length (minutes)</Label>
+              <Input
+                id="show-maxlen"
+                type="number"
+                min={0}
+                max={600}
+                placeholder="inherit"
+                value={draft.maxTrackMinutes ?? ''}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                  const raw = e.target.value.trim();
+                  setDraftField({ maxTrackMinutes: raw === '' ? null : Math.max(0, parseInt(raw, 10) || 0) });
+                }}
+              />
+              <span className="field-hint">
+                The longest a single track can run while this show is on air. The
+                DJ skips anything longer when it picks, so this is a hard limit,
+                not a lean like the fields above. Leave it blank to use the
+                station limit, enter 0 to allow any length (good for a show built
+                around long mixes or DJ sets), or set a number to cap it just for
+                this show.
+              </span>
+            </Field>
 
             <Field>
               <Label htmlFor="show-topic">topic (fed to the DJ as the show theme)</Label>

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -73,6 +73,10 @@ interface Show {
    *  pool instead of a soft lean — off-genre tracks only play as a last resort
    *  to avoid silence. Defaults off. */
   genreStrict: boolean;
+  /** Per-show track-length cap (minutes). null = inherit the station default;
+   *  0 = unlimited (opt this show out of the cap so it can air long mixes);
+   *  >0 = this show's own cap. */
+  maxTrackMinutes: number | null;
 }
 
 // Decade presets for the era dropdown → fromYear/toYear. 'any' clears the window.
@@ -180,9 +184,10 @@ function NowCard({ label, accent, slotHour, show, color, personaLabel }: NowCard
 // Compact " · genre · 80s · high" suffix for the show summary lines, omitting
 // whatever the show doesn't pin. A strict genre is flagged inline so the hard
 // lock is visible at a glance.
-function showFilterSummary(s: { genre: string; fromYear: number | null; toYear: number | null; energy: string; genreStrict?: boolean }): string {
+function showFilterSummary(s: { genre: string; fromYear: number | null; toYear: number | null; energy: string; genreStrict?: boolean; maxTrackMinutes?: number | null }): string {
   const genre = s.genre ? (s.genreStrict ? `${s.genre} (strict)` : s.genre) : '';
-  const bits = [genre, decadeLabelOf(s), s.energy].filter(Boolean);
+  const len = s.maxTrackMinutes == null ? '' : s.maxTrackMinutes === 0 ? 'any length' : `≤${s.maxTrackMinutes}m`;
+  const bits = [genre, decadeLabelOf(s), s.energy, len].filter(Boolean);
   return bits.length ? ` · ${bits.join(' · ')}` : '';
 }
 
@@ -290,6 +295,7 @@ export default function ShowsPanel() {
           toYear: s.toYear ?? null,
           energy: s.energy ?? '',
           genreStrict: s.genreStrict ?? false,
+          maxTrackMinutes: s.maxTrackMinutes ?? null,
         }));
         setForm({ shows, schedule: week });
         // Arm the first valid show as the brush so the grid is paintable at once.
@@ -351,6 +357,7 @@ export default function ShowsPanel() {
       personaId: personas[0]?.id || '', mood: moods[0] || '',
       themeId: '',
       genre: '', fromYear: null, toYear: null, energy: '', genreStrict: false,
+      maxTrackMinutes: null,
     });
   };
   const openEdit = (i: number) => {
@@ -364,6 +371,7 @@ export default function ShowsPanel() {
       themeId: s.themeId || '',
       genre: s.genre || '', fromYear: s.fromYear ?? null, toYear: s.toYear ?? null, energy: s.energy || '',
       genreStrict: s.genreStrict ?? false,
+      maxTrackMinutes: s.maxTrackMinutes ?? null,
     });
   };
   const closeModal = () => { setEditIndex(null); setDraft(null); };
@@ -377,6 +385,7 @@ export default function ShowsPanel() {
       genre: draft.genre.trim(), fromYear: draft.fromYear, toYear: draft.toYear, energy: draft.energy || '',
       // Strict is only meaningful with a genre to lock to — drop it otherwise.
       genreStrict: !!draft.genre.trim() && draft.genreStrict,
+      maxTrackMinutes: draft.maxTrackMinutes,
     };
     if (editIndex === -1) {
       const id = clientMintId();
@@ -514,6 +523,7 @@ export default function ShowsPanel() {
             themeId: s.themeId || '',
             genre: s.genre.trim(), fromYear: s.fromYear, toYear: s.toYear, energy: s.energy || '',
             genreStrict: !!s.genre.trim() && s.genreStrict,
+            maxTrackMinutes: s.maxTrackMinutes,
           })),
           schedule: form.schedule,
         }),
@@ -907,6 +917,20 @@ export default function ShowsPanel() {
                   </SelectContent>
                 </Select>
               </Field>
+              <Field>
+                <Label>max length</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  max={600}
+                  placeholder="inherit"
+                  value={draft.maxTrackMinutes ?? ''}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                    const raw = e.target.value.trim();
+                    setDraftField({ maxTrackMinutes: raw === '' ? null : Math.max(0, parseInt(raw, 10) || 0) });
+                  }}
+                />
+              </Field>
             </div>
 
             <div className="flex items-start gap-3">
@@ -932,6 +956,9 @@ export default function ShowsPanel() {
               Optional soft music steer for this show: a genre, an era, an energy
               band, or any mix. The DJ leans toward these but can break them for
               flow; leave blank to let the topic and mood drive selection.
+              {' '}<b>Max length</b> (minutes) caps how long a picked track can be —
+              leave blank to inherit the station limit, set 0 to allow any length
+              (e.g. a long-form mix show), or a number for this show&rsquo;s own cap.
             </span>
 
             <Field>


### PR DESCRIPTION
Closes #447.

## What

Operator-configurable **maximum track length** so hour-long album mixes and ready-to-go DJ sets stop getting auto-picked into rotation.

- **Station-wide cap** `maxTrackMinutes` — `0` = off (default, no behaviour change).
- **Per-show override** — `null` = inherit the station default, `0` = unlimited (opt a long-form mix show *out* of the cap), `>0` = the show's own cap.
- Precedence resolved in one place: `settings.effectiveMaxTrackSec(show, s)`.

## How

- Enforced at the single `filterPickerCandidates` chokepoint via a `maxDurationSec` pre-filter that runs **before** the recency-relaxation loop — so an over-length track never airs even when the candidate pool is starved. Tracks with unknown duration pass through (the cap targets the long mixes, where Subsonic reports a reliable length).
- Wired into **both** picker paths (the stateless pool picker and the session DJ agent) and the **auto-playlist** fallback (`scheduler.ts`, station-level cap only).
- **Listener requests bypass the cap entirely** — an explicit ask always plays, any length.
- `slimTrack` + the `songsByMood` projection now carry `durationSec`, so locally mood-tagged candidates are capped too (symmetric with Subsonic's `duration`).
- Admin **Settings → Max track length** card (no mixer restart needed) and a per-show **max length** field in the Shows editor. `GET /settings` surfaces the station value.

## Testing

- `npm test` (controller) — `picker-recency-regression.ts` extended with drop/keep/relaxation-survival/no-cap assertions; controller + web `tsc`/lint clean.
- Integration test against the **real** `settings` + `recency` modules: precedence (all 5 cases), the duration filter on mixed Subsonic/library candidates, requests-bypass, and a real on-disk `update()` → `load()` round-trip with validation.
- **Live-tested in the browser** on a dev stack:
  - Station card: set 10 → persisted (API + `settings.json`) → **reads back after reload** (this surfaced a route-projection gap where `GET /settings` wasn't returning the station value — fixed in `routes/settings.ts`).
  - Per-show: "DJ Sets" with max length `0` → summary shows "any length" → round-trips through API + `schedule.json`.
  - Real-data proof the cap bites on the live Navidrome library via auto-playlist refresh: **29 tracks uncapped → 0 at a 1-min cap → 29 at 10-min**.

## Notes

Part 2 of the issue (multi-hour "fit the DJ set into the remaining show time" scheduling) is intentionally **not** included — it's a separate show-scheduling feature. This PR fully covers the original request plus the exclusion half of the follow-up comment, and the per-show `0 = unlimited` override gives a clean home for long-form mix shows.
