### PR TITLE
feat(personas): community persona sharing — catalog, install, showcase + submission flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-persona.yml
+++ b/.github/ISSUE_TEMPLATE/add-persona.yml
@@ -1,0 +1,151 @@
+name: 🎙️ Share a DJ persona with the community
+description: Contribute a DJ persona (a name, a soul, a few behaviour knobs) to the shared catalog — no fork, no YAML. Fill this in and a pull request is opened for you automatically.
+title: "Add persona: "
+labels: ["persona-submission"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing a persona! A persona is a DJ identity — a name, a short
+        soul (the character prose that shapes everything they say on air), and a few
+        behaviour knobs. A bot turns this issue into a one-file pull request; a
+        maintainer reviews and merges it, and it ships to every station as an
+        installable community persona.
+
+        Voices and avatars stay station-side — every operator picks their own TTS
+        engine and artwork after installing. **You don't need to fork anything.**
+  - type: input
+    id: persona-slug
+    attributes:
+      label: Persona slug
+      description: Lowercase, hyphenated, starts with a letter or digit (a–z, 0–9, hyphens), ≤49 chars. This is the folder name in the catalog and must be unique.
+      placeholder: saffron-am
+    validations:
+      required: true
+  - type: input
+    id: display-name
+    attributes:
+      label: On-air name
+      description: The DJ's name as it appears in the roster and on air. Up to 40 characters.
+      placeholder: Saffron
+    validations:
+      required: true
+  - type: input
+    id: tagline
+    attributes:
+      label: Tagline
+      description: One line that sells the persona in the roster. Up to 80 characters.
+      placeholder: Breakfast-show warmth, whatever the hour.
+    validations:
+      required: false
+  - type: textarea
+    id: soul
+    attributes:
+      label: The soul
+      description: >
+        The character prose — who this DJ is, how they talk, what they never do.
+        Written as description, not instructions to a model. 1–1000 characters;
+        this becomes the persona's `soul` verbatim.
+      placeholder: A morning-show host at heart, even at midnight. Warm, quick to smile, talks to one listener at a time…
+    validations:
+      required: true
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: Talk frequency
+      description: How often this persona speaks between tracks.
+      options:
+        - moderate
+        - quiet
+        - aggressive
+      default: 0
+    validations:
+      required: false
+  - type: dropdown
+    id: script-length
+    attributes:
+      label: Script length
+      description: Concise is the standard one-to-four sentence segment; extended is roughly double, for storytellers.
+      options:
+        - concise
+        - extended
+      default: 0
+    validations:
+      required: false
+  - type: dropdown
+    id: dj-mode
+    attributes:
+      label: DJ mode
+      description: On = behaves like a working radio DJ (back-announces, teases what's next, runs callbacks). Off = the tasteful-narrator default.
+      options:
+        - "off"
+        - "on"
+      default: 0
+    validations:
+      required: false
+  - type: input
+    id: humour
+    attributes:
+      label: Humour dial
+      description: 0–10, where 0 plays it straight and 10 is playful & dry. Leave blank for neutral (5).
+      placeholder: "7"
+    validations:
+      required: false
+  - type: input
+    id: local-colour
+    attributes:
+      label: Local colour dial
+      description: 0–10, where 0 is universal and 10 leans local. Leave blank for neutral (5).
+      placeholder: "5"
+    validations:
+      required: false
+  - type: input
+    id: warmth
+    attributes:
+      label: Warmth dial
+      description: 0–10, where 0 is cool & dry and 10 is warm & earnest. Leave blank for neutral (5).
+      placeholder: "8"
+    validations:
+      required: false
+  - type: input
+    id: language
+    attributes:
+      label: On-air language
+      description: Free text, e.g. "Turkish" or "Türkçe". Leave blank for English.
+    validations:
+      required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: What are they like? (for reviewers)
+      description: One or two sentences on the persona and why it's worth sharing. Not saved into the persona — just helps the maintainer review.
+      placeholder: A gentle breakfast-radio host for stations that want warmth without chatter.
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        ### Contribution terms
+
+        By submitting a persona you agree:
+
+        - The soul is your own work (or cleared for sharing), contains nothing
+          unlawful, hateful, or designed to deceive listeners, and does not
+          imitate a real, living person without their consent.
+        - It contains no secrets or personal data.
+        - Your GitHub username is recorded as the persona's submitter (shown as a
+          credit line in the community catalog), along with the dates it was added
+          and last updated.
+        - SUB/WAVE may include, edit, or remove it from the catalog at its discretion.
+        - It's shared under the same licence as the SUB/WAVE repository.
+
+        This isn't legal advice.
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Before you submit
+      options:
+        - label: I understand a pull request will be opened from this issue and a maintainer will review it.
+          required: true
+        - label: I agree to the contribution terms above.
+          required: true

--- a/.github/workflows/persona-submission.yml
+++ b/.github/workflows/persona-submission.yml
@@ -1,0 +1,233 @@
+name: Persona submission → PR
+
+# Turns a "🎙️ Share a DJ persona" issue (see .github/ISSUE_TEMPLATE/add-persona.yml)
+# into a one-file pull request that adds a community persona under
+# controller/src/personas/community/<slug>/PERSONA.md — so contributors can share
+# a persona WITHOUT forking the repo or hand-writing frontmatter. A maintainer
+# then reviews and merges the generated PR; the persona ships in the controller
+# image on the next release and becomes installable from every station's
+# /admin/personas.
+#
+# This mirrors .github/workflows/skill-submission.yml. Security: the issue body
+# is UNTRUSTED user input. It is parsed and written to a file entirely inside
+# actions/github-script via the REST API (Buffer/base64, createOrUpdateFileContents)
+# — NEVER interpolated into a shell `run:` step, so there is no command-injection
+# surface. The only file this workflow can write is
+# controller/src/personas/community/<slug>/PERSONA.md (slug sanitised + validated
+# against the loader's SLUG_RE). Personas are data-only by construction — no code
+# ever ships through this path.
+
+# NOTE: the `persona-submission` label MUST exist as a repo label, otherwise
+# GitHub silently drops it from the issue template and the `if:` guard below
+# never matches (every run shows "skipped"). `labeled` is included so a
+# maintainer can re-trigger a stuck submission by re-applying the label.
+on:
+  issues:
+    types: [opened, edited, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: persona-submission-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  build-pr:
+    name: Build persona PR from issue
+    runs-on: ubuntu-latest
+    if: contains(join(github.event.issue.labels.*.name, ','), 'persona-submission')
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const { owner, repo } = context.repo;
+            const BASE = 'develop';
+            const DIR = 'controller/src/personas/community';
+
+            const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,48}$/;
+            const FREQUENCIES = new Set(['quiet', 'moderate', 'aggressive']);
+            const SCRIPT_LENGTHS = new Set(['concise', 'extended']);
+
+            // --- 1. Parse the issue-form body into a { heading: value } map ---
+            // GitHub renders each field as "### <label>\n\n<value>"; empty optional
+            // fields render as "_No response_". Walk line-by-line so a multi-line
+            // soul isn't truncated.
+            const body = issue.body || '';
+            const fields = {};
+            let curKey = null, buf = [];
+            const flush = () => {
+              if (curKey === null) return;
+              let v = buf.join('\n').trim();
+              if (v === '_No response_') v = '';
+              fields[curKey] = v;
+            };
+            for (const line of body.split(/\r?\n/)) {
+              const h = line.match(/^###\s+(.+?)\s*$/);
+              if (h) { flush(); curKey = h[1].trim(); buf = []; }
+              else if (curKey !== null) { buf.push(line); }
+            }
+            flush();
+            const get = (label) => (fields[label] || '').trim();
+
+            const slug = get('Persona slug').toLowerCase();
+            const displayName = get('On-air name');
+            const tagline = get('Tagline');
+            const soul = get('The soul');
+            const frequency = get('Talk frequency').toLowerCase();
+            const scriptLength = get('Script length').toLowerCase();
+            const djMode = get('DJ mode').toLowerCase();
+            const language = get('On-air language');
+
+            // Optional 0-10 integer dial; '' → unset (neutral downstream).
+            // Returns { ok, value } so a malformed value fails loudly instead of
+            // being silently dropped.
+            const dial = (label) => {
+              const raw = get(label);
+              if (!raw) return { ok: true, value: '' };
+              const n = Number(raw);
+              if (!Number.isInteger(n) || n < 0 || n > 10) return { ok: false, value: raw };
+              return { ok: true, value: String(n) };
+            };
+            const humour = dial('Humour dial');
+            const localColour = dial('Local colour dial');
+            const warmth = dial('Warmth dial');
+
+            // --- 2. Validate (mirrors controller settings.validatePersonasStrict
+            // bounds so the installed persona always passes) ---
+            const problems = [];
+            if (!slug) problems.push('**Persona slug** is required.');
+            else if (!SLUG_RE.test(slug)) problems.push('**Persona slug** must be a lowercase slug: start with a letter or digit, then letters/digits/hyphens, ≤49 chars (e.g. `saffron-am`).');
+            if (!displayName) problems.push('**On-air name** is required.');
+            else if (displayName.length > 40) problems.push('**On-air name** must be at most 40 characters.');
+            if (tagline.length > 80) problems.push('**Tagline** must be at most 80 characters.');
+            if (!soul) problems.push('**The soul** is required — it\'s the character prose the DJ speaks from.');
+            else if (soul.length > 1000) problems.push(`**The soul** must be at most 1000 characters (currently ${soul.length}).`);
+            if (frequency && !FREQUENCIES.has(frequency)) problems.push('**Talk frequency** must be quiet, moderate, or aggressive.');
+            if (scriptLength && !SCRIPT_LENGTHS.has(scriptLength)) problems.push('**Script length** must be concise or extended.');
+            if (!humour.ok) problems.push('**Humour dial** must be a whole number 0–10.');
+            if (!localColour.ok) problems.push('**Local colour dial** must be a whole number 0–10.');
+            if (!warmth.ok) problems.push('**Warmth dial** must be a whole number 0–10.');
+            if (language.length > 60) problems.push('**On-air language** must be at most 60 characters.');
+
+            const fail = async (lines) => {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issue.number,
+                body: `⚠️ I couldn't build a pull request from this submission:\n\n` +
+                  lines.map((l) => `- ${l}`).join('\n') +
+                  `\n\nEdit the issue to fix it and I'll try again automatically.`,
+              });
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: issue.number, labels: ['needs-info'],
+              }).catch(() => {});
+            };
+
+            if (problems.length) { await fail(problems); return; }
+
+            const filePath = `${DIR}/${slug}/PERSONA.md`;
+            // Provenance: who submitted it (the issue author) and when. `new Date`
+            // is the CI clock (UTC) — this runs in real Node, not a sandbox.
+            const submittedBy = (issue.user && issue.user.login) || '';
+            const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
+
+            // --- 3. Ensure a branch off develop ---
+            const branch = `persona/${slug}`;
+            const baseRef = await github.rest.git.getRef({
+              owner, repo, ref: `heads/${BASE}`,
+            });
+            const baseSha = baseRef.data.object.sha;
+            try {
+              await github.rest.git.createRef({
+                owner, repo, ref: `refs/heads/${branch}`, sha: baseSha,
+              });
+            } catch (e) {
+              if (e.status !== 422) throw e; // 422 = branch already exists (edited issue)
+            }
+
+            // --- 4. Find any existing copy on the branch (an edited issue, or a
+            // version already merged into develop that this branch carries). We
+            // need its blob sha to update in place, and its `dateAdded:` so the
+            // original added-date survives re-runs — only dateModified moves. ---
+            let existingSha;
+            let existingAdded = '';
+            try {
+              const existing = await github.rest.repos.getContent({
+                owner, repo, path: filePath, ref: branch,
+              });
+              existingSha = existing.data.sha;
+              const prev = Buffer.from(existing.data.content || '', 'base64').toString('utf8');
+              const m = prev.match(/^dateAdded:\s*(.+?)\s*$/m);
+              if (m) existingAdded = m[1].trim();
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
+            const dateAdded = existingAdded || today;
+
+            // --- 5. Render PERSONA.md — frontmatter matching the catalog reader
+            // (controller/src/personas/community.ts CommunityPersona), plus the
+            // provenance it reads back (submittedBy / dateAdded / dateModified). ---
+            const fm = ['---', `name: ${slug}`, `displayName: ${displayName}`];
+            if (tagline) fm.push(`tagline: ${tagline}`);
+            if (frequency && frequency !== 'moderate') fm.push(`frequency: ${frequency}`);
+            if (scriptLength && scriptLength !== 'concise') fm.push(`scriptLength: ${scriptLength}`);
+            if (djMode === 'on') fm.push('djMode: true');
+            if (humour.value) fm.push(`humour: ${humour.value}`);
+            if (localColour.value) fm.push(`localColour: ${localColour.value}`);
+            if (warmth.value) fm.push(`warmth: ${warmth.value}`);
+            if (language) fm.push(`language: ${language}`);
+            if (submittedBy) fm.push(`submittedBy: ${submittedBy}`);
+            fm.push(`dateAdded: ${dateAdded}`);
+            fm.push(`dateModified: ${today}`);
+            fm.push('---', soul, '');
+            const content = fm.join('\n');
+            const contentB64 = Buffer.from(content, 'utf8').toString('base64');
+
+            // --- 6. Write/refresh the persona file on that branch ---
+            await github.rest.repos.createOrUpdateFileContents({
+              owner, repo, path: filePath, branch,
+              message: `feat(personas): add ${displayName} community persona (from #${issue.number})`,
+              content: contentB64,
+              ...(existingSha ? { sha: existingSha } : {}),
+            });
+
+            // --- 7. Open the PR (or reuse the existing one) ---
+            const open = await github.rest.pulls.list({
+              owner, repo, state: 'open', head: `${owner}:${branch}`,
+            });
+            let pr = open.data[0];
+            const summary = get('What are they like? (for reviewers)');
+            const prBody =
+              `Adds the **${displayName}** community persona.\n\n` +
+              (summary ? `> ${summary}\n\n` : '') +
+              `Generated automatically from #${issue.number}. Closes #${issue.number}.\n\n` +
+              '```markdown\n' + content + '```\n';
+            if (!pr) {
+              const created = await github.rest.pulls.create({
+                owner, repo, base: BASE, head: branch,
+                title: `feat(personas): add ${displayName} community persona`,
+                body: prBody,
+              });
+              pr = created.data;
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: pr.number, labels: ['personas'],
+              }).catch(() => {});
+            } else {
+              await github.rest.pulls.update({
+                owner, repo, pull_number: pr.number, body: prBody,
+              });
+            }
+
+            // --- 8. Tell the contributor ---
+            await github.rest.issues.removeLabel({
+              owner, repo, issue_number: issue.number, name: 'needs-info',
+            }).catch(() => {});
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: issue.number,
+              body: `✅ Opened ${pr.html_url} with your persona at \`${filePath}\`.\n\n` +
+                `A maintainer will review and merge it — your persona then ships with the next ` +
+                `release and becomes installable from every station's admin panel. Need to ` +
+                `change something? Just edit this issue and the PR updates automatically.`,
+            });

--- a/controller/src/personas/community.ts
+++ b/controller/src/personas/community.ts
@@ -1,0 +1,123 @@
+// Shipped COMMUNITY persona catalog — DJ personas contributed via the
+// community-submission flow (.github/workflows/persona-submission.yml), COPYd
+// into the image alongside the code. Mirrors the community skill catalog
+// (skills/loader.ts COMMUNITY_DIR): this is NOT a runtime store — it is a
+// read-only catalog the operator browses (public /personas showcase, admin
+// /admin/personas → Community) and *installs* into the settings.personas
+// roster on demand (routes/personas.ts). An installed community persona is an
+// ordinary roster persona — editable, deletable, no special posture.
+//
+// One entry per directory:
+//
+//   controller/src/personas/community/<slug>/PERSONA.md
+//     frontmatter → the persona's portable knobs + provenance
+//     body        → the soul (the character prose, 1-1000 chars)
+//
+// Station-specific fields are deliberately NOT part of the format: `tts`
+// (engines/voices/keys differ per station — install applies the piper
+// defaults), `avatar` (binary, uploaded locally), `skills` (installed sets
+// differ — install uses null, the "all skills" roster default), and `id`
+// (minted on install by settings.update()).
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseFrontmatter, SLUG_RE } from '../skills/loader.js';
+import { FREQUENCIES, SCRIPT_LENGTHS } from '../settings.js';
+
+export const COMMUNITY_PERSONAS_DIR = resolve(dirname(fileURLToPath(import.meta.url)), 'community');
+
+// One entry in the shipped community persona catalog (browse-only). The fields
+// mirror a roster persona's portable knobs so the install route can hand them
+// straight to settings.update() and the UIs can render without a second fetch.
+export interface CommunityPersona {
+  slug: string;
+  displayName: string;         // the DJ's on-air name (persona.name, ≤40)
+  tagline?: string;            // ≤80
+  soul: string;                // the character prose (PERSONA.md body, 1-1000)
+  frequency: 'quiet' | 'moderate' | 'aggressive';
+  scriptLength: 'concise' | 'extended';
+  djMode: boolean;
+  humour?: number;             // tone dials 0-10; absent = neutral (5)
+  localColour?: number;
+  warmth?: number;
+  language?: string;           // free-text on-air language, ≤60
+  // Provenance stamped by the submission workflow when a persona is approved +
+  // merged (.github/workflows/persona-submission.yml). Absent on hand-added
+  // entries — parsed defensively, UI degrades gracefully.
+  submittedBy?: string;        // GitHub login of the contributor who submitted it
+  dateAdded?: string;          // ISO date (YYYY-MM-DD) it first entered the catalog
+  dateModified?: string;       // ISO date (YYYY-MM-DD) of the last catalog change
+}
+
+function titleCase(slug: string): string {
+  return slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+// Optional 0-10 integer dial. Anything unparsable → undefined (neutral
+// downstream — settings normalizeDial defaults to 5).
+function parseDial(raw: string | undefined): number | undefined {
+  if (raw == null || raw === '') return undefined;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0 || n > 10) return undefined;
+  return n;
+}
+
+// Parse one community catalog dir into a CommunityPersona, or null when it
+// isn't a valid entry (no PERSONA.md, bad slug, empty soul, oversize fields).
+// Same lenient-but-strict-on-identity posture as readCommunityDir (skills).
+async function readCommunityPersonaDir(slug: string): Promise<CommunityPersona | null> {
+  if (!SLUG_RE.test(slug)) return null;
+  let raw: string;
+  try {
+    raw = await readFile(join(COMMUNITY_PERSONAS_DIR, slug, 'PERSONA.md'), 'utf8');
+  } catch {
+    return null;
+  }
+  const { data, body } = parseFrontmatter(raw);
+  const name = (data.name || slug).trim();
+  if (name !== slug) return null; // name must match its folder, like skills
+  const soul = body.trim();
+  if (!soul || soul.length > 1000) return null; // the roster's hard bound
+  const displayName = (data.displayName || titleCase(slug)).trim().slice(0, 40);
+  return {
+    slug,
+    displayName,
+    tagline: data.tagline?.trim().slice(0, 80) || undefined,
+    soul,
+    frequency: (FREQUENCIES as string[]).includes(data.frequency) ? data.frequency as CommunityPersona['frequency'] : 'moderate',
+    scriptLength: (SCRIPT_LENGTHS as string[]).includes(data.scriptLength) ? data.scriptLength as CommunityPersona['scriptLength'] : 'concise',
+    djMode: data.djMode === 'true',
+    humour: parseDial(data.humour),
+    localColour: parseDial(data.localColour),
+    warmth: parseDial(data.warmth),
+    language: data.language?.trim().slice(0, 60) || undefined,
+    submittedBy: data.submittedBy?.trim() || undefined,
+    dateAdded: data.dateAdded?.trim() || undefined,
+    dateModified: data.dateModified?.trim() || undefined,
+  };
+}
+
+// List the shipped community persona catalog (browse-only). Returns [] when
+// the dir is absent. Never throws — a broken entry is skipped.
+export async function listCommunityPersonas(): Promise<CommunityPersona[]> {
+  let entries: string[] = [];
+  try {
+    const dirents = await readdir(COMMUNITY_PERSONAS_DIR, { withFileTypes: true });
+    entries = dirents.filter(d => d.isDirectory()).map(d => d.name);
+  } catch {
+    return []; // no community/ dir shipped — nothing to browse
+  }
+  const out: CommunityPersona[] = [];
+  for (const slug of entries.sort()) {
+    const cp = await readCommunityPersonaDir(slug).catch(() => null);
+    if (cp) out.push(cp);
+  }
+  return out;
+}
+
+// Read a single community catalog entry by slug (for the install route).
+// Returns null when there's no such valid entry.
+export async function readCommunityPersona(slug: string): Promise<CommunityPersona | null> {
+  return readCommunityPersonaDir(slug);
+}

--- a/controller/src/personas/community/saffron-am/PERSONA.md
+++ b/controller/src/personas/community/saffron-am/PERSONA.md
@@ -1,0 +1,14 @@
+---
+name: saffron-am
+displayName: Saffron
+tagline: Breakfast-show warmth, whatever the hour.
+frequency: moderate
+scriptLength: concise
+djMode: true
+humour: 7
+warmth: 8
+submittedBy: perminder-klair
+dateAdded: 2026-07-05
+dateModified: 2026-07-05
+---
+A morning-show host at heart, even at midnight. Warm, quick to smile, greets the day (or the graveyard shift) like it personally showed up for her. Loves a good segue and isn't above a gentle pun, but never laughs at her own jokes — she just leaves a beat and moves on. Talks to one listener at a time, never "everyone out there". Keeps the energy a notch above the record she's introducing, never two.

--- a/controller/src/personas/community/the-archivist/PERSONA.md
+++ b/controller/src/personas/community/the-archivist/PERSONA.md
@@ -1,0 +1,13 @@
+---
+name: the-archivist
+displayName: The Archivist
+tagline: Liner notes, pressing dates, and why this take.
+frequency: quiet
+scriptLength: extended
+humour: 3
+warmth: 5
+submittedBy: perminder-klair
+dateAdded: 2026-07-05
+dateModified: 2026-07-05
+---
+A crate-digger who treats every record like a found document. Speaks rarely, and when he does it's one precise thing: the session this was cut in, the b-side that outlived the single, the borrowed bassline nobody credits. Never gushes — the facts carry the affection. If he doesn't know the story, he says nothing and lets the record be the story. Dates and names over adjectives, always.

--- a/controller/src/routes/personas.ts
+++ b/controller/src/routes/personas.ts
@@ -14,6 +14,9 @@ import express from 'express';
 import { mkdir, readdir, unlink, writeFile } from 'node:fs/promises';
 import * as settings from '../settings.js';
 import { requireAdmin } from '../middleware/auth.js';
+import { readCommunityPersona } from '../personas/community.js';
+import { SLUG_RE } from '../skills/loader.js';
+import { queue } from '../broadcast/queue.js';
 
 export const router = express.Router();
 
@@ -159,6 +162,66 @@ router.delete('/personas/:id/avatar', requireAdmin, async (req, res) => {
     const result = await clearAvatar(String(req.params.id));
     res.json(result);
   } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /personas/community/:slug/install — append a community catalog persona
+// to the station's roster as an ordinary persona: editable, deletable, and NOT
+// on air (activePersonaId is untouched — the analogue of a community skill
+// arriving disabled). Station-specific fields get the roster defaults: a
+// minted id, the piper tts block, no avatar, skills=null ("all skills").
+// Rejects a roster at PERSONA_LIMIT and a duplicate on-air name (409) so the
+// operator isn't left with two indistinguishable DJs.
+// ---------------------------------------------------------------------------
+router.post('/personas/community/:slug/install', requireAdmin, async (req, res) => {
+  const slug = String(req.params.slug);
+  if (!SLUG_RE.test(slug)) {
+    return res.status(400).json({ error: `invalid persona slug: ${slug}` });
+  }
+
+  const cp = await readCommunityPersona(slug);
+  if (!cp) {
+    return res.status(404).json({ error: `no such community persona: ${slug}` });
+  }
+
+  await settings.load();
+  const personas = settings.get().personas || [];
+  if (personas.length >= settings.PERSONA_LIMIT) {
+    return res.status(409).json({ error: `the roster is full (${settings.PERSONA_LIMIT} personas max) — remove one first` });
+  }
+  const wanted = cp.displayName.trim().toLowerCase();
+  if (personas.some((p: any) => String(p.name).trim().toLowerCase() === wanted)) {
+    return res.status(409).json({ error: `a persona named "${cp.displayName}" is already in the roster` });
+  }
+
+  // A complete persona object — settings.update() validates strictly and
+  // mints the id (no valid `id` supplied → mintId('p_')).
+  const persona = {
+    name: cp.displayName,
+    tagline: cp.tagline || '',
+    frequency: cp.frequency,
+    scriptLength: cp.scriptLength,
+    djMode: cp.djMode,
+    humour: cp.humour ?? 5,
+    localColour: cp.localColour ?? 5,
+    warmth: cp.warmth ?? 5,
+    soul: cp.soul,
+    language: cp.language || '',
+    avatar: '',
+    tts: { engine: 'piper', cloudProvider: 'openai', voice: '', gainDb: 0, speed: 1 },
+    skills: null,
+  };
+
+  try {
+    await settings.update({ personas: [...personas, persona] });
+    const next = settings.get().personas || [];
+    const installed = next.find((p: any) => String(p.name).trim().toLowerCase() === wanted) || null;
+    queue.log('scheduler', `[personas] community "${slug}" installed via admin UI as "${cp.displayName}"`);
+    res.json({ personas: next, persona: installed });
+  } catch (err: any) {
+    queue.log('error', `POST /personas/community/${slug}/install failed: ${err.message}`);
     res.status(400).json({ error: err.message });
   }
 });

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -15,6 +15,7 @@ import { getSetupStatusSync } from '../setup/firstRun.js';
 import { getStationTimezone } from '../time.js';
 import { listThemesAnnotated, DEFAULT_THEME_ID } from '../themes.js';
 import { listCommunitySkills } from '../skills/loader.js';
+import { listCommunityPersonas } from '../personas/community.js';
 import { lifetimeTokenCount } from '../llm/log.js';
 
 export const router = express.Router();
@@ -463,6 +464,25 @@ router.get('/skills/community', async (req, res) => {
     res.json({ community });
   } catch (err) {
     queue.log('error', `/skills/community failed: ${err.message}`);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /personas/community — the shipped community persona catalog (DJ personas
+// contributed via the community-submission flow, COPYd into the image). Same
+// posture as /skills/community: browse-only public reference powering the
+// public /personas showcase AND the admin Personas → Community modal (which
+// computes per-station "installed" client-side from the roster it already
+// holds). Never throws — an empty catalog returns []. No admin gate: static
+// shipped data, identical across every install of the same version.
+// ---------------------------------------------------------------------------
+router.get('/personas/community', async (req, res) => {
+  try {
+    const community = await listCommunityPersonas();
+    res.json({ community });
+  } catch (err) {
+    queue.log('error', `/personas/community failed: ${err.message}`);
     res.status(500).json({ error: err.message });
   }
 });

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -540,7 +540,9 @@ export const AVATAR_EXTENSIONS = ['png', 'jpg', 'jpeg', 'webp'] as const;
 // source of truth for which slugs exist; settings only checks the shape.
 const SKILL_SLUG_RE = /^[a-z0-9-]{1,40}$/;
 
-const PERSONA_LIMIT = 24;
+// Exported for the community-persona install route (routes/personas.ts), which
+// gives a friendly 409 before settings.update() would throw on an oversize roster.
+export const PERSONA_LIMIT = 48;
 const SHOWS_LIMIT = 64;
 const PLAYLISTS_PER_SHOW = 10;
 const EXCLUDED_PLAYLISTS_PER_SHOW = 10;

--- a/docs/superpowers/specs/2026-07-05-community-personas-design.md
+++ b/docs/superpowers/specs/2026-07-05-community-personas-design.md
@@ -1,0 +1,142 @@
+# Community personas — design
+
+**Date:** 2026-07-05
+**Status:** approved-by-pattern (mirrors the shipped community-skills pipeline end to end)
+
+## What
+
+Let operators share DJ personas with the community the same way they share
+skills: a shipped read-only catalog browsable on a public page and in the
+admin console, one-tap install into the station's roster, and a no-fork
+GitHub Issue Form that a workflow turns into a one-file PR.
+
+## Why
+
+Skills sharing (#851/#849) proved the loop: contribute via issue form →
+bot PR → maintainer merge → ships in the image → installable everywhere.
+Personas are the other half of a station's character and are just as
+portable — a persona is a name, a tagline, a soul (character prose), and a
+few behaviour knobs. Voice/avatar are station-specific and stay local.
+
+## Approaches considered
+
+1. **Mirror the skills pipeline file-for-file** (chosen) — markdown catalog
+   dirs shipped in the controller image, list/read module, public browse
+   route, admin install route, issue form + submission workflow, public
+   showcase page. Maintainers and contributors already know this shape.
+2. JSON catalog file — fewer files but breaks the one-dir-per-entry PR
+   ergonomics (merge conflicts, no per-entry provenance) the skills flow
+   relies on.
+3. Registry service / external repo — over-engineered for a catalog that
+   ships with the image and updates on release.
+
+## Portable persona fields
+
+From `validatePersonasStrict` (settings.ts): `name` (≤40, the DJ's on-air
+name), `tagline` (≤80), `soul` (1–1000, the character prose — the file
+body), `frequency` (quiet|moderate|aggressive), `scriptLength`
+(concise|extended), `djMode` (bool), tone dials `humour`/`localColour`/
+`warmth` (0–10, 5 = neutral), `language` (≤60, free text).
+
+NOT portable: `id` (minted on install), `avatar` (binary, station-local),
+`tts` (engines/voices/keys are station-specific — install uses the piper
+defaults), `skills` (installed set differs per station — install uses
+`null` = "all skills", the roster default).
+
+## Components
+
+### 1. Catalog store — `controller/src/personas/community/<slug>/PERSONA.md`
+
+Mirrors `skills/community/<slug>/SKILL.md`. Flat frontmatter parsed by the
+existing `parseFrontmatter` (skills/loader.ts):
+
+```markdown
+---
+name: <slug>              # must equal the folder name (like skills)
+displayName: Marlowe      # the DJ's on-air name; falls back to title-cased slug
+tagline: …                # ≤80
+frequency: moderate       # quiet|moderate|aggressive (default moderate)
+scriptLength: concise     # concise|extended (default concise)
+djMode: true              # optional, default false
+humour: 7                 # optional 0–10, default 5
+localColour: 5
+warmth: 8
+language: …               # optional, ≤60
+submittedBy: <gh-login>   # provenance, stamped by the workflow
+dateAdded: YYYY-MM-DD
+dateModified: YYYY-MM-DD
+---
+<soul — the character prose, 1–1000 chars>
+```
+
+New module `controller/src/personas/community.ts`: `CommunityPersona`
+interface, `listCommunityPersonas()`, `readCommunityPersona(slug)` —
+defensive like the skills versions (missing dir → `[]`, broken entry →
+skipped, slug must match `SLUG_RE` from skills/loader). Two seed entries
+ship so the page/modal isn't empty.
+
+### 2. Controller routes
+
+- **`GET /personas/community`** (routes/public.ts, no gate) — `{ community: [...] }`.
+  Static shipped catalog, same posture as `GET /skills/community`. The admin
+  panel reuses this same route and computes `installed` client-side by
+  case-insensitive name match against the roster it already holds (unlike
+  skills, install state lives in settings the panel has loaded — no
+  annotated admin route needed).
+- **`POST /personas/community/:slug/install`** (routes/personas.ts,
+  requireAdmin) — 404 unknown slug, 409 when the roster already has a
+  persona with the same name (case-insensitive) or is at `PERSONA_LIMIT`.
+  Builds a complete persona (minted `p_` id, default piper tts block,
+  `skills: null`, `avatar: ''`) and appends via `settings.update()`.
+  Does NOT touch `activePersonaId` — the persona arrives in the roster but
+  not on air, the analogue of a skill arriving disabled. Returns
+  `{ personas, persona }`. `PERSONA_LIMIT` gets exported from settings.ts.
+
+### 3. Admin UI
+
+- **PersonasPanel**: a `Community` button in the hero (mirrors SkillsPanel),
+  opening a modal that lists the catalog with brief/tagline/provenance and
+  an Install button per entry (`installed` pill when the name is already in
+  the roster). Install appends the returned persona to the local form state
+  so unsaved edits survive.
+- **PersonaEditor**: a `Share to community` footer button — opens the
+  prefilled `add-persona.yml` Issue Form in a new tab via a new
+  `personaSubmitUrl()` in web/lib/repo.ts (mirrors `skillSubmitUrl`).
+
+### 4. Public showcase — `/personas`
+
+Mirrors `/skills`: `web/app/personas/{layout,page}.tsx` (force-dynamic,
+fetches via `CONTROLLER_INTERNAL_URL`), `web/lib/communityPersonas.ts`,
+`web/components/personas/CommunityPersonaCard.tsx` (reuses the `bs-skill-*`
+broadsheet card classes; shows name, tagline, soul, behaviour tags,
+@submitter credit). Footer gains a fourth Back Page (§§ 01–04, grid goes
+2-col on sm / 4-col on lg). Sitemap gains `/personas` (and `/skills` if
+missing).
+
+### 5. Submission flow — GitHub
+
+- `.github/ISSUE_TEMPLATE/add-persona.yml` — slug, display name, tagline,
+  soul (textarea), frequency/scriptLength/djMode dropdowns, dials, language,
+  reviewer summary, contribution-terms checkboxes. Mirrors add-skill.yml.
+- `.github/workflows/persona-submission.yml` — mirrors
+  skill-submission.yml: parses the issue body inside actions/github-script
+  (untrusted input never touches a shell), validates (SLUG_RE, soul 1–1000,
+  enums, dials 0–10, lengths), writes
+  `controller/src/personas/community/<slug>/PERSONA.md` on a
+  `persona/<slug>` branch off develop, opens/updates the PR, comments back.
+  Requires a `persona-submission` repo label (same caveat as
+  `skill-submission` — created once by the maintainer).
+
+## Error handling
+
+Same postures as skills: catalog reads never throw (skip broken entries),
+public route 500s only on unexpected errors, install route maps
+known failures to 400/404/409, workflow comments validation problems back
+onto the issue with a `needs-info` label.
+
+## Testing
+
+No test runner in this repo — `npm run lint` (eslint + tsc) in both
+`controller/` and `web/` is the merge gate. Manual verification: run the
+dev stack from the worktree, hit `GET /personas/community`, install a seed
+via the admin panel, render `/personas`.

--- a/web/app/personas/layout.tsx
+++ b/web/app/personas/layout.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import Masthead from '@/components/landing/Masthead';
+import StationFooter from '@/components/landing/StationFooter';
+
+export const metadata: Metadata = {
+  title: 'SUB/WAVE — Community Personas',
+  description:
+    'The community persona catalog for SUB/WAVE — DJ identities shared by other stations, installable from any station&rsquo;s admin console.',
+};
+
+// Shared chrome for the /personas showcase: the broadsheet masthead, the page
+// body in the single full-width broadsheet column, and the station footer.
+// Mirrors app/skills/layout.tsx.
+export default function PersonasLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-bg text-ink">
+      <Masthead />
+      <main className="bs-paper">
+        {children}
+        <StationFooter />
+      </main>
+    </div>
+  );
+}

--- a/web/app/personas/page.tsx
+++ b/web/app/personas/page.tsx
@@ -1,0 +1,83 @@
+import { AnimatedLink } from '@/components/ui/animated-link';
+import CommunityPersonaCard from '@/components/personas/CommunityPersonaCard';
+import { fetchCommunityPersonas } from '@/lib/communityPersonas';
+import { pageMeta } from '@/lib/seo';
+import { REPO_URL } from '@/lib/repo';
+
+export const metadata = pageMeta({
+  title: 'SUB/WAVE — Community Personas',
+  description:
+    'The community persona catalog — DJ identities shared by other stations. Browse them here, then install any from your station&rsquo;s admin console.',
+  path: '/personas',
+});
+
+// The catalog is baked into the controller image and refreshed on update, so
+// read it live from the local controller at request time rather than at build.
+export const dynamic = 'force-dynamic';
+
+// Submission opens a GitHub Issue Form (no fork, no YAML). A workflow turns the
+// issue into a one-file pull request automatically — see
+// .github/workflows/persona-submission.yml. Mirrors the /skills share flow.
+const SUBMIT_URL = `${REPO_URL}/issues/new?template=add-persona.yml`;
+
+export default async function CommunityPersonasIndex() {
+  const personas = await fetchCommunityPersonas();
+  const count = personas.length;
+
+  return (
+    <article>
+      <header className="bs-news-hero">
+        <p className="bs-eyebrow">THE GREEN ROOM</p>
+        <h1>Community Personas.</h1>
+        <p>
+          A persona is a DJ identity — a name, a soul, and a few behaviour knobs that shape
+          everything they say on air. These are shared by the community and ship with every
+          station. Browse them here, then install the ones you like from your own admin
+          console — and give them your own voice and face there.
+        </p>
+      </header>
+
+      {count > 0 ? (
+        <p className="bs-stat-strip">
+          <span>
+            <strong>{count}</strong> {count === 1 ? 'persona' : 'personas'} in the catalog
+          </span>
+        </p>
+      ) : null}
+
+      <div className="bs-station-cta">
+        <p className="bs-station-cta-copy">Dreamed up a DJ worth sharing? Add them to the catalog.</p>
+        <AnimatedLink href={SUBMIT_URL} variant="arrow" className="bs-station-cta-link">
+          Share a persona
+        </AnimatedLink>
+        <AnimatedLink href="/manual/dj" className="bs-station-cta-help">
+          How personas work
+        </AnimatedLink>
+      </div>
+
+      {count > 0 ? (
+        <ul className="bs-stations-grid">
+          {personas.map((p) => (
+            <CommunityPersonaCard key={p.slug} persona={p} />
+          ))}
+        </ul>
+      ) : (
+        <p className="bs-news-empty">
+          No community personas to show yet — the catalog may still be loading, or this station
+          hasn&rsquo;t shipped one. Be the first to{' '}
+          <AnimatedLink href={SUBMIT_URL} className="bs-link">
+            share a persona
+          </AnimatedLink>
+          .
+        </p>
+      )}
+
+      <p className="bs-stations-report">
+        Installing is a two-tap job in your station&rsquo;s admin: open{' '}
+        <strong>Personas → Community</strong>, then <strong>Install</strong>. The persona joins
+        your roster off-air, with your station&rsquo;s default voice — audition it, pick a voice
+        and an avatar, then put it on the desk when you&rsquo;re ready.
+      </p>
+    </article>
+  );
+}

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -12,9 +12,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { notify, errorMessage } from '../../lib/notify';
-import { Card } from './ui';
+import { Card, Btn, Pill } from './ui';
 import { V3AlertDialog } from '../ui/alert-dialog';
-import type { Persona, PersonaTts, FormState, SettingsResponse } from './personas/types';
+import { Modal } from '../ui/modal';
+import type { Persona, PersonaTts, FormState, SettingsResponse, CommunityPersona } from './personas/types';
 import { DIAL_NEUTRAL, PERSONA_MAX, PROMPT_MIN, PROMPT_MAX } from './personas/constants';
 import {
   clientMintId, fetchDicebearAvatar, fileToAvatarDataUrl, personaValid, voiceForSave, cloudIssue,
@@ -48,6 +49,10 @@ export default function PersonasPanel() {
   const [uploadingId, setUploadingId] = useState<string | null>(null);
   // Index of the persona pending a delete-confirm (null = no dialog open).
   const [confirmDeleteIdx, setConfirmDeleteIdx] = useState<number | null>(null);
+  // The shipped community persona catalog (best-effort; null = still loading).
+  const [community, setCommunity] = useState<CommunityPersona[] | null>(null);
+  const [communityOpen, setCommunityOpen] = useState(false); // catalog modal open?
+  const [installing, setInstalling] = useState<string | null>(null); // community slug installing, or null
   // The editor block. After adding a persona we scroll it into view so the
   // operator actually sees the new persona open for editing — it stacks below
   // the roster and would otherwise be off-screen.
@@ -119,6 +124,18 @@ export default function PersonasPanel() {
         });
       }
     })();
+    // The community catalog is best-effort — a failure here shouldn't blank the
+    // roster, so it fetches independently and just leaves the modal empty.
+    (async () => {
+      try {
+        const r = await adminFetch('/personas/community');
+        if (!r.ok) throw new Error(`failed (${r.status})`);
+        const j = (await r.json()) as { community?: CommunityPersona[] };
+        setCommunity(Array.isArray(j.community) ? j.community : []);
+      } catch {
+        setCommunity([]);
+      }
+    })();
   }, [hydrated, needsAuth, adminFetch]);
 
   // After an add bumps focus to the new persona, bring the editor into view.
@@ -167,6 +184,51 @@ export default function PersonasPanel() {
     setEditorOpen(true);
     notify.ok('New persona added. Fill in its details, then Save persona.');
   };
+  // Install a community persona: the controller appends it to the persisted
+  // roster (off-air, default voice) and returns the stored persona. We append
+  // that to the local form too — mapped through the same defaulting as the
+  // initial load — so any unsaved edits to other personas survive.
+  const installCommunity = async (slug: string) => {
+    setInstalling(slug);
+    try {
+      const r = await adminFetch(`/personas/community/${encodeURIComponent(slug)}/install`, { method: 'POST' });
+      const j = (await r.json().catch(() => ({}))) as { error?: string; persona?: Partial<Persona> | null };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      const p = j.persona;
+      if (p && typeof p.id === 'string') {
+        const allSkills = (data?.skills?.catalog || []).map(s => s.name);
+        setForm(f => f ? {
+          ...f,
+          personas: [...f.personas, {
+            id: p.id as string,
+            name: p.name ?? '',
+            tagline: p.tagline ?? '',
+            frequency: p.frequency ?? 'moderate',
+            scriptLength: p.scriptLength ?? 'concise',
+            djMode: p.djMode === true,
+            humour: typeof p.humour === 'number' ? p.humour : DIAL_NEUTRAL,
+            localColour: typeof p.localColour === 'number' ? p.localColour : DIAL_NEUTRAL,
+            warmth: typeof p.warmth === 'number' ? p.warmth : DIAL_NEUTRAL,
+            soul: p.soul ?? '',
+            language: typeof p.language === 'string' ? p.language : '',
+            avatar: '',
+            tts: {
+              engine: p.tts?.engine ?? 'piper',
+              cloudProvider: p.tts?.cloudProvider ?? 'openai',
+              voice: p.tts?.voice ?? '',
+              gainDb: typeof p.tts?.gainDb === 'number' ? p.tts.gainDb : 0,
+              speed: typeof p.tts?.speed === 'number' ? p.tts.speed : 1,
+            },
+            skills: Array.isArray(p.skills) ? p.skills : allSkills,
+          }],
+        } : f);
+      }
+      notify.ok(`Installed “${p?.name || slug}” — off air until you put them on the desk`);
+    } catch (e) {
+      notify.err(`Install failed: ${errorMessage(e)}`);
+    } finally { setInstalling(null); }
+  };
+
   const removePersona = (i: number) =>
     setForm(f => {
       if (!f) return f;
@@ -391,7 +453,92 @@ export default function PersonasPanel() {
         onTogglePrompt={() => setShowPrompt(s => !s)}
         onAdd={addPersona}
         onSelect={(i) => { setCreatingId(null); setFocusIdx(i); setEditorOpen(true); }}
+        communityCount={community?.length ?? null}
+        onCommunity={() => setCommunityOpen(true)}
       />
+
+      {/* ── COMMUNITY CATALOG MODAL ──────────────────────────────────────── */}
+      <Modal
+        open={communityOpen}
+        onOpenChange={setCommunityOpen}
+        title="community"
+        sub="personas shared by other stations"
+        width={640}
+      >
+        <div className="text-[12px] leading-[1.65] text-muted">
+          These personas ship with SUB/WAVE and update when you do.
+          <strong> Install</strong> adds one to your roster as your own editable persona — it
+          arrives <strong>off air</strong> with your station&rsquo;s default voice, so give it a
+          voice and an avatar, then put it on the desk. Made one worth sharing? Hit{' '}
+          <strong>Edit → Share to community</strong> on any persona.
+        </div>
+        <div className="mt-4 grid gap-3">
+          {community && community.length > 0 ? (
+            community.map(c => {
+              const inRoster = form.personas.some(
+                p => p.name.trim().toLowerCase() === c.displayName.trim().toLowerCase(),
+              );
+              return (
+                <div key={c.slug} className="grid grid-cols-[1fr_auto] items-center gap-4 border border-ink p-3">
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <span className="text-[13px] font-extrabold">{c.displayName}</span>
+                      <Pill className="text-[8px]">{c.frequency}</Pill>
+                      {c.scriptLength === 'extended' && <Pill className="text-[8px]">extended</Pill>}
+                      {c.djMode && <Pill className="text-[8px]">dj mode</Pill>}
+                      {c.language && <Pill className="max-w-[120px] truncate text-[8px]">{c.language}</Pill>}
+                    </div>
+                    {c.tagline && (
+                      <div className="mt-0.5 text-[11px] font-bold text-muted">{c.tagline}</div>
+                    )}
+                    <div className="mt-1 line-clamp-3 text-[12px] leading-[1.6] text-muted">{c.soul}</div>
+                    {(c.submittedBy || c.dateAdded) && (
+                      <div className="mt-1.5 text-[10px] leading-[1.5] text-muted">
+                        {c.submittedBy && (
+                          <>
+                            by{' '}
+                            <a
+                              href={`https://github.com/${c.submittedBy}`}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="font-bold text-vermilion underline decoration-[1.5px] underline-offset-2"
+                            >
+                              @{c.submittedBy}
+                            </a>
+                          </>
+                        )}
+                        {c.submittedBy && c.dateAdded && ' · '}
+                        {c.dateAdded && <>added {c.dateAdded}</>}
+                        {c.dateAdded && c.dateModified && c.dateModified !== c.dateAdded && (
+                          <> · updated {c.dateModified}</>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex flex-col items-end gap-2">
+                    {inRoster ? (
+                      <Pill tone="accent" dot>in roster</Pill>
+                    ) : (
+                      <Btn
+                        tone="accent"
+                        onClick={() => installCommunity(c.slug)}
+                        disabled={installing === c.slug || form.personas.length >= PERSONA_MAX}
+                        title={form.personas.length >= PERSONA_MAX ? 'The roster is full' : undefined}
+                      >
+                        {installing === c.slug ? 'Installing…' : 'Install'}
+                      </Btn>
+                    )}
+                  </div>
+                </div>
+              );
+            })
+          ) : (
+            <div className="py-6 text-center text-[13px] text-muted italic">
+              No community personas yet.
+            </div>
+          )}
+        </div>
+      </Modal>
 
       <PersonaEditor
         persona={focused}

--- a/web/components/admin/personas/PersonaEditor.tsx
+++ b/web/components/admin/personas/PersonaEditor.tsx
@@ -92,33 +92,9 @@ export function PersonaEditor({
       title={<Eyebrow className="text-vermilion">{isNew ? 'New persona' : 'Edit persona'}</Eyebrow>}
       sub={<span className="caption truncate">{persona.name.trim() || `Persona ${index + 1}`} · {index + 1} of {personaCount}</span>}
       footer={
-        <div className="flex flex-wrap items-center gap-3">
-          {/* left — persona-scoped actions */}
-          <span className="flex items-center gap-2">
-            {persona.id === onAirPersonaId && <Pill tone="accent" className="text-[8px]">on air</Pill>}
-            {persona.id === activePersonaId
-              ? <Pill className="text-[8px]">default</Pill>
-              : <Btn lg onClick={onSetActive}>Set as default</Btn>}
-            <Btn
-              lg
-              tone="danger"
-              onClick={onRemove}
-              disabled={personaCount <= 1}
-              title={personaCount > 1 ? 'Remove this persona' : 'At least one persona is required'}
-            >
-              Remove
-            </Btn>
-            <Btn
-              lg
-              onClick={shareToCommunity}
-              disabled={!persona.name.trim() || !persona.soul.trim()}
-              title="Open a prefilled GitHub form to share this persona with every station (voice and avatar stay yours)"
-            >
-              Share to community
-            </Btn>
-          </span>
-          {/* right — status + discard/save */}
-          <span className="ml-auto flex items-center gap-3">
+        <div className="flex w-full flex-col gap-2">
+          {/* status line — its own row so the action buttons never wrap */}
+          <div className="flex items-center gap-2">
             <span
               className={cn(
                 'size-1.5 flex-none rounded-full',
@@ -134,11 +110,41 @@ export function PersonaEditor({
                     ? <span className="text-[var(--danger)]">fix the custom system prompt</span>
                     : 'changes apply on the next spoken line · no mixer restart'}
             </span>
-            <Btn lg onClick={onDiscard} disabled={busy}>Discard</Btn>
-            <Btn lg tone="accent" onClick={onSave} disabled={busy || !canSave}>
-              {busy ? 'Saving…' : 'Save persona'}
-            </Btn>
-          </span>
+          </div>
+          {/* action row */}
+          <div className="flex flex-wrap items-center gap-3">
+            {/* left — persona-scoped actions */}
+            <span className="flex items-center gap-2">
+              {persona.id === onAirPersonaId && <Pill tone="accent" className="text-[8px]">on air</Pill>}
+              {persona.id === activePersonaId
+                ? <Pill className="text-[8px]">default</Pill>
+                : <Btn lg onClick={onSetActive}>Set as default</Btn>}
+              <Btn
+                lg
+                tone="danger"
+                onClick={onRemove}
+                disabled={personaCount <= 1}
+                title={personaCount > 1 ? 'Remove this persona' : 'At least one persona is required'}
+              >
+                Remove
+              </Btn>
+              <Btn
+                lg
+                onClick={shareToCommunity}
+                disabled={!persona.name.trim() || !persona.soul.trim()}
+                title="Open a prefilled GitHub form to share this persona with every station (voice and avatar stay yours)"
+              >
+                Share to community
+              </Btn>
+            </span>
+            {/* right — discard/save */}
+            <span className="ml-auto flex items-center gap-3">
+              <Btn lg onClick={onDiscard} disabled={busy}>Discard</Btn>
+              <Btn lg tone="accent" onClick={onSave} disabled={busy || !canSave}>
+                {busy ? 'Saving…' : 'Save persona'}
+              </Btn>
+            </span>
+          </div>
         </div>
       }
     >

--- a/web/components/admin/personas/PersonaEditor.tsx
+++ b/web/components/admin/personas/PersonaEditor.tsx
@@ -9,6 +9,8 @@ import type { Persona, PersonaTts, SettingsResponse, SkillCatalogEntry } from '.
 import type { AdminAuth } from '../../../lib/adminAuth';
 import { Btn, Eyebrow, Pill } from '../ui';
 import { cn } from '../../../lib/cn';
+import { personaSubmitUrl } from '../../../lib/repo';
+import { DIAL_NEUTRAL } from './constants';
 import { EditorDialog } from '../../ui/editor-dialog';
 import { PersonaIdentityCard } from './PersonaIdentityCard';
 import { PersonaBehaviorCard } from './PersonaBehaviorCard';
@@ -60,6 +62,29 @@ export function PersonaEditor({
   const updateTts = (patch: Partial<PersonaTts>) => setPersonaTts(index, patch);
   const setSkills = (skills: string[]) => setPersonaSkills(index, skills);
 
+  // Share this persona to the community: open the prefilled add-persona Issue
+  // Form on GitHub in a new tab. A workflow turns the issue into a one-file PR;
+  // once merged it ships to everyone as an installable community persona. Only
+  // the portable fields travel — voice and avatar stay station-side.
+  const shareToCommunity = () => {
+    const slug = persona.name.trim().toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 49);
+    const url = personaSubmitUrl({
+      'persona-slug': slug,
+      'display-name': persona.name.trim(),
+      tagline: persona.tagline.trim(),
+      soul: persona.soul.trim(),
+      frequency: persona.frequency,
+      'script-length': persona.scriptLength,
+      'dj-mode': persona.djMode ? 'on' : '',
+      humour: persona.humour !== DIAL_NEUTRAL ? String(persona.humour) : '',
+      'local-colour': persona.localColour !== DIAL_NEUTRAL ? String(persona.localColour) : '',
+      warmth: persona.warmth !== DIAL_NEUTRAL ? String(persona.warmth) : '',
+      language: persona.language.trim(),
+    });
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
   return (
     <EditorDialog
       open={open}
@@ -82,6 +107,14 @@ export function PersonaEditor({
               title={personaCount > 1 ? 'Remove this persona' : 'At least one persona is required'}
             >
               Remove
+            </Btn>
+            <Btn
+              lg
+              onClick={shareToCommunity}
+              disabled={!persona.name.trim() || !persona.soul.trim()}
+              title="Open a prefilled GitHub form to share this persona with every station (voice and avatar stay yours)"
+            >
+              Share to community
             </Btn>
           </span>
           {/* right — status + discard/save */}

--- a/web/components/admin/personas/PersonaRoster.tsx
+++ b/web/components/admin/personas/PersonaRoster.tsx
@@ -3,6 +3,7 @@
 // avatar + tagline + meta pills on the left, status pills + Edit on the right.
 // Click Edit to open the full-screen editor; adding lives in the hero's
 // "+ Add persona" button.
+import { Users } from 'lucide-react';
 import type { Persona } from './types';
 import { API_BASE, PERSONA_MAX } from './constants';
 import { initialsFor, personaValid } from './helpers';
@@ -20,17 +21,30 @@ interface PersonaRosterProps {
   onTogglePrompt: () => void;
   onAdd: () => void;
   onSelect: (idx: number) => void;
+  // Shipped community catalog size (null = still loading — button disabled).
+  communityCount: number | null;
+  onCommunity: () => void;
 }
 
 export function PersonaRoster({
   personas, activePersonaId, onAirPersonaId, avatarTick,
-  showPrompt, onTogglePrompt, onAdd, onSelect,
+  showPrompt, onTogglePrompt, onAdd, onSelect, communityCount, onCommunity,
 }: PersonaRosterProps) {
   return (
     <section className="grid gap-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <span className="caption">roster · {personas.length} / {PERSONA_MAX}</span>
         <div className="flex flex-wrap gap-2">
+          <Btn
+            onClick={onCommunity}
+            disabled={communityCount === null}
+            title="Browse and install personas shared by other stations"
+          >
+            <Users size={14} /> Community
+            {communityCount !== null && communityCount > 0 && (
+              <span className="ml-1 text-vermilion">{communityCount}</span>
+            )}
+          </Btn>
           <Btn onClick={onTogglePrompt}>
             {showPrompt ? 'Hide system prompt' : 'System prompt'}
           </Btn>

--- a/web/components/admin/personas/constants.ts
+++ b/web/components/admin/personas/constants.ts
@@ -56,7 +56,7 @@ export const SOUL_MAX = 1000;
 export const LANGUAGE_MAX = 60;
 export const PROMPT_MIN = 50;
 export const PROMPT_MAX = 4000;
-export const PERSONA_MAX = 24;
+export const PERSONA_MAX = 48;
 
 // 512×512 output target. The controller hard-caps the decoded image at 300 KB
 // and the JSON body at 600 KB; a center-cropped 512×512 WebP from a typical

--- a/web/components/admin/personas/types.ts
+++ b/web/components/admin/personas/types.ts
@@ -92,3 +92,24 @@ export interface SettingsResponse {
   };
   env?: Record<string, unknown>;
 }
+
+// One entry in the shipped community persona catalog (GET /personas/community).
+// Mirrors the controller's CommunityPersona (personas/community.ts). The
+// catalog is station-agnostic — "already in the roster" is computed client-side
+// by name match, since the panel holds the roster anyway.
+export interface CommunityPersona {
+  slug: string;
+  displayName: string;
+  tagline?: string;
+  soul: string;
+  frequency: 'quiet' | 'moderate' | 'aggressive';
+  scriptLength: 'concise' | 'extended';
+  djMode: boolean;
+  humour?: number;
+  localColour?: number;
+  warmth?: number;
+  language?: string;
+  submittedBy?: string;  // GitHub login of the contributor who submitted it
+  dateAdded?: string;    // ISO date (YYYY-MM-DD) it first entered the catalog
+  dateModified?: string; // ISO date (YYYY-MM-DD) of the last catalog change
+}

--- a/web/components/landing/StationFooter.tsx
+++ b/web/components/landing/StationFooter.tsx
@@ -4,10 +4,11 @@ import Link from 'next/link';
 
 import { AnimatedLink } from '@/components/ui/animated-link';
 
-// The Back Pages — the footer as a broadsheet back-page index. Three ruled
+// The Back Pages — the footer as a broadsheet back-page index. Four ruled
 // section panels give the station's secondary destinations (dispatches,
-// stations, skills) real front-of-house billing, then a single colophon
-// strip carries the small print. Copy ends with the press-room "-30-" mark.
+// stations, skills, personas) real front-of-house billing, then a single
+// colophon strip carries the small print. Copy ends with the press-room
+// "-30-" mark.
 const BACK_PAGES = [
   {
     no: '01',
@@ -33,6 +34,14 @@ const BACK_PAGES = [
     cta: 'Explore the skills',
     href: '/skills',
   },
+  {
+    no: '04',
+    tag: 'The Green Room',
+    title: 'Community Personas',
+    teaser: 'DJs other operators dreamed up — book one for your booth.',
+    cta: 'Meet the personas',
+    href: '/personas',
+  },
 ] as const;
 
 export default function StationFooter({ djName }: { djName?: string }) {
@@ -42,20 +51,20 @@ export default function StationFooter({ djName }: { djName?: string }) {
 
       <div className="flex items-baseline justify-between gap-4 py-[7px] text-[10px] tracking-[0.3em] text-muted uppercase">
         <span className="font-bold text-ink">The Back Pages</span>
-        <span className="hidden sm:inline">Reader services · §§ 01–03</span>
+        <span className="hidden sm:inline">Reader services · §§ 01–04</span>
       </div>
 
       <div className="bs-rule" />
 
       <nav
         aria-label="Back pages"
-        className="grid divide-y divide-ink/20 sm:grid-cols-3 sm:divide-x sm:divide-y-0"
+        className="grid divide-y divide-ink/20 lg:grid-cols-4 lg:divide-x lg:divide-y-0"
       >
         {BACK_PAGES.map((page) => (
           <Link
             key={page.href}
             href={page.href}
-            className="group relative flex flex-col gap-[10px] overflow-hidden px-5 py-6 no-underline transition-colors duration-300 hover:bg-ink/[0.04] sm:first:pl-1 sm:last:pr-1"
+            className="group relative flex flex-col gap-[10px] overflow-hidden px-5 py-6 no-underline transition-colors duration-300 hover:bg-ink/[0.04] lg:first:pl-1 lg:last:pr-1"
           >
             <span
               aria-hidden="true"

--- a/web/components/personas/CommunityPersonaCard.tsx
+++ b/web/components/personas/CommunityPersonaCard.tsx
@@ -1,0 +1,60 @@
+import type { CommunityPersona } from '@/lib/communityPersonas';
+
+// One card in the /personas showcase grid. Browse-only: it presents a
+// community persona's soul and provenance — installation happens in a
+// station's admin console, not here. Reuses the bs-skill-* broadsheet card
+// styles from the /skills showcase; the content shape is near-identical.
+export default function CommunityPersonaCard({ persona }: { persona: CommunityPersona }) {
+  // Behaviour tags — only the non-default knobs, so a plain persona shows a
+  // clean card and a characterful one wears its settings.
+  const tags: string[] = [];
+  if (persona.frequency !== 'moderate') tags.push(persona.frequency);
+  if (persona.scriptLength !== 'concise') tags.push(persona.scriptLength);
+  if (persona.djMode) tags.push('dj mode');
+  if (persona.language) tags.push(persona.language);
+
+  return (
+    <li className="bs-skill-card">
+      <div className="bs-skill-head">
+        <h3 className="bs-skill-name">{persona.displayName}</h3>
+      </div>
+
+      {persona.tagline && <p className="bs-skill-cadence">{persona.tagline}</p>}
+
+      <p className="bs-skill-brief">{persona.soul}</p>
+
+      {tags.length > 0 && (
+        <ul className="bs-skill-tags" aria-label="Behaviour">
+          {tags.map((t) => (
+            <li key={t} className="bs-skill-tag">
+              {t}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {(persona.submittedBy || persona.dateAdded) && (
+        <p className="bs-skill-credit">
+          {persona.submittedBy && (
+            <>
+              by{' '}
+              <a
+                href={`https://github.com/${persona.submittedBy}`}
+                target="_blank"
+                rel="noreferrer"
+                className="bs-skill-credit-link"
+              >
+                @{persona.submittedBy}
+              </a>
+            </>
+          )}
+          {persona.submittedBy && persona.dateAdded && ' · '}
+          {persona.dateAdded && <>added {persona.dateAdded}</>}
+          {persona.dateAdded && persona.dateModified && persona.dateModified !== persona.dateAdded && (
+            <> · updated {persona.dateModified}</>
+          )}
+        </p>
+      )}
+    </li>
+  );
+}

--- a/web/lib/communityPersonas.ts
+++ b/web/lib/communityPersonas.ts
@@ -1,0 +1,54 @@
+// Server-side lookup of the shipped community persona catalog, used by the
+// public /personas showcase page. Mirrors lib/communitySkills.ts: it runs in
+// the Next.js server (the `web` container in prod), NOT the browser, so it
+// reaches the controller directly over the internal compose network rather
+// than through the browser's `/api` Caddy route.
+//   CONTROLLER_INTERNAL_URL (set on the web service in both prod composes)
+//   → http://localhost:7701 (dev fallback: `npm run dev` web runs on the host
+//     and the dev compose binds the controller on 7701).
+const CONTROLLER_BASE = (
+  process.env.CONTROLLER_INTERNAL_URL || 'http://localhost:7701'
+).replace(/\/$/, '');
+
+// One entry in the shipped community catalog (GET /personas/community).
+// Mirrors the controller's CommunityPersona (personas/community.ts) — the
+// showcase is browse-only and station-agnostic.
+export interface CommunityPersona {
+  slug: string;
+  displayName: string; // the DJ's on-air name
+  tagline?: string;
+  soul: string; // the character prose (PERSONA.md body)
+  frequency: 'quiet' | 'moderate' | 'aggressive';
+  scriptLength: 'concise' | 'extended';
+  djMode: boolean;
+  humour?: number; // tone dials 0-10; absent = neutral
+  localColour?: number;
+  warmth?: number;
+  language?: string;
+  // Provenance stamped by the submission workflow — absent on hand-added
+  // entries, so every consumer must degrade gracefully.
+  submittedBy?: string; // GitHub login of the contributor who submitted it
+  dateAdded?: string; // ISO date (YYYY-MM-DD) it first entered the catalog
+  dateModified?: string; // ISO date (YYYY-MM-DD) of the last catalog change
+}
+
+interface CommunityResponse {
+  community?: CommunityPersona[];
+}
+
+// Fetch the shipped community catalog from the controller. Returns [] on any
+// failure (controller down, timeout, non-OK, malformed) so the showcase page
+// renders its empty state instead of throwing.
+export async function fetchCommunityPersonas(): Promise<CommunityPersona[]> {
+  try {
+    const res = await fetch(`${CONTROLLER_BASE}/personas/community`, {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) return [];
+    const data = (await res.json()) as CommunityResponse;
+    return Array.isArray(data?.community) ? data.community : [];
+  } catch {
+    return [];
+  }
+}

--- a/web/lib/repo.ts
+++ b/web/lib/repo.ts
@@ -14,3 +14,15 @@ export function skillSubmitUrl(params: Record<string, string | undefined>): stri
   }
   return `${REPO_URL}/issues/new?${qs.toString()}`;
 }
+
+// Prefilled community-persona submission — opens the add-persona Issue Form (no
+// fork, no YAML). A workflow (.github/workflows/persona-submission.yml) turns
+// the issue into a one-file PR under controller/src/personas/community/<slug>/.
+// `params` map to the form field ids, so GitHub prefills the fields.
+export function personaSubmitUrl(params: Record<string, string | undefined>): string {
+  const qs = new URLSearchParams({ template: 'add-persona.yml' });
+  for (const [k, v] of Object.entries(params)) {
+    if (v && v.trim()) qs.set(k, v.trim());
+  }
+  return `${REPO_URL}/issues/new?${qs.toString()}`;
+}


### PR DESCRIPTION
Mirrors the community-skills pipeline (#851) for **DJ personas** — share, browse, and install DJ identities across stations.

## What's in it

**Controller**
- Shipped read-only catalog at `controller/src/personas/community/<slug>/PERSONA.md` — frontmatter carries the portable knobs (displayName, tagline, frequency, scriptLength, djMode, tone dials, language) + provenance (submittedBy/dateAdded/dateModified); the body is the soul. New `personas/community.ts` module (list/read, defensive like the skills loader).
- Public `GET /personas/community` — powers both the showcase and the admin modal (no annotated admin route needed: "in roster" is computed client-side by name match).
- Admin `POST /personas/community/:slug/install` — appends to the roster **off-air** with the station's default piper voice, minted id, `skills: null`; 409 on duplicate name or full roster; `activePersonaId` untouched.
- Two seed personas: **Saffron** (breakfast-show warmth, DJ mode) and **The Archivist** (quiet crate-digger, extended scripts).

**Admin UI**
- Personas → **Community** button + catalog modal with Install.
- Persona editor → **Share to community**: opens the prefilled add-persona Issue Form (`personaSubmitUrl`). Voice and avatar deliberately stay station-side.

**Web**
- Public `/personas` broadsheet showcase (mirrors `/skills`), reusing the `bs-skill-*` card styles.
- Footer Back Pages grows to four panels (№ 04 · The Green Room), stacked until `lg`.

**GitHub**
- `add-persona.yml` Issue Form + `persona-submission.yml` workflow: issue → validated one-file PR under the catalog. Untrusted issue input is handled only inside `actions/github-script` via the REST API — no `run:` steps, same posture as skill-submission.

**Also**
- Persona roster limit raised **24 → 48** (`PERSONA_LIMIT` server-side + `PERSONA_MAX` client-side), per request.
- Design doc: `docs/superpowers/specs/2026-07-05-community-personas-design.md`.

## ⚠️ Post-merge
Create the `persona-submission` repo label — without it GitHub silently drops the label from the issue template and the workflow's `if:` guard never matches (same caveat as `skill-submission`).

## Verified
- `npm run lint` clean in both `controller/` and `web/` (0 errors).
- Scratch-booted the worktree controller: catalog lists both seeds; install persists correct dials/defaults (minted `p_` id, piper tts, dials 7/5/8 for Saffron) and leaves `activePersonaId` untouched; re-install → 409, unknown slug → 404, unauthenticated → 401.
- `/personas` rendered via `next dev` against the scratch controller — 200 with both seed cards, CTA, and the new footer panel.