### PR TITLE
feat(llm): improve the hourly time-check generator

### DIFF
--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -334,7 +334,7 @@ async function refreshAutoPlaylistInner() {
 export async function runHourlyCheck() {
   return withTrace({ kind: 'hourly' }, async () => {
     const ctx = await getFullContext();
-    const script = await dj.generateHourlyTime(ctx.time, ctx.weather, {
+    const script = await dj.generateHourlyTime({
       recap: queue.getDjRecap(),
       context: ctx,
       recentOpeners: queue.getRecentOpeners(),

--- a/controller/src/llm/internal/prompts/context.ts
+++ b/controller/src/llm/internal/prompts/context.ts
@@ -49,6 +49,11 @@ export const ANGLES = {
     'Open with where in the day we are (mid-afternoon lull, evening getting started, etc.) before the actual time.',
     'Just one short sentence that happens to mention the time.',
     'Acknowledge what kind of listener might be tuning in at this exact hour, without naming them.',
+    'Note what this hour usually means — the kettle hour, the last-push hour, the winding-down hour — then land the time inside it.',
+    'Mark the hour as a small milestone in the day: one down, or one to go, or the halfway point.',
+    'Mention the time as if answering someone who just asked — offhand, unbothered.',
+    'Let the hour prompt a tiny aside about how fast or slow the day is moving, time folded in.',
+    'Tie the hour to the light outside — what the sky is probably doing right now — and slip the time in after.',
   ],
 };
 

--- a/controller/src/llm/internal/prompts/scripts.ts
+++ b/controller/src/llm/internal/prompts/scripts.ts
@@ -162,10 +162,9 @@ export async function generateLink({ previous, current, context, recap = null, r
   });
 }
 
-export async function generateHourlyTime(time: any, weather: any, { recap = null, context = null, recentOpeners = null }: any = {}) {
-  const ctx = context || { time, weather };
-  const ctxLines = buildContextLines(ctx, { contextFields: SCRIPT_CONTEXT_FIELDS });
-  ctxLines.push(`Task: a brief top-of-the-hour time check, in character. ${lengthPhrase('hourly')}.`);
+export async function generateHourlyTime({ recap = null, context = null, recentOpeners = null }: any = {}) {
+  const ctxLines = buildContextLines(context, { contextFields: SCRIPT_CONTEXT_FIELDS });
+  ctxLines.push(`Task: a brief top-of-the-hour time check, in character. ${lengthPhrase('hourly')}. Say the time in natural spoken words ("two in the afternoon", "just gone eight") — never digits or 24-hour form.`);
   return djText({
     system: djSystem(),
     prompt: decoratePrompt(ctxLines.join('\n'), { kind: 'hourly', recap, recentOpeners }),


### PR DESCRIPTION
Follow-up from a review of `generateHourlyTime` — three small improvements, no behavior risk:

## 1. Drop the dead `(time, weather)` positional params
The only caller (`runHourlyCheck`) always passed `context`, so the positional fallback never fired — and `weather` was fully dead either way, since `SCRIPT_CONTEXT_FIELDS` deliberately excludes weather from the generic script generators (#471). The signature falsely advertised that weather influences the time check. Now matches every other generator: `generateHourlyTime({ context, recap, recentOpeners })`.

## 2. Spoken-time formatting hint
The model sees `Local time: 14:00` (24h `hhmm`) and had to invent the spoken form itself. Small local models (the default Ollama path) can echo the digits verbatim, which Piper reads as "fourteen zero zero" on air. The task line now says: *say the time in natural spoken words ("two in the afternoon", "just gone eight") — never digits or 24-hour form.*

## 3. Five more hourly narrative angles
The hourly segment can fire up to 24×/day (aggressive frequency) but had the smallest angle pool (5), so its shape settled fast. Added five more, per the "Add freely" note in `context.ts`.

## Verification
`npm run lint` in `controller/` passes (eslint + tsc, 0 errors). Confirmed the barrel re-export in `llm/dj.ts` and the single call site are the only references to `generateHourlyTime`.