### PR TITLE
feat(admin): redesign show cards with host/guest faces + mode kickers

### DIFF
--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -14,7 +14,7 @@
 // cells; click a day label or hour header to fill a whole row/column. On
 // touch, a tap toggles one cell and a long-press arms drag-painting — a
 // plain swipe only scrolls (see HOLD_MS below).
-import type { ChangeEvent, RefObject, TouchEvent } from 'react';
+import type { ChangeEvent, ReactNode, RefObject, TouchEvent } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { useDynamicStyle } from '../../hooks/useDynamicStyle';
@@ -1022,6 +1022,10 @@ export default function ShowsPanel() {
       {form.shows.map((s, i) => {
         const ok = showValid(s);
         const hrs = countHours(s.id);
+        const host = personas.find(p => p.id === s.personaId) ?? null;
+        const guests = (s.guestPersonaIds || [])
+          .map(id => personas.find(p => p.id === id))
+          .filter((p): p is Persona => Boolean(p));
         return (
           <ShowDefRow
             key={s.id}
@@ -1029,12 +1033,9 @@ export default function ShowsPanel() {
             index={i}
             ok={ok}
             hrs={hrs}
-            personaLabel={
-              personaName(s.personaId)
-              + ((s.guestPersonaIds?.length ?? 0) > 0
-                ? ` · with ${s.guestPersonaIds.map(personaName).join(' & ')}`
-                : '')
-            }
+            host={host}
+            guests={guests}
+            apiBase={apiBase}
             onEdit={() => focusShow(i)}
           />
         );
@@ -1819,51 +1820,207 @@ function GridCell({
   );
 }
 
+// A persona avatar — the initials-behind-<img> pattern shared with the show
+// pickers (a broken/absent avatar falls back to readable initials). Two sizes:
+// 'lg' anchors the host; 'sm' builds the overlapping guest cluster.
+function ShowAvatar({
+  persona, apiBase, size, className,
+}: {
+  persona: Persona | null;
+  apiBase: string;
+  size: 'lg' | 'sm';
+  className?: string;
+}) {
+  const src = persona?.avatar
+    ? `${apiBase}/persona-avatar/${encodeURIComponent(persona.id)}`
+    : null;
+  const name = persona?.name?.trim();
+  return (
+    <span
+      className={cn(
+        'relative grid flex-none place-items-center overflow-hidden border border-ink bg-[var(--ink-softer)]',
+        size === 'lg' ? 'size-12' : 'size-6',
+        className,
+      )}
+    >
+      <span className={cn('font-extrabold text-muted', size === 'lg' ? 'text-[13px]' : 'text-[8px]')}>
+        {name ? abbrev(name) : '—'}
+      </span>
+      {src && (
+        <img
+          src={src}
+          alt=""
+          className="absolute inset-0 h-full w-full object-cover"
+          onError={(e) => { e.currentTarget.style.visibility = 'hidden'; }}
+        />
+      )}
+    </span>
+  );
+}
+
+// Read-only facet chip for the show card's "what it plays" row — hairline by
+// default, accent when it flags a hard lock (strict filters).
+function MetaChip({ children, accent }: { children: ReactNode; accent?: boolean }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center border px-1.5 py-[3px] text-[10px] font-semibold tracking-[0.02em]',
+        accent
+          ? 'border-[var(--accent)] text-vermilion'
+          : 'border-separator-strong text-muted',
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+// Grammatical name join: "Kai", "Kai & Rae", "Kai, Rae & Sol".
+function joinNames(names: string[]): string {
+  if (names.length <= 1) return names[0] ?? '';
+  return `${names.slice(0, -1).join(', ')} & ${names[names.length - 1]}`;
+}
+
 interface ShowDefRowProps {
   show: Show;
   index: number;
   ok: boolean;
   hrs: number;
-  personaLabel: string;
+  host: Persona | null;
+  guests: Persona[];
+  apiBase: string;
   onEdit: () => void;
 }
 
-// One show as a full-width card, matching the skills list: a colour dot + name
-// with status pills on the right, a persona/mood/topic summary on the left, and
-// an Edit action on the right (Remove lives inside the editor).
-function ShowDefRow({ show: s, index: i, ok, hrs, personaLabel, onEdit }: ShowDefRowProps) {
-  const dotRef = useRef<HTMLSpanElement>(null);
-  useDynamicStyle(dotRef, { background: SHOW_COLORS[i % SHOW_COLORS.length] ?? '#000' });
+// One show as a "broadcast slate": a colour spine keyed to the weekly grid, the
+// host — and any guest co-hosts overlapping beneath — as faces, mode kickers
+// (Programme / Banter), the weekly airtime as a metric, and a scannable row of
+// music facets over the DJ brief. The whole card is the edit target (the
+// personas "click a show to open it" pattern); Remove lives inside the editor.
+function ShowDefRow({ show: s, index: i, ok, hrs, host, guests, apiBase, onEdit }: ShowDefRowProps) {
+  const spineRef = useRef<HTMLSpanElement>(null);
+  useDynamicStyle(spineRef, { background: SHOW_COLORS[i % SHOW_COLORS.length] ?? '#000' });
+
+  const hostName = host?.name?.trim() || (s.personaId ? 'Unnamed' : '');
+  const guestNames = guests.map(g => g.name?.trim() || 'Unnamed');
+  const skillPin = s.programme && s.segmentSkill ? s.segmentSkill : '';
+
+  // "What it plays" facets — moods, genres, eras, energies as chips, plus the
+  // hard-lock / playlist / length flags. The visual counterpart to the text
+  // showFilterSummary() the strip cards still use.
+  const facets: { key: string; label: string; accent?: boolean }[] = [];
+  if (s.moods.length) s.moods.forEach(m => facets.push({ key: `mood-${m}`, label: m }));
+  else facets.push({ key: 'mood-any', label: 'any mood' });
+  s.genres.forEach(g => facets.push({ key: `genre-${g}`, label: g }));
+  s.eras.forEach((e, idx) => facets.push({ key: `era-${idx}`, label: eraLabelOf(e) }));
+  s.energies.forEach(en => facets.push({ key: `energy-${en}`, label: en }));
+  if (s.filtersStrict && hasAnyMusicFilter(s)) facets.push({ key: 'strict', label: 'strict', accent: true });
+  const nPl = s.playlistIds?.length ?? 0;
+  if (nPl) facets.push({ key: 'playlists', label: `${nPl} playlist${nPl > 1 ? 's' : ''}${s.playlistStrict ? ' · strict' : ''}` });
+  const nEx = s.excludedPlaylistIds?.length ?? 0;
+  if (nEx) facets.push({ key: 'excluded', label: `${nEx} excluded` });
+  if (s.maxTrackSeconds != null) {
+    facets.push({ key: 'length', label: s.maxTrackSeconds === 0 ? 'any length' : `≤${s.maxTrackSeconds}s` });
+  }
+
   return (
-    <Card
-      title={
-        <span className="inline-flex items-center gap-2">
-          <span ref={dotRef} className="size-2.5 flex-none rounded-full" />
-          {s.name.trim() || 'untitled'}
-        </span>
-      }
-      right={
-        <>
-          {!ok && <Pill tone="accent">incomplete</Pill>}
-          {hrs > 0 ? <Pill tone="ink">{hrs}h / week</Pill> : <Pill>unscheduled</Pill>}
-        </>
-      }
+    <article
+      role="button"
+      tabIndex={0}
+      aria-label={`Edit ${s.name.trim() || 'untitled show'}`}
+      onClick={onEdit}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onEdit(); }
+      }}
+      className={cn(
+        'group card relative cursor-pointer transition-colors hover:bg-[var(--ink-softer)]',
+        'focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--accent)]',
+      )}
     >
-      <div className="grid grid-cols-[1fr_auto] items-center gap-4">
-        <div className="min-w-0">
-          <div className="text-[12px] leading-[1.6] text-muted">
-            persona · {personaLabel} · mood · {s.moods.length ? s.moods.join(', ') : 'any'}{showFilterSummary(s)}
-          </div>
-          {s.topic.trim() && (
-            <div className="mt-1 line-clamp-2 text-[12px] leading-[1.6] text-muted italic">
-              {s.topic.trim()}
+      {/* colour spine — the same per-show colour the weekly grid paints with */}
+      <span
+        ref={spineRef}
+        aria-hidden="true"
+        className="absolute inset-y-0 left-0 w-1 transition-[width] group-hover:w-1.5"
+      />
+
+      <div className="card-body flex gap-3.5">
+        {/* faces — host, then any guest co-hosts overlapping beneath, centred */}
+        <div className="flex flex-none flex-col items-center">
+          <ShowAvatar persona={host} apiBase={apiBase} size="lg" />
+          {guests.length > 0 && (
+            <div className="mt-1 flex">
+              {guests.map((g, gi) => (
+                <ShowAvatar
+                  key={g.id}
+                  persona={g}
+                  apiBase={apiBase}
+                  size="sm"
+                  className={cn('ring-2 ring-[var(--card-bg)]', gi > 0 && '-ml-2')}
+                />
+              ))}
             </div>
           )}
         </div>
-        <div className="flex flex-col gap-2">
-          <Btn className="min-w-[92px]" onClick={onEdit}>Edit</Btn>
+
+        {/* body */}
+        <div className="grid min-w-0 flex-1 gap-2.5">
+          <div className="flex items-start gap-3">
+            {/* name + roster */}
+            <div className="min-w-0 flex-1">
+              {(s.programme || (s.banter && guests.length > 0)) && (
+                <div className="mb-1 flex flex-wrap items-center gap-1.5">
+                  {s.programme && (
+                    <Pill tone="solid" dot>
+                      Programme{skillPin ? ` · ${skillPin}` : ''}
+                    </Pill>
+                  )}
+                  {s.banter && guests.length > 0 && <Pill>Banter</Pill>}
+                </div>
+              )}
+              <div className="truncate text-[17px] font-extrabold tracking-[-0.01em] text-ink">
+                {s.name.trim() || 'untitled'}
+              </div>
+              <div className="mt-0.5 truncate text-[12px] text-muted">
+                {host
+                  ? <>host · <span className="font-semibold text-ink">{hostName}</span></>
+                  : <span className="text-[var(--danger)]">no persona set</span>}
+                {guests.length > 0 && <> · with {joinNames(guestNames)}</>}
+              </div>
+            </div>
+
+            {/* right rail — status, weekly airtime, edit affordance */}
+            <div className="flex flex-none flex-col items-end gap-1.5 text-right">
+              {!ok && <Pill tone="accent">incomplete</Pill>}
+              {hrs > 0 ? (
+                <div className="leading-none">
+                  <span className="mono-num text-[20px] font-extrabold text-ink">{hrs}</span>
+                  <span className="caption ml-1">h / wk</span>
+                </div>
+              ) : (
+                <span className="caption">unscheduled</span>
+              )}
+              <span className="inline-flex items-center gap-1 text-[10px] font-bold tracking-[0.16em] text-muted uppercase transition-colors group-hover:text-vermilion">
+                Edit <span aria-hidden="true">→</span>
+              </span>
+            </div>
+          </div>
+
+          {/* facets — what this show plays */}
+          <div className="flex flex-wrap gap-1">
+            {facets.map(f => (
+              <MetaChip key={f.key} accent={f.accent}>{f.label}</MetaChip>
+            ))}
+          </div>
+
+          {/* brief */}
+          {s.topic.trim() && (
+            <p className="line-clamp-2 text-[12px] leading-[1.55] text-muted italic">
+              {s.topic.trim()}
+            </p>
+          )}
         </div>
       </div>
-    </Card>
+    </article>
   );
 }


### PR DESCRIPTION
## What

Reworks each show item on **/admin/shows** from a plain colour-dot + grey summary line into a **"broadcast slate"** card.

### Added
- **Host face** (avatar) with any **guest co-hosts overlapping beneath**, reusing the initials-behind-`<img>` pattern from the show pickers (broken/absent avatar → readable initials).
- **Colour spine** down the left edge, keyed to the same per-show palette the weekly grid paints with (replaces the tiny dot); widens slightly on hover.
- **Programme / Banter kickers** as pills — these were completely invisible in the list before. Programme surfaces its pinned feature skill when set (`Programme · news`).
- **Music facets** (mood, genre, era, energy, strict, playlists, length) as a scannable chip row instead of one cramped muted line.

### Changed
- Weekly airtime is now a bold `mono-num` metric; incomplete / unscheduled status kept.
- The **whole card is the edit target** (keyboard-accessible `role="button"` + Enter/Space), matching the personas "click a show to open it" pattern. The standalone Edit button becomes a hover affordance.

### Scope
- Single presentational component (`ShowDefRow` + small local `ShowAvatar` / `MetaChip` helpers) in `web/components/admin/ShowsPanel.tsx`. No data-model, API, or controller changes.

## Verification
- `web` ESLint passes; `ShowsPanel.tsx` type-checks clean. (Pre-existing `tsc` errors elsewhere are missing-dep noise from an un-installed `ai-elements` set in this checkout, unrelated to this change.)
- Visual states covered: programme + guests + banter, solo, initials-fallback duo, 3-guest cluster with wrapping chips, incomplete/unscheduled — in light + dark.