### PR TITLE
fix(admin): stop native basic-auth popup on skill edit

### DIFF
--- a/web/lib/adminAuth.ts
+++ b/web/lib/adminAuth.ts
@@ -67,14 +67,24 @@ export function useAdminAuth(): AdminAuth {
   // flips us into the sign-in flow on 401.
   const adminFetch = useCallback(async (path: string, init: RequestInit = {}): Promise<Response> => {
     const headers: Record<string, string> = { ...((init.headers as Record<string, string>) || {}) };
-    if (auth) headers.Authorization = `Basic ${auth}`;
+    // Resolve the token from state, falling back to the persisted copy. A
+    // freshly mounted hook instance can fire a request from a mount effect
+    // BEFORE its own hydration effect has copied the token out of localStorage
+    // into `auth`. Without this fallback that first request goes out
+    // unauthenticated, the controller answers 401 + `WWW-Authenticate: Basic`,
+    // and the browser pops its NATIVE basic-auth dialog over the app (the
+    // symptom seen when opening the skill-edit modal).
+    let token = auth;
+    if (!token && typeof window !== 'undefined') {
+      try { token = localStorage.getItem(STORAGE_KEY); } catch {}
+    }
+    if (token) headers.Authorization = `Basic ${token}`;
     const r = await fetch(`${API_URL}${path}`, { ...init, headers });
     if (r.status === 401) {
       // Only treat a 401 as a revoked token when we actually sent
-      // credentials. A 401 on a call made before this hook instance has
-      // hydrated (auth still null) must not wipe a valid token that a
-      // sibling useAdminAuth instance is relying on.
-      if (auth) {
+      // credentials. A 401 on a call made with no token at all must not wipe a
+      // valid token that a sibling useAdminAuth instance is relying on.
+      if (token) {
         try { localStorage.removeItem(STORAGE_KEY); } catch {}
         setAuth(null);
       }


### PR DESCRIPTION
## What

Opening the skill-edit modal (and potentially any freshly mounted admin component) could trigger the browser's **native HTTP basic-auth username/password dialog** instead of using the in-app cached credentials.

## Why

`SkillEditModal` mounts its own `useAdminAuth()` instance and fires `GET /dj/skills/:id/file` from a mount effect **before** that instance's hydration effect copies the cached token out of `localStorage` into `auth`. So the first request went out with **no `Authorization` header**. The controller's `requireAdmin` answers an unauthenticated request with `401` + `WWW-Authenticate: Basic realm="SUB/WAVE admin"`, and a `fetch()` that receives that header makes the browser pop its native auth dialog. A credentialed retry fired once hydration completed, which is why it intermittently "just worked".

Surfaced after #708 reworked `SkillEditModal`.

## Fix

`adminFetch` now resolves its token from state, falling back to the persisted `localStorage` copy when the in-state value hasn't hydrated yet — so the first request is always authenticated. The 401-handling guard keys off the resolved token too. Fixes the race for every admin component, not just skills.

## Test

- `npm run lint` (eslint + tsc) passes.
- Rebuilt + deployed the prod `web` image; `/admin/skills` edit no longer pops the native dialog; stream healthy (on-air, audio ~−13 dB).