### PR TITLE
docker: add iputils-ping to AIO + controller images

### DIFF
--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -61,6 +61,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 #  - sudo: lets the supervisor drop privileges to icecast2 / liquidsoap
 #  - openssl: first-boot icecast secret generation
 #  - curl/ca-certificates: liquidsoap's HTTPS Subsonic fetch + health probes
+#  - iputils-ping: `ping` for in-container network debugging (self-host request)
 #  - espeak-ng/libsndfile1: Kokoro phonemisation + audio I/O
 #  - ffmpeg: jingle/SFX transcode on import (audio/audio-import.ts)
 #  - python3/python3-venv: the Kokoro worker venv
@@ -69,6 +70,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq \
  && apt-get install -y --no-install-recommends \
         icecast2 sudo openssl curl ca-certificates \
+        iputils-ping \
         espeak-ng libsndfile1 ffmpeg \
         python3 python3-venv \
         wget tar xz-utils gnupg \

--- a/docker/Dockerfile.controller
+++ b/docker/Dockerfile.controller
@@ -3,8 +3,9 @@ FROM node:22-bookworm-slim
 # Shared build deps + espeak-ng for Kokoro phonemization (British English).
 # ffmpeg transcodes + level-matches operator-imported jingles/SFX (see
 # audio/audio-import.ts); without it the import path stores raw uploads as-is.
+# iputils-ping supplies `ping` for network debugging when you exec into the container.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl ca-certificates wget tar \
+    curl ca-certificates wget tar iputils-ping \
     python3 python3-venv \
     espeak-ng libsndfile1 ffmpeg \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## What
Add `iputils-ping` to the apt lists of `docker/Dockerfile.aio` and `docker/Dockerfile.controller` so `ping` is available inside the containers.

## Why
A self-hoster in the Sub/Wave Discord hit this while debugging network connectivity from the all-in-one container:

```
root@a5a5a5670223:/app# ping 10.253.X.X
bash: ping: command not found
```

The lean images don't bundle `ping` — ICMP works fine on Docker's default bridge, the binary just isn't installed. This bakes it in so `docker exec … ping` works out of the box.

- **`Dockerfile.aio`** — the image the reporter is on (single container named `subwave`, root, `/app`).
- **`Dockerfile.controller`** — same one-liner, so split-stack users get `ping` when they exec into `sub-wave-controller`.

Tiny package, no extra build layer.

## Verification
On the AIO base `savonet/liquidsoap:v2.4.5` (as root, mirroring the Dockerfile):
- `ping` absent before install ✓
- apt candidate `iputils-ping 3:20240905-3` ✓
- installs to `/usr/bin/ping`, and `ping -c1 127.0.0.1` returns replies ✓