### PR TITLE
fix(dj): let a show's pinned mood and energy override the daypart wind-down

### DIFF
--- a/controller/src/context.ts
+++ b/controller/src/context.ts
@@ -224,8 +224,8 @@ export function getClockContext(date = new Date()) {
 // kokoro, cloud). `register` is a coarse delivery label carried forward for
 // future style/emotion hints (cloud/chatterbox) — Stage 1 only acts on speed.
 //
-// Pure function of the existing daypart + clock so there's a single source of
-// truth and it's trivially testable. A daypart that maps to speed 1.0
+// Function of the daypart + clock + the scheduled show (if it pins an energy)
+// so there's a single source of truth. A daypart that maps to speed 1.0
 // (afternoon) yields no change at all, so a station with the default
 // afternoon profile behaves exactly as before.
 const DAYPART_ENERGY: Record<string, { speed: number; register: string }> = {
@@ -239,7 +239,22 @@ const DAYPART_ENERGY: Record<string, { speed: number; register: string }> = {
   'after-hours':   { speed: 0.92, register: 'intimate' },  // graveyard
 };
 
+// A show's pinned energy overrides the daypart profile wholesale — including
+// the late-night/commute clamps below, because a schedule slot is an explicit
+// operator call (a high-energy evening show should not speak at the 0.97
+// wind-down pace, and a 2am workout show should not be forced intimate).
+// '' (Any) keeps the autonomous daypart behaviour. Values stay inside the
+// daypart table's range so a pin never sounds outside the station's normal
+// delivery envelope.
+const SHOW_ENERGY_DELIVERY: Record<string, { speed: number; register: string }> = {
+  high:   { speed: 1.06, register: 'up' },
+  medium: { speed: 1.0,  register: 'even' },
+  low:    { speed: 0.94, register: 'intimate' },
+};
+
 export function energyForDaypart(date = new Date()) {
+  const pinned = SHOW_ENERGY_DELIVERY[resolveActiveShow(date)?.energy ?? ''];
+  if (pinned) return pinned;
   const { period } = getTimeContext(date);
   const { isLateNight, isCommute } = getClockContext(date);
   const base = DAYPART_ENERGY[period] || { speed: 1.0, register: 'even' };

--- a/controller/src/llm/internal/prompts/context.ts
+++ b/controller/src/llm/internal/prompts/context.ts
@@ -128,7 +128,17 @@ export function buildContextLines(
     // energy pacing in code (context.ts) — it just isn't prompt fodder anymore.
     lines.push(`Local time: ${context.clock.hhmm}${tags.length ? ' · ' + tags.join(' · ') : ''}`);
   }
-  if (on('time') && context?.time) lines.push(`Period: ${context.time.period} (${context.time.vibe})`);
+  if (on('time') && context?.time) {
+    // A show's pinned mood overrides the autonomous mood chain (context.ts),
+    // but the daypart vibe ("wind down") was still riding into every script
+    // prompt and pulling the talk against the show's brief — a high-energy
+    // evening show kept mellowing out. With a mood pinned, keep the period
+    // label (the clock is real) and stand the vibe down; the show line below
+    // carries the tone instead.
+    lines.push(context?.activeShow?.mood
+      ? `Period: ${context.time.period}`
+      : `Period: ${context.time.period} (${context.time.vibe})`);
+  }
   if (on('weather') && context?.weather && context.weather.condition && context.weather.condition !== 'unknown') {
     lines.push(`Weather in ${context.weather.location}: ${context.weather.condition}${context.weather.temp != null ? `, ${context.weather.temp}°${context.weather.tempUnit || 'C'}` : ''}`);
   }
@@ -142,7 +152,11 @@ export function buildContextLines(
     // getFullContext) keeps mid-show links and segments on today's line, not
     // just the standing brief.
     const angle = context.activeShow.episodeAngle ? ` Today's episode angle: ${context.activeShow.episodeAngle}.` : '';
-    lines.push(`On now: the show "${context.activeShow.name}"${topic}.${angle} Stay loosely on its theme.`);
+    // The pinned mood already steers the pick pool via dominantMood, but the
+    // talk prompts never saw it — say it here so the delivery follows the
+    // show's brief, not the hour's default.
+    const mood = context.activeShow.mood ? ` Its mood is ${context.activeShow.mood} — let that set the tone, not the time of day.` : '';
+    lines.push(`On now: the show "${context.activeShow.name}"${topic}.${angle}${mood} Stay loosely on its theme.`);
   }
   if (on('listeners') && context?.listeners?.count != null) {
     const n = context.listeners.count;


### PR DESCRIPTION
## What

A Discord operator reported that a high-energy DJ persona still "winds down" after the evening commute, with no apparent way to change the station's mood. The supported mechanism is a scheduled Show with a pinned mood/energy — but two daypart defaults leaked through and undermined it:

1. **The daypart vibe text still rode into every script prompt.** `buildContextLines` always emitted `Period: evening (wind down)`, nudging the talk against the show's brief even while the show's mood overrode `dominantMood` for picks. Meanwhile the pinned mood itself never reached the talk prompts at all.
2. **TTS pacing ignored the show entirely.** `energyForDaypart()` was a pure function of the clock, so an energetic evening show still spoke at the 0.97 "wind down" rate with a warm register.

## How

- `llm/internal/prompts/context.ts`: when the active show pins a mood, the time line drops the vibe parenthetical (the period label stays — the clock is real) and the show line gains "Its mood is <mood> — let that set the tone, not the time of day." Empty mood ("Any") keeps today's behaviour byte-for-byte.
- `context.ts`: a show's pinned energy (`high`/`medium`/`low`) now maps to a delivery profile (`1.06/up`, `1.0/even`, `0.94/intimate`) that overrides the daypart table, including the late-night/commute clamps — a schedule slot is an explicit operator call. Values stay inside the existing daypart range. `''` (Any) keeps the autonomous daypart pacing. Since `energyForDaypart()` also feeds run-target steering (`dj-agent.ts`) and the mix energy nudge (`queue.ts`), those now follow the show's pinned energy too, which keeps picks and delivery coherent.

## Verification

- `npm run lint` (eslint + tsc) passes in `controller/` — 0 errors.
- Smoke-tested `buildContextLines`: no show → `Period: evening (wind down)`; show with mood pinned → `Period: evening` + mood clause on the show line; show with mood Any → unchanged.
- Smoke-tested `energyForDaypart` with a show painted into the 20:00 schedule slot: no show → `0.97/warm`; energy high → `1.06/up`; low → `0.94/intimate`; Any → `0.97/warm`.