### PR TITLE
fix(caddy): route /stream.flac, /stream.aac, /listen.* in the AIO edge

### DIFF
--- a/docker/aio/Caddyfile
+++ b/docker/aio/Caddyfile
@@ -12,9 +12,12 @@
 }
 
 :80 {
-	# /stream.mp3 + /stream.opus — Icecast (served by liquidsoap → icecast on
-	# 7702). flush_interval -1 keeps the never-ending audio body live.
-	@streams path /stream.mp3 /stream.opus
+	# /stream.mp3 + /stream.opus + /stream.flac + /stream.aac — Icecast (served by
+	# liquidsoap → icecast on 7702). Opus/FLAC/AAC are opt-in and off by default,
+	# but they must still be listed here or they fall through to the Next.js
+	# catch-all below and 404. flush_interval -1 keeps the never-ending audio
+	# body live.
+	@streams path /stream.mp3 /stream.opus /stream.flac /stream.aac
 	handle @streams {
 		reverse_proxy 127.0.0.1:7702 {
 			flush_interval -1
@@ -31,13 +34,22 @@
 		reverse_proxy 127.0.0.1:7701
 	}
 
+	# /listen.pls + /listen.m3u — one-paste tune-in files (VLC, Sonos, hardware).
+	# Served by the controller at its root (NOT under /api), so use a plain handle
+	# with no path stripping. Without this they fall through to the catch-all
+	# below and 404.
+	@listen path /listen.pls /listen.m3u
+	handle @listen {
+		reverse_proxy 127.0.0.1:7701
+	}
+
 	# Everything else → Next.js web UI.
 	handle {
 		reverse_proxy 127.0.0.1:7700
 	}
 
 	# Don't gzip the already-compressed live audio mounts.
-	@compressible not path /stream.mp3 /stream.opus
+	@compressible not path /stream.mp3 /stream.opus /stream.flac /stream.aac
 	encode @compressible gzip zstd
 
 	log {


### PR DESCRIPTION
## Problem

FLAC listeners on the Unraid **all-in-one** image get a 404 from `/stream.flac` while MP3 and Opus play fine. From the reporter's Caddy log, the 404 is served by **Next.js**, not Icecast:

```
"uri": "/stream.flac" ... "status": 404,
"resp_headers": { "Content-Type": ["text/html; charset=utf-8"],
                  "X-Powered-By": ["Next.js"], "X-Nextjs-Cache": ["HIT"] }
```

That means the request never reached Icecast — the edge router handed `/stream.flac` to the web UI catch-all. So this is **not** a mixer / `flac_enabled` problem; the mount can be perfectly healthy and it still 404s.

## Root cause

`docker/aio/Caddyfile` was last updated in #499 and never picked up stream routes added later:

- **#699** added the `/stream.flac` + `/stream.aac` Icecast mounts and updated the split-stack `docker/Caddyfile` — but **not** the AIO Caddyfile.
- **#689** added `/listen.pls` + `/listen.m3u`, likewise only in the split file.

So on the AIO image the `@streams` matcher was still just `/stream.mp3 /stream.opus`; everything else fell through to `handle { reverse_proxy 127.0.0.1:7700 }` (Next.js) → 404. The split `docker/Caddyfile` already routes all four mounts + the listen files, and its `@listen` comment even names this exact failure mode ("Without this they fall through to the Next.js catch-all below and 404").

## Fix

Bring the AIO route table back in sync with `docker/Caddyfile`:

- add `/stream.flac` + `/stream.aac` to `@streams`
- add the `@listen` handler for `/listen.pls` + `/listen.m3u` → controller (`127.0.0.1:7701`)
- add `/stream.flac` + `/stream.aac` to the `@compressible not path` exclusion so the live lossless body isn't gzip-buffered against `flush_interval -1`

## Validation

- `caddy adapt --adapter caddyfile` against `caddy:2` → **OK** (valid config)
- `caddy fmt` → already canonical
- Ships in the next AIO image build; existing images need a re-pull once merged + released.

Reported in the Discord support channel (Unraid AIO, `0.41`).