### PR TITLE
fix(admin): stop /debug polling from stacking requests and starving the controller

### DIFF
--- a/controller/src/routes/debug.ts
+++ b/controller/src/routes/debug.ts
@@ -37,7 +37,36 @@ router.get('/requests', requireAdmin, (req, res) => {
   }
 });
 
+// A debug snapshot is expensive to assemble — it loads the mood library, fetches
+// Icecast + weather, sweeps the state dir with stat(), and serialises the whole
+// DJ session (~170KB). The admin panel polls it every ~2s. Coalesce concurrent
+// and rapid hits behind a tiny single-flight cache so a burst of polls — or
+// several open admin tabs — triggers the build at most once per TTL, instead of
+// stacking that work on the single-threaded event loop and starving other
+// /api/* routes (the cause of the edge 524s).
+const DEBUG_CACHE_TTL_MS = 1000;
+let debugCache: { at: number; payload: any } | null = null;
+let debugInflight: Promise<any> | null = null;
+
 router.get('/debug', requireAdmin, async (req, res) => {
+  try {
+    const now = Date.now();
+    if (debugCache && now - debugCache.at < DEBUG_CACHE_TTL_MS) {
+      res.json(debugCache.payload);
+      return;
+    }
+    if (!debugInflight) {
+      debugInflight = buildDebugSnapshot(req)
+        .then((payload) => { debugCache = { at: Date.now(), payload }; return payload; })
+        .finally(() => { debugInflight = null; });
+    }
+    res.json(await debugInflight);
+  } catch (err: any) {
+    res.status(500).json({ error: err?.message || String(err) });
+  }
+});
+
+async function buildDebugSnapshot(req: express.Request): Promise<any> {
   // Station zone so the DJ-log timestamps render in station-local time, matching
   // what the DJ speaks on-air (#418).
   let settingsSnapshot: any = null;
@@ -257,8 +286,8 @@ router.get('/debug', requireAdmin, async (req, res) => {
     port: config.server.port,
   };
 
-  res.json(out);
-});
+  return out;
+}
 
 // GET /sessions — archived session list, newest first. The live session is
 // served inline by /debug; this lists the rolled-off runs in state/sessions/.

--- a/web/components/admin/DebugPanel.tsx
+++ b/web/components/admin/DebugPanel.tsx
@@ -216,31 +216,58 @@ export default function DebugPanel() {
   useEffect(() => {
     if (!hydrated || needsAuth) return;
     let cancelled = false;
+    let running = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
     const tick = async () => {
-      if (paused) return;
+      // Single-flight: never start a new poll while one is in flight. A slow
+      // /debug (it can take several seconds) must not stack overlapping
+      // requests on the single-threaded controller — that pileup starved every
+      // other /api/* call and caused edge 524s.
+      if (cancelled || running) return;
+      running = true;
       try {
-        const r = await adminFetch('/debug');
-        if (r.status === 401) {
-          if (!cancelled) setData(null);
-          return;
-        }
-        const j = (await r.json()) as DebugData;
-        if (!cancelled) {
-          if (!j || typeof j !== 'object' || !j.queue) {
-            setErr(j?.error || 'unexpected response shape from /debug');
-            setData(null);
+        // Skip the fetch when paused or the tab is hidden — no point polling a
+        // backgrounded tab — but keep the loop alive so it resumes cleanly.
+        if (!paused && !(typeof document !== 'undefined' && document.hidden)) {
+          const r = await adminFetch('/debug');
+          if (r.status === 401) {
+            if (!cancelled) setData(null);
           } else {
-            setData(j);
-            setErr(null);
+            const j = (await r.json()) as DebugData;
+            if (!cancelled) {
+              if (!j || typeof j !== 'object' || !j.queue) {
+                setErr(j?.error || 'unexpected response shape from /debug');
+                setData(null);
+              } else {
+                setData(j);
+                setErr(null);
+              }
+            }
           }
         }
       } catch (e) {
         if (!cancelled) setErr(e instanceof Error ? e.message : String(e));
+      } finally {
+        running = false;
+        // Schedule the next poll only after this one settles, so the gap is
+        // measured from completion, not from start — no overlap is possible.
+        if (!cancelled) timer = setTimeout(tick, 2000);
       }
     };
     tick();
-    const id = setInterval(tick, 2000);
-    return () => { cancelled = true; clearInterval(id); };
+    // Refresh promptly when the tab regains focus so the panel isn't stale.
+    const onVisible = () => {
+      if (!cancelled && !document.hidden) {
+        if (timer) { clearTimeout(timer); timer = null; }
+        tick();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
   }, [paused, needsAuth, hydrated, adminFetch]);
 
   useEffect(() => {


### PR DESCRIPTION
## What

The admin **Debug** panel (`/admin/debug`) polled `/api/debug` on a fixed **2s `setInterval`** that fired **regardless of whether the previous request had returned**.

A single `/debug` build is expensive — it loads the mood library, fetches Icecast + weather, sweeps the state dir with `stat()`, and serialises the **full ~170KB DJ session**. When a response was slow (observed up to **8.5s** while the controller was mid-LLM-pick), **3–4 polls stacked up concurrently** on the single-threaded controller, blocking the event loop and starving every other `/api/*` route.

Externally this surfaced as intermittent **Cloudflare 524 timeouts** on the public site.

## Root cause (observed)

Caddy access logs showed multiple simultaneous `/api/debug` requests from one browser, each taking 3–8.5s, coinciding with controller CPU at ~135% during DJ picks. Plain page loads (served by `web`) were unaffected — only `/api/*` (controller) stalled, which is why the station kept playing while requests timed out.

## Fix — both sides, so it can't recur regardless of client

- **web (`components/admin/DebugPanel.tsx`)** — self-scheduling poll that waits for each `/debug` to **settle before scheduling the next** (a single-flight guard makes overlap impossible), the gap measured from completion rather than start. Also **pauses while the tab is hidden** and re-polls immediately on visibility regain.
- **controller (`routes/debug.ts`)** — coalesce concurrent/rapid `/debug` hits behind a **1s single-flight cache**, so the expensive build runs at most once per TTL even with several admin tabs (or the panel + another operator) open.

## Testing

- `web`: `npm run lint` (eslint + `tsc --noEmit`) — clean.
- `controller`: `npm run lint` — 0 errors.
- Built + deployed both to the live single-host prod stack; verified `web /` 200, `/api/health` 200, `/stream.mp3` 206, DJ live, all containers healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)