### PR TITLE
News dispatches: surface buried enumerations as lists

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3860,11 +3860,23 @@ html.lite *::after {
     padding-left: 22px;
 }
 .bs-prose li {
-    margin-bottom: 0.4em;
+    margin-bottom: 0.5em;
     line-height: 1.6;
 }
 .bs-prose li::marker {
     color: var(--accent);
+}
+/* Loose lists (blank line between items) render each item as a <p>; keep that
+   from inheriting the 1.2em paragraph gap so description-style lists stay tight. */
+.bs-prose li > p {
+    margin: 0 0 0.4em;
+}
+.bs-prose li > p:last-child {
+    margin-bottom: 0;
+}
+/* A bold lead-in term ("Blend — …") reads as the item's label. */
+.bs-prose li > strong:first-child {
+    color: var(--ink);
 }
 .bs-prose code {
     padding: 1px 6px;

--- a/web/content/news/2026-05-12-what-is-subwave.md
+++ b/web/content/news/2026-05-12-what-is-subwave.md
@@ -14,7 +14,14 @@ It's a radio station for one person to run and anyone to tune into. You point it
 
 ## How it works
 
-Four small pieces do the work. Navidrome holds your music. An LLM is the DJ's brain and decides what plays next and what to say. A text-to-speech voice turns those lines into audio. Liquidsoap and Icecast mix it all into one stream and broadcast it. That's the whole machine.
+Four small pieces do the work:
+
+- **Navidrome** holds your music.
+- **An LLM** is the DJ's brain — it decides what plays next and what to say.
+- **A text-to-speech voice** turns those lines into audio.
+- **Liquidsoap and Icecast** mix it all into one stream and broadcast it.
+
+That's the whole machine.
 
 The DJ pulls from what you actually own, so the station sounds like your taste, not an algorithm's idea of it.
 

--- a/web/content/news/2026-05-30-clone-a-voice.md
+++ b/web/content/news/2026-05-30-clone-a-voice.md
@@ -11,7 +11,11 @@ Voice cloning used to be a Chatterbox-only party trick. PocketTTS can do it too 
 
 ## What's new
 
-PocketTTS does zero-shot cloning from one reference WAV. There's also a single shared voices folder both heavy engines look in, and the voice picker in admin scrolls properly when you've got a lot of them.
+Three things landed:
+
+- **Zero-shot cloning in PocketTTS** — one reference WAV is enough.
+- **A single shared voices folder** both heavy engines read from.
+- **A voice picker that scrolls** properly when you've got a lot of them.
 
 ## How to use it
 

--- a/web/content/news/2026-06-01-dj-mode-mixes.md
+++ b/web/content/news/2026-06-01-dj-mode-mixes.md
@@ -10,7 +10,13 @@ DJ mode used to change what the DJ said. It teased the next track and called bac
 
 ## What's new
 
-When a persona is in DJ mode, the crossfade stops being one fixed length. Two tracks that share a tempo and key lock into a short, tight blend. A clash gets a longer wash that hides the seam. On a big jump up in tempo, the DJ can drop a riser across the join. It also times its between-track line to finish before the vocals come in, and it will string together a short run of tracks that drift in tempo with the time of day.
+When a persona is in DJ mode, the crossfade stops being one fixed length. It shapes each join to the two tracks:
+
+- Tracks that **share a tempo and key** lock into a short, tight blend.
+- A **clash** gets a longer wash that hides the seam.
+- A **big jump up in tempo** can get a riser dropped across the join.
+
+It also times its between-track line to finish before the vocals come in, and it strings together a short run of tracks that drift in tempo with the time of day.
 
 ## How to use it
 

--- a/web/content/news/2026-06-04-put-your-station-on-the-map.md
+++ b/web/content/news/2026-06-04-put-your-station-on-the-map.md
@@ -10,7 +10,11 @@ SUB/WAVE is self-hosted, so anyone can run their own station. Until now there wa
 
 ## What's new
 
-Visit /stations and you get three things. A live grid of station cards, each one showing what it is playing this second. A world map with every station plotted as a dot and labelled by city. And a strip at the top counting the stations and countries on the network.
+Visit /stations and you get three things:
+
+- **A live grid of station cards**, each showing what it's playing this second.
+- **A world map** with every station plotted as a dot and labelled by city.
+- **A strip at the top** counting the stations and countries on the network.
 
 Each card checks its station's public now-playing feed straight from your browser and refreshes every 30 seconds. It flips between ON AIR with the artist and title, and Offline when a station is down or unreachable. Nothing is mocked up. The cards are reading the real streams.
 

--- a/web/content/news/2026-06-13-see-the-shape-of-your-library.md
+++ b/web/content/news/2026-06-13-see-the-shape-of-your-library.md
@@ -10,7 +10,14 @@ The DJ holds a lot in its head: every track's mood, energy, tempo, key, and a pa
 
 ## What's new
 
-It's a full-screen map of every track you've tagged. Each one is a point, sitting near others in its genre, lit on an ink-to-vermilion ramp by how energetic it is. Faint lines wire close neighbours together. Pan around, scroll to zoom. The panels down the right keep a running count: energy split, mood field, a tempo histogram, a loudness histogram, a Camelot key wheel, and the major/minor and vocal/instrumental balance.
+It's a full-screen map of every track you've tagged. Each one is a point, sitting near others in its genre, lit on an ink-to-vermilion ramp by how energetic it is. Faint lines wire close neighbours together. Pan around, scroll to zoom.
+
+The panels down the right keep a running count:
+
+- Energy split and mood field
+- A tempo histogram and a loudness histogram
+- A Camelot key wheel
+- The major/minor and vocal/instrumental balance
 
 ![The Library Observatory: every tagged track placed by genre, lit by energy, with stat panels alongside](/screenshots/observatory.webp)
 

--- a/web/content/news/2026-06-23-meet-the-booth-buddy.md
+++ b/web/content/news/2026-06-23-meet-the-booth-buddy.md
@@ -10,7 +10,13 @@ The player has a new resident. It's a small pixel creature that sits at the head
 
 ## What's new
 
-The booth buddy is a tiny mascot drawn entirely in CSS, so it adds nothing to load and picks up your theme colours on its own. It has five moods. Open mouth and a pulsing antenna when the DJ is talking. A head tilt and wide eyes when the DJ is picking the next track. A calm face when things are quiet, and droopy eyes with little z's once it has been idle a while. Tap it on the player and it gets spooked, eyes blown wide, then settles back down.
+The booth buddy is a tiny mascot drawn entirely in CSS, so it adds nothing to load and picks up your theme colours on its own. It has five moods:
+
+- **On air** — open mouth and a pulsing antenna while the DJ is talking.
+- **Curious** — a head tilt and wide eyes while the DJ picks the next track.
+- **Content** — a calm face when things are quiet.
+- **Sleepy** — droopy eyes and little z's once it's been idle a while.
+- **Spooked** — tap it and its eyes blow wide, then it settles back down.
 
 ![The booth buddy's five moods, each a small pixel face: content with an even mouth, on air with an open mouth, curious with a head tilt, sleepy with droopy eyes and drifting z's, and spooked with eyes blown wide](/screenshots/booth-buddy.webp)
 

--- a/web/content/news/2026-07-03-four-ways-to-leave-a-track.md
+++ b/web/content/news/2026-07-03-four-ways-to-leave-a-track.md
@@ -11,13 +11,10 @@ A crossfade used to be a crossfade, one fixed shape for every pair of songs. DJ 
 
 ## The four moves
 
-A blend is for tracks that already sit well together. The outgoing song hands off its bass, then its mids, to the incoming one, and keeps only its highs to the end. The next track comes up from underneath, low end first. For a moment it sounds like one piece of music whose ingredients are quietly swapping.
-
-A washout is a dub echo tail. As the outgoing track fades, its last bar loads into a delay that swells and decays over the new song coming up. That one is the DJ closing a chapter rather than smoothing a seam.
-
-A sweep is the dramatic one. A filter closes down hard over the track you're leaving, choking it into the dark while the new pick rises clean underneath it.
-
-A dissolve is a reverb wash. The outgoing track loses its beat to a diffuse haze and recedes into a big dark room, and the next track walks in through the cloud.
+- **Blend** — for tracks that already sit well together. The outgoing song hands off its bass, then its mids, to the incoming one, and keeps only its highs to the end. The next track comes up from underneath, low end first. For a moment it sounds like one piece of music whose ingredients are quietly swapping.
+- **Washout** — a dub echo tail. As the outgoing track fades, its last bar loads into a delay that swells and decays over the new song coming up. That one is the DJ closing a chapter rather than smoothing a seam.
+- **Sweep** — the dramatic one. A filter closes down hard over the track you're leaving, choking it into the dark while the new pick rises clean underneath it.
+- **Dissolve** — a reverb wash. The outgoing track loses its beat to a diffuse haze and recedes into a big dark room, and the next track walks in through the cloud.
 
 ## How to use it
 


### PR DESCRIPTION
## What

Several `/news` (Dispatches) articles buried clear enumerations inside dense paragraphs, so they read as walls of text with no scannable structure — the thing that prompted this ("feels like paragraphs, no lists").

Converted those enumerations to bullet lists with bold lead-in labels, and left genuinely narrative sections (the "Why it helps" closers, lyrical descriptions) as prose so the broadsheet voice survives.

### Articles touched
- **what-is-subwave** — the four pieces of the machine (Navidrome / LLM / TTS / Liquidsoap+Icecast)
- **clone-a-voice** — the three "what's new" items
- **dj-mode-mixes** — the crossfade behaviours
- **put-your-station-on-the-map** — the three things `/stations` gives you
- **see-the-shape-of-your-library** — the stat panels
- **meet-the-booth-buddy** — the five moods
- **four-ways-to-leave-a-track** — the four transition moves (blend / washout / sweep / dissolve)

Articles that already used lists appropriately (bring-your-own-llm, listen-anywhere, request-a-track, one-click-on-unraid) or that are genuinely step-by-step guides were left alone.

### CSS
Small defensive additions to `.bs-prose`:
- stop loose-list `<p>` wrapping from inheriting the 1.2em paragraph gap
- style a bold lead-in term as the list item's label
- slightly more room between list items

## Verify
Rendered the edited articles through the live dev server. Lists show clean `<ul><li>` markup (no stray `<p>` wrappers), vermilion bullet markers, bold accent lead-in labels; drop cap and section rhythm unchanged.