### PR TITLE
feat(web): visual show editor — genre, persona & theme pickers

### DIFF
--- a/controller/src/music/genre-suggest.ts
+++ b/controller/src/music/genre-suggest.ts
@@ -1,0 +1,100 @@
+// Genre suggestions for the show editor's "genre lean" field.
+//
+// The embedding data's real value at a single-value field is *adjacency*: given
+// a genre, what else sounds like it. We compute that as genre→genre cosine
+// similarity over each genre's mean text-embedding (the centroid; see
+// library-db.genreCentroids) and return the nearest neighbours per genre.
+// Backs GET /library/genres/related → the related-genre chips
+// (web/components/admin/GenreSuggest.tsx).
+//
+// Also returns the full genre list (by track count) so the picker can offer
+// popular quick-picks when the field is empty and substring matches while the
+// operator types — both useful even with no embeddings, where `related` is
+// simply empty and `hasEmbeddings` is false.
+
+import * as db from './library-db.js';
+import * as library from './library.js';
+
+export interface GenreItem {
+  value: string;
+  songCount: number;
+}
+
+export interface GenreSuggest {
+  genres: GenreItem[]; // every known genre, descending by track count
+  related: Record<string, GenreItem[]>; // genre → nearest genres by embedding
+  hasEmbeddings: boolean;
+  computedAt: string;
+}
+
+// Nearest neighbours kept per genre. Eight is enough to surface the obvious
+// cousins without turning into a wall of chips.
+const NEIGHBOURS = 8;
+// Cosine below this isn't a meaningful neighbour — drop it rather than pad the
+// list with unrelated genres.
+const MIN_SIM = 0.2;
+const MIN_FOR_EMBEDDINGS = 3;
+
+let cache: { key: string; payload: GenreSuggest } | null = null;
+
+export function buildGenreSuggest(): GenreSuggest {
+  const stats = library.stats();
+  const byGenre = stats.byGenre || {};
+  const key = `${stats.updatedAt ?? ''}:${db.vectorCount()}`;
+  if (cache && cache.key === key) return cache.payload;
+
+  const centroids = db.genreCentroids();
+  const centroidCount = new Map(centroids.map((c) => [c.genre, c.count]));
+  const countOf = (g: string) => byGenre[g] ?? centroidCount.get(g) ?? 0;
+
+  // Full genre list — union of the tagged-index genres and any genre that has a
+  // centroid — sorted by how much music sits under it.
+  const names = new Set<string>([...Object.keys(byGenre), ...centroids.map((c) => c.genre)]);
+  const genres: GenreItem[] = [...names]
+    .map((value) => ({ value, songCount: countOf(value) }))
+    .sort((a, b) => b.songCount - a.songCount);
+
+  const related: Record<string, GenreItem[]> = {};
+  const hasEmbeddings = centroids.length >= MIN_FOR_EMBEDDINGS;
+
+  if (hasEmbeddings) {
+    // Unit-normalise each centroid so a dot product is the cosine similarity.
+    const units = centroids.map((c) => normalise(c.centroid));
+    for (let i = 0; i < centroids.length; i++) {
+      const sims: Array<{ value: string; sim: number }> = [];
+      for (let j = 0; j < centroids.length; j++) {
+        if (j === i) continue;
+        const sim = dot(units[i], units[j]);
+        if (sim >= MIN_SIM) sims.push({ value: centroids[j].genre, sim });
+      }
+      sims.sort((a, b) => b.sim - a.sim);
+      related[centroids[i].genre] = sims
+        .slice(0, NEIGHBOURS)
+        .map((s) => ({ value: s.value, songCount: countOf(s.value) }));
+    }
+  }
+
+  const payload: GenreSuggest = {
+    genres,
+    related,
+    hasEmbeddings,
+    computedAt: new Date().toISOString(),
+  };
+  cache = { key, payload };
+  return payload;
+}
+
+function normalise(v: Float32Array): Float32Array {
+  let s = 0;
+  for (let i = 0; i < v.length; i++) s += v[i] * v[i];
+  const n = Math.sqrt(s) || 1;
+  const out = new Float32Array(v.length);
+  for (let i = 0; i < v.length; i++) out[i] = v[i] / n;
+  return out;
+}
+
+function dot(a: Float32Array, b: Float32Array): number {
+  let s = 0;
+  for (let i = 0; i < a.length; i++) s += a[i] * b[i];
+  return s;
+}

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -1082,6 +1082,45 @@ export function trackIdsByGenreDecade(): Map<string, string[]> {
 }
 
 // ---------------------------------------------------------------------------
+// Per-genre embedding centroids — the mean text-embedding vector across every
+// tagged+embedded track in each genre. Powers the genre-cloud 2D projection
+// (music/genre-cloud.ts): semantically similar genres land near each other.
+// One streaming SQL join so a multi-thousand-track library stays light on
+// memory — vectors are accumulated into per-genre running sums, never all held
+// at once.
+// ---------------------------------------------------------------------------
+export function genreCentroids(): Array<{ genre: string; count: number; centroid: Float32Array }> {
+  const stmt = requireDb().prepare(
+    `SELECT t.genre AS genre, v.embedding AS embedding
+       FROM tracks t JOIN track_vectors v ON v.id = t.id
+      WHERE t.genre IS NOT NULL AND TRIM(t.genre) != ''`,
+  );
+  const sums = new Map<string, { sum: Float64Array; count: number }>();
+  let dim = 0;
+  for (const row of stmt.iterate() as Iterable<{ genre: string; embedding: Buffer }>) {
+    const b = row.embedding;
+    const vec = new Float32Array(b.buffer, b.byteOffset, Math.floor(b.byteLength / 4));
+    if (!dim) dim = vec.length;
+    if (vec.length !== dim) continue; // defensive: skip any stray off-dim rows
+    let acc = sums.get(row.genre);
+    if (!acc) {
+      acc = { sum: new Float64Array(dim), count: 0 };
+      sums.set(row.genre, acc);
+    }
+    for (let i = 0; i < dim; i++) acc.sum[i] += vec[i];
+    acc.count++;
+  }
+  const out: Array<{ genre: string; count: number; centroid: Float32Array }> = [];
+  for (const [genre, { sum, count }] of sums) {
+    if (!count) continue;
+    const centroid = new Float32Array(dim);
+    for (let i = 0; i < dim; i++) centroid[i] = sum[i] / count;
+    out.push({ genre, count, centroid });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
 // Filter (admin UI library browse panel)
 // ---------------------------------------------------------------------------
 

--- a/controller/src/routes/library.ts
+++ b/controller/src/routes/library.ts
@@ -11,6 +11,7 @@ import * as subsonic from '../music/subsonic.js';
 import * as lastfm from '../music/lastfm.js';
 import * as settings from '../settings.js';
 import * as embeddings from '../music/embeddings.js';
+import { buildGenreSuggest } from '../music/genre-suggest.js';
 import { tagBatch, TAGGER_BATCH_SYSTEM } from '../music/tagger-core.js';
 import { promptVocabHash } from '../music/embeddings.js';
 import { activeModelLabel } from '../llm/provider.js';
@@ -93,6 +94,22 @@ router.get('/library/genres', requireAdmin, async (req, res) => {
       .map(([value, songCount]) => ({ value, songCount }))
       .sort((a, b) => b.songCount - a.songCount);
     res.json({ genres: list });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /library/genres/related — genre suggestions for the show editor. Returns
+// the full genre list (by track count) plus, per genre, its nearest genres by
+// embedding similarity (cosine over each genre's mean text-embedding). Powers
+// the related-genre chips: popular quick-picks when empty, semantic neighbours
+// once a genre is chosen. Cached until the library changes.
+// ---------------------------------------------------------------------------
+router.get('/library/genres/related', requireAdmin, async (_req, res) => {
+  try {
+    await library.load();
+    res.json(buildGenreSuggest());
   } catch (err: any) {
     res.status(500).json({ error: err.message });
   }

--- a/web/components/admin/GenreSuggest.tsx
+++ b/web/components/admin/GenreSuggest.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+// GenreSuggest — related-genre chips beneath the show editor's "genre lean"
+// field. Three states, all driven off GET /library/genres/related:
+//   • field empty        → the most-stocked genres as quick-picks
+//   • field is a genre    → its nearest genres by embedding similarity
+//   • field partially typed → genres whose name contains the text
+// Click a chip to set the lean. A single-value helper — one genre in, one out —
+// that turns the embedding data into something actionable instead of decorative.
+
+import { useEffect, useRef, useState } from 'react';
+import { cn } from '../../lib/cn';
+
+interface GenreItem {
+  value: string;
+  songCount: number;
+}
+
+interface SuggestData {
+  genres: GenreItem[];
+  related: Record<string, GenreItem[]>;
+  hasEmbeddings: boolean;
+}
+
+interface Props {
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+  value: string;
+  onSelect: (genre: string) => void;
+}
+
+const POPULAR = 12;
+const MATCHES = 10;
+const norm = (s: string) => s.trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+
+export default function GenreSuggest({ adminFetch, value, onSelect }: Props) {
+  const [data, setData] = useState<SuggestData | null>(null);
+  const [error, setError] = useState(false);
+  // Resolve the typed value to a real genre on the client (the field is free
+  // text); used to look up its neighbour list.
+  const byNorm = useRef<Map<string, GenreItem>>(new Map());
+
+  // Fetch once on mount. No "already fetched" ref guard — under React
+  // StrictMode the first mount's fetch is cancelled by the cleanup, so the
+  // remount must be free to fetch again or `data` never populates.
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      try {
+        const r = await adminFetch('/library/genres/related');
+        if (!r.ok) throw new Error(String(r.status));
+        const j = (await r.json()) as SuggestData;
+        if (!live) return;
+        if (j && Array.isArray(j.genres)) {
+          byNorm.current = new Map(j.genres.map((g) => [norm(g.value), g]));
+          setData(j);
+        } else setData(null);
+      } catch {
+        if (live) setError(true);
+      }
+    })();
+    return () => { live = false; };
+  }, [adminFetch]);
+
+  if (error || !data || data.genres.length === 0) return null;
+
+  const typed = value.trim();
+  const nv = norm(typed);
+  const match = nv ? byNorm.current.get(nv) : undefined;
+
+  let label: string;
+  let chips: GenreItem[];
+  if (match && data.related[match.value]?.length) {
+    label = `similar to ${match.value}`;
+    chips = data.related[match.value] ?? [];
+  } else if (nv) {
+    // Typed text that isn't an exact genre → substring matches (minus the exact
+    // one, which is already in the field), falling back to popular.
+    const subs = data.genres.filter((g) => norm(g.value).includes(nv) && norm(g.value) !== nv);
+    if (subs.length) {
+      label = 'matches';
+      chips = subs.slice(0, MATCHES);
+    } else {
+      label = 'popular genres';
+      chips = data.genres.slice(0, POPULAR);
+    }
+  } else {
+    label = 'popular genres';
+    chips = data.genres.slice(0, POPULAR);
+  }
+
+  if (chips.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="field-hint m-0">
+        {label}
+        {match && !data.hasEmbeddings ? ' — tag your library with embeddings for related genres' : ''}
+      </span>
+      <div className="flex flex-wrap gap-1.5">
+        {chips.map((g) => (
+          <button
+            key={g.value}
+            type="button"
+            className={cn('lib-chip', norm(g.value) === nv && nv !== '' && 'on')}
+            onClick={() => onSelect(g.value)}
+            title={`${g.songCount} track${g.songCount === 1 ? '' : 's'}`}
+          >
+            {g.value}
+            {g.songCount > 0 && <span className="n">{g.songCount}</span>}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/components/admin/ShowPickers.tsx
+++ b/web/components/admin/ShowPickers.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+// Visual pickers for the show editor's "persona owner" and "theme override"
+// fields — richer replacements for the plain name dropdowns.
+//
+//  • PersonaPicker — a card grid showing each host's avatar (initials
+//    fallback), name and tagline, so you pick a face, not a string.
+//  • ThemePicker  — swatch cards showing each palette's actual colours, plus a
+//    "Station default" card that mirrors the live station palette.
+//
+// Both mirror existing admin patterns: the persona card from
+// personas/PersonaRoster, the swatch strip + SWATCH_KEYS from SettingsPanel's
+// theme gallery. Swatch colours route through useDynamicStyle because the lint
+// rule (#50) bans the inline `style` prop.
+
+import { useRef } from 'react';
+import { cn } from '../../lib/cn';
+import { useDynamicStyle } from '../../hooks/useDynamicStyle';
+
+export interface PersonaOpt {
+  id: string;
+  name?: string;
+  tagline?: string;
+  avatar?: string;
+  tts?: { engine?: string; voice?: string };
+}
+
+export interface ThemeOpt {
+  id: string;
+  name: string;
+  mode?: string;
+  description?: string;
+  tokens?: Record<string, string>;
+}
+
+// Read the palette at a glance: paper, ink, accent, overlay — same four the
+// admin theme gallery shows.
+const SWATCH_KEYS = ['--bg', '--ink', '--accent', '--overlay'] as const;
+// Fallback for the "Station default" card when the active theme's tokens aren't
+// known: paint the live CSS variables so it still shows the real palette.
+const LIVE_TOKENS: Record<string, string> = {
+  '--bg': 'var(--bg)',
+  '--ink': 'var(--ink)',
+  '--accent': 'var(--accent)',
+  '--overlay': 'var(--overlay)',
+};
+
+const cardClass = (selected: boolean) =>
+  cn(
+    'flex min-w-0 items-center border text-left font-[inherit] transition-colors',
+    selected
+      ? 'border-[var(--accent)] bg-[var(--accent-soft)]'
+      : 'border-ink bg-[var(--card-bg)] hover:bg-[var(--overlay)]',
+  );
+
+function initials(name?: string): string {
+  const parts = (name || '').trim().split(/\s+/).filter(Boolean);
+  const first = parts[0] ?? '';
+  if (!first) return '—';
+  if (parts.length === 1) return first.slice(0, 2).toUpperCase();
+  const last = parts[parts.length - 1] ?? '';
+  return (first.slice(0, 1) + last.slice(0, 1)).toUpperCase();
+}
+
+function Swatch({ color }: { color?: string }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  useDynamicStyle(ref, { background: color || 'transparent' });
+  return <span ref={ref} className="h-5 w-5" aria-hidden="true" />;
+}
+
+// ---------------------------------------------------------------------------
+
+export function PersonaPicker({
+  personas,
+  value,
+  onChange,
+  apiBase,
+}: {
+  personas: PersonaOpt[];
+  value: string;
+  onChange: (id: string) => void;
+  apiBase: string;
+}) {
+  if (!personas.length) return null;
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      {personas.map((p) => {
+        const selected = p.id === value;
+        const src = p.avatar ? `${apiBase}/persona-avatar/${encodeURIComponent(p.id)}` : null;
+        return (
+          <button
+            key={p.id}
+            type="button"
+            onClick={() => onChange(p.id)}
+            aria-pressed={selected}
+            className={cn(cardClass(selected), 'gap-2.5 p-2.5')}
+          >
+            {/* Initials sit behind the image so a missing / broken avatar still
+                shows a readable placeholder. */}
+            <span className="relative grid size-9 flex-none place-items-center overflow-hidden border border-ink bg-[var(--ink-softer)]">
+              <span className="text-[11px] font-extrabold text-muted">{initials(p.name)}</span>
+              {src && (
+                <img
+                  src={src}
+                  alt=""
+                  className="absolute inset-0 h-full w-full object-cover"
+                  onError={(e) => { e.currentTarget.style.visibility = 'hidden'; }}
+                />
+              )}
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-[13px] font-extrabold text-ink">
+                {p.name?.trim() || 'Unnamed'}
+              </span>
+              <span className="block truncate text-[11px] text-muted">
+                {p.tagline?.trim() || 'no tagline'}
+              </span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+function ThemeCard({
+  selected,
+  name,
+  sub,
+  tokens,
+  onClick,
+}: {
+  selected: boolean;
+  name: string;
+  sub?: string;
+  tokens?: Record<string, string>;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      title={sub}
+      className={cn(cardClass(selected), 'gap-2 p-2')}
+    >
+      <span className="inline-flex shrink-0 border border-ink" aria-hidden="true">
+        {SWATCH_KEYS.map((k) => (
+          <Swatch key={k} color={tokens?.[k]} />
+        ))}
+      </span>
+      <span className="truncate text-[11px] font-bold tracking-[0.08em] uppercase">{name}</span>
+    </button>
+  );
+}
+
+export function ThemePicker({
+  themes,
+  activeThemeId,
+  value,
+  onChange,
+}: {
+  themes: ThemeOpt[];
+  activeThemeId: string;
+  value: string; // '' = station default
+  onChange: (id: string) => void;
+}) {
+  const active = themes.find((t) => t.id === activeThemeId);
+  return (
+    <div className="flex flex-wrap gap-2">
+      <ThemeCard
+        selected={!value}
+        name="Station default"
+        sub="follows the station palette"
+        tokens={active?.tokens ?? LIVE_TOKENS}
+        onClick={() => onChange('')}
+      />
+      {themes.map((t) => (
+        <ThemeCard
+          key={t.id}
+          selected={value === t.id}
+          name={t.name}
+          sub={t.description || (t.mode === 'dark' ? 'Dark palette' : 'Light palette')}
+          tokens={t.tokens}
+          onClick={() => onChange(t.id)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -27,16 +27,13 @@ import {
 import { Card, Btn, Pill, Eyebrow, Metric, Toggle } from './ui';
 import { Modal } from '../ui/modal';
 import { AiFill } from './AiFill';
+import GenreSuggest from './GenreSuggest';
+import { PersonaPicker, ThemePicker } from './ShowPickers';
 import { cn } from '../../lib/cn';
 
 const NAME_MAX = 60;
 const TOPIC_MAX = 1000;
 const SHOWS_MAX = 64;
-
-// Radix Select rejects an empty-string item value, so the "no override"
-// choice round-trips through this sentinel. Form state still stores the
-// real empty string ('' = use station default).
-const THEME_DEFAULT_SENTINEL = '__station_default__';
 
 // Storage keys are 0=Sun..6=Sat (JS getDay); display Mon-first.
 const DAYS = [
@@ -103,18 +100,22 @@ function decadeLabelOf(s: { fromYear: number | null; toYear: number | null }): s
   return hit && hit.from != null ? hit.label : null;
 }
 
-// Slim view of a theme returned by GET /themes — only the bits the picker
-// needs. Token maps are dropped here; we don't render swatches in the
-// shows panel (the admin Settings → Theme page is the gallery).
+// View of a theme returned by GET /themes. We keep the token map here so the
+// theme picker can render real colour swatches (see ShowPickers.ThemePicker).
 interface ThemeOption {
   id: string;
   name: string;
   mode?: string;
+  description?: string;
+  tokens?: Record<string, string>;
 }
 
 interface Persona {
   id: string;
   name?: string;
+  tagline?: string;
+  avatar?: string;
+  tts?: { engine?: string; voice?: string };
 }
 
 interface Schedule {
@@ -230,6 +231,7 @@ export default function ShowsPanel() {
   // Theme list for the per-show override dropdown. Public endpoint, no auth
   // needed — same source the player ThemeBootstrap reads.
   const [themes, setThemes] = useState<ThemeOption[]>([]);
+  const [activeThemeId, setActiveThemeId] = useState('');
   // Library genres for the show genre autocomplete. Admin-gated endpoint, so it
   // runs after sign-in; failures are silent (the field still accepts free text).
   const [genres, setGenres] = useState<string[]>([]);
@@ -318,8 +320,9 @@ export default function ShowsPanel() {
       try {
         const r = await fetch(`${API}/themes`);
         if (!r.ok || cancelled) return;
-        const j = (await r.json()) as { themes?: ThemeOption[] };
+        const j = (await r.json()) as { themes?: ThemeOption[]; active?: string };
         if (Array.isArray(j.themes)) setThemes(j.themes);
+        if (typeof j.active === 'string') setActiveThemeId(j.active);
       } catch {}
     })();
     return () => { cancelled = true; };
@@ -342,6 +345,7 @@ export default function ShowsPanel() {
 
   const personas: Persona[] = data?.values?.personas || [];
   const moods: string[] = data?.tts?.moods || [];
+  const apiBase = (process.env.NEXT_PUBLIC_API_URL as string | undefined) || '/api';
   const colorOf = (showId: string | null | undefined): string => {
     const idx = form && showId ? form.shows.findIndex(s => s.id === showId) : -1;
     return idx >= 0 ? (SHOW_COLORS[idx % SHOW_COLORS.length] ?? 'transparent') : 'transparent';
@@ -768,6 +772,7 @@ export default function ShowsPanel() {
       <Modal
         open={editIndex !== null}
         onOpenChange={(o) => { if (!o) closeModal(); }}
+        width={760}
         title={editIndex === -1 ? 'New show' : 'Edit show'}
         sub={editIndex === -1 ? 'define a show' : (draft?.name?.trim() || '')}
         footer={draft && (
@@ -805,23 +810,34 @@ export default function ShowsPanel() {
               <span className="field-hint">{draft.name.trim().length}/{NAME_MAX}</span>
             </Field>
 
-            <div className="stack-mobile grid grid-cols-[1fr_1fr] gap-3">
-              <Field>
-                <Label>persona owner</Label>
-                <Select
-                  value={draft.personaId || undefined}
-                  onValueChange={val => setDraftField({ personaId: val })}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="— pick persona —" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      {personas.map(p => <SelectItem key={p.id} value={p.id}>{p.name}</SelectItem>)}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-              </Field>
+            <Field>
+              <Label>persona owner</Label>
+              <PersonaPicker
+                personas={personas}
+                value={draft.personaId}
+                onChange={id => setDraftField({ personaId: id })}
+                apiBase={apiBase}
+              />
+            </Field>
+
+            <Field>
+              <Label>theme override (applied while this show is on air)</Label>
+              <ThemePicker
+                themes={themes}
+                activeThemeId={activeThemeId}
+                value={draft.themeId}
+                onChange={id => setDraftField({ themeId: id })}
+              />
+              <span className="field-hint">
+                Optional. When this show goes on air the player switches to
+                this palette; back to the station default when the hour ends.
+                Manage themes in admin → Settings → Theme.
+              </span>
+            </Field>
+
+            <Eyebrow className="text-muted">music</Eyebrow>
+
+            <div className="stack-mobile grid grid-cols-3 gap-3">
               <Field>
                 <Label>music mood</Label>
                 <Select
@@ -837,51 +853,6 @@ export default function ShowsPanel() {
                     </SelectGroup>
                   </SelectContent>
                 </Select>
-              </Field>
-            </div>
-
-            <Field>
-              <Label>theme override (applied while this show is on air)</Label>
-              <Select
-                value={draft.themeId || THEME_DEFAULT_SENTINEL}
-                onValueChange={val =>
-                  setDraftField({ themeId: val === THEME_DEFAULT_SENTINEL ? '' : val })
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    <SelectItem value={THEME_DEFAULT_SENTINEL}>Station default</SelectItem>
-                    {themes.map(t => (
-                      <SelectItem key={t.id} value={t.id}>
-                        {t.name}{t.mode ? ` — ${t.mode}` : ''}
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-              <span className="field-hint">
-                Optional. When this show goes on air the player switches to
-                this palette; back to the station default when the hour ends.
-                Manage themes in admin → Settings → Theme.
-              </span>
-            </Field>
-
-            <div className="stack-mobile grid grid-cols-[1.2fr_1fr_1fr] gap-3">
-              <Field>
-                <Label htmlFor="show-genre">genre lean</Label>
-                <Input
-                  id="show-genre"
-                  type="text" value={draft.genre} maxLength={64}
-                  list="show-genre-options"
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => setDraftField({ genre: e.target.value })}
-                  placeholder="e.g. Jazz (optional)"
-                />
-                <datalist id="show-genre-options">
-                  {genres.map(g => <option key={g} value={g} />)}
-                </datalist>
               </Field>
               <Field>
                 <Label>era</Label>
@@ -921,6 +892,26 @@ export default function ShowsPanel() {
               </Field>
             </div>
 
+            <Field>
+              <Label htmlFor="show-genre">genre lean</Label>
+              <Input
+                id="show-genre"
+                type="text" value={draft.genre} maxLength={64}
+                list="show-genre-options"
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setDraftField({ genre: e.target.value })}
+                placeholder="e.g. Jazz (optional)"
+              />
+              <datalist id="show-genre-options">
+                {genres.map(g => <option key={g} value={g} />)}
+              </datalist>
+            </Field>
+
+            <GenreSuggest
+              adminFetch={adminFetch}
+              value={draft.genre}
+              onSelect={(g) => setDraftField({ genre: g })}
+            />
+
             <div className="flex items-start gap-3">
               <div className="pt-0.5">
                 <Toggle
@@ -947,6 +938,24 @@ export default function ShowsPanel() {
             </span>
 
             <Field>
+              <Label htmlFor="show-topic">topic (fed to the DJ as the show theme)</Label>
+              <span className="field-hint">
+                This is the brief the AI DJ works from. The more you describe,
+                the better it picks music and writes links: name genres, eras,
+                moods, artists to lean into or avoid, the time of day, the kind
+                of listener, and how the host should sound. Write it like
+                you&apos;re briefing a real DJ before their slot.
+              </span>
+              <Textarea
+                id="show-topic"
+                rows={7} value={draft.topic} maxLength={TOPIC_MAX}
+                onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setDraftField({ topic: e.target.value })}
+                placeholder="e.g. Slow ambient, modern classical and downtempo for the late shift. Think Nils Frahm, Hammock, Bonobo's quieter side, nothing with a hard beat. Keep the host calm and unhurried, like a friend talking you down at 1am."
+              />
+              <span className="field-hint">{draft.topic.trim().length}/{TOPIC_MAX}</span>
+            </Field>
+
+            <Field>
               <Label htmlFor="show-maxlen">max track length (seconds)</Label>
               <Input
                 id="show-maxlen"
@@ -967,24 +976,6 @@ export default function ShowsPanel() {
                 sets), or set at least {data?.values?.minTrackSeconds ?? 30}s to
                 cap it for this show.
               </span>
-            </Field>
-
-            <Field>
-              <Label htmlFor="show-topic">topic (fed to the DJ as the show theme)</Label>
-              <span className="field-hint">
-                This is the brief the AI DJ works from. The more you describe,
-                the better it picks music and writes links: name genres, eras,
-                moods, artists to lean into or avoid, the time of day, the kind
-                of listener, and how the host should sound. Write it like
-                you&apos;re briefing a real DJ before their slot.
-              </span>
-              <Textarea
-                id="show-topic"
-                rows={7} value={draft.topic} maxLength={TOPIC_MAX}
-                onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setDraftField({ topic: e.target.value })}
-                placeholder="e.g. Slow ambient, modern classical and downtempo for the late shift. Think Nils Frahm, Hammock, Bonobo's quieter side, nothing with a hard beat. Keep the host calm and unhurried, like a friend talking you down at 1am."
-              />
-              <span className="field-hint">{draft.topic.trim().length}/{TOPIC_MAX}</span>
             </Field>
 
             {!draftValid && (


### PR DESCRIPTION
## What & why

Reworks the show editor (`/admin/shows`) to be more visual and to use the library's embedding data where it actually helps. Three field upgrades plus a layout reorg.

### Genre lean → related-genre chips
A compact chip row under the genre field, in three states:
- **empty** → most-stocked genres as quick-picks
- **a genre is set** → its nearest genres by embedding similarity (cosine over per-genre centroids)
- **typing** → substring matches

New read-only endpoint `GET /library/genres/related` (admin-gated), backed by `library-db.genreCentroids()` (mean text-embedding per genre) → cosine KNN in `music/genre-suggest.ts`. Degrades gracefully: with no embeddings, `related` is empty and you still get popular/substring picks (`hasEmbeddings: false`).

> Replaces an earlier prototype that rendered a 2D PCA "genre cloud" with rubber-band selection — it looked busy and didn't suit a single-value field, so it was dropped in favour of these chips.

### Persona owner → card grid
Avatar + name + tagline cards (initials fallback) instead of a name dropdown — mirrors the Personas roster.

### Theme override → swatch cards
Each palette shown as real colour swatches (paper / ink / accent / overlay); the **Station default** card mirrors the live station palette. Reuses the `Swatch` / `SWATCH_KEYS` pattern from the admin theme gallery.

### Layout
- **Presentation** (name → persona → theme), then a **Music** group: mood · era · energy, full-width genre + chips, strict, max length.
- Music **mood** moved out of the persona row into Music (it's a music-steering field).
- **Topic** now precedes **max track length**.
- Modal widened 600 → 760px.

## Notes
- No controller behaviour change beyond the new read-only endpoint.
- `eslint . && tsc --noEmit` clean for both controller and web.

## Testing
Verified live in the dev stack against a seeded library: all three chip states + click-to-set; persona selection; theme cards render real palette colours and select; reorganised music section intact; topic-before-max-length confirmed.
