### PR TITLE
fix(embeddings): make embedding-model changes actually work (fresh + populated)

### DIFF
--- a/controller/package.json
+++ b/controller/package.json
@@ -11,7 +11,7 @@
     "lastfm-session": "tsx scripts/lastfm-session.ts",
     "test:embed": "tsx scripts/embedding-preflight-test.ts",
     "test:llm": "tsx scripts/llm-pure.test.ts",
-    "test": "tsx scripts/llm-pure.test.ts && tsx scripts/picker-recency-regression.ts && tsx scripts/recent-plays.test.ts && tsx scripts/listeners-status.test.ts && tsx scripts/lastfm-enrich.test.ts && tsx scripts/web-search-searxng.test.ts && tsx scripts/request-dedup.test.ts && tsx scripts/stale-link.test.ts && tsx scripts/embedding-heavy.test.ts && tsx scripts/tagger-perf.test.ts && tsx scripts/rescan-scope.test.ts && tsx scripts/show-playlist.test.ts",
+    "test": "tsx scripts/llm-pure.test.ts && tsx scripts/picker-recency-regression.ts && tsx scripts/recent-plays.test.ts && tsx scripts/listeners-status.test.ts && tsx scripts/lastfm-enrich.test.ts && tsx scripts/web-search-searxng.test.ts && tsx scripts/request-dedup.test.ts && tsx scripts/stale-link.test.ts && tsx scripts/embedding-heavy.test.ts && tsx scripts/tagger-perf.test.ts && tsx scripts/rescan-scope.test.ts && tsx scripts/show-playlist.test.ts && tsx scripts/embedding-dim-migrate.test.ts",
     "lint": "eslint . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit"

--- a/controller/scripts/embedding-dim-migrate.test.ts
+++ b/controller/scripts/embedding-dim-migrate.test.ts
@@ -1,0 +1,86 @@
+// Integration tests for library-db's embedding-dim reconciliation in migrate().
+//
+// Pins the fix for the qwen3-embedding crash (Discord: "Subwave seems hardcoded
+// to 768D"): the live controller creates track_vectors at the name→dim GUESS
+// (768 for an unknown model) before the tagger probes the real width (1024), and
+// the old check — keyed off the absent embedding_meta row rather than the table's
+// own FLOAT[N] schema — neither recreated the table nor errored, so every embed
+// insert crashed and wiping the DB didn't help.
+//
+// These run a REAL better-sqlite3 + sqlite-vec DB against a temp STATE_DIR, so
+// STATE_DIR is set before library-db is imported (dynamic import below).
+// Run: `tsx scripts/embedding-dim-migrate.test.ts` (folded into `npm run test`).
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let failures = 0;
+function test(name: string, fn: () => void | Promise<void>) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => console.log(`  ✓ ${name}`))
+    .catch((err) => { failures++; console.error(`  ✗ ${name}\n      ${err?.message || err}`); });
+}
+
+async function main() {
+  const stateDir = mkdtempSync(join(tmpdir(), 'subwave-dim-'));
+  process.env.STATE_DIR = stateDir;
+
+  // Imported AFTER STATE_DIR is set so DB_PATH resolves into the temp dir.
+  const db = await import('../src/music/library-db.js');
+
+  const vec = (dim: number) => new Float32Array(dim).fill(0.1);
+
+  console.log('embedding-dim reconciliation (migrate):');
+
+  await test('empty guessed-dim table self-heals to the real dim on a normal tag run', async () => {
+    // Controller boots a fresh DB at the name→dim guess (768), writes no meta.
+    await db.open({ embeddingDim: 768, adoptStoredDim: true });
+    db.close();
+    // Tagger probes the real dim (1024) on a NORMAL run — no --reseed.
+    await db.open({ embeddingDim: 1024, reseed: false });
+    // The empty 768 table is recreated at 1024, and 1024-d inserts succeed.
+    assert.doesNotThrow(() => db.upsertTrackVector('t1', vec(1024)));
+    assert.equal(db.hasVector('t1'), true);
+    db.close();
+  });
+
+  await test('a POPULATED dim mismatch is gated behind --reseed (no silent wipe)', async () => {
+    await assert.rejects(
+      () => db.open({ embeddingDim: 512, reseed: false }),
+      /embedding dim mismatch/i,
+    );
+    // DB left intact — the 1024-d vector from the previous test survives.
+    await db.open({ embeddingDim: 1024, adoptStoredDim: true });
+    assert.equal(db.hasVector('t1'), true);
+    db.close();
+  });
+
+  await test('--reseed drops a populated index and recreates at the new dim', async () => {
+    await db.open({ embeddingDim: 512, reseed: true });
+    assert.equal(db.hasVector('t1'), false); // old vectors dropped
+    assert.doesNotThrow(() => db.upsertTrackVector('t2', vec(512)));
+    db.close();
+  });
+
+  await test('live controller adopts the on-disk dim over a wrong name→dim guess (#319)', async () => {
+    // Table is 512 on disk (from the reseed above); controller boots guessing 768.
+    await db.open({ embeddingDim: 768, adoptStoredDim: true });
+    // It adopts 512 rather than wiping — the populated index keeps working.
+    assert.doesNotThrow(() => db.upsertTrackVector('t3', vec(512)));
+    assert.equal(db.hasVector('t2'), true);
+    db.close();
+  });
+
+  rmSync(stateDir, { recursive: true, force: true });
+
+  if (failures) {
+    console.error(`\n${failures} test(s) failed`);
+    process.exit(1);
+  }
+  console.log('\nall embedding-dim migrate tests passed');
+}
+
+main();

--- a/controller/scripts/embedding-dim-migrate.test.ts
+++ b/controller/scripts/embedding-dim-migrate.test.ts
@@ -74,6 +74,35 @@ async function main() {
     db.close();
   });
 
+  await test('dim-change reseed: embeddedIds() is empty but unembeddedIds() is the whole library', async () => {
+    // Fresh DB for this scenario (the tests above left vectors around).
+    db.close();
+    for (const f of ['library.db', 'library.db-wal', 'library.db-shm']) {
+      rmSync(join(stateDir, f), { force: true });
+    }
+    // A populated 768-d index: three tracks, each embedded.
+    await db.open({ embeddingDim: 768, reseed: false });
+    for (const id of ['a', 'b', 'c']) {
+      db.upsertTrackMeta(id, { title: id, artist: 'x', album: 'y', year: 2020, genre: 'z' });
+      db.upsertTrackVector(id, vec(768));
+    }
+    assert.equal(db.embeddedIds().length, 3);
+    db.close();
+
+    // Model swap to a 1024-d model → the tagger opens with reseed:true. migrate
+    // drops the mismatched populated table, so the OLD snapshot source (the set
+    // captured AFTER open) comes back empty — which is why "Re-embed all tracks"
+    // silently rebuilt 0 vectors on exactly the model swap it advertises.
+    await db.open({ embeddingDim: 1024, reseed: true });
+    assert.deepEqual(db.embeddedIds(), []);
+    // The fix's fallback source yields the whole library to re-embed instead.
+    const reembed = db.unembeddedIds();
+    assert.deepEqual([...reembed].sort(), ['a', 'b', 'c']);
+    for (const id of reembed) db.upsertTrackVector(id, vec(1024));
+    assert.equal(db.embeddedIds().length, 3);
+    db.close();
+  });
+
   rmSync(stateDir, { recursive: true, force: true });
 
   if (failures) {

--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -7,7 +7,7 @@
 // node:assert-via-tsx style of scripts/picker-recency-regression.ts.
 
 import assert from 'node:assert/strict';
-import { stripThinking, extractJson, usageOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded } from '../src/llm/internal/core/pure.js';
+import { stripThinking, extractJson, usageOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded, errReason } from '../src/llm/internal/core/pure.js';
 import { withDeadline } from '../src/llm/internal/core/retry.js';
 import { providerOptions, needsToolCallObject, repeatPenaltyApplies, appliedNumCtx, forcedToolChoice } from '../src/llm/internal/provider/capabilities.js';
 import { agentPlan } from '../src/llm/internal/strategy/plan.js';
@@ -125,6 +125,26 @@ async function main() {
     assert.equal(isUpstreamOverloaded({ statusCode: 429, message: 'rate limit exceeded, slow down' }), false);
     assert.equal(isUpstreamOverloaded({ code: 'ECONNRESET' }), false);
     assert.equal(isUpstreamOverloaded(null), false);
+  });
+
+  // ---- errReason: turn undici's opaque "fetch failed" into an actionable log ----
+  console.log('errReason (log-friendly cause; digs the errno out of err.cause):');
+  await test('undici "fetch failed" surfaces the errno from err.cause.code, not "unknown"', () => {
+    // The Discord shape: the request never reached OpenRouter, so there is no
+    // HTTP status — the real reason (ECONNRESET / ENOTFOUND / ETIMEDOUT) is on
+    // the cause. The old retry log only read err.code and printed "unknown".
+    const e: any = new TypeError('fetch failed');
+    e.cause = { code: 'ECONNRESET' };
+    assert.equal(errReason(e), 'fetch failed (ECONNRESET)');
+    const dns: any = new TypeError('fetch failed');
+    dns.cause = { code: 'ENOTFOUND' };
+    assert.equal(errReason(dns), 'fetch failed (ENOTFOUND)');
+  });
+  await test('prefers a status when there is no errno, and never double-prints', () => {
+    assert.equal(errReason({ statusCode: 503 }), '503');
+    assert.equal(errReason({ message: '503 Service Unavailable', statusCode: 503 }), '503 Service Unavailable');
+    assert.equal(errReason(new Error('Insufficient credits. Add more credits and retry.')), 'Insufficient credits. Add more credits and retry.');
+    assert.equal(errReason(null), 'unknown');
   });
 
   // ---- per-provider thinking knob (the single most regression-prone mapping) ----

--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -82,6 +82,17 @@ async function main() {
     assert.equal(isQuotaOrAuthError({ cause: { statusCode: 402 } }), true);
     assert.equal(isQuotaOrAuthError({ cause: { message: 'quota exceeded' } }), true);
   });
+  await test('OpenRouter out-of-credit 402 classifies by message when status is flattened', () => {
+    // Canonical 402 — caught by the existing insufficient-credit branch.
+    assert.equal(isQuotaOrAuthError(new Error('Your account or API key has insufficient credits. Add more credits and retry the request.')), true);
+    // Per-request affordability 402 — no "insufficient"/"quota" token, so before
+    // this it classified ONLY while the 402 status survived (Discord: run died as
+    // "unreachable" once the SDK flattened the status into the message).
+    const afford: any = new Error('This request requires more credits, or fewer max_tokens. You requested up to 4096 tokens, but can only afford 118.');
+    assert.equal(isQuotaOrAuthError(afford), true);
+    assert.equal(isTransient(afford), false);    // fail over, not same-leg retry
+    assert.equal(isUnreachable(afford), false);   // host answered — not a network outage
+  });
   await test('plain 5xx / socket errors are NOT quota/auth (still same-leg retry)', () => {
     assert.equal(isQuotaOrAuthError({ statusCode: 503 }), false);
     assert.equal(isQuotaOrAuthError({ code: 'ECONNRESET' }), false);

--- a/controller/src/llm/internal/core/pure.ts
+++ b/controller/src/llm/internal/core/pure.ts
@@ -207,6 +207,23 @@ export function isUpstreamOverloaded(err: any): boolean {
   return UPSTREAM_OVERLOAD_RE.test(msg);
 }
 
+// A short, actionable reason string for logs. A network-transport failure
+// surfaces as undici's opaque `TypeError: fetch failed` — the real errno
+// (ECONNRESET / ENOTFOUND / ETIMEDOUT / UND_ERR_*) lives on err.cause.code,
+// NOT err.code, so a log that only reads err.code/status prints "unknown" for
+// exactly the case an operator most needs to see (a request that never reached
+// the provider — Discord: "it's not even seeing requests"). Digs into the cause
+// and appends the errno/status to the message when it adds something.
+export function errReason(err: any): string {
+  if (!err) return 'unknown';
+  const msg = String(err.message || err.cause?.message || '').trim();
+  const code = err.code ?? err.cause?.code;
+  const status = err.statusCode ?? err.status ?? err.cause?.statusCode ?? err.cause?.status;
+  const detail = typeof code === 'string' ? code : typeof status === 'number' ? String(status) : '';
+  if (msg && detail && !msg.includes(detail)) return `${msg.slice(0, 100)} (${detail})`;
+  return msg.slice(0, 100) || detail || 'unknown';
+}
+
 // ---------------------------------------------------------------------------
 // Tool-call / diagnostics extraction
 // ---------------------------------------------------------------------------

--- a/controller/src/llm/internal/core/pure.ts
+++ b/controller/src/llm/internal/core/pure.ts
@@ -161,7 +161,10 @@ export function isUnreachable(err: any): boolean {
 // leg (issue #438). Detected by message because providers surface quota/auth
 // differently and the AI SDK often flattens the status into the message text;
 // a bare 429 with no quota signature stays a plain transient rate-limit.
-const QUOTA_RE = /usage limit|quota|exceeded your current|insufficient[ _]?(quota|funds|credit|balance)|upgrade for higher|out of credit|payment required/i;
+// "requires more credits" / "can only afford" are OpenRouter's per-request
+// affordability 402 — no "insufficient"/"quota" token, so it only classified
+// while the 402 status survived; match it by text too (Discord out-of-credit run).
+const QUOTA_RE = /usage limit|quota|exceeded your current|insufficient[ _]?(quota|funds|credit|balance)|requires more credits|can only afford|upgrade for higher|out of credit|payment required/i;
 const AUTH_RE = /invalid[ _]?api[ _]?key|incorrect[ _]?api[ _]?key|unauthorized|authentication (failed|error)|forbidden|api key (not|is|was) /i;
 
 export function isQuotaOrAuthError(err: any): boolean {

--- a/controller/src/llm/internal/core/retry.ts
+++ b/controller/src/llm/internal/core/retry.ts
@@ -3,7 +3,7 @@
 //   withTransientRetry — retries the SAME call on transient upstream blips.
 //   withDeadline       — a hard wall-clock ceiling (Promise.race + AbortSignal).
 
-import { isTransient } from './pure.js';
+import { isTransient, errReason } from './pure.js';
 
 // Retry transient upstream failures (gateway timeouts, dropped sockets). Local
 // Ollama — and anything proxying it — produces occasional 502/503/504 and TCP
@@ -25,8 +25,7 @@ export async function withTransientRetry<T>(kind: string, fn: () => Promise<T>):
       if (!isTransient(err) || attempt === delays.length) throw err;
       const jitter = Math.floor(Math.random() * 200);
       const wait = delays[attempt] + jitter;
-      const status = (err as any).statusCode ?? (err as any).status ?? (err as any).cause?.statusCode;
-      console.log(`[${kind}] transient upstream error (${status || (err as any).code || 'unknown'}) — retrying in ${wait}ms (attempt ${attempt + 1}/${delays.length})`);
+      console.log(`[${kind}] transient upstream error — ${errReason(err)} — retrying in ${wait}ms (attempt ${attempt + 1}/${delays.length})`);
       await new Promise(r => setTimeout(r, wait));
     }
   }

--- a/controller/src/llm/sdk.ts
+++ b/controller/src/llm/sdk.ts
@@ -6,4 +6,4 @@
 export { djText } from './internal/strategy/text.js';
 export { djObject } from './internal/strategy/object.js';
 export { djAgent } from './internal/strategy/agent.js';
-export { isUnreachable, isQuotaOrAuthError } from './internal/core/pure.js';
+export { isUnreachable, isQuotaOrAuthError, errReason } from './internal/core/pure.js';

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -396,40 +396,62 @@ async function migrate(embeddingDim: number, reseed = false, adoptStoredDim = fa
     d.pragma('user_version = 9');
   }
 
-  // The vec0 virtual table carries the embedding dim in its schema. If the
-  // stored dim doesn't match the requested one, the caller asked for a model
-  // swap — that's a --reseed operation, not an auto-migration.
+  // Reconcile the requested embedding dim against what physically exists.
+  //
+  // The vec0 table's `FLOAT[N]` schema is the authority for what inserts accept —
+  // NOT embedding_meta, which is written separately (by the tagger, post-probe)
+  // and can lag the table. Keying off the meta row alone misses the case that
+  // bit qwen3-embedding users: the live controller creates track_vectors at the
+  // name→dim GUESS (resolveEmbeddingDim → 768 for an unknown model) on a fresh
+  // DB and writes NO meta row; the tagger then probes the real dim (1024) but,
+  // because the meta was absent, the old check neither recreated the table nor
+  // errored — so every embed insert crashed with "Expected 768 dimensions but
+  // received 1024", and wiping the DB didn't help (the controller re-created the
+  // 768 table on the next boot). Read the real width from the table itself.
   const meta = d.prepare('SELECT model, dim FROM embedding_meta WHERE pk = 1').get() as
     | { model: string; dim: number }
     | undefined;
+  const tableDim = vecTableDim(d); // null when track_vectors doesn't exist yet
   // Effective dim for the vec0 table. Defaults to what the caller asked for; the
-  // branches below may adopt the stored dim or reseed at the new dim instead.
+  // branches below may adopt the on-disk dim or drop+recreate at the new dim.
   let effectiveDim = embeddingDim;
-  if (meta && meta.dim !== embeddingDim) {
+  if (tableDim !== null && tableDim !== embeddingDim) {
+    const modelHint = meta?.model ? ` (model: ${meta.model})` : '';
     if (adoptStoredDim) {
-      // Live controller: the stored vectors are authoritative. Honour their dim
-      // so the picker keeps working off a tagged index even when the model name
+      // Live controller: the physical index is authoritative. Honour its dim so
+      // the picker keeps working off a tagged index even when the model name
       // resolves to a different default. A real model swap is reconciled by the
       // tagger's --reseed path, not silently here (#319).
       console.warn(
-        `[library-db] adopting stored embedding dim ${meta.dim} (model: ${meta.model}); ` +
+        `[library-db] adopting on-disk embedding dim ${tableDim}${modelHint}; ` +
           `caller requested ${embeddingDim}. Re-tag with --reseed to switch models.`,
       );
-      effectiveDim = meta.dim;
+      effectiveDim = tableDim;
+    } else if (vecCount(d) === 0) {
+      // Empty index at the wrong width — nothing to protect, so recreate it at
+      // the requested dim without demanding --reseed. This self-heals the
+      // guessed-dim table the live controller created before the tagger probed
+      // the real one, so a plain tag run works for any embedding model / dim.
+      console.warn(
+        `[library-db] track_vectors is empty at ${tableDim}-d${modelHint}; ` +
+          `recreating at ${embeddingDim}-d for the current embedding model`,
+      );
+      runDdl(d, 'DROP TABLE IF EXISTS track_vectors');
+      d.prepare('DELETE FROM embedding_meta WHERE pk = 1').run();
     } else if (!reseed) {
       throw new Error(
-        `embedding dim mismatch: state/library.db has ${meta.dim}-d vectors (model: ${meta.model}), ` +
+        `embedding dim mismatch: state/library.db has ${tableDim}-d vectors${modelHint}, ` +
           `but the current settings ask for ${embeddingDim}-d. ` +
           `Run \`npm run tag -- --reseed\` to re-embed.`,
       );
     } else {
-      // Reseed across a model/dim change: the stored vectors are unusable at the
-      // new dim, so drop them (the table is recreated at `effectiveDim` just
-      // below) and clear the stale meta row so a later setEmbeddingMeta() seeds
-      // it fresh and the next open() sees a matching (or absent) dim.
+      // Reseed across a model/dim change on a POPULATED index: the stored vectors
+      // are unusable at the new dim, so drop them (the table is recreated at
+      // `effectiveDim` just below) and clear the stale meta row so a later
+      // setEmbeddingMeta() seeds it fresh and the next open() sees a matching dim.
       console.warn(
-        `[library-db] reseed: embedding dim ${meta.dim}→${embeddingDim} ` +
-          `(model: ${meta.model}); dropping vectors for re-embed`,
+        `[library-db] reseed: embedding dim ${tableDim}→${embeddingDim}${modelHint}; ` +
+          `dropping vectors for re-embed`,
       );
       runDdl(d, 'DROP TABLE IF EXISTS track_vectors');
       d.prepare('DELETE FROM embedding_meta WHERE pk = 1').run();
@@ -467,6 +489,25 @@ async function migrate(embeddingDim: number, reseed = false, adoptStoredDim = fa
 // identical to db.exec(sql).
 function runDdl(d: Database.Database, sql: string): void {
   (d as any).exec(sql);
+}
+
+// The embedding width baked into the track_vectors vec0 schema — the authority
+// for what inserts accept (embedding_meta is written separately and can lag).
+// Parsed from the stored CREATE statement; null when the table doesn't exist.
+function vecTableDim(d: Database.Database): number | null {
+  const row = d
+    .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='track_vectors'`)
+    .get() as { sql: string | null } | undefined;
+  if (!row?.sql) return null;
+  const m = row.sql.match(/embedding\s+FLOAT\[(\d+)\]/i);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+// Row count of the text-vector index. Used to decide whether a dim mismatch can
+// self-heal (empty table → free to recreate) or must gate behind --reseed
+// (populated index → the operator's vectors are at stake).
+function vecCount(d: Database.Database): number {
+  return (d.prepare('SELECT COUNT(*) AS n FROM track_vectors').get() as { n: number }).n;
 }
 
 // ---------------------------------------------------------------------------

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -285,15 +285,23 @@ async function main() {
       `moodVote=${moodVoteThreshold} confidence=${confidenceThreshold}`,
   );
 
-  // A re-scan re-embed rebuilds vectors only for the already-embedded population —
-  // snapshot it BEFORE the drop (afterwards every track looks unembedded). A
-  // normal --reseed run rebuilds vectors as part of its forward pass and doesn't
-  // need the snapshot. Used by the plan.reEmbed branch below.
+  // A re-scan re-embed rebuilds the vector population; a normal --reseed run does
+  // it as part of its forward pass and doesn't need the snapshot below.
   let reembedIds: string[] = [];
   if (flags.reseed) {
+    // Snapshot the set to rebuild. A SAME-dim reseed still has the old vectors
+    // here, so embeddedIds() captures exactly the already-embedded population. A
+    // DIM-CHANGE reseed already had track_vectors dropped inside open()/migrate
+    // (the old vectors are unusable at the new width), so this comes back empty.
     if (flags.rescan) reembedIds = db.embeddedIds();
     console.log('[tag] --reseed: dropping track_vectors, re-embedding from scratch');
     db.dropVectors();
+    // Dim change wiped the vectors before we could snapshot them. The UI pass is
+    // "Re-embed all tracks" (its whole purpose is a model change, which usually
+    // changes the dim), so rebuild every track that now needs a vector — after
+    // the reset that's the whole library. Without this the pass silently rebuilt
+    // 0 vectors on exactly the model swap it advertises.
+    if (flags.rescan && reembedIds.length === 0) reembedIds = db.unembeddedIds();
   }
 
   const promptHash = embeddings.promptVocabHash(TAGGER_BATCH_SYSTEM);
@@ -572,10 +580,12 @@ async function main() {
   } // end forward "Tag moods" step (plan.forwardTag)
 
   // ---- Re-scan: RE-EMBED (model swap) ------------------------------------
-  // Rebuild vectors for the already-embedded population only (snapshotted before
-  // the drop above) — never the untagged remainder. phaseEmbed also re-embeds any
-  // tagged row that lost its vector, so the KNN graph the existing tags anchor is
-  // fully restored under the new model.
+  // Rebuild vectors under the new embedding model. A same-dim swap rebuilds the
+  // already-embedded population (snapshotted before the drop above); a dim-change
+  // swap rebuilds every track that needs a vector (the whole library) because the
+  // old vectors were dropped at open() before they could be snapshotted. Either
+  // way the KNN graph the existing tags anchor is fully restored under the new
+  // model.
   if (plan.reEmbed) {
     console.log(`[tag] re-embed: rebuilding ${reembedIds.length} vectors from scratch`);
     await phaseEmbed(reembedIds, flags.batchSize);

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -891,9 +891,24 @@ async function processBatch(
     // 429s) against a leg that won't answer. The surviving consumer redoes the
     // requeued batch.
     if (consumer.pin && (isUnreachable(err) || isQuotaOrAuthError(err))) throw err;
-    console.error(
-      `[tag] LLM batch failed (${songs.length} tracks) on ${consumer.label}: ${err.message} — falling back to per-track`,
-    );
+    // A "batch length mismatch" is NOT a failure. Some models (e.g. Mercury, and
+    // small local models) don't return one structured-output entry per input
+    // track, so we tag each track individually this batch — same seed set, same
+    // cost envelope (only the seeds ever hit the LLM), just slower. Log it as an
+    // expected degrade, not an error, so it doesn't read as something broken.
+    // Genuine batch errors keep the error-level line with their message.
+    const perTrackDegrade = /batch length mismatch/i.test(err.message || '');
+    if (perTrackDegrade) {
+      console.warn(
+        `[tag] ${consumer.label} didn't return one entry per track — tagging ` +
+          `${songs.length} tracks individually this batch (expected for some ` +
+          `models; not an error, just slower)`,
+      );
+    } else {
+      console.error(
+        `[tag] LLM batch failed (${songs.length} tracks) on ${consumer.label}: ${err.message} — falling back to per-track`,
+      );
+    }
     results = [];
     for (const song of input) {
       try {

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -45,7 +45,7 @@ import { config } from '../config.js';
 import { loadSecretsIntoEnv } from '../setup/secrets.js';
 import { loadSetupConfig } from '../setup/config.js';
 import { activeModelLabel, primaryLeg, fallbackLeg, probeLegReachable } from '../llm/provider.js';
-import { isUnreachable, isQuotaOrAuthError } from '../llm/sdk.js';
+import { isUnreachable, isQuotaOrAuthError, errReason } from '../llm/sdk.js';
 import { tagBatch, tagOne, TAGGER_BATCH_SYSTEM, type TagResult } from './tagger-core.js';
 import { runAnalysisPass } from './analyze.js';
 import { reportProgress, formatPhaseBreakdown, sortedPhaseTimings } from './tagger-progress.js';
@@ -985,7 +985,7 @@ async function runConsumer(
       const remaining = onDrop ? onDrop(err) : 0;
       const reason = isQuotaOrAuthError(err) ? 'quota/credit/auth rejected' : 'host unreachable';
       console.log(
-        `[tag] LLM leg ${consumer.label} dropped — ${reason}: ${err.message} (${remaining} leg(s) left)`,
+        `[tag] LLM leg ${consumer.label} dropped — ${reason}: ${errReason(err)} (${remaining} leg(s) left)`,
       );
       return;
     }

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -966,7 +966,7 @@ async function runConsumer(
   total: number,
   state: TagState,
   phaseInfo: TagPhaseInfo,
-  onDrop: (() => number) | null,
+  onDrop: ((err: any) => number) | null,
 ): Promise<void> {
   for (;;) {
     const batch = batches.shift();
@@ -975,12 +975,17 @@ async function runConsumer(
       const n = await processBatch(batch, consumer, promptHash, source, state);
       state.tagged += n;
       state.byLeg[consumer.label] = (state.byLeg[consumer.label] || 0) + n;
-    } catch {
-      // processBatch only throws on a pinned-leg host outage.
+    } catch (err: any) {
+      // processBatch rethrows only when a pinned leg can't recover this run:
+      // the host is down (isUnreachable) OR the provider refused the leg with a
+      // quota / credit / usage-limit / auth error (isQuotaOrAuthError, #438).
+      // Name the real reason — logging every drop as "unreachable" misdirected an
+      // operator whose OpenRouter credits had simply run out (Discord).
       batches.unshift(batch);
-      const remaining = onDrop ? onDrop() : 0;
+      const remaining = onDrop ? onDrop(err) : 0;
+      const reason = isQuotaOrAuthError(err) ? 'quota/credit/auth rejected' : 'host unreachable';
       console.log(
-        `[tag] LLM leg ${consumer.label} unreachable — dropping it (${remaining} leg(s) left)`,
+        `[tag] LLM leg ${consumer.label} dropped — ${reason}: ${err.message} (${remaining} leg(s) left)`,
       );
       return;
     }
@@ -1028,13 +1033,20 @@ async function llmTagInBatches(
     await runConsumer(batches, consumers[0], promptHash, source, ids.length, state, phaseInfo, null);
   } else {
     let alive = consumers.length;
+    let quotaOrAuthDrop = false;
     await Promise.all(
       consumers.map(c =>
-        runConsumer(batches, c, promptHash, source, ids.length, state, phaseInfo, () => --alive)),
+        runConsumer(batches, c, promptHash, source, ids.length, state, phaseInfo, (err: any) => {
+          if (isQuotaOrAuthError(err)) quotaOrAuthDrop = true;
+          return --alive;
+        })),
     );
     if (batches.length > 0) {
       const abandoned = batches.reduce((n, b) => n + b.length, 0);
-      console.log(`[tag] all LLM legs unreachable — ${abandoned} tracks left for next run`);
+      const hint = quotaOrAuthDrop
+        ? ' — a leg was refused for quota/credit/auth; check the provider credit balance, spend cap, or API key'
+        : '';
+      console.log(`[tag] all LLM legs dropped — ${abandoned} tracks left for next run${hint}`);
     }
   }
   return { tagged: state.tagged, callCount: state.callCount, byLeg: state.byLeg };

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -269,9 +269,11 @@ async function main() {
   // Tunables from settings.embedding, CLI flags override where present.
   const embedCfg: any = (settings.get() as any).embedding ?? {};
   const maxRounds = flags.maxRounds ?? Math.max(0, embedCfg.maxActiveLearningRounds ?? 3);
-  const knnK = Math.max(1, embedCfg.knnNeighbours ?? 5);
-  const moodVoteThreshold = clamp01(embedCfg.moodVoteThreshold ?? 0.6);
-  const confidenceThreshold = clamp01(embedCfg.confidenceThreshold ?? 0.6);
+  // Fallbacks kept in sync with DEFAULTS.embedding in settings.ts (settings.get()
+  // normally supplies these; the ?? only bites if the field is entirely absent).
+  const knnK = Math.max(1, embedCfg.knnNeighbours ?? 10);
+  const moodVoteThreshold = clamp01(embedCfg.moodVoteThreshold ?? 0.4);
+  const confidenceThreshold = clamp01(embedCfg.confidenceThreshold ?? 0.35);
   const seedCountCfg =
     typeof embedCfg.seedCount === 'number' && embedCfg.seedCount > 0
       ? embedCfg.seedCount
@@ -643,7 +645,14 @@ async function main() {
 }
 
 function autoSeedCount(librarySize: number): number {
-  return Math.max(200, Math.ceil(Math.sqrt(librarySize)));
+  // ~4% of the library, floored at 200 (small libraries still get a workable
+  // anchor set) and capped at 2500 (a 100k-track library shouldn't pay for 10k
+  // LLM seed tags — propagation carries the rest). Denser than the old
+  // ceil(sqrt(N)), which flatlined at 200 for everything up to ~40k tracks and
+  // left too few anchors for KNN propagation to fire before active-learning.
+  // A denser seed set is often net-cheaper: more seeds → higher propagation
+  // coverage → a smaller (expensive) active-learning residual.
+  return Math.max(200, Math.min(2500, Math.round(librarySize * 0.04)));
 }
 
 function finish(

--- a/controller/src/music/tag-propagator.ts
+++ b/controller/src/music/tag-propagator.ts
@@ -34,8 +34,12 @@ export interface VoteOpts {
 //   topSim      = max(0, neighbours[0].similarity)   (penalises far-away matches)
 //   confidence  = topSim * coverage
 //
-// Calibration is open in the spec (see §11). 0.6 is a reasonable starting
-// threshold — the implementation PR should tune this on the operator's data.
+// Because confidence is a PRODUCT of two sub-1 terms, the gate compounds fast: a
+// strong nearest match (topSim 0.75) with 3-of-5 tagged neighbours (coverage 0.6)
+// only scores 0.45. The old 0.6 default therefore rejected most genuinely-similar
+// tracks and dumped them into (expensive) active-learning; the default is now 0.35
+// (settings.ts DEFAULTS.embedding.confidenceThreshold), which still needs a real
+// neighbour but lets KNN propagation carry the bulk of tagging. Operator-tunable.
 export function vote(
   neighbours: KnnHit[],
   getTags: (id: string) => NeighbourTags | null,

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -939,10 +939,18 @@ const DEFAULTS = {
     baseUrl: '',          // openai-compatible / locca embedding server URL (with /v1)
     ollamaUrl: '',        // Ollama embedding server URL (ollama provider)
     apiKey: '',           // empty -> inherit settings.llm.apiKey
-    seedCount: 0,         // 0 → auto max(200, ceil(sqrt(library)))
-    knnNeighbours: 5,
-    moodVoteThreshold: 0.6,
-    confidenceThreshold: 0.6,
+    seedCount: 0,         // 0 → auto (see autoSeedCount in tag-library.ts: ~4% of
+                          //   the library, floored 200 / capped 2500)
+    // Propagation defaults. These were 5 / 0.6 / 0.6 and propagated almost
+    // nothing: confidence is topSim×coverage (a product of two sub-1 terms — see
+    // tag-propagator.ts), so a 0.6 gate rejected even strong matches and dumped
+    // the library into expensive active-learning. Loosened so KNN propagation
+    // actually carries the bulk of tagging. NOTE: only affects NEW installs / a
+    // reset — an existing settings.json keeps its saved values (loadWithDefaults
+    // below prefers a stored value), so operators are never silently overridden.
+    knnNeighbours: 10,        // was 5 — a broader, more stable neighbour vote
+    moodVoteThreshold: 0.4,   // was 0.6 — a mood carried by ~a third propagates
+    confidenceThreshold: 0.35, // was 0.6 — see the topSim×coverage note above
     maxActiveLearningRounds: 3,
     enrichment: {
       // Last.fm crowd tags. Tri-state: true = always fetch, false = never,

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -521,9 +521,9 @@ export default function SettingsPanel() {
         baseUrl: v.embedding?.baseUrl ?? '',
         ollamaUrl: v.embedding?.ollamaUrl ?? '',
         seedCount: String(v.embedding?.seedCount ?? 0),
-        knnNeighbours: String(v.embedding?.knnNeighbours ?? 5),
-        moodVoteThreshold: String(v.embedding?.moodVoteThreshold ?? 0.6),
-        confidenceThreshold: String(v.embedding?.confidenceThreshold ?? 0.6),
+        knnNeighbours: String(v.embedding?.knnNeighbours ?? 10),
+        moodVoteThreshold: String(v.embedding?.moodVoteThreshold ?? 0.4),
+        confidenceThreshold: String(v.embedding?.confidenceThreshold ?? 0.35),
         maxActiveLearningRounds: String(v.embedding?.maxActiveLearningRounds ?? 3),
         enrichment: {
           lastfmTags: v.embedding?.enrichment?.lastfmTags ?? false,
@@ -3688,9 +3688,9 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
         baseUrl: e.baseUrl,
         ollamaUrl: e.ollamaUrl,
         seedCount: parseInt(e.seedCount, 10) || 0,
-        knnNeighbours: parseInt(e.knnNeighbours, 10) || 5,
-        moodVoteThreshold: parseFloat(e.moodVoteThreshold) || 0.6,
-        confidenceThreshold: parseFloat(e.confidenceThreshold) || 0.6,
+        knnNeighbours: parseInt(e.knnNeighbours, 10) || 10,
+        moodVoteThreshold: parseFloat(e.moodVoteThreshold) || 0.4,
+        confidenceThreshold: parseFloat(e.confidenceThreshold) || 0.35,
         maxActiveLearningRounds: parseInt(e.maxActiveLearningRounds, 10) || 0,
         enrichment: {
           lastfmTags: e.enrichment.lastfmTags,
@@ -4208,8 +4208,10 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
             />
             <div className="field-hint">
               How many tracks the LLM tags by hand before propagation kicks in.
-              <code> 0</code> = auto: <code>max(200, ceil(sqrt(library)))</code>.
-              For a 5k library that&apos;s ~70; for 50k, ~220. CLI{' '}
+              <code> 0</code> = auto: <code>~4% of the library</code> (floored at
+              200, capped at 2500). For a 5k library that&apos;s 200; for 50k,
+              2000. A denser seed set is often net-cheaper — more anchors means a
+              smaller (expensive) active-learning residual. CLI{' '}
               <code>--seeds N</code> overrides this.
             </div>
           </div>
@@ -4235,8 +4237,9 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
             />
             <div className="field-hint">
               How many nearest tagged neighbours vote on an untagged track&apos;s
-              moods + energy. 5 is the well-tuned default; higher values smooth
-              over noise but blur edge cases.
+              moods + energy. Default <code>10</code> — a broader, steadier vote
+              than the old 5. Very high values dilute the vote on a sparsely-tagged
+              library (coverage below counts against confidence).
             </div>
           </div>
 
@@ -4258,8 +4261,8 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
             />
             <div className="field-hint">
               Fraction of voting neighbours that must carry a mood for it to
-              propagate. <code>0.6</code> ≈ 3-out-of-5 with the default
-              neighbour count. Higher = stricter, fewer propagated tags;
+              propagate. Default <code>0.4</code> — a mood shared by ~a third of
+              the voters carries. Higher = stricter, fewer propagated tags;
               lower = looser, more drift.
             </div>
           </div>
@@ -4281,9 +4284,13 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
               className="max-w-[180px]"
             />
             <div className="field-hint">
-              Minimum aggregate confidence (similarity × agreement) for a
-              propagated tag to be accepted. Below this, the track is queued
-              for LLM tagging instead.
+              Minimum confidence for a propagated tag to be accepted; below it the
+              track is queued for (pricier) LLM tagging. Confidence is{' '}
+              <code>topSim × coverage</code> — the nearest tagged neighbour&apos;s
+              similarity times the fraction of neighbours that were tagged. Being a
+              product of two sub-1 numbers it compounds fast, so the default is{' '}
+              <code>0.35</code>, not 0.6 (0.6 rejected even strong matches and sent
+              most tracks to the LLM).
             </div>
           </div>
 

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -3826,6 +3826,32 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
     }
   };
 
+  // What the tagger will actually embed with right now — resolved from the LIVE
+  // form (not saved state). "Follow LLM" resolves the provider; a blank Model
+  // field resolves to that provider's default. This is the line that stops
+  // operators reverse-engineering "what am I actually using?" — e.g. a DeepSeek
+  // DJ routed through OpenRouter embeds via openai/text-embedding-3-small, which
+  // isn't obvious from any field (Discord report).
+  const embeddedMeta = data.libraryStats?.embeddingMeta || null;
+  const suggestedDefault = EMBED_MODEL_SUGGESTIONS[effectiveProvider]?.[0];
+  // Defaults for the providers not carried in EMBED_MODEL_SUGGESTIONS (they have
+  // no combobox suggestions but still resolve to a sensible model server-side).
+  const OTHER_EMBED_DEFAULTS: Record<string, string> = {
+    'openai-compatible': 'text-embedding-3-small',
+    locca: 'nomic-embed-text',
+    anthropic: 'text-embedding-3-small',
+  };
+  const effectiveModel =
+    e.model?.trim() || suggestedDefault?.id || OTHER_EMBED_DEFAULTS[effectiveProvider] || '';
+  // Prefer a real measurement (a green probe, or the dim the library was actually
+  // embedded at) over the name→dim guess.
+  const effectiveDim =
+    probe?.dim ??
+    embeddedMeta?.dim ??
+    EMBED_MODEL_SUGGESTIONS[effectiveProvider]?.find(m => m.id === effectiveModel)?.dim ??
+    suggestedDefault?.dim ??
+    null;
+
   return (
     <>
       <SectionHeader
@@ -3909,7 +3935,21 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
               provider, so Ollama-local users get <code>nomic-embed-text</code> free.
               Anthropic has no first-party embedding API; if your LLM is Anthropic,
               pick OpenAI here (needs <code>OPENAI_API_KEY</code>).
-              {' '}Effective: <code>{llmProviderLabel(effectiveProvider)}</code>.
+            </div>
+            <div className="field-hint">
+              <strong>Embedding now:</strong> <code>{llmProviderLabel(effectiveProvider)}</code>
+              {effectiveModel && <> · <code>{effectiveModel}</code></>}
+              {effectiveDim != null && <> · {effectiveDim}-d</>}
+              {!e.provider && (
+                <> — follows your DJ provider, so switching the DJ provider changes
+                  this too (and needs a re-embed once the library is tagged). Pin a
+                  provider here to lock it.</>
+              )}
+              {embeddedMeta && embeddedMeta.model !== effectiveModel && (
+                <> Your library is currently embedded with{' '}
+                  <code>{embeddedMeta.model}</code> ({embeddedMeta.dim}-d) — changing
+                  the model means a full re-embed.</>
+              )}
             </div>
 
             {!canEmbed && (

--- a/web/components/manual/ModelsAndTokens.tsx
+++ b/web/components/manual/ModelsAndTokens.tsx
@@ -198,12 +198,23 @@ export default function ModelsAndTokens() {
             point embeddings at Ollama or OpenAI instead.
           </li>
           <li>
-            <strong>Some providers do chat only</strong> — DeepSeek and the Vercel AI
-            gateway have no embeddings endpoint at all. A DJ on one of those works fine, but
-            the tagger can't follow it, so the console only lists <em>embedding-capable</em>{' '}
-            providers in the tagger dropdown (Ollama, OpenAI, Google, OpenRouter, locca,
-            OpenAI-compatible). If you don't see your chat provider there, that's why — pick
-            Ollama (local and free) for the embedding step and leave the DJ where it is.
+            <strong>Some providers do chat only</strong> — the <code>deepseek</code> and
+            Vercel AI <code>gateway</code> <em>providers</em> have no embeddings endpoint at
+            all. A DJ on one of those works fine, but the tagger can't follow it, so the
+            console only lists <em>embedding-capable</em> providers in the tagger dropdown
+            (Ollama, OpenAI, Google, OpenRouter, locca, OpenAI-compatible). If you don't see
+            your chat provider there, that's why — pick Ollama (local and free) for the
+            embedding step and leave the DJ where it is.
+          </li>
+          <li>
+            <strong>Provider vs. model — mind the difference on a router.</strong> "DeepSeek"
+            is a <em>provider</em> (no embeddings), but it's also a <em>model</em> you can run{' '}
+            <em>through OpenRouter</em>. Those aren't the same: pick the <strong>OpenRouter</strong>{' '}
+            provider with a DeepSeek chat model and your DJ speaks via DeepSeek while embeddings
+            go through OpenRouter's own embeddings endpoint — by default{' '}
+            <code>openai/text-embedding-3-small</code>. OpenRouter, Requesty and the like carry
+            everything (chat and embeddings); the bare provider named after a chat-only company
+            does not.
           </li>
           <li>
             <strong>locca and OpenAI-compatible need a dedicated embedding server</strong> —
@@ -211,7 +222,26 @@ export default function ModelsAndTokens() {
             a second command, <code>locca embed</code>, on its own port; the console can
             detect it for you.
           </li>
+          <li>
+            <strong>Which one should I pick?</strong> Any embedding model at{' '}
+            <strong>768 dimensions or more</strong> is fine for mood similarity — favour a fast,
+            cheap one over a big "best-in-class" model. Good baselines:{' '}
+            <code>nomic-embed-text</code> (local, free, 768-d) if you run Ollama, or{' '}
+            <code>text-embedding-3-small</code> (cloud, cheap, 1536-d) otherwise. The exact
+            model matters far less than <em>picking one and sticking with it</em> — see the
+            next note.
+          </li>
         </ul>
+        <p>
+          <strong>One catch worth internalising:</strong> the vector index is built at your
+          embedding model's dimension, so <em>changing the embedding model means re-embedding
+          the whole library</em> (Admin &rarr; Library tagger &rarr; Re-scan &rarr; "Re-embed
+          all tracks"). Changing the <em>chat</em> model never needs this — but if embeddings
+          are set to "follow the LLM," switching your DJ <em>provider</em> quietly changes the
+          embedding model too. The console pins embeddings to your library's model and warns
+          you before that happens, so the safe move is to pin an embedding provider once and
+          leave it.
+        </p>
         <p>
           It all lives under <strong>Admin &rarr; Library tagger</strong>, and you can see
           the tagged library laid out in{' '}


### PR DESCRIPTION
Two related fixes so switching the embedding model (e.g. `nomic-embed-text` 768D → `qwen3-embedding` 1024D) works from the UI instead of crashing or silently doing nothing. Surfaced by a Discord report ("Subwave seems hardcoded to 768D").

## Fix 1 — `track_vectors` is created at a name guess, not the real dim

On a fresh DB the live controller creates `track_vectors` sized by `resolveEmbeddingDim()`, a **name-based** lookup that returns **768** for any model it doesn't recognise (incl. `qwen3-embedding`), writing **no `embedding_meta` row**. The tagger later probes the real dim (1024) but `migrate()`'s mismatch check keyed off the absent meta row rather than the table's own `FLOAT[N]` schema — so it neither recreated the table nor errored, and every embed insert crashed with `Expected 768 dimensions but received 1024`. Wiping `library.db` didn't help (the controller re-created the 768 table on the next boot). Only the CLI `npm run tag -- --reseed` escaped it.

`migrate()` now reconciles against the **actual on-disk vec0 width**:
- **Empty** table at a mismatched dim → recreate at the requested dim automatically (nothing to protect; no `--reseed` needed). Self-heals the guessed-dim table, so a normal **"Tag library"** run works for any embedding model.
- **Populated** mismatch → still throws the instructive "run `--reseed`" error (no silent wipe).
- `adoptStoredDim` (live controller) → still adopts the on-disk dim (#319), now keyed off the real table width.

## Fix 2 — "Re-embed all tracks" silently rebuilt 0 on a dim change

The admin Re-scan pass **"Re-embed all tracks"** (hint: *"Only after changing the embedding model"*) ran in `--rescan` mode and snapshotted the population to rebuild with `db.embeddedIds()` **after** `open()`. On a dim change, `open()`/`migrate()` already dropped the mismatched table, so the snapshot came back empty and the pass rebuilt **0** vectors — failing on exactly the model swap it advertises. It only worked when the new model kept the same vector width.

When the post-drop snapshot is empty (dim change), it now falls back to `db.unembeddedIds()` — every track needing a vector, i.e. the whole library after the reset. A same-dim reseed still rebuilds the already-embedded set.

## Tests

`controller/scripts/embedding-dim-migrate.test.ts` (real better-sqlite3 + sqlite-vec against a temp `STATE_DIR`), wired into `npm test`:
- empty guessed-dim table self-heals 768→1024
- populated mismatch is gated behind `--reseed`
- `--reseed` drops + recreates at the new dim
- controller adopts on-disk dim over a wrong name-guess (#319)
- dim-change reseed: `embeddedIds()` empty after open, `unembeddedIds()` = whole library (Fix 2's fallback source)

`tsc --noEmit` clean · `eslint` 0 errors · full `npm test` passes.

## Net effect

- **Fresh library + any embedding model** → normal "Tag library" just works (Fix 1).
- **Populated library + model/dim swap** → "Re-embed all tracks" rebuilds the whole library (Fix 2); a plain tag run gives a clear "run --reseed" message instead of a cryptic crash (Fix 1).

---

## Follow-up: embedding-model UX / docs / logs (3rd commit)

From a Discord thread where an operator running a DeepSeek DJ via OpenRouter couldn't tell what embedding model was actually in use (it silently resolves to `openai/text-embedding-3-small`). No behaviour change to the pipeline — clarity only.

- **Admin Settings** — the embedding section now shows the **live resolved config**: *"Embedding now: <provider> · <model> · <dim>"*, computed from the form (Follow-LLM + blank-model defaults included), preferring a real probe/library dim over the name guess. When following the LLM it notes that switching the DJ provider changes embeddings and needs a re-embed, and flags when the current model differs from the library's embedded model. (A provider swap on an *already-embedded* library was already guarded by the existing `embedPinNotice` auto-pin dialog.)
- **In-app manual** (`ModelsAndTokens`) — clarifies **provider vs. model-on-a-router** (the `deepseek` provider has no embeddings, but a DeepSeek model *through OpenRouter* embeds via OpenRouter's endpoint), adds a **baseline recommendation** (any 768-d+ model; `nomic-embed-text` local or `text-embedding-3-small` cloud), and spells out that changing the embedding model requires a full re-embed.
- **Tagger logs** — a `batch length mismatch` now logs as an *expected per-track degrade* (warn), not an error. Some models (e.g. Mercury) never return one structured-output entry per track; only seed tracks hit the LLM, so it's no more expensive, just slower. Genuine batch errors keep the error-level line.

Both packages lint clean (`controller` + `web`: eslint + tsc), full `npm test` passes.

---

## Follow-up: looser propagation defaults (4th commit)

The tagger's KNN-propagation defaults were too strict, so most tracks fell through to (expensive) active-learning LLM tagging instead of being propagated. Confidence is `topSim × coverage` (a product of two sub-1 terms — `tag-propagator.ts`), so the 0.6 gate rejected even strong matches (0.75 nearest match × 3-of-5 coverage = 0.45). Raised by EveningPill on Discord.

New `DEFAULTS.embedding` (settings.ts):
- `confidenceThreshold` 0.6 → **0.35**
- `knnNeighbours` 5 → **10**
- `moodVoteThreshold` 0.6 → **0.4**
- `autoSeedCount` `ceil(sqrt(N))` → **~4% of N, floored 200 / capped 2500** (sqrt flatlined at 200 for 15k–40k libraries; a denser seed set is often net-cheaper as it shrinks the active-learning residual)

**Only affects new installs / a reset** — `loadWithDefaults` prefers a stored value, so an existing `settings.json` keeps its saved numbers and operators are never silently overridden. All four stay tunable in admin Settings, and the Confidence-threshold field hint now spells out the `topSim × coverage` model so the number isn't magic.

`controller` (tsc + tests) and `web` (eslint + tsc) both clean.