### PR TITLE
feat(admin): reorder theme tab, left-align create button, add theme removal

### DIFF
--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -13,7 +13,7 @@ import * as session from '../broadcast/session.js';
 import { getStreamStatus } from '../broadcast/listeners.js';
 import { getSetupStatusSync } from '../setup/firstRun.js';
 import { getStationTimezone } from '../time.js';
-import { listThemes, DEFAULT_THEME_ID } from '../themes.js';
+import { listThemesAnnotated, DEFAULT_THEME_ID } from '../themes.js';
 import { lifetimeTokenCount } from '../llm/log.js';
 
 export const router = express.Router();
@@ -321,7 +321,7 @@ router.get('/state', (req, res) => {
 router.get('/themes', async (req, res) => {
   try {
     const s = settings.get();
-    const themes = await listThemes();
+    const themes = await listThemesAnnotated();
     const stationDefault = s?.theme?.active || DEFAULT_THEME_ID;
     const activeShow = settings.resolveActiveShow();
     // Show override wins only if it still resolves to a known theme. A stale

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -26,7 +26,7 @@ import { createDeepSeek } from '@ai-sdk/deepseek';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 import { tagger } from '../broadcast/tagger.js';
 import { skillCatalog } from '../skills/_agent.js';
-import { clearUserThemeCache, loadUserThemes, listThemes, saveUserTheme } from '../themes.js';
+import { clearUserThemeCache, loadUserThemes, listThemesAnnotated, saveUserTheme, deleteUserTheme } from '../themes.js';
 
 export const router = express.Router();
 
@@ -799,7 +799,7 @@ router.post('/themes/refresh', requireAdmin, async (req, res) => {
   try {
     clearUserThemeCache();
     await loadUserThemes(true);
-    const themes = await listThemes();
+    const themes = await listThemesAnnotated();
     res.json({ ok: true, themes });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -815,6 +815,21 @@ router.post('/themes/refresh', requireAdmin, async (req, res) => {
 router.post('/themes', requireAdmin, async (req, res) => {
   try {
     const themes = await saveUserTheme(req.body || {});
+    res.json({ ok: true, themes });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /themes/:id — remove a user theme file from ${STATE_DIR}/themes/.
+// Built-in ids are reserved and rejected. The admin UI reassigns the active
+// theme when it deletes the one in use, so this route only touches the file.
+// Returns the refreshed registry.
+// ---------------------------------------------------------------------------
+router.delete('/themes/:id', requireAdmin, async (req, res) => {
+  try {
+    const themes = await deleteUserTheme(req.params.id);
     res.json({ ok: true, themes });
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/controller/src/themes.ts
+++ b/controller/src/themes.ts
@@ -193,6 +193,15 @@ export async function listThemes(): Promise<Theme[]> {
   return [...BUILTIN_THEMES, ...user];
 }
 
+export type ThemeListItem = Theme & { builtin: boolean };
+
+// Same registry as listThemes(), but each entry is tagged with whether it's a
+// built-in. The admin UI uses the flag to gate the per-theme Remove button so
+// only user themes (state/themes/*.json) can be deleted.
+export async function listThemesAnnotated(): Promise<ThemeListItem[]> {
+  return (await listThemes()).map(t => ({ ...t, builtin: BUILTIN_IDS.has(t.id) }));
+}
+
 export async function getTheme(id: string): Promise<Theme> {
   const all = await listThemes();
   return (
@@ -224,7 +233,7 @@ export function slugifyThemeId(name: string): string {
 // shape the file-drop convention uses. Validates with the shared ThemeSchema
 // (so the token security regex applies), refuses reserved built-in ids, then
 // refreshes the user cache and returns the full registry.
-export async function saveUserTheme(input: any): Promise<Theme[]> {
+export async function saveUserTheme(input: any): Promise<ThemeListItem[]> {
   const id = (typeof input?.id === 'string' && input.id.trim())
     ? slugifyThemeId(input.id)
     : slugifyThemeId(input?.name || '');
@@ -237,5 +246,29 @@ export async function saveUserTheme(input: any): Promise<Theme[]> {
   await fs.writeFile(join(dir, `${theme.id}.json`), JSON.stringify(theme, null, 2), 'utf8');
   clearUserThemeCache();
   await loadUserThemes(true);
-  return listThemes();
+  return listThemesAnnotated();
+}
+
+// Delete a user theme file (${STATE_DIR}/themes/<id>.json) and return the
+// refreshed registry. Built-in ids are reserved (baked into the image, nothing
+// on disk to remove). The id is regex-validated before it touches the path so a
+// crafted ":id" can't traverse out of the themes dir.
+export async function deleteUserTheme(id: string): Promise<ThemeListItem[]> {
+  const clean = String(id || '').trim();
+  if (!/^[a-z0-9][a-z0-9-]{0,31}$/.test(clean)) {
+    throw new Error('invalid theme id');
+  }
+  if (BUILTIN_IDS.has(clean)) {
+    throw new Error(`"${clean}" is a built-in theme and can't be removed`);
+  }
+  const file = join(userThemesDir(), `${clean}.json`);
+  try {
+    await fs.unlink(file);
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') throw new Error(`no custom theme "${clean}"`);
+    throw err;
+  }
+  clearUserThemeCache();
+  await loadUserThemes(true);
+  return listThemesAnnotated();
 }

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -4264,6 +4264,9 @@ interface ThemeDef {
   description?: string;
   mode: 'light' | 'dark';
   tokens: Record<string, string>;
+  // Set by the controller's /themes responses. Built-ins ship in the image and
+  // can't be removed; only user themes (state/themes/*.json) show a Remove button.
+  builtin?: boolean;
 }
 
 // Swatch columns shown per theme card — chosen to read the palette at a
@@ -4350,7 +4353,7 @@ function ThemeCreator({
 
   if (!open) {
     return (
-      <Btn sm tone="accent" onClick={() => setOpen(true)}>Create theme with AI</Btn>
+      <Btn sm tone="accent" className="justify-self-start" onClick={() => setOpen(true)}>Create theme with AI</Btn>
     );
   }
 
@@ -4405,6 +4408,7 @@ function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSectionProp
   const [themes, setThemes] = useState<ThemeDef[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
+  const [confirmRemove, setConfirmRemove] = useState<ThemeDef | null>(null);
 
   const activeId = data.values?.theme?.active;
   const PUBLIC_API = (process.env.NEXT_PUBLIC_API_URL as string | undefined) || '/api';
@@ -4453,6 +4457,23 @@ function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSectionProp
     await saveSettings({ theme: { active: theme.id } });
   };
 
+  // Delete a user theme's state/themes/<id>.json. If it was the active theme,
+  // fall back to the first remaining one (built-ins lead the list) through the
+  // normal selection flow so nothing points at a now-missing id.
+  const remove = async (theme: ThemeDef) => {
+    try {
+      const r = await adminFetch(`/themes/${encodeURIComponent(theme.id)}`, { method: 'DELETE' });
+      const j = (await r.json().catch(() => ({}))) as { error?: string; themes?: ThemeDef[] };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      const next = j.themes ?? [];
+      setThemes(next);
+      notify.ok(`removed "${theme.name}"`);
+      if (theme.id === activeId && next[0]) await choose(next[0]);
+    } catch (e) {
+      notify.err(`Remove failed: ${errorMessage(e)}`);
+    }
+  };
+
   return (
     <>
       <SectionHeader
@@ -4469,54 +4490,7 @@ function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSectionProp
         manualHref="/manual/themes"
       />
 
-      <Card title="Picker" sub="active station theme">
-        {error && (
-          <div className="field-hint text-[var(--danger)]">
-            Couldn’t load themes: {error}
-          </div>
-        )}
-        {!themes && !error && (
-          <div className="text-[13px] text-muted italic">loading…</div>
-        )}
-        {themes && (
-          <div className="grid gap-2">
-            {themes.map(t => {
-              const isActive = t.id === activeId;
-              return (
-                <button
-                  key={t.id}
-                  type="button"
-                  onClick={() => choose(t)}
-                  disabled={busy}
-                  className={cn(
-                    'flex w-full items-center gap-3 border p-3 text-left disabled:cursor-not-allowed disabled:opacity-60',
-                    isActive
-                      ? 'border-vermilion bg-[var(--ink-softer)]'
-                      : 'border-ink bg-bg hover:bg-[var(--overlay)]',
-                  )}
-                >
-                  <span className="inline-flex shrink-0 border border-ink" aria-hidden="true">
-                    {SWATCH_KEYS.map(k => (
-                      <Swatch key={k} color={t.tokens[k]} />
-                    ))}
-                  </span>
-                  <div className="grid min-w-0 flex-1 gap-0.5">
-                    <span className="text-[12px] font-bold tracking-[0.12em] uppercase">
-                      {t.name}
-                    </span>
-                    <span className="text-[11px] leading-[1.4] text-muted">
-                      {t.description || (t.mode === 'dark' ? 'Dark palette' : 'Light palette')}
-                    </span>
-                  </div>
-                  {isActive && <Pill tone="accent" dot>active</Pill>}
-                </button>
-              );
-            })}
-          </div>
-        )}
-      </Card>
-
-      <Card title="Custom themes" sub="state/themes/*.json">
+      <Card title="Create theme" sub="state/themes/*.json">
         <div className="grid gap-3">
           <ThemeCreator adminFetch={adminFetch} onSaved={setThemes} />
           <div>
@@ -4532,6 +4506,79 @@ function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSectionProp
           </div>
         </div>
       </Card>
+
+      <Card title="Picker" sub="active station theme">
+        {error && (
+          <div className="field-hint text-[var(--danger)]">
+            Couldn’t load themes: {error}
+          </div>
+        )}
+        {!themes && !error && (
+          <div className="text-[13px] text-muted italic">loading…</div>
+        )}
+        {themes && (
+          <div className="grid gap-2">
+            {themes.map(t => {
+              const isActive = t.id === activeId;
+              return (
+                <div key={t.id} className="flex items-stretch gap-2">
+                  <button
+                    type="button"
+                    onClick={() => choose(t)}
+                    disabled={busy}
+                    className={cn(
+                      'flex min-w-0 flex-1 items-center gap-3 border p-3 text-left disabled:cursor-not-allowed disabled:opacity-60',
+                      isActive
+                        ? 'border-vermilion bg-[var(--ink-softer)]'
+                        : 'border-ink bg-bg hover:bg-[var(--overlay)]',
+                    )}
+                  >
+                    <span className="inline-flex shrink-0 border border-ink" aria-hidden="true">
+                      {SWATCH_KEYS.map(k => (
+                        <Swatch key={k} color={t.tokens[k]} />
+                      ))}
+                    </span>
+                    <div className="grid min-w-0 flex-1 gap-0.5">
+                      <span className="text-[12px] font-bold tracking-[0.12em] uppercase">
+                        {t.name}
+                      </span>
+                      <span className="text-[11px] leading-[1.4] text-muted">
+                        {t.description || (t.mode === 'dark' ? 'Dark palette' : 'Light palette')}
+                      </span>
+                    </div>
+                    {isActive && <Pill tone="accent" dot>active</Pill>}
+                  </button>
+                  {!t.builtin && (
+                    <Btn
+                      sm
+                      tone="danger"
+                      onClick={() => setConfirmRemove(t)}
+                      disabled={busy}
+                      title="Remove this custom theme"
+                    >
+                      Remove
+                    </Btn>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </Card>
+
+      <V3AlertDialog
+        open={confirmRemove != null}
+        onOpenChange={(o) => { if (!o) setConfirmRemove(null); }}
+        title="Remove theme"
+        description={
+          confirmRemove
+            ? `Remove the custom theme "${confirmRemove.name}"? This deletes state/themes/${confirmRemove.id}.json permanently.`
+            : ''
+        }
+        confirmLabel="remove"
+        danger
+        onConfirm={() => { if (confirmRemove) remove(confirmRemove); setConfirmRemove(null); }}
+      />
     </>
   );
 }


### PR DESCRIPTION
## What

Reworks the **admin → Settings → Theme** tab and adds the ability to delete custom themes.

### UI (`web/components/admin/SettingsPanel.tsx`)
- **Moved the create-theme card above the picker** and **renamed it "Create theme"** (was "Custom themes").
- **Left-aligned the create button** — the collapsed *Create theme with AI* button no longer stretches the full card width.
- **Remove flow** — each custom theme row in the picker gets a red **Remove** button (built-ins don't), behind the same confirm dialog used for jingles/SFX. Deleting the active theme falls back to the first remaining theme (built-ins lead the list) so nothing points at a missing id.

### Backend
- `controller/src/themes.ts` — `deleteUserTheme(id)` (regex-validates the id to block path traversal, refuses built-in ids, unlinks `state/themes/<id>.json`) and `listThemesAnnotated()` tagging each theme with a `builtin` flag.
- `controller/src/routes/settings.ts` — new admin-gated `DELETE /themes/:id`; `/themes/refresh` and `POST /themes` return the annotated list.
- `controller/src/routes/public.ts` — `GET /themes` includes the `builtin` flag so the UI knows which themes are deletable.

## Testing
- `controller`: `npm run lint` (eslint + tsc) — 0 errors.
- `web`: `npm run lint` (eslint + tsc) — 0 errors.