### PR TITLE
fix(admin/library): vocal-activity modal checkboxes appear immediately on enable

### DIFF
--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -692,8 +692,11 @@ export default function LibraryPanel() {
             : 'vocal-activity analysis enabled'
           : 'vocal-activity analysis disabled',
       );
-      // Refresh the slow settings-derived state now rather than waiting for its tick.
+      // Refresh the slow settings-derived state now rather than waiting for its
+      // tick — and coverage too, so the coverage-driven bits (vocalStatus, the
+      // vocal meter row) catch up without waiting out the 60s poll.
       void loadSettingsData();
+      void loadCoverage();
     } catch (err) {
       notify.err(errorMessage(err));
     } finally {

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -347,9 +347,11 @@ export default function TaggingPanel(p: TaggingPanelProps) {
   // The Pause/Enable button + meter-vs-collapsed layout must react to a toggle
   // immediately, so drive them off the optimistic settings prop (p.vocalEnabled,
   // flipped on click in LibraryPanel) — mirroring how the audio row uses
-  // p.audioEnabled. vocalWanted (from the polled /coverage) only lags, so it
-  // just fills the gap before /settings first loads. (The analysis-state bits —
-  // vocalStatus, the modal's vocalWanted — stay coverage-driven.)
+  // p.audioEnabled. vocalWanted (from the polled /coverage, 60s cadence) only
+  // lags, so it just fills the gap before /settings first loads. The modal's
+  // per-run vocal checkboxes get this same optimistic value — coverage-driven,
+  // they stayed invisible until a repoll/refresh after enabling. Only the
+  // analysis-state bits (vocalStatus) stay coverage-driven.
   const vocalOptedIn = p.vocalEnabled ?? vocalWanted;
   const vocalOn = (vocalAnalyzed ?? 0) > 0;
   const remaining = total != null && tagged != null ? Math.max(0, total - tagged) : null;
@@ -1029,7 +1031,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
         remaining={remaining}
         libraryTotal={total}
         analysisOff={analysisOff}
-        vocalWanted={vocalWanted}
+        vocalWanted={vocalOptedIn}
         // sounds-like only runs when the dimension is on AND the engine can do
         // it — otherwise the acoustics steps are bpm/key-only (honest hints).
         soundsLikeActive={!analysisOff && audioStatus !== 'pending-heavy' && !!p.audioEnabled}


### PR DESCRIPTION
## What

On `/admin/library`, enabling Vocal activity (Demucs) didn't reveal the tagging modal's per-run vocal checkboxes — they only appeared after a page refresh (or up to 60s later).

## How

The panel row already reacts to the Enable toggle optimistically (`vocalOptedIn = p.vocalEnabled ?? vocalWanted`), but the modal was passed the coverage-polled `vocalWanted` (60s cadence). The modal now gets the same optimistic value the row uses — safe, since the toggle's `POST /settings` completes before the optimistic flip — and `toggleVocal` also refreshes `/coverage` immediately so the coverage-driven status bits (vocal meter row, `vocalStatus`) catch up without waiting out the poll.