### PR TITLE
fix(scheduler): respect active show genre/era/energy on the fallback playlist (#629)

### DIFF
--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -12,6 +12,7 @@ import * as dj from '../llm/dj.js';
 import * as library from '../music/library.js';
 import * as settings from '../settings.js';
 import { durationSeconds, artistKey } from '../music/recency.js';
+import { normGenre, genreMatches, inYearRange, preferEnergy } from '../music/show-filter.js';
 import { getFullContext } from '../context.js';
 import { queue } from './queue.js';
 import * as session from './session.js';
@@ -29,6 +30,12 @@ const RECENT_WEIGHT = 4;         // recently-added albums
 const FREQUENT_WEIGHT = 4;       // frequent / scrobble-favourite albums
 const STARRED_WEIGHT = 6;        // hand-starred tracks
 const AUTO_MAX_PER_ARTIST = 2;   // cap any one artist's share of the fallback pool
+// When a scheduled show pins a genre/era, a dedicated Navidrome-genre source
+// becomes the dominant pool contributor and the off-genre sources shrink by
+// SHOW_NARROW_FACTOR so the show's genre/era actually fills the fallback (#629).
+const SHOW_GENRE_WEIGHT = 14;        // dedicated show-genre source (soft lean)
+const SHOW_GENRE_STRICT_WEIGHT = 24; // strict: this source carries most of the pool
+const SHOW_NARROW_FACTOR = 0.5;      // shrink mood/playlist/recent/etc. for shows
 
 function shuffle<T>(arr: T[]): T[] {
   return [...arr].sort(() => Math.random() - 0.5);
@@ -61,13 +68,46 @@ async function refreshAutoPlaylistInner() {
   // Match the auto-DJ picker's window (dj-agent.pickViaAgent) — 12h.
   const recent = queue.recentlyPlayedIds(12);
 
-  // Station-level length cap (issue #447). The auto playlist is the coarse,
-  // slow-refreshing Liquidsoap fallback that airs whenever the live queue runs
-  // dry — show overrides don't apply here, so we use the station default only.
-  const maxDurationSec = settings.effectiveMaxTrackSec(null);
+  // The fallback is what airs when the live AI picks pause (e.g. pause-when-empty
+  // with zero listeners). When a show is scheduled for this hour, the fallback
+  // should stay on-brand exactly as the picker does — so we steer the pool by the
+  // active show's genre / era / energy, mirroring music/picker.ts (issue #629).
+  const show: any = settings.resolveActiveShow();
+  const showGenre: string = show?.genre || '';
+  const fromYear: number | null = show?.fromYear ?? null;
+  const toYear: number | null = show?.toYear ?? null;
+  const showEnergy: string = show?.energy || '';
+  // A genre or a year window narrows the pool; energy alone only soft-leans
+  // (mirrors picker.hasMusicFilter). Strict opts the GENRE into a hard filter.
+  const narrow = !!(show && (showGenre || fromYear != null || toYear != null));
+  const strict = !!(show?.genreStrict && showGenre);
+
+  // Resolve the show's free-text genre to the library's exact tag once, up front.
+  // A resolution failure / absent genre leaves genreName null, which disables the
+  // strict hard-filter and the genre-targeted fetches — the documented degrade
+  // path (a misspelled / library-absent genre falls back to the normal pool).
+  let genreName: string | null = null;
+  if (showGenre) {
+    try { genreName = await subsonic.resolveGenreName(showGenre); } catch {}
+  }
+  const strictGenreNorm = strict && genreName ? normGenre(genreName) : null;
+  // Strict: hard-drop off-genre tracks from every discovery source (even if that
+  // empties the source) — the auto playlist airs in full with no LLM gatekeeper,
+  // so never-starve off-genre filler would actually play. The dedicated genre
+  // source + genre-targeted random carry the pool; an unresolved genre disables
+  // this (genreName null → no filter). Soft mode is a no-op here.
+  const enforce = (items: any[]) =>
+    strictGenreNorm ? items.filter((t: any) => genreMatches(t, strictGenreNorm)) : items;
+  // Shrink the off-genre sources so the dedicated show-genre source dominates.
+  const nz = (cap: number) => (narrow ? Math.max(2, Math.ceil(cap * SHOW_NARROW_FACTOR)) : cap);
+
+  // Length cap: the active show's override or the station default (issue #447),
+  // resolved in seconds. null = no cap. Now that the fallback honours the show's
+  // genre/era it honours its track-length cap too.
+  const maxDurationSec = settings.effectiveMaxTrackSec(show);
 
   const pool: any[] = [];
-  const fromSource: Record<string, number> = { mood: 0, playlist: 0, recent: 0, frequent: 0, starred: 0, random: 0 };
+  const fromSource: Record<string, number> = { 'show-genre': 0, mood: 0, playlist: 0, recent: 0, frequent: 0, starred: 0, random: 0 };
   // Cap each artist's share of the pool. Without this, a deep-catalogue artist
   // (many mood-tagged / starred / frequent tracks) can dominate the fallback
   // playlist, so whenever Liquidsoap coasts on auto.m3u the same artist clusters
@@ -85,16 +125,43 @@ async function refreshAutoPlaylistInner() {
         if (d != null && d > maxDurationSec) continue;
       }
       pool.push({ ...t, _source: label });
-      fromSource[label]++;
+      fromSource[label] = (fromSource[label] || 0) + 1;
       if (ak) artistInPool.set(ak, (artistInPool.get(ak) || 0) + 1);
       n++;
     }
   };
 
-  // 1. Mood-tagged from the LLM-built library (only if tagger has run).
   await library.load();
+
+  // 0. Dedicated show-genre / era source — the dominant contributor whenever a
+  // show pins a genre or a year window. Both Navidrome queries filter server-side,
+  // so this source is inherently genre/era-pure (no never-starve pollution). Soft
+  // energy lean on top. Placed first so genre-native tracks fill the pool before
+  // the (shrunk) discovery sources add variety.
+  if (narrow) {
+    try {
+      const collected: any[] = [];
+      collected.push(...await subsonic.getRandomSongs({
+        size: strict ? 60 : 40,
+        genre: genreName || undefined,
+        fromYear: fromYear ?? undefined,
+        toYear: toYear ?? undefined,
+      }));
+      if (genreName) {
+        const g = await subsonic.getSongsByGenre(genreName, { count: strict ? 100 : 60 });
+        const ranged = inYearRange(g, { fromYear, toYear });
+        collected.push(...(ranged.length ? ranged : g));
+      }
+      const leaned = preferEnergy(collected, showEnergy);
+      take('show-genre', shuffle(leaned), strict ? SHOW_GENRE_STRICT_WEIGHT : SHOW_GENRE_WEIGHT);
+    } catch (err) {
+      queue.log('error', `Show-genre fetch failed: ${err.message}`);
+    }
+  }
+
+  // 1. Mood-tagged from the LLM-built library (only if tagger has run).
   if (mood) {
-    take('mood', shuffle(library.songsByMood(mood)), MOOD_WEIGHT);
+    take('mood', enforce(shuffle(preferEnergy(library.songsByMood(mood), showEnergy))), nz(MOOD_WEIGHT));
   }
 
   // 2. Navidrome playlists whose name matches the mood — operator's hand curation.
@@ -109,7 +176,7 @@ async function refreshAutoPlaylistInner() {
           tracks.push(...songs);
         } catch {}
       }
-      take('playlist', shuffle(tracks), PLAYLIST_WEIGHT);
+      take('playlist', enforce(shuffle(tracks)), nz(PLAYLIST_WEIGHT));
     } catch (err) {
       queue.log('error', `Playlist fetch failed: ${err.message}`);
     }
@@ -119,7 +186,7 @@ async function refreshAutoPlaylistInner() {
   try {
     const recentAlbums = await subsonic.getRecentlyAddedAlbums({ size: 8 });
     const tracks = await tracksFromAlbums(shuffle(recentAlbums).slice(0, 4), 2, RECENT_WEIGHT * 2);
-    take('recent', tracks, RECENT_WEIGHT);
+    take('recent', enforce(tracks), nz(RECENT_WEIGHT));
   } catch (err) {
     queue.log('error', `Recent-albums fetch failed: ${err.message}`);
   }
@@ -128,7 +195,7 @@ async function refreshAutoPlaylistInner() {
   try {
     const freqAlbums = await subsonic.getFrequentAlbums({ size: 8 });
     const tracks = await tracksFromAlbums(shuffle(freqAlbums).slice(0, 4), 2, FREQUENT_WEIGHT * 2);
-    take('frequent', tracks, FREQUENT_WEIGHT);
+    take('frequent', enforce(tracks), nz(FREQUENT_WEIGHT));
   } catch (err) {
     queue.log('error', `Frequent-albums fetch failed: ${err.message}`);
   }
@@ -136,27 +203,54 @@ async function refreshAutoPlaylistInner() {
   // 5. Starred — hand-curated.
   try {
     const starred = shuffle(await subsonic.getStarred());
-    take('starred', starred, STARRED_WEIGHT);
+    take('starred', enforce(starred), nz(STARRED_WEIGHT));
   } catch (err) {
     queue.log('error', `Starred fetch failed: ${err.message}`);
   }
 
-  // 6. Top up with random to TARGET_POOL.
+  // 6. Top up with random to TARGET_POOL. For a show, bias the fill toward its
+  // genre/era (Navidrome filters server-side, so it stays pure).
   if (pool.length < TARGET_POOL) {
     try {
-      const random = await subsonic.getRandomSongs({ size: TARGET_POOL });
-      take('random', random, TARGET_POOL);
+      const random = narrow
+        ? await subsonic.getRandomSongs({ size: TARGET_POOL, genre: genreName || undefined, fromYear: fromYear ?? undefined, toYear: toYear ?? undefined })
+        : await subsonic.getRandomSongs({ size: TARGET_POOL });
+      take('random', shuffle(random), TARGET_POOL);
     } catch (err) {
       queue.log('error', `Random fetch failed: ${err.message}`);
+    }
+    // Soft shows: if the genre/era-biased fill couldn't reach TARGET_POOL,
+    // never-starve with unfiltered random (variety over purity). Strict shows
+    // skip this — better a short, looping in-genre playlist than off-genre filler.
+    if (narrow && !strict && pool.length < TARGET_POOL) {
+      try {
+        take('random', shuffle(await subsonic.getRandomSongs({ size: TARGET_POOL })), TARGET_POOL);
+      } catch {}
     }
   }
 
   const lines = ['#EXTM3U', ...pool.map((t: any) => subsonic.getAnnotatedUri(t))];
   await writeFile(config.liquidsoap.autoPlaylist, lines.join('\n'));
+
+  // Make the show-scoping visible to the operator (acceptance criteria #629):
+  // a misspelled / absent strict genre that silently degraded, and a strict show
+  // whose genre is too thin to fill the pool, are both worth surfacing.
+  if (strict && !genreName) {
+    queue.log('scheduler', `Auto-playlist: strict genre "${showGenre}" not found in library — fallback left unfiltered`);
+  } else if (strict && genreName && pool.length < TARGET_POOL) {
+    queue.log('scheduler', `Auto-playlist: only ${pool.length} in-genre tracks for ${genreName} — looping a short genre-pure fallback`);
+  }
+
+  const showInfo = show
+    ? `, show=${show.name}` +
+      (showGenre ? ` genre=${genreName || showGenre} (${strict ? 'strict' : 'soft'})` : '') +
+      (fromYear != null || toYear != null ? ` year=${fromYear ?? ''}-${toYear ?? ''}` : '') +
+      (showEnergy ? ` energy=${showEnergy}` : '')
+    : '';
   queue.log('scheduler',
     `Auto-playlist refreshed: ${pool.length} tracks (` +
     Object.entries(fromSource).filter(([, v]) => v > 0).map(([k, v]) => `${k}=${v}`).join(' ') +
-    `, mood=${mood || 'none'})`);
+    `, mood=${mood || 'none'}${showInfo})`);
 }
 
 // ---------------------------------------------------------------------------

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -12,7 +12,7 @@ import * as dj from '../llm/dj.js';
 import * as settings from '../settings.js';
 import { bpmCompat, keyCompat } from './mix.js';
 import { filterPickerCandidates, recencyWindowsForLibrary } from './recency.js';
-import { normGenre, genreMatches, preferGenre, inYearRange } from './show-filter.js';
+import { normGenre, genreMatches, preferGenre, inYearRange, preferEnergy } from './show-filter.js';
 
 const CANDIDATE_CAP = 18;
 const HISTORY_DEPTH = 4;
@@ -107,32 +107,11 @@ function hasMusicFilter(f: ShowFilter): boolean {
   return !!f && (!!f.genre || f.fromYear != null || f.toYear != null);
 }
 
-// Genre-matching helpers (normGenre / genreMatches / preferGenre) live in
-// ./show-filter.js — shared with the agent picker's discovery tools so both
-// paths agree on what "in-genre" means.
-
-// Per-track energy band — from the track itself (library sources carry it) or a
-// library lookup (Subsonic sources don't). null when un-analysed.
-function trackEnergy(t: any): string | null {
-  if (t?.energy) return t.energy;
-  const rec = t?.id ? library.get(t.id) : null;
-  return rec?.energy ?? null;
-}
-
-// inYearRange (decade window) lives in ./show-filter.js — shared with the agent
-// picker's discovery tools so both paths agree on what "in-era" means. Caller
-// here keeps its own never-starve fallback (the in-range-or-full pattern below).
-
-// Soft-prefer tracks matching the show's energy band; unknown-energy tracks
-// stay eligible. Falls back to the full set when no track matches.
-function preferEnergy(tracks: any[], energy?: string): any[] {
-  if (!energy) return tracks;
-  const match = tracks.filter((t: any) => {
-    const e = trackEnergy(t);
-    return e == null || e === energy;
-  });
-  return match.length ? match : tracks;
-}
+// Genre / energy / era helpers (normGenre / genreMatches / preferGenre /
+// preferEnergy / inYearRange) live in ./show-filter.js — shared with the agent
+// picker's discovery tools so every path agrees on what "in-genre" / "in-era" /
+// "in-energy" means. Caller here keeps its own never-starve fallback for the
+// year window (the in-range-or-full pattern below).
 
 function notRecent(recentIds: Set<string>) {
   return (t: any) => t && t.id && !recentIds.has(t.id);

--- a/controller/src/music/show-filter.ts
+++ b/controller/src/music/show-filter.ts
@@ -71,3 +71,25 @@ export function preferEra(tracks: any[], f: YearRange): any[] {
   const match = inYearRange(tracks, f);
   return match.length ? match : tracks;
 }
+
+// ── Energy band ──────────────────────────────────────────────────────────────
+
+// Per-track energy band — from the track itself (library sources carry it) or a
+// library lookup (Subsonic sources don't). null when un-analysed.
+export function trackEnergy(t: any): string | null {
+  if (t?.energy) return t.energy;
+  const rec = t?.id ? library.get(t.id) : null;
+  return rec?.energy ?? null;
+}
+
+// Soft-prefer tracks matching the show's energy band; unknown-energy tracks
+// stay eligible. Falls back to the full set when no track matches (never-starve,
+// mirrors preferEra). Energy stays soft even when the show's genre is strict.
+export function preferEnergy(tracks: any[], energy?: string | null): any[] {
+  if (!energy) return tracks;
+  const match = tracks.filter((t: any) => {
+    const e = trackEnergy(t);
+    return e == null || e === energy;
+  });
+  return match.length ? match : tracks;
+}


### PR DESCRIPTION
Closes #629.

## Problem

When `pauseWhenEmpty` silences the AI picks (0 listeners), Liquidsoap coasts on `auto.m3u`. That fallback was built from dominant **mood + random only**, so a strict hip-hop hour could air country during empty hours — and a few off-genre tracks still played on re-entry. The show's `genre` / `genreStrict` / year range / `energy` only steered the **picker** (`music/picker.ts`), never the fallback playlist.

## Fix

`refreshAutoPlaylist` now steers the fallback by the active show the same way the picker does, reusing the shared `music/show-filter.ts` helpers:

- **Dedicated genre/era source** (`getSongsByGenre` + genre/year-param `getRandomSongs`) becomes the dominant pool contributor — inherently genre/era-pure (Navidrome filters server-side), with a soft energy lean on top.
- **Strict genre:** every discovery source (mood/playlist/recent/frequent/starred) is hard-filtered to the resolved genre and the unfiltered random top-up is skipped, so the playlist stays genre-pure. A thin genre loops a short in-genre playlist rather than airing off-genre filler. An unresolved / library-absent genre degrades to the unfiltered pool **and logs it** (documented degrade path).
- **Soft genre/era:** the show-genre source dominates and the off-genre sources shrink by `SHOW_NARROW_FACTOR`, so the fallback is visibly genre-biased while keeping variety.
- **No scheduled show:** behaviour unchanged.
- The fallback now also honours the show's track-length cap, and logs the show scoping (`show=… genre=… (strict|soft) year=… energy=…`).

Consolidates the energy lean (`trackEnergy` / `preferEnergy`) into the shared `show-filter.ts` so the picker and the fallback agree on "in-energy".

## Verification

- `tsc --noEmit` clean; eslint 0 errors.
- `picker-recency-regression` + `listeners-status` tests pass. (The 2 `showMusicLean` failures are pre-existing on develop — a stale regex vs. a reworded prompt — and untouched by this change.)
- **Live run** against a real Navidrome (~3,084 Hip-Hop tracks), driving the real `refreshAutoPlaylist` with an injected strict-genre show:

  | Scenario | In-genre | Source mix |
  |---|---|---|
  | Baseline (no genre) | 33% | `mood=12 recent=4 frequent=4 starred=6 random=4` |
  | Soft Hip-Hop | 73% | `show-genre=14 mood=6 recent=2 frequent=2 starred=3 random=3` |
  | Strict Hip-Hop | 100% (30/30) | `show-genre=24 mood=6` |

## Acceptance criteria

- [x] Strict genre-strict show + pause-when-empty → `auto.m3u` only in-genre (or documented degrade when the genre tag is missing).
- [x] Soft genre lean → fallback visibly biased toward the genre, not mood-only + random.
- [x] No scheduled show → behaviour unchanged.
- [x] Time-to-first on-genre pick after listeners return not worse than today — improved, since pre-pick fallback tracks are now on-genre.
- [x] Operator log distinguishes show-scoped fallback (source `show-genre`, show/genre/strictness in the refresh log).

The optional "force an AI pick on listeners 0→1+" item is left as a follow-up — it lives in a different gating path (`listeners.ts` / `queue.ts`).