### PR TITLE
fix(build): copy controller/.npmrc into image so npm install gets legacy-peer-deps

### DIFF
--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -111,7 +111,10 @@ ENV KOKORO_MODEL=/opt/kokoro/models/kokoro-v1.0.onnx \
 
 # --- Controller app ---------------------------------------------------------
 WORKDIR /app
-COPY controller/package*.json ./
+# .npmrc carries `legacy-peer-deps=true` (OpenRouter provider still declares a
+# stale `peer ai@^6` after the AI SDK v7 upgrade); it must land before install
+# or npm hits ERESOLVE.
+COPY controller/package*.json controller/.npmrc ./
 RUN npm install --omit=dev
 COPY controller/src ./src
 COPY controller/scripts ./scripts

--- a/docker/Dockerfile.controller
+++ b/docker/Dockerfile.controller
@@ -144,7 +144,10 @@ ENV POCKET_TTS_PYTHON=/opt/pocket-tts/venv/bin/python \
 
 # --- Controller app -------------------------------------------------------
 WORKDIR /app
-COPY controller/package*.json ./
+# .npmrc carries `legacy-peer-deps=true` (OpenRouter provider still declares a
+# stale `peer ai@^6` after the AI SDK v7 upgrade); it must land before install
+# or npm hits ERESOLVE.
+COPY controller/package*.json controller/.npmrc ./
 RUN npm install --omit=dev
 COPY controller/src ./src
 COPY controller/scripts ./scripts


### PR DESCRIPTION
## Problem

The AI SDK v7 upgrade (#669) added `controller/.npmrc` with `legacy-peer-deps=true` to tolerate `@openrouter/ai-sdk-provider`'s stale `peer ai@^6` declaration (it has no v7 build yet, but is runtime-compatible). However, neither `docker/Dockerfile.controller` nor `docker/Dockerfile.aio` copied `.npmrc` into the build context before `npm install`.

`COPY controller/package*.json ./` globs only `package.json` / `package-lock.json` — not `.npmrc`. So inside the image build, `npm install --omit=dev` re-checks peer deps without the relaxation and dies:

```
npm error code ERESOLVE
...
target controller: failed to solve: process "/bin/sh -c npm install --omit=dev" did not complete successfully: exit code: 1
```

This breaks **every** controller image build — local `docker compose up -d --build controller` and the CI `publish-images` workflow alike. Caught during a routine `develop` deploy.

## Fix

Copy `controller/.npmrc` alongside `package*.json` in both Dockerfiles, before `npm install`, with a comment explaining why.

## Verification

Rebuilt `controller`, `broadcast`, `web` locally with the patch — controller image builds clean, stack recreated, audio-level probe on `/stream.mp3` reads -12.3 dB (live audio), `/api/health` on-air, now-playing populated.