### PR TITLE
fix(caddy): route /listen.pls + /listen.m3u to the controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ bin/subwave        Operator CLI entry: setup, status, doctor, lifecycle
 - **There is no `/skip` for listeners.** Track-end is the only natural
   transition; operators have an admin-only skip endpoint.
 - **Add to Sonos / VLC with one link.** Hardware and software players take a
-  playlist file, not a raw stream URL — paste `https://<your-station>/api/listen.pls`
-  (or `/api/listen.m3u`) into Sonos, VLC, moOde, or a car receiver and it tunes
+  playlist file, not a raw stream URL — paste `https://<your-station>/listen.pls`
+  (or `/listen.m3u`) into Sonos, VLC, moOde, or a car receiver and it tunes
   straight in. Both are public (no auth), point at the always-served MP3 mount
   (plus Opus when you've enabled it), and resolve the origin from `SITE_URL`
   when set, otherwise the address you reached the station on (LAN / Tailscale /

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -48,6 +48,17 @@
 	}
 
 	# -------------------------------------------------------------------------
+	# /listen.pls + /listen.m3u — one-paste tune-in files (VLC, Sonos, hardware)
+	# -------------------------------------------------------------------------
+	# Served by the controller at its root (NOT under /api), so use a plain
+	# handle with no path stripping. Without this they fall through to the
+	# Next.js catch-all below and 404.
+	@listen path /listen.pls /listen.m3u
+	handle @listen {
+		reverse_proxy controller:7701
+	}
+
+	# -------------------------------------------------------------------------
 	# Everything else → Next.js web UI
 	# -------------------------------------------------------------------------
 	handle {


### PR DESCRIPTION
## What

Adds a Caddy edge route so the `/listen.pls` and `/listen.m3u` tune-in endpoints (#670) actually resolve at the station root.

## Why

#670 added the `/listen.pls` + `/listen.m3u` controller routes but never added a matching Caddy route. The controller is only reachable through Caddy under `/api/*`, so root-level requests fell through to the Next.js catch-all and returned **404** — exactly what the PR review check hit:

```
https://www.getsubwave.com/listen.pls  -> 404
https://www.getsubwave.com/listen.m3u  -> 404
```

Dev never surfaced it because the web player hits the controller on `:7701` directly, bypassing Caddy.

## How

- New `@listen` handle in `docker/Caddyfile` proxying `/listen.pls` + `/listen.m3u` straight to `controller:7701` with **no** path stripping (the controller serves them at its root, unlike the `/api/*` routes).
- README updated to point at the cleaner root form (`/listen.pls`) instead of `/api/listen.pls`. Both forms work after this change.

No compose changes needed — BYO-proxy operators inherit the route by replicating `docker/Caddyfile`'s route table.

## Verified on prod

```
https://www.getsubwave.com/listen.pls  -> 200
https://www.getsubwave.com/listen.m3u  -> 200
```
Stream stayed live throughout (audio probe −21 dB), all containers healthy.