### PR TITLE
feat(tagger): embedding quality — weighted KNN voting, task prefixes, audio fusion, self-check

### DIFF
--- a/controller/package.json
+++ b/controller/package.json
@@ -11,7 +11,7 @@
     "lastfm-session": "tsx scripts/lastfm-session.ts",
     "test:embed": "tsx scripts/embedding-preflight-test.ts",
     "test:llm": "tsx scripts/llm-pure.test.ts",
-    "test": "tsx scripts/llm-pure.test.ts && tsx scripts/picker-recency-regression.ts && tsx scripts/recent-plays.test.ts && tsx scripts/listeners-status.test.ts && tsx scripts/lastfm-enrich.test.ts && tsx scripts/web-search-searxng.test.ts && tsx scripts/request-dedup.test.ts && tsx scripts/stale-link.test.ts && tsx scripts/embedding-heavy.test.ts && tsx scripts/tagger-perf.test.ts && tsx scripts/rescan-scope.test.ts && tsx scripts/show-playlist.test.ts && tsx scripts/embedding-dim-migrate.test.ts && tsx scripts/coverage-status.test.ts",
+    "test": "tsx scripts/llm-pure.test.ts && tsx scripts/picker-recency-regression.ts && tsx scripts/recent-plays.test.ts && tsx scripts/listeners-status.test.ts && tsx scripts/lastfm-enrich.test.ts && tsx scripts/web-search-searxng.test.ts && tsx scripts/request-dedup.test.ts && tsx scripts/stale-link.test.ts && tsx scripts/embedding-heavy.test.ts && tsx scripts/tagger-perf.test.ts && tsx scripts/rescan-scope.test.ts && tsx scripts/show-playlist.test.ts && tsx scripts/embedding-dim-migrate.test.ts && tsx scripts/coverage-status.test.ts && tsx scripts/tag-propagator.test.ts && tsx scripts/embedding-prefix.test.ts",
     "lint": "eslint . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit"

--- a/controller/package.json
+++ b/controller/package.json
@@ -11,7 +11,7 @@
     "lastfm-session": "tsx scripts/lastfm-session.ts",
     "test:embed": "tsx scripts/embedding-preflight-test.ts",
     "test:llm": "tsx scripts/llm-pure.test.ts",
-    "test": "tsx scripts/llm-pure.test.ts && tsx scripts/picker-recency-regression.ts && tsx scripts/recent-plays.test.ts && tsx scripts/listeners-status.test.ts && tsx scripts/lastfm-enrich.test.ts && tsx scripts/web-search-searxng.test.ts && tsx scripts/request-dedup.test.ts && tsx scripts/stale-link.test.ts && tsx scripts/embedding-heavy.test.ts && tsx scripts/tagger-perf.test.ts && tsx scripts/rescan-scope.test.ts && tsx scripts/show-playlist.test.ts && tsx scripts/embedding-dim-migrate.test.ts && tsx scripts/coverage-status.test.ts && tsx scripts/tag-propagator.test.ts && tsx scripts/embedding-prefix.test.ts",
+    "test": "tsx scripts/llm-pure.test.ts && tsx scripts/picker-recency-regression.ts && tsx scripts/recent-plays.test.ts && tsx scripts/listeners-status.test.ts && tsx scripts/lastfm-enrich.test.ts && tsx scripts/web-search-searxng.test.ts && tsx scripts/request-dedup.test.ts && tsx scripts/stale-link.test.ts && tsx scripts/embedding-heavy.test.ts && tsx scripts/tagger-perf.test.ts && tsx scripts/rescan-scope.test.ts && tsx scripts/show-playlist.test.ts && tsx scripts/embedding-dim-migrate.test.ts && tsx scripts/coverage-status.test.ts && tsx scripts/tag-propagator.test.ts && tsx scripts/embedding-prefix.test.ts && tsx scripts/propagation-eval.test.ts",
     "lint": "eslint . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit"

--- a/controller/scripts/embedding-dim-migrate.test.ts
+++ b/controller/scripts/embedding-dim-migrate.test.ts
@@ -103,6 +103,17 @@ async function main() {
     db.close();
   });
 
+  await test('embedding_meta round-trips text_mode; legacy rows read as null', async () => {
+    await db.open({ embeddingDim: 1024, adoptStoredDim: true });
+    // Legacy write (no mode) — reads back null, which resolveIndexTextMode
+    // treats as 'plain' on a populated index.
+    db.setEmbeddingMeta('ollama:nomic-embed-text', 1024);
+    assert.equal(db.getEmbeddingMeta()?.textMode, null);
+    db.setEmbeddingMeta('ollama:nomic-embed-text', 1024, 'prefixed');
+    assert.equal(db.getEmbeddingMeta()?.textMode, 'prefixed');
+    db.close();
+  });
+
   rmSync(stateDir, { recursive: true, force: true });
 
   if (failures) {

--- a/controller/scripts/embedding-prefix.test.ts
+++ b/controller/scripts/embedding-prefix.test.ts
@@ -1,0 +1,105 @@
+// Unit tests for embedding task-prefix handling — the per-model prefix table
+// (llm/internal/provider/embedding.ts) and the index-mode resolution + pure
+// prefix application in music/embeddings.ts.
+//
+// nomic-embed-text (the shipped default) is trained with mandatory
+// `search_document:` / `search_query:` prefixes; embedding bare degrades
+// retrieval. Documents and queries must agree, so the index records its mode
+// (embedding_meta.text_mode) and these tests pin the consistency rules:
+// stored mode always wins, a populated legacy index stays plain, a fresh
+// index adopts the model's preference.
+// Run: `tsx scripts/embedding-prefix.test.ts` (folded into `npm run test`).
+
+import assert from 'node:assert/strict';
+import { embeddingTextPrefixes } from '../src/llm/provider.js';
+import {
+  preferredTextMode,
+  resolveIndexTextMode,
+  applyDocPrefix,
+  applyQueryPrefix,
+} from '../src/music/embeddings.js';
+
+let failures = 0;
+function test(name: string, fn: () => void | Promise<void>) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => console.log(`  ✓ ${name}`))
+    .catch((err) => { failures++; console.error(`  ✗ ${name}\n      ${err?.message || err}`); });
+}
+
+const NOMIC = embeddingTextPrefixes('nomic-embed-text');
+const MXBAI = embeddingTextPrefixes('mxbai-embed-large');
+const NONE = embeddingTextPrefixes('text-embedding-3-small');
+
+async function main() {
+  console.log('embeddingTextPrefixes (per-model table):');
+
+  await test('nomic family prefixes both sides, tag-suffix tolerant', () => {
+    assert.equal(NOMIC.document, 'search_document: ');
+    assert.equal(NOMIC.query, 'search_query: ');
+    assert.deepEqual(embeddingTextPrefixes('nomic-embed-text:latest'), NOMIC);
+    assert.deepEqual(embeddingTextPrefixes('nomic-embed-text-v1.5'), NOMIC);
+  });
+
+  await test('mxbai-embed-large prefixes queries only', () => {
+    assert.equal(MXBAI.document, '');
+    assert.ok(MXBAI.query.length > 0);
+  });
+
+  await test('unknown models get no prefixes', () => {
+    assert.deepEqual(NONE, { document: '', query: '' });
+    assert.deepEqual(embeddingTextPrefixes(''), { document: '', query: '' });
+  });
+
+  console.log('resolveIndexTextMode (index-mode resolution):');
+
+  await test('stored mode always wins — consistency beats preference', () => {
+    assert.equal(resolveIndexTextMode('plain', 5000), 'plain');
+    assert.equal(resolveIndexTextMode('prefixed', 5000), 'prefixed');
+    assert.equal(resolveIndexTextMode('plain', 0), 'plain');
+  });
+
+  await test('populated index with no recorded mode = legacy = plain', () => {
+    assert.equal(resolveIndexTextMode(null, 5000), 'plain');
+    assert.equal(resolveIndexTextMode(undefined, 1), 'plain');
+  });
+
+  await test('empty index adopts the active model\'s preference (default = nomic = prefixed)', () => {
+    // DEFAULTS: provider ollama, model '' → nomic-embed-text → prefixed. If the
+    // shipped default embedding model ever changes, revisit this pin.
+    assert.equal(preferredTextMode(), 'prefixed');
+    assert.equal(resolveIndexTextMode(null, 0), 'prefixed');
+  });
+
+  console.log('applyDocPrefix / applyQueryPrefix (pure application):');
+
+  await test('doc prefix only applies in prefixed mode', () => {
+    assert.equal(applyDocPrefix('Artist — Title', 'prefixed', NOMIC), 'search_document: Artist — Title');
+    assert.equal(applyDocPrefix('Artist — Title', 'plain', NOMIC), 'Artist — Title');
+    assert.equal(applyDocPrefix('Artist — Title', 'prefixed', NONE), 'Artist — Title');
+  });
+
+  await test('query prefix follows the index mode for doc-prefixing models', () => {
+    assert.equal(applyQueryPrefix('hopeful lyrics', 'prefixed', NOMIC), 'search_query: hopeful lyrics');
+    // A prefixed query against bare documents is worse than bare-vs-bare.
+    assert.equal(applyQueryPrefix('hopeful lyrics', 'plain', NOMIC), 'hopeful lyrics');
+  });
+
+  await test('query-only models prefix regardless of index mode', () => {
+    assert.equal(applyQueryPrefix('hopeful lyrics', 'plain', MXBAI), MXBAI.query + 'hopeful lyrics');
+    assert.equal(applyQueryPrefix('hopeful lyrics', 'prefixed', MXBAI), MXBAI.query + 'hopeful lyrics');
+  });
+
+  await test('no-prefix models pass text through untouched', () => {
+    assert.equal(applyQueryPrefix('hopeful lyrics', 'prefixed', NONE), 'hopeful lyrics');
+    assert.equal(applyDocPrefix('x', 'prefixed', NONE), 'x');
+  });
+
+  if (failures > 0) {
+    console.error(`\n${failures} test(s) failed`);
+    process.exit(1);
+  }
+  console.log('\nall embedding-prefix tests passed');
+}
+
+main();

--- a/controller/scripts/propagation-eval.test.ts
+++ b/controller/scripts/propagation-eval.test.ts
@@ -1,0 +1,111 @@
+// Unit tests for the propagation self-check scoring (music/propagation-eval.ts)
+// — the pure math behind the tagger's held-out agreement line. Pinned so the
+// gate mirror (votingNeighbours ≥ 1 && confidence ≥ threshold && moods > 0)
+// never drifts from tag-library's real propagation gate, and the metrics stay
+// honest (agreement scored over gate-passed cases only).
+// Run: `tsx scripts/propagation-eval.test.ts` (folded into `npm run test`).
+
+import assert from 'node:assert/strict';
+import { moodJaccard, summariseEval, formatEvalSummary } from '../src/music/propagation-eval.js';
+import type { VoteResult } from '../src/music/tag-propagator.js';
+
+let failures = 0;
+function test(name: string, fn: () => void | Promise<void>) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => console.log(`  ✓ ${name}`))
+    .catch((err) => { failures++; console.error(`  ✗ ${name}\n      ${err?.message || err}`); });
+}
+
+const result = (over: Partial<VoteResult>): VoteResult => ({
+  moods: ['warm'],
+  energy: null,
+  confidence: 0.5,
+  votingNeighbours: 3,
+  ...over,
+});
+
+async function main() {
+  console.log('moodJaccard:');
+
+  await test('identical, disjoint, and partial sets', () => {
+    assert.equal(moodJaccard(['a', 'b'], ['a', 'b']), 1);
+    assert.equal(moodJaccard(['a'], ['b']), 0);
+    assert.equal(moodJaccard(['a', 'b'], ['b', 'c']), 1 / 3);
+    assert.equal(moodJaccard([], []), 1); // correctly predicted nothing
+  });
+
+  console.log('summariseEval (gate mirror + metrics):');
+
+  await test('mirrors the propagation gate exactly', () => {
+    const s = summariseEval(
+      [
+        { actual: { moods: ['warm'], energy: null }, result: result({}) },                    // passes
+        { actual: { moods: ['warm'], energy: null }, result: result({ confidence: 0.3 }) },   // below threshold
+        { actual: { moods: ['warm'], energy: null }, result: result({ moods: [] }) },         // no moods
+        { actual: { moods: ['warm'], energy: null }, result: result({ votingNeighbours: 0 }) },
+      ],
+      0.35,
+    );
+    assert.equal(s.sampled, 4);
+    assert.equal(s.gatePassed, 1);
+  });
+
+  await test('mood agreement averages over gate-passed cases only', () => {
+    const s = summariseEval(
+      [
+        { actual: { moods: ['warm'], energy: null }, result: result({ moods: ['warm'] }) },          // 1.0
+        { actual: { moods: ['warm', 'chill'], energy: null }, result: result({ moods: ['warm'] }) }, // 0.5
+        { actual: { moods: ['gloomy'], energy: null }, result: result({ confidence: 0 }) },          // gated out
+      ],
+      0.35,
+    );
+    assert.equal(s.gatePassed, 2);
+    assert.ok(Math.abs((s.moodJaccard ?? 0) - 0.75) < 1e-9);
+  });
+
+  await test('energy compared only when both sides have one', () => {
+    const s = summariseEval(
+      [
+        { actual: { moods: ['warm'], energy: 'high' }, result: result({ energy: 'high' }) },
+        { actual: { moods: ['warm'], energy: 'low' }, result: result({ energy: 'high' }) },
+        { actual: { moods: ['warm'], energy: null }, result: result({ energy: 'high' }) },
+        { actual: { moods: ['warm'], energy: 'low' }, result: result({ energy: null }) },
+      ],
+      0.35,
+    );
+    assert.equal(s.energyComparable, 2);
+    assert.equal(s.energyMatched, 1);
+  });
+
+  await test('nothing gate-passed → null agreement, no NaN', () => {
+    const s = summariseEval(
+      [{ actual: { moods: ['warm'], energy: null }, result: result({ confidence: 0 }) }],
+      0.35,
+    );
+    assert.equal(s.moodJaccard, null);
+    assert.ok(formatEvalSummary(s).includes('0%'));
+  });
+
+  await test('formatEvalSummary reads sanely', () => {
+    const s = summariseEval(
+      [
+        { actual: { moods: ['warm'], energy: 'high' }, result: result({ energy: 'high' }) },
+        { actual: { moods: ['warm'], energy: null }, result: result({}) },
+      ],
+      0.35,
+    );
+    const line = formatEvalSummary(s);
+    assert.ok(line.includes('2 held-out tracks'));
+    assert.ok(line.includes('mood agreement 100%'));
+    assert.ok(line.includes('energy match 100%'));
+  });
+
+  if (failures > 0) {
+    console.error(`\n${failures} test(s) failed`);
+    process.exit(1);
+  }
+  console.log('\nall propagation-eval tests passed');
+}
+
+main();

--- a/controller/scripts/tag-propagator.test.ts
+++ b/controller/scripts/tag-propagator.test.ts
@@ -120,6 +120,54 @@ async function main() {
     assert.ok(Math.abs(result.confidence - 0.4) < 1e-9);
   });
 
+  await test('weightOf down-weights votes (the same-album echo chamber)', () => {
+    // Two album-mates at 0.8 carry 'gloomy'; one outside track at 0.5 carries
+    // 'warm'. At full weight the album sweeps (1.6 vs 0.5). Halved to 0.4 each,
+    // gloomy carries 0.8 of a 1.3 total (≈62%) and warm 0.5 (≈38%) — with a 0.6
+    // threshold only gloomy survives, but the halving is what lets outside
+    // corroboration matter at all at lower thresholds.
+    const albumIds = new Set(['a1', 'a2']);
+    const opts = {
+      moodVoteThreshold: 0.35,
+      k: 3,
+      weightOf: (id: string) => (albumIds.has(id) ? 0.5 : 1),
+    };
+    const result = vote(
+      [hit('a1', 0.8), hit('a2', 0.8), hit('x', 0.5)],
+      tagsOf({
+        a1: { moods: ['gloomy'], energy: null },
+        a2: { moods: ['gloomy'], energy: null },
+        x: { moods: ['warm'], energy: null },
+      }),
+      opts,
+    );
+    // gloomy 0.8, warm 0.5, total 1.3, threshold 0.455 — both pass, gloomy first.
+    assert.deepEqual(result.moods, ['gloomy', 'warm']);
+    // Without weightOf the outside voice is drowned: warm 0.5 < 0.735.
+    const flat = vote(
+      [hit('a1', 0.8), hit('a2', 0.8), hit('x', 0.5)],
+      tagsOf({
+        a1: { moods: ['gloomy'], energy: null },
+        a2: { moods: ['gloomy'], energy: null },
+        x: { moods: ['warm'], energy: null },
+      }),
+      { moodVoteThreshold: 0.35, k: 3 },
+    );
+    assert.deepEqual(flat.moods, ['gloomy']);
+  });
+
+  await test('weightOf never touches the confidence formula', () => {
+    const result = vote(
+      [hit('a', 0.8), hit('b', 0.6)],
+      tagsOf({
+        a: { moods: ['warm'], energy: null },
+        b: { moods: ['warm'], energy: null },
+      }),
+      { moodVoteThreshold: 0.5, k: 4, weightOf: () => 0.1 },
+    );
+    assert.ok(Math.abs(result.confidence - 0.8 * (2 / 4)) < 1e-9);
+  });
+
   await test('no tagged neighbours → zero result', () => {
     const result = vote([hit('a', 0.9)], () => null, { moodVoteThreshold: 0.5, k: 5 });
     assert.deepEqual(result, { moods: [], energy: null, confidence: 0, votingNeighbours: 0 });

--- a/controller/scripts/tag-propagator.test.ts
+++ b/controller/scripts/tag-propagator.test.ts
@@ -11,7 +11,7 @@
 // Run: `tsx scripts/tag-propagator.test.ts` (folded into `npm run test`).
 
 import assert from 'node:assert/strict';
-import { vote, type NeighbourTags } from '../src/music/tag-propagator.js';
+import { vote, fuseNeighbours, type NeighbourTags } from '../src/music/tag-propagator.js';
 
 let failures = 0;
 function test(name: string, fn: () => void | Promise<void>) {
@@ -183,6 +183,38 @@ async function main() {
       { moodVoteThreshold: 0.5, k: 2 },
     );
     assert.deepEqual(result, { moods: [], energy: null, confidence: 0, votingNeighbours: 0 });
+  });
+
+  console.log('fuseNeighbours (CLAP audio fusion):');
+
+  await test('blend 0 or no audio hits → text list unchanged (today\'s behaviour)', () => {
+    const text = [hit('a', 0.7), hit('b', 0.5)];
+    assert.deepEqual(fuseNeighbours(text, [hit('c', 0.9)], 0, 2), text);
+    assert.deepEqual(fuseNeighbours(text, [], 0.5, 2), text);
+  });
+
+  await test('audio neighbours displace the weak text tail, list stays capped at k', () => {
+    const fused = fuseNeighbours(
+      [hit('a', 0.7), hit('b', 0.3)],
+      [hit('c', 0.9)],
+      0.5,
+      2,
+    );
+    // c enters at 0.9 × 0.5 = 0.45, pushing b (0.3) out; a stays on top.
+    assert.deepEqual(fused, [hit('a', 0.7), hit('c', 0.45)]);
+  });
+
+  await test('a track surfaced by both spaces appears once, at its higher score', () => {
+    const fused = fuseNeighbours([hit('a', 0.5)], [hit('a', 0.9)], 0.5, 4);
+    assert.deepEqual(fused, [hit('a', 0.5)]); // max(0.5, 0.45), no duplicate
+    const audioWins = fuseNeighbours([hit('a', 0.3)], [hit('a', 0.9)], 0.5, 4);
+    assert.deepEqual(audioWins, [hit('a', 0.45)]);
+  });
+
+  await test('scores stay cosine-shaped: negatives clamp, blend clamps to 0..1', () => {
+    const fused = fuseNeighbours([hit('a', -0.2)], [hit('b', 0.8)], 5, 4);
+    // blend clamped to 1 (not 5); negative text sim clamps to 0.
+    assert.deepEqual(fused, [hit('b', 0.8), hit('a', 0)]);
   });
 
   if (failures > 0) {

--- a/controller/scripts/tag-propagator.test.ts
+++ b/controller/scripts/tag-propagator.test.ts
@@ -1,0 +1,147 @@
+// Unit tests for the KNN vote logic (music/tag-propagator.ts) — the pure math
+// that propagates moods/energy from LLM-tagged seeds to their neighbours.
+//
+// Pins the similarity-WEIGHTED voting: each neighbour votes with
+// max(0, similarity) rather than a flat 1, so a 0.9-similar neighbour outvotes
+// two 0.3-similar ones (under flat counting it was the other way round — the
+// far tail of the K list drowned out the one genuinely-similar match). The
+// confidence formula (topSim * coverage) is deliberately unchanged; pinned
+// here so the weighting never silently re-tunes the operator's
+// confidenceThreshold semantics.
+// Run: `tsx scripts/tag-propagator.test.ts` (folded into `npm run test`).
+
+import assert from 'node:assert/strict';
+import { vote, type NeighbourTags } from '../src/music/tag-propagator.js';
+
+let failures = 0;
+function test(name: string, fn: () => void | Promise<void>) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => console.log(`  ✓ ${name}`))
+    .catch((err) => { failures++; console.error(`  ✗ ${name}\n      ${err?.message || err}`); });
+}
+
+// KNN results arrive closest-first; keep fixtures in that order.
+const hit = (id: string, similarity: number) => ({ id, similarity });
+const tagsOf = (map: Record<string, NeighbourTags>) => (id: string) => map[id] ?? null;
+
+async function main() {
+  console.log('vote (similarity-weighted KNN propagation):');
+
+  await test('a close neighbour outvotes two far ones (the flat-count regression)', () => {
+    // Flat counting: chill has 2 of 3 votes and wins, warm (1 of 3) loses —
+    // exactly backwards given the similarities.
+    const result = vote(
+      [hit('a', 0.9), hit('b', 0.3), hit('c', 0.3)],
+      tagsOf({
+        a: { moods: ['warm'], energy: null },
+        b: { moods: ['chill'], energy: null },
+        c: { moods: ['chill'], energy: null },
+      }),
+      { moodVoteThreshold: 0.5, k: 3 },
+    );
+    // totalWeight 1.5 → threshold 0.75. warm carries 0.9, chill only 0.6.
+    assert.deepEqual(result.moods, ['warm']);
+  });
+
+  await test('unanimous moods pass and sort by carried weight, capped at 3', () => {
+    const result = vote(
+      [hit('a', 0.8), hit('b', 0.7), hit('c', 0.6)],
+      tagsOf({
+        a: { moods: ['chill', 'warm', 'dreamy', 'mellow'], energy: null },
+        b: { moods: ['chill', 'warm', 'dreamy', 'mellow'], energy: null },
+        c: { moods: ['chill', 'warm', 'dreamy', 'mellow'], energy: null },
+      }),
+      { moodVoteThreshold: 0.5, k: 3 },
+    );
+    assert.equal(result.moods.length, 3); // vocab arrays cap at 3
+  });
+
+  await test('a mood carried only by weight-0 neighbours never passes', () => {
+    const result = vote(
+      [hit('a', 0.9), hit('b', -0.2)],
+      tagsOf({
+        a: { moods: ['warm'], energy: null },
+        b: { moods: ['gloomy'], energy: null },
+      }),
+      { moodVoteThreshold: 0, k: 2 }, // even a zero threshold
+    );
+    assert.deepEqual(result.moods, ['warm']);
+  });
+
+  await test('energy is a weighted plurality, not a head-count', () => {
+    const result = vote(
+      [hit('a', 0.9), hit('b', 0.4), hit('c', 0.4)],
+      tagsOf({
+        a: { moods: ['warm'], energy: 'high' },
+        b: { moods: ['warm'], energy: 'low' },
+        c: { moods: ['warm'], energy: 'low' },
+      }),
+      { moodVoteThreshold: 0.5, k: 3 },
+    );
+    assert.equal(result.energy, 'high'); // 0.9 vs 0.8
+  });
+
+  await test('energy ties break toward the closest neighbour', () => {
+    const result = vote(
+      [hit('a', 0.5), hit('b', 0.5)],
+      tagsOf({
+        a: { moods: ['warm'], energy: 'medium' },
+        b: { moods: ['warm'], energy: 'low' },
+      }),
+      { moodVoteThreshold: 0.5, k: 2 },
+    );
+    assert.equal(result.energy, 'medium');
+  });
+
+  await test('confidence stays topSim * coverage (operator threshold semantics)', () => {
+    const result = vote(
+      [hit('a', 0.75), hit('b', 0.6), hit('c', 0.5)],
+      tagsOf({
+        a: { moods: ['warm'], energy: null },
+        b: { moods: ['warm'], energy: null },
+        c: { moods: ['warm'], energy: null },
+      }),
+      { moodVoteThreshold: 0.5, k: 5 },
+    );
+    assert.ok(Math.abs(result.confidence - 0.75 * (3 / 5)) < 1e-9);
+    assert.equal(result.votingNeighbours, 3);
+  });
+
+  await test('untagged neighbours are skipped entirely', () => {
+    const result = vote(
+      [hit('a', 0.9), hit('b', 0.8)],
+      tagsOf({ b: { moods: ['chill'], energy: 'low' } }),
+      { moodVoteThreshold: 0.5, k: 2 },
+    );
+    assert.deepEqual(result.moods, ['chill']);
+    assert.equal(result.votingNeighbours, 1);
+    // Coverage discounts the missing neighbour: 0.8 * (1/2).
+    assert.ok(Math.abs(result.confidence - 0.4) < 1e-9);
+  });
+
+  await test('no tagged neighbours → zero result', () => {
+    const result = vote([hit('a', 0.9)], () => null, { moodVoteThreshold: 0.5, k: 5 });
+    assert.deepEqual(result, { moods: [], energy: null, confidence: 0, votingNeighbours: 0 });
+  });
+
+  await test('all-orthogonal (weight 0) neighbours → zero result, no NaN', () => {
+    const result = vote(
+      [hit('a', 0), hit('b', -0.4)],
+      tagsOf({
+        a: { moods: ['warm'], energy: 'high' },
+        b: { moods: ['warm'], energy: 'high' },
+      }),
+      { moodVoteThreshold: 0.5, k: 2 },
+    );
+    assert.deepEqual(result, { moods: [], energy: null, confidence: 0, votingNeighbours: 0 });
+  });
+
+  if (failures > 0) {
+    console.error(`\n${failures} test(s) failed`);
+    process.exit(1);
+  }
+  console.log('\nall tag-propagator tests passed');
+}
+
+main();

--- a/controller/src/llm/internal/provider/embedding.ts
+++ b/controller/src/llm/internal/provider/embedding.ts
@@ -105,6 +105,33 @@ export function isHeavyEmbeddingModel(model: string): boolean {
   return false;
 }
 
+// Task prefixes some embedding models are trained with. Name-based like
+// isHeavyEmbeddingModel — unknown models get no prefixes.
+//
+// nomic-embed-text (the shipped Ollama default) REQUIRES them: the model card
+// marks `search_document:` / `search_query:` as mandatory for retrieval, and
+// embedding bare measurably degrades neighbour quality. Its document prefix
+// changes the stored vectors, so the index records which mode it was built in
+// (embedding_meta.text_mode) and queries follow suit.
+//
+// mxbai-embed-large wants a query-side instruction only — documents embed
+// bare, so its query prefix is always safe to apply regardless of index mode.
+export interface EmbeddingTextPrefixes {
+  document: string; // prepended to indexed track texts; '' = embed bare
+  query: string;    // prepended to search queries; '' = embed bare
+}
+
+export function embeddingTextPrefixes(model: string): EmbeddingTextPrefixes {
+  const bare = (model || '').toLowerCase();
+  if (bare.includes('nomic-embed')) {
+    return { document: 'search_document: ', query: 'search_query: ' };
+  }
+  if (bare.includes('mxbai-embed-large')) {
+    return { document: '', query: 'Represent this sentence for searching relevant passages: ' };
+  }
+  return { document: '', query: '' };
+}
+
 // Does this embedding provider run on the operator's own hardware (so model
 // weight is a CPU/RAM concern they pay for), vs a cloud API that does the work
 // off-box? Gates the heavy-model perf advisory — a big model on OpenAI/Google is

--- a/controller/src/llm/internal/tools/picker-tools.ts
+++ b/controller/src/llm/internal/tools/picker-tools.ts
@@ -207,7 +207,7 @@ export function buildPickerTools({
           // queries still return tracks. No-op when embeddings aren't set up.
           if (!embeddings.isAvailable()) return out;
           await library.load();
-          const [vec] = await embeddings.embedTexts([query.trim()]);
+          const vec = await embeddings.embedQueryText(query.trim(), library.embeddingIndexTextMode());
           if (!vec) return out;
           return collect(library.tracksByVector(vec, 20));
         }
@@ -355,7 +355,7 @@ export function buildPickerTools({
           try {
             if (!embeddings.isAvailable()) return { error: 'embeddings not configured — set settings.embedding.enabled / provider' };
             await library.load();
-            const [vec] = await embeddings.embedTexts([query.trim()]);
+            const vec = await embeddings.embedQueryText(query.trim(), library.embeddingIndexTextMode());
             if (!vec) return { error: 'embedding query failed' };
             return collect(library.tracksByVector(vec, 60));
           }

--- a/controller/src/llm/provider.ts
+++ b/controller/src/llm/provider.ts
@@ -28,5 +28,6 @@ export {
   buildEmbeddingModel,
   isHeavyEmbeddingModel,
   isLocalEmbeddingProvider,
+  embeddingTextPrefixes,
 } from './internal/provider/embedding.js';
-export type { EmbeddingCfg } from './internal/provider/embedding.js';
+export type { EmbeddingCfg, EmbeddingTextPrefixes } from './internal/provider/embedding.js';

--- a/controller/src/music/embeddings.ts
+++ b/controller/src/music/embeddings.ts
@@ -22,8 +22,9 @@ import {
   buildEmbeddingModel,
   isHeavyEmbeddingModel,
   isLocalEmbeddingProvider,
+  embeddingTextPrefixes,
 } from '../llm/provider.js';
-import type { EmbeddingCfg } from '../llm/provider.js';
+import type { EmbeddingCfg, EmbeddingTextPrefixes } from '../llm/provider.js';
 import { SHOW_MOODS as MOOD_VOCAB } from '../settings.js';
 import crypto from 'node:crypto';
 
@@ -122,6 +123,81 @@ export async function embedTexts(texts: string[]): Promise<number[][]> {
     );
   }
   return embeddings as number[][];
+}
+
+// ---------------------------------------------------------------------------
+// Task-prefix handling — some embedding models (nomic-embed-text, the shipped
+// default) are trained with mandatory task prefixes: `search_document:` on
+// indexed texts and `search_query:` on queries. Document prefixes change the
+// stored vectors, so the index records its mode in embedding_meta.text_mode
+// ('plain' = embedded bare, 'prefixed' = embedded with the document prefix)
+// and every query embed must match it. See embeddingTextPrefixes in
+// llm/internal/provider/embedding.ts for the per-model table.
+// ---------------------------------------------------------------------------
+
+export type IndexTextMode = 'plain' | 'prefixed';
+
+function activePrefixes(): EmbeddingTextPrefixes {
+  return embeddingTextPrefixes(embeddingProviderInfo().model);
+}
+
+// The mode a FRESH index should be built in for the active model: 'prefixed'
+// when the model has a document prefix, else 'plain'.
+export function preferredTextMode(): IndexTextMode {
+  return activePrefixes().document ? 'prefixed' : 'plain';
+}
+
+// Resolve the mode of an EXISTING index. Stored mode always wins (consistency
+// beats preference — a prefixed query against bare documents is worse than
+// bare-vs-bare). A populated index with no recorded mode predates mode
+// tracking and was embedded bare; an empty one is free to adopt the model's
+// preferred mode.
+export function resolveIndexTextMode(
+  stored: IndexTextMode | null | undefined,
+  vectorCount: number,
+): IndexTextMode {
+  if (stored) return stored;
+  if (vectorCount > 0) return 'plain';
+  return preferredTextMode();
+}
+
+// Pure prefix application, exported for tests. `prefixes` defaults to the
+// active model's table entry.
+export function applyDocPrefix(
+  text: string,
+  mode: IndexTextMode,
+  prefixes: EmbeddingTextPrefixes = activePrefixes(),
+): string {
+  return mode === 'prefixed' && prefixes.document ? prefixes.document + text : text;
+}
+
+// A query prefix applies when the index carries document prefixes too
+// ('prefixed'), OR when the model prefixes queries only (mxbai-style — the
+// documents embed bare by design, so the index mode doesn't gate it).
+export function applyQueryPrefix(
+  text: string,
+  indexMode: IndexTextMode,
+  prefixes: EmbeddingTextPrefixes = activePrefixes(),
+): string {
+  if (!prefixes.query) return text;
+  if (!prefixes.document || indexMode === 'prefixed') return prefixes.query + text;
+  return text;
+}
+
+// Embed texts destined for the index (tracks). `mode` is the index's mode —
+// callers get it from embedding_meta via resolveIndexTextMode.
+export function embedDocTexts(texts: string[], mode: IndexTextMode): Promise<number[][]> {
+  return embedTexts(texts.map(t => applyDocPrefix(t, mode)));
+}
+
+// Embed a search query against an index built in `indexMode`. Returns null
+// when the provider comes back empty (callers already handle a missing vector).
+export async function embedQueryText(
+  text: string,
+  indexMode: IndexTextMode,
+): Promise<number[] | null> {
+  const [vec] = await embedTexts([applyQueryPrefix(text, indexMode)]);
+  return vec ?? null;
 }
 
 // ---------------------------------------------------------------------------

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -396,6 +396,16 @@ async function migrate(embeddingDim: number, reseed = false, adoptStoredDim = fa
     d.pragma('user_version = 9');
   }
 
+  if (userVersion < 10) {
+    // Task-prefix mode of the text-embedding index: 'plain' (texts embedded
+    // bare) or 'prefixed' (embedded with the model's document prefix, e.g.
+    // nomic's `search_document:`). NULL (legacy rows) = 'plain'. Lives with the
+    // index provenance because query embeds must match how the documents were
+    // embedded (music/embeddings.ts resolveIndexTextMode).
+    runDdl(d, `ALTER TABLE embedding_meta ADD COLUMN text_mode TEXT;`);
+    d.pragma('user_version = 10');
+  }
+
   // Reconcile the requested embedding dim against what physically exists.
   //
   // The vec0 table's `FLOAT[N]` schema is the authority for what inserts accept —
@@ -588,20 +598,39 @@ async function archiveMoodsJson(): Promise<void> {
 // Embedding meta
 // ---------------------------------------------------------------------------
 
-export function getEmbeddingMeta(): { model: string; dim: number } | null {
+// `textMode` records whether the vectors were embedded with the model's
+// document prefix ('prefixed') or bare ('plain'); null = legacy row from
+// before mode tracking (equivalent to 'plain' — see resolveIndexTextMode).
+export type EmbeddingTextMode = 'plain' | 'prefixed';
+
+export function getEmbeddingMeta(): {
+  model: string;
+  dim: number;
+  textMode: EmbeddingTextMode | null;
+} | null {
   const row = requireDb()
-    .prepare('SELECT model, dim FROM embedding_meta WHERE pk = 1')
-    .get() as { model: string; dim: number } | undefined;
-  return row || null;
+    .prepare('SELECT model, dim, text_mode FROM embedding_meta WHERE pk = 1')
+    .get() as { model: string; dim: number; text_mode: string | null } | undefined;
+  if (!row) return null;
+  return {
+    model: row.model,
+    dim: row.dim,
+    textMode: row.text_mode === 'prefixed' || row.text_mode === 'plain' ? row.text_mode : null,
+  };
 }
 
-export function setEmbeddingMeta(model: string, dim: number): void {
+export function setEmbeddingMeta(
+  model: string,
+  dim: number,
+  textMode: EmbeddingTextMode | null = null,
+): void {
   requireDb()
     .prepare(
-      `INSERT INTO embedding_meta (pk, model, dim, set_at) VALUES (1, ?, ?, ?)
-       ON CONFLICT(pk) DO UPDATE SET model = excluded.model, dim = excluded.dim, set_at = excluded.set_at`,
+      `INSERT INTO embedding_meta (pk, model, dim, set_at, text_mode) VALUES (1, ?, ?, ?, ?)
+       ON CONFLICT(pk) DO UPDATE SET model = excluded.model, dim = excluded.dim,
+         set_at = excluded.set_at, text_mode = excluded.text_mode`,
     )
-    .run(model, dim, new Date().toISOString());
+    .run(model, dim, new Date().toISOString(), textMode);
 }
 
 // Audio-embedding provenance — which CLAP model wrote the current audio

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -1141,6 +1141,25 @@ export function allTaggedIds(): string[] {
   ).map(r => r.id);
 }
 
+// Directly-decided tags with a vector — the trusted sample for the propagation
+// self-check (music/propagation-eval.ts). Excludes 'propagated' rows (they ARE
+// the propagation output — scoring against them would be circular) and
+// vectorless rows (KNN can't run). Null source = legacy import, decided by an
+// LLM at the time, so it counts.
+export function trustedTaggedIds(): string[] {
+  return (
+    requireDb()
+      .prepare(
+        `SELECT id FROM tracks
+          WHERE ${SQL_HAS_MOODS}
+            AND (source IS NULL OR source != 'propagated')
+            AND id IN (SELECT id FROM track_vectors)
+          ORDER BY id`,
+      )
+      .all() as Array<{ id: string }>
+  ).map(r => r.id);
+}
+
 // Tagged rows whose LLM provenance has gone stale — their prompt_hash or model
 // differs from the current ones (or is NULL, e.g. a legacy-v1 import). Drives
 // the re-scan "Re-decide moods" pass: re-LLM-tag only what a prompt/model change

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -266,6 +266,14 @@ export function tracksLikeThisAudio(seed: string, k: number): any[] {
   return out;
 }
 
+// The task-prefix mode the text-embedding index was built in — query embeds
+// must match it (embeddings.embedQueryText). 'plain' when the DB isn't loaded
+// or the meta predates mode tracking (legacy indexes were embedded bare).
+export function embeddingIndexTextMode(): 'plain' | 'prefixed' {
+  if (!loaded) return 'plain';
+  return db.getEmbeddingMeta()?.textMode ?? 'plain';
+}
+
 // KNN against an externally-computed query vector. The lyric-search tool
 // embeds a free-text query and calls this to find tracks semantically close
 // to the query — including ones whose lyrics don't literally contain those

--- a/controller/src/music/propagation-eval.ts
+++ b/controller/src/music/propagation-eval.ts
@@ -1,0 +1,90 @@
+// Held-out self-check for KNN propagation — how well does the vote reproduce
+// tags we already trust?
+//
+// The tagger samples directly-decided tracks (LLM / manual, never
+// 'propagated'), runs the SAME vote it uses for real propagation on each
+// (KNN excludes the track itself, so its own tags never vote), and scores the
+// prediction against the stored truth. One summary line per tag run turns
+// every knob change (knnNeighbours, moodVoteThreshold, confidenceThreshold,
+// the vote weighting itself) into a comparable number instead of vibes.
+//
+// Honest caveat: this is a RELATIVE signal, not a benchmark. Neighbours may
+// carry tags that were themselves propagated from the held-out track (album
+// mates especially), which inflates agreement — compare runs against each
+// other, not against 100%.
+//
+// Pure scoring only — the sampling + KNN + vote plumbing stays in
+// tag-library.ts so this file needs no DB to unit-test.
+
+import type { NeighbourTags } from './tag-propagator.js';
+import type { VoteResult } from './tag-propagator.js';
+
+export interface EvalCase {
+  actual: NeighbourTags;   // the stored (trusted) tags
+  result: VoteResult;      // what vote() predicted for this track
+}
+
+export interface EvalSummary {
+  sampled: number;
+  // Cases that clear the production propagation gate (confidence + ≥1 mood) —
+  // i.e. would have been auto-tagged had the track been untagged.
+  gatePassed: number;
+  // Mean Jaccard overlap of predicted vs actual mood sets, over gate-passed
+  // cases (0..1; 1 = identical sets). Null when nothing passed the gate.
+  moodJaccard: number | null;
+  // Energy agreement over gate-passed cases where BOTH sides have an energy.
+  energyMatched: number;
+  energyComparable: number;
+}
+
+// |A ∩ B| / |A ∪ B| over mood sets. Both-empty counts as perfect agreement
+// (the vote correctly produced nothing) — in practice gate-passed cases always
+// carry ≥1 predicted mood.
+export function moodJaccard(a: string[], b: string[]): number {
+  const sa = new Set(a);
+  const sb = new Set(b);
+  if (sa.size === 0 && sb.size === 0) return 1;
+  let inter = 0;
+  for (const m of sa) if (sb.has(m)) inter++;
+  return inter / (sa.size + sb.size - inter);
+}
+
+export function summariseEval(cases: EvalCase[], confidenceThreshold: number): EvalSummary {
+  let gatePassed = 0;
+  let jaccardSum = 0;
+  let energyMatched = 0;
+  let energyComparable = 0;
+  for (const c of cases) {
+    // Mirror the production gate in tag-library's propagation loop exactly.
+    const passes =
+      c.result.votingNeighbours >= 1 &&
+      c.result.confidence >= confidenceThreshold &&
+      c.result.moods.length > 0;
+    if (!passes) continue;
+    gatePassed++;
+    jaccardSum += moodJaccard(c.result.moods, c.actual.moods);
+    if (c.result.energy && c.actual.energy) {
+      energyComparable++;
+      if (c.result.energy === c.actual.energy) energyMatched++;
+    }
+  }
+  return {
+    sampled: cases.length,
+    gatePassed,
+    moodJaccard: gatePassed > 0 ? jaccardSum / gatePassed : null,
+    energyMatched,
+    energyComparable,
+  };
+}
+
+// One human-readable line for the run log / progress panel.
+export function formatEvalSummary(s: EvalSummary): string {
+  if (s.sampled === 0) return 'propagation self-check skipped (not enough trusted tags)';
+  const pct = (n: number, d: number) => `${Math.round((n / Math.max(1, d)) * 100)}%`;
+  const parts = [
+    `${pct(s.gatePassed, s.sampled)} of ${s.sampled} held-out tracks would auto-tag`,
+  ];
+  if (s.moodJaccard != null) parts.push(`mood agreement ${Math.round(s.moodJaccard * 100)}%`);
+  if (s.energyComparable > 0) parts.push(`energy match ${pct(s.energyMatched, s.energyComparable)}`);
+  return `Propagation self-check — ${parts.join(', ')}`;
+}

--- a/controller/src/music/seed-selector.ts
+++ b/controller/src/music/seed-selector.ts
@@ -9,8 +9,9 @@
 //      library get at least one seed (capped at ~35%)
 //   4. K-means over embedding space — fill the remainder with diverse picks
 //
-// Selection is deterministic given the same library state + random seed,
-// which keeps test assertions clean.
+// Layers 1-3 are deterministic given the same library state; layer 4's
+// k-means init and shuffle fall back to Math.random, so only the earlier
+// layers are stable across runs. Tests exercise the deterministic layers.
 
 import * as subsonic from './subsonic.js';
 import * as db from './library-db.js';

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -40,7 +40,7 @@ import * as settings from '../settings.js';
 import * as embeddings from './embeddings.js';
 import { selectSeeds } from './seed-selector.js';
 import { selectEnrichIds } from './enrich-scope.js';
-import { vote } from './tag-propagator.js';
+import { vote, fuseNeighbours } from './tag-propagator.js';
 import { summariseEval, formatEvalSummary } from './propagation-eval.js';
 import { config } from '../config.js';
 import { loadSecretsIntoEnv } from '../setup/secrets.js';
@@ -324,11 +324,23 @@ async function main() {
   // embedding is dominated by artist/album, so its KNN list is mostly its own
   // album mates; at full weight one mistagged seed swept its whole album, and
   // cross-album corroboration never got a say (the same-album echo chamber).
+  //
+  // When the track has a CLAP "sounds-like" vector, audio-KNN neighbours are
+  // fused into the list at audioFusionWeight before the vote — sound is the
+  // stronger mood signal for instrumentals / thin-metadata tracks, and CLAP
+  // doesn't cluster by album. knnAudioById returns [] for un-analysed tracks,
+  // so fusion degrades to text-only per track, not per run.
   const SAME_ALBUM_WEIGHT = 0.5;
+  const audioFusionWeight = clamp01(embedCfg.audioFusionWeight ?? 0.5);
   const voteForTrack = (id: string) => {
     const target = db.getTrack(id);
+    const textNeighbours = db.knnById(id, knnK);
+    const neighbours =
+      audioFusionWeight > 0
+        ? fuseNeighbours(textNeighbours, db.knnAudioById(id, knnK), audioFusionWeight, knnK)
+        : textNeighbours;
     return vote(
-      db.knnById(id, knnK),
+      neighbours,
       (nId) => {
         const t = db.getTrack(nId);
         if (!t || t.moods.length === 0) return null;
@@ -353,8 +365,19 @@ async function main() {
   logEvent('info', `Embedding model — ${embeddings.activeModelLabel()} (dim=${embeddingDim})`);
   console.log(
     `[tag] batch=${flags.batchSize} maxRounds=${maxRounds} knnK=${knnK} ` +
-      `moodVote=${moodVoteThreshold} confidence=${confidenceThreshold}`,
+      `moodVote=${moodVoteThreshold} confidence=${confidenceThreshold} ` +
+      `audioFusion=${audioFusionWeight}`,
   );
+  if (audioFusionWeight > 0) {
+    const audioVecs = db.audioVectorCount();
+    if (audioVecs > 0) {
+      logEvent(
+        'info',
+        `Audio fusion on — ${audioVecs.toLocaleString('en-GB')} sounds-like vectors ` +
+          `join the mood vote (weight ${audioFusionWeight})`,
+      );
+    }
+  }
 
   // A re-scan re-embed rebuilds the vector population; a normal --reseed run does
   // it as part of its forward pass and doesn't need the snapshot below.

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -41,6 +41,7 @@ import * as embeddings from './embeddings.js';
 import { selectSeeds } from './seed-selector.js';
 import { selectEnrichIds } from './enrich-scope.js';
 import { vote } from './tag-propagator.js';
+import { summariseEval, formatEvalSummary } from './propagation-eval.js';
 import { config } from '../config.js';
 import { loadSecretsIntoEnv } from '../setup/secrets.js';
 import { loadSetupConfig } from '../setup/config.js';
@@ -317,6 +318,36 @@ async function main() {
       ? embedCfg.seedCount
       : null;
 
+  // Shared vote plumbing for phase 3, the phase-4 re-propagation rounds and
+  // the post-run self-check: KNN → neighbour-tag lookup → similarity-weighted
+  // vote. Same-album+artist neighbours vote at half weight — a track's text
+  // embedding is dominated by artist/album, so its KNN list is mostly its own
+  // album mates; at full weight one mistagged seed swept its whole album, and
+  // cross-album corroboration never got a say (the same-album echo chamber).
+  const SAME_ALBUM_WEIGHT = 0.5;
+  const voteForTrack = (id: string) => {
+    const target = db.getTrack(id);
+    return vote(
+      db.knnById(id, knnK),
+      (nId) => {
+        const t = db.getTrack(nId);
+        if (!t || t.moods.length === 0) return null;
+        return { moods: t.moods, energy: t.energy };
+      },
+      {
+        moodVoteThreshold,
+        k: knnK,
+        weightOf: (nId) => {
+          if (!target?.album || !target?.artist) return 1;
+          const n = db.getTrack(nId);
+          return n?.album === target.album && n?.artist === target.artist
+            ? SAME_ALBUM_WEIGHT
+            : 1;
+        },
+      },
+    );
+  };
+
   logEvent('info', `Starting up — ${db.allTaggedIds().length.toLocaleString('en-GB')} tracks already tagged`);
   logEvent('info', `Tagging model — ${activeModelLabel()}`);
   logEvent('info', `Embedding model — ${embeddings.activeModelLabel()} (dim=${embeddingDim})`);
@@ -522,16 +553,7 @@ async function main() {
       }
       if (db.hasTags(id)) continue;        // already seeded
       if (!db.hasVector(id)) continue;     // no embedding → can't propagate
-      const neighbours = db.knnById(id, knnK);
-      const result = vote(
-        neighbours,
-        (nId) => {
-          const t = db.getTrack(nId);
-          if (!t || t.moods.length === 0) return null;
-          return { moods: t.moods, energy: t.energy };
-        },
-        { moodVoteThreshold, k: knnK },
-      );
+      const result = voteForTrack(id);
       if (
         result.votingNeighbours >= 1 &&
         result.confidence >= confidenceThreshold &&
@@ -576,16 +598,7 @@ async function main() {
       for (const id of targetUntagged) {
         if (db.hasTags(id)) continue;
         if (!db.hasVector(id)) continue;
-        const neighbours = db.knnById(id, knnK);
-        const result = vote(
-          neighbours,
-          (nId) => {
-            const t = db.getTrack(nId);
-            if (!t || t.moods.length === 0) return null;
-            return { moods: t.moods, energy: t.energy };
-          },
-          { moodVoteThreshold, k: knnK },
-        );
+        const result = voteForTrack(id);
         if (
           result.votingNeighbours >= 1 &&
           result.confidence >= confidenceThreshold &&
@@ -617,6 +630,35 @@ async function main() {
       uncertain = stillUncertain;
     }
     lap('learn');
+
+    // ---- Self-check: held-out propagation agreement ------------------------
+    // Re-run the production vote on a sample of directly-decided tracks (KNN
+    // excludes self, so a track's own tags never vote for it) and score
+    // against the stored truth. A relative signal for judging knob changes
+    // (knnK, thresholds, vote weighting) run-over-run — NOT a benchmark; see
+    // propagation-eval.ts for the circularity caveat. ~150 KNN scans,
+    // negligible next to phases 1-4. Best-effort: never fails the run.
+    try {
+      const truth = db.trustedTaggedIds();
+      if (truth.length >= 20) {
+        const SAMPLE = 150;
+        // Partial Fisher-Yates — shuffle just the head we sample.
+        const pool = [...truth];
+        const n = Math.min(SAMPLE, pool.length);
+        for (let i = 0; i < n; i++) {
+          const j = i + Math.floor(Math.random() * (pool.length - i));
+          [pool[i], pool[j]] = [pool[j], pool[i]];
+        }
+        const cases = pool.slice(0, n).map((id) => {
+          const t = db.getTrack(id)!;
+          return { actual: { moods: t.moods, energy: t.energy }, result: voteForTrack(id) };
+        });
+        logEvent('info', formatEvalSummary(summariseEval(cases, confidenceThreshold)));
+      }
+    } catch (err: any) {
+      console.log(`[tag] propagation self-check failed: ${err?.message || err}`);
+    }
+    lap('eval');
   } else if (flags.skipTag) {
     console.log('[tag] --skip-tag: skipping embed + mood tagging (phases 1-4)');
   } // end forward "Tag moods" step (plan.forwardTag)

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -287,8 +287,22 @@ async function main() {
   // runs (the bug in #307). On a same-dim run this is a no-op.
   await db.open({ embeddingDim, reseed: flags.reseed });
 
-  // The DB upserts emit when the model changes; record the current one.
-  db.setEmbeddingMeta(embeddings.activeModelLabel(), embeddingDim);
+  // The DB upserts emit when the model changes; record the current one, plus
+  // the task-prefix mode this run embeds documents in. A reseed re-embeds
+  // everything, so it adopts the active model's preferred mode; otherwise stay
+  // consistent with how the existing vectors were embedded — query embeds must
+  // match the documents (a legacy meta row with no mode = embedded bare).
+  const textMode = flags.reseed
+    ? embeddings.preferredTextMode()
+    : embeddings.resolveIndexTextMode(db.getEmbeddingMeta()?.textMode, db.vectorCount());
+  db.setEmbeddingMeta(embeddings.activeModelLabel(), embeddingDim, textMode);
+  if (textMode === 'plain' && embeddings.preferredTextMode() === 'prefixed') {
+    logEvent(
+      'info',
+      `${embeddings.activeModelLabel()} retrieves better with task prefixes — run ` +
+        `“Re-embed all tracks” (admin Re-scan tab, or --reseed) once to upgrade the index.`,
+    );
+  }
 
   // Tunables from settings.embedding, CLI flags override where present.
   const embedCfg: any = (settings.get() as any).embedding ?? {};
@@ -432,7 +446,7 @@ async function main() {
   let llmTagged = 0;
   if (plan.forwardTag) {
     // ---- Phase 1: EMBED ----------------------------------------------------
-    await phaseEmbed(targetUntagged, flags.batchSize);
+    await phaseEmbed(targetUntagged, flags.batchSize, textMode);
     lap('embed');
 
     // ---- Phase 2: SEED -----------------------------------------------------
@@ -616,7 +630,7 @@ async function main() {
   // model.
   if (plan.reEmbed) {
     console.log(`[tag] re-embed: rebuilding ${reembedIds.length} vectors from scratch`);
-    await phaseEmbed(reembedIds, flags.batchSize);
+    await phaseEmbed(reembedIds, flags.batchSize, textMode);
     lap('embed');
   }
 
@@ -821,7 +835,13 @@ async function phaseEnrich(ids: string[], reEnrich: boolean): Promise<void> {
 // Phase 1 — Embed
 // ---------------------------------------------------------------------------
 
-async function phaseEmbed(targetIds: string[], batchSize: number): Promise<void> {
+async function phaseEmbed(
+  targetIds: string[],
+  batchSize: number,
+  // The index's task-prefix mode (resolved once in run()) — every document
+  // this phase writes must match the vectors already in the index.
+  textMode: embeddings.IndexTextMode,
+): Promise<void> {
   // Embed any track in scope that doesn't already have a vector. Includes
   // already-tagged tracks (legacy v1) so they can serve as KNN neighbours.
   const needsEmbed: string[] = [];
@@ -854,7 +874,7 @@ async function phaseEmbed(targetIds: string[], batchSize: number): Promise<void>
     );
     let vecs: number[][];
     try {
-      vecs = await embeddings.embedTexts(texts);
+      vecs = await embeddings.embedDocTexts(texts, textMode);
     } catch (err: any) {
       console.error(`[tag] embedding batch failed at offset ${i}: ${err.message}`);
       throw err;

--- a/controller/src/music/tag-propagator.ts
+++ b/controller/src/music/tag-propagator.ts
@@ -14,14 +14,14 @@ export interface NeighbourTags {
 }
 
 export interface VoteResult {
-  moods: string[];                        // moods present in ≥ threshold of voting neighbours
-  energy: EnergyValue;                    // plurality vote, tie-break by top similarity
+  moods: string[];                        // moods holding ≥ threshold of the voting weight
+  energy: EnergyValue;                    // weighted plurality, tie-break by proximity
   confidence: number;                     // 0..1; combines neighbour proximity + tag coverage
   votingNeighbours: number;               // how many of the K neighbours actually had tags
 }
 
 export interface VoteOpts {
-  moodVoteThreshold: number;              // fraction of voting neighbours that must carry a mood
+  moodVoteThreshold: number;              // fraction of the total voting WEIGHT a mood must carry
   k: number;                              // how many neighbours were requested (so confidence can
                                           // discount for missing tags)
 }
@@ -29,7 +29,16 @@ export interface VoteOpts {
 // Vote on moods + energy from a KNN result. Caller supplies a lookup function
 // so we don't have to import library-db here (keeps this file unit-testable).
 //
-// Confidence formula:
+// Votes are SIMILARITY-WEIGHTED: each voting neighbour contributes
+// max(0, similarity) rather than a flat 1. Under flat counting a 0.9-similar
+// neighbour was outvoted by two 0.3-similar ones — exactly backwards at the
+// propagation frontier, where the far tail of the K list is barely related to
+// the track being tagged. A mood now passes when it carries
+// ≥ moodVoteThreshold of the total voting weight; energy is the weighted
+// plurality with ties broken by the closest neighbour carrying one.
+//
+// Confidence formula (deliberately unchanged by the weighting — the operator's
+// confidenceThreshold default was tuned against it):
 //   coverage    = votingNeighbours / k          (penalises sparse coverage early in propagation)
 //   topSim      = max(0, neighbours[0].similarity)   (penalises far-away matches)
 //   confidence  = topSim * coverage
@@ -45,47 +54,51 @@ export function vote(
   getTags: (id: string) => NeighbourTags | null,
   opts: VoteOpts,
 ): VoteResult {
-  const voting: Array<KnnHit & NeighbourTags> = [];
+  const voting: Array<KnnHit & NeighbourTags & { weight: number }> = [];
   for (const n of neighbours) {
     const tags = getTags(n.id);
     if (!tags) continue;
     if (tags.moods.length === 0 && tags.energy === null) continue;
-    voting.push({ ...n, ...tags });
+    voting.push({ ...n, ...tags, weight: Math.max(0, n.similarity) });
   }
 
-  if (voting.length === 0) {
+  const totalWeight = voting.reduce((s, v) => s + v.weight, 0);
+  if (voting.length === 0 || totalWeight <= 0) {
+    // No tagged neighbours, or every one is orthogonal-or-worse to the track —
+    // there's no real evidence to propagate from either way.
     return { moods: [], energy: null, confidence: 0, votingNeighbours: 0 };
   }
 
-  // Mood vote: count occurrences across voting neighbours.
-  const moodCounts = new Map<string, number>();
+  // Mood vote: sum each mood's neighbour weight; it passes when it carries
+  // enough of the total voting weight.
+  const moodWeights = new Map<string, number>();
   for (const v of voting) {
     for (const m of v.moods) {
-      moodCounts.set(m, (moodCounts.get(m) ?? 0) + 1);
+      moodWeights.set(m, (moodWeights.get(m) ?? 0) + v.weight);
     }
   }
-  const moodThreshold = Math.max(1, Math.ceil(opts.moodVoteThreshold * voting.length));
-  const moods = [...moodCounts.entries()]
-    .filter(([, n]) => n >= moodThreshold)
+  const moodThreshold = opts.moodVoteThreshold * totalWeight;
+  const moods = [...moodWeights.entries()]
+    .filter(([, w]) => w > 0 && w >= moodThreshold)
     .sort((a, b) => b[1] - a[1])
     .slice(0, 3) // mood vocab arrays cap at 3
     .map(([m]) => m);
 
-  // Energy vote: plurality across voting neighbours, tie-break by similarity.
-  const energyCounts = new Map<string, number>();
+  // Energy vote: weighted plurality. `voting` is in KNN order (closest first),
+  // so on an exact tie the energy that appeared on a closer neighbour wins —
+  // strictly-greater comparison keeps the earlier (closer) winner.
+  const energyWeights = new Map<string, number>();
   for (const v of voting) {
-    if (v.energy) energyCounts.set(v.energy, (energyCounts.get(v.energy) ?? 0) + 1);
+    if (v.energy) energyWeights.set(v.energy, (energyWeights.get(v.energy) ?? 0) + v.weight);
   }
   let energy: EnergyValue = null;
-  let bestCount = 0;
-  for (const [e, c] of energyCounts.entries()) {
-    if (c > bestCount) {
-      bestCount = c;
-      energy = e as EnergyValue;
-    } else if (c === bestCount) {
-      // Tie — take the energy of the closest neighbour that has any energy.
-      const closer = voting.find(v => v.energy && (v.energy === e || v.energy === energy));
-      if (closer?.energy) energy = closer.energy;
+  let bestWeight = 0;
+  for (const v of voting) {
+    if (!v.energy) continue;
+    const w = energyWeights.get(v.energy) ?? 0;
+    if (w > bestWeight) {
+      bestWeight = w;
+      energy = v.energy;
     }
   }
 

--- a/controller/src/music/tag-propagator.ts
+++ b/controller/src/music/tag-propagator.ts
@@ -24,6 +24,11 @@ export interface VoteOpts {
   moodVoteThreshold: number;              // fraction of the total voting WEIGHT a mood must carry
   k: number;                              // how many neighbours were requested (so confidence can
                                           // discount for missing tags)
+  // Optional per-neighbour weight multiplier (clamped to 0..1). The caller's
+  // policy hook — tag-library halves same-album neighbours here so an album's
+  // tags need outside corroboration instead of echoing around it. Affects the
+  // vote weights only, never the confidence formula.
+  weightOf?: (id: string) => number;
 }
 
 // Vote on moods + energy from a KNN result. Caller supplies a lookup function
@@ -59,7 +64,8 @@ export function vote(
     const tags = getTags(n.id);
     if (!tags) continue;
     if (tags.moods.length === 0 && tags.energy === null) continue;
-    voting.push({ ...n, ...tags, weight: Math.max(0, n.similarity) });
+    const scale = opts.weightOf ? Math.min(1, Math.max(0, opts.weightOf(n.id))) : 1;
+    voting.push({ ...n, ...tags, weight: Math.max(0, n.similarity) * scale });
   }
 
   const totalWeight = voting.reduce((s, v) => s + v.weight, 0);

--- a/controller/src/music/tag-propagator.ts
+++ b/controller/src/music/tag-propagator.ts
@@ -31,6 +31,39 @@ export interface VoteOpts {
   weightOf?: (id: string) => number;
 }
 
+// Fuse text-space and CLAP audio-space KNN lists into one neighbour ranking
+// for the mood vote. The audio cosine is scaled by `blend` (0..1, the
+// operator's settings.embedding.audioFusionWeight) to put it on a comparable
+// footing with text similarity; a track surfaced by BOTH spaces keeps the
+// higher of its two scores (max, not sum — the result must stay a
+// cosine-shaped 0..1 because vote()'s confidence formula reads topSim off it).
+// The fused list is re-capped at k so coverage/confidence semantics don't
+// shift: audio neighbours displace the weak tail of the text list rather than
+// widening the vote. With blend 0 or no audio hits this is exactly the text
+// list — today's behaviour.
+export function fuseNeighbours(
+  text: KnnHit[],
+  audio: KnnHit[],
+  blend: number,
+  k: number,
+): KnnHit[] {
+  const b = Math.min(1, Math.max(0, blend));
+  if (b <= 0 || audio.length === 0) return text.slice(0, Math.max(0, k));
+  const fused = new Map<string, number>();
+  for (const h of text) {
+    const s = Math.max(0, h.similarity);
+    fused.set(h.id, Math.max(fused.get(h.id) ?? 0, s));
+  }
+  for (const h of audio) {
+    const s = Math.max(0, h.similarity) * b;
+    fused.set(h.id, Math.max(fused.get(h.id) ?? 0, s));
+  }
+  return [...fused.entries()]
+    .map(([id, similarity]) => ({ id, similarity }))
+    .sort((x, y) => y.similarity - x.similarity)
+    .slice(0, Math.max(0, k));
+}
+
 // Vote on moods + energy from a KNN result. Caller supplies a lookup function
 // so we don't have to import library-db here (keeps this file unit-testable).
 //

--- a/controller/src/routes/library.ts
+++ b/controller/src/routes/library.ts
@@ -483,7 +483,13 @@ router.post('/library/retag', requireAdmin, async (req, res) => {
           },
           { lastfmTags, lyricExcerpt },
         );
-        const [vec] = await embeddings.embedTexts([text]);
+        // Document embed — must match the task-prefix mode the rest of the
+        // index was built in, or this one track drifts in the KNN space.
+        const textMode = embeddings.resolveIndexTextMode(
+          db.getEmbeddingMeta()?.textMode,
+          db.vectorCount(),
+        );
+        const [vec] = await embeddings.embedDocTexts([text], textMode);
         if (vec) db.upsertTrackVector(id, vec);
       } catch (err: any) {
         queue.log('warn', `/library/retag embed ${id}: ${err.message}`);

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -952,6 +952,14 @@ const DEFAULTS = {
     moodVoteThreshold: 0.4,   // was 0.6 — a mood carried by ~a third propagates
     confidenceThreshold: 0.35, // was 0.6 — see the topSim×coverage note above
     maxActiveLearningRounds: 3,
+    // CLAP audio fusion in mood propagation: tracks with a "sounds-like"
+    // audio vector also pull neighbours from the audio-KNN space, scaled by
+    // this weight, before the mood vote (tag-propagator.ts fuseNeighbours).
+    // Sound is the stronger mood signal for instrumentals / thin-metadata
+    // tracks, and CLAP neighbours don't cluster by album. 0 = text-only
+    // (today's behaviour); 1 = trust audio similarity as much as text. Only
+    // bites where the acoustic analysis has produced audio vectors.
+    audioFusionWeight: 0.5,
     enrichment: {
       // Last.fm crowd tags. Tri-state: true = always fetch, false = never,
       // null = auto (fetch only when a Last.fm api_key is configured — see
@@ -1581,6 +1589,10 @@ export async function load() {
         && stored.embedding.maxActiveLearningRounds >= 0
           ? Math.floor(stored.embedding.maxActiveLearningRounds)
           : DEFAULTS.embedding.maxActiveLearningRounds,
+      audioFusionWeight:
+        Number.isFinite(stored.embedding?.audioFusionWeight)
+          ? clamp01(stored.embedding.audioFusionWeight)
+          : DEFAULTS.embedding.audioFusionWeight,
       enrichment: {
         lastfmTags:
           typeof stored.embedding?.enrichment?.lastfmTags === 'boolean'
@@ -2628,6 +2640,13 @@ export async function update(patch) {
         throw new Error('embedding.maxActiveLearningRounds must be an integer 0-10');
       }
       next.embedding.maxActiveLearningRounds = v;
+    }
+    if (e.audioFusionWeight !== undefined) {
+      const v = parseFloat(e.audioFusionWeight);
+      if (!Number.isFinite(v) || v < 0 || v > 1) {
+        throw new Error('embedding.audioFusionWeight must be between 0 and 1');
+      }
+      next.embedding.audioFusionWeight = v;
     }
     if (e.enrichment !== undefined) {
       const en = e.enrichment || {};

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -187,6 +187,7 @@ interface EmbeddingForm {
   moodVoteThreshold: string;
   confidenceThreshold: string;
   maxActiveLearningRounds: string;
+  audioFusionWeight: string; // '0' = text-only vote (fusion off)
   enrichment: EmbeddingEnrichmentForm;
 }
 
@@ -313,6 +314,7 @@ interface SettingsData {
       moodVoteThreshold?: number;
       confidenceThreshold?: number;
       maxActiveLearningRounds?: number;
+      audioFusionWeight?: number;
       enrichment?: Partial<EmbeddingEnrichmentForm>;
     };
     sfx?: { enabled?: boolean };
@@ -525,6 +527,7 @@ export default function SettingsPanel() {
         moodVoteThreshold: String(v.embedding?.moodVoteThreshold ?? 0.4),
         confidenceThreshold: String(v.embedding?.confidenceThreshold ?? 0.35),
         maxActiveLearningRounds: String(v.embedding?.maxActiveLearningRounds ?? 3),
+        audioFusionWeight: String(v.embedding?.audioFusionWeight ?? 0.5),
         enrichment: {
           lastfmTags: v.embedding?.enrichment?.lastfmTags ?? false,
           lyrics: v.embedding?.enrichment?.lyrics ?? true,
@@ -3692,6 +3695,11 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
         moodVoteThreshold: parseFloat(e.moodVoteThreshold) || 0.4,
         confidenceThreshold: parseFloat(e.confidenceThreshold) || 0.35,
         maxActiveLearningRounds: parseInt(e.maxActiveLearningRounds, 10) || 0,
+        // NaN-safe rather than `|| 0.5` — 0 is a deliberate value (fusion off)
+        // and must not be coerced back to the default.
+        audioFusionWeight: Number.isFinite(parseFloat(e.audioFusionWeight))
+          ? parseFloat(e.audioFusionWeight)
+          : 0.5,
         enrichment: {
           lastfmTags: e.enrichment.lastfmTags,
           lyrics: e.enrichment.lyrics,
@@ -4232,10 +4240,10 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
               className="max-w-[180px]"
             />
             <div className="field-hint">
-              Fraction of voting neighbours that must carry a mood for it to
-              propagate. Default <code>0.4</code> — a mood shared by ~a third of
-              the voters carries. Higher = stricter, fewer propagated tags;
-              lower = looser, more drift.
+              Fraction of the total voting <em>weight</em> a mood must carry to
+              propagate (neighbours vote weighted by similarity, so close matches
+              count for more). Default <code>0.4</code>. Higher = stricter, fewer
+              propagated tags; lower = looser, more drift.
             </div>
           </div>
 
@@ -4263,6 +4271,32 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
               product of two sub-1 numbers it compounds fast, so the default is{' '}
               <code>0.35</code>, not 0.6 (0.6 rejected even strong matches and sent
               most tracks to the LLM).
+            </div>
+          </div>
+
+          <div className="field">
+            <Label>Audio fusion weight</Label>
+            <Input
+              type="number"
+              min={0}
+              max={1}
+              step={0.05}
+              value={e.audioFusionWeight}
+              onChange={(ev: ChangeEvent<HTMLInputElement>) =>
+                setForm(f => ({
+                  ...f,
+                  embedding: { ...f.embedding, audioFusionWeight: ev.target.value },
+                }))
+              }
+              className="max-w-[180px]"
+            />
+            <div className="field-hint">
+              Lets tracks with a &ldquo;sounds-like&rdquo; (CLAP) vector pull
+              audio-similar neighbours into the mood vote, scaled by this weight —
+              sound is the stronger mood signal for instrumentals and tracks with
+              thin metadata. <code>0</code> = text-only vote; <code>1</code> =
+              trust audio similarity as much as text. Default <code>0.5</code>.
+              Only applies where the acoustic analysis has produced audio vectors.
             </div>
           </div>
 


### PR DESCRIPTION
Retrieval-quality improvements to the embedding system, from the review discussed in-session.

## 1. Similarity-weighted KNN voting (`tag-propagator.ts`)

Propagation neighbours previously voted with a flat count: a 0.9-similar neighbour was outvoted by two 0.3-similar ones — exactly backwards at the propagation frontier, where the tail of the K list is barely related to the track being tagged.

- Each voting neighbour now contributes `max(0, similarity)` weight.
- A mood passes when it carries ≥ `moodVoteThreshold` of the **total voting weight**.
- Energy is the weighted plurality, ties broken toward the closest neighbour.
- The confidence formula (`topSim × coverage`) is **deliberately unchanged** so the operator's tuned `confidenceThreshold` (default 0.35) keeps its semantics — this PR changes *what* gets voted in, not *when* propagation is trusted.

## 2. Embedding task prefixes (`embeddings.ts` + index mode tracking)

`nomic-embed-text` — the shipped Ollama default — is trained with **mandatory** task prefixes (`search_document:` / `search_query:`); embedding bare measurably degrades retrieval. We embedded both tracks and DJ queries bare, silently blunting KNN propagation, `tracksLikeThis`, and `searchByLyrics`.

Since document prefixes change the stored vectors, consistency is tracked:

- `embedding_meta.text_mode` (migration 10) records whether the index was built `plain` or `prefixed`. Queries always match the stored mode.
- **Legacy indexes stay plain** (bare query vs bare docs is consistent); the tagger logs a one-line advisory to run “Re-embed all tracks” / `--reseed` to upgrade.
- A reseed or fresh index adopts the model's preferred mode automatically.
- The single-track retag route embeds documents in the stored index mode too, so retagged tracks don't drift in the KNN space.
- `mxbai-embed-large` gets its query-side instruction, which is always index-safe (its documents embed bare by design).
- Per-model knowledge lives in `llm/internal/provider/embedding.ts` next to `isHeavyEmbeddingModel`; unknown models get no prefixes.

## 3. Same-album vote down-weight (the echo chamber)

A track's text embedding is dominated by artist/album, so its KNN list is mostly its own album mates — one mistagged seed swept its whole album at full weight, and cross-album corroboration never got a say. `vote()` gains an optional `weightOf` multiplier (pure mechanism); tag-library halves same-album+artist neighbours (policy). Confidence untouched.

## 4. Held-out propagation self-check

After phase 4, the tagger samples up to 150 directly-decided tracks (`source != 'propagated'`, vector present), re-runs the production vote on each (KNN excludes self) and logs one line: gate-pass rate, mean mood Jaccard, energy match. Turns every future knob change into a comparable number. Documented as a **relative** signal — neighbours may carry tags propagated from the held-out track, so compare runs against each other, not against 100%. Pure scoring in `music/propagation-eval.ts`; best-effort, never fails a run.

## Tests

- `scripts/tag-propagator.test.ts` (15 cases — flat-count regression, weightOf, fuseNeighbours, confidence-semantics pins)
- `scripts/embedding-prefix.test.ts` (10 cases), `scripts/propagation-eval.test.ts` (6 cases)
- `embedding-dim-migrate.test.ts` extended with a `text_mode` round-trip over the real migration
- All wired into `npm test`; full suite + `npm run lint` green.

## 5. CLAP audio fusion in mood propagation

Tracks that have a "sounds-like" (CLAP) vector now pull audio-KNN neighbours into the mood vote. `fuseNeighbours()` (pure, next to `vote()`) scales audio cosines by **`embedding.audioFusionWeight`** (new setting — default `0.5`, `0` = text-only, validated + exposed in the admin embedding panel), merges the two lists keeping the max score for tracks surfaced by both spaces, and re-caps at `knnK` — so audio neighbours displace the weak tail of the text list rather than widening the vote, and `vote()`'s coverage/confidence semantics are untouched.

Why: sound is the stronger mood signal for instrumentals and thin-metadata tracks, and CLAP neighbours don't cluster by album. Degrades cleanly: `knnAudioById` returns `[]` for un-analysed tracks, so fusion is per-track, not per-run — a library with no acoustic analysis behaves exactly as before. The run log states when fusion is active and at what weight, and the propagation self-check (#4) runs the fused pipeline, so the blend factor can be calibrated against real numbers.
