### PR TITLE
feat(tts): expose ElevenLabs voice_settings globally under tts.cloud

### DIFF
--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -165,8 +165,15 @@ async function speakWith(engine: string, text: string, opts: any, personaTts: an
   }
   if (engine === 'cloud') {
     // Persona picks provider + voice; the shared tts.cloud holds key + model.
-    const cloudOverride = (personaTts && personaTts.engine === 'cloud')
+    // `opts.cloudVoiceSettings` (preview-only, from synthesizeSample) rides the
+    // same override so "Play sample" auditions UNSAVED ElevenLabs voice_settings
+    // sliders — cloud-speech spreads the override over the saved tts.cloud, so
+    // the live path (which never sets it) keeps reading saved values.
+    const personaOverride = (personaTts && personaTts.engine === 'cloud')
       ? { provider: personaTts.cloudProvider, voice: personaTts.voice }
+      : null;
+    const cloudOverride = (personaOverride || opts.cloudVoiceSettings)
+      ? { ...(personaOverride || {}), ...(opts.cloudVoiceSettings || {}) }
       : null;
     return cloud.speak(text, { ...opts, cloudOverride });
   }
@@ -207,25 +214,51 @@ const PREVIEW_TEXT_MAX = 200;
 const DEFAULT_PREVIEW_TEXT = "You're listening to SUB/WAVE. This is a voice preview.";
 
 export async function synthesizeSample(
-  { engine, voice = '', cloudProvider = 'openai', speed, lang, text }: {
+  { engine, voice = '', cloudProvider = 'openai', speed, lang, text, voiceSettings }: {
     engine: string;
     voice?: string;
     cloudProvider?: string;
     speed?: number;
     lang?: string;
     text?: string;
+    // Unsaved ElevenLabs voice_settings sliders to audition (issue #696) —
+    // same field names as settings.tts.cloud so they merge straight into the
+    // cloudOverride in speakWith(). Sanitized here, like `speed`.
+    voiceSettings?: {
+      voiceStability?: number;
+      voiceStyle?: number;
+      voiceSimilarityBoost?: number;
+      voiceUseSpeakerBoost?: boolean;
+    };
   },
 ): Promise<string> {
   if (!ENGINES.includes(engine)) throw new Error(`Unknown engine: ${engine}`);
   const raw = (typeof text === 'string' && text.trim()) ? text.trim() : DEFAULT_PREVIEW_TEXT;
   const sample = normalizeForSpeech(raw.slice(0, PREVIEW_TEXT_MAX));
   const scale = settings.clampTtsSpeed(speed);
+  // Clamp the audition voice_settings to ElevenLabs' [0,1] the same way
+  // settings.update() does for the saved values, so a hand-crafted preview
+  // request can't 400 the provider call.
+  const clamp01 = (n: unknown) =>
+    typeof n === 'number' && Number.isFinite(n) ? Math.min(1, Math.max(0, n)) : undefined;
+  let cloudVoiceSettings: Record<string, number | boolean> | undefined;
+  if (engine === 'cloud' && voiceSettings) {
+    cloudVoiceSettings = {};
+    for (const key of ['voiceStability', 'voiceStyle', 'voiceSimilarityBoost'] as const) {
+      const v = clamp01(voiceSettings[key]);
+      if (v !== undefined) cloudVoiceSettings[key] = v;
+    }
+    if (typeof voiceSettings.voiceUseSpeakerBoost === 'boolean') {
+      cloudVoiceSettings.voiceUseSpeakerBoost = voiceSettings.voiceUseSpeakerBoost;
+    }
+    if (Object.keys(cloudVoiceSettings).length === 0) cloudVoiceSettings = undefined;
+  }
   // Synthetic persona so speakWith() picks up the requested voice/provider
   // exactly (its per-engine branches key off personaTts.engine === <engine>).
   const personaTts = { engine, voice, cloudProvider };
   // No outPath → each engine self-generates a WAV path under config.piper.outDir
   // (reaped by cleanupOldVoices) and returns it.
-  return speakWith(engine, sample, { speedScale: scale, language: '', soul: '', lang }, personaTts);
+  return speakWith(engine, sample, { speedScale: scale, language: '', soul: '', lang, cloudVoiceSettings }, personaTts);
 }
 
 // Public entry point. Tries the configured engine; on failure, falls back to

--- a/controller/src/llm/internal/speech/cloud-speech.ts
+++ b/controller/src/llm/internal/speech/cloud-speech.ts
@@ -196,6 +196,24 @@ export async function speak(
   const isCompat = c.provider === 'openai-compatible';
   const speed = clampSpeed(config.tts.cloudSpeed * (speedScale != null ? speedScale : 1), c.provider);
 
+  // ElevenLabs voice_settings — expressive knobs the operator tunes in the
+  // Cloud TTS section of admin → Settings (issue #696). Only spread when the
+  // provider is actually elevenlabs so the openai / openai-compatible request
+  // shape stays byte-identical. The AI SDK's ElevenLabs provider exposes them
+  // as camelCase `voiceSettings.*` on `providerOptions.elevenlabs`.
+  const elevenlabsOpts = c.provider === 'elevenlabs'
+    ? {
+      elevenlabs: {
+        voiceSettings: {
+          stability: c.voiceStability,
+          style: c.voiceStyle,
+          similarityBoost: c.voiceSimilarityBoost,
+          useSpeakerBoost: c.voiceUseSpeakerBoost,
+        },
+      },
+    }
+    : null;
+
   const result = await generateSpeech({
     model: speechModel(c),
     text,
@@ -210,6 +228,7 @@ export async function speak(
     // openai-compatible: omit the param entirely and let the server choose —
     // `result.audio.format` below drives the file extension regardless.
     ...(isCompat ? {} : { outputFormat: c.provider === 'elevenlabs' ? 'mp3' : 'wav' }),
+    ...(elevenlabsOpts ? { providerOptions: elevenlabsOpts } : {}),
   });
 
   const fmt = result.audio.format || 'mp3';

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -429,7 +429,10 @@ router.post('/settings/secrets/test', requireAdmin, async (req, res) => {
 // POST /settings/tts/preview — synthesize a short sample in an EXPLICIT engine +
 // voice (not the on-air persona) so the admin "Play sample" button can audition
 // a voice/speed before saving. Body: { engine, voice?, cloudProvider?, speed?,
-// lang?, text? }. On success streams the rendered WAV (audio/wav). On a synth
+// lang?, text?, voiceSettings? } — voiceSettings carries UNSAVED ElevenLabs
+// slider values (issue #696) so the operator can tune the expressive knobs by
+// ear before saving; synthesizeSample clamps them like settings.update() does.
+// On success streams the rendered WAV (audio/wav). On a synth
 // failure — e.g. the tts-heavy sidecar is down or no cloud key — returns 422
 // with { ok, message } instead of silently falling back to Piper, so the
 // operator sees why. The temp WAV is unlinked once sent.
@@ -449,6 +452,9 @@ router.post('/settings/tts/preview', requireAdmin, async (req, res) => {
       speed: typeof body.speed === 'number' ? body.speed : undefined,
       lang: typeof body.lang === 'string' ? body.lang : undefined,
       text: typeof body.text === 'string' ? body.text : undefined,
+      voiceSettings: (body.voiceSettings && typeof body.voiceSettings === 'object')
+        ? body.voiceSettings
+        : undefined,
     });
     const buf = await readFile(filePath);
     // Local engines render WAV; cloud (ElevenLabs) renders MP3. Set the type

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -878,6 +878,16 @@ const DEFAULTS = {
       // (e.g. http://192.168.1.101:5000/v1). Required — and only used — when
       // provider === 'openai-compatible'.
       baseUrl: '',
+      // ElevenLabs voice_settings. Applied ONLY when provider is 'elevenlabs';
+      // ignored (and never sent) for openai / openai-compatible. All four match
+      // ElevenLabs' native ranges: stability, style, similarity_boost ∈ [0,1],
+      // use_speaker_boost is a bool. Defaults mirror ElevenLabs' UI defaults so
+      // an unconfigured install renders exactly like the SDK's own baseline
+      // (issue #696).
+      voiceStability: 0.5,
+      voiceStyle: 0,
+      voiceSimilarityBoost: 0.75,
+      voiceUseSpeakerBoost: true,
     },
     // Remote engine — a user-configured self-hosted TTS endpoint that renders
     // audio over HTTP (POST /speak → audio body, gated on a /health probe).
@@ -1629,6 +1639,25 @@ export async function load() {
           typeof stored.tts?.cloud?.baseUrl === 'string'
             ? stored.tts.cloud.baseUrl.trim()
             : DEFAULTS.tts.cloud.baseUrl,
+        // ElevenLabs voice_settings — clamped to [0,1] on load so a hand-edited
+        // settings.json can't ship an out-of-range value to the provider (which
+        // would 400 the whole speak call, silently dropping the voice).
+        voiceStability:
+          typeof stored.tts?.cloud?.voiceStability === 'number'
+            ? clamp01(stored.tts.cloud.voiceStability)
+            : DEFAULTS.tts.cloud.voiceStability,
+        voiceStyle:
+          typeof stored.tts?.cloud?.voiceStyle === 'number'
+            ? clamp01(stored.tts.cloud.voiceStyle)
+            : DEFAULTS.tts.cloud.voiceStyle,
+        voiceSimilarityBoost:
+          typeof stored.tts?.cloud?.voiceSimilarityBoost === 'number'
+            ? clamp01(stored.tts.cloud.voiceSimilarityBoost)
+            : DEFAULTS.tts.cloud.voiceSimilarityBoost,
+        voiceUseSpeakerBoost:
+          typeof stored.tts?.cloud?.voiceUseSpeakerBoost === 'boolean'
+            ? stored.tts.cloud.voiceUseSpeakerBoost
+            : DEFAULTS.tts.cloud.voiceUseSpeakerBoost,
       },
       remote: {
         url:
@@ -2752,6 +2781,27 @@ export async function update(patch) {
           throw new Error('tts.cloud.baseUrl must start with http:// or https://');
         }
         next.tts.cloud.baseUrl = v.replace(/\/+$/, ''); // strip trailing slashes
+      }
+      // ElevenLabs voice_settings — clamped, not rejected. The UI sliders can't
+      // produce out-of-range values, so a strict throw would only fire for a
+      // hand-crafted payload; clamp so the DJ never goes silent on a typo.
+      // Applied for every provider on save so switching provider later
+      // preserves the operator's tuning, but only spread into providerOptions
+      // in cloud-speech.ts when provider === 'elevenlabs' (see there).
+      if (c.voiceStability !== undefined) {
+        const n = Number(c.voiceStability);
+        next.tts.cloud.voiceStability = Number.isFinite(n) ? clamp01(n) : DEFAULTS.tts.cloud.voiceStability;
+      }
+      if (c.voiceStyle !== undefined) {
+        const n = Number(c.voiceStyle);
+        next.tts.cloud.voiceStyle = Number.isFinite(n) ? clamp01(n) : DEFAULTS.tts.cloud.voiceStyle;
+      }
+      if (c.voiceSimilarityBoost !== undefined) {
+        const n = Number(c.voiceSimilarityBoost);
+        next.tts.cloud.voiceSimilarityBoost = Number.isFinite(n) ? clamp01(n) : DEFAULTS.tts.cloud.voiceSimilarityBoost;
+      }
+      if (c.voiceUseSpeakerBoost !== undefined) {
+        next.tts.cloud.voiceUseSpeakerBoost = !!c.voiceUseSpeakerBoost;
       }
       // An OpenAI-compatible TTS server has no canonical endpoint — refuse to
       // save the provider without one. Mirrors the LLM-side check below.

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -120,6 +120,14 @@ interface CloudTtsCfg {
   model: string;
   voice: string;
   baseUrl: string;
+  // ElevenLabs voice_settings (issue #696). All four are read + saved
+  // regardless of provider so switching provider later preserves the
+  // operator's tuning, but the UI + the outbound request only surface them
+  // when provider === 'elevenlabs'.
+  voiceStability: number;
+  voiceStyle: number;
+  voiceSimilarityBoost: number;
+  voiceUseSpeakerBoost: boolean;
 }
 
 interface TtsForm {
@@ -480,6 +488,11 @@ export default function SettingsPanel() {
           model: v.tts?.cloud?.model ?? '',
           voice: v.tts?.cloud?.voice ?? '',
           baseUrl: v.tts?.cloud?.baseUrl ?? '',
+          // ElevenLabs voice_settings — defaults mirror the server's DEFAULTS.
+          voiceStability: typeof v.tts?.cloud?.voiceStability === 'number' ? v.tts.cloud.voiceStability : 0.5,
+          voiceStyle: typeof v.tts?.cloud?.voiceStyle === 'number' ? v.tts.cloud.voiceStyle : 0,
+          voiceSimilarityBoost: typeof v.tts?.cloud?.voiceSimilarityBoost === 'number' ? v.tts.cloud.voiceSimilarityBoost : 0.75,
+          voiceUseSpeakerBoost: typeof v.tts?.cloud?.voiceUseSpeakerBoost === 'boolean' ? v.tts.cloud.voiceUseSpeakerBoost : true,
         },
         remote: { url: v.tts?.remote?.url ?? '' },
         // Per-engine voice level (dB). Zero default for all 6 engine ids, then
@@ -1775,6 +1788,87 @@ function TtsSpeedField({
   );
 }
 
+// ElevenLabs voice_settings — the four expressive knobs their API takes on
+// every request. Ranges match ElevenLabs' native 0..1 (stability, style,
+// similarity_boost) plus the boolean use_speaker_boost. Rendered only when the
+// cloud provider is `elevenlabs` — other providers ignore the fields, so
+// showing them there would be misleading. Design matches TtsGainField /
+// TtsSpeedField exactly (same field class, same 360px cap, same label +
+// tabular readout row) so the block blends into the surrounding form.
+const ELEVENLABS_SLIDER_STEP = 0.01;
+
+function formatPct(v: number): string {
+  return `${Math.round(v * 100)}%`;
+}
+
+function ElevenLabsVoiceSettingsField({
+  form,
+  setForm,
+}: {
+  form: FormState;
+  setForm: FormUpdater;
+}) {
+  const c = form.tts.cloud;
+  const setCloud = (patch: Partial<CloudTtsCfg>) =>
+    setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, ...patch } } }));
+  const slider = (
+    label: string,
+    hint: ReactNode,
+    key: 'voiceStability' | 'voiceStyle' | 'voiceSimilarityBoost',
+  ) => (
+    <div className="field mt-4">
+      <div className="flex items-center justify-between gap-3">
+        <Label>{label}</Label>
+        <span className="font-mono text-[12px] text-ink tabular-nums">{formatPct(c[key])}</span>
+      </div>
+      <input
+        type="range"
+        min={0}
+        max={1}
+        step={ELEVENLABS_SLIDER_STEP}
+        value={c[key]}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => setCloud({ [key]: Number(e.target.value) } as Partial<CloudTtsCfg>)}
+        aria-label={label}
+        className="mt-1.5 w-full max-w-[360px] accent-[var(--accent)]"
+      />
+      <div className="field-hint">{hint}</div>
+    </div>
+  );
+  return (
+    <>
+      {slider(
+        'Stability',
+        <>Lower is more expressive but can wander; higher is steadier but flatter. ElevenLabs default is <code>50%</code>.</>,
+        'voiceStability',
+      )}
+      {slider(
+        'Style exaggeration',
+        <>How much the reference voice’s style is amplified. Higher costs more latency and can hurt stability. ElevenLabs default is <code>0%</code>.</>,
+        'voiceStyle',
+      )}
+      {slider(
+        'Similarity boost',
+        <>How tightly the output tracks the reference voice. ElevenLabs default is <code>75%</code>.</>,
+        'voiceSimilarityBoost',
+      )}
+      <div className="field mt-4">
+        <label className="flex cursor-pointer items-center gap-2 text-[12px] leading-[1.5] text-ink">
+          <input
+            type="checkbox"
+            checked={c.voiceUseSpeakerBoost}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setCloud({ voiceUseSpeakerBoost: e.target.checked })}
+            className="accent-[var(--accent)]"
+          />
+          <span>Speaker boost</span>
+        </label>
+        <div className="field-hint">
+          Sharpens similarity to the reference voice at a small latency cost. On by default.
+        </div>
+      </div>
+    </>
+  );
+}
+
 // Prominent, self-contained "engine not installed" callout with a step-by-step
 // setup guide. Chatterbox and PocketTTS both live in the optional `tts-heavy`
 // sidecar, so the recommended path is identical; only the engine label and the
@@ -1923,6 +2017,10 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
           model: form.tts.cloud.model,
           voice: form.tts.cloud.voice,
           baseUrl: form.tts.cloud.baseUrl,
+          voiceStability: form.tts.cloud.voiceStability,
+          voiceStyle: form.tts.cloud.voiceStyle,
+          voiceSimilarityBoost: form.tts.cloud.voiceSimilarityBoost,
+          voiceUseSpeakerBoost: form.tts.cloud.voiceUseSpeakerBoost,
         },
         remote: { url: form.tts.remote.url },
         // Per-engine voice-level trim. Always sent (server clamps + drops unknown
@@ -1961,7 +2059,16 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
     return { ...base, tts: { ...base.tts, defaultEngine: engine } };
   });
 
-  type SavedCloud = { provider?: string; voice?: string; model?: string; baseUrl?: string };
+  type SavedCloud = {
+    provider?: string;
+    voice?: string;
+    model?: string;
+    baseUrl?: string;
+    voiceStability?: number;
+    voiceStyle?: number;
+    voiceSimilarityBoost?: number;
+    voiceUseSpeakerBoost?: boolean;
+  };
   const savedTts: {
     defaultEngine?: string;
     kokoro?: { voice?: string; lang?: string };
@@ -2004,6 +2111,10 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
     || (form.tts.cloud.model || '').trim() !== (savedCloud.model || '').trim()
     || (form.tts.cloud.voice || '').trim() !== (savedCloud.voice || '').trim()
     || (form.tts.cloud.baseUrl || '').trim() !== (savedCloud.baseUrl || '').trim()
+    || form.tts.cloud.voiceStability !== (savedCloud.voiceStability ?? 0.5)
+    || form.tts.cloud.voiceStyle !== (savedCloud.voiceStyle ?? 0)
+    || form.tts.cloud.voiceSimilarityBoost !== (savedCloud.voiceSimilarityBoost ?? 0.75)
+    || form.tts.cloud.voiceUseSpeakerBoost !== (savedCloud.voiceUseSpeakerBoost ?? true)
     || (form.tts.remote.url || '').trim() !== savedRemoteUrl
     || gainDirty
     || speedDirty;
@@ -2477,6 +2588,9 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
             )}
             <TtsGainField engineId="cloud" form={form} setForm={setForm} />
             <TtsSpeedField engineId="cloud" form={form} setForm={setForm} />
+            {form.tts.cloud.provider === 'elevenlabs' && (
+              <ElevenLabsVoiceSettingsField form={form} setForm={setForm} />
+            )}
             {!isCompat && (() => {
               const kv = form.tts.cloud.provider === 'elevenlabs' ? 'ELEVENLABS_API_KEY' : 'OPENAI_API_KEY';
               return <KeyStatus envVar={kv} present={!!data.env?.[kv]} />;

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -130,6 +130,16 @@ interface CloudTtsCfg {
   voiceUseSpeakerBoost: boolean;
 }
 
+// ElevenLabs voice_settings defaults — the single client-side copy, read by
+// both form hydration and the dirty-check. Must mirror DEFAULTS.tts.cloud in
+// controller/src/settings.ts (which itself mirrors ElevenLabs' own baseline).
+const ELEVENLABS_VS_DEFAULTS = {
+  voiceStability: 0.5,
+  voiceStyle: 0,
+  voiceSimilarityBoost: 0.75,
+  voiceUseSpeakerBoost: true,
+} as const;
+
 interface TtsForm {
   defaultEngine: string;
   kokoro: { voice: string };
@@ -488,11 +498,10 @@ export default function SettingsPanel() {
           model: v.tts?.cloud?.model ?? '',
           voice: v.tts?.cloud?.voice ?? '',
           baseUrl: v.tts?.cloud?.baseUrl ?? '',
-          // ElevenLabs voice_settings — defaults mirror the server's DEFAULTS.
-          voiceStability: typeof v.tts?.cloud?.voiceStability === 'number' ? v.tts.cloud.voiceStability : 0.5,
-          voiceStyle: typeof v.tts?.cloud?.voiceStyle === 'number' ? v.tts.cloud.voiceStyle : 0,
-          voiceSimilarityBoost: typeof v.tts?.cloud?.voiceSimilarityBoost === 'number' ? v.tts.cloud.voiceSimilarityBoost : 0.75,
-          voiceUseSpeakerBoost: typeof v.tts?.cloud?.voiceUseSpeakerBoost === 'boolean' ? v.tts.cloud.voiceUseSpeakerBoost : true,
+          voiceStability: typeof v.tts?.cloud?.voiceStability === 'number' ? v.tts.cloud.voiceStability : ELEVENLABS_VS_DEFAULTS.voiceStability,
+          voiceStyle: typeof v.tts?.cloud?.voiceStyle === 'number' ? v.tts.cloud.voiceStyle : ELEVENLABS_VS_DEFAULTS.voiceStyle,
+          voiceSimilarityBoost: typeof v.tts?.cloud?.voiceSimilarityBoost === 'number' ? v.tts.cloud.voiceSimilarityBoost : ELEVENLABS_VS_DEFAULTS.voiceSimilarityBoost,
+          voiceUseSpeakerBoost: typeof v.tts?.cloud?.voiceUseSpeakerBoost === 'boolean' ? v.tts.cloud.voiceUseSpeakerBoost : ELEVENLABS_VS_DEFAULTS.voiceUseSpeakerBoost,
         },
         remote: { url: v.tts?.remote?.url ?? '' },
         // Per-engine voice level (dB). Zero default for all 6 engine ids, then
@@ -1838,7 +1847,7 @@ function ElevenLabsVoiceSettingsField({
     <>
       {slider(
         'Stability',
-        <>Lower is more expressive but can wander; higher is steadier but flatter. ElevenLabs default is <code>50%</code>.</>,
+        <>Lower is more expressive but can wander; higher is steadier but flatter. ElevenLabs default is <code>50%</code>. Note: the <code>eleven_v3</code> model only accepts 0%, 50% or 100% — other values fail on that model.</>,
         'voiceStability',
       )}
       {slider(
@@ -2111,10 +2120,10 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
     || (form.tts.cloud.model || '').trim() !== (savedCloud.model || '').trim()
     || (form.tts.cloud.voice || '').trim() !== (savedCloud.voice || '').trim()
     || (form.tts.cloud.baseUrl || '').trim() !== (savedCloud.baseUrl || '').trim()
-    || form.tts.cloud.voiceStability !== (savedCloud.voiceStability ?? 0.5)
-    || form.tts.cloud.voiceStyle !== (savedCloud.voiceStyle ?? 0)
-    || form.tts.cloud.voiceSimilarityBoost !== (savedCloud.voiceSimilarityBoost ?? 0.75)
-    || form.tts.cloud.voiceUseSpeakerBoost !== (savedCloud.voiceUseSpeakerBoost ?? true)
+    || form.tts.cloud.voiceStability !== (savedCloud.voiceStability ?? ELEVENLABS_VS_DEFAULTS.voiceStability)
+    || form.tts.cloud.voiceStyle !== (savedCloud.voiceStyle ?? ELEVENLABS_VS_DEFAULTS.voiceStyle)
+    || form.tts.cloud.voiceSimilarityBoost !== (savedCloud.voiceSimilarityBoost ?? ELEVENLABS_VS_DEFAULTS.voiceSimilarityBoost)
+    || form.tts.cloud.voiceUseSpeakerBoost !== (savedCloud.voiceUseSpeakerBoost ?? ELEVENLABS_VS_DEFAULTS.voiceUseSpeakerBoost)
     || (form.tts.remote.url || '').trim() !== savedRemoteUrl
     || gainDirty
     || speedDirty;
@@ -2654,6 +2663,16 @@ function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                   cloudProvider={form.tts.cloud.provider}
                   speed={form.tts.speed?.[e] ?? 1}
                   lang={form.kokoroLang || undefined}
+                  // Unsaved ElevenLabs sliders ride along so "Play sample"
+                  // auditions the current knob positions, not the last save.
+                  voiceSettings={e === 'cloud' && form.tts.cloud.provider === 'elevenlabs'
+                    ? {
+                      voiceStability: form.tts.cloud.voiceStability,
+                      voiceStyle: form.tts.cloud.voiceStyle,
+                      voiceSimilarityBoost: form.tts.cloud.voiceSimilarityBoost,
+                      voiceUseSpeakerBoost: form.tts.cloud.voiceUseSpeakerBoost,
+                    }
+                    : undefined}
                   adminFetch={adminFetch}
                 />
                 <div className="field-hint">

--- a/web/components/admin/tts/VoicePreviewButton.tsx
+++ b/web/components/admin/tts/VoicePreviewButton.tsx
@@ -18,6 +18,16 @@ interface VoicePreviewButtonProps {
   speed?: number;
   // Kokoro phonemizer language override (e.g. "en-gb", "ja").
   lang?: string;
+  // Unsaved ElevenLabs voice_settings sliders (issue #696) — sent so the sample
+  // auditions the CURRENT slider positions, not the last-saved values. Only
+  // meaningful when engine is 'cloud' with the elevenlabs provider; the server
+  // ignores it everywhere else.
+  voiceSettings?: {
+    voiceStability: number;
+    voiceStyle: number;
+    voiceSimilarityBoost: number;
+    voiceUseSpeakerBoost: boolean;
+  };
   adminFetch: AdminAuth['adminFetch'];
   disabled?: boolean;
   className?: string;
@@ -26,7 +36,7 @@ interface VoicePreviewButtonProps {
 type PreviewState = 'idle' | 'loading' | 'playing' | 'error';
 
 export function VoicePreviewButton({
-  engine, voice, cloudProvider, speed, lang, adminFetch, disabled, className,
+  engine, voice, cloudProvider, speed, lang, voiceSettings, adminFetch, disabled, className,
 }: VoicePreviewButtonProps) {
   const [state, setState] = useState<PreviewState>('idle');
   const [error, setError] = useState<string | null>(null);
@@ -50,7 +60,7 @@ export function VoicePreviewButton({
       const r = await adminFetch('/settings/tts/preview', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ engine, voice, cloudProvider, speed, lang }),
+        body: JSON.stringify({ engine, voice, cloudProvider, speed, lang, voiceSettings }),
       });
       if (!r.ok) {
         const j = await r.json().catch(() => ({})) as { message?: string };


### PR DESCRIPTION
The AI SDK always sends its defaults for stability, style, similarity_boost and use_speaker_boost, with no operator surface to tune them. That is issue #696: an ElevenLabs voice that reads too flat or too jittery on this station has no dial.

Add the four fields to settings.tts.cloud (defaults matching ElevenLabs' own baseline) with a 0..1 clamp in both the load normalizer and the update validator, spread them into providerOptions.elevenlabs.voiceSettings on the generateSpeech call only when the resolved provider is elevenlabs, and add a matching UI block in the Cloud TTS section of the Settings panel that appears only for the elevenlabs provider. The block reuses the exact label plus tabular readout plus range-slider pattern that TtsGainField and TtsSpeedField already use, so it blends with the surrounding form.

Per-persona overrides are left as a later step per the your suggestion on issue #696: persona.tts has no model or settings slots today, so the global path fixes the reported pain with the smallest surface.

