### PR TITLE
feat(admin): card-grid LLM provider & TTS engine pickers + onboarding model dropdown

### DIFF
--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -2,7 +2,6 @@
 
 import type { ChangeEvent, ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { useDynamicStyle } from '../../hooks/useDynamicStyle';
 import { m } from 'motion/react';
 import { notify, errorMessage } from '../../lib/notify';
@@ -18,12 +17,12 @@ import { Label } from '../ui/label';
 import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel,
 } from '../ui/select';
-import {
-  Command, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem,
-} from '../ui/command';
 import { Card, Btn, Pill, Eyebrow, Seg, Metric } from './ui';
 import { EngineSelector } from './tts/EngineSelector';
 import { VoicePreviewButton } from './tts/VoicePreviewButton';
+import { ProviderSelector } from './llm/ProviderSelector';
+import { ModelCombobox } from './llm/ModelCombobox';
+import { LLM_ENV_VARS, llmProviderLabel } from './llm/providerMeta';
 import { AiFill } from './AiFill';
 import { cn } from '../../lib/cn';
 import ArchivesPanel from './ArchivesPanel';
@@ -48,16 +47,9 @@ const SECTIONS = [
 
 type SectionId = (typeof SECTIONS)[number]['id'];
 
-// Cloud LLM providers read their key from this controller env var.
-const LLM_ENV_VARS: Record<string, string> = {
-  anthropic: 'ANTHROPIC_API_KEY',
-  openai: 'OPENAI_API_KEY',
-  google: 'GOOGLE_GENERATIVE_AI_API_KEY',
-  deepseek: 'DEEPSEEK_API_KEY',
-  openrouter: 'OPENROUTER_API_KEY',
-  requesty: 'REQUESTY_API_KEY',
-  gateway: 'AI_GATEWAY_API_KEY',
-};
+// LLM provider descriptors, the cloud-key env-var map and the badge logic live
+// in ./llm/providerMeta (imported above) — shared with the ProviderSelector card
+// grid and, later, the onboarding wizard. Don't redefine them here.
 
 const KEY_HINTS: Record<string, string> = {
   ANTHROPIC_API_KEY: 'sk-ant-...',
@@ -69,22 +61,6 @@ const KEY_HINTS: Record<string, string> = {
   ELEVENLABS_API_KEY: 'el_...',
   EMBEDDING_API_KEY: 'optional — defaults to chat key',
 };
-
-const LLM_PROVIDER_LABELS: Record<string, string> = {
-  ollama: 'Ollama (local/cloud)',
-  locca: 'locca (local llama.cpp, host)',
-  'openai-compatible': 'OpenAI-compatible (llama.cpp, vLLM, LM Studio)',
-  anthropic: 'Anthropic (Claude)',
-  openai: 'OpenAI (GPT)',
-  google: 'Google (Gemini)',
-  deepseek: 'DeepSeek',
-  openrouter: 'OpenRouter (multi-vendor aggregator)',
-  requesty: 'Requesty (multi-vendor aggregator)',
-  gateway: 'Vercel AI Gateway (multi-vendor aggregator)',
-};
-
-const llmProviderLabel = (id: string | undefined): string =>
-  (id && LLM_PROVIDER_LABELS[id]) || id || '—';
 
 // Suggested embedding model ids per provider — clickable chips under the Model
 // field so operators don't have to guess a valid name. The #1 trip-up is typing
@@ -1279,162 +1255,6 @@ function formatGainDb(v: number): string {
   return `${sign}${Math.abs(v).toFixed(1)} dB`;
 }
 
-/* ── ModelCombobox ───────────────────────────────────────────────────── */
-// Searchable model picker. Renders as a trigger button that shows the selected
-// model (or placeholder). Clicking opens an inline popover with a text filter
-// + scrollable list built on cmdk. Falls back to a plain Input when no models
-// are available (discovery hasn't run / returned nothing).
-
-interface ModelComboboxProps {
-  models: string[];
-  value: string;
-  onChange: (v: string) => void;
-  placeholder?: string;
-  disabled?: boolean;
-  className?: string;
-}
-
-function ModelCombobox({ models, value, onChange, placeholder = 'Select a model', disabled, className }: ModelComboboxProps) {
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState('');
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  const [rect, setRect] = useState<{ top: number; left: number; width: number } | null>(null);
-  const [direction, setDirection] = useState<'up' | 'down'>('down');
-
-  // Recompute position when opening
-  const openDropdown = () => {
-    if (triggerRef.current) {
-      const r = triggerRef.current.getBoundingClientRect();
-      const spaceBelow = window.innerHeight - r.bottom;
-      const dir = spaceBelow < 300 ? 'up' : 'down';
-      setDirection(dir);
-
-      const top = dir === 'down'
-        ? r.bottom + window.scrollY + 4
-        : r.top + window.scrollY - 4;
-
-      setRect({ top, left: r.left + window.scrollX, width: r.width });
-    }
-    setOpen(true);
-    setSearch('');
-  };
-
-  // Close on outside click
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (
-        triggerRef.current && !triggerRef.current.contains(e.target as Node) &&
-        dropdownRef.current && !dropdownRef.current.contains(e.target as Node)
-      ) {
-        setOpen(false);
-        setSearch('');
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [open]);
-
-  // Close on scroll/resize
-  useEffect(() => {
-    if (!open) return;
-    const close = (e: Event) => {
-      if (dropdownRef.current && dropdownRef.current.contains(e.target as Node)) return;
-      setOpen(false);
-      setSearch('');
-    };
-    window.addEventListener('scroll', close, true);
-    window.addEventListener('resize', close);
-    return () => { window.removeEventListener('scroll', close, true); window.removeEventListener('resize', close); };
-  }, [open]);
-
-  const filtered = search.trim()
-    ? models.filter(m => m.toLowerCase().includes(search.toLowerCase()))
-    : models;
-
-  const displayValue = value || placeholder;
-
-  const dropdown = open && rect ? createPortal(
-    <div
-      ref={dropdownRef}
-      style={{
-        position: 'absolute',
-        top: rect.top,
-        left: rect.left,
-        width: Math.max(rect.width, 240),
-        zIndex: 9999,
-        transform: direction === 'up' ? 'translateY(-100%)' : undefined,
-      }}
-      className="border border-ink bg-bg shadow-drawer"
-    >
-      <Command shouldFilter={false}>
-        {direction === 'down' && (
-          <CommandInput
-            placeholder="Filter models…"
-            value={search}
-            onValueChange={setSearch}
-          />
-        )}
-        <CommandList>
-          {filtered.length === 0
-            ? <CommandEmpty>No models match.</CommandEmpty>
-            : (
-              <CommandGroup>
-                {filtered.map(m => (
-                  <CommandItem
-                    key={m}
-                    value={m}
-                    onSelect={() => { onChange(m); setOpen(false); setSearch(''); }}
-                    data-selected={m === value}
-                  >
-                    <span className="truncate">{m}</span>
-                    {m === value && (
-                      <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="2" className="shrink-0">
-                        <path d="M2 6.5l3.5 3.5 5.5-6" />
-                      </svg>
-                    )}
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            )
-          }
-        </CommandList>
-        {direction === 'up' && (
-          <CommandInput
-            placeholder="Filter models…"
-            value={search}
-            onValueChange={setSearch}
-            wrapperClassName="border-t border-b-0"
-          />
-        )}
-      </Command>
-    </div>,
-    document.body,
-  ) : null;
-
-  return (
-    <div className={cn('w-full max-w-[360px]', className)}>
-      <button
-        ref={triggerRef}
-        type="button"
-        disabled={disabled}
-        onClick={() => open ? (setOpen(false), setSearch('')) : openDropdown()}
-        className={cn(
-          'flex h-9 w-full items-center justify-between gap-2 border border-ink bg-bg px-3 text-sm',
-          'focus:outline-none disabled:cursor-not-allowed disabled:opacity-40',
-          open && 'ring-1 ring-ink',
-        )}
-      >
-        <span className={cn('truncate', !value && 'text-muted')}>{displayValue}</span>
-        <svg width="12" height="12" viewBox="0 0 12 12" className="shrink-0 text-muted" fill="none" stroke="currentColor" strokeWidth="1.5">
-          <path d="M2 4l4 4 4-4" />
-        </svg>
-      </button>
-      {dropdown}
-    </div>
-  );
-}
 
 // Compact per-engine voice-level control: a labelled range slider + live readout,
 // writing into form.tts.gainDb[engineId]. Dropped into each engine's config panel.
@@ -2483,19 +2303,12 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
               <Label>Provider</Label>
               {llmDirty && <Pill tone="accent" dot>unsaved</Pill>}
             </div>
-            <Select
+            <ProviderSelector
               value={form.llm.provider}
-              onValueChange={changeLlmProvider}
-            >
-              <SelectTrigger className="max-w-[360px]"><SelectValue /></SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  {(data.llm?.providers || ['ollama']).map(p => (
-                    <SelectItem key={p} value={p}>{llmProviderLabel(p)}</SelectItem>
-                  ))}
-                </SelectGroup>
-              </SelectContent>
-            </Select>
+              providerIds={data.llm?.providers || ['ollama']}
+              env={data.env}
+              onChange={changeLlmProvider}
+            />
             <div className="field-hint">
               {llmDirty
                 ? 'Provider changed. Hit "Save LLM provider" below to route every call here.'

--- a/web/components/admin/llm/ModelCombobox.tsx
+++ b/web/components/admin/llm/ModelCombobox.tsx
@@ -1,0 +1,165 @@
+'use client';
+// Searchable model picker. Renders as a trigger button that shows the selected
+// model (or placeholder). Clicking opens an inline popover with a text filter +
+// scrollable list built on cmdk. Falls back (at the call site) to a plain input
+// when no models are available (discovery hasn't run / returned nothing).
+//
+// Extracted from SettingsPanel so the admin Settings tab and the onboarding
+// wizard share one model picker instead of each rolling their own.
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { cn } from '../../../lib/cn';
+import {
+  Command, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem,
+} from '../../ui/command';
+
+interface ModelComboboxProps {
+  models: string[];
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function ModelCombobox({ models, value, onChange, placeholder = 'Select a model', disabled, className }: ModelComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [rect, setRect] = useState<{ top: number; left: number; width: number } | null>(null);
+  const [direction, setDirection] = useState<'up' | 'down'>('down');
+
+  // Recompute position when opening
+  const openDropdown = () => {
+    if (triggerRef.current) {
+      const r = triggerRef.current.getBoundingClientRect();
+      const spaceBelow = window.innerHeight - r.bottom;
+      const dir = spaceBelow < 300 ? 'up' : 'down';
+      setDirection(dir);
+
+      const top = dir === 'down'
+        ? r.bottom + window.scrollY + 4
+        : r.top + window.scrollY - 4;
+
+      setRect({ top, left: r.left + window.scrollX, width: r.width });
+    }
+    setOpen(true);
+    setSearch('');
+  };
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        triggerRef.current && !triggerRef.current.contains(e.target as Node) &&
+        dropdownRef.current && !dropdownRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+        setSearch('');
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  // Close on scroll/resize
+  useEffect(() => {
+    if (!open) return;
+    const close = (e: Event) => {
+      if (dropdownRef.current && dropdownRef.current.contains(e.target as Node)) return;
+      setOpen(false);
+      setSearch('');
+    };
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close);
+    return () => { window.removeEventListener('scroll', close, true); window.removeEventListener('resize', close); };
+  }, [open]);
+
+  const filtered = search.trim()
+    ? models.filter(m => m.toLowerCase().includes(search.toLowerCase()))
+    : models;
+
+  const displayValue = value || placeholder;
+
+  const dropdown = open && rect ? createPortal(
+    <div
+      ref={dropdownRef}
+      style={{
+        position: 'absolute',
+        top: rect.top,
+        left: rect.left,
+        width: Math.max(rect.width, 240),
+        zIndex: 9999,
+        transform: direction === 'up' ? 'translateY(-100%)' : undefined,
+      }}
+      className="border border-ink bg-bg shadow-drawer"
+    >
+      <Command shouldFilter={false}>
+        {direction === 'down' && (
+          <CommandInput
+            placeholder="Filter models…"
+            value={search}
+            onValueChange={setSearch}
+          />
+        )}
+        <CommandList>
+          {filtered.length === 0
+            ? <CommandEmpty>No models match.</CommandEmpty>
+            : (
+              <CommandGroup>
+                {filtered.map(m => (
+                  <CommandItem
+                    key={m}
+                    value={m}
+                    onSelect={() => { onChange(m); setOpen(false); setSearch(''); }}
+                    data-selected={m === value}
+                  >
+                    <span className="truncate">{m}</span>
+                    {m === value && (
+                      <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="2" className="shrink-0">
+                        <path d="M2 6.5l3.5 3.5 5.5-6" />
+                      </svg>
+                    )}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )
+          }
+        </CommandList>
+        {direction === 'up' && (
+          <CommandInput
+            placeholder="Filter models…"
+            value={search}
+            onValueChange={setSearch}
+            wrapperClassName="border-t border-b-0"
+          />
+        )}
+      </Command>
+    </div>,
+    document.body,
+  ) : null;
+
+  return (
+    <div className={cn('w-full max-w-[360px]', className)}>
+      <button
+        ref={triggerRef}
+        type="button"
+        disabled={disabled}
+        onClick={() => open ? (setOpen(false), setSearch('')) : openDropdown()}
+        className={cn(
+          'flex h-9 w-full items-center justify-between gap-2 border border-ink bg-bg px-3 text-sm',
+          'focus:outline-none disabled:cursor-not-allowed disabled:opacity-40',
+          open && 'ring-1 ring-ink',
+        )}
+      >
+        <span className={cn('truncate', !value && 'text-muted')}>{displayValue}</span>
+        <svg width="12" height="12" viewBox="0 0 12 12" className="shrink-0 text-muted" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <path d="M2 4l4 4 4-4" />
+        </svg>
+      </button>
+      {dropdown}
+    </div>
+  );
+}

--- a/web/components/admin/llm/ProviderSelector.tsx
+++ b/web/components/admin/llm/ProviderSelector.tsx
@@ -1,34 +1,40 @@
 'use client';
-// Radio-card grid for picking a TTS engine. Replaces the cramped 5-button
-// segmented control on both the Personas voice card and the Settings voice tab:
-// every engine is a selectable card showing its name, a one-line blurb and a
-// live status badge (ready / sidecar off / no key) so availability is visible
-// before you select. Styled on the newsprint RadioOption pattern. Tailwind-only
-// (no inline styles — issue #50).
+// Radio-card grid for picking the primary LLM provider. Replaces the plain
+// dropdown on the Settings LLM tab: every provider is a selectable card showing
+// its name, a one-line blurb and a live status badge (local / self-host / key
+// set / no key) so key availability is visible before you switch and save — the
+// #1 LLM misconfiguration is routing to a cloud provider whose key isn't set.
+// Styled to match the TTS EngineSelector (newsprint RadioOption pattern).
+// Tailwind-only, no inline styles (issue #50). The fallback leg keeps the
+// dropdown — cards there would double the tab's height for a secondary control.
 import { cn } from '../../../lib/cn';
-import { ENGINE_META, engineStatus } from './engineMeta';
+import { PROVIDER_META, providerStatus } from './providerMeta';
 
-interface EngineSelectorProps {
-  // Currently selected engine id.
+interface ProviderSelectorProps {
+  // Currently selected provider id.
   value: string;
-  // Which engines to show as cards (Personas: all 5; Settings: data.tts.engines).
-  engineIds: string[];
-  // SettingsResponse.tts.available — drives the per-card status badge.
-  available?: Record<string, boolean>;
+  // Which providers to show as cards — pass SettingsResponse.llm.providers so the
+  // grid stays server-authoritative (order + future additions).
+  providerIds: string[];
+  // SettingsResponse.env — which cloud key vars are present; drives the badge.
+  env?: Record<string, unknown>;
+  // false for the onboarding wizard, where there's no live env yet — cloud
+  // providers then read as a neutral "needs key" instead of a red "no key".
+  keyAware?: boolean;
   onChange: (id: string) => void;
   className?: string;
 }
 
-export function EngineSelector({ value, engineIds, available, onChange, className }: EngineSelectorProps) {
+export function ProviderSelector({ value, providerIds, env, keyAware = true, onChange, className }: ProviderSelectorProps) {
   return (
     <div
       role="radiogroup"
-      aria-label="Voice engine"
+      aria-label="LLM provider"
       className={cn('grid grid-cols-2 gap-2.5 md:grid-cols-3', className)}
     >
-      {engineIds.map(id => {
-        const meta = ENGINE_META[id];
-        const status = engineStatus(id, available);
+      {providerIds.map(id => {
+        const meta = PROVIDER_META[id];
+        const status = providerStatus(id, env, keyAware);
         const active = value === id;
         return (
           <button
@@ -45,8 +51,8 @@ export function EngineSelector({ value, engineIds, available, onChange, classNam
             )}
           >
             {/* Title row — dot + name only, full card width. The status badge
-                moved to the bottom row so it never crowds long engine names
-                (CHATTERBOX / POCKETTTS), matching the LLM ProviderSelector. */}
+                moved to the bottom row so it never crowds long names
+                (OPENROUTER / ANTHROPIC / OpenAI-compatible). */}
             <div className="flex items-center gap-1.5">
               <span
                 className={cn(

--- a/web/components/admin/llm/providerMeta.ts
+++ b/web/components/admin/llm/providerMeta.ts
@@ -1,0 +1,110 @@
+// Single source of truth for the LLM provider picker: per-provider descriptors,
+// the cloud-key env-var map, and a pure availability→badge mapping. Mirrors the
+// TTS engineMeta.ts so the Settings LLM tab and the onboarding wizard's LLM step
+// pick a provider from the same list, blurbs and status logic instead of each
+// surface hand-rolling its own. No React, no DOM — safe to unit-import.
+
+export type ProviderKind = 'local' | 'self-hosted' | 'cloud';
+
+export interface ProviderMeta {
+  id: string;
+  // Short display name shown on the card (the dropdown used a longer descriptor;
+  // see LLM_PROVIDER_LABELS for that).
+  label: string;
+  // One-line descriptor under the name — what the operator is choosing.
+  blurb: string;
+  // local: runs on a box you own, no key (ollama/locca). self-hosted: your own
+  // OpenAI-compatible server, key optional. cloud: hosted vendor, needs a key.
+  kind: ProviderKind;
+  // Controller env var the key is read from — cloud providers only.
+  envVar?: string;
+}
+
+// Order mirrors the controller's settings.LLM_PROVIDERS. The card grid actually
+// renders data.llm.providers (server-authoritative), looking each id up here, so
+// a provider the server adds before this map does still renders as a bare card.
+export const PROVIDERS: ProviderMeta[] = [
+  { id: 'ollama',            label: 'Ollama',            blurb: 'Homelab box · no key',          kind: 'local' },
+  { id: 'locca',             label: 'locca',             blurb: 'Local llama.cpp · no key',       kind: 'local' },
+  { id: 'openai-compatible', label: 'OpenAI-compatible', blurb: 'llama.cpp · vLLM · LM Studio',   kind: 'self-hosted' },
+  { id: 'anthropic',         label: 'Anthropic',         blurb: 'Claude · cloud',                 kind: 'cloud', envVar: 'ANTHROPIC_API_KEY' },
+  { id: 'openai',            label: 'OpenAI',            blurb: 'GPT · cloud',                    kind: 'cloud', envVar: 'OPENAI_API_KEY' },
+  { id: 'google',            label: 'Google',            blurb: 'Gemini · cloud',                 kind: 'cloud', envVar: 'GOOGLE_GENERATIVE_AI_API_KEY' },
+  { id: 'deepseek',          label: 'DeepSeek',          blurb: 'Chat & reasoner · cloud',        kind: 'cloud', envVar: 'DEEPSEEK_API_KEY' },
+  { id: 'openrouter',        label: 'OpenRouter',        blurb: 'Multi-vendor aggregator',        kind: 'cloud', envVar: 'OPENROUTER_API_KEY' },
+  { id: 'requesty',          label: 'Requesty',          blurb: 'Multi-vendor aggregator',        kind: 'cloud', envVar: 'REQUESTY_API_KEY' },
+  { id: 'gateway',           label: 'AI Gateway',        blurb: 'Vercel · multi-vendor',          kind: 'cloud', envVar: 'AI_GATEWAY_API_KEY' },
+];
+
+export const PROVIDER_META: Record<string, ProviderMeta> = Object.fromEntries(
+  PROVIDERS.map(p => [p.id, p]),
+);
+
+// Default render order (local first, then cloud). The Settings tab passes the
+// server's data.llm.providers instead; the onboarding wizard — which has no
+// server list yet — maps over this.
+export const PROVIDER_IDS: string[] = PROVIDERS.map(p => p.id);
+
+// Cloud LLM providers read their key from this controller env var. Derived from
+// PROVIDERS so the two never drift; kept as a named export because call sites in
+// SettingsPanel (primaryKeyVar / fallbackKeyVar / KeyStatus) index it directly.
+export const LLM_ENV_VARS: Record<string, string> = Object.fromEntries(
+  PROVIDERS.filter(p => p.envVar).map(p => [p.id, p.envVar as string]),
+);
+
+// Longer, parenthetical descriptors for the dropdown (fallback leg) and the
+// "Routing now" banner, where there's room for the extra context.
+export const LLM_PROVIDER_LABELS: Record<string, string> = {
+  ollama: 'Ollama (local/cloud)',
+  locca: 'locca (local llama.cpp, host)',
+  'openai-compatible': 'OpenAI-compatible (llama.cpp, vLLM, LM Studio)',
+  anthropic: 'Anthropic (Claude)',
+  openai: 'OpenAI (GPT)',
+  google: 'Google (Gemini)',
+  deepseek: 'DeepSeek',
+  openrouter: 'OpenRouter (multi-vendor aggregator)',
+  requesty: 'Requesty (multi-vendor aggregator)',
+  gateway: 'Vercel AI Gateway (multi-vendor aggregator)',
+};
+
+export const llmProviderLabel = (id: string | undefined): string =>
+  (id && LLM_PROVIDER_LABELS[id]) || id || '—';
+
+export type ProviderStatusTone = 'ok' | 'warn';
+export interface ProviderStatus {
+  label: string;
+  tone: ProviderStatusTone;
+}
+
+// Pure: derive a provider's status badge from the controller's env map
+// (SettingsResponse.env — which cloud key vars are present). Local providers are
+// always "ready" (no key to miss); a self-hosted OpenAI-compatible server takes
+// an optional bearer token, so it reads as ready too. A cloud provider whose key
+// var isn't set is the one case we flag `warn` ("no key") — that's the #1
+// switch-and-it-fails misconfiguration this grid exists to surface before save.
+//
+// keyAware=false is the onboarding case: first-run has no live controller env
+// (the key is typed into the wizard, not yet on the box), so we can't say
+// whether a key is set. Cloud providers then read as a neutral "needs key"
+// instead of an alarming red "no key" the operator is about to resolve below.
+export function providerStatus(
+  id: string,
+  env: Record<string, unknown> | undefined,
+  keyAware = true,
+): ProviderStatus {
+  const meta = PROVIDER_META[id];
+  if (!meta) return { label: '', tone: 'ok' };
+  switch (meta.kind) {
+    case 'local':
+      return { label: 'local', tone: 'ok' };
+    case 'self-hosted':
+      return { label: 'self-host', tone: 'ok' };
+    case 'cloud':
+      if (!keyAware) return { label: 'needs key', tone: 'ok' };
+      return meta.envVar && (env || {})[meta.envVar]
+        ? { label: 'key set', tone: 'ok' }
+        : { label: 'no key', tone: 'warn' };
+    default:
+      return { label: '', tone: 'ok' };
+  }
+}

--- a/web/components/onboarding/steps.tsx
+++ b/web/components/onboarding/steps.tsx
@@ -2,6 +2,10 @@
 
 import { useState } from 'react';
 import type { WizardController } from './useWizard';
+import { ProviderSelector } from '../admin/llm/ProviderSelector';
+import { ModelCombobox } from '../admin/llm/ModelCombobox';
+import { PROVIDER_IDS } from '../admin/llm/providerMeta';
+import { useModelDiscovery } from '@/hooks/useModelDiscovery';
 
 // Tiny presentation primitives kept local to the wizard — avoids dragging the
 // full admin UI library into a screen most operators see exactly once.
@@ -142,25 +146,12 @@ export function NavidromeStep({ w }: { w: WizardController }) {
 }
 
 // ─── LLM ───────────────────────────────────────────────────────────────────
-const LLM_PROVIDERS = [
-  { id: 'ollama', label: 'Ollama (local, no key)' },
-  { id: 'locca', label: 'locca (local llama.cpp, no key)' },
-  { id: 'anthropic', label: 'Anthropic Claude' },
-  { id: 'openai', label: 'OpenAI' },
-  { id: 'google', label: 'Google Gemini' },
-  { id: 'deepseek', label: 'DeepSeek' },
-  { id: 'openrouter', label: 'OpenRouter' },
-  { id: 'requesty', label: 'Requesty' },
-  { id: 'gateway', label: 'Vercel AI Gateway' },
-  { id: 'openai-compatible', label: 'OpenAI-compatible (self-hosted)' },
-];
+// Provider list, labels and blurbs come from the shared admin/llm/providerMeta
+// module (PROVIDER_IDS + the ProviderSelector card grid) so onboarding and the
+// admin Settings tab never drift.
 
 export function LlmStep({ w }: { w: WizardController }) {
   const [busy, setBusy] = useState(false);
-  const [discovering, setDiscovering] = useState(false);
-  const [discovery, setDiscovery] = useState<
-    { reachable: boolean; models: string[]; error?: string } | null
-  >(null);
   const isOllama = w.data.llm.provider === 'ollama';
   const isLocca = w.data.llm.provider === 'locca';
   const isCustom = w.data.llm.provider === 'openai-compatible';
@@ -169,12 +160,21 @@ export function LlmStep({ w }: { w: WizardController }) {
     await w.testLlm();
     setBusy(false);
   };
-  const onDiscover = async () => {
-    setDiscovering(true);
-    setDiscovery(null);
-    setDiscovery(await w.discoverLocca());
-    setDiscovering(false);
-  };
+  // Same unified model discovery the admin Settings tab uses. Enabled for the
+  // keyless-discoverable providers (ollama / locca / openai-compatible with a
+  // base URL / openrouter); cloud providers need their key saved on the box
+  // first, so they fall back to free-typing the model id.
+  const discoveryEnabled =
+    isOllama || isLocca ||
+    (isCustom && !!w.data.llm.baseUrl.trim()) ||
+    w.data.llm.provider === 'openrouter';
+  const discovery = useModelDiscovery({
+    provider: w.data.llm.provider,
+    baseUrl: w.data.llm.baseUrl,
+    ollamaUrl: w.data.llm.ollamaUrl,
+    enabled: discoveryEnabled,
+    adminFetch: w.auth.adminFetch,
+  });
   return (
     <div>
       <StepHeader
@@ -182,26 +182,19 @@ export function LlmStep({ w }: { w: WizardController }) {
         blurb="The DJ talks between tracks. Ollama running on the host is the homelab default — no API key needed."
       />
       <div className="grid gap-3">
-        <Field label="Provider">
-          <Select
+        {/* Not wrapped in <Field> — that renders a <label>, and a label around a
+            radiogroup of buttons hijacks clicks. Inline the same label styling. */}
+        <div className="flex flex-col gap-1">
+          <span className="text-xs font-medium tracking-wide text-ink/60 uppercase">Provider</span>
+          <ProviderSelector
             value={w.data.llm.provider}
-            onChange={e =>
-              w.patch(d => ({ llm: { ...d.llm, provider: e.target.value }, llmTest: { ok: null } }))
+            providerIds={PROVIDER_IDS}
+            keyAware={false}
+            onChange={id =>
+              w.patch(d => ({ llm: { ...d.llm, provider: id }, llmTest: { ok: null } }))
             }
-          >
-            {LLM_PROVIDERS.map(p => (
-              <option key={p.id} value={p.id}>
-                {p.label}
-              </option>
-            ))}
-          </Select>
-        </Field>
-        <Field label="Model" hint="e.g. llama3.1:8b · claude-sonnet-4 · gpt-4o-mini">
-          <TextInput
-            value={w.data.llm.model}
-            onChange={e => w.patch(d => ({ llm: { ...d.llm, model: e.target.value }, llmTest: { ok: null } }))}
           />
-        </Field>
+        </div>
         {isOllama && (
           <Field label="Ollama URL" hint="Reachable from the controller container">
             <TextInput
@@ -236,48 +229,6 @@ export function LlmStep({ w }: { w: WizardController }) {
             />
           </Field>
         )}
-        {isLocca && (
-          <div className="grid gap-2">
-            <button
-              type="button"
-              onClick={onDiscover}
-              disabled={discovering}
-              className="w-fit rounded border border-ink px-3 py-1.5 text-xs font-medium tracking-wide uppercase hover:bg-ink hover:text-bg disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              {discovering ? 'Detecting…' : 'Detect locca models'}
-            </button>
-            {discovery && !discovery.reachable && (
-              <p className="text-xs text-amber-300">
-                No locca server reachable{discovery.error ? ` (${discovery.error})` : ''}. Start one
-                with <code>locca serve &lt;model&gt; --yes</code> on the host, then retry.
-              </p>
-            )}
-            {discovery && discovery.reachable && discovery.models.length === 0 && (
-              <p className="text-xs text-amber-300">locca is up but has no model loaded.</p>
-            )}
-            {discovery && discovery.reachable && discovery.models.length > 0 && (
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="text-xs text-ink/60">✓ locca detected — pick a model:</span>
-                {discovery.models.map(id => (
-                  <button
-                    key={id}
-                    type="button"
-                    onClick={() =>
-                      w.patch(d => ({ llm: { ...d.llm, model: id }, llmTest: { ok: null } }))
-                    }
-                    className={`rounded border px-2 py-1 text-xs ${
-                      w.data.llm.model === id
-                        ? 'border-ink bg-ink text-bg'
-                        : 'border-ink/40 hover:border-ink'
-                    }`}
-                  >
-                    {id}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
         {!isOllama && !isLocca && (
           <Field label="API key" hint="Stored in state/secrets.env (mode 0600), not in settings.json">
             <TextInput
@@ -289,6 +240,51 @@ export function LlmStep({ w }: { w: WizardController }) {
             />
           </Field>
         )}
+        {/* Model — inlined label (not <Field>): the discovery combobox trigger is
+            a <button>, and a <label> wrapping it would hijack the click. Same
+            unified picker + free-type fallback as the admin Settings tab. */}
+        <div className="flex flex-col gap-1">
+          <span className="text-xs font-medium tracking-wide text-ink/60 uppercase">Model</span>
+          <div className="flex items-stretch gap-2">
+            {discovery.models.length > 0 ? (
+              <ModelCombobox
+                models={discovery.models}
+                value={w.data.llm.model}
+                onChange={v => w.patch(d => ({ llm: { ...d.llm, model: v }, llmTest: { ok: null } }))}
+                placeholder="Select a model"
+              />
+            ) : (
+              <TextInput
+                value={w.data.llm.model}
+                onChange={e => w.patch(d => ({ llm: { ...d.llm, model: e.target.value }, llmTest: { ok: null } }))}
+                placeholder={isOllama ? 'glm-5.1:cloud' : (isCustom || isLocca) ? 'model filename or id' : 'e.g. claude-sonnet-4 · gpt-4o-mini'}
+                className="max-w-[360px] flex-1"
+              />
+            )}
+            {discovery.loading
+              ? <span className="self-center text-xs whitespace-nowrap text-ink/50">discovering…</span>
+              : discoveryEnabled && (
+                <button
+                  type="button"
+                  onClick={discovery.refresh}
+                  title="Refresh model list"
+                  className="rounded border border-ink px-2.5 text-sm hover:bg-ink hover:text-bg"
+                >↻</button>
+              )
+            }
+          </div>
+          <span className="text-xs text-ink/50">
+            {discovery.models.length > 0
+              ? `${discovery.models.length} model${discovery.models.length !== 1 ? 's' : ''} discovered — pick one or filter.`
+              : discoveryEnabled
+                ? (discovery.error
+                    ? `Discovery failed: ${discovery.error}. Type a model ID manually.`
+                    : discovery.loading
+                      ? 'Discovering models…'
+                      : 'No models found yet — set the URL above, or type a model ID.')
+                : 'Type the model ID. Discovery runs here once the API key is saved.'}
+          </span>
+        </div>
         <div>
           <button
             type="button"

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -209,8 +209,13 @@ export default defineConfig([
   // per-mood and per-size (face/antenna dimensions, tilt, scale) over the theme
   // tokens, so it's intrinsically inline-styled and can't be static Tailwind
   // utilities — same dynamic-styling deal as the Observatory above.
+  //
+  // ModelCombobox is also here: its dropdown is portalled to <body> and
+  // absolutely positioned from a runtime getBoundingClientRect (top/left/width),
+  // so the position style is intrinsically dynamic. It was previously inline in
+  // SettingsPanel (already exempt) before being extracted for reuse.
   {
-    files: ['components/BoothBuddy.tsx', 'components/admin/SettingsPanel.tsx'],
+    files: ['components/BoothBuddy.tsx', 'components/admin/SettingsPanel.tsx', 'components/admin/llm/ModelCombobox.tsx'],
     rules: {
       'react/forbid-dom-props': 'off',
     },


### PR DESCRIPTION
## What

Reworks the LLM provider and TTS engine pickers into card grids, and gives the onboarding model field the same searchable model-discovery dropdown as the admin Settings tab.

### LLM provider cards
- New shared `web/components/admin/llm/{providerMeta, ProviderSelector}`: a radio-card grid (name + blurb + key-aware status badge) replacing the plain dropdown, used by **both** the admin Settings tab and the onboarding wizard.
- The status badge sits on the card's **bottom row** with smaller fonts, so long names (OpenAI-compatible / OpenRouter / Anthropic) no longer collide with it.
- Onboarding passes `keyAware={false}` → cloud providers read a neutral `needs key` rather than the admin tab's red `no key` (the key isn't on the box yet during first-run).

### TTS engine cards
- Same bottom-badge layout applied to the shared `EngineSelector`, fixing `CHATTERBOX` / `POCKETTTS` truncating to `CHATTE…` / `POCKE…` on the Settings TTS tab and the Personas voice card.

### Onboarding model dropdown
- Extracted `ModelCombobox` into a shared module and wired the onboarding model field to `useModelDiscovery` — the same searchable dropdown as Settings. Reordered the wizard fields so the server URL precedes the model (so discovery has a base to probe).

### Cleanup
- De-duped the LLM provider labels + env-var maps into `providerMeta` (net −182 lines in `SettingsPanel`).
- Extended the dynamic-inline-style eslint exemption to the extracted `ModelCombobox` (its dropdown is portalled and positioned at runtime).

## Testing
- `npm run lint` (eslint + `tsc --noEmit`) clean.
- Manually verified in the browser against a live dev stack: admin provider grid + selection/dirty/restore, onboarding provider grid (neutral badges), TTS engine cards, admin model dropdown (post-extraction, no regression), onboarding model dropdown (11 models discovered live).
