### PR TITLE
feat(audio): configurable loudness target + peak-aware asymmetric gain clamp

### DIFF
--- a/controller/scripts/mix-fx.test.ts
+++ b/controller/scripts/mix-fx.test.ts
@@ -8,8 +8,11 @@ import {
   washoutCrossSecondsFor,
   washoutDelayFor,
   effectAllowedFor,
+  gainForLoudness,
   WASHOUT_CROSS_TARGET_SECONDS,
   CROSS_MAX_SECONDS,
+  LOUDNESS_MAX_BOOST_DB,
+  LOUDNESS_CUT_CLAMP_DB,
 } from '../src/music/mix.js';
 
 let failures = 0;
@@ -114,6 +117,58 @@ async function main() {
   await test('washout is never data-gated (cooldown rations it)', () => {
     assert.equal(effectAllowedFor('washout', { bpm: 124, key: '8A' }, { bpm: 124, key: '8A' }), true);
     assert.equal(effectAllowedFor('washout', { bpm: null, key: null }, { bpm: null, key: null }), true);
+  });
+
+  console.log('gainForLoudness (asymmetric clamp, peak headroom, operator overrides):');
+
+  await test('no measurement → null (unity gain, pre-feature behaviour)', () => {
+    assert.equal(gainForLoudness(null), null);
+    assert.equal(gainForLoudness(undefined), null);
+    assert.equal(gainForLoudness(NaN), null);
+  });
+
+  await test('within-cap gains are the exact target distance', () => {
+    assert.equal(gainForLoudness(-18), 4);    // quiet → +4 toward −14
+    assert.equal(gainForLoudness(-10), -4);   // loud → −4
+    assert.equal(gainForLoudness(-14), 0);    // on target → 0
+  });
+
+  await test('boost capped at the default max, cut gets the wider clamp', () => {
+    // −28 LUFS wants +14 → capped at the default +6.
+    assert.equal(gainForLoudness(-28), LOUDNESS_MAX_BOOST_DB);
+    // −4 LUFS wants −10 → allowed (cut clamp is 12, not 6).
+    assert.equal(gainForLoudness(-4), -10);
+    // Absurdly loud still stops at the cut clamp.
+    assert.equal(gainForLoudness(0), -LOUDNESS_CUT_CLAMP_DB);
+  });
+
+  await test('measured peak headroom caps the boost below the operator max', () => {
+    // −28 LUFS, peak −4 dBFS → headroom to the −1 ceiling is 3 dB < cap 9.
+    assert.equal(gainForLoudness(-28, { peakDb: -4, maxBoostDb: 9 }), 3);
+    // Peak already at/above the ceiling → no boost at all (never negative).
+    assert.equal(gainForLoudness(-20, { peakDb: -0.5 }), 0);
+    // Plenty of headroom → the operator max is what bites.
+    assert.equal(gainForLoudness(-28, { peakDb: -20, maxBoostDb: 9 }), 9);
+  });
+
+  await test('peak never limits the cut direction', () => {
+    // Loud track with peaks at the ceiling still gets turned down.
+    assert.equal(gainForLoudness(-8, { peakDb: -0.1 }), -6);
+  });
+
+  await test('operator target and boost-cap overrides apply', () => {
+    assert.equal(gainForLoudness(-20, { targetLufs: -16 }), 4);
+    assert.equal(gainForLoudness(-10, { targetLufs: -16 }), -6);
+    assert.equal(gainForLoudness(-28, { maxBoostDb: 12 }), 12);
+    // maxBoostDb 0 = cut-only levelling.
+    assert.equal(gainForLoudness(-28, { maxBoostDb: 0 }), 0);
+    // Junk overrides fall back to the defaults.
+    assert.equal(gainForLoudness(-28, { targetLufs: NaN, maxBoostDb: -3 }), LOUDNESS_MAX_BOOST_DB);
+  });
+
+  await test('rounded to 0.1 dB', () => {
+    assert.equal(gainForLoudness(-15.55), 1.6);
+    assert.equal(gainForLoudness(-13.333), -0.7);
   });
 
   if (failures > 0) {

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -406,15 +406,27 @@ class Queue {
     return { bpm: rec?.bpm ?? null, key: rec?.musicalKey ?? null };
   }
 
-  // Resolve a track's integrated loudness (track object first, else a library
-  // lookup) and stash a clamped gain offset toward the loudness target on the
-  // track as `gainDb`. Null measurement → leaves gainDb undefined, so
-  // getAnnotatedUri emits no liq_amplify and the track plays at unity gain.
+  // Resolve a track's integrated loudness + measured peak (track object first,
+  // else a library lookup) and stash a clamped gain offset toward the
+  // operator's loudness target on the track as `gainDb`. The peak lets
+  // gainForLoudness cap the boost by real headroom instead of a blind clamp.
+  // Null measurement → leaves gainDb undefined, so getAnnotatedUri emits no
+  // liq_amplify and the track plays at unity gain.
   applyLoudnessGain(track: any) {
     if (!track) return;
     let lufs = track.loudnessLufs;
-    if (lufs == null && track.id) lufs = library.get(track.id)?.loudnessLufs ?? null;
-    const gain = mix.gainForLoudness(lufs);
+    let peakDb = track.peakDb;
+    if ((lufs == null || peakDb == null) && track.id) {
+      const rec = library.get(track.id);
+      if (lufs == null) lufs = rec?.loudnessLufs ?? null;
+      if (peakDb == null) peakDb = rec?.peakDb ?? null;
+    }
+    const loud = settings.get().loudness;
+    const gain = mix.gainForLoudness(lufs, {
+      peakDb,
+      targetLufs: loud?.targetLufs,
+      maxBoostDb: loud?.maxBoostDb,
+    });
     if (gain != null) track.gainDb = gain;
   }
 

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -73,6 +73,12 @@ export function get(songId: string): any {
     bpm: t.bpm,
     musicalKey: t.musicalKey,
     introMs: t.introMs,
+    // Loudness surface for queue.applyLoudnessGain's library-lookup fallback —
+    // Subsonic-sourced picks (requests, similar-songs) resolve their measured
+    // LUFS/peak through here. Without these the fallback always saw null and
+    // those tracks played at unity gain.
+    loudnessLufs: t.loudnessLufs,
+    peakDb: t.peakDb,
     // Phase 2/4 acoustic surface for the agent picker's Subsonic-fallback path
     // (slim() in llm/tools.ts). Library-sourced candidates already carry these
     // via slimTrack; this keeps Subsonic-sourced candidates symmetric.

--- a/controller/src/music/mix.ts
+++ b/controller/src/music/mix.ts
@@ -15,22 +15,51 @@ export interface Analysis {
 }
 
 // --- Loudness normalisation ------------------------------------------------
-// Target integrated loudness; streaming-standard −14 LUFS (Spotify, YouTube).
-// Gain is clamped to ±LOUDNESS_GAIN_CLAMP_DB so a mis-measured
-// outlier can't blow up the mix — Liquidsoap's brick-wall limiter still backs
-// us up, but the clamp keeps us well clear of it on normal catalogue audio.
+// Target integrated loudness; streaming-standard −14 LUFS (Spotify, YouTube)
+// by default, operator-tunable via settings.loudness. The two directions are
+// clamped asymmetrically because they carry different risk: cutting a loud
+// track is always safe (wide fixed clamp), while boosting a quiet one can
+// drive high-crest material (classical, jazz) into the broadcast limiter — so
+// the boost is capped by the operator's maxBoostDb AND by the track's own
+// measured peak headroom when the analyzer has one.
 export const LOUDNESS_TARGET_LUFS = -14;
-export const LOUDNESS_GAIN_CLAMP_DB = 6;
+export const LOUDNESS_MAX_BOOST_DB = 6;
+export const LOUDNESS_CUT_CLAMP_DB = 12;
+// Boost never pushes the measured sample peak past this ceiling — it matches
+// the brick-wall limiter threshold (−1 dBFS in radio.liq) so normal catalogue
+// audio stays clear of it. Peak is measured over the analysis window (~the
+// first 2 min), not the whole file, so the limiter remains the backstop for
+// peaks later in the track.
+export const LOUDNESS_PEAK_CEILING_DBFS = -1;
 
 // dB gain to bring a track measured at `lufs` toward the target, clamped.
 // Returns null when the track has no loudness measurement (→ unity gain on the
 // playback side, i.e. today's behaviour). Result is rounded to 0.1 dB — finer
 // is inaudible and just bloats the annotate string.
-export function gainForLoudness(lufs: number | null | undefined): number | null {
+export function gainForLoudness(
+  lufs: number | null | undefined,
+  opts: { peakDb?: number | null; targetLufs?: number | null; maxBoostDb?: number | null } = {},
+): number | null {
   if (typeof lufs !== 'number' || !Number.isFinite(lufs)) return null;
-  const raw = LOUDNESS_TARGET_LUFS - lufs;
-  const clamped = Math.max(-LOUDNESS_GAIN_CLAMP_DB, Math.min(LOUDNESS_GAIN_CLAMP_DB, raw));
-  return Math.round(clamped * 10) / 10;
+  const target =
+    typeof opts.targetLufs === 'number' && Number.isFinite(opts.targetLufs)
+      ? opts.targetLufs
+      : LOUDNESS_TARGET_LUFS;
+  const maxBoost =
+    typeof opts.maxBoostDb === 'number' && Number.isFinite(opts.maxBoostDb) && opts.maxBoostDb >= 0
+      ? opts.maxBoostDb
+      : LOUDNESS_MAX_BOOST_DB;
+  const raw = target - lufs;
+  let gain: number;
+  if (raw > 0) {
+    gain = Math.min(raw, maxBoost);
+    if (typeof opts.peakDb === 'number' && Number.isFinite(opts.peakDb)) {
+      gain = Math.min(gain, Math.max(0, LOUDNESS_PEAK_CEILING_DBFS - opts.peakDb));
+    }
+  } else {
+    gain = Math.max(raw, -LOUDNESS_CUT_CLAMP_DB);
+  }
+  return Math.round(gain * 10) / 10;
 }
 
 // True when a track carries at least one measured value. An un-analysed track

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -90,6 +90,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
         minTrackSeconds: settings.minTrackSeconds(s),
         archive: s.archive,
         stream: s.stream,
+        loudness: s.loudness,
         station: s.station,
         timezone: s.timezone,
         locale: s.locale,

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -702,6 +702,16 @@ const DEFAULTS = {
     aacBitrate: 192,
     bitrate: 192,
   },
+  // Per-track loudness normalisation (music/mix.ts gainForLoudness). targetLufs
+  // is what every measured track is pulled toward; maxBoostDb caps the upward
+  // direction only — cuts have a fixed wide clamp, and the boost is further
+  // limited by the track's own measured peak headroom, so widening this on a
+  // dynamic library won't slam the broadcast limiter. Read live per track at
+  // annotate time; no mixer restart.
+  loudness: {
+    targetLufs: -14,
+    maxBoostDb: 6,
+  },
   weather: { lat: 30.7333, lng: 76.7794, locationName: 'Punjab', units: 'metric' as 'metric' | 'imperial' },
   // Operator-facing station name. Substituted into the DJ prompt's {station}
   // placeholder and returned by GET /dj for the landing page. The product is
@@ -1052,6 +1062,11 @@ const BOUNDS = {
   // 0 = off; 36000 s (10h) is a generous ceiling that still leaves room for
   // long-form mix shows without letting a typo set an absurd value.
   maxTrackSeconds: { min: 0, max: 36000, type: 'int' },
+  // −23 (EBU R128 broadcast) … −9 (very loud); −14 is the streaming standard.
+  loudnessTargetLufs: { min: -23, max: -9, type: 'float' },
+  // 0 disables boosting entirely (cut-only levelling); 12 dB is plenty — the
+  // per-track peak headroom cap bites long before that on dynamic material.
+  loudnessMaxBoostDb: { min: 0, max: 12, type: 'float' },
 };
 
 const MP3_BITRATE_SET = new Set<number>(MP3_BITRATES);
@@ -1351,6 +1366,20 @@ export async function load() {
         typeof stored.stream?.bitrate === 'number' && MP3_BITRATE_SET.has(stored.stream.bitrate)
           ? stored.stream.bitrate
           : DEFAULTS.stream.bitrate,
+    },
+    loudness: {
+      targetLufs:
+        typeof stored.loudness?.targetLufs === 'number' &&
+        stored.loudness.targetLufs >= BOUNDS.loudnessTargetLufs.min &&
+        stored.loudness.targetLufs <= BOUNDS.loudnessTargetLufs.max
+          ? stored.loudness.targetLufs
+          : DEFAULTS.loudness.targetLufs,
+      maxBoostDb:
+        typeof stored.loudness?.maxBoostDb === 'number' &&
+        stored.loudness.maxBoostDb >= BOUNDS.loudnessMaxBoostDb.min &&
+        stored.loudness.maxBoostDb <= BOUNDS.loudnessMaxBoostDb.max
+          ? stored.loudness.maxBoostDb
+          : DEFAULTS.loudness.maxBoostDb,
     },
     weather: {
       lat: stored.weather?.lat ?? DEFAULTS.weather.lat,
@@ -2248,6 +2277,27 @@ export async function update(patch) {
         next.stream.bitrate = v;
         restart = true;
       }
+    }
+  }
+  if ('loudness' in patch) {
+    // Read live by queue.applyLoudnessGain when each track is annotated — no
+    // Liquidsoap file, no restart. Applies from the next queued track.
+    const lo = patch.loudness || {};
+    if (lo.targetLufs !== undefined) {
+      const v = parseFloat(lo.targetLufs);
+      const b = BOUNDS.loudnessTargetLufs;
+      if (!Number.isFinite(v) || v < b.min || v > b.max) {
+        throw new Error(`loudness.targetLufs must be number in [${b.min}, ${b.max}]`);
+      }
+      next.loudness.targetLufs = v;
+    }
+    if (lo.maxBoostDb !== undefined) {
+      const v = parseFloat(lo.maxBoostDb);
+      const b = BOUNDS.loudnessMaxBoostDb;
+      if (!Number.isFinite(v) || v < b.min || v > b.max) {
+        throw new Error(`loudness.maxBoostDb must be number in [${b.min}, ${b.max}]`);
+      }
+      next.loudness.maxBoostDb = v;
     }
   }
   if ('weather' in patch) {

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -224,6 +224,11 @@ interface StreamForm {
   bitrate: string;
 }
 
+interface LoudnessForm {
+  targetLufs: string;
+  maxBoostDb: string;
+}
+
 // Keep in sync with MP3_BITRATES in controller/src/settings.ts — radio.liq
 // has a literal `%mp3(bitrate=…)` branch per value, so this set is fixed.
 const MP3_BITRATES = [64, 96, 128, 160, 192, 320] as const;
@@ -237,6 +242,7 @@ interface FormState {
   maxTrackSeconds: string;
   archive: ArchiveForm;
   stream: StreamForm;
+  loudness: LoudnessForm;
   station: string;
   timezone: string;
   locale: StationLocale;
@@ -286,6 +292,7 @@ interface SettingsData {
       aacBitrate?: number;
       bitrate?: number;
     };
+    loudness?: { targetLufs?: number; maxBoostDb?: number };
     station?: string;
     timezone?: string;
     locale?: StationLocale;
@@ -436,6 +443,10 @@ export default function SettingsPanel() {
         aacEnabled: v.stream?.aacEnabled ?? false,
         aacBitrate: String(v.stream?.aacBitrate ?? 192),
         bitrate: String(v.stream?.bitrate ?? 192),
+      },
+      loudness: {
+        targetLufs: String(v.loudness?.targetLufs ?? -14),
+        maxBoostDb: String(v.loudness?.maxBoostDb ?? 6),
       },
       station: v.station ?? '',
       timezone: v.timezone ?? '',
@@ -1028,6 +1039,79 @@ export default function SettingsPanel() {
                     album mixes or DJ sets that keep landing in rotation. Listener requests still
                     play any length, and a show can override this with its own limit (0 there means
                     unlimited). Applies on the next pick; no restart needed.
+                  </div>
+                </div>
+              </Card>
+            )}
+
+            {form && (
+              <Card title="Loudness levelling" sub="per-track volume normalisation">
+                <div className="grid gap-3">
+                  <div className="field">
+                    <Label>Target loudness</Label>
+                    <div className="flex items-center gap-2">
+                      <Input
+                        className="mono-num w-28"
+                        type="number"
+                        step={1}
+                        min={-23}
+                        max={-9}
+                        value={form.loudness.targetLufs}
+                        onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                          setForm(f =>
+                            f ? { ...f, loudness: { ...f.loudness, targetLufs: e.target.value } } : f,
+                          )
+                        }
+                      />
+                      <span className="text-[12px] text-muted">LUFS · −23 to −9</span>
+                    </div>
+                    <div className="field-hint">
+                      Every analysed track is pulled toward this level. −14 is the streaming
+                      standard (Spotify, YouTube). A quieter target like −16 narrows the gap in
+                      mixed libraries: loud modern masters come down more, and quiet dynamic ones
+                      (classical, jazz) need less lift to catch up.
+                    </div>
+                  </div>
+                  <div className="field">
+                    <Label>Max boost</Label>
+                    <div className="flex items-center gap-2">
+                      <Input
+                        className="mono-num w-28"
+                        type="number"
+                        step={1}
+                        min={0}
+                        max={12}
+                        value={form.loudness.maxBoostDb}
+                        onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                          setForm(f =>
+                            f ? { ...f, loudness: { ...f.loudness, maxBoostDb: e.target.value } } : f,
+                          )
+                        }
+                      />
+                      <span className="text-[12px] text-muted">dB · 0 to 12</span>
+                      <Btn
+                        sm
+                        onClick={() =>
+                          saveSettings({
+                            loudness: {
+                              targetLufs: parseFloat(form.loudness.targetLufs),
+                              maxBoostDb: parseFloat(form.loudness.maxBoostDb),
+                            },
+                          })
+                        }
+                        disabled={busy}
+                      >
+                        Save loudness
+                      </Btn>
+                    </div>
+                    <div className="field-hint">
+                      Cap on how far a quiet track is turned up (0 = level down only). Boost is
+                      also limited by each track&rsquo;s own measured peak headroom, so raising
+                      this won&rsquo;t distort dynamic material — very quiet, dynamic masters
+                      simply can&rsquo;t reach the target cleanly. Loud tracks are turned down as
+                      far as needed. Applies from the next queued track; no restart, tracks need
+                      acoustic analysis (Library → Analyze).
+                    </div>
                   </div>
                 </div>
               </Card>


### PR DESCRIPTION
Addresses a Discord report: per-track loudness normalisation was pinned to −14 LUFS with a blind symmetric ±6 dB clamp, so quiet-mastered tracks (e.g. a −28 LUFS classical piano piece) only got +6 dB and still played ~8 LU under modern pop — audible volume drops on every transition in a mixed library.

## What changed

**`gainForLoudness` (music/mix.ts) — asymmetric, peak-aware clamp.** The two directions carry different risk, so they're no longer clamped the same:
- **Cut** (loud tracks): widened to a fixed −12 dB — turning down is always safe, and loud modern masters are the other half of the jump problem.
- **Boost** (quiet tracks): capped by the operator's `maxBoostDb` **and** by the track's own measured peak headroom against a −1 dBFS ceiling (matching the broadcast brick-wall limiter). Widening the boost cap therefore can't slam high-crest material (classical, jazz) into the limiter — very quiet dynamic masters get exactly as much lift as their peaks allow. Peak is measured over the analysis window, so the limiter stays the backstop.

**New `settings.loudness` group** — `targetLufs` (−23…−9, default −14) and `maxBoostDb` (0…12, default 6). Validated in `settings.update()`, read live per queued track at annotate time — no mixer restart. For wide-ranging libraries, a −16 target narrows the gap from both ends.

**Admin UI** — a "Loudness levelling" card in the broadcast-control section next to crossfade / max track length.

**Bug fix found while wiring:** `library.get()` never projected `loudnessLufs` (or `peakDb`), so the queue's library-lookup fallback always resolved null — Subsonic-sourced picks (listener requests, similar-songs) silently skipped normalisation entirely. Both fields are now projected.

## Tests

`controller/scripts/mix-fx.test.ts` gains 7 cases: null passthrough, exact within-cap gains, clamp asymmetry, headroom capping (including peak-at-ceiling → 0 boost), cut never peak-limited, operator overrides (incl. junk fallback and `maxBoostDb: 0` = cut-only), 0.1 dB rounding. All pass; `npm run lint` clean in controller and web.