### PR TITLE
feat(dj): add ElevenLabs v3 audio-tag hint to the system prompt

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -18,6 +18,8 @@ import { embeddingBaseUrl } from '../src/llm/internal/provider/embedding.js';
 import { DEFAULT_LOCCA_EMBED_BASE_URL } from '../src/llm/internal/provider/registry.js';
 import { personaToneDirectives, normalizeDial, DIAL_NEUTRAL, validatePersonasStrict, clampTtsSpeed, TTS_SPEED_DEFAULT, clampMaxOutputTokens, resolveMaxOutputTokens, MAX_OUTPUT_TOKENS_MIN, MAX_OUTPUT_TOKENS_MAX } from '../src/settings.js';
 import { showMusicLean } from '../src/llm/internal/prompts/picker.js';
+import { resolveCloudModel } from '../src/llm/internal/speech/cloud-speech.js';
+import { isElevenLabsV3 } from '../src/llm/internal/prompts/system.js';
 
 let failures = 0;
 function test(name: string, fn: () => void | Promise<void>) {
@@ -681,6 +683,72 @@ async function main() {
     assert.equal(nearestId('', ['abcdef123456789012345']), null);
     assert.equal(nearestId(undefined as any, ['abcdef123456789012345']), null);
     assert.equal(nearestId('abcdef123456789012345', []), null);
+  });
+
+  // ---- resolveCloudModel: cloud TTS model resolution for the v3 tag hint ----
+  // Pins the "mirror of speak() + resolveEngine()" claim (issue #696): the
+  // model djSystem gates the ElevenLabs v3 hint on must be the one the persona
+  // is actually voiced by at speak() time.
+  console.log('resolveCloudModel (ElevenLabs v3 hint gating, issue #696):');
+  const cloudCfg = { defaultEngine: 'piper', provider: 'elevenlabs', model: 'eleven_v3' };
+  await test('explicit cloud persona with no provider override → global model', () => {
+    assert.equal(resolveCloudModel({ engine: 'cloud' }, cloudCfg), 'eleven_v3');
+  });
+  await test('provider override away from global → new provider default, NOT the global model', () => {
+    // Persona on ElevenLabs while the global cloud provider is OpenAI is
+    // voiced by eleven_flash_v2_5 — gating on the provider alone would hint a
+    // v2 voice that reads the brackets aloud.
+    assert.equal(
+      resolveCloudModel({ engine: 'cloud', cloudProvider: 'elevenlabs' }, { defaultEngine: 'piper', provider: 'openai', model: 'gpt-4o-mini-tts' }),
+      'eleven_flash_v2_5',
+    );
+  });
+  await test('provider override matching the global provider → global model', () => {
+    assert.equal(resolveCloudModel({ engine: 'cloud', cloudProvider: 'elevenlabs' }, cloudCfg), 'eleven_v3');
+  });
+  await test('override to openai-compatible (no per-provider default) keeps the global model', () => {
+    assert.equal(
+      resolveCloudModel({ engine: 'cloud', cloudProvider: 'openai-compatible' }, cloudCfg),
+      'eleven_v3',
+    );
+  });
+  await test('persona with no engine rides the station defaultEngine: cloud', () => {
+    // The common setup: global defaultEngine cloud + untouched personas — a
+    // persona-engine check would miss this and the hint would never fire.
+    assert.equal(
+      resolveCloudModel({}, { defaultEngine: 'cloud', provider: 'elevenlabs', model: 'eleven_v3' }),
+      'eleven_v3',
+    );
+    assert.equal(
+      resolveCloudModel(null, { defaultEngine: 'cloud', provider: 'elevenlabs', model: 'eleven_v3' }),
+      'eleven_v3',
+    );
+  });
+  await test('persona on a local engine → no model, regardless of defaultEngine', () => {
+    assert.equal(resolveCloudModel({ engine: 'piper' }, { defaultEngine: 'cloud', provider: 'elevenlabs', model: 'eleven_v3' }), '');
+    assert.equal(resolveCloudModel({ engine: 'chatterbox' }, { defaultEngine: 'cloud', provider: 'elevenlabs', model: 'eleven_v3' }), '');
+  });
+  await test('no engine anywhere near cloud → no model', () => {
+    assert.equal(resolveCloudModel({}, cloudCfg), '');
+    assert.equal(resolveCloudModel({ engine: '' }, cloudCfg), '');
+  });
+  await test('unknown persona engine string fails closed (no hint beats a spoken bracket)', () => {
+    assert.equal(resolveCloudModel({ engine: 'bogus' }, { defaultEngine: 'cloud', provider: 'elevenlabs', model: 'eleven_v3' }), '');
+  });
+
+  console.log('isElevenLabsV3 (model-family gate):');
+  await test('matches the v3 family, case- and separator-insensitive', () => {
+    assert.equal(isElevenLabsV3('eleven_v3'), true);
+    assert.equal(isElevenLabsV3('ELEVEN_V3'), true);
+    assert.equal(isElevenLabsV3('eleven-v3'), true);
+    assert.equal(isElevenLabsV3('eleven_v3_preview'), true);
+  });
+  await test('rejects v2 families, non-TTS v3 ids, and junk', () => {
+    assert.equal(isElevenLabsV3('eleven_flash_v2_5'), false);
+    assert.equal(isElevenLabsV3('eleven_multilingual_v2'), false);
+    assert.equal(isElevenLabsV3('eleven_ttv_v3'), false);
+    assert.equal(isElevenLabsV3('gpt-4o-mini-tts'), false);
+    assert.equal(isElevenLabsV3(''), false);
   });
 
   console.log(failures === 0 ? '\nAll llm-pure tests passed.' : `\n${failures} test(s) FAILED.`);

--- a/controller/src/llm/internal/prompts/system.ts
+++ b/controller/src/llm/internal/prompts/system.ts
@@ -16,12 +16,17 @@ const CHATTERBOX_TAG_HINT =
 // than reading them aloud (issue #696). Gated on the RESOLVED cloud model —
 // only eleven_v3* families support this — so an ElevenLabs persona still on
 // v2 (or a persona whose provider override resolves to eleven_flash_v2_5)
-// never sees the hint. Direct mirror of CHATTERBOX_TAG_HINT above; the base
-// DJ prompt template already forbids asterisks and quotes but says nothing
-// about brackets, so no rule loosening is needed for either engine.
-const ELEVENLABS_V3_TAG_HINT = CHATTERBOX_TAG_HINT;
+// never sees the hint. Same structure as CHATTERBOX_TAG_HINT above but a
+// separate constant with v3's own verb-form tag vocabulary (per the
+// ElevenLabs prompting guide), so a tweak to one engine's cue list can't
+// silently retune the other. The base DJ prompt template already forbids
+// asterisks and quotes but says nothing about brackets, so no rule loosening
+// is needed for either engine.
+const ELEVENLABS_V3_TAG_HINT =
+  '\n\nYou may sparingly insert non-verbal audio cues in square brackets: [laughs], [sighs], [whispers], [excited]. Use them only where genuinely natural — at most one per segment, and never as filler.';
 
-function isElevenLabsV3(model: string): boolean {
+// Exported for scripts/llm-pure.test.ts.
+export function isElevenLabsV3(model: string): boolean {
   return /^eleven[_-]?v3/i.test(model || '');
 }
 
@@ -49,7 +54,11 @@ export function djSystem(
     location: s.weather?.locationName,
   }) + settings.onAirRosterClause(persona);
   if (persona?.tts?.engine === 'chatterbox') return base + CHATTERBOX_TAG_HINT;
-  if (persona?.tts?.engine === 'cloud' && isElevenLabsV3(cloudModel)) return base + ELEVENLABS_V3_TAG_HINT;
+  // cloudModel is non-empty only when the persona actually resolves to a
+  // configured cloud engine — including via the station defaultEngine when
+  // the persona sets no engine of its own, which a persona-engine check here
+  // would miss (see resolveCloudModelForPersona).
+  if (isElevenLabsV3(cloudModel)) return base + ELEVENLABS_V3_TAG_HINT;
   return base;
 }
 

--- a/controller/src/llm/internal/prompts/system.ts
+++ b/controller/src/llm/internal/prompts/system.ts
@@ -3,6 +3,7 @@
 // otherwise the admin-selected active persona — settings.getEffectivePersona).
 
 import * as settings from '../../../settings.js';
+import { resolveCloudModelForPersona } from '../speech/cloud-speech.js';
 
 // Paralinguistic tags Chatterbox renders as actual non-verbal sounds. Every
 // other engine (piper, kokoro, cloud) reads `[laugh]` aloud as the word
@@ -11,6 +12,19 @@ import * as settings from '../../../settings.js';
 const CHATTERBOX_TAG_HINT =
   '\n\nYou may sparingly insert non-verbal cues in square brackets: [laugh], [chuckle], [sigh], [cough]. Use them only where genuinely natural — at most one per segment, and never as filler.';
 
+// ElevenLabs v3 renders bracketed audio tags as actual expressive cues rather
+// than reading them aloud (issue #696). Gated on the RESOLVED cloud model —
+// only eleven_v3* families support this — so an ElevenLabs persona still on
+// v2 (or a persona whose provider override resolves to eleven_flash_v2_5)
+// never sees the hint. Direct mirror of CHATTERBOX_TAG_HINT above; the base
+// DJ prompt template already forbids asterisks and quotes but says nothing
+// about brackets, so no rule loosening is needed for either engine.
+const ELEVENLABS_V3_TAG_HINT = CHATTERBOX_TAG_HINT;
+
+function isElevenLabsV3(model: string): boolean {
+  return /^eleven[_-]?v3/i.test(model || '');
+}
+
 // `persona` overrides the on-air persona — used by the persona-handoff
 // generators (generateSignoff / generateHandoffGreeting) to render the sign-off
 // under the OUTGOING persona and the greeting under the incoming one, since the
@@ -18,13 +32,24 @@ const CHATTERBOX_TAG_HINT =
 // and by the guest-speaker rotation (settings.pickOnAirSpeaker) to voice a
 // standalone segment under a co-host. The roster clause tells the speaker who
 // else is in the studio when the active show has guests (empty otherwise).
-export function djSystem(persona: any = settings.getEffectivePersona()) {
+//
+// `cloudModel` optionally overrides the resolved cloud TTS model for the
+// ElevenLabs v3 tag hint. Left blank, the resolver runs against the passed
+// persona — which is what every current caller wants. Kept as an override so a
+// future caller who already resolved the model (e.g. a preview endpoint) can
+// pass it in without re-resolving, per PR #696 owner review: "thread the
+// effective model into djSystem…pass it in explicitly."
+export function djSystem(
+  persona: any = settings.getEffectivePersona(),
+  cloudModel: string = resolveCloudModelForPersona(persona),
+) {
   const s = settings.get();
   const base = settings.renderDjPrompt(persona, {
     station: s.station,
     location: s.weather?.locationName,
   }) + settings.onAirRosterClause(persona);
   if (persona?.tts?.engine === 'chatterbox') return base + CHATTERBOX_TAG_HINT;
+  if (persona?.tts?.engine === 'cloud' && isElevenLabsV3(cloudModel)) return base + ELEVENLABS_V3_TAG_HINT;
   return base;
 }
 

--- a/controller/src/llm/internal/speech/cloud-speech.ts
+++ b/controller/src/llm/internal/speech/cloud-speech.ts
@@ -25,6 +25,26 @@ const CLOUD_DEFAULT_MODELS: Record<string, string> = {
   elevenlabs: 'eleven_flash_v2_5',
 };
 
+// Resolve the cloud TTS model that a given persona will actually be voiced by,
+// mirroring the exact rule speak() applies below: persona picks the provider,
+// the global tts.cloud holds the model, and a persona that overrode the
+// provider away from the global one falls back to the new provider's default
+// (openai-compatible has no default so it keeps the global model). Empty
+// string when the persona isn't on the cloud engine or the config is
+// unresolved — callers should treat that as "don't apply model-specific
+// hints". Callers pass this into djSystem() so the DJ prompt layer can gate a
+// hint on the model that actually resolves at speak() time — NOT the raw
+// global model and NOT the persona's provider alone (issue #696).
+export function resolveCloudModelForPersona(persona: any): string {
+  if (persona?.tts?.engine !== 'cloud') return '';
+  const base = cloudCfg();
+  const personaProvider = persona?.tts?.cloudProvider;
+  if (personaProvider && personaProvider !== base.provider) {
+    return CLOUD_DEFAULT_MODELS[personaProvider] || base.model || '';
+  }
+  return base.model || '';
+}
+
 // Speech-rate multiplier limits per provider. A value outside the supported
 // range makes the provider API reject the request, so we clamp before calling.
 // ElevenLabs allows 0.7–1.2; OpenAI allows 0.25–4.0.

--- a/controller/src/llm/internal/speech/cloud-speech.ts
+++ b/controller/src/llm/internal/speech/cloud-speech.ts
@@ -25,24 +25,51 @@ const CLOUD_DEFAULT_MODELS: Record<string, string> = {
   elevenlabs: 'eleven_flash_v2_5',
 };
 
-// Resolve the cloud TTS model that a given persona will actually be voiced by,
-// mirroring the exact rule speak() applies below: persona picks the provider,
-// the global tts.cloud holds the model, and a persona that overrode the
-// provider away from the global one falls back to the new provider's default
-// (openai-compatible has no default so it keeps the global model). Empty
-// string when the persona isn't on the cloud engine or the config is
-// unresolved — callers should treat that as "don't apply model-specific
-// hints". Callers pass this into djSystem() so the DJ prompt layer can gate a
-// hint on the model that actually resolves at speak() time — NOT the raw
-// global model and NOT the persona's provider alone (issue #696).
-export function resolveCloudModelForPersona(persona: any): string {
-  if (persona?.tts?.engine !== 'cloud') return '';
-  const base = cloudCfg();
-  const personaProvider = persona?.tts?.cloudProvider;
-  if (personaProvider && personaProvider !== base.provider) {
-    return CLOUD_DEFAULT_MODELS[personaProvider] || base.model || '';
+// Pure resolution rule for the cloud TTS model a persona will be voiced by,
+// mirroring speak() below plus resolveEngine() in audio/tts.ts: the persona
+// owns the engine when set, otherwise the station defaultEngine speaks; a
+// persona that overrode the provider away from the global one falls back to
+// the new provider's default (openai-compatible has no default so it keeps
+// the global model); a persona voiced by the DEFAULT cloud engine carries no
+// provider override (speakWith only builds cloudOverride for an explicit
+// persona engine === 'cloud'). An unrecognised persona engine string fails
+// closed to '' — resolveEngine would route it to the defaultEngine, but a
+// missing hint is harmless while a wrong one is spoken aloud. Empty string =
+// not voiced by cloud / unresolved — callers treat that as "don't apply
+// model-specific hints". Kept pure and unit-pinned in scripts/llm-pure.test.ts
+// so the "mirror of speak()" claim is testable rather than comment-enforced.
+export function resolveCloudModel(
+  personaTts: { engine?: string; cloudProvider?: string } | null | undefined,
+  cfg: { defaultEngine?: string; provider?: string; model?: string },
+): string {
+  const explicit = personaTts?.engine === 'cloud';
+  if (!explicit && (personaTts?.engine || cfg.defaultEngine !== 'cloud')) return '';
+  const personaProvider = explicit ? personaTts?.cloudProvider : '';
+  if (personaProvider && personaProvider !== cfg.provider) {
+    return CLOUD_DEFAULT_MODELS[personaProvider] || cfg.model || '';
   }
-  return base.model || '';
+  return cfg.model || '';
+}
+
+// The model `persona` actually resolves to at speak() time, or '' when the
+// persona won't be voiced by a usable cloud engine — NOT the raw global model
+// and NOT the persona's provider alone (issue #696). On top of the pure rule
+// above this mirrors resolveEngine()'s key check: an enabled-but-unconfigured
+// cloud engine silently reroutes to a local engine that reads brackets aloud
+// as words, so report no model — and therefore no hint — in that case too.
+// Callers pass this into djSystem() so the DJ prompt layer can gate a hint on
+// what will actually speak.
+export function resolveCloudModelForPersona(persona: any): string {
+  const t: any = settings.get().tts || {};
+  const model = resolveCloudModel(persona?.tts, {
+    defaultEngine: t.defaultEngine,
+    provider: t.cloud?.provider,
+    model: t.cloud?.model,
+  });
+  if (!model) return '';
+  const explicit = persona?.tts?.engine === 'cloud';
+  if (!isConfigured(explicit ? persona?.tts?.cloudProvider || null : null)) return '';
+  return model;
 }
 
 // Speech-rate multiplier limits per provider. A value outside the supported


### PR DESCRIPTION
ElevenLabs v3 renders bracketed audio tags as expressive cues instead of reading them aloud as words. Today's DJ prompt has no signal for that, so v3 voices never get to use their expressive range on this station. Issue #696.

Add ELEVENLABS_V3_TAG_HINT as a direct mirror of CHATTERBOX_TAG_HINT (same syntax, same list of cues) and gate it on the RESOLVED cloud model, not the raw global model and not the provider alone. That matters because a persona that overrides cloudProvider to elevenlabs while the global provider is OpenAI ends up voiced by eleven_flash_v2_5, not v3, so gating on the persona's provider would send the hint to a v2 voice that reads the brackets literally.

Add resolveCloudModelForPersona(persona) to cloud-speech.ts (owner of CLOUD_DEFAULT_MODELS) so the resolution rule stays a single source of truth with speak(), and thread it through djSystem via an optional second parameter that defaults to the resolver. Existing callers stay zero-touch; a future preview endpoint that already resolved the model can pass it in explicitly.

The base DJ prompt template forbids asterisks and quotes but says nothing about brackets, so no rule loosening is needed here or for the existing Chatterbox hint.
