### PR TITLE
fix(analyzer): pass HF_TOKEN through to the analyzer sidecar

### DIFF
--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -302,6 +302,10 @@ services:
       # .env.example "Optional model overrides").
       - DEMUCS_MODEL=\${DEMUCS_MODEL:-}
       - ANALYZE_SECONDS=\${ANALYZE_SECONDS:-}
+      # CLAP isn't gated, but an anonymous HF Hub download is rate-limited and
+      # slow. Same var as tts-heavy — set HF_TOKEN=hf_... in your root .env once
+      # and both sidecars pick it up.
+      - HF_TOKEN=\${HF_TOKEN:-}
     volumes:
       # Shared mount with the controller — reads tracks the controller
       # pre-fetched into /var/sub-wave/analyze-tmp.
@@ -561,6 +565,10 @@ services:
       # .env.example "Optional model overrides").
       - DEMUCS_MODEL=\${DEMUCS_MODEL:-}
       - ANALYZE_SECONDS=\${ANALYZE_SECONDS:-}
+      # CLAP isn't gated, but an anonymous HF Hub download is rate-limited and
+      # slow. Same var as tts-heavy — set HF_TOKEN=hf_... in your root .env once
+      # and both sidecars pick it up.
+      - HF_TOKEN=\${HF_TOKEN:-}
     volumes:
       - *state-mount
       - analyzer-cache:/opt/analyzer/hf-cache
@@ -786,6 +794,10 @@ services:
       # .env.example "Optional model overrides").
       - DEMUCS_MODEL=\${DEMUCS_MODEL:-}
       - ANALYZE_SECONDS=\${ANALYZE_SECONDS:-}
+      # CLAP isn't gated, but an anonymous HF Hub download is rate-limited and
+      # slow. Same var as tts-heavy — set HF_TOKEN=hf_... in your root .env once
+      # and both sidecars pick it up.
+      - HF_TOKEN=\${HF_TOKEN:-}
     volumes:
       - *state-mount
       - analyzer-cache:/opt/analyzer/hf-cache

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -240,6 +240,10 @@ services:
       # .env.example "Optional model overrides").
       - DEMUCS_MODEL=${DEMUCS_MODEL:-}
       - ANALYZE_SECONDS=${ANALYZE_SECONDS:-}
+      # CLAP isn't gated, but an anonymous HF Hub download is rate-limited and
+      # slow. Same var as tts-heavy — set HF_TOKEN=hf_... in your root .env once
+      # and both sidecars pick it up.
+      - HF_TOKEN=${HF_TOKEN:-}
     volumes:
       - *state-mount
       - analyzer-cache:/opt/analyzer/hf-cache

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -212,6 +212,10 @@ services:
       # .env.example "Optional model overrides").
       - DEMUCS_MODEL=${DEMUCS_MODEL:-}
       - ANALYZE_SECONDS=${ANALYZE_SECONDS:-}
+      # CLAP isn't gated, but an anonymous HF Hub download is rate-limited and
+      # slow. Same var as tts-heavy — set HF_TOKEN=hf_... in your root .env once
+      # and both sidecars pick it up.
+      - HF_TOKEN=${HF_TOKEN:-}
     volumes:
       - *state-mount
       - analyzer-cache:/opt/analyzer/hf-cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -293,6 +293,10 @@ services:
       # .env.example "Optional model overrides").
       - DEMUCS_MODEL=${DEMUCS_MODEL:-}
       - ANALYZE_SECONDS=${ANALYZE_SECONDS:-}
+      # CLAP isn't gated, but an anonymous HF Hub download is rate-limited and
+      # slow. Same var as tts-heavy — set HF_TOKEN=hf_... in your root .env once
+      # and both sidecars pick it up.
+      - HF_TOKEN=${HF_TOKEN:-}
     volumes:
       # Shared mount with the controller — reads tracks the controller
       # pre-fetched into /var/sub-wave/analyze-tmp.


### PR DESCRIPTION
## Summary
- The `analyzer` sidecar's CLAP embedding download hits the Hugging Face Hub unauthenticated even when `HF_TOKEN` is set in the root `.env` — only `tts-heavy` wired the var through, so `analyzer` never saw it. CLAP isn't gated, but an anonymous download is rate-limited and slower.
- Adds `HF_TOKEN=${HF_TOKEN:-}` to the `analyzer` service's `environment:` block in all three compose files (`docker-compose.yml`, `docker-compose.byo.yml`, `docker-compose.dev.yml`), mirroring the existing `tts-heavy` pattern. `huggingface_hub`/`transformers` picks the var up automatically — no worker code changes needed.

## Test plan
- [x] `docker compose -f docker-compose.yml config -q` / byo / dev all validate
- [x] Recreated the live `analyzer` service with `ANALYZER_HEAVY=1`; confirmed `HF_TOKEN` is present inside the container (`docker exec sub-wave-analyzer sh -c 'echo ${#HF_TOKEN}'`)
- [x] `/api/health` stayed `on-air` throughout