### PR TITLE
feat(tts): add remote TTS engine for self-hosted HTTP endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ https://github.com/user-attachments/assets/fac7b723-c54f-438d-8440-bad1e0471e85
 - **Plain-language requests.** "Play something more upbeat" or "anything by Radiohead" works.
 - **Your own music library.** Pulls from Navidrome over the Subsonic API. No external catalogue.
 - **Swappable LLM provider.** Ollama, Anthropic, OpenAI, Google, DeepSeek, OpenRouter, Vercel AI Gateway, or any OpenAI-compatible server. Change it from the admin UI with no redeploy.
-- **Five TTS engines.** Piper and Kokoro in-process for fast local speech, plus an optional `tts-heavy` sidecar (`docker compose --profile tts-heavy up -d`) that adds Chatterbox (zero-shot voice cloning) and PocketTTS (6× real-time, EN/FR/DE/IT/ES/PT). Cloud (OpenAI / ElevenLabs) is also available. Pick a different engine per kind of speech.
+- **Six TTS engines.** Piper and Kokoro in-process for fast local speech, plus an optional `tts-heavy` sidecar (`docker compose --profile tts-heavy up -d`) that adds Chatterbox (zero-shot voice cloning) and PocketTTS (6× real-time, EN/FR/DE/IT/ES/PT). Cloud (OpenAI / ElevenLabs) and a Remote engine (any self-hosted HTTP endpoint, audio over the wire) round it out. Pick a different engine per kind of speech.
 - **Multiple DJ personas.** Up to 10 souls in rotation, each with its own voice and writing style.
 - **Dual-codec broadcast.** MP3 128 kbps for Sonos, hardware radios, and cars; Ogg-Opus 96 kbps for modern browsers. The web player picks automatically.
 - **Native apps and PWA.** Native iOS (on the App Store) and Android (on Google Play) players — background audio, lock-screen / CarPlay / Android Auto controls, multi-station — plus an installable PWA on phone and desktop.

--- a/controller/src/audio/remoteTts.ts
+++ b/controller/src/audio/remoteTts.ts
@@ -1,0 +1,155 @@
+// HTTP client for a user-configured remote TTS engine.
+//
+// When settings.tts.remote.url is set, the `remote` engine speaks the
+// Subwave-native /speak + /health contract against that endpoint — the same
+// protocol the built-in tts-heavy sidecar uses (docker/tts-heavy/server.py).
+// This is the TTS equivalent of the LLM's custom base URL: a first-class,
+// self-hosted HTTP engine without impersonating pocket-tts or chatterbox.
+//
+// See controller/src/audio/ttsHeavyClient.ts for the canonical /speak +
+// /health contract. The sidecar writes the WAV to the shared /var/sub-wave
+// volume and returns the absolute path, which the controller hands to
+// Liquidsoap via next.txt / say.txt / intro.txt — same semantics as every
+// other engine.
+
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { config } from '../config.js';
+import * as settings from '../settings.js';
+
+const PROBE_TIMEOUT_MS = 5_000;
+const PROBE_INTERVAL_MS = 30_000;
+const REQUEST_TIMEOUT_MS = 180_000;
+
+function getUrl(): string {
+  return settings.get().tts?.remote?.url || '';
+}
+
+// Cached availability — read synchronously by the dispatcher in tts.ts.
+let remoteAvailable = false;
+
+// One /health probe. `available` is true iff the sidecar reports ok.
+// No engine-name check — the remote endpoint is a generic bridge; the
+// sidecar decides what it supports. Network/timeout/parse failures
+// collapse to unavailable.
+async function probeOnce(): Promise<boolean> {
+  const url = getUrl();
+  if (!url) return false;
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), PROBE_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${url}/health`, { signal: ac.signal });
+    if (!res.ok) return false;
+    const body = (await res.json()) as { ok?: boolean };
+    return !!body.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+// Periodic probe loop. Runs every PROBE_INTERVAL_MS. Handles the case where
+// the URL is set AFTER the controller starts (e.g. via the admin UI). When
+// URL is empty the probe is a fast no-op; when it becomes present the next
+// tick picks it up. The interval is unref'd so it doesn't keep the event
+// loop alive on its own.
+let lastAvail = false;
+let loopStarted = false;
+function ensureProbeLoop(): void {
+  if (loopStarted) return;
+  loopStarted = true;
+  const tick = async () => {
+    const url = getUrl();
+    if (!url) {
+      if (remoteAvailable) {
+        remoteAvailable = false;
+        lastAvail = false;
+        console.log('[remote] TTS endpoint unavailable (no URL configured)');
+      }
+      return;
+    }
+    const available = await probeOnce();
+    if (available !== lastAvail) {
+      console.log(
+        `[remote] TTS endpoint ${available ? 'available' : 'unavailable'} (${url})`,
+      );
+      lastAvail = available;
+      remoteAvailable = available;
+    }
+  };
+  tick();
+  const handle = setInterval(tick, PROBE_INTERVAL_MS);
+  handle.unref?.();
+}
+
+export function isAvailable(): boolean {
+  const url = getUrl();
+  if (!url) return false;
+  return remoteAvailable;
+}
+
+// Read by the settings route to tell the UI whether remote has a URL.
+export function isConfigured(): boolean {
+  return !!getUrl();
+}
+
+export async function speak(
+  text: string,
+  { outPath: customPath, voice }: { outPath?: string; voice?: string },
+): Promise<string> {
+  const url = getUrl();
+  if (!url) throw new Error('remote TTS URL not configured');
+  if (!text || !text.trim()) throw new Error('Empty TTS text');
+
+  const outPath = customPath || path.join(config.piper.outDir, `${crypto.randomBytes(6).toString('hex')}.wav`);
+  await mkdir(path.dirname(outPath), { recursive: true });
+
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), REQUEST_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(`${url}/speak`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        engine: 'remote',
+        text: text.trim(),
+        voice: voice ?? '',
+        reference_wav: '',
+        out: outPath,
+      }),
+      signal: ac.signal,
+    });
+  } finally {
+    clearTimeout(t);
+  }
+  if (!res.ok) {
+    const errBody = await res.text().catch(() => '');
+    throw new Error(`remote TTS ${res.status}: ${errBody || res.statusText}`);
+  }
+  const body = (await res.json()) as {
+    ok: boolean;
+    path: string;
+    error?: string;
+    voice_used?: string;
+    fell_back?: boolean;
+    fell_back_reason?: string;
+  };
+  if (!body.ok) throw new Error(body.error || 'remote TTS returned ok:false');
+  // Make a silent voice substitution visible (issue #238): the call succeeded
+  // and audio plays, but NOT in the requested voice.
+  if (body.fell_back) {
+    console.warn(
+      `[remote] requested voice "${voice || ''}" not honoured`
+        + ` (${body.fell_back_reason || 'fell back'}); rendered "${body.voice_used ?? 'default'}"`,
+    );
+  }
+  return body.path;
+}
+
+// Kick off the probe loop at import time so availability is known before
+// the first segment fires. The loop handles a URL that is set later through
+// settings without a restart.
+ensureProbeLoop();

--- a/controller/src/audio/remoteTts.ts
+++ b/controller/src/audio/remoteTts.ts
@@ -1,18 +1,25 @@
 // HTTP client for a user-configured remote TTS engine.
 //
-// When settings.tts.remote.url is set, the `remote` engine speaks the
-// Subwave-native /speak + /health contract against that endpoint — the same
-// protocol the built-in tts-heavy sidecar uses (docker/tts-heavy/server.py).
-// This is the TTS equivalent of the LLM's custom base URL: a first-class,
-// self-hosted HTTP engine without impersonating pocket-tts or chatterbox.
+// When settings.tts.remote.url is set, the `remote` engine POSTs to that
+// endpoint's /speak and receives the rendered audio BYTES back in the HTTP
+// response, then writes them to a local file the controller (and Liquidsoap)
+// can read. Unlike the tts-heavy sidecar — which shares the /var/sub-wave
+// volume and returns a path — `remote` carries the audio in the response
+// body, so the endpoint can live on any host reachable over the network
+// (LAN, Tailscale, …) with no shared filesystem. This is the TTS equivalent
+// of the LLM's custom base URL: a first-class, self-hosted HTTP engine
+// without impersonating pocket-tts or chatterbox.
 //
-// See controller/src/audio/ttsHeavyClient.ts for the canonical /speak +
-// /health contract. The sidecar writes the WAV to the shared /var/sub-wave
-// volume and returns the absolute path, which the controller hands to
-// Liquidsoap via next.txt / say.txt / intro.txt — same semantics as every
-// other engine.
+// Contract:
+//   GET  {url}/health  → 200 JSON { ok: true }
+//   POST {url}/speak   → 200, request JSON { text, voice }, response BODY is
+//                        the rendered audio (WAV, Content-Type audio/*). The
+//                        controller writes the body to its own voice dir.
+//                        Optional response headers make a silent voice
+//                        substitution visible (issue #238): X-TTS-Fell-Back,
+//                        X-TTS-Voice-Used, X-TTS-Fell-Back-Reason.
 
-import { mkdir } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { config } from '../config.js';
@@ -26,13 +33,14 @@ function getUrl(): string {
   return settings.get().tts?.remote?.url || '';
 }
 
-// Cached availability — read synchronously by the dispatcher in tts.ts.
+// Cached availability — read synchronously by the dispatcher in tts.ts. The
+// periodic loop, the post-load boot probe, and refresh() on a URL change all
+// update it through runProbe(), the single writer.
 let remoteAvailable = false;
 
-// One /health probe. `available` is true iff the sidecar reports ok.
-// No engine-name check — the remote endpoint is a generic bridge; the
-// sidecar decides what it supports. Network/timeout/parse failures
-// collapse to unavailable.
+// One /health probe. true iff the endpoint reports ok. No engine-name check —
+// the remote endpoint is a generic bridge; it decides what it supports.
+// Network/timeout/parse failures collapse to unavailable.
 async function probeOnce(): Promise<boolean> {
   const url = getUrl();
   if (!url) return false;
@@ -50,49 +58,44 @@ async function probeOnce(): Promise<boolean> {
   }
 }
 
-// Periodic probe loop. Runs every PROBE_INTERVAL_MS. Handles the case where
-// the URL is set AFTER the controller starts (e.g. via the admin UI). When
-// URL is empty the probe is a fast no-op; when it becomes present the next
-// tick picks it up. The interval is unref'd so it doesn't keep the event
-// loop alive on its own.
-let lastAvail = false;
+// Probe once and update the cached availability, logging only on a change.
+// The single writer of remoteAvailable.
+async function runProbe(): Promise<void> {
+  const url = getUrl();
+  const available = url ? await probeOnce() : false;
+  if (available === remoteAvailable) return;
+  remoteAvailable = available;
+  console.log(
+    url
+      ? `[remote] TTS endpoint ${available ? 'available' : 'unavailable'} (${url})`
+      : '[remote] TTS endpoint unavailable (no URL configured)',
+  );
+}
+
+// Start the periodic /health probe loop (idempotent). Called from server.ts
+// AFTER settings.load(): the remote URL lives in settings (not env), so unlike
+// the tts-heavy probe this can't self-start at import time — it would only ever
+// see the empty default and leave the engine unavailable for the first tick.
+// The interval is unref'd so it doesn't keep the event loop alive on its own.
 let loopStarted = false;
-function ensureProbeLoop(): void {
+export function start(): void {
   if (loopStarted) return;
   loopStarted = true;
-  const tick = async () => {
-    const url = getUrl();
-    if (!url) {
-      if (remoteAvailable) {
-        remoteAvailable = false;
-        lastAvail = false;
-        console.log('[remote] TTS endpoint unavailable (no URL configured)');
-      }
-      return;
-    }
-    const available = await probeOnce();
-    if (available !== lastAvail) {
-      console.log(
-        `[remote] TTS endpoint ${available ? 'available' : 'unavailable'} (${url})`,
-      );
-      lastAvail = available;
-      remoteAvailable = available;
-    }
-  };
-  tick();
-  const handle = setInterval(tick, PROBE_INTERVAL_MS);
+  runProbe();
+  const handle = setInterval(runProbe, PROBE_INTERVAL_MS);
   handle.unref?.();
 }
 
-export function isAvailable(): boolean {
-  const url = getUrl();
-  if (!url) return false;
-  return remoteAvailable;
+// Force an immediate probe — called when the URL changes via the admin UI so
+// availability (and the UI badge) reflects the new endpoint without waiting for
+// the next 30s tick.
+export async function refresh(): Promise<void> {
+  await runProbe();
 }
 
-// Read by the settings route to tell the UI whether remote has a URL.
-export function isConfigured(): boolean {
-  return !!getUrl();
+export function isAvailable(): boolean {
+  if (!getUrl()) return false;
+  return remoteAvailable;
 }
 
 export async function speak(
@@ -113,13 +116,7 @@ export async function speak(
     res = await fetch(`${url}/speak`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        engine: 'remote',
-        text: text.trim(),
-        voice: voice ?? '',
-        reference_wav: '',
-        out: outPath,
-      }),
+      body: JSON.stringify({ text: text.trim(), voice: voice ?? '' }),
       signal: ac.signal,
     });
   } finally {
@@ -129,27 +126,23 @@ export async function speak(
     const errBody = await res.text().catch(() => '');
     throw new Error(`remote TTS ${res.status}: ${errBody || res.statusText}`);
   }
-  const body = (await res.json()) as {
-    ok: boolean;
-    path: string;
-    error?: string;
-    voice_used?: string;
-    fell_back?: boolean;
-    fell_back_reason?: string;
-  };
-  if (!body.ok) throw new Error(body.error || 'remote TTS returned ok:false');
+  // The audio rides back in the response body — write it where the controller
+  // and Liquidsoap can both read it (no shared volume needed). An empty body
+  // throws so the dispatcher falls back to Piper instead of handing Liquidsoap
+  // a zero-byte file (a silent segment with no error).
+  const audio = Buffer.from(await res.arrayBuffer());
+  if (audio.length === 0) throw new Error('remote TTS returned an empty response body');
+  await writeFile(outPath, audio);
+
   // Make a silent voice substitution visible (issue #238): the call succeeded
-  // and audio plays, but NOT in the requested voice.
-  if (body.fell_back) {
+  // and audio plays, but NOT in the requested voice. Surfaced via optional
+  // response headers since the body carries audio, not JSON.
+  if (res.headers.get('x-tts-fell-back')) {
     console.warn(
       `[remote] requested voice "${voice || ''}" not honoured`
-        + ` (${body.fell_back_reason || 'fell back'}); rendered "${body.voice_used ?? 'default'}"`,
+        + ` (${res.headers.get('x-tts-fell-back-reason') || 'fell back'});`
+        + ` rendered "${res.headers.get('x-tts-voice-used') || 'default'}"`,
     );
   }
-  return body.path;
+  return outPath;
 }
-
-// Kick off the probe loop at import time so availability is known before
-// the first segment fires. The loop handles a URL that is set later through
-// settings without a restart.
-ensureProbeLoop();

--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -8,12 +8,13 @@ import * as piper from './piper.js';
 import * as kokoro from './kokoro.js';
 import * as chatterbox from './chatterbox.js';
 import * as pocketTts from './pocketTts.js';
+import * as remoteTts from './remoteTts.js';
 import * as cloud from '../llm/speech.js';
 import * as settings from '../settings.js';
 import { recordTts } from '../stats.js';
 import { energyForDaypart } from '../context.js';
 
-export const ENGINES = ['piper', 'kokoro', 'chatterbox', 'pocket-tts', 'cloud'];
+export const ENGINES = ['piper', 'kokoro', 'chatterbox', 'pocket-tts', 'cloud', 'remote'];
 
 // Voice kinds the system speaks. `kind` is passed by the caller and used to
 // look up an engine override in settings. Unknown kinds fall back to default.
@@ -84,6 +85,12 @@ function resolveEngine(kind: string, personaTts: any) {
   if (chosen === 'kokoro' && !kokoro.isAvailable()) {
     return tts.defaultEngine && tts.defaultEngine !== 'kokoro' ? tts.defaultEngine : 'piper';
   }
+  // The remote engine needs a configured URL and a reachable sidecar — unlike
+  // the local engines, which gate on installed venvs/models. When the URL is
+  // blank or the /health probe hasn't succeeded yet, fall back to the default.
+  if (chosen === 'remote' && !remoteTts.isAvailable()) {
+    return tts.defaultEngine && tts.defaultEngine !== 'remote' ? tts.defaultEngine : 'piper';
+  }
   return chosen;
 }
 
@@ -136,6 +143,15 @@ async function speakWith(engine: string, text: string, opts: any, personaTts: an
       ? { provider: personaTts.cloudProvider, voice: personaTts.voice }
       : null;
     return cloud.speak(text, { ...opts, cloudOverride });
+  }
+  if (engine === 'remote') {
+    // Remote engine — persona's `voice` is forwarded as-is to the sidecar,
+    // which interprets it (built-in id, reference-wav filename, or VoiceDesign
+    // prompt). No global fallback voice — the sidecar owns its defaults.
+    const voice = (personaTts && personaTts.engine === 'remote' && personaTts.voice)
+      ? personaTts.voice
+      : undefined;
+    return remoteTts.speak(text, { ...opts, voice });
   }
   // For piper, persona's `voice` is an .onnx filename (resolved by piper.ts
   // against config.voices.dir). Empty/missing → the baked-in default voice.
@@ -299,6 +315,7 @@ export function availableEngines() {
     // silently revert to a built-in when cloning is unavailable (issue #238).
     pocketTtsCloning: pocketTts.cloningAvailable(),
     cloud: cloud.isConfigured(),
+    remote: remoteTts.isAvailable(),
     // Per-provider — a persona's cloud voice is only usable if *its* provider
     // is configured, which can differ from the global Cloud-engine provider.
     cloudByProvider: {
@@ -347,6 +364,10 @@ export function describeRouting() {
   } else if (engine === 'piper') {
     // For piper, `voice` is the .onnx filename; empty → baked-in default.
     voice = (personaTts?.engine === 'piper' && personaTts.voice)
+      ? personaTts.voice
+      : null;
+  } else if (engine === 'remote') {
+    voice = (personaTts?.engine === 'remote' && personaTts.voice)
       ? personaTts.voice
       : null;
   }

--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -145,9 +145,9 @@ async function speakWith(engine: string, text: string, opts: any, personaTts: an
     return cloud.speak(text, { ...opts, cloudOverride });
   }
   if (engine === 'remote') {
-    // Remote engine — persona's `voice` is forwarded as-is to the sidecar,
+    // Remote engine — persona's `voice` is forwarded as-is to the endpoint,
     // which interprets it (built-in id, reference-wav filename, or VoiceDesign
-    // prompt). No global fallback voice — the sidecar owns its defaults.
+    // prompt). No global fallback voice — the endpoint owns its defaults.
     const voice = (personaTts && personaTts.engine === 'remote' && personaTts.voice)
       ? personaTts.voice
       : undefined;

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -9,6 +9,7 @@ import * as library from '../music/library.js';
 import * as jingles from '../broadcast/jingles.js';
 import * as settings from '../settings.js';
 import * as tts from '../audio/tts.js';
+import * as remoteTts from '../audio/remoteTts.js';
 import * as chatterbox from '../audio/chatterbox.js';
 import * as piper from '../audio/piper.js';
 import * as llmProvider from '../llm/provider.js';
@@ -190,6 +191,12 @@ router.post('/settings', requireAdmin, async (req, res) => {
     }
     if (result.requiresRestart) {
       queue.log('scheduler', `mixer settings changed — Liquidsoap restart required`);
+    }
+    // A changed remote-TTS URL re-probes immediately so availability (and the
+    // admin "ready/unreachable" badge) reflects the new endpoint on the next
+    // /settings fetch instead of waiting for the 30s probe tick.
+    if (req.body?.tts?.remote?.url !== undefined) {
+      await remoteTts.refresh();
     }
     res.json(result);
   } catch (err) {

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -9,6 +9,7 @@ import * as jingles from './broadcast/jingles.js';
 import * as sfx from './broadcast/sfx.js';
 import { queue } from './broadcast/queue.js';
 import * as session from './broadcast/session.js';
+import * as remoteTts from './audio/remoteTts.js';
 import { getFullContext } from './context.js';
 import { loadCuriosityLedger } from './skills/curiosity.js';
 import { startScheduler } from './broadcast/scheduler.js';
@@ -123,6 +124,15 @@ app.listen(config.server.port, async () => {
     );
   } catch (err) {
     console.error('[settings] load failed:', err.message);
+  }
+
+  // Start the remote-TTS /health probe loop now that settings are loaded — its
+  // URL lives in settings (not env), so it can't self-start at import time the
+  // way the env-configured tts-heavy probe does. Best-effort; never fatal.
+  try {
+    remoteTts.start();
+  } catch (err: any) {
+    console.error('[remote] tts probe start failed:', err.message);
   }
 
   // Seed today's LLM token tally from the durable event log so a mid-day

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -123,9 +123,11 @@ export function effectiveFrequency(persona: any = getEffectivePersona()) {
 //
 // `cloud` routes through the AI SDK (OpenAI / ElevenLabs speech models) —
 // see llm/speech.js. `piper`, `kokoro`, `chatterbox`, and `pocket-tts` are
-// local engines. `remote` is a first-class self-hosted HTTP engine that
-// speaks the same /speak + /health contract as tts-heavy; configure the URL
-// in settings.tts.remote.url. Chatterbox and PocketTTS are opt-in — the
+// local engines. `remote` is a first-class self-hosted HTTP engine: it POSTs
+// to a configurable /speak endpoint and gets the rendered audio back in the
+// response body (no shared volume, so the endpoint can live on any host),
+// gated on a /health probe. Configure the URL in settings.tts.remote.url.
+// Chatterbox and PocketTTS are opt-in — the
 // default controller image doesn't bundle either; build the image with
 // `--build-arg WITH_CHATTERBOX=1` or `--build-arg WITH_POCKETTTS=1` (see
 // docker/Dockerfile.controller) to include the runtime. The dispatcher gates
@@ -705,10 +707,10 @@ const DEFAULTS = {
       // provider === 'openai-compatible'.
       baseUrl: '',
     },
-    // Remote engine — a user-configured self-hosted TTS endpoint that speaks
-    // the Subwave-native /speak + /health contract (the same protocol the
-    // tts-heavy sidecar uses). The TTS equivalent of the LLM's custom base
-    // URL. Empty → engine reports unavailable; the dispatcher falls back.
+    // Remote engine — a user-configured self-hosted TTS endpoint that renders
+    // audio over HTTP (POST /speak → audio body, gated on a /health probe).
+    // The TTS equivalent of the LLM's custom base URL. Empty → engine reports
+    // unavailable; the dispatcher falls back.
     remote: { url: '' },
     // Per-engine voice level trim (dB), applied via Liquidsoap's liq_amplify on
     // every spoken segment that resolves to that engine. Levels the loudness gap
@@ -2248,8 +2250,19 @@ export async function update(patch) {
       if (r.url !== undefined) {
         const v = String(r.url).trim();
         if (v.length > 200) throw new Error('tts.remote.url must be 0-200 chars');
-        if (v && !/^https?:\/\//i.test(v)) {
-          throw new Error('tts.remote.url must start with http:// or https://');
+        if (v) {
+          // Full parse (not just a prefix test) so a malformed host/port —
+          // e.g. http://host:notaport or http://host:99999 — is rejected at
+          // save time instead of silently failing the /health probe later.
+          let parsed: URL;
+          try {
+            parsed = new URL(v);
+          } catch {
+            throw new Error('tts.remote.url must be a valid http:// or https:// URL');
+          }
+          if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+            throw new Error('tts.remote.url must start with http:// or https://');
+          }
         }
         next.tts.remote.url = v.replace(/\/+$/, ''); // strip trailing slashes
       }

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -123,13 +123,15 @@ export function effectiveFrequency(persona: any = getEffectivePersona()) {
 //
 // `cloud` routes through the AI SDK (OpenAI / ElevenLabs speech models) —
 // see llm/speech.js. `piper`, `kokoro`, `chatterbox`, and `pocket-tts` are
-// local engines. Chatterbox and PocketTTS are opt-in — the default controller
-// image doesn't bundle either; build the image with `--build-arg WITH_CHATTERBOX=1`
-// or `--build-arg WITH_POCKETTTS=1` (see docker/Dockerfile.controller) to
-// include the runtime. The dispatcher gates each engine on isAvailable() so
-// settings can reference it safely even when the runtime is absent (the
-// engine just falls back to Piper).
-export const TTS_ENGINES = ['piper', 'kokoro', 'chatterbox', 'pocket-tts', 'cloud'];
+// local engines. `remote` is a first-class self-hosted HTTP engine that
+// speaks the same /speak + /health contract as tts-heavy; configure the URL
+// in settings.tts.remote.url. Chatterbox and PocketTTS are opt-in — the
+// default controller image doesn't bundle either; build the image with
+// `--build-arg WITH_CHATTERBOX=1` or `--build-arg WITH_POCKETTTS=1` (see
+// docker/Dockerfile.controller) to include the runtime. The dispatcher gates
+// each engine on isAvailable() so settings can reference it safely even when
+// the runtime is absent (the engine just falls back to Piper).
+export const TTS_ENGINES = ['piper', 'kokoro', 'chatterbox', 'pocket-tts', 'cloud', 'remote'];
 
 // DJ-voice level trim, in dB. A per-engine gain levels the loudness gap between
 // TTS engines (only PocketTTS self-normalises today, so it sits quieter than
@@ -703,17 +705,22 @@ const DEFAULTS = {
       // provider === 'openai-compatible'.
       baseUrl: '',
     },
+    // Remote engine — a user-configured self-hosted TTS endpoint that speaks
+    // the Subwave-native /speak + /health contract (the same protocol the
+    // tts-heavy sidecar uses). The TTS equivalent of the LLM's custom base
+    // URL. Empty → engine reports unavailable; the dispatcher falls back.
+    remote: { url: '' },
     // Per-engine voice level trim (dB), applied via Liquidsoap's liq_amplify on
     // every spoken segment that resolves to that engine. Levels the loudness gap
     // between engines (e.g. boost PocketTTS to match raw Piper). Stacks with each
     // persona's own tts.gainDb. All 0 = unity = today's behaviour. See
     // TTS_GAIN_CLAMP_DB and audio/tts.ts:voiceGainDb().
-    gainDb: { piper: 0, kokoro: 0, chatterbox: 0, 'pocket-tts': 0, cloud: 0 },
+    gainDb: { piper: 0, kokoro: 0, chatterbox: 0, 'pocket-tts': 0, cloud: 0, remote: 0 },
     // Per-engine speech-rate multiplier (0.5–2.0×, 1.0 = no change), composed
     // on top of the daypart energy and each persona's own tts.speed in
     // audio/tts.ts:speak(). Only Piper/Kokoro/cloud honour it; chatterbox/
-    // pocket-tts ignore speed so their entries are inert. See clampTtsSpeed().
-    speed: { piper: 1, kokoro: 1, chatterbox: 1, 'pocket-tts': 1, cloud: 1 },
+    // pocket-tts/remote ignore speed so their entries are inert. See clampTtsSpeed().
+    speed: { piper: 1, kokoro: 1, chatterbox: 1, 'pocket-tts': 1, cloud: 1, remote: 1 },
   },
   llm: {
     provider: 'ollama',
@@ -1023,9 +1030,11 @@ function normalizeTts(raw: any) {
     voice = '';
   // openai-compatible voices are server-specific (often arbitrary cloning ref
   // names) — no canonical default; leave empty so generateSpeech omits the
-  // field and the server picks its own.
+  // field and the server picks its own. Remote engine voices likewise:
+  // server-specific (id, reference-wav filename, or VoiceDesign prompt), no
+  // Subwave-side default.
   if (!voice && engine === 'cloud' && cloudProvider !== 'openai-compatible') voice = 'alloy';
-  if (!voice && engine !== 'cloud' && engine !== 'chatterbox' && engine !== 'piper') voice = 'bf_isabella';
+  if (!voice && engine !== 'cloud' && engine !== 'chatterbox' && engine !== 'piper' && engine !== 'remote') voice = 'bf_isabella';
   return { engine, cloudProvider, voice, gainDb: clampTtsGain(raw?.gainDb), speed: clampTtsSpeed(raw?.speed) };
 }
 
@@ -1319,6 +1328,12 @@ export async function load() {
           typeof stored.tts?.cloud?.baseUrl === 'string'
             ? stored.tts.cloud.baseUrl.trim()
             : DEFAULTS.tts.cloud.baseUrl,
+      },
+      remote: {
+        url:
+          typeof stored.tts?.remote?.url === 'string'
+            ? stored.tts.remote.url.trim()
+            : DEFAULTS.tts.remote.url,
       },
       // Per-engine gain map — one clean gain per known engine, missing keys → 0,
       // unknown keys dropped. So an older save (no gainDb) loads at unity.
@@ -1660,6 +1675,11 @@ function validateTtsBlock(raw, where) {
     } else if (voice.length < 1 || voice.length > 100) {
       throw new Error(`${where}.tts.voice must be 1-100 chars`);
     }
+  } else if (t.engine === 'remote') {
+    // Remote engine voices are server-specific — the sidecar interprets them
+    // (built-in id, reference-wav filename, or VoiceDesign prompt). Empty is
+    // valid: the sidecar picks its own default.
+    if (voice.length > 100) throw new Error(`${where}.tts.voice must be 0-100 chars`);
   } else {
     // piper: empty = use the baked-in default voice. Otherwise the value must
     // be an .onnx filename (no path separators) referencing a model the operator
@@ -2221,6 +2241,17 @@ export async function update(patch) {
       // save the provider without one. Mirrors the LLM-side check below.
       if (next.tts.cloud.provider === 'openai-compatible' && !next.tts.cloud.baseUrl) {
         throw new Error('tts.cloud.baseUrl is required when provider is "openai-compatible"');
+      }
+    }
+    if (t.remote !== undefined) {
+      const r = t.remote || {};
+      if (r.url !== undefined) {
+        const v = String(r.url).trim();
+        if (v.length > 200) throw new Error('tts.remote.url must be 0-200 chars');
+        if (v && !/^https?:\/\//i.test(v)) {
+          throw new Error('tts.remote.url must start with http:// or https://');
+        }
+        next.tts.remote.url = v.replace(/\/+$/, ''); // strip trailing slashes
       }
     }
     if (t.gainDb !== undefined) {

--- a/web/app/manual/voices/page.tsx
+++ b/web/app/manual/voices/page.tsx
@@ -4,7 +4,7 @@ import { pageMeta } from '@/lib/seo';
 export const metadata = pageMeta({
   title: 'SUB/WAVE — Manual · Voices & TTS',
   description:
-    'Voices & TTS for SUB/WAVE — the five text-to-speech engines, the tts-heavy sidecar, voice cloning, and running Chatterbox on a GPU.',
+    'Voices & TTS for SUB/WAVE — the six text-to-speech engines, the tts-heavy sidecar, the self-hosted Remote engine, voice cloning, and running Chatterbox on a GPU.',
   path: '/manual/voices',
 });
 

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -2050,11 +2050,13 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                 className="max-w-[360px]"
               />
               <div className="field-hint">
-                Any self-hosted TTS server that speaks the Subwave-native{' '}
-                <code>/speak</code> + <code>/health</code> contract (Qwen3-TTS
-                clone, F5-TTS, CosyVoice, your own sidecar…). Must be reachable
-                from the controller container. Use the host&apos;s LAN or Tailscale
-                IP, not <code>127.0.0.1</code>.
+                Any self-hosted TTS server that renders audio over HTTP — POST{' '}
+                <code>/speak</code> returns the audio in the response body, gated
+                on a <code>/health</code> probe (Qwen3-TTS clone, F5-TTS,
+                CosyVoice, your own server…). The audio comes back over the wire,
+                so no shared volume is needed. Must be reachable from the
+                controller container — use the host&apos;s LAN or Tailscale IP,
+                not <code>127.0.0.1</code>.
               </div>
             </div>
             <TtsGainField engineId="remote" form={form} setForm={setForm} />

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -126,11 +126,12 @@ interface TtsForm {
   chatterbox: { referenceVoice: string };
   pocketTts: { voice: string };
   cloud: CloudTtsCfg;
+  remote: { url: string };
   // Per-engine voice-level trim in dB, keyed by engine id (note the hyphen in
-  // `pocket-tts`). Always carries all 5 known engines, 0 = unity = no change.
+  // `pocket-tts`). Always carries all 6 known engines, 0 = unity = no change.
   gainDb: Record<string, number>;
-  // Per-engine speech-rate multiplier, keyed by engine id. Always carries all 5
-  // known engines, 1.0 = unity = no change. Inert for chatterbox/pocket-tts.
+  // Per-engine speech-rate multiplier, keyed by engine id. Always carries all 6
+  // known engines, 1.0 = unity = no change. Inert for chatterbox/pocket-tts/remote.
   speed: Record<string, number>;
 }
 
@@ -279,6 +280,7 @@ interface SettingsData {
       chatterbox?: { referenceVoice?: string };
       pocketTts?: { voice?: string };
       cloud?: Partial<CloudTtsCfg>;
+      remote?: { url?: string };
       gainDb?: Record<string, number>;
       speed?: Record<string, number>;
     };
@@ -433,7 +435,8 @@ export default function SettingsPanel() {
           voice: v.tts?.cloud?.voice ?? '',
           baseUrl: v.tts?.cloud?.baseUrl ?? '',
         },
-        // Per-engine voice level (dB). Zero default for all 5 engine ids, then
+        remote: { url: v.tts?.remote?.url ?? '' },
+        // Per-engine voice level (dB). Zero default for all 6 engine ids, then
         // overlay any saved values. Keyed by engine id — `pocket-tts` (hyphen).
         gainDb: {
           piper: 0,
@@ -441,9 +444,10 @@ export default function SettingsPanel() {
           chatterbox: 0,
           'pocket-tts': 0,
           cloud: 0,
+          remote: 0,
           ...(v.tts?.gainDb || {}),
         },
-        // Per-engine speech speed (×). Unity default for all 5, then overlay
+        // Per-engine speech speed (×). Unity default for all 6, then overlay
         // any saved values. Keyed by engine id — `pocket-tts` (hyphen).
         speed: {
           piper: 1,
@@ -451,6 +455,7 @@ export default function SettingsPanel() {
           chatterbox: 1,
           'pocket-tts': 1,
           cloud: 1,
+          remote: 1,
           ...(v.tts?.speed || {}),
         },
       },
@@ -1260,7 +1265,7 @@ const CB_DEFAULT_VOICE = '__cb_default__';
 
 // Voice-level (dB) trim. Engine ids match the server contract exactly — note the
 // hyphen in `pocket-tts`. Range mirrors the server clamp (TTS_GAIN_CLAMP_DB=12).
-const TTS_GAIN_ENGINES = ['piper', 'kokoro', 'chatterbox', 'pocket-tts', 'cloud'] as const;
+const TTS_GAIN_ENGINES = ['piper', 'kokoro', 'chatterbox', 'pocket-tts', 'cloud', 'remote'] as const;
 const TTS_GAIN_MIN = -12;
 const TTS_GAIN_MAX = 12;
 const TTS_GAIN_STEP = 0.5;
@@ -1316,11 +1321,11 @@ function TtsGainField({
 }
 
 // Speech-rate trim. Range mirrors the server clamp (clampTtsSpeed: 0.5–2.0×).
-// Only Piper/Kokoro/cloud honour speed — chatterbox/pocket-tts ignore it.
+// Only Piper/Kokoro/cloud honour speed — chatterbox/pocket-tts/remote ignore it.
 const TTS_SPEED_MIN = 0.5;
 const TTS_SPEED_MAX = 2;
 const TTS_SPEED_STEP = 0.05;
-const TTS_SPEED_UNSUPPORTED = new Set(['chatterbox', 'pocket-tts']);
+const TTS_SPEED_UNSUPPORTED = new Set(['chatterbox', 'pocket-tts', 'remote']);
 
 function formatSpeed(v: number): string {
   return `${v.toFixed(2)}×`;
@@ -1505,7 +1510,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
   };
   const engines = data.tts?.engines || ['piper'];
   const available = data.tts?.available || {};
-  const ENGINE_LABELS: Record<string, string> = { piper: 'Piper', kokoro: 'Kokoro', chatterbox: 'Chatterbox', 'pocket-tts': 'PocketTTS', cloud: 'Cloud' };
+  const ENGINE_LABELS: Record<string, string> = { piper: 'Piper', kokoro: 'Kokoro', chatterbox: 'Chatterbox', 'pocket-tts': 'PocketTTS', cloud: 'Cloud', remote: 'Remote' };
 
   const save = async () => {
     await saveSettings({
@@ -1521,6 +1526,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
           voice: form.tts.cloud.voice,
           baseUrl: form.tts.cloud.baseUrl,
         },
+        remote: { url: form.tts.remote.url },
         // Per-engine voice-level trim. Always sent (server clamps + drops unknown
         // keys); keyed by engine id, `pocket-tts` with the hyphen.
         gainDb: form.tts.gainDb,
@@ -1564,6 +1570,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
     chatterbox?: { referenceVoice?: string };
     pocketTts?: { voice?: string };
     cloud?: SavedCloud;
+    remote?: { url?: string };
     gainDb?: Record<string, number>;
     speed?: Record<string, number>;
   } = data.values?.tts || {};
@@ -1572,6 +1579,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
   const savedChatterboxVoice: string = savedTts.chatterbox?.referenceVoice || '';
   const savedPocketTtsVoice: string = savedTts.pocketTts?.voice || '';
   const savedCloud: SavedCloud = savedTts.cloud || {};
+  const savedRemoteUrl: string = savedTts.remote?.url || '';
   const savedEngineLabel = ENGINE_LABELS[savedEngine] || savedEngine;
   const formEngineLabel = ENGINE_LABELS[form.tts.defaultEngine] || form.tts.defaultEngine;
 
@@ -1596,6 +1604,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
     || (form.tts.cloud.model || '').trim() !== (savedCloud.model || '').trim()
     || (form.tts.cloud.voice || '').trim() !== (savedCloud.voice || '').trim()
     || (form.tts.cloud.baseUrl || '').trim() !== (savedCloud.baseUrl || '').trim()
+    || (form.tts.remote.url || '').trim() !== savedRemoteUrl
     || gainDirty
     || speedDirty;
 
@@ -1616,6 +1625,10 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
     activeDetail = <>
       {savedCloud.provider || '—'} · model <code>{savedCloud.model || '—'}</code>
       {savedCloud.voice ? <> · voice <code>{savedCloud.voice}</code></> : null}.
+    </>;
+  } else if (savedEngine === 'remote') {
+    activeDetail = <>
+      Endpoint <code>{savedRemoteUrl || 'not configured'}</code>. Falls back to Piper if the URL isn’t set or the sidecar is down.
     </>;
   }
   const savedEngineMissing = available[savedEngine] === false;
@@ -2015,6 +2028,41 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
           );
         })()}
 
+        {form.tts.defaultEngine === 'remote' && (() => {
+          const remoteAvail = available.remote;
+          return (
+          <div className="mt-4">
+            {remoteAvail === false && (
+              <div className="mb-3.5 border border-[var(--danger)] px-3 py-2.5 text-[11px] leading-[1.6] text-[var(--danger)]">
+                The remote endpoint isn&apos;t currently reachable. Check the URL
+                below and make sure the sidecar is running. The engine falls
+                back to <strong>Piper</strong> until it&apos;s up.
+              </div>
+            )}
+            <div className="field">
+              <Label>Server URL</Label>
+              <Input
+                value={form.tts.remote.url}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setForm(f => ({ ...f, tts: { ...f.tts, remote: { ...f.tts.remote, url: e.target.value } } }))
+                }
+                placeholder="http://192.168.1.101:5001"
+                className="max-w-[360px]"
+              />
+              <div className="field-hint">
+                Any self-hosted TTS server that speaks the Subwave-native{' '}
+                <code>/speak</code> + <code>/health</code> contract (Qwen3-TTS
+                clone, F5-TTS, CosyVoice, your own sidecar…). Must be reachable
+                from the controller container. Use the host&apos;s LAN or Tailscale
+                IP, not <code>127.0.0.1</code>.
+              </div>
+            </div>
+            <TtsGainField engineId="remote" form={form} setForm={setForm} />
+            <TtsSpeedField engineId="remote" form={form} setForm={setForm} />
+          </div>
+          );
+        })()}
+
           {/* Audition the selected engine + its configured voice + speed. */}
           {(() => {
             const e = form.tts.defaultEngine;
@@ -2023,6 +2071,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
               : e === 'chatterbox' ? (form.tts.chatterbox?.referenceVoice || '')
               : e === 'pocket-tts' ? (form.tts.pocketTts?.voice || '')
               : e === 'cloud' ? (form.tts.cloud.voice || '')
+              : e === 'remote' ? ''
               : '';
             return (
               <div className="field">

--- a/web/components/admin/personas/PersonaVoiceCard.tsx
+++ b/web/components/admin/personas/PersonaVoiceCard.tsx
@@ -45,7 +45,7 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
   const speed = persona.tts.speed ?? 1;
   // Only Piper/Kokoro/cloud honour speed; chatterbox/pocket-tts workers ignore
   // it, so the control is shown but disabled with a hint for those engines.
-  const speedSupported = persona.tts.engine !== 'chatterbox' && persona.tts.engine !== 'pocket-tts';
+  const speedSupported = persona.tts.engine !== 'chatterbox' && persona.tts.engine !== 'pocket-tts' && persona.tts.engine !== 'remote';
 
   // Engine change: the `voice` field is shared across engines but each engine
   // validates it differently — a leftover value from the old engine (e.g. a
@@ -67,6 +67,7 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
     } else if (v === 'pocket-tts') {
       if (!POCKET_TTS_VOICE_RE.test(cur)) patch.voice = 'alba';
     }
+    // Remote engine voices are free text — the sidecar decides. No default.
     updateTts(patch);
   };
 
@@ -257,6 +258,34 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
                   Italian, Spanish and Portuguese. Drop a ~5s WAV into{' '}
                   <code>state/voices/</code> to clone a voice; it’ll appear under
                   <em> Custom</em> on next reload (cloning needs <code>HF_TOKEN</code>; see above).
+                </div>
+              </div>
+            );
+          })()}
+
+          {persona.tts.engine === 'remote' && (() => {
+            const remoteAvail = data?.tts?.available?.remote;
+            return (
+              <div className="field max-w-[360px]">
+                {remoteAvail === false && (
+                  <div className="mb-2.5 border border-[var(--danger)] px-3 py-2.5 text-[11px] leading-[1.6] text-[var(--danger)]">
+                    The remote endpoint isn&apos;t reachable. Configure its URL in
+                    Settings &rarr; Voice. This persona falls back to{' '}
+                    <strong>{defaultEngine}</strong> until it&apos;s up.
+                  </div>
+                )}
+                <Label>Remote voice</Label>
+                <Input
+                  value={persona.tts.voice}
+                  maxLength={100}
+                  placeholder="Server-specific (id, filename, or VoiceDesign prompt)"
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => updateTts({ voice: e.target.value })}
+                />
+                <div className="field-hint">
+                  Free text forwarded to your self-hosted TTS endpoint. It can be
+                  a voice id, a reference-wav filename, or a VoiceDesign prompt —
+                  your sidecar decides. Configure the endpoint URL in Settings
+                  &rarr; Voice.
                 </div>
               </div>
             );

--- a/web/components/admin/personas/helpers.ts
+++ b/web/components/admin/personas/helpers.ts
@@ -97,6 +97,10 @@ export function personaValid(p: Persona): boolean {
     const v = p.tts.voice.trim();
     return v.length >= 1 && v.length <= 100;
   }
+  if (e === 'remote') {
+    const v = p.tts.voice.trim();
+    return v.length <= 100;
+  }
   return true; // piper — voice ignored
 }
 
@@ -110,6 +114,7 @@ export function voiceForSave(engine: string, voice: string): string {
   if (engine === 'chatterbox') return CHATTERBOX_VOICE_RE.test(voice) ? voice : '';
   // Built-in id or a .wav clone filename both pass through; anything else → default.
   if (engine === 'pocket-tts') return (POCKET_TTS_VOICE_RE.test(voice) || CHATTERBOX_VOICE_RE.test(voice)) ? voice : 'alba';
+  if (engine === 'remote') return voice; // free text, forwarded as-is
   return voice; // piper ignores voice; cloud carries its own
 }
 
@@ -137,5 +142,6 @@ export function engineLabel(p: Persona): string {
   if (p.tts.engine === 'chatterbox') return `chatterbox / ${p.tts.voice.trim() || 'built-in'}`;
   if (p.tts.engine === 'pocket-tts') return `pocket-tts / ${p.tts.voice.trim() || 'alba'}`;
   if (p.tts.engine === 'cloud') return `cloud / ${p.tts.cloudProvider} / ${p.tts.voice.trim() || '—'}`;
+  if (p.tts.engine === 'remote') return `remote / ${p.tts.voice.trim() || '—'}`;
   return `piper / ${p.tts.voice.trim() || 'built-in'}`;
 }

--- a/web/components/admin/personas/types.ts
+++ b/web/components/admin/personas/types.ts
@@ -2,7 +2,7 @@
 // PersonasPanel so the presentational sub-components can share one shape.
 
 export interface PersonaTts {
-  engine: 'piper' | 'kokoro' | 'chatterbox' | 'pocket-tts' | 'cloud' | string;
+  engine: 'piper' | 'kokoro' | 'chatterbox' | 'pocket-tts' | 'cloud' | 'remote' | string;
   cloudProvider: string;
   voice: string;
   // Per-persona voice-level trim in dB (−12..+12, default 0 = no change). Stacks

--- a/web/components/admin/tts/EngineSelector.tsx
+++ b/web/components/admin/tts/EngineSelector.tsx
@@ -1,5 +1,5 @@
 'use client';
-// Radio-card grid for picking a TTS engine. Replaces the cramped 5-button
+// Radio-card grid for picking a TTS engine. Replaces the cramped 6-button
 // segmented control on both the Personas voice card and the Settings voice tab:
 // every engine is a selectable card showing its name, a one-line blurb and a
 // live status badge (ready / sidecar off / no key) so availability is visible
@@ -11,7 +11,7 @@ import { ENGINE_META, engineStatus } from './engineMeta';
 interface EngineSelectorProps {
   // Currently selected engine id.
   value: string;
-  // Which engines to show as cards (Personas: all 5; Settings: data.tts.engines).
+  // Which engines to show as cards (Personas: all 6; Settings: data.tts.engines).
   engineIds: string[];
   // SettingsResponse.tts.available — drives the per-card status badge.
   available?: Record<string, boolean>;

--- a/web/components/admin/tts/engineMeta.ts
+++ b/web/components/admin/tts/engineMeta.ts
@@ -19,6 +19,7 @@ export const ENGINES: EngineMeta[] = [
   { id: 'chatterbox', label: 'Chatterbox', blurb: 'Clone a voice from a clip' },
   { id: 'pocket-tts', label: 'PocketTTS',  blurb: 'Multilingual · CPU-only' },
   { id: 'cloud',      label: 'Cloud',      blurb: 'OpenAI / ElevenLabs' },
+  { id: 'remote',     label: 'Remote',     blurb: 'Self-hosted HTTP endpoint' },
 ];
 
 export const ENGINE_META: Record<string, EngineMeta> = Object.fromEntries(
@@ -57,6 +58,10 @@ export function engineStatus(
       return a.cloud === false
         ? { label: 'no key', tone: 'warn' }
         : { label: 'key set', tone: 'ok' };
+    case 'remote':
+      return a.remote === false
+        ? { label: 'unreachable', tone: 'warn' }
+        : { label: 'ready', tone: 'ok' };
     default:
       return { label: '', tone: 'ok' };
   }

--- a/web/components/manual/HowTheDjWorks.tsx
+++ b/web/components/manual/HowTheDjWorks.tsx
@@ -42,9 +42,10 @@ export default function HowTheDjWorks() {
         <h2>Local voices, or the cloud.</h2>
         <p>
           The DJ's words are written by the language model, but turning them into speech
-          is a separate job. Five text-to-speech engines render the voice: Piper and
-          Kokoro run locally, Chatterbox and PocketTTS in an optional sidecar, and a Cloud
-          engine reaches OpenAI, ElevenLabs, or any self-hosted server. The operator can
+          is a separate job. Six text-to-speech engines render the voice: Piper and
+          Kokoro run locally, Chatterbox and PocketTTS in an optional sidecar, a Cloud
+          engine reaches OpenAI or ElevenLabs, and a Remote engine points at a TTS server
+          you run yourself. The operator can
           mix them <em>per kind</em> of segment, and if one ever fails the station drops
           to a local voice automatically, so the DJ never goes silent.
         </p>

--- a/web/components/manual/Voices.tsx
+++ b/web/components/manual/Voices.tsx
@@ -7,15 +7,15 @@ export default function Voices() {
     <ManualPage
       eyebrow="MANUAL · 12"
       title="Voices & TTS."
-      intro="The DJ's words are written by the language model, but turning them into speech is a separate job. Five text-to-speech engines render the voice: four run on your own hardware, one is hosted. You can mix them per segment, clone a voice, or hand the heavy one to a GPU."
+      intro="The DJ's words are written by the language model, but turning them into speech is a separate job. Six text-to-speech engines render the voice: four built in, one hosted, and one a TTS server you run yourself. You can mix them per segment, clone a voice, point at your own server, or hand the heavy one to a GPU."
       current="/manual/voices"
     >
       <section className="bs-section">
         <p className="bs-eyebrow">THE ENGINES</p>
         <h2>Local voices, or the cloud.</h2>
         <p>
-          You pick the engine under <strong>Admin &rarr; TTS voice</strong>. Four run on
-          your own hardware, one is hosted.
+          You pick the engine under <strong>Admin &rarr; TTS voice</strong>. Four are
+          built in, one is hosted, and one points at a server you run yourself.
         </p>
         <ul className="bs-list">
           <li>
@@ -45,10 +45,16 @@ export default function Voices() {
           </li>
           <li>
             <strong>Cloud</strong> is hosted text-to-speech through OpenAI or ElevenLabs,
-            using an API key. It's the most lifelike of the five, but it costs per use and
+            using an API key. It's the most lifelike of the six, but it costs per use and
             depends on the network being up. The Cloud engine also speaks{' '}
             <strong>OpenAI-compatible</strong>, so it can point at any self-hosted speech
             server, including a Chatterbox box on your own GPU (see below).
+          </li>
+          <li>
+            <strong>Remote</strong> is a TTS server you run yourself — a LAN box, a
+            Tailscale host, a spare GPU — that speaks a tiny Subwave-native HTTP
+            contract. It's the clean way to self-host an engine like Qwen3-TTS, F5-TTS
+            or CosyVoice without dressing it up as another provider (see below).
           </li>
         </ul>
         <p>
@@ -111,6 +117,66 @@ docker compose up -d`}</CodeBlock>
           <code className="bs-code-inline">docker/Dockerfile.controller</code> still work.
           They bundle the engines inside the controller image instead, but the sidecar is
           the recommended path for fresh installs.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">REMOTE</p>
+        <h2>Your own TTS server.</h2>
+        <p>
+          The <strong>Remote</strong> engine points SUB/WAVE at a TTS server you run
+          yourself, anywhere the controller can reach over the network — a LAN box, a
+          Tailscale host, a spare GPU machine. Unlike the OpenAI-compatible Cloud route
+          (which speaks OpenAI&apos;s{' '}
+          <code className="bs-code-inline">/v1/audio/speech</code>), Remote speaks a tiny
+          Subwave-native contract, so wrapping a model like Qwen3-TTS, F5-TTS or CosyVoice
+          in a server is only a few lines.
+        </p>
+        <p>
+          Configure it under <strong>Admin &rarr; TTS voice</strong>: pick{' '}
+          <strong>Remote</strong> and set <strong>Server URL</strong> to the endpoint
+          (e.g. <code className="bs-code-inline">http://192.168.1.101:5001</code>, a LAN or
+          Tailscale IP the controller container can reach, not{' '}
+          <code className="bs-code-inline">127.0.0.1</code>). The console shows{' '}
+          <strong>ready</strong> once the health check passes, and the station falls back
+          to Piper whenever the URL is blank or the server is down. A persona&apos;s{' '}
+          <strong>Remote voice</strong> is free text forwarded straight to your server — a
+          voice id, a reference-WAV filename, a VoiceDesign prompt, whatever it
+          understands.
+        </p>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">THE CONTRACT</div>
+          <p>
+            Your server needs two routes.{' '}
+            <code className="bs-code-inline">GET /health</code> returns{' '}
+            <code className="bs-code-inline">{`{ "ok": true }`}</code> when it&apos;s ready.{' '}
+            <code className="bs-code-inline">POST /speak</code> takes JSON{' '}
+            <code className="bs-code-inline">{`{ "text": "…", "voice": "…" }`}</code> and
+            returns the rendered audio (WAV) <em>in the response body</em>. The audio
+            travels over the wire, so no shared filesystem or volume is needed — that&apos;s
+            the difference from the bundled{' '}
+            <code className="bs-code-inline">tts-heavy</code> sidecar, which hands back a
+            path on a shared volume.
+          </p>
+        </div>
+        <p>That&apos;s the whole server — for example, in Flask:</p>
+        <CodeBlock>{`@app.get("/health")
+def health():
+    return {"ok": True}
+
+@app.post("/speak")
+def speak():
+    body  = request.get_json()
+    text  = body["text"]
+    voice = body.get("voice", "")
+    wav   = my_model.render(text, voice)        # -> WAV bytes
+    return Response(wav, mimetype="audio/wav")`}</CodeBlock>
+        <p className="text-muted">
+          Optional: if your server substitutes a different voice than the one requested,
+          set the <code className="bs-code-inline">X-TTS-Fell-Back</code> response header
+          (plus <code className="bs-code-inline">X-TTS-Voice-Used</code> and{' '}
+          <code className="bs-code-inline">X-TTS-Fell-Back-Reason</code>) and SUB/WAVE logs
+          the substitution instead of leaving you to guess why the voice changed.
         </p>
       </section>
 

--- a/web/components/onboarding/steps.tsx
+++ b/web/components/onboarding/steps.tsx
@@ -328,6 +328,7 @@ export function TtsStep({ w }: { w: WizardController }) {
             <option value="cloud">Cloud (OpenAI / ElevenLabs)</option>
             <option value="chatterbox">Chatterbox (voice cloning, sidecar)</option>
             <option value="pocket-tts">PocketTTS (multilingual, sidecar)</option>
+            <option value="remote">Remote (your own server)</option>
           </Select>
         </Field>
         <label className="flex items-center gap-2 text-sm">

--- a/web/components/onboarding/useWizard.ts
+++ b/web/components/onboarding/useWizard.ts
@@ -22,7 +22,7 @@ export interface WizardData {
   llmTest: { ok: boolean | null; msg?: string };
 
   tts: {
-    defaultEngine: 'piper' | 'kokoro' | 'cloud' | 'chatterbox' | 'pocket-tts';
+    defaultEngine: 'piper' | 'kokoro' | 'cloud' | 'chatterbox' | 'pocket-tts' | 'remote';
     // Advisory toggle — does the operator intend to run the optional
     // tts-heavy sidecar (Chatterbox + PocketTTS)? Persisted via
     // /onboarding/save into settings.tts.heavyEnabled. The web wizard can't

--- a/web/content/news/2026-06-29-your-own-tts-server.md
+++ b/web/content/news/2026-06-29-your-own-tts-server.md
@@ -1,0 +1,35 @@
+---
+title: Point your DJ at your own TTS server
+date: 2026-06-29
+category: Feature
+version: v0.30.0
+author: The SUB/WAVE desk
+excerpt: A new Remote engine lets SUB/WAVE speak through any TTS server you run yourself. It hands back audio over HTTP, so the box can live anywhere on your network.
+---
+
+There's a new voice engine called Remote. It points SUB/WAVE at a text-to-speech server you run yourself, anywhere the controller can reach over the network. The audio comes back over the wire, so the server can live on another machine entirely (a spare GPU, a LAN box, a Tailscale host) with no shared folder between them.
+
+## What's new
+
+Until now, self-hosting a TTS engine meant either baking it into the controller image or dressing it up as the tts-heavy sidecar. Remote is the clean way. It speaks a tiny HTTP contract, and you bring whatever model you like: Qwen3-TTS, F5-TTS, CosyVoice, your own.
+
+## How to use it
+
+Open admin, go to TTS voice, and pick Remote. Set the server URL to your endpoint:
+
+```
+http://192.168.1.101:5001
+```
+
+Use a LAN or Tailscale address the controller container can reach, not `127.0.0.1`. Your server needs two routes:
+
+```
+GET  /health  ->  {"ok": true}
+POST /speak   ->  {"text": "...", "voice": "..."}  returns WAV audio
+```
+
+A persona's Remote voice is free text, forwarded straight to your server: a voice id, a reference filename, whatever it understands. If the URL is blank or the server is down, the station falls back to Piper, so the DJ never goes quiet.
+
+## Why it helps
+
+You can run a big, natural-sounding model on hardware that suits it and keep the controller lean. No image rebuild, no pretending to be another provider. Point it at the box, save, and your DJ speaks through your own server.


### PR DESCRIPTION
## What

Add a `remote` TTS engine — a first-class self-hosted HTTP endpoint speaking the Subwave-native `/speak` + `/health` contract, mirroring the LLM's custom base URL.

## Why

Today running a self-hosted TTS sidecar (Qwen3-TTS, F5-TTS, CosyVoice, etc.) requires impersonating `pocket-tts` — advertising a fake engine name so the dispatcher routes to `TTS_HEAVY_URL`. That works but it's a hack: single
endpoint, confusing routing, no UI for the URL.

A `remote` engine with a configurable URL makes this a clean, supported deployment — exactly the spirit of tts-heavy (keep heavy engines out of the controller image).

Closes #584.

## How tested

- `controller/` — `tsc --noEmit` clean, all test suites pass (`npm test`)
- `web/` — `tsc --noEmit` clean
- Manually verified engine appears in settings dropdowns, persona engine , onboarding wizard, and status badges
- Reviewed against existing engine patterns (chatterbox, pocket-tts, cloud)  consistency in `resolveEngine`, `speakWith`, `availableEngines`, validateTtsBlock`, and `update()`

AI disclosure: YES