### PR TITLE
fix(web): stop backup tab from triggering the browser's native auth popup

### DIFF
--- a/web/components/admin/BackupPanel.tsx
+++ b/web/components/admin/BackupPanel.tsx
@@ -44,7 +44,7 @@ function fmtSize(bytes: number): string {
 }
 
 export default function BackupPanel() {
-  const { adminFetch } = useAdminAuth();
+  const { adminFetch, hydrated, needsAuth } = useAdminAuth();
   const fileRef = useRef<HTMLInputElement>(null);
 
   const [exporting, setExporting] = useState(false);
@@ -110,9 +110,14 @@ export default function BackupPanel() {
     }
   }, [adminFetch]);
 
+  // Wait for the cached token to hydrate before the first fetch. Firing it
+  // immediately sends an unauthenticated /backup/restorable, and the
+  // controller's 401 carries `WWW-Authenticate: Basic`, which makes the
+  // browser pop its native login dialog. Mirrors the gate in the other panels.
   useEffect(() => {
+    if (!hydrated || needsAuth) return;
     loadDiskFiles();
-  }, [loadDiskFiles]);
+  }, [hydrated, needsAuth, loadDiskFiles]);
 
   const onPick = (e: React.ChangeEvent<HTMLInputElement>) => {
     const f = e.target.files?.[0] || null;


### PR DESCRIPTION
## What

The admin **Backup** tab pops the browser's native HTTP Basic username/password dialog when you open it, even though you're already signed into the admin shell.

## Why

`BackupPanel` auto-loads the disk-restore list on mount:

```tsx
useEffect(() => {
  loadDiskFiles();   // → adminFetch('/backup/restorable')
}, [loadDiskFiles]);
```

But `useAdminAuth` starts each instance with `auth = null` and only reads the cached token out of `localStorage` in its own `useEffect`. On the first render that effect hasn't applied yet, so the first `/backup/restorable` request goes out **without** the `Authorization` header. The controller's `requireAdmin` answers that unauthenticated request with a `401` carrying `WWW-Authenticate: Basic realm="SUB/WAVE admin"`, and the browser reacts to that header by showing its native login dialog.

Every other panel that fetches on mount already guards against this (`DoctorPanel`, `SettingsPanel` gate on `hydrated`/`needsAuth`). `BackupPanel` was the one panel firing unconditionally.

## Fix

Gate the on-mount fetch on `hydrated && !needsAuth` so the first request always carries the cached token. No unauthenticated 401 → no `WWW-Authenticate` challenge → no native popup.

## Testing

- `npm run lint` (eslint + `tsc --noEmit`) passes clean in `web/`.