### PR TITLE
feat(doctor): settings-tuning section + settings-aware DJ Doc review

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# These are supported funding model platforms
+ko_fi: pklair

--- a/controller/src/doctor-knowledge.ts
+++ b/controller/src/doctor-knowledge.ts
@@ -106,6 +106,58 @@ skills and library tags as a single archive, restorable later. **Proactively sug
 taking a backup** before big changes (re-tagging, switching providers) and on a
 regular cadence — it's cheap insurance.
 
+## Daily token budget (settings.llm.dailyTokenCap / budgetSoftPct / exemptRequests)
+- \`dailyTokenCap\` (0 = off) is a per-UTC-day token ceiling. It degrades in two tiers:
+  at \`budgetSoftPct\`% of the cap ("soft") the DJ forces the cheap pool picker and
+  mutes optional segments (links, station IDs, hourly, weather/news); at the cap
+  ("hard") it makes NO model call and coasts on the LLM-free auto playlist — music
+  never stops. Listener requests stay exempt through the hard cap unless
+  \`exemptRequests\` is off.
+- The report's **Tuning → token budget** finding projects today's burn rate against
+  the cap ("on track to hit the cap ~15:00 UTC"). If it will exhaust early, advise:
+  raise the cap, turn on **pause-when-empty** so idle hours don't spend tokens, or
+  ease off reasoning / the agentic picker (both spend more per pick).
+- A **soft tier of 0 or 100 disables graceful degrade** — the DJ goes from full to
+  silent with no warning. Recommend ~80.
+
+## Context window (settings.llm.numCtx, Ollama only)
+- The Ollama context size. The **agentic picker** sends a system prompt + tool
+  defs + candidates; too small a window truncates them, the agent can't call its
+  "done" tool, and it falls back to the pool. Keep ≥8192 (16384 default) when the
+  agentic picker is on, or turn the picker off. Not relevant for cloud providers.
+
+## Max response size (settings.llm.maxOutputTokens)
+- Per-call OUTPUT cap (distinct from the daily budget). 0 = strategy defaults
+  (generous). A small value can truncate the agent's tool-call JSON mid-object,
+  forcing a fallback. Leave at 0 unless a small-context local model needs it.
+
+## Agent deadline vs measured latency
+- Beyond the raw \`agentTimeoutMs\` value, the report compares it to the model's
+  **p90 latency** (Tuning → agent deadline vs latency). If p90 crowds or exceeds the
+  deadline, the agentic picker is timing out into the pool on most tracks — the
+  operator is paying for session-aware picks and not getting them. Fix: raise the
+  deadline, or run a faster/smaller model (or reasoning OFF).
+
+## Broadcast stream encoders (settings.stream.* + archive)
+- \`/stream.mp3\` is always on. Opus / FLAC / AAC mounts and the **hourly archive**
+  are each a CONTINUOUS extra encoder = real, constant CPU. The hourly archive is
+  the single biggest cost. On a small / loaded box, recommend disabling mounts the
+  operator's players don't use (the web/native players only ever use MP3, optionally
+  Opus). The report's **Tuning → broadcast encoders** finding weighs the count
+  against host cores + load.
+
+## Audio analysis features vs analyzer flavour (settings.audio.embeddings / vocalActivity)
+- "Sounds-like" audio embeddings need the **heavy analyzer** (CLAP); vocal-range /
+  talk-timing needs the heavy analyzer (Demucs). The default LEAN analyzer image
+  can't do either, so these toggles **silently no-op** on it. If the report flags
+  this, tell the operator to set \`ANALYZER_HEAVY=1\` in .env and re-pull/rebuild the
+  analyzer, or turn the setting off (it's costing nothing but false expectations).
+
+## Listener-request web-resolve (settings.llm.requestWebResolve)
+- Lets the request agent resolve *described* tracks ("that song from the advert")
+  via web search — so it depends on Settings → Search being configured. If it's on
+  while search isn't ready, the feature is dead; either configure search or turn it off.
+
 ## Where to look when things break
 The admin Debug page is a live snapshot (recent AI calls + success, mixer status,
 log tail) — first stop when the stream stalls, the DJ goes quiet, or a voice sounds

--- a/controller/src/doctor.ts
+++ b/controller/src/doctor.ts
@@ -33,6 +33,8 @@ import { getSetupStatus } from './setup/firstRun.js';
 import { djObject } from './llm/sdk.js';
 import { searchReady, searchWeb } from './skills/web-search.js';
 import * as system from './system.js';
+import { budgetStatus } from './broadcast/dj-budget.js';
+import * as analyzer from './music/analyzer.js';
 import { DJ_DOC_KNOWLEDGE } from './doctor-knowledge.js';
 
 export type Status = 'ok' | 'warn' | 'fail' | 'skip';
@@ -103,6 +105,7 @@ export async function runDoctor(): Promise<DoctorReport> {
   sections.push({ name: 'Capabilities', findings: await safe(() => checkCapabilities(s)) });
   sections.push({ name: 'Content', findings: await safe(checkContent) });
   sections.push({ name: 'Resources', findings: await safe(checkResources) });
+  sections.push({ name: 'Tuning', findings: await safe(() => checkTuning(s)) });
   sections.push({ name: 'Storage', findings: await safe(checkStorage) });
   sections.push({ name: 'Setup', findings: await safe(checkSetup) });
 
@@ -497,6 +500,196 @@ async function checkResources(): Promise<Finding[]> {
   return out;
 }
 
+// Tuning — the cross-setting + telemetry-vs-config checks that the settings
+// panel itself can't show. Each finding weighs one performance knob against the
+// OTHER settings, the live LLM telemetry, or the host resources — the stuff an
+// operator can't eyeball. Findings are advisory (no one-click fix): the remedy
+// is a settings change, which DJ Doc's review then narrates the trade-off for.
+async function checkTuning(s: any): Promise<Finding[]> {
+  const out: Finding[] = [];
+  const llm = s?.llm || {};
+
+  // --- Daily token budget: cliff detection + burn-rate projection ---
+  // Uses the live tally (broadcast/dj-budget), not just the configured number,
+  // so it can say "you'll hit the cap by mid-afternoon" instead of "a cap is set".
+  try {
+    const b = budgetStatus();
+    if (!b.enabled) {
+      out.push({ label: 'token budget', status: 'skip', detail: 'no daily cap (unlimited)' });
+    } else {
+      // A soft tier of 0 or 100 disables graceful degrade — the DJ jumps from
+      // full service straight to silent at the cap.
+      if (b.softPct <= 0 || b.softPct >= 100) {
+        out.push({
+          label: 'budget soft tier',
+          status: 'warn',
+          detail: `soft tier disabled (softPct ${b.softPct})`,
+          hint: 'With no soft tier the DJ jumps straight from full service to silent at the cap. Set Settings → LLM → budget soft % to ~80 so it first drops to the cheap pool picker and mutes optional segments, warning you before it hits the wall.',
+        });
+      }
+      // Project today's exhaustion from the burn rate so far (UTC day).
+      const now = Date.now();
+      const dayStart = Date.parse(new Date().toISOString().slice(0, 10) + 'T00:00:00Z');
+      const hrsElapsed = Math.max(0.05, (now - dayStart) / 3600000);
+      const rate = b.usedToday / hrsElapsed; // tokens/hour
+      const willExhaust = b.mode !== 'hard' && rate * 24 > b.cap && b.usedToday > 0;
+      const hitHour = willExhaust ? Math.min(24, Math.round(b.cap / rate)) : null;
+      const pct = b.cap > 0 ? Math.round((b.usedToday / b.cap) * 100) : 0;
+      out.push({
+        label: 'token budget',
+        status: b.mode === 'hard' ? 'fail' : b.mode === 'soft' || willExhaust ? 'warn' : 'ok',
+        detail:
+          b.mode === 'hard'
+            ? `cap reached (${fmtTokens(b.usedToday)}/${fmtTokens(b.cap)}) — DJ is coasting on the auto playlist`
+            : `${fmtTokens(b.usedToday)}/${fmtTokens(b.cap)} used today (${pct}%)${willExhaust ? ` · on track to hit the cap ~${hitHour}:00 UTC` : ''}`,
+        hint:
+          b.mode === 'hard'
+            ? 'No model calls until UTC midnight (listener requests still run if exempt). Raise Settings → LLM → daily token cap, or turn on pause-when-empty so idle hours don’t burn the budget.'
+            : willExhaust
+              ? 'At the current rate the DJ drops to the cheap picker (soft), then goes silent (hard) before the day ends. Raise the cap, enable pause-when-empty, or ease off reasoning / the agentic picker to slow the burn.'
+              : undefined,
+      });
+    }
+  } catch { /* budget module best-effort */ }
+
+  // --- Agent deadline vs MEASURED latency ---
+  // checkLlm only warns when the configured number looks low; here we compare it
+  // to what the model is actually doing. If p90 latency crowds the deadline, the
+  // agentic picker is silently timing out into the pool on most tracks.
+  if (llm.pickerAgent !== false) {
+    const lat = recentCalls
+      .filter((c: any) => c && c.ok !== false && Number.isFinite(c.ms) && c.ms > 0)
+      .map((c: any) => c.ms as number)
+      .sort((a, b) => a - b);
+    const deadlineMs = Number(llm.agentTimeoutMs);
+    if (lat.length >= 5 && Number.isFinite(deadlineMs) && deadlineMs > 0) {
+      const p90 = lat[Math.min(lat.length - 1, Math.floor(lat.length * 0.9))];
+      const ratio = p90 / deadlineMs;
+      out.push({
+        label: 'agent deadline vs latency',
+        status: ratio >= 1 ? 'fail' : ratio >= 0.8 ? 'warn' : 'ok',
+        detail: `p90 model latency ${(p90 / 1000).toFixed(1)}s vs ${Math.round(deadlineMs / 1000)}s deadline`,
+        hint:
+          ratio >= 0.8
+            ? 'Recent calls are running close to (or past) the agent deadline, so the agentic picker is probably timing out into the pool fallback on many tracks — you lose the session-aware picks you’re paying for. Raise Settings → LLM → agent deadline, or switch to a faster/smaller model (or turn reasoning OFF).'
+            : undefined,
+      });
+    }
+  }
+
+  // --- Context window too small for the agentic picker (Ollama only) ---
+  if (llm.provider === 'ollama' && llm.pickerAgent !== false) {
+    const nc = Number(llm.numCtx);
+    if (Number.isFinite(nc) && nc > 0 && nc < 8192) {
+      out.push({
+        label: 'context window',
+        status: 'warn',
+        detail: `numCtx ${nc} — tight for the agentic picker`,
+        hint: 'The agentic picker sends a system prompt + tool definitions + candidates; a small Ollama context window truncates them so the agent can’t call its “done” tool and falls back to the pool. Raise Settings → LLM → context window to ≥8192 (16384 is the default), or turn the agentic picker off.',
+      });
+    }
+  }
+
+  // --- Reasoning vs structured output (cross-setting, telemetry-backed) ---
+  // "Thinking" tokens are a common cause of malformed JSON. Tie the risk to the
+  // actual schema-failure count so it only fires when both are true.
+  if (llm.reasoning) {
+    const schemaFails = recentCalls.filter(isSchemaFailure).length;
+    if (schemaFails > 0) {
+      out.push({
+        label: 'reasoning vs structured output',
+        status: 'warn',
+        detail: `reasoning ON with ${schemaFails} recent schema failure(s)`,
+        hint: 'Chain-of-thought output is a common cause of malformed structured JSON (the picker, request matcher, tagger and this report all need strict JSON). Try turning Settings → LLM → reasoning OFF and re-checking — most local models emit cleaner JSON without it.',
+      });
+    }
+  }
+
+  // --- Max response size too small for the agentic picker ---
+  {
+    const mo = Number(llm.maxOutputTokens);
+    if (Number.isFinite(mo) && mo > 0 && mo < 1000 && llm.pickerAgent !== false) {
+      out.push({
+        label: 'max response size',
+        status: 'warn',
+        detail: `maxOutputTokens ${mo} — low for the agentic picker`,
+        hint: 'A small per-call output cap can truncate the agent’s tool calls mid-JSON, forcing a fallback. Leave Settings → LLM → max response size at 0 (strategy default) unless a small-context local model specifically needs it.',
+      });
+    }
+  }
+
+  // --- Listener-request web-resolve needs web search configured ---
+  if (llm.requestWebResolve) {
+    let ready = true;
+    try { ready = searchReady(); } catch { ready = true; }
+    if (!ready) {
+      out.push({
+        label: 'request web-resolve',
+        status: 'warn',
+        detail: 'on, but web search isn’t ready',
+        hint: 'Resolving described track requests ("that song from the film") needs a working web search. Configure it in Settings → Search, or turn Settings → LLM → request web-resolve off.',
+      });
+    }
+  }
+
+  // --- Audio-analysis features vs the analyzer flavour actually running ---
+  // audio.embeddings / vocalActivity silently no-op on the lean analyzer image
+  // (no CLAP / Demucs). Cross-check the setting against the live capability probe.
+  try {
+    const wantEmb = !!s?.audio?.embeddings;
+    const wantVocal = !!s?.audio?.vocalActivity;
+    if (wantEmb || wantVocal) {
+      try { await analyzer.refreshCapabilities(); } catch { /* best-effort probe */ }
+      if (wantEmb && analyzer.audioEmbeddingAvailable() === false) {
+        out.push({
+          label: 'audio embeddings',
+          status: 'warn',
+          detail: 'enabled, but the analyzer can’t produce them',
+          hint: 'The “sounds-like” audio embeddings need the heavy analyzer (CLAP). You’re on the lean image, so this setting silently does nothing. Set ANALYZER_HEAVY=1 in .env and re-pull/rebuild the analyzer, or turn the setting off.',
+        });
+      }
+      if (wantVocal && analyzer.vocalActivityAvailable() === false) {
+        out.push({
+          label: 'vocal activity',
+          status: 'warn',
+          detail: 'enabled, but the analyzer can’t produce it',
+          hint: 'Vocal-range / talk-timing analysis needs the heavy analyzer (Demucs). The lean image can’t, so this setting no-ops. Set ANALYZER_HEAVY=1 in .env and rebuild the analyzer, or turn the setting off.',
+        });
+      }
+    }
+  } catch { /* analyzer unavailable — skip */ }
+
+  // --- Broadcast encoder load vs host CPU ---
+  // Every extra mount and the hourly archive is a continuous encoder — real CPU.
+  // Flag it only when several are on AND the host is already under pressure.
+  try {
+    const st = s?.stream || {};
+    const extra: string[] = [];
+    if (st.opusEnabled) extra.push('opus');
+    if (st.flacEnabled) extra.push('flac');
+    if (st.aacEnabled) extra.push('aac');
+    if (s?.archive?.enabled) extra.push('hourly archive');
+    const encoderCount = 1 + extra.length; // /stream.mp3 always
+    const sys = await system.summary();
+    const cores = sys.host?.cpus || 0;
+    const load1 = Array.isArray(sys.host?.loadavg) ? sys.host.loadavg[0] : 0;
+    const perCore = cores > 0 ? load1 / cores : 0;
+    const pressured = (cores > 0 && cores <= 2) || perCore > 0.8;
+    const heavy = extra.length >= 2;
+    out.push({
+      label: 'broadcast encoders',
+      status: heavy && pressured ? 'warn' : 'ok',
+      detail: `${encoderCount} encoder${encoderCount === 1 ? '' : 's'} (mp3${extra.length ? ' + ' + extra.join(' + ') : ''}) · ${cores} cores, load ${load1.toFixed(2)}`,
+      hint:
+        heavy && pressured
+          ? 'Each extra stream mount and the hourly archive is a continuous encoder, and this host is already loaded for its core count. The hourly archive is the single biggest cost — disable mounts you don’t use (Settings → Broadcast) to free CPU for the DJ and TTS.'
+          : undefined,
+    });
+  } catch { /* resources unavailable — skip encoder check */ }
+
+  return out;
+}
+
 async function checkContent(): Promise<Finding[]> {
   const out: Finding[] = [];
 
@@ -626,9 +819,11 @@ const REVIEW_SYSTEM = [
   'personal internet radio station (Navidrome library, an LLM DJ, Liquidsoap mixer, Icecast stream,',
   'local/cloud TTS).',
   'A knowledge base about how SUB/WAVE works is provided below — USE IT. Ground every recommendation',
-  'in it, and tailor model / picker / chain-of-thought / agent-deadline / TTS-engine advice to the',
-  'HOST RESOURCES and CURRENT SETTINGS shown in the report (e.g. don\'t tell a small-CPU box to run',
-  'Chatterbox or the agentic picker on a 9B model).',
+  'in it, and tailor model / picker / chain-of-thought / agent-deadline / budget / stream-encoder /',
+  'TTS-engine advice to the HOST RESOURCES and CURRENT SETTINGS shown in the report (e.g. don\'t tell',
+  'a small-CPU box to run Chatterbox, four stream encoders, or the agentic picker on a 9B model). The',
+  '"Tuning" section and the settings snapshot spell out the current knob values — use them to spot',
+  'settings that fight each other or the hardware, and say plainly which knob to change and to what.',
   'Interpret the findings for a non-expert operator: what is fine, what needs attention, what to do',
   'first. Be concrete and brief — keep the swagger to a light seasoning, no fluff, don\'t restate',
   'every finding. Prioritise anything that takes the station off air or starves the DJ (stream',
@@ -655,13 +850,16 @@ export async function reviewReport(report: DoctorReport): Promise<DoctorReview> 
       prompt: [
         DJ_DOC_KNOWLEDGE,
         '\n---\n',
+        renderSettingsSnapshot(),
+        '',
         'Here is the latest station health report.',
         '',
         renderReportText(report),
         '',
-        'Review it for the operator. Lean on the knowledge base above, and tailor any model / picker /',
-        'chain-of-thought / agent-deadline / TTS recommendations to the host resources and current',
-        'settings shown in the report.',
+        'Review it for the operator. Lean on the knowledge base above. Cross-reference the "Tuning"',
+        'section and the current settings snapshot against the host resources, and tailor any model /',
+        'picker / chain-of-thought / agent-deadline / budget / encoder / TTS recommendations to what',
+        'this specific box can actually handle.',
       ].join('\n'),
       schema: REVIEW_SCHEMA,
       temperature: 0.5,
@@ -701,6 +899,42 @@ function classifyModel(label: string): { code: boolean; sizeB: number | null } {
   const sizeMatch = m.match(/(\d+(?:\.\d+)?)\s*b(?:[^a-z0-9]|$)/);
   const sizeB = sizeMatch ? parseFloat(sizeMatch[1]) : null;
   return { code, sizeB };
+}
+
+// Compact snapshot of the live performance-affecting settings, so the AI review
+// can reason about the actual knob values + trade-offs (not just the findings
+// that fired). Pairs with the "Tuning" section and the knowledge base.
+function renderSettingsSnapshot(): string {
+  let s: any = null;
+  try { s = settings.get(); } catch { return ''; }
+  const llm = s?.llm || {};
+  const st = s?.stream || {};
+  const mounts = ['mp3'];
+  if (st.opusEnabled) mounts.push('opus');
+  if (st.flacEnabled) mounts.push('flac');
+  if (st.aacEnabled) mounts.push('aac');
+
+  let budget = 'unlimited';
+  try {
+    const b = budgetStatus();
+    budget = b.enabled
+      ? `${fmtTokens(b.usedToday)}/${fmtTokens(b.cap)} today (soft ${b.softPct}%, mode ${b.mode})`
+      : 'unlimited';
+  } catch { /* budget best-effort */ }
+
+  let analyzerLabel = 'unknown';
+  try { analyzerLabel = analyzer.backendLabel(); } catch { /* best-effort */ }
+
+  return [
+    '## Current settings (tune these against the findings + host resources)',
+    `- LLM: ${providerName()} · ${activeModelLabel()} · pickerAgent ${llm.pickerAgent === false ? 'OFF' : 'ON'} · reasoning ${llm.reasoning ? 'ON' : 'OFF'} · agentDeadline ${Math.round(Number(llm.agentTimeoutMs || 0) / 1000)}s · numCtx ${llm.numCtx ?? 'n/a'} · toolChoice ${llm.toolChoice || 'required'} · maxOutputTokens ${llm.maxOutputTokens || 'default'}`,
+    `- Budget: ${budget} · exemptRequests ${llm.exemptRequests === false ? 'OFF' : 'ON'} · pauseWhenEmpty ${llm.pauseWhenEmpty ? 'ON' : 'OFF'}`,
+    `- Picking: noRepeatWindow ${llm.noRepeatWindow ?? 'n/a'} · requestWebResolve ${llm.requestWebResolve ? 'ON' : 'OFF'}`,
+    `- Broadcast: crossfade ${s?.crossfadeDuration ?? '?'}s · jingle 1/${s?.jingleRatio ?? '?'} · maxTrack ${s?.maxTrackSeconds ? s.maxTrackSeconds + 's' : 'unlimited'} · loudness ${s?.loudness?.targetLufs ?? '?'} LUFS · mounts ${mounts.join('+')} · archive ${s?.archive?.enabled ? 'ON' : 'OFF'}`,
+    `- Voice: default TTS ${s?.tts?.defaultEngine || 'piper'}`,
+    `- Analysis: audio.embeddings ${s?.audio?.embeddings ? 'ON' : 'OFF'} · vocalActivity ${s?.audio?.vocalActivity ? 'ON' : 'OFF'} · analyzer ${analyzerLabel}`,
+    `- Search: ${s?.search?.provider || 'duckduckgo'}`,
+  ].join('\n');
 }
 
 // Compact, prompt-friendly rendering of the report — labels/status/detail/hint
@@ -753,6 +987,13 @@ async function dirSize(path: string, cap = 5000): Promise<{ bytes: number; files
   }
   await walk(path);
   return { bytes, files };
+}
+
+function fmtTokens(n: number): string {
+  if (!Number.isFinite(n)) return '?';
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
+  return String(n);
 }
 
 function fmtBytes(n: number): string {


### PR DESCRIPTION
## What

Extends **DJ Doc** so it covers the performance-affecting settings the operator can't easily reason about from the settings panel. Two parts:

### 1. New "Tuning" section (deterministic, cross-setting + telemetry-backed)
Each finding weighs one knob against the *other* settings, the *live* LLM telemetry, or the *host* resources:

| Finding | What it catches |
|---|---|
| **token budget** | Projects today's burn rate against the cap ("on track to hit the cap ~15:00 UTC"); reports soft/hard mode |
| **budget soft tier** | `budgetSoftPct` of 0/100 → no graceful degrade, DJ goes full→silent with no warning |
| **agent deadline vs latency** | Compares `agentTimeoutMs` to measured **p90 latency** — the agentic picker silently timing out into the pool |
| **context window** | Ollama `numCtx` too small for the agentic picker's prompt+tools |
| **reasoning vs structured output** | `reasoning` ON *and* recent schema failures → thinking tokens corrupting JSON |
| **max response size** | `maxOutputTokens` too low to fit agent tool calls |
| **request web-resolve** | `requestWebResolve` on but web search isn't ready |
| **audio embeddings / vocal activity** | `audio.*` enabled but the **lean** analyzer can't produce them (silently no-ops) |
| **broadcast encoders** | Count of stream mounts + hourly archive vs host cores/load |

Findings are advisory (no one-click fix) — the remedy is a settings change, which the review narrates.

### 2. Settings-aware buddy review
`reviewReport()` now feeds the LLM a compact **live settings snapshot** (LLM/budget/picking/broadcast/voice/analysis/search), and `DJ_DOC_KNOWLEDGE` gains a tuning block covering each knob's trade-off — so DJ Doc's advice is grounded in the actual values, not generic.

## Verification
- `npm run lint` (eslint + `tsc --noEmit`) passes clean — 0 errors.
- Ran `runDoctor()` on defaults: Tuning section renders (`token budget: skip`, `broadcast encoders: ok`).
- Ran with a misconfigured settings object: correctly fired `budget soft tier` (warn), `context window` (warn), and correctly *stayed quiet* where the live signal was ready/unknown rather than false (search ready via keyless DuckDuckGo; analyzer capability `null`).

## Notes
No frontend change — `DoctorPanel` renders sections generically, so the new section + findings appear automatically.