### PR TITLE
feat(library): Reset tab — wipe all tagging data and start fresh

### DIFF
--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -260,6 +260,20 @@ export async function restoreFromFile(srcPath: string): Promise<void> {
   await rm(`${DB_PATH}-shm`, { force: true });
 }
 
+// Delete the entire on-disk DB — every track row, mood/energy tag, text +
+// audio embedding, acoustic-analysis column, and enrichment cache — plus the
+// WAL/SHM sidecars, so the next open() recreates an empty schema from scratch.
+// Mirrors restoreFromFile()'s close→swap-file→drop-sidecars shape, and like it
+// leaves the reopen to the caller (music/library.ts:reset()). This is the
+// "start fresh" wipe behind the admin library Reset action — irreversible short
+// of restoring a backup.
+export async function reset(): Promise<void> {
+  close();
+  await rm(DB_PATH, { force: true });
+  await rm(`${DB_PATH}-wal`, { force: true });
+  await rm(`${DB_PATH}-shm`, { force: true });
+}
+
 function requireDb(): Database.Database {
   if (!db) throw new Error('library-db not opened — call open() first');
   return db;

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -36,6 +36,16 @@ export async function reload() {
   await load();
 }
 
+// Wipe the whole library (tags, embeddings, acoustic analysis, enrichment) and
+// reopen an empty DB, so the picker/tools immediately see a clean slate without
+// a controller restart. Backs the admin library "Reset" action. Unlike
+// reload(), this deletes the file first (db.reset()) for a true fresh start.
+export async function reset() {
+  loaded = false;
+  await db.reset();
+  await load();
+}
+
 // SQLite WAL writes are durable per statement — no batched save needed. Kept
 // as a no-op so existing callers that call save() at intervals still work.
 export async function save() {

--- a/controller/src/routes/library.ts
+++ b/controller/src/routes/library.ts
@@ -393,6 +393,31 @@ router.post('/library/reconcile', requireAdmin, (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
+// POST /library/reset — nuke ALL tagging data and start fresh. Deletes the
+// entire library.db (mood/energy tags, text + CLAP embeddings, acoustic
+// analysis, Last.fm/lyric enrichment) and reopens an empty DB. Coverage's
+// `total` (the Navidrome library size) is untouched — only the tagged/analysed
+// figures drop to 0. Refused while a tagger/analyzer run holds the single-flight
+// slot (deleting the file out from under the child would corrupt it). This is
+// irreversible short of a backup restore; the admin UI gates it behind an
+// explicit typed confirmation.
+// ---------------------------------------------------------------------------
+router.post('/library/reset', requireAdmin, async (_req, res) => {
+  if (tagger.running) return res.status(409).json({ error: 'a tagger/analyzer run is already active', tagger });
+  try {
+    await library.reset();
+    // The tagged/analysed counts are read live from the DB, so they're already 0
+    // now; kick a coverage refresh so the panel's snapshot reflects it promptly.
+    coverage.refresh();
+    queue.log('warn', 'library reset: wiped all tagging data (tags, embeddings, acoustics, enrichment)');
+    res.json({ ok: true });
+  } catch (err: any) {
+    queue.log('error', `/library/reset failed: ${err.message}`);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // POST /library/retag — single-track refresh through the bulk pipeline.
 // Body: { id, title?, artist?, album?, year?, genre? }
 //

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -723,6 +723,39 @@ export default function LibraryPanel() {
     }
   };
 
+  // Reset — wipe ALL tagging data (tags, embeddings, acoustics, enrichment) and
+  // start fresh. Deletes library.db server-side; the Navidrome library itself is
+  // untouched, so every track simply returns to the untagged pool. Gated behind
+  // the modal's typed confirmation. Refused (409) while a tagger run is active.
+  const resetLibrary = async () => {
+    setTaggerBusy(true);
+    try {
+      const r = await adminFetch('/library/reset', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      const j = await r.json().catch(() => ({})) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `reset failed (${r.status})`);
+      notify.ok('library reset — all tagging data wiped');
+      // Everything the tables/meters showed is gone. Refresh coverage + settings
+      // and drop the cached views so each tab reloads against the empty library.
+      await loadCoverage();
+      void loadSettingsData();
+      setBrowse(null);
+      setSearchResults(null);
+      setRecent(null);
+      setUntagged([]);
+      setUntaggedCursor(null);
+      if (tab === 'browse') runBrowse();
+      else if (tab === 'recent') loadRecent();
+    } catch (err) {
+      notify.err(errorMessage(err));
+    } finally {
+      setTaggerBusy(false);
+    }
+  };
+
   // -----------------------------------------------------------------------
   // derived
   // -----------------------------------------------------------------------
@@ -771,6 +804,7 @@ export default function LibraryPanel() {
         onStop={stopTagger}
         onRescan={rescanTagger}
         onReconcile={reconcile}
+        onReset={resetLibrary}
         audioEnabled={audioEnabled}
         onToggleAudio={toggleAudio}
         onAnalyzeAudio={analyzeAudio}

--- a/web/components/admin/LibraryTaggingModal.tsx
+++ b/web/components/admin/LibraryTaggingModal.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 // The single "Tagging" modal opened from the library panel's primary button.
-// Two tabs, one per intent:
+// Three tabs, one per intent:
 //   • Run     — pick which pipeline steps run, then start a forward run
 //   • Re-scan — maintenance passes that redo already-done work after a model change
-// Both tabs are "configure + launch a pipeline run". The optional-dimension
-// lifecycle (enable / disable / backfill CLAP + Demucs) lives on the panel's
-// coverage rows instead, next to the meters it changes.
+//   • Reset   — nuke ALL tagging data (tags, embeddings, acoustics, enrichment)
+//               and start fresh, behind a double confirmation
+// Run/Re-scan are "configure + launch a pipeline run"; Reset is a destructive
+// one-shot. The optional-dimension lifecycle (enable / disable / backfill CLAP +
+// Demucs) lives on the panel's coverage rows instead, next to the meters it changes.
 
 import { useEffect, useState } from 'react';
-import { Play, RefreshCw } from 'lucide-react';
+import { Play, RefreshCw, Trash2, AlertTriangle } from 'lucide-react';
 import { Modal } from '../ui/modal';
 import { V3AlertDialog } from '../ui/alert-dialog';
 import { Btn } from './ui';
@@ -17,7 +19,7 @@ import { cn } from '../../lib/cn';
 import type { Batch, BudgetMode, RescanOpts, TagSteps } from './LibraryTaggingPanel';
 import { num } from './LibraryTaggingPanel';
 
-type Tab = 'run' | 'rescan';
+type Tab = 'run' | 'rescan' | 'reset';
 
 interface Props {
   open: boolean;
@@ -51,11 +53,14 @@ interface Props {
   onStart: (steps?: TagSteps) => void;
   onReconcile: () => void;
   onRescan: (opts: RescanOpts) => void;
+  // Wipe ALL tagging data and start fresh (deletes library.db server-side).
+  onReset: () => void;
 }
 
 const TABS: { key: Tab; label: string }[] = [
   { key: 'run', label: 'Run' },
   { key: 'rescan', label: 'Re-scan' },
+  { key: 'reset', label: 'Reset' },
 ];
 
 export default function LibraryTaggingModal(p: Props) {
@@ -85,6 +90,11 @@ export default function LibraryTaggingModal(p: Props) {
   // since that banner blocked a run the operator actually wanted.
   const [thenTag, setThenTag] = useState(false);
   const togglePass = (k: keyof RescanOpts) => setPasses(prev => ({ ...prev, [k]: !prev[k] }));
+
+  // Reset tab — first confirmation is an acknowledgement checkbox that arms the
+  // button; clicking it then opens the second (a danger alert dialog).
+  const [resetAck, setResetAck] = useState(false);
+  const [confirmReset, setConfirmReset] = useState(false);
   const passAllSelected = !!(passes.reseed && passes.reEnrich && passes.reAnalyze && passes.upgrade);
   const anyPass = !!(passes.reseed || passes.reEnrich || passes.reAnalyze || passes.upgrade);
   const reseedOnly = !!passes.reseed && !passes.reEnrich && !passes.reAnalyze && !passes.upgrade;
@@ -103,6 +113,9 @@ export default function LibraryTaggingModal(p: Props) {
       setTab('run');
       setThenTag(false);
     }
+    // The destructive acknowledgement never survives a modal close — every open
+    // starts un-armed so Reset can't be one-clicked from a stale tick.
+    setResetAck(false);
     // Only re-run when the modal transitions open (or the intent changes).
   }, [p.open, p.intent]);
 
@@ -186,7 +199,7 @@ export default function LibraryTaggingModal(p: Props) {
         {/* Daily-token-budget caution — shown on both tabs when the day's spend
             is near (soft) or past (hard) the cap, so a run's LLM steps won't
             surprise the operator with extra spend or mid-run failures. */}
-        {budgetWarn && (
+        {tab !== 'reset' && budgetWarn && (
           <div className="flex items-start gap-2 border border-l-[3px] border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger)_8%,transparent)] px-3 py-2 text-[11px] leading-[1.5] text-ink">
             {budgetWarn === 'soft' ? (
               <span><b>Daily token budget nearly used</b> — this run will spend more against it.</span>
@@ -322,6 +335,57 @@ export default function LibraryTaggingModal(p: Props) {
             </div>
           </>
         )}
+
+        {/* ---------------------------------------------------------------- RESET */}
+        {tab === 'reset' && (
+          <>
+            <div className="flex items-start gap-2.5 border border-l-[3px] border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger)_8%,transparent)] px-3 py-2.5 text-[12px] leading-[1.55] text-ink">
+              <AlertTriangle size={16} className="mt-px shrink-0 text-vermilion" />
+              <span>
+                <b>This wipes everything the tagger has learned.</b> It permanently deletes all
+                mood &amp; energy tags, similarity embeddings, acoustic analysis (bpm / key /
+                loudness / vocal), and Last.fm / lyric enrichment
+                {p.libraryTotal != null ? <> for all <b className="mono-num">{num(p.libraryTotal)}</b> tracks</> : ''}.
+                Your music in Navidrome is <b>not</b> touched — every track just returns to the
+                untagged pool.
+              </span>
+            </div>
+            <p className="text-[12px] leading-[1.55] text-muted">
+              There&rsquo;s no undo short of restoring a backup. Afterwards you&rsquo;ll start from{' '}
+              <b>0%</b> and need a fresh <b>Run</b> (including the slow acoustic + embedding passes)
+              to rebuild coverage. Use this only to start completely clean — for a model change,
+              the <b>Re-scan</b> tab redoes just the affected work and keeps your tags.
+            </p>
+            {/* first confirmation — arm the action */}
+            <button
+              type="button"
+              role="checkbox"
+              aria-checked={resetAck}
+              className={cn('lib-pass', resetAck && 'on')}
+              onClick={() => setResetAck(v => !v)}
+              disabled={p.busy}
+            >
+              <span className="box">
+                <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
+                  <path d="M2.5 6.2L4.8 8.5L9.5 3.5" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </span>
+              <span>
+                <span className="lib-pass-name">I understand this permanently deletes all tagging data</span>
+                <span className="lib-pass-hint">
+                  Tags, embeddings, and acoustic analysis for the whole library are erased and cannot be recovered.
+                </span>
+              </span>
+            </button>
+            <div className="flex items-center justify-end gap-2.5 border-t border-dashed border-separator-strong pt-3.5">
+              <Btn onClick={() => p.onOpenChange(false)}>Cancel</Btn>
+              {/* second confirmation happens in the danger dialog this opens */}
+              <Btn tone="danger" disabled={!resetAck || p.busy} onClick={() => setConfirmReset(true)}>
+                <Trash2 size={12} /> Reset library…
+              </Btn>
+            </div>
+          </>
+        )}
       </div>
 
       <V3AlertDialog
@@ -332,6 +396,16 @@ export default function LibraryTaggingModal(p: Props) {
         confirmLabel="re-scan"
         danger
         onConfirm={() => { p.onRescan(rescanPayload()); clearPasses(); setConfirmRescan(false); p.onOpenChange(false); }}
+      />
+
+      <V3AlertDialog
+        open={confirmReset}
+        onOpenChange={setConfirmReset}
+        title={p.libraryTotal != null ? `Delete all tagging data for ${num(p.libraryTotal)} tracks?` : 'Delete all tagging data?'}
+        description={`This permanently erases every mood/energy tag, similarity embedding, acoustic-analysis result (bpm, key, loudness, vocal), and Last.fm/lyric enrichment${p.libraryTotal != null ? ` across all ${num(p.libraryTotal)} tracks` : ''}. Your music in Navidrome is not affected — but there is no undo short of restoring a backup, and rebuilding coverage means a full tag + analysis run from scratch.`}
+        confirmLabel="Delete everything"
+        danger
+        onConfirm={() => { p.onReset(); setConfirmReset(false); setResetAck(false); p.onOpenChange(false); }}
       />
     </Modal>
   );

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -192,6 +192,9 @@ interface TaggingPanelProps {
   onRescan: (opts: RescanOpts) => void;
   // Walk Navidrome and prune library entries for tracks that no longer exist.
   onReconcile: () => void;
+  // Wipe ALL tagging data (tags, embeddings, acoustics, enrichment) and start
+  // fresh — backs the modal's Reset tab, behind a typed confirmation.
+  onReset: () => void;
   // sounds-like (CLAP) controls — null until the first settings poll lands.
   audioEnabled: boolean | null;
   onToggleAudio: () => void;
@@ -1034,6 +1037,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
         onStart={p.onStart}
         onReconcile={p.onReconcile}
         onRescan={p.onRescan}
+        onReset={p.onReset}
       />
     </section>
   );


### PR DESCRIPTION
## What

Adds a third **Reset** tab to the library tagging modal (`/admin/library` → Start tagging → **Reset**), alongside Run and Re-scan. It deletes everything the tagger has learned and returns the whole library to the untagged pool.

## Why

There was no way to start completely fresh — Re-scan only redoes already-processed work and keeps tags. This is the "wipe the slate" action for when you want a clean rebuild.

## How

**Backend**
- `library-db.reset()` — closes the DB, deletes `state/library.db` + its WAL/SHM sidecars (mirrors the existing `restoreFromFile` pattern).
- `library.reset()` — wipes and reopens an empty DB, so the live picker/tools see a clean slate with no controller restart.
- `POST /library/reset` (admin-gated) — **refused with 409 while a tagger/analyzer run holds the single-flight slot** (deleting the file under a running child would corrupt it), logs the wipe, kicks a coverage refresh.

**Frontend**
- New Reset tab with a danger banner spelling out exactly what's erased (mood/energy tags, similarity embeddings, bpm/key/loudness/vocal analysis, Last.fm/lyric enrichment) and that **Navidrome music is untouched** — tracks just return to the untagged pool.
- **Double confirmation**: an acknowledgement checkbox that arms the button (reset on every modal open, so it can't be one-clicked from a stale tick) + a danger alert dialog before the wipe.
- On success, coverage meters drop to 0% and cached table views reload against the empty library.

Coverage's `total` (the Navidrome library size) is preserved — only the tagged/analysed figures reset to 0.

## Testing

- `npm run lint` (eslint + `tsc --noEmit`) clean in both `controller/` and `web/`.
- Controller hot-reloaded cleanly; `POST /library/reset` returns `401` unauthenticated (admin gate wired), station stayed on-air.
- The destructive wipe itself was not exercised (would delete real tagging data); everything up to the final confirm is verified.