### PR TITLE
feat(broadcast): air station idents at track boundaries, not mid-song

### DIFF
--- a/controller/package-lock.json
+++ b/controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sub-wave-controller",
-  "version": "0.33.0",
+  "version": "0.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sub-wave-controller",
-      "version": "0.33.0",
+      "version": "0.35.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.1",

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -99,6 +99,7 @@ class Queue {
   _recentPlaysTimer: NodeJS.Timeout | null = null; // debounce for the recent-plays.json sidecar
   _recentPlays: { id: string | null; title: string | null; artist: string | null; endedAt: string }[] = [];
   _emptyDjQueueStreak = 0;      // consecutive reconcile checks seeing an empty dj_queue while sent items remain — see reconcileWithDjQueue
+  _pendingVoice: { text: string; kind: string; wavPath: string; persona: any; meta: any; t: number } | null = null; // one boundary-deferred segment awaiting the next track start — see announceAtNextTrack
 
   // Snapshot upcoming/current/history to disk. The queue is otherwise purely
   // in-memory, so a controller restart (every `--build controller` rebuild)
@@ -328,6 +329,20 @@ class Queue {
       if (out.length >= n) break;
     }
     return out;
+  }
+
+  // Timestamp (ms) of the most recent on-air spoken segment, or 0. Defaults to
+  // every voice kind; pass `kinds` to narrow it (the segment director's
+  // frequency floor asks only about the scheduler's wall-clock talkers —
+  // idents/hourly/handoff — since track-tied links would mute it entirely on a
+  // chatty station). Its private lastAnySegment counter only ever saw its own
+  // segments, so this is how a just-aired ident suppresses a back-to-back one.
+  getLastVoiceAt(kinds?: readonly string[]) {
+    const match = kinds ? new Set(kinds) : VOICE_KINDS;
+    for (const entry of this.djLog) {
+      if (match.has(entry.kind)) return new Date(entry.t).getTime();
+    }
+    return 0;
   }
 
   // Push a listener request. Adds to upcoming and kicks off the Liquidsoap sender.
@@ -709,6 +724,55 @@ class Queue {
     }
   }
 
+  // Defer a spoken segment to the NEXT track boundary instead of airing it
+  // immediately. Used for station idents: they have no real-time constraint
+  // (unlike the hourly time check), so ducking the current song mid-vocal at
+  // an arbitrary wall-clock minute is pure loss — at a transition the same
+  // ident lands like real radio. The WAV is rendered NOW (TTS latency off the
+  // air path); onTrackStarted airs it via the light-duck intro channel so the
+  // incoming song stays audible underneath, same feel as an auto-DJ link.
+  //
+  // One slot only: a newer pending segment replaces an unaired older one (on
+  // an aggressive station a fresh ident supersedes a stale one rather than
+  // stacking). All bookkeeping (djLog → recap/opener anti-repeat, session
+  // turn, webhook) happens at AIR time, so the DJ's memory reflects what
+  // actually reached the stream, not what was merely scheduled.
+  async announceAtNextTrack(text, kind = 'announcement', { persona = null, meta = {} }: { persona?: any; meta?: any } = {}) {
+    if (!text || !text.trim()) return;
+    try {
+      const wavPath = await speak(text, { kind, persona });
+      this._pendingVoice = { text, kind, wavPath, persona, meta, t: Date.now() };
+      this.log('scheduler', `Holding ${kind} for the next track boundary`);
+    } catch (err: any) {
+      this.log('error', `Deferred announce failed: ${err.message}`);
+    }
+  }
+
+  // Air the boundary-deferred segment, if one is pending. Called from
+  // onTrackStarted BEFORE airIntro so the ident lands ahead of the track's own
+  // link in the shared voice chain (ident → link reads as a natural hand-off).
+  // The prompt context bakes in the local clock, so a clip that waited past
+  // PENDING_VOICE_MAX_AGE_MS (a long mix, a stream stall) is dropped rather
+  // than aired with a stale time reference — the next cron fire replaces it.
+  async airPendingVoice() {
+    const p = this._pendingVoice;
+    if (!p) return;
+    this._pendingVoice = null;
+    if (Date.now() - p.t > PENDING_VOICE_MAX_AGE_MS) {
+      this.log('scheduler', `Dropped pending ${p.kind} — waited too long for a track boundary`);
+      return;
+    }
+    if (!existsSync(p.wavPath)) return;
+    try {
+      await airVoice(config.liquidsoap.introFile, p.wavPath, p.text, voiceGainDb(p.kind, p.persona));
+      this.log(p.kind, p.text);
+      session.appendTurn({ role: 'segment', kind: p.kind, text: p.text, meta: p.meta });
+      webhooks.notify('dj.say', { text: p.text, kind: p.kind });
+    } catch (err: any) {
+      this.log('error', `Air pending voice failed: ${err.message}`);
+    }
+  }
+
   // Air a queued item's track-tied intro/link. Called from onTrackStarted the
   // moment the item's track actually starts playing, so the voice lands over
   // the RIGHT song rather than over whatever was on-air when it was queued
@@ -782,6 +846,12 @@ class Queue {
     const key = `${np.subsonic_id || ''}|${np.title}|${np.artist || ''}`;
     if (key === this.lastSeenKey) return;
     this.lastSeenKey = key;
+
+    // A fresh track boundary — air any boundary-deferred segment (station
+    // ident) now. Fired BEFORE airIntro below so the shared voice chain plays
+    // ident → link in that order. Fire-and-forget for the same reason as
+    // airIntro: must not stall the watcher tick.
+    void this.airPendingVoice();
 
     // Snapshot the outgoing track BEFORE the history roll mutates `this.current`
     // — scrobble.onTrackEvent below needs the previous play + its start time
@@ -1403,6 +1473,10 @@ function wavDurationMs(path: string): number | null {
 // 'handoff' (the two-voice persona mic-pass) counts too, so the incoming DJ's
 // next segments don't echo the greeting's opener.
 const VOICE_KINDS = new Set(['dj-speak', 'link', 'station-id', 'hourly-check', 'handoff']);
+// How long a boundary-deferred segment may wait for a track start before it's
+// dropped as stale (its prompt context baked in the clock at generation time).
+// Comfortably past a long album cut, well short of the next ident sounding odd.
+const PENDING_VOICE_MAX_AGE_MS = 20 * 60_000;
 // Kinds whose recap entries are de-duped. Skills are added at load time too.
 // 'handoff' is deliberately NOT deduped — its two lines (sign-off + greeting)
 // are distinct utterances by different voices.

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -427,8 +427,12 @@ async function skillsTick() {
 // Random ident every ~45 mins
 // ---------------------------------------------------------------------------
 
-// Gate-free runner — also called directly by the /dj/segment command route.
-export async function runStationId() {
+// Gate-free runner — also called directly by the /dj/segment command route
+// (immediate: an operator pressing the button wants it NOW). The scheduled
+// path passes atNextTrack so the ident holds for the next track boundary
+// instead of ducking the current song mid-vocal at an arbitrary wall-clock
+// minute — an ident has no real-time constraint, so the wait is free.
+export async function runStationId({ atNextTrack = false } = {}) {
   return withTrace({ kind: 'station-id' }, async () => {
     const ctx = await getFullContext();
     const script = await dj.generateStationId({
@@ -436,7 +440,8 @@ export async function runStationId() {
       context: ctx,
       recentOpeners: queue.getRecentOpeners(),
     });
-    await queue.announce(script, 'station-id');
+    if (atNextTrack) await queue.announceAtNextTrack(script, 'station-id');
+    else await queue.announce(script, 'station-id');
     return script;
   });
 }
@@ -446,7 +451,7 @@ async function stationId() {
   if (!djCallsAllowed()) return;  // nobody listening — skip the ident
   if (!optionalSegmentsAllowed()) return;  // over the daily token budget — mute optional segments
   try {
-    await runStationId();
+    await runStationId({ atNextTrack: true });
   } catch (err) {
     queue.log('error', `Station ID failed: ${err.message}`);
   }

--- a/controller/src/llm/internal/prompts/context.ts
+++ b/controller/src/llm/internal/prompts/context.ts
@@ -39,6 +39,9 @@ export const ANGLES = {
     'Make it a near-aside: like someone reminding themselves where they are.',
     'Open with the time of day, then drop the station name in the middle of the sentence.',
     'One small observation about the station itself — its scale, its late hours, its one-room intimacy — with the name woven in.',
+    'Address the listener directly for once — wherever they are, whatever they\'re doing, they found the right place.',
+    'Say it like a signature at the bottom of a letter — brief, warm, done.',
+    'Fold the ident into a quiet promise of what the next stretch holds — more of this, whatever this is.',
   ],
   hourly: [
     'State the time as a small fact, then anchor it with one observation about the day.',
@@ -49,10 +52,19 @@ export const ANGLES = {
   ],
 };
 
+// Uniform random, but never the same angle twice running for a kind — on an
+// aggressive station (3 idents/hour) a ~20% consecutive-repeat chance made the
+// segment shape audibly settle. The opener blocklist only guards first words;
+// this guards the whole framing.
+const lastAngleIdx = new Map<string, number>();
+
 export function pickAngle(kind: string) {
   const list = (ANGLES as any)[kind];
   if (!list || list.length === 0) return null;
-  return list[Math.floor(Math.random() * list.length)];
+  let idx = Math.floor(Math.random() * list.length);
+  if (list.length > 1 && idx === lastAngleIdx.get(kind)) idx = (idx + 1) % list.length;
+  lastAngleIdx.set(kind, idx);
+  return list[idx];
 }
 
 export function randomSeed() {

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -263,8 +263,19 @@ export async function agenticTick(ctx) {
   // between-track segments (weather, curiosity, deep cuts) get through.
   const freq = settings.effectiveFrequency(persona);
 
-  // Floor on the gap between any two segments.
-  if (now.getTime() - segmentState.lastAnySegment < frequencyFloorMs(freq)) return;
+  // Floor on the gap between any two spoken breaks. lastAnySegment only sees
+  // what THIS agent aired, but the scheduler's station idents and hourly
+  // checks share the same on-air voice (and the ident cron minutes
+  // :15/:30/:45 all land on this 5-minute tick), so without queue's view the
+  // DJ could talk twice in the same minute — the same stacking issue #310
+  // fixed for ident+hourly at :00. Deliberately narrowed to the wall-clock
+  // talkers: track-tied links/intros fire every few tracks and would mute the
+  // director outright under a 15-minute moderate floor.
+  const lastSpoke = Math.max(
+    segmentState.lastAnySegment,
+    queue.getLastVoiceAt(['station-id', 'hourly-check', 'handoff']),
+  );
+  if (now.getTime() - lastSpoke < frequencyFloorMs(freq)) return;
 
   const caps = availableCapabilities(ctx, now);
   if (caps.length === 0) return;


### PR DESCRIPTION
## What

Three on-air quality improvements to the station-ident pipeline, from a review of `generateStationId` and its scheduling.

### 1. Boundary-deferred idents (the big one)

Scheduled station IDs used to air at exactly :15/:30/:45 wall-clock, heavy-ducking whatever was playing — potentially right over a chorus. Unlike the hourly time check, an ident has no real-time constraint, so the wait for a transition is free.

- `queue.announceAtNextTrack()` renders the WAV immediately (TTS latency off the air path) and holds it in a single pending slot; `onTrackStarted` airs it over the incoming track via the **light-duck intro channel**, ahead of the track's own link in the shared voice chain (ident → link reads as a natural hand-off).
- One slot only: a newer ident replaces an unaired one. A clip that waits >20 min for a boundary is dropped — its prompt context baked in the clock at generation time.
- All bookkeeping (djLog → recap/opener anti-repeat, session turn, webhook) happens at **air** time, so the DJ's memory reflects what actually reached the stream.
- The manual `POST /dj/segment` route still airs immediately — an operator pressing the button wants it now.

### 2. No more same-minute stacking with the segment director

The ident cron minutes (:15/:30/:45) all land on the segment director's 5-minute tick, and the director's frequency floor only saw its *own* segments — so an ident and a weather/news segment could air back-to-back in the same minute (the same shape #310 fixed for ident+hourly at :00). The floor now also reads `queue.getLastVoiceAt(['station-id', 'hourly-check', 'handoff'])`. Track-tied links are deliberately excluded — they fire every few tracks and would mute the director outright under the 15-minute moderate floor.

### 3. Angle variety

`pickAngle` never repeats the same narrative angle twice running per kind (uniform random had ~20% consecutive-repeat odds — audible at 3 idents/hour on aggressive), and `station_id` gains three new angles.

Also included: a two-line `package-lock.json` version-stamp sync (0.33.0 → 0.35.0) that had lagged behind release-please's package.json bump.

## Testing

- `npm run lint` (eslint + tsc) passes — 0 errors.
- Not yet soak-tested on a live stream; the deferral path is exercised on every track transition once a scheduled ident fires.