### PR TITLE
fix(webhooks): gate track.play on listener count

### DIFF
--- a/controller/src/broadcast/listeners.ts
+++ b/controller/src/broadcast/listeners.ts
@@ -181,6 +181,17 @@ export function getListenerCount() {
   return lastCount;
 }
 
+// Fail-closed presence check: the listener count when it is known and > 0,
+// else null. The single definition of "someone is tuned in" for outbound
+// side effects (scrobbles, gated track.play webhooks) — an unknown count
+// must never fire to an empty room. Contrast djCallsAllowed() below, which
+// deliberately fails OPEN so a stats outage can't take the DJ off the air.
+export function presentListeners(): number | null {
+  return typeof lastCount === 'number' && Number.isFinite(lastCount) && lastCount > 0
+    ? lastCount
+    : null;
+}
+
 // Last known stream status, from the same 15s poll. Returns offline + 0/0
 // until the first successful poll — same shape /now-playing always exposed.
 export function getStreamStatus(): StreamStatus {

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -17,7 +17,7 @@ import * as session from './session.js';
 import { getFullContext, energyForDaypart } from '../context.js';
 import * as settings from '../settings.js';
 import { logEvent } from '../observability/events.js';
-import { djCallsAllowed } from './listeners.js';
+import { djCallsAllowed, getListenerCount } from './listeners.js';
 import * as webhooks from './webhooks.js';
 import * as scrobble from './scrobble.js';
 import * as liquidsoapControl from './liquidsoap-control.js';
@@ -982,13 +982,20 @@ class Queue {
     });
 
     // Outbound fan-out — fire-and-forget; never blocks the picker path.
-    webhooks.notify('track.play', {
-      title: this.current.track.title,
-      artist: this.current.track.artist || null,
-      album: this.current.track.album || null,
-      source: this.current.source,
-      requestedBy: this.current.requestedBy || null,
-    });
+    // track.play is listener-gated (fail-closed) like scrobble — see scrobble.ts.
+    const listeners = getListenerCount();
+    if (typeof listeners !== 'number' || listeners <= 0) {
+      console.log(`[webhook] skip track.play: ${listeners ?? 'null'} listener(s)`);
+    } else {
+      webhooks.notify('track.play', {
+        title: this.current.track.title,
+        artist: this.current.track.artist || null,
+        album: this.current.track.album || null,
+        source: this.current.source,
+        requestedBy: this.current.requestedBy || null,
+        listeners,
+      });
+    }
 
     // Last.fm / ListenBrainz — also fire-and-forget. Internally gated on
     // listener count > 0 (fail-closed) and per-backend enable flags.

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -981,20 +981,27 @@ class Queue {
       requestedBy: this.current.requestedBy || null,
     });
 
+    const trackPayload = {
+      title: this.current.track.title,
+      artist: this.current.track.artist || null,
+      album: this.current.track.album || null,
+      source: this.current.source,
+      requestedBy: this.current.requestedBy || null,
+    };
+
     // Outbound fan-out — fire-and-forget; never blocks the picker path.
-    // track.play is listener-gated (fail-closed) like scrobble — see scrobble.ts.
-    const listeners = getListenerCount();
-    if (typeof listeners !== 'number' || listeners <= 0) {
-      console.log(`[webhook] skip track.play: ${listeners ?? 'null'} listener(s)`);
+    // Optional listener gate (webhooksPolicy.trackPlayListenerGated): fail-closed
+    // like scrobble — see scrobble.ts. Silent skip when gated and count unknown.
+    const gated = !!settings.get()?.webhooksPolicy?.trackPlayListenerGated;
+    if (gated) {
+      const raw = getListenerCount();
+      const listeners =
+        typeof raw === 'number' && Number.isFinite(raw) && raw > 0 ? raw : null;
+      if (listeners !== null) {
+        webhooks.notify('track.play', { ...trackPayload, listeners });
+      }
     } else {
-      webhooks.notify('track.play', {
-        title: this.current.track.title,
-        artist: this.current.track.artist || null,
-        album: this.current.track.album || null,
-        source: this.current.source,
-        requestedBy: this.current.requestedBy || null,
-        listeners,
-      });
+      webhooks.notify('track.play', trackPayload);
     }
 
     // Last.fm / ListenBrainz — also fire-and-forget. Internally gated on

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -17,7 +17,7 @@ import * as session from './session.js';
 import { getFullContext, energyForDaypart } from '../context.js';
 import * as settings from '../settings.js';
 import { logEvent } from '../observability/events.js';
-import { djCallsAllowed, getListenerCount } from './listeners.js';
+import { djCallsAllowed, presentListeners } from './listeners.js';
 import * as webhooks from './webhooks.js';
 import * as scrobble from './scrobble.js';
 import * as liquidsoapControl from './liquidsoap-control.js';
@@ -994,9 +994,7 @@ class Queue {
     // like scrobble — see scrobble.ts. Silent skip when gated and count unknown.
     const gated = !!settings.get()?.webhooksPolicy?.trackPlayListenerGated;
     if (gated) {
-      const raw = getListenerCount();
-      const listeners =
-        typeof raw === 'number' && Number.isFinite(raw) && raw > 0 ? raw : null;
+      const listeners = presentListeners();
       if (listeners !== null) {
         webhooks.notify('track.play', { ...trackPayload, listeners });
       }

--- a/controller/src/broadcast/scrobble.ts
+++ b/controller/src/broadcast/scrobble.ts
@@ -20,7 +20,7 @@
 
 import { createHash } from 'node:crypto';
 import * as settings from '../settings.js';
-import { getListenerCount } from './listeners.js';
+import { getListenerCount, presentListeners } from './listeners.js';
 
 const TIMEOUT_MS = 5000;
 const LASTFM_API = 'https://ws.audioscrobbler.com/2.0/';
@@ -366,9 +366,9 @@ async function listenbrainzSubmit(track: ScrobbleTrack, startedAt: string, token
 // side-effects — never throws, never blocks the caller. Fires both backends
 // in parallel (fire-and-forget).
 export function onTrackEvent({ outgoing, outgoingStartedAt, incoming }: TrackEventArgs): void {
-  const listeners = getListenerCount();
-  if (typeof listeners !== 'number' || listeners <= 0) {
-    console.log(`[scrobble] skip: ${listeners ?? 'null'} listener(s)`);
+  const listeners = presentListeners();
+  if (listeners === null) {
+    console.log(`[scrobble] skip: ${getListenerCount() ?? 'null'} listener(s)`);
     return;
   }
 

--- a/controller/src/broadcast/webhooks.ts
+++ b/controller/src/broadcast/webhooks.ts
@@ -10,6 +10,8 @@
 //
 // The shape of the payload is documented in routes/webhooks.ts. Each event
 // is a stable JSON object with `event`, `t`, and event-specific fields.
+// `track.play` is gated at the call site in queue.ts (listener count > 0);
+// notify() does not apply that gate to other events.
 
 import * as settings from '../settings.js';
 

--- a/controller/src/broadcast/webhooks.ts
+++ b/controller/src/broadcast/webhooks.ts
@@ -10,8 +10,8 @@
 //
 // The shape of the payload is documented in routes/webhooks.ts. Each event
 // is a stable JSON object with `event`, `t`, and event-specific fields.
-// `track.play` is gated at the call site in queue.ts (listener count > 0);
-// notify() does not apply that gate to other events.
+// `track.play` can be listener-gated at the call site in queue.ts when
+// webhooksPolicy.trackPlayListenerGated is on; notify() does not gate events.
 
 import * as settings from '../settings.js';
 

--- a/controller/src/routes/webhooks.ts
+++ b/controller/src/routes/webhooks.ts
@@ -35,8 +35,13 @@ router.get('/webhooks', requireAdmin, async (req, res) => {
 router.post('/webhooks', requireAdmin, async (req, res) => {
   // The UI sends the whole list back. settings.update() validates the array
   // strictly and replaces it atomically — same pattern as personas/shows.
+  // Both fields are optional so the gate toggle can save on its own without
+  // re-submitting (and re-validating) the hook list, and vice versa.
   try {
-    const patch: Record<string, unknown> = { webhooks: req.body?.webhooks };
+    const patch: Record<string, unknown> = {};
+    if (req.body?.webhooks !== undefined) {
+      patch.webhooks = req.body.webhooks;
+    }
     if (req.body?.trackPlayListenerGated !== undefined) {
       patch.webhooksPolicy = { trackPlayListenerGated: !!req.body.trackPlayListenerGated };
     }

--- a/controller/src/routes/webhooks.ts
+++ b/controller/src/routes/webhooks.ts
@@ -2,7 +2,8 @@
 // in broadcast/webhooks.ts and reads its config from settings on each fire.
 //
 // Event payloads emitted by the fan-out:
-//   track.play       { event, t, title, artist, album?, source, requestedBy? }
+//   track.play       { event, t, title, artist, album?, source, requestedBy?, listeners }
+//                    (only POSTs when listener count > 0; fail-closed on null/0)
 //   dj.say           { event, t, text, kind }      // kind is the original `announce` kind
 //   dj.link          { event, t, text }
 //   request.received { event, t, requestedBy, text }   // text is the listener's raw ask

--- a/controller/src/routes/webhooks.ts
+++ b/controller/src/routes/webhooks.ts
@@ -2,8 +2,9 @@
 // in broadcast/webhooks.ts and reads its config from settings on each fire.
 //
 // Event payloads emitted by the fan-out:
-//   track.play       { event, t, title, artist, album?, source, requestedBy?, listeners }
-//                    (only POSTs when listener count > 0; fail-closed on null/0)
+//   track.play       { event, t, title, artist, album?, source, requestedBy?, listeners? }
+//                    (when webhooksPolicy.trackPlayListenerGated is on, only POSTs
+//                     when listener count > 0 — fail-closed; `listeners` included)
 //   dj.say           { event, t, text, kind }      // kind is the original `announce` kind
 //   dj.link          { event, t, text }
 //   request.received { event, t, requestedBy, text }   // text is the listener's raw ask
@@ -20,7 +21,12 @@ router.get('/webhooks', requireAdmin, async (req, res) => {
   try {
     await settings.load();
     const s = settings.getRedacted();
-    res.json({ events: WEBHOOK_EVENTS, webhooks: s.webhooks || [] });
+    const policy = settings.get().webhooksPolicy || {};
+    res.json({
+      events: WEBHOOK_EVENTS,
+      webhooks: s.webhooks || [],
+      trackPlayListenerGated: !!policy.trackPlayListenerGated,
+    });
   } catch (err: any) {
     res.status(500).json({ error: err.message });
   }
@@ -30,8 +36,17 @@ router.post('/webhooks', requireAdmin, async (req, res) => {
   // The UI sends the whole list back. settings.update() validates the array
   // strictly and replaces it atomically — same pattern as personas/shows.
   try {
-    const r = await settings.update({ webhooks: req.body?.webhooks });
-    res.json({ webhooks: settings.getRedacted().webhooks, requiresRestart: r.requiresRestart });
+    const patch: Record<string, unknown> = { webhooks: req.body?.webhooks };
+    if (req.body?.trackPlayListenerGated !== undefined) {
+      patch.webhooksPolicy = { trackPlayListenerGated: !!req.body.trackPlayListenerGated };
+    }
+    const r = await settings.update(patch);
+    const policy = settings.get().webhooksPolicy || {};
+    res.json({
+      webhooks: settings.getRedacted().webhooks,
+      trackPlayListenerGated: !!policy.trackPlayListenerGated,
+      requiresRestart: r.requiresRestart,
+    });
   } catch (err: any) {
     res.status(400).json({ error: err.message });
   }

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -1085,7 +1085,9 @@ const DEFAULTS = {
   },
   // Outbound webhooks. Each entry POSTs station events (see broadcast/
   // webhooks.ts for the event list) to `url` with a fire-and-forget HTTP
-  // call. Empty by default — operators add hooks via the admin UI.
+  // call. `track.play` is listener-gated like scrobble (fail-closed on
+  // null/0 — see broadcast/queue.ts). Empty by default — operators add hooks
+  // via the admin UI.
   webhooks: [] as any[],
   // Station-wide scrobbling. Each backend is independent; both are paste-only
   // (no OAuth) and both are gated on listener count > 0 at scrobble time (a

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -1085,10 +1085,15 @@ const DEFAULTS = {
   },
   // Outbound webhooks. Each entry POSTs station events (see broadcast/
   // webhooks.ts for the event list) to `url` with a fire-and-forget HTTP
-  // call. `track.play` is listener-gated like scrobble (fail-closed on
-  // null/0 — see broadcast/queue.ts). Empty by default — operators add hooks
+  // call. `track.play` can be listener-gated via webhooksPolicy (off by
+  // default — see broadcast/queue.ts). Empty by default — operators add hooks
   // via the admin UI.
   webhooks: [] as any[],
+  webhooksPolicy: {
+    // When true, track.play POSTs only when listener count > 0 (fail-closed on
+    // null/unknown/non-finite, like scrobble). Default false = always send.
+    trackPlayListenerGated: false,
+  },
   // Station-wide scrobbling. Each backend is independent; both are paste-only
   // (no OAuth) and both are gated on listener count > 0 at scrobble time (a
   // null/unknown count is treated as zero — fail closed, see broadcast/
@@ -1738,6 +1743,12 @@ export async function load() {
       enabled: typeof stored.sfx?.enabled === 'boolean' ? stored.sfx.enabled : DEFAULTS.sfx.enabled,
     },
     webhooks: normalizeWebhooks(stored.webhooks),
+    webhooksPolicy: {
+      trackPlayListenerGated:
+        typeof stored.webhooksPolicy?.trackPlayListenerGated === 'boolean'
+          ? stored.webhooksPolicy.trackPlayListenerGated
+          : DEFAULTS.webhooksPolicy.trackPlayListenerGated,
+    },
     scrobble: {
       lastfm: {
         enabled:
@@ -2886,6 +2897,12 @@ export async function update(patch) {
   }
   if ('webhooks' in patch) {
     next.webhooks = validateWebhooksStrict(patch.webhooks, next.webhooks || []);
+  }
+  if ('webhooksPolicy' in patch) {
+    const wp = patch.webhooksPolicy || {};
+    if (wp.trackPlayListenerGated !== undefined) {
+      next.webhooksPolicy.trackPlayListenerGated = !!wp.trackPlayListenerGated;
+    }
   }
   if ('scrobble' in patch) {
     const sb = patch.scrobble || {};

--- a/web/components/admin/WebhooksPanel.tsx
+++ b/web/components/admin/WebhooksPanel.tsx
@@ -240,23 +240,44 @@ export default function WebhooksPanel() {
     return () => { cancelled = true; };
   }, [hydrated, needsAuth, adminFetch]);
 
-  const save = async (next: Webhook[], gated = trackPlayListenerGated) => {
+  const save = async (next: Webhook[]) => {
     setBusy(true);
     try {
       const r = await adminFetch('/webhooks', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ webhooks: next, trackPlayListenerGated: gated }),
+        body: JSON.stringify({ webhooks: next }),
+      });
+      const j = (await r.json().catch(() => ({}))) as { webhooks?: Webhook[]; error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      setHooks(j.webhooks || []);
+      notify.ok('Webhooks saved.');
+    } catch (e) {
+      notify.err(`Save failed: ${errorMessage(e)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // The gate persists on its own the moment it's flipped (like the skills
+  // toggles) — it must not ride the hooks Save button, which an invalid
+  // draft row would disable. Doesn't touch `hooks`, so unsaved row edits
+  // survive a toggle.
+  const saveGate = async (next: boolean) => {
+    setBusy(true);
+    try {
+      const r = await adminFetch('/webhooks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ trackPlayListenerGated: next }),
       });
       const j = (await r.json().catch(() => ({}))) as {
-        webhooks?: Webhook[];
         trackPlayListenerGated?: boolean;
         error?: string;
       };
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      setHooks(j.webhooks || []);
       setTrackPlayListenerGated(!!j.trackPlayListenerGated);
-      notify.ok('Webhooks saved.');
+      notify.ok(`track.play listener gate ${j.trackPlayListenerGated ? 'on' : 'off'}.`);
     } catch (e) {
       notify.err(`Save failed: ${errorMessage(e)}`);
     } finally {
@@ -319,7 +340,7 @@ export default function WebhooksPanel() {
           <Btn
             sm
             tone="accent"
-            onClick={() => save(hooks, trackPlayListenerGated)}
+            onClick={() => save(hooks)}
             disabled={!allValid || busy}
           >{busy ? 'Saving…' : 'Save'}</Btn>
         </div>
@@ -330,7 +351,8 @@ export default function WebhooksPanel() {
         right={
           <Toggle
             on={trackPlayListenerGated}
-            onClick={() => setTrackPlayListenerGated(v => !v)}
+            onClick={() => saveGate(!trackPlayListenerGated)}
+            disabled={busy}
           />
         }
       >
@@ -338,7 +360,7 @@ export default function WebhooksPanel() {
           Gate <code>track.play</code> on listener count (off by default). When on, hooks only
           receive the event when at least one listener is tuned in — unknown or zero count is
           skipped silently, matching scrobble. The payload includes <code>listeners</code> when
-          fired.
+          fired. Applies immediately — no Save needed.
         </div>
       </Card>
 

--- a/web/components/admin/WebhooksPanel.tsx
+++ b/web/components/admin/WebhooksPanel.tsx
@@ -23,6 +23,7 @@ interface Webhook {
 interface WebhooksResponse {
   events: string[];
   webhooks: Webhook[];
+  trackPlayListenerGated?: boolean;
 }
 
 function clientMintId() {
@@ -61,7 +62,7 @@ interface PayloadDoc {
 const PAYLOADS: PayloadDoc[] = [
   {
     event: 'track.play',
-    blurb: 'A track started. Only delivered when at least one listener is tuned in (fail-closed on unknown/zero count). `source` is "auto" (the playlist), "ai" (picker agent) or "request"; `artist`/`album`/`requestedBy` may be null; `listeners` is the current count when fired.',
+    blurb: 'A track started. By default always delivered; enable “Gate track.play on listeners” below to skip when nobody is tuned in (fail-closed on unknown count). `source` is "auto" (the playlist), "ai" (picker agent) or "request"; `artist`/`album`/`requestedBy` may be null; `listeners` is included when the gate is on.',
     json: `{
   "event": "track.play",
   "t": "2026-06-02T19:04:12.880Z",
@@ -215,6 +216,7 @@ export default function WebhooksPanel() {
   const { adminFetch, needsAuth, hydrated } = useAdminAuth();
   const [events, setEvents] = useState<string[] | null>(null);
   const [hooks, setHooks] = useState<Webhook[] | null>(null);
+  const [trackPlayListenerGated, setTrackPlayListenerGated] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -229,6 +231,7 @@ export default function WebhooksPanel() {
         if (cancelled) return;
         setEvents(j.events);
         setHooks(j.webhooks || []);
+        setTrackPlayListenerGated(!!j.trackPlayListenerGated);
       } catch (e) {
         if (cancelled) return;
         setErr(errorMessage(e));
@@ -237,17 +240,22 @@ export default function WebhooksPanel() {
     return () => { cancelled = true; };
   }, [hydrated, needsAuth, adminFetch]);
 
-  const save = async (next: Webhook[]) => {
+  const save = async (next: Webhook[], gated = trackPlayListenerGated) => {
     setBusy(true);
     try {
       const r = await adminFetch('/webhooks', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ webhooks: next }),
+        body: JSON.stringify({ webhooks: next, trackPlayListenerGated: gated }),
       });
-      const j = (await r.json().catch(() => ({}))) as { webhooks?: Webhook[]; error?: string };
+      const j = (await r.json().catch(() => ({}))) as {
+        webhooks?: Webhook[];
+        trackPlayListenerGated?: boolean;
+        error?: string;
+      };
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
       setHooks(j.webhooks || []);
+      setTrackPlayListenerGated(!!j.trackPlayListenerGated);
       notify.ok('Webhooks saved.');
     } catch (e) {
       notify.err(`Save failed: ${errorMessage(e)}`);
@@ -311,11 +319,28 @@ export default function WebhooksPanel() {
           <Btn
             sm
             tone="accent"
-            onClick={() => save(hooks)}
+            onClick={() => save(hooks, trackPlayListenerGated)}
             disabled={!allValid || busy}
           >{busy ? 'Saving…' : 'Save'}</Btn>
         </div>
       </section>
+
+      <Card
+        title="track.play delivery"
+        right={
+          <Toggle
+            on={trackPlayListenerGated}
+            onClick={() => setTrackPlayListenerGated(v => !v)}
+          />
+        }
+      >
+        <div className="text-[12px] leading-[1.6] text-muted">
+          Gate <code>track.play</code> on listener count (off by default). When on, hooks only
+          receive the event when at least one listener is tuned in — unknown or zero count is
+          skipped silently, matching scrobble. The payload includes <code>listeners</code> when
+          fired.
+        </div>
+      </Card>
 
       {hooks.length === 0 && (
         <Card title="No webhooks yet">

--- a/web/components/admin/WebhooksPanel.tsx
+++ b/web/components/admin/WebhooksPanel.tsx
@@ -61,7 +61,7 @@ interface PayloadDoc {
 const PAYLOADS: PayloadDoc[] = [
   {
     event: 'track.play',
-    blurb: 'A track started. `source` is "auto" (the playlist), "ai" (picker agent) or "request"; `artist`/`album`/`requestedBy` may be null.',
+    blurb: 'A track started. Only delivered when at least one listener is tuned in (fail-closed on unknown/zero count). `source` is "auto" (the playlist), "ai" (picker agent) or "request"; `artist`/`album`/`requestedBy` may be null; `listeners` is the current count when fired.',
     json: `{
   "event": "track.play",
   "t": "2026-06-02T19:04:12.880Z",
@@ -69,7 +69,8 @@ const PAYLOADS: PayloadDoc[] = [
   "artist": "Massive Attack",
   "album": "Mezzanine",
   "source": "auto",
-  "requestedBy": null
+  "requestedBy": null,
+  "listeners": 1
 }`,
   },
   {


### PR DESCRIPTION
## Summary
- Gate outbound `track.play` webhooks on listener count > 0 (fail-closed when count is null, matching scrobble semantics)
- Add `listeners` to the webhook payload when fired
- Update admin payload docs / example JSON

## Why
Homelab HA ambient-light automation should not run when nobody is listening. Scrobble already gates this way; webhooks did not.

## Test plan
- [ ] 0 listeners → no POST, skip log line
- [ ] 1 listener → POST with listeners field
- [ ] dj.say / request.received unchanged
- [ ] npm test in controller