### PR TITLE
fix(web): reduce admin/doctor horizontal padding on mobile

### DIFF
--- a/web/components/admin/DoctorPanel.tsx
+++ b/web/components/admin/DoctorPanel.tsx
@@ -203,7 +203,7 @@ export default function DoctorPanel() {
   const buddyMood: BuddyMood = review?.available && review.overall ? MOOD_BY_OVERALL[review.overall] : 'content';
 
   return (
-    <div className="mx-auto max-w-[1100px] px-7 py-8">
+    <div className="mx-auto max-w-[1100px] px-0 py-8 sm:px-7">
       {/* Init hero — DJ Doc introduces himself and the whole run is one press.
           The booth's-open pitch is the primary content; "Let's go" runs the
           full assessment AND his review together. Stays up through the first


### PR DESCRIPTION
## What

On `admin/doctor`, the content sat too far from the screen edges on mobile (left/right padding was too large).

## Why

`DoctorPanel` wrapped its content in `px-7` (28px) at every breakpoint. But the admin shell (`.shell-body`) already provides horizontal padding — 28px on desktop, 18px on mobile. On phones those stacked to **46px** per side, where every other admin panel (DashPanel, SettingsPanel, …) adds no horizontal padding of its own and sits at the shell's 18px.

## Change

`web/components/admin/DoctorPanel.tsx` — root wrapper:

```diff
- mx-auto max-w-[1100px] px-7 py-8
+ mx-auto max-w-[1100px] px-0 py-8 sm:px-7
```

- **Mobile (<640px):** drops the extra 28px → content sits at the shell's 18px, matching the other admin panels.
- **Desktop (≥640px):** unchanged — keeps the centered `max-w-[1100px]` with `px-7`.

## Verification

`tsc --noEmit` and `eslint` both clean.