### PR TITLE
fix(aio): warn at boot when /var/sub-wave isn't mounted (#902)

### DIFF
--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -215,6 +215,17 @@ RUN chmod +x /usr/local/bin/subwave-supervisor
 # Shared state dir (the supervisor re-asserts perms on every boot).
 RUN mkdir -p /var/sub-wave && chmod 777 /var/sub-wave
 
+# Declare the state dir a volume so a bare `docker run` that forgets a host
+# mapping still lands state (settings, library.db, archives, model cache) in a
+# Docker-managed volume rather than the container's throwaway writable layer,
+# where a pull-and-recreate would silently wipe it (issue #902). NOTE: this is a
+# safety net, not a substitute for an explicit /var/sub-wave path mapping — the
+# Unraid CA template's required Appdata path is what actually guarantees
+# persistence across image updates (a recreate attaches a fresh anonymous volume
+# otherwise). Compose/template deployments bind-mount over this, so it's a no-op
+# there. Nothing is baked under /var/sub-wave at build time, so it shadows nothing.
+VOLUME /var/sub-wave
+
 # Re-declared for the final stage (ARGs don't cross stage boundaries) so the
 # controller process reports the same version (backup manifest) as the web
 # build above. Same source as the webbuild-stage arg.

--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -215,17 +215,6 @@ RUN chmod +x /usr/local/bin/subwave-supervisor
 # Shared state dir (the supervisor re-asserts perms on every boot).
 RUN mkdir -p /var/sub-wave && chmod 777 /var/sub-wave
 
-# Declare the state dir a volume so a bare `docker run` that forgets a host
-# mapping still lands state (settings, library.db, archives, model cache) in a
-# Docker-managed volume rather than the container's throwaway writable layer,
-# where a pull-and-recreate would silently wipe it (issue #902). NOTE: this is a
-# safety net, not a substitute for an explicit /var/sub-wave path mapping — the
-# Unraid CA template's required Appdata path is what actually guarantees
-# persistence across image updates (a recreate attaches a fresh anonymous volume
-# otherwise). Compose/template deployments bind-mount over this, so it's a no-op
-# there. Nothing is baked under /var/sub-wave at build time, so it shadows nothing.
-VOLUME /var/sub-wave
-
 # Re-declared for the final stage (ARGs don't cross stage boundaries) so the
 # controller process reports the same version (backup manifest) as the web
 # build above. Same source as the webbuild-stage arg.

--- a/docker/aio/supervisor.sh
+++ b/docker/aio/supervisor.sh
@@ -63,6 +63,30 @@ init_state() {
 }
 
 # ---------------------------------------------------------------------------
+# Warn loudly if the state dir isn't a mounted volume. With no host path (or
+# volume) mapped to /var/sub-wave, everything the station writes — settings,
+# library.db with the acoustic analysis, hourly archives, the model cache —
+# lives in the container's throwaway writable layer, and the next image update
+# (which recreates the container) silently wipes it. The Unraid CA template maps
+# this as a required Appdata path; a bare `docker run` that forgets `-v` is the
+# footgun this catches (issue #902). A real bind/volume mount gets its own entry
+# in /proc/mounts at the target path; an un-mapped dir on the overlay fs doesn't.
+# ---------------------------------------------------------------------------
+warn_if_state_unmounted() {
+	if ! grep -q ' /var/sub-wave ' /proc/mounts 2>/dev/null; then
+		log "################################################################"
+		log "WARNING: /var/sub-wave is NOT a mounted volume."
+		log "  Your settings, library cache (library.db), hourly archives and"
+		log "  model cache are being written into the container's writable"
+		log "  layer, and will be LOST the next time this image is updated."
+		log "  Map a host path to /var/sub-wave (on Unraid: the Appdata path,"
+		log "  e.g. /mnt/user/appdata/subwave) and recreate the container."
+		log "  https://github.com/perminder-klair/subwave/issues/902"
+		log "################################################################"
+	fi
+}
+
+# ---------------------------------------------------------------------------
 # Resolve the three ICECAST_*_PASSWORD values and render icecast.xml.
 # Precedence (unchanged from broadcast-entrypoint): env override > persisted
 # state/icecast-secrets.env > freshly generated. Resolved values are exported
@@ -203,6 +227,7 @@ supervise() {
 # ---------------------------------------------------------------------------
 # Boot.
 # ---------------------------------------------------------------------------
+warn_if_state_unmounted
 init_state
 init_secrets
 


### PR DESCRIPTION
## What

The AIO supervisor now checks at boot whether `/var/sub-wave` is a real mount, and logs a loud warning if it isn't.

## Why (issue #902)

A user running `subwave-aio-heavy` via a bare `docker run` had no `/var/sub-wave` path mapping. With no mapping, all state (settings, `library.db` with the acoustic analysis, hourly archives, model cache) lives in the container's writable layer, and the next image update silently wipes it. Nothing surfaced the misconfiguration.

## Why not a `VOLUME` declaration (the first attempt)

`VOLUME /var/sub-wave` does not actually fix this. An Unraid update is stop -> rm -> create -> start; the recreate attaches a **fresh anonymous volume**, so unmapped state is still wiped, and the old anonymous volume is orphaned (for the heavy image, a multi-GB model cache left dangling). It only helps if you manually re-run with the old volume id, which nobody does. So it added disk-bloat risk without protecting the reported case.

## Approach

Detect the mount instead of trying to paper over its absence. A real bind/volume mount gets its own entry in `/proc/mounts` at the target path; an unmapped dir on the overlay fs does not. If it's missing, print a boxed warning pointing at the fix (map a host path, on Unraid the Appdata path) and the issue.

- No behaviour change when the state dir **is** mapped (compose, CA template, or a correct `docker run`) — the check is silent.
- The CA template (`templates/subwave.xml`) already maps `/var/sub-wave` as a **required** Appdata path, so template installs are unaffected and stay quiet.

## Test

- `bash -n docker/aio/supervisor.sh` passes.
- Verified the `/proc/mounts` grep warns when unmapped and stays quiet when a `/var/sub-wave` mount entry is present.