### PR TITLE
style(web): soften CRT scanline contrast in the tagging log drawer

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3294,8 +3294,8 @@ html.lite *::after {
    text, and a soft inset vignette. Theme-aware via tokens. */
 .admin-root .term-crt {
     background-image: repeating-linear-gradient(
-        color-mix(in srgb, var(--ink) 22%, transparent) 0px,
-        color-mix(in srgb, var(--ink) 22%, transparent) 1px,
+        color-mix(in srgb, var(--ink) 9%, transparent) 0px,
+        color-mix(in srgb, var(--ink) 9%, transparent) 1px,
         transparent 1px,
         transparent 3px
     );


### PR DESCRIPTION
## What

Follow-up to the CRT log styling. The scanlines in the tagging-log drawer (`term-crt`) read too strong. This drops the scanline ink mix from **22% → 9%**, so the lines are a faint texture under the text rather than hard bands.

CSS-only (`web/app/globals.css`), no behaviour change. Lint unaffected.