### PR TITLE
fix(picker): non-relaxable count-based no-repeat guard + recent-plays dedup

### DIFF
--- a/controller/package.json
+++ b/controller/package.json
@@ -11,7 +11,7 @@
     "lastfm-session": "tsx scripts/lastfm-session.ts",
     "test:embed": "tsx scripts/embedding-preflight-test.ts",
     "test:llm": "tsx scripts/llm-pure.test.ts",
-    "test": "tsx scripts/llm-pure.test.ts && tsx scripts/picker-recency-regression.ts && tsx scripts/listeners-status.test.ts && tsx scripts/lastfm-enrich.test.ts && tsx scripts/web-search-searxng.test.ts && tsx scripts/request-dedup.test.ts",
+    "test": "tsx scripts/llm-pure.test.ts && tsx scripts/picker-recency-regression.ts && tsx scripts/recent-plays.test.ts && tsx scripts/listeners-status.test.ts && tsx scripts/lastfm-enrich.test.ts && tsx scripts/web-search-searxng.test.ts && tsx scripts/request-dedup.test.ts",
     "lint": "eslint . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit"

--- a/controller/scripts/picker-recency-regression.ts
+++ b/controller/scripts/picker-recency-regression.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_ARTIST_RECENCY_HOURS,
   DEFAULT_TRACK_RECENCY_HOURS,
   durationSeconds,
+  effectiveNoRepeatWindow,
   filterPickerCandidates,
   recencyWindowsForLibrary,
 } from '../src/music/recency.js';
@@ -94,5 +95,64 @@ assert(
 // No cap (null / 0) leaves every track — default behaviour is unchanged.
 assert.equal(filterPickerCandidates(mixedLengths, { maxDurationSec: null }).length, 4);
 assert.equal(filterPickerCandidates(mixedLengths, { maxDurationSec: 0 }).length, 4);
+
+// ── count-based hard no-repeat guard (live-repeats fix) ─────────────────────
+
+// The RELAXABLE recent guard re-serves a fully-recent pool (every candidate
+// played) rather than returning nothing — this is the cascade behaviour the
+// hard guard exists to backstop.
+const allRecent = filterPickerCandidates(songs, {
+  recentIds: new Set(songs.map((s) => s.id)),
+});
+assert(allRecent.length > 0, 'relaxable recent guard must relax to avoid an empty pool');
+
+// The HARD guard does NOT relax: when every candidate is in hardRecentIds the
+// filter returns [] no matter how starved the pool is. This is what stops a
+// just-played track re-airing through a thin similarity cluster.
+const allHard = filterPickerCandidates(songs, {
+  hardRecentIds: new Set(songs.map((s) => s.id)),
+});
+assert.equal(allHard.length, 0, 'hard no-repeat guard must never relax');
+
+// Mixed: only the hard-blocked track is removed; the rest survive (and the
+// relaxable guard is untouched here).
+const partialHard = filterPickerCandidates(songs, {
+  hardRecentIds: new Set(['song-2']),
+});
+assert.deepEqual(
+  partialHard.map((s) => s.id),
+  ['song-1', 'song-3'],
+  'hard guard must drop exactly the blocked id and keep the rest',
+);
+
+// hardRecentKeys blocks a candidate whose id is fresh but whose title|artist
+// matches a recent play — the path that catches an id-less (events-backfilled)
+// recent play, or the same song re-imported under a new Subsonic id.
+const keyBlocked = filterPickerCandidates(
+  [{ id: 'fresh-id', title: 'One', artist: 'A' }],
+  { hardRecentKeys: new Set(['one|a']) },
+);
+assert.equal(keyBlocked.length, 0, 'hardRecentKeys must block by title|artist even with a fresh id');
+
+// The hard guard survives the relaxation cascade even when stacked with a
+// fully-recent relaxable set: song-1 stays blocked, song-2/3 relax back in.
+const stacked = filterPickerCandidates(songs, {
+  recentIds: new Set(songs.map((s) => s.id)),
+  hardRecentIds: new Set(['song-1']),
+});
+assert(
+  !stacked.some((s) => s.id === 'song-1'),
+  'hard guard must hold even while the relaxable guard relaxes around it',
+);
+assert(stacked.length > 0, 'pool must still yield the non-hard-blocked tracks');
+
+// effectiveNoRepeatWindow clamp table (config N, library total) → effective N.
+assert.equal(effectiveNoRepeatWindow(100, 1000), 100, '(100,1000) → 100');
+assert.equal(effectiveNoRepeatWindow(100, 40), 15, '(100,40) → 15 (3/8 of library)');
+assert.equal(effectiveNoRepeatWindow(100, 20), 0, '(100,20) → 0 (below the min-effective floor)');
+assert.equal(effectiveNoRepeatWindow(0, 1000), 0, '(0,*) → 0 (disabled)');
+assert.equal(effectiveNoRepeatWindow(100, null), 0, '(100,null) → 0 (unknown library)');
+assert.equal(effectiveNoRepeatWindow(100, 0), 0, '(100,0) → 0 (empty library)');
+assert.equal(effectiveNoRepeatWindow(50, 1000), 50, '(50,1000) → 50 (under the library ceiling)');
 
 console.log('picker-recency regression checks passed');

--- a/controller/scripts/recent-plays.test.ts
+++ b/controller/scripts/recent-plays.test.ts
@@ -7,7 +7,9 @@
 // scripts/request-dedup.test.ts.
 
 import assert from 'node:assert/strict';
-import { queue } from '../src/broadcast/queue.js';
+import { queue, playAlreadyRecorded } from '../src/broadcast/queue.js';
+
+const GAP = 15 * 60_000; // BACKFILL_DEDUP_MAX_GAP_MS
 
 // recentlyPlayedByCount reads queue.current + queue._recentPlays only; no disk
 // or Liquidsoap side effects, so no neutralising needed beyond a clean slate.
@@ -54,5 +56,62 @@ const withCurrent = queue.recentlyPlayedByCount(1);
 assert(withCurrent.ids.has('CUR'), 'current track id is always blocked');
 assert(withCurrent.keys.has('on air|live'), 'current track key is always blocked');
 assert(withCurrent.ids.has('B'), 'the N sidecar tracks are still blocked alongside current');
+
+// ── events-backfill dedup (playAlreadyRecorded) ─────────────────────────────
+
+// A recordPlay entry stamps endedAt at the track's END — ~2.5 min after the
+// event's start `t` for a normal track. The same play must be recognised as
+// already recorded (the old exact-timestamp key missed this and double-counted
+// every play).
+const start = '2026-06-26T18:00:00.000Z';
+const startMs = new Date(start).getTime();
+const endStamp = new Date(startMs + 2.5 * 60_000).toISOString();
+assert.equal(
+  playAlreadyRecorded(
+    [{ id: 'A', title: 'Song One', artist: 'Artist R', endedAt: endStamp } as any],
+    { title: 'Song One', artist: 'Artist R', t: start },
+    GAP,
+  ),
+  true,
+  'recordPlay end-stamp within a track length of the event start must dedup',
+);
+
+// A genuine replay 20 min later is NOT the same play — the first play's
+// end-stamp falls outside the replay's [t, t+gap] window, so the replay keeps
+// its own entry.
+const replay = new Date(startMs + 20 * 60_000).toISOString();
+assert.equal(
+  playAlreadyRecorded(
+    [{ id: 'A', title: 'Song One', artist: 'Artist R', endedAt: endStamp } as any],
+    { title: 'Song One', artist: 'Artist R', t: replay },
+    GAP,
+  ),
+  false,
+  'a later replay spaced beyond a track length must not be merged away',
+);
+
+// Different track → never a match.
+assert.equal(
+  playAlreadyRecorded(
+    [{ id: 'A', title: 'Song One', artist: 'Artist R', endedAt: endStamp } as any],
+    { title: 'Song Two', artist: 'Artist S', t: start },
+    GAP,
+  ),
+  false,
+  'a different title|artist must not dedup',
+);
+
+// Idempotent across restarts: a prior backfill wrote an id-less copy stamped at
+// the start `t`; re-running must recognise it (at == t, gap 0) and not add a
+// third copy.
+assert.equal(
+  playAlreadyRecorded(
+    [{ id: null, title: 'Song One', artist: 'Artist R', endedAt: start } as any],
+    { title: 'Song One', artist: 'Artist R', t: start },
+    GAP,
+  ),
+  true,
+  'backfill must be idempotent — an existing start-stamped copy dedups on re-run',
+);
 
 console.log('recent-plays count + dedup checks passed');

--- a/controller/scripts/recent-plays.test.ts
+++ b/controller/scripts/recent-plays.test.ts
@@ -1,0 +1,58 @@
+// Regression test for the count-based no-repeat guard's data source —
+// queue.recentlyPlayedByCount(n) — and the events-backfill dedup that keeps the
+// recent-plays sidecar from double-counting every play (live-repeats fix).
+// Run: `tsx scripts/recent-plays.test.ts`.
+//
+// node:assert-via-tsx style, matching scripts/picker-recency-regression.ts and
+// scripts/request-dedup.test.ts.
+
+import assert from 'node:assert/strict';
+import { queue } from '../src/broadcast/queue.js';
+
+// recentlyPlayedByCount reads queue.current + queue._recentPlays only; no disk
+// or Liquidsoap side effects, so no neutralising needed beyond a clean slate.
+function setPlays(plays: any[]) {
+  (queue as any).current = null;
+  (queue as any)._recentPlays = plays;
+}
+
+// ── distinct counting ───────────────────────────────────────────────────────
+
+// The sidecar holds TWO rows for one play after a restart: recordPlay logs it
+// with an id (track-end), the events backfill logs an id-less copy (track-start)
+// of the SAME song. recentlyPlayedByCount must collapse them so `n` means n
+// distinct songs, not n rows. Here three rows describe TWO songs; n=2 must
+// reach the second song (B) — proving the id-less duplicate of A did not burn a
+// slot. If it counted rows, n=2 would stop at row 2 and B would be missing.
+setPlays([
+  { id: 'A', title: 'Song One', artist: 'Artist R', endedAt: '2026-06-26T18:00:00.000Z' },
+  { id: null, title: 'Song One', artist: 'Artist R', endedAt: '2026-06-26T17:58:00.000Z' },
+  { id: 'B', title: 'Song Two', artist: 'Artist S', endedAt: '2026-06-26T17:55:00.000Z' },
+]);
+const twoDistinct = queue.recentlyPlayedByCount(2);
+assert(twoDistinct.ids.has('A'), 'first distinct track id present');
+assert(twoDistinct.ids.has('B'), 'duplicate row must not consume a slot — second song must be reached');
+assert(twoDistinct.keys.has('song one|artist r'), 'title|artist key recorded for blocking id-less candidates');
+assert(twoDistinct.keys.has('song two|artist s'), 'second song key recorded');
+
+// n=1 stops at the first distinct song; the duplicate and the later song are
+// out of the window.
+const oneDistinct = queue.recentlyPlayedByCount(1);
+assert(oneDistinct.ids.has('A'), 'n=1 includes the most recent song');
+assert(!oneDistinct.ids.has('B'), 'n=1 must not reach the second distinct song');
+
+// n <= 0 disables the guard — empty sets.
+assert.equal(queue.recentlyPlayedByCount(0).ids.size, 0, 'n=0 → no ids');
+assert.equal(queue.recentlyPlayedByCount(0).keys.size, 0, 'n=0 → no keys');
+assert.equal(queue.recentlyPlayedByCount(-5).ids.size, 0, 'negative n → no ids');
+
+// The current (on-air) track is added on top of the N so a mid-song pick can't
+// re-pick it, regardless of whether it's already in the sidecar.
+setPlays([{ id: 'B', title: 'Song Two', artist: 'Artist S', endedAt: '2026-06-26T17:55:00.000Z' }]);
+(queue as any).current = { track: { id: 'CUR', title: 'On Air', artist: 'Live' } };
+const withCurrent = queue.recentlyPlayedByCount(1);
+assert(withCurrent.ids.has('CUR'), 'current track id is always blocked');
+assert(withCurrent.keys.has('on air|live'), 'current track key is always blocked');
+assert(withCurrent.ids.has('B'), 'the N sidecar tracks are still blocked alongside current');
+
+console.log('recent-plays count + dedup checks passed');

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -25,7 +25,7 @@ import { buildPickerTools } from '../llm/tools.js';
 import { recordPick } from '../llm/log.js';
 import * as budget from './dj-budget.js';
 import { withTrace, logEvent } from '../observability/events.js';
-import { recencyWindowsForLibrary } from '../music/recency.js';
+import { recencyWindowsForLibrary, effectiveNoRepeatWindow } from '../music/recency.js';
 
 // --- Feature 4: DJ-mode mini-runs ------------------------------------------
 // A short, deliberate tempo/key journey across 2-3 consecutive picks. While a
@@ -282,7 +282,7 @@ export const pickerAgent = defineAgent({
   maxSteps: 4,
   timeoutMs: agentDeadline,
   buildSystem: () => pickSystem(),
-  buildTools: ({ recentIds, recentKeys, audioWaypoint }) => {
+  buildTools: ({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint }) => {
     // Resolve the active show live (a show that just came on air takes effect):
     // its length override (issue #447) and, for a strict show, hard genre + era
     // locks the discovery tools enforce on candidates — not just the prompt.
@@ -294,7 +294,7 @@ export const pickerAgent = defineAgent({
     const eraLock = strict && (activeShow?.fromYear != null || activeShow?.toYear != null)
       ? { fromYear: activeShow.fromYear, toYear: activeShow.toYear }
       : null;
-    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, audioWaypoint, maxDurationSec, genreLock, eraLock });
+    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, maxDurationSec, genreLock, eraLock });
     return { tools, extras: { seen } };
   },
 });
@@ -360,7 +360,8 @@ async function enqueuePick(queue, song, reason, source, link: string | null = nu
 
 async function pickViaAgent(queue, { wantLink, audioWaypoint = null }: { wantLink: boolean; audioWaypoint?: number[] | null }): Promise<boolean> {
   await library.load();
-  const windows = recencyWindowsForLibrary(library.stats().distinctArtists);
+  const stats = library.stats();
+  const windows = recencyWindowsForLibrary(stats.distinctArtists);
   // Scale the track-recency window to the tagged library's artist diversity:
   // dense catalogues keep the long anti-repeat guard, while small-artist
   // libraries don't exclude every real candidate before the picker sees it.
@@ -368,12 +369,23 @@ async function pickViaAgent(queue, { wantLink, audioWaypoint = null }: { wantLin
   // the buildPickerTools note (the similarity tools cluster on the just-played
   // artist, so an artist strip starved them).
   const { ids: recentIds, keys: recentKeys } = queue.recentlyPlayed(windows.trackHours);
+  // Queued-but-not-yet-aired ids belong in the RELAXABLE set — they're not
+  // "recently played", just in-flight, and shouldn't tighten the hard guard.
   for (const id of queue.queuedIds()) recentIds.add(id);
+
+  // Count-based HARD no-repeat guard: the last N distinct plays can't re-air,
+  // and (unlike recentIds/recentKeys above) this survives the tool-level
+  // starvation cascade. Clamped to library size so a small catalogue never
+  // fully blocks; 0 = off, leaving the relaxable window in sole charge.
+  const effN = effectiveNoRepeatWindow(settings.get().llm?.noRepeatWindow ?? 0, stats.total);
+  const { ids: hardRecentIds, keys: hardRecentKeys } = queue.recentlyPlayedByCount(effN);
 
   const { object, steps, toolCalls, extras } = await pickerAgent.run({
     messages: session.windowMessages(),
     recentIds,
     recentKeys,
+    hardRecentIds,
+    hardRecentKeys,
     // Sonic journey (Phase 2): registers the tracksTowardJourney tool, closed
     // over the run's current waypoint, so the agent path drifts the sound the
     // same way the pool path does. The event text tells the agent to use it.

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -732,6 +732,51 @@ class Queue {
     return this.recentlyPlayed(hours).ids;
   }
 
+  // The last `n` DISTINCT tracks played — the count-based HARD no-repeat guard
+  // (filterPickerCandidates hardRecent*; never relaxed). Clock-independent: it
+  // walks the rolling sidecar newest-first and stops once it has seen `n`
+  // distinct tracks, so a busy or a quiet hour blocks the same number of songs.
+  //
+  // Counts DISTINCT tracks, not raw rows: the sidecar can hold two entries for
+  // one play (recordPlay logs it with an id at track-end; the boot events
+  // backfill logs an id-less copy at track-start), and those collapse here —
+  // `n` means n songs, not n rows — so the guard's strength matches the
+  // configured number regardless of the double-write. Collapses an id-less
+  // (backfilled) row against an id'd row of the same track via the shared
+  // title|artist key. Returns BOTH ids and keys so a candidate is blocked by
+  // whichever identifier it carries; the current track is added on top so a
+  // mid-song pick can't re-pick it. Empty sets when n <= 0.
+  recentlyPlayedByCount(n = 0): { ids: Set<string>; keys: Set<string> } {
+    const ids = new Set<string>();
+    const keys = new Set<string>();
+    if (!Number.isFinite(n) || n <= 0) return { ids, keys };
+    const keyOf = (title: string | null | undefined, artist: string | null | undefined) =>
+      `${(title || '').toLowerCase().trim()}|${(artist || '').toLowerCase().trim()}`;
+    const cur = this.current?.track;
+    if (cur?.id) ids.add(cur.id);
+    if (cur?.title) keys.add(keyOf(cur.title, cur.artist));
+    const seenIds = new Set<string>();
+    const seenKeys = new Set<string>();
+    let distinct = 0;
+    for (const p of this._recentPlays) {
+      if (distinct >= n) break;
+      const k = keyOf(p.title, p.artist);
+      // Already counted this track (by id OR by title|artist key)? Skip — this
+      // is the duplicate sidecar row, not a second distinct play.
+      if ((p.id && seenIds.has(p.id)) || (k && seenKeys.has(k))) continue;
+      distinct++;
+      if (p.id) {
+        seenIds.add(p.id);
+        ids.add(p.id);
+      }
+      if (k) {
+        seenKeys.add(k);
+        keys.add(k);
+      }
+    }
+    return { ids, keys };
+  }
+
   queuedIds(): Set<string> {
     const ids = new Set<string>();
     if (this.current?.track?.id) ids.add(this.current.track.id);

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -35,6 +35,41 @@ function pickLinkInterval() {
   return 1 + Math.floor(Math.random() * 9);
 }
 
+// Upper bound on how far a recordPlay end-stamp can sit after the play's start
+// for the events-backfill dedup (playAlreadyRecorded). recordPlay stamps
+// endedAt at the track's END; an event's `t` is its START, so the two differ by
+// the track length. 15 min comfortably covers normal tracks (a track longer
+// than this is rare and only costs one harmless duplicate sidecar row), while
+// staying short enough that a genuine replay — always spaced more than a track
+// length apart — keeps its own entry rather than being merged away.
+export const BACKFILL_DEDUP_MAX_GAP_MS = 15 * 60_000;
+
+// Has this events-log play already been recorded by recordPlay? The old dedup
+// keyed on `${endedAt}|${title}` — an EXACT timestamp match — but recordPlay's
+// end-stamp never equals the event's start `t`, so it never fired and every
+// play got a duplicate id-less copy, filling the 300-entry sidecar in ~5h
+// instead of ~12h (halving the real anti-repeat window). Match on title|artist
+// with an existing endedAt landing in [t, t + maxGapMs] instead: exactly the
+// window a recordPlay end-stamp falls in for the SAME play. Pure + exported so
+// the dedup logic is unit-pinned (scripts/recent-plays.test.ts) without disk.
+export function playAlreadyRecorded(
+  existing: { title: string | null; artist: string | null; endedAt: string }[],
+  ev: { title?: string | null; artist?: string | null; t: string },
+  maxGapMs: number,
+): boolean {
+  const keyOf = (title: string | null | undefined, artist: string | null | undefined) =>
+    `${(title || '').toLowerCase().trim()}|${(artist || '').toLowerCase().trim()}`;
+  const k = keyOf(ev.title, ev.artist);
+  const t = new Date(ev.t).getTime();
+  if (!Number.isFinite(t)) return false;
+  for (const p of existing) {
+    if (keyOf(p.title, p.artist) !== k) continue;
+    const at = new Date(p.endedAt).getTime();
+    if (Number.isFinite(at) && at >= t && at - t <= maxGapMs) return true;
+  }
+  return false;
+}
+
 class Queue {
   upcoming: any[] = [];        // request items pushed by listeners, not yet playing
   current: any = null;         // what's broadcasting right now (request or auto)
@@ -151,11 +186,10 @@ class Queue {
   backfillRecentPlaysFromEvents() {
     try {
       const cutoff = Date.now() - 24 * 3_600_000;
-      // Dedup by `t|title` against existing sidecar (which records endedAt
-      // close to the play.start time; near-enough that exact equality works).
-      const have = new Set(
-        this._recentPlays.map(p => `${p.endedAt}|${p.title || ''}`),
-      );
+      // Dedup against plays recordPlay already logged — matched on title|artist
+      // with the existing end-stamp inside a track-length window of the event's
+      // start (playAlreadyRecorded), NOT an exact-timestamp key. The old exact
+      // key never matched (end-stamp ≠ start `t`), so every play was duplicated.
       const filled: typeof this._recentPlays = [];
       const today = new Date().toISOString().slice(0, 10);
       const yest = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
@@ -170,7 +204,10 @@ class Queue {
             const e = JSON.parse(line);
             if (e.type !== 'track.play' || !e.t || !e.title) continue;
             if (new Date(e.t).getTime() < cutoff) continue;
-            if (have.has(`${e.t}|${e.title}`)) continue;
+            // Compare against both the existing sidecar AND plays already filled
+            // in this pass, so two events for one play can't both slip through.
+            if (playAlreadyRecorded(this._recentPlays, e, BACKFILL_DEDUP_MAX_GAP_MS)) continue;
+            if (playAlreadyRecorded(filled, e, BACKFILL_DEDUP_MAX_GAP_MS)) continue;
             filled.push({
               id: null,
               title: e.title || null,

--- a/controller/src/config.ts
+++ b/controller/src/config.ts
@@ -191,6 +191,16 @@ export const config = {
     // why we keep a separate, longer-lived store.
     recentPlaysFile: `${STATE_DIR}/recent-plays.json`,
     recentPlaysMax: 300,
+    // Count-based hard no-repeat guard: the picker (both pool and agent paths)
+    // never re-airs any of the last N DISTINCT plays. Unlike the time-window
+    // guard (recencyWindowsForLibrary) this is non-relaxable — it survives the
+    // filterPickerCandidates starvation cascade, closing the hole where a
+    // thin/over-visited mood cluster let the cascade drop the recent-track guard
+    // and re-serve a just-played song. Clamped to library size at use
+    // (effectiveNoRepeatWindow) so a small catalogue never fully blocks; 0
+    // disables. Seeds settings.llm.noRepeatWindow — the live, admin-tunable
+    // value; env wins. Listener requests stay exempt (request path is untouched).
+    noRepeatWindow: parseInt(process.env.NO_REPEAT_WINDOW || '100', 10),
   },
   curiosity: {
     // Durable dedup ledger for the `curiosity` segment capability. Holds every

--- a/controller/src/llm/internal/tools/picker-tools.ts
+++ b/controller/src/llm/internal/tools/picker-tools.ts
@@ -83,6 +83,8 @@ function shuffle<T>(arr: T[]): T[] {
 export function buildPickerTools({
   recentIds = new Set<string>(),
   recentKeys = new Set<string>(),
+  hardRecentIds = new Set<string>(),
+  hardRecentKeys = new Set<string>(),
   audioWaypoint = null,
   resolveReferences = false,
   maxDurationSec = null,
@@ -91,6 +93,13 @@ export function buildPickerTools({
 }: {
   recentIds?: Set<string>;
   recentKeys?: Set<string>;        // lowercased "title|artist" — backfilled entries lack ids
+  // Count-based HARD no-repeat set (last N distinct plays). Non-relaxable — a
+  // track in here is filtered out of every tool's results and survives the
+  // starvation cascade, so the agent literally cannot re-pick a just-played
+  // song even when a thin similarity cluster is all it can see. Populated from
+  // queue.recentlyPlayedByCount(N); empty on the request path (requests exempt).
+  hardRecentIds?: Set<string>;
+  hardRecentKeys?: Set<string>;    // lowercased "title|artist" — blocks id-less backfilled plays
   // Hard genre constraint for a strict-genre show (settings.genreStrict). When
   // set, every tool's candidates are genre-filtered (preferGenre, never-starve)
   // before recency + cap, so the agent path enforces the lock in code, not just
@@ -137,6 +146,8 @@ export function buildPickerTools({
     const accepted = filterPickerCandidates(pool, {
       recentIds,
       recentKeys,
+      hardRecentIds,
+      hardRecentKeys,
       seenIds: new Set(seen.keys()),
       cap,
       maxDurationSec,

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -11,7 +11,7 @@ import * as library from './library.js';
 import * as dj from '../llm/dj.js';
 import * as settings from '../settings.js';
 import { bpmCompat, keyCompat } from './mix.js';
-import { filterPickerCandidates, recencyWindowsForLibrary } from './recency.js';
+import { filterPickerCandidates, recencyWindowsForLibrary, effectiveNoRepeatWindow } from './recency.js';
 import { normGenre, genreMatches, preferGenre, inYearRange, preferEnergy } from './show-filter.js';
 
 const CANDIDATE_CAP = 18;
@@ -135,7 +135,7 @@ async function tracksFromAlbums(albums: any[], perAlbum: number, max: number) {
   return out;
 }
 
-async function buildCandidates(mood: string | null | undefined, recentIds: Set<string>, recentArtists: Set<string>, currentTrack: any, rankTarget: { bpm: number | null; key: string | null } | null = null, audioWaypoint: number[] | null = null, showFilter: ShowFilter = null, maxDurationSec: number | null = null) {
+async function buildCandidates(mood: string | null | undefined, recentIds: Set<string>, recentArtists: Set<string>, currentTrack: any, rankTarget: { bpm: number | null; key: string | null } | null = null, audioWaypoint: number[] | null = null, showFilter: ShowFilter = null, maxDurationSec: number | null = null, hardRecentIds: Set<string> = new Set(), hardRecentKeys: Set<string> = new Set()) {
   await library.load();
   const pool: any[] = [];
   const sources: Record<string, number> = {};
@@ -365,6 +365,8 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
   const final = filterPickerCandidates(softRankByCompat(pool, curAnalysis), {
     recentIds,
     recentArtists,
+    hardRecentIds,
+    hardRecentKeys,
     artistCounts: perArtist,
     maxPerArtist: MAX_PER_ARTIST,
     cap: CANDIDATE_CAP,
@@ -412,9 +414,15 @@ function summariseRecent(queue: any) {
 
 export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; key: string | null } | null = null, audioWaypoint: number[] | null = null) {
   await library.load();
-  const windows = recencyWindowsForLibrary(library.stats().distinctArtists);
+  const stats = library.stats();
+  const windows = recencyWindowsForLibrary(stats.distinctArtists);
   const recentIds = queue.recentlyPlayedIds(windows.trackHours);
   const recentArtists = queue.recentArtistsSince(windows.artistHours);
+  // Count-based HARD no-repeat guard (last N distinct plays) — non-relaxable,
+  // survives buildCandidates' starvation cascade. Clamped to library size so a
+  // small catalogue never fully blocks; 0 = off. Mirrors the agent path.
+  const effN = effectiveNoRepeatWindow(settings.get().llm?.noRepeatWindow ?? 0, stats.total);
+  const { ids: hardRecentIds, keys: hardRecentKeys } = queue.recentlyPlayedByCount(effN);
   const currentTrack = queue.current?.track || null;
   // Resolve the active show once: its music-steering filters shape the pool
   // (below) and its brief steers the LLM pick (further down).
@@ -425,7 +433,7 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   // Length cap for this pick: the active show's override or the station default
   // (issue #447), resolved in seconds. null = no cap.
   const maxDurationSec = settings.effectiveMaxTrackSec(activeShow);
-  const { candidates, sources, strictInfo } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack, rankTarget, audioWaypoint, showFilter, maxDurationSec);
+  const { candidates, sources, strictInfo } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack, rankTarget, audioWaypoint, showFilter, maxDurationSec, hardRecentIds, hardRecentKeys);
 
   if (candidates.length === 0) {
     queue.log('picker', 'no candidates available, skipping LLM pick');
@@ -436,7 +444,7 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
     'picker',
     `pool ${candidates.length} (${Object.entries(sources)
       .map(([k, v]) => `${k}=${v}`)
-      .join(' ')})`,
+      .join(' ')})${effN > 0 ? ` no-repeat=${effN}` : ''}`,
   );
 
   // Strict-genre visibility — make the never-starve fallback audible in the log

--- a/controller/src/music/recency.ts
+++ b/controller/src/music/recency.ts
@@ -4,6 +4,15 @@ const DIVERSE_LIBRARY_ARTISTS = 48;
 const MIN_TRACK_RECENCY_HOURS = 1;
 const MIN_ARTIST_RECENCY_HOURS = 0.25;
 
+// Count-based hard no-repeat guard tuning (effectiveNoRepeatWindow below).
+// Never hard-block more than this fraction of the tagged library, so even a
+// configured window larger than the catalogue can support still leaves a fresh
+// pool to pick from. And below MIN_EFFECTIVE distinct tracks the guard is both
+// too weak to matter and too likely to starve a tiny library — so it switches
+// off entirely and the relaxable time-window guard carries on alone.
+const NO_REPEAT_MAX_LIBRARY_FRACTION = 0.375;
+const NO_REPEAT_MIN_EFFECTIVE = 15;
+
 export interface RecencyWindows {
   trackHours: number;
   artistHours: number;
@@ -23,6 +32,14 @@ export interface CandidateFilterState {
   recentIds?: Set<string>;
   recentKeys?: Set<string>;
   recentArtists?: Set<string>;
+  // Count-based hard no-repeat guard (live-repeats fix). Checked OUTSIDE the
+  // relaxation cascade's mode loop — like maxDurationSec, a track in here is
+  // never an acceptable pick, so it survives every starvation stage. This is
+  // what guarantees the last N distinct plays can't re-air even when the
+  // relaxable recentIds/recentKeys guard below is dropped to keep the pool from
+  // emptying. Populated from queue.recentlyPlayedByCount(N); empty = guard off.
+  hardRecentIds?: Set<string>;
+  hardRecentKeys?: Set<string>;
   seenIds?: Set<string>;
   artistCounts?: Map<string, number>;
   maxPerArtist?: number;
@@ -83,12 +100,32 @@ export function recencyWindowsForLibrary(distinctArtists: number | null | undefi
   };
 }
 
+// Clamp a configured count-based no-repeat window to what the tagged library
+// can safely support. Pure + unit-pinned (picker-recency-regression.ts).
+//   - configuredN <= 0, or an unknown/empty library  → 0 (guard self-disables)
+//   - never block more than NO_REPEAT_MAX_LIBRARY_FRACTION of the library
+//   - if the result would be below NO_REPEAT_MIN_EFFECTIVE              → 0
+// Examples: (100,1000)→100, (100,40)→15, (100,20)→0, (0,*)→0, (100,null)→0.
+export function effectiveNoRepeatWindow(
+  configuredN: number | null | undefined,
+  libraryTotal: number | null | undefined,
+): number {
+  const n = Math.floor(Number(configuredN) || 0);
+  const total = Math.floor(Number(libraryTotal) || 0);
+  if (n <= 0 || total <= 0) return 0;
+  const ceiling = Math.floor(total * NO_REPEAT_MAX_LIBRARY_FRACTION);
+  const eff = Math.min(n, ceiling);
+  return eff < NO_REPEAT_MIN_EFFECTIVE ? 0 : eff;
+}
+
 export function filterPickerCandidates<T extends CandidateLike>(
   list: T[],
   {
     recentIds = new Set<string>(),
     recentKeys = new Set<string>(),
     recentArtists = new Set<string>(),
+    hardRecentIds = new Set<string>(),
+    hardRecentKeys = new Set<string>(),
     seenIds = new Set<string>(),
     artistCounts = new Map<string, number>(),
     maxPerArtist = Infinity,
@@ -129,6 +166,13 @@ export function filterPickerCandidates<T extends CandidateLike>(
 
     for (const song of pool) {
       if (!song?.id || nextSeen.has(song.id)) continue;
+      // Hard no-repeat guard — NO mode gate, so it holds through every
+      // relaxation stage. A track in the last-N-distinct set never airs, even
+      // when the cascade has dropped the relaxable track guard below to avoid an
+      // empty pool. (effectiveNoRepeatWindow keeps this set well under the
+      // library size so this can't starve the pool to nothing.)
+      if (hardRecentIds.has(song.id)) continue;
+      if (hardRecentKeys.has(trackKey(song))) continue;
       if (mode.recentTracks && recentIds.has(song.id)) continue;
       if (mode.recentTracks && recentKeys.has(trackKey(song))) continue;
 

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -6,7 +6,7 @@
 import { readFile, writeFile, unlink, readdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
-import { STATE_DIR } from './config.js';
+import { STATE_DIR, config } from './config.js';
 import { DEFAULT_THEME_ID, isValidThemeId, listThemes } from './themes.js';
 import { isValidTimezone, setStationTimezone, zonedParts } from './time.js';
 
@@ -234,6 +234,16 @@ function clampDailyTokenCap(raw: any, def: number): number {
 function clampBudgetSoftPct(raw: any, def: number): number {
   if (typeof raw !== 'number' || !Number.isFinite(raw)) return def;
   return Math.min(100, Math.max(0, Math.floor(raw)));
+}
+
+// Count-based hard no-repeat window (distinct plays). Floored to an integer in
+// [0, 290]: 0 disables; the 290 ceiling stays under the 300-entry _recentPlays
+// cap so the requested window is never silently truncated by a too-short
+// sidecar. Library-size clamping happens separately at use time
+// (effectiveNoRepeatWindow). Non-numeric/NaN falls back to `def`.
+function clampNoRepeatWindow(raw: any, def: number): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return def;
+  return Math.min(290, Math.max(0, Math.floor(raw)));
 }
 
 // Validate + apply the connection fields shared by the primary LLM leg and its
@@ -651,6 +661,14 @@ const DEFAULTS = {
     // dj-agent.js). When off, the stateless pool picker runs instead — still
     // inside a session, still logged, just without the conversational loop.
     pickerAgent: true,
+    // Count-based hard no-repeat window: the picker never re-airs any of the
+    // last N DISTINCT plays. Non-relaxable (survives the filterPickerCandidates
+    // starvation cascade), so it closes the hole where a thin mood cluster let
+    // the cascade re-serve a just-played song. Clamped to library size at use
+    // (effectiveNoRepeatWindow) so a small catalogue never fully blocks; 0
+    // disables. Seeded from config.queue.noRepeatWindow (env NO_REPEAT_WINDOW);
+    // listener requests stay exempt. See music/recency.ts + broadcast/queue.ts.
+    noRepeatWindow: config.queue.noRepeatWindow,
     // When on, the listener-request agent (djAgentRequest only — never the
     // per-track picker) gets an extra `identifyRequestedTrack` tool that resolves
     // a DESCRIBED track ("the song from the new Dune movie") via web search, then
@@ -1225,6 +1243,9 @@ export async function load() {
         typeof stored.llm?.pickerAgent === 'boolean'
           ? stored.llm.pickerAgent
           : DEFAULTS.llm.pickerAgent,
+      // Clamped to [0, 290] (≤ the 300-entry sidecar cap); pre-field
+      // settings.json picks up the config/env-seeded default.
+      noRepeatWindow: clampNoRepeatWindow(stored.llm?.noRepeatWindow, DEFAULTS.llm.noRepeatWindow),
       requestWebResolve:
         typeof stored.llm?.requestWebResolve === 'boolean'
           ? stored.llm.requestWebResolve

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -2173,6 +2173,9 @@ export async function update(patch) {
     if (l.pickerAgent !== undefined) {
       next.llm.pickerAgent = !!l.pickerAgent;
     }
+    if (l.noRepeatWindow !== undefined) {
+      next.llm.noRepeatWindow = clampNoRepeatWindow(Number(l.noRepeatWindow), next.llm.noRepeatWindow);
+    }
     if (l.requestWebResolve !== undefined) {
       next.llm.requestWebResolve = !!l.requestWebResolve;
     }

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -170,6 +170,7 @@ interface LlmForm {
   reasoning: boolean;
   toolChoice: string;
   pickerAgent: boolean;
+  noRepeatWindow: number;
   requestWebResolve: boolean;
   agentTimeoutMs: number;
   pauseWhenEmpty: boolean;
@@ -479,6 +480,7 @@ export default function SettingsPanel() {
         reasoning: !!v.llm?.reasoning,
         toolChoice: v.llm?.toolChoice === 'auto' ? 'auto' : 'required',
         pickerAgent: !!v.llm?.pickerAgent,
+        noRepeatWindow: typeof v.llm?.noRepeatWindow === 'number' ? v.llm.noRepeatWindow : 100,
         requestWebResolve: !!v.llm?.requestWebResolve,
         agentTimeoutMs: typeof v.llm?.agentTimeoutMs === 'number' ? v.llm.agentTimeoutMs : 45000,
         pauseWhenEmpty: !!v.llm?.pauseWhenEmpty,
@@ -2402,6 +2404,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
         reasoning: form.llm.reasoning,
         toolChoice: form.llm.toolChoice,
         pickerAgent: form.llm.pickerAgent,
+        noRepeatWindow: form.llm.noRepeatWindow,
         requestWebResolve: form.llm.requestWebResolve,
         agentTimeoutMs: form.llm.agentTimeoutMs,
         pauseWhenEmpty: form.llm.pauseWhenEmpty,
@@ -3109,6 +3112,28 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
             />
           </div>
         )}
+
+        <div className="field mt-4">
+          <Label>No-repeat window (tracks)</Label>
+          <Input
+            type="number"
+            min={0}
+            max={290}
+            step={10}
+            value={form.llm.noRepeatWindow}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setForm(f => ({ ...f, llm: { ...f.llm, noRepeatWindow: Math.max(0, Number(e.target.value)) } }))
+            }
+            placeholder="100"
+            className="max-w-[200px]"
+          />
+          <div className="field-hint">
+            The last N <strong>distinct</strong> tracks can never be re-picked &mdash; a hard
+            guard on both the agent and candidate-pool pickers, on top of the time-based
+            window. Auto-scales down on a small library so it never blocks everything.
+            {' '}<strong>0 = off</strong>. Listener requests stay exempt. 0&ndash;290.
+          </div>
+        </div>
       </Card>
 
       <Card title="Idle behaviour" sub="when no one's listening">


### PR DESCRIPTION
## Why

A track (`Yaad Meri` by Fateh) re-aired **6 times in <5h** on the live station, the gaps collapsing to 15 min — despite the "12h anti-repeat window". Investigation found two compounding root causes:

1. **The anti-repeat guard was relaxable.** `filterPickerCandidates` runs a starvation cascade whose final stage drops the recent-track guard entirely so a thin candidate pool still yields a pick. On a niche catalogue an audio-journey *anchor* track (few close neighbours, all recently played) repeatedly collapsed the cascade to its last stage and got re-served. The "12h window" is real but is a *soft preference*, not a hard ceiling.

2. **The recent-plays window was silently halved.** `recordPlay` stamps each play's sidecar entry at the track's **end** time; the boot `backfillRecentPlaysFromEvents` stamps an id-less copy at the track's **start** time. The dedup keyed on an *exact* timestamp match, so the two never matched and **every play was recorded twice** — the 300-entry sidecar filled in ~5h instead of ~12h. (Live data: the whole buffer spanned ~4h50m; 149/300 entries were id-less duplicates.)

## What

### Commit 1 — non-relaxable count-based no-repeat guard
A second exclusion set that **supplements** (does not replace) the time-window + artist guards:

- `recency.ts`: `hardRecentIds`/`hardRecentKeys` checked **outside** the cascade's mode loop (mirrors the existing `maxDurationSec` precedent), so the last N plays survive every relaxation stage. `effectiveNoRepeatWindow()` clamps N to library size so a small catalogue never fully blocks (`0` = self-disable).
- `queue.ts`: `recentlyPlayedByCount(n)` counts **distinct** tracks (collapsing the id'd + id-less rows for one play), so configured N means *N songs, not N rows*.
- Wired into **both** the pool path (`picker.ts`) and the agent path (`dj-agent.ts` → `picker-tools.ts`). **Listener requests stay exempt** (request path untouched).
- `settings.llm.noRepeatWindow` (default **100**, env `NO_REPEAT_WINDOW`), clamped to `[0, 290]` under the 300-entry sidecar cap.

### Commit 2 — recent-plays backfill dedup
- `playAlreadyRecorded()` (pure, exported) matches on `title|artist` with the existing end-stamp landing in a track-length window `[t, t+15min]` of the event start — exactly where a `recordPlay` end-stamp falls for the same play — while a genuine replay (spaced > a track length) keeps its own entry. Restores the time-window guard to actually span ~12h.

## Testing
- `picker-recency-regression.ts`: hard guard never relaxes; `hardRecentKeys` blocks by `title|artist`; `effectiveNoRepeatWindow` clamp table `(100,1000)→100`, `(100,40)→15`, `(100,20)→0`, `(0,*)→0`, `(100,null)→0`.
- New `recent-plays.test.ts`: distinct counting (duplicate row doesn't burn a slot), current-track-on-top, and `playAlreadyRecorded` (same-play dedup, later-replay kept, different-track, restart idempotency).
- `npm run lint` (eslint + tsc) clean. Full `npm test` green except 2 pre-existing `showMusicLean` prompt-wording failures on `develop`, unrelated to this change.

## Notes
Did not raise `recentPlaysMax` — once Commit 2 lands, 300 slots ≈ 10–12h again. Can revisit if a busy day proves otherwise.