### PR TITLE
feat(scrobble): configurable ListenBrainz API URL for self-hosted scrobbles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,12 @@ SITE_URL=
 # chat key. OpenRouter embeddings also fall back to OPENROUTER_API_KEY above.
 # EMBEDDING_API_KEY=
 
+# ───────── Scrobbling (optional — also configurable in admin UI) ─────────
+# LISTENBRAINZ_USER_TOKEN=          # ListenBrainz or LB-compatible scrobbler token
+# LISTENBRAINZ_API_URL=             # optional full submit-listens URL override
+#                                   # e.g. http://koito:4110/apis/listenbrainz/1/submit-listens
+#                                   # otherwise set base URL in admin → Settings → Scrobbling
+
 # ───────── Acoustic analysis (CLAP audio-similarity + Demucs vocals) ─────────
 # The analysis pass (npm run analyze / admin "Analyze audio") computes bpm, key,
 # loudness, structure, pace and a beat grid for every track. This runs by

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -1087,6 +1087,12 @@ SITE_URL=
 # chat key. OpenRouter embeddings also fall back to OPENROUTER_API_KEY above.
 # EMBEDDING_API_KEY=
 
+# ───────── Scrobbling (optional — also configurable in admin UI) ─────────
+# LISTENBRAINZ_USER_TOKEN=          # ListenBrainz or LB-compatible scrobbler token
+# LISTENBRAINZ_API_URL=             # optional full submit-listens URL override
+#                                   # e.g. http://koito:4110/apis/listenbrainz/1/submit-listens
+#                                   # otherwise set base URL in admin → Settings → Scrobbling
+
 # ───────── Acoustic analysis (CLAP audio-similarity + Demucs vocals) ─────────
 # The analysis pass (npm run analyze / admin "Analyze audio") computes bpm, key,
 # loudness, structure, pace and a beat grid for every track. This runs by

--- a/controller/src/broadcast/scrobble.ts
+++ b/controller/src/broadcast/scrobble.ts
@@ -24,7 +24,28 @@ import { getListenerCount } from './listeners.js';
 
 const TIMEOUT_MS = 5000;
 const LASTFM_API = 'https://ws.audioscrobbler.com/2.0/';
-const LISTENBRAINZ_API = 'https://api.listenbrainz.org/1/submit-listens';
+const LISTENBRAINZ_DEFAULT = 'https://api.listenbrainz.org/1/submit-listens';
+
+// Shared base for submit + validate-token. Env LISTENBRAINZ_API_URL wins (may be
+// a full submit-listens URL — strip that suffix). Settings baseUrl is the API
+// root (e.g. http://koito:4110/apis/listenbrainz/1). Default → listenbrainz.org.
+export function listenbrainzApiBase(): string {
+  const envUrl = process.env.LISTENBRAINZ_API_URL?.trim();
+  if (envUrl) return envUrl.replace(/\/submit-listens\/?$/i, '').replace(/\/$/, '');
+  const base = settings.get()?.scrobble?.listenbrainz?.baseUrl?.trim();
+  if (base) return base.replace(/\/$/, '');
+  return 'https://api.listenbrainz.org/1';
+}
+
+// Env wins (LISTENBRAINZ_API_URL in .env / secrets.env), then settings baseUrl
+// (for self-hosted ListenBrainz-compatible scrobblers), else LB.org.
+function listenbrainzSubmitUrl(): string {
+  const envUrl = process.env.LISTENBRAINZ_API_URL?.trim();
+  if (envUrl) return envUrl;
+  const base = settings.get()?.scrobble?.listenbrainz?.baseUrl?.trim();
+  if (base) return `${base.replace(/\/$/, '')}/submit-listens`;
+  return LISTENBRAINZ_DEFAULT;
+}
 
 // Last.fm's documented rule for a "valid scrobble":
 //   - the track must be longer than 30 seconds
@@ -272,7 +293,7 @@ async function postListenbrainz(payload: Record<string, unknown>, token: string,
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
   try {
-    const r = await fetch(LISTENBRAINZ_API, {
+    const r = await fetch(listenbrainzSubmitUrl(), {
       method: 'POST',
       headers: {
         'Authorization': `Token ${token}`,

--- a/controller/src/broadcast/scrobble.ts
+++ b/controller/src/broadcast/scrobble.ts
@@ -26,25 +26,30 @@ const TIMEOUT_MS = 5000;
 const LASTFM_API = 'https://ws.audioscrobbler.com/2.0/';
 const LISTENBRAINZ_DEFAULT = 'https://api.listenbrainz.org/1/submit-listens';
 
-// Shared base for submit + validate-token. Env LISTENBRAINZ_API_URL wins (may be
-// a full submit-listens URL — strip that suffix). Settings baseUrl is the API
-// root (e.g. http://koito:4110/apis/listenbrainz/1). Default → listenbrainz.org.
+// Shared base for submit + validate-token. Env LISTENBRAINZ_API_URL wins. Both env +
+// settings inputs may be either the API root (…/1) or the submit endpoint
+// (…/1/submit-listens) — normalize to a base.
 export function listenbrainzApiBase(): string {
-  const envUrl = process.env.LISTENBRAINZ_API_URL?.trim();
-  if (envUrl) return envUrl.replace(/\/submit-listens\/?$/i, '').replace(/\/$/, '');
-  const base = settings.get()?.scrobble?.listenbrainz?.baseUrl?.trim();
-  if (base) return base.replace(/\/$/, '');
-  return 'https://api.listenbrainz.org/1';
+  const raw =
+    process.env.LISTENBRAINZ_API_URL?.trim() ||
+    settings.get()?.scrobble?.listenbrainz?.baseUrl?.trim() ||
+    '';
+  const base = raw.replace(/\/submit-listens\/?$/i, '').replace(/\/$/, '');
+  return base || 'https://api.listenbrainz.org/1';
 }
 
 // Env wins (LISTENBRAINZ_API_URL in .env / secrets.env), then settings baseUrl
 // (for self-hosted ListenBrainz-compatible scrobblers), else LB.org.
 function listenbrainzSubmitUrl(): string {
-  const envUrl = process.env.LISTENBRAINZ_API_URL?.trim();
-  if (envUrl) return envUrl;
-  const base = settings.get()?.scrobble?.listenbrainz?.baseUrl?.trim();
-  if (base) return `${base.replace(/\/$/, '')}/submit-listens`;
-  return LISTENBRAINZ_DEFAULT;
+  const raw =
+    process.env.LISTENBRAINZ_API_URL?.trim() ||
+    settings.get()?.scrobble?.listenbrainz?.baseUrl?.trim() ||
+    '';
+  const normalized = raw.replace(/\/$/, '');
+  if (!normalized) return LISTENBRAINZ_DEFAULT;
+  return /\/submit-listens$/i.test(normalized)
+    ? normalized
+    : `${normalized.replace(/\/submit-listens$/i, '')}/submit-listens`;
 }
 
 // Last.fm's documented rule for a "valid scrobble":

--- a/controller/src/broadcast/scrobble.ts
+++ b/controller/src/broadcast/scrobble.ts
@@ -24,10 +24,10 @@ import { getListenerCount } from './listeners.js';
 
 const TIMEOUT_MS = 5000;
 const LASTFM_API = 'https://ws.audioscrobbler.com/2.0/';
-const LISTENBRAINZ_DEFAULT = 'https://api.listenbrainz.org/1/submit-listens';
 
-// Shared base for submit + validate-token. Env LISTENBRAINZ_API_URL wins. Both env +
-// settings inputs may be either the API root (…/1) or the submit endpoint
+// Shared base for submit + validate-token. Env LISTENBRAINZ_API_URL wins, then
+// settings baseUrl (for self-hosted LB-compatible scrobblers), else LB.org. Both
+// inputs may be either the API root (…/1) or the submit endpoint
 // (…/1/submit-listens) — normalize to a base.
 export function listenbrainzApiBase(): string {
   const raw =
@@ -38,18 +38,9 @@ export function listenbrainzApiBase(): string {
   return base || 'https://api.listenbrainz.org/1';
 }
 
-// Env wins (LISTENBRAINZ_API_URL in .env / secrets.env), then settings baseUrl
-// (for self-hosted ListenBrainz-compatible scrobblers), else LB.org.
+// The submit endpoint is always the base + /submit-listens.
 function listenbrainzSubmitUrl(): string {
-  const raw =
-    process.env.LISTENBRAINZ_API_URL?.trim() ||
-    settings.get()?.scrobble?.listenbrainz?.baseUrl?.trim() ||
-    '';
-  const normalized = raw.replace(/\/$/, '');
-  if (!normalized) return LISTENBRAINZ_DEFAULT;
-  return /\/submit-listens$/i.test(normalized)
-    ? normalized
-    : `${normalized.replace(/\/submit-listens$/i, '')}/submit-listens`;
+  return `${listenbrainzApiBase()}/submit-listens`;
 }
 
 // Last.fm's documented rule for a "valid scrobble":

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -19,6 +19,7 @@ import { restartLiquidsoap, startStream, stopStream, streamStatus } from '../bro
 import { invalidateWeatherCache } from '../context.js';
 import { requireAdmin } from '../middleware/auth.js';
 import { saveSecrets, SECRET_ENV_KEYS } from '../setup/secrets.js';
+import { listenbrainzApiBase } from '../broadcast/scrobble.js';
 import { generateText, createGateway } from 'ai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
@@ -166,6 +167,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
         LASTFM_API_SECRET: !!process.env.LASTFM_API_SECRET,
         LASTFM_SESSION_KEY: !!process.env.LASTFM_SESSION_KEY,
         LISTENBRAINZ_USER_TOKEN: !!process.env.LISTENBRAINZ_USER_TOKEN,
+        LISTENBRAINZ_API_URL: !!process.env.LISTENBRAINZ_API_URL,
       },
       // Skill catalogue — consumed by the Skills page and by Personas for the
       // per-persona skill-assignment checklist.
@@ -374,7 +376,7 @@ async function probeKey(
       return { ok: true, message: '✓ Last.fm API key valid' };
     }
     case 'LISTENBRAINZ_USER_TOKEN': {
-      const r = await fetch('https://api.listenbrainz.org/1/validate-token', {
+      const r = await fetch(`${listenbrainzApiBase()}/validate-token`, {
         headers: { Authorization: `Token ${value}` },
         signal: AbortSignal.timeout(8000),
       });

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -1054,6 +1054,9 @@ const DEFAULTS = {
       enabled: false,
       userToken: '',
       username: '',
+      // Optional override for self-hosted LB-compatible scrobblers (e.g. Koito).
+      // Full submit URL is `${baseUrl}/submit-listens`. Env LISTENBRAINZ_API_URL wins.
+      baseUrl: '',
     },
   },
 };
@@ -1701,6 +1704,10 @@ export async function load() {
         username:
           typeof stored.scrobble?.listenbrainz?.username === 'string'
             ? stored.scrobble.listenbrainz.username.trim().slice(0, 40)
+            : '',
+        baseUrl:
+          typeof stored.scrobble?.listenbrainz?.baseUrl === 'string'
+            ? stored.scrobble.listenbrainz.baseUrl.trim().slice(0, 500)
             : '',
       },
     },
@@ -2802,6 +2809,14 @@ export async function update(patch) {
         const v = String(lb.userToken ?? '').trim();
         if (v.length > 200) throw new Error('scrobble.listenbrainz.userToken must be 0-200 chars');
         next.scrobble.listenbrainz.userToken = v;
+      }
+      if (lb.baseUrl !== undefined) {
+        const trimmed = String(lb.baseUrl ?? '').trim();
+        if (trimmed.length > 500) throw new Error('scrobble.listenbrainz.baseUrl too long');
+        if (trimmed && !/^https?:\/\//i.test(trimmed)) {
+          throw new Error('scrobble.listenbrainz.baseUrl must start with http:// or https://');
+        }
+        next.scrobble.listenbrainz.baseUrl = trimmed;
       }
     }
   }

--- a/controller/src/setup/secrets.ts
+++ b/controller/src/setup/secrets.ts
@@ -35,6 +35,7 @@ export const SECRET_ENV_KEYS = [
   'LASTFM_API_SECRET',
   'LASTFM_SESSION_KEY',
   'LISTENBRAINZ_USER_TOKEN',
+  'LISTENBRAINZ_API_URL',
 ];
 
 // Read state/secrets.env and merge into process.env for keys that aren't

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -5979,8 +5979,8 @@ function ScrobbleSection({ data, form, setForm, busy, saveSettings, adminFetch, 
             />
             <div className="field-hint">
               Leave blank for listenbrainz.org. For self-hosted LB-compatible scrobblers, use the
-              API root (e.g. <code>http://koito:4110/apis/listenbrainz/1</code>). Overrides via
-              <code> LISTENBRAINZ_API_URL</code> env when set.
+              API root (e.g. <code>http://koito:4110/apis/listenbrainz/1</code>). Overrides via{' '}
+              <code>LISTENBRAINZ_API_URL</code> env when set.
             </div>
           </div>
 

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -203,6 +203,7 @@ interface ScrobbleListenbrainzForm {
   enabled: boolean;
   userToken: string;
   username: string;
+  baseUrl: string;
 }
 
 interface ScrobbleForm {
@@ -557,6 +558,7 @@ export default function SettingsPanel() {
           enabled: !!v.scrobble?.listenbrainz?.enabled,
           userToken: v.scrobble?.listenbrainz?.userToken ?? '',
           username: v.scrobble?.listenbrainz?.username ?? '',
+          baseUrl: v.scrobble?.listenbrainz?.baseUrl ?? '',
         },
       },
     });
@@ -5689,6 +5691,7 @@ function ScrobbleSection({ data, form, setForm, busy, saveSettings, adminFetch, 
     const patch: Partial<ScrobbleListenbrainzForm> = {
       enabled: lb.enabled,
       username: lb.username,
+      baseUrl: lb.baseUrl,
     };
     if (lb.userToken && lb.userToken !== 'set') patch.userToken = lb.userToken;
     saveSettings({ scrobble: { listenbrainz: patch } });
@@ -5954,6 +5957,30 @@ function ScrobbleSection({ data, form, setForm, busy, saveSettings, adminFetch, 
             <div className="field-hint">
               ListenBrainz is the open-source alternative to Last.fm, with the same listener gate
               and eligibility rules.
+            </div>
+          </div>
+
+          <div className="field">
+            <Label>API base URL</Label>
+            <Input
+              type="url"
+              value={lb.baseUrl}
+              placeholder="https://api.listenbrainz.org/1"
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setForm(f => ({
+                  ...f,
+                  scrobble: {
+                    ...f.scrobble,
+                    listenbrainz: { ...f.scrobble.listenbrainz, baseUrl: e.target.value },
+                  },
+                }))
+              }
+              className="max-w-[360px]"
+            />
+            <div className="field-hint">
+              Leave blank for listenbrainz.org. For self-hosted LB-compatible scrobblers, use the
+              API root (e.g. <code>http://koito:4110/apis/listenbrainz/1</code>). Overrides via
+              <code> LISTENBRAINZ_API_URL</code> env when set.
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- Allow scrobbling to self-hosted ListenBrainz-compatible endpoints (e.g. Koito) via `scrobble.listenbrainz.baseUrl` in settings or `LISTENBRAINZ_API_URL` env override.
- Default behaviour unchanged: blank baseUrl still submits to api.listenbrainz.org.
- Admin token probe and scrobble submit both respect the configured base.

## Why
Homelab operators often run Koito or other LB-compatible scrobblers on their LAN. The existing ListenBrainz backend hardcoded the public API URL, so enabling scrobbling required forking.

## Test plan
- [ ] Blank baseUrl + enabled token → scrobbles still reach listenbrainz.org (or skip if no listeners)
- [ ] Set baseUrl to a local LB-compatible instance → submit-listens receives playing_now + single listens
- [ ] LISTENBRAINZ_API_URL env overrides settings baseUrl
- [ ] Admin Settings → Scrobble → Test works against custom base
- [ ] Listener gate unchanged: 0 listeners → `[scrobble] skip: 0 listener(s)`