### PR TITLE
feat(web): remember last-used player volume (#783)

### DIFF
--- a/web/hooks/usePlayer.ts
+++ b/web/hooks/usePlayer.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, type Dispatch, type RefObject, type SetStateAction } from 'react';
 import { isIOSDevice } from '@/lib/platform';
 import { useStationOrigin } from '@/lib/stationOrigin';
+import { loadVolumePref, saveVolumePref } from '@/lib/volume';
 
 // We pick MP3 vs Ogg-Opus on the client via canPlayType — Opus is roughly
 // equal-or-better quality at half the bandwidth on browsers that decode it.
@@ -106,6 +107,31 @@ export function usePlayer({ initialVolume = 1 }: UsePlayerOptions = {}): Player 
 
   useEffect(() => {
     if (audioRef.current) audioRef.current.volume = volume;
+  }, [volume]);
+
+  // Restore the listener's last-used volume (issue #783). localStorage is
+  // effect-only (never read during render) so SSR + first paint stay on the
+  // default and there's no hydration mismatch — the knob snaps to the stored
+  // level a tick later, same as the lite-mode toggle. Gate persistence on
+  // `hydrated` so this restoring setVolume doesn't race the persist effect.
+  const hydratedRef = useRef(false);
+  useEffect(() => {
+    const stored = loadVolumePref();
+    if (stored !== null) {
+      setVolume(stored);
+      preMuteVolume.current = stored > 0 ? stored : preMuteVolume.current;
+    }
+    hydratedRef.current = true;
+  }, []);
+
+  // Persist volume on change, debounced so a knob drag (dozens of setVolume
+  // calls) collapses to one write. The cleanup clears the pending timer on each
+  // re-run, so the transient default value the mount pass carries before the
+  // restore effect's setVolume lands never actually reaches localStorage.
+  useEffect(() => {
+    if (!hydratedRef.current) return;
+    const id = setTimeout(() => saveVolumePref(volume), 300);
+    return () => clearTimeout(id);
   }, [volume]);
 
   // Pick Opus on browsers that *definitively* decode it (Chrome, Edge — they

--- a/web/lib/volume.ts
+++ b/web/lib/volume.ts
@@ -1,0 +1,38 @@
+// Persisted listener volume (issue #783).
+//
+// The player's volume lives as React state in usePlayer, defaulting to full.
+// Listeners expect their last-used level to survive a reload, so we mirror it
+// into localStorage on change and restore it at mount. Stored as a clamped
+// 0..1 float string; muting (volume 0) is persisted verbatim so "last used
+// volume" stays faithful.
+//
+// Reads/writes are effect-only (never during render) so there's no hydration
+// mismatch — the knob renders at the default on first paint, then snaps to the
+// stored value a tick later, same as the lite-mode toggle.
+
+const STORAGE_KEY = 'subwave-volume';
+
+/** Read the stored volume (0..1), or null when nothing valid is stored so the
+ *  caller can keep its own default. No-op / null on the server. */
+export function loadVolumePref(): number | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return null;
+    const v = Number(raw);
+    if (!Number.isFinite(v)) return null;
+    return Math.min(1, Math.max(0, v));
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the volume (clamped 0..1). Failures (private mode, quota) are
+ *  swallowed — playback is unaffected. */
+export function saveVolumePref(volume: number): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const v = Math.min(1, Math.max(0, volume));
+    window.localStorage.setItem(STORAGE_KEY, String(v));
+  } catch { /* private mode / quota — non-fatal */ }
+}


### PR DESCRIPTION
## What

The web player now remembers the listener's last-used volume across reloads. Previously every visit reset to full volume.

Closes #783.

## How

- **`web/lib/volume.ts`** — small `loadVolumePref` / `saveVolumePref` helpers (clamped `0..1`, SSR-safe, failures swallowed), mirroring the existing `lib/lite.ts` pattern.
- **`web/hooks/usePlayer.ts`** — two effects:
  - *restore-on-mount*: reads localStorage in an effect (never during render, so no hydration mismatch — the knob snaps to the stored level a tick after paint, same as the lite-mode toggle). Also seeds `preMuteVolume` so unmute round-trips after a reload.
  - *debounced persist*: writes on change with a 300ms debounce so a knob drag (dozens of `setVolume` calls) collapses to one write; the debounce cleanup also cancels the transient default-value write from the mount pass, so the stored value is never clobbered.

Mute (volume `0`) is persisted verbatim — faithful to "last used volume."

## Verification

- `npm run lint` in `web/` (eslint + `tsc --noEmit`) — clean.
- Round-trip logic exercised against a fake localStorage: round-trip, mute-as-0, clamp high/low, garbage/empty → null — 7/7 pass.

(Could not stand up the Next dev server in this environment to click through the knob manually; the wiring is a direct mirror of the shipping lite-mode persistence.)