### PR TITLE
fix(skills): drop nullable on segment object so Gemma-4 keeps its schema (#906)

### DIFF
--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -115,7 +115,12 @@ function segmentSchema() {
         .describe('the segment kind — MUST be one of the kinds offered in the system prompt for this tick'),
       text: z.string().describe(`the spoken line in the DJ voice — ${lengthPhrase('segment')}`),
       sfx: z.string().nullable().describe('the exact name of one sound effect from the catalogue in the system prompt to play under this line, or null for no effect (null is usually right — most segments need none)'),
-    }).nullable().describe('the segment to air when air is true; null when air is false'),
+      // NOT nullable: a nullable nested object loses its `properties` in
+      // llama.cpp's peg-gemma4 tool serializer, so Gemma-4 never sees the
+      // shape and emits it as a string (issue #906). Silence rides entirely on
+      // the `air` boolean above, so a non-null segment on a silent tick is
+      // simply ignored at the consumption site (`object.air ? segment : null`).
+    }).describe('the segment to air when air is true; ignored when air is false (empty strings for kind/text, null sfx when silent)'),
   });
 }
 


### PR DESCRIPTION
## What

Drops `.nullable()` from the `segment` object in the segment director schema (`controller/src/skills/_agent.ts`).

## Why

Fixes #906. On self-hosted **Gemma-4 via llama.cpp** (`peg-gemma4` chat format), the segment director stayed silent on every tick. Root cause: llama.cpp's `peg-gemma4` tool serializer renders a `["object","null"]` param with a blank type and **no `properties`** — so Gemma never sees the segment's shape, emits the whole thing as a string, and validation fails (`AI_TypeValidationError: expected object, received string`). The done-only recovery then produces an object missing `kind`, `caps.find(c => c.kind === seg.kind)` fails, and the segment is dropped as "stayed silent."

## Why it's safe

- `segment` is the **only** `z.object().nullable()` in the controller — verified. The pick schema's nullables are scalars/enums, which serialize fine.
- Silence rides entirely on the existing `air` boolean, not on `segment` being null. The consumption site is `const seg = object?.air ? object?.segment : null` — on a silent tick the (now non-null) segment is simply ignored.
- The `air` boolean was already introduced precisely because small models struggled to encode "stay silent" via a nullable object, making `.nullable()` on `segment` redundant belt-and-suspenders that this backend chokes on.
- A boolean-gated non-nullable object is a conventional schema, so this is a no-op on providers that already handle nullable objects (Ollama/cloud) and unblocks the llama.cpp path. May also remove one trigger for the done-only recovery loop from #555.

## Testing

- `npm run lint` (controller): 0 errors.
- Reporter confirmed on-air: after the change, `/slots` shows `properties` restored and real mailbag/curiosity segments air again on gemma-4-12b-qat.