### PR TITLE
feat(api): /listen.pls + /listen.m3u tune-in endpoints + now-playing stream block

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,15 @@ bin/subwave        Operator CLI entry: setup, status, doctor, lifecycle
   call goes through the Vercel AI SDK.
 - **There is no `/skip` for listeners.** Track-end is the only natural
   transition; operators have an admin-only skip endpoint.
+- **Add to Sonos / VLC with one link.** Hardware and software players take a
+  playlist file, not a raw stream URL — paste `https://<your-station>/api/listen.pls`
+  (or `/api/listen.m3u`) into Sonos, VLC, moOde, or a car receiver and it tunes
+  straight in. Both are public (no auth), point at the always-served MP3 mount
+  (plus Opus when you've enabled it), and resolve the origin from `SITE_URL`
+  when set, otherwise the address you reached the station on (LAN / Tailscale /
+  custom domain). `/api/now-playing` also carries a `stream` block
+  (`mount`, `format`, `bitrate`, `sampleRate`, `channels`) for clients that want
+  the broadcast's shape.
 - **Navidrome ≥0.62 is recommended.** It ships several security hardening
   fixes (internet-radio management now admin-gated, transcode-config
   disclosure restricted to admins, concurrent-transcode DoS limits) and the

--- a/controller/scripts/listeners-status.test.ts
+++ b/controller/scripts/listeners-status.test.ts
@@ -20,7 +20,13 @@ function test(name: string, fn: () => void | Promise<void>) {
 }
 
 const LIMIT = 4;
-const online: StreamStatus = { online: true, listeners: { current: 3, peak: 5 }, bitrate: 192 };
+const online: StreamStatus = {
+  online: true,
+  listeners: { current: 3, peak: 5 },
+  bitrate: 192,
+  sampleRate: 44100,
+  channels: 2,
+};
 
 async function main() {
   console.log('statusAfterFailure (transient vs sustained outage):');
@@ -29,6 +35,8 @@ async function main() {
     const next = statusAfterFailure(online, 1, LIMIT, 5);
     assert.equal(next.online, true);              // not torn offline by one blip
     assert.equal(next.bitrate, 192);              // last known bitrate kept
+    assert.equal(next.sampleRate, 44100);         // last known stream shape kept
+    assert.equal(next.channels, 2);
     assert.equal(next.listeners.current, 3);      // last known count, NOT a flashed 0
     assert.equal(next.listeners.peak, 5);
   });
@@ -43,6 +51,8 @@ async function main() {
     const next = statusAfterFailure(online, LIMIT, LIMIT, 5);
     assert.equal(next.online, false);             // genuinely-down Icecast surfaces
     assert.equal(next.bitrate, null);
+    assert.equal(next.sampleRate, null);          // stream shape cleared with the mount
+    assert.equal(next.channels, null);
     assert.equal(next.listeners.current, 0);      // nobody's listening to a dead mount
     assert.equal(next.listeners.peak, 5);         // run's peak preserved
   });
@@ -54,7 +64,7 @@ async function main() {
   });
 
   await test('an already-offline prior status stays offline while transient', () => {
-    const offline: StreamStatus = { online: false, listeners: { current: 0, peak: 2 }, bitrate: null };
+    const offline: StreamStatus = { online: false, listeners: { current: 0, peak: 2 }, bitrate: null, sampleRate: null, channels: null };
     const next = statusAfterFailure(offline, 1, LIMIT, 2);
     assert.equal(next.online, false);             // never flips a cold start "online"
     assert.equal(next.listeners.peak, 2);
@@ -66,7 +76,7 @@ async function main() {
   });
 
   await test('does not mutate the previous status object', () => {
-    const prev: StreamStatus = { online: true, listeners: { current: 3, peak: 5 }, bitrate: 192 };
+    const prev: StreamStatus = { online: true, listeners: { current: 3, peak: 5 }, bitrate: 192, sampleRate: 44100, channels: 2 };
     statusAfterFailure(prev, 1, LIMIT, 7);
     assert.equal(prev.listeners.peak, 5);         // input untouched
     assert.equal(prev.listeners.current, 3);

--- a/controller/src/broadcast/listeners.ts
+++ b/controller/src/broadcast/listeners.ts
@@ -38,10 +38,20 @@ let consecutiveStatusFailures = 0;          // resets to 0 on every successful p
 export interface StreamStatus {
   online: boolean;
   listeners: { current: number; peak: number };
-  /** Bitrate (kbps) of the first attached broadcast mount, null when offline. */
+  /** Bitrate (kbps) of the primary (mp3) broadcast mount, null when offline. */
   bitrate: number | null;
+  /** Sample rate (Hz) of the primary mount, null when offline/unknown. */
+  sampleRate: number | null;
+  /** Channel count of the primary mount, null when offline/unknown. */
+  channels: number | null;
 }
-let lastStatus: StreamStatus = { online: false, listeners: { current: 0, peak: 0 }, bitrate: null };
+let lastStatus: StreamStatus = {
+  online: false,
+  listeners: { current: 0, peak: 0 },
+  bitrate: null,
+  sampleRate: null,
+  channels: null,
+};
 
 // How many *consecutive* failed status polls before we stop trusting the last
 // known `online` and report the broadcast as offline. Below this we hold the
@@ -66,7 +76,7 @@ export function statusAfterFailure(
   peak: number,
 ): StreamStatus {
   if (consecutiveFailures >= limit) {
-    return { online: false, listeners: { current: 0, peak }, bitrate: null };
+    return { online: false, listeners: { current: 0, peak }, bitrate: null, sampleRate: null, channels: null };
   }
   return { ...prev, listeners: { ...prev.listeners, peak } };
 }
@@ -78,9 +88,22 @@ export function statusAfterFailure(
 const HISTORY_FILE = join(config.stateDir, 'listeners.jsonl');
 let lastPersistedMinute = -1;
 
+// Pull samplerate / channels off an Icecast status source. Icecast exposes
+// these either as top-level numeric fields or folded into the semicolon-
+// delimited `audio_info` string ("samplerate=44100;channels=2;quality=…"),
+// depending on build and encoder — try the direct field first, then the string.
+function audioParam(src: any, key: 'samplerate' | 'channels'): number | null {
+  const direct = Number(src?.[key]);
+  if (Number.isFinite(direct) && direct > 0) return direct;
+  const m = String(src?.audio_info || '').match(new RegExp(`${key}=([0-9]+)`, 'i'));
+  return m ? Number(m[1]) : null;
+}
+
 async function fetchCount() {
   let online = false;
   let bitrate: number | null = null;
+  let sampleRate: number | null = null;
+  let channels: number | null = null;
   let rawCount = 0; // un-deduped status sum — the fallback when admin is unreachable
   try {
     const ctrl = new AbortController();
@@ -97,10 +120,19 @@ async function fetchCount() {
     online = broadcastSources.length > 0;
     rawCount = broadcastSources.reduce(
       (sum: number, s: any) => sum + Number(s.listeners || 0), 0);
-    // Bitrate from the first attached mount — both share the same `radio` bus,
-    // so one figure represents the broadcast. Comes free off this same poll.
-    const firstBitrate = Number(broadcastSources[0]?.bitrate);
+    // Describe the broadcast off the *primary* mount — /stream.mp3, the
+    // always-served universal floor — rather than whichever source Icecast
+    // happened to list first (Opus, when enabled, is a different 96k/48kHz
+    // encode and would misreport the figures listeners actually receive). Falls
+    // back to the first attached source if the mp3 mount isn't found. All comes
+    // free off this same poll.
+    const primarySource =
+      broadcastSources.find((s: any) => String(s?.listenurl || '').includes('/stream.mp3')) ??
+      broadcastSources[0];
+    const firstBitrate = Number(primarySource?.bitrate);
     bitrate = Number.isFinite(firstBitrate) ? firstBitrate : null;
+    sampleRate = audioParam(primarySource, 'samplerate');
+    channels = audioParam(primarySource, 'channels');
 
     // Dedupe by IP+UA off the admin per-connection feed (Safari double-counts —
     // see dedupeListeners). Only worth a call when someone's actually attached;
@@ -117,7 +149,7 @@ async function fetchCount() {
 
     lastCount = current;
     peakSeen = Math.max(peakSeen, current);
-    lastStatus = { online, listeners: { current, peak: peakSeen }, bitrate };
+    lastStatus = { online, listeners: { current, peak: peakSeen }, bitrate, sampleRate, channels };
     consecutiveStatusFailures = 0;
   } catch {
     lastCount = null;

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -41,6 +41,21 @@ function avatarUrlFor(personaId?: string | null): string {
   return personaId ? `/persona-avatar/${encodeURIComponent(personaId)}` : '';
 }
 
+// Resolve the public origin to build tune-in URLs from. SITE_URL (set by the
+// operator) wins — it's the trusted, canonical address and is immune to a
+// spoofed Host header on a misconfigured reverse proxy. When it's unset we fall
+// back to how the listener actually reached us (X-Forwarded-Proto/Host from the
+// proxy, else the request's own protocol/host) so LAN, Tailscale, and ad-hoc
+// custom-domain deployments still emit a URL that resolves for the listener.
+function publicOrigin(req: express.Request): string {
+  const fromEnv = (process.env.SITE_URL || '').trim().replace(/\/+$/, '');
+  if (fromEnv) return fromEnv;
+  const xfProto = String(req.headers['x-forwarded-proto'] || '').split(',')[0].trim();
+  const proto = xfProto || req.protocol || 'http';
+  const host = String(req.headers['x-forwarded-host'] || req.headers.host || '').split(',')[0].trim();
+  return host ? `${proto}://${host}` : `http://localhost`;
+}
+
 // ---------------------------------------------------------------------------
 // GET /cover/:id — proxy Subsonic cover art so listener browsers can use it
 // as MediaSession artwork (lock screen / CarPlay / Bluetooth display) without
@@ -195,6 +210,19 @@ router.get('/now-playing', async (req, res) => {
       listeners: stream.listeners,
       streamOnline: stream.online,
       streamBitrate: stream.bitrate,
+      // Structured description of the live broadcast for hardware players and
+      // tune-in helpers (the /listen.pls + /listen.m3u routes mirror this). The
+      // flat streamOnline/streamBitrate above stay for the existing web player;
+      // this `stream` object is additive. mount/format describe the always-
+      // served MP3 floor; opusEnabled tells clients the Opus mount is also live.
+      stream: {
+        mount: '/stream.mp3',
+        format: 'mp3',
+        bitrate: stream.bitrate,
+        sampleRate: stream.sampleRate,
+        channels: stream.channels,
+        opusEnabled: stationSettings.stream?.opusEnabled === true,
+      },
       // Cumulative since-boot LLM token total — drives the listener-facing
       // token ticker next to the now-playing time. Aggregate integer only; no
       // model/cost breakdown (that stays on the admin-gated /stats surface).
@@ -209,6 +237,50 @@ router.get('/now-playing', async (req, res) => {
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
+});
+
+// ---------------------------------------------------------------------------
+// GET /listen.pls and GET /listen.m3u — one-paste tune-in files for hardware
+// and software players (Sonos, VLC, moOde, car receivers). A listener adds the
+// station by pasting one URL instead of hunting for the raw /stream.mp3 mount.
+//
+// Both wrap the always-served MP3 floor; the Opus mount is appended only when
+// the operator has enabled it. Origin comes from publicOrigin() (SITE_URL when
+// set, else the request host) so the link works from however the listener
+// reached the site. Unauthenticated by design — these expose nothing beyond the
+// already-public stream URL and station name.
+// ---------------------------------------------------------------------------
+function listenMounts(req: express.Request) {
+  const origin = publicOrigin(req);
+  const s = settings.get();
+  const station = s.station || 'SUB/WAVE';
+  const entries = [{ url: `${origin}/stream.mp3`, title: station }];
+  if (s.stream?.opusEnabled === true) {
+    entries.push({ url: `${origin}/stream.opus`, title: `${station} (Opus)` });
+  }
+  return { station, entries };
+}
+
+router.get('/listen.pls', (req, res) => {
+  const { entries } = listenMounts(req);
+  const lines = ['[playlist]', `NumberOfEntries=${entries.length}`];
+  entries.forEach((e, i) => {
+    const n = i + 1;
+    lines.push(`File${n}=${e.url}`, `Title${n}=${e.title}`, `Length${n}=-1`);
+  });
+  lines.push('Version=2');
+  res.setHeader('Content-Type', 'audio/x-scpls; charset=utf-8');
+  res.setHeader('Content-Disposition', 'inline; filename="listen.pls"');
+  res.send(lines.join('\n') + '\n');
+});
+
+router.get('/listen.m3u', (req, res) => {
+  const { entries } = listenMounts(req);
+  const lines = ['#EXTM3U'];
+  for (const e of entries) lines.push(`#EXTINF:-1,${e.title}`, e.url);
+  res.setHeader('Content-Type', 'audio/x-mpegurl; charset=utf-8');
+  res.setHeader('Content-Disposition', 'inline; filename="listen.m3u"');
+  res.send(lines.join('\n') + '\n');
 });
 
 // ---------------------------------------------------------------------------

--- a/web/components/manual/Clients.tsx
+++ b/web/components/manual/Clients.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import ManualPage from './ManualPage';
 import StreamUrl from './StreamUrl';
+import ListenLinks from './ListenLinks';
 import CodeBlock from "@/components/CodeBlock";
 
 // Where the "open a network stream" command lives in each VLC build. VLC's
@@ -126,6 +127,27 @@ export default function Clients() {
             Sonos, hardware internet radios, car receivers, and older mobile devices.
           </p>
         </div>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">THE EVEN EASIER WAY</p>
+        <h2>One-tap tune-in links.</h2>
+        <p>
+          Some players — Sonos, moOde, hardware internet radios, car receivers —
+          want a <em>playlist file</em>, not a bare stream address. The station
+          serves both, each a one-line wrapper around the{' '}
+          <code className="bs-code-inline">/stream.mp3</code> mount above:
+        </p>
+        <ListenLinks />
+        <p className="text-muted">
+          Paste either link where the player asks for a station or stream URL and it
+          tunes straight in — no need to type the raw address.{' '}
+          <code className="bs-code-inline">.pls</code> is the most widely supported
+          (Sonos, VLC, foobar2000); <code className="bs-code-inline">.m3u</code> is the
+          fallback for anything that prefers it. Both follow whatever domain you are
+          reading this on, need no sign-in, and add the Opus mount automatically when
+          the operator has enabled it.
+        </p>
       </section>
 
       <section className="bs-section">

--- a/web/components/manual/ListenLinks.tsx
+++ b/web/components/manual/ListenLinks.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import CodeBlock from '@/components/CodeBlock';
+
+// Renders the station's one-tap tune-in playlist links (.pls / .m3u) in
+// copyable code blocks. Like StreamUrl, the origin is resolved from the live
+// browser location after mount, so the guide always shows the address of
+// whatever host it is being read on. The pre-mount placeholder matches the
+// server render, so there is no hydration mismatch.
+export default function ListenLinks() {
+  const [origin, setOrigin] = useState('https://your-station.example');
+
+  useEffect(() => {
+    setOrigin(window.location.origin);
+  }, []);
+
+  return (
+    <>
+      <CodeBlock>{`${origin}/api/listen.pls`}</CodeBlock>
+      <CodeBlock>{`${origin}/api/listen.m3u`}</CodeBlock>
+    </>
+  );
+}


### PR DESCRIPTION
Closes #621.

## What

Adds one-paste tune-in helpers for hardware/software players and a structured stream descriptor on `/now-playing`.

- **`GET /listen.pls` + `GET /listen.m3u`** — public, no-auth playlist files. A listener pastes `https://<station>/api/listen.pls` (or `.m3u`) into Sonos, VLC, moOde, or a car receiver instead of hunting for the raw `/stream.mp3` URL. Single entry → `{origin}/stream.mp3`, title = station name; the Opus mount is appended only when `stream.opusEnabled`. Correct content types (`audio/x-scpls`, `audio/x-mpegurl`) + `Content-Disposition`.
- **Origin derivation** (`publicOrigin`) — prefers `SITE_URL` (trusted, canonical, immune to a spoofed `Host` header on a misconfigured proxy), falling back to `X-Forwarded-Proto/Host` then the request's own host, so LAN / Tailscale / custom-domain listeners get a URL that resolves for them.
- **`/now-playing` `stream` block** — `{ mount, format, bitrate, sampleRate, channels, opusEnabled }`. Additive: the existing flat `streamOnline` / `streamBitrate` stay for the web player.
- **Listener monitor** — `StreamStatus` gains `sampleRate`/`channels`, parsed from Icecast status (direct field or the `audio_info` string). bitrate/sampleRate/channels are read from the **mp3** mount specifically, so an enabled Opus mount (96k/48kHz) can't misreport the figures listeners actually receive. Sustained-outage path nulls them.

## Why

Hardware-player onboarding is real friction — most players want a `.pls`/`.m3u`, not a bare stream URL. Deriving the origin from how the listener reached the site (not only `SITE_URL`) makes it work on LAN/Tailscale/custom-domain setups.

## Acceptance criteria

- [x] Works behind bundled Caddy and BYO reverse-proxy compose (mounted on the same public router as `/stream.mp3`; origin from request/`SITE_URL`)
- [x] Documented (README "Add to Sonos / VLC")
- [x] No auth required on the listen helpers

## Test

- `tsc --noEmit` clean; `eslint` passes (warnings only, pre-existing `any` style)
- `scripts/listeners-status.test.ts` extended (new fields held on transient blip, cleared on sustained outage) — passes
- `doctor.ts` (the other `getStreamStatus` consumer) only reads existing fields — unaffected

> Note: two failures in `llm-pure.test.ts` (`showMusicLean` strict-genre wording) are pre-existing on `develop` and unrelated to this change.