### PR TITLE
feat(scrobble): in-admin "Connect to Last.fm", drop the CLI session-key step

### DIFF
--- a/controller/src/broadcast/scrobble.ts
+++ b/controller/src/broadcast/scrobble.ts
@@ -108,7 +108,16 @@ function signLastfm(params: Record<string, string>, secret: string): string {
   return createHash('md5').update(sigStr, 'utf8').digest('hex');
 }
 
-async function callLastfm(method: string, baseParams: Record<string, string>, creds: LastfmCreds): Promise<void> {
+// Outcome of a single Last.fm/ListenBrainz call. `ok:false` carries a one-line
+// reason. The fire-and-forget callers (onTrackEvent) ignore this; only the
+// admin Test button inspects it — for years it couldn't, because this swallowed
+// every failure and always read as success.
+interface CallResult {
+  ok: boolean;
+  message?: string;
+}
+
+async function callLastfm(method: string, baseParams: Record<string, string>, creds: LastfmCreds): Promise<CallResult> {
   const params: Record<string, string> = {
     ...baseParams,
     method,
@@ -134,20 +143,26 @@ async function callLastfm(method: string, baseParams: Record<string, string>, cr
     if (!r.ok) {
       let detail = '';
       try { detail = (await r.text()).slice(0, 200); } catch {}
-      console.warn(`[scrobble] last.fm ${method} → ${r.status}${detail ? ` — ${detail}` : ''}`);
-      return;
+      const message = `HTTP ${r.status}${detail ? ` — ${detail}` : ''}`;
+      console.warn(`[scrobble] last.fm ${method} → ${message}`);
+      return { ok: false, message };
     }
     // 200 doesn't guarantee success — Last.fm embeds a JSON `error` field.
     try {
       const data = (await r.json()) as any;
       if (data?.error) {
-        console.warn(`[scrobble] last.fm ${method} error ${data.error}: ${data.message || ''}`);
+        const message = `error ${data.error}: ${data.message || ''}`.trim();
+        console.warn(`[scrobble] last.fm ${method} ${message}`);
+        return { ok: false, message };
       }
     } catch {
       // Non-JSON body on 200 — treat as success.
     }
+    return { ok: true };
   } catch (err: any) {
-    console.warn(`[scrobble] last.fm ${method} failed: ${err?.message || err}`);
+    const message = err?.name === 'AbortError' ? 'request timed out' : (err?.message || String(err));
+    console.warn(`[scrobble] last.fm ${method} failed: ${message}`);
+    return { ok: false, message };
   } finally {
     clearTimeout(timer);
   }
@@ -164,27 +179,96 @@ function lastfmTrackParams(track: ScrobbleTrack): Record<string, string> {
   return p;
 }
 
-async function lastfmUpdateNowPlaying(track: ScrobbleTrack, creds: LastfmCreds): Promise<void> {
-  await callLastfm('track.updateNowPlaying', lastfmTrackParams(track), creds);
+async function lastfmUpdateNowPlaying(track: ScrobbleTrack, creds: LastfmCreds): Promise<CallResult> {
+  return callLastfm('track.updateNowPlaying', lastfmTrackParams(track), creds);
 }
 
 async function lastfmScrobble(
   track: ScrobbleTrack,
   startedAt: string,
   creds: LastfmCreds,
-): Promise<void> {
+): Promise<CallResult> {
   const ts = Math.floor(Date.parse(startedAt) / 1000);
-  if (!Number.isFinite(ts)) return;
-  await callLastfm(
+  if (!Number.isFinite(ts)) return { ok: false, message: 'invalid start timestamp' };
+  return callLastfm(
     'track.scrobble',
     { ...lastfmTrackParams(track), timestamp: String(ts) },
     creds,
   );
 }
 
+// ── Last.fm web-auth flow (admin "Connect to Last.fm") ───────────────────────
+//
+// Replaces the CLI `npm run lastfm-session` dance with a two-step handshake the
+// admin UI drives: getAuthToken → operator authorizes in the browser →
+// completeAuth trades the token for a long-lived session key. Uses the SAME
+// env-wins api-key/secret resolution as scrobble time, so the session key it
+// mints is bound to the exact api key scrobbling will use (no mismatch).
+
+// Just the api key + secret — no session key yet, no `enabled` gate (the whole
+// point of the flow is to obtain the missing session key).
+function lastfmApiCreds(): { apiKey: string; apiSecret: string } | null {
+  const s: any = settings.get()?.scrobble?.lastfm || {};
+  const apiKey = process.env.LASTFM_API_KEY || s.apiKey || '';
+  const apiSecret = process.env.LASTFM_API_SECRET || s.apiSecret || '';
+  if (!apiKey || !apiSecret) return null;
+  return { apiKey, apiSecret };
+}
+
+// Signed GET to a Last.fm auth method. Unlike the write calls these are reads
+// whose body we need, so this THROWS on any failure for the route to surface.
+async function callLastfmAuth(
+  method: string,
+  extra: Record<string, string>,
+  creds: { apiKey: string; apiSecret: string },
+): Promise<any> {
+  const params: Record<string, string> = { api_key: creds.apiKey, method, ...extra };
+  params.api_sig = signLastfm(params, creds.apiSecret);
+  params.format = 'json';
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const r = await fetch(`${LASTFM_API}?${new URLSearchParams(params)}`, {
+      headers: { 'User-Agent': 'sub-wave/scrobble' },
+      signal: ctrl.signal,
+    });
+    const data: any = await r.json().catch(() => ({}));
+    if (!r.ok || data?.error) {
+      throw new Error(data?.message || `Last.fm ${method} failed (HTTP ${r.status})`);
+    }
+    return data;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Step 1: mint a request token + the URL the operator visits to grant access.
+export async function lastfmGetAuthToken(): Promise<{ token: string; authUrl: string }> {
+  const creds = lastfmApiCreds();
+  if (!creds) throw new Error('Save your Last.fm API key and secret first');
+  const data = await callLastfmAuth('auth.getToken', {}, creds);
+  const token: string = data?.token;
+  if (!token) throw new Error('Last.fm did not return an auth token');
+  const authUrl = `https://www.last.fm/api/auth/?api_key=${encodeURIComponent(creds.apiKey)}&token=${encodeURIComponent(token)}`;
+  return { token, authUrl };
+}
+
+// Step 2: after the operator authorizes, trade the token for a session key
+// (long-lived, never expires) and the username it belongs to.
+export async function lastfmCompleteAuth(token: string): Promise<{ sessionKey: string; username: string }> {
+  const creds = lastfmApiCreds();
+  if (!creds) throw new Error('Save your Last.fm API key and secret first');
+  if (!token || !token.trim()) throw new Error('Missing auth token');
+  const data = await callLastfmAuth('auth.getSession', { token: token.trim() }, creds);
+  const sessionKey: string = data?.session?.key;
+  const username: string = data?.session?.name || '';
+  if (!sessionKey) throw new Error('Last.fm returned no session key — was access granted?');
+  return { sessionKey, username };
+}
+
 // ── ListenBrainz client ─────────────────────────────────────────────────────
 
-async function postListenbrainz(payload: Record<string, unknown>, token: string, label: string): Promise<void> {
+async function postListenbrainz(payload: Record<string, unknown>, token: string, label: string): Promise<CallResult> {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
   try {
@@ -201,10 +285,15 @@ async function postListenbrainz(payload: Record<string, unknown>, token: string,
     if (!r.ok) {
       let detail = '';
       try { detail = (await r.text()).slice(0, 200); } catch {}
-      console.warn(`[scrobble] listenbrainz ${label} → ${r.status}${detail ? ` — ${detail}` : ''}`);
+      const message = `HTTP ${r.status}${detail ? ` — ${detail}` : ''}`;
+      console.warn(`[scrobble] listenbrainz ${label} → ${message}`);
+      return { ok: false, message };
     }
+    return { ok: true };
   } catch (err: any) {
-    console.warn(`[scrobble] listenbrainz ${label} failed: ${err?.message || err}`);
+    const message = err?.name === 'AbortError' ? 'request timed out' : (err?.message || String(err));
+    console.warn(`[scrobble] listenbrainz ${label} failed: ${message}`);
+    return { ok: false, message };
   } finally {
     clearTimeout(timer);
   }
@@ -225,8 +314,8 @@ function listenbrainzTrackMetadata(track: ScrobbleTrack): Record<string, unknown
   return md;
 }
 
-async function listenbrainzPlayingNow(track: ScrobbleTrack, token: string): Promise<void> {
-  await postListenbrainz(
+async function listenbrainzPlayingNow(track: ScrobbleTrack, token: string): Promise<CallResult> {
+  return postListenbrainz(
     {
       listen_type: 'playing_now',
       payload: [{ track_metadata: listenbrainzTrackMetadata(track) }],
@@ -236,10 +325,10 @@ async function listenbrainzPlayingNow(track: ScrobbleTrack, token: string): Prom
   );
 }
 
-async function listenbrainzSubmit(track: ScrobbleTrack, startedAt: string, token: string): Promise<void> {
+async function listenbrainzSubmit(track: ScrobbleTrack, startedAt: string, token: string): Promise<CallResult> {
   const ts = Math.floor(Date.parse(startedAt) / 1000);
-  if (!Number.isFinite(ts)) return;
-  await postListenbrainz(
+  if (!Number.isFinite(ts)) return { ok: false, message: 'invalid start timestamp' };
+  return postListenbrainz(
     {
       listen_type: 'single',
       payload: [
@@ -320,22 +409,18 @@ export async function testNowPlaying(
   if (provider === 'lastfm') {
     const creds = lastfmCreds();
     if (!creds) return { ok: false, message: 'last.fm not enabled or missing credentials' };
-    try {
-      await lastfmUpdateNowPlaying(track, creds);
-      return { ok: true, message: `sent now-playing to last.fm for "${track.title}"` };
-    } catch (err: any) {
-      return { ok: false, message: err?.message || 'last.fm test failed' };
-    }
+    const res = await lastfmUpdateNowPlaying(track, creds);
+    return res.ok
+      ? { ok: true, message: `sent now-playing to last.fm for "${track.title}"` }
+      : { ok: false, message: `last.fm rejected it — ${res.message || 'unknown error'}` };
   }
   if (provider === 'listenbrainz') {
     const token = listenbrainzToken();
     if (!token) return { ok: false, message: 'listenbrainz not enabled or missing user token' };
-    try {
-      await listenbrainzPlayingNow(track, token);
-      return { ok: true, message: `sent playing_now to listenbrainz for "${track.title}"` };
-    } catch (err: any) {
-      return { ok: false, message: err?.message || 'listenbrainz test failed' };
-    }
+    const res = await listenbrainzPlayingNow(track, token);
+    return res.ok
+      ? { ok: true, message: `sent playing_now to listenbrainz for "${track.title}"` }
+      : { ok: false, message: `listenbrainz rejected it — ${res.message || 'unknown error'}` };
   }
   return { ok: false, message: `unknown provider "${provider}"` };
 }

--- a/controller/src/routes/scrobble.ts
+++ b/controller/src/routes/scrobble.ts
@@ -1,13 +1,21 @@
-// Admin-gated scrobble test endpoint.
+// Admin-gated scrobble endpoints.
 //
 // The scrobble fan-out itself lives in broadcast/scrobble.ts and consumes
-// track events from broadcast/queue.ts. This route only exposes the "Test"
-// button in /admin/settings → Scrobbling: fires a now-playing ping at the
-// requested backend using the currently-playing track, reports the result.
+// track events from broadcast/queue.ts. This route exposes the admin surface:
+//   - the "Test" button (now-playing ping at a backend, reports the result)
+//   - the "Connect to Last.fm" flow (auth.getToken → operator authorizes →
+//     auth.getSession), which replaces the CLI `npm run lastfm-session` dance
+//     and persists the minted session key straight into settings.
 import express from 'express';
 import { requireAdmin } from '../middleware/auth.js';
 import { queue } from '../broadcast/queue.js';
-import { testNowPlaying, type ScrobbleProvider } from '../broadcast/scrobble.js';
+import * as settings from '../settings.js';
+import {
+  testNowPlaying,
+  lastfmGetAuthToken,
+  lastfmCompleteAuth,
+  type ScrobbleProvider,
+} from '../broadcast/scrobble.js';
 
 export const router = express.Router();
 
@@ -37,5 +45,29 @@ router.post('/scrobble/test', requireAdmin, async (req, res) => {
     res.json(result);
   } catch (err: any) {
     res.status(500).json({ ok: false, message: err?.message || 'test failed' });
+  }
+});
+
+// Step 1 of "Connect to Last.fm": mint a request token and return the URL the
+// operator opens to grant access. Needs the API key + secret already set.
+router.post('/scrobble/lastfm/connect', requireAdmin, async (_req, res) => {
+  try {
+    const { token, authUrl } = await lastfmGetAuthToken();
+    res.json({ ok: true, token, authUrl });
+  } catch (err: any) {
+    res.status(400).json({ ok: false, message: err?.message || 'could not start Last.fm authorization' });
+  }
+});
+
+// Step 2: after the operator authorizes in the browser, trade the token for a
+// session key, persist it, and switch scrobbling on — no CLI, no copy-paste.
+router.post('/scrobble/lastfm/complete', requireAdmin, async (req, res) => {
+  const token = typeof req.body?.token === 'string' ? req.body.token : '';
+  try {
+    const { sessionKey, username } = await lastfmCompleteAuth(token);
+    await settings.update({ scrobble: { lastfm: { sessionKey, username, enabled: true } } });
+    res.json({ ok: true, username });
+  } catch (err: any) {
+    res.status(400).json({ ok: false, message: err?.message || 'could not complete Last.fm authorization' });
   }
 });

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -789,7 +789,7 @@ export default function SettingsPanel() {
             {activeSection === 'scrobble' && (
               <ScrobbleSection
                 data={data} form={form} setForm={updateForm} busy={busy}
-                saveSettings={saveSettings} adminFetch={adminFetch}
+                saveSettings={saveSettings} adminFetch={adminFetch} refresh={refresh}
               />
             )}
           </>
@@ -5175,9 +5175,10 @@ function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uploadSfx, 
 
 interface ScrobbleSectionProps extends SectionProps {
   adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+  refresh: () => void;
 }
 
-function ScrobbleSection({ data, form, setForm, busy, saveSettings, adminFetch }: ScrobbleSectionProps) {
+function ScrobbleSection({ data, form, setForm, busy, saveSettings, adminFetch, refresh }: ScrobbleSectionProps) {
   const lf = form.scrobble.lastfm;
   const lb = form.scrobble.listenbrainz;
   const savedLf = data.values?.scrobble?.lastfm || {};
@@ -5196,6 +5197,12 @@ function ScrobbleSection({ data, form, setForm, busy, saveSettings, adminFetch }
   const lbTokenSet = lb.userToken === 'set' || !!env.LISTENBRAINZ_USER_TOKEN;
   const lfReady = lf.enabled && lfApiKeySet && lfApiSecretSet && lfSessionSet;
   const lbReady = lb.enabled && lbTokenSet;
+
+  // "Connect to Last.fm" flow — replaces the CLI session-key dance. Needs the
+  // API key + secret saved first (the backend reads them from settings/env).
+  const canConnect = lfApiKeySet && lfApiSecretSet;
+  const [authToken, setAuthToken] = useState<string | null>(null);
+  const [connecting, setConnecting] = useState(false);
 
   const saveLastfm = () => {
     const patch: Partial<ScrobbleLastfmForm> = {
@@ -5234,6 +5241,56 @@ function ScrobbleSection({ data, form, setForm, busy, saveSettings, adminFetch }
     }
   };
 
+  // Step 1: ask the controller for an auth token + URL, open it for the user.
+  const connectLastfm = async () => {
+    setConnecting(true);
+    try {
+      const r = await adminFetch('/scrobble/lastfm/connect', { method: 'POST' });
+      const j = (await r.json().catch(() => ({}))) as {
+        ok?: boolean; token?: string; authUrl?: string; message?: string;
+      };
+      if (!r.ok || !j.ok || !j.authUrl || !j.token) {
+        notify.err(j.message || `couldn't start (${r.status})`);
+        return;
+      }
+      window.open(j.authUrl, '_blank', 'noopener,noreferrer');
+      setAuthToken(j.token);
+      notify.ok('Authorize in the Last.fm tab, then click “I authorized — finish”.');
+    } catch (e) {
+      notify.err(errorMessage(e));
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  // Step 2: trade the authorized token for a session key; the controller saves
+  // it and switches scrobbling on, so a refresh reflects "connected".
+  const finishLastfm = async () => {
+    if (!authToken) return;
+    setConnecting(true);
+    try {
+      const r = await adminFetch('/scrobble/lastfm/complete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: authToken }),
+      });
+      const j = (await r.json().catch(() => ({}))) as {
+        ok?: boolean; username?: string; message?: string;
+      };
+      if (!r.ok || !j.ok) {
+        notify.err(j.message || `couldn't finish (${r.status})`);
+        return;
+      }
+      setAuthToken(null);
+      notify.ok(`Connected to Last.fm${j.username ? ` as ${j.username}` : ''}.`);
+      refresh();
+    } catch (e) {
+      notify.err(errorMessage(e));
+    } finally {
+      setConnecting(false);
+    }
+  };
+
   return (
     <>
       <SectionHeader
@@ -5241,9 +5298,9 @@ function ScrobbleSection({ data, form, setForm, busy, saveSettings, adminFetch }
         title="Station-wide scrobbling to Last.fm and ListenBrainz."
         sub={<>
           Each backend is independent, pick one or both. Tracks scrobble only when at
-          least one listener is tuned in to the stream. Paste credentials below; nothing
-          here leaves the controller. See the <code>npm run lastfm-session</code> helper
-          if you don&apos;t already have a Last.fm session key.
+          least one listener is tuned in to the stream. For Last.fm, enter your API key
+          and secret, then hit <strong>Connect to Last.fm</strong> to authorize, no
+          session-key wrangling. Nothing here leaves the controller.
         </>}
         metrics={[
           { n: lfReady ? 'on' : 'off', l: 'last.fm', accent: lfReady },
@@ -5317,6 +5374,36 @@ function ScrobbleSection({ data, form, setForm, busy, saveSettings, adminFetch }
           </div>
 
           <div className="field">
+            <Label>Authorize</Label>
+            {!authToken ? (
+              <Btn
+                sm
+                tone="accent"
+                onClick={connectLastfm}
+                disabled={busy || connecting || !canConnect}
+              >
+                {connecting ? 'Opening Last.fm…' : 'Connect to Last.fm'}
+              </Btn>
+            ) : (
+              <div className="flex items-center gap-2">
+                <Btn sm tone="accent" onClick={finishLastfm} disabled={busy || connecting}>
+                  {connecting ? 'Finishing…' : 'I authorized — finish'}
+                </Btn>
+                <Btn sm onClick={() => setAuthToken(null)} disabled={connecting}>
+                  Cancel
+                </Btn>
+              </div>
+            )}
+            <div className="field-hint">
+              {!canConnect
+                ? 'Enter your API key + secret above and Save first, then connect.'
+                : !authToken
+                  ? 'Opens Last.fm to grant access, then fills in your session key and switches scrobbling on — no terminal needed.'
+                  : 'A Last.fm tab opened. Click “Yes, allow access” there, then finish here.'}
+            </div>
+          </div>
+
+          <div className="field">
             <Label>Session key</Label>
             <Input
               type="password"
@@ -5331,10 +5418,10 @@ function ScrobbleSection({ data, form, setForm, busy, saveSettings, adminFetch }
               className="max-w-[360px]"
             />
             <div className="field-hint">
-              Generated by authorizing your account. Run
-              <code> cd controller &amp;&amp; npm run lastfm-session</code> for a guided
-              flow, or fetch one yourself via <code>auth.getSession</code>. Doesn&apos;t
-              expire. Falls back to <code>LASTFM_SESSION_KEY</code>.
+              Easiest: hit <strong>Connect to Last.fm</strong> above and it fills this
+              in for you. Advanced: paste one from
+              <code> npm run lastfm-session</code>. Doesn&apos;t expire. Falls back to
+              <code> LASTFM_SESSION_KEY</code>.
             </div>
           </div>
 


### PR DESCRIPTION
## Why

Getting a Last.fm **session key** previously meant running `npm run lastfm-session` in a terminal. That's fine in a clone, but a non-starter for anyone on the packaged / Unraid all-in-one install (raised on Discord). Scrobbling looked "broken" when really the session key was just unobtainable without a shell.

## What

**In-admin "Connect to Last.fm" flow** (replaces the CLI dance):

- `POST /scrobble/lastfm/connect` → `auth.getToken`, returns the authorize URL
- operator clicks **Connect to Last.fm**, grants access in a new tab
- `POST /scrobble/lastfm/complete` → `auth.getSession`, persists the session key and flips scrobbling **on**

Uses the same env-wins api-key/secret resolution as scrobble time, so the minted session key is always bound to the api key scrobbling will actually use. The session-key field is now optional/advanced and the helper text points at the button.

**Honest Test button (bug fix):** `callLastfm` / `postListenbrainz` swallowed every failure, so `testNowPlaying` always returned `ok:true` even when Last.fm rejected the request. They now return a result and the Test surfaces the real response — on both the Last.fm and ListenBrainz paths.

## Verification

- `controller` and `web` lint/tsc both clean
- The underlying `auth.getToken` → `auth.getSession` → signed scrobble path was exercised live end-to-end on a dev stack: 3 real scrobbles landed (`user.getRecentTracks` total = 3), no errors

## Notes

- No schema/settings changes; session key still persists in `settings.scrobble.lastfm`
- The CLI helper (`npm run lastfm-session`) stays as an advanced fallback