### PR TITLE
fix(dj): pick under the incoming show's rules near a show boundary

### DIFF
--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -226,7 +226,13 @@ function requestSchema() {
 // settings.effectsActive; there is no separate toggle). Invisible otherwise,
 // so the model leaves "transition" null.
 
-export function pickSystem() {
+// `showAt` — resolve the show brief/leans for that future moment instead of
+// now: the pick airs when the current track ends, so near a show boundary the
+// INCOMING show's rules are the ones to follow (see the look-ahead in
+// queue.onTrackStarted). The persona stays the live one — the outgoing DJ
+// tees the changeover up in their own voice; the on-air mic-pass is
+// runPersonaHandoff's job.
+export function pickSystem(showAt: Date | null = null) {
   const persona = settings.getEffectivePersona();
   // In DJ mode, lean on the live session history: a working DJ runs threads
   // and calls back to a track or a remark from earlier in the shift. This pairs
@@ -239,7 +245,7 @@ export function pickSystem() {
   // opening message: the session window (~40 turns) scrolls past the opener
   // within the first hour, after which the picker would lose every show
   // constraint mid-show and revert to generic picks.
-  const activeShow = settings.resolveActiveShow();
+  const activeShow = settings.resolveActiveShow(showAt ?? undefined);
   const showLine = activeShow?.topic
     ? `\n\nCurrent show brief — follow this for every pick:\n${activeShow.topic}`
     : '';
@@ -336,14 +342,17 @@ export const pickerAgent = defineAgent({
   // on every provider now; maxSteps is just the backstop.
   maxSteps: 4,
   timeoutMs: agentDeadline,
-  buildSystem: () => pickSystem(),
-  buildTools: ({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, playlistLock, playlistTracks, excludedIds }) => {
-    // Resolve the active show live (a show that just came on air takes effect):
-    // for a strict show (filtersStrict), EVERY set music filter — genre, era,
-    // mood, energy — becomes a hard lock the discovery tools enforce on
-    // candidates, not just the prompt. Track length is enforced as an on-air
-    // cut, NOT a pick filter (issue #447), so no length cap is passed here.
-    const activeShow = settings.resolveActiveShow();
+  buildSystem: ({ showAt }: any = {}) => pickSystem(showAt ?? null),
+  buildTools: ({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, playlistLock, playlistTracks, excludedIds, showAt }) => {
+    // Resolve the active show live (a show that just came on air takes effect),
+    // at the pick's look-ahead moment when one is threaded through (showAt —
+    // same clock the system prompt's brief resolved against, so prompt and
+    // locks can't disagree across a boundary): for a strict show
+    // (filtersStrict), EVERY set music filter — genre, era, mood, energy —
+    // becomes a hard lock the discovery tools enforce on candidates, not just
+    // the prompt. Track length is enforced as an on-air cut, NOT a pick filter
+    // (issue #447), so no length cap is passed here.
+    const activeShow = settings.resolveActiveShow(showAt ?? undefined);
     const strict = !!(activeShow?.filtersStrict);
     const genreLock = strict && activeShow?.genre ? activeShow.genre : null;
     const eraLock = strict && (activeShow?.fromYear != null || activeShow?.toYear != null)
@@ -482,7 +491,7 @@ async function repickFromSeen({ seen, badId, wantLink }: { seen: Map<string, any
   }
 }
 
-async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = null }: { wantLink: boolean; audioWaypoint?: number[] | null; current?: any }): Promise<boolean> {
+async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = null, showAt = null }: { wantLink: boolean; audioWaypoint?: number[] | null; current?: any; showAt?: Date | null }): Promise<boolean> {
   await library.load();
   const stats = library.stats();
   const windows = recencyWindowsForLibrary(stats.distinctArtists);
@@ -508,8 +517,11 @@ async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = n
   // thread it into the agent's tools. Strict → a hard lock set so every tool's
   // results are intersected with the playlist (the agent can only pick in-set);
   // soft → just the tracks, exposed via showPlaylistTracks for a strong prompt
-  // preference, no lock. Null when the show pins no playlists.
-  const activeShow = settings.resolveActiveShow();
+  // preference, no lock. Null when the show pins no playlists. Resolved at the
+  // pick's look-ahead moment (showAt) so the anchored playlist is the show's
+  // that will be on air when the pick plays — same clock as pickSystem's brief
+  // and buildTools' locks.
+  const activeShow = settings.resolveActiveShow(showAt ?? undefined);
   const playlistPool = activeShow ? await resolveShowPlaylistPool(activeShow) : null;
   const playlistLock = playlistPool && activeShow?.playlistStrict ? playlistPool.ids : null;
   const playlistTracks = playlistPool?.tracks ?? null;
@@ -528,6 +540,7 @@ async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = n
     playlistLock,
     playlistTracks,
     excludedIds,
+    showAt,
   });
   const { steps, toolCalls, extras } = run;
   let object = run.object;
@@ -682,7 +695,12 @@ async function pickViaPool(queue, ctx, { wantLink, current }, rankTarget: { bpm:
 // Called by the queue watcher when an autonomous track starts and the queue is
 // empty. Posts the event to the session, then picks the next track (and an
 // optional between-track link) via the agent, falling back to the pool.
-export async function runTrackEvent(queue, ctx, { wantLink }) {
+// `ctx` is the pick's context — near a show boundary the queue watcher hands
+// in a look-ahead snapshot (getFullContext at the pick's expected airtime) plus
+// the matching `showAt` clock, so both pick paths follow the show that will
+// actually be on air when the pick plays. `showAt` null → resolve at now,
+// exactly the pre-look-ahead behaviour.
+export async function runTrackEvent(queue, ctx, { wantLink, showAt = null }: { wantLink: boolean; showAt?: Date | null }) {
   return withTrace({ kind: 'track-event', wantLink }, async () => {
     // Daily token cap. At the hard cap we make NO model call: skip the pick and
     // let Liquidsoap fall through to the LLM-free auto playlist (music keeps
@@ -778,7 +796,7 @@ export async function runTrackEvent(queue, ctx, { wantLink }) {
     // and go straight to the one-call pool picker below to stretch the budget.
     if (settings.get().llm?.pickerAgent && !cheap && !breakerOpen()) {
       try {
-        const queued = await pickViaAgent(queue, { wantLink, audioWaypoint, current });
+        const queued = await pickViaAgent(queue, { wantLink, audioWaypoint, current, showAt });
         breakerSuccess();
         if (queued) return;
         // The agent produced a valid pick but it was already queued/on-air, so

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -56,6 +56,15 @@ const EMPTY_DJ_QUEUE_CLEAR_THRESHOLD = 3;
 // length apart — keeps its own entry rather than being merged away.
 export const BACKFILL_DEDUP_MAX_GAP_MS = 15 * 60_000;
 
+// How far PAST the next pick's expected start the show-boundary look-ahead
+// probes (see onTrackStarted). The pick's start time alone under-corrects: a
+// track starting 30s before a boundary plays almost entirely inside the new
+// show but would still resolve the old one. Two minutes ≈ the midpoint of a
+// typical track, so whichever show owns most of the pick's airtime wins. The
+// symmetric cost — an on-format-for-the-NEXT-show track starting a minute or
+// two early — is how real radio tees up a changeover anyway.
+const PICK_SHOW_LOOKAHEAD_SEC = 120;
+
 // Has this events-log play already been recorded by recordPlay? The old dedup
 // keyed on `${endedAt}|${title}` — an EXACT timestamp match — but recordPlay's
 // end-stamp never equals the event's start `t`, so it never fired and every
@@ -1021,7 +1030,23 @@ class Queue {
           } catch (err: any) {
             this.log('error', `Persona handoff failed: ${err.message}`);
           }
-          await djAgent.runTrackEvent(this, ctx, { wantLink });
+          // The pick made now airs when the track that just started ends — so
+          // near a show boundary the rules to pick by are the NEXT show's, not
+          // this one's (a pick queued minutes before the boundary used to
+          // follow the outgoing show's brief, handing the incoming DJ an
+          // off-format opener). Probe a little past the pick's expected start
+          // so a pick that begins just shy of the boundary — and plays mostly
+          // inside the new show — also counts as the new show's. The session
+          // roll and handoff above stay on the live clock: only the pick
+          // looks ahead. Unknown duration → no look-ahead, today's behaviour.
+          const durSec = Number(this.current?.track?.duration);
+          let pickCtx = ctx;
+          let showAt: Date | null = null;
+          if (Number.isFinite(durSec) && durSec > 0) {
+            showAt = new Date(Date.now() + (durSec + PICK_SHOW_LOOKAHEAD_SEC) * 1000);
+            pickCtx = await getFullContext(showAt);
+          }
+          await djAgent.runTrackEvent(this, pickCtx, { wantLink, showAt });
         } catch (err: any) {
           this.log('error', `DJ track event failed: ${err.message}`);
         } finally {

--- a/controller/src/context.ts
+++ b/controller/src/context.ts
@@ -258,9 +258,15 @@ export function energyForDaypart(date = new Date()) {
   return base;
 }
 
-// Combined snapshot — what's the vibe right now?
-export async function getFullContext() {
-  const now = new Date();
+// Combined snapshot — what's the vibe right now? Pass `at` to resolve the
+// clock-derived parts (time, festival, date, clock, active show, and therefore
+// dominantMood) for a future moment instead — the queue watcher uses this to
+// pick the NEXT track under the rules of the show that will actually be on air
+// when it plays (issue: a pick made minutes before a show boundary followed the
+// outgoing show's brief). Weather and listener count stay live: they're
+// station-now facts and drift too little over one track to matter.
+export async function getFullContext(at?: Date) {
+  const now = at ?? new Date();
   const time = getTimeContext(now);
   const weather = await getWeather();
   const festival = getFestivalContext(now);

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -486,8 +486,13 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   const { ids: hardRecentIds, keys: hardRecentKeys } = queue.recentlyPlayedByCount(effN);
   const currentTrack = queue.current?.track || null;
   // Resolve the active show once: its music-steering filters shape the pool
-  // (below) and its brief steers the LLM pick (further down).
-  const activeShow = settings.resolveActiveShow();
+  // (below) and its brief steers the LLM pick (further down). Prefer the show
+  // already resolved into ctx — near a show boundary the queue watcher passes
+  // a look-ahead context (getFullContext at the pick's expected airtime), so
+  // the pool follows the show that will be on air when the pick plays, and
+  // stays consistent with ctx.dominantMood below. Contexts without the field
+  // (picker-test's stub) fall back to resolving at now.
+  const activeShow = ctx?.activeShow !== undefined ? ctx.activeShow : settings.resolveActiveShow();
   const showFilter: ShowFilter = activeShow
     ? { mood: activeShow.mood, genre: activeShow.genre, fromYear: activeShow.fromYear, toYear: activeShow.toYear, energy: activeShow.energy, strict: activeShow.filtersStrict }
     : null;


### PR DESCRIPTION
Fixes the changeover gap reported in [discussion #247](https://github.com/perminder-klair/subwave/discussions/247#discussioncomment-17532186): at the end of the hour the picker had already run under the outgoing show's rules, so the incoming DJ (post-handoff) introduced an off-format track — a 70s show didn't hit a 70s song until ~5 minutes in.

## Why it happened

Picks are one track ahead: the pick runs when a track *starts* but airs when it *ends*. A pick made at :56 resolved `resolveActiveShow()` / `getEffectivePersona()` at *now*, so it followed the outgoing show's brief, strict filters, playlist anchor, and mood — and nothing re-picks on the session roll.

## The fix — look-ahead picking

The queue watcher now probes the schedule at the pick's **expected airtime** (just-started track's duration, plus a 2-minute midpoint bias so a pick starting just shy of the boundary — playing mostly inside the new show — also counts as the new show's) and threads that clock through both pick paths:

- **`context.ts`** — `getFullContext(at?)` resolves the clock-derived parts (time, festival, date, clock, active show, and therefore `dominantMood`) for a future moment. Weather + listener count stay live.
- **`broadcast/queue.ts`** — the watcher computes the probe time, builds a look-ahead `pickCtx`, and passes `{ showAt }` to `runTrackEvent`. Session roll and the persona handoff keep the live clock — only the pick looks ahead.
- **`broadcast/dj-agent.ts`** — `showAt` threads through `runTrackEvent` → `pickViaAgent` → the picker agent's `buildSystem`/`buildTools`, so the show brief, music leans, strict locks, and playlist anchor all resolve on the same clock and can't disagree across a boundary.
- **`music/picker.ts`** — the pool path uses `ctx.activeShow` from the look-ahead context (falls back to resolving at now for contexts without the field, e.g. picker-test's stub), keeping the pool filters consistent with `ctx.dominantMood`.

Deliberately **not** changed: the persona voicing the pick's link stays the live one — the outgoing DJ teeing up the next show's opener is natural radio, and the on-air mic-pass remains `runPersonaHandoff`'s job. Unknown track duration → no look-ahead, byte-identical to today's behaviour; away from boundaries the resolved show is identical, so prompts don't change.

## Testing

- `controller`: `npm run lint` (eslint + `tsc --noEmit`) — 0 errors.
- `controller`: `npm run test:llm` — all passing.
- No test runner for this path. Manual smoke: schedule two adjacent shows with different genres/eras, let a track start ~2–4 min before the boundary, and check the pick log — the pick made before the boundary should follow the incoming show's brief/filters.

## Follow-up candidates (not in this PR)

- Flush-and-re-pick on roll for picks already sitting in `dj_queue` when the schedule is edited mid-hour (needs a Liquidsoap queue-removal telnet command).
- `effectiveMaxTrackSec` is applied at drain time with the live show's cap — a boundary-crossing pick uses the outgoing show's track-length cap (pre-existing, minor).