### PR TITLE
fix(state): atomic state-dir writes, log/archive retention, now-playing cache

### DIFF
--- a/controller/src/audio/piper.ts
+++ b/controller/src/audio/piper.ts
@@ -80,14 +80,18 @@ export async function speak(
   });
 }
 
-// Clean up old voice files (call periodically)
+// Clean up old voice files (call periodically). Per-file try/catch: a WAV
+// removed concurrently between readdir and stat (ENOENT) must not abort the
+// sweep and leave the rest of the stale files unreaped until the next hour.
 export async function cleanupOldVoices(maxAgeMs = 60 * 60 * 1000) {
   const files = await readdir(config.piper.outDir);
   const now = Date.now();
   for (const f of files) {
     const fp = path.join(config.piper.outDir, f);
-    const s = await stat(fp);
-    if (now - s.mtimeMs > maxAgeMs) await unlink(fp);
+    try {
+      const s = await stat(fp);
+      if (now - s.mtimeMs > maxAgeMs) await unlink(fp);
+    } catch {}
   }
 }
 

--- a/controller/src/broadcast/archives.ts
+++ b/controller/src/broadcast/archives.ts
@@ -88,6 +88,43 @@ export function openStream(abs: string) {
   return createReadStream(abs);
 }
 
+// Retention sweep — delete whole day directories older than `days`. 0 (the
+// default setting) means keep forever, and callers gate on that before calling.
+// Day-granular on purpose: comparing the YYYY-MM-DD directory name against a
+// cutoff date can never touch the file Liquidsoap currently holds open (today's
+// dir is always inside any positive retention window). `.ndignore` and anything
+// else at the root is untouched, same as clearAll below.
+export async function pruneOlderThan(days: number): Promise<{ removed: number; bytes: number }> {
+  if (!Number.isFinite(days) || days <= 0) return { removed: 0, bytes: 0 };
+  if (!existsSync(ARCHIVE_ROOT)) return { removed: 0, bytes: 0 };
+  const cutoff = new Date(Date.now() - days * 86_400_000).toISOString().slice(0, 10);
+  let dayDirs: string[] = [];
+  try {
+    dayDirs = (await readdir(ARCHIVE_ROOT)).filter(d => DATE_RE.test(d) && d < cutoff);
+  } catch {
+    return { removed: 0, bytes: 0 };
+  }
+
+  let removed = 0;
+  let bytes = 0;
+  for (const date of dayDirs) {
+    const dir = join(ARCHIVE_ROOT, date);
+    try {
+      for (const f of await readdir(dir)) {
+        if (!HOUR_RE.test(f)) continue;
+        try {
+          const st = await stat(join(dir, f));
+          if (st.isFile()) { removed += 1; bytes += st.size; }
+        } catch {}
+      }
+    } catch {}
+    try {
+      await rm(dir, { recursive: true, force: true });
+    } catch {}
+  }
+  return { removed, bytes };
+}
+
 // Delete every hourly recording under the archive root. Only YYYY-MM-DD day
 // directories are removed — anything else in the tree (notably the `.ndignore`
 // the broadcast entrypoint drops here to keep these mixdowns out of a

--- a/controller/src/broadcast/jingles.ts
+++ b/controller/src/broadcast/jingles.ts
@@ -10,6 +10,7 @@ import { existsSync } from 'node:fs';
 import crypto from 'node:crypto';
 import { speak } from '../audio/tts.js';
 import { STATE_DIR } from '../config.js';
+import { writeFileAtomic } from '../util/atomic-file.js';
 import {
   transcodeAudio, hasFfmpeg, extOf, baseName, isAcceptedAudio,
 } from '../audio/audio-import.js';
@@ -33,12 +34,14 @@ async function loadMeta(): Promise<any> {
 }
 
 async function saveMeta(meta: any) {
-  await writeFile(META, JSON.stringify(meta, null, 2));
+  await writeFileAtomic(META, JSON.stringify(meta, null, 2));
 }
 
+// Atomic replace: Liquidsoap watches jingles.m3u (reload_mode="watch"), so an
+// in-place rewrite can reload a truncated playlist mid-write.
 async function rewritePlaylist(filenames: string[]) {
   const lines = filenames.map((f: string) => `${DIR}/${f}`);
-  await writeFile(PLAYLIST, lines.join('\n') + (lines.length ? '\n' : ''));
+  await writeFileAtomic(PLAYLIST, lines.join('\n') + (lines.length ? '\n' : ''));
 }
 
 async function statOrNull(p: string) {

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -2,10 +2,11 @@
 // to the file Liquidsoap watches. A now-playing watcher rotates items
 // between upcoming → current → history based on what Liquidsoap reports.
 
-import { writeFile, readFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { existsSync, readFileSync, openSync, readSync, closeSync, statSync } from 'node:fs';
-import { stat, rename } from 'node:fs/promises';
+import { stat } from 'node:fs/promises';
 import { config } from '../config.js';
+import { writeFileAtomic } from '../util/atomic-file.js';
 import * as subsonic from '../music/subsonic.js';
 import * as mix from '../music/mix.js';
 import * as library from '../music/library.js';
@@ -97,6 +98,8 @@ class Queue {
   history: any[] = [];         // finished tracks, newest first
   djLog: any[] = [];           // controller-level events for the web UI
   lastSeenKey: string | null = null;   // for change detection in the watcher
+  _nowPlaying: any = null;             // last parse of now-playing.json, refreshed by the watcher
+  _nowPlayingFresh = false;            // true once the watcher's first tick has landed
   senderBusy = false;          // drain-to-Liquidsoap mutex
   pickerBusy = false;          // prevent concurrent LLM picks
   autoPick = true;             // toggle: should we ask Ollama for next track when idle
@@ -120,7 +123,7 @@ class Queue {
     this._persistTimer = setTimeout(async () => {
       this._persistTimer = null;
       try {
-        await writeFile(config.queue.file, JSON.stringify({
+        await writeFileAtomic(config.queue.file, JSON.stringify({
           upcoming: this.upcoming,
           current: this.current,
           history: this.history,
@@ -140,7 +143,7 @@ class Queue {
     this._recentPlaysTimer = setTimeout(async () => {
       this._recentPlaysTimer = null;
       try {
-        await writeFile(config.queue.recentPlaysFile,
+        await writeFileAtomic(config.queue.recentPlaysFile,
           JSON.stringify(this._recentPlays, null, 2));
       } catch (err: any) {
         console.error('[queue] recent-plays persist failed:', err.message);
@@ -1254,12 +1257,17 @@ class Queue {
     return out;
   }
 
-  // Poll now-playing.json every 1.5s and dispatch track changes
+  // Poll now-playing.json every 1.5s and dispatch track changes. Each tick
+  // also refreshes the in-memory copy getNowPlaying() serves, so the
+  // per-listener /now-playing poll never has to touch the disk.
   startWatcher() {
-    setInterval(async () => {
-      const np = await this.getNowPlaying();
-      this.onTrackStarted(np);
-    }, 1500);
+    const tick = async () => {
+      this._nowPlaying = await this.readNowPlayingFromDisk();
+      this._nowPlayingFresh = true;
+      this.onTrackStarted(this._nowPlaying);
+    };
+    void tick();
+    setInterval(tick, 1500);
     this.log('scheduler', 'Now-playing watcher started');
   }
 
@@ -1286,8 +1294,22 @@ class Queue {
     };
   }
 
-  // Read the now-playing JSON Liquidsoap writes
+  // Now-playing as Liquidsoap last reported it. Served from the watcher's
+  // in-memory copy: every listener polls /now-playing every ~5s and the
+  // watcher already re-reads the file every 1.5s, so a per-request disk
+  // read + parse buys nothing. Falls back to a direct read until the first
+  // watcher tick lands (or when the watcher was never started, e.g. one-off
+  // scripts). Returns a copy — callers (routes/public.ts) enrich the object
+  // in place and must not leak those fields into the shared cache.
   async getNowPlaying() {
+    const np = this._nowPlayingFresh
+      ? this._nowPlaying
+      : await this.readNowPlayingFromDisk();
+    return np ? { ...np } : null;
+  }
+
+  // Read the now-playing JSON Liquidsoap writes
+  async readNowPlayingFromDisk() {
     try {
       const raw = await readFile(config.liquidsoap.nowPlayingFile, 'utf8');
       return JSON.parse(raw);
@@ -1392,8 +1414,7 @@ async function writeHandoff(path: string, contents: string, { maxWaitMs = 1500 }
       // half-written (or truncated-but-empty) file — its poll handlers read,
       // DELETE, then check non-empty, so a poll landing mid-write would drop
       // this handoff silently. rename(2) is atomic on the same volume.
-      await writeFile(`${path}.tmp`, contents);
-      await rename(`${path}.tmp`, path);
+      await writeFileAtomic(path, contents);
     });
   // Hold the slot until liquidsoap consumes THIS write too, so the next
   // queued writer waits for the audio to land, not just for the write call to

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -5,8 +5,8 @@
 //   - agentic segment tick (weather, news, now-playing digs, facts, web search) every 5 min
 
 import cron from 'node-cron';
-import { writeFile } from 'node:fs/promises';
 import { config } from '../config.js';
+import { writeFileAtomic } from '../util/atomic-file.js';
 import * as subsonic from '../music/subsonic.js';
 import * as dj from '../llm/dj.js';
 import * as library from '../music/library.js';
@@ -23,7 +23,8 @@ import { shouldFire } from './dj-gate.js';
 import { djCallsAllowed } from './listeners.js';
 import { optionalSegmentsAllowed } from './dj-budget.js';
 import { agenticTick, skillCatalog } from '../skills/_agent.js';
-import { withTrace } from '../observability/events.js';
+import { withTrace, pruneOldEvents } from '../observability/events.js';
+import * as archives from './archives.js';
 import * as doctor from '../doctor.js';
 
 const TARGET_POOL = 30;
@@ -295,7 +296,9 @@ async function refreshAutoPlaylistInner() {
   // pure on-air cue_out cut, not a selection filter, so over-length tracks stay
   // in the pool and simply crossfade out at the cap when the queue runs dry.
   const lines = ['#EXTM3U', ...pool.map((t: any) => subsonic.getAnnotatedUri(t, { maxDurationSec }))];
-  await writeFile(config.liquidsoap.autoPlaylist, lines.join('\n'));
+  // Atomic replace: Liquidsoap watches this file (reload_mode="watch"), so an
+  // in-place write can trigger a reload that loads a truncated playlist.
+  await writeFileAtomic(config.liquidsoap.autoPlaylist, lines.join('\n'));
 
   // Make the show-scoping visible to the operator (acceptance criteria #629):
   // a misspelled / absent strict genre that silently degraded, and a strict show
@@ -476,6 +479,28 @@ async function cleanup() {
     library.checkpoint();
   } catch (err) {
     queue.log('error', `Library WAL checkpoint failed: ${err.message}`);
+  }
+  // Drop event day-files past the retention horizon — the JSONL timeline
+  // rotates daily but nothing ever deleted old days.
+  try {
+    const removed = await pruneOldEvents();
+    if (removed) queue.log('scheduler', `Cleanup: pruned ${removed} old event log file(s)`);
+  } catch (err) {
+    queue.log('error', `Event log prune failed: ${err.message}`);
+  }
+  // Archive retention — delete hourly recordings older than the operator's
+  // window. 0 (the default) keeps everything, matching prior behaviour.
+  try {
+    const days = settings.get().archive?.retentionDays || 0;
+    if (days > 0) {
+      const { removed, bytes } = await archives.pruneOlderThan(days);
+      if (removed) {
+        queue.log('scheduler',
+          `Archive retention: removed ${removed} recording(s) older than ${days}d (${Math.round(bytes / 1_000_000)} MB freed)`);
+      }
+    }
+  } catch (err) {
+    queue.log('error', `Archive retention failed: ${err.message}`);
   }
 }
 

--- a/controller/src/broadcast/session.ts
+++ b/controller/src/broadcast/session.ts
@@ -15,15 +15,23 @@
 //   - The live session is persisted to state/session.json; archived sessions
 //     land in state/sessions/<id>.json on roll.
 
-import { writeFile, readFile, mkdir } from 'node:fs/promises';
+import { readFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
 import { config } from '../config.js';
+import { writeFileAtomic } from '../util/atomic-file.js';
 import * as settings from '../settings.js';
 import { logEvent } from '../observability/events.js';
 
 const MAX_SESSION_MS = 4 * 60 * 60 * 1000;  // safety cap — roll even if key is stable
-const WINDOW_TURNS = 40;                    // turns fed to the agent (full log is kept)
+const WINDOW_TURNS = 40;                    // turns fed to the agent
+// Hard bound on the messages array. A normal 4h session generates a few
+// hundred turns, so this never trims in practice — it exists because persist()
+// rewrites the whole array on every turn (1s debounce), and an unbounded array
+// makes that O(n²) over the session (and lets a pathological session grow
+// session.json without limit). Far above WINDOW_TURNS and everything
+// buildHandoff reads, so trimming is invisible to the agent.
+const MAX_TURNS = 500;
 const RATIONALE_WINDOW = 3;                 // most-recent dj/pick reasons kept in the window (anti-thread-momentum)
 const PERSIST_DEBOUNCE_MS = 1000;
 
@@ -95,7 +103,9 @@ function buildHandoff(prev: any) {
 async function persist() {
   if (!_session) return;
   try {
-    await writeFile(config.session.currentFile, JSON.stringify(_session, null, 2));
+    // Atomic replace — /debug and boot recovery read this file, and a crash
+    // mid-write should leave the previous snapshot, not a truncated one.
+    await writeFileAtomic(config.session.currentFile, JSON.stringify(_session, null, 2));
   } catch {}
 }
 
@@ -108,7 +118,7 @@ async function archive(s: any) {
   if (!s?.id) return;
   try {
     await mkdir(config.session.dir, { recursive: true });
-    await writeFile(`${config.session.dir}/${s.id}.json`, JSON.stringify(s, null, 2));
+    await writeFileAtomic(`${config.session.dir}/${s.id}.json`, JSON.stringify(s, null, 2));
   } catch {}
 }
 
@@ -122,6 +132,9 @@ export function appendTurn({ role, kind, text, meta = {} }: { role: string; kind
   if (!_session) return null;
   const turn = { t: new Date().toISOString(), role, kind, text: text || '', meta };
   _session.messages.push(turn);
+  if (_session.messages.length > MAX_TURNS) {
+    _session.messages.splice(0, _session.messages.length - MAX_TURNS);
+  }
   schedulePersist();
   return turn;
 }

--- a/controller/src/llm/internal/telemetry/log.ts
+++ b/controller/src/llm/internal/telemetry/log.ts
@@ -6,6 +6,7 @@
 // prompt layer (prompts) can record without an import cycle.
 
 import { appendFile } from 'node:fs/promises';
+import { statSync, renameSync } from 'node:fs';
 import { STATE_DIR } from '../../../config.js';
 import { logEvent, cap } from '../../../observability/events.js';
 import { addDailyUsage } from './budget.js';
@@ -74,8 +75,27 @@ export function record(call: any) {
 // survives, so repeated-pick patterns stay reviewable after the fact.
 // Best-effort: a write failure must never break a pick.
 const PICKS_LOG = `${STATE_DIR}/logs/picks.log`;
+// Rotate to one .old backup at this cap — same policy as subsonic.log and
+// requests.log. Checked on module load and every 500 picks; this was the one
+// append log in the state dir with no size bound at all.
+const PICKS_LOG_MAX_BYTES = 10 * 1024 * 1024;
+
+function maybeRotatePicksLog() {
+  try {
+    if (statSync(PICKS_LOG).size > PICKS_LOG_MAX_BYTES) {
+      renameSync(PICKS_LOG, `${PICKS_LOG}.old`);
+    }
+  } catch {}
+}
+
+maybeRotatePicksLog();
+let _picksSinceRotateCheck = 0;
 
 export function recordPick({ song, reason, source }: { song: any; reason?: string; source?: string }) {
+  if (++_picksSinceRotateCheck >= 500) {
+    _picksSinceRotateCheck = 0;
+    maybeRotatePicksLog();
+  }
   const line = [
     new Date().toISOString(),
     source || '?',

--- a/controller/src/observability/events.ts
+++ b/controller/src/observability/events.ts
@@ -15,7 +15,7 @@
 // Best-effort everywhere: a write failure or a logging bug must never break a
 // broadcast. logEvent swallows its own errors and never throws into callers.
 
-import { appendFile, mkdir } from 'node:fs/promises';
+import { appendFile, mkdir, readdir, unlink } from 'node:fs/promises';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { randomUUID } from 'node:crypto';
 import { STATE_DIR } from '../config.js';
@@ -70,6 +70,36 @@ export function logEvent(type: string, data: any = {}) {
   } catch {
     // Logging must never break a broadcast.
   }
+}
+
+// Delete event day-files older than `maxAgeDays`. Daily rotation means old
+// days are never reopened, but nothing ever removed them either — on a busy
+// station the JSONL files were the biggest unbounded state-dir growth vector.
+// The horizon is generous: recent-plays backfill (queue.ts) needs 2 days and
+// the budget seed (telemetry/budget.ts) needs today only. Called from the
+// hourly scheduler cleanup; best-effort per file so one unlink failure can't
+// stop the sweep.
+export const EVENTS_MAX_AGE_DAYS = 14;
+
+export async function pruneOldEvents(maxAgeDays = EVENTS_MAX_AGE_DAYS): Promise<number> {
+  // Lexicographic compare works because the filename embeds YYYY-MM-DD.
+  const cutoff = new Date(Date.now() - maxAgeDays * 86_400_000).toISOString().slice(0, 10);
+  let removed = 0;
+  let names: string[] = [];
+  try {
+    names = await readdir(LOGS_DIR);
+  } catch {
+    return 0;
+  }
+  for (const name of names) {
+    const m = name.match(/^events-(\d{4}-\d{2}-\d{2})\.jsonl$/);
+    if (!m || m[1] >= cutoff) continue;
+    try {
+      await unlink(`${LOGS_DIR}/${name}`);
+      removed += 1;
+    } catch {}
+  }
+  return removed;
 }
 
 // Run `fn` inside a fresh trace scope. Emits a `trace.start` event up front and

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -7,6 +7,7 @@ import { readFile, writeFile, unlink, readdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
 import { STATE_DIR, config } from './config.js';
+import { writeFileAtomic } from './util/atomic-file.js';
 import { DEFAULT_THEME_ID, isValidThemeId, listThemes } from './themes.js';
 import { isValidTimezone, setStationTimezone, zonedParts } from './time.js';
 
@@ -735,7 +736,10 @@ const DEFAULTS = {
   // container — operators who don't use the archives can switch this off to
   // reclaim that headroom (issue #137). Dropping the bitrate (e.g. 128 → 64
   // mono in a future change) also helps for operators who want the tape.
-  archive: { enabled: true, bitrate: 128 },
+  // retentionDays: hourly recordings older than this many days are deleted by
+  // the scheduler's hourly cleanup. 0 = keep forever — the default, because a
+  // retention default would silently delete archives operators already have.
+  archive: { enabled: true, bitrate: 128, retentionDays: 0 },
   // Secondary Ogg-Opus broadcast mount (/stream.opus). Off by default — only
   // Blink (Chrome/Edge) clients ever select it (web/hooks/usePlayer.ts keeps
   // Safari/iOS/Firefox on MP3), and it adds a continuous Opus encoder + a
@@ -1398,6 +1402,10 @@ export async function load() {
           ? stored.archive.enabled
           : DEFAULTS.archive.enabled,
       bitrate: archiveBitrate,
+      retentionDays:
+        Number.isInteger(stored.archive?.retentionDays) && stored.archive.retentionDays >= 0
+          ? stored.archive.retentionDays
+          : DEFAULTS.archive.retentionDays,
     },
     stream: {
       opusEnabled:
@@ -2314,6 +2322,15 @@ export async function update(patch) {
         restart = true;
       }
     }
+    if (a.retentionDays !== undefined) {
+      const v = parseInt(a.retentionDays, 10);
+      if (!Number.isInteger(v) || v < 0 || v > 3650) {
+        throw new Error('archive.retentionDays must be 0 (keep forever) or 1–3650 days');
+      }
+      // Enforced controller-side (scheduler cleanup), no Liquidsoap file or
+      // restart involved.
+      next.archive.retentionDays = v;
+    }
   }
   if ('stream' in patch) {
     const st = patch.stream || {};
@@ -2957,8 +2974,10 @@ export async function update(patch) {
   // resolveActiveShow / getEffectivePersona / the integrity sweep all
   // continue to work against one merged view.
   const { shows: _shows, schedule: _schedule, ...settingsPersist } = next;
-  await writeFile(SETTINGS_PATH, JSON.stringify(settingsPersist, null, 2));
-  await writeFile(
+  // Atomic replace — a crash mid-write must not take the operator's whole
+  // config (or show schedule) with it.
+  await writeFileAtomic(SETTINGS_PATH, JSON.stringify(settingsPersist, null, 2));
+  await writeFileAtomic(
     SCHEDULE_PATH,
     JSON.stringify({ shows: next.shows, schedule: next.schedule }, null, 2),
   );

--- a/controller/src/setup/config.ts
+++ b/controller/src/setup/config.ts
@@ -11,9 +11,10 @@
 // the runtime admin store, setup-config.json stays the one-shot wizard output.
 
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { STATE_DIR } from '../config.js';
+import { writeFileAtomic } from '../util/atomic-file.js';
 
 const PATH = `${STATE_DIR}/setup-config.json`;
 
@@ -51,7 +52,7 @@ export async function saveSetupConfig(patch: Partial<SetupConfig>): Promise<Setu
     navidrome: { ...(current.navidrome || {}), ...(patch.navidrome || {}) },
   };
   await mkdir(dirname(PATH), { recursive: true });
-  await writeFile(PATH, JSON.stringify(next, null, 2));
+  await writeFileAtomic(PATH, JSON.stringify(next, null, 2));
   return next;
 }
 

--- a/controller/src/setup/secrets.ts
+++ b/controller/src/setup/secrets.ts
@@ -8,8 +8,9 @@
 // pair of surrounding quotes.
 
 import { existsSync } from 'node:fs';
-import { chmod, readFile, writeFile } from 'node:fs/promises';
+import { chmod, readFile } from 'node:fs/promises';
 import { STATE_DIR } from '../config.js';
+import { writeFileAtomic } from '../util/atomic-file.js';
 
 const PATH = `${STATE_DIR}/secrets.env`;
 
@@ -111,7 +112,9 @@ export async function saveSecrets(patch: Record<string, string>): Promise<void> 
     ...Object.entries(current).map(([k, v]) => `${k}=${envEscape(v)}`),
     '',
   ].join('\n');
-  await writeFile(PATH, body);
+  // Atomic replace, created 0600 — the temp file never exists with looser
+  // permissions, and a crash mid-write can't truncate existing secrets.
+  await writeFileAtomic(PATH, body, { mode: 0o600 });
   await chmod(PATH, 0o600);
   // Only now — after the file is safely on disk — mutate the live process env,
   // so any subsequent AI SDK call sees the new key without a restart. Doing this

--- a/controller/src/util/atomic-file.ts
+++ b/controller/src/util/atomic-file.ts
@@ -1,0 +1,28 @@
+// Atomic file replacement — write to a temp file beside the target, then
+// rename(2) over it, so no reader ever observes a half-written file.
+//
+// Two reader populations make this matter:
+//   - Liquidsoap consumes several state files the controller writes (auto.m3u
+//     via reload_mode="watch", the next/say/intro/sfx handoffs via a
+//     read-delete poll) — a poll or inotify event landing mid-write would see
+//     a truncated file.
+//   - Durable JSON (settings.json, session.json, queue.json, …) survives a
+//     crash or power loss mid-write only if the old contents stay intact
+//     until the new ones are fully on disk.
+//
+// The temp name carries a random suffix so two un-serialised writers to the
+// same path can't rename each other's half-written temp into place. The temp
+// lives next to the target, so the rename never crosses a filesystem boundary.
+
+import { randomBytes } from 'node:crypto';
+import { rename, writeFile } from 'node:fs/promises';
+
+export async function writeFileAtomic(
+  path: string,
+  contents: string | Buffer,
+  { mode }: { mode?: number } = {},
+): Promise<void> {
+  const tmp = `${path}.${randomBytes(4).toString('hex')}.tmp`;
+  await writeFile(tmp, contents, mode != null ? { mode } : {});
+  await rename(tmp, path);
+}

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -1103,7 +1103,11 @@ def on_meta(m) =
       filename = filename,
       timestamp = ts
     })
-    file.write(data=payload, "/var/sub-wave/now-playing.json")
+    # atomic=true (temp file + rename) — the controller re-reads this file
+    # every 1.5s and per /now-playing request, and its reader treats ANY parse
+    # failure as null; an in-place truncate-then-write here made it possible to
+    # observe a half-written JSON and blank the now-playing data for a tick.
+    file.write(data=payload, atomic=true, "/var/sub-wave/now-playing.json")
     # Push the same metadata onto the Icecast stream so the ICY title
     # tracks the current song instead of lagging a transition behind.
     radio.insert_metadata([
@@ -1365,6 +1369,13 @@ def stream_down() =
     fn = stream_shutdown()
     fn()
     stream_on := false
+    # Off air — drop now-playing.json so the UI stops advertising the last
+    # track that played. on_meta rewrites it as soon as we're back on air and
+    # the next track's metadata fires; the controller reads a missing file as
+    # "nothing playing".
+    if file.exists("/var/sub-wave/now-playing.json") then
+      file.remove("/var/sub-wave/now-playing.json")
+    end
   end
 end
 

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -215,6 +215,7 @@ interface ScrobbleForm {
 interface ArchiveForm {
   enabled: boolean;
   bitrate: string;
+  retentionDays: string;
 }
 
 interface StreamForm {
@@ -287,7 +288,7 @@ interface SettingsData {
     crossfadeDuration?: number;
     maxTrackSeconds?: number;
     minTrackSeconds?: number;
-    archive?: { enabled?: boolean; bitrate?: number };
+    archive?: { enabled?: boolean; bitrate?: number; retentionDays?: number };
     stream?: {
       opusEnabled?: boolean;
       opusBitrate?: number;
@@ -442,6 +443,7 @@ export default function SettingsPanel() {
       archive: {
         enabled: v.archive?.enabled ?? true,
         bitrate: String(v.archive?.bitrate ?? 128),
+        retentionDays: String(v.archive?.retentionDays ?? 0),
       },
       stream: {
         opusEnabled: v.stream?.opusEnabled ?? true,
@@ -936,6 +938,45 @@ export default function SettingsPanel() {
                       Lower bitrate = smaller archives, less encoder CPU
                       (current: {data?.values?.archive?.bitrate ?? '—'} kbps). 128 kbps is the
                       original default.
+                    </div>
+                  </div>
+
+                  <div className="field">
+                    <Label>Keep recordings for</Label>
+                    <div className="flex items-center gap-2">
+                      <Input
+                        className="mono-num w-28"
+                        type="number"
+                        min={0}
+                        max={3650}
+                        step={1}
+                        value={form.archive.retentionDays}
+                        onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                          setForm(f =>
+                            f
+                              ? { ...f, archive: { ...f.archive, retentionDays: e.target.value } }
+                              : f,
+                          )
+                        }
+                      />
+                      <span className="text-[12px] text-muted">days</span>
+                      <Btn
+                        sm
+                        onClick={() =>
+                          saveSettings({
+                            archive: { retentionDays: parseInt(form.archive.retentionDays, 10) },
+                          })
+                        }
+                        disabled={busy}
+                      >
+                        Save retention
+                      </Btn>
+                    </div>
+                    <div className="field-hint">
+                      0 = keep forever (the default). With a window set, the hourly cleanup
+                      deletes whole days of recordings once they age past it — at 128 kbps the
+                      archive grows ~1.4 GB per day, so an unbounded archive eventually fills
+                      the disk. Applies live, no restart.
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

State-dir I/O hardening, from an audit of every read/write against the shared `state/` volume. Nine fixes in three groups:

### Write-atomicity (partial-read / crash-corruption races)
- **New `controller/src/util/atomic-file.ts`** — `writeFileAtomic()` (write temp beside target + `rename(2)`, optional `mode`), adopted by every load-bearing persister: `settings.json` + `schedule.json`, `session.json` + session archives, `queue.json`, `recent-plays.json`, `jingles.m3u`/`jingles.json`, `auto.m3u`, `setup-config.json`, `secrets.env` (temp created 0600 so the file never exists with looser perms), and the existing Liquidsoap handoff writer (same pattern, now shared).
- **`auto.m3u` / `jingles.m3u`** were rewritten in place while Liquidsoap watches them (`reload_mode="watch"`) — an inotify reload landing mid-write could load a truncated playlist. This was the same race `writeHandoff` already guarded for `next.txt`/`say.txt`.
- **`radio.liq`: `now-playing.json`** now written with `file.write(atomic=true, …)` — the controller re-reads it every 1.5s and treats any parse failure as `null`, so the in-place truncate-then-write could blank now-playing for a tick on every track change.

### Retention (unbounded state-dir growth)
- **`events-*.jsonl`** day files pruned after 14 days (`pruneOldEvents`, wired into the hourly scheduler cleanup). Previously never deleted — the biggest steady growth vector.
- **`picks.log`** rotates to one `.old` at 10MB, same policy as `subsonic.log`/`requests.log` (it was the only unbounded append log left).
- **`archive.retentionDays`** setting (0 = keep forever, the default — a retention default would silently delete existing archives). Enforced day-granular in the hourly cleanup via `archives.pruneOlderThan()`; new field in admin → Archives. Applies live, no mixer restart.

### Perf / robustness
- **`/now-playing`** served from the watcher's in-memory copy (refreshed every 1.5s) instead of a disk read + `JSON.parse` per listener poll (every listener, every ~5s). Returns a copy so the route's DB enrichment can't leak into the cache.
- **`session.json`** messages capped at 500 turns — `persist()` rewrites the whole array on every turn (1s debounce), so an unbounded array made that O(n²) over a session. A normal 4h session generates a few hundred turns, so the cap never trims in practice.
- **`stream_off`** now removes `now-playing.json` so the UI stops advertising the last-played track while off air.
- **`cleanupOldVoices`**: per-file try/catch — one concurrently-deleted WAV no longer aborts the hourly sweep.

## Verification
- `controller`: `eslint` 0 errors + `tsc --noEmit` clean
- `web`: `eslint` 0 errors + `tsc --noEmit` clean
- `radio.liq`: `liquidsoap --check` passes (savonet/liquidsoap:v2.4.4)
- Runtime exercise via tsx: atomic write round-trips with no leftover `.tmp`, `mode: 0o600` honored on `secrets.env`, `pruneOldEvents(14)` removed a 33-day-old day file and kept today's

## Notes for review
- `liquidsoap_*.txt` writes stay plain `writeFile` on purpose — read once at Liquidsoap startup, no concurrent reader.
- Rotation of Liquidsoap's own `radio.log` (boot-only today) was deliberately left out of scope, per discussion.