### PR TITLE
fix(web): make the volume knob touch-friendly with a relative vertical drag

### DIFF
--- a/web/components/PlayerApp.tsx
+++ b/web/components/PlayerApp.tsx
@@ -236,7 +236,7 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
     else tune();
   };
   // Ticker that increments only on keyboard-driven volume adjusts. The
-  // TransportBar watches it to pulse the volume cells; slider drags don't
+  // TransportBar watches it to pulse the volume cells; knob drags don't
   // tick it (the cells need to track the finger pixel-for-pixel during a
   // drag — pulsing would fight that).
   const [volumePulse, setVolumePulse] = useState(0);

--- a/web/components/TransportBar.tsx
+++ b/web/components/TransportBar.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { memo, useEffect, useRef } from 'react';
+import { memo, useEffect, useRef, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent } from 'react';
 import { animate as motionAnimate, m, useAnimate } from 'motion/react';
 import { ChevronDown, ChevronUp, Volume2 } from 'lucide-react';
 import { cn } from '@/lib/cn';
-import { Slider } from './ui/slider';
 import { useIsIOS } from '@/lib/hooks';
 import { useElapsed } from '@/hooks/useElapsed';
 import { SCALE_MAX, type SignalQuality } from '@/hooks/useSignal';
@@ -18,7 +17,7 @@ export interface TransportBarProps {
   offline?: boolean;
   volume: number;
   setVolume: (v: number) => void;
-  /** Increments on keyboard-only volume adjusts; slider drags don't tick it. */
+  /** Increments on keyboard-only volume adjusts; knob drags don't tick it. */
   volumePulse?: number;
   muted: boolean;
   onToggleMute: () => void;
@@ -33,6 +32,19 @@ export interface TransportBarProps {
 }
 
 const SCALE_NUMS = [0, 50, 100, 150, 200, 250];
+
+// Drag distance (px) that sweeps the volume knob across its full 0→1 range.
+// The gesture is *relative* to the press point — unbounded by the knob's ~40px
+// footprint — so this sets the dial's resolution: a comfortable thumb travel
+// for the whole range, with small nudges giving fine control.
+const KNOB_DRAG_RANGE_PX = 160;
+// Movement (px) before a press counts as a drag — swallows tap jitter so a
+// tap on the knob leaves the level untouched.
+const KNOB_DRAG_DEADZONE_PX = 4;
+
+const clamp01 = (n: number) => Math.min(1, Math.max(0, n));
+// Snap to whole-percent steps so the readout and rotation land on clean values.
+const quantizeVolume = (n: number) => Math.round(clamp01(n) * 100) / 100;
 
 const QUALITY_LABEL: Record<SignalQuality, string> = {
   offline: 'Offline',
@@ -141,6 +153,63 @@ export default memo(function TransportBar({
     }
   }, [volume]);
 
+  // ── Volume knob: relative vertical drag ───────────────────────────────
+  // Press anywhere on the knob and drag up to raise / down to lower — the
+  // standard hardware-knob gesture. Movement is measured relative to the
+  // press point, so the finger can roam the whole screen (pointer capture
+  // keeps tracking after it leaves the 40px target) and resolution isn't
+  // crushed into the knob's footprint the way the old horizontal slider was.
+  const dragRef = useRef<{ id: number; startY: number; startVolume: number; engaged: boolean } | null>(null);
+
+  const onKnobPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    if (dragRef.current) return; // a drag is already live — ignore a second finger
+    if (e.button !== 0 && e.pointerType === 'mouse') return; // primary button only
+    e.currentTarget.setPointerCapture(e.pointerId);
+    e.currentTarget.focus(); // tap focuses the slider for SR/keyboard, even with preventDefault
+    dragRef.current = { id: e.pointerId, startY: e.clientY, startVolume: volume, engaged: false };
+    e.preventDefault();
+  };
+
+  const onKnobPointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.id !== e.pointerId) return;
+    const dy = drag.startY - e.clientY; // up = louder
+    // Dead-zone: a tap (or its incidental finger jitter) shouldn't jog the
+    // level — only engage once the press turns into a deliberate drag, then
+    // re-baseline so the first adjustment starts from the engagement point
+    // with no jump.
+    if (!drag.engaged) {
+      if (Math.abs(dy) < KNOB_DRAG_DEADZONE_PX) return;
+      drag.engaged = true;
+      drag.startY = e.clientY;
+      drag.startVolume = volume;
+      return;
+    }
+    setVolume(quantizeVolume(drag.startVolume + dy / KNOB_DRAG_RANGE_PX));
+  };
+
+  const endKnobDrag = (e: ReactPointerEvent<HTMLDivElement>) => {
+    if (dragRef.current?.id !== e.pointerId) return;
+    dragRef.current = null;
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+  };
+
+  // Keyboard a11y for the role="slider" knob. Up/Down are handled globally
+  // (PlayerApp's shortcuts) regardless of focus, so binding them here too would
+  // double-step — we only add the non-conflicting jump keys.
+  const onKnobKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    let next: number | null = null;
+    if (e.key === 'Home') next = 0;
+    else if (e.key === 'End') next = 1;
+    else if (e.key === 'PageUp') next = volume + 0.1;
+    else if (e.key === 'PageDown') next = volume - 0.1;
+    if (next == null) return;
+    e.preventDefault();
+    setVolume(quantizeVolume(next));
+  };
+
   const handleTune = () => {
     if (offline) return;
     if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
@@ -247,7 +316,28 @@ export default memo(function TransportBar({
             </div>
           ) : (
             <div className="flex items-center gap-3 lg:gap-4">
-              <div ref={knobWrapRef} className="fz-knob-wrap h-10 w-10 lg:h-[48px] lg:w-[48px]">
+              {/* The knob is its own control: a role="slider" surface driving a
+                  relative vertical-drag gesture (see onKnobPointerDown). The
+                  ARIA value attrs keep it readable by screen readers; Up/Down
+                  come from PlayerApp's global shortcuts. touch-none stops the
+                  page scrolling out from under a drag. */}
+              <div
+                ref={knobWrapRef}
+                role="slider"
+                tabIndex={0}
+                aria-label="Volume"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={Math.round(volume * 100)}
+                aria-valuetext={`${Math.round(volume * 100)}%`}
+                aria-orientation="vertical"
+                onPointerDown={onKnobPointerDown}
+                onPointerMove={onKnobPointerMove}
+                onPointerUp={endKnobDrag}
+                onPointerCancel={endKnobDrag}
+                onKeyDown={onKnobKeyDown}
+                className="fz-knob-wrap v3-focus h-10 w-10 cursor-ns-resize touch-none rounded-full select-none lg:h-[48px] lg:w-[48px]"
+              >
                 <div className="fz-knob-ticks" />
                 <div
                   className="fz-knob"
@@ -256,17 +346,6 @@ export default memo(function TransportBar({
                   <span className="fz-cap" />
                   <span className="fz-pointer" />
                 </div>
-                {/* Interaction layer only — the rotating knob above is the visible
-                    control, so the accessible Radix Slider is overlaid invisibly. */}
-                <Slider
-                  min={0}
-                  max={1}
-                  step={0.01}
-                  value={[volume]}
-                  onValueChange={([v]) => setVolume(v ?? 0)}
-                  aria-label="Volume"
-                  className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
-                />
               </div>
 
               <button


### PR DESCRIPTION
## What

Keep the rotary volume knob exactly as-is and fix its touch usability by replacing the interaction model. Closes the need behind #627 **without** removing the knob (the issue proposed swapping it for a vertical slider; this keeps the dial people like and just makes it drag naturally).

## Why it was fiddly on touch

The visible knob's interaction was an **invisible horizontal Radix slider** crammed into the knob's ~40×40px box. The whole 0→100% range mapped to ~40px of horizontal travel (~0.4px per 1%), so:
- a tap slammed the volume to wherever the finger landed horizontally,
- a tiny twitch jumped the level wildly,
- the round visual implied a twist / up-down gesture, not a 40px horizontal sweep — worst on touch where there's no hover to discover the behaviour.

## The fix

Standard hardware-knob gesture — **relative vertical drag** via Pointer Events + pointer capture:
- press anywhere on the knob, drag **up = louder / down = quieter**;
- movement is measured **relative to the press point**, so resolution isn't bounded by the 40px footprint (~160px sweeps the full range; small nudges give fine control) and pointer capture keeps it tracking after the finger leaves the knob;
- `touch-action: none` stops the page scrolling out from under a drag;
- a small **movement dead-zone** means a tap (and its incidental finger jitter) leaves the level untouched — only a deliberate drag engages, re-baselined so there's no jump.

The visible knob, its rotation, and the haptic/pulse feedback are unchanged — they already key off `volume`.

## Accessibility

The knob is now its own `role="slider"` with `aria-valuemin/max/now/valuetext` + `aria-orientation="vertical"` for screen readers. Arrow Up/Down stay on PlayerApp's existing global shortcuts (binding them locally too would double-step), with **Home/End/PageUp/PageDown** added on the focused control. Focus ring via `v3-focus`.

Dropped the Radix `Slider` usage here; the shared `ui/slider` component is untouched (still used elsewhere).

## Verification

- `npm run lint` (eslint + `tsc --noEmit`) clean.
- Drove the running player in a browser:
  - **Drag down** 100% → 66%; `audio.volume` followed to 0.66; knob rotated to 43.2° (`-135 + 0.66×270`). ✓
  - **Dead-zone**: a tap that previously jogged the value now leaves it untouched. ✓
  - **Controlled pointer sequence**: 3px move = no-op (deadzone), 6px move engages + re-baselines, 100px-down move lands at exactly `100% − 100/160 = 38%`, `audio.volume` → 0.38. ✓
  - **Keyboard**: Home→0, PageUp→10→20, End→100, PageDown→90, focus retained, `audio.volume` tracks. ✓
  - ARIA attrs, `touch-action: none`, `cursor: ns-resize` all confirmed in the DOM. ✓

## Acceptance criteria (from #627)

- [x] Works on mobile Chrome (Pointer Events + capture; no horizontal-sweep trap). iOS path is unchanged — it already shows the hardware-volume hint since iOS makes volume read-only.
- [x] Accessible (keyboard / screen reader) — `role="slider"` + ARIA values + keyboard handling.

Refs #627