### PR TITLE
fix(llm): honour forceNoThink on openai-compatible/locca picker legs

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -15,7 +15,7 @@ import { providerOptions, needsToolCallObject, repeatPenaltyApplies, appliedNumC
 import { agentPlan } from '../src/llm/internal/strategy/plan.js';
 import { introBudgetPhrase, enforceIntroBudget } from '../src/llm/internal/prompts/intro-budget.js';
 import { embeddingBaseUrl } from '../src/llm/internal/provider/embedding.js';
-import { DEFAULT_LOCCA_EMBED_BASE_URL } from '../src/llm/internal/provider/registry.js';
+import { DEFAULT_LOCCA_EMBED_BASE_URL, openAICompatibleFetch } from '../src/llm/internal/provider/registry.js';
 import { personaToneDirectives, normalizeDial, DIAL_NEUTRAL, validatePersonasStrict, clampTtsSpeed, TTS_SPEED_DEFAULT, clampMaxOutputTokens, resolveMaxOutputTokens, MAX_OUTPUT_TOKENS_MIN, MAX_OUTPUT_TOKENS_MAX, effectiveFrequency, SCRIPT_LENGTHS } from '../src/settings.js';
 import { lengthMode, lengthPhrase } from '../src/llm/internal/prompts/system.js';
 import { showMusicLean } from '../src/llm/internal/prompts/picker.js';
@@ -408,6 +408,29 @@ async function main() {
     assert.equal(appliedRepeatPenalty({ provider: 'openai', repeatPenalty: 1.2 }), null);
     // Missing / junk value → null, no throw.
     assert.equal(appliedRepeatPenalty({ provider: 'openai-compatible' }), null);
+  });
+
+  console.log('openAICompatibleFetch (body no-think injection for self-hosted llama.cpp/locca):');
+  await test('reasoning ON + forceNoThink OFF: thinking left ON (free-text DJ path keeps reasoning)', async () => {
+    let sent: any = null;
+    const impl = openAICompatibleFetch({ provider: 'locca', reasoning: true }, async (_u: any, init: any) => { sent = JSON.parse(init.body); return {} as any; }, false);
+    await impl('http://x/v1/chat/completions', { method: 'POST', body: JSON.stringify({ model: 'm', messages: [] }) });
+    assert.equal(sent.chat_template_kwargs?.enable_thinking, undefined);
+    assert.equal(sent.reasoning_format, undefined);
+  });
+  await test('reasoning ON + forceNoThink ON: thinking SUPPRESSED (the picker legs — issue: schema-fail-on-picks)', async () => {
+    let sent: any = null;
+    const impl = openAICompatibleFetch({ provider: 'locca', reasoning: true }, async (_u: any, init: any) => { sent = JSON.parse(init.body); return {} as any; }, true);
+    await impl('http://x/v1/chat/completions', { method: 'POST', body: JSON.stringify({ model: 'm', messages: [] }) });
+    assert.equal(sent.chat_template_kwargs.enable_thinking, false);
+    assert.equal(sent.reasoning_format, 'deepseek');
+  });
+  await test('reasoning OFF: thinking suppressed regardless of forceNoThink (existing behaviour preserved)', async () => {
+    let sent: any = null;
+    const impl = openAICompatibleFetch({ provider: 'openai-compatible', reasoning: false }, async (_u: any, init: any) => { sent = JSON.parse(init.body); return {} as any; }, false);
+    await impl('http://x/v1/chat/completions', { method: 'POST', body: JSON.stringify({ model: 'm', messages: [] }) });
+    assert.equal(sent.chat_template_kwargs.enable_thinking, false);
+    assert.equal(sent.reasoning_format, 'deepseek');
   });
 
   await test('forcedToolChoice: only the literal "auto" downgrades; everything else is "required" (issue #570)', () => {

--- a/controller/src/llm/internal/provider/registry.ts
+++ b/controller/src/llm/internal/provider/registry.ts
@@ -108,9 +108,21 @@ export function noThinkFetch(url: any, init: any, baseFetch: any = fetch) {
 //     script and reaches TTS. reasoning_format:"deepseek" routes it to
 //     reasoning_content, which the SDK surfaces as a reasoning part, not text
 //     (gist quirk #4).
-export function openAICompatibleFetch(cfg: any, baseFetch: any = fetch) {
+//
+// `forceNoThink` suppresses thinking on THIS instance even when the operator
+// left reasoning on: the forced-tool structured-output legs (picker done-tool,
+// objectViaToolCall) run no-think so a reasoning model doesn't burn its whole
+// output budget thinking and then truncate mid-<think> (→ NoObjectGeneratedError
+// on every pick) or fail to emit the forced tool. Unlike Anthropic/DeepSeek
+// (per-call providerOptions) and OpenRouter (construction-time reasoning), the
+// only no-think lever these self-hosted servers have is this body injection, so
+// forceNoThink has to be honoured HERE — a distinct no-think model instance is
+// built for the picker legs (see languageModel's bodyNoThink). Without it a
+// reasoning-on locca/openai-compatible model failed schema validation on picks
+// and looped </think> at handoffs (the free-text signoff path, issue #914).
+export function openAICompatibleFetch(cfg: any, baseFetch: any = fetch, forceNoThink = false) {
   const penalty = appliedRepeatPenalty(cfg);
-  const noThink = cfg?.reasoning !== true;
+  const noThink = forceNoThink || cfg?.reasoning !== true;
   return (url: any, init: any) => {
     if (init?.body && typeof init.body === 'string') {
       try {
@@ -176,10 +188,11 @@ export const DEFAULT_REQUESTY_BASE_URL = 'https://router.requesty.ai/v1';
 // Most accept any non-empty key, so fall back to a placeholder. The fetch
 // wrapper injects the body-only knobs (repeat_penalty, and — reasoning off —
 // enable_thinking:false + reasoning_format); see openAICompatibleFetch.
-function openAICompatibleModel(cfg: any, id: string, baseURL: string, name: string) {
+function openAICompatibleModel(cfg: any, id: string, baseURL: string, name: string, forceNoThink = false) {
   // debugFetch is the inner transport, so what's recorded is the body exactly
-  // as sent (post-injection).
-  const fetchImpl = openAICompatibleFetch(cfg, debugFetch);
+  // as sent (post-injection). forceNoThink builds the picker's no-think variant
+  // (see languageModel) — thinking suppressed even with operator reasoning on.
+  const fetchImpl = openAICompatibleFetch(cfg, debugFetch, forceNoThink);
   const provider = createOpenAI({
     baseURL,
     apiKey: cfg.apiKey || 'unused',
@@ -207,13 +220,18 @@ export function resolveModelId(cfg: any): string {
 export function languageModel(cfg: any = llmCfg(), opts: { forceNoThink?: boolean } = {}) {
   const id = resolveModelId(cfg);
   const baseUrlSig = cfg.provider === 'locca' ? loccaBaseUrl(cfg) : (cfg.baseUrl || '');
-  // Construction-time no-think: only providers whose reasoning is set at build
-  // time (OpenRouter) need a distinct reasoning-disabled instance for forced-tool
-  // legs; everyone else suppresses per-call via providerOptions, so the same
-  // cached model serves both. Keyed into the sig so the two variants don't collide.
-  const constructionNoThink = opts.forceNoThink === true
-    && capabilitiesFor(cfg.provider).reasoningConstructionOnly === true;
-  const sig = `${cfg.provider}|${id}|${cfg.apiKey || ''}|${ollamaBaseUrl(cfg)}|${baseUrlSig}|${cfg.reasoning ? 'r1' : 'r0'}|${constructionNoThink ? 'nt1' : 'nt0'}`;
+  // Construction-time no-think: two provider families can't suppress thinking
+  // per-call, so a forced-tool leg needs its own reasoning-disabled INSTANCE.
+  //   - OpenRouter (reasoningConstructionOnly): reasoning is fixed at model build.
+  //   - openai-compatible / locca (samplingViaBody): no-think rides the request
+  //     BODY via openAICompatibleFetch, bound at construction — so the picker's
+  //     no-think variant must be a separate instance whose wrapper forces it.
+  // Everyone else suppresses per-call via providerOptions, so the same cached
+  // model serves both. Keyed into the sig so the variants don't collide.
+  const caps = capabilitiesFor(cfg.provider);
+  const constructionNoThink = opts.forceNoThink === true && caps.reasoningConstructionOnly === true;
+  const bodyNoThink = opts.forceNoThink === true && caps.samplingViaBody === true;
+  const sig = `${cfg.provider}|${id}|${cfg.apiKey || ''}|${ollamaBaseUrl(cfg)}|${baseUrlSig}|${cfg.reasoning ? 'r1' : 'r0'}|${(constructionNoThink || bodyNoThink) ? 'nt1' : 'nt0'}`;
 
   const cached = clientCache.get(sig);
   if (cached) return cached;
@@ -231,14 +249,14 @@ export function languageModel(cfg: any = llmCfg(), opts: { forceNoThink?: boolea
       break;
     }
     case 'openai-compatible': {
-      model = openAICompatibleModel(cfg, id, cfg.baseUrl, 'openai-compatible');
+      model = openAICompatibleModel(cfg, id, cfg.baseUrl, 'openai-compatible', bodyNoThink);
       break;
     }
     case 'locca': {
       // First-class locca: an openai-compatible llama.cpp server with a sane
       // default base URL (host.docker.internal:8080) so the operator doesn't
       // hand-type a URL. Same transport as openai-compatible, incl. no-think.
-      model = openAICompatibleModel(cfg, id, loccaBaseUrl(cfg), 'locca');
+      model = openAICompatibleModel(cfg, id, loccaBaseUrl(cfg), 'locca', bodyNoThink);
       break;
     }
     case 'google': {


### PR DESCRIPTION
## What & why

From a Discord report: *"persistent JSON schema validation issues for DJ calls — fails on many picks and almost always on programming handovers, after which the DJ never recovers and goes very silent for the remainder of the programming."*

Root cause: on the **`openai-compatible`** and **`locca`** providers, the picker's no-think request is silently ignored. The forced-tool structured-output legs (picker `done` tool, `objectViaToolCall`) build their model with `forceNoThink: true`, but:

1. `capabilities.ts` `thinkingBlock` is `NONE` for these providers — no per-call `providerOptions` knob.
2. `legs.ts` `noThinkModel = languageModel(cfg, { forceNoThink: true })` resolved to the **same cached instance** as `model` — `constructionNoThink` only covered OpenRouter (`reasoningConstructionOnly`).
3. `openAICompatibleFetch` decided no-think purely from `cfg.reasoning`, bound at construction — never seeing `forceNoThink`.

So with **chain-of-thought ON**, every pick and every `djObject` call ran with thinking fully enabled. On a self-hosted llama.cpp/GGUF reasoning model that means unbounded thinking → blows the 8000-token output cap mid-`<think>` → `NoObjectGeneratedError`/JSON-parse failure on picks (or never emits the forced tool).

The **"never recovers, silent"** cascade: agent picks fail 3× → circuit breaker opens → the pool picker (also a forced-tool `djObject` call) fails the same way → no track queued → Liquidsoap coasts on `auto.m3u` with **no DJ talk**. The free-text signoff at a handover is where a reasoning model's `</think>` loop is most visible — the exact live incident behind #914.

## The fix

Thread `forceNoThink` into `openAICompatibleFetch` (`noThink = forceNoThink || cfg?.reasoning !== true`) and `openAICompatibleModel`, and build a **distinct no-think instance** for these providers (`bodyNoThink`, keyed on the existing `samplingViaBody` capability + folded into the client-cache signature). The DJ's free-text patter keeps reasoning; the picker legs run no-think. Anthropic/DeepSeek (per-call `providerOptions`) and OpenRouter (construction-time instance) already did this — openai-compatible/locca fell through both mechanisms.

## Operator note

Anyone hitting this today can mitigate without upgrading by turning **Chain-of-thought OFF** for the self-hosted model in Settings → LLM (that already injects `enable_thinking:false`), which is what the picks want anyway.

## Testing
- New `openAICompatibleFetch` regression tests in `llm-pure.test.ts` cover the three cases: reasoning-on + forceNoThink-off (thinking stays on for free text), reasoning-on + forceNoThink-on (suppressed — the picker legs), reasoning-off (existing behaviour preserved).
- `npm run test:llm` ✅ · `npm run lint` (eslint + `tsc --noEmit`) ✅ — 0 errors.

I couldn't reproduce the reporter's exact model/config, so this is verified by code trace + unit tests rather than an end-to-end repro.