### PR TITLE
fix(embedding): stop chat-provider switch from silently breaking vector search

### DIFF
--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -272,6 +272,21 @@ export function tracksLikeThisAudio(seed: string, k: number): any[] {
 // words.
 export function tracksByVector(vec: number[] | Float32Array, k: number): any[] {
   if (!loaded) return [];
+  // Guard against an embedding model/provider drift: if the live query vector's
+  // length no longer matches the dim the index was built at, knnByVector would
+  // throw a raw "Dimension mismatch" from sqlite-vec (surfaced to the DJ agent
+  // as a tool error). Degrade to an empty semantic result instead — the picker
+  // falls through to its lexical/other sources — and log an actionable hint.
+  const meta = db.getEmbeddingMeta();
+  const got = (vec as { length?: number }).length;
+  if (meta?.dim && got && meta.dim !== got) {
+    console.warn(
+      `[library] vector search skipped: query vector is ${got}-d but the index ` +
+        `is ${meta.dim}-d (model: ${meta.model}). The embedding model changed — ` +
+        `re-embed the library or pin settings.embedding back to the index's model.`,
+    );
+    return [];
+  }
   const hits = db.knnByVector(vec, k);
   const out: any[] = [];
   for (const hit of hits) {
@@ -298,7 +313,7 @@ export function tracksByAudioVector(vec: number[] | Float32Array, k: number): an
 
 export function stats() {
   if (!loaded) {
-    return { total: 0, distinctArtists: 0, byMood: {}, byEnergy: {}, byGenre: {}, updatedAt: null };
+    return { total: 0, distinctArtists: 0, byMood: {}, byEnergy: {}, byGenre: {}, updatedAt: null, embeddingMeta: null };
   }
   const s = db.stats();
   return {
@@ -311,6 +326,10 @@ export function stats() {
     withEmbedding: s.withEmbedding,
     withAudioEmbedding: s.withAudioEmbedding,
     updatedAt: s.updatedAt,
+    // Provenance of the text-embedding index ({model, dim} or null) so the admin
+    // UI can warn before a chat-provider switch silently changes the embedding
+    // model out from under an existing index.
+    embeddingMeta: db.getEmbeddingMeta(),
   };
 }
 

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -336,7 +336,14 @@ interface SettingsData {
     locale?: StationLocale;
   };
   jingles?: JingleEntry[];
-  libraryStats?: { total?: number };
+  libraryStats?: {
+    total?: number;
+    withEmbedding?: number;
+    // Provenance of the text-embedding index: the model it was built with
+    // ("provider:model") and its vector dim. Null when the library was never
+    // embedded. Drives the chat-provider-switch warning in LlmSection.
+    embeddingMeta?: { model: string; dim: number } | null;
+  };
   tagger?: { running?: boolean };
   env?: Record<string, unknown>;
   streamOnAir?: boolean;
@@ -1906,6 +1913,36 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
   useEffect(() => { setCompatKeyInput(''); setCompatKeyTest(null); }, [form.llm.provider]);
   useEffect(() => { setCompatFallbackKeyInput(''); setCompatFallbackKeyTest(null); }, [form.llm.fallback.provider]);
 
+  // Embeddings inherit settings.llm by default (embedding.provider === ''), so
+  // switching the CHAT provider silently changes the EMBEDDING model too — which
+  // invalidates an already-embedded library and breaks vector search until a
+  // re-embed (#dimension-mismatch). When the library is embedded and embeddings
+  // are inheriting, pin them to the index's actual model on a provider switch and
+  // surface a notice so the operator understands what happened (and can opt to
+  // re-embed on the new provider instead).
+  const [embedPinNotice, setEmbedPinNotice] = useState<{ model: string; dim: number; newProvider: string } | null>(null);
+  const changeLlmProvider = (v: string) => {
+    if (v === form.llm.provider) return;
+    const inheriting = (form.embedding.provider ?? '') === '';
+    const meta = data.libraryStats?.embeddingMeta;
+    const pin = inheriting && !!meta?.model;
+    setForm(f => {
+      if (!f) return f;
+      const next = { ...f, llm: { ...f.llm, provider: v } };
+      if (pin && meta) {
+        // Stored as "provider:model" (e.g. "ollama:nomic-embed-text"); split on
+        // the FIRST colon so ollama tags with their own colon (bge-m3:latest)
+        // keep the tag intact in the model field.
+        const i = meta.model.indexOf(':');
+        const pinProvider = i > 0 ? meta.model.slice(0, i) : '';
+        const pinModel = i > 0 ? meta.model.slice(i + 1) : meta.model;
+        if (pinProvider) next.embedding = { ...f.embedding, provider: pinProvider, model: pinModel };
+      }
+      return next;
+    });
+    if (pin && meta) setEmbedPinNotice({ model: meta.model, dim: meta.dim, newProvider: v });
+  };
+
   const saveKey = async (envVar: string, value: string): Promise<boolean> => {
     if (!value.trim()) return true;
     try {
@@ -2070,7 +2107,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
             </div>
             <Select
               value={form.llm.provider}
-              onValueChange={v => setForm(f => ({ ...f, llm: { ...f.llm, provider: v } }))}
+              onValueChange={changeLlmProvider}
             >
               <SelectTrigger className="max-w-[360px]"><SelectValue /></SelectTrigger>
               <SelectContent>
@@ -2746,6 +2783,36 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
         busy={busy}
         onSave={save}
         saveLabel="Save LLM provider"
+      />
+
+      {/* Chat-provider switch would otherwise drag the inherited embedding model
+          with it and invalidate the already-embedded library. We pinned
+          embeddings to the index's model; this notice explains it and lets the
+          operator instead opt to re-embed on the new provider. The SAFE outcome
+          (keep the pin) is the default — only the explicit confirm switches. */}
+      <V3AlertDialog
+        open={embedPinNotice != null}
+        onOpenChange={(o) => { if (!o) setEmbedPinNotice(null); }}
+        title="Embeddings kept on your library's model"
+        description={embedPinNotice ? (
+          <>
+            Your library is embedded with <code>{embedPinNotice.model}</code> ({embedPinNotice.dim}-d
+            vectors). Embeddings were following the chat provider, so switching to{' '}
+            <strong>{llmProviderLabel(embedPinNotice.newProvider)}</strong> would have changed the
+            embedding model too — and a different model produces incompatible vectors, breaking
+            library / vibe search until you re-embed every track.
+            {' '}To keep search working, embeddings are now <strong>pinned</strong> to{' '}
+            <code>{embedPinNotice.model}</code> (Library tagger → Embedding). Switch embeddings to
+            the new provider instead? You’ll need to re-embed the whole library afterwards.
+          </>
+        ) : ''}
+        confirmLabel="switch embeddings too"
+        cancelLabel="keep pinned"
+        danger
+        onConfirm={() => {
+          setForm(f => (f ? { ...f, embedding: { ...f.embedding, provider: '', model: '' } } : f));
+          setEmbedPinNotice(null);
+        }}
       />
     </>
   );


### PR DESCRIPTION
## Problem

`djAgentPick` / `searchLibrary` started failing with:

```
{"error":"Dimension mismatch for query vector for the \"embedding\" column. Expected 768 dimensions but received 1536."}
```

Not a tool bug — **config drift from a chat-provider switch.** `settings.embedding.provider`/`model` blank means "inherit `settings.llm`". Switching the chat LLM from Ollama to OpenRouter silently changed the *embedding* model too:

| | Model | Dim |
|---|---|---|
| Library index (`state/library.db`) | `ollama:nomic-embed-text` | **768** |
| Live query embeddings (after switch) | `openrouter → openai/text-embedding-3-small` | **1536** |

The controller adopts the stored 768-d schema for reads, but the query-embed path follows live config — so `tracksByVector` threw a raw `Dimension mismatch` straight into the DJ agent.

## Changes

- **`controller/src/music/library.ts`**
  - `tracksByVector`: when the query vector dim no longer matches the index dim, **skip + log an actionable hint** instead of throwing, so the picker degrades to its other sources rather than erroring.
  - `stats()`: expose `embeddingMeta {model, dim}` (index provenance) for the UI.
- **`web/components/admin/SettingsPanel.tsx`**
  - Switching the chat provider while embeddings inherit **and** the library is embedded now **auto-pins** embeddings to the index's actual model and shows a confirm dialog explaining the chaining. Safe default = keep pinned; the explicit `danger` confirm switches embeddings (and warns a re-embed is required).

## Operational fix (already applied live, not in this diff)

The running station was restored by pinning `settings.embedding` to `ollama:nomic-embed-text` so query vectors are 768-d again (probe → `dim:768`). This PR prevents the footgun recurring.

## Testing

- `controller`: `npm run lint` — 0 errors (pre-existing warnings + unrelated missing-`multer` tsc errors only).
- `web`: `npm run lint` — 0 errors.