### PR TITLE
fix(admin/shows): touch-safe schedule painting — long-press to paint, tap to toggle, swipe scrolls

### DIFF
--- a/docs/superpowers/specs/2026-07-02-shows-grid-touch-paint-design.md
+++ b/docs/superpowers/specs/2026-07-02-shows-grid-touch-paint-design.md
@@ -1,0 +1,69 @@
+# Shows grid: long-press-to-paint on touch — design
+
+**Date:** 2026-07-02
+**Scope:** `web/components/admin/ShowsPanel.tsx` only (grid interaction layer). No API, state-shape, or desktop-behaviour changes.
+
+## Problem
+
+The weekly schedule paint grid at `/admin/shows` is unreliable on touch screens:
+
+1. **Paint fires on finger-down.** `GridCell` wires `onTouchStart={() => beginStroke(...)}`, so the cell under the finger toggles the instant a touch lands — before the browser knows whether the gesture is a scroll or a paint. Every horizontal scroll that starts on a cell flips that cell (the reported "accidental unchecks/checks while scrolling").
+2. **`preventDefault()` in `onGridTouchMove` is a no-op.** React 17+ attaches `touchmove` at the root as a *passive* listener, so the call is ignored. While drag-painting, the `overflow-x-auto` container still pans (`touch-pan-x`), cells slide under the stationary finger, and `elementFromPoint` paints stray cells.
+3. **No `touchcancel` handling.** The window listeners end a stroke on `mouseup`/`touchend` only; an OS-interrupted gesture (notification shade, browser takes over the scroll) can leave `strokeRef.active = true`.
+
+Desktop (mouse) behaviour is considered correct and must not change.
+
+## Decision
+
+Fix in place — no redesign. Adopt **long-press-to-paint** as the touch gesture:
+
+- **Swipe** (finger moves before the hold delay) → scrolls, paints nothing.
+- **Hold ~300 ms on a cell** (movement under a small slop) → arms a paint stroke: haptic tick, scroll suppressed for the rest of the gesture, origin cell painted, drag extends the stroke.
+- **Quick tap** (release before the hold delay, under slop) → toggles that single cell, committed **on release** — so a scroll that merely starts on a cell never toggles anything.
+- **Mouse path unchanged** (`mousedown` paints immediately, `mouseenter` extends, as today).
+
+## Mechanics
+
+### Pending-press state
+
+A new `pressRef` alongside the existing `strokeRef`:
+
+```
+pressRef: { day, hour, x, y, timer } | null
+```
+
+- `touchstart` on a cell (single touch only; ignore if `e.touches.length > 1`): record origin cell + coords, start a `HOLD_MS = 300` timer. **Do not paint.**
+- `touchmove` while pending: if the touch drifts beyond `SLOP_PX = 8` from origin, cancel the timer and clear `pressRef` — it's a scroll. The browser pans as normal.
+- Timer fires (finger still down, within slop): arm the stroke — `strokeRef = { active: true, value: strokeValueFor(origin) }`, paint the origin cell, `navigator.vibrate?.(10)` where supported, set a `painting` state flag.
+- `touchend` while still pending (i.e. quick tap, under slop): commit a single-cell toggle (`beginStroke`-equivalent for that one cell, immediately ended). Clear `pressRef`.
+- `touchcancel` (new): clear `pressRef`, end any active stroke.
+
+### Scroll suppression while painting
+
+`touch-action` can't change the behaviour of an already-started gesture, so the fix is a **non-passive** `touchmove` listener attached imperatively to the scroll-container element via `ref` + `addEventListener('touchmove', handler, { passive: false })` in a `useEffect`. The handler:
+
+- while a press is *pending*: applies the slop check above (no `preventDefault` — scrolling must stay native);
+- while a stroke is *active*: calls `e.preventDefault()` (now effective) and extends the stroke via the existing `elementFromPoint` → `[data-cell]` lookup.
+
+The current React `onTouchMove={onGridTouchMove}` prop is removed (it's the broken passive path).
+
+### Long-press side effects to suppress
+
+- `contextmenu` on the grid container: `preventDefault` while a press/stroke is live (Android long-press menu).
+- Add `[-webkit-touch-callout:none]` on cells alongside the existing `select-none` (iOS callout).
+
+### What doesn't change
+
+- Desktop mouse handlers, brush model, `strokeValueFor` toggle semantics, day/hour fill buttons (plain `onClick` — already touch-safe), save flow, grid markup and styling (aside from the callout utility), `touch-pan-x` (still correct for the not-painting case).
+
+## Error handling / edge cases
+
+- Multi-touch (pinch) during a pending press → cancel the press.
+- Timer must be cleared on unmount and on `touchend`/`touchcancel` (no stray paints after release).
+- `navigator.vibrate` is feature-detected; absence (iOS Safari) is fine — the visual paint of the origin cell is the arming cue there.
+- Stroke lifecycle stays on the existing window `touchend` listener; `touchcancel` is added beside it.
+
+## Testing
+
+- `npm run lint` in `web/` (the merge gate; no test runner in this repo).
+- Manual verification via Chrome DevTools touch emulation against the dev server: (a) horizontal + vertical swipes starting on painted and empty cells change nothing; (b) hold-then-drag paints a run of cells without the container panning; (c) quick tap toggles exactly one cell; (d) mouse click + drag behave exactly as before.

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -354,6 +354,12 @@ export default function TaggingPanel(p: TaggingPanelProps) {
   // analysis-state bits (vocalStatus) stay coverage-driven.
   const vocalOptedIn = p.vocalEnabled ?? vocalWanted;
   const vocalOn = (vocalAnalyzed ?? 0) > 0;
+  // Whether ANY tagging/analysis work has ever landed. On a completely virgin
+  // library the honest affordance is the primary Start-tagging run, so the
+  // per-dimension Backfill buttons stay hidden until there's an actual gap to
+  // fill (some work done, this dimension behind) instead of sitting next to a
+  // 0-of-N meter looking like a duplicate of the modal's "Analyze acoustics".
+  const anyWorkDone = (tagged ?? 0) > 0 || (analysed ?? 0) > 0 || audioOn || vocalOn;
   const remaining = total != null && tagged != null ? Math.max(0, total - tagged) : null;
   const running = !!p.tagger?.running;
   // The first library count (walking Navidrome for a total) is in flight — size
@@ -605,7 +611,9 @@ export default function TaggingPanel(p: TaggingPanelProps) {
       {/* acoustic & audio coverage — status meter on each row, plus the controls
           that change it: bpm/key is always-on (engine permitting); sounds-like
           (CLAP) and vocal (Demucs) are opt-in, so they carry Enable/Disable + a
-          contextual Backfill (shown only while enabled, capable, and < 100%). */}
+          contextual Backfill (shown only while enabled, capable, < 100%, and the
+          library has SOME work done — on a virgin library the primary
+          Start-tagging run is the one entry point). */}
       <div className="flex flex-col gap-3 border-b border-ink px-6 py-4">
         <div className="flex flex-wrap items-center gap-x-3.5 gap-y-2">
           <span className="caption flex items-center gap-2">
@@ -666,7 +674,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
           </span>
           {!analysisOff && (
             <span className="ml-auto flex items-center gap-2">
-              {p.audioEnabled && canBackfill(audioStatus) && (
+              {p.audioEnabled && anyWorkDone && canBackfill(audioStatus) && (
                 <Btn
                   sm
                   tone="accent"
@@ -674,7 +682,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
                   disabled={p.busy || running}
                   title="Fingerprint the tracks still missing a “sounds-like” vector — without redoing bpm/key."
                 >
-                  <Play size={12} /> {audioOn ? 'Backfill' : 'Analyze'}
+                  <Play size={12} /> Backfill
                 </Btn>
               )}
               <Btn
@@ -739,7 +747,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
                 </span>
                 {!analysisOff && (
                   <span className="ml-auto flex items-center gap-2">
-                    {canBackfill(vocalStatus) && (
+                    {anyWorkDone && canBackfill(vocalStatus) && (
                       <Btn
                         sm
                         tone="accent"
@@ -747,7 +755,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
                         disabled={p.busy || running}
                         title="Separate vocals for the tracks still missing it — without redoing bpm/key."
                       >
-                        <Play size={12} /> {vocalOn ? 'Backfill' : 'Analyze'}
+                        <Play size={12} /> Backfill
                       </Btn>
                     )}
                     <Btn

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -10,9 +10,11 @@
 // Shows are created/edited through an in-page editor (ShowEditor, below the
 // show list) — the personas pattern: click a show to open it, edit it in place.
 // The weekly grid is drag-paintable: pick a brush, then click-drag across
-// cells; click a day label or hour header to fill a whole row/column.
+// cells; click a day label or hour header to fill a whole row/column. On
+// touch, a tap toggles one cell and a long-press arms drag-painting — a
+// plain swipe only scrolls (see HOLD_MS below).
 import type { ChangeEvent, RefObject, TouchEvent } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { useDynamicStyle } from '../../hooks/useDynamicStyle';
 import { notify, errorMessage } from '../../lib/notify';
@@ -44,6 +46,13 @@ const DAYS = [
   { key: 0, label: 'Sun' },
 ];
 const HOURS = Array.from({ length: 24 }, (_, h) => h);
+
+// Touch paint gesture: holding a cell this long (without drifting past the
+// slop) arms a paint stroke; releasing earlier is a tap (single-cell toggle,
+// committed on release); drifting past the slop first is a scroll and paints
+// nothing. Mouse painting is immediate and unaffected.
+const HOLD_MS = 300;
+const PRESS_SLOP_PX = 8;
 
 const SHOW_COLORS = [
   '#c5302a', '#2f6f4f', '#3a5fa8', '#9a5b1f', '#6b4a8a', '#1f7a7a',
@@ -270,6 +279,19 @@ export default function ShowsPanel() {
     active: false,
     value: undefined,
   });
+  // Pending touch press — a finger is down on a cell but the gesture hasn't
+  // resolved yet into tap (release early), paint (hold HOLD_MS) or scroll
+  // (drift past PRESS_SLOP_PX). Nothing is painted until it resolves, so a
+  // scroll that merely starts on a cell can never toggle it.
+  const pressRef = useRef<{
+    day: number; hour: number; x: number; y: number;
+    timer: ReturnType<typeof setTimeout>;
+  } | null>(null);
+  // Detach for the grid's non-passive touchmove listener (set by the callback
+  // ref below when the grid mounts/unmounts).
+  const gridTouchMoveCleanup = useRef<(() => void) | null>(null);
+  // Latest extendStroke for the once-attached touchmove listener.
+  const extendStrokeRef = useRef<(day: number, hour: number) => void>(() => {});
 
   // Live clock — the grid highlights the cell the station is in right now.
   useEffect(() => {
@@ -283,14 +305,23 @@ export default function ShowsPanel() {
   const stationLocale = normalizeStationLocale(data?.values?.locale);
   const { dow: nowDay, hour: nowHour } = zonedDayHour(now, stationTz);
 
-  // End any drag-paint stroke when the pointer is released anywhere.
+  // End any drag-paint stroke when the pointer is released anywhere. A
+  // touchcancel (OS took the gesture — notification shade, browser nav) also
+  // discards any pending press so no stray paint lands after the fact.
   useEffect(() => {
     const end = () => { strokeRef.current.active = false; };
+    const cancel = () => {
+      strokeRef.current.active = false;
+      if (pressRef.current) { clearTimeout(pressRef.current.timer); pressRef.current = null; }
+    };
     window.addEventListener('mouseup', end);
     window.addEventListener('touchend', end);
+    window.addEventListener('touchcancel', cancel);
     return () => {
       window.removeEventListener('mouseup', end);
       window.removeEventListener('touchend', end);
+      window.removeEventListener('touchcancel', cancel);
+      cancel();
     };
   }, []);
 
@@ -517,18 +548,76 @@ export default function ShowsPanel() {
   };
   const clearWeek = () => setForm(f => f ? ({ ...f, schedule: emptyWeek() }) : f);
 
-  // Touch drag — translate the moving touch point into a grid cell.
-  const onGridTouchMove = (e: TouchEvent<HTMLDivElement>) => {
-    if (!strokeRef.current.active) return;
+  // ── touch paint (long-press to arm; see HOLD_MS above) ──────────────────
+  const clearPress = () => {
+    if (pressRef.current) { clearTimeout(pressRef.current.timer); pressRef.current = null; }
+  };
+  // Finger down on a cell: don't paint yet — start the hold timer. If it
+  // fires (finger still down, within slop) the stroke arms from this cell and
+  // the touchmove listener below takes over.
+  const onCellTouchStart = (day: number, hour: number, e: TouchEvent<HTMLButtonElement>) => {
+    clearPress();
+    if (brush == null || e.touches.length > 1) return;
     const t = e.touches[0];
     if (!t) return;
-    const el = document.elementFromPoint(t.clientX, t.clientY);
-    const cell = el?.closest?.('[data-cell]') as HTMLElement | null;
-    if (cell) {
-      e.preventDefault();
-      extendStroke(Number(cell.dataset.day), Number(cell.dataset.hour));
+    const timer = setTimeout(() => {
+      pressRef.current = null;
+      beginStroke(day, hour);
+      navigator.vibrate?.(10);
+    }, HOLD_MS);
+    pressRef.current = { day, hour, x: t.clientX, y: t.clientY, timer };
+  };
+  // Finger up before the hold timer fired and without drifting → a tap:
+  // toggle just that cell, committed on release so scrolls never toggle.
+  // preventDefault() stops the browser's compatibility mousedown that follows
+  // touchend — it would re-enter beginStroke and toggle the cell right back.
+  const onCellTouchEnd = (e: TouchEvent<HTMLButtonElement>) => {
+    const press = pressRef.current;
+    if (press) {
+      clearPress();
+      if (e.cancelable) e.preventDefault();
+      beginStroke(press.day, press.hour);
+      strokeRef.current.active = false;
+    } else if (strokeRef.current.active) {
+      // End of a long-press paint stroke — same synthetic-mouse suppression;
+      // the window touchend listener clears the stroke itself.
+      if (e.cancelable) e.preventDefault();
     }
   };
+  extendStrokeRef.current = extendStroke;
+  // Touch drag — translate the moving touch point into a grid cell. Attached
+  // imperatively with passive:false because React registers root touchmove
+  // listeners passively, which silently ignores preventDefault() — the pan
+  // and the paint used to run at once, spraying cells while scrolling. A
+  // callback ref (not an effect) because the grid only mounts once /settings
+  // has loaded. The handler reads refs only, so the [] memo is safe.
+  const gridScrollRef = useCallback((el: HTMLDivElement | null) => {
+    gridTouchMoveCleanup.current?.();
+    gridTouchMoveCleanup.current = null;
+    if (!el) return;
+    const onMove = (e: globalThis.TouchEvent) => {
+      const t = e.touches[0];
+      const press = pressRef.current;
+      if (press) {
+        // Still deciding: a drift past the slop means it's a scroll — drop
+        // the press and let the browser pan natively (no preventDefault).
+        if (!t || e.touches.length > 1
+          || Math.abs(t.clientX - press.x) > PRESS_SLOP_PX
+          || Math.abs(t.clientY - press.y) > PRESS_SLOP_PX) {
+          clearTimeout(press.timer);
+          pressRef.current = null;
+        }
+        return;
+      }
+      if (!strokeRef.current.active || !t) return;
+      e.preventDefault(); // stroke armed: suppress the pan, paint instead
+      const cell = document.elementFromPoint(t.clientX, t.clientY)
+        ?.closest?.('[data-cell]') as HTMLElement | null;
+      if (cell) extendStrokeRef.current(Number(cell.dataset.day), Number(cell.dataset.hour));
+    };
+    el.addEventListener('touchmove', onMove, { passive: false });
+    gridTouchMoveCleanup.current = () => el.removeEventListener('touchmove', onMove);
+  }, []);
 
   // ── validation ───────────────────────────────────────────────────────────
   const allShowsOk = form ? form.shows.every(showValid) : false;
@@ -704,8 +793,13 @@ export default function ShowsPanel() {
         </div>
 
         <div
+          ref={gridScrollRef}
           className="overflow-x-auto"
-          onTouchMove={onGridTouchMove}
+          onContextMenu={e => {
+            // Long-press opens the context menu on Android — swallow it while
+            // a press is resolving or a stroke is being painted.
+            if (pressRef.current || strokeRef.current.active) e.preventDefault();
+          }}
         >
           <div className="grid min-w-[760px] touch-pan-x grid-cols-[44px_repeat(24,minmax(28px,1fr))] gap-0 select-none">
             <span />
@@ -738,6 +832,8 @@ export default function ShowsPanel() {
                 fillDay={fillDay}
                 beginStroke={beginStroke}
                 extendStroke={extendStroke}
+                onCellTouchStart={onCellTouchStart}
+                onCellTouchEnd={onCellTouchEnd}
                 showById={showById}
                 colorOf={colorOf}
               />
@@ -759,10 +855,12 @@ export default function ShowsPanel() {
         </div>
 
         <p className="mt-2.5 text-[11px] leading-[1.5] text-muted">
-          Pick a brush, then <b>click or drag</b> across cells to paint. Click a
-          {' '}<b>day name</b> to fill that day, or an <b>hour</b> to fill that hour
-          {' '}across the week. Painting over a matching cell clears it. The
-          {' '}vermilion-ringed cell is the hour on air.
+          Pick a brush, then <b>click or drag</b> across cells to paint — on a
+          {' '}touch screen, <b>tap</b> a cell or <b>hold it</b> a moment to start
+          {' '}painting (a quick swipe just scrolls). Click a <b>day name</b> to
+          {' '}fill that day, or an <b>hour</b> to fill that hour across the week.
+          {' '}Painting over a matching cell clears it. The vermilion-ringed cell
+          {' '}is the hour on air.
         </p>
       </Card>
 
@@ -1279,13 +1377,16 @@ interface DayRowProps {
   fillDay: (day: number) => void;
   beginStroke: (day: number, hour: number) => void;
   extendStroke: (day: number, hour: number) => void;
+  onCellTouchStart: (day: number, hour: number, e: TouchEvent<HTMLButtonElement>) => void;
+  onCellTouchEnd: (e: TouchEvent<HTMLButtonElement>) => void;
   showById: (id: string | null | undefined) => Show | null;
   colorOf: (id: string | null | undefined) => string;
 }
 
 function DayRow({
   dayKey, label, brush, form, nowDay, nowHour,
-  fillDay, beginStroke, extendStroke, showById, colorOf,
+  fillDay, beginStroke, extendStroke, onCellTouchStart, onCellTouchEnd,
+  showById, colorOf,
 }: DayRowProps) {
   return (
     <>
@@ -1317,7 +1418,8 @@ function DayRow({
             brush={brush}
             onMouseDown={() => beginStroke(dayKey, h)}
             onMouseEnter={() => extendStroke(dayKey, h)}
-            onTouchStart={() => beginStroke(dayKey, h)}
+            onTouchStart={e => onCellTouchStart(dayKey, h, e)}
+            onTouchEnd={onCellTouchEnd}
           />
         );
       })}
@@ -1335,12 +1437,13 @@ interface GridCellProps {
   brush: string | 'erase' | null;
   onMouseDown: () => void;
   onMouseEnter: () => void;
-  onTouchStart: () => void;
+  onTouchStart: (e: TouchEvent<HTMLButtonElement>) => void;
+  onTouchEnd: (e: TouchEvent<HTMLButtonElement>) => void;
 }
 
 function GridCell({
   day, hour, label, show, color, isNow, brush,
-  onMouseDown, onMouseEnter, onTouchStart,
+  onMouseDown, onMouseEnter, onTouchStart, onTouchEnd,
 }: GridCellProps) {
   const cellRef = useRef<HTMLButtonElement>(null);
   useDynamicStyle(cellRef, {
@@ -1356,12 +1459,13 @@ function GridCell({
       onMouseDown={onMouseDown}
       onMouseEnter={onMouseEnter}
       onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
       title={
         (show ? `${show.name} (${show.mood})` : `${label} ${String(hour).padStart(2, '0')}:00, empty`)
         + (isNow ? ' · on air now' : '')
       }
       className={cn(
-        'relative -mt-px -ml-px flex h-8 items-center justify-center border border-separator-strong p-0 font-[inherit] text-[9px] font-bold tracking-[0.15em] uppercase',
+        'relative -mt-px -ml-px flex h-8 items-center justify-center border border-separator-strong p-0 font-[inherit] text-[9px] font-bold tracking-[0.15em] uppercase [-webkit-touch-callout:none]',
         show ? 'text-white' : 'text-muted',
         brush == null ? 'cursor-default' : 'cursor-pointer',
       )}


### PR DESCRIPTION
## Problem

The weekly schedule paint grid at `/admin/shows` was unreliable on touch screens — scrolling the grid left/right kept accidentally toggling cells.

Two root causes in `ShowsPanel.tsx`:

1. **Cells painted on `touchstart`** — the instant a finger landed, before the browser could know whether the gesture was a scroll or a paint. Every scroll that began on a cell flipped it.
2. **`preventDefault()` in the touch-drag handler was a no-op** — React 17+ attaches root `touchmove` listeners passively, so while drag-painting the container also panned (`touch-pan-x`), cells slid under the finger, and `elementFromPoint` painted stray cells.

Plus no `touchcancel` handling, so an OS-interrupted gesture could leave a stroke armed.

## Fix

Each touch now resolves into exactly one of three gestures before anything is painted:

- **Swipe** (drifts past an 8px slop before the hold delay) → scrolls natively, paints nothing.
- **Hold ~300ms** (haptic tick where supported) → arms a paint stroke, suppresses the pan via a **non-passive** `touchmove` listener (attached with a callback ref, since the grid mounts only after `/settings` loads), and drag-paints exactly as before.
- **Quick tap** → toggles that one cell, committed **on release** — so a scroll can never toggle.

Also:
- `preventDefault()` on `touchend` swallows the browser's compatibility `mousedown` that would otherwise re-enter `beginStroke` and immediately un-toggle a tapped cell.
- `touchcancel` discards pending presses and ends strokes.
- Android long-press context menu and iOS touch callout suppressed while a press/stroke is live.
- Grid help text updated to describe the touch gestures.

**Desktop mouse painting is unchanged** (mousedown paints, drag extends — same as before).

Design spec: `docs/superpowers/specs/2026-07-02-shows-grid-touch-paint-design.md`

## Testing

- `npm run lint` (eslint + tsc) passes in `web/`.
- Not yet exercised on a real touch device — worth a quick phone check of: swipe scrolls without toggling, tap toggles one cell, hold-then-drag paints a run, desktop click-drag unchanged.