### PR TITLE
fix(llm): fail over to fallback model on upstream-overload errors (#671)

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -7,7 +7,7 @@
 // node:assert-via-tsx style of scripts/picker-recency-regression.ts.
 
 import assert from 'node:assert/strict';
-import { stripThinking, extractJson, usageOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError } from '../src/llm/internal/core/pure.js';
+import { stripThinking, extractJson, usageOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded } from '../src/llm/internal/core/pure.js';
 import { withDeadline } from '../src/llm/internal/core/retry.js';
 import { providerOptions, needsToolCallObject, repeatPenaltyApplies, appliedNumCtx, forcedToolChoice } from '../src/llm/internal/provider/capabilities.js';
 import { agentPlan } from '../src/llm/internal/strategy/plan.js';
@@ -85,6 +85,35 @@ async function main() {
   await test('plain 5xx / socket errors are NOT quota/auth (still same-leg retry)', () => {
     assert.equal(isQuotaOrAuthError({ statusCode: 503 }), false);
     assert.equal(isQuotaOrAuthError({ code: 'ECONNRESET' }), false);
+  });
+
+  // ---- upstream-overload gate: STAYS transient (retry first), THEN fails over (#671) ----
+  console.log('isUpstreamOverloaded (reachable gateway relays a saturated upstream → retry, then fail over):');
+  await test('OpenRouter "Upstream error from <provider>: ResourceExhausted" → upstream-overload', () => {
+    // The exact shape from issue #671: OpenRouter relaying a saturated Nvidia upstream.
+    const e: any = { statusCode: 429, message: 'Upstream error from Nvidia: ResourceExhausted: Worker local total request limit reached (32/32)' };
+    assert.equal(isUpstreamOverloaded(e), true);
+    assert.equal(isTransient(e), true);          // stays transient — a brief blip clears on the chosen model
+    assert.equal(isUnreachable(e), false);        // gateway answered, host is up
+    assert.equal(isQuotaOrAuthError(e), false);   // not the user's quota — the upstream is saturated
+  });
+  await test('Anthropic 529 "Overloaded" → upstream-overload (529 is outside the transient status set)', () => {
+    assert.equal(isUpstreamOverloaded({ statusCode: 529 }), true);
+    assert.equal(isUpstreamOverloaded({ message: 'Overloaded' }), true);
+  });
+  await test('gRPC RESOURCE_EXHAUSTED / "no instances available" → upstream-overload', () => {
+    assert.equal(isUpstreamOverloaded({ message: 'RESOURCE_EXHAUSTED: model is overloaded' }), true);
+    assert.equal(isUpstreamOverloaded({ message: 'No instances available for this model' }), true);
+  });
+  await test('cause.message / cause.statusCode are unwrapped', () => {
+    assert.equal(isUpstreamOverloaded({ cause: { message: 'Upstream error from Together: overloaded' } }), true);
+    assert.equal(isUpstreamOverloaded({ cause: { statusCode: 529 } }), true);
+  });
+  await test('plain 503 / quota / socket errors are NOT upstream-overload (no false failover)', () => {
+    assert.equal(isUpstreamOverloaded({ statusCode: 503 }), false);
+    assert.equal(isUpstreamOverloaded({ statusCode: 429, message: 'rate limit exceeded, slow down' }), false);
+    assert.equal(isUpstreamOverloaded({ code: 'ECONNRESET' }), false);
+    assert.equal(isUpstreamOverloaded(null), false);
   });
 
   // ---- per-provider thinking knob (the single most regression-prone mapping) ----

--- a/controller/src/llm/internal/core/failover.ts
+++ b/controller/src/llm/internal/core/failover.ts
@@ -4,13 +4,14 @@
 // inside withFailover(): the primary leg is tried first, and the call retries
 // once against the optional fallback leg when the primary leg can't recover this
 // call — either its host is unreachable (connection refused / DNS / timeout —
-// see isUnreachable) or it refused with a quota/usage-limit/auth error (see
-// isQuotaOrAuthError; issue #438). record* lives here so a call is logged
-// exactly once, with the leg that actually ran.
+// see isUnreachable), it refused with a quota/usage-limit/auth error (see
+// isQuotaOrAuthError; issue #438), or a reachable gateway relayed a saturated
+// upstream that survived same-leg retries (see isUpstreamOverloaded; issue #671).
+// record* lives here so a call is logged exactly once, with the leg that ran.
 
 import { primaryLeg, fallbackLeg } from '../provider/legs.js';
 import { record } from '../telemetry/log.js';
-import { isUnreachable, isQuotaOrAuthError } from './pure.js';
+import { isUnreachable, isQuotaOrAuthError, isUpstreamOverloaded } from './pure.js';
 
 // Centralised success/failure record writers. Every LLM call goes through one
 // of each. The required-shape args (kind/started/via/sampling/usage for
@@ -68,8 +69,9 @@ export interface AttemptResult<T> {
 // it throws on error, optionally tagging the error with `__via` so the failure
 // record attributes to the right sub-path (djObject/djAgent set this). The
 // primary leg is tried first; only when the primary leg can't recover this call
-// — host unreachable OR a quota/usage-limit/auth rejection — and only when a
-// fallback is configured, is `attempt` retried once against the backup leg.
+// — host unreachable OR a quota/usage-limit/auth rejection OR a reachable
+// gateway relaying a saturated upstream (#671) — and only when a fallback is
+// configured, is `attempt` retried once against the backup leg.
 // On a failover the primary's failure is also recorded (via `…:failover→<backup>`)
 // so /debug shows the switch happened.
 //
@@ -108,13 +110,14 @@ export async function withFailover<T>(
   } catch (err: any) {
     const primaryVia = err?.__via || 'ai-sdk';
     const quotaOrAuth = isQuotaOrAuthError(err);
-    const backup = (isUnreachable(err) || quotaOrAuth) ? fallbackLeg() : null;
+    const upstreamOverloaded = isUpstreamOverloaded(err);
+    const backup = (isUnreachable(err) || quotaOrAuth || upstreamOverloaded) ? fallbackLeg() : null;
     if (!backup) {
       logFailurePreview(kind, err);
       recordFailure({ kind, started: primaryStarted, via: primaryVia, model: primary.label, error: err?.message, extra: failExtra(err) });
       throw err;
     }
-    const reason = quotaOrAuth ? 'refused (quota/auth)' : 'unreachable';
+    const reason = quotaOrAuth ? 'refused (quota/auth)' : upstreamOverloaded ? 'upstream overloaded' : 'unreachable';
     const detail = err?.statusCode || err?.cause?.statusCode || err?.code || err?.cause?.code || err?.name || 'unknown';
     console.log(`[${kind}] primary LLM (${primary.label}) ${reason} (${detail}) — failing over to ${backup.label}`);
     recordFailure({ kind, started: primaryStarted, via: `${primaryVia}:failover→${backup.label}`, model: primary.label, error: err?.message, extra: failExtra(err) });

--- a/controller/src/llm/internal/core/pure.ts
+++ b/controller/src/llm/internal/core/pure.ts
@@ -78,12 +78,14 @@ export function budgetMode(
 // Transient vs unreachable error classification
 // ---------------------------------------------------------------------------
 //
-// Three classifiers gate two different recovery mechanisms:
-//   isTransient        → withTransientRetry retries on the SAME leg (5xx / plain 429 / socket).
-//   isUnreachable      → withFailover switches to the BACKUP leg (host is DOWN).
-//   isQuotaOrAuthError → withFailover switches to the BACKUP leg (host UP but
-//                        refusing this leg: quota/usage-limit/billing 429, or
-//                        an auth failure — retrying the same model is futile).
+// Four classifiers gate two different recovery mechanisms:
+//   isTransient         → withTransientRetry retries on the SAME leg (5xx / plain 429 / socket).
+//   isUnreachable       → withFailover switches to the BACKUP leg (host is DOWN).
+//   isQuotaOrAuthError  → withFailover switches to the BACKUP leg (host UP but
+//                         refusing this leg: quota/usage-limit/billing 429, or
+//                         an auth failure — retrying the same model is futile).
+//   isUpstreamOverloaded→ withFailover switches to the BACKUP leg (a reachable
+//                         gateway relayed a saturated upstream — see below).
 // isUnreachable is a strict subset of isTransient: it EXCLUDES 408/425/429/5xx,
 // because a host that answers with a status is reachable — those stay with
 // transient retry on the configured model rather than being masked by a silent
@@ -92,6 +94,15 @@ export function budgetMode(
 // recover this call, so it is pulled OUT of the transient set and fails over
 // instead of pointlessly retrying a dead leg (issue #438 — Ollama Cloud's
 // "weekly usage limit" 429s looped on the exhausted leg and never failed over).
+//
+// isUpstreamOverloaded is the inverse-shaped sibling: it is ADDED to the
+// failover set but deliberately LEFT IN the transient set. An OpenRouter
+// "Upstream error from <provider>: ResourceExhausted" (issue #671) or an
+// Anthropic 529 "Overloaded" means the chosen model/route is saturated right
+// now — which, unlike a quota cap, CAN clear in a second. So withTransientRetry
+// gets first crack on the chosen model (honouring #320); only when the overload
+// persists past that budget does withFailover try the configured fallback model,
+// instead of the call dying on the saturated route having never tried the backup.
 
 const TRANSIENT_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
 const TRANSIENT_CODE = new Set([
@@ -166,6 +177,31 @@ export function isQuotaOrAuthError(err: any): boolean {
   if (AUTH_RE.test(msg)) return true;
   if (QUOTA_RE.test(msg)) return true;
   return false;
+}
+
+// A reachable gateway relayed a saturated upstream: the host answered, but the
+// model/route it fronts is at capacity right now. OpenRouter surfaces this as
+// "Upstream error from <provider>: ResourceExhausted: Worker local total
+// request limit reached (32/32)" (issue #671); Anthropic as a 529 "Overloaded";
+// Vertex/gRPC as RESOURCE_EXHAUSTED. Unlike a quota cap this is NOT the user's
+// account being out of credit (so it is NOT isQuotaOrAuthError) and the host is
+// UP (so it is NOT isUnreachable) — it is a transient capacity blip that CAN
+// clear on a retry. So it deliberately STAYS in the transient set
+// (withTransientRetry gets first crack on the chosen model); withFailover then
+// adds it as a failover trigger, so a persistent overload finally tries the
+// configured fallback model rather than dying on the saturated route. Matched
+// by message because the signal is in the relayed text, plus Anthropic's 529.
+// Kept tight to avoid stealing plain rate-limit 429s (which should stay same-leg
+// transient retries): only an explicit upstream/overload/exhausted phrase or a
+// 529 qualifies — a bare 503 or "rate limit exceeded, slow down" does not.
+const UPSTREAM_OVERLOAD_RE = /upstream error|resource[ _]?exhausted|overloaded|no instances?\b.*\bavailable|worker local total request limit/i;
+
+export function isUpstreamOverloaded(err: any): boolean {
+  if (!err) return false;
+  const status = err.statusCode ?? err.status ?? err.cause?.statusCode ?? err.cause?.status;
+  if (status === 529) return true; // Anthropic "Overloaded" — outside TRANSIENT_STATUS
+  const msg = String(err.message || err.cause?.message || '');
+  return UPSTREAM_OVERLOAD_RE.test(msg);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #671.

## Problem

When a reachable LLM gateway relays a saturated upstream, the host answers, so the error matched neither `isUnreachable` nor `isQuotaOrAuthError`. It fell through as a plain transient 429/5xx: `withTransientRetry` burned its same-leg retries on the still-saturated route and the call died there, never reaching the configured fallback model.

Reporter's example (OpenRouter):
> `Upstream error from Nvidia: ResourceExhausted: Worker local total request limit reached (32/32)`

## Fix

Add an `isUpstreamOverloaded` classifier (`pure.ts`) and wire it into the `withFailover` backup gate (`failover.ts`). It catches OpenRouter's `Upstream error from <provider>: ResourceExhausted`, Anthropic's 529 `Overloaded`, gRPC `RESOURCE_EXHAUSTED`, and `no instances available`, by relayed message text plus the 529 status (with `cause` unwrapping).

### Design note

Unlike a quota cap (#438, which is pulled **out** of the transient set), an overload **can** clear on a retry, so it deliberately **stays** transient:

- `withTransientRetry` still gets first crack on the chosen model (honouring #320's "don't mask a brief blip with a silent model switch").
- Only a *persistent* overload escalates to the fallback leg.
- The regex is kept tight so plain rate-limit 429s keep their same-leg retries.
- No regression for users without a fallback configured: they keep the existing retries, then the error propagates as before.

## Verification

- `npm run test:llm` — new cases cover the reporter's exact OpenRouter shape, 529, gRPC, `cause` unwrapping, and negatives (bare 503 / plain rate-limit / socket do not false-trigger).
- `npm test` (full controller suite) — all pass.
- `npm run lint` (`eslint . && tsc --noEmit`) — 0 errors.

3 files, +83/-15.