### PR TITLE
fix(shows): wire excluded playlists into pick paths + make strict filters actually strict

### DIFF
--- a/controller/scripts/resolve-show.test.ts
+++ b/controller/scripts/resolve-show.test.ts
@@ -1,0 +1,91 @@
+// Regression pins for settings.resolveActiveShow — the resolved-show object is
+// what EVERY pick path consumes (dj-agent, pool picker, auto-playlist refresh),
+// so a field the resolver drops is a feature silently disabled station-wide.
+// The canonical case: excludedPlaylistIds was validated + persisted but never
+// copied into the resolved show, so resolveExcludedPlaylistIds() always saw
+// undefined and the #779 playlist blocklist was a global no-op.
+//
+// Run: npm test -- resolve-show
+
+import assert from 'node:assert/strict';
+import { resolveActiveShow } from '../src/settings.js';
+import { setStationTimezone } from '../src/time.js';
+
+let failures = 0;
+async function test(name: string, fn: () => void | Promise<void>) {
+  try {
+    await fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  ✗ ${name}\n    ${(err as Error).message}`);
+  }
+}
+
+// Deterministic wall clock: pin the station zone and resolve at a fixed
+// instant — Saturday 2026-01-03 19:00 UTC (dow 6, hour 19).
+setStationTimezone('UTC');
+const at = new Date(Date.UTC(2026, 0, 3, 19, 0, 0));
+
+const schedule: (string | null)[][] = Array.from({ length: 7 }, () => Array(24).fill(null));
+schedule[6][19] = 's1';
+
+const settings = {
+  schedule,
+  shows: [
+    {
+      id: 's1',
+      name: 'Jazz Hour',
+      topic: 'smooth jazz for the weekend evening',
+      personaId: 'p1',
+      moods: ['calm'],
+      genres: ['Jazz'],
+      eras: [{ fromYear: 1960, toYear: 1979 }],
+      energies: ['low'],
+      filtersStrict: true,
+      playlistIds: ['pl-anchor-1', 'pl-anchor-2'],
+      playlistStrict: true,
+      excludedPlaylistIds: ['pl-blocked'],
+    },
+  ],
+  personas: [{ id: 'p1', name: 'Miles', avatar: '' }],
+};
+
+console.log('resolveActiveShow field propagation:');
+await test('resolves the scheduled show at the station-zone slot', () => {
+  const show = resolveActiveShow(at, settings as any);
+  assert.ok(show, 'expected a show at Sat 19:00');
+  assert.equal(show!.id, 's1');
+  assert.equal(show!.name, 'Jazz Hour');
+});
+
+await test('carries the playlist anchor (ids + strict toggle)', () => {
+  const show = resolveActiveShow(at, settings as any)!;
+  assert.deepEqual(show.playlistIds, ['pl-anchor-1', 'pl-anchor-2']);
+  assert.equal(show.playlistStrict, true);
+});
+
+await test('carries excludedPlaylistIds — the blocklist the pick paths read (#779 no-op regression)', () => {
+  const show = resolveActiveShow(at, settings as any)!;
+  assert.deepEqual((show as any).excludedPlaylistIds, ['pl-blocked']);
+});
+
+await test('carries the strict music filters', () => {
+  const show = resolveActiveShow(at, settings as any)!;
+  assert.equal(show.filtersStrict, true);
+  assert.deepEqual(show.genres, ['Jazz']);
+  assert.deepEqual(show.moods, ['calm']);
+  assert.deepEqual(show.energies, ['low']);
+  assert.deepEqual(show.eras, [{ fromYear: 1960, toYear: 1979 }]);
+});
+
+await test('returns null on an unscheduled slot', () => {
+  const off = new Date(Date.UTC(2026, 0, 3, 18, 0, 0)); // Sat 18:00 — empty cell
+  assert.equal(resolveActiveShow(off, settings as any), null);
+});
+
+if (failures) {
+  console.error(`\n${failures} failing`);
+  process.exit(1);
+}
+console.log('\nall resolve-show tests passed');

--- a/controller/scripts/show-filter.test.ts
+++ b/controller/scripts/show-filter.test.ts
@@ -11,7 +11,7 @@ import {
   normGenre, genreMatches, preferGenre,
   hasEraBound, eraSpan, inYearRange, preferEra,
   preferEnergy, preferEnergyStrict, preferMood,
-  onlyGenre, onlyMood, onlyEnergy,
+  onlyGenre, onlyMood, onlyEnergy, applyStrictLocks,
 } from '../src/music/show-filter.js';
 
 let failures = 0;
@@ -141,6 +141,51 @@ await test('inYearRange is the hard era filter: unknown-year drops, empty allowe
   const noYear = t({ year: null });
   assert.deepEqual(inYearRange([in20s, old, noYear], [{ fromYear: 2020, toYear: 2029 }]), [in20s]);
   assert.deepEqual(inYearRange([old, noYear], [{ fromYear: 2020, toYear: 2029 }]), []);
+});
+await test('inYearRange: null/empty-string year does NOT pass an open-lower-bound window (Number(null)===0 trap)', () => {
+  const in80s = t({ year: 1985 });
+  const nullYear = t({ year: null });
+  const emptyYear = t({ year: '' });
+  const zeroYear = t({ year: 0 });
+  // "1989 and earlier" — the old Number()-coercion let year:null/'' (→ 0) and a
+  // genuine year:0 sail through 0 <= 1989. Only the real 1985 track may pass.
+  assert.deepEqual(
+    inYearRange([in80s, nullYear, emptyYear, zeroYear], [{ fromYear: null, toYear: 1989 }]),
+    [in80s],
+  );
+});
+
+console.log('applyStrictLocks (per-dimension cascade — the shared strict enforcer):');
+await test('starve:true drops every dimension hard, even to empty (agent-tool contract)', () => {
+  const jazz80sCalm = t({ id: '1', genre: 'Jazz', year: 1985, moods: ['calm'], audioMoods: [], energy: 'low' });
+  const rock = t({ id: '2', genre: 'Rock', year: 1985, moods: ['calm'], audioMoods: [], energy: 'low' });
+  const locks = { genres: ['Jazz'], eras: [{ fromYear: 1980, toYear: 1989 }], moods: ['calm'], energies: ['low'] };
+  assert.deepEqual(applyStrictLocks([jazz80sCalm, rock], locks, { starve: true }).map(x => x.id), ['1']);
+  // Un-tagged pool + a mood lock → hard-empties (the wider scope guards dead air).
+  const untagged = t({ id: '3', genre: 'Jazz', year: 1985, moods: [], audioMoods: [], energy: 'low' });
+  assert.deepEqual(applyStrictLocks([untagged], locks, { starve: true }), []);
+});
+await test('starve:false never-starves PER DIMENSION: one zero-coverage class keeps the rest pure', () => {
+  // Genre + era have matches; NO track carries a mood (un-tagged library). The
+  // old all-or-nothing joint revert dumped the whole (off-genre) pool back in;
+  // the cascade must keep the genre/era-pure subset and skip only the mood step.
+  const jazz80s = t({ id: '1', genre: 'Jazz', year: 1985, moods: [], audioMoods: [] });
+  const rock80s = t({ id: '2', genre: 'Rock', year: 1985, moods: [], audioMoods: [] });
+  const jazz90s = t({ id: '3', genre: 'Jazz', year: 1995, moods: [], audioMoods: [] });
+  const locks = { genres: ['Jazz'], eras: [{ fromYear: 1980, toYear: 1989 }], moods: ['calm'], energies: [] };
+  const out = applyStrictLocks([jazz80s, rock80s, jazz90s], locks, { starve: false }).map(x => x.id);
+  assert.deepEqual(out, ['1']); // Jazz + 80s kept; mood step skipped (would empty), NOT reverted to full pool
+});
+await test('starve:false: a dimension WITH coverage still filters hard', () => {
+  const calm = t({ id: '1', genre: 'Jazz', moods: ['calm'], audioMoods: [] });
+  const loud = t({ id: '2', genre: 'Jazz', moods: ['loud'], audioMoods: [] });
+  const out = applyStrictLocks([calm, loud], { genres: ['Jazz'], moods: ['calm'] }, { starve: false }).map(x => x.id);
+  assert.deepEqual(out, ['1']);
+});
+await test('applyStrictLocks: empty locks are a full passthrough (no constraint)', () => {
+  const pool = [t({ id: '1', genre: 'Jazz' }), t({ id: '2', genre: 'Rock' })];
+  assert.deepEqual(applyStrictLocks(pool, { genres: [], eras: [], moods: [], energies: [] }, { starve: true }), pool);
+  assert.deepEqual(applyStrictLocks(pool, {}, { starve: false }), pool);
 });
 
 if (failures) {

--- a/controller/scripts/show-filter.test.ts
+++ b/controller/scripts/show-filter.test.ts
@@ -11,6 +11,7 @@ import {
   normGenre, genreMatches, preferGenre,
   hasEraBound, eraSpan, inYearRange, preferEra,
   preferEnergy, preferEnergyStrict, preferMood,
+  onlyGenre, onlyMood, onlyEnergy,
 } from '../src/music/show-filter.js';
 
 let failures = 0;
@@ -109,6 +110,37 @@ await test('preferMood matches any selected mood, case-insensitive', () => {
 await test('preferMood never-starves: un-tagged pool → full set', () => {
   const pool = [t({ moods: [], audioMoods: [] })];
   assert.deepEqual(preferMood(pool, ['calm']), pool);
+});
+
+console.log('hard filters (only*, NO never-starve — agent-tool locks + final-pool strict):');
+await test('onlyGenre drops off-genre and untagged, even to empty', () => {
+  const rock = t({ genre: 'Hard Rock' });
+  const jazz = t({ genre: 'Jazz' });
+  const untagged = t({ id: null });
+  assert.deepEqual(onlyGenre([rock, jazz, untagged], ['Rock']), [rock]);
+  assert.deepEqual(onlyGenre([jazz], ['Rock']), []);           // no fallback
+  assert.deepEqual(onlyGenre([rock, jazz], []), [rock, jazz]); // no constraint
+});
+await test('onlyMood drops un-tagged, even to empty', () => {
+  const a = t({ moods: ['calm'], audioMoods: [] });
+  const b = t({ moods: [], audioMoods: [] });
+  assert.deepEqual(onlyMood([a, b], ['calm']), [a]);
+  assert.deepEqual(onlyMood([b], ['calm']), []);
+  assert.deepEqual(onlyMood([a, b], []), [a, b]);
+});
+await test('onlyEnergy drops unknowns and off-band, even to empty', () => {
+  const hi = t({ energy: 'high' });
+  const unknown = t({ id: null });
+  assert.deepEqual(onlyEnergy([hi, unknown], ['high']), [hi]);
+  assert.deepEqual(onlyEnergy([hi, unknown], ['low']), []);
+  assert.deepEqual(onlyEnergy([hi, unknown], []), [hi, unknown]);
+});
+await test('inYearRange is the hard era filter: unknown-year drops, empty allowed', () => {
+  const in20s = t({ year: 2022 });
+  const old = t({ year: 1999 });
+  const noYear = t({ year: null });
+  assert.deepEqual(inYearRange([in20s, old, noYear], [{ fromYear: 2020, toYear: 2029 }]), [in20s]);
+  assert.deepEqual(inYearRange([old, noYear], [{ fromYear: 2020, toYear: 2029 }]), []);
 });
 
 if (failures) {

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -17,6 +17,7 @@ import * as session from './session.js';
 import * as picker from '../music/picker.js';
 import { resolveShowPlaylistPool, resolveExcludedPlaylistIds } from '../music/show-playlist.js';
 import * as library from '../music/library.js';
+import * as subsonic from '../music/subsonic.js';
 import * as mix from '../music/mix.js';
 import * as journey from '../music/journey.js';
 import { shuffle } from '../util/shuffle.js';
@@ -377,25 +378,16 @@ export const pickerAgent = defineAgent({
   maxSteps: 2,
   timeoutMs: agentDeadline,
   buildSystem: ({ showAt, playlistTracks }: any = {}) => pickSystem(showAt ?? null, !!playlistTracks?.length),
-  buildTools: ({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, playlistLock, playlistTracks, excludedIds, showAt }) => {
-    // Resolve the active show live (a show that just came on air takes effect),
-    // at the pick's look-ahead moment when one is threaded through (showAt —
-    // same clock the system prompt's brief resolved against, so prompt and
-    // locks can't disagree across a boundary): for a strict show
-    // (filtersStrict), EVERY set music filter — genre, era, mood, energy —
-    // becomes a hard lock the discovery tools enforce on candidates, not just
-    // the prompt. Track length is enforced as an on-air cut, NOT a pick filter
-    // (issue #447), so no length cap is passed here.
-    const activeShow = settings.resolveActiveShow(showAt ?? undefined);
-    const strict = !!(activeShow?.filtersStrict);
-    // Each lock is an any-of list (#929): a candidate passes when it matches
-    // ANY entry; the locks AND together across attributes.
-    const genreLock = strict && activeShow?.genres?.length ? activeShow.genres : null;
-    const eraLock = strict && hasEraBound(activeShow?.eras) ? activeShow.eras : null;
-    const moodLock = strict && activeShow?.moods?.length ? activeShow.moods : null;
-    const energyLock = strict && activeShow?.energies?.length ? activeShow.energies : null;
-    // playlistLock / playlistTracks are pre-resolved by pickViaAgent (the
-    // Navidrome fetch is async; buildTools is sync) and threaded through run().
+  buildTools: ({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, genreLock, eraLock, moodLock, energyLock, playlistLock, playlistTracks, excludedIds }) => {
+    // For a strict show (filtersStrict) EVERY set music filter — genre, era,
+    // mood, energy — becomes a hard lock the discovery tools enforce on
+    // candidates, not just the prompt. The locks are ALL pre-resolved in
+    // pickViaAgent and threaded through run() (async work — genre free text →
+    // library tags, library-coverage gating — that this sync builder can't do),
+    // alongside playlistLock / playlistTracks / excludedIds. Resolving them in
+    // one place off one show snapshot also keeps the prompt's brief and the
+    // tools' locks agreeing across a show boundary. Track length is an on-air
+    // cut, NOT a pick filter (#447), so no length cap is passed here.
     const { tools, seen } = buildPickerTools({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, genreLock, eraLock, moodLock, energyLock, playlistLock, playlistTracks, excludedIds });
     return { tools, extras: { seen } };
   },
@@ -543,7 +535,7 @@ async function enqueuePick(
 // the same closing move pickNextTrack already uses. Returns a full pick object
 // (id/reason/say/transition) or null; never throws, so a salvage failure falls
 // through to the caller's pick.rejected path unchanged.
-async function repickFromSeen({ seen, badId, wantLink }: { seen: Map<string, any>; badId: string | null; wantLink: boolean }) {
+async function repickFromSeen({ seen, badId, wantLink, showAt = null, playlistResolved = true }: { seen: Map<string, any>; badId: string | null; wantLink: boolean; showAt?: Date | null; playlistResolved?: boolean }) {
   const ids = [...seen.keys()];
   if (ids.length === 0) return null;
   const schema = modelTolerant(pickSchemaBase().extend({
@@ -551,7 +543,12 @@ async function repickFromSeen({ seen, badId, wantLink }: { seen: Map<string, any
   }));
   try {
     return await djObject({
-      system: pickSystem(),
+      // Same show snapshot as the failed run (showAt) and the same playlist-
+      // resolved gate — a tool-less salvage call must NOT reinstate "call
+      // showPlaylistTracks first / every pick MUST come from the playlist" when
+      // the anchor never resolved (no such tool exists here) or resolve a
+      // different show than the run whose candidates we're re-picking from.
+      system: pickSystem(showAt, playlistResolved),
       prompt: JSON.stringify({ candidates: [...seen.values()] }, null, 2)
         + `\n\nYou explored the library and then answered with ${badId ? `the id "${badId}", which matches none of the tracks your tools returned` : 'no usable track id'}. Only ids from the candidates above are real. Choose the best next track from them.`
         + (wantLink
@@ -601,6 +598,37 @@ async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = n
   const playlistLock = playlistPool && activeShow?.playlistStrict ? playlistPool.ids : null;
   const playlistTracks = playlistPool?.tracks ?? null;
   const excludedIds = activeShow ? await resolveExcludedPlaylistIds(activeShow) : null;
+
+  // Strict music locks for the discovery tools (filtersStrict). Resolved HERE,
+  // once, off the same show snapshot as the playlist pool — the async work the
+  // sync buildTools can't do — then threaded through run() alongside the
+  // playlist artifacts so prompt-brief and tool-locks agree across a boundary.
+  // Each lock is an any-of list (#929); the locks AND across attributes.
+  const strict = !!activeShow?.filtersStrict;
+  // Genre: resolve free text → the library's exact tags, dropping any that
+  // don't resolve (a misspelled / library-absent genre → no genre lock, not a
+  // starved-to-empty tool). This mirrors the pool path (music/picker.ts) so the
+  // two paths agree; the removed per-tool never-starve used to mask this.
+  let genreLock: string[] | null = null;
+  if (strict && activeShow?.genres?.length) {
+    const resolved: string[] = [];
+    for (const g of activeShow.genres) {
+      try { const r = await subsonic.resolveGenreName(g); if (r) resolved.push(r); } catch {}
+    }
+    genreLock = resolved.length ? resolved : null;
+  }
+  const eraLock = strict && hasEraBound(activeShow?.eras) ? activeShow!.eras : null;
+  // Mood / energy locks only bite when the tagger / analyzer has actually run:
+  // an un-tagged / un-analysed library carries no mood / energy on ANY track,
+  // so a hard lock would empty every tool for the whole show and trip the
+  // breaker with a misleading "model can't handle tools" diagnosis. Gate on
+  // library coverage (byMood / byEnergy vocab) — the same spirit as the genre
+  // drop-out. With coverage, a specific thin value still filters hard; the pool
+  // fallback (never-starve per dimension) is the dead-air backstop behind it.
+  const hasMoodCoverage = Object.keys(stats.byMood ?? {}).length > 0;
+  const hasEnergyCoverage = Object.keys(stats.byEnergy ?? {}).length > 0;
+  const moodLock = strict && activeShow?.moods?.length && hasMoodCoverage ? activeShow.moods : null;
+  const energyLock = strict && activeShow?.energies?.length && hasEnergyCoverage ? activeShow.energies : null;
   // A pinned anchor that resolves to nothing (deleted/recreated playlist →
   // stale id, or a Navidrome error — resolveShowPlaylistPool swallows both)
   // silently un-anchors the show: no lock, no showPlaylistTracks tool. Say so,
@@ -620,6 +648,10 @@ async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = n
     // over the run's current waypoint, so the agent path drifts the sound the
     // same way the pool path does. The event text tells the agent to use it.
     audioWaypoint,
+    genreLock,
+    eraLock,
+    moodLock,
+    energyLock,
     playlistLock,
     playlistTracks,
     excludedIds,
@@ -652,7 +684,7 @@ async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = n
     }
   }
   if (!song && extras.seen.size) {
-    const repicked = await repickFromSeen({ seen: extras.seen, badId: object?.id ?? null, wantLink });
+    const repicked = await repickFromSeen({ seen: extras.seen, badId: object?.id ?? null, wantLink, showAt, playlistResolved: !!playlistTracks?.length });
     if (repicked) {
       logEvent('pick.repicked', { agent: 'pick', from: object?.id ?? null, to: repicked.id, candidates: extras.seen.size });
       queue.log('picker', `agent returned unknown id "${object?.id}" — re-picked "${repicked.id}" from its own candidates`);

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -252,7 +252,7 @@ export function requestSchema() {
 // queue.onTrackStarted). The persona stays the live one — the outgoing DJ
 // tees the changeover up in their own voice; the on-air mic-pass is
 // runPersonaHandoff's job.
-export function pickSystem(showAt: Date | null = null) {
+export function pickSystem(showAt: Date | null = null, playlistResolved = true) {
   const persona = settings.getEffectivePersona();
   // In DJ mode, lean on the live session history: a working DJ runs threads
   // and calls back to a track or a remark from earlier in the shift. This pairs
@@ -280,8 +280,11 @@ export function pickSystem(showAt: Date | null = null) {
   // come from the pinned playlist (the tools already enforce this in code, but
   // saying so keeps the agent reaching for showPlaylistTracks instead of
   // burning steps on tools that come back empty); soft → strong preference,
-  // occasional steps outside allowed for flow.
-  const playlistLean = activeShow?.playlistIds?.length
+  // occasional steps outside allowed for flow. Gated on playlistResolved: when
+  // the show pins playlists but none resolved (stale ids / Navidrome error),
+  // the showPlaylistTracks tool is NOT registered — telling the model to call
+  // a tool that doesn't exist burns steps and invites fabrication.
+  const playlistLean = activeShow?.playlistIds?.length && playlistResolved
     ? (activeShow.playlistStrict
         ? `\n\nThis show is anchored to a curated playlist: every track you pick MUST come from it. Call showPlaylistTracks first and choose from what it returns.`
         : `\n\nThis show leans on a curated playlist: call showPlaylistTracks first and strongly prefer those tracks; only step outside occasionally when the flow calls for it.`)
@@ -373,7 +376,7 @@ export const pickerAgent = defineAgent({
   // actually rescues these, not more steps on a polluted trail.
   maxSteps: 2,
   timeoutMs: agentDeadline,
-  buildSystem: ({ showAt }: any = {}) => pickSystem(showAt ?? null),
+  buildSystem: ({ showAt, playlistTracks }: any = {}) => pickSystem(showAt ?? null, !!playlistTracks?.length),
   buildTools: ({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, playlistLock, playlistTracks, excludedIds, showAt }) => {
     // Resolve the active show live (a show that just came on air takes effect),
     // at the pick's look-ahead moment when one is threaded through (showAt —
@@ -598,6 +601,14 @@ async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = n
   const playlistLock = playlistPool && activeShow?.playlistStrict ? playlistPool.ids : null;
   const playlistTracks = playlistPool?.tracks ?? null;
   const excludedIds = activeShow ? await resolveExcludedPlaylistIds(activeShow) : null;
+  // A pinned anchor that resolves to nothing (deleted/recreated playlist →
+  // stale id, or a Navidrome error — resolveShowPlaylistPool swallows both)
+  // silently un-anchors the show: no lock, no showPlaylistTracks tool. Say so,
+  // loudly — a strict show playing 100% off-playlist with zero log output is
+  // undiagnosable from the operator's side.
+  if (activeShow?.playlistIds?.length && !playlistPool) {
+    queue.log('picker', `show "${activeShow.name}" pins ${activeShow.playlistIds.length} playlist(s) but none resolved to tracks — anchor ignored${activeShow.playlistStrict ? ' (STRICT toggle has no effect)' : ''}. Stale playlist id (deleted/recreated in Navidrome?) or a Navidrome error; re-select the playlists in the show editor.`);
+  }
 
   const run = await pickerAgent.run({
     messages: session.windowMessages(),

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -104,6 +104,11 @@ async function refreshAutoPlaylistInner() {
   const hasPlaylist = !!playlistPool?.tracks?.length;
   const strictPlaylist = hasPlaylist && !!show?.playlistStrict;
   const excludedIds = show ? await resolveExcludedPlaylistIds(show) : null;
+  // Pinned anchor resolved to nothing → the fallback playlist is silently
+  // un-anchored too. Surface it (same warning as the pick paths).
+  if (show?.playlistIds?.length && !playlistPool) {
+    queue.log('picker', `show "${show.name}" pins ${show.playlistIds.length} playlist(s) but none resolved to tracks — auto-playlist anchor ignored. Stale playlist id (deleted/recreated in Navidrome?) or a Navidrome error; re-select the playlists in the show editor.`);
+  }
 
   // Resolve the show's free-text genres to the library's exact tags once, up
   // front. Entries that fail to resolve drop out; NONE resolving disables the

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -12,7 +12,7 @@ import * as subsonic from '../music/subsonic.js';
 import * as dj from '../llm/dj.js';
 import * as library from '../music/library.js';
 import * as settings from '../settings.js';
-import { normGenre, genreMatches, inYearRange, preferEnergy, preferEnergyStrict, preferMood, hasEraBound, eraSpan } from '../music/show-filter.js';
+import { normGenre, genreMatches, inYearRange, preferEnergy, preferEnergyStrict, preferMood, applyStrictLocks, hasEraBound, eraSpan } from '../music/show-filter.js';
 import { resolveShowPlaylistPool, resolveExcludedPlaylistIds } from '../music/show-playlist.js';
 import { getFullContext } from '../context.js';
 import { queue } from './queue.js';
@@ -325,6 +325,25 @@ async function refreshAutoPlaylistInner() {
   if (strictPlaylist) {
     const inPl = pool.filter((t: any) => t?.id && playlistPool!.ids.has(t.id));
     if (inPl.length) { pool.length = 0; pool.push(...inPl); }
+  }
+
+  // Strict music filters on the FINAL pool. enforce() only ever hard-drops
+  // genre/era per source; mood/energy went through per-source never-starve
+  // (preferMood / preferEnergyStrict), so any source with zero in-mood/energy
+  // matches dumped its whole result into auto.m3u and the coast (LLM down,
+  // budget-hard, zero listeners) aired off-filter tracks with no gatekeeper.
+  // Filter the assembled pool the same way music/picker.ts does — per-dimension
+  // never-starve, so one zero-coverage dimension can't throw away the rest.
+  // Genre/era are already enforce()-pure, so those steps are no-ops here.
+  if (strict) {
+    const filtered = applyStrictLocks(pool, {
+      genres: genreNames,   // resolved library tags ([] → no genre step)
+      eras,
+      moods: showMoods,
+      energies: showEnergies,
+    }, { starve: false });
+    pool.length = 0;
+    pool.push(...filtered);
   }
 
   // Excluded playlists (blocklist): drop every track from a blocklisted

--- a/controller/src/llm/internal/tools/picker-tools.ts
+++ b/controller/src/llm/internal/tools/picker-tools.ts
@@ -15,7 +15,7 @@ import * as library from '../../../music/library.js';
 import * as embeddings from '../../../music/embeddings.js';
 import * as analyzer from '../../../music/analyzer.js';
 import { filterPickerCandidates, durationSeconds } from '../../../music/recency.js';
-import { preferGenre, preferEra, preferMood, preferEnergyStrict } from '../../../music/show-filter.js';
+import { onlyGenre, inYearRange, onlyMood, onlyEnergy } from '../../../music/show-filter.js';
 import { shuffle } from '../../../util/shuffle.js';
 import { searchWeb, searchReady } from '../../../skills/web-search.js';
 import { identifyTrackFromText } from '../prompts/request.js';
@@ -115,23 +115,22 @@ export function buildPickerTools({
   hardRecentKeys?: Set<string>;    // lowercased "title|artist" — blocks id-less backfilled plays
   // Hard genre constraint for a strict show (show.filtersStrict) — a list of
   // genres, any-of (#929). When set, every tool's candidates are genre-filtered
-  // (preferGenre, never-starve) before recency + cap, so the agent path
-  // enforces the lock in code, not just the prompt — mirroring the pool
-  // picker's strict mode. null/empty = no lock. Deliberately NOT set on the
-  // request path: an explicit listener ask wins.
+  // (onlyGenre — HARD, no per-tool never-starve; see the collect() note) before
+  // recency + cap, so the agent path enforces the lock in code, not just the
+  // prompt. null/empty = no lock. Deliberately NOT set on the request path: an
+  // explicit listener ask wins.
   genreLock?: string[] | null;
   // Hard era constraint — a list of decade/year windows, any-of (#929) —
   // applied only for a strict show (same filtersStrict flag — one toggle
-  // governs every filter). When set, candidates are year-filtered (preferEra,
-  // never-starve) before recency + cap. null/empty = no era lock.
+  // governs every filter). When set, candidates are year-filtered (inYearRange
+  // — HARD, unknown-year tracks drop) before recency + cap. null/empty = no lock.
   eraLock?: { fromYear?: number | null; toYear?: number | null }[] | null;
   // Hard mood constraint for a strict show — any-of list: candidates are
-  // filtered to tracks tagged with any of the show's moods (preferMood,
-  // never-starve). null/empty = no lock.
+  // filtered to tracks tagged with any of the show's moods (onlyMood — HARD).
+  // null/empty = no lock.
   moodLock?: string[] | null;
   // Hard energy-band constraint for a strict show — any-of list: candidates
-  // are filtered to the analysed bands (preferEnergyStrict — unknowns dropped,
-  // never-starve).
+  // are filtered to the analysed bands (onlyEnergy — HARD, unknowns dropped).
   energyLock?: string[] | null;
   // The active sonic journey's current waypoint vector (broadcast/dj-agent.ts).
   // When present, the tracksTowardJourney tool below is registered, closing
@@ -170,14 +169,20 @@ export function buildPickerTools({
   // grows with each tool call regardless.
   const collect = (list: any, cap = 8) => {
     // Strict show: filter candidates BEFORE recency + cap, so the 8 the agent
-    // sees are genre-/era-/mood-/energy-pure. Each lock never-starves (falls
-    // back to the full list when a tool returns no match), so a thin constraint
-    // degrades to off-target rather than dead air — same contract as the pool path.
+    // sees are genre-/era-/mood-/energy-pure. Each lock is HARD — a tool whose
+    // results contain no match contributes nothing (emptyResult steers the
+    // model to another tool), mirroring playlistLock below. The old per-tool
+    // never-starve passed a tool's ENTIRE unfiltered result through on zero
+    // matches; the similarity tools cluster on the (possibly off-filter)
+    // current track, so strict shows leaked off-filter picks constantly.
+    // Dead-air is still guarded at wider scopes: a run with zero candidates
+    // fails into the pool picker (which never-starves on its final pool), and
+    // behind that the auto.m3u coast.
     let pool = shuffle((list || []) as any[]);
-    if (genreLock?.length) pool = preferGenre(pool, genreLock);
-    if (eraLock?.length) pool = preferEra(pool, eraLock);
-    if (moodLock?.length) pool = preferMood(pool, moodLock);
-    if (energyLock?.length) pool = preferEnergyStrict(pool, energyLock);
+    if (genreLock?.length) pool = onlyGenre(pool, genreLock);
+    if (eraLock?.length) pool = inYearRange(pool, eraLock);
+    if (moodLock?.length) pool = onlyMood(pool, moodLock);
+    if (energyLock?.length) pool = onlyEnergy(pool, energyLock);
     // Strict playlist: HARD-intersect with the lock set, with NO never-starve to
     // off-playlist (a playlist is an exact set, so a tool with no overlap simply
     // contributes nothing). The guaranteed in-set source is showPlaylistTracks
@@ -213,10 +218,11 @@ export function buildPickerTools({
   // day). `matched` is the pre-recency-filter count, so the note distinguishes
   // "nothing matches" from "matches exist but were all played recently or
   // already shown this pick" — opposite next moves for the model.
+  const hasStrictLock = !!(genreLock?.length || eraLock?.length || moodLock?.length || energyLock?.length);
   const emptyResult = (matched: number, hint: string) => ({
     tracks: [],
     note: matched > 0
-      ? `${matched} matching track(s) exist but were all played recently or already shown this pick — ${hint}`
+      ? `${matched} matching track(s) exist but were all played recently, already shown this pick${hasStrictLock ? ', or outside this show\'s strict music filters' : ''} — ${hint}`
       : hint,
     rule: 'Never invent a song id — only ids returned by a tool are valid picks.',
   });

--- a/controller/src/llm/internal/tools/picker-tools.ts
+++ b/controller/src/llm/internal/tools/picker-tools.ts
@@ -15,7 +15,7 @@ import * as library from '../../../music/library.js';
 import * as embeddings from '../../../music/embeddings.js';
 import * as analyzer from '../../../music/analyzer.js';
 import { filterPickerCandidates, durationSeconds } from '../../../music/recency.js';
-import { onlyGenre, inYearRange, onlyMood, onlyEnergy } from '../../../music/show-filter.js';
+import { applyStrictLocks } from '../../../music/show-filter.js';
 import { shuffle } from '../../../util/shuffle.js';
 import { searchWeb, searchReady } from '../../../skills/web-search.js';
 import { identifyTrackFromText } from '../prompts/request.js';
@@ -169,20 +169,21 @@ export function buildPickerTools({
   // grows with each tool call regardless.
   const collect = (list: any, cap = 8) => {
     // Strict show: filter candidates BEFORE recency + cap, so the 8 the agent
-    // sees are genre-/era-/mood-/energy-pure. Each lock is HARD — a tool whose
-    // results contain no match contributes nothing (emptyResult steers the
-    // model to another tool), mirroring playlistLock below. The old per-tool
-    // never-starve passed a tool's ENTIRE unfiltered result through on zero
-    // matches; the similarity tools cluster on the (possibly off-filter)
+    // sees are genre-/era-/mood-/energy-pure. Each lock is HARD (starve:true) —
+    // a tool whose results contain no match contributes nothing (emptyResult
+    // steers the model to another tool), mirroring playlistLock below. The old
+    // per-tool never-starve passed a tool's ENTIRE unfiltered result through on
+    // zero matches; the similarity tools cluster on the (possibly off-filter)
     // current track, so strict shows leaked off-filter picks constantly.
     // Dead-air is still guarded at wider scopes: a run with zero candidates
     // fails into the pool picker (which never-starves on its final pool), and
-    // behind that the auto.m3u coast.
-    let pool = shuffle((list || []) as any[]);
-    if (genreLock?.length) pool = onlyGenre(pool, genreLock);
-    if (eraLock?.length) pool = inYearRange(pool, eraLock);
-    if (moodLock?.length) pool = onlyMood(pool, moodLock);
-    if (energyLock?.length) pool = onlyEnergy(pool, energyLock);
+    // behind that the auto.m3u coast. The locks are pre-resolved + coverage-
+    // gated in pickViaAgent (genres → library tags, mood/energy dropped when the
+    // library has no such tags) so an un-analysed library can't starve every
+    // tool for the whole show.
+    let pool = applyStrictLocks(shuffle((list || []) as any[]), {
+      genres: genreLock, eras: eraLock, moods: moodLock, energies: energyLock,
+    }, { starve: true });
     // Strict playlist: HARD-intersect with the lock set, with NO never-starve to
     // off-playlist (a playlist is an exact set, so a tool with no overlap simply
     // contributes nothing). The guaranteed in-set source is showPlaylistTracks
@@ -218,11 +219,15 @@ export function buildPickerTools({
   // day). `matched` is the pre-recency-filter count, so the note distinguishes
   // "nothing matches" from "matches exist but were all played recently or
   // already shown this pick" — opposite next moves for the model.
-  const hasStrictLock = !!(genreLock?.length || eraLock?.length || moodLock?.length || energyLock?.length);
+  // A strict lock is anything that can drop a candidate the source DID return:
+  // the music filters, the playlist intersection, and the blocklist. Any of
+  // them makes "matches exist but were filtered" a real cause the note should
+  // name, not just recency (steering the model to switch tools, not retry).
+  const hasStrictLock = !!(genreLock?.length || eraLock?.length || moodLock?.length || energyLock?.length || playlistLock || excludedIds);
   const emptyResult = (matched: number, hint: string) => ({
     tracks: [],
     note: matched > 0
-      ? `${matched} matching track(s) exist but were all played recently, already shown this pick${hasStrictLock ? ', or outside this show\'s strict music filters' : ''} — ${hint}`
+      ? `${matched} matching track(s) exist but were all played recently, already shown this pick${hasStrictLock ? ', or outside this show\'s strict filters' : ''} — ${hint}`
       : hint,
     rule: 'Never invent a song id — only ids returned by a tool are valid picks.',
   });
@@ -545,7 +550,17 @@ export function buildPickerTools({
         description: "Tracks from the show's pinned playlist(s) — the operator's hand-picked selection for this show. Prefer these: call this first and choose from what it returns. Takes no input.",
         inputSchema: z.object({}),
         execute: async () => {
-          try { return collect(playlistTracks, 12); }
+          try {
+            const out = collect(playlistTracks, 12);
+            // The show's mandated source must never return a bare [] — with the
+            // strict music locks also applied here, an un-tagged playlist can
+            // filter to empty, and pickSystem simultaneously tells the model
+            // "every pick MUST come from it". A note-less [] is the documented
+            // fabrication trigger; emptyResult carries the "never invent an id"
+            // rule and explains WHY (recency vs strict filters).
+            if (out.length) return out;
+            return emptyResult(playlistTracks.length, 'the pinned playlist tracks were all filtered out by recency or this show\'s strict music filters — choose from an earlier result, or a later tool call may surface a fresh in-playlist track');
+          }
           catch (err) { return { error: err.message }; }
         },
       }),

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -15,7 +15,7 @@ import * as settings from '../settings.js';
 import { bpmCompat, keyCompat } from './mix.js';
 import { shuffle } from '../util/shuffle.js';
 import { filterPickerCandidates, recencyWindowsForLibrary, effectiveNoRepeatWindow } from './recency.js';
-import { normGenre, genreMatches, preferGenre, preferEra, inYearRange, preferEnergy, preferEnergyStrict, preferMood, onlyGenre, onlyMood, onlyEnergy, hasEraBound, eraSpan, type YearRange } from './show-filter.js';
+import { normGenre, genreMatches, preferGenre, preferEra, inYearRange, preferEnergy, preferEnergyStrict, preferMood, applyStrictLocks, hasEraBound, eraSpan, type YearRange } from './show-filter.js';
 import { resolveShowPlaylistPool, resolveExcludedPlaylistIds, type PlaylistPool } from './show-playlist.js';
 
 // A track flowing through the pool builder — a raw Subsonic child, a slimTrack
@@ -466,21 +466,23 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     if (inPl.length) selectionPool = inPl;
   }
 
-  // Strict music filters: enforce on the FINAL merged pool too, same
-  // never-starve scope as the strict-playlist block above. The per-source
+  // Strict music filters: enforce on the FINAL merged pool too. The per-source
   // lean() alone wasn't enough — any source with zero in-filter matches passed
   // its whole result through (never-starve per source), so the pool the LLM
   // saw was routinely half off-filter and "strict" hinged on prompt
-  // compliance (Discord: strict-era show playing pre-era tracks half the
-  // time). Filtering here keeps the pool pure whenever ANY in-filter track
-  // survived; a genuinely starved constraint still degrades to the full pool.
+  // compliance (Discord: strict-era show playing pre-era tracks half the time).
+  // applyStrictLocks(starve:false) never-starves PER DIMENSION, so a single
+  // zero-coverage tag class (e.g. a mood on an un-tagged library) can't throw
+  // away the genre/era purity the other dimensions established — the earlier
+  // all-or-nothing joint revert did exactly that. genres pre-resolved to
+  // library tags above (strictGenres); [] there = no genre step.
   if (strict) {
-    let inFilter = selectionPool;
-    if (strictGenres.length) inFilter = onlyGenre(inFilter, strictGenres);
-    inFilter = inYearRange(inFilter, showFilter!.eras);
-    inFilter = onlyMood(inFilter, showFilter!.moods);
-    inFilter = onlyEnergy(inFilter, showFilter!.energies);
-    if (inFilter.length) selectionPool = inFilter;
+    selectionPool = applyStrictLocks(selectionPool, {
+      genres: strictGenres,
+      eras: showFilter!.eras,
+      moods: showFilter!.moods,
+      energies: showFilter!.energies,
+    }, { starve: false });
   }
 
   // De-dup by id, cap per artist so one name can't dominate the pool (the LLM

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -15,7 +15,7 @@ import * as settings from '../settings.js';
 import { bpmCompat, keyCompat } from './mix.js';
 import { shuffle } from '../util/shuffle.js';
 import { filterPickerCandidates, recencyWindowsForLibrary, effectiveNoRepeatWindow } from './recency.js';
-import { normGenre, genreMatches, preferGenre, preferEra, inYearRange, preferEnergy, preferEnergyStrict, preferMood, hasEraBound, eraSpan, type YearRange } from './show-filter.js';
+import { normGenre, genreMatches, preferGenre, preferEra, inYearRange, preferEnergy, preferEnergyStrict, preferMood, onlyGenre, onlyMood, onlyEnergy, hasEraBound, eraSpan, type YearRange } from './show-filter.js';
 import { resolveShowPlaylistPool, resolveExcludedPlaylistIds, type PlaylistPool } from './show-playlist.js';
 
 // A track flowing through the pool builder — a raw Subsonic child, a slimTrack
@@ -466,6 +466,23 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     if (inPl.length) selectionPool = inPl;
   }
 
+  // Strict music filters: enforce on the FINAL merged pool too, same
+  // never-starve scope as the strict-playlist block above. The per-source
+  // lean() alone wasn't enough — any source with zero in-filter matches passed
+  // its whole result through (never-starve per source), so the pool the LLM
+  // saw was routinely half off-filter and "strict" hinged on prompt
+  // compliance (Discord: strict-era show playing pre-era tracks half the
+  // time). Filtering here keeps the pool pure whenever ANY in-filter track
+  // survived; a genuinely starved constraint still degrades to the full pool.
+  if (strict) {
+    let inFilter = selectionPool;
+    if (strictGenres.length) inFilter = onlyGenre(inFilter, strictGenres);
+    inFilter = inYearRange(inFilter, showFilter!.eras);
+    inFilter = onlyMood(inFilter, showFilter!.moods);
+    inFilter = onlyEnergy(inFilter, showFilter!.energies);
+    if (inFilter.length) selectionPool = inFilter;
+  }
+
   // De-dup by id, cap per artist so one name can't dominate the pool (the LLM
   // can only rotate artists across what it's handed), shuffle, cap.
   const MAX_PER_ARTIST = 3;
@@ -587,6 +604,11 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   const playlistPool = activeShow ? await resolveShowPlaylistPool(activeShow) : null;
   const playlistStrict = !!activeShow?.playlistStrict;
   const excludedIds = activeShow ? await resolveExcludedPlaylistIds(activeShow) : null;
+  // Pinned anchor resolved to nothing → the show is silently un-anchored.
+  // Surface it (same warning as the agent path in dj-agent.ts).
+  if (activeShow?.playlistIds?.length && !playlistPool) {
+    queue.log('picker', `show "${activeShow.name}" pins ${activeShow.playlistIds.length} playlist(s) but none resolved to tracks — anchor ignored${playlistStrict ? ' (STRICT toggle has no effect)' : ''}. Stale playlist id (deleted/recreated in Navidrome?) or a Navidrome error; re-select the playlists in the show editor.`);
+  }
   const { candidates: rawCandidates, sources, strictInfo, playlistInfo } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack, rankTarget, audioWaypoint, showFilter, hardRecentIds, hardRecentKeys, playlistPool, playlistStrict);
 
   // Excluded playlists (blocklist): drop any track whose id appears in the

--- a/controller/src/music/show-filter.ts
+++ b/controller/src/music/show-filter.ts
@@ -122,8 +122,13 @@ function inAnyWindow(year: number, eras: YearRange[]): boolean {
 export function inYearRange<T extends FilterTrack>(tracks: T[], eras: YearRange[]): T[] {
   if (!hasEraBound(eras)) return tracks;
   return tracks.filter((t) => {
+    // Unknown year drops (the hard-filter contract). Two traps this guards:
+    // Number(null)/Number('') are 0, and some taggers write TYER=0000 → a
+    // literal 0 — either would sail through a window with an open lower bound
+    // ("1989 and earlier": 0 <= 1989). A real recording year is always > 0, so
+    // treat null / '' / non-finite / non-positive as unknown and drop it.
     const y = Number(t?.year);
-    return Number.isFinite(y) && inAnyWindow(y, eras);
+    return Number.isFinite(y) && y > 0 && inAnyWindow(y, eras);
   });
 }
 
@@ -215,4 +220,51 @@ export function onlyEnergy<T extends FilterTrack>(tracks: T[], energies?: string
     const e = trackEnergy(t);
     return e != null && energies.includes(e);
   });
+}
+
+// ── Strict lock composition ──────────────────────────────────────────────────
+
+// A show's strict music constraints, resolved to library-comparable values:
+// genres are the library's exact tags (the caller resolves free text via
+// subsonic.resolveGenreName upstream — genre matching still normalises); eras /
+// moods / energies are as the show declares them. Any dimension left
+// empty/absent is "no constraint".
+export type StrictLocks = {
+  genres?: string[] | null;
+  eras?: YearRange[] | null;
+  moods?: string[] | null;
+  energies?: string[] | null;
+};
+
+// Apply a show's strict music locks as a PER-DIMENSION cascade — the single
+// source of truth for "make this pool strict", shared by both pick paths and
+// the auto-playlist coast so they can't drift on what strict means.
+//
+//   starve: true  — every dimension drops hard, even to empty. The agent-tool
+//     contract (llm/internal/tools/picker-tools.ts): a tool that ends up empty
+//     contributes nothing, and dead-air is guarded at a WIDER scope — a run
+//     with zero candidates fails into the pool picker, which never-starves.
+//   starve: false — never-starve PER DIMENSION: a dimension whose filter would
+//     empty the running pool is skipped, so the OTHER dimensions' purity
+//     survives. This replaces the old all-or-nothing joint revert, where one
+//     zero-coverage tag class (e.g. a mood on an un-tagged library) threw away
+//     an otherwise genre- and era-pure pool and leaked off-filter tracks back.
+//
+// Order is genre → era → mood → energy; with starve:false each step commits
+// only if it left something, so a starved late dimension can't undo an earlier
+// one's tightening.
+export function applyStrictLocks<T extends FilterTrack>(
+  tracks: T[],
+  locks: StrictLocks,
+  { starve }: { starve: boolean },
+): T[] {
+  let pool = tracks;
+  const step = (next: T[]) => {
+    if (starve || next.length) pool = next;
+  };
+  if (locks.genres?.length) step(onlyGenre(pool, locks.genres));
+  if (hasEraBound(locks.eras)) step(inYearRange(pool, locks.eras!));
+  if (locks.moods?.length) step(onlyMood(pool, locks.moods));
+  if (locks.energies?.length) step(onlyEnergy(pool, locks.energies));
+  return pool;
 }

--- a/controller/src/music/show-filter.ts
+++ b/controller/src/music/show-filter.ts
@@ -65,6 +65,18 @@ export function preferGenre<T extends FilterTrack>(tracks: T[], genreNames?: str
   return match.length ? match : tracks;
 }
 
+// Hard genre filter — NO never-starve: off-genre (and untagged) tracks drop
+// even when that empties the list. For call sites that guarantee
+// non-starvation at a WIDER scope than one source: the agent tools starve
+// per-tool and rely on the pool fallback; the pool picker never-starves on the
+// final merged pool. The per-source never-starve in prefer* is what let strict
+// shows leak off-filter tracks whenever a single source had zero matches.
+export function onlyGenre<T extends FilterTrack>(tracks: T[], genreNames?: string[] | null): T[] {
+  const targets = (genreNames ?? []).map(normGenre).filter(Boolean);
+  if (!targets.length) return tracks;
+  return tracks.filter((t) => genreMatches(t, targets));
+}
+
 // ── Era (decade / year windows) ──────────────────────────────────────────────
 
 export type YearRange = { fromYear?: number | null; toYear?: number | null };
@@ -186,4 +198,21 @@ export function preferMood<T extends FilterTrack>(tracks: T[], moods?: string[] 
   const targets = moods.map(m => String(m).toLowerCase());
   const match = tracks.filter((t) => trackMoods(t).some((x) => targets.includes(String(x).toLowerCase())));
   return match.length ? match : tracks;
+}
+
+// Hard mood filter — NO never-starve (see onlyGenre for the scoping contract).
+export function onlyMood<T extends FilterTrack>(tracks: T[], moods?: string[] | null): T[] {
+  if (!moods?.length) return tracks;
+  const targets = moods.map(m => String(m).toLowerCase());
+  return tracks.filter((t) => trackMoods(t).some((x) => targets.includes(String(x).toLowerCase())));
+}
+
+// Hard energy filter — NO never-starve (see onlyGenre). Unknown-energy tracks
+// drop too, same as preferEnergyStrict.
+export function onlyEnergy<T extends FilterTrack>(tracks: T[], energies?: string[] | null): T[] {
+  if (!energies?.length) return tracks;
+  return tracks.filter((t) => {
+    const e = trackEnergy(t);
+    return e != null && energies.includes(e);
+  });
 }

--- a/controller/src/music/show-playlist.ts
+++ b/controller/src/music/show-playlist.ts
@@ -72,7 +72,14 @@ export async function resolveShowPlaylistPool(show: any): Promise<PlaylistPool |
       lists.push(songs || []);
       const meta = index.find((p: any) => p.id === id);
       if (meta?.name) names.push(meta.name);
-    } catch {}
+    } catch (err) {
+      // Still degrade (never strand the stream on one bad anchor), but say so:
+      // a stale id (playlist deleted/recreated in Navidrome) failing silently
+      // here is what turned a "playlist only (strict)" show into an unanchored
+      // one with no trace. The pick paths log the operator-facing warning when
+      // the whole pool comes back null.
+      console.warn(`[show-playlist] anchor playlist ${id} failed to resolve: ${(err as Error)?.message}`);
+    }
   }
 
   const tracks = mergePlaylistTracks(lists);
@@ -98,7 +105,9 @@ export async function resolveExcludedPlaylistIds(show: any): Promise<Set<string>
       for (const t of songs || []) {
         if (t?.id) blocked.add(t.id);
       }
-    } catch {}
+    } catch (err) {
+      console.warn(`[show-playlist] excluded playlist ${id} failed to resolve: ${(err as Error)?.message}`);
+    }
   }
   return blocked.size ? blocked : null;
 }

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -3700,6 +3700,11 @@ export function resolveActiveShow(date = new Date(), s = get()) {
     // entire universe; soft just lets it dominate. Empty array = no anchor.
     playlistIds: Array.isArray(show.playlistIds) ? show.playlistIds.filter((v: unknown) => typeof v === 'string') : [],
     playlistStrict: show.playlistStrict === true,
+    // Navidrome playlist blocklist: tracks in these playlists are hard-dropped
+    // from the show's candidate pool (resolveExcludedPlaylistIds reads this off
+    // the RESOLVED show, so omitting it here silently disabled the whole
+    // feature on every pick path — the #779 blocklist no-op).
+    excludedPlaylistIds: Array.isArray(show.excludedPlaylistIds) ? show.excludedPlaylistIds.filter((v: unknown) => typeof v === 'string') : [],
     // Empty string means "fall back to the station-wide default". The route
     // layer is responsible for resolving an empty/stale id against the live
     // theme registry; we just surface what the show declares.


### PR DESCRIPTION
## What

Fixes three related field reports from Discord about show music constraints not being honoured:

1. **"Excluded playlist song just played on my show"** — the playlist blocklist (#779) was a **global no-op**: `settings.resolveActiveShow()` never copied `excludedPlaylistIds` onto the resolved show object, so `resolveExcludedPlaylistIds()` always received `undefined` on every pick path (DJ agent, pool picker, auto.m3u fallback) and returned null. Broken since the feature shipped. Fixed in the resolver, pinned by the new `resolve-show.test.ts`.

2. **"Era set to 2020s with strict on, majority of tracks not from 2020s"** — the never-starve fallback in strict mode ran **per source / per tool call**: any discovery source containing zero in-filter tracks passed its *entire unfiltered result* through (`preferEra`/`preferGenre`/`preferMood` contract). The similarity tools cluster on the current track, so once one off-era track aired they returned 0 in-era matches and flooded the candidate set — "strict" was held only by prompt compliance. Now:
   - **Agent tools**: strict locks are HARD per tool (new `onlyGenre`/`inYearRange`/`onlyMood`/`onlyEnergy`), mirroring how `playlistLock` already worked. A tool with no matches returns an empty result steering the model to another tool; a fully-starved run fails into the pool fallback.
   - **Pool picker**: strict filters are additionally enforced on the FINAL merged pool, which is where never-starve now lives — a genuinely starved constraint still degrades to the full pool rather than dead air (same scoping as the existing strict-playlist block).
   - The auto.m3u fallback already hard-filtered genre/era; unchanged.

3. **"Playlist only (strict) show played 13/13 off-playlist songs"** — the enforcement code is genuinely hard on all paths, but `resolveShowPlaylistPool()` swallows every fetch failure with bare `catch {}`. A stale playlist id (playlist deleted/recreated in Navidrome) or a Navidrome error silently un-anchors the show: no lock, no `showPlaylistTracks` tool, zero log output — while the system prompt still told the agent to call the unregistered tool. Now all three pick paths log an operator-facing warning when a pinned anchor resolves to nothing, `show-playlist.ts` warns per failed fetch, and the prompt's playlist steer is gated on the pool actually resolving.

## Verification

- `npm test` — all 31 test files pass, including the new `resolve-show.test.ts` (fails without the settings fix) and extended `show-filter.test.ts` hard-filter pins.
- `npm run lint` / `tsc --noEmit` — clean.

## Notes for the reporters

- The excluded-playlist and strict-era reports are fully explained by (1) and (2).
- The 13/13 strict-playlist report is most likely (3) — worth asking Pezzles to re-select the playlists in the show editor (stale ids) and check the DJ log for the new warning after upgrading.