### PR TITLE
feat(web): resolve GA Measurement ID at runtime (no rebuild needed)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,9 @@ SITE_URL=
 
 # Web
 # SUBWAVE_HOMEPAGE=player          # or 'landing' for the marketing host
-# NEXT_PUBLIC_GA_ID=
+# NEXT_PUBLIC_GA_ID=               # Google Analytics ID. Applied at RUNTIME
+#                                  # (recreate `web`, no rebuild) as well as at
+#                                  # build time. Unset → no analytics.
 
 # Pin the whole stack to a specific published image tag. Every subwave-* image
 # ref resolves ${SUBWAVE_VERSION:-latest}, so unset/removed follows :latest.

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -225,6 +225,11 @@ services:
       # share-card tags render per-request. Define SITE_URL once in .env and
       # both build-arg and runtime env pick it up.
       - SITE_URL=\${SITE_URL:-}
+      # Google Analytics Measurement ID at RUNTIME (web/lib/ga.ts). Plumbs the
+      # operator's NEXT_PUBLIC_GA_ID from .env into a runtime var, so analytics
+      # turn on with a \`web\` recreate — no image rebuild. The build-arg above
+      # still bakes it for images built with a value.
+      - GA_ID=\${NEXT_PUBLIC_GA_ID:-}
       # Server-side base URL for generateMetadata on the force-dynamic homepage
       # to read the live station name from the controller. Internal compose
       # network name — not exposed to the browser (which uses /api via Caddy).
@@ -558,6 +563,11 @@ services:
       - NODE_ENV=production
       - SUBWAVE_HOMEPAGE=\${SUBWAVE_HOMEPAGE:-player}
       - SITE_URL=\${SITE_URL:-}
+      # Google Analytics Measurement ID at RUNTIME (web/lib/ga.ts). Plumbs the
+      # operator's NEXT_PUBLIC_GA_ID from .env into a runtime var, so analytics
+      # turn on with a \`web\` recreate — no image rebuild. The build-arg still
+      # bakes it for images built with a value.
+      - GA_ID=\${NEXT_PUBLIC_GA_ID:-}
       # Server-side base URL for generateMetadata on the force-dynamic homepage
       # to read the live station name from the controller. Internal compose
       # network name — not exposed to the browser (which uses /api via Caddy).
@@ -1030,7 +1040,9 @@ SITE_URL=
 
 # Web
 # SUBWAVE_HOMEPAGE=player          # or 'landing' for the marketing host
-# NEXT_PUBLIC_GA_ID=
+# NEXT_PUBLIC_GA_ID=               # Google Analytics ID. Applied at RUNTIME
+#                                  # (recreate \`web\`, no rebuild) as well as at
+#                                  # build time. Unset → no analytics.
 
 # Pin the whole stack to a specific published image tag. Every subwave-* image
 # ref resolves \${SUBWAVE_VERSION:-latest}, so unset/removed follows :latest.

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -186,6 +186,11 @@ services:
       - NODE_ENV=production
       - SUBWAVE_HOMEPAGE=${SUBWAVE_HOMEPAGE:-player}
       - SITE_URL=${SITE_URL:-}
+      # Google Analytics Measurement ID at RUNTIME (web/lib/ga.ts). Plumbs the
+      # operator's NEXT_PUBLIC_GA_ID from .env into a runtime var, so analytics
+      # turn on with a `web` recreate — no image rebuild. The build-arg still
+      # bakes it for images built with a value.
+      - GA_ID=${NEXT_PUBLIC_GA_ID:-}
       # Server-side base URL for generateMetadata on the force-dynamic homepage
       # to read the live station name from the controller. Internal compose
       # network name — not exposed to the browser (which uses /api via Caddy).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,6 +216,11 @@ services:
       # share-card tags render per-request. Define SITE_URL once in .env and
       # both build-arg and runtime env pick it up.
       - SITE_URL=${SITE_URL:-}
+      # Google Analytics Measurement ID at RUNTIME (web/lib/ga.ts). Plumbs the
+      # operator's NEXT_PUBLIC_GA_ID from .env into a runtime var, so analytics
+      # turn on with a `web` recreate — no image rebuild. The build-arg above
+      # still bakes it for images built with a value.
+      - GA_ID=${NEXT_PUBLIC_GA_ID:-}
       # Server-side base URL for generateMetadata on the force-dynamic homepage
       # to read the live station name from the controller. Internal compose
       # network name — not exposed to the browser (which uses /api via Caddy).

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -19,9 +19,12 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # (docker-compose.yml → web.build.args). Unset → localhost fallback.
 ARG SITE_URL
 ENV SITE_URL=${SITE_URL}
-# Google Analytics Measurement ID. NEXT_PUBLIC_* vars are inlined into the
-# client bundle at build time, so this must be present here, not at runtime.
-# Unset → no analytics script is emitted.
+# Google Analytics Measurement ID. This build arg bakes it into the client
+# bundle (NEXT_PUBLIC_* is inlined at build). NOTE: it is ALSO resolved at
+# RUNTIME now — web/lib/ga.ts reads a plain `GA_ID` env var, which the compose
+# files plumb from the operator's NEXT_PUBLIC_GA_ID — so setting it in .env +
+# recreating `web` turns analytics on with no rebuild. Unset both → no analytics
+# script is emitted.
 ARG NEXT_PUBLIC_GA_ID
 ENV NEXT_PUBLIC_GA_ID=${NEXT_PUBLIC_GA_ID}
 # Version shown in the admin console footer, inlined into the client bundle at

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -6,14 +6,15 @@ import { GoogleAnalytics } from '@next/third-parties/google';
 import { THEME_INIT_SCRIPT } from '@/lib/theme';
 import { LITE_INIT_SCRIPT } from '@/lib/lite';
 import { SITE_URL } from '@/lib/site';
+import { GA_ID } from '@/lib/ga';
 import ServiceWorkerRegister from '@/components/ServiceWorkerRegister';
 import MotionProvider from '@/components/MotionProvider';
 import ThemeBootstrap from '@/components/ThemeBootstrap';
 import JsonLd from '@/components/JsonLd';
 
 // Visitor tracking. The gtag.js script only loads when a Measurement ID is
-// configured, so dev and un-instrumented deploys stay analytics-free.
-const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+// configured (see lib/ga — resolved from the runtime env so it works without a
+// rebuild), so dev and un-instrumented deploys stay analytics-free.
 
 // Fraunces — the display serif. Soft, optical-axis editorial face used for
 // every headline + the masthead wordmark; opsz makes it self-tune contrast to

--- a/web/lib/ga.ts
+++ b/web/lib/ga.ts
@@ -1,0 +1,23 @@
+// Google Analytics Measurement ID — resolved at BUILD **and** RUNTIME, mirroring
+// lib/site.ts's SITE_URL handling.
+//
+// The problem it solves: `NEXT_PUBLIC_*` vars are inlined into the bundle at
+// build time, so a Measurement ID set only in a running container's env never
+// reached the client — operators had to rebuild the web image to turn analytics
+// on. Reading a plain (non-`NEXT_PUBLIC`) `GA_ID` lets the value come from the
+// container's runtime env instead, so setting it in .env + recreating `web`
+// works with no rebuild. docker-compose plumbs the operator's existing
+// `NEXT_PUBLIC_GA_ID` into a runtime `GA_ID` env var, so no .env change is
+// needed. `NEXT_PUBLIC_GA_ID` stays as the build-time bake for images built
+// with it. Empty = analytics off (dev + un-instrumented deploys stay clean).
+//
+// Runtime caveat is identical to SITE_URL: the value is read where the tree
+// renders — per-request for the force-dynamic homepage, at build for statically
+// rendered routes. The homepage (the primary entry point) is force-dynamic, so
+// the runtime value takes effect there; client-side SPA navigation then carries
+// gtag across the rest of the app.
+export const GA_ID = (
+  process.env.GA_ID ||
+  process.env.NEXT_PUBLIC_GA_ID ||
+  ''
+).trim();


### PR DESCRIPTION
## What

`NEXT_PUBLIC_GA_ID` is inlined into the client bundle at **build** time (that's how `NEXT_PUBLIC_*` works), so a Measurement ID set only in a running container's env never reached the browser — operators had to **rebuild the web image** to turn Google Analytics on.

This makes it work at **runtime** from `.env`, mirroring how `lib/site.ts` already handles `SITE_URL` (build **and** runtime).

## How

- **`web/lib/ga.ts`** (new) — resolves the ID from a plain runtime `GA_ID`, falling back to build-time `NEXT_PUBLIC_GA_ID`, then empty (analytics off).
- **`web/app/layout.tsx`** — imports `GA_ID` from `@/lib/ga` instead of reading the inlined `process.env.NEXT_PUBLIC_GA_ID` directly.
- **`docker-compose.yml` + `docker-compose.byo.yml`** — plumb the operator's existing `NEXT_PUBLIC_GA_ID` from `.env` into a runtime `GA_ID` env var on the `web` service. **No `.env` change for operators** — the var they already set keeps working.
- Docs: `web/Dockerfile` + `.env.example` comments updated.

## Result

Setting `NEXT_PUBLIC_GA_ID=G-XXXX` in `.env` + `docker compose up -d web` now enables analytics **with no rebuild**. Images baked with the build arg still work unchanged.

## Caveat (same as SITE_URL)

The value is read where the tree renders: **per-request** on the force-dynamic homepage (the primary entry point), at **build** for statically rendered routes. Client-side SPA navigation then carries gtag across the rest of the app.

## Testing

- `cd web && npm run lint` → eslint 0 errors (3 pre-existing warnings in unrelated files), `tsc --noEmit` clean.
- Motivation: verified on the live cloud deploy that a `.env` `NEXT_PUBLIC_GA_ID` did **not** apply on a prebuilt image without this change.