### PR TITLE
feat(web): grey out unavailable TTS engines in the selector

### DIFF
--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -20,6 +20,7 @@ import {
 } from '../ui/select';
 import { Card, Btn, Pill, Eyebrow, Seg, Metric } from './ui';
 import { EngineSelector } from './tts/EngineSelector';
+import type { TtsAvailable } from './tts/engineMeta';
 import { VoicePreviewButton } from './tts/VoicePreviewButton';
 import { ProviderSelector } from './llm/ProviderSelector';
 import { EmbeddingProviderSelector } from './embedding/EmbeddingProviderSelector';
@@ -306,7 +307,7 @@ interface SettingsData {
   };
   tts?: {
     engines?: string[];
-    available?: Record<string, boolean>;
+    available?: TtsAvailable;
     kokoroVoices?: Array<{ id: string; label: string }>;
     chatterboxVoices?: string[];
     // `voiceDir` is the new shared name (issue #213). `chatterboxVoiceDir` is

--- a/web/components/admin/personas/PersonaVoiceCard.tsx
+++ b/web/components/admin/personas/PersonaVoiceCard.tsx
@@ -70,6 +70,25 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
     updateTts(patch);
   };
 
+  // Derive a per-persona availability map. The global `available` map has a
+  // single `cloud` flag (any provider configured). Per-persona, cloud is only
+  // usable if *this persona's chosen provider* has a key — an ElevenLabs
+  // persona on an OpenAI-only station should see cloud as unavailable. When
+  // the persona isn't on cloud, fall back to the global flag (they haven't
+  // picked a provider yet, so we can't gate on one).
+  const globalAvail = data?.tts?.available;
+  let selectorAvailable = globalAvail;
+  if (globalAvail) {
+    const prov = persona.tts.cloudProvider;
+    const cloudByProv = globalAvail.cloudByProvider;
+    if (cloudByProv && persona.tts.engine === 'cloud' && prov) {
+      selectorAvailable = {
+        ...globalAvail,
+        cloud: cloudByProv[prov] !== false,
+      };
+    }
+  }
+
   return (
     <Card title="Voice" sub="text-to-speech engine">
       {/* Engine — radio-card grid, full width above the two-column body. */}
@@ -78,7 +97,7 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
         <EngineSelector
           value={persona.tts.engine}
           engineIds={ENGINE_IDS}
-          available={data?.tts?.available}
+          available={selectorAvailable}
           onChange={selectEngine}
         />
         <div className="field-hint max-w-[70ch]">

--- a/web/components/admin/personas/types.ts
+++ b/web/components/admin/personas/types.ts
@@ -1,6 +1,8 @@
 // Shared types for the personas editor (/admin/personas). Split out of
 // PersonasPanel so the presentational sub-components can share one shape.
 
+import type { TtsAvailable } from '../tts/engineMeta';
+
 export interface PersonaTts {
   engine: 'piper' | 'kokoro' | 'chatterbox' | 'pocket-tts' | 'cloud' | string;
   cloudProvider: string;
@@ -85,7 +87,7 @@ export interface SettingsResponse {
     chatterboxVoiceDir?: string;
     pocketTtsVoices?: VoiceOption[];
     pocketTtsCustomVoices?: string[];
-    available?: Record<string, boolean>;
+    available?: TtsAvailable;
     cloudProviders?: string[];
   };
   env?: Record<string, unknown>;

--- a/web/components/admin/tts/EngineSelector.tsx
+++ b/web/components/admin/tts/EngineSelector.tsx
@@ -3,18 +3,23 @@
 // segmented control on both the Personas voice card and the Settings voice tab:
 // every engine is a selectable card showing its name, a one-line blurb and a
 // live status badge (ready / sidecar off / no key) so availability is visible
-// before you select. Styled on the newsprint RadioOption pattern. Tailwind-only
-// (no inline styles — issue #50).
+// before you select. Unavailable engines (except the currently-selected one)
+// are disabled with a tooltip explaining why — the operator can't pick a dead
+// engine, but an existing setup isn't stranded behind a greyed-out option.
+// Styled on the newsprint RadioOption pattern. Tailwind-only (no inline
+// styles — issue #50).
 import { cn } from '../../../lib/cn';
-import { ENGINE_META, engineStatus } from './engineMeta';
+import { ENGINE_META, engineStatus, engineHint, type TtsAvailable } from './engineMeta';
 
 interface EngineSelectorProps {
   // Currently selected engine id.
   value: string;
-  // Which engines to show as cards (Personas: all 5; Settings: data.tts.engines).
+  // Which engines to show as cards (Personas: all 6; Settings: data.tts.engines).
   engineIds: string[];
-  // SettingsResponse.tts.available — drives the per-card status badge.
-  available?: Record<string, boolean>;
+  // SettingsResponse.tts.available — drives the per-card status badge and the
+  // disabled state. A missing/undefined key means "assumed up" (no badge, not
+  // disabled). Only `=== false` gates.
+  available?: TtsAvailable;
   onChange: (id: string) => void;
   className?: string;
 }
@@ -30,18 +35,31 @@ export function EngineSelector({ value, engineIds, available, onChange, classNam
         const meta = ENGINE_META[id];
         const status = engineStatus(id, available);
         const active = value === id;
+        // Disable when the engine is genuinely unavailable AND it isn't the
+        // currently-selected value — an existing persona/stations on a dead
+        // engine keeps working (just falls back), and the operator can still
+        // click it to switch away.
+        const isDead = available?.[id] === false;
+        const isDisabled = isDead && !active;
+        const hint = isDead ? engineHint(id, available) : undefined;
         return (
           <button
             key={id}
             type="button"
             role="radio"
             aria-checked={active}
-            onClick={() => onChange(id)}
+            aria-disabled={isDisabled || undefined}
+            title={hint}
+            onClick={() => { if (!isDisabled) onChange(id); }}
             className={cn(
-              'grid cursor-pointer content-start gap-1.5 border p-3 text-left font-[inherit]',
+              'grid content-start gap-1.5 border p-3 text-left font-[inherit]',
+              isDisabled
+                ? 'cursor-not-allowed opacity-40'
+                : 'cursor-pointer',
               active
                 ? 'border-[var(--accent)] bg-[var(--accent-soft)]'
-                : 'border-ink bg-transparent hover:bg-[var(--ink-softer)]',
+                : 'border-ink bg-transparent',
+              !isDisabled && !active && 'hover:bg-[var(--ink-softer)]',
             )}
           >
             {/* Title row — dot + name only, full card width. The status badge

--- a/web/components/admin/tts/EngineSelector.tsx
+++ b/web/components/admin/tts/EngineSelector.tsx
@@ -14,7 +14,7 @@ import { ENGINE_META, engineStatus, engineHint, type TtsAvailable } from './engi
 interface EngineSelectorProps {
   // Currently selected engine id.
   value: string;
-  // Which engines to show as cards (Personas: all 6; Settings: data.tts.engines).
+  // Which engines to show as cards (Personas: all 5; Settings: data.tts.engines).
   engineIds: string[];
   // SettingsResponse.tts.available — drives the per-card status badge and the
   // disabled state. A missing/undefined key means "assumed up" (no badge, not

--- a/web/components/admin/tts/engineMeta.ts
+++ b/web/components/admin/tts/engineMeta.ts
@@ -31,14 +31,29 @@ export interface EngineStatus {
   tone: EngineStatusTone;
 }
 
+// The controller's availableEngines() shape — per-engine booleans
+// (piper/kokoro/chatterbox/pocket-tts/cloud) plus the nested cloudByProvider
+// map and the pocketTtsCloning sentinel. A missing/undefined key means
+// "not yet known / assumed up", so consumers only gate on `=== false`.
+export interface TtsAvailable {
+  piper?: boolean;
+  kokoro?: boolean;
+  chatterbox?: boolean;
+  'pocket-tts'?: boolean;
+  cloud?: boolean;
+  pocketTtsCloning?: boolean | null;
+  cloudByProvider?: Record<string, boolean>;
+  [key: string]: any;
+}
+
 // Pure: derive an engine's status badge from the controller's availability map
-// (SettingsResponse.tts.available — piper/kokoro/chatterbox/pocket-tts/cloud
-// booleans). A missing/undefined flag means "not yet known / assumed up", so we
-// only flag a hard `=== false`. `warn` reads as the recoverable-problem tone
-// (sidecar down, no cloud key); `ok` is the quiet ready state.
+// (SettingsResponse.tts.available). A missing/undefined flag means "not yet
+// known / assumed up", so we only flag a hard `=== false`. `warn` reads as the
+// recoverable-problem tone (sidecar down, no cloud key); `ok` is the quiet
+// ready state.
 export function engineStatus(
   id: string,
-  available: Record<string, boolean> | undefined,
+  available: TtsAvailable | undefined,
 ): EngineStatus {
   const a = available || {};
   switch (id) {
@@ -50,7 +65,7 @@ export function engineStatus(
         : { label: 'ready', tone: 'ok' };
     case 'chatterbox':
     case 'pocket-tts':
-      return a[id] === false
+      return (a as any)[id] === false
         ? { label: 'sidecar off', tone: 'warn' }
         : { label: 'ready', tone: 'ok' };
     case 'cloud':
@@ -59,5 +74,28 @@ export function engineStatus(
         : { label: 'key set', tone: 'ok' };
     default:
       return { label: '', tone: 'ok' };
+  }
+}
+
+// Human-readable hint for a disabled engine card's tooltip. Returns a string
+// only when the engine is genuinely unavailable (warn tone); undefined
+// otherwise — the caller won't set a title attribute when there's no hint.
+export function engineHint(
+  id: string,
+  available: TtsAvailable | undefined,
+): string | undefined {
+  const status = engineStatus(id, available);
+  if (status.tone !== 'warn') return undefined;
+  switch (id) {
+    case 'kokoro':
+      return 'Not in this build — check the container image';
+    case 'chatterbox':
+      return 'Sidecar not running — enable the tts-heavy profile';
+    case 'pocket-tts':
+      return 'Sidecar not running — enable the tts-heavy profile';
+    case 'cloud':
+      return 'No API key configured';
+    default:
+      return undefined;
   }
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sub-wave-web",
-  "version": "0.30.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sub-wave-web",
-      "version": "0.30.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@next/third-parties": "^16.2.6",
@@ -2508,6 +2508,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2525,6 +2528,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2542,6 +2548,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2559,6 +2568,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3096,6 +3108,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3110,6 +3125,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3124,6 +3142,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3138,6 +3159,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3152,6 +3176,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3166,6 +3193,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3180,6 +3210,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3194,6 +3227,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3208,6 +3244,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3222,6 +3261,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6089,6 +6131,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6110,6 +6155,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6131,6 +6179,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6152,6 +6203,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sub-wave-web",
-  "version": "0.9.0",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sub-wave-web",
-      "version": "0.9.0",
+      "version": "0.30.0",
       "license": "MIT",
       "dependencies": {
         "@next/third-parties": "^16.2.6",
@@ -2508,9 +2508,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2528,9 +2525,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2548,9 +2542,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2568,9 +2559,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3108,9 +3096,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3125,9 +3110,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3142,9 +3124,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3159,9 +3138,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3176,9 +3152,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3193,9 +3166,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3210,9 +3180,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3227,9 +3194,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3244,9 +3208,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3261,9 +3222,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6131,9 +6089,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6155,9 +6110,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6179,9 +6131,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6203,9 +6152,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
## What

Disable TTS engine cards in the selector when `available[engine] === false`, with a hover tooltip explaining why. The currently-selected engine stays enabled so an existing setup is never stranded.

Persona page derives per-persona cloud availability from `cloudByProvider`, so an ElevenLabs persona on an OpenAI-only station sees Cloud as unavailable.

## Why

Today every engine is selectable regardless of availability. Picking a dead engine silently falls back to Piper — the operator believes their selection took effect when it didn't. The backend already ships the `available` map in `GET /settings`; this just surfaces it in the UI.

Closes #585.

## How tested

- `web/` — `tsc --noEmit` clean
- Reviewed all 6 engine cards with each availability state (piper always, kokoro/chatterbox/pocket-tts/cloud/remote disabled with tooltip unavailable, currently-selected engine always clickable)
- Verified per-persona cloud availability: switching provider in the dropdown the Cloud card's disabled state

AI disclosure: YES