### PR TITLE
feat(player): deeper live-stream buffering to survive poor cellular coverage

### DIFF
--- a/app/src/audio/player.ts
+++ b/app/src/audio/player.ts
@@ -6,6 +6,7 @@
 // useStationFeed (the same model the web uses). Lock-screen metadata is pushed
 // from /now-playing polls via updateNowPlayingMetadata (see useNowPlayingInfo).
 
+import { Platform } from 'react-native';
 import TrackPlayer, {
   AppKilledPlaybackBehavior,
   Capability,
@@ -26,12 +27,21 @@ export function setupPlayer(): Promise<void> {
       // but missing from the lib's PlayerOptions type — extend it locally.
       const options: PlayerOptions & { iosCategoryPolicy?: 'longFormAudio' } = {
         autoHandleInterruptions: true,
-        // Do NOT set minBuffer here. Any non-zero preferredForwardBufferDuration
-        // on this infinite live stream silences AVPlayer entirely — its
-        // "safe to play" heuristic never satisfies on a duration-∞ item no
-        // matter how much data is buffered (4s behaved identically to 12s,
-        // with the station's ~11s Icecast burst fully available). Verified on
-        // device via the route-change/event trail, 2026-07-09.
+        // Deep buffering is ANDROID-ONLY. On iOS, minBuffer maps to
+        // preferredForwardBufferDuration, and any non-zero value on this
+        // infinite live stream silences AVPlayer entirely — its "safe to
+        // play" heuristic never satisfies on a duration-∞ item no matter how
+        // much data is buffered (4s behaved identically to 12s, with the
+        // station's Icecast burst fully available). Verified on device via
+        // the route-change/event trail, 2026-07-09. Never set these
+        // unconditionally.
+        // On Android these map to ExoPlayer's LoadControl: the player eagerly
+        // holds up to maxBuffer seconds (the Icecast connect burst fills most
+        // of it instantly), so a cellular dead zone drains the buffer instead
+        // of stalling (#993). playBuffer stays small so tune-in is instant.
+        ...(Platform.OS === 'android'
+          ? { minBuffer: 60, maxBuffer: 120, playBuffer: 2, backBuffer: 0 }
+          : {}),
         // The long-form-audio route-sharing policy (what Apple Music/Podcasts
         // use): iOS remembers the listener's chosen AirPlay device for this
         // app and keeps routing to it through audio-session churn. Without

--- a/docker/icecast.xml.template
+++ b/docker/icecast.xml.template
@@ -6,18 +6,24 @@
         <clients>${ICECAST_MAX_CLIENTS}</clients>
         <sources>4</sources>
         <!-- queue-size: per-client backlog before Icecast drops a lagging
-             listener. 1 MB ≈ 65s of MP3 / 85s of Opus — gives jittery mobile
-             and Cloudflare-proxied clients more rope before they're kicked. -->
-        <queue-size>1048576</queue-size>
+             listener. 2 MB ≈ 87s of MP3@192k / 131s@128k — must comfortably
+             exceed burst-size, and gives jittery mobile and Cloudflare-proxied
+             clients over a minute of rope to ride out a coverage gap without
+             being kicked (issue #993). -->
+        <queue-size>2097152</queue-size>
         <client-timeout>30</client-timeout>
         <header-timeout>15</header-timeout>
         <source-timeout>10</source-timeout>
         <burst-on-connect>1</burst-on-connect>
         <!-- burst-size: audio bursted to a client on connect to prime its
-             buffer. 256 KB ≈ 16s of MP3 / 20s of Opus (was 64 KB ≈ 4s/5s),
-             so a brief mobile network blip drains the buffer instead of
-             stalling and forcing the player's watchdog to reconnect. -->
-        <burst-size>262144</burst-size>
+             buffer. 512 KB ≈ 22s of MP3@192k / 33s@128k (was 256 KB ≈ 16s),
+             deep enough that a real cellular dead zone drains the buffer
+             instead of stalling (issue #993). Delivered at line speed, so
+             tune-in stays instant — the cost is listening that far behind
+             the live edge (and now-playing metadata leading the audio by
+             the same amount). Every player-watchdog reconnect carries a
+             ?t= cache-buster, so each reconnect primes a fresh burst. -->
+        <burst-size>524288</burst-size>
     </limits>
 
     <authentication>


### PR DESCRIPTION
Addresses the first two directions of #993 (the cheap wins; the HLS mount for iOS is a separate follow-up).

## What changed

**Icecast burst (`docker/icecast.xml.template`)** — benefits every client (web, app, hardware radios):
- `burst-size` 256 KB → **512 KB** ≈ 22s of MP3 at the default 192 kbps (~33s at 128k). A cellular dead zone now drains the buffer instead of stalling. The burst is delivered at line speed so tune-in stays instant; the trade is listening ~22s behind live, and now-playing metadata leading the audio by the same amount. Every player-watchdog reconnect carries a `?t=` cache-buster, so each reconnect primes a fresh burst.
- `queue-size` 1 MB → **2 MB** so a lagging client has over a minute of rope before Icecast kicks it.

**Android deep buffer (`app/src/audio/player.ts`)** — ExoPlayer buffer options in `setupPlayer` (`minBuffer: 60, maxBuffer: 120, playBuffer: 2, backBuffer: 0`), gated on `Platform.OS === 'android'`. On iOS, `minBuffer` maps to `preferredForwardBufferDuration`, which silences AVPlayer entirely on this duration-∞ stream (the documented dead end in player.ts, verified on device 2026-07-09) — the comment now warns these must never be set unconditionally.

## Why not more?

768 KB (~32s at 192k) was considered but dialled back per operator preference — 512 KB keeps the behind-live drift and metadata skew ~22s while still doubling the cushion.

## Verification

- `app`: `npm run typecheck` (tsc --noEmit) passes — confirms the RNTP 4.1.2 `PlayerOptions` buffer field names.
- Icecast constraint holds: burst-size (512 KB) < queue-size (2 MB).

## Deploy note

The template is baked into the broadcast image: needs `docker compose up -d --build broadcast` to take effect. Android change rides the next app build.

## Not included

iOS still runs dry after the burst is spent in a long outage — fixing that properly needs the HLS mount (#993 direction 3), which touches liquidsoap, Caddy, and settings. Suggested as a follow-up issue.