### PR TITLE
feat(dj): on-air persona handoff at show boundaries

### DIFF
--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -39,10 +39,19 @@ export const VOICE_KINDS = [
 // persona-agnostic stinger) falls back to the global defaultEngine.
 const GLOBAL_VOICE_KINDS = new Set(['jingle', 'default']);
 
-// The effective persona's TTS config for a persona-voiced kind, else null.
-function djPersonaTts(kind: string): any {
+// Which persona voices a segment: an explicit override (the persona-handoff
+// mic-pass — broadcast/dj-agent.runPersonaHandoff — voices the OUTGOING persona
+// even though the clock has already moved on to the incoming one), else the
+// clock-driven effective persona. `null`/absent → today's behaviour exactly.
+function personaFor(persona?: any): any {
+  return persona ?? settings.getEffectivePersona();
+}
+
+// The persona's TTS config for a persona-voiced kind, else null. `persona`
+// overrides the effective persona (persona handoff); absent → effective persona.
+function djPersonaTts(kind: string, persona?: any): any {
   if (GLOBAL_VOICE_KINDS.has(kind)) return null;
-  return settings.getEffectivePersona()?.tts || null;
+  return personaFor(persona)?.tts || null;
 }
 
 function resolveEngine(kind: string, personaTts: any) {
@@ -102,8 +111,8 @@ function resolveEngine(kind: string, personaTts: any) {
 // written), i.e. today's behaviour. Uses the *resolved* engine (post
 // availability/key fallback), so the gain matches the engine that will actually
 // speak; the rare runtime-throw fallback inside speak() is an error path.
-export function voiceGainDb(kind: string): number {
-  const personaTts = djPersonaTts(kind);
+export function voiceGainDb(kind: string, persona?: any): number {
+  const personaTts = djPersonaTts(kind, persona);
   const engine = resolveEngine(kind, personaTts);
   const tts: any = settings.get().tts || {};
   const engineGain = settings.clampTtsGain(tts.gainDb?.[engine]);
@@ -209,10 +218,13 @@ export async function synthesizeSample(
 // admin Stats page can show per-engine usage, latency, and the fallback rate.
 export async function speak(
   text: string,
-  { kind = 'default', outPath, speedScale }: { kind?: string; outPath?: string; speedScale?: number } = {},
+  { kind = 'default', outPath, speedScale, persona }: { kind?: string; outPath?: string; speedScale?: number; persona?: any } = {},
 ) {
   const speakText = normalizeForSpeech(text);
-  const personaTts = djPersonaTts(kind);
+  // `persona` overrides the clock-driven effective persona so the persona-handoff
+  // mic-pass can voice the outgoing DJ (engine, voice, language, soul, speed)
+  // after the hour has flipped. Absent → getEffectivePersona(), i.e. today.
+  const personaTts = djPersonaTts(kind, persona);
   const primary = resolveEngine(kind, personaTts);
   // Persona on-air language (e.g. "French") rides along to the cloud engine as a
   // pronunciation hint so a non-English script isn't read with English phonetics
@@ -222,7 +234,7 @@ export async function speak(
   // kokoro / pocket-tts).
   const language = GLOBAL_VOICE_KINDS.has(kind)
     ? ''
-    : String(settings.getEffectivePersona()?.language || '').trim();
+    : String(personaFor(persona)?.language || '').trim();
   // The persona's soul (e.g. "thoughtful and a little wistful") rides the same
   // path so the voice delivery carries the same character as the writing (issue
   // #579). DJ-voiced kinds only, like `language`; only the OpenAI gpt-4o*-tts
@@ -230,7 +242,7 @@ export async function speak(
   // other engine ignores it.
   const soul = GLOBAL_VOICE_KINDS.has(kind)
     ? ''
-    : String(settings.getEffectivePersona()?.soul || '').trim();
+    : String(personaFor(persona)?.soul || '').trim();
   // Delivery pace — a MULTIPLIER on the engine's configured speech rate (1.0 =
   // unchanged), composed (not overridden) on top of an operator's global env
   // base PIPER_SPEED/KOKORO_SPEED/CLOUD_TTS_SPEED. Three factors multiply:

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -908,7 +908,10 @@ export async function runPersonaHandoff(queue: any, ctx: any): Promise<void> {
     let aired = false;
 
     // 1. Sign-off, in the OUTGOING persona's voice. Tag the session turn with
-    //    the outgoing persona id so the window shows who actually spoke it.
+    //    the outgoing persona's id + name — session.windowMessages() uses the id
+    //    to spot a turn spoken by someone other than the session's own persona
+    //    and names the real speaker, so the incoming DJ never reads the
+    //    sign-off as its own words.
     let signoffText: string | null = null;
     try {
       signoffText = await dj.generateSignoff({
@@ -916,7 +919,7 @@ export async function runPersonaHandoff(queue: any, ctx: any): Promise<void> {
         context: ctx, recap: queue.getDjRecap(), recentOpeners,
       });
       await queue.announce(signoffText, 'handoff', {
-        persona: personaOut, meta: { personaId: personaOut.id },
+        persona: personaOut, meta: { personaId: personaOut.id, personaName: personaOut.name },
       });
       aired = true;
     } catch (err: any) {

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -27,6 +27,7 @@ import { recordPick } from '../llm/log.js';
 import * as budget from './dj-budget.js';
 import { withTrace, logEvent } from '../observability/events.js';
 import { recencyWindowsForLibrary, effectiveNoRepeatWindow } from '../music/recency.js';
+import { djCallsAllowed } from './listeners.js';
 
 // --- Feature 4: DJ-mode mini-runs ------------------------------------------
 // A short, deliberate tempo/key journey across 2-3 consecutive picks. While a
@@ -760,5 +761,88 @@ async function runRequestViaAgent(queue: any, { requester }: { requester: string
       track: { title: song.title, artist: song.artist, id: song.id },
       introScript: intro || null,
     };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Persona handoff — a two-voice mic-pass at a show boundary.
+// ---------------------------------------------------------------------------
+//
+// When session.maybeRoll() hard-rolls and the effective PERSONA changed, it
+// stamps roll metadata on the fresh session (session.pendingHandoff). This runs
+// after the roll — driven by whichever maybeRoll call site fires first (the
+// queue's track-start, or the :00 hourly cron) — and, when a handoff is pending,
+// airs a sign-off in the OUTGOING persona's voice followed by a greeting in the
+// incoming persona's voice. Both go through the serialized say.txt voice chain
+// (queue.announce → airVoice), so they play cleanly back to back.
+//
+// Never throws (callers still need to run the pick after it) and is idempotent:
+// it marks the handoff aired up front, so a concurrent second call — or a
+// mid-way failure — can't double-air or retry into the middle of the new show.
+export async function runPersonaHandoff(queue: any, ctx: any): Promise<void> {
+  const pending = session.pendingHandoff();
+  if (!pending) return;
+
+  // Nobody listening → the mic-pass moment has passed; don't stack a stale
+  // handoff for later. Budget: treated as an optional segment (muted in soft
+  // and hard tiers, policy in dj-budget.ts). Either way, mark aired so it
+  // doesn't retry — a handoff fires at most ~once an hour and is cheap to loosen.
+  if (!djCallsAllowed() || !budget.optionalSegmentsAllowed()) {
+    session.markHandoffAired();
+    return;
+  }
+
+  // Outgoing persona comes from the roll metadata — its clock slot is already
+  // over, so getEffectivePersona() no longer returns it. Incoming is the fresh
+  // session's persona. A persona deleted mid-shift → nothing to voice; drop it.
+  const personaOut = settings.resolvePersonaById(pending.personaId);
+  const cur = session.getSession();
+  const personaIn = settings.resolvePersonaById(cur?.persona?.id) || settings.getEffectivePersona();
+  if (!personaOut || !personaIn) {
+    session.markHandoffAired();
+    return;
+  }
+  const showIn = cur?.show?.name || null;
+
+  // Mark aired BEFORE airing (see the idempotency note above).
+  session.markHandoffAired();
+
+  await withTrace({ kind: 'handoff', from: personaOut.name, to: personaIn.name }, async () => {
+    const recentOpeners = queue.getRecentOpeners();
+    let aired = false;
+
+    // 1. Sign-off, in the OUTGOING persona's voice. Tag the session turn with
+    //    the outgoing persona id so the window shows who actually spoke it.
+    let signoffText: string | null = null;
+    try {
+      signoffText = await dj.generateSignoff({
+        personaOut, personaIn, showIn,
+        context: ctx, recap: queue.getDjRecap(), recentOpeners,
+      });
+      await queue.announce(signoffText, 'handoff', {
+        persona: personaOut, meta: { personaId: personaOut.id },
+      });
+      aired = true;
+    } catch (err: any) {
+      queue.log('error', `Handoff sign-off failed: ${err.message}`);
+      signoffText = null;
+    }
+
+    // 2. Greeting, in the INCOMING persona's voice — fed the sign-off text so
+    //    it can genuinely respond. Stands alone if the sign-off didn't air.
+    try {
+      const greeting = await dj.generateHandoffGreeting({
+        personaIn, personaOut, signoffText, showIn,
+        context: ctx, recap: queue.getDjRecap(), recentOpeners,
+      });
+      await queue.announce(greeting, 'handoff', { persona: personaIn });
+      aired = true;
+    } catch (err: any) {
+      queue.log('error', `Handoff greeting failed: ${err.message}`);
+    }
+
+    if (aired) {
+      logEvent('dj.handoff', { from: personaOut.name, to: personaIn.name, show: showIn });
+    }
   });
 }

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -1383,14 +1383,19 @@ function wavDurationMs(path: string): number | null {
 // Voice kinds the DJ recap remembers. The fixed channels are always present;
 // every skill kind (built-in + custom) is registered at skill-load time via
 // registerSkillKinds() — so a new skill is recapped without editing this list.
-const VOICE_KINDS = new Set(['dj-speak', 'link', 'station-id', 'hourly-check']);
+// 'handoff' (the two-voice persona mic-pass) counts too, so the incoming DJ's
+// next segments don't echo the greeting's opener.
+const VOICE_KINDS = new Set(['dj-speak', 'link', 'station-id', 'hourly-check', 'handoff']);
 // Kinds whose recap entries are de-duped. Skills are added at load time too.
+// 'handoff' is deliberately NOT deduped — its two lines (sign-off + greeting)
+// are distinct utterances by different voices.
 const DEDUPE_KINDS = new Set(['station-id', 'hourly-check']);
 const KIND_LABEL: Record<string, string> = {
   'dj-speak': 'intro',
   'link': 'link',
   'station-id': 'ident',
   'hourly-check': 'hourly',
+  'handoff': 'handoff',
 };
 
 // Register the loaded skill kinds (built-in + custom) as recap voice/dedupe

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -640,16 +640,22 @@ class Queue {
   //              song that just started stays audible underneath the voice)
   //   - everything else → say.txt → voice_queue → HEAVY duck (solo voice
   //              dominates; used for station ID / hourly / weather)
-  async announce(text, kind = 'announcement') {
+  //
+  // `opts.persona` overrides the on-air persona for THIS clip's voice — the
+  // persona-handoff mic-pass voices the outgoing DJ after the hour has flipped
+  // (see broadcast/dj-agent.runPersonaHandoff). `opts.meta` is merged into the
+  // session turn (e.g. tagging the sign-off with the outgoing persona id). Both
+  // default to absent, so every existing call site is byte-identical.
+  async announce(text, kind = 'announcement', { persona = null, meta = {} }: { persona?: any; meta?: any } = {}) {
     if (!text || !text.trim()) return;
     try {
-      const wavPath = await speak(text, { kind });
+      const wavPath = await speak(text, { kind, persona });
       const targetFile = kind === 'link'
         ? config.liquidsoap.introFile
         : config.liquidsoap.sayFile;
-      await airVoice(targetFile, wavPath, text, voiceGainDb(kind));
+      await airVoice(targetFile, wavPath, text, voiceGainDb(kind, persona));
       this.log(kind, text);
-      session.appendTurn({ role: 'segment', kind, text });
+      session.appendTurn({ role: 'segment', kind, text, meta });
       // The auto-DJ link channel is its own event; everything else (station
       // IDs, weather, hourly) is `dj.say`. Operators that pipe these into
       // Discord usually want to filter the chatty link stream separately.
@@ -894,6 +900,14 @@ class Queue {
         try {
           const ctx = await getFullContext();
           await session.maybeRoll(ctx);
+          // If that roll crossed a persona boundary, air the mic-pass first
+          // (sign-off + greeting) so it plays before the incoming DJ's first
+          // pick. Guarded so a handoff failure never blocks the next track.
+          try {
+            await djAgent.runPersonaHandoff(this, ctx);
+          } catch (err: any) {
+            this.log('error', `Persona handoff failed: ${err.message}`);
+          }
           await djAgent.runTrackEvent(this, ctx, { wantLink });
         } catch (err: any) {
           this.log('error', `DJ track event failed: ${err.message}`);

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -321,9 +321,12 @@ export async function runHourlyCheck() {
 async function hourlyCheck() {
   // The top of the hour is the natural show boundary — roll the session here
   // so a scheduled show starting/ending opens a fresh chat history even if no
-  // track happens to start right on the hour.
-  const ctx = await getFullContext();
+  // track happens to start right on the hour. getFullContext() stays inside the
+  // try — node-cron doesn't catch async throws, so an escape here would be an
+  // unhandled rejection.
+  let ctx: Awaited<ReturnType<typeof getFullContext>> | null = null;
   try {
+    ctx = await getFullContext();
     await session.maybeRoll(ctx);
   } catch (err) {
     queue.log('error', `Session roll failed: ${err.message}`);
@@ -331,11 +334,14 @@ async function hourlyCheck() {
   // If that roll crossed a persona boundary, air the two-voice mic-pass. It
   // does its own listener/budget gating and marks itself aired, so it's safe to
   // call unconditionally here (whichever of this cron or a track-start rolls the
-  // session first drives it — the other no-ops).
-  try {
-    await djAgent.runPersonaHandoff(queue, ctx);
-  } catch (err) {
-    queue.log('error', `Persona handoff failed: ${err.message}`);
+  // session first drives it — the other no-ops). No ctx → the roll above didn't
+  // happen either; leave the handoff pending for the next call site.
+  if (ctx) {
+    try {
+      await djAgent.runPersonaHandoff(queue, ctx);
+    } catch (err) {
+      queue.log('error', `Persona handoff failed: ${err.message}`);
+    }
   }
   if (!shouldFire('hourly')) return;
   if (!djCallsAllowed()) return;  // nobody listening — stay on the auto playlist

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -17,6 +17,7 @@ import { resolveShowPlaylistPool } from '../music/show-playlist.js';
 import { getFullContext } from '../context.js';
 import { queue } from './queue.js';
 import * as session from './session.js';
+import * as djAgent from './dj-agent.js';
 import { cleanupOldVoices } from '../audio/tts.js';
 import { shouldFire } from './dj-gate.js';
 import { djCallsAllowed } from './listeners.js';
@@ -321,10 +322,20 @@ async function hourlyCheck() {
   // The top of the hour is the natural show boundary — roll the session here
   // so a scheduled show starting/ending opens a fresh chat history even if no
   // track happens to start right on the hour.
+  const ctx = await getFullContext();
   try {
-    await session.maybeRoll(await getFullContext());
+    await session.maybeRoll(ctx);
   } catch (err) {
     queue.log('error', `Session roll failed: ${err.message}`);
+  }
+  // If that roll crossed a persona boundary, air the two-voice mic-pass. It
+  // does its own listener/budget gating and marks itself aired, so it's safe to
+  // call unconditionally here (whichever of this cron or a track-start rolls the
+  // session first drives it — the other no-ops).
+  try {
+    await djAgent.runPersonaHandoff(queue, ctx);
+  } catch (err) {
+    queue.log('error', `Persona handoff failed: ${err.message}`);
   }
   if (!shouldFire('hourly')) return;
   if (!djCallsAllowed()) return;  // nobody listening — stay on the auto playlist

--- a/controller/src/broadcast/session.ts
+++ b/controller/src/broadcast/session.ts
@@ -182,7 +182,49 @@ export async function maybeRoll(ctx: any): Promise<any> {
 
   const prev = _session;
   await end();
-  return start(ctx, buildHandoff(prev));
+  const next = start(ctx, buildHandoff(prev));
+  stampRolledFrom(next, prev);
+  await persist();
+  return next;
+}
+
+// After a hard roll, record whether the on-air PERSONA changed so a caller can
+// air a two-voice mic-pass (broadcast/dj-agent.runPersonaHandoff): the outgoing
+// DJ signs off in their own voice, the incoming DJ acknowledges in theirs. Same
+// persona across a show boundary (e.g. a host's show ends but they stay on as
+// the active persona) → no on-air handoff; the existing text handoff already
+// covers continuity. The flag lives on the PERSISTED session, so a controller
+// restart between roll and airing can't double-fire, and either maybeRoll call
+// site (hourly cron at :00 or the first track-start after the boundary) can
+// trigger it. Session.ts stays free of queue/TTS imports (no cycle): callers
+// read pendingHandoff() and drive the runner.
+function stampRolledFrom(next: any, prev: any) {
+  const prevId = prev?.persona?.id ?? null;
+  const nextId = next?.persona?.id ?? null;
+  next.handoffAired = false;
+  next.rolledFrom = (prevId && nextId && prevId !== nextId)
+    ? {
+        personaId: prevId,
+        personaName: prev?.persona?.name ?? null,
+        showName: prev?.show?.name ?? null,   // show that just ended, or null for an auto block
+      }
+    : null;
+}
+
+// The pending on-air handoff for the live session (outgoing persona metadata),
+// or null when there's nothing to air (no persona change, or already aired).
+export function pendingHandoff(): { personaId: string; personaName: string | null; showName: string | null } | null {
+  if (!_session?.rolledFrom || _session.handoffAired) return null;
+  return _session.rolledFrom;
+}
+
+// Mark the handoff aired so it fires at most once. Called up front by the runner
+// (before generating/airing) so a mid-way failure can't retry into the middle
+// of the new show — the existing text handoff is the floor.
+export function markHandoffAired() {
+  if (!_session) return;
+  _session.handoffAired = true;
+  schedulePersist();
 }
 
 // Soft continuation across an autonomous daypart/mood turnover: same session id,

--- a/controller/src/broadcast/session.ts
+++ b/controller/src/broadcast/session.ts
@@ -143,8 +143,12 @@ export function start(ctx: any, handoff: any = null): any {
     handoff: handoff || null,
     messages: [],
   };
+  // appendTurn above already scheduled a debounced persist. No immediate
+  // write here: maybeRoll's hard-roll path stamps rolledFrom right after
+  // start() returns and awaits its own persist() — an unawaited write started
+  // now could land AFTER that stamped write and leave a stale (handoff-less)
+  // session.json on disk until the next debounce.
   appendTurn({ role: 'event', kind: 'scenario', text: scenarioText(_session) });
-  persist();
   // Milestone on the unified timeline — marks where one DJ run ends and the
   // next begins, so traces can be grouped by the session they belong to.
   logEvent('session.start', {
@@ -319,9 +323,22 @@ export function windowMessages() {
     // the same assistant block as real spoken segments, leaving the picker unable
     // to tell its own scratchpad from its broadcast voice. Mark it so the role of
     // each line stays unambiguous even after coalescing.
+    //
+    // Same identity guard for a turn VOICED BY A DIFFERENT PERSONA: the handoff
+    // sign-off is spoken by the outgoing DJ but stored in the new session
+    // (dj-agent.runPersonaHandoff tags it with the speaker's id + name).
+    // Untagged it would read as the incoming DJ's own words — name the real
+    // speaker instead.
+    const foreignSpeaker = (m.role === 'segment'
+      && m.meta?.personaId
+      && m.meta.personaId !== _session.persona?.id)
+      ? (m.meta.personaName || 'the previous host')
+      : null;
     const content = (m.role === 'dj' && m.kind === 'pick')
       ? `(pick note to self — not aired) ${m.text}`
-      : m.text;
+      : foreignSpeaker
+        ? `(${foreignSpeaker} said this on air while handing over — their words, not yours) ${m.text}`
+        : m.text;
     raw.push({ role, content });
   }
   const out: any[] = [];

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -17,6 +17,8 @@ export { matchRequest, identifyTrackFromText } from './internal/prompts/request.
 export {
   generateIntro,
   generateStationId,
+  generateSignoff,
+  generateHandoffGreeting,
   generateAdLib,
   generateLink,
   generateHourlyTime,

--- a/controller/src/llm/internal/prompts/scripts.ts
+++ b/controller/src/llm/internal/prompts/scripts.ts
@@ -65,6 +65,51 @@ export async function generateStationId({ recap = null, context = null, recentOp
   });
 }
 
+// --- Persona handoff at a show boundary ------------------------------------
+// When a show ends and a different persona takes over, the outgoing DJ signs
+// off on air and passes the mic; the incoming DJ acknowledges and opens their
+// shift. Both render as free text like every other segment, but each is voiced
+// by ITS OWN persona — the system prompt is rendered with an explicit persona
+// (djSystem(personaOut/In)) rather than the clock-driven effective one, which
+// has already flipped to the incoming persona by the time these run.
+// Anti-repeat: no ANGLES entry for 'handoff' (pickAngle returns null → no tone
+// line), but the recent-openers blocklist still steers the first words clear of
+// what just aired. A handoff fires at most ~once an hour, so that's plenty.
+
+export async function generateSignoff({ personaOut, personaIn, showIn = null, context = null, recap = null, recentOpeners = null }: any) {
+  const ctxLines = buildContextLines(context, { contextFields: SCRIPT_CONTEXT_FIELDS });
+  const outName = personaOut?.name || 'your host';
+  const inName = personaIn?.name || 'the next host';
+  const handTo = showIn ? `${inName}, who's bringing you "${showIn}"` : inName;
+  ctxLines.push(`Task: your time on air is wrapping up. Sign off in character as ${outName} and hand the mic over to ${handTo}. Say ${inName}'s name as you pass it along. ${lengthPhrase('link', personaOut)}. This is a real DJ passing the baton, warm and natural — not a formal announcement, and don't over-explain the schedule.`);
+  return djText({
+    system: djSystem(personaOut),
+    prompt: decoratePrompt(ctxLines.join('\n'), { kind: 'handoff', recap, recentOpeners }),
+    temperature: 1.0, topP: 0.9, repeatPenalty: 1.25, seed: randomSeed(),
+    kind: 'generateSignoff',
+  });
+}
+
+export async function generateHandoffGreeting({ personaIn, personaOut, signoffText = null, showIn = null, context = null, recap = null, recentOpeners = null }: any) {
+  const ctxLines = buildContextLines(context, { contextFields: SCRIPT_CONTEXT_FIELDS });
+  const inName = personaIn?.name || 'your host';
+  const outName = personaOut?.name || 'the previous host';
+  // The predecessor's actual sign-off rides in the prompt so the greeting can
+  // genuinely respond to it ("Cheers Johnny…") rather than a generic hello.
+  if (signoffText) {
+    const clipped = String(signoffText).replace(/\s+/g, ' ').trim().slice(0, 240);
+    if (clipped) ctxLines.push(`${outName} just signed off with: "${clipped}"`);
+  }
+  const showClause = showIn ? ` You're kicking off "${showIn}".` : '';
+  ctxLines.push(`Task: you're ${inName}, just taking over the mic from ${outName}. Acknowledge ${outName} warmly and naturally — a quick nod to what they said if it fits — then ease into your shift.${showClause} ${lengthPhrase('link', personaIn)}. Keep it easy and in character; you're stepping up to the decks, not reading a bulletin.`);
+  return djText({
+    system: djSystem(personaIn),
+    prompt: decoratePrompt(ctxLines.join('\n'), { kind: 'handoff', recap, recentOpeners }),
+    temperature: 0.95, topP: 0.92, repeatPenalty: 1.2, seed: randomSeed(),
+    kind: 'generateHandoffGreeting',
+  });
+}
+
 // Operator ad-lib — the command-center "manual voice DJ" in styled mode.
 // Takes a free-text instruction/topic and performs it in character, rather
 // than reading it verbatim (that's what raw mode is for).

--- a/controller/src/llm/internal/prompts/system.ts
+++ b/controller/src/llm/internal/prompts/system.ts
@@ -11,8 +11,11 @@ import * as settings from '../../../settings.js';
 const CHATTERBOX_TAG_HINT =
   '\n\nYou may sparingly insert non-verbal cues in square brackets: [laugh], [chuckle], [sigh], [cough]. Use them only where genuinely natural — at most one per segment, and never as filler.';
 
-export function djSystem() {
-  const persona = settings.getEffectivePersona();
+// `persona` overrides the on-air persona — used by the persona-handoff
+// generators (generateSignoff / generateHandoffGreeting) to render the sign-off
+// under the OUTGOING persona and the greeting under the incoming one, since the
+// clock-driven getEffectivePersona() has already moved on by the time they run.
+export function djSystem(persona: any = settings.getEffectivePersona()) {
   const s = settings.get();
   const base = settings.renderDjPrompt(persona, {
     station: s.station,

--- a/docs/superpowers/specs/2026-07-03-persona-handoff-design.md
+++ b/docs/superpowers/specs/2026-07-03-persona-handoff-design.md
@@ -1,0 +1,151 @@
+# On-air persona handoff at show boundaries
+
+**Date:** 2026-07-03
+**Status:** Draft — awaiting operator review
+
+## The idea
+
+When a show ends and a different persona takes over, the outgoing DJ signs off
+on air and passes the mic; the incoming DJ acknowledges and opens their shift.
+
+> "This is Johnny Fever signing off for now — passing the mic over to Cool
+> Hand Luke for your Afternoon Drive."
+>
+> "Cheers Johnny. Luke here — let's ease into the afternoon…"
+
+Two distinct voices, back to back, heavy-ducked over whatever's playing.
+
+## Why it's feasible today
+
+Everything needed already exists except one primitive:
+
+- **Boundary detection** — `session.maybeRoll()` (broadcast/session.ts) already
+  hard-rolls the session at show boundaries and builds a *text* handoff
+  (`buildHandoff`) carried into the new session. Nothing is spoken today.
+- **Two voices in sequence** — `airVoice()`'s `_voiceChain` lock (queue.ts)
+  already serializes every spoken clip across both duck channels, holding until
+  each clip finishes. Two `announce()` calls play cleanly in order.
+- **Per-persona voices** — each persona carries its own `tts` block (engine,
+  voice, gain, speed) plus `language`/`soul`.
+- **The one gap** — `tts.speak()` resolves the persona *internally* via
+  `settings.getEffectivePersona()`, which is clock-driven. The moment the hour
+  flips, the outgoing persona is no longer "effective", so their sign-off would
+  render in the *new* persona's voice. Fix: a persona override option threaded
+  through `speak()`/`announce()`.
+
+## Approaches considered
+
+**A. On-air handoff at the hard roll (recommended).** When the session
+hard-rolls and the effective persona actually changed, generate a sign-off (as
+the outgoing persona) and a greeting (as the incoming persona, fed the sign-off
+text so it can genuinely respond), voice each with its own persona's TTS, and
+air both through `say.txt`. One trigger point, both halves paired atomically,
+the greeting can reference the sign-off.
+
+**B. Pre-boundary sign-off (e.g. :57 cron) + post-boundary greeting.** The
+sign-off airs while the outgoing persona is still effective (no TTS override
+needed), the greeting rides the new session's first segment. Rejected: two
+loosely-coupled halves (a restart between them orphans the pair), a new cron
+path, and the acknowledgment can't quote a sign-off that hasn't aired when the
+new session's first segment is generated independently.
+
+**C. Prompt-only.** Enrich the existing text handoff so the incoming persona's
+*first* scripted segment acknowledges the predecessor. Cheapest, but no
+guaranteed sign-off moment, one voice only — doesn't deliver the two-voice
+mic-pass.
+
+## Design (Approach A)
+
+### Trigger
+
+`maybeRoll()`'s hard-roll branch stamps roll metadata onto the *fresh* session:
+
+```js
+_session.rolledFrom = prevPersonaChanged ? {
+  personaId, personaName,        // outgoing persona
+  showName,                      // show that just ended (or null for auto block)
+} : null;
+_session.handoffAired = false;
+```
+
+Persona change is judged by comparing `prev.persona?.id` against the fresh
+session's `persona?.id` — same persona across a show boundary (e.g. Marlowe's
+show ends, Marlowe stays on as the active persona) means **no** on-air handoff;
+the existing text handoff already covers continuity.
+
+Because the flag lives *on the persisted session*, a controller restart between
+roll and airing can't double-fire, and either `maybeRoll()` call site (hourly
+cron at :00, or the first track-start after the boundary) can trigger the
+handoff — whichever runs first. Session.ts itself stays free of queue/TTS
+imports (no cycle): the *callers* check `session.rolledFrom && !handoffAired`
+and invoke the runner.
+
+### Runner — `runPersonaHandoff(queue, ctx)` in broadcast/dj-agent.ts
+
+Gate order (all existing helpers):
+1. `session.rolledFrom` present and `handoffAired` false, else no-op.
+2. `djCallsAllowed()` — nobody listening → mark aired, skip (don't stack a
+   stale handoff for later; the moment has passed).
+3. Budget: treated as an **optional segment** — skipped at both `soft` and
+   `hard` tiers (policy stays in broadcast/dj-budget.ts like every other gate).
+   Mark aired either way. Cheap to loosen later; a handoff fires at most ~once
+   an hour.
+
+Then, marking `handoffAired = true` up front (a failed attempt must not retry
+into the middle of the new show):
+
+1. **Sign-off** — `dj.generateSignoff({ personaOut, personaIn, showIn, context })`
+   (new free-text generator in llm/internal/prompts/scripts.ts, patterned on
+   `generateStationId`). System prompt rendered with the *outgoing* persona's
+   soul/language; brief: 1–2 sentences, sign off by name, hand to the incoming
+   host (and show name when there is one). Reuses the existing random-angle +
+   opener-anti-repeat machinery.
+2. **Greeting** — `dj.generateHandoffGreeting({ personaIn, personaOut,
+   signoffText, showIn, context })`. System prompt rendered with the *incoming*
+   persona; the sign-off text is in the user prompt so the reply can actually
+   acknowledge it ("Cheers Johnny…"). 1–2 sentences, tee up the shift.
+3. **Air both** — `queue.announce(signoff, 'handoff', { persona: personaOut })`
+   then `queue.announce(greeting, 'handoff', { persona: personaIn })`.
+   `_voiceChain` plays them in order on the heavy-duck channel.
+
+Failure handling: each half is independent. Sign-off LLM/TTS failure → still
+attempt the greeting (it stands alone: "taking over from Johnny…"). Greeting
+failure → the sign-off alone still airs. Any failure logs via `queue.log` and
+never blocks the roll — the existing text handoff is the floor.
+
+### TTS persona override
+
+- `tts.speak(text, { kind, persona })` — when `opts.persona` is provided,
+  `djPersonaTts()`, the `language`/`soul` ride-alongs, and the persona speed
+  term all resolve from it instead of `getEffectivePersona()`. Absent, behaviour
+  is byte-identical to today.
+- `queue.announce(text, kind, { persona })` grows the same optional third
+  argument and forwards it. All existing call sites unchanged.
+
+### Session + telemetry bookkeeping
+
+- The previous session is already archived by the time the runner fires, so
+  both turns append to the **new** session as
+  `role: 'segment', kind: 'handoff'` (the sign-off tagged
+  `meta: { personaId: <outgoing> }`), so the incoming DJ's window opens with the
+  mic-pass it just took part in. `windowMessages()` needs no new filter —
+  handoff turns are real on-air speech and belong in the window.
+- `webhooks.notify('dj.say', { text, kind: 'handoff' })` per line, matching
+  other spoken segments.
+- `logEvent('dj.handoff', { from, to, show })` on the unified timeline.
+
+### Scope
+
+- **In:** hard rolls where the effective persona changes — show starts, show
+  ends (back to the active persona), show→show, and the 4h age-cap roll if the
+  persona happens to differ.
+- **Out (follow-ups):** a manual persona flip in the admin UI mid-block (it
+  doesn't roll the session today, so there's no boundary to hook); a handoff
+  jingle/sweeper between the two lines; per-show custom sign-off briefs.
+
+### Testing
+
+No test runner in this repo — verification is `npm run lint` in controller/
+plus a live smoke test: schedule two adjacent one-hour shows with different
+personas in the dev stack, watch the :00 boundary, confirm two voices air in
+order and `state/sessions/` + the event log carry the handoff turns.

--- a/docs/superpowers/specs/2026-07-03-persona-handoff-design.md
+++ b/docs/superpowers/specs/2026-07-03-persona-handoff-design.md
@@ -1,7 +1,7 @@
 # On-air persona handoff at show boundaries
 
 **Date:** 2026-07-03
-**Status:** Draft — awaiting operator review
+**Status:** Implemented on this branch (PR #762)
 
 ## The idea
 
@@ -127,9 +127,15 @@ never blocks the roll — the existing text handoff is the floor.
 - The previous session is already archived by the time the runner fires, so
   both turns append to the **new** session as
   `role: 'segment', kind: 'handoff'` (the sign-off tagged
-  `meta: { personaId: <outgoing> }`), so the incoming DJ's window opens with the
-  mic-pass it just took part in. `windowMessages()` needs no new filter —
-  handoff turns are real on-air speech and belong in the window.
+  `meta: { personaId, personaName }` of the outgoing persona), so the incoming
+  DJ's window opens with the mic-pass it just took part in. Handoff turns are
+  real on-air speech and belong in the window, but the sign-off was spoken by
+  a *different* persona — `windowMessages()` uses the meta tag to prefix it
+  with the real speaker's name (mirroring the pick-note marker) so the
+  incoming DJ never reads the predecessor's words as its own.
+- `kind: 'handoff'` is registered in the queue's recap `VOICE_KINDS`, so both
+  lines feed `getDjRecap()` / `getRecentOpeners()` and later segments don't
+  echo the greeting's opener.
 - `webhooks.notify('dj.say', { text, kind: 'handoff' })` per line, matching
   other spoken segments.
 - `logEvent('dj.handoff', { from, to, show })` on the unified timeline.


### PR DESCRIPTION
## What

On-air persona handoff when a show ends and a different persona takes over: the outgoing DJ signs off and passes the mic in their own voice, the incoming DJ acknowledges in theirs.

> "This is Johnny Fever signing off for now — passing the mic over to Cool Hand Luke for your Afternoon Drive."
> "Cheers Johnny. Luke here — let's ease into the afternoon…"

## Status

**Spec + implementation.** The design spec (`docs/superpowers/specs/2026-07-03-persona-handoff-design.md`) landed first; the implementation followed on this branch and matches the recommended Approach A.

## How it works

- `session.maybeRoll()`'s hard roll stamps `rolledFrom` + `handoffAired` on the fresh **persisted** session when the effective persona changed — restart-safe, single-fire.
- `runPersonaHandoff` (broadcast/dj-agent.ts) runs after the roll from either call site (track-start or the :00 hourly cron; whichever fires first, the other no-ops). It gates on listeners + daily token budget, marks itself aired up front (idempotent — the check-and-mark section has no awaits), then airs a sign-off in the **outgoing** persona's voice and a greeting in the **incoming** persona's voice — the greeting is fed the sign-off text so it genuinely responds. Each half fails independently; failures never block the pick.
- New primitive: a persona override threaded through `tts.speak()` / `queue.announce()` / `voiceGainDb()` — engine, voice, gain, speed, language, and soul all resolve from the override. Absent, behaviour is byte-identical to today.
- Both lines air through the serialized `say.txt` voice chain, so they play cleanly back to back; the greeting's LLM call overlaps the sign-off's airtime.

## Review fixes (2cd0fb1)

- `windowMessages()` names the real speaker on the sign-off turn (it's the outgoing persona's speech stored in the new session) so the incoming DJ never absorbs the predecessor's words as its own.
- `'handoff'` registered in the queue recap `VOICE_KINDS` so the mic-pass feeds the opener anti-repeat.
- `getFullContext()` kept inside `hourlyCheck`'s try (node-cron doesn't catch async throws).
- Removed a stale-write race between `session.start()`'s unawaited persist and the stamped `rolledFrom` persist.

## Verification

`npm run lint` in controller/ passes (0 errors). Live smoke test per the spec: schedule two adjacent one-hour shows with different personas in the dev stack, watch the :00 boundary, confirm two voices air in order and `state/sessions/` + the event log carry the handoff turns.
