### PR TITLE
fix(admin): restore Save button when editing the system prompt (#724)

### DIFF
--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -372,9 +372,13 @@ export default function PersonasPanel() {
           promptOk={promptOk}
           promptText={promptText}
           busy={busy}
+          canSave={canSave}
+          allPersonasOk={allPersonasOk}
           onSetUseCustom={(custom) => setForm(f => f ? ({ ...f, useCustomPrompt: custom }) : f)}
           onChangePrompt={(text) => setForm(f => f ? ({ ...f, systemPrompt: text }) : f)}
           onRestore={() => setForm(f => f ? ({ ...f, systemPrompt: data?.defaults?.djPrompt || '' }) : f)}
+          onSave={() => { save(); }}
+          onDiscard={() => { load(); }}
         />
       )}
 

--- a/web/components/admin/personas/SystemPromptCard.tsx
+++ b/web/components/admin/personas/SystemPromptCard.tsx
@@ -14,14 +14,22 @@ interface SystemPromptCardProps {
   promptOk: boolean;
   promptText: string;   // trimmed
   busy: boolean;
+  // Save is shared with the persona editor — both POST the whole form (personas
+  // + djPrompt) — so `canSave` carries the same roster-wide gate. When it's
+  // blocked by something other than the prompt, `allPersonasOk` lets us say why.
+  canSave: boolean;
+  allPersonasOk: boolean;
   onSetUseCustom: (custom: boolean) => void;
   onChangePrompt: (text: string) => void;
   onRestore: () => void;
+  onSave: () => void;
+  onDiscard: () => void;
 }
 
 export function SystemPromptCard({
   useCustomPrompt, systemPrompt, defaultPrompt, promptOk, promptText, busy,
-  onSetUseCustom, onChangePrompt, onRestore,
+  canSave, allPersonasOk,
+  onSetUseCustom, onChangePrompt, onRestore, onSave, onDiscard,
 }: SystemPromptCardProps) {
   return (
     <Card title="System prompt" sub="shared by every persona">
@@ -67,6 +75,31 @@ export function SystemPromptCard({
           </div>
         </div>
       )}
+
+      {/* Save bar. Lives on the card itself because the persona editor — the
+          only other place this form can be saved from — is a modal that's
+          closed while you're editing the prompt (issue #724). */}
+      <div className="mt-4 flex flex-wrap items-center gap-3 border-t border-ink pt-3">
+        <span
+          className={cn(
+            'size-1.5 flex-none rounded-full',
+            canSave ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
+          )}
+        />
+        <span className="text-[11px] text-muted">
+          {!canSave && !promptOk
+            ? <span className="text-[var(--danger)]">fix the custom system prompt</span>
+            : !canSave && !allPersonasOk
+              ? <span className="text-[var(--danger)]">a persona in the roster is incomplete — fix it before saving</span>
+              : 'changes apply on the next spoken line · no mixer restart'}
+        </span>
+        <span className="ml-auto flex items-center gap-3">
+          <Btn onClick={onDiscard} disabled={busy}>Discard</Btn>
+          <Btn tone="accent" onClick={onSave} disabled={busy || !canSave}>
+            {busy ? 'Saving…' : 'Save system prompt'}
+          </Btn>
+        </span>
+      </div>
     </Card>
   );
 }


### PR DESCRIPTION
## What

Fixes #724 — "System prompt save button gone, poof!"

The **System prompt** editor (admin → Personas → *System prompt*) had no Save button. You could edit the shared DJ system-prompt template but couldn't persist it.

## Root cause

PR #708 (full-screen editor dialog) moved `PersonaEditor` — which holds the **only** Save button that persists `djPrompt` — into a modal gated on `editorOpen`. The `SystemPromptCard` is a separate top-level card toggled from the roster's "System prompt" button. So opening the prompt card *without* also opening a persona in the editor left **no visible Save button anywhere**. Before #708 the persona editor's save bar rendered inline on the page, always reachable.

## Fix

Give `SystemPromptCard` its own Save / Discard bar, wired to the panel's existing `save()` / `load()` (the same functions the persona editor uses — `save()` already POSTs the whole form: personas **and** `djPrompt`). It reuses the panel-level `canSave` / `allPersonasOk` gate so the status line explains a blocked save (invalid custom prompt vs. an incomplete persona in the roster).

- `web/components/admin/personas/SystemPromptCard.tsx` — add Save/Discard bar + status line
- `web/components/admin/PersonasPanel.tsx` — pass `canSave`, `allPersonasOk`, `onSave`, `onDiscard`

## Verification

- `npm run lint` (eslint + tsc, the repo's merge gate) passes clean.
- Full browser-drive of the authenticated save flow needs admin credentials; the save path itself is the proven `save()` already used by the persona editor's "Save persona".