### PR TITLE
feat(archive): disable hourly archives by default

### DIFF
--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -773,15 +773,15 @@ const DEFAULTS = {
   // i.e. opt back out of the station cap for a long-form show). Listener
   // requests bypass the cap entirely — an explicit ask always plays.
   maxTrackSeconds: 0,
-  // Hourly archive output. Enabled by default to preserve existing behaviour.
-  // The second MP3 encoder is the largest constant CPU cost in the broadcast
-  // container — operators who don't use the archives can switch this off to
-  // reclaim that headroom (issue #137). Dropping the bitrate (e.g. 128 → 64
-  // mono in a future change) also helps for operators who want the tape.
+  // Hourly archive output. Off by default — the second MP3 encoder is the
+  // largest constant CPU cost in the broadcast container, and most operators
+  // don't use the archives, so they opt in via admin → Settings rather than
+  // paying for the tape by default (issue #137). Dropping the bitrate (e.g.
+  // 128 → 64 mono in a future change) also helps for operators who want it.
   // retentionDays: hourly recordings older than this many days are deleted by
   // the scheduler's hourly cleanup. 0 = keep forever — the default, because a
   // retention default would silently delete archives operators already have.
-  archive: { enabled: true, bitrate: 128, retentionDays: 0 },
+  archive: { enabled: false, bitrate: 128, retentionDays: 0 },
   // Secondary Ogg-Opus broadcast mount (/stream.opus). Off by default — only
   // Blink (Chrome/Edge) clients ever select it (web/hooks/usePlayer.ts keeps
   // Safari/iOS/Firefox on MP3), and it adds a continuous Opus encoder + a

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -20,7 +20,7 @@ settings.server.telnet.port := 1234
 
 jingle_ratio = ref(30)
 crossfade_duration = ref(10.0)
-archive_enabled = ref(true)
+archive_enabled = ref(false)
 archive_bitrate = ref(128)
 opus_enabled = ref(false)
 opus_bitrate = ref(96)

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -443,7 +443,7 @@ export default function SettingsPanel() {
       crossfadeDuration: String(v.crossfadeDuration ?? ''),
       maxTrackSeconds: String(v.maxTrackSeconds ?? 0),
       archive: {
-        enabled: v.archive?.enabled ?? true,
+        enabled: v.archive?.enabled ?? false,
         bitrate: String(v.archive?.bitrate ?? 128),
         retentionDays: String(v.archive?.retentionDays ?? 0),
       },


### PR DESCRIPTION
## What

Fresh SUB/WAVE installs now ship with **hourly archives off**. Previously the archive was enabled by default.

## Why

The hourly archive output runs a second constant MP3 encoder — the largest steady CPU cost in the broadcast container — on every install even though most operators never use the recordings. Making it opt-in matches how Opus/FLAC/AAC already behave (all off by default, enabled from admin → Settings).

## Changes

Flipped the default in all three places that carry it:

- `controller/src/settings.ts` — `DEFAULTS.archive.enabled: true → false`
- `liquidsoap/radio.liq` — `archive_enabled = ref(true) → ref(false)` (the fallback used before the controller writes `liquidsoap_archive_enabled.txt`)
- `web/components/admin/SettingsPanel.tsx` — UI fallback `?? true → ?? false`

## Impact

- **Existing installs**: unchanged — their persisted `archive.enabled` in `settings.json` still wins.
- **Fresh installs**: archives off; operators opt in via admin → Settings.