### PR TITLE
fix(analyzer): raise worker stdout line limit so /embed-text batches don't 500 (#996)

### DIFF
--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -336,6 +336,17 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
   // without the text tower.
   await scoreAudioMoods();
 
+  // The worker degrades silently when Demucs fails to load at runtime (weights
+  // download, OOM): every track analyses "ok" with vocal_ranges omitted, so a
+  // vocal backfill that stored nothing would otherwise look like a clean run —
+  // and re-target the same tracks forever (#996).
+  if (vocalBackfill && analyzed > 0 && vocalAnalyzed === 0) {
+    logEvent(
+      'warning',
+      'Vocal backfill stored no vocal-activity ranges — Demucs likely failed to load at runtime; check the analyzer container logs for "Demucs load failed"',
+    );
+  }
+
   logEvent(
     'success',
     `Audio analysed — ${analyzed.toLocaleString('en-GB')} tracks` +

--- a/controller/src/music/audio-moods.ts
+++ b/controller/src/music/audio-moods.ts
@@ -115,6 +115,16 @@ export async function runAudioMoodPass(): Promise<AudioMoodStats> {
   const prompts = SHOW_MOODS.map(moodPrompt);
   const vecs = await analyzer.embedTexts(prompts, { timeoutMs: 10 * 60_000 });
   if (!vecs || vecs.length !== SHOW_MOODS.length) {
+    // A backend that ADVERTISES the text tower but failed the call is a runtime
+    // fault (worker error, oversized-response 500 — #996), not a lean build;
+    // "enable ANALYZER_HEAVY" would send the operator in the wrong direction.
+    if (analyzer.textEmbeddingAvailable() === true) {
+      logEvent(
+        'warning',
+        'Text embedding failed even though the backend reports a CLAP text tower — check the analyzer container logs; skipping audio moods',
+      );
+      return { scored: 0, scope: ids.length, skipped: 'text embedding failed' };
+    }
     logEvent(
       'info',
       'Backend has no CLAP text tower — skipping audio moods (ANALYZER_HEAVY=1 enables it)',

--- a/docker/analyzer/server.py
+++ b/docker/analyzer/server.py
@@ -49,6 +49,12 @@ ANALYZE_SECONDS = os.environ.get("ANALYZE_SECONDS", "").strip() or "40"
 # compose files mount a named volume over it so the download survives recreates.
 ANALYZER_HF_HOME = os.environ.get("ANALYZER_HF_HOME", "/opt/analyzer/hf-cache")
 
+# Max bytes of one worker stdout line. asyncio's default StreamReader limit is
+# 64 KiB, which a batch /embed-text response blows straight past (17 mood
+# prompts x 512 floats is ~150 KB on one line) — readline() then raises
+# LimitOverrunError and the endpoint 500s (#996).
+WORKER_STDOUT_LIMIT = 16 * 1024 * 1024
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
@@ -130,6 +136,7 @@ class StdioWorker:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
+            limit=WORKER_STDOUT_LIMIT,
         )
         # Pump stderr to our log so the operator sees model load progress / fatal
         # errors in the container logs. The task exits when the worker closes

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -49,6 +49,11 @@ POCKET_TTS_DEFAULT_VOICE = os.environ.get("POCKET_TTS_VOICE", "alba")
 CHATTERBOX_HF_HOME = os.environ.get("CHATTERBOX_HF_HOME", "/opt/chatterbox/hf-cache")
 POCKET_HF_HOME = os.environ.get("POCKET_HF_HOME", "/opt/pocket-tts/hf-cache")
 
+# Max bytes of one worker stdout line. asyncio's default StreamReader limit is
+# 64 KiB; TTS responses are small (a WAV path) but keep this in step with the
+# analyzer sidecar so a future payload can't hit LimitOverrunError (#996).
+WORKER_STDOUT_LIMIT = 16 * 1024 * 1024
+
 # Which engines this sidecar should actually load. BOTH are baked into the
 # image, but loading a PyTorch model costs RAM + a multi-GB first-boot weight
 # download + 30-60s of startup — so an operator who only uses one engine can
@@ -161,6 +166,7 @@ class TtsWorker:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
+            limit=WORKER_STDOUT_LIMIT,
         )
         # Pump stderr to our log so the operator sees the worker's startup
         # output (model load progress, fatal errors, etc.) in tts-heavy's


### PR DESCRIPTION
## Problem (#996)

The analyzer sidecar reads its stdio worker's responses with `StreamReader.readline()`, but `asyncio.create_subprocess_exec` was created without a `limit=`, so lines are capped at asyncio's default **64 KiB**. A batch `POST /embed-text` response — 17 mood-vocab prompts × 512 floats on one JSON line — is ~113 KB, so `readline()` raises `LimitOverrunError` and the endpoint 500s. This means **every heavy-analyzer install's bulk audio-mood pass fails**, and because the controller treats any non-OK `/embed-text` as "lean build", it prints the misleading `Backend has no CLAP text tower — (ANALYZER_HEAVY=1 enables it)` even when the heavy image is running — exactly the reporter's confusion.

Single-text calls (the picker's `searchBySound`, ~10 KB) stay under the limit, which is why only the bulk pass broke.

## Fix

- `docker/analyzer/server.py`: pass `limit=16 MiB` to `create_subprocess_exec`.
- `docker/tts-heavy/server.py`: same hardening (responses are small today, but same latent pattern).

Repro/verify: a 17×512-float JSON line fails `readline()` at the default limit with the exact reported error and reads cleanly at 16 MiB.

## Observability (the issue's other two symptoms)

- **audio-moods**: when the backend *advertises* `analyze_text_capable` but the embed call fails, warn "check the analyzer container logs" instead of suggesting `ANALYZER_HEAVY=1`.
- **analyze pass**: `vocalAnalyzed: 0` after a vocal backfill that analysed everything "ok" means Demucs failed to load at runtime (sticky `_vocal_failed` in the worker degrades silently, and the backfill would re-target the same tracks forever). Emit a warning pointing at the `Demucs load failed` line in the analyzer logs.

## Notes for the issue reporter

The `/embed-text` 500 is fixed here. The `vocalAnalyzed: 0` needs their analyzer container logs (`docker logs subwave-analyzer-1 | grep -i demucs`) — most likely the htdemucs checkpoint download failed on first use (it fetches from `dl.fbaipublicfiles.com` at runtime; weights aren't baked into the image). Restarting the analyzer container retries the download.

## Testing

- `python -m py_compile` on both servers
- `npm run lint` (controller): 0 errors
- Scripted repro of the LimitOverrunError with/without the fix