### PR TITLE
release: fix AIO image build so v0.38 Kokoro images publish

### DIFF
--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -105,10 +105,21 @@ RUN mkdir -p /opt/piper/voices && \
       https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/alan/medium/en_GB-alan-medium.onnx.json
 
 # --- Kokoro (optional second TTS, more natural) ----------------------------
-RUN python3 -m venv /opt/kokoro/venv && \
-    /opt/kokoro/venv/bin/pip install --no-cache-dir --upgrade pip && \
-    /opt/kokoro/venv/bin/pip install --no-cache-dir \
-      kokoro-onnx==0.5.0 soundfile==0.12.1 misaki==0.9.4
+# kokoro_worker.py imports misaki unconditionally, and kokoro-onnx 0.5.0 pairs
+# with misaki 0.9.4 (the controller image's validated combo). But misaki 0.9.4
+# requires Python <3.13, while this base (liquidsoap/Debian trixie) ships 3.13 —
+# so, unlike the controller (bookworm/py3.11), the system python3 can't build
+# the kokoro venv (misaki 0.9.4 has no 3.13 wheel and pip resolves nothing).
+# Provision a standalone CPython 3.12 via uv for THIS venv only; the analyzer
+# venv below stays on the system python3. The final import mirrors the worker's
+# import block, so a broken combo fails the build instead of silently falling
+# back to Piper at runtime.
+COPY --from=ghcr.io/astral-sh/uv:0.11.27 /uv /usr/local/bin/uv
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
+RUN uv venv --python 3.12 /opt/kokoro/venv && \
+    uv pip install --python /opt/kokoro/venv/bin/python --no-cache \
+      kokoro-onnx==0.5.0 soundfile==0.12.1 misaki==0.9.4 && \
+    /opt/kokoro/venv/bin/python -c "import kokoro_onnx, misaki; from misaki import espeak"
 RUN mkdir -p /opt/kokoro/models && \
     wget -q ${WGET_RETRY} -O /opt/kokoro/models/kokoro-v1.0.onnx \
       https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx && \


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge with "Create a merge commit"** — not "Squash and merge". Squash collapses the individual `feat:` / `fix:` / `chore:` commits into one `release: …` commit, and release-please then sees no conventional-commit signal and skips the version bump.

## Summary

Patch release. The v0.38.0 publish run pushed every image except the two AIO tags (`subwave-aio` / `subwave-aio-heavy`), which failed to build: the Kokoro fix in v0.38.0 (#896) pinned `misaki==0.9.4`, but the AIO base (`savonet/liquidsoap:v2.4.5` → Debian trixie → Python 3.13) can't install it (misaki 0.9.4 requires `<3.13`). This PR provisions a standalone CPython 3.12 via `uv` for the AIO kokoro venv so the same validated `kokoro-onnx 0.5.0 + misaki 0.9.4` combo installs and the AIO images publish. Infra-only, no app behaviour change.

Once this lands, release-please cuts the next patch tag and the publish run rebuilds the AIO images.

**Bug Fixes**
- `69c66ac` fix(tts): build the AIO kokoro venv on Python 3.12 so misaki 0.9.4 installs (#909)

## Test plan
- [ ] `subwave-aio` and `subwave-aio-heavy` build green in the next publish run
- [ ] On the AIO image, selecting Kokoro TTS produces speech (no silent fallback to Piper)