### PR TITLE
feat(admin): clear-archive button + DELETE /archives endpoint

### DIFF
--- a/controller/src/broadcast/archives.ts
+++ b/controller/src/broadcast/archives.ts
@@ -9,7 +9,7 @@
 // archive directory by hand, so we don't watch for changes; each /archives
 // GET re-scans. Two-level directory walk is cheap (one entry per hour).
 
-import { readdir, stat } from 'node:fs/promises';
+import { readdir, stat, rm } from 'node:fs/promises';
 import { createReadStream, existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { config } from '../config.js';
@@ -86,4 +86,43 @@ export function resolveEntry(rel: string): string | null {
 
 export function openStream(abs: string) {
   return createReadStream(abs);
+}
+
+// Delete every hourly recording under the archive root. Only YYYY-MM-DD day
+// directories are removed — anything else in the tree (notably the `.ndignore`
+// the broadcast entrypoint drops here to keep these mixdowns out of a
+// co-located Navidrome scan) is left untouched. Returns how many hour files
+// were removed and the bytes freed, for the operator's confirmation toast.
+//
+// Safe to run while on air: if Liquidsoap currently holds this hour's file
+// open, the unlink just detaches the name — it keeps writing to the now-orphan
+// inode and reopens a fresh file at the next HH:00 (output.file reopen_when).
+export async function clearAll(): Promise<{ removed: number; bytes: number }> {
+  if (!existsSync(ARCHIVE_ROOT)) return { removed: 0, bytes: 0 };
+  let dayDirs: string[] = [];
+  try {
+    dayDirs = (await readdir(ARCHIVE_ROOT)).filter(d => DATE_RE.test(d));
+  } catch {
+    return { removed: 0, bytes: 0 };
+  }
+
+  let removed = 0;
+  let bytes = 0;
+  for (const date of dayDirs) {
+    const dir = join(ARCHIVE_ROOT, date);
+    // Tally the hour files before the directory goes, for the report.
+    try {
+      for (const f of await readdir(dir)) {
+        if (!HOUR_RE.test(f)) continue;
+        try {
+          const st = await stat(join(dir, f));
+          if (st.isFile()) { removed += 1; bytes += st.size; }
+        } catch {}
+      }
+    } catch {}
+    try {
+      await rm(dir, { recursive: true, force: true });
+    } catch {}
+  }
+  return { removed, bytes };
 }

--- a/controller/src/routes/archives.ts
+++ b/controller/src/routes/archives.ts
@@ -4,7 +4,8 @@
 import express from 'express';
 import { statSync } from 'node:fs';
 import { requireAdmin } from '../middleware/auth.js';
-import { list, resolveEntry, openStream } from '../broadcast/archives.js';
+import { list, resolveEntry, openStream, clearAll } from '../broadcast/archives.js';
+import { queue } from '../broadcast/queue.js';
 
 export const router = express.Router();
 
@@ -12,6 +13,19 @@ router.get('/archives', requireAdmin, async (req, res) => {
   try {
     const limit = Math.min(parseInt(String(req.query.limit ?? ''), 10) || 500, 5000);
     res.json({ archives: await list({ limit }) });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Wipe every hourly recording — the collection-level DELETE (there is no
+// per-file delete; the operator either keeps a download or clears the lot).
+// Safe on air: see clearAll() in broadcast/archives.ts.
+router.delete('/archives', requireAdmin, async (_req, res) => {
+  try {
+    const result = await clearAll();
+    queue.log('scheduler', `archive cleared — ${result.removed} hour(s), ${result.bytes} bytes freed`);
+    res.json({ ok: true, ...result });
   } catch (err: any) {
     res.status(500).json({ error: err.message });
   }

--- a/web/components/admin/ArchivesPanel.tsx
+++ b/web/components/admin/ArchivesPanel.tsx
@@ -1,14 +1,15 @@
 'use client';
 
 // Archives — /admin/archives. The hourly broadcast recordings Liquidsoap
-// writes under state/archive/. Read-only: download or delete via the file
-// system, no playback controls here (these MP3s are an hour long each and
-// the browser audio element doesn't seek well into them).
+// writes under state/archive/. Download a single hour or clear the whole lot;
+// no playback controls here (these MP3s are an hour long each and the browser
+// audio element doesn't seek well into them).
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { fmtSize, relTime } from '../../lib/format';
 import { Card, Btn, Eyebrow, Pill } from './ui';
+import { V3AlertDialog } from '../ui/alert-dialog';
 
 interface ArchiveEntry {
   path: string;
@@ -32,25 +33,44 @@ export default function ArchivesPanel() {
   const [err, setErr] = useState<string | null>(null);
   const [downloading, setDownloading] = useState<string | null>(null);
   const [dlErr, setDlErr] = useState<string | null>(null);
+  const [confirmClear, setConfirmClear] = useState(false);
+  const [clearing, setClearing] = useState(false);
+  const [clearErr, setClearErr] = useState<string | null>(null);
+
+  const load = useCallback(async (): Promise<void> => {
+    try {
+      const r = await adminFetch('/archives');
+      if (!r.ok) throw new Error(`failed (${r.status})`);
+      const j = (await r.json()) as ArchivesResponse;
+      setEntries(Array.isArray(j.archives) ? j.archives : []);
+      setErr(null);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    }
+  }, [adminFetch]);
 
   useEffect(() => {
     if (!hydrated || needsAuth) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const r = await adminFetch('/archives');
-        if (!r.ok) throw new Error(`failed (${r.status})`);
-        const j = (await r.json()) as ArchivesResponse;
-        if (cancelled) return;
-        setEntries(Array.isArray(j.archives) ? j.archives : []);
-        setErr(null);
-      } catch (e) {
-        if (cancelled) return;
-        setErr(e instanceof Error ? e.message : String(e));
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [hydrated, needsAuth, adminFetch]);
+    void load();
+  }, [hydrated, needsAuth, load]);
+
+  // Wipe every recording in one shot — the only delete affordance (per-file
+  // delete isn't worth the UI for hour-long mixdowns). Re-fetches the now-empty
+  // list on success so the panel reflects the freed disk immediately.
+  const clearArchive = async () => {
+    setClearing(true);
+    setClearErr(null);
+    try {
+      const r = await adminFetch('/archives', { method: 'DELETE' });
+      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      await load();
+    } catch (e) {
+      setClearErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setClearing(false);
+    }
+  };
 
   // Group by date — the operator's mental model is "let me grab yesterday's
   // 9am hour", not "give me a flat list of 720 mp3s sorted by mtime".
@@ -134,11 +154,23 @@ export default function ArchivesPanel() {
         <div className="flex items-center gap-4 bg-[var(--ink-softer)] p-3.5">
           <span className="caption">{entries.length} hour{entries.length === 1 ? '' : 's'}</span>
           <span className="caption text-vermilion">{fmtSize(totalBytes)} total</span>
+          <Btn
+            sm
+            tone="danger"
+            className="ml-auto"
+            onClick={() => setConfirmClear(true)}
+            disabled={clearing || entries.length === 0}
+          >
+            {clearing ? 'Clearing…' : 'Clear archive'}
+          </Btn>
         </div>
       </section>
 
       {dlErr && (
         <div className="text-[12px] text-[var(--danger)]">download error: {dlErr}</div>
+      )}
+      {clearErr && (
+        <div className="text-[12px] text-[var(--danger)]">clear failed: {clearErr}</div>
       )}
 
       {byDate.length === 0 && (
@@ -177,6 +209,22 @@ export default function ArchivesPanel() {
           </ul>
         </Card>
       ))}
+
+      <V3AlertDialog
+        open={confirmClear}
+        onOpenChange={setConfirmClear}
+        danger
+        title="Clear archive"
+        description={
+          <>
+            Permanently delete all {entries.length} recorded hour{entries.length === 1 ? '' : 's'}
+            {' '}({fmtSize(totalBytes)})? This frees the disk under <code>state/archive/</code> and
+            cannot be undone. The current hour keeps recording.
+          </>
+        }
+        confirmLabel="clear archive"
+        onConfirm={clearArchive}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## What

Adds a **"Clear archive"** button to the admin **Settings → Archives** tab. It wipes every hourly recording under `state/archive/` in one shot, behind a danger confirmation that shows exactly what will be deleted (e.g. *"Permanently delete all 47 recorded hours (3.2 GB)? … The current hour keeps recording."*). The list refetches on success so freed disk is reflected immediately.

## Why

The Archives panel could already download individual hours but had no way to delete them — the header even told operators recordings are "kept until the operator deletes them," with no affordance to do so. There's no automatic rotation, so a 24/7 station needs a way to reclaim disk from the UI.

## How

- **`controller/src/broadcast/archives.ts`** — new `clearAll()` removes only `YYYY-MM-DD` day directories, deliberately preserving the `.ndignore` the broadcast entrypoint drops there (so a co-located Navidrome keeps ignoring the dir). Returns `{ removed, bytes }` for the confirmation/log.
- **`controller/src/routes/archives.ts`** — new `DELETE /archives` (`requireAdmin`), audit-logged via `queue.log`, mirroring the existing GET route.
- **`web/components/admin/ArchivesPanel.tsx`** — danger `Btn` in the summary header + `V3AlertDialog` confirm, matching the existing jingle/SFX delete patterns; dedicated `clearErr` state for honest error labeling.

## Safety

Safe to run on air: if Liquidsoap holds the current hour's MP3 open, the unlink only detaches the name — it keeps writing to the orphaned inode and reopens a fresh file at the next `HH:00`. Music never stops.

## Verification

`npm run lint` (eslint + tsc) passes with 0 errors in both `controller/` and `web/` — the repo's merge gate.