### PR TITLE
style(web): drop 'Bring any LLM' / 'Runs in your homelab' from landing hero taglines

### DIFF
--- a/web/components/what/ArticleHead.tsx
+++ b/web/components/what/ArticleHead.tsx
@@ -37,10 +37,6 @@ export default function ArticleHead() {
         <span aria-hidden="true">·</span>
         <span>Shows, skills &amp; guest co-hosts</span>
         <span aria-hidden="true">·</span>
-        <span>Bring any LLM</span>
-        <span aria-hidden="true">·</span>
-        <span>Runs in your homelab</span>
-        <span aria-hidden="true">·</span>
         <span className="text-vermilion">Open source</span>
       </div>
     </EditorialReveal>


### PR DESCRIPTION
Removes the "Bring any LLM" and "Runs in your homelab" entries (and their · separators) from the tagline strip under the landing hero in `web/components/what/ArticleHead.tsx`.

The strip now reads: An agentic AI DJ · Cloned-voice personas · Shows, skills & guest co-hosts · Open source.

Web lint (eslint + tsc) passes.