### PR TITLE
fix(broadcast): fire transition stingers at the crossfade, bound SFX durations

### DIFF
--- a/controller/src/audio/audio-import.ts
+++ b/controller/src/audio/audio-import.ts
@@ -66,6 +66,31 @@ export async function hasFfmpeg(): Promise<boolean> {
   return ffmpegOk;
 }
 
+// Duration of an audio file in seconds via ffprobe (ships alongside ffmpeg in
+// the Docker image). Returns null when ffprobe is missing or the file can't be
+// probed — callers treat unknown length as acceptable rather than fail.
+export function probeDurationSec(filePath: string): Promise<number | null> {
+  return new Promise((resolve) => {
+    try {
+      const proc = spawn('ffprobe', [
+        '-v', 'error',
+        '-show_entries', 'format=duration',
+        '-of', 'default=noprint_wrappers=1:nokey=1',
+        filePath,
+      ]);
+      let out = '';
+      proc.stdout.on('data', (d) => { out += d.toString(); });
+      proc.on('error', () => resolve(null));
+      proc.on('close', (code) => {
+        const n = parseFloat(out.trim());
+        resolve(code === 0 && Number.isFinite(n) && n > 0 ? Math.round(n * 10) / 10 : null);
+      });
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
 export type TranscodeFormat = 'wav' | 'mp3';
 
 function runFfmpeg(args: string[]): Promise<void> {

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -624,13 +624,19 @@ class Queue {
 
     // Feature 2 — transition FX, spaced by the chattiness ladder and gated on
     // settings.sfx.enabled; never two transitions in a row, and never a riser
-    // over a sweep/washout transition.
+    // over a sweep/washout transition. Only ARMED here: this runs at drain
+    // time, right after the PREVIOUS track started — the crossfade this
+    // stinger is sized for (prevTrack → item) is a full track away. Playing it
+    // now (the original behaviour) landed a drum-roll a few seconds into a
+    // song, apropos of nothing. onTrackStarted fires it when item airs, i.e.
+    // while that crossfade is actually happening.
     this._transitionsSinceSfx++;
     if (!effectFired && settings.get().sfx?.enabled && this._transitionsSinceSfx >= this.sfxTransitionGap()) {
       const fx = mix.transitionSfxFor(cur, next);
       if (fx) {
         this._transitionsSinceSfx = 0;
-        void this.playSfx(fx);
+        item.transitionSfx = fx;
+        this.log('mix', `transition stinger armed (${fx}) → ${item.track.title}`);
       }
     }
   }
@@ -816,8 +822,8 @@ class Queue {
   // Writes the effect's file path straight to sfx.txt — no TTS, the audio is
   // already rendered. Liquidsoap's sfx_queue mixes it beneath the voice
   // channels (see liquidsoap/radio.liq). Used by the segment-director agent
-  // to garnish a spoken line, and by applyMixTransition for between-track
-  // stingers.
+  // to garnish a spoken line, and by onTrackStarted for the between-track
+  // stingers applyMixTransition arms at drain time.
   //
   // `underVoice` offsets the write by the voice lead-in (VOICE_LEADIN_MS) so a
   // stinger meant to sit under a spoken line lands with the DJ's first word
@@ -910,6 +916,13 @@ class Queue {
       // A tracked item matched → controller and Liquidsoap are in sync; clear any
       // dj_queue-empty desync streak accumulated from prior untracked plays.
       this._emptyDjQueueStreak = 0;
+      // Transition stinger armed at drain (applyMixTransition) — fired HERE
+      // because the crossfade this stinger was sized for is airing right now.
+      // Re-gated on the live toggle: the operator may have switched SFX off
+      // in the minutes between drain and air.
+      if (item.transitionSfx && settings.get().sfx?.enabled) {
+        void this.playSfx(item.transitionSfx);
+      }
       // Air this track's intro/link now that it's actually on-air — deferred
       // from queue time so the voice lands over the right song (#189). Fire-
       // and-forget: airIntro's writeHandoff can block up to maxWaitMs and must

--- a/controller/src/broadcast/sfx.ts
+++ b/controller/src/broadcast/sfx.ts
@@ -12,7 +12,13 @@
 import { readFile, writeFile, unlink, mkdir, stat, copyFile } from 'node:fs/promises';
 import { STATE_DIR, SOUNDS_DIR } from '../config.js';
 import { generateSfx, isConfigured } from '../audio/sfx-gen.js';
-import { transcodeAudio, hasFfmpeg, extOf, isAcceptedAudio } from '../audio/audio-import.js';
+import { transcodeAudio, hasFfmpeg, extOf, isAcceptedAudio, probeDurationSec } from '../audio/audio-import.js';
+
+// Hard ceiling on any effect's length, generated or uploaded. Effects are
+// stingers that ride under a voice line or a crossfade, not beds — Liquidsoap
+// mixes them at 0.7 gain with only a light music duck, so a long clip keeps
+// droning over the programme after the voice has finished.
+export const MAX_DURATION_SEC = 10;
 
 const DIR = `${STATE_DIR}/sfx`;
 const META = `${STATE_DIR}/sfx.json`;
@@ -110,10 +116,11 @@ export async function list() {
   return out;
 }
 
-// Name + description only — the slim view the segment agent reads to decide
-// whether (and which) effect fits a line.
+// The slim view the segment agent reads to decide whether (and which) effect
+// fits a line. Duration rides along so the prompt can show it — a name and
+// description alone hide how long a clip will sit under the voice.
 export async function catalog() {
-  return (await list()).map((s: any) => ({ name: s.name, description: s.description }));
+  return (await list()).map((s: any) => ({ name: s.name, description: s.description, durationSec: s.durationSec }));
 }
 
 // Absolute path to an effect's audio file, or null if unknown / missing.
@@ -129,17 +136,29 @@ export async function create({ name, description, prompt, durationSec, builtin =
   const slug = slugify(name);
   if (!slug) throw new Error('Sound effect name is required');
   if (!prompt || !prompt.trim()) throw new Error('Sound effect prompt is required');
+  const requestedSec = Number(durationSec) || null;
+  if (requestedSec && requestedSec > MAX_DURATION_SEC) {
+    throw new Error(`sound effects are capped at ${MAX_DURATION_SEC}s — shorter stingers sit better under the voice`);
+  }
   await mkdir(DIR, { recursive: true });
 
-  const file = `${slug}.mp3`;
-  await generateSfx(prompt, { durationSec, outPath: `${DIR}/${file}` });
-
+  // Same guard as importAudio: regenerating into an existing name would
+  // silently clobber its audio — and flip a built-in to deletable, since
+  // `builtin` defaults false here. Delete first, then create.
   const meta = await loadMeta();
+  if (meta.items[slug]) throw new Error(`a sound effect named "${slug}" already exists`);
+
+  const file = `${slug}.mp3`;
+  await generateSfx(prompt, { durationSec: requestedSec ?? undefined, outPath: `${DIR}/${file}` });
+  // ElevenLabs picks its own length when none was requested — record what it
+  // actually rendered so the agent-facing catalogue shows real numbers.
+  const measured = await probeDurationSec(`${DIR}/${file}`);
+
   meta.items[slug] = {
     name: slug,
     description: (description || '').trim(),
     prompt: prompt.trim(),
-    durationSec: Number(durationSec) || null,
+    durationSec: measured ?? requestedSec,
     file,
     builtin,
     createdAt: new Date().toISOString(),
@@ -177,11 +196,20 @@ export async function importAudio(
     await writeFile(`${DIR}/${file}`, buffer);
   }
 
+  // Length gate — a 3-minute "effect" would drone under the programme long
+  // after the voice line ends. Unknown duration (no ffprobe on a bare-host
+  // dev box) is accepted rather than blocking the feature there.
+  const measured = await probeDurationSec(`${DIR}/${file}`);
+  if (measured && measured > MAX_DURATION_SEC) {
+    await unlink(`${DIR}/${file}`).catch(() => {});
+    throw new Error(`"${originalName || slug}" is ${measured}s long — sound effects are capped at ${MAX_DURATION_SEC}s`);
+  }
+
   meta.items[slug] = {
     name: slug,
     description: (description || '').trim(),
     prompt: '',
-    durationSec: null,
+    durationSec: measured,
     file,
     builtin: false,
     source: 'upload',

--- a/controller/src/routes/sfx.ts
+++ b/controller/src/routes/sfx.ts
@@ -26,6 +26,11 @@ router.post('/sfx', requireAdmin, async (req, res) => {
   if (!name) return res.status(400).json({ error: 'name is required' });
   if (!prompt) return res.status(400).json({ error: 'prompt is required' });
   if (prompt.length > 500) return res.status(400).json({ error: 'prompt too long (max 500)' });
+  if (durationSec != null && durationSec !== '') {
+    const d = Number(durationSec);
+    if (!Number.isFinite(d) || d <= 0) return res.status(400).json({ error: 'durationSec must be a positive number' });
+    if (d > sfx.MAX_DURATION_SEC) return res.status(400).json({ error: `durationSec is capped at ${sfx.MAX_DURATION_SEC}s` });
+  }
   try {
     const created = await sfx.create({ name, description, prompt, durationSec });
     queue.log('scheduler', `New sound effect created: "${created.name}"`);

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -133,7 +133,10 @@ function forcedSchema() {
 // agent and nothing in the schema can be satisfied.
 function sfxBlock(sfxCatalog: any) {
   if (!sfxCatalog || !sfxCatalog.length) return '';
-  const list = sfxCatalog.map((s: any) => `- ${s.name}: ${s.description}`).join('\n');
+  const list = sfxCatalog.map((s: any) => {
+    const dur = s.durationSec ? ` (~${s.durationSec}s)` : '';
+    return `- ${s.name}${dur}: ${s.description}`;
+  }).join('\n');
   return `
 
 SOUND EFFECTS: you may optionally play ONE sound effect underneath your voice for this segment. Use one only when it genuinely sharpens the line — most segments need none, and an effect on every break gets old fast. Set "sfx" to the exact name of an effect below, or null:


### PR DESCRIPTION
## What

Three fixes to the sound-effects feature, from a review of how effects are chosen and triggered:

### 1. Transition stingers now fire at the crossfade they were sized for
`transitionSfxFor` picks a whoosh/drum-roll for the tempo jump **current → next**, but `applyMixTransition` runs at drain time — right after the *current* track starts, since picks happen on track start. The stinger therefore aired a few seconds-to-a-minute into a song, a full track before the transition it garnished (listeners heard a drum-roll apropos of nothing).

`applyMixTransition` now only **arms** the effect on the queue item (`item.transitionSfx`); `onTrackStarted` fires it when that item actually goes on-air — while the crossfade is audibly happening. The chattiness-ladder spacing, the never-over-a-sweep/washout rule, and the BPM-ratio maths are unchanged. The `sfx.enabled` toggle is re-checked at air time since minutes can pass between drain and air.

### 2. `create()` can no longer clobber existing effects
`importAudio` rejected duplicate names ('so a built-in can't be clobbered') but `create()` didn't — `POST /sfx` with the name "drum roll" regenerated `drum-roll`'s audio and reset `builtin: false`, stripping its delete protection. `create()` now rejects an existing name with the same error importAudio uses; delete first, then create.

### 3. Effect durations are bounded and visible to the agent
Effects are stingers (built-ins are 1.2–2.5s) mixed at 0.7 gain with only a −3 dB music dip — but generation accepted up to ElevenLabs' 22s and uploads any length, and the segment agent's catalogue showed name + description only.

- `MAX_DURATION_SEC = 10` enforced on generation (route 400 + library guard) and uploads (ffprobe-measured post-transcode; over-length rejected, file cleaned up). Unknown duration (no ffprobe on a bare-host dev box) is accepted rather than blocking the feature.
- Generated effects are probed for their *actual* rendered length (ElevenLabs picks its own when none is requested); uploads now store duration too.
- The catalogue block in the segment-director prompt shows `- name (~2.5s): description` so the model can judge whether a clip suits a short aside.

## Testing
- `npm run lint` (eslint + tsc) passes in `controller/`.
- No behavior change when SFX are disabled, the library is empty, or ffprobe is absent.