### PR TITLE
feat(web): "Back Pages" footer index + masthead print-craft & disc-morph wordmark

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1213,6 +1213,62 @@ html.lite *::after {
     text-transform: uppercase;
 }
 
+/* Off-register ink plate behind the nameplate — the vermilion plate printed a
+   hair off-register, the way cheap newsprint presses actually drifted. Em
+   offsets so the drift scales with the clamp()ed wordmark. Hovering the
+   nameplate pulls the plate into perfect register — the press operator's
+   micro-adjust — and reduced-motion readers get the settled plate outright. */
+.bs-wordmark-plate {
+    text-shadow: 0.032em 0.026em 0 color-mix(in oklab, var(--accent) 42%, transparent);
+    transition: text-shadow 280ms ease;
+}
+.bs-wordmark-plate:hover {
+    text-shadow: 0 0 0 color-mix(in oklab, var(--accent) 42%, transparent);
+}
+@media (prefers-reduced-motion: reduce) {
+    .bs-wordmark-plate,
+    .bs-wordmark-plate:hover {
+        text-shadow: none;
+        transition: none;
+    }
+}
+
+/* Motto rule — the line under the nameplate carries the paper's motto (the
+   system's one load-bearing promise) between full-width hairlines, flanked
+   by the ✦ used in the footer's press credit. Replaces the plain .bs-rule
+   in the masthead, so it must keep reading as a rule at a glance. */
+.bs-masthead-motto {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    color: var(--accent);
+    font-size: 9px;
+}
+.bs-masthead-motto::before,
+.bs-masthead-motto::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--ink);
+}
+.bs-masthead-motto-text {
+    color: var(--muted);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+@media (max-width: 560px) {
+    .bs-masthead-motto {
+        gap: 8px;
+    }
+    .bs-masthead-motto-text {
+        font-size: 8px;
+        letter-spacing: 0.14em;
+    }
+}
+
 /* Eyebrow — vermilion small-caps section label, sits above each section. */
 .bs-eyebrow {
     font-size: 10px;

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1233,6 +1233,95 @@ html.lite *::after {
     }
 }
 
+/* Slash → disc morph — hovering the nameplate spins the slash away and the
+   station's disc mark (the .bs-dj-glyph / .player-mark vocabulary) drops
+   into the gap already turning. The slash glyph keeps its box (opacity only)
+   so the nameplate never reflows; the disc is absolutely centred over it and
+   em-sized, so the morph scales with the clamp()ed wordmark. The face spins
+   on its own inner element — the outer element owns the scale/fade
+   transition, so the two transforms never fight. */
+.bs-wordmark-slash {
+    position: relative;
+    display: inline-block;
+    /* Hover eases SUB and WAVE apart a touch so the disc gets clear air —
+       symmetric padding keeps the mark optically centred while it spreads. */
+    transition: padding 420ms cubic-bezier(0.34, 1.3, 0.4, 1);
+}
+.bs-wordmark-plate:hover .bs-wordmark-slash {
+    padding: 0 0.09em;
+}
+.bs-wordmark-slash-glyph {
+    display: inline-block;
+    transition:
+        opacity 300ms ease,
+        transform 380ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+.bs-wordmark-plate:hover .bs-wordmark-slash-glyph {
+    opacity: 0;
+    transform: rotate(114deg) scale(0.5);
+}
+.bs-wordmark-disc {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 0.56em;
+    height: 0.56em;
+    /* -0.28em centres the box; +0.006em drops it onto the caps' optical
+       centre (baseline minus half the measured cap-ink height). */
+    margin: -0.274em 0 0 -0.28em;
+    transform: scale(0.3);
+    opacity: 0;
+    pointer-events: none;
+    transition:
+        opacity 300ms ease,
+        transform 420ms cubic-bezier(0.34, 1.3, 0.4, 1);
+}
+.bs-wordmark-plate:hover .bs-wordmark-disc {
+    opacity: 1;
+    transform: scale(1);
+}
+.bs-wordmark-disc-face {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    border: 1px solid var(--ink);
+    background: repeating-conic-gradient(
+        from 0deg,
+        var(--ink) 0deg 9deg,
+        transparent 9deg 18deg
+    );
+    position: relative;
+    /* Always turning (it's invisible at rest), so the disc arrives mid-spin
+       instead of starting from a standstill. */
+    animation: bs-dj-spin 4s linear infinite;
+}
+.bs-wordmark-disc-face::after {
+    content: "";
+    position: absolute;
+    inset: 33%;
+    background: var(--accent);
+    border-radius: 50%;
+    box-shadow: 0 0 0 1px var(--bg);
+}
+@media (prefers-reduced-motion: reduce) {
+    /* No morph for reduced-motion readers — the slash simply stays put. */
+    .bs-wordmark-disc {
+        display: none;
+    }
+    .bs-wordmark-slash,
+    .bs-wordmark-plate:hover .bs-wordmark-slash {
+        transition: none;
+        padding: 0;
+    }
+    .bs-wordmark-slash-glyph,
+    .bs-wordmark-plate:hover .bs-wordmark-slash-glyph {
+        transition: none;
+        opacity: 1;
+        transform: none;
+    }
+}
+
 /* Motto rule — the line under the nameplate carries the paper's motto (the
    system's one load-bearing promise) between full-width hairlines, flanked
    by the ✦ used in the footer's press credit. Replaces the plain .bs-rule

--- a/web/components/landing/Masthead.tsx
+++ b/web/components/landing/Masthead.tsx
@@ -15,7 +15,9 @@ function issueNo(d: Date): number {
 // DJ-name strip that belonged on a newspaper but not a marketing site.
 //
 // No motion on the masthead — wordmark and meta row land static. The page's
-// reference frame should feel like print, not a performance.
+// reference frame should feel like print, not a performance. (The wordmark's
+// off-register ink plate settling on hover is the one exception: it only
+// fires on intent, never on load.)
 export default function Masthead() {
   const now = useClock();
 
@@ -33,9 +35,9 @@ export default function Masthead() {
         <Link
           href="/"
           aria-label="SUB/WAVE home"
-          className="bs-wordmark bs-masthead-mark text-ink no-underline"
+          className="bs-wordmark bs-wordmark-plate bs-masthead-mark text-ink no-underline"
         >
-          SUB/WAVE
+          SUB<span className="text-vermilion">/</span>WAVE
         </Link>
 
         <div className="bs-masthead-status flex items-center gap-2 text-[11px] font-bold tracking-[0.3em] uppercase">
@@ -44,7 +46,13 @@ export default function Masthead() {
         </div>
       </div>
 
-      <div className="bs-rule" />
+      <div className="bs-masthead-motto" aria-label="Motto">
+        <span aria-hidden="true">✦</span>
+        <span className="bs-masthead-motto-text">
+          Every listener hears the same broadcast
+        </span>
+        <span aria-hidden="true">✦</span>
+      </div>
 
       <nav aria-label="Primary" className="bs-masthead-nav">
         <AnimatedLink href="/listen" className="bs-masthead-link">

--- a/web/components/landing/Masthead.tsx
+++ b/web/components/landing/Masthead.tsx
@@ -56,7 +56,7 @@ export default function Masthead() {
       <div className="bs-masthead-motto" aria-label="Motto">
         <span aria-hidden="true">✦</span>
         <span className="bs-masthead-motto-text">
-          Every listener hears the same broadcast
+          No skips&nbsp;·&nbsp;No shuffle&nbsp;·&nbsp;No mercy
         </span>
         <span aria-hidden="true">✦</span>
       </div>

--- a/web/components/landing/Masthead.tsx
+++ b/web/components/landing/Masthead.tsx
@@ -37,7 +37,14 @@ export default function Masthead() {
           aria-label="SUB/WAVE home"
           className="bs-wordmark bs-wordmark-plate bs-masthead-mark text-ink no-underline"
         >
-          SUB<span className="text-vermilion">/</span>WAVE
+          SUB
+          <span className="bs-wordmark-slash">
+            <span className="bs-wordmark-slash-glyph text-vermilion">/</span>
+            <span className="bs-wordmark-disc" aria-hidden="true">
+              <span className="bs-wordmark-disc-face" />
+            </span>
+          </span>
+          WAVE
         </Link>
 
         <div className="bs-masthead-status flex items-center gap-2 text-[11px] font-bold tracking-[0.3em] uppercase">

--- a/web/components/landing/Masthead.tsx
+++ b/web/components/landing/Masthead.tsx
@@ -56,7 +56,7 @@ export default function Masthead() {
       <div className="bs-masthead-motto" aria-label="Motto">
         <span aria-hidden="true">✦</span>
         <span className="bs-masthead-motto-text">
-          No skips&nbsp;·&nbsp;No shuffle&nbsp;·&nbsp;No mercy
+          No skips&nbsp;·&nbsp;No shuffle&nbsp;·&nbsp;Just radio
         </span>
         <span aria-hidden="true">✦</span>
       </div>

--- a/web/components/landing/StationFooter.tsx
+++ b/web/components/landing/StationFooter.tsx
@@ -1,19 +1,105 @@
 'use client';
 
+import Link from 'next/link';
+
 import { AnimatedLink } from '@/components/ui/animated-link';
+
+// The Back Pages — the footer as a broadsheet back-page index. Three ruled
+// section panels give the station's secondary destinations (dispatches,
+// stations, skills) real front-of-house billing, then a single colophon
+// strip carries the small print. Copy ends with the press-room "-30-" mark.
+const BACK_PAGES = [
+  {
+    no: '01',
+    tag: 'The Wire',
+    title: 'Dispatches',
+    teaser: 'Field notes, release wires & tales from the press desk.',
+    cta: 'Read the dispatches',
+    href: '/news',
+  },
+  {
+    no: '02',
+    tag: 'The Dial',
+    title: 'Stations',
+    teaser: 'Other SUB/WAVEs broadcasting right now. Spin the dial.',
+    cta: 'Browse the stations',
+    href: '/stations',
+  },
+  {
+    no: '03',
+    tag: 'The Exchange',
+    title: 'Community Skills',
+    teaser: 'Segments operators taught their DJs — take one home.',
+    cta: 'Explore the skills',
+    href: '/skills',
+  },
+] as const;
 
 export default function StationFooter({ djName }: { djName?: string }) {
   return (
-    <footer className="mt-16 flex flex-col gap-[14px]">
+    <footer className="mt-16 flex flex-col">
       <div className="bs-rule-double" />
+
+      <div className="flex items-baseline justify-between gap-4 py-[7px] text-[10px] tracking-[0.3em] text-muted uppercase">
+        <span className="font-bold text-ink">The Back Pages</span>
+        <span className="hidden sm:inline">Reader services · §§ 01–03</span>
+      </div>
+
+      <div className="bs-rule" />
+
+      <nav
+        aria-label="Back pages"
+        className="grid divide-y divide-ink/20 sm:grid-cols-3 sm:divide-x sm:divide-y-0"
+      >
+        {BACK_PAGES.map((page) => (
+          <Link
+            key={page.href}
+            href={page.href}
+            className="group relative flex flex-col gap-[10px] overflow-hidden px-5 py-6 no-underline transition-colors duration-300 hover:bg-ink/[0.04] sm:first:pl-1 sm:last:pr-1"
+          >
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute -top-4 right-1 [font-family:var(--font-display),Georgia,serif] text-[92px] leading-none font-black text-ink/[0.05] transition-colors duration-300 select-none group-hover:text-vermilion/10"
+            >
+              {page.no}
+            </span>
+
+            <span className="flex items-baseline justify-between gap-3 text-[10px] tracking-[0.25em] text-muted uppercase">
+              <span className="font-mono transition-colors duration-300 group-hover:text-vermilion">
+                № {page.no}
+              </span>
+              <span>{page.tag}</span>
+            </span>
+
+            <span className="[font-family:var(--font-display),Georgia,serif] text-[26px] leading-none font-black text-ink italic">
+              {page.title}
+            </span>
+
+            <span className="max-w-[26ch] text-[12.5px] leading-relaxed text-muted">
+              {page.teaser}
+            </span>
+
+            <span className="mt-auto flex items-center gap-[6px] pt-1 text-[10px] font-bold tracking-[0.25em] text-ink uppercase transition-colors duration-300 group-hover:text-vermilion">
+              {page.cta}
+              <span
+                aria-hidden="true"
+                className="transition-transform duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] group-hover:translate-x-[5px]"
+              >
+                →
+              </span>
+            </span>
+          </Link>
+        ))}
+      </nav>
+
+      <div className="bs-rule" />
+
       <div
-        className="flex flex-col items-center gap-2 py-5 text-center text-[11px] tracking-[0.18em] text-muted uppercase
+        className="flex flex-col items-center gap-2 py-5 text-center text-[10px] tracking-[0.22em] text-muted uppercase
           sm:flex-row sm:flex-wrap sm:items-baseline sm:justify-between sm:gap-4 sm:text-left"
       >
         <span className="font-bold text-ink">SUB/WAVE · EST. 2026</span>
-        <span>
-          Navidrome · Liquidsoap · Icecast · your LLM · your voice
-        </span>
+        <span>Navidrome · Liquidsoap · Icecast · your LLM · your voice</span>
         <span>
           {djName ? `${djName} on the desk · ` : ''}
           <AnimatedLink
@@ -33,20 +119,8 @@ export default function StationFooter({ djName }: { djName?: string }) {
           </AnimatedLink>
         </span>
       </div>
-      <div className="pb-[6px] text-center text-[10px] tracking-[0.3em] text-muted uppercase">
-        —{' '}
-        <AnimatedLink href="/news" className="font-semibold tracking-[inherit] text-ink hover:text-vermilion">
-          read the dispatches
-        </AnimatedLink>{' '}
-        ·{' '}
-        <AnimatedLink href="/stations" className="font-semibold tracking-[inherit] text-ink hover:text-vermilion">
-          browse the stations
-        </AnimatedLink>{' '}
-        ·{' '}
-        <AnimatedLink href="/skills" className="font-semibold tracking-[inherit] text-ink hover:text-vermilion">
-          community skills
-        </AnimatedLink>{' '}
-        ·{' '}
+
+      <div className="pb-1 text-center text-[10px] tracking-[0.3em] text-muted uppercase">
         <AnimatedLink href="/listen" className="font-semibold tracking-[inherit] text-ink hover:text-vermilion">
           open the player
         </AnimatedLink>{' '}
@@ -57,9 +131,17 @@ export default function StationFooter({ djName }: { djName?: string }) {
         ·{' '}
         <AnimatedLink href="/terms" className="font-semibold tracking-[inherit] text-ink hover:text-vermilion">
           terms
-        </AnimatedLink>{' '}
-        —
+        </AnimatedLink>
       </div>
+
+      <div
+        className="py-3 text-center font-mono text-[11px] tracking-[0.4em] text-muted select-none"
+        title="End of copy — the old press-room sign-off"
+        aria-hidden="true"
+      >
+        — 30 —
+      </div>
+
       <div className="pb-[6px] text-center text-[10px] tracking-[0.3em] text-balance text-muted uppercase">
         Set in type &amp; sent to press by{' '}
         <AnimatedLink


### PR DESCRIPTION
The landing footer had grown into three rows of tiny uppercase links, with the newer destinations (dispatches, stations, community skills) buried in the small print.

This turns the footer into a proper broadsheet back page:

- **"The Back Pages" index** — three ruled panels (№ 01 The Wire / Dispatches, № 02 The Dial / Stations, № 03 The Exchange / Community Skills), each with a ghost Fraunces numeral, an italic display headline, a one-line teaser, and a small-caps CTA. Whole panel is clickable; hover flushes the numeral, ghost digit, and CTA vermilion and nudges the arrow.
- **One colophon strip** — station line, stack line, GitHub/Discord, then player/privacy/terms on a single quiet row.
- **"— 30 —"** — the traditional press-room end-of-copy mark closes the page, above the klair.co press credit.

`StationFooter` is shared, so News, Stations, Skills, Setup, and Manual pages all pick this up.

Verified by rendering `/landing` from the worktree: light + dark themes, hover state, and 390px mobile (panels stack with hairline dividers). `npm run lint` in `web/` passes (0 errors; the 2 warnings are pre-existing in DoctorPanel).