### PR TITLE
Segment director prompt hardening: silence-friendly schema, scaled recap, steerable tools

### DIFF
--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -253,7 +253,7 @@ export function pickSystem() {
         ? `\n\nThis show is anchored to a curated playlist: every track you pick MUST come from it. Call showPlaylistTracks first and choose from what it returns.`
         : `\n\nThis show leans on a curated playlist: call showPlaylistTracks first and strongly prefer those tracks; only step outside occasionally when the flow calls for it.`)
     : '';
-  return `${settings.agentPersonaPreamble(persona, { rules: false })}
+  return `${settings.agentPersonaPreamble(persona)}
 
 You run the station as one continuous shift. The messages above are the live session.${djModeLine}${showLine}${musicLean}${playlistLean}
 
@@ -264,7 +264,7 @@ Finding candidates: prefer tools backed by the local library — searchLibrary, 
 
 function requestSystem() {
   const persona = settings.getEffectivePersona();
-  return `${settings.agentPersonaPreamble(persona, { rules: false })}
+  return `${settings.agentPersonaPreamble(persona)}
 
 The messages above are the live session — the last user turn is a listener request.${settings.agentLanguageReminder(persona, 'the "ack" and "intro" lines')}`;
 }

--- a/controller/src/llm/internal/tools/segment-tools.ts
+++ b/controller/src/llm/internal/tools/segment-tools.ts
@@ -6,11 +6,13 @@
 //
 // Built-in and custom skills run on identical footing: every cap that ships a
 // `toolFn` (loaded from its directory's tool.mjs by skills/loader.js) gets one
-// tool here, invoked as `toolFn(ctx, state, services, config)`:
+// tool here, invoked as `toolFn(ctx, state, services, config, input)`:
 //   ctx      — the moment ({ time, weather, festival, dominantMood, clock })
 //   state    — dedup memory carried across ticks (seen headlines, last artist…)
 //   services — the curated station facade (search, library, play log, feeds…)
 //   config   — the skill's own frontmatter (e.g. news' feed / feedMaxItems)
+//   input    — the agent's arguments for the skill's declared `inputs` params
+//              (nullable strings; {} for the historical zero-arg tools)
 //
 // Every skill tool now lives in state/skills (built-ins seeded there on first
 // boot), so all of them run behind a hard timeout + try/catch — a slow or
@@ -28,12 +30,22 @@ export function buildSegmentTools(ctx: any, state: any, caps: any[]) {
 
   for (const cap of caps as any[]) {
     if (typeof cap.toolFn !== 'function' || !cap.toolName) continue;
+    // A skill's optional `inputs` export ({ name: description }) becomes
+    // agent-steerable string parameters — nullable (required-but-null, the
+    // same convention as the segment schema's sfx field, which small models
+    // handle better than optional keys), so a model that passes null still
+    // gets the skill's own default behaviour. No `inputs` → the historical
+    // zero-arg tool.
+    const shape: Record<string, any> = {};
+    for (const [name, desc] of Object.entries(cap.toolInputs || {})) {
+      shape[name] = z.string().nullable().describe(String(desc));
+    }
     tools[cap.toolName] = tool({
       description: cap.toolDesc,
-      inputSchema: z.object({}),
-      execute: async () => {
+      inputSchema: z.object(shape),
+      execute: async (input: any) => {
         try {
-          const p = Promise.resolve(cap.toolFn(ctx, state, services, cap.config));
+          const p = Promise.resolve(cap.toolFn(ctx, state, services, cap.config, input || {}));
           return await withTimeout(p, 8000);
         } catch (err: any) {
           return { error: err?.message || String(err) };

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -3095,21 +3095,19 @@ export function renderDjPrompt(persona: any, ctx: any = {}) {
 // opener everywhere. Paste this at the top of any new agent system prompt;
 // never hand-roll the opener.
 //
-// `rules` is OPT-IN, defaulting to true. Pass `false` for tool-loop agents
-// whose primary task is structured exploration + strict JSON output (the
-// track picker and the request agent): the ~600-char humanness block at the
-// top of the prompt competes for the model's attention with the tool-loop
-// instructions and reliably derails small cloud models — they read "sound
-// like a person talking" and emit conversational prose instead of executing
-// the tool loop. The rules belong on agents whose primary task IS spoken
-// output (the segment director), not on agents whose primary task is
-// orchestration with an incidental spoken side-channel.
-export function agentPersonaPreamble(persona, { rules = true } = {}) {
+// Deliberately JUST the opener — no style-rule block. A DJ_HUMANNESS_RULES
+// word-blocklist used to be appendable here (and in renderDjPrompt); it was
+// lost in the a0d58b3 editor-mangle, and when a restore was attempted the
+// operator chose to keep it out: the station ran fine without it for weeks,
+// the ~600-char negative list competes with each persona's soul and flattens
+// voices toward one register, and it taxes every call. Voice steering lives
+// in the persona souls, tone dials, and the operator-editable djPrompt
+// template — add style rules there, not as a hard-coded appended constant.
+export function agentPersonaPreamble(persona) {
   const name = persona?.name || 'the DJ';
   const soul = persona?.soul || '';
   const station = cache?.station || DEFAULTS.station;
-  const opener = `You are ${name}, the on-air DJ for ${station}, a personal internet radio station. ${soul}${languageDirective(persona)}`;
-  return rules ? `${opener}` : opener;
+  return `You are ${name}, the on-air DJ for ${station}, a personal internet radio station. ${soul}${languageDirective(persona)}`;
 }
 
 // Liquidsoap reads tiny text files instead of JSON.

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -36,24 +36,6 @@ Hard rules:
 - Reference the context you're given naturally; never invent facts that aren't in it (the weather, news, events, what's happening outside).
 - Vary your opener and shape every time — never start the same way twice in a row, never use the same metaphor or framing as your last few lines.`;
 
-// Distilled from the "Signs of AI writing" guide — the subset that matters for
-// short spoken radio links. Reaches the DJ system prompts through two channels:
-// renderDjPrompt() for the legacy dj.generateXxx callers (always included), and
-// agentPersonaPreamble() for tool-loop agents (opt-in per caller — the segment
-// director opts in; the track-picker and request agents opt OUT, see the
-// preamble's comment). Deleted by the editor-mangle commit a0d58b3 and restored
-// verbatim — the sibling LLM_PROVIDERS damage from that commit was fixed at the
-// time, this one slipped through.
-export const DJ_HUMANNESS_RULES = `Sound like a person talking, not a write-up:
-- Skip AI-essay vocabulary: "delve", "tapestry", "testament", "boasts", "vibrant", "bustling", "elevate", "realm", "whilst", "moreover", "furthermore".
-- No significance inflation — a song is just a song; don't call it "more than just" anything or "a testament to" something.
-- Drop the "not just X, it's Y" / "not only... but also" framing.
-- No press-release hype: "iconic", "legendary", "timeless masterpiece", "must-listen".
-- Speak for yourself — never "many say", "it's often said", "critics agree".
-- No trailing "..., showcasing/highlighting..." analysis tacked onto a sentence.
-- Don't land on a tidy summary or a little moral. Make your point and stop.
-- Use contractions and plain words; let it have the rhythm of real speech.`;
-
 // Seed souls — the SEED_PERSONAS roster picks from these. renderDjPrompt()
 // falls back to DJ_SOULS[0] when the substituted persona has no soul of its
 // own; the agent path (agentPersonaPreamble) instead substitutes an empty
@@ -3098,12 +3080,11 @@ export function renderDjPrompt(persona: any, ctx: any = {}) {
     .replaceAll('{station}', station)
     .replaceAll('{location}', location);
   const tone = personaToneDirectives(persona);
-  const rules = `\n\n${DJ_HUMANNESS_RULES}`;
   if (tpl.includes('{language}')) {
     const lang = String(persona?.language || '').trim();
-    return rendered.replaceAll('{language}', lang || 'English') + rules + tone;
+    return rendered.replaceAll('{language}', lang || 'English') + tone;
   }
-  return rendered + rules + languageDirective(persona) + tone;
+  return rendered + languageDirective(persona) + tone;
 }
 
 // Persona prelude shared by every tool-loop agent system prompt — the picker
@@ -3128,7 +3109,7 @@ export function agentPersonaPreamble(persona, { rules = true } = {}) {
   const soul = persona?.soul || '';
   const station = cache?.station || DEFAULTS.station;
   const opener = `You are ${name}, the on-air DJ for ${station}, a personal internet radio station. ${soul}${languageDirective(persona)}`;
-  return rules ? `${opener}\n\n${DJ_HUMANNESS_RULES}` : opener;
+  return rules ? `${opener}` : opener;
 }
 
 // Liquidsoap reads tiny text files instead of JSON.

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -36,6 +36,24 @@ Hard rules:
 - Reference the context you're given naturally; never invent facts that aren't in it (the weather, news, events, what's happening outside).
 - Vary your opener and shape every time — never start the same way twice in a row, never use the same metaphor or framing as your last few lines.`;
 
+// Distilled from the "Signs of AI writing" guide — the subset that matters for
+// short spoken radio links. Reaches the DJ system prompts through two channels:
+// renderDjPrompt() for the legacy dj.generateXxx callers (always included), and
+// agentPersonaPreamble() for tool-loop agents (opt-in per caller — the segment
+// director opts in; the track-picker and request agents opt OUT, see the
+// preamble's comment). Deleted by the editor-mangle commit a0d58b3 and restored
+// verbatim — the sibling LLM_PROVIDERS damage from that commit was fixed at the
+// time, this one slipped through.
+export const DJ_HUMANNESS_RULES = `Sound like a person talking, not a write-up:
+- Skip AI-essay vocabulary: "delve", "tapestry", "testament", "boasts", "vibrant", "bustling", "elevate", "realm", "whilst", "moreover", "furthermore".
+- No significance inflation — a song is just a song; don't call it "more than just" anything or "a testament to" something.
+- Drop the "not just X, it's Y" / "not only... but also" framing.
+- No press-release hype: "iconic", "legendary", "timeless masterpiece", "must-listen".
+- Speak for yourself — never "many say", "it's often said", "critics agree".
+- No trailing "..., showcasing/highlighting..." analysis tacked onto a sentence.
+- Don't land on a tidy summary or a little moral. Make your point and stop.
+- Use contractions and plain words; let it have the rhythm of real speech.`;
+
 // Seed souls — the SEED_PERSONAS roster picks from these. renderDjPrompt()
 // falls back to DJ_SOULS[0] when the substituted persona has no soul of its
 // own; the agent path (agentPersonaPreamble) instead substitutes an empty
@@ -3080,11 +3098,12 @@ export function renderDjPrompt(persona: any, ctx: any = {}) {
     .replaceAll('{station}', station)
     .replaceAll('{location}', location);
   const tone = personaToneDirectives(persona);
+  const rules = `\n\n${DJ_HUMANNESS_RULES}`;
   if (tpl.includes('{language}')) {
     const lang = String(persona?.language || '').trim();
-    return rendered.replaceAll('{language}', lang || 'English') + tone;
+    return rendered.replaceAll('{language}', lang || 'English') + rules + tone;
   }
-  return rendered + languageDirective(persona) + tone;
+  return rendered + rules + languageDirective(persona) + tone;
 }
 
 // Persona prelude shared by every tool-loop agent system prompt — the picker
@@ -3109,7 +3128,7 @@ export function agentPersonaPreamble(persona, { rules = true } = {}) {
   const soul = persona?.soul || '';
   const station = cache?.station || DEFAULTS.station;
   const opener = `You are ${name}, the on-air DJ for ${station}, a personal internet radio station. ${soul}${languageDirective(persona)}`;
-  return rules ? `${opener}` : opener;
+  return rules ? `${opener}\n\n${DJ_HUMANNESS_RULES}` : opener;
 }
 
 // Liquidsoap reads tiny text files instead of JSON.

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -37,7 +37,7 @@ import { z } from 'zod';
 import { queue } from '../broadcast/queue.js';
 import * as settings from '../settings.js';
 import { defineAgent } from '../llm/agent.js';
-import { buildContextLines, CONTEXT_FIELDS, lengthPhrase } from '../llm/dj.js';
+import { buildContextLines, CONTEXT_FIELDS, lengthMode, lengthPhrase } from '../llm/dj.js';
 import { buildSegmentTools } from '../llm/segment-tools.js';
 import { recordCuriosity, recentAiredCuriosity } from './curiosity.js';
 import { loadedCapabilities } from './loader.js';
@@ -96,8 +96,17 @@ function unionContextFields(caps: any[]): string[] {
 // lengthPhrase('segment'), so an 'extended' storytelling persona stretches its
 // segments the way it already stretches intros and links. A hard-coded
 // description here previously pinned every persona to one-liners.
+// Field order is deliberate: models generate JSON in property order, so
+// `reason` comes FIRST (decide and justify before writing the line — a free
+// mini chain-of-thought), then the explicit `air` boolean, then the segment.
+// The boolean exists because a nullable nested object alone proved hard for
+// small models to encode "stay silent" with — they emitted bare top-level
+// `null` or prose instead (see isBareNullSilent / isSilentFailure below);
+// `air: false` gives them an unambiguous silence token to reach for.
 function segmentSchema() {
   return z.object({
+    reason: z.string().describe('one short internal sentence on why this segment (or why silent) — never shown to the listener; write this BEFORE deciding the segment'),
+    air: z.boolean().describe('true to air one segment now, false to stay silent — silence is a perfectly good answer, often the best one, when the data is dull, stale, unchanged, or there is nothing fresh worth a listener\'s attention'),
     segment: z.object({
       // Kept as a free string (not a fixed enum) so operator-dropped custom
       // skills get valid kinds too. The agent is told which kinds are on offer in
@@ -106,8 +115,7 @@ function segmentSchema() {
         .describe('the segment kind — MUST be one of the kinds offered in the system prompt for this tick'),
       text: z.string().describe(`the spoken line in the DJ voice — ${lengthPhrase('segment')}`),
       sfx: z.string().nullable().describe('the exact name of one sound effect from the catalogue in the system prompt to play under this line, or null for no effect (null is usually right — most segments need none)'),
-    }).nullable().describe('the segment to air, or null to stay silent — silence is a perfectly good answer, often the best one, when the data is dull, stale, unchanged, or there is nothing fresh worth a listener\'s attention'),
-    reason: z.string().describe('one short internal sentence on why this segment (or why silent) — never shown to the listener'),
+    }).nullable().describe('the segment to air when air is true; null when air is false'),
   });
 }
 
@@ -234,7 +242,11 @@ function buildSituation(ctx: any, { forced = false, contextFields, recentCuriosi
   if (ctxLines.length) lines.push(...ctxLines);
   const cur = queue.current?.track;
   if (cur) lines.push(`On air now: "${cur.title}" by ${cur.artist || 'unknown'}`);
-  const recap = queue.getDjRecap();
+  // The default 140-char recap truncation fits a concise one-liner segment,
+  // but an 'extended' persona's 3-5-sentence segment gets cut after roughly
+  // its first sentence — a topic repeated mid-segment would be invisible to
+  // the anti-repeat instruction. Scale the cap with the persona's verbosity.
+  const recap = queue.getDjRecap({ maxChars: lengthMode() === 'extended' ? 360 : 140 });
   if (recap) {
     lines.push(`\nWhat you have already said on air recently (do NOT repeat these topics or phrasing):\n${recap}`);
   }
@@ -289,7 +301,9 @@ export async function agenticTick(ctx) {
       ctx, segmentState,
     });
 
-    const seg = object?.segment;
+    // `air: false` is the explicit silence signal; a missing/empty segment
+    // despite air=true still degrades to silence rather than erroring.
+    const seg = object?.air ? object?.segment : null;
     if (!seg || !seg.text || !seg.text.trim()) {
       queue.log('scheduler', `Segment agent stayed silent — ${object?.reason || 'nothing to add'}`);
       return;
@@ -327,8 +341,8 @@ export async function agenticTick(ctx) {
     }
   } catch (err) {
     // Distinguish a model that couldn't produce parseable JSON from a real
-    // outage. The schema explicitly allows {segment: null} as "stay silent",
-    // and the system prompt actively encourages silence — so a model that
+    // outage. The schema explicitly allows {air: false, segment: null} as
+    // "stay silent", and the system prompt actively encourages silence — so a model that
     // emits unparseable output was most likely TRYING to stay silent but
     // expressing it wrong. The listener-facing outcome is the same either way
     // (silence), so report it as silence with a parse note instead of
@@ -355,7 +369,7 @@ export async function agenticTick(ctx) {
 // `did not call the done tool` (issue #555) is included for the same reason:
 // gemma-class models on the forced done-tool path occasionally emit prose
 // instead of the `done` call — even through the recovery — and throw. On the
-// autonomous tick the schema allows {segment: null} and the prompt encourages
+// autonomous tick the schema allows {air: false} and the prompt encourages
 // silence, so a botched done call is overwhelmingly the model either staying
 // silent in prose or fumbling a segment; either way the listener gets silence.
 // (The operator-forced path doesn't use this classifier, so it still errors.)

--- a/controller/src/skills/builtins/web-search/tool.mjs
+++ b/controller/src/skills/builtins/web-search/tool.mjs
@@ -1,20 +1,27 @@
-// Web search — something recent about the on-air artist (release, tour, press).
+// Web search — something recent about the on-air artist (release, tour, press),
+// or whatever the segment director asks for via the optional `query` input.
 // `ready` gates the whole skill on a configured search provider, so it's never
 // even offered when search is unavailable.
-export const description = 'Search the web for something recent about the artist currently on air.';
+export const description = 'Search the web. Pass a query to dig into something specific (the track, an event, a topic worth a line), or pass null to default to recent news about the artist currently on air.';
+
+export const inputs = {
+  query: 'what to search for — a specific question or topic; null to default to recent news about the on-air artist',
+};
 
 export const ready = (services) => services.searchReady();
 
-export default async function searchArtistNews(ctx, state, services) {
+export default async function searchArtistNews(ctx, state, services, config, input) {
+  const custom = String(input?.query || '').trim();
   const artist = services.nowPlaying()?.artist;
-  if (!artist || /^unknown/i.test(artist)) return { available: false };
-  const alreadySearched = artist === state.lastSearchedArtist;
-  const data = await services.searchWeb(`${artist} musician latest news`, { recency: 'week' });
-  state.lastSearchedArtist = artist;
+  if (!custom && (!artist || /^unknown/i.test(artist))) return { available: false };
+  const query = custom || `${artist} musician latest news`;
+  const alreadySearched = !custom && artist === state.lastSearchedArtist;
+  const data = await services.searchWeb(query, { recency: 'week' });
+  if (!custom) state.lastSearchedArtist = artist;
   const answer = (data.answer || '').trim();
   const sources = (data.results || [])
     .slice(0, 3)
     .map(r => `${r.title}: ${(r.content || '').replace(/\s+/g, ' ').trim().slice(0, 240)}`);
   if (!answer && sources.length === 0) return { available: false };
-  return { artist, alreadySearched, answer, sources };
+  return { query, artist, alreadySearched, answer, sources };
 }

--- a/controller/src/skills/loader.ts
+++ b/controller/src/skills/loader.ts
@@ -15,9 +15,11 @@
 // reserved naming — NOT a separate load path or trust posture.
 //
 // A skill's tool.mjs is the same contract for everyone:
-//   export default async (ctx, state, services, config) => data
+//   export default async (ctx, state, services, config, input) => data
 //   export const description = '…'   // OPTIONAL: tool description for the agent
 //   export const ready = (services) => boolean   // OPTIONAL: gate availability
+//   export const inputs = { query: '…' }   // OPTIONAL: agent-steerable string
+//     params ({ name: description }); validated values arrive as `input`
 // `services` (station-services.ts) is the curated facade onto search, the
 // library, the play log, feeds and durable recall — the one way a tool reaches
 // the world. Every tool runs behind a timeout + try/catch at the call site
@@ -225,9 +227,24 @@ export async function discoverSeededKinds(): Promise<Set<string>> {
   return SEEDED_KINDS;
 }
 
+// A tool.mjs `inputs` export declares agent-steerable string parameters:
+// a flat { paramName: 'description for the agent' } object. Sanitised here —
+// only identifier-shaped keys with string descriptions survive, so a malformed
+// export narrows to nothing instead of breaking the tool-call JSON schema.
+const INPUT_KEY_RE = /^[a-zA-Z_][a-zA-Z0-9_]{0,48}$/;
+function sanitizeToolInputs(raw: any): Record<string, string> | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (INPUT_KEY_RE.test(k) && typeof v === 'string' && v.trim()) out[k] = v.trim();
+  }
+  return Object.keys(out).length ? out : undefined;
+}
+
 // Dynamically import a skill's optional tool.mjs. Returns the data function plus
-// its optional `description` / `ready` exports, or null when there's no tool.
-async function loadToolModule(dir: string): Promise<{ fn: any; description?: string; ready?: any } | null> {
+// its optional `description` / `ready` / `inputs` exports, or null when there's
+// no tool.
+async function loadToolModule(dir: string): Promise<{ fn: any; description?: string; ready?: any; inputs?: Record<string, string> } | null> {
   const file = join(dir, 'tool.mjs');
   try {
     await stat(file);
@@ -239,12 +256,13 @@ async function loadToolModule(dir: string): Promise<{ fn: any; description?: str
   const mod = await import(url);
   const fn = mod.default || mod.fetchData || mod.tool;
   if (typeof fn !== 'function') {
-    throw new Error('tool.mjs must export a default async function (ctx, state, services, config) => data');
+    throw new Error('tool.mjs must export a default async function (ctx, state, services, config, input) => data');
   }
   return {
     fn,
     description: typeof mod.description === 'string' ? mod.description : undefined,
     ready: typeof mod.ready === 'function' ? mod.ready : undefined,
+    inputs: sanitizeToolInputs(mod.inputs),
   };
 }
 
@@ -314,6 +332,11 @@ async function loadSkillDir(dir: string, slug: string, { seeded }: { seeded: boo
     cap.toolName = `skill_${name.replace(/-/g, '_')}`;
     cap.toolDesc = (toolMod.description || data.toolDescription || '').trim()
       || `Fetch live data for the ${label} segment before speaking. Returns { available: false } when there is nothing fresh worth airing.`;
+    // Optional agent-steerable parameters ({ name: description }, strings
+    // only) — becomes the tool's input schema in llm/segment-tools.js and is
+    // handed to toolFn as its 5th argument. Absent → zero-arg tool, the
+    // historical shape.
+    cap.toolInputs = toolMod.inputs;
   }
 
   return cap;

--- a/docs/custom-skills.md
+++ b/docs/custom-skills.md
@@ -114,11 +114,13 @@ tool the segment director can call **before** writing the line. This is the
 directories with a `SKILL.md` and a `tool.mjs`, loaded the same way as yours.
 
 ```js
-export default async function (ctx, state, services, config) {
+export default async function (ctx, state, services, config, input) {
   // ctx      — the moment: { time, weather, festival, dominantMood, clock }
   // state    — cross-tick dedup memory (persists between firings)
   // services — the curated station facade (see below)
   // config   — this skill's own SKILL.md frontmatter (e.g. a custom `feed:`)
+  // input    — the agent's values for your declared `inputs` (see below); {}
+  //            when you declare none
   // Return any JSON-serialisable object. The `{ available: false }` convention
   // tells the agent there's nothing worth airing right now.
   return { available: true, foo: 'bar' };
@@ -130,6 +132,13 @@ export const description = 'Fetch X for the … segment.';
 // OPTIONAL: gate the whole skill on a runtime condition — when this returns
 // false the skill is never even offered (e.g. no search provider configured).
 export const ready = (services) => services.searchReady();
+
+// OPTIONAL: agent-steerable parameters — a flat { name: description } object of
+// string params. The agent may pass a value or null for each; handle null by
+// falling back to your own default (see the web-search built-in's `query`).
+// Without this export the tool is zero-arg, which small models handle best —
+// only declare inputs the agent genuinely benefits from steering.
+export const inputs = { query: 'what to search for; null for the default dig' };
 ```
 
 ### `services` — the station facade


### PR DESCRIPTION
Hardens the segment-director (`djAgentSegment`) prompt layer — improvements from a prompt review.

## 1. Reason-first schema with an explicit `air` boolean
The director's output schema is now `{ reason, air, segment | null }`:
- `reason` first: models generate JSON in property order, so the model now decides/justifies **before** writing the spoken line instead of after.
- `air: boolean`: the old nullable-nested-object-only encoding is what produced the bare-`null` / prose silence failures that `isBareNullSilent` / `isSilentFailure` patch around (issues #555 and the minimax bare-null case). An explicit boolean gives small models an unambiguous silence token. The classifiers stay as safety nets.

## 2. Verbosity-scaled anti-repeat recap
`getDjRecap()`'s 140-char truncation fits a concise one-liner but cuts an `extended` persona's 3–5-sentence segment after its first sentence — mid-segment topics were invisible to the "do NOT repeat" instruction. `buildSituation` now passes `maxChars: 360` for extended personas.

## 3. Agent-steerable tool inputs
`tool.mjs` may now export `inputs` — a flat `{ name: description }` object of string params. Loader sanitises it, `segment-tools` builds the input schema (nullable strings, matching the `sfx` convention), values arrive as `toolFn`'s 5th arg. No export → the historical zero-arg tool, so **all existing skills work unchanged**. web-search is the first steerable skill (`query`, null = artist-news default). Docs updated.

⚠️ Note: seeded skill files win after first boot, so existing installs need /admin/skills → Reset-to-default on web-search to pick up the steerable tool.mjs.

## 4. DJ_HUMANNESS_RULES: considered, restored, then deliberately removed
The prompt review found the anti-AI-writing rules block had been accidentally deleted by a0d58b3 (dead `rules` param in `agentPersonaPreamble`). This PR first restored it, then **reverted by operator decision**: the station has run without it since May with no audible regression, the ~600-char negative word-list competes with each persona's soul and flattens voices toward one register, and it taxes every call. The final state removes the dead `rules` machinery entirely and documents the decision in a comment so it doesn't get 're-fixed'. Voice steering belongs in persona souls, tone dials, and the operator-editable djPrompt template.

## Verification
- `npm run lint` (eslint + tsc) — 0 errors
- `npm run test:llm` — all pass
- Runtime-checked with stubs: new schema accepts both `{air:false, segment:null}` and the air shape; steerable web-search uses a custom query without touching dedup memory, falls back to artist news on null, and still returns `{available:false}` with no artist and no query.
- Not verified against a live model/stack — worth watching a few segment ticks in /debug after deploy, especially on small Ollama models.

Prompt-review follow-up not included here (declined for now): persisting per-kind cooldowns across restarts.