### PR TITLE
docs(news): skill-sharing dispatch + refresh manual skills page

### DIFF
--- a/web/components/manual/CustomSkills.tsx
+++ b/web/components/manual/CustomSkills.tsx
@@ -67,6 +67,7 @@ name: moon-phase          # the slug (defaults to the folder name)
 label: Moon phase         # label shown in admin (defaults to a title-cased name)
 cooldown: 6h              # min gap between auto firings — "90m" | "6h" | "2d" | "45" (minutes)
 window: any               # "any" (default) | "commute" — commute hours only
+context: time, festival   # OPTIONAL: "right now" fields it may mention (see below)
 requiresKey: SOME_API_KEY # OPTIONAL: env var the skill needs; unset → stays inert
 ---
 If tonight's moon is at a notable phase, work it into one short, in-character
@@ -78,6 +79,17 @@ the phase is unremarkable.`}</CodeBlock>
           <em>edits</em> that one instead (see below). Bad frontmatter is logged and
           skipped, and never crashes the station.
         </p>
+        <p className="text-muted">
+          <code className="bs-code-inline">context:</code> is an allow-list of the &ldquo;right
+          now&rdquo; fields the DJ may weave in — <code className="bs-code-inline">date</code>,{' '}
+          <code className="bs-code-inline">clock</code>, <code className="bs-code-inline">time</code>,{' '}
+          <code className="bs-code-inline">weather</code>, <code className="bs-code-inline">festival</code>,{' '}
+          <code className="bs-code-inline">show</code>, <code className="bs-code-inline">listeners</code>.
+          Leave it off and the skill gets everything <em>except</em> weather, which stays with
+          the dedicated weather skill so the DJ doesn&rsquo;t staple the forecast to every break.
+          Tick it back on (in the frontmatter, or per-field on the admin Edit sheet) where
+          it&rsquo;s genuinely topical.
+        </p>
       </section>
 
       <section className="bs-section">
@@ -85,14 +97,24 @@ the phase is unremarkable.`}</CodeBlock>
         <h2>The shipped skills are files too.</h2>
         <p>
           The seven built-ins — weather, news, now-playing digs, curiosity, album anniversaries,
-          library deep-cuts, and web search — ship as directories (under{' '}
+          library deep-cuts, and web search — ship as read-only templates (under{' '}
           <code className="bs-code-inline">controller/src/skills/builtins/&lt;kind&gt;/</code>) and
-          load through the same loader as your own. Each is scaffolded into{' '}
-          <code className="bs-code-inline">state/skills/&lt;kind&gt;/SKILL.md</code> the first
-          time the station boots. Editing that (on the admin <strong>Skills</strong> page, or
-          the file directly) overrides its brief, cooldown, context, or label in place — without
-          touching the built-in&rsquo;s <code className="bs-code-inline">tool.mjs</code>, which
-          always runs. An override may leave the body empty to keep the default wording.
+          are seeded into <code className="bs-code-inline">state/skills/&lt;kind&gt;/</code> —
+          both <code className="bs-code-inline">SKILL.md</code> <em>and</em>{' '}
+          <code className="bs-code-inline">tool.mjs</code> — the first time the station boots.
+          From then on they&rsquo;re ordinary editable skills: change the brief, cooldown,
+          context, or label on the admin <strong>Skills</strong> page, and edit the{' '}
+          <code className="bs-code-inline">tool.mjs</code> on disk + Rescan, exactly as you
+          would for a skill you wrote. The seeder never overwrites a file that already exists,
+          so your edits survive restarts and upgrades.
+        </p>
+        <p>
+          A built-in still differs from a skill you add in three ways: it&rsquo;s enabled by
+          default, it can be disabled but not deleted (delete its folder and the seeder
+          restores it on the next boot), and its edit sheet has a{' '}
+          <strong>↺ Reset to default</strong> that overwrites both files from the shipped
+          template — the way back from a broken edit, and the way to pull in a newer
+          image&rsquo;s <code className="bs-code-inline">tool.mjs</code>.
         </p>
         <p>
           The big one: <strong>News reads the BBC by default</strong>. Hit{' '}
@@ -132,18 +154,23 @@ not a newsreader's. Skip anything dull or stale; silence is fine.`}</CodeBlock>
           <code className="bs-code-inline">fetchHeadlines</code>, durable{' '}
           <code className="bs-code-inline">recall</code> — so a custom skill can reach as far as a built-in.
         </p>
-        <CodeBlock>{`export default async function (ctx, state, services, config) {
+        <CodeBlock>{`export default async function (ctx, state, services, config, input) {
   // ctx      — the moment: { time, weather, festival, dominantMood, clock }
   // state    — cross-tick memory (persists between firings)
   // services — the station facade (searchWeb, library, nowPlaying, onThisDay…)
   // config   — this skill's own SKILL.md frontmatter
+  // input    — the agent's values for your declared inputs ({} if none)
   const artist = services.nowPlaying()?.artist;
   if (!artist) return { available: false };
   return { available: true, artist };
 }
 
 // OPTIONAL: gate the skill on a runtime condition (e.g. a search provider).
-export const ready = (services) => services.searchReady();`}</CodeBlock>
+export const ready = (services) => services.searchReady();
+
+// OPTIONAL: agent-steerable string params — the agent may pass a value or
+// null for each; without this the tool is zero-arg (best for small models).
+export const inputs = { query: 'what to search for; null for the default dig' };`}</CodeBlock>
         <p>
           The call is timeout-guarded and any error degrades cleanly to &ldquo;no
           data&rdquo;; a slow or broken skill can never hang the station. With no{' '}
@@ -168,7 +195,9 @@ export const ready = (services) => services.searchReady();`}</CodeBlock>
           prompt-only skill (no <code className="bs-code-inline">tool.mjs</code>) grows a{' '}
           <strong>Share to community</strong> button. It opens a prefilled GitHub issue; a
           workflow checks the slug and frontmatter and opens a one-file PR. Once that&rsquo;s
-          merged the skill ships in the next controller image, so any station can pick it up.
+          merged the skill ships in the next controller image, so any station can pick it up —
+          with your GitHub handle and the dates stamped on it (the Community list shows
+          &ldquo;by @who · added · updated&rdquo; under each entry).
         </p>
         <p>
           The other direction is the <strong>Community</strong> button next to{' '}

--- a/web/content/news/2026-07-04-pass-a-skill-along.md
+++ b/web/content/news/2026-07-04-pass-a-skill-along.md
@@ -1,0 +1,26 @@
+---
+title: Pass a skill to another station
+date: 2026-07-04
+category: Feature
+version: v0.35.0
+author: The SUB/WAVE desk
+excerpt: Skills can move between stations now. Browse the community catalog in admin, share your own with one button, or hand a zip straight to another operator.
+---
+
+You spent three evenings getting a skill's brief just right, and now the DJ lands the line every time. Until now, the only way to give that to a friend's station was to paste the file into a chat and hope they dropped it in the right folder. Skills travel properly now, three ways.
+
+## Take one from the catalog
+
+The admin Skills page has a Community button, next to New skill. It opens a catalog of skills other operators have contributed, shipped inside the controller image, with a credit line under each one (who wrote it, when it landed). Hit Install and it copies into `state/skills/` like any skill of your own. It arrives switched off, so you can read the brief before it goes on air. The catalog only carries prompts, never code, so installing one runs nothing.
+
+## Put yours in
+
+A skill with no `tool.mjs` shows a Share to community button on its edit sheet. That opens a prefilled GitHub issue; a check runs on the name and fields, then a one-file pull request appears for review. Once merged, your skill ships in the next release and turns up in everyone's catalog with your GitHub handle on it.
+
+## Or hand over a zip
+
+For a direct handoff, hit Export on the edit sheet and you get a `.zip` of the whole skill. The other operator brings it in with Import .zip in the Community window. A zip can carry a `tool.mjs`, which is code, so this route is for people you trust. The import lands switched off, and the page flags it when there is a tool inside. Read it before you flip it on.
+
+## Why it bothers
+
+The bits between tracks are where a station gets its personality, and a good brief takes real fiddling to get right. Two community skills are in the catalog already: a two-line micro-poem sparked by the moment, and a warm aside about taping songs off the radio. There's room next to them.


### PR DESCRIPTION
## What

Two docs pieces around the skill-sharing feature set (#782, #847):

**New dispatch** `web/content/news/2026-07-04-pass-a-skill-along.md` — "Pass a skill to another station", serving at `/news/pass-a-skill-along`. Covers the three sharing paths: the community catalog (Install, disabled on arrival, prompt-only), Share to community (issue form → one-file PR → ships with provenance credit), and zip export/import (with the a-zip-can-carry-code caveat). Draft was run through the humanizer pass per the dispatch skill.

**Manual page refresh** `web/components/manual/CustomSkills.tsx` — the built-ins section still described the pre-seeding model (SKILL.md-only scaffold, "tool.mjs always runs"). Updated to match `docs/custom-skills.md` and the code:
- built-ins seed **both** SKILL.md and tool.mjs as editable files; seeder never clobbers; ↺ Reset to default restores both
- frontmatter example gains `context:` plus a short field guide (the #471 no-weather default)
- tool.mjs example gains the 5th `input` arg and the `inputs` export
- sharing section mentions the provenance credit line ("by @who · added · updated")

## Verify

`cd web && npm run lint && npm run build` — clean (2 pre-existing warnings); `/news/pass-a-skill-along` prerenders and all `/manual/*` pages build.