### PR TITLE
fix(sfx): align under-voice stingers with the DJ's first word

### DIFF
--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -490,8 +490,14 @@ class Queue {
   // Writes the effect's file path straight to sfx.txt — no TTS, the audio is
   // already rendered. Liquidsoap's sfx_queue mixes it beneath the voice
   // channels (see liquidsoap/radio.liq). Used by the segment-director agent
-  // to garnish a spoken line.
-  async playSfx(name: string) {
+  // to garnish a spoken line, and by applyMixTransition for between-track
+  // stingers.
+  //
+  // `underVoice` offsets the write by the voice lead-in (VOICE_LEADIN_MS) so a
+  // stinger meant to sit under a spoken line lands with the DJ's first word
+  // instead of during the channel's silent pre-roll. Transition stingers leave
+  // it false — they have no voice to align to and must fire at the crossfade.
+  async playSfx(name: string, { underVoice = false }: { underVoice?: boolean } = {}) {
     if (!name) return;
     try {
       const path = await sfx.getPath(name);
@@ -499,6 +505,7 @@ class Queue {
         this.log('error', `Unknown sound effect: ${name}`);
         return;
       }
+      if (underVoice) await sleep(VOICE_LEADIN_MS);
       await writeHandoff(config.liquidsoap.sfxFile, path);
       this.log('sfx', name);
       session.appendTurn({ role: 'segment', kind: 'sfx', text: name });

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -378,7 +378,7 @@ export async function agenticTick(ctx) {
     // unoffered kind.
     if (seg.sfx) {
       if (sfxCatalog.some(s => s.name === seg.sfx)) {
-        await queue.playSfx(seg.sfx);
+        await queue.playSfx(seg.sfx, { underVoice: true });
       } else {
         queue.log('error', `Segment agent picked unknown sfx "${seg.sfx}" — dropping`);
       }
@@ -513,7 +513,7 @@ export async function runCapability(which, ctx) {
   const pick = object?.sfx;
   if (pick) {
     if (sfxCatalog.some(s => s.name === pick)) {
-      await queue.playSfx(pick);
+      await queue.playSfx(pick, { underVoice: true });
     } else {
       queue.log('error', `Segment agent picked unknown sfx "${pick}" — dropping`);
     }


### PR DESCRIPTION
## What

Segment-director sound effects (the stingers the DJ agent plays under a spoken line) now line up with the DJ's **first word** instead of firing ~0.8s early.

## Why

SFX go through the same `sfx_queue` poll path as the voice channels, but — unlike `say.txt`/`intro.txt` — they get **no silent lead-in clip**. The voice channels push `sounds/leadin.wav` (0.8s of silence) ahead of every spoken file so the music duck completes before the DJ's first word. Because the controller writes `sfx.txt` at the same moment as `say.txt`, the stinger started ~0.8s **early**, during that silent pre-roll. Short effects (the 1.2–1.5s defaults) largely burned off before the DJ actually spoke.

## How

`queue.playSfx` gains an `underVoice` flag. When set, it delays the `sfx.txt` write by the existing `VOICE_LEADIN_MS` (0.8s) so the stinger lands with the first word.

- Both segment-director callers (`skills/_agent.ts`) pass `{ underVoice: true }`.
- The between-track **transition** stinger (`applyMixTransition` → `playSfx`) is left as-is — it has no voice to align to and must fire at the crossfade.

No Liquidsoap change needed: the fix stays in the controller and off the shared `poll_sfx` path, so transition stingers are untouched.

### Scope / known limitation

Fixes the systematic ~0.8s offset. The residual ±0.5s jitter from `poll_voice` and `poll_sfx` being independent 0.5s threads is unchanged — eliminating it would mean restructuring the pollers for a sub-half-second gain, not worth it here.

## Test

- `npm run lint` (controller: `eslint . && tsc --noEmit`) — 0 errors.
- Manual on-air verification of stinger placement still recommended (this is a code-level fix).
