### PR TITLE
feat(admin): card-grid embedding provider picker for the library tagger

### DIFF
--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -21,6 +21,7 @@ import { Card, Btn, Pill, Eyebrow, Seg, Metric } from './ui';
 import { EngineSelector } from './tts/EngineSelector';
 import { VoicePreviewButton } from './tts/VoicePreviewButton';
 import { ProviderSelector } from './llm/ProviderSelector';
+import { EmbeddingProviderSelector } from './embedding/EmbeddingProviderSelector';
 import { ModelCombobox } from './llm/ModelCombobox';
 import { LLM_ENV_VARS, llmProviderLabel } from './llm/providerMeta';
 import { AiFill } from './AiFill';
@@ -3544,27 +3545,16 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
         <div className="grid gap-[18px]">
           <div className="field">
             <Label>Provider</Label>
-            <Select
-              value={e.provider || '__follow__'}
-              onValueChange={v =>
-                setForm(f => ({
-                  ...f,
-                  embedding: { ...f.embedding, provider: v === '__follow__' ? '' : v },
-                }))
+            <EmbeddingProviderSelector
+              value={e.provider || ''}
+              providerIds={providers}
+              llmProvider={llmProvider}
+              env={data.env}
+              onChange={v =>
+                setForm(f => ({ ...f, embedding: { ...f.embedding, provider: v } }))
               }
-            >
-              <SelectTrigger className="max-w-[360px]"><SelectValue /></SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  <SelectItem value="__follow__">
-                    Follow LLM provider — {llmProviderLabel(llmProvider)}
-                  </SelectItem>
-                  {providers.map(p => (
-                    <SelectItem key={p} value={p}>{llmProviderLabel(p)}</SelectItem>
-                  ))}
-                </SelectGroup>
-              </SelectContent>
-            </Select>
+              className="max-w-[560px]"
+            />
             <div className="field-hint">
               Where the text embeddings come from. Default follows your LLM
               provider, so Ollama-local users get <code>nomic-embed-text</code> free.

--- a/web/components/admin/embedding/EmbeddingProviderSelector.tsx
+++ b/web/components/admin/embedding/EmbeddingProviderSelector.tsx
@@ -1,0 +1,133 @@
+'use client';
+// Radio-card grid for picking the library tagger's embedding provider. Mirrors
+// the LLM ProviderSelector / TTS EngineSelector card grids, with one extra card
+// up front: "Follow LLM" (value ''), the default, which routes embeddings through
+// whatever provider the DJ LLM already uses. Reuses the LLM provider descriptors
+// and status logic — embedding providers are a subset of the LLM list — so the
+// blurbs and key badges stay in lockstep with the LLM tab. Tailwind-only, no
+// inline styles (issue #50).
+import { cn } from '../../../lib/cn';
+import { PROVIDER_META, providerStatus, type ProviderStatus } from '../llm/providerMeta';
+
+interface EmbeddingProviderSelectorProps {
+  // Currently selected provider id; '' means "follow the LLM provider".
+  value: string;
+  // Embedding-capable provider ids to show as cards (SettingsResponse.embedding
+  // .providers, possibly with a stale explicit choice prepended). The "Follow
+  // LLM" card is always rendered first, on top of these.
+  providerIds: string[];
+  // The LLM provider id the "Follow LLM" card resolves to right now — shown as
+  // that card's blurb so the operator sees what "follow" means before saving.
+  llmProvider: string;
+  // SettingsResponse.env — which cloud key vars are present; drives the badge.
+  env?: Record<string, unknown>;
+  // '' for the Follow card, otherwise the provider id.
+  onChange: (id: string) => void;
+  className?: string;
+}
+
+export function EmbeddingProviderSelector({
+  value,
+  providerIds,
+  llmProvider,
+  env,
+  onChange,
+  className,
+}: EmbeddingProviderSelectorProps) {
+  const followLabel = PROVIDER_META[llmProvider]?.label || llmProvider;
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Embedding provider"
+      className={cn('grid grid-cols-2 gap-2.5 md:grid-cols-3', className)}
+    >
+      {/* Follow-LLM card — the default. Same card chrome as the rest, but its
+          blurb is the live resolved LLM provider, not a static descriptor. */}
+      <ProviderCard
+        active={value === ''}
+        label="Follow LLM"
+        blurb={`Same as DJ · ${followLabel}`}
+        status={{ label: 'default', tone: 'ok' }}
+        onClick={() => onChange('')}
+      />
+      {providerIds.map(id => {
+        const meta = PROVIDER_META[id];
+        return (
+          <ProviderCard
+            key={id}
+            active={value === id}
+            label={meta?.label || id}
+            blurb={meta?.blurb}
+            status={providerStatus(id, env)}
+            onClick={() => onChange(id)}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+// One selectable card — kept private to this file; the chrome is copied from the
+// LLM ProviderSelector so the two grids read identically.
+function ProviderCard({
+  active,
+  label,
+  blurb,
+  status,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  blurb?: string;
+  status: ProviderStatus;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={active}
+      onClick={onClick}
+      className={cn(
+        'grid cursor-pointer content-start gap-1.5 border p-3 text-left font-[inherit]',
+        active
+          ? 'border-[var(--accent)] bg-[var(--accent-soft)]'
+          : 'border-ink bg-transparent hover:bg-[var(--ink-softer)]',
+      )}
+    >
+      {/* Title row — dot + name only, full card width. */}
+      <div className="flex items-center gap-1.5">
+        <span
+          className={cn(
+            'size-2 flex-none rounded-full border',
+            active ? 'border-[var(--accent)] bg-[var(--accent)]' : 'border-ink bg-transparent',
+          )}
+        />
+        <span
+          className={cn(
+            'min-w-0 text-[10px] font-bold tracking-[0.16em] break-words uppercase',
+            active ? 'text-vermilion' : 'text-ink',
+          )}
+        >
+          {label}
+        </span>
+      </div>
+      {/* Bottom row — blurb on the left, status badge pinned bottom-right. */}
+      <div className="flex items-end justify-between gap-2">
+        <span className="min-w-0 text-[9px] leading-[1.4] text-muted">{blurb}</span>
+        {status.label && (
+          <span
+            className={cn(
+              'flex-none border px-1 py-[1px] text-[8px] font-bold tracking-[0.1em] uppercase',
+              status.tone === 'warn'
+                ? 'border-[var(--danger)] text-[var(--danger)]'
+                : 'border-[color:var(--separator-strong)] text-muted',
+            )}
+          >
+            {status.label}
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}


### PR DESCRIPTION
## What

Convert the **Library tagger → Embedding server → Provider** picker (admin → Settings) from a plain dropdown into the radio-card grid used for the LLM provider and TTS engine pickers in #645.

## How

- New `web/components/admin/embedding/EmbeddingProviderSelector.tsx` — a radio-card grid that reuses the LLM provider descriptors and `providerStatus()` from `llm/providerMeta.ts` (embedding providers are a subset of the LLM list), so the per-card blurbs and live `local / self-host / key set / no key` badges stay in lockstep with the LLM tab.
- `SettingsPanel.tsx` Library section swaps the `<Select>` for the new component (net −10 lines there).

## Notes

- The tagger's **"Follow LLM provider"** default has no native card equivalent, so it renders as the **first card** ("Follow LLM", value `''`, `default` badge) with its blurb showing the live resolved LLM provider (e.g. `Same as DJ · Ollama`).
- Selection semantics unchanged: follow → `''`, otherwise the provider id. The stale-explicit-choice handling and the `!canEmbed` warning beneath the picker are untouched.

## Verification

`npm run lint` in `web/` (eslint + `tsc --noEmit`) passes.
