### PR TITLE
fix(admin): remove issue-count badge from DJ Doc header link

### DIFF
--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -257,58 +257,6 @@ export default function AdminShell({ children }: AdminShellProps) {
   );
 }
 
-interface DoctorSummary {
-  counts: { ok: number; warn: number; fail: number; skip: number } | null;
-  overall: 'healthy' | 'attention' | 'critical' | null;
-}
-
-// Small health badge on the header's DJ Doc link — the count of failing/warning
-// findings from the last cached assessment (manual run or nightly auto-run), so
-// a degraded station surfaces without the operator opening the panel. Silent
-// when healthy or when no run has been cached yet.
-function DoctorBadge() {
-  const { adminFetch } = useAdminAuth();
-  const [summary, setSummary] = useState<DoctorSummary | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
-      try {
-        const r = await adminFetch('/doctor/summary');
-        const j = (await r.json().catch(() => null)) as DoctorSummary | null;
-        if (!cancelled) setSummary(j);
-      } catch {
-        /* header badge is best-effort */
-      }
-    };
-    load();
-    const timer = setInterval(load, 60_000);
-    return () => {
-      cancelled = true;
-      clearInterval(timer);
-    };
-  }, [adminFetch]);
-
-  const counts = summary?.counts;
-  if (!counts) return null;
-  const n = counts.fail || counts.warn;
-  if (!n) return null;
-  const critical = counts.fail > 0;
-  return (
-    <span
-      className={`inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] leading-none font-bold ${
-        critical
-          ? 'bg-[var(--accent)] text-white'
-          : 'border border-[var(--accent)] text-[var(--accent)]'
-      }`}
-      title={`${counts.fail} fail · ${counts.warn} warn`}
-      aria-label={`Station health: ${counts.fail} failing, ${counts.warn} warnings`}
-    >
-      {n}
-    </span>
-  );
-}
-
 interface ShellHeaderProps {
   pathname: string | null;
   signedIn: boolean;
@@ -390,7 +338,6 @@ function ShellHeader({ pathname, signedIn, onSignOut }: ShellHeaderProps) {
           >
             <BoothBuddy mood="onair" size={16} />
             <span className="caption">DJ Doc</span>
-            <DoctorBadge />
           </Link>
           <ThemeSwitcher variant="admin" />
           <Link


### PR DESCRIPTION
Removes the red failing/warning count badge (`DoctorBadge`) shown on the admin top-bar **DJ Doc** link, per request.

- Drop `<DoctorBadge />` from the header link in `web/components/admin/AdminShell.tsx`
- Remove the now-unused `DoctorBadge` component and `DoctorSummary` interface (which polled `/doctor/summary` every 60s)

The DJ Doc link itself (booth buddy + label) is unchanged; the doctor panel still surfaces health when opened.

Verified: `npm run lint` (eslint + tsc) passes clean in `web/`.