### PR TITLE
fix(deploy): stop health-check error scan false-failing on benign log noise

### DIFF
--- a/.claude/skills/subwave-deploy/scripts/health-check.sh
+++ b/.claude/skills/subwave-deploy/scripts/health-check.sh
@@ -149,6 +149,22 @@ echo
 # benign "aborting with incomplete response / context canceled" for
 # /stream.mp3. That (and any normal stream-client disconnect) is filtered out
 # below so it doesn't read as a deploy failure.
+#
+# Also filtered: Liquidsoap's playlist-parser probing. On startup (and on the
+# first track resolve) it tries every registered parser in order — the XML and
+# SCPLS parsers reject non-matching content by raising, and Liquidsoap 2.4.x
+# prints those internal exceptions to stderr as "Error -1: Exception raised:
+# xml error: expected root element" / "...: Not_found" with backtraces. They
+# land exactly in the post-restart window this scan covers. Benign; the M3U
+# parser wins right after. Keep the patterns anchored to "Exception raised:"
+# so a real error elsewhere still trips the scan.
+#
+# Also filtered: the controller's raw LLM debug capture (settings
+# llm.debugRawRequests or LLM_DEBUG_RAW). When on, every outbound model
+# request body is mirrored to stderr — a "[llm-debug-raw]" header line plus
+# one huge single-line JSON body starting {"model": — and prompt text inside
+# routinely contains words like "fail"/"error". Diagnostic mirroring, not a
+# fault; without this filter the scan false-fails whenever the toggle is on.
 echo "=== errors in last 2m ==="
 ANY_ERRS=0
 SERVICES=$(docker compose -f "$COMPOSE" config --services 2>/dev/null)
@@ -157,6 +173,8 @@ for svc in $SERVICES; do
          | grep -iE "error|fail|exception|fatal" \
          | grep -viE "no error|errors: 0|stderr|--with-stderr" \
          | grep -viE "aborting with incomplete response|context canceled|reading: context" \
+         | grep -vE "Exception raised: xml error: expected root element|Exception raised: Not_found" \
+         | grep -vE '\[llm-debug-raw\]|\| \{"model":' \
          | head -3)
   if [ -n "$errs" ]; then
     echo "--- $svc ---"


### PR DESCRIPTION
## What

The `subwave-deploy` skill's `health-check.sh` exits 1 on two known-benign log patterns, making healthy deploys read as failed. This adds two tightly-anchored `grep -v` filters to the error scan.

## The two false positives

**1. Liquidsoap playlist-parser probing (broadcast).** On startup — and on the first track resolve — Liquidsoap 2.4.x tries every registered playlist parser in order; the XML and SCPLS parsers reject non-matching content by raising, and those internal exceptions are printed to stderr with full OCaml backtraces (`Error -1: Exception raised: xml error: expected root element` / `…: Not_found`). They land exactly inside the 2-minute window the scan covers right after a broadcast recreate, i.e. every deploy that rebuilds broadcast trips it. Confirmed benign: 3 blocks in the first 6 seconds after start, zero since, stream audio verified at −9 to −15 dB.

**2. Raw LLM debug capture (controller).** With `llm.debugRawRequests` (or `LLM_DEBUG_RAW`) on, every outbound model request body is mirrored to stderr — a `[llm-debug-raw]` header plus one huge single-line JSON body — and prompt text naturally contains words like "fail"/"error". That's diagnostic mirroring working as designed, not a fault, so the scan shouldn't fail on it.

## Why filter, not fix upstream

The Liquidsoap prints go to stderr, not through its logger, so no `settings.log.level` tweak in `radio.liq` can suppress them; no existing upstream issue covers this exact spam. Filtering at the scan keeps container logs intact as evidence while fixing the only real symptom (false-red deploys).

Both patterns are anchored (`Exception raised: …` signatures; the `[llm-debug-raw]` / `| {"model":` dump shape) so genuine errors still trip the scan.

## Verified

- Full broadcast log (including the startup burst) replayed through the new filter chain → zero lines remain, and no other error lines were masked.
- `health-check.sh` now exits 0 on the live healthy stack with `debugRawRequests` on: on-air, mean_volume −15.2 dB, error scan `(none)`.