### PR TITLE
fix(analyzer): local backend reports real CLAP/Demucs capability + AIO-aware doctor hints

### DIFF
--- a/controller/src/doctor-knowledge.ts
+++ b/controller/src/doctor-knowledge.ts
@@ -148,14 +148,24 @@ regular cadence — it's cheap insurance.
 
 ## Audio analysis features vs analyzer flavour (settings.audio.embeddings / vocalActivity)
 - "Sounds-like" audio embeddings need the **heavy analyzer** (CLAP); vocal-range /
-  talk-timing needs the heavy analyzer (Demucs). The default LEAN analyzer image
-  can't do either, so these toggles **silently no-op** on it. If the report flags
-  this, tell the operator to switch to the heavy analyzer image: with docker compose
-  that's \`ANALYZER_HEAVY=1\` in .env + re-pull; on non-compose installs (Unraid,
-  Portainer, plain \`docker run\`) it's changing the analyzer container's image to
-  \`ghcr.io/perminder-klair/subwave-analyzer-heavy\` — \`ANALYZER_HEAVY\` is a compose
-  interpolation variable, so setting it on the container itself does nothing. Or turn
-  the setting off (it's costing nothing but false expectations).
+  talk-timing needs the heavy analyzer (Demucs). A LEAN build can't do either, so
+  these toggles **silently no-op** on it. The snapshot's \`analyzer\` line states the
+  measured capability: \`(heavy: CLAP yes)\`, \`(lean: no CLAP)\`, or \`(CLAP unknown)\`.
+  ONLY claim the operator is on a lean build when it says \`lean\` or the report's
+  Tuning section flagged it — never infer lean from \`analyzer local\` or from the
+  toggles alone; \`unknown\` means the capability hasn't been probed yet, say so.
+- The upgrade path depends on the deployment shape:
+  - **Split stack** (\`analyzer sidecar\`): with docker compose, \`ANALYZER_HEAVY=1\`
+    in .env + re-pull; on non-compose installs (Unraid, Portainer, plain
+    \`docker run\`) change the analyzer container's image to
+    \`ghcr.io/perminder-klair/subwave-analyzer-heavy\`. \`ANALYZER_HEAVY\` is a compose
+    interpolation variable, so setting it on a container does nothing.
+  - **All-in-one image** (\`analyzer local\` — the AIO bundles the analyzer
+    in-process): switch the single container's image to
+    \`ghcr.io/perminder-klair/subwave-aio-heavy\`. Do NOT point an AIO install at
+    \`subwave-analyzer-heavy\` — that's the bare analyzer micro-service, and swapping
+    the AIO container to it replaces the whole station with just an analyzer.
+  - Or turn the setting off (it's costing nothing but false expectations).
 
 ## Listener-request web-resolve (settings.llm.requestWebResolve)
 - Lets the request agent resolve *described* tracks ("that song from the advert")

--- a/controller/src/doctor.ts
+++ b/controller/src/doctor.ts
@@ -780,12 +780,20 @@ async function checkTuning(s: StationSettings | null): Promise<Finding[]> {
     const wantVocal = !!s?.audio?.vocalActivity;
     if (wantEmb || wantVocal) {
       try { await analyzer.refreshCapabilities(); } catch { /* best-effort probe */ }
+      // The upgrade path depends on which backend is running: 'sidecar' is the
+      // split stack's analyzer service; 'local' is the in-process venv — the
+      // AIO image (or a dev ANALYZE_PYTHON venv). Pointing an AIO operator at
+      // the analyzer image replaces their whole station with a bare analyzer
+      // micro-service (issue #966), so the hint has to name the right image.
+      const upgradeHint = analyzer.backendLabel() === 'local'
+        ? 'On the all-in-one image, switch the container to ghcr.io/perminder-klair/subwave-aio-heavy (NOT subwave-analyzer-heavy — that’s the bare analyzer service, not a station image); on a dev venv, install the heavy Python deps.'
+        : 'With docker compose, set ANALYZER_HEAVY=1 in .env and re-pull; without compose (Unraid, Portainer, plain docker) switch the analyzer container’s image to ghcr.io/perminder-klair/subwave-analyzer-heavy.';
       if (wantEmb && analyzer.audioEmbeddingAvailable() === false) {
         out.push({
           label: 'audio embeddings',
           status: 'warn',
           detail: 'enabled, but the analyzer can’t produce them',
-          hint: 'The “sounds-like” audio embeddings need the heavy analyzer (CLAP). You’re on the lean image, so this setting silently does nothing. With docker compose, set ANALYZER_HEAVY=1 in .env and re-pull; without compose (Unraid, Portainer, plain docker) switch the analyzer container’s image to ghcr.io/perminder-klair/subwave-analyzer-heavy. Or turn the setting off.',
+          hint: `The “sounds-like” audio embeddings need the heavy analyzer (CLAP). You’re on the lean build, so this setting silently does nothing. ${upgradeHint} Or turn the setting off.`,
         });
       }
       if (wantVocal && analyzer.vocalActivityAvailable() === false) {
@@ -793,7 +801,7 @@ async function checkTuning(s: StationSettings | null): Promise<Finding[]> {
           label: 'vocal activity',
           status: 'warn',
           detail: 'enabled, but the analyzer can’t produce it',
-          hint: 'Vocal-range / talk-timing analysis needs the heavy analyzer (Demucs). The lean image can’t, so this setting no-ops. With docker compose, set ANALYZER_HEAVY=1 in .env and re-pull; without compose switch the analyzer container’s image to ghcr.io/perminder-klair/subwave-analyzer-heavy. Or turn the setting off.',
+          hint: `Vocal-range / talk-timing analysis needs the heavy analyzer (Demucs). The lean build can’t, so this setting no-ops. ${upgradeHint} Or turn the setting off.`,
         });
       }
     }
@@ -1074,7 +1082,13 @@ function renderSettingsSnapshot(): string {
   } catch { /* budget best-effort */ }
 
   let analyzerLabel = 'unknown';
-  try { analyzerLabel = analyzer.backendLabel(); } catch { /* best-effort */ }
+  try {
+    analyzerLabel = analyzer.backendLabel();
+    // Append the definitive CLAP capability so the AI review reasons from fact,
+    // not from "local probably means lean" (issue #966's false warning).
+    const clap = analyzer.audioEmbeddingAvailable();
+    analyzerLabel += clap === null ? ' (CLAP unknown)' : clap ? ' (heavy: CLAP yes)' : ' (lean: no CLAP)';
+  } catch { /* best-effort */ }
 
   return [
     '## Current settings (tune these against the findings + host resources)',

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -169,7 +169,7 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
       console.log(`[analyze] audio backfill: +${ids.length - bpmIds.length} already-analysed tracks missing an audio vector`);
     }
   } else if (audioWanted && !reAnalyzeScope) {
-    console.log('[analyze] audio backfill skipped — backend has no CLAP (set ANALYZER_HEAVY=1 to enable sounds-like vectors)');
+    console.log('[analyze] audio backfill skipped — backend has no CLAP (switch to the heavy analyzer/AIO image to enable sounds-like vectors)');
   }
 
   // Vocal backfill: same idea for tracks missing vocal-activity ranges. The

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -231,6 +231,11 @@ interface WorkerMessage {
   ready?: boolean;
   fatal?: boolean;
   error?: string;
+  // Capability flags the worker reports on its ready line (find_spec probes —
+  // no model load). The sidecar surfaces the same fields via /health.
+  audio_embedding_capable?: boolean;
+  vocal_activity_capable?: boolean;
+  text_embedding_capable?: boolean;
   bpm?: number | null;
   key?: string | null;
   intro_ms?: number | null;
@@ -257,6 +262,16 @@ let buffer = '';
 let reqSeq = 0;
 const pending = new Map<string, Pending>();
 
+// Local-backend capability flags, mirroring the sidecar's /health fields. Set
+// from the worker's ready line when it boots (authoritative — includes hard
+// load failures), or by the one-shot find_spec probe below when the doctor asks
+// before any analysis has run. null = not yet known. Without this the AIO image
+// (local backend) could never answer "can you do CLAP?" and the doctor guessed
+// — issue #966's false "you're on the lean image" warning on subwave-aio-heavy.
+let _localAudioCapable: boolean | null = null;
+let _localVocalCapable: boolean | null = null;
+let _localTextCapable: boolean | null = null;
+
 function startWorker(): Promise<void> {
   if (booting) return booting;
   booting = new Promise<void>((resolve, reject) => {
@@ -276,7 +291,17 @@ function startWorker(): Promise<void> {
         if (!line) continue;
         let msg: WorkerMessage;
         try { msg = JSON.parse(line); } catch { continue; }
-        if (msg.ready) { ready = true; clearTimeout(readyTimer); resolve(); continue; }
+        if (msg.ready) {
+          ready = true;
+          // The ready line knows about hard load failures the find_spec probe
+          // can't see, so it always overwrites.
+          if (typeof msg.audio_embedding_capable === 'boolean') _localAudioCapable = msg.audio_embedding_capable;
+          if (typeof msg.vocal_activity_capable === 'boolean') _localVocalCapable = msg.vocal_activity_capable;
+          if (typeof msg.text_embedding_capable === 'boolean') _localTextCapable = msg.text_embedding_capable;
+          clearTimeout(readyTimer);
+          resolve();
+          continue;
+        }
         if (msg.fatal) { clearTimeout(readyTimer); reject(new Error(msg.error || 'analyze worker fatal')); continue; }
         const waiter = pending.get(msg.id!);
         if (!waiter) continue;
@@ -346,6 +371,47 @@ function localRequest(req: ({ url: string } | { path: string }) & AnalyzeRequest
     });
     proc?.stdin.write(JSON.stringify({ id, ...req }) + '\n');
   });
+}
+
+// One-shot capability probe for the local backend — the same find_spec checks
+// the worker runs before its ready line (keep the module lists in sync with
+// analyze_worker.py), in a throwaway `python -c` so the doctor can get a
+// definitive answer without booting the persistent worker (which imports
+// librosa and stays resident). Fills only still-null flags: a booted worker's
+// ready line is authoritative and must not be overwritten by a fresh process
+// that can't know about hard load failures.
+const LOCAL_CAPABILITY_PROBE = [
+  'import importlib.util as u, json',
+  'h = lambda *m: all(u.find_spec(x) is not None for x in m)',
+  'print(json.dumps({"audio": h("torch", "transformers"), "vocal": h("torch", "demucs"), "text": h("torch", "transformers")}))',
+].join('\n');
+
+let _localProbe: Promise<void> | null = null;
+
+function probeLocalCapabilities(): Promise<void> {
+  if (_localProbe) return _localProbe;
+  _localProbe = new Promise<void>((resolve) => {
+    let out = '';
+    // Only reached when localConfigured() saw the python binary, so a spawn
+    // failure surfaces as the 'error' event, not a sync throw.
+    const p = spawn(config.analyzer.python, ['-c', LOCAL_CAPABILITY_PROBE], { stdio: ['ignore', 'pipe', 'ignore'] });
+    const timer = setTimeout(() => p.kill(), 15_000);
+    p.stdout.on('data', (c: Buffer) => { out += c.toString('utf8'); });
+    p.on('error', () => { clearTimeout(timer); _localProbe = null; resolve(); });
+    p.on('close', () => {
+      clearTimeout(timer);
+      try {
+        const caps = JSON.parse(out.trim()) as { audio?: boolean; vocal?: boolean; text?: boolean };
+        if (_localAudioCapable === null && typeof caps.audio === 'boolean') _localAudioCapable = caps.audio;
+        if (_localVocalCapable === null && typeof caps.vocal === 'boolean') _localVocalCapable = caps.vocal;
+        if (_localTextCapable === null && typeof caps.text === 'boolean') _localTextCapable = caps.text;
+      } catch {
+        _localProbe = null; // bad/empty output — stay unknown, allow retry
+      }
+      resolve();
+    });
+  });
+  return _localProbe;
 }
 
 async function analyzeViaLocal(url: string, opts: AnalyzeRequestOpts = {}): Promise<AnalysisResult> {
@@ -472,35 +538,45 @@ export function backendLabel(): string {
 }
 
 // Whether the active backend can emit CLAP "sounds-like" audio embeddings right
-// now. null = unknown (local backend — we don't probe its venv; or sidecar not
-// yet reached); false = sidecar reachable but built without the CLAP stack
-// (WITH_CLAP=0) — the signal the admin UI turns into a "rebuild the sidecar"
-// warning. Only meaningful for the sidecar backend.
+// now. null = unknown (backend not yet reached/probed); false = the backend is
+// definitively built without the CLAP stack (sidecar WITH_CLAP=0, or a lean
+// local/AIO venv) — the signal the admin UI turns into a "switch to the heavy
+// image" warning. Sidecar answers come from /health; local answers from the
+// worker's ready line or the find_spec probe (refreshCapabilities).
 export function audioEmbeddingAvailable(): boolean | null {
-  return _backend === 'sidecar' ? _sidecarAudioCapable : null;
+  if (_backend === 'sidecar') return _sidecarAudioCapable;
+  if (_backend === 'local') return _localAudioCapable;
+  return null;
 }
 
 // Whether the active backend can emit Demucs vocal-activity ranges right now.
-// Same semantics as audioEmbeddingAvailable: null = unknown (local, or sidecar
-// not yet reached / old sidecar without the field); false = sidecar built
-// without the demucs stack (WITH_DEMUCS=0). Only meaningful for the sidecar.
+// Same semantics as audioEmbeddingAvailable: null = unknown; false = built
+// without the demucs stack (sidecar WITH_DEMUCS=0, or a lean local/AIO venv).
 export function vocalActivityAvailable(): boolean | null {
-  return _backend === 'sidecar' ? _sidecarVocalCapable : null;
+  if (_backend === 'sidecar') return _sidecarVocalCapable;
+  if (_backend === 'local') return _localVocalCapable;
+  return null;
 }
 
-// Re-read sidecar /health so capability reflects a sidecar rebuilt under a
-// long-lived controller (resolveBackend caches the backend *choice* forever,
-// but CLAP support flips when the operator rebuilds with WITH_CLAP=1). Cheap;
-// driven on the coverage staleness cadence.
+// Refresh capability so it reflects the backend actually running under a
+// long-lived controller. Sidecar: re-read /health (the sidecar can be rebuilt
+// with WITH_CLAP=1 while the controller stays up). Local: run the one-shot
+// find_spec probe unless the persistent worker already reported its ready line
+// (an image/venv swap restarts the whole AIO process, so probe-once is enough).
+// Cheap; driven on the coverage staleness cadence + the doctor checks.
 export async function refreshCapabilities(): Promise<void> {
-  if ((await resolveBackend()) === 'sidecar') await sidecarReachable();
+  const backend = await resolveBackend();
+  if (backend === 'sidecar') { await sidecarReachable(); return; }
+  if (backend === 'local' && !ready) await probeLocalCapabilities();
 }
 
 // Whether the active backend can embed TEXT through the CLAP text tower (same
-// semantics as audioEmbeddingAvailable: null = unknown/local, false = sidecar
-// definitively can't — lean build or pre-text-tower image).
+// semantics as audioEmbeddingAvailable: null = unknown, false = definitively
+// can't — lean build or pre-text-tower image).
 export function textEmbeddingAvailable(): boolean | null {
-  return _backend === 'sidecar' ? _sidecarTextCapable : null;
+  if (_backend === 'sidecar') return _sidecarTextCapable;
+  if (_backend === 'local') return _localTextCapable;
+  return null;
 }
 
 // Coerce a worker text_embeddings payload to clean number[][] or null: one


### PR DESCRIPTION
Closes the remaining gap from #966 (follow-up to #974).

## Problem

Two layers failed for the Unraid operator in #966, who runs the **AIO** image (`subwave-aio-heavy`):

1. **The controller genuinely didn't know.** The local (`ANALYZE_PYTHON`) backend always returned `null` (unknown) from `audioEmbeddingAvailable()` / `vocalActivityAvailable()` / `textEmbeddingAvailable()` — capability was only ever probed via the sidecar's `/health`. With embeddings ON and the snapshot saying `analyzer local`, the doctor's AI review guessed 'you're on the LEAN image' — on an install where CLAP was loaded and working.
2. **The #974 hint reword sends AIO users the wrong way.** It tells non-compose installs to switch the analyzer container to `subwave-analyzer-heavy`. On an AIO install there is no analyzer container — following that advice swaps the whole station for a bare analyzer micro-service, which is exactly what locked up the reporter's system.

## Fix

- **`analyzer.ts`** — the local worker already emits `audio_embedding_capable` / `vocal_activity_capable` / `text_embedding_capable` on its ready line (cheap `find_spec` checks; the sidecar's `/health` reads the same fields); the local backend was discarding them. Now captured. Plus a one-shot `python -c` find_spec probe so `refreshCapabilities()` gets a definitive answer before the persistent worker ever boots (doctor-page case). The ready line is authoritative (it knows about hard load failures); the probe only fills nulls.
- **`doctor.ts`** — the upgrade hint is now backend-aware: sidecar installs get the `ANALYZER_HEAVY=1` / `subwave-analyzer-heavy` path; local installs get `subwave-aio-heavy` with an explicit warning **not** to use `subwave-analyzer-heavy`. The settings snapshot's analyzer line now carries measured capability (`heavy: CLAP yes` / `lean: no CLAP` / `CLAP unknown`) so the AI review reasons from fact.
- **`doctor-knowledge.ts`** — upgrade path split by deployment shape, and the AI review is forbidden from inferring 'lean' from `analyzer local` or the toggles alone.
- **`music/analyze.ts`** — shape-neutral wording on the backfill-skipped log.

## Side effect (intended)

A genuinely lean AIO now reports `false` instead of `null`, so the existing `!== false` gates correctly hide sound-search and skip futile embedding-backfill widening there too.

## Verification

- `npm run lint` (controller): 0 errors.
- Probe one-liner run against a real python: prints `{"audio": true, "vocal": false, "text": true}` (matches installed libs).