### PR TITLE
feat(web): public community-skills showcase page + footer link

### DIFF
--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -14,6 +14,7 @@ import { getStreamStatus } from '../broadcast/listeners.js';
 import { getSetupStatusSync } from '../setup/firstRun.js';
 import { getStationTimezone } from '../time.js';
 import { listThemesAnnotated, DEFAULT_THEME_ID } from '../themes.js';
+import { listCommunitySkills } from '../skills/loader.js';
 import { lifetimeTokenCount } from '../llm/log.js';
 
 export const router = express.Router();
@@ -444,6 +445,26 @@ router.get('/session', (req, res) => {
     },
     messages: s.messages.filter(m => m.kind !== 'sfx').slice(-120),
   });
+});
+
+// ---------------------------------------------------------------------------
+// GET /skills/community — the shipped community skill catalog (prompt-only DJ
+// segments contributed via the community-submission flow, COPYd into the
+// image). Browse-only public reference: the same catalog the admin Skills →
+// Community modal installs from, minus the per-station `installed`/`reserved`
+// annotations (those are meaningful only inside a specific station's admin).
+// Powers the public /skills showcase page. Never throws — an empty catalog
+// (no community/ dir shipped) returns []. No admin gate: it's static shipped
+// data, identical across every install of the same version.
+// ---------------------------------------------------------------------------
+router.get('/skills/community', async (req, res) => {
+  try {
+    const community = await listCommunitySkills();
+    res.json({ community });
+  } catch (err) {
+    queue.log('error', `/skills/community failed: ${err.message}`);
+    res.status(500).json({ error: err.message });
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4069,6 +4069,79 @@ html.lite *::after {
     min-width: 0;
 }
 
+/* Community-skill card — same newspaper-run column as the station grid, but a
+   text-first entry: title + cadence, the DJ brief, context tags, credit line.
+   Reuses .bs-stations-grid for layout. */
+.bs-skill-card {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-top: 20px;
+    border-top: 1px solid var(--separator-strong);
+    min-width: 0;
+}
+.bs-skill-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+}
+.bs-skill-name {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(19px, 2vw, 24px);
+    font-weight: 800;
+    letter-spacing: -0.01em;
+    line-height: 1.05;
+}
+.bs-skill-cadence {
+    flex: none;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+.bs-skill-brief {
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--muted);
+}
+.bs-skill-tags {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+.bs-skill-tag {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--muted);
+    border: 1px solid var(--separator-strong);
+    padding: 3px 7px;
+}
+.bs-skill-credit {
+    margin: 2px 0 0;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+.bs-skill-credit-link {
+    font-weight: 700;
+    color: var(--accent);
+    text-decoration: underline;
+    text-decoration-thickness: 1.5px;
+    text-underline-offset: 2px;
+}
+
 /* Live strip — ON AIR + current track, or Offline / Checking. */
 .bs-station-live {
     display: flex;

--- a/web/app/skills/layout.tsx
+++ b/web/app/skills/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import Masthead from '@/components/landing/Masthead';
+import StationFooter from '@/components/landing/StationFooter';
+
+export const metadata: Metadata = {
+  title: 'SUB/WAVE — Community Skills',
+  description:
+    'The community skill catalog for SUB/WAVE — prompt-only DJ segments shared by other stations, installable from any station&rsquo;s admin console.',
+};
+
+// Shared chrome for the /skills showcase: the broadsheet masthead, the page
+// body in the single full-width broadsheet column, and the station footer.
+// Mirrors app/stations/layout.tsx (via StationsShell) but inlined here since
+// the skills page is the only route under it.
+export default function SkillsLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-bg text-ink">
+      <Masthead />
+      <main className="bs-paper">
+        {children}
+        <StationFooter />
+      </main>
+    </div>
+  );
+}

--- a/web/app/skills/page.tsx
+++ b/web/app/skills/page.tsx
@@ -1,0 +1,83 @@
+import { AnimatedLink } from '@/components/ui/animated-link';
+import CommunitySkillCard from '@/components/skills/CommunitySkillCard';
+import { fetchCommunitySkills } from '@/lib/communitySkills';
+import { pageMeta } from '@/lib/seo';
+
+export const metadata = pageMeta({
+  title: 'SUB/WAVE — Community Skills',
+  description:
+    'The community skill catalog — prompt-only DJ segments shared by other stations. Browse them here, then install any from your station&rsquo;s admin console.',
+  path: '/skills',
+});
+
+// The catalog is baked into the controller image and refreshed on update, so
+// read it live from the local controller at request time rather than at build.
+export const dynamic = 'force-dynamic';
+
+const REPO = 'https://github.com/perminder-klair/subwave';
+// Submission opens a GitHub Issue Form (no fork, no YAML). A workflow turns the
+// issue into a one-file pull request automatically — see
+// .github/workflows/skill-submission.yml. Mirrors the /stations add flow.
+const SUBMIT_URL = `${REPO}/issues/new?template=add-skill.yml`;
+const DOCS_URL = `${REPO}/blob/main/docs/custom-skills.md`;
+
+export default async function CommunitySkillsIndex() {
+  const skills = await fetchCommunitySkills();
+  const count = skills.length;
+
+  return (
+    <article>
+      <header className="bs-news-hero">
+        <p className="bs-eyebrow">THE WORKSHOP</p>
+        <h1>Community Skills.</h1>
+        <p>
+          A skill is an autonomous segment the AI DJ can air between tracks — a short brief
+          telling it what to say, and when to stay quiet. These are shared by the community and
+          ship with every station. Browse them here, then install the ones you like from your
+          own admin console.
+        </p>
+      </header>
+
+      {count > 0 ? (
+        <p className="bs-stat-strip">
+          <span>
+            <strong>{count}</strong> {count === 1 ? 'skill' : 'skills'} in the catalog
+          </span>
+        </p>
+      ) : null}
+
+      <div className="bs-station-cta">
+        <p className="bs-station-cta-copy">Made a segment worth sharing? Add it to the catalog.</p>
+        <AnimatedLink href={SUBMIT_URL} variant="arrow" className="bs-station-cta-link">
+          Share a skill
+        </AnimatedLink>
+        <AnimatedLink href={DOCS_URL} className="bs-station-cta-help">
+          How it works
+        </AnimatedLink>
+      </div>
+
+      {count > 0 ? (
+        <ul className="bs-stations-grid">
+          {skills.map((s) => (
+            <CommunitySkillCard key={s.slug} skill={s} />
+          ))}
+        </ul>
+      ) : (
+        <p className="bs-news-empty">
+          No community skills to show yet — the catalog may still be loading, or this station
+          hasn&rsquo;t shipped one. Be the first to{' '}
+          <AnimatedLink href={SUBMIT_URL} className="bs-link">
+            share a skill
+          </AnimatedLink>
+          .
+        </p>
+      )}
+
+      <p className="bs-stations-report">
+        Installing is a two-tap job in your station&rsquo;s admin: open{' '}
+        <strong>Skills → Community</strong>, then <strong>Install</strong>. Every skill arrives
+        disabled so you can read the brief and enable it on your own terms.
+      </p>
+    </article>
+  );
+}

--- a/web/components/landing/StationFooter.tsx
+++ b/web/components/landing/StationFooter.tsx
@@ -43,6 +43,10 @@ export default function StationFooter({ djName }: { djName?: string }) {
           browse the stations
         </AnimatedLink>{' '}
         ·{' '}
+        <AnimatedLink href="/skills" className="font-semibold tracking-[inherit] text-ink hover:text-vermilion">
+          community skills
+        </AnimatedLink>{' '}
+        ·{' '}
         <AnimatedLink href="/listen" className="font-semibold tracking-[inherit] text-ink hover:text-vermilion">
           open the player
         </AnimatedLink>{' '}

--- a/web/components/skills/CommunitySkillCard.tsx
+++ b/web/components/skills/CommunitySkillCard.tsx
@@ -1,0 +1,56 @@
+import type { CommunitySkill } from '@/lib/communitySkills';
+
+// One card in the /skills showcase grid. Browse-only: it presents a community
+// skill's brief and provenance — installation happens in a station's admin
+// console, not here. Mirrors the admin community-modal entry (SkillsPanel) but
+// styled for the public broadsheet.
+export default function CommunitySkillCard({ skill }: { skill: CommunitySkill }) {
+  const contexts = (skill.context || '')
+    .split(',')
+    .map((c) => c.trim())
+    .filter(Boolean);
+
+  return (
+    <li className="bs-skill-card">
+      <div className="bs-skill-head">
+        <h3 className="bs-skill-name">{skill.label}</h3>
+        {skill.cooldown && <span className="bs-skill-cadence">{skill.cooldown} cooldown</span>}
+      </div>
+
+      <p className="bs-skill-brief">{skill.brief}</p>
+
+      {contexts.length > 0 && (
+        <ul className="bs-skill-tags" aria-label="Uses live context">
+          {contexts.map((c) => (
+            <li key={c} className="bs-skill-tag">
+              {c}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {(skill.submittedBy || skill.dateAdded) && (
+        <p className="bs-skill-credit">
+          {skill.submittedBy && (
+            <>
+              by{' '}
+              <a
+                href={`https://github.com/${skill.submittedBy}`}
+                target="_blank"
+                rel="noreferrer"
+                className="bs-skill-credit-link"
+              >
+                @{skill.submittedBy}
+              </a>
+            </>
+          )}
+          {skill.submittedBy && skill.dateAdded && ' · '}
+          {skill.dateAdded && <>added {skill.dateAdded}</>}
+          {skill.dateAdded && skill.dateModified && skill.dateModified !== skill.dateAdded && (
+            <> · updated {skill.dateModified}</>
+          )}
+        </p>
+      )}
+    </li>
+  );
+}

--- a/web/lib/communitySkills.ts
+++ b/web/lib/communitySkills.ts
@@ -1,0 +1,49 @@
+// Server-side lookup of the shipped community skill catalog, used by the public
+// /skills showcase page. Mirrors lib/station.ts: it runs in the Next.js server
+// (the `web` container in prod), NOT the browser, so it reaches the controller
+// directly over the internal compose network rather than through the browser's
+// `/api` Caddy route.
+//   CONTROLLER_INTERNAL_URL (set on the web service in both prod composes)
+//   → http://localhost:7701 (dev fallback: `npm run dev` web runs on the host
+//     and the dev compose binds the controller on 7701).
+const CONTROLLER_BASE = (
+  process.env.CONTROLLER_INTERNAL_URL || 'http://localhost:7701'
+).replace(/\/$/, '');
+
+// One entry in the shipped community catalog (GET /skills/community). Mirrors
+// the controller's CommunitySkill (skills/loader.ts) minus per-station install
+// state — the showcase is browse-only and station-agnostic.
+export interface CommunitySkill {
+  slug: string;
+  label: string;
+  brief: string; // the agent's brief (SKILL.md body)
+  cooldown?: string; // e.g. "6h" — the frontmatter value, verbatim
+  window?: 'any' | 'commute';
+  context?: string; // comma-separated "right now" fields
+  // Provenance stamped by the submission workflow — absent on hand-added or
+  // pre-provenance entries, so every consumer must degrade gracefully.
+  submittedBy?: string; // GitHub login of the contributor who submitted it
+  dateAdded?: string; // ISO date (YYYY-MM-DD) it first entered the catalog
+  dateModified?: string; // ISO date (YYYY-MM-DD) of the last catalog change
+}
+
+interface CommunityResponse {
+  community?: CommunitySkill[];
+}
+
+// Fetch the shipped community catalog from the controller. Returns [] on any
+// failure (controller down, timeout, non-OK, malformed) so the showcase page
+// renders its empty state instead of throwing.
+export async function fetchCommunitySkills(): Promise<CommunitySkill[]> {
+  try {
+    const res = await fetch(`${CONTROLLER_BASE}/skills/community`, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) return [];
+    const data = (await res.json()) as CommunityResponse;
+    return Array.isArray(data?.community) ? data.community : [];
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## What

Adds a dedicated **/skills** page that showcases the shipped **community skill catalog** — the same prompt-only DJ segments the admin *Skills → Community* modal installs from — and links it from the site footer.

Requested: "we have community skills which we install inside admin — can we have a dedicated page for community skills showcase and add its link to the footer."

## Changes

- **Controller** — new public `GET /skills/community` route (`routes/public.ts`) reusing `listCommunitySkills()`. Browse-only, no admin gate (static shipped data, identical across a version); drops the per-station `installed`/`reserved` annotations that only mean something inside a specific station's admin.
- **Web** — new `/skills` route (`force-dynamic`) that fetches the catalog from the controller server-side over `CONTROLLER_INTERNAL_URL` (mirrors `lib/station.ts`, so it works in prod and in `npm run dev`). Broadsheet layout matching `/stations`: hero, skill count, a *Share a skill* CTA pointing at the `add-skill.yml` issue form, and skill cards showing the brief, cooldown, context tags, and `@submitter` provenance credit. Graceful empty state when the controller is down or ships no catalog.
- **Footer** — `community skills` link added between *browse the stations* and *open the player* (`StationFooter`, shown on landing / stations / news / skills).

## Verification

Ran a dev stack from a worktree:
- `GET /skills/community` returns the catalog (`micro-poem`, `mixtape-memory`) ✓
- `/skills` renders 200 with both seed skills, cooldowns, context tags, and the linked `@perminder-klair` credit ✓
- Footer `community skills` link present across pages ✓
- `npm run lint` (eslint + tsc) clean for both `web` and `controller`; `web` production build succeeds ✓

## Notes

- Base is `develop` — the community-skills feature it builds on lives on `develop`, not yet `main`.
- Screenshots of the rendered page available on request.