### PR TITLE
feat(admin): slate cards for /admin/skills and /admin/personas

### DIFF
--- a/docs/superpowers/specs/2026-07-13-admin-skills-personas-slate-cards-design.md
+++ b/docs/superpowers/specs/2026-07-13-admin-skills-personas-slate-cards-design.md
@@ -1,0 +1,219 @@
+# Slate cards for /admin/skills and /admin/personas
+
+**Date:** 2026-07-13
+**Status:** approved (pending spec review)
+**Scope:** `web/components/admin/SkillsPanel.tsx`, `web/components/admin/personas/PersonaRoster.tsx`, plus a small shared-chip extraction into `web/components/admin/ui.tsx`.
+
+## Why
+
+PR #1025 (`feat(admin): redesign show cards`) promoted each show on `/admin/shows`
+from a plain `Card` (colour dot + grey summary line + right-rail Edit button)
+into a "broadcast slate": a full-card click target with a left colour spine, a
+prominent face, mode kickers, a bold name, a right-rail metric + "Edit →"
+affordance, a scannable facet-chip row, and an italic brief.
+
+Skills and personas were the *template* shows were built from — their own source
+comments still say so:
+
+- `SkillsPanel.tsx` show rows were described as "matching the skills list".
+- `PersonaRoster.tsx`: "a list of cards … matching the skills list: avatar +
+  tagline + meta pills on the left, status pills + Edit on the right."
+
+So the two panels are now the last holdouts of the pre-#1025 pattern. This spec
+ports the slate treatment to both, keeping each panel's own semantics.
+
+## The slate anatomy (from #1025)
+
+The reusable shape, as `ShowDefRow` implements it:
+
+1. `<article role="button" tabIndex={0}>` — the whole card is the edit target,
+   keyboard-accessible (`Enter`/`Space`), `focus-visible` ring, `aria-label`,
+   `hover:bg-[var(--ink-softer)]`.
+2. A left **colour spine** — `absolute inset-y-0 left-0 w-1`, widening to
+   `w-1.5` on `group-hover`.
+3. A **face** column (`size-12`, initials-behind-`<img>` fallback).
+4. **Kicker pills** above the name (mode/identity flags).
+5. A bold **name** (`text-[17px] font-extrabold`).
+6. A **right rail**: status pill(s), a `mono-num` **metric**, and an
+   uppercase "Edit →" affordance that turns vermilion on hover.
+7. A **facet-chip row** (`MetaChip`) — the read-only "what this is" summary.
+8. An italic **brief** (`line-clamp-2 text-muted italic`).
+
+## Shared extraction: `MetaChip` → `ui.tsx`
+
+`MetaChip` is currently a file-local helper in `ShowsPanel.tsx`:
+
+```tsx
+// hairline by default; accent when it flags a hard lock
+function MetaChip({ children, accent }: { children: ReactNode; accent?: boolean }) { … }
+```
+
+All three panels will use it, so move it to `web/components/admin/ui.tsx` and
+export it. Update `ShowsPanel.tsx` to import it instead of declaring it locally
+(behaviour unchanged — same markup). This is the only cross-file refactor; it is
+in service of the current goal (one chip across all three slates), not
+speculative.
+
+Everything else stays panel-local:
+- Personas keep `initialsFor` (`personas/helpers.ts`) for the avatar.
+- Skills get a small **kind → icon** map, local to `SkillsPanel.tsx`.
+- The spine needs **no** `useDynamicStyle` here — unlike shows' arbitrary
+  `SHOW_COLORS` hexes, both spines key off theme CSS vars, so they are plain
+  conditional Tailwind `bg-` classes.
+
+## Decision 1 — spine keys to status (both panels)
+
+Shows key the spine to a per-show palette (`SHOW_COLORS`) that is *also* painted
+in the weekly grid, so the colour is a shared identity. Personas and skills have
+no such palette, so a hashed hue would be decorative-only. Instead the spine
+encodes **status**, so the colour means something at a glance:
+
+**Personas** (priority order):
+
+| condition            | spine                             |
+| -------------------- | --------------------------------- |
+| on air               | `bg-[var(--accent)]` (vermilion)  |
+| default (not on air) | `bg-ink`                          |
+| incomplete           | `bg-[var(--danger)]`              |
+| otherwise            | `bg-separator-strong` (hairline)  |
+
+`on air` and `default` are mutually exclusive with the current pill logic
+(`isOnAir` / `isDefault && !isOnAir`). `incomplete` (`!personaValid(p)`) takes
+precedence over the plain hairline but ranks below on-air/default (an on-air
+persona that's technically incomplete still reads as "on air").
+
+**Skills:**
+
+| condition | spine                            |
+| --------- | -------------------------------- |
+| enabled   | `bg-[var(--accent)]`             |
+| disabled  | `bg-separator-strong` (hairline) |
+
+## Decision 2 — skill cards: whole card opens the editor
+
+Skills carry inline controls shows don't: the enable **Toggle** and the **Run
+now** seg-pad. Per the approved decision, the whole card still opens the edit
+sheet (`setModal({ mode: 'edit', skill: s })`), matching shows, and the inline
+controls `e.stopPropagation()` in their handlers so they act in place without
+also opening the editor.
+
+Accepted trade-off: `<article role="button">` will contain `<button>` (Toggle,
+Run now) and an `<a>` (the API-key link inside `SkillDescription`). This is
+nested interactive content. Mitigations:
+- Every inner control calls `e.stopPropagation()` in its `onClick` (the key link
+  too), so a mouse click on a control never also opens the editor.
+- The card's `onKeyDown` guards with `if (e.target !== e.currentTarget) return;`
+  before handling `Enter`/`Space`. Without this, a keydown on the focused Toggle
+  or Run now button would *bubble* to the article and open the editor on top of
+  the control's own action. The guard makes the card respond to the keyboard only
+  when the card itself is focused; the inner controls remain independent focus
+  stops with their own `aria-label` / accessible text.
+
+## Skills card layout
+
+Follows the approved preview exactly:
+
+```
+┌─▌────────────────────────────────────────┐   spine: enabled=accent, else hairline
+│▌ [kind]  Weather  ‹custom?›     [⏻ Toggle]│   header: icon+name+custom pill | toggle + state
+│▌                                enabled    │
+│▌ ‹needs-key alert, only when ready===false›│
+│▌ Reads the local forecast before a track…  │   brief: SkillDescription, line-clamp-2, italic
+│▌ 30 min cooldown · All DJs · #ambient       │   facet chips: cooldown, assignment, #tags, pinned
+│▌ [ Run now ]                       Edit →   │   actions: seg-pad (stopProp) | Edit affordance
+└────────────────────────────────────────────┘
+```
+
+Field mapping:
+
+- **Face** — a `size-12` square tile (border + `bg-[var(--ink-softer)]`) holding
+  a lucide icon from a local `KIND_ICONS` map; icon colour is `text-ink` when
+  enabled, `text-muted` when disabled. Map:
+  - `weather` → `CloudSun`, `news` → `Newspaper`, `traffic` → `TrafficCone`,
+    `curiosity` → `Lightbulb`, `album-anniversary` → `Cake`,
+    `library-deep-cut` → `Disc3`, `web-search` → `Globe`.
+  - fallback (custom or any unknown kind) → `Sparkles`. The map only needs the
+    seven built-ins; anything else — including all custom skills — falls back, so
+    it is not a maintenance trap.
+- **Kicker / name** — bold name (`s.label || s.name`); a small `custom` pill sits
+  beside it when `s.custom`.
+- **Right rail** — the `Toggle` (top, `stopPropagation`), a compact
+  `enabled`/`disabled` caption beneath it, and the "Edit →" affordance.
+- **needs-key alert** — the existing `V3Alert` (with its "Get a key here" link)
+  stays, rendered between header and brief, only when `s.ready === false`. The
+  redundant standalone state pill is dropped (spine + toggle + caption already
+  carry enabled/disabled).
+- **Brief** — `SkillDescription` (keeps the inline API-key link), styled as the
+  muted italic brief, `line-clamp-2`. The key `<a>` gets `stopPropagation`.
+- **Facet chips** (`MetaChip`) — cooldown (`cooldownLabel`), the assignment label
+  (`All DJs` / `N of M DJs`, hidden when no roster), the `pinned feature` chip
+  (accent, when filtered by a show whose `segmentSkill === s.name`), and `#tag`
+  chips. Same data the old meta pills showed, restyled.
+- **Actions** — the existing `Run now` seg-pad (`seg-pad seg-pad--slim`,
+  `stopPropagation`) bottom-left; "Edit →" affordance bottom-right (redundant
+  with whole-card click, but a clear signpost, matching shows).
+
+The list-level plumbing (`visible.map`, filters, sort, community modal, edit
+modal, hero, organise bar) is untouched — only the per-row markup changes.
+
+## Personas card layout
+
+```
+┌─▌──────────────────────────────────────────┐   spine: on-air=accent / default=ink /
+│▌ [avatar] ‹on air›                           │           incomplete=danger / else hairline
+│▌          Kai Mercer          ‹incomplete›   │   kicker: on air / default | right: status
+│▌                                    7        │   metric: skills count (mono-num)
+│▌                                 skills      │
+│▌                                  Edit →     │
+│▌ moderate · long · kokoro · ember-voice      │   facet chips: freq, scriptLength, engine, voice
+│▌ Late-night warmth for the small hours.       │   brief: tagline, italic, line-clamp-2
+└──────────────────────────────────────────────┘
+```
+
+Field mapping:
+
+- **Face** — the existing initials-behind-`<img>` avatar, bumped `size-11` →
+  `size-12` to match the show/skill face. `?v=${avatarTick}` cache-bust kept.
+- **Kicker** — `on air` (accent, `dot`) or `default` (plain), above the name.
+  These move out of the old right-rail `right={…}` slot into the kicker row,
+  mirroring shows' Programme/Banter placement.
+- **Name** — bold `text-[17px]`.
+- **Right rail** — `incomplete` pill (danger border) when `!personaValid(p)`; a
+  `mono-num` **metric** of the skill count (`{n}` big + `skills` caption — `all`
+  when `p.skills === null`, if that sentinel reaches this list); the "Edit →"
+  affordance.
+- **Facet chips** (`MetaChip`) — `frequency`, `scriptLength` (when not
+  `concise`), `tts.engine`, and `tts.voice` (when engine ≠ `piper` and a voice is
+  set). Same fields as the old meta pills.
+- **Brief** — `tagline` (or "no tagline"), italic, `line-clamp-2`.
+
+The whole card opens the editor via the existing `onSelect(i)`; the explicit
+`Edit` button is removed. `PersonaRoster`'s props and the parent `PersonasPanel`
+are otherwise unchanged.
+
+## Non-goals
+
+- No changes to controller routes, data shapes, or `/settings`.
+- No change to the community modals, the skill edit sheet, the persona editor,
+  filters/sort, or the heroes.
+- No new colour palette; no `useDynamicStyle` in these two panels.
+- Shows (`ShowsPanel.tsx`) change only by importing the extracted `MetaChip`.
+
+## Testing / verification
+
+No unit-test runner for `web/`. Verification is:
+
+1. `npm run lint` in `web/` (`eslint . && tsc --noEmit`) — the merge gate.
+2. Visual check of `/admin/skills` and `/admin/personas` against `/admin/shows`
+   in the running dev stack (or via the `verify` skill's isolated controller +
+   Playwright), confirming: spine colours track status; whole-card click opens
+   the right editor; Toggle and Run now still act without opening the editor; the
+   API-key link still navigates; facet chips render; layout holds at narrow
+   widths.
+
+## Files touched
+
+- `web/components/admin/ui.tsx` — export `MetaChip` (moved in).
+- `web/components/admin/ShowsPanel.tsx` — drop local `MetaChip`, import it.
+- `web/components/admin/SkillsPanel.tsx` — slate row + `KIND_ICONS` map.
+- `web/components/admin/personas/PersonaRoster.tsx` — slate row.

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -14,7 +14,7 @@
 // cells; click a day label or hour header to fill a whole row/column. On
 // touch, a tap toggles one cell and a long-press arms drag-painting — a
 // plain swipe only scrolls (see HOLD_MS below).
-import type { ChangeEvent, ReactNode, RefObject, TouchEvent } from 'react';
+import type { ChangeEvent, RefObject, TouchEvent } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Users, Share2 } from 'lucide-react';
 import { useAdminAuth } from '../../lib/adminAuth';
@@ -29,7 +29,7 @@ import { Field } from '../ui/field';
 import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup,
 } from '../ui/select';
-import { Card, Btn, Pill, Eyebrow, Metric, Toggle } from './ui';
+import { Card, Btn, Pill, Eyebrow, Metric, MetaChip, Toggle } from './ui';
 import { V3AlertDialog } from '../ui/alert-dialog';
 import { EditorDialog } from '../ui/editor-dialog';
 import { Modal } from '../ui/modal';
@@ -2096,23 +2096,6 @@ function ShowAvatar({
           onError={(e) => { e.currentTarget.style.visibility = 'hidden'; }}
         />
       )}
-    </span>
-  );
-}
-
-// Read-only facet chip for the show card's "what it plays" row — hairline by
-// default, accent when it flags a hard lock (strict filters).
-function MetaChip({ children, accent }: { children: ReactNode; accent?: boolean }) {
-  return (
-    <span
-      className={cn(
-        'inline-flex items-center border px-1.5 py-[3px] text-[10px] font-semibold tracking-[0.02em]',
-        accent
-          ? 'border-[var(--accent)] text-vermilion'
-          : 'border-separator-strong text-muted',
-      )}
-    >
-      {children}
     </span>
   );
 }

--- a/web/components/admin/SkillsPanel.tsx
+++ b/web/components/admin/SkillsPanel.tsx
@@ -16,8 +16,12 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from '../../lib/cn';
 import { notify, errorMessage } from '../../lib/notify';
 import { useAdminAuth } from '../../lib/adminAuth';
-import { RefreshCw, Plus, Users, Upload, Search, X } from 'lucide-react';
-import { Card, Btn, Pill, Eyebrow, Toggle } from './ui';
+import {
+  RefreshCw, Plus, Users, Upload, Search, X,
+  CloudSun, Newspaper, TrafficCone, Lightbulb, Cake, Disc3, Globe, Sparkles,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { Card, Btn, Pill, Eyebrow, MetaChip, Toggle } from './ui';
 import { V3Alert } from '../ui/alert';
 import { Modal } from '../ui/modal';
 import { Input } from '../ui/input';
@@ -103,6 +107,19 @@ function cooldownLabel(ms?: number): string {
   const h = Math.round(min / 6) / 10;
   return `${h} h cooldown`;
 }
+
+// A glyph for each of the seven built-in segment kinds — fills the slate card's
+// "face" slot where personas/shows have an avatar. Custom skills (and any
+// unmapped kind) fall back to Sparkles, so this is not a maintenance trap.
+const KIND_ICONS: Record<string, LucideIcon> = {
+  weather: CloudSun,
+  news: Newspaper,
+  traffic: TrafficCone,
+  curiosity: Lightbulb,
+  'album-anniversary': Cake,
+  'library-deep-cut': Disc3,
+  'web-search': Globe,
+};
 
 interface SkillDescriptionProps {
   text?: string;
@@ -562,81 +579,133 @@ export default function SkillsPanel() {
           </div>
         </Card>
       )}
-      {visible.map(s => (
-        <Card
-          key={s.name}
-          title={s.label || s.name}
-          right={
-            <>
-              {s.custom && <Pill>custom</Pill>}
-              <Pill tone={s.enabled ? 'accent' : 'default'} dot={s.enabled}>
-                {s.enabled ? 'enabled' : 'disabled'}
-              </Pill>
-              <Toggle
-                on={s.enabled}
-                disabled={busy === s.name}
-                onClick={() => toggle(s.name, !s.enabled)}
-              />
-            </>
-          }
-        >
-          {s.ready === false && (
-            <div className="mb-3">
-              <V3Alert tone="error" title="API key not set">
-                This skill needs the <code>{s.requiresKey || 'required API key'}</code> environment
-                variable set in <code>.env</code>. Until then it stays inert and never
-                fires autonomously, even when enabled.
-                {s.keyUrl && (
-                  <>
-                    {' '}
-                    <a
-                      href={s.keyUrl}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="font-bold text-vermilion underline decoration-[1.5px] underline-offset-2"
-                    >
-                      Get a key here
-                    </a>.
-                  </>
+      {visible.map(s => {
+        const Icon = KIND_ICONS[s.kind || s.name] ?? Sparkles;
+        // Spine keyed to enabled state — the same signal the toggle carries.
+        const spine = s.enabled ? 'bg-[var(--accent)]' : 'bg-separator-strong';
+        const assign = assignmentLabel(s);
+        const pinned = who.startsWith('s:')
+          && shows.find(x => x.id === who.slice(2))?.segmentSkill === s.name;
+        return (
+          // The whole card opens the edit sheet; the Toggle, Run now, and the
+          // API-key link stopPropagation so they act in place. The onKeyDown
+          // guard (target === currentTarget) keeps a keyboard press on those
+          // inner controls from bubbling up and also opening the editor.
+          <article
+            key={s.name}
+            role="button"
+            tabIndex={0}
+            aria-label={`Edit ${s.label || s.name}`}
+            onClick={() => setModal({ mode: 'edit', skill: s })}
+            onKeyDown={(e) => {
+              if (e.target !== e.currentTarget) return;
+              if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setModal({ mode: 'edit', skill: s }); }
+            }}
+            className={cn(
+              'group card relative cursor-pointer transition-colors hover:bg-[var(--ink-softer)]',
+              'focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--accent)]',
+            )}
+          >
+            {/* enabled/disabled spine */}
+            <span
+              aria-hidden="true"
+              className={cn('absolute inset-y-0 left-0 w-1 transition-[width] group-hover:w-1.5', spine)}
+            />
+
+            <div className="card-body flex gap-3.5">
+              {/* kind glyph — the face slot */}
+              <span
+                className={cn(
+                  'grid size-12 flex-none place-items-center border border-ink bg-[var(--ink-softer)]',
+                  s.enabled ? 'text-ink' : 'text-muted',
                 )}
-              </V3Alert>
-            </div>
-          )}
-          <div className="grid grid-cols-[1fr_auto] items-center gap-4">
-            <div>
-              <div className="line-clamp-2 text-[12px] leading-[1.6] text-muted">
-                <SkillDescription text={s.description} keyUrl={s.keyUrl} />
-              </div>
-              <div className="mt-2 flex flex-wrap gap-2">
-                <Pill className="text-[8px]">{cooldownLabel(s.cooldownMs)}</Pill>
-                {assignmentLabel(s) && <Pill className="text-[8px]">{assignmentLabel(s)}</Pill>}
-                {who.startsWith('s:') && shows.find(x => x.id === who.slice(2))?.segmentSkill === s.name && (
-                  <Pill tone="accent" className="text-[8px]">pinned feature</Pill>
-                )}
-                {(s.tags || []).map(t => (
-                  <Pill key={t} className="text-[8px]">#{t}</Pill>
-                ))}
-              </div>
-            </div>
-            <div className="flex flex-col gap-2">
-              {/* Same cart-pad language as the dash DJ segment pads, slimmed
-                  to one line — LED arms on hover, blinks while running. */}
-              <button
-                type="button"
-                onClick={() => runNow(s.name)}
-                disabled={busy === s.name}
-                className={cn('seg-pad seg-pad--slim', busy === s.name && 'is-firing')}
               >
-                <span className="seg-led" aria-hidden />
-                <span className="seg-label">{busy === s.name ? 'Working…' : 'Run now'}</span>
-              </button>
-              {/* Edit opens the segment-sheet modal for both built-in and custom
-                  skills; Run now / Delete live inside the sheet. */}
-              <Btn onClick={() => setModal({ mode: 'edit', skill: s })}>Edit</Btn>
+                <Icon size={20} strokeWidth={1.75} aria-hidden />
+              </span>
+
+              {/* body */}
+              <div className="grid min-w-0 flex-1 gap-2.5">
+                <div className="flex items-start gap-3">
+                  {/* name + custom flag */}
+                  <div className="flex min-w-0 flex-1 items-center gap-2">
+                    <span className="truncate text-[17px] font-extrabold tracking-[-0.01em] text-ink">
+                      {s.label || s.name}
+                    </span>
+                    {s.custom && <Pill className="text-[8px]">custom</Pill>}
+                  </div>
+
+                  {/* right rail — the toggle + its state */}
+                  <div className="flex flex-none flex-col items-end gap-1 text-right">
+                    <span onClick={e => e.stopPropagation()}>
+                      <Toggle
+                        on={s.enabled}
+                        disabled={busy === s.name}
+                        onClick={() => toggle(s.name, !s.enabled)}
+                      />
+                    </span>
+                    <span className="caption">{s.enabled ? 'enabled' : 'disabled'}</span>
+                  </div>
+                </div>
+
+                {s.ready === false && (
+                  <V3Alert tone="error" title="API key not set">
+                    This skill needs the <code>{s.requiresKey || 'required API key'}</code> environment
+                    variable set in <code>.env</code>. Until then it stays inert and never
+                    fires autonomously, even when enabled.
+                    {s.keyUrl && (
+                      <>
+                        {' '}
+                        <a
+                          href={s.keyUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          onClick={e => e.stopPropagation()}
+                          className="font-bold text-vermilion underline decoration-[1.5px] underline-offset-2"
+                        >
+                          Get a key here
+                        </a>.
+                      </>
+                    )}
+                  </V3Alert>
+                )}
+
+                {/* brief */}
+                <p className="line-clamp-2 text-[12px] leading-[1.55] text-muted italic">
+                  <SkillDescription text={s.description} keyUrl={s.keyUrl} />
+                </p>
+
+                {/* facets — cadence, reach, tags */}
+                <div className="flex flex-wrap gap-1">
+                  <MetaChip>{cooldownLabel(s.cooldownMs)}</MetaChip>
+                  {assign && <MetaChip>{assign}</MetaChip>}
+                  {pinned && <MetaChip accent>pinned feature</MetaChip>}
+                  {(s.tags || []).map(t => (
+                    <MetaChip key={t}>#{t}</MetaChip>
+                  ))}
+                </div>
+
+                {/* actions — Run now on the left, Edit affordance on the right.
+                    Same cart-pad language as the dash DJ segment pads, slimmed
+                    to one line — LED arms on hover, blinks while running. */}
+                <div className="flex items-center justify-between gap-3">
+                  <button
+                    type="button"
+                    onClick={(e) => { e.stopPropagation(); runNow(s.name); }}
+                    disabled={busy === s.name}
+                    className={cn('seg-pad seg-pad--slim', busy === s.name && 'is-firing')}
+                  >
+                    <span className="seg-led" aria-hidden />
+                    <span className="seg-label">{busy === s.name ? 'Working…' : 'Run now'}</span>
+                  </button>
+                  <span className="inline-flex items-center gap-1 text-[10px] font-bold tracking-[0.16em] text-muted uppercase transition-colors group-hover:text-vermilion">
+                    Edit <span aria-hidden="true">→</span>
+                  </span>
+                </div>
+              </div>
             </div>
-          </div>
-        </Card>
-      ))}
+          </article>
+        );
+      })}
 
       {/* ── COMMUNITY CATALOG MODAL ──────────────────────────────────────── */}
       <Modal

--- a/web/components/admin/personas/PersonaRoster.tsx
+++ b/web/components/admin/personas/PersonaRoster.tsx
@@ -1,13 +1,16 @@
 'use client';
-// Persona roster — a list of cards (one per persona), matching the skills list:
-// avatar + tagline + meta pills on the left, status pills + Edit on the right.
-// Click Edit to open the full-screen editor; adding lives in the hero's
-// "+ Add persona" button.
+// Persona roster — a list of "broadcast slate" cards (one per persona), matching
+// the show cards on /admin/shows: an avatar, a status-keyed colour spine, mode
+// kickers (on air / default), a bold name, the skill count as a metric, a
+// scannable facet-chip row, and the tagline as a brief. The whole card is the
+// edit target (the "click a persona to open it" pattern); adding lives in the
+// hero's "+ Add persona" button.
 import { Users } from 'lucide-react';
 import type { Persona } from './types';
 import { API_BASE, PERSONA_MAX } from './constants';
 import { initialsFor, personaValid } from './helpers';
-import { Card, Btn, Pill } from '../ui';
+import { cn } from '../../../lib/cn';
+import { Btn, Pill, MetaChip } from '../ui';
 
 interface PersonaRosterProps {
   personas: Persona[];
@@ -58,57 +61,100 @@ export function PersonaRoster({
         const src = p.avatar
           ? `${API_BASE}/persona-avatar/${encodeURIComponent(p.id)}?v=${avatarTick}`
           : null;
+        const nSkills = p.skills.length;
+        // Spine keyed to status — on air wins, then default, then incomplete,
+        // then a plain hairline. The colour means something at a glance.
+        const spine = isOnAir
+          ? 'bg-[var(--accent)]'
+          : isDefault
+            ? 'bg-ink'
+            : !valid
+              ? 'bg-[var(--danger)]'
+              : 'bg-separator-strong';
         return (
-          <Card
+          <article
             key={p.id}
-            title={p.name.trim() || `Persona ${i + 1}`}
-            right={
-              <>
-                {isOnAir && <Pill tone="accent" dot>on air</Pill>}
-                {isDefault && !isOnAir && <Pill>default</Pill>}
-                {!valid && (
-                  <Pill className="border-[var(--danger)] text-[var(--danger)]">incomplete</Pill>
-                )}
-              </>
-            }
+            role="button"
+            tabIndex={0}
+            aria-label={`Edit ${p.name.trim() || `Persona ${i + 1}`}`}
+            onClick={() => onSelect(i)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(i); }
+            }}
+            className={cn(
+              'group card relative cursor-pointer transition-colors hover:bg-[var(--ink-softer)]',
+              'focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--accent)]',
+            )}
           >
-            <div className="grid grid-cols-[1fr_auto] items-center gap-4">
-              <div className="flex min-w-0 items-start gap-3">
-                {/* Initials sit behind the image so a missing / broken avatar
-                    still shows a readable placeholder. */}
-                <span className="relative grid size-11 flex-none place-items-center overflow-hidden border border-ink bg-[var(--ink-softer)]">
-                  <span className="text-[13px] font-extrabold text-muted">{initialsFor(p.name)}</span>
-                  {src && (
-                    <img
-                      src={src}
-                      alt=""
-                      className="absolute inset-0 h-full w-full object-cover"
-                      onError={e => { e.currentTarget.style.visibility = 'hidden'; }}
-                    />
-                  )}
-                </span>
-                <div className="min-w-0">
-                  <div className="text-[12px] leading-[1.6] text-muted">
-                    {p.tagline.trim() || 'no tagline'}
-                  </div>
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    <Pill className="text-[8px]">{p.frequency}</Pill>
-                    {p.scriptLength !== 'concise' && <Pill className="text-[8px]">{p.scriptLength}</Pill>}
-                    <Pill className="text-[8px]">{p.tts.engine}</Pill>
-                    {p.tts.engine !== 'piper' && p.tts.voice.trim() && (
-                      <Pill className="max-w-[120px] truncate text-[8px]">{p.tts.voice.trim()}</Pill>
+            {/* status spine */}
+            <span
+              aria-hidden="true"
+              className={cn('absolute inset-y-0 left-0 w-1 transition-[width] group-hover:w-1.5', spine)}
+            />
+
+            <div className="card-body flex gap-3.5">
+              {/* avatar — initials sit behind the image so a missing / broken
+                  avatar still shows a readable placeholder */}
+              <span className="relative grid size-12 flex-none place-items-center overflow-hidden border border-ink bg-[var(--ink-softer)]">
+                <span className="text-[13px] font-extrabold text-muted">{initialsFor(p.name)}</span>
+                {src && (
+                  <img
+                    src={src}
+                    alt=""
+                    className="absolute inset-0 h-full w-full object-cover"
+                    onError={e => { e.currentTarget.style.visibility = 'hidden'; }}
+                  />
+                )}
+              </span>
+
+              {/* body */}
+              <div className="grid min-w-0 flex-1 gap-2.5">
+                <div className="flex items-start gap-3">
+                  {/* kicker + name */}
+                  <div className="min-w-0 flex-1">
+                    {(isOnAir || isDefault) && (
+                      <div className="mb-1 flex flex-wrap items-center gap-1.5">
+                        {isOnAir && <Pill tone="accent" dot>on air</Pill>}
+                        {isDefault && !isOnAir && <Pill>default</Pill>}
+                      </div>
                     )}
-                    <Pill className="text-[8px]">
-                      {p.skills.length} skill{p.skills.length === 1 ? '' : 's'}
-                    </Pill>
+                    <div className="truncate text-[17px] font-extrabold tracking-[-0.01em] text-ink">
+                      {p.name.trim() || `Persona ${i + 1}`}
+                    </div>
+                  </div>
+
+                  {/* right rail — status, skill count, edit affordance */}
+                  <div className="flex flex-none flex-col items-end gap-1.5 text-right">
+                    {!valid && (
+                      <Pill className="border-[var(--danger)] text-[var(--danger)]">incomplete</Pill>
+                    )}
+                    <div className="leading-none">
+                      <span className="mono-num text-[20px] font-extrabold text-ink">{nSkills}</span>
+                      <span className="caption ml-1">skill{nSkills === 1 ? '' : 's'}</span>
+                    </div>
+                    <span className="inline-flex items-center gap-1 text-[10px] font-bold tracking-[0.16em] text-muted uppercase transition-colors group-hover:text-vermilion">
+                      Edit <span aria-hidden="true">→</span>
+                    </span>
                   </div>
                 </div>
-              </div>
-              <div className="flex flex-col gap-2">
-                <Btn className="min-w-[92px]" onClick={() => onSelect(i)}>Edit</Btn>
+
+                {/* facets — how this persona sounds */}
+                <div className="flex flex-wrap gap-1">
+                  <MetaChip>{p.frequency}</MetaChip>
+                  {p.scriptLength !== 'concise' && <MetaChip>{p.scriptLength}</MetaChip>}
+                  <MetaChip>{p.tts.engine}</MetaChip>
+                  {p.tts.engine !== 'piper' && p.tts.voice.trim() && (
+                    <MetaChip className="max-w-[140px] truncate">{p.tts.voice.trim()}</MetaChip>
+                  )}
+                </div>
+
+                {/* brief */}
+                <p className="line-clamp-2 text-[12px] leading-[1.55] text-muted italic">
+                  {p.tagline.trim() || 'no tagline'}
+                </p>
               </div>
             </div>
-          </Card>
+          </article>
         );
       })}
     </section>

--- a/web/components/admin/ui.tsx
+++ b/web/components/admin/ui.tsx
@@ -82,6 +82,32 @@ export function Pill({ children, tone, dot, className, onClick, title }: PillPro
   );
 }
 
+export interface MetaChipProps {
+  children?: ReactNode;
+  accent?: boolean;
+  className?: string;
+}
+
+/* Read-only facet chip for the "broadcast slate" cards (shows / skills /
+   personas) — a hairline "what this is" tag, smaller and quieter than a Pill.
+   `accent` flags a hard lock (strict filters, pinned feature). `className`
+   lets a caller cap/truncate a long value (e.g. a cloned-voice filename). */
+export function MetaChip({ children, accent, className }: MetaChipProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center border px-1.5 py-[3px] text-[10px] font-semibold tracking-[0.02em]',
+        accent
+          ? 'border-[var(--accent)] text-vermilion'
+          : 'border-separator-strong text-muted',
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
 /* Legacy `tone` → shadcn Button `variant`. `danger` maps to `destructive`. */
 type BtnTone = 'solid' | 'accent' | 'danger';
 


### PR DESCRIPTION
## What

Ports the #1025 "broadcast slate" show-card redesign to `/admin/skills` and `/admin/personas` — the two panels the show cards were originally modelled on. Both still used the pre-#1025 `Card` + colour-dot + right-rail-Edit pattern (their own source comments admit as much), so they were the last holdouts.

## Changes

- **Shared chip** — `MetaChip` moves out of `ShowsPanel.tsx` into `ui.tsx` so all three slates use one read-only facet chip. Gains an optional `className` (to truncate a long cloned-voice filename). `ShowsPanel` now imports it; markup unchanged.
- **Personas** (`PersonaRoster.tsx`) — the whole card opens the editor (drops the explicit Edit button). Left spine keyed to **status**: on air = accent, default = ink, incomplete = danger, else hairline. `size-12` avatar, `on air`/`default` kicker, bold name, **skill-count metric**, facet chips (frequency, script length, engine, voice), tagline as the italic brief.
- **Skills** (`SkillsPanel.tsx`) — the whole card opens the edit sheet; the **Toggle**, **Run now** seg-pad, and the API-key link `stopPropagation` so they act in place, and the card's `onKeyDown` guards on `target === currentTarget` so a keyboard press on those controls doesn't also open the editor. Spine keyed to enabled/disabled. A **kind-glyph tile** fills the face slot (7 built-ins → lucide icons; custom/unknown → `Sparkles`). Facet chips: cooldown, DJ assignment, pinned-feature, `#tags`. Run now + `Edit →` in the actions row.

No controller, route, data-shape, filter, sort, modal, or hero changes.

## Verification

- `web` `npm run lint` — my four files are **type-clean** and eslint passes. (The worktree shares main's `node_modules`, which is currently missing some third-party packages — `ai`, `shiki`, `@radix-ui/*` — so `tsc` reports pre-existing errors in unrelated `ai-elements/*` and `ui/*` files; none in the files this PR touches. CI does a full install and won't hit these.)
- **Live visual pass still pending** — recommend eyeballing `/admin/skills` and `/admin/personas` against `/admin/shows` before merge (spine colours track status; whole-card click opens the right editor; Toggle / Run now still act without opening it; the API-key link still navigates).

## Spec

`docs/superpowers/specs/2026-07-13-admin-skills-personas-slate-cards-design.md`