### PR TITLE
fix(picker): stop artist/track over-repetition from three sources

### DIFF
--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -11,7 +11,7 @@ import * as subsonic from '../music/subsonic.js';
 import * as dj from '../llm/dj.js';
 import * as library from '../music/library.js';
 import * as settings from '../settings.js';
-import { durationSeconds } from '../music/recency.js';
+import { durationSeconds, artistKey } from '../music/recency.js';
 import { getFullContext } from '../context.js';
 import { queue } from './queue.js';
 import * as session from './session.js';
@@ -28,6 +28,7 @@ const PLAYLIST_WEIGHT = 6;       // mood-matched Navidrome playlists
 const RECENT_WEIGHT = 4;         // recently-added albums
 const FREQUENT_WEIGHT = 4;       // frequent / scrobble-favourite albums
 const STARRED_WEIGHT = 6;        // hand-starred tracks
+const AUTO_MAX_PER_ARTIST = 2;   // cap any one artist's share of the fallback pool
 
 function shuffle<T>(arr: T[]): T[] {
   return [...arr].sort(() => Math.random() - 0.5);
@@ -67,17 +68,25 @@ async function refreshAutoPlaylistInner() {
 
   const pool: any[] = [];
   const fromSource: Record<string, number> = { mood: 0, playlist: 0, recent: 0, frequent: 0, starred: 0, random: 0 };
+  // Cap each artist's share of the pool. Without this, a deep-catalogue artist
+  // (many mood-tagged / starred / frequent tracks) can dominate the fallback
+  // playlist, so whenever Liquidsoap coasts on auto.m3u the same artist clusters
+  // on air — e.g. one artist's tracks airing 7× purely from this source.
+  const artistInPool = new Map<string, number>();
   const take = (label: string, items: any[], cap: number) => {
     let n = 0;
     for (const t of items) {
       if (n >= cap || pool.length >= TARGET_POOL) break;
       if (!t?.id || recent.has(t.id) || pool.find((p: any) => p.id === t.id)) continue;
+      const ak = artistKey(t);
+      if (ak && (artistInPool.get(ak) || 0) >= AUTO_MAX_PER_ARTIST) continue;
       if (maxDurationSec) {
         const d = durationSeconds(t);
         if (d != null && d > maxDurationSec) continue;
       }
       pool.push({ ...t, _source: label });
       fromSource[label]++;
+      if (ak) artistInPool.set(ak, (artistInPool.get(ak) || 0) + 1);
       n++;
     }
   };

--- a/controller/src/broadcast/session.ts
+++ b/controller/src/broadcast/session.ts
@@ -24,6 +24,7 @@ import { logEvent } from '../observability/events.js';
 
 const MAX_SESSION_MS = 4 * 60 * 60 * 1000;  // safety cap — roll even if key is stable
 const WINDOW_TURNS = 40;                    // turns fed to the agent (full log is kept)
+const RATIONALE_WINDOW = 3;                 // most-recent dj/pick reasons kept in the window (anti-thread-momentum)
 const PERSIST_DEBOUNCE_MS = 1000;
 
 let _session: any = null;
@@ -230,8 +231,14 @@ function softShift(ctx: any, nextKey: string): any {
 //   gemini's reliability drops from 5/5 short → 2-3/5 long in the
 //   picker-test.mjs LONG benchmark, with "No output generated" failures.
 //
-// The DJ's own reasons (role='dj' kind='pick') stay — those are the agent's
-// short memory of recent decisions, useful for variety.
+// The DJ's own reasons (role='dj' kind='pick') stay — but only the most recent
+// RATIONALE_WINDOW of them. Each one is the agent's 12-word scratchpad ("Punjabi
+// thread continues, …"); left unbounded, ~15-20 accumulate in the window and the
+// agent reads its own running commentary as a mandate to keep the thread going
+// (one artist re-airing every ~1.2h). Keeping the last few preserves short-term
+// "what did I just play" memory without the momentum. Artist-recency is enforced
+// at the tool layer regardless (recentArtists in buildPickerTools), so trimming
+// these costs the picker no anti-repeat coverage.
 export function windowMessages() {
   if (!_session) return [];
   const raw: any[] = [];
@@ -245,12 +252,19 @@ export function windowMessages() {
   for (let i = recent.length - 1; i >= 0; i--) {
     if (recent[i].role === 'event' && recent[i].kind === 'pick') { lastPickEventIdx = i; break; }
   }
+  // Keep only the most-recent RATIONALE_WINDOW dj/pick rationales — older ones
+  // are the thread-momentum noise we want gone.
+  const keepRationaleIdx = new Set<number>();
+  for (let i = recent.length - 1, kept = 0; i >= 0 && kept < RATIONALE_WINDOW; i--) {
+    if (recent[i].role === 'dj' && recent[i].kind === 'pick') { keepRationaleIdx.add(i); kept++; }
+  }
   for (let i = 0; i < recent.length; i++) {
     const m = recent[i];
     if (!m.text) continue;
     if (m.kind === 'scenario') continue;  // infra noise
     if (m.kind === 'play') continue;       // redundant — current track is in the pick event
     if (m.role === 'event' && m.kind === 'pick' && i !== lastPickEventIdx) continue;  // old pick asks
+    if (m.role === 'dj' && m.kind === 'pick' && !keepRationaleIdx.has(i)) continue;   // stale pick rationales
     const role = (m.role === 'dj' || m.role === 'segment') ? 'assistant' : 'user';
     raw.push({ role, content: m.text });
   }

--- a/controller/src/llm/internal/tools/picker-tools.ts
+++ b/controller/src/llm/internal/tools/picker-tools.ts
@@ -112,6 +112,11 @@ export function buildPickerTools({
       maxPerArtist: MAX_PER_ARTIST,
       cap,
       maxDurationSec,
+      // Per-tool, never relax the recent-artist guard: a single-artist tool
+      // result (topSongsByArtist / similarSongs narrowed to a just-played
+      // artist) returns empty so the agent uses a different tool, instead of the
+      // cascade handing that artist right back (the artist-fixation bypass).
+      allowArtistRelaxation: false,
     });
     const out: any[] = [];
     for (const s of accepted) {

--- a/controller/src/music/recency.ts
+++ b/controller/src/music/recency.ts
@@ -32,6 +32,15 @@ export interface CandidateFilterState {
   // recency relaxation below, so an over-length track never airs even when the
   // pool is starved.
   maxDurationSec?: number | null;
+  // Whether a starved result may relax the recent-ARTIST guard. Default true
+  // preserves the pool picker's "never return empty" behaviour. The agent's
+  // per-tool collect() passes false: a single-artist tool (topSongsByArtist /
+  // similarSongs narrowed to one recent artist) then returns empty instead of
+  // handing the just-played artist straight back — the agent reaches for one of
+  // its other six discovery tools. This closes the artist-fixation bypass that
+  // let one artist re-air every ~1.2h despite the 2h artist window. Tracks may
+  // still relax as a last resort, but only for FRESH (non-recent) artists.
+  allowArtistRelaxation?: boolean;
 }
 
 // Track length in seconds from whichever field the source carries, or null when
@@ -85,6 +94,7 @@ export function filterPickerCandidates<T extends CandidateLike>(
     maxPerArtist = Infinity,
     cap = Infinity,
     maxDurationSec = null,
+    allowArtistRelaxation = true,
   }: CandidateFilterState = {},
 ): T[] {
   // Length cap first, outside the recency loop: a too-long track is never an
@@ -97,11 +107,20 @@ export function filterPickerCandidates<T extends CandidateLike>(
       })
     : (list || []);
 
-  const modes = [
-    { recentTracks: true, recentArtists: true },
-    { recentTracks: true, recentArtists: false },
-    { recentTracks: false, recentArtists: false },
-  ];
+  // Relaxation cascade: each mode drops a guard so a starved pool still yields
+  // something rather than nothing. When artist relaxation is disabled the artist
+  // guard stays ON in every mode — only the track guard may drop, and only for
+  // fresh artists — so the agent is never handed an artist it just played.
+  const modes = allowArtistRelaxation
+    ? [
+        { recentTracks: true, recentArtists: true },
+        { recentTracks: true, recentArtists: false },
+        { recentTracks: false, recentArtists: false },
+      ]
+    : [
+        { recentTracks: true, recentArtists: true },
+        { recentTracks: false, recentArtists: true },
+      ];
 
   for (const mode of modes) {
     const nextSeen = new Set(seenIds);


### PR DESCRIPTION
## Why

7-day playout logs (Jun 19–25) showed the DJ over-repeating a handful of artists/tracks despite a ~10k-track library. The library isn't the problem — **894 distinct artists and 1,793 distinct tracks** aired (~18% of the catalogue). The problem is a **skewed head**:

- **Sikander Kahlon: 81 plays** = ~21× the 3.8 average artist, and **53 of his 80 inter-play gaps were under 2 hours** — i.e. the 2h artist-recency window was being bypassed.
- 74% of plays come from the `ai` (DJ-agent) path; 17% from the `auto.m3u` fallback.

Three independent mechanisms were found, each fixed here.

## What changed

### 1. Per-tool recency relaxation re-admitted the just-played artist (the big one)
`filterPickerCandidates` runs a 3-mode relaxation cascade and falls through **per `collect()` call** when a mode yields zero. When the agent narrows a tool to one artist (`topSongsByArtist`/`similarSongs`), mode-1 blocks all (recent artist) → mode-2 **drops the artist guard** → the artist comes right back.

- New `allowArtistRelaxation` option (default `true` keeps the pool picker's never-starve behaviour).
- The agent's per-tool `collect()` passes `false`: a single-recent-artist result now returns **empty**, so the agent reaches for one of its six other discovery tools. Only the track guard may relax, and only for **fresh** artists.

### 2. Session-thread momentum
The agent read its own accumulated `dj/pick` rationales ("Punjabi thread continues" × many; "Sikander" in 46 rationales/7d) as a mandate to keep threading. `windowMessages()` now keeps only the most-recent `RATIONALE_WINDOW = 3` pick rationales (older ones filtered like stale pick-events already are). Artist-recency is tool-enforced regardless, so **no anti-repeat coverage is lost**.

### 3. `auto.m3u` fallback clustered one artist
"Denzel" aired 7×, all `source:auto`. `refreshAutoPlaylist`'s `take()` deduped by id only — added `AUTO_MAX_PER_ARTIST = 2` cap across the fallback pool.

## Verification
- `npm run lint` — clean on changed files (pre-existing `multer` env errors are unrelated, in untouched files).
- `npm run test:llm` — pure unit tests pass.
- Filter behaviour simulated: single-recent-artist tool result → empty; pool picker unchanged; mixed pools still pass fresh artists.

## Follow-ups for the operator
- **Re-run `subwave-picker-benchmark`** — change #2 touches the agent's context window, and prior notes flagged pick-rationale text as load-bearing for flow on some models. Confirm no reliability regression.
- Prod images bake source at build time → deploy with `up -d --build controller`.
- Verify after ~24h on air: `jq -r 'select(.type=="track.play")|"\(.title)|\(.artist)"' state/logs/events-*.jsonl | sort | uniq -c | sort -rn | head -20` — target is no artist near 80/week and the sub-2h gaps gone.