### PR TITLE
feat(tts): choose which heavy TTS engines load via TTS_HEAVY_ENGINES

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,6 +141,13 @@ SITE_URL=
 #                         # ending, tail loudness/tempo — drives the
 #                         # ending-aware crossfade). Pure librosa, cheap
 #
+# Which heavy-TTS engines the tts-heavy sidecar loads. Chatterbox AND PocketTTS
+# are both baked into the image, but each costs RAM + a first-boot weight
+# download + startup time — so if you only use one, name it here and the other
+# never loads. Comma-separated; default loads both. Only matters with
+# --profile tts-heavy.
+# TTS_HEAVY_ENGINES=pocket-tts     # or: chatterbox  |  chatterbox,pocket-tts
+#
 # Memory ceilings for the model-loading sidecars (OOM containment — keeps a
 # runaway model load from taking down the host's other services). Defaults are
 # generous; raise for the heavy analyzer on large libraries, lower on a

--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ to Piper. The old `docker build --build-arg WITH_CHATTERBOX=1` path still
 works if you already have a custom-built controller image — see
 `docker/Dockerfile.controller`.
 
+**Run just one engine.** Both engines load by default, but each costs RAM and a
+first-boot weight download. If you only use one, name it in `.env` and the other
+never loads:
+
+```ini
+TTS_HEAVY_ENGINES=pocket-tts       # PocketTTS only (no Chatterbox)
+# TTS_HEAVY_ENGINES=chatterbox     # Chatterbox only
+# TTS_HEAVY_ENGINES=chatterbox,pocket-tts   # default — both
+```
+
 Acoustic analysis (tempo/key/loudness) does **not** need the heavy TTS sidecar —
 it runs in its own `subwave-analyzer` service, which **starts by default**
 alongside the controller and web. The default image is **lean and multi-arch**

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -286,6 +286,11 @@ services:
       - TTS_HEAVY_DEVICE=\${TTS_HEAVY_DEVICE:-cpu}
       # Default voice id used by PocketTTS when a persona doesn't override it.
       - POCKET_TTS_VOICE=\${POCKET_TTS_VOICE:-alba}
+      # Which heavy engines to actually load. Both are baked into the image;
+      # each costs RAM + a first-boot weight download + startup time, so set
+      # this to a single engine if you only use one. Comma-separated.
+      # e.g. TTS_HEAVY_ENGINES=pocket-tts runs PocketTTS only (no Chatterbox).
+      - TTS_HEAVY_ENGINES=\${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
       # Optional — enables PocketTTS zero-shot voice CLONING (issue #238). The
       # cloning weights (kyutai/pocket-tts) are gated on Hugging Face; without a
       # token the engine loads the open weights and cloned .wav voices revert to
@@ -617,6 +622,11 @@ services:
     environment:
       - TTS_HEAVY_DEVICE=\${TTS_HEAVY_DEVICE:-cpu}
       - POCKET_TTS_VOICE=\${POCKET_TTS_VOICE:-alba}
+      # Which heavy engines to actually load. Both are baked into the image;
+      # each costs RAM + a first-boot weight download + startup time, so set
+      # this to a single engine if you only use one. Comma-separated.
+      # e.g. TTS_HEAVY_ENGINES=pocket-tts runs PocketTTS only (no Chatterbox).
+      - TTS_HEAVY_ENGINES=\${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
       # Optional — enables PocketTTS voice CLONING (issue #238). Cloning weights
       # are gated on Hugging Face; accept the terms at
       # huggingface.co/kyutai/pocket-tts and set HF_TOKEN in your root .env.
@@ -886,6 +896,11 @@ services:
     environment:
       - TTS_HEAVY_DEVICE=\${TTS_HEAVY_DEVICE:-cpu}
       - POCKET_TTS_VOICE=\${POCKET_TTS_VOICE:-alba}
+      # Which heavy engines to actually load. Both are baked into the image;
+      # each costs RAM + a first-boot weight download + startup time, so set
+      # this to a single engine if you only use one. Comma-separated.
+      # e.g. TTS_HEAVY_ENGINES=pocket-tts runs PocketTTS only (no Chatterbox).
+      - TTS_HEAVY_ENGINES=\${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
       # Optional — enables PocketTTS voice CLONING (issue #238). Cloning weights
       # are gated; accept terms at huggingface.co/kyutai/pocket-tts and set
       # HF_TOKEN in your .env. Built-in voices need no token.
@@ -1151,6 +1166,13 @@ SITE_URL=
 #                         # complete file for outro analysis (fade-vs-cold
 #                         # ending, tail loudness/tempo — drives the
 #                         # ending-aware crossfade). Pure librosa, cheap
+#
+# Which heavy-TTS engines the tts-heavy sidecar loads. Chatterbox AND PocketTTS
+# are both baked into the image, but each costs RAM + a first-boot weight
+# download + startup time — so if you only use one, name it here and the other
+# never loads. Comma-separated; default loads both. Only matters with
+# --profile tts-heavy.
+# TTS_HEAVY_ENGINES=pocket-tts     # or: chatterbox  |  chatterbox,pocket-tts
 #
 # Memory ceilings for the model-loading sidecars (OOM containment — keeps a
 # runaway model load from taking down the host's other services). Defaults are

--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -9,6 +9,7 @@ import * as kokoro from './kokoro.js';
 import { applyEdgeFades } from './wav-edges.js';
 import * as chatterbox from './chatterbox.js';
 import * as pocketTts from './pocketTts.js';
+import { heavyEnabledEngines } from './ttsHeavyClient.js';
 import * as remoteTts from './remoteTts.js';
 import * as cloud from '../llm/speech.js';
 import { stripThinking } from '../llm/sdk.js';
@@ -391,6 +392,11 @@ export function availableEngines() {
     kokoro: kokoro.isAvailable(),
     chatterbox: chatterbox.isAvailable(),
     'pocket-tts': pocketTts.isAvailable(),
+    // The tts-heavy sidecar's configured engines (TTS_HEAVY_ENGINES): a
+    // string[] when reachable and reporting it, null otherwise. Lets the admin
+    // badge separate "engine off" (sidecar up, engine disabled) from "sidecar
+    // off" (whole sidecar down). See engineMeta.engineStatus.
+    heavyEnabled: heavyEnabledEngines(),
     // Whether PocketTTS can clone voices (gated weights present). null = not
     // yet known. The admin UI uses this to warn that a cloned .wav voice will
     // silently revert to a built-in when cloning is unavailable (issue #238).

--- a/controller/src/audio/ttsHeavyClient.ts
+++ b/controller/src/audio/ttsHeavyClient.ts
@@ -31,6 +31,23 @@ export function isRemoteEnabled(): boolean {
 // once the worker has declared whether the gated cloning weights loaded.
 export type ProbeMeta = { voiceCloning: boolean | null };
 
+// Sidecar-wide health snapshot, refreshed on every /health probe (independent
+// of the per-engine onChange, which only fires on availability/capability
+// changes). Lets the admin UI tell "sidecar down" apart from "sidecar up but
+// this engine disabled via TTS_HEAVY_ENGINES". `enabled` is the sidecar's
+// configured engine list; null when the sidecar is unreachable OR is an older
+// image that doesn't report the field (so callers fall back to old behaviour).
+let cachedHealth: { up: boolean; enabled: string[] | null } = { up: false, enabled: null };
+
+// The tts-heavy sidecar's configured engines (TTS_HEAVY_ENGINES). Returns null
+// when not in sidecar mode, the sidecar is unreachable, or it's too old to
+// report the list — in every "unknown" case, so the UI degrades to the plain
+// "sidecar off" label rather than guessing.
+export function heavyEnabledEngines(): string[] | null {
+  if (!config.ttsHeavy.url) return null;
+  return cachedHealth.up ? cachedHealth.enabled : null;
+}
+
 // One /health probe. `available` is true iff the sidecar reports ok and lists
 // the requested engine. Network/timeout/parse failures collapse to
 // unavailable — the dispatcher reads the result the same way it reads an
@@ -44,11 +61,20 @@ async function probeOnce(engine: RemoteEngine): Promise<{ available: boolean; me
   const t = setTimeout(() => ac.abort(), PROBE_TIMEOUT_MS);
   try {
     const res = await fetch(`${url}/health`, { signal: ac.signal });
-    if (!res.ok) return miss;
+    if (!res.ok) {
+      cachedHealth = { up: false, enabled: null };
+      return miss;
+    }
     const body = (await res.json()) as {
       ok?: boolean;
       engines?: string[];
+      enabled?: string[];
       pocket_voice_cloning?: boolean | null;
+    };
+    // Refresh the sidecar-wide snapshot on every probe (see cachedHealth).
+    cachedHealth = {
+      up: !!body.ok,
+      enabled: Array.isArray(body.enabled) ? body.enabled : null,
     };
     const available =
       !!body.ok && Array.isArray(body.engines) && body.engines.includes(engine);
@@ -58,6 +84,7 @@ async function probeOnce(engine: RemoteEngine): Promise<{ available: boolean; me
         : null;
     return { available, meta: { voiceCloning } };
   } catch {
+    cachedHealth = { up: false, enabled: null };
     return miss;
   } finally {
     clearTimeout(t);

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -240,6 +240,11 @@ services:
     environment:
       - TTS_HEAVY_DEVICE=${TTS_HEAVY_DEVICE:-cpu}
       - POCKET_TTS_VOICE=${POCKET_TTS_VOICE:-alba}
+      # Which heavy engines to actually load. Both are baked into the image;
+      # each costs RAM + a first-boot weight download + startup time, so set
+      # this to a single engine if you only use one. Comma-separated.
+      # e.g. TTS_HEAVY_ENGINES=pocket-tts runs PocketTTS only (no Chatterbox).
+      - TTS_HEAVY_ENGINES=${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
       # Optional — enables PocketTTS voice CLONING (issue #238). Cloning weights
       # are gated on Hugging Face; accept the terms at
       # huggingface.co/kyutai/pocket-tts and set HF_TOKEN in your root .env.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -195,6 +195,11 @@ services:
     environment:
       - TTS_HEAVY_DEVICE=${TTS_HEAVY_DEVICE:-cpu}
       - POCKET_TTS_VOICE=${POCKET_TTS_VOICE:-alba}
+      # Which heavy engines to actually load. Both are baked into the image;
+      # each costs RAM + a first-boot weight download + startup time, so set
+      # this to a single engine if you only use one. Comma-separated.
+      # e.g. TTS_HEAVY_ENGINES=pocket-tts runs PocketTTS only (no Chatterbox).
+      - TTS_HEAVY_ENGINES=${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
       # Optional — enables PocketTTS voice CLONING (issue #238). Cloning weights
       # are gated; accept terms at huggingface.co/kyutai/pocket-tts and set
       # HF_TOKEN in your .env. Built-in voices need no token.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -277,6 +277,11 @@ services:
       - TTS_HEAVY_DEVICE=${TTS_HEAVY_DEVICE:-cpu}
       # Default voice id used by PocketTTS when a persona doesn't override it.
       - POCKET_TTS_VOICE=${POCKET_TTS_VOICE:-alba}
+      # Which heavy engines to actually load. Both are baked into the image;
+      # each costs RAM + a first-boot weight download + startup time, so set
+      # this to a single engine if you only use one. Comma-separated.
+      # e.g. TTS_HEAVY_ENGINES=pocket-tts runs PocketTTS only (no Chatterbox).
+      - TTS_HEAVY_ENGINES=${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
       # Optional — enables PocketTTS zero-shot voice CLONING (issue #238). The
       # cloning weights (kyutai/pocket-tts) are gated on Hugging Face; without a
       # token the engine loads the open weights and cloned .wav voices revert to

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -49,6 +49,25 @@ POCKET_TTS_DEFAULT_VOICE = os.environ.get("POCKET_TTS_VOICE", "alba")
 CHATTERBOX_HF_HOME = os.environ.get("CHATTERBOX_HF_HOME", "/opt/chatterbox/hf-cache")
 POCKET_HF_HOME = os.environ.get("POCKET_HF_HOME", "/opt/pocket-tts/hf-cache")
 
+# Which engines this sidecar should actually load. BOTH are baked into the
+# image, but loading a PyTorch model costs RAM + a multi-GB first-boot weight
+# download + 30-60s of startup — so an operator who only uses one engine can
+# skip the other entirely by narrowing this list. Comma-separated; defaults to
+# both for back-compat. e.g. TTS_HEAVY_ENGINES=pocket-tts runs PocketTTS only
+# (no Chatterbox). Unknown/empty entries are ignored; an empty result falls
+# back to loading both so a typo never silently disables all TTS.
+_ALL_ENGINES = ("chatterbox", "pocket-tts")
+ENABLED_ENGINES = [
+    e
+    for e in (
+        s.strip().lower()
+        for s in os.environ.get("TTS_HEAVY_ENGINES", "chatterbox,pocket-tts").split(",")
+    )
+    if e in _ALL_ENGINES
+]
+if not ENABLED_ENGINES:
+    ENABLED_ENGINES = list(_ALL_ENGINES)
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
@@ -249,10 +268,12 @@ async def lifespan(_app: FastAPI):
     # the port bind and the controller's probe would see "connection refused"
     # for the entire boot — leading operators to think the sidecar is broken
     # when it's just still loading.
-    tasks = [
-        asyncio.create_task(chatterbox_worker.run(), name="chatterbox-run"),
-        asyncio.create_task(pocket_worker.run(), name="pocket-tts-run"),
-    ]
+    log.info(f"enabled engines: {', '.join(ENABLED_ENGINES)}")
+    tasks = []
+    if "chatterbox" in ENABLED_ENGINES:
+        tasks.append(asyncio.create_task(chatterbox_worker.run(), name="chatterbox-run"))
+    if "pocket-tts" in ENABLED_ENGINES:
+        tasks.append(asyncio.create_task(pocket_worker.run(), name="pocket-tts-run"))
     try:
         yield
     finally:
@@ -292,6 +313,10 @@ async def health():
     return {
         "ok": True,
         "engines": ready_engines,
+        # The engines this sidecar was configured to load (TTS_HEAVY_ENGINES),
+        # regardless of whether they've finished loading yet — for operator
+        # diagnostics. `engines` above is the subset currently *ready*.
+        "enabled": ENABLED_ENGINES,
         "chatterbox_loaded": chatterbox_worker.ready,
         "pocket_loaded": pocket_worker.ready,
         # Whether PocketTTS can do zero-shot voice cloning. False when the
@@ -313,6 +338,16 @@ async def speak(req: SpeakRequest):
     if not req.out:
         raise HTTPException(400, "missing 'out' path")
     Path(req.out).parent.mkdir(parents=True, exist_ok=True)
+
+    # A known engine that this sidecar was told not to load: fail clearly so
+    # the controller's dispatcher falls back to Piper instead of blocking on a
+    # worker that will never become ready.
+    if req.engine in _ALL_ENGINES and req.engine not in ENABLED_ENGINES:
+        raise HTTPException(
+            503,
+            f"engine '{req.engine}' is disabled on this sidecar "
+            f"(TTS_HEAVY_ENGINES={','.join(ENABLED_ENGINES)})",
+        )
 
     if req.engine == "chatterbox":
         msg = await chatterbox_worker.request({

--- a/docs/tts-heavy.md
+++ b/docs/tts-heavy.md
@@ -136,6 +136,30 @@ Compose itself, so the sidecar starts without any CLI flag. See
 [`unraid.md`](unraid.md#acoustic-analysis--expressive-voices-the-tts-heavy-sidecar)
 for the Unraid-specific walkthrough.
 
+### Run just one engine (Chatterbox *or* PocketTTS)
+
+Both engines are baked into the `tts-heavy` image, and by default the sidecar
+loads **both** on boot. But each one is a separate PyTorch model: loading it
+costs RAM, a multi-gigabyte weight download the first time, and 30–60 s of
+startup. If your personas only use one engine, tell the sidecar to skip the
+other — one line in `.env`, no rebuild:
+
+```ini
+# root .env — comma-separated; default is "chatterbox,pocket-tts" (both)
+TTS_HEAVY_ENGINES=pocket-tts       # PocketTTS only — Chatterbox never loads
+# TTS_HEAVY_ENGINES=chatterbox     # Chatterbox only
+```
+
+Then `docker compose --profile tts-heavy up -d` (recreates the sidecar). The
+skipped engine's worker never starts, so you reclaim its memory and its cold
+load. If a persona is still pointed at the disabled engine, its `/speak` calls
+return a clean `503` and the DJ falls back to Piper — nothing goes silent.
+
+`GET /health` on the sidecar reports `enabled: [...]` (what it was told to load)
+alongside `engines: [...]` (what's currently ready), so you can confirm the
+selection took. An empty or all-typo value falls back to loading both, so a bad
+entry never silently disables all heavy TTS.
+
 ---
 
 ## Verify it's running

--- a/web/components/admin/tts/EngineSelector.tsx
+++ b/web/components/admin/tts/EngineSelector.tsx
@@ -2,11 +2,12 @@
 // Radio-card grid for picking a TTS engine. Replaces the cramped 6-button
 // segmented control on both the Personas voice card and the Settings voice tab:
 // every engine is a selectable card showing its name, a one-line blurb and a
-// live status badge (ready / sidecar off / no key) so availability is visible
-// before you select. Styled on the newsprint RadioOption pattern. Tailwind-only
+// live status badge (ready / starting… / engine off / sidecar off / no key) so
+// availability is visible before you select. Styled on the newsprint
+// RadioOption pattern. Tailwind-only
 // (no inline styles — issue #50).
 import { cn } from '../../../lib/cn';
-import { ENGINE_META, engineStatus } from './engineMeta';
+import { ENGINE_META, engineStatus, type EngineAvailability } from './engineMeta';
 
 interface EngineSelectorProps {
   // Currently selected engine id.
@@ -14,7 +15,7 @@ interface EngineSelectorProps {
   // Which engines to show as cards (Personas: all 6; Settings: data.tts.engines).
   engineIds: string[];
   // SettingsResponse.tts.available — drives the per-card status badge.
-  available?: Record<string, boolean>;
+  available?: EngineAvailability;
   onChange: (id: string) => void;
   className?: string;
 }

--- a/web/components/admin/tts/engineMeta.ts
+++ b/web/components/admin/tts/engineMeta.ts
@@ -32,14 +32,23 @@ export interface EngineStatus {
   tone: EngineStatusTone;
 }
 
-// Pure: derive an engine's status badge from the controller's availability map
-// (SettingsResponse.tts.available — piper/kokoro/chatterbox/pocket-tts/cloud
-// booleans). A missing/undefined flag means "not yet known / assumed up", so we
-// only flag a hard `=== false`. `warn` reads as the recoverable-problem tone
-// (sidecar down, no cloud key); `ok` is the quiet ready state.
+// The controller's availability map (SettingsResponse.tts.available). Most keys
+// are per-engine booleans, but a couple carry richer values — hence the mixed
+// value type. `heavyEnabled` is the tts-heavy sidecar's configured engine list
+// (TTS_HEAVY_ENGINES): a string[] when the sidecar is reachable and reports it,
+// null when it's unreachable / not in use.
+export interface EngineAvailability {
+  heavyEnabled?: string[] | null;
+  [engine: string]: boolean | string[] | null | Record<string, boolean> | undefined;
+}
+
+// Pure: derive an engine's status badge from the controller's availability map.
+// A missing/undefined flag means "not yet known / assumed up", so we only flag
+// a hard `=== false`. `warn` reads as the recoverable-problem tone (sidecar
+// down, engine disabled, no cloud key); `ok` is the quiet ready state.
 export function engineStatus(
   id: string,
-  available: Record<string, boolean> | undefined,
+  available: EngineAvailability | undefined,
 ): EngineStatus {
   const a = available || {};
   switch (id) {
@@ -50,10 +59,18 @@ export function engineStatus(
         ? { label: 'unavailable', tone: 'warn' }
         : { label: 'ready', tone: 'ok' };
     case 'chatterbox':
-    case 'pocket-tts':
-      return a[id] === false
-        ? { label: 'sidecar off', tone: 'warn' }
-        : { label: 'ready', tone: 'ok' };
+    case 'pocket-tts': {
+      if (a[id] !== false) return { label: 'ready', tone: 'ok' };
+      // Engine isn't ready. Use the sidecar's configured engine list to say
+      // *why*: deliberately disabled vs still loading vs whole sidecar down.
+      const enabled = Array.isArray(a.heavyEnabled) ? a.heavyEnabled : null;
+      if (enabled) {
+        return enabled.includes(id)
+          ? { label: 'starting…', tone: 'warn' } // enabled, weights still loading
+          : { label: 'engine off', tone: 'warn' }; // disabled via TTS_HEAVY_ENGINES
+      }
+      return { label: 'sidecar off', tone: 'warn' };
+    }
     case 'cloud':
       return a.cloud === false
         ? { label: 'no key', tone: 'warn' }

--- a/web/components/manual/Voices.tsx
+++ b/web/components/manual/Voices.tsx
@@ -110,6 +110,19 @@ docker compose up -d`}</CodeBlock>
           Until the sidecar is started, selecting either engine silently falls back to
           Piper.
         </p>
+        <p>
+          Both engines load when the sidecar starts, but each is a separate PyTorch
+          model that costs memory and a first-boot weight download. If you only use one,
+          name it in <code className="bs-code-inline">.env</code> and the other never
+          loads &mdash; comma-separated, defaulting to both:
+        </p>
+        <CodeBlock>{`TTS_HEAVY_ENGINES=pocket-tts       # PocketTTS only (no Chatterbox)
+# TTS_HEAVY_ENGINES=chatterbox     # Chatterbox only
+# TTS_HEAVY_ENGINES=chatterbox,pocket-tts   # default — both`}</CodeBlock>
+        <p>
+          Bring the sidecar back up after changing it. If a persona is still pointed at
+          the disabled engine, its speech falls back to Piper rather than failing.
+        </p>
         <p className="text-muted">
           For backwards compatibility, the older{' '}
           <code className="bs-code-inline">--build-arg WITH_CHATTERBOX=1</code> /{' '}


### PR DESCRIPTION
## What

Adds `TTS_HEAVY_ENGINES` — a comma-separated env var that selects which heavy TTS engines the `tts-heavy` sidecar loads. Both Chatterbox and PocketTTS are baked into the image, but until now the sidecar always started **both** workers on boot. Each is a separate PyTorch model that costs RAM, a multi-GB first-boot weight download, and 30–60s of startup, so operators who use only one engine paid for both.

## Changes

- **`docker/tts-heavy/server.py`**
  - Parse `ENABLED_ENGINES` from `TTS_HEAVY_ENGINES` (defaults to `chatterbox,pocket-tts` for back-compat).
  - `lifespan` starts only the listed engines' workers.
  - `/speak` returns a clean `503` for a known-but-disabled engine → controller falls back to Piper instead of hanging on a worker that never becomes ready.
  - `/health` now reports `enabled: [...]` alongside the ready `engines: [...]`.
  - Empty / all-typo value safely falls back to loading **both** — a bad entry never silently disables all heavy TTS.
- **Compose** — wired `TTS_HEAVY_ENGINES=${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}` into `docker-compose.yml`, `docker-compose.byo.yml`, `docker-compose.dev.yml`.
- **Docs** — `README.md`, `.env.example`, `docs/tts-heavy.md` (new "Run just one engine" section), and the in-app **manual → Voices** page.

## Usage

```ini
# root .env — only matters with --profile tts-heavy
TTS_HEAVY_ENGINES=pocket-tts     # PocketTTS only (no Chatterbox)
# TTS_HEAVY_ENGINES=chatterbox   # Chatterbox only
# default (unset) loads both
```

## Verification

Built the image locally and recreated the sidecar with `TTS_HEAVY_ENGINES=pocket-tts`:

- Logs: `enabled engines: pocket-tts` — only the PocketTTS worker started, no Chatterbox load.
- `/health`: `{"engines":["pocket-tts"],"enabled":["pocket-tts"],"chatterbox_loaded":false,"pocket_loaded":true,"pocket_voice_cloning":true}`

Fully backward-compatible: existing installs (var unset) still load both engines as before.

---

## Admin UI — precise engine badge (follow-up commit)

Once an engine can be disabled via `TTS_HEAVY_ENGINES`, the admin **Settings/Personas → TTS voice** picker was showing a deliberately-disabled engine as **"sidecar off"**, which wrongly implies the whole sidecar is down. The picker now reads the sidecar's configured engine list and shows the accurate state:

| State | Badge |
|-------|-------|
| Engine loaded and ready | `ready` |
| Enabled but still loading weights | `starting…` |
| Baked in but disabled via `TTS_HEAVY_ENGINES` | `engine off` |
| Whole sidecar unreachable / not running | `sidecar off` |

- `ttsHeavyClient.heavyEnabledEngines()` caches a sidecar-wide health snapshot (reachable + `enabled` list from `/health`) on every probe; returns `null` in every "unknown" case (not in sidecar mode, unreachable, or an older sidecar image that predates the `enabled` field) so the UI safely degrades to the old `sidecar off` label.
- `tts.availableEngines()` exposes it as `available.heavyEnabled`; `engineMeta.engineStatus()` consumes it (new `EngineAvailability` type).

**Verified live:** with `TTS_HEAVY_ENGINES=pocket-tts`, `/api/settings` returns `heavyEnabled:["pocket-tts"]` → Chatterbox card badge = **engine off**, PocketTTS = **ready**. Both `controller` and `web` typecheck clean.
