### PR TITLE
fix(tagger): mute raw-debug stderr mirror in the standalone tagger

### DIFF
--- a/controller/src/llm/internal/telemetry/raw-debug.ts
+++ b/controller/src/llm/internal/telemetry/raw-debug.ts
@@ -70,6 +70,15 @@ function redactUrl(raw: string): string {
   }
 }
 
+// Whether to also mirror each captured request to stderr. On by default (for
+// operators grepping container logs), but the standalone tagger flips it off so
+// its clean, formatted CLI output isn't drowned by raw request JSON — the
+// rolling llm-debug.log file still captures everything.
+let stderrMirror = true;
+export function setRawDebugStderrMirror(enabled: boolean): void {
+  stderrMirror = enabled;
+}
+
 // In-memory ring of the last LLM_DEBUG_MAX formatted entries, newest first.
 const entries: string[] = [];
 
@@ -106,10 +115,13 @@ export function recordRawRequest(method: string, url: string, body: string): voi
   if (entries.length > LLM_DEBUG_MAX) entries.length = LLM_DEBUG_MAX;
 
   // Keep the legacy "dump to stderr" behaviour too, for operators already
-  // grepping container logs.
-  try {
-    process.stderr.write(`[llm-debug-raw] ${entry}`);
-  } catch { /* never break a model call */ }
+  // grepping container logs — unless a caller (e.g. the standalone tagger) has
+  // muted the mirror to keep its formatted CLI output readable.
+  if (stderrMirror) {
+    try {
+      process.stderr.write(`[llm-debug-raw] ${entry}`);
+    } catch { /* never break a model call */ }
+  }
 
   const snapshot = entries.join('\n');
   writeChain = writeChain.then(async () => {

--- a/controller/src/llm/log.ts
+++ b/controller/src/llm/log.ts
@@ -19,6 +19,7 @@ export { budgetMode } from './internal/core/pure.js';
 export {
   rawDebugEnabled,
   rawDebugEnabledViaEnv,
+  setRawDebugStderrMirror,
   LLM_DEBUG_LOG,
   LLM_DEBUG_MAX,
 } from './internal/telemetry/raw-debug.js';

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -46,6 +46,7 @@ import { loadSecretsIntoEnv } from '../setup/secrets.js';
 import { loadSetupConfig } from '../setup/config.js';
 import { activeModelLabel, primaryLeg, fallbackLeg, probeLegReachable } from '../llm/provider.js';
 import { isUnreachable, isQuotaOrAuthError, errReason } from '../llm/sdk.js';
+import { setRawDebugStderrMirror } from '../llm/log.js';
 import { tagBatch, tagOne, TAGGER_BATCH_SYSTEM, type TagResult } from './tagger-core.js';
 import { runAnalysisPass } from './analyze.js';
 import { reportProgress, formatPhaseBreakdown, sortedPhaseTimings, makeEventLogger } from './tagger-progress.js';
@@ -223,6 +224,11 @@ async function applyWizardOverlay() {
 async function main() {
   const flags = parseFlags();
   const startedAt = Date.now();
+
+  // Keep the raw-LLM-request debug capture writing to state/logs/llm-debug.log,
+  // but mute its stderr mirror so it doesn't drown the tagger's formatted output
+  // (the `[llm-debug-raw] {...}` JSON dumps). The file still captures everything.
+  setRawDebugStderrMirror(false);
 
   // Belt-and-braces single-flight: a controller-spawned run is already covered by
   // the pidfile the controller wrote (MANAGED_ENV set → this is a no-op). A manual


### PR DESCRIPTION
## What

The standalone library tagger's clean, formatted CLI output was being drowned by raw `[llm-debug-raw] {"model":"glm-5.1:cloud",...}` request dumps.

That dump comes from the raw-request debug capture (`raw-debug.ts`), which mirrors **every** model call to stderr whenever `settings.llm.debugRawRequests` (or the `LLM_DEBUG_RAW` env flag) is on. It's app-wide, so it bleeds into the tagger run even though the tagger isn't what enabled it.

## How

- `raw-debug.ts` — add a `stderrMirror` flag + `setRawDebugStderrMirror()` setter, gate the `process.stderr.write` on it.
- `llm/log.ts` — re-export the setter through the barrel.
- `music/tag-library.ts` — call `setRawDebugStderrMirror(false)` at the top of `main()`.

The rolling `state/logs/llm-debug.log` file still captures everything, so no debug data is lost — only the noisy stderr mirror is muted, and only for the tagger process. The station's own behaviour (mirroring to container logs) is unchanged.

## Notes

Prod-baked code — the running controller image needs `docker compose up -d --build controller` for the tagger change to take effect.

Lint/typecheck: 0 errors.