### PR TITLE
fix(landing): a11y + polish touchups across the broadsheet

### DIFF
--- a/web/components/Landing.tsx
+++ b/web/components/Landing.tsx
@@ -20,9 +20,15 @@ import type { ShowcaseStation } from '@/lib/stations';
 export default function Landing({ stations = [] }: { stations?: ShowcaseStation[] }) {
   return (
     <div className="min-h-screen bg-bg text-ink">
+      <a
+        href="#landing-main"
+        className="sr-only z-50 bg-bg px-4 py-2 text-[12px] font-bold tracking-[0.18em] text-ink uppercase focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:border focus:border-ink"
+      >
+        Skip to content
+      </a>
       <Masthead />
 
-      <main className="bs-paper pt-0">
+      <main id="landing-main" className="bs-paper pt-0">
         <ArticleHead />
         <OnTheAir stations={stations} />
         <MeetTheVoices />

--- a/web/components/landing/Masthead.tsx
+++ b/web/components/landing/Masthead.tsx
@@ -53,7 +53,7 @@ export default function Masthead() {
         </div>
       </div>
 
-      <div className="bs-masthead-motto" aria-label="Motto">
+      <div className="bs-masthead-motto">
         <span aria-hidden="true">✦</span>
         <span className="bs-masthead-motto-text">
           No skips&nbsp;·&nbsp;No shuffle&nbsp;·&nbsp;Just radio

--- a/web/components/landing/Navidrome.tsx
+++ b/web/components/landing/Navidrome.tsx
@@ -20,18 +20,18 @@ export default function Navidrome() {
       <div className="bs-navidrome-grid">
         <div className="bs-navidrome-copy">
           <p className="bs-eyebrow">WORKS WITH YOUR LIBRARY</p>
-          <h2>We don't bring the music. You do.</h2>
+          <h2>We don&rsquo;t bring the music. You do.</h2>
           <p className="text-muted">
             SUB/WAVE is the DJ, the mixer, and the broadcast layer. The music
             comes from <strong className="text-ink">your</strong>{' '}
             Navidrome, the self-hosted music server with a Subsonic API. Run
             Navidrome on your homelab, point SUB/WAVE at it, and the DJ
-            picks from your collection. Nobody else's algorithm. Nobody else's catalogue.
+            picks from your collection. Nobody else&rsquo;s algorithm. Nobody else&rsquo;s catalogue.
           </p>
 
           <ul className="bs-navidrome-bullets">
             <li><strong>Your taste, not a recommendation engine.</strong> The picker reads the metadata you tagged (genres, moods, your own folders) and chooses from there.</li>
-            <li><strong>No licensing fees.</strong> You already own (or, you know, have on disk) the music. SUB/WAVE doesn't add a streaming bill on top.</li>
+            <li><strong>No licensing fees.</strong> You already own (or, you know, have on disk) the music. SUB/WAVE doesn&rsquo;t add a streaming bill on top.</li>
             <li><strong>Private by default.</strong> Listeners hit one MP3 stream. Nobody outside your stack ever sees your library, your tags, or who requested what.</li>
             <li><strong>BYO Subsonic-compatible server.</strong> Subsonic, Airsonic, Gonic, Funkwhale. If it speaks the Subsonic API, it works.</li>
             <li><strong>Scrobbles like a real station.</strong> Every spin can report to Last.fm or ListenBrainz, including your own self-hosted instance.</li>
@@ -39,7 +39,7 @@ export default function Navidrome() {
 
           <div className="bs-navidrome-cta">
             <Link href="/setup" className="bs-tune">
-              Connect your library &nbsp;→
+              Connect your library <span aria-hidden="true">&nbsp;→</span>
             </Link>
             <AnimatedLink
               href="https://www.navidrome.org/"

--- a/web/components/landing/PlayerShowcase.tsx
+++ b/web/components/landing/PlayerShowcase.tsx
@@ -89,7 +89,7 @@ export default function PlayerShowcase({ stations = [] }: PlayerShowcaseProps) {
     <div className="bs-frame">
       {visible.length > 1 && (
         <div className="bs-frame-tabs" role="tablist" aria-label="Stations">
-          {visible.map((s) => {
+          {visible.map((s, i) => {
             const selected = s.slug === active?.slug;
             return (
               <button
@@ -97,9 +97,34 @@ export default function PlayerShowcase({ stations = [] }: PlayerShowcaseProps) {
                 type="button"
                 role="tab"
                 aria-selected={selected}
+                tabIndex={selected ? 0 : -1}
                 className="bs-frame-tab"
                 data-active={selected || undefined}
                 onClick={() => setActiveSlug(s.slug)}
+                onKeyDown={(e) => {
+                  // Roving-tabindex tablist: arrows move between station tabs,
+                  // selection follows focus (each tab swap is cheap — a remount
+                  // of the embedded player).
+                  const delta =
+                    e.key === 'ArrowRight' ? 1 : e.key === 'ArrowLeft' ? -1 : 0;
+                  const next =
+                    delta !== 0
+                      ? (i + delta + visible.length) % visible.length
+                      : e.key === 'Home'
+                        ? 0
+                        : e.key === 'End'
+                          ? visible.length - 1
+                          : null;
+                  const target = next === null ? undefined : visible[next];
+                  if (next === null || !target) return;
+                  e.preventDefault();
+                  setActiveSlug(target.slug);
+                  const tabs =
+                    e.currentTarget.parentElement?.querySelectorAll<HTMLElement>(
+                      '[role="tab"]',
+                    );
+                  tabs?.[next]?.focus();
+                }}
                 title={s.genre || s.name}
               >
                 <span className="bs-frame-tab-dot" aria-hidden="true" />

--- a/web/components/what/ArticleHead.tsx
+++ b/web/components/what/ArticleHead.tsx
@@ -17,7 +17,7 @@ export default function ArticleHead() {
 
         <div className="bs-hero-cta">
           <Link href="/setup" className="bs-tune">
-            Setup &nbsp;→
+            Setup <span aria-hidden="true">&nbsp;→</span>
           </Link>
           <a
             href="https://github.com/perminder-klair/subwave"
@@ -25,7 +25,7 @@ export default function ArticleHead() {
             rel="noreferrer"
             className="bs-tune bs-tune--ghost"
           >
-            Source &nbsp;↗
+            Source <span aria-hidden="true">&nbsp;↗</span>
           </a>
         </div>
       </div>

--- a/web/components/what/BehindTheDesk.tsx
+++ b/web/components/what/BehindTheDesk.tsx
@@ -66,6 +66,8 @@ export default function BehindTheDesk() {
         src="/screenshots/admin-dash.webp"
         alt="Admin — Dash"
         label="Admin — Dash"
+        width={2360}
+        height={1640}
         caption="The Dash panel: live status, the queue, the booth log, and manual voice control."
       />
 
@@ -86,6 +88,8 @@ export default function BehindTheDesk() {
                   alt={p.fig.label}
                   label={p.fig.label}
                   caption={p.fig.caption}
+                  width={2360}
+                  height={1640}
                 />
               </div>
             )}
@@ -98,12 +102,16 @@ export default function BehindTheDesk() {
           src="/screenshots/admin-library.webp"
           alt="Admin — Library"
           label="Admin — Library"
+          width={2360}
+          height={1640}
           caption="Library: search by text, mood, and energy, queue any track, and run the mood tagger."
         />
         <Figure
           src="/screenshots/admin-debug.webp"
           alt="Admin — Debug"
           label="Admin — Debug"
+          width={2360}
+          height={1640}
           caption="Debug: a health strip, Liquidsoap logs, and recent LLM calls, refreshed live."
         />
       </div>

--- a/web/components/what/Coda.tsx
+++ b/web/components/what/Coda.tsx
@@ -12,9 +12,11 @@ export default function Coda() {
       </p>
 
       <div className="mt-2 flex flex-wrap items-center justify-center gap-4">
-        <Link href="/stations" className="bs-tune">▶ Browse the stations</Link>
+        <Link href="/stations" className="bs-tune">
+          <span aria-hidden="true">▶ </span>Browse the stations
+        </Link>
         <Link href="/setup" className="bs-link text-[13px] font-bold tracking-[0.12em] uppercase">
-          Run your own station →
+          Run your own station <span aria-hidden="true">→</span>
         </Link>
       </div>
 
@@ -26,7 +28,7 @@ export default function Coda() {
           rel="noreferrer"
           className="bs-link font-semibold tracking-[inherit] text-ink"
         >
-          App Store ↗
+          App Store <span aria-hidden="true">↗</span>
         </a>
         <span aria-hidden>·</span>
         <a
@@ -35,7 +37,7 @@ export default function Coda() {
           rel="noreferrer"
           className="bs-link font-semibold tracking-[inherit] text-ink"
         >
-          Google Play ↗
+          Google Play <span aria-hidden="true">↗</span>
         </a>
       </p>
     </EditorialReveal>

--- a/web/components/what/Figure.tsx
+++ b/web/components/what/Figure.tsx
@@ -9,6 +9,9 @@ interface FigureProps {
   caption?: string;
   label?: string;
   ratio?: '16 / 10' | '9 / 16';
+  /** Intrinsic pixel size of `src` — reserves the box before load (no CLS). */
+  width?: number;
+  height?: number;
 }
 
 // Screenshot slot for the /what feature story. While `src` is empty it renders
@@ -18,7 +21,15 @@ interface FigureProps {
 // Mount-driven stagger: image fades first, caption fades + rises 180 ms
 // behind. Mimics reading order. No scroll trigger — everything settles as the
 // page loads.
-export default function Figure({ src, alt, caption, label, ratio = '16 / 10' }: FigureProps) {
+export default function Figure({
+  src,
+  alt,
+  caption,
+  label,
+  ratio = '16 / 10',
+  width,
+  height,
+}: FigureProps) {
   const aspectClass = ratio === '9 / 16' ? 'aspect-[9/16]' : 'aspect-[16/10]';
   return (
     <figure className="m-0 flex flex-col gap-2">
@@ -26,6 +37,10 @@ export default function Figure({ src, alt, caption, label, ratio = '16 / 10' }: 
         <m.img
           src={src}
           alt={alt || caption || label || ''}
+          width={width}
+          height={height}
+          loading="lazy"
+          decoding="async"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: 0.28, ease: [0.2, 0.7, 0.2, 1] }}

--- a/web/components/what/MakeARequest.tsx
+++ b/web/components/what/MakeARequest.tsx
@@ -67,6 +67,8 @@ export default function MakeARequest() {
             label="Player — Request a Song"
             caption="The request drawer: type a song, get an instant ack, watch the match land."
             ratio="9 / 16"
+            width={828}
+            height={1792}
           />
         </div>
       </div>

--- a/web/components/what/MeetTheVoices.tsx
+++ b/web/components/what/MeetTheVoices.tsx
@@ -34,6 +34,8 @@ export default function MeetTheVoices() {
         src="/screenshots/admin-personas.webp"
         alt="Admin — Personas"
         label="Admin — Personas"
+        width={2360}
+        height={1640}
         caption="The persona roster: up to twenty-four DJ identities, each with its own voice and habits."
       />
 

--- a/web/components/what/UnderTheHood.tsx
+++ b/web/components/what/UnderTheHood.tsx
@@ -38,7 +38,11 @@ export default function UnderTheHood() {
                 {b.note}
               </div>
             </div>
-            {i < BOXES.length - 1 && <div className="bs-arrow">⟶</div>}
+            {i < BOXES.length - 1 && (
+              <div className="bs-arrow" aria-hidden="true">
+                ⟶
+              </div>
+            )}
           </Fragment>
         ))}
       </div>


### PR DESCRIPTION
Small design/UX/a11y touchups on the landing page, following the recent header + footer refresh (#852, #880, #881). Reviewed against the Web Interface Guidelines; header and footer themselves came out almost clean — most fixes landed in the article sections.

## Changes

- **No more layout shift from screenshots** — every `Figure` screenshot now carries its intrinsic `width`/`height` so the browser reserves the box before the image loads, plus `loading="lazy"`/`decoding="async"` (they're all below the fold).
- **Skip-to-content link** — first Tab press reveals a broadsheet-styled "Skip to content" link that jumps past the masthead.
- **Station tabs keyboard nav** — the player-showcase tab strip (`role="tablist"`) now implements the roving-tabindex pattern: Arrow keys / Home / End move between stations, selection follows focus.
- **Decorative glyphs hidden from screen readers** — the `→ ↗ ▶ ⟶` ornaments in the hero CTAs, Navidrome CTA, coda links, and the under-the-hood flow diagram are `aria-hidden` so AT no longer announces "black right-pointing triangle".
- **Typography** — straight apostrophes in the Navidrome section become curly ones ("We don't bring the music" etc.), matching the rest of the page.
- **Masthead nit** — dropped the invalid `aria-label` on the motto `div` (aria-label isn't valid on a plain div).

## Verified

- `npm run lint` (eslint + tsc) passes — only pre-existing warnings in untouched admin files.
- Rendered at desktop (1440px) and mobile (390px): header, footer, Navidrome section, and coda all render as before; no horizontal overflow; skip link appears on Tab; all 7 figures confirmed carrying dims + lazy in the DOM.