### PR TITLE
feat(admin/shows): add blacklisted playlists to shows

### DIFF
--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -15,7 +15,7 @@ import { z } from 'zod';
 import * as settings from '../settings.js';
 import * as session from './session.js';
 import * as picker from '../music/picker.js';
-import { resolveShowPlaylistPool } from '../music/show-playlist.js';
+import { resolveShowPlaylistPool, resolveExcludedPlaylistIds } from '../music/show-playlist.js';
 import * as library from '../music/library.js';
 import * as mix from '../music/mix.js';
 import * as journey from '../music/journey.js';
@@ -332,7 +332,7 @@ export const pickerAgent = defineAgent({
     const energyLock = strict && activeShow?.energy ? activeShow.energy : null;
     // playlistLock / playlistTracks are pre-resolved by pickViaAgent (the
     // Navidrome fetch is async; buildTools is sync) and threaded through run().
-    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, genreLock, eraLock, moodLock, energyLock, playlistLock, playlistTracks });
+    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, genreLock, eraLock, moodLock, energyLock, playlistLock, playlistTracks, excludedIds });
     return { tools, extras: { seen } };
   },
   // Native-path acceptance: the picked id must be one a discovery tool actually
@@ -489,6 +489,7 @@ async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = n
   const playlistPool = activeShow ? await resolveShowPlaylistPool(activeShow) : null;
   const playlistLock = playlistPool && activeShow?.playlistStrict ? playlistPool.ids : null;
   const playlistTracks = playlistPool?.tracks ?? null;
+  const excludedIds = activeShow ? await resolveExcludedPlaylistIds(activeShow) : null;
 
   const run = await pickerAgent.run({
     messages: session.windowMessages(),
@@ -502,6 +503,7 @@ async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = n
     audioWaypoint,
     playlistLock,
     playlistTracks,
+    excludedIds,
   });
   const { steps, toolCalls, extras } = run;
   let object = run.object;

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -316,7 +316,7 @@ export const pickerAgent = defineAgent({
   maxSteps: 4,
   timeoutMs: agentDeadline,
   buildSystem: () => pickSystem(),
-  buildTools: ({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, playlistLock, playlistTracks }) => {
+  buildTools: ({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, playlistLock, playlistTracks, excludedIds }) => {
     // Resolve the active show live (a show that just came on air takes effect):
     // for a strict show (filtersStrict), EVERY set music filter — genre, era,
     // mood, energy — becomes a hard lock the discovery tools enforce on

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -280,7 +280,11 @@ async function refreshAutoPlaylistInner() {
   }
 
   // Excluded playlists (blocklist): drop every track from a blocklisted
-  // playlist. Hard exclusion, no never-starve fallback.
+  // playlist. The pick paths (picker.ts / picker-tools.ts) apply this as a HARD
+  // filter — an empty pool there just skips the LLM pick and coasts on this
+  // auto.m3u. This IS that coast, the last dead-air guard, so it mirrors the
+  // strict-playlist block above: never-starve if the blocklist would empty the
+  // pool (a mis-set "exclude everything" plays an excluded track over silence).
   if (excludedIds) {
     const allowed = pool.filter((t: any) => t?.id && !excludedIds.has(t.id));
     if (allowed.length) { pool.length = 0; pool.push(...allowed); }

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -13,7 +13,7 @@ import * as library from '../music/library.js';
 import * as settings from '../settings.js';
 import { artistKey } from '../music/recency.js';
 import { normGenre, genreMatches, inYearRange, preferEnergy, preferEnergyStrict, preferMood } from '../music/show-filter.js';
-import { resolveShowPlaylistPool } from '../music/show-playlist.js';
+import { resolveShowPlaylistPool, resolveExcludedPlaylistIds } from '../music/show-playlist.js';
 import { getFullContext } from '../context.js';
 import { queue } from './queue.js';
 import * as session from './session.js';
@@ -98,6 +98,7 @@ async function refreshAutoPlaylistInner() {
   const playlistPool = show ? await resolveShowPlaylistPool(show) : null;
   const hasPlaylist = !!playlistPool?.tracks?.length;
   const strictPlaylist = hasPlaylist && !!show?.playlistStrict;
+  const excludedIds = show ? await resolveExcludedPlaylistIds(show) : null;
 
   // Resolve the show's free-text genre to the library's exact tag once, up front.
   // A resolution failure / absent genre leaves genreName null, which disables the
@@ -276,6 +277,13 @@ async function refreshAutoPlaylistInner() {
   if (strictPlaylist) {
     const inPl = pool.filter((t: any) => t?.id && playlistPool!.ids.has(t.id));
     if (inPl.length) { pool.length = 0; pool.push(...inPl); }
+  }
+
+  // Excluded playlists (blocklist): drop every track from a blocklisted
+  // playlist. Hard exclusion, no never-starve fallback.
+  if (excludedIds) {
+    const allowed = pool.filter((t: any) => t?.id && !excludedIds.has(t.id));
+    if (allowed.length) { pool.length = 0; pool.push(...allowed); }
   }
 
   // Stamp the station cap on every fallback entry (#447). max-track-length is a

--- a/controller/src/llm/internal/tools/picker-tools.ts
+++ b/controller/src/llm/internal/tools/picker-tools.ts
@@ -172,10 +172,14 @@ export function buildPickerTools({
     // Strict playlist: HARD-intersect with the lock set, with NO never-starve to
     // off-playlist (a playlist is an exact set, so a tool with no overlap simply
     // contributes nothing). The guaranteed in-set source is showPlaylistTracks
-    // below, so `seen` is never empty and the agent's pick is always in-playlist.
+    // below, so `seen` is normally non-empty and the agent's pick is in-playlist
+    // — unless the blocklist below drops it too (see next).
     if (playlistLock) pool = pool.filter((s: any) => s?.id && playlistLock.has(s.id));
     // Excluded playlists (blocklist): hard-drop tracks from any blocklisted
-    // playlist. The agent simply never sees these ids.
+    // playlist, AFTER the playlist lock so it overrides the anchor (this runs on
+    // every source, showPlaylistTracks included). No never-starve: if a show
+    // excludes its whole pool `seen` can end up empty and the LLM pick is
+    // skipped — the auto.m3u coast (scheduler.ts) is the dead-air backstop.
     if (excludedIds) pool = pool.filter((s: any) => s?.id && !excludedIds.has(s.id));
     const accepted = filterPickerCandidates(pool, {
       recentIds,

--- a/controller/src/llm/internal/tools/picker-tools.ts
+++ b/controller/src/llm/internal/tools/picker-tools.ts
@@ -96,6 +96,7 @@ export function buildPickerTools({
   energyLock = null,
   playlistLock = null,
   playlistTracks = null,
+  excludedIds = null,
 }: {
   recentIds?: Set<string>;
   recentKeys?: Set<string>;        // lowercased "title|artist" — backfilled entries lack ids
@@ -144,6 +145,10 @@ export function buildPickerTools({
   // the agent's window into the operator's curation. Set in BOTH strict (with
   // playlistLock) and soft (no lock, just a strong prompt preference) modes.
   playlistTracks?: any[] | null;
+  // Track ids from the show's excluded playlists (blocklist). Any track whose
+  // id is in this set is dropped from every tool's results so the agent never
+  // sees — and can never pick — a blocklisted track. null = no exclusions.
+  excludedIds?: Set<string> | null;
 } = {}) {
   const seen = new Map<string, any>(); // id → slim song, accumulated across all tool calls
 
@@ -169,6 +174,9 @@ export function buildPickerTools({
     // contributes nothing). The guaranteed in-set source is showPlaylistTracks
     // below, so `seen` is never empty and the agent's pick is always in-playlist.
     if (playlistLock) pool = pool.filter((s: any) => s?.id && playlistLock.has(s.id));
+    // Excluded playlists (blocklist): hard-drop tracks from any blocklisted
+    // playlist. The agent simply never sees these ids.
+    if (excludedIds) pool = pool.filter((s: any) => s?.id && !excludedIds.has(s.id));
     const accepted = filterPickerCandidates(pool, {
       recentIds,
       recentKeys,

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -13,7 +13,7 @@ import * as settings from '../settings.js';
 import { bpmCompat, keyCompat } from './mix.js';
 import { filterPickerCandidates, recencyWindowsForLibrary, effectiveNoRepeatWindow } from './recency.js';
 import { normGenre, genreMatches, preferGenre, preferEra, inYearRange, preferEnergy, preferEnergyStrict, preferMood } from './show-filter.js';
-import { resolveShowPlaylistPool, type PlaylistPool } from './show-playlist.js';
+import { resolveShowPlaylistPool, resolveExcludedPlaylistIds, type PlaylistPool } from './show-playlist.js';
 
 const CANDIDATE_CAP = 18;
 const HISTORY_DEPTH = 4;
@@ -495,7 +495,15 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   // track pool. Null when the show pins none (the common case → pool unchanged).
   const playlistPool = activeShow ? await resolveShowPlaylistPool(activeShow) : null;
   const playlistStrict = !!activeShow?.playlistStrict;
-  const { candidates, sources, strictInfo, playlistInfo } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack, rankTarget, audioWaypoint, showFilter, hardRecentIds, hardRecentKeys, playlistPool, playlistStrict);
+  const excludedIds = activeShow ? await resolveExcludedPlaylistIds(activeShow) : null;
+  const { candidates: rawCandidates, sources, strictInfo, playlistInfo } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack, rankTarget, audioWaypoint, showFilter, hardRecentIds, hardRecentKeys, playlistPool, playlistStrict);
+
+  // Excluded playlists (blocklist): drop any track whose id appears in the
+  // show's excluded playlist union. Applied after buildCandidates so the full
+  // pool is built first; no never-starve fallback — the blocklist is hard.
+  const candidates = excludedIds
+    ? rawCandidates.filter((t: any) => t?.id && !excludedIds.has(t.id))
+    : rawCandidates;
 
   if (candidates.length === 0) {
     queue.log('picker', 'no candidates available, skipping LLM pick');

--- a/controller/src/music/show-playlist.ts
+++ b/controller/src/music/show-playlist.ts
@@ -83,9 +83,10 @@ export async function resolveShowPlaylistPool(show: any): Promise<PlaylistPool |
 // Resolve a show's excluded playlists (blocklist) into a set of track ids to
 // suppress. Any track whose id is in this set is dropped from the candidate
 // pool before the LLM sees it. Returns null when the show has no excluded
-// playlists (the common case → callers treat it as a no-op). Same memoised
-// fetch as resolveShowPlaylistPool; cache keys are prefixed "excl:" so they
-// don't collide.
+// playlists (the common case → callers treat it as a no-op). Shares the same
+// `playlist:${id}` memo key as resolveShowPlaylistPool — it's the identical
+// getPlaylist fetch, so a playlist used as both anchor and blocklist is fetched
+// once, not twice.
 export async function resolveExcludedPlaylistIds(show: any): Promise<Set<string> | null> {
   const ids = Array.isArray(show?.excludedPlaylistIds) ? show.excludedPlaylistIds.filter(Boolean) : [];
   if (!ids.length) return null;
@@ -93,7 +94,7 @@ export async function resolveExcludedPlaylistIds(show: any): Promise<Set<string>
   const blocked = new Set<string>();
   for (const id of ids) {
     try {
-      const songs = await memoFetch(`excl:${id}`, () => subsonic.getPlaylist(id));
+      const songs = await memoFetch(`playlist:${id}`, () => subsonic.getPlaylist(id));
       for (const t of songs || []) {
         if (t?.id) blocked.add(t.id);
       }

--- a/controller/src/music/show-playlist.ts
+++ b/controller/src/music/show-playlist.ts
@@ -79,3 +79,25 @@ export async function resolveShowPlaylistPool(show: any): Promise<PlaylistPool |
   if (!tracks.length) return null;
   return { ids: new Set<string>(tracks.map((t: any) => t.id)), tracks, names };
 }
+
+// Resolve a show's excluded playlists (blocklist) into a set of track ids to
+// suppress. Any track whose id is in this set is dropped from the candidate
+// pool before the LLM sees it. Returns null when the show has no excluded
+// playlists (the common case → callers treat it as a no-op). Same memoised
+// fetch as resolveShowPlaylistPool; cache keys are prefixed "excl:" so they
+// don't collide.
+export async function resolveExcludedPlaylistIds(show: any): Promise<Set<string> | null> {
+  const ids = Array.isArray(show?.excludedPlaylistIds) ? show.excludedPlaylistIds.filter(Boolean) : [];
+  if (!ids.length) return null;
+
+  const blocked = new Set<string>();
+  for (const id of ids) {
+    try {
+      const songs = await memoFetch(`excl:${id}`, () => subsonic.getPlaylist(id));
+      for (const t of songs || []) {
+        if (t?.id) blocked.add(t.id);
+      }
+    } catch {}
+  }
+  return blocked.size ? blocked : null;
+}

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -516,6 +516,7 @@ const SKILL_SLUG_RE = /^[a-z0-9-]{1,40}$/;
 const PERSONA_LIMIT = 24;
 const SHOWS_LIMIT = 64;
 const PLAYLISTS_PER_SHOW = 10;
+const EXCLUDED_PLAYLISTS_PER_SHOW = 10;
 const SKILLS_PER_PERSONA_LIMIT = 20;
 const WEBHOOKS_LIMIT = 16;
 
@@ -535,6 +536,24 @@ function coercePlaylistIds(raw: any): string[] {
     seen.add(id);
     out.push(id);
     if (out.length >= PLAYLISTS_PER_SHOW) break;
+  }
+  return out;
+}
+
+// A show can exclude tracks from one or more Navidrome playlists: any track
+// that appears in these playlists is dropped from the candidate pool at pick
+// time. Same shape/rules as coercePlaylistIds. Empty = no exclusions.
+function coerceExcludedPlaylistIds(raw: any): string[] {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of raw) {
+    if (typeof v !== 'string') continue;
+    const id = v.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+    if (out.length >= EXCLUDED_PLAYLISTS_PER_SHOW) break;
   }
   return out;
 }
@@ -1242,6 +1261,9 @@ function normalizeShows(raw: any, personaIds: string[]) {
     // so existing shows are byte-for-byte unchanged.
     const playlistIds = coercePlaylistIds(item.playlistIds);
     const playlistStrict = item.playlistStrict === true;
+    // Optional Navidrome playlist blocklist — tracks from these playlists are
+    // excluded from the candidate pool. Empty = no exclusions.
+    const excludedPlaylistIds = coerceExcludedPlaylistIds(item.excludedPlaylistIds);
     out.push({
       id,
       name,
@@ -1257,6 +1279,7 @@ function normalizeShows(raw: any, personaIds: string[]) {
       maxTrackSeconds,
       playlistIds,
       playlistStrict,
+      excludedPlaylistIds,
     });
     if (out.length >= SHOWS_LIMIT) break;
   }
@@ -2074,10 +2097,25 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
       playlistIds = coercePlaylistIds(item.playlistIds);
     }
     const playlistStrict = item.playlistStrict === true;
+    // Optional Navidrome playlist blocklist. Shape-checked only — same rules as
+    // playlistIds; stale ids contribute nothing at pick time.
+    let excludedPlaylistIds: string[] = [];
+    if (item.excludedPlaylistIds !== undefined && item.excludedPlaylistIds !== null) {
+      if (!Array.isArray(item.excludedPlaylistIds)) {
+        throw new Error(`shows[${i}].excludedPlaylistIds must be an array of strings`);
+      }
+      if (item.excludedPlaylistIds.length > EXCLUDED_PLAYLISTS_PER_SHOW) {
+        throw new Error(`shows[${i}].excludedPlaylistIds must have at most ${EXCLUDED_PLAYLISTS_PER_SHOW} entries`);
+      }
+      for (const v of item.excludedPlaylistIds) {
+        if (typeof v !== 'string') throw new Error(`shows[${i}].excludedPlaylistIds entries must be strings`);
+      }
+      excludedPlaylistIds = coerceExcludedPlaylistIds(item.excludedPlaylistIds);
+    }
     let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('s_');
     if (seen.has(id)) id = mintId('s_');
     seen.add(id);
-    return { id, name, topic, personaId: item.personaId, mood, themeId, genre, fromYear, toYear, energy, filtersStrict, maxTrackSeconds, playlistIds, playlistStrict };
+    return { id, name, topic, personaId: item.personaId, mood, themeId, genre, fromYear, toYear, energy, filtersStrict, maxTrackSeconds, playlistIds, playlistStrict, excludedPlaylistIds };
   });
 }
 

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -97,6 +97,9 @@ interface Show {
    *  universe; off-playlist tracks only play as a never-starve fallback. When
    *  false, the playlist just dominates the pool. Defaults off. */
   playlistStrict: boolean;
+  /** Navidrome playlist blocklist — tracks from these playlists are excluded
+   *  from the candidate pool regardless of other filters. Empty = no exclusions. */
+  excludedPlaylistIds: string[];
 }
 
 // Decade presets for the era dropdown → fromYear/toYear. 'any' clears the window.
@@ -210,15 +213,17 @@ function NowCard({ label, accent, slotHour, show, color, personaLabel }: NowCard
 // Compact " · genre · 80s · high" suffix for the show summary lines, omitting
 // whatever the show doesn't pin. Strict filters are flagged inline so the hard
 // lock is visible at a glance.
-function showFilterSummary(s: { mood?: string; genre: string; fromYear: number | null; toYear: number | null; energy: string; filtersStrict?: boolean; maxTrackSeconds?: number | null; playlistIds?: string[]; playlistStrict?: boolean }): string {
+function showFilterSummary(s: { mood?: string; genre: string; fromYear: number | null; toYear: number | null; energy: string; filtersStrict?: boolean; maxTrackSeconds?: number | null; playlistIds?: string[]; playlistStrict?: boolean; excludedPlaylistIds?: string[] }): string {
   const len = s.maxTrackSeconds == null ? '' : s.maxTrackSeconds === 0 ? 'any length' : `≤${s.maxTrackSeconds}s`;
   const nPl = s.playlistIds?.length ?? 0;
   const playlist = nPl ? `${nPl} playlist${nPl > 1 ? 's' : ''}${s.playlistStrict ? ' (strict)' : ''}` : '';
+  const nEx = s.excludedPlaylistIds?.length ?? 0;
+  const excluded = nEx ? `${nEx} excluded` : '';
   // The strict chip covers every music filter (mood included) — only shown when
   // there's actually a filter for it to bite on.
   const strict = s.filtersStrict && (s.mood || s.genre || s.energy || s.fromYear != null || s.toYear != null)
     ? 'strict filters' : '';
-  const bits = [s.genre, decadeLabelOf(s), s.energy, strict, len, playlist].filter(Boolean);
+  const bits = [s.genre, decadeLabelOf(s), s.energy, strict, len, playlist, excluded].filter(Boolean);
   return bits.length ? ` · ${bits.join(' · ')}` : '';
 }
 
@@ -384,6 +389,7 @@ export default function ShowsPanel() {
           maxTrackSeconds: s.maxTrackSeconds ?? null,
           playlistIds: Array.isArray(s.playlistIds) ? s.playlistIds : [],
           playlistStrict: s.playlistStrict ?? false,
+          excludedPlaylistIds: Array.isArray(s.excludedPlaylistIds) ? s.excludedPlaylistIds : [],
         }));
         setForm({ shows, schedule: week });
         // Arm the first valid show as the brush so the grid is paintable at once.
@@ -478,7 +484,7 @@ export default function ShowsPanel() {
           personaId: personas[0]?.id || '', mood: '',
           themeId: '', genre: '', fromYear: null, toYear: null, energy: '',
           filtersStrict: false, maxTrackSeconds: null,
-          playlistIds: [], playlistStrict: false,
+          playlistIds: [], playlistStrict: false, excludedPlaylistIds: [],
         }],
       };
     });
@@ -674,6 +680,7 @@ export default function ShowsPanel() {
             playlistIds: s.playlistIds || [],
             // Strict only means something with at least one playlist pinned.
             playlistStrict: (s.playlistIds?.length ?? 0) > 0 && s.playlistStrict,
+            excludedPlaylistIds: s.excludedPlaylistIds || [],
           })),
           schedule: form.schedule,
         }),
@@ -1271,6 +1278,50 @@ function ShowEditor({
               </div>
             </div>
           )}
+
+          <Field>
+            <Label>excluded playlists</Label>
+            <span className="field-hint">
+              Tracks from these playlists will never play during this show,
+              regardless of other filters. Useful for blocking genres or moods
+              that don&apos;t fit — add them to a Navidrome playlist and
+              exclude it here (up to 10).
+            </span>
+            {playlists.length === 0 ? (
+              <span className="field-hint opacity-60">
+                No Navidrome playlists found yet — create some in Navidrome and
+                reopen this panel.
+              </span>
+            ) : (
+              <div className="grid max-h-44 gap-1 overflow-y-auto border border-ink bg-[var(--ink-softer)] p-2">
+                {playlists.map(pl => {
+                  const checked = show.excludedPlaylistIds.includes(pl.id);
+                  const atCap = !checked && show.excludedPlaylistIds.length >= 10;
+                  return (
+                    <label
+                      key={pl.id}
+                      className={`flex items-center gap-2 text-sm ${atCap ? 'opacity-40' : 'cursor-pointer'}`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        disabled={atCap}
+                        onChange={() => update({
+                          excludedPlaylistIds: checked
+                            ? show.excludedPlaylistIds.filter(id => id !== pl.id)
+                            : [...show.excludedPlaylistIds, pl.id],
+                        })}
+                      />
+                      <span className="truncate">{pl.name}</span>
+                      {pl.songCount != null && (
+                        <span className="field-hint">({pl.songCount})</span>
+                      )}
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+          </Field>
         </Card>
 
         <Card flat title="Brief" bodyClass="grid gap-3.5">


### PR DESCRIPTION
## What
Added an option to exclude tracks from playlists. This works by adding songs you don't want to hear in a show to a playlist, ticking the box, and they will be removed from the pool.
This overrides the playlist anchor as well. So if you select a high-energy playlist for the anchor, but don't want techno in it, you can select the techno playlist as excluded, and the pool will only have non-techno high-energy tracks.

## Why
Even finer control on what can be played on a show

## How tested
Built the docker containers, and played around with some songs and playlists. Probably needs more testing (like literally more time, to see if excluded songs come up or not).

## Notes for reviewers
More testing, and probably another set of eyes on the logic, just to make sure I didn't mix stuff up.

<img width="1323" height="203" alt="image" src="https://github.com/user-attachments/assets/7e0899e3-e429-4ad0-a451-8ba3655df07f" />
