### PR TITLE
fix(tts): apply speech speed locally for openai-compatible cloud TTS

### DIFF
--- a/controller/src/audio/audio-import.ts
+++ b/controller/src/audio/audio-import.ts
@@ -93,6 +93,17 @@ export function probeDurationSec(filePath: string): Promise<number | null> {
 
 export type TranscodeFormat = 'wav' | 'mp3';
 
+// ffmpeg's atempo filter only accepts 0.5–2.0 per instance; factors outside
+// that range are reached by chaining instances (e.g. 4.0 → atempo=2.0,atempo=2.0).
+export function atempoChain(factor: number): string {
+  const steps: string[] = [];
+  let f = factor;
+  while (f > 2.0) { steps.push('atempo=2.0'); f /= 2.0; }
+  while (f < 0.5) { steps.push('atempo=0.5'); f /= 0.5; }
+  steps.push(`atempo=${f.toFixed(4)}`);
+  return steps.join(',');
+}
+
 function runFfmpeg(args: string[]): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const proc = spawn('ffmpeg', args);
@@ -113,7 +124,7 @@ function runFfmpeg(args: string[]): Promise<void> {
 // loudnorm on <2s of audio is unreliable.
 export async function transcodeAudio(
   input: Buffer,
-  { outPath, format, loudnorm = false }: { outPath: string; format: TranscodeFormat; loudnorm?: boolean },
+  { outPath, format, loudnorm = false, atempo }: { outPath: string; format: TranscodeFormat; loudnorm?: boolean; atempo?: number },
 ): Promise<void> {
   if (!input?.length) throw new Error('empty audio buffer');
   await mkdir(path.dirname(outPath), { recursive: true });
@@ -122,7 +133,10 @@ export async function transcodeAudio(
   await writeFile(tmp, input);
   try {
     const args = ['-hide_banner', '-loglevel', 'error', '-i', tmp];
-    if (loudnorm) args.push('-af', 'loudnorm=I=-16:TP=-1.5:LRA=11');
+    const filters: string[] = [];
+    if (loudnorm) filters.push('loudnorm=I=-16:TP=-1.5:LRA=11');
+    if (atempo && Number.isFinite(atempo) && atempo > 0 && atempo !== 1.0) filters.push(atempoChain(atempo));
+    if (filters.length) args.push('-af', filters.join(','));
     if (format === 'wav') args.push('-c:a', 'pcm_s16le');
     else args.push('-c:a', 'libmp3lame', '-q:a', '4');
     args.push('-y', outPath);

--- a/controller/src/llm/internal/speech/cloud-speech.ts
+++ b/controller/src/llm/internal/speech/cloud-speech.ts
@@ -13,6 +13,7 @@ import path from 'node:path';
 import crypto from 'node:crypto';
 import { config } from '../../../config.js';
 import * as settings from '../../../settings.js';
+import { transcodeAudio, hasFfmpeg } from '../../../audio/audio-import.js';
 import { isElevenLabsV3, snapV3Stability } from '../core/pure.js';
 
 // Default TTS model per cloud provider. A model id is provider-specific — an
@@ -235,14 +236,18 @@ export async function speak(
   // Speech rate — the per-call speedScale (daypart energy) composes on top of
   // CLOUD_TTS_SPEED / TTS_SPEED, then clamped to the provider's range. Only
   // sent when it differs from default so default stations are unaffected and
-  // providers that ignore the field never see it. openai-compatible servers
-  // get it too (issue: the admin speed slider was silently inert for them):
-  // the common self-hosted /v1/audio/speech servers (Kokoro-FastAPI,
-  // openedai-speech, Chatterbox shims) honour `speed`, the rest ignore the
-  // extra field, and the non-unity guard keeps untouched stations sending
-  // exactly the request they always did.
+  // providers that ignore the field never see it.
+  //
+  // openai-compatible servers NEVER receive `speed` — their implementations
+  // are wildly uneven (issue #942: a Chatterbox shim behind LiteLLM produced
+  // comb-filtered "echo chamber" audio with broken mp3 frame timestamps
+  // whenever `speed` was present, and daypart energy makes it non-unity most
+  // of the day). Instead the server renders at its natural 1x and the rate is
+  // applied locally below via ffmpeg atempo — the slider/persona/daypart knobs
+  // still work (the point of #897), but the fragile server-side path is gone.
   const isCompat = c.provider === 'openai-compatible';
   const speed = clampSpeed(config.tts.cloudSpeed * (speedScale != null ? speedScale : 1), c.provider);
+  const stretchLocally = isCompat && speed !== 1.0;
 
   // ElevenLabs voice_settings — expressive knobs the operator tunes in the
   // Cloud TTS section of admin → Settings (issue #696). Only spread when the
@@ -274,7 +279,7 @@ export async function speak(
     model: speechModel(c),
     text,
     voice: c.voice || undefined,
-    ...(speed !== 1.0 ? { speed } : {}),
+    ...(speed !== 1.0 && !isCompat ? { speed } : {}),
     // Persona character (soul) + language → provider-native delivery hint
     // (issues #579 / #558).
     ...deliveryHint({ language, soul }, c.provider, c.model),
@@ -287,10 +292,33 @@ export async function speak(
     ...(elevenlabsOpts ? { providerOptions: elevenlabsOpts } : {}),
   });
 
+  const audio = Buffer.from(result.audio.uint8Array);
+
+  // Local speed for openai-compatible: transcode to WAV with an atempo chain
+  // (pitch-preserving, and WAV output means applyEdgeFades works on the result
+  // too). Best-effort — if ffmpeg is missing or chokes, air the 1x render
+  // rather than throwing into the Piper fallback (a rate miss is inaudible
+  // next to a voice change). The fallback writes the server's original bytes
+  // under the .wav name; Liquidsoap decodes by content, not extension.
+  if (stretchLocally) {
+    const wavPath = outPath
+      || path.join(config.piper.outDir, `${crypto.randomBytes(6).toString('hex')}.wav`);
+    try {
+      if (!(await hasFfmpeg())) throw new Error('ffmpeg unavailable');
+      await transcodeAudio(audio, { outPath: wavPath, format: 'wav', atempo: speed });
+      return wavPath;
+    } catch (err: any) {
+      console.warn(`[cloud-tts] local speed ${speed}x skipped (${err?.message || err}); airing 1x render`);
+      await mkdir(path.dirname(wavPath), { recursive: true });
+      await writeFile(wavPath, audio);
+      return wavPath;
+    }
+  }
+
   const fmt = result.audio.format || 'mp3';
   const finalPath = outPath
     || path.join(config.piper.outDir, `${crypto.randomBytes(6).toString('hex')}.${fmt}`);
   await mkdir(path.dirname(finalPath), { recursive: true });
-  await writeFile(finalPath, Buffer.from(result.audio.uint8Array));
+  await writeFile(finalPath, audio);
   return finalPath;
 }


### PR DESCRIPTION
## Problem

Since #897 (v0.38.0) the composed speech speed — engine slider × persona speed × **daypart energy** — is sent as `speed` to openai-compatible `/v1/audio/speech` servers whenever it isn't exactly 1.0. Daypart energy is non-unity most of the day (late-night ≤0.92, commute push, etc.), so these servers started receiving `speed` on nearly every live call even with all sliders at 1x.

Self-hosted servers implement `speed` unevenly. In #942, a Chatterbox shim behind a LiteLLM passthrough returns comb-filtered "echo chamber" audio with broken mp3 frame timestamps (`mp3float: Could not update timestamps for skipped samples` in the broadcast logs) whenever the param is present. Test TTS stayed clean because its explicit 1x omits the param — the exact clean-test/dirty-air split the reporter saw, and why "set it back to 1x" only helped until the daypart shifted.

## Fix

Never send `speed` to openai-compatible servers. Request the natural 1x render and apply the rate locally with ffmpeg `atempo` (pitch-preserving; chained for factors outside atempo's 0.5–2.0 per-instance range), writing a WAV — which also lets `applyEdgeFades` work on the result.

- The request an openai-compatible server sees is byte-identical to pre-0.38.
- Slider, persona speed, and daypart pacing all still work (the point of #897).
- Best-effort: if ffmpeg is missing or fails, the 1x render airs as-is (a rate miss is inaudible next to a Piper voice-change fallback).
- `openai` / `elevenlabs` providers are untouched — they honour `speed` natively.

## Verification

- `npm run lint` (eslint + tsc) passes in `controller/`.
- Functional ffmpeg round-trip: 2s tone at speed 0.92 → 2.17s, at 3.0 → 0.67s; chains render as `atempo=0.9200`, `atempo=2.0,atempo=1.5000`, `atempo=0.5,atempo=0.5000`.

Fixes #942