### PR TITLE
feat(skills): stamp community skill provenance (submitter + dates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-skill.yml
+++ b/.github/ISSUE_TEMPLATE/add-skill.yml
@@ -87,6 +87,8 @@ body:
         - The brief is your own work (or cleared for sharing), and contains nothing
           unlawful, hateful, or designed to deceive listeners.
         - It contains no secrets, personal data, or instructions to fetch untrusted code.
+        - Your GitHub username is recorded as the skill's submitter (shown as a credit
+          line in the community catalog), along with the dates it was added and last updated.
         - SUB/WAVE may include, edit, or remove it from the catalog at its discretion.
         - It's shared under the same licence as the SUB/WAVE repository.
 

--- a/.github/workflows/skill-submission.yml
+++ b/.github/workflows/skill-submission.yml
@@ -119,20 +119,14 @@ jobs:
 
             if (problems.length) { await fail(problems); return; }
 
-            // --- 3. Render SKILL.md (frontmatter matching writeSkillFile) ---
-            const fm = ['---', `name: ${slug}`];
-            if (label) fm.push(`label: ${label}`);
-            if (cooldown) fm.push(`cooldown: ${cooldown}`);
-            if (contextList.length) fm.push(`context: ${contextList.join(', ')}`);
-            if (windowRaw === 'commute') fm.push('window: commute');
-            fm.push('---', brief, '');
-            const content = fm.join('\n');
-            const contentB64 = Buffer.from(content, 'utf8').toString('base64');
-
             const filePath = `${DIR}/${slug}/SKILL.md`;
             const displayLabel = label || slug;
+            // Provenance: who submitted it (the issue author) and when. `new Date`
+            // is the CI clock (UTC) — this runs in real Node, not a sandbox.
+            const submittedBy = (issue.user && issue.user.login) || '';
+            const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
 
-            // --- 4. Ensure a branch off develop ---
+            // --- 3. Ensure a branch off develop ---
             const branch = `skill/${slug}`;
             const baseRef = await github.rest.git.getRef({
               owner, repo, ref: `heads/${BASE}`,
@@ -146,16 +140,41 @@ jobs:
               if (e.status !== 422) throw e; // 422 = branch already exists (edited issue)
             }
 
-            // --- 5. Write/refresh the skill file on that branch ---
+            // --- 4. Find any existing copy on the branch (an edited issue, or a
+            // version already merged into develop that this branch carries). We
+            // need its blob sha to update in place, and its `dateAdded:` so the
+            // original added-date survives re-runs — only dateModified moves. ---
             let existingSha;
+            let existingAdded = '';
             try {
               const existing = await github.rest.repos.getContent({
                 owner, repo, path: filePath, ref: branch,
               });
               existingSha = existing.data.sha;
+              const prev = Buffer.from(existing.data.content || '', 'base64').toString('utf8');
+              const m = prev.match(/^dateAdded:\s*(.+?)\s*$/m);
+              if (m) existingAdded = m[1].trim();
             } catch (e) {
               if (e.status !== 404) throw e;
             }
+            const dateAdded = existingAdded || today;
+
+            // --- 5. Render SKILL.md — frontmatter matching writeSkillFile, plus
+            // the provenance the loader reads back (submittedBy / dateAdded /
+            // dateModified). See controller/src/skills/loader.ts CommunitySkill. ---
+            const fm = ['---', `name: ${slug}`];
+            if (label) fm.push(`label: ${label}`);
+            if (cooldown) fm.push(`cooldown: ${cooldown}`);
+            if (contextList.length) fm.push(`context: ${contextList.join(', ')}`);
+            if (windowRaw === 'commute') fm.push('window: commute');
+            if (submittedBy) fm.push(`submittedBy: ${submittedBy}`);
+            fm.push(`dateAdded: ${dateAdded}`);
+            fm.push(`dateModified: ${today}`);
+            fm.push('---', brief, '');
+            const content = fm.join('\n');
+            const contentB64 = Buffer.from(content, 'utf8').toString('base64');
+
+            // --- 6. Write/refresh the skill file on that branch ---
             await github.rest.repos.createOrUpdateFileContents({
               owner, repo, path: filePath, branch,
               message: `feat(skills): add ${displayLabel} community skill (from #${issue.number})`,
@@ -163,7 +182,7 @@ jobs:
               ...(existingSha ? { sha: existingSha } : {}),
             });
 
-            // --- 6. Open the PR (or reuse the existing one) ---
+            // --- 7. Open the PR (or reuse the existing one) ---
             const open = await github.rest.pulls.list({
               owner, repo, state: 'open', head: `${owner}:${branch}`,
             });
@@ -190,7 +209,7 @@ jobs:
               });
             }
 
-            // --- 7. Tell the contributor ---
+            // --- 8. Tell the contributor ---
             await github.rest.issues.removeLabel({
               owner, repo, issue_number: issue.number, name: 'needs-info',
             }).catch(() => {});

--- a/controller/src/skills/community/micro-poem/SKILL.md
+++ b/controller/src/skills/community/micro-poem/SKILL.md
@@ -3,5 +3,8 @@ name: micro-poem
 label: Micro Poem
 cooldown: 4h
 context: time, weather
+submittedBy: perminder-klair
+dateAdded: 2026-07-03
+dateModified: 2026-07-03
 ---
 A two-line, unrhymed micro-poem sparked by the track that just played or the feel of the moment — the light outside, the hour, the weather. Say it plainly, like a thought you couldn't keep in. No title, no preamble, no "here's a little poem" — just the two lines. Keep it under twenty words total and never explain it afterward.

--- a/controller/src/skills/community/mixtape-memory/SKILL.md
+++ b/controller/src/skills/community/mixtape-memory/SKILL.md
@@ -2,5 +2,8 @@
 name: mixtape-memory
 label: Mixtape Memory
 cooldown: 6h
+submittedBy: perminder-klair
+dateAdded: 2026-07-03
+dateModified: 2026-07-03
 ---
 A short, warm aside about the lost rituals of recording music off the radio — hovering over the tape deck for a favourite song, the DJ talking over the intro, hand-labelled cassettes, the hiss between tracks. One specific, sensory memory, told like you lived it. Keep it to a sentence or two and let it fade back into the music. Never call it "the good old days" or lecture about how things were better.

--- a/controller/src/skills/loader.ts
+++ b/controller/src/skills/loader.ts
@@ -160,6 +160,12 @@ export interface CommunitySkill {
   cooldown?: string;           // e.g. "6h" — the frontmatter value, verbatim
   window?: 'any' | 'commute';
   context?: string;            // comma-separated "right now" fields
+  // Provenance stamped by the submission workflow when a skill is approved +
+  // merged (.github/workflows/skill-submission.yml). Absent on hand-added or
+  // pre-provenance catalog entries — parsed defensively, UI degrades gracefully.
+  submittedBy?: string;        // GitHub login of the contributor who submitted it
+  dateAdded?: string;          // ISO date (YYYY-MM-DD) it first entered the catalog
+  dateModified?: string;       // ISO date (YYYY-MM-DD) of the last catalog change
 }
 
 // Parse one community catalog dir into a CommunitySkill, or null when it isn't a
@@ -183,6 +189,9 @@ async function readCommunityDir(slug: string): Promise<CommunitySkill | null> {
     cooldown: data.cooldown ? String(data.cooldown).trim() : undefined,
     window: data.window === 'commute' ? 'commute' : undefined,
     context: (data.context ?? data.contextFields)?.trim() || undefined,
+    submittedBy: data.submittedBy?.trim() || undefined,
+    dateAdded: data.dateAdded?.trim() || undefined,
+    dateModified: data.dateModified?.trim() || undefined,
   };
 }
 

--- a/docs/custom-skills.md
+++ b/docs/custom-skills.md
@@ -259,6 +259,13 @@ then opens a one-file PR adding `controller/src/skills/community/<slug>/SKILL.md
 operator through the normal update path. A skill that carries a `tool.mjs` can't
 be shared this way; use a zip.
 
+The workflow also stamps **provenance** into the frontmatter it writes:
+`submittedBy` (the GitHub login that filed the issue), `dateAdded` (when it first
+entered the catalog), and `dateModified` (each time the PR is refreshed).
+`dateAdded` is preserved across issue edits — only `dateModified` moves — so an
+approved skill keeps its original credit line. The Community modal shows this
+under each entry ("by @who · added … · updated …").
+
 ### Zip export / import
 
 For a direct operator-to-operator handoff, the skill edit sheet has **↓ Export**

--- a/web/components/admin/SkillsPanel.tsx
+++ b/web/components/admin/SkillsPanel.tsx
@@ -44,6 +44,9 @@ interface CommunitySkill {
   cooldown?: string;
   window?: 'any' | 'commute';
   context?: string;
+  submittedBy?: string;  // GitHub login of the contributor who submitted it
+  dateAdded?: string;    // ISO date (YYYY-MM-DD) it first entered the catalog
+  dateModified?: string; // ISO date (YYYY-MM-DD) of the last catalog change
   installed?: boolean;   // a state/skills/<slug>/ folder already exists
   reserved?: boolean;    // slug shadows a built-in kind — can't be installed
 }
@@ -446,6 +449,28 @@ export default function SkillsPanel() {
                     {c.cooldown && <Pill className="text-[8px]">{c.cooldown} cooldown</Pill>}
                   </div>
                   <div className="mt-1 line-clamp-3 text-[12px] leading-[1.6] text-muted">{c.brief}</div>
+                  {(c.submittedBy || c.dateAdded) && (
+                    <div className="mt-1.5 text-[10px] leading-[1.5] text-muted">
+                      {c.submittedBy && (
+                        <>
+                          by{' '}
+                          <a
+                            href={`https://github.com/${c.submittedBy}`}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="font-bold text-vermilion underline decoration-[1.5px] underline-offset-2"
+                          >
+                            @{c.submittedBy}
+                          </a>
+                        </>
+                      )}
+                      {c.submittedBy && c.dateAdded && ' · '}
+                      {c.dateAdded && <>added {c.dateAdded}</>}
+                      {c.dateAdded && c.dateModified && c.dateModified !== c.dateAdded && (
+                        <> · updated {c.dateModified}</>
+                      )}
+                    </div>
+                  )}
                 </div>
                 <div className="flex flex-col items-end gap-2">
                   {c.installed ? (


### PR DESCRIPTION
## What

Community skills submitted via GitHub issue now **remember their origin** once approved and added to the catalog: who submitted them (GitHub user), when they were added, and when they were last modified.

## How

- **`.github/workflows/skill-submission.yml`** — the approval workflow now stamps three provenance keys into the `SKILL.md` frontmatter it generates:
  - `submittedBy` — the issue author's GitHub login (`issue.user.login`)
  - `dateAdded` — set on first creation; **preserved across issue re-edits** by reading the branch's existing copy, so an approved skill keeps its original added-date
  - `dateModified` — advances to today on every refresh
- **`controller/src/skills/loader.ts`** — `CommunitySkill` gains the three optional fields; `readCommunityDir` parses them defensively (absent on hand-added / pre-provenance entries → `undefined`). The `GET /dj/skills/community` route already spreads the whole object, so no route change was needed.
- **`web/components/admin/SkillsPanel.tsx`** — the Community modal shows a credit line under each entry: *by @who · added <date> · updated <date>*, with `@who` linking to the contributor's GitHub profile. Degrades gracefully when fields are absent.
- Backfilled the two shipped seed entries (`micro-poem`, `mixtape-memory`) with accurate provenance from git history.
- Added a transparency note to the issue template's contribution terms and documented the flow in `docs/custom-skills.md`.

## Verification

- `npm run lint` (eslint + tsc) passes with **0 errors** for both `controller/` and `web/` (only pre-existing `no-explicit-any` warnings).
- Workflow YAML parses; the embedded github-script JS passes `node --check`.
- Round-trip test: a simulated workflow-rendered `SKILL.md` and both real backfilled files parse into the expected provenance objects, with `dateAdded` preserved (2026-07-01) while `dateModified` moves (2026-07-04).

_Note: this branches from `develop`, where the community-skills feature lives (it is not yet on `main`)._