### PR TITLE
fix(admin): prominent pending-restart banner with one-click apply

### DIFF
--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -497,6 +497,28 @@ export default function SettingsPanel() {
             </div>
           </div>
         )}
+        {pendingRestart && (
+          <div
+            role="alert"
+            className="flex flex-wrap items-center gap-x-3 gap-y-2 border border-vermilion bg-vermilion/10 px-4 py-3 text-[12px] text-ink"
+          >
+            <AlertTriangle className="size-4 shrink-0 text-vermilion" strokeWidth={2} aria-hidden />
+            <span className="min-w-0 flex-1">
+              <strong className="tracking-[0.08em] uppercase">Saved — not yet on air.</strong>{' '}
+              The live stream is still running the previous mixer settings (bitrate, format,
+              crossfade, jingle frequency). Restart the mixer to apply what you saved.
+            </span>
+            <Btn
+              sm
+              tone="danger"
+              className="ml-auto"
+              onClick={() => setConfirmRestart(true)}
+              disabled={busy || !data}
+            >
+              Restart mixer to apply
+            </Btn>
+          </div>
+        )}
         {!data && !err && (
           <div className="text-[13px] text-muted italic">loading…</div>
         )}


### PR DESCRIPTION
## Why

Encoder-affecting settings — stream/archive MP3 **bitrate**, opus/aac/flac enable+bitrate, crossfade, jingle frequency — are written to the `liquidsoap_*.txt` files (and `settings.json`) on every save. But `%mp3(bitrate=…)` and friends are **parse-time literals baked at Liquidsoap startup**, so the live stream keeps the old values until the mixer restarts.

Until now that "requires restart" state surfaced only as:
- a dismissible toast (`saved, restart the mixer to apply`), and
- a small `<strong>` line buried in the **Mixer** card at the bottom of the panel.

Easy to miss → a saved-but-not-applied change silently diverges from what's on air: the admin UI shows 192 kbps while Icecast still serves 128. This is exactly the confusion in the Discord report about stream bitrate never reaching the live mount.

To be clear: the `.txt` sync itself is **not** broken — `writeLiquidsoapSettings()` rewrites all of them on save (shipped in #676), and the AIO image pins `STATE_DIR=/var/sub-wave` to match `radio.liq`. The gap is purely that the required restart is under-surfaced.

## Change

A persistent, `role="alert"` banner at the **top of the settings content column** (visible on every section tab) whenever `pendingRestart` is set, with a one-click **Restart mixer to apply** that reuses the existing confirm dialog + `restartMixer()`. It clears as soon as the restart is triggered.

Single-file, additive change — reuses `AlertTriangle`, `Btn`, `vermilion` tokens, and the existing `confirmRestart` flow already in the panel.

## Verification

- `tsc --noEmit`: no type errors in `SettingsPanel.tsx`.
- `eslint components/admin/SettingsPanel.tsx`: clean.
- Visual/live verification (banner appears after an encoder-affecting save, one-click restart clears it) still to be done in a running stack.

## Known follow-ups (not in this PR)

- `pendingRestart` is in-session React state, so a page reload before restarting drops the banner. A robust fix would derive the pending state from server truth (live Liquidsoap encoder params vs saved settings) so it survives reloads and reflects reality.
- `radio.liq` hardcodes `/var/sub-wave`; a deploy that overrides `STATE_DIR` without changing `radio.liq` would reproduce the reporter's symptom for real. Consider reading `STATE_DIR` in `radio.liq` or asserting the two match at boot.