### PR TITLE
fix(dj-agent): gate mid-run link guidance on wantLink

### DIFF
--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -483,8 +483,14 @@ export async function runTrackEvent(queue, ctx, { wantLink }) {
     // the next track, they TEASE it — name the artist or capture its feel so
     // listeners know what's coming. The agent already knows its own pick when
     // it writes `say`, so this costs nothing extra.
+    // The "nod to it in the link" half only makes sense when a link is actually
+    // being written — gate it on wantLink so a silent mid-run pick ("Stay silent
+    // — no link this time.") doesn't also get told it may phrase something in a
+    // link that won't exist. The energy-direction guidance is pick selection, so
+    // it stays unconditional.
     const runClause = inRun
-      ? ` You're mid-run — keep the energy moving in the same direction (a touch ${energyForDaypart().speed >= 1 ? 'brisker' : 'mellower'}) and you may nod to it in the link, but never say tempo numbers.`
+      ? ` You're mid-run — keep the energy moving in the same direction (a touch ${energyForDaypart().speed >= 1 ? 'brisker' : 'mellower'}).`
+        + (wantLink ? ' You may nod to it in the link, but never say tempo numbers.' : '')
       : '';
     // Gated on the waypoint itself, not inRun: on a run's final pick the run
     // state is already cleared (advanceRun) but the last waypoint — the


### PR DESCRIPTION
## What

Gate the mid-run `runClause`'s "you may nod to it in the link" half on `wantLink` in `broadcast/dj-agent.ts`.

## Why

The per-pick event message is assembled from independent clauses. `linkClause` and `runClause` could contradict each other on a **silent mid-run pick** (`wantLink === false` while a run is active):

> …Pick the track to play next. **Stay silent — no link this time.** You're mid-run — keep the energy moving in the same direction (a touch mellower) **and you may nod to it in the link**, but never say tempo numbers.

The agent is told to be silent *and* to phrase something "in the link" that won't exist. `runClause` referenced the link unconditionally on every mid-run pick, with no awareness of `wantLink`.

## Fix

Split `runClause`: the energy-direction guidance ("keep the energy moving, a touch mellower/brisker") stays unconditional since it's **pick-selection** advice; the link half ("you may nod to it in the link…") is now appended only when `wantLink` is true.

Resulting event text:
- **Silent mid-run pick** → "…Stay silent — no link this time. You're mid-run — keep the energy moving in the same direction (a touch mellower)." — no contradiction.
- **Mid-run pick with link** → unchanged.

## Checks

- `npm run lint` (controller) → 0 errors (pre-existing `any` warnings only)
- `tsc --noEmit` → clean
