### PR TITLE
fix(broadcast): micro edge fades on DJ voice clips to kill boundary clicks

### DIFF
--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -897,8 +897,19 @@ end
 # BEFORE mic_chain so the fixed-threshold compressor sees a levelled input. The
 # un-annotated silent lead-in carries no `liq_amplify`, so it plays at the base
 # factor 1. (unity). Un-trimmed clips (gainDb 0) write a bare path → also unity.
-voice = mic_chain(amplify(override="liq_amplify", 1., voice_queue))
-intro = mic_chain(amplify(override="liq_amplify", 1., intro_queue))
+# Micro edge fades on each spoken clip. Some TTS engines cut the WAV hard at
+# the file boundary; once the mic-chain compressor's makeup gain lifts the
+# clip, that hard edge lands as an audible click/tick. 40 ms is short enough
+# not to soften the first word (speech onsets are slower than that) but long
+# enough to zero out the boundary discontinuity. Applied per track, so the
+# silent lead-in clip is faded too (harmless — it's silence). Placed BEFORE
+# amplify/mic_chain so the compressor never sees the raw edge.
+def edge_fade(s) =
+  fade.in(duration=0.04, fade.out(duration=0.04, s))
+end
+
+voice = mic_chain(amplify(override="liq_amplify", 1., edge_fade(voice_queue)))
+intro = mic_chain(amplify(override="liq_amplify", 1., edge_fade(intro_queue)))
 
 # ---------------------------------------------------------------------------
 # STUDIO BED — continuous low-level ambient room tone (Phase 2)


### PR DESCRIPTION
## What

Adds a 40 ms fade-in/fade-out to every spoken clip on both DJ voice channels (`voice_queue` / `intro_queue`) in `radio.liq`, applied per track before `amplify`/`mic_chain`.

## Why

The voice WAV/MP3 previously started and ended dry. Some TTS engines cut the file hard at the boundary, and the mic-chain compressor's +7 dB makeup gain amplifies that discontinuity into an audible click/tick at the start or end of a spoken segment. The existing softness (0.8 s `smooth_add` duck ramps + silent lead-in) shapes the *music* around the voice but never touched the voice file's own edges.

40 ms is below speech-onset perception, so the first word is not softened; the silent lead-in clip gets faded too, which is harmless.

## Performance

Effectively zero: `fade.in`/`fade.out` are amplitude envelopes (one multiply per sample during the 40 ms windows, passthrough otherwise) on a source that is silent most of the time — noise next to the MP3/Opus encoders already running.

## Verification

`liquidsoap --check` passes against `savonet/liquidsoap:v2.4.4` (the broadcast image base), confirming the fades type-check on the `request.queue` sources with no "Early computation of source content-type" error (the failure mode that blocked HPF/EQ here).