### PR TITLE
feat(broadcast): configurable Icecast listener cap (ICECAST_MAX_CLIENTS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,10 @@ SITE_URL=
 # ICECAST_ADMIN_PASSWORD=
 # ICECAST_RELAY_PASSWORD=
 
+# Max concurrent listeners across all mounts (icecast <limits><clients>).
+# Unset → 100. Lower it to bound bandwidth on a small host.
+# ICECAST_MAX_CLIENTS=
+
 # ───────── Overrides for the wizard's fields ─────────
 # These all live in state/settings.json after the wizard runs. Set them here
 # only if you want env to win (12-factor / CI / GitOps style deploys).

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -85,6 +85,9 @@ services:
       - ICECAST_SOURCE_PASSWORD=\${ICECAST_SOURCE_PASSWORD:-}
       - ICECAST_ADMIN_PASSWORD=\${ICECAST_ADMIN_PASSWORD:-}
       - ICECAST_RELAY_PASSWORD=\${ICECAST_RELAY_PASSWORD:-}
+      # Concurrent-listener ceiling for icecast (<limits><clients>).
+      # Empty/unset → 100 (the historical default).
+      - ICECAST_MAX_CLIENTS=\${ICECAST_MAX_CLIENTS:-}
       # Keeps the hourly archive paths (%Y-%m-%d/%H-00.mp3) on local wall time.
       - TZ=\${TZ:-Europe/London}
     extra_hosts:
@@ -443,6 +446,9 @@ services:
       - ICECAST_SOURCE_PASSWORD=\${ICECAST_SOURCE_PASSWORD:-}
       - ICECAST_ADMIN_PASSWORD=\${ICECAST_ADMIN_PASSWORD:-}
       - ICECAST_RELAY_PASSWORD=\${ICECAST_RELAY_PASSWORD:-}
+      # Concurrent-listener ceiling for icecast (<limits><clients>).
+      # Empty/unset → 100 (the historical default).
+      - ICECAST_MAX_CLIENTS=\${ICECAST_MAX_CLIENTS:-}
       - TZ=\${TZ:-Europe/London}
     ports:
       # BIND_ADDRESS defaults to 0.0.0.0; set 127.0.0.1 in .env for a same-host
@@ -746,6 +752,9 @@ services:
       - ICECAST_SOURCE_PASSWORD=\${ICECAST_SOURCE_PASSWORD:-}
       - ICECAST_ADMIN_PASSWORD=\${ICECAST_ADMIN_PASSWORD:-}
       - ICECAST_RELAY_PASSWORD=\${ICECAST_RELAY_PASSWORD:-}
+      # Concurrent-listener ceiling for icecast (<limits><clients>).
+      # Empty/unset → 100 (the historical default).
+      - ICECAST_MAX_CLIENTS=\${ICECAST_MAX_CLIENTS:-}
       - TZ=\${TZ:-Europe/London}
     extra_hosts:
       # Lets Liquidsoap fetch Subsonic stream URLs that point at host services
@@ -1086,6 +1095,10 @@ SITE_URL=
 # ICECAST_SOURCE_PASSWORD=
 # ICECAST_ADMIN_PASSWORD=
 # ICECAST_RELAY_PASSWORD=
+
+# Max concurrent listeners across all mounts (icecast <limits><clients>).
+# Unset → 100. Lower it to bound bandwidth on a small host.
+# ICECAST_MAX_CLIENTS=
 
 # ───────── Overrides for the wizard's fields ─────────
 # These all live in state/settings.json after the wizard runs. Set them here

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -61,6 +61,9 @@ services:
       - ICECAST_SOURCE_PASSWORD=${ICECAST_SOURCE_PASSWORD:-}
       - ICECAST_ADMIN_PASSWORD=${ICECAST_ADMIN_PASSWORD:-}
       - ICECAST_RELAY_PASSWORD=${ICECAST_RELAY_PASSWORD:-}
+      # Concurrent-listener ceiling for icecast (<limits><clients>).
+      # Empty/unset → 100 (the historical default).
+      - ICECAST_MAX_CLIENTS=${ICECAST_MAX_CLIENTS:-}
       - TZ=${TZ:-Europe/London}
     ports:
       # BIND_ADDRESS defaults to 0.0.0.0; set 127.0.0.1 in .env for a same-host

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,6 +45,9 @@ services:
       - ICECAST_SOURCE_PASSWORD=${ICECAST_SOURCE_PASSWORD:-}
       - ICECAST_ADMIN_PASSWORD=${ICECAST_ADMIN_PASSWORD:-}
       - ICECAST_RELAY_PASSWORD=${ICECAST_RELAY_PASSWORD:-}
+      # Concurrent-listener ceiling for icecast (<limits><clients>).
+      # Empty/unset → 100 (the historical default).
+      - ICECAST_MAX_CLIENTS=${ICECAST_MAX_CLIENTS:-}
       - TZ=${TZ:-Europe/London}
     extra_hosts:
       # Lets Liquidsoap fetch Subsonic stream URLs that point at host services

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,9 @@ services:
       - ICECAST_SOURCE_PASSWORD=${ICECAST_SOURCE_PASSWORD:-}
       - ICECAST_ADMIN_PASSWORD=${ICECAST_ADMIN_PASSWORD:-}
       - ICECAST_RELAY_PASSWORD=${ICECAST_RELAY_PASSWORD:-}
+      # Concurrent-listener ceiling for icecast (<limits><clients>).
+      # Empty/unset → 100 (the historical default).
+      - ICECAST_MAX_CLIENTS=${ICECAST_MAX_CLIENTS:-}
       # Keeps the hourly archive paths (%Y-%m-%d/%H-00.mp3) on local wall time.
       - TZ=${TZ:-Europe/London}
     extra_hosts:

--- a/docker/aio/supervisor.sh
+++ b/docker/aio/supervisor.sh
@@ -126,10 +126,14 @@ init_secrets() {
 	# radio.liq reads ICECAST_HOST (default "icecast").
 	export ICECAST_HOST=localhost
 
+	# Concurrent-listener ceiling (<limits><clients>). Empty/unset → the stock 100.
+	ICECAST_MAX_CLIENTS="${ICECAST_MAX_CLIENTS:-100}"
+
 	sed \
 		-e "s|\${ICECAST_SOURCE_PASSWORD}|$ICECAST_SOURCE_PASSWORD|g" \
 		-e "s|\${ICECAST_ADMIN_PASSWORD}|$ICECAST_ADMIN_PASSWORD|g" \
 		-e "s|\${ICECAST_RELAY_PASSWORD}|$ICECAST_RELAY_PASSWORD|g" \
+		-e "s|\${ICECAST_MAX_CLIENTS}|$ICECAST_MAX_CLIENTS|g" \
 		"$TEMPLATE" > "$RENDERED"
 	chown icecast2 "$RENDERED" 2>/dev/null || true
 }

--- a/docker/aio/supervisor.sh
+++ b/docker/aio/supervisor.sh
@@ -127,7 +127,15 @@ init_secrets() {
 	export ICECAST_HOST=localhost
 
 	# Concurrent-listener ceiling (<limits><clients>). Empty/unset → the stock 100.
+	# A non-numeric value would render invalid XML and fail icecast at boot,
+	# so fall back to the default with a warning instead.
 	ICECAST_MAX_CLIENTS="${ICECAST_MAX_CLIENTS:-100}"
+	case "$ICECAST_MAX_CLIENTS" in
+		*[!0-9]*|'')
+			log "ICECAST_MAX_CLIENTS='$ICECAST_MAX_CLIENTS' is not a number — using 100"
+			ICECAST_MAX_CLIENTS=100
+			;;
+	esac
 
 	sed \
 		-e "s|\${ICECAST_SOURCE_PASSWORD}|$ICECAST_SOURCE_PASSWORD|g" \

--- a/docker/broadcast-entrypoint.sh
+++ b/docker/broadcast-entrypoint.sh
@@ -126,7 +126,15 @@ export ICECAST_HOST=localhost
 # delimiter keeps slashes safe.
 
 # Concurrent-listener ceiling (<limits><clients>). Empty/unset → the stock 100.
+# A non-numeric value would render invalid XML and fail icecast at boot, so
+# fall back to the default with a warning instead of taking the stream down.
 ICECAST_MAX_CLIENTS="${ICECAST_MAX_CLIENTS:-100}"
+case "$ICECAST_MAX_CLIENTS" in
+    *[!0-9]*|'')
+        echo "broadcast: ICECAST_MAX_CLIENTS='$ICECAST_MAX_CLIENTS' is not a number — using 100" >&2
+        ICECAST_MAX_CLIENTS=100
+        ;;
+esac
 
 sed \
     -e "s|\${ICECAST_SOURCE_PASSWORD}|$ICECAST_SOURCE_PASSWORD|g" \

--- a/docker/broadcast-entrypoint.sh
+++ b/docker/broadcast-entrypoint.sh
@@ -121,13 +121,18 @@ export ICECAST_SOURCE_PASSWORD ICECAST_ADMIN_PASSWORD ICECAST_RELAY_PASSWORD
 export ICECAST_HOST=localhost
 
 # ---- Render icecast.xml -----------------------------------------------------
-# Plain sed is enough for three placeholders; the secrets are hex so there's
-# no escaping risk. Using `|` as the sed delimiter keeps slashes safe.
+# Plain sed is enough for four placeholders; the secrets are hex and the
+# listener cap numeric, so there's no escaping risk. Using `|` as the sed
+# delimiter keeps slashes safe.
+
+# Concurrent-listener ceiling (<limits><clients>). Empty/unset → the stock 100.
+ICECAST_MAX_CLIENTS="${ICECAST_MAX_CLIENTS:-100}"
 
 sed \
     -e "s|\${ICECAST_SOURCE_PASSWORD}|$ICECAST_SOURCE_PASSWORD|g" \
     -e "s|\${ICECAST_ADMIN_PASSWORD}|$ICECAST_ADMIN_PASSWORD|g" \
     -e "s|\${ICECAST_RELAY_PASSWORD}|$ICECAST_RELAY_PASSWORD|g" \
+    -e "s|\${ICECAST_MAX_CLIENTS}|$ICECAST_MAX_CLIENTS|g" \
     "$TEMPLATE" > "$RENDERED"
 chown icecast2 "$RENDERED" 2>/dev/null || true
 

--- a/docker/icecast.xml.template
+++ b/docker/icecast.xml.template
@@ -3,7 +3,7 @@
     <admin>parm@homelab</admin>
 
     <limits>
-        <clients>100</clients>
+        <clients>${ICECAST_MAX_CLIENTS}</clients>
         <sources>4</sources>
         <!-- queue-size: per-client backlog before Icecast drops a lagging
              listener. 1 MB ≈ 65s of MP3 / 85s of Opus — gives jittery mobile


### PR DESCRIPTION
Templates the Icecast `<limits><clients>` value (was a hard-coded 100) behind a new `ICECAST_MAX_CLIENTS` env var.

## Why
- Small hosts want to bound bandwidth by capping concurrent listeners.
- The hosted SUB/WAVE offering positions stations as private (personal, ~15 listeners); this makes that cap enforceable at the Icecast level.

## Behaviour
- Empty/unset → `100` (the historical default), so existing installs are unchanged.
- Rendered by the broadcast entrypoint via the same `sed` pass as the Icecast passwords (numeric value, no escaping risk).

## Changes
- `docker/icecast.xml.template` — `<clients>${ICECAST_MAX_CLIENTS}</clients>`
- `docker/broadcast-entrypoint.sh` — default + sed substitution
- `docker-compose.yml` — passes `ICECAST_MAX_CLIENTS` through to the broadcast service
- `.env.example` — documents the var

Verified the render defaults to 100 when unset and honours an explicit value (e.g. 15).