### PR TITLE
feat(tts): add support for kokoro multilingual capabilities

### DIFF
--- a/controller/scripts/kokoro_worker.py
+++ b/controller/scripts/kokoro_worker.py
@@ -60,25 +60,31 @@ def main():
     log("ready")
     emit({"id": None, "ready": True})
 
+    lang_mapping = {
+        "a": "en-us",
+        "b": "en-gb",
+        "e": "es",
+        "i": "it",
+        "f": "fr",
+        "h": "hi",
+        "p": "pt-br",
+        "j": "ja",
+        "z": "cmn",
+    }
+    # EspeakG2P construction isn't free, and there are only a handful of
+    # languages, so build each phonemizer once and reuse it across requests.
+    g2p_cache = {}
+
     def _phonemize(voice_code, lang=None):
-        """Build a language-aware phonemizer. When `lang` is explicitly
+        """Return a cached language-aware phonemizer. When `lang` is explicitly
         provided use it directly (voice timbre, accent preserved); otherwise
         auto-detect from the voice code prefix character."""
-        code_char = voice_code[0]
-        mapping = {
-            "a": "en-us",
-            "b": "en-gb",
-            "e": "es",
-            "i": "it",
-            "f": "fr",
-            "h": "hi",
-            "p": "pt-br",
-            "j": "ja",
-            "z": "cmn",
-        }
-        if not lang or lang not in mapping.values():
-            lang = mapping.get(code_char, "en-gb") # british english fallback
-        g2p = espeak.EspeakG2P(language=lang)
+        if not lang or lang not in lang_mapping.values():
+            lang = lang_mapping.get(voice_code[0], "en-gb")  # british english fallback
+        g2p = g2p_cache.get(lang)
+        if g2p is None:
+            g2p = espeak.EspeakG2P(language=lang)
+            g2p_cache[lang] = g2p
         return g2p
 
 

--- a/controller/scripts/kokoro_worker.py
+++ b/controller/scripts/kokoro_worker.py
@@ -10,8 +10,10 @@ Request:  {"id": "<any>", "text": "...", "voice": "bm_george", "out": "/path/to.
 Response: {"id": "<echoed>", "ok": true,  "path": "/path/to.wav", "duration_s": 3.4}
        |  {"id": "<echoed>", "ok": false, "error": "..."}
 
-`lang` is fixed to "en-gb" for British English — kokoro-onnx picks a phonemizer
-based on this, and the misaki package needs espeak-ng installed in the image.
+`lang` (optional) explicitly overrides the phonemizer language (e.g. "en-gb").
+When provided, the voice's audio/timbre is preserved but the phonemes are
+generated for the given language (e.g. a Japanese voice reading English text).
+When absent, the language is auto-detected from the voice code prefix character.
 """
 
 import json
@@ -41,6 +43,8 @@ def main():
     try:
         from kokoro_onnx import Kokoro
         import soundfile as sf
+        import misaki
+        from misaki import espeak
     except Exception as e:
         emit({"id": None, "ok": False, "fatal": True, "error": f"import failed: {e}"})
         sys.exit(1)
@@ -56,6 +60,28 @@ def main():
     log("ready")
     emit({"id": None, "ready": True})
 
+    def _phonemize(voice_code, lang=None):
+        """Build a language-aware phonemizer. When `lang` is explicitly
+        provided use it directly (voice timbre, accent preserved); otherwise
+        auto-detect from the voice code prefix character."""
+        code_char = voice_code[0]
+        mapping = {
+            "a": "en-us",
+            "b": "en-gb",
+            "e": "es",
+            "i": "it",
+            "f": "fr",
+            "h": "hi",
+            "p": "pt-br",
+            "j": "ja",
+            "z": "cmn",
+        }
+        if not lang or lang not in mapping.values():
+            lang = mapping.get(code_char, "en-gb") # british english fallback
+        g2p = espeak.EspeakG2P(language=lang)
+        return g2p
+
+
     for line in sys.stdin:
         line = line.strip()
         if not line:
@@ -68,14 +94,16 @@ def main():
             if not text:
                 raise ValueError("empty text")
             voice = req.get("voice") or DEFAULT_VOICE
-            lang = req.get("lang") or DEFAULT_LANG
+            lang = (req.get("lang") or "").strip() or None
             speed = float(req.get("speed") or 1.0)
             out = req.get("out")
             if not out:
                 raise ValueError("missing 'out' path")
             Path(out).parent.mkdir(parents=True, exist_ok=True)
 
-            samples, sample_rate = kokoro.create(text, voice=voice, speed=speed, lang=lang)
+            phonemes, _ = _phonemize(voice, lang)(text)
+
+            samples, sample_rate = kokoro.create(phonemes, voice=voice, speed=speed, is_phonemes=True)
             sf.write(out, samples, sample_rate)
 
             duration = float(len(samples)) / float(sample_rate)

--- a/controller/src/audio/kokoro.ts
+++ b/controller/src/audio/kokoro.ts
@@ -153,7 +153,7 @@ async function ensureWorker(): Promise<KokoroWorker> {
 
 export async function speak(
   text: string,
-  { outPath: customPath, voice, speedScale }: { outPath?: string; voice?: string; speedScale?: number } = {},
+  { outPath: customPath, voice, lang, speedScale }: { outPath?: string; voice?: string; lang?: string; speedScale?: number } = {},
 ): Promise<string> {
   if (!text || !text.trim()) throw new Error('Empty TTS text');
   await mkdir(config.piper.outDir, { recursive: true });
@@ -166,7 +166,7 @@ export async function speak(
   const msg = await w.send(id, {
     text: text.trim(),
     voice: voice || config.kokoro.voice,
-    lang: config.kokoro.lang,
+    lang: lang || config.kokoro.lang,
     // Per-call speedScale (daypart energy) composes on top of the config speed.
     speed: config.kokoro.speed * (speedScale != null ? speedScale : 1),
     out: outPath,

--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -116,7 +116,11 @@ async function speakWith(engine: string, text: string, opts: any, personaTts: an
     const voice = (personaTts && personaTts.engine === 'kokoro' && personaTts.voice)
       ? personaTts.voice
       : settings.get().tts?.kokoro?.voice;
-    return kokoro.speak(text, { ...opts, voice });
+    // Station-level language override — explicitly chosen phonemizer lang
+    // (e.g. use a Japanese voice code for the accent but British phonemes for
+    // English text). Absent → falls through to KOKORO_LANG env → auto-detect.
+    const lang = opts.lang || settings.get().tts?.kokoro?.lang || undefined;
+    return kokoro.speak(text, { ...opts, voice, lang });
   }
   if (engine === 'chatterbox') {
     // For chatterbox, persona's `voice` is a reference-WAV filename (resolved
@@ -181,11 +185,12 @@ const PREVIEW_TEXT_MAX = 200;
 const DEFAULT_PREVIEW_TEXT = "You're listening to SUB/WAVE. This is a voice preview.";
 
 export async function synthesizeSample(
-  { engine, voice = '', cloudProvider = 'openai', speed, text }: {
+  { engine, voice = '', cloudProvider = 'openai', speed, lang, text }: {
     engine: string;
     voice?: string;
     cloudProvider?: string;
     speed?: number;
+    lang?: string;
     text?: string;
   },
 ): Promise<string> {
@@ -198,7 +203,7 @@ export async function synthesizeSample(
   const personaTts = { engine, voice, cloudProvider };
   // No outPath → each engine self-generates a WAV path under config.piper.outDir
   // (reaped by cleanupOldVoices) and returns it.
-  return speakWith(engine, sample, { speedScale: scale, language: '', soul: '' }, personaTts);
+  return speakWith(engine, sample, { speedScale: scale, language: '', soul: '', lang }, personaTts);
 }
 
 // Public entry point. Tries the configured engine; on failure, falls back to

--- a/controller/src/config.ts
+++ b/controller/src/config.ts
@@ -89,7 +89,7 @@ export const config = {
     model: process.env.KOKORO_MODEL || '/opt/kokoro/models/kokoro-v1.0.onnx',
     voices: process.env.KOKORO_VOICES || '/opt/kokoro/models/voices-v1.0.bin',
     voice: process.env.KOKORO_VOICE || 'bf_isabella',   // British female, BBC-ish
-    lang: process.env.KOKORO_LANG || 'en-gb',
+    lang: process.env.KOKORO_LANG || '',
     speed: parseFloat(process.env.KOKORO_SPEED || TTS_SPEED),
   },
   // Chatterbox is opt-in: the default controller image does not bundle the

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -123,6 +123,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
         available: tts.availableEngines(),
         kokoroVoices: settings.KOKORO_VOICES,
         kokoroVoiceLanguages: settings.KOKORO_VOICE_LANGUAGES,
+        kokoroLangs: settings.KOKORO_LANGS,
         voiceDir,
         piperVoices,
         chatterboxVoices: customVoices,
@@ -424,10 +425,10 @@ router.post('/settings/secrets/test', requireAdmin, async (req, res) => {
 // POST /settings/tts/preview — synthesize a short sample in an EXPLICIT engine +
 // voice (not the on-air persona) so the admin "Play sample" button can audition
 // a voice/speed before saving. Body: { engine, voice?, cloudProvider?, speed?,
-// text? }. On success streams the rendered WAV (audio/wav). On a synth failure —
-// e.g. the tts-heavy sidecar is down or no cloud key — returns 422 with
-// { ok, message } instead of silently falling back to Piper, so the operator
-// sees why. The temp WAV is unlinked once sent.
+// lang?, text? }. On success streams the rendered WAV (audio/wav). On a synth
+// failure — e.g. the tts-heavy sidecar is down or no cloud key — returns 422
+// with { ok, message } instead of silently falling back to Piper, so the
+// operator sees why. The temp WAV is unlinked once sent.
 // ---------------------------------------------------------------------------
 router.post('/settings/tts/preview', requireAdmin, async (req, res) => {
   const body = req.body || {};
@@ -442,6 +443,7 @@ router.post('/settings/tts/preview', requireAdmin, async (req, res) => {
       voice: typeof body.voice === 'string' ? body.voice : '',
       cloudProvider: typeof body.cloudProvider === 'string' ? body.cloudProvider : 'openai',
       speed: typeof body.speed === 'number' ? body.speed : undefined,
+      lang: typeof body.lang === 'string' ? body.lang : undefined,
       text: typeof body.text === 'string' ? body.text : undefined,
     });
     const buf = await readFile(filePath);

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -121,7 +121,8 @@ router.get('/settings', requireAdmin, async (req, res) => {
       tts: {
         engines: tts.ENGINES,
         available: tts.availableEngines(),
-        kokoroVoices: settings.KOKORO_VOICES_BRITISH,
+        kokoroVoices: settings.KOKORO_VOICES,
+        kokoroVoiceLanguages: settings.KOKORO_VOICE_LANGUAGES,
         voiceDir,
         piperVoices,
         chatterboxVoices: customVoices,

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -499,6 +499,13 @@ export function formatKokoroVoiceLabel(code: string): string {
 }
 
 const KOKORO_VOICE_RE = /^[a-z]{2}_[a-z0-9]+$/;
+
+// Kokoro language override — the set of phonemizer languages the worker accepts
+// (passed through _espeak_code()). Empty string = auto-detect from voice prefix.
+// Synced with the prefix→lang mapping in controller/scripts/kokoro_worker.py.
+export const KOKORO_LANGS = ['en-gb', 'en-us', 'es', 'it', 'fr', 'hi', 'pt-br', 'ja', 'cmn'];
+const KOKORO_LANG_RE = new RegExp(`^(${KOKORO_LANGS.join('|')})$`);
+
 // PocketTTS built-in voices — the curated set the admin UI offers. Issue #213
 // also surfaced zero-shot cloning, so `tts.voice` for pocket-tts may now be
 // either an entry from this list (or another id passing POCKET_TTS_VOICE_RE)
@@ -773,7 +780,7 @@ const DEFAULTS = {
     // is the source of truth. This is purely for the UI to show consistent
     // state and for the CLI to know whether to write COMPOSE_PROFILES.
     heavyEnabled: false,
-    kokoro: { voice: 'bf_isabella' },
+    kokoro: { voice: 'bf_isabella', lang: '' },
     // Global Chatterbox fallback — used as the reference voice when the
     // engine resolves to chatterbox but no persona-level voice is set.
     // Empty filename means "use the model's built-in default voice".
@@ -1437,6 +1444,11 @@ export async function load() {
           KOKORO_VOICE_RE.test(stored.tts.kokoro.voice)
             ? stored.tts.kokoro.voice
             : DEFAULTS.tts.kokoro.voice,
+        lang:
+          typeof stored.tts?.kokoro?.lang === 'string' &&
+          KOKORO_LANG_RE.test(stored.tts.kokoro.lang)
+            ? stored.tts.kokoro.lang
+            : DEFAULTS.tts.kokoro.lang,
       },
       chatterbox: {
         referenceVoice:
@@ -2388,6 +2400,13 @@ export async function update(patch) {
           throw new Error('tts.kokoro.voice must match <lang><gender>_<name>, e.g. bf_isabella');
         }
         next.tts.kokoro.voice = v;
+      }
+      if (k.lang !== undefined) {
+        const v = String(k.lang).trim();
+        if (v && !KOKORO_LANG_RE.test(v)) {
+          throw new Error(`tts.kokoro.lang must be one of: ${KOKORO_LANGS.join(', ')}`);
+        }
+        next.tts.kokoro.lang = v;
       }
     }
     if (t.chatterbox !== undefined) {

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -459,19 +459,44 @@ export const SHOW_MOODS = [
 // tagger's per-track energy classes and the `tracksByMood` agent-tool filter.
 export const SHOW_ENERGY = ['low', 'medium', 'high'];
 
-// British English Kokoro voices — the ones that fit a BBC 6 Music tone. The
-// underlying model ships 54 voices total; we expose only the British subset to
-// keep the UI tidy. Any voice matching KOKORO_VOICE_RE still passes validation.
-export const KOKORO_VOICES_BRITISH = [
-  { id: 'bm_george', label: 'George (M)' },
-  { id: 'bm_fable', label: 'Fable (M)' },
-  { id: 'bm_daniel', label: 'Daniel (M)' },
-  { id: 'bm_lewis', label: 'Lewis (M)' },
-  { id: 'bf_emma', label: 'Emma (F)' },
-  { id: 'bf_isabella', label: 'Isabella (F)' },
-  { id: 'bf_alice', label: 'Alice (F)' },
-  { id: 'bf_lily', label: 'Lily (F)' },
+// All 54 official Kokoro voices from kokoro-onnx v1.0. The UI filters by
+// language prefix and formats display names from the code (bm_george → "George (M)").
+// Any voice matching KOKORO_VOICE_RE passes validation.
+export const KOKORO_VOICES = [
+  'af_alloy', 'af_aoede', 'af_bella', 'af_heart', 'af_jessica', 'af_kore',
+  'af_nicole', 'af_nova', 'af_river', 'af_sarah', 'af_sky',
+  'am_adam', 'am_echo', 'am_eric', 'am_fenrir', 'am_liam', 'am_michael',
+  'am_onyx', 'am_puck', 'am_santa',
+  'bf_alice', 'bf_emma', 'bf_isabella', 'bf_lily',
+  'bm_daniel', 'bm_fable', 'bm_george', 'bm_lewis',
+  'ef_dora', 'em_alex', 'em_santa',
+  'ff_siwis',
+  'hf_alpha', 'hf_beta', 'hm_omega', 'hm_psi',
+  'if_sara', 'im_nicola',
+  'jf_alpha', 'jf_gongitsune', 'jf_nezumi', 'jf_tebukuro', 'jm_kumo',
+  'pf_dora', 'pm_alex', 'pm_santa',
+  'zf_xiaobei', 'zf_xiaoni', 'zf_xiaoxiao', 'zf_xiaoyi',
+  'zm_yunjian', 'zm_yunxi', 'zm_yunxia', 'zm_yunyang',
 ];
+
+export const KOKORO_VOICE_LANGUAGES: Record<string, string> = {
+  'a': 'English (US)',
+  'b': 'English (UK)',
+  'e': 'Spanish',
+  'f': 'French',
+  'h': 'Hindi',
+  'i': 'Italian',
+  'j': 'Japanese',
+  'p': 'Portuguese (Brazilian)',
+  'z': 'Mandarin Chinese',
+};
+
+export function formatKokoroVoiceLabel(code: string): string {
+  const [langGender, name] = code.split('_');
+  const gender = (langGender?.[1] ?? '').toUpperCase();
+  const displayName = name.charAt(0).toUpperCase() + name.slice(1);
+  return `${displayName} (${gender})`;
+}
 
 const KOKORO_VOICE_RE = /^[a-z]{2}_[a-z0-9]+$/;
 // PocketTTS built-in voices — the curated set the admin UI offers. Issue #213

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -491,17 +491,11 @@ export const KOKORO_VOICE_LANGUAGES: Record<string, string> = {
   'z': 'Mandarin Chinese',
 };
 
-export function formatKokoroVoiceLabel(code: string): string {
-  const [langGender, name] = code.split('_');
-  const gender = (langGender?.[1] ?? '').toUpperCase();
-  const displayName = name.charAt(0).toUpperCase() + name.slice(1);
-  return `${displayName} (${gender})`;
-}
-
 const KOKORO_VOICE_RE = /^[a-z]{2}_[a-z0-9]+$/;
 
-// Kokoro language override — the set of phonemizer languages the worker accepts
-// (passed through _espeak_code()). Empty string = auto-detect from voice prefix.
+// Kokoro language override — the set of phonemizer languages the worker accepts.
+// The worker builds an espeak.EspeakG2P for the chosen language (see _phonemize
+// in kokoro_worker.py). Empty string = auto-detect from the voice-code prefix.
 // Synced with the prefix→lang mapping in controller/scripts/kokoro_worker.py.
 export const KOKORO_LANGS = ['en-gb', 'en-us', 'es', 'it', 'fr', 'hi', 'pt-br', 'ja', 'cmn'];
 const KOKORO_LANG_RE = new RegExp(`^(${KOKORO_LANGS.join('|')})$`);

--- a/docker/Dockerfile.controller
+++ b/docker/Dockerfile.controller
@@ -48,7 +48,7 @@ RUN mkdir -p /opt/piper/voices && \
 RUN python3 -m venv /opt/kokoro/venv && \
     /opt/kokoro/venv/bin/pip install --no-cache-dir --upgrade pip && \
     /opt/kokoro/venv/bin/pip install --no-cache-dir \
-      kokoro-onnx==0.4.9 soundfile==0.12.1
+      kokoro-onnx==0.5.0 soundfile==0.12.1 misaki==0.9.4
 
 RUN mkdir -p /opt/kokoro/models && \
     wget -q ${WGET_RETRY} -O /opt/kokoro/models/kokoro-v1.0.onnx \

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -240,6 +240,7 @@ interface FormState {
   station: string;
   timezone: string;
   locale: StationLocale;
+  kokoroLang: string;
   weather: WeatherCfg;
   tts: TtsForm;
   llm: LlmForm;
@@ -293,7 +294,7 @@ interface SettingsData {
     weather?: { lat?: number; lng?: number; locationName?: string; units?: 'metric' | 'imperial' };
     tts?: {
       defaultEngine?: string;
-      kokoro?: { voice?: string };
+      kokoro?: { voice?: string; lang?: string };
       chatterbox?: { referenceVoice?: string };
       pocketTts?: { voice?: string };
       cloud?: Partial<CloudTtsCfg>;
@@ -329,6 +330,7 @@ interface SettingsData {
     available?: Record<string, boolean>;
     kokoroVoices?: string[];
     kokoroVoiceLanguages?: Record<string, string>;
+    kokoroLangs?: string[];
     chatterboxVoices?: string[];
     // `voiceDir` is the new shared name (issue #213). `chatterboxVoiceDir` is
     // kept as an alias so the UI keeps working against older controllers.
@@ -441,6 +443,7 @@ export default function SettingsPanel() {
       station: v.station ?? '',
       timezone: v.timezone ?? '',
       locale: normalizeStationLocale(v.locale),
+      kokoroLang: v.tts?.kokoro?.lang ?? '',
       weather: {
         lat: String(v.weather?.lat ?? ''),
         lng: String(v.weather?.lng ?? ''),
@@ -1777,7 +1780,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
     await saveSettings({
       tts: {
         defaultEngine: form.tts.defaultEngine,
-        kokoro: { voice: form.tts.kokoro?.voice },
+        kokoro: { voice: form.tts.kokoro?.voice, lang: form.kokoroLang },
         chatterbox: { referenceVoice: form.tts.chatterbox?.referenceVoice ?? '' },
         pocketTts: { voice: form.tts.pocketTts?.voice ?? 'alba' },
         cloud: {
@@ -1827,7 +1830,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
   type SavedCloud = { provider?: string; voice?: string; model?: string; baseUrl?: string };
   const savedTts: {
     defaultEngine?: string;
-    kokoro?: { voice?: string };
+    kokoro?: { voice?: string; lang?: string };
     chatterbox?: { referenceVoice?: string };
     pocketTts?: { voice?: string };
     cloud?: SavedCloud;
@@ -1837,6 +1840,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
   } = data.values?.tts || {};
   const savedEngine: string = savedTts.defaultEngine || 'piper';
   const savedKokoroVoice: string = savedTts.kokoro?.voice || '';
+  const savedKokoroLang: string = savedTts.kokoro?.lang || '';
   const savedChatterboxVoice: string = savedTts.chatterbox?.referenceVoice || '';
   const savedPocketTtsVoice: string = savedTts.pocketTts?.voice || '';
   const savedCloud: SavedCloud = savedTts.cloud || {};
@@ -1859,6 +1863,7 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
   const ttsDirty =
     form.tts.defaultEngine !== savedEngine
     || (form.tts.kokoro?.voice || '') !== savedKokoroVoice
+    || (form.kokoroLang || '') !== savedKokoroLang
     || (form.tts.chatterbox?.referenceVoice || '') !== savedChatterboxVoice
     || (form.tts.pocketTts?.voice || '') !== savedPocketTtsVoice
     || form.tts.cloud.provider !== (savedCloud.provider || '')
@@ -2022,11 +2027,32 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                         </SelectContent>
                       </Select>
                     </div>
-                    <div className="field-hint">Applies to every kind routed through Kokoro.</div>
                   </>
                 ) : (
                   <div className="field-hint">This build reports no Kokoro voices.</div>
                 )}
+              </div>
+              <div className="field mt-3">
+                <Label>Language override</Label>
+                <Select
+                  value={form.kokoroLang || '__auto__'}
+                  onValueChange={val =>
+                    setForm(f => ({ ...f, kokoroLang: val === '__auto__' ? '' : val }))
+                  }
+                >
+                  <SelectTrigger className="w-[260px]"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectItem value="__auto__">Natural, voice default</SelectItem>
+                      {(data.tts?.kokoroLangs || []).map(v => (
+                        <SelectItem key={v} value={v}>{KOKORO_LANG_LABELS[v] || v}</SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+                <div className="field-hint">
+                  Force the Kokoro TTS engine to assume a specific language. Leave on <em>Natural</em> to auto-detect from each selected voice.
+                </div>
               </div>
               <TtsGainField engineId="kokoro" form={form} setForm={setForm} />
               <TtsSpeedField engineId="kokoro" form={form} setForm={setForm} />
@@ -2379,11 +2405,13 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                   voice={previewVoice}
                   cloudProvider={form.tts.cloud.provider}
                   speed={form.tts.speed?.[e] ?? 1}
+                  lang={form.kokoroLang || undefined}
                   adminFetch={adminFetch}
                 />
                 <div className="field-hint">
                   Plays a short sample in the selected engine &amp; voice. Reflects voice
                   and speed; the dB trim is applied later, on air.
+                  {e === 'kokoro' || e === 'pocket-tts' ? "Sample text is English; non-English language settings may sound strange" : ""}
                 </div>
               </div>
             );
@@ -4464,6 +4492,20 @@ const TZ_GROUPS: Array<{ region: string; zones: string[] }> = (() => {
 function clockPreview(timeZone: string, locale: StationLocale) {
   return fmtClockMinute(new Date(), timeZone || undefined, locale);
 }
+
+// Labels for Kokoro phonemizer language override options. Keyed by the lang
+// codes exposed by the controller (synced with KOKORO_LANGS in settings.ts).
+const KOKORO_LANG_LABELS: Record<string, string> = {
+  'en-gb': 'English (UK)',
+  'en-us': 'English (US)',
+  cmn: 'Chinese (Mandarin)',
+  fr: 'French',
+  hi: 'Hindi',
+  it: 'Italian',
+  ja: 'Japanese',
+  'pt-br': 'Portuguese (Brazilian)',
+  es: 'Spanish',
+};
 
 function StationSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
   const save = () => saveSettings({

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -327,7 +327,8 @@ interface SettingsData {
   tts?: {
     engines?: string[];
     available?: Record<string, boolean>;
-    kokoroVoices?: Array<{ id: string; label: string }>;
+    kokoroVoices?: string[];
+    kokoroVoiceLanguages?: Record<string, string>;
     chatterboxVoices?: string[];
     // `voiceDir` is the new shared name (issue #213). `chatterboxVoiceDir` is
     // kept as an alias so the UI keeps working against older controllers.
@@ -1960,42 +1961,78 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
           </>
         )}
 
-        {form.tts.defaultEngine === 'kokoro' && (
-          <>
-            <div className="field mt-4">
-              <Label>Kokoro voice</Label>
-              {available.kokoro === false && (
-                <div className="field-hint text-[var(--danger)]">
-                  Kokoro is not installed in this build, so it will fall back to Piper.
-                </div>
-              )}
-              {(data.tts?.kokoroVoices?.length || 0) > 0 ? (
-                <>
-                  <Select
-                    value={form.tts.kokoro?.voice ?? 'bf_isabella'}
-                    onValueChange={val => setForm(f => ({
-                      ...f, tts: { ...f.tts, kokoro: { ...f.tts.kokoro, voice: val } },
-                    }))}
-                  >
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        {data.tts?.kokoroVoices?.map(v => (
-                          <SelectItem key={v.id} value={v.id}>{v.label} — {v.id}</SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                  <div className="field-hint">British English only. Applies to every kind routed through Kokoro.</div>
-                </>
-              ) : (
-                <div className="field-hint">This build reports no Kokoro voices.</div>
-              )}
-            </div>
-            <TtsGainField engineId="kokoro" form={form} setForm={setForm} />
-            <TtsSpeedField engineId="kokoro" form={form} setForm={setForm} />
-          </>
-        )}
+        {form.tts.defaultEngine === 'kokoro' && (() => {
+          const voices = data.tts?.kokoroVoices || [];
+          const languages = data.tts?.kokoroVoiceLanguages || {};
+          const voice = form.tts.kokoro?.voice ?? 'bf_isabella';
+          const langPrefix = voice.charAt(0);
+          const filtered = voices.filter(v => v.startsWith(langPrefix));
+          const fmt = (code: string) => {
+            const [lg, name = ''] = code.split('_');
+            const g = (lg?.[1] ?? '').toUpperCase();
+            const n = name.charAt(0).toUpperCase() + name.slice(1);
+            return `${n} (${g})`;
+          };
+          const setVoice = (val: string) => setForm(f => ({
+            ...f, tts: { ...f.tts, kokoro: { ...f.tts.kokoro, voice: val } },
+          }));
+          return (
+            <>
+              <div className="field mt-4">
+                <Label>Kokoro voice</Label>
+                {available.kokoro === false && (
+                  <div className="field-hint text-[var(--danger)]">
+                    Kokoro is not installed in this build, so it will fall back to Piper.
+                  </div>
+                )}
+                {voices.length > 0 ? (
+                  <>
+                    <div className="field mt-3">
+                      <Label>Language</Label>
+                      <Select
+                        value={langPrefix}
+                        onValueChange={lang => {
+                          const first = voices.find(v => v.startsWith(lang));
+                          if (first) setVoice(first);
+                        }}
+                      >
+                        <SelectTrigger><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          <SelectGroup>
+                            {Object.entries(languages).map(([k, v]) => (
+                              <SelectItem key={k} value={k}>{v}</SelectItem>
+                            ))}
+                          </SelectGroup>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="field mt-3">
+                      <Label>Voice</Label>
+                      <Select value={voice} onValueChange={setVoice}>
+                        <SelectTrigger><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          <SelectGroup>
+                            {!filtered.includes(voice) && (
+                              <SelectItem value={voice}>{fmt(voice)}</SelectItem>
+                            )}
+                            {filtered.map(v => (
+                              <SelectItem key={v} value={v}>{fmt(v)}</SelectItem>
+                            ))}
+                          </SelectGroup>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="field-hint">Applies to every kind routed through Kokoro.</div>
+                  </>
+                ) : (
+                  <div className="field-hint">This build reports no Kokoro voices.</div>
+                )}
+              </div>
+              <TtsGainField engineId="kokoro" form={form} setForm={setForm} />
+              <TtsSpeedField engineId="kokoro" form={form} setForm={setForm} />
+            </>
+          );
+        })()}
 
         {form.tts.defaultEngine === 'chatterbox' && (
           <>

--- a/web/components/admin/personas/PersonaVoiceCard.tsx
+++ b/web/components/admin/personas/PersonaVoiceCard.tsx
@@ -33,7 +33,8 @@ interface PersonaVoiceCardProps {
 }
 
 export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText, adminFetch, updateTts }: PersonaVoiceCardProps) {
-  const kokoroVoices = data?.tts?.kokoroVoices || [];
+  const kokoroVoices: string[] = data?.tts?.kokoroVoices || [];
+  const kokoroLanguages = data?.tts?.kokoroVoiceLanguages || {};
   const pocketTtsVoices = data?.tts?.pocketTtsVoices || [];
   const cloudProviders = data?.tts?.cloudProviders || ['openai', 'elevenlabs'];
 
@@ -123,26 +124,61 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
             );
           })()}
 
-          {persona.tts.engine === 'kokoro' && (
-            <div className="field max-w-[320px]">
-              <Label>Kokoro voice</Label>
-              <Select
-                value={persona.tts.voice}
-                onValueChange={val => updateTts({ voice: val })}
-              >
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    {!kokoroVoices.some(v => v.id === persona.tts.voice) && (
-                      <SelectItem value={persona.tts.voice}>{persona.tts.voice}</SelectItem>
-                    )}
-                    {kokoroVoices.map(v => <SelectItem key={v.id} value={v.id}>{v.label}</SelectItem>)}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-              <div className="field-hint">The kokoro-onnx voice id for this persona.</div>
-            </div>
-          )}
+          {persona.tts.engine === 'kokoro' && (() => {
+            const voice = persona.tts.voice || 'bf_isabella';
+            const langPrefix = voice.charAt(0);
+            const filtered = kokoroVoices.filter(v => v.startsWith(langPrefix));
+            const fmt = (code: string) => {
+              const [lg, name = ''] = code.split('_');
+              const g = (lg?.[1] ?? '').toUpperCase();
+              const n = name.charAt(0).toUpperCase() + name.slice(1);
+              return `${n} (${g})`;
+            };
+            return (
+              <div className="field max-w-[320px]">
+                <Label>Kokoro voice</Label>
+                <div className="field mt-3">
+                  <Label>Language</Label>
+                  <Select
+                    value={langPrefix}
+                    onValueChange={lang => {
+                      const first = kokoroVoices.find(v => v.startsWith(lang));
+                      if (first) updateTts({ voice: first });
+                    }}
+                  >
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        {Object.entries(kokoroLanguages).map(([k, v]) => (
+                          <SelectItem key={k} value={k}>{v}</SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="field mt-3">
+                  <Label>Voice</Label>
+                  <Select
+                    value={voice}
+                    onValueChange={val => updateTts({ voice: val })}
+                  >
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        {!filtered.includes(voice) && (
+                          <SelectItem value={voice}>{fmt(voice)}</SelectItem>
+                        )}
+                        {filtered.map(v => (
+                          <SelectItem key={v} value={v}>{fmt(v)}</SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="field-hint">The kokoro-onnx voice id for this persona.</div>
+              </div>
+            );
+          })()}
 
           {persona.tts.engine === 'chatterbox' && (() => {
             const cbVoices: string[] = data?.tts?.chatterboxVoices || [];

--- a/web/components/admin/personas/types.ts
+++ b/web/components/admin/personas/types.ts
@@ -76,7 +76,8 @@ export interface SettingsResponse {
   defaults?: { djPrompt?: string };
   skills?: { catalog?: SkillCatalogEntry[] };
   tts?: {
-    kokoroVoices?: VoiceOption[];
+    kokoroVoices?: string[];
+    kokoroVoiceLanguages?: Record<string, string>;
     piperVoices?: string[];
     chatterboxVoices?: string[];
     // `voiceDir` is the new shared name (issue #213). `chatterboxVoiceDir` is

--- a/web/components/admin/personas/types.ts
+++ b/web/components/admin/personas/types.ts
@@ -78,6 +78,7 @@ export interface SettingsResponse {
   tts?: {
     kokoroVoices?: string[];
     kokoroVoiceLanguages?: Record<string, string>;
+    kokoroLangs?: string[];
     piperVoices?: string[];
     chatterboxVoices?: string[];
     // `voiceDir` is the new shared name (issue #213). `chatterboxVoiceDir` is

--- a/web/components/admin/tts/VoicePreviewButton.tsx
+++ b/web/components/admin/tts/VoicePreviewButton.tsx
@@ -16,6 +16,8 @@ interface VoicePreviewButtonProps {
   cloudProvider?: string;
   // Final rate multiplier to audition (server clamps to 0.5–2.0×).
   speed?: number;
+  // Kokoro phonemizer language override (e.g. "en-gb", "ja").
+  lang?: string;
   adminFetch: AdminAuth['adminFetch'];
   disabled?: boolean;
   className?: string;
@@ -24,7 +26,7 @@ interface VoicePreviewButtonProps {
 type PreviewState = 'idle' | 'loading' | 'playing' | 'error';
 
 export function VoicePreviewButton({
-  engine, voice, cloudProvider, speed, adminFetch, disabled, className,
+  engine, voice, cloudProvider, speed, lang, adminFetch, disabled, className,
 }: VoicePreviewButtonProps) {
   const [state, setState] = useState<PreviewState>('idle');
   const [error, setError] = useState<string | null>(null);
@@ -48,7 +50,7 @@ export function VoicePreviewButton({
       const r = await adminFetch('/settings/tts/preview', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ engine, voice, cloudProvider, speed }),
+        body: JSON.stringify({ engine, voice, cloudProvider, speed, lang }),
       });
       if (!r.ok) {
         const j = await r.json().catch(() => ({})) as { message?: string };

--- a/web/components/admin/tts/engineMeta.ts
+++ b/web/components/admin/tts/engineMeta.ts
@@ -15,7 +15,7 @@ export interface EngineMeta {
 // Order mirrors the on-air dispatcher (controller audio/tts.ts ENGINES).
 export const ENGINES: EngineMeta[] = [
   { id: 'piper',      label: 'Piper',      blurb: 'Local · fast · keyless' },
-  { id: 'kokoro',     label: 'Kokoro',     blurb: 'More natural, slower' },
+  { id: 'kokoro',     label: 'Kokoro',     blurb: 'More natural · multilingual' },
   { id: 'chatterbox', label: 'Chatterbox', blurb: 'Clone a voice from a clip' },
   { id: 'pocket-tts', label: 'PocketTTS',  blurb: 'Multilingual · CPU-only' },
   { id: 'cloud',      label: 'Cloud',      blurb: 'OpenAI / ElevenLabs' },


### PR DESCRIPTION
## What
Adds config options and display to allow selection from full suite of kokoro voices, along with phonemization in all of kokoro's available languages via misaki's espeak phonemizer.

## Why
One of kokoro's many advantages aside from its speed is the number of languages it can handle; not supporting it is a waste. Also should resolve #725 as it provides an Italian phonemizer.

## How tested
I tested it by hand in a development instance. Also verified no lint errors.