### PR TITLE
Fix/acoustic analysis disabled state

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3387,6 +3387,7 @@ html.lite *::after {
     padding: 12px 13px; cursor: pointer; text-align: left; font-family: inherit;
 }
 .admin-root .lib-pass:hover { border-color: var(--ink); }
+.admin-root .lib-pass:disabled { opacity: 0.4; cursor: not-allowed; pointer-events: none; }
 .admin-root .lib-pass.on { border-color: var(--accent); background: var(--accent-soft); }
 .admin-root .lib-pass .box {
     width: 15px; height: 15px; border: 1px solid var(--ink); flex: none; margin-top: 2px;

--- a/web/components/admin/LibraryTaggingModal.tsx
+++ b/web/components/admin/LibraryTaggingModal.tsx
@@ -218,8 +218,8 @@ export default function LibraryTaggingModal(p: Props) {
                 hint="Drop & rebuild the similarity vectors you already have — re-spends embedding calls. Only after changing the embedding model." />
               <Pass on={!!passes.upgrade} onClick={() => togglePass('upgrade')} name="Re-decide moods" tag="AI · billed"
                 hint="Re-tag already-tagged rows whose prompt or model has gone stale (never your manual tags). No model change → nothing to redo. Uses model calls." />
-              <Pass on={!!passes.reAnalyze} onClick={() => togglePass('reAnalyze')} name="Re-analyse acoustics" tag="slow"
-                hint="Redo bpm/key + sounds-like for tracks you've already analysed. Drops their acoustic data and rebuilds it." />
+              <Pass on={!!passes.reAnalyze} onClick={() => togglePass('reAnalyze')} disabled={p.analysisOff} name="Re-analyse acoustics" tag="slow"
+                hint={p.analysisOff ? 'No analysis engine running — start the tts-heavy sidecar or a local librosa venv.' : 'Redo bpm/key + sounds-like for tracks you\'ve already analysed. Drops their acoustic data and rebuilds it.'} />
               {p.vocalWanted && (
                 <div className="pl-6">
                   <Pass on={!!passes.reAnalyze && reAnalyzeVocal} onClick={() => setReAnalyzeVocal(v => !v)}


### PR DESCRIPTION
## What

The **Re-analyse acoustics** pass in the **Rescan** tab was always clickable, even when no acoustic analysis engine was running. The **Analyze acoustics** pass in the **Run** tab already had the correct disabled logic, but there was no visual styling to indicate that it was disabled.

## Why

The **Rescan** tab was missing `disabled={p.analysisOff}` entirely, most likely due to a copy-and-paste oversight when the tab was implemented. As a result, users could select the pass and start a rescan that would silently do nothing, with no indication of why.

The **Run** tab already had the correct disabled guard, but `.lib-pass:disabled` had no corresponding CSS rule. Disabled buttons therefore appeared identical to enabled ones across both tabs.

## How tested

* Verified that with no `tts-heavy` sidecar running, both **Analyze acoustics** (Run tab) and **Re-analyse acoustics** (Rescan tab) are greyed out and cannot be clicked.
* Started the `tts-heavy` sidecar and confirmed that both passes become fully interactive.
* Verified that there are no regressions for the other library passes (`enrich`, `embed`, `tag`, `reseed`, and `upgrade`).
