### PR TITLE
feat(loudness): ReplayGain-first loudness source + stereo BS.1770 measurement (#998)

### DIFF
--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -470,7 +470,11 @@ def analyze_outro(path, librosa, duration_s):
     if not duration_s or duration_s <= OUTRO_SECONDS + 1.0:
         return None  # too short to have a distinct outro
     offset = max(0.0, duration_s - OUTRO_SECONDS)
-    y, sr = librosa.load(path, sr=ANALYZE_SR, mono=True, offset=offset)
+    # Channel-preserving decode for the loudness meter (the tail LUFS must be
+    # comparable to the body's stereo loudness_lufs — issue #998); RMS shape
+    # and the beat grid work off the mono downmix as before.
+    y_src, sr = librosa.load(path, sr=ANALYZE_SR, mono=False, offset=offset)
+    y = librosa.to_mono(y_src) if y_src is not None else None
     # Validation backstop for an unknown completeness: a truncated file either
     # errors here or decodes well short of the requested tail — skip it.
     if y is None or len(y) < ANALYZE_SR * OUTRO_SECONDS * 0.6:
@@ -506,7 +510,7 @@ def analyze_outro(path, librosa, duration_s):
 
     # Tail loudness — comparable to the track's loudness_lufs, so consumers can
     # judge how hot the material under the next intro will actually be.
-    lufs, _peak = measure_loudness(y, sr)
+    lufs, _peak = measure_loudness(y_src, sr)
 
     # Tail tempo + grid (absolute ms) — the truer anchor for bar-aligning the
     # exit than the leading window's tempo (outros drift/ritard).
@@ -717,10 +721,14 @@ def fetch_audio(url):
 
 def measure_loudness(y, sr):
     """Integrated loudness (LUFS, ITU-R BS.1770 / EBU R128) + true-ish peak in
-    dBFS over the decoded window. Best-effort: pyloudnorm is an optional dep, so
-    a missing import or any failure returns (None, None) and the caller simply
-    omits the fields — every consumer treats NULL as "no loudness, behave as
-    today" (same contract as the CLAP embedding)."""
+    dBFS over the decoded window. Accepts mono (n,) or librosa's multichannel
+    (channels, n) — pass the STEREO decode when available: BS.1770 sums the
+    energy of both channels, so the old mono average under-read center-heavy
+    mixes by up to ~3 dB and every gain computed from it aired that much hot
+    (issue #998). Best-effort: pyloudnorm is an optional dep, so a missing
+    import or any failure returns (None, None) and the caller simply omits the
+    fields — every consumer treats NULL as "no loudness, behave as today"
+    (same contract as the CLAP embedding)."""
     import numpy as np
 
     try:
@@ -731,8 +739,11 @@ def measure_loudness(y, sr):
 
     try:
         meter = pyln.Meter(sr)  # BS.1770 meter at the decode sample rate
-        lufs = float(meter.integrated_loudness(y))
-        peak = float(np.max(np.abs(y))) if len(y) else 0.0
+        # pyloudnorm wants (samples,) or (samples, channels); librosa decodes
+        # multichannel as (channels, samples).
+        data = y.T if getattr(y, "ndim", 1) > 1 else y
+        lufs = float(meter.integrated_loudness(data))
+        peak = float(np.max(np.abs(y))) if np.size(y) else 0.0
         peak_db = 20.0 * float(np.log10(peak)) if peak > 0 else None
         # integrated_loudness returns -inf for digital silence; treat as no signal.
         if not np.isfinite(lufs):
@@ -768,7 +779,11 @@ def analyze(librosa, url=None, path=None, embed=None, vocal=None, complete=None)
             log(f"duration probe failed ({e})")
             duration_s = 0.0
 
-        y, sr = librosa.load(path, sr=ANALYZE_SR, mono=True, duration=ANALYZE_SECONDS)
+        # Decode once WITH channels (a mono file still comes back 1-D): the
+        # loudness meter needs real stereo for a correct BS.1770 channel sum
+        # (issue #998); every other feature works off the mono downmix.
+        y_src, sr = librosa.load(path, sr=ANALYZE_SR, mono=False, duration=ANALYZE_SECONDS)
+        y = librosa.to_mono(y_src)
         # CLAP wants 48 kHz mono — decode fresh copies at that rate from the
         # SAME file (still present here, before the finally removes owned
         # temps), windowed across the track (see embed_windows). A model/
@@ -862,9 +877,10 @@ def analyze(librosa, url=None, path=None, embed=None, vocal=None, complete=None)
     pace = estimate_pace(y, sr, librosa)
 
     # Perceptual loudness (LUFS) over the decoded window — feeds per-track gain
-    # normalisation toward a target on the playback side. None when pyloudnorm
-    # is absent or measurement fails.
-    loudness_lufs, peak_db = measure_loudness(y, sr)
+    # normalisation toward a target on the playback side. Measured off the
+    # channel-preserving decode, not the mono downmix (issue #998). None when
+    # pyloudnorm is absent or measurement fails.
+    loudness_lufs, peak_db = measure_loudness(y_src, sr)
 
     # Overall confidence: dominated by how cleanly the key resolved, nudged by
     # whether we got a plausible tempo. Kept conservative on purpose.

--- a/controller/scripts/mix-fx.test.ts
+++ b/controller/scripts/mix-fx.test.ts
@@ -9,10 +9,12 @@ import {
   washoutDelayFor,
   effectAllowedFor,
   gainForLoudness,
+  loudnessFromReplayGain,
   WASHOUT_CROSS_TARGET_SECONDS,
   CROSS_MAX_SECONDS,
   LOUDNESS_MAX_BOOST_DB,
   LOUDNESS_CUT_CLAMP_DB,
+  REPLAYGAIN_REFERENCE_LUFS,
 } from '../src/music/mix.js';
 
 let failures = 0;
@@ -169,6 +171,42 @@ async function main() {
   await test('rounded to 0.1 dB', () => {
     assert.equal(gainForLoudness(-15.55), 1.6);
     assert.equal(gainForLoudness(-13.333), -0.7);
+  });
+
+  console.log('loudnessFromReplayGain (OpenSubsonic tag → measured-equivalent shape):');
+
+  await test('trackGain inverts around the −18 LUFS reference', () => {
+    assert.equal(REPLAYGAIN_REFERENCE_LUFS, -18);
+    // The issue-#998 track: RG trackGain −9.8 dB → the file really sits at −8.2 LUFS.
+    assert.deepEqual(loudnessFromReplayGain({ trackGain: -9.8 }), { lufs: -8.2, peakDb: null });
+    // A quiet master: +4 of gain needed → −22 LUFS.
+    assert.deepEqual(loudnessFromReplayGain({ trackGain: 4 }), { lufs: -22, peakDb: null });
+    // Exactly at reference.
+    assert.deepEqual(loudnessFromReplayGain({ trackGain: 0 }), { lufs: -18, peakDb: null });
+  });
+
+  await test('linear trackPeak converts to dBFS', () => {
+    assert.deepEqual(loudnessFromReplayGain({ trackGain: -9.8, trackPeak: 1.0 }), { lufs: -8.2, peakDb: 0 });
+    assert.equal(loudnessFromReplayGain({ trackGain: 0, trackPeak: 0.5 })!.peakDb, -6.02);
+    // Junk peak (0, negative, non-number) → null peak, gain still usable.
+    assert.equal(loudnessFromReplayGain({ trackGain: 0, trackPeak: 0 })!.peakDb, null);
+    assert.equal(loudnessFromReplayGain({ trackGain: 0, trackPeak: 'x' })!.peakDb, null);
+  });
+
+  await test('untagged / malformed shapes → null (fall through to measured)', () => {
+    assert.equal(loudnessFromReplayGain(null), null);
+    assert.equal(loudnessFromReplayGain(undefined), null);
+    assert.equal(loudnessFromReplayGain({}), null); // Navidrome's empty block for untagged files
+    assert.equal(loudnessFromReplayGain({ trackGain: NaN }), null);
+    assert.equal(loudnessFromReplayGain({ trackGain: '−9.8' }), null);
+    assert.equal(loudnessFromReplayGain('replaygain'), null);
+  });
+
+  await test('feeds gainForLoudness like a measurement (end-to-end for #998)', () => {
+    // Target −18: the −8.2 LUFS track gets the full −9.8 cut (within the 12 dB clamp)
+    // instead of the −4.3 the mis-measured −13.7 produced.
+    const rg = loudnessFromReplayGain({ trackGain: -9.8 })!;
+    assert.equal(gainForLoudness(rg.lufs, { targetLufs: -18 }), -9.8);
   });
 
   if (failures > 0) {

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -443,6 +443,10 @@ function trackFields(song) {
     // source: Subsonic `duration`, the picker tools' slim projection (what the
     // agent's `seen` map stores) `duration_sec`, library rows `durationSec`.
     duration: song.duration ?? song.duration_sec ?? song.durationSec ?? null,
+    // ReplayGain rides raw Subsonic songs (pool picks) but not the slim
+    // projection agent picks resolve from — stays undefined there, which
+    // tells queue.applyLoudnessGain to recover it with a getSong lookup.
+    replayGain: song.replayGain,
   };
 }
 

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -49,6 +49,11 @@ interface Track {
   musicalKey?: string | null;
   loudnessLufs?: number | null;
   peakDb?: number | null;
+  // OpenSubsonic ReplayGain block riding the raw Navidrome song object —
+  // subsonic.ts returns API children unmodified, so tagged files carry it
+  // into the queue for free. applyLoudnessGain prefers it over the measured
+  // LUFS when settings.loudness.source allows (issue #998).
+  replayGain?: { trackGain?: number | null; trackPeak?: number | null } | null;
   introMs?: number | null;
   keyRanges?: TrackKeyRange[] | null;
   outro?: TrackOutro | null;
@@ -560,22 +565,53 @@ class Queue {
     };
   }
 
-  // Resolve a track's integrated loudness + measured peak (track object first,
-  // else a library lookup) and stash a clamped gain offset toward the
-  // operator's loudness target on the track as `gainDb`. The peak lets
-  // gainForLoudness cap the boost by real headroom instead of a blind clamp.
-  // Null measurement → leaves gainDb undefined, so getAnnotatedUri emits no
+  // Resolve a track's integrated loudness + peak and stash a clamped gain
+  // offset toward the operator's loudness target on the track as `gainDb`.
+  // Source ladder is settings.loudness.source: an embedded ReplayGain tag
+  // (whole-file stereo R128 via Navidrome, issue #998) outranks the analyzer's
+  // measured LUFS (leading-window only) unless the operator pins one source.
+  // A track object without the `replayGain` key came through a projection
+  // that dropped it (the agent's slim candidates, a JSON round trip), so a
+  // one-row getSong recovers it — `replayGain: {}`/null means Navidrome was
+  // asked and the file is untagged, no lookup. Measured values resolve track
+  // object first, else a library lookup. The peak lets gainForLoudness cap
+  // the boost by real headroom instead of a blind clamp; a ReplayGain
+  // loudness keeps its own trackPeak (mixing it with the analyzer's window
+  // peak would cap against a different scan). Null loudness from every
+  // allowed source → leaves gainDb undefined, so getAnnotatedUri emits no
   // liq_amplify and the track plays at unity gain.
-  applyLoudnessGain(track: Track | null) {
+  async applyLoudnessGain(track: Track | null) {
     if (!track) return;
-    let lufs = track.loudnessLufs;
-    let peakDb = track.peakDb;
-    if ((lufs == null || peakDb == null) && track.id) {
-      const rec = library.get(track.id);
-      if (lufs == null) lufs = rec?.loudnessLufs ?? null;
-      if (peakDb == null) peakDb = rec?.peakDb ?? null;
-    }
     const loud = settings.get().loudness;
+    const source = loud?.source ?? 'replaygain-then-measured';
+    let lufs: number | null | undefined = null;
+    let peakDb: number | null | undefined = null;
+    if (source !== 'measured') {
+      let rg = mix.loudnessFromReplayGain(track.replayGain);
+      if (!rg && track.replayGain === undefined && track.id) {
+        try {
+          const song = await subsonic.getSong(track.id);
+          track.replayGain = song?.replayGain ?? null; // cache the answer either way
+          rg = mix.loudnessFromReplayGain(song?.replayGain);
+        } catch (err) {
+          // Best-effort — an unreachable Navidrome falls through to measured.
+          this.log('warn', `replayGain lookup failed for ${track.id}: ${(err as Error).message}`);
+        }
+      }
+      if (rg) {
+        lufs = rg.lufs;
+        peakDb = rg.peakDb;
+      }
+    }
+    if (lufs == null && source !== 'replaygain') {
+      lufs = track.loudnessLufs;
+      peakDb = track.peakDb;
+      if ((lufs == null || peakDb == null) && track.id) {
+        const rec = library.get(track.id);
+        if (lufs == null) lufs = rec?.loudnessLufs ?? null;
+        if (peakDb == null) peakDb = rec?.peakDb ?? null;
+      }
+    }
     const gain = mix.gainForLoudness(lufs, {
       peakDb,
       targetLufs: loud?.targetLufs,
@@ -900,11 +936,12 @@ class Queue {
         this.applyMixTransition(item);
 
         // Loudness normalisation (feature: LUFS gain) — applies to EVERY track,
-        // not just DJ mode. Resolve the track's integrated loudness (from the
-        // item or a library lookup) and stash a clamped gain offset toward the
-        // target; subsonic.getAnnotatedUri folds it into liq_amplify. Un-measured
-        // tracks resolve to null → no liq_amplify → unity gain, i.e. today.
-        this.applyLoudnessGain(item.track);
+        // not just DJ mode. Resolve the track's integrated loudness (ReplayGain
+        // tag first by default — see applyLoudnessGain — else the measured
+        // value from the item or a library lookup) and stash a clamped gain
+        // offset toward the target; subsonic.getAnnotatedUri folds it into
+        // liq_amplify. No loudness from any source → no liq_amplify → unity.
+        await this.applyLoudnessGain(item.track);
 
         // Hard length cap (#447 max-track-length): stamp a cue_out so Liquidsoap
         // cuts an over-length autonomous pick mid-air. Explicit listener requests

--- a/controller/src/music/mix.ts
+++ b/controller/src/music/mix.ts
@@ -137,6 +137,33 @@ export function gainForLoudness(
   return Math.round(gain * 10) / 10;
 }
 
+// ReplayGain 2.0 reference level (EBU R128). A tag's trackGain is the dB
+// offset that brings the track TO this reference, so the track's own
+// integrated loudness is reference − trackGain.
+export const REPLAYGAIN_REFERENCE_LUFS = -18;
+
+// OpenSubsonic `replayGain` field (Navidrome exposes it on every song Child
+// when the file carries RG tags) → the same {lufs, peakDb} shape the analyzer
+// measures, so gainForLoudness treats both sources identically. Preferred over
+// the analyzer's own measurement when present (issue #998): the tag is a
+// whole-file, stereo R128 scan, while the measured value covers only the
+// leading analysis window. trackPeak is linear (1.0 = FS) → dBFS. Returns null
+// when there's no usable trackGain — untagged files serialise as `{}` or omit
+// the field entirely.
+export function loudnessFromReplayGain(
+  rg: unknown,
+): { lufs: number; peakDb: number | null } | null {
+  if (!rg || typeof rg !== 'object') return null;
+  const gain = (rg as { trackGain?: unknown }).trackGain;
+  if (typeof gain !== 'number' || !Number.isFinite(gain)) return null;
+  const peak = (rg as { trackPeak?: unknown }).trackPeak;
+  const peakDb =
+    typeof peak === 'number' && Number.isFinite(peak) && peak > 0
+      ? Math.round(20 * Math.log10(peak) * 100) / 100
+      : null;
+  return { lufs: Math.round((REPLAYGAIN_REFERENCE_LUFS - gain) * 100) / 100, peakDb };
+}
+
 // True when a track carries at least one measured value. An un-analysed track
 // (both null) makes every consumer below a no-op, so an un-analysed library
 // behaves exactly as before.

--- a/controller/src/routes/dj.ts
+++ b/controller/src/routes/dj.ts
@@ -50,6 +50,7 @@ interface AdminSong {
   genre?: string | null;
   duration?: number | null;
   path?: string | null;
+  replayGain?: { trackGain?: number | null; trackPeak?: number | null } | null;
 }
 
 const SAY_TEXT_MAX = 500;
@@ -734,6 +735,12 @@ function toAdminRow(s: AdminSong) {
     // path lets getLocalPath() use the on-disk file when MUSIC_LIBRARY_PATH
     // is mounted, matching how listener-requested tracks are queued.
     path: s.path ?? null,
+    // Rides back through POST /dj/queue-track so a manually queued track gets
+    // the same ReplayGain-first loudness resolution as picker/request tracks.
+    // Deliberately NOT `?? null`: an absent key drops out of the JSON round
+    // trip and stays undefined, which tells applyLoudnessGain to re-fetch the
+    // song rather than trusting that the tag is really missing.
+    replayGain: s.replayGain,
     moods: tag?.moods ?? [],
     energy: tag?.energy ?? null,
     source: tag?.source ?? null,

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -1006,6 +1006,12 @@ export const MP3_BITRATES = [64, 96, 128, 160, 192, 320] as const;
 export const OPUS_BITRATES = [96, 128, 192, 256, 320] as const;
 export const AAC_BITRATES = [128, 192, 256] as const;
 
+// Where per-track loudness comes from (queue.applyLoudnessGain, issue #998):
+// an embedded ReplayGain tag (Navidrome's OpenSubsonic replayGain field),
+// the analyzer's measured LUFS, or tag-with-measured-fallback (the default).
+export const LOUDNESS_SOURCES = ['replaygain-then-measured', 'replaygain', 'measured'] as const;
+export type LoudnessSource = (typeof LOUDNESS_SOURCES)[number];
+
 const DEFAULTS = {
   jingleRatio: 30, // 1 jingle per N music tracks
   crossfadeDuration: 10.0, // seconds
@@ -1043,10 +1049,15 @@ const DEFAULTS = {
   // direction only — cuts have a fixed wide clamp, and the boost is further
   // limited by the track's own measured peak headroom, so widening this on a
   // dynamic library won't slam the broadcast limiter. Read live per track at
-  // annotate time; no mixer restart.
+  // annotate time; no mixer restart. `source` picks where the loudness figure
+  // comes from (issue #998): embedded ReplayGain tags (whole-file stereo R128,
+  // via Navidrome's OpenSubsonic replayGain field) vs the analyzer's measured
+  // LUFS (leading window only). The default prefers the tag and falls back to
+  // the measurement, so untagged libraries behave exactly as before.
   loudness: {
     targetLufs: -14,
     maxBoostDb: 6,
+    source: 'replaygain-then-measured' as LoudnessSource,
   },
   weather: { lat: 30.7333, lng: 76.7794, locationName: 'Punjab', units: 'metric' as 'metric' | 'imperial' },
   // Operator-facing station name. Substituted into the DJ prompt's {station}
@@ -1839,6 +1850,9 @@ export async function load() {
         stored.loudness.maxBoostDb <= BOUNDS.loudnessMaxBoostDb.max
           ? stored.loudness.maxBoostDb
           : DEFAULTS.loudness.maxBoostDb,
+      source: LOUDNESS_SOURCES.includes(stored.loudness?.source)
+        ? (stored.loudness.source as LoudnessSource)
+        : DEFAULTS.loudness.source,
     },
     weather: {
       lat: stored.weather?.lat ?? DEFAULTS.weather.lat,
@@ -2976,6 +2990,12 @@ export async function update(patch) {
         throw new Error(`loudness.maxBoostDb must be number in [${b.min}, ${b.max}]`);
       }
       next.loudness.maxBoostDb = v;
+    }
+    if (lo.source !== undefined) {
+      if (!LOUDNESS_SOURCES.includes(lo.source)) {
+        throw new Error(`loudness.source must be one of: ${LOUDNESS_SOURCES.join(', ')}`);
+      }
+      next.loudness.source = lo.source;
     }
   }
   if ('weather' in patch) {

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -24,6 +24,7 @@ import {
   SectionHeader, ELEVENLABS_VS_DEFAULTS,
   type FormState, type FormUpdater, type SettingsData, type SaveSettings,
   type SfxData, type SfxForm, type JingleImportFailure, type JingleImportResult,
+  type LoudnessSource,
 } from './settings/shared';
 import { TtsSection } from './settings/TtsSection';
 import { LlmSection } from './settings/LlmSection';
@@ -125,6 +126,7 @@ export default function SettingsPanel() {
       loudness: {
         targetLufs: String(v.loudness?.targetLufs ?? -14),
         maxBoostDb: String(v.loudness?.maxBoostDb ?? 6),
+        source: v.loudness?.source ?? 'replaygain-then-measured',
       },
       station: v.station ?? '',
       timezone: v.timezone ?? '',
@@ -809,6 +811,40 @@ export default function SettingsPanel() {
               <Card title="Loudness levelling" sub="per-track volume normalisation">
                 <div className="grid gap-3">
                   <div className="field">
+                    <Label>Loudness source</Label>
+                    <Select
+                      value={form.loudness.source}
+                      onValueChange={v =>
+                        setForm(f =>
+                          f
+                            ? {
+                                ...f,
+                                loudness: { ...f.loudness, source: v as LoudnessSource },
+                              }
+                            : f,
+                        )
+                      }
+                    >
+                      <SelectTrigger className="w-64">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="replaygain-then-measured">
+                          ReplayGain tags, then measured
+                        </SelectItem>
+                        <SelectItem value="replaygain">ReplayGain tags only</SelectItem>
+                        <SelectItem value="measured">Measured (acoustic analysis)</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <div className="field-hint">
+                      Where each track&rsquo;s loudness figure comes from. ReplayGain tags (read
+                      via Navidrome) are a whole-file stereo measurement — the most accurate when
+                      your library carries them. Measured values come from this station&rsquo;s
+                      acoustic analysis, which scans only the opening of each track. The default
+                      prefers the tag and falls back to the measurement for untagged files.
+                    </div>
+                  </div>
+                  <div className="field">
                     <Label>Target loudness</Label>
                     <div className="flex items-center gap-2">
                       <Input
@@ -857,6 +893,7 @@ export default function SettingsPanel() {
                             loudness: {
                               targetLufs: parseFloat(form.loudness.targetLufs),
                               maxBoostDb: parseFloat(form.loudness.maxBoostDb),
+                              source: form.loudness.source,
                             },
                           })
                         }

--- a/web/components/admin/settings/shared.tsx
+++ b/web/components/admin/settings/shared.tsx
@@ -165,9 +165,12 @@ export interface StreamForm {
   bitrate: string;
 }
 
+export type LoudnessSource = 'replaygain-then-measured' | 'replaygain' | 'measured';
+
 export interface LoudnessForm {
   targetLufs: string;
   maxBoostDb: string;
+  source: LoudnessSource;
 }
 
 export interface FormState {
@@ -227,7 +230,7 @@ export interface SettingsData {
       aacBitrate?: number;
       bitrate?: number;
     };
-    loudness?: { targetLufs?: number; maxBoostDb?: number };
+    loudness?: { targetLufs?: number; maxBoostDb?: number; source?: LoudnessSource };
     station?: string;
     timezone?: string;
     locale?: StationLocale;


### PR DESCRIPTION
Fixes #998 — tracks airing 3–6 dB over the loudness target.

## Why it aired hot

The analyzer's integrated LUFS was measured over a **mono downmix** of only the **leading analysis window**. `librosa`'s `mono=True` *averages* channels while BS.1770 *sums* their energy, so center-heavy mixes under-read by up to ~3 dB (verified: exactly +3.01 dB on center-panned content), and quiet intros dragged the figure further down. `gainForLoudness` then computed cuts that were far too small — the reporter's −13.7-measured / really-−8.2 LUFS track aired ~5.5 dB over target.

## Option A — ReplayGain as a loudness source

New `settings.loudness.source` (admin → Settings → Loudness levelling):

- **`replaygain-then-measured`** (default) — prefer the embedded ReplayGain tag, fall back to the analyzer's measurement. Untagged libraries behave exactly as before.
- **`replaygain`** — tags only (untagged tracks play at unity gain).
- **`measured`** — today's behaviour, pinned.

`mix.loudnessFromReplayGain` converts Navidrome's OpenSubsonic `replayGain` field — a whole-file, stereo, proper R128 scan — into the same `{lufs, peakDb}` shape the analyzer produces (`lufs = −18 − trackGain`, linear `trackPeak` → dBFS), so the existing clamping/peak-headroom logic in `gainForLoudness` applies unchanged.

Plumbing: raw Subsonic song objects already carry `replayGain` into the queue (picker pool, requests). Tracks that arrive through a projection that drops it — the pick agent's slim candidates, the admin manual queue's JSON round trip — recover it with a best-effort `getSong` lookup at drain time (`replayGain: {}`/`null` means "asked, untagged" and skips the lookup; an unreachable Navidrome falls through to measured).

## Option B (stereo half) — fix the measured path

`analyze_worker.py` now decodes with channels preserved and feeds pyloudnorm real stereo for a correct BS.1770 channel sum — both the body loudness and the outro tail LUFS (they must stay comparable for the tail-drop shaping). All other features (bpm, key, chroma, sections, intro) still work off the mono downmix, unchanged.

Verified inside the running `subwave-analyzer-heavy` container:
- center-panned stereo reads **+3.01 dB** over the old mono average (the textbook BS.1770 delta);
- anti-phase content, which the old downmix cancelled to digital silence, now measures;
- full `analyze()` smoke on a synthetic 30s stereo WAV produces bpm/key/loudness/peak + outro (fade detected, tail LUFS present).

## Notes

- **Existing library rows keep their mono-window LUFS until re-analysed.** The ReplayGain-first default sidesteps stale values wherever tags exist; a follow-up could version the loudness measurement and let doctor/coverage suggest re-analysis for untagged libraries.
- The 40s-window half of Option B is intentionally not in scope — a whole-file measurement conflicts with the byte-capped download design; RG tags are the whole-file answer.
- Analyzer change ships with the next image build (worker is baked into `subwave-analyzer*` and the AIO).

## Testing

- `mix-fx.test.ts` extended: RG→LUFS inversion (pinning the issue's exact numbers), peak conversion, untagged/malformed fallbacks, end-to-end gain for the reported track.
- Full controller suite: 29/29 test files pass. `controller` and `web` lint (eslint + tsc) clean.