### PR TITLE
fix(tts): surface silent engine fallbacks + guide operators to matching-language voices (#691, #725)

### DIFF
--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -45,6 +45,18 @@ function djPersonaTts(kind: string): any {
   return settings.getEffectivePersona()?.tts || null;
 }
 
+// The engine the persona (or the global default) actually asked for, BEFORE
+// resolveEngine()'s availability/key reroute. Recorded alongside the engine
+// that truly spoke so a *resolve-time* fallback — e.g. a persona on pocket-tts
+// when the tts-heavy sidecar is down, silently routed to piper — shows up in
+// Stats as `fellBack`, instead of looking like a healthy piper call the
+// operator never configured (issue #691). Mirrors describeRouting()'s
+// `requested`.
+function requestedEngine(kind: string, personaTts: any): string {
+  if (personaTts && ENGINES.includes(personaTts.engine)) return personaTts.engine;
+  return settings.get().tts?.defaultEngine || 'piper';
+}
+
 function resolveEngine(kind: string, personaTts: any) {
   const tts = settings.get().tts || {};
   let chosen;
@@ -213,6 +225,7 @@ export async function speak(
 ) {
   const speakText = normalizeForSpeech(text);
   const personaTts = djPersonaTts(kind);
+  const requested = requestedEngine(kind, personaTts);
   const primary = resolveEngine(kind, personaTts);
   // Persona on-air language (e.g. "French") rides along to the cloud engine as a
   // pronunciation hint so a non-English script isn't read with English phonetics
@@ -263,7 +276,7 @@ export async function speak(
   try {
     const result = await speakWith(primary, speakText, { outPath, speedScale: scale, language, soul }, personaTts);
     recordTts({
-      kind, engine: primary, requested: primary, fellBack: false,
+      kind, engine: primary, requested, fellBack: requested !== primary,
       ok: true, ms: Date.now() - started, chars, t: new Date().toISOString(),
     });
     return result;
@@ -274,7 +287,7 @@ export async function speak(
     const fallback = primary === 'piper' ? 'kokoro' : 'piper';
     if (fallback === 'kokoro' && !kokoro.isAvailable()) {
       recordTts({
-        kind, engine: primary, requested: primary, fellBack: false,
+        kind, engine: primary, requested, fellBack: requested !== primary,
         ok: false, ms: Date.now() - started, chars, error: err.message,
         t: new Date().toISOString(),
       });
@@ -284,13 +297,13 @@ export async function speak(
     try {
       const result = await speakWith(fallback, speakText, { outPath, speedScale: scale, language, soul }, personaTts);
       recordTts({
-        kind, engine: fallback, requested: primary, fellBack: true,
+        kind, engine: fallback, requested, fellBack: true,
         ok: true, ms: Date.now() - started, chars, t: new Date().toISOString(),
       });
       return result;
     } catch (err2) {
       recordTts({
-        kind, engine: fallback, requested: primary, fellBack: true,
+        kind, engine: fallback, requested, fellBack: true,
         ok: false, ms: Date.now() - started, chars, error: err2.message,
         t: new Date().toISOString(),
       });

--- a/web/components/admin/personas/PersonaIdentityCard.tsx
+++ b/web/components/admin/personas/PersonaIdentityCard.tsx
@@ -97,8 +97,11 @@ export function PersonaIdentityCard({
               onChange={(e: ChangeEvent<HTMLInputElement>) => update({ language: e.target.value })}
             />
             <div className="field-hint">
-              The DJ speaks every on-air line in this language. Leave empty for English.
-              Pick a voice that can actually speak it.
+              The DJ <em>writes</em> every on-air line in this language. Leave empty for English.
+              The <em>accent</em> comes from the voice, not this field — set a voice that speaks
+              it in the Voice section below (e.g. drop a Piper voice like <code>it_IT-*.onnx</code>{' '}
+              into <code>state/voices/</code>, or use a Cloud voice). An English-only voice will
+              read this language with an English accent.
               <span className="ml-2 text-muted">{persona.language.trim().length} / {LANGUAGE_MAX}</span>
             </div>
           </div>


### PR DESCRIPTION
Two small, independent fixes for the pair of TTS-language issues (#691, #725). Neither overlaps PR #759 (multilingual Kokoro) — different files/regions.

## 1. Surface resolve-time engine fallbacks in Stats (#691)

`speak()` recorded `requested: primary`, but `primary` is the **post-fallback** engine `resolveEngine()` returns. When a persona is set to an engine that isn't available in this build — e.g. **pocket-tts with the `tts-heavy` sidecar down** — `resolveEngine()` silently reroutes to Piper, and the stats ring logged `requested: piper, fellBack: false`: a healthy-looking Piper call the operator never configured, invisible on the Stats page. This is the "key bug" behind #691.

- New `requestedEngine()` helper captures the persona's (or global default's) *actual* ask, before the reroute — mirroring `describeRouting()`.
- All four `recordTts()` paths now record that true `requested` with `fellBack: requested !== engine`.
- The existing UI surfaces already consume this — `StatsPanel` "Fallbacks" cell (`fallbackRate`), `DashPanel` `ttsFallbackPct`, `DebugPanel` "requested X · fell back" — so they now light up for resolve-time reroutes instead of only runtime throws. Pure telemetry; nothing spoken changes.

## 2. Guide operators to a matching-language voice (#725)

The persona **Language** field changes what the DJ *writes*, but the accent comes from the voice model — a fact the UI never stated. The #725 reporter set Italian, heard English pronunciation, and found no admin option. The hint now names the concrete working path on `develop` today: drop a matching Piper voice (e.g. `it_IT-*.onnx`) into `state/voices/` and select it, or use a Cloud voice.

## Notes for the reporters (not fixed here, by design)

- **#691 / pocket-tts + Spanish:** pocket-tts *is* multilingual now (kyutai, May 2026), so the earlier "English-only" read was wrong. But our `pocket_tts_worker.py` calls `load_model()` with no `language=`, so it loads the default English model and reads Spanish English-accented. Proper support needs per-language model loading + per-language voice catalogs (each language model has its own voices) — a feature on the scale of #759, tracked as a follow-up rather than built blind.
- **Kokoro multilingual** is #759's scope.

## Tested
`npm run lint` in both `controller/` and `web/` (eslint + `tsc --noEmit`) — 0 errors.