### PR TITLE
feat(admin): city-search location picker with auto timezone

### DIFF
--- a/controller/src/context.ts
+++ b/controller/src/context.ts
@@ -113,6 +113,72 @@ function weatherToMood(condition) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Geocoding via Open-Meteo (no API key required) — powers the admin/onboarding
+// location picker: type a place name, get back coordinates + IANA timezone so
+// the operator never hand-copies lat/lng. Same provider we already use for
+// weather, so no new dependency. Results are cached per lowercased query for a
+// day (place coordinates don't move) with a soft entry cap to stay polite.
+// ---------------------------------------------------------------------------
+export interface GeocodeResult {
+  name: string;
+  admin1?: string;
+  country?: string;
+  countryCode?: string;
+  lat: number;
+  lng: number;
+  timezone?: string;
+  label: string;
+}
+
+const GEOCODE_TTL_MS = 24 * 60 * 60 * 1000;
+const GEOCODE_CACHE_MAX = 200;
+const geocodeCache = new Map<string, { results: GeocodeResult[]; fetchedAt: number }>();
+
+export async function geocodePlace(query: string): Promise<GeocodeResult[]> {
+  const q = query.trim();
+  if (q.length < 2) return [];
+
+  const key = q.toLowerCase();
+  const hit = geocodeCache.get(key);
+  if (hit && Date.now() - hit.fetchedAt < GEOCODE_TTL_MS) {
+    // Refresh recency — Map iteration order is insertion order, so delete+set
+    // keeps the oldest entry first for eviction.
+    geocodeCache.delete(key);
+    geocodeCache.set(key, hit);
+    return hit.results;
+  }
+
+  const url =
+    'https://geocoding-api.open-meteo.com/v1/search?name=' +
+    encodeURIComponent(q) +
+    '&count=6&language=en&format=json';
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`geocoding upstream ${res.status}`);
+  const data = (await res.json()) as { results?: any[] };
+  const results: GeocodeResult[] = (data.results || []).map((r: any) => {
+    const name = r.name as string;
+    const admin1 = r.admin1 as string | undefined;
+    const country = r.country as string | undefined;
+    return {
+      name,
+      admin1,
+      country,
+      countryCode: r.country_code,
+      lat: r.latitude,
+      lng: r.longitude,
+      timezone: r.timezone,
+      label: [name, admin1, country].filter(Boolean).join(', '),
+    };
+  });
+
+  geocodeCache.set(key, { results, fetchedAt: Date.now() });
+  if (geocodeCache.size > GEOCODE_CACHE_MAX) {
+    geocodeCache.delete(geocodeCache.keys().next().value!);
+  }
+  return results;
+}
+
 const DAY_LABELS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 const MONTH_LABELS = ['January', 'February', 'March', 'April', 'May', 'June',
                       'July', 'August', 'September', 'October', 'November', 'December'];

--- a/controller/src/routes/onboarding.ts
+++ b/controller/src/routes/onboarding.ts
@@ -235,6 +235,9 @@ router.post('/onboarding/save', requireAdmin, async (req, res) => {
     if (Array.isArray(b.personas)) settingsPatch.personas = b.personas;
     if (b.weather && typeof b.weather === 'object') settingsPatch.weather = b.weather;
     if (typeof b.station === 'string') settingsPatch.station = b.station;
+    // Timezone rides along from the wizard's location picker (Open-Meteo returns
+    // the IANA zone for the picked city). settings.update() validates it.
+    if (typeof b.timezone === 'string') settingsPatch.timezone = b.timezone;
     if (Object.keys(settingsPatch).length) await settings.update(settingsPatch);
 
     // Mark setup complete so the wizard exits even if Navidrome was skipped.

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -7,7 +7,7 @@ import { createHash } from 'node:crypto';
 import * as subsonic from '../music/subsonic.js';
 import * as library from '../music/library.js';
 import * as settings from '../settings.js';
-import { getFullContext } from '../context.js';
+import { getFullContext, geocodePlace } from '../context.js';
 import { queue } from '../broadcast/queue.js';
 import * as session from '../broadcast/session.js';
 import { getStreamStatus } from '../broadcast/listeners.js';
@@ -359,6 +359,25 @@ router.get('/session', (req, res) => {
     },
     messages: s.messages.filter(m => m.kind !== 'sfx').slice(-120),
   });
+});
+
+// ---------------------------------------------------------------------------
+// GET /geocode?q= — place-name lookup for the admin/onboarding location picker.
+// Thin proxy over Open-Meteo's free, keyless geocoding API (the web layer never
+// calls external hosts directly — the controller owns all external IO). Returns
+// { results: [...] } with coordinates + IANA timezone so the picker can fill
+// lat/lng/name and set the station clock in one tap. Unauthenticated: onboarding
+// runs pre-auth and this is harmless public reference data. On upstream failure
+// returns 502 so the client can fall back to manual coordinate entry.
+// ---------------------------------------------------------------------------
+router.get('/geocode', async (req, res) => {
+  const q = typeof req.query.q === 'string' ? req.query.q : '';
+  try {
+    const results = await geocodePlace(q);
+    res.json({ results });
+  } catch {
+    res.status(502).json({ error: 'geocode_unavailable' });
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/docs/superpowers/specs/2026-06-27-location-picker-design.md
+++ b/docs/superpowers/specs/2026-06-27-location-picker-design.md
@@ -1,0 +1,250 @@
+# Location picker with city search — design
+
+**Date:** 2026-06-27
+**Status:** Approved, ready for implementation plan
+**Area:** `web/` (admin settings + onboarding) and `controller/` (geocoding proxy + onboarding save)
+
+## Problem
+
+The station's broadcast location is entered as three raw inputs — a free-text
+name, a numeric latitude, and a numeric longitude — in two places that duplicate
+the same markup:
+
+- **Admin:** `web/components/admin/SettingsPanel.tsx`, the "Station location" card
+  (~line 4099), bound to `form.weather = { locationName, lat, lng, units }`.
+- **Onboarding:** `web/components/onboarding/steps.tsx`, `DjStep`, bound to
+  `w.data.dj = { stationName, locationName, lat, lng }`.
+
+Both back lat/lng with **strings**. The data feeds exactly two things:
+
+1. the DJ's `{location}` prompt context, and
+2. Open-Meteo weather — `controller/src/context.ts` →
+   `api.open-meteo.com/v1/forecast?latitude=…&longitude=…`.
+
+The friction: an operator must look up their coordinates elsewhere (right-click
+Google Maps, copy two decimals) and risks transposing lat/lng. We replace this
+with a **type-a-city → pick-from-a-list → coordinates auto-fill** flow.
+
+The lucky break: we already depend on Open-Meteo, which ships a **free,
+no-API-key geocoding endpoint** that *also returns the IANA timezone* for each
+result — so this needs zero new keys and no map library, and the same pick can
+set the station timezone.
+
+## Goals
+
+- Operator types a place name, picks from a dropdown, and lat/lng/name fill in
+  one action.
+- A city pick also captures the **IANA timezone** and applies it to the station
+  clock (admin: as a suggestion; onboarding: auto-applied — see Wiring).
+- Manual coordinate entry remains available as an always-works fallback (offline
+  homelab boxes, power users).
+- One shared component, used in both admin settings and onboarding (kills the
+  duplication).
+
+## Non-goals
+
+- No interactive map / tile rendering.
+- No new third-party API keys or dependencies.
+- No change to how location/weather is consumed downstream (DJ prompt,
+  `getWeather()`), or to the lat/lng save payload shape.
+- No full timezone `<Select>` added to onboarding (keep that step short).
+
+## Architecture
+
+Three units, each independently understandable:
+
+1. **Geocoding proxy (controller)** — owns the external Open-Meteo geocoding
+   call, matching the existing convention that the web layer only ever calls
+   same-origin `/api` and the controller owns all external IO.
+2. **`<LocationPicker>` (web, shared)** — a controlled, style-neutral composite
+   that turns a query into a coordinate selection. Knows nothing about admin vs
+   onboarding.
+3. **Two wirings** — admin and onboarding each mount the picker against their own
+   state shape; both consume the picked timezone, differently.
+
+### 1. Backend — geocoding proxy
+
+**Helper** `geocodePlace(q)` in `controller/src/context.ts`, next to the existing
+Open-Meteo weather code:
+
+- Calls
+  `https://geocoding-api.open-meteo.com/v1/search?name=<q>&count=6&language=en&format=json`
+  (free, **no API key**).
+- Maps each `results[]` entry to a compact shape:
+
+  ```ts
+  {
+    name: string;         // "Chandigarh"
+    admin1?: string;      // "Punjab"  (state/region)
+    country?: string;     // "India"
+    countryCode?: string; // "IN"
+    lat: number;          // result.latitude
+    lng: number;          // result.longitude
+    timezone?: string;    // IANA, e.g. "Asia/Kolkata"
+    label: string;        // formatted "Chandigarh, Punjab, India"
+  }
+  ```
+
+  `label` joins the present-of `[name, admin1, country]` with `, `.
+- **Cache:** in-memory `Map` keyed by the lowercased query, ~24h TTL, to be
+  polite to Open-Meteo. Soft cap ~200 entries.
+- On fetch error, throws; the route translates to a clean failure (the web side
+  degrades to manual entry — see Error handling).
+
+**Route** `GET /geocode?q=` in `controller/src/routes/public.ts` (alongside
+`/health`, `/now-playing`):
+
+- **Unauthenticated** — onboarding runs pre-auth, and this is harmless public
+  reference data.
+- Trims `q`; if `< 2` chars, returns `{ results: [] }` (no upstream call).
+- Returns `{ results: GeocodeResult[] }`. On upstream failure, returns HTTP 502
+  with `{ error: "geocode_unavailable" }` so the client can show the right
+  fallback.
+
+### 2. Frontend — shared `<LocationPicker>`
+
+**File:** `web/components/LocationPicker.tsx` (shared composite; built on the
+`ui/input` primitive so it renders natively in both contexts).
+
+**Props (controlled):**
+
+```ts
+interface LocationValue { locationName: string; lat: string; lng: string }
+
+interface LocationPickerProps {
+  value: LocationValue;
+  onChange: (next: LocationValue) => void;
+  // Fires with the full geocode result on selection, so a host can react to
+  // extra fields (both hosts use it for the timezone — admin suggests,
+  // onboarding auto-applies). Optional so a host can ignore it.
+  onPick?: (result: GeocodeResult) => void;
+  className?: string;
+}
+```
+
+**Behaviour:**
+
+- A search text input, **debounced ~300ms**, queries `/api/geocode?q=` once the
+  query is ≥ 2 chars.
+- Results render as a **keyboard-navigable ARIA combobox dropdown**
+  (`role="combobox"` on the input, `role="listbox"`/`role="option"` on results;
+  ArrowUp/Down to move, Enter to select, Esc to close, click to select). Each row
+  shows `label` plus faint coordinates.
+- Selecting a result calls `onChange({ locationName: label, lat: String(lat),
+  lng: String(lng) })` and `onPick(result)`, then closes the dropdown.
+- A `▸ Enter coordinates manually` **disclosure** reveals the raw name / lat /
+  lng inputs (the existing three inputs, preserved). This is the offline / power
+  fallback and must always be reachable. Editing them flows straight to
+  `onChange`. Manual mode enforces lat ∈ [−90, 90], lng ∈ [−180, 180] (inline
+  hint on out-of-range; does not block typing).
+- States: loading spinner in the input while a query is in flight; "No matches"
+  empty row when results are empty; on request failure show
+  "Search unavailable — enter coordinates manually" **and auto-expand the manual
+  disclosure**.
+- Shows a one-line summary of the current selection (name @ lat, lng).
+
+### 3. Wiring
+
+**Admin** (`SettingsPanel.tsx`, "Station location" card): replace the three
+inputs with
+
+```tsx
+<LocationPicker
+  value={{ locationName: form.weather.locationName, lat: form.weather.lat, lng: form.weather.lng }}
+  onChange={next => setForm(f => ({ ...f, weather: { ...f.weather, ...next } }))}
+  onPick={handleGeocodePick}
+/>
+```
+
+Keep the existing "Applies live" hint and the "current: … @ lat, lng" line.
+
+*Timezone — admin = suggestion.* Admin already has a full Timezone `<Select>`
+card, so a city pick must **not** silently overwrite the operator's chosen zone.
+`handleGeocodePick` stashes the picked `result.timezone`; when it is present and
+differs from the effective current zone (`form.timezone || serverTz`), render a
+subtle inline action beneath the picker (or atop the Timezone card): **"Set
+station timezone to `Asia/Kolkata`?"** with an Apply control that does
+`setForm(f => ({ ...f, timezone: result.timezone }))`. Non-automatic; dismissible.
+
+> **Radix Select caveat:** `form.timezone` is rendered by a Radix `Select` whose
+> items come from `TZ_GROUPS`. Setting a zone not in `TZ_GROUPS` leaves the
+> trigger blank. Fix: in the Timezone card, render a fallback `SelectItem` for
+> the current `form.timezone` when it is non-empty and not already in
+> `TZ_GROUPS`, so any picked IANA zone displays correctly.
+
+**Onboarding** (`steps.tsx`, `DjStep`): replace the Location + Latitude +
+Longitude `Field`s with a single `<LocationPicker>` bound to `w.data.dj`.
+
+*Timezone — onboarding = auto-apply.* Onboarding has no timezone control and the
+step is meant to stay short, so `onPick` **auto-applies** the picked timezone:
+`w.patch(d => ({ dj: { ...d.dj, timezone: result.timezone } }))`, with a small
+visible note under the picker — e.g. "Timezone: `Asia/Kolkata` (from your
+location)". No separate `<Select>`. If the operator only ever types coordinates
+manually, `timezone` stays `''` (Auto / server zone), exactly as today.
+
+Onboarding plumbing for the new field:
+
+- `web/components/onboarding/useWizard.ts`:
+  - add `timezone: string` to `WizardData.dj`; default `''` in `DEFAULT_DATA.dj`
+    (`''` = Auto, matching the admin sentinel).
+  - in `save()`, add `timezone: data.dj.timezone` to the request `body`.
+- `controller/src/routes/onboarding.ts` save handler: add a pass-through line
+  `if (typeof b.timezone === 'string') settingsPatch.timezone = b.timezone;`
+  (alongside the existing `weather` / `station` lines). `settings.update()`
+  already validates `timezone` via `isValidTimezone`, and Open-Meteo returns
+  valid IANA names, so no extra validation is needed.
+
+## Data flow
+
+```
+user types → LocationPicker (debounce) → GET /api/geocode?q=
+  → controller geocodePlace() → Open-Meteo geocoding (cached)
+  → results → dropdown → select
+  → onChange fills {locationName, lat, lng} into host form state
+  → onPick surfaces timezone:
+       admin     → optional "set timezone" action (form.timezone)
+       onboarding→ auto-applies (w.data.dj.timezone) + note
+  → Save:
+       admin     → existing settings save (lat/lng parseFloat, timezone) — path unchanged
+       onboarding→ /onboarding/save body now carries timezone → settings.update()
+  → getWeather() / station clock pick up new values — consumption UNCHANGED
+```
+
+## Error handling
+
+- **Geocode request fails / no internet to Open-Meteo:** inline "Search
+  unavailable — enter coordinates manually"; auto-expand manual fields. Config is
+  never blocked by search being down. Timezone simply isn't set (stays Auto).
+- **No matches:** "No matches" empty state.
+- **Query < 2 chars:** no request; dropdown closed.
+- **Out-of-range manual coords:** inline range hint; typing not blocked; save
+  validation/`parseFloat` unchanged.
+
+## Testing
+
+This repo has no route/component test harness (only `npm run test:llm` pure
+tests). The merge gate is `npm run lint` (`eslint . && tsc --noEmit`) in both
+`controller/` and `web/`. Verification:
+
+- `npm run lint` passes in `controller/` and `web/`.
+- Manual smoke (dev stack), **admin**: Station tab → type a city → results →
+  select → name/lat/lng fill → timezone suggestion offered → Apply → Save →
+  "current:" line, weather, and station clock reflect the new location.
+- Manual smoke, **onboarding**: DJ step → pick a city → lat/lng fill + timezone
+  note shows → finish wizard → settings reflect location *and* timezone.
+- Manual fallback: with search unreachable (or offline), the manual disclosure is
+  reachable and saving works in both places.
+
+## Files touched
+
+- `controller/src/context.ts` — add `geocodePlace(q)` + cache.
+- `controller/src/routes/public.ts` — add `GET /geocode`.
+- `controller/src/routes/onboarding.ts` — pass `timezone` into `settingsPatch`.
+- `web/components/LocationPicker.tsx` — **new** shared component.
+- `web/components/admin/SettingsPanel.tsx` — mount picker in Station location
+  card; timezone-suggestion action + Timezone-card fallback `SelectItem`.
+- `web/components/onboarding/steps.tsx` — mount picker in `DjStep`; auto-apply
+  timezone + note.
+- `web/components/onboarding/useWizard.ts` — add `timezone` to `dj` state +
+  default + save body.
+```

--- a/web/components/LocationPicker.tsx
+++ b/web/components/LocationPicker.tsx
@@ -1,0 +1,290 @@
+'use client';
+
+import { useEffect, useId, useRef, useState } from 'react';
+import type { ChangeEvent, KeyboardEvent } from 'react';
+import { Input } from './ui/input';
+import { cn } from '@/lib/cn';
+
+// Shared location picker — type a city, pick from a dropdown, and the station's
+// name + coordinates (+ IANA timezone, via onPick) fill in one tap. Used by both
+// the admin Station tab and the onboarding wizard. Talks to the controller's
+// unauthenticated GET /geocode proxy (Open-Meteo geocoding). Manual coordinate
+// entry stays available as an always-works fallback for offline boxes.
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '/api';
+
+export interface GeocodeResult {
+  name: string;
+  admin1?: string;
+  country?: string;
+  countryCode?: string;
+  lat: number;
+  lng: number;
+  timezone?: string;
+  label: string;
+}
+
+export interface LocationValue {
+  locationName: string;
+  lat: string;
+  lng: string;
+}
+
+interface LocationPickerProps {
+  value: LocationValue;
+  onChange: (next: LocationValue) => void;
+  // Fires with the full result on selection so a host can use extra fields —
+  // both call sites use it for the picked timezone (admin suggests, onboarding
+  // auto-applies). Omit to ignore.
+  onPick?: (result: GeocodeResult) => void;
+  // Cosmetic only: onboarding uses rounded inputs, the admin shell sharp ones.
+  variant?: 'admin' | 'onboarding';
+  className?: string;
+}
+
+// Out-of-range only flags a non-empty value; an empty field isn't an error.
+function rangeError(value: string, min: number, max: number): boolean {
+  if (value.trim() === '') return false;
+  const n = Number(value);
+  return Number.isNaN(n) || n < min || n > max;
+}
+
+export function LocationPicker({
+  value,
+  onChange,
+  onPick,
+  variant = 'admin',
+  className,
+}: LocationPickerProps) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<GeocodeResult[]>([]);
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(-1);
+  const [loading, setLoading] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const [manual, setManual] = useState(false);
+  const listId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const rounded = variant === 'onboarding' ? 'rounded' : '';
+
+  // Debounced geocode lookup. < 2 chars makes no request.
+  useEffect(() => {
+    const q = query.trim();
+    if (q.length < 2) {
+      setResults([]);
+      setOpen(false);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => {
+      fetch(`${API_URL}/geocode?q=${encodeURIComponent(q)}`, { signal: ctrl.signal })
+        .then(r => {
+          if (!r.ok) throw new Error('geocode failed');
+          return r.json() as Promise<{ results?: GeocodeResult[] }>;
+        })
+        .then(j => {
+          setResults(j.results || []);
+          setActive(-1);
+          setFailed(false);
+          setOpen(true);
+        })
+        .catch((e: unknown) => {
+          if (e instanceof DOMException && e.name === 'AbortError') return;
+          // Search is down (offline homelab, Open-Meteo unreachable) — surface a
+          // hint and open the manual fields so config is never blocked.
+          setFailed(true);
+          setManual(true);
+          setOpen(false);
+        })
+        .finally(() => setLoading(false));
+    }, 300);
+    return () => {
+      clearTimeout(timer);
+      ctrl.abort();
+    };
+  }, [query]);
+
+  // Close the dropdown on an outside click.
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [open]);
+
+  const select = (r: GeocodeResult) => {
+    onChange({ locationName: r.label, lat: String(r.lat), lng: String(r.lng) });
+    onPick?.(r);
+    setQuery('');
+    setResults([]);
+    setOpen(false);
+    setActive(-1);
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (!open && results.length) setOpen(true);
+      setActive(a => (results.length ? (a + 1) % results.length : -1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive(a => (results.length ? (a <= 0 ? results.length - 1 : a - 1) : -1));
+    } else if (e.key === 'Enter') {
+      if (open && active >= 0 && results[active]) {
+        e.preventDefault();
+        select(results[active]);
+      }
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+    }
+  };
+
+  const latErr = rangeError(value.lat, -90, 90);
+  const lngErr = rangeError(value.lng, -180, 180);
+  const hasValue = Boolean(value.locationName || value.lat || value.lng);
+
+  return (
+    <div ref={rootRef} className={cn('relative flex flex-col gap-2', className)}>
+      {/* Search box */}
+      <div className="relative w-full max-w-[420px]">
+        <Input
+          type="text"
+          role="combobox"
+          aria-expanded={open}
+          aria-controls={listId}
+          aria-autocomplete="list"
+          aria-activedescendant={active >= 0 ? `${listId}-opt-${active}` : undefined}
+          placeholder="Search a city or place…"
+          value={query}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => setQuery(e.target.value)}
+          onKeyDown={onKeyDown}
+          onFocus={() => {
+            if (results.length) setOpen(true);
+          }}
+          className={cn('pr-8', rounded)}
+        />
+        {loading ? (
+          <span
+            aria-hidden
+            className="absolute top-1/2 right-2.5 h-3.5 w-3.5 -translate-y-1/2 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent"
+          />
+        ) : null}
+
+        {open ? (
+          <ul
+            id={listId}
+            role="listbox"
+            className={cn(
+              'absolute z-20 mt-1 max-h-64 w-full overflow-auto border border-input bg-popover text-popover-foreground shadow-md',
+              rounded,
+            )}
+          >
+            {results.length === 0 ? (
+              <li className="px-3 py-2 text-[13px] text-muted-foreground">No matches</li>
+            ) : (
+              results.map((r, i) => (
+                <li
+                  key={`${r.label}-${r.lat}-${r.lng}`}
+                  id={`${listId}-opt-${i}`}
+                  role="option"
+                  aria-selected={i === active}
+                  onMouseEnter={() => setActive(i)}
+                  onMouseDown={e => {
+                    e.preventDefault();
+                    select(r);
+                  }}
+                  className={cn(
+                    'flex cursor-pointer items-center justify-between gap-3 px-3 py-2 text-[13px]',
+                    i === active ? 'bg-muted' : '',
+                  )}
+                >
+                  <span className="truncate">{r.label}</span>
+                  <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+                    {r.lat.toFixed(2)}, {r.lng.toFixed(2)}
+                  </span>
+                </li>
+              ))
+            )}
+          </ul>
+        ) : null}
+      </div>
+
+      {/* Current selection summary */}
+      {hasValue ? (
+        <div className="text-[13px] text-muted-foreground">
+          Selected: <span className="text-foreground">{value.locationName || '—'}</span>
+          {value.lat && value.lng ? (
+            <span className="tabular-nums">
+              {' '}
+              @ {value.lat}, {value.lng}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+
+      {failed ? (
+        <div className="text-[13px] text-destructive">
+          Search unavailable — enter coordinates manually below.
+        </div>
+      ) : null}
+
+      {/* Manual entry disclosure — always reachable */}
+      <button
+        type="button"
+        onClick={() => setManual(m => !m)}
+        className="self-start text-xs text-muted-foreground hover:text-foreground"
+      >
+        {manual ? '▾' : '▸'} Enter coordinates manually
+      </button>
+
+      {manual ? (
+        <div className="flex flex-wrap gap-2">
+          <Input
+            placeholder="name"
+            aria-label="location name"
+            value={value.locationName}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              onChange({ ...value, locationName: e.target.value })
+            }
+            className={cn('w-[200px]', rounded)}
+          />
+          <div className="flex flex-col">
+            <Input
+              className={cn('w-[132px] tabular-nums', rounded)}
+              type="number"
+              step="any"
+              placeholder="lat"
+              aria-label="latitude"
+              aria-invalid={latErr}
+              value={value.lat}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                onChange({ ...value, lat: e.target.value })
+              }
+            />
+            {latErr ? <span className="mt-0.5 text-xs text-destructive">−90 to 90</span> : null}
+          </div>
+          <div className="flex flex-col">
+            <Input
+              className={cn('w-[132px] tabular-nums', rounded)}
+              type="number"
+              step="any"
+              placeholder="lng"
+              aria-label="longitude"
+              aria-invalid={lngErr}
+              value={value.lng}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                onChange({ ...value, lng: e.target.value })
+              }
+            />
+            {lngErr ? <span className="mt-0.5 text-xs text-destructive">−180 to 180</span> : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -26,6 +26,7 @@ import { EmbeddingProviderSelector } from './embedding/EmbeddingProviderSelector
 import { ModelCombobox } from './llm/ModelCombobox';
 import { LLM_ENV_VARS, llmProviderLabel } from './llm/providerMeta';
 import { AiFill } from './AiFill';
+import { LocationPicker, type GeocodeResult } from '../LocationPicker';
 import { cn } from '../../lib/cn';
 import ArchivesPanel from './ArchivesPanel';
 import WebhooksPanel from './WebhooksPanel';
@@ -4067,6 +4068,18 @@ function StationSection({ data, form, setForm, busy, saveSettings }: SectionProp
   const preview = clockPreview(previewTz, form.locale);
   const localeLabel = form.locale === 'en-US' ? 'English (US)' : 'English (UK)';
 
+  // A picked city carries its IANA zone. We *suggest* it rather than overwrite —
+  // the operator may have deliberately set a different station clock. Cleared
+  // once applied or dismissed.
+  const [tzSuggestion, setTzSuggestion] = useState<string | null>(null);
+  const handleGeocodePick = (r: GeocodeResult) => {
+    const effective = form.timezone || data.serverTimezone || '';
+    setTzSuggestion(r.timezone && r.timezone !== effective ? r.timezone : null);
+  };
+  // A picked zone may not be one of TZ_GROUPS' items; Radix Select needs a
+  // matching <SelectItem> to render it, so the card adds a fallback item.
+  const tzInGroups = !form.timezone || TZ_GROUPS.some(g => g.zones.includes(form.timezone));
+
   return (
     <>
       <SectionHeader
@@ -4099,36 +4112,40 @@ function StationSection({ data, form, setForm, busy, saveSettings }: SectionProp
       <Card title="Station location" sub="DJ context + Open-Meteo weather">
         <div className="field">
           <Label>Location</Label>
-          <div className="flex flex-wrap gap-2">
-            <Input
-              placeholder="name"
-              value={form.weather.locationName}
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                setForm(f => ({ ...f, weather: { ...f.weather, locationName: e.target.value } }))
-              }
-              className="w-[200px]"
-            />
-            <Input
-              className="mono-num w-[132px]"
-              type="number"
-              step="any"
-              placeholder="lat"
-              value={form.weather.lat}
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                setForm(f => ({ ...f, weather: { ...f.weather, lat: e.target.value } }))
-              }
-            />
-            <Input
-              className="mono-num w-[132px]"
-              type="number"
-              step="any"
-              placeholder="lng"
-              value={form.weather.lng}
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                setForm(f => ({ ...f, weather: { ...f.weather, lng: e.target.value } }))
-              }
-            />
-          </div>
+          <LocationPicker
+            variant="admin"
+            value={{
+              locationName: form.weather.locationName,
+              lat: form.weather.lat,
+              lng: form.weather.lng,
+            }}
+            onChange={next =>
+              setForm(f => ({ ...f, weather: { ...f.weather, ...next } }))
+            }
+            onPick={handleGeocodePick}
+          />
+          {tzSuggestion ? (
+            <div className="mt-2 flex flex-wrap items-center gap-2 text-[13px]">
+              <span className="text-muted-foreground">
+                Set station timezone to <span className="text-foreground">{tzSuggestion}</span>?
+              </span>
+              <Btn
+                onClick={() => {
+                  setForm(f => ({ ...f, timezone: tzSuggestion }));
+                  setTzSuggestion(null);
+                }}
+              >
+                Apply
+              </Btn>
+              <button
+                type="button"
+                className="text-xs text-muted-foreground hover:text-foreground"
+                onClick={() => setTzSuggestion(null)}
+              >
+                Dismiss
+              </button>
+            </div>
+          ) : null}
           <div className="field-hint">
             Where the station broadcasts from. Sets the DJ’s {'{location}'} and the Open-Meteo
             weather it reads on air (current: {data.values?.weather?.locationName} @ {data.values?.weather?.lat}, {data.values?.weather?.lng}). Applies live.
@@ -4175,6 +4192,13 @@ function StationSection({ data, form, setForm, busy, saveSettings }: SectionProp
               <SelectGroup>
                 <SelectItem value="auto">Auto, server timezone ({serverTz})</SelectItem>
               </SelectGroup>
+              {/* Fallback for a zone picked via the location search that isn't in
+                  the enumerated groups — Radix needs an item to show it. */}
+              {!tzInGroups ? (
+                <SelectGroup>
+                  <SelectItem value={form.timezone}>{form.timezone}</SelectItem>
+                </SelectGroup>
+              ) : null}
               {TZ_GROUPS.map(g => (
                 <SelectGroup key={g.region}>
                   <SelectLabel>{g.region}</SelectLabel>

--- a/web/components/onboarding/steps.tsx
+++ b/web/components/onboarding/steps.tsx
@@ -6,6 +6,7 @@ import { ProviderSelector } from '../admin/llm/ProviderSelector';
 import { ModelCombobox } from '../admin/llm/ModelCombobox';
 import { PROVIDER_IDS } from '../admin/llm/providerMeta';
 import { useModelDiscovery } from '@/hooks/useModelDiscovery';
+import { LocationPicker } from '../LocationPicker';
 
 // Tiny presentation primitives kept local to the wizard — avoids dragging the
 // full admin UI library into a screen most operators see exactly once.
@@ -421,27 +422,32 @@ export function DjStep({ w }: { w: WizardController }) {
             onChange={e => w.patch(d => ({ dj: { ...d.dj, stationName: e.target.value } }))}
           />
         </Field>
-        <Field label="Location" hint="Used for weather + 'broadcasting from…' prompts">
-          <TextInput
-            value={w.data.dj.locationName}
-            onChange={e => w.patch(d => ({ dj: { ...d.dj, locationName: e.target.value } }))}
+        {/* Not a <Field>/<label> — the picker is a composite (combobox + buttons)
+            and shouldn't live inside a single <label>. */}
+        <div className="flex flex-col gap-1">
+          <span className="text-xs font-medium tracking-wide text-ink/60 uppercase">Location</span>
+          <LocationPicker
+            variant="onboarding"
+            value={{
+              locationName: w.data.dj.locationName,
+              lat: w.data.dj.lat,
+              lng: w.data.dj.lng,
+            }}
+            onChange={next => w.patch(d => ({ dj: { ...d.dj, ...next } }))}
+            onPick={r => {
+              const tz = r.timezone;
+              if (tz) w.patch(d => ({ dj: { ...d.dj, timezone: tz } }));
+            }}
           />
-        </Field>
-        <div className="grid grid-cols-2 gap-3">
-          <Field label="Latitude" hint="-90 to 90">
-            <TextInput
-              inputMode="decimal"
-              value={w.data.dj.lat}
-              onChange={e => w.patch(d => ({ dj: { ...d.dj, lat: e.target.value } }))}
-            />
-          </Field>
-          <Field label="Longitude" hint="-180 to 180">
-            <TextInput
-              inputMode="decimal"
-              value={w.data.dj.lng}
-              onChange={e => w.patch(d => ({ dj: { ...d.dj, lng: e.target.value } }))}
-            />
-          </Field>
+          <span className="text-xs text-ink/50">
+            Search a city — coordinates and timezone fill in automatically. Used for weather +
+            “broadcasting from…” prompts.
+          </span>
+          {w.data.dj.timezone ? (
+            <span className="text-xs text-ink/50">
+              Timezone: {w.data.dj.timezone} (from your location)
+            </span>
+          ) : null}
         </div>
       </div>
     </div>

--- a/web/components/onboarding/useWizard.ts
+++ b/web/components/onboarding/useWizard.ts
@@ -40,6 +40,9 @@ export interface WizardData {
     // range-checked by the controller's settings.update() on save.
     lat: string;
     lng: string;
+    // IANA zone, auto-filled when a city is picked in the location step. '' =
+    // Auto (server zone), matching the admin sentinel.
+    timezone: string;
     frequency: 'quiet' | 'moderate' | 'aggressive';
   };
 
@@ -73,6 +76,7 @@ export const DEFAULT_DATA: WizardData = {
     locationName: 'Punjab',
     lat: '30.7333',
     lng: '76.7794',
+    timezone: '',
     frequency: 'moderate',
   },
   apiKeys: {},
@@ -191,6 +195,8 @@ export function useWizard() {
       },
       weather: { locationName: data.dj.locationName, lat: data.dj.lat, lng: data.dj.lng },
       station: data.dj.stationName,
+      // '' = Auto; only sent so a picked city's zone reaches settings.update().
+      timezone: data.dj.timezone,
       apiKeys,
     };
     const r = await auth.adminFetch('/onboarding/save', {


### PR DESCRIPTION
## What

Replaces the raw lat/lng/name inputs in the **admin Station tab** and the **onboarding wizard** with a shared `<LocationPicker>`: type a city, pick from an Open-Meteo geocoding dropdown, and the station name + coordinates fill in one tap. No more hunting for coordinates in Google Maps or transposing lat/lng.

A picked city also carries its **IANA timezone** — admin *suggests* it (Apply/Dismiss, never a silent overwrite of the operator's chosen clock); onboarding *auto-applies* it with a visible note. Manual coordinate entry stays as an always-works fallback for offline boxes.

## How

**Backend (`controller/`)**
- `context.ts` — `geocodePlace(q)`: keyless Open-Meteo geocoding (the same provider already used for weather), mapped to a compact `{ name, admin1, country, countryCode, lat, lng, timezone, label }`, cached per lowercased query for 24h (soft cap 200).
- `routes/public.ts` — unauthenticated `GET /geocode?q=` (onboarding runs pre-auth; harmless public data). `<2`-char short-circuit; `502 { error: "geocode_unavailable" }` on upstream failure so the client falls back to manual entry.
- `routes/onboarding.ts` — `timezone` now passes through to `settings.update()` (which already validates it).

**Frontend (`web/`)**
- **New** `components/LocationPicker.tsx` — shared controlled component: debounced (~300ms) search → keyboard-navigable ARIA combobox dropdown (arrows / enter / esc / click), `onPick` surfacing the timezone, a `▸ Enter coordinates manually` disclosure with ±90 / ±180 range hints, plus loading / "No matches" / offline states.
- `admin/SettingsPanel.tsx` — Station card uses the picker; timezone suggestion action; Timezone `Select` gains a fallback item so a picked IANA zone outside `TZ_GROUPS` still renders.
- `onboarding/steps.tsx` + `useWizard.ts` — picker in the DJ step auto-applies the timezone with a note; `timezone` added to wizard state, default, and save body.

## Testing

- `npm run lint` (eslint + `tsc --noEmit`) passes clean in **both** `controller/` and `web/`.
- Verified the live Open-Meteo geocoding response shape matches the proxy's field mapping.
- Not yet run through a full dev-stack click-through — manual smoke (type city → pick → fields fill → timezone applies → save → weather/clock reflect it; offline fallback) still to do on next stack run.

Design spec: `docs/superpowers/specs/2026-06-27-location-picker-design.md`.