### PR TITLE
feat(web): favicon → sunburst disc mark

### DIFF
--- a/web/app/apple-icon.js
+++ b/web/app/apple-icon.js
@@ -1,32 +1,9 @@
 import { ImageResponse } from 'next/og';
+import { DiscMark } from '../lib/discMark';
 
 export const size = { width: 180, height: 180 };
 export const contentType = 'image/png';
 
 export default function AppleIcon() {
-  return new ImageResponse(
-    (
-      <div
-        style={{
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          background: '#100e0c',
-        }}
-      >
-        <div
-          style={{
-            width: 22,
-            height: 110,
-            background: '#f3efe6',
-            transform: 'rotate(35deg)',
-            borderRadius: 9,
-          }}
-        />
-      </div>
-    ),
-    { ...size }
-  );
+  return new ImageResponse(<DiscMark size={size.width} />, { ...size });
 }

--- a/web/app/icon.js
+++ b/web/app/icon.js
@@ -1,32 +1,9 @@
 import { ImageResponse } from 'next/og';
+import { DiscMark } from '../lib/discMark';
 
 export const size = { width: 64, height: 64 };
 export const contentType = 'image/png';
 
 export default function Icon() {
-  return new ImageResponse(
-    (
-      <div
-        style={{
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          background: '#100e0c',
-        }}
-      >
-        <div
-          style={{
-            width: 8,
-            height: 38,
-            background: '#f3efe6',
-            transform: 'rotate(35deg)',
-            borderRadius: 3,
-          }}
-        />
-      </div>
-    ),
-    { ...size }
-  );
+  return new ImageResponse(<DiscMark size={size.width} />, { ...size });
 }

--- a/web/app/icons/[size]/route.js
+++ b/web/app/icons/[size]/route.js
@@ -1,7 +1,8 @@
 import { ImageResponse } from 'next/og';
+import { DiscMark } from '../../../lib/discMark';
 
-// Renders the SUB/WAVE slash mark at any size, with an optional maskable
-// variant that respects the Android 80% safe zone (smaller slash + larger
+// Renders the SUB/WAVE disc mark at any size, with an optional maskable
+// variant that respects the Android 80% safe zone (smaller disc + larger
 // dark padding so it fills the adaptive icon mask without clipping).
 // Routes (all served as PNG):
 //   /icons/192            — manifest standard 192
@@ -29,35 +30,12 @@ export async function GET(_req, { params }) {
   if (!variant) return new Response('Not Found', { status: 404 });
 
   const { size, maskable } = variant;
-  // Standard icons fill more of the canvas; maskable shrinks to ~62% so the
-  // slash stays inside the launcher's safe zone after the mask is applied.
-  const slashHeight = maskable ? size * 0.42 : size * 0.62;
-  const slashWidth = maskable ? size * 0.085 : size * 0.12;
-  const radius = slashWidth * 0.45;
+  // Standard icons fill most of the canvas; maskable shrinks the disc to
+  // ~58% so it stays inside the launcher's safe zone after the mask.
+  const fill = maskable ? 0.58 : 0.8;
 
-  return new ImageResponse(
-    (
-      <div
-        style={{
-          width: size,
-          height: size,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          background: '#100e0c',
-        }}
-      >
-        <div
-          style={{
-            width: slashWidth,
-            height: slashHeight,
-            background: '#f3efe6',
-            transform: 'rotate(35deg)',
-            borderRadius: radius,
-          }}
-        />
-      </div>
-    ),
-    { width: size, height: size }
-  );
+  return new ImageResponse(<DiscMark size={size} fill={fill} />, {
+    width: size,
+    height: size,
+  });
 }

--- a/web/lib/discMark.js
+++ b/web/lib/discMark.js
@@ -1,0 +1,59 @@
+// Shared SUB/WAVE disc mark for the favicons and PWA install icons.
+//
+// The sunburst disc — cream face, 20 ink spokes, a vermilion hub on the
+// near-black plate — is the station's real logo (same mark as the native
+// app icon, app/assets/icon.png, and the .bs-wordmark-disc-face hover state
+// in globals.css, whose repeating-conic-gradient is 9deg ink / 9deg gap).
+// Rendered as inline SVG so next/og (Satori) reproduces it crisply at any
+// size instead of the old single rotated slash.
+
+const BG = '#100e0c'; // dark plate (--bg)
+const DISC = '#ece6dc'; // cream face (--ink, dark theme)
+const SPOKE = '#141310'; // ink spokes
+const HUB = '#d94b2a'; // hot vermilion hub (--accent)
+
+// 20 pie wedges — 9deg of ink, 9deg of cream gap — as SVG arc paths on a
+// 100x100 canvas centred at (50,50).
+function spokePaths(r) {
+  const rad = (deg) => (deg * Math.PI) / 180;
+  const paths = [];
+  for (let i = 0; i < 20; i++) {
+    const a0 = rad(i * 18);
+    const a1 = rad(i * 18 + 9);
+    const x0 = (50 + r * Math.cos(a0)).toFixed(3);
+    const y0 = (50 + r * Math.sin(a0)).toFixed(3);
+    const x1 = (50 + r * Math.cos(a1)).toFixed(3);
+    const y1 = (50 + r * Math.sin(a1)).toFixed(3);
+    paths.push(`M50 50 L${x0} ${y0} A${r} ${r} 0 0 1 ${x1} ${y1} Z`);
+  }
+  return paths;
+}
+
+// `fill` (0-1) is how much of the canvas the disc occupies — standard icons
+// fill most of it (~0.8); maskable icons shrink so the disc stays inside the
+// Android launcher safe zone once the adaptive mask is applied.
+export function DiscMark({ size, fill = 0.8 }) {
+  const r = 50 * fill;
+  const hub = r * 0.31;
+  const wedges = spokePaths(r);
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        background: BG,
+      }}
+    >
+      <svg width={size} height={size} viewBox="0 0 100 100">
+        <circle cx="50" cy="50" r={r} fill={DISC} />
+        {wedges.map((d, i) => (
+          <path key={i} d={d} fill={SPOKE} />
+        ))}
+        {/* dark ring, then the vermilion hub over the converging spokes */}
+        <circle cx="50" cy="50" r={hub + 1.4} fill={BG} />
+        <circle cx="50" cy="50" r={hub} fill={HUB} />
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Replaces the web favicon (and the Apple touch icon + PWA install icons) with the station's real logo — the **sunburst disc** (cream face, 20 ink spokes, vermilion hub on the near-black plate), the same mark already shipping as the native app icon (`app/assets/icon.png`).

Previously all three surfaces drew the old **single rotated slash**, which no longer matches the brand.

## How

- New shared `web/lib/discMark.js` renders the disc as **inline SVG through `next/og`** (Satori), so it stays crisp at any size — no raster asset to keep in sync.
- `web/app/icon.js` (64px tab favicon), `web/app/apple-icon.js` (180px), and the `web/app/icons/[size]/route.js` PWA route (192/512 + maskable) all now render `DiscMark`.
- Colours come straight from the brand tokens: `#100e0c` plate, `#ece6dc` cream face, `#141310` spokes, `#d94b2a` vermilion hub.
- Maskable variants shrink the disc to ~58% so it stays inside the Android launcher safe zone.

## Verification

- `npm run lint` (eslint + tsc) clean — 0 errors.
- Rendered `/icon`, `/apple-icon`, `/icons/512` and `/icons/512-maskable` from a dev server and confirmed the output matches the native app mark; the 64px favicon stays legible and the maskable variant respects the safe zone.