### PR TITLE
feat(llm): add configurable per-call max output tokens (#712)

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -14,7 +14,7 @@ import { agentPlan } from '../src/llm/internal/strategy/plan.js';
 import { introBudgetPhrase, enforceIntroBudget } from '../src/llm/internal/prompts/intro-budget.js';
 import { embeddingBaseUrl } from '../src/llm/internal/provider/embedding.js';
 import { DEFAULT_LOCCA_EMBED_BASE_URL } from '../src/llm/internal/provider/registry.js';
-import { personaToneDirectives, normalizeDial, DIAL_NEUTRAL, validatePersonasStrict, clampTtsSpeed, TTS_SPEED_DEFAULT } from '../src/settings.js';
+import { personaToneDirectives, normalizeDial, DIAL_NEUTRAL, validatePersonasStrict, clampTtsSpeed, TTS_SPEED_DEFAULT, clampMaxOutputTokens, resolveMaxOutputTokens, MAX_OUTPUT_TOKENS_MIN, MAX_OUTPUT_TOKENS_MAX } from '../src/settings.js';
 import { showMusicLean } from '../src/llm/internal/prompts/picker.js';
 
 let failures = 0;
@@ -398,6 +398,36 @@ async function main() {
     assert.match(out, /Soul-only/);   // strict genre lock (#618)
     assert.match(out, /Music steer for this show — prefer tracks from 1970–1979; favour medium-energy tracks/);
     assert.doesNotMatch(out, /lean toward Soul/);  // genre is the hard rule, not a soft part
+  });
+
+  // ---- clampMaxOutputTokens / resolveMaxOutputTokens (per-call cap, #712) ----
+  console.log('clampMaxOutputTokens / resolveMaxOutputTokens (per-call output cap):');
+  await test('0 and negatives mean "off" — pass through as 0, not the floor', () => {
+    assert.equal(clampMaxOutputTokens(0, 4000), 0);
+    assert.equal(clampMaxOutputTokens(-5, 4000), 0);
+  });
+  await test('non-numeric / NaN falls back to def (leaves the stored value untouched)', () => {
+    assert.equal(clampMaxOutputTokens('nope', 4000), 4000);
+    assert.equal(clampMaxOutputTokens(NaN, 8000), 8000);
+    assert.equal(clampMaxOutputTokens(undefined, 1234), 1234);
+    assert.equal(clampMaxOutputTokens(Infinity, 4000), 4000);
+  });
+  await test('1..499 rounds up to the 500 floor; over-max clamps to 8000', () => {
+    assert.equal(clampMaxOutputTokens(1, 4000), MAX_OUTPUT_TOKENS_MIN);
+    assert.equal(clampMaxOutputTokens(499, 4000), 500);
+    assert.equal(clampMaxOutputTokens(9000, 4000), MAX_OUTPUT_TOKENS_MAX);
+  });
+  await test('in-range values pass through, floored to an int', () => {
+    assert.equal(clampMaxOutputTokens(500, 4000), 500);
+    assert.equal(clampMaxOutputTokens(2000, 4000), 2000);
+    assert.equal(clampMaxOutputTokens(8000, 4000), 8000);
+    assert.equal(clampMaxOutputTokens(2000.9, 4000), 2000);
+  });
+  await test('resolveMaxOutputTokens returns the strategy fallback when unset (default 0)', () => {
+    // No update() has run in this pure harness, so settings.get() is DEFAULTS
+    // (maxOutputTokens: 0) → each strategy keeps its own built-in default.
+    assert.equal(resolveMaxOutputTokens(4000), 4000);
+    assert.equal(resolveMaxOutputTokens(8000), 8000);
   });
 
   console.log(failures === 0 ? '\nAll llm-pure tests passed.' : `\n${failures} test(s) FAILED.`);

--- a/controller/src/llm/internal/strategy/agent.ts
+++ b/controller/src/llm/internal/strategy/agent.ts
@@ -33,7 +33,11 @@ import { stripThinking, extractJson, usageOf, flattenToolCalls, failureDiagnosti
 import { needsToolCallObject, providerOptions, samplingWithNumCtx, forcedToolChoice } from '../provider/capabilities.js';
 import { objectViaToolCall } from './object-via-tool.js';
 import { agentPlan } from './plan.js';
+import { resolveMaxOutputTokens } from '../../../settings.js';
 
+// Operator-overridable via settings.llm.maxOutputTokens (issue #712); 0 keeps
+// this default. Resolved here and threaded down to objectViaToolCall and the
+// ToolLoopAgent, so the cap is uniform across the agent's sub-paths.
 const MAX_TOKENS_AGENT = 8000;
 
 // prepareStep pins activeTools so EVERY step is a cornered single-purpose
@@ -94,7 +98,7 @@ export async function djAgent({
   schema,
   maxSteps = 8,
   temperature = 0.6,
-  maxOutputTokens = MAX_TOKENS_AGENT,
+  maxOutputTokens = resolveMaxOutputTokens(MAX_TOKENS_AGENT),
   kind = 'sdk.djAgent',
   timeoutMs,
 }: any): Promise<{ object: any; steps: number; toolCalls: any[] }> {

--- a/controller/src/llm/internal/strategy/object.ts
+++ b/controller/src/llm/internal/strategy/object.ts
@@ -18,7 +18,10 @@ import { withTransientRetry } from '../core/retry.js';
 import { stripThinking, extractJson, usageOf, failureDiagnostics } from '../core/pure.js';
 import { needsToolCallObject, providerOptions, samplingWithNumCtx } from '../provider/capabilities.js';
 import { objectViaToolCall } from './object-via-tool.js';
+import { resolveMaxOutputTokens } from '../../../settings.js';
 
+// Operator-overridable via settings.llm.maxOutputTokens (issue #712); 0 keeps
+// this default.
 const MAX_TOKENS_OBJECT = 8000;
 
 export async function djObject({
@@ -26,7 +29,7 @@ export async function djObject({
   prompt,
   schema,
   temperature = 0.4,
-  maxOutputTokens = MAX_TOKENS_OBJECT,
+  maxOutputTokens = resolveMaxOutputTokens(MAX_TOKENS_OBJECT),
   kind = 'sdk.djObject',
   leg = undefined,
 }: any): Promise<any> {

--- a/controller/src/llm/internal/strategy/text.ts
+++ b/controller/src/llm/internal/strategy/text.ts
@@ -9,12 +9,14 @@ import { withFailover } from '../core/failover.js';
 import { withTransientRetry } from '../core/retry.js';
 import { stripThinking, usageOf, failureDiagnostics } from '../core/pure.js';
 import { providerOptions, repeatPenaltyApplies, samplingWithNumCtx } from '../provider/capabilities.js';
+import { resolveMaxOutputTokens } from '../../../settings.js';
 
 // Hard output-token cap. A reasoning model with no cap can generate until it
 // fills the whole context window — one runaway <think> ramble then ties up the
 // inference slot for minutes. Generous backstop for normal output (idents are
 // ~150 tokens); raise it if you turn `llm.reasoning` on and need room for the
-// chain-of-thought.
+// chain-of-thought. The operator can override via settings.llm.maxOutputTokens
+// (issue #712); 0 there keeps this default.
 const MAX_TOKENS_TEXT = 4000;
 
 export async function djText({
@@ -24,7 +26,7 @@ export async function djText({
   topP = 0.95,
   repeatPenalty = 1.15,
   seed = null,
-  maxOutputTokens = MAX_TOKENS_TEXT,
+  maxOutputTokens = resolveMaxOutputTokens(MAX_TOKENS_TEXT),
   kind = 'sdk.djText',
 }: any): Promise<string> {
   return withFailover(

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -274,6 +274,28 @@ function clampBudgetSoftPct(raw: any, def: number): number {
   return Math.min(100, Math.max(0, Math.floor(raw)));
 }
 
+// Per-call max output tokens (issue #712). 0 is a first-class value meaning
+// "off — use each strategy's built-in default", so it passes through unclamped.
+// Any other value is floored and clamped to [MAX_OUTPUT_TOKENS_MIN,
+// MAX_OUTPUT_TOKENS_MAX]; non-numeric/NaN falls back to `def`.
+export const MAX_OUTPUT_TOKENS_MIN = 500;
+export const MAX_OUTPUT_TOKENS_MAX = 8000;
+export function clampMaxOutputTokens(raw: any, def: number): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return def;
+  const n = Math.floor(raw);
+  if (n <= 0) return 0;
+  return Math.min(MAX_OUTPUT_TOKENS_MAX, Math.max(MAX_OUTPUT_TOKENS_MIN, n));
+}
+
+// Resolve the effective per-call output-token cap. Returns the operator's
+// configured value when set (> 0), else `fallback` — the strategy's own
+// built-in default. The single read point for settings.llm.maxOutputTokens;
+// strategy/text|object|agent all default their maxOutputTokens param through it.
+export function resolveMaxOutputTokens(fallback: number): number {
+  const v = get().llm?.maxOutputTokens;
+  return typeof v === 'number' && v > 0 ? v : fallback;
+}
+
 // Count-based hard no-repeat window (distinct plays). Floored to an integer in
 // [0, 290]: 0 disables; the 290 ceiling stays under the 300-entry _recentPlays
 // cap so the requested window is never silently truncated by a too-short
@@ -856,6 +878,15 @@ const DEFAULTS = {
     // over the cap fall through to the stateless matcher cascade like every
     // other LLM path. No effect until dailyTokenCap is set.
     exemptRequests: true,
+    // Per-call max OUTPUT tokens — distinct from dailyTokenCap (a cumulative
+    // daily budget). This caps the size of each individual model response. The
+    // strategy primitives default to generous built-ins (4000 text / 8000
+    // object / 8000 agent); 0 = use those defaults. Set a value (clamped
+    // 500–8000) to override all three — the lever for a local model on a small
+    // context window, where an 8000-token response allowance can crowd out the
+    // system prompt / tool listing and risk truncation, and is pure waste with
+    // reasoning off. Resolved via resolveMaxOutputTokens(); see issue #712.
+    maxOutputTokens: 0,
     // When on (or when LLM_DEBUG_RAW is set in the env), every outbound model
     // request's exact body is captured to ${STATE_DIR}/logs/llm-debug.log (the
     // last 10, newest first) and dumped to stderr — a copy-pasteable view of
@@ -1455,6 +1486,9 @@ export async function load() {
       // up the defaults (0 = disabled, so they behave exactly as before).
       dailyTokenCap: clampDailyTokenCap(stored.llm?.dailyTokenCap, DEFAULTS.llm.dailyTokenCap),
       budgetSoftPct: clampBudgetSoftPct(stored.llm?.budgetSoftPct, DEFAULTS.llm.budgetSoftPct),
+      // Per-call output cap (issue #712) — pre-existing settings.json lacks the
+      // field and picks up the 0 default (= built-in per-strategy defaults).
+      maxOutputTokens: clampMaxOutputTokens(stored.llm?.maxOutputTokens, DEFAULTS.llm.maxOutputTokens),
       exemptRequests:
         typeof stored.llm?.exemptRequests === 'boolean'
           ? stored.llm.exemptRequests
@@ -2449,6 +2483,9 @@ export async function update(patch) {
     }
     if (l.budgetSoftPct !== undefined) {
       next.llm.budgetSoftPct = clampBudgetSoftPct(Number(l.budgetSoftPct), next.llm.budgetSoftPct);
+    }
+    if (l.maxOutputTokens !== undefined) {
+      next.llm.maxOutputTokens = clampMaxOutputTokens(Number(l.maxOutputTokens), next.llm.maxOutputTokens);
     }
     if (l.exemptRequests !== undefined) {
       next.llm.exemptRequests = !!l.exemptRequests;

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -161,6 +161,7 @@ interface LlmForm {
   dailyTokenCap: number;
   budgetSoftPct: number;
   exemptRequests: boolean;
+  maxOutputTokens: number;
   fallback: LlmFallbackForm;
 }
 
@@ -495,6 +496,7 @@ export default function SettingsPanel() {
         dailyTokenCap: typeof v.llm?.dailyTokenCap === 'number' ? v.llm.dailyTokenCap : 0,
         budgetSoftPct: typeof v.llm?.budgetSoftPct === 'number' ? v.llm.budgetSoftPct : 80,
         exemptRequests: v.llm?.exemptRequests !== false,
+        maxOutputTokens: typeof v.llm?.maxOutputTokens === 'number' ? v.llm.maxOutputTokens : 0,
         fallback: {
           enabled: !!v.llm?.fallback?.enabled,
           provider: v.llm?.fallback?.provider ?? 'ollama',
@@ -2553,6 +2555,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
         dailyTokenCap: form.llm.dailyTokenCap,
         budgetSoftPct: form.llm.budgetSoftPct,
         exemptRequests: form.llm.exemptRequests,
+        maxOutputTokens: form.llm.maxOutputTokens,
         ...(form.llm.provider === 'openai-compatible' && compatKeyInput.trim()
           ? { apiKey: compatKeyInput.trim() }
           : {}),
@@ -3177,6 +3180,31 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
             ]}
             onChange={v => setForm(f => ({ ...f, llm: { ...f.llm, reasoning: v === 'on' } }))}
           />
+        </div>
+
+        <div className="field mt-4">
+          <Label>Max response size (tokens)</Label>
+          <Input
+            type="number"
+            min={0}
+            max={8000}
+            step={500}
+            value={form.llm.maxOutputTokens}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setForm(f => ({ ...f, llm: { ...f.llm, maxOutputTokens: Math.min(8000, Math.max(0, Number(e.target.value))) } }))
+            }
+            placeholder="0"
+            className="max-w-[200px]"
+          />
+          <div className="field-hint">
+            Caps the tokens the model may generate per response &mdash; the size
+            of each reply, not a daily total. <strong>0 = use the built-in
+            defaults</strong> (the default). Set a value (500&ndash;8000) to
+            shrink it: useful on a local model with a small context window, where
+            an oversized response allowance crowds out the system prompt and tool
+            list and risks truncation &mdash; especially with reasoning off, where
+            replies are short anyway. Values between 1 and 499 round up to 500.
+          </div>
         </div>
       </Card>
 


### PR DESCRIPTION
Closes #712.

## What

Adds `llm.maxOutputTokens` — a per-call cap on the size of each model response, configurable from **admin → Settings → Reasoning** ("Max response size (tokens)").

This is **not** the same axis as the existing `dailyTokenCap`:

| Setting | Scope |
|---|---|
| `dailyTokenCap` (existing) | cumulative tokens per UTC **day**, across all calls |
| `maxOutputTokens` (new) | max tokens generated in a **single** response |

## Why

On a local model with a small context window, an 8000-token response allowance can crowd out the system prompt / tool listing and risk truncation — and it's pure waste with reasoning off, where replies are short anyway. #712 asks to expose this next to the reasoning toggle, capped 500–8000.

## How

- **`settings.ts`** — new field `maxOutputTokens: 0`. `0` = "use built-in defaults"; any other value is clamped to `[500, 8000]` (`clampMaxOutputTokens`). Wired through `load()` (old settings.json picks up `0`) and `update()`. New `resolveMaxOutputTokens(fallback)` accessor is the single read point.
- **`strategy/text|object|agent`** — each defaults its `maxOutputTokens` param to `resolveMaxOutputTokens(<its built-in>)` (4000 / 8000 / 8000). The agent threads the resolved value down to `objectViaToolCall` and the `ToolLoopAgent`, so the cap is uniform across its sub-paths. `capabilities.ts` stays pure (value is provider-agnostic).
- **`SettingsPanel.tsx`** — "Max response size (tokens)" input in the Reasoning card, wired through the form type/init/save payload.

Behavior at the default (`0`) is byte-for-byte unchanged.

## Tests

- `clampMaxOutputTokens` + `resolveMaxOutputTokens` unit coverage added to `llm-pure.test.ts` (`npm run test:llm`, all pass).
- Verified locally against a temp `STATE_DIR`: the full `load → update → persist → resolve` round-trip, clamp on both save and load, and that a set value overrides all three strategy defaults.
- `controller` and `web` lint (eslint + tsc) both clean.