### PR TITLE
fix(app): pause + drop stream when iOS output device disappears (#992)

### DIFF
--- a/app/docs/QA-CHECKLIST.md
+++ b/app/docs/QA-CHECKLIST.md
@@ -26,6 +26,8 @@ Mark each box per platform. Note the device + OS version you tested on.
 ## Resilience & connectivity
 
 - [ ] **iOS** / [ ] **Android** — **Headphone / Bluetooth unplug** pauses playback; pressing play (or replugging) **resumes at the LIVE edge**, not a stale buffered segment. _(validates A3 — `service.ts` RemotePlay re-load)_
+- [ ] **iOS** — **Output device disappears** (Bluetooth speaker powered off, or CarPlay: car turned off / cable pulled): app pauses instead of "playing" silently, and the **admin listener count decrements** within a few seconds (no phantom Icecast session). _(validates #992 — `usePlayer` route-change tune-out on `oldDeviceUnavailable`)_
+- [ ] **iOS** — **AirPlay regression guard**: pick a HomePod from the in-app AirPlay button, let a crossfade pass, pick the phone back — playback keeps running on the chosen device throughout, never snapping to the built-in speaker or pausing. _(the #992 pause must fire ONLY on `oldDeviceUnavailable`, not on handoffs — 0b060a3a behavior)_
 - [ ] **iOS** / [ ] **Android** — **Phone-call interruption**: audio ducks/pauses for the call and resumes after. _(validates `autoHandleInterruptions: true`)_
 - [ ] **iOS** / [ ] **Android** — **Wi-Fi → cellular switch** while tuned in: the **`CONNECTING…` / `NO CONNECTION` banner** appears and playback **reconnects within a beat** (not the full ~6s watchdog wait). _(validates A1 — `useConnectivity` proactive reconnect)_
 - [ ] **iOS** / [ ] **Android** — **Airplane-mode cold start**: launch with no network → app reaches the player with a **`NO CONNECTION` banner**, **no stuck splash**, no crash. Turn network back on → banner clears, can tune in.

--- a/app/modules/airplay-route-picker/index.tsx
+++ b/app/modules/airplay-route-picker/index.tsx
@@ -26,10 +26,17 @@ export default function AirplayButton(props: AirplayButtonProps) {
   return <NativeView {...props} />;
 }
 
+/** AVAudioSession.RouteChangeReason.oldDeviceUnavailable — the output device
+ *  the session was playing to went away (Bluetooth speaker powered off,
+ *  CarPlay disconnected, headphones unplugged). The one route-change reason
+ *  that means "pause"; every other reason is a handoff or reconfiguration to
+ *  keep playing through. */
+export const ROUTE_REASON_OLD_DEVICE_UNAVAILABLE = 2;
+
 export interface AudioRouteChange {
-  /** AVAudioSession.RouteChangeReason raw value — 3 = newDeviceAvailable,
-   *  2 = oldDeviceUnavailable, 4 = categoryChange, 6 = wakeFromSleep,
-   *  8 = routeConfigurationChange. */
+  /** AVAudioSession.RouteChangeReason raw value — 1 = newDeviceAvailable,
+   *  2 = oldDeviceUnavailable, 3 = categoryChange, 4 = override,
+   *  6 = wakeFromSleep, 8 = routeConfigurationChange. */
   reason: number;
   /** Current outputs, e.g. "AirPlay:HomePod" or "Speaker:iPad Speakers". */
   outputs: string;

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "subwave-app",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "subwave-app",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "hasInstallScript": true,
       "dependencies": {
         "@expo-google-fonts/fraunces": "^0.4.1",

--- a/app/src/hooks/usePlayer.ts
+++ b/app/src/hooks/usePlayer.ts
@@ -11,7 +11,10 @@ import TrackPlayer, {
   State,
   useTrackPlayerEvents,
 } from 'react-native-track-player';
-import { addAudioRouteChangeListener } from '../../modules/airplay-route-picker';
+import {
+  addAudioRouteChangeListener,
+  ROUTE_REASON_OLD_DEVICE_UNAVAILABLE,
+} from '../../modules/airplay-route-picker';
 import { getLastLiveMeta, loadAndPlay, setupPlayer, teardown } from '@/audio/player';
 import type { StationApi } from '@/lib/api';
 import { loadVolumePref, saveVolumePref } from '@/lib/volume';
@@ -66,17 +69,6 @@ export function usePlayer(
   useEffect(() => { apiRef.current = api; }, [api]);
 
   useEffect(() => { setupPlayer().catch(() => {}); }, []);
-
-  // Log iOS audio-route changes in dev builds — the forensic trail for
-  // AirPlay handoff issues (which reason code fires, what the route becomes,
-  // and how that interleaves with our reconnects).
-  useEffect(() => {
-    if (!__DEV__) return;
-    const sub = addAudioRouteChangeListener((e) => {
-      plog(`route change reason=${e.reason} outputs=${e.outputs}`);
-    });
-    return () => sub?.remove();
-  }, []);
 
   // Apply volume to the player engine whenever it changes.
   useEffect(() => {
@@ -211,6 +203,36 @@ export function usePlayer(
       }
     },
   );
+
+  // iOS audio-route changes. When the device we were playing to goes away
+  // (reason oldDeviceUnavailable: Bluetooth speaker powered off, CarPlay
+  // disconnected, headphones unplugged), treat it as a tune-out (#992). The
+  // longFormAudio session policy that keeps AirPlay routes sticky (see
+  // player.ts) also keeps AVPlayer "playing" to the vanished route — silent
+  // audio with the Icecast socket held open, a phantom listener. Every other
+  // reason is deliberately left alone: newDeviceAvailable / override /
+  // routeConfigurationChange are the AirPlay/HomePod handoffs that must keep
+  // playing (the 0b060a3a behavior). Also the dev-build forensic trail for
+  // route/handoff issues.
+  useEffect(() => {
+    const sub = addAudioRouteChangeListener((e) => {
+      plog(`route change reason=${e.reason} outputs=${e.outputs}`);
+      if (e.reason !== ROUTE_REASON_OLD_DEVICE_UNAVAILABLE || !tunedInRef.current) return;
+      // Same synchronous flip as the RemotePause handler above — the ref must
+      // read false before the trailing Stopped event lands, or the watchdog
+      // "recovers" the stream and the phantom listener is back.
+      clearWatchdog();
+      retryCount.current = 0;
+      tunedInRef.current = false;
+      setTunedIn(false);
+      setStatus('idle');
+      // stop() (not pause) unloads the item, so the stream connection drops
+      // and the listener count clears. lastLiveMeta survives (only teardown
+      // clears it), so a later Play resumes at the live edge via service.ts.
+      TrackPlayer.stop().catch(() => {});
+    });
+    return () => sub?.remove();
+  }, [clearWatchdog]);
 
   // Proactive reconnect: when the device link returns (false → true) while
   // we're tuned in but not already playing, reconnect immediately instead of


### PR DESCRIPTION
Fixes #992.

## What

On iOS, when the current output device goes away — Bluetooth speaker powered off, CarPlay disconnected, headphones unplugged — the app now pauses and drops the stream connection instead of "playing" silently and holding a phantom Icecast listener.

## Why

Regression from 0b060a3a: the `longFormAudio` session policy (added so AirPlay routes stay sticky through session churn) also suppresses the fall-back-to-speaker pause iOS would otherwise perform on `oldDeviceUnavailable`. AVPlayer stayed in the playing state with no audible output, the Icecast socket stayed open, and `listeners.ts` kept counting the session until the app was force-killed.

## How

Smaller than the issue proposed — **no Swift changes**. The `AirplayRoutePicker` native module already forwards `AVAudioSession.routeChangeNotification` (with the reason code) to JS; it was only consumed as a dev-build log. Now, in `usePlayer`:

- On **reason 2 (`oldDeviceUnavailable`)** while tuned in → tune-out: synchronous `tunedInRef` flip (same move as the RemotePause handler, so the stall watchdog can't "recover" the stream 500ms later), then `TrackPlayer.stop()` — which **unloads the item**, dropping the stream connection so the listener count clears.
- `lastLiveMeta` survives (only `teardown()` clears it), so a later lock-screen Play still resumes at the **live edge** via the `service.ts` RemotePlay re-load.
- **Every other reason is untouched** — `newDeviceAvailable` / `override` / `routeConfigurationChange` are the AirPlay/HomePod handoffs that must keep playing. The 0b060a3a stickiness is preserved.

Also: fixed the wrong reason-code doc comment in the module wrapper (`newDeviceAvailable` is 1 not 3, `categoryChange` 3, `override` 4 — the load-bearing `oldDeviceUnavailable = 2` was already right), exported the reason as a named constant, added the #992 scenarios plus an AirPlay regression guard to `QA-CHECKLIST.md`, and synced the app lockfile's stale version field (1.3.0 → 1.4.0) with package.json.

JS/TS-only → **OTA-shippable**, no new binary needed.

## Verification

- `npm run typecheck` (app): clean.
- Needs on-device QA (can't repro in simulator) — new checklist items cover it:
  - Bluetooth speaker: playing → power off → app pauses, admin listener count decrements, Play resumes at live edge.
  - CarPlay: playing → car off / cable pulled → same.
  - Regression guard: AirPlay to a HomePod and back keeps playing, never snaps to the built-in speaker.