### PR TITLE
feat(shows): in-page show editor with save/delete confirms

### DIFF
--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -13,6 +13,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { notify, errorMessage } from '../../lib/notify';
 import { Card } from './ui';
+import { V3AlertDialog } from '../ui/alert-dialog';
 import type { Persona, PersonaTts, FormState, SettingsResponse } from './personas/types';
 import { DIAL_NEUTRAL, PERSONA_MAX, PROMPT_MIN, PROMPT_MAX } from './personas/constants';
 import {
@@ -40,6 +41,8 @@ export default function PersonasPanel() {
   // Per-persona "uploading" flag — drives the spinner / disables the buttons
   // while the request is in flight.
   const [uploadingId, setUploadingId] = useState<string | null>(null);
+  // Index of the persona pending a delete-confirm (null = no dialog open).
+  const [confirmDeleteIdx, setConfirmDeleteIdx] = useState<number | null>(null);
   // The editor block. After adding a persona we scroll it into view so the
   // operator actually sees the new persona open for editing — it stacks below
   // the roster and would otherwise be off-screen.
@@ -400,7 +403,7 @@ export default function PersonasPanel() {
         onGenerateAvatar={generateAvatar}
         onClearAvatar={clearAvatar}
         onSetActive={() => setForm(f => f ? ({ ...f, activePersonaId: focused.id }) : f)}
-        onRemove={() => { removePersona(safeIdx); setFocusIdx(i => Math.max(0, i - 1)); }}
+        onRemove={() => setConfirmDeleteIdx(safeIdx)}
         canSave={canSave}
         focusedOk={focusedOk}
         allPersonasOk={allPersonasOk}
@@ -408,6 +411,29 @@ export default function PersonasPanel() {
         busy={busy}
         onSave={save}
         onDiscard={load}
+      />
+
+      <V3AlertDialog
+        open={confirmDeleteIdx !== null}
+        onOpenChange={(o) => { if (!o) setConfirmDeleteIdx(null); }}
+        title="Delete persona"
+        description={
+          <>
+            Remove{' '}
+            <b>{confirmDeleteIdx !== null ? (form.personas[confirmDeleteIdx]?.name.trim() || 'this persona') : 'this persona'}</b>
+            {' '}from the roster? Nothing is permanent until you Save persona.
+          </>
+        }
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        danger
+        onConfirm={() => {
+          if (confirmDeleteIdx !== null) {
+            removePersona(confirmDeleteIdx);
+            setFocusIdx(i => Math.max(0, i - 1));
+          }
+          setConfirmDeleteIdx(null);
+        }}
       />
     </div>
   );

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -7,10 +7,11 @@
 // An empty hour = the station runs autonomously, as it does today.
 // Everything POSTs to /settings and applies live.
 //
-// Shows are created/edited through a centered modal (components/ui/modal).
+// Shows are created/edited through an in-page editor (ShowEditor, below the
+// show list) — the personas pattern: click a show to open it, edit it in place.
 // The weekly grid is drag-paintable: pick a brush, then click-drag across
 // cells; click a day label or hour header to fill a whole row/column.
-import type { ChangeEvent, TouchEvent } from 'react';
+import type { ChangeEvent, RefObject, TouchEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { useDynamicStyle } from '../../hooks/useDynamicStyle';
@@ -25,7 +26,7 @@ import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup,
 } from '../ui/select';
 import { Card, Btn, Pill, Eyebrow, Metric, Toggle } from './ui';
-import { Modal } from '../ui/modal';
+import { V3AlertDialog } from '../ui/alert-dialog';
 import { AiFill } from './AiFill';
 import GenreSuggest from './GenreSuggest';
 import { PersonaPicker, ThemePicker } from './ShowPickers';
@@ -225,9 +226,21 @@ export default function ShowsPanel() {
   const [brush, setBrush] = useState<string | 'erase' | null>(null);
   const [now, setNow] = useState(() => new Date());
 
-  // Modal state: `editIndex` is null (closed), -1 (new show), or a show index.
-  const [editIndex, setEditIndex] = useState<number | null>(null);
-  const [draft, setDraft] = useState<Show | null>(null);
+  // Inline editor: `focusIdx` is the show open in the editor below the list
+  // (null = none open). Shows are edited in place — no modal, no draft copy;
+  // edits land straight on `form.shows[focusIdx]` and persist on Save schedule.
+  const [focusIdx, setFocusIdx] = useState<number | null>(null);
+  // The editor block, scrolled into view when a show is opened (add / edit) so
+  // the operator actually sees it — it stacks below the list and would else be
+  // off-screen. The flag gates the scroll to deliberate opens (not re-renders).
+  const editorRef = useRef<HTMLDivElement | null>(null);
+  const scrollToEditorRef = useRef(false);
+  // Index of the show pending a delete-confirm (null = no dialog open). Both the
+  // list ✕ and the editor's Remove route through it so deletes need confirming.
+  const [confirmDeleteIdx, setConfirmDeleteIdx] = useState<number | null>(null);
+  // Open-state for the "clear the whole week" confirm — wiping every painted
+  // cell is destructive enough to gate behind a yes/no.
+  const [confirmClearWeek, setConfirmClearWeek] = useState(false);
   // Theme list for the per-show override dropdown. Public endpoint, no auth
   // needed — same source the player ThemeBootstrap reads.
   const [themes, setThemes] = useState<ThemeOption[]>([]);
@@ -265,6 +278,14 @@ export default function ShowsPanel() {
       window.removeEventListener('touchend', end);
     };
   }, []);
+
+  // When a show is opened (add / Edit click sets the flag), bring the editor
+  // into view. Guarded by scrollToEditorRef so unrelated re-renders don't yank.
+  useEffect(() => {
+    if (!scrollToEditorRef.current) return;
+    scrollToEditorRef.current = false;
+    editorRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, [focusIdx]);
 
   const load = async (): Promise<SettingsResponse | null> => {
     try {
@@ -354,65 +375,42 @@ export default function ShowsPanel() {
     (id && form?.shows.find(s => s.id === id)) || null;
   const personaName = (id: string): string => personas.find(p => p.id === id)?.name || '—';
 
-  // ── show modal ───────────────────────────────────────────────────────────
-  const openNew = () => {
+  // ── inline show editor ─────────────────────────────────────────────────
+  // Edits land straight on the show in form state (no draft) — same live-edit
+  // model as PersonasPanel. Trimming/cleaning happens once, at Save schedule.
+  const setShow = (i: number, patch: Partial<Show>) =>
+    setForm(f => f ? ({ ...f, shows: f.shows.map((s, idx) => (idx === i ? { ...s, ...patch } : s)) }) : f);
+
+  // Open an existing show in the editor below the list, scrolling it into view.
+  const focusShow = (i: number) => { scrollToEditorRef.current = true; setFocusIdx(i); };
+
+  // Append a fresh show (persona + mood pre-filled, name blank so it reads as
+  // incomplete until named) and open it for editing.
+  const addShow = () => {
     if (!form || form.shows.length >= SHOWS_MAX || personas.length === 0) return;
-    setEditIndex(-1);
-    setDraft({
-      id: '', name: '', topic: '',
-      personaId: personas[0]?.id || '', mood: moods[0] || '',
-      themeId: '',
-      genre: '', fromYear: null, toYear: null, energy: '', genreStrict: false,
-      maxTrackSeconds: null,
-    });
-  };
-  const openEdit = (i: number) => {
-    if (!form) return;
-    const s = form.shows[i];
-    if (!s) return;
-    setEditIndex(i);
-    setDraft({
-      id: s.id, name: s.name, topic: s.topic,
-      personaId: s.personaId, mood: s.mood,
-      themeId: s.themeId || '',
-      genre: s.genre || '', fromYear: s.fromYear ?? null, toYear: s.toYear ?? null, energy: s.energy || '',
-      genreStrict: s.genreStrict ?? false,
-      maxTrackSeconds: s.maxTrackSeconds ?? null,
-    });
-  };
-  const closeModal = () => { setEditIndex(null); setDraft(null); };
-  const setDraftField = (patch: Partial<Show>) => setDraft(d => d ? ({ ...d, ...patch }) : d);
-  const commitDraft = () => {
-    if (!draft || !showValid(draft)) return;
-    const clean = {
-      name: draft.name.trim(), topic: draft.topic.trim(),
-      personaId: draft.personaId, mood: draft.mood,
-      themeId: draft.themeId || '',
-      genre: draft.genre.trim(), fromYear: draft.fromYear, toYear: draft.toYear, energy: draft.energy || '',
-      // Strict is only meaningful with a genre to lock to — drop it otherwise.
-      genreStrict: !!draft.genre.trim() && draft.genreStrict,
-      maxTrackSeconds: draft.maxTrackSeconds,
-    };
-    if (editIndex === -1) {
-      const id = clientMintId();
-      setForm(f => {
-        if (!f) return f;
-        return f.shows.length >= SHOWS_MAX
-          ? f
-          : { ...f, shows: [...f.shows, { id, ...clean }] };
-      });
-      // arm the new show as the brush if nothing is armed yet
-      setBrush(b => b ?? id);
-    } else {
-      setForm(f => f ? ({
+    const id = clientMintId();
+    const newIdx = form.shows.length;
+    setForm(f => {
+      if (!f) return f;
+      if (f.shows.length >= SHOWS_MAX) return f;
+      return {
         ...f,
-        shows: f.shows.map((s, idx) => (idx === editIndex ? { ...s, ...clean } : s)),
-      }) : f);
-    }
-    closeModal();
+        shows: [...f.shows, {
+          id, name: '', topic: '',
+          personaId: personas[0]?.id || '', mood: moods[0] || '',
+          themeId: '', genre: '', fromYear: null, toYear: null, energy: '',
+          genreStrict: false, maxTrackSeconds: null,
+        }],
+      };
+    });
+    // arm the new show as the brush if nothing is armed yet
+    setBrush(b => b ?? id);
+    scrollToEditorRef.current = true;
+    setFocusIdx(newIdx);
+    notify.ok('New show added — give it a name, persona and mood, then Save schedule.');
   };
 
-  const removeShow = (i: number) =>
+  const removeShow = (i: number) => {
     setForm(f => {
       if (!f) return f;
       const target = f.shows[i];
@@ -424,6 +422,10 @@ export default function ShowsPanel() {
       if (brush === target.id) setBrush(null);
       return { ...f, shows: f.shows.filter((_, idx) => idx !== i), schedule: week };
     });
+    // Keep the editor focus aligned with the shifted list: close it if the open
+    // show was removed, decrement if an earlier one was.
+    setFocusIdx(cur => (cur == null ? cur : cur === i ? null : cur > i ? cur - 1 : cur));
+  };
 
   // ── grid helpers ─────────────────────────────────────────────────────────
   const setCell = (day: number, hour: number, value: string | null) =>
@@ -569,13 +571,15 @@ export default function ShowsPanel() {
   const after = slotAhead(2);
   const upNextShow = upNext.showId ? showById(upNext.showId) : null;
   const afterShow = after.showId ? showById(after.showId) : null;
-  const draftValid = draft ? showValid(draft) : false;
+  // The show open in the inline editor. focusIdx can briefly point past the end
+  // after a removal — coerce an out-of-range index to "nothing open".
+  const focused = focusIdx != null ? (form.shows[focusIdx] ?? null) : null;
 
   return (
     <div className="grid gap-4">
       {/* ── HERO ─────────────────────────────────────────────────────────── */}
       <section className="card">
-        <div className="stack-mobile grid grid-cols-[1fr_auto_auto] items-center gap-4 border-b border-ink p-4">
+        <div className="stack-mobile grid grid-cols-[1fr_auto] items-center gap-4 border-b border-ink p-4">
           <div>
             <div className="flex flex-wrap items-baseline gap-2.5">
               <Eyebrow className="text-vermilion">shows · weekly grid</Eyebrow>
@@ -598,10 +602,6 @@ export default function ShowsPanel() {
             </div>
           </div>
           <Metric n={String(scheduledHours)} l="hours scheduled" />
-          <Btn lg tone="accent" onClick={openNew}
-            disabled={form.shows.length >= SHOWS_MAX || personas.length === 0}>
-            + New show
-          </Btn>
         </div>
 
         {/* Now / Up next / After that strip */}
@@ -630,7 +630,14 @@ export default function ShowsPanel() {
       <Card
         title="Weekly schedule"
         sub="Mon–Sun · 24h"
-        right={<Btn sm onClick={clearWeek}>Clear week</Btn>}
+        right={
+          <span className="flex gap-2">
+            <Btn sm tone="accent" onClick={save} disabled={busy || !canSave}>
+              {busy ? 'saving…' : 'Save schedule'}
+            </Btn>
+            <Btn sm onClick={() => setConfirmClearWeek(true)}>Clear week</Btn>
+          </span>
+        }
       >
         {/* brush picker — colour-swatched, click to arm */}
         <div className="mb-3 flex flex-wrap items-center gap-2">
@@ -724,7 +731,7 @@ export default function ShowsPanel() {
       <Card
         title="Show definitions"
         sub={`${form.shows.length}/${SHOWS_MAX} shows`}
-        right={<Btn sm tone="accent" onClick={openNew}
+        right={<Btn sm tone="accent" onClick={addShow}
           disabled={form.shows.length >= SHOWS_MAX || personas.length === 0}>
           + Add show
         </Btn>}
@@ -745,247 +752,350 @@ export default function ShowsPanel() {
                 index={i}
                 ok={ok}
                 hrs={hrs}
+                focused={focusIdx === i}
                 personaLabel={personaName(s.personaId)}
-                onEdit={() => openEdit(i)}
-                onRemove={() => removeShow(i)}
+                onEdit={() => focusShow(i)}
+                onRemove={() => setConfirmDeleteIdx(i)}
               />
             );
           })}
         </div>
+        {form.shows.length > 0 && (
+          <p className="mt-2.5 text-[11px] text-muted">
+            Click a show (or <b>Edit</b>) to open it in the editor below.
+          </p>
+        )}
       </Card>
 
-      {/* ── SAVE ─────────────────────────────────────────────────────────── */}
-      <Card title="Apply" sub="POST /settings">
-        <div className="flex flex-wrap items-center gap-3">
-          <Btn lg tone="accent" onClick={save} disabled={busy || !canSave}>
-            {busy ? 'saving…' : 'Save schedule'}
-          </Btn>
-          {!canSave && !busy && (
-            <span className="text-[11px] text-[var(--danger)]">
-              every show needs a name, persona, and mood
+      {/* ── INLINE SHOW EDITOR ───────────────────────────────────────────── */}
+      {focused && focusIdx != null && (
+        <ShowEditor
+          key={focused.id}
+          show={focused}
+          editorRef={editorRef}
+          personas={personas}
+          moods={moods}
+          themes={themes}
+          activeThemeId={activeThemeId}
+          genres={genres}
+          apiBase={apiBase}
+          adminFetch={adminFetch}
+          minTrackSeconds={data?.values?.minTrackSeconds}
+          allShowsOk={allShowsOk}
+          canSave={canSave}
+          busy={busy}
+          update={(patch) => setShow(focusIdx, patch)}
+          onSave={save}
+          onClose={() => setFocusIdx(null)}
+          onRemove={() => setConfirmDeleteIdx(focusIdx)}
+        />
+      )}
+
+      {/* ── DELETE CONFIRM ───────────────────────────────────────────────── */}
+      <V3AlertDialog
+        open={confirmDeleteIdx !== null}
+        onOpenChange={(o) => { if (!o) setConfirmDeleteIdx(null); }}
+        title="Delete show"
+        description={
+          <>
+            Remove{' '}
+            <b>{confirmDeleteIdx !== null ? (form.shows[confirmDeleteIdx]?.name.trim() || 'this show') : 'this show'}</b>
+            ? It&apos;s also cleared from any scheduled hours. Nothing is permanent
+            until you Save schedule.
+          </>
+        }
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        danger
+        onConfirm={() => {
+          if (confirmDeleteIdx !== null) removeShow(confirmDeleteIdx);
+          setConfirmDeleteIdx(null);
+        }}
+      />
+
+      {/* ── CLEAR-WEEK CONFIRM ───────────────────────────────────────────── */}
+      <V3AlertDialog
+        open={confirmClearWeek}
+        onOpenChange={setConfirmClearWeek}
+        title="Clear week"
+        description={
+          <>
+            Empty every hour on the grid? Your shows stay defined, but the whole
+            week unschedules. Nothing is permanent until you Save schedule.
+          </>
+        }
+        confirmLabel="Clear week"
+        cancelLabel="Cancel"
+        danger
+        onConfirm={() => { clearWeek(); setConfirmClearWeek(false); }}
+      />
+    </div>
+  );
+}
+
+// ── inline show editor ─────────────────────────────────────────────────────
+// The former modal body, lifted to an in-page editor (the personas pattern).
+// Edits are written straight through `update` onto form state; nothing is saved
+// here — the page's "Save schedule" persists shows + schedule together. Keyed by
+// show id at the call site so switching shows remounts it (resets the AiFill box).
+interface ShowEditorProps {
+  show: Show;
+  editorRef: RefObject<HTMLDivElement | null>;
+  personas: Persona[];
+  moods: string[];
+  themes: ThemeOption[];
+  activeThemeId: string;
+  genres: string[];
+  apiBase: string;
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+  minTrackSeconds?: number;
+  // Whole-form save state — one Save persists every show + the weekly grid, so
+  // the bar reflects the form, not just this show.
+  allShowsOk: boolean;
+  canSave: boolean;
+  busy: boolean;
+  update: (patch: Partial<Show>) => void;
+  onSave: () => void;
+  onClose: () => void;
+  onRemove: () => void;
+}
+
+function ShowEditor({
+  show, editorRef, personas, moods, themes, activeThemeId, genres, apiBase,
+  adminFetch, minTrackSeconds, allShowsOk, canSave, busy,
+  update, onSave, onClose, onRemove,
+}: ShowEditorProps) {
+  const valid = showValid(show);
+  return (
+    <div ref={editorRef} className="scroll-mt-4">
+      <Card
+        title={show.name.trim() ? 'Edit show' : 'New show'}
+        sub={show.name.trim() || 'define a show'}
+        right={
+          <span className="flex gap-2">
+            <Btn sm tone="danger" onClick={onRemove}>Remove</Btn>
+            <Btn sm onClick={onClose}>Close</Btn>
+          </span>
+        }
+      >
+        <div className="grid gap-3.5">
+          <AiFill<Partial<Omit<Show, 'personaId' | 'themeId'>> & { personaId?: string | null; themeId?: string | null }>
+            endpoint="/generate/show"
+            resultKey="show"
+            adminFetch={adminFetch}
+            placeholder="e.g. a Sunday-morning gospel hour, warm and uplifting"
+            onApply={(s) => update({
+              ...s,
+              personaId: s.personaId ?? show.personaId ?? '',
+              themeId: s.themeId ?? '',
+            })}
+          />
+          <Field>
+            <Label htmlFor="show-name">show name</Label>
+            <Input
+              id="show-name"
+              type="text" value={show.name} maxLength={NAME_MAX}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => update({ name: e.target.value })}
+              placeholder="e.g. The Late Shift"
+              className="text-[15px] font-bold"
+            />
+            <span className="field-hint">{show.name.trim().length}/{NAME_MAX}</span>
+          </Field>
+
+          <Field>
+            <Label>persona owner</Label>
+            <PersonaPicker
+              personas={personas}
+              value={show.personaId}
+              onChange={id => update({ personaId: id })}
+              apiBase={apiBase}
+            />
+          </Field>
+
+          <Field>
+            <Label>theme override (applied while this show is on air)</Label>
+            <ThemePicker
+              themes={themes}
+              activeThemeId={activeThemeId}
+              value={show.themeId}
+              onChange={id => update({ themeId: id })}
+            />
+            <span className="field-hint">
+              Optional. When this show goes on air the player switches to
+              this palette; back to the station default when the hour ends.
+              Manage themes in admin → Settings → Theme.
             </span>
-          )}
+          </Field>
+
+          <Eyebrow className="text-muted">music</Eyebrow>
+
+          <div className="stack-mobile grid grid-cols-3 gap-3">
+            <Field>
+              <Label>music mood</Label>
+              <Select
+                value={show.mood || undefined}
+                onValueChange={val => update({ mood: val })}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="— pick mood —" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    {moods.map(m => <SelectItem key={m} value={m}>{m}</SelectItem>)}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </Field>
+            <Field>
+              <Label>era</Label>
+              <Select
+                value={decadeKeyOf(show)}
+                onValueChange={val => {
+                  const d = DECADES.find(x => x.key === val);
+                  update({ fromYear: d?.from ?? null, toYear: d?.to ?? null });
+                }}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    {DECADES.map(d => <SelectItem key={d.key} value={d.key}>{d.label}</SelectItem>)}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </Field>
+            <Field>
+              <Label>energy</Label>
+              <Select
+                value={show.energy || ANY_SENTINEL}
+                onValueChange={val => update({ energy: val === ANY_SENTINEL ? '' : val })}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectItem value={ANY_SENTINEL}>Any</SelectItem>
+                    {ENERGY_OPTIONS.map(e => <SelectItem key={e} value={e}>{e}</SelectItem>)}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </Field>
+          </div>
+
+          <Field>
+            <Label htmlFor="show-genre">genre lean</Label>
+            <Input
+              id="show-genre"
+              type="text" value={show.genre} maxLength={64}
+              list="show-genre-options"
+              onChange={(e: ChangeEvent<HTMLInputElement>) => update({ genre: e.target.value })}
+              placeholder="e.g. Jazz (optional)"
+            />
+            <datalist id="show-genre-options">
+              {genres.map(g => <option key={g} value={g} />)}
+            </datalist>
+          </Field>
+
+          <GenreSuggest
+            adminFetch={adminFetch}
+            value={show.genre}
+            onSelect={(g) => update({ genre: g })}
+          />
+
+          <div className="flex items-start gap-3">
+            <div className="pt-0.5">
+              <Toggle
+                on={show.genreStrict}
+                disabled={!show.genre.trim()}
+                onClick={() => update({ genreStrict: !show.genreStrict })}
+              />
+            </div>
+            <div className="grid gap-0.5">
+              <Label className={!show.genre.trim() ? 'opacity-40' : undefined}>
+                Strict genre
+              </Label>
+              <span className="field-hint">
+                Stay strictly within this genre (off-genre tracks only as a last
+                resort to avoid silence). Needs a genre lean set above.
+              </span>
+            </div>
+          </div>
+
+          <span className="field-hint -mt-1.5">
+            Optional soft music steer for this show: a genre, an era, an energy
+            band, or any mix. The DJ leans toward these but can break them for
+            flow; leave blank to let the topic and mood drive selection.
+          </span>
+
+          <Field>
+            <Label htmlFor="show-topic">topic (fed to the DJ as the show theme)</Label>
+            <span className="field-hint">
+              This is the brief the AI DJ works from. The more you describe,
+              the better it picks music and writes links: name genres, eras,
+              moods, artists to lean into or avoid, the time of day, the kind
+              of listener, and how the host should sound. Write it like
+              you&apos;re briefing a real DJ before their slot.
+            </span>
+            <Textarea
+              id="show-topic"
+              rows={7} value={show.topic} maxLength={TOPIC_MAX}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) => update({ topic: e.target.value })}
+              placeholder="e.g. Slow ambient, modern classical and downtempo for the late shift. Think Nils Frahm, Hammock, Bonobo's quieter side, nothing with a hard beat. Keep the host calm and unhurried, like a friend talking you down at 1am."
+            />
+            <span className="field-hint">{show.topic.trim().length}/{TOPIC_MAX}</span>
+          </Field>
+
+          <Field>
+            <Label htmlFor="show-maxlen">max track length (seconds)</Label>
+            <Input
+              id="show-maxlen"
+              type="number"
+              min={0}
+              max={36000}
+              placeholder="inherit"
+              value={show.maxTrackSeconds ?? ''}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                const raw = e.target.value.trim();
+                update({ maxTrackSeconds: raw === '' ? null : Math.max(0, parseInt(raw, 10) || 0) });
+              }}
+            />
+            <span className="field-hint">
+              The longest a single track plays while this show is on air —
+              anything longer fades out at the limit. Leave it blank to use the
+              station limit, enter 0 for no limit (good for long mixes or DJ
+              sets), or set at least {minTrackSeconds ?? 30}s to
+              cap it for this show.
+            </span>
+          </Field>
+
+          {/* Save bar — labelled "Save show" for the editing context, though one
+              Save actually persists every show + the weekly grid (the personas
+              pattern, where "Save persona" likewise saves the whole roster). The
+              status line spells out that wider scope. */}
+          <div className="flex flex-wrap items-center gap-3 border border-ink bg-[var(--ink-softer)] p-3">
+            <span
+              className={cn(
+                'size-1.5 flex-none rounded-full',
+                canSave ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
+              )}
+            />
+            <span className="text-[11px] text-muted">
+              {!valid
+                ? <span className="text-[var(--danger)]">this show needs a name, a persona, and a mood</span>
+                : !allShowsOk
+                  ? <span className="text-[var(--danger)]">another show in the list is incomplete</span>
+                  : 'saves all shows + the weekly grid · applies live on the next pick'}
+            </span>
+            <span className="ml-auto">
+              <Btn tone="accent" onClick={onSave} disabled={busy || !canSave}>
+                {busy ? 'Saving…' : 'Save show'}
+              </Btn>
+            </span>
+          </div>
         </div>
       </Card>
-
-      {/* ── ADD / EDIT SHOW MODAL ────────────────────────────────────────── */}
-      <Modal
-        open={editIndex !== null}
-        onOpenChange={(o) => { if (!o) closeModal(); }}
-        width={760}
-        title={editIndex === -1 ? 'New show' : 'Edit show'}
-        sub={editIndex === -1 ? 'define a show' : (draft?.name?.trim() || '')}
-        footer={draft && (
-          <>
-            <Btn onClick={closeModal}>Cancel</Btn>
-            <Btn tone="accent" onClick={commitDraft} disabled={!draftValid}>
-              {editIndex === -1 ? 'Add show' : 'Save changes'}
-            </Btn>
-          </>
-        )}
-      >
-        {draft && (
-          <div className="grid gap-3.5">
-            <AiFill<Partial<Omit<Show, 'personaId' | 'themeId'>> & { personaId?: string | null; themeId?: string | null }>
-              endpoint="/generate/show"
-              resultKey="show"
-              adminFetch={adminFetch}
-              placeholder="e.g. a Sunday-morning gospel hour, warm and uplifting"
-              onApply={(s) => setDraftField({
-                ...s,
-                personaId: s.personaId ?? draft.personaId ?? '',
-                themeId: s.themeId ?? '',
-              })}
-            />
-            <Field>
-              <Label htmlFor="show-name">show name</Label>
-              <Input
-                id="show-name"
-                type="text" value={draft.name} maxLength={NAME_MAX}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => setDraftField({ name: e.target.value })}
-                placeholder="e.g. The Late Shift"
-                className="text-[15px] font-bold"
-                autoFocus
-              />
-              <span className="field-hint">{draft.name.trim().length}/{NAME_MAX}</span>
-            </Field>
-
-            <Field>
-              <Label>persona owner</Label>
-              <PersonaPicker
-                personas={personas}
-                value={draft.personaId}
-                onChange={id => setDraftField({ personaId: id })}
-                apiBase={apiBase}
-              />
-            </Field>
-
-            <Field>
-              <Label>theme override (applied while this show is on air)</Label>
-              <ThemePicker
-                themes={themes}
-                activeThemeId={activeThemeId}
-                value={draft.themeId}
-                onChange={id => setDraftField({ themeId: id })}
-              />
-              <span className="field-hint">
-                Optional. When this show goes on air the player switches to
-                this palette; back to the station default when the hour ends.
-                Manage themes in admin → Settings → Theme.
-              </span>
-            </Field>
-
-            <Eyebrow className="text-muted">music</Eyebrow>
-
-            <div className="stack-mobile grid grid-cols-3 gap-3">
-              <Field>
-                <Label>music mood</Label>
-                <Select
-                  value={draft.mood || undefined}
-                  onValueChange={val => setDraftField({ mood: val })}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="— pick mood —" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      {moods.map(m => <SelectItem key={m} value={m}>{m}</SelectItem>)}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-              </Field>
-              <Field>
-                <Label>era</Label>
-                <Select
-                  value={decadeKeyOf(draft)}
-                  onValueChange={val => {
-                    const d = DECADES.find(x => x.key === val);
-                    setDraftField({ fromYear: d?.from ?? null, toYear: d?.to ?? null });
-                  }}
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      {DECADES.map(d => <SelectItem key={d.key} value={d.key}>{d.label}</SelectItem>)}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-              </Field>
-              <Field>
-                <Label>energy</Label>
-                <Select
-                  value={draft.energy || ANY_SENTINEL}
-                  onValueChange={val => setDraftField({ energy: val === ANY_SENTINEL ? '' : val })}
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      <SelectItem value={ANY_SENTINEL}>Any</SelectItem>
-                      {ENERGY_OPTIONS.map(e => <SelectItem key={e} value={e}>{e}</SelectItem>)}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-              </Field>
-            </div>
-
-            <Field>
-              <Label htmlFor="show-genre">genre lean</Label>
-              <Input
-                id="show-genre"
-                type="text" value={draft.genre} maxLength={64}
-                list="show-genre-options"
-                onChange={(e: ChangeEvent<HTMLInputElement>) => setDraftField({ genre: e.target.value })}
-                placeholder="e.g. Jazz (optional)"
-              />
-              <datalist id="show-genre-options">
-                {genres.map(g => <option key={g} value={g} />)}
-              </datalist>
-            </Field>
-
-            <GenreSuggest
-              adminFetch={adminFetch}
-              value={draft.genre}
-              onSelect={(g) => setDraftField({ genre: g })}
-            />
-
-            <div className="flex items-start gap-3">
-              <div className="pt-0.5">
-                <Toggle
-                  on={draft.genreStrict}
-                  disabled={!draft.genre.trim()}
-                  onClick={() => setDraftField({ genreStrict: !draft.genreStrict })}
-                />
-              </div>
-              <div className="grid gap-0.5">
-                <Label className={!draft.genre.trim() ? 'opacity-40' : undefined}>
-                  Strict genre
-                </Label>
-                <span className="field-hint">
-                  Stay strictly within this genre (off-genre tracks only as a last
-                  resort to avoid silence). Needs a genre lean set above.
-                </span>
-              </div>
-            </div>
-
-            <span className="field-hint -mt-1.5">
-              Optional soft music steer for this show: a genre, an era, an energy
-              band, or any mix. The DJ leans toward these but can break them for
-              flow; leave blank to let the topic and mood drive selection.
-            </span>
-
-            <Field>
-              <Label htmlFor="show-topic">topic (fed to the DJ as the show theme)</Label>
-              <span className="field-hint">
-                This is the brief the AI DJ works from. The more you describe,
-                the better it picks music and writes links: name genres, eras,
-                moods, artists to lean into or avoid, the time of day, the kind
-                of listener, and how the host should sound. Write it like
-                you&apos;re briefing a real DJ before their slot.
-              </span>
-              <Textarea
-                id="show-topic"
-                rows={7} value={draft.topic} maxLength={TOPIC_MAX}
-                onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setDraftField({ topic: e.target.value })}
-                placeholder="e.g. Slow ambient, modern classical and downtempo for the late shift. Think Nils Frahm, Hammock, Bonobo's quieter side, nothing with a hard beat. Keep the host calm and unhurried, like a friend talking you down at 1am."
-              />
-              <span className="field-hint">{draft.topic.trim().length}/{TOPIC_MAX}</span>
-            </Field>
-
-            <Field>
-              <Label htmlFor="show-maxlen">max track length (seconds)</Label>
-              <Input
-                id="show-maxlen"
-                type="number"
-                min={0}
-                max={36000}
-                placeholder="inherit"
-                value={draft.maxTrackSeconds ?? ''}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                  const raw = e.target.value.trim();
-                  setDraftField({ maxTrackSeconds: raw === '' ? null : Math.max(0, parseInt(raw, 10) || 0) });
-                }}
-              />
-              <span className="field-hint">
-                The longest a single track plays while this show is on air —
-                anything longer fades out at the limit. Leave it blank to use the
-                station limit, enter 0 for no limit (good for long mixes or DJ
-                sets), or set at least {data?.values?.minTrackSeconds ?? 30}s to
-                cap it for this show.
-              </span>
-            </Field>
-
-            {!draftValid && (
-              <div className="text-[11px] text-[var(--danger)]">
-                A show needs a name, a persona, and a mood.
-              </div>
-            )}
-          </div>
-        )}
-      </Modal>
     </div>
   );
 }
@@ -1174,24 +1284,33 @@ interface ShowDefRowProps {
   index: number;
   ok: boolean;
   hrs: number;
+  focused: boolean;
   personaLabel: string;
   onEdit: () => void;
   onRemove: () => void;
 }
 
-function ShowDefRow({ show: s, index: i, ok, hrs, personaLabel, onEdit, onRemove }: ShowDefRowProps) {
+function ShowDefRow({ show: s, index: i, ok, hrs, focused, personaLabel, onEdit, onRemove }: ShowDefRowProps) {
   const stripeRef = useRef<HTMLDivElement>(null);
   useDynamicStyle(stripeRef, { background: SHOW_COLORS[i % SHOW_COLORS.length] ?? '#000' });
   return (
     <div
       className={cn(
         'flex items-center gap-3 border py-2.5 pr-3',
-        ok ? 'border-separator-strong' : 'border-[var(--danger)]',
+        focused
+          ? 'border-[var(--accent)] bg-[var(--accent-soft)]'
+          : ok ? 'border-separator-strong' : 'border-[var(--danger)]',
       )}
     >
       <div ref={stripeRef} className="w-1 self-stretch" />
-      <div className="grid min-w-0 flex-1 gap-0.5">
-        <div className="overflow-hidden text-[14px] font-extrabold tracking-[-0.01em] text-ellipsis whitespace-nowrap">
+      {/* Clicking the row opens the show in the editor below (same as Edit). */}
+      <button
+        type="button"
+        onClick={onEdit}
+        aria-pressed={focused}
+        className="grid min-w-0 flex-1 cursor-pointer gap-0.5 border-0 bg-transparent p-0 text-left font-[inherit]"
+      >
+        <div className="overflow-hidden text-[14px] font-extrabold tracking-[-0.01em] text-ellipsis whitespace-nowrap text-ink">
           {s.name.trim() || 'untitled'}
         </div>
         <div className="text-[11px] text-muted">
@@ -1202,13 +1321,13 @@ function ShowDefRow({ show: s, index: i, ok, hrs, personaLabel, onEdit, onRemove
             {s.topic.trim()}
           </div>
         )}
-      </div>
+      </button>
       <div className="flex shrink-0 items-center gap-1.5">
         {!ok && <Pill tone="accent">incomplete</Pill>}
         {hrs > 0
           ? <Pill tone="ink">{hrs}h / week</Pill>
           : <Pill>unscheduled</Pill>}
-        <Btn sm onClick={onEdit}>Edit</Btn>
+        <Btn sm onClick={onEdit}>{focused ? 'Editing' : 'Edit'}</Btn>
         <Btn sm tone="danger" onClick={onRemove} title="Remove this show">
           ✕
         </Btn>


### PR DESCRIPTION
## What

Replaces the `/admin/shows` edit **modal** with an **in-page editor** (the personas pattern), and tightens the save/delete UX across Shows and Personas.

### Why
The edit modal opened narrow then snapped wider — it was the only modal passing a non-default `width={760}`, so its first paint used the Modal's hardcoded `600px` CSS-var fallback before the width effect ran. Removing the Dialog entirely makes the glitch structurally impossible.

### Changes
- **Shows: modal → in-page editor.** Clicking a show (or **Edit**) opens it in a card below the list; the open show is highlighted. Edits are live in form state (no draft copy).
- **Save placement.** Save lives in the editor (**Save show**) and in the Weekly schedule header (**Save schedule**). Removed the redundant bottom "Apply / POST /settings" card and the duplicate **+ New show** hero button (use **+ Add show**).
- **Delete confirms.** Deleting a show (list row ✕ and editor **Remove**) and deleting a persona now go through a confirm dialog (`V3AlertDialog`, red `danger`).
- **Clear week confirm.** The weekly-grid **Clear week** is gated behind a confirm too.

### Notes
- A single save still persists all shows + the weekly grid together (unchanged); the editor's status line spells out that scope.
- Touches `web/components/admin/ShowsPanel.tsx` and `web/components/admin/PersonasPanel.tsx` only.

### Test
- `npm run lint` (eslint + tsc) passes.
- Smoke-tested on the dev stack: `/admin/shows` and `/admin/personas` serve 200; editor opens inline, no width jump; confirms fire on delete and clear-week.