### PR TITLE
fix(broadcast): un-silence DJ voice clips — fade.out on request.queue kills the whole clip

### DIFF
--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -6,6 +6,7 @@
 
 import * as piper from './piper.js';
 import * as kokoro from './kokoro.js';
+import { applyEdgeFades } from './wav-edges.js';
 import * as chatterbox from './chatterbox.js';
 import * as pocketTts from './pocketTts.js';
 import * as remoteTts from './remoteTts.js';
@@ -295,6 +296,11 @@ export async function speak(
   const chars = (speakText || '').length;
   try {
     const result = await speakWith(primary, speakText, { outPath, speedScale: scale, language, soul }, personaTts);
+    // Bake 40ms edge fades into the rendered clip so hard file boundaries
+    // never reach the broadcast compressor as a click. Render time is the only
+    // place the tail can be faded — see audio/wav-edges.ts. Best-effort:
+    // non-WAV output (cloud mp3) is left as-is.
+    if (typeof result === 'string') await applyEdgeFades(result);
     recordTts({
       kind, engine: primary, requested, fellBack: requested !== primary,
       ok: true, ms: Date.now() - started, chars, t: new Date().toISOString(),
@@ -316,6 +322,7 @@ export async function speak(
     console.error(`[tts] ${primary} failed for kind=${kind}: ${err.message} — falling back to ${fallback}`);
     try {
       const result = await speakWith(fallback, speakText, { outPath, speedScale: scale, language, soul }, personaTts);
+      if (typeof result === 'string') await applyEdgeFades(result);
       recordTts({
         kind, engine: fallback, requested, fellBack: true,
         ok: true, ms: Date.now() - started, chars, t: new Date().toISOString(),

--- a/controller/src/audio/wav-edges.ts
+++ b/controller/src/audio/wav-edges.ts
@@ -1,0 +1,98 @@
+// Bake micro edge fades into a rendered voice WAV, in place.
+//
+// Some TTS engines cut the file hard at the clip boundary; once the broadcast
+// mic-chain compressor's makeup gain lifts the clip, that hard edge lands on
+// air as an audible click. The head fade also exists in radio.liq (fade.in on
+// the voice queues), but the TAIL fade cannot live there: fade.out on a
+// request.queue source doesn't know the track's remaining time in this
+// Liquidsoap build and silences the entire clip (the 2026-07-04 silent-DJ
+// incident, PR #830). So both edges are baked into the file at render time —
+// the only place the clip's true length is known.
+//
+// Only canonical PCM WAVs are edited: 16-bit int (format 1) and 32-bit float
+// (format 3). Anything else — notably the cloud engine's mp3 output — is left
+// untouched: lossy encoders pad the stream with silence at both ends, so the
+// hard-edge click doesn't arise there.
+
+import { readFile, writeFile } from 'node:fs/promises';
+
+const RIFF = 0x46464952; // "RIFF" LE
+const WAVE = 0x45564157; // "WAVE" LE
+
+type Fmt = { audioFormat: number; channels: number; sampleRate: number; bitsPerSample: number };
+
+// Walk the RIFF chunks for `fmt ` + `data`. Returns null on anything that
+// isn't a plain little-endian WAV.
+function parseWav(buf: Buffer): { fmt: Fmt; dataStart: number; dataLen: number } | null {
+  if (buf.length < 44) return null;
+  if (buf.readUInt32LE(0) !== RIFF || buf.readUInt32LE(8) !== WAVE) return null;
+  let fmt: Fmt | null = null;
+  let dataStart = -1;
+  let dataLen = 0;
+  let off = 12;
+  while (off + 8 <= buf.length) {
+    const id = buf.toString('ascii', off, off + 4);
+    const size = buf.readUInt32LE(off + 4);
+    if (id === 'fmt ' && off + 8 + 16 <= buf.length) {
+      fmt = {
+        audioFormat: buf.readUInt16LE(off + 8),
+        channels: buf.readUInt16LE(off + 10),
+        sampleRate: buf.readUInt32LE(off + 12),
+        bitsPerSample: buf.readUInt16LE(off + 22),
+      };
+    } else if (id === 'data') {
+      dataStart = off + 8;
+      // A streaming writer may leave the size field stale — trust the file.
+      dataLen = Math.min(size, buf.length - dataStart);
+    }
+    off += 8 + size + (size % 2); // chunks are word-aligned
+  }
+  if (!fmt || dataStart < 0 || dataLen <= 0) return null;
+  return { fmt, dataStart, dataLen };
+}
+
+// Linear ramp over the first and last `ms` of the data chunk. Mutates `buf`.
+// Returns false when the format isn't one we can safely edit.
+function rampInPlace(buf: Buffer, fmt: Fmt, dataStart: number, dataLen: number, ms: number): boolean {
+  const bytesPerSample = fmt.bitsPerSample / 8;
+  const int16 = fmt.audioFormat === 1 && fmt.bitsPerSample === 16;
+  const float32 = fmt.audioFormat === 3 && fmt.bitsPerSample === 32;
+  if (!int16 && !float32) return false;
+  if (!fmt.channels || !fmt.sampleRate) return false;
+
+  const frameBytes = bytesPerSample * fmt.channels;
+  const totalFrames = Math.floor(dataLen / frameBytes);
+  const fadeFrames = Math.min(Math.floor((fmt.sampleRate * ms) / 1000), Math.floor(totalFrames / 2));
+  if (fadeFrames <= 0) return true; // nothing to do on a tiny clip
+
+  const scale = (frame: number, gain: number) => {
+    const base = dataStart + frame * frameBytes;
+    for (let ch = 0; ch < fmt.channels; ch++) {
+      const at = base + ch * bytesPerSample;
+      if (int16) buf.writeInt16LE(Math.round(buf.readInt16LE(at) * gain), at);
+      else buf.writeFloatLE(buf.readFloatLE(at) * gain, at);
+    }
+  };
+  for (let i = 0; i < fadeFrames; i++) {
+    const gain = i / fadeFrames;
+    scale(i, gain);                    // head: 0 → 1
+    scale(totalFrames - 1 - i, gain);  // tail: 1 → 0 (mirrored)
+  }
+  return true;
+}
+
+// Public entry point — best-effort by design: a voice clip must never fail to
+// air because the edge polish couldn't be applied. Returns true when fades
+// were baked, false when the file was left untouched.
+export async function applyEdgeFades(filePath: string, ms = 40): Promise<boolean> {
+  try {
+    const buf = await readFile(filePath);
+    const parsed = parseWav(buf);
+    if (!parsed) return false;
+    if (!rampInPlace(buf, parsed.fmt, parsed.dataStart, parsed.dataLen, ms)) return false;
+    await writeFile(filePath, buf);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -897,15 +897,20 @@ end
 # BEFORE mic_chain so the fixed-threshold compressor sees a levelled input. The
 # un-annotated silent lead-in carries no `liq_amplify`, so it plays at the base
 # factor 1. (unity). Un-trimmed clips (gainDb 0) write a bare path → also unity.
-# Micro edge fades on each spoken clip. Some TTS engines cut the WAV hard at
+# Micro edge fade-IN on each spoken clip. Some TTS engines cut the WAV hard at
 # the file boundary; once the mic-chain compressor's makeup gain lifts the
 # clip, that hard edge lands as an audible click/tick. 40 ms is short enough
 # not to soften the first word (speech onsets are slower than that) but long
 # enough to zero out the boundary discontinuity. Applied per track, so the
 # silent lead-in clip is faded too (harmless — it's silence). Placed BEFORE
 # amplify/mic_chain so the compressor never sees the raw edge.
+# fade.in ONLY — no fade.out. On a request.queue source this Liquidsoap build
+# doesn't know the track's remaining time, so fade.out treats the whole clip
+# as inside the fade zone and multiplies it to silence (every voice segment
+# aired as dead air under the duck). Verified empirically against the
+# broadcast image. Tail clicks must be faded at WAV-render time instead.
 def edge_fade(s) =
-  fade.in(duration=0.04, fade.out(duration=0.04, s))
+  fade.in(duration=0.04, s)
 end
 
 voice = mic_chain(amplify(override="liq_amplify", 1., edge_fade(voice_queue)))


### PR DESCRIPTION
## What

Since #830 every DJ voice segment — links, station IDs, hourly checks, weather/curiosity segments, request intros — aired as **dead air**: the duck engaged, listeners heard a 3–4s volume dip mid-song, and no voice. Reported live today (dips during Skyfull ~0:30 and Senorita ~1:30; both aligned exactly with a curiosity segment and the 14:00 hourly).

Two commits:

1. **`radio.liq`: drop `fade.out` from `edge_fade`.** On a `request.queue` source this Liquidsoap build (v2.4.4) doesn't know the track's remaining time, so `fade.out` treats the entire clip as inside the fade zone and multiplies it to ~0. `fade.in` is kept — it still kills the head-boundary click #830 targeted, and is proven harmless.
2. **Bake 40ms edge fades into the WAV at render time** (`audio/wav-edges.ts`, wired into both success paths of `tts.speak()`). Render time is the only place the clip's true length is known, so the tail fade lives here. Handles PCM16 + float32 WAVs in-place; skips mp3 (cloud engine) and anything unparseable — best-effort by design, a clip never fails to air because polish couldn't be applied.

## Evidence

Offline repro in the exact broadcast image (sine through the voice chain, `request.queue` + `output.file`):

| Chain | RMS |
|---|---|
| plain queue | 13612 |
| `fade.in` only | 13477 |
| `fade.out` only | 1291 (brief blip, then silence) |
| `edge_fade` as shipped in #830 | **0** |

Note `liquidsoap --check` (what #830 was verified with) can't catch this — it's runtime semantics, the script parses fine.

## Verification

- **On-air**: after deploying commit 1, a manual `POST /dj/segment` station-id recorded off `/stream.mp3` shows voice peaks (RMS 10–12k) riding the duck, with the ducked-music floor (~1.4k) visible only in the trailing gap — previously the whole window sat at the floor.
- **Render-time fades**: rendered on-air WAVs pulled from the container show heads ramping from 0 and tails landing at 0 (40ms edge RMS 16–47 vs body ~7,900), body untouched. Unit-tested against synthetic PCM16/float32 WAVs + mp3/missing-file negative cases.
- `npm run lint` clean (0 errors).

Both fixes are already running on the live station (locally-built images) — merging + publishing keeps the next pull from reinstating the bug.