### PR TITLE
feat(doctor): stream results, persist last run + header badge, wire review fixes

### DIFF
--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -24,6 +24,7 @@ import { djCallsAllowed } from './listeners.js';
 import { optionalSegmentsAllowed } from './dj-budget.js';
 import { agenticTick, skillCatalog } from '../skills/_agent.js';
 import { withTrace } from '../observability/events.js';
+import * as doctor from '../doctor.js';
 
 const TARGET_POOL = 30;
 const MOOD_WEIGHT = 12;          // up to this many mood-tagged tracks per pool
@@ -479,6 +480,21 @@ async function cleanup() {
 }
 
 // ---------------------------------------------------------------------------
+// NIGHTLY HEALTH CHECK
+// Run the deterministic doctor assessment once a day so the admin header badge
+// and the DJ Doc panel reflect the station's health even before the operator
+// opens it. No LLM call — runDoctor is LLM-free; the result is just cached.
+// ---------------------------------------------------------------------------
+
+async function nightlyDoctor() {
+  try {
+    await withTrace({ kind: 'doctor' }, () => doctor.runDoctor());
+  } catch (err) {
+    queue.log('error', `Nightly health check failed: ${err.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // START
 // ---------------------------------------------------------------------------
 
@@ -503,6 +519,10 @@ export function startScheduler() {
 
   // Cleanup every hour
   cron.schedule('0 * * * *', cleanup);
+
+  // Nightly health check at 04:17 — populates the DJ Doc last-run cache + header
+  // badge without the operator having to open the panel. Deterministic (no LLM).
+  cron.schedule('17 4 * * *', nightlyDoctor);
 
   queue.log('scheduler', `Scheduler started · skills: ${skillCatalog().map((s: any) => s.name).join(', ')}`);
 }

--- a/controller/src/doctor.ts
+++ b/controller/src/doctor.ts
@@ -10,7 +10,7 @@
 // probe, Subsonic ping, listener monitor, TTS routing, library stats); nothing
 // here adds new probing infrastructure.
 
-import { readFile, readdir, stat } from 'node:fs/promises';
+import { readFile, readdir, stat, writeFile } from 'node:fs/promises';
 import { z } from 'zod';
 import { config, STATE_DIR } from './config.js';
 import * as settings from './settings.js';
@@ -77,6 +77,10 @@ export interface ReviewPriority {
   severity: 'low' | 'med' | 'high';
   why: string;
   suggestedFix: string;
+  // When set, the panel can render the matching one-click fix button right on
+  // this priority. The panel still cross-checks it against the report's own
+  // findings, so a stray/hallucinated id never surfaces a button.
+  fixId?: FixId | null;
 }
 
 export interface DoctorReview {
@@ -91,28 +95,136 @@ export interface DoctorReview {
 // runDoctor — assemble all sections.
 // ---------------------------------------------------------------------------
 
-export async function runDoctor(): Promise<DoctorReport> {
-  let s: any = null;
-  try { s = settings.get(); } catch { s = null; }
+// The section roster, in display order. Each check swallows its own errors and
+// degrades to a 'skip'/'fail' finding (via `safe`), so one failing subsystem
+// never blanks the whole report. Kept as data so both the batch runner and the
+// streaming generator drive the same list.
+const SECTION_CHECKS: Array<{ name: string; run: (s: any) => Promise<Finding[]> }> = [
+  { name: 'LLM', run: (s) => checkLlm(s) },
+  { name: 'Navidrome & library', run: () => checkNavidrome() },
+  { name: 'Broadcast', run: () => checkBroadcast() },
+  { name: 'Voice (TTS)', run: (s) => checkTts(s) },
+  { name: 'Capabilities', run: (s) => checkCapabilities(s) },
+  { name: 'Content', run: () => checkContent() },
+  { name: 'Resources', run: () => checkResources() },
+  { name: 'Tuning', run: (s) => checkTuning(s) },
+  { name: 'Storage', run: () => checkStorage() },
+  { name: 'Setup', run: () => checkSetup() },
+];
 
-  const sections: DoctorSection[] = [];
-  // Each check swallows its own errors and degrades to a 'skip'/'fail' finding,
-  // so one failing subsystem never blanks the whole report.
-  sections.push({ name: 'LLM', findings: await safe(() => checkLlm(s)) });
-  sections.push({ name: 'Navidrome & library', findings: await safe(checkNavidrome) });
-  sections.push({ name: 'Broadcast', findings: await safe(checkBroadcast) });
-  sections.push({ name: 'Voice (TTS)', findings: await safe(() => checkTts(s)) });
-  sections.push({ name: 'Capabilities', findings: await safe(() => checkCapabilities(s)) });
-  sections.push({ name: 'Content', findings: await safe(checkContent) });
-  sections.push({ name: 'Resources', findings: await safe(checkResources) });
-  sections.push({ name: 'Tuning', findings: await safe(() => checkTuning(s)) });
-  sections.push({ name: 'Storage', findings: await safe(checkStorage) });
-  sections.push({ name: 'Setup', findings: await safe(checkSetup) });
+function loadSettingsSafe(): any {
+  try { return settings.get(); } catch { return null; }
+}
 
+// Yield each section as its check completes, so the streaming route can flush
+// partial results to the panel instead of blocking on the whole assessment
+// (some checks — an unreachable LLM host, the live web-search probe — take
+// several seconds each).
+export async function* runDoctorSections(): AsyncGenerator<DoctorSection> {
+  const s = loadSettingsSafe();
+  for (const c of SECTION_CHECKS) {
+    yield { name: c.name, findings: await safe(() => c.run(s)) };
+  }
+}
+
+export function tallyCounts(sections: DoctorSection[]): DoctorReport['counts'] {
   const counts = { ok: 0, warn: 0, fail: 0, skip: 0 };
   for (const sec of sections) for (const f of sec.findings) counts[f.status]++;
+  return counts;
+}
 
-  return { t: new Date().toISOString(), sections, counts };
+// Stamp + tally a completed set of sections into a report, and cache it as the
+// station's last-known health. The single place a report is minted, so every
+// path (batch, stream, nightly cron) caches consistently.
+export function finalizeReport(sections: DoctorSection[]): DoctorReport {
+  const report: DoctorReport = { t: new Date().toISOString(), sections, counts: tallyCounts(sections) };
+  rememberReport(report);
+  return report;
+}
+
+export async function runDoctor(): Promise<DoctorReport> {
+  const sections: DoctorSection[] = [];
+  for await (const sec of runDoctorSections()) sections.push(sec);
+  return finalizeReport(sections);
+}
+
+// ---------------------------------------------------------------------------
+// Last-run cache — the panel hydrates from this on mount and the admin header
+// badges station health from it, so a report survives navigation and a restart
+// without forcing an immediate re-run. Deterministic data only (counts + DJ
+// Doc's verdict when a review has run). Best-effort disk mirror under STATE_DIR;
+// never throws into a check path.
+// ---------------------------------------------------------------------------
+
+const CACHE_FILE = `${STATE_DIR}/doctor-last.json`;
+
+interface DoctorCache {
+  report: DoctorReport | null;
+  review: DoctorReview | null;
+}
+
+let cache: DoctorCache = { report: null, review: null };
+let cacheLoaded = false;
+
+async function ensureCacheLoaded(): Promise<void> {
+  if (cacheLoaded) return;
+  cacheLoaded = true;
+  try {
+    const parsed = JSON.parse(await readFile(CACHE_FILE, 'utf8'));
+    if (parsed && typeof parsed === 'object') {
+      cache = { report: parsed.report ?? null, review: parsed.review ?? null };
+    }
+  } catch { /* no prior run persisted — fine */ }
+}
+
+function persistCache(): void {
+  // Fire-and-forget: the in-memory cache is the source of truth for this
+  // session; the disk mirror only bootstraps the next boot.
+  writeFile(CACHE_FILE, JSON.stringify(cache)).catch(() => {});
+}
+
+export function rememberReport(report: DoctorReport): void {
+  cacheLoaded = true; // a fresh run supersedes anything still on disk
+  // A new report describes a new moment — the old review no longer matches it.
+  cache = { report, review: null };
+  persistCache();
+}
+
+export function rememberReview(review: DoctorReview): void {
+  if (!cache.report) return; // a review with no report to attach to is meaningless
+  cache = { ...cache, review };
+  persistCache();
+}
+
+// Derive a headline verdict from the counts alone — used for the header badge
+// when no LLM review has run (runDoctor is LLM-free). A real review's `overall`
+// takes precedence when present.
+export function derivedOverall(counts: DoctorReport['counts']): 'healthy' | 'attention' | 'critical' {
+  if (counts.fail > 0) return 'critical';
+  if (counts.warn > 0) return 'attention';
+  return 'healthy';
+}
+
+export interface DoctorSummary {
+  t: string | null;
+  counts: DoctorReport['counts'] | null;
+  overall: 'healthy' | 'attention' | 'critical' | null;
+}
+
+// Compact health headline for the admin header badge — no section detail.
+export async function lastSummary(): Promise<DoctorSummary> {
+  await ensureCacheLoaded();
+  const r = cache.report;
+  if (!r) return { t: null, counts: null, overall: null };
+  const overall =
+    cache.review?.available && cache.review.overall ? cache.review.overall : derivedOverall(r.counts);
+  return { t: r.t, counts: r.counts, overall };
+}
+
+// Full last-run payload for the panel to hydrate from on mount.
+export async function lastRun(): Promise<DoctorCache> {
+  await ensureCacheLoaded();
+  return cache;
 }
 
 // Wrap a check so a thrown error becomes a single fail finding rather than
@@ -805,6 +917,13 @@ const REVIEW_SCHEMA = z.object({
         severity: z.enum(['low', 'med', 'high']),
         why: z.string().describe('one sentence: why it matters for listeners or reliability'),
         suggestedFix: z.string().describe('the concrete next step the operator should take'),
+        fixId: z
+          .enum(['refresh-playlist', 'restart-mixer', 'generate-jingles', 'tag-library', 'subsonic-reset'])
+          .nullable()
+          .optional()
+          .describe(
+            'When this priority is resolved by one of the one-click fixes listed in the prompt, you MUST set this to that exact fix id (so the operator gets a button). Leave it out only when no listed fix applies.',
+          ),
       }),
     )
     .describe('0-5 items, highest severity first; empty array when everything is healthy'),
@@ -856,6 +975,8 @@ export async function reviewReport(report: DoctorReport): Promise<DoctorReview> 
         '',
         renderReportText(report),
         '',
+        renderAvailableFixes(report),
+        '',
         'Review it for the operator. Lean on the knowledge base above. Cross-reference the "Tuning"',
         'section and the current settings snapshot against the host resources, and tailor any model /',
         'picker / chain-of-thought / agent-deadline / budget / encoder / TTS recommendations to what',
@@ -865,7 +986,9 @@ export async function reviewReport(report: DoctorReport): Promise<DoctorReview> 
       temperature: 0.5,
       kind: 'doctor:review',
     });
-    return { available: true, ...review };
+    const result: DoctorReview = { available: true, ...review };
+    rememberReview(result);
+    return result;
   } catch (err: any) {
     // A schema/shape mismatch here is itself a diagnosis: the review model can't
     // do structured output. Say so plainly instead of dumping the Zod error, and
@@ -934,6 +1057,28 @@ function renderSettingsSnapshot(): string {
     `- Voice: default TTS ${s?.tts?.defaultEngine || 'piper'}`,
     `- Analysis: audio.embeddings ${s?.audio?.embeddings ? 'ON' : 'OFF'} · vocalActivity ${s?.audio?.vocalActivity ? 'ON' : 'OFF'} · analyzer ${analyzerLabel}`,
     `- Search: ${s?.search?.provider || 'duckduckgo'}`,
+  ].join('\n');
+}
+
+// Tell the reviewer which one-click fixes are actually applicable right now —
+// the set of fix ids the findings surfaced this run — so it only attaches a
+// `fixId` to a priority when the corresponding button really exists.
+function renderAvailableFixes(report: DoctorReport): string {
+  const seen = new Map<FixId, string>();
+  for (const sec of report.sections) {
+    for (const f of sec.findings) {
+      if (f.fix && !seen.has(f.fix.id)) seen.set(f.fix.id, f.fix.label);
+    }
+  }
+  if (!seen.size) {
+    return 'One-click fixes available this run: none. Do NOT set fixId on any priority.';
+  }
+  const lines = [...seen.entries()].map(([id, label]) => `- ${id} — ${label}`);
+  return [
+    'One-click fixes available this run — for ANY priority that one of these resolves, you MUST set that',
+    'priority\'s `fixId` to the exact id shown here (the operator then gets a working button, not just',
+    'prose telling them to run it):',
+    ...lines,
   ].join('\n');
 }
 

--- a/controller/src/routes/doctor.ts
+++ b/controller/src/routes/doctor.ts
@@ -15,6 +15,54 @@ router.get('/doctor', requireAdmin, async (_req, res) => {
   }
 });
 
+// Streaming variant — Server-Sent Events, one `section` event per check as it
+// completes, then a final `done` event carrying the assembled report. Lets the
+// panel paint findings progressively instead of waiting on the slowest probe.
+// Consumed via fetch + a ReadableStream reader (EventSource can't carry the
+// admin Basic-auth header).
+router.get('/doctor/stream', requireAdmin, async (_req, res) => {
+  res.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+  res.setHeader('Cache-Control', 'no-cache, no-transform');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no'); // defeat any intermediary buffering
+  (res as any).flushHeaders?.();
+  const send = (event: string, data: unknown) => {
+    res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+  };
+  try {
+    const sections: doctor.DoctorSection[] = [];
+    for await (const sec of doctor.runDoctorSections()) {
+      sections.push(sec);
+      send('section', sec);
+    }
+    send('done', doctor.finalizeReport(sections));
+  } catch (err: any) {
+    send('error', { error: err?.message || 'doctor failed' });
+  } finally {
+    res.end();
+  }
+});
+
+// The last assessment (report + review), cached in the controller. Lets the
+// panel show the previous run immediately on mount instead of a blank slate.
+router.get('/doctor/last', requireAdmin, async (_req, res) => {
+  try {
+    res.json(await doctor.lastRun());
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Compact health headline (counts + overall) for the admin header badge — no
+// section detail, safe to poll.
+router.get('/doctor/summary', requireAdmin, async (_req, res) => {
+  try {
+    res.json(await doctor.lastSummary());
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // Body: { report: DoctorReport } — the report the panel already has in hand, so
 // the review reflects exactly what the operator is looking at (no re-run race).
 router.post('/doctor/review', requireAdmin, async (req, res) => {

--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import type { ComponentType, ReactNode } from 'react';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { AnimatePresence, m } from 'motion/react';
 import { useDynamicStyle } from '../../hooks/useDynamicStyle';
 import {
@@ -254,6 +254,58 @@ export default function AdminShell({ children }: AdminShellProps) {
   );
 }
 
+interface DoctorSummary {
+  counts: { ok: number; warn: number; fail: number; skip: number } | null;
+  overall: 'healthy' | 'attention' | 'critical' | null;
+}
+
+// Small health badge on the header's DJ Doc link — the count of failing/warning
+// findings from the last cached assessment (manual run or nightly auto-run), so
+// a degraded station surfaces without the operator opening the panel. Silent
+// when healthy or when no run has been cached yet.
+function DoctorBadge() {
+  const { adminFetch } = useAdminAuth();
+  const [summary, setSummary] = useState<DoctorSummary | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const r = await adminFetch('/doctor/summary');
+        const j = (await r.json().catch(() => null)) as DoctorSummary | null;
+        if (!cancelled) setSummary(j);
+      } catch {
+        /* header badge is best-effort */
+      }
+    };
+    load();
+    const timer = setInterval(load, 60_000);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [adminFetch]);
+
+  const counts = summary?.counts;
+  if (!counts) return null;
+  const n = counts.fail || counts.warn;
+  if (!n) return null;
+  const critical = counts.fail > 0;
+  return (
+    <span
+      className={`inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] leading-none font-bold ${
+        critical
+          ? 'bg-[var(--accent)] text-white'
+          : 'border border-[var(--accent)] text-[var(--accent)]'
+      }`}
+      title={`${counts.fail} fail · ${counts.warn} warn`}
+      aria-label={`Station health: ${counts.fail} failing, ${counts.warn} warnings`}
+    >
+      {n}
+    </span>
+  );
+}
+
 interface ShellHeaderProps {
   pathname: string | null;
   signedIn: boolean;
@@ -335,6 +387,7 @@ function ShellHeader({ pathname, signedIn, onSignOut }: ShellHeaderProps) {
           >
             <BoothBuddy mood="onair" size={16} />
             <span className="caption">DJ Doc</span>
+            <DoctorBadge />
           </Link>
           <ThemeSwitcher variant="admin" />
           <Link

--- a/web/components/admin/DoctorPanel.tsx
+++ b/web/components/admin/DoctorPanel.tsx
@@ -4,7 +4,7 @@
 // one-click fix where a safe action exists, asks the buddy (the LLM) to review
 // the report in plain English, and copies the whole thing as GitHub-ready
 // Markdown. Mirrors DashPanel's adminFetch + act() pattern; primitives from ./ui.
-import { useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { notify, errorMessage } from '../../lib/notify';
 import { Card, Btn, Pill } from './ui';
@@ -40,6 +40,9 @@ interface ReviewPriority {
   severity: 'low' | 'med' | 'high';
   why: string;
   suggestedFix: string;
+  // DJ Doc may tag a priority with a one-click fix; we only render the button
+  // when that fix id actually appears in the current report's findings.
+  fixId?: FixId | null;
 }
 interface DoctorReview {
   available: boolean;
@@ -76,6 +79,27 @@ const HQ_ISSUES_NEW = 'https://github.com/perminder-klair/subwave/issues/new';
 // back to the clipboard when the report is too big to prefill safely.
 const HQ_URL_LIMIT = 7000;
 
+function tallyCounts(sections: DoctorSection[]): DoctorReport['counts'] {
+  const c = { ok: 0, warn: 0, fail: 0, skip: 0 };
+  for (const s of sections) for (const f of s.findings) c[f.status]++;
+  return c;
+}
+
+// Parse one SSE frame ("event: …\ndata: …") into its event name + JSON payload.
+function parseSseFrame(frame: string): { event: string | null; data: any } {
+  let event: string | null = null;
+  const dataLines: string[] = [];
+  for (const line of frame.split('\n')) {
+    if (line.startsWith('event:')) event = line.slice(6).trim();
+    else if (line.startsWith('data:')) dataLines.push(line.slice(5).replace(/^ /, ''));
+  }
+  let data: any = null;
+  if (dataLines.length) {
+    try { data = JSON.parse(dataLines.join('\n')); } catch { /* keep null */ }
+  }
+  return { event, data };
+}
+
 export default function DoctorPanel() {
   const { adminFetch, needsAuth, hydrated } = useAdminAuth();
   const [report, setReport] = useState<DoctorReport | null>(null);
@@ -84,8 +108,63 @@ export default function DoctorPanel() {
   const [reviewing, setReviewing] = useState(false);
   const [busyFix, setBusyFix] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  // True until the mount hydration from /doctor/last resolves — suppresses the
+  // intro hero flashing before a cached report loads in.
+  const [hydrating, setHydrating] = useState(true);
 
   const ready = hydrated && !needsAuth;
+
+  // Hydrate from the last cached run so navigating back to DJ Doc (or a nightly
+  // auto-run) shows the previous report immediately instead of a blank slate.
+  const hydratedRef = useRef(false);
+  useEffect(() => {
+    if (!ready || hydratedRef.current) return;
+    hydratedRef.current = true;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await adminFetch('/doctor/last');
+        const j = (await r.json().catch(() => null)) as
+          | { report?: DoctorReport | null; review?: DoctorReview | null }
+          | null;
+        if (!cancelled && j?.report) {
+          setReport(j.report);
+          if (j.review) setReview(j.review);
+        }
+      } catch {
+        /* no cached run — the intro hero shows instead */
+      } finally {
+        if (!cancelled) setHydrating(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [ready, adminFetch]);
+
+  // Fix actions present in the current report, keyed by id — the source of truth
+  // for both the finding buttons' labels and whether a review priority may show
+  // its own one-click fix button (a fixId not in this map is never surfaced).
+  const fixById = useMemo(() => {
+    const m = new Map<FixId, FixAction>();
+    report?.sections.forEach((s) =>
+      s.findings.forEach((f) => {
+        if (f.fix && !m.has(f.fix.id)) m.set(f.fix.id, f.fix);
+      }),
+    );
+    return m;
+  }, [report]);
+
+  // One-shot batch run — the fallback when SSE streaming isn't available.
+  const runBatch = async (): Promise<DoctorReport | null> => {
+    const r = await adminFetch('/doctor');
+    const j = (await r.json().catch(() => null)) as DoctorReport | { error?: string } | null;
+    if (!r.ok || !j || !('sections' in j)) {
+      throw new Error((j as { error?: string })?.error || `failed (${r.status})`);
+    }
+    setReport(j);
+    return j;
+  };
 
   const run = async (): Promise<DoctorReport | null> => {
     setRunning(true);
@@ -93,16 +172,45 @@ export default function DoctorPanel() {
     // A fresh run invalidates the previous review (it described the old report).
     setReview(null);
     try {
-      const r = await adminFetch('/doctor');
-      const j = (await r.json().catch(() => null)) as DoctorReport | { error?: string } | null;
-      if (!r.ok || !j || !('sections' in j)) {
-        throw new Error((j as { error?: string })?.error || `failed (${r.status})`);
+      // Stream sections as each check finishes so findings paint progressively.
+      const r = await adminFetch('/doctor/stream', { headers: { Accept: 'text/event-stream' } });
+      if (!r.ok || !r.body) throw new Error(`stream unavailable (${r.status})`);
+      const reader = r.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = '';
+      const sections: DoctorSection[] = [];
+      let final: DoctorReport | null = null;
+      // Empty shell first so the intro hero yields to the progressive report.
+      setReport({ t: new Date().toISOString(), sections: [], counts: tallyCounts([]) });
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        let idx: number;
+        while ((idx = buf.indexOf('\n\n')) !== -1) {
+          const { event, data } = parseSseFrame(buf.slice(0, idx));
+          buf = buf.slice(idx + 2);
+          if (event === 'section' && data) {
+            sections.push(data as DoctorSection);
+            setReport({ t: new Date().toISOString(), sections: [...sections], counts: tallyCounts(sections) });
+          } else if (event === 'done' && data) {
+            final = data as DoctorReport;
+            setReport(final);
+          } else if (event === 'error') {
+            throw new Error((data as { error?: string })?.error || 'doctor failed');
+          }
+        }
       }
-      setReport(j);
-      return j;
-    } catch (e) {
-      setErr(errorMessage(e));
-      return null;
+      return final ?? (sections.length ? { t: new Date().toISOString(), sections, counts: tallyCounts(sections) } : null);
+    } catch {
+      // Streaming failed (proxy, older controller, aborted body) — fall back to
+      // the single-shot endpoint so the check still works.
+      try {
+        return await runBatch();
+      } catch (e2) {
+        setErr(errorMessage(e2));
+        return null;
+      }
     } finally {
       setRunning(false);
     }
@@ -208,7 +316,7 @@ export default function DoctorPanel() {
           The booth's-open pitch is the primary content; "Let's go" runs the
           full assessment AND his review together. Stays up through the first
           run so the CTA can show progress. */}
-      {ready && !report && (
+      {ready && !hydrating && !report && (
         <Card title="DJ Doc" sub="booth's open">
           <div className="flex items-start gap-4">
             <BoothBuddy mood="curious" size={52} />
@@ -358,23 +466,39 @@ export default function DoctorPanel() {
                 <p className="text-[15px] leading-[1.65]">{review.summary}</p>
                 {review.priorities && review.priorities.length > 0 && (
                   <ul className="mt-4 flex flex-col gap-3">
-                    {review.priorities.map((p, i) => (
-                      <li key={i} className="border-l-2 border-[color:var(--separator-strong)] pl-3">
-                        <div className="flex items-center gap-2">
-                          <Pill
-                            tone={p.severity === 'high' ? 'accent' : 'ink'}
-                            className={p.severity === 'high' ? 'border-[var(--accent)] bg-[var(--accent)] text-white' : undefined}
-                          >
-                            {p.severity}
-                          </Pill>
-                          <span className="text-[14px] font-bold">{p.title}</span>
-                        </div>
-                        <p className="mt-1 text-[13px] leading-[1.55] text-muted">{p.why}</p>
-                        <p className="mt-1 text-[13px] leading-[1.55]">
-                          <span className="font-bold">Fix:</span> {p.suggestedFix}
-                        </p>
-                      </li>
-                    ))}
+                    {review.priorities.map((p, i) => {
+                      // Only offer the one-click button when DJ Doc's tagged fix
+                      // actually exists in this report's findings.
+                      const fix = p.fixId ? fixById.get(p.fixId) : undefined;
+                      return (
+                        <li key={i} className="border-l-2 border-[color:var(--separator-strong)] pl-3">
+                          <div className="flex items-center gap-2">
+                            <Pill
+                              tone={p.severity === 'low' ? 'ink' : 'accent'}
+                              className={
+                                p.severity === 'high'
+                                  ? 'border-[var(--accent)] bg-[var(--accent)] text-white'
+                                  : undefined
+                              }
+                            >
+                              {p.severity}
+                            </Pill>
+                            <span className="text-[14px] font-bold">{p.title}</span>
+                          </div>
+                          <p className="mt-1 text-[13px] leading-[1.55] text-muted">{p.why}</p>
+                          <p className="mt-1 text-[13px] leading-[1.55]">
+                            <span className="font-bold">Fix:</span> {p.suggestedFix}
+                          </p>
+                          {fix && (
+                            <div className="mt-2">
+                              <Btn sm onClick={() => runFix(fix)} disabled={busyFix === fix.id}>
+                                {busyFix === fix.id ? '…' : fix.label}
+                              </Btn>
+                            </div>
+                          )}
+                        </li>
+                      );
+                    })}
                   </ul>
                 )}
               </div>
@@ -393,7 +517,7 @@ export default function DoctorPanel() {
         <Card key={sec.name} className="mt-6" title={sec.name}>
           <ul className="flex flex-col divide-y divide-[color:var(--separator-strong)]">
             {sec.findings.map((f, i) => (
-              <li key={i} className="flex flex-wrap items-center gap-x-3 gap-y-1.5 py-2.5 first:pt-0 last:pb-0">
+              <li key={`${sec.name}-${f.label}-${i}`} className="flex flex-wrap items-center gap-x-3 gap-y-1.5 py-2.5 first:pt-0 last:pb-0">
                 <StatusPill status={f.status} />
                 <span className="text-[14px] font-bold">{f.label}</span>
                 {f.detail && <span className="font-mono text-[12px] text-muted">{f.detail}</span>}


### PR DESCRIPTION
Four improvements to the **DJ Doc** admin panel, following up on the review of the existing feature.

## 1. Progressive (streamed) results
`GET /doctor/stream` (Server-Sent Events) emits one `section` event per check as it finishes, then a `done` event with the assembled report. The panel paints findings live instead of staring at a spinner while the slowest probe (unreachable LLM host, live web-search) completes. `runDoctor()` now drives the same `SECTION_CHECKS` roster through `runDoctorSections()`; the panel **falls back to the batch `/doctor` endpoint** if streaming isn't available (older controller, buffering proxy).

## 2. Persisted last run + nightly refresh
The controller caches the last report + review in memory with a best-effort disk mirror (`state/doctor-last.json`). New endpoints:
- `GET /doctor/last` — full report + review; the panel **hydrates from it on mount** so navigating away and back shows the previous run instead of a blank slate.
- `GET /doctor/summary` — compact `{ t, counts, overall }` for the header badge.

A nightly cron (`04:17`) runs the **LLM-free** assessment so the cache and badge stay fresh without the operator opening the panel.

## 3. Header status badge
The admin header's DJ Doc link now shows the count of failing/warning findings from the cached summary — accent-filled for fails, outline for warns, **silent when healthy** or before any run.

## 4. Review priorities → one-click fixes
DJ Doc may tag a priority with a `fixId`; the panel renders the matching one-click fix button right on the verdict card, **cross-checked against the report's own findings** so a stray/hallucinated id never surfaces a button. Also tidied the severity pill hierarchy (high filled / med outline / low ink) and gave findings stable keys.

## Verification
- `npm run lint` (eslint + tsc) passes clean in both `controller/` and `web/` (0 errors).
- Booted the controller standalone against a scratch state dir and exercised the endpoints:
  - `/doctor/stream` emits 10 `section` events + `done`; `rememberReport` populates the cache (in-memory + disk).
  - `/doctor/summary` then returns `overall: critical` (5 fails), `/doctor/last` returns the full 10-section report.
  - `/doctor/review` against a reachable LLM populated `fixId` on 4/5 priorities (restart-mixer, refresh-playlist, generate-jingles, tag-library); the "Configure Navidrome" priority correctly carried none.
  - Auth gate: `/doctor/summary` with no creds → 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)