### PR TITLE
fix(onboarding): surface errors and bound timeouts on the Test buttons (#682)

### DIFF
--- a/controller/src/routes/onboarding.ts
+++ b/controller/src/routes/onboarding.ts
@@ -174,6 +174,12 @@ router.post('/onboarding/test-llm', requireAdmin, async (req, res) => {
       model: m,
       prompt: 'Reply with the single word OK.',
       maxOutputTokens: 8,
+      // A test must always answer. Without a bound an unreachable/stalled model
+      // hangs this handler forever, the wizard's fetch never resolves, and the
+      // button is stuck on "Asking…" with no feedback (issue #682). maxRetries:0
+      // so the operator sees the first real error fast instead of silent backoff.
+      maxRetries: 0,
+      abortSignal: AbortSignal.timeout(45_000),
     });
     res.json({ ok: true, sample: (out.text || '').trim().slice(0, 60) });
   } catch (err: any) {

--- a/web/components/onboarding/steps.tsx
+++ b/web/components/onboarding/steps.tsx
@@ -82,8 +82,14 @@ export function NavidromeStep({ w }: { w: WizardController }) {
   const [busy, setBusy] = useState(false);
   const onTest = async () => {
     setBusy(true);
-    await w.testNavidrome();
-    setBusy(false);
+    // testNavidrome never throws — it catches its own errors into the pill —
+    // but the finally is the backstop so the button can never get wedged on
+    // "Testing…" if anything unexpected slips through (issue #682).
+    try {
+      await w.testNavidrome();
+    } finally {
+      setBusy(false);
+    }
   };
   return (
     <div>
@@ -158,8 +164,11 @@ export function LlmStep({ w }: { w: WizardController }) {
   const isCustom = w.data.llm.provider === 'openai-compatible';
   const onTest = async () => {
     setBusy(true);
-    await w.testLlm();
-    setBusy(false);
+    try {
+      await w.testLlm();
+    } finally {
+      setBusy(false);
+    }
   };
   // Same unified model discovery the admin Settings tab uses. Enabled for the
   // keyless-discoverable providers (ollama / locca / openai-compatible with a

--- a/web/components/onboarding/useWizard.ts
+++ b/web/components/onboarding/useWizard.ts
@@ -94,6 +94,18 @@ export const STEP_LABELS: Record<StepId, string> = {
   review: 'Review',
 };
 
+// Turn a thrown fetch failure into a human-readable pill message. AbortSignal
+// timeouts reject with a TimeoutError; everything else (connection refused,
+// DNS, CORS/TLS) is a bare "Failed to fetch" that means nothing to an operator
+// — so we point them at the real culprit: reaching the controller.
+function fetchErrorMsg(err: unknown): string {
+  if (err instanceof DOMException && err.name === 'TimeoutError') {
+    return 'timed out — the controller did not respond';
+  }
+  const m = err instanceof Error ? err.message : '';
+  return `could not reach the controller${m ? ` (${m})` : ''}`;
+}
+
 export function useWizard() {
   const auth = useAdminAuth();
   const [data, setData] = useState<WizardData>(DEFAULT_DATA);
@@ -115,29 +127,52 @@ export function useWizard() {
   }, []);
 
   // POST helpers — every wizard write goes through adminFetch so the same
-  // 401-handling that the admin shell uses applies here.
+  // 401-handling that the admin shell uses applies here. Both test helpers
+  // catch their own failures into the result pill: a rejected/timed-out
+  // browser→controller fetch must surface as a red pill, never as an
+  // unhandled throw that wedges the button on "Testing…" (issue #682).
   const testNavidrome = useCallback(async () => {
-    const r = await auth.adminFetch('/onboarding/test-navidrome', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(data.navidrome),
-    });
-    const j = (await r.json().catch(() => ({}))) as { ok?: boolean; serverType?: string; serverVersion?: string; error?: string };
-    const result = { ok: !!j.ok, msg: j.ok ? `${j.serverType || 'Subsonic'} v${j.serverVersion || ''}` : j.error };
-    patch({ navidromeTest: result });
-    return result;
+    // The browser→controller hop has no default timeout; without one a request
+    // that never gets a response leaves the button stuck forever. 15s clears
+    // the 5s server-side Subsonic probe with margin.
+    try {
+      const r = await auth.adminFetch('/onboarding/test-navidrome', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(data.navidrome),
+        signal: AbortSignal.timeout(15000),
+      });
+      const j = (await r.json().catch(() => ({}))) as { ok?: boolean; serverType?: string; serverVersion?: string; error?: string };
+      const result = { ok: !!j.ok, msg: j.ok ? `${j.serverType || 'Subsonic'} v${j.serverVersion || ''}` : (j.error || `controller returned HTTP ${r.status}`) };
+      patch({ navidromeTest: result });
+      return result;
+    } catch (err: unknown) {
+      const result = { ok: false, msg: fetchErrorMsg(err) };
+      patch({ navidromeTest: result });
+      return result;
+    }
   }, [auth, data.navidrome, patch]);
 
   const testLlm = useCallback(async () => {
-    const r = await auth.adminFetch('/onboarding/test-llm', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(data.llm),
-    });
-    const j = (await r.json().catch(() => ({}))) as { ok?: boolean; sample?: string; error?: string };
-    const result = { ok: !!j.ok, msg: j.ok ? `responded: "${j.sample}"` : j.error };
-    patch({ llmTest: result });
-    return result;
+    // 60s client cap sits just above the controller's 45s generateText abort,
+    // so a slow/unreachable model surfaces the server's error rather than a
+    // bare client timeout — and the button can never hang forever.
+    try {
+      const r = await auth.adminFetch('/onboarding/test-llm', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(data.llm),
+        signal: AbortSignal.timeout(60000),
+      });
+      const j = (await r.json().catch(() => ({}))) as { ok?: boolean; sample?: string; error?: string };
+      const result = { ok: !!j.ok, msg: j.ok ? `responded: "${j.sample}"` : (j.error || `controller returned HTTP ${r.status}`) };
+      patch({ llmTest: result });
+      return result;
+    } catch (err: unknown) {
+      const result = { ok: false, msg: fetchErrorMsg(err) };
+      patch({ llmTest: result });
+      return result;
+    }
   }, [auth, data.llm, patch]);
 
   // Probe a locca / openai-compatible server for its loaded model list so the


### PR DESCRIPTION
Fixes #682.

## Problem

The Navidrome **Test connection** and LLM **Send a test prompt** buttons could stick on "Testing…" / "Asking…" forever with **zero feedback** — no error, no success. The handlers set `busy=true` then `await`ed the test with no `try/finally`, and the whole fetch chain (browser `fetch` → wizard helper → server `generateText`) had **no timeout**. So any rejected or never-resolving request left the button wedged and the result pill hidden.

The reporter's `curl` from inside the controller container works because that's the **controller→Navidrome** hop. The button's failing hop is **browser→controller** (`/api/onboarding/test-navidrome`), which the old code swallowed silently instead of surfacing.

## Fix

- **`web/components/onboarding/steps.tsx`** — wrap both `onTest` handlers in `try/finally` so `busy` always resets; the button can never get wedged.
- **`web/components/onboarding/useWizard.ts`** — `testNavidrome` / `testLlm` now catch their own failures into a red pill with a human-readable message (`could not reach the controller (…)`, `timed out — the controller did not respond`, or an HTTP-status fallback), and pass an `AbortSignal.timeout` (15s Navidrome / 60s LLM) so a dead browser→controller hop fails fast instead of hanging.
- **`controller/src/routes/onboarding.ts`** — bound the `test-llm` `generateText` call with `abortSignal: AbortSignal.timeout(45_000)` + `maxRetries: 0` so the handler always answers instead of hanging on a stalled/unreachable model.

The 60s client cap sits just above the 45s server abort so a slow model surfaces the server's error rather than a bare client timeout.

## Deliberately out of scope

- **`web/lib/adminAuth.ts`** — not touched. Passing `signal` through `init` reaches the same browser `fetch` without imposing a blanket timeout on every admin call (some are legitimately long).
- **`docker/Caddyfile`** `/api/*` — no `response_header_timeout` added; it would wrongly cut off legitimately-slow synchronous endpoints (jingle render, library scans). The server-side `generateText` bound already prevents the controller from hanging on the test route.

## Note on the underlying env issue

This PR makes the *symptom* (silent hang) into a clear error, which is the issue's actual ask. For affected operators (e.g. unraid) the real blocker is usually that the browser can't reach the controller's `/api` — confirmable by loading `/api/health` in the same browser; the typical fix is accessing the **Caddy edge port** rather than the web container directly, or replicating the Caddyfile route table in a BYO reverse proxy.

## Verification

`npm run lint` (eslint + `tsc --noEmit`) green in both `web/` and `controller/` (0 errors).