### PR TITLE
fix(stats): scroll the pick-source list + reliably wire the docker-socket-proxy

### DIFF
--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -101,6 +101,11 @@ services:
     depends_on:
       broadcast:
         condition: service_healthy
+      # Bring the socket-proxy up whenever the controller is (re)created — even a
+      # selective \`up -d controller\` — so the Stats system panel works without a
+      # separate full \`up -d\`. Remove this entry too if you drop the proxy below.
+      docker-socket-proxy:
+        condition: service_started
     environment:
       # Enables the production-only admin gate: refuses to boot unless
       # ADMIN_USER + ADMIN_PASS are set in .env.
@@ -141,7 +146,8 @@ services:
   # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
   # controller image itself never holds the socket. No host port — only
   # reachable on the internal compose network. Optional: remove this service
-  # (and the controller's DOCKER_HOST above) to drop the Stats system panel.
+  # (plus the controller's DOCKER_HOST and its docker-socket-proxy depends_on
+  # entry above) to drop the Stats system panel.
   docker-socket-proxy:
     image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
     container_name: sub-wave-docker-proxy
@@ -360,6 +366,11 @@ services:
     depends_on:
       broadcast:
         condition: service_healthy
+      # Bring the socket-proxy up whenever the controller is (re)created — even a
+      # selective \`up -d controller\` — so the Stats system panel works without a
+      # separate full \`up -d\`. Remove this entry too if you drop the proxy below.
+      docker-socket-proxy:
+        condition: service_started
     environment:
       - NODE_ENV=production
       - TZ=\${TZ:-Europe/London}
@@ -390,7 +401,8 @@ services:
   # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
   # controller image itself never holds the socket. No host port — only
   # reachable on the internal compose network. Optional: remove this service
-  # (and the controller's DOCKER_HOST above) to drop the Stats system panel.
+  # (plus the controller's DOCKER_HOST and its docker-socket-proxy depends_on
+  # entry above) to drop the Stats system panel.
   docker-socket-proxy:
     image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
     container_name: sub-wave-docker-proxy
@@ -581,6 +593,11 @@ services:
     depends_on:
       broadcast:
         condition: service_healthy
+      # Bring the socket-proxy up whenever the controller is (re)created — even a
+      # selective \`up -d controller\` — so the Stats system panel works without a
+      # separate full \`up -d\`. Remove this entry too if you drop the proxy below.
+      docker-socket-proxy:
+        condition: service_started
     environment:
       - TZ=\${TZ:-Europe/London}
       - STATE_DIR=/var/sub-wave
@@ -626,7 +643,8 @@ services:
   # other section refused by default). The controller reads per-container
   # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
   # controller never holds the socket. No host port. Optional: remove this
-  # service (and the controller's DOCKER_HOST above) to drop the Stats panel.
+  # service (plus the controller's DOCKER_HOST and its docker-socket-proxy
+  # depends_on entry above) to drop the Stats panel.
   docker-socket-proxy:
     image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
     container_name: sub-wave-docker-proxy

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -76,6 +76,11 @@ services:
     depends_on:
       broadcast:
         condition: service_healthy
+      # Bring the socket-proxy up whenever the controller is (re)created — even a
+      # selective `up -d controller` — so the Stats system panel works without a
+      # separate full `up -d`. Remove this entry too if you drop the proxy below.
+      docker-socket-proxy:
+        condition: service_started
     environment:
       - NODE_ENV=production
       - TZ=${TZ:-Europe/London}
@@ -106,7 +111,8 @@ services:
   # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
   # controller image itself never holds the socket. No host port — only
   # reachable on the internal compose network. Optional: remove this service
-  # (and the controller's DOCKER_HOST above) to drop the Stats system panel.
+  # (plus the controller's DOCKER_HOST and its docker-socket-proxy depends_on
+  # entry above) to drop the Stats system panel.
   docker-socket-proxy:
     image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
     container_name: sub-wave-docker-proxy

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -75,6 +75,11 @@ services:
     depends_on:
       broadcast:
         condition: service_healthy
+      # Bring the socket-proxy up whenever the controller is (re)created — even a
+      # selective `up -d controller` — so the Stats system panel works without a
+      # separate full `up -d`. Remove this entry too if you drop the proxy below.
+      docker-socket-proxy:
+        condition: service_started
     environment:
       - TZ=${TZ:-Europe/London}
       - STATE_DIR=/var/sub-wave
@@ -120,7 +125,8 @@ services:
   # other section refused by default). The controller reads per-container
   # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
   # controller never holds the socket. No host port. Optional: remove this
-  # service (and the controller's DOCKER_HOST above) to drop the Stats panel.
+  # service (plus the controller's DOCKER_HOST and its docker-socket-proxy
+  # depends_on entry above) to drop the Stats panel.
   docker-socket-proxy:
     image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
     container_name: sub-wave-docker-proxy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,11 @@ services:
     depends_on:
       broadcast:
         condition: service_healthy
+      # Bring the socket-proxy up whenever the controller is (re)created — even a
+      # selective `up -d controller` — so the Stats system panel works without a
+      # separate full `up -d`. Remove this entry too if you drop the proxy below.
+      docker-socket-proxy:
+        condition: service_started
     environment:
       # Enables the production-only admin gate: refuses to boot unless
       # ADMIN_USER + ADMIN_PASS are set in .env.
@@ -132,7 +137,8 @@ services:
   # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
   # controller image itself never holds the socket. No host port — only
   # reachable on the internal compose network. Optional: remove this service
-  # (and the controller's DOCKER_HOST above) to drop the Stats system panel.
+  # (plus the controller's DOCKER_HOST and its docker-socket-proxy depends_on
+  # entry above) to drop the Stats system panel.
   docker-socket-proxy:
     image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
     container_name: sub-wave-docker-proxy

--- a/web/components/admin/StatsPanel.tsx
+++ b/web/components/admin/StatsPanel.tsx
@@ -890,15 +890,17 @@ export default function StatsPanel() {
                   <div className="grid gap-3.5 p-3.5">
                     <div>
                       <div className="caption mb-2">by pick source</div>
-                      <Table<ByPickSourceRow>
-                        empty="no pick sources"
-                        rows={requests.byPickSource}
-                        cols={[
-                          { key: 'source', label: 'Source' },
-                          { key: 'count', label: 'Picks', align: 'right',
-                            render: r => <span className="mono-num">{r.count}</span> },
-                        ]}
-                      />
+                      <ScrollBox>
+                        <Table<ByPickSourceRow>
+                          empty="no pick sources"
+                          rows={requests.byPickSource}
+                          cols={[
+                            { key: 'source', label: 'Source' },
+                            { key: 'count', label: 'Picks', align: 'right',
+                              render: r => <span className="mono-num">{r.count}</span> },
+                          ]}
+                        />
+                      </ScrollBox>
                     </div>
                     <div>
                       <div className="caption mb-2">top requesters</div>
@@ -960,8 +962,9 @@ export default function StatsPanel() {
             <div className="p-3.5">
               {!systemRes.dockerAvailable ? (
                 <span className="field-hint italic">
-                  container stats unavailable, mount /var/run/docker.sock (read-only)
-                  into the controller to enable
+                  container stats unavailable — start the docker-socket-proxy
+                  sidecar (docker compose up -d) to enable
+                  {systemRes.dockerError ? ` · ${systemRes.dockerError}` : ''}
                 </span>
               ) : sysContainers.length === 0 ? (
                 <span className="field-hint italic">no containers reporting</span>


### PR DESCRIPTION
Two fixes on the admin **Stats** page.

## 1. "By pick source" → scrolling area
Wraps the table in `<ScrollBox>` (same `max-h-[260px] overflow-y-auto` component already used by top referrers/countries/DJ activity/containers), so a long source tail can't stretch the Requests card down the page.

## 2. "Container stats unavailable" — message + wiring
The panel reads container CPU/memory through the locked-down `docker-socket-proxy` sidecar (since #481); the controller never holds the raw socket. Two problems fixed:

- **Stale hint.** The "unavailable" message still told operators to *mount `/var/run/docker.sock` into the controller* — the pre-#481 approach. It now points at the proxy sidecar and surfaces the underlying `dockerError` for debugging.
- **Proxy not created on a selective recreate.** A partial `up -d controller` never created the newly-added proxy service, so the panel read "unavailable" forever. Added `controller depends_on: docker-socket-proxy` (`service_started`) in all three composes so the proxy is brought up alongside the controller. Updated the "proxy is optional/removable" comments to note the depends_on goes with it. Re-embedded `cli/src/assets.generated.ts` to match.

Kept the proxy architecture rather than re-mounting the raw socket into the controller (the #481 security choice), so this doesn't regress that.

## Verification
- `docker compose config` passes for all three composes; rendered config shows the new `controller → docker-socket-proxy` dependency.
- `cli/src/assets.generated.ts` diff is exactly the mirrored compose changes (CLI assets-check job will pass).
- `web` lint green (`eslint . && tsc --noEmit`).
