### PR TITLE
feat(admin): full-screen editor dialog + unified list cards

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -435,6 +435,26 @@ body::after {
 .v3-modal-pop {
     animation: v3-modal-pop 160ms cubic-bezier(0.2, 0.7, 0.2, 1);
 }
+
+/* V3 AlertDialog — smooth fade + zoom on open AND close, keyed on Radix's
+   data-state (the shadcn pattern). Centering is the static -translate-* (CSS
+   `translate` property), so the keyframe's `transform: scale()` composes with
+   it and the box zooms from its own centre. Radix's Presence waits for the
+   `closed` animation before unmounting. */
+@keyframes v3-alert-overlay-in { from { opacity: 0; } to { opacity: 1; } }
+@keyframes v3-alert-overlay-out { from { opacity: 1; } to { opacity: 0; } }
+@keyframes v3-alert-pop-in {
+    from { opacity: 0; transform: scale(0.96); }
+    to { opacity: 1; transform: scale(1); }
+}
+@keyframes v3-alert-pop-out {
+    from { opacity: 1; transform: scale(1); }
+    to { opacity: 0; transform: scale(0.96); }
+}
+.v3-alert-overlay[data-state="open"] { animation: v3-alert-overlay-in 160ms ease-out; }
+.v3-alert-overlay[data-state="closed"] { animation: v3-alert-overlay-out 140ms ease-in; }
+.v3-alert-content[data-state="open"] { animation: v3-alert-pop-in 170ms cubic-bezier(0.2, 0.7, 0.2, 1); }
+.v3-alert-content[data-state="closed"] { animation: v3-alert-pop-out 140ms ease-in; }
 .v3-blink {
     animation: v3-blink 1s steps(1) infinite;
 }
@@ -748,6 +768,8 @@ body::after {
     }
     .v3-drawer-content,
     .v3-drawer-overlay,
+    .v3-alert-overlay,
+    .v3-alert-content,
     .v3-blink,
     .v3-tunein-pulse,
     .v3-connecting-pulse,
@@ -2824,6 +2846,27 @@ html.lite *::after {
 .admin-root .card-body.loose {
     padding: 18px;
 }
+/* Flat — used inside EditorDialog so stacked sections read as one continuous
+   modal form separated by hairline dividers, not boxed cards. No border/bg, no
+   side padding (the dialog supplies the gutter); a top rule divides each section
+   from the previous one. The first section in a group has no rule. */
+.admin-root .card.is-flat {
+    border: 0;
+    background: transparent;
+    border-top: 1px solid var(--soft-border);
+    padding: 26px 0;
+}
+.admin-root .card.is-flat:first-child {
+    border-top: 0;
+    padding-top: 0;
+}
+.admin-root .card.is-flat > .card-head {
+    padding: 0 0 14px;
+    border-bottom: 0;
+}
+.admin-root .card.is-flat > .card-body {
+    padding: 0;
+}
 /* Spotlight — lifts a card above the plain stack with an accent rail + faint
    wash. Used for DJ Doc's verdict ("DJ Doc says") so the operator's eye lands
    on the producer's read before the raw findings. */
@@ -4319,16 +4362,13 @@ html.lite *::after {
 }
 
 /* ───────────────────────────────────────────────────────────────────────────
-   Skill Edit Card ("segment sheet") modal — /admin/skills. Pseudo-elements and
-   keyframes the SkillEditModal sheet relies on (kept here, not injected from
-   JS). Scoped to .sw-seg so they can't leak into the rest of the admin.
+   Skill Edit Card ("segment sheet") typography — /admin/skills. The SkillEditModal
+   body now renders inside the shared full-screen EditorDialog, which carries the
+   `sw-seg` class so these descendant rules still resolve (focus accents, muted
+   placeholders, the brief drop-cap). Scoped to .sw-seg so they can't leak into
+   the rest of the admin. The old sheet's spin/ring/blink keyframes went with the
+   bespoke overlay — the flash now uses the shared `v3-blink`.
    ─────────────────────────────────────────────────────────────────────────── */
-@keyframes sw-spin { to { transform: rotate(360deg); } }
-@keyframes sw-ring {
-    0% { box-shadow: 0 0 0 0 color-mix(in oklab, var(--accent) 55%, transparent); }
-    70%, 100% { box-shadow: 0 0 0 8px transparent; }
-}
-@keyframes sw-blink { 0%, 45% { opacity: 1; } 55%, 100% { opacity: 0.2; } }
 .sw-seg textarea:focus, .sw-seg input:focus { border-color: var(--accent) !important; }
 .sw-seg ::placeholder { color: var(--muted); opacity: 0.75; }
 .sw-seg .sw-ghost:hover { background: var(--ink-soft); }
@@ -4337,6 +4377,7 @@ html.lite *::after {
     font-size: 2.7em; font-weight: 800; float: left; line-height: 0.74;
     color: var(--accent); padding: 4px 9px 0 0;
 }
-@media (prefers-reduced-motion: reduce) {
-    .sw-seg [style*="sw-spin"], .sw-seg [style*="sw-ring"] { animation: none !important; }
-}
+/* Body sections — hairline dividers between them, matching .card.is-flat, so the
+   skills editor reads as one continuous modal form rather than spaced blocks. */
+.sw-seg .sw-section { border-top: 1px solid var(--soft-border); padding: 26px 0; }
+.sw-seg .sw-section:first-child { border-top: 0; padding-top: 0; }

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -32,6 +32,11 @@ export default function PersonasPanel() {
   const [busy, setBusy] = useState(false);
   // index of the persona being edited
   const [focusIdx, setFocusIdx] = useState(0);
+  // whether the full-screen persona editor is open (the roster is the browse
+  // view; selecting a card or adding a persona opens this).
+  const [editorOpen, setEditorOpen] = useState(false);
+  // id of a freshly-added persona — the AI-draft field shows only while creating.
+  const [creatingId, setCreatingId] = useState<string | null>(null);
   // toggles the system-prompt editor card
   const [showPrompt, setShowPrompt] = useState(false);
   // Bumped on every avatar mutation. Appended as ?v=… so the admin <img>
@@ -136,13 +141,14 @@ export default function PersonasPanel() {
     // The new persona lands at the end of the roster — its index is the
     // current length. Capture it before the append so we can focus it.
     const newIdx = form.personas.length;
+    const newId = clientMintId();
     setForm(f => {
       if (!f) return f;
       if (f.personas.length >= PERSONA_MAX) return f;
       return {
         ...f,
         personas: [...f.personas, {
-          id: clientMintId(), name: 'New persona', tagline: '',
+          id: newId, name: 'New persona', tagline: '',
           frequency: 'moderate', scriptLength: 'concise', djMode: false,
           humour: DIAL_NEUTRAL, localColour: DIAL_NEUTRAL, warmth: DIAL_NEUTRAL, soul: '',
           language: '',
@@ -156,7 +162,9 @@ export default function PersonasPanel() {
     // with a toast — otherwise the add is silent and the operator never notices
     // the entry tucked at the end of the roster.
     scrollToEditorRef.current = true;
+    setCreatingId(newId);
     setFocusIdx(newIdx);
+    setEditorOpen(true);
     notify.ok('New persona added. Fill in its details, then Save persona.');
   };
   const removePersona = (i: number) =>
@@ -250,8 +258,8 @@ export default function PersonasPanel() {
   const canSave = !!form && allPersonasOk && promptOk
     && form.personas.some(p => p.id === form.activePersonaId);
 
-  const save = async () => {
-    if (!canSave || !form) return;
+  const save = async (): Promise<boolean> => {
+    if (!canSave || !form) return false;
     setBusy(true);
     try {
       const r = await adminFetch('/settings', {
@@ -294,8 +302,10 @@ export default function PersonasPanel() {
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
       notify.ok('personas saved, applies on the next spoken line');
       await load();
+      return true;
     } catch (e) {
       notify.err(errorMessage(e));
+      return false;
     } finally { setBusy(false); }
   };
 
@@ -352,10 +362,6 @@ export default function PersonasPanel() {
         onAirShow={onAirShow}
         defaultEngine={defaultEngine}
         onAirCloudIssue={onAirCloudIssue}
-        personaCount={form.personas.length}
-        showPrompt={showPrompt}
-        onTogglePrompt={() => setShowPrompt(s => !s)}
-        onAdd={addPersona}
       />
 
       {showPrompt && (
@@ -376,10 +382,11 @@ export default function PersonasPanel() {
         personas={form.personas}
         activePersonaId={form.activePersonaId}
         onAirPersonaId={onAirPersonaId}
-        focusedIdx={safeIdx}
         avatarTick={avatarTick}
-        onSelect={setFocusIdx}
+        showPrompt={showPrompt}
+        onTogglePrompt={() => setShowPrompt(s => !s)}
         onAdd={addPersona}
+        onSelect={(i) => { setCreatingId(null); setFocusIdx(i); setEditorOpen(true); }}
       />
 
       <PersonaEditor
@@ -396,6 +403,9 @@ export default function PersonasPanel() {
         cloudIssueText={focusedCloudIssue}
         skillCatalog={skillCatalog}
         editorRef={editorRef}
+        open={editorOpen}
+        isNew={focused.id === creatingId}
+        onClose={() => setEditorOpen(false)}
         setPersona={setPersona}
         setPersonaTts={setPersonaTts}
         setPersonaSkills={setPersonaSkills}
@@ -409,8 +419,8 @@ export default function PersonasPanel() {
         allPersonasOk={allPersonasOk}
         promptOk={promptOk}
         busy={busy}
-        onSave={save}
-        onDiscard={load}
+        onSave={async () => { if (await save()) setEditorOpen(false); }}
+        onDiscard={() => { load(); setEditorOpen(false); }}
       />
 
       <V3AlertDialog
@@ -433,6 +443,7 @@ export default function PersonasPanel() {
             setFocusIdx(i => Math.max(0, i - 1));
           }
           setConfirmDeleteIdx(null);
+          setEditorOpen(false);
         }}
       />
     </div>

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -27,6 +27,7 @@ import {
 } from '../ui/select';
 import { Card, Btn, Pill, Eyebrow, Metric, Toggle } from './ui';
 import { V3AlertDialog } from '../ui/alert-dialog';
+import { EditorDialog } from '../ui/editor-dialog';
 import { AiFill } from './AiFill';
 import GenreSuggest from './GenreSuggest';
 import { PersonaPicker, ThemePicker } from './ShowPickers';
@@ -239,6 +240,8 @@ export default function ShowsPanel() {
   // (null = none open). Shows are edited in place — no modal, no draft copy;
   // edits land straight on `form.shows[focusIdx]` and persist on Save schedule.
   const [focusIdx, setFocusIdx] = useState<number | null>(null);
+  // id of a freshly-added show — the AI-draft field shows only while creating.
+  const [creatingId, setCreatingId] = useState<string | null>(null);
   // The editor block, scrolled into view when a show is opened (add / edit) so
   // the operator actually sees it — it stacks below the list and would else be
   // off-screen. The flag gates the scroll to deliberate opens (not re-renders).
@@ -411,7 +414,7 @@ export default function ShowsPanel() {
     setForm(f => f ? ({ ...f, shows: f.shows.map((s, idx) => (idx === i ? { ...s, ...patch } : s)) }) : f);
 
   // Open an existing show in the editor below the list, scrolling it into view.
-  const focusShow = (i: number) => { scrollToEditorRef.current = true; setFocusIdx(i); };
+  const focusShow = (i: number) => { scrollToEditorRef.current = true; setCreatingId(null); setFocusIdx(i); };
 
   // Append a fresh show (persona + mood pre-filled, name blank so it reads as
   // incomplete until named) and open it for editing.
@@ -436,6 +439,7 @@ export default function ShowsPanel() {
     // arm the new show as the brush if nothing is armed yet
     setBrush(b => b ?? id);
     scrollToEditorRef.current = true;
+    setCreatingId(id);
     setFocusIdx(newIdx);
     notify.ok('New show added — give it a name, persona and mood, then Save schedule.');
   };
@@ -547,8 +551,8 @@ export default function ShowsPanel() {
     return { day: d, hour: h, showId: form?.schedule?.[d]?.[h] ?? null };
   };
 
-  const save = async () => {
-    if (!canSave || !form) return;
+  const save = async (): Promise<boolean> => {
+    if (!canSave || !form) return false;
     setBusy(true);
     try {
       const r = await adminFetch('/settings', {
@@ -573,8 +577,10 @@ export default function ShowsPanel() {
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
       notify.ok('schedule saved, the current hour applies on the next pick');
       await load();
+      return true;
     } catch (e) {
       notify.err(errorMessage(e));
+      return false;
     } finally { setBusy(false); }
   };
 
@@ -761,44 +767,37 @@ export default function ShowsPanel() {
       </Card>
 
       {/* ── SHOW DEFINITIONS ─────────────────────────────────────────────── */}
-      <Card
-        title="Show definitions"
-        sub={`${form.shows.length}/${SHOWS_MAX} shows`}
-        right={<Btn sm tone="accent" onClick={addShow}
-          disabled={form.shows.length >= SHOWS_MAX || personas.length === 0}>
+      <div className="mt-1 flex flex-wrap items-center justify-between gap-3">
+        <span className="caption">show definitions · {form.shows.length}/{SHOWS_MAX} shows</span>
+        <Btn
+          tone="accent"
+          onClick={addShow}
+          disabled={form.shows.length >= SHOWS_MAX || personas.length === 0}
+        >
           + Add show
-        </Btn>}
-      >
-        {form.shows.length === 0 && (
-          <p className="text-[12px] text-muted">
-            No shows yet. Add one to start programming the week.
-          </p>
-        )}
-        <div className="grid gap-2">
-          {form.shows.map((s, i) => {
-            const ok = showValid(s);
-            const hrs = countHours(s.id);
-            return (
-              <ShowDefRow
-                key={s.id}
-                show={s}
-                index={i}
-                ok={ok}
-                hrs={hrs}
-                focused={focusIdx === i}
-                personaLabel={personaName(s.personaId)}
-                onEdit={() => focusShow(i)}
-                onRemove={() => setConfirmDeleteIdx(i)}
-              />
-            );
-          })}
-        </div>
-        {form.shows.length > 0 && (
-          <p className="mt-2.5 text-[11px] text-muted">
-            Click a show (or <b>Edit</b>) to open it in the editor below.
-          </p>
-        )}
-      </Card>
+        </Btn>
+      </div>
+      {form.shows.length === 0 && (
+        <p className="text-[12px] text-muted">
+          No shows yet. Add one to start programming the week.
+        </p>
+      )}
+
+      {form.shows.map((s, i) => {
+        const ok = showValid(s);
+        const hrs = countHours(s.id);
+        return (
+          <ShowDefRow
+            key={s.id}
+            show={s}
+            index={i}
+            ok={ok}
+            hrs={hrs}
+            personaLabel={personaName(s.personaId)}
+            onEdit={() => focusShow(i)}
+          />
+        );
+      })}
 
       {/* ── INLINE SHOW EDITOR ───────────────────────────────────────────── */}
       {focused && focusIdx != null && (
@@ -818,8 +817,9 @@ export default function ShowsPanel() {
           allShowsOk={allShowsOk}
           canSave={canSave}
           busy={busy}
+          isNew={focused.id === creatingId}
           update={(patch) => setShow(focusIdx, patch)}
-          onSave={save}
+          onSave={async () => { if (await save()) setFocusIdx(null); }}
           onClose={() => setFocusIdx(null)}
           onRemove={() => setConfirmDeleteIdx(focusIdx)}
         />
@@ -889,6 +889,7 @@ interface ShowEditorProps {
   allShowsOk: boolean;
   canSave: boolean;
   busy: boolean;
+  isNew: boolean;       // show the AI-draft field only while creating
   update: (patch: Partial<Show>) => void;
   onSave: () => void;
   onClose: () => void;
@@ -897,34 +898,58 @@ interface ShowEditorProps {
 
 function ShowEditor({
   show, editorRef, personas, moods, themes, activeThemeId, genres, playlists, apiBase,
-  adminFetch, minTrackSeconds, allShowsOk, canSave, busy,
+  adminFetch, minTrackSeconds, allShowsOk, canSave, busy, isNew,
   update, onSave, onClose, onRemove,
 }: ShowEditorProps) {
   const valid = showValid(show);
   return (
-    <div ref={editorRef} className="scroll-mt-4">
-      <Card
-        title={show.name.trim() ? 'Edit show' : 'New show'}
-        sub={show.name.trim() || 'define a show'}
-        right={
-          <span className="flex gap-2">
-            <Btn sm tone="danger" onClick={onRemove}>Remove</Btn>
-            <Btn sm onClick={onClose}>Close</Btn>
+    <EditorDialog
+      open
+      onOpenChange={(o) => { if (!o) onClose(); }}
+      title={<Eyebrow className="text-vermilion">{isNew ? 'New show' : 'Edit show'}</Eyebrow>}
+      sub={<span className="caption truncate">{show.name.trim() || 'define a show'}</span>}
+      footer={
+        <div className="flex flex-wrap items-center gap-3">
+          {/* left — destructive action */}
+          <Btn lg tone="danger" onClick={onRemove}>Remove</Btn>
+          {/* right — status + close/save */}
+          <span className="ml-auto flex items-center gap-3">
+            <span
+              className={cn(
+                'size-1.5 flex-none rounded-full',
+                canSave ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
+              )}
+            />
+            <span className="text-[11px] text-muted">
+              {!valid
+                ? <span className="text-[var(--danger)]">this show needs a name, a persona, and a mood</span>
+                : !allShowsOk
+                  ? <span className="text-[var(--danger)]">another show in the list is incomplete</span>
+                  : 'saves all shows + the weekly grid · applies live on the next pick'}
+            </span>
+            <Btn lg onClick={onClose}>Close</Btn>
+            <Btn lg tone="accent" onClick={onSave} disabled={busy || !canSave}>
+              {busy ? 'Saving…' : 'Save show'}
+            </Btn>
           </span>
-        }
-      >
-        <div className="grid gap-3.5">
-          <AiFill<Partial<Omit<Show, 'personaId' | 'themeId'>> & { personaId?: string | null; themeId?: string | null }>
-            endpoint="/generate/show"
-            resultKey="show"
-            adminFetch={adminFetch}
-            placeholder="e.g. a Sunday-morning gospel hour, warm and uplifting"
-            onApply={(s) => update({
-              ...s,
-              personaId: s.personaId ?? show.personaId ?? '',
-              themeId: s.themeId ?? '',
-            })}
-          />
+        </div>
+      }
+    >
+      <div ref={editorRef} className="grid">
+        <Card flat title="Identity" bodyClass="grid gap-3.5">
+          {isNew && (
+            <AiFill<Partial<Omit<Show, 'personaId' | 'themeId'>> & { personaId?: string | null; themeId?: string | null }>
+              endpoint="/generate/show"
+              resultKey="show"
+              adminFetch={adminFetch}
+              placeholder="e.g. a Sunday-morning gospel hour, warm and uplifting"
+              onApply={(s) => update({
+                ...s,
+                personaId: s.personaId ?? show.personaId ?? '',
+                themeId: s.themeId ?? '',
+              })}
+            />
+          )}
           <Field>
             <Label htmlFor="show-name">show name</Label>
             <Input
@@ -961,9 +986,9 @@ function ShowEditor({
               Manage themes in admin → Settings → Theme.
             </span>
           </Field>
+        </Card>
 
-          <Eyebrow className="text-muted">music</Eyebrow>
-
+        <Card flat title="Music" bodyClass="grid gap-3.5">
           <div className="stack-mobile grid grid-cols-3 gap-3">
             <Field>
               <Label>music mood</Label>
@@ -1126,7 +1151,9 @@ function ShowEditor({
               </div>
             </div>
           )}
+        </Card>
 
+        <Card flat title="Brief" bodyClass="grid gap-3.5">
           <Field>
             <Label htmlFor="show-topic">topic (fed to the DJ as the show theme)</Label>
             <span className="field-hint">
@@ -1167,34 +1194,9 @@ function ShowEditor({
               cap it for this show.
             </span>
           </Field>
-
-          {/* Save bar — labelled "Save show" for the editing context, though one
-              Save actually persists every show + the weekly grid (the personas
-              pattern, where "Save persona" likewise saves the whole roster). The
-              status line spells out that wider scope. */}
-          <div className="flex flex-wrap items-center gap-3 border border-ink bg-[var(--ink-softer)] p-3">
-            <span
-              className={cn(
-                'size-1.5 flex-none rounded-full',
-                canSave ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
-              )}
-            />
-            <span className="text-[11px] text-muted">
-              {!valid
-                ? <span className="text-[var(--danger)]">this show needs a name, a persona, and a mood</span>
-                : !allShowsOk
-                  ? <span className="text-[var(--danger)]">another show in the list is incomplete</span>
-                  : 'saves all shows + the weekly grid · applies live on the next pick'}
-            </span>
-            <span className="ml-auto">
-              <Btn tone="accent" onClick={onSave} disabled={busy || !canSave}>
-                {busy ? 'Saving…' : 'Save show'}
-              </Btn>
-            </span>
-          </div>
-        </div>
-      </Card>
-    </div>
+        </Card>
+      </div>
+    </EditorDialog>
   );
 }
 
@@ -1382,54 +1384,46 @@ interface ShowDefRowProps {
   index: number;
   ok: boolean;
   hrs: number;
-  focused: boolean;
   personaLabel: string;
   onEdit: () => void;
-  onRemove: () => void;
 }
 
-function ShowDefRow({ show: s, index: i, ok, hrs, focused, personaLabel, onEdit, onRemove }: ShowDefRowProps) {
-  const stripeRef = useRef<HTMLDivElement>(null);
-  useDynamicStyle(stripeRef, { background: SHOW_COLORS[i % SHOW_COLORS.length] ?? '#000' });
+// One show as a full-width card, matching the skills list: a colour dot + name
+// with status pills on the right, a persona/mood/topic summary on the left, and
+// an Edit action on the right (Remove lives inside the editor).
+function ShowDefRow({ show: s, index: i, ok, hrs, personaLabel, onEdit }: ShowDefRowProps) {
+  const dotRef = useRef<HTMLSpanElement>(null);
+  useDynamicStyle(dotRef, { background: SHOW_COLORS[i % SHOW_COLORS.length] ?? '#000' });
   return (
-    <div
-      className={cn(
-        'flex items-center gap-3 border py-2.5 pr-3',
-        focused
-          ? 'border-[var(--accent)] bg-[var(--accent-soft)]'
-          : ok ? 'border-separator-strong' : 'border-[var(--danger)]',
-      )}
-    >
-      <div ref={stripeRef} className="w-1 self-stretch" />
-      {/* Clicking the row opens the show in the editor below (same as Edit). */}
-      <button
-        type="button"
-        onClick={onEdit}
-        aria-pressed={focused}
-        className="grid min-w-0 flex-1 cursor-pointer gap-0.5 border-0 bg-transparent p-0 text-left font-[inherit]"
-      >
-        <div className="overflow-hidden text-[14px] font-extrabold tracking-[-0.01em] text-ellipsis whitespace-nowrap text-ink">
+    <Card
+      title={
+        <span className="inline-flex items-center gap-2">
+          <span ref={dotRef} className="size-2.5 flex-none rounded-full" />
           {s.name.trim() || 'untitled'}
-        </div>
-        <div className="text-[11px] text-muted">
-          persona · {personaLabel} · mood · {s.mood || '—'}{showFilterSummary(s)}
-        </div>
-        {s.topic.trim() && (
-          <div className="overflow-hidden text-[11px] text-ellipsis whitespace-nowrap text-muted italic">
-            {s.topic.trim()}
+        </span>
+      }
+      right={
+        <>
+          {!ok && <Pill tone="accent">incomplete</Pill>}
+          {hrs > 0 ? <Pill tone="ink">{hrs}h / week</Pill> : <Pill>unscheduled</Pill>}
+        </>
+      }
+    >
+      <div className="grid grid-cols-[1fr_auto] items-center gap-4">
+        <div className="min-w-0">
+          <div className="text-[12px] leading-[1.6] text-muted">
+            persona · {personaLabel} · mood · {s.mood || '—'}{showFilterSummary(s)}
           </div>
-        )}
-      </button>
-      <div className="flex shrink-0 items-center gap-1.5">
-        {!ok && <Pill tone="accent">incomplete</Pill>}
-        {hrs > 0
-          ? <Pill tone="ink">{hrs}h / week</Pill>
-          : <Pill>unscheduled</Pill>}
-        <Btn sm onClick={onEdit}>{focused ? 'Editing' : 'Edit'}</Btn>
-        <Btn sm tone="danger" onClick={onRemove} title="Remove this show">
-          ✕
-        </Btn>
+          {s.topic.trim() && (
+            <div className="mt-1 line-clamp-2 text-[12px] leading-[1.6] text-muted italic">
+              {s.topic.trim()}
+            </div>
+          )}
+        </div>
+        <div className="flex flex-col gap-2">
+          <Btn className="min-w-[92px]" onClick={onEdit}>Edit</Btn>
+        </div>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/web/components/admin/personas/PersonaBehaviorCard.tsx
+++ b/web/components/admin/personas/PersonaBehaviorCard.tsx
@@ -15,7 +15,7 @@ interface PersonaBehaviorCardProps {
 
 export function PersonaBehaviorCard({ persona, update }: PersonaBehaviorCardProps) {
   return (
-    <Card title="Behaviour" sub="how this persona talks">
+    <Card flat title="Behaviour" sub="how this persona talks">
       <div className="lg:grid lg:grid-cols-2 lg:items-start lg:gap-x-8">
         {/* LEFT — frequency, script length, DJ mode */}
         <div>

--- a/web/components/admin/personas/PersonaEditor.tsx
+++ b/web/components/admin/personas/PersonaEditor.tsx
@@ -1,12 +1,15 @@
 'use client';
-// Full-width editor for the focused persona: identity, behaviour, voice and
+// Full-screen editor for the focused persona: identity, behaviour, voice and
 // skills cards plus the save bar. Binds the index-taking mutators down to the
-// focused persona so the cards stay index-agnostic.
+// focused persona so the cards stay index-agnostic. Rendered inside the shared
+// EditorDialog (edge-to-edge, centered column) — the roster is the browse view,
+// this is the edit surface.
 import type { RefObject } from 'react';
 import type { Persona, PersonaTts, SettingsResponse, SkillCatalogEntry } from './types';
 import type { AdminAuth } from '../../../lib/adminAuth';
-import { Btn } from '../ui';
+import { Btn, Eyebrow, Pill } from '../ui';
 import { cn } from '../../../lib/cn';
+import { EditorDialog } from '../../ui/editor-dialog';
 import { PersonaIdentityCard } from './PersonaIdentityCard';
 import { PersonaBehaviorCard } from './PersonaBehaviorCard';
 import { PersonaVoiceCard } from './PersonaVoiceCard';
@@ -26,6 +29,9 @@ interface PersonaEditorProps {
   cloudIssueText: string | null;
   skillCatalog: SkillCatalogEntry[];
   editorRef: RefObject<HTMLDivElement | null>;
+  open: boolean;
+  isNew: boolean;
+  onClose: () => void;
   setPersona: (i: number, patch: Partial<Persona>) => void;
   setPersonaTts: (i: number, patch: Partial<PersonaTts>) => void;
   setPersonaSkills: (i: number, skills: string[]) => void;
@@ -45,7 +51,7 @@ interface PersonaEditorProps {
 
 export function PersonaEditor({
   persona, index, personaCount, activePersonaId, onAirPersonaId, data, adminFetch, avatarTick, uploadingId,
-  defaultEngine, cloudIssueText, skillCatalog, editorRef,
+  defaultEngine, cloudIssueText, skillCatalog, editorRef, open, isNew, onClose,
   setPersona, setPersonaTts, setPersonaSkills,
   onUploadAvatar, onGenerateAvatar, onClearAvatar, onSetActive, onRemove,
   canSave, focusedOk, allPersonasOk, promptOk, busy, onSave, onDiscard,
@@ -55,62 +61,80 @@ export function PersonaEditor({
   const setSkills = (skills: string[]) => setPersonaSkills(index, skills);
 
   return (
-    <div ref={editorRef} className="grid scroll-mt-4 gap-4">
-      <PersonaIdentityCard
-        persona={persona}
-        index={index}
-        personaCount={personaCount}
-        isActive={persona.id === activePersonaId}
-        isOnAir={persona.id === onAirPersonaId}
-        canRemove={personaCount > 1}
-        adminFetch={adminFetch}
-        avatarTick={avatarTick}
-        uploading={uploadingId === persona.id}
-        update={update}
-        onSetActive={onSetActive}
-        onRemove={onRemove}
-        onPickAvatar={(file) => onUploadAvatar(persona.id, file)}
-        onGenerateAvatar={() => onGenerateAvatar(persona.id)}
-        onClearAvatar={() => onClearAvatar(persona.id)}
-      />
-
-      <PersonaBehaviorCard persona={persona} update={update} />
-
-      <PersonaVoiceCard
-        persona={persona}
-        data={data}
-        defaultEngine={defaultEngine}
-        cloudIssueText={cloudIssueText}
-        adminFetch={adminFetch}
-        updateTts={updateTts}
-      />
-
-      <PersonaSkillsCard persona={persona} skillCatalog={skillCatalog} setSkills={setSkills} />
-
-      {/* Save bar */}
-      <div className="flex flex-wrap items-center gap-3 border border-ink bg-[var(--ink-softer)] p-3">
-        <span
-          className={cn(
-            'size-1.5 flex-none rounded-full',
-            canSave ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
-          )}
+    <EditorDialog
+      open={open}
+      onOpenChange={(o) => { if (!o) onClose(); }}
+      title={<Eyebrow className="text-vermilion">{isNew ? 'New persona' : 'Edit persona'}</Eyebrow>}
+      sub={<span className="caption truncate">{persona.name.trim() || `Persona ${index + 1}`} · {index + 1} of {personaCount}</span>}
+      footer={
+        <div className="flex flex-wrap items-center gap-3">
+          {/* left — persona-scoped actions */}
+          <span className="flex items-center gap-2">
+            {persona.id === onAirPersonaId && <Pill tone="accent" className="text-[8px]">on air</Pill>}
+            {persona.id === activePersonaId
+              ? <Pill className="text-[8px]">default</Pill>
+              : <Btn lg onClick={onSetActive}>Set as default</Btn>}
+            <Btn
+              lg
+              tone="danger"
+              onClick={onRemove}
+              disabled={personaCount <= 1}
+              title={personaCount > 1 ? 'Remove this persona' : 'At least one persona is required'}
+            >
+              Remove
+            </Btn>
+          </span>
+          {/* right — status + discard/save */}
+          <span className="ml-auto flex items-center gap-3">
+            <span
+              className={cn(
+                'size-1.5 flex-none rounded-full',
+                canSave ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
+              )}
+            />
+            <span className="text-[11px] text-muted">
+              {!canSave && !focusedOk
+                ? <span className="text-[var(--danger)]">this persona has a missing or invalid field</span>
+                : !canSave && !allPersonasOk
+                  ? <span className="text-[var(--danger)]">another persona in the roster is incomplete</span>
+                  : !canSave && !promptOk
+                    ? <span className="text-[var(--danger)]">fix the custom system prompt</span>
+                    : 'changes apply on the next spoken line · no mixer restart'}
+            </span>
+            <Btn lg onClick={onDiscard} disabled={busy}>Discard</Btn>
+            <Btn lg tone="accent" onClick={onSave} disabled={busy || !canSave}>
+              {busy ? 'Saving…' : 'Save persona'}
+            </Btn>
+          </span>
+        </div>
+      }
+    >
+      <div ref={editorRef} className="grid">
+        <PersonaIdentityCard
+          persona={persona}
+          isNew={isNew}
+          adminFetch={adminFetch}
+          avatarTick={avatarTick}
+          uploading={uploadingId === persona.id}
+          update={update}
+          onPickAvatar={(file) => onUploadAvatar(persona.id, file)}
+          onGenerateAvatar={() => onGenerateAvatar(persona.id)}
+          onClearAvatar={() => onClearAvatar(persona.id)}
         />
-        <span className="text-[11px] text-muted">
-          {!canSave && !focusedOk
-            ? <span className="text-[var(--danger)]">this persona has a missing or invalid field</span>
-            : !canSave && !allPersonasOk
-              ? <span className="text-[var(--danger)]">another persona in the roster is incomplete</span>
-              : !canSave && !promptOk
-                ? <span className="text-[var(--danger)]">fix the custom system prompt</span>
-                : 'changes apply on the next spoken line · no mixer restart'}
-        </span>
-        <span className="ml-auto flex gap-2">
-          <Btn onClick={onDiscard} disabled={busy}>Discard</Btn>
-          <Btn tone="accent" onClick={onSave} disabled={busy || !canSave}>
-            {busy ? 'Saving…' : 'Save persona'}
-          </Btn>
-        </span>
+
+        <PersonaBehaviorCard persona={persona} update={update} />
+
+        <PersonaVoiceCard
+          persona={persona}
+          data={data}
+          defaultEngine={defaultEngine}
+          cloudIssueText={cloudIssueText}
+          adminFetch={adminFetch}
+          updateTts={updateTts}
+        />
+
+        <PersonaSkillsCard persona={persona} skillCatalog={skillCatalog} setSkills={setSkills} />
       </div>
-    </div>
+    </EditorDialog>
   );
 }

--- a/web/components/admin/personas/PersonaHero.tsx
+++ b/web/components/admin/personas/PersonaHero.tsx
@@ -1,9 +1,8 @@
 'use client';
 // Hero header + live/active strip for /admin/personas.
 import type { Persona } from './types';
-import { PERSONA_MAX } from './constants';
 import { engineLabel } from './helpers';
-import { Btn, Eyebrow } from '../ui';
+import { Eyebrow } from '../ui';
 
 interface PersonaHeroProps {
   // The persona actually broadcasting (show override aware) — what the live
@@ -16,37 +15,22 @@ interface PersonaHeroProps {
   onAirShow: { id: string; name: string } | null;
   defaultEngine: string;
   onAirCloudIssue: string | null;
-  personaCount: number;
-  showPrompt: boolean;
-  onTogglePrompt: () => void;
-  onAdd: () => void;
 }
 
 export function PersonaHero({
   onAirPersona, defaultPersona, onAirShow, defaultEngine, onAirCloudIssue,
-  personaCount, showPrompt, onTogglePrompt, onAdd,
 }: PersonaHeroProps) {
   const overridden = !!onAirShow && defaultPersona?.id !== onAirPersona?.id;
   return (
     <section className="card">
-      <div className="stack-mobile grid grid-cols-[1fr_auto] items-center gap-4 border-b border-ink p-4">
-        <div>
-          <Eyebrow className="text-vermilion">personas</Eyebrow>
-          <div className="mt-1.5 text-[22px] font-extrabold tracking-[-0.02em]">
-            The voices on your station.
-          </div>
-          <div className="mt-1 text-[11px] leading-[1.6] text-muted">
-            One persona is on air at a time. A scheduled show can hand the hour to a different one.
-            Every change applies live; no mixer restart.
-          </div>
+      <div className="border-b border-ink p-4">
+        <Eyebrow className="text-vermilion">personas</Eyebrow>
+        <div className="mt-1.5 text-[22px] font-extrabold tracking-[-0.02em]">
+          The voices on your station.
         </div>
-        <div className="flex flex-wrap gap-2">
-          <Btn onClick={onTogglePrompt}>
-            {showPrompt ? 'Hide system prompt' : 'System prompt'}
-          </Btn>
-          <Btn tone="accent" onClick={onAdd} disabled={personaCount >= PERSONA_MAX}>
-            + Add persona
-          </Btn>
+        <div className="mt-1 text-[11px] leading-[1.6] text-muted">
+          One persona is on air at a time. A scheduled show can hand the hour to a different one.
+          Every change applies live; no mixer restart.
         </div>
       </div>
 

--- a/web/components/admin/personas/PersonaIdentityCard.tsx
+++ b/web/components/admin/personas/PersonaIdentityCard.tsx
@@ -6,7 +6,7 @@ import type { ChangeEvent } from 'react';
 import type { Persona } from './types';
 import type { AdminAuth } from '../../../lib/adminAuth';
 import { NAME_MAX, TAGLINE_MAX, SOUL_MAX, LANGUAGE_MAX } from './constants';
-import { Card, Btn, Pill } from '../ui';
+import { Card } from '../ui';
 import { Input } from '../../ui/input';
 import { Textarea } from '../../ui/textarea';
 import { Label } from '../../ui/label';
@@ -16,61 +16,35 @@ import { cn } from '../../../lib/cn';
 
 interface PersonaIdentityCardProps {
   persona: Persona;
-  index: number;        // 0-based, for the "persona X of Y" sub
-  personaCount: number;
-  // The admin-selected default. `isOnAir` is whether this persona is the one
-  // actually broadcasting right now (a scheduled show can override the default).
-  isActive: boolean;
-  isOnAir: boolean;
-  canRemove: boolean;
+  isNew: boolean;       // show the AI-draft field only while creating
   adminFetch: AdminAuth['adminFetch'];
   avatarTick: number;
   uploading: boolean;
   update: (patch: Partial<Persona>) => void;
-  onSetActive: () => void;
-  onRemove: () => void;
   onPickAvatar: (file: File) => void;
   onGenerateAvatar: () => void;
   onClearAvatar: () => void;
 }
 
 export function PersonaIdentityCard({
-  persona, index, personaCount, isActive, isOnAir, canRemove, adminFetch, avatarTick, uploading,
-  update, onSetActive, onRemove, onPickAvatar, onGenerateAvatar, onClearAvatar,
+  persona, isNew, adminFetch, avatarTick, uploading,
+  update, onPickAvatar, onGenerateAvatar, onClearAvatar,
 }: PersonaIdentityCardProps) {
   const soulLen = persona.soul.trim().length;
   const soulOver = soulLen > SOUL_MAX;
   return (
-    <Card
-      title={`Editing · ${persona.name.trim() || `Persona ${index + 1}`}`}
-      sub={`persona ${index + 1} of ${personaCount}`}
-      right={
-        <>
-          {isOnAir && <Pill tone="accent" className="text-[8px]">on air</Pill>}
-          {isActive
-            ? <Pill className="text-[8px]">default</Pill>
-            : <Btn sm onClick={onSetActive}>Set as default</Btn>}
-          <Btn
-            sm
-            tone="danger"
-            onClick={onRemove}
-            disabled={!canRemove}
-            title={canRemove ? 'Remove this persona' : 'At least one persona is required'}
-          >
-            Remove
-          </Btn>
-        </>
-      }
-    >
-      <div className="mb-4">
-        <AiFill<Partial<Persona>>
-          endpoint="/generate/persona"
-          resultKey="persona"
-          adminFetch={adminFetch}
-          placeholder="e.g. a late-night jazz host with a dry wit"
-          onApply={(p) => update(p)}
-        />
-      </div>
+    <Card flat title="Identity">
+      {isNew && (
+        <div className="mb-4">
+          <AiFill<Partial<Persona>>
+            endpoint="/generate/persona"
+            resultKey="persona"
+            adminFetch={adminFetch}
+            placeholder="e.g. a late-night jazz host with a dry wit"
+            onApply={(p) => update(p)}
+          />
+        </div>
+      )}
 
       <div className="lg:grid lg:grid-cols-2 lg:items-start lg:gap-x-8">
         {/* LEFT — avatar, name, tagline, language */}

--- a/web/components/admin/personas/PersonaRoster.tsx
+++ b/web/components/admin/personas/PersonaRoster.tsx
@@ -1,61 +1,71 @@
 'use client';
-// Full-width selectable roster — sits below the hero. A responsive grid of
-// persona cards (avatar + name + tagline + badges) that wraps as personas are
-// added; click a card to edit it in the full-width editor below. The last cell
-// is a dashed "+ new persona" add card.
+// Persona roster — a list of cards (one per persona), matching the skills list:
+// avatar + tagline + meta pills on the left, status pills + Edit on the right.
+// Click Edit to open the full-screen editor; adding lives in the hero's
+// "+ Add persona" button.
 import type { Persona } from './types';
 import { API_BASE, PERSONA_MAX } from './constants';
 import { initialsFor, personaValid } from './helpers';
-import { Pill } from '../ui';
-import { cn } from '../../../lib/cn';
+import { Card, Btn, Pill } from '../ui';
 
 interface PersonaRosterProps {
   personas: Persona[];
   // The admin-selected default — gets the "default" pill.
   activePersonaId: string;
   // The persona actually broadcasting now (show override aware) — gets the
-  // accent dot + "on air" pill. Equals activePersonaId unless a show overrides.
+  // "on air" pill. Equals activePersonaId unless a show overrides.
   onAirPersonaId: string;
-  focusedIdx: number;
   avatarTick: number;
-  onSelect: (idx: number) => void;
+  showPrompt: boolean;
+  onTogglePrompt: () => void;
   onAdd: () => void;
+  onSelect: (idx: number) => void;
 }
 
 export function PersonaRoster({
-  personas, activePersonaId, onAirPersonaId, focusedIdx, avatarTick, onSelect, onAdd,
+  personas, activePersonaId, onAirPersonaId, avatarTick,
+  showPrompt, onTogglePrompt, onAdd, onSelect,
 }: PersonaRosterProps) {
-  const atMax = personas.length >= PERSONA_MAX;
   return (
-    <section className="grid gap-2.5">
-      <span className="caption">roster · {personas.length} / {PERSONA_MAX}</span>
-      <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
-        {personas.map((p, i) => {
-          const isOnAir = p.id === onAirPersonaId;
-          const isDefault = p.id === activePersonaId;
-          const isFocused = i === focusedIdx;
-          const valid = personaValid(p);
-          const src = p.avatar
-            ? `${API_BASE}/persona-avatar/${encodeURIComponent(p.id)}?v=${avatarTick}`
-            : null;
-          return (
-            <button
-              key={p.id}
-              type="button"
-              onClick={() => onSelect(i)}
-              aria-pressed={isFocused}
-              className={cn(
-                'grid min-w-0 cursor-pointer content-start gap-2 border p-3 text-left font-[inherit]',
-                isFocused
-                  ? 'border-[var(--accent)] bg-[var(--accent-soft)]'
-                  : 'border-ink bg-[var(--card-bg)]',
-              )}
-            >
-              <div className="flex min-w-0 items-start gap-2.5">
-                {/* Initials sit behind the image so a missing / transparent /
-                    broken avatar still shows a readable placeholder. */}
-                <span className="relative grid size-10 flex-none place-items-center overflow-hidden border border-ink bg-[var(--ink-softer)]">
-                  <span className="text-[12px] font-extrabold text-muted">{initialsFor(p.name)}</span>
+    <section className="grid gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <span className="caption">roster · {personas.length} / {PERSONA_MAX}</span>
+        <div className="flex flex-wrap gap-2">
+          <Btn onClick={onTogglePrompt}>
+            {showPrompt ? 'Hide system prompt' : 'System prompt'}
+          </Btn>
+          <Btn tone="accent" onClick={onAdd} disabled={personas.length >= PERSONA_MAX}>
+            + Add persona
+          </Btn>
+        </div>
+      </div>
+      {personas.map((p, i) => {
+        const isOnAir = p.id === onAirPersonaId;
+        const isDefault = p.id === activePersonaId;
+        const valid = personaValid(p);
+        const src = p.avatar
+          ? `${API_BASE}/persona-avatar/${encodeURIComponent(p.id)}?v=${avatarTick}`
+          : null;
+        return (
+          <Card
+            key={p.id}
+            title={p.name.trim() || `Persona ${i + 1}`}
+            right={
+              <>
+                {isOnAir && <Pill tone="accent" dot>on air</Pill>}
+                {isDefault && !isOnAir && <Pill>default</Pill>}
+                {!valid && (
+                  <Pill className="border-[var(--danger)] text-[var(--danger)]">incomplete</Pill>
+                )}
+              </>
+            }
+          >
+            <div className="grid grid-cols-[1fr_auto] items-center gap-4">
+              <div className="flex min-w-0 items-start gap-3">
+                {/* Initials sit behind the image so a missing / broken avatar
+                    still shows a readable placeholder. */}
+                <span className="relative grid size-11 flex-none place-items-center overflow-hidden border border-ink bg-[var(--ink-softer)]">
+                  <span className="text-[13px] font-extrabold text-muted">{initialsFor(p.name)}</span>
                   {src && (
                     <img
                       src={src}
@@ -65,49 +75,30 @@ export function PersonaRoster({
                     />
                   )}
                 </span>
-                <div className="min-w-0 flex-1">
-                  <div className="flex min-w-0 items-center gap-1.5">
-                    {isOnAir && <span className="size-1.5 flex-none rounded-full bg-[var(--accent)]" />}
-                    <span className="min-w-0 truncate text-[14px] font-extrabold tracking-[-0.01em] text-ink">
-                      {p.name.trim() || `Persona ${i + 1}`}
-                    </span>
-                  </div>
-                  <div className="truncate text-[11px] text-muted">
+                <div className="min-w-0">
+                  <div className="text-[12px] leading-[1.6] text-muted">
                     {p.tagline.trim() || 'no tagline'}
+                  </div>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    <Pill className="text-[8px]">{p.frequency}</Pill>
+                    {p.scriptLength === 'extended' && <Pill className="text-[8px]">extended</Pill>}
+                    <Pill className="text-[8px]">{p.tts.engine}</Pill>
+                    {p.tts.engine !== 'piper' && p.tts.voice.trim() && (
+                      <Pill className="max-w-[120px] truncate text-[8px]">{p.tts.voice.trim()}</Pill>
+                    )}
+                    <Pill className="text-[8px]">
+                      {p.skills.length} skill{p.skills.length === 1 ? '' : 's'}
+                    </Pill>
                   </div>
                 </div>
               </div>
-              <div className="flex flex-wrap gap-1.5">
-                {isOnAir && <Pill tone="accent" className="text-[8px]">on air</Pill>}
-                {isDefault && !isOnAir && <Pill className="text-[8px]">default</Pill>}
-                <Pill className="text-[8px]">{p.frequency}</Pill>
-                {p.scriptLength === 'extended' && <Pill className="text-[8px]">extended</Pill>}
-                <Pill className="text-[8px]">{p.tts.engine}</Pill>
-                {p.tts.engine !== 'piper' && p.tts.voice.trim() && (
-                  <Pill className="max-w-[120px] truncate text-[8px]">{p.tts.voice.trim()}</Pill>
-                )}
-                <Pill className="text-[8px]">
-                  {p.skills.length} skill{p.skills.length === 1 ? '' : 's'}
-                </Pill>
-                {!valid && (
-                  <Pill className="border-[var(--danger)] text-[8px] text-[var(--danger)]">incomplete</Pill>
-                )}
+              <div className="flex flex-col gap-2">
+                <Btn className="min-w-[92px]" onClick={() => onSelect(i)}>Edit</Btn>
               </div>
-            </button>
-          );
-        })}
-        <button
-          type="button"
-          onClick={onAdd}
-          disabled={atMax}
-          className={cn(
-            'grid min-h-[88px] place-items-center border border-dashed border-muted bg-transparent p-3 font-[inherit] text-[11px] font-bold tracking-[0.18em] text-muted uppercase',
-            atMax ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
-          )}
-        >
-          {atMax ? `maximum ${PERSONA_MAX}` : '+ new persona'}
-        </button>
-      </div>
+            </div>
+          </Card>
+        );
+      })}
     </section>
   );
 }

--- a/web/components/admin/personas/PersonaSkillsCard.tsx
+++ b/web/components/admin/personas/PersonaSkillsCard.tsx
@@ -12,7 +12,7 @@ interface PersonaSkillsCardProps {
 
 export function PersonaSkillsCard({ persona, skillCatalog, setSkills }: PersonaSkillsCardProps) {
   return (
-    <Card title="Skills" sub="autonomous segments this persona runs">
+    <Card flat title="Skills" sub="autonomous segments this persona runs">
       <p className="mb-2.5 max-w-[70ch] text-[12px] leading-[1.6] text-muted">
         When this persona is on air, only the skills ticked here can fire. A skill must
         also be enabled station-wide on the <strong>Skills</strong> page.

--- a/web/components/admin/personas/PersonaVoiceCard.tsx
+++ b/web/components/admin/personas/PersonaVoiceCard.tsx
@@ -72,7 +72,7 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
   };
 
   return (
-    <Card title="Voice" sub="text-to-speech engine">
+    <Card flat title="Voice" sub="text-to-speech engine">
       {/* Engine — radio-card grid, full width above the two-column body. */}
       <div className="field mb-4">
         <Label>Engine</Label>

--- a/web/components/admin/skills/SkillEditModal.tsx
+++ b/web/components/admin/skills/SkillEditModal.tsx
@@ -20,6 +20,8 @@ import type { CSSProperties } from 'react';
 import { notify, errorMessage } from '../../../lib/notify';
 import { useAdminAuth } from '../../../lib/adminAuth';
 import { V3AlertDialog } from '../../ui/alert-dialog';
+import { EditorDialog } from '../../ui/editor-dialog';
+import { Eyebrow } from '../ui';
 import { CONTEXT_FIELD_LABELS, CONTEXT_FIELDS_FALLBACK, splitContext } from './contextFields';
 
 // Minimal shape of a catalogue skill (from GET /dj/skills) — only what the
@@ -175,13 +177,9 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isEdit, fileId, adminFetch]);
 
-  // ── Escape to close ───────────────────────────────────────────────────────
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // Escape-to-close and body scroll-lock are handled by EditorDialog (Radix
+  // Dialog) — no manual key listener, so the nested delete confirm gets escape
+  // first and the page behind stays locked.
 
   const dirty = loaded && fieldsKey(fields) !== snapshot;
   const nameValid = !isEdit ? SLUG_RE.test(name) : true;
@@ -369,89 +367,102 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
     border: '1px solid var(--ink)', background: 'var(--field)', color: 'var(--ink)',
   };
 
-  return (
+  // ── Header / footer slots for the full-screen EditorDialog ──────────────────
+  // Uniform header: a static label + the segment type (the editable name/slug
+  // live in the body's first section, matching the other editors).
+  const headerTitle = (
+    <Eyebrow className="text-vermilion">{isEdit ? 'Edit skill' : 'New skill'}</Eyebrow>
+  );
+  const headerSub = (
+    <span className="caption truncate">{custom ? 'custom segment' : 'built-in segment'}</span>
+  );
+  // On-air toggle (edit only) — lives in the footer with the other actions so
+  // the header stays uniform across all three editors.
+  const airToggle = isEdit ? (
     <div
-      onClick={onClose}
-      style={{
-        // z-30: above admin chrome (≤ z-20), below the V3AlertDialog (overlay
-        // z-40 / content z-50) so the delete confirm layers on top of this sheet.
-        position: 'fixed', inset: 0, zIndex: 30, display: 'flex', alignItems: 'flex-start',
-        justifyContent: 'center', padding: '40px 16px', overflowY: 'auto',
-        background: 'color-mix(in oklab, var(--ink) 55%, transparent)',
-        backdropFilter: 'blur(2px)',
-      }}
+      onClick={() => { if (!acting) toggleEnabled(); }}
+      title={enabled ? 'On air — click to take off air' : 'Off air — click to put on air'}
+      style={{ position: 'relative', width: 62, height: 30, border: '1px solid var(--ink)', flex: 'none', cursor: acting ? 'wait' : 'pointer', transition: 'background .15s cubic-bezier(.2,.7,.2,1)', background: enabled ? 'var(--ink)' : 'transparent', opacity: acting ? 0.6 : 1 }}
     >
-      {/* The pseudo-elements + keyframes this sheet relies on live in
-          globals.css under the `.sw-seg` / `sw-*` names (kept out of JS to
-          avoid dangerouslySetInnerHTML). */}
-      <div
-        className="sw-seg"
-        onClick={e => e.stopPropagation()}
-        style={{ width: 'min(1000px,100%)', position: 'relative', border: '1px solid var(--ink)', background: 'var(--bg)' }}
-      >
-        {/* Masthead */}
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 28, padding: '16px 30px 14px' }}>
-          <div style={{ display: 'flex', alignItems: 'flex-start', minWidth: 0 }}>
-            <div style={{ minWidth: 0 }}>
-              {/* Editable skill name (label) */}
+      <div style={{ position: 'absolute', top: 2, left: 2, width: 24, height: 24, transition: 'transform .18s cubic-bezier(.2,.7,.2,1)', background: enabled ? 'var(--bg)' : 'var(--ink)', transform: `translateX(${enabled ? 32 : 0}px)` }} />
+    </div>
+  ) : null;
+
+  // Transport bar — on-air toggle / Run / Delete on the left, unsaved / flash /
+  // Close / Save on the right. Border + padding supplied by EditorDialog's footer.
+  const footer = (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 16, flexWrap: 'wrap' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        {airToggle}
+        {isEdit && (
+          <button type="button" onClick={run} disabled={acting} style={{ padding: '13px 26px', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', transition: 'transform .1s', border: '1px solid var(--accent)', background: 'var(--accent)', color: '#fff', cursor: acting ? 'wait' : 'pointer', opacity: acting ? 0.7 : 1 }}>
+            ▸ RUN NOW
+          </button>
+        )}
+        {isEdit && custom && (
+          <button type="button" onClick={() => setConfirmDelete(true)} disabled={acting} className="sw-ghost" style={{ padding: '13px 22px', background: 'transparent', color: 'var(--danger)', border: '1px solid var(--danger)', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', cursor: acting ? 'wait' : 'pointer', opacity: acting ? 0.7 : 1 }}>
+            DELETE
+          </button>
+        )}
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+        {dirty && (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--accent)', fontWeight: 700 }}>
+            <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--accent)' }} />UNSAVED EDITS
+          </span>
+        )}
+        {flash && (
+          <span className="v3-blink" style={{ fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--accent)', fontWeight: 700 }}>✓ {flash}</span>
+        )}
+        <button type="button" onClick={onClose} className="sw-ghost" style={{ padding: '13px 22px', background: 'transparent', color: 'var(--muted)', border: '1px solid color-mix(in oklab, var(--ink) 24%, transparent)', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', cursor: 'pointer' }}>
+          CLOSE
+        </button>
+        <button type="button" onClick={save} disabled={!canSave} style={{ padding: '13px 26px', background: canSave ? 'var(--ink)' : 'color-mix(in oklab, var(--ink) 20%, transparent)', color: 'var(--bg)', border: '1px solid var(--ink)', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', cursor: canSave ? 'pointer' : 'not-allowed' }}>
+          {busy ? (mode === 'create' ? 'CREATING…' : 'SAVING…') : (mode === 'create' ? 'CREATE' : 'SAVE')}
+        </button>
+      </div>
+    </div>
+  );
+
+  return (
+    <EditorDialog
+      open
+      onOpenChange={(o) => { if (!o) onClose(); }}
+      title={headerTitle}
+      sub={headerSub}
+      footer={footer}
+      className="sw-seg"
+    >
+      {!loaded ? (
+        <div style={{ padding: '40px 0', textAlign: 'center', color: 'var(--muted)', fontStyle: 'italic', fontSize: 13 }}>loading…</div>
+      ) : (
+        <div style={{ opacity: isEdit && !enabled ? 0.6 : 1, transition: 'opacity .2s ease' }}>
+
+            {/* Skill name + slug */}
+            <div className="sw-section">
+              <div style={sectionLabel}>SKILL NAME</div>
               <input
-                className="sw-title"
                 value={fields.label}
                 onChange={e => patch({ label: e.target.value })}
                 placeholder={displayName}
-                style={{
-                  ...inputBase, background: 'transparent', border: 'none', borderBottom: '1px solid transparent',
-                  fontSize: 24, lineHeight: 1.1, letterSpacing: '-0.01em', fontWeight: 800,
-                  padding: '2px 0', width: '100%', minWidth: 0,
-                }}
+                aria-label="Skill name"
+                style={{ ...inputBase, marginTop: 16, padding: '12px 16px', fontSize: 18, fontWeight: 800, letterSpacing: '-0.01em', width: '100%', boxSizing: 'border-box' }}
               />
               {mode === 'create' && (
-                <div style={{ display: 'flex', gap: 8, marginTop: 14, flexWrap: 'wrap', alignItems: 'center' }}>
-                  <label style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
-                    <span style={{ fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--muted)', fontWeight: 700 }}>SLUG</span>
-                    <input
-                      value={name}
-                      onChange={e => setName(e.target.value.toLowerCase())}
-                      placeholder="moon-phase"
-                      style={{
-                        ...inputBase, padding: '6px 10px', fontSize: 12, fontWeight: 700, letterSpacing: '0.04em', width: 180,
-                        borderColor: name && !nameValid ? 'var(--accent)' : 'var(--ink)',
-                      }}
-                    />
-                  </label>
-                </div>
+                <label style={{ display: 'inline-flex', alignItems: 'center', gap: 10, marginTop: 14 }}>
+                  <span style={{ fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--muted)', fontWeight: 700 }}>SLUG</span>
+                  <input
+                    value={name}
+                    onChange={e => setName(e.target.value.toLowerCase())}
+                    placeholder="moon-phase"
+                    style={{ ...inputBase, padding: '8px 12px', fontSize: 13, fontWeight: 700, letterSpacing: '0.04em', width: 200, borderColor: name && !nameValid ? 'var(--accent)' : 'var(--ink)' }}
+                  />
+                </label>
               )}
             </div>
-          </div>
-
-          {/* Segment tag + on-air toggle — one slim row */}
-          <div style={{ display: 'flex', alignItems: 'center', gap: 14, flex: 'none' }}>
-            <span style={{ fontSize: 10, letterSpacing: '0.2em', textTransform: 'uppercase', color: 'var(--muted)', fontWeight: 600 }}>
-              {custom ? 'CUSTOM SEGMENT' : 'BUILT-IN SEGMENT'}
-            </span>
-            {isEdit && (
-              <div
-                onClick={() => { if (!acting) toggleEnabled(); }}
-                title={enabled ? 'On air — click to take off air' : 'Off air — click to put on air'}
-                style={{ position: 'relative', width: 62, height: 30, border: '1px solid var(--ink)', flex: 'none', cursor: acting ? 'wait' : 'pointer', transition: 'background .15s cubic-bezier(.2,.7,.2,1)', background: enabled ? 'var(--ink)' : 'transparent', opacity: acting ? 0.6 : 1 }}
-              >
-                <div style={{ position: 'absolute', top: 2, left: 2, width: 24, height: 24, transition: 'transform .18s cubic-bezier(.2,.7,.2,1)', background: enabled ? 'var(--bg)' : 'var(--ink)', transform: `translateX(${enabled ? 32 : 0}px)` }} />
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* Double rule */}
-        <div style={{ height: 5, borderTop: '1px solid var(--ink)', borderBottom: '1px solid var(--ink)' }} />
-
-        {/* Body */}
-        {!loaded ? (
-          <div style={{ padding: 60, textAlign: 'center', color: 'var(--muted)', fontStyle: 'italic', fontSize: 13 }}>loading…</div>
-        ) : (
-          <div style={{ padding: 30, opacity: isEdit && !enabled ? 0.6 : 1, transition: 'opacity .2s ease' }}>
 
             {/* Cooldown */}
-            <div style={{ marginBottom: 34 }}>
+            <div className="sw-section">
               <div style={sectionLabel}>COOLDOWN — MINIMUM GAP BETWEEN AIRINGS</div>
               <div style={{ display: 'flex', alignItems: 'center', gap: 18, flexWrap: 'wrap', marginTop: 16 }}>
                 <div style={{ display: 'flex' }}>
@@ -472,7 +483,7 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
 
             {/* Window — custom skills only (built-in window isn't editable) */}
             {custom && (
-              <div style={{ marginBottom: 34 }}>
+              <div className="sw-section">
                 <div style={sectionLabel}>WHEN IT CAN AIR</div>
                 <div style={{ display: 'flex', marginTop: 16 }}>
                   {([['any', 'ANY TIME'], ['commute', 'COMMUTE ONLY']] as const).map(([w, lbl], i) => (
@@ -485,7 +496,7 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
 
             {/* News feed — news built-in only */}
             {isNews && (
-              <div style={{ marginBottom: 34 }}>
+              <div className="sw-section">
                 <div style={sectionLabel}>NEWS FEED — RSS 2.0</div>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap', marginTop: 16 }}>
                   <input
@@ -511,7 +522,7 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
             )}
 
             {/* Context bank */}
-            <div style={{ marginBottom: 34 }}>
+            <div className="sw-section">
               <div style={sectionLabel}>CONTEXT THE DJ MAY MENTION</div>
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, marginTop: 16 }}>
                 {knownContext.map(field => {
@@ -535,7 +546,7 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
             </div>
 
             {/* Brief */}
-            <div>
+            <div className="sw-section">
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
                 <div style={sectionLabel}>THE BRIEF — WHAT THE DJ SAYS, AND WHEN TO STAY SILENT</div>
                 {/* Built-ins revert to their shipped default — restores both the
@@ -576,62 +587,8 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
           </div>
         )}
 
-        {/* Transport / actions — Run now (left), Close + Save (right) */}
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 16, padding: '18px 30px', borderTop: '1px solid var(--ink)', flexWrap: 'wrap' }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-            {isEdit && (
-              <button
-                type="button"
-                onClick={run}
-                disabled={acting}
-                style={{ padding: '13px 26px', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', transition: 'transform .1s', border: '1px solid var(--accent)', background: 'var(--accent)', color: '#fff', cursor: acting ? 'wait' : 'pointer', opacity: acting ? 0.7 : 1 }}
-              >
-                ▸ RUN NOW
-              </button>
-            )}
-            {isEdit && custom && (
-              <button
-                type="button"
-                onClick={() => setConfirmDelete(true)}
-                disabled={acting}
-                className="sw-ghost"
-                style={{ padding: '13px 22px', background: 'transparent', color: 'var(--danger)', border: '1px solid var(--danger)', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', cursor: acting ? 'wait' : 'pointer', opacity: acting ? 0.7 : 1 }}
-              >
-                DELETE
-              </button>
-            )}
-          </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
-            {dirty && (
-              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--accent)', fontWeight: 700 }}>
-                <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--accent)' }} />UNSAVED EDITS
-              </span>
-            )}
-            {flash && (
-              <span style={{ fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--accent)', fontWeight: 700, animation: 'sw-blink 1s steps(1) infinite' }}>✓ {flash}</span>
-            )}
-            <button
-              type="button"
-              onClick={onClose}
-              className="sw-ghost"
-              style={{ padding: '13px 22px', background: 'transparent', color: 'var(--muted)', border: '1px solid color-mix(in oklab, var(--ink) 24%, transparent)', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', cursor: 'pointer' }}
-            >
-              CLOSE
-            </button>
-            <button
-              type="button"
-              onClick={save}
-              disabled={!canSave}
-              style={{ padding: '13px 26px', background: canSave ? 'var(--ink)' : 'color-mix(in oklab, var(--ink) 20%, transparent)', color: 'var(--bg)', border: '1px solid var(--ink)', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', cursor: canSave ? 'pointer' : 'not-allowed' }}
-            >
-              {busy ? (mode === 'create' ? 'CREATING…' : 'SAVING…') : (mode === 'create' ? 'CREATE' : 'SAVE')}
-            </button>
-          </div>
-        </div>
-      </div>
-
-      {/* Delete confirm — the shared V3AlertDialog (same as Dash's skip-track
-          prompt). Portals above this sheet (sheet is z-30, dialog content z-50). */}
+      {/* Delete confirm — the shared V3AlertDialog. Layers above the
+          full-screen EditorDialog (both Radix) and now receives Escape first. */}
       <V3AlertDialog
         open={confirmDelete}
         onOpenChange={setConfirmDelete}
@@ -641,6 +598,6 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
         danger
         onConfirm={remove}
       />
-    </div>
+    </EditorDialog>
   );
 }

--- a/web/components/admin/ui.tsx
+++ b/web/components/admin/ui.tsx
@@ -34,11 +34,15 @@ export interface CardProps {
   className?: string;
   bodyClass?: string;
   headClass?: string;
+  // `flat` drops the box border/background and side padding so the section
+  // reads as part of a continuous form separated by hairline dividers — used
+  // inside EditorDialog (.card.is-flat in globals.css).
+  flat?: boolean;
 }
 
-export function Card({ title, sub, right, children, className, bodyClass, headClass }: CardProps) {
+export function Card({ title, sub, right, children, className, bodyClass, headClass, flat }: CardProps) {
   return (
-    <section className={cn('card', className)}>
+    <section className={cn('card', flat && 'is-flat', className)}>
       {(title || right) && (
         <div className={cn('card-head', headClass)}>
           {title && <span className="title">{title}</span>}

--- a/web/components/ui/alert-dialog.tsx
+++ b/web/components/ui/alert-dialog.tsx
@@ -7,7 +7,16 @@ import { cn } from '../../lib/cn';
 /* V3 AlertDialog — sharp, ink-bordered confirmation modal. Controlled: pass
    `open` + `onOpenChange`. `onConfirm` fires when the operator accepts; the
    dialog closes itself either way. `danger` paints the confirm button red for
-   destructive actions (skip track, restart mixer, delete jingle). */
+   destructive actions (skip track, restart mixer, delete jingle).
+
+   Enter/exit are CSS animations keyed on Radix's `data-state` (the shadcn
+   approach) — `.v3-alert-overlay` / `.v3-alert-content` in globals.css fade +
+   zoom in on open and out on close. Radix's Presence waits for the close
+   animation to finish before unmounting, so it's smooth in BOTH directions
+   without motion/asChild (which `AlertDialog.Content` doesn't compose with).
+   The overlay carries a soft backdrop blur. Centering stays on the Tailwind
+   `-translate-*` utilities (the CSS `translate` property in v4) so the keyframe's
+   `transform: scale()` composes with it and the box zooms from its own centre. */
 export interface V3AlertDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -32,10 +41,10 @@ export function V3AlertDialog({
   return (
     <AlertDialog.Root open={open} onOpenChange={onOpenChange}>
       <AlertDialog.Portal>
-        <AlertDialog.Overlay className="v3-drawer-overlay fixed inset-0 z-40 bg-overlay" />
+        <AlertDialog.Overlay className="v3-alert-overlay fixed inset-0 z-[60] bg-overlay [backdrop-filter:blur(6px)_saturate(1.05)] [-webkit-backdrop-filter:blur(6px)_saturate(1.05)]" />
         <AlertDialog.Content
           className={cn(
-            'fixed top-1/2 left-1/2 z-50 w-[calc(100vw-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 border border-ink bg-bg text-ink shadow-drawer outline-none',
+            'v3-alert-content fixed top-1/2 left-1/2 z-[70] w-[calc(100vw-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 border border-ink bg-bg text-ink shadow-drawer outline-none',
           )}
         >
           <div className="border-b border-ink px-5 py-3">

--- a/web/components/ui/editor-dialog.tsx
+++ b/web/components/ui/editor-dialog.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useEffect, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { AnimatePresence, m } from 'motion/react';
+import { cn } from '../../lib/cn';
+
+/* V3 EditorDialog — the full-screen, edge-to-edge editor used for add/edit of
+   shows, personas and skills. One shell, three editors, one consistent shape:
+
+     • header  — title + sub + close, identical across all three (no actions).
+     • body    — full-width, scrollable. Sections inside are separated by
+                 hairline dividers (see `.card.is-flat`), never boxed cards.
+     • footer  — the transport bar; ALL actions live here (save, delete,
+                 run, toggles…), so the header stays uniform.
+
+   Why full-screen rather than the centered `Modal`: a `fixed inset-0` panel has
+   no width to animate, so it can't reproduce the width-jump glitch that pushed
+   the shows/personas editors in-page (#694). It is built on Radix Dialog — so
+   focus trap, body scroll-lock and hierarchical Escape come for free — instead
+   of a hand-rolled overlay (the old glitchy skills modal).
+
+   Motion mirrors `sheet.tsx`: AnimatePresence + Radix `forceMount` so the exit
+   plays before unmount; `<m.div>` (LazyMotion is `strict` — `motion.div` is
+   forbidden, see MotionProvider). The content fades + rises (transform/opacity
+   only → GPU-composited, no layout shift). Reduced motion is honoured globally
+   by `MotionConfig reducedMotion="user"`, so there is no per-component branch.
+
+   It portals into `.admin-root` (falling back to <body>) so the admin-scoped
+   class names (`.input` / `.btn` / `.card` / `.eyebrow` …) resolve for the
+   form controls rendered inside. Controlled: pass `open` + `onOpenChange`. */
+export interface EditorDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title?: ReactNode;
+  sub?: ReactNode;
+  footer?: ReactNode;
+  /* Extra class on the content panel — lets a consumer scope its own descendant
+     CSS inside (e.g. the skills editor's `.sw-seg` typographic rules). */
+  className?: string;
+  children?: ReactNode;
+}
+
+export function EditorDialog({
+  open,
+  onOpenChange,
+  title,
+  sub,
+  footer,
+  className,
+  children,
+}: EditorDialogProps) {
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setContainer(document.querySelector<HTMLElement>('.admin-root') || document.body);
+  }, []);
+
+  // Full-width content with generous side padding — the form fills the modal.
+  const column = 'w-full px-5 sm:px-8';
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <AnimatePresence>
+        {open && (
+          <Dialog.Portal forceMount container={container}>
+            <Dialog.Overlay asChild forceMount>
+              <m.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.18 }}
+                className="fixed inset-0 z-40 bg-overlay [backdrop-filter:blur(8px)_saturate(1.1)] [-webkit-backdrop-filter:blur(8px)_saturate(1.1)]"
+              />
+            </Dialog.Overlay>
+            <Dialog.Content asChild forceMount aria-describedby={undefined}>
+              <m.div
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 12 }}
+                transition={{ duration: 0.22, ease: [0.2, 0.7, 0.2, 1] }}
+                className={cn('fixed inset-0 z-50 flex flex-col bg-bg text-ink outline-none', className)}
+              >
+                {/* Sticky header — title + sub + close, identical for all editors */}
+                <div className="flex-none border-b border-ink">
+                  <div className={cn(column, 'flex items-center justify-between gap-3 py-3.5')}>
+                    <div className="flex min-w-0 flex-1 items-baseline gap-3">
+                      <Dialog.Title asChild>
+                        <div className="m-0 min-w-0 flex-1 text-ink">{title}</div>
+                      </Dialog.Title>
+                      {sub && <div className="flex-none">{sub}</div>}
+                    </div>
+                    <Dialog.Close
+                      className="v3-focus flex-none cursor-pointer border-0 bg-transparent p-0 text-[22px] leading-none text-muted"
+                      aria-label="Close"
+                    >
+                      ×
+                    </Dialog.Close>
+                  </div>
+                </div>
+
+                {/* Scrollable body — full width */}
+                <div className="v3-scroll flex-1 overflow-auto">
+                  <div className={cn(column, 'py-6')}>
+                    {children}
+                  </div>
+                </div>
+
+                {/* Sticky footer — the transport bar; all actions live here */}
+                {footer && (
+                  <div className="flex-none border-t border-ink">
+                    <div className={cn(column, 'py-3')}>
+                      {footer}
+                    </div>
+                  </div>
+                )}
+              </m.div>
+            </Dialog.Content>
+          </Dialog.Portal>
+        )}
+      </AnimatePresence>
+    </Dialog.Root>
+  );
+}

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -134,6 +134,9 @@ export default defineConfig([
             // .is-spotlight — accent-rail card modifier (.admin-root
             // .card.is-spotlight) used by DJ Doc's verdict card.
             '^is-spotlight$',
+            // .is-flat — flat-section card modifier (.admin-root .card.is-flat)
+            // used inside EditorDialog so sections read as divider-separated.
+            '^is-flat$',
             '^strip-mobile$',
             // bare state / descendant classes used with .lib-* parents
             '^on$',


### PR DESCRIPTION
## What

Unifies the three admin editors (Shows · Personas · Skills) onto one shared **full-screen, edge-to-edge `EditorDialog`**, and brings the shows & personas **list views** onto the skills card style. Replaces the glitchy hand-rolled skills modal and the in-page shows/personas editors.

## EditorDialog — `web/components/ui/editor-dialog.tsx` (new)

- Built on Radix Dialog + Motion (same pattern as `Sheet`), portals into `.admin-root`. Focus trap, body scroll-lock and hierarchical Escape come for free instead of the old bespoke `<div>` overlay.
- **Uniform header** (title / sub / close), **full-width body** with hairline divider sections, **sticky footer** for all actions.
- Edge-to-edge `fixed inset-0` geometry can't reproduce the width-jump glitch that originally pushed shows/personas to in-page editors (#694).

## Editors

- **Skills** (`SkillEditModal`): dropped the hand-rolled overlay + manual `keydown` Escape listener (the source of the escape-vs-delete-confirm conflict). The editable **name + slug moved into the body's first section**.
- **Shows & Personas**: edit/add now open in `EditorDialog`; sections are flat with hairline dividers (no boxed cards); all actions live in the footer at the `lg` button size; the AI-draft "Describe what you want…" field shows on **add only**.

## List views

- Shows & personas list items are now **skills-style cards** (name + status pill, meta, Edit).
- Plain caption + add-button headers (no wrapper card).
- Shows cards are **Edit-only** — Remove lives in the editor; Edit sized to match the skills Edit button.
- Personas: **System prompt** + **Add persona** moved beside the roster caption, mirroring the shows layout.

## Shared

- `V3AlertDialog`: backdrop blur + smooth fade/zoom **in-and-out** via Radix `data-state` CSS (reduced-motion aware); z-index raised above the full-screen editor so the blur covers it.
- `Card` gains a `flat` variant (`.card.is-flat`) for divider sections.

## Testing

- `npm run lint` (`eslint . && tsc --noEmit`) — green.
- Verified live in-browser: all three editors open full-screen with dividers + footer actions; lists render as cards; add vs edit hides/shows the AI field; the confirm dialog blurs + animates (with lite mode off — lite mode intentionally disables blur/animation globally).
