### PR TITLE
fix(web): don't false-flag raw LLM-request dumps as warnings in tagging log

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3289,6 +3289,20 @@ html.lite *::after {
     overflow: auto;
 }
 
+/* CRT modifier — a minimal phosphor look for the live tagging-log drawer:
+   fixed scanlines (don't scroll with content), a faint accent glow on the
+   text, and a soft inset vignette. Theme-aware via tokens. */
+.admin-root .term-crt {
+    background-image: repeating-linear-gradient(
+        color-mix(in srgb, var(--ink) 22%, transparent) 0px,
+        color-mix(in srgb, var(--ink) 22%, transparent) 1px,
+        transparent 1px,
+        transparent 3px
+    );
+    text-shadow: 0 0 3px color-mix(in srgb, var(--accent) 35%, transparent);
+    box-shadow: inset 0 0 36px color-mix(in srgb, var(--ink) 55%, transparent);
+}
+
 /* ─────────────────────────────────────────────────────────────────────────
    LIBRARY — redesigned /admin/library. One merged tagging panel + clearer
    browse/search/untagged. Every value is a token (or token-derived color-mix)

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -592,7 +592,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
       {/* log drawer — reuses the theme-aware .term surface; each line is dressed
           up for humans (emoji + friendly phrasing + tint) via beautifyLog */}
       {p.logOpen && (
-        <pre ref={logRef} className="term m-0 max-h-56 overflow-y-auto !border-t !border-l-0 border-separator-strong">
+        <pre ref={logRef} className="term term-crt m-0 max-h-56 overflow-y-auto !border-t !border-l-0 border-separator-strong">
           {(p.tagger?.lastLog ?? []).length
             ? (p.tagger?.lastLog ?? []).map((line, i) => {
                 const f = beautifyLog(line);

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -223,6 +223,11 @@ function beautifyLog(raw: string): { text: string; cls: string } {
   if (/^\[exit 0\]/.test(raw)) return { text: '✅  Finished', cls: 'text-emerald-500 font-semibold' };
   if (/^\[exit/.test(raw)) return { text: `⏹  Stopped (${raw.replace(/^\[exit\s*|\]\s*$/g, '')})`, cls: 'text-vermilion font-semibold' };
   const s = raw.replace(/^\[(tag|analyze|stats|scheduler|error)\]\s*/, '');
+  // Raw LLM-request dumps (the `[llm-debug-raw]` header and its JSON body) are
+  // verbose debug output, not status lines — never keyword-scan them. A song
+  // title carried inside the body (e.g. "Closer (Cotto's Can't Stop Remix)")
+  // would otherwise false-trigger the failure warning below.
+  if (/^\[llm-debug-raw\]/.test(s) || /^\s*\{/.test(s)) return { text: s, cls: 'text-muted' };
   const low = s.toLowerCase();
   // Real failures (but not "0 failed" / "fail=0") → vermilion warning.
   if (/(fail(ed)?|error|unreachable|can'?t|missing)/.test(low) && !/fail=0|0 failed/.test(low)) {

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -97,6 +97,7 @@ export default defineConfig([
             '^field-hint$',
             '^rule-label$',
             '^term$',
+            '^term-crt$',
             '^log$',
             '^msg$',
             '^t$',


### PR DESCRIPTION
## What

The admin **Library Tagging** panel's `beautifyLog` (`web/components/admin/LibraryTaggingPanel.tsx`) tints any log line containing `fail`/`error`/`unreachable`/`can't`/`missing` vermilion and prefixes it with `⚠️`. When raw LLM-request capture is on (`LLM_DEBUG_RAW` / `settings.llm.debugRawRequests`), the `[llm-debug-raw]` dumps stream the full JSON request body — which carries song titles. A track like `Closer (Cotto's Can't Stop Remix)` contains "Can't", so the body line got painted red as if a failure occurred.

## Fix

Skip keyword-scanning for raw-debug lines — both the `[llm-debug-raw]` header and the JSON body (`^\s*\{`). These are verbose debug output, not status, and now render muted like the rest of the dump.

## Why it's safe

The skip only short-circuits the cosmetic warning tint. Raw-debug lines never matched any `LOG_RULES`, so they fell through to muted styling anyway — the only behaviour change is they no longer false-trigger the failure highlight.

`npm run lint` (eslint + tsc) passes.