### PR TITLE
feat(admin): surface Navidrome-unreachable banner across admin

### DIFF
--- a/controller/src/doctor.ts
+++ b/controller/src/doctor.ts
@@ -472,6 +472,27 @@ async function checkNavidrome(): Promise<Finding[]> {
   return out;
 }
 
+// Cached live-config Navidrome connectivity for the always-on admin banner.
+// The banner polls this from every admin page every ~30s; a short cache keeps
+// that from becoming a steady drip of Subsonic `ping` calls (and shields a
+// flapping Navidrome). Shares subsonic.ping() — the same never-throwing check
+// checkNavidrome() uses — so the banner and the Doctor's connectivity finding
+// can never disagree.
+let navidromeCache: { at: number; result: { ok: boolean; reason?: string } } | null = null;
+const NAVIDROME_TTL_MS = 20_000;
+
+export async function navidromeConnectivity(): Promise<{
+  ok: boolean;
+  reason?: string;
+  url: string;
+}> {
+  const now = Date.now();
+  if (!navidromeCache || now - navidromeCache.at > NAVIDROME_TTL_MS) {
+    navidromeCache = { at: now, result: await subsonic.ping() };
+  }
+  return { ...navidromeCache.result, url: config.navidrome.url };
+}
+
 async function checkBroadcast(): Promise<Finding[]> {
   const out: Finding[] = [];
 

--- a/controller/src/routes/doctor.ts
+++ b/controller/src/routes/doctor.ts
@@ -63,6 +63,18 @@ router.get('/doctor/summary', requireAdmin, async (_req, res) => {
   }
 });
 
+// Live-config Navidrome connectivity for the always-on admin banner. Returns
+// { ok, reason?, url } from the same never-throwing ping the Doctor's
+// connectivity finding uses, cached ~20s so polling every admin page doesn't
+// drip Subsonic calls. Cheap and safe to poll.
+router.get('/doctor/navidrome', requireAdmin, async (_req, res) => {
+  try {
+    res.json(await doctor.navidromeConnectivity());
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // Body: { report: DoctorReport } — the report the panel already has in hand, so
 // the review reflects exactly what the operator is looking at (no re-run race).
 router.post('/doctor/review', requireAdmin, async (req, res) => {

--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -27,6 +27,7 @@ import { useAdminAuth } from '../../lib/adminAuth';
 import type { SignInResult } from '../../lib/adminAuth';
 import { useStationFeed } from '../../hooks/useStationFeed';
 import SignInForm from './SignInForm';
+import NavidromeBanner from './NavidromeBanner';
 import OdometerNumber from '../OdometerNumber';
 import BoothBuddy from '../BoothBuddy';
 import ThemeSwitcher from '../ThemeSwitcher';
@@ -156,6 +157,9 @@ export default function AdminShell({ children }: AdminShellProps) {
   return (
     <div className="admin-root paper">
       <ShellHeader pathname={pathname} signedIn onSignOut={signOut} />
+      {/* Persistent connectivity warning — visible on every admin page whenever
+          the live station can't reach Navidrome. Renders nothing when healthy. */}
+      <NavidromeBanner adminFetch={adminFetch} />
       <div className="shell-body">
         <nav className="shell-nav">
           {NAV_SECTIONS.map(section => (

--- a/web/components/admin/NavidromeBanner.tsx
+++ b/web/components/admin/NavidromeBanner.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import { AlertTriangle } from 'lucide-react';
+
+interface NavidromeStatus {
+  ok: boolean;
+  reason?: string;
+  url?: string;
+}
+
+// Always-on connectivity banner. Polls the live-config Navidrome ping (cached
+// server-side) every 30s and, when it fails, warns on every admin page that the
+// DJ has no music source. Uses the same ping the DJ Doc reads, so the two never
+// disagree. Renders nothing until the first failing result arrives — a healthy
+// or not-yet-known station shows no chrome.
+export default function NavidromeBanner({
+  adminFetch,
+}: {
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+}) {
+  const [status, setStatus] = useState<NavidromeStatus | null>(null);
+  // adminFetch's identity changes as auth state ticks; hold the latest in a ref
+  // so the poll interval mounts once instead of tearing down every render.
+  const fetchRef = useRef(adminFetch);
+  fetchRef.current = adminFetch;
+
+  useEffect(() => {
+    let cancelled = false;
+    const check = async () => {
+      try {
+        const r = await fetchRef.current('/doctor/navidrome');
+        if (!r.ok) return; // 401 / 5xx — don't flip the banner on an auth blip
+        const j = (await r.json()) as NavidromeStatus;
+        if (!cancelled) setStatus(j);
+      } catch {
+        // Controller unreachable — leave the last known state rather than
+        // flapping; a dead controller has its own, louder failure modes.
+      }
+    };
+    check();
+    const id = setInterval(check, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  if (!status || status.ok) return null;
+
+  return (
+    <div
+      role="alert"
+      className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger)_10%,transparent)] px-7 py-2 text-[11px] text-ink"
+    >
+      <AlertTriangle size={14} className="shrink-0 text-[var(--danger)]" aria-hidden="true" />
+      <span>
+        <b>Can&rsquo;t reach Navidrome.</b> The DJ has no music source
+        {status.reason ? <> — {status.reason}</> : null}. Check the URL / username / password in
+        setup and that Navidrome is running.
+      </span>
+      <Link
+        href="/admin/doctor"
+        className="ml-auto font-bold text-[var(--danger)] underline-offset-2 hover:underline"
+      >
+        DJ Doc &rarr;
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds a persistent, always-visible admin banner that warns on **every** admin page when the live station can't reach Navidrome, and confirms the DJ Doc already checks for the same condition.

## Why

The DJ Doc's `checkNavidrome()` already pings Navidrome and emits a `fail` finding when it can't connect — but that only surfaces *inside* the Doctor panel. An operator sitting on Dash, Settings, or Library had no signal that the DJ's only music source was down.

## How

- **Backend** — new admin-gated `GET /doctor/navidrome` returning `{ ok, reason?, url }` from `doctor.navidromeConnectivity()`, which wraps the same never-throwing `subsonic.ping()` the Doctor's connectivity finding reads (so the banner and DJ Doc can never disagree). Result is cached ~20s server-side so polling every admin page never becomes a drip of Subsonic `ping` calls or hammers a flapping Navidrome.
- **Frontend** — `NavidromeBanner` polls that endpoint every 30s from `AdminShell` (so it renders on every admin page), showing a danger banner with the failure reason and a link to DJ Doc. Renders nothing when healthy or not-yet-known; ignores 401/5xx and controller-unreachable blips rather than flapping.
- **DJ Doc** — no functional change needed; `checkNavidrome()` already covers connectivity. The new banner deliberately shares its ping source.

## Verification

- `controller` lint: 0 errors (pre-existing `any` warnings only).
- `web` lint (eslint + `tsc --noEmit`): clean, exit 0.
- Not yet rendered live against a down-Navidrome station — reviewer may want to spot-check the banner visually (e.g. via `/verify`).