### PR TITLE
fix(picker): skip mood-name playlist match when a show pins playlists

### DIFF
--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -184,7 +184,10 @@ async function refreshAutoPlaylistInner() {
   }
 
   // 2. Navidrome playlists whose name matches the mood — operator's hand curation.
-  if (mood) {
+  // Skipped when the show already pins its own playlist(s) (0b): mood-substring
+  // matching would otherwise leak other shows' same-mood playlists into the
+  // fallback pool (#642). Autonomous hours (no pinned playlists) keep it.
+  if (mood && !hasPlaylist) {
     try {
       const playlists = await subsonic.getPlaylists();
       const matched = playlists.filter((p: any) => p.name?.toLowerCase().includes(mood.toLowerCase()));

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -281,8 +281,12 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     add('mood-library', sampleWithRecentFallback(moodHits, recentIds, CAP_MOOD_LIBRARY));
   }
 
-  // 3. Mood-matched Navidrome playlists — operator's hand curation.
-  if (mood) {
+  // 3. Mood-matched Navidrome playlists — operator's hand curation. Skipped when
+  // the show already pins its own playlist(s) (1f): the operator has named exactly
+  // which playlists to use, so also grabbing every playlist whose name merely
+  // contains the mood word would leak other shows' same-mood playlists into the
+  // pool (#642). Autonomous hours (no pinned playlists) keep the mood match.
+  if (mood && !hasPlaylist) {
     try {
       const playlists = await memo('playlists', CACHE_TTL_MS, () => subsonic.getPlaylists());
       const matched = playlists.filter((p: any) => p.name?.toLowerCase().includes(mood.toLowerCase()));


### PR DESCRIPTION
## What

When a show pins its own Navidrome playlist(s), the candidate pool no longer *also* pulls in every playlist whose name merely contains the mood word.

## Why

Reported in #642. On a station where several shows share a mood (e.g. three `Sunny - *` playlists), pinning `Sunny - Street Beats` to a show didn't stop the loose mood-substring source from dragging `Sunny - Morning Rewind` etc. into the pool. In **soft** mode both the live picker and the LLM-free `auto.m3u` fallback leaked the wrong show's tracks. Strict mode already filtered them out at the final step; soft did not.

The explicit `show.playlistIds` / `playlistStrict` feature superseded most of #642's original proposal (name-convention matching) — this closes the one residual soft-mode gap.

## How

Guard the mood-name playlist source with `!hasPlaylist` in both spots:
- `controller/src/music/picker.ts` (source #3)
- `controller/src/broadcast/scheduler.ts` `refreshAutoPlaylistInner()` (source #2)

| Situation | Result |
|---|---|
| Show with pinned playlists, soft | only pinned playlists (+ narrowed discovery) — leak gone |
| Show with pinned playlists, strict | unchanged result, slightly cheaper (source not fetched) |
| Show, genre/mood only (no pins) | unchanged |
| Autonomous hour (no show) | unchanged |

Closes #642.

## Checks

`npm run lint` in `controller/` — eslint 0 errors, `tsc --noEmit` exit 0.