### PR TITLE
feat(tools): import track analysis from AudioMuse-AI

### DIFF
--- a/tools/audiomuse-import/.gitignore
+++ b/tools/audiomuse-import/.gitignore
@@ -1,0 +1,5 @@
+# Standalone tool: its own deps and any local db copies stay out of git.
+node_modules/
+*.db
+*.db-wal
+*.db-shm

--- a/tools/audiomuse-import/README.md
+++ b/tools/audiomuse-import/README.md
@@ -1,0 +1,107 @@
+# audiomuse-import
+
+Import pre-computed track analysis from an [AudioMuse-AI](https://github.com/NeptuneHub/AudioMuse-AI)
+instance into SUB/WAVE's `library.db`, so a user who already tagged their library
+in AudioMuse doesn't have to run SUB/WAVE's slow LLM tagging + BPM/key pass again.
+
+**Standalone** — imports nothing from the controller. It talks only to AudioMuse
+over HTTP and to `state/library.db` over SQLite. Only dependency is
+[`better-sqlite3`](https://www.npmjs.com/package/better-sqlite3).
+
+## Why this works (and its limits)
+
+Both systems key every track by the **media-server song id**. When AudioMuse and
+SUB/WAVE point at the **same Navidrome**, AudioMuse's `score.item_id` *is*
+SUB/WAVE's `tracks.id` (the Subsonic id) — so the join is exact and needs no
+Navidrome auth at all. The tool reads AudioMuse's whole library via
+`GET /api/sync` and writes matched rows straight into `library.db`.
+
+**Navidrome only.** If AudioMuse was run against Jellyfin / Plex / Emby / LMS, its
+ids live in that server's namespace and won't match SUB/WAVE's Subsonic ids. The
+tool checks `provider_type` on the first page and refuses if it isn't `navidrome`.
+
+### What transfers
+
+| AudioMuse | → SUB/WAVE `tracks` column | Notes |
+| --- | --- | --- |
+| `tempo` | `bpm` | direct |
+| `key` + `scale` | `musical_key` | converted to Camelot (e.g. A minor → `8A`) |
+| `energy` | `energy` | bucketed to `low` / `medium` / `high` |
+| `mood_vector` + `other_features` | `moods` (JSON array) | static translation to SUB/WAVE's 17-mood vocab (see `map.mjs`); genre/decade tags don't produce moods |
+| top genre tag from `mood_vector` | `genre` | only fills an empty genre |
+
+### What does NOT transfer (still needs `npm run analyze`)
+
+- **CLAP / MusiCNN embeddings** — AudioMuse's are a different model + vector space
+  from SUB/WAVE's laion-clap, so they can't drive `searchBySound` or zero-shot
+  audio moods. Not imported.
+- **Ending/outro, structure, LUFS, beats/bars, vocal ranges** — AudioMuse doesn't
+  compute them; SUB/WAVE's transitions depend on them.
+
+So this is a **bootstrap, not a full replacement**: it saves the expensive tagging
++ BPM/key work, then you still run `npm run analyze` (heavy tier for sonic search)
+to add the transition/embedding data. The import deliberately leaves
+`analysis_version` NULL so `npm run analyze` still selects these tracks — and
+stamps `tagger_version` so `npm run tag` treats the imported moods as current and
+won't redo them.
+
+## Setup
+
+```bash
+cd tools/audiomuse-import
+npm install
+```
+
+## Usage
+
+```bash
+AUDIOMUSE_URL=http://audiomuse:8000 node import.mjs [options]
+```
+
+| Flag | Default | Notes |
+| --- | --- | --- |
+| `--audiomuse-url <url>` | `$AUDIOMUSE_URL` | AudioMuse base URL. Required. |
+| `--library-db <path>` | `<STATE_DIR>/library.db` or `../../state/library.db` | Target DB. |
+| `--overwrite` | off | Overwrite existing `bpm`/`moods`/`key`/`energy`. Default fills only empty fields and never clobbers SUB/WAVE's own tags. |
+| `--dry-run` | off | Map and report, write nothing. |
+| `--concurrency <n>` | `8` | (Reserved; paging is currently sequential.) |
+| `--mood-cutoff <0..1>` | `0.4` | Min AudioMuse tag score to count a mood. |
+| `--limit <n>` | — | Stop after N tracks (testing). |
+
+### Examples
+
+```bash
+# See what would happen, no writes
+AUDIOMUSE_URL=http://audiomuse:8000 node import.mjs --dry-run
+
+# Import, filling only gaps (safe alongside SUB/WAVE's own analyzer/tagger)
+AUDIOMUSE_URL=http://audiomuse:8000 node import.mjs
+
+# Let AudioMuse's data win everywhere
+AUDIOMUSE_URL=http://audiomuse:8000 node import.mjs --overwrite
+```
+
+Run it while the station is idle — `library.db` is shared with the running
+controller; SQLite serialises the writes, but avoiding a heavy tagging/analysis
+pass at the same time is tidier.
+
+## Notes & safety
+
+- **Requires `library.db` schema ≥ v2** (the migration with `bpm`/`musical_key`).
+  If lower, the tool refuses and asks you to boot the controller once to migrate.
+  It never runs migrations itself — `controller/src/music/library-db.ts` owns the
+  schema; this tool only writes columns it defines.
+- **Works on a fresh install.** Matched-but-absent tracks are `INSERT`ed from
+  AudioMuse's own title/artist/album, so an empty `library.db` gets populated —
+  which is the whole point for "I don't want to tag it all again".
+- Tracks AudioMuse has but SUB/WAVE's Navidrome doesn't (different `id`) simply
+  never match; the import counts and skips them.
+
+## Testing
+
+```bash
+node --test          # pure mapping tests (no db needed)
+```
+
+`map.mjs` holds all the pure transforms (tag parsing, Camelot conversion, energy
+bucketing, the mood map); `map.test.mjs` pins them.

--- a/tools/audiomuse-import/import.mjs
+++ b/tools/audiomuse-import/import.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+// Import pre-computed analysis from an AudioMuse-AI instance into SUB/WAVE's
+// library.db, so a user who already tagged their library in AudioMuse can skip
+// SUB/WAVE's slow LLM tagging + BPM/key pass.
+//
+// Standalone — imports nothing from the controller. It talks only to AudioMuse
+// over HTTP (GET /api/sync) and to state/library.db over SQLite. Because
+// AudioMuse keys everything by the media-server track id, and SUB/WAVE's
+// tracks.id IS the Navidrome/Subsonic song id, the join is exact and needs no
+// Navidrome auth. See README.md.
+//
+// What it imports:  tempo -> bpm, key+scale -> Camelot musical_key,
+//                   energy -> low/medium/high, mood_vector/other_features ->
+//                   SUB/WAVE moods (static map), top genre tag -> genre.
+// What it does NOT: CLAP/MusiCNN embeddings (different vector space), and it
+//                   deliberately leaves analysis_version NULL so a later
+//                   `npm run analyze` still adds outro/structure/embeddings.
+
+import Database from 'better-sqlite3';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+import { mapTrack } from './map.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Column-set version this tool writes against; matches TAGGER_VERSION in
+// controller/src/music/library-db.ts (imported moods count as current tags so
+// `npm run tag` won't redo them). MIN_USER_VERSION is the earliest schema that
+// has every column we write: moods/energy/source/tagger_version/tagged_at land
+// in v1, bpm/musical_key in v2 — so v2 is the floor. (We intentionally do NOT
+// touch v11 audio_moods or v12 outro_json.) Below the floor we refuse and tell
+// the user to boot the controller once to migrate.
+const TAGGER_VERSION = 3;
+const MIN_USER_VERSION = 2;
+
+// --- args -------------------------------------------------------------------
+function parseArgs(argv) {
+  const args = { concurrency: 8, moodCutoff: 0.4 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => argv[++i];
+    if (a === '--audiomuse-url') args.audiomuseUrl = next();
+    else if (a === '--library-db') args.libraryDb = next();
+    else if (a === '--concurrency') args.concurrency = Math.max(1, Number(next()) || 8);
+    else if (a === '--limit') args.limit = Number(next()) || undefined;
+    else if (a === '--mood-cutoff') args.moodCutoff = Number(next());
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--overwrite') args.overwrite = true;
+    else if (a === '-h' || a === '--help') args.help = true;
+    else {
+      console.error(`Unknown argument: ${a}`);
+      args.badArg = true;
+    }
+  }
+  return args;
+}
+
+const HELP = `audiomuse-import — import AudioMuse-AI analysis into SUB/WAVE's library.db
+
+Usage:
+  AUDIOMUSE_URL=http://audiomuse:8000 node import.mjs [options]
+
+Options:
+  --audiomuse-url <url>   AudioMuse base URL (or AUDIOMUSE_URL env). Required.
+  --library-db <path>     Path to library.db (default: <STATE_DIR>/library.db
+                          or ../../state/library.db).
+  --overwrite             Overwrite existing bpm/moods/key/energy (default:
+                          fill only empty fields, never clobber SUB/WAVE's own).
+  --dry-run               Map and report, write nothing.
+  --concurrency <n>       Parallel page fetches (default 8).
+  --mood-cutoff <0..1>    Min tag score to count a mood (default 0.4).
+  --limit <n>             Stop after N AudioMuse tracks (testing).
+  -h, --help              This help.
+`;
+
+// --- AudioMuse /api/sync paging --------------------------------------------
+async function* iterateAudioMuseTracks(baseUrl, { limit } = {}) {
+  const root = baseUrl.replace(/\/+$/, '');
+  let page = 1;
+  let seen = 0;
+  let providerChecked = false;
+  while (true) {
+    const url = `${root}/api/sync?page=${page}&limit=500&include_embeddings=false`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`GET ${url} -> ${res.status} ${res.statusText}`);
+    }
+    const body = await res.json();
+    if (!providerChecked) {
+      providerChecked = true;
+      if (body.provider_type && body.provider_type.toLowerCase() !== 'navidrome') {
+        throw new Error(
+          `AudioMuse is configured for '${body.provider_type}', not navidrome. ` +
+            `Its item ids won't match SUB/WAVE's Subsonic ids, so the import can't join. ` +
+            `Point AudioMuse at the same Navidrome SUB/WAVE uses.`,
+        );
+      }
+    }
+    const tracks = body.tracks || [];
+    for (const t of tracks) {
+      if (limit && seen >= limit) return;
+      seen++;
+      yield t;
+    }
+    if (!body.has_more || (limit && seen >= limit)) return;
+    page = body.next_page || page + 1;
+  }
+}
+
+// --- library.db writes ------------------------------------------------------
+function makeWriter(db) {
+  const selectStmt = db.prepare(
+    `SELECT bpm, musical_key, moods FROM tracks WHERE id = ?`,
+  );
+  const insertStmt = db.prepare(
+    `INSERT INTO tracks (id, title, artist, album, year, genre, bpm, musical_key,
+        moods, energy, source, tagger_version, tagged_at)
+     VALUES (@id, @title, @artist, @album, @year, @genre, @bpm, @musicalKey,
+        @moods, @energy, 'manual', @taggerVersion, @now)`,
+  );
+
+  return function writeTrack(id, meta, mapped, { overwrite }) {
+    const existing = selectStmt.get(id);
+    const now = new Date().toISOString();
+    const moodsJson = mapped.moods.length ? JSON.stringify(mapped.moods) : null;
+
+    if (!existing) {
+      insertStmt.run({
+        id,
+        title: meta.title ?? null,
+        artist: meta.artist ?? null,
+        album: meta.album ?? null,
+        year: Number.isFinite(meta.year) ? meta.year : null,
+        genre: mapped.genre ?? null,
+        bpm: mapped.bpm,
+        musicalKey: mapped.musicalKey,
+        moods: moodsJson,
+        energy: mapped.energy,
+        taggerVersion: moodsJson ? TAGGER_VERSION : null,
+        now,
+      });
+      return moodsJson || mapped.bpm != null ? 'inserted' : 'inserted-empty';
+    }
+
+    // Existing row: fill gaps unless --overwrite. Build a targeted UPDATE.
+    const sets = [];
+    const params = { id };
+    const wantBpm = overwrite || existing.bpm == null;
+    const wantKey = overwrite || existing.musical_key == null;
+    const wantMoods = overwrite || existing.moods == null;
+
+    if (wantBpm && mapped.bpm != null) {
+      sets.push('bpm = @bpm');
+      params.bpm = mapped.bpm;
+    }
+    if (wantKey && mapped.musicalKey != null) {
+      sets.push('musical_key = @musicalKey');
+      params.musicalKey = mapped.musicalKey;
+    }
+    if (wantMoods && moodsJson) {
+      sets.push('moods = @moods', 'energy = @energy', "source = 'manual'",
+        'tagger_version = @taggerVersion', 'tagged_at = @now');
+      params.moods = moodsJson;
+      params.energy = mapped.energy;
+      params.taggerVersion = TAGGER_VERSION;
+      params.now = now;
+    }
+    // Genre only fills a truly empty genre.
+    if (mapped.genre != null) {
+      sets.push('genre = COALESCE(genre, @genre)');
+      params.genre = mapped.genre;
+    }
+
+    if (!sets.length) return 'skipped';
+    db.prepare(`UPDATE tracks SET ${sets.join(', ')} WHERE id = @id`).run(params);
+    return 'updated';
+  };
+}
+
+// --- main -------------------------------------------------------------------
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || args.badArg) {
+    console.log(HELP);
+    process.exit(args.badArg ? 2 : 0);
+  }
+
+  const audiomuseUrl = args.audiomuseUrl || process.env.AUDIOMUSE_URL;
+  if (!audiomuseUrl) {
+    console.error('Missing AudioMuse URL. Pass --audiomuse-url or set AUDIOMUSE_URL.\n');
+    console.log(HELP);
+    process.exit(1);
+  }
+
+  const stateDir = process.env.STATE_DIR || resolve(__dirname, '../../state');
+  const dbPath = args.libraryDb || resolve(stateDir, 'library.db');
+  if (!existsSync(dbPath)) {
+    console.error(
+      `library.db not found at ${dbPath}. Start the SUB/WAVE controller once ` +
+        `(or run \`npm run analyze\`) to create it, or pass --library-db.`,
+    );
+    process.exit(1);
+  }
+
+  const db = new Database(dbPath);
+  db.pragma('busy_timeout = 5000');
+  const userVersion = db.pragma('user_version', { simple: true }) || 0;
+  if (userVersion < MIN_USER_VERSION) {
+    console.error(
+      `library.db schema is v${userVersion}, need >= v${MIN_USER_VERSION}. ` +
+        `Boot the SUB/WAVE controller once to run migrations, then re-run.`,
+    );
+    db.close();
+    process.exit(1);
+  }
+
+  console.log(`AudioMuse: ${audiomuseUrl}`);
+  console.log(`library.db: ${dbPath} (schema v${userVersion})`);
+  console.log(args.overwrite ? 'Mode: OVERWRITE existing fields' : 'Mode: fill gaps only');
+  if (args.dryRun) console.log('Mode: DRY RUN (no writes)');
+  console.log('');
+
+  const writeTrack = makeWriter(db);
+  const counts = { seen: 0, inserted: 0, updated: 0, skipped: 0, noSignal: 0 };
+  const samples = [];
+
+  const commit = db.transaction((batch) => {
+    for (const t of batch) {
+      const mapped = mapTrack(t, { moodCutoff: args.moodCutoff });
+      const hasSignal = mapped.bpm != null || mapped.moods.length || mapped.musicalKey != null;
+      if (!hasSignal) {
+        counts.noSignal++;
+        continue;
+      }
+      if (samples.length < 5) {
+        samples.push({ title: t.title, artist: t.author, ...mapped });
+      }
+      if (args.dryRun) continue;
+      const outcome = writeTrack(t.id, { title: t.title, artist: t.author, album: t.album, year: t.year }, mapped, { overwrite: args.overwrite });
+      if (outcome === 'inserted' || outcome === 'inserted-empty') counts.inserted++;
+      else if (outcome === 'updated') counts.updated++;
+      else counts.skipped++;
+    }
+  });
+
+  // Buffer pages and commit in batches for a fast single transaction per chunk.
+  let batch = [];
+  const BATCH = 500;
+  for await (const t of iterateAudioMuseTracks(audiomuseUrl, { limit: args.limit })) {
+    counts.seen++;
+    batch.push(t);
+    if (batch.length >= BATCH) {
+      commit(batch);
+      batch = [];
+      process.stdout.write(`\r  processed ${counts.seen} tracks…`);
+    }
+  }
+  if (batch.length) commit(batch);
+  process.stdout.write('\r');
+
+  db.close();
+
+  console.log('Sample mappings:');
+  for (const s of samples) {
+    console.log(
+      `  ${s.artist ?? '?'} — ${s.title ?? '?'}: bpm=${s.bpm ?? '—'} key=${s.musicalKey ?? '—'} ` +
+        `energy=${s.energy ?? '—'} moods=[${s.moods.join(', ')}] genre=${s.genre ?? '—'}`,
+    );
+  }
+  console.log('');
+  console.log(`AudioMuse tracks read:  ${counts.seen}`);
+  console.log(`  no usable signal:     ${counts.noSignal}`);
+  if (args.dryRun) {
+    console.log('(dry run — nothing written)');
+  } else {
+    console.log(`  rows inserted:        ${counts.inserted}`);
+    console.log(`  rows updated:         ${counts.updated}`);
+    console.log(`  left untouched:       ${counts.skipped}`);
+  }
+  console.log('');
+  console.log(
+    'Done. This imported moods/bpm/key only — embeddings and ending-aware\n' +
+      'transition data are NOT included. Run `npm run analyze` in the controller\n' +
+      '(heavy tier for sonic search) to add outro/structure/CLAP embeddings.',
+  );
+}
+
+main().catch((err) => {
+  console.error(`\nImport failed: ${err.message}`);
+  process.exit(1);
+});

--- a/tools/audiomuse-import/map.mjs
+++ b/tools/audiomuse-import/map.mjs
@@ -1,0 +1,138 @@
+// Pure mapping from AudioMuse-AI's analysis vocabulary into SUB/WAVE's
+// library.db columns. No I/O here — every function is a pure transform so it
+// can be unit-tested (see map.test.mjs). Coupling note: the target shapes
+// (Camelot musical_key, energy low/medium/high, the 17-mood vocab, the JSON
+// moods array) mirror controller/src/music/library-db.ts + settings.ts — if
+// those change, update this file to match.
+
+// --- tag-score strings ------------------------------------------------------
+// AudioMuse stores mood_vector / other_features as "label:score,label:score"
+// with 3-decimal scores (database.py). Labels never contain a colon, so a
+// single split on ":" is safe even for "easy listening" / "Hip-Hop" / "00s".
+export function parseTagScores(str) {
+  const out = {};
+  if (!str || typeof str !== 'string') return out;
+  for (const pair of str.split(',')) {
+    const i = pair.indexOf(':');
+    if (i < 0) continue;
+    const label = pair.slice(0, i).trim();
+    const score = Number(pair.slice(i + 1));
+    if (label && Number.isFinite(score)) out[label] = score;
+  }
+  return out;
+}
+
+// --- musical key -> Camelot -------------------------------------------------
+// AudioMuse gives key (e.g. "C", "F#", "Db") + scale ("major"/"minor").
+// SUB/WAVE's musical_key is a Camelot code (e.g. "8A" = A minor, "8B" = C major).
+const PITCH_CLASS = {
+  C: 0, 'B#': 0, 'C#': 1, DB: 1, D: 2, 'D#': 3, EB: 3, E: 4, FB: 4,
+  'E#': 5, F: 5, 'F#': 6, GB: 6, G: 7, 'G#': 8, AB: 8, A: 9, 'A#': 10,
+  BB: 10, B: 11, CB: 11,
+};
+// Indexed by pitch class 0..11 (C..B).
+const CAMELOT_MAJOR = ['8B', '3B', '10B', '5B', '12B', '7B', '2B', '9B', '4B', '11B', '6B', '1B'];
+const CAMELOT_MINOR = ['5A', '12A', '7A', '2A', '9A', '4A', '11A', '6A', '1A', '8A', '3A', '10A'];
+
+export function keyToCamelot(key, scale) {
+  if (!key || !scale) return null;
+  const pc = PITCH_CLASS[String(key).trim().toUpperCase()];
+  if (pc == null) return null;
+  const mode = String(scale).trim().toLowerCase();
+  if (mode === 'major') return CAMELOT_MAJOR[pc];
+  if (mode === 'minor') return CAMELOT_MINOR[pc];
+  return null;
+}
+
+// --- energy -> low/medium/high ---------------------------------------------
+// AudioMuse energy is a raw RMS-ish REAL; it normalises against ENERGY_MIN/MAX
+// (config.py) before use. We reproduce that range, then bucket into the three
+// values SUB/WAVE's energy CHECK constraint allows.
+const ENERGY_MIN = 0.01;
+const ENERGY_MAX = 0.15;
+
+export function energyToBucket(energy) {
+  if (energy == null || !Number.isFinite(Number(energy))) return null;
+  const n = Math.min(1, Math.max(0, (Number(energy) - ENERGY_MIN) / (ENERGY_MAX - ENERGY_MIN)));
+  if (n < 0.34) return 'low';
+  if (n < 0.67) return 'medium';
+  return 'high';
+}
+
+// --- mood translation -------------------------------------------------------
+// Static map from AudioMuse's tags (the 50 MusiCNN mood_vector labels + the 6
+// CLAP other_features labels) to SUB/WAVE's 17 editorial moods (SHOW_MOODS in
+// settings.ts). Keys are lower-cased for case-insensitive lookup. Only tags
+// with a genuine mood signal are mapped; pure genre/decade/instrument tags
+// (rock, pop, 80s, guitar…) intentionally map to nothing — SUB/WAVE's own
+// audio-mood pass and the contextual moods (rainy/night/workout…) fill those.
+export const AUDIOMUSE_MOOD_MAP = {
+  // energetic
+  aggressive: 'energetic', 'hard rock': 'energetic', 'heavy metal': 'energetic',
+  metal: 'energetic', punk: 'energetic', electro: 'energetic', dance: 'energetic',
+  house: 'energetic',
+  // calm
+  chill: 'calm', chillout: 'calm', mellow: 'calm', ambient: 'calm',
+  'easy listening': 'calm', relaxed: 'calm', acoustic: 'calm',
+  // reflective
+  sad: 'reflective', beautiful: 'reflective', blues: 'reflective', folk: 'reflective',
+  oldies: 'reflective',
+  // celebratory
+  happy: 'celebratory', party: 'celebratory', catchy: 'celebratory', funk: 'celebratory',
+  danceable: 'celebratory',
+  // romantic
+  sexy: 'romantic', soul: 'romantic', rnb: 'romantic',
+  // focus
+  instrumental: 'focus', experimental: 'focus',
+};
+
+// Genre-like tags eligible to populate tracks.genre (order-independent set).
+const GENRE_TAGS = new Set([
+  'rock', 'pop', 'alternative', 'indie', 'electronic', 'dance', 'jazz', 'metal',
+  'soul', 'folk', 'punk', 'blues', 'funk', 'country', 'hip-hop', 'rnb', 'house',
+  'ambient', 'electronica', 'classic rock', 'hard rock', 'heavy metal', 'indie rock',
+  'indie pop', 'alternative rock', 'progressive rock', 'electro', 'experimental',
+]);
+
+// Highest-scoring genre-like tag from a parsed mood_vector, or null. Returns the
+// original-cased label as AudioMuse spelled it.
+export function topGenre(moodScores) {
+  let best = null;
+  let bestScore = -Infinity;
+  for (const [label, score] of Object.entries(moodScores)) {
+    if (GENRE_TAGS.has(label.toLowerCase()) && score > bestScore) {
+      best = label;
+      bestScore = score;
+    }
+  }
+  return best;
+}
+
+// Full per-track mapping. `row` is one entry from AudioMuse's /api/sync payload
+// ({ tempo, key, scale, mood_vector, other_features, energy, ... }). Returns the
+// SUB/WAVE-shaped fields to write. `moodCutoff` gates which tag scores count.
+export function mapTrack(row, { moodCutoff = 0.4 } = {}) {
+  const moodScores = parseTagScores(row.mood_vector);
+  const otherScores = parseTagScores(row.other_features);
+
+  const moods = [];
+  const seen = new Set();
+  for (const [label, score] of [...Object.entries(moodScores), ...Object.entries(otherScores)]) {
+    if (score < moodCutoff) continue;
+    const mood = AUDIOMUSE_MOOD_MAP[label.toLowerCase()];
+    if (mood && !seen.has(mood)) {
+      seen.add(mood);
+      moods.push(mood);
+    }
+  }
+
+  const bpm = Number.isFinite(Number(row.tempo)) && Number(row.tempo) > 0 ? Number(row.tempo) : null;
+
+  return {
+    bpm,
+    musicalKey: keyToCamelot(row.key, row.scale),
+    energy: energyToBucket(row.energy),
+    moods,
+    genre: topGenre(moodScores),
+  };
+}

--- a/tools/audiomuse-import/map.test.mjs
+++ b/tools/audiomuse-import/map.test.mjs
@@ -1,0 +1,103 @@
+// Pure-mapping tests. Run: node --test  (no deps, no library.db needed).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseTagScores,
+  keyToCamelot,
+  energyToBucket,
+  topGenre,
+  mapTrack,
+  AUDIOMUSE_MOOD_MAP,
+} from './map.mjs';
+
+test('parseTagScores parses label:score pairs', () => {
+  assert.deepEqual(parseTagScores('rock:0.812,indie:0.640'), { rock: 0.812, indie: 0.64 });
+});
+
+test('parseTagScores handles empty / null / malformed', () => {
+  assert.deepEqual(parseTagScores(''), {});
+  assert.deepEqual(parseTagScores(null), {});
+  assert.deepEqual(parseTagScores('garbage'), {});
+});
+
+test('parseTagScores keeps multi-word and hyphen/decade labels', () => {
+  const s = parseTagScores('easy listening:0.5,Hip-Hop:0.3,00s:0.9');
+  assert.equal(s['easy listening'], 0.5);
+  assert.equal(s['Hip-Hop'], 0.3);
+  assert.equal(s['00s'], 0.9);
+});
+
+test('keyToCamelot maps majors and minors (relative pairs align)', () => {
+  assert.equal(keyToCamelot('C', 'major'), '8B');
+  assert.equal(keyToCamelot('A', 'minor'), '8A'); // relative minor of C major
+  assert.equal(keyToCamelot('G', 'major'), '9B');
+  assert.equal(keyToCamelot('E', 'minor'), '9A'); // relative minor of G major
+  assert.equal(keyToCamelot('Eb', 'major'), '5B');
+  assert.equal(keyToCamelot('C', 'minor'), '5A'); // relative minor of Eb major
+});
+
+test('keyToCamelot handles enharmonics and casing', () => {
+  assert.equal(keyToCamelot('Db', 'major'), keyToCamelot('C#', 'major'));
+  assert.equal(keyToCamelot('f#', 'MINOR'), '11A');
+});
+
+test('keyToCamelot returns null on missing / unknown input', () => {
+  assert.equal(keyToCamelot('', 'major'), null);
+  assert.equal(keyToCamelot('C', ''), null);
+  assert.equal(keyToCamelot('H', 'major'), null);
+  assert.equal(keyToCamelot('C', 'dorian'), null);
+});
+
+test('energyToBucket buckets across the normalised range', () => {
+  assert.equal(energyToBucket(0.01), 'low'); // == ENERGY_MIN -> 0
+  assert.equal(energyToBucket(0.08), 'medium'); // mid-range
+  assert.equal(energyToBucket(0.15), 'high'); // == ENERGY_MAX -> 1
+  assert.equal(energyToBucket(null), null);
+  assert.equal(energyToBucket('x'), null);
+});
+
+test('energyToBucket only ever emits CHECK-valid values', () => {
+  for (let e = 0; e <= 0.2; e += 0.005) {
+    const b = energyToBucket(e);
+    assert.ok(b === 'low' || b === 'medium' || b === 'high');
+  }
+});
+
+test('topGenre picks the highest-scoring genre-like tag', () => {
+  assert.equal(topGenre({ rock: 0.4, jazz: 0.9, happy: 0.99 }), 'jazz');
+  assert.equal(topGenre({ happy: 0.9, sad: 0.8 }), null); // no genre tags
+  assert.equal(topGenre({}), null);
+});
+
+test('mood map only carries genuine mood signal, not genre', () => {
+  assert.equal(AUDIOMUSE_MOOD_MAP['rock'], undefined);
+  assert.equal(AUDIOMUSE_MOOD_MAP['aggressive'], 'energetic');
+  assert.equal(AUDIOMUSE_MOOD_MAP['chillout'], 'calm');
+});
+
+test('mapTrack produces the full SUB/WAVE shape and dedupes moods', () => {
+  const row = {
+    tempo: 128.4,
+    key: 'A',
+    scale: 'minor',
+    mood_vector: 'rock:0.9,aggressive:0.7,chill:0.1,jazz:0.5',
+    other_features: 'danceable:0.8,party:0.6,sad:0.2',
+    energy: 0.12,
+  };
+  const m = mapTrack(row);
+  assert.equal(m.bpm, 128.4);
+  assert.equal(m.musicalKey, '8A');
+  assert.equal(m.energy, 'high');
+  assert.equal(m.genre, 'rock'); // highest genre tag
+  // aggressive->energetic, danceable+party->celebratory (deduped); chill/sad below cutoff
+  assert.deepEqual([...m.moods].sort(), ['celebratory', 'energetic']);
+});
+
+test('mapTrack tolerates missing analysis fields', () => {
+  const m = mapTrack({ tempo: 0, key: null, scale: null, mood_vector: '', energy: null });
+  assert.equal(m.bpm, null);
+  assert.equal(m.musicalKey, null);
+  assert.equal(m.energy, null);
+  assert.deepEqual(m.moods, []);
+  assert.equal(m.genre, null);
+});

--- a/tools/audiomuse-import/package-lock.json
+++ b/tools/audiomuse-import/package-lock.json
@@ -1,0 +1,470 @@
+{
+  "name": "audiomuse-import",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "audiomuse-import",
+      "version": "1.0.0",
+      "dependencies": {
+        "better-sqlite3": "^11.0.0"
+      },
+      "bin": {
+        "audiomuse-import": "import.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/tools/audiomuse-import/package.json
+++ b/tools/audiomuse-import/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "audiomuse-import",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Import pre-computed track analysis (moods, bpm, key, energy) from an AudioMuse-AI instance into SUB/WAVE's library.db, so a Navidrome user who already tagged their library doesn't have to re-tag.",
+  "bin": {
+    "audiomuse-import": "./import.mjs"
+  },
+  "scripts": {
+    "start": "node import.mjs",
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.0.0"
+  }
+}

--- a/web/content/news/2026-07-08-import-from-audiomuse.md
+++ b/web/content/news/2026-07-08-import-from-audiomuse.md
@@ -1,0 +1,33 @@
+---
+title: Bring your AudioMuse tags across
+date: 2026-07-08
+category: Feature
+author: The SUB/WAVE desk
+excerpt: Already ran AudioMuse-AI over your library? A new importer pulls those moods, BPM, key and energy straight into SUB/WAVE, so you don't tag everything a second time.
+---
+
+Plenty of you turned up already having tagged your whole library in AudioMuse-AI, and then found SUB/WAVE wanted to analyse it all over again. Fair complaint. There's now a tool that carries that work straight across instead.
+
+## What's new
+
+A small standalone tool lives under `tools/audiomuse-import`. Point it at your AudioMuse instance and it reads the analysis you already have and writes it into SUB/WAVE's library. Both apps happen to key tracks by the same Navidrome song id, so the match is exact, no guessing by filename. It works even on a fresh SUB/WAVE with an empty library.
+
+## How to use it
+
+Both apps need to point at the same Navidrome. Then:
+
+```
+cd tools/audiomuse-import
+npm install
+AUDIOMUSE_URL=http://your-audiomuse:8000 node import.mjs
+```
+
+By default it only fills in blanks, so anything you've already tagged in SUB/WAVE stays put. Add `--dry-run` to see what it would do first, or `--overwrite` to let AudioMuse's data win everywhere.
+
+What comes across: moods, BPM, musical key (as Camelot), energy, and genre. What stays behind: the audio embeddings and the ending and structure data, because SUB/WAVE measures those with a different model than AudioMuse does. So run `npm run analyze` once afterwards to layer the transition and "sounds like" data on top.
+
+## Why it helps
+
+Tagging a big library from scratch is the slow part of getting on air. If you've already done it once in AudioMuse, this gets you a station that knows your music in a couple of minutes rather than a couple of hours.
+
+One catch: it's Navidrome only for now. Jellyfin, Plex, Emby and LMS hand out track IDs from a different system that won't line up.


### PR DESCRIPTION
## What

A standalone importer (`tools/audiomuse-import`) that pulls pre-computed analysis from an [AudioMuse-AI](https://github.com/NeptuneHub/AudioMuse-AI) instance into SUB/WAVE's `library.db`. Answers a recurring community ask: *"I already tagged my library in AudioMuse, I don't want to redo it."*

## How it works

Both apps key tracks by the media-server song id, and for Navidrome that id is the same Subsonic id SUB/WAVE's `tracks.id` uses. So the join is exact and needs no Navidrome auth. The tool reads AudioMuse's whole library over `GET /api/sync` and writes matched rows straight into `library.db`.

Standalone like `tools/jamendo`: own `package.json`, plain `.mjs`, imports nothing from the controller. Only dep is `better-sqlite3`.

### Transfers
- `tempo` → `bpm`
- `key` + `scale` → `musical_key` (Camelot)
- `energy` → `low`/`medium`/`high`
- `mood_vector` + `other_features` → SUB/WAVE moods (static translation map)
- top genre tag → `genre`

### Deliberately does not transfer
- **Embeddings** (AudioMuse's CLAP/MusiCNN are a different model + vector space from SUB/WAVE's laion-clap, so they can't drive `searchBySound` or zero-shot audio moods).
- **Outro/structure/LUFS/beats** (AudioMuse doesn't compute them).

Leaves `analysis_version` NULL so `npm run analyze` still selects these tracks for the transition/embedding data. Stamps `tagger_version` so `npm run tag` treats imported moods as current.

## Behaviour
- **Fill-gaps by default** (never clobbers SUB/WAVE's own tags); `--overwrite` to force; `--dry-run` to preview.
- **Works on a fresh install**: unmatched tracks are `INSERT`ed from AudioMuse's own metadata, so an empty `library.db` gets populated.
- **Navidrome only**: guards on `provider_type` and refuses with a clear message otherwise.
- Requires schema `>= v2` (has `bpm`/`musical_key`); refuses below and asks the user to boot the controller once to migrate.

## Tests / verification
- Pure mapping logic (tag parsing, Camelot conversion, energy bucketing, mood map) unit-tested: `node --test` (12 cases pass).
- Verified end-to-end against a mock AudioMuse server + a copy of the real `library.db`: fill-gaps preserves existing tags, new rows insert with `source='manual'`, `--overwrite` replaces, non-Navidrome guard fires.

## Also
- `/news` dispatch (`web/content/news/2026-07-08-import-from-audiomuse.md`) explaining the feature and its limits. `web` build passes; page prerenders at `/news/import-from-audiomuse`.