### PR TITLE
fix(admin/library): hide Backfill buttons on a virgin library, drop the Analyze label flip

### DIFF
--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -354,6 +354,12 @@ export default function TaggingPanel(p: TaggingPanelProps) {
   // analysis-state bits (vocalStatus) stay coverage-driven.
   const vocalOptedIn = p.vocalEnabled ?? vocalWanted;
   const vocalOn = (vocalAnalyzed ?? 0) > 0;
+  // Whether ANY tagging/analysis work has ever landed. On a completely virgin
+  // library the honest affordance is the primary Start-tagging run, so the
+  // per-dimension Backfill buttons stay hidden until there's an actual gap to
+  // fill (some work done, this dimension behind) instead of sitting next to a
+  // 0-of-N meter looking like a duplicate of the modal's "Analyze acoustics".
+  const anyWorkDone = (tagged ?? 0) > 0 || (analysed ?? 0) > 0 || audioOn || vocalOn;
   const remaining = total != null && tagged != null ? Math.max(0, total - tagged) : null;
   const running = !!p.tagger?.running;
   // The first library count (walking Navidrome for a total) is in flight — size
@@ -605,7 +611,9 @@ export default function TaggingPanel(p: TaggingPanelProps) {
       {/* acoustic & audio coverage — status meter on each row, plus the controls
           that change it: bpm/key is always-on (engine permitting); sounds-like
           (CLAP) and vocal (Demucs) are opt-in, so they carry Enable/Disable + a
-          contextual Backfill (shown only while enabled, capable, and < 100%). */}
+          contextual Backfill (shown only while enabled, capable, < 100%, and the
+          library has SOME work done — on a virgin library the primary
+          Start-tagging run is the one entry point). */}
       <div className="flex flex-col gap-3 border-b border-ink px-6 py-4">
         <div className="flex flex-wrap items-center gap-x-3.5 gap-y-2">
           <span className="caption flex items-center gap-2">
@@ -666,7 +674,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
           </span>
           {!analysisOff && (
             <span className="ml-auto flex items-center gap-2">
-              {p.audioEnabled && canBackfill(audioStatus) && (
+              {p.audioEnabled && anyWorkDone && canBackfill(audioStatus) && (
                 <Btn
                   sm
                   tone="accent"
@@ -674,7 +682,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
                   disabled={p.busy || running}
                   title="Fingerprint the tracks still missing a “sounds-like” vector — without redoing bpm/key."
                 >
-                  <Play size={12} /> {audioOn ? 'Backfill' : 'Analyze'}
+                  <Play size={12} /> Backfill
                 </Btn>
               )}
               <Btn
@@ -739,7 +747,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
                 </span>
                 {!analysisOff && (
                   <span className="ml-auto flex items-center gap-2">
-                    {canBackfill(vocalStatus) && (
+                    {anyWorkDone && canBackfill(vocalStatus) && (
                       <Btn
                         sm
                         tone="accent"
@@ -747,7 +755,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
                         disabled={p.busy || running}
                         title="Separate vocals for the tracks still missing it — without redoing bpm/key."
                       >
-                        <Play size={12} /> {vocalOn ? 'Backfill' : 'Analyze'}
+                        <Play size={12} /> Backfill
                       </Btn>
                     )}
                     <Btn


### PR DESCRIPTION
## Summary
- The per-dimension buttons on the sounds-like and vocal-activity coverage rows always read **Backfill** now — previously they flipped to "Analyze" at 0 coverage, impersonating the modal's "Analyze acoustics" step and looking like a duplicate entry point.
- Both buttons are hidden while the library is completely untouched (no tags, no bpm/key, no fingerprints, no vocal ranges) — on a virgin library the primary **Start tagging** run is the one honest entry point. They reappear as soon as any work lands, preserving the "enabled CLAP/Demucs later" backfill path (`/library/analyze` is the only route that sweeps already-tagged tracks).

## Test plan
- `npm run lint` in `web/` (eslint + tsc) passes
- On a 0-coverage library, `/admin/library` shows no Analyze/Backfill buttons on the audio-fingerprint and vocal rows; Enable/Pause toggles unaffected
- With partial coverage on an enabled dimension, the row shows a "Backfill" button that starts the targeted analyze pass