### PR TITLE
docs(skills): document community sharing, catalog install & zip export/import

### DIFF
--- a/docs/custom-skills.md
+++ b/docs/custom-skills.md
@@ -235,3 +235,41 @@ there (or in `/admin/skills`), not in `.env`.
   fires autonomously when it's enabled *and* assigned to the persona on air
   (Personas page). **Run now** is an operator override that bypasses the toggle,
   the persona assignment, the frequency gate, and the cooldown.
+
+## Sharing skills
+
+Three ways to move a skill between stations, sorted from most-reviewed to
+most-direct.
+
+### The community catalog
+
+`/admin/skills` has a **Community** button (next to **New skill**) that lists a
+catalog of skills shipped in the controller image. **Install** copies one into
+`state/skills/` as an ordinary custom skill — **disabled on arrival**, for you to
+read before it airs. The catalog is **prompt-only by contract**: no `tool.mjs` is
+ever shipped or written, so installing from it never runs third-party code.
+
+### Sharing your own
+
+Any **prompt-only** custom skill (no `tool.mjs`) shows a **Share to community**
+button. It opens a prefilled GitHub Issue Form; a workflow
+(`skill-submission.yml`) validates the slug, reserved names, and context fields,
+then opens a one-file PR adding `controller/src/skills/community/<slug>/SKILL.md`
+— no fork, no code. Once merged it ships in the next image and reaches every
+operator through the normal update path. A skill that carries a `tool.mjs` can't
+be shared this way; use a zip.
+
+### Zip export / import
+
+For a direct operator-to-operator handoff, the skill edit sheet has **↓ Export**
+(`GET /api/dj/skills/:slug/export`) that streams a `.zip` of `SKILL.md` plus
+`tool.mjs` if present. The **Import .zip** button in the Community modal
+(`POST /api/dj/skills/import`) takes it back in, deriving the slug from the
+bundle's `name:`.
+
+> **A zip may carry code.** Unlike the reviewed catalog, an imported `.zip` can
+> include a `tool.mjs` — a direct action on your own box, the same trust as
+> dropping a folder in by hand or restoring a backup. Imports arrive **disabled**;
+> when the bundle has a tool, the response flags it so the UI can warn you before
+> you enable it. (Hardened against zip-slip; 5 MB upload cap, only `SKILL.md` +
+> `tool.mjs` are extracted. Reserved names and re-imports are rejected.)

--- a/web/components/manual/CustomSkills.tsx
+++ b/web/components/manual/CustomSkills.tsx
@@ -161,6 +161,48 @@ export const ready = (services) => services.searchReady();`}</CodeBlock>
       </section>
 
       <section className="bs-section">
+        <p className="bs-eyebrow">SHARING</p>
+        <h2>Send one out, pull one in.</h2>
+        <p>
+          Wrote a skill worth passing on? On the admin <strong>Skills</strong> page, any
+          prompt-only skill (no <code className="bs-code-inline">tool.mjs</code>) grows a{' '}
+          <strong>Share to community</strong> button. It opens a prefilled GitHub issue; a
+          workflow checks the slug and frontmatter and opens a one-file PR. Once that&rsquo;s
+          merged the skill ships in the next controller image, so any station can pick it up.
+        </p>
+        <p>
+          The other direction is the <strong>Community</strong> button next to{' '}
+          <strong>New skill</strong>. It lists the shipped catalog; <strong>Install</strong>{' '}
+          drops a copy into <code className="bs-code-inline">state/skills/</code> — toggled
+          off, for you to read before it airs. The catalog is prompt-only by design, so
+          installing from it never runs anyone else&rsquo;s code.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">ZIP EXPORT / IMPORT</p>
+        <h2>Hand a skill straight to another operator.</h2>
+        <p>
+          To pass a skill directly instead, the edit sheet has an{' '}
+          <strong>↓ Export</strong> that streams a <code className="bs-code-inline">.zip</code>{' '}
+          (the <code className="bs-code-inline">SKILL.md</code>, plus{' '}
+          <code className="bs-code-inline">tool.mjs</code> if it has one). The Community modal
+          has the matching <strong>Import .zip</strong>. Like everything else, an import lands
+          disabled.
+        </p>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">A ZIP CAN CARRY CODE</div>
+          <p>
+            Unlike the reviewed catalog, an imported{' '}
+            <code className="bs-code-inline">.zip</code> may include a{' '}
+            <code className="bs-code-inline">tool.mjs</code> — the same trust as dropping a
+            folder in by hand. When it does, the UI flags it on arrival; read the code before
+            you enable it.
+          </p>
+        </div>
+      </section>
+
+      <section className="bs-section">
         <p className="bs-eyebrow">GOING LIVE</p>
         <h2>Discovered, then enabled by you.</h2>
         <p>


### PR DESCRIPTION
## What

Documents the skills marketplace/sharing surface shipped in #782, which was previously undocumented in both the web manual and the canonical doc.

**Web manual** (`web/components/manual/CustomSkills.tsx`) — two new sections before *Going live*:
- **Sharing** — the Community catalog + Install, and the Share-to-community button (prompt-only, opens a validated one-file PR).
- **Zip export / import** — Export/Import `.zip`, with a callout that a zip may carry a `tool.mjs` (runs code; review before enabling).

**Canonical doc** (`docs/custom-skills.md`) — a new *Sharing skills* section covering the same three flows with route names and the hardening notes (prompt-only catalog vs code-carrying zip).

## Why

Before this, `/manual/skills` and the doc only described drop-a-folder / New skill / Rescan. The load-bearing point throughout is the trust distinction: the reviewed catalog never runs third-party code, an imported zip can.

## Notes
- Docs-only; no code changes. `web` lint (eslint + tsc) passes.
- Copy run through the humanizer pass.
