### PR TITLE
fix(dj-agent): salvage unknown-id picks and make empty tool results teach

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -7,7 +7,7 @@
 // node:assert-via-tsx style of scripts/picker-recency-regression.ts.
 
 import assert from 'node:assert/strict';
-import { stripThinking, extractJson, usageOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded, errReason } from '../src/llm/internal/core/pure.js';
+import { stripThinking, extractJson, usageOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded, errReason, nearestId } from '../src/llm/internal/core/pure.js';
 import { withDeadline } from '../src/llm/internal/core/retry.js';
 import { providerOptions, needsToolCallObject, repeatPenaltyApplies, appliedNumCtx, forcedToolChoice } from '../src/llm/internal/provider/capabilities.js';
 import { agentPlan } from '../src/llm/internal/strategy/plan.js';
@@ -459,6 +459,35 @@ async function main() {
     // (maxOutputTokens: 0) → each strategy keeps its own built-in default.
     assert.equal(resolveMaxOutputTokens(4000), 4000);
     assert.equal(resolveMaxOutputTokens(8000), 8000);
+  });
+
+  // ---- nearestId: near-miss id repair for the picker agents ----
+  console.log('nearestId (unknown-id near-miss repair):');
+  await test('repairs the observed live case: final character dropped from a nanoid', () => {
+    // glm-5.1 returned "BFjCKvSeWFKFpKTRvroPC" for the real "BFjCKvSeWFKFpKTRvroPCp".
+    const seen = ['2igTN1Xw3uJBY9CjdKzZGl', 'H8G6Y1gPsSsMNJwflWbstW', 'BFjCKvSeWFKFpKTRvroPCp'];
+    assert.equal(nearestId('BFjCKvSeWFKFpKTRvroPC', seen), 'BFjCKvSeWFKFpKTRvroPCp');
+  });
+  await test('repairs a single substituted character (edit distance 1)', () => {
+    const seen = ['yu4ZsUclpGxnr8CU2YfNf7', 'qJcxd61T5W7YJ0bNryKakG'];
+    assert.equal(nearestId('yu4ZsUclpGxnr8CU2YfNf8', seen), 'yu4ZsUclpGxnr8CU2YfNf7');
+  });
+  await test('rejects a fabricated id (nothing near any candidate)', () => {
+    const seen = ['2igTN1Xw3uJBY9CjdKzZGl', 'H8G6Y1gPsSsMNJwflWbstW'];
+    assert.equal(nearestId('3bKpTnYlqR8vD4sXe2aJ0m', seen), null);
+  });
+  await test('rejects an ambiguous match (two candidates equally close)', () => {
+    // Both differ from the query by one trailing character — no safe winner.
+    const seen = ['AAAAAAAAAAAAAAAAAAAAAx', 'AAAAAAAAAAAAAAAAAAAAAy'];
+    assert.equal(nearestId('AAAAAAAAAAAAAAAAAAAAAz', seen), null);
+  });
+  await test('rejects short-prefix matches (below the 12-char floor)', () => {
+    assert.equal(nearestId('abc', ['abcdef123456789012345']), null);
+  });
+  await test('handles junk input without throwing', () => {
+    assert.equal(nearestId('', ['abcdef123456789012345']), null);
+    assert.equal(nearestId(undefined as any, ['abcdef123456789012345']), null);
+    assert.equal(nearestId('abcdef123456789012345', []), null);
   });
 
   console.log(failures === 0 ? '\nAll llm-pure tests passed.' : `\n${failures} test(s) FAILED.`);

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -198,14 +198,12 @@ const REQUEST_SCHEMA = z.object({
 // competes with the framework's structural signals and derails smaller
 // models. PICKER_CRITERIA stays because it's editorial preference (flow,
 // context, variety, interest) — that's not in any tool or schema.
-// Guidance for the transition effects (PICK_SCHEMA.transition), appended to the
-// picker system prompt ONLY when effects are active (the on-air persona's
-// djMode — see settings.effectsActive; there is no separate toggle). Invisible
-// otherwise, so the model leaves "transition" null.
-function effectsGuidance(): string {
-  if (!settings.effectsActive()) return '';
-  return `\n\nTRANSITION EFFECTS ("transition") — part of your craft, not a gimmick: a working DJ fires one every few songs when the moment earns it. Actively look for the moment on every pick; when you spot one, flag it — the station validates your choice against the audio analysis and skips ones that don't land. The PACING is entirely yours: there is no rate limit, so be the taste — an effect hits hardest coming out of a stretch of clean blends, so let a few ordinary transitions breathe between them. VARY THE TWO: they are equals in your kit, and if your recent picks leaned on one, reach for the other.\n- "washout": your pick dissolves into a pulsing, tempo-synced echo tail as it ENDS, ringing out into whatever follows. Fire it whenever your pick is the natural END of something: the last track of a run of similar songs, a song with a big or atmospheric ending, anything dreamy/hazy/anthemic, or when the NEXT stretch will change direction. In a normal set several tracks qualify — this is your workhorse exit move, not a rarity.\n- "sweep": the track playing before your pick sinks under a slowly closing filter across the blend while your pick rises clean underneath. Use it on a genuine gear-change — a clear jump in energy, tempo, or mood (it only fires when the tracks measurably clash).\n- "blend": spectral handover — across a long crossfade the outgoing track hands its bass, then its mids, to your pick, keeping only its highs to the end, while your pick arrives lows-first underneath. The two feel like ONE continuous piece of music. Use it for same-lane picks: similar tempo, energy, or mood (it only fires when the tracks measurably fit).\nUse "normal" or null only when nothing above applies.`;
-}
+// The transition-effects guidance (PICK_SCHEMA.transition) now lives in
+// llm/internal/prompts/picker.ts (dj.effectsGuidance) so the pool picker
+// shares it verbatim — it's appended to the picker system prompt ONLY when
+// effects are active (the on-air persona's djMode — see
+// settings.effectsActive; there is no separate toggle). Invisible otherwise,
+// so the model leaves "transition" null.
 
 export function pickSystem() {
   const persona = settings.getEffectivePersona();
@@ -247,7 +245,7 @@ You run the station as one continuous shift. The messages above are the live ses
 
 ${dj.PICKER_CRITERIA}
 
-Finding candidates: prefer tools backed by the local library — searchLibrary, songsByGenre, tracksByMood, tracksByEnergy, randomSongs, and the audio/embedding similarity tools. similarSongs and topSongsByArtist use external data and often return little, so try them second. If a tool returns nothing, switch tools rather than retrying. If a tool returns only a few tracks (fewer than ~4), make one more discovery call with a different tool before choosing, so you pick from a real range rather than whatever the first call happened to surface.${effectsGuidance()}${settings.agentLanguageReminder(persona, 'the "say" link')}`;
+Finding candidates: prefer tools backed by the local library — searchLibrary, songsByGenre, tracksByMood, tracksByEnergy, randomSongs, and the audio/embedding similarity tools. similarSongs and topSongsByArtist use external data and often return little, so try them second. If a tool returns nothing, switch tools rather than retrying. If a tool returns only a few tracks (fewer than ~4), make one more discovery call with a different tool before choosing, so you pick from a real range rather than whatever the first call happened to surface.${dj.effectsGuidance()}${settings.agentLanguageReminder(persona, 'the "say" link')}`;
 }
 
 function requestSystem() {
@@ -614,9 +612,21 @@ async function pickViaPool(queue, ctx, { wantLink, current }, rankTarget: { bpm:
       queue.log('error', `DJ link failed: ${err.message}`);
     }
   }
+  // Transition effects ride the pool path too (pickNextTrack only offers the
+  // field when settings.effectsActive()), so a DJ-mode persona keeps its craft
+  // while picks run through this fallback. Re-check effectsActive at enqueue
+  // time like the agent path does — the queue would strip a stale flag anyway
+  // (applyMixTransition's dj-mode-off strip), but not stamping it keeps the
+  // pick log honest.
+  const fxActive = settings.effectsActive();
+  const fx = {
+    sweep: fxActive && result.transition === 'sweep',
+    washout: fxActive && result.transition === 'washout',
+    blend: fxActive && result.transition === 'blend',
+  };
   // `current` is the link's back-announce target (passed to generateLink as
   // `previous`); stamp it so the queue drops the link if a request jumps ahead.
-  const queued = await enqueuePick(queue, result.song, result.reason, result.source || 'pool', link, current);
+  const queued = await enqueuePick(queue, result.song, result.reason, result.source || 'pool', link, current, fx);
   // Even the pool landed on an already-queued track (a tiny library whose pool
   // collapsed to recents). Skip the session turn and let auto.m3u backstop the
   // slot — the next track-start re-triggers runTrackEvent for a fresh pick.

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -22,6 +22,7 @@ import * as journey from '../music/journey.js';
 import * as dj from '../llm/dj.js';
 import { energyForDaypart } from '../context.js';
 import { defineAgent } from '../llm/agent.js';
+import { djObject, nearestId } from '../llm/sdk.js';
 import { buildPickerTools } from '../llm/tools.js';
 import { recordPick } from '../llm/log.js';
 import * as budget from './dj-budget.js';
@@ -333,6 +334,11 @@ export const pickerAgent = defineAgent({
     const { tools, seen } = buildPickerTools({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, genreLock, eraLock, playlistLock, playlistTracks });
     return { tools, extras: { seen } };
   },
+  // Native-path acceptance: the picked id must be one a discovery tool actually
+  // surfaced this run. A fabricated id falls the run through to the done-tool
+  // harness instead of surfacing as an unknown-id rejection (observed:
+  // gpt-5-mini invented 7/32 ids after an empty tool result).
+  validateObject: (object, extras) => !!(object?.id && extras?.seen?.has(object.id)),
 });
 
 export const requestAgent = defineAgent({
@@ -353,6 +359,9 @@ export const requestAgent = defineAgent({
     });
     return { tools, extras: { seen } };
   },
+  // Same native-path acceptance as pickerAgent — the request agent runs the
+  // same model through the same harness, so it fabricates the same way.
+  validateObject: (object, extras) => !!(object?.id && extras?.seen?.has(object.id)),
 });
 
 function trackFields(song) {
@@ -417,6 +426,37 @@ async function enqueuePick(
 // Track event — a track started; pick the next one and maybe air a link.
 // ---------------------------------------------------------------------------
 
+// Stage-2 salvage for an agent run whose final id no tool surfaced (see the
+// cascade in pickViaAgent): one djObject call over the run's OWN accumulated
+// candidates (`seen`), with the id constrained to that exact set — z.enum
+// becomes a decode-time grammar on local models and a Zod reject elsewhere,
+// the same closing move pickNextTrack already uses. Returns a full pick object
+// (id/reason/say/transition) or null; never throws, so a salvage failure falls
+// through to the caller's pick.rejected path unchanged.
+async function repickFromSeen({ seen, badId, wantLink }: { seen: Map<string, any>; badId: string | null; wantLink: boolean }) {
+  const ids = [...seen.keys()];
+  if (ids.length === 0) return null;
+  const base = settings.effectsActive() ? PICK_SCHEMA : PICK_SCHEMA_NO_FX;
+  const schema = base.extend({
+    id: z.enum(ids as [string, ...string[]]).describe('the exact id of one candidate'),
+  });
+  try {
+    return await djObject({
+      system: pickSystem(),
+      prompt: JSON.stringify({ candidates: [...seen.values()] }, null, 2)
+        + `\n\nYou explored the library and then answered with ${badId ? `the id "${badId}", which matches none of the tracks your tools returned` : 'no usable track id'}. Only ids from the candidates above are real. Choose the best next track from them.`
+        + (wantLink
+            ? ' Write the "say" link for the track you choose, following the same rules.'
+            : ' Set "say" to null.'),
+      schema,
+      temperature: 0.5,
+      kind: 'djAgentRepick',
+    });
+  } catch {
+    return null;
+  }
+}
+
 async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = null }: { wantLink: boolean; audioWaypoint?: number[] | null; current?: any }): Promise<boolean> {
   await library.load();
   const stats = library.stats();
@@ -449,7 +489,7 @@ async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = n
   const playlistLock = playlistPool && activeShow?.playlistStrict ? playlistPool.ids : null;
   const playlistTracks = playlistPool?.tracks ?? null;
 
-  const { object, steps, toolCalls, extras } = await pickerAgent.run({
+  const run = await pickerAgent.run({
     messages: session.windowMessages(),
     recentIds,
     recentKeys,
@@ -462,14 +502,48 @@ async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = n
     playlistLock,
     playlistTracks,
   });
+  const { steps, toolCalls, extras } = run;
+  let object = run.object;
 
-  const song = object?.id ? extras.seen.get(object.id) : null;
+  let song = object?.id ? extras.seen.get(object.id) : null;
+
+  // The agent returned an id that isn't in the candidate set it was shown.
+  // Two-stage salvage before giving up on the run (both observed live):
+  //   1. Near-miss repair — the model transcribed a REAL id imperfectly
+  //      (glm-5.1 dropped the final character of a 22-char nanoid it had
+  //      picked from its own tool results). nearestId only accepts a single
+  //      unambiguous prefix / edit-distance-1 match, so this can't misfire
+  //      onto a different track. Free — no model call.
+  //   2. Corrective re-pick — the model fabricated an id outright (gpt-5-mini
+  //      after an empty tool result) while its `seen` map held real
+  //      candidates. One djObject call constrained to those ids (grammar-
+  //      enforced on local models, Zod-checked everywhere) beats paying the
+  //      pool fallback + a breaker increment for a run that DID explore.
+  if (!song && object?.id && extras.seen.size) {
+    const fixed = nearestId(object.id, extras.seen.keys());
+    if (fixed) {
+      logEvent('pick.repaired', { agent: 'pick', from: object.id, to: fixed });
+      queue.log('picker', `agent id "${object.id}" repaired to near-miss match "${fixed}"`);
+      object = { ...object, id: fixed };
+      song = extras.seen.get(fixed);
+    }
+  }
+  if (!song && extras.seen.size) {
+    const repicked = await repickFromSeen({ seen: extras.seen, badId: object?.id ?? null, wantLink });
+    if (repicked) {
+      logEvent('pick.repicked', { agent: 'pick', from: object?.id ?? null, to: repicked.id, candidates: extras.seen.size });
+      queue.log('picker', `agent returned unknown id "${object?.id}" — re-picked "${repicked.id}" from its own candidates`);
+      object = repicked;
+      song = extras.seen.get(repicked.id);
+    }
+  }
+
   if (!song) {
-    // The agent returned an id that isn't in the candidate set it was shown —
-    // it fabricated one. The trace still ends ok:true (we fall back to the pool
-    // and air a track), so without this explicit event the rejection is
-    // invisible to /debug and the log analyzer, which then over-report agent
-    // health. Emit it inside the live trace so agent-pick reliability is real.
+    // Both salvage stages missed (or the run surfaced zero candidates). The
+    // trace still ends ok:true (we fall back to the pool and air a track), so
+    // without this explicit event the rejection is invisible to /debug and the
+    // log analyzer, which then over-report agent health. Emit it inside the
+    // live trace so agent-pick reliability is real.
     logEvent('pick.rejected', { agent: 'pick', id: object?.id ?? null, candidates: extras.seen.size, steps, toolCalls });
     throw new Error(`agent returned unknown id ${object?.id}`);
   }
@@ -722,7 +796,19 @@ async function runRequestViaAgent(queue: any, { requester }: { requester: string
       recentIds,
     });
 
-    const song = object?.id ? extras.seen.get(object.id) : null;
+    let song = object?.id ? extras.seen.get(object.id) : null;
+    // Near-miss repair, same as the pick path: a single unambiguous prefix /
+    // edit-distance-1 match against the run's own candidates rescues an id the
+    // model transcribed imperfectly. No re-pick stage here — a request that
+    // can't resolve should fall to the caller's stateless matcher cascade,
+    // which understands the listener's actual text.
+    if (!song && object?.id && extras.seen.size) {
+      const fixed = nearestId(object.id, extras.seen.keys());
+      if (fixed) {
+        logEvent('pick.repaired', { agent: 'request', from: object.id, to: fixed });
+        song = extras.seen.get(fixed);
+      }
+    }
     if (!song) {
       logEvent('pick.rejected', { agent: 'request', id: object?.id ?? null, candidates: extras.seen.size, toolCalls });
       throw new Error(`request agent returned unknown id ${object?.id}`);

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -21,7 +21,7 @@ export {
   generateLink,
   generateHourlyTime,
 } from './internal/prompts/scripts.js';
-export { PICKER_CRITERIA, pickNextTrack, showMusicLean } from './internal/prompts/picker.js';
+export { PICKER_CRITERIA, pickNextTrack, showMusicLean, effectsGuidance } from './internal/prompts/picker.js';
 export { generatePersona, generateShow, generateTheme } from './internal/prompts/generate.js';
 
 // Re-exported so routes/debug.js can read the LLM call ring buffer through the

--- a/controller/src/llm/internal/agent-factory.ts
+++ b/controller/src/llm/internal/agent-factory.ts
@@ -35,6 +35,10 @@ export interface AgentDefinition {
   timeoutMs?: number | (() => number);
   temperature?: number;
   maxOutputTokens?: number;
+  // Acceptance check on the native path's object, given this run's buildTools
+  // extras (the picker checks its chosen id against the `seen` map). A miss
+  // falls the run through to the done-tool harness — see djAgent's validate.
+  validateObject?: (object: any, extras: any) => boolean;
 }
 
 export interface AgentRunResult {
@@ -92,6 +96,9 @@ export function defineAgent(def: AgentDefinition): DjAgentInstance {
         temperature: def.temperature,
         maxOutputTokens: def.maxOutputTokens,
         kind: def.kind,
+        ...(def.validateObject
+          ? { validate: (object: any) => def.validateObject!(object, built.extras) }
+          : {}),
       });
       return {
         object: result.object,

--- a/controller/src/llm/internal/core/pure.ts
+++ b/controller/src/llm/internal/core/pure.ts
@@ -273,3 +273,51 @@ export function failureDiagnostics(err: any): any {
   }
   return out;
 }
+
+// ---------------------------------------------------------------------------
+// Near-miss id resolution
+// ---------------------------------------------------------------------------
+
+// Levenshtein distance capped at 2 — we only ever care about distance ≤ 1, so
+// bail as soon as a row's minimum exceeds the cap instead of filling the table.
+function editDistanceAtMost2(a: string, b: string): number {
+  if (Math.abs(a.length - b.length) > 2) return 3;
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const cur = [i];
+    let rowMin = i;
+    for (let j = 1; j <= b.length; j++) {
+      cur[j] = Math.min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1));
+      if (cur[j] < rowMin) rowMin = cur[j];
+    }
+    if (rowMin > 2) return 3;
+    prev = cur;
+  }
+  return prev[b.length];
+}
+
+// Resolve a model-returned id that isn't in the candidate set to the candidate
+// it almost certainly meant, or null when no single safe match exists. Covers
+// the observed transcription slips (glm-5.1 dropped the final character of an
+// id it had genuinely picked from its own tool results — a 22-char nanoid
+// returned as 21) without ever guessing between two plausible candidates:
+//   1. prefix — one string is a prefix of the other, ≥ 12 chars shared and ≤ 3
+//      chars difference (nanoid-style ids make a 12-char prefix collision
+//      astronomically unlikely; 12 also keeps short ids from matching wildly).
+//   2. edit distance ≤ 1 — a single dropped/added/substituted character.
+// Both passes require EXACTLY one candidate to match — any ambiguity → null,
+// the caller falls back to its re-pick / stateless path rather than airing a
+// coin-flip.
+export function nearestId(id: string, candidateIds: Iterable<string>): string | null {
+  if (!id || typeof id !== 'string') return null;
+  const ids = [...candidateIds];
+  const prefix = ids.filter((c) =>
+    c !== id
+    && Math.min(c.length, id.length) >= 12
+    && Math.abs(c.length - id.length) <= 3
+    && (c.startsWith(id) || id.startsWith(c)));
+  if (prefix.length === 1) return prefix[0];
+  if (prefix.length > 1) return null;
+  const near = ids.filter((c) => c !== id && editDistanceAtMost2(c, id) <= 1);
+  return near.length === 1 ? near[0] : null;
+}

--- a/controller/src/llm/internal/prompts/picker.ts
+++ b/controller/src/llm/internal/prompts/picker.ts
@@ -12,6 +12,18 @@ export const PICKER_CRITERIA = `Selection criteria, in order:
 3. VARIETY — avoid the same artist back-to-back; don't repeat tracks you've already played today; rotate energy. Variety over cleverness — never pick a track because its title literally matches the time of day, the weather, or anything else literal.
 4. INTEREST — prefer something that creates a moment, not the most generic option.`;
 
+// Coaching for the DJ transition effects (the "transition" output field),
+// shared by both pick strategies — the conversational agent (dj-agent.ts
+// pickSystem) and the pool picker below — so the craft guidance can't drift
+// between them. Returns '' when effects are off (the on-air persona isn't in
+// DJ mode — settings.effectsActive), so callers append it unconditionally.
+// Lives here rather than in broadcast/dj-agent.ts because llm/ must not
+// import from broadcast/.
+export function effectsGuidance(): string {
+  if (!settings.effectsActive()) return '';
+  return `\n\nTRANSITION EFFECTS ("transition") — part of your craft, not a gimmick: a working DJ fires one every few songs when the moment earns it. Actively look for the moment on every pick; when you spot one, flag it — the station validates your choice against the audio analysis and skips ones that don't land. The PACING is entirely yours: there is no rate limit, so be the taste — an effect hits hardest coming out of a stretch of clean blends, so let a few ordinary transitions breathe between them. VARY THE TWO: they are equals in your kit, and if your recent picks leaned on one, reach for the other.\n- "washout": your pick dissolves into a pulsing, tempo-synced echo tail as it ENDS, ringing out into whatever follows. Fire it whenever your pick is the natural END of something: the last track of a run of similar songs, a song with a big or atmospheric ending, anything dreamy/hazy/anthemic, or when the NEXT stretch will change direction. In a normal set several tracks qualify — this is your workhorse exit move, not a rarity.\n- "sweep": the track playing before your pick sinks under a slowly closing filter across the blend while your pick rises clean underneath. Use it on a genuine gear-change — a clear jump in energy, tempo, or mood (it only fires when the tracks measurably clash).\n- "blend": spectral handover — across a long crossfade the outgoing track hands its bass, then its mids, to your pick, keeping only its highs to the end, while your pick arrives lows-first underneath. The two feel like ONE continuous piece of music. Use it for same-lane picks: similar tempo, energy, or mood (it only fires when the tracks measurably fit).\nUse "normal" or null only when nothing above applies.`;
+}
+
 export type ShowMusic = { name: string; topic: string; genre?: string; fromYear?: number | null; toYear?: number | null; energy?: string; genreStrict?: boolean };
 
 // A show can pin a genre, decade and/or energy band on track selection. Genre
@@ -77,11 +89,16 @@ unplayed, so you never need to reject one for being recent.
 Pick exactly one candidate.`;
 }
 
-export async function pickNextTrack({ candidates, recentPlays, context, show = null }: {
+export async function pickNextTrack({ candidates, recentPlays, context, show = null, recentTransitions = [] }: {
   candidates: any[];
   recentPlays: any;
   context: any;
   show?: ShowMusic | null;
+  // The model's recent transition asks (oldest first), for the same deliberate-
+  // variety nudge the agent path gets — the queue's monoculture guard strips a
+  // third identical choice either way, this just keeps the model from wasting
+  // picks on choices that will be stripped. Only used when effects are active.
+  recentTransitions?: string[];
 }) {
   const user = JSON.stringify({
     now: {
@@ -112,12 +129,28 @@ export async function pickNextTrack({ candidates, recentPlays, context, show = n
     ? z.enum(candidateIds as [string, ...string[]]).describe('the exact id of one candidate')
     : z.string().describe('the exact id of one candidate');
 
+  // Transition effects on the pool path too: the queue's applyMixTransition
+  // validates/strips whatever any pick strategy asks for, so a DJ-mode persona
+  // keeps its craft even while picks run through this fallback (breaker open,
+  // soft budget tier, pickerAgent off). Unlike the agent's session-anchored
+  // schema pair (PICK_SCHEMA / PICK_SCHEMA_NO_FX), this is a one-shot call with
+  // no history to poison — when effects are off the field simply doesn't exist.
+  const fxActive = settings.effectsActive();
+  const fxGuidance = effectsGuidance();
+  const fxHistory = fxActive && recentTransitions.length
+    ? `\n\nYour recent transition choices, oldest first: ${recentTransitions.join(', ')} — the station strips a third repeat, so vary deliberately.`
+    : '';
+
   return djObject({
-    system: pickerSystem(show),
+    system: `${pickerSystem(show)}${fxGuidance}${fxHistory}`,
     prompt: user,
     schema: z.object({
       id: idSchema,
       reason: z.string().describe('one short sentence on why this one'),
+      ...(fxActive ? {
+        transition: z.enum(['normal', 'blend', 'sweep', 'washout']).nullable()
+          .describe('transition treatment for this pick — "blend" for a same-lane pick (similar tempo/energy/mood), "sweep" for a genuine gear-change, "washout" to dissolve this pick out as it ends; "normal" or null for a plain crossfade. The TRANSITION EFFECTS guidance above explains each.'),
+      } : {}),
     }),
     temperature: 0.5,
     kind: 'pickNextTrack',

--- a/controller/src/llm/internal/strategy/agent.ts
+++ b/controller/src/llm/internal/strategy/agent.ts
@@ -101,6 +101,18 @@ export async function djAgent({
   maxOutputTokens = resolveMaxOutputTokens(MAX_TOKENS_AGENT),
   kind = 'sdk.djAgent',
   timeoutMs,
+  // Optional caller-supplied acceptance check on the native path's object
+  // (e.g. "the picked id must be one a discovery tool actually surfaced").
+  // The native path is the only branch with no structural control over WHAT
+  // the model emits — Output.object + auto tool choice validates the schema
+  // shape, not the content — so a fabricated-but-well-formed answer sails
+  // through where the done-tool harness would have cornered the model.
+  // A validate miss falls through to the done-tool path instead of returning
+  // an object the caller can only throw away (observed: gpt-5-mini invented
+  // 7/32 pick ids after an empty tool result, each costing a pool fallback +
+  // a breaker increment). Not applied to the done-tool/recovery results: the
+  // caller repairs those itself with the full `seen` context.
+  validate,
 }: any): Promise<{ object: any; steps: number; toolCalls: any[] }> {
   return withFailover(
     kind,
@@ -161,7 +173,13 @@ export async function djAgent({
             // the caller resolves the id against `seen`, which only tool calls
             // populate, so an explored pick is also a resolvable one.
             const explored = (nr.steps || []).some((s: any) => (s.toolCalls || []).length > 0);
-            if (nObj && explored) {
+            // Caller acceptance check (see the validate param note). A throwing
+            // validator counts as a miss, never as an agent failure.
+            let accepted = true;
+            if (nObj && explored && typeof validate === 'function') {
+              try { accepted = !!validate(nObj); } catch { accepted = false; }
+            }
+            if (nObj && explored && accepted) {
               const toolCalls = flattenToolCalls(nr);
               return {
                 value: { object: nObj, steps: nSteps, toolCalls },
@@ -171,7 +189,7 @@ export async function djAgent({
                 extra: { system, messages, toolCalls, steps: nSteps, response: JSON.stringify(nObj, null, 2) },
               };
             }
-            console.log(`[${kind}] native output produced no usable pick (explored=${explored}) — falling back to done-tool`);
+            console.log(`[${kind}] native output produced no usable pick (explored=${explored}, accepted=${accepted}) — falling back to done-tool`);
           } catch (e: any) {
             console.log(`[${kind}] native output failed (${e?.message}) — falling back to done-tool`);
           }

--- a/controller/src/llm/internal/telemetry/log.ts
+++ b/controller/src/llm/internal/telemetry/log.ts
@@ -58,7 +58,13 @@ export function record(call: any) {
       kind: call.kind,
       name: tc.name,
       args: cap(JSON.stringify(tc.args ?? null), 1000),
-      resultCount: Array.isArray(tc.result) ? tc.result.length : undefined,
+      // Picker tools return either a bare track array or, when empty, a
+      // { tracks: [], note, rule } hint object — count both shapes so an
+      // empty-with-hint result still logs resultCount: 0 (the log analyzer
+      // keys on it), not undefined.
+      resultCount: Array.isArray(tc.result) ? tc.result.length
+        : Array.isArray(tc.result?.tracks) ? tc.result.tracks.length
+        : undefined,
     });
   }
 }

--- a/controller/src/llm/internal/tools/picker-tools.ts
+++ b/controller/src/llm/internal/tools/picker-tools.ts
@@ -53,7 +53,10 @@ function slim(s: any) {
     ...(src.energy != null ? { energy: src.energy } : {}),
     ...(durationSec != null ? { duration_sec: durationSec } : {}),
     ...(instrumental != null ? { instrumental } : {}),
-    ...(src.bpm != null ? { bpm: src.bpm } : {}),
+    // Truthy, not != null: un-analysed tracks carry bpm 0, and emitting
+    // "bpm": 0 tells the model the tempo is zero while PICKER_CRITERIA says to
+    // segue on it. 0 means unknown — omit, like every other absent fact.
+    ...(src.bpm ? { bpm: src.bpm } : {}),
     ...(src.musicalKey != null ? { key: src.musicalKey } : {}),
     ...(src.introMs != null ? { intro_ms: src.introMs } : {}),
     ...(src.paceMean != null ? { pace: src.paceMean } : {}),
@@ -173,6 +176,20 @@ export function buildPickerTools({
     return out;
   };
 
+  // When a tool comes up empty, say WHY and what to try next instead of a bare
+  // [] — the observed fabrication pattern is "tool returned nothing → model
+  // invents a plausible-looking id anyway" (7 of gpt-5-mini's 32 picks in one
+  // day). `matched` is the pre-recency-filter count, so the note distinguishes
+  // "nothing matches" from "matches exist but were all played recently or
+  // already shown this pick" — opposite next moves for the model.
+  const emptyResult = (matched: number, hint: string) => ({
+    tracks: [],
+    note: matched > 0
+      ? `${matched} matching track(s) exist but were all played recently or already shown this pick — ${hint}`
+      : hint,
+    rule: 'Never invent a song id — only ids returned by a tool are valid picks.',
+  });
+
   // Snapshot the embedding index counts once at tool-build time (synchronous
   // after library.load() — pickViaAgent awaits library.load() before reaching
   // buildPickerTools, so stats() never returns its empty-sentinel zeros here).
@@ -205,11 +222,15 @@ export function buildPickerTools({
           // Lexical search3 found nothing — fall back to semantic embedding
           // search over the library (same path as searchByLyrics) so vibe
           // queries still return tracks. No-op when embeddings aren't set up.
-          if (!embeddings.isAvailable()) return out;
-          await library.load();
-          const vec = await embeddings.embedQueryText(query.trim(), library.embeddingIndexTextMode());
-          if (!vec) return out;
-          return collect(library.tracksByVector(vec, 20));
+          if (embeddings.isAvailable()) {
+            await library.load();
+            const vec = await embeddings.embedQueryText(query.trim(), library.embeddingIndexTextMode());
+            if (vec) {
+              const sem = collect(library.tracksByVector(vec, 20));
+              if (sem.length > 0) return sem;
+            }
+          }
+          return emptyResult(songs.length, 'this search matches literal titles/artists/genres first and the vibe index found nothing — try songsByGenre with a single genre word, or tracksByMood');
         }
         catch (err) { return { error: err.message }; }
       },
@@ -219,7 +240,11 @@ export function buildPickerTools({
       description: 'Find songs similar to a given song id. Pass the currently-playing song id to keep the flow going.',
       inputSchema: z.object({ songId: z.string() }),
       execute: async ({ songId }) => {
-        try { return collect(await subsonic.getSimilarSongs(songId, { count: 20 })); }
+        try {
+          const list = await subsonic.getSimilarSongs(songId, { count: 20 });
+          const out = collect(list);
+          return out.length ? out : emptyResult(list.length, 'no similarity data for that track — try tracksByMood, songsByGenre, or searchLibrary instead');
+        }
         catch (err) { return { error: err.message }; }
       },
     }),
@@ -228,7 +253,11 @@ export function buildPickerTools({
       description: 'Top songs for a named artist — good for staying in an artist\'s orbit without repeating a track.',
       inputSchema: z.object({ artist: z.string() }),
       execute: async ({ artist }) => {
-        try { return collect(await subsonic.getTopSongs(artist, { count: 15 })); }
+        try {
+          const list = await subsonic.getTopSongs(artist, { count: 15 });
+          const out = collect(list);
+          return out.length ? out : emptyResult(list.length, 'no top-songs data for that artist — try searchLibrary with the artist name');
+        }
         catch (err) { return { error: err.message }; }
       },
     }),
@@ -240,7 +269,11 @@ export function buildPickerTools({
         // Keep the source list tight (newest ~6 tracks): collect() shuffles, so
         // a wide pool would let the shuffle drop the actual-newest tracks,
         // defeating "latest".
-        try { return collect(await subsonic.getRecentSongsByArtist(artist, { albums: 2, count: 6 })); }
+        try {
+          const list = await subsonic.getRecentSongsByArtist(artist, { albums: 2, count: 6 });
+          const out = collect(list);
+          return out.length ? out : emptyResult(list.length, 'that artist has no releases in the library — try topSongsByArtist or searchLibrary');
+        }
         catch (err) { return { error: err.message }; }
       },
     }),
@@ -252,7 +285,9 @@ export function buildPickerTools({
         try {
           const name = await subsonic.resolveGenreName(genre);
           if (!name) return { error: `no library genre matching "${genre}"` };
-          return collect(await subsonic.getSongsByGenre(name, { count: 50 }));
+          const list = await subsonic.getSongsByGenre(name, { count: 50 });
+          const out = collect(list);
+          return out.length ? out : emptyResult(list.length, `the "${name}" genre has nothing fresh right now — try another genre or tracksByMood`);
         }
         catch (err) { return { error: err.message }; }
       },
@@ -273,9 +308,23 @@ export function buildPickerTools({
       execute: async ({ mood, energy }) => {
         try {
           await library.load();
-          let rows = library.songsByMood(mood);
-          if (energy) rows = rows.filter((r: any) => r.energy === energy);
-          return collect(rows);
+          const moodRows = library.songsByMood(mood);
+          const rows = energy ? moodRows.filter((r: any) => r.energy === energy) : moodRows;
+          const out = collect(rows);
+          if (out.length) return out;
+          // Empty for three distinct reasons — tell the model which, because
+          // the fixes are different (observed: {mood:"night", energy:"low"} →
+          // bare [] → fabricated id).
+          if (energy && moodRows.length > 0 && rows.length === 0) {
+            return emptyResult(0, `${moodRows.length} "${mood}" track(s) exist but none tagged ${energy} energy — call again with energy: null`);
+          }
+          if (moodRows.length === 0) {
+            const covered = Object.keys(library.stats().byMood || {}).join(', ');
+            return emptyResult(0, covered
+              ? `no tracks tagged "${mood}" — moods with coverage in this library: ${covered}`
+              : `no tracks tagged "${mood}"`);
+          }
+          return emptyResult(rows.length, 'try another mood, drop the energy filter, or use songsByGenre');
         }
         catch (err) { return { error: err.message }; }
       },
@@ -285,7 +334,12 @@ export function buildPickerTools({
       description: 'Songs tagged with a specific energy level: low (slow / mellow / ambient), medium (mid-tempo / steady), or high (uptempo / driving). Use for time-of-day or activity-based picks the mood vocab alone can\'t express — e.g. high for a workout, low for a wind-down, medium for a commute.',
       inputSchema: z.object({ energy: z.enum(['low', 'medium', 'high']) }),
       execute: async ({ energy }) => {
-        try { await library.load(); return collect(library.songsByEnergy(energy)); }
+        try {
+          await library.load();
+          const list = library.songsByEnergy(energy);
+          const out = collect(list);
+          return out.length ? out : emptyResult(list.length, `no ${energy}-energy tracks available — try tracksByMood or songsByGenre`);
+        }
         catch (err) { return { error: err.message }; }
       },
     }),
@@ -310,7 +364,13 @@ export function buildPickerTools({
           songId: z.string().describe('a song id (preferred) or a track title'),
         }),
         execute: async ({ songId }) => {
-          try { await library.load(); return collect(library.tracksLikeThis(songId, 60)); }
+          try {
+            await library.load();
+            const list = library.tracksLikeThis(songId, 60);
+            const out = collect(list);
+            return out.length ? out : emptyResult(list.length,
+              `that track has no embedding yet (${_stats.withEmbedding ?? 0} of ${_stats.total} tracks indexed so far) — try similarSongs or tracksByMood`);
+          }
           catch (err) { return { error: err.message }; }
         },
       }),
@@ -331,7 +391,13 @@ export function buildPickerTools({
           songId: z.string().describe('a song id (preferred) or a track title'),
         }),
         execute: async ({ songId }) => {
-          try { await library.load(); return collect(library.tracksLikeThisAudio(songId, 60)); }
+          try {
+            await library.load();
+            const list = library.tracksLikeThisAudio(songId, 60);
+            const out = collect(list);
+            return out.length ? out : emptyResult(list.length,
+              `the seed track likely has no audio vector yet (audio analysis covers ${_stats.withAudioEmbedding ?? 0} of ${_stats.total} tracks so far) — try tracksLikeThis or similarSongs`);
+          }
           catch (err) { return { error: err.message }; }
         },
       }),
@@ -357,7 +423,9 @@ export function buildPickerTools({
             await library.load();
             const vec = await embeddings.embedQueryText(query.trim(), library.embeddingIndexTextMode());
             if (!vec) return { error: 'embedding query failed' };
-            return collect(library.tracksByVector(vec, 60));
+            const list = library.tracksByVector(vec, 60);
+            const out = collect(list);
+            return out.length ? out : emptyResult(list.length, 'no thematic match — try tracksByMood or songsByGenre');
           }
           catch (err) { return { error: err.message }; }
         },
@@ -425,7 +493,12 @@ export function buildPickerTools({
           // Pull a wide KNN (60) around the waypoint: the nearest neighbours
           // cluster tightly and many will be recently-played, so a small k left
           // the agent with ~1 candidate. collect() still caps to 8 fresh ones.
-          try { await library.load(); return collect(library.tracksByAudioVector(audioWaypoint, 60)); }
+          try {
+            await library.load();
+            const list = library.tracksByAudioVector(audioWaypoint, 60);
+            const out = collect(list);
+            return out.length ? out : emptyResult(list.length, 'the journey has no fresh tracks near this waypoint — pick via the library mood/genre/audio tools and keep the energy heading the same way');
+          }
           catch (err) { return { error: err.message }; }
         },
       }),

--- a/controller/src/llm/sdk.ts
+++ b/controller/src/llm/sdk.ts
@@ -6,4 +6,4 @@
 export { djText } from './internal/strategy/text.js';
 export { djObject } from './internal/strategy/object.js';
 export { djAgent } from './internal/strategy/agent.js';
-export { isUnreachable, isQuotaOrAuthError, errReason } from './internal/core/pure.js';
+export { isUnreachable, isQuotaOrAuthError, errReason, nearestId } from './internal/core/pure.js';

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -519,6 +519,12 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   }
 
   const recentPlays = summariseRecent(queue);
+  // The model's recent transition asks, for the deliberate-variety nudge —
+  // only consulted by pickNextTrack when effects are active. Guarded call:
+  // picker-test.mjs drives this path with a stub queue.
+  const recentTransitions = typeof queue.recentTransitionChoices === 'function'
+    ? queue.recentTransitionChoices()
+    : [];
 
   let pickRaw;
   try {
@@ -569,6 +575,7 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
       }),
       recentPlays,
       context: ctx,
+      recentTransitions,
     });
   } catch (err) {
     // The LLM pick failed outright (e.g. unparseable structured output even
@@ -599,5 +606,9 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
     song: chosen,
     reason: pickRaw.reason || null,
     source: chosen._source,
+    // Present only when effects were active at call time (the schema omits the
+    // field otherwise). The caller maps it to the queued track's effect flags;
+    // the queue's applyMixTransition validates/strips it like any agent pick.
+    transition: pickRaw.transition ?? null,
   };
 }


### PR DESCRIPTION
## What

Two changes from a review of a full day of live picker telemetry (387 agent picks, 8 `pick.rejected` events, 1 breaker trip):

**1. Close the unknown-id failure modes.** Two distinct patterns were observed live:
- **Near-miss transcription** — glm-5.1 returned a real id minus its final character (`…vroPC` for `…vroPCp`), an id it had picked from its own tool results. 1/355 picks.
- **Outright fabrication after an empty tool result** — gpt-5-mini fired a vibe-phrase at `searchLibrary` or an off-vocabulary mood at `tracksByMood`, got a bare `[]`, and invented a plausible-looking nanoid despite holding 8–24 real candidates. 7/32 picks (~22%), tripping the circuit breaker and forcing 25 minutes on the stateless pool.

Each rejection previously cost a pool fallback plus a breaker increment.

**2. Transition effects on the pool pick path.** The pool runs precisely when the agent is unhealthy (breaker open, soft budget tier, `pickerAgent` off) — and a DJ-mode persona silently lost all transition effects during those stretches, because `pickNextTrack`'s schema was `{id, reason}` only.

## How

Unknown-id integrity:
- **`nearestId`** (`core/pure.ts`, unit-pinned): accepts only a single unambiguous prefix (≥12 shared chars, ≤3 diff) or edit-distance-1 match against the run's `seen` map — repairs the transcription slip with zero model calls, can never coin-flip between two candidates. Applied on both the pick and request paths before rejecting.
- **`repickFromSeen`** (`dj-agent.ts`): stage-2 salvage — one `djObject` call over the run's own accumulated candidates with the id constrained via `z.enum` (decode-time grammar on local models, Zod reject elsewhere). A run that genuinely explored salvages a real pick instead of being thrown away.
- **`validateObject`** (agent factory → `djAgent` `validate`): the native structured-output path now requires the picked id to be one a discovery tool surfaced this run; a fabrication falls through to the done-tool harness that corners the model.
- **Empty tool results teach**: picker tools return `{ tracks: [], note, rule }` instead of a bare `[]` — distinguishing "nothing matches" from "matches exist but were all played recently / already shown", listing the mood vocabulary with coverage on a mood miss, naming the mood-vs-energy filter conflict, surfacing embedding-index coverage on the KNN tools, and stating that invented ids are never valid. Bare `[]` preceded every observed fabrication.
- **`slim()`**: omit `bpm: 0` (un-analysed sentinel) — it told the model the tempo was zero while PICKER_CRITERIA says to segue on it.
- **Telemetry**: `resultCount` counts the hinted-empty shape as `0`; new `pick.repaired` / `pick.repicked` events; `pick.rejected` now only fires when both salvage stages miss.

Pool transitions:
- **`effectsGuidance`** moves from `broadcast/dj-agent.ts` to `llm/internal/prompts/picker.ts` (exported via the `llm/dj.js` barrel) so both pick strategies share the coaching verbatim — `llm/` can't import from `broadcast/`, so the move goes this direction.
- **`pickNextTrack`** gains the `transition` enum, present only when `settings.effectsActive()` (one-shot call, no session history — no need for the agent's `PICK_SCHEMA_NO_FX` always-null trick), plus the same recent-transition-choices variety nudge the agent path gets.
- **`pickViaPool`** threads `queue.recentTransitionChoices()` in and the chosen transition out; dj-agent's pool caller maps it to the `sweep`/`washout`/`blend` flags on `enqueuePick`.
- Validation is unchanged and shared: `applyMixTransition` already validates/strips whatever any queued pick asks for against the audio analysis, dj-mode state, and the monoculture guard — it's pick-strategy-agnostic.

Candidate input data was already at parity (the pool sends the same measured facts — bpm/key/pace/sections/moods/energy — plus `source` and `similarity`), so the model has what it needs to judge blend-vs-sweep on the pool path.

## Testing

- `npm run test:llm` — 6 new `nearestId` cases, including the exact live glm truncation; all pass.
- `npm run lint` + `tsc --noEmit` clean.