### PR TITLE
feat(personas): system-prompt template library with switching + modal editor

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: verify
+description: Drive a controller/admin-UI change end-to-end from a worktree without touching the live station — isolated controller on a spare port + temp STATE_DIR, worktree Next dev server, Playwright against /admin.
+---
+
+# Verifying controller + admin-UI changes in isolation
+
+The operator's real station is usually running (docker `sub-wave-*` containers). Never restart or
+point tests at it. Boot your own stack from the worktree instead:
+
+## Isolated controller (API surface)
+
+```bash
+cd <worktree>/controller
+STATE_DIR=$CLAUDE_JOB_DIR/tmp/state PORT=7791 ADMIN_USER=test ADMIN_PASS=test \
+  NODE_ENV=development \
+  NAVIDROME_URL=http://localhost:9999 NAVIDROME_USER=x NAVIDROME_PASS=x \
+  npx tsx src/server.ts
+```
+
+- A fresh `STATE_DIR` boots clean (seeds sfx/jingles, writes `settings.json` on first save).
+- The fake `NAVIDROME_*` env matters: without it `needsSetup` is true and the admin shell
+  redirects every page to `/onboarding`, so UI tests never find their controls.
+- Drive `/settings` etc. with `curl -u test:test http://localhost:7791/...`.
+- To test load-time migrations: stop the server, hand-edit `settings.json`, restart, GET.
+- Kill by port (`fuser -k 7791/tcp`) — a `pkill -f "tsx src/server.ts"` matches the Bash tool's
+  own wrapper cmdline and kills your shell (exit 144).
+
+## Worktree web dev server (UI surface)
+
+```bash
+cd <worktree>/web
+NEXT_PUBLIC_API_URL=http://localhost:7791 npm run dev -- -p 7793
+```
+
+Then Playwright (headless chromium, sync API):
+
+- Pre-seed auth before load: `ctx.add_init_script("localStorage.setItem('subwave_admin_auth', '<base64 user:pass>')")`.
+- Assert state through the controller API after clicking Save, not through sonner toasts.
+- Admin modals portal into `.admin-root`; scope input lookups with `[role="dialog"]`.

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -99,6 +99,8 @@ router.get('/settings', requireAdmin, async (req, res) => {
         festivals: s.festivals,
         weather: s.weather,
         djPrompt: s.djPrompt,
+        djPrompts: s.djPrompts,
+        activeDjPromptId: s.activeDjPromptId,
         personas: s.personas,
         activePersonaId: s.activePersonaId,
         shows: s.shows,

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -590,6 +590,13 @@ const PLAYLISTS_PER_SHOW = 10;
 const EXCLUDED_PLAYLISTS_PER_SHOW = 10;
 const SKILLS_PER_PERSONA_LIMIT = 20;
 const WEBHOOKS_LIMIT = 16;
+// Prompt-template library (djPrompts). Text bounds match the historical
+// single-djPrompt rule — keep them in lockstep with PROMPT_MIN/PROMPT_MAX in
+// web/components/admin/personas/constants.ts.
+const DJ_PROMPT_LIMIT = 20;
+const DJ_PROMPT_NAME_MAX = 60;
+const DJ_PROMPT_TEXT_MIN = 50;
+const DJ_PROMPT_TEXT_MAX = 4000;
 
 // A show can anchor to one or more Navidrome playlists: the playlist union
 // becomes the show's candidate pool. Stored as Subsonic playlist ids; deduped,
@@ -870,7 +877,14 @@ const DEFAULTS = {
   // so the line shows the classic ♪/◇ marker until an operator opts in.
   ui: { boothBuddy: false },
   // Global DJ prompt template. '' means "use DEFAULT_DJ_PROMPT_TEMPLATE".
+  // Always the RESOLVED text of the active djPrompts entry — kept so
+  // renderDjPrompt() (and an older controller sharing the same settings.json)
+  // never has to chase the library.
   djPrompt: '',
+  // Saved prompt-template library + which entry is active ('' = built-in
+  // default). Switching templates just moves activeDjPromptId.
+  djPrompts: [],
+  activeDjPromptId: '',
   // The persona roster. One persona is "active" at a time (activePersonaId);
   // a scheduled show can override which persona is on-air for its hour.
   personas: SEED_PERSONAS,
@@ -1352,6 +1366,31 @@ function normalizePersonaArray(raw: any) {
   return out.length ? out : null;
 }
 
+// Lenient load-time path for the prompt-template library: drop entries that
+// can't render (bad text) rather than failing the whole settings load. A
+// missing/duplicate name degrades to "Prompt N" instead of dropping the entry —
+// the text is the part the operator can't afford to lose.
+function normalizeDjPrompts(raw: any) {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
+  const out: any[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const text = typeof item.text === 'string' ? item.text.trim() : '';
+    if (text.length < DJ_PROMPT_TEXT_MIN || text.length > DJ_PROMPT_TEXT_MAX) continue;
+    if (!text.includes('{name}')) continue;
+    let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('dp_');
+    if (seen.has(id)) id = mintId('dp_');
+    seen.add(id);
+    const name =
+      (typeof item.name === 'string' ? item.name.trim().slice(0, DJ_PROMPT_NAME_MAX) : '') ||
+      `Prompt ${out.length + 1}`;
+    out.push({ id, name, text });
+    if (out.length >= DJ_PROMPT_LIMIT) break;
+  }
+  return out;
+}
+
 function normalizeShows(raw: any, personaIds: string[]) {
   if (!Array.isArray(raw)) return [];
   const seen = new Set<string>();
@@ -1506,6 +1545,23 @@ export async function load() {
         : '';
   if (djPrompt.trim() === DEFAULT_DJ_PROMPT_TEMPLATE.trim()) djPrompt = '';
 
+  // Prompt-template library. A pre-library settings.json (single custom
+  // djPrompt, no djPrompts array) migrates that custom text into a lone
+  // library entry so the operator finds their prompt where the UI now lives.
+  let djPrompts = normalizeDjPrompts(stored.djPrompts);
+  let activeDjPromptId =
+    typeof stored.activeDjPromptId === 'string' ? stored.activeDjPromptId : '';
+  if (!djPrompts.length && djPrompt.trim()) {
+    djPrompts = [{ id: mintId('dp_'), name: 'Custom prompt', text: djPrompt.trim() }];
+    activeDjPromptId = djPrompts[0].id;
+  }
+  // Dangling active id (hand-edited file) falls back to the built-in default.
+  if (activeDjPromptId && !djPrompts.some(p => p.id === activeDjPromptId)) {
+    activeDjPromptId = '';
+  }
+  // djPrompt is always the resolved active text — see DEFAULTS.
+  djPrompt = djPrompts.find(p => p.id === activeDjPromptId)?.text ?? '';
+
   const shows = normalizeShows(stored.shows, personaIds);
   const schedule = normalizeSchedule(
     stored.schedule,
@@ -1584,6 +1640,8 @@ export async function load() {
           : DEFAULTS.weather.units,
     },
     djPrompt,
+    djPrompts,
+    activeDjPromptId,
     station:
       typeof stored.station === 'string' && stored.station.trim()
         ? stored.station.trim().slice(0, 80)
@@ -2091,6 +2149,36 @@ function validateTtsBlock(raw, where) {
     }
   }
   return { engine: t.engine, cloudProvider: t.cloudProvider, voice, gainDb: clampTtsGain(t.gainDb), speed: clampTtsSpeed(t.speed) };
+}
+
+// Strict update-time path for the prompt-template library — any bad entry
+// rejects the whole patch so the operator sees the error instead of silently
+// losing a prompt.
+export function validateDjPromptsStrict(raw) {
+  if (!Array.isArray(raw) || raw.length > DJ_PROMPT_LIMIT) {
+    throw new Error(`djPrompts must be an array of 0-${DJ_PROMPT_LIMIT} entries`);
+  }
+  const seen = new Set();
+  return raw.map((item, i) => {
+    if (!item || typeof item !== 'object') throw new Error(`djPrompts[${i}] must be an object`);
+    const name = String(item.name ?? '').trim();
+    if (name.length < 1 || name.length > DJ_PROMPT_NAME_MAX) {
+      throw new Error(`djPrompts[${i}].name must be 1-${DJ_PROMPT_NAME_MAX} chars`);
+    }
+    const text = String(item.text ?? '').trim();
+    if (text.length < DJ_PROMPT_TEXT_MIN || text.length > DJ_PROMPT_TEXT_MAX) {
+      throw new Error(
+        `djPrompts[${i}].text must be ${DJ_PROMPT_TEXT_MIN}-${DJ_PROMPT_TEXT_MAX} chars`,
+      );
+    }
+    if (!text.includes('{name}')) {
+      throw new Error(`djPrompts[${i}].text must contain the {name} placeholder`);
+    }
+    let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('dp_');
+    if (seen.has(id)) id = mintId('dp_');
+    seen.add(id);
+    return { id, name, text };
+  });
 }
 
 export function validatePersonasStrict(raw) {
@@ -2692,19 +2780,56 @@ export async function update(patch) {
   if ('festivals' in patch) {
     next.festivals = validateFestivalsStrict(patch.festivals);
   }
+  // Prompt-template library. `djPrompts` replaces the whole library;
+  // `activeDjPromptId` switches which entry renders ('' = built-in default).
+  // The legacy single-field `djPrompt` (onboarding wizard, older clients)
+  // still works by mapping onto the library: '' selects the default, custom
+  // text reuses the entry with identical text or appends a "Custom prompt".
+  if ('djPrompts' in patch) {
+    next.djPrompts = validateDjPromptsStrict(patch.djPrompts);
+  }
+  if ('activeDjPromptId' in patch) {
+    next.activeDjPromptId = String(patch.activeDjPromptId ?? '').trim();
+  }
   if ('djPrompt' in patch) {
     const v = String(patch.djPrompt ?? '').trim();
     if (v === '') {
-      next.djPrompt = '';
+      next.activeDjPromptId = '';
     } else {
-      if (v.length < 50 || v.length > 4000) {
-        throw new Error('djPrompt must be empty (use the default) or 50-4000 chars');
+      if (v.length < DJ_PROMPT_TEXT_MIN || v.length > DJ_PROMPT_TEXT_MAX) {
+        throw new Error(
+          `djPrompt must be empty (use the default) or ${DJ_PROMPT_TEXT_MIN}-${DJ_PROMPT_TEXT_MAX} chars`,
+        );
       }
       if (!v.includes('{name}')) {
         throw new Error('djPrompt must contain the {name} placeholder');
       }
-      next.djPrompt = v;
+      let entry = next.djPrompts.find((p: any) => p.text === v);
+      if (!entry) {
+        if (next.djPrompts.length >= DJ_PROMPT_LIMIT) {
+          throw new Error(`the prompt library is full (${DJ_PROMPT_LIMIT} entries)`);
+        }
+        entry = { id: mintId('dp_'), name: 'Custom prompt', text: v };
+        next.djPrompts.push(entry);
+      }
+      next.activeDjPromptId = entry.id;
     }
+  }
+  if ('djPrompts' in patch || 'activeDjPromptId' in patch || 'djPrompt' in patch) {
+    if (
+      next.activeDjPromptId &&
+      !next.djPrompts.some((p: any) => p.id === next.activeDjPromptId)
+    ) {
+      if ('activeDjPromptId' in patch || 'djPrompt' in patch) {
+        throw new Error('activeDjPromptId must be "" or the id of a djPrompts entry');
+      }
+      // A library-only patch removed the entry that was active — fall back to
+      // the built-in default rather than failing the save.
+      next.activeDjPromptId = '';
+    }
+    // djPrompt stays the resolved active text — the single field readers use.
+    next.djPrompt =
+      next.djPrompts.find((p: any) => p.id === next.activeDjPromptId)?.text ?? '';
   }
   if ('personas' in patch) {
     next.personas = validatePersonasStrict(patch.personas);

--- a/docs/superpowers/specs/2026-07-08-dj-prompt-library-design.md
+++ b/docs/superpowers/specs/2026-07-08-dj-prompt-library-design.md
@@ -1,0 +1,66 @@
+# DJ system-prompt library — design
+
+**Goal.** The admin Personas page has one global system-prompt template (built-in default or a single
+custom string). Operators want to keep several templates and switch between them, and the inline
+textarea editor should move into a modal.
+
+## Data model (controller)
+
+Two new settings fields alongside the existing `djPrompt`:
+
+- `djPrompts: Array<{ id, name, text }>` — the saved template library. `id` is server-minted
+  (`dp_xxxxxx`, same `mintId` as personas/shows), `name` 1–60 chars, `text` 50–4000 chars and must
+  contain `{name}` (same bounds as today's `djPrompt`). Max 20 presets.
+- `activeDjPromptId: string` — `''` selects the built-in default template, otherwise must reference
+  an entry in `djPrompts`.
+
+`djPrompt` stays in the cache (and in `settings.json`) as the **resolved active text** (`''` when
+the built-in default is active). `renderDjPrompt()` and every other reader keep working untouched,
+and an older controller pointed at the same `settings.json` still honours the active prompt.
+
+**Load / migration** (`load()`): parse `stored.djPrompts` leniently; if empty and the legacy
+`djPrompt` (or `dj.systemPrompt`) is a non-default custom string, seed the library with one entry
+named "Custom prompt" and activate it. A dangling `activeDjPromptId` falls back to `''`. Then
+resolve `cache.djPrompt` from the active entry.
+
+**Update** (`update(patch)`):
+
+- `djPrompts` → `validateDjPromptsStrict()`: array ≤ 20; per entry name/text bounds as above; ids
+  re-minted when missing/invalid/duplicate.
+- `activeDjPromptId` → string; after both patches apply, a non-empty id that doesn't exist in
+  `next.djPrompts` throws.
+- Legacy `djPrompt` (onboarding wizard, older UI) still accepted: `''` → activate built-in;
+  non-empty → reuse the library entry with identical text or append a "Custom prompt" entry, then
+  activate it.
+- Finally `next.djPrompt` is recomputed from the active entry so the persisted file and cache stay
+  the single source of truth for readers.
+
+**GET /settings**: `values.djPrompts` + `values.activeDjPromptId` added; `values.djPrompt` (resolved)
+and `defaults.djPrompt` (built-in template text) stay for older clients.
+
+## Web UI (`/admin/personas`)
+
+`FormState` swaps `useCustomPrompt`/`systemPrompt` for `djPrompts` + `activeDjPromptId`.
+
+`SystemPromptCard` becomes a **prompt library**:
+
+- A list of rows: "Built-in default" first, then each saved preset (name + char count). Each row has
+  an activate control (radio-style; the active row is marked), the built-in row a **View** button,
+  preset rows an **Edit** and **Delete** button.
+- **New prompt** button appends a preset seeded from the built-in default text (disabled at the
+  20-preset cap). Ids minted client-side (`dp_` + 3 random bytes); the server re-mints invalid ones.
+- Deleting the active preset falls the selection back to the built-in default. Deletion is a form
+  edit — nothing persists until Save.
+- **Modal editor** (existing `components/ui/modal.tsx`): name input, mono textarea (~16 rows),
+  char counter with `{name}`/min-length hints, "Restore default text", footer Done. Edits write
+  straight into form state; the card's existing save bar (whole-form POST to `/settings`) persists.
+  The built-in default opens in the same modal read-only.
+- Validation: every preset valid (name 1–60, text 50–4000 with `{name}`) and the active id must
+  exist; both feed the existing `canSave` gate with per-cause messaging.
+
+Save body sends `djPrompts` + `activeDjPromptId` (no more legacy `djPrompt`).
+
+## Out of scope
+
+Per-persona prompts (the template stays global — personas ride through `{name}`/`{soul}`),
+import/export, and the native app (it has no admin surface).

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -4,7 +4,8 @@
 // One persona is "active" at a time (a scheduled Show can override which
 // persona is on air for its hour). Each persona owns its name, tagline, talk
 // frequency, soul, and full voice (TTS engine + cloud provider + voice).
-// The system prompt is one global template shared by every persona.
+// The system prompt is a library of global templates shared by every persona,
+// one active at a time ('' = the built-in default).
 // Everything POSTs to /settings and applies live — no mixer restart.
 //
 // This file is the stateful container: it owns the form, validation, save, and
@@ -15,10 +16,11 @@ import { notify, errorMessage } from '../../lib/notify';
 import { Card, Btn, Pill } from './ui';
 import { V3AlertDialog } from '../ui/alert-dialog';
 import { Modal } from '../ui/modal';
-import type { Persona, PersonaTts, FormState, SettingsResponse, CommunityPersona } from './personas/types';
-import { DIAL_NEUTRAL, PERSONA_MAX, PROMPT_MIN, PROMPT_MAX } from './personas/constants';
+import type { Persona, PersonaTts, DjPromptPreset, FormState, SettingsResponse, CommunityPersona } from './personas/types';
+import { DIAL_NEUTRAL, PERSONA_MAX } from './personas/constants';
 import {
-  clientMintId, fetchDicebearAvatar, fileToAvatarDataUrl, personaValid, voiceForSave, cloudIssue,
+  clientMintId, fetchDicebearAvatar, fileToAvatarDataUrl, personaValid, promptPresetValid,
+  voiceForSave, cloudIssue,
 } from './personas/helpers';
 import { PersonaHero } from './personas/PersonaHero';
 import { SystemPromptCard } from './personas/SystemPromptCard';
@@ -90,8 +92,26 @@ export default function PersonasPanel() {
       if (j?.values?.personas) {
         const v = j.values;
         const defaultPrompt = j.defaults?.djPrompt || '';
-        const stored = v.djPrompt || '';
-        const custom = stored !== '' && stored !== defaultPrompt;
+        // Prompt-template library. An older controller (no djPrompts field)
+        // degrades to its single custom djPrompt as a lone library entry.
+        let djPrompts: DjPromptPreset[] = Array.isArray(v.djPrompts)
+          ? v.djPrompts.map(p => ({
+              id: typeof p.id === 'string' && p.id ? p.id : clientMintId('dp_'),
+              name: typeof p.name === 'string' ? p.name : '',
+              text: typeof p.text === 'string' ? p.text : '',
+            }))
+          : [];
+        let activeDjPromptId = typeof v.activeDjPromptId === 'string' ? v.activeDjPromptId : '';
+        if (!Array.isArray(v.djPrompts)) {
+          const stored = v.djPrompt || '';
+          if (stored !== '' && stored !== defaultPrompt) {
+            djPrompts = [{ id: clientMintId('dp_'), name: 'Custom prompt', text: stored }];
+            activeDjPromptId = djPrompts[0]!.id;
+          }
+        }
+        if (activeDjPromptId && !djPrompts.some(p => p.id === activeDjPromptId)) {
+          activeDjPromptId = '';
+        }
         // Catalog of every skill. A persona with no stored `skills` (legacy /
         // code default) is treated as running all of them.
         const allSkills = (j.skills?.catalog || []).map(s => s.name);
@@ -119,8 +139,8 @@ export default function PersonasPanel() {
             skills: Array.isArray(p.skills) ? p.skills : allSkills,
           })),
           activePersonaId: v.activePersonaId ?? '',
-          useCustomPrompt: custom,
-          systemPrompt: custom ? stored : defaultPrompt,
+          djPrompts,
+          activeDjPromptId,
         });
       }
     })();
@@ -312,12 +332,28 @@ export default function PersonasPanel() {
     }
   };
 
+  // ── prompt-library helpers ─────────────────────────────────────────────────
+  const addPromptPreset = (preset: DjPromptPreset) =>
+    setForm(f => f ? { ...f, djPrompts: [...f.djPrompts, preset] } : f);
+  const patchPromptPreset = (id: string, patch: Partial<Pick<DjPromptPreset, 'name' | 'text'>>) =>
+    setForm(f => f ? { ...f, djPrompts: f.djPrompts.map(p => (p.id === id ? { ...p, ...patch } : p)) } : f);
+  const removePromptPreset = (id: string) =>
+    setForm(f => f
+      ? {
+          ...f,
+          djPrompts: f.djPrompts.filter(p => p.id !== id),
+          // Deleting the in-use template falls back to the built-in default.
+          activeDjPromptId: f.activeDjPromptId === id ? '' : f.activeDjPromptId,
+        }
+      : f);
+
   // ── validation ───────────────────────────────────────────────────────────
-  const promptText = form ? form.systemPrompt.trim() : '';
-  const promptOk = !form?.useCustomPrompt
-    || (promptText.length >= PROMPT_MIN && promptText.length <= PROMPT_MAX && promptText.includes('{name}'));
+  const promptsOk = form
+    ? form.djPrompts.every(promptPresetValid)
+      && (form.activeDjPromptId === '' || form.djPrompts.some(p => p.id === form.activeDjPromptId))
+    : false;
   const allPersonasOk = form ? form.personas.every(p => personaValid(p)) : false;
-  const canSave = !!form && allPersonasOk && promptOk
+  const canSave = !!form && allPersonasOk && promptsOk
     && form.personas.some(p => p.id === form.activePersonaId);
 
   const save = async (): Promise<boolean> => {
@@ -357,7 +393,8 @@ export default function PersonasPanel() {
             skills: p.skills,
           })),
           activePersonaId: form.activePersonaId,
-          djPrompt: form.useCustomPrompt ? form.systemPrompt.trim() : '',
+          djPrompts: form.djPrompts.map(p => ({ id: p.id, name: p.name.trim(), text: p.text.trim() })),
+          activeDjPromptId: form.activeDjPromptId,
         }),
       });
       const j = (await r.json().catch(() => ({}))) as { error?: string };
@@ -428,17 +465,17 @@ export default function PersonasPanel() {
 
       {showPrompt && (
         <SystemPromptCard
-          useCustomPrompt={form.useCustomPrompt}
-          systemPrompt={form.systemPrompt}
+          presets={form.djPrompts}
+          activeId={form.activeDjPromptId}
           defaultPrompt={data?.defaults?.djPrompt || ''}
-          promptOk={promptOk}
-          promptText={promptText}
           busy={busy}
           canSave={canSave}
           allPersonasOk={allPersonasOk}
-          onSetUseCustom={(custom) => setForm(f => f ? ({ ...f, useCustomPrompt: custom }) : f)}
-          onChangePrompt={(text) => setForm(f => f ? ({ ...f, systemPrompt: text }) : f)}
-          onRestore={() => setForm(f => f ? ({ ...f, systemPrompt: data?.defaults?.djPrompt || '' }) : f)}
+          promptsOk={promptsOk}
+          onSetActive={(id) => setForm(f => f ? ({ ...f, activeDjPromptId: id }) : f)}
+          onAddPreset={addPromptPreset}
+          onPatchPreset={patchPromptPreset}
+          onRemovePreset={removePromptPreset}
           onSave={() => { save(); }}
           onDiscard={() => { load(); }}
         />
@@ -568,7 +605,7 @@ export default function PersonasPanel() {
         canSave={canSave}
         focusedOk={focusedOk}
         allPersonasOk={allPersonasOk}
-        promptOk={promptOk}
+        promptOk={promptsOk}
         busy={busy}
         onSave={async () => { if (await save()) setEditorOpen(false); }}
         onDiscard={() => { load(); setEditorOpen(false); }}

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -23,7 +23,7 @@ import {
   voiceForSave, cloudIssue,
 } from './personas/helpers';
 import { PersonaHero } from './personas/PersonaHero';
-import { SystemPromptCard } from './personas/SystemPromptCard';
+import { SystemPromptModal } from './personas/SystemPromptModal';
 import { PersonaRoster } from './personas/PersonaRoster';
 import { PersonaEditor } from './personas/PersonaEditor';
 
@@ -40,7 +40,7 @@ export default function PersonasPanel() {
   const [editorOpen, setEditorOpen] = useState(false);
   // id of a freshly-added persona — the AI-draft field shows only while creating.
   const [creatingId, setCreatingId] = useState<string | null>(null);
-  // toggles the system-prompt editor card
+  // whether the system-prompt library modal is open
   const [showPrompt, setShowPrompt] = useState(false);
   // Bumped on every avatar mutation. Appended as ?v=… so the admin <img>
   // refetches even though the public endpoint caches for an hour — the cache
@@ -463,31 +463,30 @@ export default function PersonasPanel() {
         onAirCloudIssue={onAirCloudIssue}
       />
 
-      {showPrompt && (
-        <SystemPromptCard
-          presets={form.djPrompts}
-          activeId={form.activeDjPromptId}
-          defaultPrompt={data?.defaults?.djPrompt || ''}
-          busy={busy}
-          canSave={canSave}
-          allPersonasOk={allPersonasOk}
-          promptsOk={promptsOk}
-          onSetActive={(id) => setForm(f => f ? ({ ...f, activeDjPromptId: id }) : f)}
-          onAddPreset={addPromptPreset}
-          onPatchPreset={patchPromptPreset}
-          onRemovePreset={removePromptPreset}
-          onSave={() => { save(); }}
-          onDiscard={() => { load(); }}
-        />
-      )}
+      <SystemPromptModal
+        open={showPrompt}
+        onOpenChange={setShowPrompt}
+        presets={form.djPrompts}
+        activeId={form.activeDjPromptId}
+        defaultPrompt={data?.defaults?.djPrompt || ''}
+        busy={busy}
+        canSave={canSave}
+        allPersonasOk={allPersonasOk}
+        promptsOk={promptsOk}
+        onSetActive={(id) => setForm(f => f ? ({ ...f, activeDjPromptId: id }) : f)}
+        onAddPreset={addPromptPreset}
+        onPatchPreset={patchPromptPreset}
+        onRemovePreset={removePromptPreset}
+        onSave={async () => { if (await save()) setShowPrompt(false); }}
+        onDiscard={() => { load(); setShowPrompt(false); }}
+      />
 
       <PersonaRoster
         personas={form.personas}
         activePersonaId={form.activePersonaId}
         onAirPersonaId={onAirPersonaId}
         avatarTick={avatarTick}
-        showPrompt={showPrompt}
-        onTogglePrompt={() => setShowPrompt(s => !s)}
+        onOpenPrompt={() => setShowPrompt(true)}
         onAdd={addPersona}
         onSelect={(i) => { setCreatingId(null); setFocusIdx(i); setEditorOpen(true); }}
         communityCount={community?.length ?? null}

--- a/web/components/admin/personas/PersonaEditor.tsx
+++ b/web/components/admin/personas/PersonaEditor.tsx
@@ -107,7 +107,7 @@ export function PersonaEditor({
                 : !canSave && !allPersonasOk
                   ? <span className="text-[var(--danger)]">another persona in the roster is incomplete</span>
                   : !canSave && !promptOk
-                    ? <span className="text-[var(--danger)]">fix the custom system prompt</span>
+                    ? <span className="text-[var(--danger)]">fix the system-prompt library</span>
                     : 'changes apply on the next spoken line · no mixer restart'}
             </span>
           </div>

--- a/web/components/admin/personas/PersonaRoster.tsx
+++ b/web/components/admin/personas/PersonaRoster.tsx
@@ -17,8 +17,8 @@ interface PersonaRosterProps {
   // "on air" pill. Equals activePersonaId unless a show overrides.
   onAirPersonaId: string;
   avatarTick: number;
-  showPrompt: boolean;
-  onTogglePrompt: () => void;
+  // Opens the system-prompt library modal.
+  onOpenPrompt: () => void;
   onAdd: () => void;
   onSelect: (idx: number) => void;
   // Shipped community catalog size (null = still loading — button disabled).
@@ -28,7 +28,7 @@ interface PersonaRosterProps {
 
 export function PersonaRoster({
   personas, activePersonaId, onAirPersonaId, avatarTick,
-  showPrompt, onTogglePrompt, onAdd, onSelect, communityCount, onCommunity,
+  onOpenPrompt, onAdd, onSelect, communityCount, onCommunity,
 }: PersonaRosterProps) {
   return (
     <section className="grid gap-4">
@@ -45,9 +45,7 @@ export function PersonaRoster({
               <span className="ml-1 text-vermilion">{communityCount}</span>
             )}
           </Btn>
-          <Btn onClick={onTogglePrompt}>
-            {showPrompt ? 'Hide system prompt' : 'System prompt'}
-          </Btn>
+          <Btn onClick={onOpenPrompt}>System prompt</Btn>
           <Btn tone="accent" onClick={onAdd} disabled={personas.length >= PERSONA_MAX}>
             + Add persona
           </Btn>

--- a/web/components/admin/personas/SystemPromptCard.tsx
+++ b/web/components/admin/personas/SystemPromptCard.tsx
@@ -1,80 +1,158 @@
 'use client';
-// The global system-prompt editor — one template shared by every persona.
-// Toggled from the hero.
-import type { ChangeEvent } from 'react';
-import { Card, Btn, Seg } from '../ui';
+// The global system-prompt library — saved templates shared by every persona,
+// one active at a time ('' = the built-in default). Rows switch/manage the
+// templates; the actual text is edited in a modal. Toggled from the roster.
+import type { ChangeEvent, ReactNode } from 'react';
+import { useState } from 'react';
+import { Card, Btn, Pill } from '../ui';
+import { Input } from '../../ui/input';
 import { Textarea } from '../../ui/textarea';
+import { Modal } from '../../ui/modal';
+import { V3AlertDialog } from '../../ui/alert-dialog';
 import { cn } from '../../../lib/cn';
-import { PROMPT_MIN, PROMPT_MAX } from './constants';
+import type { DjPromptPreset } from './types';
+import { promptPresetValid, clientMintId } from './helpers';
+import { PROMPT_MIN, PROMPT_MAX, PROMPT_NAME_MAX, PROMPT_PRESET_MAX } from './constants';
 
 interface SystemPromptCardProps {
-  useCustomPrompt: boolean;
-  systemPrompt: string;
-  defaultPrompt: string;
-  promptOk: boolean;
-  promptText: string;   // trimmed
+  presets: DjPromptPreset[];
+  activeId: string;        // '' = built-in default
+  defaultPrompt: string;   // the built-in template text
   busy: boolean;
   // Save is shared with the persona editor — both POST the whole form (personas
-  // + djPrompt) — so `canSave` carries the same roster-wide gate. When it's
-  // blocked by something other than the prompt, `allPersonasOk` lets us say why.
+  // + prompt library) — so `canSave` carries the same roster-wide gate. When
+  // it's blocked by something other than the prompts, `allPersonasOk` lets us
+  // say why.
   canSave: boolean;
   allPersonasOk: boolean;
-  onSetUseCustom: (custom: boolean) => void;
-  onChangePrompt: (text: string) => void;
-  onRestore: () => void;
+  promptsOk: boolean;      // every preset in the library is valid
+  onSetActive: (id: string) => void;
+  onAddPreset: (preset: DjPromptPreset) => void;
+  onPatchPreset: (id: string, patch: Partial<Pick<DjPromptPreset, 'name' | 'text'>>) => void;
+  onRemovePreset: (id: string) => void;
   onSave: () => void;
   onDiscard: () => void;
 }
 
 export function SystemPromptCard({
-  useCustomPrompt, systemPrompt, defaultPrompt, promptOk, promptText, busy,
-  canSave, allPersonasOk,
-  onSetUseCustom, onChangePrompt, onRestore, onSave, onDiscard,
+  presets, activeId, defaultPrompt, busy, canSave, allPersonasOk, promptsOk,
+  onSetActive, onAddPreset, onPatchPreset, onRemovePreset, onSave, onDiscard,
 }: SystemPromptCardProps) {
-  return (
-    <Card title="System prompt" sub="shared by every persona">
-      <p className="mb-2.5 max-w-[70ch] text-[12px] leading-[1.6] text-muted">
-        One template wrapped around every DJ generation, shared by all personas.
-        Placeholders: <code>{'{name}'}</code> · <code>{'{soul}'}</code> ·{' '}
-        <code>{'{station}'}</code> · <code>{'{location}'}</code> · <code>{'{language}'}</code>.
-        Most stations never touch this.
-      </p>
-      <Seg
-        value={useCustomPrompt ? 'custom' : 'default'}
-        options={[{ id: 'default', label: 'Built-in default' }, { id: 'custom', label: 'Custom' }]}
-        onChange={v => onSetUseCustom(v === 'custom')}
-      />
-      {!useCustomPrompt ? (
-        <div className="mt-3">
-          <div className="caption mb-1.5">the DJ uses this built-in template</div>
-          <pre className="term max-h-[220px]">
-            {defaultPrompt || '(default unavailable)'}
-          </pre>
-        </div>
-      ) : (
-        <div className="mt-3">
-          <Textarea
-            rows={12}
-            value={systemPrompt}
-            maxLength={PROMPT_MAX}
-            onChange={(e: ChangeEvent<HTMLTextAreaElement>) => onChangePrompt(e.target.value)}
-            className={cn(
-              'font-mono text-[12px]',
-              promptOk ? 'border-ink' : 'border-[var(--danger)]',
-            )}
-          />
-          <div className="mt-2.5 flex flex-wrap items-center gap-3">
-            <Btn onClick={onRestore} disabled={busy || !defaultPrompt}>
-              Restore default text
-            </Btn>
-            <span className={cn('caption', promptOk ? 'text-muted' : 'text-[var(--danger)]')}>
-              {promptText.length}/{PROMPT_MAX} chars
-              {!promptText.includes('{name}') && ' · missing {name}'}
-              {promptText.length > 0 && promptText.length < PROMPT_MIN && ` · min ${PROMPT_MIN}`}
-            </span>
-          </div>
-        </div>
+  // Which template the modal shows: 'default' is the read-only built-in view,
+  // otherwise a preset id. null = modal closed. Local to the card — the form
+  // data itself lives in the container.
+  const [editing, setEditing] = useState<string | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const addPreset = () => {
+    if (presets.length >= PROMPT_PRESET_MAX) return;
+    // Seed from the built-in template so the operator edits from a working
+    // prompt instead of a blank textarea.
+    const preset: DjPromptPreset = {
+      id: clientMintId('dp_'),
+      name: `Prompt ${presets.length + 1}`,
+      text: defaultPrompt,
+    };
+    onAddPreset(preset);
+    setEditing(preset.id);
+  };
+
+  const editingPreset = editing && editing !== 'default'
+    ? presets.find(p => p.id === editing) ?? null
+    : null;
+  const editingText = editingPreset ? editingPreset.text.trim() : '';
+  const editingNameOk = !editingPreset
+    || (editingPreset.name.trim().length >= 1 && editingPreset.name.trim().length <= PROMPT_NAME_MAX);
+  const editingTextOk = !editingPreset
+    || (editingText.length >= PROMPT_MIN && editingText.length <= PROMPT_MAX && editingText.includes('{name}'));
+  const deleting = confirmDeleteId ? presets.find(p => p.id === confirmDeleteId) : null;
+
+  const row = (opts: {
+    key: string;
+    name: string;
+    meta: string;
+    isActive: boolean;
+    invalid?: boolean;
+    onUse: () => void;
+    actions: ReactNode;
+  }) => (
+    <div
+      key={opts.key}
+      className={cn(
+        'grid grid-cols-[auto_1fr_auto] items-center gap-3 border p-2.5',
+        opts.invalid ? 'border-[var(--danger)]' : opts.isActive ? 'border-ink' : 'border-ink/40',
       )}
+    >
+      {/* radio-style activate control */}
+      <button
+        type="button"
+        aria-label={opts.isActive ? `${opts.name} is in use` : `Use ${opts.name}`}
+        onClick={opts.onUse}
+        disabled={opts.isActive}
+        className={cn(
+          'v3-focus grid size-4 flex-none place-items-center rounded-full border border-ink bg-transparent p-0',
+          opts.isActive ? 'cursor-default' : 'cursor-pointer hover:border-[var(--accent)]',
+        )}
+      >
+        {opts.isActive && <span className="size-2 rounded-full bg-[var(--accent)]" />}
+      </button>
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-[13px] font-extrabold">{opts.name}</span>
+          {opts.isActive && <Pill tone="accent" dot className="flex-none text-[8px]">in use</Pill>}
+          {opts.invalid && <Pill className="flex-none text-[8px] text-[var(--danger)]">incomplete</Pill>}
+        </div>
+        <div className="caption mt-0.5">{opts.meta}</div>
+      </div>
+      <div className="flex flex-none items-center gap-2">{opts.actions}</div>
+    </div>
+  );
+
+  return (
+    <Card title="System prompt" sub="template library — shared by every persona">
+      <p className="mb-3 max-w-[70ch] text-[12px] leading-[1.6] text-muted">
+        One template is wrapped around every DJ generation, shared by all personas.
+        Keep several saved and switch which one is in use. Placeholders:{' '}
+        <code>{'{name}'}</code> · <code>{'{soul}'}</code> · <code>{'{station}'}</code> ·{' '}
+        <code>{'{location}'}</code> · <code>{'{language}'}</code>. Most stations stay on the built-in default.
+      </p>
+
+      <div className="grid gap-2">
+        {row({
+          key: 'default',
+          name: 'Built-in default',
+          meta: 'ships with SUB/WAVE · read-only',
+          isActive: activeId === '',
+          onUse: () => onSetActive(''),
+          actions: <Btn sm onClick={() => setEditing('default')}>View</Btn>,
+        })}
+        {presets.map(p =>
+          row({
+            key: p.id,
+            name: p.name.trim() || '(unnamed)',
+            meta: `${p.text.trim().length} chars`,
+            isActive: activeId === p.id,
+            invalid: !promptPresetValid(p),
+            onUse: () => onSetActive(p.id),
+            actions: (
+              <>
+                <Btn sm onClick={() => setEditing(p.id)}>Edit</Btn>
+                <Btn sm onClick={() => setConfirmDeleteId(p.id)} disabled={busy}>Delete</Btn>
+              </>
+            ),
+          }),
+        )}
+      </div>
+
+      <div className="mt-3">
+        <Btn
+          onClick={addPreset}
+          disabled={busy || presets.length >= PROMPT_PRESET_MAX}
+          title={presets.length >= PROMPT_PRESET_MAX ? `The library is full (${PROMPT_PRESET_MAX} templates)` : undefined}
+        >
+          New prompt
+        </Btn>
+      </div>
 
       {/* Save bar. Lives on the card itself because the persona editor — the
           only other place this form can be saved from — is a modal that's
@@ -87,8 +165,8 @@ export function SystemPromptCard({
           )}
         />
         <span className="text-[11px] text-muted">
-          {!canSave && !promptOk
-            ? <span className="text-[var(--danger)]">fix the custom system prompt</span>
+          {!canSave && !promptsOk
+            ? <span className="text-[var(--danger)]">fix the incomplete prompt template</span>
             : !canSave && !allPersonasOk
               ? <span className="text-[var(--danger)]">a persona in the roster is incomplete — fix it before saving</span>
               : 'changes apply on the next spoken line · no mixer restart'}
@@ -100,6 +178,79 @@ export function SystemPromptCard({
           </Btn>
         </span>
       </div>
+
+      {/* ── TEMPLATE EDITOR MODAL ─────────────────────────────────────────── */}
+      <Modal
+        open={editing !== null}
+        onOpenChange={(o) => { if (!o) setEditing(null); }}
+        title={editing === 'default' ? 'built-in default' : 'edit prompt'}
+        sub={editing === 'default' ? 'read-only — New prompt starts from this text' : editingPreset?.name.trim() || undefined}
+        width={720}
+        footer={
+          <>
+            {editingPreset && (
+              <span className={cn('caption mr-auto', editingTextOk && editingNameOk ? 'text-muted' : 'text-[var(--danger)]')}>
+                {editingText.length}/{PROMPT_MAX} chars
+                {!editingNameOk && ' · name required'}
+                {!editingText.includes('{name}') && ' · missing {name}'}
+                {editingText.length > 0 && editingText.length < PROMPT_MIN && ` · min ${PROMPT_MIN}`}
+              </span>
+            )}
+            <Btn onClick={() => setEditing(null)}>Done</Btn>
+          </>
+        }
+      >
+        {editing === 'default' ? (
+          <pre className="term max-h-[420px]">{defaultPrompt || '(default unavailable)'}</pre>
+        ) : editingPreset ? (
+          <div className="grid gap-3">
+            <div>
+              <div className="caption mb-1.5">name</div>
+              <Input
+                value={editingPreset.name}
+                maxLength={PROMPT_NAME_MAX}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => onPatchPreset(editingPreset.id, { name: e.target.value })}
+                className={cn(!editingNameOk && 'border-[var(--danger)]')}
+              />
+            </div>
+            <div>
+              <div className="caption mb-1.5">template</div>
+              <Textarea
+                rows={16}
+                value={editingPreset.text}
+                maxLength={PROMPT_MAX}
+                onChange={(e: ChangeEvent<HTMLTextAreaElement>) => onPatchPreset(editingPreset.id, { text: e.target.value })}
+                className={cn('font-mono text-[12px]', editingTextOk ? 'border-ink' : 'border-[var(--danger)]')}
+              />
+            </div>
+            <div>
+              <Btn onClick={() => onPatchPreset(editingPreset.id, { text: defaultPrompt })} disabled={!defaultPrompt}>
+                Restore default text
+              </Btn>
+            </div>
+          </div>
+        ) : null}
+      </Modal>
+
+      <V3AlertDialog
+        open={confirmDeleteId !== null}
+        onOpenChange={(o) => { if (!o) setConfirmDeleteId(null); }}
+        title="Delete prompt"
+        description={
+          <>
+            Remove <b>{deleting?.name.trim() || 'this prompt'}</b> from the library?
+            {confirmDeleteId === activeId && ' The station falls back to the built-in default.'}
+            {' '}Nothing is permanent until you Save.
+          </>
+        }
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        danger
+        onConfirm={() => {
+          if (confirmDeleteId) onRemovePreset(confirmDeleteId);
+          setConfirmDeleteId(null);
+        }}
+      />
     </Card>
   );
 }

--- a/web/components/admin/personas/SystemPromptModal.tsx
+++ b/web/components/admin/personas/SystemPromptModal.tsx
@@ -1,10 +1,13 @@
 'use client';
-// The global system-prompt library — saved templates shared by every persona,
-// one active at a time ('' = the built-in default). Rows switch/manage the
-// templates; the actual text is edited in a modal. Toggled from the roster.
+// The global system-prompt library, in a modal — saved templates shared by
+// every persona, one active at a time ('' = the built-in default). Opened from
+// the roster's "System prompt" button. One modal, two views: the library list
+// (switch / manage templates, save bar in the footer) and an editor view for a
+// single template (Back returns to the list). Form data lives in the container;
+// this component only holds which view is showing.
 import type { ChangeEvent, ReactNode } from 'react';
-import { useState } from 'react';
-import { Card, Btn, Pill } from '../ui';
+import { useEffect, useState } from 'react';
+import { Btn, Pill } from '../ui';
 import { Input } from '../../ui/input';
 import { Textarea } from '../../ui/textarea';
 import { Modal } from '../../ui/modal';
@@ -14,7 +17,9 @@ import type { DjPromptPreset } from './types';
 import { promptPresetValid, clientMintId } from './helpers';
 import { PROMPT_MIN, PROMPT_MAX, PROMPT_NAME_MAX, PROMPT_PRESET_MAX } from './constants';
 
-interface SystemPromptCardProps {
+interface SystemPromptModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   presets: DjPromptPreset[];
   activeId: string;        // '' = built-in default
   defaultPrompt: string;   // the built-in template text
@@ -34,15 +39,20 @@ interface SystemPromptCardProps {
   onDiscard: () => void;
 }
 
-export function SystemPromptCard({
+export function SystemPromptModal({
+  open, onOpenChange,
   presets, activeId, defaultPrompt, busy, canSave, allPersonasOk, promptsOk,
   onSetActive, onAddPreset, onPatchPreset, onRemovePreset, onSave, onDiscard,
-}: SystemPromptCardProps) {
-  // Which template the modal shows: 'default' is the read-only built-in view,
-  // otherwise a preset id. null = modal closed. Local to the card — the form
-  // data itself lives in the container.
+}: SystemPromptModalProps) {
+  // Which view the modal shows: null = the library list, 'default' = the
+  // read-only built-in template, otherwise a preset id being edited.
   const [editing, setEditing] = useState<string | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  // Re-opening always lands on the library list, never a stale editor.
+  useEffect(() => {
+    if (!open) { setEditing(null); setConfirmDeleteId(null); }
+  }, [open]);
 
   const addPreset = () => {
     if (presets.length >= PROMPT_PRESET_MAX) return;
@@ -108,99 +118,105 @@ export function SystemPromptCard({
     </div>
   );
 
-  return (
-    <Card title="System prompt" sub="template library — shared by every persona">
-      <p className="mb-3 max-w-[70ch] text-[12px] leading-[1.6] text-muted">
-        One template is wrapped around every DJ generation, shared by all personas.
-        Keep several saved and switch which one is in use. Placeholders:{' '}
-        <code>{'{name}'}</code> · <code>{'{soul}'}</code> · <code>{'{station}'}</code> ·{' '}
-        <code>{'{location}'}</code> · <code>{'{language}'}</code>. Most stations stay on the built-in default.
-      </p>
-
-      <div className="grid gap-2">
-        {row({
-          key: 'default',
-          name: 'Built-in default',
-          meta: 'ships with SUB/WAVE · read-only',
-          isActive: activeId === '',
-          onUse: () => onSetActive(''),
-          actions: <Btn sm onClick={() => setEditing('default')}>View</Btn>,
-        })}
-        {presets.map(p =>
-          row({
-            key: p.id,
-            name: p.name.trim() || '(unnamed)',
-            meta: `${p.text.trim().length} chars`,
-            isActive: activeId === p.id,
-            invalid: !promptPresetValid(p),
-            onUse: () => onSetActive(p.id),
-            actions: (
-              <>
-                <Btn sm onClick={() => setEditing(p.id)}>Edit</Btn>
-                <Btn sm onClick={() => setConfirmDeleteId(p.id)} disabled={busy}>Delete</Btn>
-              </>
-            ),
-          }),
+  // ── footer per view ──────────────────────────────────────────────────────
+  const libraryFooter = (
+    <>
+      <span
+        className={cn(
+          'size-1.5 flex-none rounded-full',
+          canSave ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
         )}
-      </div>
-
-      <div className="mt-3">
-        <Btn
-          onClick={addPreset}
-          disabled={busy || presets.length >= PROMPT_PRESET_MAX}
-          title={presets.length >= PROMPT_PRESET_MAX ? `The library is full (${PROMPT_PRESET_MAX} templates)` : undefined}
-        >
-          New prompt
-        </Btn>
-      </div>
-
-      {/* Save bar. Lives on the card itself because the persona editor — the
-          only other place this form can be saved from — is a modal that's
-          closed while you're editing the prompt (issue #724). */}
-      <div className="mt-4 flex flex-wrap items-center gap-3 border-t border-ink pt-3">
-        <span
-          className={cn(
-            'size-1.5 flex-none rounded-full',
-            canSave ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
-          )}
-        />
-        <span className="text-[11px] text-muted">
-          {!canSave && !promptsOk
-            ? <span className="text-[var(--danger)]">fix the incomplete prompt template</span>
-            : !canSave && !allPersonasOk
-              ? <span className="text-[var(--danger)]">a persona in the roster is incomplete — fix it before saving</span>
-              : 'changes apply on the next spoken line · no mixer restart'}
+      />
+      <span className="mr-auto text-[11px] text-muted">
+        {!canSave && !promptsOk
+          ? <span className="text-[var(--danger)]">fix the incomplete prompt template</span>
+          : !canSave && !allPersonasOk
+            ? <span className="text-[var(--danger)]">a persona in the roster is incomplete — fix it before saving</span>
+            : 'changes apply on the next spoken line · no mixer restart'}
+      </span>
+      <Btn onClick={onDiscard} disabled={busy}>Discard</Btn>
+      <Btn tone="accent" onClick={onSave} disabled={busy || !canSave}>
+        {busy ? 'Saving…' : 'Save system prompt'}
+      </Btn>
+    </>
+  );
+  const editorFooter = (
+    <>
+      {editingPreset && (
+        <span className={cn('caption mr-auto', editingTextOk && editingNameOk ? 'text-muted' : 'text-[var(--danger)]')}>
+          {editingText.length}/{PROMPT_MAX} chars
+          {!editingNameOk && ' · name required'}
+          {!editingText.includes('{name}') && ' · missing {name}'}
+          {editingText.length > 0 && editingText.length < PROMPT_MIN && ` · min ${PROMPT_MIN}`}
         </span>
-        <span className="ml-auto flex items-center gap-3">
-          <Btn onClick={onDiscard} disabled={busy}>Discard</Btn>
-          <Btn tone="accent" onClick={onSave} disabled={busy || !canSave}>
-            {busy ? 'Saving…' : 'Save system prompt'}
-          </Btn>
-        </span>
-      </div>
+      )}
+      <Btn onClick={() => setEditing(null)}>Back to library</Btn>
+    </>
+  );
 
-      {/* ── TEMPLATE EDITOR MODAL ─────────────────────────────────────────── */}
+  return (
+    <>
       <Modal
-        open={editing !== null}
-        onOpenChange={(o) => { if (!o) setEditing(null); }}
-        title={editing === 'default' ? 'built-in default' : 'edit prompt'}
-        sub={editing === 'default' ? 'read-only — New prompt starts from this text' : editingPreset?.name.trim() || undefined}
-        width={720}
-        footer={
-          <>
-            {editingPreset && (
-              <span className={cn('caption mr-auto', editingTextOk && editingNameOk ? 'text-muted' : 'text-[var(--danger)]')}>
-                {editingText.length}/{PROMPT_MAX} chars
-                {!editingNameOk && ' · name required'}
-                {!editingText.includes('{name}') && ' · missing {name}'}
-                {editingText.length > 0 && editingText.length < PROMPT_MIN && ` · min ${PROMPT_MIN}`}
-              </span>
-            )}
-            <Btn onClick={() => setEditing(null)}>Done</Btn>
-          </>
+        open={open}
+        onOpenChange={onOpenChange}
+        title={
+          editing === null ? 'system prompt'
+            : editing === 'default' ? 'built-in default'
+              : 'edit prompt'
         }
+        sub={
+          editing === null ? 'template library — shared by every persona'
+            : editing === 'default' ? 'read-only — New prompt starts from this text'
+              : editingPreset?.name.trim() || undefined
+        }
+        width={720}
+        footer={editing === null ? libraryFooter : editorFooter}
       >
-        {editing === 'default' ? (
+        {editing === null ? (
+          <>
+            <p className="mb-3 max-w-[70ch] text-[12px] leading-[1.6] text-muted">
+              One template is wrapped around every DJ generation, shared by all personas.
+              Keep several saved and switch which one is in use. Placeholders:{' '}
+              <code>{'{name}'}</code> · <code>{'{soul}'}</code> · <code>{'{station}'}</code> ·{' '}
+              <code>{'{location}'}</code> · <code>{'{language}'}</code>. Most stations stay on the built-in default.
+            </p>
+            <div className="grid gap-2">
+              {row({
+                key: 'default',
+                name: 'Built-in default',
+                meta: 'ships with SUB/WAVE · read-only',
+                isActive: activeId === '',
+                onUse: () => onSetActive(''),
+                actions: <Btn sm onClick={() => setEditing('default')}>View</Btn>,
+              })}
+              {presets.map(p =>
+                row({
+                  key: p.id,
+                  name: p.name.trim() || '(unnamed)',
+                  meta: `${p.text.trim().length} chars`,
+                  isActive: activeId === p.id,
+                  invalid: !promptPresetValid(p),
+                  onUse: () => onSetActive(p.id),
+                  actions: (
+                    <>
+                      <Btn sm onClick={() => setEditing(p.id)}>Edit</Btn>
+                      <Btn sm onClick={() => setConfirmDeleteId(p.id)} disabled={busy}>Delete</Btn>
+                    </>
+                  ),
+                }),
+              )}
+            </div>
+            <div className="mt-3">
+              <Btn
+                onClick={addPreset}
+                disabled={busy || presets.length >= PROMPT_PRESET_MAX}
+                title={presets.length >= PROMPT_PRESET_MAX ? `The library is full (${PROMPT_PRESET_MAX} templates)` : undefined}
+              >
+                New prompt
+              </Btn>
+            </div>
+          </>
+        ) : editing === 'default' ? (
           <pre className="term max-h-[420px]">{defaultPrompt || '(default unavailable)'}</pre>
         ) : editingPreset ? (
           <div className="grid gap-3">
@@ -251,6 +267,6 @@ export function SystemPromptCard({
           setConfirmDeleteId(null);
         }}
       />
-    </Card>
+    </>
   );
 }

--- a/web/components/admin/personas/constants.ts
+++ b/web/components/admin/personas/constants.ts
@@ -80,6 +80,10 @@ export const SOUL_MAX = 1000;
 export const LANGUAGE_MAX = 60;
 export const PROMPT_MIN = 50;
 export const PROMPT_MAX = 4000;
+// Prompt-template library caps — keep in lockstep with the controller's
+// DJ_PROMPT_LIMIT / DJ_PROMPT_NAME_MAX (settings.ts).
+export const PROMPT_PRESET_MAX = 20;
+export const PROMPT_NAME_MAX = 60;
 export const PERSONA_MAX = 48;
 
 // 512×512 output target. The controller hard-caps the decoded image at 300 KB

--- a/web/components/admin/personas/helpers.ts
+++ b/web/components/admin/personas/helpers.ts
@@ -4,12 +4,28 @@ import type { Persona, SettingsResponse } from './types';
 import {
   AVATAR_TARGET_PX, DICEBEAR_STYLES,
   NAME_MAX, TAGLINE_MAX, SOUL_MAX, LANGUAGE_MAX,
+  PROMPT_NAME_MAX, PROMPT_MIN, PROMPT_MAX,
   KOKORO_RE, CHATTERBOX_VOICE_RE, POCKET_TTS_VOICE_RE,
 } from './constants';
 
-export function clientMintId() {
+// Client-minted opaque id ('p_' personas, 'dp_' prompt presets). The server
+// re-mints anything that fails its ID_RE, so these only need to be unique
+// within the form.
+export function clientMintId(prefix: string = 'p_') {
   const b = crypto.getRandomValues(new Uint8Array(3));
-  return 'p_' + [...b].map(x => x.toString(16).padStart(2, '0')).join('');
+  return prefix + [...b].map(x => x.toString(16).padStart(2, '0')).join('');
+}
+
+// Client-side mirror of the controller's per-preset validation
+// (settings.ts:validateDjPromptsStrict) — used to gate Save.
+export function promptPresetValid(p: { name: string; text: string }): boolean {
+  const name = p.name.trim();
+  const text = p.text.trim();
+  return (
+    name.length >= 1 && name.length <= PROMPT_NAME_MAX &&
+    text.length >= PROMPT_MIN && text.length <= PROMPT_MAX &&
+    text.includes('{name}')
+  );
 }
 
 export function initialsFor(name: string): string {

--- a/web/components/admin/personas/types.ts
+++ b/web/components/admin/personas/types.ts
@@ -40,11 +40,21 @@ export interface Persona {
   skills: string[];
 }
 
+// One saved system-prompt template in the library. Mirrors the controller's
+// djPrompts entries (settings.ts:validateDjPromptsStrict).
+export interface DjPromptPreset {
+  id: string;
+  name: string;
+  text: string;
+}
+
 export interface FormState {
   personas: Persona[];
   activePersonaId: string;
-  useCustomPrompt: boolean;
-  systemPrompt: string;
+  // The system-prompt template library + which entry is active. '' selects
+  // the built-in default template.
+  djPrompts: DjPromptPreset[];
+  activeDjPromptId: string;
 }
 
 export interface SkillCatalogEntry {
@@ -71,6 +81,8 @@ export interface SettingsResponse {
     personas?: Array<Partial<Persona> & { avatar?: string }>;
     activePersonaId?: string;
     djPrompt?: string;
+    djPrompts?: Array<Partial<DjPromptPreset>>;
+    activeDjPromptId?: string;
     tts?: { defaultEngine?: string };
   };
   defaults?: { djPrompt?: string };


### PR DESCRIPTION
## What

The admin Personas page had one global system prompt (built-in default or a single custom string). This turns it into a **template library**: keep up to 20 saved prompts, switch which one is in use with one click, and edit the text in a **modal** (name + template + live validation) instead of the inline textarea.

## Controller

- New settings fields: `djPrompts: [{id, name, text}]` (max 20, text 50–4000 chars with `{name}`, ids `dp_*`) and `activeDjPromptId` (`''` = built-in default).
- `settings.djPrompt` stays as the **resolved active text**, so `renderDjPrompt()` and every other reader are untouched — and an older controller pointed at the same `settings.json` still honours the active prompt.
- Load-time migration: a pre-library custom `djPrompt` becomes a lone "Custom prompt" entry, active.
- Legacy `djPrompt` patch (onboarding wizard, older clients) maps onto the library: `''` → built-in; custom text reuses an identical entry or appends one.
- Strict validation on update (`validateDjPromptsStrict`); a library patch that removes the active entry falls back to the built-in default; an explicit dangling `activeDjPromptId` 400s.

## Web UI

- `SystemPromptCard` → library view: Built-in default row (read-only, viewable in the modal) + one row per saved template with radio-style switching, char count, Edit/Delete (delete confirms; deleting the in-use template falls back to built-in).
- "New prompt" seeds from the built-in template and opens the editor modal directly.
- Same whole-form save flow as before (save bar on the card, POSTs personas + library together).

## Verification

Ran an isolated controller (temp STATE_DIR, port 7791) + the worktree web dev server, and drove both surfaces:

- API: library save/switch/resolve round-trips, persisted to disk; dangling active id / missing `{name}` / long name all 400 without clobbering state; legacy `djPrompt` set/clear maps onto the library; boot migration from a legacy `settings.json` seeds "Custom prompt" and keeps the resolved text identical.
- UI (Playwright): card renders both rows with the "in use" pill; built-in View modal; New prompt opens seeded editor; invalid text shows red border + "missing {name} · min 50"; activate + Save persists (confirmed via API); Delete confirm warns about the fallback and Save persists it.
- `npm run lint` clean in `controller/` and `web/` (0 errors).

Also adds a repo `.claude/skills/verify` recipe for isolated controller/admin-UI verification, and the design spec under `docs/superpowers/specs/`.