### PR TITLE
feat(admin/tagger): add option to change batch size for LLM tagging

### DIFF
--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -79,7 +79,7 @@ function clamp01(n: number): number {
 
 interface CliFlags {
   limit: number;
-  batchSize: number;
+  batchSize: number | null;
   seedCount: number | null;
   maxRounds: number | null;
   noPropagate: boolean;
@@ -114,7 +114,9 @@ function parseFlags(): CliFlags {
   const args = process.argv.slice(2);
   return {
     limit: parseIntFlag(args, '--limit') ?? Infinity,
-    batchSize: Math.max(1, Math.min(50, parseIntFlag(args, '--batch') ?? 25)),
+    batchSize: parseIntFlag(args, '--batch') !== null
+      ? Math.max(1, Math.min(50, parseIntFlag(args, '--batch')!))
+      : null,
     seedCount: parseIntFlag(args, '--seeds'),
     // null = fall back to settings.embedding.maxActiveLearningRounds
     maxRounds: parseIntFlag(args, '--max-rounds'),
@@ -308,6 +310,7 @@ async function main() {
   // Tunables from settings.embedding, CLI flags override where present.
   const embedCfg: any = (settings.get() as any).embedding ?? {};
   const maxRounds = flags.maxRounds ?? Math.max(0, embedCfg.maxActiveLearningRounds ?? 3);
+  const tagBatchSize = flags.batchSize ?? Math.max(1, Math.min(50, embedCfg.batchSize ?? 25));
   // Fallbacks kept in sync with DEFAULTS.embedding in settings.ts (settings.get()
   // normally supplies these; the ?? only bites if the field is entirely absent).
   const knnK = Math.max(1, embedCfg.knnNeighbours ?? 10);
@@ -364,7 +367,7 @@ async function main() {
   logEvent('info', `Tagging model — ${activeModelLabel()}`);
   logEvent('info', `Embedding model — ${embeddings.activeModelLabel()} (dim=${embeddingDim})`);
   console.log(
-    `[tag] batch=${flags.batchSize} maxRounds=${maxRounds} knnK=${knnK} ` +
+    `[tag] batch=${tagBatchSize} maxRounds=${maxRounds} knnK=${knnK} ` +
       `moodVote=${moodVoteThreshold} confidence=${confidenceThreshold} ` +
       `audioFusion=${audioFusionWeight}`,
   );
@@ -500,7 +503,7 @@ async function main() {
   let llmTagged = 0;
   if (plan.forwardTag) {
     // ---- Phase 1: EMBED ----------------------------------------------------
-    await phaseEmbed(targetUntagged, flags.batchSize, textMode);
+    await phaseEmbed(targetUntagged, tagBatchSize, textMode);
     lap('embed');
 
     // ---- Phase 2: SEED -----------------------------------------------------
@@ -542,7 +545,7 @@ async function main() {
 
     if (seedSelection.seeds.length > 0) {
       const tagged = await llmTagInBatches(
-        seedSelection.seeds, flags.batchSize, promptHash, 'llm', tagConsumers, { phase: 'seed' },
+        seedSelection.seeds, tagBatchSize, promptHash, 'llm', tagConsumers, { phase: 'seed' },
       );
       llmCalls += tagged.callCount;
       llmTagged += tagged.tagged;
@@ -605,7 +608,7 @@ async function main() {
       logEvent('info', `Round ${round}: re-checking ${uncertain.length} unsure tracks…`);
       const tagged = await llmTagInBatches(
         uncertain,
-        flags.batchSize,
+        tagBatchSize,
         promptHash,
         'uncertain-llm',
         tagConsumers,
@@ -695,7 +698,7 @@ async function main() {
   // model.
   if (plan.reEmbed) {
     console.log(`[tag] re-embed: rebuilding ${reembedIds.length} vectors from scratch`);
-    await phaseEmbed(reembedIds, flags.batchSize, textMode);
+    await phaseEmbed(reembedIds, tagBatchSize, textMode);
     lap('embed');
   }
 
@@ -714,7 +717,7 @@ async function main() {
     } else {
       console.log(`[tag] re-decide: re-tagging ${stale.length} stale row(s)`);
       const tagged = await llmTagInBatches(
-        stale, flags.batchSize, promptHash, 'llm', tagConsumers, { phase: 'seed' },
+        stale, tagBatchSize, promptHash, 'llm', tagConsumers, { phase: 'seed' },
       );
       llmCalls += tagged.callCount;
       llmTagged += tagged.tagged;

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -981,6 +981,7 @@ const DEFAULTS = {
     // (today's behaviour); 1 = trust audio similarity as much as text. Only
     // bites where the acoustic analysis has produced audio vectors.
     audioFusionWeight: 0.5,
+    batchSize: 25,
     enrichment: {
       // Last.fm crowd tags. Tri-state: true = always fetch, false = never,
       // null = auto (fetch only when a Last.fm api_key is configured — see
@@ -1638,6 +1639,10 @@ export async function load() {
         Number.isFinite(stored.embedding?.audioFusionWeight)
           ? clamp01(stored.embedding.audioFusionWeight)
           : DEFAULTS.embedding.audioFusionWeight,
+      batchSize:
+        Number.isFinite(stored.embedding?.batchSize) && stored.embedding.batchSize >= 1
+          ? Math.max(1, Math.min(50, Math.floor(stored.embedding.batchSize)))
+          : DEFAULTS.embedding.batchSize,
       enrichment: {
         lastfmTags:
           typeof stored.embedding?.enrichment?.lastfmTags === 'boolean'

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -188,6 +188,7 @@ interface EmbeddingForm {
   confidenceThreshold: string;
   maxActiveLearningRounds: string;
   audioFusionWeight: string; // '0' = text-only vote (fusion off)
+  batchSize: string;         // '5', '10', or '25'
   enrichment: EmbeddingEnrichmentForm;
 }
 
@@ -235,6 +236,7 @@ const MP3_BITRATES = [64, 96, 128, 160, 192, 320] as const;
 // Keep in sync with OPUS_BITRATES / AAC_BITRATES in controller/src/settings.ts.
 const OPUS_BITRATES = [96, 128, 192, 256, 320] as const;
 const AAC_BITRATES = [128, 192, 256] as const;
+const LLM_BATCH_SIZES = [5, 10, 25] as const;
 
 interface FormState {
   jingleRatio: string;
@@ -322,6 +324,7 @@ interface SettingsData {
       confidenceThreshold?: number;
       maxActiveLearningRounds?: number;
       audioFusionWeight?: number;
+      batchSize?: number;
       enrichment?: Partial<EmbeddingEnrichmentForm>;
     };
     sfx?: { enabled?: boolean };
@@ -539,6 +542,7 @@ export default function SettingsPanel() {
         confidenceThreshold: String(v.embedding?.confidenceThreshold ?? 0.35),
         maxActiveLearningRounds: String(v.embedding?.maxActiveLearningRounds ?? 3),
         audioFusionWeight: String(v.embedding?.audioFusionWeight ?? 0.5),
+        batchSize: String(v.embedding?.batchSize ?? 25),
         enrichment: {
           lastfmTags: v.embedding?.enrichment?.lastfmTags ?? false,
           lyrics: v.embedding?.enrichment?.lyrics ?? true,
@@ -3784,6 +3788,7 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
         audioFusionWeight: Number.isFinite(parseFloat(e.audioFusionWeight))
           ? parseFloat(e.audioFusionWeight)
           : 0.5,
+        batchSize: parseInt(e.batchSize, 10) || 25,
         enrichment: {
           lastfmTags: e.enrichment.lastfmTags,
           lyrics: e.enrichment.lyrics,
@@ -3974,6 +3979,29 @@ function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, r
               setForm(f => ({ ...f, embedding: { ...f.embedding, enabled: v === 'on' } }))
             }
           />
+        </div>
+
+        <hr className="my-5 border-[var(--border)]" />
+
+        <div className="field">
+          <Label>LLM batch size</Label>
+          <Select
+            value={e.batchSize}
+            onValueChange={v => setForm(f => ({ ...f, embedding: { ...f.embedding, batchSize: v } }))}
+          >
+            <SelectTrigger className="max-w-[100px]"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {LLM_BATCH_SIZES.map(s => (
+                  <SelectItem key={s} value={String(s)}>{s} songs</SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <div className="field-hint">
+            How many songs to tag in a single LLM call. Smaller models may need
+            a lower batch size to avoid truncation or errors. 25 is the default.
+          </div>
         </div>
       </Card>
 


### PR DESCRIPTION
## What
A dropdown to change the batch for LLM tagging with weaker models. Preset to 5, 10, and 25. Can be changed to a textbox if that's preferable, but this one should be fine.

## Why
Lot's of cheaper/weaker models fail to tag 25 tracks in a batch, and the tagger then defaults to 1 track per request. This way if needed the operators can fine tune the tagging, and increase the tagging performance even on weaker models.

## How tested
Built the docker container, and tagged with tiny models. 25 fails, 10 works.

## Notes for reviewers
Could be changed to use textbox instead of a dropdown menu.
