### PR TITLE
fix(llm): namespace inline API keys per-provider (#657)

### DIFF
--- a/controller/src/llm/internal/provider/legs.ts
+++ b/controller/src/llm/internal/provider/legs.ts
@@ -43,8 +43,11 @@ export function primaryLeg(): Leg {
 // no model) degrades to "no fallback" rather than throwing over the primary's
 // own error.
 export function fallbackLeg(): Leg | null {
-  const fb = settings.get().llm?.fallback;
-  if (!fb || !fb.enabled) return null;
+  const stored = settings.get().llm?.fallback;
+  if (!stored || !stored.enabled) return null;
+  // Resolve the fallback's inline key per-provider (issue #657) — the stored
+  // fallback.apiKey slot is legacy/empty now. Empty → its env var, as before.
+  const fb = { ...stored, apiKey: settings.llmKeyFor(stored.provider) };
   try {
     return { cfg: fb, model: languageModel(fb), noThinkModel: languageModel(fb, { forceNoThink: true }), label: labelFor(fb) };
   } catch {

--- a/controller/src/llm/internal/provider/registry.ts
+++ b/controller/src/llm/internal/provider/registry.ts
@@ -35,8 +35,13 @@ import { capabilitiesFor } from './capabilities.js';
 const clientCache = new Map();
 
 export function llmCfg() {
-  return settings.get().llm
+  const llm = settings.get().llm
     || { provider: 'ollama', model: '', apiKey: '', ollamaUrl: '', baseUrl: '', reasoning: false };
+  // The stored `apiKey` slot is legacy (always '' after settings.load()); the
+  // active key is resolved per-provider from settings.llm.keys (issue #657).
+  // Empty → every provider case below falls through to its env var, as before.
+  // Embedding inheritance reads llm.apiKey from here too, so it stays correct.
+  return { ...llm, apiKey: settings.llmKeyFor(llm.provider) };
 }
 
 // When raw-request debug capture is enabled (LLM_DEBUG_RAW env flag or the

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -492,15 +492,15 @@ router.post('/settings/llm/probe-compat', requireAdmin, async (req, res) => {
     if (!resolvedApiKey) {
       await settings.load();
       const s = settings.get();
-      const _primaryUrl = (s.llm?.baseUrl || '').trim().replace(/\/+$/, '');
       const fallbackUrl = (s.llm?.fallback?.baseUrl || '').trim().replace(/\/+$/, '');
       const targetUrl = baseUrl.trim().replace(/\/+$/, '');
-
-      if (targetUrl === fallbackUrl && s.llm?.fallback?.apiKey) {
-        resolvedApiKey = s.llm.fallback.apiKey;
-      } else if (s.llm?.apiKey) {
-        resolvedApiKey = s.llm.apiKey;
-      }
+      // Match the target server to a leg, then read that leg's provider's inline
+      // key from the per-provider map (issue #657). Falls back to the
+      // openai-compatible slot when neither leg's URL matches.
+      const legProvider = (targetUrl && targetUrl === fallbackUrl)
+        ? s.llm?.fallback?.provider
+        : s.llm?.provider;
+      resolvedApiKey = settings.llmKeyFor(legProvider || 'openai-compatible');
     }
 
     const m = createOpenAI({
@@ -558,15 +558,10 @@ router.get('/settings/llm/models', requireAdmin, async (req, res) => {
           || (provider === 'locca' ? llmProvider.DEFAULT_LOCCA_BASE_URL : '');
         if (!url) throw new Error('baseUrl is required for openai-compatible');
         await settings.load();
-        const s = settings.get();
-        // Resolve the key the way probe-compat does: a discovery aimed at the
-        // fallback server's URL uses the fallback key; otherwise the primary's.
-        // `url` and `baseUrl` are already trailing-slash-stripped above.
-        const fallbackUrl = (s.llm?.fallback?.baseUrl || '').trim().replace(/\/+$/, '');
-        const apiKey =
-          (url === fallbackUrl && typeof s.llm?.fallback?.apiKey === 'string' && s.llm.fallback.apiKey)
-            ? s.llm.fallback.apiKey
-            : (typeof s.llm?.apiKey === 'string' ? s.llm.apiKey : '');
+        // Inline key for this provider from the per-provider map (issue #657).
+        // Primary and fallback inline legs of the same provider share one entry,
+        // so the key resolves by provider id without a baseUrl match.
+        const apiKey = settings.llmKeyFor(provider);
         const headers: Record<string, string> = {};
         if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
         const r = await fetch(`${url}/models`, { signal: ctrl.signal, headers });

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -300,11 +300,10 @@ function applyLlmLegPatch(target: any, patch: any, label: string): void {
     if (v.length > 100) throw new Error(`${label}.model must be 0-100 chars`);
     target.model = v;
   }
-  // 'set' is the redaction sentinel from getRedacted() — ignore it so a
-  // round-tripped settings form doesn't overwrite the real key.
-  if (l.apiKey !== undefined && l.apiKey !== 'set') {
-    target.apiKey = String(l.apiKey);
-  }
+  // NB: the inline API key is NOT handled here — it's routed per-provider into
+  // settings.llm.keys by applyInlineKey() at the call site, after the leg's
+  // provider has been resolved. Keeping it out of the shared leg patch is what
+  // stops one provider's key leaking into another's slot (issue #657).
   if (l.ollamaUrl !== undefined) {
     const v = String(l.ollamaUrl).trim();
     if (v.length > 200) throw new Error(`${label}.ollamaUrl must be 0-200 chars`);
@@ -336,6 +335,52 @@ function applyLlmLegPatch(target: any, patch: any, label: string): void {
     }
     target.toolChoice = v;
   }
+}
+
+// Route an incoming inline API key to its provider's slot in `llmHost.keys`
+// (issue #657). `provider` is the leg's already-resolved provider, so the key
+// lands under the identity it belongs to and can never shadow another
+// provider's key after a switch. '' clears that provider's entry; 'set' (the
+// getRedacted() sentinel) and undefined leave it untouched.
+function applyInlineKey(llmHost: any, provider: string, rawApiKey: any): void {
+  if (rawApiKey === undefined || rawApiKey === 'set') return;
+  const v = String(rawApiKey);
+  if (v.length > 1000) throw new Error('llm.apiKey must be 0-1000 chars');
+  if (!llmHost.keys || typeof llmHost.keys !== 'object') llmHost.keys = {};
+  if (v) llmHost.keys[provider] = v;
+  else delete llmHost.keys[provider];
+}
+
+// Build the per-provider inline-key map from a stored settings.llm blob.
+// Sanitises any persisted `keys` (string values, known providers only) and
+// migrates the two legacy single slots (settings.llm.apiKey /
+// settings.llm.fallback.apiKey). Those were only ever written by the
+// openai-compatible / locca inline-key path, so a value found while the leg's
+// provider is something else is a STALE compat token that leaked into the
+// shared slot (issue #657) — attribute it to its true owner (openai-compatible)
+// rather than the current provider, which both preserves the real key and keeps
+// the env-var provider's slot empty so it resolves from secrets.env again.
+function normalizeLlmKeys(storedLlm: any): Record<string, string> {
+  const out: Record<string, string> = {};
+  const raw = storedLlm?.keys;
+  if (raw && typeof raw === 'object') {
+    for (const p of Object.keys(raw)) {
+      if (LLM_PROVIDERS.includes(p) && typeof raw[p] === 'string' && raw[p]) out[p] = raw[p];
+    }
+  }
+  const ownerFor = (prov: any) =>
+    prov === 'openai-compatible' || prov === 'locca' ? prov : 'openai-compatible';
+  const legacyPrimary = typeof storedLlm?.apiKey === 'string' ? storedLlm.apiKey : '';
+  if (legacyPrimary) {
+    const owner = ownerFor(storedLlm?.provider);
+    if (!out[owner]) out[owner] = legacyPrimary;
+  }
+  const legacyFallback = typeof storedLlm?.fallback?.apiKey === 'string' ? storedLlm.fallback.apiKey : '';
+  if (legacyFallback) {
+    const owner = ownerFor(storedLlm?.fallback?.provider);
+    if (!out[owner]) out[owner] = legacyFallback;
+  }
+  return out;
 }
 
 // Cloud TTS vendors usable by the `cloud` engine. `openai-compatible` targets
@@ -673,7 +718,16 @@ const DEFAULTS = {
   llm: {
     provider: 'ollama',
     model: '',
+    // Legacy single inline-key slot. Superseded by `keys` (per-provider) — kept
+    // only so an old settings.json migrates cleanly. Always '' after load();
+    // resolution reads `keys`, never this. See llmKeyFor() / normalizeLlmKeys().
     apiKey: '',
+    // Per-provider inline API keys, keyed by provider id (issue #657). Only the
+    // inline-key providers (openai-compatible, locca) ever populate this from the
+    // UI — env-var providers (openrouter, anthropic, …) keep their key in
+    // state/secrets.env. Namespacing by provider means switching providers can
+    // never leave one provider's key in the slot another provider then reads.
+    keys: {},
     // Ollama server URL. Empty → fall back to config.ollama.url. Only used
     // when provider === 'ollama'.
     ollamaUrl: '',
@@ -1278,7 +1332,10 @@ export async function load() {
         ? stored.llm.provider
         : DEFAULTS.llm.provider,
       model: typeof stored.llm?.model === 'string' ? stored.llm.model.trim() : DEFAULTS.llm.model,
-      apiKey: typeof stored.llm?.apiKey === 'string' ? stored.llm.apiKey : DEFAULTS.llm.apiKey,
+      // Legacy single slot is migrated into `keys` below, then cleared — there
+      // is exactly one source of truth for inline keys (issue #657).
+      apiKey: '',
+      keys: normalizeLlmKeys(stored.llm),
       ollamaUrl:
         typeof stored.llm?.ollamaUrl === 'string'
           ? stored.llm.ollamaUrl.trim()
@@ -1332,7 +1389,9 @@ export async function load() {
             ? fb.provider
             : DEFAULTS.llm.fallback.provider,
           model: typeof fb.model === 'string' ? fb.model.trim() : DEFAULTS.llm.fallback.model,
-          apiKey: typeof fb.apiKey === 'string' ? fb.apiKey : DEFAULTS.llm.fallback.apiKey,
+          // Legacy fallback slot migrated into settings.llm.keys above, then
+          // cleared. The fallback resolves its key from `keys[fb.provider]`.
+          apiKey: '',
           ollamaUrl:
             typeof fb.ollamaUrl === 'string' ? fb.ollamaUrl.trim() : DEFAULTS.llm.fallback.ollamaUrl,
           baseUrl:
@@ -1509,11 +1568,31 @@ export function getDefaults() {
   return DEFAULTS;
 }
 
+// Resolve the operator-entered inline API key for a provider from the
+// per-provider map (issue #657). Returns '' when none is stored, in which case
+// the registry/embedding layer falls through to the provider's env var
+// (OPENROUTER_API_KEY etc.) exactly as before. This is the single resolution
+// chokepoint — leg assembly (registry.llmCfg / legs.fallbackLeg) and the
+// openai-compatible probe/discovery routes all go through it.
+export function llmKeyFor(provider: string): string {
+  const keys = get().llm?.keys || {};
+  const v = keys[provider];
+  return typeof v === 'string' ? v : '';
+}
+
 // Settings with secret fields masked — for the admin /settings response.
 export function getRedacted() {
   const s = get();
   const clone = JSON.parse(JSON.stringify(s));
-  if (clone.llm) clone.llm.apiKey = s.llm?.apiKey ? 'set' : '';
+  if (clone.llm) {
+    clone.llm.apiKey = s.llm?.apiKey ? 'set' : '';
+    // Per-provider inline keys masked to 'set' | '' per entry, so the admin UI
+    // can show which providers have a key on file without exposing the value.
+    clone.llm.keys = {};
+    for (const p of Object.keys(s.llm?.keys || {})) {
+      clone.llm.keys[p] = s.llm.keys[p] ? 'set' : '';
+    }
+  }
   if (clone.llm?.fallback) clone.llm.fallback.apiKey = s.llm?.fallback?.apiKey ? 'set' : '';
   if (clone.tts?.cloud) clone.tts.cloud.apiKey = s.tts?.cloud?.apiKey ? 'set' : '';
   if (clone.search) clone.search.apiKey = s.search?.apiKey ? 'set' : '';
@@ -2170,6 +2249,9 @@ export async function update(patch) {
   if ('llm' in patch) {
     const l = patch.llm || {};
     applyLlmLegPatch(next.llm, l, 'llm');
+    // Route the primary inline key into keys[provider] AFTER the provider is
+    // resolved, so it's stored under the identity it belongs to (issue #657).
+    applyInlineKey(next.llm, next.llm.provider, l.apiKey);
     if (l.pickerAgent !== undefined) {
       next.llm.pickerAgent = !!l.pickerAgent;
     }
@@ -2210,6 +2292,10 @@ export async function update(patch) {
         next.llm.fallback.enabled = !!fb.enabled;
       }
       applyLlmLegPatch(next.llm.fallback, fb, 'llm.fallback');
+      // Fallback inline key shares the same per-provider map (keys live at
+      // next.llm.keys, not under the fallback) — routed by the fallback's
+      // resolved provider.
+      applyInlineKey(next.llm, next.llm.fallback.provider, fb.apiKey);
       if (
         next.llm.fallback.enabled &&
         next.llm.fallback.provider === 'openai-compatible' &&

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -2408,7 +2408,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                     type="password"
                     value={compatKeyInput}
                     onChange={(e: ChangeEvent<HTMLInputElement>) => setCompatKeyInput(e.target.value)}
-                    placeholder={(data.values?.llm as Record<string, unknown>)?.apiKey === 'set' ? '•••••• (on file)' : 'Bearer token (optional)'}
+                    placeholder={(data.values?.llm as { keys?: Record<string, unknown> })?.keys?.['openai-compatible'] === 'set' ? '•••••• (on file)' : 'Bearer token (optional)'}
                     className="max-w-[360px]"
                   />
                   <Btn
@@ -2704,7 +2704,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                         type="password"
                         value={compatFallbackKeyInput}
                         onChange={(e: ChangeEvent<HTMLInputElement>) => setCompatFallbackKeyInput(e.target.value)}
-                        placeholder={(data.values?.llm?.fallback as unknown as Record<string, unknown>)?.apiKey === 'set' ? '•••••• (on file)' : 'Bearer token (optional)'}
+                        placeholder={(data.values?.llm as { keys?: Record<string, unknown> })?.keys?.['openai-compatible'] === 'set' ? '•••••• (on file)' : 'Bearer token (optional)'}
                         className="max-w-[360px]"
                       />
                       <Btn


### PR DESCRIPTION
Fixes #657.

## The bug
A working OpenRouter (primary) + Requesty (fallback) setup broke after trying an `openai-compatible` endpoint and reverting — every call failed with `Missing Authentication header` (OpenRouter) / a balance error (Requesty), even though both still showed saved keys.

## Root cause
`settings.llm.apiKey` is a **single shared slot**, but only `openai-compatible` writes a key into it inline — every env-var provider (openrouter, anthropic, …) keeps its key in `state/secrets.env`. So configuring `openai-compatible` stored its token in the slot; reverting to `openrouter` never cleared it, and the non-empty stale token **shadowed `OPENROUTER_API_KEY`** when the client was built (`registry.ts` does `cfg.apiKey ? {apiKey} : {}`, inline wins over env).

## The fix — credentials bound to provider identity, not a slot
- **`settings.ts`** — inline keys now live in `settings.llm.keys`, keyed by provider id. `applyInlineKey()` routes a save into `keys[provider]` *after* the leg's provider is resolved; `normalizeLlmKeys()` migrates + sanitises; `getRedacted()` masks the map per-entry; new exported `llmKeyFor()` is the single resolution chokepoint.
- **`registry.ts` / `legs.ts`** — `llmCfg()` and `fallbackLeg()` resolve `apiKey` via `llmKeyFor(provider)`. Empty → falls through to the provider's env var exactly as before, so **env-var providers are completely unaffected**.
- **`routes/settings.ts`** — the openai-compatible probe + model-discovery endpoints read the stored key from the map.
- **`web/.../SettingsPanel.tsx`** — the "key on file" indicators read `keys['openai-compatible']`.

Because a key is now namespaced by the provider it belongs to, one provider's key can never leak into another provider's resolution. The whole bug class is structurally impossible.

## Migration auto-heals already-broken installs
The legacy `llm.apiKey` / `fallback.apiKey` slots were only ever written by `openai-compatible`/`locca`, so a value found while the active provider is something else is a stale leaked token — it's attributed to its true owner (`openai-compatible`) instead of the current provider. Result on next boot: `openrouter` resolves to its env key again and the compat key is preserved. Migration is idempotent.

## Known limitation (acceptable)
Primary + fallback that are *both* `openai-compatible` now share one `keys['openai-compatible']` entry (two self-hosted servers with different keys would collapse to one). Niche — failover only triggers on host-unreachable, so a same-provider primary+fallback is already pointless. Noted in code.

## Verification
- `controller` `tsc --noEmit`: 0 errors
- `web` `npm run lint` (eslint + tsc): 0 errors
- Algorithm test (reported scenario + 9 edge cases incl. idempotent reload, runtime switch, `set` sentinel, explicit clear): 10/10 pass