### PR TITLE
feat(web): lite mode to drop blur + animations on low-power devices

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -736,6 +736,16 @@ body::after {
 
 /* Reduced motion — collapse anything that animates. */
 @media (prefers-reduced-motion: reduce) {
+    /* Low-power concession: the frosted backdrop blur is the single biggest GPU
+       cost on weak devices, and listeners who ask for reduced motion are often
+       on exactly those devices — drop it too. (Lite mode does the same wholesale
+       via html.lite below.) */
+    *,
+    *::before,
+    *::after {
+        backdrop-filter: none !important;
+        -webkit-backdrop-filter: none !important;
+    }
     .v3-drawer-content,
     .v3-drawer-overlay,
     .v3-blink,
@@ -774,6 +784,20 @@ body::after {
     .fz-scale .fz-needle {
         transition: none;
     }
+}
+
+/* Lite (low-power) mode — toggled from the player theme menu or pinned with
+   ?lite=1 (see lib/lite.ts). Drops every backdrop-filter blur and disables
+   animations so weak GPUs (kiosks, Raspberry Pi) stop re-compositing frosted
+   layers and looping effects every frame — the measured Pi 4 win is ~170% →
+   ~40% Chromium CPU. Transitions are intentionally left alone: they only fire
+   on interaction and aren't the continuous repaint cost. */
+html.lite *,
+html.lite *::before,
+html.lite *::after {
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    animation: none !important;
 }
 
 /* Player title — Fraunces display serif (see the type-roles block up top).

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { Fraunces, Plus_Jakarta_Sans, JetBrains_Mono } from 'next/font/google';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import { THEME_INIT_SCRIPT } from '@/lib/theme';
+import { LITE_INIT_SCRIPT } from '@/lib/lite';
 import { SITE_URL } from '@/lib/site';
 import ServiceWorkerRegister from '@/components/ServiceWorkerRegister';
 import MotionProvider from '@/components/MotionProvider';
@@ -120,6 +121,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         {/* Apply stored theme before paint to avoid flash of wrong palette.
             Script body is a static constant from lib/theme — no untrusted input. */}
         <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
+
+        {/* Resolve low-power "lite" mode (?lite=… or stored pref) before paint
+            so a pinned kiosk never flashes the heavy, blur-heavy build. Static
+            constant from lib/lite — no untrusted input. */}
+        <script dangerouslySetInnerHTML={{ __html: LITE_INIT_SCRIPT }} />
 
         {/* Site-wide structured data (WebSite + Organization). */}
         <JsonLd data={SITE_JSONLD} />

--- a/web/components/ThemeSwitcher.tsx
+++ b/web/components/ThemeSwitcher.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
-import { Palette } from 'lucide-react';
+import { Palette, Zap } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { useDynamicStyle } from '../hooks/useDynamicStyle';
+import { useLiteMode } from '../hooks/useLiteMode';
 import { useThemeSwitcher } from './ThemeBootstrap';
 
 /** The columns shown in each card's swatch — paper, ink, accent, overlay.
@@ -44,6 +45,7 @@ export default function ThemeSwitcher({ variant = 'player' }: ThemeSwitcherProps
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
   const popoverId = useId();
+  const { lite, setLite } = useLiteMode();
 
   // Close on outside click and Escape. mousedown beats click so the popover
   // doesn't flicker when a listener clicks a different control elsewhere in
@@ -179,6 +181,43 @@ export default function ThemeSwitcher({ variant = 'player' }: ThemeSwitcherProps
                 ({themes.find(t => t.id === stationActiveId)?.name ?? stationActiveId})
               </span>
             )}
+          </button>
+
+          {/* Low-power toggle. Drops backdrop blur + animations so weak GPUs
+              (kiosks, Raspberry Pi) stop re-compositing frosted layers every
+              frame. Persists per-browser; a kiosk can also pin it with ?lite=1
+              in its start URL. A top margin sets it off from the theme rows —
+              no section title, by request. */}
+          <button
+            type="button"
+            role="menuitemcheckbox"
+            aria-checked={lite}
+            onClick={() => setLite(!lite)}
+            className={cn(
+              'mt-2 flex w-full items-center gap-2 border px-2 py-1.5 text-left',
+              lite
+                ? 'border-vermilion bg-[var(--ink-softer)]'
+                : 'border-soft-border bg-bg hover:bg-[var(--overlay)]',
+            )}
+          >
+            <Zap className="h-4 w-4 shrink-0" aria-hidden="true" />
+            <span className="grid min-w-0 flex-1 gap-0.5">
+              <span className="truncate text-[11px] font-bold tracking-[0.12em] uppercase">
+                Lite mode
+              </span>
+              <span className="truncate text-[10px] leading-[1.3] text-muted">
+                Improves performance on low-power screens
+              </span>
+            </span>
+            <span
+              className={cn(
+                'shrink-0 text-[10px] font-bold tracking-[0.2em] uppercase',
+                lite ? 'text-vermilion' : 'text-muted',
+              )}
+              aria-hidden="true"
+            >
+              {lite ? 'On' : 'Off'}
+            </span>
           </button>
         </div>
       )}

--- a/web/hooks/useLiteMode.ts
+++ b/web/hooks/useLiteMode.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { applyLite, loadLitePref, saveLitePref } from '@/lib/lite';
+
+export interface LiteModeState {
+  /** Whether low-power mode is active (blur + animations dropped). */
+  lite: boolean;
+  /** Set the mode explicitly and sync the <html> class + localStorage. */
+  setLite: (on: boolean) => void;
+}
+
+/** Listener-facing low-power toggle. The `lite` class is already applied
+ *  pre-paint by LITE_INIT_SCRIPT, so this hook only surfaces the current value
+ *  to the UI and keeps the class + localStorage in sync when the listener
+ *  flips it. */
+export function useLiteMode(): LiteModeState {
+  const [lite, setLiteState] = useState(false);
+
+  // localStorage is only safe to read in an effect. The pre-paint script
+  // already set the class, so a one-tick lag before the toggle reflects the
+  // stored value is invisible (the menu starts closed).
+  useEffect(() => {
+    setLiteState(loadLitePref() === true);
+  }, []);
+
+  const setLite = useCallback((on: boolean) => {
+    saveLitePref(on);
+    applyLite(on);
+    setLiteState(on);
+  }, []);
+
+  return { lite, setLite };
+}

--- a/web/lib/lite.ts
+++ b/web/lib/lite.ts
@@ -1,0 +1,71 @@
+// Lite (low-power) mode.
+//
+// The frosted-glass `backdrop-filter` blur and the always-on looping animations
+// (spinning disc, live-cover glitch/scan, pulses) are cheap on a laptop GPU but
+// brutal on weak ones: a Raspberry Pi 4 re-compositing blurred layers at ~50fps
+// pegs Chromium at ~170% CPU. Lite mode adds a `lite` class to <html> that drops
+// every backdrop-filter and disables animations (see globals.css) — the heavy
+// paint goes away while audio + controls stay intact.
+//
+// Triggered three ways, in precedence order:
+//   1. `?lite=1` / `?lite=0` in the URL — lets a kiosk pin the mode from its
+//      start URL. The value is written through to localStorage so a later visit
+//      without the param sticks.
+//   2. The toggle in the player theme menu — writes the same localStorage key.
+//   3. Nothing set → off (full-fat experience).
+//
+// Applied pre-paint via LITE_INIT_SCRIPT (inlined in layout.tsx) so a pinned
+// kiosk never flashes the heavy build before hydration.
+
+const STORAGE_KEY = 'subwave-lite';
+export const LITE_CLASS = 'lite';
+
+/** Toggle the `lite` class on <html>. No-op on the server. */
+export function applyLite(on: boolean): void {
+  if (typeof document === 'undefined') return;
+  document.documentElement.classList.toggle(LITE_CLASS, on);
+}
+
+/** Read the stored lite preference. Returns null when nothing is stored, so
+ *  callers can tell "never chosen" apart from "explicitly off". */
+export function loadLitePref(): boolean | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === '1') return true;
+    if (raw === '0') return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the lite preference. Failures (private mode, quota) are swallowed —
+ *  the DOM class still applies for the session. */
+export function saveLitePref(on: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, on ? '1' : '0');
+  } catch { /* private mode / quota — non-fatal */ }
+}
+
+// Pre-hydration <script> body — resolves lite mode from the URL (?lite=…) then
+// localStorage and toggles the `lite` class on <html> before paint, so a pinned
+// kiosk never flashes the heavy build. A URL param also writes through to
+// localStorage so the choice survives the next param-less load. Static string,
+// inlined via dangerouslySetInnerHTML; no untrusted input reaches it.
+export const LITE_INIT_SCRIPT = `
+  try {
+    var KEY = '${STORAGE_KEY}';
+    var on = null;
+    var p = new URLSearchParams(location.search).get('lite');
+    if (p !== null) {
+      on = (p === '' || p === '1' || p === 'true' || p === 'yes');
+      try { localStorage.setItem(KEY, on ? '1' : '0'); } catch (e) {}
+    } else {
+      var raw = localStorage.getItem(KEY);
+      if (raw === '1') on = true; else if (raw === '0') on = false;
+    }
+    if (on) document.documentElement.classList.add('${LITE_CLASS}');
+  } catch (e) {}
+`;


### PR DESCRIPTION
## What

Adds an in-app **Lite mode** for the web player — a low-power path that drops every `backdrop-filter` blur and disables looping/entrance animations. On weak GPUs those drive continuous ~50fps repaints; a Raspberry Pi 4 kiosk measured **~170% → ~40% Chromium CPU** with blur + animations off. This replaces the per-device Chromium-extension workaround with something cross-device and self-contained.

## How it's triggered (precedence: URL → stored → off)

1. **`?lite=1` / `?lite=0`** in the URL — a kiosk pins it once in its start URL; the value persists to `localStorage`.
2. **Toggle in the player theme menu** (under the theme list).
3. **Default off** — full-fat experience on capable devices.

## Changes

- **`web/lib/lite.ts`** (new) — stored pref + a pre-paint `LITE_INIT_SCRIPT` (mirrors the theme system's no-flash pattern) so a pinned kiosk never flashes the heavy build before hydration.
- **`web/hooks/useLiteMode.ts`** (new) — surfaces `{ lite, setLite }`, keeps the `<html>.lite` class + `localStorage` in sync.
- **`web/app/layout.tsx`** — inlines `LITE_INIT_SCRIPT` next to the theme script.
- **`web/app/globals.css`** — `html.lite *` drops `backdrop-filter` + `animation`; also folds `backdrop-filter: none` into the existing `prefers-reduced-motion` block (accessibility win). Transitions are intentionally left alone — they only fire on interaction.
- **`web/components/ThemeSwitcher.tsx`** — the toggle, as a `menuitemcheckbox` row in the player theme menu.

## Kiosk migration

Point the kiosk at `…/?lite=1` and the `subwave-perf-ext` Chromium extension can be removed — the in-app mode does the same (drops blur + animations) but cross-device.

## Verification

- `npm run lint` (eslint + `tsc --noEmit`) — clean.
- Pre-paint resolution logic unit-tested across 9 URL/stored-pref cases.
- Live dev-stack check: toggling on applies `html.lite`, persists `localStorage`, drops the TopBar `backdrop-filter` from `blur(24px) saturate(1.5)` → `none`, and cancels all running animations (0 animating). Toggling off restores both.