### PR TITLE
fix(web): transparent favicon so the disc reads as round, not a black square

### DIFF
--- a/web/app/icons/[size]/route.js
+++ b/web/app/icons/[size]/route.js
@@ -33,8 +33,9 @@ export async function GET(_req, { params }) {
   // Standard icons fill most of the canvas; maskable shrinks the disc to
   // ~58% so it stays inside the launcher's safe zone after the mask.
   const fill = maskable ? 0.58 : 0.8;
-
-  return new ImageResponse(<DiscMark size={size} fill={fill} />, {
+  // Maskable icons need the opaque dark plate to fill the adaptive-icon safe
+  // zone; standard icons stay transparent so the disc reads as round.
+  return new ImageResponse(<DiscMark size={size} fill={fill} opaque={maskable} />, {
     width: size,
     height: size,
   });

--- a/web/lib/discMark.js
+++ b/web/lib/discMark.js
@@ -32,7 +32,13 @@ function spokePaths(r) {
 // `fill` (0-1) is how much of the canvas the disc occupies — standard icons
 // fill most of it (~0.8); maskable icons shrink so the disc stays inside the
 // Android launcher safe zone once the adaptive mask is applied.
-export function DiscMark({ size, fill = 0.8 }) {
+//
+// `opaque` fills the canvas behind the disc with the dark plate. Off by
+// default so the favicon / apple-touch / standard PWA icons read as a round
+// disc on transparent corners rather than a black square. Maskable icons must
+// set it — Android's adaptive mask needs a full-bleed opaque background or it
+// drops the icon onto a system backdrop and clips it.
+export function DiscMark({ size, fill = 0.8, opaque = false }) {
   const r = 50 * fill;
   const hub = r * 0.31;
   const wedges = spokePaths(r);
@@ -42,7 +48,7 @@ export function DiscMark({ size, fill = 0.8 }) {
         width: '100%',
         height: '100%',
         display: 'flex',
-        background: BG,
+        background: opaque ? BG : 'transparent',
       }}
     >
       <svg width={size} height={size} viewBox="0 0 100 100">


### PR DESCRIPTION
## What

The recently-shipped sunburst disc favicon (#880) appeared as a **black square** in the browser tab — the round disc sat on the station's dark plate (`--bg #100e0c`), which filled the whole icon canvas.

`DiscMark` rendered that plate as a full-canvas `<div>` background. This makes the plate **transparent by default**, so the disc reads as a round mark with transparent corners.

## Icons affected
- **Tab favicon** (`/icon`) and **apple-touch / standard PWA icons** — now transparent → round disc.
- **Maskable PWA icons** (`/icons/*-maskable`) — **kept opaque**. Android's adaptive-icon mask needs a full-bleed opaque background; a transparent maskable icon gets dropped onto a system backdrop and clipped. These pass `opaque` explicitly.

## Verification
- `npm run lint` (eslint + tsc) passes — 0 errors.
- Rendered the exact SVG the component emits: favicon shows the round disc with transparent corners; maskable keeps its full-bleed dark plate + safe-zone disc.