### PR TITLE
style(admin): single-column layout for booth log, DJ log & DJ session

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3141,8 +3141,10 @@ html.lite *::after {
 /* Log line */
 .admin-root .log {
     display: grid;
-    grid-template-columns: 1fr;
-    gap: 2px;
+    grid-template-columns: auto 1fr;
+    align-items: baseline;
+    column-gap: 8px;
+    row-gap: 2px;
     font-size: 11px;
     line-height: 1.6;
     padding: 4px 0;
@@ -3152,12 +3154,14 @@ html.lite *::after {
     color: var(--muted);
 }
 .admin-root .log .k {
+    justify-self: start;
     font-size: 9px;
     letter-spacing: 0.22em;
     text-transform: uppercase;
     font-weight: 700;
 }
 .admin-root .log .msg {
+    grid-column: 1 / -1;
     color: var(--ink);
     word-break: break-word;
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3141,8 +3141,8 @@ html.lite *::after {
 /* Log line */
 .admin-root .log {
     display: grid;
-    grid-template-columns: 64px 96px 1fr;
-    gap: 12px;
+    grid-template-columns: 1fr;
+    gap: 2px;
     font-size: 11px;
     line-height: 1.6;
     padding: 4px 0;

--- a/web/components/admin/DebugPanel.tsx
+++ b/web/components/admin/DebugPanel.tsx
@@ -536,11 +536,8 @@ function SessionChat({ session }: { session: DebugSession }) {
         <div
           key={i}
           className={cn(
-            // 178px fits the widest role·kind label, 'segment·album-anniversary'
-            // (~170px at text-[9px]/tracking-[0.12em]/uppercase) + breathing room.
-            // Each row is its own grid, so a fixed width is needed to keep the
-            // kind column aligned across rows — bump it if a longer kind is added.
-            'grid grid-cols-[auto_178px_1fr] items-baseline gap-2 py-0.5 text-[12px]',
+            // Single column: time, role·kind, and text stack vertically per turn.
+            'grid grid-cols-1 gap-0.5 py-0.5 text-[12px]',
             i < msgs.length - 1 && 'border-b border-dashed border-separator-strong',
           )}
         >

--- a/web/components/admin/DebugPanel.tsx
+++ b/web/components/admin/DebugPanel.tsx
@@ -536,8 +536,9 @@ function SessionChat({ session }: { session: DebugSession }) {
         <div
           key={i}
           className={cn(
-            // Single column: time, role·kind, and text stack vertically per turn.
-            'grid grid-cols-1 gap-0.5 py-0.5 text-[12px]',
+            // Time + role·kind share the first line; text wraps to a full-width
+            // second row below them.
+            'grid grid-cols-[auto_1fr] items-baseline gap-x-2 gap-y-0.5 py-0.5 text-[12px]',
             i < msgs.length - 1 && 'border-b border-dashed border-separator-strong',
           )}
         >
@@ -556,7 +557,7 @@ function SessionChat({ session }: { session: DebugSession }) {
           >
             {m.role}{m.kind ? `·${m.kind}` : ''}
           </span>
-          <span className="break-words whitespace-pre-wrap">{m.text}</span>
+          <span className="col-span-2 break-words whitespace-pre-wrap">{m.text}</span>
         </div>
       ))}
     </div>


### PR DESCRIPTION
Collapses the three-column row layouts in the admin panels to a single column, so each log entry / turn stacks its fields (time, kind/role, message) vertically.

## Changes
- **`web/app/globals.css`** — `.admin-root .log` grid `64px 96px 1fr` → single column (`1fr`), tighter `gap`. Covers the **Booth log** (admin/dash) and the **DJ log** (admin/debug), which share this class.
- **`web/components/admin/DebugPanel.tsx`** — `SessionChat` message rows: `grid-cols-[auto_178px_1fr]` → `grid-cols-1`. Covers the **DJ session** (admin/debug). Removed the now-stale 178px kind-column alignment comment.

## Verification
- `cd web && npm run lint` passes (eslint + tsc): 0 errors; the 3 remaining warnings are pre-existing `any` warnings in unrelated files.