### PR TITLE
feat(admin/shows): Any mood option + unified Strict filter toggle

### DIFF
--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -223,11 +223,11 @@ export function pickSystem() {
   const showLine = activeShow?.topic
     ? `\n\nCurrent show brief — follow this for every pick:\n${activeShow.topic}`
     : '';
-  // The same genre/decade/energy steer the pool picker applies — the agent
+  // The same mood/genre/decade/energy steer the pool picker applies — the agent
   // already owns songsByGenre + tracksByMood(energy) tools, so this line is
   // enough to make it reach for them. showMusicLean reflects the show's
-  // genreStrict here too: a strict show gets a hard "stay within {genre}" rule
-  // instead of a soft lean, so both pick paths honour strict the same way. Lives
+  // filtersStrict here too: a strict show gets a hard "stay within" rule
+  // instead of soft leans, so both pick paths honour strict the same way. Lives
   // in the system prompt for the same session-window reason as the show brief.
   const musicLean = dj.showMusicLean(activeShow);
   // Playlist anchor: a separate steer from genre/era. Strict → every pick MUST
@@ -318,19 +318,21 @@ export const pickerAgent = defineAgent({
   buildSystem: () => pickSystem(),
   buildTools: ({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, playlistLock, playlistTracks }) => {
     // Resolve the active show live (a show that just came on air takes effect):
-    // for a strict show, hard genre + era locks the discovery tools enforce on
-    // candidates — not just the prompt. Era rides the same genreStrict flag (no
-    // separate era-strict toggle). Track length is enforced as an on-air cut,
-    // NOT a pick filter (issue #447), so no length cap is passed here.
+    // for a strict show (filtersStrict), EVERY set music filter — genre, era,
+    // mood, energy — becomes a hard lock the discovery tools enforce on
+    // candidates, not just the prompt. Track length is enforced as an on-air
+    // cut, NOT a pick filter (issue #447), so no length cap is passed here.
     const activeShow = settings.resolveActiveShow();
-    const strict = !!(activeShow?.genreStrict);
+    const strict = !!(activeShow?.filtersStrict);
     const genreLock = strict && activeShow?.genre ? activeShow.genre : null;
     const eraLock = strict && (activeShow?.fromYear != null || activeShow?.toYear != null)
       ? { fromYear: activeShow.fromYear, toYear: activeShow.toYear }
       : null;
+    const moodLock = strict && activeShow?.mood ? activeShow.mood : null;
+    const energyLock = strict && activeShow?.energy ? activeShow.energy : null;
     // playlistLock / playlistTracks are pre-resolved by pickViaAgent (the
     // Navidrome fetch is async; buildTools is sync) and threaded through run().
-    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, genreLock, eraLock, playlistLock, playlistTracks });
+    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, genreLock, eraLock, moodLock, energyLock, playlistLock, playlistTracks });
     return { tools, extras: { seen } };
   },
 });

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -12,7 +12,7 @@ import * as dj from '../llm/dj.js';
 import * as library from '../music/library.js';
 import * as settings from '../settings.js';
 import { artistKey } from '../music/recency.js';
-import { normGenre, genreMatches, inYearRange, preferEnergy } from '../music/show-filter.js';
+import { normGenre, genreMatches, inYearRange, preferEnergy, preferEnergyStrict, preferMood } from '../music/show-filter.js';
 import { resolveShowPlaylistPool } from '../music/show-playlist.js';
 import { getFullContext } from '../context.js';
 import { queue } from './queue.js';
@@ -83,9 +83,11 @@ async function refreshAutoPlaylistInner() {
   const toYear: number | null = show?.toYear ?? null;
   const showEnergy: string = show?.energy || '';
   // A genre or a year window narrows the pool; energy alone only soft-leans
-  // (mirrors picker.hasMusicFilter). Strict opts the GENRE into a hard filter.
+  // (mirrors picker.hasMusicFilter). Strict (show.filtersStrict) opts EVERY set
+  // filter — mood, genre, era, energy — into a hard filter on the pool.
   const narrow = !!(show && (showGenre || fromYear != null || toYear != null));
-  const strict = !!(show?.genreStrict && showGenre);
+  const showMood: string = show?.mood || '';
+  const strict = !!(show?.filtersStrict && (showGenre || showMood || showEnergy || fromYear != null || toYear != null));
 
   // Show playlist anchor: resolve the union once. The fallback must honour it
   // too, so the LLM-free coast (LLM down, budget-hard, zero listeners) still
@@ -105,13 +107,23 @@ async function refreshAutoPlaylistInner() {
     try { genreName = await subsonic.resolveGenreName(showGenre); } catch {}
   }
   const strictGenreNorm = strict && genreName ? normGenre(genreName) : null;
-  // Strict: hard-drop off-genre tracks from every discovery source (even if that
-  // empties the source) — the auto playlist airs in full with no LLM gatekeeper,
-  // so never-starve off-genre filler would actually play. The dedicated genre
-  // source + genre-targeted random carry the pool; an unresolved genre disables
-  // this (genreName null → no filter). Soft mode is a no-op here.
-  const enforce = (items: any[]) =>
-    strictGenreNorm ? items.filter((t: any) => genreMatches(t, strictGenreNorm)) : items;
+  // Strict: hard-drop off-genre / off-era tracks from every discovery source
+  // (even if that empties the source) — the auto playlist airs in full with no
+  // LLM gatekeeper, so never-starve off-target filler would actually play. The
+  // dedicated genre source + genre/era-targeted random carry the pool; an
+  // unresolved genre disables the genre drop (genreName null → no filter).
+  // Mood and energy enforce with per-source never-starve instead (preferMood /
+  // preferEnergyStrict): they depend on the tagger/analyzer having run, and an
+  // un-tagged library hard-dropping everything would empty the dead-air
+  // fallback entirely. Soft mode is a no-op here.
+  const enforce = (items: any[]) => {
+    let out = items;
+    if (strictGenreNorm) out = out.filter((t: any) => genreMatches(t, strictGenreNorm));
+    if (strict && (fromYear != null || toYear != null)) out = inYearRange(out, { fromYear, toYear });
+    if (strict && showMood) out = preferMood(out, showMood);
+    if (strict && showEnergy) out = preferEnergyStrict(out, showEnergy);
+    return out;
+  };
   // Shrink the off-genre / off-playlist sources so the dedicated show source
   // (genre or playlist) dominates the pool.
   const nz = (cap: number) => ((narrow || hasPlaylist) ? Math.max(2, Math.ceil(cap * SHOW_NARROW_FACTOR)) : cap);
@@ -163,7 +175,9 @@ async function refreshAutoPlaylistInner() {
         const ranged = inYearRange(g, { fromYear, toYear });
         collected.push(...(ranged.length ? ranged : g));
       }
-      const leaned = preferEnergy(collected, showEnergy);
+      // Genre/era are server-side native here; enforce() adds the strict
+      // mood/energy filters on top (no-op in soft mode).
+      const leaned = enforce(preferEnergy(collected, showEnergy));
       take('show-genre', shuffle(leaned), strict ? SHOW_GENRE_STRICT_WEIGHT : SHOW_GENRE_WEIGHT);
     } catch (err) {
       queue.log('error', `Show-genre fetch failed: ${err.message}`);
@@ -285,8 +299,8 @@ async function refreshAutoPlaylistInner() {
     ? (playlistPool!.names.length ? playlistPool!.names.join('/') : `${show.playlistIds.length} playlist(s)`)
     : '';
   const showInfo = show
-    ? `, show=${show.name}` +
-      (showGenre ? ` genre=${genreName || showGenre} (${strict ? 'strict' : 'soft'})` : '') +
+    ? `, show=${show.name}${strict ? ' filters=strict' : ''}` +
+      (showGenre ? ` genre=${genreName || showGenre}` : '') +
       (fromYear != null || toYear != null ? ` year=${fromYear ?? ''}-${toYear ?? ''}` : '') +
       (showEnergy ? ` energy=${showEnergy}` : '') +
       (hasPlaylist ? ` playlist=${playlistTag} (${strictPlaylist ? 'strict' : 'soft'})` : '')

--- a/controller/src/llm/internal/prompts/generate.ts
+++ b/controller/src/llm/internal/prompts/generate.ts
@@ -57,7 +57,7 @@ interface ShowCtx {
 // `.catch(...)`-wrapped for the same reason as PERSONA_SCHEMA above: a partial
 // model response (the common failure on small / non-tool-tuned local models) must
 // degrade to an editable draft, not a thrown ZodError. The route then re-checks
-// personaId / themeId / mood / energy / genreStrict against the live lists
+// personaId / themeId / mood / energy / filtersStrict against the live lists
 // (routes/generate.ts) — that normalisation only runs because parse no longer
 // throws here.
 const SHOW_SCHEMA = z.object({
@@ -65,7 +65,7 @@ const SHOW_SCHEMA = z.object({
   topic: z.string().max(1000).describe('the brief the AI DJ reads before the slot: genres, eras, moods, artists, time of day, listener type, host tone. 1-4 sentences, max 1000 chars.').catch(''),
   mood: z.enum(SHOW_MOODS as [string, ...string[]]).describe('the single closest music mood for this show').catch(SHOW_MOODS[0]),
   genre: z.string().max(64).describe('a music genre lean if one fits (e.g. "jazz", "gospel", "lofi"); "" for no lean. Prefer a genre present in the supplied library list when relevant.').catch(''),
-  genreStrict: z.boolean().describe('true ONLY when the description demands genre exclusivity ("only plays hip-hop", "strictly jazz", "nothing but metal") — hard-locks every pick to the genre. false for a normal lean. Requires a genre; leave false when genre is "".').catch(false),
+  filtersStrict: z.boolean().describe('true ONLY when the description demands exclusivity ("only plays hip-hop", "strictly 80s", "nothing but calm tracks") — hard-locks every pick to ALL the filters set (mood, genre, era, energy). false for normal soft leans. Requires at least one filter; leave false when none is set.').catch(false),
   fromYear: z.number().int().nullable().describe('start year of an era window if the show targets a decade (e.g. 1970), else null').catch(null),
   toYear: z.number().int().nullable().describe('end year of that era window (e.g. 1979), else null').catch(null),
   energy: z.enum(['', ...SHOW_ENERGY] as [string, ...string[]]).describe('soft energy steer: low, medium, high, or "" for any').catch(''),
@@ -73,7 +73,7 @@ const SHOW_SCHEMA = z.object({
   themeId: z.string().nullable().describe('the id of a per-show theme override chosen from the supplied theme list, or null for the station default').catch(null),
 });
 
-const SHOW_SYSTEM = `You design radio shows for a personal internet radio station. Given a free-text description, produce a single show definition: a name, a DJ brief (topic), a music mood, an optional genre lean and era window, an energy steer, and the best-matching persona and (optional) theme from the supplied lists. Pick personaId / themeId ONLY from the ids given; use null when nothing clearly fits. The mood MUST be one of the listed moods. Set genreStrict=true only when the description signals genre exclusivity ("only", "strictly", "nothing but", "pure <genre>") — otherwise keep the genre a soft lean (genreStrict=false). Keep the topic concrete and useful as a brief — name the kind of music, the moment of day, and the tone.`;
+const SHOW_SYSTEM = `You design radio shows for a personal internet radio station. Given a free-text description, produce a single show definition: a name, a DJ brief (topic), a music mood, an optional genre lean and era window, an energy steer, and the best-matching persona and (optional) theme from the supplied lists. Pick personaId / themeId ONLY from the ids given; use null when nothing clearly fits. The mood MUST be one of the listed moods. Set filtersStrict=true only when the description signals exclusivity ("only", "strictly", "nothing but", "pure <genre>") — it hard-locks every pick to ALL the set filters (mood, genre, era, energy); otherwise keep them soft leans (filtersStrict=false). Keep the topic concrete and useful as a brief — name the kind of music, the moment of day, and the tone.`;
 
 export async function generateShow(description: string, ctx: ShowCtx = {}) {
   const lines: string[] = [];

--- a/controller/src/llm/internal/prompts/picker.ts
+++ b/controller/src/llm/internal/prompts/picker.ts
@@ -12,40 +12,49 @@ export const PICKER_CRITERIA = `Selection criteria, in order:
 3. VARIETY — avoid the same artist back-to-back; don't repeat tracks you've already played today; rotate energy. Variety over cleverness — never pick a track because its title literally matches the time of day, the weather, or anything else literal.
 4. INTEREST — prefer something that creates a moment, not the most generic option.`;
 
-export type ShowMusic = { name: string; topic: string; genre?: string; fromYear?: number | null; toYear?: number | null; energy?: string; genreStrict?: boolean };
+export type ShowMusic = { name: string; topic: string; mood?: string; genre?: string; fromYear?: number | null; toYear?: number | null; energy?: string; filtersStrict?: boolean };
 
-// A show can pin a genre, decade and/or energy band on track selection. Genre
-// is a SOFT lean by default, or a HARD constraint when `genreStrict` is on;
-// decade and energy are always soft. Render it as one prompt line shared by both
-// pick paths (the pool picker here and the conversational agent in
+// A show can pin a mood, genre, decade and/or energy band on track selection.
+// All are SOFT leans by default, or HARD constraints when `filtersStrict` is on
+// (one toggle governs every set filter). Render it as one prompt line shared by
+// both pick paths (the pool picker here and the conversational agent in
 // broadcast/dj-agent.ts). Returns '' when the show pins nothing, so callers can
 // append it unconditionally.
 export function showMusicLean(show?: ShowMusic | null): string {
   if (!show) return '';
-  // Strict only bites when there's actually a genre to lock to.
-  const strict = !!(show.genreStrict && show.genre);
-  // Soft preferences (the genre lean is dropped here when strict — it becomes a
-  // hard rule on its own line below).
-  const parts: string[] = [];
-  if (show.genre && !strict) parts.push(`lean toward ${show.genre}`);
-  if (show.fromYear != null || show.toYear != null) {
+  const eraText = (() => {
+    if (show.fromYear == null && show.toYear == null) return '';
     const from = show.fromYear != null ? String(show.fromYear) : '';
     const to = show.toYear != null ? String(show.toYear) : '';
-    parts.push(from && to ? `prefer tracks from ${from}–${to}` : `prefer tracks ${from ? `from ${from} onward` : `up to ${to}`}`);
-  }
-  if (show.energy) parts.push(`favour ${show.energy}-energy tracks`);
+    return from && to ? `${from}–${to}` : from ? `${from} onward` : `up to ${to}`;
+  })();
+  // Strict only bites when there's actually a filter to lock to.
+  const hasFilter = !!(show.genre || show.mood || show.energy || eraText);
+  const strict = !!(show.filtersStrict && hasFilter);
 
-  // The hard genre rule. Track selection is now code-enforced for strict shows
-  // (preferGenre in both pick paths), so this is lean: it governs the DJ's TALK
-  // and the never-starve fallback case (where off-genre tracks can still surface),
-  // not the candidate list.
-  const lock = strict
-    ? `\n\nThis show is ${show.genre}-only — keep your picks and your talk in ${show.genre}; only step outside if there is genuinely no ${show.genre} track left to play (never leave dead air).`
-    : '';
-  const soft = parts.length
+  if (strict) {
+    // The hard rule. Track selection is code-enforced for strict shows (the
+    // prefer* locks in both pick paths), so this is lean: it governs the DJ's
+    // TALK and the never-starve fallback case (where off-filter tracks can
+    // still surface), not the candidate list. Mood joins the lock here — soft
+    // shows carry mood through the room-context prompt instead.
+    const locks: string[] = [];
+    if (show.genre) locks.push(`${show.genre} tracks`);
+    if (eraText) locks.push(`the ${eraText} era`);
+    if (show.mood) locks.push(`the ${show.mood} mood`);
+    if (show.energy) locks.push(`${show.energy}-energy tracks`);
+    return `\n\nThis show's music filters are STRICT — every pick must fit: ${locks.join('; ')}. Keep your talk inside them too; only step outside if there is genuinely nothing left that fits (never leave dead air).`;
+  }
+
+  // Soft preferences. Mood is deliberately absent — it steers the room context
+  // (dominantMood) rather than reading as a per-track preference.
+  const parts: string[] = [];
+  if (show.genre) parts.push(`lean toward ${show.genre}`);
+  if (eraText) parts.push(`prefer tracks from ${eraText}`);
+  if (show.energy) parts.push(`favour ${show.energy}-energy tracks`);
+  return parts.length
     ? `\n\nMusic steer for this show — ${parts.join('; ')}. These are preferences, not hard filters: break them only when the flow genuinely demands it.`
     : '';
-  return `${lock}${soft}`;
 }
 
 function pickerSystem(show?: ShowMusic | null) {

--- a/controller/src/llm/internal/tools/picker-tools.ts
+++ b/controller/src/llm/internal/tools/picker-tools.ts
@@ -14,7 +14,7 @@ import * as subsonic from '../../../music/subsonic.js';
 import * as library from '../../../music/library.js';
 import * as embeddings from '../../../music/embeddings.js';
 import { filterPickerCandidates, durationSeconds } from '../../../music/recency.js';
-import { preferGenre, preferEra } from '../../../music/show-filter.js';
+import { preferGenre, preferEra, preferMood, preferEnergyStrict } from '../../../music/show-filter.js';
 import { searchWeb, searchReady } from '../../../skills/web-search.js';
 import { identifyTrackFromText } from '../prompts/request.js';
 
@@ -89,6 +89,8 @@ export function buildPickerTools({
   resolveReferences = false,
   genreLock = null,
   eraLock = null,
+  moodLock = null,
+  energyLock = null,
   playlistLock = null,
   playlistTracks = null,
 }: {
@@ -101,17 +103,23 @@ export function buildPickerTools({
   // queue.recentlyPlayedByCount(N); empty on the request path (requests exempt).
   hardRecentIds?: Set<string>;
   hardRecentKeys?: Set<string>;    // lowercased "title|artist" — blocks id-less backfilled plays
-  // Hard genre constraint for a strict-genre show (settings.genreStrict). When
-  // set, every tool's candidates are genre-filtered (preferGenre, never-starve)
+  // Hard genre constraint for a strict show (show.filtersStrict). When set,
+  // every tool's candidates are genre-filtered (preferGenre, never-starve)
   // before recency + cap, so the agent path enforces the lock in code, not just
   // the prompt — mirroring the pool picker's strict mode. null = no lock.
   // Deliberately NOT set on the request path: an explicit listener ask wins.
   genreLock?: string | null;
   // Hard era (decade/year window) constraint, applied only for a strict show
-  // (gated on the same genreStrict flag — there's no separate era-strict toggle).
-  // When set, candidates are year-filtered (preferEra, never-starve) before
-  // recency + cap. null / both-bounds-null = no era lock.
+  // (same filtersStrict flag — one toggle governs every filter). When set,
+  // candidates are year-filtered (preferEra, never-starve) before recency +
+  // cap. null / both-bounds-null = no era lock.
   eraLock?: { fromYear?: number | null; toYear?: number | null } | null;
+  // Hard mood constraint for a strict show: candidates are filtered to tracks
+  // tagged with the show's mood (preferMood, never-starve). null = no lock.
+  moodLock?: string | null;
+  // Hard energy-band constraint for a strict show: candidates are filtered to
+  // the analysed band (preferEnergyStrict — unknowns dropped, never-starve).
+  energyLock?: string | null;
   // The active sonic journey's current waypoint vector (broadcast/dj-agent.ts).
   // When present, the tracksTowardJourney tool below is registered, closing
   // over it — the agent never sees the raw vector, only the tracks near it.
@@ -145,12 +153,14 @@ export function buildPickerTools({
   // grows with each tool call regardless.
   const collect = (list: any, cap = 8) => {
     // Strict show: filter candidates BEFORE recency + cap, so the 8 the agent
-    // sees are genre-/era-pure. Both never-starve (fall back to the full list
-    // when a tool returns no match), so a thin genre/era degrades to off-target
-    // rather than dead air — same contract as the pool path.
+    // sees are genre-/era-/mood-/energy-pure. Each lock never-starves (falls
+    // back to the full list when a tool returns no match), so a thin constraint
+    // degrades to off-target rather than dead air — same contract as the pool path.
     let pool = shuffle((list || []) as any[]);
     if (genreLock) pool = preferGenre(pool, genreLock);
     if (eraLock) pool = preferEra(pool, eraLock);
+    if (moodLock) pool = preferMood(pool, moodLock);
+    if (energyLock) pool = preferEnergyStrict(pool, energyLock);
     // Strict playlist: HARD-intersect with the lock set, with NO never-starve to
     // off-playlist (a playlist is an exact set, so a tool with no overlap simply
     // contributes nothing). The guaranteed in-set source is showPlaylistTracks

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -12,7 +12,7 @@ import * as dj from '../llm/dj.js';
 import * as settings from '../settings.js';
 import { bpmCompat, keyCompat } from './mix.js';
 import { filterPickerCandidates, recencyWindowsForLibrary, effectiveNoRepeatWindow } from './recency.js';
-import { normGenre, genreMatches, preferGenre, inYearRange, preferEnergy } from './show-filter.js';
+import { normGenre, genreMatches, preferGenre, preferEra, inYearRange, preferEnergy, preferEnergyStrict, preferMood } from './show-filter.js';
 import { resolveShowPlaylistPool, type PlaylistPool } from './show-playlist.js';
 
 const CANDIDATE_CAP = 18;
@@ -95,19 +95,19 @@ function softRankByCompat(pool: any[], current: { bpm: number | null; key: strin
 }
 
 // --- Show music-steering filters -------------------------------------------
-// A show can pin a genre, a decade (fromYear/toYear) and an energy band. By
-// default none is a hard filter: each prefers matching tracks but falls back to
-// the full set when matches are too thin to fill the pool, so a sparse genre or
-// an un-analysed library never starves the stream.
+// A show can pin a mood, a genre, a decade (fromYear/toYear) and an energy
+// band. By default none is a hard filter: each prefers matching tracks but
+// falls back to the full set when matches are too thin to fill the pool, so a
+// sparse genre or an un-analysed library never starves the stream.
 //
-// `strict` opts the GENRE (only) into a hard filter: the off-genre discovery
-// sources are genre-filtered before they enter the pool, so the pool is
-// genuinely genre-dominated rather than just shrunk. The same never-starve
-// fallback applies — a genre too thin to fill the pool degrades to off-genre
-// tracks rather than dead air (logged by the caller). Decade and energy stay
-// soft either way.
+// `strict` (show.filtersStrict) opts EVERY set filter into a hard filter: the
+// discovery sources are mood/genre/era/energy-filtered before they enter the
+// pool, so the pool is genuinely filter-dominated rather than just shrunk. The
+// same never-starve fallback applies per dimension — a constraint too thin to
+// fill the pool degrades to off-filter tracks rather than dead air (logged by
+// the caller for genre).
 
-type ShowFilter = { genre?: string; fromYear?: number | null; toYear?: number | null; energy?: string; strict?: boolean } | null;
+type ShowFilter = { mood?: string; genre?: string; fromYear?: number | null; toYear?: number | null; energy?: string; strict?: boolean } | null;
 
 function hasMusicFilter(f: ShowFilter): boolean {
   return !!f && (!!f.genre || f.fromYear != null || f.toYear != null);
@@ -159,21 +159,35 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
   const narrow = hasMusicFilter(showFilter) || hasPlaylist;
   const nz = (cap: number) => (narrow ? Math.max(2, Math.ceil(cap * SHOW_NARROW_FACTOR)) : cap);
 
-  // Strict genre: resolve the show's free-text genre to the library's exact tag
-  // ONCE, up front, so the off-genre discovery sources below can be hard-filtered
-  // to it before they enter the pool — making the pool genuinely genre-dominated,
-  // not just shrunk. Soft mode (or no genre) leaves the sources untouched (only
-  // the nz() shrink applies). A resolution failure / absent genre degrades to no
-  // filter so a misspelled genre never strands the show (never-starve).
-  const strict = !!(showFilter?.strict && showFilter?.genre);
+  // Strict filters (show.filtersStrict): every SET filter — genre, era, mood,
+  // energy — becomes a hard filter on the discovery sources before they enter
+  // the pool, making the pool genuinely filter-dominated, not just shrunk.
+  // Each dimension keeps its own never-starve fallback (preferGenre/preferEra/
+  // preferMood/preferEnergyStrict all fall back to the full set on zero
+  // matches), so a thin constraint degrades rather than strands the show.
+  // Soft mode leaves the sources untouched (only the nz() shrink applies).
+  const strict = !!(showFilter?.strict
+    && (showFilter?.genre || showFilter?.mood || showFilter?.energy
+      || showFilter?.fromYear != null || showFilter?.toYear != null));
+  // Resolve the show's free-text genre to the library's exact tag ONCE, up
+  // front. A resolution failure / absent genre degrades to no genre filter so
+  // a misspelled genre never strands the show (never-starve).
   let strictGenre: string | null = null;
-  if (strict) {
-    try { strictGenre = await subsonic.resolveGenreName(showFilter!.genre!); } catch {}
+  if (strict && showFilter?.genre) {
+    try { strictGenre = await subsonic.resolveGenreName(showFilter.genre); } catch {}
   }
-  // Hard-prefer the resolved genre on a discovery source in strict mode; a no-op
-  // otherwise. preferGenre always falls back to the full set when nothing in the
-  // source matches, so leaning a source can only tighten genre, never starve it.
-  const lean = (items: any[]) => (strict && strictGenre ? preferGenre(items, strictGenre) : items);
+  // Hard-prefer every set filter on a discovery source in strict mode; a no-op
+  // otherwise. Each prefer* falls back to the full set when nothing in the
+  // source matches, so leaning a source can only tighten, never starve it.
+  const lean = (items: any[]) => {
+    if (!strict) return items;
+    let out = items;
+    if (strictGenre) out = preferGenre(out, strictGenre);
+    out = preferEra(out, showFilter!);
+    out = preferMood(out, showFilter!.mood);
+    out = preferEnergyStrict(out, showFilter!.energy);
+    return out;
+  };
 
   // 1. Similar-songs from current track — strongest contextual signal.
   if (currentTrack?.id) {
@@ -261,7 +275,9 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
         const ranged = inYearRange(g, showFilter!);
         collected.push(...(ranged.length ? ranged : g));
       }
-      const leaned = preferEnergy(collected, showFilter!.energy);
+      // Genre/era are already native to this source; lean() adds the strict
+      // mood/energy filters on top (no-op in soft mode).
+      const leaned = lean(preferEnergy(collected, showFilter!.energy));
       // Strict bumps the cap so this genre-native source dominates the merged pool.
       add('show-genre', sampleWithRecentFallback(shuffle(leaned), recentIds, strict ? CAP_SHOW_GENRE_STRICT : CAP_SHOW_GENRE));
     } catch {}
@@ -411,7 +427,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
   // final pool actually landed in-genre. `resolved` is null when the show's
   // genre didn't map to any library tag (strict silently degraded to soft).
   let strictInfo: { requested: string; resolved: string | null; matched: number; total: number } | null = null;
-  if (strict) {
+  if (strict && showFilter?.genre) {
     const target = strictGenre ? normGenre(strictGenre) : '';
     strictInfo = {
       requested: showFilter!.genre!,
@@ -473,7 +489,7 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   // (below) and its brief steers the LLM pick (further down).
   const activeShow = settings.resolveActiveShow();
   const showFilter: ShowFilter = activeShow
-    ? { genre: activeShow.genre, fromYear: activeShow.fromYear, toYear: activeShow.toYear, energy: activeShow.energy, strict: activeShow.genreStrict }
+    ? { mood: activeShow.mood, genre: activeShow.genre, fromYear: activeShow.fromYear, toYear: activeShow.toYear, energy: activeShow.energy, strict: activeShow.filtersStrict }
     : null;
   // Resolve the show's anchored Navidrome playlist(s), if any, into a deduped
   // track pool. Null when the show pins none (the common case → pool unchanged).
@@ -529,11 +545,12 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
         ? {
             name: activeShow.name,
             topic: activeShow.topic,
+            mood: activeShow.mood,
             genre: activeShow.genre,
             fromYear: activeShow.fromYear,
             toYear: activeShow.toYear,
             energy: activeShow.energy,
-            genreStrict: activeShow.genreStrict,
+            filtersStrict: activeShow.filtersStrict,
           }
         : null,
       candidates: candidates.map(c => {

--- a/controller/src/music/show-filter.ts
+++ b/controller/src/music/show-filter.ts
@@ -84,12 +84,45 @@ export function trackEnergy(t: any): string | null {
 
 // Soft-prefer tracks matching the show's energy band; unknown-energy tracks
 // stay eligible. Falls back to the full set when no track matches (never-starve,
-// mirrors preferEra). Energy stays soft even when the show's genre is strict.
+// mirrors preferEra). This is the soft-lean path; strict shows
+// (show.filtersStrict) use preferEnergyStrict below.
 export function preferEnergy(tracks: any[], energy?: string | null): any[] {
   if (!energy) return tracks;
   const match = tracks.filter((t: any) => {
     const e = trackEnergy(t);
     return e == null || e === energy;
   });
+  return match.length ? match : tracks;
+}
+
+// Strict energy filter (show.filtersStrict): only tracks whose analysed energy
+// band matches survive — unknown-energy tracks are dropped too, that's the
+// point of strict. Never-starve: an un-analysed library (everything unknown)
+// falls back to the full set rather than emptying the source.
+export function preferEnergyStrict(tracks: any[], energy?: string | null): any[] {
+  if (!energy) return tracks;
+  const match = tracks.filter((t: any) => trackEnergy(t) === energy);
+  return match.length ? match : tracks;
+}
+
+// ── Mood ─────────────────────────────────────────────────────────────────────
+
+// Per-track mood tags — from the track itself (library sources carry them) or a
+// library lookup (Subsonic sources don't). Empty when un-tagged.
+export function trackMoods(t: any): string[] {
+  if (Array.isArray(t?.moods)) return t.moods;
+  const rec = t?.id ? library.get(t.id) : null;
+  return Array.isArray(rec?.moods) ? rec.moods : [];
+}
+
+// Strict mood filter (show.filtersStrict): only tracks tagged with the show's
+// mood survive; un-tagged tracks are dropped. Never-starve: an un-tagged
+// library falls back to the full set rather than emptying the source. Soft
+// shows don't use this — their mood steering happens through the
+// dominantMood-driven pool sources, not a per-track filter.
+export function preferMood(tracks: any[], mood?: string | null): any[] {
+  if (!mood) return tracks;
+  const m = String(mood).toLowerCase();
+  const match = tracks.filter((t: any) => trackMoods(t).some((x: any) => String(x).toLowerCase() === m));
   return match.length ? match : tracks;
 }

--- a/controller/src/routes/generate.ts
+++ b/controller/src/routes/generate.ts
@@ -59,7 +59,9 @@ router.post('/generate/show', requireAdmin, async (req, res) => {
     }
     const themeIds = new Set(themes.map(t => t.id));
     if (!draft.themeId || !themeIds.has(draft.themeId)) draft.themeId = null;
-    if (!settings.SHOW_MOODS.includes(draft.mood)) draft.mood = settings.SHOW_MOODS[0];
+    // An unknown/missing mood becomes '' (Any — the autonomous mood applies)
+    // rather than an arbitrary vocabulary entry the operator didn't ask for.
+    if (!draft.mood || !settings.SHOW_MOODS.includes(draft.mood)) draft.mood = '';
     if (draft.energy && !settings.SHOW_ENERGY.includes(draft.energy)) draft.energy = '';
     // Strict only makes sense with a genre to lock to.
     if (draft.genreStrict && !draft.genre) draft.genreStrict = false;

--- a/controller/src/routes/generate.ts
+++ b/controller/src/routes/generate.ts
@@ -63,8 +63,10 @@ router.post('/generate/show', requireAdmin, async (req, res) => {
     // rather than an arbitrary vocabulary entry the operator didn't ask for.
     if (!draft.mood || !settings.SHOW_MOODS.includes(draft.mood)) draft.mood = '';
     if (draft.energy && !settings.SHOW_ENERGY.includes(draft.energy)) draft.energy = '';
-    // Strict only makes sense with a genre to lock to.
-    if (draft.genreStrict && !draft.genre) draft.genreStrict = false;
+    // Strict only makes sense with at least one music filter to lock to.
+    if (draft.filtersStrict && !(draft.genre || draft.mood || draft.energy || draft.fromYear != null || draft.toYear != null)) {
+      draft.filtersStrict = false;
+    }
 
     res.json({ ok: true, show: draft });
   } catch (err: any) {

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -1210,10 +1210,11 @@ function normalizeShows(raw: any, personaIds: string[]) {
     const fromYear = Number.isFinite(item.fromYear) ? Math.trunc(item.fromYear) : null;
     const toYear = Number.isFinite(item.toYear) ? Math.trunc(item.toYear) : null;
     const energy = SHOW_ENERGY.includes(item.energy) ? item.energy : '';
-    // Opt-in: hard-filter the pick pool to `genre` instead of the default soft
-    // lean. Only meaningful when a genre is set; defaults off so existing shows
-    // and soft shows are byte-for-byte unchanged.
-    const genreStrict = item.genreStrict === true;
+    // Opt-in: hard-filter the pick pool to EVERY set music filter (mood, genre,
+    // era, energy) instead of the default soft leans. Only meaningful when at
+    // least one filter is set; defaults off so existing shows are unchanged.
+    // Legacy `genreStrict` (the old genre-only toggle) migrates into it on load.
+    const filtersStrict = item.filtersStrict === true || item.genreStrict === true;
     // Per-show track-length override (seconds). null = inherit the station-wide
     // maxTrackSeconds; 0 = unlimited (opt this show back out of the cap so a
     // long-form mix show can air hour-long sets); >0 = this show's own cap.
@@ -1235,7 +1236,7 @@ function normalizeShows(raw: any, personaIds: string[]) {
       fromYear,
       toYear,
       energy,
-      genreStrict,
+      filtersStrict,
       maxTrackSeconds,
       playlistIds,
       playlistStrict,
@@ -1984,8 +1985,10 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
     if (energy && !SHOW_ENERGY.includes(energy)) {
       throw new Error(`shows[${i}].energy must be one of: ${SHOW_ENERGY.join(', ')}`);
     }
-    // Opt-in hard genre filter (vs the default soft lean). Boolean, defaults off.
-    const genreStrict = item.genreStrict === true;
+    // Opt-in hard filter across every set music constraint — mood, genre, era,
+    // energy (vs the default soft leans). Boolean, defaults off. Legacy
+    // `genreStrict` from pre-rename clients/state migrates into it.
+    const filtersStrict = item.filtersStrict === true || item.genreStrict === true;
     const parseYear = (v, field) => {
       if (v == null || v === '') return null;
       const n = Number(v);
@@ -2041,7 +2044,7 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
     let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('s_');
     if (seen.has(id)) id = mintId('s_');
     seen.add(id);
-    return { id, name, topic, personaId: item.personaId, mood, themeId, genre, fromYear, toYear, energy, genreStrict, maxTrackSeconds, playlistIds, playlistStrict };
+    return { id, name, topic, personaId: item.personaId, mood, themeId, genre, fromYear, toYear, energy, filtersStrict, maxTrackSeconds, playlistIds, playlistStrict };
   });
 }
 
@@ -2837,10 +2840,10 @@ export function resolveActiveShow(date = new Date(), s = get()) {
     fromYear: Number.isFinite(show.fromYear) ? show.fromYear : null,
     toYear: Number.isFinite(show.toYear) ? show.toYear : null,
     energy: typeof show.energy === 'string' ? show.energy : '',
-    // When true (and a genre is set) the pick pool is hard-filtered to the
-    // genre instead of softly leaned; off-genre tracks only survive as a
-    // never-starve fallback. Defaults off.
-    genreStrict: show.genreStrict === true,
+    // When true, every set music filter (mood, genre, era, energy) is a hard
+    // filter on the pick pool instead of a soft lean; off-filter tracks only
+    // survive as a never-starve fallback. Defaults off.
+    filtersStrict: show.filtersStrict === true,
     // Per-show track-length cap override (seconds). null = inherit the station
     // default; 0 = unlimited; >0 = own cap. See effectiveMaxTrackSec().
     maxTrackSeconds: show.maxTrackSeconds != null ? show.maxTrackSeconds : null,

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -1227,9 +1227,11 @@ function normalizeShows(raw: any, personaIds: string[]) {
     const energy = SHOW_ENERGY.includes(item.energy) ? item.energy : '';
     // Opt-in: hard-filter the pick pool to EVERY set music filter (mood, genre,
     // era, energy) instead of the default soft leans. Only meaningful when at
-    // least one filter is set; defaults off so existing shows are unchanged.
-    // Legacy `genreStrict` (the old genre-only toggle) migrates into it on load.
-    const filtersStrict = item.filtersStrict === true || item.genreStrict === true;
+    // least one filter is set; defaults OFF. The legacy genre-only `genreStrict`
+    // is deliberately NOT carried over: the toggle now spans every filter, so
+    // auto-migrating an old genre-strict show would silently harden mood/era/
+    // energy too. Old shows come back soft; the operator re-opts into strict.
+    const filtersStrict = item.filtersStrict === true;
     // Per-show track-length override (seconds). null = inherit the station-wide
     // maxTrackSeconds; 0 = unlimited (opt this show back out of the cap so a
     // long-form mix show can air hour-long sets); >0 = this show's own cap.
@@ -2015,9 +2017,11 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
       throw new Error(`shows[${i}].energy must be one of: ${SHOW_ENERGY.join(', ')}`);
     }
     // Opt-in hard filter across every set music constraint — mood, genre, era,
-    // energy (vs the default soft leans). Boolean, defaults off. Legacy
-    // `genreStrict` from pre-rename clients/state migrates into it.
-    const filtersStrict = item.filtersStrict === true || item.genreStrict === true;
+    // energy (vs the default soft leans). Boolean, defaults OFF. The legacy
+    // genre-only `genreStrict` is deliberately NOT carried over (see the load
+    // path): the toggle now spans every filter, so migrating it would silently
+    // harden mood/era/energy an old show never opted into.
+    const filtersStrict = item.filtersStrict === true;
     const parseYear = (v, field) => {
       if (v == null || v === '') return null;
       const n = Number(v);

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -434,7 +434,9 @@ export const SEARCH_PROVIDERS = ['duckduckgo', 'tavily', 'searxng'] as const;
 
 // Canonical mood vocabulary. Shared by the library tagger (music/tag-library.js
 // imports this as MOOD_VOCAB) and the Shows scheduler — a show's `mood`
-// overrides the autonomous dominantMood, so it must come from this list.
+// overrides the autonomous dominantMood, so a non-empty value must come from
+// this list. Empty string means "Any": the show pins no mood and the
+// autonomous chain (festival > weather > time) applies while it's on air.
 export const SHOW_MOODS = [
   'energetic',
   'calm',
@@ -1184,7 +1186,9 @@ function normalizeShows(raw: any, personaIds: string[]) {
     const name = typeof item.name === 'string' ? item.name.trim().slice(0, 60) : '';
     if (!name) continue;
     if (!personaIds.includes(item.personaId)) continue; // drop dangling owner
-    if (!SHOW_MOODS.includes(item.mood)) continue;
+    // Empty mood = "Any" (the autonomous mood applies on air). An unknown mood
+    // string is coerced to Any rather than dropping the whole show on the floor.
+    const mood = SHOW_MOODS.includes(item.mood) ? item.mood : '';
     let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('s_');
     if (seen.has(id)) id = mintId('s_');
     seen.add(id);
@@ -1225,7 +1229,7 @@ function normalizeShows(raw: any, personaIds: string[]) {
       name,
       topic: typeof item.topic === 'string' ? item.topic.trim().slice(0, 1000) : '',
       personaId: item.personaId,
-      mood: item.mood,
+      mood,
       themeId,
       genre,
       fromYear,
@@ -1953,8 +1957,12 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
     if (!personaIds.includes(item.personaId)) {
       throw new Error(`shows[${i}].personaId must reference an existing persona`);
     }
-    if (!SHOW_MOODS.includes(item.mood)) {
-      throw new Error(`shows[${i}].mood must be one of: ${SHOW_MOODS.join(', ')}`);
+    // Empty/missing mood means "Any": the show pins no mood and the autonomous
+    // dominantMood chain (festival > weather > time) applies while it's on air.
+    // A non-empty mood must come from the canonical vocabulary.
+    const mood = item.mood == null || item.mood === '' ? '' : String(item.mood);
+    if (mood && !SHOW_MOODS.includes(mood)) {
+      throw new Error(`shows[${i}].mood must be empty (any) or one of: ${SHOW_MOODS.join(', ')}`);
     }
     // Optional per-show theme override. Empty/missing means "fall back to the
     // station default while this show is on air". The allow-set is built once
@@ -2033,7 +2041,7 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
     let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('s_');
     if (seen.has(id)) id = mintId('s_');
     seen.add(id);
-    return { id, name, topic, personaId: item.personaId, mood: item.mood, themeId, genre, fromYear, toYear, energy, genreStrict, maxTrackSeconds, playlistIds, playlistStrict };
+    return { id, name, topic, personaId: item.personaId, mood, themeId, genre, fromYear, toYear, energy, genreStrict, maxTrackSeconds, playlistIds, playlistStrict };
   });
 }
 

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -3,7 +3,8 @@
 // Shows scheduler — /admin/shows. A show is a reusable definition (name,
 // topic, owner persona, music mood). The weekly grid assigns a show to any
 // 1-hour cell, Mon–Sun. When the current hour has a show, its persona goes on
-// air, its mood overrides the autonomous mood, and its topic feeds the DJ.
+// air, its mood (when set — empty means Any/auto) overrides the autonomous
+// mood, and its topic feeds the DJ.
 // An empty hour = the station runs autonomously, as it does today.
 // Everything POSTs to /settings and applies live.
 //
@@ -55,6 +56,8 @@ interface Show {
   name: string;
   topic: string;
   personaId: string;
+  /** '' = Any — the show pins no mood; the autonomous mood (festival >
+   *  weather > time of day) applies while it's on air. */
   mood: string;
   /** Optional theme override — empty string means "fall back to the station
    *  default while this show is on air". Validated against the live theme
@@ -186,7 +189,7 @@ function NowCard({ label, accent, slotHour, show, color, personaLabel }: NowCard
       </div>
       <div className="text-[11px] text-muted">
         {show
-          ? <>persona · {personaLabel} · mood · {show.mood}{showFilterSummary(show)}</>
+          ? <>persona · {personaLabel} · mood · {show.mood || 'any'}{showFilterSummary(show)}</>
           : 'station runs on its own picker'}
       </div>
     </div>
@@ -223,8 +226,9 @@ function abbrev(name: string): string {
 }
 
 function showValid(s: Show): boolean {
+  // mood is deliberately not required — '' means "Any" (autonomous mood).
   return s.name.trim().length >= 1 && s.name.trim().length <= NAME_MAX
-    && !!s.personaId && !!s.mood && s.topic.trim().length <= TOPIC_MAX;
+    && !!s.personaId && s.topic.trim().length <= TOPIC_MAX;
 }
 
 export default function ShowsPanel() {
@@ -429,7 +433,7 @@ export default function ShowsPanel() {
         ...f,
         shows: [...f.shows, {
           id, name: '', topic: '',
-          personaId: personas[0]?.id || '', mood: moods[0] || '',
+          personaId: personas[0]?.id || '', mood: '',
           themeId: '', genre: '', fromYear: null, toYear: null, energy: '',
           genreStrict: false, maxTrackSeconds: null,
           playlistIds: [], playlistStrict: false,
@@ -441,7 +445,7 @@ export default function ShowsPanel() {
     scrollToEditorRef.current = true;
     setCreatingId(id);
     setFocusIdx(newIdx);
-    notify.ok('New show added — give it a name, persona and mood, then Save schedule.');
+    notify.ok('New show added — give it a name and a persona, then Save schedule.');
   };
 
   const removeShow = (i: number) => {
@@ -922,7 +926,7 @@ function ShowEditor({
             />
             <span className="text-[11px] text-muted">
               {!valid
-                ? <span className="text-[var(--danger)]">this show needs a name, a persona, and a mood</span>
+                ? <span className="text-[var(--danger)]">this show needs a name and a persona</span>
                 : !allShowsOk
                   ? <span className="text-[var(--danger)]">another show in the list is incomplete</span>
                   : 'saves all shows + the weekly grid · applies live on the next pick'}
@@ -993,14 +997,15 @@ function ShowEditor({
             <Field>
               <Label>music mood</Label>
               <Select
-                value={show.mood || undefined}
-                onValueChange={val => update({ mood: val })}
+                value={show.mood || ANY_SENTINEL}
+                onValueChange={val => update({ mood: val === ANY_SENTINEL ? '' : val })}
               >
                 <SelectTrigger>
-                  <SelectValue placeholder="— pick mood —" />
+                  <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectGroup>
+                    <SelectItem value={ANY_SENTINEL}>Any (auto)</SelectItem>
                     {moods.map(m => <SelectItem key={m} value={m}>{m}</SelectItem>)}
                   </SelectGroup>
                 </SelectContent>
@@ -1086,7 +1091,9 @@ function ShowEditor({
           <span className="field-hint -mt-1.5">
             Optional soft music steer for this show: a genre, an era, an energy
             band, or any mix. The DJ leans toward these but can break them for
-            flow; leave blank to let the topic and mood drive selection.
+            flow; leave blank to let the topic and mood drive selection. Mood
+            set to Any (auto) follows the station&apos;s autonomous mood — time
+            of day, weather, festivals — instead of pinning one.
           </span>
 
           <Field>
@@ -1357,7 +1364,7 @@ function GridCell({
       onMouseEnter={onMouseEnter}
       onTouchStart={onTouchStart}
       title={
-        (show ? `${show.name} (${show.mood})` : `${label} ${String(hour).padStart(2, '0')}:00, empty`)
+        (show ? `${show.name}${show.mood ? ` (${show.mood})` : ''}` : `${label} ${String(hour).padStart(2, '0')}:00, empty`)
         + (isNow ? ' · on air now' : '')
       }
       className={cn(
@@ -1412,7 +1419,7 @@ function ShowDefRow({ show: s, index: i, ok, hrs, personaLabel, onEdit }: ShowDe
       <div className="grid grid-cols-[1fr_auto] items-center gap-4">
         <div className="min-w-0">
           <div className="text-[12px] leading-[1.6] text-muted">
-            persona · {personaLabel} · mood · {s.mood || '—'}{showFilterSummary(s)}
+            persona · {personaLabel} · mood · {s.mood || 'any'}{showFilterSummary(s)}
           </div>
           {s.topic.trim() && (
             <div className="mt-1 line-clamp-2 text-[12px] leading-[1.6] text-muted italic">

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -71,10 +71,12 @@ interface Show {
   fromYear: number | null;
   toYear: number | null;
   energy: string;
-  /** When true (and a genre is set) the genre becomes a HARD filter on the pick
-   *  pool instead of a soft lean — off-genre tracks only play as a last resort
-   *  to avoid silence. Defaults off. */
-  genreStrict: boolean;
+  /** When true (and ≥1 music filter is set) EVERY set filter — mood, genre,
+   *  era, energy — becomes a HARD filter on the pick pool instead of a soft
+   *  lean; off-filter tracks only play as a last resort to avoid silence.
+   *  Defaults off. (Renamed from the genre-only `genreStrict`; the controller
+   *  migrates legacy state on load.) */
+  filtersStrict: boolean;
   /** Per-show track-length cap (seconds). null = inherit the station default;
    *  0 = unlimited (opt this show out of the cap so it can air long mixes);
    *  >0 = this show's own cap. */
@@ -197,14 +199,17 @@ function NowCard({ label, accent, slotHour, show, color, personaLabel }: NowCard
 }
 
 // Compact " · genre · 80s · high" suffix for the show summary lines, omitting
-// whatever the show doesn't pin. A strict genre is flagged inline so the hard
+// whatever the show doesn't pin. Strict filters are flagged inline so the hard
 // lock is visible at a glance.
-function showFilterSummary(s: { genre: string; fromYear: number | null; toYear: number | null; energy: string; genreStrict?: boolean; maxTrackSeconds?: number | null; playlistIds?: string[]; playlistStrict?: boolean }): string {
-  const genre = s.genre ? (s.genreStrict ? `${s.genre} (strict)` : s.genre) : '';
+function showFilterSummary(s: { mood?: string; genre: string; fromYear: number | null; toYear: number | null; energy: string; filtersStrict?: boolean; maxTrackSeconds?: number | null; playlistIds?: string[]; playlistStrict?: boolean }): string {
   const len = s.maxTrackSeconds == null ? '' : s.maxTrackSeconds === 0 ? 'any length' : `≤${s.maxTrackSeconds}s`;
   const nPl = s.playlistIds?.length ?? 0;
   const playlist = nPl ? `${nPl} playlist${nPl > 1 ? 's' : ''}${s.playlistStrict ? ' (strict)' : ''}` : '';
-  const bits = [genre, decadeLabelOf(s), s.energy, len, playlist].filter(Boolean);
+  // The strict chip covers every music filter (mood included) — only shown when
+  // there's actually a filter for it to bite on.
+  const strict = s.filtersStrict && (s.mood || s.genre || s.energy || s.fromYear != null || s.toYear != null)
+    ? 'strict filters' : '';
+  const bits = [s.genre, decadeLabelOf(s), s.energy, strict, len, playlist].filter(Boolean);
   return bits.length ? ` · ${bits.join(' · ')}` : '';
 }
 
@@ -229,6 +234,12 @@ function showValid(s: Show): boolean {
   // mood is deliberately not required — '' means "Any" (autonomous mood).
   return s.name.trim().length >= 1 && s.name.trim().length <= NAME_MAX
     && !!s.personaId && s.topic.trim().length <= TOPIC_MAX;
+}
+
+// At least one music filter set — the Strict filter toggle only means
+// something when there's a filter for it to harden.
+function hasAnyMusicFilter(s: Show): boolean {
+  return !!(s.mood || s.genre.trim() || s.energy || s.fromYear != null || s.toYear != null);
 }
 
 export default function ShowsPanel() {
@@ -338,7 +349,7 @@ export default function ShowsPanel() {
           fromYear: s.fromYear ?? null,
           toYear: s.toYear ?? null,
           energy: s.energy ?? '',
-          genreStrict: s.genreStrict ?? false,
+          filtersStrict: s.filtersStrict ?? false,
           maxTrackSeconds: s.maxTrackSeconds ?? null,
           playlistIds: Array.isArray(s.playlistIds) ? s.playlistIds : [],
           playlistStrict: s.playlistStrict ?? false,
@@ -435,7 +446,7 @@ export default function ShowsPanel() {
           id, name: '', topic: '',
           personaId: personas[0]?.id || '', mood: '',
           themeId: '', genre: '', fromYear: null, toYear: null, energy: '',
-          genreStrict: false, maxTrackSeconds: null,
+          filtersStrict: false, maxTrackSeconds: null,
           playlistIds: [], playlistStrict: false,
         }],
       };
@@ -568,7 +579,8 @@ export default function ShowsPanel() {
             personaId: s.personaId, mood: s.mood,
             themeId: s.themeId || '',
             genre: s.genre.trim(), fromYear: s.fromYear, toYear: s.toYear, energy: s.energy || '',
-            genreStrict: !!s.genre.trim() && s.genreStrict,
+            // Strict only means something with at least one music filter set.
+            filtersStrict: hasAnyMusicFilter(s) && s.filtersStrict,
             maxTrackSeconds: s.maxTrackSeconds,
             playlistIds: s.playlistIds || [],
             // Strict only means something with at least one playlist pinned.
@@ -1072,28 +1084,31 @@ function ShowEditor({
           <div className="flex items-start gap-3">
             <div className="pt-0.5">
               <Toggle
-                on={show.genreStrict}
-                disabled={!show.genre.trim()}
-                onClick={() => update({ genreStrict: !show.genreStrict })}
+                on={show.filtersStrict}
+                disabled={!hasAnyMusicFilter(show)}
+                onClick={() => update({ filtersStrict: !show.filtersStrict })}
               />
             </div>
             <div className="grid gap-0.5">
-              <Label className={!show.genre.trim() ? 'opacity-40' : undefined}>
-                Strict genre
+              <Label className={!hasAnyMusicFilter(show) ? 'opacity-40' : undefined}>
+                Strict filter
               </Label>
               <span className="field-hint">
-                Stay strictly within this genre (off-genre tracks only as a last
-                resort to avoid silence). Needs a genre lean set above.
+                Hard-enforce every filter set above — mood, era, energy and
+                genre. Off-filter tracks only play as a last resort to avoid
+                silence. When off, they&apos;re all soft leans the DJ can break
+                for flow. Needs at least one filter set.
               </span>
             </div>
           </div>
 
           <span className="field-hint -mt-1.5">
-            Optional soft music steer for this show: a genre, an era, an energy
-            band, or any mix. The DJ leans toward these but can break them for
-            flow; leave blank to let the topic and mood drive selection. Mood
-            set to Any (auto) follows the station&apos;s autonomous mood — time
-            of day, weather, festivals — instead of pinning one.
+            Optional music steer for this show: a mood, a genre, an era, an
+            energy band, or any mix. Soft by default — the DJ leans toward them
+            but can break them for flow; Strict filter above turns every set
+            one into a hard rule. Mood set to Any (auto) follows the
+            station&apos;s autonomous mood — time of day, weather, festivals —
+            instead of pinning one.
           </span>
 
           <Field>

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -83,8 +83,8 @@ interface Show {
   /** When true (and ≥1 music filter is set) EVERY set filter — mood, genre,
    *  era, energy — becomes a HARD filter on the pick pool instead of a soft
    *  lean; off-filter tracks only play as a last resort to avoid silence.
-   *  Defaults off. (Renamed from the genre-only `genreStrict`; the controller
-   *  migrates legacy state on load.) */
+   *  Defaults off. (Replaces the genre-only `genreStrict`; the controller does
+   *  NOT auto-migrate legacy strict shows — they load soft, opt back in here.) */
   filtersStrict: boolean;
   /** Per-show track-length cap (seconds). null = inherit the station default;
    *  0 = unlimited (opt this show out of the cap so it can air long mixes);


### PR DESCRIPTION
## What

Two connected changes to the show music filters (`admin/shows` → Edit show), from a full UX/flow audit:

1. **Music mood gains an "Any (auto)" option** — it was the only filter without one, and was mandatory. Empty mood now means the autonomous mood chain (festival > weather > time of day) applies while the show is on air.
2. **"Strict genre" becomes "Strict filter"** — one toggle that hard-enforces *every* set music filter (mood, genre, era, energy) instead of just the genre. Off = all soft leans. This fixes the audit's core inconsistency: mood was a hard override while genre/era/energy were soft leans, presented side-by-side with no distinction.

## Commit 1 — Any (auto) mood

- mood Select gains **Any (auto)** (same `ANY_SENTINEL` pattern as energy); mood no longer required; new shows default to Any instead of an arbitrary 'energetic'
- `settings.ts`: `''` valid as Any; the lenient schedule loader **coerces** an unknown mood instead of silently dropping the whole show (pre-existing bug)
- AI show draft coerces unknown/missing mood to Any; empty-mood display fixed in NowCard, grid tooltip, list summary

## Commit 2 — unified Strict filter

New show field `filtersStrict` (legacy `genreStrict` migrates on load). When on, every set filter is a **hard, never-starve** filter in all three music paths:

| Path | Enforcement |
|---|---|
| Pool picker (`music/picker.ts`) | `lean()` applies genre + era + mood + energy to every discovery source |
| Agent tools (`picker-tools.ts`) | new `moodLock`/`energyLock` alongside `genreLock`/`eraLock` |
| Auto-playlist coast (`scheduler.ts`) | genre/era hard-drop (playlist airs unfiltered); mood/energy never-starve per source (tagger/analyzer-dependent — hard-dropping would empty the dead-air fallback on an un-tagged library) |

New shared helpers `preferMood` / `preferEnergyStrict` in `music/show-filter.ts` keep all paths agreeing. `showMusicLean` renders one STRICT lock line listing every set filter (governs the DJ's talk + the never-starve case; selection itself is code-enforced). AI show-draft schema renamed and reworded.

**UI**: toggle renamed **Strict filter**, enabled when ≥1 music filter is set (was: genre only); summaries show a `strict filters` chip; the Music-card hint explains soft vs strict and what Any (auto) mood follows.

## Verification
- `npm run lint` clean in both `controller/` and `web/` (eslint + tsc)
- `grep genreStrict` → only the two deliberate legacy-migration reads remain
- Every consumer traced: pool picker, agent locks, auto-playlist, prompts, AI draft, settings round-trip, session key (mood-independent), `/state` payload