### PR TITLE
feat(skills): tags, filter/sort, and assign-to-DJs from the skill editor

### DIFF
--- a/controller/src/routes/dj.ts
+++ b/controller/src/routes/dj.ts
@@ -15,7 +15,7 @@ import * as settings from '../settings.js';
 import { runStationId, runHourlyCheck, runLink, runBanter, runProgrammeIntro, runProgrammeFeature, runProgrammeOutro, refreshAutoPlaylist } from '../broadcast/scheduler.js';
 import { skillCatalog, runCapability, effectiveContextFields } from '../skills/_agent.js';
 import * as sfxLib from '../broadcast/sfx.js';
-import { loadSkills, parseFrontmatter, SEEDED_KINDS, RESERVED_KINDS, SLUG_RE, readTemplate, listCommunitySkills, readCommunitySkill } from '../skills/loader.js';
+import { loadSkills, parseFrontmatter, parseTags, SEEDED_KINDS, RESERVED_KINDS, SLUG_RE, TAG_RE, TAGS_PER_SKILL_LIMIT, readTemplate, listCommunitySkills, readCommunitySkill } from '../skills/loader.js';
 import { writeSkillFile, msToCooldownStr, resetBuiltinSkill } from '../skills/scaffold.js';
 import { mapPool } from '../util/async-pool.js';
 import { readFile, rm, stat, mkdir, writeFile } from 'node:fs/promises';
@@ -37,7 +37,28 @@ interface SkillFields {
   requiresKey?: string;
   feed?: string;
   feedMaxItems?: number;
+  tags?: string[];
   brief?: string;
+}
+
+// Normalise a tags form value (array or comma string) with LOUD validation — a
+// bad tag 400s here instead of silently vanishing (the loader's lenient
+// parseTags is for hand-edited files; the form should fail fast).
+function buildTags(raw: unknown): string[] | undefined {
+  const list = Array.isArray(raw) ? raw : String(raw ?? '').split(',');
+  const out: string[] = [];
+  for (const item of list) {
+    const tag = String(item ?? '').trim().toLowerCase();
+    if (!tag) continue;
+    if (!TAG_RE.test(tag)) {
+      throw new Error(`invalid tag "${tag}" — lowercase slugs (a-z, 0-9, hyphens), max 24 chars`);
+    }
+    if (!out.includes(tag)) out.push(tag);
+  }
+  if (out.length > TAGS_PER_SKILL_LIMIT) {
+    throw new Error(`at most ${TAGS_PER_SKILL_LIMIT} tags per skill`);
+  }
+  return out.length ? out : undefined;
 }
 
 // The subset of a Subsonic song toAdminRow reads to build a queue-ready row.
@@ -309,6 +330,8 @@ function buildCustomSkillFields(slug: string, b: Record<string, unknown>): Skill
     fields.requiresKey = key;
   }
 
+  if (b.tags !== undefined) fields.tags = buildTags(b.tags);
+
   return fields;
 }
 
@@ -332,6 +355,7 @@ router.get('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
       label: tpl.data.label || kind,
       cooldown: tpl.data.cooldown || '60m',
       context: (effectiveContextFields({ contextFields: tpl.data.context ?? tpl.data.contextFields }) || []).join(', '),
+      tags: parseTags(tpl.data.tags),
       brief: tpl.body || '',
       ...(kind === 'news' ? { feed: config.news.feedUrl, feedMaxItems: config.news.maxItems } : {}),
     } : null;
@@ -353,6 +377,7 @@ router.get('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
         knownContextFields: [...dj.CONTEXT_FIELDS],
         feed: data.feed || cat?.feed || null,
         feedMaxItems: data.feedMaxItems ? parseInt(data.feedMaxItems, 10) : (cat?.feedMaxItems || null),
+        tags: parseTags(data.tags),
         brief: body || cat?.description || '',
         // Built-ins now carry an editable tool.mjs in state too (seeded on first
         // boot), so the edit form shows the same "edit on disk + Rescan" hint as
@@ -373,6 +398,7 @@ router.get('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
         knownContextFields: [...dj.CONTEXT_FIELDS],
         feed: cat?.feed || null,
         feedMaxItems: cat?.feedMaxItems || null,
+        tags: cat?.tags || [],
         brief: cat?.description || '',
         hasTool: await skillHasTool(kind),
         defaults,
@@ -398,6 +424,7 @@ router.get('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
       knownContextFields: [...dj.CONTEXT_FIELDS],
       window: data.window === 'commute' ? 'commute' : 'any',
       requiresKey: data.requiresKey || '',
+      tags: parseTags(data.tags),
       hasTool: await skillHasTool(kind),
       brief: body || '',
     });
@@ -504,6 +531,14 @@ router.put('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
     if (toks.length) fields.contextFields = toks;
   }
 
+  if (b.tags !== undefined) {
+    try {
+      fields.tags = buildTags(b.tags);
+    } catch (err) {
+      return res.status(400).json({ error: err.message });
+    }
+  }
+
   // Feed is news-only. Validate it parses as an http(s) URL.
   if (kind === 'news') {
     const feed = typeof b.feed === 'string' ? b.feed.trim() : '';
@@ -527,6 +562,64 @@ router.put('/dj/skills/:kind/file', requireAdmin, async (req, res) => {
     res.json({ skills: skillCatalog() });
   } catch (err) {
     queue.log('error', `PUT /dj/skills/${kind}/file failed: ${err.message}`);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// PUT /dj/skills/:slug/personas — reverse assignment: set exactly which DJs run
+// this skill, from the skill's own editor (instead of persona-by-persona in
+// PersonaSkillsCard — both write the same personas[].skills field).
+// Body: { personaIds: string[] } — the personas that SHOULD have the skill.
+// The read-modify-write happens server-side so the null sentinel ("all skills")
+// is interpreted in exactly one place: null + assigned → stays null (already
+// covered); null + unassigned → materialises the full current catalog minus
+// this skill (what un-ticking the first box in PersonaSkillsCard does too).
+// ---------------------------------------------------------------------------
+router.put('/dj/skills/:slug/personas', requireAdmin, async (req, res) => {
+  const slug = req.params.slug;
+  const catalog = skillCatalog();
+  if (!catalog.some((sk) => sk.name === slug)) {
+    return res.status(404).json({ error: `no such skill: ${slug}` });
+  }
+
+  const raw = req.body?.personaIds;
+  if (!Array.isArray(raw) || raw.some((id) => typeof id !== 'string')) {
+    return res.status(400).json({ error: 'personaIds must be an array of persona ids' });
+  }
+  const want = new Set<string>(raw);
+  const s = settings.get();
+  const known = new Set(s.personas.map((p) => p.id));
+  const unknown = [...want].filter((id) => !known.has(id));
+  if (unknown.length) {
+    return res.status(400).json({ error: `unknown persona id(s): ${unknown.join(', ')}` });
+  }
+
+  const allSlugs = catalog.map((sk) => sk.name);
+  let changed = false;
+  const personas = s.personas.map((p) => {
+    const has = p.skills === null || p.skills.includes(slug);
+    const should = want.has(p.id);
+    if (has === should) return p;
+    changed = true;
+    // `should && !has` implies p.skills is an array (null would mean has=true).
+    if (should) return { ...p, skills: [...p.skills, slug] };
+    const base = p.skills === null ? allSlugs : p.skills;
+    return { ...p, skills: base.filter((sl) => sl !== slug) };
+  });
+
+  try {
+    if (changed) await settings.update({ personas });
+    queue.log('scheduler', `[skills] "${slug}" DJ assignments updated via admin UI`);
+    res.json({
+      personas: personas.map((p) => ({
+        id: p.id,
+        name: p.name,
+        hasSkill: p.skills === null || p.skills.includes(slug),
+      })),
+    });
+  } catch (err) {
+    queue.log('error', `PUT /dj/skills/${slug}/personas failed: ${err.message}`);
     res.status(500).json({ error: err.message });
   }
 });

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -656,7 +656,10 @@ const EXCLUDED_PLAYLISTS_PER_SHOW = 10;
 // attribute the values OR together at pick time; across attributes they AND —
 // so past a handful the filter stops meaning anything.
 const SHOW_FILTER_VALUES_MAX = 6;
-const SKILLS_PER_PERSONA_LIMIT = 20;
+// Must comfortably exceed a realistic skill library: unticking one skill on an
+// "all skills" (null) persona materialises the FULL catalog minus one, so a cap
+// near the library size would make that first untick fail (#skill-organization).
+const SKILLS_PER_PERSONA_LIMIT = 64;
 const WEBHOOKS_LIMIT = 16;
 // Prompt-template library (djPrompts). Text bounds match the historical
 // single-djPrompt rule — keep them in lockstep with PROMPT_MIN/PROMPT_MAX in

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -769,6 +769,9 @@ export function skillCatalog() {
       // #471). Resolved to the default profile (no weather) when unset, so the
       // admin UI can render the current tick-box selection without guessing.
       contextFields: effectiveContextFields(c),
+      // Freeform organisation tags from SKILL.md frontmatter — filter fodder
+      // for the admin skill list.
+      tags: c.tags || [],
     };
   });
 }

--- a/controller/src/skills/loader.ts
+++ b/controller/src/skills/loader.ts
@@ -125,6 +125,24 @@ function parseContextFields(raw: string | undefined): string[] | undefined {
   return list.length ? list : undefined;
 }
 
+// Freeform organisation tags (`tags: late-night, factual`) — operator vocabulary
+// for filtering the admin skill list. Lowercase slugs, deduped, capped; invalid
+// entries are dropped (lenient, like every other frontmatter field). Exported so
+// the admin routes normalise form input with the exact rules the loader applies.
+export const TAG_RE = /^[a-z0-9][a-z0-9-]{0,23}$/;
+export const TAGS_PER_SKILL_LIMIT = 8;
+export function parseTags(raw: unknown): string[] {
+  const list = Array.isArray(raw) ? raw : String(raw ?? '').split(',');
+  const out: string[] = [];
+  for (const item of list) {
+    const tag = String(item ?? '').trim().toLowerCase();
+    if (!TAG_RE.test(tag) || out.includes(tag)) continue;
+    out.push(tag);
+    if (out.length >= TAGS_PER_SKILL_LIMIT) break;
+  }
+  return out;
+}
+
 // A shipped built-in template, read on demand by the seeder / reset route /
 // admin "defaults" payload. The template FILES are never kept resident.
 export interface SkillTemplate {
@@ -321,6 +339,8 @@ async function loadSkillDir(dir: string, slug: string, { seeded }: { seeded: boo
     requiresKey,
     // Absent → effectiveContextFields() falls back to the default profile (#471).
     contextFields: parseContextFields(data.context ?? data.contextFields),
+    // Freeform organisation tags for the admin skill list.
+    tags: parseTags(data.tags),
     // The skill's own frontmatter, handed to the tool as its 4th arg so a skill
     // can read its own knobs (e.g. news' feed / feedMaxItems).
     config: data,

--- a/controller/src/skills/scaffold.ts
+++ b/controller/src/skills/scaffold.ts
@@ -44,6 +44,7 @@ interface SkillFileFields {
   requiresKey?: string;       // custom skills only — env var the skill needs
   feed?: string;        // news only
   feedMaxItems?: number; // news only
+  tags?: string[];      // freeform organisation tags
   brief?: string;
 }
 
@@ -65,6 +66,7 @@ export async function writeSkillFile(fields: SkillFileFields): Promise<void> {
   if (fields.requiresKey) lines.push(`requiresKey: ${fields.requiresKey}`);
   if (fields.feed) lines.push(`feed: ${fields.feed}`);
   if (fields.feedMaxItems) lines.push(`feedMaxItems: ${fields.feedMaxItems}`);
+  if (fields.tags && fields.tags.length) lines.push(`tags: ${fields.tags.join(', ')}`);
   lines.push('---', (fields.brief || '').trim(), '');
   const dir = join(SKILLS_DIR, kind);
   await mkdir(dir, { recursive: true });

--- a/docs/superpowers/specs/2026-07-12-skill-organization-design.md
+++ b/docs/superpowers/specs/2026-07-12-skill-organization-design.md
@@ -1,7 +1,7 @@
 # Skill organization: tags, filter/sort, and assign-from-skill
 
 **Date:** 2026-07-12
-**Status:** Draft — awaiting review
+**Status:** Implemented
 **Origin:** Discord community request — libraries past ~15–20 skills with 8+ personas make the who-has-what matrix unwieldy. Three asks: (1) filter/sort, especially "filter by which DJ/Show has it enabled", (2) freeform tags, (3) assign a skill to DJs from the skill itself instead of DJ-by-DJ.
 
 ## Problem

--- a/docs/superpowers/specs/2026-07-12-skill-organization-design.md
+++ b/docs/superpowers/specs/2026-07-12-skill-organization-design.md
@@ -1,0 +1,128 @@
+# Skill organization: tags, filter/sort, and assign-from-skill
+
+**Date:** 2026-07-12
+**Status:** Draft — awaiting review
+**Origin:** Discord community request — libraries past ~15–20 skills with 8+ personas make the who-has-what matrix unwieldy. Three asks: (1) filter/sort, especially "filter by which DJ/Show has it enabled", (2) freeform tags, (3) assign a skill to DJs from the skill itself instead of DJ-by-DJ.
+
+## Problem
+
+The admin Skills page (`web/components/admin/SkillsPanel.tsx`) renders skill cards in raw `readdir` order with no search, sort, or filter. Skill→DJ assignment lives only on the persona side (`personas[i].skills`, edited via `PersonaSkillsCard` one DJ at a time), so answering "which DJs run the news skill?" means opening every persona. There is no tagging or grouping concept anywhere in the stack.
+
+## Current model (facts the design builds on)
+
+- A skill is `state/skills/<slug>/SKILL.md` (flat `key: value` frontmatter parsed by `parseFrontmatter` in `controller/src/skills/loader.ts`) + optional `tool.mjs`. Unknown frontmatter keys are already retained verbatim in `cap.config`.
+- `skillCatalog()` (`controller/src/skills/_agent.ts`) is the single API/UI projection, served by `GET /dj/skills`.
+- Assignment = `personas[i].skills : string[] | null`. `null` (default) means **all skills**; `[]` means none; capped at `SKILLS_PER_PERSONA_LIMIT = 20` (`controller/src/settings.ts`). Runtime gate: `availableCapabilities()` skips a capability when `persona?.skills && !persona.skills.includes(cap.skill)`.
+- Shows do not hold skill lists. A show's skill eligibility keys off its **host persona**; `shows[i].segmentSkill` only pins the programme feature beat.
+- Skills travel: export `.zip`, import, and community install all round-trip `SKILL.md` — so anything stored in frontmatter travels with the skill.
+
+## Goals
+
+1. Freeform tags on skills, editable in the skill editor, that survive export/import/community sharing.
+2. Search, sort, and filter on the Skills page — including "enabled for DJ X" and (via the host mapping) "enabled for show Y".
+3. Assign/unassign a skill to any set of personas from the skill's own editor, in one place.
+
+## Non-goals
+
+- No managed/central category taxonomy (tags stay freeform and skill-owned).
+- No per-show skill lists — shows keep deriving eligibility from the host persona (changing that is a much bigger behaviour change).
+- No changes to runtime gating semantics (`availableCapabilities`, cooldowns, frequency, budget).
+- No native-app changes; admin web only.
+
+## Approaches considered
+
+**A. File-backed tags + client-side organization + a server-side assignment endpoint (chosen).**
+Tags live in `SKILL.md` frontmatter so they ride export/import/community for free and stay consistent with everything else about a skill. Filter/sort is pure client-side over data the admin page already has access to. Reverse assignment gets one new controller endpoint that does the read-modify-write on `personas[].skills` server-side, so the null-sentinel logic lives in exactly one place.
+
+**B. Client-only minimal.** Ship search/sort/persona-filter using existing `GET /dj/skills` + `GET /settings`; no tags, no assignment endpoint. Fast, but delivers only one of the three asks and the null-sentinel join logic ends up in the UI anyway.
+
+**C. Settings-backed taxonomy.** A `settings.skillTags` registry with managed categories and skill→category mapping in `settings.json`. Rejected: second source of truth beside `SKILL.md`, tags would not travel with skill export/community sharing, and it adds admin surface (category CRUD) nobody asked for.
+
+## Design (Approach A)
+
+### 1. Tags — data model
+
+New frontmatter key on `SKILL.md`:
+
+```yaml
+tags: late-night, factual, chatty
+```
+
+- **Parsing** (`loader.ts`): new `parseTags(raw)` — split on commas, trim, lowercase, validate each against `TAG_RE = /^[a-z0-9][a-z0-9-]{0,23}$/` (invalid entries dropped, not fatal), dedupe, cap at `TAGS_PER_SKILL_LIMIT = 8`. `loadSkillDir` sets `cap.tags: string[]` (default `[]`).
+- **Catalog**: `skillCatalog()` adds `tags` to each entry.
+- **Write path**: `writeSkillFile` (`scaffold.ts`) renders a `tags:` line when non-empty; `buildCustomSkillFields` (`routes/dj.ts`) accepts `tags` as `string[]` or comma string from both `POST /dj/skills` and `PUT /dj/skills/:kind/file`, normalized with the same `parseTags`.
+- **Built-ins**: editing a built-in's `SKILL.md` already works (state copy is the live one), so tags on built-ins need no special casing. Shipped templates get **no** seeded tags — tags are operator vocabulary.
+- **Compat**: older controllers ignore an unknown `tags:` key (retained in `config`), so shared/imported skills degrade gracefully in both directions.
+
+### 2. Assign-from-skill — API
+
+New admin endpoint in `controller/src/routes/dj.ts`:
+
+```
+PUT /dj/skills/:slug/personas        (requireAdmin)
+body:     { personaIds: string[] }   // the personas that should have this skill
+returns:  { assignments: Record<personaId, boolean>, personas: [{id, name, hasSkill}] }
+errors:   404 unknown skill, 400 bad personaIds
+```
+
+Server-side read-modify-write over `settings.personas`:
+
+- **Persona should have the skill** (`id ∈ personaIds`):
+  - `skills === null` → no-op (null already means "all skills"). Do **not** materialize.
+  - array missing the slug → append.
+- **Persona should not have it** (`id ∉ personaIds`):
+  - `skills === null` → materialize to the full current catalog slug list **minus** this skill (same thing `PersonaSkillsCard` effectively does the first time an operator unticks something).
+  - array containing the slug → remove.
+- Persist once via `settings.update({ personas })`; unchanged personas pass through untouched.
+- Unknown persona ids in the payload → 400 listing them.
+
+**Limit bump (required by materialization):** `SKILLS_PER_PERSONA_LIMIT` goes from **20 → 64**. Rationale: the whole premise of this feature is libraries past 20 skills; materializing "all minus one" for a 25-skill library would exceed the current cap, and `PersonaSkillsCard` already has this latent bug today (ticking everything on a >20-skill library fails strict validation). 64 matches `SHOWS_LIMIT`. The strict validator error message updates accordingly. No migration needed — existing arrays are all ≤20.
+
+### 3. Skills page — filter, sort, search (client-side)
+
+All in `SkillsPanel.tsx`; no new fetch pattern (stays `adminFetch` + `useEffect`). The panel additionally fetches `GET /settings` once (the admin page is already behind the same Basic-auth gate) and keeps only `personas: [{id, name, skills}]` and `shows: [{id, name, personaId, segmentSkill}]` (`personaId` is the host) from it.
+
+Toolbar above the card list:
+
+- **Search box** — case-insensitive substring over `label`, `name`, and the brief/description.
+- **Filter: DJ / show** — one shadcn `Select`. Options: "All", each persona ("DJ: Vex"), each show ("Show: Night Drive"). A skill matches a persona when `persona.skills === null || persona.skills.includes(skill.name)`. A show resolves to its host persona and additionally matches its `segmentSkill` pin (pin shown as a badge on the matching card while a show filter is active).
+- **Filter: tag** — chip row of the union of all catalog tags (hidden when no tags exist yet), multi-select, OR semantics; mirrors the show-music-filter chip idiom.
+- **Filter: status** — "All / Enabled / Disabled / Needs key / Custom / Built-in" select.
+- **Sort** — "A–Z (default) / Enabled first / Cooldown". A–Z becomes the default presentation, fixing today's arbitrary `readdir` order.
+- Header gets a filtered-count readout ("12 of 27 skills") and a one-click "Clear filters".
+
+Filter/sort state is component-local (resets on navigation) — no URL params or persistence in v1.
+
+Card additions: tag pills (small, after the cooldown pill) and an assignment pill — "All DJs" when every persona matches (including via `null`), otherwise "3 of 8 DJs".
+
+### 4. Skill editor — tags input + DJs section
+
+In `SkillEditModal.tsx`:
+
+- **Tags** — freeform chip input (type, Enter/comma to add, click to remove), with suggestion chips drawn from tags already used elsewhere in the catalog. Client-validates against the same slug rule/8-cap; saved through the existing `PUT /dj/skills/:kind/file` / `POST /dj/skills` payloads.
+- **DJs** — a checklist of all personas (name + checked state), semantics identical to `PersonaSkillsCard` but inverted. Initial checked state: `skills === null || skills.includes(name)`. On save, if the set changed, the modal calls `PUT /dj/skills/:slug/personas` **after** a successful SKILL.md save; the section is hidden in create mode until the skill exists (create → then assign, or default remains "all DJs via null"). A caption repeats the existing rule: the skill must also be enabled station-wide to air.
+- `PersonaSkillsCard` stays as-is — the two edit surfaces write the same field and cannot drift because the server owns the merge.
+
+### 5. Error handling
+
+- Assignment endpoint failures surface as a toast; the SKILL.md save is not rolled back (the two saves are independent resources — the modal reports which part failed).
+- Invalid tags in hand-edited files are silently dropped at load (consistent with the loader's lenient posture); the editor never produces them.
+- `Rescan` keeps working unchanged; tags flow through it like every other frontmatter field.
+
+### 6. Testing / verification
+
+- No test runner in the repo; the merge gate is `npm run lint` in `controller/` and `web/` — both must pass.
+- Manual verification with the `verify` skill flow (isolated controller + Playwright against `/admin/skills`): tag a skill, confirm the tag survives a rescan and an export→import round-trip; filter by a persona with a materialized list and one with `null`; assign/unassign from the modal and confirm `PersonaSkillsCard` reflects it; confirm a >20-skill materialization persists after the limit bump.
+
+### Touched files
+
+| Area | File | Change |
+|---|---|---|
+| Loader | `controller/src/skills/loader.ts` | `parseTags`, `TAG_RE`, `cap.tags` |
+| Catalog | `controller/src/skills/_agent.ts` | `tags` in `skillCatalog()` |
+| Scaffold | `controller/src/skills/scaffold.ts` | render `tags:` in `writeSkillFile` |
+| Routes | `controller/src/routes/dj.ts` | `tags` in create/edit validators; new `PUT /dj/skills/:slug/personas` |
+| Settings | `controller/src/settings.ts` | `SKILLS_PER_PERSONA_LIMIT` 20 → 64 |
+| Skills page | `web/components/admin/SkillsPanel.tsx` | toolbar (search/filters/sort), card pills, `/settings` fetch |
+| Editor | `web/components/admin/skills/SkillEditModal.tsx` | tags chip input, DJs checklist |
+| Types | `web/components/admin/personas/types.ts` | `SkillCatalogEntry.tags` |

--- a/web/components/admin/SkillsPanel.tsx
+++ b/web/components/admin/SkillsPanel.tsx
@@ -12,15 +12,20 @@
 // Creating and editing a skill (custom or built-in) opens the SkillEditModal
 // "segment sheet" — the list here is just the roster + quick actions.
 import type { ReactNode } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from '../../lib/cn';
 import { notify, errorMessage } from '../../lib/notify';
 import { useAdminAuth } from '../../lib/adminAuth';
-import { RefreshCw, Plus, Users, Upload } from 'lucide-react';
+import { RefreshCw, Plus, Users, Upload, Search, X } from 'lucide-react';
 import { Card, Btn, Pill, Eyebrow, Toggle } from './ui';
 import { V3Alert } from '../ui/alert';
 import { Modal } from '../ui/modal';
+import { Input } from '../ui/input';
+import {
+  Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel,
+} from '../ui/select';
 import SkillEditModal from './skills/SkillEditModal';
+import type { PersonaLite } from './skills/SkillEditModal';
 
 interface Skill {
   name: string;
@@ -35,7 +40,25 @@ interface Skill {
   custom?: boolean;
   feed?: string | null;
   feedMaxItems?: number | null;
+  tags?: string[];
 }
+
+// Slim show shape from GET /settings — enough for the "filter by show" option
+// (a show's skills are its HOST persona's, plus its pinned feature segment).
+interface ShowLite {
+  id: string;
+  name: string;
+  personaId: string;
+  segmentSkill: string;
+}
+
+// Does this persona run the skill? `skills: null` is the "all skills" sentinel.
+function personaHasSkill(p: PersonaLite, name: string): boolean {
+  return p.skills === null || p.skills.includes(name);
+}
+
+type StatusFilter = 'all' | 'enabled' | 'disabled' | 'needs-key' | 'custom' | 'builtin';
+type SortMode = 'az' | 'enabled' | 'cooldown';
 
 // One entry in the shipped community catalog (GET /dj/skills/community).
 interface CommunitySkill {
@@ -121,6 +144,50 @@ export default function SkillsPanel() {
   const [importing, setImporting] = useState(false);                 // zip import in flight?
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // Roster context for the organisation tools — best-effort from GET /settings;
+  // when it fails the DJ/show filter and assignment pills simply don't render.
+  const [personas, setPersonas] = useState<PersonaLite[]>([]);
+  const [shows, setShows] = useState<ShowLite[]>([]);
+
+  // Organisation controls — component-local, reset on navigation.
+  const [query, setQuery] = useState('');
+  const [who, setWho] = useState('all');            // 'all' | 'p:<personaId>' | 's:<showId>'
+  const [tagSel, setTagSel] = useState<string[]>([]);
+  const [status, setStatus] = useState<StatusFilter>('all');
+  const [sort, setSort] = useState<SortMode>('az');
+
+  // Pull the slim persona/show roster out of GET /settings. Reused after the
+  // modal saves DJ assignments, so the filter + pills stay accurate.
+  const refreshRoster = useCallback(async () => {
+    try {
+      const r = await adminFetch('/settings');
+      if (!r.ok) return;
+      const j = (await r.json().catch(() => ({}))) as {
+        values?: {
+          personas?: Array<{ id?: string; name?: string; skills?: string[] | null }>;
+          shows?: Array<{ id?: string; name?: string; personaId?: string; segmentSkill?: string }>;
+        };
+      };
+      const ps = Array.isArray(j.values?.personas) ? j.values.personas : [];
+      setPersonas(ps
+        .map(p => ({
+          id: String(p.id || ''),
+          name: String(p.name || ''),
+          skills: Array.isArray(p.skills) ? p.skills.map(String) : null,
+        }))
+        .filter(p => p.id));
+      const sh = Array.isArray(j.values?.shows) ? j.values.shows : [];
+      setShows(sh
+        .map(s => ({
+          id: String(s.id || ''),
+          name: String(s.name || ''),
+          personaId: String(s.personaId || ''),
+          segmentSkill: typeof s.segmentSkill === 'string' ? s.segmentSkill : '',
+        }))
+        .filter(s => s.id));
+    } catch { /* organisation tools degrade gracefully */ }
+  }, [adminFetch]);
+
   useEffect(() => {
     if (!hydrated || needsAuth) return;
     let cancelled = false;
@@ -150,8 +217,10 @@ export default function SkillsPanel() {
         if (!cancelled) setCommunity([]);
       }
     })();
+    // Roster for the DJ/show filter — best-effort like the community catalog.
+    refreshRoster();
     return () => { cancelled = true; };
-  }, [hydrated, needsAuth, adminFetch]);
+  }, [hydrated, needsAuth, adminFetch, refreshRoster]);
 
   const toggle = async (name: string, on: boolean) => {
     setBusy(name);
@@ -271,6 +340,62 @@ export default function SkillsPanel() {
 
   const enabledCount = skills.filter(s => s.enabled).length;
 
+  // Union of every tag in the catalog — the tag filter's vocabulary. Hidden
+  // until at least one skill carries a tag.
+  const allTags = [...new Set(skills.flatMap(s => s.tags || []))].sort();
+
+  // Who runs this skill — drives the DJ/show filter and the assignment pill.
+  const matchesWho = (s: Skill): boolean => {
+    if (who === 'all') return true;
+    if (who.startsWith('p:')) {
+      const p = personas.find(x => x.id === who.slice(2));
+      return !!p && personaHasSkill(p, s.name);
+    }
+    const show = shows.find(x => x.id === who.slice(2));
+    if (!show) return true;
+    if (show.segmentSkill === s.name) return true; // the show's pinned feature
+    const host = personas.find(x => x.id === show.personaId);
+    return !!host && personaHasSkill(host, s.name);
+  };
+
+  const matchesStatus = (s: Skill): boolean => {
+    switch (status) {
+      case 'enabled': return !!s.enabled;
+      case 'disabled': return !s.enabled;
+      case 'needs-key': return s.ready === false;
+      case 'custom': return !!s.custom;
+      case 'builtin': return !s.custom;
+      default: return true;
+    }
+  };
+
+  const q = query.trim().toLowerCase();
+  const visible = skills
+    .filter(s =>
+      (!q
+        || (s.label || '').toLowerCase().includes(q)
+        || s.name.toLowerCase().includes(q)
+        || (s.description || '').toLowerCase().includes(q))
+      && (!tagSel.length || (s.tags || []).some(t => tagSel.includes(t)))
+      && matchesWho(s)
+      && matchesStatus(s))
+    .sort((a, b) => {
+      const az = (a.label || a.name).localeCompare(b.label || b.name);
+      if (sort === 'enabled') return Number(!!b.enabled) - Number(!!a.enabled) || az;
+      if (sort === 'cooldown') return (a.cooldownMs || 0) - (b.cooldownMs || 0) || az;
+      return az;
+    });
+
+  const filtered = query.trim() !== '' || who !== 'all' || tagSel.length > 0 || status !== 'all';
+  const clearFilters = () => { setQuery(''); setWho('all'); setTagSel([]); setStatus('all'); };
+
+  // "All DJs" / "3 of 8 DJs" pill copy — needs the roster; empty string hides it.
+  const assignmentLabel = (s: Skill): string => {
+    if (!personas.length) return '';
+    const n = personas.filter(p => personaHasSkill(p, s.name)).length;
+    return n === personas.length ? 'All DJs' : `${n} of ${personas.length} DJs`;
+  };
+
   return (
     <div className="grid gap-4">
       {/* ── HERO ─────────────────────────────────────────────────────────── */}
@@ -282,8 +407,9 @@ export default function SkillsPanel() {
           </div>
           <div className="mt-1 text-[11px] leading-[1.6] text-muted">
             Each skill is an autonomous segment. A skill fires only when it is enabled here
-            <strong> and</strong> assigned to the persona on air. Set per-persona assignments
-            on the Personas page. “Run now” is an operator override and ignores both.
+            <strong> and</strong> assigned to the persona on air. Assign DJs from each skill&apos;s
+            Edit sheet, or per-persona on the Personas page. “Run now” is an operator override
+            and ignores both.
           </div>
           <div className="mt-1 text-[11px] leading-[1.6] text-muted">
             Hit <strong>Edit</strong> on any skill to open its segment sheet — change the brief,
@@ -306,7 +432,9 @@ export default function SkillsPanel() {
           </a>
         </div>
         <div className="flex items-center gap-4 bg-[var(--ink-softer)] p-3.5">
-          <span className="caption">{skills.length} skill{skills.length === 1 ? '' : 's'}</span>
+          <span className="caption">
+            {filtered ? `${visible.length} of ${skills.length}` : skills.length} skill{skills.length === 1 ? '' : 's'}
+          </span>
           <span className="caption text-vermilion">{enabledCount} enabled</span>
           <div className="ml-auto flex items-center gap-2">
             <Btn
@@ -333,8 +461,108 @@ export default function SkillsPanel() {
         </div>
       </section>
 
+      {/* ── ORGANISE — search / filter / sort ─────────────────────────────── */}
+      <section className="card p-3.5">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="relative min-w-[200px] flex-1">
+            <Search size={14} className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-muted" />
+            <Input
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              placeholder="Search skills…"
+              aria-label="Search skills"
+              className="pl-8"
+            />
+          </div>
+          {personas.length > 0 && (
+            <Select value={who} onValueChange={setWho}>
+              <SelectTrigger className="w-[190px]" aria-label="Filter by DJ or show">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All DJs &amp; shows</SelectItem>
+                <SelectGroup>
+                  <SelectLabel>DJs</SelectLabel>
+                  {personas.map(p => (
+                    <SelectItem key={p.id} value={`p:${p.id}`}>DJ: {p.name}</SelectItem>
+                  ))}
+                </SelectGroup>
+                {shows.length > 0 && (
+                  <SelectGroup>
+                    <SelectLabel>Shows</SelectLabel>
+                    {shows.map(s => (
+                      <SelectItem key={s.id} value={`s:${s.id}`}>Show: {s.name}</SelectItem>
+                    ))}
+                  </SelectGroup>
+                )}
+              </SelectContent>
+            </Select>
+          )}
+          <Select value={status} onValueChange={v => setStatus(v as StatusFilter)}>
+            <SelectTrigger className="w-[130px]" aria-label="Filter by status">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Any status</SelectItem>
+              <SelectItem value="enabled">Enabled</SelectItem>
+              <SelectItem value="disabled">Disabled</SelectItem>
+              <SelectItem value="needs-key">Needs key</SelectItem>
+              <SelectItem value="custom">Custom</SelectItem>
+              <SelectItem value="builtin">Built-in</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={sort} onValueChange={v => setSort(v as SortMode)}>
+            <SelectTrigger className="w-[140px]" aria-label="Sort skills">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="az">A–Z</SelectItem>
+              <SelectItem value="enabled">Enabled first</SelectItem>
+              <SelectItem value="cooldown">Cooldown</SelectItem>
+            </SelectContent>
+          </Select>
+          {filtered && (
+            <Btn onClick={clearFilters} title="Clear all filters">
+              <X size={14} /> Clear
+            </Btn>
+          )}
+        </div>
+        {allTags.length > 0 && (
+          <div className="mt-2.5 flex flex-wrap items-center gap-1">
+            <span className="caption mr-1">tags</span>
+            {allTags.map(t => {
+              const on = tagSel.includes(t);
+              return (
+                <button
+                  key={t}
+                  type="button"
+                  aria-pressed={on}
+                  onClick={() => setTagSel(cur => (on ? cur.filter(x => x !== t) : [...cur, t]))}
+                  className={cn(
+                    'border border-ink px-2 py-0.5 text-[12px]',
+                    on ? 'bg-ink text-bg' : 'text-ink hover:bg-[var(--ink-soft)]',
+                  )}
+                >
+                  {t}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
       {/* ── SKILL LIST ───────────────────────────────────────────────────── */}
-      {skills.map(s => (
+      {visible.length === 0 && (
+        <Card title="No matches">
+          <div className="text-[13px] text-muted italic">
+            No skill matches the current filters.{' '}
+            <button type="button" onClick={clearFilters} className="font-bold text-vermilion underline decoration-[1.5px] underline-offset-2">
+              Clear filters
+            </button>
+          </div>
+        </Card>
+      )}
+      {visible.map(s => (
         <Card
           key={s.name}
           title={s.label || s.name}
@@ -381,6 +609,13 @@ export default function SkillsPanel() {
               </div>
               <div className="mt-2 flex flex-wrap gap-2">
                 <Pill className="text-[8px]">{cooldownLabel(s.cooldownMs)}</Pill>
+                {assignmentLabel(s) && <Pill className="text-[8px]">{assignmentLabel(s)}</Pill>}
+                {who.startsWith('s:') && shows.find(x => x.id === who.slice(2))?.segmentSkill === s.name && (
+                  <Pill tone="accent" className="text-[8px]">pinned feature</Pill>
+                )}
+                {(s.tags || []).map(t => (
+                  <Pill key={t} className="text-[8px]">#{t}</Pill>
+                ))}
               </div>
             </div>
             <div className="flex flex-col gap-2">
@@ -507,8 +742,11 @@ export default function SkillsPanel() {
         <SkillEditModal
           mode={modal.mode}
           skill={modal.mode === 'edit' ? modal.skill : undefined}
+          personas={personas}
+          tagSuggestions={allTags}
           onClose={() => setModal(null)}
           onSkillsChange={next => { if (Array.isArray(next)) setSkills(next as Skill[]); }}
+          onRosterChange={refreshRoster}
         />
       )}
     </div>

--- a/web/components/admin/personas/types.ts
+++ b/web/components/admin/personas/types.ts
@@ -61,6 +61,8 @@ export interface SkillCatalogEntry {
   name: string;
   label?: string;
   description?: string;
+  // Freeform organisation tags from the skill's SKILL.md frontmatter.
+  tags?: string[];
 }
 
 export interface VoiceOption {

--- a/web/components/admin/skills/SkillEditModal.tsx
+++ b/web/components/admin/skills/SkillEditModal.tsx
@@ -36,11 +36,23 @@ export interface SkillLike {
   cooldownMs?: number;
 }
 
+// Slim persona shape from GET /settings — enough for the DJ assignment
+// checklist. `skills: null` is the "all skills" sentinel (see controller
+// settings.ts:validatePersonasStrict).
+export interface PersonaLite {
+  id: string;
+  name: string;
+  skills: string[] | null;
+}
+
 interface SkillEditModalProps {
   mode: 'create' | 'edit';
   skill?: SkillLike;                 // required in edit mode
+  personas?: PersonaLite[];          // roster for the DJ assignment checklist
+  tagSuggestions?: string[];         // tags already used elsewhere in the catalog
   onClose: () => void;
   onSkillsChange: (skills: SkillLike[]) => void;  // refresh the panel list after any mutation
+  onRosterChange?: () => void;       // re-fetch personas after assignments change
 }
 
 // The shipped defaults for a built-in (read from the image template), used to
@@ -68,6 +80,7 @@ interface SkillFileResponse {
   hasTool?: boolean;
   feed?: string | null;
   feedMaxItems?: number | null;
+  tags?: string[];
   brief?: string;
   defaults?: SkillDefaults | null;
   error?: string;
@@ -75,6 +88,10 @@ interface SkillFileResponse {
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,48}$/;
 const COOLDOWN_PRESETS = ['15m', '25m', '45m', '1h', '6h'];
+// Mirror the controller's tag rules (skills/loader.ts TAG_RE / limit) so a bad
+// tag fails here instead of on save.
+const TAG_RE = /^[a-z0-9][a-z0-9-]{0,23}$/;
+const TAGS_MAX = 8;
 
 // The mutable file fields — snapshotted so we can compute "dirty" and revert.
 interface FileFields {
@@ -84,14 +101,16 @@ interface FileFields {
   window: 'any' | 'commute';
   feed: string;
   feedMaxItems: string;
+  tags: string[];
   brief: string;
 }
 
 function emptyFields(): FileFields {
-  return { label: '', cooldown: '', context: [], window: 'any', feed: '', feedMaxItems: '', brief: '' };
+  return { label: '', cooldown: '', context: [], window: 'any', feed: '', feedMaxItems: '', tags: [], brief: '' };
 }
 
-// Order-independent comparison key for the tracked fields.
+// Order-independent comparison key for the tracked fields. Tags keep their
+// order (they're an authored list, not a set) — only context is order-free.
 function fieldsKey(f: FileFields): string {
   return JSON.stringify({ ...f, context: [...f.context].sort() });
 }
@@ -100,7 +119,7 @@ function titleCase(slug: string): string {
   return slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
-export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }: SkillEditModalProps) {
+export default function SkillEditModal({ mode, skill, personas, tagSuggestions, onClose, onSkillsChange, onRosterChange }: SkillEditModalProps) {
   const { adminFetch } = useAdminAuth();
 
   const isEdit = mode === 'edit';
@@ -119,6 +138,17 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
 
   const [fields, setFields] = useState<FileFields>(emptyFields());
   const [snapshot, setSnapshot] = useState<string>(fieldsKey(emptyFields()));
+  const [tagDraft, setTagDraft] = useState('');   // the tag input's in-progress text
+
+  // DJ assignment — which personas run this skill. Seeded from the roster at
+  // mount (a `skills: null` persona runs everything); saved via
+  // PUT /dj/skills/:slug/personas alongside (after) the file save.
+  const roster = personas || [];
+  const initialAssigned = () => (skill
+    ? roster.filter(p => p.skills === null || p.skills.includes(skill.name)).map(p => p.id)
+    : []);
+  const [assigned, setAssigned] = useState<string[]>(initialAssigned);
+  const [assignSnapshot, setAssignSnapshot] = useState<string>(() => JSON.stringify([...initialAssigned()].sort()));
 
   const [enabled, setEnabled] = useState(!!skill?.enabled);
   const [busy, setBusy] = useState(false);          // saving / creating
@@ -128,6 +158,26 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
   const [defaults, setDefaults] = useState<SkillDefaults | null>(null); // built-in shipped defaults
 
   const patch = (p: Partial<FileFields>) => setFields(f => ({ ...f, ...p }));
+
+  // Commit the tag input's draft (Enter / comma / blur). Mirrors the
+  // controller's rules so a bad tag fails here, loudly, before save.
+  const addTag = (raw: string) => {
+    const tag = raw.trim().toLowerCase();
+    if (!tag) return;
+    if (!TAG_RE.test(tag)) {
+      notify.err(`"${tag}" isn't a valid tag — lowercase letters, digits, hyphens, max 24 chars`);
+      return;
+    }
+    setFields(f => {
+      if (f.tags.includes(tag)) return f;
+      if (f.tags.length >= TAGS_MAX) {
+        notify.err(`At most ${TAGS_MAX} tags per skill`);
+        return f;
+      }
+      return { ...f, tags: [...f.tags, tag] };
+    });
+    setTagDraft('');
+  };
 
   const flashFor = (msg: string) => {
     setFlash(msg);
@@ -152,6 +202,7 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
           window: j.window === 'commute' ? 'commute' : 'any',
           feed: j.feed || '',
           feedMaxItems: j.feedMaxItems != null ? String(j.feedMaxItems) : '',
+          tags: Array.isArray(j.tags) ? j.tags : [],
           brief: j.brief || '',
         };
         setFields(next);
@@ -182,7 +233,8 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
   // Dialog) — no manual key listener, so the nested delete confirm gets escape
   // first and the page behind stays locked.
 
-  const dirty = loaded && fieldsKey(fields) !== snapshot;
+  const assignDirty = isEdit && JSON.stringify([...assigned].sort()) !== assignSnapshot;
+  const dirty = loaded && (fieldsKey(fields) !== snapshot || assignDirty);
   const nameValid = !isEdit ? SLUG_RE.test(name) : true;
   const canSave = loaded && !!fields.brief.trim() && nameValid && !busy;
 
@@ -198,6 +250,7 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
         label: fields.label.trim() || undefined,
         cooldown: fields.cooldown.trim() || undefined,
         context: fields.context,                 // [] resets to the default profile
+        tags: fields.tags,                       // [] clears the tags line
         brief: fields.brief,
       };
       if (custom) {
@@ -233,6 +286,23 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
         onClose();
       } else {
         setSnapshot(fieldsKey(fields));   // edits are now the saved baseline
+        // DJ assignments save as a separate resource (personas[].skills). The
+        // file save above already stood — a failure here reports on its own.
+        if (assignDirty && skill) {
+          try {
+            const ar = await adminFetch(`/dj/skills/${skill.name}/personas`, {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ personaIds: assigned }),
+            });
+            const aj = (await ar.json().catch(() => ({}))) as { error?: string };
+            if (!ar.ok) throw new Error(aj.error || `failed (${ar.status})`);
+            setAssignSnapshot(JSON.stringify([...assigned].sort()));
+            onRosterChange?.();
+          } catch (e) {
+            notify.err(`Skill saved, but updating DJ assignments failed: ${errorMessage(e)}`);
+          }
+        }
         flashFor('SAVED TO BOOTH');
       }
     } catch (e) {
@@ -365,6 +435,7 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
           window: fj.window === 'commute' ? 'commute' : 'any',
           feed: fj.feed || '',
           feedMaxItems: fj.feedMaxItems != null ? String(fj.feedMaxItems) : '',
+          tags: Array.isArray(fj.tags) ? fj.tags : [],
           brief: fj.brief || '',
         };
         setFields(next);
@@ -596,6 +667,80 @@ export default function SkillEditModal({ mode, skill, onClose, onSkillsChange }:
                 Switch on only what&apos;s topical for this segment. A context left dark stays out of the prompt — so the DJ stops working it into every break.
               </div>
             </div>
+
+            {/* Tags — freeform organisation labels for the skill list */}
+            <div className="sw-section">
+              <div style={sectionLabel}>TAGS — ORGANISE THE SKILL LIST</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 10, marginTop: 16 }}>
+                {fields.tags.map(t => (
+                  <button
+                    key={t}
+                    type="button"
+                    title={`Remove tag "${t}"`}
+                    onClick={() => patch({ tags: fields.tags.filter(x => x !== t) })}
+                    style={chipStyle(true)}
+                  >
+                    <span>#{t}</span>
+                    <span aria-hidden>×</span>
+                  </button>
+                ))}
+                <input
+                  value={tagDraft}
+                  onChange={e => setTagDraft(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter' || e.key === ',') {
+                      e.preventDefault();
+                      addTag(tagDraft);
+                    }
+                  }}
+                  onBlur={() => addTag(tagDraft)}
+                  placeholder={fields.tags.length ? 'add tag…' : 'late-night, factual…'}
+                  aria-label="Add tag"
+                  style={{ ...inputBase, width: 160, padding: '9px 12px', fontSize: 13 }}
+                />
+              </div>
+              {(tagSuggestions || []).filter(t => !fields.tags.includes(t)).length > 0 && (
+                <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 8, marginTop: 12 }}>
+                  <span style={{ fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--muted)', fontWeight: 600 }}>IN USE</span>
+                  {(tagSuggestions || []).filter(t => !fields.tags.includes(t)).map(t => (
+                    <button key={t} type="button" onClick={() => addTag(t)} style={chipStyle(false)}>
+                      #{t}
+                    </button>
+                  ))}
+                </div>
+              )}
+              <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 12 }}>
+                Freeform — tag by show, mood, type, whatever helps you filter. Tags travel with the skill when exported or shared.
+              </div>
+            </div>
+
+            {/* DJ assignment — which personas run this skill (edit only) */}
+            {isEdit && roster.length > 0 && (
+              <div className="sw-section">
+                <div style={sectionLabel}>WHICH DJS RUN IT</div>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, marginTop: 16 }}>
+                  {roster.map(p => {
+                    const on = assigned.includes(p.id);
+                    return (
+                      <button
+                        key={p.id}
+                        type="button"
+                        aria-pressed={on}
+                        onClick={() => setAssigned(cur => (on ? cur.filter(id => id !== p.id) : [...cur, p.id]))}
+                        style={chipStyle(on)}
+                      >
+                        <span style={markStyle(on)} />
+                        <span>{p.name}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+                <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 14, lineHeight: 1.6, maxWidth: '78ch' }}>
+                  The same assignments as each persona&apos;s Skills card, edited from the skill&apos;s side.
+                  A skill fires only for the ticked DJs — and must be enabled station-wide (the on-air toggle below).
+                </div>
+              </div>
+            )}
 
             {/* Brief */}
             <div className="sw-section">


### PR DESCRIPTION
## What

Skill-organisation tools requested on Discord — past ~15–20 skills and 8+ personas, the flat skill list and the DJ-by-DJ assignment matrix get unwieldy. All three asks land:

1. **Freeform tags** — new `tags:` frontmatter key in `SKILL.md` (lowercase slugs, max 8). Parsed leniently by the loader, validated loudly by the admin routes, edited via a chip input in the skill sheet. Tags live in the skill file, so they ride export/import/community sharing for free and older controllers just ignore the key.
2. **Filter / sort / search on /admin/skills** — search box, DJ/show filter (a show resolves through its host persona plus its `segmentSkill` pin), tag chips, status filter (enabled/disabled/needs key/custom/built-in), and sort (A–Z default — the list was raw `readdir` order before). Cards get tag pills and an "n of m DJs" assignment pill; header shows "x of y skills" while filtered.
3. **Assign DJs from the skill** — a "Which DJs run it" checklist in the skill edit sheet, backed by a new `PUT /dj/skills/:slug/personas`. The read-modify-write over `personas[].skills` happens server-side so the `null` "all skills" sentinel is interpreted in exactly one place: null + assigned stays null; null + unassigned materialises the full catalog minus this skill. `PersonaSkillsCard` keeps working unchanged — both surfaces write the same field.

Side change: `SKILLS_PER_PERSONA_LIMIT` 20 → 64. Materialising "all minus one" on a >20-skill library would overflow the old cap — a bug the persona checklist already had latently.

Design spec: `docs/superpowers/specs/2026-07-12-skill-organization-design.md`.

## Verification

- `npm run lint` green in both `controller/` and `web/`.
- Isolated controller (fresh STATE_DIR) + worktree Next dev server + Playwright:
  - tags: create/edit via modal and API, survive rescan and an export round-trip, invalid tags 400 with a clear message, dedupe + lowercase normalisation;
  - assignment endpoint: 404 unknown skill, 400 bad payload / unknown persona id, null-persona materialisation (catalog minus one), add/remove, idempotent re-PUT;
  - UI: A–Z order, search narrows correctly, tag chip and DJ filters produce the right card sets, count readout, unsaved-edits indicator, modal save persists tags + assignments (verified through the controller API, not toasts).