### PR TITLE
fix(controller): checkpoint the library DB WAL and shut down cleanly

### DIFF
--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -441,7 +441,7 @@ async function stationId() {
 }
 
 // ---------------------------------------------------------------------------
-// CLEAN UP — old voice WAVs
+// CLEAN UP — old voice WAVs + library DB WAL
 // ---------------------------------------------------------------------------
 
 async function cleanup() {
@@ -449,6 +449,15 @@ async function cleanup() {
     await cleanupOldVoices();
   } catch (err) {
     queue.log('error', `Cleanup failed: ${err.message}`);
+  }
+  // Fold the library DB's WAL sidecar back into the main file. Without a
+  // periodic TRUNCATE checkpoint a bulk write pass (tagging, acoustic
+  // analysis) leaves the WAL at its high-water mark — 730MB in #786 — and
+  // every query afterwards pays to walk it.
+  try {
+    library.checkpoint();
+  } catch (err) {
+    queue.log('error', `Library WAL checkpoint failed: ${err.message}`);
   }
 }
 

--- a/controller/src/config.ts
+++ b/controller/src/config.ts
@@ -47,6 +47,10 @@ export const config = {
     password: process.env.NAVIDROME_PASS || '',
     apiVersion: '1.16.1',
     clientName: 'sub-wave',
+    // Per-request cap on Subsonic API calls. Without one, a slow or hung
+    // Navidrome leaves fetches pending forever and admin routes stack up
+    // behind them (#786's "recent failed (500)").
+    timeoutMs: parseInt(process.env.NAVIDROME_TIMEOUT_MS || '', 10) || 30_000,
   },
   ollama: {
     // Default-when-blank server URL + model. The admin Settings UI

--- a/controller/src/music/analyze-library.ts
+++ b/controller/src/music/analyze-library.ts
@@ -39,6 +39,14 @@ import { acquireStandaloneLock, installPidfileCleanup } from './tagger-lock.js';
 
 const logEvent = makeEventLogger('analyze');
 
+// Close (and TRUNCATE-checkpoint) the library DB on every exit path. The
+// analysis pass is the biggest bulk writer in the system — fat *_json blobs
+// per track — and exiting without a close is exactly what left a 730MB WAL
+// sidecar behind in #786. db.close() is synchronous, so an 'exit' hook is safe.
+process.on('exit', () => {
+  try { if (db.isOpen()) db.close(); } catch { /* best-effort */ }
+});
+
 function parseIntFlag(args: string[], name: string): number | undefined {
   const idx = args.indexOf(name);
   if (idx < 0) return undefined;

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -218,6 +218,12 @@ export async function open(opts: {
   db = new Database(DB_PATH);
   db.pragma('journal_mode = WAL');
   db.pragma('synchronous = NORMAL');
+  // Cap the -wal sidecar: after any checkpoint SQLite truncates it back to this
+  // size instead of leaving it at its high-water mark. Without it a bulk write
+  // pass (acoustic analysis, tagging) balloons the WAL to hundreds of MB — 2.4×
+  // the DB itself in #786 — and every later query walks that giant WAL on
+  // better-sqlite3's synchronous thread, stalling the whole event loop.
+  db.pragma('journal_size_limit = 67108864'); // 64 MiB
   sqliteVec.load(db);
 
   // migrate() may adopt the stored dim; trust its return as the live schema dim.
@@ -231,6 +237,17 @@ export async function open(opts: {
 
 export function close(): void {
   if (db) {
+    // Fold the WAL back into the main DB file before closing. SQLite only
+    // auto-checkpoints on the LAST connection to close, and the controller,
+    // tagger and analyzer can hold the DB concurrently — so an explicit
+    // best-effort TRUNCATE here is what keeps the sidecar from surviving
+    // (and regrowing across) restarts. Synchronous, so it also runs safely
+    // from a process 'exit' hook.
+    try {
+      db.pragma('wal_checkpoint(TRUNCATE)');
+    } catch {
+      /* busy/readonly — the hourly checkpoint or next close gets it */
+    }
     db.close();
     db = null;
     currentEmbeddingDim = null;
@@ -243,6 +260,26 @@ export function close(): void {
 
 export function isOpen(): boolean {
   return db !== null;
+}
+
+// Best-effort PRAGMA wal_checkpoint(TRUNCATE): fold the WAL into the main DB
+// file and truncate the sidecar to zero. Returns what SQLite reports — busy=1
+// means a concurrent reader/writer kept the checkpoint from completing (fine;
+// the next run catches up) — or null when the DB isn't open. Called after bulk
+// passes and hourly from the scheduler so the WAL can never balloon unbounded
+// again (#786).
+export function checkpointWal(): { busy: number; log: number; checkpointed: number } | null {
+  if (!db) return null;
+  try {
+    const row = db.pragma('wal_checkpoint(TRUNCATE)') as Array<{
+      busy: number;
+      log: number;
+      checkpointed: number;
+    }>;
+    return row?.[0] ?? null;
+  } catch {
+    return null;
+  }
 }
 
 // Write a consistent, single-file copy of the live DB to `destPath`. Uses

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -52,6 +52,24 @@ export async function save() {
   // no-op
 }
 
+// Fold the WAL sidecar back into library.db (best-effort TRUNCATE checkpoint).
+// Safe to call whether or not the DB is open. Wired to the scheduler's hourly
+// cleanup and the server's shutdown path (#786).
+export function checkpoint(): void {
+  if (!db.isOpen()) return;
+  const r = db.checkpointWal();
+  if (r && r.busy) {
+    console.log('[library] WAL checkpoint incomplete (concurrent reader/writer); will retry next pass');
+  }
+}
+
+// Close the backing DB (checkpointing the WAL on the way out). The graceful-
+// shutdown counterpart to load(); a later load() reopens.
+export function shutdown(): void {
+  if (db.isOpen()) db.close();
+  loaded = false;
+}
+
 export function get(songId: string): any {
   if (!loaded) return null;
   const t = db.getTrack(songId);

--- a/controller/src/music/subsonic.ts
+++ b/controller/src/music/subsonic.ts
@@ -90,7 +90,20 @@ async function call(endpoint, params = {}) {
   const started = Date.now();
   try {
     const url = buildUrl(endpoint, params);
-    const res = await fetch(url);
+    // Bounded fetch: a hung Navidrome must fail fast, not pin the request
+    // (and every admin route queued behind it) forever (#786). The abort
+    // rejects with a TimeoutError, translated into a readable message.
+    let res;
+    try {
+      res = await fetch(url, { signal: AbortSignal.timeout(config.navidrome.timeoutMs) });
+    } catch (err) {
+      if (err?.name === 'TimeoutError' || err?.name === 'AbortError') {
+        throw new Error(
+          `Subsonic ${endpoint} timed out after ${config.navidrome.timeoutMs}ms — is Navidrome responding?`,
+        );
+      }
+      throw err;
+    }
     if (!res.ok) {
       // Capture the first 200 chars of the body so outage triage gets the
       // actual server message (Cloudflare 522, Navidrome 5xx detail, etc.)

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -59,6 +59,14 @@ import { acquireStandaloneLock, installPidfileCleanup } from './tagger-lock.js';
 // controller relays to the panel — one call site per notable milestone.
 const logEvent = makeEventLogger('tag');
 
+// Close (and TRUNCATE-checkpoint) the library DB on every exit path — this CLI
+// bails via process.exit() from several places, and a bulk run that skips the
+// close leaves the WAL sidecar at its high-water mark forever (#786).
+// db.close() is fully synchronous, so it's safe inside an 'exit' hook.
+process.on('exit', () => {
+  try { if (db.isOpen()) db.close(); } catch { /* best-effort */ }
+});
+
 // ---------------------------------------------------------------------------
 // CLI arg parsing
 // ---------------------------------------------------------------------------

--- a/controller/src/routes/dj.ts
+++ b/controller/src/routes/dj.ts
@@ -16,6 +16,7 @@ import { runStationId, runHourlyCheck, runLink, refreshAutoPlaylist } from '../b
 import { skillCatalog, runCapability, effectiveContextFields } from '../skills/_agent.js';
 import { loadSkills, parseFrontmatter, SEEDED_KINDS, RESERVED_KINDS, SLUG_RE, readTemplate, listCommunitySkills, readCommunitySkill } from '../skills/loader.js';
 import { writeSkillFile, msToCooldownStr, resetBuiltinSkill } from '../skills/scaffold.js';
+import { mapPool } from '../util/async-pool.js';
 import { readFile, rm, stat, mkdir, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { STATE_DIR, config } from '../config.js';
@@ -731,8 +732,12 @@ router.get('/dj/recent', requireAdmin, async (req, res) => {
   try {
     await library.load();
     const albums = await subsonic.getRecentlyAddedAlbums({ size: limit });
-    const songLists = await Promise.all(
-      albums.map((a: any) => subsonic.getAlbum(a.id).catch(() => [])),
+    // Bounded fan-out: an unbounded Promise.all fired one getAlbum per album
+    // (~21 parallel Navidrome calls at the default limit), which tipped a
+    // slow/loaded Navidrome into failures (#786). 5-wide keeps it snappy
+    // without the thundering herd.
+    const songLists = await mapPool(albums, 5, (a: any) =>
+      subsonic.getAlbum(a.id).catch(() => []),
     );
     const results = songLists.flat().slice(0, limit).map((s: any) => {
       const tag = library.get(s.id);

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -40,9 +40,37 @@ import { router as doctorRoutes } from './routes/doctor.js';
 import { loadSecretsIntoEnv } from './setup/secrets.js';
 import { loadSetupConfig } from './setup/config.js';
 import { getSetupStatus } from './setup/firstRun.js';
+import * as library from './music/library.js';
 
 // Fail fast in production if the admin gate isn't configured.
 assertAdminConfigured();
+
+// Log-don't-die guard. Node's default since v15 is to CRASH the process on any
+// unhandled promise rejection — under the AIO supervisor (and compose's
+// restart policy) that showed up as random 502s while the controller bounced
+// (#786). A stray rejection from a background poll is never worth taking the
+// station's API down; log it loudly and keep serving.
+process.on('unhandledRejection', (reason: any) => {
+  console.error('[fatal-ish] unhandled promise rejection (continuing):', reason?.stack || reason);
+});
+
+// Graceful shutdown: fold the library DB's WAL back into library.db before the
+// process dies. Without this, `docker stop` (SIGTERM) left the -wal sidecar
+// behind on every restart, and it only ever grew (#786). Synchronous work only.
+let shuttingDown = false;
+function shutdown(signal: string): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`[shutdown] ${signal} — closing library DB`);
+  try {
+    library.shutdown();
+  } catch (err: any) {
+    console.error('[shutdown] library close failed:', err.message);
+  }
+  process.exit(0);
+}
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
 
 const app = express();
 // Global cap covers small JSON payloads everywhere; the persona-avatar route

--- a/docker/aio/supervisor.sh
+++ b/docker/aio/supervisor.sh
@@ -206,9 +206,16 @@ supervise() {
 init_state
 init_secrets
 
-# On stop, signal the whole process group once and bail (reset the trap first
-# so the kill doesn't re-enter this handler).
-trap 'trap "" TERM INT; log "shutting down"; kill -TERM 0 2>/dev/null; exit 0' TERM INT
+# On stop, signal the whole process group once, then give the children time to
+# shut down before exiting (reset the trap first so the kill doesn't re-enter
+# this handler). The grace period matters: this script is PID 1, and the
+# instant it exits the container namespace is torn down and everything left
+# gets SIGKILLed — which robbed the controller of its SIGTERM handler and left
+# library.db's WAL sidecar un-checkpointed on every stop (#786). `wait` covers
+# the supervise loops; the sleep covers their children (node etc.), which get
+# reparented to us when the loops die and which bash's wait can't see. Docker's
+# stop timeout (default 10s) still hard-caps the whole thing.
+trap 'trap "" TERM INT; log "shutting down"; kill -TERM 0 2>/dev/null; wait; sleep 2; exit 0' TERM INT
 
 supervise broadcast  run_broadcast  &
 supervise controller run_controller &

--- a/docs/unraid.md
+++ b/docs/unraid.md
@@ -44,7 +44,18 @@ same images as the Compose stack, just packaged together.
 
 > ⚠️ **Keep Appdata on the array/pool, not the flash drive.** SUB/WAVE's state
 > grows — hourly archives, the library cache, rendered voices — so point it at
-> `/mnt/user/appdata/subwave`, never `/boot/...`.
+> your appdata share, never `/boot/...`.
+
+> ⚠️ **If your appdata share lives on a pool (cache), use the direct pool path**
+> — e.g. `/mnt/cache/appdata/subwave` instead of `/mnt/user/appdata/subwave`.
+> The library cache is a SQLite database in WAL mode, and `/mnt/user` paths go
+> through Unraid's shfs/FUSE layer even for cache-only shares. SQLite
+> [documents](https://www.sqlite.org/wal.html) that WAL doesn't work properly
+> over FUSE-style filesystems — in practice it means sluggish admin pages and
+> a WAL file that balloons to hundreds of MB (issue #786). Same rule the
+> Sonarr/Radarr projects apply to their databases. Already installed on
+> `/mnt/user`? Stop the container, edit the path mapping to the `/mnt/cache/...`
+> equivalent (same data, FUSE bypassed), and start it again.
 
 Fronting this with your own NPM / SWAG / Traefik for TLS + a hostname? See
 [Putting it behind your own reverse

--- a/templates/subwave.xml
+++ b/templates/subwave.xml
@@ -67,9 +67,13 @@
           Type="Port" Display="always" Required="true" Mask="false">7700</Config>
 
   <!-- Persistent state. Keep this on the array/pool, NOT the flash drive —
-       it grows (hourly archives, library cache, rendered voices). -->
+       it grows (hourly archives, library cache, rendered voices). Prefer a
+       direct pool path (/mnt/cache/...) over /mnt/user/...: the library cache
+       is a SQLite database, and /mnt/user routes through Unraid's shfs/FUSE
+       layer, which SQLite's WAL mode is documented not to work well over
+       (slow queries, checkpoint stalls — issue #786). -->
   <Config Name="Appdata" Target="/var/sub-wave" Default="/mnt/user/appdata/subwave" Mode="rw"
-          Description="Persistent state: settings, library cache, rendered voices, hourly archives."
+          Description="Persistent state: settings, library cache, rendered voices, hourly archives. If your appdata share lives on a pool, prefer the direct pool path (e.g. /mnt/cache/appdata/subwave) over /mnt/user/... — the library cache is a SQLite database and performs poorly through Unraid's FUSE layer."
           Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/subwave</Config>
 
   <Config Name="ADMIN_USER" Target="ADMIN_USER" Default="admin"

--- a/web/components/setup/Unraid.tsx
+++ b/web/components/setup/Unraid.tsx
@@ -95,6 +95,24 @@ export default function Unraid() {
                 <code className="bs-code-inline">/boot/…</code>.
               </p>
             </div>
+            <div className="bs-callout">
+              <div className="bs-eyebrow">ON A POOL? USE THE DIRECT PATH</div>
+              <p>
+                If your appdata share lives on a pool (cache), prefer the direct
+                pool path — e.g.{' '}
+                <code className="bs-code-inline">/mnt/cache/appdata/subwave</code>{' '}
+                instead of{' '}
+                <code className="bs-code-inline">/mnt/user/appdata/subwave</code>.
+                The library cache is a SQLite database, and{' '}
+                <code className="bs-code-inline">/mnt/user</code> paths route
+                through Unraid&apos;s shfs/FUSE layer, which SQLite performs
+                poorly over — sluggish admin pages and a ballooning{' '}
+                <code className="bs-code-inline">library.db-wal</code> file.
+                Already installed? Stop the container, edit the path mapping to
+                the <code className="bs-code-inline">/mnt/cache/…</code>{' '}
+                equivalent (same data), and start it again.
+              </p>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
Fixes #786 — slow admin UI on the Unraid AIO caused by an unbounded `library.db-wal` (730MB on a 303MB DB) plus SQLite-over-FUSE on `/mnt/user` appdata paths.

## Root cause

`library-db.ts` set `journal_mode = WAL` at open and nothing else, ever:

- No `journal_size_limit`, so once a bulk write pass (acoustic analysis writes fat `*_json` blobs per track) ballooned the WAL, it stayed at its high-water mark forever.
- The bulk CLIs (`npm run tag` / `npm run analyze`) exit via `process.exit()` without closing the DB, so the pass that grew the WAL never folded it back.
- The AIO supervisor's stop trap was `kill -TERM 0; exit 0` — as PID 1, its immediate exit tears the namespace down and SIGKILLs node before any shutdown work; and `server.ts` had no SIGTERM handler anyway.
- With better-sqlite3 being synchronous, every query walking that giant WAL blocked the whole event loop — sluggish admin pages at ~0% CPU, exactly as reported.

Separately, `server.ts` had no `unhandledRejection` handler (Node's default since v15 is to crash), so a stray rejection killed the controller and the supervisor bounced it — the random 502s. And Subsonic fetches had no timeout while `/dj/recent` fanned out ~21 parallel Navidrome calls — the "recent failed (500)".

## Changes

**WAL management**
- `journal_size_limit = 64 MiB` at open, so any checkpoint truncates the sidecar back down.
- `close()` runs a best-effort `wal_checkpoint(TRUNCATE)` first (SQLite only auto-checkpoints on the *last* connection close, and controller/tagger/analyzer can hold the DB concurrently).
- New `checkpointWal()` helper; the scheduler's hourly cleanup job now calls it, so the WAL can't balloon unbounded even mid-run.
- Both bulk CLIs register a `process.on('exit')` hook that closes the DB on every exit path (better-sqlite3 close is synchronous, so this is safe).

**Clean shutdown**
- `server.ts`: SIGTERM/SIGINT handler closes the library DB before exiting.
- AIO supervisor: after `kill -TERM 0`, `wait` for the supervise loops + a 2s grace for their reparented children before PID 1 exits, so node's handler actually runs. Docker's stop timeout still hard-caps it.

**Resilience**
- `unhandledRejection` now logs loudly and continues instead of killing the controller.
- Subsonic API calls get a 30s timeout (`NAVIDROME_TIMEOUT_MS` to override) with a readable error.
- `/dj/recent`'s album expansion is bounded to 5 concurrent Navidrome calls via the existing `mapPool` util.

**Docs / template (FUSE)**
- `docs/unraid.md`, the `/setup/unraid` page, and the CA template description now recommend the direct pool path (`/mnt/cache/appdata/subwave`) over `/mnt/user/...` — SQLite WAL over Unraid's shfs/FUSE layer is a documented-bad combo. Template *default* stays `/mnt/user` since `/mnt/cache` only exists when a pool is named `cache`.

## Verified

- `npm run lint` clean in both `controller/` and `web/`.
- Smoke-tested the checkpoint path against the installed better-sqlite3: a 4.1MB WAL truncates to 0 bytes on `wal_checkpoint(TRUNCATE)` and the sidecar is removed on close.