### PR TITLE
Feat/plex music source

### DIFF
--- a/cli/src/doctor.ts
+++ b/cli/src/doctor.ts
@@ -187,7 +187,7 @@ async function checkController(compose: ComposeStatus): Promise<Finding[]> {
       out.push({
         label: 'setup',
         status: 'fail',
-        detail: 'incomplete — Navidrome + LLM not configured',
+        detail: 'incomplete — music source + LLM not configured',
         hint: `Run \`subwave setup\` or open ${webBaseFor(compose.env)}/onboarding to finish configuration.`,
       });
     } else if (needsSetup === false) {

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -340,6 +340,8 @@ function trackFields(song) {
     album: song.album,
     year: song.year,
     genre: song.genre,
+    path: song.path ?? null,
+    _partKey: song.plexPartKey || song._partKey || null,
   };
 }
 

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -6,7 +6,7 @@ import { writeFile, readFile } from 'node:fs/promises';
 import { existsSync, readFileSync, openSync, readSync, closeSync, statSync } from 'node:fs';
 import { stat, rename } from 'node:fs/promises';
 import { config } from '../config.js';
-import * as subsonic from '../music/subsonic.js';
+import { getSource } from '../music/source/index.js';
 import * as mix from '../music/mix.js';
 import * as library from '../music/library.js';
 import { speak, voiceGainDb } from '../audio/tts.js';
@@ -488,7 +488,7 @@ class Queue {
         // (requestedBy set) stay exempt — a requested long mix plays in full,
         // mirroring the request path's selection-cap exemption in picker-tools.
         const maxDurationSec = item.requestedBy ? null : settings.effectiveMaxTrackSec();
-        const uri = subsonic.getAnnotatedUri(item.track, { maxDurationSec });
+        const uri = getSource().getAnnotatedUri(item.track, { maxDurationSec });
         await writeHandoff(config.liquidsoap.queueFile, uri);
         item.sent = true;
         this.persist();  // record the sent flag — these are now live in dj_queue

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -7,7 +7,7 @@
 import cron from 'node-cron';
 import { writeFile } from 'node:fs/promises';
 import { config } from '../config.js';
-import * as subsonic from '../music/subsonic.js';
+import { getSource } from '../music/source/index.js';
 import * as dj from '../llm/dj.js';
 import * as library from '../music/library.js';
 import * as settings from '../settings.js';
@@ -51,7 +51,7 @@ async function tracksFromAlbums(albums: any[], perAlbum: number, max: number) {
   for (const a of albums) {
     if (out.length >= max) break;
     try {
-      const songs = await subsonic.getAlbum(a.id);
+      const songs = await getSource().getAlbum(a.id);
       out.push(...shuffle(songs).slice(0, perAlbum));
     } catch {}
   }
@@ -102,7 +102,7 @@ async function refreshAutoPlaylistInner() {
   // path (a misspelled / library-absent genre falls back to the normal pool).
   let genreName: string | null = null;
   if (showGenre) {
-    try { genreName = await subsonic.resolveGenreName(showGenre); } catch {}
+    try { genreName = await getSource().resolveGenreName(showGenre); } catch {}
   }
   const strictGenreNorm = strict && genreName ? normGenre(genreName) : null;
   // Strict: hard-drop off-genre tracks from every discovery source (even if that
@@ -152,14 +152,14 @@ async function refreshAutoPlaylistInner() {
   if (narrow) {
     try {
       const collected: any[] = [];
-      collected.push(...await subsonic.getRandomSongs({
+      collected.push(...await getSource().getRandomSongs({
         size: strict ? 60 : 40,
         genre: genreName || undefined,
         fromYear: fromYear ?? undefined,
         toYear: toYear ?? undefined,
       }));
       if (genreName) {
-        const g = await subsonic.getSongsByGenre(genreName, { count: strict ? 100 : 60 });
+        const g = await getSource().getSongsByGenre(genreName, { count: strict ? 100 : 60 });
         const ranged = inYearRange(g, { fromYear, toYear });
         collected.push(...(ranged.length ? ranged : g));
       }
@@ -186,12 +186,12 @@ async function refreshAutoPlaylistInner() {
   // 2. Navidrome playlists whose name matches the mood — operator's hand curation.
   if (mood) {
     try {
-      const playlists = await subsonic.getPlaylists();
+      const playlists = await getSource().getPlaylists();
       const matched = playlists.filter((p: any) => p.name?.toLowerCase().includes(mood.toLowerCase()));
       const tracks: any[] = [];
       for (const pl of matched.slice(0, 2)) {
         try {
-          const songs = await subsonic.getPlaylist(pl.id);
+          const songs = await getSource().getPlaylist(pl.id);
           tracks.push(...songs);
         } catch {}
       }
@@ -203,7 +203,7 @@ async function refreshAutoPlaylistInner() {
 
   // 3. Recently-added albums — surfaces new music without any tagging.
   try {
-    const recentAlbums = await subsonic.getRecentlyAddedAlbums({ size: 8 });
+    const recentAlbums = await getSource().getRecentlyAddedAlbums({ size: 8 });
     const tracks = await tracksFromAlbums(shuffle(recentAlbums).slice(0, 4), 2, RECENT_WEIGHT * 2);
     take('recent', enforce(tracks), nz(RECENT_WEIGHT));
   } catch (err) {
@@ -212,7 +212,7 @@ async function refreshAutoPlaylistInner() {
 
   // 4. Frequent albums — Navidrome's scrobble-backed favourites.
   try {
-    const freqAlbums = await subsonic.getFrequentAlbums({ size: 8 });
+    const freqAlbums = await getSource().getFrequentAlbums({ size: 8 });
     const tracks = await tracksFromAlbums(shuffle(freqAlbums).slice(0, 4), 2, FREQUENT_WEIGHT * 2);
     take('frequent', enforce(tracks), nz(FREQUENT_WEIGHT));
   } catch (err) {
@@ -221,7 +221,7 @@ async function refreshAutoPlaylistInner() {
 
   // 5. Starred — hand-curated.
   try {
-    const starred = shuffle(await subsonic.getStarred());
+    const starred = shuffle(await getSource().getStarred());
     take('starred', enforce(starred), nz(STARRED_WEIGHT));
   } catch (err) {
     queue.log('error', `Starred fetch failed: ${err.message}`);
@@ -235,8 +235,8 @@ async function refreshAutoPlaylistInner() {
   if (pool.length < TARGET_POOL && !strictPlaylist) {
     try {
       const random = narrow
-        ? await subsonic.getRandomSongs({ size: TARGET_POOL, genre: genreName || undefined, fromYear: fromYear ?? undefined, toYear: toYear ?? undefined })
-        : await subsonic.getRandomSongs({ size: TARGET_POOL });
+        ? await getSource().getRandomSongs({ size: TARGET_POOL, genre: genreName || undefined, fromYear: fromYear ?? undefined, toYear: toYear ?? undefined })
+        : await getSource().getRandomSongs({ size: TARGET_POOL });
       take('random', shuffle(random), TARGET_POOL);
     } catch (err) {
       queue.log('error', `Random fetch failed: ${err.message}`);
@@ -246,7 +246,7 @@ async function refreshAutoPlaylistInner() {
     // skip this — better a short, looping in-genre playlist than off-genre filler.
     if (narrow && !strict && pool.length < TARGET_POOL) {
       try {
-        take('random', shuffle(await subsonic.getRandomSongs({ size: TARGET_POOL })), TARGET_POOL);
+        take('random', shuffle(await getSource().getRandomSongs({ size: TARGET_POOL })), TARGET_POOL);
       } catch {}
     }
   }
@@ -263,7 +263,7 @@ async function refreshAutoPlaylistInner() {
   // Stamp the station cap on every fallback entry (#447). max-track-length is a
   // pure on-air cue_out cut, not a selection filter, so over-length tracks stay
   // in the pool and simply crossfade out at the cap when the queue runs dry.
-  const lines = ['#EXTM3U', ...pool.map((t: any) => subsonic.getAnnotatedUri(t, { maxDurationSec }))];
+  const lines = ['#EXTM3U', ...pool.map((t: any) => getSource().getAnnotatedUri(t, { maxDurationSec }))];
   await writeFile(config.liquidsoap.autoPlaylist, lines.join('\n'));
 
   // Make the show-scoping visible to the operator (acceptance criteria #629):

--- a/controller/src/broadcast/tagger.ts
+++ b/controller/src/broadcast/tagger.ts
@@ -5,6 +5,7 @@
 import { spawn, ChildProcess } from 'node:child_process';
 import { queue } from './queue.js';
 import { PROGRESS_PREFIX, type TaggerProgress } from '../music/tagger-progress.js';
+import { refresh as refreshCoverage } from '../music/library-coverage.js';
 
 type TaggerState = {
   running: boolean;
@@ -177,6 +178,8 @@ function spawnChild(mode: 'tag' | 'analyze' | 'reconcile', args: string[], detai
     if (activeChild === child) activeChild = null;
     tagger.lastLog.push(`[exit ${signal || code}]`);
     queue.log('scheduler', `${label} finished (${signal ? `signal ${signal}` : `exit ${code}`})`);
+    // Invalidate coverage cache so the UI reflects the new track count immediately.
+    if (code === 0) refreshCoverage();
   });
   queue.log('scheduler', `${label} started${detail ? ` (${detail})` : ''}`);
 }

--- a/controller/src/config.ts
+++ b/controller/src/config.ts
@@ -48,6 +48,10 @@ export const config = {
     apiVersion: '1.16.1',
     clientName: 'sub-wave',
   },
+  plex: {
+    url: process.env.PLEX_URL || '',
+    token: process.env.PLEX_TOKEN || '',
+  },
   ollama: {
     // Default-when-blank server URL + model. The admin Settings UI
     // (`llm.ollamaUrl` / `llm.model`) overrides both — there are no

--- a/controller/src/doctor.ts
+++ b/controller/src/doctor.ts
@@ -14,7 +14,7 @@ import { readFile, readdir, stat } from 'node:fs/promises';
 import { z } from 'zod';
 import { config, STATE_DIR } from './config.js';
 import * as settings from './settings.js';
-import * as subsonic from './music/subsonic.js';
+import { getSource } from './music/source/index.js';
 import * as subsonicLog from './music/subsonic-log.js';
 import * as library from './music/library.js';
 import * as embeddings from './music/embeddings.js';
@@ -260,7 +260,7 @@ async function checkLlm(s: any): Promise<Finding[]> {
 async function checkNavidrome(): Promise<Finding[]> {
   const out: Finding[] = [];
 
-  const p = await subsonic.ping();
+  const p = await getSource().ping();
   out.push({
     label: 'connectivity',
     status: p.ok ? 'ok' : 'fail',

--- a/controller/src/doctor.ts
+++ b/controller/src/doctor.ts
@@ -97,7 +97,7 @@ export async function runDoctor(): Promise<DoctorReport> {
   // Each check swallows its own errors and degrades to a 'skip'/'fail' finding,
   // so one failing subsystem never blanks the whole report.
   sections.push({ name: 'LLM', findings: await safe(() => checkLlm(s)) });
-  sections.push({ name: 'Navidrome & library', findings: await safe(checkMusicSource) });
+  sections.push({ name: 'Music source & library', findings: await safe(checkMusicSource) });
   sections.push({ name: 'Broadcast', findings: await safe(checkBroadcast) });
   sections.push({ name: 'Voice (TTS)', findings: await safe(() => checkTts(s)) });
   sections.push({ name: 'Capabilities', findings: await safe(() => checkCapabilities(s)) });
@@ -569,7 +569,7 @@ async function checkSetup(): Promise<Finding[]> {
     out.push({
       label: 'configuration',
       status: st.needsSetup ? 'fail' : 'ok',
-      detail: st.needsSetup ? 'incomplete — Navidrome not configured' : `complete (${st.navidromeSource})`,
+      detail: st.needsSetup ? 'incomplete — music source not configured' : `complete (${st.navidromeSource})`,
       hint: st.needsSetup ? 'Finish the wizard at /onboarding (or run `subwave setup`).' : undefined,
     });
   } catch (err: any) {
@@ -624,7 +624,7 @@ const REVIEW_SYSTEM = [
   'muddy signal, and total confidence. You talk like a producer in the booth — a little swagger,',
   'the odd studio metaphor ("the low end\'s clean", "that channel\'s clipping", "tighten the mix")',
   '— but every call you make is technically correct. You review an automated health report for a',
-  'personal internet radio station (Navidrome library, an LLM DJ, Liquidsoap mixer, Icecast stream,',
+  'personal internet radio station (music library — Navidrome or Plex — an LLM DJ, Liquidsoap mixer, Icecast stream,',
   'local/cloud TTS).',
   'A knowledge base about how SUB/WAVE works is provided below — USE IT. Ground every recommendation',
   'in it, and tailor model / picker / chain-of-thought / agent-deadline / TTS-engine advice to the',
@@ -633,7 +633,7 @@ const REVIEW_SYSTEM = [
   'Interpret the findings for a non-expert operator: what is fine, what needs attention, what to do',
   'first. Be concrete and brief — keep the swagger to a light seasoning, no fluff, don\'t restate',
   'every finding. Prioritise anything that takes the station off air or starves the DJ (stream',
-  'offline, Navidrome unreachable, LLM unreachable) above cosmetic warnings. Where it fits, nudge',
+  'offline, music source unreachable, LLM unreachable) above cosmetic warnings. Where it fits, nudge',
   'the operator toward good hygiene like taking a backup. If everything is healthy, say so plainly',
   'and return an empty priorities array.',
 ].join(' ');

--- a/controller/src/doctor.ts
+++ b/controller/src/doctor.ts
@@ -12,7 +12,7 @@
 
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { z } from 'zod';
-import { config, STATE_DIR } from './config.js';
+import { STATE_DIR } from './config.js';
 import * as settings from './settings.js';
 import { getSource } from './music/source/index.js';
 import * as subsonicLog from './music/subsonic-log.js';
@@ -97,7 +97,7 @@ export async function runDoctor(): Promise<DoctorReport> {
   // Each check swallows its own errors and degrades to a 'skip'/'fail' finding,
   // so one failing subsystem never blanks the whole report.
   sections.push({ name: 'LLM', findings: await safe(() => checkLlm(s)) });
-  sections.push({ name: 'Navidrome & library', findings: await safe(checkNavidrome) });
+  sections.push({ name: 'Navidrome & library', findings: await safe(checkMusicSource) });
   sections.push({ name: 'Broadcast', findings: await safe(checkBroadcast) });
   sections.push({ name: 'Voice (TTS)', findings: await safe(() => checkTts(s)) });
   sections.push({ name: 'Capabilities', findings: await safe(() => checkCapabilities(s)) });
@@ -257,17 +257,18 @@ async function checkLlm(s: any): Promise<Finding[]> {
   return out;
 }
 
-async function checkNavidrome(): Promise<Finding[]> {
+async function checkMusicSource(): Promise<Finding[]> {
   const out: Finding[] = [];
 
+  const source = (settings.get() as any).music?.source || 'navidrome';
   const p = await getSource().ping();
   out.push({
     label: 'connectivity',
     status: p.ok ? 'ok' : 'fail',
-    detail: p.ok ? `${config.navidrome.url} · authenticated` : p.reason || 'unreachable',
-    hint: p.ok
-      ? undefined
-      : 'The picker has no music source without Navidrome. Check the URL / username / password in setup, and that Navidrome is up.',
+    detail: p.ok
+      ? `${source} · authenticated`
+      : p.reason || 'unreachable',
+    hint: p.ok ? undefined : `The picker has no music source. Check the ${source} URL and credentials in Settings -> Music.`,
   });
 
   // Recent call error rate across all endpoints.

--- a/controller/src/llm/internal/tools/picker-tools.ts
+++ b/controller/src/llm/internal/tools/picker-tools.ts
@@ -10,7 +10,7 @@
 
 import { tool } from 'ai';
 import { z } from 'zod';
-import * as subsonic from '../../../music/subsonic.js';
+import { getSource } from '../../../music/source/index.js';
 import * as library from '../../../music/library.js';
 import * as embeddings from '../../../music/embeddings.js';
 import { filterPickerCandidates, durationSeconds } from '../../../music/recency.js';
@@ -192,13 +192,13 @@ export function buildPickerTools({
       }),
       execute: async ({ query }) => {
         try {
-          let songs = await subsonic.search(query, { songCount: 25 });
+          let songs = await getSource().search(query, { songCount: 25 });
           // A lexical miss is often just a spelling/transliteration variance —
           // resolve the query as an artist and retry with the library's actual
           // spelling ("Sikandar Kahlon" → the tagged "Sikander Kahlon").
           if (songs.length === 0) {
-            const artist = await subsonic.resolveArtist(query);
-            if (artist) songs = await subsonic.search(artist.name, { songCount: 25 });
+            const artist = await getSource().resolveArtist(query);
+            if (artist) songs = await getSource().search(artist.name, { songCount: 25 });
           }
           const out = collect(songs);
           if (out.length > 0) return out;
@@ -219,7 +219,7 @@ export function buildPickerTools({
       description: 'Find songs similar to a given song id. Pass the currently-playing song id to keep the flow going.',
       inputSchema: z.object({ songId: z.string() }),
       execute: async ({ songId }) => {
-        try { return collect(await subsonic.getSimilarSongs(songId, { count: 20 })); }
+        try { return collect(await getSource().getSimilarSongs(songId, { count: 20 })); }
         catch (err) { return { error: err.message }; }
       },
     }),
@@ -228,7 +228,7 @@ export function buildPickerTools({
       description: 'Top songs for a named artist — good for staying in an artist\'s orbit without repeating a track.',
       inputSchema: z.object({ artist: z.string() }),
       execute: async ({ artist }) => {
-        try { return collect(await subsonic.getTopSongs(artist, { count: 15 })); }
+        try { return collect(await getSource().getTopSongs(artist, { count: 15 })); }
         catch (err) { return { error: err.message }; }
       },
     }),
@@ -240,7 +240,7 @@ export function buildPickerTools({
         // Keep the source list tight (newest ~6 tracks): collect() shuffles, so
         // a wide pool would let the shuffle drop the actual-newest tracks,
         // defeating "latest".
-        try { return collect(await subsonic.getRecentSongsByArtist(artist, { albums: 2, count: 6 })); }
+        try { return collect(await getSource().getRecentSongsByArtist(artist, { albums: 2, count: 6 })); }
         catch (err) { return { error: err.message }; }
       },
     }),
@@ -250,9 +250,9 @@ export function buildPickerTools({
       inputSchema: z.object({ genre: z.string().describe('a genre, language, or country word, e.g. "jazz", "turkish", "punjabi"') }),
       execute: async ({ genre }) => {
         try {
-          const name = await subsonic.resolveGenreName(genre);
+          const name = await getSource().resolveGenreName(genre);
           if (!name) return { error: `no library genre matching "${genre}"` };
-          return collect(await subsonic.getSongsByGenre(name, { count: 50 }));
+          return collect(await getSource().getSongsByGenre(name, { count: 50 }));
         }
         catch (err) { return { error: err.message }; }
       },
@@ -369,10 +369,10 @@ export function buildPickerTools({
       inputSchema: z.object({}),
       execute: async () => {
         try {
-          const albums = await subsonic.getRecentlyAddedAlbums({ size: 8 });
+          const albums = await getSource().getRecentlyAddedAlbums({ size: 8 });
           const out: any[] = [];
           for (const a of albums.slice(0, 5)) {
-            try { out.push(...(await subsonic.getAlbum(a.id)).slice(0, 3)); } catch {}
+            try { out.push(...(await getSource().getAlbum(a.id)).slice(0, 3)); } catch {}
           }
           return collect(out);
         } catch (err) { return { error: err.message }; }
@@ -383,7 +383,7 @@ export function buildPickerTools({
       description: "The operator's starred / favourite songs — always a safe, on-brand pick.",
       inputSchema: z.object({}),
       execute: async () => {
-        try { return collect(await subsonic.getStarred()); }
+        try { return collect(await getSource().getStarred()); }
         catch (err) { return { error: err.message }; }
       },
     }),
@@ -392,7 +392,7 @@ export function buildPickerTools({
       description: 'A random sample of songs from the library — use to break a predictable run.',
       inputSchema: z.object({}),
       execute: async () => {
-        try { return collect(await subsonic.getRandomSongs({ size: 18 })); }
+        try { return collect(await getSource().getRandomSongs({ size: 18 })); }
         catch (err) { return { error: err.message }; }
       },
     }),
@@ -457,14 +457,14 @@ export function buildPickerTools({
             // lands in `seen`. Try "artist title", then a resolved-artist retry
             // (spelling/transliteration), then title-only.
             const q = [guess.artist, guess.title].filter(Boolean).join(' ');
-            let songs = await subsonic.search(q, { songCount: 25 });
+            let songs = await getSource().search(q, { songCount: 25 });
             if (songs.length === 0 && guess.artist) {
-              const a = await subsonic.resolveArtist(guess.artist);
-              if (a) songs = await subsonic.search(`${a.name} ${guess.title}`, { songCount: 25 });
+              const a = await getSource().resolveArtist(guess.artist);
+              if (a) songs = await getSource().search(`${a.name} ${guess.title}`, { songCount: 25 });
             }
-            if (songs.length === 0) songs = await subsonic.search(guess.title, { songCount: 25 });
+            if (songs.length === 0) songs = await getSource().search(guess.title, { songCount: 25 });
             if (songs.length === 0 && guess.keyword && guess.keyword !== guess.title) {
-              songs = await subsonic.search(guess.keyword, { songCount: 25 });
+              songs = await getSource().search(guess.keyword, { songCount: 25 });
             }
             return { identified: guess, candidates: collect(songs) };
           } catch (err) { return { error: err.message }; }

--- a/controller/src/music/analyze-library.ts
+++ b/controller/src/music/analyze-library.ts
@@ -25,13 +25,13 @@
 // The heavy DSP lives in music/analyzer.ts's backend (tts-heavy sidecar or a
 // local librosa venv via ANALYZE_PYTHON). With no backend the pass is a no-op.
 
-import * as subsonic from './subsonic.js';
 import * as db from './library-db.js';
 import * as settings from '../settings.js';
 import * as embeddings from './embeddings.js';
 import { config } from '../config.js';
 import { loadSecretsIntoEnv } from '../setup/secrets.js';
 import { loadSetupConfig } from '../setup/config.js';
+import { getSource } from './source/index.js';
 import { runAnalysisPass } from './analyze.js';
 import * as analyzer from './analyzer.js';
 import { reportProgress } from './tagger-progress.js';
@@ -56,6 +56,10 @@ async function applyWizardOverlay() {
       if (!process.env.NAVIDROME_URL && sc.navidrome.url) config.navidrome.url = sc.navidrome.url;
       if (!process.env.NAVIDROME_USER && sc.navidrome.user) config.navidrome.user = sc.navidrome.user;
       if (!process.env.NAVIDROME_PASS && sc.navidrome.pass) config.navidrome.password = sc.navidrome.pass;
+    }
+    if (sc.plex) {
+      if (!process.env.PLEX_URL && sc.plex.url) config.plex.url = sc.plex.url;
+      if (!process.env.PLEX_TOKEN && sc.plex.token) config.plex.token = sc.plex.token;
     }
   } catch (err: any) {
     console.error('[setup-config] load failed:', err.message);
@@ -90,7 +94,7 @@ async function main() {
     console.log(
       forceWalk
         ? '[analyze] --walk: refreshing track metadata...'
-        : '[analyze] empty catalogue — walking Navidrome...',
+        : '[analyze] empty catalogue — walking music source...',
     );
   } else {
     console.log(
@@ -99,10 +103,10 @@ async function main() {
   }
 
   if (shouldWalk) {
-    reportProgress({ phase: 'walk', label: 'Scanning Navidrome library', done: 0 });
+    reportProgress({ phase: 'walk', label: 'Scanning music library', done: 0 });
     let walked = 0;
     const liveIds = new Set<string>();
-    for await (const song of subsonic.iterateAllSongs()) {
+    for await (const song of getSource().iterateAllSongs()) {
       db.upsertTrackMeta(song.id, {
         title: song.title,
         artist: song.artist,
@@ -110,23 +114,26 @@ async function main() {
         year: song.year,
         genre: song.genre,
         duration: song.duration,
+        path: song.path ?? null,
+        plexPartKey: song._partKey ?? null,
+        plexThumb: song._thumb ?? null,
       });
       liveIds.add(song.id);
       walked += 1;
       if (walked % 500 === 0) {
         console.log(`[analyze] walked ${walked} tracks`);
-        reportProgress({ phase: 'walk', label: 'Scanning Navidrome library', done: walked });
+        reportProgress({ phase: 'walk', label: 'Scanning music library', done: walked });
       }
     }
     console.log(`[analyze] walked ${walked} total tracks`);
 
-    // Reconcile: drop rows for tracks no longer in Navidrome so the analysis
-    // scope reflects the live catalogue, not orphans from past full rescans.
+    // Reconcile: drop rows for tracks no longer in the music source so the
+    // analysis scope reflects the live catalogue, not orphans from past rescans.
     // Guarded on a non-empty walk (a complete, authoritative pass).
     if (walked > 0) {
       const pruned = db.pruneMissingTracks(liveIds);
       if (pruned > 0) {
-        console.log(`[analyze] pruned ${pruned} orphaned tracks no longer in Navidrome`);
+        console.log(`[analyze] pruned ${pruned} orphaned tracks no longer in music source`);
       }
     }
   }

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -16,6 +16,7 @@ import { existsSync, mkdirSync, createWriteStream, readFileSync } from 'node:fs'
 import { pipeline } from 'node:stream/promises';
 import { config } from '../config.js';
 import * as subsonic from './subsonic.js';
+import { getSource } from './source/index.js';
 
 // A structural span over the track, in milliseconds (span shape). Spans
 // are contiguous and cover the analysed window; the first is the intro/leading
@@ -423,7 +424,7 @@ export async function refreshCapabilities(): Promise<void> {
 export async function analyze(songId: string, opts: AnalyzeRequestOpts = {}): Promise<AnalysisResult> {
   const backend = await resolveBackend();
   if (!backend) throw new Error('no analysis backend available');
-  const url = subsonic.getRawStreamUrl(songId);
+  const url = getSource().getRawStreamUrl(songId);
   return backend === 'sidecar' ? analyzeViaSidecar(url, opts) : analyzeViaLocal(url, opts);
 }
 
@@ -463,7 +464,7 @@ function subsonicErrorMessage(body: string): string {
 export async function downloadCapped(songId: string): Promise<string> {
   mkdirSync(ANALYZE_TMP_DIR, { recursive: true });
   const dest = `${ANALYZE_TMP_DIR}/${encodeURIComponent(songId)}.audio`;
-  const url = subsonic.getRawStreamUrl(songId);
+  const url = getSource().getRawStreamUrl(songId);
   const ac = new AbortController();
   const t = setTimeout(() => ac.abort(), config.analyzer.requestTimeoutMs);
   try {

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -15,7 +15,6 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { existsSync, mkdirSync, createWriteStream, readFileSync } from 'node:fs';
 import { pipeline } from 'node:stream/promises';
 import { config } from '../config.js';
-import * as subsonic from './subsonic.js';
 import { getSource } from './source/index.js';
 
 // A structural span over the track, in milliseconds (span shape). Spans

--- a/controller/src/music/lastfm.ts
+++ b/controller/src/music/lastfm.ts
@@ -14,7 +14,7 @@
 // API is generous and the tagger loop is already sequential + per-artist cached).
 
 import * as settings from '../settings.js';
-import * as subsonic from './subsonic.js';
+import { getSource } from './source/index.js';
 
 const TIMEOUT_MS = 5000;
 const LASTFM_API = 'https://ws.audioscrobbler.com/2.0/';
@@ -267,10 +267,11 @@ export async function getArtistTags(
     return getArtistTopTags(artist, { count });
   }
   try {
-    const matches = await subsonic.searchArtists(artist, { artistCount: 1 });
+    const source = getSource();
+    const matches = await source.searchArtists(artist, { artistCount: 1 });
     const artistId = matches?.[0]?.id;
     if (!artistId) return [];
-    const tags = await subsonic.getArtistLastfmTags(artistId, { count });
+    const tags = await source.getArtistLastfmTags(artistId, { count });
     return Array.isArray(tags) ? tags : [];
   } catch {
     return [];

--- a/controller/src/music/lastfm.ts
+++ b/controller/src/music/lastfm.ts
@@ -103,6 +103,151 @@ export async function getArtistTopTags(
   }
 }
 
+// Similar artists for a given artist from Last.fm. Returns up to `count`
+// (default 10) artist name strings. Returns [] on missing key, no coverage, or
+// any request failure — same fire-and-forget contract as getArtistTopTags.
+export async function getSimilarArtists(
+  artist: string,
+  opts: { count?: number } = {},
+): Promise<string[]> {
+  const count = opts.count ?? 10;
+  const apiKey = resolveKey();
+  if (!apiKey || !artist || !artist.trim()) return [];
+
+  const params = new URLSearchParams({
+    method: 'artist.getSimilar',
+    artist,
+    limit: String(count),
+    api_key: apiKey,
+    format: 'json',
+  });
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const r = await fetch(`${LASTFM_API}?${params.toString()}`, {
+      method: 'GET',
+      headers: { 'User-Agent': 'sub-wave/tags' },
+      signal: ctrl.signal,
+    });
+    if (!r.ok) {
+      console.warn(`[lastfm] artist.getSimilar → ${r.status} for "${artist}"`);
+      return [];
+    }
+    const data = (await r.json()) as any;
+    if (data?.error) return [];
+    const raw = data?.similarartists?.artist ?? [];
+    const arr = Array.isArray(raw) ? raw : [raw];
+    return arr
+      .map((a: any) => (typeof a === 'string' ? a : a?.name))
+      .filter((s: any): s is string => typeof s === 'string' && s.trim().length > 0)
+      .map((s: string) => s.trim())
+      .slice(0, count);
+  } catch (err: any) {
+    console.warn(`[lastfm] artist.getSimilar failed for "${artist}": ${err?.message || err}`);
+    return [];
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Top tracks for an artist from Last.fm. Returns up to `count` (default 10)
+// objects with { title, artist }. Returns [] on missing key, no coverage, or
+// any request failure.
+export async function getTopTracks(
+  artist: string,
+  opts: { count?: number } = {},
+): Promise<{ title: string; artist: string }[]> {
+  const count = opts.count ?? 10;
+  const apiKey = resolveKey();
+  if (!apiKey || !artist || !artist.trim()) return [];
+
+  const params = new URLSearchParams({
+    method: 'artist.getTopTracks',
+    artist,
+    limit: String(count),
+    api_key: apiKey,
+    format: 'json',
+  });
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const r = await fetch(`${LASTFM_API}?${params.toString()}`, {
+      method: 'GET',
+      headers: { 'User-Agent': 'sub-wave/tags' },
+      signal: ctrl.signal,
+    });
+    if (!r.ok) {
+      console.warn(`[lastfm] artist.getTopTracks → ${r.status} for "${artist}"`);
+      return [];
+    }
+    const data = (await r.json()) as any;
+    if (data?.error) return [];
+    const raw = data?.toptracks?.track ?? [];
+    const arr = Array.isArray(raw) ? raw : [raw];
+    return arr
+      .map((t: any) => ({ title: String(t?.name || '').trim(), artist }))
+      .filter((t: { title: string; artist: string }) => t.title.length > 0)
+      .slice(0, count);
+  } catch (err: any) {
+    console.warn(`[lastfm] artist.getTopTracks failed for "${artist}": ${err?.message || err}`);
+    return [];
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Bio and genre tags for an artist from Last.fm. Returns null on missing key,
+// no coverage, or any request failure. Bio HTML is stripped to plain text.
+export async function getArtistInfo(
+  artist: string,
+): Promise<{ bio?: string; tags?: string[] } | null> {
+  const apiKey = resolveKey();
+  if (!apiKey || !artist || !artist.trim()) return null;
+
+  const params = new URLSearchParams({
+    method: 'artist.getInfo',
+    artist,
+    autocorrect: '1',
+    api_key: apiKey,
+    format: 'json',
+  });
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const r = await fetch(`${LASTFM_API}?${params.toString()}`, {
+      method: 'GET',
+      headers: { 'User-Agent': 'sub-wave/tags' },
+      signal: ctrl.signal,
+    });
+    if (!r.ok) {
+      console.warn(`[lastfm] artist.getInfo → ${r.status} for "${artist}"`);
+      return null;
+    }
+    const data = (await r.json()) as any;
+    if (data?.error) return null;
+    const a = data?.artist;
+    if (!a) return null;
+    const bio = String(a?.bio?.summary || '')
+      .replace(/<[^>]*>/g, '')
+      .trim() || undefined;
+    const rawTags = a?.tags?.tag ?? [];
+    const tagsArr = Array.isArray(rawTags) ? rawTags : [rawTags];
+    const tags = tagsArr
+      .map((t: any) => (typeof t === 'string' ? t : t?.name))
+      .filter((s: any): s is string => typeof s === 'string' && s.trim().length > 0)
+      .map((s: string) => s.toLowerCase().trim());
+    return { bio, tags: tags.length > 0 ? tags : undefined };
+  } catch (err: any) {
+    console.warn(`[lastfm] artist.getInfo failed for "${artist}": ${err?.message || err}`);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // Best-available crowd tags for an artist. Prefers the direct Last.fm API when
 // an api_key is configured (works on vanilla Navidrome); otherwise routes
 // through Navidrome's getArtistInfo2, which only surfaces tag[] on a custom

--- a/controller/src/music/library-coverage.ts
+++ b/controller/src/music/library-coverage.ts
@@ -1,4 +1,4 @@
-// Library coverage — total Navidrome song count vs tagged tracks, plus
+// Library coverage — total music-source song count vs tagged tracks, plus
 // acoustic-analysis coverage (tracks with bpm/key/intro) against that same
 // total.
 // `total` requires walking iterateAllSongs() once (one Subsonic call per
@@ -7,7 +7,7 @@
 // after a manual refresh. Concurrent /coverage requests share the in-flight
 // scan via a single promise.
 
-import * as subsonic from './subsonic.js';
+import { getSource } from './source/index.js';
 import * as library from './library.js';
 import * as db from './library-db.js';
 import * as analyzer from './analyzer.js';
@@ -64,13 +64,23 @@ async function doScan() {
   cache.scanning = true;
   try {
     let count = 0;
-    for await (const _song of subsonic.iterateAllSongs()) count++;
+    for await (const _song of getSource().iterateAllSongs()) count++;
     cache.total = count;
     cache.scannedAt = new Date().toISOString();
   } finally {
     cache.scanning = false;
     inflight = null;
   }
+}
+
+// Return the last known cached total (null if never scanned).
+export function getTotal(): number | null {
+  return cache.scannedAt ? cache.total : null;
+}
+
+// Invalidate the cache so the next get() triggers a fresh scan.
+export function invalidate() {
+  cache.scannedAt = null;
 }
 
 // Kick off a scan if one isn't running. Non-blocking — callers read the

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -91,6 +91,7 @@ export interface TrackRecord {
   taggedAt: string | null;
   path: string | null;
   plexPartKey: string | null;
+  plexThumb: string | null;
   // Acoustic analysis (music/analyze-library.ts). All nullable — a track that
   // hasn't been analysed reads null and every consumer treats that as "no
   // signal, behave as today".
@@ -141,6 +142,7 @@ export interface TrackMeta {
   duration?: number | null;
   path?: string | null;
   plexPartKey?: string | null;
+  plexThumb?: string | null;
 }
 
 export interface TrackEnrichment {
@@ -200,6 +202,12 @@ export interface LibraryStats {
 // on the normal matching-dim path.
 // `adoptStoredDim` (live controller) treats the dim already recorded in the DB
 // as authoritative: the stored vectors win, and `embeddingDim` is only the
+// Flags set during DB migration — read by server.ts after open() to decide
+// whether a post-migration backfill tagger run is needed.
+export const migrationFlags: { needsPlexThumbBackfill: boolean } = {
+  needsPlexThumbBackfill: false,
+};
+
 // fallback used when the DB has never been tagged. This stops the runtime from
 // wiping a tagged index just because the model *name* maps to a different
 // default than the dim the tagger actually probed (#319). The tagger leaves it
@@ -405,6 +413,13 @@ async function migrate(embeddingDim: number, reseed = false, adoptStoredDim = fa
     runDdl(d, `ALTER TABLE tracks ADD COLUMN path TEXT;`);
     runDdl(d, `ALTER TABLE tracks ADD COLUMN plex_part_key TEXT;`);
     d.pragma('user_version = 10');
+  }
+
+  if (userVersion < 11) {
+    // Plex album-thumb path for cover art (track ratingKey ≠ album ratingKey).
+    runDdl(d, `ALTER TABLE tracks ADD COLUMN plex_thumb TEXT;`);
+    d.pragma('user_version = 11');
+    migrationFlags.needsPlexThumbBackfill = true;
   }
 
   // The vec0 virtual table carries the embedding dim in its schema. If the
@@ -618,8 +633,8 @@ export function upsertTrackMeta(id: string, meta: TrackMeta): void {
   requireDb()
     .prepare(
       `
-      INSERT INTO tracks (id, title, artist, album, year, genre, duration_sec, path, plex_part_key)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO tracks (id, title, artist, album, year, genre, duration_sec, path, plex_part_key, plex_thumb)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         title        = COALESCE(excluded.title, tracks.title),
         artist       = COALESCE(excluded.artist, tracks.artist),
@@ -628,7 +643,8 @@ export function upsertTrackMeta(id: string, meta: TrackMeta): void {
         genre        = COALESCE(excluded.genre, tracks.genre),
         duration_sec = COALESCE(excluded.duration_sec, tracks.duration_sec),
         path         = COALESCE(excluded.path, tracks.path),
-        plex_part_key = COALESCE(excluded.plex_part_key, tracks.plex_part_key)
+        plex_part_key = COALESCE(excluded.plex_part_key, tracks.plex_part_key),
+        plex_thumb   = COALESCE(excluded.plex_thumb, tracks.plex_thumb)
     `,
     )
     .run(
@@ -641,6 +657,7 @@ export function upsertTrackMeta(id: string, meta: TrackMeta): void {
       Number.isFinite(meta.duration as number) ? (meta.duration as number) : null,
       meta.path ?? null,
       meta.plexPartKey ?? null,
+      meta.plexThumb ?? null,
     );
 }
 
@@ -1408,6 +1425,7 @@ function rowToTrack(row: any): TrackRecord {
     taggedAt: row.tagged_at,
     path: row.path ?? null,
     plexPartKey: row.plex_part_key ?? null,
+    plexThumb: row.plex_thumb ?? null,
     bpm: row.bpm ?? null,
     musicalKey: row.musical_key ?? null,
     introMs: row.intro_ms ?? null,

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -89,6 +89,8 @@ export interface TrackRecord {
   promptHash: string | null;
   model: string | null;
   taggedAt: string | null;
+  path: string | null;
+  plexPartKey: string | null;
   // Acoustic analysis (music/analyze-library.ts). All nullable — a track that
   // hasn't been analysed reads null and every consumer treats that as "no
   // signal, behave as today".
@@ -137,6 +139,8 @@ export interface TrackMeta {
   year?: number | string | null;
   genre?: string | null;
   duration?: number | null;
+  path?: string | null;
+  plexPartKey?: string | null;
 }
 
 export interface TrackEnrichment {
@@ -396,6 +400,13 @@ async function migrate(embeddingDim: number, reseed = false, adoptStoredDim = fa
     d.pragma('user_version = 9');
   }
 
+  if (userVersion < 10) {
+    // File paths and Plex-specific part keys for streaming.
+    runDdl(d, `ALTER TABLE tracks ADD COLUMN path TEXT;`);
+    runDdl(d, `ALTER TABLE tracks ADD COLUMN plex_part_key TEXT;`);
+    d.pragma('user_version = 10');
+  }
+
   // The vec0 virtual table carries the embedding dim in its schema. If the
   // stored dim doesn't match the requested one, the caller asked for a model
   // swap — that's a --reseed operation, not an auto-migration.
@@ -607,15 +618,17 @@ export function upsertTrackMeta(id: string, meta: TrackMeta): void {
   requireDb()
     .prepare(
       `
-      INSERT INTO tracks (id, title, artist, album, year, genre, duration_sec)
-      VALUES (?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO tracks (id, title, artist, album, year, genre, duration_sec, path, plex_part_key)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         title        = COALESCE(excluded.title, tracks.title),
         artist       = COALESCE(excluded.artist, tracks.artist),
         album        = COALESCE(excluded.album, tracks.album),
         year         = COALESCE(excluded.year, tracks.year),
         genre        = COALESCE(excluded.genre, tracks.genre),
-        duration_sec = COALESCE(excluded.duration_sec, tracks.duration_sec)
+        duration_sec = COALESCE(excluded.duration_sec, tracks.duration_sec),
+        path         = COALESCE(excluded.path, tracks.path),
+        plex_part_key = COALESCE(excluded.plex_part_key, tracks.plex_part_key)
     `,
     )
     .run(
@@ -626,6 +639,8 @@ export function upsertTrackMeta(id: string, meta: TrackMeta): void {
       normaliseYear(meta.year),
       meta.genre ?? null,
       Number.isFinite(meta.duration as number) ? (meta.duration as number) : null,
+      meta.path ?? null,
+      meta.plexPartKey ?? null,
     );
 }
 
@@ -1391,6 +1406,8 @@ function rowToTrack(row: any): TrackRecord {
     promptHash: row.prompt_hash,
     model: row.model,
     taggedAt: row.tagged_at,
+    path: row.path ?? null,
+    plexPartKey: row.plex_part_key ?? null,
     bpm: row.bpm ?? null,
     musicalKey: row.musical_key ?? null,
     introMs: row.intro_ms ?? null,

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -70,6 +70,8 @@ export function get(songId: string): any {
     structure: t.structure,
     vocalRanges: t.vocalRanges, // [] = instrumental, null = not computed
     paceMean: paceMeanOf(t.pace),
+    path: t.path,
+    plexPartKey: t.plexPartKey,
   };
 }
 

--- a/controller/src/music/plex.test.ts
+++ b/controller/src/music/plex.test.ts
@@ -21,7 +21,9 @@ const SAMPLE_PLEX_TRACK = {
   duration: 235568,
   thumb: '/library/metadata/2/thumb/1782812114',
   Genre: [{ tag: 'Pop/Rock' }],
-  Part: [{ file: '/media/music/09 - Girls Like You.opus', key: '/library/parts/1/1782811927/file.opus' }],
+  Media: [{
+    Part: [{ file: '/media/music/09 - Girls Like You.opus', key: '/library/parts/1/1782811927/file.opus' }]
+  }]
 };
 
 test('normalizePlexTrack maps Plex track to SubWave Song shape', () => {

--- a/controller/src/music/plex.test.ts
+++ b/controller/src/music/plex.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { normalizePlexTrack } from './plex.js';
+
+let failures = 0;
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log(`  ok ${name}`);
+  } catch (err: any) {
+    failures++;
+    console.error(`  FAIL ${name}\n      ${err?.message || err}`);
+  }
+}
+
+const SAMPLE_PLEX_TRACK = {
+  ratingKey: '3',
+  title: 'Girls Like You',
+  grandparentTitle: 'Maroon 5',
+  parentTitle: 'Red Pill Blues',
+  parentYear: 2017,
+  duration: 235568,
+  thumb: '/library/metadata/2/thumb/1782812114',
+  Genre: [{ tag: 'Pop/Rock' }],
+  Part: [{ file: '/media/music/09 - Girls Like You.opus', key: '/library/parts/1/1782811927/file.opus' }],
+};
+
+test('normalizePlexTrack maps Plex track to SubWave Song shape', () => {
+  const song = normalizePlexTrack(SAMPLE_PLEX_TRACK);
+  assert.equal(song.id, 'plex:3');
+  assert.equal(song.title, 'Girls Like You');
+  assert.equal(song.artist, 'Maroon 5');
+  assert.equal(song.album, 'Red Pill Blues');
+  assert.equal(song.year, 2017);
+  assert.equal(song.genre, 'Pop/Rock');
+  assert.equal(song.duration, 235);
+  assert.equal(song.path, '/media/music/09 - Girls Like You.opus');
+});
+
+test('normalizePlexTrack handles missing optional fields', () => {
+  const minimal = {
+    ratingKey: '99',
+    title: 'Test',
+    grandparentTitle: 'Artist',
+    parentTitle: 'Album',
+    Part: [{ file: '/music/test.mp3', key: '/library/parts/99/0/file.mp3' }],
+  };
+  const song = normalizePlexTrack(minimal);
+  assert.equal(song.id, 'plex:99');
+  assert.equal(song.year, undefined);
+  assert.equal(song.genre, undefined);
+  assert.equal(song.duration, undefined);
+});
+
+if (failures > 0) {
+  console.error(`\n${failures} test(s) failed`);
+  process.exit(1);
+} else {
+  console.log('\nAll tests passed');
+}

--- a/controller/src/music/plex.ts
+++ b/controller/src/music/plex.ts
@@ -281,32 +281,87 @@ export async function getArtistLastfmTags(id: string, opts: { count?: number } =
 }
 
 export async function getLyrics(songId: string): Promise<string> {
-  // Fetch lyrics from LRCLIB (free, no key) by title+artist — same source
-  // Navidrome uses internally. Falls back to Plex Mood tags when LRCLIB has
-  // no coverage, then empty string.
+  // Fetch lyrics using the same chain Navidrome's lyrics plugin uses:
+  //   1. LRCLIB /api/get  — exact match by title + artist + album + duration
+  //   2. LRCLIB /api/search — fuzzy query, pick by duration within 2s
+  //   3. lyrics.ovh       — plain text fallback, good coverage for new releases
+  //   4. Plex Mood tags   — last resort when nothing else has coverage
+  const LRCLIB = 'https://lrclib.net';
+  const LYRICS_OVH = 'https://api.lyrics.ovh';
+  const UA = { 'User-Agent': 'sub-wave/lyrics' };
+  const DURATION_TOLERANCE = 2;
+  const EXCERPT = 300;
+
+  async function lrclibGet(title: string, artist: string, album: string, duration: number): Promise<string> {
+    const params = new URLSearchParams({
+      artist_name: artist,
+      track_name: title,
+      album_name: album,
+      duration: String(Math.round(duration)),
+    });
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 5000);
+    try {
+      const r = await fetch(`${LRCLIB}/api/get?${params}`, { headers: UA, signal: ctrl.signal });
+      if (!r.ok) return '';
+      const data = await r.json() as any;
+      return (data?.plainLyrics || data?.syncedLyrics || '').trim();
+    } catch { return ''; } finally { clearTimeout(timer); }
+  }
+
+  async function lrclibSearch(title: string, artist: string, duration: number): Promise<string> {
+    const params = new URLSearchParams({ q: `${artist} ${title}` });
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 5000);
+    try {
+      const r = await fetch(`${LRCLIB}/api/search?${params}`, { headers: UA, signal: ctrl.signal });
+      if (!r.ok) return '';
+      const results = await r.json() as any[];
+      const match = Array.isArray(results)
+        ? results.find(x => typeof x.duration === 'number' && Math.abs(x.duration - duration) <= DURATION_TOLERANCE)
+        : null;
+      return ((match?.plainLyrics || match?.syncedLyrics) ?? '').trim();
+    } catch { return ''; } finally { clearTimeout(timer); }
+  }
+
+  async function lyricsOvh(title: string, artist: string): Promise<string> {
+    const enc = (s: string) => encodeURIComponent(s);
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 5000);
+    try {
+      const r = await fetch(`${LYRICS_OVH}/v1/${enc(artist)}/${enc(title)}`, { headers: UA, signal: ctrl.signal });
+      if (!r.ok) return '';
+      const data = await r.json() as any;
+      return (data?.lyrics || '').trim();
+    } catch { return ''; } finally { clearTimeout(timer); }
+  }
+
   try {
     const t = db.isOpen() ? db.getTrack(songId) : null;
-    const title = t?.title;
-    const artist = t?.artist;
+    const title = t?.title || '';
+    const artist = t?.artist || '';
+    const album = t?.album || '';
+    const duration = t?.durationSec ?? 0;
+
     if (title && artist) {
-      const ctrl = new AbortController();
-      const timer = setTimeout(() => ctrl.abort(), 5000);
-      try {
-        const params = new URLSearchParams({ artist_name: artist, track_name: title });
-        const r = await fetch(`https://lrclib.net/api/get?${params}`, {
-          headers: { 'User-Agent': 'sub-wave/lyrics' },
-          signal: ctrl.signal,
-        });
-        if (r.ok) {
-          const data = await r.json() as any;
-          const plain: string = data?.plainLyrics || '';
-          if (plain.trim()) return plain.slice(0, 300).trim();
-        }
-      } finally {
-        clearTimeout(timer);
+      // 1. LRCLIB exact match
+      if (album && duration) {
+        const lyrics = await lrclibGet(title, artist, album, duration);
+        if (lyrics) return lyrics.slice(0, EXCERPT);
       }
+
+      // 2. LRCLIB fuzzy search
+      if (duration) {
+        const lyrics = await lrclibSearch(title, artist, duration);
+        if (lyrics) return lyrics.slice(0, EXCERPT);
+      }
+
+      // 3. lyrics.ovh
+      const lyrics = await lyricsOvh(title, artist);
+      if (lyrics) return lyrics.slice(0, EXCERPT);
     }
-    // Fallback: Plex Mood tags when LRCLIB has no coverage
+
+    // 4. Plex Mood tags
     const ratingKey = songId.replace('plex:', '');
     const data = await plexFetch(`/library/metadata/${ratingKey}`);
     const track = data?.MediaContainer?.Metadata?.[0];

--- a/controller/src/music/plex.ts
+++ b/controller/src/music/plex.ts
@@ -1,6 +1,7 @@
 import { config } from '../config.js';
 import { buildAnnotatedUri } from './subsonic.js';
 import * as lastfm from './lastfm.js';
+import * as db from './library-db.js';
 
 function plexHeaders(): Record<string, string> {
   return {
@@ -35,7 +36,9 @@ async function getSectionKey(): Promise<string> {
 }
 
 export function normalizePlexTrack(t: any): any {
-  const part = Array.isArray(t.Part) ? t.Part[0] : t.Part;
+  const media = Array.isArray(t.Media) ? t.Media[0] : t.Media;
+  const partList = t.Part || media?.Part;
+  const part = Array.isArray(partList) ? partList[0] : partList;
   return {
     id: `plex:${t.ratingKey}`,
     title: t.title || '',
@@ -310,8 +313,20 @@ export function getStreamUrl(songId: string): string {
 }
 
 export function getRawStreamUrl(songId: string): string {
-  const ratingKey = songId.replace('plex:', '');
-  return `${config.plex.url}/library/parts/${ratingKey}/0/file?X-Plex-Token=${config.plex.token}`;
+  let partPath = '';
+  if (db.isOpen()) {
+    try {
+      const t = db.getTrack(songId);
+      if (t?.plexPartKey) {
+        partPath = t.plexPartKey;
+      }
+    } catch { /* ignore */ }
+  }
+  if (!partPath) {
+    const ratingKey = songId.replace('plex:', '');
+    partPath = `/library/parts/${ratingKey}/0/file`;
+  }
+  return `${config.plex.url}${partPath}?X-Plex-Token=${config.plex.token}`;
 }
 
 export function getLocalPath(_song: any): string | null {
@@ -319,7 +334,18 @@ export function getLocalPath(_song: any): string | null {
 }
 
 export function getPlayableUri(song: any): string {
-  const partPath = song._partKey || `/library/parts/${song.id.replace('plex:', '')}/0/file`;
+  let partPath = song._partKey || song.plexPartKey;
+  if (!partPath && db.isOpen()) {
+    try {
+      const t = db.getTrack(song.id);
+      if (t?.plexPartKey) {
+        partPath = t.plexPartKey;
+      }
+    } catch { /* ignore */ }
+  }
+  if (!partPath) {
+    partPath = `/library/parts/${song.id.replace('plex:', '')}/0/file`;
+  }
   return `subhttp:${config.plex.url}${partPath}?X-Plex-Token=${config.plex.token}`;
 }
 

--- a/controller/src/music/plex.ts
+++ b/controller/src/music/plex.ts
@@ -281,11 +281,32 @@ export async function getArtistLastfmTags(id: string, opts: { count?: number } =
 }
 
 export async function getLyrics(songId: string): Promise<string> {
-  // Plex has no lyrics API, but exposes Mood tags per track (from MusicBrainz /
-  // acoustic analysis). Return them as a comma-separated hint so the enrichment
-  // phase stores them in lyric_excerpt and the LLM tagger sees real mood context
-  // instead of an empty string.
+  // Fetch lyrics from LRCLIB (free, no key) by title+artist — same source
+  // Navidrome uses internally. Falls back to Plex Mood tags when LRCLIB has
+  // no coverage, then empty string.
   try {
+    const t = db.isOpen() ? db.getTrack(songId) : null;
+    const title = t?.title;
+    const artist = t?.artist;
+    if (title && artist) {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), 5000);
+      try {
+        const params = new URLSearchParams({ artist_name: artist, track_name: title });
+        const r = await fetch(`https://lrclib.net/api/get?${params}`, {
+          headers: { 'User-Agent': 'sub-wave/lyrics' },
+          signal: ctrl.signal,
+        });
+        if (r.ok) {
+          const data = await r.json() as any;
+          const plain: string = data?.plainLyrics || '';
+          if (plain.trim()) return plain.slice(0, 300).trim();
+        }
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+    // Fallback: Plex Mood tags when LRCLIB has no coverage
     const ratingKey = songId.replace('plex:', '');
     const data = await plexFetch(`/library/metadata/${ratingKey}`);
     const track = data?.MediaContainer?.Metadata?.[0];

--- a/controller/src/music/plex.ts
+++ b/controller/src/music/plex.ts
@@ -216,6 +216,24 @@ export async function getRecentSongsByArtist(artistName: string, opts: { count?:
   } catch { return []; }
 }
 
+export async function getAlbumList(offset = 0, size = 500): Promise<any[]> {
+  try {
+    const key = await getSectionKey();
+    const data = await plexFetch(`/library/sections/${key}/all`, {
+      type: '9',
+      sort: 'titleSort',
+      'X-Plex-Container-Start': String(offset),
+      'X-Plex-Container-Size': String(size),
+    });
+    return (data?.MediaContainer?.Metadata || []).map((a: any) => ({
+      id: `plex:${a.ratingKey}`,
+      name: a.title,
+      artist: a.parentTitle,
+      year: a.year,
+    }));
+  } catch { return []; }
+}
+
 export async function getAlbum(id: string): Promise<any[]> {
   try {
     const ratingKey = id.replace('plex:', '');
@@ -262,8 +280,18 @@ export async function getArtistLastfmTags(id: string, opts: { count?: number } =
   } catch { return []; }
 }
 
-export async function getLyrics(_songId: string): Promise<string> {
-  return '';
+export async function getLyrics(songId: string): Promise<string> {
+  // Plex has no lyrics API, but exposes Mood tags per track (from MusicBrainz /
+  // acoustic analysis). Return them as a comma-separated hint so the enrichment
+  // phase stores them in lyric_excerpt and the LLM tagger sees real mood context
+  // instead of an empty string.
+  try {
+    const ratingKey = songId.replace('plex:', '');
+    const data = await plexFetch(`/library/metadata/${ratingKey}`);
+    const track = data?.MediaContainer?.Metadata?.[0];
+    const moods: string[] = (track?.Mood || []).map((m: any) => m.tag).filter(Boolean);
+    return moods.length ? `Moods: ${moods.join(', ')}` : '';
+  } catch { return ''; }
 }
 
 export async function* iterateAllSongs(): AsyncGenerator<any> {
@@ -303,7 +331,28 @@ export async function getPlaylist(id: string): Promise<any[]> {
   } catch { return []; }
 }
 
-export function getCoverArtUrl(id: string, _size?: number): string {
+export async function getCoverArtUrl(id: string, _size?: number): Promise<string> {
+  // Plex tracks inherit cover art from their album; the thumb path on the track
+  // metadata points to the album ratingKey, not the track's own ratingKey.
+  // We store it in plex_thumb during the library walk. When it's not in the DB
+  // (track added after last walk), fetch it live from the Plex API rather than
+  // guessing /library/metadata/<track-ratingKey>/thumb which always 404s.
+  if (db.isOpen()) {
+    try {
+      const t = db.getTrack(id);
+      if (t?.plexThumb) {
+        return `${config.plex.url}${t.plexThumb}?X-Plex-Token=${config.plex.token}`;
+      }
+    } catch { /* ignore */ }
+  }
+  // Live lookup: the track's own metadata carries a `thumb` field pointing at
+  // the album ratingKey (e.g. /library/metadata/55/thumb/…), which Plex serves.
+  try {
+    const ratingKey = id.replace('plex:', '');
+    const data = await plexFetch(`/library/metadata/${ratingKey}`);
+    const track = data?.MediaContainer?.Metadata?.[0];
+    if (track?.thumb) return `${config.plex.url}${track.thumb}?X-Plex-Token=${config.plex.token}`;
+  } catch { /* ignore */ }
   const ratingKey = id.replace('plex:', '');
   return `${config.plex.url}/library/metadata/${ratingKey}/thumb?X-Plex-Token=${config.plex.token}`;
 }

--- a/controller/src/music/plex.ts
+++ b/controller/src/music/plex.ts
@@ -1,0 +1,328 @@
+import { config } from '../config.js';
+import { buildAnnotatedUri } from './subsonic.js';
+import * as lastfm from './lastfm.js';
+
+function plexHeaders(): Record<string, string> {
+  return {
+    'X-Plex-Token': config.plex.token,
+    'Accept': 'application/json',
+    'X-Plex-Client-Identifier': 'subwave',
+    'X-Plex-Product': 'SubWave',
+  };
+}
+
+async function plexFetch(path: string, params?: Record<string, string>): Promise<any> {
+  const url = new URL(config.plex.url + path);
+  if (params) Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  const res = await fetch(url.toString(), {
+    headers: plexHeaders(),
+    signal: AbortSignal.timeout(10000),
+  });
+  if (!res.ok) throw new Error(`Plex ${path} -> HTTP ${res.status}`);
+  return res.json();
+}
+
+let _sectionKey: string | null = null;
+
+async function getSectionKey(): Promise<string> {
+  if (_sectionKey) return _sectionKey;
+  const data = await plexFetch('/library/sections');
+  const sections: any[] = data?.MediaContainer?.Directory || [];
+  const music = sections.find((s: any) => s.type === 'artist');
+  if (!music) throw new Error('No Plex music library found. Add a Music library in Plex first.');
+  _sectionKey = music.key;
+  return _sectionKey!;
+}
+
+export function normalizePlexTrack(t: any): any {
+  const part = Array.isArray(t.Part) ? t.Part[0] : t.Part;
+  return {
+    id: `plex:${t.ratingKey}`,
+    title: t.title || '',
+    artist: t.grandparentTitle || '',
+    album: t.parentTitle || '',
+    year: t.parentYear || undefined,
+    genre: (Array.isArray(t.Genre) ? t.Genre[0]?.tag : t.Genre?.tag) || undefined,
+    duration: t.duration ? Math.floor(t.duration / 1000) : undefined,
+    path: part?.file || undefined,
+    _partKey: part?.key || '',
+    _thumb: t.thumb || '',
+  };
+}
+
+async function fetchTracks(params: Record<string, string>): Promise<any[]> {
+  const key = await getSectionKey();
+  const data = await plexFetch(`/library/sections/${key}/all`, { type: '10', ...params });
+  return (data?.MediaContainer?.Metadata || []).map(normalizePlexTrack);
+}
+
+export async function ping(): Promise<{ ok: boolean; reason?: string }> {
+  try {
+    if (!config.plex.url || !config.plex.token) {
+      return { ok: false, reason: 'Plex URL or token not configured' };
+    }
+    const data = await plexFetch('/identity');
+    return { ok: true, reason: `Plex ${data?.MediaContainer?.version || ''}` };
+  } catch (err: any) {
+    return { ok: false, reason: err.message };
+  }
+}
+
+export function isStationArchive(song: any): boolean {
+  const p = song?.path || '';
+  return /\barchive\b/.test(p) && /\d{2}-00\.\w+$/.test(p);
+}
+
+export async function search(query: string, opts: { songCount?: number; songOffset?: number } = {}): Promise<any[]> {
+  try {
+    const key = await getSectionKey();
+    const data = await plexFetch('/search', { query, type: '10', sectionId: key, limit: String(opts.songCount ?? 20) });
+    return (data?.MediaContainer?.Metadata || []).map(normalizePlexTrack);
+  } catch { return []; }
+}
+
+export async function getRandomSongs(opts: { size?: number; genre?: string } = {}): Promise<any[]> {
+  try {
+    const params: Record<string, string> = { sort: 'random', 'X-Plex-Container-Size': String(opts.size ?? 20) };
+    if (opts.genre) params.genre = opts.genre;
+    return fetchTracks(params);
+  } catch { return []; }
+}
+
+export async function getSongsByGenre(genre: string, opts: { count?: number } = {}): Promise<any[]> {
+  try {
+    return fetchTracks({ genre, 'X-Plex-Container-Size': String(opts.count ?? 20) });
+  } catch { return []; }
+}
+
+export async function getGenres(): Promise<{ value: string; songCount: number; albumCount: number }[]> {
+  try {
+    const key = await getSectionKey();
+    const data = await plexFetch(`/library/sections/${key}/genre`);
+    return (data?.MediaContainer?.Directory || []).map((g: any) => ({
+      value: g.title || '',
+      songCount: g.size || 0,
+      albumCount: 0,
+    }));
+  } catch { return []; }
+}
+
+export async function resolveGenreName(name: string): Promise<string | null> {
+  const genres = await getGenres();
+  const match = genres.find(g => g.value.toLowerCase() === name.toLowerCase());
+  return match?.value || null;
+}
+
+export async function resolveArtist(name: string): Promise<any | null> {
+  try {
+    const results = await searchArtists(name, { artistCount: 1 });
+    return results[0] || null;
+  } catch { return null; }
+}
+
+export async function getSimilarSongs(id: string, opts: { count?: number } = {}): Promise<any[]> {
+  try {
+    const song = await getSong(id);
+    if (!song) return [];
+    const similarArtists = await lastfm.getSimilarArtists(song.artist, { count: 3 });
+    const results: any[] = [];
+    for (const artist of similarArtists.slice(0, 3)) {
+      const tracks = await search(artist, { songCount: Math.ceil((opts.count || 10) / 3) });
+      results.push(...tracks);
+      if (results.length >= (opts.count || 10)) break;
+    }
+    return results.slice(0, opts.count || 10);
+  } catch { return []; }
+}
+
+export async function supportsSonicSimilarity(): Promise<boolean> {
+  return false;
+}
+
+export async function getSonicSimilarTracks(id: string, opts: { count?: number } = {}): Promise<any[]> {
+  return getSimilarSongs(id, opts);
+}
+
+export async function getStarred(): Promise<any[]> {
+  try {
+    return fetchTracks({ 'userRating>>': '0', sort: 'userRating:desc' });
+  } catch { return []; }
+}
+
+export async function getRecentlyAddedAlbums(opts: { size?: number } = {}): Promise<any[]> {
+  try {
+    const key = await getSectionKey();
+    const data = await plexFetch(`/library/sections/${key}/all`, {
+      type: '9', sort: 'addedAt:desc', 'X-Plex-Container-Size': String(opts.size ?? 20),
+    });
+    return (data?.MediaContainer?.Metadata || []).map((a: any) => ({
+      id: `plex:${a.ratingKey}`,
+      name: a.title,
+      artist: a.parentTitle,
+      year: a.year,
+    }));
+  } catch { return []; }
+}
+
+export async function getFrequentAlbums(opts: { size?: number } = {}): Promise<any[]> {
+  try {
+    const key = await getSectionKey();
+    const data = await plexFetch(`/library/sections/${key}/all`, {
+      type: '9', sort: 'viewCount:desc', 'X-Plex-Container-Size': String(opts.size ?? 20),
+    });
+    return (data?.MediaContainer?.Metadata || []).map((a: any) => ({
+      id: `plex:${a.ratingKey}`,
+      name: a.title,
+      artist: a.parentTitle,
+      year: a.year,
+    }));
+  } catch { return []; }
+}
+
+export async function getArtistInfo(id: string, _opts: { count?: number } = {}): Promise<any | null> {
+  try {
+    const ratingKey = id.replace('plex:', '');
+    const data = await plexFetch(`/library/metadata/${ratingKey}`);
+    const artist = data?.MediaContainer?.Metadata?.[0];
+    if (!artist) return null;
+    const lfmInfo = await lastfm.getArtistInfo(artist.title || '');
+    return {
+      id,
+      name: artist.title,
+      biography: lfmInfo?.bio || artist.summary || '',
+      tags: lfmInfo?.tags || [],
+    };
+  } catch { return null; }
+}
+
+export async function getTopSongs(artistName: string, opts: { count?: number } = {}): Promise<any[]> {
+  try {
+    const topTracks = await lastfm.getTopTracks(artistName, { count: opts.count || 10 });
+    const results: any[] = [];
+    for (const t of topTracks.slice(0, opts.count || 10)) {
+      const found = await search(`${t.title} ${t.artist}`, { songCount: 1 });
+      if (found.length) results.push(found[0]);
+    }
+    return results;
+  } catch { return []; }
+}
+
+export async function getRecentSongsByArtist(artistName: string, opts: { count?: number } = {}): Promise<any[]> {
+  try {
+    return search(artistName, { songCount: opts.count || 10 });
+  } catch { return []; }
+}
+
+export async function getAlbum(id: string): Promise<any[]> {
+  try {
+    const ratingKey = id.replace('plex:', '');
+    const data = await plexFetch(`/library/metadata/${ratingKey}/children`);
+    return (data?.MediaContainer?.Metadata || []).map(normalizePlexTrack);
+  } catch { return []; }
+}
+
+export async function getSong(id: string): Promise<any | null> {
+  try {
+    const ratingKey = id.replace('plex:', '');
+    const data = await plexFetch(`/library/metadata/${ratingKey}`);
+    const track = data?.MediaContainer?.Metadata?.[0];
+    return track ? normalizePlexTrack(track) : null;
+  } catch { return null; }
+}
+
+export async function getArtist(id: string): Promise<any | null> {
+  try {
+    const ratingKey = id.replace('plex:', '');
+    const data = await plexFetch(`/library/metadata/${ratingKey}`);
+    const artist = data?.MediaContainer?.Metadata?.[0];
+    if (!artist) return null;
+    return { id, name: artist.title, albumCount: artist.childCount || 0 };
+  } catch { return null; }
+}
+
+export async function searchArtists(query: string, opts: { artistCount?: number } = {}): Promise<any[]> {
+  try {
+    const key = await getSectionKey();
+    const data = await plexFetch('/search', { query, type: '8', sectionId: key, limit: String(opts.artistCount ?? 10) });
+    return (data?.MediaContainer?.Metadata || []).map((a: any) => ({
+      id: `plex:${a.ratingKey}`,
+      name: a.title,
+    }));
+  } catch { return []; }
+}
+
+export async function getArtistLastfmTags(id: string, opts: { count?: number } = {}): Promise<string[]> {
+  try {
+    const artist = await getArtist(id);
+    if (!artist) return [];
+    return lastfm.getArtistTopTags(artist.name, opts);
+  } catch { return []; }
+}
+
+export async function getLyrics(_songId: string): Promise<string> {
+  return '';
+}
+
+export async function* iterateAllSongs(): AsyncGenerator<any> {
+  const key = await getSectionKey();
+  let start = 0;
+  const size = 100;
+  while (true) {
+    const data = await plexFetch(`/library/sections/${key}/all`, {
+      type: '10',
+      'X-Plex-Container-Start': String(start),
+      'X-Plex-Container-Size': String(size),
+    });
+    const tracks: any[] = data?.MediaContainer?.Metadata || [];
+    if (tracks.length === 0) break;
+    for (const t of tracks) yield normalizePlexTrack(t);
+    if (tracks.length < size) break;
+    start += size;
+  }
+}
+
+export async function getPlaylists(): Promise<any[]> {
+  try {
+    const data = await plexFetch('/playlists', { playlistType: 'audio' });
+    return (data?.MediaContainer?.Metadata || []).map((p: any) => ({
+      id: `plex:${p.ratingKey}`,
+      name: p.title,
+      songCount: p.leafCount || 0,
+    }));
+  } catch { return []; }
+}
+
+export async function getPlaylist(id: string): Promise<any[]> {
+  try {
+    const ratingKey = id.replace('plex:', '');
+    const data = await plexFetch(`/playlists/${ratingKey}/items`);
+    return (data?.MediaContainer?.Metadata || []).map(normalizePlexTrack);
+  } catch { return []; }
+}
+
+export function getCoverArtUrl(id: string, _size?: number): string {
+  const ratingKey = id.replace('plex:', '');
+  return `${config.plex.url}/library/metadata/${ratingKey}/thumb?X-Plex-Token=${config.plex.token}`;
+}
+
+export function getStreamUrl(songId: string): string {
+  return getRawStreamUrl(songId);
+}
+
+export function getRawStreamUrl(songId: string): string {
+  const ratingKey = songId.replace('plex:', '');
+  return `${config.plex.url}/library/parts/${ratingKey}/0/file?X-Plex-Token=${config.plex.token}`;
+}
+
+export function getLocalPath(_song: any): string | null {
+  return null;
+}
+
+export function getPlayableUri(song: any): string {
+  const partPath = song._partKey || `/library/parts/${song.id.replace('plex:', '')}/0/file`;
+  return `subhttp:${config.plex.url}${partPath}?X-Plex-Token=${config.plex.token}`;
+}
+
+export function getAnnotatedUri(song: any, opts: { maxDurationSec?: number | null } = {}): string {
+  return buildAnnotatedUri(song, getPlayableUri(song), opts);
+}

--- a/controller/src/music/source/index.ts
+++ b/controller/src/music/source/index.ts
@@ -37,13 +37,16 @@ export function getSourceSync(): any {
 }
 
 // Pre-warm both backends at startup so getSource() is synchronous in routes.
+// Both are always loaded — plex.ts is safe to import without credentials
+// (no network calls at import time) and reads config at call time, so a
+// source switch is instant without needing to reload the module.
 export async function warmSourceCache() {
   await loadNavidrome();
-  // Plex only loaded if configured (avoids import errors when plex.ts has no config).
-  if ((settings.get() as any).music?.source === 'plex') await loadPlex();
+  await loadPlex().catch(() => { /* no-op if plex.ts fails to import */ });
 }
 
 export function invalidateSourceCache() {
-  _plex = null;
-  // Navidrome is always available; keep it cached.
+  // Both modules read config.plex at call time — no need to clear _plex.
+  // Re-warm eagerly so a source switch to Plex is immediately ready.
+  warmSourceCache().catch(console.error);
 }

--- a/controller/src/music/source/index.ts
+++ b/controller/src/music/source/index.ts
@@ -3,7 +3,6 @@ import * as settings from '../../settings.js';
 // Lazy imports — avoids circular deps and lets the router swap at runtime.
 let _navidrome: any = null;
 let _plex: any = null;
-let _cachedSource: string | null = null;
 
 async function loadNavidrome() {
   if (!_navidrome) _navidrome = await import('../subsonic.js');
@@ -23,11 +22,11 @@ export function getSource(): any {
     if (!_plex) {
       // Synchronous fallback: trigger load but return Navidrome until ready.
       // In practice plex.ts is always pre-loaded by the time any route fires.
-      loadPlex();
+      loadPlex().catch(console.error);
     }
     return _plex || _navidrome;
   }
-  if (!_navidrome) loadNavidrome();
+  if (!_navidrome) loadNavidrome().catch(console.error);
   return _navidrome;
 }
 
@@ -45,7 +44,6 @@ export async function warmSourceCache() {
 }
 
 export function invalidateSourceCache() {
-  _cachedSource = null;
   _plex = null;
   // Navidrome is always available; keep it cached.
 }

--- a/controller/src/music/source/index.ts
+++ b/controller/src/music/source/index.ts
@@ -1,0 +1,51 @@
+import * as settings from '../../settings.js';
+
+// Lazy imports — avoids circular deps and lets the router swap at runtime.
+let _navidrome: any = null;
+let _plex: any = null;
+let _cachedSource: string | null = null;
+
+async function loadNavidrome() {
+  if (!_navidrome) _navidrome = await import('../subsonic.js');
+  return _navidrome;
+}
+
+async function loadPlex() {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore -- plex.ts added in a later task; dynamic import is intentional
+  if (!_plex) _plex = await import('../plex.js');
+  return _plex;
+}
+
+export function getSource(): any {
+  const source = (settings.get() as any).music?.source || 'navidrome';
+  if (source === 'plex') {
+    if (!_plex) {
+      // Synchronous fallback: trigger load but return Navidrome until ready.
+      // In practice plex.ts is always pre-loaded by the time any route fires.
+      loadPlex();
+    }
+    return _plex || _navidrome;
+  }
+  if (!_navidrome) loadNavidrome();
+  return _navidrome;
+}
+
+// Sync version for use in non-async contexts (after warm-up).
+export function getSourceSync(): any {
+  const source = (settings.get() as any).music?.source || 'navidrome';
+  return source === 'plex' ? (_plex || _navidrome) : (_navidrome || _plex);
+}
+
+// Pre-warm both backends at startup so getSource() is synchronous in routes.
+export async function warmSourceCache() {
+  await loadNavidrome();
+  // Plex only loaded if configured (avoids import errors when plex.ts has no config).
+  if ((settings.get() as any).music?.source === 'plex') await loadPlex();
+}
+
+export function invalidateSourceCache() {
+  _cachedSource = null;
+  _plex = null;
+  // Navidrome is always available; keep it cached.
+}

--- a/controller/src/music/source/types.ts
+++ b/controller/src/music/source/types.ts
@@ -1,0 +1,49 @@
+// Song contract shared by all backends.
+export interface Song {
+  id: string;           // 'plex:{ratingKey}' or bare Navidrome base32
+  title: string;
+  artist: string;
+  album: string;
+  year?: number;
+  genre?: string;
+  duration?: number;    // seconds
+  path?: string;        // local path, used by isStationArchive guard
+  // controller-augmented (not from source API):
+  crossSec?: number;    // adaptive crossfade seconds (DJ mode)
+  gainDb?: number;      // loudness normalisation in dB
+}
+
+export interface MusicSource {
+  ping(): Promise<{ ok: boolean; reason?: string }>;
+  isStationArchive(song: Song): boolean;
+  search(query: string, opts?: { songCount?: number; songOffset?: number }): Promise<Song[]>;
+  getRandomSongs(opts?: { size?: number; genre?: string; fromYear?: number; toYear?: number }): Promise<Song[]>;
+  getSongsByGenre(genre: string, opts?: { count?: number }): Promise<Song[]>;
+  getGenres(): Promise<{ value: string; songCount: number; albumCount: number }[]>;
+  resolveGenreName(name: string): Promise<string | null>;
+  resolveArtist(name: string, opts?: { artistCount?: number }): Promise<any | null>;
+  getSimilarSongs(id: string, opts?: { count?: number }): Promise<Song[]>;
+  supportsSonicSimilarity(): Promise<boolean>;
+  getSonicSimilarTracks(id: string, opts?: { count?: number }): Promise<Song[]>;
+  getStarred(): Promise<Song[]>;
+  getRecentlyAddedAlbums(opts?: { size?: number }): Promise<any[]>;
+  getFrequentAlbums(opts?: { size?: number }): Promise<any[]>;
+  getArtistInfo(id: string, opts?: { count?: number }): Promise<any | null>;
+  getTopSongs(artistName: string, opts?: { count?: number }): Promise<Song[]>;
+  getRecentSongsByArtist(artistName: string, opts?: { albums?: number; count?: number }): Promise<Song[]>;
+  getAlbum(id: string): Promise<Song[]>;
+  getSong(id: string): Promise<Song | null>;
+  getArtist(id: string): Promise<any | null>;
+  searchArtists(query: string, opts?: { artistCount?: number }): Promise<any[]>;
+  getArtistLastfmTags(id: string, opts?: { count?: number }): Promise<string[]>;
+  getLyrics(songId: string): Promise<string>;
+  iterateAllSongs(): AsyncGenerator<Song>;
+  getPlaylists(): Promise<any[]>;
+  getPlaylist(id: string): Promise<Song[]>;
+  getCoverArtUrl(id: string, size?: number): string;
+  getStreamUrl(songId: string): string;
+  getRawStreamUrl(songId: string): string;
+  getLocalPath(song: Song): string | null;
+  getPlayableUri(song: Song): string;
+  getAnnotatedUri(song: Song, opts?: { maxDurationSec?: number | null }): string;
+}

--- a/controller/src/music/subsonic.ts
+++ b/controller/src/music/subsonic.ts
@@ -565,44 +565,32 @@ export function getPlayableUri(song) {
   return getLocalPath(song) || getStreamUrl(song.id);
 }
 
+// Shared annotate-URI builder used by both Navidrome and Plex backends.
+// Encodes song metadata into the annotate: prefix Liquidsoap reads on intake.
+export function buildAnnotatedUri(
+  song: { id: string; title: string; artist: string; album: string; year?: any; genre?: any; crossSec?: any; gainDb?: any },
+  streamUri: string,
+  opts: { maxDurationSec?: number | null } = {},
+): string {
+  const esc = (v: any) => String(v ?? '').replace(/"/g, '\\"');
+  const fields = [
+    `title="${esc(song.title)}"`,
+    `artist="${esc(song.artist)}"`,
+    `album="${esc(song.album)}"`,
+    `subsonic_id="${esc(song.id)}"`,
+  ];
+  if (song.year) fields.push(`year="${esc(song.year)}"`);
+  if (song.genre) fields.push(`genre="${esc(song.genre)}"`);
+  if (song.crossSec != null) fields.push(`liq_cross_duration="${esc(song.crossSec)}"`);
+  if (song.gainDb != null) fields.push(`liq_amplify="${esc(song.gainDb)} dB"`);
+  if (opts.maxDurationSec != null && opts.maxDurationSec > 0) {
+    fields.push(`liq_cue_out="${esc(opts.maxDurationSec)}"`);
+  }
+  return `annotate:${fields.join(',')}:${streamUri}`;
+}
+
 // Liquidsoap `annotate:` URI — embeds metadata up front so on_track_change
 // reports real artist/title/album rather than waiting on stream-level ID3.
-function escAnnotate(s) {
-  return String(s ?? '').replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-}
-export function getAnnotatedUri(song, opts: { maxDurationSec?: number | null } = {}) {
-  const fields = [
-    `title="${escAnnotate(song.title)}"`,
-    `artist="${escAnnotate(song.artist)}"`,
-    `album="${escAnnotate(song.album)}"`,
-    `subsonic_id="${escAnnotate(song.id)}"`,
-  ];
-  if (song.year) fields.push(`year="${escAnnotate(song.year)}"`);
-  if (song.genre) fields.push(`genre="${escAnnotate(song.genre)}"`);
-  // DJ-mode adaptive blend: the queue stashes a per-transition crossfade length
-  // (seconds) on the track when the persona is in DJ mode and both tracks are
-  // analysed. Liquidsoap's `cross` honours `liq_cross_duration` to size the
-  // blend for this transition (radio.liq dj_transition reads the same key for
-  // its fades, keeping fade == buffer). Absent → Liquidsoap uses its startup
-  // crossfade_duration(), i.e. today's behaviour.
-  if (song.crossSec != null) fields.push(`liq_cross_duration="${escAnnotate(song.crossSec)}"`);
-  // Loudness normalisation: the queue stashes a per-track gain offset (dB,
-  // clamped) toward the loudness target when the track has a measured LUFS.
-  // Emitted in the "<n> dB" form Liquidsoap's amplify override parses natively
-  // (the same shape as replaygain_track_gain). radio.liq applies it via
-  // amplify(override="liq_amplify") before the ducking layers so quiet and loud
-  // tracks play at even perceived volume — masters untouched, no bus
-  // normaliser. Absent → no gain applied, i.e. unity / today's behaviour.
-  if (song.gainDb != null) fields.push(`liq_amplify="${escAnnotate(song.gainDb)} dB"`);
-  // Hard track-length cap (issue #447 / max-track-length). When the caller passes
-  // a positive cap, stamp `liq_cue_out` so radio.liq's `cue_cut` stops the track
-  // at that second offset — a real ceiling that fires no matter how the track
-  // reached the stream, not just a selection bias. Only the capped paths set it
-  // (autonomous picks in queue.drainToLiquidsoap + the auto.m3u fallback);
-  // explicit listener requests pass null and play in full. A cue_out past a
-  // shorter track's end is a Liquidsoap no-op, so sub-cap tracks play untouched.
-  if (opts.maxDurationSec != null && opts.maxDurationSec > 0) {
-    fields.push(`liq_cue_out="${escAnnotate(opts.maxDurationSec)}"`);
-  }
-  return `annotate:${fields.join(',')}:${getPlayableUri(song)}`;
+export function getAnnotatedUri(song: any, opts: { maxDurationSec?: number | null } = {}) {
+  return buildAnnotatedUri(song, getPlayableUri(song), opts);
 }

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -33,7 +33,7 @@
 // On boot the library-db auto-migrates any state/moods.json into the SQLite
 // tracks table as legacy v1 entries (see library-db.ts).
 
-import * as subsonic from './subsonic.js';
+import { getSource, warmSourceCache } from './source/index.js';
 import * as lastfm from './lastfm.js';
 import * as db from './library-db.js';
 import * as settings from '../settings.js';
@@ -134,15 +134,15 @@ function parseFlags(): CliFlags {
   };
 }
 
-// Walk the entire Navidrome catalogue, upserting each song's metadata into the
-// tracks table and collecting the live id set. Shared by the full tagger run
-// (Phase A) and the standalone --reconcile-only path. Cheap: metadata only, no
-// embeddings or LLM calls.
-async function walkNavidrome(): Promise<{ walked: number; liveIds: Set<string> }> {
-  reportProgress({ phase: 'walk', label: 'Scanning Navidrome library', done: 0 });
+// Walk the entire music library catalogue, upserting each song's metadata into
+// the tracks table and collecting the live id set. Shared by the full tagger
+// run (Phase A) and the standalone --reconcile-only path. Cheap: metadata only,
+// no embeddings or LLM calls.
+async function walkMusicSource(): Promise<{ walked: number; liveIds: Set<string> }> {
+  reportProgress({ phase: 'walk', label: 'Scanning music library', done: 0 });
   let walked = 0;
   const liveIds = new Set<string>();
-  for await (const song of subsonic.iterateAllSongs()) {
+  for await (const song of getSource().iterateAllSongs()) {
     db.upsertTrackMeta(song.id, {
       title: song.title,
       artist: song.artist,
@@ -155,43 +155,43 @@ async function walkNavidrome(): Promise<{ walked: number; liveIds: Set<string> }
     walked += 1;
     if (walked % 500 === 0) {
       console.log(`[tag] walked ${walked} tracks`);
-      reportProgress({ phase: 'walk', label: 'Scanning Navidrome library', done: walked });
+      reportProgress({ phase: 'walk', label: 'Scanning music library', done: walked });
     }
   }
   console.log(`[tag] walked ${walked} total tracks`);
   return { walked, liveIds };
 }
 
-// Standalone reconcile: diff library-db against the live Navidrome catalogue and
-// drop rows (and their vectors) for tracks that are gone. No embedding preflight
-// and no LLM — opens the existing DB at its stored dim so vectors are untouched.
+// Standalone reconcile: diff library-db against the live music source catalogue
+// and drop rows (and their vectors) for tracks that are gone. No embedding
+// preflight and no LLM — opens the existing DB at its stored dim so vectors
+// are untouched.
 async function reconcileOnly() {
   await db.open({ embeddingDim: embeddings.resolveEmbeddingDim(), adoptStoredDim: true });
-  console.log('[tag] reconcile-only: walking Navidrome to prune orphaned rows');
-  const { walked, liveIds } = await walkNavidrome();
+  console.log('[tag] reconcile-only: walking music source to prune orphaned rows');
+  const { walked, liveIds } = await walkMusicSource();
   let pruned = 0;
   if (walked > 0) {
     pruned = db.pruneMissingTracks(liveIds);
-    console.log(`[tag] reconcile pruned ${pruned} orphaned tracks no longer in Navidrome`);
+    console.log(`[tag] reconcile pruned ${pruned} orphaned tracks no longer in music source`);
   } else {
-    // A transient empty Navidrome response must never wipe the DB.
-    console.warn('[tag] reconcile: Navidrome returned 0 tracks — skipping prune');
+    // A transient empty response must never wipe the DB.
+    console.warn('[tag] reconcile: music source returned 0 tracks — skipping prune');
   }
   reportProgress({
     phase: 'done',
     label: pruned > 0
-      ? `Removed ${pruned} track${pruned === 1 ? '' : 's'} no longer in Navidrome`
-      : 'Library is in sync with Navidrome',
+      ? `Removed ${pruned} track${pruned === 1 ? '' : 's'} no longer in music library`
+      : 'Library is in sync with music source',
     done: pruned,
   });
   console.log(`[tag] reconcile complete (walked ${walked}, pruned ${pruned})`);
   process.exit(0);
 }
 
-// Mirrors server.ts boot: cloud API keys from secrets.env, Navidrome creds
+// Mirrors server.ts boot: cloud API keys from secrets.env, music source creds
 // from setup-config.json. Standalone CLIs skip server.ts, so without this
-// they fall back to the hardcoded `http://navidrome:4533` and ENOTFOUND on
-// any install with a custom Navidrome host.
+// they fall back to the hardcoded defaults and ENOTFOUND on custom hosts.
 async function applyWizardOverlay() {
   try {
     await loadSecretsIntoEnv();
@@ -205,6 +205,10 @@ async function applyWizardOverlay() {
       if (!process.env.NAVIDROME_USER && sc.navidrome.user) config.navidrome.user = sc.navidrome.user;
       if (!process.env.NAVIDROME_PASS && sc.navidrome.pass)
         config.navidrome.password = sc.navidrome.pass;
+    }
+    if (sc.plex) {
+      if (!process.env.PLEX_URL && sc.plex.url) config.plex.url = sc.plex.url;
+      if (!process.env.PLEX_TOKEN && sc.plex.token) config.plex.token = sc.plex.token;
     }
   } catch (err: any) {
     console.error('[setup-config] load failed:', err.message);
@@ -232,6 +236,8 @@ async function main() {
 
   await applyWizardOverlay();
   await settings.load();
+  // Load the active music backend (navidrome or plex) before any walk.
+  await warmSourceCache();
 
   // Reconcile is a pure catalogue diff — short-circuit before any embedding /
   // LLM setup so it runs even when embeddings are disabled or unconfigured.
@@ -307,24 +313,24 @@ async function main() {
     for (const [k, v] of Object.entries(m)) byLeg[k] = (byLeg[k] || 0) + v;
   };
 
-  // ---- Phase A: iterate Navidrome and upsert track metadata into DB ------
-  // Cheap; ensures every Navidrome song is in the tracks table so subsequent
-  // phases can operate purely off SQL.
+  // ---- Phase A: iterate music source and upsert track metadata into DB -----
+  // Cheap; ensures every song is in the tracks table so subsequent phases can
+  // operate purely off SQL.
   lap('setup');
-  console.log('[tag] walking Navidrome library...');
-  const { walked, liveIds } = await walkNavidrome();
+  console.log('[tag] walking music library...');
+  const { walked, liveIds } = await walkMusicSource();
 
   // Reconcile against the live catalogue. The walk above is complete and
-  // authoritative, so any track row it didn't see is gone from Navidrome
+  // authoritative, so any track row it didn't see is gone from the music source
   // (typically after a full rescan that re-mints IDs). Pruning the orphans
   // keeps coverage %, untagged scope and analysis scope honest. Guarded on a
-  // non-empty walk so a transient empty Navidrome response can't wipe the DB.
+  // non-empty walk so a transient empty response can't wipe the DB.
   if (flags.noPrune) {
     console.log('[tag] --no-prune: skipping orphan prune (reconcile step deselected)');
   } else if (walked > 0) {
     const pruned = db.pruneMissingTracks(liveIds);
     if (pruned > 0) {
-      console.log(`[tag] pruned ${pruned} orphaned tracks no longer in Navidrome`);
+      console.log(`[tag] pruned ${pruned} orphaned tracks no longer in music source`);
     }
   }
   lap('walk');
@@ -740,7 +746,7 @@ async function phaseEnrich(ids: string[], reEnrich: boolean): Promise<void> {
     let lyricExcerpt: string | null = null;
     if (lyricsEnabled) {
       try {
-        const raw = await subsonic.getLyrics(id);
+        const raw = await getSource().getLyrics(id);
         if (typeof raw === 'string' && raw.trim()) {
           lyricExcerpt = raw.trim();
         }

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -49,6 +49,7 @@ import { isUnreachable, isQuotaOrAuthError } from '../llm/sdk.js';
 import { tagBatch, tagOne, TAGGER_BATCH_SYSTEM, type TagResult } from './tagger-core.js';
 import { runAnalysisPass } from './analyze.js';
 import { reportProgress, formatPhaseBreakdown, sortedPhaseTimings } from './tagger-progress.js';
+import { getTotal as getCoverageTotal, invalidate as invalidateCoverage } from './library-coverage.js';
 import { planRun } from './rescan-scope.js';
 import { mapPool, memoizeByKey } from '../util/async-pool.js';
 
@@ -152,6 +153,7 @@ async function walkMusicSource(): Promise<{ walked: number; liveIds: Set<string>
       duration: song.duration,
       path: song.path ?? null,
       plexPartKey: song._partKey ?? null,
+      plexThumb: song._thumb ?? null,
     });
     liveIds.add(song.id);
     walked += 1;
@@ -180,6 +182,8 @@ async function reconcileOnly() {
     // A transient empty response must never wipe the DB.
     console.warn('[tag] reconcile: music source returned 0 tracks — skipping prune');
   }
+  const cachedTotal = getCoverageTotal();
+  if (cachedTotal === null || cachedTotal !== walked) invalidateCoverage();
   reportProgress({
     phase: 'done',
     label: pruned > 0
@@ -334,6 +338,13 @@ async function main() {
     if (pruned > 0) {
       console.log(`[tag] pruned ${pruned} orphaned tracks no longer in music source`);
     }
+  }
+
+  // Invalidate the coverage cache if the library size changed so the UI
+  // shows the correct total without waiting for the 6h TTL.
+  const cachedTotal = getCoverageTotal();
+  if (cachedTotal === null || cachedTotal !== walked) {
+    invalidateCoverage();
   }
   lap('walk');
 
@@ -875,6 +886,7 @@ async function processBatch(
     album: t.album ?? undefined,
     year: t.year ?? undefined,
     genre: t.genre ?? undefined,
+    lastfmTags: t.lastfmTags ?? undefined,
   }));
   const opts = consumer.pin ? { leg: consumer.pin } : {};
 
@@ -915,6 +927,11 @@ async function processBatch(
       continue;
     }
     const { moods, energy } = result;
+    // LLM returns moods=[] when it genuinely can't determine mood from the
+    // metadata. Don't save that — it would set tagged_at and lock the track
+    // out of the untagged pool forever, making re-tagging impossible.
+    // Leave it as NULL so it stays untagged and can be retried.
+    if (moods.length === 0) continue;
     db.upsertTrackTags(songs[j].id, {
       moods,
       energy,

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -150,6 +150,8 @@ async function walkMusicSource(): Promise<{ walked: number; liveIds: Set<string>
       year: song.year,
       genre: song.genre,
       duration: song.duration,
+      path: song.path ?? null,
+      plexPartKey: song._partKey ?? null,
     });
     liveIds.add(song.id);
     walked += 1;

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -887,6 +887,7 @@ async function processBatch(
     year: t.year ?? undefined,
     genre: t.genre ?? undefined,
     lastfmTags: t.lastfmTags ?? undefined,
+    lyricExcerpt: t.lyricExcerpt ?? undefined,
   }));
   const opts = consumer.pin ? { leg: consumer.pin } : {};
 

--- a/controller/src/music/tagger-core.ts
+++ b/controller/src/music/tagger-core.ts
@@ -62,6 +62,7 @@ export interface TaggableSong {
   year?: number | string | null;
   genre?: string | null;
   lastfmTags?: string[] | null;
+  lyricExcerpt?: string | null;
 }
 
 export interface TagResult {
@@ -83,13 +84,15 @@ function sanitizeTag(parsed: { moods?: unknown; energy?: unknown }): TagResult {
 
 function formatSong(song: TaggableSong): string {
   const tags = song.lastfmTags?.length ? song.lastfmTags.join(', ') : '?';
+  const excerpt = song.lyricExcerpt?.trim() || '?';
   return (
     `Title: ${song.title || '?'} | ` +
     `Artist: ${song.artist || '?'} | ` +
     `Album: ${song.album || '?'} | ` +
     `Year: ${song.year || '?'} | ` +
     `Genre: ${song.genre || '?'} | ` +
-    `Tags: ${tags}`
+    `Tags: ${tags} | ` +
+    `Lyrics/Context: ${excerpt}`
   );
 }
 
@@ -102,13 +105,15 @@ export interface TagOpts {
 
 export async function tagOne(song: TaggableSong, opts: TagOpts = {}): Promise<TagResult> {
   const tags = song.lastfmTags?.length ? song.lastfmTags.join(', ') : '?';
+  const excerpt = song.lyricExcerpt?.trim() || '?';
   const userPrompt =
     `Title: ${song.title}\n` +
     `Artist: ${song.artist || '?'}\n` +
     `Album: ${song.album || '?'}\n` +
     `Year: ${song.year || '?'}\n` +
     `Genre: ${song.genre || '?'}\n` +
-    `Tags: ${tags}`;
+    `Tags: ${tags}\n` +
+    `Lyrics/Context: ${excerpt}`;
 
   const parsed = await djObject({
     system: TAGGER_SYSTEM,

--- a/controller/src/music/tagger-core.ts
+++ b/controller/src/music/tagger-core.ts
@@ -61,6 +61,7 @@ export interface TaggableSong {
   album?: string;
   year?: number | string | null;
   genre?: string | null;
+  lastfmTags?: string[] | null;
 }
 
 export interface TagResult {
@@ -81,12 +82,14 @@ function sanitizeTag(parsed: { moods?: unknown; energy?: unknown }): TagResult {
 }
 
 function formatSong(song: TaggableSong): string {
+  const tags = song.lastfmTags?.length ? song.lastfmTags.join(', ') : '?';
   return (
     `Title: ${song.title || '?'} | ` +
     `Artist: ${song.artist || '?'} | ` +
     `Album: ${song.album || '?'} | ` +
     `Year: ${song.year || '?'} | ` +
-    `Genre: ${song.genre || '?'}`
+    `Genre: ${song.genre || '?'} | ` +
+    `Tags: ${tags}`
   );
 }
 
@@ -98,12 +101,14 @@ export interface TagOpts {
 }
 
 export async function tagOne(song: TaggableSong, opts: TagOpts = {}): Promise<TagResult> {
+  const tags = song.lastfmTags?.length ? song.lastfmTags.join(', ') : '?';
   const userPrompt =
     `Title: ${song.title}\n` +
     `Artist: ${song.artist || '?'}\n` +
     `Album: ${song.album || '?'}\n` +
     `Year: ${song.year || '?'}\n` +
-    `Genre: ${song.genre || '?'}`;
+    `Genre: ${song.genre || '?'}\n` +
+    `Tags: ${tags}`;
 
   const parsed = await djObject({
     system: TAGGER_SYSTEM,

--- a/controller/src/routes/dj.ts
+++ b/controller/src/routes/dj.ts
@@ -541,7 +541,7 @@ router.get('/dj/search', requireAdmin, async (req, res) => {
 // ---------------------------------------------------------------------------
 router.get('/dj/playlists', requireAdmin, async (_req, res) => {
   try {
-    const playlists = await subsonic.getPlaylists();
+    const playlists = await getSource().getPlaylists();
     const results = (Array.isArray(playlists) ? playlists : []).map((p: any) => ({
       id: p.id,
       name: p.name,

--- a/controller/src/routes/dj.ts
+++ b/controller/src/routes/dj.ts
@@ -7,7 +7,7 @@ import express from 'express';
 import { requireAdmin } from '../middleware/auth.js';
 import { queue } from '../broadcast/queue.js';
 import * as dj from '../llm/dj.js';
-import * as subsonic from '../music/subsonic.js';
+import { getSource } from '../music/source/index.js';
 import * as library from '../music/library.js';
 import * as settings from '../settings.js';
 import { runStationId, runHourlyCheck, runLink, refreshAutoPlaylist } from '../broadcast/scheduler.js';
@@ -506,7 +506,7 @@ router.get('/dj/search', requireAdmin, async (req, res) => {
   if (!q) return res.status(400).json({ error: 'q is required' });
   try {
     await library.load();
-    const songs = await subsonic.search(q, { songCount: 12 });
+    const songs = await getSource().search(q, { songCount: 12 });
     const results = songs.map(s => {
       const tag = library.get(s.id);
       return {
@@ -563,9 +563,9 @@ router.get('/dj/recent', requireAdmin, async (req, res) => {
   const limit = Math.min(Math.max(parseInt(String(req.query?.limit || ''), 10) || 20, 1), 50);
   try {
     await library.load();
-    const albums = await subsonic.getRecentlyAddedAlbums({ size: limit });
+    const albums = await getSource().getRecentlyAddedAlbums({ size: limit });
     const songLists = await Promise.all(
-      albums.map((a: any) => subsonic.getAlbum(a.id).catch(() => [])),
+      albums.map((a: any) => getSource().getAlbum(a.id).catch(() => [])),
     );
     const results = songLists.flat().slice(0, limit).map((s: any) => {
       const tag = library.get(s.id);

--- a/controller/src/routes/library.ts
+++ b/controller/src/routes/library.ts
@@ -7,7 +7,7 @@ import { requireAdmin } from '../middleware/auth.js';
 import * as library from '../music/library.js';
 import * as db from '../music/library-db.js';
 import * as coverage from '../music/library-coverage.js';
-import * as subsonic from '../music/subsonic.js';
+import { getSource } from '../music/source/index.js';
 import * as lastfm from '../music/lastfm.js';
 import * as settings from '../settings.js';
 import * as embeddings from '../music/embeddings.js';
@@ -53,7 +53,7 @@ router.get('/library/browse', requireAdmin, async (req, res) => {
     // Drop any station-archive rows the tagger may have written into the index
     // before the subsonic-layer guard existed (issue #273), so the admin library
     // is clean without requiring a re-tag.
-    const cleanRows = result.rows.filter((row) => !subsonic.isStationArchive(row));
+    const cleanRows = result.rows.filter((row) => !getSource().isStationArchive(row));
     const removed = result.rows.length - cleanRows.length;
     result.rows = cleanRows;
     result.total = Math.max(0, result.total - removed);
@@ -84,7 +84,7 @@ router.get('/library/genres', requireAdmin, async (req, res) => {
     await library.load();
     const tagged = library.stats().byGenre || {};
     let navidromeGenres: { value: string; songCount?: number }[] = [];
-    try { navidromeGenres = await subsonic.getGenres(); } catch {}
+    try { navidromeGenres = await getSource().getGenres(); } catch {}
     const merged: Record<string, number> = { ...tagged };
     for (const g of navidromeGenres || []) {
       if (!g?.value) continue;
@@ -150,7 +150,7 @@ router.get('/library/observatory', requireAdmin, async (req, res) => {
     const all = sampled ? db.allTaggedSampled(max, total) : db.allTagged();
     const truncated = sampled;
     const tracks = all
-      .filter((t) => !subsonic.isStationArchive(t))
+      .filter((t) => !getSource().isStationArchive(t))
       .slice(0, max)
       .map((t) => ({
         id: t.id,
@@ -293,12 +293,12 @@ router.get('/library/untagged', requireAdmin, async (req, res) => {
 
   try {
     outer: while (visited < SCAN_BUDGET) {
-      const albums = await subsonic.getAlbumList(albumOffset, BATCH);
+      const albums = await getSource().getAlbumList(albumOffset, BATCH);
       if (albums.length === 0) break;
       for (let i = 0; i < albums.length; i++) {
         const album = albums[i];
         let songs: any[] = [];
-        try { songs = await subsonic.getAlbum(album.id); } catch { songs = []; }
+        try { songs = await getSource().getAlbum(album.id); } catch { songs = []; }
         for (let j = (i === 0 ? songIndex : 0); j < songs.length; j++) {
           const s = songs[j];
           visited++;
@@ -405,7 +405,7 @@ router.post('/library/retag', requireAdmin, async (req, res) => {
     let song: any = req.body || {};
     if (!song.title || !song.artist) {
       // Reach back to Subsonic to fill metadata when the caller only sent an id.
-      const found = await subsonic.search(`${song.title || ''} ${song.artist || ''}`.trim() || id, { songCount: 25 });
+      const found = await getSource().search(`${song.title || ''} ${song.artist || ''}`.trim() || id, { songCount: 25 });
       const hit = (found || []).find((s: any) => s.id === id);
       if (hit) song = { ...hit, ...song };
     }
@@ -446,7 +446,7 @@ router.post('/library/retag', requireAdmin, async (req, res) => {
     }
     if (lyricsEnabled) {
       try {
-        const raw = await subsonic.getLyrics(id);
+        const raw = await getSource().getLyrics(id);
         if (typeof raw === 'string' && raw.trim()) lyricExcerpt = raw.trim();
       } catch (err: any) {
         queue.log('warn', `/library/retag enrich(lyrics) ${id}: ${err.message}`);
@@ -509,7 +509,7 @@ router.post('/library/retag', requireAdmin, async (req, res) => {
 //
 // `moods: []` clears the tags entirely (track returns to the untagged pool).
 // `applyToAlbum` resolves the whole album server-side from the track id
-// (subsonic.getSong → albumId → getAlbum) and applies the same tags to every
+// (getSource().getSong → albumId → getAlbum) and applies the same tags to every
 // track — this is the "tag an album/folder for targeted queuing" path
 // (discussion #336). Moods are restricted to settings.SHOW_MOODS so manual
 // rows feed songsByMood()/MOOD_NEIGHBOURS exactly like LLM-tagged ones.
@@ -539,7 +539,7 @@ router.post('/library/manual-tag', requireAdmin, async (req, res) => {
     // Resolve the seed track — Subsonic first (carries albumId), library-db
     // row as fallback so already-indexed tracks work even if Navidrome misses.
     let song: any = null;
-    try { song = await subsonic.getSong(id); } catch {}
+    try { song = await getSource().getSong(id); } catch {}
     if (!song) {
       const row = db.getTrack(id);
       if (row) song = { id: row.id, title: row.title, artist: row.artist, album: row.album, year: row.year, genre: row.genre, duration: row.durationSec };
@@ -549,7 +549,7 @@ router.post('/library/manual-tag', requireAdmin, async (req, res) => {
     let targets: any[] = [song];
     if (applyToAlbum) {
       if (!song.albumId) return res.status(404).json({ error: 'album not resolvable for this track' });
-      targets = await subsonic.getAlbum(song.albumId);
+      targets = await getSource().getAlbum(song.albumId);
       if (!targets.length) return res.status(404).json({ error: 'album has no tracks' });
     }
 

--- a/controller/src/routes/onboarding.ts
+++ b/controller/src/routes/onboarding.ts
@@ -109,6 +109,35 @@ router.post('/onboarding/test-navidrome', requireAdmin, async (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
+// POST /onboarding/test-plex — body: { url, token }
+// ---------------------------------------------------------------------------
+router.post('/onboarding/test-plex', requireAdmin, async (req, res) => {
+  const { url, token } = req.body || {};
+  if (!url || !token) {
+    return res.status(400).json({ ok: false, error: 'url and token required' });
+  }
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 5000);
+    const r = await fetch(`${String(url).replace(/\/$/, '')}/identity`, {
+      headers: { 'X-Plex-Token': String(token), 'Accept': 'application/json' },
+      signal: ctrl.signal,
+    });
+    clearTimeout(timer);
+    if (!r.ok) return res.json({ ok: false, error: `HTTP ${r.status}` });
+    const data: any = await r.json();
+    const mc = data?.MediaContainer;
+    return res.json({
+      ok: true,
+      version: mc?.version || '',
+      machineIdentifier: mc?.machineIdentifier || '',
+    });
+  } catch (err: any) {
+    return res.json({ ok: false, error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // POST /onboarding/test-llm — body: { provider, model, apiKey?, baseUrl? }
 // Constructs a one-off AI SDK model and asks it for a single token. Does NOT
 // touch the live llm settings.
@@ -220,6 +249,15 @@ router.post('/onboarding/save', requireAdmin, async (req, res) => {
       if (b.navidrome.user) config.navidrome.user = String(b.navidrome.user).trim();
       if (b.navidrome.pass !== undefined) config.navidrome.password = String(b.navidrome.pass);
       clearSetupConfigCache();
+    }
+
+    if (b.plex && typeof b.plex === 'object') {
+      const plexPatch: any = {};
+      if (b.plex.url !== undefined) plexPatch.url = String(b.plex.url || '').trim().replace(/\/$/, '');
+      if (b.plex.token !== undefined) plexPatch.token = String(b.plex.token || '');
+      await saveSetupConfig({ plex: plexPatch });
+      if (plexPatch.url) config.plex.url = plexPatch.url;
+      if (plexPatch.token) config.plex.token = plexPatch.token;
     }
 
     // API keys — persisted to state/secrets.env (mode 0600), also set on

--- a/controller/src/routes/onboarding.ts
+++ b/controller/src/routes/onboarding.ts
@@ -237,27 +237,40 @@ router.post('/onboarding/save', requireAdmin, async (req, res) => {
   try {
     // Navidrome — only the wizard-managed overlay; never mutate the live env.
     if (b.navidrome && typeof b.navidrome === 'object') {
+      const navidromePatch: Record<string, string> = {};
+      if (b.navidrome.url !== undefined) {
+        navidromePatch.url = String(b.navidrome.url || '').trim().replace(/\/$/, '');
+      }
+      if (b.navidrome.user !== undefined) {
+        navidromePatch.user = String(b.navidrome.user || '').trim();
+      }
+      const passVal = String(b.navidrome.pass || '').trim();
+      if (passVal) {
+        navidromePatch.pass = passVal;
+      }
+
       await saveSetupConfig({
-        navidrome: {
-          url: String(b.navidrome.url || '').trim().replace(/\/$/, ''),
-          user: String(b.navidrome.user || '').trim(),
-          pass: String(b.navidrome.pass || ''),
-        },
+        navidrome: navidromePatch,
       });
       // Apply to the live config so subsonic calls work without a restart.
-      if (b.navidrome.url) config.navidrome.url = String(b.navidrome.url).trim().replace(/\/$/, '');
-      if (b.navidrome.user) config.navidrome.user = String(b.navidrome.user).trim();
-      if (b.navidrome.pass !== undefined) config.navidrome.password = String(b.navidrome.pass);
+      if (navidromePatch.url) config.navidrome.url = navidromePatch.url;
+      if (navidromePatch.user) config.navidrome.user = navidromePatch.user;
+      if (passVal) config.navidrome.password = passVal;
       clearSetupConfigCache();
     }
 
     if (b.plex && typeof b.plex === 'object') {
       const plexPatch: any = {};
-      if (b.plex.url !== undefined) plexPatch.url = String(b.plex.url || '').trim().replace(/\/$/, '');
-      if (b.plex.token !== undefined) plexPatch.token = String(b.plex.token || '');
+      if (b.plex.url !== undefined) {
+        plexPatch.url = String(b.plex.url || '').trim().replace(/\/$/, '');
+      }
+      const tokenVal = String(b.plex.token || '').trim();
+      if (tokenVal) {
+        plexPatch.token = tokenVal;
+      }
       await saveSetupConfig({ plex: plexPatch });
       if (plexPatch.url) config.plex.url = plexPatch.url;
-      if (plexPatch.token) config.plex.token = plexPatch.token;
+      if (tokenVal) config.plex.token = tokenVal;
     }
 
     // API keys — persisted to state/secrets.env (mode 0600), also set on

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -5,6 +5,7 @@ import express from 'express';
 import { stat, readFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import * as subsonic from '../music/subsonic.js';
+import * as plexSource from '../music/plex.js';
 import * as library from '../music/library.js';
 import * as settings from '../settings.js';
 import { getFullContext, geocodePlace } from '../context.js';
@@ -72,7 +73,7 @@ router.get('/cover/:id', async (req, res) => {
   const { id } = req.params;
   // Subsonic ids are short alphanumerics (Navidrome uses base32 hashes).
   // Reject anything else to keep this from being a generic SSRF surface.
-  if (!/^[\w-]{1,64}$/.test(id)) return res.status(400).end();
+  if (!/^[\w:.-]{1,80}$/.test(id)) return res.status(400).end();
 
   const sendCover = (entry: { buf: Buffer; contentType: string }) => {
     res.setHeader('Content-Type', entry.contentType);
@@ -92,7 +93,10 @@ router.get('/cover/:id', async (req, res) => {
   try {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), 5000);
-    const r = await fetch(subsonic.getCoverArtUrl(id, 512), { signal: ctrl.signal });
+    const coverUrl = id.startsWith('plex:')
+      ? plexSource.getCoverArtUrl(id, 512)
+      : subsonic.getCoverArtUrl(id, 512);
+    const r = await fetch(coverUrl, { signal: ctrl.signal });
     clearTimeout(timer);
     if (!r.ok) return res.status(502).end();
     const entry = {

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -94,7 +94,7 @@ router.get('/cover/:id', async (req, res) => {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), 5000);
     const coverUrl = id.startsWith('plex:')
-      ? plexSource.getCoverArtUrl(id, 512)
+      ? await plexSource.getCoverArtUrl(id, 512)
       : subsonic.getCoverArtUrl(id, 512);
     const r = await fetch(coverUrl, { signal: ctrl.signal });
     clearTimeout(timer);

--- a/controller/src/routes/request.ts
+++ b/controller/src/routes/request.ts
@@ -4,7 +4,7 @@
 // outcome so the UI can poll for it.
 import express from 'express';
 import { randomUUID } from 'node:crypto';
-import * as subsonic from '../music/subsonic.js';
+import { getSource } from '../music/source/index.js';
 import * as dj from '../llm/dj.js';
 import * as library from '../music/library.js';
 import { getFullContext } from '../context.js';
@@ -69,9 +69,9 @@ async function pickByArtistAndSort({ artistName, sort, scope: _scope, recentIds 
   try {
     // Fuzzy-resolve so a transliteration variance or typo ("Sikandar" vs the
     // library's "Sikander") still lands on the right artist instead of failing.
-    const matchedArtist = await subsonic.resolveArtist(artistName);
+    const matchedArtist = await getSource().resolveArtist(artistName);
     if (!matchedArtist) return null;
-    const artist = await subsonic.getArtist(matchedArtist.id);
+    const artist = await getSource().getArtist(matchedArtist.id);
     let albums = artist?.album || [];
     if (albums.length === 0) return null;
 
@@ -90,7 +90,7 @@ async function pickByArtistAndSort({ artistName, sort, scope: _scope, recentIds 
     // Try the top-ranked album first; if its tracks are all recently played,
     // walk down the list before giving up.
     for (const album of albums.slice(0, 5)) {
-      const songs = await subsonic.getAlbum(album.id);
+      const songs = await getSource().getAlbum(album.id);
       if (songs.length === 0) continue;
       const fresh = songs.filter(s => !recentIds.has(s.id));
       const pool = fresh.length > 0 ? fresh : songs;
@@ -121,13 +121,13 @@ async function pickSimilarToTrack(reference, recentIds: Set<string>) {
     return list[Math.floor(Math.random() * list.length)];
   };
   try {
-    if (await subsonic.supportsSonicSimilarity()) {
-      const pick = pickFresh(await subsonic.getSonicSimilarTracks(id, { count: 25 }));
+    if (await getSource().supportsSonicSimilarity()) {
+      const pick = pickFresh(await getSource().getSonicSimilarTracks(id, { count: 25 }));
       if (pick) return pick;
     }
   } catch (err) { queue.log('error', `more-like-this sonic similar failed: ${err.message}`); }
   try {
-    const pick = pickFresh(await subsonic.getSimilarSongs(id, { count: 25 }));
+    const pick = pickFresh(await getSource().getSimilarSongs(id, { count: 25 }));
     if (pick) return pick;
   } catch (err) { queue.log('error', `more-like-this similar songs failed: ${err.message}`); }
   return null;
@@ -139,7 +139,7 @@ async function pickSimilarToTrack(reference, recentIds: Set<string>) {
 // getSongsByGenre with an exact genre name. Returns the matched name or null.
 async function resolveGenre(name) {
   try {
-    return await subsonic.resolveGenreName(name);
+    return await getSource().resolveGenreName(name);
   } catch (err) {
     queue.log('error', `resolveGenre failed: ${err.message}`);
     return null;
@@ -394,7 +394,7 @@ async function resolveRequest(entry) {
     const genre = await resolveGenre(matched.genre);
     if (genre) {
       try {
-        const songs = await subsonic.getSongsByGenre(genre, { count: 100 });
+        const songs = await getSource().getSongsByGenre(genre, { count: 100 });
         pick = randomFresh(songs);
         if (pick) pickSource = `genre:${genre}`;
       } catch (err) {
@@ -412,7 +412,7 @@ async function resolveRequest(entry) {
     const genre = await resolveGenre(matched.language);
     if (genre) {
       try {
-        const songs = await subsonic.getSongsByGenre(genre, { count: 100 });
+        const songs = await getSource().getSongsByGenre(genre, { count: 100 });
         pick = randomFresh(songs);
         if (pick) pickSource = `language-genre:${genre}`;
       } catch (err) {
@@ -421,7 +421,7 @@ async function resolveRequest(entry) {
     }
     if (!pick) {
       try {
-        const r = await subsonic.search(matched.language, { songCount: 25 });
+        const r = await getSource().search(matched.language, { songCount: 25 });
         pick = randomFresh(r);
         if (pick) pickSource = `language-search:${matched.language}`;
       } catch (err) {
@@ -446,11 +446,11 @@ async function resolveRequest(entry) {
       let candidates: any[] = [];
       for (const term of terms) {
         const songOffset = Math.floor(Math.random() * 3) * 25;
-        let r = await subsonic.search(term, { songCount: 25, songOffset });
+        let r = await getSource().search(term, { songCount: 25, songOffset });
         // A deep offset can land past the end of the result set — fall back
         // to the first page so a valid query never comes back empty.
         if (r.length === 0 && songOffset > 0) {
-          r = await subsonic.search(term, { songCount: 25 });
+          r = await getSource().search(term, { songCount: 25 });
         }
         candidates = [...candidates, ...r];
       }
@@ -479,7 +479,7 @@ async function resolveRequest(entry) {
   // adjacency that wasn't captured in our local mood tags.
   if (!pick && currentTrack?.id && (matched.mood || /similar|like|match/i.test(text))) {
     try {
-      const similar = await subsonic.getSimilarSongs(currentTrack.id, { count: 20 });
+      const similar = await getSource().getSimilarSongs(currentTrack.id, { count: 20 });
       pick = randomFresh(similar);
       if (pick) pickSource = 'similar-to-current';
     } catch {}
@@ -497,7 +497,7 @@ async function resolveRequest(entry) {
   // 2g. Starred — operator's hand-picked favourites are always a safe pick.
   if (!pick) {
     try {
-      const starred = await subsonic.getStarred();
+      const starred = await getSource().getStarred();
       pick = randomFresh(starred);
       if (pick) pickSource = 'starred';
     } catch {}

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -19,6 +19,7 @@ import { restartLiquidsoap, startStream, stopStream, streamStatus } from '../bro
 import { invalidateWeatherCache } from '../context.js';
 import { requireAdmin } from '../middleware/auth.js';
 import { saveSecrets, SECRET_ENV_KEYS } from '../setup/secrets.js';
+import { loadSetupConfig } from '../setup/config.js';
 import { generateText, createGateway } from 'ai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
@@ -64,6 +65,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
     // (issue #230) — only those with a matching .onnx.json manifest are listed.
     const piperVoices = await piper.listPiperVoices();
     const voiceDir = chatterbox.voiceDir();
+    const setupCfg = await loadSetupConfig();
     res.json({
       autoPick: queue.autoPick,
       pickerBusy: queue.pickerBusy,
@@ -76,6 +78,10 @@ router.get('/settings', requireAdmin, async (req, res) => {
       // What the configured zone resolves to when timezone is '' (Auto) —
       // lets the UI label the Auto option with the actual server zone.
       serverTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
+      setup: {
+        navidrome: { url: setupCfg.navidrome?.url || '', user: setupCfg.navidrome?.user || '' },
+        plex: { url: setupCfg.plex?.url || '' },
+      },
       values: {
         jingleRatio: s.jingleRatio,
         crossfadeDuration: s.crossfadeDuration,
@@ -103,6 +109,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
         sfx: s.sfx,
         ui: s.ui,
         scrobble: s.scrobble,
+        music: s.music,
       },
       defaults: {
         // The built-in prompt template — the UI shows this when djPrompt is "".

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -37,6 +37,7 @@ import { router as audienceRoutes } from './routes/audience.js';
 import { router as systemRoutes } from './routes/system.js';
 import { router as generateRoutes } from './routes/generate.js';
 import { router as doctorRoutes } from './routes/doctor.js';
+import { warmSourceCache } from './music/source/index.js';
 import { loadSecretsIntoEnv } from './setup/secrets.js';
 import { loadSetupConfig } from './setup/config.js';
 import { getSetupStatus } from './setup/firstRun.js';
@@ -124,6 +125,13 @@ app.listen(config.server.port, async () => {
     );
   } catch (err) {
     console.error('[settings] load failed:', err.message);
+  }
+
+  // Warm the source cache so the first request picker call returns instantly.
+  try {
+    await warmSourceCache();
+  } catch (err: any) {
+    console.error('[source] warm cache failed:', err.message);
   }
 
   // Start the remote-TTS /health probe loop now that settings are loaded — its

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -41,6 +41,8 @@ import { warmSourceCache } from './music/source/index.js';
 import { loadSecretsIntoEnv } from './setup/secrets.js';
 import { loadSetupConfig } from './setup/config.js';
 import { getSetupStatus } from './setup/firstRun.js';
+import { migrationFlags } from './music/library-db.js';
+import { startTagger, tagger } from './broadcast/tagger.js';
 
 // Fail fast in production if the admin gate isn't configured.
 assertAdminConfigured();
@@ -97,7 +99,7 @@ app.listen(config.server.port, async () => {
     console.error('[secrets] load failed:', err.message);
   }
 
-  // Wizard overlay — Navidrome creds the operator typed in. Env wins; this
+  // Wizard overlay — music source creds the operator typed in. Env wins; this
   // only fills in fields that env didn't already provide.
   try {
     const sc = await loadSetupConfig();
@@ -106,6 +108,10 @@ app.listen(config.server.port, async () => {
       if (!process.env.NAVIDROME_USER && sc.navidrome.user) config.navidrome.user = sc.navidrome.user;
       if (!process.env.NAVIDROME_PASS && sc.navidrome.pass)
         config.navidrome.password = sc.navidrome.pass;
+    }
+    if (sc.plex) {
+      if (!process.env.PLEX_URL && sc.plex.url) config.plex.url = sc.plex.url;
+      if (!process.env.PLEX_TOKEN && sc.plex.token) config.plex.token = sc.plex.token;
     }
   } catch (err: any) {
     console.error('[setup-config] load failed:', err.message);
@@ -132,6 +138,14 @@ app.listen(config.server.port, async () => {
     await warmSourceCache();
   } catch (err: any) {
     console.error('[source] warm cache failed:', err.message);
+  }
+
+  // Migration backfill: if migration 11 just ran, plex_thumb is NULL for all
+  // existing tracks. Auto-start a tagger walk to populate it without any
+  // manual action needed from the operator.
+  if (migrationFlags.needsPlexThumbBackfill && !tagger.running) {
+    console.log('[migration] backfilling plex_thumb — starting tagger walk...');
+    startTagger();
   }
 
   // Start the remote-TTS /health probe loop now that settings are loaded — its

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -197,6 +197,13 @@ function normalizeTtsSpeedMap(raw: any): Record<string, number> {
   return out;
 }
 
+// Music source backends. `navidrome` is the default (Subsonic-compatible);
+// `plex` is the alternative for operators with a Plex Media Server.
+// Validated by settings.music.source; the active source is resolved at
+// runtime by music/source/index.ts.
+export const MUSIC_SOURCES = ['navidrome', 'plex'] as const;
+export type MusicSourceId = typeof MUSIC_SOURCES[number];
+
 // LLM provider abstraction. `ollama` is the homelab default; the cloud
 // providers are opt-in and resolved by llm/provider.js. `openrouter` and
 // `gateway` are aggregators — one key, any vendor's models. `openai-compatible`
@@ -965,6 +972,13 @@ const DEFAULTS = {
   sfx: {
     enabled: true,
   },
+  // Active music source — which backend the controller uses to browse and
+  // stream tracks. 'navidrome' is the default (Subsonic-compatible);
+  // 'plex' is the alternative for operators with a Plex Media Server.
+  // Validated against MUSIC_SOURCES on load/update; defaults to 'navidrome'.
+  music: {
+    source: 'navidrome' as string,
+  },
   // Outbound webhooks. Each entry POSTs station events (see broadcast/
   // webhooks.ts for the event list) to `url` with a fire-and-forget HTTP
   // call. Empty by default — operators add hooks via the admin UI.
@@ -1565,6 +1579,11 @@ export async function load() {
     },
     sfx: {
       enabled: typeof stored.sfx?.enabled === 'boolean' ? stored.sfx.enabled : DEFAULTS.sfx.enabled,
+    },
+    music: {
+      source: (MUSIC_SOURCES as readonly string[]).includes(stored.music?.source)
+        ? stored.music.source
+        : 'navidrome',
     },
     webhooks: normalizeWebhooks(stored.webhooks),
     scrobble: {
@@ -2621,6 +2640,17 @@ export async function update(patch) {
     const sx = patch.sfx || {};
     if (sx.enabled !== undefined) {
       next.sfx.enabled = !!sx.enabled;
+    }
+  }
+  if (patch.music !== undefined && patch.music !== null) {
+    if (typeof patch.music !== 'object') throw new Error('music must be an object');
+    if (patch.music.source !== undefined) {
+      if (!(MUSIC_SOURCES as readonly string[]).includes(patch.music.source)) {
+        throw new Error(`music.source must be one of: ${MUSIC_SOURCES.join(', ')}`);
+      }
+      next.music = { ...next.music, source: patch.music.source };
+      const { invalidateSourceCache } = await import('./music/source/index.js');
+      invalidateSourceCache();
     }
   }
   if ('ui' in patch) {

--- a/controller/src/setup/config.ts
+++ b/controller/src/setup/config.ts
@@ -45,11 +45,12 @@ export async function loadSetupConfig(): Promise<SetupConfig> {
 
 export async function saveSetupConfig(patch: Partial<SetupConfig>): Promise<SetupConfig> {
   const current = await loadSetupConfig();
-  // Shallow-merge top level, deep-merge navidrome to allow partial updates.
+  // Shallow-merge top level, deep-merge navidrome & plex to allow partial updates.
   const next: SetupConfig = {
     ...current,
     ...patch,
     navidrome: { ...(current.navidrome || {}), ...(patch.navidrome || {}) },
+    plex: { ...(current.plex || {}), ...(patch.plex || {}) },
   };
   await mkdir(dirname(PATH), { recursive: true });
   await writeFile(PATH, JSON.stringify(next, null, 2));

--- a/controller/src/setup/config.ts
+++ b/controller/src/setup/config.ts
@@ -23,6 +23,7 @@ export interface SetupConfig {
     user?: string;
     pass?: string;
   };
+  plex?: { url?: string; token?: string };
   // ISO timestamp written when the wizard saves successfully.
   setupCompletedAt?: string;
 }

--- a/controller/src/setup/firstRun.ts
+++ b/controller/src/setup/firstRun.ts
@@ -19,13 +19,10 @@ export interface SetupStatus {
 export async function getSetupStatus(): Promise<SetupStatus> {
   // config.navidrome.* is populated from env at boot; setup-config.json is the
   // wizard's persistence layer. If env supplies values, env wins.
-  const envHasNavidrome = Boolean(
-    process.env.NAVIDROME_URL &&
-      process.env.NAVIDROME_USER &&
-      process.env.NAVIDROME_PASS,
-  );
+  const hasNavidrome = !!(process.env.NAVIDROME_URL && process.env.NAVIDROME_USER && process.env.NAVIDROME_PASS);
+  const hasPlex = !!(process.env.PLEX_URL && process.env.PLEX_TOKEN);
 
-  if (envHasNavidrome) {
+  if (hasNavidrome) {
     return {
       needsSetup: false,
       setupCompletedAt: null,
@@ -33,12 +30,21 @@ export async function getSetupStatus(): Promise<SetupStatus> {
     };
   }
 
+  if (hasPlex) {
+    return {
+      needsSetup: false,
+      setupCompletedAt: null,
+      navidromeSource: 'unset',
+    };
+  }
+
   const sc = await loadSetupConfig();
   const nv = sc.navidrome || {};
   const setupConfigHasNavidrome = Boolean(nv.url && nv.user && nv.pass);
+  const setupConfigHasPlex = Boolean(sc.plex?.url && sc.plex?.token);
 
   return {
-    needsSetup: !setupConfigHasNavidrome,
+    needsSetup: !(setupConfigHasNavidrome || setupConfigHasPlex),
     setupCompletedAt: sc.setupCompletedAt || null,
     navidromeSource: setupConfigHasNavidrome ? 'setup-config' : 'unset',
   };
@@ -56,13 +62,18 @@ export function getSetupStatusSync(): SetupStatus {
   if (envHasNavidrome) {
     return { needsSetup: false, setupCompletedAt: null, navidromeSource: 'env' };
   }
+  const envHasPlex = Boolean(process.env.PLEX_URL && process.env.PLEX_TOKEN);
+  if (envHasPlex) {
+    return { needsSetup: false, setupCompletedAt: null, navidromeSource: 'unset' };
+  }
   // Read the config we already loaded into memory rather than touching disk.
   const url = config.navidrome.url;
   const user = config.navidrome.user;
   const pass = config.navidrome.password;
   const filled = Boolean(url && user && pass && url !== 'http://navidrome:4533');
+  const plexFilled = Boolean(config.plex.url && config.plex.token);
   return {
-    needsSetup: !filled,
+    needsSetup: !(filled || plexFilled),
     setupCompletedAt: null,
     navidromeSource: filled ? 'setup-config' : 'unset',
   };

--- a/controller/src/setup/firstRun.ts
+++ b/controller/src/setup/firstRun.ts
@@ -13,7 +13,7 @@ export interface SetupStatus {
   needsSetup: boolean;
   setupCompletedAt: string | null;
   // Useful for the wizard's "I see you already have NAVIDROME_URL in env" UX.
-  navidromeSource: 'env' | 'setup-config' | 'unset';
+  navidromeSource: 'env' | 'setup-config' | 'plex' | 'plex/env' | 'unset';
 }
 
 export async function getSetupStatus(): Promise<SetupStatus> {
@@ -34,7 +34,7 @@ export async function getSetupStatus(): Promise<SetupStatus> {
     return {
       needsSetup: false,
       setupCompletedAt: null,
-      navidromeSource: 'unset',
+      navidromeSource: 'plex/env',
     };
   }
 
@@ -46,7 +46,7 @@ export async function getSetupStatus(): Promise<SetupStatus> {
   return {
     needsSetup: !(setupConfigHasNavidrome || setupConfigHasPlex),
     setupCompletedAt: sc.setupCompletedAt || null,
-    navidromeSource: setupConfigHasNavidrome ? 'setup-config' : 'unset',
+    navidromeSource: setupConfigHasNavidrome ? 'setup-config' : setupConfigHasPlex ? 'plex' : 'unset',
   };
 }
 
@@ -64,7 +64,7 @@ export function getSetupStatusSync(): SetupStatus {
   }
   const envHasPlex = Boolean(process.env.PLEX_URL && process.env.PLEX_TOKEN);
   if (envHasPlex) {
-    return { needsSetup: false, setupCompletedAt: null, navidromeSource: 'unset' };
+    return { needsSetup: false, setupCompletedAt: null, navidromeSource: 'plex/env' };
   }
   // Read the config we already loaded into memory rather than touching disk.
   const url = config.navidrome.url;
@@ -75,6 +75,6 @@ export function getSetupStatusSync(): SetupStatus {
   return {
     needsSetup: !(filled || plexFilled),
     setupCompletedAt: null,
-    navidromeSource: filled ? 'setup-config' : 'unset',
+    navidromeSource: filled ? 'setup-config' : plexFilled ? 'plex' : 'unset',
   };
 }

--- a/docs/superpowers/specs/2026-06-30-plex-music-source-design.md
+++ b/docs/superpowers/specs/2026-06-30-plex-music-source-design.md
@@ -1,0 +1,358 @@
+# Plex Music Source — Design Spec
+
+**Issue:** perminder-klair/subwave#692
+**Branch:** `feat/plex-music-source`
+**Date:** 2026-06-30
+
+---
+
+## Goal
+
+Add Plex Media Server as a selectable music backend alongside Navidrome. One source is active at a time (selector model). The AI picker, session agent, recency, moods/tags, and all downstream logic stay untouched — only the music-data layer changes.
+
+---
+
+## Owner Decisions (locked, from issue #692)
+
+- **Selector model only** — no merged dual-library. One backend drives the whole station.
+- **Source-tagged ids** — Plex ids are `plex:{ratingKey}` so a future "both at once" mode can be added without a rewrite.
+- **Last.fm for picker parity** — Plex doesn't proxy Last.fm; extend the existing `lastfm.ts` with the methods Plex needs (`getSimilar`, `getTopTracks`, `getArtistInfo`). Already in scrobbling section in UI — not duplicated.
+- **No Plex Pass dependency** — `supportsSonicSimilarity()` returns `false`; picker degrades gracefully.
+
+---
+
+## Plex API (confirmed live against LXC 131 at 192.168.0.158:32400)
+
+### Auth
+- `X-Plex-Token` header for JSON data endpoints
+- `?X-Plex-Token=` query string for stream and cover URLs (so Liquidsoap's `subhttp:` curl sees them)
+- Token lives in `Preferences.xml`; operator pastes it into the admin UI
+
+### Key endpoints
+
+| Purpose | Endpoint |
+|---------|----------|
+| Connection test (no auth) | `GET /identity` |
+| List music libraries | `GET /library/sections` → `type: "artist"` entries |
+| All tracks | `GET /library/sections/{key}/all?type=10` |
+| Random tracks | `?type=10&sort=random` |
+| Recently added | `?type=10&sort=addedAt:desc` |
+| Most played | `?type=10&sort=viewCount:desc` |
+| Genre filter | `?type=10&genre=Pop/Rock` |
+| Artist's albums | `GET /library/metadata/{artistRatingKey}/children` |
+| Album tracks | `GET /library/metadata/{albumRatingKey}/children` |
+| Search | `GET /search?query=&type=10` |
+| Cover art | `{baseUrl}{track.thumb}?X-Plex-Token=` (use `thumb` field directly — contains timestamped path) |
+| Stream | `subhttp:{baseUrl}{Part.key}?X-Plex-Token=` |
+
+### Track object → SubWave song shape
+
+```ts
+// Plex track (JSON, Accept: application/json)
+{
+  ratingKey: "3",
+  title: "Girls Like You",
+  grandparentTitle: "Maroon 5",   // artist
+  parentTitle: "Red Pill Blues",  // album
+  parentYear: 2017,
+  duration: 235568,               // milliseconds
+  thumb: "/library/metadata/2/thumb/1782812114",  // album art path
+  Genre: [{ tag: "Pop/Rock" }],
+  Part: {
+    key: "/library/parts/1/1782811927/file.opus",
+    file: "/media/music/09 - Girls Like You.opus",
+  }
+}
+
+// → SubWave Song
+{
+  id: "plex:3",
+  title: "Girls Like You",
+  artist: "Maroon 5",
+  album: "Red Pill Blues",
+  year: 2017,
+  genre: "Pop/Rock",
+  duration: 235,                  // seconds
+  path: "/media/music/09 - Girls Like You.opus",  // for isStationArchive
+}
+```
+
+---
+
+## Architecture
+
+### New files
+
+#### `controller/src/music/source/types.ts`
+The `MusicSource` interface — every backend satisfies it. Pins the song-object contract.
+
+```ts
+export interface Song {
+  id: string;          // 'plex:{ratingKey}' or bare Navidrome base32
+  title: string;
+  artist: string;
+  album: string;
+  year?: number;
+  genre?: string;
+  duration?: number;   // seconds
+  path?: string;       // local path, for isStationArchive guard
+  crossSec?: number;   // controller-augmented: adaptive crossfade
+  gainDb?: number;     // controller-augmented: loudness normalisation
+}
+
+export interface MusicSource {
+  ping(): Promise<{ ok: boolean; reason?: string }>;
+  isStationArchive(song: Song): boolean;
+  search(query: string, opts?: { songCount?: number; songOffset?: number }): Promise<Song[]>;
+  getRandomSongs(opts?: { size?: number; genre?: string; fromYear?: number; toYear?: number }): Promise<Song[]>;
+  getSongsByGenre(genre: string, opts?: { count?: number }): Promise<Song[]>;
+  getGenres(): Promise<{ value: string; songCount: number; albumCount: number }[]>;
+  resolveGenreName(name: string): Promise<string | null>;
+  resolveArtist(name: string, opts?: { artistCount?: number }): Promise<any | null>;
+  getSimilarSongs(id: string, opts?: { count?: number }): Promise<Song[]>;
+  supportsSonicSimilarity(): Promise<boolean>;
+  getSonicSimilarTracks(id: string, opts?: { count?: number }): Promise<Song[]>;
+  getStarred(): Promise<Song[]>;
+  getRecentlyAddedAlbums(opts?: { size?: number }): Promise<any[]>;
+  getFrequentAlbums(opts?: { size?: number }): Promise<any[]>;
+  getArtistInfo(id: string, opts?: { count?: number }): Promise<any | null>;
+  getTopSongs(artistName: string, opts?: { count?: number }): Promise<Song[]>;
+  getRecentSongsByArtist(artistName: string, opts?: { albums?: number; count?: number }): Promise<Song[]>;
+  getAlbum(id: string): Promise<Song[]>;
+  getSong(id: string): Promise<Song | null>;
+  getArtist(id: string): Promise<any | null>;
+  searchArtists(query: string, opts?: { artistCount?: number }): Promise<any[]>;
+  getArtistLastfmTags(id: string, opts?: { count?: number }): Promise<string[]>;
+  getLyrics(songId: string): Promise<string>;
+  iterateAllSongs(): AsyncGenerator<Song>;
+  getPlaylists(): Promise<any[]>;
+  getPlaylist(id: string): Promise<Song[]>;
+  getCoverArtUrl(id: string, size?: number): string;
+  getStreamUrl(songId: string): string;
+  getRawStreamUrl(songId: string): string;
+  getLocalPath(song: Song): string | null;
+  getPlayableUri(song: Song): string;
+  getAnnotatedUri(song: Song, opts?: { maxDurationSec?: number | null }): string;
+}
+```
+
+#### `controller/src/music/source/index.ts`
+Router — reads `settings.music.source`, returns the active backend. Memoized by config signature (same pattern as `llm/internal/provider/registry.ts`).
+
+```ts
+import * as navidrome from '../subsonic.js';
+import * as plex from '../plex.js';
+import * as settings from '../../settings.js';
+
+let _cached: { source: string; instance: MusicSource } | null = null;
+
+export function getSource(): MusicSource {
+  const source = settings.get().music?.source || 'navidrome';
+  if (_cached?.source === source) return _cached.instance;
+  const instance = source === 'plex' ? plex : navidrome;
+  _cached = { source, instance };
+  return instance;
+}
+
+export function invalidateSourceCache() { _cached = null; }
+```
+
+#### `controller/src/music/plex.ts`
+Full Plex backend satisfying `MusicSource`. Key implementation notes:
+
+- Reads `config.plex.url` and `config.plex.token`
+- All JSON requests: `Accept: application/json` header + `X-Plex-Token` header
+- Stream/cover URLs: token in query string
+- Music section key auto-discovered on first call via `/library/sections` (cached, reset on `invalidateSourceCache()`)
+- `getSimilarSongs` / `getTopSongs` / `getArtistInfo` → route through extended `lastfm.ts` + Plex search resolution
+- `supportsSonicSimilarity()` → `false` always
+- `getLyrics()` → `''` (Plex has lyrics in newer versions but not required)
+- `getLocalPath()` → `null` (Plex is always remote)
+- `isStationArchive()` → checks `song.path` for `archive/` prefix, same logic as Navidrome impl
+- `getAnnotatedUri()` → shared helper extracted from `subsonic.ts`, field name stays `subsonic_id` (value is `plex:3`), adds `source="plex"` annotation
+
+#### Extended `controller/src/music/lastfm.ts`
+Add three methods needed by the Plex backend (Navidrome proxies these via its Subsonic API; Plex doesn't):
+
+```ts
+// New exports:
+export async function getSimilarArtists(artist: string, opts?: { count?: number }): Promise<string[]>
+export async function getTopTracks(artist: string, opts?: { count?: number }): Promise<{ title: string; artist: string }[]>
+export async function getArtistInfo(artist: string): Promise<{ bio?: string; tags?: string[] } | null>
+```
+
+`plex.ts` calls these and resolves names back to Plex tracks via `search()`.
+
+---
+
+### Modified files
+
+#### `controller/src/config.ts`
+Add Plex block:
+```ts
+plex: {
+  url: process.env.PLEX_URL || '',
+  token: process.env.PLEX_TOKEN || '',
+},
+```
+
+#### `controller/src/settings.ts`
+```ts
+export const MUSIC_SOURCES = ['navidrome', 'plex'] as const;
+
+// In DEFAULTS:
+music: { source: 'navidrome' as string },
+
+// In load():
+music: {
+  source: MUSIC_SOURCES.includes(stored.music?.source) ? stored.music.source : 'navidrome',
+},
+
+// In update():
+if (patch.music?.source !== undefined) {
+  if (!MUSIC_SOURCES.includes(patch.music.source)) throw new Error('...');
+  next.music.source = patch.music.source;
+  invalidateSourceCache();  // imported from music/source/index.ts
+}
+```
+
+#### 10 call sites → import from `music/source/index.ts`
+Files: `doctor.ts`, `broadcast/queue.ts`, `broadcast/scheduler.ts`, `llm/internal/tools/segment-tools.ts`, `llm/internal/tools/picker-tools.ts`, `routes/dj.ts`, `routes/debug.ts`, `routes/public.ts`, `routes/library.ts`, `routes/request.ts`
+
+Change: `import * as subsonic from '../music/subsonic.js'` → `import { getSource } from '../music/source/index.js'` + use `getSource()` at call time (not module load time, so source switches take effect immediately).
+
+#### `routes/public.ts` — cover proxy
+```ts
+// Updated id validation — allow source-prefixed ids:
+const ID_RE = /^[\w:-]{1,80}$/;
+
+// Route by prefix:
+const coverUrl = id.startsWith('plex:')
+  ? plex.getCoverArtUrl(id, 512)
+  : subsonic.getCoverArtUrl(id, 512);
+const r = await fetch(coverUrl, { signal: ctrl.signal });
+```
+
+#### `doctor.ts`
+Replace `subsonic.ping()` with `getSource().ping()`. Label shows active source name.
+
+#### `setup/config.ts`
+```ts
+export interface SetupConfig {
+  navidrome?: { url?: string; user?: string; pass?: string };
+  plex?: { url?: string; token?: string };  // ADD
+  setupCompletedAt?: string;
+}
+```
+
+#### `setup/firstRun.ts` — `needsSetup`
+`needsSetup = false` when EITHER Navidrome creds OR Plex URL+token are configured:
+```ts
+const hasNavidrome = !!(nv.url && nv.user && nv.pass) || !!(env.NAVIDROME_URL && env.NAVIDROME_USER && env.NAVIDROME_PASS);
+const hasPlex = !!(setupCfg.plex?.url && setupCfg.plex?.token) || !!(process.env.PLEX_URL && process.env.PLEX_TOKEN);
+needsSetup = !(hasNavidrome || hasPlex);
+```
+
+#### `routes/onboarding.ts`
+Add `POST /onboarding/test-plex` — hits `/identity` with `X-Plex-Token`, returns `{ ok, version, machineIdentifier }`.
+Add Plex save path in `POST /onboarding/save` — saves to `setup-config.json` and patches `config.plex.*` live.
+
+---
+
+## Settings UI — Music Source Section
+
+### New section in `web/components/admin/SettingsPanel.tsx`
+
+Positioned after the existing library/Navidrome fields. Follows existing section pattern exactly:
+
+```
+┌─────────────────────────────────────────┐
+│ Music source                            │
+│                                         │
+│  ┌──────────────┐  ┌─────────────────┐  │
+│  │  Navidrome   │  │      Plex       │  │
+│  │  (selected)  │  │                 │  │
+│  └──────────────┘  └─────────────────┘  │
+│                                         │
+│  [Navidrome fields — shown when active] │
+│  Server URL ______________________      │
+│  Username   ______________________      │
+│  Password   ______________________ 👁   │
+│                                         │
+│  [Plex fields — shown when active]      │
+│  Server URL ______________________      │
+│  X-Plex-Token __________________ 👁    │
+│  field-hint: Found in Plex → Settings   │
+│  → Plex Media Server → General →        │
+│  "X-Plex-Token" or Preferences.xml     │
+│                                         │
+│  [ Test connection ]  [ Save ]          │
+└─────────────────────────────────────────┘
+```
+
+- Source toggle: `Seg` (segmented control) with `Navidrome` | `Plex` — same component used for cloud TTS provider selector
+- Navidrome URL/user/pass: already exist in onboarding only; replicated here, save via `saveSetupConfig` + live `config.navidrome.*` patch
+- Plex URL: save via `saveSetupConfig({ plex: { url } })` + live `config.plex.url` patch
+- Plex token: save via `POST /settings/secrets` with `{ PLEX_TOKEN: value }` — same secrets path used by LLM/TTS API keys
+- Test button: `POST /onboarding/test-plex` (Plex) or existing `POST /onboarding/test-navidrome` (Navidrome)
+- `music.source` setting: saved via `POST /settings` with `{ music: { source: 'plex' | 'navidrome' } }`
+
+### `web/` types changes
+- `SettingsResponse` — add `music?: { source: string }` to `values`
+- Add `PlexSection` component (or inline in `SettingsPanel.tsx` following existing pattern)
+- Add `music` to SECTIONS nav array: `{ id: 'music', label: 'Music', hint: 'source · library', icon: Music2 }`
+
+---
+
+## Unit Test
+
+Pin the Plex song-object normalizer (owner's verification requirement):
+
+```ts
+// controller/src/music/plex.test.ts
+import { normalizePlexTrack } from './plex.js';
+
+test('normalizes Plex track to SubWave Song shape', () => {
+  const plexTrack = {
+    ratingKey: "3",
+    title: "Girls Like You",
+    grandparentTitle: "Maroon 5",
+    parentTitle: "Red Pill Blues",
+    parentYear: 2017,
+    duration: 235568,
+    thumb: "/library/metadata/2/thumb/1782812114",
+    Genre: [{ tag: "Pop/Rock" }],
+    Part: [{ file: "/media/music/09 - Girls Like You.opus", key: "/library/parts/1/1782811927/file.opus" }],
+  };
+  const song = normalizePlexTrack(plexTrack);
+  expect(song.id).toBe('plex:3');
+  expect(song.title).toBe('Girls Like You');
+  expect(song.artist).toBe('Maroon 5');
+  expect(song.album).toBe('Red Pill Blues');
+  expect(song.year).toBe(2017);
+  expect(song.genre).toBe('Pop/Rock');
+  expect(song.duration).toBe(235);
+  expect(song.path).toBe('/media/music/09 - Girls Like You.opus');
+});
+```
+
+---
+
+## Explicitly Out of Scope
+
+- Merged dual-library (owner decided: selector only)
+- Plex Pass sonic analysis
+- Lyrics via Plex
+- Plex playlist sync to Liquidsoap auto.m3u (Navidrome-only feature for now)
+- Global Last.fm section in UI (already in scrobbling)
+
+---
+
+## Verification (from owner's issue)
+
+1. `cd controller && npm run lint` — 0 errors
+2. `cd web && npm run lint` — 0 errors
+3. Unit test for `normalizePlexTrack` passes
+4. Switch `settings.music.source = 'navidrome'` → existing station unchanged (regression guard)
+5. Switch to `plex` → `/api/health` on-air, `/now-playing` advances, `/cover/plex:3` resolves Plex art, `next.txt` carries valid `annotate:…:subhttp:` Plex URL
+6. Listener request + auto-playlist refresh against Plex exercises Last.fm-extended discovery path

--- a/web/components/admin/DoctorPanel.tsx
+++ b/web/components/admin/DoctorPanel.tsx
@@ -226,7 +226,7 @@ export default function DoctorPanel() {
                 </li>
                 <li>
                   <span className="font-bold">The crate</span>{' '}
-                  <span className="text-muted">— Navidrome + your mood tags: connected, and stocked so the picks aren&apos;t blind.</span>
+                  <span className="text-muted">— your music library + mood tags: connected, and stocked so the picks aren&apos;t blind.</span>
                 </li>
                 <li>
                   <span className="font-bold">The mix</span>{' '}
@@ -286,7 +286,7 @@ export default function DoctorPanel() {
           <div>
             <div className="min-w-0 flex-1">
               <p className="text-[14px] leading-[1.6] text-muted">
-                Full assessment of the station — the LLM, Navidrome &amp; library, the broadcast chain,
+                Full assessment of the station — the LLM, music source &amp; library, the broadcast chain,
                 voices, capabilities, content, resources and storage. Where a safe fix exists you can
                 apply it in one click.
               </p>

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -81,7 +81,7 @@ interface SettingsResponse {
   tagger?: TaggerState;
   libraryStats?: LibraryStatsLite;
   // Only the slice this panel needs from the full settings payload.
-  values?: { audio?: { embeddings?: boolean; vocalActivity?: boolean } };
+  values?: { audio?: { embeddings?: boolean; vocalActivity?: boolean }; music?: { source?: string } };
 }
 
 type Tab = 'recent' | 'browse' | 'search' | 'untagged';
@@ -143,6 +143,8 @@ export default function LibraryPanel() {
   const [audioEnabled, setAudioEnabled] = useState<boolean | null>(null);
   // settings.audio.vocalActivity — null until the first /settings poll lands.
   const [vocalEnabled, setVocalEnabled] = useState<boolean | null>(null);
+  // active music source — drives the Search tab hint label.
+  const [musicSource, setMusicSource] = useState<string>('navidrome');
   const [logOpen, setLogOpen] = useState(false);
   const [queuing, setQueuing] = useState<string | null>(null);
   const [retagging, setRetagging] = useState<string | null>(null);
@@ -208,6 +210,7 @@ export default function LibraryPanel() {
         setAudioEnabled(!!j.values.audio.embeddings);
         setVocalEnabled(!!j.values.audio.vocalActivity);
       }
+      if (j.values?.music?.source) setMusicSource(j.values.music.source);
     } catch { /* transient */ }
   }, [adminFetch, ready]);
 
@@ -590,7 +593,7 @@ export default function LibraryPanel() {
       });
       const j = await r.json().catch(() => ({})) as { error?: string };
       if (!r.ok) throw new Error(j.error || `reconcile failed (${r.status})`);
-      notify.ok('reconcile started, scanning Navidrome');
+      notify.ok('reconcile started, scanning music library');
       setLogOpen(true);
       await loadTagger();
     } catch (err) {
@@ -723,7 +726,7 @@ export default function LibraryPanel() {
         onVocalBackfill={vocalBackfill}
       />
 
-      <Tabs tab={tab} setTab={setTab} counts={counts} />
+      <Tabs tab={tab} setTab={setTab} counts={counts} musicSource={musicSource} />
 
       {/* contextual controls */}
       {tab === 'browse' && (
@@ -866,15 +869,16 @@ export default function LibraryPanel() {
 // ---------------------------------------------------------------------------
 // tabs
 // ---------------------------------------------------------------------------
-function Tabs({ tab, setTab, counts }: {
+function Tabs({ tab, setTab, counts, musicSource }: {
   tab: Tab;
   setTab: (t: Tab) => void;
   counts: { browse: number | null; untagged: number | null; recent: number | null };
+  musicSource: string;
 }) {
   const items: { id: Tab; name: string; hint: string; badge: number | null }[] = [
     { id: 'recent', name: 'Recently added', hint: 'newest first', badge: counts.recent },
     { id: 'browse', name: 'Browse', hint: 'tagged index', badge: counts.browse },
-    { id: 'search', name: 'Search', hint: 'navidrome', badge: null },
+    { id: 'search', name: 'Search', hint: musicSource, badge: null },
     { id: 'untagged', name: 'Untagged', hint: 'needs tags', badge: counts.untagged },
   ];
   return (

--- a/web/components/admin/LibraryTaggingModal.tsx
+++ b/web/components/admin/LibraryTaggingModal.tsx
@@ -146,8 +146,8 @@ export default function LibraryTaggingModal(p: Props) {
             </p>
             <div className="grid gap-2.5">
               <Pass on={steps.reconcile} onClick={() => toggleStep('reconcile')}
-                name="Reconcile with Navidrome" tag="quick"
-                hint="Find newly-added tracks and drop ones deleted from Navidrome. Fast — no AI, no model calls." />
+                name="Reconcile library" tag="quick"
+                hint="Find newly-added tracks and drop ones deleted from your music source. Fast — no AI, no model calls." />
               <Pass on={steps.enrich} onClick={() => toggleStep('enrich')}
                 name="Enrich metadata" tag="network"
                 hint="Fetch Last.fm tags + lyrics per track to sharpen the mood read. External API calls — slower on big batches." />

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -534,7 +534,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
                 </>
               ) : (
                 p.tagger?.mode === 'analyze' ? 'Audio analysis in progress…'
-                  : p.tagger?.mode === 'reconcile' ? 'Reconciling with Navidrome…'
+                  : p.tagger?.mode === 'reconcile' ? 'Reconciling library…'
                   : 'Tagging in progress…'
               )}
             </span>
@@ -560,7 +560,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
               (p.tagger?.mode === 'analyze'
                 ? 'The analysis engine is listening to each track: measuring tempo and key, and fingerprinting how it sounds.'
                 : p.tagger?.mode === 'reconcile'
-                  ? 'Checking every track against Navidrome and removing entries for files that no longer exist.'
+                  ? 'Checking every track against your music source and removing entries for files that no longer exist.'
                   : 'The DJ is listening to each new track and deciding its mood & energy.')}
             {' '}You can keep browsing. This runs in the background.
           </div>

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -152,7 +152,7 @@ interface TaggingPanelProps {
 // One friendly sentence per pipeline phase — shown under the live progress so
 // the operator knows what the run is actually doing right now.
 const PHASE_HINT: Record<TaggerProgress['phase'], string> = {
-  walk: 'Reading the track list from Navidrome.',
+  walk: 'Reading the track list from your music library.',
   enrich: 'Fetching Last.fm tags and lyrics that help the DJ understand each track.',
   embed: 'Computing similarity vectors so tags can spread between similar tracks.',
   seed: 'The DJ is deciding mood & energy for a representative set of tracks.',

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -33,7 +33,7 @@ import WebhooksPanel from './WebhooksPanel';
 import BackupPanel from './BackupPanel';
 import {
   Radio, Palette, Cpu, Mic, Library, Search, Music, AudioLines,
-  Activity, Archive, Webhook, Save, AlertTriangle,
+  Activity, Archive, Webhook, Save, AlertTriangle, Music2,
 } from 'lucide-react';
 
 const SECTIONS = [
@@ -45,6 +45,7 @@ const SECTIONS = [
   { id: 'search',   label: 'Web search', hint: 'live-facts backend', icon: Search },
   { id: 'jingles',  label: 'Jingles', hint: 'stingers', icon: Music },
   { id: 'sfx',      label: 'Sound FX', hint: 'agent stingers', icon: AudioLines },
+  { id: 'music',    label: 'Music', hint: 'source · library', icon: Music2 },
   { id: 'scrobble', label: 'Scrobbling', hint: 'last.fm · listenbrainz', icon: Activity },
   { id: 'archives', label: 'Archives', hint: 'hourly recordings', icon: Archive },
   { id: 'webhooks', label: 'Webhooks', hint: 'outbound events', icon: Webhook },
@@ -229,6 +230,22 @@ const MP3_BITRATES = [64, 96, 128, 160, 192, 320] as const;
 const OPUS_BITRATES = [96, 128, 192, 256, 320] as const;
 const AAC_BITRATES = [128, 192, 256] as const;
 
+interface MusicNavidromeForm {
+  url: string;
+  user: string;
+  pass: string;
+}
+
+interface MusicPlexForm {
+  url: string;
+}
+
+interface MusicForm {
+  source: string;
+  navidrome: MusicNavidromeForm;
+  plex: MusicPlexForm;
+}
+
 interface FormState {
   jingleRatio: string;
   crossfadeDuration: string;
@@ -244,6 +261,8 @@ interface FormState {
   search: SearchForm;
   embedding: EmbeddingForm;
   scrobble: ScrobbleForm;
+  music: MusicForm;
+  musicKeyInput: string;
 }
 
 interface JingleEntry {
@@ -320,6 +339,7 @@ interface SettingsData {
       lastfm?: Partial<ScrobbleLastfmForm>;
       listenbrainz?: Partial<ScrobbleListenbrainzForm>;
     };
+    music?: { source?: string };
   };
   tts?: {
     engines?: string[];
@@ -362,6 +382,12 @@ interface SettingsData {
   streamOnAir?: boolean;
   // What timezone '' (Auto) resolves to — the controller's own zone.
   serverTimezone?: string;
+  // Setup config — navidrome/plex credentials from state/setup-config.json.
+  // Returned by /settings when available; used to pre-populate the Music section.
+  setup?: {
+    navidrome?: { url?: string; user?: string };
+    plex?: { url?: string };
+  };
 }
 
 interface SfxForm {
@@ -543,6 +569,18 @@ export default function SettingsPanel() {
           username: v.scrobble?.listenbrainz?.username ?? '',
         },
       },
+      music: {
+        source: v.music?.source || 'navidrome',
+        navidrome: {
+          url: data.setup?.navidrome?.url ?? '',
+          user: data.setup?.navidrome?.user ?? '',
+          pass: '',
+        },
+        plex: {
+          url: data.setup?.plex?.url ?? '',
+        },
+      },
+      musicKeyInput: '',
     });
   }, [data, form]);
 
@@ -815,6 +853,12 @@ export default function SettingsPanel() {
               <ScrobbleSection
                 data={data} form={form} setForm={updateForm} busy={busy}
                 saveSettings={saveSettings} adminFetch={adminFetch} refresh={refresh}
+              />
+            )}
+            {activeSection === 'music' && (
+              <MusicSection
+                data={data} form={form} setForm={updateForm} busy={busy}
+                saveSettings={saveSettings} adminFetch={adminFetch}
               />
             )}
           </>
@@ -5847,6 +5891,207 @@ function ScrobbleSection({ data, form, setForm, busy, saveSettings, adminFetch, 
           }
         />
       </Card>
+    </>
+  );
+}
+
+/* ── Music source ────────────────────────────────────────────────────── */
+
+interface MusicSectionProps extends SectionProps {
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+}
+
+function MusicSection({ data, form, setForm, busy, saveSettings, adminFetch }: MusicSectionProps) {
+  const [testResult, setTestResult] = useState<{ ok: boolean; detail?: string } | null>(null);
+  const [testing, setTesting] = useState(false);
+  const isNavidrome = form.music.source === 'navidrome';
+
+  const testConnection = async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      if (isNavidrome) {
+        const r = await adminFetch('/onboarding/test-navidrome', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            url: form.music.navidrome.url,
+            user: form.music.navidrome.user,
+            pass: form.music.navidrome.pass,
+          }),
+        });
+        const j = (await r.json().catch(() => ({}))) as { ok?: boolean; serverVersion?: string; error?: string };
+        setTestResult({
+          ok: r.ok && j.ok !== false,
+          detail: r.ok && j.ok !== false
+            ? `Navidrome ${j.serverVersion || ''}`.trim()
+            : (j.error || `failed (${r.status})`),
+        });
+      } else {
+        const r = await adminFetch('/onboarding/test-plex', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url: form.music.plex.url, token: form.musicKeyInput }),
+        });
+        const j = (await r.json().catch(() => ({}))) as { ok?: boolean; version?: string; error?: string };
+        setTestResult({
+          ok: r.ok && j.ok !== false,
+          detail: r.ok && j.ok !== false
+            ? `Plex ${j.version || ''}`.trim()
+            : (j.error || `failed (${r.status})`),
+        });
+      }
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const save = async () => {
+    await saveSettings({ music: { source: form.music.source } });
+    if (isNavidrome && (form.music.navidrome.url || form.music.navidrome.user || form.music.navidrome.pass)) {
+      await adminFetch('/onboarding/save', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ navidrome: form.music.navidrome }),
+      });
+    }
+    if (!isNavidrome && form.music.plex.url) {
+      await adminFetch('/onboarding/save', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ plex: { url: form.music.plex.url } }),
+      });
+    }
+    if (!isNavidrome && form.musicKeyInput) {
+      await adminFetch('/settings/secrets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ PLEX_TOKEN: form.musicKeyInput }),
+      });
+    }
+  };
+
+  return (
+    <>
+      <SectionHeader
+        eyebrow="music"
+        title="Music source backend."
+        sub="Choose between Navidrome and Plex as the music library backend. Navidrome uses the Subsonic API; Plex uses X-Plex-Token auth. Only one backend is active at a time."
+        metrics={[
+          { n: data.values?.music?.source || 'navidrome', l: 'source', accent: true },
+        ]}
+      />
+
+      <Card title="Music source" sub="one backend at a time">
+        <div className="rule-label">backend</div>
+        <Seg
+          value={form.music.source}
+          options={[{ id: 'navidrome', label: 'Navidrome' }, { id: 'plex', label: 'Plex' }]}
+          onChange={(v: string) => setForm(f => ({ ...f, music: { ...f.music, source: v } }))}
+        />
+        <div className="field-hint mt-2">
+          {isNavidrome
+            ? 'Navidrome via the Subsonic API. Configure URL and credentials below.'
+            : 'Plex Media Server via X-Plex-Token auth. Enter your server URL and token below.'}
+        </div>
+
+        {isNavidrome && (
+          <>
+            <div className="rule-label">Navidrome</div>
+            <div className="field">
+              <Label>Server URL</Label>
+              <Input
+                value={form.music.navidrome.url}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setForm(f => ({ ...f, music: { ...f.music, navidrome: { ...f.music.navidrome, url: e.target.value } } }))
+                }
+                placeholder="http://navidrome:4533"
+                className="max-w-[360px]"
+              />
+            </div>
+            <div className="field">
+              <Label>Username</Label>
+              <Input
+                value={form.music.navidrome.user}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setForm(f => ({ ...f, music: { ...f.music, navidrome: { ...f.music.navidrome, user: e.target.value } } }))
+                }
+                placeholder="admin"
+                className="max-w-[360px]"
+              />
+            </div>
+            <div className="field">
+              <Label>Password</Label>
+              <Input
+                type="password"
+                value={form.music.navidrome.pass}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setForm(f => ({ ...f, music: { ...f.music, navidrome: { ...f.music.navidrome, pass: e.target.value } } }))
+                }
+                placeholder="leave blank to keep existing"
+                className="max-w-[360px]"
+              />
+            </div>
+          </>
+        )}
+
+        {!isNavidrome && (
+          <>
+            <div className="rule-label">Plex Media Server</div>
+            <div className="field">
+              <Label>Server URL</Label>
+              <Input
+                value={form.music.plex.url}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setForm(f => ({ ...f, music: { ...f.music, plex: { url: e.target.value } } }))
+                }
+                placeholder="http://192.168.0.158:32400"
+                className="max-w-[360px]"
+              />
+              <div className="field-hint">Base URL of your Plex Media Server including port.</div>
+            </div>
+            <div className="field">
+              <Label>X-Plex-Token</Label>
+              <Input
+                type="password"
+                value={form.musicKeyInput}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setForm(f => ({ ...f, musicKeyInput: e.target.value }))
+                }
+                placeholder={data.setup?.plex?.url ? 'set — leave blank to keep' : 'paste your Plex token'}
+                className="max-w-[360px]"
+              />
+              <div className="field-hint">
+                Found in Plex Settings → Troubleshooting → Plex Media Server, or in Preferences.xml as PlexOnlineToken.
+              </div>
+            </div>
+          </>
+        )}
+
+        <div className="flex items-center gap-3 pt-1">
+          <Btn sm onClick={testConnection} disabled={testing || busy}>
+            {testing ? 'Testing…' : 'Test connection'}
+          </Btn>
+          {testResult && (
+            <span
+              className={
+                testResult.ok
+                  ? 'text-[12px] text-[color:var(--accent)]'
+                  : 'text-[12px] text-[var(--danger)]'
+              }
+            >
+              {testResult.ok ? '✓ ' : '✗ '}{testResult.detail}
+            </span>
+          )}
+        </div>
+      </Card>
+
+      <SaveBar
+        note="Applies on the next track pick, no restart needed."
+        busy={busy}
+        onSave={save}
+        saveLabel="Save music source"
+      />
     </>
   );
 }

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -5998,7 +5998,7 @@ function MusicSection({ data, form, setForm, busy, saveSettings, adminFetch }: M
         {isNavidrome && (
           <>
             <div className="rule-label">Navidrome</div>
-            <div className="field">
+            <div className="field mt-3.5">
               <Label>Server URL</Label>
               <Input
                 value={form.music.navidrome.url}
@@ -6009,7 +6009,7 @@ function MusicSection({ data, form, setForm, busy, saveSettings, adminFetch }: M
                 className="max-w-[360px]"
               />
             </div>
-            <div className="field">
+            <div className="field mt-3.5">
               <Label>Username</Label>
               <Input
                 value={form.music.navidrome.user}
@@ -6020,7 +6020,7 @@ function MusicSection({ data, form, setForm, busy, saveSettings, adminFetch }: M
                 className="max-w-[360px]"
               />
             </div>
-            <div className="field">
+            <div className="field mt-3.5">
               <Label>Password</Label>
               <Input
                 type="password"
@@ -6038,7 +6038,7 @@ function MusicSection({ data, form, setForm, busy, saveSettings, adminFetch }: M
         {!isNavidrome && (
           <>
             <div className="rule-label">Plex Media Server</div>
-            <div className="field">
+            <div className="field mt-3.5">
               <Label>Server URL</Label>
               <Input
                 value={form.music.plex.url}
@@ -6050,7 +6050,7 @@ function MusicSection({ data, form, setForm, busy, saveSettings, adminFetch }: M
               />
               <div className="field-hint">Base URL of your Plex Media Server including port.</div>
             </div>
-            <div className="field">
+            <div className="field mt-3.5">
               <Label>X-Plex-Token</Label>
               <Input
                 type="password"
@@ -6062,7 +6062,7 @@ function MusicSection({ data, form, setForm, busy, saveSettings, adminFetch }: M
                 className="max-w-[360px]"
               />
               <div className="field-hint">
-                Found in Plex Settings → Troubleshooting → Plex Media Server, or in Preferences.xml as PlexOnlineToken.
+                In Plex Web: open any media item, click ... → Get Info → View XML. The token appears as X-Plex-Token= in the URL.
               </div>
             </div>
           </>

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -33,7 +33,7 @@ import WebhooksPanel from './WebhooksPanel';
 import BackupPanel from './BackupPanel';
 import {
   Radio, Palette, Cpu, Mic, Library, Search, Music, AudioLines,
-  Activity, Archive, Webhook, Save, AlertTriangle, Music2,
+  Activity, Archive, Webhook, Save, AlertTriangle, Music2, HelpCircle,
 } from 'lucide-react';
 
 const SECTIONS = [
@@ -5904,6 +5904,7 @@ interface MusicSectionProps extends SectionProps {
 function MusicSection({ data, form, setForm, busy, saveSettings, adminFetch }: MusicSectionProps) {
   const [testResult, setTestResult] = useState<{ ok: boolean; detail?: string } | null>(null);
   const [testing, setTesting] = useState(false);
+  const [showTokenGuide, setShowTokenGuide] = useState(false);
   const isNavidrome = form.music.source === 'navidrome';
 
   const testConnection = async () => {
@@ -6051,7 +6052,18 @@ function MusicSection({ data, form, setForm, busy, saveSettings, adminFetch }: M
               <div className="field-hint">Base URL of your Plex Media Server including port.</div>
             </div>
             <div className="field mt-3.5">
-              <Label>X-Plex-Token</Label>
+              <div className="flex items-center gap-2">
+                <Label>X-Plex-Token</Label>
+                <button
+                  type="button"
+                  onClick={() => setShowTokenGuide(true)}
+                  className="flex items-center gap-1 text-[11px] text-muted hover:text-ink transition-colors"
+                  aria-label="How to find your Plex token"
+                >
+                  <HelpCircle size={12} />
+                  <span>How to find</span>
+                </button>
+              </div>
               <Input
                 type="password"
                 value={form.musicKeyInput}
@@ -6061,12 +6073,38 @@ function MusicSection({ data, form, setForm, busy, saveSettings, adminFetch }: M
                 placeholder={data.setup?.plex?.url ? 'set — leave blank to keep' : 'paste your Plex token'}
                 className="max-w-[360px]"
               />
-              <div className="field-hint">
-                In Plex Web: open any media item, click ... → Get Info → View XML. The token appears as X-Plex-Token= in the URL.
-              </div>
             </div>
           </>
         )}
+
+        <Modal
+          open={showTokenGuide}
+          onOpenChange={setShowTokenGuide}
+          title="Finding your X-Plex-Token"
+          sub="one-time setup"
+          width={500}
+          footer={<Btn onClick={() => setShowTokenGuide(false)}>Done</Btn>}
+        >
+          <div className="space-y-4 text-sm">
+            <div>
+              <div className="eyebrow mb-2">Method 1 — Plex Web App</div>
+              <ol className="list-decimal pl-4 space-y-1.5 text-ink/80 leading-relaxed">
+                <li>Open your Plex Web App (e.g. <code className="caption bg-[var(--ink-softer)] px-1 rounded">{form.music.plex.url || 'http://your-plex:32400'}/web</code>)</li>
+                <li>Click on any song, album, or movie</li>
+                <li>Click the <strong>...</strong> (three-dot) menu on the item</li>
+                <li>Click <strong>Get Info</strong></li>
+                <li>In the dialog, click <strong>View XML</strong></li>
+                <li>Look at the URL in the new tab — copy the value after <code className="caption bg-[var(--ink-softer)] px-1 rounded">X-Plex-Token=</code></li>
+              </ol>
+            </div>
+            <div className="border-t border-ink/20 pt-4">
+              <div className="eyebrow mb-2">Method 2 — Preferences.xml (server)</div>
+              <p className="text-ink/70 mb-2">SSH into your Plex server and run:</p>
+              <pre className="caption bg-[var(--ink-softer)] p-2 rounded overflow-x-auto">grep PlexOnlineToken &quot;/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Preferences.xml&quot;</pre>
+              <p className="field-hint mt-1">The token is the value of the <code>PlexOnlineToken</code> attribute.</p>
+            </div>
+          </div>
+        </Modal>
 
         <div className="flex items-center gap-3 pt-1">
           <Btn sm onClick={testConnection} disabled={testing || busy}>

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -5956,18 +5956,14 @@ function MusicSection({ data, form, setForm, busy, saveSettings, adminFetch }: M
         body: JSON.stringify({ navidrome: form.music.navidrome }),
       });
     }
-    if (!isNavidrome && form.music.plex.url) {
+    if (!isNavidrome && (form.music.plex.url || form.musicKeyInput)) {
+      const plexBody: Record<string, string> = {};
+      if (form.music.plex.url) plexBody.url = form.music.plex.url;
+      if (form.musicKeyInput) plexBody.token = form.musicKeyInput;
       await adminFetch('/onboarding/save', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ plex: { url: form.music.plex.url } }),
-      });
-    }
-    if (!isNavidrome && form.musicKeyInput) {
-      await adminFetch('/settings/secrets', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ PLEX_TOKEN: form.musicKeyInput }),
+        body: JSON.stringify({ plex: plexBody }),
       });
     }
   };

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -6053,7 +6053,7 @@ function MusicSection({ data, form, setForm, busy, saveSettings, adminFetch }: M
                 <button
                   type="button"
                   onClick={() => setShowTokenGuide(true)}
-                  className="flex items-center gap-1 text-[11px] text-muted hover:text-ink transition-colors"
+                  className="flex items-center gap-1 text-[11px] text-muted transition-colors hover:text-ink"
                   aria-label="How to find your Plex token"
                 >
                   <HelpCircle size={12} />
@@ -6084,19 +6084,19 @@ function MusicSection({ data, form, setForm, busy, saveSettings, adminFetch }: M
           <div className="space-y-4 text-sm">
             <div>
               <div className="eyebrow mb-2">Method 1 — Plex Web App</div>
-              <ol className="list-decimal pl-4 space-y-1.5 text-ink/80 leading-relaxed">
-                <li>Open your Plex Web App (e.g. <code className="caption bg-[var(--ink-softer)] px-1 rounded">{form.music.plex.url || 'http://your-plex:32400'}/web</code>)</li>
+              <ol className="list-decimal space-y-1.5 pl-4 leading-relaxed text-ink/80">
+                <li>Open your Plex Web App (e.g. <code className="caption rounded bg-[var(--ink-softer)] px-1">{form.music.plex.url || 'http://your-plex:32400'}/web</code>)</li>
                 <li>Click on any song, album, or movie</li>
                 <li>Click the <strong>...</strong> (three-dot) menu on the item</li>
                 <li>Click <strong>Get Info</strong></li>
                 <li>In the dialog, click <strong>View XML</strong></li>
-                <li>Look at the URL in the new tab — copy the value after <code className="caption bg-[var(--ink-softer)] px-1 rounded">X-Plex-Token=</code></li>
+                <li>Look at the URL in the new tab — copy the value after <code className="caption rounded bg-[var(--ink-softer)] px-1">X-Plex-Token=</code></li>
               </ol>
             </div>
             <div className="border-t border-ink/20 pt-4">
               <div className="eyebrow mb-2">Method 2 — Preferences.xml (server)</div>
-              <p className="text-ink/70 mb-2">SSH into your Plex server and run:</p>
-              <pre className="caption bg-[var(--ink-softer)] p-2 rounded overflow-x-auto">grep PlexOnlineToken &quot;/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Preferences.xml&quot;</pre>
+              <p className="mb-2 text-ink/70">SSH into your Plex server and run:</p>
+              <pre className="caption overflow-x-auto rounded bg-[var(--ink-softer)] p-2">grep PlexOnlineToken &quot;/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Preferences.xml&quot;</pre>
               <p className="field-hint mt-1">The token is the value of the <code>PlexOnlineToken</code> attribute.</p>
             </div>
           </div>


### PR DESCRIPTION
Closes #692.

## What

Adds Plex as a fully supported music source alongside Navidrome. Operators can switch between the two in the admin settings. All major subsystems, including library walks, cover art, tagging, enrichment, playback, the doctor, and the coverage counter, now route through the active source instead of assuming Navidrome.

## Why

Plex users did not have a fully working integration.

* Cover art requests returned 404s because Plex track artwork is resolved through the album rather than the track.
* The library was never walked or tagged because the tagger was hardcoded to Navidrome.
* Last.fm enrichment was silently skipped because the fallback path always called Navidrome, even when Plex was the active source.
* Tracks with ambiguous metadata could become permanently stuck in the untagged pool because an empty mood response still wrote `tagged_at`, marking the track as processed without valid tags.

## How tested

* Switched the music source to Plex in the admin settings and verified that credentials persist across restarts and source changes.
* Ran a full library walk and tagger against a Plex library. Confirmed that cover art, playback URIs, and mood tags are handled correctly.
* Verified that cover art resolves correctly for tracks that have not yet been imported into the database by using the live API fallback.
* Confirmed that tracks receiving empty mood results from the LLM remain in the untagged pool instead of being permanently marked as tagged.
* Verified that Last.fm enrichment runs correctly for Plex artists, both with and without an API key configured.
* Confirmed that the coverage counter updates automatically after a tagger run without requiring a manual refresh.
* Regression tested the Navidrome path to ensure all existing behavior is preserved.

## Notes for reviewers

`getCoverArtUrl()` on the Plex source is now asynchronous, while the Navidrome implementation remains synchronous. `public.ts` branches on the `plex:` ID prefix and awaits only the Plex implementation when required.

For tagging, the Plex **Mood** field (acoustic and MusicBrainz-derived tags stored per track) is used as the equivalent contextual signal that lyrics provide on the Navidrome path. It serves the same purpose for the LLM tagger, even though the underlying data differs.

Migration 11 adds the `plex_thumb` and `plex_part_key` columns. When Plex is the active source, the tagger backfills both fields during the first tagging pass.
