### PR TITLE
release: heavy AIO image diffq build fix

### DIFF
--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -148,15 +148,17 @@ RUN python3 -m venv /opt/analyzer/venv && \
     if [ "$WITH_DEMUCS" = "1" ]; then \
       # diffq: decompressor for demucs' quantized checkpoints (mdx_q, …). Tiny,
       # but without it a DEMUCS_MODEL=*_q override makes demucs fatal() at load.
-      # It ships sdist-only (Cython ext), so lend it gcc for the install and
-      # purge in the SAME layer — the lean image never pays for any of this.
-      apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev && \
+      # It ships sdist-only (Cython ext), so lend it gcc + Python headers for the
+      # install and purge in the SAME layer — the lean image never pays for any
+      # of this. Unlike the analyzer image (python:3.11-slim ships headers), this
+      # base's apt python3 has none, so python3-dev is required for Python.h.
+      apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev python3-dev && \
       /opt/analyzer/venv/bin/pip install --no-cache-dir \
         --index-url https://download.pytorch.org/whl/cpu \
         --extra-index-url https://pypi.org/simple \
         torch torchaudio demucs diffq && \
       /opt/analyzer/venv/bin/python -c "import torch, demucs, diffq" && \
-      apt-get purge -y gcc libc6-dev && apt-get autoremove -y && rm -rf /var/lib/apt/lists/* ; \
+      apt-get purge -y gcc libc6-dev python3-dev && apt-get autoremove -y && rm -rf /var/lib/apt/lists/* ; \
     fi && \
     find /opt/analyzer/venv -depth -type d -name __pycache__ -exec rm -rf {} +
 # ANALYZE_PYTHON flips on the controller's local analyze backend; HF_HOME points


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge with "Create a merge commit"** — not "Squash and merge". Squash collapses the individual `fix:` commit into one `release: …` commit, and release-please then sees no conventional-commit signal and skips the version bump.

## Summary

Single-fix infra release. The `subwave-aio-heavy` image build broke on the v0.34.0 publish run — `diffq`'s Cython extension failed to compile with `Python.h: No such file or directory` because the AIO's `savonet/liquidsoap` base gets `python3` from apt (no dev headers), unlike the analyzer image on `python:3.11-slim`. This queues the one-line fix so the next tag republishes a working heavy AIO image. No env-var, migration, or breaking changes; only the heavy AIO variant is affected.

**Bug Fixes**
- `a31b2b7` fix(aio): install python3-dev for the diffq sdist build in heavy AIO image (#744)

## Test plan
- [ ] `subwave-aio-heavy` publish job builds and pushes successfully (diffq wheel compiles)
- [ ] Lean `subwave-aio` image build is unaffected (never enters the `WITH_DEMUCS=1` branch)
- [ ] All other matrix images still publish green