### PR TITLE
feat(mcp): catch the MCP server up with the controller API + on-air sound effects

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,8 @@
 name: Lint
 
 # Runs ESLint + tsc --noEmit on every PR and on pushes to main/develop.
-# Both controller/ and web/ already expose `npm run lint` that does
-# `eslint . && tsc --noEmit`; this just enforces it.
+# controller/ and web/ expose `npm run lint` (`eslint . && tsc --noEmit`);
+# mcp-subwave/ exposes `npm run lint` (`tsc --noEmit`). This just enforces them.
 #
 # The two packages run in a matrix so a controller failure doesn't mask a
 # web failure (and vice versa). Branch protection on main/develop should
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [controller, web]
+        package: [controller, web, mcp-subwave]
     defaults:
       run:
         working-directory: ${{ matrix.package }}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "subwave": {
+      "command": "node",
+      "args": ["mcp-subwave/dist/index.js"],
+      "env": {
+        "SUBWAVE_API_URL": "http://localhost:7701"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ docker compose up -d --build broadcast      # after radio.liq / icecast.xml.temp
 
 `web` runs as a Next.js dev server (`npm run dev`) and hot-reloads in dev; prod builds the web image and needs a rebuild like the others.
 
-No test runner. `controller/` and `web/` each expose `npm run lint` (`eslint . && tsc --noEmit`); CI runs both on every PR (`.github/workflows/lint.yml`) and they are the merge gate.
+No test runner. `controller/` and `web/` each expose `npm run lint` (`eslint . && tsc --noEmit`), and `mcp-subwave/` exposes `npm run lint` (`tsc --noEmit`); CI runs all three on every PR (`.github/workflows/lint.yml`) and they are the merge gate.
 
 ## Architecture
 

--- a/controller/src/routes/dj.ts
+++ b/controller/src/routes/dj.ts
@@ -14,6 +14,7 @@ import * as library from '../music/library.js';
 import * as settings from '../settings.js';
 import { runStationId, runHourlyCheck, runLink, runBanter, runProgrammeIntro, runProgrammeFeature, runProgrammeOutro, refreshAutoPlaylist } from '../broadcast/scheduler.js';
 import { skillCatalog, runCapability, effectiveContextFields } from '../skills/_agent.js';
+import * as sfxLib from '../broadcast/sfx.js';
 import { loadSkills, parseFrontmatter, SEEDED_KINDS, RESERVED_KINDS, SLUG_RE, readTemplate, listCommunitySkills, readCommunitySkill } from '../skills/loader.js';
 import { writeSkillFile, msToCooldownStr, resetBuiltinSkill } from '../skills/scaffold.js';
 import { mapPool } from '../util/async-pool.js';
@@ -556,9 +557,12 @@ router.delete('/dj/skills/:slug', requireAdmin, async (req, res) => {
 
 // ---------------------------------------------------------------------------
 // POST /dj/say — manual voice DJ
-// Body: { text, kind?: 'dj-speak'|'link', mode?: 'raw'|'styled' }
+// Body: { text, kind?: 'dj-speak'|'link', mode?: 'raw'|'styled', sfx?: string }
 //   raw    → the DJ speaks `text` verbatim
 //   styled → `text` is an instruction; the LLM writes it in persona, then speaks
+//   sfx    → a library effect aired under the opening words (attention stinger
+//            for e.g. emergency announcements). Manual trigger — ignores the
+//            settings.sfx.enabled autonomy toggle like every operator press.
 // ---------------------------------------------------------------------------
 router.post('/dj/say', requireAdmin, async (req, res) => {
   const text = (typeof req.body?.text === 'string' ? req.body.text : '').trim().slice(0, SAY_TEXT_MAX);
@@ -566,6 +570,14 @@ router.post('/dj/say', requireAdmin, async (req, res) => {
 
   const kind = SAY_KINDS.includes(req.body?.kind) ? req.body.kind : 'dj-speak';
   const mode = req.body?.mode === 'styled' ? 'styled' : 'raw';
+
+  // Validate the effect name up front so a typo is a 400 naming the catalogue,
+  // not a silent no-op inside playSfx after the voice is already rendered.
+  const sfxName = (typeof req.body?.sfx === 'string' ? req.body.sfx : '').trim();
+  if (sfxName && !(await sfxLib.getPath(sfxName))) {
+    const names = (await sfxLib.list()).map(e => e.name).join(', ');
+    return res.status(400).json({ error: `unknown sound effect: ${sfxName}${names ? `. Available: ${names}` : ''}` });
+  }
 
   try {
     let spoken = text;
@@ -578,7 +590,8 @@ router.post('/dj/say', requireAdmin, async (req, res) => {
       });
     }
     await queue.announce(spoken, kind);
-    res.json({ ok: true, mode, kind, spoken });
+    if (sfxName) void queue.playSfx(sfxName, { underVoice: true });
+    res.json({ ok: true, mode, kind, spoken, sfx: sfxName || null });
   } catch (err) {
     queue.log('error', `/dj/say failed: ${err.message}`);
     res.status(500).json({ error: err.message });

--- a/controller/src/routes/sfx.ts
+++ b/controller/src/routes/sfx.ts
@@ -81,3 +81,19 @@ router.get('/sfx/:name/audio', requireAdmin, async (req, res) => {
     res.status(500).json({ error: err.message });
   }
 });
+
+// Fire an effect on-air now — the automation-facing trigger (MCP, webhooks,
+// an external alerting agent). Manual trigger, so it ignores the
+// settings.sfx.enabled autonomy toggle like every explicit operator press.
+router.post('/sfx/:name/play', requireAdmin, async (req, res) => {
+  try {
+    if (!(await sfx.getPath(req.params.name))) {
+      const names = (await sfx.list()).map(e => e.name).join(', ');
+      return res.status(404).json({ error: `unknown sound effect: ${req.params.name}${names ? `. Available: ${names}` : ''}` });
+    }
+    await queue.playSfx(req.params.name);
+    res.json({ ok: true, name: req.params.name });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,7 +1,8 @@
 # The SUB/WAVE MCP Server
 
-How an AI agent talks to the radio station — requesting songs and driving the
-DJ on-air over the [Model Context Protocol](https://modelcontextprotocol.io).
+How an AI agent talks to the radio station — requesting songs, queueing exact
+tracks, and driving the DJ (voice, segments, skills, sound effects) on-air over
+the [Model Context Protocol](https://modelcontextprotocol.io).
 
 The server lives at [`mcp-subwave/`](../mcp-subwave/). For the always-on
 broadcast pipeline see [`streaming-flow.md`](./streaming-flow.md); for the
@@ -14,13 +15,14 @@ human listener request path see [`request-flow.md`](./request-flow.md).
 ```
 MCP client            subwave-mcp              Controller
 (Claude Code,   ──stdio/JSON-RPC──▶  ──HTTP──▶  (Express :7701
- Desktop, …)         5 tools                     /api behind Caddy)
+ Desktop, …)         17 tools                    /api behind Caddy)
 ```
 
-`subwave-mcp` is a thin stdio MCP server. It owns no state and no logic of its
-own — each tool is a typed wrapper over one controller HTTP endpoint. The model
-gets five tools; the controller does the real work (LLM matching, track
-selection, TTS, queueing).
+`subwave-mcp` is a thin stdio MCP server. It owns no state and almost no logic
+of its own — each tool is a typed wrapper over one controller HTTP endpoint
+(the one exception: `subwave_request_song` polls the request receipt so the
+agent gets an outcome, not a ticket). The model gets seventeen tools; the
+controller does the real work (LLM matching, track selection, TTS, queueing).
 
 It is the agent-facing twin of the listener request drawer: where a human types
 into the browser and hits `POST /request`, an agent calls `subwave_request_song`
@@ -35,67 +37,119 @@ controller itself. An *MCP server* is a typed capability surface: the tools,
 their schemas, their auth, and their error handling are defined once, in code,
 and every MCP client gets them identically. For an action surface that mutates
 station state and carries rate limits and admin auth, that contract belongs in
-code, not prose. The agent never sees a URL or an auth header — only five
+code, not prose. The agent never sees a URL or an auth header — only
 intent-shaped tools.
 
 ---
 
-## The five tools
+## The tools
 
 | Tool | Endpoint | Auth | Mutates air? |
 |---|---|---|---|
+| `subwave_health` | `GET /health` | none | no |
 | `subwave_now_playing` | `GET /now-playing` | none | no |
 | `subwave_station_state` | `GET /state` | none | no |
-| `subwave_request_song` | `POST /request` | none | queues a track |
+| `subwave_schedule` | `GET /schedule` | none | no |
+| `subwave_session` | `GET /session` | none | no |
+| `subwave_request_song` | `POST /request` + `GET /request/:id` | none | queues a track |
+| `subwave_request_status` | `GET /request/:id` | none | no |
+| `subwave_search_library` | `GET /dj/search` | admin | no |
+| `subwave_queue_track` | `POST /dj/queue-track` | admin | queues a track |
+| `subwave_skip_track` | `POST /dj/skip` | admin | ends the current track |
 | `subwave_dj_announce` | `POST /dj/say` | admin | speaks now |
 | `subwave_dj_segment` | `POST /dj/segment` | admin | speaks now |
+| `subwave_list_skills` | `GET /dj/skills` | admin | no |
+| `subwave_run_skill` | `POST /dj/skill` | admin | speaks now |
+| `subwave_list_sfx` | `GET /sfx` | admin | no |
+| `subwave_play_sfx` | `POST /sfx/:name/play` | admin | plays a stinger now |
+| `subwave_refresh_playlist` | `POST /dj/refresh-playlist` | admin | no (fallback playlist only) |
 
-### Read tools — `subwave_now_playing`, `subwave_station_state`
+### Read tools — `subwave_health`, `subwave_now_playing`, `subwave_station_state`, `subwave_schedule`, `subwave_session`
 
-Both are read-only passthroughs. `now-playing` returns the current track,
-station context (time, weather, dominant mood), and live listener counts;
-`state` returns the upcoming queue, recent history, and the DJ booth log.
+All read-only passthroughs. `now-playing` returns the current track, station
+context (time, weather, dominant mood), and live listener counts; `state`
+returns the upcoming queue, recent history, and the DJ booth log; `schedule`
+the personas, shows, and weekly grid (in the station's timezone); `session`
+the DJ's live session identity and recent transcript turns.
 
 These exist so the agent can ground a request in what's actually on-air. A
 request like *"something slower than this"* is only meaningful if the model
 first knows what *this* is — the controller's `matchRequest` interprets vibe
 queries against the current track, so a good agent reads before it writes.
+`schedule` matters for the show-bound segments: `banter` needs a guest show on
+air, `programme-*` a programme show.
 
-### `subwave_request_song`
+### `subwave_request_song` and `subwave_request_status`
 
 The headline tool. Takes a natural-language `request` (a track, an artist, a
-vibe, or `"more like this"`) and an optional `requester` name. It calls
-`POST /request`, where the controller runs the LLM matcher, resolves a track
-through its pick cascade, generates a spoken DJ intro, and pushes it to the
-queue.
+vibe, or `"more like this"`) and an optional `requester` name. `POST /request`
+hands back a **202 receipt** and the booth resolves the request in the
+background (LLM matcher, pick cascade, spoken intro, queue push) — so the tool
+polls `GET /request/:id` (2s interval, ~45s budget) and reports the outcome:
+matched track + queue position + the DJ's ack, or the miss message. If the
+booth is still working past the budget, the tool returns the `requestId` and
+points the agent at `subwave_request_status`.
 
-Two things the tool description makes explicit to the model, because they are
-easy to get wrong:
+Three things the tool description makes explicit to the model, because they
+are easy to get wrong:
 
-- **It queues, it does not interrupt.** There is no skip on SUB/WAVE —
-  track-end is the only transition. A request lands *after* the current song.
+- **It queues, it does not interrupt.** A request lands *after* the current
+  song. (Listeners have no skip; the admin-gated `subwave_skip_track` is the
+  deliberate operator override.)
 - **It is rate-limited.** The public `/request` endpoint allows 1 call per 20s
   and 8 per hour per source. On an HTTP 429 the tool surfaces the controller's
   `Retry-After` in its error text, so the agent can back off instead of
   hammering.
+- **It pauses with the station.** With zero listeners tuned in the DJ idles
+  and `/request` returns 503 — the controller's explanation is passed through.
+
+### `subwave_search_library` and `subwave_queue_track`
+
+The deterministic path: search Navidrome by terms (12 queue-ready results with
+mood tags), then queue an exact result by id. Admin-gated, no LLM, no rate
+limit, no DJ intro. This is the right pair when the agent already knows the
+exact track; `subwave_request_song` is for vibes and natural language.
 
 ### `subwave_dj_announce`
 
-Puts a spoken update on-air via `POST /dj/say`. Two axes, both exposed as enums
-with sensible defaults:
+Puts a spoken update on-air via `POST /dj/say`. Three axes:
 
 - **`mode`** — `styled` (default) hands the text to the LLM as an *instruction*
   and the DJ rewrites it in persona before speaking; `raw` speaks the text
-  verbatim. Give a topic → `styled`. Give finished words → `raw`.
+  verbatim. Give a topic → `styled`. Give finished words → `raw` (also the
+  right choice for emergency wording that must not be paraphrased).
 - **`placement`** — `solo` (default) is a heavy-ducked solo DJ moment (maps to
   the controller's `dj-speak` kind → `say.txt`); `over-track` is lightly ducked
   so the DJ talks over the playing song (maps to `link` → `intro.txt`).
+- **`sfx`** — optional name of a library sound effect aired under the opening
+  words as an attention stinger (e.g. `airhorn` ahead of a weather warning).
+  Names come from `subwave_list_sfx`; an unknown name is a 400 listing the
+  catalogue.
 
 ### `subwave_dj_segment`
 
-Fires a scripted voice segment — `station-id`, `hourly`, or `link` — on demand.
-This is an operator override: it bypasses the DJ's `shouldFire` frequency gate.
-For a custom message, `subwave_dj_announce` is the right tool.
+Fires a scripted voice segment on demand: `station-id`, `hourly`, `link`,
+`banter` (multi-voice guest exchange — needs a guest show on air), or
+`programme-intro` / `programme-feature` / `programme-outro` (episode beats —
+need a programme show on air). This is an operator override: it bypasses the
+DJ's `shouldFire` frequency gate. For a custom message, `subwave_dj_announce`
+is the right tool.
+
+### `subwave_list_skills` and `subwave_run_skill`
+
+`list` returns the skill catalogue — the seven built-ins (weather, news,
+traffic, curiosity, album-anniversary, library-deep-cut, web-search) plus any
+operator-authored skills from `state/skills/`. `run` fires one by name through
+the segment director, which fetches real data (forecast, headlines, …) before
+voicing it. Manual runs ignore cooldowns and work even on disabled skills.
+
+### `subwave_list_sfx` and `subwave_play_sfx`
+
+`list` returns the sound-effects library (short stingers, ≤10s). `play` fires
+one on-air immediately, mixed over the programme with a light duck — the
+automation-facing trigger for external alerting agents. To pair a stinger with
+spoken words, prefer `subwave_dj_announce`'s `sfx` parameter, which aligns the
+effect with the voice's first words.
 
 ---
 
@@ -104,14 +158,15 @@ For a custom message, `subwave_dj_announce` is the right tool.
 The controller splits its surface in two (see
 [`CLAUDE.md`](../CLAUDE.md) → middleware):
 
-- **Public, rate-limited** — `/now-playing`, `/state`, `/request`. No auth.
-- **Admin, Basic-auth gated** — `/dj/*`. Gated by the controller's
+- **Public** — `/health`, `/now-playing`, `/state`, `/schedule`, `/session`,
+  `/request` (rate-limited), `/request/:id`. No auth.
+- **Admin, Basic-auth gated** — `/dj/*` and `/sfx`. Gated by the controller's
   `ADMIN_USER` / `ADMIN_PASS`.
 
 `subwave-mcp` reads admin credentials from its own environment
 (`SUBWAVE_ADMIN_USER` / `SUBWAVE_ADMIN_PASS`) and sends them as a Basic auth
 header only on the admin tools. If they are unset, the read and request tools
-still work; the two DJ-control tools return an error that names exactly which
+still work; the DJ-control tools return an error that names exactly which
 env vars to set. The credentials live in the MCP client's config, never in a
 prompt.
 
@@ -141,8 +196,9 @@ to act on, not for a log:
 - **HTTP 429** → the cooldown in seconds, plus the rate-limit policy.
 - **HTTP 401/403** → whether credentials are missing entirely or simply don't
   match the controller's.
-- **HTTP 503** → song requests are closed (`REQUESTS_DISABLED` on the
-  controller).
+- **HTTP 503** → the controller's own explanation is passed through — song
+  requests closed by the operator (`REQUESTS_DISABLED`) or the zero-listener
+  autopilot pause.
 
 The tool wrapper catches these and returns them as MCP error results
 (`isError: true`) rather than throwing, so the model sees the message and can
@@ -161,7 +217,9 @@ npm run inspect    # build + MCP Inspector for manual testing
 
 Wire it into a client by pointing at `dist/index.js` with `node` and passing
 the three env vars — see [`mcp-subwave/README.md`](../mcp-subwave/README.md)
-for ready-to-paste Claude Code and Claude Desktop snippets.
+for ready-to-paste Claude Code and Claude Desktop snippets. Inside this repo,
+the root [`.mcp.json`](../.mcp.json) already wires it up for Claude Code —
+build once and the tools are available in any session opened here.
 
 The controller must be running first — start the stack with the `subwave-control`
 skill or `docker compose up -d` (see [`CLAUDE.md`](../CLAUDE.md)).
@@ -172,6 +230,6 @@ skill or `docker compose up -d` (see [`CLAUDE.md`](../CLAUDE.md)).
 
 | File | Role |
 |---|---|
-| `mcp-subwave/src/index.ts` | MCP server: registers the five tools, stdio transport, error-to-result wrapper. |
+| `mcp-subwave/src/index.ts` | MCP server: registers the tools, stdio transport, request polling, error-to-result wrapper. |
 | `mcp-subwave/src/client.ts` | `SubwaveClient` — typed HTTP client, Basic auth, `SubwaveError` with actionable messages. |
 | `mcp-subwave/package.json` | `subwave-mcp` bin, build scripts, MCP SDK + Zod deps. |

--- a/mcp-subwave/README.md
+++ b/mcp-subwave/README.md
@@ -1,30 +1,44 @@
 # subwave-mcp
 
 An [MCP](https://modelcontextprotocol.io) server that lets an agent drive the
-**SUB/WAVE** personal radio station — request songs and put the AI DJ on-air.
+**SUB/WAVE** personal radio station — request songs, queue exact tracks, and
+put the AI DJ (voice, segments, skills, sound effects) on-air.
 
 It wraps the SUB/WAVE controller's HTTP API as MCP tools, so any MCP client
 (Claude Code, Claude Desktop, etc.) can ask the station to play a track or
-announce an update.
+announce an update. See [`docs/mcp-server.md`](../docs/mcp-server.md) for the
+full architecture write-up.
 
 ## Tools
 
 | Tool | Auth | What it does |
 |---|---|---|
+| `subwave_health` | none | Liveness — controller reachable, stream on-air. |
 | `subwave_now_playing` | none | Current track, station context, listener counts. |
 | `subwave_station_state` | none | Upcoming queue, recent history, DJ booth log. |
-| `subwave_request_song` | none | Natural-language song request — the AI DJ matches, intros, and queues it. |
-| `subwave_dj_announce` | admin | Make the DJ speak an update on-air (`styled` rewrite or `raw` verbatim). |
-| `subwave_dj_segment` | admin | Fire a scripted segment: `station-id`, `hourly`, or `link`. |
+| `subwave_schedule` | none | Personas, shows, weekly schedule grid. |
+| `subwave_session` | none | The DJ's live session + recent transcript. |
+| `subwave_request_song` | none | Natural-language song request — submits, then polls the outcome (~45s budget). |
+| `subwave_request_status` | none | Poll an earlier request by its `requestId`. |
+| `subwave_search_library` | admin | Deterministic library search (no LLM, no rate limit). |
+| `subwave_queue_track` | admin | Queue an exact search result — no DJ intro. |
+| `subwave_skip_track` | admin | Force-end the current track (operator override). |
+| `subwave_dj_announce` | admin | Speak an update on-air (`styled`/`raw`), optionally over an `sfx` stinger. |
+| `subwave_dj_segment` | admin | Fire a scripted segment: `station-id`, `hourly`, `link`, `banter`, `programme-*`. |
+| `subwave_list_skills` | admin | The skill catalogue (built-in + operator skills). |
+| `subwave_run_skill` | admin | Run a named skill segment now (weather, news, …). |
+| `subwave_list_sfx` | admin | The sound-effects library. |
+| `subwave_play_sfx` | admin | Fire a sound effect on-air immediately. |
+| `subwave_refresh_playlist` | admin | Rebuild the fallback auto-playlist for the current mood. |
 
-There is no "skip" — track-end is the only transition. A requested song is
-**queued**, not played immediately.
+Listeners have no skip — track-end is the only transition, and a requested
+song is **queued**, not played immediately. `subwave_skip_track` exists as a
+deliberate admin-only operator override.
 
 ## Setup
 
 ```bash
-npm install
-npm run build
+npm install    # `prepare` builds dist/ automatically
 ```
 
 ## Configuration
@@ -37,13 +51,15 @@ The server is configured entirely through environment variables:
 | `SUBWAVE_ADMIN_USER` | — | Controller `ADMIN_USER`. Required for the DJ control tools. |
 | `SUBWAVE_ADMIN_PASS` | — | Controller `ADMIN_PASS`. Required for the DJ control tools. |
 
-`subwave_now_playing`, `subwave_station_state`, and `subwave_request_song` work
-without admin credentials. `subwave_dj_announce` and `subwave_dj_segment` need
-them — if unset, those tools return an error explaining what to set.
+The tools marked `none` above work without admin credentials. The admin tools
+need them — if unset, those tools return an error explaining what to set.
 
 ## Wiring it into a client
 
 ### Claude Code
+
+Inside this repo the root `.mcp.json` already wires the server up (build it
+once with `npm install`). For other checkouts or global use:
 
 ```bash
 claude mcp add subwave \
@@ -75,6 +91,7 @@ claude mcp add subwave \
 
 ```bash
 npm run watch     # recompile on change
+npm run lint      # tsc --noEmit (runs in CI)
 npm run inspect   # build + open the MCP Inspector
 ```
 
@@ -82,10 +99,24 @@ The transport is stdio — keep `stdout` clean; the server logs only to `stderr`
 
 ## Notes
 
+- **Async requests.** `POST /request` returns a 202 receipt and the booth
+  resolves in the background. `subwave_request_song` polls `GET /request/:id`
+  every 2s for up to ~45s and reports the outcome; if the booth is still
+  working it hands back the `requestId` for `subwave_request_status`.
 - **Rate limits.** `subwave_request_song` hits the controller's public
   `/request` endpoint: 1 request per 20s, 8 per hour per source. On a 429 the
-  tool returns the wait time so the agent can back off.
-- **Admin endpoints.** `subwave_dj_announce` / `subwave_dj_segment` bypass the
-  DJ's frequency gate — they are an operator override. Use them deliberately.
+  tool returns the wait time so the agent can back off. The admin
+  search/queue-track pair has no rate limit — prefer it when the exact track
+  is known.
+- **Zero-listener pause.** With nobody tuned in, the DJ idles and `/request`
+  returns 503; the controller's explanation is passed through.
+- **Admin endpoints.** The `subwave_dj_*`, skill, sfx, and skip tools bypass
+  the DJ's frequency gate, cooldowns, and budget gates — they are an operator
+  override. Use them deliberately.
+- **Sound effects.** Effects are short stingers (≤10s) mixed over the
+  programme. For an attention cue tied to spoken words (e.g. an airhorn ahead
+  of an emergency weather warning), use `subwave_dj_announce`'s `sfx`
+  parameter; `subwave_play_sfx` fires one standalone. For wording that must
+  not be paraphrased, use `mode='raw'`.
 - The controller must be running. If it isn't reachable, every tool returns an
   error naming the URL it tried and what to check.

--- a/mcp-subwave/package-lock.json
+++ b/mcp-subwave/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "subwave-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "subwave-mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
+      "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.18.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^3.25.76"
       },
       "bin": {

--- a/mcp-subwave/package.json
+++ b/mcp-subwave/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subwave-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP server for the SUB/WAVE personal radio station — request songs and drive the AI DJ on-air.",
   "license": "MIT",
   "type": "module",
@@ -12,13 +12,15 @@
   ],
   "scripts": {
     "build": "tsc",
+    "lint": "tsc --noEmit",
+    "prepare": "npm run build",
     "watch": "tsc --watch",
     "start": "node dist/index.js",
     "dev": "tsc && node dist/index.js",
     "inspect": "npm run build && npx @modelcontextprotocol/inspector node dist/index.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.18.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/mcp-subwave/src/client.ts
+++ b/mcp-subwave/src/client.ts
@@ -2,9 +2,11 @@
  * HTTP client for the SUB/WAVE controller API.
  *
  * The controller is a local Express service (default :7701 in dev, or behind
- * the Caddy edge at :7700/api in prod). Two endpoint classes matter here:
- *   - public, rate-limited:   GET /now-playing, GET /state, POST /request
- *   - admin, Basic-auth gated: POST /dj/say, POST /dj/segment
+ * the Caddy edge at :7700/api in prod). Three endpoint classes matter here:
+ *   - public, read-only:        GET /health, /now-playing, /state, /schedule,
+ *                               /session, /request/:id
+ *   - public, rate-limited:     POST /request (202 receipt + background resolve)
+ *   - admin, Basic-auth gated:  the /dj/* command surface and /sfx
  *
  * Every failure is turned into a SubwaveError carrying a message written for
  * the agent — it says what went wrong AND what to do about it, so the model
@@ -31,15 +33,25 @@ export interface SubwaveConfig {
   adminPass?: string;
 }
 
-export interface RequestResult {
+/** POST /request hands back a receipt; the booth resolves in the background. */
+export interface RequestSubmission {
   success: boolean;
+  requestId: string;
+  status: string;
+}
+
+/** GET /request/:id — outcome of a submitted request. */
+export interface RequestStatus {
+  /** 'pending' | 'resolved' | 'failed' | 'unknown' (pruned or lost to a restart). */
+  status: string;
+  success?: boolean;
   /** DJ's spoken acknowledgement of the request, when matched. */
-  ack?: string;
-  /** Operator-facing message on a miss / closed / throttled request. */
-  message?: string;
-  track?: { title: string; artist: string };
+  ack?: string | null;
+  track?: { title: string; artist: string | null } | null;
   /** 1-based position in the upcoming queue. */
-  queuePosition?: number;
+  queuePosition?: number | null;
+  /** Operator-facing message on a miss / closed / throttled request. */
+  message?: string | null;
 }
 
 export interface DjSayResult {
@@ -48,12 +60,32 @@ export interface DjSayResult {
   kind: "dj-speak" | "link";
   /** The exact words sent to air (post-LLM rewrite when mode=styled). */
   spoken: string;
+  /** Sound effect aired under the announcement, when one was requested. */
+  sfx?: string | null;
 }
 
 export interface DjSegmentResult {
   ok: boolean;
   type: string;
   spoken: string;
+}
+
+export interface DjSkillResult {
+  ok: boolean;
+  name: string;
+  /** What went to air — null when the skill chose to stay silent. */
+  spoken: string | null;
+}
+
+export interface QueueTrackResult {
+  ok: boolean;
+  track: { title: string; artist: string | null };
+  queuePosition: number;
+}
+
+export interface SfxPlayResult {
+  ok: boolean;
+  name: string;
 }
 
 export class SubwaveClient {
@@ -72,7 +104,7 @@ export class SubwaveClient {
   /** Core fetch wrapper: timeout, JSON parsing, and agent-readable errors. */
   private async call<T>(
     path: string,
-    init: { method?: string; body?: unknown; admin?: boolean } = {},
+    init: { method?: string; body?: unknown; admin?: boolean; allowStatuses?: number[] } = {},
   ): Promise<T> {
     const url = `${this.config.baseUrl}${path}`;
     const controller = new AbortController();
@@ -100,14 +132,27 @@ export class SubwaveClient {
       clearTimeout(timer);
     }
 
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch {
+      body = undefined;
+    }
+    const field = (key: string): string | undefined => {
+      const v = body && typeof body === "object" ? (body as Record<string, unknown>)[key] : undefined;
+      return typeof v === "string" ? v : undefined;
+    };
+
+    // Some endpoints use an error status as a meaningful answer (e.g. 404 from
+    // GET /request/:id means "unknown request") — let the caller opt in.
+    if (init.allowStatuses?.includes(res.status)) return body as T;
+
     if (res.status === 429) {
       const retryAfter = Number(res.headers.get("retry-after")) || undefined;
-      const body = await res.json().catch(() => ({}) as Record<string, unknown>);
       throw new SubwaveError(
-        typeof body.message === "string"
-          ? body.message
-          : `Rate limited — wait ${retryAfter ?? "a moment"}s before requesting again. ` +
-              `The controller caps song requests at 1 per 20s and 8 per hour.`,
+        field("message") ??
+          `Rate limited — wait ${retryAfter ?? "a moment"}s before requesting again. ` +
+            `The controller caps song requests at 1 per 20s and 8 per hour.`,
         retryAfter,
       );
     }
@@ -123,29 +168,25 @@ export class SubwaveClient {
       );
     }
 
+    // 503 carries its own explanation — requests closed by the operator
+    // (REQUESTS_DISABLED) or the zero-listener autopilot pause. Pass the
+    // controller's message through rather than guessing which.
     if (res.status === 503) {
       throw new SubwaveError(
-        `Song requests are temporarily closed on the station (REQUESTS_DISABLED is set on the controller).`,
+        field("message") ??
+          field("error") ??
+          `The station declined the call (HTTP 503) — requests may be closed or the DJ paused.`,
       );
     }
 
-    let body: unknown;
-    try {
-      body = await res.json();
-    } catch {
-      body = undefined;
-    }
-
     if (!res.ok) {
-      const msg =
-        body && typeof body === "object" && "error" in body
-          ? String((body as Record<string, unknown>).error)
-          : `HTTP ${res.status} from ${path}`;
-      throw new SubwaveError(msg);
+      throw new SubwaveError(field("error") ?? field("message") ?? `HTTP ${res.status} from ${path}`);
     }
 
     return body as T;
   }
+
+  // -------------------------------------------------------------- public --
 
   /** GET /health — liveness probe; resolves to true when the stream is on-air. */
   async health(): Promise<boolean> {
@@ -163,33 +204,108 @@ export class SubwaveClient {
     return this.call<Record<string, unknown>>("/state");
   }
 
-  /** POST /request — submit a natural-language song request to the AI DJ. */
-  async requestSong(text: string, requester?: string): Promise<RequestResult> {
-    return this.call<RequestResult>("/request", {
+  /** GET /schedule — shows, personas, and the weekly schedule grid. */
+  async schedule(): Promise<Record<string, unknown>> {
+    return this.call<Record<string, unknown>>("/schedule");
+  }
+
+  /** GET /session — the live DJ session and its recent transcript turns. */
+  async session(): Promise<Record<string, unknown>> {
+    return this.call<Record<string, unknown>>("/session");
+  }
+
+  /** POST /request — submit a song request; returns a 202 receipt to poll. */
+  async requestSong(text: string, requester?: string): Promise<RequestSubmission> {
+    return this.call<RequestSubmission>("/request", {
       method: "POST",
       body: { text, name: requester },
     });
   }
 
-  /** POST /dj/say — make the DJ speak on-air (admin). */
+  /** GET /request/:id — poll the outcome of a submitted request. */
+  async requestStatus(id: string): Promise<RequestStatus> {
+    // 404 here means "unknown id" (pruned or lost to a restart), not an error.
+    return this.call<RequestStatus>(`/request/${encodeURIComponent(id)}`, {
+      allowStatuses: [404],
+    });
+  }
+
+  // --------------------------------------------------------------- admin --
+
+  /** POST /dj/say — make the DJ speak on-air, optionally over a stinger. */
   async djSay(
     text: string,
     mode: "raw" | "styled",
     kind: "dj-speak" | "link",
+    sfx?: string,
   ): Promise<DjSayResult> {
     return this.call<DjSayResult>("/dj/say", {
       method: "POST",
       admin: true,
-      body: { text, mode, kind },
+      body: { text, mode, kind, ...(sfx ? { sfx } : {}) },
     });
   }
 
-  /** POST /dj/segment — fire a scripted voice segment on demand (admin). */
-  async djSegment(type: "station-id" | "hourly" | "link"): Promise<DjSegmentResult> {
+  /** POST /dj/segment — fire a scripted voice segment on demand. */
+  async djSegment(type: string): Promise<DjSegmentResult> {
     return this.call<DjSegmentResult>("/dj/segment", {
       method: "POST",
       admin: true,
       body: { type },
+    });
+  }
+
+  /** GET /dj/skills — the skill catalogue (built-in + operator skills). */
+  async listSkills(): Promise<Record<string, unknown>> {
+    return this.call<Record<string, unknown>>("/dj/skills", { admin: true });
+  }
+
+  /** POST /dj/skill — run a named skill segment now (operator override). */
+  async runSkill(name: string): Promise<DjSkillResult> {
+    return this.call<DjSkillResult>("/dj/skill", {
+      method: "POST",
+      admin: true,
+      body: { name },
+    });
+  }
+
+  /** GET /dj/search?q= — deterministic library search (no LLM, no rate limit). */
+  async searchLibrary(q: string): Promise<{ results: Record<string, unknown>[] }> {
+    return this.call<{ results: Record<string, unknown>[] }>(
+      `/dj/search?q=${encodeURIComponent(q)}`,
+      { admin: true },
+    );
+  }
+
+  /** POST /dj/queue-track — queue an exact track from a search result. */
+  async queueTrack(track: Record<string, unknown>): Promise<QueueTrackResult> {
+    return this.call<QueueTrackResult>("/dj/queue-track", {
+      method: "POST",
+      admin: true,
+      body: track,
+    });
+  }
+
+  /** POST /dj/skip — force-end the current track (operator override). */
+  async skipTrack(): Promise<{ ok: boolean }> {
+    return this.call<{ ok: boolean }>("/dj/skip", { method: "POST", admin: true });
+  }
+
+  /** POST /dj/refresh-playlist — rebuild the fallback auto-playlist now. */
+  async refreshPlaylist(): Promise<{ ok: boolean }> {
+    return this.call<{ ok: boolean }>("/dj/refresh-playlist", { method: "POST", admin: true });
+  }
+
+  /** GET /sfx — the sound-effects library. */
+  async listSfx(): Promise<Record<string, unknown>> {
+    return this.call<Record<string, unknown>>("/sfx", { admin: true });
+  }
+
+  /** POST /sfx/:name/play — fire a sound effect on-air now. */
+  async playSfx(name: string): Promise<SfxPlayResult> {
+    return this.call<SfxPlayResult>(`/sfx/${encodeURIComponent(name)}/play`, {
+      method: "POST",
+      admin: true,
     });
   }
 }

--- a/mcp-subwave/src/index.ts
+++ b/mcp-subwave/src/index.ts
@@ -4,7 +4,8 @@
  *
  * Exposes the SUB/WAVE controller's request and DJ surfaces as MCP tools so a
  * model can: see what's on-air, request a song (the AI DJ matches, intros, and
- * queues it), put a spoken update on-air, and fire scripted voice segments.
+ * queues it), search and queue exact tracks, put spoken updates and sound
+ * effects on-air, and fire scripted voice segments and skills.
  *
  * Transport: stdio — this server is meant to run next to a local controller.
  *
@@ -14,10 +15,13 @@
  *   SUBWAVE_ADMIN_USER  admin Basic-auth user  — required for DJ control tools
  *   SUBWAVE_ADMIN_PASS  admin Basic-auth pass  — required for DJ control tools
  */
+import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { SubwaveClient, SubwaveError } from "./client.js";
+import { SubwaveClient, SubwaveError, RequestStatus } from "./client.js";
+
+const pkg = createRequire(import.meta.url)("../package.json") as { version: string };
 
 const client = new SubwaveClient({
   baseUrl: (process.env.SUBWAVE_API_URL || "http://localhost:7701").replace(/\/$/, ""),
@@ -27,7 +31,7 @@ const client = new SubwaveClient({
 
 const server = new McpServer({
   name: "subwave-mcp",
-  version: "0.1.0",
+  version: pkg.version,
 });
 
 /** Render any value as a text content block. */
@@ -37,6 +41,8 @@ function text(value: unknown): { type: "text"; text: string } {
     text: typeof value === "string" ? value : JSON.stringify(value, null, 2),
   };
 }
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 /**
  * Wrap a tool body so SubwaveError (and anything else) becomes an MCP error
@@ -57,6 +63,67 @@ async function run(
   }
 }
 
+// Song requests resolve in the booth in the background (LLM match + TTS
+// intro); the receipt is polled until it lands. The budget covers a slow
+// homelab LLM leg; past it the tool hands back the id for a later status call.
+const REQUEST_POLL_MS = 2_000;
+const REQUEST_POLL_BUDGET_MS = 45_000;
+
+/** Shared output shape for the request tools — mirrors GET /request/:id. */
+const REQUEST_OUTPUT = {
+  requestId: z.string(),
+  status: z.string().describe("'pending' | 'resolved' | 'failed' | 'unknown'"),
+  success: z.boolean().optional(),
+  ack: z.string().nullable().optional(),
+  track: z.object({ title: z.string(), artist: z.string().nullable() }).nullable().optional(),
+  queuePosition: z.number().nullable().optional(),
+  message: z.string().nullable().optional(),
+};
+
+function summarizeRequest(requestId: string, status: RequestStatus): string {
+  if (status.status === "resolved") {
+    return (
+      `Queued "${status.track?.title}" by ${status.track?.artist} at position ` +
+      `${status.queuePosition}. DJ says: ${status.ack ?? "(no ack)"}`
+    );
+  }
+  if (status.status === "failed") {
+    return `Request not fulfilled: ${status.message ?? "no match in the library."}`;
+  }
+  if (status.status === "pending") {
+    return (
+      `Request ${requestId} is still being matched in the booth — check the outcome ` +
+      `with subwave_request_status in a little while.`
+    );
+  }
+  return `Request ${requestId} is unknown to the controller — it was pruned or lost to a restart.`;
+}
+
+// ---------------------------------------------------------------------------
+// subwave_health — is the station up?
+// ---------------------------------------------------------------------------
+server.registerTool(
+  "subwave_health",
+  {
+    title: "SUB/WAVE liveness",
+    description:
+      "Check that the SUB/WAVE controller is reachable and the station reports on-air. " +
+      "Call this first when other tools fail — it separates 'stack is down' from " +
+      "'endpoint-specific problem'.",
+    inputSchema: {},
+    outputSchema: { onAir: z.boolean() },
+    annotations: { readOnlyHint: true, openWorldHint: true },
+  },
+  () =>
+    run(async () => {
+      const onAir = await client.health();
+      return {
+        content: [text(onAir ? "SUB/WAVE is on-air." : "Controller reachable, but not reporting on-air.")],
+        structuredContent: { onAir },
+      };
+    }),
+);
+
 // ---------------------------------------------------------------------------
 // subwave_now_playing — what's on-air right now
 // ---------------------------------------------------------------------------
@@ -75,7 +142,7 @@ server.registerTool(
   () =>
     run(async () => {
       const data = await client.nowPlaying();
-      return { content: [text(data)], structuredContent: data };
+      return { content: [text(data)] };
     }),
 );
 
@@ -96,7 +163,51 @@ server.registerTool(
   () =>
     run(async () => {
       const data = await client.state();
-      return { content: [text(data)], structuredContent: data };
+      return { content: [text(data)] };
+    }),
+);
+
+// ---------------------------------------------------------------------------
+// subwave_schedule — shows, personas, weekly grid
+// ---------------------------------------------------------------------------
+server.registerTool(
+  "subwave_schedule",
+  {
+    title: "SUB/WAVE schedule",
+    description:
+      "Get the station's programming: DJ personas, shows, and the weekly schedule " +
+      "grid (interpreted in the station's timezone, which is included). Useful for " +
+      "knowing who's on air and whether a guest show or programme is running before " +
+      "firing 'banter' or 'programme-*' segments.",
+    inputSchema: {},
+    annotations: { readOnlyHint: true, openWorldHint: true },
+  },
+  () =>
+    run(async () => {
+      const data = await client.schedule();
+      return { content: [text(data)] };
+    }),
+);
+
+// ---------------------------------------------------------------------------
+// subwave_session — the DJ's live session transcript
+// ---------------------------------------------------------------------------
+server.registerTool(
+  "subwave_session",
+  {
+    title: "SUB/WAVE DJ session",
+    description:
+      "Get the DJ's current stream session — its identity (show or auto period/mood, " +
+      "start time) and the recent transcript of spoken segments and events. This is " +
+      "what the DJ 'remembers'; read it to keep an announcement coherent with what " +
+      "was just said on-air.",
+    inputSchema: {},
+    annotations: { readOnlyHint: true, openWorldHint: true },
+  },
+  () =>
+    run(async () => {
+      const data = await client.session();
+      return { content: [text(data)] };
     }),
 );
 
@@ -112,8 +223,11 @@ server.registerTool(
       "specific track or artist (\"play Midnight City by M83\"), a vibe (\"something " +
       "calm for a rainy evening\"), or a follow-on like \"more like this\". The DJ " +
       "matches it against the library, writes a spoken intro, and queues the track — " +
-      "it does NOT interrupt the current song; track-end is the only transition. " +
-      "Public endpoint, rate-limited to 1 request per 20s and 8 per hour.",
+      "it does NOT interrupt the current song. The controller resolves requests in " +
+      "the background; this tool waits (up to ~45s) for the outcome and reports it. " +
+      "Public endpoint, rate-limited to 1 request per 20s and 8 per hour; requests " +
+      "pause when nobody is listening. For an exact, non-LLM pick use " +
+      "subwave_search_library + subwave_queue_track instead.",
     inputSchema: {
       request: z
         .string()
@@ -129,16 +243,137 @@ server.registerTool(
         .optional()
         .describe("Name to credit the request to on-air. Defaults to 'anon'."),
     },
+    outputSchema: REQUEST_OUTPUT,
     annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   },
   ({ request, requester }) =>
     run(async () => {
-      const result = await client.requestSong(request, requester);
-      const summary = result.success
-        ? `Queued "${result.track?.title}" by ${result.track?.artist} at position ` +
-          `${result.queuePosition}. DJ says: ${result.ack ?? "(no ack)"}`
-        : `Request not fulfilled: ${result.message ?? "no match in the library."}`;
-      return { content: [text(summary)], structuredContent: { ...result } };
+      const receipt = await client.requestSong(request, requester);
+      let status: RequestStatus = { status: receipt.status || "pending" };
+      const deadline = Date.now() + REQUEST_POLL_BUDGET_MS;
+      while (status.status === "pending" && Date.now() < deadline) {
+        await sleep(REQUEST_POLL_MS);
+        status = await client.requestStatus(receipt.requestId);
+      }
+      return {
+        content: [text(summarizeRequest(receipt.requestId, status))],
+        structuredContent: { requestId: receipt.requestId, ...status },
+      };
+    }),
+);
+
+// ---------------------------------------------------------------------------
+// subwave_request_status — poll an earlier request's outcome
+// ---------------------------------------------------------------------------
+server.registerTool(
+  "subwave_request_status",
+  {
+    title: "Check a song request",
+    description:
+      "Look up the outcome of a previously submitted song request by its requestId " +
+      "(returned by subwave_request_song). Status 'unknown' means the id was pruned " +
+      "or lost to a controller restart — stop polling.",
+    inputSchema: {
+      requestId: z.string().min(1).describe("The requestId from subwave_request_song."),
+    },
+    outputSchema: REQUEST_OUTPUT,
+    annotations: { readOnlyHint: true, openWorldHint: true },
+  },
+  ({ requestId }) =>
+    run(async () => {
+      const status = await client.requestStatus(requestId);
+      return {
+        content: [text(summarizeRequest(requestId, status))],
+        structuredContent: { requestId, ...status },
+      };
+    }),
+);
+
+// ---------------------------------------------------------------------------
+// subwave_search_library — deterministic library search (admin)
+// ---------------------------------------------------------------------------
+server.registerTool(
+  "subwave_search_library",
+  {
+    title: "Search the music library",
+    description:
+      "Search the station's music library by title/artist/album terms. Returns up to " +
+      "12 queue-ready tracks (id, title, artist, album, year, genre, duration, mood " +
+      "tags). ADMIN endpoint — no LLM, no rate limit. Pair with subwave_queue_track " +
+      "to queue an exact result.",
+    inputSchema: {
+      q: z.string().min(1).describe("Search terms, e.g. 'boards of canada roygbiv'."),
+    },
+    annotations: { readOnlyHint: true, openWorldHint: true },
+  },
+  ({ q }) =>
+    run(async () => {
+      const data = await client.searchLibrary(q);
+      return { content: [text(data)] };
+    }),
+);
+
+// ---------------------------------------------------------------------------
+// subwave_queue_track — queue an exact track (admin)
+// ---------------------------------------------------------------------------
+server.registerTool(
+  "subwave_queue_track",
+  {
+    title: "Queue an exact track",
+    description:
+      "Push a specific track onto the play queue — an operator pick, no DJ intro, no " +
+      "rate limit. ADMIN endpoint. Pass the fields of a subwave_search_library " +
+      "result; id and title are required. The track plays after the queue ahead of " +
+      "it; it does not interrupt the current song.",
+    inputSchema: {
+      id: z.string().min(1).describe("Track id from subwave_search_library."),
+      title: z.string().min(1),
+      artist: z.string().optional(),
+      album: z.string().optional(),
+      year: z.number().optional(),
+      genre: z.string().optional(),
+    },
+    outputSchema: {
+      ok: z.boolean(),
+      track: z.object({ title: z.string(), artist: z.string().nullable() }),
+      queuePosition: z.number(),
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
+  },
+  (track) =>
+    run(async () => {
+      const result = await client.queueTrack(track);
+      return {
+        content: [
+          text(
+            `Queued "${result.track.title}"${result.track.artist ? ` by ${result.track.artist}` : ""} ` +
+              `at position ${result.queuePosition}.`,
+          ),
+        ],
+        structuredContent: { ...result },
+      };
+    }),
+);
+
+// ---------------------------------------------------------------------------
+// subwave_skip_track — force-end the current track (admin)
+// ---------------------------------------------------------------------------
+server.registerTool(
+  "subwave_skip_track",
+  {
+    title: "Skip the current track",
+    description:
+      "Force-end the track playing right now and move to the next item — an operator " +
+      "override, since every listener hears the same broadcast. ADMIN endpoint. Use " +
+      "sparingly and deliberately; there is intentionally no listener-facing skip.",
+    inputSchema: {},
+    outputSchema: { ok: z.boolean() },
+    annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: true },
+  },
+  () =>
+    run(async () => {
+      const result = await client.skipTrack();
+      return { content: [text("Track skipped — the next queue item is taking over.")], structuredContent: { ...result } };
     }),
 );
 
@@ -150,14 +385,18 @@ server.registerTool(
   {
     title: "Send a DJ announcement",
     description:
-      "Make the SUB/WAVE DJ speak an update on-air — a news flash, a shout-out, a " +
-      "heads-up, anything you want voiced. ADMIN endpoint: needs SUBWAVE_ADMIN_USER " +
+      "Make the SUB/WAVE DJ speak an update on-air — a news flash, a weather warning, " +
+      "a shout-out, anything you want voiced. ADMIN endpoint: needs SUBWAVE_ADMIN_USER " +
       "and SUBWAVE_ADMIN_PASS set for this server.\n" +
       "mode='styled' (default) treats your text as an instruction and lets the DJ " +
       "rewrite it in persona before speaking — best when you give a topic or rough " +
-      "wording. mode='raw' speaks your text verbatim — best for exact wording.\n" +
+      "wording. mode='raw' speaks your text verbatim — best for exact wording (use " +
+      "raw for emergency alerts so nothing gets paraphrased).\n" +
       "placement='solo' (default) is a heavy-ducked solo DJ moment; placement=" +
-      "'over-track' is lightly ducked so the DJ talks over the playing song.",
+      "'over-track' is lightly ducked so the DJ talks over the playing song.\n" +
+      "sfx names a sound effect from the station library to air under the opening " +
+      "words as an attention stinger (e.g. 'airhorn' before an emergency warning) — " +
+      "list valid names with subwave_list_sfx.",
     inputSchema: {
       message: z
         .string()
@@ -172,15 +411,31 @@ server.registerTool(
         .enum(["solo", "over-track"])
         .default("solo")
         .describe("'solo': ducked solo moment. 'over-track': voiced over the current song."),
+      sfx: z
+        .string()
+        .optional()
+        .describe(
+          "Optional sound-effect name to air under the announcement's opening words " +
+            "(defaults available on most stations: airhorn, record-scratch, applause, " +
+            "whoosh, drum-roll). Omit for voice only.",
+        ),
+    },
+    outputSchema: {
+      ok: z.boolean(),
+      mode: z.enum(["raw", "styled"]),
+      kind: z.string(),
+      spoken: z.string(),
+      sfx: z.string().nullable().optional(),
     },
     annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   },
-  ({ message, mode, placement }) =>
+  ({ message, mode, placement, sfx }) =>
     run(async () => {
       const kind = placement === "over-track" ? "link" : "dj-speak";
-      const result = await client.djSay(message, mode, kind);
+      const result = await client.djSay(message, mode, kind, sfx);
+      const stinger = result.sfx ? ` with '${result.sfx}' stinger` : "";
       return {
-        content: [text(`On-air now (${result.mode}/${result.kind}): "${result.spoken}"`)],
+        content: [text(`On-air now (${result.mode}/${result.kind}${stinger}): "${result.spoken}"`)],
         structuredContent: { ...result },
       };
     }),
@@ -195,15 +450,27 @@ server.registerTool(
     title: "Fire a DJ voice segment",
     description:
       "Trigger one of the SUB/WAVE DJ's scripted voice segments on demand: " +
-      "'station-id' (station ident), 'hourly' (time/weather check-in), or 'link' " +
-      "(a between-track auto-DJ link). ADMIN endpoint — needs SUBWAVE_ADMIN_USER / " +
-      "SUBWAVE_ADMIN_PASS. This is an operator override: it bypasses the DJ's " +
-      "frequency gate. For a custom message, use subwave_dj_announce instead.",
+      "'station-id' (station ident), 'hourly' (time/weather check-in), 'link' (a " +
+      "between-track auto-DJ link), 'banter' (multi-voice guest exchange — needs a " +
+      "guest show on air), or 'programme-intro'/'programme-feature'/'programme-outro' " +
+      "(episode beats — need a programme show on air; check subwave_schedule first). " +
+      "ADMIN endpoint. This is an operator override: it bypasses the DJ's frequency " +
+      "gate. For a custom message, use subwave_dj_announce; for a data-driven " +
+      "segment (weather, news, …), use subwave_run_skill.",
     inputSchema: {
       type: z
-        .enum(["station-id", "hourly", "link"])
+        .enum([
+          "station-id",
+          "hourly",
+          "link",
+          "banter",
+          "programme-intro",
+          "programme-feature",
+          "programme-outro",
+        ])
         .describe("Which scripted segment to fire."),
     },
+    outputSchema: { ok: z.boolean(), type: z.string(), spoken: z.string() },
     annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   },
   ({ type }) =>
@@ -216,11 +483,149 @@ server.registerTool(
     }),
 );
 
+// ---------------------------------------------------------------------------
+// subwave_list_skills — the skill catalogue (admin)
+// ---------------------------------------------------------------------------
+server.registerTool(
+  "subwave_list_skills",
+  {
+    title: "List DJ skills",
+    description:
+      "List the DJ's between-track segment skills — the built-ins (weather, news, " +
+      "traffic, curiosity, album-anniversary, library-deep-cut, web-search) plus any " +
+      "operator-authored skills — with their labels, cooldowns, and enabled state. " +
+      "ADMIN endpoint. Use the 'name' field with subwave_run_skill.",
+    inputSchema: {},
+    annotations: { readOnlyHint: true, openWorldHint: true },
+  },
+  () =>
+    run(async () => {
+      const data = await client.listSkills();
+      return { content: [text(data)] };
+    }),
+);
+
+// ---------------------------------------------------------------------------
+// subwave_run_skill — run a named skill segment now (admin)
+// ---------------------------------------------------------------------------
+server.registerTool(
+  "subwave_run_skill",
+  {
+    title: "Run a DJ skill",
+    description:
+      "Run one of the DJ's segment skills on-air right now — e.g. 'weather' for a " +
+      "weather check-in, 'news' for a headlines beat, or any custom skill the " +
+      "operator has installed. The segment director fetches real data and voices it " +
+      "in persona. ADMIN endpoint; operator override (ignores cooldowns and the " +
+      "frequency gate, works even on a disabled skill). List valid names with " +
+      "subwave_list_skills.",
+    inputSchema: {
+      name: z.string().min(1).describe("Skill name from subwave_list_skills, e.g. 'weather'."),
+    },
+    outputSchema: {
+      ok: z.boolean(),
+      name: z.string(),
+      spoken: z.string().nullable(),
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
+  },
+  ({ name }) =>
+    run(async () => {
+      const result = await client.runSkill(name);
+      return {
+        content: [
+          text(
+            result.spoken
+              ? `Ran skill '${result.name}'. On-air: "${result.spoken}"`
+              : `Ran skill '${result.name}' — it chose to stay silent this time.`,
+          ),
+        ],
+        structuredContent: { ...result },
+      };
+    }),
+);
+
+// ---------------------------------------------------------------------------
+// subwave_list_sfx — the sound-effects library (admin)
+// ---------------------------------------------------------------------------
+server.registerTool(
+  "subwave_list_sfx",
+  {
+    title: "List sound effects",
+    description:
+      "List the station's sound-effects library — short stingers (≤10s) the DJ can " +
+      "play under a voice line or on their own. ADMIN endpoint. Use a returned name " +
+      "with subwave_play_sfx or the sfx parameter of subwave_dj_announce.",
+    inputSchema: {},
+    annotations: { readOnlyHint: true, openWorldHint: true },
+  },
+  () =>
+    run(async () => {
+      const data = await client.listSfx();
+      return { content: [text(data)] };
+    }),
+);
+
+// ---------------------------------------------------------------------------
+// subwave_play_sfx — fire a sound effect on-air (admin)
+// ---------------------------------------------------------------------------
+server.registerTool(
+  "subwave_play_sfx",
+  {
+    title: "Play a sound effect on-air",
+    description:
+      "Fire a sound effect from the station library on-air immediately — mixed over " +
+      "the programme with a light music duck (it does not stop the song). ADMIN " +
+      "endpoint. Good as a standalone attention cue; to pair a stinger with spoken " +
+      "words, prefer subwave_dj_announce's sfx parameter so the two are aligned. " +
+      "List valid names with subwave_list_sfx.",
+    inputSchema: {
+      name: z
+        .string()
+        .min(1)
+        .describe("Effect name, e.g. 'airhorn'. List valid names with subwave_list_sfx."),
+    },
+    outputSchema: { ok: z.boolean(), name: z.string() },
+    annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
+  },
+  ({ name }) =>
+    run(async () => {
+      const result = await client.playSfx(name);
+      return {
+        content: [text(`Sound effect '${result.name}' is going to air.`)],
+        structuredContent: { ...result },
+      };
+    }),
+);
+
+// ---------------------------------------------------------------------------
+// subwave_refresh_playlist — rebuild the fallback auto-playlist (admin)
+// ---------------------------------------------------------------------------
+server.registerTool(
+  "subwave_refresh_playlist",
+  {
+    title: "Refresh the auto-playlist",
+    description:
+      "Rebuild the Liquidsoap fallback auto-playlist for the current mood right now, " +
+      "instead of waiting for the scheduled refresh. ADMIN endpoint. Use after big " +
+      "library changes or a mood shift; it does not affect the current track or the " +
+      "request queue.",
+    inputSchema: {},
+    outputSchema: { ok: z.boolean() },
+    annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
+  },
+  () =>
+    run(async () => {
+      const result = await client.refreshPlaylist();
+      return { content: [text("Auto-playlist rebuilt for the current mood.")], structuredContent: { ...result } };
+    }),
+);
+
 async function main(): Promise<void> {
   const transport = new StdioServerTransport();
   await server.connect(transport);
   // stderr only — stdout is the MCP channel.
-  console.error("subwave-mcp ready on stdio");
+  console.error(`subwave-mcp ${pkg.version} ready on stdio`);
 }
 
 main().catch((err) => {

--- a/web/components/manual/AgentAccess.tsx
+++ b/web/components/manual/AgentAccess.tsx
@@ -1,13 +1,25 @@
 import Link from 'next/link';
 import ManualPage from './ManualPage';
 
-// The five MCP tools — see docs/mcp-server.md for the full contract.
+// The MCP tool surface — see docs/mcp-server.md for the full contract.
 const TOOLS = [
+  { name: 'subwave_health', summary: 'Liveness: the controller is reachable and the stream reports on-air.', auth: '—' },
   { name: 'subwave_now_playing', summary: 'The current track, station context, and live listener count.', auth: '—' },
   { name: 'subwave_station_state', summary: 'The upcoming queue, recent history, and the DJ booth log.', auth: '—' },
-  { name: 'subwave_request_song', summary: 'Queues a track from a natural-language request: a song, an artist, or a vibe.', auth: '—' },
-  { name: 'subwave_dj_announce', summary: 'Puts a spoken update on air, rewritten in persona or read verbatim.', auth: 'Admin' },
-  { name: 'subwave_dj_segment', summary: 'Fires a scripted segment on demand: station ID, the hour, or a link.', auth: 'Admin' },
+  { name: 'subwave_schedule', summary: 'Personas, shows, and the weekly schedule grid, in station time.', auth: '—' },
+  { name: 'subwave_session', summary: "The DJ's live session and its recent on-air transcript.", auth: '—' },
+  { name: 'subwave_request_song', summary: 'Queues a track from a natural-language request — a song, an artist, or a vibe — and waits for the booth’s verdict.', auth: '—' },
+  { name: 'subwave_request_status', summary: 'Checks on an earlier request by its receipt id.', auth: '—' },
+  { name: 'subwave_search_library', summary: 'Searches the library by terms: exact results, no LLM, no rate limit.', auth: 'Admin' },
+  { name: 'subwave_queue_track', summary: 'Queues an exact search result — an operator pick, no DJ intro.', auth: 'Admin' },
+  { name: 'subwave_skip_track', summary: 'Force-ends the current track. An operator override; listeners have no skip.', auth: 'Admin' },
+  { name: 'subwave_dj_announce', summary: 'Puts a spoken update on air, rewritten in persona or read verbatim — optionally over a sound-effect stinger.', auth: 'Admin' },
+  { name: 'subwave_dj_segment', summary: 'Fires a scripted segment on demand: station ID, the hour, a link, guest banter, or a programme beat.', auth: 'Admin' },
+  { name: 'subwave_list_skills', summary: 'The skill catalogue — weather, news, and any custom skills installed.', auth: 'Admin' },
+  { name: 'subwave_run_skill', summary: 'Runs a named skill segment now, with real data behind it.', auth: 'Admin' },
+  { name: 'subwave_list_sfx', summary: 'The sound-effects library: short stingers the station can play.', auth: 'Admin' },
+  { name: 'subwave_play_sfx', summary: 'Fires a sound effect on air immediately, mixed over the programme.', auth: 'Admin' },
+  { name: 'subwave_refresh_playlist', summary: 'Rebuilds the fallback auto-playlist for the current mood.', auth: 'Admin' },
 ];
 
 export default function AgentAccess() {
@@ -15,7 +27,7 @@ export default function AgentAccess() {
     <ManualPage
       eyebrow="MANUAL · 14"
       title="Agent access."
-      intro="SUB/WAVE isn't only for human listeners. An AI agent can read what's on air and put songs and DJ segments onto the broadcast through the station's MCP server."
+      intro="SUB/WAVE isn't only for human listeners. An AI agent can read what's on air and put songs, DJ segments, and sound effects onto the broadcast through the station's MCP server."
       current="/manual/mcp"
     >
       <section className="bs-section">
@@ -37,15 +49,15 @@ export default function AgentAccess() {
           browser, an agent calls a tool, and the same controller does the work.
         </p>
         <p className="text-muted">
-          The server holds no logic of its own; each tool is a typed wrapper over one
-          controller endpoint. The agent never sees a URL or an auth header, only the
-          five intent-shaped tools below.
+          The server holds almost no logic of its own; each tool is a typed wrapper over
+          one controller endpoint. The agent never sees a URL or an auth header, only
+          the intent-shaped tools below.
         </p>
       </section>
 
       <section className="bs-section">
         <p className="bs-eyebrow">THE TOOLS</p>
-        <h2>Five things an agent can do.</h2>
+        <h2>Seventeen things an agent can do.</h2>
         <table className="bs-doc-table">
           <thead>
             <tr>
@@ -67,7 +79,25 @@ export default function AgentAccess() {
         <p className="text-muted">
           Like the human request path, <code className="bs-code-inline">subwave_request_song</code>{' '}
           queues a track (it never interrupts the song that's playing) and it's
-          rate-limited. The two DJ-control tools speak immediately.
+          rate-limited; the booth resolves the request in the background, so the tool
+          waits for the outcome and reports the matched track and the DJ's ack. When an
+          agent already knows the exact track, the search-and-queue pair does the same
+          job with no LLM and no rate limit. The DJ-control tools speak immediately.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">AN ALERT, WITH AN AIRHORN</p>
+        <h2>Attention first, then the message.</h2>
+        <p>
+          The announce tool takes an optional sound effect from the station's library,
+          aired under its opening words. That turns an external watcher into a proper
+          alert system: an agent monitoring weather warnings for your area can call{' '}
+          <code className="bs-code-inline">subwave_dj_announce</code> with the warning
+          text, <code className="bs-code-inline">mode: raw</code> so nothing gets
+          paraphrased, and <code className="bs-code-inline">sfx: airhorn</code> to cut
+          through the music before the words land. Effects can also fire on their own
+          with <code className="bs-code-inline">subwave_play_sfx</code>.
         </p>
       </section>
 
@@ -75,10 +105,10 @@ export default function AgentAccess() {
         <p className="bs-eyebrow">PUBLIC vs ADMIN</p>
         <h2>Reading and requesting are open.</h2>
         <p>
-          The three read-and-request tools need no credentials: they map to the same
-          public, rate-limited endpoints a browser uses. The two DJ-control tools, which
-          put a voice on air, are gated: the server sends the station's{' '}
-          <code className="bs-code-inline">ADMIN_USER</code> /{' '}
+          The seven read-and-request tools need no credentials: they map to the same
+          public endpoints a browser uses. Everything that drives the station — voice,
+          segments, skills, effects, the queue, the skip — is gated: the server sends
+          the station's <code className="bs-code-inline">ADMIN_USER</code> /{' '}
           <code className="bs-code-inline">ADMIN_PASS</code> as a Basic auth header, read
           from its own environment. Without them, an agent can still see what's on air
           and request songs; it just can't drive the DJ.
@@ -90,11 +120,13 @@ export default function AgentAccess() {
         <h2>Point an MCP client at it.</h2>
         <p>
           The server lives in the repo at <code className="bs-code-inline">mcp-subwave/</code>.
-          Build it once with <code className="bs-code-inline">npm install &amp;&amp; npm run build</code>,
-          then point any MCP client (Claude Code, Claude Desktop, or another) at the
-          built <code className="bs-code-inline">dist/index.js</code>, passing the
-          controller URL and, optionally, the admin credentials as environment variables.
-          The station must be running first.
+          Build it once with <code className="bs-code-inline">npm install</code>, then
+          point any MCP client (Claude Code, Claude Desktop, or another) at the built{' '}
+          <code className="bs-code-inline">dist/index.js</code>, passing the controller
+          URL and, optionally, the admin credentials as environment variables. Inside
+          the repo itself, Claude Code picks the server up automatically from the root{' '}
+          <code className="bs-code-inline">.mcp.json</code>. The station must be
+          running first.
         </p>
         <div className="bs-callout">
           <div className="bs-eyebrow">FULL REFERENCE</div>

--- a/web/components/manual/Overview.tsx
+++ b/web/components/manual/Overview.tsx
@@ -55,7 +55,7 @@ const GUIDE = [
   {
     href: '/manual/mcp',
     label: 'Agent Access',
-    blurb: 'Let an AI agent read the station and request tracks over the MCP server.',
+    blurb: 'Let an AI agent read the station, request tracks, and drive the DJ over the MCP server.',
   },
   {
     href: '/manual/faq',

--- a/web/content/news/2026-07-06-agent-in-the-booth.md
+++ b/web/content/news/2026-07-06-agent-in-the-booth.md
@@ -1,0 +1,27 @@
+---
+title: Let an agent work the booth
+date: 2026-07-06
+category: Feature
+author: The SUB/WAVE desk
+excerpt: The station's MCP server grew from five tools to seventeen. An AI agent can now search the library, queue exact tracks, run skills, and sound an airhorn before an emergency announcement.
+---
+
+An operator wired an agent to Environment Canada so weather warnings for his area go straight to air, read by the DJ. The one thing he couldn't do was sound the airhorn first. Now he can, and the agent side of the station got a lot bigger while we were at it.
+
+## What's new
+
+The MCP server (`mcp-subwave/` in the repo) is how an AI agent like Claude talks to your station. It launched with five tools; it now has seventeen. An agent can read the schedule and the DJ's session transcript, or search the library and queue an exact track with no rate limit. It can run any skill, skip the current track (operators only), and fire a sound effect on air. Announcements can carry a stinger too: name an effect and it plays under the DJ's first words. Song requests also report properly again; the tool now waits for the booth's verdict and comes back with the matched track and the DJ's ack.
+
+## How to use it
+
+Build it once:
+
+```
+cd mcp-subwave && npm install
+```
+
+Then point your MCP client at `dist/index.js`, with `SUBWAVE_API_URL` and, for the booth tools, your admin credentials. Claude Desktop and Claude Code both work. Inside the repo, Claude Code picks the server up automatically from the root `.mcp.json`. For the alert trick, call `subwave_dj_announce` with `mode: raw` so nothing gets paraphrased, and `sfx: airhorn`.
+
+## Why it helps
+
+The station already runs itself; this gives your other automations a proper way in. A weather watcher, a calendar bot, a home server that wants to say the backup finished: anything that can speak MCP can now put a voice on your air, airhorn included, with the same guardrails the admin panel uses.


### PR DESCRIPTION
## Why

`mcp-subwave/` was frozen at mid-May while the controller API moved on — its headline tool was silently broken, and none of the newer surfaces (skills, programmes, manual queueing, SFX) were reachable by agents. This also implements the community ask: an external alerting agent (e.g. an emergency weather watcher) being able to sound an attention stinger like the airhorn before an announcement.

## MCP server fixes

- **`subwave_request_song` worked against a removed contract.** `POST /request` returns a 202 receipt and resolves in the booth in the background, so every request reported `Queued "undefined" by undefined at position undefined`. The tool now polls `GET /request/:id` (2s interval, ~45s budget) and reports the real outcome; past the budget it hands back the `requestId` for the new `subwave_request_status` tool.
- **503s are passed through**, not hardcoded to `REQUESTS_DISABLED` — the zero-listener autopilot pause was being misdiagnosed as an env-var problem.
- **`subwave_dj_segment`** now accepts `banter` and `programme-intro/feature/outro`.

## New tools (17 total)

`subwave_health`, `subwave_schedule`, `subwave_session`, `subwave_request_status`, `subwave_search_library` + `subwave_queue_track` (deterministic, no-LLM queueing), `subwave_skip_track` (admin override, `destructiveHint`), `subwave_list_skills` + `subwave_run_skill`, `subwave_list_sfx` + `subwave_play_sfx`, `subwave_refresh_playlist`.

## Controller: on-air sound effects for automations

- `POST /dj/say` accepts an optional `sfx` name — validated against the library (400 lists the catalogue on a miss), aired under the announcement's opening words via the same `underVoice` alignment the segment director uses. Manual trigger, so it ignores the `settings.sfx.enabled` autonomy toggle like every operator press.
- `POST /sfx/:name/play` fires an effect on-air standalone.

## Hygiene

- `outputSchema` declared on tools returning `structuredContent`; loose passthrough tools return text JSON only (spec-conformant).
- MCP SDK bumped to ^1.29; server version read from `package.json` (0.2.0); `prepare` builds on install.
- `npm run lint` (`tsc --noEmit`) added and wired into the CI lint matrix.
- Root `.mcp.json` so Claude Code sessions in this repo get the tools automatically.
- `docs/mcp-server.md` + `mcp-subwave/README.md` refreshed (async request flow, admin skip nuance, new tool table).

## Verification

- `controller`: `npm run lint` clean (0 errors) on the rebased branch.
- `mcp-subwave`: builds; stdio smoke test (initialize → tools/list) registers all 17 tools with the intended output schemas.
- Not live-tested against a running stack (controller wasn't up); the request-poll loop and the sfx-under-voice timing are worth one manual pass: request a song, and `curl -u admin: -X POST :7701/dj/say -d '{"text":"test","mode":"raw","sfx":"airhorn"}'`.
