### PR TITLE
fix(request): dedup concurrent listener requests for the same track (#619)

### DIFF
--- a/controller/package.json
+++ b/controller/package.json
@@ -11,7 +11,7 @@
     "lastfm-session": "tsx scripts/lastfm-session.ts",
     "test:embed": "tsx scripts/embedding-preflight-test.ts",
     "test:llm": "tsx scripts/llm-pure.test.ts",
-    "test": "tsx scripts/llm-pure.test.ts && tsx scripts/picker-recency-regression.ts && tsx scripts/listeners-status.test.ts && tsx scripts/lastfm-enrich.test.ts && tsx scripts/web-search-searxng.test.ts",
+    "test": "tsx scripts/llm-pure.test.ts && tsx scripts/picker-recency-regression.ts && tsx scripts/listeners-status.test.ts && tsx scripts/lastfm-enrich.test.ts && tsx scripts/web-search-searxng.test.ts && tsx scripts/request-dedup.test.ts",
     "lint": "eslint . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit"

--- a/controller/scripts/request-dedup.test.ts
+++ b/controller/scripts/request-dedup.test.ts
@@ -1,0 +1,123 @@
+// Regression test for the queue dedup guard (issue #619 + the #538 guarantee).
+// Run: `tsx scripts/request-dedup.test.ts`.
+//
+// #538 scoped queue.push()'s dedup to aiPicked picks so listener requests
+// never got a silent drop. #619 showed two concurrent listener requests
+// resolving to the same song over the slow identify/match window both reach
+// push() and queue the track twice (back-to-back replay), because each read
+// queuedIds() before the other inserted. The fix broadens the guard to all
+// pushes (atomic check-and-insert in push() — no await between the .some()
+// test and upcoming.push()), with an allowDuplicate opt-out for explicit
+// operator actions. These asserts pin every branch of that behaviour.
+//
+// node:assert-via-tsx style, matching scripts/picker-recency-regression.ts.
+
+import assert from 'node:assert/strict';
+import { queue } from '../src/broadcast/queue.js';
+
+// Neutralise the real side effects of push(): persist() debounces a JSON write
+// and drainToLiquidsoap() renders TTS + writes the handoff file Liquidsoap
+// polls. Neither is part of the dedup contract under test, and both would
+// touch disk / block on a poll timeout in a bare test process.
+(queue as any).persist = () => {};
+(queue as any).drainToLiquidsoap = async () => {};
+
+function reset() {
+  queue.upcoming = [];
+  queue.current = null;
+}
+
+const trackX = { id: 'song-X', title: 'Track X', artist: 'Artist X' };
+const trackY = { id: 'song-Y', title: 'Track Y', artist: 'Artist Y' };
+
+let failures = 0;
+async function test(name: string, fn: () => void | Promise<void>) {
+  try {
+    reset();
+    await fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err: any) {
+    failures++;
+    console.error(`  ✗ ${name}\n      ${err?.message || err}`);
+  }
+}
+
+async function main() {
+  console.log('queue dedup guard (#619 / #538):');
+
+  await test('two CONCURRENT listener requests for the same track → one queued, second deduped (#619)', async () => {
+    // Fire both pushes "in parallel". push() runs its critical section
+    // synchronously to the return, so the second observes the first's insert.
+    const [a, b] = await Promise.all([
+      queue.push({ track: trackX, requestedBy: 'alice' }),
+      queue.push({ track: trackX, requestedBy: 'bob' }),
+    ]);
+    assert.equal(a, 1, 'first request should queue at position 1');
+    assert.equal(b, -1, 'second request should be deduped (-1)');
+    assert.equal(queue.upcoming.length, 1, 'only one copy should be in the queue');
+  });
+
+  await test('sequential listener requests for the same track also dedup', async () => {
+    const a = await queue.push({ track: trackX, requestedBy: 'alice' });
+    const b = await queue.push({ track: trackX, requestedBy: 'bob' });
+    assert.equal(a, 1);
+    assert.equal(b, -1);
+    assert.equal(queue.upcoming.length, 1);
+  });
+
+  await test('a request for the CURRENTLY-PLAYING track is deduped', async () => {
+    queue.current = { track: trackX };
+    const b = await queue.push({ track: trackX, requestedBy: 'bob' });
+    assert.equal(b, -1, 'requesting the on-air track should dedup');
+    assert.equal(queue.upcoming.length, 0);
+  });
+
+  await test('distinct tracks are NOT deduped', async () => {
+    const a = await queue.push({ track: trackX, requestedBy: 'alice' });
+    const b = await queue.push({ track: trackY, requestedBy: 'bob' });
+    assert.equal(a, 1);
+    assert.equal(b, 2);
+    assert.equal(queue.upcoming.length, 2);
+  });
+
+  await test('allowDuplicate (operator studio queue-track) bypasses the guard', async () => {
+    const a = await queue.push({ track: trackX, requestedBy: 'studio' });
+    const b = await queue.push({ track: trackX, requestedBy: 'studio', allowDuplicate: true });
+    assert.equal(a, 1);
+    assert.equal(b, 2, 'explicit operator action should always queue');
+    assert.equal(queue.upcoming.length, 2);
+  });
+
+  await test('aiPicked picks are still deduped (#538 unchanged)', async () => {
+    const a = await queue.push({ track: trackX, aiPicked: true });
+    const b = await queue.push({ track: trackX, aiPicked: true });
+    assert.equal(a, 1);
+    assert.equal(b, -1);
+  });
+
+  await test('a track with no id is never deduped (guard requires track.id)', async () => {
+    const noId = { title: 'No Id', artist: 'Anon' };
+    const a = await queue.push({ track: noId, requestedBy: 'alice' });
+    const b = await queue.push({ track: noId, requestedBy: 'bob' });
+    assert.equal(a, 1);
+    assert.equal(b, 2, 'without an id there is nothing to match on — both queue');
+  });
+
+  await test('dedupAck distinguishes on-air from already-queued', async () => {
+    queue.current = { track: trackX };
+    queue.upcoming = [{ track: trackY }];
+    const onAir = queue.dedupAck('song-X');
+    const queued = queue.dedupAck('song-Y');
+    assert.match(onAir, /spinning right now/i, 'on-air track should read as playing now');
+    assert.match(queued, /already queued|on the way/i, 'queued track should read as on the way');
+  });
+
+  if (failures > 0) {
+    console.error(`\n${failures} test(s) failed`);
+    process.exit(1);
+  }
+  console.log('\nall request-dedup tests passed');
+  process.exit(0);
+}
+
+void main();

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -597,13 +597,26 @@ async function runRequestViaAgent(queue: any, { requester }: { requester: string
     }
 
     const intro = typeof object.intro === 'string' ? object.intro.trim() : '';
-    await queue.push({
+    const pos = await queue.push({
       track: trackFields(song),
       requestedBy: requester,
       intent: 'listener request',
       introScript: intro || null,
       introKind: 'dj-speak',
     });
+    // A concurrent request already queued this exact track — push() deduped it
+    // (#619). Acknowledge honestly (no second back-to-back play, no false
+    // "coming up", no intro to air) and still append the line as the session
+    // reply so the request event isn't left without one.
+    if (pos === -1) {
+      const ack = queue.dedupAck(song.id);
+      session.appendTurn({
+        role: 'dj', kind: 'request',
+        text: ack,
+        meta: { trackId: song.id, requester, toolCalls },
+      });
+      return { ack, track: { title: song.title, artist: song.artist, id: song.id }, introScript: null };
+    }
     session.appendTurn({
       role: 'dj', kind: 'request',
       text: intro || object.ack || `Queued "${song.title}".`,

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -277,15 +277,26 @@ class Queue {
   // `introKind` picks both the TTS engine routing and the duck channel:
   //   'dj-speak' → say.txt   (HEAVY duck — request intros)
   //   'link'     → intro.txt (LIGHT duck — between-track auto-DJ links)
-  async push({ track, requestedBy = null, intent = null, introScript = null, introKind = 'dj-speak', aiPicked = false }: {
+  async push({ track, requestedBy = null, intent = null, introScript = null, introKind = 'dj-speak', aiPicked = false, allowDuplicate = false }: {
     track: any;
     requestedBy?: string | null;
     intent?: string | null;
     introScript?: string | null;
     introKind?: string;
     aiPicked?: boolean;
+    allowDuplicate?: boolean;
   }) {
-    if (aiPicked && track?.id) {
+    // Dedup guard. Applies to AI picks AND listener requests: two listener
+    // requests resolving to the same song over the 25-45s identify/match window
+    // each read queuedIds() before either reaches push(), so the early read
+    // can't see the other (issue #619). This check is the only synchronous
+    // point where both are visible — there is no await between it and the
+    // upcoming.push() below, so within the single-threaded event loop it's
+    // atomic and closes the race. Returns -1 so the caller can acknowledge
+    // honestly ("already on the way") instead of queuing a second back-to-back
+    // play. `allowDuplicate` opts an explicit operator action (the studio
+    // queue-track route) out — a deliberate manual queue always fires.
+    if (!allowDuplicate && track?.id) {
       const dominated = this.upcoming.some(i => i.track?.id === track.id)
         || (this.current?.track?.id === track.id);
       if (dominated) {
@@ -728,6 +739,18 @@ class Queue {
       if (item.track?.id) ids.add(item.track.id);
     }
     return ids;
+  }
+
+  // Honest acknowledgement for a listener request whose resolved track is
+  // already queued or on air — used when push() dedups the request (issue
+  // #619). Lets the caller send a truthful line instead of a false "coming up"
+  // or a phantom second back-to-back play. Distinguishes the on-air case so the
+  // listener isn't told something is "on the way" when it's playing right now.
+  dedupAck(trackId: string | null | undefined): string {
+    const onAir = !!trackId && this.current?.track?.id === trackId;
+    return onAir
+      ? `That one's spinning right now — stay tuned.`
+      : `That track's already queued — it's on the way.`;
   }
 
   // Lowercased artist names heard in the last `hours` hours — used by the

--- a/controller/src/routes/dj.ts
+++ b/controller/src/routes/dj.ts
@@ -360,7 +360,9 @@ router.post('/dj/queue-track', requireAdmin, async (req, res) => {
     return res.status(400).json({ error: 'id and title are required' });
   }
   try {
-    const queuePosition = await queue.push({ track, requestedBy: 'studio' });
+    // Explicit operator action — bypass the request/AI dedup guard (#619) so a
+    // deliberate manual queue always fires, even for an already-queued track.
+    const queuePosition = await queue.push({ track, requestedBy: 'studio', allowDuplicate: true });
     res.json({
       ok: true,
       track: { title: track.title, artist: track.artist || null },

--- a/controller/src/routes/request.ts
+++ b/controller/src/routes/request.ts
@@ -274,16 +274,24 @@ async function resolveRequest(entry) {
       recentTracks: queue.getRecentTracks(),
       recentOpeners: queue.getRecentOpeners(),
     });
-    await queue.push({
+    const pos = await queue.push({
       track: pick, requestedBy: requester, intent: 'more_like_this', introScript,
       introKind: 'dj-speak',
     });
+    entry.pick = pick;
+    if (pos === -1) {
+      // A concurrent request already queued this exact track — acknowledge
+      // honestly instead of airing a second intro over a phantom replay (#619).
+      const dupAck = queue.dedupAck(pick.id);
+      entry.pickSource = `${entry.pickSource}:already-queued`;
+      session.appendTurn({ role: 'dj', kind: 'request', text: dupAck, meta: { trackId: pick.id, requester } });
+      return resolved({ ack: dupAck, track: { title: pick.title, artist: pick.artist }, queuePosition: null });
+    }
     session.appendTurn({
       role: 'dj', kind: 'request',
       text: introScript || ackLine,
       meta: { trackId: pick.id, requester },
     });
-    entry.pick = pick;
     entry.introScript = introScript || null;
     return resolved({
       ack: ackLine,
@@ -539,21 +547,29 @@ async function resolveRequest(entry) {
     recentOpeners: queue.getRecentOpeners(),
   });
 
-  // 4. Add to queue (will trigger Liquidsoap via the queue manager)
-  await queue.push({
+  // 4. Add to queue (will trigger Liquidsoap via the queue manager). A
+  // concurrent request that already queued this exact track makes push() dedup
+  // it (#619) — acknowledge honestly rather than pretending it's freshly queued.
+  const pos = await queue.push({
     track: pick,
     requestedBy: requester,
     intent: matched.intent,
     introScript,
     introKind: 'dj-speak',
   });
+  entry.pick = pick;
+  if (pos === -1) {
+    const dupAck = queue.dedupAck(pick.id);
+    entry.pickSource = `${pickSource}:already-queued`;
+    session.appendTurn({ role: 'dj', kind: 'request', text: dupAck, meta: { trackId: pick.id, requester } });
+    return resolved({ ack: dupAck, track: { title: pick.title, artist: pick.artist }, queuePosition: null });
+  }
   session.appendTurn({
     role: 'dj', kind: 'request',
     text: introScript || ack || `Queued "${pick.title}".`,
     meta: { trackId: pick.id, requester },
   });
 
-  entry.pick = pick;
   entry.pickSource = pickSource;
   entry.introScript = introScript || null;
   return resolved({


### PR DESCRIPTION
Closes #619.

Huge thanks to @geekylakshya for the precise root-cause write-up — the report nailed exactly where and why this slips through, which made the fix straightforward. (You offered to implement it; I had a window so I took it on, but the analysis was all yours. 🙏)

## The bug

Two listener requests submitted in quick succession that resolve to the **same** song both get queued and play back-to-back. The request pipeline can take 25–45s (web search → `identifyRequestedTrack` → library match), and during that window each request reads `queuedIds()` before the other reaches `queue.push()`, so neither sees the other.

The `queue.push()` dedup guard added in #538 was deliberately scoped to `aiPicked` picks only (to avoid acknowledging a human request with "coming up" and then silently dropping it), so listener requests skipped the guard entirely.

## The fix

Broaden the guard to cover listener requests too. The key is **where** the check happens: `push()`'s check-and-insert has no `await` between the `upcoming.some()` test and `upcoming.push()`, so on the single-threaded event loop it runs atomically — the second request now observes the first already queued and gets the `-1` sentinel. This closes the race that the early `queuedIds()` reads structurally cannot.

To preserve #538's guarantee (a listener is never told "coming up" and then silently dropped), the three request paths — `more-like-this`, the stateless cascade, and the session agent — turn `-1` into an **honest acknowledgement** via a new `queue.dedupAck()`:
- *"That one's spinning right now — stay tuned."* (the track is on air)
- *"That track's already queued — it's on the way."* (already upcoming)

instead of a phantom second play. An explicit operator action (the studio `queue-track` route) opts out with `allowDuplicate: true`, matching the codebase's "an explicit operator action always fires" principle.

## Files

- `controller/src/broadcast/queue.ts` — broadened guard + `allowDuplicate` opt-out + `dedupAck()` helper
- `controller/src/routes/request.ts` — honest ack on `-1` for `more-like-this` and the stateless cascade
- `controller/src/broadcast/dj-agent.ts` — honest ack on `-1` for the session request agent
- `controller/src/routes/dj.ts` — operator studio queue passes `allowDuplicate: true`

## Tests

New `controller/scripts/request-dedup.test.ts` drives the real `queue.push()` and pins every branch: the concurrent-request race, dedup against the on-air track, distinct tracks untouched, the operator bypass, `aiPicked` still deduped (#538 preserved), no-id tracks never deduped, and the `dedupAck` phrasing. 8/8 pass; wired into `npm test`.

`npm run lint` (eslint + `tsc --noEmit`) is clean.