### PR TITLE
fix(broadcast): Liquidsoap 2.4.5 — un-stall DJ transition effects + boot log rotation

### DIFF
--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -49,7 +49,9 @@ RUN npm run build
 FROM caddy:2 AS caddybin
 
 # ---- final: everything under the liquidsoap (Debian bookworm) base ----------
-FROM savonet/liquidsoap:v2.4.4
+# v2.4.5 minimum — same reason as Dockerfile.broadcast: 2.4.4's O(n) clock
+# scan made the per-transition DJ effect chains stall the stream clock.
+FROM savonet/liquidsoap:v2.4.5
 
 USER root
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/Dockerfile.broadcast
+++ b/docker/Dockerfile.broadcast
@@ -13,7 +13,14 @@
 #   - A tiny shell supervisor (broadcast-entrypoint.sh) resolves the shared
 #     password, renders icecast.xml, launches both, and exits if either dies
 #     so the container's restart policy bounces them together.
-FROM savonet/liquidsoap:v2.4.4
+# v2.4.5 minimum: 2.4.4's clock scanned every source in the graph per pull,
+# and pass-through layers (smooth_add/compress) pull more than once per frame —
+# together the per-transition DJ effect chains (sweep/washout/dissolve, ~30
+# operators) pegged a core and stalled the stream clock at every crossfade
+# ("Latency is too high" → dead-air source resets). 2.4.5 makes clock
+# sync-source propagation push-based/O(1), which removes the stall entirely
+# (verified against the dissolve worst case in an isolated sandbox).
+FROM savonet/liquidsoap:v2.4.5
 
 USER root
 

--- a/docker/broadcast-entrypoint.sh
+++ b/docker/broadcast-entrypoint.sh
@@ -70,6 +70,16 @@ touch /var/sub-wave/archive/.ndignore
 mkdir -p /var/log/liquidsoap
 chown -R liquidsoap:liquidsoap /var/log/liquidsoap 2>/dev/null || true
 
+# Rotate radio.log on boot once it passes 50MB. Liquidsoap has no size-based
+# rotation of its own and appends forever (200MB+ after a couple of months);
+# boot is the one safe moment to move it since liquidsoap isn't holding the
+# fd yet. One .old generation caps disk at ~2x the threshold.
+RADIO_LOG=/var/log/liquidsoap/radio.log
+if [ -f "$RADIO_LOG" ] && [ "$(stat -c %s "$RADIO_LOG" 2>/dev/null || echo 0)" -gt 52428800 ]; then
+    mv -f "$RADIO_LOG" "$RADIO_LOG.old"
+    echo "broadcast: rotated oversized radio.log to radio.log.old" >&2
+fi
+
 # ---- Resolve passwords ------------------------------------------------------
 # Capture env values FIRST so sourcing the secrets file can't clobber them.
 

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -39,7 +39,10 @@ station_name = ref("SUB/WAVE")
 # no threads, no shared state): sample-accurate in AUDIO time, so they hold
 # under any clock — the offline render harness (sync="none") exposed that
 # wall-clock thread envelopes and audio time drift apart.
-# Verified on liquidsoap v2.2.5 AND v2.4.4 (scripts/fx-render-test.sh probe):
+# Verified on liquidsoap v2.2.5, v2.4.4 AND v2.4.5 (scripts/fx-render-test.sh
+# probe). NB: v2.4.5 is the MINIMUM runtime for these effects — on 2.4.4 the
+# clock's O(n) source scan × multi-pull pass-through layers made every effect
+# transition peg a core and stall the stream (see Dockerfile.broadcast).
 # filter.rc and comb instantiate cleanly INSIDE the cross callback on a
 # request.queue-backed source — the "Early computation of source content-type"
 # crash is specific to iir_filter/HPF — and audibly alter the render.

--- a/scripts/fx-render-test.sh
+++ b/scripts/fx-render-test.sh
@@ -24,7 +24,7 @@
 
 set -euo pipefail
 
-IMAGE="${LIQ_IMAGE:-savonet/liquidsoap:v2.4.4}"
+IMAGE="${LIQ_IMAGE:-savonet/liquidsoap:v2.4.5}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 WORK="$HERE/.fx-render"
 mkdir -p "$WORK"


### PR DESCRIPTION
## Summary

Since the 2.2.5 → 2.4.4 engine upgrade (#784), every crossfade using the DJ-mode transition effects (#606 sweep/washout/dissolve) stalled the stream clock — 1,378 `Latency is too high` warnings in one day (zero in the prior two months) and two `Too much latency` source resets with audible dead air.

**Root cause** (proven by isolated full-graph sandbox + bisect, not just log correlation): 2.4.4's clock scans every source in the graph per pull, and pass-through layers pull their input more than once per frame — the three stacked `smooth_add` ducking layers were the dominant multiplier (removing them cut warnings ~6×). The per-transition effect chains add ~30 operators with fan-out (dissolve's `pure_tail` = 17 consumers of one `fade.out`), so the multiplication pegs a full core mid-crossfade. The same chains in a minimal graph, or rendered offline, cost nothing.

**Fix**: Liquidsoap **2.4.5** makes clock sync-source propagation push-based/O(1). Sandbox A/B on the identical graph: dissolve worst case went from ~76 warnings/crossfade at 100% CPU to **0 warnings at ~8%**; washout and sweep also clean. `scripts/fx-render-test.sh probe` passes on 2.4.5 (filter.rc + comb still audibly process — the reason that probe exists). Effects code untouched.

Second commit: boot-time rotation for `radio.log` (>50MB → `.old`) — liquidsoap has no size rotation and the file had grown to 218MB since May.

- `cb138be` fix(broadcast): upgrade Liquidsoap 2.4.4 → 2.4.5 — un-stall DJ transition effects
- `df19da2` fix(broadcast): rotate oversized radio.log at boot

**Live since 19:35 on the production station**: 7+ effect crossfades (washouts + sweeps), 0 latency warnings, idle CPU ~9% (down from ~18-20% on 2.4.4).

## Test plan
- [ ] `docker compose up -d --build broadcast` — container reports `Liquidsoap 2.4.5`, stream comes back on air
- [ ] With djMode on, effect crossfades (`DJ sweep:`/`DJ washout:` in radio.log) produce **no** `Latency is too high` lines
- [ ] `LIQ_IMAGE=savonet/liquidsoap:v2.4.5 scripts/fx-render-test.sh probe` → PASS
- [ ] Boot with a >50MB `state/logs/radio.log` → rotated to `radio.log.old`, fresh log starts