### PR TITLE
fix(tts): normalize display text to spoken form; never air intro fragments

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -605,8 +605,29 @@ async function main() {
     assert.equal(enforceIntroBudget('text', 20000), 'text');                         // ≥18s
     const sentences = enforceIntroBudget('One. Two. Three. Four. Five. Six. Seven. Eight. Nine. Ten. Eleven. Twelve.', 4000);
     assert.ok(sentences.endsWith('.') && sentences.split(/\s+/).length <= 10);        // last full sentence
-    const hardcut = enforceIntroBudget('a b c d e f g h i j k l m n o p q r s t', 4000);
-    assert.ok(hardcut.endsWith('…') && hardcut.split(/\s+/).length <= 11);            // ellipsis fallback
+  });
+  await test('enforceIntroBudget never airs a fragment: clause, else drop (#962)', () => {
+    // No sentence or clause boundary anywhere — the line is dropped, not "…"-cut.
+    assert.equal(enforceIntroBudget('a b c d e f g h i j k l m n o p q r s t', 4000), '');
+    // A short complete sentence beats silence even when it's well under 40%.
+    const short = enforceIntroBudget('Nice. Then a very long thought that rambles on and on without ever stopping for breath at all', 4000);
+    assert.equal(short, 'Nice.');
+    // No sentence fits but a late clause does — cut at the LAST clause
+    // boundary that fits (the longest complete thought), closed with a period.
+    const clause = enforceIntroBudget('Ever notice how a single chord, held just long enough, can feel like a tiny pause in the day', 4000);
+    assert.equal(clause, 'Ever notice how a single chord, held just long enough.');
+    // A decimal point is not a sentence boundary.
+    const decimal = enforceIntroBudget('Running at 3.5 minutes this one just keeps going and going and going without a stop', 4000);
+    assert.equal(decimal, '');
+  });
+  await test('enforceIntroBudget word ceiling scales with speech pace', () => {
+    const line = 'One two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty.';
+    // 4s × 2.5w/s = 10 words at pace 1 → over budget; at 2× the whole line fits.
+    assert.equal(enforceIntroBudget(line, 4000, 2), line);
+    // At half pace the ceiling halves — still no fragment, so it drops.
+    assert.equal(enforceIntroBudget('a b c d e f g h i j', 4000, 0.5), '');
+    // Garbage pace values fall back to the historical 1.0 assumption.
+    assert.equal(enforceIntroBudget('Short line.', 5000, NaN), 'Short line.');
   });
 
   // ---- persona tone dials (humour / local colour / warmth) ----

--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -619,6 +619,13 @@ async function main() {
     // A decimal point is not a sentence boundary.
     const decimal = enforceIntroBudget('Running at 3.5 minutes this one just keeps going and going and going without a stop', 4000);
     assert.equal(decimal, '');
+    // An abbreviation period is not a sentence end — the DJ never airs "Dr."
+    // alone; the cut falls through to the clause/drop steps instead.
+    assert.equal(enforceIntroBudget('Dr. Dre eases us in with a slow-building intro that takes its sweet time before the beat', 4000), '');
+    assert.equal(enforceIntroBudget('Here is a smooth cut feat. a guest who drifts in over a long patient intro tonight', 4000), '');
+    // …but a real stop later in the same line still wins, abbreviation and all.
+    const abbrev = enforceIntroBudget('St. Vincent is here. Now a very long ramble that goes on and on forever', 4000);
+    assert.equal(abbrev, 'St. Vincent is here.');
   });
   await test('enforceIntroBudget word ceiling scales with speech pace', () => {
     const line = 'One two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty.';

--- a/controller/scripts/speech-text.test.ts
+++ b/controller/scripts/speech-text.test.ts
@@ -1,0 +1,102 @@
+// Unit tests for the pure spoken-text normalizer (audio/speech-text.ts) —
+// the defensive layer between generated radio copy and TTS (issue #963).
+// Run: `npm test -- speech-text` (tsx scripts/speech-text.test.ts).
+//
+// Two families of pins: display forms that MUST convert to spoken forms
+// (weather units, %, $, mph, &, markdown emphasis), and real-world text that
+// MUST survive untouched (artist names, Chatterbox [laugh] tags, decimals).
+
+import assert from 'node:assert/strict';
+import { normalizeForSpeech } from '../src/audio/speech-text.js';
+
+let failures = 0;
+function test(name: string, fn: () => void | Promise<void>) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => console.log(`  ✓ ${name}`))
+    .catch((err) => { failures++; console.error(`  ✗ ${name}\n      ${err?.message || err}`); });
+}
+
+async function main() {
+  console.log('temperature units:');
+  await test('°F expands, with and without a space', () => {
+    assert.equal(normalizeForSpeech('Clear night, 76°F — the sky refuses to dim.'),
+      'Clear night, 76 degrees Fahrenheit — the sky refuses to dim.');
+    assert.equal(normalizeForSpeech('76 °F'), '76 degrees Fahrenheit');
+  });
+  await test('°C expands, with and without a space', () => {
+    assert.equal(normalizeForSpeech('18°C'), '18 degrees Celsius');
+    assert.equal(normalizeForSpeech('18 °C'), '18 degrees Celsius');
+  });
+  await test('bare ° after a number expands to degrees', () => {
+    assert.equal(normalizeForSpeech('a 45° turn'), 'a 45 degrees turn');
+  });
+  await test('° glued to a non-unit letter is left alone', () => {
+    assert.equal(normalizeForSpeech('12°N of the equator'), '12°N of the equator');
+  });
+
+  console.log('symbols and units:');
+  await test('% after a digit becomes percent', () => {
+    assert.equal(normalizeForSpeech('40% chance of rain'), '40 percent chance of rain');
+    assert.equal(normalizeForSpeech('100% Endurance'), '100 percent Endurance');
+  });
+  await test('lone % is left alone', () => {
+    assert.equal(normalizeForSpeech('the % key'), 'the % key');
+  });
+  await test('$ before a number reads as dollars after it', () => {
+    assert.equal(normalizeForSpeech('$12 at the door'), '12 dollars at the door');
+    assert.equal(normalizeForSpeech('$1,200'), '1,200 dollars');
+    assert.equal(normalizeForSpeech('sold for $5 million last year'), 'sold for 5 million dollars last year');
+  });
+  await test('$ inside a name is untouched (Ke$ha)', () => {
+    assert.equal(normalizeForSpeech('Ke$ha on deck'), 'Ke$ha on deck');
+  });
+  await test('speed units expand after a number', () => {
+    assert.equal(normalizeForSpeech('35 mph winds'), '35 miles per hour winds');
+    assert.equal(normalizeForSpeech('gusts to 56 km/h'), 'gusts to 56 kilometers per hour');
+  });
+  await test('& reads as and, including inside names', () => {
+    assert.equal(normalizeForSpeech('A & B'), 'A and B');
+    assert.equal(normalizeForSpeech('Florence & the Machine'), 'Florence and the Machine');
+    assert.equal(normalizeForSpeech('classic R&B'), 'classic R and B');
+  });
+
+  console.log('markdown / display markup:');
+  await test('emphasis marks drop, words stay', () => {
+    assert.equal(normalizeForSpeech('**RadioMania**'), 'RadioMania');
+    assert.equal(normalizeForSpeech('*quietly*'), 'quietly');
+    assert.equal(normalizeForSpeech('__loud__ and _clear_'), 'loud and clear');
+    assert.equal(normalizeForSpeech('the `stream.mp3` mount'), 'the stream.mp3 mount');
+  });
+  await test('bold wrapping a unit still normalizes the unit', () => {
+    assert.equal(normalizeForSpeech('**76°F**'), '76 degrees Fahrenheit');
+  });
+  await test('markdown headings drop their hashes', () => {
+    assert.equal(normalizeForSpeech('## Tonight'), 'Tonight');
+  });
+  await test('stray asterisks vanish, snake_case survives', () => {
+    assert.equal(normalizeForSpeech('a * b'), 'a b');
+    assert.equal(normalizeForSpeech('track_01_final stays'), 'track_01_final stays');
+  });
+  await test('Chatterbox paralinguistic tags keep their brackets', () => {
+    assert.equal(normalizeForSpeech('[laugh] good one [sigh]'), '[laugh] good one [sigh]');
+  });
+
+  console.log('station branding + shape:');
+  await test('SUB/WAVE reads as Subwave (existing rule preserved)', () => {
+    assert.equal(normalizeForSpeech("You're listening to SUB/WAVE."), "You're listening to Subwave.");
+    assert.equal(normalizeForSpeech('sub slash wave'), 'Subwave');
+  });
+  await test('other slashes are untouched (AC/DC)', () => {
+    assert.equal(normalizeForSpeech('AC/DC up next'), 'AC/DC up next');
+  });
+  await test('whitespace collapses, empty passes through', () => {
+    assert.equal(normalizeForSpeech('two   spaces'), 'two spaces');
+    assert.equal(normalizeForSpeech(''), '');
+  });
+
+  console.log(failures ? `\n${failures} failing` : '\nall passing');
+  process.exit(failures ? 1 : 0);
+}
+
+main();

--- a/controller/scripts/speech-text.test.ts
+++ b/controller/scripts/speech-text.test.ts
@@ -51,6 +51,30 @@ async function main() {
   await test('$ inside a name is untouched (Ke$ha)', () => {
     assert.equal(normalizeForSpeech('Ke$ha on deck'), 'Ke$ha on deck');
   });
+  await test('compact magnitude suffixes expand ($100k, $5M, $2bn)', () => {
+    assert.equal(normalizeForSpeech('won $100k on the show'), 'won 100 thousand dollars on the show');
+    assert.equal(normalizeForSpeech('sold for $5M last year'), 'sold for 5 million dollars last year');
+    assert.equal(normalizeForSpeech('a $2bn valuation'), 'a 2 billion dollars valuation');
+  });
+  await test('already-spoken "dollars" is not doubled', () => {
+    assert.equal(normalizeForSpeech('sold for $5 million dollars'), 'sold for 5 million dollars');
+    assert.equal(normalizeForSpeech('$5 dollars at the door'), '5 dollars at the door');
+  });
+  await test('magnitude words match whole words only ($5 millionaire)', () => {
+    assert.equal(normalizeForSpeech('a $5 millionaire lifestyle'), 'a 5 dollars millionaire lifestyle');
+  });
+  await test('an unknown glued suffix leaves the amount alone ($100x)', () => {
+    assert.equal(normalizeForSpeech('the $100x return'), 'the $100x return');
+  });
+  await test('HTML entities decode before the & rule', () => {
+    assert.equal(normalizeForSpeech('Florence &amp; the Machine'), 'Florence and the Machine');
+    assert.equal(normalizeForSpeech('it&#39;s a classic'), "it's a classic");
+    assert.equal(normalizeForSpeech('she said &quot;play it&quot;'), 'she said "play it"');
+  });
+  await test('undecoded entity shapes are not mangled into "and"', () => {
+    assert.equal(normalizeForSpeech('4 &lt; 5'), '4 &lt; 5');
+    assert.equal(normalizeForSpeech('Tom & Jerry; a classic duo'), 'Tom and Jerry; a classic duo');
+  });
   await test('speed units expand after a number', () => {
     assert.equal(normalizeForSpeech('35 mph winds'), '35 miles per hour winds');
     assert.equal(normalizeForSpeech('gusts to 56 km/h'), 'gusts to 56 kilometers per hour');

--- a/controller/src/audio/speech-text.ts
+++ b/controller/src/audio/speech-text.ts
@@ -1,0 +1,65 @@
+// Pure spoken-text normalizer — the defensive layer between generated radio
+// copy and the TTS engines (issue #963). The DJ prompts already ask for
+// "spoken words only", but a model can still emit display text — weather
+// units, markdown emphasis, currency symbols — and engines read it literally
+// ("seventy-six F", or an awkward beat where the asterisks were). Every
+// booth-bound string converges on normalizeForSpeech() in audio/tts.ts, so
+// the rules here must stay conservative: real artist/title text rides the
+// same lines ("Ke$ha", "AC/DC", "P!nk" must survive untouched), and
+// Chatterbox's paralinguistic [laugh]/[sigh] tags must keep their brackets —
+// bracketed text is deliberately left alone.
+//
+// Digit-to-word expansion is NOT done here: every engine already reads plain
+// numbers naturally. The scope is symbols and markup only.
+//
+// No imports — pure module, unit-pinned by scripts/speech-text.test.ts.
+
+// Magnitude words that ride between a $ amount and the spoken "dollars":
+// "$5 million" must become "5 million dollars", not "5 dollars million".
+const DOLLAR_MAGNITUDE = '(?:\\s+(?:thousand|million|billion|trillion))?';
+
+export function normalizeForSpeech(text: string): string {
+  if (!text) return text;
+  let t = text;
+
+  // --- markdown / display markup (before unit rules, so `**76°F**` works) ---
+  // Paired emphasis: keep the words, drop the marks. Bold before italic so
+  // `**x**` doesn't leave stray asterisks for the italic pass to mis-pair.
+  t = t.replace(/\*\*([^*]+)\*\*/g, '$1');
+  t = t.replace(/\*([^*\n]+)\*/g, '$1');
+  t = t.replace(/__([^_]+)__/g, '$1');
+  // Single-underscore emphasis only when it wraps a word run (snake_case and
+  // file_names have word chars on the outside of each underscore — untouched).
+  t = t.replace(/(?<!\w)_([^_\n]+)_(?!\w)/g, '$1');
+  t = t.replace(/`([^`]+)`/g, '$1');
+  // Leading markdown headings on any line.
+  t = t.replace(/^#{1,6}\s+/gm, '');
+  // Leftover decorative marks that are never spoken. NOT brackets (Chatterbox
+  // [laugh] tags) and NOT lone underscores (titles/filenames).
+  t = t.replace(/[*`]/g, '');
+
+  // --- units and symbols (all keyed on an adjacent digit — conservative) ---
+  t = t.replace(/(\d)\s*°\s*F\b/g, '$1 degrees Fahrenheit');
+  t = t.replace(/(\d)\s*°\s*C\b/g, '$1 degrees Celsius');
+  // Bare degree after a number ("45° today") — after the F/C passes so only
+  // unitless degrees remain; a ° glued to any other letter is left alone.
+  t = t.replace(/(\d)\s*°(?![A-Za-z])/g, '$1 degrees');
+  t = t.replace(/(\d)\s*%/g, '$1 percent');
+  // $ only when it PRECEDES a number — "Ke$ha" has no digit after the $ and
+  // survives. The amount keeps its own formatting ("1,200", "12.50").
+  t = t.replace(
+    new RegExp(`\\$(\\d[\\d,]*(?:\\.\\d+)?${DOLLAR_MAGNITUDE})`, 'gi'),
+    '$1 dollars',
+  );
+  t = t.replace(/(\d)\s*mph\b/gi, '$1 miles per hour');
+  t = t.replace(/(\d)\s*km\/h\b/gi, '$1 kilometers per hour');
+  // "&" reads as "and" everywhere — that's the spoken form even inside names
+  // ("Florence & the Machine", "R&B").
+  t = t.replace(/\s*&\s*/g, ' and ');
+
+  // --- station branding: TTS engines read "SUB/WAVE" as "sub slash wave" ---
+  t = t.replace(/\bSUB\s*(?:\/|slash)\s*WAVE\b/gi, 'Subwave');
+
+  // Markup removal can leave doubled spaces; speech has no layout to preserve.
+  return t.replace(/\s+/g, ' ').trim();
+}

--- a/controller/src/audio/speech-text.ts
+++ b/controller/src/audio/speech-text.ts
@@ -16,7 +16,10 @@
 
 // Magnitude words that ride between a $ amount and the spoken "dollars":
 // "$5 million" must become "5 million dollars", not "5 dollars million".
-const DOLLAR_MAGNITUDE = '(?:\\s+(?:thousand|million|billion|trillion))?';
+// The \b keeps "millionaire" from prefix-matching ("5 million dollarsaire").
+const DOLLAR_MAGNITUDE = '(?:\\s+(?:thousand|million|billion|trillion)\\b)?';
+// The $ amount itself: digits with their own formatting ("1,200", "12.50").
+const DOLLAR_AMOUNT = '\\d[\\d,]*(?:\\.\\d+)?';
 
 export function normalizeForSpeech(text: string): string {
   if (!text) return text;
@@ -38,6 +41,15 @@ export function normalizeForSpeech(text: string): string {
   // [laugh] tags) and NOT lone underscores (titles/filenames).
   t = t.replace(/[*`]/g, '');
 
+  // --- HTML entities (a model quirk: encoded text in place of the glyph) ---
+  // Decoded BEFORE the symbol rules so "&amp;" reads as "and", not "and amp;".
+  // Only the entities that actually show up in chat-model output — a full
+  // entity table would be scope creep for a spoken-text pass.
+  t = t.replace(/&amp;/gi, '&');
+  t = t.replace(/&(?:#0*39|apos|#0*8217|rsquo);/gi, "'");
+  t = t.replace(/&(?:#0*34|quot|#0*8220|ldquo|#0*8221|rdquo);/gi, '"');
+  t = t.replace(/&nbsp;/gi, ' ');
+
   // --- units and symbols (all keyed on an adjacent digit — conservative) ---
   t = t.replace(/(\d)\s*°\s*F\b/g, '$1 degrees Fahrenheit');
   t = t.replace(/(\d)\s*°\s*C\b/g, '$1 degrees Celsius');
@@ -46,16 +58,32 @@ export function normalizeForSpeech(text: string): string {
   t = t.replace(/(\d)\s*°(?![A-Za-z])/g, '$1 degrees');
   t = t.replace(/(\d)\s*%/g, '$1 percent');
   // $ only when it PRECEDES a number — "Ke$ha" has no digit after the $ and
-  // survives. The amount keeps its own formatting ("1,200", "12.50").
+  // survives. Four passes, most specific first:
+  // 1. The model already wrote the spoken form ("$5 million dollars", "$5
+  //    dollars") — drop the symbol instead of speaking "dollars" twice.
   t = t.replace(
-    new RegExp(`\\$(\\d[\\d,]*(?:\\.\\d+)?${DOLLAR_MAGNITUDE})`, 'gi'),
+    new RegExp(`\\$(${DOLLAR_AMOUNT}${DOLLAR_MAGNITUDE})(?=\\s+dollars?\\b)`, 'gi'),
+    '$1',
+  );
+  // 2./3. Compact magnitude suffixes ("$100k", "$5M", "$2bn") — expanded here
+  //    so the letter can't glue onto "dollars" ("100 dollarsk"). Anchored on
+  //    the $ AND the suffix, so a bare "5k run" is untouched.
+  t = t.replace(new RegExp(`\\$(${DOLLAR_AMOUNT})k\\b`, 'gi'), '$1 thousand dollars');
+  t = t.replace(new RegExp(`\\$(${DOLLAR_AMOUNT})m\\b`, 'gi'), '$1 million dollars');
+  t = t.replace(new RegExp(`\\$(${DOLLAR_AMOUNT})(?:bn|b)\\b`, 'gi'), '$1 billion dollars');
+  // 4. The plain form. The trailing (?!\w) leaves any OTHER glued suffix
+  //    ("$100x") alone entirely — unspoken beats mangled.
+  t = t.replace(
+    new RegExp(`\\$(${DOLLAR_AMOUNT}${DOLLAR_MAGNITUDE})(?!\\w)`, 'gi'),
     '$1 dollars',
   );
   t = t.replace(/(\d)\s*mph\b/gi, '$1 miles per hour');
   t = t.replace(/(\d)\s*km\/h\b/gi, '$1 kilometers per hour');
   // "&" reads as "and" everywhere — that's the spoken form even inside names
-  // ("Florence & the Machine", "R&B").
-  t = t.replace(/\s*&\s*/g, ' and ');
+  // ("Florence & the Machine", "R&B") — EXCEPT when it opens an entity-shaped
+  // sequence we didn't decode above ("&lt;"): mangling those into "and lt;"
+  // is worse than leaving them.
+  t = t.replace(/\s*&(?!(?:#\d+|[a-zA-Z]+);)\s*/g, ' and ');
 
   // --- station branding: TTS engines read "SUB/WAVE" as "sub slash wave" ---
   t = t.replace(/\bSUB\s*(?:\/|slash)\s*WAVE\b/gi, 'Subwave');

--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -11,6 +11,7 @@ import * as chatterbox from './chatterbox.js';
 import * as pocketTts from './pocketTts.js';
 import { heavyEnabledEngines } from './ttsHeavyClient.js';
 import * as remoteTts from './remoteTts.js';
+import { normalizeForSpeech } from './speech-text.js';
 import * as cloud from '../llm/speech.js';
 import { stripThinking } from '../llm/sdk.js';
 import * as settings from '../settings.js';
@@ -135,6 +136,38 @@ export function voiceGainDb(kind: string, persona?: any): number {
   return settings.clampTtsGain(engineGain + personaGain);
 }
 
+// Effective speech-rate multiplier for a spoken segment of `kind` (1.0 =
+// engine default pace). Three factors multiply — engine base
+// (settings.tts.speed[engine]) × persona (persona.tts.speed) × daypart energy
+// (energyForDaypart().speed) — clamped to [0.5, 2.0]. The engine base applies
+// UNIVERSALLY, including jingles/default, mirroring the env-base
+// PIPER_SPEED/KOKORO_SPEED/CLOUD_TTS_SPEED behaviour; persona × daypart apply
+// only to live, persona-voiced kinds (a jingle cut at 2am must not carry 2am
+// pacing into a noon playout). `liveOverride` (speak()'s explicit `speedScale`)
+// replaces the persona/daypart term but still composes with the engine base.
+// Resolved-engine speed (post availability/key fallback) is used so the rate
+// matches the engine that will actually speak — same approach as voiceGainDb().
+//
+// Exported for the intro-budget word ceiling (issue #962): a persona speaking
+// at 0.8× fits fewer words in the same intro runway, so
+// broadcast/dj-agent.ts feeds this scale into dj.enforceIntroBudget().
+export function speechPaceScale(kind: string, persona?: any, liveOverride?: number | null): number {
+  const personaTts = djPersonaTts(kind, persona);
+  const primary = resolveEngine(kind, personaTts);
+  const ttsCfg: any = settings.get().tts || {};
+  const engineSpeed = settings.clampTtsSpeed(ttsCfg.speed?.[primary]);
+  const live = liveOverride != null
+    ? liveOverride
+    : GLOBAL_VOICE_KINDS.has(kind)
+      ? 1
+      : (personaTts ? settings.clampTtsSpeed(personaTts.speed) : 1) * energyForDaypart().speed;
+  // Bounds-clamp the product but do NOT snap to the 0.05 grid — the daypart
+  // energy is a non-grid value, so at default knobs (all 1.0) the on-air scale
+  // stays exactly today's daypart figure. Snapping happens only on the stored
+  // per-engine / per-persona knobs (clampTtsSpeed above).
+  return Math.min(settings.TTS_SPEED_MAX, Math.max(settings.TTS_SPEED_MIN, engineSpeed * live));
+}
+
 async function speakWith(engine: string, text: string, opts: any, personaTts: any) {
   if (engine === 'kokoro') {
     const voice = (personaTts && personaTts.engine === 'kokoro' && personaTts.voice)
@@ -196,12 +229,10 @@ async function speakWith(engine: string, text: string, opts: any, personaTts: an
   return piper.speak(text, { ...opts, voice });
 }
 
-// TTS engines read "SUB/WAVE" as "sub slash wave". Spell the station name
-// phonetically before synthesis — visual branding keeps the slash, audio doesn't.
-function normalizeForSpeech(text: string) {
-  if (!text) return text;
-  return text.replace(/\bSUB\s*(?:\/|slash)\s*WAVE\b/gi, 'Subwave');
-}
+// Display-text → spoken-text normalization (station branding, weather units,
+// markdown emphasis, display symbols — issue #963) lives in the pure
+// speech-text.ts module so it's unit-testable without this file's heavy deps.
+// Applied at the two synthesis entry points below: speak() and synthesizeSample().
 
 // Admin voice-preview ("Play sample"). Renders a one-off sample WAV with an
 // EXPLICIT engine + voice, deliberately bypassing both the on-air persona
@@ -307,33 +338,12 @@ export async function speak(
   const soul = GLOBAL_VOICE_KINDS.has(kind)
     ? ''
     : String(personaFor(persona)?.soul || '').trim();
-  // Delivery pace — a MULTIPLIER on the engine's configured speech rate (1.0 =
-  // unchanged), composed (not overridden) on top of an operator's global env
-  // base PIPER_SPEED/KOKORO_SPEED/CLOUD_TTS_SPEED. Three factors multiply:
-  //   engine base (settings.tts.speed[engine]) × persona (persona.tts.speed)
-  //   × daypart energy (energyForDaypart().speed)
-  // The engine base applies UNIVERSALLY — including jingles/default — mirroring
-  // how the env base already does; persona × daypart apply only to live,
-  // persona-voiced kinds (jingles are pre-rendered offline, so a jingle cut at
-  // 2am must not carry 2am pacing into a noon playout). An explicit `speedScale`
-  // (e.g. a future talk-up-to-post budget) replaces the persona/daypart live
-  // term but still composes with the engine base. Resolved-engine speed (post
-  // availability/key fallback) is used so the rate matches the engine that
-  // speaks — same approach as voiceGainDb(); the rare runtime-throw fallback
-  // reuses this scale. All factors default to 1.0, so a stock station is
-  // byte-for-byte unchanged. Final product clamped to [0.5, 2.0].
-  const ttsCfg: any = settings.get().tts || {};
-  const engineSpeed = settings.clampTtsSpeed(ttsCfg.speed?.[primary]);
-  const live = speedScale != null
-    ? speedScale
-    : GLOBAL_VOICE_KINDS.has(kind)
-      ? 1
-      : (personaTts ? settings.clampTtsSpeed(personaTts.speed) : 1) * energyForDaypart().speed;
-  // Bounds-clamp the product but do NOT snap to the 0.05 grid — the daypart
-  // energy is a non-grid value, so at default knobs (all 1.0) the on-air scale
-  // stays exactly today's daypart figure. Snapping happens only on the stored
-  // per-engine / per-persona knobs (clampTtsSpeed above).
-  const scale = Math.min(settings.TTS_SPEED_MAX, Math.max(settings.TTS_SPEED_MIN, engineSpeed * live));
+  // Delivery pace — engine base × persona × daypart (or the explicit
+  // `speedScale` override), clamped to [0.5, 2.0]. All the semantics live in
+  // speechPaceScale() above (shared with the intro-budget word ceiling); the
+  // rare runtime-throw fallback below reuses this scale. All factors default
+  // to 1.0, so a stock station is byte-for-byte unchanged.
+  const scale = speechPaceScale(kind, persona, speedScale);
   const started = Date.now();
   const chars = (speakText || '').length;
   // Shared fields for every recordTts() outcome below. `text` is capped so the

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -22,11 +22,12 @@ import * as journey from '../music/journey.js';
 import * as dj from '../llm/dj.js';
 import { energyForDaypart } from '../context.js';
 import { defineAgent } from '../llm/agent.js';
-import { djObject, nearestId, modelTolerant } from '../llm/sdk.js';
+import { djObject, nearestId, modelTolerant, stripThinking } from '../llm/sdk.js';
 import { buildPickerTools } from '../llm/tools.js';
 import { recordPick } from '../llm/log.js';
 import * as budget from './dj-budget.js';
 import { speechPaceScale } from '../audio/tts.js';
+import { normalizeForSpeech } from '../audio/speech-text.js';
 import { withTrace, logEvent } from '../observability/events.js';
 import { recencyWindowsForLibrary, effectiveNoRepeatWindow } from '../music/recency.js';
 import { hasEraBound } from '../music/show-filter.js';
@@ -442,6 +443,25 @@ function trackFields(song) {
   };
 }
 
+// Talk-within-the-intro budget (#962), applied to a between-track link in DJ
+// mode: trim to the pick's measured intro runway so the DJ lands before the
+// vocals — sentence/clause-complete or dropped (null), never a fragment.
+// Enforced on the SPOKEN form of the line: tts.speak() later runs
+// normalizeForSpeech(stripThinking(...)), which can EXPAND display symbols
+// into extra words ("$5 million" → "5 million dollars"), so counting the raw
+// text under-budgets the line that actually airs. The normalized text is what
+// gets aired/queued — speak()'s own normalize pass is a no-op on it.
+// speechPaceScale('link') maps the word ceiling to the rate the line will be
+// spoken at (engine × persona × daypart). Returns the text unchanged when not
+// in DJ mode; enforceIntroBudget itself no-ops on an un-analysed pick.
+function trimLinkToIntro(text: string | null | undefined, song: any): string | null {
+  const raw = (text || '').trim();
+  if (!raw) return null;
+  if (!settings.getEffectivePersona()?.djMode) return raw;
+  const spoken = normalizeForSpeech(stripThinking(raw));
+  return dj.enforceIntroBudget(spoken, introMsOf(song), speechPaceScale('link')) || null;
+}
+
 // `link`, when present, is the between-track line to speak as this pick starts
 // playing. It's attached to the queued item so the queue airs it at the
 // transition INTO this track (queue.airIntro), not over whatever is currently
@@ -460,6 +480,12 @@ async function enqueuePick(
   linkPrev: any = null,
   { sweep = false, washout = false, blend = false, dissolve = false, chop = false, loop = false }: { sweep?: boolean; washout?: boolean; blend?: boolean; dissolve?: boolean; chop?: boolean; loop?: boolean } = {},
 ): Promise<number> {
+  // Single chokepoint for the intro budget: every pick path (agent, pool, any
+  // future producer) funnels its link through here, so enforcement can't be
+  // skipped by a new caller. Idempotent — callers that already trimmed (the
+  // agent path does, to record the aired text in its session turn) pass
+  // through unchanged.
+  const introLink = trimLinkToIntro(link, song);
   const track: any = trackFields(song);
   // Flag the transition effects on this pick (DJ mode only). getAnnotatedUri
   // stamps liq_sweep / liq_washout / liq_dissolve / liq_chop; radio.liq ramps
@@ -477,7 +503,7 @@ async function enqueuePick(
     track,
     requestedBy: null,
     intent: reason || 'ai pick',
-    introScript: link,
+    introScript: introLink,
     introKind: 'link',
     aiPicked: true,
     linkPrev,
@@ -620,16 +646,11 @@ async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = n
   }
 
   const rawSay = typeof object.say === 'string' ? object.say.trim() : '';
-  // Talk-within-the-intro (feature 3a): in DJ mode, trim the link to the
-  // pick's measured intro runway so the DJ lands before the vocals instead of
-  // talking over them — sentence/clause-complete or dropped, never an
-  // ellipsis fragment (#962). speechPaceScale('link') maps the word ceiling
-  // to the rate the line will actually be spoken at (engine × persona ×
-  // daypart). No-op when the pick is un-analysed or not in DJ mode.
-  const djMode = !!settings.getEffectivePersona()?.djMode;
-  const say = (djMode && rawSay)
-    ? dj.enforceIntroBudget(rawSay, introMsOf(song), speechPaceScale('link'))
-    : rawSay;
+  // Talk-within-the-intro (feature 3a): enqueuePick re-applies this trim at
+  // the chokepoint (idempotent); it runs here too so the session turn below
+  // records the line as it will actually air — trimmed, and dropped links as
+  // null, never a line the listeners didn't hear.
+  const say = trimLinkToIntro(rawSay, song) || '';
   // Transition effects on this pick (persona djMode via settings.effectsActive),
   // independent of whether a link airs.
   const link = (wantLink && say) ? say : null;
@@ -697,14 +718,8 @@ async function pickViaPool(queue, ctx, { wantLink, current, showAt = null }: { w
       queue.log('error', `DJ link failed: ${err.message}`);
     }
   }
-  // Talk-within-the-intro applies to the pool path too (#962 follow-up): the
-  // generateLink prompt carries the advisory budget phrase, but enforcement
-  // previously only ran on the agent path, so a pool link could still talk
-  // over the vocals — and would have aired an ellipsis fragment if trimmed.
-  // Same DJ-mode gate and pace scale as the agent path; '' → no spoken intro.
-  if (link && settings.getEffectivePersona()?.djMode) {
-    link = dj.enforceIntroBudget(link, introMsOf(result.song), speechPaceScale('link')) || null;
-  }
+  // Talk-within-the-intro rides enqueuePick's trimLinkToIntro chokepoint —
+  // the pool link needs no enforcement of its own here (#962 follow-up).
   // Transition effects ride the pool path too (pickNextTrack only offers the
   // field when settings.effectsActive()), so a DJ-mode persona keeps its craft
   // while picks run through this fallback. Re-check effectsActive at enqueue

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -26,6 +26,7 @@ import { djObject, nearestId, modelTolerant } from '../llm/sdk.js';
 import { buildPickerTools } from '../llm/tools.js';
 import { recordPick } from '../llm/log.js';
 import * as budget from './dj-budget.js';
+import { speechPaceScale } from '../audio/tts.js';
 import { withTrace, logEvent } from '../observability/events.js';
 import { recencyWindowsForLibrary, effectiveNoRepeatWindow } from '../music/recency.js';
 import { hasEraBound } from '../music/show-filter.js';
@@ -619,11 +620,16 @@ async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = n
   }
 
   const rawSay = typeof object.say === 'string' ? object.say.trim() : '';
-  // Talk-within-the-intro (feature 3a): in DJ mode, hard-trim the link to the
+  // Talk-within-the-intro (feature 3a): in DJ mode, trim the link to the
   // pick's measured intro runway so the DJ lands before the vocals instead of
-  // talking over them. No-op when the pick is un-analysed or not in DJ mode.
+  // talking over them — sentence/clause-complete or dropped, never an
+  // ellipsis fragment (#962). speechPaceScale('link') maps the word ceiling
+  // to the rate the line will actually be spoken at (engine × persona ×
+  // daypart). No-op when the pick is un-analysed or not in DJ mode.
   const djMode = !!settings.getEffectivePersona()?.djMode;
-  const say = (djMode && rawSay) ? dj.enforceIntroBudget(rawSay, introMsOf(song)) : rawSay;
+  const say = (djMode && rawSay)
+    ? dj.enforceIntroBudget(rawSay, introMsOf(song), speechPaceScale('link'))
+    : rawSay;
   // Transition effects on this pick (persona djMode via settings.effectsActive),
   // independent of whether a link airs.
   const link = (wantLink && say) ? say : null;
@@ -690,6 +696,14 @@ async function pickViaPool(queue, ctx, { wantLink, current, showAt = null }: { w
     } catch (err) {
       queue.log('error', `DJ link failed: ${err.message}`);
     }
+  }
+  // Talk-within-the-intro applies to the pool path too (#962 follow-up): the
+  // generateLink prompt carries the advisory budget phrase, but enforcement
+  // previously only ran on the agent path, so a pool link could still talk
+  // over the vocals — and would have aired an ellipsis fragment if trimmed.
+  // Same DJ-mode gate and pace scale as the agent path; '' → no spoken intro.
+  if (link && settings.getEffectivePersona()?.djMode) {
+    link = dj.enforceIntroBudget(link, introMsOf(result.song), speechPaceScale('link')) || null;
   }
   // Transition effects ride the pool path too (pickNextTrack only offers the
   // field when settings.effectsActive()), so a DJ-mode persona keeps its craft

--- a/controller/src/llm/internal/prompts/context.ts
+++ b/controller/src/llm/internal/prompts/context.ts
@@ -140,7 +140,12 @@ export function buildContextLines(
       : `Period: ${context.time.period} (${context.time.vibe})`);
   }
   if (on('weather') && context?.weather && context.weather.condition && context.weather.condition !== 'unknown') {
-    lines.push(`Weather in ${context.weather.location}: ${context.weather.condition}${context.weather.temp != null ? `, ${context.weather.temp}°${context.weather.tempUnit || 'C'}` : ''}`);
+    // Spoken form ("24 degrees Celsius"), not display form ("24°C") — the
+    // model echoes whatever unit shape the prompt uses, and a °F/°C echo
+    // reaches TTS as "seventy-six F" (issue #963). The speech-text normalizer
+    // is the backstop; this stops the most common case at the source.
+    const unitWord = (context.weather.tempUnit || 'C') === 'F' ? 'Fahrenheit' : 'Celsius';
+    lines.push(`Weather in ${context.weather.location}: ${context.weather.condition}${context.weather.temp != null ? `, ${context.weather.temp} degrees ${unitWord}` : ''}`);
   }
   if (on('festival') && context?.festival) {
     const note = context.festival.description ? ` — ${context.festival.description}` : '';

--- a/controller/src/llm/internal/prompts/intro-budget.ts
+++ b/controller/src/llm/internal/prompts/intro-budget.ts
@@ -60,15 +60,27 @@ export function enforceIntroBudget(text: string, introMs: number | null | undefi
   const capped = words.slice(0, maxWords).join(' ');
   // Last index of a boundary character that ends a word (followed by space or
   // end-of-string) — so a decimal ("3.5") or a thousands comma ("1,200")
-  // never counts as a cut point.
-  const lastBoundary = (re: RegExp): number => {
+  // never counts as a cut point. `skip` vetoes individual matches.
+  const lastBoundary = (re: RegExp, skip?: (m: RegExpExecArray) => boolean): number => {
     let at = -1;
-    for (let m = re.exec(capped); m; m = re.exec(capped)) at = m.index;
+    for (let m = re.exec(capped); m; m = re.exec(capped)) {
+      if (!skip || !skip(m)) at = m.index;
+    }
     return at;
   };
+  // A period after an abbreviation or a lone initial ("Dr.", "St.", "feat.",
+  // "E. Street") is not a sentence end — without this veto the cut lands right
+  // after it and the DJ airs "Dr." alone, the exact fragment this cascade
+  // exists to prevent. Vetoing too eagerly is safe (the line falls through to
+  // the clause/drop steps); accepting wrongly is not. Applies to '.' only —
+  // '!' and '?' never end abbreviations.
+  const ABBREV_BEFORE_STOP = /(?:^|\s)(?:[A-Za-z]|Dr|Mr|Mrs|Ms|St|Jr|Sr|Prof|Rev|Sgt|Capt|Lt|Gen|Col|Mt|No|vs|feat|ft)$/i;
   // Prefer the last complete sentence, however short — a one-word "Nice."
   // sounds intentional; a fragment never does.
-  const lastStop = lastBoundary(/[.!?](?=\s|$)/g);
+  const lastStop = lastBoundary(
+    /[.!?](?=\s|$)/g,
+    (m) => m[0] === '.' && ABBREV_BEFORE_STOP.test(capped.slice(0, m.index)),
+  );
   if (lastStop > 0) return capped.slice(0, lastStop + 1).trim();
   // No full sentence fits — keep the longest clause if it carries enough of
   // the line to stand alone, closed with a period.

--- a/controller/src/llm/internal/prompts/intro-budget.ts
+++ b/controller/src/llm/internal/prompts/intro-budget.ts
@@ -35,25 +35,47 @@ export function introBudgetPhrase(introMs: number | null | undefined): string {
 
 // Hard backstop for talk-within-the-intro (Stage A.3 phase 2): the budget PHRASE
 // above is advisory — a small model will still occasionally overrun. This
-// enforces it deterministically. Speaking pace is ~2.5 words/sec, so a known
-// intro runway maps to a word ceiling; over-long lines are trimmed to the last
-// sentence that fits, and only hard-cut mid-sentence if even one sentence won't
-// fit. Returns the text unchanged when there's no usable runway (null, very
-// short, or a long ≥18s intro) — symmetric with introBudgetPhrase's guards.
-export function enforceIntroBudget(text: string, introMs: number | null | undefined): string {
+// enforces it deterministically. Base speaking pace is ~2.5 words/sec, scaled
+// by `paceScale` — the live speech-rate multiplier from
+// audio/tts.speechPaceScale() (engine × persona × daypart) — so a persona
+// speaking at 0.8× gets a proportionally smaller word ceiling; 1 (the
+// default) is the historical fixed-pace assumption.
+//
+// A spoken fragment sounds like a station failure, so this NEVER hard-cuts
+// mid-thought (#962): over-long lines trim to the last complete sentence that
+// fits, else the last clause boundary (closed with a period so it still
+// sounds intentional), else the line is DROPPED — callers treat '' as "no
+// spoken intro" and the track just plays. Returns the text unchanged when
+// there's no usable runway (null, very short, or a long ≥18s intro) —
+// symmetric with introBudgetPhrase's guards.
+export function enforceIntroBudget(text: string, introMs: number | null | undefined, paceScale = 1): string {
   const t = (text || '').trim();
   if (!t || !introMs || introMs < 2500 || introMs >= 18000) return t;
-  const WORDS_PER_SEC = 2.5;
-  const maxWords = Math.max(3, Math.floor((introMs / 1000) * WORDS_PER_SEC));
+  const BASE_WORDS_PER_SEC = 2.5;
+  const pace = (Number.isFinite(paceScale) && paceScale > 0) ? paceScale : 1;
+  const maxWords = Math.max(3, Math.floor((introMs / 1000) * BASE_WORDS_PER_SEC * pace));
   const words = t.split(/\s+/);
   if (words.length <= maxWords) return t;
 
-  // Trim to the last sentence boundary that fits the budget.
   const capped = words.slice(0, maxWords).join(' ');
-  const lastStop = Math.max(capped.lastIndexOf('.'), capped.lastIndexOf('!'), capped.lastIndexOf('?'));
-  if (lastStop >= Math.floor(capped.length * 0.4)) {
-    return capped.slice(0, lastStop + 1).trim();
+  // Last index of a boundary character that ends a word (followed by space or
+  // end-of-string) — so a decimal ("3.5") or a thousands comma ("1,200")
+  // never counts as a cut point.
+  const lastBoundary = (re: RegExp): number => {
+    let at = -1;
+    for (let m = re.exec(capped); m; m = re.exec(capped)) at = m.index;
+    return at;
+  };
+  // Prefer the last complete sentence, however short — a one-word "Nice."
+  // sounds intentional; a fragment never does.
+  const lastStop = lastBoundary(/[.!?](?=\s|$)/g);
+  if (lastStop > 0) return capped.slice(0, lastStop + 1).trim();
+  // No full sentence fits — keep the longest clause if it carries enough of
+  // the line to stand alone, closed with a period.
+  const lastClause = lastBoundary(/[,;:—](?=\s|$)/g);
+  if (lastClause >= Math.floor(capped.length * 0.4)) {
+    return capped.slice(0, lastClause).trim() + '.';
   }
-  // No sentence boundary worth keeping — hard cut and punctuate cleanly.
-  return capped.replace(/[,;:\-—\s]+$/, '') + '…';
+  // Nothing complete fits the runway — silence beats an ellipsis fragment.
+  return '';
 }


### PR DESCRIPTION
Fixes #963, fixes #962 — both reported TTS speech-quality issues, plus the gaps found while tracing them.

## #963 — spoken-text normalization before synthesis

- New pure module `controller/src/audio/speech-text.ts` (no imports, unit-testable), applied at the existing chokepoint every booth-bound string already converges on: `tts.speak()` and the admin `synthesizeSample()` preview.
- Rules, all keyed on an adjacent digit where it matters (conservative by design — real artist/title text rides the same lines):
  - `76°F` / `76 °F` → `76 degrees Fahrenheit`, same for °C, bare `45°` → `45 degrees`
  - `40%` → `40 percent`, `$12` → `12 dollars` (`$5 million` → `5 million dollars`), `35 mph` / `56 km/h` expand
  - `&` → `and` (the spoken form even inside names: Florence & the Machine, R&B)
  - markdown emphasis/backticks/headings stripped, words kept (`*quietly*` → `quietly`)
  - **untouched**: `Ke$ha`, `AC/DC`, snake_case, decimals, and Chatterbox's paralinguistic `[laugh]`/`[sigh]` tags (brackets deliberately preserved)
  - the existing SUB/WAVE → Subwave rule moves here unchanged
- **Source fix too**: the weather context line rendered `24°C` into the DJ prompt itself, so the model echoed display units. It now renders `24 degrees Celsius` — the normalizer stays as the backstop.

## #962 — intro budget never airs an ellipsis fragment

`enforceIntroBudget` used to hard-cut over-budget lines and append `…`, airing fragments like *"Ever notice how a single chord…"*. New cascade:

1. keep the last **complete sentence** that fits (however short — "Nice." sounds intentional)
2. else the last **clause boundary**, closed with a period
3. else **drop the line** (`''` — callers already treat it as "no spoken intro"; the track just plays)

Boundary detection now requires the punctuation to end a word, so decimals (`3.5`) and thousands commas (`1,200`) are never cut points.

### Gaps found while tracing, also fixed

- **Pool-picker links were never budget-enforced** — only the agent path was. The pool path now runs the same enforcement (same DJ-mode gate).
- **The 2.5 words/sec assumption ignored speech rate** — a persona at 0.8× overran even "fitting" lines. The word ceiling now scales by the new `tts.speechPaceScale()` (engine × persona × daypart — extracted from `speak()`'s existing pace computation, no behaviour change to playout).

## Tests

- New `controller/scripts/speech-text.test.ts` (19 cases, auto-discovered by run-tests) pinning every conversion **and** every must-survive case.
- `llm-pure.test.ts`: the old ellipsis-fallback pin replaced with the sentence/clause/drop cascade + pace-scaling pins.
- `npm run lint` clean (0 errors), full `npm test` suite: all 25 files pass.