### PR TITLE
fix(llm): stop runaway </think> repetition loops leaking to air

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -448,6 +448,20 @@ async function main() {
     assert.equal(stripThinking('leftover reasoning</think>  the answer'), 'the answer');
     assert.equal(stripThinking('plain text'), 'plain text');
   });
+  await test('stripThinking collapses a </think>-separated repetition loop to the first answer', () => {
+    // Live incident 2026-07-07: glm-5.2:cloud looped the sign-off, emitting
+    // </think> between each repeat until the token cap truncated the tail.
+    const runaway =
+      'Alright, I\'m out — good hands, see you tomorrow.</think>' +
+      'Alright, I\'m clocking out — good hands, see you tomorrow.</think>' +
+      'Alright, I\'m clocking out — good hands, see you tomorrow.</think>' +
+      'Alright, I\'m clocking out before I talk myself into a';
+    assert.equal(stripThinking(runaway), 'Alright, I\'m out — good hands, see you tomorrow.');
+    // Never leak a stray tag even when nothing else matches.
+    assert.equal(stripThinking('done for the night</think>'), 'done for the night');
+    // A verbatim two-way repeat (no third segment) is still a loop, not a leak.
+    assert.equal(stripThinking('same line here</think>same line here'), 'same line here');
+  });
   await test('extractJson pulls the object out of fences and prose', () => {
     assert.equal(extractJson('```json\n{"a":1}\n```'), '{"a":1}');
     assert.equal(extractJson('here you go: {"a":1,"b":2} done'), '{"a":1,"b":2}');

--- a/controller/src/llm/internal/core/pure.ts
+++ b/controller/src/llm/internal/core/pure.ts
@@ -15,11 +15,36 @@
 // `llm.reasoning` is off (provider no-think fetch + the Ollama `think` flag);
 // we still strip any leftover tags defensively here.
 const THINK_TAG_RE = /<think>[\s\S]*?<\/think>\s*/gi;
-const DANGLING_THINK_RE = /^[\s\S]*?<\/think>\s*/i;
+const CLOSE_THINK_RE = /<\/think>/i;
+const ANY_THINK_TAG_RE = /<\/?think>/gi;
+
+// Normalise a segment for the repetition check (lowercase + collapse whitespace).
+function normSeg(s: string): string {
+  return s.toLowerCase().replace(/\s+/g, ' ').trim();
+}
 
 export function stripThinking(s: any): any {
-  if (!s) return s;
-  return s.replace(THINK_TAG_RE, '').replace(DANGLING_THINK_RE, '').trim();
+  if (!s || typeof s !== 'string') return s;
+  // 1. Well-formed <think>…</think> blocks.
+  let t = s.replace(THINK_TAG_RE, '');
+  // 2. Stray closing tags with no opener. Two shapes reach here:
+  //    (a) a genuine reasoning leak — `reasoning</think>answer`, ONE close tag,
+  //        the answer follows it → keep the LAST segment.
+  //    (b) a runaway loop where a reasoning model (thinking not actually
+  //        suppressed by the endpoint, e.g. an Ollama :cloud GLM) emits </think>
+  //        as a separator between repeated near-identical answers until it hits
+  //        the output-token cap (live incident 2026-07-07, generateSignoff). The
+  //        tail is a truncated duplicate, so keep the FIRST complete segment.
+  if (CLOSE_THINK_RE.test(t)) {
+    const segs = t.split(/<\/think>/i).map((x) => x.trim()).filter(Boolean);
+    if (segs.length) {
+      const norm = segs.map(normSeg);
+      const hasRepeat = norm.some((v, i) => norm.indexOf(v) !== i);
+      t = segs.length >= 3 || hasRepeat ? segs[0] : segs[segs.length - 1];
+    }
+  }
+  // 3. Belt-and-suspenders — no stray <think>/</think> ever reaches TTS/booth.
+  return t.replace(ANY_THINK_TAG_RE, '').trim();
 }
 
 // Pull a JSON object out of a free-text reply: drop ```json fences and any


### PR DESCRIPTION
## What happened

At a show handoff (2026-07-07 ~08:05 IST), the sign-off generation (`generateSignoff`) ran away: `ollama:glm-5.2:cloud` degenerated into a repetition loop, emitting the same sentence ~18 times with a stray `</think>` between each repeat, only stopping when it hit the 4000-token output cap (leaving the tail truncated mid-word). Because there was no opening `<think>`, the old `stripThinking()` cleaned none of it — 16+ `</think>` tags plus the repeated garbage reached TTS and the booth.

The model loop itself is outside our code (Ollama cloud ignoring `think:false`), so this hardens the single free-text chokepoint every DJ segment passes through so the garbage never airs.

## Change

`controller/src/llm/internal/core/pure.ts` — `stripThinking()`:
1. Remove well-formed `<think>…</think>` blocks (unchanged).
2. On stray closing tags, split on `</think>`:
   - **repetition loop** (≥3 segments or any duplicate) → keep the **first complete** segment, not the truncated tail;
   - **genuine reasoning leak** (`reasoning</think>answer`) → keep the last segment (existing behaviour, still tested).
3. Belt-and-suspenders: strip any remaining `<think>`/`</think>` so no tag ever reaches TTS/booth.

On the incident text this collapses the 4000-token loop to the clean opening line.

## Tests

- Added a regression test in `controller/scripts/llm-pure.test.ts` pinned to the incident shape (loop collapse, stray-tag strip, verbatim two-way repeat).
- `npm run test:llm` passes; `npm run lint` clean (0 errors).

## Notes (not in this PR)

- Blast radius is still ~4000 tokens / ~34s per occurrence. If it recurs, worth lowering `MAX_TOKENS_TEXT` (`strategy/text.ts`).
- Live station is on `glm-5.2:cloud`; the tested picker keeper was `glm-5.1:cloud` — possible silent model regression worth checking.