### PR TITLE
fix(broadcast): rotate jingles on the raw music source so they keep firing

### DIFF
--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -222,6 +222,33 @@ end
 # one song behind until the next crossfade.
 music_meta = music
 
+# JINGLES & STATION ID — rotate a jingle in every N tracks.
+#
+# CRITICAL: this rotate MUST sit here, on the raw pre-cross / pre-duck music
+# source, NOT at the top of the chain. `rotate` defaults to track_sensitive=true
+# so it only advances to the next source at a *track boundary* of the source it
+# is currently playing. Both `cross` (below) and the `smooth_add` ducking layers
+# present their output as ONE continuous, never-ending track — they do not
+# propagate the underlying per-track boundaries upward (the same reason
+# on_metadata hooks `music_meta` here and not the post-cross source). If the
+# rotate is placed above them it plays exactly one jingle at startup, switches to
+# the music side, never sees a track end again, and is stuck on music forever —
+# jingles "stop triggering" (issue: jingles only fire once per restart). Placing
+# it on the raw playlist sources keeps the boundaries clean so it rotates
+# indefinitely. An empty jingles.m3u is fine: rotate skips the unavailable
+# source and plays music. music_meta is captured ABOVE this, so jingles never
+# show up in now-playing.
+jingles = playlist(
+  id="jingles",
+  mode="randomize",
+  reload_mode="watch",
+  "/var/sub-wave/jingles.m3u"
+)
+music = rotate(
+  weights=[1, jingle_ratio()],  # 1 jingle for every N music tracks (settings.json)
+  [jingles, music]
+)
+
 # Per-track loudness normalisation. The controller stamps `liq_amplify` (in the
 # "<n> dB" form, via subsonic.getAnnotatedUri) on any track with a measured LUFS;
 # `amplify` reads it per track — exactly the ReplayGain mechanism. Base factor
@@ -456,21 +483,11 @@ radio = smooth_add(
   special=sfx_bed
 )
 
-# ---------------------------------------------------------------------------
-# JINGLES & STATION ID — every 30 mins, rotate a jingle in
-# ---------------------------------------------------------------------------
-
-jingles = playlist(
-  id="jingles",
-  mode="randomize",
-  reload_mode="watch",
-  "/var/sub-wave/jingles.m3u"
-)
-
-radio = rotate(
-  weights=[1, jingle_ratio()],  # 1 jingle for every N music tracks (settings.json)
-  [jingles, radio]
-)
+# NOTE: jingles are NOT rotated in here. The rotate lives up on the raw pre-cross
+# music source (see the "JINGLES & STATION ID" block above music_meta) because a
+# track_sensitive rotate placed above `cross` + `smooth_add` only ever fires one
+# jingle at startup and then stalls — those operators hide the per-track
+# boundaries it needs to switch on.
 
 # ---------------------------------------------------------------------------
 # SAFETY — fallback to the emergency loop when the source dies


### PR DESCRIPTION
## Problem

Jingles only ever fire **once per restart**, then never trigger again (reported via Reddit). Importing jingles through the GUI and hand-editing `jingles.m3u` both appeared to do nothing — the files and playlist were correct.

## Root cause

The jingle rotate sat at the **top** of the Liquidsoap chain:

```liquidsoap
radio = rotate(weights=[1, jingle_ratio()], [jingles, radio])   # radio = crossfaded + ducked music
```

`rotate` defaults to `track_sensitive=true` — it only switches sources at a **track boundary of the source it is currently playing**. But the `radio` it rotated against had already been through `cross` (crossfade) and three `smooth_add` ducking layers, and **those operators present their output as one continuous, never-ending track** — they don't propagate the underlying per-track boundaries upward (the same reason `on_metadata` hooks the *pre-cross* `music_meta`).

So at boot rotate plays one jingle, the jingle ends, it switches to the music side — and then never sees another track end, so it's **stuck on music forever**. Matches the report exactly (one jingle decoded per restart, then nothing).

## Reproduction (savonet/liquidsoap:v2.2.5, `weights=[1,3]`, logging which source rotate pulls)

| structure | result |
|---|---|
| rotate over **plain music** | `JINGLE, M, M, M, JINGLE, M, M, M…` ✅ |
| rotate over **`cross(music)`** | `JINGLE, M`, then frozen ❌ |
| rotate over **`smooth_add(music)`** | `JINGLE, M`, then frozen ❌ |

Both `cross` and `smooth_add` break it independently, and the live chain has both stacked above the rotate.

## Fix

Move the rotate onto the **raw pre-cross playlist sources** (above `music_meta`'s amplify+cross), where track boundaries are clean, then let `cross` + ducking wrap the combined stream.

- ✅ Jingles rotate **indefinitely** (verified).
- ✅ Empty `jingles.m3u` is safe — rotate skips the unavailable source, music keeps playing (no dead air).
- ✅ Edited `radio.liq` passes `liquidsoap --check` (exit 0).
- Jingles stay out of now-playing (`music_meta` is captured above the rotate).

### Intentional behavior change

Jingles now pass through `cross`, so they **crossfade** with adjacent tracks instead of hard-swapping. This is the only way to keep clean track boundaries for the rotate; it's arguably nicer.

## Deploy note

`radio.liq` is baked into the prod broadcast image — this needs `docker compose up -d --build broadcast`, not just a restart.