### PR TITLE
feat(observatory): move MAP SIZE and RESET DIAL into the top header

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4816,12 +4816,12 @@ html.lite .sw-ripple-circle {
 .observatory-root .rail-foot { margin-top: auto; padding-top: 14px; border-top: 1px solid var(--separator-strong); display: flex; flex-direction: column; gap: 10px; }
 .observatory-root .rail-count { font-size: 13px; font-weight: 700; letter-spacing: 0.02em; }
 .observatory-root .rail-count .ad-muted { font-size: 10px; letter-spacing: 0.16em; }
-.observatory-root .rail-reset { border: 1px solid var(--ink); background: transparent; color: var(--ink); font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; font-weight: 700; padding: 10px; cursor: pointer; }
-.observatory-root .rail-reset:hover { background: var(--ink); color: var(--bg); }
-.observatory-root .obs-maxrow { display: flex; gap: 6px; }
-.observatory-root .obs-maxsel { flex: 1; appearance: none; -webkit-appearance: none; border: 1px solid var(--separator-strong); background: var(--field); color: var(--ink); font-family: inherit; font-size: 11px; letter-spacing: 0.04em; padding: 8px 10px; cursor: pointer; border-radius: 0; }
+.observatory-root .obs-top-max { display: flex; align-items: center; gap: 8px; }
+.observatory-root .obs-maxsel { appearance: none; -webkit-appearance: none; border: 1px solid var(--separator-strong); background: var(--field); color: var(--ink); font-family: inherit; font-size: 10px; letter-spacing: 0.04em; padding: 4px 8px; cursor: pointer; border-radius: 0; }
 .observatory-root .obs-maxsel:hover { border-color: var(--ink); }
 .observatory-root .obs-maxsel:focus { outline: none; border-color: var(--accent); }
+.observatory-root .obs-top-reset { border: 1px solid var(--ink); background: transparent; color: var(--ink); font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; font-weight: 700; padding: 5px 12px; cursor: pointer; }
+.observatory-root .obs-top-reset:hover { background: var(--ink); color: var(--bg); }
 
 /* ---- stage / constellation ---- */
 .observatory-root .obs-stage { display: flex; flex-direction: column; min-width: 0; position: relative; background: var(--bg); }

--- a/web/components/observatory/ObservatoryApp.tsx
+++ b/web/components/observatory/ObservatoryApp.tsx
@@ -221,7 +221,25 @@ export default function ObservatoryApp({ adminFetch }: { adminFetch: AdminFetch 
             THE DJ&apos;S MIND
           </span>
           <span className="obs-vsep" />
-          <span className="obs-stat t-nums">{total} TRACKS</span>
+          {lib?.mock ? (
+            <span className="obs-stat t-nums">{total} TRACKS</span>
+          ) : (
+            <label className="obs-top-max">
+              <span className="obs-stat">MAP SIZE</span>
+              <select
+                className="obs-maxsel"
+                value={effectiveMax}
+                onChange={(e) => setMax(Number(e.target.value))}
+                aria-label="maximum nodes on the map"
+              >
+                {maxOptions.map((n) => (
+                  <option key={n} value={n}>
+                    {n.toLocaleString()} nodes
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
           {lib?.mock && (
             <>
               <span className="obs-vsep" />
@@ -238,6 +256,10 @@ export default function ObservatoryApp({ adminFetch }: { adminFetch: AdminFetch 
               </span>
             </>
           )}
+          <span className="obs-vsep" />
+          <button className="obs-top-reset" onClick={onReset}>
+            RESET DIAL
+          </button>
         </div>
       </header>
 
@@ -327,39 +349,13 @@ export default function ObservatoryApp({ adminFetch }: { adminFetch: AdminFetch 
             </div>
           )}
 
-          {!lib?.mock && (
-            <div className="rail-sec">
-              <div className="rail-label">
-                MAP SIZE
-                {lib?.sampled && <span className="ad-muted"> · SAMPLED OF {lib.stats.total.toLocaleString()}</span>}
-              </div>
-              <div className="obs-maxrow">
-                <select
-                  className="obs-maxsel"
-                  value={effectiveMax}
-                  onChange={(e) => setMax(Number(e.target.value))}
-                  aria-label="maximum nodes on the map"
-                >
-                  {maxOptions.map((n) => (
-                    <option key={n} value={n}>
-                      {n.toLocaleString()} nodes
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div className="ad-muted t-caption">
-                GALAXY RENDERER · {lib?.soundMap ? 'PLACED BY SOUND' : 'PLACED BY GENRE'}
-              </div>
-            </div>
-          )}
-
           <div className="rail-foot">
             <div className="rail-count">
               <span className="t-nums acc">{matched.length}</span> <span className="ad-muted">/ {total} IN VIEW</span>
             </div>
-            <button className="rail-reset" onClick={onReset}>
-              RESET DIAL
-            </button>
+            <div className="ad-muted t-caption">
+              GALAXY RENDERER · {lib?.soundMap ? 'PLACED BY SOUND' : 'PLACED BY GENRE'}
+            </div>
           </div>
         </aside>
 


### PR DESCRIPTION
## What

The MAP SIZE dropdown lived at the bottom-left of the Observatory's filter rail, where most people couldn't find it. This moves it into the top header, replacing the `N TRACKS` stat, and moves the RESET DIAL button up there too.

- **Header right side** now reads: THE DJ'S MIND · **MAP SIZE** `[select]` · **RESET DIAL**
- The track count isn't lost: it still shows in the stats side panel (`100 TRACKS` tile) and in the header's `CAPPED/SAMPLED · x / y` indicator when truncated.
- The rail footer keeps the `x / y IN VIEW` count and picks up the `GALAXY RENDERER · PLACED BY …` caption from the removed rail section.
- On mock/sample data the header falls back to the old `N TRACKS` stat (no server cap to choose from), same condition as before.
- Dropped now-unused `.rail-reset` / `.obs-maxrow` CSS; added compact header variants.

## Verified

- `npm run lint` (eslint + tsc) clean in `web/`.
- Playwright against an isolated worktree stack (real library.db, 100 tracks): header select + reset present, rail clean of both, select change persists to `localStorage` and refetches, RESET DIAL clears filters. 10/10 checks pass.