### PR TITLE
feat(personas): expand persona limits — soul 400→1000, roster 12→24 (#722)

### DIFF
--- a/controller/src/llm/internal/prompts/generate.ts
+++ b/controller/src/llm/internal/prompts/generate.ts
@@ -25,7 +25,7 @@ import { djObject } from '../strategy/object.js';
 const PERSONA_SCHEMA = z.object({
   name: z.string().min(1).max(40).describe('the DJ name shown in the player — 1-3 words, evocative, never generic like "DJ" or "Host"').catch('New DJ'),
   tagline: z.string().max(80).describe('a short one-line descriptor shown next to the name (e.g. "atmospheric & immersive"), 0-80 chars; "" if none fits').catch(''),
-  soul: z.string().min(1).max(400).describe('the personality/voice sketch the DJ speaks with — tone, sensibility, quirks, the kind of imagery they reach for. 1-3 sentences, max 400 chars. Concrete and specific, not a list of adjectives.').catch(''),
+  soul: z.string().min(1).max(1000).describe('the personality/voice sketch the DJ speaks with — tone, sensibility, quirks, the kind of imagery they reach for. Aim for 1-3 sentences; max 1000 chars. Concrete and specific, not a list of adjectives.').catch(''),
   frequency: z.enum(FREQUENCIES as [string, ...string[]]).describe('how chatty: quiet (rarely talks), moderate, or aggressive (talks a lot)').catch('moderate'),
   scriptLength: z.enum(SCRIPT_LENGTHS as [string, ...string[]]).describe('concise (one or two lines) or extended (longer riffs)').catch('concise'),
   djMode: z.boolean().describe('true if this host works the desk like a real radio DJ — back-announces tracks, teases what is coming, more present; false for a quieter selector').catch(true),

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -502,7 +502,7 @@ export const AVATAR_EXTENSIONS = ['png', 'jpg', 'jpeg', 'webp'] as const;
 // source of truth for which slugs exist; settings only checks the shape.
 const SKILL_SLUG_RE = /^[a-z0-9-]{1,40}$/;
 
-const PERSONA_LIMIT = 12;
+const PERSONA_LIMIT = 24;
 const SHOWS_LIMIT = 64;
 const PLAYLISTS_PER_SHOW = 10;
 const SKILLS_PER_PERSONA_LIMIT = 20;

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -1110,7 +1110,7 @@ function normalizeTts(raw: any) {
 function normalizePersona(raw: any) {
   if (!raw || typeof raw !== 'object') return null;
   const name = typeof raw.name === 'string' ? raw.name.trim().slice(0, 40) : '';
-  const soul = typeof raw.soul === 'string' ? raw.soul.trim().slice(0, 400) : '';
+  const soul = typeof raw.soul === 'string' ? raw.soul.trim().slice(0, 1000) : '';
   if (!name || !soul) return null;
   // Avatar — stored as a bare basename. Reset to '' if the persisted value
   // doesn't match the strict basename shape, so a hand-edited settings.json
@@ -1811,8 +1811,8 @@ export function validatePersonasStrict(raw) {
     if (name.length < 1 || name.length > 40)
       throw new Error(`personas[${i}].name must be 1-40 chars`);
     const soul = String(item.soul ?? '').trim();
-    if (soul.length < 1 || soul.length > 400)
-      throw new Error(`personas[${i}].soul must be 1-400 chars`);
+    if (soul.length < 1 || soul.length > 1000)
+      throw new Error(`personas[${i}].soul must be 1-1000 chars`);
     const tagline = String(item.tagline ?? '').trim();
     if (tagline.length > 80) throw new Error(`personas[${i}].tagline must be 0-80 chars`);
     // language — optional free text ("Turkish", "Türkçe", …). Absent/empty →

--- a/web/components/admin/personas/constants.ts
+++ b/web/components/admin/personas/constants.ts
@@ -52,7 +52,7 @@ export const KOKORO_RE = /^[a-z]{2}_[a-z0-9]+$/;
 
 export const NAME_MAX = 40;
 export const TAGLINE_MAX = 80;
-export const SOUL_MAX = 400;
+export const SOUL_MAX = 1000;
 export const LANGUAGE_MAX = 60;
 export const PROMPT_MIN = 50;
 export const PROMPT_MAX = 4000;

--- a/web/components/admin/personas/constants.ts
+++ b/web/components/admin/personas/constants.ts
@@ -56,7 +56,7 @@ export const SOUL_MAX = 1000;
 export const LANGUAGE_MAX = 60;
 export const PROMPT_MIN = 50;
 export const PROMPT_MAX = 4000;
-export const PERSONA_MAX = 12;
+export const PERSONA_MAX = 24;
 
 // 512×512 output target. The controller hard-caps the decoded image at 300 KB
 // and the JSON body at 600 KB; a center-cropped 512×512 WebP from a typical


### PR DESCRIPTION
Expands two persona-related caps so operators have more room to build rich, acoustic-aware DJ line-ups. Spirit of #722: *the bottleneck is now vocabulary, not data.*

## 1. Persona `soul` cap: 400 → 1000

Issue #722 asks for more room to write acoustic-aware DJ direction (BPM, key, `intro_ms`, time-signature feel, pace curve). The issue names the show `topic` field and reports a 400-char limit — but `topic` is already **1000** in current code (500 → 1000 at the TS migration; never 400). The **only** 400-char DJ-direction field is the persona **`soul`** (the DJ's voice/personality sketch). That's the cap this lifts, per maintainer direction.

All four enforcement points moved to 1000 to stay in sync:

| Where | File |
|---|---|
| Loader slice | `controller/src/settings.ts:1113` |
| Strict validator + msg | `controller/src/settings.ts:1814-1815` |
| AI-fill draft schema | `controller/src/llm/internal/prompts/generate.ts:28` |
| Admin counter (`SOUL_MAX`) | `web/components/admin/personas/constants.ts:55` |

1000 matches the show `topic` cap. Kept bounded (not unbounded) because `soul` is injected into **every** free-text DJ generation call — each char is a recurring per-call token cost.

## 2. Persona roster cap: 12 → 24

Operators were hitting the 12-persona ceiling. It's a soft limit with no structural dependency, so it's bumped to 24 in the two spots that stay in sync:

| Where | File |
|---|---|
| Loader cap + strict validator (`PERSONA_LIMIT`) | `controller/src/settings.ts:505` |
| Admin roster counter + add gate (`PERSONA_MAX`) | `web/components/admin/personas/constants.ts:59` |

## Verification

- `controller`: `tsc --noEmit` exit 0, `eslint` 0 errors
- `web`: `npm run lint` exit 0

## Not included (issue's "consider" item)

A dedicated structured "acoustic direction" sub-field (BPM range, key filter, intro hints) — larger design surface, left as a follow-up.

Refs #722