### PR TITLE
fix(queue): replace _autoMisses heuristic with Liquidsoap telnet sync…

### DIFF
--- a/controller/src/broadcast/liquidsoap-control.ts
+++ b/controller/src/broadcast/liquidsoap-control.ts
@@ -120,8 +120,8 @@ export async function getDjQueueIds(): Promise<Set<string>> {
           if (match && match[1]) {
             subsonicIds.add(match[1]);
           }
-        } catch {
-          // Per-RID errors swallowed (RID may be consumed/played between calls)
+        } catch (ridErr: any) {
+          console.warn(`[liquidsoap] request.metadata ${rid} failed: ${ridErr.message}`);
         }
       }
 

--- a/controller/src/broadcast/liquidsoap-control.ts
+++ b/controller/src/broadcast/liquidsoap-control.ts
@@ -87,3 +87,59 @@ export async function streamStatus() {
   const res = await sendCommand('stream_status', 2000);
   return /\bon\b/i.test(res);
 }
+
+interface DjQueueCache {
+  timestamp: number;
+  ids: Set<string>;
+}
+let _djQueueCache: DjQueueCache | null = null;
+let _djQueueInflight: Promise<Set<string>> | null = null;
+
+// Query Liquidsoap's dj_queue using two telnet hops:
+// 1. dj_queue.queue returns space-separated request IDs.
+// 2. request.metadata <rid> returns metadata for each request ID.
+// Returns a Set of subsonic_ids currently in the queue.
+export async function getDjQueueIds(): Promise<Set<string>> {
+  if (_djQueueCache && Date.now() - _djQueueCache.timestamp < 4000) {
+    return _djQueueCache.ids;
+  }
+  if (_djQueueInflight) {
+    return _djQueueInflight;
+  }
+
+  _djQueueInflight = (async () => {
+    try {
+      const res = await sendCommand('dj_queue.queue', 2000);
+      const rids = res.trim().split(/\s+/).filter(Boolean);
+      const subsonicIds = new Set<string>();
+
+      for (const rid of rids) {
+        try {
+          const meta = await sendCommand(`request.metadata ${rid}`, 2000);
+          const match = /^subsonic_id="([^"]*)"/m.exec(meta);
+          if (match && match[1]) {
+            subsonicIds.add(match[1]);
+          }
+        } catch {
+          // Per-RID errors swallowed (RID may be consumed/played between calls)
+        }
+      }
+
+      const ids = subsonicIds;
+      _djQueueCache = {
+        timestamp: Date.now(),
+        ids
+      };
+      return ids;
+    } finally {
+      _djQueueInflight = null;
+    }
+  })();
+
+  return _djQueueInflight;
+}
+
+export function invalidateDjQueueCache() {
+  _djQueueCache = null;
+}
+

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -19,6 +19,7 @@ import { logEvent } from '../observability/events.js';
 import { djCallsAllowed } from './listeners.js';
 import * as webhooks from './webhooks.js';
 import * as scrobble from './scrobble.js';
+import * as liquidsoapControl from './liquidsoap-control.js';
 
 // Random gap between DJ links on auto-played tracks. The frequency setting
 // scales how chatty the DJ is:
@@ -85,7 +86,6 @@ class Queue {
   _persistTimer: NodeJS.Timeout | null = null; // debounce for the queue.json snapshot
   _recentPlaysTimer: NodeJS.Timeout | null = null; // debounce for the recent-plays.json sidecar
   _recentPlays: { id: string | null; title: string | null; artist: string | null; endedAt: string }[] = [];
-  _autoMisses = 0;             // consecutive untracked plays — see onTrackStarted
 
   // Snapshot upcoming/current/history to disk. The queue is otherwise purely
   // in-memory, so a controller restart (every `--build controller` rebuild)
@@ -628,7 +628,6 @@ class Queue {
       const source = item.aiPicked ? 'ai' : 'request';
       this.current = { ...item, startedAt: new Date().toISOString(), source };
       this.log('playing', `${np.title} — ${np.artist}`, { requestedBy: item.requestedBy, source });
-      this._autoMisses = 0;
       // Air this track's intro/link now that it's actually on-air — deferred
       // from queue time so the voice lands over the right song (#189). Fire-
       // and-forget: airIntro's writeHandoff can block up to maxWaitMs and must
@@ -637,17 +636,11 @@ class Queue {
       void this.airIntro(this.current);
     } else {
       // Not a tracked request → auto-playlist or jingle.
-      // If we keep seeing untracked plays while `upcoming` is non-empty, those
-      // queued items aren't actually in Liquidsoap's dj_queue — the usual cause
-      // is a full-stack restart that wiped dj_queue while the controller
-      // recovered a stale queue.json. Drop the stale items so the auto-DJ
-      // (gated on `upcoming.length === 0`) starts picking again. The threshold
-      // tolerates an interleaved jingle without clearing a genuine pending pick.
-      this._autoMisses++;
-      if (this._autoMisses >= 3 && this.upcoming.length > 0) {
-        this.log('scheduler',
-          `Cleared ${this.upcoming.length} stale queue item(s) — not in Liquidsoap's dj_queue`);
-        this.upcoming = [];
+      // If we see untracked plays while there are sent items in `upcoming`,
+      // those items might no longer be in Liquidsoap's dj_queue (e.g. after a restart).
+      // Reconcile with the live dj_queue to clean up any stale entries.
+      if (this.upcoming.some(i => i.sent)) {
+        void this.reconcileWithDjQueue();
       }
       this.current = {
         track: {
@@ -742,6 +735,33 @@ class Queue {
           this.pickerBusy = false;
         }
       })();
+    }
+  }
+
+  // Reconcile Node's upcoming queue with Liquidsoap's actual dj_queue.
+  // Sent items that are missing from Liquidsoap are dropped (e.g. after a Liquidsoap restart).
+  async reconcileWithDjQueue() {
+    const sentItems = this.upcoming.filter(i => i.sent);
+    if (sentItems.length === 0) return;
+
+    try {
+      const liveIds = await liquidsoapControl.getDjQueueIds();
+      const beforeCount = this.upcoming.length;
+
+      this.upcoming = this.upcoming.filter(item => {
+        if (!item.sent) return true;
+        const id = item.track?.id;
+        return id && liveIds.has(id);
+      });
+
+      const droppedCount = beforeCount - this.upcoming.length;
+      if (droppedCount > 0) {
+        this.log('scheduler',
+          `Reconciled with Liquidsoap dj_queue: dropped ${droppedCount} stale queue item(s) not present in Liquidsoap`);
+        this.persist();
+      }
+    } catch (err: any) {
+      this.log('error', `reconcileWithDjQueue failed: ${err.message}`);
     }
   }
 

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -36,6 +36,17 @@ function pickLinkInterval() {
   return 1 + Math.floor(Math.random() * 9);
 }
 
+// How many consecutive reconcile checks may report an EMPTY dj_queue (while the
+// controller still holds sent items) before we treat those items as genuinely
+// gone and clear them. A single empty read is ambiguous — a just-sent pick may
+// be mid-poll, or Liquidsoap may have restarted and lost the queue — so we never
+// drop on one read. Unlike the old `_autoMisses` heuristic (which advanced on
+// benign metadata mismatches while the tracks were still in dj_queue, wrongly
+// wiping live queues — #632), this only advances when Liquidsoap AUTHORITATIVELY
+// reports no pending requests, so an interleaved jingle or artist-string variance
+// can't trip it.
+const EMPTY_DJ_QUEUE_CLEAR_THRESHOLD = 3;
+
 // Upper bound on how far a recordPlay end-stamp can sit after the play's start
 // for the events-backfill dedup (playAlreadyRecorded). recordPlay stamps
 // endedAt at the track's END; an event's `t` is its START, so the two differ by
@@ -86,6 +97,7 @@ class Queue {
   _persistTimer: NodeJS.Timeout | null = null; // debounce for the queue.json snapshot
   _recentPlaysTimer: NodeJS.Timeout | null = null; // debounce for the recent-plays.json sidecar
   _recentPlays: { id: string | null; title: string | null; artist: string | null; endedAt: string }[] = [];
+  _emptyDjQueueStreak = 0;      // consecutive reconcile checks seeing an empty dj_queue while sent items remain — see reconcileWithDjQueue
 
   // Snapshot upcoming/current/history to disk. The queue is otherwise purely
   // in-memory, so a controller restart (every `--build controller` rebuild)
@@ -640,6 +652,9 @@ class Queue {
       const source = item.aiPicked ? 'ai' : 'request';
       this.current = { ...item, startedAt: new Date().toISOString(), source };
       this.log('playing', `${np.title} — ${np.artist}`, { requestedBy: item.requestedBy, source });
+      // A tracked item matched → controller and Liquidsoap are in sync; clear any
+      // dj_queue-empty desync streak accumulated from prior untracked plays.
+      this._emptyDjQueueStreak = 0;
       // Air this track's intro/link now that it's actually on-air — deferred
       // from queue time so the voice lands over the right song (#189). Fire-
       // and-forget: airIntro's writeHandoff can block up to maxWaitMs and must
@@ -751,25 +766,49 @@ class Queue {
   }
 
   // Reconcile Node's upcoming queue with Liquidsoap's actual dj_queue.
-  // Reconcile Node's upcoming queue with Liquidsoap's actual dj_queue.
-  // Only drops items that were confirmed present in dj_queue at least once
-  // and are now gone (played/consumed). Items that have never been seen in
-  // dj_queue (in-flight grace period) are kept so a just-sent pick isn't
-  // dropped before Liquidsoap's next poll (up to 1s after writeHandoff).
+  // Drops items that were confirmed present in dj_queue at least once and are
+  // now gone (played/consumed). Items never yet seen in dj_queue (the in-flight
+  // grace period) are kept so a just-sent pick isn't dropped before Liquidsoap's
+  // next poll (up to 1s after writeHandoff). An empty dj_queue is handled
+  // separately — see the consecutive-empty-reads guard below.
   async reconcileWithDjQueue() {
     const sentItems = this.upcoming.filter(i => i.sent);
-    if (sentItems.length === 0) return;
+    if (sentItems.length === 0) {
+      this._emptyDjQueueStreak = 0;
+      return;
+    }
 
     try {
       const liveIds = await liquidsoapControl.getDjQueueIds();
 
-      // If Liquidsoap returned an empty set while we have sent items, it's
-      // either mid-poll (item in flight) or truly restarted. We can't tell
-      // which — bail and drop nothing.
+      // Empty dj_queue while we still hold sent items. On a single read this is
+      // ambiguous — a pick may be mid-poll (written to next.txt, not yet pulled
+      // in), Liquidsoap may have restarted and lost the queue, or the last item
+      // is on-air (popped from the queue) but its metadata didn't match in
+      // onTrackStarted so it never left `upcoming`. Don't drop on one read, but
+      // count consecutive empties: once the queue has been authoritatively empty
+      // for EMPTY_DJ_QUEUE_CLEAR_THRESHOLD checks the sent items are genuinely
+      // gone (restart) or stuck, so clear them and let the auto-DJ — gated on
+      // `upcoming.length === 0` — start picking again. This restores the restart
+      // self-heal the old `_autoMisses` clear provided, without its false wipes:
+      // it advances only on an authoritatively empty queue, so an interleaved
+      // jingle or an artist-string mismatch (with tracks still queued) resets it
+      // instead of tripping it.
       if (liveIds.size === 0) {
-        this.log('scheduler', 'reconcileWithDjQueue: empty liveIds, skipping drop');
+        this._emptyDjQueueStreak++;
+        if (this._emptyDjQueueStreak >= EMPTY_DJ_QUEUE_CLEAR_THRESHOLD) {
+          const cleared = sentItems.length;
+          this.upcoming = this.upcoming.filter(i => !i.sent);
+          this._emptyDjQueueStreak = 0;
+          this.log('scheduler',
+            `Cleared ${cleared} stale queue item(s) — dj_queue reported empty for ${EMPTY_DJ_QUEUE_CLEAR_THRESHOLD} consecutive checks (Liquidsoap restarted or queue desynced)`);
+          this.persist();
+        }
         return;
       }
+
+      // Non-empty read → the queue is live; reset the desync streak.
+      this._emptyDjQueueStreak = 0;
 
       // Pass 1: confirm items that ARE currently in dj_queue.
       for (const item of this.upcoming) {

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -149,6 +149,17 @@ class Queue {
       }
       this.log('scheduler',
         `Queue recovered: ${this.upcoming.length} upcoming, ${this.history.length} played`);
+
+      // Re-drain any items snapshotted as sent:false mid-TTS during a crash.
+      if (this.upcoming.some(i => !i.sent)) {
+        void this.drainToLiquidsoap();
+      }
+
+      // Reconcile sent:true items against the live dj_queue after a short
+      // delay so Liquidsoap has time to accept telnet connections on boot.
+      if (this.upcoming.some(i => i.sent)) {
+        setTimeout(() => { void this.reconcileWithDjQueue(); }, 3000);
+      }
     } catch (err: any) {
       console.error('[queue] recover failed:', err.message);
     }
@@ -347,6 +358,7 @@ class Queue {
       introAired: false,
       queuedAt: new Date().toISOString(),
       sent: false,
+      confirmedInLiquidsoap: false,
     };
     this.upcoming.push(item);
     this.log('queued', `${track.title} — ${track.artist}`, { requestedBy, queueDepth: this.upcoming.length });
@@ -739,19 +751,41 @@ class Queue {
   }
 
   // Reconcile Node's upcoming queue with Liquidsoap's actual dj_queue.
-  // Sent items that are missing from Liquidsoap are dropped (e.g. after a Liquidsoap restart).
+  // Reconcile Node's upcoming queue with Liquidsoap's actual dj_queue.
+  // Only drops items that were confirmed present in dj_queue at least once
+  // and are now gone (played/consumed). Items that have never been seen in
+  // dj_queue (in-flight grace period) are kept so a just-sent pick isn't
+  // dropped before Liquidsoap's next poll (up to 1s after writeHandoff).
   async reconcileWithDjQueue() {
     const sentItems = this.upcoming.filter(i => i.sent);
     if (sentItems.length === 0) return;
 
     try {
       const liveIds = await liquidsoapControl.getDjQueueIds();
-      const beforeCount = this.upcoming.length;
 
+      // If Liquidsoap returned an empty set while we have sent items, it's
+      // either mid-poll (item in flight) or truly restarted. We can't tell
+      // which — bail and drop nothing.
+      if (liveIds.size === 0) {
+        this.log('scheduler', 'reconcileWithDjQueue: empty liveIds, skipping drop');
+        return;
+      }
+
+      // Pass 1: confirm items that ARE currently in dj_queue.
+      for (const item of this.upcoming) {
+        if (item.sent && item.track?.id && liveIds.has(item.track.id)) {
+          item.confirmedInLiquidsoap = true;
+        }
+      }
+
+      // Pass 2: drop only items that were confirmed-present and are now gone.
+      const beforeCount = this.upcoming.length;
       this.upcoming = this.upcoming.filter(item => {
         if (!item.sent) return true;
+        if (!item.confirmedInLiquidsoap) return true;  // grace period — keep
         const id = item.track?.id;
-        return id && liveIds.has(id);
+        if (!id) return true;  // no id to match against — keep
+        return liveIds.has(id);
       });
 
       const droppedCount = beforeCount - this.upcoming.length;


### PR DESCRIPTION
## What

Replace the `_autoMisses` counter and threshold in `queue.ts` with a real Liquidsoap telnet sync check. Instead of guessing whether upcoming items are stale after three consecutive metadata mismatches, query Liquidsoap's `dj_queue` directly and reconcile the queue state.

## Why

The `_autoMisses >= 3` heuristic could clear `upcoming` during normal playback when jingles or artist string mismatches caused consecutive match failures. The tracks were already present in Liquidsoap's `dj_queue`, so playback continued correctly, but the web UI showed an empty queue.

Fixes #632.

## How tested

* `cd controller && npm run lint` with 0 errors.

## Notes for reviewers

* Added `getDjQueueIds()` in `liquidsoap-control.ts`, which performs two telnet queries:

  * `dj_queue.queue` to retrieve request IDs.
  * `request.metadata <rid>` for each request ID to extract `subsonic_id`.
* Added a 4-second timestamp cache and in-flight promise deduplication so rapid transitions do not generate repeated telnet requests.
* `reconcileWithDjQueue()` is invoked as fire-and-forget (`void this.reconcileWithDjQueue()`), so the 1.5-second watcher tick is never blocked.
* On telnet failure, the code logs the error and returns without clearing the queue based on guesswork.
* `invalidateDjQueueCache()` is exported for future use but is not wired up yet.
