### PR TITLE
fix(tts): existsSync Kokoro model/voices in isAvailable()

### DIFF
--- a/controller/src/audio/kokoro.ts
+++ b/controller/src/audio/kokoro.ts
@@ -7,6 +7,7 @@
 
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { config } from '../config.js';
@@ -173,6 +174,16 @@ export async function speak(
   return msg.path;
 }
 
+// Mirrors chatterbox/pocket-tts: existsSync the actual on-disk assets rather
+// than trusting the config paths (which always have env defaults). Kokoro's
+// model + voices files are downloaded at image build — if that wget failed
+// (transient GitHub 429/5xx) the worker would spawn and then die on load, so a
+// path-only check would report `kokoro: true` on the Debug page while every
+// segment silently falls back to Piper. Checking the files keeps availableEngines()
+// honest and lets the dispatcher skip the doomed spawn.
 export function isAvailable() {
-  return Boolean(config.kokoro.python && config.kokoro.workerScript);
+  return existsSync(config.kokoro.python)
+    && existsSync(config.kokoro.workerScript)
+    && existsSync(config.kokoro.model)
+    && existsSync(config.kokoro.voices);
 }

--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -77,6 +77,13 @@ function resolveEngine(kind: string, personaTts: any) {
   if (chosen === 'pocket-tts' && !pocketTts.isAvailable()) {
     return tts.defaultEngine && tts.defaultEngine !== 'pocket-tts' ? tts.defaultEngine : 'piper';
   }
+  // Kokoro ships in the default image, but its model/voices files are pulled at
+  // build time and can be missing if that download failed. isAvailable() now
+  // existsSyncs them, so route around a broken Kokoro install instead of
+  // spawning a worker that just dies on load and falls back per segment.
+  if (chosen === 'kokoro' && !kokoro.isAvailable()) {
+    return tts.defaultEngine && tts.defaultEngine !== 'kokoro' ? tts.defaultEngine : 'piper';
+  }
   return chosen;
 }
 


### PR DESCRIPTION
## Why

A Discord operator reported Kokoro silently falling back to Piper. Root cause: `kokoro.isAvailable()` only checked that the config *paths* were set, which are always set via env defaults. So `availableEngines().kokoro` reported `true` on the **Debug page** even when the model files weren't actually on disk — and there was no signal in the UI that the worker was dying on load and falling back to Piper on every segment.

Kokoro's model (`kokoro-v1.0.onnx`) + voices (`voices-v1.0.bin`) are downloaded at image build. If that wget fails (transient GitHub 429/5xx), the files are absent but the engine still reports available.

## What

- **`kokoro.ts`** — `isAvailable()` now `existsSync`s the venv python, worker script, and the model + voices files, matching how `chatterbox`/`pocket-tts` check their venvs.
- **`tts.ts`** — added a `kokoro` guard in `resolveEngine()` mirroring the chatterbox/pocket-tts guards, so a broken install routes straight to the default/Piper instead of spawning a worker that dies on load and falls back per segment.

All three consumers of `isAvailable()` benefit and none break:
- `availableEngines().kokoro` (Debug page) is now honest.
- The Piper→Kokoro fallback path won't try a broken Kokoro.
- `resolveEngine()` skips the doomed spawn.

## Test

`npm run lint` (eslint + `tsc --noEmit`) exits 0. Only pre-existing `no-explicit-any` warnings remain, none in the changed lines.