### PR TITLE
fix(tts): build the AIO kokoro venv on Python 3.12 so misaki 0.9.4 installs

### DIFF
--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -105,10 +105,21 @@ RUN mkdir -p /opt/piper/voices && \
       https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/alan/medium/en_GB-alan-medium.onnx.json
 
 # --- Kokoro (optional second TTS, more natural) ----------------------------
-RUN python3 -m venv /opt/kokoro/venv && \
-    /opt/kokoro/venv/bin/pip install --no-cache-dir --upgrade pip && \
-    /opt/kokoro/venv/bin/pip install --no-cache-dir \
-      kokoro-onnx==0.5.0 soundfile==0.12.1 misaki==0.9.4
+# kokoro_worker.py imports misaki unconditionally, and kokoro-onnx 0.5.0 pairs
+# with misaki 0.9.4 (the controller image's validated combo). But misaki 0.9.4
+# requires Python <3.13, while this base (liquidsoap/Debian trixie) ships 3.13 —
+# so, unlike the controller (bookworm/py3.11), the system python3 can't build
+# the kokoro venv (misaki 0.9.4 has no 3.13 wheel and pip resolves nothing).
+# Provision a standalone CPython 3.12 via uv for THIS venv only; the analyzer
+# venv below stays on the system python3. The final import mirrors the worker's
+# import block, so a broken combo fails the build instead of silently falling
+# back to Piper at runtime.
+COPY --from=ghcr.io/astral-sh/uv:0.11.27 /uv /usr/local/bin/uv
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
+RUN uv venv --python 3.12 /opt/kokoro/venv && \
+    uv pip install --python /opt/kokoro/venv/bin/python --no-cache \
+      kokoro-onnx==0.5.0 soundfile==0.12.1 misaki==0.9.4 && \
+    /opt/kokoro/venv/bin/python -c "import kokoro_onnx, misaki; from misaki import espeak"
 RUN mkdir -p /opt/kokoro/models && \
     wget -q ${WGET_RETRY} -O /opt/kokoro/models/kokoro-v1.0.onnx \
       https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx && \


### PR DESCRIPTION
## Summary

Fixes the failing **v0.38.0 Publish images** jobs for `subwave-aio` and `subwave-aio-heavy` ([run 28836310608](https://github.com/perminder-klair/subwave/actions/runs/28836310608)).

Root cause: #896 mirrored the controller's `misaki==0.9.4` pin into `docker/Dockerfile.aio`, but the AIO's base (`savonet/liquidsoap:v2.4.5` → Debian **trixie**) ships **Python 3.13**, and misaki 0.9.4 requires `>=3.8,<3.13`. On 3.13 pip resolves nothing and the build dies:

```
ERROR: Could not find a version that satisfies the requirement misaki==0.9.4
```

The controller image builds the identical line fine because it's `node:22-bookworm-slim` (Debian bookworm / Python 3.11).

## Fix

Provision a standalone CPython **3.12** via `uv` for the kokoro venv **only** (the analyzer venv stays on the system python3), keeping the exact validated `kokoro-onnx 0.5.0` + `misaki 0.9.4` combo the controller ships. A build-time import mirroring `kokoro_worker.py` (`import kokoro_onnx, misaki; from misaki import espeak`) makes a bad combo fail the build instead of silently degrading to Piper at runtime — the very failure mode #896 was chasing.

Verified locally on the trixie base:

```
Using CPython 3.12.13
Installed 34 packages ... + misaki==0.9.4
KOKORO IMPORTS OK
```

## Note on releasing

v0.38.0 is already tagged; its publish run pushed every image **except** the two AIO tags. So `subwave-aio:v0.38.0` / `:latest` were never published (the existing `:latest` still points at the working 0.37.x AIO). Once this lands and a new version tag is cut, publish-images rebuilds all images including the fixed AIO. If AIO images are wanted under v0.38.0 specifically, re-running the publish job won't help (same tagged commit) — it needs a v0.38.1.

## Test plan
- [ ] `subwave-aio` and `subwave-aio-heavy` build green in the next publish run
- [ ] On the AIO image, selecting Kokoro TTS produces speech (no silent fallback to Piper)