### PR TITLE
fix(analyzer): lend gcc to the diffq sdist build in heavy images

### DIFF
--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -148,11 +148,15 @@ RUN python3 -m venv /opt/analyzer/venv && \
     if [ "$WITH_DEMUCS" = "1" ]; then \
       # diffq: decompressor for demucs' quantized checkpoints (mdx_q, …). Tiny,
       # but without it a DEMUCS_MODEL=*_q override makes demucs fatal() at load.
+      # It ships sdist-only (Cython ext), so lend it gcc for the install and
+      # purge in the SAME layer — the lean image never pays for any of this.
+      apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev && \
       /opt/analyzer/venv/bin/pip install --no-cache-dir \
         --index-url https://download.pytorch.org/whl/cpu \
         --extra-index-url https://pypi.org/simple \
         torch torchaudio demucs diffq && \
-      /opt/analyzer/venv/bin/python -c "import torch, demucs, diffq" ; \
+      /opt/analyzer/venv/bin/python -c "import torch, demucs, diffq" && \
+      apt-get purge -y gcc libc6-dev && apt-get autoremove -y && rm -rf /var/lib/apt/lists/* ; \
     fi && \
     find /opt/analyzer/venv -depth -type d -name __pycache__ -exec rm -rf {} +
 # ANALYZE_PYTHON flips on the controller's local analyze backend; HF_HOME points

--- a/docker/Dockerfile.analyzer
+++ b/docker/Dockerfile.analyzer
@@ -72,11 +72,15 @@ RUN python3 -m venv /opt/analyzer/venv && \
     if [ "$WITH_DEMUCS" = "1" ]; then \
       # diffq: decompressor for demucs' quantized checkpoints (mdx_q, …). Tiny,
       # but without it a DEMUCS_MODEL=*_q override makes demucs fatal() at load.
+      # It ships sdist-only (Cython ext), so lend it gcc for the install and
+      # purge in the SAME layer — the lean image never pays for any of this.
+      apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev && \
       /opt/analyzer/venv/bin/pip install --no-cache-dir \
         --index-url https://download.pytorch.org/whl/cpu \
         --extra-index-url https://pypi.org/simple \
         torch torchaudio demucs diffq && \
-      /opt/analyzer/venv/bin/python -c "import torch, demucs, diffq" ; \
+      /opt/analyzer/venv/bin/python -c "import torch, demucs, diffq" && \
+      apt-get purge -y gcc libc6-dev && apt-get autoremove -y && rm -rf /var/lib/apt/lists/* ; \
     fi && \
     find /opt/analyzer/venv -depth -type d -name __pycache__ -exec rm -rf {} +
 


### PR DESCRIPTION
## What

Follow-up to #718 (`63736ab`, which added `diffq` to the heavy analyzer/AIO images): `diffq` ships **sdist-only** (it has a Cython extension, no wheels), so the `pip install` in the `WITH_DEMUCS=1` branch fails on the slim base image, which carries no compiler.

## How

In both `docker/Dockerfile.analyzer` and `docker/Dockerfile.aio`:

- Install `gcc` + `libc6-dev` right before the torch/demucs/diffq pip install
- Purge them (`apt-get purge` + `autoremove` + clean apt lists) **in the same RUN layer**, so neither image gains any size
- Everything stays inside the `WITH_DEMUCS=1` conditional — the lean images never run any of it

## Verification

Heavy image builds through the diffq install and the `import torch, demucs, diffq` smoke check passes.