### PR TITLE
fix(aio): install python3-dev for the diffq sdist build in heavy AIO image

### DIFF
--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -148,15 +148,17 @@ RUN python3 -m venv /opt/analyzer/venv && \
     if [ "$WITH_DEMUCS" = "1" ]; then \
       # diffq: decompressor for demucs' quantized checkpoints (mdx_q, …). Tiny,
       # but without it a DEMUCS_MODEL=*_q override makes demucs fatal() at load.
-      # It ships sdist-only (Cython ext), so lend it gcc for the install and
-      # purge in the SAME layer — the lean image never pays for any of this.
-      apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev && \
+      # It ships sdist-only (Cython ext), so lend it gcc + Python headers for the
+      # install and purge in the SAME layer — the lean image never pays for any
+      # of this. Unlike the analyzer image (python:3.11-slim ships headers), this
+      # base's apt python3 has none, so python3-dev is required for Python.h.
+      apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev python3-dev && \
       /opt/analyzer/venv/bin/pip install --no-cache-dir \
         --index-url https://download.pytorch.org/whl/cpu \
         --extra-index-url https://pypi.org/simple \
         torch torchaudio demucs diffq && \
       /opt/analyzer/venv/bin/python -c "import torch, demucs, diffq" && \
-      apt-get purge -y gcc libc6-dev && apt-get autoremove -y && rm -rf /var/lib/apt/lists/* ; \
+      apt-get purge -y gcc libc6-dev python3-dev && apt-get autoremove -y && rm -rf /var/lib/apt/lists/* ; \
     fi && \
     find /opt/analyzer/venv -depth -type d -name __pycache__ -exec rm -rf {} +
 # ANALYZE_PYTHON flips on the controller's local analyze backend; HF_HOME points


### PR DESCRIPTION
## Problem

The `subwave-aio-heavy` publish job [failed](https://github.com/perminder-klair/subwave/actions/runs/28599972179/job/84805307866) building the `diffq` wheel:

```
bitpack.c:32:10: fatal error: Python.h: No such file or directory
error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
ERROR: Failed building wheel for diffq
```

`diffq` ships sdist-only (a Cython extension), so it compiles against the Python headers at install time. The AIO's `savonet/liquidsoap` base installs `python3` from apt, which does **not** include `Python.h`. The demucs layer only lent `gcc libc6-dev`, so the compile had no headers.

The parallel `subwave-analyzer-heavy` build passes because it's on `python:3.11-slim`, which bundles the dev headers — that's why only the AIO heavy variant broke.

## Fix

Add `python3-dev` to the temporary build-deps in the demucs `WITH_DEMUCS=1` layer (`gcc libc6-dev python3-dev`), purged in the same layer. The lean `subwave-aio` image is unaffected — it never enters this branch.