### PR TITLE
fix(build): stamp deployed version into images so the admin footer isn't a release behind

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -77,7 +77,18 @@ jobs:
               WITH_CLAP=1
               WITH_DEMUCS=1
     steps:
+      # fetch-depth: 0 pulls full history + tags so `git describe` resolves the
+      # version on a workflow_dispatch from a branch (a tag push already has the
+      # tag at HEAD).
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # The version stamped into the images (admin footer + controller). On a tag
+      # push `git describe` returns the tag (e.g. v0.31.0); a branch dispatch
+      # yields <tag>-<n>-g<sha>. Empty → builds fall back to package.json.
+      - id: version
+        run: echo "version=$(git describe --tags --always 2>/dev/null || echo '')" >> "$GITHUB_OUTPUT"
 
       # QEMU provides the cross-arch emulation buildx needs to build the
       # linux/arm64 variant on the amd64 GitHub runner.
@@ -106,7 +117,9 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           platforms: ${{ matrix.platforms }}
-          build-args: ${{ matrix.build_args }}
+          build-args: |
+            ${{ matrix.build_args }}
+            SUBWAVE_BUILD_VERSION=${{ steps.version.outputs.version }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -92,6 +92,10 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.controller
+      args:
+        # Version reported by the controller (backup manifest). Same source as
+        # the web build arg below; unset → falls back to controller/package.json.
+        - SUBWAVE_BUILD_VERSION=\${SUBWAVE_BUILD_VERSION:-}
     container_name: sub-wave-controller
     restart: unless-stopped
     depends_on:
@@ -161,6 +165,10 @@ services:
         - SITE_URL=\${SITE_URL:-}
         # NEXT_PUBLIC_* is inlined into the client bundle at BUILD time.
         - NEXT_PUBLIC_GA_ID=\${NEXT_PUBLIC_GA_ID:-}
+        # Version shown in the admin console footer, inlined at BUILD time.
+        # scripts/update.sh sets it from \`git describe\`; unset → falls back to
+        # web/package.json (see web/next.config.js).
+        - SUBWAVE_BUILD_VERSION=\${SUBWAVE_BUILD_VERSION:-}
     container_name: sub-wave-web
     restart: unless-stopped
     depends_on:
@@ -339,6 +347,10 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.controller
+      args:
+        # Version reported by the controller (backup manifest). Same source as
+        # the web build arg below; unset → falls back to controller/package.json.
+        - SUBWAVE_BUILD_VERSION=\${SUBWAVE_BUILD_VERSION:-}
     container_name: sub-wave-controller
     restart: unless-stopped
     depends_on:
@@ -395,6 +407,10 @@ services:
       args:
         - SITE_URL=\${SITE_URL:-}
         - NEXT_PUBLIC_GA_ID=\${NEXT_PUBLIC_GA_ID:-}
+        # Version shown in the admin console footer, inlined at BUILD time.
+        # scripts/update.sh sets it from \`git describe\`; unset → falls back to
+        # web/package.json (see web/next.config.js).
+        - SUBWAVE_BUILD_VERSION=\${SUBWAVE_BUILD_VERSION:-}
     container_name: sub-wave-web
     restart: unless-stopped
     depends_on:
@@ -546,6 +562,11 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.controller
+      args:
+        # Version reported by the controller (backup manifest); unset → falls
+        # back to controller/package.json. The dev web UI runs \`npm run dev\`
+        # outside Docker, where next.config.js resolves it via \`git describe\`.
+        - SUBWAVE_BUILD_VERSION=\${SUBWAVE_BUILD_VERSION:-}
     platform: linux/amd64
     container_name: sub-wave-controller
     restart: unless-stopped

--- a/controller/src/routes/backup.ts
+++ b/controller/src/routes/backup.ts
@@ -55,6 +55,12 @@ const INCLUDE_DIRS = [
 const RESTORABLE = new Set<string>([...INCLUDE_FILES, ...INCLUDE_DIRS]);
 
 const appVersion = (() => {
+  // Build-arg wins (set from `git describe` by scripts/update.sh and the
+  // publish-images CI) so an image built off `develop` reports its true version
+  // rather than the stale package.json number, which only bumps on `main`.
+  // Mirrors web/next.config.js.
+  const fromEnv = process.env.SUBWAVE_BUILD_VERSION;
+  if (fromEnv) return fromEnv.replace(/^v/, '');
   try {
     const p = fileURLToPath(new URL('../../package.json', import.meta.url));
     return JSON.parse(readFileSync(p, 'utf8')).version || 'unknown';

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -67,6 +67,10 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.controller
+      args:
+        # Version reported by the controller (backup manifest). Same source as
+        # the web build arg below; unset → falls back to controller/package.json.
+        - SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION:-}
     container_name: sub-wave-controller
     restart: unless-stopped
     depends_on:
@@ -123,6 +127,10 @@ services:
       args:
         - SITE_URL=${SITE_URL:-}
         - NEXT_PUBLIC_GA_ID=${NEXT_PUBLIC_GA_ID:-}
+        # Version shown in the admin console footer, inlined at BUILD time.
+        # scripts/update.sh sets it from `git describe`; unset → falls back to
+        # web/package.json (see web/next.config.js).
+        - SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION:-}
     container_name: sub-wave-web
     restart: unless-stopped
     depends_on:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -64,6 +64,11 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.controller
+      args:
+        # Version reported by the controller (backup manifest); unset → falls
+        # back to controller/package.json. The dev web UI runs `npm run dev`
+        # outside Docker, where next.config.js resolves it via `git describe`.
+        - SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION:-}
     platform: linux/amd64
     container_name: sub-wave-controller
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,10 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.controller
+      args:
+        # Version reported by the controller (backup manifest). Same source as
+        # the web build arg below; unset → falls back to controller/package.json.
+        - SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION:-}
     container_name: sub-wave-controller
     restart: unless-stopped
     depends_on:
@@ -152,6 +156,10 @@ services:
         - SITE_URL=${SITE_URL:-}
         # NEXT_PUBLIC_* is inlined into the client bundle at BUILD time.
         - NEXT_PUBLIC_GA_ID=${NEXT_PUBLIC_GA_ID:-}
+        # Version shown in the admin console footer, inlined at BUILD time.
+        # scripts/update.sh sets it from `git describe`; unset → falls back to
+        # web/package.json (see web/next.config.js).
+        - SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION:-}
     container_name: sub-wave-web
     restart: unless-stopped
     depends_on:

--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -31,6 +31,11 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # SITE_URL env for live share-card tags.
 ARG SITE_URL
 ENV SITE_URL=${SITE_URL}
+# Admin-console footer version, inlined into the web bundle at build time. See
+# web/next.config.js. Set from `git describe` by the publish-images CI; unset →
+# falls back to web/package.json.
+ARG SUBWAVE_BUILD_VERSION
+ENV SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION}
 RUN npm run build
 
 # ---- caddy binary: lift the glibc build from the official Debian image ------
@@ -128,9 +133,14 @@ RUN chmod +x /usr/local/bin/subwave-supervisor
 # Shared state dir (the supervisor re-asserts perms on every boot).
 RUN mkdir -p /var/sub-wave && chmod 777 /var/sub-wave
 
+# Re-declared for the final stage (ARGs don't cross stage boundaries) so the
+# controller process reports the same version (backup manifest) as the web
+# build above. Same source as the webbuild-stage arg.
+ARG SUBWAVE_BUILD_VERSION
 ENV NODE_ENV=production \
     STATE_DIR=/var/sub-wave \
-    SOUNDS_DIR=/sounds
+    SOUNDS_DIR=/sounds \
+    SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION}
 
 # Single public port: Caddy on :80. Health = the controller's liveness via the
 # edge, which only answers once web + controller are both up.

--- a/docker/Dockerfile.controller
+++ b/docker/Dockerfile.controller
@@ -149,6 +149,12 @@ RUN npm install --omit=dev
 COPY controller/src ./src
 COPY controller/scripts ./scripts
 
+# Version reported by the controller (e.g. the backup manifest). Set from `git
+# describe` by scripts/update.sh and the publish-images CI; unset → falls back
+# to controller/package.json (see routes/backup.ts).
+ARG SUBWAVE_BUILD_VERSION
+ENV SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION}
+
 # Bake repo-bundled audio (emergency loop + studio bed + sfx). Prod no longer
 # bind-mounts ../sounds — operators install via the image-only path. Dev
 # compose can still bind-mount over the top for hot reload of new SFX.

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -14,7 +14,13 @@ git pull --ff-only
 echo "→ Pulling base images"
 $COMPOSE pull --ignore-buildable
 
-echo "→ Building local images"
+# Stamp the build with the real version (latest tag + commits since), so the
+# admin console footer and controller report the deployed version instead of the
+# package.json number — which only bumps on `main` and so trails `develop` by a
+# release. Empty if git/tags are unavailable; the builds then fall back to
+# package.json. Exported so compose's build.args interpolation picks it up.
+export SUBWAVE_BUILD_VERSION="${SUBWAVE_BUILD_VERSION:-$(git describe --tags --always --dirty 2>/dev/null || true)}"
+echo "→ Building local images (version: ${SUBWAVE_BUILD_VERSION:-package.json})"
 $COMPOSE build --pull
 
 echo "→ Recreating changed services"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -24,6 +24,12 @@ ENV SITE_URL=${SITE_URL}
 # Unset → no analytics script is emitted.
 ARG NEXT_PUBLIC_GA_ID
 ENV NEXT_PUBLIC_GA_ID=${NEXT_PUBLIC_GA_ID}
+# Version shown in the admin console footer, inlined into the client bundle at
+# build time (NEXT_PUBLIC_*), so it must be present *here*. Set from `git
+# describe` by scripts/update.sh and the publish-images CI; unset → the build
+# falls back to web/package.json (see web/next.config.js).
+ARG SUBWAVE_BUILD_VERSION
+ENV SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION}
 RUN npm run build
 
 # ---- runner ----

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,8 +1,36 @@
-// Surface the package version (release-please bumps all three package.json
-// files in lockstep, so the web build version is the deployed station
-// version) to the client bundle for the admin console footer.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { version } = require('./package.json');
+// Resolve the version shown in the admin console footer, in priority order:
+//   1. SUBWAVE_BUILD_VERSION build-arg — set from `git describe` by
+//      scripts/update.sh and the publish-images CI, so an image built off
+//      `develop` reports its true, commit-accurate version. (release-please only
+//      bumps package.json on `main`; `develop` trails it by a release, so
+//      reading package.json here left the sidebar a version behind.)
+//   2. `git describe` — for local `npm run dev` / `npm run build`. A Docker
+//      build has no .git in its context, so this is skipped there (the build-arg
+//      covers that path) and step 3 applies.
+//   3. web/package.json — the original source; correct on a tagged checkout.
+function resolveAppVersion() {
+  const fromEnv = process.env.SUBWAVE_BUILD_VERSION;
+  if (fromEnv) return fromEnv.replace(/^v/, '');
+  try {
+    // execFileSync (no shell) with a fixed, no-user-input command.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { execFileSync } = require('node:child_process');
+    const described = execFileSync(
+      'git',
+      ['describe', '--tags', '--always', '--dirty'],
+      { cwd: __dirname, stdio: ['ignore', 'pipe', 'ignore'] },
+    )
+      .toString()
+      .trim();
+    if (described) return described.replace(/^v/, '');
+  } catch {
+    // No git available (e.g. inside a Docker build) — fall through.
+  }
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require('./package.json').version;
+}
+
+const version = resolveAppVersion();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {


### PR DESCRIPTION
## Problem

The admin console sidebar footer (and the controller's backup manifest) read the version from the build's `package.json`. release-please only bumps `package.json` on `main`, so a build off `develop` always trailed the latest release by one — the sidebar showed the **previous** version.

## Fix

Resolve the version from a new `SUBWAVE_BUILD_VERSION` build-arg first, falling back to `git describe`, then `package.json`:

1. **`SUBWAVE_BUILD_VERSION`** — set from `git describe` by `scripts/update.sh` and the publish-images CI (from the pushed tag). Decoupled from the image-tag `SUBWAVE_VERSION` so it never clobbers the tag.
2. **`git describe`** — for local `npm run dev` / `npm run build` (a Docker build has no `.git`, so this is skipped there).
3. **`package.json`** — the original source; correct on a tagged checkout.

Result:
- **Pulled / released images** show clean semver (e.g. `0.31.0`).
- **Source / dev builds** show the precise commit (e.g. `v0.29.0-40-gc325995`) — honest about being a pre-release between tags, instead of a misleading clean number.

## Files

- `web/next.config.js`, `controller/src/routes/backup.ts` — version resolvers (env → describe → package.json)
- `web/Dockerfile`, `docker/Dockerfile.controller`, `docker/Dockerfile.aio` — declare the build-arg (aio: web-build + controller-runtime stages)
- `docker-compose.yml`, `.byo.yml`, `.dev.yml` — pass it through `build.args`
- `scripts/update.sh` — compute it from `git describe`
- `.github/workflows/publish-images.yml` — stamp it from the tag (`fetch-depth: 0` so describe resolves on branch dispatch)

## Verification

- `npm run lint` (eslint + tsc): web clean, controller 0 errors.
- All three compose files + the workflow parse as valid YAML.
- Runtime resolution confirmed: no env → `git describe`; `SUBWAVE_BUILD_VERSION=v0.31.0` → `0.31.0`; both decoupled from the stale `package.json` `0.30.0`.

## Note

Source builds (your develop deploy path) will now show a `git describe` string rather than a clean `0.31.0` — develop's git lineage doesn't contain the main-only release tags, so no develop-derived value can produce `0.31.0`. The describe string is longer and could wrap in the `nav-foot-version` span (likely fine). Easy to trim the format if preferred.