### PR TITLE
fix(dj): locale-aware spoken clock + deterministic hourly time phrase

### DIFF
--- a/controller/scripts/clock-phrase.test.ts
+++ b/controller/scripts/clock-phrase.test.ts
@@ -1,0 +1,86 @@
+// Unit tests for the pure clock helpers in time.ts — the shapes the DJ prompt
+// layer shows the model (issue: DJs saying "thirteen oh five" with the station
+// set to AM/PM, and the hourly check announcing "one in the morning" at 00:03).
+// Run: `npm test -- clock-phrase` (tsx scripts/clock-phrase.test.ts).
+
+import assert from 'node:assert/strict';
+import { clockDisplay, spokenHourPhrase } from '../src/time.js';
+
+let failures = 0;
+function test(name: string, fn: () => void | Promise<void>) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => console.log(`  ✓ ${name}`))
+    .catch((err) => { failures++; console.error(`  ✗ ${name}\n      ${err?.message || err}`); });
+}
+
+async function main() {
+  console.log('clockDisplay 24h (en-GB default):');
+  await test('afternoon stays 24-hour', () => {
+    assert.equal(clockDisplay(13, 5, false), '13:05');
+  });
+  await test('midnight is 00:xx, zero-padded', () => {
+    assert.equal(clockDisplay(0, 3, false), '00:03');
+  });
+
+  console.log('clockDisplay 12h (en-US / AM/PM):');
+  await test('the reported case — 13:05 renders as 1:05 pm', () => {
+    assert.equal(clockDisplay(13, 5, true), '1:05 pm');
+  });
+  await test('midnight is 12:xx am, never 0', () => {
+    assert.equal(clockDisplay(0, 3, true), '12:03 am');
+  });
+  await test('noon is 12:xx pm', () => {
+    assert.equal(clockDisplay(12, 0, true), '12:00 pm');
+  });
+  await test('morning hours are am', () => {
+    assert.equal(clockDisplay(9, 30, true), '9:30 am');
+  });
+  await test('11pm is 11:xx pm', () => {
+    assert.equal(clockDisplay(23, 59, true), '11:59 pm');
+  });
+
+  console.log('spokenHourPhrase:');
+  await test('the reported case — hour 0 is midnight, not one in the morning', () => {
+    assert.equal(spokenHourPhrase(0), 'midnight');
+  });
+  await test('hour 12 is noon', () => {
+    assert.equal(spokenHourPhrase(12), 'noon');
+  });
+  await test('1am is one in the morning', () => {
+    assert.equal(spokenHourPhrase(1), 'one in the morning');
+  });
+  await test('11am is eleven in the morning', () => {
+    assert.equal(spokenHourPhrase(11), 'eleven in the morning');
+  });
+  await test('13 is one in the afternoon', () => {
+    assert.equal(spokenHourPhrase(13), 'one in the afternoon');
+  });
+  await test('17 is five in the afternoon', () => {
+    assert.equal(spokenHourPhrase(17), 'five in the afternoon');
+  });
+  await test('18 is six in the evening', () => {
+    assert.equal(spokenHourPhrase(18), 'six in the evening');
+  });
+  await test('21 is nine in the evening', () => {
+    assert.equal(spokenHourPhrase(21), 'nine in the evening');
+  });
+  await test('22 is ten at night', () => {
+    assert.equal(spokenHourPhrase(22), 'ten at night');
+  });
+  await test('23 is eleven at night', () => {
+    assert.equal(spokenHourPhrase(23), 'eleven at night');
+  });
+  await test('out-of-range hours normalise instead of crashing', () => {
+    assert.equal(spokenHourPhrase(24), 'midnight');
+    assert.equal(spokenHourPhrase(-1), 'eleven at night');
+  });
+
+  if (failures) {
+    console.error(`\n${failures} failing`);
+    process.exit(1);
+  }
+  console.log('\nall clock-phrase pins pass');
+}
+
+main();

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -846,7 +846,7 @@ export async function runTrackEvent(queue, ctx, { wantLink, showAt = null }: { w
     // look-ahead (unknown duration), ban the clock outright.
     const clockClause = wantLink
       ? (showAt && ctx?.clock?.hhmm
-          ? ` The link airs at about ${ctx.clock.hhmm} — if you mention the clock, that is the time to use, never an earlier one.`
+          ? ` The link airs at about ${ctx.clock.display || ctx.clock.hhmm} — if you mention the clock, that is the time to use, never an earlier one.`
           : ` Never state the clock time in the link — you can't know exactly when it airs.`)
       : '';
     const varietyClause = wantLink

--- a/controller/src/context.ts
+++ b/controller/src/context.ts
@@ -5,7 +5,7 @@ import { config } from './config.js';
 import { resolveActiveShow, get as getSettings } from './settings.js';
 import * as session from './broadcast/session.js';
 import { getListenerCount } from './broadcast/listeners.js';
-import { zonedParts, zonedISODate } from './time.js';
+import { zonedParts, zonedISODate, clockDisplay, spokenHourPhrase } from './time.js';
 
 export function getTimeContext(date = new Date()) {
   const h = zonedParts(date).hour;
@@ -211,6 +211,15 @@ export function getClockContext(date = new Date()) {
   const minutesOfDay = h * 60 + m;
   return {
     hhmm: `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`,
+    // What the prompts show the model — the model speaks whatever clock shape
+    // it sees, so this follows the operator's locale (en-US → "1:05 pm")
+    // instead of always feeding 24-hour digits (issue: "thirteen oh five" on
+    // air with AM/PM selected in admin → Settings → Station).
+    display: clockDisplay(h, m, getSettings().locale === 'en-US'),
+    // Deterministic spoken hour for the hourly time check ("midnight", "one
+    // in the morning") — computed here so the model never converts 24-hour
+    // digits itself (it says "one in the morning" at 00:03).
+    spokenHour: spokenHourPhrase(h),
     isWeekend: dow === 0 || dow === 6,
     isLateNight: h < 5,
     isCommute: (minutesOfDay >= 450 && minutesOfDay < 570) ||  // 07:30-09:30

--- a/controller/src/llm/internal/prompts/context.ts
+++ b/controller/src/llm/internal/prompts/context.ts
@@ -126,7 +126,11 @@ export function buildContextLines(
     // drive-time period label) made the DJ read as a traffic-report station for
     // two hours a day. isCommute still gates commute-window skills and the
     // energy pacing in code (context.ts) — it just isn't prompt fodder anymore.
-    lines.push(`Local time: ${context.clock.hhmm}${tags.length ? ' · ' + tags.join(' · ') : ''}`);
+    // `display` follows the operator's locale (en-US → "1:05 pm") — the model
+    // speaks whatever clock shape it sees, so raw 24-hour hhmm here put
+    // "thirteen oh five" on air for AM/PM stations. hhmm kept as fallback for
+    // callers that build a bare clock object.
+    lines.push(`Local time: ${context.clock.display || context.clock.hhmm}${tags.length ? ' · ' + tags.join(' · ') : ''}`);
   }
   if (on('time') && context?.time) {
     // A show's pinned mood overrides the autonomous mood chain (context.ts),

--- a/controller/src/llm/internal/prompts/scripts.ts
+++ b/controller/src/llm/internal/prompts/scripts.ts
@@ -186,7 +186,15 @@ export async function generateLink({ previous, current, context, clockIsAirTime 
 
 export async function generateHourlyTime({ recap = null, context = null, recentOpeners = null, persona = null }: any = {}) {
   const ctxLines = buildContextLines(context, { contextFields: SCRIPT_CONTEXT_FIELDS });
-  ctxLines.push(`Task: a brief top-of-the-hour time check, in character. ${lengthPhrase('hourly', persona || undefined)}. Say the time in natural spoken words ("two in the afternoon", "just gone eight") — never digits or 24-hour form.`);
+  // The hour is converted to words in code (context.clock.spokenHour) rather
+  // than asking the model to read the clock line itself — small models get
+  // the 24-hour conversion wrong at the edges ("00:03" announced as "one in
+  // the morning"). The fallback keeps the old behaviour for a bare context.
+  const spoken = context?.clock?.spokenHour;
+  const timeClause = spoken
+    ? `The hour to announce is ${spoken} — say exactly that hour, in natural spoken words ("just gone ${spoken}", or similar) — never digits or 24-hour form, never a different hour.`
+    : `Say the time in natural spoken words ("two in the afternoon", "just gone eight") — never digits or 24-hour form.`;
+  ctxLines.push(`Task: a brief top-of-the-hour time check, in character. ${lengthPhrase('hourly', persona || undefined)}. ${timeClause}`);
   return djText({
     system: djSystem(persona || undefined),
     prompt: decoratePrompt(ctxLines.join('\n'), { kind: 'hourly', recap, recentOpeners }),

--- a/controller/src/time.ts
+++ b/controller/src/time.ts
@@ -84,3 +84,37 @@ export function zonedISODate(date = new Date()) {
   const { year, month, day } = zonedParts(date);
   return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
 }
+
+// --- clock display + spoken forms (pure, pinned by scripts/clock-phrase.test.ts) ---
+// The DJ prompt layer speaks whatever clock shape it is shown (issue: DJs
+// saying "thirteen oh five" with the station set to AM/PM), so the prompt
+// clock must be rendered here in the operator's chosen style rather than
+// letting the model convert 24-hour digits itself.
+
+// "13:05" (24h) or "1:05 pm" (12h). hour12 mirrors settings.locale === 'en-US'.
+export function clockDisplay(hour: number, minute: number, hour12: boolean) {
+  const mm = String(minute).padStart(2, '0');
+  if (!hour12) return `${String(hour).padStart(2, '0')}:${mm}`;
+  const h12 = hour % 12 === 0 ? 12 : hour % 12;
+  return `${h12}:${mm} ${hour < 12 ? 'am' : 'pm'}`;
+}
+
+const HOUR_WORDS = [
+  'twelve', 'one', 'two', 'three', 'four', 'five',
+  'six', 'seven', 'eight', 'nine', 'ten', 'eleven',
+];
+
+// The hour as a radio DJ would say it: "midnight", "noon", "one in the
+// morning", "two in the afternoon", "eleven at night". Computed in code so
+// the hourly time check never asks the model to convert 24-hour digits —
+// small models get midnight wrong ("00:03" spoken as "one in the morning").
+export function spokenHourPhrase(hour: number) {
+  const h = ((hour % 24) + 24) % 24;
+  if (h === 0) return 'midnight';
+  if (h === 12) return 'noon';
+  const word = HOUR_WORDS[h % 12];
+  if (h < 12) return `${word} in the morning`;
+  if (h < 18) return `${word} in the afternoon`;
+  if (h < 22) return `${word} in the evening`;
+  return `${word} at night`;
+}


### PR DESCRIPTION
## What

Two Discord-reported on-air time bugs, one root cause each:

1. **DJs say "13:05" even with AM/PM selected** (Mrain1, Sparks) — every spoken-segment prompt injected `Local time: 13:05` (raw 24-hour `clock.hhmm`), and the model echoes whatever clock shape it sees. The admin AM/PM setting (`settings.locale = 'en-US'`) was only ever shipped to the web UI; the prompt layer never read it.
2. **Hourly check says "one in the morning" at 00:03** (K8-Bit) — `generateHourlyTime` handed the model `00:03` and asked it to convert to natural words itself; small models botch the 24-hour conversion at the edges (midnight → "one in the morning").

## How

- `time.ts`: pure `clockDisplay(h, m, hour12)` (`13:05` / `1:05 pm`) and `spokenHourPhrase(h)` (`midnight`, `noon`, `one in the morning`, … `eleven at night`) — no imports, unit-pinned.
- `getClockContext`: new `display` field rendered per `settings.locale`, and deterministic `spokenHour`; `hhmm` unchanged for compat.
- `buildContextLines` (the single clock chokepoint for every generate*, matchRequest, banter, and the segment director) and the dj-agent air-time link clause now show the model `display` instead of raw hhmm.
- `generateHourlyTime`: the hour phrase is computed in code and pinned in the task line ("The hour to announce is midnight — say exactly that hour…") so the model never converts digits; bare-context callers keep the old instruction.

## Testing

- New `controller/scripts/clock-phrase.test.ts` (auto-discovered by `npm test`) pins both reported cases: `13:05 → 1:05 pm` and hour 0 → `midnight`, plus noon/edges/out-of-range. All pass.
- `npm run lint` (eslint + tsc) clean — 0 errors.