### PR TITLE
fix(llm): GLM structured-output fixes with object-level payload coercion (supersedes #923)

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -10,7 +10,7 @@ import assert from 'node:assert/strict';
 import { z } from 'zod';
 import { generateText, APICallError } from 'ai';
 import { MockLanguageModelV3 } from 'ai/test';
-import { stripThinking, extractJson, usageOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded, isRateLimited, errReason, nearestId, nullableFromModel, objectFromModel, schemaHint } from '../src/llm/internal/core/pure.js';
+import { stripThinking, extractJson, usageOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded, isRateLimited, errReason, nearestId, modelTolerant, schemaHint } from '../src/llm/internal/core/pure.js';
 import { withDeadline, withTransientRetry, retryAfterMs } from '../src/llm/internal/core/retry.js';
 import { providerOptions, needsToolCallObject, repeatPenaltyApplies, appliedNumCtx, appliedRepeatPenalty, forcedToolChoice } from '../src/llm/internal/provider/capabilities.js';
 import { agentPlan } from '../src/llm/internal/strategy/plan.js';
@@ -777,95 +777,109 @@ async function main() {
     assert.equal(nearestId('abcdef123456789012345', []), null);
   });
 
-  console.log('nullableFromModel (coerce the string "null", an omitted key, or a double-JSON-encoded string some providers send instead of JSON null):');
-  await test('an object schema: the string "null" coerces to real null', () => {
-    const schema = nullableFromModel(z.object({ kind: z.string() }));
-    assert.deepEqual(schema.parse('null'), null);
+  // Miniature twins of the real agent schemas (PICK_SCHEMA / segmentSchema)
+  // — same field shapes, same wrapper placement — so these tests pin the
+  // mechanism the live schemas rely on without importing modules that carry
+  // side effects (dj-agent.ts pulls in settings/queue).
+  const pickLike = () => modelTolerant(z.object({
+    id: z.string().describe('the exact id'),
+    reason: z.string(),
+    say: z.string().nullable().describe('spoken line or null'),
+    transition: z.enum(['normal', 'blend']).nullable().describe('transition'),
+  }));
+  const SEGMENT_FALLBACK = { kind: '', text: '', sfx: null };
+  const segmentLike = (onDiscard?: (field: string, value: unknown) => void) => modelTolerant(z.object({
+    reason: z.string(),
+    air: z.boolean(),
+    segment: z.object({
+      kind: z.string(),
+      text: z.string(),
+      sfx: z.string().nullable(),
+    }),
+  }), { objectFallbacks: { segment: { ...SEGMENT_FALLBACK } }, onDiscard });
+
+  console.log('modelTolerant / coerceModelPayload (object-level rescue of GLM\'s malformed shapes — the string "null", an omitted key, a double-JSON-encoded object):');
+  await test('the string "null" coerces to real null for nullable string and enum fields', () => {
+    const parsed: any = pickLike().parse({ id: 'a', reason: 'r', say: 'null', transition: 'null' });
+    assert.equal(parsed.say, null);
+    assert.equal(parsed.transition, null);
   });
-  await test('an enum schema: the string "null" coerces to real null', () => {
-    const schema = nullableFromModel(z.enum(['normal', 'blend']));
-    assert.deepEqual(schema.parse('null'), null);
+  await test('an omitted nullable key coerces to null (observed: `done` with `say`/`transition` entirely absent)', () => {
+    const parsed: any = pickLike().parse({ id: 'a', reason: 'r' });
+    assert.deepEqual(parsed, { id: 'a', reason: 'r', say: null, transition: null });
   });
-  await test('genuine JSON null still passes through unchanged', () => {
-    const schema = nullableFromModel(z.object({ kind: z.string() }));
-    assert.deepEqual(schema.parse(null), null);
-  });
-  await test('a genuinely valid value still passes through unchanged', () => {
-    const objSchema = nullableFromModel(z.object({ kind: z.string() }));
-    assert.deepEqual(objSchema.parse({ kind: 'weather' }), { kind: 'weather' });
-    const enumSchema = nullableFromModel(z.enum(['normal', 'blend']));
-    assert.equal(enumSchema.parse('blend'), 'blend');
-  });
-  await test('a genuinely valid string value still passes through unchanged', () => {
-    const schema = nullableFromModel(z.string());
-    assert.equal(schema.parse('a spoken line'), 'a spoken line');
+  await test('genuine JSON null and genuinely valid values pass through unchanged', () => {
+    const parsed: any = pickLike().parse({ id: 'a', reason: 'r', say: 'a spoken line', transition: null });
+    assert.equal(parsed.say, 'a spoken line');
+    assert.equal(parsed.transition, null);
+    assert.equal((pickLike().parse({ id: 'a', reason: 'r', say: null, transition: 'blend' }) as any).transition, 'blend');
   });
   await test('does not widen validation beyond observed junk — other junk still rejects', () => {
-    const schema = nullableFromModel(z.enum(['normal', 'blend']));
-    assert.throws(() => schema.parse('None'));
-    assert.throws(() => schema.parse('nonexistent-transition'));
+    assert.throws(() => pickLike().parse({ id: 'a', reason: 'r', say: null, transition: 'None' }));
+    assert.throws(() => pickLike().parse({ id: 'a', reason: 'r', say: null, transition: 'nonexistent-transition' }));
   });
-  await test('an omitted key (undefined) coerces to null, same as an explicit null (observed: a `done` call with `segment` entirely absent)', () => {
-    const schema = z.object({
-      reason: z.string(),
-      air: z.boolean(),
-      segment: nullableFromModel(z.object({ kind: z.string(), text: z.string() })),
-    });
-    const parsed = schema.parse({ reason: 'nothing fresh to say', air: false });
-    assert.deepEqual(parsed, { reason: 'nothing fresh to say', air: false, segment: null });
+  await test('a REQUIRED (non-nullable) string field is untouched — an omitted `id`/`reason` still rejects', () => {
+    assert.throws(() => pickLike().parse({ say: null, transition: null }));
   });
-  await test('an omitted key coerces to null for a nullable string field too', () => {
-    const schema = z.object({ id: z.string(), say: nullableFromModel(z.string()) });
-    const parsed = schema.parse({ id: 'abc' });
-    assert.deepEqual(parsed, { id: 'abc', say: null });
+  await test('does NOT JSON-parse a nullable STRING field — a coincidental JSON-looking answer stays a plain string', () => {
+    const parsed: any = pickLike().parse({ id: 'a', reason: 'r', say: '42', transition: null });
+    assert.equal(parsed.say, '42');
+    assert.equal((pickLike().parse({ id: 'a', reason: 'r', say: 'true', transition: null }) as any).say, 'true');
   });
-  await test('a nested object double-encoded as a JSON string parses through (observed: `done`\'s segment field)', () => {
-    const schema = z.object({
-      reason: z.string(),
-      air: z.boolean(),
-      segment: nullableFromModel(z.object({ kind: z.string(), text: z.string(), sfx: nullableFromModel(z.string()) })),
-    });
-    const parsed = schema.parse({
+  await test('a nested object double-encoded as a JSON string parses through, recursing so its own nullable fields are repaired too', () => {
+    const parsed: any = segmentLike().parse({
       reason: 'x',
       air: true,
-      segment: JSON.stringify({ kind: 'now-playing-dig', sfx: null, text: 'a real line' }),
+      segment: JSON.stringify({ kind: 'now-playing-dig', sfx: 'null', text: 'a real line' }),
     });
     assert.deepEqual(parsed.segment, { kind: 'now-playing-dig', sfx: null, text: 'a real line' });
   });
-  await test('does NOT attempt JSON-string parsing for a nullable STRING field — a coincidental JSON-looking answer stays a plain string', () => {
-    const schema = nullableFromModel(z.string());
-    assert.equal(schema.parse('42'), '42');
-    assert.equal(schema.parse('true'), 'true');
+
+  console.log('modelTolerant objectFallbacks (required object field, must never throw) + onDiscard:');
+  await test('a genuinely valid segment passes through unchanged', () => {
+    const parsed: any = segmentLike().parse({ reason: 'r', air: true, segment: { kind: 'weather', text: 'hi', sfx: null } });
+    assert.deepEqual(parsed.segment, { kind: 'weather', text: 'hi', sfx: null });
   });
-  await test('a string that fails to parse as JSON for an object field still rejects (not silently swallowed)', () => {
-    const schema = z.object({ segment: nullableFromModel(z.object({ kind: z.string() })) });
-    assert.throws(() => schema.parse({ segment: 'not json at all' }));
+  await test('a missing segment key falls back to the placeholder instead of throwing — and does NOT report a discard (the model said nothing)', () => {
+    const discards: any[] = [];
+    const parsed: any = segmentLike((f, v) => discards.push([f, v])).parse({ reason: 'nothing fresh to say', air: false });
+    assert.deepEqual(parsed.segment, SEGMENT_FALLBACK);
+    assert.deepEqual(discards, []);
+  });
+  await test('the string "null" falls back to the placeholder, no discard reported', () => {
+    const discards: any[] = [];
+    const parsed: any = segmentLike((f, v) => discards.push([f, v])).parse({ reason: 'r', air: false, segment: 'null' });
+    assert.deepEqual(parsed.segment, SEGMENT_FALLBACK);
+    assert.deepEqual(discards, []);
+  });
+  await test('unparseable garbage falls back to the placeholder AND reports the discard (content was thrown away)', () => {
+    const discards: any[] = [];
+    const parsed: any = segmentLike((f, v) => discards.push([f, v])).parse({ reason: 'r', air: true, segment: 'not json at all' });
+    assert.deepEqual(parsed.segment, SEGMENT_FALLBACK);
+    assert.deepEqual(discards, [['segment', 'not json at all']]);
+  });
+  await test('a partially-valid segment (one bad field) falls back and reports the discard', () => {
+    const discards: any[] = [];
+    const parsed: any = segmentLike((f, v) => discards.push([f, v])).parse({ reason: 'r', air: true, segment: { kind: 'weather', text: 42, sfx: null } });
+    assert.deepEqual(parsed.segment, SEGMENT_FALLBACK);
+    assert.equal(discards.length, 1);
   });
 
-  console.log('objectFromModel (the non-nullable sibling — required object field, must never throw):');
-  await test('a genuinely valid value passes through unchanged', () => {
-    const schema = objectFromModel({ kind: z.string(), text: z.string() }, { kind: '', text: '' });
-    assert.deepEqual(schema.parse({ kind: 'weather', text: 'hi' }), { kind: 'weather', text: 'hi' });
+  console.log('modelTolerant wire schema (the regression that motivated object-level placement — AI SDK renders tool inputSchemas with io:\'input\', where a per-field preprocess silently drops the field from `required`):');
+  await test('every field stays in `required` under io:\'input\' — identical to the plain object schema', () => {
+    const rendered: any = z.toJSONSchema(pickLike(), { target: 'draft-7', io: 'input' });
+    assert.deepEqual(rendered.required.sort(), ['id', 'reason', 'say', 'transition']);
+    // Nullable-ness and enum values survive too — the model still sees the contract.
+    assert.deepEqual(rendered.properties.say.anyOf.map((b: any) => b.type).sort(), ['null', 'string']);
+    assert.deepEqual(rendered.properties.transition.anyOf[0].enum, ['normal', 'blend']);
+    // Field descriptions still travel (they are the model's primary coaching channel).
+    assert.equal(rendered.properties.id.description, 'the exact id');
   });
-  await test('a double-JSON-encoded string still rescues the real content', () => {
-    const schema = objectFromModel(
-      { kind: z.string(), text: z.string(), sfx: nullableFromModel(z.string()) },
-      { kind: '', text: '', sfx: null },
-    );
-    const parsed = schema.parse(JSON.stringify({ kind: 'now-playing-dig', sfx: null, text: 'a real line' }));
-    assert.deepEqual(parsed, { kind: 'now-playing-dig', sfx: null, text: 'a real line' });
-  });
-  await test('a missing key falls back to the placeholder instead of throwing', () => {
-    const schema = objectFromModel({ kind: z.string(), text: z.string() }, { kind: '', text: '' });
-    assert.deepEqual(schema.parse(undefined), { kind: '', text: '' });
-  });
-  await test('the string "null" falls back to the placeholder instead of throwing', () => {
-    const schema = objectFromModel({ kind: z.string(), text: z.string() }, { kind: '', text: '' });
-    assert.deepEqual(schema.parse('null'), { kind: '', text: '' });
-  });
-  await test('unparseable garbage falls back to the placeholder instead of throwing', () => {
-    const schema = objectFromModel({ kind: z.string(), text: z.string() }, { kind: '', text: '' });
-    assert.deepEqual(schema.parse('not json at all'), { kind: '', text: '' });
+  await test('objectFallbacks does not leak a visible "default" into the schema (a field-level .catch() would)', () => {
+    const rendered: any = z.toJSONSchema(segmentLike(), { target: 'draft-7', io: 'input' });
+    assert.deepEqual(rendered.required.sort(), ['air', 'reason', 'segment']);
+    assert.equal(JSON.stringify(rendered).includes('"default"'), false);
+    assert.deepEqual(rendered.properties.segment.required.sort(), ['kind', 'sfx', 'text']);
   });
 
   console.log('schemaHint (JSON Schema embedded in djObject\'s free-text recovery prompt):');

--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -7,9 +7,10 @@
 // node:assert-via-tsx style of scripts/picker-recency-regression.test.ts.
 
 import assert from 'node:assert/strict';
+import { z } from 'zod';
 import { generateText, APICallError } from 'ai';
 import { MockLanguageModelV3 } from 'ai/test';
-import { stripThinking, extractJson, usageOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded, isRateLimited, errReason, nearestId } from '../src/llm/internal/core/pure.js';
+import { stripThinking, extractJson, usageOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded, isRateLimited, errReason, nearestId, nullableFromModel, objectFromModel, schemaHint } from '../src/llm/internal/core/pure.js';
 import { withDeadline, withTransientRetry, retryAfterMs } from '../src/llm/internal/core/retry.js';
 import { providerOptions, needsToolCallObject, repeatPenaltyApplies, appliedNumCtx, appliedRepeatPenalty, forcedToolChoice } from '../src/llm/internal/provider/capabilities.js';
 import { agentPlan } from '../src/llm/internal/strategy/plan.js';
@@ -774,6 +775,128 @@ async function main() {
     assert.equal(nearestId('', ['abcdef123456789012345']), null);
     assert.equal(nearestId(undefined as any, ['abcdef123456789012345']), null);
     assert.equal(nearestId('abcdef123456789012345', []), null);
+  });
+
+  console.log('nullableFromModel (coerce the string "null", an omitted key, or a double-JSON-encoded string some providers send instead of JSON null):');
+  await test('an object schema: the string "null" coerces to real null', () => {
+    const schema = nullableFromModel(z.object({ kind: z.string() }));
+    assert.deepEqual(schema.parse('null'), null);
+  });
+  await test('an enum schema: the string "null" coerces to real null', () => {
+    const schema = nullableFromModel(z.enum(['normal', 'blend']));
+    assert.deepEqual(schema.parse('null'), null);
+  });
+  await test('genuine JSON null still passes through unchanged', () => {
+    const schema = nullableFromModel(z.object({ kind: z.string() }));
+    assert.deepEqual(schema.parse(null), null);
+  });
+  await test('a genuinely valid value still passes through unchanged', () => {
+    const objSchema = nullableFromModel(z.object({ kind: z.string() }));
+    assert.deepEqual(objSchema.parse({ kind: 'weather' }), { kind: 'weather' });
+    const enumSchema = nullableFromModel(z.enum(['normal', 'blend']));
+    assert.equal(enumSchema.parse('blend'), 'blend');
+  });
+  await test('a genuinely valid string value still passes through unchanged', () => {
+    const schema = nullableFromModel(z.string());
+    assert.equal(schema.parse('a spoken line'), 'a spoken line');
+  });
+  await test('does not widen validation beyond observed junk — other junk still rejects', () => {
+    const schema = nullableFromModel(z.enum(['normal', 'blend']));
+    assert.throws(() => schema.parse('None'));
+    assert.throws(() => schema.parse('nonexistent-transition'));
+  });
+  await test('an omitted key (undefined) coerces to null, same as an explicit null (observed: a `done` call with `segment` entirely absent)', () => {
+    const schema = z.object({
+      reason: z.string(),
+      air: z.boolean(),
+      segment: nullableFromModel(z.object({ kind: z.string(), text: z.string() })),
+    });
+    const parsed = schema.parse({ reason: 'nothing fresh to say', air: false });
+    assert.deepEqual(parsed, { reason: 'nothing fresh to say', air: false, segment: null });
+  });
+  await test('an omitted key coerces to null for a nullable string field too', () => {
+    const schema = z.object({ id: z.string(), say: nullableFromModel(z.string()) });
+    const parsed = schema.parse({ id: 'abc' });
+    assert.deepEqual(parsed, { id: 'abc', say: null });
+  });
+  await test('a nested object double-encoded as a JSON string parses through (observed: `done`\'s segment field)', () => {
+    const schema = z.object({
+      reason: z.string(),
+      air: z.boolean(),
+      segment: nullableFromModel(z.object({ kind: z.string(), text: z.string(), sfx: nullableFromModel(z.string()) })),
+    });
+    const parsed = schema.parse({
+      reason: 'x',
+      air: true,
+      segment: JSON.stringify({ kind: 'now-playing-dig', sfx: null, text: 'a real line' }),
+    });
+    assert.deepEqual(parsed.segment, { kind: 'now-playing-dig', sfx: null, text: 'a real line' });
+  });
+  await test('does NOT attempt JSON-string parsing for a nullable STRING field — a coincidental JSON-looking answer stays a plain string', () => {
+    const schema = nullableFromModel(z.string());
+    assert.equal(schema.parse('42'), '42');
+    assert.equal(schema.parse('true'), 'true');
+  });
+  await test('a string that fails to parse as JSON for an object field still rejects (not silently swallowed)', () => {
+    const schema = z.object({ segment: nullableFromModel(z.object({ kind: z.string() })) });
+    assert.throws(() => schema.parse({ segment: 'not json at all' }));
+  });
+
+  console.log('objectFromModel (the non-nullable sibling — required object field, must never throw):');
+  await test('a genuinely valid value passes through unchanged', () => {
+    const schema = objectFromModel({ kind: z.string(), text: z.string() }, { kind: '', text: '' });
+    assert.deepEqual(schema.parse({ kind: 'weather', text: 'hi' }), { kind: 'weather', text: 'hi' });
+  });
+  await test('a double-JSON-encoded string still rescues the real content', () => {
+    const schema = objectFromModel(
+      { kind: z.string(), text: z.string(), sfx: nullableFromModel(z.string()) },
+      { kind: '', text: '', sfx: null },
+    );
+    const parsed = schema.parse(JSON.stringify({ kind: 'now-playing-dig', sfx: null, text: 'a real line' }));
+    assert.deepEqual(parsed, { kind: 'now-playing-dig', sfx: null, text: 'a real line' });
+  });
+  await test('a missing key falls back to the placeholder instead of throwing', () => {
+    const schema = objectFromModel({ kind: z.string(), text: z.string() }, { kind: '', text: '' });
+    assert.deepEqual(schema.parse(undefined), { kind: '', text: '' });
+  });
+  await test('the string "null" falls back to the placeholder instead of throwing', () => {
+    const schema = objectFromModel({ kind: z.string(), text: z.string() }, { kind: '', text: '' });
+    assert.deepEqual(schema.parse('null'), { kind: '', text: '' });
+  });
+  await test('unparseable garbage falls back to the placeholder instead of throwing', () => {
+    const schema = objectFromModel({ kind: z.string(), text: z.string() }, { kind: '', text: '' });
+    assert.deepEqual(schema.parse('not json at all'), { kind: '', text: '' });
+  });
+
+  console.log('schemaHint (JSON Schema embedded in djObject\'s free-text recovery prompt):');
+  await test('renders required keys for a flat object schema', () => {
+    const schema = z.object({ id: z.string(), reason: z.string(), say: z.string().nullable() });
+    const hint = schemaHint(schema);
+    assert.equal(typeof hint, 'string');
+    const parsed = JSON.parse(hint as string);
+    assert.deepEqual(parsed.required.sort(), ['id', 'reason', 'say']);
+  });
+  await test('never throws on a schema it cannot render — returns null instead', () => {
+    // z.custom with no shape metadata is the sharpest edge toJSONSchema can hit.
+    const schema = z.custom(() => true);
+    assert.doesNotThrow(() => schemaHint(schema as any));
+  });
+  await test('strips verbose .describe() text so the recovery prompt stays lean', () => {
+    const longDescription = 'x'.repeat(500);
+    const schema = z.object({
+      id: z.string().describe('the exact id'),
+      transition: z.enum(['normal', 'blend']).nullable().describe(longDescription),
+    });
+    const hint = schemaHint(schema) as string;
+    // The structure (keys, types, required-ness) must survive...
+    const parsed = JSON.parse(hint);
+    assert.ok(parsed.properties.id);
+    assert.ok(parsed.properties.transition);
+    assert.deepEqual(parsed.required.sort(), ['id', 'transition']);
+    // ...but none of the description prose, at any nesting depth, does.
+    assert.equal(hint.includes(longDescription), false);
+    assert.equal(hint.includes('the exact id'), false);
+    assert.equal(hint.includes('"description"'), false);
   });
 
   console.log(failures === 0 ? '\nAll llm-pure tests passed.' : `\n${failures} test(s) FAILED.`);

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -22,7 +22,7 @@ import * as journey from '../music/journey.js';
 import * as dj from '../llm/dj.js';
 import { energyForDaypart } from '../context.js';
 import { defineAgent } from '../llm/agent.js';
-import { djObject, nearestId } from '../llm/sdk.js';
+import { djObject, nearestId, nullableFromModel } from '../llm/sdk.js';
 import { buildPickerTools } from '../llm/tools.js';
 import { recordPick } from '../llm/log.js';
 import * as budget from './dj-budget.js';
@@ -166,9 +166,15 @@ export function runActive(): boolean {
 export const PICK_SCHEMA = z.object({
   id: z.string().describe('the exact song id returned by one of the discovery tools — never invent or compose ids'),
   reason: z.string().describe('internal scratchpad only — max 12 words, never shown to the listener; do not justify, just note what makes THIS pick a fresh step (new artist, a shift in energy/era/texture), not a vibe label you would recycle pick after pick (e.g. "new artist, lifts the energy", never a repeated "mellow reflective step")'),
-  say: z.string().nullable().describe('when the latest event message says to write a spoken link, set this to one or two natural sentences in the DJ voice that INTRODUCE the track you are about to play — set it up, name the artist or capture its feel, vary your opener. Do NOT back-announce, recap, or name the track that just played (a listener request may slip in ahead of your pick, so what aired right before it is not certain). Never state a clock time unless the event message tells you when the link airs — then use exactly that time. When the event says stay silent, set this to null'),
+  // nullableFromModel: a nullable field the model can also just OMIT
+  // entirely, or double-encode as a JSON string, when there's nothing to say
+  // — see the comment on nullableFromModel itself (core/pure.ts).
+  say: nullableFromModel(z.string()).describe('when the latest event message says to write a spoken link, set this to one or two natural sentences in the DJ voice that INTRODUCE the track you are about to play — set it up, name the artist or capture its feel, vary your opener. Do NOT back-announce, recap, or name the track that just played (a listener request may slip in ahead of your pick, so what aired right before it is not certain). Never state a clock time unless the event message tells you when the link airs — then use exactly that time. When the event says stay silent, set this to null'),
   // Transition effects (only honoured when the system prompt offers them — persona djMode, see settings.effectsActive).
-  transition: z.enum(['normal', 'blend', 'sweep', 'washout', 'dissolve', 'chop', 'loop']).nullable().describe('transition treatment for this pick: "blend" — spectral handover: your pick and the track before it trade the spectrum in complementary bands across a long crossfade so they feel like ONE continuous piece; reserve it for an exceptionally locked pair (near-identical tempo, close key) — a plain crossfade already handles an ordinary same-lane pick, so this should be an occasional call, not your default. "sweep" — the track playing before your pick sinks under a slowly closing filter while your pick rises clean; choose it for a real gear-change (big jump in energy, tempo, or mood). "washout" — THIS pick dissolves into a pulsing echo tail as it ENDS, ringing out into whatever follows; choose it to close a chapter (end of a themed run, before a talk break, or out of a dreamy track). "dissolve" — the track playing before your pick melts into a diffuse ambient wash as your pick rises clean through it; the SMOOTH way across a clash (sweep is the dramatic way) — choose it for a tempo/mood mismatch you want to hide rather than announce. "chop" — the track playing before your pick is cut rhythmically on its own beat, stabs thinning out as your pick rises through the gaps; the PERCUSSIVE way across a clash — choose it to jump energy UP on a beat-driven track (a drop, a takeover moment), never out of something ambient. "loop" — THIS pick\'s last bar is caught in a tempo-synced loop as it ENDS, repeating hypnotically under the next track before it cuts away; choose it to leave a groove-driven track with intent — a great riff, a locked drum pattern, the end of a rhythmic run (it needs the track\'s measured tempo; the station drops it otherwise). "normal" or null for a plain crossfade'),
+  // nullableFromModel: GLM observed sending the STRING "null" for a nullable
+  // enum field, which satisfies neither the enum nor the null branch of a
+  // plain .nullable() and fails validation outright — coerce it.
+  transition: nullableFromModel(z.enum(['normal', 'blend', 'sweep', 'washout', 'dissolve', 'chop', 'loop'])).describe('transition treatment for this pick: "blend" — spectral handover: your pick and the track before it trade the spectrum in complementary bands across a long crossfade so they feel like ONE continuous piece; reserve it for an exceptionally locked pair (near-identical tempo, close key) — a plain crossfade already handles an ordinary same-lane pick, so this should be an occasional call, not your default. "sweep" — the track playing before your pick sinks under a slowly closing filter while your pick rises clean; choose it for a real gear-change (big jump in energy, tempo, or mood). "washout" — THIS pick dissolves into a pulsing echo tail as it ENDS, ringing out into whatever follows; choose it to close a chapter (end of a themed run, before a talk break, or out of a dreamy track). "dissolve" — the track playing before your pick melts into a diffuse ambient wash as your pick rises clean through it; the SMOOTH way across a clash (sweep is the dramatic way) — choose it for a tempo/mood mismatch you want to hide rather than announce. "chop" — the track playing before your pick is cut rhythmically on its own beat, stabs thinning out as your pick rises through the gaps; the PERCUSSIVE way across a clash — choose it to jump energy UP on a beat-driven track (a drop, a takeover moment), never out of something ambient. "loop" — THIS pick\'s last bar is caught in a tempo-synced loop as it ENDS, repeating hypnotically under the next track before it cuts away; choose it to leave a groove-driven track with intent — a great riff, a locked drum pattern, the end of a rhythmic run (it needs the track\'s measured tempo; the station drops it otherwise). "normal" or null for a plain crossfade'),
 });
 
 // Same shape, transition coaching stripped. Zod field descriptions travel to
@@ -178,7 +184,7 @@ export const PICK_SCHEMA = z.object({
 // the LLM log showed effects that could never air. The enum stays identical
 // (validation must not depend on persona state); only the description flips.
 export const PICK_SCHEMA_NO_FX = PICK_SCHEMA.extend({
-  transition: z.enum(['normal', 'blend', 'sweep', 'washout', 'dissolve', 'chop', 'loop']).nullable().describe('always set to null — transition effects are not available for this persona'),
+  transition: nullableFromModel(z.enum(['normal', 'blend', 'sweep', 'washout', 'dissolve', 'chop', 'loop'])).describe('always set to null — transition effects are not available for this persona'),
 });
 
 // The live pick schema, resolved per run: the transition coaching follows the
@@ -190,7 +196,7 @@ export const PICK_SCHEMA_NO_FX = PICK_SCHEMA.extend({
 export function pickSchema() {
   const base = settings.effectsActive() ? PICK_SCHEMA : PICK_SCHEMA_NO_FX;
   return base.extend({
-    say: z.string().nullable().describe(`when the latest event message says to write a spoken link, set this to ${dj.lengthPhrase('link')} of natural speech in the DJ voice that INTRODUCE the track you are about to play — set it up, name the artist or capture its feel, vary your opener. Do NOT back-announce, recap, or name the track that just played (a listener request may slip in ahead of your pick, so what aired right before it is not certain). Never state a clock time unless the event message tells you when the link airs — then use exactly that time. When the event says stay silent, set this to null`),
+    say: nullableFromModel(z.string()).describe(`when the latest event message says to write a spoken link, set this to ${dj.lengthPhrase('link')} of natural speech in the DJ voice that INTRODUCE the track you are about to play — set it up, name the artist or capture its feel, vary your opener. Do NOT back-announce, recap, or name the track that just played (a listener request may slip in ahead of your pick, so what aired right before it is not certain). Never state a clock time unless the event message tells you when the link airs — then use exactly that time. When the event says stay silent, set this to null`),
   });
 }
 
@@ -319,8 +325,9 @@ function breakerFailure(queue: any) {
 // `pickerAgent.maxSteps` / `pickerAgent.timeoutMs` so test runs match prod
 // without drifting. The hard timeout is what fails fast into the stateless
 // fallback below instead of dragging on a pathological model call — enforced
-// by withDeadline in llm/sdk.ts (main + recovery runs each get the full
-// budget, so worst case per agent call is ~2× this). It comes from
+// by runDeadlined's shared deadline in agent.ts (native run, main run, and
+// both recovery attempts all draw down the SAME overall budget, so worst
+// case per agent call is this value, not a multiple of it). It comes from
 // settings.llm.agentTimeoutMs (default 45s, admin-tunable) — slow
 // reasoning-heavy cloud models routinely need 20-40s per pick, and a pick has
 // a whole track length of slack; the deadline exists to contain the unbounded
@@ -335,9 +342,18 @@ export const pickerAgent = defineAgent({
   // the on-air persona's djMode, and the say length its scriptLength — same
   // reason effectsGuidance() is dynamic. See pickSchema above.
   schema: () => pickSchema(),
-  // The done-tool path ends the loop at step 1 (COMMIT_AFTER_STEPS in sdk.js)
-  // on every provider now; maxSteps is just the backstop.
-  maxSteps: 4,
+  // The done-tool path is meant to end the loop at step 1 (COMMIT_AFTER_STEPS
+  // in agent.ts): step 0 discovers, step 1 commits. That held for every
+  // provider UNTIL GLM (Zhipu/Z.ai) — it can decline the forced `done` call
+  // repeatedly within the SAME conversation rather than complying on the first
+  // attempt, so a taller maxSteps stopped being a rarely-hit backstop and
+  // became a real (and wasted) retry budget: each extra step just grows an
+  // increasingly "I already declined" trail, which made compliance WORSE, not
+  // better, in testing. 2 keeps the main run to exactly discovery + one
+  // committed attempt and hands off to agent.ts's own two-tier recovery (which
+  // includes a clean-context retry) sooner — recovery is the mechanism that
+  // actually rescues these, not more steps on a polluted trail.
+  maxSteps: 2,
   timeoutMs: agentDeadline,
   buildSystem: ({ showAt }: any = {}) => pickSystem(showAt ?? null),
   buildTools: ({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, playlistLock, playlistTracks, excludedIds, showAt }) => {
@@ -374,7 +390,8 @@ export const requestAgent = defineAgent({
   // Function form — resolved per run so the intro length follows the on-air
   // persona's scriptLength (see requestSchema).
   schema: () => requestSchema(),
-  maxSteps: 4,
+  // See pickerAgent.maxSteps above — same reasoning.
+  maxSteps: 2,
   timeoutMs: agentDeadline,
   buildSystem: () => requestSystem(),
   // resolveReferences adds the web-backed reference resolver (request path only;

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -22,7 +22,7 @@ import * as journey from '../music/journey.js';
 import * as dj from '../llm/dj.js';
 import { energyForDaypart } from '../context.js';
 import { defineAgent } from '../llm/agent.js';
-import { djObject, nearestId, nullableFromModel } from '../llm/sdk.js';
+import { djObject, nearestId, modelTolerant } from '../llm/sdk.js';
 import { buildPickerTools } from '../llm/tools.js';
 import { recordPick } from '../llm/log.js';
 import * as budget from './dj-budget.js';
@@ -163,18 +163,19 @@ export function runActive(): boolean {
   return !!(runState && runState.remaining > 0);
 }
 
+// Plain .nullable() fields, deliberately — GLM's malformed spellings of
+// "nothing" (the string "null", an omitted key, a double-JSON-encoded object)
+// are repaired by the modelTolerant wrapper in pickSchema() below, at the
+// OBJECT level. Do not wrap individual fields in a preprocess: a per-field
+// pipe drops that field from the tool inputSchema's `required` array (the AI
+// SDK renders Zod with io:'input'), which invites every provider to omit it —
+// see modelTolerant's comment in core/pure.ts.
 export const PICK_SCHEMA = z.object({
   id: z.string().describe('the exact song id returned by one of the discovery tools — never invent or compose ids'),
   reason: z.string().describe('internal scratchpad only — max 12 words, never shown to the listener; do not justify, just note what makes THIS pick a fresh step (new artist, a shift in energy/era/texture), not a vibe label you would recycle pick after pick (e.g. "new artist, lifts the energy", never a repeated "mellow reflective step")'),
-  // nullableFromModel: a nullable field the model can also just OMIT
-  // entirely, or double-encode as a JSON string, when there's nothing to say
-  // — see the comment on nullableFromModel itself (core/pure.ts).
-  say: nullableFromModel(z.string()).describe('when the latest event message says to write a spoken link, set this to one or two natural sentences in the DJ voice that INTRODUCE the track you are about to play — set it up, name the artist or capture its feel, vary your opener. Do NOT back-announce, recap, or name the track that just played (a listener request may slip in ahead of your pick, so what aired right before it is not certain). Never state a clock time unless the event message tells you when the link airs — then use exactly that time. When the event says stay silent, set this to null'),
+  say: z.string().nullable().describe('when the latest event message says to write a spoken link, set this to one or two natural sentences in the DJ voice that INTRODUCE the track you are about to play — set it up, name the artist or capture its feel, vary your opener. Do NOT back-announce, recap, or name the track that just played (a listener request may slip in ahead of your pick, so what aired right before it is not certain). Never state a clock time unless the event message tells you when the link airs — then use exactly that time. When the event says stay silent, set this to null'),
   // Transition effects (only honoured when the system prompt offers them — persona djMode, see settings.effectsActive).
-  // nullableFromModel: GLM observed sending the STRING "null" for a nullable
-  // enum field, which satisfies neither the enum nor the null branch of a
-  // plain .nullable() and fails validation outright — coerce it.
-  transition: nullableFromModel(z.enum(['normal', 'blend', 'sweep', 'washout', 'dissolve', 'chop', 'loop'])).describe('transition treatment for this pick: "blend" — spectral handover: your pick and the track before it trade the spectrum in complementary bands across a long crossfade so they feel like ONE continuous piece; reserve it for an exceptionally locked pair (near-identical tempo, close key) — a plain crossfade already handles an ordinary same-lane pick, so this should be an occasional call, not your default. "sweep" — the track playing before your pick sinks under a slowly closing filter while your pick rises clean; choose it for a real gear-change (big jump in energy, tempo, or mood). "washout" — THIS pick dissolves into a pulsing echo tail as it ENDS, ringing out into whatever follows; choose it to close a chapter (end of a themed run, before a talk break, or out of a dreamy track). "dissolve" — the track playing before your pick melts into a diffuse ambient wash as your pick rises clean through it; the SMOOTH way across a clash (sweep is the dramatic way) — choose it for a tempo/mood mismatch you want to hide rather than announce. "chop" — the track playing before your pick is cut rhythmically on its own beat, stabs thinning out as your pick rises through the gaps; the PERCUSSIVE way across a clash — choose it to jump energy UP on a beat-driven track (a drop, a takeover moment), never out of something ambient. "loop" — THIS pick\'s last bar is caught in a tempo-synced loop as it ENDS, repeating hypnotically under the next track before it cuts away; choose it to leave a groove-driven track with intent — a great riff, a locked drum pattern, the end of a rhythmic run (it needs the track\'s measured tempo; the station drops it otherwise). "normal" or null for a plain crossfade'),
+  transition: z.enum(['normal', 'blend', 'sweep', 'washout', 'dissolve', 'chop', 'loop']).nullable().describe('transition treatment for this pick: "blend" — spectral handover: your pick and the track before it trade the spectrum in complementary bands across a long crossfade so they feel like ONE continuous piece; reserve it for an exceptionally locked pair (near-identical tempo, close key) — a plain crossfade already handles an ordinary same-lane pick, so this should be an occasional call, not your default. "sweep" — the track playing before your pick sinks under a slowly closing filter while your pick rises clean; choose it for a real gear-change (big jump in energy, tempo, or mood). "washout" — THIS pick dissolves into a pulsing echo tail as it ENDS, ringing out into whatever follows; choose it to close a chapter (end of a themed run, before a talk break, or out of a dreamy track). "dissolve" — the track playing before your pick melts into a diffuse ambient wash as your pick rises clean through it; the SMOOTH way across a clash (sweep is the dramatic way) — choose it for a tempo/mood mismatch you want to hide rather than announce. "chop" — the track playing before your pick is cut rhythmically on its own beat, stabs thinning out as your pick rises through the gaps; the PERCUSSIVE way across a clash — choose it to jump energy UP on a beat-driven track (a drop, a takeover moment), never out of something ambient. "loop" — THIS pick\'s last bar is caught in a tempo-synced loop as it ENDS, repeating hypnotically under the next track before it cuts away; choose it to leave a groove-driven track with intent — a great riff, a locked drum pattern, the end of a rhythmic run (it needs the track\'s measured tempo; the station drops it otherwise). "normal" or null for a plain crossfade'),
 });
 
 // Same shape, transition coaching stripped. Zod field descriptions travel to
@@ -184,7 +185,7 @@ export const PICK_SCHEMA = z.object({
 // the LLM log showed effects that could never air. The enum stays identical
 // (validation must not depend on persona state); only the description flips.
 export const PICK_SCHEMA_NO_FX = PICK_SCHEMA.extend({
-  transition: nullableFromModel(z.enum(['normal', 'blend', 'sweep', 'washout', 'dissolve', 'chop', 'loop'])).describe('always set to null — transition effects are not available for this persona'),
+  transition: z.enum(['normal', 'blend', 'sweep', 'washout', 'dissolve', 'chop', 'loop']).nullable().describe('always set to null — transition effects are not available for this persona'),
 });
 
 // The live pick schema, resolved per run: the transition coaching follows the
@@ -193,11 +194,22 @@ export const PICK_SCHEMA_NO_FX = PICK_SCHEMA.extend({
 // persona stretched to 4-6 sentence links on the pool path (generateLink gets
 // lengthPhrase in its prompt) but snapped back to the consts' hard-coded "one
 // or two sentences" whenever the default-on agent picker was doing the talking.
-export function pickSchema() {
+// The plain (un-wrapped) object — for callers that still need to .extend()
+// (repickFromSeen pins `id` to the run's own candidate set). Extend THIS,
+// then re-wrap with modelTolerant; a ZodPreprocess pipe has no .extend.
+function pickSchemaBase() {
   const base = settings.effectsActive() ? PICK_SCHEMA : PICK_SCHEMA_NO_FX;
   return base.extend({
-    say: nullableFromModel(z.string()).describe(`when the latest event message says to write a spoken link, set this to ${dj.lengthPhrase('link')} of natural speech in the DJ voice that INTRODUCE the track you are about to play — set it up, name the artist or capture its feel, vary your opener. Do NOT back-announce, recap, or name the track that just played (a listener request may slip in ahead of your pick, so what aired right before it is not certain). Never state a clock time unless the event message tells you when the link airs — then use exactly that time. When the event says stay silent, set this to null`),
+    say: z.string().nullable().describe(`when the latest event message says to write a spoken link, set this to ${dj.lengthPhrase('link')} of natural speech in the DJ voice that INTRODUCE the track you are about to play — set it up, name the artist or capture its feel, vary your opener. Do NOT back-announce, recap, or name the track that just played (a listener request may slip in ahead of your pick, so what aired right before it is not certain). Never state a clock time unless the event message tells you when the link airs — then use exactly that time. When the event says stay silent, set this to null`),
   });
+}
+
+export function pickSchema() {
+  // modelTolerant repairs GLM's malformed nullable spellings ("null"-the-
+  // string, an omitted key) at the object level, on every parse path (done-
+  // tool args, text salvage) — the wire schema stays identical to the plain
+  // object's, all fields still required. See core/pure.ts.
+  return modelTolerant(pickSchemaBase());
 }
 
 // Resolved per run, like pickSchema: the intro length follows the on-air
@@ -488,9 +500,9 @@ async function enqueuePick(
 async function repickFromSeen({ seen, badId, wantLink }: { seen: Map<string, any>; badId: string | null; wantLink: boolean }) {
   const ids = [...seen.keys()];
   if (ids.length === 0) return null;
-  const schema = pickSchema().extend({
+  const schema = modelTolerant(pickSchemaBase().extend({
     id: z.enum(ids as [string, ...string[]]).describe('the exact id of one candidate'),
-  });
+  }));
   try {
     return await djObject({
       system: pickSystem(),

--- a/controller/src/llm/internal/core/pure.ts
+++ b/controller/src/llm/internal/core/pure.ts
@@ -1,10 +1,13 @@
 // Pure, side-effect-free LLM helpers — the unit-test seam.
 //
 // Everything here is a pure function of its arguments: no imports from `ai`,
-// `settings`, `fs`, or any module with side effects. That's deliberate — these
-// are the regression-critical bits (the failover gate, the JSON salvage, the
-// usage normaliser), so they live in one importable, testable place
-// (controller/scripts/llm-pure.test.ts pins their behaviour).
+// `settings`, `fs`, or any module with side effects (zod is the one
+// exception — a schema-construction library, not an I/O one). That's
+// deliberate — these are the regression-critical bits (the failover gate,
+// the JSON salvage, the usage normaliser), so they live in one importable,
+// testable place (controller/scripts/llm-pure.test.ts pins their behaviour).
+
+import { z } from 'zod';
 
 // ---------------------------------------------------------------------------
 // Thinking-block stripping
@@ -429,4 +432,116 @@ export function nearestId(id: string, candidateIds: Iterable<string>): string | 
   if (prefix.length > 1) return null;
   const near = ids.filter((c) => c !== id && editDistanceAtMost2(c, id) <= 1);
   return near.length === 1 ? near[0] : null;
+}
+
+// ---------------------------------------------------------------------------
+// Malformed-nullable-field rescue (GLM/Zhipu observed, incl. the GLM Coding
+// Plan)
+// ---------------------------------------------------------------------------
+//
+// GLM doesn't send a well-formed value for a nullable field it has nothing to
+// say — three distinct shapes observed on live traffic (2026-07-07), all
+// producing a `done` tool call that is fully coherent in substance (a real
+// reason, real content) but fails Zod validation on ONE field, which is
+// indistinguishable from djAgent's perspective from the model never calling
+// `done` at all — it silently misclassifies a valid call as "agent did not
+// call the done tool before stopping" and burns a full recovery cascade on a
+// call that already succeeded:
+//   1. the literal STRING "null" instead of JSON null.
+//   2. OMITTING THE KEY ENTIRELY (a `done` call with a coherent `reason`/
+//      `air:false` but no `segment` key at all — not even null). `.nullable()`
+//      accepts `null`, not `undefined` — Zod runs the field parser with
+//      `undefined` for a genuinely-missing key, same as an explicit
+//      `undefined` value, and this rejects same as case 1.
+//   3. DOUBLE-ENCODING a nested object as a JSON STRING — e.g.
+//      `segment: "{\"kind\":\"now-playing-dig\",...}"` instead of the real
+//      nested object.
+
+// Wrap a nullable field's inner schema with this to coerce all three shapes
+// before validating. Deliberately narrow — exact matches / a targeted parse
+// attempt only, no guessing at other malformed spellings that haven't been
+// observed. The JSON-string rescue (case 3) only fires for OBJECT/ARRAY inner
+// schemas: a plain nullable STRING field's own value could coincidentally look
+// like JSON (a bare number/boolean/quoted word), and re-parsing THAT would
+// corrupt a genuine string answer.
+export function nullableFromModel<T extends z.ZodTypeAny>(inner: T) {
+  const isContainer = inner instanceof z.ZodObject || inner instanceof z.ZodArray;
+  return z.preprocess((v) => {
+    if (v === 'null' || v === undefined) return null;
+    if (isContainer && typeof v === 'string') {
+      try {
+        const parsed = JSON.parse(v);
+        if (parsed && typeof parsed === 'object') return parsed;
+      } catch { /* not JSON — fall through, let normal validation reject it */ }
+    }
+    return v;
+  }, inner.nullable());
+}
+
+// The sibling for a REQUIRED (non-nullable) object field — some providers
+// (llama.cpp's peg-gemma4 tool serializer, issue #906) drop a nullable nested
+// object's `properties` entirely, so the field must stay non-nullable for
+// them. That rules out nullableFromModel's `.nullable()` wrapper, but the
+// SAME GLM double-JSON-encoding tendency (case 3 above) still needs rescuing,
+// and a missing/malformed value still needs to degrade gracefully rather than
+// throw. Attempts the JSON-string rescue, then falls back to `fallback` for
+// anything else that still doesn't validate. Only safe when the caller's
+// consumption site already treats a placeholder/empty value as "nothing to
+// do" — verify that before reusing this for a new field.
+export function objectFromModel<Shape extends z.ZodRawShape>(
+  shape: Shape,
+  fallback: z.infer<z.ZodObject<Shape>>,
+) {
+  const schema = z.object(shape);
+  return z.preprocess((v) => {
+    if (typeof v === 'string') {
+      try {
+        const parsed = JSON.parse(v);
+        if (parsed && typeof parsed === 'object') return parsed;
+      } catch { /* not JSON — fall through, let normal validation reject it */ }
+    }
+    return v;
+  }, schema).catch(fallback);
+}
+
+// Strip every `description` key from a JSON-Schema-shaped value, recursively.
+// z.toJSONSchema() carries every Zod .describe() call through verbatim —
+// several of this codebase's schemas (e.g. the picker's `transition` field)
+// have a multi-hundred-word description, since that prose is the primary
+// channel for coaching the model on the native/tool-forced paths. Embedded
+// verbatim into schemaHint's recovery prompt, that same prose would bloat the
+// retry's token count for every caller, not just the one schema that needs
+// it (Copilot review, PR #923) — and the recovery prompt only needs the
+// STRUCTURE (field names, types, required-ness, enum values) to stop the
+// model guessing at keys; the coaching prose already lives in the original
+// system/prompt text passed alongside it.
+function stripDescriptions(value: any): any {
+  if (Array.isArray(value)) return value.map(stripDescriptions);
+  if (value && typeof value === 'object') {
+    const out: any = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (k === 'description') continue;
+      out[k] = stripDescriptions(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+// Best-effort JSON Schema for a Zod object, embedded in djObject's free-text
+// recovery prompt so that retry is self-describing regardless of what the
+// caller's own system/prompt text happens to restate. Every OTHER structured-
+// output path conveys the schema to the model via a real provider channel —
+// native Output.object's response_format, or a forced tool's inputSchema — but
+// the recovery path is plain generateText with no schema attached at all, so
+// a model that doesn't already have the exact required keys memorised from
+// prose (observed: GLM omitting `reason`/`say` — issue triaged 2026-07-07)
+// has nothing to go on. Swallows conversion failures (never let a schema this
+// can't render block the retry it's meant to help).
+export function schemaHint(schema: z.ZodTypeAny): string | null {
+  try {
+    return JSON.stringify(stripDescriptions(z.toJSONSchema(schema)));
+  } catch {
+    return null;
+  }
 }

--- a/controller/src/llm/internal/core/pure.ts
+++ b/controller/src/llm/internal/core/pure.ts
@@ -370,7 +370,11 @@ export function failureDiagnostics(err: any): any {
     out.causeMessage = err.cause.message;
   }
   // The agent loop's partial steps before the final-output failure — same
-  // shape as the success-path toolCalls flatten.
+  // shape as the success-path toolCalls flatten, but with oversized string
+  // results truncated: these entries live in the 120-entry /debug ring buffer
+  // for the process lifetime, and a discovery tool's result (a full candidate
+  // list) can run to tens of KB per step. The head is what triage needs.
+  const clip = (v: any) => (typeof v === 'string' && v.length > 2000 ? `${v.slice(0, 2000)}… [truncated ${v.length - 2000} chars]` : v);
   const steps = err?.response?.steps || err?.steps;
   if (Array.isArray(steps) && steps.length) {
     out.toolCalls = steps.flatMap((s: any) => {
@@ -378,7 +382,7 @@ export function failureDiagnostics(err: any): any {
       return (s.toolCalls || []).map((c: any, i: number) => ({
         name: c.toolName,
         args: c.input ?? c.args ?? null,
-        result: results[i]?.output ?? results[i]?.result ?? null,
+        result: clip(results[i]?.output ?? results[i]?.result ?? null),
       }));
     });
     out.steps = steps.length;
@@ -457,51 +461,99 @@ export function nearestId(id: string, candidateIds: Iterable<string>): string | 
 //      `segment: "{\"kind\":\"now-playing-dig\",...}"` instead of the real
 //      nested object.
 
-// Wrap a nullable field's inner schema with this to coerce all three shapes
-// before validating. Deliberately narrow — exact matches / a targeted parse
-// attempt only, no guessing at other malformed spellings that haven't been
-// observed. The JSON-string rescue (case 3) only fires for OBJECT/ARRAY inner
-// schemas: a plain nullable STRING field's own value could coincidentally look
-// like JSON (a bare number/boolean/quoted word), and re-parsing THAT would
-// corrupt a genuine string answer.
-export function nullableFromModel<T extends z.ZodTypeAny>(inner: T) {
-  const isContainer = inner instanceof z.ZodObject || inner instanceof z.ZodArray;
-  return z.preprocess((v) => {
-    if (v === 'null' || v === undefined) return null;
-    if (isContainer && typeof v === 'string') {
+// The coercion is applied at the OBJECT level (one z.preprocess wrapping the
+// whole payload schema), never per-field. That placement is load-bearing: the
+// AI SDK renders tool inputSchemas with z.toJSONSchema(…, { io: 'input' })
+// (zod4Schema in @ai-sdk/provider-utils), and a per-field z.preprocess pipe
+// accepts `undefined` on its input side — so wrapping a field DROPS IT FROM
+// THE PARENT'S `required` ARRAY in the schema every provider sees, silently
+// inviting well-behaved models to omit `say`/`transition`/`segment` (fewer
+// spoken links, dropped segments) to fix a malformation only GLM exhibits. A
+// top-level preprocess renders with the full `required` array intact (pinned
+// in llm-pure.test.ts), so the wire schema is byte-identical to the plain
+// object's.
+
+// Schema-driven payload repair: walks `schema.shape` and coerces each
+// observed malformed shape on the raw value BEFORE validation —
+//   - a nullable field sent as the STRING "null", or omitted → real null
+//   - an object/array field double-encoded as a JSON STRING → parsed, then
+//     recursed into (so a nested nullable like segment.sfx is repaired too)
+// Deliberately narrow — exact matches / a targeted parse attempt only, no
+// guessing at other malformed spellings that haven't been observed. The
+// JSON-string rescue only fires for OBJECT/ARRAY fields: a plain string
+// field's genuine value could coincidentally look like JSON (a bare
+// number/boolean/quoted word), and re-parsing THAT would corrupt it.
+export function coerceModelPayload(raw: unknown, schema: z.ZodObject<any>): unknown {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return raw;
+  const out: any = { ...raw };
+  for (const [key, field] of Object.entries(schema.shape) as [string, z.ZodTypeAny][]) {
+    let v = out[key];
+    if ((v === 'null' || v === undefined) && field.safeParse(null).success) {
+      out[key] = null;
+      continue;
+    }
+    if (v === undefined) continue; // missing non-nullable key — modelTolerant's fallbacks handle it
+    // See through Nullable/Optional wrappers to the core type (.describe()
+    // returns the same class, so it needs no unwrapping).
+    let core: any = field;
+    while (core instanceof z.ZodNullable || core instanceof z.ZodOptional) core = core.unwrap();
+    if ((core instanceof z.ZodObject || core instanceof z.ZodArray) && typeof v === 'string') {
       try {
         const parsed = JSON.parse(v);
-        if (parsed && typeof parsed === 'object') return parsed;
-      } catch { /* not JSON — fall through, let normal validation reject it */ }
+        if (parsed && typeof parsed === 'object') v = parsed;
+      } catch { /* not JSON — leave it, let normal validation reject it */ }
     }
-    return v;
-  }, inner.nullable());
+    if (core instanceof z.ZodObject && v && typeof v === 'object' && !Array.isArray(v)) {
+      v = coerceModelPayload(v, core);
+    }
+    out[key] = v;
+  }
+  return out;
 }
 
-// The sibling for a REQUIRED (non-nullable) object field — some providers
-// (llama.cpp's peg-gemma4 tool serializer, issue #906) drop a nullable nested
-// object's `properties` entirely, so the field must stay non-nullable for
-// them. That rules out nullableFromModel's `.nullable()` wrapper, but the
-// SAME GLM double-JSON-encoding tendency (case 3 above) still needs rescuing,
-// and a missing/malformed value still needs to degrade gracefully rather than
-// throw. Attempts the JSON-string rescue, then falls back to `fallback` for
-// anything else that still doesn't validate. Only safe when the caller's
-// consumption site already treats a placeholder/empty value as "nothing to
-// do" — verify that before reusing this for a new field.
-export function objectFromModel<Shape extends z.ZodRawShape>(
-  shape: Shape,
-  fallback: z.infer<z.ZodObject<Shape>>,
+// The schema wrapper call sites use: the plain object schema stays the single
+// source of the wire contract (tool inputSchema / response_format), and this
+// preprocess repairs GLM's malformed shapes just before validation — on every
+// parse path (done-tool args, text salvage, djObject recovery) since the
+// preprocess rides the schema itself.
+//
+// `objectFallbacks` handles a REQUIRED (non-nullable) object field — some
+// providers (llama.cpp's peg-gemma4 tool serializer, issue #906) drop a
+// nullable nested object's `properties` entirely, so a field like `segment`
+// must stay non-nullable for them, yet a missing/malformed value still needs
+// to degrade gracefully rather than throw (the whole point: a coherent `done`
+// call must not be misclassified as "never called done"). After coercion,
+// any listed field that still fails its own validation is replaced by its
+// fallback. Only safe when the caller's consumption site already treats the
+// placeholder as "nothing to do" — verify that before adding a field here.
+// A field-level .catch() is NOT equivalent: it renders a visible `"default"`
+// into the JSON schema and drops the field from `required` (same io:'input'
+// trap as above).
+//
+// `onDiscard` fires when a fallback replaces a value that HAD content (not
+// undefined/null/"null") — real model output is being thrown away, and the
+// operator should be able to tell that apart from the model choosing silence.
+// Callers pass a logger; this module stays side-effect-free.
+export function modelTolerant<T extends z.ZodObject<any>>(
+  schema: T,
+  opts?: {
+    objectFallbacks?: Record<string, unknown>;
+    onDiscard?: (field: string, value: unknown) => void;
+  },
 ) {
-  const schema = z.object(shape);
-  return z.preprocess((v) => {
-    if (typeof v === 'string') {
-      try {
-        const parsed = JSON.parse(v);
-        if (parsed && typeof parsed === 'object') return parsed;
-      } catch { /* not JSON — fall through, let normal validation reject it */ }
+  return z.preprocess((raw) => {
+    const coerced: any = coerceModelPayload(raw, schema);
+    if (opts?.objectFallbacks && coerced && typeof coerced === 'object' && !Array.isArray(coerced)) {
+      for (const [key, fallback] of Object.entries(opts.objectFallbacks)) {
+        const fieldSchema: z.ZodTypeAny | undefined = (schema.shape as any)[key];
+        if (!fieldSchema || fieldSchema.safeParse(coerced[key]).success) continue;
+        const v = coerced[key];
+        if (opts.onDiscard && v !== undefined && v !== null && v !== 'null') opts.onDiscard(key, v);
+        coerced[key] = fallback;
+      }
     }
-    return v;
-  }, schema).catch(fallback);
+    return coerced;
+  }, schema);
 }
 
 // Strip every `description` key from a JSON-Schema-shaped value, recursively.

--- a/controller/src/llm/internal/provider/registry.ts
+++ b/controller/src/llm/internal/provider/registry.ts
@@ -107,7 +107,16 @@ export function noThinkFetch(url: any, init: any, baseFetch: any = fetch) {
 //     llama.cpp routes that thought to `content`, so it leaks into the visible
 //     script and reaches TTS. reasoning_format:"deepseek" routes it to
 //     reasoning_content, which the SDK surfaces as a reasoning part, not text
-//     (gist quirk #4).
+//     (gist quirk #4). GLM-family models (Zhipu/Z.ai — including the GLM
+//     Coding Plan's api.z.ai/api/coding/paas/v4 endpoint) ignore
+//     enable_thinking entirely and read a DIFFERENT, top-level `thinking.type`
+//     field instead, so their thinking never actually turned off via the
+//     knobs above alone — the hidden chain-of-thought burned through
+//     maxOutputTokens/step budgets before a forced tool call could land,
+//     surfacing as multi-minute calls or "agent did not call the done tool
+//     before stopping". Send it alongside the others — an unrecognised field
+//     is silently ignored by servers that don't define it, same bet as the
+//     other body-injection knobs here.
 export function openAICompatibleFetch(cfg: any, baseFetch: any = fetch) {
   const penalty = appliedRepeatPenalty(cfg);
   const noThink = cfg?.reasoning !== true;
@@ -124,6 +133,7 @@ export function openAICompatibleFetch(cfg: any, baseFetch: any = fetch) {
             enable_thinking: false,
           };
           if (body.reasoning_format === undefined) body.reasoning_format = 'deepseek';
+          if (body.thinking === undefined) body.thinking = { type: 'disabled' };
         }
         init = { ...init, body: JSON.stringify(body) };
       } catch { /* not JSON — leave the request untouched */ }

--- a/controller/src/llm/internal/strategy/agent.ts
+++ b/controller/src/llm/internal/strategy/agent.ts
@@ -78,13 +78,62 @@ function gatedDiscoveryPrepareStep(discoveryToolNames: string[], toolChoice: 're
   };
 }
 
+// Shared shape for the done-only recovery agent — same harness for both the
+// first (trail-carrying) and second (clean-context) recovery attempts below;
+// only the messages they're run against differ.
+function buildRecoveryAgent(leg: any, system: string, allTools: any, temperature: number, maxOutputTokens: number, forcedChoice: 'required' | 'auto') {
+  return new ToolLoopAgent({
+    // Recovery forces done-only every step → no-think model (see above).
+    model: leg.noThinkModel ?? leg.model,
+    // Append an explicit terminal instruction at the exact point
+    // gemma-class models stall (issue #555): after a negative tool
+    // result (`available:false`) they tend to emit prose instead of
+    // obeying toolChoice:'required', and the bare done-only re-run
+    // sometimes does the same. activeTools is already pinned to
+    // done-only; this plain-language line in the recovery system prompt
+    // tells the model the ONLY valid move is the done call. Put in
+    // `instructions` (not a trailing user turn) so it can't create two
+    // consecutive user messages and trip providers that require strict
+    // role alternation (Anthropic). Harmless on the picker path.
+    instructions: `${system}\n\nYou now have everything you need. Respond ONLY by calling the \`done\` tool with your final answer — do not write a normal text message.`,
+    tools: allTools,
+    stopWhen: [stepCountIs(2), hasToolCall('done')],
+    temperature,
+    maxOutputTokens,
+    // Recovery forces done-only every step, so it has the same
+    // Anthropic/DeepSeek thinking conflict as the main run — suppress here too.
+    providerOptions: providerOptions(leg.cfg, { forceNoThink: true }),
+    toolChoice: forcedChoice,
+    prepareStep: async () => ({ activeTools: ['done'], toolChoice: forcedChoice }),
+  } as any);
+}
+
 // The withDeadline(Promise.race + abort) + withTransientRetry wrapper around a
 // single agent.generate(). The `timeout` generate option is NOT honoured by the
 // ai-sdk-ollama transport, so the wall-clock ceiling is enforced here; the abort
 // signal is forwarded so transports that DO support cancellation stop the request
-// server-side. Main run and recovery each get the full timeoutMs (worst case ~2×).
-function runDeadlined(timeoutMs: any, kind: string, label: string, agent: any, messages: any) {
-  return withDeadline(timeoutMs, `${kind} ${label}`, (signal) =>
+// server-side.
+//
+// `deadlineAt` is a SHARED absolute deadline (a Date.now()-style timestamp),
+// not a fresh duration per call — every attempt djAgent makes for one pick
+// (native run, main run, both recovery attempts) draws down the SAME overall
+// budget, computed once in djAgent below. Passing the same timeoutMs to each
+// attempt independently (the prior behaviour) let a single pick run up to
+// ~3x timeoutMs in the worst case before falling back to the caller's
+// stateless path (Copilot review, PR #923) — a slow main run now correctly
+// leaves less time for recovery instead of resetting the clock. undefined
+// means no deadline at all (unlimited).
+function runDeadlined(deadlineAt: number | undefined, kind: string, label: string, agent: any, messages: any) {
+  if (deadlineAt == null) {
+    return withTransientRetry(kind, () => agent.generate({ messages }));
+  }
+  const remaining = deadlineAt - Date.now();
+  if (remaining <= 0) {
+    const err: any = new Error(`${kind} ${label} — no time left on the shared deadline`);
+    err.name = 'AgentDeadlineError';
+    return Promise.reject(err);
+  }
+  return withDeadline(remaining, `${kind} ${label}`, (signal) =>
     withTransientRetry(kind, () => agent.generate({
       messages,
       ...(signal ? { abortSignal: signal } : {}),
@@ -123,6 +172,9 @@ export async function djAgent({
       // Default to the agent path; branches override before their await. A
       // failure record always attributes to the path actually attempted.
       let lastVia = 'ai-sdk:agent';
+      // One shared wall-clock ceiling for every attempt below (native run,
+      // main run, both recovery attempts) — see runDeadlined's comment.
+      const deadlineAt = timeoutMs ? Date.now() + timeoutMs : undefined;
       try {
         // No discovery tools + an Ollama model that ignores JSON mode: there is
         // no loop to run, and ToolLoopAgent + Output.object would throw
@@ -164,7 +216,7 @@ export async function djAgent({
               providerOptions: providerOptions(leg.cfg, { forceNoThink: true }),
               output: Output.object({ schema }),
             } as any);
-            const nr: any = await runDeadlined(timeoutMs, kind, 'native run', nativeAgent, messages);
+            const nr: any = await runDeadlined(deadlineAt, kind, 'native run', nativeAgent, messages);
             const nObj = nr.output;
             const nSteps = nr.steps?.length ?? 0;
             // The cross-provider failure signature is "emitted the object WITHOUT
@@ -233,8 +285,25 @@ export async function djAgent({
         // timeoutMs (when set) is a hard ceiling — a slow/looping run throws,
         // flows through the catch below, and the caller falls back to its
         // stateless path rather than blocking on a pathological model call.
-        let result: any = await runDeadlined(timeoutMs, kind, 'agent run', agent, messages);
+        let result: any = await runDeadlined(deadlineAt, kind, 'agent run', agent, messages);
         let steps = result.steps?.length ?? 0;
+
+        // What the model said INSTEAD of calling `done`, one entry per attempt
+        // that declined — surfaced on the eventual throw below (via err.text)
+        // so failureDiagnostics() in core/pure.ts picks it up into the /debug
+        // record as `responseText`, and failover.ts's logFailurePreview prints
+        // it to the container logs too. Without this, a "did not call the done
+        // tool" failure carried no evidence of what the model actually said,
+        // making it unguessable whether it declined outright, answered in
+        // prose, or something else entirely.
+        const declinedAttempts: string[] = [];
+        const noteIfDeclined = (label: string, r: any) => {
+          if (!(r.staticToolCalls || []).some((c: any) => c.toolName === 'done')
+            && typeof r.text === 'string' && r.text.trim()) {
+            declinedAttempts.push(`[${label}] ${r.text.trim()}`);
+          }
+        };
+        noteIfDeclined('main', result);
 
         // Recovery for the "agent did not call the done tool" failure mode (issue
         // #140). Local/cloud Ollama models occasionally ignore toolChoice:'required'
@@ -251,32 +320,32 @@ export async function djAgent({
           lastVia = 'ai-sdk:agent:recovery';
           const priorMessages = (result as any).response?.messages || [];
           const recoveryMessages = priorMessages.length ? [...messages, ...priorMessages] : messages;
-          const recoveryAgent = new ToolLoopAgent({
-            // Recovery forces done-only every step → no-think model (see above).
-            model: leg.noThinkModel ?? leg.model,
-            // Append an explicit terminal instruction at the exact point
-            // gemma-class models stall (issue #555): after a negative tool
-            // result (`available:false`) they tend to emit prose instead of
-            // obeying toolChoice:'required', and the bare done-only re-run
-            // sometimes does the same. activeTools is already pinned to
-            // done-only; this plain-language line in the recovery system prompt
-            // tells the model the ONLY valid move is the done call. Put in
-            // `instructions` (not a trailing user turn) so it can't create two
-            // consecutive user messages and trip providers that require strict
-            // role alternation (Anthropic). Harmless on the picker path.
-            instructions: `${system}\n\nYou now have everything you need. Respond ONLY by calling the \`done\` tool with your final answer — do not write a normal text message.`,
-            tools: allTools,
-            stopWhen: [stepCountIs(2), hasToolCall('done')],
-            temperature,
-            maxOutputTokens,
-            // Recovery forces done-only every step, so it has the same
-            // Anthropic/DeepSeek thinking conflict as the main run — suppress here too.
-            providerOptions: providerOptions(leg.cfg, { forceNoThink: true }),
-            toolChoice: forcedChoice,
-            prepareStep: async () => ({ activeTools: ['done'], toolChoice: forcedChoice }),
-          } as any);
-          result = await runDeadlined(timeoutMs, kind, 'agent recovery', recoveryAgent, recoveryMessages);
+          result = await runDeadlined(deadlineAt, kind, 'agent recovery',
+            buildRecoveryAgent(leg, system, allTools, temperature, maxOutputTokens, forcedChoice), recoveryMessages);
           steps = result.steps?.length ?? 0;
+          noteIfDeclined('recovery', result);
+
+          // Second-chance recovery: GLM (Zhipu/Z.ai, incl. the GLM Coding Plan)
+          // observed declining the forced `done` call ~1/3 of the time even under
+          // toolChoice:'required', AND tends to keep declining once it already has
+          // in the SAME conversation — direct API testing showed a fresh single-turn
+          // done-only call succeeds far more reliably than a continuation of a trail
+          // where the model already answered in prose. Retry ONCE more from a CLEAN
+          // conversation (just the original `messages`, none of the "I already
+          // declined" turns) so the model isn't anchored to its own prior refusal.
+          // Safe for the picker: `seen` (the discovered-candidate map) is a side
+          // effect of TOOL EXECUTION during the main run, not of conversation
+          // replay, so it's already populated regardless of what this attempt sees
+          // — an id this step fabricates still gets caught by the caller's
+          // nearestId/repickFromSeen salvage, same as any other unknown-id miss.
+          if (!(result.staticToolCalls || []).some((c: any) => c.toolName === 'done')) {
+            console.log(`[${kind}] recovery also stopped without calling done — retrying once more from a clean context`);
+            lastVia = 'ai-sdk:agent:recovery2';
+            result = await runDeadlined(deadlineAt, kind, 'agent recovery (clean)',
+              buildRecoveryAgent(leg, system, allTools, temperature, maxOutputTokens, forcedChoice), messages);
+            steps = result.steps?.length ?? 0;
+            noteIfDeclined('recovery-clean', result);
+          }
         }
 
         let object;
@@ -296,7 +365,15 @@ export async function djAgent({
               object = schema.parse(JSON.parse(extractJson(stripThinking(result.text || ''))));
               lastVia = `${lastVia}:text`;
             } catch {
-              throw new Error('agent did not call the done tool before stopping');
+              const err: any = new Error('agent did not call the done tool before stopping');
+              // See declinedAttempts above — picked up by failureDiagnostics()
+              // into the /debug record's responseText/toolCalls, and by
+              // failover.ts's logFailurePreview into the container log line.
+              err.text = declinedAttempts.length ? declinedAttempts.join('\n\n') : (result.text || '');
+              err.finishReason = result.finishReason;
+              err.usage = result.usage;
+              err.steps = result.steps;
+              throw err;
             }
           }
         } else if (schema) {

--- a/controller/src/llm/internal/strategy/object.ts
+++ b/controller/src/llm/internal/strategy/object.ts
@@ -15,7 +15,7 @@
 import { generateText, Output } from 'ai';
 import { withFailover } from '../core/failover.js';
 import { withTransientRetry } from '../core/retry.js';
-import { stripThinking, extractJson, usageOf, failureDiagnostics } from '../core/pure.js';
+import { stripThinking, extractJson, usageOf, failureDiagnostics, schemaHint } from '../core/pure.js';
 import { needsToolCallObject, providerOptions, samplingWithLocalKnobs } from '../provider/capabilities.js';
 import { objectViaToolCall } from './object-via-tool.js';
 import { resolveMaxOutputTokens } from '../../../settings.js';
@@ -72,16 +72,39 @@ export async function djObject({
             usage = usageOf(result);
           } else {
             lastVia = 'ai-sdk:recovery';
+            // Self-describing retry: the native/tool attempt above conveys the
+            // schema to the model via a real provider channel (response_format
+            // or a forced tool's inputSchema) — this plain generateText call has
+            // neither, so without restating the shape here the model is guessing
+            // required keys from whatever the caller's own prose happens to
+            // mention (observed: GLM dropping `reason`/`say` entirely — see
+            // schemaHint's comment). Also route through the no-think model +
+            // forced suppression, same as every other structured-output leg
+            // (objectViaToolCall, djAgent's done-tool path) — this was the one
+            // branch still using the operator's raw reasoning-on model instance.
+            const hint = schemaHint(schema);
             const result = await withTransientRetry(kind, () => generateText({
-              model: l.model,
+              model: l.noThinkModel ?? l.model,
               system,
-              prompt: `${prompt}\n\nRespond with a single JSON object only — no prose, no markdown fences.`,
+              prompt: `${prompt}\n\nRespond with a single JSON object only — no prose, no markdown fences.`
+                + (hint ? ` It MUST validate against this JSON Schema — every required key must be present:\n${hint}` : ''),
               temperature,
               maxOutputTokens,
-              providerOptions: providerOptions(l.cfg),
+              providerOptions: providerOptions(l.cfg, { forceNoThink: true }),
               ...(signal ? { abortSignal: signal } : {}),
             }), signal);
-            object = schema.parse(JSON.parse(extractJson(stripThinking(result.text))));
+            try {
+              object = schema.parse(JSON.parse(extractJson(stripThinking(result.text))));
+            } catch (parseErr: any) {
+              // Surface the raw output on a shape/parse miss, mirroring the
+              // done-tool agent's diagnostics — without this a recovery-path
+              // failure carried no evidence of what the model actually
+              // produced, only the Zod/JSON error.
+              parseErr.text = result.text || '';
+              parseErr.finishReason = result.finishReason;
+              parseErr.usage = result.usage;
+              throw parseErr;
+            }
             usage = usageOf(result);
           }
           return {

--- a/controller/src/llm/sdk.ts
+++ b/controller/src/llm/sdk.ts
@@ -6,4 +6,4 @@
 export { djText } from './internal/strategy/text.js';
 export { djObject } from './internal/strategy/object.js';
 export { djAgent } from './internal/strategy/agent.js';
-export { isUnreachable, isQuotaOrAuthError, errReason, nearestId } from './internal/core/pure.js';
+export { isUnreachable, isQuotaOrAuthError, errReason, nearestId, nullableFromModel, objectFromModel } from './internal/core/pure.js';

--- a/controller/src/llm/sdk.ts
+++ b/controller/src/llm/sdk.ts
@@ -6,4 +6,4 @@
 export { djText } from './internal/strategy/text.js';
 export { djObject } from './internal/strategy/object.js';
 export { djAgent } from './internal/strategy/agent.js';
-export { isUnreachable, isQuotaOrAuthError, errReason, nearestId, nullableFromModel, objectFromModel } from './internal/core/pure.js';
+export { isUnreachable, isQuotaOrAuthError, errReason, nearestId, modelTolerant } from './internal/core/pure.js';

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -37,6 +37,7 @@ import { z } from 'zod';
 import { queue } from '../broadcast/queue.js';
 import * as settings from '../settings.js';
 import { defineAgent } from '../llm/agent.js';
+import { nullableFromModel, objectFromModel } from '../llm/sdk.js';
 import { buildContextLines, CONTEXT_FIELDS, lengthMode, lengthPhrase } from '../llm/dj.js';
 import { buildSegmentTools } from '../llm/segment-tools.js';
 import { recordCuriosity, recentAiredCuriosity } from './curiosity.js';
@@ -107,20 +108,31 @@ function segmentSchema() {
   return z.object({
     reason: z.string().describe('one short internal sentence on why this segment (or why silent) — never shown to the listener; write this BEFORE deciding the segment'),
     air: z.boolean().describe('true to air one segment now, false to stay silent — silence is a perfectly good answer, often the best one, when the data is dull, stale, unchanged, or there is nothing fresh worth a listener\'s attention'),
-    segment: z.object({
+    // NOT .nullable(): a nullable nested object loses its `properties` in
+    // llama.cpp's peg-gemma4 tool serializer, so Gemma-4 never sees the shape
+    // and emits it as a string (issue #906). Silence rides entirely on the
+    // `air` boolean above, so a non-null segment on a silent tick is simply
+    // ignored at the consumption site (`object.air ? segment : null`).
+    // objectFromModel (in place of a plain z.object): GLM separately observed
+    // (a) omitting this key entirely on an otherwise coherent `done` call, and
+    // (b) double-JSON-encoding the whole object as a STRING — both would
+    // throw under a plain required object just as they would under
+    // .nullable(), which is indistinguishable from djAgent's perspective from
+    // "the model never called done" and burns a full recovery cascade on a
+    // call that already succeeded. Rescues the double-encoded-string case back
+    // into a real object, and falls back to an empty placeholder for anything
+    // else malformed — safe because the consumption site already treats an
+    // empty/malformed segment as silence regardless of `air` (see the check
+    // right after `const seg = object?.air ? object?.segment : null`).
+    segment: objectFromModel({
       // Kept as a free string (not a fixed enum) so operator-dropped custom
       // skills get valid kinds too. The agent is told which kinds are on offer in
       // the system prompt, and agenticTick drops any kind it wasn't offered.
       kind: z.string()
         .describe('the segment kind — MUST be one of the kinds offered in the system prompt for this tick'),
       text: z.string().describe(`the spoken line in the DJ voice — ${lengthPhrase('segment')}`),
-      sfx: z.string().nullable().describe('the exact name of one sound effect from the catalogue in the system prompt to play under this line, or null for no effect (null is usually right — most segments need none)'),
-      // NOT nullable: a nullable nested object loses its `properties` in
-      // llama.cpp's peg-gemma4 tool serializer, so Gemma-4 never sees the
-      // shape and emits it as a string (issue #906). Silence rides entirely on
-      // the `air` boolean above, so a non-null segment on a silent tick is
-      // simply ignored at the consumption site (`object.air ? segment : null`).
-    }).describe('the segment to air when air is true; ignored when air is false (empty strings for kind/text, null sfx when silent)'),
+      sfx: nullableFromModel(z.string()).describe('the exact name of one sound effect from the catalogue in the system prompt to play under this line, or null for no effect (null is usually right — most segments need none)'),
+    }, { kind: '', text: '', sfx: null }).describe('the segment to air when air is true; ignored when air is false (empty strings for kind/text, null sfx when silent)'),
   });
 }
 
@@ -129,7 +141,7 @@ function segmentSchema() {
 function forcedSchema() {
   return z.object({
     text: z.string().describe(`the spoken line in the DJ voice — ${lengthPhrase('segment')}`),
-    sfx: z.string().nullable().describe('the exact name of one sound effect from the catalogue in the system prompt to play under this line, or null for no effect'),
+    sfx: nullableFromModel(z.string()).describe('the exact name of one sound effect from the catalogue in the system prompt to play under this line, or null for no effect'),
   });
 }
 
@@ -236,6 +248,14 @@ function segmentDeadline(): number {
 export const directorAgent = defineAgent({
   kind: 'djAgentSegment',
   schema: () => segmentSchema(),
+  // Discovery (step 0) + exactly one committed done-tool attempt (step 1),
+  // same reasoning as pickerAgent.maxSteps in dj-agent.ts: a taller budget
+  // just grows an increasingly "I already declined" trail on providers that
+  // don't comply on the first forced attempt (GLM/Zhipu observed), which made
+  // things worse, not better, and was the direct cause of a run burning the
+  // FULL agentTimeoutMs internally (45002ms observed) before recovery ever got
+  // a turn. Left unset before, silently inheriting djAgent's default of 8.
+  maxSteps: 2,
   // Wall-clock ceiling, mirroring the picker (dj-agent.ts). Without it a
   // gemma-class model that ignores toolChoice can drive the done-tool recovery
   // into a multi-step stall (86s observed in issue #555) and hang the tick;

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -37,7 +37,7 @@ import { z } from 'zod';
 import { queue } from '../broadcast/queue.js';
 import * as settings from '../settings.js';
 import { defineAgent } from '../llm/agent.js';
-import { nullableFromModel, objectFromModel } from '../llm/sdk.js';
+import { modelTolerant } from '../llm/sdk.js';
 import { buildContextLines, CONTEXT_FIELDS, lengthMode, lengthPhrase } from '../llm/dj.js';
 import { buildSegmentTools } from '../llm/segment-tools.js';
 import { recordCuriosity, recentAiredCuriosity } from './curiosity.js';
@@ -105,7 +105,7 @@ function unionContextFields(caps: any[]): string[] {
 // `null` or prose instead (see isBareNullSilent / isSilentFailure below);
 // `air: false` gives them an unambiguous silence token to reach for.
 function segmentSchema() {
-  return z.object({
+  return modelTolerant(z.object({
     reason: z.string().describe('one short internal sentence on why this segment (or why silent) — never shown to the listener; write this BEFORE deciding the segment'),
     air: z.boolean().describe('true to air one segment now, false to stay silent — silence is a perfectly good answer, often the best one, when the data is dull, stale, unchanged, or there is nothing fresh worth a listener\'s attention'),
     // NOT .nullable(): a nullable nested object loses its `properties` in
@@ -113,36 +113,46 @@ function segmentSchema() {
     // and emits it as a string (issue #906). Silence rides entirely on the
     // `air` boolean above, so a non-null segment on a silent tick is simply
     // ignored at the consumption site (`object.air ? segment : null`).
-    // objectFromModel (in place of a plain z.object): GLM separately observed
-    // (a) omitting this key entirely on an otherwise coherent `done` call, and
-    // (b) double-JSON-encoding the whole object as a STRING — both would
-    // throw under a plain required object just as they would under
-    // .nullable(), which is indistinguishable from djAgent's perspective from
-    // "the model never called done" and burns a full recovery cascade on a
-    // call that already succeeded. Rescues the double-encoded-string case back
-    // into a real object, and falls back to an empty placeholder for anything
-    // else malformed — safe because the consumption site already treats an
-    // empty/malformed segment as silence regardless of `air` (see the check
-    // right after `const seg = object?.air ? object?.segment : null`).
-    segment: objectFromModel({
+    segment: z.object({
       // Kept as a free string (not a fixed enum) so operator-dropped custom
       // skills get valid kinds too. The agent is told which kinds are on offer in
       // the system prompt, and agenticTick drops any kind it wasn't offered.
       kind: z.string()
         .describe('the segment kind — MUST be one of the kinds offered in the system prompt for this tick'),
       text: z.string().describe(`the spoken line in the DJ voice — ${lengthPhrase('segment')}`),
-      sfx: nullableFromModel(z.string()).describe('the exact name of one sound effect from the catalogue in the system prompt to play under this line, or null for no effect (null is usually right — most segments need none)'),
-    }, { kind: '', text: '', sfx: null }).describe('the segment to air when air is true; ignored when air is false (empty strings for kind/text, null sfx when silent)'),
+      sfx: z.string().nullable().describe('the exact name of one sound effect from the catalogue in the system prompt to play under this line, or null for no effect (null is usually right — most segments need none)'),
+    }).describe('the segment to air when air is true; ignored when air is false (empty strings for kind/text, null sfx when silent)'),
+  }), {
+    // GLM separately observed (a) omitting `segment` entirely on an otherwise
+    // coherent `done` call, and (b) double-JSON-encoding it as a STRING —
+    // both would throw under a plain required object, which is
+    // indistinguishable from djAgent's perspective from "the model never
+    // called done" and burns a full recovery cascade on a call that already
+    // succeeded. modelTolerant rescues the double-encoded string back into a
+    // real object (recursing so `sfx` gets its nullable repair too); this
+    // fallback covers whatever still doesn't validate — safe because the
+    // consumption site already treats an empty/malformed segment as silence
+    // regardless of `air` (see the check right after
+    // `const seg = object?.air ? object?.segment : null`).
+    objectFallbacks: { segment: { kind: '', text: '', sfx: null } },
+    // Content-bearing discards are logged so /debug triage can tell "we threw
+    // a written segment away" apart from "the model chose silence" — an
+    // absent/null segment (the common GLM silence shape) stays quiet.
+    onDiscard: (field, value) => {
+      let preview = '';
+      try { preview = JSON.stringify(value).slice(0, 200); } catch { preview = String(value).slice(0, 200); }
+      console.warn(`[djAgentSegment] discarding malformed ${field} from model output: ${preview}`);
+    },
   });
 }
 
 // Operator-override schema: the segment is mandatory, the kind is already
 // known, so the agent only returns the spoken line.
 function forcedSchema() {
-  return z.object({
+  return modelTolerant(z.object({
     text: z.string().describe(`the spoken line in the DJ voice — ${lengthPhrase('segment')}`),
-    sfx: nullableFromModel(z.string()).describe('the exact name of one sound effect from the catalogue in the system prompt to play under this line, or null for no effect'),
-  });
+    sfx: z.string().nullable().describe('the exact name of one sound effect from the catalogue in the system prompt to play under this line, or null for no effect'),
+  }));
 }
 
 // The optional sound-effects block appended to the agent's system prompt.

--- a/web/components/admin/DebugPanel.tsx
+++ b/web/components/admin/DebugPanel.tsx
@@ -91,6 +91,11 @@ interface LlmCall {
   messages?: Array<{ role?: string; content?: unknown }>;
   toolCalls?: Array<{ name?: string; args?: unknown; result?: unknown }>;
   response?: string;
+  /** What the model said INSTEAD of the expected structured output on a
+   * failed call (e.g. "agent did not call the done tool") — one labelled
+   * block per attempt that declined. Populated by failureDiagnostics() in
+   * the controller; absent on success (see `response` instead). */
+  responseText?: string;
   steps?: number;
 }
 
@@ -1038,6 +1043,11 @@ function LlmCalls({ llm }: { llm: DebugLlm | undefined }) {
               {c.error && (
                 <CallSection label="error" tone="err" preview={oneLine(c.error)}>
                   {c.error}
+                </CallSection>
+              )}
+              {c.responseText && (
+                <CallSection label="model said instead" tone="err" preview={oneLine(c.responseText)}>
+                  {c.responseText}
                 </CallSection>
               )}
               {c.user && (


### PR DESCRIPTION
Builds on #923 (DMCK96's GLM structured-output/thinking-suppression fixes — first commit here is that branch verbatim) and applies the review follow-ups on top. If #923 is updated instead, this can be closed.

## What the follow-up commit changes

**Object-level coercion (the review's blocking finding).** The per-field `nullableFromModel`/`objectFromModel` preprocess wrappers changed the wire contract for every provider, not just GLM: the AI SDK renders tool inputSchemas with `z.toJSONSchema(…, { io: 'input' })` (`zod4Schema` in `@ai-sdk/provider-utils`), and a per-field pipe accepts `undefined` on its input side — so `say`/`transition`/`sfx` silently dropped out of the schema's `required` array, and `objectFromModel`'s `.catch()` leaked a visible `"default"` placeholder into the segment schema. Both invite well-behaved models to omit fields the schema previously forced them to decide on (fewer spoken links, dropped segments). Replaced with one schema-driven `coerceModelPayload` + a top-level `modelTolerant` preprocess: same three GLM rescues (string `"null"`, omitted key, double-JSON-encoded object — recursed, so nested nullables like `segment.sfx` repair too), but the wire schema stays byte-identical to the plain object's. Verified through the AI SDK's actual `zodSchema()` conversion path, not just `z.toJSONSchema` directly.

**Discard visibility.** The segment fallback moved to `modelTolerant`'s `objectFallbacks` with an `onDiscard` hook: a content-bearing segment we throw away is now logged (`[djAgentSegment] discarding malformed segment…`), while the common absent/null GLM silence shapes stay quiet — triage can tell "we discarded a written segment" apart from "the model chose silence".

**Schema-rendering regression tests.** `llm-pure.test.ts` now pins the rendered `required` arrays under `io: 'input'` (and the absence of a leaked `"default"`) — the exact regression the per-field wrappers introduced, and the one a `.parse()`-only suite can't see. The coercion tests were rewritten against miniature twins of the live pick/segment schemas.

**Diagnostics bloat guard.** `failureDiagnostics` truncates tool-result strings past 2 KB — failed-run discovery payloads no longer park tens of KB per entry in the 120-entry /debug ring buffer.

Everything else from #923 (thinking.type knob, shared deadline, two-tier recovery, declined-attempt diagnostics, maxSteps trims, DebugPanel) is unchanged.

## Test plan

- [x] `npm run test:llm` — 34 tests incl. new wire-schema pins
- [x] `npm run lint` clean (controller + web, 0 errors)
- [x] Tool inputSchema verified through `@ai-sdk/provider-utils`' `zodSchema()` (the real conversion path): all fields `required`, nullable/enum branches intact, no `"default"` leak, coercions parse