### PR TITLE
feat(shows): anchor shows to Navidrome playlists

### DIFF
--- a/controller/package.json
+++ b/controller/package.json
@@ -11,7 +11,7 @@
     "lastfm-session": "tsx scripts/lastfm-session.ts",
     "test:embed": "tsx scripts/embedding-preflight-test.ts",
     "test:llm": "tsx scripts/llm-pure.test.ts",
-    "test": "tsx scripts/llm-pure.test.ts && tsx scripts/picker-recency-regression.ts && tsx scripts/recent-plays.test.ts && tsx scripts/listeners-status.test.ts && tsx scripts/lastfm-enrich.test.ts && tsx scripts/web-search-searxng.test.ts && tsx scripts/request-dedup.test.ts && tsx scripts/stale-link.test.ts && tsx scripts/embedding-heavy.test.ts && tsx scripts/tagger-perf.test.ts && tsx scripts/rescan-scope.test.ts",
+    "test": "tsx scripts/llm-pure.test.ts && tsx scripts/picker-recency-regression.ts && tsx scripts/recent-plays.test.ts && tsx scripts/listeners-status.test.ts && tsx scripts/lastfm-enrich.test.ts && tsx scripts/web-search-searxng.test.ts && tsx scripts/request-dedup.test.ts && tsx scripts/stale-link.test.ts && tsx scripts/embedding-heavy.test.ts && tsx scripts/tagger-perf.test.ts && tsx scripts/rescan-scope.test.ts && tsx scripts/show-playlist.test.ts",
     "lint": "eslint . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit"

--- a/controller/scripts/show-playlist.test.ts
+++ b/controller/scripts/show-playlist.test.ts
@@ -1,0 +1,44 @@
+// Unit tests for the pure playlist-anchor merge helper. Side-effect-free, so
+// it's pinned here without touching Subsonic. Run via `npm test`.
+// node:assert-via-tsx style, matching scripts/recent-plays.test.ts.
+
+import assert from 'node:assert/strict';
+import { mergePlaylistTracks } from '../src/music/show-playlist.js';
+
+// Empty / falsy inputs → empty pool.
+assert.deepEqual(mergePlaylistTracks([]), [], 'no lists → empty');
+assert.deepEqual(mergePlaylistTracks([[], []]), [], 'empty lists → empty');
+assert.deepEqual(mergePlaylistTracks([null as any, undefined as any]), [], 'null/undefined lists tolerated');
+
+// Single list passes through, preserving order.
+assert.deepEqual(
+  mergePlaylistTracks([[{ id: 'a' }, { id: 'b' }]]).map(t => t.id),
+  ['a', 'b'],
+  'single list preserves order',
+);
+
+// Union across lists, first occurrence wins (dedupe by id).
+assert.deepEqual(
+  mergePlaylistTracks([
+    [{ id: 'a', n: 1 }, { id: 'b', n: 1 }],
+    [{ id: 'b', n: 2 }, { id: 'c', n: 2 }],
+  ]).map(t => `${t.id}:${t.n}`),
+  ['a:1', 'b:1', 'c:2'],
+  'union dedupes by id, first occurrence wins',
+);
+
+// Entries without an id are dropped (a playlist row Subsonic returned malformed).
+assert.deepEqual(
+  mergePlaylistTracks([[{ id: 'a' }, { title: 'no id' } as any, { id: '' } as any, { id: 'b' }]]).map(t => t.id),
+  ['a', 'b'],
+  'entries without an id are dropped',
+);
+
+// Duplicates WITHIN one list also collapse.
+assert.deepEqual(
+  mergePlaylistTracks([[{ id: 'a' }, { id: 'a' }, { id: 'a' }]]).map(t => t.id),
+  ['a'],
+  'intra-list duplicates collapse',
+);
+
+console.log('show-playlist merge checks passed');

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -15,6 +15,7 @@ import { z } from 'zod';
 import * as settings from '../settings.js';
 import * as session from './session.js';
 import * as picker from '../music/picker.js';
+import { resolveShowPlaylistPool } from '../music/show-playlist.js';
 import * as library from '../music/library.js';
 import * as mix from '../music/mix.js';
 import * as journey from '../music/journey.js';
@@ -208,9 +209,19 @@ export function pickSystem() {
   // instead of a soft lean, so both pick paths honour strict the same way. Lives
   // in the system prompt for the same session-window reason as the show brief.
   const musicLean = dj.showMusicLean(activeShow);
+  // Playlist anchor: a separate steer from genre/era. Strict → every pick MUST
+  // come from the pinned playlist (the tools already enforce this in code, but
+  // saying so keeps the agent reaching for showPlaylistTracks instead of
+  // burning steps on tools that come back empty); soft → strong preference,
+  // occasional steps outside allowed for flow.
+  const playlistLean = activeShow?.playlistIds?.length
+    ? (activeShow.playlistStrict
+        ? `\n\nThis show is anchored to a curated playlist: every track you pick MUST come from it. Call showPlaylistTracks first and choose from what it returns.`
+        : `\n\nThis show leans on a curated playlist: call showPlaylistTracks first and strongly prefer those tracks; only step outside occasionally when the flow calls for it.`)
+    : '';
   return `${settings.agentPersonaPreamble(persona, { rules: false })}
 
-You run the station as one continuous shift. The messages above are the live session.${djModeLine}${showLine}${musicLean}
+You run the station as one continuous shift. The messages above are the live session.${djModeLine}${showLine}${musicLean}${playlistLean}
 
 ${dj.PICKER_CRITERIA}
 
@@ -282,7 +293,7 @@ export const pickerAgent = defineAgent({
   maxSteps: 4,
   timeoutMs: agentDeadline,
   buildSystem: () => pickSystem(),
-  buildTools: ({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint }) => {
+  buildTools: ({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, playlistLock, playlistTracks }) => {
     // Resolve the active show live (a show that just came on air takes effect):
     // for a strict show, hard genre + era locks the discovery tools enforce on
     // candidates — not just the prompt. Era rides the same genreStrict flag (no
@@ -294,7 +305,9 @@ export const pickerAgent = defineAgent({
     const eraLock = strict && (activeShow?.fromYear != null || activeShow?.toYear != null)
       ? { fromYear: activeShow.fromYear, toYear: activeShow.toYear }
       : null;
-    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, genreLock, eraLock });
+    // playlistLock / playlistTracks are pre-resolved by pickViaAgent (the
+    // Navidrome fetch is async; buildTools is sync) and threaded through run().
+    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, genreLock, eraLock, playlistLock, playlistTracks });
     return { tools, extras: { seen } };
   },
 });
@@ -384,6 +397,16 @@ async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = n
   const effN = effectiveNoRepeatWindow(settings.get().llm?.noRepeatWindow ?? 0, stats.total);
   const { ids: hardRecentIds, keys: hardRecentKeys } = queue.recentlyPlayedByCount(effN);
 
+  // Show playlist anchor: resolve the union here (async Navidrome fetch) and
+  // thread it into the agent's tools. Strict → a hard lock set so every tool's
+  // results are intersected with the playlist (the agent can only pick in-set);
+  // soft → just the tracks, exposed via showPlaylistTracks for a strong prompt
+  // preference, no lock. Null when the show pins no playlists.
+  const activeShow = settings.resolveActiveShow();
+  const playlistPool = activeShow ? await resolveShowPlaylistPool(activeShow) : null;
+  const playlistLock = playlistPool && activeShow?.playlistStrict ? playlistPool.ids : null;
+  const playlistTracks = playlistPool?.tracks ?? null;
+
   const { object, steps, toolCalls, extras } = await pickerAgent.run({
     messages: session.windowMessages(),
     recentIds,
@@ -394,6 +417,8 @@ async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = n
     // over the run's current waypoint, so the agent path drifts the sound the
     // same way the pool path does. The event text tells the agent to use it.
     audioWaypoint,
+    playlistLock,
+    playlistTracks,
   });
 
   const song = object?.id ? extras.seen.get(object.id) : null;

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -13,6 +13,7 @@ import * as library from '../music/library.js';
 import * as settings from '../settings.js';
 import { artistKey } from '../music/recency.js';
 import { normGenre, genreMatches, inYearRange, preferEnergy } from '../music/show-filter.js';
+import { resolveShowPlaylistPool } from '../music/show-playlist.js';
 import { getFullContext } from '../context.js';
 import { queue } from './queue.js';
 import * as session from './session.js';
@@ -35,6 +36,10 @@ const AUTO_MAX_PER_ARTIST = 2;   // cap any one artist's share of the fallback p
 // SHOW_NARROW_FACTOR so the show's genre/era actually fills the fallback (#629).
 const SHOW_GENRE_WEIGHT = 14;        // dedicated show-genre source (soft lean)
 const SHOW_GENRE_STRICT_WEIGHT = 24; // strict: this source carries most of the pool
+// A show anchored to Navidrome playlist(s): the union becomes the dominant
+// fallback source (soft) or — after the strict end-filter — the whole pool.
+const SHOW_PLAYLIST_WEIGHT = 14;        // dedicated show-playlist source (soft)
+const SHOW_PLAYLIST_STRICT_WEIGHT = 24; // strict: this source carries the pool
 const SHOW_NARROW_FACTOR = 0.5;      // shrink mood/playlist/recent/etc. for shows
 
 function shuffle<T>(arr: T[]): T[] {
@@ -82,6 +87,15 @@ async function refreshAutoPlaylistInner() {
   const narrow = !!(show && (showGenre || fromYear != null || toYear != null));
   const strict = !!(show?.genreStrict && showGenre);
 
+  // Show playlist anchor: resolve the union once. The fallback must honour it
+  // too, so the LLM-free coast (LLM down, budget-hard, zero listeners) still
+  // plays the show's playlist. Strict → the pool is hard-filtered to it at the
+  // end (and the off-playlist random top-up is skipped); soft → it just
+  // dominates. Null when the show pins no playlists.
+  const playlistPool = show ? await resolveShowPlaylistPool(show) : null;
+  const hasPlaylist = !!playlistPool?.tracks?.length;
+  const strictPlaylist = hasPlaylist && !!show?.playlistStrict;
+
   // Resolve the show's free-text genre to the library's exact tag once, up front.
   // A resolution failure / absent genre leaves genreName null, which disables the
   // strict hard-filter and the genre-targeted fetches — the documented degrade
@@ -98,8 +112,9 @@ async function refreshAutoPlaylistInner() {
   // this (genreName null → no filter). Soft mode is a no-op here.
   const enforce = (items: any[]) =>
     strictGenreNorm ? items.filter((t: any) => genreMatches(t, strictGenreNorm)) : items;
-  // Shrink the off-genre sources so the dedicated show-genre source dominates.
-  const nz = (cap: number) => (narrow ? Math.max(2, Math.ceil(cap * SHOW_NARROW_FACTOR)) : cap);
+  // Shrink the off-genre / off-playlist sources so the dedicated show source
+  // (genre or playlist) dominates the pool.
+  const nz = (cap: number) => ((narrow || hasPlaylist) ? Math.max(2, Math.ceil(cap * SHOW_NARROW_FACTOR)) : cap);
 
   // Length cap: the active show's override or the station default (issue #447),
   // resolved in seconds. null = no cap. Now that the fallback honours the show's
@@ -107,7 +122,7 @@ async function refreshAutoPlaylistInner() {
   const maxDurationSec = settings.effectiveMaxTrackSec(show);
 
   const pool: any[] = [];
-  const fromSource: Record<string, number> = { 'show-genre': 0, mood: 0, playlist: 0, recent: 0, frequent: 0, starred: 0, random: 0 };
+  const fromSource: Record<string, number> = { 'show-genre': 0, 'show-playlist': 0, mood: 0, playlist: 0, recent: 0, frequent: 0, starred: 0, random: 0 };
   // Cap each artist's share of the pool. Without this, a deep-catalogue artist
   // (many mood-tagged / starred / frequent tracks) can dominate the fallback
   // playlist, so whenever Liquidsoap coasts on auto.m3u the same artist clusters
@@ -153,6 +168,14 @@ async function refreshAutoPlaylistInner() {
     } catch (err) {
       queue.log('error', `Show-genre fetch failed: ${err.message}`);
     }
+  }
+
+  // 0b. Dedicated show-playlist source — the dominant contributor whenever the
+  // show is anchored to Navidrome playlist(s). Placed early so playlist tracks
+  // fill the pool before the (shrunk) discovery sources. In strict mode the
+  // whole pool is filtered to these ids at the end, so this is the universe.
+  if (hasPlaylist) {
+    take('show-playlist', shuffle(playlistPool!.tracks), strictPlaylist ? SHOW_PLAYLIST_STRICT_WEIGHT : SHOW_PLAYLIST_WEIGHT);
   }
 
   // 1. Mood-tagged from the LLM-built library (only if tagger has run).
@@ -205,8 +228,11 @@ async function refreshAutoPlaylistInner() {
   }
 
   // 6. Top up with random to TARGET_POOL. For a show, bias the fill toward its
-  // genre/era (Navidrome filters server-side, so it stays pure).
-  if (pool.length < TARGET_POOL) {
+  // genre/era (Navidrome filters server-side, so it stays pure). A strict
+  // playlist show skips this entirely — random can't be playlist-filtered, so
+  // better a short looping in-playlist fallback than off-playlist filler (the
+  // strict end-filter below would drop it anyway).
+  if (pool.length < TARGET_POOL && !strictPlaylist) {
     try {
       const random = narrow
         ? await subsonic.getRandomSongs({ size: TARGET_POOL, genre: genreName || undefined, fromYear: fromYear ?? undefined, toYear: toYear ?? undefined })
@@ -225,6 +251,15 @@ async function refreshAutoPlaylistInner() {
     }
   }
 
+  // Strict playlist: drop every off-playlist track so the LLM-free coast plays
+  // only the show's curation. The dedicated show-playlist source guarantees
+  // in-set tracks are present, so this is normally a clean filter; never-starve
+  // to the unfiltered pool only if NOT ONE survived (a true dead-air guard).
+  if (strictPlaylist) {
+    const inPl = pool.filter((t: any) => t?.id && playlistPool!.ids.has(t.id));
+    if (inPl.length) { pool.length = 0; pool.push(...inPl); }
+  }
+
   // Stamp the station cap on every fallback entry (#447). max-track-length is a
   // pure on-air cue_out cut, not a selection filter, so over-length tracks stay
   // in the pool and simply crossfade out at the cap when the queue runs dry.
@@ -239,12 +274,19 @@ async function refreshAutoPlaylistInner() {
   } else if (strict && genreName && pool.length < TARGET_POOL) {
     queue.log('scheduler', `Auto-playlist: only ${pool.length} in-genre tracks for ${genreName} — looping a short genre-pure fallback`);
   }
+  if (strictPlaylist && pool.length < TARGET_POOL) {
+    queue.log('scheduler', `Auto-playlist: only ${pool.length} in-playlist tracks — looping a short playlist-pure fallback`);
+  }
 
+  const playlistTag = hasPlaylist
+    ? (playlistPool!.names.length ? playlistPool!.names.join('/') : `${show.playlistIds.length} playlist(s)`)
+    : '';
   const showInfo = show
     ? `, show=${show.name}` +
       (showGenre ? ` genre=${genreName || showGenre} (${strict ? 'strict' : 'soft'})` : '') +
       (fromYear != null || toYear != null ? ` year=${fromYear ?? ''}-${toYear ?? ''}` : '') +
-      (showEnergy ? ` energy=${showEnergy}` : '')
+      (showEnergy ? ` energy=${showEnergy}` : '') +
+      (hasPlaylist ? ` playlist=${playlistTag} (${strictPlaylist ? 'strict' : 'soft'})` : '')
     : '';
   queue.log('scheduler',
     `Auto-playlist refreshed: ${pool.length} tracks (` +

--- a/controller/src/llm/internal/tools/picker-tools.ts
+++ b/controller/src/llm/internal/tools/picker-tools.ts
@@ -89,6 +89,8 @@ export function buildPickerTools({
   resolveReferences = false,
   genreLock = null,
   eraLock = null,
+  playlistLock = null,
+  playlistTracks = null,
 }: {
   recentIds?: Set<string>;
   recentKeys?: Set<string>;        // lowercased "title|artist" — backfilled entries lack ids
@@ -119,6 +121,18 @@ export function buildPickerTools({
   // library. No-op unless a web-search provider is ready (searchReady()). Never
   // set on the per-track picker — see the gating note on the tool below.
   resolveReferences?: boolean;
+  // Hard playlist constraint for a strict playlist-anchored show. The id set is
+  // the union of the show's pinned Navidrome playlists; when set, every tool's
+  // candidates are intersected with it (HARD — no never-starve to off-playlist,
+  // unlike genreLock, because a playlist is an exact set and the showPlaylistTracks
+  // tool below is the guaranteed in-set source). So the agent's `seen` map only
+  // ever holds playlist tracks — it cannot return an off-playlist id. null = no lock.
+  // Deliberately NOT set on the request path: an explicit listener ask wins.
+  playlistLock?: Set<string> | null;
+  // The show's playlist union tracks. Registers the showPlaylistTracks tool —
+  // the agent's window into the operator's curation. Set in BOTH strict (with
+  // playlistLock) and soft (no lock, just a strong prompt preference) modes.
+  playlistTracks?: any[] | null;
 } = {}) {
   const seen = new Map<string, any>(); // id → slim song, accumulated across all tool calls
 
@@ -137,6 +151,11 @@ export function buildPickerTools({
     let pool = shuffle((list || []) as any[]);
     if (genreLock) pool = preferGenre(pool, genreLock);
     if (eraLock) pool = preferEra(pool, eraLock);
+    // Strict playlist: HARD-intersect with the lock set, with NO never-starve to
+    // off-playlist (a playlist is an exact set, so a tool with no overlap simply
+    // contributes nothing). The guaranteed in-set source is showPlaylistTracks
+    // below, so `seen` is never empty and the agent's pick is always in-playlist.
+    if (playlistLock) pool = pool.filter((s: any) => s?.id && playlistLock.has(s.id));
     const accepted = filterPickerCandidates(pool, {
       recentIds,
       recentKeys,
@@ -377,6 +396,22 @@ export function buildPickerTools({
         catch (err) { return { error: err.message }; }
       },
     }),
+
+    // Only registered when the active show is anchored to Navidrome playlist(s).
+    // Returns a sample of the operator's hand-picked tracks for this show. In a
+    // STRICT playlist show this is the only source that's guaranteed to return
+    // in-set tracks (every other tool is hard-intersected with the lock), so the
+    // agent should lead with it; in a SOFT show it's the strongly-preferred source.
+    ...(playlistTracks && playlistTracks.length ? {
+      showPlaylistTracks: tool({
+        description: "Tracks from the show's pinned playlist(s) — the operator's hand-picked selection for this show. Prefer these: call this first and choose from what it returns. Takes no input.",
+        inputSchema: z.object({}),
+        execute: async () => {
+          try { return collect(playlistTracks, 12); }
+          catch (err) { return { error: err.message }; }
+        },
+      }),
+    } : {}),
 
     // Only registered while a sonic journey is active (the event message tells
     // the agent when that is). Closes over the journey's current waypoint, so

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -13,6 +13,7 @@ import * as settings from '../settings.js';
 import { bpmCompat, keyCompat } from './mix.js';
 import { filterPickerCandidates, recencyWindowsForLibrary, effectiveNoRepeatWindow } from './recency.js';
 import { normGenre, genreMatches, preferGenre, inYearRange, preferEnergy } from './show-filter.js';
+import { resolveShowPlaylistPool, type PlaylistPool } from './show-playlist.js';
 
 const CANDIDATE_CAP = 18;
 const HISTORY_DEPTH = 4;
@@ -35,6 +36,11 @@ const CAP_SHOW_GENRE = 12;
 // larger cap than the soft path so genre matches fill most of the final pool
 // (CANDIDATE_CAP) even after dedup / artist-cap / recency trims it.
 const CAP_SHOW_GENRE_STRICT = 24;
+// A show anchored to Navidrome playlist(s): the union is the dominant source
+// (soft) or — after the strict end-filter below — the show's entire universe.
+// Mirrors the show-genre caps so playlist tracks fill most of the final pool.
+const CAP_SHOW_PLAYLIST = 12;
+const CAP_SHOW_PLAYLIST_STRICT = 24;
 const SHOW_NARROW_FACTOR = 0.5;
 
 // TTL cache for sources that don't change between picks. Without this, every
@@ -135,7 +141,7 @@ async function tracksFromAlbums(albums: any[], perAlbum: number, max: number) {
   return out;
 }
 
-async function buildCandidates(mood: string | null | undefined, recentIds: Set<string>, recentArtists: Set<string>, currentTrack: any, rankTarget: { bpm: number | null; key: string | null } | null = null, audioWaypoint: number[] | null = null, showFilter: ShowFilter = null, hardRecentIds: Set<string> = new Set(), hardRecentKeys: Set<string> = new Set()) {
+async function buildCandidates(mood: string | null | undefined, recentIds: Set<string>, recentArtists: Set<string>, currentTrack: any, rankTarget: { bpm: number | null; key: string | null } | null = null, audioWaypoint: number[] | null = null, showFilter: ShowFilter = null, hardRecentIds: Set<string> = new Set(), hardRecentKeys: Set<string> = new Set(), playlistPool: PlaylistPool | null = null, playlistStrict = false) {
   await library.load();
   const pool: any[] = [];
   const sources: Record<string, number> = {};
@@ -144,9 +150,13 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     pool.push(...items.map((t: any) => ({ ...t, _source: label })));
     sources[label] = (sources[label] || 0) + items.length;
   };
-  // When a show pins a genre/decade, shrink the unrelated discovery sources so
-  // the dedicated show-genre source dominates the candidate list (soft lean).
-  const narrow = hasMusicFilter(showFilter);
+  // A non-empty playlist anchor on this show: the union of its tracks. Strict
+  // mode (below) hard-filters the final pool to it; soft just lets it dominate.
+  const hasPlaylist = !!playlistPool?.tracks?.length;
+  const strictPlaylist = hasPlaylist && playlistStrict;
+  // When a show pins a genre/decade OR a playlist, shrink the unrelated
+  // discovery sources so the dedicated show source dominates the candidate list.
+  const narrow = hasMusicFilter(showFilter) || hasPlaylist;
   const nz = (cap: number) => (narrow ? Math.max(2, Math.ceil(cap * SHOW_NARROW_FACTOR)) : cap);
 
   // Strict genre: resolve the show's free-text genre to the library's exact tag
@@ -257,6 +267,14 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     } catch {}
   }
 
+  // 1f. Show-anchored Navidrome playlist(s) — the operator's explicit per-show
+  // curation. In strict mode this is the show's entire universe (the final pool
+  // is hard-filtered to its ids below); in soft mode it's just the dominant
+  // source, with the discovery sources contributing a (narrowed) minority.
+  if (hasPlaylist) {
+    add('show-playlist', sampleWithRecentFallback(shuffle(playlistPool!.tracks), recentIds, strictPlaylist ? CAP_SHOW_PLAYLIST_STRICT : CAP_SHOW_PLAYLIST));
+  }
+
   // 2. Mood-tagged library (LLM-built tags, may be sparse).
   if (mood) {
     const moodHits = shuffle(lean(preferEnergy(library.songsByMood(mood), showFilter?.energy)));
@@ -347,6 +365,19 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     } catch {}
   }
 
+  // Strict playlist: the playlist union is the show's whole universe, so drop
+  // every off-playlist candidate (the discovery sources above) before ranking.
+  // The dedicated show-playlist source guarantees in-playlist tracks are here,
+  // so this is normally a clean filter; never-starve to the unfiltered pool only
+  // if NOT ONE playlist track survived (a true dead-air guard). Recency / no-
+  // repeat still apply below — they relax within the filtered set as usual.
+  let selectionPool = pool;
+  let playlistInfo: { names: string[]; matched: number; total: number } | null = null;
+  if (strictPlaylist) {
+    const inPl = pool.filter((t: any) => t?.id && playlistPool!.ids.has(t.id));
+    if (inPl.length) selectionPool = inPl;
+  }
+
   // De-dup by id, cap per artist so one name can't dominate the pool (the LLM
   // can only rotate artists across what it's handed), shuffle, cap.
   const MAX_PER_ARTIST = 3;
@@ -362,7 +393,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
   // current track's own analysis when no run is active.
   const curAnalysis = rankTarget
     || (currentTrack?.id ? analysisFor(currentTrack) : { bpm: null, key: null });
-  const final = filterPickerCandidates(softRankByCompat(pool, curAnalysis), {
+  const final = filterPickerCandidates(softRankByCompat(selectionPool, curAnalysis), {
     recentIds,
     recentArtists,
     hardRecentIds,
@@ -386,7 +417,18 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     };
   }
 
-  return { candidates: final, sources, strictInfo };
+  // Playlist-anchor diagnostics for the caller's log: how much of the final pool
+  // is actually in-playlist. In strict mode this is the never-starve audit; in
+  // soft mode it shows how strongly the anchor dominated.
+  if (hasPlaylist) {
+    playlistInfo = {
+      names: playlistPool!.names,
+      matched: final.filter((t: any) => t?.id && playlistPool!.ids.has(t.id)).length,
+      total: final.length,
+    };
+  }
+
+  return { candidates: final, sources, strictInfo, playlistInfo };
 }
 
 function summariseRecent(queue: any) {
@@ -429,7 +471,11 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   const showFilter: ShowFilter = activeShow
     ? { genre: activeShow.genre, fromYear: activeShow.fromYear, toYear: activeShow.toYear, energy: activeShow.energy, strict: activeShow.genreStrict }
     : null;
-  const { candidates, sources, strictInfo } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack, rankTarget, audioWaypoint, showFilter, hardRecentIds, hardRecentKeys);
+  // Resolve the show's anchored Navidrome playlist(s), if any, into a deduped
+  // track pool. Null when the show pins none (the common case → pool unchanged).
+  const playlistPool = activeShow ? await resolveShowPlaylistPool(activeShow) : null;
+  const playlistStrict = !!activeShow?.playlistStrict;
+  const { candidates, sources, strictInfo, playlistInfo } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack, rankTarget, audioWaypoint, showFilter, hardRecentIds, hardRecentKeys, playlistPool, playlistStrict);
 
   if (candidates.length === 0) {
     queue.log('picker', 'no candidates available, skipping LLM pick');
@@ -454,6 +500,17 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
       queue.log('picker', `strict genre ${strictInfo.resolved}: ${strictInfo.matched}/${strictInfo.total} in-genre (off-genre allowed as fallback)`);
     } else {
       queue.log('picker', `strict genre ${strictInfo.resolved}: ${strictInfo.matched}/${strictInfo.total} in-genre`);
+    }
+  }
+
+  // Playlist-anchor visibility — same idea: surface how much of the pool came
+  // from the show's pinned playlist(s), and whether strict had to never-starve.
+  if (playlistInfo) {
+    const tag = playlistInfo.names.length ? playlistInfo.names.join(', ') : `${activeShow!.playlistIds.length} playlist(s)`;
+    if (playlistStrict && playlistInfo.matched === 0) {
+      queue.log('picker', `strict playlist [${tag}]: 0 in-playlist candidates — falling back to keep the stream alive`);
+    } else {
+      queue.log('picker', `playlist [${tag}]: ${playlistInfo.matched}/${playlistInfo.total} in-playlist${playlistStrict ? ' (strict)' : ''}`);
     }
   }
 

--- a/controller/src/music/show-playlist.ts
+++ b/controller/src/music/show-playlist.ts
@@ -1,0 +1,81 @@
+// Show → Navidrome playlist anchor resolver.
+//
+// A show can pin one or more Navidrome playlists (settings show.playlistIds);
+// the union of their tracks becomes the show's candidate pool. This module
+// turns that id list into a deduped track pool, shared by all three consumers:
+// the pool picker (music/picker.ts), the session DJ agent's tools
+// (broadcast/dj-agent.ts), and the LLM-free fallback (broadcast/scheduler.ts).
+//
+// subsonic.getPlaylist already rejects station-archive entries, so there's no
+// extra archive filtering here — the merge is purely union + dedupe by id.
+
+import * as subsonic from './subsonic.js';
+
+export type PlaylistPool = {
+  ids: Set<string>; // every track id in the union — the strict lock set
+  tracks: any[];     // deduped Subsonic song objects
+  names: string[];   // resolved playlist names, for logging / debug
+};
+
+// Pure: flatten a list of playlist track-lists into one deduped array, keeping
+// the first occurrence of each id and dropping entries without an id. The
+// unit-test seam (scripts/show-playlist.test.ts) — no Subsonic, no I/O.
+export function mergePlaylistTracks(lists: any[][]): any[] {
+  const seen = new Set<string>();
+  const out: any[] = [];
+  for (const list of lists) {
+    for (const t of list || []) {
+      const id = t?.id;
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      out.push(t);
+    }
+  }
+  return out;
+}
+
+// TTL cache so a pick / refresh doesn't re-walk every playlist. Same 30-min
+// horizon the pool picker uses for its other Subsonic sources; a playlist edited
+// in Navidrome shows up within a refresh cycle.
+const CACHE_TTL_MS = 30 * 60 * 1000;
+const cache = new Map<string, { val: any[]; at: number }>();
+
+async function memoFetch(key: string, fn: () => Promise<any[]>): Promise<any[]> {
+  const hit = cache.get(key);
+  if (hit && Date.now() - hit.at < CACHE_TTL_MS) return hit.val;
+  const val = await fn();
+  cache.set(key, { val, at: Date.now() });
+  return val;
+}
+
+// Resolve a show's anchored playlists into a deduped track pool. Returns null
+// when the show pins no playlists (the common case → callers behave as today).
+// A missing / deleted / empty playlist id contributes nothing rather than
+// throwing, so a stale anchor degrades to the show's other steering (or the
+// full library) instead of stranding the stream.
+export async function resolveShowPlaylistPool(show: any): Promise<PlaylistPool | null> {
+  const ids = Array.isArray(show?.playlistIds) ? show.playlistIds.filter(Boolean) : [];
+  if (!ids.length) return null;
+
+  // One index fetch (memoised) to map ids → names for the log line; failures
+  // here just drop the names, never the tracks.
+  let index: any[] = [];
+  try {
+    index = await memoFetch('playlists-index', () => subsonic.getPlaylists());
+  } catch {}
+
+  const lists: any[][] = [];
+  const names: string[] = [];
+  for (const id of ids) {
+    try {
+      const songs = await memoFetch(`playlist:${id}`, () => subsonic.getPlaylist(id));
+      lists.push(songs || []);
+      const meta = index.find((p: any) => p.id === id);
+      if (meta?.name) names.push(meta.name);
+    } catch {}
+  }
+
+  const tracks = mergePlaylistTracks(lists);
+  if (!tracks.length) return null;
+  return { ids: new Set<string>(tracks.map((t: any) => t.id)), tracks, names };
+}

--- a/controller/src/routes/dj.ts
+++ b/controller/src/routes/dj.ts
@@ -312,6 +312,25 @@ router.get('/dj/search', requireAdmin, async (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
+// GET /dj/playlists — the operator's Navidrome playlists, for the show editor's
+// playlist-anchor multi-select. id + name + songCount is all the UI needs.
+// ---------------------------------------------------------------------------
+router.get('/dj/playlists', requireAdmin, async (_req, res) => {
+  try {
+    const playlists = await subsonic.getPlaylists();
+    const results = (Array.isArray(playlists) ? playlists : []).map((p: any) => ({
+      id: p.id,
+      name: p.name,
+      songCount: p.songCount ?? null,
+    }));
+    res.json({ results });
+  } catch (err) {
+    queue.log('error', `/dj/playlists failed: ${err.message}`);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // GET /dj/recent — most recently added tracks, for the manual queue UI.
 // Navidrome only sorts albums by recency, so we expand the newest albums into
 // their songs and flatten. Results are queue-ready /dj/search-shaped objects.

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -482,8 +482,29 @@ const SKILL_SLUG_RE = /^[a-z0-9-]{1,40}$/;
 
 const PERSONA_LIMIT = 12;
 const SHOWS_LIMIT = 64;
+const PLAYLISTS_PER_SHOW = 10;
 const SKILLS_PER_PERSONA_LIMIT = 20;
 const WEBHOOKS_LIMIT = 16;
+
+// A show can anchor to one or more Navidrome playlists: the playlist union
+// becomes the show's candidate pool. Stored as Subsonic playlist ids; deduped,
+// trimmed, capped. Never validated against the live Navidrome here (offline
+// validation, same as `genre` free-text) — an id that no longer exists simply
+// contributes nothing at pick time (never-starve). Empty = no anchor.
+function coercePlaylistIds(raw: any): string[] {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of raw) {
+    if (typeof v !== 'string') continue;
+    const id = v.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+    if (out.length >= PLAYLISTS_PER_SHOW) break;
+  }
+  return out;
+}
 
 // Event names the outbound webhook fan-out can subscribe to. Kept in sync
 // with broadcast/webhooks.ts WEBHOOK_EVENTS — duplicated here so settings.ts
@@ -1123,6 +1144,12 @@ function normalizeShows(raw: any, personaIds: string[]) {
     // maxTrackSeconds; 0 = unlimited (opt this show back out of the cap so a
     // long-form mix show can air hour-long sets); >0 = this show's own cap.
     const maxTrackSeconds = coerceMaxTrackSeconds(rawMaxTrackSec(item), true);
+    // Optional Navidrome playlist anchor — the union of these playlists becomes
+    // the show's candidate pool. playlistStrict (default off) makes the playlist
+    // the show's ENTIRE universe; soft just lets it dominate. Both default empty
+    // so existing shows are byte-for-byte unchanged.
+    const playlistIds = coercePlaylistIds(item.playlistIds);
+    const playlistStrict = item.playlistStrict === true;
     out.push({
       id,
       name,
@@ -1136,6 +1163,8 @@ function normalizeShows(raw: any, personaIds: string[]) {
       energy,
       genreStrict,
       maxTrackSeconds,
+      playlistIds,
+      playlistStrict,
     });
     if (out.length >= SHOWS_LIMIT) break;
   }
@@ -1889,10 +1918,27 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
       }
       maxTrackSeconds = n;
     }
+    // Optional Navidrome playlist anchor. Shape-checked only (array of strings,
+    // capped) — ids are resolved against the live Navidrome at pick time, never
+    // here, so a stale id is tolerated. playlistStrict is a plain boolean.
+    let playlistIds: string[] = [];
+    if (item.playlistIds !== undefined && item.playlistIds !== null) {
+      if (!Array.isArray(item.playlistIds)) {
+        throw new Error(`shows[${i}].playlistIds must be an array of strings`);
+      }
+      if (item.playlistIds.length > PLAYLISTS_PER_SHOW) {
+        throw new Error(`shows[${i}].playlistIds must have at most ${PLAYLISTS_PER_SHOW} entries`);
+      }
+      for (const v of item.playlistIds) {
+        if (typeof v !== 'string') throw new Error(`shows[${i}].playlistIds entries must be strings`);
+      }
+      playlistIds = coercePlaylistIds(item.playlistIds);
+    }
+    const playlistStrict = item.playlistStrict === true;
     let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('s_');
     if (seen.has(id)) id = mintId('s_');
     seen.add(id);
-    return { id, name, topic, personaId: item.personaId, mood: item.mood, themeId, genre, fromYear, toYear, energy, genreStrict, maxTrackSeconds };
+    return { id, name, topic, personaId: item.personaId, mood: item.mood, themeId, genre, fromYear, toYear, energy, genreStrict, maxTrackSeconds, playlistIds, playlistStrict };
   });
 }
 
@@ -2647,6 +2693,11 @@ export function resolveActiveShow(date = new Date(), s = get()) {
     // Per-show track-length cap override (seconds). null = inherit the station
     // default; 0 = unlimited; >0 = own cap. See effectiveMaxTrackSec().
     maxTrackSeconds: show.maxTrackSeconds != null ? show.maxTrackSeconds : null,
+    // Navidrome playlist anchor: the union of these playlists becomes the show's
+    // candidate pool (music/show-playlist.ts). playlistStrict makes it the show's
+    // entire universe; soft just lets it dominate. Empty array = no anchor.
+    playlistIds: Array.isArray(show.playlistIds) ? show.playlistIds.filter((v: any) => typeof v === 'string') : [],
+    playlistStrict: show.playlistStrict === true,
     // Empty string means "fall back to the station-wide default". The route
     // layer is responsible for resolving an empty/stale id against the live
     // theme registry; we just surface what the show declares.

--- a/docs/superpowers/specs/2026-06-30-show-playlist-anchor-design.md
+++ b/docs/superpowers/specs/2026-06-30-show-playlist-anchor-design.md
@@ -1,0 +1,171 @@
+# Anchor shows to Navidrome playlists
+
+**Status:** Design — pending review
+**Date:** 2026-06-30
+
+## Summary
+
+Let an operator bind a scheduled **show** to one or more **Navidrome playlists**. While
+that show is on air, the AI DJ draws its tracks from the *union* of those playlists,
+sequencing and talking over them exactly as it does today. A per-show `playlistStrict`
+flag chooses between two behaviours:
+
+- **Strict** — the playlist union is the show's entire song universe.
+- **Soft** — the playlist union dominates the candidate pool, but the existing
+  genre/era/mood/similarity sources still contribute a minority for variety.
+
+This gives the operator deliberate, hand-curated control over a show's song universe
+without giving up the AI-DJ feel (smart sequencing, links, persona, session continuity).
+
+It replaces today's only playlist hook, which is accidental: the pool picker and
+seed-selector currently pull in any playlist whose *name happens to contain the current
+mood string* (`chill` → a playlist called "chill"). That stays as generic fallback
+behaviour for shows with no explicit `playlistIds`.
+
+## Goals
+
+- Deliberate operator control over a show's song universe via Navidrome playlists.
+- Keep the AI DJ in charge of sequencing and narration.
+- Multiple playlists per show, unioned with equal weight.
+- Works across **both** pickers (dj-agent and pool picker) **and** the LLM-free
+  `auto.m3u` fallback, so the anchor holds even when the LLM is unavailable.
+- Fully backward compatible: a show without `playlistIds` behaves byte-for-byte as today.
+
+## Non-goals (this iteration)
+
+- **Fixed rundown / play-in-order mode** (the "traditional radio show" option). Anchoring
+  always lets the AI sequence; a deterministic in-order playthrough is a separate feature.
+- **Per-playlist weighting** (e.g. "70 % from A, 30 % from B"). Union, equal weight only.
+- **Listener-facing playlist browsing / requesting.**
+- **A "now playing from playlist X" badge** in the listener/booth UI. Possible future nicety.
+
+## Decisions baked in (flagged for review)
+
+1. **Listener requests are exempt from the playlist lock.** A `/request` can pull any
+   track in the library, even during a strict playlist show. This mirrors the existing
+   `genreLock` convention in `picker-tools.ts` ("Deliberately NOT set on the request
+   path: an explicit listener ask wins").
+2. **Strict shows honor the playlist in the LLM-free fallback.** `refreshAutoPlaylist`
+   seeds `auto.m3u` from the playlist union for a strict show, so when Liquidsoap coasts
+   (LLM down, budget-hard, or zero listeners) it still plays the show's playlist.
+
+## Data model
+
+Extend the show schema in `controller/src/settings.ts` (`validateShowsStrict`, the object
+returned at the end of the per-show map; shows live in `schedule.json`):
+
+| Field            | Type       | Default | Notes |
+|------------------|------------|---------|-------|
+| `playlistIds`    | `string[]` | `[]`    | Navidrome playlist ids. Validate shape only — array of non-empty strings, deduped, capped (≤ 10). **Not** checked against the live Navidrome (offline validation, same as `genre` free-text). |
+| `playlistStrict` | `boolean`  | `false` | Only meaningful when `playlistIds` is non-empty. |
+
+Migration: absent → `[]` / `false`. No `schedule.json` rewrite required; defaults are
+applied on load, so existing shows are unchanged.
+
+## Resolving the playlist universe
+
+New helper in the music layer (e.g. `music/show-playlist.ts`):
+
+```
+resolveShowPlaylistPool(show) -> { ids: Set<string>, tracks: Song[], names: string[] }
+```
+
+- For each id in `show.playlistIds`, call `subsonic.getPlaylist(id)` (memoised ~30 min,
+  reusing the picker's `memo` cache key space, e.g. `playlist:<id>`).
+- Union the entries, dedupe by song id, filter out `subsonic.isStationArchive(song)`.
+- Return the id set (for the lock), the track list (for the pool), and playlist names
+  (for logging / debug / future UI).
+- Empty or deleted playlist ids contribute nothing; callers degrade via never-starve.
+
+Keep the **merge/dedupe/never-starve selection** logic in a **pure function** so it can be
+unit-tested without Navidrome (see Testing).
+
+## Picker wiring
+
+Both pickers already enforce hard constraints via the `genreLock` / `eraLock` pattern.
+Playlist anchoring follows the same shape.
+
+### Pool picker (`music/picker.ts`)
+
+`buildCandidates(...)` gains a `playlistPool` argument (`{ ids, tracks }`).
+
+- **Strict:** candidate pool = playlist tracks only. Recency/dedup/`rankTarget`
+  (bpm/key sequencing) still apply. If the show also sets genre/era/energy, those
+  *narrow within* the playlist (`preferGenre` / `preferEra`, never-starve). If the
+  playlist union can't supply a non-recent track, never-starve to the normal show pool.
+- **Soft:** add the playlist tracks as a **dominant source** (large cap) alongside the
+  existing seven sources, which become the minority. Reuse the existing
+  `sampleWithRecentFallback` / cap machinery.
+
+### DJ agent (`llm/internal/tools/picker-tools.ts` + `broadcast/dj-agent.ts`)
+
+`buildPickerTools(...)` gains `playlistLock?: Set<string>` (the union id set), used **only
+in strict mode**:
+
+- In `collect()`, intersect each tool's candidate list with `playlistLock` **before**
+  recency + cap, never-starve to the full list — byte-for-byte the same treatment
+  `genreLock`/`eraLock` already get a few lines above. The agent keeps every discovery
+  tool (`similarSongs`, `searchLibrary`, `tracksByMood`, …) but can only ever *surface*
+  playlist tracks, so it cannot pick outside the set.
+
+For **soft** mode (no lock): register a new `showPlaylistTracks` tool that returns a
+sample of the union, and add a prompt line instructing the agent to strongly prefer it
+while allowing the occasional step outside for flow.
+
+`broadcast/dj-agent.ts` resolves the active show's playlist pool right where it already
+derives `genreLock` / `eraLock` (`runTrackEvent`, ~lines 291–295) and passes
+`playlistLock` (strict) or wires the soft tool.
+
+**Request path** (`djAgentRequest` / `/request`): `playlistLock` is **not** set — decision
+#1 above. An explicit listener ask escapes the anchor.
+
+## LLM-free fallback (`auto.m3u`)
+
+`broadcast/scheduler.ts` (`refreshAutoPlaylist`) and `music/seed-selector.ts`:
+
+- When the active show has `playlistIds`, seed `auto.m3u` from the playlist union:
+  - **Strict:** pool = playlist union (decision #2 — coasting honors the playlist).
+  - **Soft:** playlist union as the dominant seed; the rest of the show-narrowed fill is
+    the minority.
+- This **overrides** the generic mood-name-matching in `seed-selector.ts` *for that show*.
+  The name-match path stays intact for shows with no explicit `playlistIds`.
+
+## Admin API + UI
+
+- **New route** `GET /dj/playlists` (behind `requireAdmin`, in `routes/dj.ts`):
+  `subsonic.getPlaylists()` mapped to `[{ id, name, songCount }]`. Populates the show
+  editor multi-select. (`getPlaylists` exists but is currently exposed nowhere.)
+- **`web/components/admin/ShowsPanel.tsx`:** add a playlist multi-select and a
+  "Playlist only (strict)" checkbox (shown only when ≥ 1 playlist is selected), beside
+  the existing genre/era/energy controls. Update show types in `web/lib/types.ts` and
+  `web/components/admin/personas/types.ts`.
+- The existing show-save PUT path carries `playlistIds` / `playlistStrict` through with
+  no new endpoint.
+
+## Edge cases
+
+- **Deleted / empty playlist ids** → empty union → never-starve to the show's other
+  filters / full library; log a warning. Never hard-fail the show.
+- **Playlist edited in Navidrome mid-show** → reflected after the ~30 min cache TTL or the
+  next auto-playlist refresh. Acceptable.
+- **Very large playlist** → sampled/capped like every other source.
+- **`playlistStrict` + `genreStrict` both set** → intersection, never-starve in priority
+  order playlist → genre → era. Documented precedence; degrades to off-target rather than
+  dead air.
+
+## Testing / verification
+
+- No test runner; the merge gate is lint (`eslint . && tsc --noEmit`) for both
+  `controller/` and `web/`.
+- **Pure-logic unit seam:** put the union / dedupe / never-starve pool-merge in a pure
+  helper and pin it with a unit test alongside the existing pure tests
+  (`scripts/llm-pure.test.ts`, `npm run test:llm`) or an equivalent small harness.
+- **Manual smoke (dev stack):** create a show, anchor it to a playlist, schedule it to
+  "now"; confirm via `/admin/debug` pick log that strict picks stay inside the playlist
+  and soft picks wander minimally; confirm a `/request` still escapes; force budget-hard
+  (or stop the LLM) and confirm `auto.m3u` plays the playlist.
+
+## Rollout
+
+- Backward compatible — shows without `playlistIds` are unchanged; no data migration.
+- No compose / `.env` changes, so **no CLI asset re-embed** is needed.

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -75,6 +75,13 @@ interface Show {
    *  0 = unlimited (opt this show out of the cap so it can air long mixes);
    *  >0 = this show's own cap. */
   maxTrackSeconds: number | null;
+  /** Navidrome playlist anchor — the union of these playlists becomes the show's
+   *  candidate pool. Empty = no anchor (behaves as before). */
+  playlistIds: string[];
+  /** When true (and ≥1 playlist is pinned) the playlist is the show's ENTIRE
+   *  universe; off-playlist tracks only play as a never-starve fallback. When
+   *  false, the playlist just dominates the pool. Defaults off. */
+  playlistStrict: boolean;
 }
 
 // Decade presets for the era dropdown → fromYear/toYear. 'any' clears the window.
@@ -188,10 +195,12 @@ function NowCard({ label, accent, slotHour, show, color, personaLabel }: NowCard
 // Compact " · genre · 80s · high" suffix for the show summary lines, omitting
 // whatever the show doesn't pin. A strict genre is flagged inline so the hard
 // lock is visible at a glance.
-function showFilterSummary(s: { genre: string; fromYear: number | null; toYear: number | null; energy: string; genreStrict?: boolean; maxTrackSeconds?: number | null }): string {
+function showFilterSummary(s: { genre: string; fromYear: number | null; toYear: number | null; energy: string; genreStrict?: boolean; maxTrackSeconds?: number | null; playlistIds?: string[]; playlistStrict?: boolean }): string {
   const genre = s.genre ? (s.genreStrict ? `${s.genre} (strict)` : s.genre) : '';
   const len = s.maxTrackSeconds == null ? '' : s.maxTrackSeconds === 0 ? 'any length' : `≤${s.maxTrackSeconds}s`;
-  const bits = [genre, decadeLabelOf(s), s.energy, len].filter(Boolean);
+  const nPl = s.playlistIds?.length ?? 0;
+  const playlist = nPl ? `${nPl} playlist${nPl > 1 ? 's' : ''}${s.playlistStrict ? ' (strict)' : ''}` : '';
+  const bits = [genre, decadeLabelOf(s), s.energy, len, playlist].filter(Boolean);
   return bits.length ? ` · ${bits.join(' · ')}` : '';
 }
 
@@ -248,6 +257,9 @@ export default function ShowsPanel() {
   // Library genres for the show genre autocomplete. Admin-gated endpoint, so it
   // runs after sign-in; failures are silent (the field still accepts free text).
   const [genres, setGenres] = useState<string[]>([]);
+  // Navidrome playlists for the per-show playlist-anchor picker. Admin-gated;
+  // failures are silent (the picker just shows no options to choose from).
+  const [playlists, setPlaylists] = useState<{ id: string; name: string; songCount: number | null }[]>([]);
 
   // Drag-paint stroke: { active, value } — value is the showId/null painted
   // for the whole stroke, decided on mousedown so a drag doesn't flicker.
@@ -321,6 +333,8 @@ export default function ShowsPanel() {
           energy: s.energy ?? '',
           genreStrict: s.genreStrict ?? false,
           maxTrackSeconds: s.maxTrackSeconds ?? null,
+          playlistIds: Array.isArray(s.playlistIds) ? s.playlistIds : [],
+          playlistStrict: s.playlistStrict ?? false,
         }));
         setForm({ shows, schedule: week });
         // Arm the first valid show as the brush so the grid is paintable at once.
@@ -364,6 +378,21 @@ export default function ShowsPanel() {
     return () => { cancelled = true; };
   }, [hydrated, needsAuth]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Fetch Navidrome playlists once for the show playlist-anchor picker (admin-gated).
+  useEffect(() => {
+    if (!hydrated || needsAuth) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await adminFetch('/dj/playlists');
+        if (!r.ok || cancelled) return;
+        const j = (await r.json()) as { results?: { id: string; name: string; songCount: number | null }[] };
+        if (Array.isArray(j.results)) setPlaylists(j.results);
+      } catch {}
+    })();
+    return () => { cancelled = true; };
+  }, [hydrated, needsAuth]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const personas: Persona[] = data?.values?.personas || [];
   const moods: string[] = data?.tts?.moods || [];
   const apiBase = (process.env.NEXT_PUBLIC_API_URL as string | undefined) || '/api';
@@ -400,6 +429,7 @@ export default function ShowsPanel() {
           personaId: personas[0]?.id || '', mood: moods[0] || '',
           themeId: '', genre: '', fromYear: null, toYear: null, energy: '',
           genreStrict: false, maxTrackSeconds: null,
+          playlistIds: [], playlistStrict: false,
         }],
       };
     });
@@ -532,6 +562,9 @@ export default function ShowsPanel() {
             genre: s.genre.trim(), fromYear: s.fromYear, toYear: s.toYear, energy: s.energy || '',
             genreStrict: !!s.genre.trim() && s.genreStrict,
             maxTrackSeconds: s.maxTrackSeconds,
+            playlistIds: s.playlistIds || [],
+            // Strict only means something with at least one playlist pinned.
+            playlistStrict: (s.playlistIds?.length ?? 0) > 0 && s.playlistStrict,
           })),
           schedule: form.schedule,
         }),
@@ -778,6 +811,7 @@ export default function ShowsPanel() {
           themes={themes}
           activeThemeId={activeThemeId}
           genres={genres}
+          playlists={playlists}
           apiBase={apiBase}
           adminFetch={adminFetch}
           minTrackSeconds={data?.values?.minTrackSeconds}
@@ -846,6 +880,7 @@ interface ShowEditorProps {
   themes: ThemeOption[];
   activeThemeId: string;
   genres: string[];
+  playlists: { id: string; name: string; songCount: number | null }[];
   apiBase: string;
   adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
   minTrackSeconds?: number;
@@ -861,7 +896,7 @@ interface ShowEditorProps {
 }
 
 function ShowEditor({
-  show, editorRef, personas, moods, themes, activeThemeId, genres, apiBase,
+  show, editorRef, personas, moods, themes, activeThemeId, genres, playlists, apiBase,
   adminFetch, minTrackSeconds, allShowsOk, canSave, busy,
   update, onSave, onClose, onRemove,
 }: ShowEditorProps) {
@@ -1028,6 +1063,69 @@ function ShowEditor({
             band, or any mix. The DJ leans toward these but can break them for
             flow; leave blank to let the topic and mood drive selection.
           </span>
+
+          <Field>
+            <Label>playlist anchor</Label>
+            <span className="field-hint">
+              Pin one or more Navidrome playlists: their combined tracks become
+              this show&apos;s pool. The AI DJ still sequences and talks over
+              them. Pick none to let genre/era/mood drive selection (up to 10).
+            </span>
+            {playlists.length === 0 ? (
+              <span className="field-hint opacity-60">
+                No Navidrome playlists found yet — create some in Navidrome and
+                reopen this panel.
+              </span>
+            ) : (
+              <div className="grid max-h-44 gap-1 overflow-y-auto border border-ink bg-[var(--ink-softer)] p-2">
+                {playlists.map(pl => {
+                  const checked = show.playlistIds.includes(pl.id);
+                  const atCap = !checked && show.playlistIds.length >= 10;
+                  return (
+                    <label
+                      key={pl.id}
+                      className={`flex items-center gap-2 text-sm ${atCap ? 'opacity-40' : 'cursor-pointer'}`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        disabled={atCap}
+                        onChange={() => update({
+                          playlistIds: checked
+                            ? show.playlistIds.filter(id => id !== pl.id)
+                            : [...show.playlistIds, pl.id],
+                        })}
+                      />
+                      <span className="truncate">{pl.name}</span>
+                      {pl.songCount != null && (
+                        <span className="field-hint">({pl.songCount})</span>
+                      )}
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+          </Field>
+
+          {show.playlistIds.length > 0 && (
+            <div className="flex items-start gap-3">
+              <div className="pt-0.5">
+                <Toggle
+                  on={show.playlistStrict}
+                  onClick={() => update({ playlistStrict: !show.playlistStrict })}
+                />
+              </div>
+              <div className="grid gap-0.5">
+                <Label>Playlist only (strict)</Label>
+                <span className="field-hint">
+                  Play ONLY tracks from the pinned playlist(s) — off-playlist
+                  tracks air only as a last resort to avoid silence. Off: the
+                  playlist dominates but the DJ can still wander for variety.
+                  Listener requests are always allowed through, either way.
+                </span>
+              </div>
+            </div>
+          )}
 
           <Field>
             <Label htmlFor="show-topic">topic (fed to the DJ as the show theme)</Label>


### PR DESCRIPTION
## What

A show can now be anchored to one or more **Navidrome playlists**. Their deduped
union becomes the show's candidate pool, and the AI DJ still sequences and talks
over the tracks. A per-show **`playlistStrict`** flag chooses between:

- **Strict** — the playlist union is the show's *entire* universe.
- **Soft** — the playlist union *dominates* the pool, but genre/era/mood/similarity
  sources still contribute a minority for variety.

This replaces the only previous playlist hook (an accidental name-match: a playlist
called "chill" got pulled in when the mood was `chill`), which stays as generic
behaviour for shows with no explicit `playlistIds`.

## How

Reuses the existing `genreLock` constraint pattern across both pickers + the
LLM-free fallback:

- **Schema** (`settings.ts`) — `playlistIds: string[]` + `playlistStrict` on the show
  schema (lenient load + strict save validation, capped at 10), surfaced via
  `resolveActiveShow`. Default empty = today's behaviour, byte-for-byte unchanged.
- **Resolver** (`music/show-playlist.ts`) — memoised union of the playlists, deduped
  by id, with a pure `mergePlaylistTracks` helper (unit-tested). Shared by all
  three consumers.
- **Pool picker** — dedicated dominant `show-playlist` source; strict adds an
  end-filter to the playlist ids with a never-starve dead-air guard.
- **DJ agent** — `playlistLock` hard-intersects *every* discovery tool's results
  (strict), so the agent keeps all its tools but can only surface playlist tracks;
  plus a `showPlaylistTracks` tool + prompt nudge. Soft = strong preference, no lock.
- **LLM-free fallback** (`scheduler.ts`) — `auto.m3u` seeds from the playlist union,
  so the coast honours the anchor even with the LLM down / budget-hard / no listeners.
- **Admin** — `GET /dj/playlists` feeds a multi-select + "Playlist only (strict)"
  toggle in `ShowsPanel`.

## Decisions

- **Listener requests stay exempt** from the lock — a request can pull any track,
  even during a strict show (mirrors the `genreLock` "explicit ask wins" rule).
- **Strict shows honour the playlist in fallback** too (not just the live picker).
- **Out of scope** (YAGNI): fixed play-in-order rundown mode, per-playlist weights,
  listener-facing playlist browsing.

## Testing

Verified end-to-end on a dev stack against a real Navidrome (14-track test playlist),
both modes:

| Path | Strict | Soft |
|---|---|---|
| Pool picker | `playlist […]: 14/14 in-playlist (strict)`, pick in-playlist | `12/16 in-playlist` (dominant, not exclusive) |
| DJ agent (live) | consecutive on-air picks all in-playlist after activation | — |
| `auto.m3u` fallback | 14/14 in-playlist, off-playlist sources dropped | — |

Plus: `GET /dj/playlists` works; `POST /settings` round-trips both flags through
validation. `controller` + `web` lint (`eslint . && tsc --noEmit`) pass; new pure
unit test wired into `npm test`.

Note: `docs/superpowers/specs/…-design.md` is the design write-up — drop that commit
on merge if you'd rather not keep it in the tree.
