### PR TITLE
feat(skills): create, edit & delete skills from the admin UI

### DIFF
--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -24,7 +24,7 @@ export const VOICE_KINDS = [
   'hourly-check',   // top-of-hour time/weather mention
   'weather',        // weather change announcements (segment capability)
   'news',           // headline read (segment capability)
-  'traffic',        // tongue-in-cheek traffic filler (segment capability)
+  'now-playing-dig',   // search-grounded detail about the on-air track (segment capability)
   'curiosity',      // on-this-day / oddly-specific factoid (segment capability)
   'album-anniversary', // round-number anniversary of the on-air album (segment capability)
   'library-deep-cut',  // tease a forgotten track by the on-air artist (segment capability)
@@ -32,7 +32,7 @@ export const VOICE_KINDS = [
   'default',        // fallback when a kind isn't explicitly mapped
 ];
 
-// Every spoken segment — track intros, links, idents, weather, news, traffic,
+// Every spoken segment — track intros, links, idents, weather, news, digs,
 // facts — is voiced by the persona on air: engine and voice come from the
 // effective persona's `tts` config. Only jingle rendering (a pre-recorded,
 // persona-agnostic stinger) falls back to the global defaultEngine.

--- a/controller/src/broadcast/dj-gate.ts
+++ b/controller/src/broadcast/dj-gate.ts
@@ -6,7 +6,7 @@
 // scheduled show's owner this hour, or the active persona) — quiet | moderate
 // | aggressive.
 //
-// Between-track segments (weather, news, traffic, facts, web search) are NOT
+// Between-track segments (weather, news, now-playing digs, facts, web search) are NOT
 // gated here — the segment-director agent (skills/_agent.js) owns its own
 // frequency floor. Lives outside scheduler.js to keep that file lean.
 

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -1140,8 +1140,8 @@ function wavDurationMs(path: string): number | null {
   }
 }
 
-const VOICE_KINDS = new Set(['dj-speak', 'link', 'station-id', 'hourly-check', 'weather', 'news', 'traffic', 'curiosity', 'album-anniversary', 'library-deep-cut', 'web-search']);
-const DEDUPE_KINDS = new Set(['station-id', 'hourly-check', 'weather', 'news', 'traffic', 'curiosity', 'album-anniversary', 'library-deep-cut', 'web-search']);
+const VOICE_KINDS = new Set(['dj-speak', 'link', 'station-id', 'hourly-check', 'weather', 'news', 'now-playing-dig', 'curiosity', 'album-anniversary', 'library-deep-cut', 'web-search']);
+const DEDUPE_KINDS = new Set(['station-id', 'hourly-check', 'weather', 'news', 'now-playing-dig', 'curiosity', 'album-anniversary', 'library-deep-cut', 'web-search']);
 const KIND_LABEL: Record<string, string> = {
   'dj-speak': 'intro',
   'link': 'link',
@@ -1149,7 +1149,7 @@ const KIND_LABEL: Record<string, string> = {
   'hourly-check': 'hourly',
   'weather': 'weather',
   'news': 'news',
-  'traffic': 'traffic',
+  'now-playing-dig': 'now-playing',
   'curiosity': 'curiosity',
   'album-anniversary': 'anniversary',
   'library-deep-cut': 'deep-cut',

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -2,7 +2,7 @@
 //   - refreshes the auto-playlist file Liquidsoap falls back to
 //   - hourly time check (top of every hour, in character)
 //   - station IDs (every ~45 min, varied by frequency setting)
-//   - agentic segment tick (weather, news, traffic, facts, web search) every 5 min
+//   - agentic segment tick (weather, news, now-playing digs, facts, web search) every 5 min
 
 import cron from 'node-cron';
 import { writeFile } from 'node:fs/promises';
@@ -316,7 +316,7 @@ export async function runLink() {
 // SEGMENT TICK
 // Hands a snapshot of the moment and a set of real-world data tools to the
 // segment-director agent (skills/_agent.js), which decides whether to air one
-// between-track segment (weather / news / traffic / fact / artist news) or to
+// between-track segment (weather / news / now-playing dig / fact / artist news) or to
 // stay silent. The same agent also backs the /dj/skill manual-override route
 // (runCapability), forced to one capability.
 // ---------------------------------------------------------------------------

--- a/controller/src/llm/internal/tools/segment-tools.ts
+++ b/controller/src/llm/internal/tools/segment-tools.ts
@@ -18,9 +18,10 @@ import { fetchOnThisDay, curiositySeen, recordCuriosity } from '../../../skills/
 import { getArtist, searchArtists } from '../../../music/subsonic.js';
 
 // `caps` is the list of capabilities offered this tick (see skills/_agent.js).
-// Only data-backed kinds get a tool — traffic is pure generation and needs none.
-// `curiosity` has a data tool but the agent is free to fall through to pure
-// generation under cap.desc when the tool returns `available: false`.
+// Only data-backed kinds get a tool. `curiosity` has a data tool but the agent
+// is free to fall through to pure generation under cap.desc when the tool
+// returns `available: false`; `now-playing-dig` does NOT — it must stay silent
+// unless its search tool surfaces a real, specific detail (no invented trivia).
 export function buildSegmentTools(ctx: any, state: any, caps: any[]) {
   const kinds = new Set(caps.map((c: any) => c.kind));
   const tools: any = {};
@@ -181,6 +182,37 @@ export function buildSegmentTools(ctx: any, state: any, caps: any[]) {
             .map(r => `${r.title}: ${(r.content || '').replace(/\s+/g, ' ').trim().slice(0, 240)}`);
           if (!answer && sources.length === 0) return { available: false };
           return { artist, alreadySearched, answer, sources };
+        } catch (err) {
+          return { error: err.message };
+        }
+      },
+    });
+  }
+
+  // Now-playing dig — search the web for a concrete detail about the EXACT track
+  // on air (producer, sample, B-side, chart, backstory). Grounded so the DJ
+  // never invents track trivia: returns { available: false } when nothing solid
+  // comes back, and the brief says to stay silent on that.
+  if (kinds.has('now-playing-dig') && searchReady()) {
+    tools.digCurrentTrack = tool({
+      description: 'Search the web for a specific, verifiable detail about the exact track currently on air (producer, sample, B-side, chart, backstory).',
+      inputSchema: z.object({}),
+      execute: async () => {
+        const cur = queue.current?.track;
+        const artist = cur?.artist;
+        const title = cur?.title;
+        if (!artist || !title || /^unknown/i.test(artist) || /^unknown/i.test(title)) return { available: false };
+        const trackKey = `${artist} — ${title}`;
+        const alreadyDug = trackKey === state.lastDugTrack;
+        try {
+          const data = await searchWeb(`${artist} "${title}" song producer sample b-side chart story`);
+          state.lastDugTrack = trackKey;
+          const answer = (data.answer || '').trim();
+          const sources = (data.results || [])
+            .slice(0, 3)
+            .map(r => `${r.title}: ${(r.content || '').replace(/\s+/g, ' ').trim().slice(0, 240)}`);
+          if (!answer && sources.length === 0) return { available: false };
+          return { artist, title, alreadyDug, answer, sources };
         } catch (err) {
           return { error: err.message };
         }

--- a/controller/src/middleware/cors.ts
+++ b/controller/src/middleware/cors.ts
@@ -2,7 +2,7 @@
 // Caddy in prod and is only reachable on the LAN in dev.
 export function cors(req, res, next) {
   res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
   if (req.method === 'OPTIONS') return res.sendStatus(200);
   next();

--- a/controller/src/routes/dj.ts
+++ b/controller/src/routes/dj.ts
@@ -11,12 +11,12 @@ import * as subsonic from '../music/subsonic.js';
 import * as library from '../music/library.js';
 import * as settings from '../settings.js';
 import { runStationId, runHourlyCheck, runLink, refreshAutoPlaylist } from '../broadcast/scheduler.js';
-import { skillCatalog, runCapability } from '../skills/_agent.js';
-import { loadCustomSkills, parseFrontmatter, BUILTIN_KINDS } from '../skills/loader.js';
-import { writeBuiltinSkillFile, msToCooldownStr } from '../skills/scaffold.js';
-import { readFile } from 'node:fs/promises';
+import { skillCatalog, runCapability, CAPABILITIES, effectiveContextFields } from '../skills/_agent.js';
+import { loadCustomSkills, parseFrontmatter, BUILTIN_KINDS, RESERVED_KINDS, SLUG_RE } from '../skills/loader.js';
+import { writeSkillFile, msToCooldownStr } from '../skills/scaffold.js';
+import { readFile, rm, stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
-import { STATE_DIR } from '../config.js';
+import { STATE_DIR, config } from '../config.js';
 import { skipTrack } from '../broadcast/liquidsoap-control.js';
 import { getFullContext } from '../context.js';
 
@@ -51,73 +51,242 @@ router.post('/dj/skills/rescan', requireAdmin, async (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
-// GET /dj/skills/:kind/file — read a built-in skill's editable SKILL.md so the
-// admin UI can prefill its edit form. Scoped to the 7 built-in kinds; custom
-// skills are edited on disk + Rescan, not here. Falls back to live defaults
-// (skillCatalog) when the file hasn't been scaffolded yet.
+// Custom-skill CRUD helpers. Custom skills live at state/skills/<slug>/SKILL.md
+// (prompt-only: frontmatter + the markdown brief). The controller is the single
+// validation gate, reusing SLUG_RE / RESERVED_KINDS / dj.CONTEXT_FIELDS so the
+// rules never drift from what the loader enforces. tool.mjs stays a disk-drop +
+// Rescan power-feature — writeSkillFile never touches it.
+// ---------------------------------------------------------------------------
+const SKILLS_DIR = resolve(STATE_DIR, 'skills');
+const COOLDOWN_RE = /^\d+\s*[smhd]?$/;
+const ENV_KEY_RE = /^[A-Z][A-Z0-9_]*$/;
+
+// True when SKILL.md exists for this slug (folder is a real skill).
+async function skillFileExists(slug: string): Promise<boolean> {
+  try { await stat(join(SKILLS_DIR, slug, 'SKILL.md')); return true; } catch { return false; }
+}
+
+// True when the custom skill has a tool.mjs data fetcher beside SKILL.md, so the
+// edit form can warn that a data tool is attached and edited on disk, not here.
+async function skillHasTool(slug: string): Promise<boolean> {
+  try { await stat(join(SKILLS_DIR, slug, 'tool.mjs')); return true; } catch { return false; }
+}
+
+// Validate the prompt-only fields shared by create + custom-edit, returning a
+// SkillFileFields object for writeSkillFile. Throws Error(message) on the first
+// invalid field; callers map that to a 400. The slug is the immutable identity,
+// passed in (from the URL on edit, from the body on create).
+function buildCustomSkillFields(slug: string, b: any): any {
+  const brief = typeof b.brief === 'string' ? b.brief.trim() : '';
+  if (!brief) throw new Error('brief is required');
+
+  const cooldown = typeof b.cooldown === 'string' ? b.cooldown.trim() : '';
+  if (cooldown && !COOLDOWN_RE.test(cooldown)) {
+    throw new Error('cooldown must look like "45m", "6h", "2d", or a bare number (minutes)');
+  }
+
+  const label = typeof b.label === 'string' && b.label.trim() ? b.label.trim() : undefined;
+  const fields: any = { kind: slug, label, cooldown: cooldown || undefined, brief };
+
+  // Context fields — the "right now" lines this segment may weave in (#471).
+  // Accept a comma string or an array; validate every token so a typo fails
+  // loudly here. An empty selection resets the skill to the default profile.
+  if (b.context !== undefined) {
+    const raw = Array.isArray(b.context) ? b.context : String(b.context).split(',');
+    const toks = raw.map((s: any) => String(s).trim().toLowerCase()).filter(Boolean);
+    const known = new Set<string>(dj.CONTEXT_FIELDS as readonly string[]);
+    const bad = toks.filter((t: string) => !known.has(t));
+    if (bad.length) {
+      throw new Error(`unknown context field(s): ${bad.join(', ')} — valid: ${[...known].join(', ')}`);
+    }
+    if (toks.length) fields.contextFields = toks;
+  }
+
+  if (b.window !== undefined) {
+    const w = String(b.window).trim().toLowerCase();
+    if (w !== 'any' && w !== 'commute') throw new Error('window must be "any" or "commute"');
+    if (w === 'commute') fields.window = 'commute';
+  }
+
+  if (b.requiresKey !== undefined && String(b.requiresKey).trim()) {
+    const key = String(b.requiresKey).trim();
+    if (!ENV_KEY_RE.test(key)) throw new Error('requiresKey must be an env var name (UPPER_SNAKE_CASE)');
+    fields.requiresKey = key;
+  }
+
+  return fields;
+}
+
+// ---------------------------------------------------------------------------
+// GET /dj/skills/:kind/file — read a skill's editable SKILL.md so the admin UI
+// can prefill its edit form. Serves both the 7 built-in kinds (falling back to
+// live defaults when the file hasn't been scaffolded yet) and custom skills
+// (404 when there's no such folder).
 // ---------------------------------------------------------------------------
 router.get('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
   const kind = req.params.kind;
-  if (!BUILTIN_KINDS.has(kind)) {
-    return res.status(400).json({ error: `not an editable built-in skill: ${kind}` });
-  }
-  const file = join(resolve(STATE_DIR, 'skills', kind), 'SKILL.md');
   const cat = skillCatalog().find(s => s.kind === kind);
+
+  if (BUILTIN_KINDS.has(kind)) {
+    // Shipped defaults from the RAW CAPABILITIES entry (NOT the override-merged
+    // catalogue), so the admin "Reset to default" restores the as-shipped brief
+    // even after the SKILL.md has been edited. News seeds its feed from config
+    // (env-or-BBC), mirroring the scaffolder.
+    const rawCap = CAPABILITIES.find((c: any) => c.kind === kind);
+    const defaults = rawCap ? {
+      label: rawCap.label || kind,
+      cooldown: msToCooldownStr(rawCap.cooldownMs || 0),
+      context: (effectiveContextFields(rawCap) || []).join(', '),
+      brief: rawCap.desc || '',
+      ...(kind === 'news' ? { feed: config.news.feedUrl, feedMaxItems: config.news.maxItems } : {}),
+    } : null;
+
+    const file = join(SKILLS_DIR, kind, 'SKILL.md');
+    try {
+      const raw = await readFile(file, 'utf8');
+      const { data, body } = parseFrontmatter(raw);
+      return res.json({
+        kind,
+        custom: false,
+        exists: true,
+        isNews: kind === 'news',
+        label: data.label || cat?.label || kind,
+        cooldown: data.cooldown || msToCooldownStr(cat?.cooldownMs || 0),
+        // Comma-separated "right now" fields this segment may weave in (#471).
+        // Prefer the file's own value; fall back to the live effective set.
+        context: (data.context ?? data.contextFields)?.trim() || (cat?.contextFields || []).join(', '),
+        knownContextFields: [...dj.CONTEXT_FIELDS],
+        feed: data.feed || cat?.feed || null,
+        feedMaxItems: data.feedMaxItems ? parseInt(data.feedMaxItems, 10) : (cat?.feedMaxItems || null),
+        brief: body || cat?.description || '',
+        defaults,
+      });
+    } catch {
+      // No file yet — hand back the live built-in defaults so the form prefills.
+      return res.json({
+        kind,
+        custom: false,
+        exists: false,
+        isNews: kind === 'news',
+        label: cat?.label || kind,
+        cooldown: msToCooldownStr(cat?.cooldownMs || 0),
+        context: (cat?.contextFields || []).join(', '),
+        knownContextFields: [...dj.CONTEXT_FIELDS],
+        feed: cat?.feed || null,
+        feedMaxItems: cat?.feedMaxItems || null,
+        brief: cat?.description || '',
+        defaults,
+      });
+    }
+  }
+
+  // Custom skill — prefill the edit form from its SKILL.md.
+  if (!SLUG_RE.test(kind)) {
+    return res.status(400).json({ error: `invalid skill name: ${kind}` });
+  }
   try {
-    const raw = await readFile(file, 'utf8');
+    const raw = await readFile(join(SKILLS_DIR, kind, 'SKILL.md'), 'utf8');
     const { data, body } = parseFrontmatter(raw);
     res.json({
       kind,
+      custom: true,
       exists: true,
-      isNews: kind === 'news',
+      isNews: false,
       label: data.label || cat?.label || kind,
-      cooldown: data.cooldown || msToCooldownStr(cat?.cooldownMs || 0),
-      // Comma-separated "right now" fields this segment may weave in (#471).
-      // Prefer the file's own value; fall back to the live effective set.
+      cooldown: data.cooldown || (cat?.cooldownMs ? msToCooldownStr(cat.cooldownMs) : ''),
       context: (data.context ?? data.contextFields)?.trim() || (cat?.contextFields || []).join(', '),
       knownContextFields: [...dj.CONTEXT_FIELDS],
-      feed: data.feed || cat?.feed || null,
-      feedMaxItems: data.feedMaxItems ? parseInt(data.feedMaxItems, 10) : (cat?.feedMaxItems || null),
-      brief: body || cat?.description || '',
+      window: data.window === 'commute' ? 'commute' : 'any',
+      requiresKey: data.requiresKey || '',
+      hasTool: await skillHasTool(kind),
+      brief: body || '',
     });
   } catch {
-    // No file yet — hand back the live built-in defaults so the form prefills.
-    res.json({
-      kind,
-      exists: false,
-      isNews: kind === 'news',
-      label: cat?.label || kind,
-      cooldown: msToCooldownStr(cat?.cooldownMs || 0),
-      context: (cat?.contextFields || []).join(', '),
-      knownContextFields: [...dj.CONTEXT_FIELDS],
-      feed: cat?.feed || null,
-      feedMaxItems: cat?.feedMaxItems || null,
-      brief: cat?.description || '',
-    });
+    res.status(404).json({ error: `no such skill: ${kind}` });
   }
 });
 
 // ---------------------------------------------------------------------------
-// PUT /dj/skills/:kind/file — write a built-in skill's SKILL.md from the admin
-// edit form (brief/cooldown/label, + feed/feedMaxItems for news), then reload
-// so the override applies immediately. Scoped to the 7 built-in kinds.
+// POST /dj/skills — create a custom (prompt-only) skill. Writes a new
+// state/skills/<slug>/SKILL.md and reloads. Created skills arrive DISABLED (the
+// loader's posture) — the operator reviews + enables them before they can air.
+// Body: { name, label?, cooldown?, context?, window?, requiresKey?, brief }
+// ---------------------------------------------------------------------------
+router.post('/dj/skills', requireAdmin, async (req, res) => {
+  const b = req.body || {};
+  const name = typeof b.name === 'string' ? b.name.trim().toLowerCase() : '';
+  if (!SLUG_RE.test(name)) {
+    return res.status(400).json({ error: 'name must be a lowercase slug (a–z, 0–9, hyphens), 1–49 chars' });
+  }
+  if (RESERVED_KINDS.has(name)) {
+    return res.status(400).json({ error: `"${name}" is reserved — it shadows a built-in capability, pick another name` });
+  }
+  if (await skillFileExists(name)) {
+    return res.status(409).json({ error: `a skill named "${name}" already exists` });
+  }
+
+  let fields: any;
+  try {
+    fields = buildCustomSkillFields(name, b);
+  } catch (err: any) {
+    return res.status(400).json({ error: err.message });
+  }
+
+  try {
+    await writeSkillFile(fields);
+    await loadCustomSkills();
+    queue.log('scheduler', `[skills] custom "${name}" created via admin UI`);
+    res.json({ skills: skillCatalog() });
+  } catch (err: any) {
+    queue.log('error', `POST /dj/skills (${name}) failed: ${err.message}`);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// PUT /dj/skills/:kind/file — write a skill's SKILL.md from the admin edit form,
+// then reload so the change applies immediately. Built-in kinds take the news-
+// aware path; custom slugs (which must already exist) take the prompt-only path.
 // ---------------------------------------------------------------------------
 router.put('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
   const kind = req.params.kind;
-  if (!BUILTIN_KINDS.has(kind)) {
-    return res.status(400).json({ error: `not an editable built-in skill: ${kind}` });
-  }
   const b = req.body || {};
+
+  // Custom skill edit — same validation as create, minus the slug (immutable).
+  if (!BUILTIN_KINDS.has(kind)) {
+    if (!SLUG_RE.test(kind)) {
+      return res.status(400).json({ error: `invalid skill name: ${kind}` });
+    }
+    if (!(await skillFileExists(kind))) {
+      return res.status(404).json({ error: `no such custom skill: ${kind} — create it first` });
+    }
+    let fields: any;
+    try {
+      fields = buildCustomSkillFields(kind, b);
+    } catch (err: any) {
+      return res.status(400).json({ error: err.message });
+    }
+    try {
+      await writeSkillFile(fields); // rewrites SKILL.md only; a sibling tool.mjs is left intact
+      await loadCustomSkills();
+      queue.log('scheduler', `[skills] custom "${kind}" edited via admin UI`);
+      return res.json({ skills: skillCatalog() });
+    } catch (err: any) {
+      queue.log('error', `PUT /dj/skills/${kind}/file failed: ${err.message}`);
+      return res.status(500).json({ error: err.message });
+    }
+  }
+
+  // Built-in edit — brief/cooldown/label/context, + feed/feedMaxItems for news.
   const brief = typeof b.brief === 'string' ? b.brief.trim() : '';
   if (!brief) return res.status(400).json({ error: 'brief is required' });
 
   const cooldown = typeof b.cooldown === 'string' ? b.cooldown.trim() : '';
-  if (cooldown && !/^\d+\s*[smhd]?$/.test(cooldown)) {
+  if (cooldown && !COOLDOWN_RE.test(cooldown)) {
     return res.status(400).json({ error: 'cooldown must look like "45m", "6h", "2d", or a bare number (minutes)' });
   }
 
   const label = typeof b.label === 'string' && b.label.trim() ? b.label.trim() : undefined;
-
   const fields: any = { kind, label, cooldown: cooldown || undefined, brief };
 
   // Context fields — the "right now" lines this segment may weave in (#471).
@@ -152,12 +321,39 @@ router.put('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
   }
 
   try {
-    await writeBuiltinSkillFile(fields);
+    await writeSkillFile(fields);
     await loadCustomSkills();
     queue.log('scheduler', `[skills] built-in "${kind}" edited via admin UI`);
     res.json({ skills: skillCatalog() });
   } catch (err: any) {
     queue.log('error', `PUT /dj/skills/${kind}/file failed: ${err.message}`);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /dj/skills/:slug — remove a custom skill (its whole folder, including
+// any tool.mjs). Built-ins can't be deleted; they're edited in place. Reloads
+// and returns the refreshed catalogue.
+// ---------------------------------------------------------------------------
+router.delete('/dj/skills/:slug', requireAdmin, async (req, res) => {
+  const slug = req.params.slug;
+  if (BUILTIN_KINDS.has(slug)) {
+    return res.status(400).json({ error: "built-in skills can't be deleted — edit them instead" });
+  }
+  if (!SLUG_RE.test(slug)) {
+    return res.status(400).json({ error: `invalid skill name: ${slug}` });
+  }
+  if (!(await skillFileExists(slug))) {
+    return res.status(404).json({ error: `no such custom skill: ${slug}` });
+  }
+  try {
+    await rm(join(SKILLS_DIR, slug), { recursive: true, force: true });
+    await loadCustomSkills();
+    queue.log('scheduler', `[skills] custom "${slug}" deleted via admin UI`);
+    res.json({ skills: skillCatalog() });
+  } catch (err: any) {
+    queue.log('error', `DELETE /dj/skills/${slug} failed: ${err.message}`);
     res.status(500).json({ error: err.message });
   }
 });

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -28,7 +28,8 @@
 //   - a frequency-derived floor on the gap between ANY two segments
 //   - capabilities the operator disabled, or the on-air persona doesn't own,
 //     are never offered
-//   - traffic is only offered during commute hours; web-search only with a key
+//   - commute-only skills (via `window: commute`) air only during commute hours;
+//     search-backed skills (web-search, now-playing-dig) only with a provider
 
 import { z } from 'zod';
 import { queue } from '../broadcast/queue.js';
@@ -48,7 +49,7 @@ import * as sfx from '../broadcast/sfx.js';
 //   label       — human label for the admin command-center UI
 //   cooldownMs  — hard minimum gap between autonomous firings of this kind
 //   desc        — the one-line briefing shown BOTH to the agent (per-capability
-//                 guidance — for traffic, which has no data tool, this is the
+//                 guidance — for a skill with no data tool, this is the
 //                 agent's ONLY brief) and to the admin UI
 //   contextFields — (optional) the "right now" fields (CONTEXT_FIELDS) this
 //                 capability's situation block may include. Unset → the default
@@ -71,32 +72,35 @@ export const CAPABILITIES: any[] = [
     // default profile (no weather), so weather stops bleeding into news,
     // curiosity, deep cuts, etc. (issue #471).
     contextFields: [...CONTEXT_FIELDS],
-    desc: 'A short weather check, in character — one or two sentences. Only worth airing when conditions have genuinely changed.',
+    desc: 'A quick, in-character read on the weather right now — one or two sentences that fold the conditions into the moment, never a forecast or a temperature readout. Only air it when the weather has genuinely turned; don\'t narrate "still grey out". Never open with "here\'s your weather" or "weather check".',
   },
   {
     kind: 'news', skill: 'news', label: 'News headlines',
     cooldownMs: 45 * 60 * 1000,
-    desc: 'Read one fresh headline in a single sentence — half-distracted BBC 6 Music tone, never an anchor voice, no editorialising, no "in other news".',
+    desc: 'Glance at one fresh headline and drop it into a single sentence in your own words — a casual, half-distracted aside between songs, never an anchor or newsreader voice, never the headline read verbatim, no editorialising, no "in other news". Steer to the lighter, cultural, or human-interest item; if everything on the feed is grim — war, death, disaster — say nothing. A music station shouldn\'t read tragedy in a breezy aside.',
   },
   {
-    kind: 'traffic', skill: 'traffic', label: 'Traffic',
-    cooldownMs: 90 * 60 * 1000,
-    desc: 'A deadpan mock "travel and traffic report for the listening area" — one absurd, small-scale sentence played dead straight, like a real travel bulletin, but about everyday or online congestion instead of roads: a tailback at the kettle, a bottleneck on the stairs, slow buffering in the inside lane, a queue building on the sofa. Keep it small and universal — never a real road, place name, or actual incident.',
+    kind: 'now-playing-dig', skill: 'now-playing-dig', label: 'Now-playing dig',
+    cooldownMs: 45 * 60 * 1000,
+    // Search-grounded, like web-search: only ready when a provider is configured.
+    // The data tool (digCurrentTrack) is wired by kind in llm/segment-tools.ts.
+    ready: () => searchReady(),
+    desc: 'One concrete, verifiable detail about the exact track on air — who produced it, a sample it\'s built on, the B-side, where it charted, the story behind it — worked into a single conversational line. Use only what the search tool actually surfaces; if it returns nothing solid, say nothing. Never guess, never "I think", no "fun fact", no URLs. It\'s about this specific track, not the artist in general.',
   },
   {
     kind: 'curiosity', skill: 'curiosity', label: 'Curiosity',
     cooldownMs: 60 * 60 * 1000,
-    desc: 'One oddly-specific moment of interest — a real "on this day in 19xx" beat from history if the tool surfaces a good one, otherwise a concrete factoid lightly themed to the hour or season. Never say "fun fact", "interestingly", or "did you know".',
+    desc: 'One oddly-specific moment of interest — ideally a real "on this day" beat from the tool (any year), dropped in like you just remembered it. If the tool has nothing, offer a light, true observation tied to the date or season rather than a hard "fact" you can\'t vouch for — and if you\'d be guessing, skip it. Never say "fun fact", "interestingly", or "did you know".',
   },
   {
     kind: 'album-anniversary', skill: 'album-anniversary', label: 'Album anniversary',
     cooldownMs: 6 * 60 * 60 * 1000,
-    desc: 'If the album currently on air is hitting a 5/10/20/25-year mark this year, note it like a presenter spotting a date in the prep notes — one short sentence, never gushing, never "classic".',
+    desc: 'If the album on air is hitting a round-number anniversary this year, note it like a presenter spotting a date in the prep notes — one short sentence on the date itself. Trust the year you\'re given; don\'t pad it with claims about what the album "meant" or how it charted. Never gushing, never "classic".',
   },
   {
     kind: 'library-deep-cut', skill: 'library-deep-cut', label: 'Library deep-cut tease',
     cooldownMs: 90 * 60 * 1000,
-    desc: 'If the on-air artist has a track in the library that has not been played in months, tease that it might come around later — one sentence, like a presenter teasing the rest of the show. Never name the track unless the tool surfaced exactly one.',
+    desc: 'If the on-air artist has a track in the library that\'s gone cold (not played in a while), tease it like there\'s more worth digging out of the crate — one sentence, in passing, without promising when it\'ll play. Never name the track unless the tool surfaced exactly one, and don\'t characterise how it sounds.',
   },
   {
     kind: 'web-search', skill: 'web-search', label: 'Web search',
@@ -106,7 +110,7 @@ export const CAPABILITIES: any[] = [
     // DuckDuckGo (the default) needs no key; Tavily needs SEARCH_API_KEY (or a
     // key pasted into the admin UI). searchReady() encapsulates both.
     ready: () => searchReady(),
-    desc: 'Work one genuine, recent detail about the artist on air into a single conversational line — no "I read online", no URLs, no list.',
+    desc: 'Work one genuine, recent thing the on-air artist is up to — a new release, a tour, something in the press this week — into a single conversational line. Use only what the search returned; if it surfaced nothing solid or nothing new, say nothing. No "I read online", no URLs, no list, no embellishing beyond the facts.',
   },
 ];
 
@@ -227,9 +231,10 @@ function availableCapabilities(ctx: any, now: Date) {
     if (!isEnabled) continue;
     if (persona?.skills && !persona.skills.includes(cap.skill)) continue;
     if (now.getTime() - (lastFired.get(cap.kind) || 0) < cap.cooldownMs) continue;
-    // Window gating: built-in traffic is commute-only; custom skills opt in via
-    // `window: commute` in their SKILL.md frontmatter.
-    if ((cap.kind === 'traffic' || cap.window === 'commute') && !ctx.clock?.isCommute) continue;
+    // Window gating: custom skills opt into commute-hours-only firing via
+    // `window: commute` in their SKILL.md frontmatter. (No built-in is
+    // commute-gated by default since the traffic skill was retired.)
+    if (cap.window === 'commute' && !ctx.clock?.isCommute) continue;
     if (cap.ready && !cap.ready()) continue;
     out.push(cap);
   }

--- a/controller/src/skills/loader.ts
+++ b/controller/src/skills/loader.ts
@@ -57,19 +57,24 @@ import { queue } from '../broadcast/queue.js';
 // than rejected — that's how operators edit the shipped skills. Everything else
 // in RESERVED_KINDS is queue-internal and stays un-overridable.
 export const BUILTIN_KINDS = new Set([
-  'weather', 'news', 'traffic', 'curiosity',
+  'weather', 'news', 'now-playing-dig', 'curiosity',
   'album-anniversary', 'library-deep-cut', 'web-search',
 ]);
 
-// Built-in capability kinds — custom skills may not shadow these.
-const RESERVED_KINDS = new Set([
+// Built-in capability kinds — custom skills may not shadow these. Exported so
+// the admin create route (POST /dj/skills) rejects the same set the loader does.
+export const RESERVED_KINDS = new Set([
   ...BUILTIN_KINDS,
   // queue.announce reserves 'link' for the light-ducked intro channel.
   'link', 'dj-speak', 'announcement', 'station-id', 'hourly',
 ]);
 
 const SKILLS_DIR = resolve(STATE_DIR, 'skills');
-const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,48}$/;
+// Custom-skill slug: lowercase, starts alphanumeric, then alphanumeric/hyphen,
+// ≤49 chars. Anchored, so it can't contain '/', '.', or whitespace — the routes
+// rely on that to keep a slug from escaping state/skills/. Exported so the admin
+// create route validates against the exact pattern the loader enforces.
+export const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,48}$/;
 
 // Loaded custom capabilities, in the same shape as _agent.js CAPABILITIES,
 // plus { custom: true } and an optional wrapped data tool. Rebuilt on reload.

--- a/controller/src/skills/scaffold.ts
+++ b/controller/src/skills/scaffold.ts
@@ -28,20 +28,25 @@ export function msToCooldownStr(ms: number): string {
 }
 
 interface SkillFileFields {
-  kind: string;
+  kind: string;             // == the slug for a custom skill
   label?: string;
   cooldown?: string;
   contextFields?: string[]; // "right now" fields the segment may mention (#471)
+  window?: 'any' | 'commute'; // custom skills only — emitted when 'commute'
+  requiresKey?: string;       // custom skills only — env var the skill needs
   feed?: string;        // news only
   feedMaxItems?: number; // news only
   brief?: string;
 }
 
-// Render + write a built-in skill's SKILL.md. Used by the scaffolder (seeding
-// defaults) and the admin edit route (PUT /dj/skills/:kind/file). Creates the
-// folder if absent and overwrites the file unconditionally — callers decide
-// whether to call it (the scaffolder stats first; the route always writes).
-export async function writeBuiltinSkillFile(fields: SkillFileFields): Promise<void> {
+// Render + write a skill's SKILL.md. Used by the scaffolder (seeding the 7
+// built-in defaults), the admin built-in edit route (PUT /dj/skills/:kind/file),
+// and the custom-skill create/edit routes (POST /dj/skills, PUT
+// /dj/skills/:slug/file). Creates the folder if absent and overwrites the file
+// unconditionally — callers decide whether to call it (the scaffolder stats
+// first; the routes always write). Never touches a sibling `tool.mjs`, so
+// editing a custom skill's brief leaves its data tool intact.
+export async function writeSkillFile(fields: SkillFileFields): Promise<void> {
   const { kind } = fields;
   const lines = ['---', `name: ${kind}`];
   if (fields.label) lines.push(`label: ${fields.label}`);
@@ -50,6 +55,10 @@ export async function writeBuiltinSkillFile(fields: SkillFileFields): Promise<vo
   // the knob is visible+editable in every scaffolded SKILL.md; add or drop
   // tokens (e.g. `weather`) to change what the segment is allowed to mention.
   if (fields.contextFields && fields.contextFields.length) lines.push(`context: ${fields.contextFields.join(', ')}`);
+  // Custom-skill knobs. `window: any` is the loader default, so only the
+  // restrictive `commute` value is worth writing.
+  if (fields.window === 'commute') lines.push('window: commute');
+  if (fields.requiresKey) lines.push(`requiresKey: ${fields.requiresKey}`);
   if (fields.feed) lines.push(`feed: ${fields.feed}`);
   if (fields.feedMaxItems) lines.push(`feedMaxItems: ${fields.feedMaxItems}`);
   lines.push('---', (fields.brief || '').trim(), '');
@@ -86,7 +95,7 @@ export async function scaffoldBuiltinSkills(): Promise<void> {
         fields.feed = config.news.feedUrl; // already env-or-BBC (config.ts)
         fields.feedMaxItems = config.news.maxItems;
       }
-      await writeBuiltinSkillFile(fields);
+      await writeSkillFile(fields);
       queue.log('scheduler', `[skills] scaffolded built-in "${cap.kind}" → state/skills/${cap.kind}/SKILL.md`);
     } catch (err: any) {
       queue.log('error', `[skills] failed to scaffold "${cap.kind}": ${err?.message || err}`);

--- a/docs/custom-skills.md
+++ b/docs/custom-skills.md
@@ -1,11 +1,19 @@
 # Custom skills
 
 SUB/WAVE's **skills** are the things the AI DJ does *between* tracks — a weather
-check, a headline, a tongue-in-cheek traffic gag. The built-in ones are defined in
+check, a headline, a dig on the song playing. The built-in ones are defined in
 `controller/src/skills/_agent.ts` and **scaffolded as editable files** into
 `state/skills/<kind>/SKILL.md` on first boot — so you can change what they say (and,
 for news, which feed they read) without touching the codebase. You can also add
-entirely new skills by dropping a folder into `state/skills/`.
+entirely new skills — either from the admin UI or by dropping a folder into
+`state/skills/`.
+
+> **TL;DR — want a brand-new segment?** Open **/admin/skills → New skill**, fill in
+> a name, a brief, and a cooldown, then **Create skill**. It writes
+> `state/skills/<slug>/SKILL.md` for you (and arrives **disabled** — enable it when
+> you're happy). Custom skills can also be **edited** and **deleted** from the same
+> page. The form is prompt-only; a `tool.mjs` data fetcher is still a disk-drop (see
+> [tool.mjs (optional)](#toolmjs-optional) below).
 
 > **TL;DR — News reads UK/BBC and you want something local?** Open
 > **/admin/skills → News → Edit**, paste your own RSS feed URL and rewrite the
@@ -90,7 +98,7 @@ You can also set this from the admin UI: **/admin/skills → Edit** shows a
 tick-box per field. An empty selection resets the skill to the default profile.
 
 For a **new** skill the `name` must be a lowercase slug that isn't a built-in kind
-(`weather`, `news`, `traffic`, `curiosity`, `album-anniversary`, `library-deep-cut`,
+(`weather`, `news`, `now-playing-dig`, `curiosity`, `album-anniversary`, `library-deep-cut`,
 `web-search`). Naming a folder after a built-in kind instead *edits* that built-in —
 see [Editing the built-in skills](#editing-the-built-in-skills). Bad frontmatter is
 logged and skipped — it never crashes the controller.
@@ -113,8 +121,8 @@ export default async function (ctx, state) {
 
 The call is **timeout-guarded (8 s)** and any throw degrades cleanly to "no
 data" — a slow or broken skill can never hang the between-track tick. With no
-`tool.mjs`, the skill is pure generation (like the built-in `traffic`): the DJ
-writes from the brief alone.
+`tool.mjs`, the skill is pure generation: the DJ writes from the brief alone,
+with no live data to look at.
 
 > **Security.** `tool.mjs` runs operator-supplied code inside the controller
 > container — the same trust model as a locally-installed Claude Code skill.
@@ -122,7 +130,7 @@ writes from the brief alone.
 
 ## Editing the built-in skills
 
-The 7 built-ins — `weather`, `news`, `traffic`, `curiosity`, `album-anniversary`,
+The 7 built-ins — `weather`, `news`, `now-playing-dig`, `curiosity`, `album-anniversary`,
 `library-deep-cut`, `web-search` — are written into `state/skills/<kind>/SKILL.md`
 the first time the controller boots. A file **named after a built-in kind** is an
 **override**: it edits that skill's brief / cooldown / label / `context:` in place

--- a/docs/superpowers/specs/2026-06-29-admin-create-skills-design.md
+++ b/docs/superpowers/specs/2026-06-29-admin-create-skills-design.md
@@ -1,0 +1,271 @@
+# Create custom skills from the admin UI — design
+
+**Date:** 2026-06-29
+**Branch:** `worktree-admin-create-skills`
+**Issue/ask:** `/admin/skills` has no way to *create* a skill. Custom skills can
+only be made by dropping `state/skills/<slug>/SKILL.md` on disk and hitting
+Rescan. Make it work like Themes / Shows / Personas — create, edit, delete from
+the UI.
+
+## Goal
+
+Give **custom** skills full create / edit / delete from `/admin/skills`, matching
+the experience of Themes / Shows / Personas. Authoring is **prompt-only**:
+frontmatter + the markdown brief. The executable `tool.mjs` data-fetcher stays a
+power-user, disk-drop feature (an operator drops `tool.mjs` next to the
+UI-created `SKILL.md` and hits Rescan).
+
+### Non-goals (YAGNI for v1)
+
+- **No `tool.mjs` code editor.** No arbitrary JS authored over an HTTP form.
+- **No deleting / folder-removing built-in skills.** Built-ins keep their existing
+  edit-in-place behaviour and cannot be deleted (the 7 kinds are always present).
+- **No "AI-draft a skill" generator.** Themes/Shows/Personas each have a
+  `/generate/*` LLM helper; a `/generate/skill` companion is a plausible
+  *follow-up* but is out of scope here. Noted so it isn't silently dropped.
+
+## Background — how skills differ from shows/personas
+
+Themes, Shows, and Personas live in `state/settings.json` and are mutated through
+`settings.update()`. **Skills are file-based**: each lives at
+`state/skills/<slug>/SKILL.md` (YAML frontmatter + a markdown body that *is* the
+DJ's brief), optionally beside a `tool.mjs`. The loader
+(`controller/src/skills/loader.ts`) scans that dir and merges results into the
+segment-director capability table.
+
+What already exists and is reused unchanged:
+
+- **The file writer** — `writeBuiltinSkillFile()` in `skills/scaffold.ts` renders
+  frontmatter + brief to `SKILL.md`. (Renamed/generalised below.)
+- **The parser** — `parseFrontmatter()` in `skills/loader.ts`.
+- **The loader/reload** — `loadCustomSkills()`; already wired to the Rescan button.
+- **The catalogue** — `skillCatalog()` in `skills/_agent.ts`; backs the list and
+  already surfaces `custom`, `requiresKey`, `keyUrl`, `cooldownMs`, etc.
+- **The validation vocabulary** — `dj.CONTEXT_FIELDS`
+  (`['date','clock','time','weather','festival','show','listeners']`), the slug
+  regex `SLUG_RE` and the `RESERVED_KINDS` set in `loader.ts`.
+
+So this feature is mostly **new routes + a UI form**, not new machinery.
+
+## Architecture
+
+Three layers, each with one job:
+
+1. **Controller routes** (`controller/src/routes/dj.ts`) — the CRUD surface and the
+   single point of validation. The controller is the source of truth; the browser
+   does only light UX validation.
+2. **File writer** (`controller/src/skills/scaffold.ts`) — generalised to render
+   the two extra prompt-only frontmatter keys custom skills use (`window`,
+   `requiresKey`).
+3. **Admin UI** (`web/components/admin/SkillsPanel.tsx` + a new
+   `web/components/admin/skills/SkillForm.tsx`) — a "New skill" button and a
+   reusable create/edit form; Edit + Delete buttons on custom skill cards.
+
+### Data flow
+
+```
+[New skill] / [Edit] (custom)        SkillForm (web)
+        │  POST /dj/skills            ──► validate ──► writeSkillFile() ──► SKILL.md
+        │  PUT  /dj/skills/:slug/file ──► validate ──► writeSkillFile() ──► SKILL.md
+        │  GET  /dj/skills/:slug/file ◄── parseFrontmatter() (prefill edit form)
+        │  DELETE /dj/skills/:slug    ──► rm -rf state/skills/<slug>/
+        ▼
+  loadCustomSkills()  ──►  skillCatalog()  ──►  { skills:[…] } back to the panel
+```
+
+Every mutating route ends by calling `loadCustomSkills()` then returning
+`{ skills: skillCatalog() }`, exactly like the existing toggle/edit/rescan routes,
+so the panel refreshes from one response shape.
+
+## Controller changes
+
+### 1. `skills/scaffold.ts` — generalise the writer
+
+Rename `writeBuiltinSkillFile` → **`writeSkillFile`** (clearer; it now writes
+custom skills too) and extend `SkillFileFields` with two optional prompt-only keys:
+
+```ts
+interface SkillFileFields {
+  kind: string;             // == slug for custom skills
+  label?: string;
+  cooldown?: string;
+  contextFields?: string[];
+  window?: 'any' | 'commute';   // NEW — emitted only when 'commute'
+  requiresKey?: string;         // NEW — emitted when set
+  feed?: string;                // news built-in only
+  feedMaxItems?: number;        // news built-in only
+  brief?: string;
+}
+```
+
+Emit `window:` only when `=== 'commute'` (the loader treats absent/any identically,
+so we don't write noise), and `requiresKey:` when non-empty. Update the two
+existing call sites (the scaffold loop in the same file; the PUT route in `dj.ts`).
+`msToCooldownStr` is unchanged.
+
+### 2. `skills/loader.ts` — widen the export surface
+
+Export `SLUG_RE` and `RESERVED_KINDS` (currently module-private) so the routes
+validate against the *same* constants the loader enforces — no drift. `BUILTIN_KINDS`
+is already exported.
+
+### 3. `routes/dj.ts` — the CRUD routes
+
+A small shared helper keeps every route honest:
+
+```ts
+const SKILLS_DIR = resolve(STATE_DIR, 'skills');
+// state/skills/<slug> — slug must pass SLUG_RE (already anchored, no '/' or '.'),
+// and the resolved path must stay directly under SKILLS_DIR (defence in depth).
+function customSkillDir(slug: string): string { … }   // throws on invalid/traversal
+```
+
+**`POST /dj/skills`** — create a custom skill. Body:
+`{ name, label?, cooldown?, context?: string[], window?, requiresKey?, brief }`.
+Validation (all 400 on failure, with a specific message):
+
+- `name` matches `SLUG_RE`; **not** in `RESERVED_KINDS` (can't shadow a built-in
+  kind or a queue-internal kind like `link`/`station-id`).
+- The folder must **not already exist** → `409` "a skill named <slug> already exists".
+- `brief` required, non-empty.
+- `cooldown` (optional) matches `/^\d+\s*[smhd]?$/` (reuse the PUT route's check).
+- `context` (optional array): every token in `dj.CONTEXT_FIELDS`, else 400 listing
+  the bad tokens + the valid set (mirror the PUT route's logic exactly).
+- `window` (optional): `'any'` | `'commute'`, default `'any'`.
+- `requiresKey` (optional): matches `/^[A-Z][A-Z0-9_]*$/` (an env-var name), else 400.
+
+On success: `writeSkillFile({ kind: name, … })` → `loadCustomSkills()` →
+`queue.log('scheduler', …)` → `res.json({ skills: skillCatalog() })`.
+**Created skills arrive disabled** (that's the loader's existing posture — a custom
+skill never auto-airs until the operator enables it), so no enable side-effect here.
+
+**`GET /dj/skills/:slug/file`** — broaden the *existing* built-in-only reader to
+also serve custom skills, so the Edit form can prefill from disk. Branch on
+`BUILTIN_KINDS.has(slug)`:
+
+- built-in → unchanged response (adds `custom: false`).
+- custom (folder exists on disk) → parse `SKILL.md`; return
+  `{ slug, custom: true, label, cooldown, context, knownContextFields,
+     window, requiresKey, hasTool, brief }`, where `hasTool` is
+  `existsSync(state/skills/<slug>/tool.mjs)` (read-only flag so the form can warn
+  "a data tool is attached and is not edited here").
+- neither → 404.
+
+**`PUT /dj/skills/:slug/file`** — broaden the existing built-in editor to also edit
+custom skills. Branch on `BUILTIN_KINDS.has(slug)`:
+
+- built-in → the existing path (writeSkillFile with news feed handling), unchanged.
+- custom (folder exists) → validate `{ label, cooldown, context, window,
+  requiresKey, brief }` with the **same** rules as POST (minus the slug — the slug
+  is the immutable identity and comes from the URL). `writeSkillFile` rewrites only
+  `SKILL.md`; an existing `tool.mjs` is left untouched. Then reload + return catalogue.
+- neither → 404.
+
+**`DELETE /dj/skills/:slug`** — remove a custom skill. Refuse `BUILTIN_KINDS`
+(400 "built-in skills can't be deleted"); 404 if the folder doesn't exist; else
+`rm(customSkillDir(slug), { recursive: true, force: true })` (removes `SKILL.md`
+**and** any `tool.mjs`). Reload, log, return catalogue. The skill's
+`settings.skills.enabled[slug]` flag, if any, is left as an inert stale key (it
+references a kind that no longer loads, so it's never consulted) — not worth a
+settings write.
+
+New imports in `dj.ts`: `mkdir`/`rm`/`stat`/`existsSync` as needed (`readFile`,
+`join`, `resolve`, `STATE_DIR` already imported), plus `SLUG_RE`, `RESERVED_KINDS`
+from `loader.js` and `writeSkillFile` from `scaffold.js`.
+
+## Web changes
+
+### `web/components/admin/skills/SkillForm.tsx` (new)
+
+A focused, reusable form for **custom create + custom edit** (built-ins keep their
+existing inline editor untouched — it has news-specific fields and is working).
+
+Props: `{ mode: 'create' | 'edit', initial?, onSaved(skills), onCancel }`.
+Fields:
+
+- **Name (slug)** — text, lowercase-slug; **create-only** (disabled & shown as
+  read-only identity in edit mode). Inline hint mirrors `SLUG_RE`.
+- **Label** — text (defaults to title-cased slug if blank).
+- **Cooldown** — text (`45m` / `6h` / `2d` / bare minutes), same hint as built-in form.
+- **Context this segment may mention** — the same tick-box group the built-in form
+  uses, via the shared helpers extracted to `web/components/admin/skills/contextFields.ts`
+  (`CONTEXT_FIELD_LABELS`, `splitContext`, `CONTEXT_FIELDS_FALLBACK`).
+- **Window** — radio: *Any time* (default) / *Commute hours only* (maps to the
+  loader's existing `window: commute`, the same gate the built-in traffic skill uses).
+- **Brief** — textarea (the DJ's instructions); required.
+
+`requiresKey` is **not** a visible field. It only gates a skill inert until an env
+var is set, which is only meaningful when the skill has a hand-dropped `tool.mjs`
+that calls a keyed API — and tool.mjs authoring is out of scope here. The form
+keeps it as a hidden passthrough (empty on create, loaded-as-is on edit) so editing
+a disk-authored skill never silently strips its key-gate.
+- When `hasTool` (edit mode): a small read-only note "A `tool.mjs` data tool is
+  attached. Edit or remove it on disk + Rescan."
+
+Submit → `POST /dj/skills` (create) or `PUT /dj/skills/:slug/file` (edit); on
+success calls `onSaved(j.skills)`. Shared context-field helpers move out of
+`SkillsPanel` into `skills/contextFields.ts`; both the built-in editor (in
+`SkillsPanel`) and `SkillForm` import them, so the vocabulary is defined once.
+
+### `web/components/admin/SkillsPanel.tsx`
+
+- **Hero bar:** add a **New skill** button beside *Rescan*. Toggling it renders
+  `SkillForm` (create mode) as a card at the top of the list.
+- **Custom skill cards:** today they only have *Run now* + the toggle (the panel
+  explicitly hides Edit for `s.custom`). Add **Edit** (expands `SkillForm` in edit
+  mode inline under the card, prefilled from `GET /dj/skills/:slug/file`) and
+  **Delete** (confirm dialog → `DELETE /dj/skills/:slug`). Built-in cards are
+  unchanged (their existing inline editor stays).
+- On any create/edit/delete success, replace `skills` state from the returned
+  `{ skills }` array (same pattern as toggle/rescan).
+- Update the hero copy: "Drop your own skills into `state/skills/…` and Rescan"
+  becomes "Click **New skill** to author one here, or drop a folder into
+  `state/skills/<name>/` (with an optional `tool.mjs` data tool) and Rescan."
+
+## Error handling
+
+- Controller validates everything and returns `4xx` + `{ error }`; the form surfaces
+  it via the existing `notify.err` / `errorMessage` helpers (same as the rest of the
+  panel).
+- Duplicate slug → `409`; the form maps it to a friendly "that name is taken".
+- Path-traversal / bad slug can't reach the filesystem: `SLUG_RE` is anchored and
+  rejects `/`, `.`, and uppercase, and `customSkillDir()` re-asserts the path stays
+  under `SKILLS_DIR`.
+- Reload after a write is best-effort logged (loader never throws); a write that
+  succeeds but reload-warns still returns the (now-current) catalogue.
+
+## Testing & verification
+
+No unit-test runner in this repo; the merge gate is `npm run lint`
+(`eslint . && tsc --noEmit`) in **both** `controller/` and `web/`. Plan:
+
+1. `npm run lint` in `controller/` and `web/` — must pass (the CI gate).
+2. Manual smoke in the dev stack (`docker-compose.dev.yml` + `web` dev server):
+   - Create a prompt-only skill → appears in the list, **disabled**, with a
+     `state/skills/<slug>/SKILL.md` on disk whose frontmatter round-trips.
+   - Edit it (change brief, cooldown, window, context) → file rewrites,
+     catalogue reflects it.
+   - Drop a `tool.mjs` beside it on disk + Rescan → `hasTool` note shows on Edit;
+     editing the brief leaves `tool.mjs` intact.
+   - Delete it → folder gone, removed from the list.
+   - Reject paths: reserved name (`news`), bad slug (`My Skill`), empty brief,
+     bad context token, duplicate name → each returns a clear error in the UI.
+   - Built-in edit (e.g. News feed) still works unchanged (regression check).
+
+## Docs
+
+- `docs/custom-skills.md` — note that prompt-only skills can now be created /
+  edited / deleted from **/admin/skills**, and that `tool.mjs` remains a disk-drop
+  (+ Rescan) addition.
+- `web/content/manual/skills.*` (the `/manual/skills` page) — same note, if present.
+- `SkillsPanel` hero copy (above).
+
+## Files touched
+
+- `controller/src/skills/scaffold.ts` — rename→`writeSkillFile`, add `window`/`requiresKey`.
+- `controller/src/skills/loader.ts` — export `SLUG_RE`, `RESERVED_KINDS`.
+- `controller/src/routes/dj.ts` — POST create, DELETE, broaden GET/PUT `…/file` to custom.
+- `web/components/admin/skills/SkillForm.tsx` — new reusable create/edit form.
+- `web/components/admin/skills/contextFields.ts` — new (shared context-field helpers, imported by both `SkillsPanel` and `SkillForm`).
+- `web/components/admin/SkillsPanel.tsx` — New-skill button, custom Edit/Delete, copy.
+- `docs/custom-skills.md`, `web/content/manual/skills.*` — doc notes.

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4317,3 +4317,26 @@ html.lite *::after {
     .observatory-root .cmap-ripple,
     .observatory-root .wire-line { animation: none !important; }
 }
+
+/* ───────────────────────────────────────────────────────────────────────────
+   Skill Edit Card ("segment sheet") modal — /admin/skills. Pseudo-elements and
+   keyframes the SkillEditModal sheet relies on (kept here, not injected from
+   JS). Scoped to .sw-seg so they can't leak into the rest of the admin.
+   ─────────────────────────────────────────────────────────────────────────── */
+@keyframes sw-spin { to { transform: rotate(360deg); } }
+@keyframes sw-ring {
+    0% { box-shadow: 0 0 0 0 color-mix(in oklab, var(--accent) 55%, transparent); }
+    70%, 100% { box-shadow: 0 0 0 8px transparent; }
+}
+@keyframes sw-blink { 0%, 45% { opacity: 1; } 55%, 100% { opacity: 0.2; } }
+.sw-seg textarea:focus, .sw-seg input:focus { border-color: var(--accent) !important; }
+.sw-seg ::placeholder { color: var(--muted); opacity: 0.75; }
+.sw-seg .sw-ghost:hover { background: var(--ink-soft); }
+.sw-seg .sw-title:focus { border-bottom-color: var(--accent) !important; }
+.sw-seg .sw-dropcap::first-letter {
+    font-size: 2.7em; font-weight: 800; float: left; line-height: 0.74;
+    color: var(--accent); padding: 4px 9px 0 0;
+}
+@media (prefers-reduced-motion: reduce) {
+    .sw-seg [style*="sw-spin"], .sw-seg [style*="sw-ring"] { animation: none !important; }
+}

--- a/web/components/admin/SkillsPanel.tsx
+++ b/web/components/admin/SkillsPanel.tsx
@@ -1,19 +1,24 @@
 'use client';
 
 // Skills editor — /admin/skills. The autonomous DJ segments (weather, news,
-// traffic, random facts) the station can fire between tracks.
+// now-playing digs, random facts) the station can fire between tracks.
 //
 // Each skill is toggled on/off station-wide here. A skill only fires
 // autonomously when it is enabled here AND assigned to the persona on air
 // (see /admin/personas). "Run now" is an operator override — it fires the
 // segment immediately, bypassing the enable toggle, the persona assignment,
 // the frequency gate, and the cooldown.
+//
+// Creating and editing a skill (custom or built-in) opens the SkillEditModal
+// "segment sheet" — the list here is just the roster + quick actions.
 import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 import { notify, errorMessage } from '../../lib/notify';
 import { useAdminAuth } from '../../lib/adminAuth';
+import { RefreshCw, Plus } from 'lucide-react';
 import { Card, Btn, Pill, Eyebrow, Toggle } from './ui';
 import { V3Alert } from '../ui/alert';
+import SkillEditModal from './skills/SkillEditModal';
 
 interface Skill {
   name: string;
@@ -44,52 +49,8 @@ interface SkillRunResponse {
   error?: string;
 }
 
-// Response of GET /dj/skills/:kind/file — the editable contents of a built-in
-// skill's SKILL.md (or live defaults when it hasn't been scaffolded yet).
-interface SkillFileResponse {
-  kind: string;
-  exists?: boolean;
-  isNews?: boolean;
-  label?: string;
-  cooldown?: string;
-  context?: string;                 // comma-separated "right now" fields (#471)
-  knownContextFields?: string[];    // the full vocabulary, for the tick-boxes
-  feed?: string | null;
-  feedMaxItems?: number | null;
-  brief?: string;
-  error?: string;
-}
-
-// The in-form editing state for one built-in skill.
-interface EditForm {
-  kind: string;
-  isNews: boolean;
-  label: string;
-  cooldown: string;
-  context: string[];          // selected "right now" fields the segment may mention
-  knownContext: string[];     // the full vocabulary to render tick-boxes from
-  feed: string;
-  feedMaxItems: string;
-  brief: string;
-}
-
-// Friendly labels for the context fields (#471). Keys are the controller's
-// CONTEXT_FIELDS vocabulary; anything not listed falls back to the raw key.
-const CONTEXT_FIELD_LABELS: Record<string, string> = {
-  date: 'Date & season',
-  clock: 'Clock time',
-  time: 'Daypart',
-  weather: 'Weather',
-  festival: 'Festival',
-  show: 'Current show',
-  listeners: 'Listener count',
-};
-// Fallback vocabulary if the controller doesn't send knownContextFields.
-const CONTEXT_FIELDS_FALLBACK = ['date', 'clock', 'time', 'weather', 'festival', 'show', 'listeners'];
-
-function splitContext(s?: string): string[] {
-  return typeof s === 'string' ? s.split(',').map(t => t.trim()).filter(Boolean) : [];
-}
+// Which skill the modal is editing/creating, if any.
+type ModalState = { mode: 'create' } | { mode: 'edit'; skill: Skill };
 
 function cooldownLabel(ms?: number): string {
   if (!ms) return 'no cooldown';
@@ -132,9 +93,7 @@ export default function SkillsPanel() {
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);   // skill name currently mutating, or null
   const [rescanning, setRescanning] = useState(false);
-  const [editing, setEditing] = useState<string | null>(null); // kind whose edit form is open
-  const [editForm, setEditForm] = useState<EditForm | null>(null);
-  const [editBusy, setEditBusy] = useState(false);             // loading or saving the edit form
+  const [modal, setModal] = useState<ModalState | null>(null); // open editor sheet, or null
 
   useEffect(() => {
     if (!hydrated || needsAuth) return;
@@ -182,68 +141,6 @@ export default function SkillsPanel() {
     } catch (e) {
       notify.err(`Rescan failed: ${errorMessage(e)}`);
     } finally { setRescanning(false); }
-  };
-
-  // Open (or toggle closed) the inline edit form for a built-in skill. Fetches
-  // the current SKILL.md contents so the form prefills with what's on disk.
-  const openEdit = async (kind: string) => {
-    if (editing === kind) { setEditing(null); setEditForm(null); return; }
-    setEditing(kind);
-    setEditForm(null);
-    setEditBusy(true);
-    try {
-      const r = await adminFetch(`/dj/skills/${kind}/file`);
-      const j = (await r.json().catch(() => ({}))) as SkillFileResponse;
-      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      setEditForm({
-        kind,
-        isNews: !!j.isNews,
-        label: j.label || '',
-        cooldown: j.cooldown || '',
-        context: splitContext(j.context),
-        knownContext: Array.isArray(j.knownContextFields) && j.knownContextFields.length
-          ? j.knownContextFields
-          : CONTEXT_FIELDS_FALLBACK,
-        feed: j.feed || '',
-        feedMaxItems: j.feedMaxItems != null ? String(j.feedMaxItems) : '',
-        brief: j.brief || '',
-      });
-    } catch (e) {
-      notify.err(`Couldn't load skill: ${errorMessage(e)}`);
-      setEditing(null);
-    } finally { setEditBusy(false); }
-  };
-
-  const saveEdit = async () => {
-    if (!editForm) return;
-    setEditBusy(true);
-    try {
-      const body: Record<string, unknown> = {
-        brief: editForm.brief,
-        cooldown: editForm.cooldown,
-        label: editForm.label,
-        // Sent as an array; an empty list resets the skill to the default
-        // profile (everything except weather). See issue #471.
-        context: editForm.context,
-      };
-      if (editForm.isNews) {
-        body.feed = editForm.feed;
-        if (editForm.feedMaxItems) body.feedMaxItems = editForm.feedMaxItems;
-      }
-      const r = await adminFetch(`/dj/skills/${editForm.kind}/file`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-      const j = (await r.json().catch(() => ({}))) as SkillToggleResponse;
-      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      if (Array.isArray(j.skills)) setSkills(j.skills);
-      notify.ok(`Saved ${editForm.kind}`);
-      setEditing(null);
-      setEditForm(null);
-    } catch (e) {
-      notify.err(`Save failed: ${errorMessage(e)}`);
-    } finally { setEditBusy(false); }
   };
 
   const runNow = async (name: string) => {
@@ -298,15 +195,15 @@ export default function SkillsPanel() {
             on the Personas page. “Run now” is an operator override and ignores both.
           </div>
           <div className="mt-1 text-[11px] leading-[1.6] text-muted">
-            The built-in skills are editable too. Hit <strong>Edit</strong> to change a skill&apos;s
-            brief, cooldown, or which real-world context (time, weather…) it may mention
-            (and, for News, its feed URL). Edits are saved to
-            <code> state/skills/&lt;kind&gt;/SKILL.md</code>.
+            Hit <strong>Edit</strong> on any skill to open its segment sheet — change the brief,
+            cooldown, or which real-world context (time, weather…) it may mention (and, for News,
+            its feed URL). Edits are saved to <code>state/skills/&lt;kind&gt;/SKILL.md</code>.
           </div>
           <div className="mt-1 text-[11px] leading-[1.6] text-muted">
-            Drop your own skills into <code>state/skills/&lt;name&gt;/SKILL.md</code> and hit
-            <strong> Rescan</strong>. Custom skills arrive <strong>disabled</strong>, so review
-            them, then enable them before they can air.
+            Add your own with <strong>New skill</strong> — it writes
+            <code> state/skills/&lt;name&gt;/SKILL.md</code> for you. (You can still drop a folder there
+            by hand — with an optional <code>tool.mjs</code> data tool — and hit <strong>Rescan</strong>.)
+            Custom skills arrive <strong>disabled</strong>, so review them, then enable them before they can air.
           </div>
           <a
             href="/manual/skills"
@@ -320,9 +217,16 @@ export default function SkillsPanel() {
         <div className="flex items-center gap-4 bg-[var(--ink-softer)] p-3.5">
           <span className="caption">{skills.length} skill{skills.length === 1 ? '' : 's'}</span>
           <span className="caption text-vermilion">{enabledCount} enabled</span>
-          <div className="ml-auto">
-            <Btn onClick={rescan} disabled={rescanning}>
-              {rescanning ? 'Rescanning…' : 'Rescan state/skills'}
+          <div className="ml-auto flex items-center gap-2">
+            <Btn tone="accent" onClick={() => setModal({ mode: 'create' })}>
+              <Plus size={14} /> New skill
+            </Btn>
+            <Btn
+              onClick={rescan}
+              disabled={rescanning}
+              title={rescanning ? 'Rescanning state/skills…' : 'Rescan state/skills'}
+            >
+              <RefreshCw size={14} className={rescanning ? 'animate-spin' : ''} />
             </Btn>
           </div>
         </div>
@@ -333,7 +237,6 @@ export default function SkillsPanel() {
         <Card
           key={s.name}
           title={s.label || s.name}
-          sub={s.kind}
           right={
             <>
               {s.custom && <Pill>custom</Pill>}
@@ -372,12 +275,11 @@ export default function SkillsPanel() {
           )}
           <div className="grid grid-cols-[1fr_auto] items-center gap-4">
             <div>
-              <div className="text-[12px] leading-[1.6] text-muted">
+              <div className="line-clamp-2 text-[12px] leading-[1.6] text-muted">
                 <SkillDescription text={s.description} keyUrl={s.keyUrl} />
               </div>
               <div className="mt-2 flex flex-wrap gap-2">
                 <Pill className="text-[8px]">{cooldownLabel(s.cooldownMs)}</Pill>
-                <Pill className="text-[8px]">kind · {s.kind}</Pill>
               </div>
             </div>
             <div className="flex flex-col gap-2">
@@ -388,113 +290,23 @@ export default function SkillsPanel() {
               >
                 {busy === s.name ? 'Working…' : 'Run now'}
               </Btn>
-              {/* Built-in skills are editable in place; custom skills are edited
-                  on disk + Rescan, so no Edit button for them. */}
-              {!s.custom && (
-                <Btn
-                  onClick={() => openEdit(s.kind || s.name)}
-                  disabled={editBusy && editing === (s.kind || s.name)}
-                >
-                  {editing === (s.kind || s.name) ? 'Close' : 'Edit'}
-                </Btn>
-              )}
+              {/* Edit opens the segment-sheet modal for both built-in and custom
+                  skills; Run now / Delete live inside the sheet. */}
+              <Btn onClick={() => setModal({ mode: 'edit', skill: s })}>Edit</Btn>
             </div>
           </div>
-
-          {/* ── INLINE EDIT FORM ──────────────────────────────────────────── */}
-          {editing === (s.kind || s.name) && (
-            <div className="mt-3 border-t border-ink pt-3">
-              {!editForm ? (
-                <div className="text-[12px] text-muted italic">loading…</div>
-              ) : (
-                <div className="grid gap-3">
-                  {editForm.isNews && (
-                    <>
-                      <label className="grid gap-1">
-                        <span className="caption">Feed URL (RSS 2.0)</span>
-                        <input
-                          type="url"
-                          value={editForm.feed}
-                          onChange={e => setEditForm({ ...editForm, feed: e.target.value })}
-                          placeholder="https://…/rss.xml"
-                          className="border border-ink bg-transparent px-2 py-1.5 text-[12px] outline-none focus:border-vermilion"
-                        />
-                      </label>
-                      <label className="grid gap-1">
-                        <span className="caption">Max items to scan</span>
-                        <input
-                          type="number"
-                          min={1}
-                          value={editForm.feedMaxItems}
-                          onChange={e => setEditForm({ ...editForm, feedMaxItems: e.target.value })}
-                          placeholder="10"
-                          className="w-28 border border-ink bg-transparent px-2 py-1.5 text-[12px] outline-none focus:border-vermilion"
-                        />
-                      </label>
-                    </>
-                  )}
-                  <label className="grid gap-1">
-                    <span className="caption">Cooldown</span>
-                    <input
-                      type="text"
-                      value={editForm.cooldown}
-                      onChange={e => setEditForm({ ...editForm, cooldown: e.target.value })}
-                      placeholder="45m"
-                      className="w-28 border border-ink bg-transparent px-2 py-1.5 text-[12px] outline-none focus:border-vermilion"
-                    />
-                    <span className="text-[10px] text-muted">e.g. <code>45m</code>, <code>6h</code>, <code>2d</code>, or a bare number (minutes)</span>
-                  </label>
-                  <div className="grid gap-1">
-                    <span className="caption">Context this segment may mention</span>
-                    <div className="flex flex-wrap gap-x-4 gap-y-1.5">
-                      {editForm.knownContext.map(field => {
-                        const checked = editForm.context.includes(field);
-                        return (
-                          <label key={field} className="flex items-center gap-1.5 text-[12px]">
-                            <input
-                              type="checkbox"
-                              checked={checked}
-                              onChange={() => setEditForm({
-                                ...editForm,
-                                context: checked
-                                  ? editForm.context.filter(f => f !== field)
-                                  : [...editForm.context, field],
-                              })}
-                              className="accent-vermilion"
-                            />
-                            {CONTEXT_FIELD_LABELS[field] || field}
-                          </label>
-                        );
-                      })}
-                    </div>
-                    <span className="text-[10px] text-muted">
-                      Tick only what&apos;s topical for this segment. Leaving <strong>Weather</strong> off keeps it
-                      out of the prompt, so the DJ stops mentioning it on every break.
-                    </span>
-                  </div>
-                  <label className="grid gap-1">
-                    <span className="caption">Brief (what the DJ says, and when to stay silent)</span>
-                    <textarea
-                      rows={4}
-                      value={editForm.brief}
-                      onChange={e => setEditForm({ ...editForm, brief: e.target.value })}
-                      className="border border-ink bg-transparent px-2 py-1.5 text-[12px] leading-[1.5] outline-none focus:border-vermilion"
-                    />
-                  </label>
-                  <div className="flex items-center gap-2">
-                    <Btn tone="accent" onClick={saveEdit} disabled={editBusy || !editForm.brief.trim()}>
-                      {editBusy ? 'Saving…' : 'Save'}
-                    </Btn>
-                    <Btn onClick={() => { setEditing(null); setEditForm(null); }} disabled={editBusy}>
-                      Cancel
-                    </Btn>
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
         </Card>
       ))}
+
+      {/* ── EDIT / CREATE MODAL ──────────────────────────────────────────── */}
+      {modal && (
+        <SkillEditModal
+          mode={modal.mode}
+          skill={modal.mode === 'edit' ? modal.skill : undefined}
+          onClose={() => setModal(null)}
+          onSkillsChange={next => { if (Array.isArray(next)) setSkills(next as Skill[]); }}
+        />
+      )}
     </div>
   );
 }

--- a/web/components/admin/skills/SkillEditModal.tsx
+++ b/web/components/admin/skills/SkillEditModal.tsx
@@ -1,0 +1,622 @@
+'use client';
+
+// Skill Edit Card — the "segment sheet" editor, shown as a modal over
+// /admin/skills. Implements the claude.ai/design "Skill Edit Card" redesign:
+// a newspaper-styled sheet with a masthead (name, kind, status toggle), a body
+// (cooldown presets + input, optional window, optional news feed, a context
+// chip bank, the brief) and a transport bar (Save / Cancel / Run now / Close).
+//
+// One component serves three jobs:
+//   • create a custom (prompt-only) skill  → POST /dj/skills
+//   • edit an existing custom skill        → PUT  /dj/skills/:slug/file
+//   • edit a built-in skill (incl. News)   → PUT  /dj/skills/:kind/file
+// The controller is the validation gate; this form does light client checks.
+//
+// The on/off toggle and Run now are LIVE operator actions (toggle hits
+// /dj/skill-toggle, run hits /dj/skill) — they don't participate in the
+// Save/dirty flow, which only writes the SKILL.md file fields.
+import { useEffect, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { notify, errorMessage } from '../../../lib/notify';
+import { useAdminAuth } from '../../../lib/adminAuth';
+import { V3AlertDialog } from '../../ui/alert-dialog';
+import { CONTEXT_FIELD_LABELS, CONTEXT_FIELDS_FALLBACK, splitContext } from './contextFields';
+
+// Minimal shape of a catalogue skill (from GET /dj/skills) — only what the
+// modal needs. The full list type lives in SkillsPanel.
+export interface SkillLike {
+  name: string;
+  kind?: string;
+  label?: string;
+  custom?: boolean;
+  enabled?: boolean;
+  cooldownMs?: number;
+}
+
+interface SkillEditModalProps {
+  mode: 'create' | 'edit';
+  skill?: SkillLike;                 // required in edit mode
+  onClose: () => void;
+  onSkillsChange: (skills: SkillLike[]) => void;  // refresh the panel list after any mutation
+}
+
+// The shipped defaults for a built-in (from the raw CAPABILITIES entry), used by
+// "Reset to default".
+interface SkillDefaults {
+  label?: string;
+  cooldown?: string;
+  context?: string;
+  feed?: string;
+  feedMaxItems?: number;
+  brief?: string;
+}
+
+// GET /dj/skills/:kind/file — covers built-in and custom responses.
+interface SkillFileResponse {
+  kind: string;
+  custom?: boolean;
+  isNews?: boolean;
+  label?: string;
+  cooldown?: string;
+  context?: string;
+  knownContextFields?: string[];
+  window?: 'any' | 'commute';
+  requiresKey?: string;
+  hasTool?: boolean;
+  feed?: string | null;
+  feedMaxItems?: number | null;
+  brief?: string;
+  defaults?: SkillDefaults | null;
+  error?: string;
+}
+
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,48}$/;
+const COOLDOWN_PRESETS = ['15m', '25m', '45m', '1h', '6h'];
+
+// The mutable file fields — snapshotted so we can compute "dirty" and revert.
+interface FileFields {
+  label: string;
+  cooldown: string;
+  context: string[];
+  window: 'any' | 'commute';
+  feed: string;
+  feedMaxItems: string;
+  brief: string;
+}
+
+function emptyFields(): FileFields {
+  return { label: '', cooldown: '', context: [], window: 'any', feed: '', feedMaxItems: '', brief: '' };
+}
+
+// Order-independent comparison key for the tracked fields.
+function fieldsKey(f: FileFields): string {
+  return JSON.stringify({ ...f, context: [...f.context].sort() });
+}
+
+function titleCase(slug: string): string {
+  return slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }: SkillEditModalProps) {
+  const { adminFetch } = useAdminAuth();
+
+  const isEdit = mode === 'edit';
+  // File id for GET/PUT — the kind (built-in) or slug (custom). For toggle/run/
+  // delete the controller keys off the skill name.
+  const fileId = skill ? (skill.kind || skill.name) : '';
+
+  const [loaded, setLoaded] = useState(!isEdit);   // create starts ready
+  const [name, setName] = useState('');            // slug — create only
+  const [kind, setKind] = useState(skill?.kind || skill?.name || '');
+  const [custom, setCustom] = useState(mode === 'create' ? true : !!skill?.custom);
+  const [isNews, setIsNews] = useState(false);
+  const [hasTool, setHasTool] = useState(false);
+  const [requiresKey, setRequiresKey] = useState('');   // hidden passthrough
+  const [knownContext, setKnownContext] = useState<string[]>(CONTEXT_FIELDS_FALLBACK);
+
+  const [fields, setFields] = useState<FileFields>(emptyFields());
+  const [snapshot, setSnapshot] = useState<string>(fieldsKey(emptyFields()));
+
+  const [enabled, setEnabled] = useState(!!skill?.enabled);
+  const [busy, setBusy] = useState(false);          // saving / creating
+  const [acting, setActing] = useState(false);      // toggle / run in flight
+  const [flash, setFlash] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);  // delete confirm dialog
+  const [defaults, setDefaults] = useState<SkillDefaults | null>(null); // built-in shipped defaults
+
+  const patch = (p: Partial<FileFields>) => setFields(f => ({ ...f, ...p }));
+
+  const flashFor = (msg: string) => {
+    setFlash(msg);
+    window.setTimeout(() => setFlash(cur => (cur === msg ? null : cur)), 2000);
+  };
+
+  // ── Prefill (edit) ────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!isEdit || !fileId) return;
+    let cancelled = false;
+    setLoaded(false);
+    (async () => {
+      try {
+        const r = await adminFetch(`/dj/skills/${fileId}/file`);
+        const j = (await r.json().catch(() => ({}))) as SkillFileResponse;
+        if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+        if (cancelled) return;
+        const next: FileFields = {
+          label: j.label || '',
+          cooldown: j.cooldown || '',
+          context: splitContext(j.context),
+          window: j.window === 'commute' ? 'commute' : 'any',
+          feed: j.feed || '',
+          feedMaxItems: j.feedMaxItems != null ? String(j.feedMaxItems) : '',
+          brief: j.brief || '',
+        };
+        setFields(next);
+        setSnapshot(fieldsKey(next));
+        setKind(j.kind || fileId);
+        setCustom(!!j.custom);
+        setIsNews(!!j.isNews);
+        setHasTool(!!j.hasTool);
+        setRequiresKey(j.requiresKey || '');
+        setDefaults(j.defaults || null);
+        setKnownContext(
+          Array.isArray(j.knownContextFields) && j.knownContextFields.length
+            ? j.knownContextFields
+            : CONTEXT_FIELDS_FALLBACK,
+        );
+        setLoaded(true);
+      } catch (e) {
+        if (cancelled) return;
+        notify.err(`Couldn't load skill: ${errorMessage(e)}`);
+        onClose();
+      }
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isEdit, fileId, adminFetch]);
+
+  // ── Escape to close ───────────────────────────────────────────────────────
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const dirty = loaded && fieldsKey(fields) !== snapshot;
+  const nameValid = !isEdit ? SLUG_RE.test(name) : true;
+  const canSave = loaded && !!fields.brief.trim() && nameValid && !busy;
+
+  // Display name in the masthead: the label, falling back to the slug/kind.
+  const displayName = fields.label || (isEdit ? titleCase(kind) : (name ? titleCase(name) : 'New skill'));
+
+  // ── Actions ───────────────────────────────────────────────────────────────
+  const save = async () => {
+    if (!canSave) return;
+    setBusy(true);
+    try {
+      const body: Record<string, unknown> = {
+        label: fields.label.trim() || undefined,
+        cooldown: fields.cooldown.trim() || undefined,
+        context: fields.context,                 // [] resets to the default profile
+        brief: fields.brief,
+      };
+      if (custom) {
+        body.window = fields.window;
+        if (requiresKey) body.requiresKey = requiresKey;  // preserve disk-authored gate
+      }
+      if (isNews) {
+        body.feed = fields.feed.trim() || undefined;
+        if (fields.feedMaxItems.trim()) body.feedMaxItems = fields.feedMaxItems.trim();
+      }
+
+      let r: Response;
+      if (mode === 'create') {
+        body.name = name.trim().toLowerCase();
+        r = await adminFetch('/dj/skills', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+      } else {
+        r = await adminFetch(`/dj/skills/${fileId}/file`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+      }
+      const j = (await r.json().catch(() => ({}))) as { skills?: SkillLike[]; error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      onSkillsChange(Array.isArray(j.skills) ? j.skills : []);
+
+      if (mode === 'create') {
+        notify.ok(`Created “${name}” — disabled until you enable it`);
+        onClose();
+      } else {
+        setSnapshot(fieldsKey(fields));   // edits are now the saved baseline
+        flashFor('SAVED TO BOOTH');
+      }
+    } catch (e) {
+      notify.err(`${mode === 'create' ? 'Create' : 'Save'} failed: ${errorMessage(e)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const toggleEnabled = async () => {
+    if (!isEdit || !skill) return;
+    setActing(true);
+    const next = !enabled;
+    try {
+      const r = await adminFetch('/dj/skill-toggle', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: skill.name, on: next }),
+      });
+      const j = (await r.json().catch(() => ({}))) as { skills?: SkillLike[]; error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      setEnabled(next);
+      onSkillsChange(Array.isArray(j.skills) ? j.skills : []);
+      flashFor(next ? 'ON AIR' : 'OFF AIR');
+    } catch (e) {
+      notify.err(`Toggle failed: ${errorMessage(e)}`);
+    } finally { setActing(false); }
+  };
+
+  const run = async () => {
+    if (!isEdit || !skill) return;
+    setActing(true);
+    try {
+      const r = await adminFetch('/dj/skill', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: skill.name }),
+      });
+      const j = (await r.json().catch(() => ({}))) as { spoken?: string; error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      flashFor('QUEUED TO BOOTH');
+      if (j.spoken) notify.ok(`On air: “${j.spoken}”`);
+    } catch (e) {
+      notify.err(`Run failed: ${errorMessage(e)}`);
+    } finally { setActing(false); }
+  };
+
+  // Delete a custom skill (its whole state/skills/<slug>/ folder), then close.
+  // Confirmation is the V3AlertDialog below (driven by confirmDelete), not a
+  // native window.confirm.
+  const remove = async () => {
+    if (!isEdit || !skill) return;
+    setConfirmDelete(false);
+    setActing(true);
+    try {
+      const r = await adminFetch(`/dj/skills/${skill.name}`, { method: 'DELETE' });
+      const j = (await r.json().catch(() => ({}))) as { skills?: SkillLike[]; error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      onSkillsChange(Array.isArray(j.skills) ? j.skills : []);
+      notify.ok(`Deleted “${skill.name}”`);
+      onClose();
+    } catch (e) {
+      notify.err(`Delete failed: ${errorMessage(e)}`);
+      setActing(false);
+    }
+  };
+
+  // Restore the form to the built-in's shipped defaults. Repopulates the fields
+  // (doesn't persist) so the operator reviews and then Saves — at which point
+  // the SKILL.md is rewritten to the default.
+  const resetToDefault = () => {
+    if (!defaults) return;
+    setFields(f => ({
+      ...f,
+      label: defaults.label ?? f.label,
+      cooldown: defaults.cooldown ?? f.cooldown,
+      context: splitContext(defaults.context),
+      feed: defaults.feed ?? '',
+      feedMaxItems: defaults.feedMaxItems != null ? String(defaults.feedMaxItems) : '',
+      brief: defaults.brief ?? '',
+    }));
+    flashFor('RESET — REVIEW & SAVE');
+  };
+
+  // ── Style helpers (mirror the design, using our theme vars) ─────────────────
+  const I = 'var(--ink)';
+  const sectionLabel: CSSProperties = {
+    fontSize: 11, letterSpacing: '0.22em', textTransform: 'uppercase', fontWeight: 700, color: I,
+  };
+  const trans = 'all .12s cubic-bezier(.2,.7,.2,1)';
+
+  const presetStyle = (active: boolean, i: number): CSSProperties => ({
+    padding: '9px 16px', cursor: 'pointer', fontSize: 10, fontWeight: 700, letterSpacing: '0.18em',
+    textTransform: 'uppercase', fontVariantNumeric: 'tabular-nums', transition: trans,
+    border: '1px solid var(--ink)', marginLeft: i === 0 ? 0 : -1,
+    background: active ? 'var(--ink)' : 'transparent', color: active ? 'var(--bg)' : 'var(--ink)',
+  });
+  const chipStyle = (on: boolean): CSSProperties => ({
+    display: 'inline-flex', alignItems: 'center', gap: 10, padding: '9px 14px', cursor: 'pointer',
+    userSelect: 'none', whiteSpace: 'nowrap', fontSize: 13, letterSpacing: '0.01em', transition: trans,
+    border: `1px solid ${on ? 'var(--ink)' : 'color-mix(in oklab, var(--ink) 22%, transparent)'}`,
+    background: on ? 'var(--ink)' : 'transparent', color: on ? 'var(--bg)' : 'var(--muted)',
+    fontWeight: on ? 600 : 500,
+  });
+  const markStyle = (on: boolean): CSSProperties => ({
+    width: 9, height: 9, flex: 'none', transition: trans,
+    background: on ? 'var(--accent)' : 'transparent',
+    border: `1px solid ${on ? 'var(--accent)' : 'color-mix(in oklab, var(--ink) 35%, transparent)'}`,
+  });
+  const inputBase: CSSProperties = {
+    border: '1px solid var(--ink)', background: 'var(--field)', color: 'var(--ink)',
+  };
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        // z-30: above admin chrome (≤ z-20), below the V3AlertDialog (overlay
+        // z-40 / content z-50) so the delete confirm layers on top of this sheet.
+        position: 'fixed', inset: 0, zIndex: 30, display: 'flex', alignItems: 'flex-start',
+        justifyContent: 'center', padding: '40px 16px', overflowY: 'auto',
+        background: 'color-mix(in oklab, var(--ink) 55%, transparent)',
+        backdropFilter: 'blur(2px)',
+      }}
+    >
+      {/* The pseudo-elements + keyframes this sheet relies on live in
+          globals.css under the `.sw-seg` / `sw-*` names (kept out of JS to
+          avoid dangerouslySetInnerHTML). */}
+      <div
+        className="sw-seg"
+        onClick={e => e.stopPropagation()}
+        style={{ width: 'min(1000px,100%)', position: 'relative', border: '1px solid var(--ink)', background: 'var(--bg)' }}
+      >
+        {/* Masthead */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 28, padding: '16px 30px 14px' }}>
+          <div style={{ display: 'flex', alignItems: 'flex-start', minWidth: 0 }}>
+            <div style={{ minWidth: 0 }}>
+              {/* Editable skill name (label) */}
+              <input
+                className="sw-title"
+                value={fields.label}
+                onChange={e => patch({ label: e.target.value })}
+                placeholder={displayName}
+                style={{
+                  ...inputBase, background: 'transparent', border: 'none', borderBottom: '1px solid transparent',
+                  fontSize: 24, lineHeight: 1.1, letterSpacing: '-0.01em', fontWeight: 800,
+                  padding: '2px 0', width: '100%', minWidth: 0,
+                }}
+              />
+              {mode === 'create' && (
+                <div style={{ display: 'flex', gap: 8, marginTop: 14, flexWrap: 'wrap', alignItems: 'center' }}>
+                  <label style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+                    <span style={{ fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--muted)', fontWeight: 700 }}>SLUG</span>
+                    <input
+                      value={name}
+                      onChange={e => setName(e.target.value.toLowerCase())}
+                      placeholder="moon-phase"
+                      style={{
+                        ...inputBase, padding: '6px 10px', fontSize: 12, fontWeight: 700, letterSpacing: '0.04em', width: 180,
+                        borderColor: name && !nameValid ? 'var(--accent)' : 'var(--ink)',
+                      }}
+                    />
+                  </label>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Segment tag + on-air toggle — one slim row */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 14, flex: 'none' }}>
+            <span style={{ fontSize: 10, letterSpacing: '0.2em', textTransform: 'uppercase', color: 'var(--muted)', fontWeight: 600 }}>
+              {custom ? 'CUSTOM SEGMENT' : 'BUILT-IN SEGMENT'}
+            </span>
+            {isEdit && (
+              <div
+                onClick={() => { if (!acting) toggleEnabled(); }}
+                title={enabled ? 'On air — click to take off air' : 'Off air — click to put on air'}
+                style={{ position: 'relative', width: 62, height: 30, border: '1px solid var(--ink)', flex: 'none', cursor: acting ? 'wait' : 'pointer', transition: 'background .15s cubic-bezier(.2,.7,.2,1)', background: enabled ? 'var(--ink)' : 'transparent', opacity: acting ? 0.6 : 1 }}
+              >
+                <div style={{ position: 'absolute', top: 2, left: 2, width: 24, height: 24, transition: 'transform .18s cubic-bezier(.2,.7,.2,1)', background: enabled ? 'var(--bg)' : 'var(--ink)', transform: `translateX(${enabled ? 32 : 0}px)` }} />
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Double rule */}
+        <div style={{ height: 5, borderTop: '1px solid var(--ink)', borderBottom: '1px solid var(--ink)' }} />
+
+        {/* Body */}
+        {!loaded ? (
+          <div style={{ padding: 60, textAlign: 'center', color: 'var(--muted)', fontStyle: 'italic', fontSize: 13 }}>loading…</div>
+        ) : (
+          <div style={{ padding: 30, opacity: isEdit && !enabled ? 0.6 : 1, transition: 'opacity .2s ease' }}>
+
+            {/* Cooldown */}
+            <div style={{ marginBottom: 34 }}>
+              <div style={sectionLabel}>COOLDOWN — MINIMUM GAP BETWEEN AIRINGS</div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 18, flexWrap: 'wrap', marginTop: 16 }}>
+                <div style={{ display: 'flex' }}>
+                  {COOLDOWN_PRESETS.map((v, i) => (
+                    <button key={v} type="button" onClick={() => patch({ cooldown: v })} style={presetStyle(fields.cooldown === v, i)}>{v}</button>
+                  ))}
+                </div>
+                <span style={{ fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--muted)', fontWeight: 600 }}>OR TYPE</span>
+                <input
+                  value={fields.cooldown}
+                  onChange={e => patch({ cooldown: e.target.value })}
+                  placeholder="45m"
+                  style={{ ...inputBase, width: 128, padding: '11px 15px', fontSize: 15, fontWeight: 700, letterSpacing: '0.04em', fontVariantNumeric: 'tabular-nums' }}
+                />
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 12, letterSpacing: '0.01em' }}>e.g. 45m, 6h, 2d, or a bare number (minutes).</div>
+            </div>
+
+            {/* Window — custom skills only (built-in window isn't editable) */}
+            {custom && (
+              <div style={{ marginBottom: 34 }}>
+                <div style={sectionLabel}>WHEN IT CAN AIR</div>
+                <div style={{ display: 'flex', marginTop: 16 }}>
+                  {([['any', 'ANY TIME'], ['commute', 'COMMUTE ONLY']] as const).map(([w, lbl], i) => (
+                    <button key={w} type="button" onClick={() => patch({ window: w })} style={presetStyle(fields.window === w, i)}>{lbl}</button>
+                  ))}
+                </div>
+                <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 12 }}>Commute-only restricts this segment to the morning and evening commute hours.</div>
+              </div>
+            )}
+
+            {/* News feed — news built-in only */}
+            {isNews && (
+              <div style={{ marginBottom: 34 }}>
+                <div style={sectionLabel}>NEWS FEED — RSS 2.0</div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap', marginTop: 16 }}>
+                  <input
+                    type="url"
+                    value={fields.feed}
+                    onChange={e => patch({ feed: e.target.value })}
+                    placeholder="https://…/rss.xml"
+                    style={{ ...inputBase, flex: '1 1 320px', minWidth: 0, padding: '11px 15px', fontSize: 14 }}
+                  />
+                  <label style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+                    <span style={{ fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--muted)', fontWeight: 600 }}>MAX ITEMS</span>
+                    <input
+                      type="number"
+                      min={1}
+                      value={fields.feedMaxItems}
+                      onChange={e => patch({ feedMaxItems: e.target.value })}
+                      placeholder="10"
+                      style={{ ...inputBase, width: 90, padding: '11px 12px', fontSize: 14, fontVariantNumeric: 'tabular-nums' }}
+                    />
+                  </label>
+                </div>
+              </div>
+            )}
+
+            {/* Context bank */}
+            <div style={{ marginBottom: 34 }}>
+              <div style={sectionLabel}>CONTEXT THE DJ MAY MENTION</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, marginTop: 16 }}>
+                {knownContext.map(field => {
+                  const on = fields.context.includes(field);
+                  return (
+                    <button
+                      key={field}
+                      type="button"
+                      onClick={() => patch({ context: on ? fields.context.filter(f => f !== field) : [...fields.context, field] })}
+                      style={chipStyle(on)}
+                    >
+                      <span style={markStyle(on)} />
+                      <span>{CONTEXT_FIELD_LABELS[field] || field}</span>
+                    </button>
+                  );
+                })}
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 14, lineHeight: 1.6, maxWidth: '78ch' }}>
+                Switch on only what&apos;s topical for this segment. A context left dark stays out of the prompt — so the DJ stops working it into every break.
+              </div>
+            </div>
+
+            {/* Brief */}
+            <div>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+                <div style={sectionLabel}>THE BRIEF — WHAT THE DJ SAYS, AND WHEN TO STAY SILENT</div>
+                {/* Built-ins can be reverted to their shipped default brief/cooldown/context. */}
+                {!custom && defaults && (
+                  <button
+                    type="button"
+                    onClick={resetToDefault}
+                    className="sw-ghost"
+                    title="Restore the shipped default for this built-in skill (review, then Save)"
+                    style={{ flex: 'none', padding: '6px 12px', background: 'transparent', color: 'var(--muted)', border: '1px solid color-mix(in oklab, var(--ink) 24%, transparent)', fontSize: 10, fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', cursor: 'pointer' }}
+                  >
+                    ↺ Reset to default
+                  </button>
+                )}
+              </div>
+              <p className="sw-dropcap" style={{ fontSize: 13, lineHeight: 1.65, color: 'var(--muted)', margin: '14px 0', maxWidth: '74ch' }}>
+                Write it the way the DJ would read it on air. One or two lines, in character — and say plainly when the segment is better left unaired.
+              </p>
+              <textarea
+                value={fields.brief}
+                onChange={e => patch({ brief: e.target.value })}
+                rows={7}
+                placeholder="What should the DJ say — and when should it stay quiet?"
+                style={{ ...inputBase, width: '100%', boxSizing: 'border-box', minHeight: 200, borderLeft: '3px solid var(--accent)', padding: '16px 18px', fontSize: 15, lineHeight: 1.7, resize: 'vertical' }}
+              />
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 10 }}>
+                <span style={{ fontSize: 10, letterSpacing: '0.2em', textTransform: 'uppercase', color: 'var(--muted)', fontWeight: 600 }}>DJ VOICE · IN CHARACTER</span>
+                <span style={{ fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--muted)', fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{fields.brief.length} CHARS</span>
+              </div>
+              {hasTool && (
+                <div style={{ marginTop: 14, border: '1px solid color-mix(in oklab, var(--ink) 24%, transparent)', borderLeft: '3px solid var(--accent)', padding: '12px 14px', fontSize: 12, lineHeight: 1.6, color: 'var(--muted)' }}>
+                  A <code>tool.mjs</code> data fetcher is attached and runs each tick before the DJ speaks. Edit or remove it on disk + Rescan — it isn&apos;t editable here. Deleting the skill removes it too.
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Transport / actions — Run now (left), Close + Save (right) */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 16, padding: '18px 30px', borderTop: '1px solid var(--ink)', flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            {isEdit && (
+              <button
+                type="button"
+                onClick={run}
+                disabled={acting}
+                style={{ padding: '13px 26px', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', transition: 'transform .1s', border: '1px solid var(--accent)', background: 'var(--accent)', color: '#fff', cursor: acting ? 'wait' : 'pointer', opacity: acting ? 0.7 : 1 }}
+              >
+                ▸ RUN NOW
+              </button>
+            )}
+            {isEdit && custom && (
+              <button
+                type="button"
+                onClick={() => setConfirmDelete(true)}
+                disabled={acting}
+                className="sw-ghost"
+                style={{ padding: '13px 22px', background: 'transparent', color: 'var(--danger)', border: '1px solid var(--danger)', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', cursor: acting ? 'wait' : 'pointer', opacity: acting ? 0.7 : 1 }}
+              >
+                DELETE
+              </button>
+            )}
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+            {dirty && (
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--accent)', fontWeight: 700 }}>
+                <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--accent)' }} />UNSAVED EDITS
+              </span>
+            )}
+            {flash && (
+              <span style={{ fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--accent)', fontWeight: 700, animation: 'sw-blink 1s steps(1) infinite' }}>✓ {flash}</span>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              className="sw-ghost"
+              style={{ padding: '13px 22px', background: 'transparent', color: 'var(--muted)', border: '1px solid color-mix(in oklab, var(--ink) 24%, transparent)', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', cursor: 'pointer' }}
+            >
+              CLOSE
+            </button>
+            <button
+              type="button"
+              onClick={save}
+              disabled={!canSave}
+              style={{ padding: '13px 26px', background: canSave ? 'var(--ink)' : 'color-mix(in oklab, var(--ink) 20%, transparent)', color: 'var(--bg)', border: '1px solid var(--ink)', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', cursor: canSave ? 'pointer' : 'not-allowed' }}
+            >
+              {busy ? (mode === 'create' ? 'CREATING…' : 'SAVING…') : (mode === 'create' ? 'CREATE' : 'SAVE')}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Delete confirm — the shared V3AlertDialog (same as Dash's skip-track
+          prompt). Portals above this sheet (sheet is z-30, dialog content z-50). */}
+      <V3AlertDialog
+        open={confirmDelete}
+        onOpenChange={setConfirmDelete}
+        title="Delete skill"
+        description={`Delete the “${skill?.name ?? ''}” skill? This removes state/skills/${skill?.name ?? ''}/ from disk and can't be undone.`}
+        confirmLabel="delete skill"
+        danger
+        onConfirm={remove}
+      />
+    </div>
+  );
+}

--- a/web/components/admin/skills/contextFields.ts
+++ b/web/components/admin/skills/contextFields.ts
@@ -1,0 +1,23 @@
+// Shared "right now" context-field vocabulary for the Skills admin (#471).
+// The skill edit/create sheet (SkillEditModal) renders these as a chip bank, so
+// the labels + fallback list + the comma-string parser live here, defined once.
+
+// Friendly labels for the context fields. Keys are the controller's
+// CONTEXT_FIELDS vocabulary; anything not listed falls back to the raw key.
+export const CONTEXT_FIELD_LABELS: Record<string, string> = {
+  date: 'Date & season',
+  clock: 'Clock time',
+  time: 'Daypart',
+  weather: 'Weather',
+  festival: 'Festival',
+  show: 'Current show',
+  listeners: 'Listener count',
+};
+
+// Fallback vocabulary if the controller doesn't send knownContextFields.
+export const CONTEXT_FIELDS_FALLBACK = ['date', 'clock', 'time', 'weather', 'festival', 'show', 'listeners'];
+
+// Split a comma-separated `context` value into trimmed, non-empty tokens.
+export function splitContext(s?: string): string[] {
+  return typeof s === 'string' ? s.split(',').map(t => t.trim()).filter(Boolean) : [];
+}

--- a/web/components/manual/AdminSettings.tsx
+++ b/web/components/manual/AdminSettings.tsx
@@ -69,7 +69,7 @@ export default function AdminSettings() {
           </li>
           <li>
             <strong>Skills</strong> — the real-world segments the autonomous DJ can run:
-            weather, news, traffic, facts, web search. Toggle each on or off
+            weather, news, now-playing digs, facts, web search. Toggle each on or off
             station-wide.
           </li>
         </ul>

--- a/web/components/manual/CustomSkills.tsx
+++ b/web/components/manual/CustomSkills.tsx
@@ -6,7 +6,7 @@ export default function CustomSkills() {
     <ManualPage
       eyebrow="MANUAL · 06"
       title="Custom skills."
-      intro="The things the DJ does between tracks (a weather check, a headline, a traffic gag) are skills. Seven ship built in, and you can edit any of them or add your own by dropping a folder into state/skills, no code changes to the station."
+      intro="The things the DJ does between tracks (a weather check, a headline, a dig on the song playing) are skills. Seven ship built in, and you can edit any of them or add your own — from the admin Skills page or by dropping a folder into state/skills — with no code changes to the station."
       current="/manual/skills"
     >
       <section className="bs-section">
@@ -44,6 +44,14 @@ export default function CustomSkills() {
           into <code className="bs-code-inline">state/skills/</code> and hit{' '}
           <strong>Rescan</strong> on the admin Skills page.
         </p>
+        <p>
+          Prefer not to touch disk? The admin <strong>Skills</strong> page has a{' '}
+          <strong>New skill</strong> button that writes the{' '}
+          <code className="bs-code-inline">SKILL.md</code> for you, and lets you edit or
+          delete custom skills in place. It&rsquo;s prompt-only — frontmatter plus the brief;
+          a <code className="bs-code-inline">tool.mjs</code> data fetcher is still added on
+          disk + Rescan.
+        </p>
       </section>
 
       <section className="bs-section">
@@ -76,7 +84,7 @@ the phase is unremarkable.`}</CodeBlock>
         <p className="bs-eyebrow">EDITING THE BUILT-INS</p>
         <h2>The shipped skills are files too.</h2>
         <p>
-          The seven built-ins — weather, news, traffic, curiosity, album anniversaries,
+          The seven built-ins — weather, news, now-playing digs, curiosity, album anniversaries,
           library deep-cuts, and web search — are written into{' '}
           <code className="bs-code-inline">state/skills/&lt;kind&gt;/SKILL.md</code> the first
           time the station boots. Editing one (on the admin <strong>Skills</strong> page, or
@@ -126,7 +134,7 @@ not a newsreader's. Skip anything dull or stale; silence is fine.`}</CodeBlock>
           The call is timeout-guarded and any error degrades cleanly to &ldquo;no
           data&rdquo;; a slow or broken skill can never hang the station. With no{' '}
           <code className="bs-code-inline">tool.mjs</code>, the skill writes from its brief
-          alone (like the built-in traffic gag).
+          alone — no live data to look at.
         </p>
         <div className="bs-callout">
           <div className="bs-eyebrow">IT RUNS YOUR CODE</div>

--- a/web/components/what/BehindTheDesk.tsx
+++ b/web/components/what/BehindTheDesk.tsx
@@ -18,7 +18,7 @@ const PANELS = [
     eyebrow: 'SKILLS',
     title: 'What the DJ does between tracks.',
     body:
-      'Each skill is an autonomous segment: a weather check, a news headline, an absurd traffic update, an oddly-specific fact. Toggle each one on, assign it to a persona, or run any one now as an operator override.',
+      'Each skill is an autonomous segment: a weather check, a news headline, a dig on the song playing, an oddly-specific fact. Toggle each one on, assign it to a persona, or run any one now as an operator override.',
     fig: {
       src: '/screenshots/admin-skills.webp',
       label: 'Admin — Skills',

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -222,6 +222,21 @@ export default defineConfig([
     },
   },
 
+  // Exemption for the Skill Edit Card — the /admin/skills "segment sheet" modal,
+  // a faithful port of a Claude Design prototype (claude.ai/design "Skill Edit
+  // Card"). Its styling is intrinsically state-driven: per-chip on/off fills,
+  // active-preset inversion, the on-air toggle thumb transform, status colours
+  // and the body dim are all computed from the form's live state over the theme
+  // tokens — the same dynamic-styling deal as the Observatory / Booth Sprite
+  // ports above. Its keyframes + pseudo-elements live in app/globals.css under
+  // `.sw-seg`.
+  {
+    files: ['components/admin/skills/SkillEditModal.tsx'],
+    rules: {
+      'react/forbid-dom-props': 'off',
+    },
+  },
+
   {
     rules: {
       // Prose noise — JSX renders apostrophes/quotes fine.


### PR DESCRIPTION
## What & why

`/admin/skills` had no way to **create** a skill — custom skills could only be made by hand-dropping `state/skills/<slug>/SKILL.md` and hitting Rescan, and custom skills had no Edit/Delete in the UI. This brings skills up to the themes/shows/personas bar with a full create / edit / delete experience, presented as a newspaper-styled **"segment sheet" modal** (ported from a Claude Design prototype).

## Changes

**Backend**
- `POST /dj/skills` (create custom, prompt-only) and `DELETE /dj/skills/:slug`.
- Broadened `GET`/`PUT /dj/skills/:kind/file` to serve **custom** skills too; the controller is the single validation gate (slug regex, reserved kinds, cooldown format, context vocabulary, env-key format), reusing the loader's own constants so rules never drift.
- `GET` returns each built-in's **shipped defaults** (from raw `CAPABILITIES`) for the new *Reset to default*.
- **CORS fix:** `Access-Control-Allow-Methods` only listed `GET, POST, DELETE`, so the modal's cross-origin **PUT** edits failed preflight with *"Failed to fetch"*. Added `PUT, PATCH`.

**UI**
- `SkillEditModal` — the segment sheet: cooldown presets + free input, context chip bank, commute window (custom), brief; on-air toggle, **Run now**, **Delete** (shared `V3AlertDialog` confirm), and **Reset to default** for built-ins. Replaces both old inline editors. Cards gain **New skill (+)** and an icon Rescan; dropped the redundant `kind` line/pill.
- Styling lives in `globals.css` under `.sw-seg`; the modal is exempted from the no-inline-style rule like the other Claude Design ports (Observatory, Booth Sprite).

**Built-in skills**
- Retired the locality-less **traffic** gag (a personal station has no real locality to report) and replaced it with **`now-playing-dig`** — a **search-grounded** detail about the *exact track* on air (producer, sample, B-side, chart), reusing `searchWeb` and **staying silent when nothing solid surfaces** so it never invents trivia.
- Tightened every shipped brief with anti-hallucination guards (use only tool data / stay silent / don't fabricate) and **removed the BBC reference** from news so it doesn't clash with the operator's persona.

**Docs:** refreshed `custom-skills.md` + manual pages for the new lineup; design spec under `docs/superpowers/specs/`.

## Test plan

- `npm run lint` green in both `controller/` and `web/` (the merge gate).
- Verified live on a dev stack: create → file round-trips & arrives disabled; edit (PUT) returns 200; delete removes the folder; rejection paths (reserved name, bad slug, dup → 409, empty brief) return correct codes; CORS preflight now returns `GET, POST, PUT, PATCH, DELETE`; GET exposes `defaults`; `now-playing-dig` scaffolds and replaces traffic in the catalogue.

## Note

The six edited built-in briefs are **shipped defaults** (fresh installs). Existing stations keep their already-scaffolded `SKILL.md` until *Reset to default* + Save (or a manual re-scaffold) — by design (file wins).
