### PR TITLE
feat(admin): radio-card TTS engine picker + voice preview (#151)

### DIFF
--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -145,6 +145,39 @@ function normalizeForSpeech(text: string) {
   return text.replace(/\bSUB\s*(?:\/|slash)\s*WAVE\b/gi, 'Subwave');
 }
 
+// Admin voice-preview ("Play sample"). Renders a one-off sample WAV with an
+// EXPLICIT engine + voice, deliberately bypassing both the on-air persona
+// resolution and the silent fallback chain in speak() — the operator wants to
+// hear exactly the engine they picked, or get a real error if it's unavailable
+// (sidecar down, no cloud key). A synthetic persona-shaped object routes the
+// voice/provider through speakWith() the same way a live persona would. `speed`
+// is the final rate multiplier to audition, clamped to the playout [0.5,2.0]
+// band; gain (dB) is a playout-time mix trim and is intentionally NOT baked in.
+// Returns the path to the generated WAV — the caller serves and unlinks it.
+const PREVIEW_TEXT_MAX = 200;
+const DEFAULT_PREVIEW_TEXT = "You're listening to SUB/WAVE. This is a voice preview.";
+
+export async function synthesizeSample(
+  { engine, voice = '', cloudProvider = 'openai', speed, text }: {
+    engine: string;
+    voice?: string;
+    cloudProvider?: string;
+    speed?: number;
+    text?: string;
+  },
+): Promise<string> {
+  if (!ENGINES.includes(engine)) throw new Error(`Unknown engine: ${engine}`);
+  const raw = (typeof text === 'string' && text.trim()) ? text.trim() : DEFAULT_PREVIEW_TEXT;
+  const sample = normalizeForSpeech(raw.slice(0, PREVIEW_TEXT_MAX));
+  const scale = settings.clampTtsSpeed(speed);
+  // Synthetic persona so speakWith() picks up the requested voice/provider
+  // exactly (its per-engine branches key off personaTts.engine === <engine>).
+  const personaTts = { engine, voice, cloudProvider };
+  // No outPath → each engine self-generates a WAV path under config.piper.outDir
+  // (reaped by cleanupOldVoices) and returns it.
+  return speakWith(engine, sample, { speedScale: scale, language: '', soul: '' }, personaTts);
+}
+
 // Public entry point. Tries the configured engine; on failure, falls back to
 // a local engine so the DJ never goes silent because a model (or the network)
 // failed. Piper is the universal fallback — local, keyless, fast.

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -2,6 +2,8 @@
 // UI consumes, the matching write endpoint, plus the mixer-restart and
 // auto-pick toggles.
 import express from 'express';
+import { readFile, unlink } from 'node:fs/promises';
+import { extname } from 'node:path';
 import { config } from '../config.js';
 import * as library from '../music/library.js';
 import * as jingles from '../broadcast/jingles.js';
@@ -399,6 +401,41 @@ router.post('/settings/secrets/test', requireAdmin, async (req, res) => {
     res.json({ ok: result.ok, message: result.message, latencyMs: Date.now() - t0 });
   } catch (err: any) {
     res.json({ ok: false, message: err?.message || 'probe failed', latencyMs: Date.now() - t0 });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /settings/tts/preview — synthesize a short sample in an EXPLICIT engine +
+// voice (not the on-air persona) so the admin "Play sample" button can audition
+// a voice/speed before saving. Body: { engine, voice?, cloudProvider?, speed?,
+// text? }. On success streams the rendered WAV (audio/wav). On a synth failure —
+// e.g. the tts-heavy sidecar is down or no cloud key — returns 422 with
+// { ok, message } instead of silently falling back to Piper, so the operator
+// sees why. The temp WAV is unlinked once sent.
+// ---------------------------------------------------------------------------
+router.post('/settings/tts/preview', requireAdmin, async (req, res) => {
+  const body = req.body || {};
+  const engine = typeof body.engine === 'string' ? body.engine : '';
+  if (!engine || !tts.ENGINES.includes(engine)) {
+    return res.status(400).json({ ok: false, message: `Unknown engine: ${engine || '(none)'}` });
+  }
+  let filePath: string | null = null;
+  try {
+    filePath = await tts.synthesizeSample({
+      engine,
+      voice: typeof body.voice === 'string' ? body.voice : '',
+      cloudProvider: typeof body.cloudProvider === 'string' ? body.cloudProvider : 'openai',
+      speed: typeof body.speed === 'number' ? body.speed : undefined,
+      text: typeof body.text === 'string' ? body.text : undefined,
+    });
+    const buf = await readFile(filePath);
+    // Local engines render WAV; cloud (ElevenLabs) renders MP3. Set the type
+    // from the actual extension so the browser <audio> gets the right MIME.
+    res.type(extname(filePath) || '.wav').send(buf);
+  } catch (err: any) {
+    res.status(422).json({ ok: false, message: err?.message || 'Preview synthesis failed' });
+  } finally {
+    if (filePath) unlink(filePath).catch(() => {});
   }
 });
 

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -22,6 +22,8 @@ import {
   Command, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem,
 } from '../ui/command';
 import { Card, Btn, Pill, Eyebrow, Seg, Metric } from './ui';
+import { EngineSelector } from './tts/EngineSelector';
+import { VoicePreviewButton } from './tts/VoicePreviewButton';
 import { AiFill } from './AiFill';
 import { cn } from '../../lib/cn';
 import ArchivesPanel from './ArchivesPanel';
@@ -1663,7 +1665,6 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
   const engines = data.tts?.engines || ['piper'];
   const available = data.tts?.available || {};
   const ENGINE_LABELS: Record<string, string> = { piper: 'Piper', kokoro: 'Kokoro', chatterbox: 'Chatterbox', 'pocket-tts': 'PocketTTS', cloud: 'Cloud' };
-  const engineOptions = engines.map(e => ({ id: e, label: ENGINE_LABELS[e] || e }));
 
   const save = async () => {
     await saveSettings({
@@ -1819,10 +1820,10 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
               <Label>Engine</Label>
               {ttsDirty && <Pill tone="accent" dot>unsaved</Pill>}
             </div>
-            <Seg
-              accent
+            <EngineSelector
               value={form.tts.defaultEngine}
-              options={engineOptions}
+              engineIds={engines}
+              available={available}
               onChange={selectEngine}
             />
             <div className="field-hint">
@@ -2172,6 +2173,32 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
           </div>
           );
         })()}
+
+          {/* Audition the selected engine + its configured voice + speed. */}
+          {(() => {
+            const e = form.tts.defaultEngine;
+            const previewVoice =
+              e === 'kokoro' ? (form.tts.kokoro?.voice || '')
+              : e === 'chatterbox' ? (form.tts.chatterbox?.referenceVoice || '')
+              : e === 'pocket-tts' ? (form.tts.pocketTts?.voice || '')
+              : e === 'cloud' ? (form.tts.cloud.voice || '')
+              : '';
+            return (
+              <div className="field">
+                <VoicePreviewButton
+                  engine={e}
+                  voice={previewVoice}
+                  cloudProvider={form.tts.cloud.provider}
+                  speed={form.tts.speed?.[e] ?? 1}
+                  adminFetch={adminFetch}
+                />
+                <div className="field-hint">
+                  Plays a short sample in the selected engine &amp; voice. Reflects voice
+                  and speed; the dB trim is applied later, on air.
+                </div>
+              </div>
+            );
+          })()}
         </div>
       </Card>
 

--- a/web/components/admin/personas/PersonaEditor.tsx
+++ b/web/components/admin/personas/PersonaEditor.tsx
@@ -81,6 +81,7 @@ export function PersonaEditor({
         data={data}
         defaultEngine={defaultEngine}
         cloudIssueText={cloudIssueText}
+        adminFetch={adminFetch}
         updateTts={updateTts}
       />
 

--- a/web/components/admin/personas/PersonaVoiceCard.tsx
+++ b/web/components/admin/personas/PersonaVoiceCard.tsx
@@ -1,13 +1,18 @@
 'use client';
-// Text-to-speech engine, the engine-specific voice selector, and the per-persona
-// voice-level trim. Two columns from lg up (engine + selector on the left, the
-// level meter on the right) so the card fills the editor width instead of
-// stacking in a narrow left strip.
+// Text-to-speech engine picker, the engine-specific voice selector, and the
+// per-persona voice-level + speed trims. The engine is chosen from a radio-card
+// grid (shared EngineSelector) that surfaces availability up front; below it,
+// two columns from lg up — the engine's voice selector + a "Play sample" button
+// on the left, the level meter + speed slider on the right.
 import type { ChangeEvent } from 'react';
 import type { Persona, PersonaTts, SettingsResponse } from './types';
+import type { AdminAuth } from '../../../lib/adminAuth';
 import { CLOUD_VOICES } from '../../../lib/cloudVoices';
-import { ENGINES, CB_DEFAULT_VOICE, KOKORO_RE, CHATTERBOX_VOICE_RE, POCKET_TTS_VOICE_RE } from './constants';
+import { CB_DEFAULT_VOICE, KOKORO_RE, CHATTERBOX_VOICE_RE, POCKET_TTS_VOICE_RE } from './constants';
 import { Card, Seg } from '../ui';
+import { EngineSelector } from '../tts/EngineSelector';
+import { VoicePreviewButton } from '../tts/VoicePreviewButton';
+import { ENGINES } from '../tts/engineMeta';
 import { Input } from '../../ui/input';
 import { Label } from '../../ui/label';
 import {
@@ -16,15 +21,18 @@ import {
 import { VoiceMeter } from './VoiceMeter';
 import { cn } from '../../../lib/cn';
 
+const ENGINE_IDS = ENGINES.map(e => e.id);
+
 interface PersonaVoiceCardProps {
   persona: Persona;
   data: SettingsResponse | null;
   defaultEngine: string;
   cloudIssueText: string | null;
+  adminFetch: AdminAuth['adminFetch'];
   updateTts: (patch: Partial<PersonaTts>) => void;
 }
 
-export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText, updateTts }: PersonaVoiceCardProps) {
+export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText, adminFetch, updateTts }: PersonaVoiceCardProps) {
   const kokoroVoices = data?.tts?.kokoroVoices || [];
   const pocketTtsVoices = data?.tts?.pocketTtsVoices || [];
   const cloudProviders = data?.tts?.cloudProviders || ['openai', 'elevenlabs'];
@@ -39,46 +47,49 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
   // it, so the control is shown but disabled with a hint for those engines.
   const speedSupported = persona.tts.engine !== 'chatterbox' && persona.tts.engine !== 'pocket-tts';
 
+  // Engine change: the `voice` field is shared across engines but each engine
+  // validates it differently — a leftover value from the old engine (e.g. a
+  // Kokoro id like "bm_george") fails the new engine's check on save. Normalize
+  // voice to something the target engine accepts whenever the engine changes.
+  const selectEngine = (v: string) => {
+    const patch: Partial<PersonaTts> = { engine: v };
+    const cur = persona.tts.voice.trim();
+    if (v === 'cloud') {
+      const provVoices = CLOUD_VOICES[persona.tts.cloudProvider as keyof typeof CLOUD_VOICES] || [];
+      if (!provVoices.some(pv => pv.id === cur)) {
+        patch.voice = provVoices[0]?.id || cur;
+      }
+    } else if (v === 'kokoro') {
+      if (!KOKORO_RE.test(cur)) patch.voice = 'bf_isabella';
+    } else if (v === 'chatterbox') {
+      // Empty = built-in voice; a real value must be a .wav filename.
+      if (cur && !CHATTERBOX_VOICE_RE.test(cur)) patch.voice = '';
+    } else if (v === 'pocket-tts') {
+      if (!POCKET_TTS_VOICE_RE.test(cur)) patch.voice = 'alba';
+    }
+    updateTts(patch);
+  };
+
   return (
     <Card title="Voice" sub="text-to-speech engine">
+      {/* Engine — radio-card grid, full width above the two-column body. */}
+      <div className="field mb-4">
+        <Label>Engine</Label>
+        <EngineSelector
+          value={persona.tts.engine}
+          engineIds={ENGINE_IDS}
+          available={data?.tts?.available}
+          onChange={selectEngine}
+        />
+        <div className="field-hint max-w-[70ch]">
+          Each persona can use its own engine and voice. The badge on each card
+          shows whether it&apos;s ready in this build.
+        </div>
+      </div>
+
       <div className="lg:grid lg:grid-cols-2 lg:items-start lg:gap-x-8">
-        {/* LEFT — engine + the engine-specific voice selector */}
+        {/* LEFT — the engine-specific voice selector + a sample player */}
         <div className="min-w-0">
-          <div className="field mb-3.5">
-            <Label>Engine</Label>
-            <Seg
-              value={persona.tts.engine}
-              options={ENGINES}
-              onChange={v => {
-                // The `voice` field is shared across engines but each engine
-                // validates it differently — a leftover value from the old
-                // engine (e.g. a Kokoro id like "bm_george") fails the new
-                // engine's check on save. Normalize voice to something the
-                // target engine accepts whenever the engine changes.
-                const patch: Partial<PersonaTts> = { engine: v };
-                const cur = persona.tts.voice.trim();
-                if (v === 'cloud') {
-                  const provVoices = CLOUD_VOICES[persona.tts.cloudProvider as keyof typeof CLOUD_VOICES] || [];
-                  if (!provVoices.some(pv => pv.id === cur)) {
-                    patch.voice = provVoices[0]?.id || cur;
-                  }
-                } else if (v === 'kokoro') {
-                  if (!KOKORO_RE.test(cur)) patch.voice = 'bf_isabella';
-                } else if (v === 'chatterbox') {
-                  // Empty = built-in voice; a real value must be a .wav filename.
-                  if (cur && !CHATTERBOX_VOICE_RE.test(cur)) patch.voice = '';
-                } else if (v === 'pocket-tts') {
-                  if (!POCKET_TTS_VOICE_RE.test(cur)) patch.voice = 'alba';
-                }
-                updateTts(patch);
-              }}
-            />
-            <div className="field-hint max-w-[70ch]">
-              Piper is local &amp; fast. Kokoro is more natural but slower. Chatterbox
-              clones a voice from a reference clip (local, opt-in). Cloud routes through
-              OpenAI / ElevenLabs.
-            </div>
-          </div>
 
           {persona.tts.engine === 'piper' && (() => {
             const piperVoices: string[] = data?.tts?.piperVoices || [];
@@ -342,6 +353,21 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
               </>
             );
           })()}
+
+          {/* Audition this persona's engine + voice + speed before saving. */}
+          <div className="mt-4">
+            <VoicePreviewButton
+              engine={persona.tts.engine}
+              voice={persona.tts.voice}
+              cloudProvider={persona.tts.cloudProvider}
+              speed={persona.tts.speed}
+              adminFetch={adminFetch}
+            />
+            <div className="field-hint mt-1.5">
+              Plays a short sample in this persona&apos;s voice. Reflects the voice
+              and speed; the dB trim is applied later, on air.
+            </div>
+          </div>
         </div>
 
         {/* RIGHT — voice level */}

--- a/web/components/admin/personas/constants.ts
+++ b/web/components/admin/personas/constants.ts
@@ -36,13 +36,9 @@ export const KNOB_ROTATIONS = [
 ] as const;
 export const VOICE_CELLS = 32;
 
-export const ENGINES = [
-  { id: 'piper',  label: 'Piper' },
-  { id: 'kokoro', label: 'Kokoro' },
-  { id: 'chatterbox', label: 'Chatterbox' },
-  { id: 'pocket-tts', label: 'PocketTTS' },
-  { id: 'cloud',  label: 'Cloud' },
-];
+// Engine descriptors live in components/admin/tts/engineMeta.ts (shared with the
+// Settings voice tab) — import ENGINES from there, not here.
+
 // Chatterbox reference voice files are validated against this in audio/chatterbox.ts
 // — basename only, no path separators, .wav extension, conservative chars.
 export const CHATTERBOX_VOICE_RE = /^[A-Za-z0-9_.-]{1,80}\.wav$/;

--- a/web/components/admin/tts/EngineSelector.tsx
+++ b/web/components/admin/tts/EngineSelector.tsx
@@ -1,0 +1,83 @@
+'use client';
+// Radio-card grid for picking a TTS engine. Replaces the cramped 5-button
+// segmented control on both the Personas voice card and the Settings voice tab:
+// every engine is a selectable card showing its name, a one-line blurb and a
+// live status badge (ready / sidecar off / no key) so availability is visible
+// before you select. Styled on the newsprint RadioOption pattern. Tailwind-only
+// (no inline styles — issue #50).
+import { cn } from '../../../lib/cn';
+import { ENGINE_META, engineStatus } from './engineMeta';
+
+interface EngineSelectorProps {
+  // Currently selected engine id.
+  value: string;
+  // Which engines to show as cards (Personas: all 5; Settings: data.tts.engines).
+  engineIds: string[];
+  // SettingsResponse.tts.available — drives the per-card status badge.
+  available?: Record<string, boolean>;
+  onChange: (id: string) => void;
+  className?: string;
+}
+
+export function EngineSelector({ value, engineIds, available, onChange, className }: EngineSelectorProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Voice engine"
+      className={cn('grid grid-cols-2 gap-2.5 md:grid-cols-3', className)}
+    >
+      {engineIds.map(id => {
+        const meta = ENGINE_META[id];
+        const status = engineStatus(id, available);
+        const active = value === id;
+        return (
+          <button
+            key={id}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => onChange(id)}
+            className={cn(
+              'grid cursor-pointer content-start gap-1.5 border p-3 text-left font-[inherit]',
+              active
+                ? 'border-[var(--accent)] bg-[var(--accent-soft)]'
+                : 'border-ink bg-transparent hover:bg-[var(--ink-softer)]',
+            )}
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span className="flex min-w-0 items-center gap-1.5">
+                <span
+                  className={cn(
+                    'size-2.5 flex-none rounded-full border',
+                    active ? 'border-[var(--accent)] bg-[var(--accent)]' : 'border-ink bg-transparent',
+                  )}
+                />
+                <span
+                  className={cn(
+                    'truncate text-[11px] font-bold tracking-[0.18em] uppercase',
+                    active ? 'text-vermilion' : 'text-ink',
+                  )}
+                >
+                  {meta?.label || id}
+                </span>
+              </span>
+              {status.label && (
+                <span
+                  className={cn(
+                    'flex-none border px-1.5 py-[2px] text-[9px] font-bold tracking-[0.1em] uppercase',
+                    status.tone === 'warn'
+                      ? 'border-[var(--danger)] text-[var(--danger)]'
+                      : 'border-[color:var(--separator-strong)] text-muted',
+                  )}
+                >
+                  {status.label}
+                </span>
+              )}
+            </div>
+            <span className="text-[10px] leading-[1.4] text-muted">{meta?.blurb}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/components/admin/tts/VoicePreviewButton.tsx
+++ b/web/components/admin/tts/VoicePreviewButton.tsx
@@ -1,0 +1,86 @@
+'use client';
+// "Play sample" button for the TTS picker. Posts the chosen engine/voice/speed
+// to POST /settings/tts/preview, gets back a WAV blob and plays it — so the
+// operator can hear a voice before saving. Shared by the Personas voice card and
+// the Settings voice tab. The endpoint bypasses the on-air persona AND the
+// silent fallback, so an unavailable engine returns a real error message here
+// rather than quietly playing Piper. Gain (dB) is a playout-time mix trim and is
+// not part of the rendered sample — only voice + speed are auditioned.
+import { useEffect, useRef, useState } from 'react';
+import type { AdminAuth } from '../../../lib/adminAuth';
+import { Btn } from '../ui';
+
+interface VoicePreviewButtonProps {
+  engine: string;
+  voice: string;
+  cloudProvider?: string;
+  // Final rate multiplier to audition (server clamps to 0.5–2.0×).
+  speed?: number;
+  adminFetch: AdminAuth['adminFetch'];
+  disabled?: boolean;
+  className?: string;
+}
+
+type PreviewState = 'idle' | 'loading' | 'playing' | 'error';
+
+export function VoicePreviewButton({
+  engine, voice, cloudProvider, speed, adminFetch, disabled, className,
+}: VoicePreviewButtonProps) {
+  const [state, setState] = useState<PreviewState>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const urlRef = useRef<string | null>(null);
+
+  const stop = () => {
+    if (audioRef.current) { audioRef.current.pause(); audioRef.current = null; }
+    if (urlRef.current) { URL.revokeObjectURL(urlRef.current); urlRef.current = null; }
+  };
+
+  // Revoke the object URL + stop playback if the card unmounts mid-sample.
+  useEffect(() => stop, []);
+
+  const onClick = async () => {
+    // Re-click while loading/playing cancels.
+    if (state === 'loading' || state === 'playing') { stop(); setState('idle'); return; }
+    setError(null);
+    setState('loading');
+    try {
+      const r = await adminFetch('/settings/tts/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ engine, voice, cloudProvider, speed }),
+      });
+      if (!r.ok) {
+        const j = await r.json().catch(() => ({})) as { message?: string };
+        setError(j.message || `Preview failed (${r.status})`);
+        setState('error');
+        return;
+      }
+      const blob = await r.blob();
+      stop();
+      const url = URL.createObjectURL(blob);
+      urlRef.current = url;
+      const audio = new Audio(url);
+      audioRef.current = audio;
+      audio.onended = () => { stop(); setState('idle'); };
+      audio.onerror = () => { stop(); setError('Could not play sample'); setState('error'); };
+      await audio.play();
+      setState('playing');
+    } catch (e) {
+      stop();
+      setError(e instanceof Error ? e.message : 'Preview failed');
+      setState('error');
+    }
+  };
+
+  const label = state === 'loading' ? 'Synthesizing…' : state === 'playing' ? 'Stop' : 'Play sample';
+
+  return (
+    <div className={className}>
+      <Btn sm onClick={onClick} disabled={disabled}>{label}</Btn>
+      {error && (
+        <span className="ml-2 text-[10px] leading-[1.4] text-[var(--danger)]">{error}</span>
+      )}
+    </div>
+  );
+}

--- a/web/components/admin/tts/engineMeta.ts
+++ b/web/components/admin/tts/engineMeta.ts
@@ -1,0 +1,63 @@
+// Single source of truth for the TTS engine picker: per-engine descriptors and
+// a pure availability→badge mapping. Shared by the Personas page
+// (PersonaVoiceCard) and the Settings page (TtsSection) so the engine list,
+// blurbs and status logic live in exactly one place instead of being duplicated
+// across the two surfaces. No React, no DOM — safe to unit-import.
+
+export interface EngineMeta {
+  id: string;
+  // Display name shown on the card.
+  label: string;
+  // One-line descriptor under the name — what the operator is choosing.
+  blurb: string;
+}
+
+// Order mirrors the on-air dispatcher (controller audio/tts.ts ENGINES).
+export const ENGINES: EngineMeta[] = [
+  { id: 'piper',      label: 'Piper',      blurb: 'Local · fast · keyless' },
+  { id: 'kokoro',     label: 'Kokoro',     blurb: 'More natural, slower' },
+  { id: 'chatterbox', label: 'Chatterbox', blurb: 'Clone a voice from a clip' },
+  { id: 'pocket-tts', label: 'PocketTTS',  blurb: 'Multilingual · CPU-only' },
+  { id: 'cloud',      label: 'Cloud',      blurb: 'OpenAI / ElevenLabs' },
+];
+
+export const ENGINE_META: Record<string, EngineMeta> = Object.fromEntries(
+  ENGINES.map(e => [e.id, e]),
+);
+
+export type EngineStatusTone = 'ok' | 'warn';
+export interface EngineStatus {
+  label: string;
+  tone: EngineStatusTone;
+}
+
+// Pure: derive an engine's status badge from the controller's availability map
+// (SettingsResponse.tts.available — piper/kokoro/chatterbox/pocket-tts/cloud
+// booleans). A missing/undefined flag means "not yet known / assumed up", so we
+// only flag a hard `=== false`. `warn` reads as the recoverable-problem tone
+// (sidecar down, no cloud key); `ok` is the quiet ready state.
+export function engineStatus(
+  id: string,
+  available: Record<string, boolean> | undefined,
+): EngineStatus {
+  const a = available || {};
+  switch (id) {
+    case 'piper':
+      return { label: 'ready', tone: 'ok' };
+    case 'kokoro':
+      return a.kokoro === false
+        ? { label: 'unavailable', tone: 'warn' }
+        : { label: 'ready', tone: 'ok' };
+    case 'chatterbox':
+    case 'pocket-tts':
+      return a[id] === false
+        ? { label: 'sidecar off', tone: 'warn' }
+        : { label: 'ready', tone: 'ok' };
+    case 'cloud':
+      return a.cloud === false
+        ? { label: 'no key', tone: 'warn' }
+        : { label: 'key set', tone: 'ok' };
+    default:
+      return { label: '', tone: 'ok' };
+  }
+}


### PR DESCRIPTION
## What

Redesigns the confusing TTS **engine picker** on **admin/personas** (the persona Voice card) and **admin/settings → Voice engine** tab, and adds a **voice preview** — closing #151.

### Before
Both pages used the same cramped 5-button segmented tab strip, with a *second* stacked tab strip for cloud providers, and engine availability was only discoverable via a red box *after* selecting an engine.

### After
- **Radio-card grid** (shared `EngineSelector`) — each engine is a selectable card with a one-line blurb and a **live status badge**: `ready` / `sidecar off` / `no key`. Availability is visible up front.
- **"Play sample" button** (shared `VoicePreviewButton`) on both pages — auditions the chosen engine + voice + speed before saving.
- Cloud provider is now a clearly-labelled sub-control (no more tabs-in-tabs).

## How

- **web**: new shared `components/admin/tts/{engineMeta,EngineSelector,VoicePreviewButton}`. `engineMeta` is the single source of truth for engine descriptors + a pure `engineStatus()` mapping, replacing duplicated lists across the two pages. Persona voice-normalization on engine switch and the dB meter + speech-speed slider are preserved.
- **controller**: `POST /settings/tts/preview` (admin-gated, modelled on `/settings/secrets/test`) renders a one-off sample via new `tts.synthesizeSample()` with an **explicit** engine/voice/speed — so it previews *unsaved* edits, bypassing on-air persona resolution. It deliberately **bypasses the silent fallback** so an unavailable engine returns a real error instead of quietly playing Piper (the status badges already surface availability). Content-type is derived from the rendered file's extension (WAV local, MP3 ElevenLabs); the temp file is unlinked after send.

Preserves the per-engine / per-persona speech-speed controls from #639.

## Verification

- `web` lint (`eslint . && tsc --noEmit`): **pass**.
- `controller` lint (`eslint . && tsc --noEmit`): **pass** (0 errors).
- Live smoke test not run from the worktree (the dev compose binds the main checkout's `controller/src`, and a parallel job is using it). Endpoint mirrors the proven secrets-test pattern; happy to run a worktree dev smoke test on request.

Closes #151