### PR TITLE
fix(llm): force parallel_tool_calls:false on openai-compatible tool requests

### DIFF
--- a/controller/src/llm/internal/provider/registry.ts
+++ b/controller/src/llm/internal/provider/registry.ts
@@ -108,6 +108,14 @@ export function noThinkFetch(url: any, init: any, baseFetch: any = fetch) {
 //     script and reaches TTS. reasoning_format:"deepseek" routes it to
 //     reasoning_content, which the SDK surfaces as a reasoning part, not text
 //     (gist quirk #4).
+//   • parallel_tool_calls:false on tool-bearing requests — absent, llama.cpp
+//     resolves it from the chat template's capability default, which is true
+//     for Gemma-4-family templates; the model then emits several tool calls in
+//     one turn and the peg-gemma4 parser 500s on call #2, failing the whole
+//     pick/segment attempt (issue #940). The agent design is one call per step
+//     (gated discovery, COMMIT_AFTER_STEPS=1), so forcing max one call matches
+//     intent everywhere. Only sent when tools are present — strict servers
+//     reject the field on tool-less requests.
 export function openAICompatibleFetch(cfg: any, baseFetch: any = fetch) {
   const penalty = appliedRepeatPenalty(cfg);
   const noThink = cfg?.reasoning !== true;
@@ -124,6 +132,10 @@ export function openAICompatibleFetch(cfg: any, baseFetch: any = fetch) {
             enable_thinking: false,
           };
           if (body.reasoning_format === undefined) body.reasoning_format = 'deepseek';
+        }
+        if (Array.isArray(body.tools) && body.tools.length > 0 &&
+            body.parallel_tool_calls === undefined) {
+          body.parallel_tool_calls = false;
         }
         init = { ...init, body: JSON.stringify(body) };
       } catch { /* not JSON — leave the request untouched */ }


### PR DESCRIPTION
Fixes #940.

## Problem

On the `openai-compatible` / `locca` path (self-hosted `llama-server`), Subwave never sends `parallel_tool_calls`. When the field is absent, llama.cpp resolves it from the chat template's capability default — `true` for Gemma-4-family templates — so the grammar permits multiple tool calls per turn. Models that take that option (Gemma-4 does, at the agent's step-0 discovery where all tools are exposed with `toolChoice:'required'`) emit several well-formed calls in one turn, and llama.cpp's `peg-gemma4` parser 500s on call #2, failing the whole `djAgentPick` / `djAgentSegment` attempt.

## Fix

Inject `parallel_tool_calls: false` in `openAICompatibleFetch` — the same request-body-rewrite chokepoint that already carries `repeat_penalty` and `enable_thinking`/`reasoning_format` (#918). Two guards:

- **tools present** — strict OpenAI-compatible servers reject the field on tool-less requests;
- **`=== undefined`** — never clobber an explicitly-set value, matching the wrapper's existing `repeat_penalty` convention. The broken case is *absence*, which still gets `false`.

This enforces the agent's existing design rather than changing it: gated discovery + `COMMIT_AFTER_STEPS = 1` already assume one tool call per step; the wire request just never said so.

Scoped to the openai-compatible/locca transport only — Ollama and cloud providers are untouched.

## Verification

- `npm run lint` (controller): 0 errors.
- Reporter hot-patched this exact change in their running container: confirmed `"parallel_tool_calls": false` on the wire via raw-request logging, and the `common_chat_peg_parse: unparsed peg-gemma4 output` 500s stopped across picks/segments.

Credit to @magicguitarist for the excellent report and root-cause analysis.