### PR TITLE
fix(doctor): analyzer heavy-image hints cover non-compose installs

### DIFF
--- a/controller/src/doctor-knowledge.ts
+++ b/controller/src/doctor-knowledge.ts
@@ -150,8 +150,12 @@ regular cadence — it's cheap insurance.
 - "Sounds-like" audio embeddings need the **heavy analyzer** (CLAP); vocal-range /
   talk-timing needs the heavy analyzer (Demucs). The default LEAN analyzer image
   can't do either, so these toggles **silently no-op** on it. If the report flags
-  this, tell the operator to set \`ANALYZER_HEAVY=1\` in .env and re-pull/rebuild the
-  analyzer, or turn the setting off (it's costing nothing but false expectations).
+  this, tell the operator to switch to the heavy analyzer image: with docker compose
+  that's \`ANALYZER_HEAVY=1\` in .env + re-pull; on non-compose installs (Unraid,
+  Portainer, plain \`docker run\`) it's changing the analyzer container's image to
+  \`ghcr.io/perminder-klair/subwave-analyzer-heavy\` — \`ANALYZER_HEAVY\` is a compose
+  interpolation variable, so setting it on the container itself does nothing. Or turn
+  the setting off (it's costing nothing but false expectations).
 
 ## Listener-request web-resolve (settings.llm.requestWebResolve)
 - Lets the request agent resolve *described* tracks ("that song from the advert")

--- a/controller/src/doctor.ts
+++ b/controller/src/doctor.ts
@@ -757,7 +757,7 @@ async function checkTuning(s: any): Promise<Finding[]> {
           label: 'audio embeddings',
           status: 'warn',
           detail: 'enabled, but the analyzer can’t produce them',
-          hint: 'The “sounds-like” audio embeddings need the heavy analyzer (CLAP). You’re on the lean image, so this setting silently does nothing. Set ANALYZER_HEAVY=1 in .env and re-pull/rebuild the analyzer, or turn the setting off.',
+          hint: 'The “sounds-like” audio embeddings need the heavy analyzer (CLAP). You’re on the lean image, so this setting silently does nothing. With docker compose, set ANALYZER_HEAVY=1 in .env and re-pull; without compose (Unraid, Portainer, plain docker) switch the analyzer container’s image to ghcr.io/perminder-klair/subwave-analyzer-heavy. Or turn the setting off.',
         });
       }
       if (wantVocal && analyzer.vocalActivityAvailable() === false) {
@@ -765,7 +765,7 @@ async function checkTuning(s: any): Promise<Finding[]> {
           label: 'vocal activity',
           status: 'warn',
           detail: 'enabled, but the analyzer can’t produce it',
-          hint: 'Vocal-range / talk-timing analysis needs the heavy analyzer (Demucs). The lean image can’t, so this setting no-ops. Set ANALYZER_HEAVY=1 in .env and rebuild the analyzer, or turn the setting off.',
+          hint: 'Vocal-range / talk-timing analysis needs the heavy analyzer (Demucs). The lean image can’t, so this setting no-ops. With docker compose, set ANALYZER_HEAVY=1 in .env and re-pull; without compose switch the analyzer container’s image to ghcr.io/perminder-klair/subwave-analyzer-heavy. Or turn the setting off.',
         });
       }
     }


### PR DESCRIPTION
## What

Rewords the doctor's audio-embeddings and vocal-activity hints (plus the matching doctor-knowledge entry) so the fix they suggest works on installs without docker compose.

## Why

The hints told every operator to set `ANALYZER_HEAVY=1` in `.env`. That variable is compose interpolation — it resolves which image tag compose pulls (`subwave-analyzer${ANALYZER_HEAVY:+-heavy}`). On Unraid, Portainer, or plain `docker run` there is no `.env`, and setting the variable on the container itself does nothing, which sent the reporter of #966 down a dead end.

## Changes

- `controller/src/doctor.ts` — both hints now give the compose path (`.env` + re-pull) and the non-compose path (switch the analyzer container's image to `ghcr.io/perminder-klair/subwave-analyzer-heavy`).
- `controller/src/doctor-knowledge.ts` — same for the LLM-rendered advice, with an explicit note that `ANALYZER_HEAVY` is compose interpolation so the advisor never tells a non-compose operator to set it as a container env var.

Text-only; no behaviour change. `controller` lint (eslint + tsc) passes.

Refs #966