### PR TITLE
fix(web): let the no-repeat window input be cleared while editing

### DIFF
--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -190,7 +190,7 @@ export default function SettingsPanel() {
         reasoning: !!v.llm?.reasoning,
         toolChoice: v.llm?.toolChoice === 'auto' ? 'auto' : 'required',
         pickerAgent: !!v.llm?.pickerAgent,
-        noRepeatWindow: typeof v.llm?.noRepeatWindow === 'number' ? v.llm.noRepeatWindow : 100,
+        noRepeatWindow: String(typeof v.llm?.noRepeatWindow === 'number' ? v.llm.noRepeatWindow : 100),
         requestWebResolve: !!v.llm?.requestWebResolve,
         agentTimeoutMs: typeof v.llm?.agentTimeoutMs === 'number' ? v.llm.agentTimeoutMs : 45000,
         pauseWhenEmpty: !!v.llm?.pauseWhenEmpty,

--- a/web/components/admin/settings/LlmSection.tsx
+++ b/web/components/admin/settings/LlmSection.tsx
@@ -207,7 +207,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
         reasoning: form.llm.reasoning,
         toolChoice: form.llm.toolChoice,
         pickerAgent: form.llm.pickerAgent,
-        noRepeatWindow: form.llm.noRepeatWindow,
+        noRepeatWindow: Math.max(0, parseInt(form.llm.noRepeatWindow, 10) || 0),
         requestWebResolve: form.llm.requestWebResolve,
         agentTimeoutMs: form.llm.agentTimeoutMs,
         pauseWhenEmpty: form.llm.pauseWhenEmpty,
@@ -997,7 +997,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
             step={10}
             value={form.llm.noRepeatWindow}
             onChange={(e: ChangeEvent<HTMLInputElement>) =>
-              setForm(f => ({ ...f, llm: { ...f.llm, noRepeatWindow: Math.max(0, Number(e.target.value)) } }))
+              setForm(f => ({ ...f, llm: { ...f.llm, noRepeatWindow: e.target.value } }))
             }
             placeholder="100"
             className="max-w-[200px]"

--- a/web/components/admin/settings/shared.tsx
+++ b/web/components/admin/settings/shared.tsx
@@ -92,7 +92,7 @@ export interface LlmForm {
   reasoning: boolean;
   toolChoice: string;
   pickerAgent: boolean;
-  noRepeatWindow: number;
+  noRepeatWindow: string;
   requestWebResolve: boolean;
   agentTimeoutMs: number;
   pauseWhenEmpty: boolean;


### PR DESCRIPTION
## Problem

In **Admin → Settings → LLM**, the agent-picker **No-repeat window (tracks)** field always kept a stubborn `0`. Clearing the field to type a fresh number snapped it right back to `0`, so editing (e.g. entering `0100` then deleting the leading zero) felt sticky and unpredictable.

## Root cause

The field's form state was a `number`, and its `onChange` coerced input through `Math.max(0, Number(e.target.value))`. When the field is emptied, `Number("")` is `0`, so the state became `0` and the input re-rendered showing `"0"` — the field could never be empty.

## Fix

Store `noRepeatWindow` as a **string** in form state, matching the codebase's existing convention for numeric text inputs (`embedding.seedCount`, `embedding.knnNeighbours` are handled exactly this way). The input can now be cleared while typing; the value is parsed and clamped (`Math.max(0, parseInt(...) || 0)`) on save. Empty saves as `0`, preserving the original semantics.

- `shared.tsx` — form type `number` → `string`
- `SettingsPanel.tsx` — hydrate as `String(...)`
- `LlmSection.tsx` — `onChange` sets the raw string; save-payload parses + clamps

## Verification

`npm run lint` (eslint + `tsc --noEmit`) passes clean.