### PR TITLE
fix(broadcast): stop shipping mis-targeted DJ adaptive-blend length (#749)

### DIFF
--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -483,9 +483,23 @@ class Queue {
     // admin slider acts as a real ceiling on DJ-mode transitions too.
     const maxSec = settings.get()?.crossfadeDuration ?? null;
     const secs = mix.crossSecondsFor(cur, next, { energyDelta, nextIntroMs, maxSec });
+    // NOT stamped onto item.track.crossSec (#749 — off-by-one, confirmed still
+    // live on inspection despite the issue being closed with no fix commit).
+    // liq_cross_duration governs the crossfade at the STAMPED track's OWN end
+    // (radio.liq's dj_transition reads it off `a`, the outgoing branch) — but
+    // `secs` here is sized for the transition INTO item (prevTrack → item).
+    // The only track that could correctly carry this value is prevTrack, and
+    // drainToLiquidsoap drains strictly FIFO, marking each item sent before
+    // the next is even looked at — so prevTrack has invariably already been
+    // annotated and handed to Liquidsoap by the time this runs. Stamping it
+    // on item instead silently governs item's OWN exit (item → next), sized
+    // by the wrong pair's compatibility and intro cap, one hop later than
+    // intended — and that error compounds every transition for the rest of
+    // the session. Left un-applied (logged only) until there's a real fix: a
+    // buffer-time override channel Liquidsoap re-reads dynamically, not a
+    // static per-track annotation baked in ahead of the pair being known.
     if (secs != null) {
-      item.track.crossSec = secs;
-      this.log('mix', `blend ${secs}s → ${item.track.title}`);
+      this.log('mix', `blend would be ${secs}s for ${prevTrack.title || '?'} → ${item.track.title} (not applied — #749)`);
     }
 
     // DJ transition effects (sweep/washout) — the agent proposes, the data


### PR DESCRIPTION
## What

Discord reports of stations "acting up" led back to DJ-mode's adaptive crossfade blend (feature 1 of the transition-FX rework in #606). `applyMixTransition` computes the blend length for the **prevTrack → item** transition but stamps it onto `item.track.crossSec`, which becomes `liq_cross_duration` on `item`. `radio.liq`'s `cross` reads that metadata off the **outgoing** branch to size its buffer — so the stamp actually governs `item`'s own exit (`item → next`), not the transition it was computed for.

This is issue #749, which correctly diagnosed the bug but was closed with no fix commit — it's still live in `develop`.

## Impact

Every DJ-mode transition length was one hop late relative to the pair it was computed from, and the intro-safety cap (meant to stop the fade-in from cutting into `item`'s own vocals) ended up protecting whichever track came *after* `item` — not `item` itself. Compounds across a whole session since each transition inherits a value meant for a different pair.

## Why not a "real" fix

Confirmed by tracing `drainToLiquidsoap`: it drains `upcoming` strictly FIFO and marks each item `sent` before the next is even inspected, so `prevTrack` has *always* already been annotated and handed to Liquidsoap by the time `applyMixTransition(item)` runs — there's no track left that can correctly carry the value under the current "bake it into a static per-track annotation" design. A correct fix needs a buffer-time override channel Liquisoap re-reads dynamically, not a bigger change I want to ship blind against a live station.

## This PR

Stops stamping the mis-targeted value — DJ-mode blends fall back to the operator's configured default crossfade length (safe, predictable) instead of a desynced one. The value is still logged (`[mix] blend would be Ns ... (not applied — #749)`) for visibility. Washout's own `crossSec` stamp is untouched — it targets the flagged track's own end, which is exactly where washout fires, so it was never affected by this bug.

## Test plan

- [x] `npm run lint` (controller) — 0 errors, no new warnings
- [ ] Confirm on a live DJ-mode station that transitions sound consistent again and the `blend would be...` log line shows up without a corresponding metadata stamp