### PR TITLE
fix(admin/library): disable Re-analyse acoustics when no analysis engine is running

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3459,6 +3459,7 @@ html.lite *::after {
     padding: 12px 13px; cursor: pointer; text-align: left; font-family: inherit;
 }
 .admin-root .lib-pass:hover { border-color: var(--ink); }
+.admin-root .lib-pass:disabled { opacity: 0.4; cursor: not-allowed; pointer-events: none; }
 .admin-root .lib-pass.on { border-color: var(--accent); background: var(--accent-soft); }
 .admin-root .lib-pass .box {
     width: 15px; height: 15px; border: 1px solid var(--ink); flex: none; margin-top: 2px;

--- a/web/components/admin/LibraryTaggingModal.tsx
+++ b/web/components/admin/LibraryTaggingModal.tsx
@@ -313,10 +313,12 @@ export default function LibraryTaggingModal(p: Props) {
                   Model calls only for rows with a stale prompt or model — often zero if nothing has changed.
                 </p>
               )}
-              <Pass on={!!passes.reAnalyze} onClick={() => togglePass('reAnalyze')} name="Re-analyse acoustics" tag="slow"
-                hint={p.soundsLikeActive
-                  ? "Redo bpm/key + sounds-like for tracks you've already analysed. Drops their acoustic data and rebuilds it."
-                  : "Redo bpm/key for tracks you've already analysed. Drops their acoustic data and rebuilds it. Sounds-like is off."} />
+              <Pass on={!!passes.reAnalyze} onClick={() => togglePass('reAnalyze')} disabled={p.analysisOff} name="Re-analyse acoustics" tag="slow"
+                hint={p.analysisOff
+                  ? 'No analysis engine running — start the analyzer or tts-heavy sidecar (or a local librosa venv).'
+                  : p.soundsLikeActive
+                    ? "Redo bpm/key + sounds-like for tracks you've already analysed. Drops their acoustic data and rebuilds it."
+                    : "Redo bpm/key for tracks you've already analysed. Drops their acoustic data and rebuilds it. Sounds-like is off."} />
               {p.vocalWanted && (
                 <div className="pl-6">
                   <Pass on={!!passes.reAnalyze && reAnalyzeVocal} onClick={() => setReAnalyzeVocal(v => !v)}


### PR DESCRIPTION
## What

In the library tagging modal's **Rescan** tab, the **Re-analyse acoustics** pass was always clickable even when no acoustic analysis engine was available. Ticking it would start a rescan that silently did nothing. This adds `disabled={p.analysisOff}` to gate it (matching the Run tab's **Analyze acoustics**), plus the missing `.lib-pass:disabled` CSS so disabled passes actually look disabled.

## Why

Fresh take on #706, which reported the same two gaps but has since gone stale (conflicts + outdated hint wording after the analyzer was split into a default-on standalone sidecar in #717 and the tagging UX was reworked in #730/#753). Both gaps still exist on `develop`:

- Rescan-tab **Re-analyse acoustics** had no `disabled` guard.
- `globals.css` had `.lib-pass:hover` but no `.lib-pass:disabled` rule, so disabled passes rendered identically to enabled ones.

The `analysisOff`-first hint here matches the current Run-tab wording ("start the analyzer or tts-heavy sidecar (or a local librosa venv)") rather than #706's stale "tts-heavy sidecar" phrasing, then falls through to the existing `soundsLikeActive` branch.

## Testing

- `npm run lint` (eslint + tsc) passes clean in `web/`.

Closes #706.