### PR TITLE
fix(llm): forward repeat_penalty + reasoning_format on the openai-compatible path

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -11,7 +11,7 @@ import { generateText, APICallError } from 'ai';
 import { MockLanguageModelV3 } from 'ai/test';
 import { stripThinking, extractJson, usageOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded, isRateLimited, errReason, nearestId } from '../src/llm/internal/core/pure.js';
 import { withDeadline, withTransientRetry, retryAfterMs } from '../src/llm/internal/core/retry.js';
-import { providerOptions, needsToolCallObject, repeatPenaltyApplies, appliedNumCtx, forcedToolChoice } from '../src/llm/internal/provider/capabilities.js';
+import { providerOptions, needsToolCallObject, repeatPenaltyApplies, appliedNumCtx, appliedRepeatPenalty, forcedToolChoice } from '../src/llm/internal/provider/capabilities.js';
 import { agentPlan } from '../src/llm/internal/strategy/plan.js';
 import { introBudgetPhrase, enforceIntroBudget } from '../src/llm/internal/prompts/intro-budget.js';
 import { embeddingBaseUrl } from '../src/llm/internal/provider/embedding.js';
@@ -393,6 +393,21 @@ async function main() {
     assert.equal(appliedNumCtx({ provider: 'openai', model: 'gpt-4.1-mini', numCtx: 8192 }), null);
     assert.equal(appliedNumCtx({ provider: 'locca', model: 'qwen3', numCtx: 8192 }), null);
   });
+  await test('appliedRepeatPenalty: body-injection providers only, and only when > 1.0', () => {
+    // openai-compatible + locca inject via the request body (the openai
+    // provider can't carry repeat_penalty in providerOptions).
+    assert.equal(appliedRepeatPenalty({ provider: 'openai-compatible', repeatPenalty: 1.15 }), 1.15);
+    assert.equal(appliedRepeatPenalty({ provider: 'locca', repeatPenalty: 1.25 }), 1.25);
+    // 1.0 (or below) is a no-op — never injected.
+    assert.equal(appliedRepeatPenalty({ provider: 'openai-compatible', repeatPenalty: 1.0 }), null);
+    // Ollama reads its own value via providerOptions.ollama.options — not here
+    // (no double-write into the sampling record).
+    assert.equal(appliedRepeatPenalty({ provider: 'ollama', repeatPenalty: 1.2 }), null);
+    // Cloud providers never inject.
+    assert.equal(appliedRepeatPenalty({ provider: 'openai', repeatPenalty: 1.2 }), null);
+    // Missing / junk value → null, no throw.
+    assert.equal(appliedRepeatPenalty({ provider: 'openai-compatible' }), null);
+  });
 
   await test('forcedToolChoice: only the literal "auto" downgrades; everything else is "required" (issue #570)', () => {
     // Opt-in downgrade for crash-prone forced-tool servers (newer Intel vLLM).
@@ -447,6 +462,23 @@ async function main() {
     assert.equal(stripThinking('<think>reasoning</think>hello'), 'hello');
     assert.equal(stripThinking('leftover reasoning</think>  the answer'), 'the answer');
     assert.equal(stripThinking('plain text'), 'plain text');
+  });
+  await test('stripThinking strips Gemma/harmony channel reasoning, keeps the final message', () => {
+    // thought → final: keep only the final channel's message
+    assert.equal(
+      stripThinking('<|channel|>thought<|message|>let me think…<|channel|>final<|message|>Coming up next: a classic.'),
+      'Coming up next: a classic.',
+    );
+    // token variant without the trailing pipe (<|channel>thought)
+    assert.equal(
+      stripThinking('<|channel>analysis<|message>deliberating<|channel>final<|message>Here we go.'),
+      'Here we go.',
+    );
+    // no final channel — the answer is trapped in the thought channel; strip to
+    // empty rather than speak the deliberation aloud
+    assert.equal(stripThinking('<|channel|>thought<|message|>hmm, still thinking'), '');
+    // plain text with no channel tokens is untouched
+    assert.equal(stripThinking('Just a normal DJ line.'), 'Just a normal DJ line.');
   });
   await test('extractJson pulls the object out of fences and prose', () => {
     assert.equal(extractJson('```json\n{"a":1}\n```'), '{"a":1}');

--- a/controller/src/llm/internal/core/pure.ts
+++ b/controller/src/llm/internal/core/pure.ts
@@ -17,9 +17,44 @@
 const THINK_TAG_RE = /<think>[\s\S]*?<\/think>\s*/gi;
 const DANGLING_THINK_RE = /^[\s\S]*?<\/think>\s*/i;
 
+// Harmony / channel reasoning format (gpt-oss, Gemma-4): the model emits its
+// deliberation in a `thought`/`analysis` channel before the answer's `final`
+// channel, e.g.
+//   <|channel|>thought<|message|>…reasoning…<|channel|>final<|message|>…answer…
+// On the openai-compatible path reasoning_format:"deepseek" routes this to
+// reasoning_content so it never reaches us — but on a build or model that still
+// leaks it into `content`, strip it here (the <think> handling above only
+// catches the Qwen/R1 tag form). Some llama.cpp builds emit the tokens without
+// the trailing pipe (`<|channel>thought`), so the pipe before `>` is optional.
+//
+// The reliable primitive is "keep only the FINAL channel's message". When no
+// final channel is present the reply is all reasoning scaffolding (the answer
+// got stuck in the thought channel), so we drop from the first channel opener
+// on — returning '' rather than speaking the deliberation aloud.
+const FINAL_CHANNEL_RE = /<\|channel\|?>\s*final\s*<\|message\|?>/gi;
+const ANY_CHANNEL_OPEN_RE = /<\|channel\|?>/i;
+const HARMONY_TOKENS_RE = /<\|(?:start|end|return|message|channel)\|?>/gi;
+
 export function stripThinking(s: any): any {
   if (!s) return s;
-  return s.replace(THINK_TAG_RE, '').replace(DANGLING_THINK_RE, '').trim();
+  let t = s.replace(THINK_TAG_RE, '').replace(DANGLING_THINK_RE, '');
+  // Keep only the text after the LAST final-channel opener, if any.
+  let lastFinalEnd = -1;
+  for (const m of t.matchAll(FINAL_CHANNEL_RE)) {
+    lastFinalEnd = (m.index ?? 0) + m[0].length;
+  }
+  if (lastFinalEnd !== -1) {
+    t = t.slice(lastFinalEnd);
+  } else {
+    // No final channel — if any channel scaffolding is present, everything from
+    // the first opener on is trapped reasoning; keep only what precedes it.
+    const open = t.search(ANY_CHANNEL_OPEN_RE);
+    if (open !== -1) t = t.slice(0, open);
+  }
+  // Sweep up any leftover harmony control tokens (a trailing <|end|>/<|return|>).
+  // These literals never appear in a real DJ script.
+  t = t.replace(HARMONY_TOKENS_RE, '');
+  return t.trim();
 }
 
 // Pull a JSON object out of a free-text reply: drop ```json fences and any

--- a/controller/src/llm/internal/provider/capabilities.ts
+++ b/controller/src/llm/internal/provider/capabilities.ts
@@ -27,6 +27,13 @@ export interface ProviderCapabilities {
   objectStrategy: 'native' | 'tool';
   // repeat_penalty rides inside providerOptions.ollama, so only Ollama reads it.
   repeatPenaltyApplies: boolean;
+  // llama.cpp / vLLM / LM Studio (openai-compatible, locca) take sampling +
+  // thinking controls the AI SDK's openai provider has no first-class field for
+  // (repeat_penalty, reasoning_format, enable_thinking) via a request-body
+  // injection in the fetch wrapper, not providerOptions — the openai provider
+  // validates providerOptions against its own schema and drops the rest. Flags
+  // the providers openAICompatibleFetch() rewrites the body for.
+  samplingViaBody?: boolean;
   // The providerOptions fragment for this provider given the resolved model id +
   // reasoning/forceNoThink flags.
   thinkingBlock(a: ThinkingArgs): Record<string, unknown>;
@@ -66,8 +73,10 @@ const CAPS: Record<string, ProviderCapabilities> = {
   'openai-compatible': {
     objectStrategy: 'tool',
     repeatPenaltyApplies: false,
-    // Thinking suppression is done at the transport layer (noThinkFetch in the
-    // registry), not via providerOptions.
+    // repeat_penalty / reasoning_format / enable_thinking are injected into the
+    // request body at the transport layer (openAICompatibleFetch in the
+    // registry), not via providerOptions — the openai provider would drop them.
+    samplingViaBody: true,
     thinkingBlock: NONE,
   },
   // locca serves local llama.cpp GGUF models — the SAME model class as Ollama,
@@ -79,6 +88,7 @@ const CAPS: Record<string, ProviderCapabilities> = {
   locca: {
     objectStrategy: 'tool',
     repeatPenaltyApplies: false,
+    samplingViaBody: true,
     thinkingBlock: NONE,
   },
   anthropic: {
@@ -182,10 +192,25 @@ export function forcedToolChoice(cfg: any): 'required' | 'auto' {
   return cfg?.toolChoice === 'auto' ? 'auto' : 'required';
 }
 
-// True when repeat_penalty actually reaches the model — gates the sampling log
-// so /debug doesn't claim the value was applied when the provider dropped it.
+// True when repeat_penalty actually reaches the model via providerOptions —
+// gates the sampling log so /debug doesn't claim the value was applied when the
+// provider dropped it. Ollama-only; the body-injection providers are covered by
+// appliedRepeatPenalty() instead.
 export function repeatPenaltyApplies(cfg: any): boolean {
   return capabilitiesFor(cfg?.provider).repeatPenaltyApplies;
+}
+
+// The repeat_penalty a body-injection provider (openai-compatible, locca) will
+// actually send this leg, or null when none is. llama.cpp's own default is
+// 1.0 = OFF, so without this the operator's configured floor is silently
+// dropped and the tool-loop agent can run away repeating a token block until
+// it hits the output cap, never emitting `done` (gist quirk #2). A value of
+// 1.0 (or below) is a no-op, so we skip it to keep the body clean. Reads
+// cfg.repeatPenalty (primary or fallback leg).
+export function appliedRepeatPenalty(cfg: any): number | null {
+  if (!capabilitiesFor(cfg?.provider).samplingViaBody) return null;
+  const rp = Number(cfg?.repeatPenalty);
+  return Number.isFinite(rp) && rp > 1.0 ? rp : null;
 }
 
 // The num_ctx that will actually be sent for this leg, or null when none is.
@@ -205,12 +230,19 @@ export function appliedNumCtx(cfg: any): number | null {
   return null;
 }
 
-// Add the leg's effective num_ctx to a sampling record when one was sent, so
-// /admin/debug shows the context window each call actually ran with. Mirrors how
-// repeat_penalty is conditionally recorded.
-export function samplingWithNumCtx(cfg: any, sampling: any): any {
+// Stamp a sampling record with the local-only knobs each call actually ran with,
+// so /admin/debug reflects them: Ollama's effective num_ctx, and the
+// repeat_penalty injected into the body for openai-compatible / locca (the
+// agent/object paths don't pass repeat_penalty through providerOptions, so this
+// is the only place it gets recorded for them). Ollama's providerOptions-carried
+// repeat_penalty is recorded separately at the djText call site via
+// repeatPenaltyApplies(), so appliedRepeatPenalty() returns null there — no
+// double-write.
+export function samplingWithLocalKnobs(cfg: any, sampling: any): any {
   const n = appliedNumCtx(cfg);
   if (n != null) sampling.num_ctx = n;
+  const rp = appliedRepeatPenalty(cfg);
+  if (rp != null) sampling.repeat_penalty = rp;
   return sampling;
 }
 

--- a/controller/src/llm/internal/provider/registry.ts
+++ b/controller/src/llm/internal/provider/registry.ts
@@ -27,7 +27,7 @@ import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 import { config } from '../../../config.js';
 import * as settings from '../../../settings.js';
 import { recordRawRequest, rawDebugEnabled } from '../telemetry/raw-debug.js';
-import { capabilitiesFor } from './capabilities.js';
+import { capabilitiesFor, appliedRepeatPenalty } from './capabilities.js';
 
 // Memoise built clients so we don't reconstruct a provider on every call.
 // Keyed by a signature that changes whenever provider/model/key changes, so a
@@ -88,6 +88,50 @@ export function noThinkFetch(url: any, init: any, baseFetch: any = fetch) {
   return baseFetch(url, init);
 }
 
+// Fetch wrapper for the openai-compatible / locca (llama.cpp / vLLM / LM Studio)
+// path. The AI SDK's openai provider has no first-class field for these knobs,
+// and it validates providerOptions against its own schema — so anything not in
+// that schema is dropped. We inject them straight into the JSON request body
+// instead (servers ignore keys they don't recognise, same bet the existing
+// chat_template_kwargs injection already makes):
+//   • repeat_penalty — llama.cpp's own default is 1.0 (OFF), so the operator's
+//     configured repetition floor is otherwise never applied and the tool-loop
+//     agent can run away repeating a token block (gist quirk #2). This is the
+//     ONLY path that carries it to the agent/object calls, which never pass
+//     repeat_penalty through providerOptions. `repeat_penalty` is llama.cpp's
+//     param name (vLLM's is `repetition_penalty`); to opt out, set
+//     llm.repeatPenalty to 1.0. We never clobber a value already on the body.
+//   • reasoning off → enable_thinking:false PLUS reasoning_format. Gemma-4's
+//     chat template pre-seeds an empty <|channel|>thought block even with
+//     enable_thinking:false, and with reasoning_format unset (defaults to none)
+//     llama.cpp routes that thought to `content`, so it leaks into the visible
+//     script and reaches TTS. reasoning_format:"deepseek" routes it to
+//     reasoning_content, which the SDK surfaces as a reasoning part, not text
+//     (gist quirk #4).
+export function openAICompatibleFetch(cfg: any, baseFetch: any = fetch) {
+  const penalty = appliedRepeatPenalty(cfg);
+  const noThink = cfg?.reasoning !== true;
+  return (url: any, init: any) => {
+    if (init?.body && typeof init.body === 'string') {
+      try {
+        const body = JSON.parse(init.body);
+        if (penalty != null && body.repeat_penalty === undefined) {
+          body.repeat_penalty = penalty;
+        }
+        if (noThink) {
+          body.chat_template_kwargs = {
+            ...(body.chat_template_kwargs || {}),
+            enable_thinking: false,
+          };
+          if (body.reasoning_format === undefined) body.reasoning_format = 'deepseek';
+        }
+        init = { ...init, body: JSON.stringify(body) };
+      } catch { /* not JSON — leave the request untouched */ }
+    }
+    return baseFetch(url, init);
+  };
+}
+
 // Ollama server URL — from settings (admin UI), falling back to the config
 // default when the settings field is left blank.
 export function ollamaBaseUrl(cfg: any): string {
@@ -129,15 +173,13 @@ export const DEFAULT_REQUESTY_BASE_URL = 'https://router.requesty.ai/v1';
 // Build a LanguageModel for any self-hosted OpenAI-compatible server (llama.cpp,
 // vLLM, LM Studio, locca). `.chat()` pins /v1/chat/completions — these servers
 // don't implement the Responses API the default `provider(id)` would target.
-// Most accept any non-empty key, so fall back to a placeholder. Reasoning off →
-// wrap fetch to force chat_template_kwargs.enable_thinking=false.
+// Most accept any non-empty key, so fall back to a placeholder. The fetch
+// wrapper injects the body-only knobs (repeat_penalty, and — reasoning off —
+// enable_thinking:false + reasoning_format); see openAICompatibleFetch.
 function openAICompatibleModel(cfg: any, id: string, baseURL: string, name: string) {
-  // Reasoning off → force enable_thinking=false (noThinkFetch) THEN capture;
-  // reasoning on → capture only. debugFetch is the inner transport in both
-  // cases, so what's recorded is the body exactly as sent (post no-think).
-  const fetchImpl = cfg.reasoning
-    ? debugFetch
-    : (url: any, init: any) => noThinkFetch(url, init, debugFetch);
+  // debugFetch is the inner transport, so what's recorded is the body exactly
+  // as sent (post-injection).
+  const fetchImpl = openAICompatibleFetch(cfg, debugFetch);
   const provider = createOpenAI({
     baseURL,
     apiKey: cfg.apiKey || 'unused',

--- a/controller/src/llm/internal/strategy/agent.ts
+++ b/controller/src/llm/internal/strategy/agent.ts
@@ -30,7 +30,7 @@ import { Output, stepCountIs, hasToolCall, ToolLoopAgent, tool } from 'ai';
 import { withFailover } from '../core/failover.js';
 import { withTransientRetry, withDeadline } from '../core/retry.js';
 import { stripThinking, extractJson, usageOf, flattenToolCalls, failureDiagnostics } from '../core/pure.js';
-import { needsToolCallObject, providerOptions, samplingWithNumCtx, forcedToolChoice } from '../provider/capabilities.js';
+import { needsToolCallObject, providerOptions, samplingWithLocalKnobs, forcedToolChoice } from '../provider/capabilities.js';
 import { objectViaToolCall } from './object-via-tool.js';
 import { agentPlan } from './plan.js';
 import { resolveMaxOutputTokens } from '../../../settings.js';
@@ -134,7 +134,7 @@ export async function djAgent({
           return {
             value: { object, steps: 0, toolCalls: [] },
             via: lastVia,
-            sampling: samplingWithNumCtx(leg.cfg, { temperature }),
+            sampling: samplingWithLocalKnobs(leg.cfg, { temperature }),
             usage,
             extra: { system, messages, toolCalls: [], steps: 0, response: JSON.stringify(object, null, 2) },
           };
@@ -184,7 +184,7 @@ export async function djAgent({
               return {
                 value: { object: nObj, steps: nSteps, toolCalls },
                 via: lastVia,
-                sampling: samplingWithNumCtx(leg.cfg, { temperature }),
+                sampling: samplingWithLocalKnobs(leg.cfg, { temperature }),
                 usage: usageOf(nr),
                 extra: { system, messages, toolCalls, steps: nSteps, response: JSON.stringify(nObj, null, 2) },
               };
@@ -310,7 +310,7 @@ export async function djAgent({
         return {
           value: { object, steps, toolCalls },
           via: lastVia,
-          sampling: samplingWithNumCtx(leg.cfg, { temperature }),
+          sampling: samplingWithLocalKnobs(leg.cfg, { temperature }),
           usage: usageOf(result),
           // Full, untruncated — the agent's entire input and trail.
           extra: {

--- a/controller/src/llm/internal/strategy/object.ts
+++ b/controller/src/llm/internal/strategy/object.ts
@@ -16,7 +16,7 @@ import { generateText, Output } from 'ai';
 import { withFailover } from '../core/failover.js';
 import { withTransientRetry } from '../core/retry.js';
 import { stripThinking, extractJson, usageOf, failureDiagnostics } from '../core/pure.js';
-import { needsToolCallObject, providerOptions, samplingWithNumCtx } from '../provider/capabilities.js';
+import { needsToolCallObject, providerOptions, samplingWithLocalKnobs } from '../provider/capabilities.js';
 import { objectViaToolCall } from './object-via-tool.js';
 import { resolveMaxOutputTokens } from '../../../settings.js';
 
@@ -87,7 +87,7 @@ export async function djObject({
           return {
             value: object,
             via: lastVia,
-            sampling: samplingWithNumCtx(l.cfg, { temperature }),
+            sampling: samplingWithLocalKnobs(l.cfg, { temperature }),
             usage,
             // Full, untruncated — the /debug surface shows the whole system prompt.
             extra: { system, user: prompt, response: JSON.stringify(object).slice(0, 500) },

--- a/controller/src/llm/internal/strategy/text.ts
+++ b/controller/src/llm/internal/strategy/text.ts
@@ -8,7 +8,7 @@ import { generateText } from 'ai';
 import { withFailover } from '../core/failover.js';
 import { withTransientRetry } from '../core/retry.js';
 import { stripThinking, usageOf, failureDiagnostics } from '../core/pure.js';
-import { providerOptions, repeatPenaltyApplies, samplingWithNumCtx } from '../provider/capabilities.js';
+import { providerOptions, repeatPenaltyApplies, samplingWithLocalKnobs } from '../provider/capabilities.js';
 import { resolveMaxOutputTokens } from '../../../settings.js';
 
 // Hard output-token cap. A reasoning model with no cap can generate until it
@@ -55,7 +55,7 @@ export async function djText({
       // repeatPenaltyApplies() and providerOptions handling.
       const sampling: any = { temperature, top_p: topP, seed };
       if (repeatPenaltyApplies(leg.cfg)) sampling.repeat_penalty = repeatPenalty;
-      samplingWithNumCtx(leg.cfg, sampling);
+      samplingWithLocalKnobs(leg.cfg, sampling);
       return {
         value: out,
         via: 'ai-sdk',

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -258,6 +258,16 @@ function clampNumCtx(raw: any, def: number): number {
   return Math.min(131072, Math.max(2048, Math.floor(raw)));
 }
 
+// repeat_penalty for local openai-compatible / locca servers. Clamped to
+// [1.0, 2.0]: 1.0 is OFF (a no-op, never injected), and >2.0 mangles output.
+// Non-numeric/NaN falls back to `def`. See appliedRepeatPenalty() in
+// capabilities.ts — Ollama reads its own value via providerOptions and ignores
+// this field.
+function clampRepeatPenalty(raw: any, def: number): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return def;
+  return Math.min(2.0, Math.max(1.0, raw));
+}
+
 // Coerce a stored agent-deadline value (ms). Clamped to [5s, 180s] and floored
 // to an integer; non-numeric/NaN falls back to `def`. The lower bound keeps a
 // fat-fingered save from making every agent pick fail instantly; the upper
@@ -361,6 +371,9 @@ function applyLlmLegPatch(target: any, patch: any, label: string): void {
   }
   if (l.numCtx !== undefined) {
     target.numCtx = clampNumCtx(Number(l.numCtx), target.numCtx);
+  }
+  if (l.repeatPenalty !== undefined) {
+    target.repeatPenalty = clampRepeatPenalty(Number(l.repeatPenalty), target.repeatPenalty);
   }
   // Forced-tool tool_choice: 'required' (default) or 'auto'. Only those two are
   // legal; anything else is a config error. See forcedToolChoice() / issue #570.
@@ -942,6 +955,15 @@ const DEFAULTS = {
     // if you run those. Ignored for `:cloud` models and every other provider
     // (they manage their own context). 0 → don't send num_ctx (Ollama default).
     numCtx: 16384,
+    // Repetition penalty for local openai-compatible / locca servers (llama.cpp,
+    // vLLM, LM Studio). llama.cpp's own default is 1.0 = OFF, which lets the
+    // tool-loop picker run away repeating a token block until it hits the output
+    // cap and never calls `done`. 1.15 is a sane floor; raise toward 1.25 if a
+    // model still loops, or set 1.0 to disable (e.g. a vLLM server that rejects
+    // the `repeat_penalty` body field). Injected into the request body — the AI
+    // SDK's openai provider has no field for it. Ignored by every other provider
+    // (Ollama reads its own value via providerOptions).
+    repeatPenalty: 1.15,
     // When on, the session DJ agent drives track-picking, links and listener
     // requests as a tool-loop over the session chat history (broadcast/
     // dj-agent.js). When off, the stateless pool picker runs instead — still
@@ -1030,6 +1052,7 @@ const DEFAULTS = {
       reasoning: false,
       toolChoice: 'required',
       numCtx: 16384,
+      repeatPenalty: 1.15,
     },
   },
   // Embedding-propagated library tagger (music/tag-library.ts).

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -143,6 +143,7 @@ interface LlmFallbackForm {
   model: string;
   ollamaUrl: string;
   numCtx: number;
+  repeatPenalty: number;
   baseUrl: string;
   reasoning: boolean;
 }
@@ -152,6 +153,7 @@ interface LlmForm {
   model: string;
   ollamaUrl: string;
   numCtx: number;
+  repeatPenalty: number;
   baseUrl: string;
   reasoning: boolean;
   toolChoice: string;
@@ -510,6 +512,7 @@ export default function SettingsPanel() {
         model: v.llm?.model ?? '',
         ollamaUrl: v.llm?.ollamaUrl ?? '',
         numCtx: typeof v.llm?.numCtx === 'number' ? v.llm.numCtx : 16384,
+        repeatPenalty: typeof v.llm?.repeatPenalty === 'number' ? v.llm.repeatPenalty : 1.15,
         baseUrl: v.llm?.baseUrl ?? '',
         reasoning: !!v.llm?.reasoning,
         toolChoice: v.llm?.toolChoice === 'auto' ? 'auto' : 'required',
@@ -528,6 +531,7 @@ export default function SettingsPanel() {
           model: v.llm?.fallback?.model ?? '',
           ollamaUrl: v.llm?.fallback?.ollamaUrl ?? '',
           numCtx: typeof v.llm?.fallback?.numCtx === 'number' ? v.llm.fallback.numCtx : 16384,
+          repeatPenalty: typeof v.llm?.fallback?.repeatPenalty === 'number' ? v.llm.fallback.repeatPenalty : 1.15,
           baseUrl: v.llm?.fallback?.baseUrl ?? '',
           reasoning: !!v.llm?.fallback?.reasoning,
         },
@@ -2746,6 +2750,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
         model: form.llm.model,
         ollamaUrl: form.llm.ollamaUrl,
         numCtx: form.llm.numCtx,
+        repeatPenalty: form.llm.repeatPenalty,
         baseUrl: form.llm.baseUrl,
         reasoning: form.llm.reasoning,
         toolChoice: form.llm.toolChoice,
@@ -2767,6 +2772,7 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
           model: form.llm.fallback.model,
           ollamaUrl: form.llm.fallback.ollamaUrl,
           numCtx: form.llm.fallback.numCtx,
+          repeatPenalty: form.llm.fallback.repeatPenalty,
           baseUrl: form.llm.fallback.baseUrl,
           reasoning: form.llm.fallback.reasoning,
           ...(form.llm.fallback.provider === 'openai-compatible' && compatFallbackKeyInput.trim()
@@ -2971,6 +2977,34 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                 >
                   locca on GitHub ↗
                 </a>
+              </div>
+            </div>
+          )}
+
+          {(form.llm.provider === 'openai-compatible' || form.llm.provider === 'locca') && (
+            <div className="field">
+              <Label>Repetition penalty (repeat_penalty)</Label>
+              <Input
+                type="number"
+                min={1}
+                max={2}
+                step={0.05}
+                value={form.llm.repeatPenalty}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setForm(f => ({ ...f, llm: { ...f.llm, repeatPenalty: Number(e.target.value) } }))
+                }
+                placeholder="1.15"
+                className="max-w-[200px]"
+              />
+              <div className="field-hint">
+                Repetition penalty sent to the local server (llama.cpp, vLLM, LM
+                Studio). llama.cpp&apos;s own default is <code>1.0</code> = OFF,
+                which lets the track-picker agent run away repeating a token block
+                and never finish a pick. <strong>1.15</strong> is a sane floor;
+                raise toward 1.25 if a model still loops. Set <code>1.0</code> to
+                disable (e.g. a vLLM server that rejects the{' '}
+                <code>repeat_penalty</code> field — its name there is{' '}
+                <code>repetition_penalty</code>).
               </div>
             </div>
           )}
@@ -3241,6 +3275,29 @@ function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refre
                   </div>
                   {compatFallbackKeyTest && <KeyTestResult result={compatFallbackKeyTest} />}
                 </>
+              )}
+
+              {(form.llm.fallback.provider === 'openai-compatible' || form.llm.fallback.provider === 'locca') && (
+                <div className="field">
+                  <Label>Repetition penalty (repeat_penalty)</Label>
+                  <Input
+                    type="number"
+                    min={1}
+                    max={2}
+                    step={0.05}
+                    value={form.llm.fallback.repeatPenalty}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                      setForm(f => ({ ...f, llm: { ...f.llm, fallback: { ...f.llm.fallback, repeatPenalty: Number(e.target.value) } } }))
+                    }
+                    placeholder="1.15"
+                    className="max-w-[200px]"
+                  />
+                  <div className="field-hint">
+                    Repetition penalty for the backup local server. <strong>1.15</strong>{' '}
+                    is a sane floor (llama.cpp&apos;s own default is <code>1.0</code> =
+                    off); set <code>1.0</code> to disable.
+                  </div>
+                </div>
               )}
 
               {LLM_ENV_VARS[form.llm.fallback.provider] && (() => {


### PR DESCRIPTION
Fixes two real gaps in the newer **openai-compatible / locca** provider path (llama.cpp, vLLM, LM Studio), reported by a local-stack operator ([gist](https://gist.github.com/magicguitarist/0f73fb298c0676669d5c51fe49b46a15)) with server-side workarounds already in place. This moves the fixes into the code so the local path works out of the box.

## Quirk #2 — `repeat_penalty` silently dropped
`providerOptions()` only merges sampling options into the request when `provider === 'ollama'`; the AI SDK's openai provider validates `providerOptions` against its own schema and drops the rest. On llama.cpp (server default `repeat_penalty` = **1.0 = OFF**) the operator's configured floor never applied, and the tool-loop picker could run away repeating a token block, never emitting `done`.

- New `settings.llm.repeatPenalty` (default **1.15**, clamped 1.0–2.0; `1.0` = off) for primary + fallback legs.
- Injected into the request body via the transport wrapper (`openAICompatibleFetch`) — **this is the only path that reaches the agent/object calls**, which never pass `repeat_penalty` through `providerOptions`. Never clobbers a value already on the body.
- Admin Settings field for both legs, gated on openai-compatible/locca.

## Quirk #4 — reasoning leaks into visible content
The no-think fetch set `enable_thinking:false` but never `reasoning_format`, so Gemma-4's pre-seeded `<|channel|>thought` block routed to `content` and reached TTS.

- Inject `reasoning_format:"deepseek"` alongside `enable_thinking:false` so llama.cpp routes the thought to `reasoning_content`.
- Extend `stripThinking` to catch the harmony/channel format defensively (was `<think>`-only).

## Notes
- `repeat_penalty` is llama.cpp's param name (vLLM's is `repetition_penalty`); servers that don't recognise it ignore it, and an operator can set the field to `1.0` to opt out. Same tolerance bet the existing `chat_template_kwargs` injection already makes.
- Quirks #1, #3, #5, #6 from the gist are server-side llama.cpp operational notes, not code issues (#5 is already handled by the existing no-think fetch).

## Verification
- `npm run lint` (controller + web): 0 errors.
- `npm run test:llm`: new pure-fn coverage for `appliedRepeatPenalty` + the harmony/channel `stripThinking` cases, all passing.
- Exercised `openAICompatibleFetch` directly with a stubbed transport: reasoning-off injects `repeat_penalty` + `enable_thinking:false` + `reasoning_format`; reasoning-on injects only `repeat_penalty`; a caller-set `repeat_penalty` is preserved.