### PR TITLE
fix(app): clamp DJ thinking line so long scripts don't overlap the waveform

### DIFF
--- a/app/src/player/DjThinkingLine.tsx
+++ b/app/src/player/DjThinkingLine.tsx
@@ -3,7 +3,7 @@
 // Ported from web DjThinkingLine (without the per-character typing animation).
 
 import { useMemo } from 'react';
-import { Pressable, Text } from 'react-native';
+import { Pressable, Text, useWindowDimensions } from 'react-native';
 import { selectThinkingTurn, turnClass, turnText } from '@/lib/sessionFeed';
 import type { SessionTurn } from '@/lib/types';
 import { useTheme } from '@/theme/ThemeContext';
@@ -22,6 +22,14 @@ export interface DjThinkingLineProps {
 
 export default function DjThinkingLine({ feed, enabled, currentTrackId = null, onOpenBooth }: DjThinkingLineProps) {
   const { colors } = useTheme();
+  // Clamp the inline teaser so long "extended" scripts can't grow the column and
+  // spill down over the waveform (web issue #576 — there it's line-clamp-2 →
+  // line-clamp-6 on tall viewports). RN has no overflow clip in this column, so an
+  // unclamped script overflows CenterStage's centred flex-1 onto the Waveform
+  // below. Mirror the web breakpoint: 6 lines on tall screens, 3 on short ones.
+  // The full text stays one tap away in the Booth.
+  const { height } = useWindowDimensions();
+  const maxLines = height >= 760 ? 6 : 3;
   // The DJ turn relevant to what's ON AIR now — see selectThinkingTurn (#546).
   const latest = useMemo<SessionTurn | null>(
     () => selectThinkingTurn(feed, currentTrackId),
@@ -39,7 +47,12 @@ export default function DjThinkingLine({ feed, enabled, currentTrackId = null, o
       <Text className="font-mono text-muted" style={{ fontSize: 14, opacity: 0.7 }}>
         {MARKER[cls] || '·'}
       </Text>
-      <Text className="font-mono text-muted flex-1" style={{ fontSize: 14, lineHeight: 22 }}>
+      <Text
+        className="font-mono text-muted flex-1"
+        style={{ fontSize: 14, lineHeight: 22 }}
+        numberOfLines={maxLines}
+        ellipsizeMode="tail"
+      >
         {display}
         <Text style={{ color: colors.accent }}> ▍</Text>
       </Text>


### PR DESCRIPTION
The native LIVE page stacks CenterStage (flex-1, justify-center) above a
fixed-height Waveform in a column. The DJ thinking line rendered its script
text unbounded, so a long "extended" script overflowed CenterStage's centred
content downward over the waveform and other UI.

Mirror the web player's existing fix (issue #576, line-clamp-2 → line-clamp-6
on tall viewports) using RN's numberOfLines: clamp to 6 lines on tall screens,
3 on short ones, with tail ellipsis. The full text stays one tap away in the
Booth.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GLbwbxxGG41VMiLdD5Xk4K