### PR TITLE
fix(tts): run Chatterbox on RTX 50-series (Blackwell) GPUs

### DIFF
--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -227,6 +227,10 @@ services:
         # and layer on docker-compose.tts-heavy-gpu.yml (device reservation +
         # TTS_HEAVY_DEVICE=cuda). Source build only. See docs/gpu-tts.md.
         CHATTERBOX_TORCH_INDEX_URL: \${CHATTERBOX_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}
+        # RTX 50-series (Blackwell) only: chatterbox-tts pins torch==2.6.0, which
+        # has no sm_120 kernels. Set a newer spec to override the pin, paired with
+        # a cu128 index above, e.g. CHATTERBOX_TORCH_SPEC="torch==2.9.1 torchaudio==2.9.1".
+        CHATTERBOX_TORCH_SPEC: \${CHATTERBOX_TORCH_SPEC:-}
     # amd64-only image (heavy PyTorch stack); pinned so it runs under emulation
     # on arm64 hosts. The other services are multi-arch and auto-select.
     platform: linux/amd64
@@ -456,6 +460,10 @@ services:
         # layer on docker-compose.tts-heavy-gpu.yml. Defaults to CPU wheels.
         # Source build only. See docs/gpu-tts.md.
         CHATTERBOX_TORCH_INDEX_URL: \${CHATTERBOX_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}
+        # RTX 50-series (Blackwell) only: override chatterbox-tts's torch==2.6.0
+        # pin (no sm_120 kernels) with a newer spec + a cu128 index above, e.g.
+        # CHATTERBOX_TORCH_SPEC="torch==2.9.1 torchaudio==2.9.1". See docs/gpu-tts.md.
+        CHATTERBOX_TORCH_SPEC: \${CHATTERBOX_TORCH_SPEC:-}
     # amd64-only image (heavy PyTorch stack); pinned so it runs under emulation
     # on arm64 hosts. The other services are multi-arch and auto-select.
     platform: linux/amd64
@@ -653,6 +661,10 @@ services:
         # layer on docker-compose.tts-heavy-gpu.yml. Defaults to CPU wheels.
         # Source build only. See docs/gpu-tts.md.
         CHATTERBOX_TORCH_INDEX_URL: \${CHATTERBOX_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}
+        # RTX 50-series (Blackwell) only: override chatterbox-tts's torch==2.6.0
+        # pin (no sm_120 kernels) with a newer spec + a cu128 index above, e.g.
+        # CHATTERBOX_TORCH_SPEC="torch==2.9.1 torchaudio==2.9.1". See docs/gpu-tts.md.
+        CHATTERBOX_TORCH_SPEC: \${CHATTERBOX_TORCH_SPEC:-}
     platform: linux/amd64
     container_name: sub-wave-tts-heavy
     restart: unless-stopped
@@ -705,6 +717,13 @@ export const COMPOSE_TTS_HEAVY_GPU_YML = `# GPU opt-in overlay for the tts-heavy
 #
 # (BYO reverse-proxy hosts: swap docker-compose.yml for docker-compose.byo.yml.)
 #
+# RTX 50-series (Blackwell / sm_120): chatterbox-tts pins torch==2.6.0, which has
+# no sm_120 kernels, so the default cu124 build loads but 500s at synthesis. Use
+# a cu128 index AND override the pin:
+#
+#   echo 'CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128' >> .env
+#   echo 'CHATTERBOX_TORCH_SPEC=torch==2.9.1 torchaudio==2.9.1' >> .env
+#
 # Requirements: an NVIDIA GPU with the driver + NVIDIA Container Toolkit
 # installed. Pick the cuXXX wheel tag that matches your driver — see
 # https://pytorch.org/get-started/locally/. Full guide: docs/gpu-tts.md.
@@ -717,6 +736,17 @@ services:
       # CUDA isn't actually visible, so a misconfigured host degrades, not fails.
       - TTS_HEAVY_DEVICE=cuda
     # Hand the GPU into the container (needs the NVIDIA Container Toolkit).
+    #
+    # The deploy.resources reservation below is the modern (CDI) path. On hosts
+    # where the NVIDIA runtime is registered in LEGACY mode, that reservation
+    # fails with "could not select device driver nvidia"; there, delete the
+    # \`deploy:\` block and instead use the legacy runtime:
+    #
+    #   runtime: nvidia
+    #   environment:
+    #     - TTS_HEAVY_DEVICE=cuda
+    #     - NVIDIA_VISIBLE_DEVICES=all
+    #     - NVIDIA_DRIVER_CAPABILITIES=compute,utility
     deploy:
       resources:
         reservations:

--- a/controller/scripts/chatterbox_worker.py
+++ b/controller/scripts/chatterbox_worker.py
@@ -44,11 +44,44 @@ def log(msg):
 def main():
     try:
         import torch
-        import torchaudio as ta
+        import soundfile as sf
         from chatterbox.tts_turbo import ChatterboxTurboTTS
     except Exception as e:
         emit({"id": None, "ok": False, "fatal": True, "error": f"import failed: {e}"})
         sys.exit(1)
+
+    # --- torch >= 2.9 float64 guard (RTX 50-series / Blackwell) ----------------
+    # The CUDA build for newer cards (sm_120) runs chatterbox-tts — which is
+    # built against torch 2.6 — on torch >= 2.9, and 2.9 is strict about dtype
+    # mismatches. In ChatterboxTurboTTS.prepare_conditionals the reference clip
+    # is loudness-normalised by multiplying with a pyloudnorm float64 gain, which
+    # upcasts the waveform to float64; that array then flows through
+    # librosa.resample into the voice encoder as a Double tensor and trips
+    # "expected scalar type Float but found Double" (torch 2.6 silently promoted
+    # it). Coerce librosa's audio output back to float32 at the source. No-op on
+    # the CPU / older-GPU paths, where the audio is already float32.
+    try:
+        import librosa
+
+        _orig_load = librosa.load
+        _orig_resample = librosa.resample
+
+        def _load_f32(*args, **kwargs):
+            y, sr = _orig_load(*args, **kwargs)
+            if hasattr(y, "dtype") and y.dtype != "float32":
+                y = y.astype("float32")
+            return y, sr
+
+        def _resample_f32(*args, **kwargs):
+            y = _orig_resample(*args, **kwargs)
+            if hasattr(y, "dtype") and y.dtype != "float32":
+                y = y.astype("float32")
+            return y
+
+        librosa.load = _load_f32
+        librosa.resample = _resample_f32
+    except Exception as e:
+        log(f"librosa float32 guard not applied: {e}")
 
     device = DEVICE
     if device == "cuda" and not torch.cuda.is_available():
@@ -93,13 +126,24 @@ def main():
             else:
                 wav = model.generate(text)
 
-            # generate() returns a torch tensor shaped [channels, samples];
-            # torchaudio.save needs it on CPU.
+            # generate() returns a torch tensor shaped [channels, samples].
+            # Write via soundfile (libsndfile) rather than torchaudio.save:
+            # torch >= 2.8 routes torchaudio.save through torchcodec — an extra
+            # native dep that isn't in the image and whose libnvrtc mismatches
+            # the cu128 wheels on the GPU build. soundfile is already present
+            # (librosa depends on it) and writes the same WAV. It wants a numpy
+            # array shaped [samples] (mono) or [samples, channels].
+            if hasattr(wav, "detach"):
+                wav = wav.detach()
             if hasattr(wav, "cpu"):
                 wav = wav.cpu()
-            ta.save(out, wav, sample_rate)
+            samples = wav.numpy() if hasattr(wav, "numpy") else wav
+            if getattr(samples, "ndim", 1) == 2:
+                # [channels, samples] -> mono [samples] or [samples, channels]
+                samples = samples[0] if samples.shape[0] == 1 else samples.T
+            sf.write(out, samples, sample_rate)
 
-            duration = float(wav.shape[-1]) / float(sample_rate)
+            duration = float(samples.shape[0]) / float(sample_rate)
             emit({"id": req_id, "ok": True, "path": out, "duration_s": round(duration, 3)})
         except Exception as e:
             log(f"request failed: {e}\n{traceback.format_exc()}")

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -176,6 +176,10 @@ services:
         # layer on docker-compose.tts-heavy-gpu.yml. Defaults to CPU wheels.
         # Source build only. See docs/gpu-tts.md.
         CHATTERBOX_TORCH_INDEX_URL: ${CHATTERBOX_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}
+        # RTX 50-series (Blackwell) only: override chatterbox-tts's torch==2.6.0
+        # pin (no sm_120 kernels) with a newer spec + a cu128 index above, e.g.
+        # CHATTERBOX_TORCH_SPEC="torch==2.9.1 torchaudio==2.9.1". See docs/gpu-tts.md.
+        CHATTERBOX_TORCH_SPEC: ${CHATTERBOX_TORCH_SPEC:-}
     # amd64-only image (heavy PyTorch stack); pinned so it runs under emulation
     # on arm64 hosts. The other services are multi-arch and auto-select.
     platform: linux/amd64

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -155,6 +155,10 @@ services:
         # layer on docker-compose.tts-heavy-gpu.yml. Defaults to CPU wheels.
         # Source build only. See docs/gpu-tts.md.
         CHATTERBOX_TORCH_INDEX_URL: ${CHATTERBOX_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}
+        # RTX 50-series (Blackwell) only: override chatterbox-tts's torch==2.6.0
+        # pin (no sm_120 kernels) with a newer spec + a cu128 index above, e.g.
+        # CHATTERBOX_TORCH_SPEC="torch==2.9.1 torchaudio==2.9.1". See docs/gpu-tts.md.
+        CHATTERBOX_TORCH_SPEC: ${CHATTERBOX_TORCH_SPEC:-}
     platform: linux/amd64
     container_name: sub-wave-tts-heavy
     restart: unless-stopped

--- a/docker-compose.tts-heavy-gpu.yml
+++ b/docker-compose.tts-heavy-gpu.yml
@@ -14,6 +14,13 @@
 #
 # (BYO reverse-proxy hosts: swap docker-compose.yml for docker-compose.byo.yml.)
 #
+# RTX 50-series (Blackwell / sm_120): chatterbox-tts pins torch==2.6.0, which has
+# no sm_120 kernels, so the default cu124 build loads but 500s at synthesis. Use
+# a cu128 index AND override the pin:
+#
+#   echo 'CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128' >> .env
+#   echo 'CHATTERBOX_TORCH_SPEC=torch==2.9.1 torchaudio==2.9.1' >> .env
+#
 # Requirements: an NVIDIA GPU with the driver + NVIDIA Container Toolkit
 # installed. Pick the cuXXX wheel tag that matches your driver — see
 # https://pytorch.org/get-started/locally/. Full guide: docs/gpu-tts.md.
@@ -26,6 +33,17 @@ services:
       # CUDA isn't actually visible, so a misconfigured host degrades, not fails.
       - TTS_HEAVY_DEVICE=cuda
     # Hand the GPU into the container (needs the NVIDIA Container Toolkit).
+    #
+    # The deploy.resources reservation below is the modern (CDI) path. On hosts
+    # where the NVIDIA runtime is registered in LEGACY mode, that reservation
+    # fails with "could not select device driver nvidia"; there, delete the
+    # `deploy:` block and instead use the legacy runtime:
+    #
+    #   runtime: nvidia
+    #   environment:
+    #     - TTS_HEAVY_DEVICE=cuda
+    #     - NVIDIA_VISIBLE_DEVICES=all
+    #     - NVIDIA_DRIVER_CAPABILITIES=compute,utility
     deploy:
       resources:
         reservations:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -218,6 +218,10 @@ services:
         # and layer on docker-compose.tts-heavy-gpu.yml (device reservation +
         # TTS_HEAVY_DEVICE=cuda). Source build only. See docs/gpu-tts.md.
         CHATTERBOX_TORCH_INDEX_URL: ${CHATTERBOX_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}
+        # RTX 50-series (Blackwell) only: chatterbox-tts pins torch==2.6.0, which
+        # has no sm_120 kernels. Set a newer spec to override the pin, paired with
+        # a cu128 index above, e.g. CHATTERBOX_TORCH_SPEC="torch==2.9.1 torchaudio==2.9.1".
+        CHATTERBOX_TORCH_SPEC: ${CHATTERBOX_TORCH_SPEC:-}
     # amd64-only image (heavy PyTorch stack); pinned so it runs under emulation
     # on arm64 hosts. The other services are multi-arch and auto-select.
     platform: linux/amd64

--- a/docker/Dockerfile.controller
+++ b/docker/Dockerfile.controller
@@ -76,6 +76,14 @@ ENV KOKORO_MODEL=/opt/kokoro/models/kokoro-v1.0.onnx \
 ENV HF_HOME=/opt/chatterbox/hf-cache
 ARG WITH_CHATTERBOX=0
 ARG CHATTERBOX_PIP_PKG=chatterbox-tts
+# GPU opt-in, mirroring docker/Dockerfile.tts-heavy. Defaults keep the CPU-only
+# build. Point CHATTERBOX_TORCH_INDEX_URL at a cuXXX wheel index, and for
+# RTX 50-series (Blackwell) also set CHATTERBOX_TORCH_SPEC to a newer torch
+# (e.g. "torch==2.9.1 torchaudio==2.9.1") to override chatterbox's ==2.6.0 pin.
+# The in-process route still needs a GPU device reservation on the controller
+# service itself — see docs/gpu-tts.md.
+ARG CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
+ARG CHATTERBOX_TORCH_SPEC=
 # Image size: the default PyPI `torch` wheel is the CUDA build, which drags in
 # ~3.6GB of NVIDIA libraries (nvidia-*, triton, cusparselt) that are dead weight
 # on a CPU-only station. torch + torchaudio + chatterbox-tts are therefore all
@@ -87,13 +95,20 @@ ARG CHATTERBOX_PIP_PKG=chatterbox-tts
 # second resolve sees only PyPI and re-pulls the CUDA torch. The final cleanup
 # strips compiled bytecode and torch's C++ headers/test suite (unused at runtime).
 RUN if [ "$WITH_CHATTERBOX" = "1" ]; then \
-      echo "Bundling Chatterbox Turbo (PyTorch, CPU-only) — adds ~3-4GB to the image" && \
+      echo "Bundling Chatterbox Turbo (PyTorch) — adds ~3-4GB to the image" && \
       python3 -m venv /opt/chatterbox/venv && \
       /opt/chatterbox/venv/bin/pip install --no-cache-dir --upgrade pip && \
       /opt/chatterbox/venv/bin/pip install --no-cache-dir \
-        --index-url https://download.pytorch.org/whl/cpu \
+        --index-url ${CHATTERBOX_TORCH_INDEX_URL} \
         --extra-index-url https://pypi.org/simple \
         torch torchaudio "${CHATTERBOX_PIP_PKG}" && \
+      if [ -n "${CHATTERBOX_TORCH_SPEC}" ]; then \
+        echo "Overriding chatterbox torch pin with: ${CHATTERBOX_TORCH_SPEC}" && \
+        /opt/chatterbox/venv/bin/pip install --no-cache-dir --force-reinstall \
+          --index-url ${CHATTERBOX_TORCH_INDEX_URL} \
+          --extra-index-url https://pypi.org/simple \
+          ${CHATTERBOX_TORCH_SPEC} ; \
+      fi && \
       /opt/chatterbox/venv/bin/python -c \
         "from chatterbox.tts_turbo import ChatterboxTurboTTS; ChatterboxTurboTTS.from_pretrained(device='cpu')" && \
       find /opt/chatterbox/venv -depth -type d -name __pycache__ -exec rm -rf {} + && \

--- a/docker/Dockerfile.tts-heavy
+++ b/docker/Dockerfile.tts-heavy
@@ -79,6 +79,18 @@ ENV CHATTERBOX_HF_HOME=/opt/chatterbox/hf-cache
 # the Chatterbox venv on purpose: PocketTTS (fast on CPU) and the analyzer don't
 # benefit and CUDA torch would add several GB to each. See docs/gpu-tts.md.
 ARG CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
+# Override the torch/torchaudio that chatterbox-tts pins (==2.6.0). Leave empty
+# to honour the pin — correct for CPU and for CUDA cards up to sm_90 (RTX 40xx
+# and older). RTX 50-series (Blackwell, sm_120) needs newer kernels than 2.6.0
+# ships, so its inference dies with "no kernel image is available"; and pip
+# cannot bump torch past chatterbox's exact pin in one resolve, even with a cu128
+# index. Set this to a Blackwell-capable spec (e.g. "torch==2.9.1
+# torchaudio==2.9.1") together with a cu128 CHATTERBOX_TORCH_INDEX_URL. It is
+# reinstalled OVER chatterbox's deps (which stay intact) WITH deps, so the
+# matching nvidia-* runtime libs come along — avoiding a --no-deps hand-install
+# of the whole tree. The worker carries the torch-2.9 float32 shim. See
+# docs/gpu-tts.md.
+ARG CHATTERBOX_TORCH_SPEC=
 RUN python3 -m venv /opt/chatterbox/venv && \
     /opt/chatterbox/venv/bin/pip install --no-cache-dir --upgrade pip "setuptools<81" wheel && \
     /opt/chatterbox/venv/bin/pip install --no-cache-dir numpy Cython && \
@@ -86,6 +98,13 @@ RUN python3 -m venv /opt/chatterbox/venv && \
       --index-url ${CHATTERBOX_TORCH_INDEX_URL} \
       --extra-index-url https://pypi.org/simple \
       torch torchaudio onnxruntime chatterbox-tts && \
+    if [ -n "${CHATTERBOX_TORCH_SPEC}" ]; then \
+      echo "Overriding chatterbox torch pin with: ${CHATTERBOX_TORCH_SPEC}" && \
+      /opt/chatterbox/venv/bin/pip install --no-cache-dir --force-reinstall \
+        --index-url ${CHATTERBOX_TORCH_INDEX_URL} \
+        --extra-index-url https://pypi.org/simple \
+        ${CHATTERBOX_TORCH_SPEC} ; \
+    fi && \
     /opt/chatterbox/venv/bin/python -c \
       "from chatterbox.tts_turbo import ChatterboxTurboTTS" && \
     find /opt/chatterbox/venv -depth -type d -name __pycache__ -exec rm -rf {} + && \

--- a/docs/gpu-tts.md
+++ b/docs/gpu-tts.md
@@ -133,6 +133,29 @@ echo 'CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cu124' >> .env
 This is scoped to the Chatterbox venv. PocketTTS and the analyzer stay on CPU
 wheels, so the image only grows by the one CUDA torch it actually needs.
 
+#### RTX 50-series (Blackwell / sm_120)
+
+The index swap alone is **not enough** on a 50-series card. `chatterbox-tts`
+hard-pins `torch==2.6.0`, whose CUDA kernels stop at sm_90 — so on Blackwell the
+model loads but every synthesis fails with `CUDA error: no kernel image is
+available`, surfacing as a 500 from the sidecar. pip won't bump torch past that
+exact pin in a single resolve, even with a cu128 index. Set **both** a cu128
+index and a newer torch spec to override the pin:
+
+```bash
+echo 'CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128' >> .env
+echo 'CHATTERBOX_TORCH_SPEC=torch==2.9.1 torchaudio==2.9.1' >> .env
+```
+
+`CHATTERBOX_TORCH_SPEC` is reinstalled over chatterbox's deps (kept intact) once
+the normal install finishes, so the matching `nvidia-*` cu128 runtime libs come
+with it. The worker (`chatterbox_worker.py`) carries the two shims torch 2.9
+needs against a 2.6-era chatterbox: it writes WAVs via `soundfile` instead of
+`torchaudio.save` (which on torch ≥ 2.8 wants the absent `torchcodec`), and it
+coerces librosa's audio output back to `float32` (2.9 rejects the `float64` that
+chatterbox's loudness-normalisation introduces). Both are no-ops on CPU and on
+older cards.
+
 ### 2. Build + start with the GPU overlay
 
 Layer `docker-compose.tts-heavy-gpu.yml` on top of your prod compose file. The
@@ -160,10 +183,16 @@ Voice cloning works exactly as on CPU: drop a reference WAV into
 page in the in-app manual for the cloning workflow).
 
 > The overlay only covers the sidecar. The legacy in-process build
-> (`--build-arg WITH_CHATTERBOX=1` in `docker/Dockerfile.controller`) still
-> installs CPU PyTorch and has no equivalent build arg yet, so running *that*
-> variant on a GPU needs a manual torch-index swap there plus a device
-> reservation on the `controller` service.
+> (`--build-arg WITH_CHATTERBOX=1` in `docker/Dockerfile.controller`) honours the
+> same `CHATTERBOX_TORCH_INDEX_URL` / `CHATTERBOX_TORCH_SPEC` build args, but has
+> no compose overlay — running *that* variant on a GPU means passing those build
+> args yourself plus adding a device reservation on the `controller` service.
+
+> **Legacy NVIDIA runtime?** If `docker compose up` fails the device reservation
+> with *"could not select device driver nvidia"*, your host registers the NVIDIA
+> runtime in legacy mode. Drop the overlay's `deploy:` block and use
+> `runtime: nvidia` with `NVIDIA_VISIBLE_DEVICES=all` instead — the overlay
+> comments spell out the swap.
 
 ---
 


### PR DESCRIPTION
## Why

A Discord report: following the **Chatterbox-on-GPU** guide on an RTX 5070 Ti, the `tts-heavy` sidecar builds and loads the model but every synthesis 500s. Root cause confirmed against PyPI: `chatterbox-tts` 0.1.7 hard-pins `torch==2.6.0`, whose CUDA kernels stop at **sm_90**. On Blackwell (**sm_120**) inference dies with `CUDA error: no kernel image is available`, and pip won't bump torch past that exact pin in a single resolve — even with a cu128 index. Our entire native-GPU route therefore worked for RTX 40-series and older but could never work on 50-series.

## What

Four chained fixes, smallest blast radius first. All GPU paths stay opt-in; CPU and ≤sm_90 builds are unchanged.

- **Configurable torch override (the unblock).** New `CHATTERBOX_TORCH_SPEC` build arg in `Dockerfile.tts-heavy` and `Dockerfile.controller`. When set, a newer torch/torchaudio is force-reinstalled **over** chatterbox's deps (kept intact) **with** deps, so the matching `nvidia-*` cu128 runtime libs come along — avoiding a `--no-deps` hand-install of the whole tree. Empty by default. The controller block also gains `CHATTERBOX_TORCH_INDEX_URL` for parity. Surfaced as a build arg in all three compose files.
- **`torchaudio.save` → `soundfile`** in `chatterbox_worker.py`. torch ≥2.8 routes `torchaudio.save` through `torchcodec`, an extra native dep that isn't in the image and whose libnvrtc mismatches the cu128 wheels. `soundfile` is already present (librosa depends on it) and writes the same WAV. Better on every path, not just GPU.
- **float32 guard** in `chatterbox_worker.py`. Reading the `chatterbox-tts` 0.1.7 source showed the float64 originates in `prepare_conditionals`' loudness-normalisation (a pyloudnorm float64 gain), which rides `librosa.resample` into the voice encoder as a Double tensor — torch 2.9 rejects it, 2.6 silently promoted it. Coerce librosa's audio output back to float32 at the source. No-op on CPU/older cards.
- **Legacy NVIDIA runtime fallback.** On hosts where the runtime is registered in legacy mode, the `deploy.resources` reservation fails; documented the `runtime: nvidia` + `NVIDIA_VISIBLE_DEVICES` swap in the GPU overlay and `docs/gpu-tts.md`, alongside the full Blackwell recipe.

## 50-series recipe

```bash
echo 'CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128' >> .env
echo 'CHATTERBOX_TORCH_SPEC=torch==2.9.1 torchaudio==2.9.1' >> .env
docker compose -f docker-compose.yml -f docker-compose.tts-heavy-gpu.yml \
  --profile tts-heavy up -d --build
```

## Verified

- `chatterbox-tts==0.1.7` torch/librosa pins, against PyPI.
- The true float64 origin, by reading the downloaded `tts_turbo.py` + `s3gen.py`.
- Worker compiles (`py_compile`); all four compose files parse; CLI assets re-embedded (`cli-assets-check` will pass). Lint gate (controller/web) untouched by these files.

## Not verified

No Blackwell card / CUDA torch in the dev environment, so **the CUDA image build and on-GPU synthesis are untested here**. The reporter got an equivalent fix set working on a 5070 Ti.
