### PR TITLE
fix(dj): hemisphere-correct season + surface day/night

### DIFF
--- a/controller/src/context.ts
+++ b/controller/src/context.ts
@@ -183,11 +183,15 @@ const DAY_LABELS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Fri
 const MONTH_LABELS = ['January', 'February', 'March', 'April', 'May', 'June',
                       'July', 'August', 'September', 'October', 'November', 'December'];
 
-// Northern-hemisphere meteorological seasons — the box is in Wolverhampton.
-function seasonFor(month /* 1-12 */) {
-  if (month === 12 || month <= 2) return 'winter';
-  if (month <= 5) return 'spring';
-  if (month <= 8) return 'summer';
+// Meteorological seasons, hemisphere-aware. Open-Meteo hands us the station's
+// latitude, so a southern-hemisphere station (negative lat) reads July as
+// winter, not summer (issue: Buenos Aires DJ talking about "summer" and "heat"
+// in July). The southern seasons are the northern ones shifted six months.
+function seasonFor(month /* 1-12 */, lat = config.weather.lat) {
+  const m = lat < 0 ? ((month + 5) % 12) + 1 : month;
+  if (m === 12 || m <= 2) return 'winter';
+  if (m <= 5) return 'spring';
+  if (m <= 8) return 'summer';
   return 'autumn';
 }
 
@@ -258,6 +262,13 @@ export async function getFullContext() {
   const festival = getFestivalContext(now);
   const date = getDateContext(now);
   const clock = getClockContext(now);
+
+  // Open-Meteo reports whether the sun is up at the station right now; ride it
+  // on the clock so the DJ stops describing dusk/daylight after dark (issue:
+  // "night is starting to claim its place" / "shadows lengthen" said two hours
+  // past sunset). Only set when known — a failed weather fetch leaves it unset
+  // and the model falls back to inferring from the wall-clock time.
+  if (typeof weather?.isDay === 'boolean') (clock as any).isDark = !weather.isDay;
 
   // A scheduled show for this hour, if any. Its mood wins everything below —
   // an empty hour leaves the station running autonomously.

--- a/controller/src/llm/internal/prompts/context.ts
+++ b/controller/src/llm/internal/prompts/context.ts
@@ -97,6 +97,7 @@ export function buildContextLines(
   }
   if (on('clock') && context?.clock) {
     const tags: string[] = [];
+    if (context.clock.isDark) tags.push('after dark');
     if (context.clock.isWeekend) tags.push('weekend');
     if (context.clock.isLateNight) tags.push('late night');
     if (context.clock.isCommute) tags.push('commute hour');


### PR DESCRIPTION
## Problem (from Discord)

A Buenos Aires operator's DJ kept describing **summer and heat in the dead of winter** (July, 8 °C):

> "The heat of Wednesday still lingers in the air, even though night is already starting to claim its place."
> "…the air is still heavy, although you can already feel that slow relief of summer." *(said at 9 pm, winter)*

Two of the quoted lines are also **day/night errors** — "shadows lengthen on the asphalt" and "night is *starting* to claim its place", both said ~2 hours after full dark.

## Root cause

1. **Season was hardcoded to the northern hemisphere.** `seasonFor()` in `context.ts` mapped July → summer unconditionally (the comment literally said *"the box is in Wolverhampton"*). That `(season)` string is injected into every DJ script prompt (`prompts/context.ts`), and the model elaborates it into summer/heat narrative. For any negative-latitude station the season was inverted.
2. **Day/night was never surfaced.** Open-Meteo returns `is_day` and `getWeather()` already parses it into `weather.isDay`, but nothing passed it to the prompt — the DJ only saw "21:00 / evening" and guessed at dusk.

## Fix

- `seasonFor(month, lat)` shifts the season six months for negative-latitude stations, using the latitude Open-Meteo already provides. Northern hemisphere is unchanged.
- Attach `isDark = !weather.isDay` onto the clock in `getFullContext()` and emit it as an **"after dark"** tag on the `Local time:` line. Only set when known — a failed weather fetch falls back to wall-clock inference as before.

No weather chatter reintroduced (#471) — day/night is a lighting fact, not a weather line, and rides the clock tag rather than the weather line.

## Not addressed (deliberately)

- **"Thinks it's 68 °F" / wrong temperature:** weather is intentionally excluded from between-track scripts (#471), so any temperature the DJ states in an intro is *hallucinated*, not a wrong reading. Fixing that means either reintroducing weather-heaviness or constraining the model from inventing numbers — out of scope here.
- **"Station-ID and time-check use different timezones":** both runners pass the same `getFullContext()` (one station-timezone clock source), so there's no divergence to fix. The likely cause is a station left on Auto timezone (→ container UTC); that's a config/onboarding concern, not this bug.

## Verification

Exercised the real `getDateContext` + `buildContextLines` path:
- Buenos Aires (lat −34.6), 3 July → `Day: Friday, 3 July (winter)` + `Local time: 21:00 · after dark`
- Northern station, July → still `summer`

`npm run lint` (eslint + tsc) clean — 0 errors.