### PR TITLE
feat(tts-heavy): add DISABLE_CHATTERBOX and DISABLE_POCKET_TTS env vars

### DIFF
--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -248,6 +248,12 @@ services:
       # host + nvidia runtime; the server gracefully falls back to cpu when
       # CUDA isn't actually available.
       - TTS_HEAVY_DEVICE=\${TTS_HEAVY_DEVICE:-cpu}
+      # Set DISABLE_CHATTERBOX=1 or DISABLE_POCKET_TTS=1 in your root .env to
+      # skip loading that engine entirely. The model is never started so no RAM
+      # or swap is consumed. Useful when you only use one TTS engine, or when
+      # you run tts-heavy solely for acoustic analysis (both engines disabled).
+      - DISABLE_CHATTERBOX=\${DISABLE_CHATTERBOX:-}
+      - DISABLE_POCKET_TTS=\${DISABLE_POCKET_TTS:-}
       # Default voice id used by PocketTTS when a persona doesn't override it.
       - POCKET_TTS_VOICE=\${POCKET_TTS_VOICE:-alba}
       # Optional — enables PocketTTS zero-shot voice CLONING (issue #238). The
@@ -484,6 +490,12 @@ services:
     profiles: ["tts-heavy"]
     environment:
       - TTS_HEAVY_DEVICE=\${TTS_HEAVY_DEVICE:-cpu}
+      # Set DISABLE_CHATTERBOX=1 or DISABLE_POCKET_TTS=1 in your root .env to
+      # skip loading that engine entirely. The model is never started so no RAM
+      # or swap is consumed. Useful when you only use one TTS engine, or when
+      # you run tts-heavy solely for acoustic analysis (both engines disabled).
+      - DISABLE_CHATTERBOX=\${DISABLE_CHATTERBOX:-}
+      - DISABLE_POCKET_TTS=\${DISABLE_POCKET_TTS:-}
       - POCKET_TTS_VOICE=\${POCKET_TTS_VOICE:-alba}
       # Optional — enables PocketTTS voice CLONING (issue #238). Cloning weights
       # are gated on Hugging Face; accept the terms at
@@ -689,6 +701,12 @@ services:
     profiles: ["tts-heavy"]
     environment:
       - TTS_HEAVY_DEVICE=\${TTS_HEAVY_DEVICE:-cpu}
+      # Set DISABLE_CHATTERBOX=1 or DISABLE_POCKET_TTS=1 in your root .env to
+      # skip loading that engine entirely. The model is never started so no RAM
+      # or swap is consumed. Useful when you only use one TTS engine, or when
+      # you run tts-heavy solely for acoustic analysis (both engines disabled).
+      - DISABLE_CHATTERBOX=\${DISABLE_CHATTERBOX:-}
+      - DISABLE_POCKET_TTS=\${DISABLE_POCKET_TTS:-}
       - POCKET_TTS_VOICE=\${POCKET_TTS_VOICE:-alba}
       # Optional — enables PocketTTS voice CLONING (issue #238). Cloning weights
       # are gated; accept terms at huggingface.co/kyutai/pocket-tts and set

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -194,6 +194,12 @@ services:
     profiles: ["tts-heavy"]
     environment:
       - TTS_HEAVY_DEVICE=${TTS_HEAVY_DEVICE:-cpu}
+      # Set DISABLE_CHATTERBOX=1 or DISABLE_POCKET_TTS=1 in your root .env to
+      # skip loading that engine entirely. The model is never started so no RAM
+      # or swap is consumed. Useful when you only use one TTS engine, or when
+      # you run tts-heavy solely for acoustic analysis (both engines disabled).
+      - DISABLE_CHATTERBOX=${DISABLE_CHATTERBOX:-}
+      - DISABLE_POCKET_TTS=${DISABLE_POCKET_TTS:-}
       - POCKET_TTS_VOICE=${POCKET_TTS_VOICE:-alba}
       # Optional — enables PocketTTS voice CLONING (issue #238). Cloning weights
       # are gated on Hugging Face; accept the terms at

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -171,6 +171,12 @@ services:
     profiles: ["tts-heavy"]
     environment:
       - TTS_HEAVY_DEVICE=${TTS_HEAVY_DEVICE:-cpu}
+      # Set DISABLE_CHATTERBOX=1 or DISABLE_POCKET_TTS=1 in your root .env to
+      # skip loading that engine entirely. The model is never started so no RAM
+      # or swap is consumed. Useful when you only use one TTS engine, or when
+      # you run tts-heavy solely for acoustic analysis (both engines disabled).
+      - DISABLE_CHATTERBOX=${DISABLE_CHATTERBOX:-}
+      - DISABLE_POCKET_TTS=${DISABLE_POCKET_TTS:-}
       - POCKET_TTS_VOICE=${POCKET_TTS_VOICE:-alba}
       # Optional — enables PocketTTS voice CLONING (issue #238). Cloning weights
       # are gated; accept terms at huggingface.co/kyutai/pocket-tts and set

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,6 +239,12 @@ services:
       # host + nvidia runtime; the server gracefully falls back to cpu when
       # CUDA isn't actually available.
       - TTS_HEAVY_DEVICE=${TTS_HEAVY_DEVICE:-cpu}
+      # Set DISABLE_CHATTERBOX=1 or DISABLE_POCKET_TTS=1 in your root .env to
+      # skip loading that engine entirely. The model is never started so no RAM
+      # or swap is consumed. Useful when you only use one TTS engine, or when
+      # you run tts-heavy solely for acoustic analysis (both engines disabled).
+      - DISABLE_CHATTERBOX=${DISABLE_CHATTERBOX:-}
+      - DISABLE_POCKET_TTS=${DISABLE_POCKET_TTS:-}
       # Default voice id used by PocketTTS when a persona doesn't override it.
       - POCKET_TTS_VOICE=${POCKET_TTS_VOICE:-alba}
       # Optional — enables PocketTTS zero-shot voice CLONING (issue #238). The

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -48,6 +48,15 @@ ANALYZE_SECONDS = os.environ.get("ANALYZE_SECONDS", "60")
 DEVICE = os.environ.get("TTS_HEAVY_DEVICE", "cpu").lower()
 POCKET_TTS_DEFAULT_VOICE = os.environ.get("POCKET_TTS_VOICE", "alba")
 
+# Per-engine kill switches. Set DISABLE_CHATTERBOX=1 or DISABLE_POCKET_TTS=1
+# in your .env to skip loading that engine entirely. The worker object is still
+# created so /health and /speak can return a clean "not ready" rather than
+# crashing, but its run() supervisor is never started — the model is never
+# loaded and no RAM or swap is consumed. Useful when you only use one TTS
+# engine, or when you run tts-heavy solely for acoustic analysis.
+DISABLE_CHATTERBOX = os.environ.get("DISABLE_CHATTERBOX", "").lower() in ("1", "true", "yes")
+DISABLE_POCKET_TTS = os.environ.get("DISABLE_POCKET_TTS", "").lower() in ("1", "true", "yes")
+
 # Per-worker HF cache homes so the two engines don't fight over the same
 # directory. Each is a named volume in the compose files, so the weights a
 # worker downloads on its first boot survive container recreates. The env vars
@@ -271,11 +280,11 @@ async def lifespan(_app: FastAPI):
     # the port bind and the controller's probe would see "connection refused"
     # for the entire boot — leading operators to think the sidecar is broken
     # when it's just still loading.
-    tasks = [
-        asyncio.create_task(chatterbox_worker.run(), name="chatterbox-run"),
-        asyncio.create_task(pocket_worker.run(), name="pocket-tts-run"),
-        asyncio.create_task(analyzer_worker.run(), name="analyze-run"),
-    ]
+    tasks = [asyncio.create_task(analyzer_worker.run(), name="analyze-run")]
+    if not DISABLE_CHATTERBOX:
+        tasks.append(asyncio.create_task(chatterbox_worker.run(), name="chatterbox-run"))
+    if not DISABLE_POCKET_TTS:
+        tasks.append(asyncio.create_task(pocket_worker.run(), name="pocket-tts-run"))
     try:
         yield
     finally:

--- a/docs/tts-heavy.md
+++ b/docs/tts-heavy.md
@@ -116,6 +116,34 @@ heatmap.
   on an **older `tts-heavy` image** built without the full stack — pull the
   latest image and recreate the sidecar.
 
+### Disabling individual TTS engines to save memory
+
+Both TTS workers (Chatterbox and PocketTTS) load their full model weights at
+container startup and hold them resident — even when you only use one engine.
+On CPU-only hosts this can fill several gigabytes of swap while RAM sits mostly
+free (the kernel pages out idle model weights and never proactively reclaims
+the swap). If you only use one TTS engine, or if you run the sidecar solely for
+acoustic analysis, you can skip loading the unused engine(s):
+
+```ini
+# in your root .env
+
+# Using PocketTTS and don't want Chatterbox's 2–3 GB model in swap:
+DISABLE_CHATTERBOX=1
+
+# Using Chatterbox only:
+DISABLE_POCKET_TTS=1
+
+# Analysis-only — sidecar with no TTS engines at all:
+DISABLE_CHATTERBOX=1
+DISABLE_POCKET_TTS=1
+```
+
+The worker objects still exist so `/health` and `/speak` return a clean "not
+ready" instead of crashing, but their supervisors are never started and the
+models are never loaded. If you later switch engines, remove the flag and
+recreate the container (`docker compose --profile tts-heavy up -d`).
+
 ### Running analysis without the sidecar (dev / offline)
 
 The analyzer has a second backend: a **local Python venv** with `librosa`


### PR DESCRIPTION
Fixes #710.

## What

Adds `DISABLE_CHATTERBOX=1` and `DISABLE_POCKET_TTS=1` environment variables to the `tts-heavy` sidecar.

When either variable is set, the corresponding TTS worker supervisor is not started, preventing that worker's model weights from being loaded into memory.

## Why

On CPU-only hosts, both TTS workers load their full model weights during startup regardless of which engine is selected in the settings.

Although unused workers remain idle, the kernel eventually pages much of their model weights to swap after peak memory usage. Those pages are not proactively reclaimed, resulting in high swap usage despite ample free RAM. On a stock installation with `defaultEngine: pocket-tts`, the idle Chatterbox worker alone consumed approximately 3 GB of swap while more than 5 GB of RAM remained available.

## How tested

* Set `DISABLE_CHATTERBOX=1` in `.env`, recreated the sidecar container, and confirmed that `chatterbox_worker.run()` is never started and no Chatterbox process appears in `ps aux`.
* Verified that `/health` still returns `ok: true` with `chatterbox_loaded: false`, and that the controller falls back to Piper as expected.
* Confirmed that PocketTTS continues to function normally when it is the active engine.
* Verified `DISABLE_CHATTERBOX=1` and `DISABLE_POCKET_TTS=1` together in analysis-only mode. The analyzer worker starts, `/analyze` responds successfully, and no TTS worker processes appear in `ps`.

## Notes for reviewers

The worker objects (`chatterbox_worker` and `pocket_worker`) are still instantiated. Only their background `run()` supervisor tasks are skipped. This allows endpoints such as `/health` and `/speak` to return a clean `{"ok": false, "engines": [...]}` response or an HTTP 500 `"worker not ready"` error instead of failing due to missing worker state.

There is no behavior change for existing installations that do not set these environment variables, as both default to an empty string and therefore remain disabled by default.
