### PR TITLE
feat(admin): per-call TTS log in the debug panel's TTS routing card

### DIFF
--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -336,6 +336,16 @@ export async function speak(
   const scale = Math.min(settings.TTS_SPEED_MAX, Math.max(settings.TTS_SPEED_MIN, engineSpeed * live));
   const started = Date.now();
   const chars = (speakText || '').length;
+  // Shared fields for every recordTts() outcome below. `text` is capped so the
+  // ring buffer stays small (the admin debug panel polls the whole ring every
+  // ~2s); `persona` names who voiced the segment (null for the global
+  // jingle/default kinds), resolved through the same override path as the
+  // engine so a handoff clip attributes to the outgoing DJ.
+  const callBase = {
+    kind, requested, chars,
+    text: (speakText || '').slice(0, 240),
+    persona: GLOBAL_VOICE_KINDS.has(kind) ? null : (personaFor(persona)?.name || null),
+  };
   try {
     const result = await speakWith(primary, speakText, { outPath, speedScale: scale, language, soul }, personaTts);
     // Bake 40ms edge fades into the rendered clip so hard file boundaries
@@ -344,8 +354,8 @@ export async function speak(
     // non-WAV output (cloud mp3) is left as-is.
     if (typeof result === 'string') await applyEdgeFades(result);
     recordTts({
-      kind, engine: primary, requested, fellBack: requested !== primary,
-      ok: true, ms: Date.now() - started, chars, t: new Date().toISOString(),
+      ...callBase, engine: primary, fellBack: requested !== primary,
+      ok: true, ms: Date.now() - started, t: new Date().toISOString(),
     });
     return result;
   } catch (err) {
@@ -355,8 +365,8 @@ export async function speak(
     const fallback = primary === 'piper' ? 'kokoro' : 'piper';
     if (fallback === 'kokoro' && !kokoro.isAvailable()) {
       recordTts({
-        kind, engine: primary, requested, fellBack: requested !== primary,
-        ok: false, ms: Date.now() - started, chars, error: err.message,
+        ...callBase, engine: primary, fellBack: requested !== primary,
+        ok: false, ms: Date.now() - started, error: err.message,
         t: new Date().toISOString(),
       });
       throw err;
@@ -366,14 +376,14 @@ export async function speak(
       const result = await speakWith(fallback, speakText, { outPath, speedScale: scale, language, soul }, personaTts);
       if (typeof result === 'string') await applyEdgeFades(result);
       recordTts({
-        kind, engine: fallback, requested, fellBack: true,
-        ok: true, ms: Date.now() - started, chars, t: new Date().toISOString(),
+        ...callBase, engine: fallback, fellBack: true,
+        ok: true, ms: Date.now() - started, t: new Date().toISOString(),
       });
       return result;
     } catch (err2) {
       recordTts({
-        kind, engine: fallback, requested, fellBack: true,
-        ok: false, ms: Date.now() - started, chars, error: err2.message,
+        ...callBase, engine: fallback, fellBack: true,
+        ok: false, ms: Date.now() - started, error: err2.message,
         t: new Date().toISOString(),
       });
       throw err2;

--- a/controller/src/routes/debug.ts
+++ b/controller/src/routes/debug.ts
@@ -11,6 +11,7 @@ import {
   LLM_DEBUG_MAX,
 } from '../llm/log.js';
 import * as tts from '../audio/tts.js';
+import { ttsCalls } from '../stats.js';
 import * as library from '../music/library.js';
 import * as subsonicLog from '../music/subsonic-log.js';
 import { getFullContext } from '../context.js';
@@ -237,9 +238,11 @@ async function buildDebugSnapshot(req: express.Request): Promise<any> {
 
   // 6c. TTS routing — which engine/voice the effective persona resolves to,
   // and whether it's silently falling back from the engine the persona asked
-  // for (e.g. a cloud voice with the Cloud engine switched off).
+  // for (e.g. a cloud voice with the Cloud engine switched off). Plus the raw
+  // TTS call ring (stats.ts, same since-boot window as the LLM ring) so the
+  // debug panel can show what actually aired, per call.
   try {
-    out.tts = tts.describeRouting();
+    out.tts = { ...tts.describeRouting(), recentCalls: ttsCalls };
   } catch (err) {
     out.tts = { error: err.message };
   }

--- a/controller/src/stats.ts
+++ b/controller/src/stats.ts
@@ -13,7 +13,10 @@ export const ttsCalls: any[] = [];
 
 // Recorded by audio/tts.js on every speak(): one entry per spoken segment,
 // success or failure, including whether the engine fell back to a local one.
-// Shape: { kind, engine, requested, fellBack, ok, ms, chars, error?, t }
+// Shape: { kind, engine, requested, fellBack, ok, ms, chars, text, persona, error?, t }
+// The raw ring is also exposed on /debug (tts.recentCalls) for the admin
+// debug panel's per-call TTS log; summarizeTts() below only reads the
+// original aggregate fields.
 export function recordTts(call: any) {
   ttsCalls.unshift(call);
   if (ttsCalls.length > MAX_TTS_CALLS) ttsCalls.length = MAX_TTS_CALLS;

--- a/docs/superpowers/specs/2026-07-09-tts-call-log-design.md
+++ b/docs/superpowers/specs/2026-07-09-tts-call-log-design.md
@@ -1,0 +1,90 @@
+# TTS call log in admin/debug — design
+
+**Date:** 2026-07-09
+**Ask:** the admin `/admin/debug` page has a "TTS routing" section; show a log of TTS calls with details there.
+
+## Context
+
+Every spoken segment already goes through `tts.speak()` (`controller/src/audio/tts.ts`),
+which records one entry per call into the in-memory ring buffer `ttsCalls`
+(`controller/src/stats.ts`, last 120 entries, lost on restart by design):
+
+```
+{ kind, engine, requested, fellBack, ok, ms, chars, error?, t }
+```
+
+Today that ring only feeds the Stats page **aggregates** (`summarizeTts`). The raw
+entries are never exposed anywhere — the debug panel's TTS routing card shows only the
+*prospective* routing snapshot (`describeRouting()`), not what actually aired.
+
+## Approaches considered
+
+- **A — expose the existing ring (chosen).** Enrich the recorded entries with the
+  spoken text + persona, attach the ring to `/debug`, render it in the TTS routing
+  card. Mirrors exactly how the LLM ring (`llm/log.ts` → `out.llm.recentCalls` →
+  `LlmCalls`) and the Subsonic ring already work. No new state, no new endpoint.
+- **B — durable `tts` events in events.jsonl.** Survives restarts, but heavier and
+  inconsistent with the debug panel's other call lists, which are all since-boot rings.
+  The durable timeline already gets TTS failures via console + can be added later.
+- **C — point the operator at the Stats page.** Already exists, but it's aggregates
+  only; the ask is per-call detail (what text, which engine, why it fell back).
+
+## Design (approach A)
+
+### 1. Controller — enrich the ring entries (`audio/tts.ts`)
+
+`speak()` builds one shared `base` object used by all four `recordTts()` call sites
+(success, fallback-unavailable failure, fallback success, fallback failure):
+
+- `text` — the normalized spoken text, capped at 240 chars (ring is polled every 2s
+  by the debug panel; keep the payload bounded).
+- `persona` — the voicing persona's name for persona-voiced kinds, `null` for the
+  global kinds (`jingle`, `default`). Uses the same `personaFor(persona)` override
+  path as the rest of `speak()`, so handoff clips attribute correctly.
+
+Additive fields only — `summarizeTts()` and the Stats page are untouched.
+
+### 2. Controller — expose the ring (`routes/debug.ts`)
+
+Section 6c becomes:
+
+```ts
+out.tts = { ...tts.describeRouting(), recentCalls: ttsCalls };
+```
+
+(`ttsCalls` imported from `../stats.js`.) Payload cost ≈ 120 × ~350 B ≈ 40 KB on a
+snapshot that already carries the ~170 KB session — acceptable, and the existing
+1 s single-flight cache bounds the assembly rate.
+
+### 3. Web — render in the TTS routing card (`DebugPanel.tsx`)
+
+- `DebugTts` gains `recentCalls?: TtsCall[]`; new `TtsCall` interface mirrors the
+  ring shape.
+- Card sub becomes `who voices the next spoken segment · N recent calls`.
+- Below the existing routing row, a `TtsCallList`:
+  - **Filter chips by kind** (all / dj-speak / link / station-id / …), same
+    `FilterChip` component as the LLM list.
+  - **Row** (collapsed `<details>` summary, same grid as Subsonic rows):
+    ✓/✗ · kind · engine (with `↳ requested X` in danger tone when `fellBack`) ·
+    chars · ms · time.
+  - **Expanded:** spoken text, persona, error (via the shared `CallSection`).
+  - Scrollable (`max-h`), empty state "no spoken segments yet".
+
+### Error handling
+
+- Ring exposure is inside the existing try/catch for `out.tts` — a failure degrades
+  to `{ error }` like today.
+- Old entries recorded before a controller update simply lack `text`/`persona`;
+  the UI renders those fields only when present.
+
+### Testing
+
+- `npm run lint` in `controller/` and `web/` (the repo's merge gate; no test runner).
+- Manual: covered by the entries the running station generates; the UI degrades
+  gracefully with zero calls.
+
+## Out of scope
+
+- Durable/persistent TTS log across restarts.
+- Recording the resolved voice id per call (voice resolution happens per-engine
+  inside `speakWith()`; engine + requested + fellBack covers the routing question).

--- a/web/components/admin/DebugPanel.tsx
+++ b/web/components/admin/DebugPanel.tsx
@@ -54,10 +54,29 @@ interface DebugTtsSpoken {
   requested?: string;
 }
 
+/** One entry from the controller's TTS call ring (stats.ts ttsCalls) — every
+ * speak() outcome since boot, newest first, incl. silent engine fallbacks. */
+interface TtsCall {
+  ok?: boolean;
+  kind?: string;
+  engine?: string;
+  requested?: string;
+  fellBack?: boolean;
+  ms?: number;
+  chars?: number;
+  t?: string;
+  error?: string;
+  /** Spoken text, capped at ~240 chars by the controller. */
+  text?: string;
+  /** Voicing persona name; null for global kinds (jingle/default). */
+  persona?: string | null;
+}
+
 interface DebugTts {
   spoken?: DebugTtsSpoken;
   jingle?: { engine?: string };
   effectivePersona?: { name?: string };
+  recentCalls?: TtsCall[];
   error?: string;
 }
 
@@ -361,7 +380,10 @@ export default function DebugPanel() {
 
           {/* ── TTS ROUTING ────────────────────────────── */}
           {data.tts && !data.tts.error && (
-            <Card title="TTS routing" sub="who voices the next spoken segment">
+            <Card
+              title="TTS routing"
+              sub={`who voices the next spoken segment · ${data.tts.recentCalls?.length ?? 0} recent calls`}
+            >
               <TtsRouting tts={data.tts} />
             </Card>
           )}
@@ -521,6 +543,83 @@ function TtsRouting({ tts }: { tts: DebugTts }) {
           out of <strong>{s.engine}</strong> instead. Fix it in Settings → TTS voice.
         </V3Alert>
       )}
+      <TtsCallList calls={tts.recentCalls || []} />
+    </div>
+  );
+}
+
+// Per-call TTS log — the raw speak() ring from the controller, rendered with
+// the same expandable-row pattern as the LLM / Subsonic call lists. A row in
+// danger tone means the call failed outright; an "↳ from <engine>" note means
+// the segment still aired but not through the engine the persona asked for.
+function TtsCallList({ calls }: { calls: TtsCall[] }) {
+  const [filter, setFilter] = useState('all');
+  const kinds = Array.from(new Set(calls.map(c => c.kind).filter(Boolean) as string[]));
+  const shown = filter === 'all' ? calls : calls.filter(c => c.kind === filter);
+  return (
+    <div className="grid gap-1.5">
+      <div className="flex flex-wrap items-center gap-1">
+        <span className="caption mr-1">recent calls</span>
+        <FilterChip active={filter === 'all'} onClick={() => setFilter('all')}>
+          all {calls.length}
+        </FilterChip>
+        {kinds.map(k => (
+          <FilterChip key={k} active={filter === k} onClick={() => setFilter(k)}>
+            {k} {calls.filter(c => c.kind === k).length}
+          </FilterChip>
+        ))}
+      </div>
+      <div className="grid max-h-[420px] gap-1.5 overflow-y-auto">
+        {shown.length === 0 && (
+          <span className="field-hint italic">
+            {calls.length === 0 ? 'no spoken segments yet' : 'no calls match this filter'}
+          </span>
+        )}
+        {shown.map((c, i) => (
+          <details key={i} className="border border-separator-strong">
+            <summary className="grid cursor-pointer grid-cols-[auto_auto_1fr_auto_auto] items-center gap-2.5 px-2.5 py-2">
+              <span className={cn('font-bold', c.ok ? 'text-vermilion' : 'text-[var(--danger)]')}>
+                {c.ok ? '✓' : '✗'}
+              </span>
+              <span className="text-[12px] font-bold">{c.kind}</span>
+              <span className="flex min-w-0 items-center gap-1.5 overflow-hidden">
+                <Pill
+                  tone={c.fellBack ? undefined : 'accent'}
+                  className={c.fellBack ? 'border-[var(--danger)] text-[var(--danger)]' : undefined}
+                >
+                  {c.engine}
+                </Pill>
+                {c.fellBack && (
+                  <span className="caption flex-none text-[var(--danger)]">↳ from {c.requested}</span>
+                )}
+                <span className="min-w-0 overflow-hidden text-[11px] text-ellipsis whitespace-nowrap text-muted">
+                  {oneLine(c.text)}
+                </span>
+              </span>
+              <span className="mono-num text-[11px] text-muted">{c.ms}ms</span>
+              <span className="mono-num text-[10px] text-muted">
+                {c.t ? new Date(c.t).toLocaleTimeString('en-GB', { hour12: false }) : '—'}
+              </span>
+            </summary>
+            <div className="grid gap-1 px-2.5 pt-1 pb-2.5">
+              <div className="caption text-[9px]">
+                {c.persona ? `${c.persona} · ` : ''}{c.chars ?? 0} chars
+                {c.fellBack ? ` · requested ${c.requested}, spoke via ${c.engine}` : ''}
+              </div>
+              {c.error && (
+                <CallSection label="error" tone="err" preview={oneLine(c.error)}>
+                  {c.error}
+                </CallSection>
+              )}
+              {c.text && (
+                <CallSection label="spoken text" preview={oneLine(c.text)}>
+                  {c.text}
+                </CallSection>
+              )}
+            </div>
+          </details>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What

The admin **/admin/debug → TTS routing** card now shows a per-call log of every TTS invocation, not just the prospective routing snapshot.

The controller already recorded every `tts.speak()` outcome into the 120-entry ring in `stats.ts` (it fed only the Stats page aggregates). This PR:

- **`audio/tts.ts`** — enriches each recorded entry with the spoken `text` (capped at 240 chars) and the voicing `persona` name (null for the global jingle/default kinds; uses the same persona-override path as the engine resolution, so handoff clips attribute to the outgoing DJ). All four record sites share one `callBase`.
- **`routes/debug.ts`** — exposes the raw ring as `tts.recentCalls` on `/debug` (same since-boot window as the LLM ring; inside the existing try/catch so failures degrade to `{ error }` as before).
- **`DebugPanel.tsx`** — renders the list inside the TTS routing card with the same expandable-row pattern as the LLM/Subsonic call lists: kind filter chips, ✓/✗, engine pill with a danger-toned "↳ from <requested>" when the call silently fell back, spoken-text preview, latency, timestamp; expand for full text, persona, char count, and error.

Additive only — `summarizeTts()` / the Stats page are untouched, and entries recorded by an older controller (no `text`/`persona`) render fine.

Design doc: `docs/superpowers/specs/2026-07-09-tts-call-log-design.md`.

## Testing

- `npm run lint` in `controller/` and `web/` — both pass (0 errors).