### PR TITLE
fix(stations): Brisflix Radio showed offline — url carried a /listen path

### DIFF
--- a/web/content/stations/brisflix-radio.json
+++ b/web/content/stations/brisflix-radio.json
@@ -1,6 +1,6 @@
 {
   "name": "Brisflix Radio",
-  "url": "https://radio.brisflix.com/listen",
+  "url": "https://radio.brisflix.com",
   "operator": "dervish",
   "location": "Bristol, UK",
   "country": "United Kingdom",

--- a/web/lib/stations.ts
+++ b/web/lib/stations.ts
@@ -43,6 +43,17 @@ function fileToSlug(file: string): string {
   return file.replace(/\.json$/i, '');
 }
 
+// `url` must be the bare site origin — StationCard probes `‹url›/api/now-playing`
+// and originForStation appends `/api` + `/stream.mp3`, so a submitted path like
+// `https://radio.example.com/listen` would 404 every consumer (#925 follow-up).
+function toOrigin(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return url.replace(/\/$/, '');
+  }
+}
+
 // Coerce whatever the JSON carries into a clean Station. Unknown/missing fields
 // fall back to undefined so a sparse submission (just name + url + location)
 // still renders. lat/lon are only kept when both parse to finite numbers.
@@ -64,7 +75,7 @@ function parseStation(slug: string, raw: string): Station | null {
   return {
     slug: (typeof data.slug === 'string' && data.slug) || slug,
     name,
-    url: url.replace(/\/$/, ''),
+    url: toOrigin(url),
     location: data.location ? String(data.location) : undefined,
     country: data.country ? String(data.country) : undefined,
     operator: data.operator ? String(data.operator) : undefined,


### PR DESCRIPTION
Follow-up to #925 — dervish666 reported the station listed as **Offline** even though `https://radio.brisflix.com/api/now-playing` is up.

## Root cause
The submitted `url` was `https://radio.brisflix.com/listen`. `StationCard` probes `${url}/api/now-playing`, so the check hit `/listen/api/now-playing` → 404 (verified live) → Offline badge. The README documents `url` as the bare public origin, but nothing enforced it.

## Fix
- Correct the Brisflix entry to `https://radio.brisflix.com`.
- Harden `web/lib/stations.ts`: `parseStation` now normalizes any submitted url to its origin (`new URL(url).origin`, falling back to the old trailing-slash trim on an unparseable value), so a future path-carrying submission can't break the live probe, the landing showcase tabs, or `stations.json`.

## Verification
- `curl https://radio.brisflix.com/listen/api/now-playing` → 404; `curl https://radio.brisflix.com/api/now-playing` → live now-playing JSON.
- `web` lint (`eslint . && tsc --noEmit`) passes; only pre-existing warnings in unrelated admin panels.