### PR TITLE
fix(llm): never air truncated reasoning (handoff spoke its own instructions)

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -9,7 +9,7 @@
 import assert from 'node:assert/strict';
 import { generateText, APICallError } from 'ai';
 import { MockLanguageModelV3 } from 'ai/test';
-import { stripThinking, extractJson, usageOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded, isRateLimited, errReason, nearestId } from '../src/llm/internal/core/pure.js';
+import { stripThinking, truncationError, extractJson, usageOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded, isRateLimited, errReason, nearestId } from '../src/llm/internal/core/pure.js';
 import { withDeadline, withTransientRetry, retryAfterMs } from '../src/llm/internal/core/retry.js';
 import { providerOptions, needsToolCallObject, repeatPenaltyApplies, appliedNumCtx, appliedRepeatPenalty, forcedToolChoice } from '../src/llm/internal/provider/capabilities.js';
 import { agentPlan } from '../src/llm/internal/strategy/plan.js';
@@ -531,6 +531,28 @@ async function main() {
     assert.equal(stripThinking('<|channel|>thought<|message|>hmm, still thinking'), '');
     // plain text with no channel tokens is untouched
     assert.equal(stripThinking('Just a normal DJ line.'), 'Just a normal DJ line.');
+  });
+  await test('truncationError fails a token-capped reply, passes a finished one', () => {
+    // Issue #947: a 'length' finish means the model ran to the output cap —
+    // for DJ free text that's always a runaway, never a usable script.
+    assert.equal(truncationError({ finishReason: 'stop', text: 'Coming up next.' }), null);
+    assert.equal(truncationError({ finishReason: 'unknown', text: 'x' }), null);
+    assert.equal(truncationError({}), null);
+    const err = truncationError({ finishReason: 'length', text: 'We need to output spoken words only…', usage: { outputTokens: 4000 } });
+    assert.ok(err instanceof Error);
+    // Raw text/usage ride on the error so failureDiagnostics + the console
+    // preview still show WHY the call failed.
+    assert.equal(err.text, 'We need to output spoken words only…');
+    assert.equal(err.finishReason, 'length');
+    assert.deepEqual(err.usage, { outputTokens: 4000 });
+    // The error must not look like a network status to any classifier — it
+    // should propagate straight to the caller's skip-segment path, never
+    // burning same-leg retries or silently failing over to the backup model.
+    assert.equal(isTransient(err), false);
+    assert.equal(isUnreachable(err), false);
+    assert.equal(isQuotaOrAuthError(err), false);
+    assert.equal(isUpstreamOverloaded(err), false);
+    assert.equal(isRateLimited(err), false);
   });
   await test('extractJson pulls the object out of fences and prose', () => {
     assert.equal(extractJson('```json\n{"a":1}\n```'), '{"a":1}');

--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -503,6 +503,18 @@ async function main() {
     // A verbatim two-way repeat (no third segment) is still a loop, not a leak.
     assert.equal(stripThinking('same line here</think>same line here'), 'same line here');
   });
+  await test('stripThinking drops an unterminated <think> block (token-cap truncation)', () => {
+    // Issue #947: a reasoning model looped inside its <think> block until the
+    // output-token cap cut it off, so the closing </think> never arrived. The
+    // whole body is trapped reasoning — drop it rather than speak it aloud.
+    assert.equal(
+      stripThinking('<think>We need to output spoken words only. Must not use articles. Also no his. Also no her. Also'),
+      '',
+    );
+    // Anything before the opener is real answer text — keep it (mirrors the
+    // harmony no-final-channel rule below).
+    assert.equal(stripThinking('Here we go. <think>wait, should I mention the'), 'Here we go.');
+  });
   await test('stripThinking strips Gemma/harmony channel reasoning, keeps the final message', () => {
     // thought → final: keep only the final channel's message
     assert.equal(

--- a/controller/src/llm/internal/core/pure.ts
+++ b/controller/src/llm/internal/core/pure.ts
@@ -89,6 +89,24 @@ export function stripThinking(s: any): any {
   return t.replace(ANY_THINK_TAG_RE, '').replace(HARMONY_TOKENS_RE, '').trim();
 }
 
+// A 'length' finish means the reply was cut at the output-token cap — for DJ
+// free text that's always a runaway reasoning generation, never a usable
+// script (issue #947: the truncated deliberation carried no closing marker for
+// stripThinking to catch and aired verbatim). Returns the Error the caller
+// should throw — with the raw text/usage attached so failureDiagnostics and
+// the console preview still show WHY — or null when the reply finished
+// normally. The message deliberately carries no digits so no transient/
+// failover classifier mistakes it for a network status (pinned in
+// llm-pure.test.ts). Pure so the guard itself is unit-testable.
+export function truncationError(result: { finishReason?: string; text?: string; usage?: any }): any | null {
+  if (result?.finishReason !== 'length') return null;
+  const err: any = new Error('reply truncated at the output-token cap — refusing to air a runaway generation');
+  err.text = result.text;
+  err.finishReason = 'length';
+  err.usage = result.usage;
+  return err;
+}
+
 // Pull a JSON object out of a free-text reply: drop ```json fences and any
 // prose around it, then take the outermost { … }. Used by djObject's recovery
 // path when native structured output fails to parse.

--- a/controller/src/llm/internal/core/pure.ts
+++ b/controller/src/llm/internal/core/pure.ts
@@ -61,7 +61,15 @@ export function stripThinking(s: any): any {
       t = segs.length >= 3 || hasRepeat ? segs[0] : segs[segs.length - 1];
     }
   }
-  // 3. Harmony / channel reasoning — keep only the text after the LAST
+  // 3. Unterminated <think> opener — the output-token cap cut the model off
+  //    mid-thought, so the closing tag never arrived (issue #947: a handoff
+  //    greeting aired ~4000 tokens of looping deliberation, and rule 4 alone
+  //    would strip just the tag and keep the body). Everything from the opener
+  //    on is trapped reasoning; keep only what precedes it (the <think>-tag
+  //    twin of the harmony no-final-channel rule below).
+  const openThink = t.search(/<think>/i);
+  if (openThink !== -1) t = t.slice(0, openThink);
+  // 4. Harmony / channel reasoning — keep only the text after the LAST
   //    final-channel opener, if any.
   let lastFinalEnd = -1;
   for (const m of t.matchAll(FINAL_CHANNEL_RE)) {
@@ -75,7 +83,7 @@ export function stripThinking(s: any): any {
     const open = t.search(ANY_CHANNEL_OPEN_RE);
     if (open !== -1) t = t.slice(0, open);
   }
-  // 4. Belt-and-suspenders — no stray <think>/</think> tag or leftover harmony
+  // 5. Belt-and-suspenders — no stray <think>/</think> tag or leftover harmony
   //    control token ever reaches TTS/booth. These literals never appear in a
   //    real DJ script.
   return t.replace(ANY_THINK_TAG_RE, '').replace(HARMONY_TOKENS_RE, '').trim();

--- a/controller/src/llm/internal/strategy/text.ts
+++ b/controller/src/llm/internal/strategy/text.ts
@@ -7,7 +7,7 @@
 import { generateText } from 'ai';
 import { withFailover } from '../core/failover.js';
 import { withTransientRetry } from '../core/retry.js';
-import { stripThinking, usageOf, failureDiagnostics } from '../core/pure.js';
+import { stripThinking, truncationError, usageOf, failureDiagnostics } from '../core/pure.js';
 import { providerOptions, repeatPenaltyApplies, samplingWithLocalKnobs } from '../provider/capabilities.js';
 import { resolveMaxOutputTokens } from '../../../settings.js';
 
@@ -53,19 +53,11 @@ export async function djText({
       // A free-text DJ script that hit the output-token cap is never a usable
       // reply — real scripts run ~150 tokens against the 4000-token backstop,
       // so 'length' means a reasoning model ran away mid-thought (issue #947:
-      // the truncated deliberation carried no closing marker for stripThinking
-      // to catch and aired verbatim, tying up the TTS GPU for minutes). Fail
-      // the call instead — announce-path callers catch and skip the segment,
-      // so the station stays on air, just without this talk break. The message
-      // deliberately carries no digits so no transient/failover classifier
-      // mistakes it for a network status.
-      if (result.finishReason === 'length') {
-        const err: any = new Error('reply truncated at the output-token cap — refusing to air a runaway generation');
-        err.text = result.text;
-        err.finishReason = result.finishReason;
-        err.usage = result.usage;
-        throw err;
-      }
+      // it tied up the TTS GPU for minutes). Fail the call instead —
+      // announce-path callers catch and skip the segment, so the station
+      // stays on air, just without this talk break.
+      const truncated = truncationError(result);
+      if (truncated) throw truncated;
       const out = stripThinking(result.text);
       // Only record sampling knobs that actually reached the model — see
       // repeatPenaltyApplies() and providerOptions handling.

--- a/controller/src/llm/internal/strategy/text.ts
+++ b/controller/src/llm/internal/strategy/text.ts
@@ -50,6 +50,22 @@ export async function djText({
         providerOptions: providerOptions(leg.cfg, { repeatPenalty }),
         ...(signal ? { abortSignal: signal } : {}),
       }), signal);
+      // A free-text DJ script that hit the output-token cap is never a usable
+      // reply — real scripts run ~150 tokens against the 4000-token backstop,
+      // so 'length' means a reasoning model ran away mid-thought (issue #947:
+      // the truncated deliberation carried no closing marker for stripThinking
+      // to catch and aired verbatim, tying up the TTS GPU for minutes). Fail
+      // the call instead — announce-path callers catch and skip the segment,
+      // so the station stays on air, just without this talk break. The message
+      // deliberately carries no digits so no transient/failover classifier
+      // mistakes it for a network status.
+      if (result.finishReason === 'length') {
+        const err: any = new Error('reply truncated at the output-token cap — refusing to air a runaway generation');
+        err.text = result.text;
+        err.finishReason = result.finishReason;
+        err.usage = result.usage;
+        throw err;
+      }
       const out = stripThinking(result.text);
       // Only record sampling knobs that actually reached the model — see
       // repeatPenaltyApplies() and providerOptions handling.


### PR DESCRIPTION
## Root cause (issue #947)

A reasoning model generating the persona-handoff greeting got stuck in a degenerate chain-of-thought loop and burned the entire 4000-token output cap without ever producing an answer (the reported blob ends mid-word — the token-cap truncation signature). Two gaps let it reach TTS:

1. **`stripThinking` only handles *complete* markers.** When truncation cuts the model off inside its `<think>` block, the closing `</think>` never arrives — rule 1 needs a closed block, rule 2 needs a stray closer, and the belt-and-suspenders pass then strips just the bare `<think>` tag and keeps the entire reasoning body. The harmony-channel path already handles its equivalent (no final channel → drop everything); the `<think>` form didn't.
2. **`djText` ignored `finishReason`.** A free-text DJ script that hit the output cap is never usable (real scripts run ~150 tokens against the 4000 backstop), yet it flowed straight to `queue.announce` → `tts.speak` — which is what kept the reporter's GPU busy rendering ~15KB of deliberation.

## Fix

- `core/pure.ts` — an unterminated `<think>` opener now drops everything from the opener on (keeping any answer text that preceded it), mirroring the harmony no-final-channel rule. Pinned in `scripts/llm-pure.test.ts` with the #947 shape.
- `strategy/text.ts` — `djText` throws on `finishReason === 'length'` instead of returning truncated text. Every announce-path caller already catches and skips the segment (e.g. `runHandoff` logs `Handoff greeting failed` and moves on), so the station stays on air — it just skips that talk break. The raw text rides on `err.text` so `/debug` and the console preview still show *why*. The error message deliberately carries no digits so no transient/failover classifier mistakes it for a network status.

Also covers the fully-untagged case (reasoning leaked into `content` with no markers at all): those replies only ever reached this size by running to the cap, so the `finishReason` guard catches them regardless of tagging.

## Verification

- The finishReason guard is extracted into `truncationError()` in `core/pure.ts` (the unit-test seam) and pinned: fails a capped reply with text/usage attached, passes a finished one, and its error matches no transient/failover classifier.

- `npm run test:llm` — all pass, including the new unterminated-`<think>` cases (verified failing before the fix).
- `npm run lint` — clean (the `src/mcp/*` TS2307s seen locally were a stale `node_modules`, pre-existing on develop, fixed by `npm install`).

Fixes #947
