### PR TITLE
fix(picker): tolerate small-model id transcription slips (#939)

### DIFF
--- a/controller/package-lock.json
+++ b/controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sub-wave-controller",
-  "version": "0.37.0",
+  "version": "0.38.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sub-wave-controller",
-      "version": "0.37.0",
+      "version": "0.38.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.1",

--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -787,6 +787,22 @@ async function main() {
     const seen = ['2igTN1Xw3uJBY9CjdKzZGl', 'H8G6Y1gPsSsMNJwflWbstW'];
     assert.equal(nearestId('3bKpTnYlqR8vD4sXe2aJ0m', seen), null);
   });
+  // The #939 echo-test corruptions, verbatim: small local models corrupt 2-3
+  // chars of a 22-char nanoid (confusable swaps, injected spaces, adjacent
+  // transpositions) — each must resolve back to the id the model meant.
+  await test('repairs a char swap + injected space (#939, distance 2)', () => {
+    const seen = ['923tdZ9Hd7Zw7XNgGGL1DR', 'H8G6Y1gPsSsMNJwflWbstW', '2igTN1Xw3uJBY9CjdKzZGl'];
+    assert.equal(nearestId('923tdZ9HdT7Zw7XNgGG L1DR', seen), '923tdZ9Hd7Zw7XNgGGL1DR');
+  });
+  await test('repairs a space + transposition (#939, distance 3)', () => {
+    const seen = ['w328pyatiNZn9HbMghVPH2', 'H8G6Y1gPsSsMNJwflWbstW', '2igTN1Xw3uJBY9CjdKzZGl'];
+    assert.equal(nearestId('w328pyat iNZn9HbMghVHP2', seen), 'w328pyatiNZn9HbMghVPH2');
+  });
+  await test('refuses when the runner-up is not clearly farther (margin)', () => {
+    // Best is 2 edits away but the runner-up is only 3 — too close to call.
+    const seen = ['AAAAAAAAAAAAAAAAAAAAxx', 'AAAAAAAAAAAAAAAAAAAyyy'];
+    assert.equal(nearestId('AAAAAAAAAAAAAAAAAAAAAA', seen), null);
+  });
   await test('rejects an ambiguous match (two candidates equally close)', () => {
     // Both differ from the query by one trailing character — no safe winner.
     const seen = ['AAAAAAAAAAAAAAAAAAAAAx', 'AAAAAAAAAAAAAAAAAAAAAy'];

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -550,10 +550,10 @@ async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = n
   // The agent returned an id that isn't in the candidate set it was shown.
   // Two-stage salvage before giving up on the run (both observed live):
   //   1. Near-miss repair — the model transcribed a REAL id imperfectly
-  //      (glm-5.1 dropped the final character of a 22-char nanoid it had
-  //      picked from its own tool results). nearestId only accepts a single
-  //      unambiguous prefix / edit-distance-1 match, so this can't misfire
-  //      onto a different track. Free — no model call.
+  //      (glm-5.1 dropped the final character of a 22-char nanoid; small
+  //      local models corrupt 2-3 chars at a time, #939). nearestId only
+  //      accepts an unambiguous prefix / clear-winner edit-distance match,
+  //      so this can't misfire onto a different track. Free — no model call.
   //   2. Corrective re-pick — the model fabricated an id outright (gpt-5-mini
   //      after an empty tool result) while its `seen` map held real
   //      candidates. One djObject call constrained to those ids (grammar-
@@ -894,9 +894,10 @@ async function runRequestViaAgent(queue: any, { requester, text }: { requester: 
     });
 
     let song = object?.id ? extras.seen.get(object.id) : null;
-    // Near-miss repair, same as the pick path: a single unambiguous prefix /
-    // edit-distance-1 match against the run's own candidates rescues an id the
-    // model transcribed imperfectly. No re-pick stage here — a request that
+    // Near-miss repair, same as the pick path: an unambiguous prefix /
+    // clear-winner edit-distance match against the run's own candidates
+    // rescues an id the model transcribed imperfectly (#939). No re-pick
+    // stage here — a request that
     // can't resolve should fall to the caller's stateless matcher cascade,
     // which understands the listener's actual text.
     if (!song && object?.id && extras.seen.size) {

--- a/controller/src/llm/internal/core/pure.ts
+++ b/controller/src/llm/internal/core/pure.ts
@@ -387,10 +387,10 @@ export function failureDiagnostics(err: any): any {
 // Near-miss id resolution
 // ---------------------------------------------------------------------------
 
-// Levenshtein distance capped at 2 — we only ever care about distance ≤ 1, so
-// bail as soon as a row's minimum exceeds the cap instead of filling the table.
-function editDistanceAtMost2(a: string, b: string): number {
-  if (Math.abs(a.length - b.length) > 2) return 3;
+// Levenshtein distance capped at `cap` — bail as soon as a row's minimum
+// exceeds the cap instead of filling the table; returns cap+1 for "farther".
+function boundedLevenshtein(a: string, b: string, cap: number): number {
+  if (Math.abs(a.length - b.length) > cap) return cap + 1;
   let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
   for (let i = 1; i <= a.length; i++) {
     const cur = [i];
@@ -399,24 +399,35 @@ function editDistanceAtMost2(a: string, b: string): number {
       cur[j] = Math.min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1));
       if (cur[j] < rowMin) rowMin = cur[j];
     }
-    if (rowMin > 2) return 3;
+    if (rowMin > cap) return cap + 1;
     prev = cur;
   }
   return prev[b.length];
 }
 
+// The runner-up must be at least this many edits farther than the best match
+// for the best to be accepted. On random 22-char nanoids the id the model
+// meant sits ~1-3 edits away while every OTHER candidate sits ~18+, so a real
+// near-miss clears this margin trivially and a genuine tie refuses.
+const NEAREST_ID_MARGIN = 4;
+
 // Resolve a model-returned id that isn't in the candidate set to the candidate
-// it almost certainly meant, or null when no single safe match exists. Covers
-// the observed transcription slips (glm-5.1 dropped the final character of an
-// id it had genuinely picked from its own tool results — a 22-char nanoid
-// returned as 21) without ever guessing between two plausible candidates:
+// it almost certainly meant, or null when no single safe match exists. Small
+// local models can't reproduce a high-entropy 22-char nanoid verbatim (#939 —
+// swapped confusables, injected spaces, 2-3 edits at a time; glm-5.1 dropped a
+// final char), so this is best-match-with-a-margin rather than a fixed tiny
+// threshold:
 //   1. prefix — one string is a prefix of the other, ≥ 12 chars shared and ≤ 3
 //      chars difference (nanoid-style ids make a 12-char prefix collision
 //      astronomically unlikely; 12 also keeps short ids from matching wildly).
-//   2. edit distance ≤ 1 — a single dropped/added/substituted character.
-// Both passes require EXACTLY one candidate to match — any ambiguity → null,
-// the caller falls back to its re-pick / stateless path rather than airing a
-// coin-flip.
+//      Requires EXACTLY one candidate to match.
+//   2. distance — score every candidate with a bounded Levenshtein; accept the
+//      closest only when it's within a length-scaled cap (5 for 22-char ids,
+//      tighter for short ones) AND clearly closer than the runner-up
+//      (NEAREST_ID_MARGIN). Any ambiguity → null, the caller falls back to its
+//      re-pick / stateless path rather than airing a coin-flip.
+// Only ever consulted AFTER an exact-id lookup misses, so models that return
+// clean ids never touch this path.
 export function nearestId(id: string, candidateIds: Iterable<string>): string | null {
   if (!id || typeof id !== 'string') return null;
   const ids = [...candidateIds];
@@ -427,6 +438,26 @@ export function nearestId(id: string, candidateIds: Iterable<string>): string | 
     && (c.startsWith(id) || id.startsWith(c)));
   if (prefix.length === 1) return prefix[0];
   if (prefix.length > 1) return null;
-  const near = ids.filter((c) => c !== id && editDistanceAtMost2(c, id) <= 1);
-  return near.length === 1 ? near[0] : null;
+  // Accept cap scales with the returned id's length so a short string can't
+  // fuzzy-match half the set; 22-char nanoids get the full cap of 5.
+  const cap = Math.min(5, Math.max(1, Math.floor(id.length / 4)));
+  // Distances only matter up to cap + margin: anything past that bound can
+  // affect neither the accept test nor the margin test.
+  const bound = cap + NEAREST_ID_MARGIN;
+  let best: string | null = null;
+  let bestDist = bound + 1;
+  let secondDist = bound + 1;
+  for (const c of ids) {
+    if (c === id) continue;
+    const d = boundedLevenshtein(c, id, bound);
+    if (d < bestDist) {
+      secondDist = bestDist;
+      bestDist = d;
+      best = c;
+    } else if (d < secondDist) {
+      secondDist = d;
+    }
+  }
+  if (!best || bestDist > cap) return null;
+  return secondDist - bestDist >= NEAREST_ID_MARGIN ? best : null;
 }

--- a/controller/src/llm/internal/prompts/picker.ts
+++ b/controller/src/llm/internal/prompts/picker.ts
@@ -125,22 +125,15 @@ export async function pickNextTrack({ candidates, recentPlays, context, show = n
     candidates,
   }, null, 2);
 
-  // Constrain the pick to the actual candidate ids. On a local model (llama.cpp
-  // via openai-compatible / locca) this becomes a grammar so the model can only
-  // emit a real id — closing the "agent returned unknown id" hole. On providers
-  // that don't enforce the schema at decode time, Zod still rejects an invalid
-  // id, so the caller's fallback fires instead of a bogus track. Empty pool →
-  // plain string (z.enum needs ≥1 literal); pickViaPool never calls with [].
-  const candidateIds = [
-    ...new Set(
-      (candidates || [])
-        .map((c: any) => c?.id)
-        .filter((id: any): id is string => typeof id === 'string' && id.length > 0),
-    ),
-  ];
-  const idSchema = candidateIds.length
-    ? z.enum(candidateIds as [string, ...string[]]).describe('the exact id of one candidate')
-    : z.string().describe('the exact id of one candidate');
+  // The id is a plain string, NOT z.enum(candidateIds), deliberately (#939):
+  // the tool-strategy providers this path was meant to protect (llama.cpp via
+  // openai-compatible / locca, ollama) deliver the schema as forced-tool
+  // ARGUMENTS, which llama.cpp does not grammar-constrain — so the enum never
+  // reached the decoder, and its only effect was a hard Zod reject on the 2-3
+  // char id corruptions small local models produce, killing the pick before
+  // pickViaPool's nearestId repair could run. Validation lives at the call
+  // site instead: exact match → near-miss repair → first-candidate fallback.
+  const idSchema = z.string().describe('the exact id of one candidate');
 
   // Transition effects on the pool path too: the queue's applyMixTransition
   // validates/strips whatever any pick strategy asks for, so a DJ-mode persona

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -9,6 +9,8 @@
 import * as subsonic from './subsonic.js';
 import * as library from './library.js';
 import * as dj from '../llm/dj.js';
+import { nearestId } from '../llm/sdk.js';
+import { logEvent } from '../observability/events.js';
 import * as settings from '../settings.js';
 import { bpmCompat, keyCompat } from './mix.js';
 import { filterPickerCandidates, recencyWindowsForLibrary, effectiveNoRepeatWindow } from './recency.js';
@@ -624,7 +626,19 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
     };
   }
 
-  const chosen = candidates.find(c => c.id === pickRaw?.id);
+  let chosen = candidates.find(c => c.id === pickRaw?.id);
+  // Near-miss repair, same as the agent path (#939): small local models can't
+  // reproduce a 22-char nanoid verbatim, so an id 1-3 edits from a real
+  // candidate is that candidate mistranscribed, not a different pick. Free —
+  // no model call — and only runs when the exact match above already missed.
+  if (!chosen && pickRaw?.id) {
+    const fixed = nearestId(pickRaw.id, candidates.map(c => c.id).filter(Boolean));
+    if (fixed) {
+      logEvent('pick.repaired', { agent: 'pool', from: pickRaw.id, to: fixed });
+      queue.log('picker', `pool pick id "${pickRaw.id}" repaired to near-miss match "${fixed}"`);
+      chosen = candidates.find(c => c.id === fixed);
+    }
+  }
   if (!chosen) {
     queue.log(
       'error',


### PR DESCRIPTION
Fixes #939.

Small local models (llama.cpp via `openai-compatible`) can't reproduce a high-entropy 22-char nanoid verbatim — the reporter's temp-0 echo test corrupted 8/8 ids (confusable swaps, injected spaces, transpositions, 2–3 edits at a time). The returned id then matches no candidate: the agent path throws `agent returned unknown id`, and the pool path dies with `picker LLM failed: invalid_value` — the DJ's actual choice is discarded either way.

This implements the issue's direction **1b (best-match with a margin)** plus a pool-path repair:

## Changes

- **`nearestId` (`llm/internal/core/pure.ts`)** — upgraded from the fixed edit-distance-≤1 / exactly-one-match rule to best-match-with-a-margin: score every candidate with a bounded Levenshtein, accept the closest only when it's within a length-scaled cap (5 for 22-char ids, tighter for short strings) **and** at least 4 edits closer than the runner-up. On random nanoids the id the model meant sits ~1–3 edits away while every other candidate sits ~18+, so real slips resolve unambiguously and genuine ties still refuse (fall through to the existing re-pick / pool path, exactly as before). Exact-match lookups short-circuit before this ever runs, so frontier models that return clean ids pay nothing.
- **Pool path (`music/picker.ts`)** — previously had no recovery at all (exact `find` → first-candidate fallback). It now gets the same `nearestId` repair, logged as `pick.repaired` with `agent: 'pool'`.
- **`pickNextTrack` schema (`llm/internal/prompts/picker.ts`)** — drops the `z.enum(candidateIds)` id constraint. This confirms the issue's suspicion about why the enum didn't help: `openai-compatible`/`ollama`/`locca` have `objectStrategy: 'tool'`, so the schema is delivered as forced-tool *arguments* (`objectViaToolCall`), which llama.cpp does not grammar-constrain. The enum never reached the decoder — its only effect was a hard Zod reject on a corrupted id (attempt 2's free-text recovery re-corrupts and re-throws), killing the pick before any repair could run.
- **Tests (`scripts/llm-pure.test.ts`)** — pins the exact corruptions from the issue report (`923tdZ9Hd7…` char-swap + space, `w328pyat…` space + transposition) plus a new margin-refusal case; all pre-existing cases (ambiguity refusal, fabricated-id refusal, short-id floor, junk input) still pass unchanged.

Also syncs `controller/package-lock.json`'s version field (0.37.0 → 0.38.1, stale since the last release bump).

## Verification

- `npm run test:llm` — all pass, including the new #939 cases
- `npm run lint` (eslint + `tsc --noEmit`) — 0 errors