### PR TITLE
feat(boardcast): configurable stream bitrate

### DIFF
--- a/controller/src/broadcast/liquidsoap-control.ts
+++ b/controller/src/broadcast/liquidsoap-control.ts
@@ -52,15 +52,61 @@ export function sendCommand(cmd: string, timeoutMs = 3000): Promise<string> {
   });
 }
 
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+// Quick liveness probe — can we open a TCP connection to the telnet port?
+// Used to confirm a restart actually took: Liquidsoap must drop before the
+// container restart-policy brings it back, so a port that stops accepting
+// connections is proof the shutdown landed. Any connect error (refused,
+// timeout) counts as "down".
+function isLiquidsoapReachable(timeoutMs = 800): Promise<boolean> {
+  return new Promise(resolve => {
+    const sock = net.createConnection({ host: HOST, port: PORT });
+    let settled = false;
+    const done = (up: boolean) => {
+      if (settled) return;
+      settled = true;
+      try { sock.destroy(); } catch {}
+      resolve(up);
+    };
+    sock.setTimeout(timeoutMs);
+    sock.once('connect', () => done(true));
+    sock.once('timeout', () => done(false));
+    sock.once('error', () => done(false));
+  });
+}
+
 export async function restartLiquidsoap() {
-  // The custom "restart" command in radio.liq calls shutdown().
-  // We don't wait for a response — the socket will just be reset.
-  try {
-    await sendCommand('restart', 2000);
-  } catch (err) {
-    // Connection reset is expected (Liquidsoap is dying)
-    if (!/ECONNRESET|EPIPE|timeout/i.test(err.message)) throw err;
+  // The custom "restart" command in radio.liq calls shutdown(); the container
+  // restart-policy then brings Liquidsoap back with the freshly-written
+  // settings files. We can't trust sendCommand resolving as proof the command
+  // landed: the telnet socket can close cleanly with an empty buffer (e.g. it
+  // raced a concurrent stream_status poll), which still resolves — so a bare
+  // "no error" would let /restart-mixer report success while pending settings
+  // silently never apply. Confirm by watching the port actually go down, and
+  // resend if it doesn't.
+  let lastErr: Error | null = null;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      await sendCommand('restart', 2000);
+    } catch (err) {
+      // A reset/timeout is expected — Liquidsoap is tearing the socket down.
+      // Anything else (e.g. an unresolved host) is a real failure to surface.
+      if (!/ECONNRESET|EPIPE|timeout/i.test(err.message)) throw err;
+      lastErr = err as Error;
+    }
+    // shutdown() is asynchronous; poll until the process actually drops. A
+    // genuine restart goes down within a couple of seconds, so if the port is
+    // still accepting after the window the command was dropped — retry it.
+    const deadline = Date.now() + 8000;
+    while (Date.now() < deadline) {
+      if (!(await isLiquidsoapReachable())) return; // confirmed down → restart took
+      await sleep(250);
+    }
   }
+  throw new Error(
+    `liquidsoap restart did not take effect after 3 attempts — telnet port stayed up${lastErr ? ` (last error: ${lastErr.message})` : ''}`,
+  );
 }
 
 // Skip the currently playing track via the custom "skip" command in radio.liq.

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -632,7 +632,7 @@ const DEFAULTS = {
   // Safari/iOS/Firefox on MP3), and it adds a continuous Opus encoder + a
   // 44.1→48k resample, so operators opt in rather than pay that CPU unasked.
   // The mandatory /stream.mp3 mount always serves everyone.
-  stream: { opusEnabled: false },
+  stream: { opusEnabled: false, bitrate: 192 },
   weather: { lat: 30.7333, lng: 76.7794, locationName: 'Punjab', units: 'metric' as 'metric' | 'imperial' },
   // Operator-facing station name. Substituted into the DJ prompt's {station}
   // placeholder and returned by GET /dj for the landing page. The product is
@@ -1218,6 +1218,10 @@ export async function load() {
         typeof stored.stream?.opusEnabled === 'boolean'
           ? stored.stream.opusEnabled
           : DEFAULTS.stream.opusEnabled,
+      bitrate:
+        typeof stored.stream?.bitrate === 'number' && ARCHIVE_BITRATE_SET.has(stored.stream.bitrate)
+          ? stored.stream.bitrate
+          : DEFAULTS.stream.bitrate,
     },
     weather: {
       lat: stored.weather?.lat ?? DEFAULTS.weather.lat,
@@ -2031,6 +2035,18 @@ export async function update(patch) {
         restart = true;
       }
     }
+    if (st.bitrate !== undefined) {
+      const v = parseInt(st.bitrate, 10);
+      if (!Number.isFinite(v) || !ARCHIVE_BITRATE_SET.has(v)) {
+        throw new Error(
+          `stream.bitrate must be one of: ${ARCHIVE_BITRATES.join(', ')}`,
+        );
+      }
+      if (v !== cur.stream.bitrate) {
+        next.stream.bitrate = v;
+        restart = true;
+      }
+    }
   }
   if ('weather' in patch) {
     const w = patch.weather || {};
@@ -2692,6 +2708,7 @@ const LIQ_CROSSFADE_PATH = `${STATE_DIR}/liquidsoap_crossfade.txt`;
 const LIQ_ARCHIVE_ENABLED_PATH = `${STATE_DIR}/liquidsoap_archive_enabled.txt`;
 const LIQ_ARCHIVE_BITRATE_PATH = `${STATE_DIR}/liquidsoap_archive_bitrate.txt`;
 const LIQ_OPUS_ENABLED_PATH = `${STATE_DIR}/liquidsoap_opus_enabled.txt`;
+const LIQ_STREAM_BITRATE_PATH = `${STATE_DIR}/liquidsoap_stream_bitrate.txt`;
 const LIQ_STATION_NAME_PATH = `${STATE_DIR}/liquidsoap_station_name.txt`;
 
 export async function writeLiquidsoapSettings(s) {
@@ -2700,6 +2717,7 @@ export async function writeLiquidsoapSettings(s) {
   await writeFile(LIQ_ARCHIVE_ENABLED_PATH, s.archive.enabled ? 'true' : 'false');
   await writeFile(LIQ_ARCHIVE_BITRATE_PATH, String(s.archive.bitrate));
   await writeFile(LIQ_OPUS_ENABLED_PATH, s.stream.opusEnabled ? 'true' : 'false');
+  await writeFile(LIQ_STREAM_BITRATE_PATH, String(s.stream.bitrate));
   await writeFile(LIQ_STATION_NAME_PATH, s.station || DEFAULTS.station);
 }
 
@@ -2712,7 +2730,8 @@ export async function ensureLiquidsoapSettingsFile() {
     !existsSync(LIQ_CROSSFADE_PATH) ||
     !existsSync(LIQ_ARCHIVE_ENABLED_PATH) ||
     !existsSync(LIQ_ARCHIVE_BITRATE_PATH) ||
-    !existsSync(LIQ_OPUS_ENABLED_PATH)
+    !existsSync(LIQ_OPUS_ENABLED_PATH) ||
+    !existsSync(LIQ_STREAM_BITRATE_PATH)
   ) {
     await writeLiquidsoapSettings(s);
   }

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -606,10 +606,11 @@ export const SEED_PERSONAS = [
   },
 ];
 
-// Allowed archive bitrates. Matches the literal branches in radio.liq —
+// Allowed MP3 bitrates — shared by the hourly archive and the live
+// /stream.mp3 mount. Matches the literal branches in radio.liq —
 // %mp3(bitrate=…) needs a parse-time int, so the encoder is pre-baked for
 // this small set. Add a branch in radio.liq if you add a value here.
-export const ARCHIVE_BITRATES = [64, 96, 128, 160, 192, 320] as const;
+export const MP3_BITRATES = [64, 96, 128, 160, 192, 320] as const;
 
 const DEFAULTS = {
   jingleRatio: 30, // 1 jingle per N music tracks
@@ -955,7 +956,7 @@ const BOUNDS = {
   maxTrackSeconds: { min: 0, max: 36000, type: 'int' },
 };
 
-const ARCHIVE_BITRATE_SET = new Set<number>(ARCHIVE_BITRATES);
+const MP3_BITRATE_SET = new Set<number>(MP3_BITRATES);
 
 let cache: any = null;
 
@@ -1198,7 +1199,7 @@ export async function load() {
   );
 
   const archiveBitrate =
-    typeof stored.archive?.bitrate === 'number' && ARCHIVE_BITRATE_SET.has(stored.archive.bitrate)
+    typeof stored.archive?.bitrate === 'number' && MP3_BITRATE_SET.has(stored.archive.bitrate)
       ? stored.archive.bitrate
       : DEFAULTS.archive.bitrate;
 
@@ -1219,7 +1220,7 @@ export async function load() {
           ? stored.stream.opusEnabled
           : DEFAULTS.stream.opusEnabled,
       bitrate:
-        typeof stored.stream?.bitrate === 'number' && ARCHIVE_BITRATE_SET.has(stored.stream.bitrate)
+        typeof stored.stream?.bitrate === 'number' && MP3_BITRATE_SET.has(stored.stream.bitrate)
           ? stored.stream.bitrate
           : DEFAULTS.stream.bitrate,
     },
@@ -2015,9 +2016,9 @@ export async function update(patch) {
     }
     if (a.bitrate !== undefined) {
       const v = parseInt(a.bitrate, 10);
-      if (!Number.isFinite(v) || !ARCHIVE_BITRATE_SET.has(v)) {
+      if (!Number.isFinite(v) || !MP3_BITRATE_SET.has(v)) {
         throw new Error(
-          `archive.bitrate must be one of: ${ARCHIVE_BITRATES.join(', ')}`,
+          `archive.bitrate must be one of: ${MP3_BITRATES.join(', ')}`,
         );
       }
       if (v !== cur.archive.bitrate) {
@@ -2037,9 +2038,9 @@ export async function update(patch) {
     }
     if (st.bitrate !== undefined) {
       const v = parseInt(st.bitrate, 10);
-      if (!Number.isFinite(v) || !ARCHIVE_BITRATE_SET.has(v)) {
+      if (!Number.isFinite(v) || !MP3_BITRATE_SET.has(v)) {
         throw new Error(
-          `stream.bitrate must be one of: ${ARCHIVE_BITRATES.join(', ')}`,
+          `stream.bitrate must be one of: ${MP3_BITRATES.join(', ')}`,
         );
       }
       if (v !== cur.stream.bitrate) {

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -23,6 +23,7 @@ crossfade_duration = ref(10.0)
 archive_enabled = ref(true)
 archive_bitrate = ref(128)
 opus_enabled = ref(false)
+stream_bitrate = ref(192)
 station_name = ref("SUB/WAVE")
 
 if file.exists("/var/sub-wave/liquidsoap_jingle_ratio.txt") then
@@ -48,6 +49,12 @@ if file.exists("/var/sub-wave/liquidsoap_archive_bitrate.txt") then
   if v > 0 then archive_bitrate := v end
 end
 
+if file.exists("/var/sub-wave/liquidsoap_stream_bitrate.txt") then
+  raw = string.trim(file.contents("/var/sub-wave/liquidsoap_stream_bitrate.txt"))
+  v = int_of_string(default=192, raw)
+  if v > 0 then stream_bitrate := v end
+end
+
 # Opt IN to the Ogg-Opus mount, which adds a continuous encoder (+ its
 # 44.1->48k resample). Only Blink (Chrome/Edge) clients ever select Opus — see
 # web/hooks/usePlayer.ts, which keeps Safari/iOS/Firefox on the MP3 mount — so
@@ -63,7 +70,7 @@ if file.exists("/var/sub-wave/liquidsoap_station_name.txt") then
   if raw != "" then station_name := raw end
 end
 
-log("settings loaded: jingle_ratio=#{jingle_ratio()} crossfade_duration=#{crossfade_duration()} archive_enabled=#{archive_enabled()} archive_bitrate=#{archive_bitrate()} opus_enabled=#{opus_enabled()} station_name=#{station_name()}")
+log("settings loaded: jingle_ratio=#{jingle_ratio()} crossfade_duration=#{crossfade_duration()} archive_enabled=#{archive_enabled()} archive_bitrate=#{archive_bitrate()} stream_bitrate=#{stream_bitrate()} opus_enabled=#{opus_enabled()} station_name=#{station_name()}")
 
 # ---------------------------------------------------------------------------
 # HTTP(S) FETCH OVERRIDE — Liquidsoap's built-in http.get.stream returns
@@ -594,7 +601,7 @@ music_meta.on_metadata(on_meta)
 # controller. It is NOT persisted: a mixer restart always comes back on air.
 #
 # Two mounts in parallel:
-#   /stream.mp3  — MP3 192 kbps, the universal compatibility floor
+#   /stream.mp3  — MP3, the universal compatibility floor (bitrate configurable)
 #                  (Sonos, hardware radios, car receivers, pre-iOS-17 Safari).
 #                  Bumped from 128 → 192: dense, brick-walled masters (e.g. hot
 #                  Punjabi/hip-hop catalogue pinned at 0 dBFS) produced audible
@@ -608,8 +615,23 @@ music_meta.on_metadata(on_meta)
 settings.init.force_start := true
 
 def make_stream_outputs() =
+  br = stream_bitrate()
+  mp3_enc =
+    if br <= 64 then
+      %mp3(bitrate=64, samplerate=44100, stereo=true)
+    elsif br <= 96 then
+      %mp3(bitrate=96, samplerate=44100, stereo=true)
+    elsif br <= 128 then
+      %mp3(bitrate=128, samplerate=44100, stereo=true)
+    elsif br <= 160 then
+      %mp3(bitrate=160, samplerate=44100, stereo=true)
+    elsif br <= 192 then
+      %mp3(bitrate=192, samplerate=44100, stereo=true)
+    else
+      %mp3(bitrate=320, samplerate=44100, stereo=true)
+    end
   mp3_out = output.icecast(
-    %mp3(bitrate=192, samplerate=44100, stereo=true),
+    mp3_enc,
     id="stream_mp3",
     fallible=true,
     host=environment.get(default="icecast", "ICECAST_HOST"),

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -601,12 +601,15 @@ music_meta.on_metadata(on_meta)
 # controller. It is NOT persisted: a mixer restart always comes back on air.
 #
 # Two mounts in parallel:
-#   /stream.mp3  — MP3, the universal compatibility floor (bitrate configurable)
+#   /stream.mp3  — MP3, the universal compatibility floor
 #                  (Sonos, hardware radios, car receivers, pre-iOS-17 Safari).
-#                  Bumped from 128 → 192: dense, brick-walled masters (e.g. hot
+#                  Bitrate is operator-configurable (admin → Settings → Stream
+#                  MP3 bitrate); 192 is the default. The default sits at 192,
+#                  not 128, because dense, brick-walled masters (e.g. hot
 #                  Punjabi/hip-hop catalogue pinned at 0 dBFS) produced audible
-#                  encode grain ("swishy static") at 128 with no headroom. The
+#                  encode grain ("swishy static") at 128 with no headroom — the
 #                  extra ~50% bandwidth buys a clean re-encode of busy material.
+#                  Dropping below 192 reintroduces that grain on hot masters.
 #   /stream.opus — Ogg-Opus 96 kbps, ~equal-or-better quality at half the
 #                  bandwidth for modern browsers (the web player auto-prefers
 #                  it via canPlayType). Browsers / VLC / cliamp on a recent
@@ -615,6 +618,9 @@ music_meta.on_metadata(on_meta)
 settings.init.force_start := true
 
 def make_stream_outputs() =
+  # Pick the encoder from a fixed set: %mp3(bitrate=…) needs a parse-time
+  # literal int (can't pass a ref), same constraint as the archive output
+  # below. Keep these branches in sync with MP3_BITRATES in settings.ts.
   br = stream_bitrate()
   mp3_enc =
     if br <= 64 then

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -267,7 +267,7 @@ interface SettingsData {
     maxTrackSeconds?: number;
     minTrackSeconds?: number;
     archive?: { enabled?: boolean; bitrate?: number };
-    stream?: { opusEnabled?: boolean };
+    stream?: { opusEnabled?: boolean; bitrate?: number };
     station?: string;
     timezone?: string;
     locale?: StationLocale;
@@ -411,6 +411,7 @@ export default function SettingsPanel() {
       },
       stream: {
         opusEnabled: v.stream?.opusEnabled ?? true,
+        bitrate: String(v.stream?.bitrate ?? 192),
       },
       station: v.station ?? '',
       timezone: v.timezone ?? '',
@@ -1040,6 +1041,48 @@ export default function SettingsPanel() {
                     44.1→48 kHz resample. Turn it on if you have Chrome/Edge listeners and want
                     the bandwidth saving. The mandatory <code>/stream.mp3</code> mount serves
                     everyone either way.
+                  </div>
+                </div>
+
+                <div className="field">
+                  <div className="flex items-center gap-2">
+                    <Label>Stream MP3 bitrate</Label>
+                    <Pill tone="ink">restart required</Pill>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Select
+                      value={form.stream.bitrate}
+                      onValueChange={v =>
+                        setForm(f => (f ? { ...f, stream: { ...f.stream, bitrate: v } } : f))
+                      }
+                    >
+                      <SelectTrigger className="w-32">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {ARCHIVE_BITRATES.map(br => (
+                          <SelectItem key={br} value={String(br)}>
+                            {br} kbps
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Btn
+                      sm
+                      onClick={() =>
+                        saveSettings({
+                          stream: { bitrate: parseInt(form.stream.bitrate, 10) },
+                        })
+                      }
+                      disabled={busy}
+                    >
+                      Save bitrate
+                    </Btn>
+                  </div>
+                  <div className="field-hint">
+                    Higher bitrate = better quality, more listener bandwidth
+                    (current: {data?.values?.stream?.bitrate ?? '—'} kbps). 192 kbps is the
+                    original default.
                   </div>
                 </div>
               </Card>

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -1045,9 +1045,14 @@ export default function SettingsPanel() {
                   </div>
                 </div>
 
+              </Card>
+            )}
+
+            {form && (
+              <Card title="Stream MP3 bitrate" sub="/stream.mp3">
                 <div className="field">
                   <div className="flex items-center gap-2">
-                    <Label>Stream MP3 bitrate</Label>
+                    <Label>Bitrate</Label>
                     <Pill tone="ink">restart required</Pill>
                   </div>
                   <div className="flex items-center gap-2">

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -217,9 +217,9 @@ interface StreamForm {
   bitrate: string;
 }
 
-// Keep in sync with ARCHIVE_BITRATES in controller/src/settings.ts — radio.liq
+// Keep in sync with MP3_BITRATES in controller/src/settings.ts — radio.liq
 // has a literal `%mp3(bitrate=…)` branch per value, so this set is fixed.
-const ARCHIVE_BITRATES = [64, 96, 128, 160, 192, 320] as const;
+const MP3_BITRATES = [64, 96, 128, 160, 192, 320] as const;
 
 interface FormState {
   jingleRatio: string;
@@ -864,7 +864,7 @@ export default function SettingsPanel() {
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                          {ARCHIVE_BITRATES.map(br => (
+                          {MP3_BITRATES.map(br => (
                             <SelectItem key={br} value={String(br)}>
                               {br} kbps
                             </SelectItem>
@@ -1066,7 +1066,7 @@ export default function SettingsPanel() {
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        {ARCHIVE_BITRATES.map(br => (
+                        {MP3_BITRATES.map(br => (
                           <SelectItem key={br} value={String(br)}>
                             {br} kbps
                           </SelectItem>

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -214,6 +214,7 @@ interface ArchiveForm {
 
 interface StreamForm {
   opusEnabled: boolean;
+  bitrate: string;
 }
 
 // Keep in sync with ARCHIVE_BITRATES in controller/src/settings.ts — radio.liq


### PR DESCRIPTION
MP3 bitrate setting

## What
Added an option to change the bitrate of the mp3 stream. Same exact implementation as the archive bitrate setting, except the UI part is in the Danger Zone.

## Why
I wanted to change the bitrate from 192 to 320 kbps.

## How tested
Built the docker containers from scratch, played a song at default 192 kbps, then tried 64 kbps, then 320 kbps. Clear difference in quality.

<img width="1140" height="213" alt="image" src="https://github.com/user-attachments/assets/36c7b0b5-579f-4e2d-be9f-a50d8061f0a7" />
