### PR TITLE
Add funding configuration for Ko-fi

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# These are supported funding model platforms
+ko_fi: pklair


### PR DESCRIPTION
## What

Adds `.github/FUNDING.yml` pointing the repo's "Sponsor" button at Ko-fi (`ko_fi: pklair`).

## Why

Gives listeners a way to financially support the project. The Sponsorships feature has been enabled in repo settings; GitHub reads `FUNDING.yml` from the default branch (`develop`), so it needs to land here for the button to appear.