### PR TITLE
fix(scheduler): stop auto.m3u repeats — telnet reload + key-based dedup (#874)

### DIFF
--- a/controller/package.json
+++ b/controller/package.json
@@ -11,7 +11,7 @@
     "lastfm-session": "tsx scripts/lastfm-session.ts",
     "test:embed": "tsx scripts/embedding-preflight-test.ts",
     "test:llm": "tsx scripts/llm-pure.test.ts",
-    "test": "tsx scripts/llm-pure.test.ts && tsx scripts/picker-recency-regression.ts && tsx scripts/recent-plays.test.ts && tsx scripts/listeners-status.test.ts && tsx scripts/lastfm-enrich.test.ts && tsx scripts/web-search-searxng.test.ts && tsx scripts/request-dedup.test.ts && tsx scripts/stale-link.test.ts && tsx scripts/embedding-heavy.test.ts && tsx scripts/tagger-perf.test.ts && tsx scripts/rescan-scope.test.ts && tsx scripts/show-playlist.test.ts && tsx scripts/embedding-dim-migrate.test.ts && tsx scripts/coverage-status.test.ts && tsx scripts/tag-propagator.test.ts && tsx scripts/embedding-prefix.test.ts && tsx scripts/propagation-eval.test.ts",
+    "test": "tsx scripts/llm-pure.test.ts && tsx scripts/picker-recency-regression.ts && tsx scripts/recent-plays.test.ts && tsx scripts/auto-pool.test.ts && tsx scripts/listeners-status.test.ts && tsx scripts/lastfm-enrich.test.ts && tsx scripts/web-search-searxng.test.ts && tsx scripts/request-dedup.test.ts && tsx scripts/stale-link.test.ts && tsx scripts/embedding-heavy.test.ts && tsx scripts/tagger-perf.test.ts && tsx scripts/rescan-scope.test.ts && tsx scripts/show-playlist.test.ts && tsx scripts/embedding-dim-migrate.test.ts && tsx scripts/coverage-status.test.ts && tsx scripts/tag-propagator.test.ts && tsx scripts/embedding-prefix.test.ts && tsx scripts/propagation-eval.test.ts",
     "lint": "eslint . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit"

--- a/controller/scripts/auto-pool.test.ts
+++ b/controller/scripts/auto-pool.test.ts
@@ -1,0 +1,116 @@
+// Regression test for the auto.m3u fallback pool builder (broadcast/auto-pool.ts)
+// — the recency / dedup / artist-cap guards that keep the LLM-free coast from
+// re-airing just-played tracks and from stacking duplicate library copies (#874).
+// Run: `tsx scripts/auto-pool.test.ts`.
+//
+// node:assert-via-tsx style, matching scripts/recent-plays.test.ts.
+
+import assert from 'node:assert/strict';
+import { createPoolBuilder } from '../src/broadcast/auto-pool.js';
+
+const song = (id: string, title: string, artist: string) => ({ id, title, artist });
+
+// ── duplicate library copies are deduped by title|artist, not just id ────────
+
+// A library holding the same song 6× has 6 distinct Subsonic ids for it. An
+// id-only dedup would let all 6 into the pool and the fallback would stack the
+// same track. The builder must keep exactly ONE copy (#874).
+{
+  const b = createPoolBuilder({ recentIds: new Set(), recentKeys: new Set(), targetPool: 30, maxPerArtist: 99 });
+  const copies = ['c1', 'c2', 'c3', 'c4', 'c5', 'c6'].map(id => song(id, 'Eyes on Me', 'Faye Wong'));
+  b.take('mood', copies, 30);
+  assert.equal(b.pool.length, 1, 'six duplicate copies collapse to one pool entry');
+  assert.equal(b.pool[0].id, 'c1', 'the first copy wins');
+  assert.equal(b.fromSource.mood, 1, 'fromSource counts the single accepted copy');
+}
+
+// Dedup is case/whitespace-insensitive on the key (mirrors trackKey lowercasing).
+{
+  const b = createPoolBuilder({ recentIds: new Set(), recentKeys: new Set(), targetPool: 30, maxPerArtist: 99 });
+  b.take('mood', [song('a', 'Drama', 'Roy Kim'), song('b', '  DRAMA  ', 'roy kim')], 30);
+  assert.equal(b.pool.length, 1, 'title|artist key ignores case and surrounding whitespace');
+}
+
+// ── recency filter blocks by id AND by title|artist key ──────────────────────
+
+// A track whose id is NOT in recentIds but whose title|artist IS in recentKeys
+// (a different copy of a just-played song) must still be blocked — this is the
+// exact hole duplicate copies opened in the id-only filter.
+{
+  const b = createPoolBuilder({
+    recentIds: new Set(['played-id']),
+    recentKeys: new Set(['eyes on me|faye wong']),
+    targetPool: 30,
+    maxPerArtist: 99,
+  });
+  b.take('mood', [
+    song('played-id', 'Eyes on Me', 'Faye Wong'),   // blocked by id
+    song('other-copy', 'Eyes on Me', 'Faye Wong'),  // blocked by key (different id!)
+    song('fresh', 'Separate Ways', 'Journey'),       // allowed
+  ], 30);
+  assert.equal(b.pool.length, 1, 'both the played id and its duplicate-copy key are blocked');
+  assert.equal(b.pool[0].id, 'fresh', 'only the genuinely fresh track survives');
+}
+
+// ── artist cap ───────────────────────────────────────────────────────────────
+
+// No one artist may exceed maxPerArtist even across sources / take() calls.
+{
+  const b = createPoolBuilder({ recentIds: new Set(), recentKeys: new Set(), targetPool: 30, maxPerArtist: 2 });
+  b.take('mood', [
+    song('t1', 'Track One', 'Arjan Dhillon'),
+    song('t2', 'Track Two', 'Arjan Dhillon'),
+    song('t3', 'Track Three', 'Arjan Dhillon'),  // over the cap → dropped
+  ], 30);
+  b.take('starred', [song('t4', 'Track Four', 'Arjan Dhillon')], 30);  // still over cap
+  assert.equal(b.pool.length, 2, 'artist cap holds across take() calls');
+  assert(b.pool.every(t => t.id === 't1' || t.id === 't2'), 'first two of the artist are kept');
+}
+
+// ── caps: per-take cap and targetPool ceiling ────────────────────────────────
+
+// The per-call `cap` limits how many a single source contributes.
+{
+  const b = createPoolBuilder({ recentIds: new Set(), recentKeys: new Set(), targetPool: 30, maxPerArtist: 99 });
+  const many = Array.from({ length: 10 }, (_, i) => song(`s${i}`, `Song ${i}`, `Artist ${i}`));
+  b.take('random', many, 3);
+  assert.equal(b.pool.length, 3, 'per-source cap limits contribution to 3');
+}
+
+// targetPool caps the whole pool regardless of per-source caps.
+{
+  const b = createPoolBuilder({ recentIds: new Set(), recentKeys: new Set(), targetPool: 4, maxPerArtist: 99 });
+  const many = Array.from({ length: 10 }, (_, i) => song(`s${i}`, `Song ${i}`, `Artist ${i}`));
+  b.take('random', many, 30);
+  assert.equal(b.pool.length, 4, 'targetPool ceiling stops accumulation');
+}
+
+// ── edge cases ───────────────────────────────────────────────────────────────
+
+// Candidates without an id are skipped (they can't be enqueued / deduped).
+{
+  const b = createPoolBuilder({ recentIds: new Set(), recentKeys: new Set(), targetPool: 30, maxPerArtist: 99 });
+  b.take('mood', [{ title: 'No Id', artist: 'Ghost' }, song('real', 'Real', 'Band')], 30);
+  assert.equal(b.pool.length, 1, 'id-less candidates are skipped');
+  assert.equal(b.pool[0].id, 'real', 'only the id-bearing track is kept');
+}
+
+// A title-less row must NOT collapse an artist's whole catalogue via an empty
+// key — two title-less tracks by one artist stay distinct (deduped by id only).
+{
+  const b = createPoolBuilder({ recentIds: new Set(), recentKeys: new Set(), targetPool: 30, maxPerArtist: 99 });
+  b.take('mood', [
+    { id: 'x1', title: '', artist: 'Band' },
+    { id: 'x2', title: '', artist: 'Band' },
+  ], 30);
+  assert.equal(b.pool.length, 2, 'title-less rows dedupe by id only, not by an empty key');
+}
+
+// Accepted tracks are stamped with their source label.
+{
+  const b = createPoolBuilder({ recentIds: new Set(), recentKeys: new Set(), targetPool: 30, maxPerArtist: 99 });
+  b.take('starred', [song('s', 'S', 'A')], 30);
+  assert.equal(b.pool[0]._source, 'starred', 'pool entry carries the source label');
+}
+
+console.log('auto-pool.test.ts: all assertions passed');

--- a/controller/src/broadcast/auto-pool.ts
+++ b/controller/src/broadcast/auto-pool.ts
@@ -1,0 +1,66 @@
+// Pure pool builder for the auto.m3u fallback (broadcast/scheduler.ts).
+//
+// Accumulates candidate tracks from several weighted Navidrome/library sources
+// into a single balanced pool, applying three guards on every candidate:
+//   1. Recency  — drop anything played in the recent window (by id AND by
+//      lowercased `title|artist` key, so N duplicate copies of one song — N
+//      distinct Subsonic ids — can't slip a just-played track back on air, #874).
+//   2. Dedup    — never add the same track twice (again by id AND key, so
+//      duplicate library copies don't each claim a slot).
+//   3. Artist cap — cap any one artist's share so a deep-catalogue artist can't
+//      dominate the fallback and cluster on air.
+//
+// Extracted from the `take()` closure so the guards are unit-testable in
+// isolation (scripts/auto-pool.test.ts) without booting Subsonic/Liquidsoap.
+// No I/O — the caller fetches the source lists and feeds them in via take().
+
+import { artistKey, trackKey } from '../music/recency.js';
+
+export interface PoolBuilderOpts {
+  recentIds: Set<string>;
+  recentKeys: Set<string>;   // lowercased `title|artist` of recent plays
+  targetPool: number;        // stop accepting once the pool reaches this size
+  maxPerArtist: number;      // cap any one artist's share of the pool
+}
+
+export interface PoolBuilder {
+  pool: any[];                          // accumulated candidates (with `_source`)
+  fromSource: Record<string, number>;   // per-source accepted counts (for logging)
+  // Pull up to `cap` fresh candidates from `items` under label `label`, applying
+  // the recency / dedup / artist-cap guards. Mutates `pool` and `fromSource`.
+  take: (label: string, items: any[], cap: number) => void;
+}
+
+export function createPoolBuilder(opts: PoolBuilderOpts): PoolBuilder {
+  const { recentIds, recentKeys, targetPool, maxPerArtist } = opts;
+  const pool: any[] = [];
+  const fromSource: Record<string, number> = {};
+  const artistInPool = new Map<string, number>();
+  const poolIds = new Set<string>();
+  const poolKeys = new Set<string>();
+
+  const take = (label: string, items: any[], cap: number) => {
+    let n = 0;
+    for (const t of items) {
+      if (n >= cap || pool.length >= targetPool) break;
+      if (!t?.id) continue;
+      // Key only when the song has a title (mirrors queue.recentlyPlayed's keyOf
+      // guard) so a title-less row can't collapse an artist's whole catalogue.
+      const tk = t.title ? trackKey(t) : '';
+      // Recency: block by id AND title|artist key (defeats duplicate copies).
+      if (recentIds.has(t.id) || (tk && recentKeys.has(tk))) continue;
+      // Pool dedup: by id AND key, so copies #2..N don't re-fill the pool.
+      if (poolIds.has(t.id) || (tk && poolKeys.has(tk))) continue;
+      const ak = artistKey(t);
+      if (ak && (artistInPool.get(ak) || 0) >= maxPerArtist) continue;
+      pool.push({ ...t, _source: label });
+      poolIds.add(t.id);
+      if (tk) poolKeys.add(tk);
+      fromSource[label] = (fromSource[label] || 0) + 1;
+      if (ak) artistInPool.set(ak, (artistInPool.get(ak) || 0) + 1);
+      n++;
+    }
+  };
+
+  return { pool, fromSource, take };
+}

--- a/controller/src/broadcast/liquidsoap-control.ts
+++ b/controller/src/broadcast/liquidsoap-control.ts
@@ -115,6 +115,24 @@ export async function skipTrack() {
   return sendCommand('skip', 2000);
 }
 
+// Force the auto.m3u fallback playlist to re-read from disk. The playlist
+// (id="auto" in radio.liq) uses reload_mode="watch", but that inotify watch can
+// silently orphan itself — the controller rewrites auto.m3u via atomic rename,
+// which swaps the inode each time, and a single missed watch means Liquidsoap
+// loops the last-loaded ~30-track snapshot forever until the container restarts
+// (issue #874). Calling the playlist's built-in `auto.reload` telnet command
+// after every write makes the reload deterministic instead of trusting inotify.
+// Best-effort: swallow errors (telnet may be unreachable in dev or mid-restart)
+// so a refresh never fails on the reload.
+export async function reloadAutoPlaylist(): Promise<boolean> {
+  try {
+    await sendCommand('auto.reload', 2000);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // Start / stop / query the broadcast. radio.liq registers stream_on /
 // stream_off / stream_status server commands: stream_off shuts the Icecast
 // output down so the /stream.mp3 mount disconnects (the station goes off

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -11,11 +11,11 @@ import * as subsonic from '../music/subsonic.js';
 import * as dj from '../llm/dj.js';
 import * as library from '../music/library.js';
 import * as settings from '../settings.js';
-import { artistKey, trackKey } from '../music/recency.js';
 import { normGenre, genreMatches, inYearRange, preferEnergy, preferEnergyStrict, preferMood } from '../music/show-filter.js';
 import { resolveShowPlaylistPool, resolveExcludedPlaylistIds } from '../music/show-playlist.js';
 import { getFullContext } from '../context.js';
 import { queue } from './queue.js';
+import { createPoolBuilder } from './auto-pool.js';
 import { reloadAutoPlaylist } from './liquidsoap-control.js';
 import * as session from './session.js';
 import * as djAgent from './dj-agent.js';
@@ -142,40 +142,21 @@ async function refreshAutoPlaylistInner() {
   // genre/era it honours its track-length cap too.
   const maxDurationSec = settings.effectiveMaxTrackSec(show);
 
-  const pool: any[] = [];
-  const fromSource: Record<string, number> = { 'show-genre': 0, 'show-playlist': 0, mood: 0, playlist: 0, recent: 0, frequent: 0, starred: 0, random: 0 };
-  // Cap each artist's share of the pool. Without this, a deep-catalogue artist
-  // (many mood-tagged / starred / frequent tracks) can dominate the fallback
-  // playlist, so whenever Liquidsoap coasts on auto.m3u the same artist clusters
-  // on air — e.g. one artist's tracks airing 7× purely from this source.
-  const artistInPool = new Map<string, number>();
-  // Track what's already in the pool by BOTH id and `title|artist` key, so N
-  // duplicate copies of one song (N distinct ids) can't each claim a slot — the
-  // fallback would otherwise stack the same track and defeat the anti-repeat the
-  // recency filter above provides (issue #874). Key only used when the song has
-  // a title (mirrors queue.recentlyPlayed's keyOf guard).
-  const poolIds = new Set<string>();
-  const poolKeys = new Set<string>();
-  const take = (label: string, items: any[], cap: number) => {
-    let n = 0;
-    for (const t of items) {
-      if (n >= cap || pool.length >= TARGET_POOL) break;
-      if (!t?.id) continue;
-      const tk = t.title ? trackKey(t) : '';
-      // Recency: block by id AND title|artist key (defeats duplicate copies).
-      if (recentIds.has(t.id) || (tk && recentKeys.has(tk))) continue;
-      // Pool dedup: by id AND key, so copies #2..N don't re-fill the pool.
-      if (poolIds.has(t.id) || (tk && poolKeys.has(tk))) continue;
-      const ak = artistKey(t);
-      if (ak && (artistInPool.get(ak) || 0) >= AUTO_MAX_PER_ARTIST) continue;
-      pool.push({ ...t, _source: label });
-      poolIds.add(t.id);
-      if (tk) poolKeys.add(tk);
-      fromSource[label] = (fromSource[label] || 0) + 1;
-      if (ak) artistInPool.set(ak, (artistInPool.get(ak) || 0) + 1);
-      n++;
-    }
-  };
+  // Balanced pool builder — applies the recency / dedup / artist-cap guards on
+  // every candidate. Recency and dedup key on BOTH id and `title|artist` so a
+  // library with duplicate copies of a song (N distinct ids for one track)
+  // can't slip a just-played track back in or stack copies into the pool (#874).
+  // The artist cap stops a deep-catalogue artist from dominating the fallback.
+  // Pure + unit-tested in scripts/auto-pool.test.ts.
+  const builder = createPoolBuilder({
+    recentIds,
+    recentKeys,
+    targetPool: TARGET_POOL,
+    maxPerArtist: AUTO_MAX_PER_ARTIST,
+  });
+  const pool = builder.pool;
+  const fromSource = builder.fromSource;
+  const take = builder.take;
 
   await library.load();
 

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -11,11 +11,12 @@ import * as subsonic from '../music/subsonic.js';
 import * as dj from '../llm/dj.js';
 import * as library from '../music/library.js';
 import * as settings from '../settings.js';
-import { artistKey } from '../music/recency.js';
+import { artistKey, trackKey } from '../music/recency.js';
 import { normGenre, genreMatches, inYearRange, preferEnergy, preferEnergyStrict, preferMood } from '../music/show-filter.js';
 import { resolveShowPlaylistPool, resolveExcludedPlaylistIds } from '../music/show-playlist.js';
 import { getFullContext } from '../context.js';
 import { queue } from './queue.js';
+import { reloadAutoPlaylist } from './liquidsoap-control.js';
 import * as session from './session.js';
 import * as djAgent from './dj-agent.js';
 import { cleanupOldVoices } from '../audio/tts.js';
@@ -73,8 +74,12 @@ export async function refreshAutoPlaylist() {
 async function refreshAutoPlaylistInner() {
   const ctx = await getFullContext();
   const mood = ctx.dominantMood;
-  // Match the auto-DJ picker's window (dj-agent.pickViaAgent) — 12h.
-  const recent = queue.recentlyPlayedIds(12);
+  // Match the auto-DJ picker's window (dj-agent.pickViaAgent) — 12h. Keyed by
+  // BOTH id and lowercased `title|artist`: a library with duplicate copies of a
+  // song holds N Subsonic ids for it, so an id-only recency filter lets copies
+  // #2..N sail into the fallback and re-air a just-played track (issue #874).
+  // Mirrors collect() in the picker's tool layer.
+  const { ids: recentIds, keys: recentKeys } = queue.recentlyPlayed(12);
 
   // The fallback is what airs when the live AI picks pause (e.g. pause-when-empty
   // with zero listeners). When a show is scheduled for this hour, the fallback
@@ -144,14 +149,28 @@ async function refreshAutoPlaylistInner() {
   // playlist, so whenever Liquidsoap coasts on auto.m3u the same artist clusters
   // on air — e.g. one artist's tracks airing 7× purely from this source.
   const artistInPool = new Map<string, number>();
+  // Track what's already in the pool by BOTH id and `title|artist` key, so N
+  // duplicate copies of one song (N distinct ids) can't each claim a slot — the
+  // fallback would otherwise stack the same track and defeat the anti-repeat the
+  // recency filter above provides (issue #874). Key only used when the song has
+  // a title (mirrors queue.recentlyPlayed's keyOf guard).
+  const poolIds = new Set<string>();
+  const poolKeys = new Set<string>();
   const take = (label: string, items: any[], cap: number) => {
     let n = 0;
     for (const t of items) {
       if (n >= cap || pool.length >= TARGET_POOL) break;
-      if (!t?.id || recent.has(t.id) || pool.find((p: any) => p.id === t.id)) continue;
+      if (!t?.id) continue;
+      const tk = t.title ? trackKey(t) : '';
+      // Recency: block by id AND title|artist key (defeats duplicate copies).
+      if (recentIds.has(t.id) || (tk && recentKeys.has(tk))) continue;
+      // Pool dedup: by id AND key, so copies #2..N don't re-fill the pool.
+      if (poolIds.has(t.id) || (tk && poolKeys.has(tk))) continue;
       const ak = artistKey(t);
       if (ak && (artistInPool.get(ak) || 0) >= AUTO_MAX_PER_ARTIST) continue;
       pool.push({ ...t, _source: label });
+      poolIds.add(t.id);
+      if (tk) poolKeys.add(tk);
       fromSource[label] = (fromSource[label] || 0) + 1;
       if (ak) artistInPool.set(ak, (artistInPool.get(ak) || 0) + 1);
       n++;
@@ -299,6 +318,14 @@ async function refreshAutoPlaylistInner() {
   // Atomic replace: Liquidsoap watches this file (reload_mode="watch"), so an
   // in-place write can trigger a reload that loads a truncated playlist.
   await writeFileAtomic(config.liquidsoap.autoPlaylist, lines.join('\n'));
+  // Deterministic reload: don't trust Liquidsoap's inotify watch. The atomic
+  // rename above swaps the file's inode, and if the watch ever orphans itself
+  // the fallback loops the last-loaded ~30-track snapshot forever until the
+  // container restarts (issue #874). Telnet `auto.reload` forces a re-read every
+  // time; best-effort so an unreachable mixer (dev / mid-restart) never fails
+  // the refresh — the watch remains as a backstop.
+  const reloaded = await reloadAutoPlaylist();
+  if (!reloaded) queue.log('scheduler', 'Auto-playlist written but telnet reload failed — relying on inotify watch');
 
   // Make the show-scoping visible to the operator (acceptance criteria #629):
   // a misspelled / absent strict genre that silently degraded, and a strict show

--- a/controller/src/config.ts
+++ b/controller/src/config.ts
@@ -202,7 +202,10 @@ export const config = {
     // queue.history is capped at 50 (~3h) and only lives in-memory, which is
     // why we keep a separate, longer-lived store.
     recentPlaysFile: `${STATE_DIR}/recent-plays.json`,
-    recentPlaysMax: 300,
+    // Rolling 24h play log cap. With a 3-min max-track cap the station can burn
+    // ~550 plays/day, so 300 entries barely spanned the 12h anti-repeat window
+    // (issue #874); 600 keeps the full window populated at that churn.
+    recentPlaysMax: 600,
     // Count-based hard no-repeat guard: the picker (both pool and agent paths)
     // never re-airs any of the last N DISTINCT plays. Unlike the time-window
     // guard (recencyWindowsForLibrary) this is non-relaxable — it survives the


### PR DESCRIPTION
Fixes #874.

Two independent faults in the `auto.m3u` fallback path made listeners hear the same ~30 tracks on repeat despite a large library. Both are small controller/scheduler changes that also harden the station for upstream operators.

## Fault 1 — Liquidsoap silently stops reloading `auto.m3u`
`reload_mode="watch"` relies on inotify, but the watch can orphan itself: the controller rewrites `auto.m3u` via atomic rename (`writeFileAtomic`), which swaps the file's inode on every write, and a single missed watch leaves Liquidsoap looping the last-loaded snapshot until the container restarts (the July-5 case: 333 auto plays cycling only 35 distinct titles).

**Fix:** after each write, the controller telnets the playlist's built-in `auto.reload` command (`broadcast/liquidsoap-control.ts` → new `reloadAutoPlaylist()`). Deterministic; the inotify watch stays as a backstop. Best-effort — an unreachable mixer (dev / mid-restart) logs a note and never fails the refresh.

- Verified `auto.reload` is a real telnet command in Liquidsoap 2.4.5 (the pinned image): it appears in `help` and returns `OK` for an `id="auto"` playlist.

## Fault 2 — duplicate library copies bypass id-keyed anti-repeat
`refreshAutoPlaylistInner` filtered recents and deduped the pool **by Subsonic id only**. A library holding the same song more than once (N ids for one title) defeated the guard — playing copy #1 didn't block copies #2..N.

**Fix:** filter recents *and* dedupe the pool by lowercased `title|artist` key as well as id, mirroring `collect()` in the picker's tool layer. `queue.recentlyPlayed(12)` already returns `.keys`, so this reuses the existing key format.

## Fix 3 (optional, from the issue)
Bump `recentPlaysMax` 300 → 600 (`config.ts`). At ~550 plays/day (3-min max-track churn) 300 entries barely spanned the 12h anti-repeat window.

## Verification
- `npm run lint` (eslint + `tsc --noEmit`) green — 0 errors.
- `auto.reload` empirically confirmed against `savonet/liquidsoap:v2.4.5`.
- Post-deploy runtime check (from the issue): over 24h, no track >3×/24h, none twice within any 8h window, and distinct/total on `src=auto` plays stays ≳90%/day.