### PR TITLE
fix: address develop→main review findings (leaked reasoning, ElevenLabs, AudioMuse importer)

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -9,7 +9,7 @@
 import assert from 'node:assert/strict';
 import { generateText, APICallError } from 'ai';
 import { MockLanguageModelV3 } from 'ai/test';
-import { stripThinking, truncationError, extractJson, usageOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded, isRateLimited, errReason, nearestId } from '../src/llm/internal/core/pure.js';
+import { stripThinking, truncationError, extractJson, usageOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded, isRateLimited, errReason, nearestId, isElevenLabsV3, snapV3Stability } from '../src/llm/internal/core/pure.js';
 import { withDeadline, withTransientRetry, retryAfterMs } from '../src/llm/internal/core/retry.js';
 import { providerOptions, needsToolCallObject, repeatPenaltyApplies, appliedNumCtx, appliedRepeatPenalty, forcedToolChoice } from '../src/llm/internal/provider/capabilities.js';
 import { agentPlan } from '../src/llm/internal/strategy/plan.js';
@@ -20,7 +20,6 @@ import { personaToneDirectives, normalizeDial, DIAL_NEUTRAL, validatePersonasStr
 import { lengthMode, lengthPhrase } from '../src/llm/internal/prompts/system.js';
 import { showMusicLean } from '../src/llm/internal/prompts/picker.js';
 import { resolveCloudModel } from '../src/llm/internal/speech/cloud-speech.js';
-import { isElevenLabsV3 } from '../src/llm/internal/prompts/system.js';
 
 let failures = 0;
 function test(name: string, fn: () => void | Promise<void>) {
@@ -915,6 +914,25 @@ async function main() {
     assert.equal(isElevenLabsV3('eleven_ttv_v3'), false);
     assert.equal(isElevenLabsV3('gpt-4o-mini-tts'), false);
     assert.equal(isElevenLabsV3(''), false);
+  });
+
+  console.log('snapV3Stability (eleven_v3 discrete-stability guard):');
+  await test('leaves the three allowed rungs untouched', () => {
+    assert.equal(snapV3Stability(0), 0);
+    assert.equal(snapV3Stability(0.5), 0.5);
+    assert.equal(snapV3Stability(1), 1);
+  });
+  await test('snaps arbitrary values to the nearest rung, ties to 0.5', () => {
+    assert.equal(snapV3Stability(0.1), 0);
+    assert.equal(snapV3Stability(0.3), 0.5);
+    assert.equal(snapV3Stability(0.42), 0.5);
+    assert.equal(snapV3Stability(0.9), 1);
+    assert.equal(snapV3Stability(0.25), 0.5); // equidistant 0/0.5 -> 0.5
+    assert.equal(snapV3Stability(0.75), 0.5); // equidistant 0.5/1 -> 0.5
+  });
+  await test('non-finite falls back to the Natural default', () => {
+    assert.equal(snapV3Stability(NaN), 0.5);
+    assert.equal(snapV3Stability(undefined as any), 0.5);
   });
 
   console.log(failures === 0 ? '\nAll llm-pure tests passed.' : `\n${failures} test(s) FAILED.`);

--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -11,6 +11,7 @@ import * as chatterbox from './chatterbox.js';
 import * as pocketTts from './pocketTts.js';
 import * as remoteTts from './remoteTts.js';
 import * as cloud from '../llm/speech.js';
+import { stripThinking } from '../llm/sdk.js';
 import * as settings from '../settings.js';
 import { recordTts } from '../stats.js';
 import { energyForDaypart } from '../context.js';
@@ -271,7 +272,14 @@ export async function speak(
   text: string,
   { kind = 'default', outPath, speedScale, persona }: { kind?: string; outPath?: string; speedScale?: number; persona?: any } = {},
 ) {
-  const speakText = normalizeForSpeech(text);
+  // Belt-and-suspenders scrub of any leaked reasoning at the single point every
+  // booth-bound string converges (follow-up to #949). The free-text generators
+  // already stripThinking their output, but a reasoning model that leaks a
+  // <think>/harmony token INTO a structured say/intro field (djObject/djAgent
+  // native path) reaches TTS unscrubbed otherwise. No-op on clean text — those
+  // literals never appear in a real script — so every non-LLM caller (jingles,
+  // idents, request intros) is unaffected.
+  const speakText = normalizeForSpeech(stripThinking(text));
   // `persona` overrides the clock-driven effective persona so the persona-handoff
   // mic-pass can voice the outgoing DJ (engine, voice, language, soul, speed)
   // after the hour has flipped. Absent → getEffectivePersona(), i.e. today.

--- a/controller/src/llm/internal/core/pure.ts
+++ b/controller/src/llm/internal/core/pure.ts
@@ -487,3 +487,30 @@ export function nearestId(id: string, candidateIds: Iterable<string>): string | 
   if (!best || bestDist > cap) return null;
   return secondDist - bestDist >= NEAREST_ID_MARGIN ? best : null;
 }
+
+// ---------------------------------------------------------------------------
+// ElevenLabs model-family helpers
+// ---------------------------------------------------------------------------
+
+// True for ElevenLabs' eleven_v3* family (v3, v3_preview, …). v3 renders
+// bracketed audio tags ([laughs]/[sighs]) as expressive cues and — unlike the
+// v2 families — accepts only a discrete `stability` (see snapV3Stability). Lives
+// here (not the prompt layer) so both djSystem's tag hint and cloud-speech's
+// stability snap share one rule without a prompts→speech import cycle. Pure +
+// unit-pinned in scripts/llm-pure.test.ts.
+export function isElevenLabsV3(model: string): boolean {
+  return /^eleven[_-]?v3/i.test(model || '');
+}
+
+// eleven_v3 only accepts stability ∈ {0, 0.5, 1}; any other value 400s the
+// request, dropping the segment to a local engine that reads v3 audio tags
+// aloud as words (issue #915 review). Snap an arbitrary [0,1] slider value to
+// the nearest allowed rung — ties round to 0.5 (v3's "Natural" default).
+export function snapV3Stability(v: number): number {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return 0.5;
+  return [0.5, 0, 1].reduce(
+    (best, r) => (Math.abs(r - n) < Math.abs(best - n) ? r : best),
+    0.5,
+  );
+}

--- a/controller/src/llm/internal/prompts/system.ts
+++ b/controller/src/llm/internal/prompts/system.ts
@@ -4,6 +4,7 @@
 
 import * as settings from '../../../settings.js';
 import { resolveCloudModelForPersona } from '../speech/cloud-speech.js';
+import { isElevenLabsV3 } from '../core/pure.js';
 
 // Paralinguistic tags Chatterbox renders as actual non-verbal sounds. Every
 // other engine (piper, kokoro, cloud) reads `[laugh]` aloud as the word
@@ -24,11 +25,6 @@ const CHATTERBOX_TAG_HINT =
 // is needed for either engine.
 const ELEVENLABS_V3_TAG_HINT =
   '\n\nYou may sparingly insert non-verbal audio cues in square brackets: [laughs], [sighs], [whispers], [excited]. Use them only where genuinely natural — at most one per segment, and never as filler.';
-
-// Exported for scripts/llm-pure.test.ts.
-export function isElevenLabsV3(model: string): boolean {
-  return /^eleven[_-]?v3/i.test(model || '');
-}
 
 // `persona` overrides the on-air persona — used by the persona-handoff
 // generators (generateSignoff / generateHandoffGreeting) to render the sign-off

--- a/controller/src/llm/internal/speech/cloud-speech.ts
+++ b/controller/src/llm/internal/speech/cloud-speech.ts
@@ -13,6 +13,7 @@ import path from 'node:path';
 import crypto from 'node:crypto';
 import { config } from '../../../config.js';
 import * as settings from '../../../settings.js';
+import { isElevenLabsV3, snapV3Stability } from '../core/pure.js';
 
 // Default TTS model per cloud provider. A model id is provider-specific — an
 // OpenAI id like "gpt-4o-mini-tts" is invalid against ElevenLabs and vice
@@ -248,11 +249,19 @@ export async function speak(
   // provider is actually elevenlabs so the openai / openai-compatible request
   // shape stays byte-identical. The AI SDK's ElevenLabs provider exposes them
   // as camelCase `voiceSettings.*` on `providerOptions.elevenlabs`.
-  const elevenlabsOpts = c.provider === 'elevenlabs'
+  //
+  // Omit the block entirely while the knobs sit at their shipped defaults
+  // (issue #915 review): sending explicit values overrides whatever per-voice
+  // settings the operator saved in ElevenLabs VoiceLab, so an untouched station
+  // must defer to the voice's own settings the way it did before #696. Once any
+  // knob is tuned we send the full set (the API takes voice_settings
+  // all-or-nothing) — with `stability` snapped to eleven_v3's discrete
+  // {0,0.5,1} so a tuned slider can't 400 the call into a Piper fallback.
+  const elevenlabsOpts = c.provider === 'elevenlabs' && !settings.cloudVoiceSettingsAreDefault(c)
     ? {
       elevenlabs: {
         voiceSettings: {
-          stability: c.voiceStability,
+          stability: isElevenLabsV3(c.model) ? snapV3Stability(c.voiceStability) : c.voiceStability,
           style: c.voiceStyle,
           similarityBoost: c.voiceSimilarityBoost,
           useSpeakerBoost: c.voiceUseSpeakerBoost,

--- a/controller/src/llm/sdk.ts
+++ b/controller/src/llm/sdk.ts
@@ -6,4 +6,4 @@
 export { djText } from './internal/strategy/text.js';
 export { djObject } from './internal/strategy/object.js';
 export { djAgent } from './internal/strategy/agent.js';
-export { isUnreachable, isQuotaOrAuthError, errReason, nearestId } from './internal/core/pure.js';
+export { isUnreachable, isQuotaOrAuthError, errReason, nearestId, stripThinking } from './internal/core/pure.js';

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -665,6 +665,20 @@ function clamp01(n: number): number {
   return n;
 }
 
+// True when the four ElevenLabs voice_settings knobs (issue #696) all sit at
+// their shipped defaults, i.e. the operator never tuned them. cloud-speech uses
+// this to OMIT the voice_settings block in that case so ElevenLabs defers to the
+// voice's own VoiceLab-saved settings, instead of forcing these literals onto
+// every call (issue #915 review). Compared against DEFAULTS so there's a single
+// source of truth for the default values.
+export function cloudVoiceSettingsAreDefault(c: any): boolean {
+  const d = DEFAULTS.tts.cloud;
+  return c?.voiceStability === d.voiceStability
+    && c?.voiceStyle === d.voiceStyle
+    && c?.voiceSimilarityBoost === d.voiceSimilarityBoost
+    && c?.voiceUseSpeakerBoost === d.voiceUseSpeakerBoost;
+}
+
 // Coerce a stored/per-show max-track-length to a clean integer SECOND count.
 // `allowNull` distinguishes the two callers: the station default has no "unset"
 // state (missing → 0 = off), whereas a per-show value uses null to mean "inherit

--- a/tools/audiomuse-import/import.mjs
+++ b/tools/audiomuse-import/import.mjs
@@ -44,7 +44,13 @@ function parseArgs(argv) {
     else if (a === '--library-db') args.libraryDb = next();
     else if (a === '--concurrency') args.concurrency = Math.max(1, Number(next()) || 8);
     else if (a === '--limit') args.limit = Number(next()) || undefined;
-    else if (a === '--mood-cutoff') args.moodCutoff = Number(next());
+    else if (a === '--mood-cutoff') {
+      // Guard NaN/out-of-range the way --concurrency/--limit already do — an
+      // unparseable value must not silently disable mood filtering (score < NaN
+      // is always false, so every tag would pass). #934 review.
+      const mc = Number(next());
+      args.moodCutoff = Number.isFinite(mc) ? Math.min(1, Math.max(0, mc)) : 0.4;
+    }
     else if (a === '--dry-run') args.dryRun = true;
     else if (a === '--overwrite') args.overwrite = true;
     else if (a === '-h' || a === '--help') args.help = true;
@@ -68,7 +74,7 @@ Options:
   --overwrite             Overwrite existing bpm/moods/key/energy (default:
                           fill only empty fields, never clobber SUB/WAVE's own).
   --dry-run               Map and report, write nothing.
-  --concurrency <n>       Parallel page fetches (default 8).
+  --concurrency <n>       Reserved; paging is currently sequential.
   --mood-cutoff <0..1>    Min tag score to count a mood (default 0.4).
   --limit <n>             Stop after N AudioMuse tracks (testing).
   -h, --help              This help.
@@ -86,7 +92,27 @@ async function* iterateAudioMuseTracks(baseUrl, { limit } = {}) {
     if (!res.ok) {
       throw new Error(`GET ${url} -> ${res.status} ${res.statusText}`);
     }
-    const body = await res.json();
+    // A proxy/login page can answer 200 with HTML, and a wrong-endpoint 200 can
+    // return JSON with no `tracks` array — parse defensively so either is a clear
+    // message, not a raw SyntaxError or a silent zero-track "success". #934 review.
+    let body;
+    try {
+      body = await res.json();
+    } catch {
+      throw new Error(
+        `GET ${url} returned ${res.status} but the body was not JSON — is ${root} ` +
+          `an AudioMuse API? (a proxy or login page can answer 200 with HTML.)`,
+      );
+    }
+    if (!body || !Array.isArray(body.tracks)) {
+      const shape = body && typeof body === 'object'
+        ? `keys: ${Object.keys(body).join(', ') || 'none'}`
+        : `type: ${typeof body}`;
+      throw new Error(
+        `GET ${url} returned JSON with no "tracks" array (${shape}). ` +
+          `Check the AudioMuse URL and that /api/sync is available.`,
+      );
+    }
     if (!providerChecked) {
       providerChecked = true;
       if (body.provider_type && body.provider_type.toLowerCase() !== 'navidrome') {
@@ -97,7 +123,7 @@ async function* iterateAudioMuseTracks(baseUrl, { limit } = {}) {
         );
       }
     }
-    const tracks = body.tracks || [];
+    const tracks = body.tracks;
     for (const t of tracks) {
       if (limit && seen >= limit) return;
       seen++;
@@ -159,12 +185,18 @@ function makeWriter(db) {
       params.musicalKey = mapped.musicalKey;
     }
     if (wantMoods && moodsJson) {
-      sets.push('moods = @moods', 'energy = @energy', "source = 'manual'",
+      sets.push('moods = @moods', "source = 'manual'",
         'tagger_version = @taggerVersion', 'tagged_at = @now');
       params.moods = moodsJson;
-      params.energy = mapped.energy;
       params.taggerVersion = TAGGER_VERSION;
       params.now = now;
+      // Energy rides with the mood write, but only when AudioMuse actually gave
+      // one — the existence SELECT doesn't read energy, so writing a null mapped
+      // energy here would clobber an energy SUB/WAVE already computed. #934 review.
+      if (mapped.energy != null) {
+        sets.push('energy = @energy');
+        params.energy = mapped.energy;
+      }
     }
     // Genre only fills a truly empty genre.
     if (mapped.genre != null) {

--- a/tools/audiomuse-import/map.mjs
+++ b/tools/audiomuse-import/map.mjs
@@ -95,11 +95,15 @@ const GENRE_TAGS = new Set([
 ]);
 
 // Highest-scoring genre-like tag from a parsed mood_vector, or null. Returns the
-// original-cased label as AudioMuse spelled it.
-export function topGenre(moodScores) {
+// original-cased label as AudioMuse spelled it. `cutoff` gates confidence the
+// same way moods are gated, so a near-zero tag ("metal:0.02") can't become a
+// track's genre off noise (#934 review); default 0 keeps standalone callers
+// unfiltered.
+export function topGenre(moodScores, cutoff = 0) {
   let best = null;
   let bestScore = -Infinity;
   for (const [label, score] of Object.entries(moodScores)) {
+    if (score < cutoff) continue;
     if (GENRE_TAGS.has(label.toLowerCase()) && score > bestScore) {
       best = label;
       bestScore = score;
@@ -133,6 +137,6 @@ export function mapTrack(row, { moodCutoff = 0.4 } = {}) {
     musicalKey: keyToCamelot(row.key, row.scale),
     energy: energyToBucket(row.energy),
     moods,
-    genre: topGenre(moodScores),
+    genre: topGenre(moodScores, moodCutoff),
   };
 }

--- a/tools/audiomuse-import/map.test.mjs
+++ b/tools/audiomuse-import/map.test.mjs
@@ -69,6 +69,22 @@ test('topGenre picks the highest-scoring genre-like tag', () => {
   assert.equal(topGenre({}), null);
 });
 
+test('topGenre honours the confidence cutoff', () => {
+  // A near-zero genre tag must not win off noise once a cutoff is applied.
+  assert.equal(topGenre({ metal: 0.02, rock: 0.9 }, 0.4), 'rock');
+  assert.equal(topGenre({ metal: 0.02 }, 0.4), null);
+  // The higher-confidence genre still wins even when both clear the cutoff.
+  assert.equal(topGenre({ rock: 0.5, jazz: 0.9 }, 0.4), 'jazz');
+});
+
+test('mapTrack applies moodCutoff to genre too', () => {
+  // metal below the default 0.4 cutoff → excluded from BOTH moods and genre.
+  const m = mapTrack({ mood_vector: 'metal:0.05,rock:0.8', other_features: '' });
+  assert.equal(m.genre, 'rock');
+  const noisy = mapTrack({ mood_vector: 'metal:0.05', other_features: '' });
+  assert.equal(noisy.genre, null);
+});
+
 test('mood map only carries genuine mood signal, not genre', () => {
   assert.equal(AUDIOMUSE_MOOD_MAP['rock'], undefined);
   assert.equal(AUDIOMUSE_MOOD_MAP['aggressive'], 'energetic');

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -1849,7 +1849,7 @@ function ElevenLabsVoiceSettingsField({
     <>
       {slider(
         'Stability',
-        <>Lower is more expressive but can wander; higher is steadier but flatter. ElevenLabs default is <code>50%</code>. Note: the <code>eleven_v3</code> model only accepts 0%, 50% or 100% — other values fail on that model.</>,
+        <>Lower is more expressive but can wander; higher is steadier but flatter. ElevenLabs default is <code>50%</code>. Note: the <code>eleven_v3</code> model only accepts 0%, 50% or 100% — other values are rounded to the nearest.</>,
         'voiceStability',
       )}
       {slider(


### PR DESCRIPTION
Follow-ups from a code review of the 11 commits queued on `develop` for the next release. Fixes the highest-value correctness/robustness findings; each is small and self-contained.

## Fixes

**1. Leaked reasoning could still air via structured output** — `fix(llm)`
`#949` hardened the free-text handoff path, but a reasoning model that leaks a `<think>`/harmony token *into* a structured `say`/`intro` field bypassed it (djObject's native path and djAgent's done-tool path return the parsed object unscrubbed; the dj-agent consumers only `.trim()` it). Applied `stripThinking` at `tts.speak()` — the single point every booth-bound string converges — so the invariant holds for all sources, present and future. No-op on clean text, so jingles/idents/request-intros are byte-identical.

**2. ElevenLabs `voice_settings` overrode operator VoiceLab tuning** — `fix(tts)`
`#915` sent an explicit `voice_settings` block on every ElevenLabs call, silently overriding per-voice settings saved in ElevenLabs VoiceLab (omitting the block defers to the voice's own settings). Now omit it while the four knobs sit at their shipped defaults, sending the full set only once the operator tunes one — restoring pre-`#915` behaviour for untouched installs.

**3. `eleven_v3` stability constraint not enforced** — `fix(tts)`
v3 only accepts `stability ∈ {0, 0.5, 1}`; the 0.01-step slider could send an off-grid value that 400s the request and drops the segment to Piper (which reads v3 audio tags aloud). Snap to the nearest rung for v3. Admin hint updated to say off-grid values round rather than fail. `isElevenLabsV3` moved to `core/pure.ts` (avoids a prompts→speech cycle) with a new `snapV3Stability`, both unit-pinned.

**4. AudioMuse importer hardening (`#934`)** — `fix(tools)`
- `--mood-cutoff`: guard NaN/out-of-range (was a bare `Number()`) so a junk value no longer disables mood filtering (`score < NaN` is always false).
- Apply the same confidence cutoff to genre — a near-zero tag could otherwise become a track's genre off noise.
- Parse `/api/sync` defensively: a 200 with an HTML body or JSON without a `tracks` array now fails with a clear message instead of a raw `SyntaxError` or a silent zero-track "success".
- Gap-fill no longer clobbers an energy SUB/WAVE already computed.
- Honest `--concurrency` help text (paging is sequential; flag reserved, matching the README).

## Verification
- Controller lint (`eslint` + `tsc --noEmit`): 0 errors · web lint: 0 errors
- `npm run test:llm`: pass, incl. new `snapV3Stability` cases
- Importer unit tests: 14 pass, incl. new genre-cutoff tests
- End-to-end importer drive (real `import.mjs` + mock AudioMuse server + temp SQLite): all 5 scenarios green (HTML-200 → clear error, JSON-without-tracks → clear error, junk `--mood-cutoff` → filtering intact, gap-fill preserves existing energy, happy path imports correctly)

ElevenLabs paths (#2/#3) rest on unit tests + typecheck (no live key to drive end-to-end).