### PR TITLE
fix(llm): raise connection-test token budget above OpenAI Responses API minimum

### DIFF
--- a/controller/src/routes/onboarding.ts
+++ b/controller/src/routes/onboarding.ts
@@ -171,7 +171,9 @@ router.post('/onboarding/test-llm', requireAdmin, async (req, res) => {
     const out = await generateText({
       model: m,
       prompt: 'Reply with the single word OK.',
-      maxOutputTokens: 8,
+      // OpenAI's Responses API (the default path for createOpenAI()(model))
+      // rejects max_output_tokens below 16, so the probe budget must clear it.
+      maxOutputTokens: 32,
       // A test must always answer. Without a bound an unreachable/stalled model
       // hangs this handler forever, the wizard's fetch never resolves, and the
       // button is stuck on "Asking…" with no feedback (issue #682). maxRetries:0

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -285,6 +285,11 @@ function briefLlmError(err: unknown): string {
 // admin UI tests the key before saving, so the saved setting can't be trusted
 // mid-edit. The UI passes the provider it's editing; absent a hint we fall
 // back to the saved provider, then Tavily (the original sole owner of the key).
+//
+// Probe budget: OpenAI's Responses API (the default path for
+// createOpenAI()(model)) rejects max_output_tokens below 16 — a smaller test
+// budget fails key validation with "integer below minimum value" and blocks
+// saving the key entirely. 32 clears the floor on every provider.
 async function probeKey(
   key: (typeof SECRET_ENV_KEYS)[number],
   value: string,
@@ -299,7 +304,7 @@ async function probeKey(
       try {
         const model = activeModel('anthropic') || 'claude-haiku-4-5-20251001';
         const m = createAnthropic({ apiKey: value })(model);
-        await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
+        await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 32, abortSignal: AbortSignal.timeout(15000) });
         return { ok: true, message: `✓ Anthropic key valid · model responded` };
       } catch (err) { return { ok: false, message: briefLlmError(err) }; }
     }
@@ -307,7 +312,7 @@ async function probeKey(
       try {
         const model = activeModel('openai') || 'gpt-4o-mini';
         const m = createOpenAI({ apiKey: value })(model);
-        await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
+        await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 32, abortSignal: AbortSignal.timeout(15000) });
         return { ok: true, message: `✓ OpenAI key valid · model responded` };
       } catch (err) { return { ok: false, message: briefLlmError(err) }; }
     }
@@ -315,7 +320,7 @@ async function probeKey(
       try {
         const model = activeModel('google') || 'gemini-1.5-flash';
         const m = createGoogleGenerativeAI({ apiKey: value })(model);
-        await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
+        await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 32, abortSignal: AbortSignal.timeout(15000) });
         return { ok: true, message: `✓ Google key valid · model responded` };
       } catch (err) { return { ok: false, message: briefLlmError(err) }; }
     }
@@ -323,7 +328,7 @@ async function probeKey(
       try {
         const model = activeModel('deepseek') || 'deepseek-chat';
         const m = createDeepSeek({ apiKey: value })(model);
-        await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
+        await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 32, abortSignal: AbortSignal.timeout(15000) });
         return { ok: true, message: `✓ DeepSeek key valid · model responded` };
       } catch (err) { return { ok: false, message: briefLlmError(err) }; }
     }
@@ -331,7 +336,7 @@ async function probeKey(
       try {
         const model = activeModel('openrouter') || 'openai/gpt-4o-mini';
         const m = createOpenRouter({ apiKey: value })(model);
-        await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 8, abortSignal: AbortSignal.timeout(15000) });
+        await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 32, abortSignal: AbortSignal.timeout(15000) });
         return { ok: true, message: `✓ OpenRouter key valid · model responded` };
       } catch (err) { return { ok: false, message: briefLlmError(err) }; }
     }
@@ -565,7 +570,7 @@ router.post('/settings/llm/probe-compat', requireAdmin, async (req, res) => {
     await generateText({
       model: m,
       prompt: 'Reply with the single word OK.',
-      maxOutputTokens: 8,
+      maxOutputTokens: 32,
       abortSignal: AbortSignal.timeout(15000),
     });
     res.json({ ok: true, message: '✓ Bearer token accepted · model responded', latencyMs: Date.now() - t0 });


### PR DESCRIPTION
## Problem

Discord report: setting up a **Fallback AI through OpenAI** always fails with:

> Invalid 'max_output_tokens': integer below minimum value

The primary (local) model works, but the fallback can never be deployed.

## Root cause

- The admin "Test key" flow (`POST /settings/secrets/test` → `probeKey` in `controller/src/routes/settings.ts`) and the onboarding LLM test (`controller/src/routes/onboarding.ts`) send `maxOutputTokens: 8`.
- `createOpenAI({apiKey})(model)` in the current AI SDK (`@ai-sdk/openai` v4) defaults to OpenAI's **Responses API**, which enforces `max_output_tokens >= 16`. The probe's 8 gets rejected with exactly the reported error.
- The admin UI only **saves** a key after a passing probe (`LlmSection.tsx` `testKey`), so the OpenAI key never persists and the fallback leg never activates — "nothing ever reaches Fallback AI".

Only the native `openai` provider is affected: Anthropic/Google/DeepSeek/OpenRouter accept tiny caps, and `probe-compat` uses `.chat()` (Chat Completions). Runtime calls are fine (4000/8000 defaults; operator clamp floor is 500).

## Fix

Raise the probe budget from 8 → 32 in both routes (all providers, kept uniform), with a comment documenting the Responses-API floor so it doesn't regress.

## Verification

- `npm --prefix controller run lint` — 0 errors (warnings pre-existing).
- No other sub-16 `maxOutputTokens` remain in `controller/src`.