### PR TITLE
fix(broadcast+aio): run liquidsoap as root so it can write state after 2.4.4 uid change

### DIFF
--- a/docker/aio/supervisor.sh
+++ b/docker/aio/supervisor.sh
@@ -135,7 +135,14 @@ run_broadcast() {
 	done
 
 	log "starting liquidsoap"
-	sudo -E -u liquidsoap liquidsoap /etc/liquidsoap/radio.liq &
+	# TEMPORARY (re-harden later): run liquidsoap as root instead of dropping to
+	# the `liquidsoap` user — same reason as docker/broadcast-entrypoint.sh. The
+	# savonet base bump 2.2.5 -> 2.4.4 changed that user's uid (10000 -> 100), so
+	# state files persisted under /var/sub-wave by the old image became unwritable
+	# to uid 100 and every on_meta write EACCES'd. Root ignores those perms.
+	# Restore the privilege drop once the state files are chowned to the new uid
+	# (radio.liq's settings.init.allow_root is set for the same reason).
+	liquidsoap /etc/liquidsoap/radio.liq &
 	local lq=$!
 
 	wait -n "$ic" "$lq"

--- a/docker/broadcast-entrypoint.sh
+++ b/docker/broadcast-entrypoint.sh
@@ -141,7 +141,15 @@ done
 # ---- Launch liquidsoap in the background -----------------------------------
 
 echo "broadcast: starting liquidsoap" >&2
-sudo -E -u liquidsoap liquidsoap /etc/liquidsoap/radio.liq &
+# TEMPORARY (re-harden later): run liquidsoap as root instead of dropping to
+# the `liquidsoap` user. The savonet base image bump 2.2.5 -> 2.4.4 changed the
+# `liquidsoap` user's uid (10000 -> 100), so the persisted state files under the
+# bind-mounted /var/sub-wave (e.g. now-playing.json, owned 10000:10001 mode 644
+# by the old image) became unwritable to uid 100 — every on_meta write EACCES'd
+# and the UI froze one song behind. Root ignores those perms. Restore the
+# privilege drop once the state files are chowned to the new liquidsoap uid
+# (needs settings.init.allow_root reverted in radio.liq too).
+liquidsoap /etc/liquidsoap/radio.liq &
 LIQ_PID=$!
 
 # ---- Wait for either to die, then exit -------------------------------------

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -1135,6 +1135,14 @@ music_meta.on_metadata(synchronous=false, on_meta)
 # Per-listener bandwidth is per-mount, so the unused side costs nothing.
 settings.init.force_start := true
 
+# TEMPORARY (re-harden later): allow running as root. The broadcast entrypoint
+# currently launches liquidsoap as root (not the privilege-dropped `liquidsoap`
+# user) because the 2.4.4 base image changed that user's uid and made the
+# persisted state files unwritable — see docker/broadcast-entrypoint.sh. Without
+# this, liquidsoap refuses to start under a root euid. Revert together with the
+# entrypoint once the state files are re-chowned to the liquidsoap uid.
+settings.init.allow_root := true
+
 # Hourly archive path. Wrap in `{time.string(...)}` so the path is a getter that
 # re-runs strftime each time `output.file` reopens (every hour via reopen_when).
 # Passing the bare string skips strftime entirely and writes everything to one


### PR DESCRIPTION
## Problem

The Liquidsoap **2.2.5 → 2.4.4** base-image bump (#784, currently **only on `develop`, unreleased**) silently changed the `liquidsoap` user's uid from **10000 → 100**. State files persisted under the bind-mounted `/var/sub-wave` by the old image — notably `now-playing.json` (owned `10000:10001`, mode `644`) — become **unwritable to uid 100**, so every `on_meta` write hits `Unix.EACCES` at `radio.liq:1087`.

Symptom: stream audio is fine, but `now-playing.json` stops updating and the web UI (admin **and** player, which poll `/now-playing`) **freezes one song behind** the live broadcast. Confirmed in `radio.log`:

```
Uncaught error error(kind="file",message="Unix.Unix_error(Unix.EACCES, \"open\", \"/var/sub-wave/now-playing.json\")" ... at /etc/liquidsoap/radio.liq, line 1087
```

**Who is affected:** upgraders only — a fresh install creates its state files under the new uid, so it self-matches. Anyone upgrading from a 2.2.5-based install (files owned by uid 10000) to a 2.4.4-based image breaks. This affects **both** delivery shapes that bundle liquidsoap: the `broadcast` image and the all-in-one `aio` image. Running as root also covers *every* stale-owned file (hourly archive dir, etc.), not just `now-playing.json`.

## Fix (temporary)

Per the operator's call, drop the non-root privilege drop for now and re-harden later:

- **`docker/broadcast-entrypoint.sh`** — launch liquidsoap as root instead of `sudo -E -u liquidsoap`.
- **`docker/aio/supervisor.sh`** — same change for the AIO image (it bases on the same 2.4.4 upgrade and privilege-dropped identically).
- **`liquidsoap/radio.liq`** — `settings.init.allow_root := true` (liquidsoap refuses a root euid without it). Shared by both images.

All three sites are marked `TEMPORARY (re-harden later)` and cross-reference each other.

## Release ordering (important)

#784 (the 2.4.4 upgrade) is unreleased and lives on `develop`. This PR **must land on `develop` and ship in the same release as #784** — if #784 reaches `main`/a tag without this fix, public upgraders break. Merging both together via the normal develop→main release keeps them in lockstep.

## Re-harden path (follow-up)

Chown the persisted `/var/sub-wave` state files to the new liquidsoap uid (100) in each entrypoint/supervisor, then revert all three markers to restore the privilege-drop.

## Verification

Rebuilt + recreated `broadcast` on the live prod stack:

- liquidsoap now runs as **uid 0 (root)**
- `now-playing.json` updates **live** and matches both the `on_meta` log line and `/api/now-playing` (e.g. *Travis Scott — Stop Trying To Be God*)
- **no `EACCES` after recreate** (last occurrence predates the fix)
- audio-level probe **−10.6 dB** — stream healthy, no silent-wedge

(AIO path is the same code shape; not separately runtime-tested here.)