### PR TITLE
feat(landing): point bottom CTA to stations page

### DIFF
--- a/web/components/what/Coda.tsx
+++ b/web/components/what/Coda.tsx
@@ -12,7 +12,7 @@ export default function Coda() {
       </p>
 
       <div className="mt-2 flex flex-wrap items-center justify-center gap-4">
-        <Link href="/listen" className="bs-tune">▶ Open the player</Link>
+        <Link href="/stations" className="bs-tune">▶ Browse the stations</Link>
         <Link href="/setup" className="bs-link text-[13px] font-bold tracking-[0.12em] uppercase">
           Run your own station →
         </Link>


### PR DESCRIPTION
## What

The landing page's bottom call-to-action button in the Coda section pointed to `/listen` ("▶ Open the player"). It now points to `/stations` ("▶ Browse the stations").

## Why

Requested: the prominent bottom button should take visitors to the stations directory rather than straight into the player.

## Notes

- Single-line change in `web/components/what/Coda.tsx`.
- `/stations` is an existing route (already linked from the footer).
- Relabeled the button so the destination matches the text.