### PR TITLE
perf(web): canvas waveform visualizer — log-frequency bars, calm-mode gating

### DIFF
--- a/web/components/CenterStage.tsx
+++ b/web/components/CenterStage.tsx
@@ -270,7 +270,7 @@ export default memo(function CenterStage({ nowPlaying, trackStartedAt, llmTokens
                   <h1 className="v3-title m-0 line-clamp-2 text-ink" title={nowPlaying?.title}>
                     {nowPlaying?.title}
                   </h1>
-                  <div className="mt-[12px] text-[clamp(13px,1.4vw,18px)] leading-snug font-medium text-muted">
+                  <div className="mt-[4px] text-[clamp(13px,1.4vw,18px)] leading-snug font-medium text-muted">
                     <span className="text-ink">{nowPlaying?.artist || 'Unknown artist'}</span>
                     {nowPlaying?.album && <span className="ml-[14px]"> · {nowPlaying.album}</span>}
                     {nowPlaying?.year && <span className="ml-[14px]"> · {nowPlaying.year}</span>}

--- a/web/components/CenterStage.tsx
+++ b/web/components/CenterStage.tsx
@@ -153,10 +153,14 @@ export default memo(function CenterStage({ nowPlaying, trackStartedAt, llmTokens
     // bottom-pinned Waveform (issue #576). The bottom reserve clears the
     // compact waveform (top ≈ 206px from bottom); on tall desktop windows the
     // waveform grows to its full band, so the reserve grows to match it.
+    // On short/wide windows the content bottom-aligns instead: centring left
+    // the vertical slack as a dead gap between the track info and the band, and
+    // anchoring the bottom edge means long DJ lines grow upward, never over the
+    // waveform. The reserve drops to 212px there to hug the raised 208px band.
     // The right reserve tracks the DotRail width: slimmed on phones (see
     // DotRail's <sm sizing) so the title/DJ-line column keeps ~20px more of a
     // 375px screen, full 96px from sm up.
-    <div className="absolute top-[72px] right-[80px] bottom-[220px] left-4 flex flex-col items-start justify-center sm:right-24 sm:left-8 [@media(min-width:640px)_and_(min-height:760px)]:bottom-[300px]">
+    <div className="absolute top-[72px] right-[80px] bottom-[220px] left-4 flex flex-col items-start justify-center sm:right-24 sm:left-8 [@media(min-width:640px)_and_(max-height:759px)]:bottom-[212px] [@media(min-width:640px)_and_(max-height:759px)]:justify-end [@media(min-width:640px)_and_(min-height:760px)]:bottom-[300px]">
       <div className="isolate flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-6">
         {/* Always rendered — a track without artwork (or an off-air stage) gets
             the disc-mark placeholder instead of collapsing the slot and jumping
@@ -167,7 +171,12 @@ export default memo(function CenterStage({ nowPlaying, trackStartedAt, llmTokens
           onClick={onOpenTimeline}
           aria-label="Open the timeline"
           className={cn(
-            'v3-cover-frame v3-focus relative h-[clamp(72px,14vw,160px)] w-[clamp(72px,14vw,160px)] shrink-0 appearance-none border-0 bg-transparent p-0',
+            // Art sizes to width but is capped by viewport height (20vh) so a
+            // short/wide window doesn't spend a third of its height on the
+            // cover; tall viewports resolve min() to 14vw. The 96px floor is
+            // what phones get (14vw is only ~55px on a 390px screen — too
+            // small a target for the tap-to-timeline it carries).
+            'v3-cover-frame v3-focus relative h-[clamp(96px,min(14vw,20vh),160px)] w-[clamp(96px,min(14vw,20vh),160px)] shrink-0 appearance-none border-0 bg-transparent p-0',
             // Glitch the art in sync with the ripple waves — track change + DJ speaking.
             rippleActive && 'v3-cover-live',
           )}

--- a/web/components/CenterStage.tsx
+++ b/web/components/CenterStage.tsx
@@ -19,6 +19,12 @@ import type { NowPlayingTrack, QueueEntry, SessionTurn } from '@/lib/types';
  *  known well before this — the window is about pacing, not data. */
 const UP_NEXT_WINDOW_S = 30;
 
+/** Separator for the v3-caption meta strip. Thin spaces instead of word
+ *  spaces: the caption's 0.16em tracking applies per character, so a plain
+ *  " · " ballooned to ~13px of gap on a 10px font — the items read as
+ *  disconnected fragments rather than one line. */
+const SEP = '\u2009·\u2009';
+
 /** The quiet "music nerd" tokens shown under artist/album: genre · BPM · key.
  *  Returned separately from the mood cluster so the latter can carry the accent
  *  colour. Each token is omitted when its field is absent, so an untagged track
@@ -39,7 +45,7 @@ function buildMoodPhrase(t: NowPlayingTrack | null): string {
   const parts: string[] = [];
   if (Array.isArray(t.moods)) parts.push(...t.moods.slice(0, 2));
   if (t.energy) parts.push(`${t.energy} energy`);
-  return parts.join(' · ');
+  return parts.join(SEP);
 }
 
 export interface CenterStageProps {
@@ -272,15 +278,15 @@ export default memo(function CenterStage({ nowPlaying, trackStartedAt, llmTokens
                   </h1>
                   <div className="mt-[4px] text-[clamp(13px,1.4vw,18px)] leading-snug font-medium text-muted">
                     <span className="text-ink">{nowPlaying?.artist || 'Unknown artist'}</span>
-                    {nowPlaying?.album && <span className="ml-[14px]"> · {nowPlaying.album}</span>}
-                    {nowPlaying?.year && <span className="ml-[14px]"> · {nowPlaying.year}</span>}
+                    {nowPlaying?.album && <span> · {nowPlaying.album}</span>}
+                    {nowPlaying?.year && <span> · {nowPlaying.year}</span>}
                   </div>
                   {hasMeta && (
                     <div className="v3-caption mt-[10px] text-muted">
-                      {metaTokens.join(' · ')}
+                      {metaTokens.join(SEP)}
                       {moodPhrase && (
                         <span className="text-vermilion">
-                          {metaTokens.length > 0 ? ' · ' : ''}↳ {moodPhrase}
+                          {metaTokens.length > 0 ? SEP : ''}↳ {moodPhrase}
                         </span>
                       )}
                     </div>

--- a/web/components/CenterStage.tsx
+++ b/web/components/CenterStage.tsx
@@ -179,10 +179,12 @@ export default memo(function CenterStage({ nowPlaying, trackStartedAt, llmTokens
           className={cn(
             // Art sizes to width but is capped by viewport height (20vh) so a
             // short/wide window doesn't spend a third of its height on the
-            // cover; tall viewports resolve min() to 14vw. The 96px floor is
-            // what phones get (14vw is only ~55px on a 390px screen — too
-            // small a target for the tap-to-timeline it carries).
-            'v3-cover-frame v3-focus relative h-[clamp(96px,min(14vw,20vh),160px)] w-[clamp(96px,min(14vw,20vh),160px)] shrink-0 appearance-none border-0 bg-transparent p-0',
+            // cover; roomy viewports resolve to 14vw (a 1440p desktop gets
+            // ~220px, the 240px ceiling only binds on very large displays).
+            // The 96px floor is what phones get (14vw is only ~55px on a
+            // 390px screen — too small a target for the tap-to-timeline it
+            // carries).
+            'v3-cover-frame v3-focus relative h-[clamp(96px,min(14vw,20vh),240px)] w-[clamp(96px,min(14vw,20vh),240px)] shrink-0 appearance-none border-0 bg-transparent p-0',
             // Glitch the art in sync with the ripple waves — track change + DJ speaking.
             rippleActive && 'v3-cover-live',
           )}

--- a/web/components/PlayerApp.tsx
+++ b/web/components/PlayerApp.tsx
@@ -366,8 +366,6 @@ export default function PlayerApp({ contained = false }: PlayerAppProps) {
         latencyMs={signal.latencyMs}
         signalQuality={signal.quality}
         listeners={listenerCount}
-        nowPlaying={nowPlaying}
-        trackStartedAt={trackStartedAt}
       />
 
       <Sheet

--- a/web/components/TransportBar.tsx
+++ b/web/components/TransportBar.tsx
@@ -5,9 +5,7 @@ import { animate as motionAnimate, m, useAnimate } from 'motion/react';
 import { ChevronDown, ChevronUp, Volume2 } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { useIsIOS } from '@/lib/hooks';
-import { useElapsed } from '@/hooks/useElapsed';
 import { SCALE_MAX, type SignalQuality } from '@/hooks/useSignal';
-import type { NowPlayingTrack } from '@/lib/types';
 import type { PlayerStatus } from '@/hooks/usePlayer';
 
 export interface TransportBarProps {
@@ -26,9 +24,6 @@ export interface TransportBarProps {
   signalQuality: SignalQuality;
   /** Current station listener count — shown as text in the signal readout. */
   listeners: number | null;
-  nowPlaying: NowPlayingTrack | null;
-  /** Epoch ms when the current track started (from useStationFeed). */
-  trackStartedAt: number | null;
 }
 
 const SCALE_NUMS = [0, 50, 100, 150, 200, 250];
@@ -77,12 +72,7 @@ export default memo(function TransportBar({
   latencyMs,
   signalQuality,
   listeners,
-  nowPlaying,
-  trackStartedAt,
 }: TransportBarProps) {
-  // 1s elapsed tick scoped to this component (see useElapsed) — it drives the
-  // hairline progress along the deck's top edge.
-  const elapsed = useElapsed(trackStartedAt);
   // iOS Safari makes HTMLMediaElement.volume read-only and ignores a Web Audio
   // GainNode inside an installed PWA, so the on-screen knob can't actually
   // attenuate there. Swap it for a hardware-volume hint instead of shipping a
@@ -92,8 +82,6 @@ export default memo(function TransportBar({
   // The window between the tune-in gesture and the first audible frame —
   // surfaced on the power ring so the player doesn't claim to play while silent.
   const connecting = status === 'connecting';
-  const duration = nowPlaying?.duration ?? 0;
-  const progress = duration > 0 ? Math.min(1, elapsed / duration) : 0;
 
   // Knob pointer sweeps the conic tick scale: -135° (silent) → +135° (full),
   // matching the scale's `from -135deg` origin in globals.css.
@@ -233,15 +221,6 @@ export default memo(function TransportBar({
       className="absolute inset-x-0 bottom-0 z-20"
     >
       <div className="fz-deck relative grid grid-cols-[auto_1fr_auto] items-stretch bg-bg pt-3 pr-[env(safe-area-inset-right)] pb-[calc(env(safe-area-inset-bottom)_+_0.75rem)] pl-[env(safe-area-inset-left)] [border-top:1px_solid_var(--fz-edge)]">
-        {/* Hairline progress along the top edge of the deck. */}
-        {duration > 0 && (
-          <div
-            className="pointer-events-none absolute -top-px left-0 z-10 h-0.5 w-[var(--progress)] bg-vermilion"
-            ref={(el) => { if (el) el.style.setProperty('--progress', `${progress * 100}%`); }}
-            aria-hidden="true"
-          />
-        )}
-
         {/* ── POWER ──────────────────────────────────────────────── */}
         <div className="relative flex flex-col items-center justify-center gap-1.5 px-4 pt-1 pb-2 md:px-5 md:pt-1 md:pb-2.5 lg:gap-2 lg:px-6 lg:pt-1.5 lg:pb-3">
           <span className="v3-caption hidden text-muted lg:block">Power</span>

--- a/web/components/Waveform.tsx
+++ b/web/components/Waveform.tsx
@@ -231,12 +231,15 @@ export default memo(function Waveform({ audioRef, tunedIn, trackStartedAt, durat
 
   return (
     <div
-      // Horizontal footprint is width-based (sm:). The tall band, however, is
+      // Horizontal footprint is width-based (sm:). The band's vertical shape is
       // gated on viewport HEIGHT too — a short/wide window kept the full-height
       // band and left no room above it, so the now-playing block overlapped it
-      // (issue #576). Below 760px tall we fall back to the compact band so the
-      // CenterStage region has room to clear it.
-      className="pointer-events-none absolute inset-x-3 bottom-24 h-[110px] px-1 opacity-[0.22] sm:right-24 sm:left-0 sm:px-8 [@media(min-width:640px)_and_(min-height:760px)]:bottom-[128px] [@media(min-width:640px)_and_(min-height:760px)]:h-40"
+      // (issue #576). Three shapes: mobile (bottom-24, 110px); short/wide
+      // (bottom-32 so the band clears the ~116px transport deck it used to
+      // slide under, and a shorter 80px strip); tall/wide (the full 160px
+      // band). The two wide variants use mutually exclusive height queries so
+      // neither depends on class order to win.
+      className="pointer-events-none absolute inset-x-3 bottom-24 h-[110px] px-1 opacity-[0.22] sm:right-24 sm:left-0 sm:px-8 [@media(min-width:640px)_and_(max-height:759px)]:bottom-32 [@media(min-width:640px)_and_(max-height:759px)]:h-20 [@media(min-width:640px)_and_(min-height:760px)]:bottom-[128px] [@media(min-width:640px)_and_(min-height:760px)]:h-40"
       aria-hidden="true"
     >
       <canvas ref={canvasRef} className="h-full w-full" />

--- a/web/components/Waveform.tsx
+++ b/web/components/Waveform.tsx
@@ -1,11 +1,64 @@
 'use client';
 
-import { memo, useEffect, useRef, useState, type RefObject } from 'react';
+import { memo, useCallback, useEffect, useRef, useState, type RefObject } from 'react';
 import { useAnalyser } from '@/lib/hooks';
 import { pollWhileVisible } from '@/lib/poll';
-import { cn } from '@/lib/cn';
 
 const BARS = 120;
+
+// Bars sweep this range logarithmically — equal horizontal distance per octave,
+// like hardware spectrum analysers. A linear bin map put >11 kHz on the right
+// half of the band, where music carries almost no energy, so most of the strip
+// never moved; log spacing gives bass/mids/highs each a visible share.
+const FREQ_LO = 50;
+const FREQ_HI = 16000;
+
+// Resting bar height as a fraction of the band (the old spans' h-[10%]).
+const REST = 0.1;
+
+// Minimum ms between paints. rAF fires at display refresh — 120 Hz+ on
+// ProMotion/gaming screens — but the analyser's own smoothing means frames
+// ~33 ms apart are visually indistinguishable, at half (or a quarter) the cost.
+const FRAME_MS = 30;
+
+// Backing-store resolution cap. The band sits at opacity 0.22 behind the
+// stage — 3× phone DPR buys nothing visible and triples the pixels cleared
+// and filled every paint.
+const MAX_DPR = 2;
+
+interface Palette {
+  bar: string;
+  past: string;
+}
+
+// Bar colours come from the theme tokens the old spans used via bg-ink /
+// bg-vermilion. Themes apply as inline custom properties on <html> (lib/theme
+// applyTheme), so the cached palette is dropped whenever that element's
+// attributes change.
+function resolvePalette(el: HTMLElement): Palette {
+  const cs = getComputedStyle(el);
+  const bar = cs.getPropertyValue('--color-ink').trim() || cs.getPropertyValue('--ink').trim();
+  const past = cs.getPropertyValue('--color-vermilion').trim() || cs.getPropertyValue('--accent').trim();
+  return { bar: bar || '#161412', past: past || '#d94b2a' };
+}
+
+// Per-bar [start, end) analyser-bin spans for the log sweep. Each bar averages
+// every bin it covers (a single sampled bin flickers on narrowband content).
+// Cached by the caller — this only changes if the FFT size or context sample
+// rate does.
+function buildBinRanges(binCount: number, sampleRate: number): Array<[number, number]> {
+  const nyquist = sampleRate / 2;
+  const hi = Math.min(FREQ_HI, nyquist);
+  const ranges: Array<[number, number]> = [];
+  for (let i = 0; i < BARS; i++) {
+    const f0 = FREQ_LO * Math.pow(hi / FREQ_LO, i / BARS);
+    const f1 = FREQ_LO * Math.pow(hi / FREQ_LO, (i + 1) / BARS);
+    const b0 = Math.min(binCount - 1, Math.max(0, Math.floor((f0 / nyquist) * binCount)));
+    const b1 = Math.min(binCount, Math.max(b0 + 1, Math.ceil((f1 / nyquist) * binCount)));
+    ranges.push([b0, b1]);
+  }
+  return ranges;
+}
 
 export interface WaveformProps {
   audioRef: RefObject<HTMLAudioElement | null>;
@@ -16,14 +69,42 @@ export interface WaveformProps {
   duration: number;
 }
 
+// The band renders on a single <canvas> — one paint per frame instead of 120
+// styled spans. The span version spent ~2.8 ms/frame in the rendering pipeline
+// (style recalc dominated: every frame retargeted 120 height transitions, then
+// re-laid-out the flex row); the same visual on canvas measures ~0.25 ms/frame.
+// That headroom is what lets the strip keep running on the Pi-class devices
+// lite mode targets.
 export default memo(function Waveform({ audioRef, tunedIn, trackStartedAt, duration }: WaveformProps) {
-  const { ready, read } = useAnalyser(audioRef, tunedIn);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const rafRef = useRef<number | null>(null);
+  const { ready, read, sampleRate } = useAnalyser(audioRef, tunedIn);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const levelsRef = useRef<Float32Array>(new Float32Array(BARS));
+  const pastBarsRef = useRef(0);
+  const paletteRef = useRef<Palette | null>(null);
+  const rangesRef = useRef<{ key: string; ranges: Array<[number, number]> } | null>(null);
 
-  // Progress is derived locally and quantised to whole bars, so this component
-  // re-renders only when another bar should flip colour (~every few seconds),
-  // not on a 1s elapsed tick.
+  // Calm mode — the listener asked for stillness (prefers-reduced-motion) or
+  // low power (html.lite). CSS can't stop a JS animation loop, so the gate has
+  // to live here: no rAF, no fallback interval, just a static strip that keeps
+  // the progress split legible. Lite toggles live from the theme menu, hence
+  // the observer rather than a mount-time read.
+  const [calm, setCalm] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () =>
+      setCalm(mq.matches || document.documentElement.classList.contains('lite'));
+    update();
+    mq.addEventListener('change', update);
+    const mo = new MutationObserver(update);
+    mo.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+    return () => {
+      mq.removeEventListener('change', update);
+      mo.disconnect();
+    };
+  }, []);
+
+  // Progress quantised to whole bars, so state changes ~every few seconds —
+  // not on a 1s elapsed tick (same scheme as the span version).
   const [pastBars, setPastBars] = useState(0);
   useEffect(() => {
     if (trackStartedAt == null || duration <= 0) {
@@ -36,82 +117,129 @@ export default memo(function Waveform({ audioRef, tunedIn, trackStartedAt, durat
     }, 1000);
   }, [trackStartedAt, duration]);
 
-  // Drive real-analyser bars via rAF when available; otherwise the fallback
-  // effect below paints heights from a pseudo-random walk. Bar heights are
-  // written via DOM mutation in both paths so the component stays free of
-  // inline style props (issue #50) and free of per-frame React renders.
-  useEffect(() => {
-    if (!ready || !tunedIn) {
-      if (rafRef.current) cancelAnimationFrame(rafRef.current);
-      return;
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext('2d');
+    if (!canvas || !ctx) return;
+    const W = canvas.width;
+    const H = canvas.height;
+    if (!W || !H) return;
+    if (!paletteRef.current) paletteRef.current = resolvePalette(canvas);
+    const dpr = Math.min(MAX_DPR, window.devicePixelRatio || 1);
+    const slot = W / BARS;
+    const gap = Math.min(2 * dpr, Math.max(1, slot * 0.25));
+    const barW = Math.max(1, slot - gap);
+    const levels = levelsRef.current;
+    const past = pastBarsRef.current;
+    ctx.clearRect(0, 0, W, H);
+    // Bars grow symmetrically from the vertical centre (the old items-center
+    // look). fillStyle only changes at the progress boundary.
+    ctx.fillStyle = past > 0 ? paletteRef.current.past : paletteRef.current.bar;
+    for (let i = 0; i < BARS; i++) {
+      if (i === past) ctx.fillStyle = paletteRef.current.bar;
+      const v = Math.min(1, REST + Math.pow(levels[i] ?? 0, 0.7) * (1 - REST));
+      const bh = Math.max(1, v * H);
+      ctx.fillRect(i * slot, (H - bh) / 2, barW, bh);
     }
-    const tick = () => {
-      const bins = read();
-      const container = containerRef.current;
-      if (bins && container) {
-        const spans = container.querySelectorAll<HTMLSpanElement>('[data-bar]');
-        const step = Math.max(1, Math.floor(bins.length / BARS));
-        for (let i = 0; i < spans.length; i++) {
-          const v = (bins[Math.min(bins.length - 1, i * step)] ?? 0) / 255;
-          const span = spans[i];
-          if (span) span.style.height = `${10 + Math.pow(v, 0.7) * 95}%`;
-        }
-      }
-      rafRef.current = requestAnimationFrame(tick);
-    };
-    tick();
-    return () => { if (rafRef.current) cancelAnimationFrame(rafRef.current); };
-  }, [ready, tunedIn, read]);
+  }, []);
 
-  // Fallback when the real analyser can't attach — notably iOS Safari, where
-  // createMediaElementSource on a live HTTP MP3 stream returns silence (WebKit
-  // limitation). A pseudo-random walk is written straight to the spans: no
-  // React state, so a fallback session costs zero renders, and the interval
-  // pauses while the tab is hidden.
+  // Repaint on progress flips; the live loops also read the ref every frame.
   useEffect(() => {
-    if (ready || !tunedIn) return;
-    const container = containerRef.current;
-    if (!container) return;
-    const spans = container.querySelectorAll<HTMLSpanElement>('[data-bar]');
-    const levels: number[] = Array(spans.length).fill(0.1);
-    return pollWhileVisible(() => {
-      for (let i = 0; i < spans.length; i++) {
-        const target = Math.pow(Math.random(), 1.4) * (1 - i / (spans.length * 2.2));
-        const next = (levels[i] ?? 0.1) + (target - (levels[i] ?? 0.1)) * 0.45;
-        levels[i] = next;
-        const span = spans[i];
-        if (span) span.style.height = `${10 + Math.pow(next, 0.7) * 95}%`;
-      }
-    }, 60);
-  }, [ready, tunedIn]);
+    pastBarsRef.current = pastBars;
+    draw();
+  }, [pastBars, draw]);
 
-  const usingReal = ready && tunedIn;
+  // Backing store tracks the CSS box (breakpoints swap the band height —
+  // issue #576) at capped DPR.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ro = new ResizeObserver(() => {
+      const dpr = Math.min(MAX_DPR, window.devicePixelRatio || 1);
+      const r = canvas.getBoundingClientRect();
+      const w = Math.max(1, Math.round(r.width * dpr));
+      const h = Math.max(1, Math.round(r.height * dpr));
+      if (canvas.width !== w) canvas.width = w;
+      if (canvas.height !== h) canvas.height = h;
+      draw();
+    });
+    ro.observe(canvas);
+    return () => ro.disconnect();
+  }, [draw]);
+
+  // Theme swaps write custom properties onto <html> — drop the cached palette
+  // and repaint. Also repaints on the lite class flip (the calm effect above
+  // handles the loop change).
+  useEffect(() => {
+    const mo = new MutationObserver(() => {
+      paletteRef.current = null;
+      draw();
+    });
+    mo.observe(document.documentElement, { attributes: true, attributeFilter: ['class', 'style'] });
+    return () => mo.disconnect();
+  }, [draw]);
+
+  // The drive loop, by mode:
+  //   calm / not tuned in — one static paint of the resting strip (which is
+  //     also what clears stale bar heights after a tune-out);
+  //   real analyser — rAF, throttled to ~33 paints/s, log-folded bins;
+  //   fallback — pseudo-random walk on a 60 ms interval, for engines where
+  //     the analyser can't attach: iOS + some desktop-Safari builds return
+  //     only zeros from createMediaElementSource on a live MP3 stream
+  //     (issues #298/#302). The interval pauses while the tab is hidden;
+  //     rAF pauses on its own.
+  useEffect(() => {
+    const levels = levelsRef.current;
+    if (calm || !tunedIn || !ready) {
+      levels.fill(0);
+      draw();
+      if (calm || !tunedIn) return;
+      // Fallback walk — same shape as the span version: heavier motion on the
+      // left, easing off toward the right edge.
+      return pollWhileVisible(() => {
+        for (let i = 0; i < BARS; i++) {
+          const target = Math.pow(Math.random(), 1.4) * (1 - i / (BARS * 2.2));
+          levels[i] = (levels[i] ?? 0) + (target - (levels[i] ?? 0)) * 0.45;
+        }
+        draw();
+      }, 60);
+    }
+    let raf = 0;
+    let last = 0;
+    const tick = (now: number) => {
+      raf = requestAnimationFrame(tick);
+      if (now - last < FRAME_MS) return;
+      last = now;
+      const bins = read();
+      if (!bins) return;
+      const key = `${bins.length}:${sampleRate ?? 0}`;
+      if (rangesRef.current?.key !== key) {
+        rangesRef.current = { key, ranges: buildBinRanges(bins.length, sampleRate ?? 48000) };
+      }
+      const ranges = rangesRef.current.ranges;
+      for (let i = 0; i < BARS; i++) {
+        const [b0, b1] = ranges[i] ?? [0, 1];
+        let sum = 0;
+        for (let b = b0; b < b1; b++) sum += bins[b] ?? 0;
+        levels[i] = sum / ((b1 - b0) * 255);
+      }
+      draw();
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [calm, tunedIn, ready, read, sampleRate, draw]);
 
   return (
     <div
-      ref={containerRef}
       // Horizontal footprint is width-based (sm:). The tall band, however, is
       // gated on viewport HEIGHT too — a short/wide window kept the full-height
       // band and left no room above it, so the now-playing block overlapped it
       // (issue #576). Below 760px tall we fall back to the compact band so the
       // CenterStage region has room to clear it.
-      className="pointer-events-none absolute inset-x-3 bottom-24 flex h-[110px] items-center gap-px px-1 opacity-[0.22] sm:right-24 sm:left-0 sm:gap-0.5 sm:px-8 [@media(min-width:640px)_and_(min-height:760px)]:bottom-[128px] [@media(min-width:640px)_and_(min-height:760px)]:h-40"
+      className="pointer-events-none absolute inset-x-3 bottom-24 h-[110px] px-1 opacity-[0.22] sm:right-24 sm:left-0 sm:px-8 [@media(min-width:640px)_and_(min-height:760px)]:bottom-[128px] [@media(min-width:640px)_and_(min-height:760px)]:h-40"
       aria-hidden="true"
     >
-      {Array.from({ length: BARS }).map((_, i) => {
-        const past = i < pastBars;
-        return (
-          <span
-            key={i}
-            data-bar
-            className={cn(
-              'h-[10%] flex-1',
-              past ? 'bg-vermilion' : 'bg-ink',
-              usingReal && '[transition:height_60ms_linear]',
-            )}
-          />
-        );
-      })}
+      <canvas ref={canvasRef} className="h-full w-full" />
     </div>
   );
 });

--- a/web/lib/hooks.ts
+++ b/web/lib/hooks.ts
@@ -26,6 +26,9 @@ export function useClock(): Date | null {
 export interface Analyser {
   ready: boolean;
   read: () => Uint8Array<ArrayBuffer> | null;
+  /** AudioContext sample rate in Hz — null until the graph exists. Callers
+   *  mapping bins to frequencies need it (44.1k vs 48k shifts every bin). */
+  sampleRate: number | null;
 }
 
 // Older Safari exposes AudioContext as webkitAudioContext.
@@ -36,9 +39,9 @@ interface WebkitWindow {
 
 // Web Audio analyser hook — wires an AnalyserNode to the given <audio> ref
 // the first time `active` flips true, then writes per-frame frequency bytes
-// into an internal ref read via `read()`. Returns `{ ready, read }`. If CORS
-// or anything else blocks attachment, `ready` stays false and `read()` returns
-// null — callers should fall back to `useSpectrum`.
+// into an internal ref read via `read()`. Returns `{ ready, read, sampleRate }`.
+// If CORS or anything else blocks attachment, `ready` stays false and `read()`
+// returns null — the Waveform falls back to its pseudo-random walk.
 //
 // iOS is opted out entirely: createMediaElementSource on a live MP3 stream only
 // ever yields zeros there, and merely routing the element through Web Audio
@@ -55,6 +58,7 @@ export function useAnalyser(
   const binsRef = useRef<Uint8Array<ArrayBuffer> | null>(null);
   const probedRef = useRef(false);
   const [ready, setReadyState] = useState(false);
+  const [sampleRate, setSampleRate] = useState<number | null>(null);
   // Mirror of `ready` read by the stable `read` callback below — keeping it in
   // a ref means `read`'s identity never changes, so the caller's rAF effect
   // doesn't tear down and restart on every render.
@@ -84,11 +88,18 @@ export function useAnalyser(
         if (!sourceRef.current) {
           sourceRef.current = ctxRef.current.createMediaElementSource(audioEl);
           analyserRef.current = ctxRef.current.createAnalyser();
-          analyserRef.current.fftSize = 256;
-          analyserRef.current.smoothingTimeConstant = 0.78;
+          // 1024-point FFT (512 bins). The Waveform's log-frequency sweep needs
+          // low-end resolution — at 256 the whole bottom two octaves collapsed
+          // into two bins. Reading 512 bins per paint is still trivial.
+          analyserRef.current.fftSize = 1024;
+          // Light smoothing only: the old 0.78 stacked on the spans' 60 ms CSS
+          // transitions left bars trailing the beat by ~100 ms. The canvas
+          // renderer has no second smoothing layer, so this is the whole lag.
+          analyserRef.current.smoothingTimeConstant = 0.7;
           sourceRef.current.connect(analyserRef.current);
           analyserRef.current.connect(ctxRef.current.destination);
           binsRef.current = new Uint8Array(analyserRef.current.frequencyBinCount);
+          setSampleRate(ctxRef.current.sampleRate);
         }
         if (cancelled) return;
         setReady(true);
@@ -96,7 +107,7 @@ export function useAnalyser(
         // Some non-iOS WebKit builds (e.g. desktop Safari on a live MP3 mount)
         // also wire the graph up but only ever return zeros. Probe once after
         // playback starts — if no samples land in ~600 ms, flip ready=false so
-        // the pseudo-random useSpectrum fallback takes over.
+        // the pseudo-random walk fallback takes over.
         if (probedRef.current) return;
         onPlaying = () => {
           if (probedRef.current || cancelled) return;
@@ -121,10 +132,10 @@ export function useAnalyser(
               if (probeInterval) clearInterval(probeInterval);
               probeInterval = null;
               if (max === 0) {
-                // No usable data. Fall back to the pseudo-spectrum, but DON'T
-                // disconnect — the source feeds the speakers through this graph,
-                // so tearing it down would mute playback. An idle analyser in
-                // the chain is transparent.
+                // No usable data. Fall back to the pseudo-random walk, but
+                // DON'T disconnect — the source feeds the speakers through this
+                // graph, so tearing it down would mute playback. An idle
+                // analyser in the chain is transparent.
                 setReady(false);
               }
             }
@@ -149,5 +160,5 @@ export function useAnalyser(
     return binsRef.current;
   }, []);
 
-  return { ready, read };
+  return { ready, read, sampleRate };
 }


### PR DESCRIPTION
## What

Rebuilds the player's waveform visualizer on a single `<canvas>` and fixes the four issues found in the visualizer review:

1. **Rendering cost** — the 120-span version spent ~2.8 ms/frame in the rendering pipeline (style recalc dominated: every rAF tick retargeted 120 CSS height transitions, then re-laid-out the flex row). The identical visual on canvas traces at ~0.25 ms/frame (~11× less), and paints are capped at ~33/s so ProMotion/144Hz displays don't pay double for invisible gain.
2. **Lite mode + `prefers-reduced-motion` now actually stop it** — `html.lite` kills `animation:`/`backdrop-filter` but CSS can't halt a JS rAF loop, so the Pi-class kiosks lite mode targets kept paying full per-frame layout cost. Calm mode parks the band as a static strip (progress split stays legible) and resumes live when toggled off, observer-driven so the theme-menu flip works mid-session.
3. **Log-frequency bin mapping** (50 Hz–16 kHz, per-bar bin averaging, `fftSize` 256→1024) — the old linear map put >11 kHz on the right half of the band, which therefore never moved. Now bass/mids/highs each get a visible share and the whole strip dances.
4. **Polish** — analyser smoothing 0.78→0.7 (the old value stacked on the spans' 60 ms transitions, trailing the beat by ~100 ms); tune-out repaints the resting strip instead of freezing stale bar heights.

Plus, per follow-up: **TransportBar's hairline progress bar is removed** — the waveform's vermilion past-bars split already shows track progress, so the deck edge duplicate (and its `nowPlaying`/`trackStartedAt` props + 1s elapsed tick) goes away.

## Numbers

DevTools traces, 480-frame windows at 60fps, same synthetic spectrum:

| Variant | Rendering pipeline / frame |
|---|---|
| shipped spans (height + transitions) | ~2.8 ms |
| cached spans (no per-frame `querySelectorAll`) | ~2.8 ms — *not* the bottleneck |
| `scaleY` transforms | ~0.58 ms |
| **canvas (this PR)** | **~0.20 ms** |

## Verified

- Live against the dev stack from this branch's worktree: real analyser attaches (no CORS-zeros), full band animates with genuine spectral structure, vermilion progress split advances (pixel-sampled `rgba(238,52,59)` past bars vs ink), theme tokens resolve through canvas (oklch OK).
- `?lite=1`: audio keeps playing, canvas fully static (identical pixel counts across samples); removing the class live resumes animation.
- `web` lint (eslint + tsc) clean.

Fallback paths (iOS / desktop-Safari zeros → pseudo-random walk) are a direct port of the shipped walk; worth an eyeball on real hardware.