### PR TITLE
docs(unraid): explain switching the one-click AIO install to the heavy image

### DIFF
--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -148,15 +148,17 @@ RUN python3 -m venv /opt/analyzer/venv && \
     if [ "$WITH_DEMUCS" = "1" ]; then \
       # diffq: decompressor for demucs' quantized checkpoints (mdx_q, …). Tiny,
       # but without it a DEMUCS_MODEL=*_q override makes demucs fatal() at load.
-      # It ships sdist-only (Cython ext), so lend it gcc for the install and
-      # purge in the SAME layer — the lean image never pays for any of this.
-      apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev && \
+      # It ships sdist-only (Cython ext), so lend it gcc + Python headers for the
+      # install and purge in the SAME layer — the lean image never pays for any
+      # of this. Unlike the analyzer image (python:3.11-slim ships headers), this
+      # base's apt python3 has none, so python3-dev is required for Python.h.
+      apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev python3-dev && \
       /opt/analyzer/venv/bin/pip install --no-cache-dir \
         --index-url https://download.pytorch.org/whl/cpu \
         --extra-index-url https://pypi.org/simple \
         torch torchaudio demucs diffq && \
       /opt/analyzer/venv/bin/python -c "import torch, demucs, diffq" && \
-      apt-get purge -y gcc libc6-dev && apt-get autoremove -y && rm -rf /var/lib/apt/lists/* ; \
+      apt-get purge -y gcc libc6-dev python3-dev && apt-get autoremove -y && rm -rf /var/lib/apt/lists/* ; \
     fi && \
     find /opt/analyzer/venv -depth -type d -name __pycache__ -exec rm -rf {} +
 # ANALYZE_PYTHON flips on the controller's local analyze backend; HF_HOME points

--- a/docs/unraid.md
+++ b/docs/unraid.md
@@ -167,10 +167,23 @@ that isn't in the lean image (the `-heavy` images are ~1.9 GB):
 - **Split stack (Compose Manager).** Add `ANALYZER_HEAVY=1` to your **.env**,
   **Save**, then **Pull & Up** — the `analyzer` container re-pulls as
   `subwave-analyzer-heavy`.
-- **All-in-one.** Point the container's **Repository** at
-  `ghcr.io/perminder-klair/subwave-aio-heavy` and re-pull.
+- **All-in-one (one-click from Community Applications).** The heavy/lean split
+  is baked into the image, so you switch by pointing the container at the heavy
+  tag — **`ANALYZER_HEAVY` does nothing here** (it's the split-stack toggle):
+  1. **Docker** tab → click the **subwave** container → **Edit** (turn on
+     *Advanced View*, top-right).
+  2. Change the **Repository** field from
+     `ghcr.io/perminder-klair/subwave-aio:latest` to
+     `ghcr.io/perminder-klair/subwave-aio-heavy:latest`.
+  3. **Apply** — Unraid re-pulls and recreates the container.
 
-Both heavy images are **amd64-only**; on an arm64 box you'd also need
+  Your state is untouched (it all lives under the appdata volume, including the
+  `hf-cache` where the CLAP/Demucs weights land), so config, personas, and
+  library tags survive the swap. First boot on heavy downloads the model weights
+  into that cache, so give it a few minutes. To go back, edit the Repository
+  field back to `subwave-aio` and **Apply**.
+
+Both heavy images are **amd64-only** (~1.9 GB); on an arm64 box you'd also need
 `DOCKER_DEFAULT_PLATFORM=linux/amd64` (emulated).
 
 > Verify with `docker ps --filter name=sub-wave-analyzer`. Full details, the

--- a/web/components/setup/Unraid.tsx
+++ b/web/components/setup/Unraid.tsx
@@ -274,6 +274,74 @@ export default function Unraid() {
         </div>
       </section>
 
+      <section className="bs-section" id="acoustic-analysis">
+        <p className="bs-eyebrow">ACOUSTIC ANALYSIS — LEAN VS HEAVY</p>
+        <h2>&ldquo;Sounds-like&rdquo; and the heavy image.</h2>
+        <p>
+          Applies to both options. Tempo, key, intro detection, and loudness run
+          out of the box, the default image analyses them in the background, so
+          just run <strong>admin &rarr; Library &rarr; Rescan</strong> (tick{' '}
+          <em>re-analyse</em>) and let it churn. The two <strong>heavy</strong>{' '}
+          dimensions, <strong>&ldquo;sounds-like&rdquo; audio embeddings</strong>{' '}
+          (CLAP) and <strong>vocal ranges</strong> (Demucs), need a CPU-torch
+          stack that isn&apos;t in the lean image, so they&apos;re a separate{' '}
+          <code className="bs-code-inline">-heavy</code> build (~1.9 GB,{' '}
+          <strong>amd64-only</strong>). Only switch if you specifically want
+          them.
+        </p>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">ONE-CLICK: POINT AT THE HEAVY TAG</div>
+          <p>
+            The heavy/lean split is baked into the all-in-one image, so you
+            switch by editing the container&apos;s image, not a setting.{' '}
+            <code className="bs-code-inline">ANALYZER_HEAVY</code> does{' '}
+            <em>nothing</em> here; it&apos;s the split-stack toggle.
+          </p>
+          <ul className="bs-list">
+            <li>
+              <strong>Docker</strong> tab &rarr; click the{' '}
+              <strong>subwave</strong> container &rarr; <strong>Edit</strong>{' '}
+              (turn on <em>Advanced View</em>, top-right).
+            </li>
+            <li>
+              Change the <strong>Repository</strong> field from{' '}
+              <code className="bs-code-inline">ghcr.io/perminder-klair/subwave-aio:latest</code>{' '}
+              to{' '}
+              <code className="bs-code-inline">ghcr.io/perminder-klair/subwave-aio-heavy:latest</code>
+              .
+            </li>
+            <li>
+              <strong>Apply</strong> &rarr; Unraid re-pulls and recreates the
+              container.
+            </li>
+          </ul>
+          <p>
+            Your state is untouched, config, personas, library tags, and the
+            cached model weights all live under the appdata volume, so the swap
+            is safe and reversible (edit the field back to{' '}
+            <code className="bs-code-inline">subwave-aio</code> to return). First
+            boot on heavy downloads the CLAP/Demucs weights, so give it a few
+            minutes.
+          </p>
+        </div>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">FULL COMPOSE STACK: ANALYZER_HEAVY=1</div>
+          <p>
+            On Option 2 the <code className="bs-code-inline">analyzer</code> is
+            its own container, so flip it from the <strong>.env</strong>:
+          </p>
+          <CodeBlock lang="env">{`ANALYZER_HEAVY=1`}</CodeBlock>
+          <p>
+            <strong>Save</strong>, then <strong>Pull &amp; Up</strong>, and the{' '}
+            <code className="bs-code-inline">analyzer</code> container re-pulls as{' '}
+            <code className="bs-code-inline">subwave-analyzer-heavy</code>. On an
+            arm64 box you&apos;d also need{' '}
+            <code className="bs-code-inline">DOCKER_DEFAULT_PLATFORM=linux/amd64</code>{' '}
+            (emulated).
+          </p>
+        </div>
+      </section>
+
       <section className="bs-section" id="reverse-proxy">
         <p className="bs-eyebrow">BEHIND YOUR OWN PROXY</p>
         <h2>Putting it behind your reverse proxy.</h2>


### PR DESCRIPTION
## What

Adds explicit guidance for using the **heavy** acoustic-analysis image on Unraid, in both docs surfaces:

- **`docs/unraid.md`** — expands the terse "All-in-one" bullet into step-by-step instructions: Docker tab → Edit container → change **Repository** to `subwave-aio-heavy:latest` → Apply. Notes state survives the swap (appdata volume + hf-cache), it's reversible, and clarifies **`ANALYZER_HEAVY` does nothing for AIO** (it's the split-stack toggle).
- **`web/components/setup/Unraid.tsx`** — the `/setup/unraid` page had **no** heavy-image guidance. Adds an "Acoustic analysis — lean vs heavy" section covering the one-click Repository swap and the Option-2 `ANALYZER_HEAVY=1` path, with the amd64-only / ~1.9 GB caveats.

## Why

A user on the one-click install asked how to get the heavy "sounds-like" (CLAP) + vocal-range (Demucs) dimensions. The correct move — repoint the container's image tag — wasn't spelled out anywhere user-facing, and it's easy to assume `ANALYZER_HEAVY=1` works on AIO when it doesn't.

## Verification

- `web`: `npm run lint` (eslint + `tsc --noEmit`) passes clean.
- Docs-only change otherwise.