### PR TITLE
feat(admin): cancel button for queued tracks on the dash

### DIFF
--- a/controller/src/broadcast/liquidsoap-control.ts
+++ b/controller/src/broadcast/liquidsoap-control.ts
@@ -177,7 +177,14 @@ async function fetchDjQueue(): Promise<DjQueueSnapshot> {
   for (const rid of rids) {
     try {
       const meta = await sendCommand(`request.metadata ${rid}`, 2000);
-      const match = /^subsonic_id="([^"]*)"/m.exec(meta);
+      // A pending request that Liquidsoap hasn't prepared yet is `status=idle`
+      // with no resolved top-level metadata — but its annotate URI is still
+      // there as `initial_uri="annotate:...,subsonic_id=\"…\"..."`. So match the
+      // id anywhere in the blob (tolerating the escaped quotes inside
+      // initial_uri), not just an anchored top-level `subsonic_id=` line — the
+      // furthest-out queued track (the one most likely to be cancelled) is
+      // exactly the one that's still idle. See #? / queue-cancel.
+      const match = /subsonic_id=\\?"([^"\\]+)/.exec(meta);
       if (match && match[1]) {
         ids.add(match[1]);
         if (!ridBySubsonicId.has(match[1])) ridBySubsonicId.set(match[1], rid);

--- a/controller/src/broadcast/liquidsoap-control.ts
+++ b/controller/src/broadcast/liquidsoap-control.ts
@@ -152,9 +152,15 @@ export async function streamStatus() {
   return /\bon\b/i.test(res);
 }
 
-interface DjQueueCache {
-  timestamp: number;
+interface DjQueueSnapshot {
   ids: Set<string>;
+  // subsonic_id → Liquidsoap request id. First occurrence wins on the off
+  // chance of a duplicate (queue.push dedupes by track id, so there shouldn't
+  // be one).
+  ridBySubsonicId: Map<string, string>;
+}
+interface DjQueueCache extends DjQueueSnapshot {
+  timestamp: number;
 }
 let _djQueueCache: DjQueueCache | null = null;
 let _djQueueInflight: Promise<Set<string>> | null = null;
@@ -162,7 +168,29 @@ let _djQueueInflight: Promise<Set<string>> | null = null;
 // Query Liquidsoap's dj_queue using two telnet hops:
 // 1. dj_queue.queue returns space-separated request IDs.
 // 2. request.metadata <rid> returns metadata for each request ID.
-// Returns a Set of subsonic_ids currently in the queue.
+async function fetchDjQueue(): Promise<DjQueueSnapshot> {
+  const res = await sendCommand('dj_queue.queue', 2000);
+  const rids = res.trim().split(/\s+/).filter(Boolean);
+  const ids = new Set<string>();
+  const ridBySubsonicId = new Map<string, string>();
+
+  for (const rid of rids) {
+    try {
+      const meta = await sendCommand(`request.metadata ${rid}`, 2000);
+      const match = /^subsonic_id="([^"]*)"/m.exec(meta);
+      if (match && match[1]) {
+        ids.add(match[1]);
+        if (!ridBySubsonicId.has(match[1])) ridBySubsonicId.set(match[1], rid);
+      }
+    } catch (ridErr: any) {
+      console.warn(`[liquidsoap] request.metadata ${rid} failed: ${ridErr.message}`);
+    }
+  }
+
+  return { ids, ridBySubsonicId };
+}
+
+// Returns a Set of subsonic_ids currently in the queue (cached ~4s).
 export async function getDjQueueIds(): Promise<Set<string>> {
   if (_djQueueCache && Date.now() - _djQueueCache.timestamp < 4000) {
     return _djQueueCache.ids;
@@ -173,33 +201,33 @@ export async function getDjQueueIds(): Promise<Set<string>> {
 
   _djQueueInflight = (async () => {
     try {
-      const res = await sendCommand('dj_queue.queue', 2000);
-      const rids = res.trim().split(/\s+/).filter(Boolean);
-      const subsonicIds = new Set<string>();
-
-      for (const rid of rids) {
-        try {
-          const meta = await sendCommand(`request.metadata ${rid}`, 2000);
-          const match = /^subsonic_id="([^"]*)"/m.exec(meta);
-          if (match && match[1]) {
-            subsonicIds.add(match[1]);
-          }
-        } catch (ridErr: any) {
-          console.warn(`[liquidsoap] request.metadata ${rid} failed: ${ridErr.message}`);
-        }
-      }
-
-      const ids = subsonicIds;
-      _djQueueCache = {
-        timestamp: Date.now(),
-        ids
-      };
-      return ids;
+      const snap = await fetchDjQueue();
+      _djQueueCache = { timestamp: Date.now(), ...snap };
+      return snap.ids;
     } finally {
       _djQueueInflight = null;
     }
   })();
 
   return _djQueueInflight;
+}
+
+// Resolve the Liquidsoap request id for a queued track. Always a fresh read —
+// cancel decisions can't ride a 4s-stale cache (the track may have gone on
+// air since). Returns null when the track is no longer pending in dj_queue.
+export async function resolveDjQueueRid(subsonicId: string): Promise<string | null> {
+  const snap = await fetchDjQueue();
+  _djQueueCache = { timestamp: Date.now(), ...snap };
+  return snap.ridBySubsonicId.get(subsonicId) ?? null;
+}
+
+// Remove a pending request from dj_queue via the custom "dj_queue_remove"
+// command in radio.liq. Returns false when Liquidsoap replies NOT_FOUND —
+// the request already left the queue (playing or played), so there is
+// nothing left to cancel.
+export async function removeFromDjQueue(rid: string): Promise<boolean> {
+  const res = await sendCommand(`dj_queue_remove ${rid}`, 2000);
+  _djQueueCache = null; // the queue just changed under the cache
+  return res.trim() === 'OK';
 }
 

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -891,6 +891,11 @@ class Queue {
           }
         }
 
+        // An operator cancel (removeUpcoming) may have spliced this item out
+        // while we were awaiting the TTS render above — don't hand a removed
+        // track to Liquidsoap.
+        if (!this.upcoming.includes(item)) continue;
+
         // DJ-mode mixing (features 1 & 2): shape the transition INTO this track
         // from its tempo/harmonic compatibility with the track it follows. The
         // predecessor is the item just ahead of it in the queue, else whatever
@@ -1428,6 +1433,30 @@ class Queue {
     }
   }
 
+  // Remove a not-yet-aired track from the upcoming queue (operator cancel).
+  // Sent items live inside Liquidsoap's dj_queue, so those are pulled back
+  // out over telnet first; the Node-side entry is only spliced once
+  // Liquidsoap confirms, so a failed removal never half-cancels. A track
+  // that already left dj_queue (on air, or being prepared as the next
+  // source) refuses with 'already-playing' — /dj/skip is the tool for that.
+  async removeUpcoming(trackId: string): Promise<{ ok: true } | { ok: false; reason: 'not-queued' | 'already-playing' }> {
+    const item = this.upcoming.find(i => i.track?.id === trackId);
+    if (!item) return { ok: false, reason: 'not-queued' };
+
+    if (item.sent) {
+      const rid = await liquidsoapControl.resolveDjQueueRid(trackId);
+      if (!rid || !(await liquidsoapControl.removeFromDjQueue(rid))) {
+        return { ok: false, reason: 'already-playing' };
+      }
+    }
+
+    const idx = this.upcoming.indexOf(item);
+    if (idx !== -1) this.upcoming.splice(idx, 1);
+    this.log('scheduler', `operator removed from queue: ${item.track.title} — ${item.track.artist}`);
+    this.persist();
+    return { ok: true };
+  }
+
   // Tracks played in the last `hours` hours — used by the picker to block
   // repeats. Returns BOTH ids and `title|artist` keys, because the boot
   // backfill (in recover()) reads from events-*.jsonl which lacks track ids;
@@ -1556,6 +1585,10 @@ class Queue {
 
   snapshot() {
     const mapItem = (i: QueueItem) => ({
+      // Track id rides along so the admin dash can target rows for the
+      // queue-cancel button (DELETE /dj/queue/:trackId); named to match the
+      // subsonic_id already public on /now-playing.
+      subsonic_id: i.track.id,
       title: i.track.title,
       artist: i.track.artist,
       album: i.track.album,

--- a/controller/src/routes/dj.ts
+++ b/controller/src/routes/dj.ts
@@ -716,6 +716,29 @@ router.post('/dj/skip', requireAdmin, async (req, res) => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// DELETE /dj/queue/:trackId — remove a not-yet-aired track from the upcoming
+// queue (operator override). Refuses with 409 once the track has left
+// Liquidsoap's dj_queue (it's on air or about to be) — that's /dj/skip
+// territory. Listeners can't reach this; there is no listener-facing cancel
+// by design, mirroring skip.
+// ---------------------------------------------------------------------------
+router.delete('/dj/queue/:trackId', requireAdmin, async (req, res) => {
+  try {
+    const result = await queue.removeUpcoming(req.params.trackId);
+    if (!result.ok) {
+      const msg = result.reason === 'already-playing'
+        ? 'too late to cancel — the track already left the queue'
+        : 'track is not in the queue';
+      return res.status(409).json({ error: msg, reason: result.reason });
+    }
+    res.json({ removed: true });
+  } catch (err) {
+    queue.log('error', `/dj/queue remove failed: ${err.message}`);
+    res.status(502).json({ error: err.message });
+  }
+});
+
 // Shape a Subsonic song into the queue-ready row the admin track tabs render,
 // merging the library index's stored tags AND acoustic-analysis columns so
 // search/recent rows carry the same mood/energy + BPM/key/LUFS badges as

--- a/docs/superpowers/specs/2026-07-12-queue-cancel-button-design.md
+++ b/docs/superpowers/specs/2026-07-12-queue-cancel-button-design.md
@@ -1,0 +1,137 @@
+# Admin dash: cancel button for queued tracks
+
+**Date:** 2026-07-12
+**Status:** Draft — awaiting review
+
+## Problem
+
+The operator sometimes sees an impending track they dislike (a bad DJ pick, or
+a track they queued by mistake) in the admin dash Queue card. Today the only
+tools are `/dj/skip` (only works once the track is already on air, and burns a
+crossfade) or waiting it out. There is no way to remove a track from the queue
+before it airs.
+
+## Goal
+
+An `[X]` cancel button on each row of the Queue card in `/admin/dash` that
+removes that track from the upcoming queue before it plays. Operator-only.
+
+## The load-bearing constraint
+
+`queue.drainToLiquidsoap()` feeds every queued item into Liquidsoap's
+`dj_queue` (a `request.queue`) as soon as it lands in `upcoming`, marking it
+`sent: true`. So by the time the operator sees a track in the dash, it is
+almost always already inside Liquidsoap. Cancelling therefore means removing
+the request from Liquidsoap's queue over telnet, then splicing the Node-side
+`upcoming` entry — not just the array splice.
+
+## Approaches considered
+
+1. **Liquidsoap-side removal via a new telnet command (chosen).** Register a
+   `dj_queue_remove <rid>` server command in `radio.liq` that filters the
+   request out of `dj_queue.queue()` and writes the remainder back with
+   `dj_queue.set_queue(...)` (Liquidsoap 2.4.x supports both methods). The
+   controller resolves the RID from the track's `subsonic_id` using the same
+   two-hop telnet pattern `getDjQueueIds()` already uses. Cost: a `radio.liq`
+   change means a broadcast image rebuild in prod. Risk: a small race if the
+   track goes on air mid-click — handled by refusing with a clear error.
+2. **Stop pre-sending: keep all but the head item Node-side.** Cancel becomes
+   a pure array splice. Rejected: the send pipeline, crossfade prefetch,
+   request-intro timing, and `reconcileWithDjQueue()` all assume items are
+   sent eagerly; restructuring that is far more risk than this feature
+   warrants.
+3. **Tombstone + auto-skip when the cancelled track starts.** Rejected: a
+   second of the unwanted track airs and a crossfade is wasted — bad listener
+   experience for no implementation saving.
+
+## Design
+
+### Liquidsoap (`liquidsoap/radio.liq`)
+
+New server command alongside the existing `skip`/`stream_*` registrations:
+
+```
+dj_queue_remove <rid>   → "OK" | "NOT_FOUND"
+```
+
+Implementation: parse the RID, `list.filter` it out of `dj_queue.queue()` by
+`request.id`, `dj_queue.set_queue(...)`. If no request matched, return
+`NOT_FOUND` and leave the queue untouched. Only requests still *pending* in
+the queue are listed by `.queue()` — a track already being played (or being
+prefetched as the current source) is naturally not removable, which is the
+behaviour we want.
+
+### Controller
+
+- **`broadcast/liquidsoap-control.ts`** — extend the existing dj_queue query
+  to also return a `subsonic_id → rid` map (same telnet hops as
+  `getDjQueueIds()`, shared code path; the 4s cache keeps its current shape).
+  New `removeFromDjQueue(rid)` sends `dj_queue_remove <rid>` and invalidates
+  the cache on success.
+- **`broadcast/queue.ts`** — new `async removeUpcoming(trackId)`, the single
+  place that owns cancel semantics:
+  - Find the item in `upcoming` by `track.id`. Not found → `{ ok: false,
+    reason: 'not-queued' }` (it probably just went on air).
+  - If `!sent` (rare in-flight window): splice, persist, done.
+  - If `sent`: resolve the RID; RID missing or Liquidsoap replies
+    `NOT_FOUND` → `{ ok: false, reason: 'already-playing' }`, leave `upcoming`
+    alone (reconcile will converge). On `OK`: splice, persist.
+  - Log via the existing DJ log: `queue.log('scheduler', 'operator removed
+    <title> — <artist> from queue')`. No LLM call, no session turn.
+  - If the queue empties, the existing auto-pick gate
+    (`upcoming.length === 0`) refills it on the next tick — no extra work.
+  - The item's pre-rendered intro WAV (if any) simply never airs —
+    `airIntro()` is keyed to `onTrackStarted` matching — and the >1h TTS
+    cleaner collects the file.
+- **`routes/dj.ts`** — `DELETE /dj/queue/:trackId`, `requireAdmin`-gated,
+  next to `POST /dj/skip`. 200 `{ removed: true }` on success; 409 with the
+  reason string on `not-queued` / `already-playing`; 502 on telnet failure.
+- **`snapshot()`** (`queue.ts`) — add `id: i.track.id` to `mapItem` so the
+  dash can target rows. `/state` is public but already exposes titles/artists,
+  and `subsonic_id` already rides on `/now-playing`; no new exposure class.
+
+### Web (`web/components/admin/DashPanel.tsx`)
+
+- Each rendered queue row gets an `[X]` button (matching the dash's existing
+  compact row styling), wired to `adminFetch('/dj/queue/<id>', { method:
+  'DELETE' })`.
+- **No confirmation dialog** — unlike Skip (which cuts on-air audio and got a
+  confirm), removing a not-yet-aired track is low-stakes and the operator
+  asked for a one-click `[X]`.
+- While the request is in flight the row's button is disabled; on success
+  re-fetch `/state` (reuse the existing refresh path) so the row disappears;
+  on 409/error surface the message via the existing error/toast surface and
+  re-fetch anyway (the queue moved under us).
+- Rows without an `id` (shouldn't happen post-`snapshot()` change) render no
+  button.
+
+## Error handling summary
+
+| Failure | Behaviour |
+|---|---|
+| Track went on air between render and click | 409 `already-playing`; UI toast + refresh |
+| Track already consumed / not in `upcoming` | 409 `not-queued`; UI toast + refresh |
+| Telnet unreachable (mixer restarting) | 502; `upcoming` untouched; UI toast |
+| Liquidsoap removed but splice raced a reconcile | Reconcile pass 2 already drops confirmed-then-gone items — converges on its own |
+
+## Testing
+
+- `npm run lint` in `controller/` and `web/` (the merge gate).
+- Manual: dev stack (`docker-compose.dev.yml` bind-mounts `radio.liq` and
+  `controller/src`), queue two tracks via admin, cancel the second → row
+  disappears, `dj_queue.queue` over telnet shows one RID, track never airs.
+  Cancel the head item just as it starts → 409 path.
+- No new pure-logic seam worth a unit test; the cancel path is I/O glue.
+
+## Out of scope (YAGNI)
+
+- Listener-facing cancel (players intentionally have no skip/cancel).
+- MCP tool (`subwave_cancel_track`) — trivial to add later on top of the same
+  endpoint if wanted.
+- Reordering the queue / drag-and-drop.
+- DJ acknowledging the cancellation on air.
+
+## Deployment note
+
+`radio.liq` is baked into the broadcast image: prod needs
+`docker compose up -d --build broadcast` (dev bind-mounts it — restart only).

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -1679,3 +1679,34 @@ server.register(
     "OK"
   end
 )
+
+# Remove a PENDING request from dj_queue by request id (RID). Whatever is on
+# air — or already pulled out of the queue as the next source — is no longer
+# in .queue(), so it reports NOT_FOUND instead of half-removing; the caller
+# treats that as "too late to cancel". Used by the controller's queue-cancel
+# endpoint (DELETE /dj/queue/:trackId), which resolves the RID via
+# dj_queue.queue + request.metadata first. Operator-only — listeners can't
+# reach this.
+server.register(
+  "dj_queue_remove",
+  description="Remove a pending request from dj_queue by request id",
+  usage="dj_queue_remove <rid>",
+  fun(arg) -> begin
+    rid = string.trim(arg)
+    q = dj_queue.queue()
+    kept = list.filter(fun(r) -> "#{request.id(r)}" != rid, q)
+    if list.length(kept) == list.length(q) then
+      "NOT_FOUND"
+    else
+      dj_queue.set_queue(kept)
+      # Destroy the dropped request so its file/URI is released now instead of
+      # lingering until Liquidsoap flags it as leaked.
+      list.iter(
+        fun(r) -> if "#{request.id(r)}" == rid then request.destroy(r) end,
+        q
+      )
+      log("Removed request #{rid} from dj_queue via server command")
+      "OK"
+    end
+  end
+)

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3457,7 +3457,7 @@ html.lite .sw-ripple-circle {
 /* Track row */
 .admin-root .track-row {
     display: grid;
-    grid-template-columns: 24px 1fr 64px 36px 60px;
+    grid-template-columns: 24px 1fr 64px 60px 36px;
     gap: 12px;
     align-items: center;
     padding: 7px 6px;

--- a/web/components/admin/DashPanel.tsx
+++ b/web/components/admin/DashPanel.tsx
@@ -24,7 +24,7 @@ import { V3Alert } from '../ui/alert';
 import { Textarea } from '../ui/textarea';
 import { Card, Btn, Pill, Seg, Toggle } from './ui';
 import { ScrollArea, ScrollBar } from '../ui/scroll-area';
-import { AudioLines, Clock3, MessagesSquare, RadioTower, type LucideIcon } from 'lucide-react';
+import { AudioLines, Clock3, MessagesSquare, RadioTower, X, type LucideIcon } from 'lucide-react';
 import StationHeader, { type HealthMetrics } from './StationHeader';
 import { cn } from '../../lib/cn';
 
@@ -388,6 +388,36 @@ export default function DashPanel() {
   // button opens a confirm dialog; this runs only after the operator accepts.
   const doSkip = () => act('skip', '/dj/skip', {}, 'skip track');
 
+  // Cancel a queued track before it airs. One click, no confirm — unlike
+  // skip, nothing on-air changes; worst case is a 409 because the track went
+  // on air first. Optimistically drop the row; the 3s poll confirms.
+  const cancelQueued = async (t: QueueEntry) => {
+    const id = typeof t.subsonic_id === 'string' ? t.subsonic_id : '';
+    if (!id) return;
+    setBusy(`cancel:${id}`);
+    try {
+      const r = await adminFetch(`/dj/queue/${encodeURIComponent(id)}`, { method: 'DELETE' });
+      const j = (await r.json().catch(() => ({}))) as ActResponse;
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      notify.ok(`removed from queue: ${t.title || 'track'}`);
+      setStatus(s =>
+        s
+          ? {
+              ...s,
+              queue: {
+                ...(s.queue || {}),
+                upcoming: (s.queue?.upcoming || []).filter(u => u.subsonic_id !== id),
+              },
+            }
+          : s,
+      );
+    } catch (e) {
+      notify.err(`cancel: ${errorMessage(e)}`);
+    } finally {
+      setBusy(null);
+    }
+  };
+
   const np = status?.nowPlaying;
   const ctx = status?.context;
   // Station zone — on-air timestamps render in it so they match what the DJ
@@ -471,7 +501,20 @@ export default function DashPanel() {
                       ? t.duration
                       : ''}
                   </span>
-                  <span></span>
+                  <span className="text-right">
+                    {typeof t.subsonic_id === 'string' && t.subsonic_id ? (
+                      <button
+                        type="button"
+                        onClick={() => cancelQueued(t)}
+                        disabled={busy === `cancel:${t.subsonic_id}`}
+                        title="Remove from queue"
+                        aria-label={`Remove ${t.title || 'track'} from queue`}
+                        className="inline-flex h-5 w-5 items-center justify-center rounded text-muted transition-colors hover:bg-vermilion/10 hover:text-vermilion disabled:pointer-events-none disabled:opacity-40"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    ) : null}
+                  </span>
                   {t.requestedBy ? (
                     <span className="text-right text-[9px] font-bold tracking-[0.2em] text-vermilion uppercase">
                       ↳ {t.requestedBy}

--- a/web/components/admin/DashPanel.tsx
+++ b/web/components/admin/DashPanel.tsx
@@ -501,6 +501,13 @@ export default function DashPanel() {
                       ? t.duration
                       : ''}
                   </span>
+                  {t.requestedBy ? (
+                    <span className="text-right text-[9px] font-bold tracking-[0.2em] text-vermilion uppercase">
+                      ↳ {t.requestedBy}
+                    </span>
+                  ) : (
+                    <span></span>
+                  )}
                   <span className="text-right">
                     {typeof t.subsonic_id === 'string' && t.subsonic_id ? (
                       <button
@@ -515,13 +522,6 @@ export default function DashPanel() {
                       </button>
                     ) : null}
                   </span>
-                  {t.requestedBy ? (
-                    <span className="text-right text-[9px] font-bold tracking-[0.2em] text-vermilion uppercase">
-                      ↳ {t.requestedBy}
-                    </span>
-                  ) : (
-                    <span></span>
-                  )}
                 </div>
               ))
             )}


### PR DESCRIPTION
Adds an **[X] cancel button** to each row of the Queue card on `/admin/dash`, so the operator can remove an impending track they dislike (or queued by mistake) before it airs.

## Why it isn't just an array splice

`drainToLiquidsoap()` feeds every pick straight into Liquidsoap's `dj_queue` (`sent: true`), so by the time a track shows on the dash it already lives inside Liquidsoap. Cancel therefore pulls the request back out over telnet first, and only then splices the Node-side entry — a failed removal never half-cancels.

## Changes

- **`radio.liq`**: new `dj_queue_remove <rid>` server command beside `skip` — filters the RID out of `dj_queue.queue()` via `set_queue`, destroys the dropped request (no leak), returns `OK`/`NOT_FOUND`. A track already on air (or pulled as the next source) is no longer in `.queue()`, so it reports `NOT_FOUND` — the safe refusal.
- **`liquidsoap-control.ts`**: the dj_queue query now also builds a `subsonic_id → rid` map; `resolveDjQueueRid()` (always a fresh read — no 4s-stale cancels) + `removeFromDjQueue()`.
- **`queue.ts`**: `removeUpcoming(trackId)` — unsent items splice directly; sent items go through Liquidsoap first; 409-style refusals for `not-queued` / `already-playing`. A guard in the drain loop stops a mid-TTS-render race from sending a just-cancelled track. `snapshot()` now exposes `subsonic_id` per item so the dash can target rows.
- **`routes/dj.ts`**: `DELETE /dj/queue/:trackId`, admin-gated, beside `/dj/skip`. No listener-facing cancel, mirroring skip.
- **`DashPanel.tsx`**: per-row [X], optimistic removal, toast on refusal, disabled while in flight. No confirm dialog — unlike Skip, nothing on-air changes; worst case the track went on air first and you get the 409 toast.

Cancelling the last queued track lets the existing auto-pick gate (`upcoming.length === 0`) refill naturally. Design spec in `docs/superpowers/specs/2026-07-12-queue-cancel-button-design.md`.

## Verified

- `liquidsoap --check` of the edited `radio.liq` in the `subwave-broadcast` image (2.4.5): clean.
- Live runtime test in a standalone broadcast container: queued 5 tracks via `next.txt`, `dj_queue_remove` of a pending RID → `OK` + gone from `dj_queue.queue`; already-consumed RID and bogus RID → `NOT_FOUND`; removal logged; pipeline kept decoding afterwards.
- `npm run lint` clean in `controller/` and `web/` (0 errors).

## Deployment note

`radio.liq` is baked into the broadcast image — prod needs `docker compose up -d --build broadcast` (dev bind-mounts it; restart only).