### PR TITLE
feat(skills): unify built-in & custom skills on one loader + services API

### DIFF
--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -1140,21 +1140,28 @@ function wavDurationMs(path: string): number | null {
   }
 }
 
-const VOICE_KINDS = new Set(['dj-speak', 'link', 'station-id', 'hourly-check', 'weather', 'news', 'now-playing-dig', 'curiosity', 'album-anniversary', 'library-deep-cut', 'web-search']);
-const DEDUPE_KINDS = new Set(['station-id', 'hourly-check', 'weather', 'news', 'now-playing-dig', 'curiosity', 'album-anniversary', 'library-deep-cut', 'web-search']);
+// Voice kinds the DJ recap remembers. The fixed channels are always present;
+// every skill kind (built-in + custom) is registered at skill-load time via
+// registerSkillKinds() — so a new skill is recapped without editing this list.
+const VOICE_KINDS = new Set(['dj-speak', 'link', 'station-id', 'hourly-check']);
+// Kinds whose recap entries are de-duped. Skills are added at load time too.
+const DEDUPE_KINDS = new Set(['station-id', 'hourly-check']);
 const KIND_LABEL: Record<string, string> = {
   'dj-speak': 'intro',
   'link': 'link',
   'station-id': 'ident',
   'hourly-check': 'hourly',
-  'weather': 'weather',
-  'news': 'news',
-  'now-playing-dig': 'now-playing',
-  'curiosity': 'curiosity',
-  'album-anniversary': 'anniversary',
-  'library-deep-cut': 'deep-cut',
-  'web-search': 'web',
 };
+
+// Register the loaded skill kinds (built-in + custom) as recap voice/dedupe
+// kinds. Called by skills/loader.js after each (re)load; idempotent (Sets).
+export function registerSkillKinds(kinds: string[]): void {
+  for (const k of kinds) {
+    if (!k) continue;
+    VOICE_KINDS.add(k);
+    DEDUPE_KINDS.add(k);
+  }
+}
 
 function formatAgo(ms: number) {
   const s = Math.floor(ms / 1000);

--- a/controller/src/llm/internal/tools/segment-tools.ts
+++ b/controller/src/llm/internal/tools/segment-tools.ts
@@ -12,9 +12,11 @@
 //   services — the curated station facade (search, library, play log, feeds…)
 //   config   — the skill's own frontmatter (e.g. news' feed / feedMaxItems)
 //
-// Operator (custom) tools run operator-supplied code, so they're fenced behind
-// a hard timeout + try/catch — a slow or throwing skill degrades to "no data"
-// rather than hanging the tick. First-party built-in tools run unfenced.
+// Every skill tool now lives in state/skills (built-ins seeded there on first
+// boot), so all of them run behind a hard timeout + try/catch — a slow or
+// throwing skill degrades to "no data" rather than hanging the tick. The
+// network-heavy built-ins (web-search, news RSS, on-this-day) must finish within
+// the timeout or that tick simply yields no segment.
 
 import { tool } from 'ai';
 import { z } from 'zod';
@@ -26,14 +28,13 @@ export function buildSegmentTools(ctx: any, state: any, caps: any[]) {
 
   for (const cap of caps as any[]) {
     if (typeof cap.toolFn !== 'function' || !cap.toolName) continue;
-    const fenced = !!cap.custom;
     tools[cap.toolName] = tool({
       description: cap.toolDesc,
       inputSchema: z.object({}),
       execute: async () => {
         try {
           const p = Promise.resolve(cap.toolFn(ctx, state, services, cap.config));
-          return await (fenced ? withTimeout(p, 8000) : p);
+          return await withTimeout(p, 8000);
         } catch (err: any) {
           return { error: err?.message || String(err) };
         }
@@ -44,8 +45,8 @@ export function buildSegmentTools(ctx: any, state: any, caps: any[]) {
   return tools;
 }
 
-// Resolve `p`, or reject after `ms` — keeps an operator skill's tool.mjs from
-// stalling the segment tick indefinitely.
+// Resolve `p`, or reject after `ms` — keeps any skill's tool.mjs from stalling
+// the segment tick indefinitely.
 function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
   return new Promise<T>((res, rej) => {
     const t = setTimeout(() => rej(new Error(`tool timed out after ${ms}ms`)), ms);

--- a/controller/src/llm/internal/tools/segment-tools.ts
+++ b/controller/src/llm/internal/tools/segment-tools.ts
@@ -1,237 +1,39 @@
-// AI SDK tool library — real-world data tools the segment-director agent
-// (skills/_agent.js) calls before deciding whether to air a between-track
-// segment. The counterpart of picker-tools.ts (music discovery): that set lets
-// the DJ agent explore the library, this one lets it look at the world.
+// AI SDK tool library — wraps each on-offer skill's data tool (its tool.mjs)
+// for the segment-director agent (skills/_agent.js) to call before deciding
+// whether to air a between-track segment. The counterpart of picker-tools.ts
+// (music discovery): that set lets the DJ agent explore the library, these let
+// it look at the world.
 //
-// Tools are built per tick and scoped to the capabilities currently on offer
-// (off-cooldown, enabled, in-window) — a tool the agent shouldn't use simply
-// isn't in the set. The shared `state` object carries dedup memory between
-// ticks: seen headline hashes, the last weather condition aired, the last
-// artist searched.
+// Built-in and custom skills run on identical footing: every cap that ships a
+// `toolFn` (loaded from its directory's tool.mjs by skills/loader.js) gets one
+// tool here, invoked as `toolFn(ctx, state, services, config)`:
+//   ctx      — the moment ({ time, weather, festival, dominantMood, clock })
+//   state    — dedup memory carried across ticks (seen headlines, last artist…)
+//   services — the curated station facade (search, library, play log, feeds…)
+//   config   — the skill's own frontmatter (e.g. news' feed / feedMaxItems)
+//
+// Operator (custom) tools run operator-supplied code, so they're fenced behind
+// a hard timeout + try/catch — a slow or throwing skill degrades to "no data"
+// rather than hanging the tick. First-party built-in tools run unfenced.
 
 import { tool } from 'ai';
 import { z } from 'zod';
-import { queue } from '../../../broadcast/queue.js';
-import { fetchHeadlines, hashHeadline } from '../../../skills/news.js';
-import { searchWeb, searchReady } from '../../../skills/web-search.js';
-import { fetchOnThisDay, curiositySeen, recordCuriosity } from '../../../skills/curiosity.js';
-import { getArtist, searchArtists } from '../../../music/subsonic.js';
+import { buildStationServices } from './station-services.js';
 
-// `caps` is the list of capabilities offered this tick (see skills/_agent.js).
-// Only data-backed kinds get a tool. `curiosity` has a data tool but the agent
-// is free to fall through to pure generation under cap.desc when the tool
-// returns `available: false`; `now-playing-dig` does NOT — it must stay silent
-// unless its search tool surfaces a real, specific detail (no invented trivia).
 export function buildSegmentTools(ctx: any, state: any, caps: any[]) {
-  const kinds = new Set(caps.map((c: any) => c.kind));
+  const services = buildStationServices();
   const tools: any = {};
 
-  if (kinds.has('weather')) {
-    tools.checkWeather = tool({
-      description: 'Get the current weather and whether it has changed since the DJ last spoke about weather on air. Dull or unchanged weather is usually not worth airing. The temperature is returned in the unit indicated by `tempUnit` ("C" or "F") — read it on air in that unit, do not convert.',
-      inputSchema: z.object({}),
-      execute: async () => {
-        const w = ctx.weather;
-        if (!w || !w.condition || w.condition === 'unknown') return { available: false };
-        return {
-          available: true,
-          location: w.location,
-          condition: w.condition,
-          temp: w.temp ?? null,
-          tempUnit: w.tempUnit || 'C',
-          changedSinceLastMention: w.condition !== state.lastWeatherCondition,
-        };
-      },
-    });
-  }
-
-  if (kinds.has('news')) {
-    // Feed URL / max-items come from the news capability, which may be
-    // overridden by state/skills/news/SKILL.md (`feed:` / `feedMaxItems`).
-    // Undefined → fetchHeadlines falls back to config.news (env NEWS_FEED_URL).
-    const newsCap = caps.find((c: any) => c.kind === 'news');
-    tools.getHeadlines = tool({
-      description: 'Fetch current news headlines from the configured feed. Returns only headlines not already read on air.',
-      inputSchema: z.object({}),
-      execute: async () => {
-        try {
-          const items = await fetchHeadlines({ feedUrl: newsCap?.feed, maxItems: newsCap?.feedMaxItems });
-          const fresh = items.filter((it: any) => !state.seenHeadlines.has(hashHeadline(it.title)));
-          // Mark surfaced headlines as seen so a later tick doesn't re-offer
-          // them — same "burn on read" approach as the old news skill.
-          for (const it of fresh.slice(0, 6) as any[]) state.seenHeadlines.add(hashHeadline(it.title));
-          if (state.seenHeadlines.size > 120) {
-            state.seenHeadlines = new Set(Array.from(state.seenHeadlines).slice(-60));
-          }
-          if (!fresh.length) return { headlines: [] };
-          return { headlines: fresh.slice(0, 6).map((it: any) => ({ title: it.title, detail: it.description || null })) };
-        } catch (err) {
-          return { error: err.message };
-        }
-      },
-    });
-  }
-
-  if (kinds.has('curiosity')) {
-    tools.getCuriosityItem = tool({
-      description: 'Fetch one historical "on this day" event for today\'s date — filtered for cultural / scientific / sporting entries since 1850, and de-duped against curiosities already aired. Returns `available: false` when no fresh item exists; treat that as a cue to fall back to your own oddly-specific factoid under the capability brief, not as a reason to stay silent.',
-      inputSchema: z.object({}),
-      execute: async () => {
-        try {
-          const items = await fetchOnThisDay();
-          const fresh = items.filter((it: any) => !curiositySeen(it.text));
-          if (!fresh.length) return { available: false };
-          // Burn-on-read into the durable ledger so a later tick — or a tick
-          // after a controller restart — doesn't re-offer the same Wikipedia
-          // event (issue #577). Recorded as aired=false: surfaced, not yet
-          // spoken. The aired line is recorded separately when it airs.
-          for (const it of fresh.slice(0, 3) as any[]) recordCuriosity(it.text);
-          return {
-            available: true,
-            items: fresh.slice(0, 3).map((it: any) => ({ year: it.year, text: it.text })),
-          };
-        } catch (err) {
-          return { error: err.message };
-        }
-      },
-    });
-  }
-
-  if (kinds.has('album-anniversary')) {
-    tools.checkAlbumAnniversary = tool({
-      description: 'Check whether the album currently on air is hitting a round-number anniversary (5/10/20/25y) this year. Returns the album, the artist, and the year count when one applies; `available: false` otherwise.',
-      inputSchema: z.object({}),
-      execute: async () => {
-        const track = queue.current?.track as any;
-        const albumName = track?.album;
-        const albumYear = Number(track?.year);
-        const artistName = track?.artist;
-        if (!albumName || !artistName) return { available: false };
-        if (!Number.isFinite(albumYear) || albumYear < 1900) return { available: false };
-        const years = new Date().getFullYear() - albumYear;
-        if (years < 5) return { available: false };
-        if (years % 5 !== 0) return { available: false };
-        return {
-          available: true,
-          album: albumName,
-          artist: artistName,
-          years,
-          releasedYear: albumYear,
-        };
-      },
-    });
-  }
-
-  if (kinds.has('library-deep-cut')) {
-    tools.findDeepCut = tool({
-      description: 'Find a track by the on-air artist that lives in the operator\'s library but has NOT been played in the last 30 days. Returns at most a handful of candidates plus a count; `available: false` if the artist has nothing cold to surface. Do NOT name a specific track unless exactly one is returned.',
-      inputSchema: z.object({}),
-      execute: async () => {
-        const artistName = queue.current?.track?.artist;
-        if (!artistName || /^unknown/i.test(artistName)) return { available: false };
-        try {
-          // Resolve the artist id — search3 returns artist matches, take the best one.
-          const matches = await searchArtists(artistName, { artistCount: 3 });
-          const artist = matches.find((a: any) => a.name?.toLowerCase() === artistName.toLowerCase())
-                       || matches[0];
-          if (!artist?.id) return { available: false };
-          const detail = await getArtist(artist.id);
-          const albums = Array.isArray(detail?.album) ? detail.album : [];
-          if (!albums.length) return { available: false };
-          const { ids, keys } = queue.recentlyPlayed(30 * 24); // 30 days
-          // Walk a bounded slice of albums (cheapest viable: top 8 by year/recent).
-          // We only need to know whether at least one cold track exists.
-          const cold: { title: string; album: string }[] = [];
-          const { getAlbum } = await import('../../../music/subsonic.js');
-          for (const album of albums.slice(0, 8)) {
-            const songs = await getAlbum(album.id);
-            for (const s of songs) {
-              const songId = String(s?.id || '');
-              const key = `${(s?.title || '').toLowerCase().trim()}|${(s?.artist || artistName).toLowerCase().trim()}`;
-              if (songId && ids.has(songId)) continue;
-              if (keys.has(key)) continue;
-              if (!s?.title) continue;
-              cold.push({ title: s.title, album: album.name || '' });
-              if (cold.length >= 6) break;
-            }
-            if (cold.length >= 6) break;
-          }
-          if (!cold.length) return { available: false };
-          return { available: true, artist: artistName, count: cold.length, candidates: cold };
-        } catch (err) {
-          return { error: err.message };
-        }
-      },
-    });
-  }
-
-  if (kinds.has('web-search') && searchReady()) {
-    tools.searchArtistNews = tool({
-      description: 'Search the web for something recent about the artist currently on air.',
-      inputSchema: z.object({}),
-      execute: async () => {
-        const artist = queue.current?.track?.artist;
-        if (!artist || /^unknown/i.test(artist)) return { available: false };
-        const alreadySearched = artist === state.lastSearchedArtist;
-        try {
-          const data = await searchWeb(`${artist} musician latest news`, { recency: 'week' });
-          state.lastSearchedArtist = artist;
-          const answer = (data.answer || '').trim();
-          const sources = (data.results || [])
-            .slice(0, 3)
-            .map(r => `${r.title}: ${(r.content || '').replace(/\s+/g, ' ').trim().slice(0, 240)}`);
-          if (!answer && sources.length === 0) return { available: false };
-          return { artist, alreadySearched, answer, sources };
-        } catch (err) {
-          return { error: err.message };
-        }
-      },
-    });
-  }
-
-  // Now-playing dig — search the web for a concrete detail about the EXACT track
-  // on air (producer, sample, B-side, chart, backstory). Grounded so the DJ
-  // never invents track trivia: returns { available: false } when nothing solid
-  // comes back, and the brief says to stay silent on that.
-  if (kinds.has('now-playing-dig') && searchReady()) {
-    tools.digCurrentTrack = tool({
-      description: 'Search the web for a specific, verifiable detail about the exact track currently on air (producer, sample, B-side, chart, backstory).',
-      inputSchema: z.object({}),
-      execute: async () => {
-        const cur = queue.current?.track;
-        const artist = cur?.artist;
-        const title = cur?.title;
-        if (!artist || !title || /^unknown/i.test(artist) || /^unknown/i.test(title)) return { available: false };
-        const trackKey = `${artist} — ${title}`;
-        const alreadyDug = trackKey === state.lastDugTrack;
-        try {
-          const data = await searchWeb(`${artist} "${title}" song producer sample b-side chart story`);
-          state.lastDugTrack = trackKey;
-          const answer = (data.answer || '').trim();
-          const sources = (data.results || [])
-            .slice(0, 3)
-            .map(r => `${r.title}: ${(r.content || '').replace(/\s+/g, ' ').trim().slice(0, 240)}`);
-          if (!answer && sources.length === 0) return { available: false };
-          return { artist, title, alreadyDug, answer, sources };
-        } catch (err) {
-          return { error: err.message };
-        }
-      },
-    });
-  }
-
-  // Operator-dropped custom skills (state/skills) that ship a tool.mjs get
-  // their data fetcher wrapped as a tool here. The fetcher runs operator-
-  // supplied code, so it is fenced behind a hard timeout + try/catch — a slow
-  // or throwing skill degrades to "no data" rather than hanging the tick.
   for (const cap of caps as any[]) {
-    if (!cap.custom || typeof cap.toolFn !== 'function') continue;
+    if (typeof cap.toolFn !== 'function' || !cap.toolName) continue;
+    const fenced = !!cap.custom;
     tools[cap.toolName] = tool({
       description: cap.toolDesc,
       inputSchema: z.object({}),
       execute: async () => {
         try {
-          return await withTimeout(Promise.resolve(cap.toolFn(ctx, state)), 8000);
+          const p = Promise.resolve(cap.toolFn(ctx, state, services, cap.config));
+          return await (fenced ? withTimeout(p, 8000) : p);
         } catch (err: any) {
           return { error: err?.message || String(err) };
         }

--- a/controller/src/llm/internal/tools/station-services.ts
+++ b/controller/src/llm/internal/tools/station-services.ts
@@ -1,0 +1,67 @@
+// Station services — the curated facade a skill's data tool (a built-in or an
+// operator's custom tool.mjs) gets to look at the world before the DJ speaks.
+// This is the SINGLE place segment tools reach into the controller's internals
+// (web search, the music library, the queue, feeds, durable recall). It is
+// passed as the third argument to every tool fetcher:
+//
+//   export default async (ctx, state, services) => data
+//
+// so the contract stays backward-compatible — existing two-arg custom skills
+// ignore the third arg and keep working.
+//
+// The surface is deliberately READ-MOSTLY: search, library reads, play-log
+// reads, a durable dedup store, and a log line. No writes to settings, no
+// secrets, no queue mutation — a custom tool.mjs running here is the operator's
+// own code (same trust model as a local Claude Code skill), fenced by the 8s
+// timeout at the call site, but it still shouldn't be handed the whole booth.
+
+import { queue } from '../../../broadcast/queue.js';
+import { searchWeb, searchReady } from '../../../skills/web-search.js';
+import { fetchOnThisDay, curiositySeen, recordCuriosity } from '../../../skills/curiosity.js';
+import { fetchHeadlines, hashHeadline } from '../../../skills/news.js';
+import { getArtist, getAlbum, searchArtists } from '../../../music/subsonic.js';
+
+export interface StationServices {
+  // Web search via the operator's configured provider (DuckDuckGo / Tavily /
+  // SearXNG). `searchReady()` is false when no provider is usable.
+  searchWeb: typeof searchWeb;
+  searchReady: typeof searchReady;
+  // The track currently on air (artist/title/album/year/id), or null.
+  nowPlaying: () => any | null;
+  // Play-log lookup over the last `hours` — { ids, keys } sets for dedup.
+  recentPlays: (hours: number) => { ids: Set<string>; keys: Set<string> };
+  // Subsonic/Navidrome library reads.
+  library: { getArtist: typeof getArtist; getAlbum: typeof getAlbum; searchArtists: typeof searchArtists };
+  // Wikipedia "on this day" events for today's date.
+  onThisDay: () => Promise<any[]>;
+  // Fetch + parse an RSS feed (defaults to the configured news feed).
+  fetchHeadlines: typeof fetchHeadlines;
+  hashHeadline: typeof hashHeadline;
+  // Durable, cross-restart dedup ledger — remember what was aired so it isn't
+  // repeated days later. (Backs the curiosity skill; available to any skill.)
+  recall: { seen: (key: string) => boolean; remember: (key: string) => void };
+  // Append a namespaced line to the station event log.
+  log: (msg: string) => void;
+}
+
+let cached: StationServices | null = null;
+
+// Build (once) the services facade. The wrappers are stateless — `nowPlaying`,
+// `recentPlays` etc. read live from the queue each call — so a single cached
+// instance is safe to reuse across ticks.
+export function buildStationServices(): StationServices {
+  if (cached) return cached;
+  cached = {
+    searchWeb,
+    searchReady,
+    nowPlaying: () => queue.current?.track ?? null,
+    recentPlays: (hours: number) => queue.recentlyPlayed(hours),
+    library: { getArtist, getAlbum, searchArtists },
+    onThisDay: () => fetchOnThisDay(),
+    fetchHeadlines,
+    hashHeadline,
+    recall: { seen: (key: string) => curiositySeen(key), remember: (key: string) => recordCuriosity(key) },
+    log: (msg: string) => queue.log('scheduler', `[skill] ${msg}`),
+  };
+  return cached;
+}

--- a/controller/src/routes/dj.ts
+++ b/controller/src/routes/dj.ts
@@ -12,8 +12,8 @@ import * as library from '../music/library.js';
 import * as settings from '../settings.js';
 import { runStationId, runHourlyCheck, runLink, refreshAutoPlaylist } from '../broadcast/scheduler.js';
 import { skillCatalog, runCapability, effectiveContextFields } from '../skills/_agent.js';
-import { loadCustomSkills, parseFrontmatter, BUILTIN_KINDS, RESERVED_KINDS, SLUG_RE, builtinBaseCaps } from '../skills/loader.js';
-import { writeSkillFile, msToCooldownStr } from '../skills/scaffold.js';
+import { loadSkills, parseFrontmatter, SEEDED_KINDS, RESERVED_KINDS, SLUG_RE, readTemplate } from '../skills/loader.js';
+import { writeSkillFile, msToCooldownStr, resetBuiltinSkill } from '../skills/scaffold.js';
 import { readFile, rm, stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { STATE_DIR, config } from '../config.js';
@@ -35,15 +35,15 @@ router.get('/dj/skills', requireAdmin, (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
-// POST /dj/skills/rescan — reload operator-dropped custom skills from
-// state/skills (picks up new folders and edited SKILL.md / tool.mjs files
-// without a controller restart). Returns the refreshed catalogue.
+// POST /dj/skills/rescan — reload all skills from state/skills (picks up new
+// folders and edited SKILL.md / tool.mjs files — built-in or custom — without a
+// controller restart). Returns the refreshed catalogue.
 // ---------------------------------------------------------------------------
 router.post('/dj/skills/rescan', requireAdmin, async (req, res) => {
   try {
-    const caps = await loadCustomSkills();
-    queue.log('scheduler', `[skills] rescanned — ${caps.length} custom skill(s) loaded`);
-    res.json({ skills: skillCatalog(), custom: caps.length });
+    const caps = await loadSkills();
+    queue.log('scheduler', `[skills] rescanned — ${caps.length} skill(s) loaded`);
+    res.json({ skills: skillCatalog(), custom: caps.filter((c: any) => !c.seeded).length });
   } catch (err) {
     queue.log('error', `/dj/skills/rescan failed: ${err.message}`);
     res.status(500).json({ error: err.message });
@@ -127,17 +127,17 @@ router.get('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
   const kind = req.params.kind;
   const cat = skillCatalog().find(s => s.kind === kind);
 
-  if (BUILTIN_KINDS.has(kind)) {
-    // Shipped defaults from the built-in's directory default (NOT the
-    // override-merged catalogue), so the admin "Reset to default" restores the
-    // as-shipped brief even after the SKILL.md has been edited. News seeds its
-    // feed from config (env-or-BBC), mirroring the scaffolder.
-    const rawCap = builtinBaseCaps().find((c: any) => c.kind === kind);
-    const defaults = rawCap ? {
-      label: rawCap.label || kind,
-      cooldown: msToCooldownStr(rawCap.cooldownMs || 0),
-      context: (effectiveContextFields(rawCap) || []).join(', '),
-      brief: rawCap.desc || '',
+  if (SEEDED_KINDS.has(kind)) {
+    // Shipped defaults read straight from the built-in's TEMPLATE (NOT the live
+    // state copy), so the admin "Reset to default" shows the as-shipped brief
+    // even after the state SKILL.md has been edited. News seeds its feed from
+    // config (env-or-BBC), mirroring the seeder.
+    const tpl = await readTemplate(kind);
+    const defaults = tpl ? {
+      label: tpl.data.label || kind,
+      cooldown: tpl.data.cooldown || '60m',
+      context: (effectiveContextFields({ contextFields: tpl.data.context ?? tpl.data.contextFields }) || []).join(', '),
+      brief: tpl.body || '',
       ...(kind === 'news' ? { feed: config.news.feedUrl, feedMaxItems: config.news.maxItems } : {}),
     } : null;
 
@@ -159,6 +159,10 @@ router.get('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
         feed: data.feed || cat?.feed || null,
         feedMaxItems: data.feedMaxItems ? parseInt(data.feedMaxItems, 10) : (cat?.feedMaxItems || null),
         brief: body || cat?.description || '',
+        // Built-ins now carry an editable tool.mjs in state too (seeded on first
+        // boot), so the edit form shows the same "edit on disk + Rescan" hint as
+        // custom skills.
+        hasTool: await skillHasTool(kind),
         defaults,
       });
     } catch {
@@ -175,6 +179,7 @@ router.get('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
         feed: cat?.feed || null,
         feedMaxItems: cat?.feedMaxItems || null,
         brief: cat?.description || '',
+        hasTool: await skillHasTool(kind),
         defaults,
       });
     }
@@ -234,7 +239,7 @@ router.post('/dj/skills', requireAdmin, async (req, res) => {
 
   try {
     await writeSkillFile(fields);
-    await loadCustomSkills();
+    await loadSkills();
     queue.log('scheduler', `[skills] custom "${name}" created via admin UI`);
     res.json({ skills: skillCatalog() });
   } catch (err: any) {
@@ -253,7 +258,7 @@ router.put('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
   const b = req.body || {};
 
   // Custom skill edit — same validation as create, minus the slug (immutable).
-  if (!BUILTIN_KINDS.has(kind)) {
+  if (!SEEDED_KINDS.has(kind)) {
     if (!SLUG_RE.test(kind)) {
       return res.status(400).json({ error: `invalid skill name: ${kind}` });
     }
@@ -268,7 +273,7 @@ router.put('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
     }
     try {
       await writeSkillFile(fields); // rewrites SKILL.md only; a sibling tool.mjs is left intact
-      await loadCustomSkills();
+      await loadSkills();
       queue.log('scheduler', `[skills] custom "${kind}" edited via admin UI`);
       return res.json({ skills: skillCatalog() });
     } catch (err: any) {
@@ -322,7 +327,7 @@ router.put('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
 
   try {
     await writeSkillFile(fields);
-    await loadCustomSkills();
+    await loadSkills();
     queue.log('scheduler', `[skills] built-in "${kind}" edited via admin UI`);
     res.json({ skills: skillCatalog() });
   } catch (err: any) {
@@ -332,14 +337,37 @@ router.put('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
+// POST /dj/skills/:kind/reset — restore a built-in to its shipped default,
+// overwriting BOTH state/skills/<kind>/SKILL.md AND tool.mjs from the image
+// template. This is how an operator reverts a broken edit or pulls in a newer
+// image's tool.mjs (which the seeder won't auto-apply once the file exists).
+// Only valid for seeded built-in kinds — custom skills have no shipped default.
+// ---------------------------------------------------------------------------
+router.post('/dj/skills/:kind/reset', requireAdmin, async (req, res) => {
+  const kind = req.params.kind;
+  if (!SEEDED_KINDS.has(kind)) {
+    return res.status(400).json({ error: `"${kind}" is not a built-in skill — only built-ins can be reset to default` });
+  }
+  try {
+    await resetBuiltinSkill(kind);
+    await loadSkills();
+    queue.log('scheduler', `[skills] built-in "${kind}" reset to default via admin UI`);
+    res.json({ skills: skillCatalog() });
+  } catch (err: any) {
+    queue.log('error', `POST /dj/skills/${kind}/reset failed: ${err.message}`);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // DELETE /dj/skills/:slug — remove a custom skill (its whole folder, including
-// any tool.mjs). Built-ins can't be deleted; they're edited in place. Reloads
-// and returns the refreshed catalogue.
+// any tool.mjs). Built-ins can't be deleted — only disabled; the seeder restores
+// a missing built-in folder on the next boot. Reloads and returns the catalogue.
 // ---------------------------------------------------------------------------
 router.delete('/dj/skills/:slug', requireAdmin, async (req, res) => {
   const slug = req.params.slug;
-  if (BUILTIN_KINDS.has(slug)) {
-    return res.status(400).json({ error: "built-in skills can't be deleted — edit them instead" });
+  if (SEEDED_KINDS.has(slug)) {
+    return res.status(400).json({ error: "built-in skills can't be deleted — disable them instead" });
   }
   if (!SLUG_RE.test(slug)) {
     return res.status(400).json({ error: `invalid skill name: ${slug}` });
@@ -349,7 +377,7 @@ router.delete('/dj/skills/:slug', requireAdmin, async (req, res) => {
   }
   try {
     await rm(join(SKILLS_DIR, slug), { recursive: true, force: true });
-    await loadCustomSkills();
+    await loadSkills();
     queue.log('scheduler', `[skills] custom "${slug}" deleted via admin UI`);
     res.json({ skills: skillCatalog() });
   } catch (err: any) {

--- a/controller/src/routes/dj.ts
+++ b/controller/src/routes/dj.ts
@@ -11,8 +11,8 @@ import * as subsonic from '../music/subsonic.js';
 import * as library from '../music/library.js';
 import * as settings from '../settings.js';
 import { runStationId, runHourlyCheck, runLink, refreshAutoPlaylist } from '../broadcast/scheduler.js';
-import { skillCatalog, runCapability, CAPABILITIES, effectiveContextFields } from '../skills/_agent.js';
-import { loadCustomSkills, parseFrontmatter, BUILTIN_KINDS, RESERVED_KINDS, SLUG_RE } from '../skills/loader.js';
+import { skillCatalog, runCapability, effectiveContextFields } from '../skills/_agent.js';
+import { loadCustomSkills, parseFrontmatter, BUILTIN_KINDS, RESERVED_KINDS, SLUG_RE, builtinBaseCaps } from '../skills/loader.js';
 import { writeSkillFile, msToCooldownStr } from '../skills/scaffold.js';
 import { readFile, rm, stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
@@ -128,11 +128,11 @@ router.get('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
   const cat = skillCatalog().find(s => s.kind === kind);
 
   if (BUILTIN_KINDS.has(kind)) {
-    // Shipped defaults from the RAW CAPABILITIES entry (NOT the override-merged
-    // catalogue), so the admin "Reset to default" restores the as-shipped brief
-    // even after the SKILL.md has been edited. News seeds its feed from config
-    // (env-or-BBC), mirroring the scaffolder.
-    const rawCap = CAPABILITIES.find((c: any) => c.kind === kind);
+    // Shipped defaults from the built-in's directory default (NOT the
+    // override-merged catalogue), so the admin "Reset to default" restores the
+    // as-shipped brief even after the SKILL.md has been edited. News seeds its
+    // feed from config (env-or-BBC), mirroring the scaffolder.
+    const rawCap = builtinBaseCaps().find((c: any) => c.kind === kind);
     const defaults = rawCap ? {
       label: rawCap.label || kind,
       cooldown: msToCooldownStr(rawCap.cooldownMs || 0),

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -147,25 +147,21 @@ app.listen(config.server.port, async () => {
     console.error('[budget] seed failed:', err.message);
   }
 
-  // Scaffold the built-in skills as editable files under state/skills/<kind>/
-  // (idempotent — never clobbers operator edits) so loadCustomSkills below picks
-  // them up as overrides. Must run before the load. Never fatal.
+  // Load the shipped built-in skills (src/skills/builtins/<kind>/), then scaffold
+  // each as an editable state/skills/<kind>/SKILL.md override (idempotent — never
+  // clobbers operator edits), then load operator custom skills + brief overrides
+  // from state/skills. Built-ins must load first so kinds classify correctly.
+  // None of this is fatal.
   try {
+    const { loadBuiltins, loadCustomSkills } = await import('./skills/loader.js');
+    const builtins = await loadBuiltins();
+    if (builtins.length) console.log(`[skills] ${builtins.length} built-in(s): ${builtins.map((c: any) => c.kind).join(', ')}`);
     const { scaffoldBuiltinSkills } = await import('./skills/scaffold.js');
     await scaffoldBuiltinSkills();
-  } catch (err: any) {
-    console.error('[skills] scaffold failed:', err.message);
-  }
-
-  // Load operator-dropped custom skills + built-in overrides from state/skills —
-  // merged into the segment director's capability set (see skills/loader.js).
-  // Never fatal.
-  try {
-    const { loadCustomSkills } = await import('./skills/loader.js');
     const caps = await loadCustomSkills();
     if (caps.length) console.log(`[skills] ${caps.length} custom skill(s): ${caps.map((c: any) => c.kind).join(', ')}`);
   } catch (err: any) {
-    console.error('[skills] custom load failed:', err.message);
+    console.error('[skills] load failed:', err.message);
   }
 
   // First-run banner — operators glancing at `docker compose logs` should

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -147,19 +147,20 @@ app.listen(config.server.port, async () => {
     console.error('[budget] seed failed:', err.message);
   }
 
-  // Load the shipped built-in skills (src/skills/builtins/<kind>/), then scaffold
-  // each as an editable state/skills/<kind>/SKILL.md override (idempotent — never
-  // clobbers operator edits), then load operator custom skills + brief overrides
-  // from state/skills. Built-ins must load first so kinds classify correctly.
-  // None of this is fatal.
+  // Seed the shipped built-ins (src/skills/builtins/<kind>/ templates) into
+  // state/skills/<kind>/ as full editable skills — SKILL.md + tool.mjs, idempotent
+  // (never clobbers operator edits) — then load state/skills as the single load
+  // root. Built-ins are no longer special at load time; the seeder just runs first
+  // so their files exist when the scan happens. None of this is fatal.
   try {
-    const { loadBuiltins, loadCustomSkills } = await import('./skills/loader.js');
-    const builtins = await loadBuiltins();
-    if (builtins.length) console.log(`[skills] ${builtins.length} built-in(s): ${builtins.map((c: any) => c.kind).join(', ')}`);
-    const { scaffoldBuiltinSkills } = await import('./skills/scaffold.js');
-    await scaffoldBuiltinSkills();
-    const caps = await loadCustomSkills();
-    if (caps.length) console.log(`[skills] ${caps.length} custom skill(s): ${caps.map((c: any) => c.kind).join(', ')}`);
+    const { loadSkills } = await import('./skills/loader.js');
+    const { seedBuiltinSkills } = await import('./skills/scaffold.js');
+    await seedBuiltinSkills();
+    const caps = await loadSkills();
+    const seeded = caps.filter((c: any) => c.seeded);
+    if (seeded.length) console.log(`[skills] ${seeded.length} built-in(s): ${seeded.map((c: any) => c.kind).join(', ')}`);
+    const custom = caps.filter((c: any) => !c.seeded);
+    if (custom.length) console.log(`[skills] ${custom.length} custom skill(s): ${custom.map((c: any) => c.kind).join(', ')}`);
   } catch (err: any) {
     console.error('[skills] load failed:', err.message);
   }

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -17,14 +17,15 @@
 // Both the autonomous tick AND the operator override now run through this
 // agent. `agenticTick()` is the 5-minute cron; `runCapability()` is the
 // /dj/skill manual override — same tool-loop, but forced to one capability
-// with cooldowns bypassed. The CAPABILITIES table below is the single source
-// of truth, and also backs the admin catalogue via `skillCatalog()`. The only
-// skill modules left in this directory — news.js, web-search.js — are pure
-// fetch helpers that back the segment tools (llm/segment-tools.js).
+// with cooldowns bypassed. The capability registry is loaded by skills/loader.js
+// (built-ins from src/skills/builtins/, custom from state/skills); this module
+// consumes it (allCapabilities) and also backs the admin catalogue via
+// `skillCatalog()`. The skill modules left in this directory — news.js,
+// web-search.js, curiosity.js — are pure fetch helpers behind station-services.
 //
 // Guard rails the autonomous tick cannot talk its way past (the operator
 // override bypasses all of them — when the operator asks, they get a segment):
-//   - per-kind hard cooldown (CAPABILITIES below)
+//   - per-kind hard cooldown (from each skill's SKILL.md)
 //   - a frequency-derived floor on the gap between ANY two segments
 //   - capabilities the operator disabled, or the on-air persona doesn't own,
 //     are never offered
@@ -37,101 +38,28 @@ import * as settings from '../settings.js';
 import { defineAgent } from '../llm/agent.js';
 import { buildContextLines, CONTEXT_FIELDS } from '../llm/dj.js';
 import { buildSegmentTools } from '../llm/segment-tools.js';
-import { searchReady } from './web-search.js';
 import { recordCuriosity, recentAiredCuriosity } from './curiosity.js';
-import { customCapabilities, getBuiltinOverrides } from './loader.js';
+import { builtinCapabilities, customCapabilities } from './loader.js';
 import * as sfx from '../broadcast/sfx.js';
 
-// Capability table — the single source of truth for the DJ's between-track
-// segment capabilities. Each entry carries:
-//   kind        — the queue.announce kind
-//   skill       — the operator enable-toggle slug (kept identical to `kind`)
-//   label       — human label for the admin command-center UI
-//   cooldownMs  — hard minimum gap between autonomous firings of this kind
-//   desc        — the one-line briefing shown BOTH to the agent (per-capability
-//                 guidance — for a skill with no data tool, this is the
-//                 agent's ONLY brief) and to the admin UI
-//   contextFields — (optional) the "right now" fields (CONTEXT_FIELDS) this
-//                 capability's situation block may include. Unset → the default
-//                 profile (everything EXCEPT weather), so a segment only sees
-//                 weather if it opts in. `weather` opts back in below; an
-//                 operator opts any skill in with `context:` in its SKILL.md.
-//   requiresKey — (optional) env key the capability needs
-//   keyUrl      — (optional) where the operator obtains that key
-//   ready       — (optional) () => boolean; false when the env key is missing
-// CAPABILITIES backs the agentic tick, the operator override (runCapability),
-// and the admin catalogue (skillCatalog). It is also the single source of
-// truth the scaffolder seeds editable state/skills/<kind>/SKILL.md files from
-// (see skills/scaffold.js), and the base that built-in overrides merge over.
-export const CAPABILITIES: any[] = [
-  {
-    kind: 'weather', skill: 'weather', label: 'Weather',
-    cooldownMs: 25 * 60 * 1000,
-    // The one built-in that opts the weather line into its situation block — it
-    // is literally the weather segment. Everything else falls back to the
-    // default profile (no weather), so weather stops bleeding into news,
-    // curiosity, deep cuts, etc. (issue #471).
-    contextFields: [...CONTEXT_FIELDS],
-    desc: 'A quick, in-character read on the weather right now — one or two sentences that fold the conditions into the moment, never a forecast or a temperature readout. Only air it when the weather has genuinely turned; don\'t narrate "still grey out". Never open with "here\'s your weather" or "weather check".',
-  },
-  {
-    kind: 'news', skill: 'news', label: 'News headlines',
-    cooldownMs: 45 * 60 * 1000,
-    desc: 'Glance at one fresh headline and drop it into a single sentence in your own words — a casual, half-distracted aside between songs, never an anchor or newsreader voice, never the headline read verbatim, no editorialising, no "in other news". Steer to the lighter, cultural, or human-interest item; if everything on the feed is grim — war, death, disaster — say nothing. A music station shouldn\'t read tragedy in a breezy aside.',
-  },
-  {
-    kind: 'now-playing-dig', skill: 'now-playing-dig', label: 'Now-playing dig',
-    cooldownMs: 45 * 60 * 1000,
-    // Search-grounded, like web-search: only ready when a provider is configured.
-    // The data tool (digCurrentTrack) is wired by kind in llm/segment-tools.ts.
-    ready: () => searchReady(),
-    desc: 'One concrete, verifiable detail about the exact track on air — who produced it, a sample it\'s built on, the B-side, where it charted, the story behind it — worked into a single conversational line. Use only what the search tool actually surfaces; if it returns nothing solid, say nothing. Never guess, never "I think", no "fun fact", no URLs. It\'s about this specific track, not the artist in general.',
-  },
-  {
-    kind: 'curiosity', skill: 'curiosity', label: 'Curiosity',
-    cooldownMs: 60 * 60 * 1000,
-    desc: 'One oddly-specific moment of interest — ideally a real "on this day" beat from the tool (any year), dropped in like you just remembered it. If the tool has nothing, offer a light, true observation tied to the date or season rather than a hard "fact" you can\'t vouch for — and if you\'d be guessing, skip it. Never say "fun fact", "interestingly", or "did you know".',
-  },
-  {
-    kind: 'album-anniversary', skill: 'album-anniversary', label: 'Album anniversary',
-    cooldownMs: 6 * 60 * 60 * 1000,
-    desc: 'If the album on air is hitting a round-number anniversary this year, note it like a presenter spotting a date in the prep notes — one short sentence on the date itself. Trust the year you\'re given; don\'t pad it with claims about what the album "meant" or how it charted. Never gushing, never "classic".',
-  },
-  {
-    kind: 'library-deep-cut', skill: 'library-deep-cut', label: 'Library deep-cut tease',
-    cooldownMs: 90 * 60 * 1000,
-    desc: 'If the on-air artist has a track in the library that\'s gone cold (not played in a while), tease it like there\'s more worth digging out of the crate — one sentence, in passing, without promising when it\'ll play. Never name the track unless the tool surfaced exactly one, and don\'t characterise how it sounds.',
-  },
-  {
-    kind: 'web-search', skill: 'web-search', label: 'Web search',
-    cooldownMs: 60 * 60 * 1000,
-    // requiresKey/keyUrl depend on the active search provider — see
-    // skillCatalog() below, which derives them from settings.search.provider.
-    // DuckDuckGo (the default) needs no key; Tavily needs SEARCH_API_KEY (or a
-    // key pasted into the admin UI). searchReady() encapsulates both.
-    ready: () => searchReady(),
-    desc: 'Work one genuine, recent thing the on-air artist is up to — a new release, a tour, something in the press this week — into a single conversational line. Use only what the search returned; if it surfaced nothing solid or nothing new, say nothing. No "I read online", no URLs, no list, no embellishing beyond the facts.',
-  },
-];
+// The capability registry now lives entirely in skills/loader.js, which loads
+// every skill — shipped and operator-added — from a directory (SKILL.md +
+// optional tool.mjs). Each cap carries: kind/skill (the queue.announce kind +
+// enable-toggle slug), label, cooldownMs, desc (the agent brief), contextFields
+// (the "right now" fields it may mention; unset → default profile, no weather),
+// window, requiresKey, ready() (from the tool module or the env key), and the
+// wrapped data tool (toolFn/toolName/toolDesc/config). The seven built-ins live
+// in src/skills/builtins/<kind>/; operator skills + brief overrides live in
+// state/skills/<slug>/.
 
-// The full capability set the segment director operates over: the built-in
-// CAPABILITIES above plus operator-dropped custom skills loaded from
-// state/skills (see skills/loader.js). Everything downstream — the autonomous
-// tick, runCapability, skillCatalog, the admin toggles — iterates THIS, so a
-// dropped skill lights up the whole chain. Custom caps carry { custom: true }
-// and are gated more conservatively (disabled until the operator enables them).
+// The full capability set the segment director operates over: built-ins (with
+// operator brief-overrides merged) plus operator-dropped custom skills.
+// Everything downstream — the autonomous tick, runCapability, skillCatalog, the
+// admin toggles — iterates THIS, so a dropped skill lights up the whole chain.
+// Custom caps carry { custom: true } and are gated more conservatively (disabled
+// until the operator enables them). Read live so a rescan takes effect at once.
 function allCapabilities(): any[] {
   return [...builtinCapabilities(), ...customCapabilities()];
-}
-
-// CAPABILITIES with operator edits from state/skills/<kind>/SKILL.md applied.
-// An override (loaded by skills/loader.js) contributes only the keys it
-// specified — desc/cooldownMs/label and, for news, feed/feedMaxItems — spread
-// over the hardcoded defaults; everything else (skill, ready, requiresKey) is
-// preserved. Read live so a rescan takes effect without a restart.
-function builtinCapabilities(): any[] {
-  const ov = getBuiltinOverrides();
-  return CAPABILITIES.map(c => (ov[c.kind] ? { ...c, ...ov[c.kind] } : c));
 }
 
 // The default per-skill context profile: every "right now" field EXCEPT

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -18,8 +18,9 @@
 // agent. `agenticTick()` is the 5-minute cron; `runCapability()` is the
 // /dj/skill manual override — same tool-loop, but forced to one capability
 // with cooldowns bypassed. The capability registry is loaded by skills/loader.js
-// (built-ins from src/skills/builtins/, custom from state/skills); this module
-// consumes it (allCapabilities) and also backs the admin catalogue via
+// from the single load root state/skills/<slug>/ (the seven built-ins are seeded
+// there on first boot from src/skills/builtins/ templates; see skills/scaffold.js).
+// This module consumes it (allCapabilities) and backs the admin catalogue via
 // `skillCatalog()`. The skill modules left in this directory — news.js,
 // web-search.js, curiosity.js — are pure fetch helpers behind station-services.
 //
@@ -39,7 +40,7 @@ import { defineAgent } from '../llm/agent.js';
 import { buildContextLines, CONTEXT_FIELDS } from '../llm/dj.js';
 import { buildSegmentTools } from '../llm/segment-tools.js';
 import { recordCuriosity, recentAiredCuriosity } from './curiosity.js';
-import { builtinCapabilities, customCapabilities } from './loader.js';
+import { loadedCapabilities } from './loader.js';
 import * as sfx from '../broadcast/sfx.js';
 
 // The capability registry now lives entirely in skills/loader.js, which loads
@@ -47,19 +48,18 @@ import * as sfx from '../broadcast/sfx.js';
 // optional tool.mjs). Each cap carries: kind/skill (the queue.announce kind +
 // enable-toggle slug), label, cooldownMs, desc (the agent brief), contextFields
 // (the "right now" fields it may mention; unset → default profile, no weather),
-// window, requiresKey, ready() (from the tool module or the env key), and the
-// wrapped data tool (toolFn/toolName/toolDesc/config). The seven built-ins live
-// in src/skills/builtins/<kind>/; operator skills + brief overrides live in
-// state/skills/<slug>/.
+// window, requiresKey, ready() (from the tool module or the env key), seeded
+// (shipped built-in vs operator skill), and the wrapped data tool
+// (toolFn/toolName/toolDesc/config). Every skill lives under state/skills/<slug>/.
 
-// The full capability set the segment director operates over: built-ins (with
-// operator brief-overrides merged) plus operator-dropped custom skills.
-// Everything downstream — the autonomous tick, runCapability, skillCatalog, the
-// admin toggles — iterates THIS, so a dropped skill lights up the whole chain.
-// Custom caps carry { custom: true } and are gated more conservatively (disabled
-// until the operator enables them). Read live so a rescan takes effect at once.
+// The full capability set the segment director operates over: every skill loaded
+// from state/skills — seeded built-ins and operator-dropped custom skills alike,
+// on one footing. Everything downstream — the autonomous tick, runCapability,
+// skillCatalog, the admin toggles — iterates THIS, so a dropped skill lights up
+// the whole chain. Non-seeded (operator) caps are gated more conservatively
+// (disabled until enabled). Read live so a rescan takes effect at once.
 function allCapabilities(): any[] {
-  return [...builtinCapabilities(), ...customCapabilities()];
+  return loadedCapabilities();
 }
 
 // The default per-skill context profile: every "right now" field EXCEPT
@@ -152,10 +152,10 @@ function availableCapabilities(ctx: any, now: Date) {
   const persona = settings.getEffectivePersona(now);
   const out: any[] = [];
   for (const cap of allCapabilities()) {
-    // Built-ins are enabled unless explicitly turned off; custom skills are
-    // DISCOVERED-BUT-DISABLED — they must be explicitly enabled before they
+    // Seeded built-ins are enabled unless explicitly turned off; operator skills
+    // are DISCOVERED-BUT-DISABLED — they must be explicitly enabled before they
     // can air, so dropping a folder never auto-airs unreviewed content/code.
-    const isEnabled = cap.custom ? enabled[cap.skill] === true : enabled[cap.skill] !== false;
+    const isEnabled = cap.seeded ? enabled[cap.skill] !== false : enabled[cap.skill] === true;
     if (!isEnabled) continue;
     if (persona?.skills && !persona.skills.includes(cap.skill)) continue;
     if (now.getTime() - (lastFired.get(cap.kind) || 0) < cap.cooldownMs) continue;
@@ -486,12 +486,13 @@ export function skillCatalog() {
       description: c.desc || '',
       kind: c.kind,
       cooldownMs: c.cooldownMs || 0,
-      // Built-ins default on; custom skills are discovered-but-disabled and
-      // only count as enabled once the operator explicitly flips them on.
-      enabled: c.custom ? enabledMap[c.skill] === true : enabledMap[c.skill] !== false,
-      // Marks an operator-dropped skill (state/skills) vs a built-in, so the
-      // admin UI can badge it and explain the off-by-default behaviour.
-      custom: !!c.custom,
+      // Seeded built-ins default on; operator skills are discovered-but-disabled
+      // and only count as enabled once the operator explicitly flips them on.
+      enabled: c.seeded ? enabledMap[c.skill] !== false : enabledMap[c.skill] === true,
+      // Marks an operator-authored skill vs a shipped built-in, so the admin UI
+      // can badge it and explain the off-by-default behaviour. (`custom` is the
+      // API's name for "not seeded".)
+      custom: !c.seeded,
       // `ready` is false when the capability needs an env key that isn't set;
       // `requiresKey` names it and `keyUrl` links the operator to its source.
       ready: typeof c.ready === 'function' ? !!c.ready() : true,

--- a/controller/src/skills/builtins/album-anniversary/SKILL.md
+++ b/controller/src/skills/builtins/album-anniversary/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: album-anniversary
+label: Album anniversary
+cooldown: 6h
+---
+If the album on air is hitting a round-number anniversary this year, note it like a presenter spotting a date in the prep notes — one short sentence on the date itself. Trust the year you're given; don't pad it with claims about what the album "meant" or how it charted. Never gushing, never "classic".

--- a/controller/src/skills/builtins/album-anniversary/tool.mjs
+++ b/controller/src/skills/builtins/album-anniversary/tool.mjs
@@ -1,0 +1,17 @@
+// Album anniversary — is the album on air hitting a round-number (5/10/20/25y…)
+// anniversary this year? Computed from the track's real ID3 year, so the year
+// is never guessed.
+export const description = 'Check whether the album currently on air is hitting a round-number anniversary (5/10/20/25y) this year. Returns the album, the artist, and the year count when one applies; `available: false` otherwise.';
+
+export default async function checkAlbumAnniversary(ctx, state, services) {
+  const track = services.nowPlaying();
+  const albumName = track?.album;
+  const albumYear = Number(track?.year);
+  const artistName = track?.artist;
+  if (!albumName || !artistName) return { available: false };
+  if (!Number.isFinite(albumYear) || albumYear < 1900) return { available: false };
+  const years = new Date().getFullYear() - albumYear;
+  if (years < 5) return { available: false };
+  if (years % 5 !== 0) return { available: false };
+  return { available: true, album: albumName, artist: artistName, years, releasedYear: albumYear };
+}

--- a/controller/src/skills/builtins/curiosity/SKILL.md
+++ b/controller/src/skills/builtins/curiosity/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: curiosity
+label: Curiosity
+cooldown: 60m
+---
+One oddly-specific moment of interest — ideally a real "on this day" beat from the tool (any year), dropped in like you just remembered it. If the tool has nothing, offer a light, true observation tied to the date or season rather than a hard "fact" you can't vouch for — and if you'd be guessing, skip it. Never say "fun fact", "interestingly", or "did you know".

--- a/controller/src/skills/builtins/curiosity/tool.mjs
+++ b/controller/src/skills/builtins/curiosity/tool.mjs
@@ -1,0 +1,18 @@
+// Curiosity — one "on this day" event for today, de-duped against curiosities
+// already aired (durable, survives restart, via services.recall). Returns
+// available:false when nothing fresh — the brief then falls back to a light
+// date/season observation rather than staying silent.
+export const description = 'Fetch one historical "on this day" event for today\'s date — filtered for cultural / scientific / sporting entries since 1850, and de-duped against curiosities already aired. Returns `available: false` when no fresh item exists; treat that as a cue to fall back to your own oddly-specific factoid under the capability brief, not as a reason to stay silent.';
+
+export default async function getCuriosityItem(ctx, state, services) {
+  const items = await services.onThisDay();
+  const fresh = items.filter(it => !services.recall.seen(it.text));
+  if (!fresh.length) return { available: false };
+  // Burn-on-read into the durable ledger so a later tick — or one after a
+  // restart — doesn't re-offer the same event (issue #577).
+  for (const it of fresh.slice(0, 3)) services.recall.remember(it.text);
+  return {
+    available: true,
+    items: fresh.slice(0, 3).map(it => ({ year: it.year, text: it.text })),
+  };
+}

--- a/controller/src/skills/builtins/library-deep-cut/SKILL.md
+++ b/controller/src/skills/builtins/library-deep-cut/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: library-deep-cut
+label: Library deep-cut tease
+cooldown: 90m
+---
+If the on-air artist has a track in the library that's gone cold (not played in a while), tease it like there's more worth digging out of the crate — one sentence, in passing, without promising when it'll play. Never name the track unless the tool surfaced exactly one, and don't characterise how it sounds.

--- a/controller/src/skills/builtins/library-deep-cut/tool.mjs
+++ b/controller/src/skills/builtins/library-deep-cut/tool.mjs
@@ -1,0 +1,33 @@
+// Library deep-cut — find a track by the on-air artist that's in the operator's
+// library but hasn't played in the last 30 days. Walks a bounded slice of the
+// artist's albums via the library service; returns a count + candidates.
+export const description = 'Find a track by the on-air artist that lives in the operator\'s library but has NOT been played in the last 30 days. Returns at most a handful of candidates plus a count; `available: false` if the artist has nothing cold to surface. Do NOT name a specific track unless exactly one is returned.';
+
+export default async function findDeepCut(ctx, state, services) {
+  const artistName = services.nowPlaying()?.artist;
+  if (!artistName || /^unknown/i.test(artistName)) return { available: false };
+  // Resolve the artist id — take the best match.
+  const matches = await services.library.searchArtists(artistName, { artistCount: 3 });
+  const artist = matches.find(a => a.name?.toLowerCase() === artistName.toLowerCase()) || matches[0];
+  if (!artist?.id) return { available: false };
+  const detail = await services.library.getArtist(artist.id);
+  const albums = Array.isArray(detail?.album) ? detail.album : [];
+  if (!albums.length) return { available: false };
+  const { ids, keys } = services.recentPlays(30 * 24); // 30 days
+  const cold = [];
+  for (const album of albums.slice(0, 8)) {
+    const songs = await services.library.getAlbum(album.id);
+    for (const s of songs) {
+      const songId = String(s?.id || '');
+      const key = `${(s?.title || '').toLowerCase().trim()}|${(s?.artist || artistName).toLowerCase().trim()}`;
+      if (songId && ids.has(songId)) continue;
+      if (keys.has(key)) continue;
+      if (!s?.title) continue;
+      cold.push({ title: s.title, album: album.name || '' });
+      if (cold.length >= 6) break;
+    }
+    if (cold.length >= 6) break;
+  }
+  if (!cold.length) return { available: false };
+  return { available: true, artist: artistName, count: cold.length, candidates: cold };
+}

--- a/controller/src/skills/builtins/news/SKILL.md
+++ b/controller/src/skills/builtins/news/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: news
+label: News headlines
+cooldown: 45m
+---
+Glance at one fresh headline and drop it into a single sentence in your own words — a casual, half-distracted aside between songs, never an anchor or newsreader voice, never the headline read verbatim, no editorialising, no "in other news". Steer to the lighter, cultural, or human-interest item; if everything on the feed is grim — war, death, disaster — say nothing. A music station shouldn't read tragedy in a breezy aside.

--- a/controller/src/skills/builtins/news/tool.mjs
+++ b/controller/src/skills/builtins/news/tool.mjs
@@ -1,0 +1,19 @@
+// News — fetch fresh headlines from the configured feed, burning each on read
+// so a later tick doesn't re-offer it. `config.feed` / `config.feedMaxItems`
+// come from the skill's frontmatter (the operator's state override, if any);
+// undefined → services.fetchHeadlines falls back to the env-configured feed.
+export const description = 'Fetch current news headlines from the configured feed. Returns only headlines not already read on air.';
+
+export default async function getHeadlines(ctx, state, services, config) {
+  if (!(state.seenHeadlines instanceof Set)) state.seenHeadlines = new Set();
+  const maxItems = config?.feedMaxItems ? Number(config.feedMaxItems) : undefined;
+  const items = await services.fetchHeadlines({ feedUrl: config?.feed || undefined, maxItems });
+  const fresh = items.filter(it => !state.seenHeadlines.has(services.hashHeadline(it.title)));
+  // Burn-on-read so a later tick doesn't re-offer the same headline.
+  for (const it of fresh.slice(0, 6)) state.seenHeadlines.add(services.hashHeadline(it.title));
+  if (state.seenHeadlines.size > 120) {
+    state.seenHeadlines = new Set(Array.from(state.seenHeadlines).slice(-60));
+  }
+  if (!fresh.length) return { headlines: [] };
+  return { headlines: fresh.slice(0, 6).map(it => ({ title: it.title, detail: it.description || null })) };
+}

--- a/controller/src/skills/builtins/now-playing-dig/SKILL.md
+++ b/controller/src/skills/builtins/now-playing-dig/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: now-playing-dig
+label: Now-playing dig
+cooldown: 45m
+---
+One concrete, verifiable detail about the exact track on air — who produced it, a sample it's built on, the B-side, where it charted, the story behind it — worked into a single conversational line. Use only what the search tool actually surfaces; if it returns nothing solid, say nothing. Never guess, never "I think", no "fun fact", no URLs. It's about this specific track, not the artist in general.

--- a/controller/src/skills/builtins/now-playing-dig/tool.mjs
+++ b/controller/src/skills/builtins/now-playing-dig/tool.mjs
@@ -1,0 +1,24 @@
+// Now-playing dig — a concrete, verifiable detail about the EXACT track on air
+// (producer, sample, B-side, chart, backstory), grounded in a real web search.
+// `ready` gates on a search provider; returns available:false when nothing
+// solid comes back so the DJ never invents trivia.
+export const description = 'Search the web for a specific, verifiable detail about the exact track currently on air (producer, sample, B-side, chart, backstory).';
+
+export const ready = (services) => services.searchReady();
+
+export default async function digCurrentTrack(ctx, state, services) {
+  const cur = services.nowPlaying();
+  const artist = cur?.artist;
+  const title = cur?.title;
+  if (!artist || !title || /^unknown/i.test(artist) || /^unknown/i.test(title)) return { available: false };
+  const trackKey = `${artist} — ${title}`;
+  const alreadyDug = trackKey === state.lastDugTrack;
+  const data = await services.searchWeb(`${artist} "${title}" song producer sample b-side chart story`);
+  state.lastDugTrack = trackKey;
+  const answer = (data.answer || '').trim();
+  const sources = (data.results || [])
+    .slice(0, 3)
+    .map(r => `${r.title}: ${(r.content || '').replace(/\s+/g, ' ').trim().slice(0, 240)}`);
+  if (!answer && sources.length === 0) return { available: false };
+  return { artist, title, alreadyDug, answer, sources };
+}

--- a/controller/src/skills/builtins/weather/SKILL.md
+++ b/controller/src/skills/builtins/weather/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: weather
+label: Weather
+cooldown: 25m
+context: date, clock, time, weather, festival, show, listeners
+---
+A quick, in-character read on the weather right now — one or two sentences that fold the conditions into the moment, never a forecast or a temperature readout. Only air it when the weather has genuinely turned; don't narrate "still grey out". Never open with "here's your weather" or "weather check".

--- a/controller/src/skills/builtins/weather/tool.mjs
+++ b/controller/src/skills/builtins/weather/tool.mjs
@@ -1,0 +1,16 @@
+// Weather — surfaces the moment's weather (already in ctx) and whether it has
+// changed since the DJ last spoke about it. No external call; reads ctx.weather.
+export const description = 'Get the current weather and whether it has changed since the DJ last spoke about weather on air. Dull or unchanged weather is usually not worth airing. The temperature is returned in the unit indicated by `tempUnit` ("C" or "F") — read it on air in that unit, do not convert.';
+
+export default async function checkWeather(ctx, state) {
+  const w = ctx.weather;
+  if (!w || !w.condition || w.condition === 'unknown') return { available: false };
+  return {
+    available: true,
+    location: w.location,
+    condition: w.condition,
+    temp: w.temp ?? null,
+    tempUnit: w.tempUnit || 'C',
+    changedSinceLastMention: w.condition !== state.lastWeatherCondition,
+  };
+}

--- a/controller/src/skills/builtins/web-search/SKILL.md
+++ b/controller/src/skills/builtins/web-search/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: web-search
+label: Web search
+cooldown: 60m
+---
+Work one genuine, recent thing the on-air artist is up to — a new release, a tour, something in the press this week — into a single conversational line. Use only what the search returned; if it surfaced nothing solid or nothing new, say nothing. No "I read online", no URLs, no list, no embellishing beyond the facts.

--- a/controller/src/skills/builtins/web-search/tool.mjs
+++ b/controller/src/skills/builtins/web-search/tool.mjs
@@ -1,0 +1,20 @@
+// Web search — something recent about the on-air artist (release, tour, press).
+// `ready` gates the whole skill on a configured search provider, so it's never
+// even offered when search is unavailable.
+export const description = 'Search the web for something recent about the artist currently on air.';
+
+export const ready = (services) => services.searchReady();
+
+export default async function searchArtistNews(ctx, state, services) {
+  const artist = services.nowPlaying()?.artist;
+  if (!artist || /^unknown/i.test(artist)) return { available: false };
+  const alreadySearched = artist === state.lastSearchedArtist;
+  const data = await services.searchWeb(`${artist} musician latest news`, { recency: 'week' });
+  state.lastSearchedArtist = artist;
+  const answer = (data.answer || '').trim();
+  const sources = (data.results || [])
+    .slice(0, 3)
+    .map(r => `${r.title}: ${(r.content || '').replace(/\s+/g, ' ').trim().slice(0, 240)}`);
+  if (!answer && sources.length === 0) return { available: false };
+  return { artist, alreadySearched, answer, sources };
+}

--- a/controller/src/skills/loader.ts
+++ b/controller/src/skills/loader.ts
@@ -1,96 +1,83 @@
-// Operator-pluggable skills — load custom between-track segment capabilities
-// from `${STATE_DIR}/skills/<slug>/SKILL.md` at boot (and on demand via the
-// admin "rescan" button), and merge them into the segment director's
-// CAPABILITIES table (see skills/_agent.js).
+// Skill loader — the single source of truth for the DJ's between-track segment
+// capabilities. Every skill, shipped or operator-added, is a self-contained
+// directory:
 //
-// This adopts the *format* of Anthropic's skills (a SKILL.md with YAML
-// frontmatter + a markdown body, plus optional code) — NOT their semantics.
-// A SUB/WAVE skill is one thing: a between-track spoken segment. The
-// frontmatter supplies the capability metadata; the markdown body IS the
-// agent's brief for that segment; an optional `tool.mjs` is wrapped as an AI
-// SDK tool so the segment can look at live data before the DJ speaks.
-//
-//   state/skills/on-this-day-music/
+//   <dir>/<slug>/
 //     SKILL.md     frontmatter (→ metadata) + body (→ the agent's brief)
-//     tool.mjs     OPTIONAL: `export default async (ctx) => ({...})`
+//     tool.mjs     OPTIONAL: a data fetcher the segment director calls first
 //
-// SKILL.md frontmatter keys (all optional except a non-empty body):
-//   name             slug == kind (defaults to the folder name)
-//   label            human label for /admin/skills (defaults to a title-cased name)
-//   cooldown         hard min gap between autonomous firings — "90m" | "6h" | "45" (minutes)
-//   window           "any" (default) | "commute" — only offered during commute hours
-//   requiresKey      env var the skill needs; absent → never offered
-//   toolDescription  description shown to the agent for the tool.mjs data tool
-//   context          comma-separated "right now" fields the segment may weave in
-//                    — any of: date, clock, time, weather, festival, show,
-//                    listeners. Absent → the default profile (everything EXCEPT
-//                    weather), so a skill only mentions weather when it opts in
-//                    (issue #471). e.g. `context: time, weather` for a commute-
-//                    conditions skill where weather is genuinely topical.
+// Two roots are scanned:
+//   1. controller/src/skills/builtins/<kind>/   — the seven shipped built-ins
+//      (first-party, read-only; bundled in the image / bind-mounted in dev).
+//   2. ${STATE_DIR}/skills/<slug>/              — operator skills + built-in
+//      brief overrides (state/skills/<built-in-kind> edits the shipped brief).
 //
-// EDITING BUILT-INS: a folder named after a built-in kind (weather, news, …;
-// see BUILTIN_KINDS) is treated as an OVERRIDE — it edits the shipped built-in's
-// brief/cooldown/label/context in place (and, for `news`, its `feed:` RSS URL +
-// `feedMaxItems`) rather than being rejected as a clash. Built-in overrides may
-// leave the body empty (= keep the default brief) and never load a tool.mjs.
-// These files are scaffolded on first boot (see skills/scaffold.js).
+// A skill's tool.mjs is the same contract for both:
+//   export default async (ctx, state, services, config) => data
+//   export const description = '…'   // OPTIONAL: tool description for the agent
+//   export const ready = (services) => boolean   // OPTIONAL: gate availability
+// `services` (station-services.ts) is the curated facade onto search, the
+// library, the play log, feeds and durable recall — the one way a tool reaches
+// the world, so built-in and custom skills run on identical footing.
 //
-// Safety posture (the operator is dropping code into their own controller, same
-// trust model as Claude Code skills, but we still fence it):
+// Safety posture (operator code in state/skills is the operator's own, same
+// trust model as a local Claude Code skill, but still fenced):
 //   - malformed skills are skipped with a logged warning, never crash boot
 //   - custom skills are DISCOVERED-BUT-DISABLED — they appear in /admin/skills
-//     toggled off and cannot air until the operator enables them (see
-//     skillCatalog/availableCapabilities in _agent.js); merely dropping a
-//     folder never auto-airs unreviewed content or runs its code on a tick
-//   - tool.mjs execution is wrapped in a timeout + try/catch at the call site
-//     (llm/segment-tools.js) so a slow or throwing skill can't hang the tick
+//     toggled off and cannot air until the operator enables them
+//   - a custom tool.mjs runs behind a timeout + try/catch at the call site
+//     (llm/segment-tools.ts); built-in tools are first-party and unfenced
 
 import { readdir, readFile, stat } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { join, resolve, dirname } from 'node:path';
+import { pathToFileURL, fileURLToPath } from 'node:url';
 import { STATE_DIR } from '../config.js';
-import { queue } from '../broadcast/queue.js';
+import { queue, registerSkillKinds } from '../broadcast/queue.js';
+import { buildStationServices } from '../llm/internal/tools/station-services.js';
 
-// The 7 built-in segment capabilities (see skills/_agent.js CAPABILITIES). A
-// state/skills/<kind>/SKILL.md whose folder name matches one of these is parsed
-// as an OVERRIDE of that built-in (brief/cooldown/label, + feed for news) rather
-// than rejected — that's how operators edit the shipped skills. Everything else
-// in RESERVED_KINDS is queue-internal and stays un-overridable.
-export const BUILTIN_KINDS = new Set([
-  'weather', 'news', 'now-playing-dig', 'curiosity',
-  'album-anniversary', 'library-deep-cut', 'web-search',
-]);
-
-// Built-in capability kinds — custom skills may not shadow these. Exported so
-// the admin create route (POST /dj/skills) rejects the same set the loader does.
-export const RESERVED_KINDS = new Set([
-  ...BUILTIN_KINDS,
-  // queue.announce reserves 'link' for the light-ducked intro channel.
-  'link', 'dj-speak', 'announcement', 'station-id', 'hourly',
-]);
-
+// Shipped built-in skill directories, resolved relative to this module so it
+// works under both dev (tsx on bind-mounted src) and prod (tsx on the COPYd
+// src). Exported so the scaffolder can seed editable state overrides from them.
+export const BUILTINS_DIR = resolve(dirname(fileURLToPath(import.meta.url)), 'builtins');
 const SKILLS_DIR = resolve(STATE_DIR, 'skills');
+const SLUG_RE_INNER = /^[a-z0-9][a-z0-9-]{0,48}$/;
+
 // Custom-skill slug: lowercase, starts alphanumeric, then alphanumeric/hyphen,
 // ≤49 chars. Anchored, so it can't contain '/', '.', or whitespace — the routes
 // rely on that to keep a slug from escaping state/skills/. Exported so the admin
 // create route validates against the exact pattern the loader enforces.
-export const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,48}$/;
+export const SLUG_RE = SLUG_RE_INNER;
 
-// Loaded custom capabilities, in the same shape as _agent.js CAPABILITIES,
-// plus { custom: true } and an optional wrapped data tool. Rebuilt on reload.
-let loaded: any[] = [];
-// Overrides for built-in capabilities, keyed by kind. A built-in SKILL.md only
-// contributes the keys it actually specifies (desc/cooldownMs/label/feed/…),
-// merged over the hardcoded CAPABILITIES entry in _agent.js. Rebuilt on reload.
-let builtinOverrides: Record<string, any> = {};
-let importCounter = 0; // cache-buster for re-importing edited tool.mjs modules
+// Kinds the queue reserves for its own voice channels — a custom skill may not
+// shadow these (built-in kinds are added below, once loaded).
+const QUEUE_INTERNAL_KINDS = ['link', 'dj-speak', 'announcement', 'station-id', 'hourly', 'hourly-check'];
 
-export function customCapabilities(): any[] {
-  return loaded;
-}
+// Derived at load time from the built-in directories. Exported as live sets that
+// callers (.has()) read after boot. `BUILTIN_KINDS` is the set of shipped kinds;
+// `RESERVED_KINDS` adds the queue-internal kinds a custom skill can't shadow.
+export const BUILTIN_KINDS = new Set<string>();
+export const RESERVED_KINDS = new Set<string>(QUEUE_INTERNAL_KINDS);
 
-export function getBuiltinOverrides(): Record<string, any> {
-  return builtinOverrides;
+let builtinBase: any[] = [];          // the shipped built-in caps (from BUILTINS_DIR)
+let loadedCustom: any[] = [];         // operator custom caps (from state/skills)
+let builtinOverrides: Record<string, any> = {}; // built-in brief overrides (from state/skills)
+let importCounter = 0;                // cache-buster for re-importing edited tool.mjs
+
+export function builtinBaseCaps(): any[] { return builtinBase; }
+export function customCapabilities(): any[] { return loadedCustom; }
+export function getBuiltinOverrides(): Record<string, any> { return builtinOverrides; }
+
+// Built-in caps with operator brief-edits from state/skills/<kind>/SKILL.md
+// applied. An override contributes only the keys it specified — desc / cooldown
+// / label / context and, for news, feed / feedMaxItems — merged over the shipped
+// default; the tool (toolFn / ready / toolName) is always the first-party one.
+// Read live so a rescan takes effect without a restart.
+export function builtinCapabilities(): any[] {
+  return builtinBase.map(c => {
+    const ov = builtinOverrides[c.kind];
+    if (!ov) return c;
+    return { ...c, ...ov, config: { ...c.config, ...ov.config } };
+  });
 }
 
 // Minimal flat-YAML frontmatter parser. The frontmatter we accept is a small,
@@ -109,7 +96,6 @@ export function parseFrontmatter(raw: string): { data: Record<string, string>; b
     if (idx === -1) continue;
     const key = trimmed.slice(0, idx).trim();
     let val = trimmed.slice(idx + 1).trim();
-    // Strip surrounding quotes if present.
     if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
       val = val.slice(1, -1);
     }
@@ -134,20 +120,17 @@ function titleCase(slug: string): string {
   return slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
-// Parse a `context:` (or `contextFields:`) frontmatter value — a comma list of
-// "right now" field names — into lowercase tokens, or undefined when absent or
-// empty. Unknown tokens are kept here and dropped downstream (buildContextLines
-// validates against CONTEXT_FIELDS), so the loader stays dependency-free.
+// Parse a `context:` (or `contextFields:`) comma list into lowercase tokens, or
+// undefined when absent/empty (→ the default profile downstream, see #471).
 function parseContextFields(raw: string | undefined): string[] | undefined {
   if (raw == null) return undefined;
   const list = String(raw).split(',').map(s => s.trim().toLowerCase()).filter(Boolean);
   return list.length ? list : undefined;
 }
 
-// Dynamically import a skill's optional tool.mjs and return its data function,
-// or null. The function is invoked per tick with the moment's context; the
-// call itself is timeout-guarded at the call site (segment-tools.js).
-async function loadToolFn(dir: string): Promise<((ctx: any, state: any) => any) | null> {
+// Dynamically import a skill's optional tool.mjs. Returns the data function plus
+// its optional `description` / `ready` exports, or null when there's no tool.
+async function loadToolModule(dir: string): Promise<{ fn: any; description?: string; ready?: any } | null> {
   const file = join(dir, 'tool.mjs');
   try {
     await stat(file);
@@ -159,124 +142,164 @@ async function loadToolFn(dir: string): Promise<((ctx: any, state: any) => any) 
   const mod = await import(url);
   const fn = mod.default || mod.fetchData || mod.tool;
   if (typeof fn !== 'function') {
-    throw new Error('tool.mjs must export a default async function (ctx) => data');
+    throw new Error('tool.mjs must export a default async function (ctx, state, services, config) => data');
   }
-  return fn;
+  return {
+    fn,
+    description: typeof mod.description === 'string' ? mod.description : undefined,
+    ready: typeof mod.ready === 'function' ? mod.ready : undefined,
+  };
 }
 
-async function loadOne(slug: string): Promise<any | null> {
-  const dir = join(SKILLS_DIR, slug);
-  const skillFile = join(dir, 'SKILL.md');
+// Build a full capability from a skill directory. `builtin` controls the trust
+// posture: built-ins are first-party (custom:false, tool unfenced); state skills
+// are operator code (custom:true, fenced at the call site).
+async function loadSkillDir(dir: string, slug: string, { builtin }: { builtin: boolean }): Promise<any | null> {
   let raw: string;
   try {
-    raw = await readFile(skillFile, 'utf8');
+    raw = await readFile(join(dir, 'SKILL.md'), 'utf8');
   } catch {
     return null; // directory without a SKILL.md — not a skill
   }
-
   const { data, body } = parseFrontmatter(raw);
   const name = (data.name || slug).trim();
-
   if (!SLUG_RE.test(name)) {
     queue.log('error', `[skills] "${slug}" rejected — name "${name}" must be a lowercase slug`);
     return null;
   }
-  // A file named after a built-in kind is an OVERRIDE, not a new skill: it
-  // contributes only the keys it specifies, merged over the hardcoded
-  // CAPABILITIES entry (see builtinCapabilities() in _agent.js). Unlike custom
-  // skills, the body may be empty — that just means "keep the default brief but
-  // override e.g. the feed". No tool.mjs is loaded for built-ins (they already
-  // have their own data tool wired by kind in llm/segment-tools.js).
-  if (BUILTIN_KINDS.has(name)) {
-    const override: any = { override: true, kind: name };
-    if (body) override.desc = body;
-    if (data.cooldown) override.cooldownMs = parseCooldownMs(data.cooldown);
-    if (data.label) override.label = data.label.trim();
-    const ovContext = parseContextFields(data.context ?? data.contextFields);
-    if (ovContext) override.contextFields = ovContext;
-    if (data.feed) override.feed = data.feed.trim();
-    if (data.feedMaxItems) {
-      const n = parseInt(data.feedMaxItems, 10);
-      if (Number.isFinite(n) && n > 0) override.feedMaxItems = n;
-    }
-    return override;
-  }
-  if (RESERVED_KINDS.has(name)) {
-    queue.log('error', `[skills] "${slug}" rejected — "${name}" shadows a built-in capability`);
-    return null;
-  }
-  if (!body) {
+  if (!builtin && !body) {
     queue.log('error', `[skills] "${slug}" rejected — SKILL.md body (the agent's brief) is empty`);
     return null;
   }
 
-  const window = data.window === 'commute' ? 'commute' : 'any';
   const requiresKey = data.requiresKey ? String(data.requiresKey).trim() : null;
 
-  let toolFn: any = null;
+  let toolMod: any = null;
   try {
-    toolFn = await loadToolFn(dir);
+    toolMod = await loadToolModule(dir);
   } catch (err: any) {
     queue.log('error', `[skills] "${slug}" tool.mjs failed to load — running prompt-only: ${err.message}`);
-    toolFn = null;
+    toolMod = null;
   }
 
+  const label = (data.label || titleCase(name)).trim();
   const cap: any = {
     kind: name,
     skill: name,
-    label: (data.label || titleCase(name)).trim(),
+    label,
     cooldownMs: parseCooldownMs(data.cooldown),
     desc: body,
-    custom: true,
-    window,
+    custom: !builtin,
+    window: data.window === 'commute' ? 'commute' : 'any',
     requiresKey,
-    // Absent → effectiveContextFields() falls back to the default profile (no
-    // weather). A skill opts weather (or any field) in via `context:` (#471).
+    // Absent → effectiveContextFields() falls back to the default profile (#471).
     contextFields: parseContextFields(data.context ?? data.contextFields),
-    // A keyed skill is only ready when its env var is set. Keyless skills are
-    // always ready. Mirrors the built-in `ready()` convention.
-    ready: requiresKey ? () => !!process.env[requiresKey] : undefined,
+    // The skill's own frontmatter, handed to the tool as its 4th arg so a skill
+    // can read its own knobs (e.g. news' feed / feedMaxItems).
+    config: data,
+    feed: data.feed ? data.feed.trim() : undefined,
+    feedMaxItems: data.feedMaxItems && Number.isFinite(parseInt(data.feedMaxItems, 10)) ? parseInt(data.feedMaxItems, 10) : undefined,
   };
 
-  if (toolFn) {
+  // Readiness: a tool module's `ready(services)` wins; else a keyed skill is
+  // ready only when its env var is set; else always ready.
+  if (toolMod?.ready) {
+    cap.ready = () => toolMod.ready(buildStationServices());
+  } else if (requiresKey) {
+    cap.ready = () => !!process.env[requiresKey];
+  }
+
+  if (toolMod?.fn) {
+    cap.toolFn = toolMod.fn;
     cap.toolName = `skill_${name.replace(/-/g, '_')}`;
-    cap.toolDesc = (data.toolDescription || '').trim()
-      || `Fetch live data for the ${cap.label} segment before speaking. Returns { available: false } when there is nothing fresh worth airing.`;
-    cap.toolFn = toolFn;
+    cap.toolDesc = (toolMod.description || data.toolDescription || '').trim()
+      || `Fetch live data for the ${label} segment before speaking. Returns { available: false } when there is nothing fresh worth airing.`;
   }
 
   return cap;
 }
 
-// Scan state/skills and rebuild the loaded capability list. Never throws —
-// a broken skill folder is logged and skipped. Returns the loaded caps.
+// Scan the shipped built-in directories. Populates builtinBase + the derived
+// BUILTIN_KINDS / RESERVED_KINDS sets. Runs once at boot (built-ins are static).
+export async function loadBuiltins(): Promise<any[]> {
+  let entries: string[] = [];
+  try {
+    const dirents = await readdir(BUILTINS_DIR, { withFileTypes: true });
+    entries = dirents.filter(d => d.isDirectory()).map(d => d.name).sort();
+  } catch (err: any) {
+    queue.log('error', `[skills] could not read built-ins dir ${BUILTINS_DIR}: ${err?.message || err}`);
+    builtinBase = [];
+    return builtinBase;
+  }
+  const out: any[] = [];
+  for (const slug of entries) {
+    try {
+      const cap = await loadSkillDir(join(BUILTINS_DIR, slug), slug, { builtin: true });
+      if (cap) out.push(cap);
+    } catch (err: any) {
+      queue.log('error', `[skills] built-in "${slug}" failed to load: ${err.message}`);
+    }
+  }
+  builtinBase = out;
+  // Rebuild the derived kind sets.
+  BUILTIN_KINDS.clear();
+  for (const c of out) BUILTIN_KINDS.add(c.kind);
+  RESERVED_KINDS.clear();
+  for (const k of QUEUE_INTERNAL_KINDS) RESERVED_KINDS.add(k);
+  for (const k of BUILTIN_KINDS) RESERVED_KINDS.add(k);
+  return builtinBase;
+}
+
+// Scan state/skills and rebuild the custom caps + built-in overrides. Never
+// throws — a broken folder is logged and skipped. Ensures built-ins are loaded
+// first (so kinds classify correctly). Returns the loaded custom caps.
 export async function loadCustomSkills(): Promise<any[]> {
+  if (!builtinBase.length) await loadBuiltins();
   builtinOverrides = {};
   let entries: string[] = [];
   try {
     const dirents = await readdir(SKILLS_DIR, { withFileTypes: true });
     entries = dirents.filter(d => d.isDirectory()).map(d => d.name);
   } catch {
-    loaded = []; // no state/skills dir → nothing to load (the common case)
-    return loaded;
+    loadedCustom = []; // no state/skills dir → nothing custom (the common case)
+    return loadedCustom;
   }
 
   const out: any[] = [];
   const seen = new Set<string>();
   for (const slug of entries) {
     try {
-      const cap = await loadOne(slug);
-      if (!cap) continue;
-      // Built-in override (file named after a built-in kind) — collected
-      // separately and merged onto CAPABILITIES, never added as a custom skill.
-      if (cap.override) {
-        if (builtinOverrides[cap.kind]) {
-          queue.log('error', `[skills] duplicate built-in override "${cap.kind}" — keeping the first`);
+      // A folder named after a built-in kind is an OVERRIDE of that built-in's
+      // brief — it never loads a tool.mjs (built-ins keep their first-party
+      // tool) and contributes only the frontmatter/body keys it specifies.
+      if (BUILTIN_KINDS.has(slug)) {
+        const raw = await readFile(join(SKILLS_DIR, slug, 'SKILL.md'), 'utf8').catch(() => null);
+        if (raw == null) continue;
+        const { data, body } = parseFrontmatter(raw);
+        const ov: any = { config: data };
+        if (body) ov.desc = body;
+        if (data.cooldown) ov.cooldownMs = parseCooldownMs(data.cooldown);
+        if (data.label) ov.label = data.label.trim();
+        const ovContext = parseContextFields(data.context ?? data.contextFields);
+        if (ovContext) ov.contextFields = ovContext;
+        if (data.feed) ov.feed = data.feed.trim();
+        if (data.feedMaxItems) {
+          const n = parseInt(data.feedMaxItems, 10);
+          if (Number.isFinite(n) && n > 0) ov.feedMaxItems = n;
+        }
+        if (builtinOverrides[slug]) {
+          queue.log('error', `[skills] duplicate built-in override "${slug}" — keeping the first`);
           continue;
         }
-        builtinOverrides[cap.kind] = cap;
+        builtinOverrides[slug] = ov;
         continue;
       }
+      if (RESERVED_KINDS.has(slug)) {
+        queue.log('error', `[skills] "${slug}" rejected — shadows a reserved capability`);
+        continue;
+      }
+      const cap = await loadSkillDir(join(SKILLS_DIR, slug), slug, { builtin: false });
+      if (!cap) continue;
       if (seen.has(cap.kind)) {
         queue.log('error', `[skills] duplicate skill kind "${cap.kind}" — keeping the first`);
         continue;
@@ -288,7 +311,10 @@ export async function loadCustomSkills(): Promise<any[]> {
     }
   }
 
-  loaded = out;
+  loadedCustom = out;
+  // Register every skill kind (built-in + custom) as a recap voice/dedupe kind,
+  // so the DJ's anti-repeat memory covers them without a hand-maintained list.
+  registerSkillKinds([...BUILTIN_KINDS, ...out.map(c => c.kind)]);
   if (out.length) {
     queue.log('scheduler', `[skills] loaded ${out.length} custom skill(s): ${out.map(c => c.kind).join(', ')}`);
   }
@@ -296,5 +322,11 @@ export async function loadCustomSkills(): Promise<any[]> {
   if (ovKinds.length) {
     queue.log('scheduler', `[skills] applied ${ovKinds.length} built-in override(s): ${ovKinds.join(', ')}`);
   }
-  return loaded;
+  return loadedCustom;
+}
+
+// Load both roots — built-ins then state. Called once at boot.
+export async function loadAllSkills(): Promise<void> {
+  await loadBuiltins();
+  await loadCustomSkills();
 }

--- a/controller/src/skills/loader.ts
+++ b/controller/src/skills/loader.ts
@@ -1,32 +1,34 @@
 // Skill loader — the single source of truth for the DJ's between-track segment
 // capabilities. Every skill, shipped or operator-added, is a self-contained
-// directory:
+// directory under ONE runtime load root, ${STATE_DIR}/skills/<slug>/:
 //
-//   <dir>/<slug>/
+//   <slug>/
 //     SKILL.md     frontmatter (→ metadata) + body (→ the agent's brief)
 //     tool.mjs     OPTIONAL: a data fetcher the segment director calls first
 //
-// Two roots are scanned:
-//   1. controller/src/skills/builtins/<kind>/   — the seven shipped built-ins
-//      (first-party, read-only; bundled in the image / bind-mounted in dev).
-//   2. ${STATE_DIR}/skills/<slug>/              — operator skills + built-in
-//      brief overrides (state/skills/<built-in-kind> edits the shipped brief).
+// The seven built-ins are not special at load time: they are *seeded* into
+// state/skills on first boot from read-only templates that ship in the image
+// (src/skills/builtins/<kind>/, see scaffold.js → seedBuiltinSkills), then loaded
+// exactly like an operator skill. The only residue of "built-in" is the
+// SEEDED_KINDS set (the shipped kinds), which drives a few first-party
+// affordances — enabled-by-default, can't-hard-delete, reset-to-default, and
+// reserved naming — NOT a separate load path or trust posture.
 //
-// A skill's tool.mjs is the same contract for both:
+// A skill's tool.mjs is the same contract for everyone:
 //   export default async (ctx, state, services, config) => data
 //   export const description = '…'   // OPTIONAL: tool description for the agent
 //   export const ready = (services) => boolean   // OPTIONAL: gate availability
 // `services` (station-services.ts) is the curated facade onto search, the
 // library, the play log, feeds and durable recall — the one way a tool reaches
-// the world, so built-in and custom skills run on identical footing.
+// the world. Every tool runs behind a timeout + try/catch at the call site
+// (llm/segment-tools.js), seeded or operator-authored alike.
 //
 // Safety posture (operator code in state/skills is the operator's own, same
 // trust model as a local Claude Code skill, but still fenced):
 //   - malformed skills are skipped with a logged warning, never crash boot
-//   - custom skills are DISCOVERED-BUT-DISABLED — they appear in /admin/skills
-//     toggled off and cannot air until the operator enables them
-//   - a custom tool.mjs runs behind a timeout + try/catch at the call site
-//     (llm/segment-tools.ts); built-in tools are first-party and unfenced
+//   - operator (non-seeded) skills are DISCOVERED-BUT-DISABLED — they appear in
+//     /admin/skills toggled off and cannot air until the operator enables them
+//   - every tool.mjs runs behind a timeout + try/catch (llm/segment-tools.js)
 
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { join, resolve, dirname } from 'node:path';
@@ -35,9 +37,10 @@ import { STATE_DIR } from '../config.js';
 import { queue, registerSkillKinds } from '../broadcast/queue.js';
 import { buildStationServices } from '../llm/internal/tools/station-services.js';
 
-// Shipped built-in skill directories, resolved relative to this module so it
-// works under both dev (tsx on bind-mounted src) and prod (tsx on the COPYd
-// src). Exported so the scaffolder can seed editable state overrides from them.
+// Shipped built-in TEMPLATE store, resolved relative to this module so it works
+// under both dev (tsx on bind-mounted src) and prod (tsx on the COPYd src). This
+// is NOT a runtime load root — it is read only by the seeder + reset route
+// (scaffold.js). Exported so those can resolve template files.
 export const BUILTINS_DIR = resolve(dirname(fileURLToPath(import.meta.url)), 'builtins');
 const SKILLS_DIR = resolve(STATE_DIR, 'skills');
 const SLUG_RE_INNER = /^[a-z0-9][a-z0-9-]{0,48}$/;
@@ -49,36 +52,21 @@ const SLUG_RE_INNER = /^[a-z0-9][a-z0-9-]{0,48}$/;
 export const SLUG_RE = SLUG_RE_INNER;
 
 // Kinds the queue reserves for its own voice channels — a custom skill may not
-// shadow these (built-in kinds are added below, once loaded).
+// shadow these (seeded kinds are added below, once discovered).
 const QUEUE_INTERNAL_KINDS = ['link', 'dj-speak', 'announcement', 'station-id', 'hourly', 'hourly-check'];
 
-// Derived at load time from the built-in directories. Exported as live sets that
-// callers (.has()) read after boot. `BUILTIN_KINDS` is the set of shipped kinds;
+// Derived at boot from the template directories. Exported as live sets that
+// callers (.has()) read after boot. `SEEDED_KINDS` is the set of shipped kinds;
 // `RESERVED_KINDS` adds the queue-internal kinds a custom skill can't shadow.
-export const BUILTIN_KINDS = new Set<string>();
+export const SEEDED_KINDS = new Set<string>();
 export const RESERVED_KINDS = new Set<string>(QUEUE_INTERNAL_KINDS);
 
-let builtinBase: any[] = [];          // the shipped built-in caps (from BUILTINS_DIR)
-let loadedCustom: any[] = [];         // operator custom caps (from state/skills)
-let builtinOverrides: Record<string, any> = {}; // built-in brief overrides (from state/skills)
-let importCounter = 0;                // cache-buster for re-importing edited tool.mjs
+let loadedSkills: any[] = []; // the single live capability set (seeded + custom)
+let importCounter = 0;        // cache-buster for re-importing edited tool.mjs
 
-export function builtinBaseCaps(): any[] { return builtinBase; }
-export function customCapabilities(): any[] { return loadedCustom; }
-export function getBuiltinOverrides(): Record<string, any> { return builtinOverrides; }
-
-// Built-in caps with operator brief-edits from state/skills/<kind>/SKILL.md
-// applied. An override contributes only the keys it specified — desc / cooldown
-// / label / context and, for news, feed / feedMaxItems — merged over the shipped
-// default; the tool (toolFn / ready / toolName) is always the first-party one.
-// Read live so a rescan takes effect without a restart.
-export function builtinCapabilities(): any[] {
-  return builtinBase.map(c => {
-    const ov = builtinOverrides[c.kind];
-    if (!ov) return c;
-    return { ...c, ...ov, config: { ...c.config, ...ov.config } };
-  });
-}
+// The full live capability set — seeded built-ins and operator skills, loaded on
+// identical footing. Read live so a rescan takes effect without a restart.
+export function loadedCapabilities(): any[] { return loadedSkills; }
 
 // Minimal flat-YAML frontmatter parser. The frontmatter we accept is a small,
 // flat key: value block — no nesting, lists, or multiline scalars — so a tiny
@@ -128,6 +116,48 @@ function parseContextFields(raw: string | undefined): string[] | undefined {
   return list.length ? list : undefined;
 }
 
+// A shipped built-in template, read on demand by the seeder / reset route /
+// admin "defaults" payload. The template FILES are never kept resident.
+export interface SkillTemplate {
+  kind: string;
+  skillMd: string;            // raw SKILL.md text (for verbatim seeding)
+  data: Record<string, string>;
+  body: string;
+  toolPath: string | null;    // absolute path to tool.mjs, or null (prompt-only)
+}
+
+// Read a shipped template's files. Returns null when there's no such template.
+export async function readTemplate(kind: string): Promise<SkillTemplate | null> {
+  const dir = join(BUILTINS_DIR, kind);
+  let skillMd: string;
+  try {
+    skillMd = await readFile(join(dir, 'SKILL.md'), 'utf8');
+  } catch {
+    return null;
+  }
+  const { data, body } = parseFrontmatter(skillMd);
+  let toolPath: string | null = join(dir, 'tool.mjs');
+  try { await stat(toolPath); } catch { toolPath = null; }
+  return { kind, skillMd, data, body, toolPath };
+}
+
+// Discover the shipped kinds from the template dir names and (re)build the
+// derived SEEDED_KINDS / RESERVED_KINDS sets. Cheap — readdir only; the template
+// FILES are read on demand. Runs once at boot (templates are static).
+export async function discoverSeededKinds(): Promise<Set<string>> {
+  SEEDED_KINDS.clear();
+  try {
+    const dirents = await readdir(BUILTINS_DIR, { withFileTypes: true });
+    for (const d of dirents) if (d.isDirectory()) SEEDED_KINDS.add(d.name);
+  } catch (err: any) {
+    queue.log('error', `[skills] could not read built-in templates ${BUILTINS_DIR}: ${err?.message || err}`);
+  }
+  RESERVED_KINDS.clear();
+  for (const k of QUEUE_INTERNAL_KINDS) RESERVED_KINDS.add(k);
+  for (const k of SEEDED_KINDS) RESERVED_KINDS.add(k);
+  return SEEDED_KINDS;
+}
+
 // Dynamically import a skill's optional tool.mjs. Returns the data function plus
 // its optional `description` / `ready` exports, or null when there's no tool.
 async function loadToolModule(dir: string): Promise<{ fn: any; description?: string; ready?: any } | null> {
@@ -151,10 +181,10 @@ async function loadToolModule(dir: string): Promise<{ fn: any; description?: str
   };
 }
 
-// Build a full capability from a skill directory. `builtin` controls the trust
-// posture: built-ins are first-party (custom:false, tool unfenced); state skills
-// are operator code (custom:true, fenced at the call site).
-async function loadSkillDir(dir: string, slug: string, { builtin }: { builtin: boolean }): Promise<any | null> {
+// Build a full capability from a skill directory. `seeded` controls the
+// first-party affordances (enabled-by-default, can't-delete, reset) — NOT the
+// trust posture: every loaded tool runs fenced at the call site, seeded or not.
+async function loadSkillDir(dir: string, slug: string, { seeded }: { seeded: boolean }): Promise<any | null> {
   let raw: string;
   try {
     raw = await readFile(join(dir, 'SKILL.md'), 'utf8');
@@ -167,7 +197,8 @@ async function loadSkillDir(dir: string, slug: string, { builtin }: { builtin: b
     queue.log('error', `[skills] "${slug}" rejected — name "${name}" must be a lowercase slug`);
     return null;
   }
-  if (!builtin && !body) {
+  // A seeded built-in always ships a brief; an operator skill must supply one.
+  if (!seeded && !body) {
     queue.log('error', `[skills] "${slug}" rejected — SKILL.md body (the agent's brief) is empty`);
     return null;
   }
@@ -189,7 +220,9 @@ async function loadSkillDir(dir: string, slug: string, { builtin }: { builtin: b
     label,
     cooldownMs: parseCooldownMs(data.cooldown),
     desc: body,
-    custom: !builtin,
+    // Provenance, NOT trust: a shipped kind (seeded into state) vs an operator
+    // skill. Drives enabled-by-default + the admin delete/reset affordances.
+    seeded,
     window: data.window === 'commute' ? 'commute' : 'any',
     requiresKey,
     // Absent → effectiveContextFields() falls back to the default profile (#471).
@@ -219,86 +252,32 @@ async function loadSkillDir(dir: string, slug: string, { builtin }: { builtin: b
   return cap;
 }
 
-// Scan the shipped built-in directories. Populates builtinBase + the derived
-// BUILTIN_KINDS / RESERVED_KINDS sets. Runs once at boot (built-ins are static).
-export async function loadBuiltins(): Promise<any[]> {
-  let entries: string[] = [];
-  try {
-    const dirents = await readdir(BUILTINS_DIR, { withFileTypes: true });
-    entries = dirents.filter(d => d.isDirectory()).map(d => d.name).sort();
-  } catch (err: any) {
-    queue.log('error', `[skills] could not read built-ins dir ${BUILTINS_DIR}: ${err?.message || err}`);
-    builtinBase = [];
-    return builtinBase;
-  }
-  const out: any[] = [];
-  for (const slug of entries) {
-    try {
-      const cap = await loadSkillDir(join(BUILTINS_DIR, slug), slug, { builtin: true });
-      if (cap) out.push(cap);
-    } catch (err: any) {
-      queue.log('error', `[skills] built-in "${slug}" failed to load: ${err.message}`);
-    }
-  }
-  builtinBase = out;
-  // Rebuild the derived kind sets.
-  BUILTIN_KINDS.clear();
-  for (const c of out) BUILTIN_KINDS.add(c.kind);
-  RESERVED_KINDS.clear();
-  for (const k of QUEUE_INTERNAL_KINDS) RESERVED_KINDS.add(k);
-  for (const k of BUILTIN_KINDS) RESERVED_KINDS.add(k);
-  return builtinBase;
-}
-
-// Scan state/skills and rebuild the custom caps + built-in overrides. Never
-// throws — a broken folder is logged and skipped. Ensures built-ins are loaded
-// first (so kinds classify correctly). Returns the loaded custom caps.
-export async function loadCustomSkills(): Promise<any[]> {
-  if (!builtinBase.length) await loadBuiltins();
-  builtinOverrides = {};
+// Scan the single load root (state/skills) and rebuild the live capability set.
+// Never throws — a broken folder is logged and skipped. Ensures the seeded kinds
+// are discovered first (so folders classify correctly). Returns the loaded caps.
+export async function loadSkills(): Promise<any[]> {
+  if (!SEEDED_KINDS.size) await discoverSeededKinds();
   let entries: string[] = [];
   try {
     const dirents = await readdir(SKILLS_DIR, { withFileTypes: true });
     entries = dirents.filter(d => d.isDirectory()).map(d => d.name);
   } catch {
-    loadedCustom = []; // no state/skills dir → nothing custom (the common case)
-    return loadedCustom;
+    loadedSkills = []; // no state/skills dir yet → nothing to load
+    registerSkillKinds([]);
+    return loadedSkills;
   }
 
   const out: any[] = [];
   const seen = new Set<string>();
   for (const slug of entries) {
     try {
-      // A folder named after a built-in kind is an OVERRIDE of that built-in's
-      // brief — it never loads a tool.mjs (built-ins keep their first-party
-      // tool) and contributes only the frontmatter/body keys it specifies.
-      if (BUILTIN_KINDS.has(slug)) {
-        const raw = await readFile(join(SKILLS_DIR, slug, 'SKILL.md'), 'utf8').catch(() => null);
-        if (raw == null) continue;
-        const { data, body } = parseFrontmatter(raw);
-        const ov: any = { config: data };
-        if (body) ov.desc = body;
-        if (data.cooldown) ov.cooldownMs = parseCooldownMs(data.cooldown);
-        if (data.label) ov.label = data.label.trim();
-        const ovContext = parseContextFields(data.context ?? data.contextFields);
-        if (ovContext) ov.contextFields = ovContext;
-        if (data.feed) ov.feed = data.feed.trim();
-        if (data.feedMaxItems) {
-          const n = parseInt(data.feedMaxItems, 10);
-          if (Number.isFinite(n) && n > 0) ov.feedMaxItems = n;
-        }
-        if (builtinOverrides[slug]) {
-          queue.log('error', `[skills] duplicate built-in override "${slug}" — keeping the first`);
-          continue;
-        }
-        builtinOverrides[slug] = ov;
-        continue;
-      }
-      if (RESERVED_KINDS.has(slug)) {
+      // A folder shadowing a queue-internal kind (link/dj-speak/…) is rejected.
+      // Seeded kinds live in RESERVED_KINDS too but are legitimate, so exempt them.
+      if (RESERVED_KINDS.has(slug) && !SEEDED_KINDS.has(slug)) {
         queue.log('error', `[skills] "${slug}" rejected — shadows a reserved capability`);
         continue;
       }
-      const cap = await loadSkillDir(join(SKILLS_DIR, slug), slug, { builtin: false });
+      const cap = await loadSkillDir(join(SKILLS_DIR, slug), slug, { seeded: SEEDED_KINDS.has(slug) });
       if (!cap) continue;
       if (seen.has(cap.kind)) {
         queue.log('error', `[skills] duplicate skill kind "${cap.kind}" — keeping the first`);
@@ -311,22 +290,19 @@ export async function loadCustomSkills(): Promise<any[]> {
     }
   }
 
-  loadedCustom = out;
-  // Register every skill kind (built-in + custom) as a recap voice/dedupe kind,
-  // so the DJ's anti-repeat memory covers them without a hand-maintained list.
-  registerSkillKinds([...BUILTIN_KINDS, ...out.map(c => c.kind)]);
-  if (out.length) {
-    queue.log('scheduler', `[skills] loaded ${out.length} custom skill(s): ${out.map(c => c.kind).join(', ')}`);
-  }
-  const ovKinds = Object.keys(builtinOverrides);
-  if (ovKinds.length) {
-    queue.log('scheduler', `[skills] applied ${ovKinds.length} built-in override(s): ${ovKinds.join(', ')}`);
-  }
-  return loadedCustom;
+  loadedSkills = out;
+  // Register every loaded kind as a recap voice/dedupe kind, so the DJ's
+  // anti-repeat memory covers them without a hand-maintained list.
+  registerSkillKinds(out.map(c => c.kind));
+  const seededN = out.filter(c => c.seeded).length;
+  const customN = out.length - seededN;
+  queue.log('scheduler', `[skills] loaded ${out.length} skill(s): ${seededN} built-in, ${customN} custom`);
+  return loadedSkills;
 }
 
-// Load both roots — built-ins then state. Called once at boot.
+// Discover + load. Called once at boot AFTER the seeder has populated state/skills
+// (server.js orders seedBuiltinSkills() before this).
 export async function loadAllSkills(): Promise<void> {
-  await loadBuiltins();
-  await loadCustomSkills();
+  await discoverSeededKinds();
+  await loadSkills();
 }

--- a/controller/src/skills/scaffold.ts
+++ b/controller/src/skills/scaffold.ts
@@ -1,26 +1,33 @@
-// Scaffold the built-in skills as editable files under state/skills/<kind>/.
+// Seed the shipped built-in skills into state/skills/<kind>/ as full, editable
+// skills — both SKILL.md AND tool.mjs.
 //
-// On first boot we write one SKILL.md per shipped built-in, seeded from its
-// directory (src/skills/builtins/<kind>/, loaded by skills/loader.js — the
-// source of truth). From then on the operator can edit those files (or use
-// /admin/skills), and the loader merges their contents back over the shipped
-// default as an override. The `news` file additionally carries a `feed:` line
-// seeded from NEWS_FEED_URL (env) so the feed is operator-editable (issue #193).
+// On boot we copy each built-in out of its read-only template
+// (src/skills/builtins/<kind>/, the source of truth) into state/skills/<kind>/.
+// From then on the operator owns those files: edit the brief in /admin/skills,
+// or the tool.mjs on disk + Rescan, exactly like a custom skill. The loader
+// (skills/loader.js) then scans state/skills as the single load root — built-ins
+// are no longer special at load time, just pre-installed.
 //
 // Idempotent: an existing file is never clobbered, so hand-edits survive a
-// restart. Writes are best-effort — a failure is logged, never fatal to boot.
+// restart. A MISSING file is restored — which is also how a deleted built-in
+// folder heals on the next boot (the delete posture is disable-only). Writes are
+// best-effort — a failure is logged, never fatal to boot.
+//
+// `resetBuiltinSkill()` is the opposite: it force-overwrites both files from the
+// template, restoring the as-shipped skill (and pulling in a newer image's
+// tool.mjs). It backs the admin "Reset to default" button.
 
-import { mkdir, stat, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, stat, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { STATE_DIR, config } from '../config.js';
 import { queue } from '../broadcast/queue.js';
-import { builtinBaseCaps, loadBuiltins } from './loader.js';
-import { effectiveContextFields } from './_agent.js';
+import { SEEDED_KINDS, discoverSeededKinds, readTemplate } from './loader.js';
 
 const SKILLS_DIR = resolve(STATE_DIR, 'skills');
 
 // Inverse of loader.js parseCooldownMs — render ms back to the shortest exact
-// "Nd" | "Nh" | "Nm" form for a readable seeded frontmatter value.
+// "Nd" | "Nh" | "Nm" form for a readable seeded frontmatter value. Kept here for
+// the admin routes (the /dj/skills "defaults" payload), which speak in strings.
 export function msToCooldownStr(ms: number): string {
   if (!Number.isFinite(ms) || ms <= 0) return '60m';
   if (ms % 86_400_000 === 0) return `${ms / 86_400_000}d`;
@@ -40,21 +47,17 @@ interface SkillFileFields {
   brief?: string;
 }
 
-// Render + write a skill's SKILL.md. Used by the scaffolder (seeding the 7
-// built-in defaults), the admin built-in edit route (PUT /dj/skills/:kind/file),
-// and the custom-skill create/edit routes (POST /dj/skills, PUT
-// /dj/skills/:slug/file). Creates the folder if absent and overwrites the file
-// unconditionally — callers decide whether to call it (the scaffolder stats
-// first; the routes always write). Never touches a sibling `tool.mjs`, so
-// editing a custom skill's brief leaves its data tool intact.
+// Render + write a skill's SKILL.md from form fields. Used by the admin routes:
+// the built-in edit route (PUT /dj/skills/:kind/file) and the custom-skill
+// create/edit routes (POST /dj/skills, PUT /dj/skills/:slug/file). Creates the
+// folder if absent and overwrites the file unconditionally. Never touches a
+// sibling `tool.mjs`, so editing a skill's brief leaves its data tool intact.
 export async function writeSkillFile(fields: SkillFileFields): Promise<void> {
   const { kind } = fields;
   const lines = ['---', `name: ${kind}`];
   if (fields.label) lines.push(`label: ${fields.label}`);
   if (fields.cooldown) lines.push(`cooldown: ${fields.cooldown}`);
-  // The "right now" fields this segment may weave in (issue #471). Seeded so
-  // the knob is visible+editable in every scaffolded SKILL.md; add or drop
-  // tokens (e.g. `weather`) to change what the segment is allowed to mention.
+  // The "right now" fields this segment may weave in (issue #471).
   if (fields.contextFields && fields.contextFields.length) lines.push(`context: ${fields.contextFields.join(', ')}`);
   // Custom-skill knobs. `window: any` is the loader default, so only the
   // restrictive `commute` value is worth writing.
@@ -77,31 +80,73 @@ async function fileExists(path: string): Promise<boolean> {
   }
 }
 
-// Write a SKILL.md for any built-in that doesn't already have one, seeded from
-// its shipped directory default. Seeds the news feed from NEWS_FEED_URL (env) or
-// the BBC default, preserving the 12-factor story on a fresh install; after
-// first boot the file wins.
-export async function scaffoldBuiltinSkills(): Promise<void> {
-  if (!builtinBaseCaps().length) await loadBuiltins();
-  for (const cap of builtinBaseCaps()) {
+// Insert or replace a single flat `key: value` line inside a SKILL.md's
+// frontmatter block, returning the new text. Used to seed news' feed /
+// feedMaxItems into the (feed-less) template while keeping the rest verbatim.
+function upsertFrontmatterKey(md: string, key: string, value: string): string {
+  const re = new RegExp(`^${key}:.*$`, 'm');
+  if (re.test(md)) return md.replace(re, `${key}: ${value}`);
+  // Insert just before the closing '---' of the frontmatter block.
+  const m = /^(---\s*\n[\s\S]*?\n)(---\s*\n)/.exec(md);
+  if (!m) return md; // no frontmatter — nothing to do
+  return md.slice(0, m[1].length) + `${key}: ${value}\n` + md.slice(m[1].length);
+}
+
+// The SKILL.md text to seed for a built-in: the template verbatim, except news'
+// `feed:` / `feedMaxItems:` are seeded from NEWS_FEED_URL (env-or-BBC, via
+// config) so the feed honours 12-factor on a fresh install (#193). After first
+// boot the file wins (the seeder never clobbers it).
+function seedSkillMd(kind: string, skillMd: string): string {
+  if (kind !== 'news') return skillMd;
+  let out = skillMd;
+  if (config.news.feedUrl) out = upsertFrontmatterKey(out, 'feed', config.news.feedUrl);
+  if (config.news.maxItems) out = upsertFrontmatterKey(out, 'feedMaxItems', String(config.news.maxItems));
+  return out;
+}
+
+// Seed every shipped built-in into state/skills/<kind>/ as a full editable skill
+// (SKILL.md + tool.mjs). Idempotent: existing files survive, missing files are
+// restored. Best-effort — a per-skill failure is logged, never fatal to boot.
+export async function seedBuiltinSkills(): Promise<void> {
+  if (!SEEDED_KINDS.size) await discoverSeededKinds();
+  for (const kind of SEEDED_KINDS) {
     try {
-      const file = join(SKILLS_DIR, cap.kind, 'SKILL.md');
-      if (await fileExists(file)) continue;
-      const fields: SkillFileFields = {
-        kind: cap.kind,
-        label: cap.label,
-        cooldown: msToCooldownStr(cap.cooldownMs),
-        contextFields: effectiveContextFields(cap),
-        brief: cap.desc,
-      };
-      if (cap.kind === 'news') {
-        fields.feed = config.news.feedUrl; // already env-or-BBC (config.ts)
-        fields.feedMaxItems = config.news.maxItems;
+      const tpl = await readTemplate(kind);
+      if (!tpl) continue;
+      const dir = join(SKILLS_DIR, kind);
+      await mkdir(dir, { recursive: true });
+
+      const skillFile = join(dir, 'SKILL.md');
+      if (!(await fileExists(skillFile))) {
+        await writeFile(skillFile, seedSkillMd(kind, tpl.skillMd), 'utf8');
+        queue.log('scheduler', `[skills] seeded built-in "${kind}" SKILL.md → state/skills/${kind}/`);
       }
-      await writeSkillFile(fields);
-      queue.log('scheduler', `[skills] scaffolded built-in "${cap.kind}" → state/skills/${cap.kind}/SKILL.md`);
+
+      if (tpl.toolPath) {
+        const toolFile = join(dir, 'tool.mjs');
+        if (!(await fileExists(toolFile))) {
+          await copyFile(tpl.toolPath, toolFile);
+          queue.log('scheduler', `[skills] seeded built-in "${kind}" tool.mjs → state/skills/${kind}/`);
+        }
+      }
     } catch (err: any) {
-      queue.log('error', `[skills] failed to scaffold "${cap.kind}": ${err?.message || err}`);
+      queue.log('error', `[skills] failed to seed "${kind}": ${err?.message || err}`);
     }
   }
+}
+
+// Force-restore a built-in to its shipped template — overwrite BOTH SKILL.md and
+// tool.mjs in state/skills/<kind>/. Backs POST /dj/skills/:kind/reset; the way an
+// operator reverts a broken edit or pulls in a newer image's tool.mjs. Throws on
+// an unknown (non-seeded) kind so the route can answer 400.
+export async function resetBuiltinSkill(kind: string): Promise<void> {
+  if (!SEEDED_KINDS.size) await discoverSeededKinds();
+  if (!SEEDED_KINDS.has(kind)) throw new Error(`"${kind}" is not a built-in skill`);
+  const tpl = await readTemplate(kind);
+  if (!tpl) throw new Error(`no shipped template for "${kind}"`);
+  const dir = join(SKILLS_DIR, kind);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'SKILL.md'), seedSkillMd(kind, tpl.skillMd), 'utf8');
+  if (tpl.toolPath) await copyFile(tpl.toolPath, join(dir, 'tool.mjs'));
+  queue.log('scheduler', `[skills] reset built-in "${kind}" to shipped default`);
 }

--- a/controller/src/skills/scaffold.ts
+++ b/controller/src/skills/scaffold.ts
@@ -1,11 +1,11 @@
-// Scaffold the 7 built-in skills as editable files under state/skills/<kind>/.
+// Scaffold the built-in skills as editable files under state/skills/<kind>/.
 //
-// On first boot we write one SKILL.md per built-in capability, seeded from the
-// hardcoded CAPABILITIES table (skills/_agent.js) — the single source of truth.
-// From then on the operator can edit those files (or use /admin/skills), and
-// the loader (skills/loader.js) merges their contents back over the built-in as
-// an override. The `news` file additionally carries a `feed:` line so the feed
-// source + tone are operator-editable without touching .env (issue #193).
+// On first boot we write one SKILL.md per shipped built-in, seeded from its
+// directory (src/skills/builtins/<kind>/, loaded by skills/loader.js — the
+// source of truth). From then on the operator can edit those files (or use
+// /admin/skills), and the loader merges their contents back over the shipped
+// default as an override. The `news` file additionally carries a `feed:` line
+// seeded from NEWS_FEED_URL (env) so the feed is operator-editable (issue #193).
 //
 // Idempotent: an existing file is never clobbered, so hand-edits survive a
 // restart. Writes are best-effort — a failure is logged, never fatal to boot.
@@ -14,7 +14,8 @@ import { mkdir, stat, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { STATE_DIR, config } from '../config.js';
 import { queue } from '../broadcast/queue.js';
-import { CAPABILITIES, effectiveContextFields } from './_agent.js';
+import { builtinBaseCaps, loadBuiltins } from './loader.js';
+import { effectiveContextFields } from './_agent.js';
 
 const SKILLS_DIR = resolve(STATE_DIR, 'skills');
 
@@ -76,11 +77,13 @@ async function fileExists(path: string): Promise<boolean> {
   }
 }
 
-// Write a SKILL.md for any built-in that doesn't already have one. Seeds the
-// news feed from NEWS_FEED_URL (env) or the BBC default, preserving the
-// 12-factor story on a fresh install; after first boot the file wins.
+// Write a SKILL.md for any built-in that doesn't already have one, seeded from
+// its shipped directory default. Seeds the news feed from NEWS_FEED_URL (env) or
+// the BBC default, preserving the 12-factor story on a fresh install; after
+// first boot the file wins.
 export async function scaffoldBuiltinSkills(): Promise<void> {
-  for (const cap of CAPABILITIES) {
+  if (!builtinBaseCaps().length) await loadBuiltins();
+  for (const cap of builtinBaseCaps()) {
     try {
       const file = join(SKILLS_DIR, cap.kind, 'SKILL.md');
       if (await fileExists(file)) continue;

--- a/docs/custom-skills.md
+++ b/docs/custom-skills.md
@@ -1,9 +1,9 @@
 # Custom skills
 
 SUB/WAVE's **skills** are the things the AI DJ does *between* tracks — a weather
-check, a headline, a dig on the song playing. The built-in ones are defined in
-`controller/src/skills/_agent.ts` and **scaffolded as editable files** into
-`state/skills/<kind>/SKILL.md` on first boot — so you can change what they say (and,
+check, a headline, a dig on the song playing. The built-in ones ship as
+directories under `controller/src/skills/builtins/<kind>/` and are **scaffolded
+as editable files** into `state/skills/<kind>/SKILL.md` on first boot — so you can change what they say (and,
 for news, which feed they read) without touching the codebase. You can also add
 entirely new skills — either from the admin UI or by dropping a folder into
 `state/skills/`.
@@ -106,32 +106,62 @@ logged and skipped — it never crashes the controller.
 ## tool.mjs (optional)
 
 If present, the default export is wrapped as an [AI SDK](https://sdk.vercel.ai)
-tool the segment director can call **before** writing the line — the same
-mechanism the built-in weather/news skills use to look at real data.
+tool the segment director can call **before** writing the line. This is the
+**exact same mechanism the built-ins use** — the seven shipped skills are just
+directories with a `SKILL.md` and a `tool.mjs`, loaded the same way as yours.
 
 ```js
-export default async function (ctx, state) {
-  // ctx   — the moment: { time, weather, festival, dominantMood, clock }
-  // state — cross-tick dedup memory (persists between firings)
+export default async function (ctx, state, services, config) {
+  // ctx      — the moment: { time, weather, festival, dominantMood, clock }
+  // state    — cross-tick dedup memory (persists between firings)
+  // services — the curated station facade (see below)
+  // config   — this skill's own SKILL.md frontmatter (e.g. a custom `feed:`)
   // Return any JSON-serialisable object. The `{ available: false }` convention
   // tells the agent there's nothing worth airing right now.
   return { available: true, foo: 'bar' };
 }
+
+// OPTIONAL: a richer tool description shown to the agent (else a generic one).
+export const description = 'Fetch X for the … segment.';
+
+// OPTIONAL: gate the whole skill on a runtime condition — when this returns
+// false the skill is never even offered (e.g. no search provider configured).
+export const ready = (services) => services.searchReady();
 ```
 
-The call is **timeout-guarded (8 s)** and any throw degrades cleanly to "no
-data" — a slow or broken skill can never hang the between-track tick. With no
-`tool.mjs`, the skill is pure generation: the DJ writes from the brief alone,
-with no live data to look at.
+### `services` — the station facade
 
-> **Security.** `tool.mjs` runs operator-supplied code inside the controller
-> container — the same trust model as a locally-installed Claude Code skill.
-> Only drop in code you've read and trust.
+The one way a tool reaches the world, so built-in and custom skills run on
+identical footing. It's read-mostly (no settings writes, no secrets):
+
+| call | what it does |
+|---|---|
+| `services.searchWeb(query, opts?)` | web search via the configured provider (DuckDuckGo / Tavily / SearXNG) |
+| `services.searchReady()` | `true` when a search provider is usable |
+| `services.nowPlaying()` | the track on air — `{ artist, title, album, year, id }` or `null` |
+| `services.recentPlays(hours)` | play-log dedup sets `{ ids, keys }` over the last *hours* |
+| `services.library.getArtist(id)` / `.getAlbum(id)` / `.searchArtists(name, opts?)` | Navidrome/Subsonic reads |
+| `services.onThisDay()` | Wikipedia "on this day" events for today |
+| `services.fetchHeadlines({ feedUrl?, maxItems? })` | fetch + parse an RSS feed |
+| `services.recall.seen(key)` / `.remember(key)` | durable, cross-restart dedup ledger |
+| `services.log(msg)` | append a line to the station event log |
+
+A **custom** skill's `tool.mjs` is **timeout-guarded (8 s)** and any throw
+degrades cleanly to "no data" — a slow or broken skill can never hang the
+between-track tick. (Built-in tools are first-party and run unfenced.) With no
+`tool.mjs`, the skill is pure generation: the DJ writes from the brief alone.
+
+> **Security.** A custom `tool.mjs` runs operator-supplied code inside the
+> controller container, and `services` lets it spend your search-provider quota
+> and read your library — the same trust model as a locally-installed Claude
+> Code skill. Only drop in code you've read and trust. (Custom skills also stay
+> disabled until you enable them in `/admin/skills`.)
 
 ## Editing the built-in skills
 
 The 7 built-ins — `weather`, `news`, `now-playing-dig`, `curiosity`, `album-anniversary`,
-`library-deep-cut`, `web-search` — are written into `state/skills/<kind>/SKILL.md`
+`library-deep-cut`, `web-search` — ship as directories under
+`controller/src/skills/builtins/<kind>/` and are copied into `state/skills/<kind>/SKILL.md`
 the first time the controller boots. A file **named after a built-in kind** is an
 **override**: it edits that skill's brief / cooldown / label / `context:` in place
 rather than being rejected as a name clash. (For everything else, a built-in kind in

--- a/docs/custom-skills.md
+++ b/docs/custom-skills.md
@@ -2,10 +2,13 @@
 
 SUB/WAVE's **skills** are the things the AI DJ does *between* tracks — a weather
 check, a headline, a dig on the song playing. The built-in ones ship as
-directories under `controller/src/skills/builtins/<kind>/` and are **scaffolded
-as editable files** into `state/skills/<kind>/SKILL.md` on first boot — so you can change what they say (and,
-for news, which feed they read) without touching the codebase. You can also add
-entirely new skills — either from the admin UI or by dropping a folder into
+read-only templates under `controller/src/skills/builtins/<kind>/` and are
+**seeded as full, editable skills** — both `SKILL.md` **and** `tool.mjs` — into
+`state/skills/<kind>/` on first boot. From then on `state/skills/` is the single
+place skills load from: a built-in is just a pre-installed skill, no different
+from one you add yourself, so you can change what it says, which feed it reads,
+**and how it fetches its data** — without touching the codebase. Add entirely new
+skills the same way: from the admin UI, or by dropping a folder into
 `state/skills/`.
 
 > **TL;DR — want a brand-new segment?** Open **/admin/skills → New skill**, fill in
@@ -146,37 +149,46 @@ identical footing. It's read-mostly (no settings writes, no secrets):
 | `services.recall.seen(key)` / `.remember(key)` | durable, cross-restart dedup ledger |
 | `services.log(msg)` | append a line to the station event log |
 
-A **custom** skill's `tool.mjs` is **timeout-guarded (8 s)** and any throw
-degrades cleanly to "no data" — a slow or broken skill can never hang the
-between-track tick. (Built-in tools are first-party and run unfenced.) With no
-`tool.mjs`, the skill is pure generation: the DJ writes from the brief alone.
+Every skill's `tool.mjs` is **timeout-guarded (8 s)** and any throw degrades
+cleanly to "no data" — a slow or broken skill can never hang the between-track
+tick. This applies to the seeded built-ins too (their network calls — search,
+RSS, on-this-day — must finish within 8 s or that tick simply yields no segment).
+With no `tool.mjs`, the skill is pure generation: the DJ writes from the brief
+alone.
 
-> **Security.** A custom `tool.mjs` runs operator-supplied code inside the
-> controller container, and `services` lets it spend your search-provider quota
-> and read your library — the same trust model as a locally-installed Claude
-> Code skill. Only drop in code you've read and trust. (Custom skills also stay
-> disabled until you enable them in `/admin/skills`.)
+> **Security.** A `tool.mjs` runs operator-supplied code inside the controller
+> container, and `services` lets it spend your search-provider quota and read
+> your library — the same trust model as a locally-installed Claude Code skill.
+> Only drop in code you've read and trust. (Skills you add stay disabled until
+> you enable them in `/admin/skills`.)
 
 ## Editing the built-in skills
 
 The 7 built-ins — `weather`, `news`, `now-playing-dig`, `curiosity`, `album-anniversary`,
-`library-deep-cut`, `web-search` — ship as directories under
-`controller/src/skills/builtins/<kind>/` and are copied into `state/skills/<kind>/SKILL.md`
-the first time the controller boots. A file **named after a built-in kind** is an
-**override**: it edits that skill's brief / cooldown / label / `context:` in place
-rather than being rejected as a name clash. (For everything else, a built-in kind in
-`name:` is still off-limits.) The scaffolded files already carry a `context:` line
-showing each built-in's current fields — `weather` ships with weather ticked on, the
-rest with the default (no-weather) profile.
+`library-deep-cut`, `web-search` — ship as read-only templates under
+`controller/src/skills/builtins/<kind>/` and are **seeded** into
+`state/skills/<kind>/` — both `SKILL.md` and `tool.mjs` — the first time the
+controller boots. After that they're ordinary editable skills: edit the brief /
+cooldown / label / `context:` in `/admin/skills`, and edit the **`tool.mjs` on
+disk + Rescan** exactly as you would for a skill you wrote. The seeded files carry
+a `context:` line showing each built-in's current fields — `weather` ships with
+weather ticked on, the rest with the default (no-weather) profile.
 
-Differences from a custom skill:
+How a built-in still differs from a skill you add:
 
-- **The body may be empty.** An empty brief means "keep the built-in default" — handy
-  when you only want to change the `feed:` or `cooldown` and leave the wording alone.
-- **No `tool.mjs`.** Built-ins already have their data tools wired in code (by kind),
-  so a `tool.mjs` dropped next to a built-in override is ignored.
-- **Stays enabled-by-default.** Editing a built-in doesn't flip it to the
-  discovered-but-disabled state that *new* custom skills start in.
+- **Enabled by default.** A built-in airs out of the box; a *new* skill starts in
+  the discovered-but-disabled state until you enable it.
+- **Can't be deleted, only disabled.** Toggle it off to silence it. If you delete
+  its folder on disk, the seeder restores it (both files) on the next boot.
+- **Reset to default.** `/admin/skills → <built-in> → ↺ Reset to default`
+  overwrites both `SKILL.md` and `tool.mjs` from the shipped template. This is the
+  way back from a broken edit — and the way to pull in a newer image's `tool.mjs`
+  (the seeder never overwrites a file that already exists, so a shipped fix only
+  reaches an existing install when you reset).
+
+> The seeder never clobbers a file that already exists, so your edits survive a
+> restart and an upgrade. Only **Reset to default** (or deleting the file on disk)
+> brings the shipped version back.
 
 ### News: swapping the feed
 

--- a/docs/examples/skills/moon-phase/tool.mjs
+++ b/docs/examples/skills/moon-phase/tool.mjs
@@ -1,15 +1,18 @@
 // Example custom-skill data tool for SUB/WAVE.
 //
 // The default export is wrapped as an AI SDK tool the segment director can call
-// before deciding whether to air this skill's line. It is invoked with the
-// moment's context (`ctx` — the same shape as getFullContext(): time, weather,
-// festival, dominantMood, clock) and the cross-tick dedup `state`. Return any
-// JSON-serialisable object; a `{ available: false }` convention tells the agent
-// there is nothing worth airing. Keep it fast — the call is timeout-guarded at
-// 8s and any throw degrades cleanly to "no data".
+// before deciding whether to air this skill's line. Full signature:
+//   (ctx, state, services, config) => data
+//   ctx      — the moment (time, weather, festival, dominantMood, clock)
+//   state    — cross-tick dedup memory
+//   services — the station facade (searchWeb, library, nowPlaying, onThisDay, …)
+//   config   — this skill's own SKILL.md frontmatter
+// Return any JSON-serialisable object; a `{ available: false }` convention tells
+// the agent there is nothing worth airing. Keep it fast — a custom skill's call
+// is timeout-guarded at 8s and any throw degrades cleanly to "no data".
 //
-// This one needs no API key and no network: it computes the lunar phase from
-// the current date with a simple synodic-month approximation.
+// This one uses none of those args — no API key, no network: it computes the
+// lunar phase from the current date with a simple synodic-month approximation.
 
 const SYNODIC = 29.530588853; // mean length of a lunar month, days
 const KNOWN_NEW_MOON = Date.UTC(2000, 0, 6, 18, 14); // 2000-01-06 18:14 UTC

--- a/docs/superpowers/specs/2026-06-30-builtins-fully-editable-in-state-design.md
+++ b/docs/superpowers/specs/2026-06-30-builtins-fully-editable-in-state-design.md
@@ -1,0 +1,253 @@
+# Built-ins become fully-editable skills in state/ — one load root
+
+**Date:** 2026-06-30
+**Depends on / stacks atop:** the `unified-skills-architecture` branch (built-ins are
+already directories with `SKILL.md` + `tool.mjs` and a shared `services` facade). This
+finishes that arc: built-in `tool.mjs` becomes operator-editable, and `state/skills`
+becomes the single runtime load root.
+
+## Problem
+
+The unified-skills work made built-in and custom skills *load* through the same code,
+but they still live in two different places with two different trust postures:
+
+- A built-in's **`SKILL.md` brief** is scaffolded to `state/skills/<kind>/` and is
+  operator-editable; the loader merges it back as an *override*.
+- A built-in's **`tool.mjs`** stays in the read-only app dir
+  (`controller/src/skills/builtins/<kind>/`) and is **never** copied out. The operator
+  can edit the words a built-in speaks, but not its data-fetch code.
+
+So a built-in is still a second-class citizen relative to a custom skill: you can fork
+a custom skill's `tool.mjs` freely, but to change how `weather` or `web-search`
+*fetches*, you'd have to fork core. The override-merge machinery
+(`builtinBase` + `builtinOverrides` + `builtinCapabilities()`) exists only to keep
+those two worlds reconciled.
+
+## Goal
+
+**Every skill — shipped or operator-added — is a self-contained directory in
+`state/skills/<slug>/` (`SKILL.md` + optional `tool.mjs`), loaded by one code path with
+one trust posture.** The seven built-ins are *seeded* there on first boot from
+read-only templates that ship in the image; after seeding they are ordinary editable
+skills. The app-dir `builtins/` folder stops being a runtime load root and becomes a
+**seed / reset template store**.
+
+### Non-goals
+
+- No change to *what* the skills do or say on air. Pure mechanism + storage change.
+- No in-browser code editor for `tool.mjs`. Editing a built-in's code is the same
+  power-user flow custom skills already have: edit the file in `state/skills/<kind>/`
+  on disk, then **Rescan**. The win is that the file now *lives* in state and is the
+  one that runs — not that we add a UI for it.
+- No new skill features, context fields, or scheduling changes.
+
+## Decisions taken (brainstorm)
+
+1. **Eager copy / full unify.** On first boot, seed `SKILL.md` **and** `tool.mjs` for
+   all seven built-ins into `state/skills/<kind>/`. `state/skills` is then the single
+   runtime load root. The override-merge machinery is deleted.
+2. **Delete posture: disable-only.** A seeded built-in can be toggled off but not
+   hard-deleted; the folder is re-seeded on boot if missing. The station's core skill
+   set stays stable (a fresh or wiped install always has weather/news/…). Matches
+   today's "built-ins can't be deleted" guard.
+3. **Fencing: fence everything.** Every tool loaded from `state/` runs behind the 8s
+   timeout + try/catch, seeded or not. One code path. The network-heavy seeded tools
+   (`web-search`, `news` RSS, `curiosity`'s on-this-day) must complete within 8s or
+   degrade to "no data" that tick — acceptable, since segments are optional and the
+   listener-facing outcome is silence either way.
+4. **Reset-to-default restores both files.** The admin "Reset to default" re-copies
+   `SKILL.md` **and** `tool.mjs` from the current image's shipped template. This is both
+   the recovery path for a broken edit and the way to pull in a shipped `tool.mjs`
+   bug-fix after first boot — the accepted mitigation for "updates don't propagate."
+
+### Accepted tradeoff
+
+Once a built-in's `tool.mjs` is seeded into `state/` it is never auto-overwritten, so a
+later image that ships an improved `weather/tool.mjs` will **not** reach an install that
+already seeded it. The operator pulls the new version deliberately via **Reset to
+default** (decision 4). This is the explicit cost of "operators fully own their
+built-ins," chosen over version-tracking complexity.
+
+## Target architecture
+
+### 1. One runtime load root
+
+`state/skills/<slug>/` is the only directory scanned to build the live capability set.
+Every folder there — `weather`, `news`, the operator's `bhangra-tip` — loads through the
+**same** `loadSkillDir()` call and yields a cap with the **same** shape and the **same**
+fenced trust posture. There is no longer a "built-in cap" vs "custom cap" at load time.
+
+### 2. The app-dir `builtins/` becomes a template store
+
+`controller/src/skills/builtins/<kind>/{SKILL.md,tool.mjs}` stays in the image (prod
+`COPY`, dev bind-mount) but is **no longer loaded at runtime**. It is read only by the
+seeder and the reset route. Two cheap helpers replace `loadBuiltins()`:
+
+- `seededKinds(): Set<string>` — `readdir` of the templates dir → the set of shipped
+  kinds. Computed once at boot. Drives the residual first-party affordances below.
+- `readTemplate(kind): { skillMd: string, hasTool: boolean, toolPath: string, data, body }`
+  — read a template's files on demand (for seeding, reset, and the admin "defaults"
+  payload). No resident template caps are kept in memory.
+
+### 3. `seeded` replaces the overloaded `custom` flag
+
+Today `cap.custom` conflates two orthogonal axes: *is the tool operator code?* (drives
+fencing) and *is this a shipped kind?* (drives enabled-by-default, the UI badge, the
+delete/edit/reset routes). After this change fencing is unconditional, so the fencing
+axis collapses and only the provenance axis remains. Rename it for honesty:
+
+- New cap field **`cap.seeded: boolean`** = `seededKinds().has(slug)`.
+- Downstream logic flips from `cap.custom` to `!cap.seeded`, unchanged in behaviour:
+  - **Enabled-by-default** (`availableCapabilities`, `skillCatalog`):
+    `cap.seeded ? enabled[slug] !== false : enabled[slug] === true`. Seeded built-ins
+    default on; operator skills are discovered-but-disabled.
+  - **Reserved names** (`RESERVED_KINDS`): queue-internal kinds + `seededKinds()`. A
+    custom skill still can't be named `weather` (the folder-exists 409 also catches it,
+    but the reserved check gives the clearer error).
+- The **`skillCatalog()` API field stays `custom: !cap.seeded`** so the web admin needs
+  no change to how it badges operator skills / explains off-by-default. (Its meaning —
+  "operator-authored, not shipped" — is exactly `!seeded`.)
+
+### 4. Fencing is unconditional
+
+`buildSegmentTools()` drops the `const fenced = !!cap.custom` branch and always wraps
+the tool call in `withTimeout(p, 8000)`. Every skill tool, seeded or operator, gets the
+same 8s ceiling. (Timeout stays 8s for consistency with today's custom fence; the
+network-heavy seeded tools are verified against it in smoke testing — see Testing.)
+
+### 5. Scaffolder → seeder: seed both files, idempotent, re-seed if missing
+
+`scaffoldBuiltinSkills()` becomes `seedBuiltinSkills()`. For each `seededKinds()` kind:
+
+- Ensure `state/skills/<kind>/SKILL.md` exists; if missing, copy it from the template.
+  News' `feed:` line is seeded from `NEWS_FEED_URL` (env) or the template's BBC default,
+  preserving the 12-factor story on a fresh install (file wins after first boot).
+- Ensure `state/skills/<kind>/tool.mjs` exists **iff the template has one**; if missing,
+  copy the template's `tool.mjs` verbatim.
+- **Idempotent**: an existing file is never clobbered, so operator edits survive a
+  restart. A *missing* file is restored — which is also how decision 2's "re-seed on
+  boot if the folder was deleted" is implemented (delete the folder on disk → next boot
+  restores both files).
+- Best-effort: a failure is logged, never fatal to boot.
+
+Seeding copies the template `SKILL.md` **verbatim** (then patches news' feed line),
+rather than re-rendering it from parsed fields — so `state/` mirrors the shipped file
+exactly. This replaces today's `writeSkillFile`-from-cap-fields seeding; `writeSkillFile`
+stays for the admin edit/create routes (which assemble a file from form fields).
+
+### 6. Reset-to-default = server-side reseed of both files
+
+Today "Reset to default" is a *client-side form repopulate*: it fills the edit form from
+the `defaults` payload and the operator saves, rewriting `SKILL.md` only. A code file
+can't be restored that way. Add a server route:
+
+- **`POST /dj/skills/:kind/reset`** (admin) — for a seeded kind, force-copy the
+  template's `SKILL.md` **and** `tool.mjs` over `state/skills/<kind>/` (overwriting),
+  reload, return the refreshed catalogue. 400 for a non-seeded slug (custom skills have
+  no shipped default).
+
+The admin "Reset to default" button calls this route instead of (or before) the form
+repopulate, then refetches the edit form. The `defaults` payload in
+`GET /dj/skills/:kind/file` stays for prefill and is sourced from `readTemplate(kind)`.
+
+### 7. Delete guard stays, keyed on `seeded`
+
+`DELETE /dj/skills/:slug` keeps rejecting seeded kinds ("built-in skills can't be
+deleted — disable them instead"), now checked against `seededKinds()`. Custom skills
+delete their whole folder as today. (Even a manual on-disk `rm` of a seeded folder is
+undone by the next boot's seeder — decision 2.)
+
+## What gets deleted / shrinks
+
+- `builtinBase`, `builtinOverrides`, `builtinCapabilities()`, `getBuiltinOverrides()`,
+  `builtinBaseCaps()`, `loadBuiltins()` — the entire override-merge layer in
+  `loader.ts`.
+- The built-in-kind **override special-case** in `loadCustomSkills()` (the branch that
+  parses a `state/skills/<built-in>/SKILL.md` as a brief-only override and skips its
+  `tool.mjs`). A seeded folder is now just loaded as a full skill.
+- `allCapabilities()` in `_agent.ts` collapses from `[...builtinCapabilities(),
+  ...customCapabilities()]` to the single loaded set.
+- The `fenced = !!cap.custom` branch in `segment-tools.ts`.
+
+## Migration & backward compatibility
+
+- **Existing install with built-in brief overrides** (`state/skills/weather/SKILL.md`,
+  no `tool.mjs`): on the upgrade boot the seeder sees `SKILL.md` present (keeps the
+  operator's brief) and `tool.mjs` missing (copies the template's in). Weather now has
+  both files; it loads as a full skill with the operator's brief preserved. The outcome
+  matches today's override merge, without the merge.
+- **Existing custom skills** (`(ctx, state[, services, config]) => …`): unaffected —
+  same folder, same loader, same fence.
+- **Enabled toggles** (`settings.skills.enabled`, keyed by kind slug): unchanged — slugs
+  are stable (`weather` stays `weather`), so existing on/off state carries over.
+- **A wiped `state/`**: the seeder recreates all seven from templates on next boot, enabled
+  by default — same as a fresh install.
+
+## Security posture
+
+Unchanged from the unified-skills baseline, and slightly *more* consistent: every skill
+tool now runs behind the 8s fence + try/catch (previously seeded tools ran unfenced).
+`services` is still the only way a tool reaches the world — a curated, read-mostly facade
+(search, library reads, play-log reads, feeds, durable recall, namespaced log) with no
+write/settings/secret surface. Seeding operator-editable copies of the built-in tools
+does not widen what a tool *can* do; it only moves where the file lives. It remains the
+operator's own controller and own keys (same trust model as a locally-installed Claude
+Code skill).
+
+## Files touched (anticipated)
+
+- **`controller/src/skills/loader.ts`** — drop `loadBuiltins`/`builtinBase`/override
+  machinery; add `seededKinds()` + `readTemplate()`; one uniform `state/skills` scan
+  setting `cap.seeded`; export `SEEDED_KINDS` (replacing `BUILTIN_KINDS`); `RESERVED_KINDS`
+  = internal + seeded.
+- **`controller/src/skills/scaffold.ts`** — `scaffoldBuiltinSkills` → `seedBuiltinSkills`
+  (copy both files from templates, idempotent, verbatim SKILL.md + news feed patch).
+  Keep `writeSkillFile`/`msToCooldownStr` for the admin routes.
+- **`controller/src/skills/_agent.ts`** — `allCapabilities()` = loaded set;
+  `cap.custom` → `!cap.seeded` at the enabled-by-default and catalogue spots.
+- **`controller/src/llm/internal/tools/segment-tools.ts`** — always fence.
+- **`controller/src/routes/dj.ts`** — `BUILTIN_KINDS` → `SEEDED_KINDS`; `defaults` payload
+  via `readTemplate`; new `POST /dj/skills/:kind/reset`; delete guard keyed on seeded.
+- **`controller/src/server.ts`** — `scaffoldBuiltinSkills()` call → `seedBuiltinSkills()`
+  (verify it still runs before `loadAllSkills()` so seeded files exist when the scan runs).
+- **`controller/src/broadcast/queue.ts`** — verify `registerSkillKinds()` still fed from
+  the single loaded set (no built-in/custom split to reconcile).
+- **`web/components/admin/skills/SkillEditModal.tsx`** — wire "Reset to default" to the
+  new reset route (restores tool.mjs too); minor copy tweak so a built-in's editor notes
+  its `tool.mjs` now lives in `state/` and is edited on disk + Rescan, like a custom skill.
+- **Docs:** `docs/custom-skills.md` — built-ins are now seeded into `state/`; the
+  app-dir is a template/reset source; Reset-to-default restores shipped code.
+
+## Testing & verification
+
+No unit runner; the merge gate is `npm run lint` (eslint + `tsc --noEmit`) in `controller/`
++ `web/`. Plan:
+
+1. Lint green in both packages.
+2. **Fresh-install seed**: empty `state/` → boot → all seven `state/skills/<kind>/` exist
+   with both `SKILL.md` and `tool.mjs`; all appear enabled in `/dj/skills`; each **Run now**
+   still fires (weather speaks, news pulls the feed, curiosity hits on-this-day,
+   web-search/now-playing-dig search) — proving the seeded tools run within the 8s fence.
+3. **Upgrade migration**: pre-seed `state/skills/weather/SKILL.md` with an edited brief and
+   no `tool.mjs` → boot → brief preserved, `tool.mjs` copied in, weather airs the edited
+   brief. Proves the override→full-skill migration.
+4. **Edit then Reset**: break `state/skills/weather/tool.mjs` (e.g. `throw`) → weather
+   degrades to no-data (fenced) → "Reset to default" → both files restored from template →
+   weather airs again. Proves decision 4 end to end.
+5. **Delete is disable-only**: DELETE a seeded kind → 400; `rm -rf` the folder on disk →
+   next boot re-seeds it. Proves decision 2.
+6. **Custom backward-compat**: the operator's existing 2-arg `bhangra-tip` still loads,
+   stays disabled until enabled, and runs.
+
+## Suggested implementation order (one PR, staged commits)
+
+1. **Seeder + templates.** `seededKinds()`/`readTemplate()`; `seedBuiltinSkills()` copies
+   both files idempotently; server calls it before the skill scan. (No load-path change
+   yet — overrides still merge; this just also drops `tool.mjs` into state.)
+2. **Single load root.** Remove the override machinery; load every `state/skills` folder
+   as a full skill with `cap.seeded`; delete the override special-case; `allCapabilities()`
+   collapses. Migration path (existing overrides) verified here.
+3. **Unconditional fence** + `custom`→`seeded` rename through `_agent.ts`/`segment-tools.ts`,
+   `BUILTIN_KINDS`→`SEEDED_KINDS` through `dj.ts`/`loader.ts`.
+4. **Reset route + web wiring** (`POST /dj/skills/:kind/reset`, SkillEditModal button).
+5. **Docs.**

--- a/docs/superpowers/specs/2026-06-30-unified-skills-architecture-design.md
+++ b/docs/superpowers/specs/2026-06-30-unified-skills-architecture-design.md
@@ -1,0 +1,244 @@
+# Unified skills architecture — built-ins and custom skills share one mechanism
+
+**Date:** 2026-06-30
+**Depends on:** PR #695 (admin skill CRUD + `now-playing-dig`) — this refactors files that PR introduced, so it stacks on / lands after it.
+
+## Problem
+
+A SUB/WAVE skill (a between-track segment) is defined two different ways depending
+on who ships it:
+
+- **Built-in skills** — metadata in the `CAPABILITIES` table (`skills/_agent.ts`),
+  and their data tool in a hand-written, `kind`-keyed block in
+  `llm/internal/tools/segment-tools.ts` (compiled TypeScript). The data tool reaches
+  straight into the station's internals: `searchWeb`, the Subsonic client
+  (`getArtist`/`getAlbum`/`searchArtists`), `queue` (now-playing, `recentlyPlayed`),
+  the on-this-day fetcher.
+- **Custom skills** — a self-contained directory `state/skills/<slug>/` with
+  `SKILL.md` (metadata + brief) and an optional `tool.mjs` (`export default async
+  (ctx, state) => data`). The fetcher receives only the **moment** — `ctx =
+  { time, weather, festival, dominantMood, clock }` — and `state` (cross-tick
+  memory). It has **no handle to search, the library, or the play log.**
+
+Two consequences:
+
+1. **Capability gap.** A custom `tool.mjs` literally cannot do what `now-playing-dig`,
+   `library-deep-cut`, `web-search`, or `curiosity` do — it can't search the web or
+   query the library. So any genuinely useful new skill has to be built *into* core.
+2. **Plumbing cruft.** Adding a built-in touches ~6 files because `kind` is duplicated
+   across parallel hand-maintained lists: `CAPABILITIES`, `BUILTIN_KINDS`
+   (`loader.ts`), `queue`'s `VOICE_KINDS`/`DEDUPE_KINDS`/`KIND_LABEL`, and
+   `tts.VOICE_KINDS`. (We felt this adding `now-playing-dig`.)
+
+## Goal
+
+**Every skill — shipped or operator-added — is a self-contained directory
+(`SKILL.md` + optional `tool.mjs`) built against one shared station-services API.
+The seven built-ins are just pre-installed skills.** Adding a skill (built-in or
+custom) is the same recipe: drop a folder, write the brief, optionally add a
+`tool.mjs` using `ctx.services`.
+
+### Non-goals
+
+- No change to *what the skills do* — `now-playing-dig` still digs, weather still
+  reads the weather. Pure mechanism refactor; on-air behaviour is unchanged.
+- No new skill features (no new context fields, no scheduling changes).
+- No change to the admin UI's skill sheet beyond what falls out of the registry
+  change (it already reads `skillCatalog()`).
+
+## Target architecture
+
+### 1. Station-services API (the unlock)
+
+Introduce a single, curated services facade and pass it to **every** tool fetcher
+as a third argument — additive, so existing 2-arg custom `tool.mjs` files keep
+working unchanged:
+
+```js
+export default async function (ctx, state, services) { … }
+//   ctx      — the moment: { time, weather, festival, dominantMood, clock }
+//   state    — cross-tick dedup memory (persists between firings)
+//   services — the station (NEW)
+```
+
+`services` (built in `llm/internal/tools/station-services.ts`, one factory, typed):
+
+```
+services = {
+  searchWeb(query, opts?),          // the configured provider (DDG/Tavily/SearXNG)
+  searchReady(): boolean,           // is a provider configured?
+  nowPlaying(): { artist, title, album, year, id } | null,   // queue.current.track
+  recentPlays(hours): { ids:Set, keys:Set },                 // queue.recentlyPlayed
+  library: { getArtist, getAlbum, searchArtists },           // Subsonic facade
+  onThisDay(): Promise<items>,      // curiosity's fetchOnThisDay
+  log(msg): void,                   // queue.log('skills', …) — namespaced
+}
+```
+
+The factory is the *only* place these internals are wired. Built-in tools and custom
+`tool.mjs` both consume `services`; neither imports controller internals directly.
+
+### 2. Built-ins are pre-installed skill directories
+
+The seven built-ins move from the `CAPABILITIES` array + `segment-tools.ts` blocks to
+shipped directories:
+
+```
+controller/src/skills/builtins/<kind>/   # bundled in the image, first-party, read-only
+  SKILL.md                               # frontmatter (kind/label/cooldown/window/context/requiresKey…) + brief
+  tool.mjs                               # optional; the same (ctx,state,services)=>data contract
+```
+
+> **Location:** under `src/` (not a top-level `controller/skills/`) because the
+> controller runs `tsx src/server.ts` in both dev and prod, the Dockerfile only
+> `COPY`s `controller/src`, and dev bind-mounts `controller/src`. Putting the
+> built-in dirs under `src/` gives them the prod COPY and the dev bind-mount with
+> no Dockerfile or compose change. The loader resolves the dir relative to its own
+> `import.meta.url`.
+
+- The loader scans **two roots**: `controller/skills` (built-ins) then
+  `state/skills` (operator). A built-in's `SKILL.md` is still **scaffolded to
+  `state/skills/<kind>/SKILL.md` as an editable override** (prompt/cooldown/context/
+  feed) — the merge-over-default behaviour from today is preserved, so operators keep
+  editing built-in briefs in the admin sheet.
+- A built-in's `tool.mjs` runs from the **read-only app dir** — first-party code,
+  not operator-editable, not scaffolded to `state/`. (An operator can still *override
+  the brief*; they cannot break weather's fetch.) This keeps the "edit the words, not
+  the code" guarantee for built-ins while using the identical loader path.
+- `CAPABILITIES` (the array) is replaced by "load the built-in directories at boot."
+  `builtinCapabilities()` becomes "built-ins + their `state/` overrides," same shape
+  as today.
+
+### 3. One registry → derived `kind` lists
+
+A single loaded-skill registry becomes the source of truth. Derive, rather than
+hand-maintain:
+
+- `BUILTIN_KINDS` → the set of kinds loaded from `controller/skills`.
+- `RESERVED_KINDS` → `BUILTIN_KINDS` + the queue-internal kinds (`link`, `dj-speak`,
+  `station-id`, `hourly-check`, `announcement`).
+- `queue`'s `VOICE_KINDS` / `DEDUPE_KINDS` / `KIND_LABEL` → derived from the registry
+  (every loaded skill kind is a voice + dedupe kind; label defaults to the kind).
+- `tts.VOICE_KINDS` → the fixed voice channels (`dj-speak`/`link`/`station-id`/
+  `hourly-check`/`jingle`/`default`) **plus** every loaded skill kind.
+
+Adding a skill then touches **one place**: its directory.
+
+### 4. Readiness lives with the skill
+
+Some built-ins gate on more than a static env var (web-search / now-playing-dig are
+ready only when a search provider is configured; that's *dynamic*, provider-derived).
+Express readiness in the skill's own module so it stays self-contained:
+
+```js
+export const ready = () => services...   // optional; absent → always ready
+```
+
+- The loader reads optional `ready` from the tool module (alongside `default`).
+- `SKILL.md` frontmatter keeps `requiresKey` / (optional) `keyUrl` for the **admin UI
+  affordance** ("set SEARCH_API_KEY"). The web-search provider-dependent `requiresKey`
+  (Tavily needs a key, DDG doesn't) is computed in `skillCatalog()` exactly as today —
+  that small piece of provider-aware UI logic stays; it's display-only.
+- The agentic tick's gate becomes: skill enabled + assigned + off-cooldown + in-window
+  + `ready()` (if present). Same as today, just sourced from the module.
+
+## The unified `tool.mjs` contract (documented)
+
+```js
+// state/skills/<slug>/tool.mjs  (or controller/skills/<kind>/tool.mjs for built-ins)
+export default async function (ctx, state, services) {
+  // Return JSON-serialisable data, or { available: false } to tell the agent
+  // there's nothing worth airing right now (the DJ then stays silent or skips).
+  return { available: true, … };
+}
+export const ready = () => services.searchReady();  // OPTIONAL
+```
+
+Backward compatible: existing custom skills (`(ctx, state) => …`, e.g. the operator's
+`bhangra-tip`) ignore the third arg and keep working.
+
+## Migration & backward compatibility
+
+- **Existing custom skills** — unaffected (services is additive; signature unchanged).
+- **Existing `state/skills/<kind>/SKILL.md` built-in overrides** — still parsed as
+  overrides over the (now directory-shipped) built-in default. Same merge.
+- **The seven built-ins** — their briefs (current `CAPABILITIES.desc`, post-#695) move
+  verbatim into `controller/skills/<kind>/SKILL.md`; their tools move from
+  `segment-tools.ts` blocks into `controller/skills/<kind>/tool.mjs` rewritten against
+  `services`. No behaviour change.
+- A running station that already scaffolded the old built-in `SKILL.md` files keeps
+  them (file wins), same as today.
+
+## What gets deleted / shrinks
+
+- The `CAPABILITIES` literal array (replaced by directory load).
+- The per-kind `if (kinds.has('weather'))…` blocks in `segment-tools.ts` (collapse to:
+  for each offered cap with a tool module, wrap it with `services` injected).
+- The hand-maintained `kind` lists in `loader.ts`, `queue.ts`, `tts.ts` (derived).
+
+## Security posture
+
+`services` hands operator-supplied `tool.mjs` access to `searchWeb` (which may spend
+the operator's paid Tavily quota) and the Subsonic client (which can hit Navidrome).
+This widens the existing sandbox. Mitigations / rationale:
+
+- The 8 s timeout fence + try/catch already wrap every tool call (degrade to "no data",
+  never hang the tick).
+- It is the operator's own controller and their own keys — the same trust model as a
+  locally-installed Claude Code skill, which the docs already state. Custom skills are
+  still **discovered-but-disabled** until the operator enables them.
+- `services` is a *curated* facade (read-mostly: search, library reads, play-log reads,
+  log). It exposes no write/delete/settings/secret surface. This is called out as a
+  deliberate boundary, not "hand them the whole controller."
+
+## Files touched (anticipated)
+
+- **New:** `controller/skills/<kind>/{SKILL.md,tool.mjs}` ×7;
+  `llm/internal/tools/station-services.ts`.
+- **Rewritten:** `skills/_agent.ts` (load built-in dirs instead of `CAPABILITIES`;
+  ready-from-module), `llm/internal/tools/segment-tools.ts` (generic wrap + services),
+  `skills/loader.ts` (scan two roots; derive `BUILTIN_KINDS`/`RESERVED_KINDS`; read
+  optional `ready`), `skills/scaffold.ts` (seed overrides from the built-in dirs),
+  `broadcast/queue.ts` (derive kind sets/labels), `audio/tts.ts` (derive voice kinds).
+- **Docs:** `docs/custom-skills.md` (the `(ctx, state, services)` contract + the
+  services reference + the `ready` export); the example skill under
+  `docs/examples/skills/`.
+
+## Testing & verification
+
+No unit runner; the merge gate is `npm run lint` (eslint + `tsc --noEmit`) in
+`controller/` + `web/`. Plan:
+
+1. Lint green in both packages.
+2. Dev-stack smoke: each of the seven built-ins still appears in `/dj/skills`, scaffolds
+   its override, and **Run now** fires it (weather speaks, now-playing-dig searches the
+   on-air track, curiosity hits on-this-day, etc.) — proving the `services`-backed tools
+   match the old hardcoded ones.
+3. A throwaway **custom** skill with a `tool.mjs` that calls `services.searchWeb` /
+   `services.library` returns data and airs — proving the capability gap is closed.
+4. The operator's existing `bhangra-tip` (2-arg `tool.mjs`) still loads and runs —
+   proving backward compatibility.
+5. Adding a hypothetical built-in touches only its directory — proving the derived lists.
+
+## Suggested implementation order (one PR, staged commits)
+
+1. `station-services.ts` factory + thread `services` through `buildSegmentTools` and the
+   custom-tool wrap (3rd arg). Existing built-in blocks rewritten to use `services` in
+   place (still in `segment-tools.ts`). — *capability + plumbing, no behaviour change.*
+2. Move the seven built-ins to `controller/skills/<kind>/` dirs; loader scans two roots;
+   `CAPABILITIES` array removed; `segment-tools.ts` blocks deleted (tools now live in the
+   dirs). — *the unify.*
+3. Derive `BUILTIN_KINDS`/`RESERVED_KINDS`/queue sets/tts kinds from the registry. —
+   *kill the duplication.*
+4. Docs + example skill.
+
+## Contract (as built)
+
+The tool fetcher signature is **`(ctx, state, services, config)`** — `services` is
+a 3rd arg (so `ctx` stays "the moment" and `services` is "the station"), and a 4th
+`config` arg carries the skill's own frontmatter (e.g. news' `feed`/`feedMaxItems`),
+which surfaced as a need while porting. The tool module may also export an optional
+`description` (the agent-facing tool description) and an optional
+`ready(services) => boolean` (gates availability — e.g. web-search/now-playing-dig
+return `services.searchReady()`). All additive, so existing two-arg custom skills
+keep working.

--- a/web/components/admin/skills/SkillEditModal.tsx
+++ b/web/components/admin/skills/SkillEditModal.tsx
@@ -40,8 +40,8 @@ interface SkillEditModalProps {
   onSkillsChange: (skills: SkillLike[]) => void;  // refresh the panel list after any mutation
 }
 
-// The shipped defaults for a built-in (from the raw CAPABILITIES entry), used by
-// "Reset to default".
+// The shipped defaults for a built-in (read from the image template), used to
+// gate the "Reset to default" button. The reset itself is server-side.
 interface SkillDefaults {
   label?: string;
   cooldown?: string;
@@ -301,21 +301,43 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
     }
   };
 
-  // Restore the form to the built-in's shipped defaults. Repopulates the fields
-  // (doesn't persist) so the operator reviews and then Saves — at which point
-  // the SKILL.md is rewritten to the default.
-  const resetToDefault = () => {
-    if (!defaults) return;
-    setFields(f => ({
-      ...f,
-      label: defaults.label ?? f.label,
-      cooldown: defaults.cooldown ?? f.cooldown,
-      context: splitContext(defaults.context),
-      feed: defaults.feed ?? '',
-      feedMaxItems: defaults.feedMaxItems != null ? String(defaults.feedMaxItems) : '',
-      brief: defaults.brief ?? '',
-    }));
-    flashFor('RESET — REVIEW & SAVE');
+  // Restore a built-in to its shipped default. Server-side and immediate: POST
+  // overwrites BOTH the SKILL.md AND the tool.mjs in state/skills/<kind>/ from the
+  // image template (an in-form repopulate couldn't restore the code). We then
+  // refetch the now-restored SKILL.md so the form mirrors the shipped values, and
+  // refresh the catalogue.
+  const resetToDefault = async () => {
+    if (custom || !isEdit || busy) return;
+    setBusy(true);
+    try {
+      const r = await adminFetch(`/dj/skills/${fileId}/reset`, { method: 'POST' });
+      const j = (await r.json().catch(() => ({}))) as { skills?: SkillLike[]; error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      onSkillsChange(Array.isArray(j.skills) ? j.skills : []);
+
+      const fr = await adminFetch(`/dj/skills/${fileId}/file`);
+      const fj = (await fr.json().catch(() => ({}))) as SkillFileResponse;
+      if (fr.ok) {
+        const next: FileFields = {
+          label: fj.label || '',
+          cooldown: fj.cooldown || '',
+          context: splitContext(fj.context),
+          window: fj.window === 'commute' ? 'commute' : 'any',
+          feed: fj.feed || '',
+          feedMaxItems: fj.feedMaxItems != null ? String(fj.feedMaxItems) : '',
+          brief: fj.brief || '',
+        };
+        setFields(next);
+        setSnapshot(fieldsKey(next));
+        setHasTool(!!fj.hasTool);
+      }
+      flashFor('RESET TO SHIPPED DEFAULT');
+      notify.ok(`Reset “${kind}” to default`);
+    } catch (e) {
+      notify.err(`Reset failed: ${errorMessage(e)}`);
+    } finally {
+      setBusy(false);
+    }
   };
 
   // ── Style helpers (mirror the design, using our theme vars) ─────────────────
@@ -516,14 +538,16 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
             <div>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
                 <div style={sectionLabel}>THE BRIEF — WHAT THE DJ SAYS, AND WHEN TO STAY SILENT</div>
-                {/* Built-ins can be reverted to their shipped default brief/cooldown/context. */}
+                {/* Built-ins revert to their shipped default — restores both the
+                    brief (SKILL.md) and the data tool (tool.mjs) from the image. */}
                 {!custom && defaults && (
                   <button
                     type="button"
                     onClick={resetToDefault}
+                    disabled={busy}
                     className="sw-ghost"
-                    title="Restore the shipped default for this built-in skill (review, then Save)"
-                    style={{ flex: 'none', padding: '6px 12px', background: 'transparent', color: 'var(--muted)', border: '1px solid color-mix(in oklab, var(--ink) 24%, transparent)', fontSize: 10, fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', cursor: 'pointer' }}
+                    title="Restore this built-in's shipped SKILL.md and tool.mjs from the image"
+                    style={{ flex: 'none', padding: '6px 12px', background: 'transparent', color: 'var(--muted)', border: '1px solid color-mix(in oklab, var(--ink) 24%, transparent)', fontSize: 10, fontWeight: 700, letterSpacing: '0.18em', textTransform: 'uppercase', cursor: busy ? 'default' : 'pointer', opacity: busy ? 0.5 : 1 }}
                   >
                     ↺ Reset to default
                   </button>
@@ -545,7 +569,7 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
               </div>
               {hasTool && (
                 <div style={{ marginTop: 14, border: '1px solid color-mix(in oklab, var(--ink) 24%, transparent)', borderLeft: '3px solid var(--accent)', padding: '12px 14px', fontSize: 12, lineHeight: 1.6, color: 'var(--muted)' }}>
-                  A <code>tool.mjs</code> data fetcher is attached and runs each tick before the DJ speaks. Edit or remove it on disk + Rescan — it isn&apos;t editable here. Deleting the skill removes it too.
+                  A <code>tool.mjs</code> data fetcher is attached and runs each tick before the DJ speaks. Edit it on disk in <code>state/skills/{kind}/</code> + Rescan — it isn&apos;t editable here.{custom ? ' Deleting the skill removes it too.' : ' Use ↺ Reset to default to restore the shipped version.'}
                 </div>
               )}
             </div>

--- a/web/components/manual/CustomSkills.tsx
+++ b/web/components/manual/CustomSkills.tsx
@@ -85,13 +85,14 @@ the phase is unremarkable.`}</CodeBlock>
         <h2>The shipped skills are files too.</h2>
         <p>
           The seven built-ins — weather, news, now-playing digs, curiosity, album anniversaries,
-          library deep-cuts, and web search — are written into{' '}
+          library deep-cuts, and web search — ship as directories (under{' '}
+          <code className="bs-code-inline">controller/src/skills/builtins/&lt;kind&gt;/</code>) and
+          load through the same loader as your own. Each is scaffolded into{' '}
           <code className="bs-code-inline">state/skills/&lt;kind&gt;/SKILL.md</code> the first
-          time the station boots. Editing one (on the admin <strong>Skills</strong> page, or
-          the file directly) overrides its brief, cooldown, or label in place. A built-in
-          file may leave the body empty to keep the default wording, and never loads a{' '}
-          <code className="bs-code-inline">tool.mjs</code>; the built-ins already have their
-          data wired in.
+          time the station boots. Editing that (on the admin <strong>Skills</strong> page, or
+          the file directly) overrides its brief, cooldown, context, or label in place — without
+          touching the built-in&rsquo;s <code className="bs-code-inline">tool.mjs</code>, which
+          always runs. An override may leave the body empty to keep the default wording.
         </p>
         <p>
           The big one: <strong>News reads the BBC by default</strong>. Hit{' '}
@@ -120,16 +121,29 @@ not a newsreader's. Skip anything dull or stale; silence is fine.`}</CodeBlock>
         <h2>Let the DJ look before it speaks.</h2>
         <p>
           With a <code className="bs-code-inline">tool.mjs</code>, the DJ can fetch live data
-          before deciding whether to air the line, the same mechanism the built-in weather
-          and news skills use. Export a default function; return any JSON, and use{' '}
+          before deciding whether to air the line — the exact same mechanism the built-ins use
+          (they&rsquo;re directories with a <code className="bs-code-inline">tool.mjs</code> too).
+          Export a default function; return any JSON, and use{' '}
           <code className="bs-code-inline">{`{ available: false }`}</code> to tell the DJ
-          there&rsquo;s nothing worth airing.
+          there&rsquo;s nothing worth airing. The 3rd arg, <code className="bs-code-inline">services</code>,
+          is the station facade — <code className="bs-code-inline">searchWeb</code>,{' '}
+          <code className="bs-code-inline">library</code>, <code className="bs-code-inline">nowPlaying</code>,{' '}
+          <code className="bs-code-inline">recentPlays</code>, <code className="bs-code-inline">onThisDay</code>,{' '}
+          <code className="bs-code-inline">fetchHeadlines</code>, durable{' '}
+          <code className="bs-code-inline">recall</code> — so a custom skill can reach as far as a built-in.
         </p>
-        <CodeBlock>{`export default async function (ctx, state) {
-  // ctx   — the moment: { time, weather, festival, dominantMood, clock }
-  // state — cross-tick memory (persists between firings)
-  return { available: true, phase: 'full moon', illumination: 100 };
-}`}</CodeBlock>
+        <CodeBlock>{`export default async function (ctx, state, services, config) {
+  // ctx      — the moment: { time, weather, festival, dominantMood, clock }
+  // state    — cross-tick memory (persists between firings)
+  // services — the station facade (searchWeb, library, nowPlaying, onThisDay…)
+  // config   — this skill's own SKILL.md frontmatter
+  const artist = services.nowPlaying()?.artist;
+  if (!artist) return { available: false };
+  return { available: true, artist };
+}
+
+// OPTIONAL: gate the skill on a runtime condition (e.g. a search provider).
+export const ready = (services) => services.searchReady();`}</CodeBlock>
         <p>
           The call is timeout-guarded and any error degrades cleanly to &ldquo;no
           data&rdquo;; a slow or broken skill can never hang the station. With no{' '}


### PR DESCRIPTION
> **Stacked on #695.** Base is `worktree-admin-create-skills` so the diff is just this refactor — please **retarget to `develop` after #695 merges**.

## What & why

Built-in and custom skills were defined two different ways: built-ins as a `CAPABILITIES` table + hand-written `kind`-keyed blocks in `segment-tools.ts` (with privileged access to search/library/queue), custom skills as a `state/skills/<slug>/` directory whose `tool.mjs` only got `(ctx, state)` — no way to search or read the library. So every genuinely useful new skill had to be built into core, and adding a built-in touched ~6 files of duplicated `kind` lists.

This unifies them: **every skill — shipped or operator-added — is a directory (`SKILL.md` + optional `tool.mjs`) on one loader, against one `services` facade.**

## Changes

- **`station-services.ts`** — a curated, read-mostly facade (`searchWeb`, `library.{getArtist,getAlbum,searchArtists}`, `nowPlaying`, `recentPlays`, `onThisDay`, `fetchHeadlines`, durable `recall`, `log`) passed to every tool fetcher as a 4th-arg-bearing signature **`(ctx, state, services, config)`**. Closes the capability gap — a custom `tool.mjs` can now do everything a built-in can.
- **Built-ins are directories** under `controller/src/skills/builtins/<kind>/` (under `src/` so the existing `tsx src` Dockerfile COPY + dev bind-mount cover them with no compose change). Loaded by the same loader; their brief still scaffolds to `state/` as an editable override, their `tool.mjs` runs first-party from the app dir.
- **`loader.ts`** scans both roots, derives `BUILTIN_KINDS`/`RESERVED_KINDS`, reads optional `description` / `ready(services)` exports from each tool module, and merges operator brief-overrides over the shipped defaults. `CAPABILITIES` and the per-kind `segment-tools.ts` blocks are deleted — `segment-tools.ts` is now a generic loop (operator code fenced by an 8s timeout, built-in tools unfenced).
- **Derived kind-lists** — `queue`'s recap voice/dedupe sets register every skill kind via `registerSkillKinds()` (custom skills now get recap memory too). Adding a skill touches one directory.
- **Docs** — `custom-skills.md` rewritten for the `(ctx, state, services, config)` contract + a full `services` reference; example + design spec updated.

Backward compatible: existing two-arg custom `tool.mjs` files keep working; existing `state/skills` built-in overrides still apply.

## Test plan

- `npm run lint` green in `controller/` + `web/`; controller `npm test` → **exit 0**.
- Verified live on a dev stack: all 7 built-ins fire through the directory loader + `services`; a services-backed custom skill (`services.library` + `nowPlaying`) airs; the operator's existing 2-arg custom skill still runs; create/edit/delete + Reset-to-default all work in the admin segment-sheet; controller boots clean ("7 built-in(s)… 1 custom… 7 overrides").

## Security note

`services` lets operator `tool.mjs` spend the search-provider quota and read the library — a curated, read-mostly surface (no writes/secrets/settings), fenced by the existing timeout, and custom skills stay disabled-until-enabled. Same trust model as a local Claude Code skill.
