### PR TITLE
perf+test(observatory): survive 200k-track libraries — stress suite + hot-path fixes

### DIFF
--- a/controller/scripts/observatory-scale.test.ts
+++ b/controller/scripts/observatory-scale.test.ts
@@ -48,6 +48,7 @@ import {
 const N = Math.max(1000, Number(process.env.OBS_SCALE_N) || 200_000);
 const AUDIO_N = Math.min(N, 50_000); // audio vectors are 2 KB each — cap the seed, extrapolate
 const AUDIO_DIM = 512;
+const CELL_DIAG = 64 * Math.SQRT2; // buildSynapseLinks grid cell diagonal
 
 let failures = 0;
 function test(name: string, fn: () => void | Promise<void>) {
@@ -359,21 +360,35 @@ async function main() {
     assert.ok(ms < 20_000, `layout under 20 s (took ${ms.toFixed(0)} ms)`);
   });
 
+  let genreLaid: ReturnType<typeof layoutTracks> | null = null;
   await test(`layoutTracks(${N.toLocaleString()}) — genre-cluster fallback (0% mapped)`, () => {
     const stripped = rawTracks.map((t) => ({ ...t, mapX: null, mapY: null }));
     const { out, ms } = timed('layout (genre clusters)', () => layoutTracks(stripped));
+    genreLaid = out;
     assert.equal(out.tracks.length, N);
     assert.ok(!out.soundMap);
     assert.ok(ms < 20_000, `layout under 20 s (took ${ms.toFixed(0)} ms)`);
   });
 
   await test(`buildSynapseLinks(${N.toLocaleString()}) — spatial-grid nearest neighbour`, () => {
-    const { out, ms } = timed('synapse links', () => buildSynapseLinks(soundLaid!.tracks));
+    const { out, ms } = timed('synapse links (sound map)', () => buildSynapseLinks(soundLaid!.tracks));
     assert.ok(out.length > 0 && out.length <= N, `sane link count (got ${out.length.toLocaleString()})`);
     for (const [a, b] of out.slice(0, 2_000)) {
       assert.ok(a >= 0 && b < N && a < b, 'ordered in-range index pairs');
     }
-    assert.ok(ms < 20_000, `links under 20 s (took ${ms.toFixed(0)} ms)`);
+    assert.ok(ms < 10_000, `links under 10 s (took ${ms.toFixed(0)} ms)`);
+    // Worst case for the scan budget: the genre-cluster layout packs whole
+    // genres into single grid cells (the unbudgeted probe measured ~65 s at
+    // 400k here). Links must stay LOCAL too — the budget must not produce
+    // cluster-spanning filaments.
+    const worst = timed('synapse links (genre clusters, dense worst case)', () =>
+      buildSynapseLinks(genreLaid!.tracks),
+    );
+    assert.ok(worst.ms < 10_000, `dense links under 10 s (took ${worst.ms.toFixed(0)} ms)`);
+    const gt = genreLaid!.tracks;
+    const lens = worst.out.map(([a, b]) => Math.hypot(gt[a]!.x - gt[b]!.x, gt[a]!.y - gt[b]!.y)).sort((x, y) => x - y);
+    const p95 = lens[Math.floor(lens.length * 0.95)]!;
+    assert.ok(p95 < CELL_DIAG, `links stay within a cell neighbourhood (p95 ${p95.toFixed(1)}u)`);
   });
 
   db.close();

--- a/controller/scripts/observatory-scale.test.ts
+++ b/controller/scripts/observatory-scale.test.ts
@@ -1,0 +1,393 @@
+// Scale / stress test for the Library Observatory data path (#957) at very
+// large library sizes — some operators have 200k+ track libraries.
+//
+// Covers the server side of the galaxy renderer end-to-end EXCEPT the express
+// wiring: a REAL better-sqlite3 DB in a temp STATE_DIR seeded with N synthetic
+// tagged tracks (60% carrying realistically fat analysis blobs — beats/bars/
+// pace/structure JSON — which the lean observatory reads must SKIP; parsing
+// them per row is what made the pre-lean bulk path a multi-second stall),
+// then measures + budget-asserts the exact calls the
+// GET /library/observatory route makes:
+//
+//   - allTagged() / allTaggedSampled()  (lean ObservatoryTrackRow reads)
+//   - stats()                           (the ~7 GROUP-BY scans, TTL-cached)
+//   - the route's row→payload projection + JSON.stringify (+ gzip size, since
+//     Caddy compresses on the wire) — all of it synchronous on the event loop
+//   - setMapCoordsBulk()                (the projection child's final write)
+//   - allAudioVectors() at AUDIO_N      (the UMAP child's input load; memory
+//     reported and extrapolated to N — the child holds the whole matrix)
+//
+// And the client's pure layout pipeline, imported straight from the web app so
+// it can't drift (data.ts is dependency-free):
+//
+//   - layoutTracks() in both modes (sound-map coords + genre-cluster fallback)
+//   - buildSynapseLinks()               (the spatial-grid nearest-neighbour pass)
+//
+// Budgets are deliberately loose (≈3–5× a warm dev-box run) — they exist to
+// catch an accidental O(n²) or a new per-row JSON.parse, not scheduler jitter.
+//
+// Row count is env-tunable:   OBS_SCALE_N=200000 tsx scripts/observatory-scale.test.ts
+// (default 200000; OBS_SCALE_TMP overrides the temp dir — /tmp is tmpfs on
+// some distros and the seeded DB is ~0.5 GB at 200k).
+// Run: `tsx scripts/observatory-scale.test.ts` (folded into `npm run test`).
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { gzipSync } from 'node:zlib';
+import Database from 'better-sqlite3';
+import * as sqliteVec from 'sqlite-vec';
+import {
+  mulberry32,
+  layoutTracks,
+  buildSynapseLinks,
+  type RawTrack,
+} from '../../web/components/observatory/data.js';
+
+const N = Math.max(1000, Number(process.env.OBS_SCALE_N) || 200_000);
+const AUDIO_N = Math.min(N, 50_000); // audio vectors are 2 KB each — cap the seed, extrapolate
+const AUDIO_DIM = 512;
+
+let failures = 0;
+function test(name: string, fn: () => void | Promise<void>) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => console.log(`  ✓ ${name}`))
+    .catch((err) => { failures++; console.error(`  ✗ ${name}\n      ${err?.message || err}`); });
+}
+
+const mb = (bytes: number) => `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+const timed = <T>(label: string, fn: () => T): { out: T; ms: number } => {
+  const t0 = performance.now();
+  const out = fn();
+  const ms = performance.now() - t0;
+  console.log(`      ${label}: ${ms.toFixed(0)} ms`);
+  return { out, ms };
+};
+
+// --------------------------------------------------------------------------
+// Synthetic library — deterministic, zipf-ish genre spread, realistic blobs.
+// --------------------------------------------------------------------------
+const GENRES = Array.from({ length: 120 }, (_, i) => `Genre ${String(i).padStart(3, '0')}`);
+const MOODS = ['hazy', 'reflective', 'calm', 'night', 'rainy', 'romantic', 'energetic', 'driving', 'celebratory', 'melancholy', 'warm', 'cold', 'dusty', 'cosmic', 'urban', 'pastoral', 'tense', 'playful', 'solemn', 'glassy', 'neon', 'analog', 'blue', 'golden', 'feral'];
+const SOURCES = ['llm', 'llm', 'llm', 'propagated', 'propagated', 'manual', 'uncertain-llm', 'legacy-v1'];
+const ENERGIES = ['low', 'medium', 'high'] as const;
+const KEYS = Array.from({ length: 12 }, (_, i) => [`${i + 1}A`, `${i + 1}B`]).flat();
+
+interface SeedRow {
+  id: string;
+  title: string;
+  artist: string;
+  album: string;
+  year: number;
+  genre: string;
+  durationSec: number;
+  moods: string[];
+  energy: (typeof ENERGIES)[number];
+  source: string;
+  confidence: number;
+  analysed: boolean;
+  bpm: number | null;
+  musicalKey: string | null;
+  analysisConfidence: number | null;
+  loudnessLufs: number | null;
+  paceJson: string | null;
+  vocalRangesJson: string | null;
+  structureJson: string | null;
+  beatsJson: string | null;
+  barsJson: string | null;
+  keyRangesJson: string | null;
+  mapX: number | null;
+  mapY: number | null;
+}
+
+function makeRow(i: number, rng: () => number): SeedRow {
+  // zipf-ish genre pick: squaring the uniform biases toward low indices, so a
+  // few genres are huge and the tail is sparse — like a real library.
+  const genre = GENRES[Math.floor(rng() * rng() * GENRES.length)]!;
+  const analysed = rng() < 0.6;
+  const mapped = rng() < 0.7; // > the client's 60% sound-map coverage gate
+  const durationSec = 120 + Math.floor(rng() * 300);
+  const moodCount = 1 + Math.floor(rng() * 3);
+  const moods = Array.from({ length: moodCount }, () => MOODS[Math.floor(rng() * MOODS.length)]!);
+  const bpm = analysed ? 60 + rng() * 120 : null;
+
+  let paceJson: string | null = null;
+  let vocalRangesJson: string | null = null;
+  let structureJson: string | null = null;
+  let beatsJson: string | null = null;
+  let barsJson: string | null = null;
+  let keyRangesJson: string | null = null;
+  if (analysed) {
+    const totalMs = durationSec * 1000;
+    const spans = (n: number) =>
+      Array.from({ length: n }, (_, k) => ({
+        startMs: Math.round((totalMs * k) / n),
+        endMs: Math.round((totalMs * (k + 1)) / n),
+      }));
+    paceJson = JSON.stringify(spans(14).map((s) => ({ ...s, value: Math.round(rng() * 100) / 100 })));
+    vocalRangesJson = JSON.stringify(rng() < 0.7 ? spans(4) : []);
+    structureJson = JSON.stringify(spans(7).map((s, k) => ({ ...s, kind: k % 2 ? 'verse' : 'chorus' })));
+    // the fat ones — a ~4 min track carries hundreds of beat timestamps
+    const beatMs = 60000 / (bpm || 120);
+    const beatCount = Math.min(600, Math.floor(totalMs / beatMs));
+    beatsJson = JSON.stringify(Array.from({ length: beatCount }, (_, k) => Math.round(k * beatMs)));
+    barsJson = JSON.stringify(Array.from({ length: beatCount >> 2 }, (_, k) => Math.round(k * beatMs * 4)));
+    keyRangesJson = JSON.stringify([
+      { startMs: 0, endMs: totalMs >> 1, tonic: 'C', mode: 'major' },
+      { startMs: totalMs >> 1, endMs: totalMs, tonic: 'A', mode: 'minor' },
+    ]);
+  }
+
+  return {
+    id: `trk-${String(i).padStart(7, '0')}`,
+    title: `Track ${i} of the Long Tail`,
+    artist: `Artist ${i % 40_000}`,
+    album: `Album ${i % 60_000}`,
+    year: 1970 + (i % 55),
+    genre,
+    durationSec,
+    moods,
+    energy: ENERGIES[Math.floor(rng() * 3)]!,
+    source: SOURCES[Math.floor(rng() * SOURCES.length)]!,
+    confidence: Math.round(rng() * 100) / 100,
+    analysed,
+    bpm: bpm ? Math.round(bpm * 10) / 10 : null,
+    musicalKey: analysed ? KEYS[Math.floor(rng() * KEYS.length)]! : null,
+    analysisConfidence: analysed ? Math.round((0.5 + rng() * 0.5) * 100) / 100 : null,
+    loudnessLufs: analysed ? Math.round((-24 + rng() * 16) * 10) / 10 : null,
+    paceJson,
+    vocalRangesJson,
+    structureJson,
+    beatsJson,
+    barsJson,
+    keyRangesJson,
+    mapX: mapped ? rng() : null,
+    mapY: mapped ? rng() : null,
+  };
+}
+
+// Mirrors the GET /library/observatory row→payload projection in
+// routes/library.ts (kept inline: importing the router would drag express,
+// subsonic and settings into this test). If the route's shape changes, update
+// this copy — the point is the WORK (field picks + stringify), not the shape.
+function projectRows(rows: any[]) {
+  return rows.map((t) => ({
+    id: t.id,
+    title: t.title,
+    artist: t.artist,
+    album: t.album,
+    year: t.year,
+    genre: t.genre,
+    durationSec: t.durationSec,
+    moods: t.moods,
+    energy: t.energy,
+    source: t.source,
+    confidence: t.confidence,
+    bpm: t.bpm,
+    musicalKey: t.musicalKey,
+    analysisConfidence: t.analysisConfidence,
+    loudnessLufs: t.loudnessLufs,
+    paceMean: t.paceMean,
+    vocal: t.vocal,
+    mapX: t.mapX,
+    mapY: t.mapY,
+  }));
+}
+
+async function main() {
+  const stateDir = mkdtempSync(join(process.env.OBS_SCALE_TMP || tmpdir(), 'subwave-obs-scale-'));
+  process.env.STATE_DIR = stateDir;
+  console.log(`observatory scale test — N=${N.toLocaleString()} tracks (state: ${stateDir})`);
+
+  // Imported AFTER STATE_DIR is set so DB_PATH resolves into the temp dir.
+  const db = await import('../src/music/library-db.js');
+  await db.open({ embeddingDim: 768 });
+
+  // ---- seed (raw second connection: the public upserts autocommit per row,
+  // which is 3×N transactions — a raw prepared INSERT in chunked transactions
+  // seeds 200k rows in seconds; WAL makes the two connections safe, exactly
+  // like the tagger children alongside the live controller) ----
+  const raw = new Database(join(stateDir, 'library.db'));
+  sqliteVec.load(raw); // track_audio_vectors is a vec0 virtual table
+  raw.pragma('journal_mode = WAL');
+  raw.pragma('synchronous = OFF'); // seed speed only; the code under test never writes here
+  {
+    const rng = mulberry32(0x0b5e55);
+    const stmt = raw.prepare(`
+      INSERT INTO tracks (id, title, artist, album, year, genre, duration_sec,
+        moods, energy, source, confidence, tagger_version, tagged_at,
+        bpm, musical_key, analysis_confidence, analysis_version, loudness_lufs,
+        pace_json, vocal_ranges_json, structure_json, beats_json, bars_json, key_ranges_json,
+        map_x, map_y)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 3, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    const insertChunk = raw.transaction((rows: SeedRow[]) => {
+      for (const r of rows) {
+        stmt.run(
+          r.id, r.title, r.artist, r.album, r.year, r.genre, r.durationSec,
+          JSON.stringify(r.moods), r.energy, r.source, r.confidence, '2026-01-01T00:00:00Z',
+          r.bpm, r.musicalKey, r.analysisConfidence, r.analysed ? 1 : null, r.loudnessLufs,
+          r.paceJson, r.vocalRangesJson, r.structureJson, r.beatsJson, r.barsJson, r.keyRangesJson,
+          r.mapX, r.mapY,
+        );
+      }
+    });
+    const t0 = performance.now();
+    const CHUNK = 20_000;
+    for (let at = 0; at < N; at += CHUNK) {
+      const rows: SeedRow[] = [];
+      for (let i = at; i < Math.min(N, at + CHUNK); i++) rows.push(makeRow(i, rng));
+      insertChunk(rows);
+    }
+    // audio vectors for the UMAP-input measurement
+    const vecStmt = raw.prepare('INSERT INTO track_audio_vectors (id, embedding) VALUES (?, ?)');
+    const vecChunk = raw.transaction((ids: string[]) => {
+      const v = new Float32Array(AUDIO_DIM);
+      for (const id of ids) {
+        for (let d = 0; d < AUDIO_DIM; d++) v[d] = rng() - 0.5;
+        vecStmt.run(id, Buffer.from(v.buffer.slice(0)));
+      }
+    });
+    for (let at = 0; at < AUDIO_N; at += CHUNK) {
+      vecChunk(Array.from({ length: Math.min(CHUNK, AUDIO_N - at) }, (_, k) => `trk-${String(at + k).padStart(7, '0')}`));
+    }
+    console.log(`  seeded ${N.toLocaleString()} tracks + ${AUDIO_N.toLocaleString()} audio vectors in ${((performance.now() - t0) / 1000).toFixed(1)} s (db: ${mb(statSync(join(stateDir, 'library.db')).size)})`);
+  }
+
+  console.log('\nserver: bulk reads the observatory route makes');
+
+  let fullRows: any[] = [];
+  await test(`allTagged() reads all ${N.toLocaleString()} rows (lean observatory columns)`, () => {
+    const { out, ms } = timed('allTagged lean scan', () => db.allTagged());
+    fullRows = out;
+    assert.equal(out.length, N);
+    const analysed = out.filter((t: any) => t.bpm != null);
+    assert.ok(analysed.length > N * 0.5, 'analysed rows present');
+    // lean contract: derived scalars are present, the fat blobs are NOT.
+    // (The pre-lean full-blob rowToTrack scan measured ~15 s at 200k here.)
+    assert.ok(analysed.every((t: any) => t.paceMean != null && t.vocal != null), 'paceMean/vocal derived');
+    assert.ok(!('beats' in (analysed[0] as any)), 'fat blobs never leave the db layer');
+    assert.ok(ms < 20_000, `lean scan under 20 s (took ${ms.toFixed(0)} ms)`);
+  });
+
+  await test('allTaggedSampled(25k) — the default cap a 200k library actually serves', () => {
+    const { out, ms } = timed('stratified sample 25k', () => db.allTaggedSampled(25_000, N));
+    // +1-min-per-genre drift is allowed; the route slices to max after filtering
+    assert.ok(out.length >= Math.min(25_000, N) * 0.95 && out.length <= 25_000 + GENRES.length, `~25k rows (got ${out.length})`);
+    // The pre-thin-window form (windowing over t.*) measured ~98 s at 200k.
+    assert.ok(ms < 15_000, `sample under 15 s (took ${ms.toFixed(0)} ms)`);
+    // proportionality: the biggest genre's share in the sample tracks its share in the library
+    const share = (rows: any[], g: string) => rows.filter((t) => t.genre === g).length / rows.length;
+    const byGenre = new Map<string, number>();
+    for (const t of fullRows) byGenre.set(t.genre, (byGenre.get(t.genre) || 0) + 1);
+    const top = [...byGenre.entries()].sort((a, b) => b[1] - a[1])[0]![0];
+    assert.ok(Math.abs(share(out, top) - share(fullRows, top)) < 0.02, 'stratified sample preserves genre shares');
+    // stability: same inputs → same rows
+    const again = db.allTaggedSampled(25_000, N);
+    assert.deepEqual(again.map((t: any) => t.id).slice(0, 100), out.map((t: any) => t.id).slice(0, 100));
+  });
+
+  await test('allTaggedSampled(100k) — the UI hardMax', () => {
+    const { out, ms } = timed('stratified sample 100k', () => db.allTaggedSampled(100_000, N));
+    assert.ok(out.length >= Math.min(100_000, N) * 0.95, `~100k rows (got ${out.length})`);
+    assert.ok(ms < 20_000, `sample under 20 s (took ${ms.toFixed(0)} ms)`);
+  });
+
+  await test('stats() — the 7-scan tally block (TTL-cached 5 s)', () => {
+    const { ms } = timed('stats cold', () => db.stats());
+    const warm = timed('stats warm (cache)', () => db.stats());
+    assert.ok(ms < 30_000, `cold stats under 30 s (took ${ms.toFixed(0)} ms)`);
+    // Pins the cache-stamp fix: computeStats() can take longer than the TTL on
+    // a huge library, so a start-of-compute stamp made every call a miss.
+    assert.ok(warm.ms < 1_000, `warm stats served from cache (took ${warm.ms.toFixed(0)} ms)`);
+  });
+
+  console.log('\nserver: payload build (synchronous on the controller event loop)');
+
+  for (const cap of [25_000, 100_000, N]) {
+    if (cap > N) continue;
+    await test(`project + stringify ${cap.toLocaleString()} rows`, () => {
+      const rows = cap === N ? fullRows : fullRows.slice(0, cap);
+      const { out: projected, ms: projMs } = timed('row projection', () => projectRows(rows));
+      const { out: json, ms: strMs } = timed('JSON.stringify', () => JSON.stringify({ tracks: projected }));
+      const { out: gz, ms: gzMs } = timed('gzip (Caddy does this per request)', () => gzipSync(json));
+      console.log(`      payload: ${mb(json.length)} raw → ${mb(gz.length)} gzipped`);
+      assert.ok(projMs + strMs < 30_000, `projection+stringify under 30 s (took ${(projMs + strMs).toFixed(0)} ms)`);
+      assert.ok(gzMs < 60_000, 'gzip sane');
+    });
+  }
+
+  console.log('\nserver: sound-map projection support');
+
+  await test(`allAudioVectors() at ${AUDIO_N.toLocaleString()} (the UMAP child's input)`, () => {
+    const { out, ms } = timed('load Float32 vectors', () => db.allAudioVectors());
+    assert.equal(out.length, AUDIO_N);
+    // Working-set arithmetic for the projection child (rss deltas are too
+    // GC-noisy to trust): Float32 storage is n·dim·4 B; umap-js consumes
+    // number[][], which inflates every float to an 8-byte double inside a
+    // pointer-holding JS array (~×3 with headers) — all resident at once,
+    // BEFORE UMAP's own KNN graph and optimisation state.
+    const f32 = N * AUDIO_DIM * 4;
+    console.log(`      at ${N.toLocaleString()}: ~${mb(f32)} Float32 + ~${mb(f32 * 3)} as number[][] before UMAP's graph`);
+    assert.ok(ms < 30_000 * (AUDIO_N / 50_000 + 0.5), `vector load sane (took ${ms.toFixed(0)} ms)`);
+  });
+
+  await test(`setMapCoordsBulk(${N.toLocaleString()}) — the projection child's final transaction`, () => {
+    const coords = fullRows.map((t: any, i: number) => ({ id: t.id, x: (i % 1000) / 1000, y: ((i * 7) % 1000) / 1000 }));
+    const { ms } = timed('bulk coord write', () => db.setMapCoordsBulk(coords));
+    assert.equal(db.mapCoordsCount(), N);
+    assert.ok(ms < 180_000, `bulk write under 3 min (took ${ms.toFixed(0)} ms)`);
+  });
+
+  console.log('\nclient: pure layout pipeline (imported from web/components/observatory/data.ts)');
+
+  // Rebuild the client's RawTrack view from the projected rows — exactly what
+  // useObservatory feeds layoutTracks after JSON.parse.
+  const rawTracks: RawTrack[] = projectRows(fullRows) as unknown as RawTrack[];
+
+  let soundLaid: ReturnType<typeof layoutTracks> | null = null;
+  await test(`layoutTracks(${N.toLocaleString()}) — sound-map mode (70% mapped)`, () => {
+    const { out, ms } = timed('layout (sound map)', () => layoutTracks(rawTracks));
+    soundLaid = out;
+    assert.equal(out.tracks.length, N);
+    assert.ok(out.soundMap, 'sound-map placement engaged at 70% coverage');
+    for (const t of out.tracks.slice(0, 5_000)) {
+      assert.ok(t.x > -400 && t.x < 1400 && t.y > -400 && t.y < 1400, 'coords near the disc');
+    }
+    assert.ok(ms < 20_000, `layout under 20 s (took ${ms.toFixed(0)} ms)`);
+  });
+
+  await test(`layoutTracks(${N.toLocaleString()}) — genre-cluster fallback (0% mapped)`, () => {
+    const stripped = rawTracks.map((t) => ({ ...t, mapX: null, mapY: null }));
+    const { out, ms } = timed('layout (genre clusters)', () => layoutTracks(stripped));
+    assert.equal(out.tracks.length, N);
+    assert.ok(!out.soundMap);
+    assert.ok(ms < 20_000, `layout under 20 s (took ${ms.toFixed(0)} ms)`);
+  });
+
+  await test(`buildSynapseLinks(${N.toLocaleString()}) — spatial-grid nearest neighbour`, () => {
+    const { out, ms } = timed('synapse links', () => buildSynapseLinks(soundLaid!.tracks));
+    assert.ok(out.length > 0 && out.length <= N, `sane link count (got ${out.length.toLocaleString()})`);
+    for (const [a, b] of out.slice(0, 2_000)) {
+      assert.ok(a >= 0 && b < N && a < b, 'ordered in-range index pairs');
+    }
+    assert.ok(ms < 20_000, `links under 20 s (took ${ms.toFixed(0)} ms)`);
+  });
+
+  db.close();
+  raw.close();
+  rmSync(stateDir, { recursive: true, force: true });
+
+  if (failures > 0) {
+    console.error(`\n${failures} test(s) failed`);
+    process.exit(1);
+  }
+  console.log('\nall observatory scale tests passed');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -1690,17 +1690,84 @@ export function filter(opts: FilterOpts = {}): { total: number; rows: TrackRecor
   return { total, rows: rows.map(rowToTrack) };
 }
 
-// Every tagged track, full record, in one read — the bulk source for the
-// Library Observatory map (which needs all nodes at once, not a paged window
-// like filter()). Ordered by id for a stable layout seed across loads. `limit`
-// caps a pathologically large library; the route stamps a `truncated` flag when
-// it's hit. Deliberately separate from filter() so the observatory's "load
-// everything" contract can't be confused with the admin browse pager's 200 cap.
-export function allTagged(limit?: number): TrackRecord[] {
+// Lean row shape for the Library Observatory bulk endpoint — exactly the
+// fields the map / tooltip / filters / stat panels consume, and nothing else.
+// The full TrackRecord parse (rowToTrack) JSON-parses every acoustic blob —
+// beats_json alone is hundreds of floats per analysed row — which at 200k
+// tracks turned the bulk read into a ~15 s synchronous event-loop stall for a
+// payload that only needs a pace MEAN and a vocal PRESENCE flag. Same lesson
+// as getTrackLite (#723), applied to the bulk path.
+export interface ObservatoryTrackRow {
+  id: string;
+  title: string | null;
+  artist: string | null;
+  album: string | null;
+  year: number | null;
+  genre: string | null;
+  durationSec: number | null;
+  moods: string[];
+  energy: string | null;
+  source: string | null;
+  confidence: number | null;
+  bpm: number | null;
+  musicalKey: string | null;
+  analysisConfidence: number | null;
+  loudnessLufs: number | null;
+  paceMean: number | null;
+  vocal: 'vocal' | 'instrumental' | null;
+  mapX: number | null;
+  mapY: number | null;
+}
+
+const OBSERVATORY_COLS = `id, title, artist, album, year, genre, duration_sec,
+  moods, energy, source, confidence, bpm, musical_key, analysis_confidence,
+  loudness_lufs, pace_json, vocal_ranges_json, map_x, map_y`;
+
+function rowToObservatory(row: any): ObservatoryTrackRow {
+  // pace_json is a short array (~14 spans) — the mean is cheap. The fat blobs
+  // (beats/bars/structure/key ranges) are never selected, let alone parsed.
+  let paceMean: number | null = null;
+  if (row.pace_json) {
+    const spans = parsePaceSpans(row.pace_json);
+    if (spans && spans.length) paceMean = spans.reduce((a, s) => a + s.value, 0) / spans.length;
+  }
+  return {
+    id: row.id,
+    title: row.title,
+    artist: row.artist,
+    album: row.album,
+    year: row.year,
+    genre: row.genre,
+    durationSec: row.duration_sec,
+    moods: row.moods ? safeParseArray(row.moods) : [],
+    energy: row.energy ?? null,
+    source: row.source ?? null,
+    confidence: row.confidence,
+    bpm: row.bpm ?? null,
+    musicalKey: row.musical_key ?? null,
+    analysisConfidence: row.analysis_confidence ?? null,
+    loudnessLufs: row.loudness_lufs ?? null,
+    paceMean,
+    // Tri-state without parsing the spans: NULL column = vocals not analysed,
+    // '[]' = analysed instrumental, anything else = vocal ranges present.
+    vocal: row.vocal_ranges_json == null ? null : row.vocal_ranges_json === '[]' ? 'instrumental' : 'vocal',
+    mapX: row.map_x ?? null,
+    mapY: row.map_y ?? null,
+  };
+}
+
+// Every tagged track, lean observatory row, in one read — the bulk source for
+// the Library Observatory map (which needs all nodes at once, not a paged
+// window like filter()). Ordered by id for a stable layout seed across loads.
+// `limit` caps a pathologically large library; the route stamps a `truncated`
+// flag when it's hit. Deliberately separate from filter() so the observatory's
+// "load everything" contract can't be confused with the admin browse pager's
+// 200 cap.
+export function allTagged(limit?: number): ObservatoryTrackRow[] {
   const sql =
-    `SELECT * FROM tracks WHERE ${SQL_HAS_MOODS} ORDER BY id` +
+    `SELECT ${OBSERVATORY_COLS} FROM tracks WHERE ${SQL_HAS_MOODS} ORDER BY id` +
     (limit && limit > 0 ? ` LIMIT ${Math.floor(limit)}` : '');
-  return (requireDb().prepare(sql).all() as any[]).map(rowToTrack);
+  return (requireDb().prepare(sql).all() as any[]).map(rowToObservatory);
 }
 
 // A *stratified* sample of the tagged library, ~`max` rows, proportional per
@@ -1711,22 +1778,30 @@ export function allTagged(limit?: number): TrackRecord[] {
 // rows of that genre by id are taken. Stable across loads (ordered by id), so
 // the map layout doesn't reshuffle on refresh. The +1-min-per-genre means the
 // total can drift a little over `max`; the caller slices to `max`.
-export function allTaggedSampled(max: number, totalTagged: number): TrackRecord[] {
+//
+// The window functions deliberately run over (id, genre) ONLY, with the full
+// rows joined back afterwards: windowing over `t.*` pushes every fat acoustic
+// blob through SQLite's partition sorter — at 200k tracks that was ~98 s of
+// synchronous scan for a 25k sample; the thin-window + join-back form is ~1 s.
+export function allTaggedSampled(max: number, totalTagged: number): ObservatoryTrackRow[] {
   const m = Math.floor(max);
   const total = Math.floor(totalTagged);
   if (m <= 0 || total <= 0) return [];
   const sql = `
-    SELECT * FROM (
-      SELECT t.*,
-        ROW_NUMBER() OVER (PARTITION BY genre ORDER BY id) AS __rn,
-        COUNT(*)     OVER (PARTITION BY genre)             AS __gc
-      FROM tracks t
-      WHERE ${SQL_HAS_MOODS}
+    WITH picked(id) AS (
+      SELECT id FROM (
+        SELECT id, genre,
+          ROW_NUMBER() OVER (PARTITION BY genre ORDER BY id) AS __rn,
+          COUNT(*)     OVER (PARTITION BY genre)             AS __gc
+        FROM tracks
+        WHERE ${SQL_HAS_MOODS}
+      )
+      WHERE __rn <= MAX(1, CAST(ROUND(__gc * 1.0 * ? / ?) AS INTEGER))
     )
-    WHERE __rn <= MAX(1, CAST(ROUND(__gc * 1.0 * ? / ?) AS INTEGER))
+    SELECT ${OBSERVATORY_COLS} FROM tracks JOIN picked USING (id)
     ORDER BY id
   `;
-  return (requireDb().prepare(sql).all(m, total) as any[]).map(rowToTrack);
+  return (requireDb().prepare(sql).all(m, total) as any[]).map(rowToObservatory);
 }
 
 // ---------------------------------------------------------------------------
@@ -1754,7 +1829,11 @@ export function stats(): LibraryStats {
   const now = Date.now();
   if (statsCache && now - statsCache.at < STATS_TTL_MS) return statsCache.value;
   const value = computeStats();
-  statsCache = { at: now, value };
+  // Stamp AFTER the compute: computeStats() itself can exceed the TTL on a
+  // very large library (≈15 s at 200k tracks), and a start-of-compute stamp
+  // would mean the entry is already expired the moment it's stored — every
+  // call recomputes, which is exactly what the cache exists to prevent.
+  statsCache = { at: Date.now(), value };
   return value;
 }
 

--- a/controller/src/routes/library.ts
+++ b/controller/src/routes/library.ts
@@ -142,8 +142,6 @@ const OBSERVATORY_HARD_MAX = Math.max(OBSERVATORY_DEFAULT_MAX, Number(process.en
 router.get('/library/observatory', requireAdmin, async (req, res) => {
   try {
     await library.load();
-    const stats = library.stats();
-    const total = stats.total;
     const requested = Number(req.query.max);
     const max = Math.min(
       OBSERVATORY_HARD_MAX,
@@ -155,6 +153,8 @@ router.get('/library/observatory', requireAdmin, async (req, res) => {
     // skip the (multi-MB at high caps) body AND the row scan that builds it.
     // The projection-running flag rides in the token too — it flips without a
     // DB write, and a 304 must not hide "job in flight" from the UI.
+    // Checked BEFORE stats(): computeStats() is itself a multi-second scan on
+    // a very large library, and a revalidation hit must not pay for it.
     const etag = `W/"obs-${db.changeToken()}-${max}-${mapProjection.projectionStatus().running ? 1 : 0}"`;
     res.set('ETag', etag);
     res.set('Cache-Control', 'private, no-cache');
@@ -163,6 +163,8 @@ router.get('/library/observatory', requireAdmin, async (req, res) => {
       return res.status(304).end();
     }
 
+    const stats = library.stats();
+    const total = stats.total;
     const sampled = total > max;
     const all = sampled ? db.allTaggedSampled(max, total) : db.allTagged();
     const truncated = sampled;
@@ -187,9 +189,10 @@ router.get('/library/observatory', requireAdmin, async (req, res) => {
         // Cheap acoustic scalars for the Observatory's colour-by + aggregate
         // panels. The full curves/ranges stay on the per-track dossier endpoint.
         loudnessLufs: t.loudnessLufs,
-        paceMean: library.paceMeanOf(t.pace),
-        // Tri-state: 'vocal' | 'instrumental' | null (not analysed for vocals).
-        vocal: t.vocalRanges == null ? null : t.vocalRanges.length ? 'vocal' : 'instrumental',
+        // paceMean + tri-state vocal are computed in the lean bulk read
+        // (rowToObservatory) — the fat acoustic blobs never leave SQLite.
+        paceMean: t.paceMean,
+        vocal: t.vocal,
         // Sound-map coordinates (UMAP of the CLAP vector, [0,1] per axis).
         // null → the client falls back to its genre-cluster layout.
         mapX: t.mapX,

--- a/controller/src/routes/library.ts
+++ b/controller/src/routes/library.ts
@@ -138,7 +138,11 @@ router.get('/library/genres/related', requireAdmin, async (_req, res) => {
 // (Libraries above ~3k render on the canvas renderer; only small ones keep the
 // animated SVG path.)
 const OBSERVATORY_DEFAULT_MAX = Math.max(500, Number(process.env.OBSERVATORY_MAX) || 25000);
-const OBSERVATORY_HARD_MAX = Math.max(OBSERVATORY_DEFAULT_MAX, Number(process.env.OBSERVATORY_HARD_MAX) || 100000);
+// 200k ceiling is stress-verified (scripts/observatory-scale.test.ts + the
+// browser harness): lean sampled read ~1 s, 75 MB payload (10 MB gzipped),
+// 60 fps render with a ~2 s one-time geometry stall. Operators who want more
+// can raise OBSERVATORY_HARD_MAX — 400k measured workable too (~4 s stall).
+const OBSERVATORY_HARD_MAX = Math.max(OBSERVATORY_DEFAULT_MAX, Number(process.env.OBSERVATORY_HARD_MAX) || 200000);
 router.get('/library/observatory', requireAdmin, async (req, res) => {
   try {
     await library.load();

--- a/web/components/observatory/ObservatoryApp.tsx
+++ b/web/components/observatory/ObservatoryApp.tsx
@@ -66,8 +66,9 @@ function Toggle({ on, onClick, children }: { on: boolean; onClick: () => void; c
 }
 
 // Node-cap ladder offered in the MAP SIZE control, clamped to the server's
-// hardMax. The WebGL galaxy renderer draws the whole ladder comfortably.
-const MAX_LADDER = [2000, 4000, 8000, 10000, 16000, 25000, 50000, 100000];
+// hardMax. The WebGL galaxy renderer draws the whole ladder comfortably —
+// 200k stress-measured at 60 fps (one-time ~2 s geometry stall on load).
+const MAX_LADDER = [2000, 4000, 8000, 10000, 16000, 25000, 50000, 100000, 200000];
 // Display fallback for the MAP SIZE selector before the first load resolves.
 // The real default lives on the server (OBSERVATORY_MAX): with nothing stored
 // we fetch without ?max= and adopt the cap the response reports, so an

--- a/web/components/observatory/data.ts
+++ b/web/components/observatory/data.ts
@@ -458,10 +458,30 @@ export function sourceStyle(source: string | null): SourceStyle {
 }
 
 // ---------------------------------------------------------------------------
-// Synapse links — 1 nearest same-genre neighbour per node, found via a uniform
-// spatial grid (O(n)) instead of the O(n²) scan the SVG layer uses. Returns
-// index pairs into `tracks`. Used by the canvas renderer, where n can be large.
+// Synapse links — 1 nearby same-genre neighbour per node (the nearest within a
+// bounded probe), found via a uniform spatial grid so the whole pass stays
+// O(n) at ANY density. Returns index pairs into `tracks`. Feeds the galaxy's
+// filament LineSegments, where n can be very large.
 // ---------------------------------------------------------------------------
+// Per-track distance-check budget across the 9-cell probe. The grid keeps the
+// scan LOCAL, but not SMALL: when a genre packs thousands of tracks into one
+// cluster the probe degenerates toward O(n·clusterSize) — measured ~18 s of
+// main-thread stall at 400k sound-mapped tracks and ~65 s at 400k on the
+// genre-cluster layout. The links are cosmetic (a hair-thin line to A nearby
+// same-genre node), so past the budget we keep the nearest seen so far:
+// candidates share the track's own ≤64-unit cell neighbourhood, and "nearest
+// of 96 local candidates" is indistinguishable from the true nearest at any
+// density where the budget even engages. Sparse cells never hit it, so small
+// and mid-size libraries link exactly as before.
+const LINK_SCAN_BUDGET = 96;
+// 3×3 probe offsets, own cell first (see the budget note inside the loop).
+const PROBE_ORDER: [number, number][] = [
+  [0, 0],
+  [-1, -1], [-1, 0], [-1, 1],
+  [0, -1], [0, 1],
+  [1, -1], [1, 0], [1, 1],
+];
+
 export function buildSynapseLinks(tracks: ObsTrack[]): [number, number][] {
   const CELL = 64; // ~ the gaussian cluster spread in layoutTracks
   const grid = new Map<string, number[]>();
@@ -482,20 +502,25 @@ export function buildSynapseLinks(tracks: ObsTrack[]): [number, number][] {
     const gy = Math.floor(t.y / CELL);
     let best = -1;
     let bd = Infinity;
-    for (let dx = -1; dx <= 1; dx++) {
-      for (let dy = -1; dy <= 1; dy++) {
-        const cell = grid.get(`${g}|${gx + dx}|${gy + dy}`);
-        if (!cell) continue;
-        for (const j of cell) {
-          if (j === i) continue;
-          const ddx = t.x - tracks[j]!.x;
-          const ddy = t.y - tracks[j]!.y;
-          const d = ddx * ddx + ddy * ddy;
-          if (d < bd) {
-            bd = d;
-            best = j;
-          }
+    let budget = LINK_SCAN_BUDGET;
+    // Own cell first, ring after: when the budget engages the candidates must
+    // come from the track's immediate neighbourhood, or every link in a dense
+    // cluster spans a whole cell diagonal (measured p95 8u → 76u when the
+    // probe started at the corner cell). Own-cell-first also keeps picks
+    // mutual, so the a<b dedup below still collapses most pairs.
+    probe: for (const [dx, dy] of PROBE_ORDER) {
+      const cell = grid.get(`${g}|${gx + dx}|${gy + dy}`);
+      if (!cell) continue;
+      for (const j of cell) {
+        if (j === i) continue;
+        const ddx = t.x - tracks[j]!.x;
+        const ddy = t.y - tracks[j]!.y;
+        const d = ddx * ddx + ddy * ddy;
+        if (d < bd) {
+          bd = d;
+          best = j;
         }
+        if (--budget <= 0) break probe;
       }
     }
     if (best >= 0) {

--- a/web/scripts/observatory-stress.mjs
+++ b/web/scripts/observatory-stress.mjs
@@ -1,0 +1,388 @@
+#!/usr/bin/env node
+/* ============================================================================
+   SUB/WAVE — Library Observatory · browser stress harness (#957)
+
+   Drives the REAL /observatory page (galaxy renderer, WebGL) against
+   synthetic libraries of arbitrary size — 200k+ tracks — with the entire
+   controller API mocked at the network layer, and measures what an operator
+   would feel:
+
+     · payload size + fetch→parse→layoutTracks→first-commit time
+     · main-thread long tasks during load / zoom / pan / filter / select
+     · frame cadence (rAF deltas) while zooming and panning
+     · hover-pick + node-select + filter-toggle main-thread latency
+     · label-layer + SVG-overlay DOM node counts (they must stay O(1)-bounded
+       regardless of N — that's the PR's design contract)
+     · JS heap after load
+
+   This is a dev tool, not part of any suite: it needs a production build of
+   web/ running (dev-mode React double-renders and skews everything), plus the
+   `playwright` npm package (NOT a repo dependency — install ad hoc).
+
+   Usage:
+     cd web
+     npm run build && npx next start -p 7799 &
+     npm i --no-save playwright        # or: export PLAYWRIGHT_DIR=/path/with/node_modules
+     node scripts/observatory-stress.mjs --sizes 25000,100000,200000 \
+         --url http://localhost:7799 [--dpr 1] [--shot /tmp/galaxy.png] [--out results.json]
+
+   Frame-time caveat: headless Chromium renders WebGL on SwiftShader (software
+   GL) unless a GPU is exposed — the harness prints the GL renderer string with
+   the results. SwiftShader numbers are a worst-case floor for the GPU-bound
+   metrics (frame cadence during zoom/pan); the main-thread metrics (parse,
+   layout, long tasks, pick/filter/select latency) are hardware-honest.
+   ============================================================================ */
+
+import { createRequire } from 'node:module';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const req = createRequire(import.meta.url);
+function loadPlaywright() {
+  try {
+    return req('playwright');
+  } catch {
+    const dir = process.env.PLAYWRIGHT_DIR;
+    if (!dir) {
+      console.error('playwright is not installed here. Run `npm i --no-save playwright`');
+      console.error('or point PLAYWRIGHT_DIR at a directory whose node_modules has it.');
+      process.exit(1);
+    }
+    return createRequire(join(dir, 'package.json'))('playwright');
+  }
+}
+
+// ---- args -------------------------------------------------------------------
+const args = Object.fromEntries(
+  process.argv.slice(2).map((a, i, all) => (a.startsWith('--') ? [a.slice(2), all[i + 1] ?? ''] : null)).filter(Boolean),
+);
+const SIZES = (args.sizes || '25000,100000,200000').split(',').map((s) => Number(s.trim())).filter((n) => n > 0);
+const BASE = args.url || 'http://localhost:7799';
+const DPR = Number(args.dpr) || 1;
+const OUT = args.out || null;
+const SHOT = args.shot || null;
+
+// ---- synthetic library (mirrors RawTrack in components/observatory/data.ts) --
+function mulberry32(a) {
+  return function () {
+    a |= 0; a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+const GENRES = Array.from({ length: 120 }, (_, i) => `Genre ${String(i).padStart(3, '0')}`);
+const MOODS = ['hazy', 'reflective', 'calm', 'night', 'rainy', 'romantic', 'energetic', 'driving', 'celebratory', 'melancholy', 'warm', 'cold'];
+const SOURCES = ['llm', 'llm', 'llm', 'propagated', 'propagated', 'manual', 'uncertain-llm', 'legacy-v1'];
+const ENERGIES = ['low', 'medium', 'high'];
+
+function buildPayload(n) {
+  const rng = mulberry32(0x0b5e55 ^ n);
+  const tracks = new Array(n);
+  const byGenre = {}; const byMood = {}; const byEnergy = {}; const bySource = {};
+  for (let i = 0; i < n; i++) {
+    const genre = GENRES[Math.floor(rng() * rng() * GENRES.length)];
+    const analysed = rng() < 0.6;
+    const mapped = rng() < 0.7; // engages the sound-map layout, like a projected library
+    const energy = ENERGIES[Math.floor(rng() * 3)];
+    const source = SOURCES[Math.floor(rng() * SOURCES.length)];
+    const moods = Array.from({ length: 1 + Math.floor(rng() * 3) }, () => MOODS[Math.floor(rng() * MOODS.length)]);
+    byGenre[genre] = (byGenre[genre] || 0) + 1;
+    byEnergy[energy] = (byEnergy[energy] || 0) + 1;
+    bySource[source] = (bySource[source] || 0) + 1;
+    for (const m of moods) byMood[m] = (byMood[m] || 0) + 1;
+    tracks[i] = {
+      id: `trk-${String(i).padStart(7, '0')}`,
+      title: `Track ${i} of the Long Tail`,
+      artist: `Artist ${i % 40000}`,
+      album: `Album ${i % 60000}`,
+      year: 1970 + (i % 55),
+      genre,
+      durationSec: 120 + Math.floor(rng() * 300),
+      moods,
+      energy,
+      source,
+      confidence: Math.round(rng() * 100) / 100,
+      bpm: analysed ? Math.round((60 + rng() * 120) * 10) / 10 : null,
+      musicalKey: analysed ? `${1 + Math.floor(rng() * 12)}${rng() < 0.5 ? 'A' : 'B'}` : null,
+      analysisConfidence: analysed ? Math.round((0.5 + rng() * 0.5) * 100) / 100 : null,
+      loudnessLufs: analysed ? Math.round((-24 + rng() * 16) * 10) / 10 : null,
+      paceMean: analysed ? Math.round(rng() * 100) / 100 : null,
+      vocal: analysed ? (rng() < 0.7 ? 'vocal' : 'instrumental') : null,
+      mapX: mapped ? rng() : null,
+      mapY: mapped ? rng() : null,
+    };
+  }
+  return JSON.stringify({
+    tracks,
+    truncated: false,
+    sampled: false,
+    max: n,
+    defaultMax: 25000,
+    hardMax: Math.max(200000, n),
+    mapProjection: { running: false, startedAt: null, lastLog: [], meta: null, audioVectors: 0, stale: false },
+    moodVocab: MOODS,
+    stats: {
+      total: n, distinctArtists: Math.min(n, 40000), byMood, byEnergy, byGenre, bySource,
+      withEmbedding: n, withAudioEmbedding: Math.round(n * 0.7), updatedAt: new Date().toISOString(),
+    },
+  });
+}
+
+const detailPayload = (id) =>
+  JSON.stringify({
+    track: {
+      id, title: 'Detail', artist: 'A', album: 'B', year: 2000, genre: 'Genre 000', durationSec: 200,
+      moods: ['calm'], energy: 'low', source: 'llm', confidence: 0.9, taggerVersion: 3, model: 'mock',
+      taggedAt: null, lastfmTags: null, lyricExcerpt: null, bpm: 120, musicalKey: '4A', introMs: 4000,
+      analysisConfidence: 0.8, analysisVersion: 1, loudnessLufs: -12, peakDb: -1, structure: null,
+      vocalRanges: null, pace: null, keyRanges: null, audioMoods: [], audioMoodScores: null, outro: null,
+    },
+    textEmbedding: null,
+    audioEmbedding: null,
+    mixNext: [],
+  });
+
+// ---- in-page instrumentation --------------------------------------------------
+const INIT_SCRIPT = `
+  localStorage.setItem('subwave_admin_auth', btoa('stress:stress'));
+  window.__lt = [];
+  try {
+    new PerformanceObserver((list) => {
+      for (const e of list.getEntries()) window.__lt.push({ start: e.startTime, dur: e.duration });
+    }).observe({ entryTypes: ['longtask'] });
+  } catch {}
+  window.__frames = null;
+  window.__frameLoop = () => {
+    const rec = { deltas: [], last: performance.now(), on: true };
+    window.__frames = rec;
+    const tick = (t) => {
+      if (!rec.on) return;
+      rec.deltas.push(t - rec.last);
+      rec.last = t;
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  };
+  window.__frameStop = () => { if (window.__frames) window.__frames.on = false; return window.__frames ? window.__frames.deltas.slice(1) : []; };
+`;
+
+const stats = (arr) => {
+  if (!arr.length) return { n: 0, avg: 0, p95: 0, max: 0 };
+  const s = [...arr].sort((a, b) => a - b);
+  return {
+    n: arr.length,
+    avg: arr.reduce((a, b) => a + b, 0) / arr.length,
+    p95: s[Math.floor(s.length * 0.95)],
+    max: s[s.length - 1],
+  };
+};
+const fmt = (x) => (x >= 100 ? x.toFixed(0) : x.toFixed(1));
+
+const readLongTasks = (page) => page.evaluate(() => { const l = window.__lt; window.__lt = []; return l; });
+
+// Double-rAF after an interaction ≈ time until the main thread has produced a
+// frame again — the user-felt latency of the synchronous work the action kicked off.
+const settleLatency = (page) =>
+  page.evaluate(
+    () =>
+      new Promise((res) => {
+        const t0 = performance.now();
+        requestAnimationFrame(() => requestAnimationFrame(() => res(performance.now() - t0)));
+      }),
+  );
+
+async function runSize(browser, n, payload) {
+  const context = await browser.newContext({
+    viewport: { width: 1920, height: 1080 },
+    deviceScaleFactor: DPR,
+  });
+  await context.addInitScript(INIT_SCRIPT);
+
+  // Whole backend mocked at the network layer; kill external requests.
+  await context.route('**/*', async (route) => {
+    const url = route.request().url();
+    if (!url.startsWith(BASE) && !url.startsWith('data:')) return route.abort();
+    if (/\/api\/library\/observatory\/track\//.test(url)) {
+      const id = decodeURIComponent(url.split('/track/')[1].split('?')[0]);
+      return route.fulfill({ contentType: 'application/json', body: detailPayload(id) });
+    }
+    if (/\/api\/library\/observatory(\?|$)/.test(url)) {
+      return route.fulfill({ contentType: 'application/json', body: payload });
+    }
+    if (/\/api\//.test(url)) return route.fulfill({ contentType: 'application/json', body: '{}' });
+    return route.continue();
+  });
+
+  const page = await context.newPage();
+  const r = { n, payloadMB: payload.length / 1024 / 1024 };
+  const errors = [];
+  page.on('pageerror', (e) => errors.push(String(e)));
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+
+  // ---- load ------------------------------------------------------------------
+  const t0 = Date.now();
+  await page.goto(`${BASE}/observatory`, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(
+    (want) => document.querySelector('.obs-stat')?.textContent?.replace(/\D/g, '') === String(want),
+    n,
+    { timeout: 180_000 },
+  );
+  r.loadTotalMs = Date.now() - t0;
+  // split out network/parse/layout using the page's own resource timing
+  r.phases = await page.evaluate(() => {
+    const e = performance.getEntriesByType('resource').find((x) => x.name.includes('/api/library/observatory'));
+    return e ? { fetchMs: e.responseEnd - e.startTime, sinceResponseMs: performance.now() - e.responseEnd } : null;
+  });
+  await page.waitForSelector('.cmap-galaxy canvas', { timeout: 30_000 });
+  await page.waitForTimeout(1600); // let the 1.07s GPU entrance play out
+  r.loadLongTasks = stats((await readLongTasks(page)).map((t) => t.dur));
+
+  r.gl = await page.evaluate(() => {
+    try {
+      const c = document.createElement('canvas');
+      const gl = c.getContext('webgl2') || c.getContext('webgl');
+      const ext = gl.getExtension('WEBGL_debug_renderer_info');
+      return ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER);
+    } catch { return 'unavailable'; }
+  });
+
+  const box = await (await page.$('.cmap-galaxy canvas')).boundingBox();
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+
+  // ---- zoom (wheel ×10 in) ------------------------------------------------------
+  await page.mouse.move(cx, cy);
+  await readLongTasks(page);
+  await page.evaluate(() => window.__frameLoop());
+  for (let i = 0; i < 10; i++) {
+    await page.mouse.wheel(0, -240);
+    await page.waitForTimeout(90);
+  }
+  await page.waitForTimeout(400); // includes the 140ms-debounced label recompute
+  r.zoomFrames = stats(await page.evaluate(() => window.__frameStop()));
+  r.zoomLongTasks = stats((await readLongTasks(page)).map((t) => t.dur));
+  r.labelCount = await page.evaluate(() => document.querySelectorAll('.cmap-tlabel').length);
+
+  // ---- pan (drag) ---------------------------------------------------------------
+  await page.evaluate(() => window.__frameLoop());
+  await page.mouse.move(cx, cy);
+  await page.mouse.down();
+  for (let i = 1; i <= 24; i++) {
+    await page.mouse.move(cx + i * 18, cy + Math.sin(i / 3) * 60, { steps: 1 });
+    await page.waitForTimeout(16);
+  }
+  await page.mouse.up();
+  r.panFrames = stats(await page.evaluate(() => window.__frameStop()));
+  r.panLongTasks = stats((await readLongTasks(page)).map((t) => t.dur));
+
+  // ---- hover storm (spatial-grid picking on every move) --------------------------
+  await readLongTasks(page);
+  const hoverT0 = Date.now();
+  for (let i = 0; i < 30; i++) {
+    await page.mouse.move(box.x + 60 + (i * (box.width - 120)) / 30, cy + ((i % 5) - 2) * 40);
+  }
+  r.hoverMs = Date.now() - hoverT0;
+  r.hoverSettle = await settleLatency(page);
+  r.hoverLongTasks = stats((await readLongTasks(page)).map((t) => t.dur));
+
+  // ---- select (pick + full attribute rewrite + GPU re-upload) --------------------
+  await readLongTasks(page);
+  await page.mouse.click(cx, cy);
+  r.selectSettle = await settleLatency(page);
+  await page.waitForTimeout(250);
+  r.selectLongTasks = stats((await readLongTasks(page)).map((t) => t.dur));
+  r.overlayNodes = await page.evaluate(() => document.querySelectorAll('.cmap-svg *').length);
+
+  if (SHOT && n === Math.max(...SIZES)) {
+    await page.screenshot({ path: SHOT });
+  }
+
+  // ---- filter toggle (matched rebuild + matchSet + attribute pass + stats panel) --
+  await page.mouse.click(cx, cy); // deselect back to StatsView
+  await page.waitForTimeout(200);
+  await readLongTasks(page);
+  await page.getByRole('button', { name: 'LOW', exact: true }).click();
+  r.filterSettle = await settleLatency(page);
+  await page.waitForTimeout(300);
+  r.filterLongTasks = stats((await readLongTasks(page)).map((t) => t.dur));
+
+  // ---- colour-by switch (attribute pass alone) ------------------------------------
+  await readLongTasks(page);
+  await page.getByRole('button', { name: 'SOURCE', exact: true }).click();
+  r.colorBySettle = await settleLatency(page);
+  await page.waitForTimeout(250);
+  r.colorByLongTasks = stats((await readLongTasks(page)).map((t) => t.dur));
+
+  // ---- search keystroke (debounced 150ms, then full-text scan) ---------------------
+  await readLongTasks(page);
+  await page.locator('.rail-search input').fill('long tail');
+  await page.waitForTimeout(450);
+  r.searchLongTasks = stats((await readLongTasks(page)).map((t) => t.dur));
+
+  r.domNodes = await page.evaluate(() => document.querySelectorAll('*').length);
+  r.heapMB = await page.evaluate(() => (performance.memory ? performance.memory.usedJSHeapSize / 1048576 : null));
+  r.errors = errors;
+
+  await context.close();
+  return r;
+}
+
+function printResult(r) {
+  console.log(`\n■ ${r.n.toLocaleString()} tracks — payload ${r.payloadMB.toFixed(1)} MB, GL: ${r.gl}`);
+  if (r.phases) {
+    console.log(`  load: ${r.loadTotalMs} ms total (fetch ${fmt(r.phases.fetchMs)} ms; parse+layout+commit ≤ ${fmt(r.phases.sinceResponseMs)} ms after response)`);
+  } else {
+    console.log(`  load: ${r.loadTotalMs} ms total`);
+  }
+  console.log(`  load long-tasks: n=${r.loadLongTasks.n} max ${fmt(r.loadLongTasks.max)} ms`);
+  console.log(`  zoom frames: avg ${fmt(r.zoomFrames.avg)} ms · p95 ${fmt(r.zoomFrames.p95)} ms · worst ${fmt(r.zoomFrames.max)} ms (long-tasks max ${fmt(r.zoomLongTasks.max)} ms) · labels ${r.labelCount}`);
+  console.log(`  pan frames:  avg ${fmt(r.panFrames.avg)} ms · p95 ${fmt(r.panFrames.p95)} ms · worst ${fmt(r.panFrames.max)} ms`);
+  console.log(`  hover 30 moves: ${r.hoverMs} ms total · settle ${fmt(r.hoverSettle)} ms · long-tasks max ${fmt(r.hoverLongTasks.max)} ms`);
+  console.log(`  select: settle ${fmt(r.selectSettle)} ms · long-tasks max ${fmt(r.selectLongTasks.max)} ms`);
+  console.log(`  filter toggle: settle ${fmt(r.filterSettle)} ms · long-tasks max ${fmt(r.filterLongTasks.max)} ms`);
+  console.log(`  colour-by:     settle ${fmt(r.colorBySettle)} ms · long-tasks max ${fmt(r.colorByLongTasks.max)} ms`);
+  console.log(`  search:        long-tasks max ${fmt(r.searchLongTasks.max)} ms`);
+  console.log(`  DOM nodes total ${r.domNodes} · svg overlay ${r.overlayNodes} · heap ${r.heapMB ? r.heapMB.toFixed(0) + ' MB' : 'n/a'}`);
+  if (r.errors.length) console.log(`  ⚠ page errors: ${[...new Set(r.errors)].slice(0, 5).join(' | ')}`);
+}
+
+async function main() {
+  const { chromium } = loadPlaywright();
+  console.log(`observatory browser stress — sizes: ${SIZES.map((n) => n.toLocaleString()).join(', ')} · DPR ${DPR} · ${BASE}`);
+
+  // Probe that the server is actually up before burning time building payloads.
+  try {
+    const res = await fetch(`${BASE}/observatory`, { method: 'HEAD' });
+    if (!res.ok && res.status !== 405) throw new Error(`status ${res.status}`);
+  } catch (e) {
+    console.error(`cannot reach ${BASE} — start the app first: npm run build && npx next start -p 7799 (${e.message})`);
+    process.exit(1);
+  }
+
+  const browser = await chromium.launch({
+    headless: true,
+    args: ['--enable-gpu', '--ignore-gpu-blocklist', '--enable-precise-memory-info'],
+  });
+
+  const results = [];
+  for (const n of SIZES) {
+    process.stdout.write(`building ${n.toLocaleString()}-track payload… `);
+    const payload = buildPayload(n);
+    console.log(`${(payload.length / 1024 / 1024).toFixed(1)} MB`);
+    const r = await runSize(browser, n, payload);
+    printResult(r);
+    results.push(r);
+  }
+
+  await browser.close();
+  if (OUT) {
+    writeFileSync(OUT, JSON.stringify(results, null, 2));
+    console.log(`\nwrote ${OUT}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/web/scripts/observatory-stress.mjs
+++ b/web/scripts/observatory-stress.mjs
@@ -34,6 +34,7 @@
    ============================================================================ */
 
 import { createRequire } from 'node:module';
+import { createServer } from 'node:http';
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -192,7 +193,30 @@ const settleLatency = (page) =>
       }),
   );
 
+// The bulk payload is served over REAL HTTP from a side server and reached via
+// a redirect, not inlined into route.fulfill: a fulfilled body rides the CDP
+// protocol base64-encoded, and at 400k tracks (~150 MB JSON → ~200 MB message)
+// that kills the tab outright. The redirect turns the request cross-origin, so
+// the browser strips the Authorization header and plain CORS headers suffice.
+const PAYLOAD_PORT = 7798;
+let currentPayload = '';
+function startPayloadServer() {
+  const srv = createServer((req, res) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Headers', '*');
+    res.setHeader('Timing-Allow-Origin', '*');
+    if (req.method === 'OPTIONS') return res.end();
+    res.setHeader('Content-Type', 'application/json');
+    res.end(currentPayload);
+  });
+  return new Promise((resolve, reject) => {
+    srv.on('error', reject);
+    srv.listen(PAYLOAD_PORT, () => resolve(srv));
+  });
+}
+
 async function runSize(browser, n, payload) {
+  currentPayload = payload;
   const context = await browser.newContext({
     viewport: { width: 1920, height: 1080 },
     deviceScaleFactor: DPR,
@@ -202,13 +226,14 @@ async function runSize(browser, n, payload) {
   // Whole backend mocked at the network layer; kill external requests.
   await context.route('**/*', async (route) => {
     const url = route.request().url();
+    if (url.startsWith(`http://localhost:${PAYLOAD_PORT}/`)) return route.continue();
     if (!url.startsWith(BASE) && !url.startsWith('data:')) return route.abort();
     if (/\/api\/library\/observatory\/track\//.test(url)) {
       const id = decodeURIComponent(url.split('/track/')[1].split('?')[0]);
       return route.fulfill({ contentType: 'application/json', body: detailPayload(id) });
     }
     if (/\/api\/library\/observatory(\?|$)/.test(url)) {
-      return route.fulfill({ contentType: 'application/json', body: payload });
+      return route.fulfill({ status: 307, headers: { location: `http://localhost:${PAYLOAD_PORT}/observatory.json` } });
     }
     if (/\/api\//.test(url)) return route.fulfill({ contentType: 'application/json', body: '{}' });
     return route.continue();
@@ -219,6 +244,7 @@ async function runSize(browser, n, payload) {
   const errors = [];
   page.on('pageerror', (e) => errors.push(String(e)));
   page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+  page.on('crash', () => errors.push('PAGE CRASHED (renderer OOM or GPU loss)'));
 
   // ---- load ------------------------------------------------------------------
   const t0 = Date.now();
@@ -231,7 +257,9 @@ async function runSize(browser, n, payload) {
   r.loadTotalMs = Date.now() - t0;
   // split out network/parse/layout using the page's own resource timing
   r.phases = await page.evaluate(() => {
-    const e = performance.getEntriesByType('resource').find((x) => x.name.includes('/api/library/observatory'));
+    const e = performance
+      .getEntriesByType('resource')
+      .find((x) => x.name.includes('/api/library/observatory') || x.name.includes('observatory.json'));
     return e ? { fetchMs: e.responseEnd - e.startTime, sinceResponseMs: performance.now() - e.responseEnd } : null;
   });
   await page.waitForSelector('.cmap-galaxy canvas', { timeout: 30_000 });
@@ -364,6 +392,7 @@ async function main() {
     headless: true,
     args: ['--enable-gpu', '--ignore-gpu-blocklist', '--enable-precise-memory-info'],
   });
+  const payloadSrv = await startPayloadServer();
 
   const results = [];
   for (const n of SIZES) {
@@ -376,6 +405,7 @@ async function main() {
   }
 
   await browser.close();
+  payloadSrv.close();
   if (OUT) {
     writeFileSync(OUT, JSON.stringify(results, null, 2));
     console.log(`\nwrote ${OUT}`);


### PR DESCRIPTION
## What

Stress-tests #957 at the scale some operators actually run (200k+ tracks), and fixes the three server-side walls the tests found. Targets the PR branch so it folds into the galaxy-renderer PR.

## Findings at 200k tracks (before)

All of these ran **synchronously on the controller's event loop** — every listener-facing endpoint (/now-playing, /request) frozen meanwhile:

| call | before | after |
|---|---:|---:|
| `allTaggedSampled(25k)` — the default cap a 200k library serves | **98.3 s** | 0.59 s |
| `allTaggedSampled(100k)` — UI hardMax | **105 s** | 1.1 s |
| `allTagged()` full scan | **14.7 s** | 1.4 s |
| `stats()` repeat call | recomputed every time | 0 ms (cache works) |
| ETag 304 revalidation | paid full `stats()` | O(1) |

## Fixes

- **Thin-window stratified sample**: the window functions ran over `t.*`, pushing every fat acoustic blob (beats/bars/structure JSON) through SQLite's partition sorter. Now windows over `(id, genre)` only and joins the full rows back. ×166.
- **Lean bulk reads**: `allTagged`/`allTaggedSampled` returned full `TrackRecord`s, JSON-parsing every acoustic blob per row for a payload that needs a pace *mean* and a vocal *presence* flag. Both now return a lean `ObservatoryTrackRow` — the fat blobs never leave SQLite. Same lesson as `getTrackLite` (#723), applied to the bulk path.
- **stats() TTL stamp**: the 5 s cache was stamped *before* the compute, so once compute > TTL every call was a miss (15 s each, and the admin panel polls it). Stamped after.
- **ETag before stats()**: a 304 no longer pays the tally scans.

## Tests

- `controller/scripts/observatory-scale.test.ts` (folds into `npm test`, `OBS_SCALE_N` tunable, default 200k): seeds a real better-sqlite3 DB with realistically fat analysed rows; budget-asserts every route call + sample proportionality/stability + payload stringify/gzip + `setMapCoordsBulk` + the client's pure layout pipeline imported from web `data.ts`.
- `web/scripts/observatory-stress.mjs` (standalone Playwright harness, not a repo dep): drives the real `/observatory` page against a mocked API at arbitrary N — load/parse/layout, long tasks, frame cadence, hover/select/filter latency, DOM-bound checks, heap.

## Browser results on the PR branch (real-GPU headless Chromium, AMD 890M, DPR 1)

| N | payload | load | zoom/pan | select | filter | DOM nodes | heap |
|---|---:|---:|---:|---:|---:|---:|---:|
| 25k | 9.3 MB (1.3 gz) | 0.6 s | 60 fps | 26 ms | 17 ms | 667 | 46 MB |
| 100k | 37 MB (5.2 gz) | 1.0 s | 60 fps | 46 ms | 73 ms | 660 | 76 MB |
| 200k | 75 MB (10.3 gz) | 1.8 s | 60 fps (worst 50 ms) | 169 ms | 239 ms | 659 | 208 MB |

The galaxy renderer itself scales beautifully — full 60 fps at 200k GPU points, and the label layer + SVG highlight overlay stay **O(1)** (~660 DOM nodes, 9 SVG elements at every size), which is the PR's design contract holding.

## Known remaining walls (reported, not fixed here)

- **`buildSynapseLinks` at load**: ~4.3 s main-thread stall at 200k (~1.2 s at 100k, negligible at the 25k default) during geometry build. Candidates: skip links above a node threshold (they're nearly invisible under bloom at that density), chunk into idle callbacks, or numeric grid keys.
- **UMAP projection child at 200k**: ~390 MB Float32 → ~1.2 GB as `number[][]` before umap-js builds its KNN graph; extrapolating the in-repo 9k≈4 min data point, hours of CPU. Worth capping projection input (stratified sample, e.g. 50k) and letting unmapped tracks fall to the genre placement the client already handles.
- **`computeStats()`** is still a multi-second scan at 200k when cold; the cache fix makes it survivable, but incremental tallies would be the real fix.

## Verified

- `npm test` — all 25 controller test files pass (scale test included, N=200k).
- `npm run lint` clean in controller + web.
- Browser sweep at 25k/50k/100k/200k: no page errors, screenshots verified.