### PR TITLE
feat(shows): multi-value genre/mood/energy/era show filters (#929)

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -705,14 +705,14 @@ async function main() {
     assert.equal(showMusicLean(null), '');
     assert.equal(showMusicLean(undefined), '');
   });
-  await test('soft genre-only show is byte-for-byte the legacy line', () => {
-    assert.equal(showMusicLean({ name: 'x', topic: 'y', genre: 'Jazz' }), SOFT_GENRE_LINE);
+  await test('soft single-genre show is byte-for-byte the legacy line', () => {
+    assert.equal(showMusicLean({ name: 'x', topic: 'y', genres: ['Jazz'] }), SOFT_GENRE_LINE);
   });
   await test('filtersStrict=false leaves the soft path unchanged', () => {
-    assert.equal(showMusicLean({ name: 'x', topic: 'y', genre: 'Jazz', filtersStrict: false }), SOFT_GENRE_LINE);
+    assert.equal(showMusicLean({ name: 'x', topic: 'y', genres: ['Jazz'], filtersStrict: false }), SOFT_GENRE_LINE);
   });
   await test('strict filters are a hard rule, not a soft lean', () => {
-    const out = showMusicLean({ name: 'x', topic: 'y', genre: 'Hip-Hop', filtersStrict: true });
+    const out = showMusicLean({ name: 'x', topic: 'y', genres: ['Hip-Hop'], filtersStrict: true });
     assert.match(out, /music filters are STRICT/);                  // the unified strict lock (#766)
     assert.match(out, /Hip-Hop tracks/);                            // genre carried into the lock
     assert.match(out, /Keep your talk inside them too/);            // stay-in-filter instruction
@@ -721,25 +721,38 @@ async function main() {
     assert.doesNotMatch(out, /Music steer/);     // no soft line when strict is on
   });
   await test('strict carries the never-starve escape hatch', () => {
-    const out = showMusicLean({ name: 'x', topic: 'y', genre: 'Metal', filtersStrict: true });
+    const out = showMusicLean({ name: 'x', topic: 'y', genres: ['Metal'], filtersStrict: true });
     assert.match(out, /never leave dead air/i);   // can stray only to avoid dead air
   });
   await test('strict needs a filter — filtersStrict alone is inert', () => {
     assert.equal(showMusicLean({ name: 'x', topic: 'y', filtersStrict: true }), '');
     // energy alone still bites: the unified toggle locks any pinned filter, not just genre
-    const out = showMusicLean({ name: 'x', topic: 'y', energy: 'high', filtersStrict: true });
+    const out = showMusicLean({ name: 'x', topic: 'y', energies: ['high'], filtersStrict: true });
     assert.match(out, /music filters are STRICT/);
     assert.match(out, /high-energy tracks/);
     assert.doesNotMatch(out, /Music steer/);   // strict, so no soft line
   });
   await test('strict locks genre, era and energy together (unified toggle)', () => {
-    const out = showMusicLean({ name: 'x', topic: 'y', genre: 'Soul', filtersStrict: true, fromYear: 1970, toYear: 1979, energy: 'medium' });
+    const out = showMusicLean({ name: 'x', topic: 'y', genres: ['Soul'], filtersStrict: true, eras: [{ fromYear: 1970, toYear: 1979 }], energies: ['medium'] });
     assert.match(out, /music filters are STRICT/);   // unified strict lock (#766)
     assert.match(out, /Soul tracks/);
     assert.match(out, /the 1970–1979 era/);
     assert.match(out, /medium-energy tracks/);
     assert.doesNotMatch(out, /Music steer/);       // era/energy are strict too — no soft line
     assert.doesNotMatch(out, /lean toward Soul/);  // genre is part of the hard lock
+  });
+  await test('multi-value filters render every entry, any-of (#929)', () => {
+    const soft = showMusicLean({ name: 'x', topic: 'y', genres: ['Hard Rock', 'Metal'], eras: [{ fromYear: 1990, toYear: 1999 }, { fromYear: 2010, toYear: 2019 }], energies: ['high', 'medium'] });
+    assert.match(soft, /lean toward Hard Rock \/ Metal/);
+    assert.match(soft, /1990–1999 or 2010–2019/);        // non-adjacent windows both named
+    assert.match(soft, /favour high \/ medium-energy tracks/);
+    const strictOut = showMusicLean({ name: 'x', topic: 'y', genres: ['Hard Rock', 'Metal'], moods: ['energetic', 'driving'], filtersStrict: true });
+    assert.match(strictOut, /Hard Rock \/ Metal tracks/);
+    assert.match(strictOut, /the energetic \/ driving moods/);
+  });
+  await test('open-ended era windows read as prose', () => {
+    const out = showMusicLean({ name: 'x', topic: 'y', eras: [{ fromYear: null, toYear: 2009 }] });
+    assert.match(out, /prefer tracks from up to 2009/);  // "nothing after the 2000s"
   });
 
   // ---- clampMaxOutputTokens / resolveMaxOutputTokens (per-call cap, #712) ----

--- a/controller/scripts/show-filter.test.ts
+++ b/controller/scripts/show-filter.test.ts
@@ -1,0 +1,118 @@
+// Unit pins for the shared show-music filter helpers (music/show-filter.ts) —
+// the multi-value semantics behind #929: OR within an attribute (any entry
+// matches), never-starve fallbacks, and the coarse era envelope (eraSpan) used
+// for single-window Subsonic calls. Every track here carries its own fields so
+// library.get() (which needs the DB open) is never consulted.
+//
+// Run: npm test -- show-filter
+
+import assert from 'node:assert/strict';
+import {
+  normGenre, genreMatches, preferGenre,
+  hasEraBound, eraSpan, inYearRange, preferEra,
+  preferEnergy, preferEnergyStrict, preferMood,
+} from '../src/music/show-filter.js';
+
+let failures = 0;
+async function test(name: string, fn: () => void | Promise<void>) {
+  try {
+    await fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  ✗ ${name}\n    ${(err as Error).message}`);
+  }
+}
+
+const t = (over: Record<string, unknown>) => ({ id: 'x', title: 't', artist: 'a', ...over });
+
+console.log('genre (any-of, never-starve):');
+await test('genreMatches matches ANY normalised target, substring both ways', () => {
+  assert.equal(genreMatches(t({ genre: 'Hip Hop' }), [normGenre('Hip-Hop')]), true);
+  assert.equal(genreMatches(t({ genre: 'Jazz' }), [normGenre('Rock'), normGenre('Jazz')]), true);
+  assert.equal(genreMatches(t({ genre: 'Jazz' }), [normGenre('Rock')]), false);
+  assert.equal(genreMatches(t({ genre: 'Jazz' }), []), false);
+});
+await test('preferGenre keeps tracks matching any entry; empty list is passthrough', () => {
+  const rock = t({ genre: 'Hard Rock' });
+  const jazz = t({ genre: 'Jazz' });
+  const metal = t({ genre: 'Metal' });
+  assert.deepEqual(preferGenre([rock, jazz, metal], ['Hard Rock', 'Metal']), [rock, metal]);
+  assert.deepEqual(preferGenre([rock, jazz], []), [rock, jazz]);
+  assert.deepEqual(preferGenre([rock, jazz], null), [rock, jazz]);
+});
+await test('preferGenre never-starves: zero matches → full set', () => {
+  const pool = [t({ genre: 'Jazz' }), t({ genre: 'Soul' })];
+  assert.deepEqual(preferGenre(pool, ['Polka']), pool);
+});
+
+console.log('era (window union, envelope):');
+await test('hasEraBound: empty / both-null windows carry no constraint', () => {
+  assert.equal(hasEraBound([]), false);
+  assert.equal(hasEraBound(null), false);
+  assert.equal(hasEraBound([{ fromYear: null, toYear: null }]), false);
+  assert.equal(hasEraBound([{ fromYear: 1990, toYear: null }]), true);
+});
+await test('inYearRange admits a track inside ANY window; gap years drop', () => {
+  const eras = [{ fromYear: 1990, toYear: 1999 }, { fromYear: 2010, toYear: 2019 }];
+  const y95 = t({ year: 1995 });
+  const y05 = t({ year: 2005 });   // the gap between the two windows
+  const y15 = t({ year: 2015 });
+  const noYear = t({});
+  assert.deepEqual(inYearRange([y95, y05, y15, noYear], eras), [y95, y15]);
+});
+await test('open-ended windows: toYear-only means "nothing after"', () => {
+  const eras = [{ fromYear: null, toYear: 2009 }];
+  assert.deepEqual(inYearRange([t({ year: 1970 }), t({ year: 2015 })], eras).length, 1);
+});
+await test('preferEra never-starves: nothing in range → full set', () => {
+  const pool = [t({ year: 1970 })];
+  assert.deepEqual(preferEra(pool, [{ fromYear: 2020, toYear: 2029 }]), pool);
+});
+await test('eraSpan: bounded windows → min/max envelope; any open bound opens that side', () => {
+  assert.deepEqual(
+    eraSpan([{ fromYear: 1990, toYear: 1999 }, { fromYear: 2010, toYear: 2019 }]),
+    { fromYear: 1990, toYear: 2019 },
+  );
+  // A toYear-only window leaves the from side open — the envelope must never
+  // exclude a track that window admits.
+  assert.deepEqual(
+    eraSpan([{ fromYear: null, toYear: 2009 }, { fromYear: 2020, toYear: 2029 }]),
+    { fromYear: null, toYear: 2029 },
+  );
+  assert.deepEqual(eraSpan([]), { fromYear: null, toYear: null });
+});
+
+console.log('energy (any-of bands):');
+await test('preferEnergy: unknown-energy tracks stay eligible; any band matches', () => {
+  const hi = t({ energy: 'high' });
+  const lo = t({ energy: 'low' });
+  const unknown = t({ id: null });   // no energy field, no id → no library lookup
+  assert.deepEqual(preferEnergy([hi, lo, unknown], ['high', 'medium']), [hi, unknown]);
+  assert.deepEqual(preferEnergy([hi, lo], []), [hi, lo]);
+});
+await test('preferEnergyStrict drops unknowns; never-starves on zero matches', () => {
+  const hi = t({ energy: 'high' });
+  const unknown = t({ id: null });
+  assert.deepEqual(preferEnergyStrict([hi, unknown], ['high', 'medium']), [hi]);
+  const pool = [t({ energy: 'low' })];
+  assert.deepEqual(preferEnergyStrict(pool, ['high']), pool);
+});
+
+console.log('mood (any-of tags):');
+await test('preferMood matches any selected mood, case-insensitive', () => {
+  const a = t({ moods: ['Energetic'], audioMoods: [] });
+  const b = t({ moods: ['calm'], audioMoods: [] });
+  const c = t({ moods: [], audioMoods: ['driving'] });
+  assert.deepEqual(preferMood([a, b, c], ['energetic', 'driving']), [a, c]);
+});
+await test('preferMood never-starves: un-tagged pool → full set', () => {
+  const pool = [t({ moods: [], audioMoods: [] })];
+  assert.deepEqual(preferMood(pool, ['calm']), pool);
+});
+
+if (failures) {
+  console.error(`\n${failures} show-filter test(s) failed.`);
+  process.exit(1);
+}
+console.log('\nAll show-filter tests passed.');

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -28,6 +28,7 @@ import { recordPick } from '../llm/log.js';
 import * as budget from './dj-budget.js';
 import { withTrace, logEvent } from '../observability/events.js';
 import { recencyWindowsForLibrary, effectiveNoRepeatWindow } from '../music/recency.js';
+import { hasEraBound } from '../music/show-filter.js';
 import { djCallsAllowed } from './listeners.js';
 
 // --- Feature 4: DJ-mode mini-runs ------------------------------------------
@@ -351,12 +352,12 @@ export const pickerAgent = defineAgent({
     // (issue #447), so no length cap is passed here.
     const activeShow = settings.resolveActiveShow(showAt ?? undefined);
     const strict = !!(activeShow?.filtersStrict);
-    const genreLock = strict && activeShow?.genre ? activeShow.genre : null;
-    const eraLock = strict && (activeShow?.fromYear != null || activeShow?.toYear != null)
-      ? { fromYear: activeShow.fromYear, toYear: activeShow.toYear }
-      : null;
-    const moodLock = strict && activeShow?.mood ? activeShow.mood : null;
-    const energyLock = strict && activeShow?.energy ? activeShow.energy : null;
+    // Each lock is an any-of list (#929): a candidate passes when it matches
+    // ANY entry; the locks AND together across attributes.
+    const genreLock = strict && activeShow?.genres?.length ? activeShow.genres : null;
+    const eraLock = strict && hasEraBound(activeShow?.eras) ? activeShow.eras : null;
+    const moodLock = strict && activeShow?.moods?.length ? activeShow.moods : null;
+    const energyLock = strict && activeShow?.energies?.length ? activeShow.energies : null;
     // playlistLock / playlistTracks are pre-resolved by pickViaAgent (the
     // Navidrome fetch is async; buildTools is sync) and threaded through run().
     const { tools, seen } = buildPickerTools({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, genreLock, eraLock, moodLock, energyLock, playlistLock, playlistTracks, excludedIds });

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -11,7 +11,7 @@ import * as subsonic from '../music/subsonic.js';
 import * as dj from '../llm/dj.js';
 import * as library from '../music/library.js';
 import * as settings from '../settings.js';
-import { normGenre, genreMatches, inYearRange, preferEnergy, preferEnergyStrict, preferMood } from '../music/show-filter.js';
+import { normGenre, genreMatches, inYearRange, preferEnergy, preferEnergyStrict, preferMood, hasEraBound, eraSpan } from '../music/show-filter.js';
 import { resolveShowPlaylistPool, resolveExcludedPlaylistIds } from '../music/show-playlist.js';
 import { getFullContext } from '../context.js';
 import { queue } from './queue.js';
@@ -87,16 +87,16 @@ async function refreshAutoPlaylistInner() {
   // should stay on-brand exactly as the picker does — so we steer the pool by the
   // active show's genre / era / energy, mirroring music/picker.ts (issue #629).
   const show: any = settings.resolveActiveShow();
-  const showGenre: string = show?.genre || '';
-  const fromYear: number | null = show?.fromYear ?? null;
-  const toYear: number | null = show?.toYear ?? null;
-  const showEnergy: string = show?.energy || '';
+  // Multi-value lists (#929): OR within an attribute, AND across attributes.
+  const showGenres: string[] = show?.genres ?? [];
+  const eras = (show?.eras ?? []) as { fromYear: number | null; toYear: number | null }[];
+  const showEnergies: string[] = show?.energies ?? [];
   // A genre or a year window narrows the pool; energy alone only soft-leans
   // (mirrors picker.hasMusicFilter). Strict (show.filtersStrict) opts EVERY set
   // filter — mood, genre, era, energy — into a hard filter on the pool.
-  const narrow = !!(show && (showGenre || fromYear != null || toYear != null));
-  const showMood: string = show?.mood || '';
-  const strict = !!(show?.filtersStrict && (showGenre || showMood || showEnergy || fromYear != null || toYear != null));
+  const narrow = !!(show && (showGenres.length || hasEraBound(eras)));
+  const showMoods: string[] = show?.moods ?? [];
+  const strict = !!(show?.filtersStrict && (showGenres.length || showMoods.length || showEnergies.length || hasEraBound(eras)));
 
   // Show playlist anchor: resolve the union once. The fallback must honour it
   // too, so the LLM-free coast (LLM down, budget-hard, zero listeners) still
@@ -108,30 +108,33 @@ async function refreshAutoPlaylistInner() {
   const strictPlaylist = hasPlaylist && !!show?.playlistStrict;
   const excludedIds = show ? await resolveExcludedPlaylistIds(show) : null;
 
-  // Resolve the show's free-text genre to the library's exact tag once, up front.
-  // A resolution failure / absent genre leaves genreName null, which disables the
+  // Resolve the show's free-text genres to the library's exact tags once, up
+  // front. Entries that fail to resolve drop out; NONE resolving disables the
   // strict hard-filter and the genre-targeted fetches — the documented degrade
   // path (a misspelled / library-absent genre falls back to the normal pool).
-  let genreName: string | null = null;
-  if (showGenre) {
-    try { genreName = await subsonic.resolveGenreName(showGenre); } catch {}
+  const genreNames: string[] = [];
+  for (const g of showGenres) {
+    try {
+      const resolved = await subsonic.resolveGenreName(g);
+      if (resolved) genreNames.push(resolved);
+    } catch {}
   }
-  const strictGenreNorm = strict && genreName ? normGenre(genreName) : null;
+  const strictGenreNorms = strict ? genreNames.map(normGenre).filter(Boolean) : [];
   // Strict: hard-drop off-genre / off-era tracks from every discovery source
   // (even if that empties the source) — the auto playlist airs in full with no
   // LLM gatekeeper, so never-starve off-target filler would actually play. The
   // dedicated genre source + genre/era-targeted random carry the pool; an
-  // unresolved genre disables the genre drop (genreName null → no filter).
+  // unresolved genre list disables the genre drop (no resolved names → no filter).
   // Mood and energy enforce with per-source never-starve instead (preferMood /
   // preferEnergyStrict): they depend on the tagger/analyzer having run, and an
   // un-tagged library hard-dropping everything would empty the dead-air
   // fallback entirely. Soft mode is a no-op here.
   const enforce = (items: any[]) => {
     let out = items;
-    if (strictGenreNorm) out = out.filter((t: any) => genreMatches(t, strictGenreNorm));
-    if (strict && (fromYear != null || toYear != null)) out = inYearRange(out, { fromYear, toYear });
-    if (strict && showMood) out = preferMood(out, showMood);
-    if (strict && showEnergy) out = preferEnergyStrict(out, showEnergy);
+    if (strictGenreNorms.length) out = out.filter((t: any) => genreMatches(t, strictGenreNorms));
+    if (strict && hasEraBound(eras)) out = inYearRange(out, eras);
+    if (strict && showMoods.length) out = preferMood(out, showMoods);
+    if (strict && showEnergies.length) out = preferEnergyStrict(out, showEnergies);
     return out;
   };
   // Shrink the off-genre / off-playlist sources so the dedicated show source
@@ -168,21 +171,33 @@ async function refreshAutoPlaylistInner() {
   // the (shrunk) discovery sources add variety.
   if (narrow) {
     try {
+      // getRandomSongs takes ONE genre + ONE contiguous range natively, so
+      // multiple values (#929) call per genre against the eras' coarse
+      // envelope (eraSpan); the genre-tagged sets post-filter to the exact
+      // window union (inYearRange).
+      const span = eraSpan(eras);
       const collected: any[] = [];
-      collected.push(...await subsonic.getRandomSongs({
-        size: strict ? 60 : 40,
-        genre: genreName || undefined,
-        fromYear: fromYear ?? undefined,
-        toYear: toYear ?? undefined,
-      }));
-      if (genreName) {
-        const g = await subsonic.getSongsByGenre(genreName, { count: strict ? 100 : 60 });
-        const ranged = inYearRange(g, { fromYear, toYear });
-        collected.push(...(ranged.length ? ranged : g));
+      const randomSize = strict ? 60 : 40;
+      const genreSetSize = strict ? 100 : 60;
+      for (const genreName of genreNames.length ? genreNames : [undefined]) {
+        collected.push(...await subsonic.getRandomSongs({
+          size: Math.ceil(randomSize / Math.max(1, genreNames.length)),
+          genre: genreName,
+          fromYear: span.fromYear ?? undefined,
+          toYear: span.toYear ?? undefined,
+        }));
+        if (genreName) {
+          const g = await subsonic.getSongsByGenre(genreName, { count: Math.ceil(genreSetSize / genreNames.length) });
+          const ranged = inYearRange(g, eras);
+          collected.push(...(ranged.length ? ranged : g));
+        }
       }
+      // The random fetch used the coarse era envelope — tighten to the exact
+      // union (never-starve to the envelope set when the union comes up empty).
+      const exact = hasEraBound(eras) ? inYearRange(collected, eras) : collected;
       // Genre/era are server-side native here; enforce() adds the strict
       // mood/energy filters on top (no-op in soft mode).
-      const leaned = enforce(preferEnergy(collected, showEnergy));
+      const leaned = enforce(preferEnergy(exact.length ? exact : collected, showEnergies));
       take('show-genre', shuffle(leaned), strict ? SHOW_GENRE_STRICT_WEIGHT : SHOW_GENRE_WEIGHT);
     } catch (err) {
       queue.log('error', `Show-genre fetch failed: ${err.message}`);
@@ -197,19 +212,32 @@ async function refreshAutoPlaylistInner() {
     take('show-playlist', shuffle(playlistPool!.tracks), strictPlaylist ? SHOW_PLAYLIST_STRICT_WEIGHT : SHOW_PLAYLIST_WEIGHT);
   }
 
-  // 1. Mood-tagged from the LLM-built library (only if tagger has run).
-  if (mood) {
-    take('mood', enforce(shuffle(preferEnergy(library.songsByMood(mood), showEnergy))), nz(MOOD_WEIGHT));
+  // 1. Mood-tagged from the LLM-built library (only if tagger has run). A
+  // multi-mood show pools ALL its moods equally (#929); autonomous hours keep
+  // the single dominantMood. Dedup by id across the unioned mood sets.
+  const poolMoods = showMoods.length ? showMoods : (mood ? [mood] : []);
+  if (poolMoods.length) {
+    const seenMoodIds = new Set<string>();
+    const moodPool: any[] = [];
+    for (const m of poolMoods) {
+      for (const t of library.songsByMood(m)) {
+        if (t?.id && seenMoodIds.has(t.id)) continue;
+        if (t?.id) seenMoodIds.add(t.id);
+        moodPool.push(t);
+      }
+    }
+    take('mood', enforce(shuffle(preferEnergy(moodPool, showEnergies))), nz(MOOD_WEIGHT));
   }
 
   // 2. Navidrome playlists whose name matches the mood — operator's hand curation.
   // Skipped when the show already pins its own playlist(s) (0b): mood-substring
   // matching would otherwise leak other shows' same-mood playlists into the
   // fallback pool (#642). Autonomous hours (no pinned playlists) keep it.
-  if (mood && !hasPlaylist) {
+  if (poolMoods.length && !hasPlaylist) {
     try {
       const playlists = await subsonic.getPlaylists();
-      const matched = playlists.filter((p: any) => p.name?.toLowerCase().includes(mood.toLowerCase()));
+      const matched = playlists.filter((p: any) =>
+        poolMoods.some(m => p.name?.toLowerCase().includes(m.toLowerCase())));
       const tracks: any[] = [];
       for (const pl of matched.slice(0, 2)) {
         try {
@@ -256,9 +284,24 @@ async function refreshAutoPlaylistInner() {
   // strict end-filter below would drop it anyway).
   if (pool.length < TARGET_POOL && !strictPlaylist) {
     try {
-      const random = narrow
-        ? await subsonic.getRandomSongs({ size: TARGET_POOL, genre: genreName || undefined, fromYear: fromYear ?? undefined, toYear: toYear ?? undefined })
-        : await subsonic.getRandomSongs({ size: TARGET_POOL });
+      let random: any[];
+      if (narrow) {
+        // Same per-genre split + coarse era envelope as the dedicated source.
+        const span = eraSpan(eras);
+        random = [];
+        for (const genreName of genreNames.length ? genreNames : [undefined]) {
+          random.push(...await subsonic.getRandomSongs({
+            size: Math.ceil(TARGET_POOL / Math.max(1, genreNames.length)),
+            genre: genreName,
+            fromYear: span.fromYear ?? undefined,
+            toYear: span.toYear ?? undefined,
+          }));
+        }
+        const exact = hasEraBound(eras) ? inYearRange(random, eras) : random;
+        random = exact.length ? exact : random;
+      } else {
+        random = await subsonic.getRandomSongs({ size: TARGET_POOL });
+      }
       take('random', shuffle(random), TARGET_POOL);
     } catch (err) {
       queue.log('error', `Random fetch failed: ${err.message}`);
@@ -312,10 +355,10 @@ async function refreshAutoPlaylistInner() {
   // Make the show-scoping visible to the operator (acceptance criteria #629):
   // a misspelled / absent strict genre that silently degraded, and a strict show
   // whose genre is too thin to fill the pool, are both worth surfacing.
-  if (strict && !genreName) {
-    queue.log('scheduler', `Auto-playlist: strict genre "${showGenre}" not found in library — fallback left unfiltered`);
-  } else if (strict && genreName && pool.length < TARGET_POOL) {
-    queue.log('scheduler', `Auto-playlist: only ${pool.length} in-genre tracks for ${genreName} — looping a short genre-pure fallback`);
+  if (strict && showGenres.length && !genreNames.length) {
+    queue.log('scheduler', `Auto-playlist: strict genre(s) "${showGenres.join(', ')}" not found in library — fallback left unfiltered`);
+  } else if (strict && genreNames.length && pool.length < TARGET_POOL) {
+    queue.log('scheduler', `Auto-playlist: only ${pool.length} in-genre tracks for ${genreNames.join(', ')} — looping a short genre-pure fallback`);
   }
   if (strictPlaylist && pool.length < TARGET_POOL) {
     queue.log('scheduler', `Auto-playlist: only ${pool.length} in-playlist tracks — looping a short playlist-pure fallback`);
@@ -324,11 +367,15 @@ async function refreshAutoPlaylistInner() {
   const playlistTag = hasPlaylist
     ? (playlistPool!.names.length ? playlistPool!.names.join('/') : `${show.playlistIds.length} playlist(s)`)
     : '';
+  const eraTag = eras
+    .filter(e => e.fromYear != null || e.toYear != null)
+    .map(e => `${e.fromYear ?? ''}-${e.toYear ?? ''}`)
+    .join(',');
   const showInfo = show
     ? `, show=${show.name}${strict ? ' filters=strict' : ''}` +
-      (showGenre ? ` genre=${genreName || showGenre}` : '') +
-      (fromYear != null || toYear != null ? ` year=${fromYear ?? ''}-${toYear ?? ''}` : '') +
-      (showEnergy ? ` energy=${showEnergy}` : '') +
+      (showGenres.length ? ` genre=${(genreNames.length ? genreNames : showGenres).join(',')}` : '') +
+      (eraTag ? ` year=${eraTag}` : '') +
+      (showEnergies.length ? ` energy=${showEnergies.join(',')}` : '') +
       (hasPlaylist ? ` playlist=${playlistTag} (${strictPlaylist ? 'strict' : 'soft'})` : '')
     : '';
   queue.log('scheduler',

--- a/controller/src/context.ts
+++ b/controller/src/context.ts
@@ -253,7 +253,10 @@ const SHOW_ENERGY_DELIVERY: Record<string, { speed: number; register: string }> 
 };
 
 export function energyForDaypart(date = new Date()) {
-  const pinned = SHOW_ENERGY_DELIVERY[resolveActiveShow(date)?.energy ?? ''];
+  // A multi-energy show (#929) speaks at its LEAD energy — vocal delivery
+  // needs one register, so the first selected band wins here even though the
+  // pick filters treat all bands equally.
+  const pinned = SHOW_ENERGY_DELIVERY[resolveActiveShow(date)?.energies?.[0] ?? ''];
   if (pinned) return pinned;
   const { period } = getTimeContext(date);
   const { isLateNight, isCommute } = getClockContext(date);
@@ -304,7 +307,10 @@ export async function getFullContext(at?: Date) {
   }
 
   // Show > festival > weather > time, in that order of priority for mood.
-  const dominantMood = activeShow?.mood || festival?.mood || weather.mood || time.mood;
+  // dominantMood is a single value by contract (scenario lines, session keys,
+  // mood-pool seeds), so a multi-mood show leads with its FIRST mood here; the
+  // pick paths union the full moods list themselves (picker/scheduler #929).
+  const dominantMood = activeShow?.moods?.[0] || festival?.mood || weather.mood || time.mood;
 
   // Live audience size, from the cached Icecast monitor. `count` is null when
   // it couldn't be read — callers treat that as "unknown" and stay quiet.

--- a/controller/src/llm/internal/prompts/context.ts
+++ b/controller/src/llm/internal/prompts/context.ts
@@ -135,7 +135,7 @@ export function buildContextLines(
     // evening show kept mellowing out. With a mood pinned, keep the period
     // label (the clock is real) and stand the vibe down; the show line below
     // carries the tone instead.
-    lines.push(context?.activeShow?.mood
+    lines.push(context?.activeShow?.moods?.length
       ? `Period: ${context.time.period}`
       : `Period: ${context.time.period} (${context.time.vibe})`);
   }
@@ -152,10 +152,13 @@ export function buildContextLines(
     // getFullContext) keeps mid-show links and segments on today's line, not
     // just the standing brief.
     const angle = context.activeShow.episodeAngle ? ` Today's episode angle: ${context.activeShow.episodeAngle}.` : '';
-    // The pinned mood already steers the pick pool via dominantMood, but the
-    // talk prompts never saw it — say it here so the delivery follows the
+    // The pinned moods already steer the pick pool via dominantMood, but the
+    // talk prompts never saw them — say them here so the delivery follows the
     // show's brief, not the hour's default.
-    const mood = context.activeShow.mood ? ` Its mood is ${context.activeShow.mood} — let that set the tone, not the time of day.` : '';
+    const showMoods: string[] = context.activeShow.moods ?? [];
+    const mood = showMoods.length
+      ? ` Its mood is ${showMoods.join(' / ')} — let that set the tone, not the time of day.`
+      : '';
     lines.push(`On now: the show "${context.activeShow.name}"${topic}.${angle}${mood} Stay loosely on its theme.`);
   }
   if (on('listeners') && context?.listeners?.count != null) {

--- a/controller/src/llm/internal/prompts/picker.ts
+++ b/controller/src/llm/internal/prompts/picker.ts
@@ -28,25 +28,33 @@ export function effectsGuidance(): string {
   return `\n\nTRANSITION EFFECTS ("transition") — part of your craft, not a gimmick: a working DJ fires one every few songs when the moment earns it. Actively look for the moment on every pick; when you spot one, flag it — the station validates your choice against the audio analysis and skips ones that don't land. The PACING is entirely yours: there is no rate limit, so be the taste — an effect hits hardest coming out of a stretch of clean blends, so let a few ordinary transitions breathe between them. VARY THEM: they are equals in your kit, and if your recent picks leaned on one, reach for another.\n- "washout": your pick dissolves into a pulsing, tempo-synced echo tail as it ENDS, ringing out into whatever follows. Fire it whenever your pick is the natural END of something: the last track of a run of similar songs, a song with a big or atmospheric ending, anything dreamy/hazy/anthemic, or when the NEXT stretch will change direction. In a normal set several tracks qualify — this is your workhorse exit move, not a rarity.\n- "sweep": the track playing before your pick sinks under a slowly closing filter across the blend while your pick rises clean underneath. Use it on a genuine gear-change — a clear jump in energy, tempo, or mood (it only fires when the tracks measurably clash).\n- "blend": spectral handover — across a long crossfade the outgoing track hands its bass, then its mids, to your pick, keeping only its highs to the end, while your pick arrives lows-first underneath. The two feel like ONE continuous piece of music. Reserve it for the EXCEPTIONAL pair, not the merely similar — your picks already flow, and the plain crossfade handles an ordinary same-lane transition on its own. Flag blend only when the two tracks are properly locked (near-identical tempo, harmonically close key) — roughly one pick in five, or it stops meaning anything (it only fires when the tracks measurably fit).\n- "dissolve": the track playing before your pick melts into a diffuse, beatless ambient wash while your pick rises clean through it — the reverb throw. The SMOOTH way across a clash where the sweep is the dramatic way: choose it when the tempo or mood jump should be hidden rather than announced (into a talk break's aftermath, easing between worlds late at night). Like the sweep it only fires when the tracks measurably clash.\n- "chop": the track playing before your pick is CUT rhythmically on its own beat — the crossfader cut: full-level stabs on the beat, thinning and sparsening out while your pick rises clean through the gaps. The PERCUSSIVE way across a clash: choose it to jump the energy UP off a beat-driven, percussive track (a takeover moment, kicking a set up a gear) — never out of anything ambient or beatless, where there is no beat to cut on. Like the sweep it only fires when the tracks measurably clash.\n- "loop": your pick\'s last bar is caught in a tempo-synced loop as it ENDS — the exit loop: the song is cut on the beat and its final bar repeats hypnotically under the next track before it filters away. Choose it to leave a groove-driven track with intent: a great riff, a locked drum pattern, the close of a rhythmic run. It needs the track\'s measured tempo (the station drops it on un-analysed tracks), and it reads best off percussive material — never out of something ambient.\nUse "normal" or null only when nothing above applies.`;
 }
 
-export type ShowMusic = { name: string; topic: string; mood?: string; genre?: string; fromYear?: number | null; toYear?: number | null; energy?: string; filtersStrict?: boolean };
+export type ShowEra = { fromYear?: number | null; toYear?: number | null };
+export type ShowMusic = { name: string; topic: string; moods?: string[]; genres?: string[]; eras?: ShowEra[]; energies?: string[]; filtersStrict?: boolean };
 
-// A show can pin a mood, genre, decade and/or energy band on track selection.
-// All are SOFT leans by default, or HARD constraints when `filtersStrict` is on
-// (one toggle governs every set filter). Render it as one prompt line shared by
-// both pick paths (the pool picker here and the conversational agent in
-// broadcast/dj-agent.ts). Returns '' when the show pins nothing, so callers can
-// append it unconditionally.
+// One era window as prose ("1990–1999", "1970 onward", "up to 1989").
+function eraWindowText(e: ShowEra): string {
+  const from = e.fromYear != null ? String(e.fromYear) : '';
+  const to = e.toYear != null ? String(e.toYear) : '';
+  return from && to ? `${from}–${to}` : from ? `${from} onward` : to ? `up to ${to}` : '';
+}
+
+// A show can pin moods, genres, decades and/or energy bands on track selection
+// — each a multi-value list (#929): any entry satisfies the attribute, all
+// entries weighted equally. All are SOFT leans by default, or HARD constraints
+// when `filtersStrict` is on (one toggle governs every set filter). Render it
+// as one prompt line shared by both pick paths (the pool picker here and the
+// conversational agent in broadcast/dj-agent.ts). Returns '' when the show
+// pins nothing, so callers can append it unconditionally.
 export function showMusicLean(show?: ShowMusic | null): string {
   if (!show) return '';
-  const eraText = (() => {
-    if (show.fromYear == null && show.toYear == null) return '';
-    const from = show.fromYear != null ? String(show.fromYear) : '';
-    const to = show.toYear != null ? String(show.toYear) : '';
-    return from && to ? `${from}–${to}` : from ? `${from} onward` : `up to ${to}`;
-  })();
+  const genres = show.genres ?? [];
+  const moods = show.moods ?? [];
+  const energies = show.energies ?? [];
+  const eraText = (show.eras ?? []).map(eraWindowText).filter(Boolean).join(' or ');
   // Strict only bites when there's actually a filter to lock to.
-  const hasFilter = !!(show.genre || show.mood || show.energy || eraText);
+  const hasFilter = !!(genres.length || moods.length || energies.length || eraText);
   const strict = !!(show.filtersStrict && hasFilter);
+  const or = (xs: string[]) => xs.join(' / ');
 
   if (strict) {
     // The hard rule. Track selection is code-enforced for strict shows (the
@@ -55,19 +63,19 @@ export function showMusicLean(show?: ShowMusic | null): string {
     // still surface), not the candidate list. Mood joins the lock here — soft
     // shows carry mood through the room-context prompt instead.
     const locks: string[] = [];
-    if (show.genre) locks.push(`${show.genre} tracks`);
-    if (eraText) locks.push(`the ${eraText} era`);
-    if (show.mood) locks.push(`the ${show.mood} mood`);
-    if (show.energy) locks.push(`${show.energy}-energy tracks`);
+    if (genres.length) locks.push(`${or(genres)} tracks`);
+    if (eraText) locks.push(`the ${eraText} era${(show.eras?.length ?? 0) > 1 ? 's' : ''}`);
+    if (moods.length) locks.push(`the ${or(moods)} mood${moods.length > 1 ? 's' : ''}`);
+    if (energies.length) locks.push(`${or(energies)}-energy tracks`);
     return `\n\nThis show's music filters are STRICT — every pick must fit: ${locks.join('; ')}. Keep your talk inside them too; only step outside if there is genuinely nothing left that fits (never leave dead air).`;
   }
 
   // Soft preferences. Mood is deliberately absent — it steers the room context
   // (dominantMood) rather than reading as a per-track preference.
   const parts: string[] = [];
-  if (show.genre) parts.push(`lean toward ${show.genre}`);
+  if (genres.length) parts.push(`lean toward ${or(genres)}`);
   if (eraText) parts.push(`prefer tracks from ${eraText}`);
-  if (show.energy) parts.push(`favour ${show.energy}-energy tracks`);
+  if (energies.length) parts.push(`favour ${or(energies)}-energy tracks`);
   return parts.length
     ? `\n\nMusic steer for this show — ${parts.join('; ')}. These are preferences, not hard filters: break them only when the flow genuinely demands it.`
     : '';

--- a/controller/src/llm/internal/tools/picker-tools.ts
+++ b/controller/src/llm/internal/tools/picker-tools.ts
@@ -115,23 +115,26 @@ export function buildPickerTools({
   // queue.recentlyPlayedByCount(N); empty on the request path (requests exempt).
   hardRecentIds?: Set<string>;
   hardRecentKeys?: Set<string>;    // lowercased "title|artist" — blocks id-less backfilled plays
-  // Hard genre constraint for a strict show (show.filtersStrict). When set,
-  // every tool's candidates are genre-filtered (preferGenre, never-starve)
-  // before recency + cap, so the agent path enforces the lock in code, not just
-  // the prompt — mirroring the pool picker's strict mode. null = no lock.
-  // Deliberately NOT set on the request path: an explicit listener ask wins.
-  genreLock?: string | null;
-  // Hard era (decade/year window) constraint, applied only for a strict show
-  // (same filtersStrict flag — one toggle governs every filter). When set,
-  // candidates are year-filtered (preferEra, never-starve) before recency +
-  // cap. null / both-bounds-null = no era lock.
-  eraLock?: { fromYear?: number | null; toYear?: number | null } | null;
-  // Hard mood constraint for a strict show: candidates are filtered to tracks
-  // tagged with the show's mood (preferMood, never-starve). null = no lock.
-  moodLock?: string | null;
-  // Hard energy-band constraint for a strict show: candidates are filtered to
-  // the analysed band (preferEnergyStrict — unknowns dropped, never-starve).
-  energyLock?: string | null;
+  // Hard genre constraint for a strict show (show.filtersStrict) — a list of
+  // genres, any-of (#929). When set, every tool's candidates are genre-filtered
+  // (preferGenre, never-starve) before recency + cap, so the agent path
+  // enforces the lock in code, not just the prompt — mirroring the pool
+  // picker's strict mode. null/empty = no lock. Deliberately NOT set on the
+  // request path: an explicit listener ask wins.
+  genreLock?: string[] | null;
+  // Hard era constraint — a list of decade/year windows, any-of (#929) —
+  // applied only for a strict show (same filtersStrict flag — one toggle
+  // governs every filter). When set, candidates are year-filtered (preferEra,
+  // never-starve) before recency + cap. null/empty = no era lock.
+  eraLock?: { fromYear?: number | null; toYear?: number | null }[] | null;
+  // Hard mood constraint for a strict show — any-of list: candidates are
+  // filtered to tracks tagged with any of the show's moods (preferMood,
+  // never-starve). null/empty = no lock.
+  moodLock?: string[] | null;
+  // Hard energy-band constraint for a strict show — any-of list: candidates
+  // are filtered to the analysed bands (preferEnergyStrict — unknowns dropped,
+  // never-starve).
+  energyLock?: string[] | null;
   // The active sonic journey's current waypoint vector (broadcast/dj-agent.ts).
   // When present, the tracksTowardJourney tool below is registered, closing
   // over it — the agent never sees the raw vector, only the tracks near it.
@@ -173,10 +176,10 @@ export function buildPickerTools({
     // back to the full list when a tool returns no match), so a thin constraint
     // degrades to off-target rather than dead air — same contract as the pool path.
     let pool = shuffle((list || []) as any[]);
-    if (genreLock) pool = preferGenre(pool, genreLock);
-    if (eraLock) pool = preferEra(pool, eraLock);
-    if (moodLock) pool = preferMood(pool, moodLock);
-    if (energyLock) pool = preferEnergyStrict(pool, energyLock);
+    if (genreLock?.length) pool = preferGenre(pool, genreLock);
+    if (eraLock?.length) pool = preferEra(pool, eraLock);
+    if (moodLock?.length) pool = preferMood(pool, moodLock);
+    if (energyLock?.length) pool = preferEnergyStrict(pool, energyLock);
     // Strict playlist: HARD-intersect with the lock set, with NO never-starve to
     // off-playlist (a playlist is an exact set, so a tool with no overlap simply
     // contributes nothing). The guaranteed in-set source is showPlaylistTracks

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -12,7 +12,7 @@ import * as dj from '../llm/dj.js';
 import * as settings from '../settings.js';
 import { bpmCompat, keyCompat } from './mix.js';
 import { filterPickerCandidates, recencyWindowsForLibrary, effectiveNoRepeatWindow } from './recency.js';
-import { normGenre, genreMatches, preferGenre, preferEra, inYearRange, preferEnergy, preferEnergyStrict, preferMood } from './show-filter.js';
+import { normGenre, genreMatches, preferGenre, preferEra, inYearRange, preferEnergy, preferEnergyStrict, preferMood, hasEraBound, eraSpan, type YearRange } from './show-filter.js';
 import { resolveShowPlaylistPool, resolveExcludedPlaylistIds, type PlaylistPool } from './show-playlist.js';
 
 const CANDIDATE_CAP = 18;
@@ -104,10 +104,12 @@ function softRankByCompat(pool: any[], current: { bpm: number | null; key: strin
 // fill the pool degrades to off-filter tracks rather than dead air (logged by
 // the caller for genre).
 
-type ShowFilter = { mood?: string; genre?: string; fromYear?: number | null; toYear?: number | null; energy?: string; strict?: boolean } | null;
+// Multi-value lists (#929): OR within an attribute, AND across attributes.
+// Empty list = no constraint on that attribute.
+type ShowFilter = { moods: string[]; genres: string[]; eras: YearRange[]; energies: string[]; strict?: boolean } | null;
 
 function hasMusicFilter(f: ShowFilter): boolean {
-  return !!f && (!!f.genre || f.fromYear != null || f.toYear != null);
+  return !!f && (f.genres.length > 0 || hasEraBound(f.eras));
 }
 
 // Genre / energy / era helpers (normGenre / genreMatches / preferGenre /
@@ -164,14 +166,19 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
   // matches), so a thin constraint degrades rather than strands the show.
   // Soft mode leaves the sources untouched (only the nz() shrink applies).
   const strict = !!(showFilter?.strict
-    && (showFilter?.genre || showFilter?.mood || showFilter?.energy
-      || showFilter?.fromYear != null || showFilter?.toYear != null));
-  // Resolve the show's free-text genre to the library's exact tag ONCE, up
-  // front. A resolution failure / absent genre degrades to no genre filter so
-  // a misspelled genre never strands the show (never-starve).
-  let strictGenre: string | null = null;
-  if (strict && showFilter?.genre) {
-    try { strictGenre = await subsonic.resolveGenreName(showFilter.genre); } catch {}
+    && (showFilter.genres.length || showFilter.moods.length || showFilter.energies.length
+      || hasEraBound(showFilter.eras)));
+  // Resolve the show's free-text genres to the library's exact tags ONCE, up
+  // front. A resolution failure drops that entry (never-starve: none resolving
+  // means no genre filter at all, so misspelled genres never strand the show).
+  const strictGenres: string[] = [];
+  if (strict && showFilter?.genres.length) {
+    for (const g of showFilter.genres) {
+      try {
+        const resolved = await subsonic.resolveGenreName(g);
+        if (resolved) strictGenres.push(resolved);
+      } catch {}
+    }
   }
   // Hard-prefer every set filter on a discovery source in strict mode; a no-op
   // otherwise. Each prefer* falls back to the full set when nothing in the
@@ -179,10 +186,10 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
   const lean = (items: any[]) => {
     if (!strict) return items;
     let out = items;
-    if (strictGenre) out = preferGenre(out, strictGenre);
-    out = preferEra(out, showFilter!);
-    out = preferMood(out, showFilter!.mood);
-    out = preferEnergyStrict(out, showFilter!.energy);
+    if (strictGenres.length) out = preferGenre(out, strictGenres);
+    out = preferEra(out, showFilter!.eras);
+    out = preferMood(out, showFilter!.moods);
+    out = preferEnergyStrict(out, showFilter!.energies);
     return out;
   };
 
@@ -247,34 +254,50 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     } catch {}
   }
 
-  // 1e. Show genre / decade — the soft-dominant source when a show pins a
-  // genre or a year range. getRandomSongs takes genre + year-range natively in
-  // one call; when a genre is set we also pull the full genre-tagged set
-  // (broader than a random sample) and soft-filter it to the decade. The whole
-  // collection is then energy-preferred. Never a hard filter — see helpers.
+  // 1e. Show genres / decades — the soft-dominant source when a show pins
+  // genres or year windows. getRandomSongs takes ONE genre + ONE contiguous
+  // year range natively, so with multiple values we call per genre (splitting
+  // the size budget) against the eras' coarse envelope (eraSpan), then post-
+  // filter the genre-tagged sets to the exact era union (inYearRange). The
+  // whole collection is then energy-preferred. Never a hard filter — see helpers.
   if (hasMusicFilter(showFilter)) {
     try {
-      // Reuse the strict-resolved tag when we already paid for it above; only
-      // resolve here on the soft path (or if strict resolution came back null).
-      let genreName: string | null = strict ? strictGenre : null;
-      if (!genreName && showFilter!.genre) {
-        genreName = await subsonic.resolveGenreName(showFilter!.genre);
+      // Reuse the strict-resolved tags when we already paid for them above;
+      // only resolve here on the soft path (or if strict resolution came back
+      // empty). Unresolvable genres drop out (never-starve).
+      const genreNames: string[] = strict ? [...strictGenres] : [];
+      if (!genreNames.length && showFilter!.genres.length) {
+        for (const g of showFilter!.genres) {
+          try {
+            const resolved = await subsonic.resolveGenreName(g);
+            if (resolved) genreNames.push(resolved);
+          } catch {}
+        }
       }
+      const span = eraSpan(showFilter!.eras);
       const collected: any[] = [];
-      collected.push(...await subsonic.getRandomSongs({
-        size: strict ? 60 : 40,
-        genre: genreName || undefined,
-        fromYear: showFilter!.fromYear ?? undefined,
-        toYear: showFilter!.toYear ?? undefined,
-      }));
-      if (genreName) {
-        const g = await subsonic.getSongsByGenre(genreName, { count: strict ? 100 : 60 });
-        const ranged = inYearRange(g, showFilter!);
-        collected.push(...(ranged.length ? ranged : g));
+      const randomSize = strict ? 60 : 40;
+      const genreSetSize = strict ? 100 : 60;
+      for (const genreName of genreNames.length ? genreNames : [undefined]) {
+        collected.push(...await subsonic.getRandomSongs({
+          size: Math.ceil(randomSize / Math.max(1, genreNames.length)),
+          genre: genreName,
+          fromYear: span.fromYear ?? undefined,
+          toYear: span.toYear ?? undefined,
+        }));
+        if (genreName) {
+          const g = await subsonic.getSongsByGenre(genreName, { count: Math.ceil(genreSetSize / genreNames.length) });
+          const ranged = inYearRange(g, showFilter!.eras);
+          collected.push(...(ranged.length ? ranged : g));
+        }
       }
+      // The random fetch used the coarse era envelope — tighten to the exact
+      // window union here (never-starve: keep the envelope set if the exact
+      // union would empty the source).
+      const exact = hasEraBound(showFilter!.eras) ? inYearRange(collected, showFilter!.eras) : collected;
       // Genre/era are already native to this source; lean() adds the strict
       // mood/energy filters on top (no-op in soft mode).
-      const leaned = lean(preferEnergy(collected, showFilter!.energy));
+      const leaned = lean(preferEnergy(exact.length ? exact : collected, showFilter!.energies));
       // Strict bumps the cap so this genre-native source dominates the merged pool.
       add('show-genre', sampleWithRecentFallback(shuffle(leaned), recentIds, strict ? CAP_SHOW_GENRE_STRICT : CAP_SHOW_GENRE));
     } catch {}
@@ -288,9 +311,21 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     add('show-playlist', sampleWithRecentFallback(shuffle(playlistPool!.tracks), recentIds, strictPlaylist ? CAP_SHOW_PLAYLIST_STRICT : CAP_SHOW_PLAYLIST));
   }
 
-  // 2. Mood-tagged library (LLM-built tags, may be sparse).
-  if (mood) {
-    const moodHits = shuffle(lean(preferEnergy(library.songsByMood(mood), showFilter?.energy)));
+  // 2. Mood-tagged library (LLM-built tags, may be sparse). A multi-mood show
+  // pools ALL its moods equally (#929); autonomous hours keep the single
+  // dominantMood. Dedup by id across the unioned mood sets.
+  const poolMoods = showFilter?.moods.length ? showFilter.moods : (mood ? [mood] : []);
+  if (poolMoods.length) {
+    const seenMoodIds = new Set<string>();
+    const moodPool: any[] = [];
+    for (const m of poolMoods) {
+      for (const t of library.songsByMood(m)) {
+        if (t?.id && seenMoodIds.has(t.id)) continue;
+        if (t?.id) seenMoodIds.add(t.id);
+        moodPool.push(t);
+      }
+    }
+    const moodHits = shuffle(lean(preferEnergy(moodPool, showFilter?.energies)));
     add('mood-library', sampleWithRecentFallback(moodHits, recentIds, CAP_MOOD_LIBRARY));
   }
 
@@ -299,10 +334,11 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
   // which playlists to use, so also grabbing every playlist whose name merely
   // contains the mood word would leak other shows' same-mood playlists into the
   // pool (#642). Autonomous hours (no pinned playlists) keep the mood match.
-  if (mood && !hasPlaylist) {
+  if (poolMoods.length && !hasPlaylist) {
     try {
       const playlists = await memo('playlists', CACHE_TTL_MS, () => subsonic.getPlaylists());
-      const matched = playlists.filter((p: any) => p.name?.toLowerCase().includes(mood.toLowerCase()));
+      const matched = playlists.filter((p: any) =>
+        poolMoods.some(m => p.name?.toLowerCase().includes(m.toLowerCase())));
       const plTracks: any[] = [];
       for (const pl of matched.slice(0, 2)) {
         try {
@@ -421,15 +457,15 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
   });
 
   // Strict-genre diagnostics for the caller's never-starve log: how much of the
-  // final pool actually landed in-genre. `resolved` is null when the show's
-  // genre didn't map to any library tag (strict silently degraded to soft).
+  // final pool actually landed in-genre. `resolved` is null when NONE of the
+  // show's genres mapped to a library tag (strict silently degraded to soft).
   let strictInfo: { requested: string; resolved: string | null; matched: number; total: number } | null = null;
-  if (strict && showFilter?.genre) {
-    const target = strictGenre ? normGenre(strictGenre) : '';
+  if (strict && showFilter?.genres.length) {
+    const targets = strictGenres.map(normGenre).filter(Boolean);
     strictInfo = {
-      requested: showFilter!.genre!,
-      resolved: strictGenre,
-      matched: target ? final.filter((t: any) => genreMatches(t, target)).length : 0,
+      requested: showFilter.genres.join(', '),
+      resolved: strictGenres.length ? strictGenres.join(', ') : null,
+      matched: targets.length ? final.filter((t: any) => genreMatches(t, targets)).length : 0,
       total: final.length,
     };
   }
@@ -491,7 +527,13 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   // (picker-test's stub) fall back to resolving at now.
   const activeShow = ctx?.activeShow !== undefined ? ctx.activeShow : settings.resolveActiveShow();
   const showFilter: ShowFilter = activeShow
-    ? { mood: activeShow.mood, genre: activeShow.genre, fromYear: activeShow.fromYear, toYear: activeShow.toYear, energy: activeShow.energy, strict: activeShow.filtersStrict }
+    ? {
+        moods: activeShow.moods ?? [],
+        genres: activeShow.genres ?? [],
+        eras: activeShow.eras ?? [],
+        energies: activeShow.energies ?? [],
+        strict: activeShow.filtersStrict,
+      }
     : null;
   // Resolve the show's anchored Navidrome playlist(s), if any, into a deduped
   // track pool. Null when the show pins none (the common case → pool unchanged).
@@ -561,11 +603,10 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
         ? {
             name: activeShow.name,
             topic: activeShow.topic,
-            mood: activeShow.mood,
-            genre: activeShow.genre,
-            fromYear: activeShow.fromYear,
-            toYear: activeShow.toYear,
-            energy: activeShow.energy,
+            moods: activeShow.moods,
+            genres: activeShow.genres,
+            eras: activeShow.eras,
+            energies: activeShow.energies,
             filtersStrict: activeShow.filtersStrict,
           }
         : null,

--- a/controller/src/music/show-filter.ts
+++ b/controller/src/music/show-filter.ts
@@ -3,6 +3,11 @@
 // stateless pool picker (music/picker.ts) and the conversational agent's
 // discovery tools (llm/internal/tools/picker-tools.ts). Keeping them here stops
 // the two paths from drifting on what "in-genre" / "in-era" means.
+//
+// Multi-value semantics (#929): every filter takes a LIST of values — a track
+// matches the attribute when it matches ANY entry (OR within the attribute);
+// the pick paths then AND the attributes together. Every entry is weighted
+// equally. An empty list means "no constraint" and passes everything through.
 
 import * as library from './library.js';
 
@@ -22,57 +27,90 @@ export function trackGenre(t: any): string | null {
   return rec?.genre ?? null;
 }
 
-// True when a track's genre matches the (already library-resolved) target genre.
-// Exact-normalised match, or substring either way — same shape as
+// True when a track's genre matches ANY of the (already normalised) target
+// genres. Exact-normalised match, or substring either way — same shape as
 // subsonic.resolveGenreName, so "Hip-Hop" matches a "Hip Hop" tag etc.
-export function genreMatches(t: any, targetNorm: string): boolean {
+export function genreMatches(t: any, targetNorms: string[]): boolean {
+  if (!targetNorms.length) return false;
   const g = trackGenre(t);
   if (!g) return false;
   const gn = normGenre(g);
-  return !!gn && (gn === targetNorm || gn.includes(targetNorm) || targetNorm.includes(gn));
+  if (!gn) return false;
+  return targetNorms.some(target => !!target && (gn === target || gn.includes(target) || target.includes(gn)));
 }
 
-// Hard-prefer tracks matching the show's genre (strict mode). Unlike the soft
-// energy/year leans, an untagged or off-genre track does NOT stay eligible —
-// the whole point of strict is a genre-pure pool. But it FALLS BACK to the
-// unfiltered set when no track matches, so a thin genre degrades to off-genre
-// rather than emptying the source (never-starve, mirrors preferEra).
-export function preferGenre(tracks: any[], genreName?: string | null): any[] {
-  if (!genreName) return tracks;
-  const target = normGenre(genreName);
-  if (!target) return tracks;
-  const match = tracks.filter((t: any) => genreMatches(t, target));
+// Hard-prefer tracks matching ANY of the show's genres (strict mode). Unlike
+// the soft energy/year leans, an untagged or off-genre track does NOT stay
+// eligible — the whole point of strict is a genre-pure pool. But it FALLS BACK
+// to the unfiltered set when no track matches, so a thin genre degrades to
+// off-genre rather than emptying the source (never-starve, mirrors preferEra).
+export function preferGenre(tracks: any[], genreNames?: string[] | null): any[] {
+  const targets = (genreNames ?? []).map(normGenre).filter(Boolean);
+  if (!targets.length) return tracks;
+  const match = tracks.filter((t: any) => genreMatches(t, targets));
   return match.length ? match : tracks;
 }
 
-// ── Era (decade / year window) ───────────────────────────────────────────────
+// ── Era (decade / year windows) ──────────────────────────────────────────────
 
-type YearRange = { fromYear?: number | null; toYear?: number | null };
+export type YearRange = { fromYear?: number | null; toYear?: number | null };
 
-// Hard-filter to tracks within [fromYear, toYear]. Unknown-year tracks are
+// True when the list carries at least one real bound — the "is there an era
+// constraint at all?" test shared by the pick paths.
+export function hasEraBound(eras?: YearRange[] | null): boolean {
+  return !!eras?.some(e => e && (e.fromYear != null || e.toYear != null));
+}
+
+// Coarse single-window envelope over a set of era windows, for APIs that take
+// one contiguous fromYear/toYear pair (Subsonic getRandomSongs). A missing
+// bound on ANY window leaves that side open (null) — the envelope must never
+// exclude a track an individual window would admit. Exact union membership is
+// enforced by inYearRange afterwards.
+export function eraSpan(eras?: YearRange[] | null): { fromYear: number | null; toYear: number | null } {
+  let fromYear: number | null = null;
+  let toYear: number | null = null;
+  let openFrom = false;
+  let openTo = false;
+  for (const e of eras ?? []) {
+    if (!e || (e.fromYear == null && e.toYear == null)) continue;
+    if (e.fromYear == null) openFrom = true;
+    else fromYear = fromYear == null ? e.fromYear : Math.min(fromYear, e.fromYear);
+    if (e.toYear == null) openTo = true;
+    else toYear = toYear == null ? e.toYear : Math.max(toYear, e.toYear);
+  }
+  return { fromYear: openFrom ? null : fromYear, toYear: openTo ? null : toYear };
+}
+
+function inAnyWindow(year: number, eras: YearRange[]): boolean {
+  return eras.some(e => {
+    if (!e || (e.fromYear == null && e.toYear == null)) return false;
+    if (e.fromYear != null && year < e.fromYear) return false;
+    if (e.toYear != null && year > e.toYear) return false;
+    return true;
+  });
+}
+
+// Hard-filter to tracks inside ANY of the era windows. Unknown-year tracks are
 // treated as out-of-range (dropped). Callers that must not starve should use
 // preferEra (or fall back to the full set themselves).
-export function inYearRange(tracks: any[], f: YearRange): any[] {
-  if (f.fromYear == null && f.toYear == null) return tracks;
+export function inYearRange(tracks: any[], eras: YearRange[]): any[] {
+  if (!hasEraBound(eras)) return tracks;
   return tracks.filter((t: any) => {
     const y = Number(t?.year);
-    if (!Number.isFinite(y)) return false;
-    if (f.fromYear != null && y < f.fromYear) return false;
-    if (f.toYear != null && y > f.toYear) return false;
-    return true;
+    return Number.isFinite(y) && inAnyWindow(y, eras);
   });
 }
 
 // Never-starve era filter: in-range tracks first, falling back to the full set
 // when nothing is in range, so a thin era degrades to off-era rather than
 // emptying the source. Mirrors preferGenre's contract.
-export function preferEra(tracks: any[], f: YearRange): any[] {
-  if (f.fromYear == null && f.toYear == null) return tracks;
-  const match = inYearRange(tracks, f);
+export function preferEra(tracks: any[], eras?: YearRange[] | null): any[] {
+  if (!hasEraBound(eras)) return tracks;
+  const match = inYearRange(tracks, eras!);
   return match.length ? match : tracks;
 }
 
-// ── Energy band ──────────────────────────────────────────────────────────────
+// ── Energy bands ─────────────────────────────────────────────────────────────
 
 // Per-track energy band — from the track itself (library sources carry it) or a
 // library lookup (Subsonic sources don't). null when un-analysed.
@@ -82,30 +120,33 @@ export function trackEnergy(t: any): string | null {
   return rec?.energy ?? null;
 }
 
-// Soft-prefer tracks matching the show's energy band; unknown-energy tracks
-// stay eligible. Falls back to the full set when no track matches (never-starve,
-// mirrors preferEra). This is the soft-lean path; strict shows
+// Soft-prefer tracks matching ANY of the show's energy bands; unknown-energy
+// tracks stay eligible. Falls back to the full set when no track matches
+// (never-starve, mirrors preferEra). This is the soft-lean path; strict shows
 // (show.filtersStrict) use preferEnergyStrict below.
-export function preferEnergy(tracks: any[], energy?: string | null): any[] {
-  if (!energy) return tracks;
+export function preferEnergy(tracks: any[], energies?: string[] | null): any[] {
+  if (!energies?.length) return tracks;
   const match = tracks.filter((t: any) => {
     const e = trackEnergy(t);
-    return e == null || e === energy;
+    return e == null || energies.includes(e);
   });
   return match.length ? match : tracks;
 }
 
 // Strict energy filter (show.filtersStrict): only tracks whose analysed energy
-// band matches survive — unknown-energy tracks are dropped too, that's the
-// point of strict. Never-starve: an un-analysed library (everything unknown)
-// falls back to the full set rather than emptying the source.
-export function preferEnergyStrict(tracks: any[], energy?: string | null): any[] {
-  if (!energy) return tracks;
-  const match = tracks.filter((t: any) => trackEnergy(t) === energy);
+// band matches an entry survive — unknown-energy tracks are dropped too, that's
+// the point of strict. Never-starve: an un-analysed library (everything
+// unknown) falls back to the full set rather than emptying the source.
+export function preferEnergyStrict(tracks: any[], energies?: string[] | null): any[] {
+  if (!energies?.length) return tracks;
+  const match = tracks.filter((t: any) => {
+    const e = trackEnergy(t);
+    return e != null && energies.includes(e);
+  });
   return match.length ? match : tracks;
 }
 
-// ── Mood ─────────────────────────────────────────────────────────────────────
+// ── Moods ────────────────────────────────────────────────────────────────────
 
 // Per-track mood tags — from the track itself (library sources carry them) or a
 // library lookup (Subsonic sources don't). Empty when un-tagged. Unions the
@@ -121,14 +162,14 @@ export function trackMoods(t: any): string[] {
   return audio.length ? [...new Set([...moods, ...audio])] : moods;
 }
 
-// Strict mood filter (show.filtersStrict): only tracks tagged with the show's
-// mood survive; un-tagged tracks are dropped. Never-starve: an un-tagged
-// library falls back to the full set rather than emptying the source. Soft
-// shows don't use this — their mood steering happens through the
+// Strict mood filter (show.filtersStrict): only tracks tagged with ANY of the
+// show's moods survive; un-tagged tracks are dropped. Never-starve: an
+// un-tagged library falls back to the full set rather than emptying the
+// source. Soft shows don't use this — their mood steering happens through the
 // dominantMood-driven pool sources, not a per-track filter.
-export function preferMood(tracks: any[], mood?: string | null): any[] {
-  if (!mood) return tracks;
-  const m = String(mood).toLowerCase();
-  const match = tracks.filter((t: any) => trackMoods(t).some((x: any) => String(x).toLowerCase() === m));
+export function preferMood(tracks: any[], moods?: string[] | null): any[] {
+  if (!moods?.length) return tracks;
+  const targets = moods.map(m => String(m).toLowerCase());
+  const match = tracks.filter((t: any) => trackMoods(t).some((x: any) => targets.includes(String(x).toLowerCase())));
   return match.length ? match : tracks;
 }

--- a/controller/src/routes/generate.ts
+++ b/controller/src/routes/generate.ts
@@ -49,24 +49,42 @@ router.post('/generate/show', requireAdmin, async (req, res) => {
     } catch {}
 
     const out = await dj.generateShow(description, { personas, themes, genres });
-    const draft = { ...out };
+    const raw: any = { ...out };
 
     // Soft-normalise against the real lists — a near-miss from a weaker model
     // becomes null/default rather than an invalid id the Save would reject.
     const personaIds = new Set(personas.map(p => p.id));
-    if (!draft.personaId || !personaIds.has(draft.personaId)) {
-      draft.personaId = personas[0]?.id ?? null;
+    if (!raw.personaId || !personaIds.has(raw.personaId)) {
+      raw.personaId = personas[0]?.id ?? null;
     }
     const themeIds = new Set(themes.map(t => t.id));
-    if (!draft.themeId || !themeIds.has(draft.themeId)) draft.themeId = null;
-    // An unknown/missing mood becomes '' (Any — the autonomous mood applies)
+    if (!raw.themeId || !themeIds.has(raw.themeId)) raw.themeId = null;
+    // The LLM schema stays singular (kinder to weak local models); the client
+    // form is multi-value (#929), so lift each field into a one-element list.
+    // An unknown/missing mood becomes [] (Any — the autonomous mood applies)
     // rather than an arbitrary vocabulary entry the operator didn't ask for.
-    if (!draft.mood || !settings.SHOW_MOODS.includes(draft.mood)) draft.mood = '';
-    if (draft.energy && !settings.SHOW_ENERGY.includes(draft.energy)) draft.energy = '';
+    const moods = raw.mood && settings.SHOW_MOODS.includes(raw.mood) ? [raw.mood] : [];
+    const genreDraft = typeof raw.genre === 'string' ? raw.genre.trim() : '';
+    const showGenres = genreDraft ? [genreDraft] : [];
+    const energies = raw.energy && settings.SHOW_ENERGY.includes(raw.energy) ? [raw.energy] : [];
+    const eras = raw.fromYear != null || raw.toYear != null
+      ? [{ fromYear: raw.fromYear ?? null, toYear: raw.toYear ?? null }]
+      : [];
     // Strict only makes sense with at least one music filter to lock to.
-    if (draft.filtersStrict && !(draft.genre || draft.mood || draft.energy || draft.fromYear != null || draft.toYear != null)) {
-      draft.filtersStrict = false;
-    }
+    const filtersStrict = raw.filtersStrict === true
+      && !!(showGenres.length || moods.length || energies.length || eras.length);
+
+    const draft = {
+      name: raw.name,
+      topic: raw.topic,
+      personaId: raw.personaId,
+      themeId: raw.themeId,
+      moods,
+      genres: showGenres,
+      energies,
+      eras,
+      filtersStrict,
+    };
 
     res.json({ ok: true, show: draft });
   } catch (err: any) {

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -350,7 +350,10 @@ router.get('/schedule', async (req, res) => {
       id: show.id,
       name: show.name,
       topic: show.topic,
-      mood: show.mood,
+      // Multi-value moods (#929). `mood` stays as the lead entry for older
+      // clients (the native app reads this endpoint) — derived, never stored.
+      moods: Array.isArray(show.moods) ? show.moods : [],
+      mood: Array.isArray(show.moods) && show.moods.length ? show.moods[0] : '',
       personaId: show.personaId,
     }));
     res.json({

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -454,9 +454,9 @@ export const TTS_CLOUD_PROVIDERS = ['openai', 'elevenlabs', 'openai-compatible']
 export const SEARCH_PROVIDERS = ['duckduckgo', 'tavily', 'searxng'] as const;
 
 // Canonical mood vocabulary. Shared by the library tagger (music/tag-library.js
-// imports this as MOOD_VOCAB) and the Shows scheduler — a show's `mood`
-// overrides the autonomous dominantMood, so a non-empty value must come from
-// this list. Empty string means "Any": the show pins no mood and the
+// imports this as MOOD_VOCAB) and the Shows scheduler — a show's `moods` (lead
+// entry) override the autonomous dominantMood, so every entry must come from
+// this list. An empty list means "Any": the show pins no mood and the
 // autonomous chain (festival > weather > time) applies while it's on air.
 export const SHOW_MOODS = [
   'energetic',
@@ -588,6 +588,10 @@ const SHOWS_LIMIT = 64;
 const GUESTS_PER_SHOW = 3;
 const PLAYLISTS_PER_SHOW = 10;
 const EXCLUDED_PLAYLISTS_PER_SHOW = 10;
+// Values per multi-select music filter (moods / genres / eras). Within one
+// attribute the values OR together at pick time; across attributes they AND —
+// so past a handful the filter stops meaning anything.
+const SHOW_FILTER_VALUES_MAX = 6;
 const SKILLS_PER_PERSONA_LIMIT = 20;
 const WEBHOOKS_LIMIT = 16;
 
@@ -627,6 +631,80 @@ function coercePlaylistIds(raw: any): string[] {
     if (out.length >= PLAYLISTS_PER_SHOW) break;
   }
   return out;
+}
+
+// ── Multi-value music filters (#929) ────────────────────────────────────────
+// A show's Genre Lean / Mood / Energy / Era each hold a LIST of values: OR
+// within the attribute, AND across attributes, every value weighted equally.
+// Legacy singular fields (`mood`, `genre`, `energy`, `fromYear`/`toYear`) are
+// migrated to one-element lists on load — same pattern as dj.soul → dj.souls.
+// The lenient coercers below serve normalizeShows (load path); the strict
+// validator has its own throwing checks that reuse the same shapes.
+
+// One era window { fromYear, toYear } — at least one bound set; both-null
+// entries are meaningless and dropped. Multiple windows let a show span
+// non-adjacent decades ("90s + 2010s") — inexpressible as a single range.
+export type EraWindow = { fromYear: number | null; toYear: number | null };
+
+function coerceEraWindow(raw: any): EraWindow | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const fromYear = Number.isFinite(raw.fromYear) ? Math.trunc(raw.fromYear) : null;
+  const toYear = Number.isFinite(raw.toYear) ? Math.trunc(raw.toYear) : null;
+  if (fromYear == null && toYear == null) return null;
+  if (fromYear != null && toYear != null && fromYear > toYear) return null;
+  return { fromYear, toYear };
+}
+
+// Plural-first: `item[plural]` wins when it's an array; otherwise the legacy
+// singular value (if any) becomes a one-element list. Dedup + cap.
+function coerceShowList<T>(
+  item: any,
+  plural: string,
+  singular: string,
+  coerceOne: (v: any) => T | null,
+  keyOf: (v: T) => string,
+): T[] {
+  const raw = Array.isArray(item?.[plural]) ? item[plural] : [item?.[singular]];
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const v of raw) {
+    const one = coerceOne(v);
+    if (one == null) continue;
+    const k = keyOf(one);
+    if (seen.has(k)) continue;
+    seen.add(k);
+    out.push(one);
+    if (out.length >= SHOW_FILTER_VALUES_MAX) break;
+  }
+  return out;
+}
+
+function coerceShowMoods(item: any): string[] {
+  return coerceShowList(item, 'moods', 'mood',
+    (v) => (typeof v === 'string' && SHOW_MOODS.includes(v) ? v : null),
+    (v) => v);
+}
+
+function coerceShowGenres(item: any): string[] {
+  return coerceShowList(item, 'genres', 'genre',
+    (v) => (typeof v === 'string' && v.trim() ? v.trim().slice(0, 64) : null),
+    (v) => v.toLowerCase());
+}
+
+function coerceShowEnergies(item: any): string[] {
+  return coerceShowList(item, 'energies', 'energy',
+    (v) => (typeof v === 'string' && SHOW_ENERGY.includes(v) ? v : null),
+    (v) => v);
+}
+
+function coerceShowEras(item: any): EraWindow[] {
+  // Legacy singular is a pair of top-level keys, not one value — synthesize
+  // the window before handing off to the shared list coercer.
+  const raw = Array.isArray(item?.eras)
+    ? item.eras
+    : [{ fromYear: item?.fromYear, toYear: item?.toYear }];
+  return coerceShowList({ eras: raw }, 'eras', 'era', coerceEraWindow,
+    (e) => `${e.fromYear ?? ''}:${e.toYear ?? ''}`);
 }
 
 // A show can exclude tracks from one or more Navidrome playlists: any track
@@ -1347,9 +1425,11 @@ function normalizeShows(raw: any, personaIds: string[]) {
     const name = typeof item.name === 'string' ? item.name.trim().slice(0, 60) : '';
     if (!name) continue;
     if (!personaIds.includes(item.personaId)) continue; // drop dangling owner
-    // Empty mood = "Any" (the autonomous mood applies on air). An unknown mood
-    // string is coerced to Any rather than dropping the whole show on the floor.
-    const mood = SHOW_MOODS.includes(item.mood) ? item.mood : '';
+    // Empty moods = "Any" (the autonomous mood applies on air). Unknown mood
+    // strings are dropped rather than failing the whole show. Multi-value
+    // (#929): plural arrays are canonical; legacy singular fields migrate to
+    // one-element lists here (coerceShow* handle both shapes).
+    const moods = coerceShowMoods(item);
     let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('s_');
     if (seen.has(id)) id = mintId('s_');
     seen.add(id);
@@ -1362,15 +1442,15 @@ function normalizeShows(raw: any, personaIds: string[]) {
       typeof item.themeId === 'string' && item.themeId.trim()
         ? item.themeId.trim().slice(0, 64)
         : '';
-    // Optional music-steering filters (soft lean, applied at pick time). Genre
-    // is stored as free text and resolved fuzzily against the live library when
-    // a pick is made (mirrors the listener-request path) — never validated
-    // against Subsonic here. fromYear/toYear are a decade window. energy is one
-    // of the tagger's three bands. All default to "no constraint".
-    const genre = typeof item.genre === 'string' ? item.genre.trim().slice(0, 64) : '';
-    const fromYear = Number.isFinite(item.fromYear) ? Math.trunc(item.fromYear) : null;
-    const toYear = Number.isFinite(item.toYear) ? Math.trunc(item.toYear) : null;
-    const energy = SHOW_ENERGY.includes(item.energy) ? item.energy : '';
+    // Optional music-steering filters (soft lean, applied at pick time). Each
+    // is a LIST — OR within the attribute, AND across attributes (#929).
+    // Genres are free text resolved fuzzily against the live library when a
+    // pick is made (mirrors the listener-request path) — never validated
+    // against Subsonic here. Eras are decade/year windows. Energies come from
+    // the tagger's three bands. All default to "no constraint" (empty list).
+    const genres = coerceShowGenres(item);
+    const eras = coerceShowEras(item);
+    const energies = coerceShowEnergies(item);
     // Opt-in: hard-filter the pick pool to EVERY set music filter (mood, genre,
     // era, energy) instead of the default soft leans. Only meaningful when at
     // least one filter is set; defaults OFF. The legacy genre-only `genreStrict`
@@ -1414,12 +1494,11 @@ function normalizeShows(raw: any, personaIds: string[]) {
       banter,
       programme,
       segmentSkill,
-      mood,
+      moods,
       themeId,
-      genre,
-      fromYear,
-      toYear,
-      energy,
+      genres,
+      eras,
+      energies,
       filtersStrict,
       maxTrackSeconds,
       playlistIds,
@@ -2203,13 +2282,23 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
     if (!personaIds.includes(item.personaId)) {
       throw new Error(`shows[${i}].personaId must reference an existing persona`);
     }
-    // Empty/missing mood means "Any": the show pins no mood and the autonomous
+    // Empty/missing moods means "Any": the show pins no mood and the autonomous
     // dominantMood chain (festival > weather > time) applies while it's on air.
-    // A non-empty mood must come from the canonical vocabulary.
-    const mood = item.mood == null || item.mood === '' ? '' : String(item.mood);
-    if (mood && !SHOW_MOODS.includes(mood)) {
-      throw new Error(`shows[${i}].mood must be empty (any) or one of: ${SHOW_MOODS.join(', ')}`);
+    // Multi-value (#929): the plural array is canonical; a legacy singular
+    // `mood` from an older client still validates and becomes a one-element
+    // list. Every entry must come from the canonical vocabulary.
+    const rawMoods = Array.isArray(item.moods)
+      ? item.moods
+      : item.mood == null || item.mood === '' ? [] : [item.mood];
+    if (rawMoods.length > SHOW_FILTER_VALUES_MAX) {
+      throw new Error(`shows[${i}].moods must have at most ${SHOW_FILTER_VALUES_MAX} entries`);
     }
+    for (const m of rawMoods) {
+      if (typeof m !== 'string' || !SHOW_MOODS.includes(m)) {
+        throw new Error(`shows[${i}].moods entries must be one of: ${SHOW_MOODS.join(', ')}`);
+      }
+    }
+    const moods = coerceShowMoods({ moods: rawMoods });
     // Optional per-show theme override. Empty/missing means "fall back to the
     // station default while this show is on air". The allow-set is built once
     // by update() so we stay sync here.
@@ -2221,15 +2310,30 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
       }
       themeId = v;
     }
-    // Optional music-steering filters — all default to "no constraint". Genre
-    // is free text resolved fuzzily at pick time, so it isn't checked against
-    // the live library here.
-    const genre = String(item.genre ?? '').trim();
-    if (genre.length > 64) throw new Error(`shows[${i}].genre must be 0-64 chars`);
-    const energy = item.energy == null || item.energy === '' ? '' : String(item.energy);
-    if (energy && !SHOW_ENERGY.includes(energy)) {
-      throw new Error(`shows[${i}].energy must be one of: ${SHOW_ENERGY.join(', ')}`);
+    // Optional music-steering filters — all default to "no constraint" and all
+    // multi-value lists (#929, legacy singular fields still accepted). Genres
+    // are free text resolved fuzzily at pick time, so they aren't checked
+    // against the live library here.
+    const rawGenres = Array.isArray(item.genres)
+      ? item.genres
+      : item.genre == null || String(item.genre).trim() === '' ? [] : [item.genre];
+    if (rawGenres.length > SHOW_FILTER_VALUES_MAX) {
+      throw new Error(`shows[${i}].genres must have at most ${SHOW_FILTER_VALUES_MAX} entries`);
     }
+    for (const g of rawGenres) {
+      if (typeof g !== 'string') throw new Error(`shows[${i}].genres entries must be strings`);
+      if (g.trim().length > 64) throw new Error(`shows[${i}].genres entries must be 0-64 chars`);
+    }
+    const genres = coerceShowGenres({ genres: rawGenres });
+    const rawEnergies = Array.isArray(item.energies)
+      ? item.energies
+      : item.energy == null || item.energy === '' ? [] : [item.energy];
+    for (const e of rawEnergies) {
+      if (typeof e !== 'string' || !SHOW_ENERGY.includes(e)) {
+        throw new Error(`shows[${i}].energies entries must be one of: ${SHOW_ENERGY.join(', ')}`);
+      }
+    }
+    const energies = coerceShowEnergies({ energies: rawEnergies });
     // Opt-in hard filter across every set music constraint — mood, genre, era,
     // energy (vs the default soft leans). Boolean, defaults OFF. The legacy
     // genre-only `genreStrict` is deliberately NOT carried over (see the load
@@ -2244,10 +2348,27 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
       }
       return n;
     };
-    const fromYear = parseYear(item.fromYear, 'fromYear');
-    const toYear = parseYear(item.toYear, 'toYear');
-    if (fromYear != null && toYear != null && fromYear > toYear) {
-      throw new Error(`shows[${i}].fromYear must be <= toYear`);
+    // Era windows: `eras` is a list of { fromYear, toYear } windows (#929);
+    // legacy top-level fromYear/toYear still validate as a one-window list.
+    // Each window needs at least one bound; both-null entries are dropped.
+    const rawEras = Array.isArray(item.eras)
+      ? item.eras
+      : item.fromYear == null && item.toYear == null ? [] : [{ fromYear: item.fromYear, toYear: item.toYear }];
+    if (rawEras.length > SHOW_FILTER_VALUES_MAX) {
+      throw new Error(`shows[${i}].eras must have at most ${SHOW_FILTER_VALUES_MAX} entries`);
+    }
+    const eras: EraWindow[] = [];
+    for (const [j, w] of rawEras.entries()) {
+      if (!w || typeof w !== 'object') throw new Error(`shows[${i}].eras[${j}] must be an object`);
+      const fromYear = parseYear((w as any).fromYear, `eras[${j}].fromYear`);
+      const toYear = parseYear((w as any).toYear, `eras[${j}].toYear`);
+      if (fromYear == null && toYear == null) continue;
+      if (fromYear != null && toYear != null && fromYear > toYear) {
+        throw new Error(`shows[${i}].eras[${j}].fromYear must be <= toYear`);
+      }
+      if (!eras.some(e => e.fromYear === fromYear && e.toYear === toYear)) {
+        eras.push({ fromYear, toYear });
+      }
     }
     // Per-show track-length override (seconds): null = inherit station default,
     // 0 = unlimited, >0 = own cap. Empty/missing → inherit. A legacy minutes
@@ -2335,7 +2456,7 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
     let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('s_');
     if (seen.has(id)) id = mintId('s_');
     seen.add(id);
-    return { id, name, topic, personaId: item.personaId, guestPersonaIds, banter, programme, segmentSkill, mood, themeId, genre, fromYear, toYear, energy, filtersStrict, maxTrackSeconds, playlistIds, playlistStrict, excludedPlaylistIds };
+    return { id, name, topic, personaId: item.personaId, guestPersonaIds, banter, programme, segmentSkill, moods, themeId, genres, eras, energies, filtersStrict, maxTrackSeconds, playlistIds, playlistStrict, excludedPlaylistIds };
   });
 }
 
@@ -3251,13 +3372,15 @@ export function resolveActiveShow(date = new Date(), s = get()) {
     id: show.id,
     name: show.name,
     topic: show.topic,
-    mood: show.mood,
-    // Optional music-steering filters (soft lean). Surfaced for the picker and
-    // DJ agent; empty string / null means "no constraint".
-    genre: typeof show.genre === 'string' ? show.genre : '',
-    fromYear: Number.isFinite(show.fromYear) ? show.fromYear : null,
-    toYear: Number.isFinite(show.toYear) ? show.toYear : null,
-    energy: typeof show.energy === 'string' ? show.energy : '',
+    // Optional music-steering filters (soft lean), each a multi-value list
+    // (#929): OR within the attribute, AND across attributes. Surfaced for the
+    // picker and DJ agent; empty list means "no constraint". The stored shows
+    // are already migrated to plural arrays by normalizeShows, but re-coerce
+    // here so a stale in-memory shape can never leak singular fields out.
+    moods: coerceShowMoods(show),
+    genres: coerceShowGenres(show),
+    eras: coerceShowEras(show),
+    energies: coerceShowEnergies(show),
     // When true, every set music filter (mood, genre, era, energy) is a hard
     // filter on the pick pool instead of a soft lean; off-filter tracks only
     // survive as a never-starve fallback. Defaults off.

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -686,7 +686,15 @@ function coerceShowMoods(item: any): string[] {
 }
 
 function coerceShowGenres(item: any): string[] {
-  return coerceShowList(item, 'genres', 'genre',
+  // Legacy singular `genre` was one free-text field and operators crammed
+  // multiple genres into it comma-separated ("funk, soul, jazz-funk") — which
+  // never resolved against the library as one tag. Split it on migration so
+  // each becomes a real, individually-resolvable entry. Plural-array entries
+  // are taken as-is (the UI adds them one at a time).
+  const raw = Array.isArray(item?.genres)
+    ? item.genres
+    : typeof item?.genre === 'string' ? item.genre.split(',') : [];
+  return coerceShowList({ genres: raw }, 'genres', 'genre',
     (v) => (typeof v === 'string' && v.trim() ? v.trim().slice(0, 64) : null),
     (v) => v.toLowerCase());
 }
@@ -2314,10 +2322,14 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
     // multi-value lists (#929, legacy singular fields still accepted). Genres
     // are free text resolved fuzzily at pick time, so they aren't checked
     // against the live library here.
+    // Legacy singular `genre` splits on commas — same rule as the load-path
+    // migration (operators crammed "funk, soul" into the one field).
     const rawGenres = Array.isArray(item.genres)
       ? item.genres
-      : item.genre == null || String(item.genre).trim() === '' ? [] : [item.genre];
-    if (rawGenres.length > SHOW_FILTER_VALUES_MAX) {
+      : item.genre == null || String(item.genre).trim() === '' ? [] : String(item.genre).split(',');
+    // Cap-check only the explicit plural form; a legacy comma-crammed string
+    // is silently capped by the coercer instead of failing an old client.
+    if (Array.isArray(item.genres) && item.genres.length > SHOW_FILTER_VALUES_MAX) {
       throw new Error(`shows[${i}].genres must have at most ${SHOW_FILTER_VALUES_MAX} entries`);
     }
     for (const g of rawGenres) {

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 // Shows scheduler — /admin/shows. A show is a reusable definition (name,
-// topic, owner persona, music mood). The weekly grid assigns a show to any
+// topic, owner persona, music moods). The weekly grid assigns a show to any
 // 1-hour cell, Mon–Sun. When the current hour has a show, its persona goes on
-// air, its mood (when set — empty means Any/auto) overrides the autonomous
+// air, its moods (when set — empty means Any/auto) override the autonomous
 // mood, and its topic feeds the DJ.
 // An empty hour = the station runs autonomously, as it does today.
 // Everything POSTs to /settings and applies live.
@@ -75,21 +75,22 @@ interface Show {
   /** Scripted banter breaks: short multi-voice exchanges between the host and
    *  guests, aired up to twice an hour. Only meaningful with guests set. */
   banter: boolean;
-  /** '' = Any — the show pins no mood; the autonomous mood (festival >
-   *  weather > time of day) applies while it's on air. */
-  mood: string;
+  /** [] = Any — the show pins no mood; the autonomous mood (festival >
+   *  weather > time of day) applies while it's on air. Multi-value (#929):
+   *  any selected mood satisfies the filter, all weighted equally. */
+  moods: string[];
   /** Optional theme override — empty string means "fall back to the station
    *  default while this show is on air". Validated against the live theme
    *  registry by the controller; a stale id silently falls back too. */
   themeId: string;
-  /** Optional music-steering filters — soft lean applied at pick time. Empty
-   *  string / null means "no constraint". Genre is free text resolved fuzzily
-   *  against the library; fromYear/toYear are a decade window; energy is one of
+  /** Optional music-steering filters — soft leans applied at pick time, each a
+   *  multi-value list (#929): OR within the attribute, AND across attributes.
+   *  Empty list means "no constraint". Genres are free text resolved fuzzily
+   *  against the library; eras are decade/year windows; energies come from
    *  low|medium|high. */
-  genre: string;
-  fromYear: number | null;
-  toYear: number | null;
-  energy: string;
+  genres: string[];
+  eras: EraWindow[];
+  energies: string[];
   /** When true (and ≥1 music filter is set) EVERY set filter — mood, genre,
    *  era, energy — becomes a HARD filter on the pick pool instead of a soft
    *  lean; off-filter tracks only play as a last resort to avoid silence.
@@ -120,9 +121,12 @@ interface Show {
   segmentSkill: string;
 }
 
-// Decade presets for the era dropdown → fromYear/toYear. 'any' clears the window.
-const DECADES: { key: string; label: string; from: number | null; to: number | null }[] = [
-  { key: 'any', label: 'Any era', from: null, to: null },
+/** One era window (mirrors the controller's EraWindow). Multiple windows let a
+ *  show span non-adjacent decades ("90s + 2010s"). */
+interface EraWindow { fromYear: number | null; toYear: number | null }
+
+// Decade presets for the era chips → one EraWindow each. Empty selection = any era.
+const DECADES: { key: string; label: string; from: number; to: number }[] = [
   { key: '2020', label: '2020s', from: 2020, to: 2029 },
   { key: '2010', label: '2010s', from: 2010, to: 2019 },
   { key: '2000', label: '2000s', from: 2000, to: 2009 },
@@ -134,14 +138,20 @@ const DECADES: { key: string; label: string; from: number | null; to: number | n
 ];
 const ENERGY_OPTIONS = ['low', 'medium', 'high'];
 const ANY_SENTINEL = '__any__';
+// Mirrors the controller's SHOW_FILTER_VALUES_MAX cap (settings.ts).
+const FILTER_VALUES_MAX = 6;
 
-function decadeKeyOf(s: { fromYear: number | null; toYear: number | null }): string {
-  const hit = DECADES.find(d => d.from === s.fromYear && d.to === s.toYear);
-  return hit ? hit.key : 'any';
+function sameEra(a: EraWindow, b: { from: number | null; to: number | null } | EraWindow): boolean {
+  const bf = 'from' in b ? b.from : b.fromYear;
+  const bt = 'to' in b ? b.to : b.toYear;
+  return a.fromYear === bf && a.toYear === bt;
 }
-function decadeLabelOf(s: { fromYear: number | null; toYear: number | null }): string | null {
-  const hit = DECADES.find(d => d.from === s.fromYear && d.to === s.toYear);
-  return hit && hit.from != null ? hit.label : null;
+/** Preset label ("90s") or the raw window ("1975–1984") for a custom one set via API. */
+function eraLabelOf(e: EraWindow): string {
+  const hit = DECADES.find(d => sameEra(e, d));
+  if (hit) return hit.label;
+  if (e.fromYear != null && e.toYear != null) return `${e.fromYear}–${e.toYear}`;
+  return e.fromYear != null ? `${e.fromYear}+` : `≤${e.toYear}`;
 }
 
 // View of a theme returned by GET /themes. We keep the token map here so the
@@ -230,7 +240,7 @@ function NowCard({ label, accent, slotHour, show, color, personaLabel }: NowCard
       </div>
       <div className="text-[11px] text-muted">
         {show
-          ? <>persona · {personaLabel} · mood · {show.mood || 'any'}{showFilterSummary(show)}</>
+          ? <>persona · {personaLabel} · mood · {show.moods.length ? show.moods.join(', ') : 'any'}{showFilterSummary(show)}</>
           : 'station runs on its own picker'}
       </div>
     </div>
@@ -240,7 +250,7 @@ function NowCard({ label, accent, slotHour, show, color, personaLabel }: NowCard
 // Compact " · genre · 80s · high" suffix for the show summary lines, omitting
 // whatever the show doesn't pin. Strict filters are flagged inline so the hard
 // lock is visible at a glance.
-function showFilterSummary(s: { mood?: string; genre: string; fromYear: number | null; toYear: number | null; energy: string; filtersStrict?: boolean; maxTrackSeconds?: number | null; playlistIds?: string[]; playlistStrict?: boolean; excludedPlaylistIds?: string[] }): string {
+function showFilterSummary(s: { moods: string[]; genres: string[]; eras: EraWindow[]; energies: string[]; filtersStrict?: boolean; maxTrackSeconds?: number | null; playlistIds?: string[]; playlistStrict?: boolean; excludedPlaylistIds?: string[] }): string {
   const len = s.maxTrackSeconds == null ? '' : s.maxTrackSeconds === 0 ? 'any length' : `≤${s.maxTrackSeconds}s`;
   const nPl = s.playlistIds?.length ?? 0;
   const playlist = nPl ? `${nPl} playlist${nPl > 1 ? 's' : ''}${s.playlistStrict ? ' (strict)' : ''}` : '';
@@ -248,10 +258,50 @@ function showFilterSummary(s: { mood?: string; genre: string; fromYear: number |
   const excluded = nEx ? `${nEx} excluded` : '';
   // The strict chip covers every music filter (mood included) — only shown when
   // there's actually a filter for it to bite on.
-  const strict = s.filtersStrict && (s.mood || s.genre || s.energy || s.fromYear != null || s.toYear != null)
+  const strict = s.filtersStrict && (s.moods.length || s.genres.length || s.energies.length || s.eras.length)
     ? 'strict filters' : '';
-  const bits = [s.genre, decadeLabelOf(s), s.energy, strict, len, playlist, excluded].filter(Boolean);
+  const bits = [
+    s.genres.join(', '),
+    s.eras.map(eraLabelOf).join(', '),
+    s.energies.join(', '),
+    strict, len, playlist, excluded,
+  ].filter(Boolean);
   return bits.length ? ` · ${bits.join(' · ')}` : '';
+}
+
+// Toggleable chip row for the multi-select music filters (#929). Selected
+// chips invert; unselected ones grey out once the cap is hit. Same visual
+// language as the LibraryPanel energy pills.
+function ChipRow({ options, selected, onToggle, cap = FILTER_VALUES_MAX }: {
+  options: { key: string; label: string }[];
+  selected: string[];
+  onToggle: (key: string) => void;
+  cap?: number;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1">
+      {options.map(o => {
+        const on = selected.includes(o.key);
+        const atCap = !on && selected.length >= cap;
+        return (
+          <button
+            key={o.key}
+            type="button"
+            aria-pressed={on}
+            disabled={atCap}
+            onClick={() => onToggle(o.key)}
+            className={cn(
+              'border border-ink px-2 py-0.5 text-[12px]',
+              on ? 'bg-ink text-bg' : 'text-ink hover:bg-[var(--ink-soft)]',
+              atCap && 'cursor-not-allowed opacity-40',
+            )}
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
 }
 
 function clientMintId() {
@@ -280,7 +330,7 @@ function showValid(s: Show): boolean {
 // At least one music filter set — the Strict filter toggle only means
 // something when there's a filter for it to harden.
 function hasAnyMusicFilter(s: Show): boolean {
-  return !!(s.mood || s.genre.trim() || s.energy || s.fromYear != null || s.toYear != null);
+  return !!(s.moods.length || s.genres.length || s.energies.length || s.eras.length);
 }
 
 export default function ShowsPanel() {
@@ -409,12 +459,16 @@ export default function ShowsPanel() {
           personaId: s.personaId ?? '',
           guestPersonaIds: Array.isArray(s.guestPersonaIds) ? s.guestPersonaIds : [],
           banter: s.banter ?? false,
-          mood: s.mood ?? '',
+          // Plural lists are canonical (#929); a legacy singular field from a
+          // stale response still hydrates as a one-element list.
+          moods: Array.isArray(s.moods) ? s.moods : (s as { mood?: string }).mood ? [(s as { mood?: string }).mood!] : [],
           themeId: s.themeId ?? '',
-          genre: s.genre ?? '',
-          fromYear: s.fromYear ?? null,
-          toYear: s.toYear ?? null,
-          energy: s.energy ?? '',
+          genres: Array.isArray(s.genres) ? s.genres : (s as { genre?: string }).genre ? [(s as { genre?: string }).genre!] : [],
+          eras: Array.isArray(s.eras) ? s.eras : (() => {
+            const { fromYear = null, toYear = null } = s as { fromYear?: number | null; toYear?: number | null };
+            return fromYear != null || toYear != null ? [{ fromYear, toYear }] : [];
+          })(),
+          energies: Array.isArray(s.energies) ? s.energies : (s as { energy?: string }).energy ? [(s as { energy?: string }).energy!] : [],
           filtersStrict: s.filtersStrict ?? false,
           maxTrackSeconds: s.maxTrackSeconds ?? null,
           playlistIds: Array.isArray(s.playlistIds) ? s.playlistIds : [],
@@ -530,8 +584,8 @@ export default function ShowsPanel() {
         ...f,
         shows: [...f.shows, {
           id, name: '', topic: '',
-          personaId: personas[0]?.id || '', guestPersonaIds: [], banter: false, mood: '',
-          themeId: '', genre: '', fromYear: null, toYear: null, energy: '',
+          personaId: personas[0]?.id || '', guestPersonaIds: [], banter: false, moods: [],
+          themeId: '', genres: [], eras: [], energies: [],
           filtersStrict: false, maxTrackSeconds: null,
           playlistIds: [], playlistStrict: false, excludedPlaylistIds: [],
           programme: false, segmentSkill: '',
@@ -727,9 +781,11 @@ export default function ShowsPanel() {
             guestPersonaIds: (s.guestPersonaIds || []).filter(id => id !== s.personaId),
             // Banter only means something with guests in the studio.
             banter: (s.guestPersonaIds?.length ?? 0) > 0 && s.banter,
-            mood: s.mood,
+            moods: s.moods,
             themeId: s.themeId || '',
-            genre: s.genre.trim(), fromYear: s.fromYear, toYear: s.toYear, energy: s.energy || '',
+            genres: s.genres.map(g => g.trim()).filter(Boolean),
+            eras: s.eras,
+            energies: s.energies,
             // Strict only means something with at least one music filter set.
             filtersStrict: hasAnyMusicFilter(s) && s.filtersStrict,
             maxTrackSeconds: s.maxTrackSeconds,
@@ -1089,6 +1145,16 @@ function ShowEditor({
   update, onSave, onClose, onRemove,
 }: ShowEditorProps) {
   const valid = showValid(show);
+  // Free-text genre being typed before it's added as a chip. The editor is
+  // remounted per show (keyed at the call site), so this resets on switch.
+  const [genreDraft, setGenreDraft] = useState('');
+  const addGenre = (g: string) => {
+    const v = g.trim().slice(0, 64);
+    if (!v || show.genres.length >= FILTER_VALUES_MAX) return;
+    if (show.genres.some(x => x.toLowerCase() === v.toLowerCase())) { setGenreDraft(''); return; }
+    update({ genres: [...show.genres, v] });
+    setGenreDraft('');
+  };
   return (
     <EditorDialog
       open
@@ -1266,80 +1332,121 @@ function ShowEditor({
         </Card>
 
         <Card flat title="Music" bodyClass="grid gap-3.5">
-          <div className="stack-mobile grid grid-cols-3 gap-3">
-            <Field>
-              <Label>music mood</Label>
-              <Select
-                value={show.mood || ANY_SENTINEL}
-                onValueChange={val => update({ mood: val === ANY_SENTINEL ? '' : val })}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    <SelectItem value={ANY_SENTINEL}>Any (auto)</SelectItem>
-                    {moods.map(m => <SelectItem key={m} value={m}>{m}</SelectItem>)}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-            </Field>
-            <Field>
-              <Label>era</Label>
-              <Select
-                value={decadeKeyOf(show)}
-                onValueChange={val => {
-                  const d = DECADES.find(x => x.key === val);
-                  update({ fromYear: d?.from ?? null, toYear: d?.to ?? null });
-                }}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    {DECADES.map(d => <SelectItem key={d.key} value={d.key}>{d.label}</SelectItem>)}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-            </Field>
-            <Field>
-              <Label>energy</Label>
-              <Select
-                value={show.energy || ANY_SENTINEL}
-                onValueChange={val => update({ energy: val === ANY_SENTINEL ? '' : val })}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    <SelectItem value={ANY_SENTINEL}>Any</SelectItem>
-                    {ENERGY_OPTIONS.map(e => <SelectItem key={e} value={e}>{e}</SelectItem>)}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-            </Field>
-          </div>
+          <Field>
+            <Label>music moods</Label>
+            <ChipRow
+              options={moods.map(m => ({ key: m, label: m }))}
+              selected={show.moods}
+              onToggle={m => update({
+                moods: show.moods.includes(m)
+                  ? show.moods.filter(x => x !== m)
+                  : [...show.moods, m],
+              })}
+            />
+            <span className="field-hint">
+              Pick any that fit — a track matching any selected mood qualifies.
+              None selected = Any (auto): the station&apos;s autonomous mood applies.
+            </span>
+          </Field>
 
           <Field>
-            <Label htmlFor="show-genre">genre lean</Label>
-            <Input
-              id="show-genre"
-              type="text" value={show.genre} maxLength={64}
-              list="show-genre-options"
-              onChange={(e: ChangeEvent<HTMLInputElement>) => update({ genre: e.target.value })}
-              placeholder="e.g. Jazz (optional)"
+            <Label>eras</Label>
+            <ChipRow
+              options={DECADES.map(d => ({ key: d.key, label: d.label }))}
+              selected={DECADES.filter(d => show.eras.some(e => sameEra(e, d))).map(d => d.key)}
+              onToggle={key => {
+                const d = DECADES.find(x => x.key === key)!;
+                const existing = show.eras.find(e => sameEra(e, d));
+                update({
+                  eras: existing
+                    ? show.eras.filter(e => e !== existing)
+                    : [...show.eras, { fromYear: d.from, toYear: d.to }],
+                });
+              }}
             />
+            {/* Custom windows (set via the API — no preset matches) stay
+                visible and removable so they can't silently constrain picks. */}
+            {show.eras.some(e => !DECADES.some(d => sameEra(e, d))) && (
+              <div className="flex flex-wrap gap-1">
+                {show.eras.filter(e => !DECADES.some(d => sameEra(e, d))).map((e, i) => (
+                  <button
+                    key={`${e.fromYear ?? ''}-${e.toYear ?? ''}-${i}`}
+                    type="button"
+                    onClick={() => update({ eras: show.eras.filter(x => x !== e) })}
+                    className="border border-ink bg-ink px-2 py-0.5 text-[12px] text-bg"
+                    title="Remove this custom era window"
+                  >
+                    {eraLabelOf(e)} ×
+                  </button>
+                ))}
+              </div>
+            )}
+            <span className="field-hint">
+              Pick any decades — non-adjacent ones work ({'"'}90s + 2010s{'"'}).
+              None selected = any era.
+            </span>
+          </Field>
+
+          <Field>
+            <Label>energy</Label>
+            <ChipRow
+              options={ENERGY_OPTIONS.map(e => ({ key: e, label: e }))}
+              selected={show.energies}
+              onToggle={e => update({
+                energies: show.energies.includes(e)
+                  ? show.energies.filter(x => x !== e)
+                  : [...show.energies, e],
+              })}
+              cap={ENERGY_OPTIONS.length}
+            />
+          </Field>
+
+          <Field>
+            <Label htmlFor="show-genre">genre leans</Label>
+            {show.genres.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {show.genres.map(g => (
+                  <button
+                    key={g}
+                    type="button"
+                    onClick={() => update({ genres: show.genres.filter(x => x !== g) })}
+                    className="border border-ink bg-ink px-2 py-0.5 text-[12px] text-bg"
+                    title="Remove this genre"
+                  >
+                    {g} ×
+                  </button>
+                ))}
+              </div>
+            )}
+            <div className="flex gap-2">
+              <Input
+                id="show-genre"
+                type="text" value={genreDraft} maxLength={64}
+                list="show-genre-options"
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setGenreDraft(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addGenre(genreDraft); } }}
+                placeholder={show.genres.length ? 'add another genre' : 'e.g. Jazz (optional)'}
+                disabled={show.genres.length >= FILTER_VALUES_MAX}
+              />
+              <Btn
+                onClick={() => addGenre(genreDraft)}
+                disabled={!genreDraft.trim() || show.genres.length >= FILTER_VALUES_MAX}
+              >
+                Add
+              </Btn>
+            </div>
             <datalist id="show-genre-options">
               {[...genres].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })).map(g => <option key={g} value={g} />)}
             </datalist>
+            <span className="field-hint">
+              Up to {FILTER_VALUES_MAX}; a track matching any of them qualifies.
+            </span>
           </Field>
 
           <GenreSuggest
             adminFetch={adminFetch}
-            value={show.genre}
-            onSelect={(g) => update({ genre: g })}
+            value={genreDraft}
+            onSelect={addGenre}
           />
 
           <div className="flex items-start gap-3">
@@ -1690,7 +1797,7 @@ function GridCell({
       onTouchStart={onTouchStart}
       onTouchEnd={onTouchEnd}
       title={
-        (show ? `${show.name}${show.mood ? ` (${show.mood})` : ''}` : `${label} ${String(hour).padStart(2, '0')}:00, empty`)
+        (show ? `${show.name}${show.moods.length ? ` (${show.moods.join(', ')})` : ''}` : `${label} ${String(hour).padStart(2, '0')}:00, empty`)
         + (isNow ? ' · on air now' : '')
       }
       className={cn(
@@ -1745,7 +1852,7 @@ function ShowDefRow({ show: s, index: i, ok, hrs, personaLabel, onEdit }: ShowDe
       <div className="grid grid-cols-[1fr_auto] items-center gap-4">
         <div className="min-w-0">
           <div className="text-[12px] leading-[1.6] text-muted">
-            persona · {personaLabel} · mood · {s.mood || 'any'}{showFilterSummary(s)}
+            persona · {personaLabel} · mood · {s.moods.length ? s.moods.join(', ') : 'any'}{showFilterSummary(s)}
           </div>
           {s.topic.trim() && (
             <div className="mt-1 line-clamp-2 text-[12px] leading-[1.6] text-muted italic">

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -75,7 +75,10 @@ export interface ScheduleShow {
   id: string;
   name: string;
   topic: string;
+  /** Lead mood — derived from moods[0] server-side (back-compat). */
   mood: string;
+  /** Full multi-value mood list (#929). */
+  moods?: string[];
   personaId: string;
 }
 /** 7 entries (Sun=0..Sat=6), each a 24-slot array of showId|null. */


### PR DESCRIPTION
Closes #929.

A show's **Genre Lean, Mood, Energy and Era** each accept multiple values now. Semantics: **OR within an attribute** (a track matching any selected value qualifies), **AND across attributes**, every value weighted equally — no primary/secondary tiers, matching the issue's "treated equally" option.

## What changed

**Schema (`settings.ts`)** — `moods[]`, `genres[]`, `energies[]`, `eras[]` (a list of `{fromYear, toYear}` windows) are the canonical stored shape. Legacy singular fields migrate to one-element lists on load — the same pattern as `dj.soul → dj.souls` — and old clients writing singular fields still validate. `eras` as a window list is what makes non-adjacent decades ("90s + 2000s") and open-ended windows ("nothing after the 2000s" = `toYear`-only) expressible.

**Shared filters (`show-filter.ts`)** — all helpers take any-of lists; `inYearRange`/`preferEra` filter against the window union; new `eraSpan()` computes the coarse single-window envelope for APIs that only take one contiguous range (Subsonic `getRandomSongs`), with the exact union enforced by post-filter. Every never-starve contract is unchanged. New pinned test file `scripts/show-filter.test.ts` (12 tests).

**Pick paths** — the pool picker and the auto-playlist refresh call Subsonic per genre (size budget split evenly) against the era envelope, then tighten to the exact union; multi-mood shows pool **all** their moods into the mood-library source (autonomous hours keep the single dominantMood). The agent's strict locks (`picker-tools.ts` / `dj-agent.ts`) are any-of lists enforced in code, as before.

**Prompts / context** — `showMusicLean` renders every entry ("lean toward Hard Rock / Metal", "prefer tracks from 1990–1999 or 2010–2019"); single-value output is byte-for-byte the legacy line (pinned in `llm-pure.test.ts`). `dominantMood` and vocal delivery (`energyForDaypart`) lead with the *first* selected mood/energy, since both need a single value by contract — documented at both sites.

**API** — `/schedule` keeps a derived singular `mood` (= `moods[0]`) alongside `moods` so the native app and older clients keep working. `/generate/show` keeps the LLM draft schema singular (kinder to weak local models) and lifts it into lists in the route.

**Admin UI (`ShowsPanel`)** — moods/eras/energy become toggle-chip rows (same visual language as the LibraryPanel energy pills), genre lean becomes an add-to-chips input with the existing autocomplete + GenreSuggest wired to append. Custom era windows set via the API render as removable chips so they can't silently constrain picks. Caps mirror the controller's limit (6 per attribute).

## Verification

- `controller` + `web` lint (`eslint && tsc --noEmit`) clean; full controller suite passes (24 test files, including the new `show-filter.test.ts` and updated `llm-pure.test.ts` multi-value pins).
- Migration smoke-tested against a temp `STATE_DIR`: a legacy singular-field `schedule.json` loads as one-element lists; multi-value strict saves round-trip; a legacy singular write still validates; an invalid mood in `moods[]` is rejected with a clear error.