### PR TITLE
feat(admin): audience time-of-day + live device/listen-time on Stats

### DIFF
--- a/web/components/admin/DashPanel.tsx
+++ b/web/components/admin/DashPanel.tsx
@@ -9,6 +9,7 @@ import { useAdminAuth } from '../../lib/adminAuth';
 import { notify, errorMessage } from '../../lib/notify';
 import { eventTurnSummary, turnClass, turnKey, turnText } from '../../lib/sessionFeed';
 import { fmtClock } from '../../lib/format';
+import { clientLabel, fmtConnected, type ListenerConnection } from '../../lib/clientLabel';
 import type { SessionTurn } from '../../lib/types';
 import type {
   NowPlayingTrack,
@@ -128,16 +129,6 @@ interface ActResponse {
   error?: string;
 }
 
-interface ListenerConnection {
-  ip: string;
-  mount: string;
-  userAgent: string;
-  connectedSeconds: number;
-  // Raw sockets folded into this row. Safari opens 2 per client (counts as one
-  // listener); >1 surfaces as a ×N badge. Absent/1 for normal single-socket clients.
-  connections?: number;
-}
-
 interface ConnectionsState {
   count: number;
   connections: ListenerConnection[];
@@ -167,17 +158,6 @@ interface RequestEntry {
   message?: string | null;
 }
 
-// connectedSeconds → short human string. Listeners rarely sit for days, so
-// hours is the coarsest unit we bother with.
-function fmtConnected(s: number): string {
-  if (!Number.isFinite(s) || s < 0) return '—';
-  if (s < 60) return `${Math.round(s)}s`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m`;
-  const h = Math.floor(m / 60);
-  return `${h}h ${m % 60}m`;
-}
-
 // Hide the host portion of an IP so a glance at the screen doesn't expose a
 // listener's full address. IPv4 drops the last octet, IPv6 keeps the first two
 // groups (the routing prefix) and masks the rest. The raw IP is still in the
@@ -191,46 +171,6 @@ function maskIp(ip: string): string {
     return groups.length > 2 ? `${groups[0]}:${groups[1]}:×` : ip;
   }
   return ip;
-}
-
-// Collapse a raw user-agent into a short "Device · App" label. Best-effort and
-// deliberately shallow — the full UA stays in the title attribute. Order
-// matters: check the specific players (Sonos, VLC) before the generic browser
-// families, since some embed "Mozilla" boilerplate.
-function clientLabel(ua: string): string {
-  if (!ua) return 'unknown';
-  const u = ua.toLowerCase();
-  if (u.includes('sonos')) return 'Sonos';
-  if (u.includes('vlc')) return 'VLC';
-  if (u.includes('itunes') || u.includes('applecoremedia')) return 'iTunes / Music';
-  if (u.includes('winamp')) return 'Winamp';
-  if (u.includes('foobar')) return 'foobar2000';
-  const device = u.includes('iphone')
-    ? 'iPhone'
-    : u.includes('ipad')
-      ? 'iPad'
-      : u.includes('android')
-        ? 'Android'
-        : u.includes('macintosh') || u.includes('mac os')
-          ? 'Mac'
-          : u.includes('windows')
-            ? 'Windows'
-            : u.includes('linux')
-              ? 'Linux'
-              : '';
-  const browser = u.includes('firefox')
-    ? 'Firefox'
-    : u.includes('edg')
-      ? 'Edge'
-      : u.includes('chrome') || u.includes('chromium')
-        ? 'Chrome'
-        : u.includes('safari')
-          ? 'Safari'
-          : '';
-  const label = [device, browser].filter(Boolean).join(' · ');
-  // Nothing recognised — show the first token of the raw UA rather than a
-  // useless "unknown" (helps with hardware radios / odd clients).
-  return label || ua.split(/[\s/]/)[0] || 'unknown';
 }
 
 type SortKey = 'ip' | 'mount' | 'connectedSeconds' | 'client';

--- a/web/components/admin/StatsPanel.tsx
+++ b/web/components/admin/StatsPanel.tsx
@@ -20,6 +20,12 @@ import { V3Alert } from '../ui/alert';
 import { Card, Btn, Pill, Eyebrow, Seg } from './ui';
 import { ScrollArea } from '../ui/scroll-area';
 import { cn } from '../../lib/cn';
+import { fmtConnected, type ListenerConnection } from '../../lib/clientLabel';
+import {
+  bucketSamplesByHour,
+  groupConnectionsByDevice,
+  type HourBucket,
+} from '../../lib/audienceStats';
 
 // --- types --------------------------------------------------------------
 
@@ -168,6 +174,16 @@ interface AudienceResponse {
   referrers?: { source: string; count: number }[];
   countries?: { country: string; count: number }[];
   paths?: { path: string; count: number }[];
+  error?: string;
+}
+
+// GET /listeners/connections — live per-listener detail from Icecast's admin
+// feed (already deduped one-row-per-listener by the server). `error` is set on
+// a 502 (Icecast admin unreachable) so the UI distinguishes "nobody connected"
+// (empty list) from "couldn't read the live detail".
+interface ConnectionsResponse {
+  count?: number;
+  connections?: ListenerConnection[];
   error?: string;
 }
 
@@ -447,6 +463,62 @@ function ListenerChart({ samples }: { samples: ListenerSample[] }) {
   );
 }
 
+// --- hour-of-day histogram ---------------------------------------------
+
+// One vertical bar in the hour-of-day chart. Height is dynamic (per-hour), so
+// it goes through useDynamicStyle rather than an inline style prop (see the
+// hook — the strict lint rule forbids `style={…}`).
+function HourColumn({ frac, title }: { frac: number; title: string }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  useDynamicStyle(ref, { height: `${Math.max(2, Math.round(frac * 100))}%` });
+  return (
+    <span className="flex h-full flex-1 items-end" title={title}>
+      <span ref={ref} className="block min-h-[2px] w-full rounded-[2px] bg-vermilion" />
+    </span>
+  );
+}
+
+// 24-bar histogram of average listeners by local hour-of-day — "when is the
+// station busiest?". Bars are anchored to the busiest hour's average. Same
+// no-dependency house style as ListenerChart; the axis labels a few anchor
+// hours rather than all 24 to stay legible.
+function HourOfDayChart({ buckets }: { buckets: HourBucket[] }) {
+  const hasData = buckets.some(b => b.samples > 0);
+  if (!hasData) {
+    return (
+      <div className="flex h-[110px] items-center justify-center">
+        <span className="field-hint italic">collecting hourly history…</span>
+      </div>
+    );
+  }
+  const maxAvg = Math.max(...buckets.map(b => b.avg), 0);
+  const pad = (h: number) => String(h).padStart(2, '0');
+  return (
+    <div>
+      <div className="flex h-[110px] items-end gap-[3px]">
+        {buckets.map(b => (
+          <HourColumn
+            key={b.hour}
+            frac={maxAvg ? b.avg / maxAvg : 0}
+            title={
+              b.samples
+                ? `${pad(b.hour)}:00 · avg ${(Math.round(b.avg * 10) / 10)} · peak ${b.peak}`
+                : `${pad(b.hour)}:00 · no data`
+            }
+          />
+        ))}
+      </div>
+      <div className="caption mt-1 flex justify-between text-muted">
+        <span>00</span>
+        <span>06</span>
+        <span>12</span>
+        <span>18</span>
+        <span>23</span>
+      </div>
+    </div>
+  );
+}
+
 const RANGE_OPTIONS = [
   { id: '1440', label: '24h' },
   { id: '10080', label: '7d' },
@@ -461,6 +533,7 @@ export default function StatsPanel() {
   const [paused, setPaused] = useState(false);
   const [listeners, setListeners] = useState<ListenersResponse | null>(null);
   const [audience, setAudience] = useState<AudienceResponse | null>(null);
+  const [connections, setConnections] = useState<ConnectionsResponse | null>(null);
   const [systemRes, setSystemRes] = useState<SystemResponse | null>(null);
   const [range, setRange] = useState('1440'); // minutes — 24h default
 
@@ -543,6 +616,34 @@ export default function StatsPanel() {
     return () => { cancelled = true; clearInterval(id); };
   }, [paused, needsAuth, hydrated, adminFetch, range]);
 
+  // /listeners/connections — live per-listener device + connected-for detail
+  // from Icecast's admin feed, 30s. Range-independent ("connected right now").
+  // A 502 (Icecast admin unreachable) is stored as an error rather than dropped,
+  // so the card can say "live detail unavailable" instead of silently blanking.
+  useEffect(() => {
+    if (!hydrated || needsAuth) return;
+    let cancelled = false;
+    const tick = async () => {
+      if (paused) return;
+      try {
+        const r = await adminFetch('/listeners/connections');
+        if (r.status === 401) {
+          if (!cancelled) setConnections(null);
+          return;
+        }
+        const j = (await r.json()) as ConnectionsResponse;
+        if (!cancelled) {
+          setConnections(r.ok ? j : { error: j?.error || 'live connection detail unavailable' });
+        }
+      } catch {
+        /* leave last reading in place */
+      }
+    };
+    tick();
+    const id = setInterval(tick, 30000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [paused, needsAuth, hydrated, adminFetch]);
+
   // /system — per-container CPU/memory, 30s (it samples the Docker stats stream
   // for ~1s per container, so it's heavier than /stats). Soft-fails like the
   // others. Range-independent — always "right now".
@@ -582,10 +683,23 @@ export default function StatsPanel() {
   const lAvg = counts.length ? counts.reduce((a, b) => a + b, 0) / counts.length : null;
   const rangeLabel = range === '10080' ? '7d' : '24h';
 
+  // Hour-of-day histogram, derived from the same listener series as the trend
+  // chart (respects the 24h/7d range toggle). Local time — labeled as such.
+  const hourBuckets = bucketSamplesByHour(samples);
+
   // Audience-source rollup (referrers / countries / distinct sessions).
   const audSessions = audience?.sessions ?? null;
   const audReferrers = audience?.referrers ?? [];
   const audCountries = audience?.countries ?? [];
+
+  // Live "connected now" device breakdown, from the Icecast admin feed.
+  const connErr = connections?.error ?? null;
+  const connList = connections?.connections ?? [];
+  const connCount = connections?.count ?? connList.length;
+  const deviceGroups = groupConnectionsByDevice(connList);
+  const connAvgSeconds = connList.length
+    ? connList.reduce((a, c) => a + (c.connectedSeconds > 0 ? c.connectedSeconds : 0), 0) / connList.length
+    : 0;
 
   // System resources (container CPU/mem + host totals).
   const sysHost = systemRes?.host ?? null;
@@ -633,6 +747,19 @@ export default function StatsPanel() {
               <ListenerChart samples={samples} />
             )}
           </div>
+          <div className="border-t border-separator-soft p-3.5">
+            <div className="caption mb-2">
+              busiest hours
+              <span className="text-muted"> · avg listeners by hour · your local time</span>
+            </div>
+            {listeners == null ? (
+              <div className="flex h-[110px] items-center justify-center">
+                <span className="field-hint italic">loading…</span>
+              </div>
+            ) : (
+              <HourOfDayChart buckets={hourBuckets} />
+            )}
+          </div>
         </div>
       </Card>
 
@@ -641,51 +768,97 @@ export default function StatsPanel() {
         title="Audience sources"
         sub={`where listeners came from · last ${rangeLabel}`}
       >
-        {audience == null ? (
-          <span className="field-hint italic">loading…</span>
-        ) : (audSessions ?? 0) === 0 ? (
-          <span className="field-hint italic">
-            no sessions recorded yet, sources appear as listeners arrive
-          </span>
-        ) : (
-          <div className="grid gap-0">
-            <MetricStrip>
-              <StatCell label="Sessions" value={fmtInt(audSessions)} accent
-                sub={`distinct, last ${rangeLabel}`} />
-              <StatCell label="Sources" value={fmtInt(audReferrers.length)} />
-              <StatCell label="Countries" value={fmtInt(audCountries.length)} last />
-            </MetricStrip>
-
-            <div className="stack-mobile grid grid-cols-[1fr_1fr] gap-0">
-              <div className="border-r border-separator-soft p-3.5">
-                <div className="caption mb-2">top referrers</div>
-                {audReferrers.length ? (
-                  <ScrollBox>
-                    <BarList
-                      rows={audReferrers.map(r => ({ label: r.source, count: r.count }))}
-                      max={audReferrers[0]?.count || 1}
-                    />
-                  </ScrollBox>
-                ) : (
-                  <span className="field-hint italic">none</span>
-                )}
-              </div>
-              <div className="p-3.5">
-                <div className="caption mb-2">top countries</div>
-                {audCountries.length ? (
-                  <ScrollBox>
-                    <BarList
-                      rows={audCountries.map(c => ({ label: c.country, count: c.count }))}
-                      max={audCountries[0]?.count || 1}
-                    />
-                  </ScrollBox>
-                ) : (
-                  <span className="field-hint italic">none</span>
-                )}
-              </div>
+        <div className="grid gap-0">
+          {/* Connected now — live device + listen time from Icecast's admin
+              feed. Rendered independently of the durable beacon rollup below, so
+              it still shows on a fresh boot with zero recorded beacon sessions.
+              No IPs here (unlike the Dash) — device class + counts + durations
+              only. */}
+          <div className="border-b border-separator-strong p-3.5">
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <span className="caption">connected now · by device</span>
+              <span className="caption text-muted">
+                {connErr
+                  ? 'live detail unavailable'
+                  : connections == null
+                    ? 'loading…'
+                    : `${fmtInt(connCount)} listening${
+                        connList.length ? ` · avg ${fmtConnected(connAvgSeconds)}` : ''
+                      }`}
+              </span>
             </div>
+            {connErr ? (
+              <span className="field-hint italic">{connErr}</span>
+            ) : connections == null ? (
+              <span className="field-hint italic">loading…</span>
+            ) : deviceGroups.length === 0 ? (
+              <span className="field-hint italic">nobody connected right now</span>
+            ) : (
+              <BarList
+                max={deviceGroups[0]?.count || 1}
+                rows={deviceGroups.map(g => ({
+                  label: g.device,
+                  count: g.count,
+                  trailing: `${g.count} · ${fmtConnected(g.avgSeconds)}${
+                    g.count > 1 ? ` · up to ${fmtConnected(g.maxSeconds)}` : ''
+                  }`,
+                }))}
+              />
+            )}
           </div>
-        )}
+
+          {/* Durable referral / geo rollup from the first-load beacon, over the
+              selected range. */}
+          {audience == null ? (
+            <div className="p-3.5">
+              <span className="field-hint italic">loading…</span>
+            </div>
+          ) : (audSessions ?? 0) === 0 ? (
+            <div className="p-3.5">
+              <span className="field-hint italic">
+                no sessions recorded yet, sources appear as listeners arrive
+              </span>
+            </div>
+          ) : (
+            <>
+              <MetricStrip>
+                <StatCell label="Sessions" value={fmtInt(audSessions)} accent
+                  sub={`distinct, last ${rangeLabel}`} />
+                <StatCell label="Sources" value={fmtInt(audReferrers.length)} />
+                <StatCell label="Countries" value={fmtInt(audCountries.length)} last />
+              </MetricStrip>
+
+              <div className="stack-mobile grid grid-cols-[1fr_1fr] gap-0">
+                <div className="border-r border-separator-soft p-3.5">
+                  <div className="caption mb-2">top referrers</div>
+                  {audReferrers.length ? (
+                    <ScrollBox>
+                      <BarList
+                        rows={audReferrers.map(r => ({ label: r.source, count: r.count }))}
+                        max={audReferrers[0]?.count || 1}
+                      />
+                    </ScrollBox>
+                  ) : (
+                    <span className="field-hint italic">none</span>
+                  )}
+                </div>
+                <div className="p-3.5">
+                  <div className="caption mb-2">top countries</div>
+                  {audCountries.length ? (
+                    <ScrollBox>
+                      <BarList
+                        rows={audCountries.map(c => ({ label: c.country, count: c.count }))}
+                        max={audCountries[0]?.count || 1}
+                      />
+                    </ScrollBox>
+                  ) : (
+                    <span className="field-hint italic">none</span>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
       </Card>
 
       {!data && !err && (

--- a/web/lib/audienceStats.test.ts
+++ b/web/lib/audienceStats.test.ts
@@ -1,0 +1,151 @@
+// Unit tests for the pure Audience-stats derivations. Same lightweight harness
+// as controller/scripts/*.test.ts (assert + ✓/✗ + non-zero exit on failure).
+// Run from the repo root:  npx tsx web/lib/audienceStats.test.ts
+//
+// bucketSamplesByHour uses local time (Date#getHours), so the hour-bucket tests
+// build timestamps from local Date components rather than hard-coded UTC ISO
+// strings — that keeps them correct regardless of the machine's timezone.
+
+import assert from 'node:assert/strict';
+import {
+  bucketSamplesByHour,
+  groupConnectionsByDevice,
+  type DeviceGroup,
+  type HourBucket,
+} from './audienceStats';
+import type { ListenerConnection } from './clientLabel';
+
+let failures = 0;
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  ✗ ${name}\n      ${(err as Error)?.message || err}`);
+  }
+}
+
+// Narrow away the `T | undefined` that strict indexed access yields, throwing a
+// legible test failure rather than leaning on non-null assertions.
+function req<T>(v: T | undefined, msg: string): T {
+  if (v === undefined) throw new Error(`missing ${msg}`);
+  return v;
+}
+const hour = (buckets: HourBucket[], h: number) => req(buckets[h], `hour ${h}`);
+const group = (groups: DeviceGroup[], i: number) => req(groups[i], `group ${i}`);
+
+// Build an ISO timestamp for a given local hour/minute on a fixed local day.
+function at(h: number, minute = 0): string {
+  return new Date(2026, 0, 5, h, minute, 0, 0).toISOString();
+}
+
+function conn(userAgent: string, connectedSeconds: number): ListenerConnection {
+  return { ip: '', mount: '/stream.mp3', userAgent, connectedSeconds };
+}
+
+console.log('bucketSamplesByHour:');
+
+test('returns all 24 hours in order, even with no samples', () => {
+  const b = bucketSamplesByHour([]);
+  assert.equal(b.length, 24);
+  assert.deepEqual(
+    b.map(x => x.hour),
+    Array.from({ length: 24 }, (_, i) => i),
+  );
+  assert.ok(b.every(x => x.avg === 0 && x.peak === 0 && x.samples === 0));
+});
+
+test('averages counts within the same local hour', () => {
+  const b = bucketSamplesByHour([
+    { t: at(9, 0), count: 2 },
+    { t: at(9, 30), count: 4 },
+    { t: at(9, 59), count: 6 },
+  ]);
+  const nine = hour(b, 9);
+  assert.equal(nine.samples, 3);
+  assert.equal(nine.avg, 4); // (2+4+6)/3
+  assert.equal(nine.peak, 6);
+});
+
+test('separates samples into their own hour buckets', () => {
+  const b = bucketSamplesByHour([
+    { t: at(0, 10), count: 1 },
+    { t: at(23, 10), count: 9 },
+  ]);
+  assert.equal(hour(b, 0).samples, 1);
+  assert.equal(hour(b, 0).avg, 1);
+  assert.equal(hour(b, 23).samples, 1);
+  assert.equal(hour(b, 23).peak, 9);
+  assert.equal(hour(b, 12).samples, 0); // untouched hour stays empty
+});
+
+test('skips unparseable timestamps without throwing', () => {
+  const b = bucketSamplesByHour([
+    { t: 'not-a-date', count: 5 },
+    { t: at(6, 0), count: 3 },
+  ]);
+  assert.equal(hour(b, 6).samples, 1);
+  assert.equal(hour(b, 6).avg, 3);
+});
+
+test('treats a non-finite count as zero', () => {
+  const b = bucketSamplesByHour([
+    { t: at(6, 0), count: Number.NaN },
+    { t: at(6, 30), count: 4 },
+  ]);
+  assert.equal(hour(b, 6).samples, 2);
+  assert.equal(hour(b, 6).avg, 2); // (0 + 4) / 2
+});
+
+console.log('groupConnectionsByDevice:');
+
+test('empty input yields an empty breakdown', () => {
+  assert.deepEqual(groupConnectionsByDevice([]), []);
+});
+
+test('groups by device class with avg + max connected-for', () => {
+  const groups = groupConnectionsByDevice([
+    conn('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Safari', 60),
+    conn('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Safari', 180),
+    conn('Mozilla/5.0 (Macintosh; Intel Mac OS X) Chrome', 300),
+  ]);
+  assert.equal(groups.length, 2);
+  // iPhone has 2 listeners → sorts first (count desc).
+  const iphone = group(groups, 0);
+  assert.equal(iphone.device, 'iPhone');
+  assert.equal(iphone.count, 2);
+  assert.equal(iphone.avgSeconds, 120); // (60+180)/2
+  assert.equal(iphone.maxSeconds, 180);
+  const mac = group(groups, 1);
+  assert.equal(mac.device, 'Mac');
+  assert.equal(mac.count, 1);
+  assert.equal(mac.avgSeconds, 300);
+});
+
+test('classifies dedicated players ahead of browser families', () => {
+  const groups = groupConnectionsByDevice([conn('Linux UPnP/1.0 Sonos/1.0', 90)]);
+  assert.equal(group(groups, 0).device, 'Sonos');
+});
+
+test('collapses unrecognised user-agents to Other', () => {
+  const groups = groupConnectionsByDevice([conn('SomeObscureRadio/2.1', 45)]);
+  assert.equal(group(groups, 0).device, 'Other');
+});
+
+test('clamps a negative connected-for to zero in the average', () => {
+  const groups = groupConnectionsByDevice([
+    conn('Mozilla/5.0 (Windows NT 10.0) Chrome', -5),
+    conn('Mozilla/5.0 (Windows NT 10.0) Chrome', 100),
+  ]);
+  const win = group(groups, 0);
+  assert.equal(win.device, 'Windows');
+  assert.equal(win.avgSeconds, 50); // (0 + 100) / 2
+  assert.equal(win.maxSeconds, 100);
+});
+
+if (failures > 0) {
+  console.error(`\n${failures} test(s) failed.`);
+  process.exit(1);
+}
+console.log('\nAll audienceStats tests passed.');

--- a/web/lib/audienceStats.ts
+++ b/web/lib/audienceStats.ts
@@ -1,0 +1,80 @@
+// Pure client-side derivations for the admin Stats "Audience" cards. Kept
+// dependency-free and side-effect-free so they unit-test in isolation
+// (audienceStats.test.ts) — the React panel just calls them and renders.
+
+import { deviceLabel, type ListenerConnection } from './clientLabel';
+
+// --- hour-of-day histogram ------------------------------------------------
+
+export interface ListenerSample {
+  t: string; // ISO timestamp
+  count: number;
+}
+
+export interface HourBucket {
+  hour: number; // 0–23, local time
+  avg: number; // mean listener count across samples in this hour
+  peak: number; // max listener count seen in this hour
+  samples: number; // how many samples landed in this hour (0 = no data)
+}
+
+// Bucket the per-minute listener series by local hour-of-day and average each
+// hour's counts — "what times of day is the station busiest?". Uses the
+// runtime's local timezone via Date#getHours (the caller labels the axis as
+// local time). Always returns all 24 hours in order; an hour with no samples
+// has avg 0 / samples 0 so the caller can render it as an empty column.
+export function bucketSamplesByHour(samples: ListenerSample[]): HourBucket[] {
+  const acc = Array.from({ length: 24 }, () => ({ total: 0, peak: 0, n: 0 }));
+  for (const s of samples) {
+    const d = new Date(s.t);
+    const ms = d.getTime();
+    if (!Number.isFinite(ms)) continue; // skip an unparseable timestamp
+    const c = Number.isFinite(s.count) ? s.count : 0;
+    const a = acc[d.getHours()];
+    if (!a) continue; // getHours() is always 0–23; guard satisfies strict indexing
+    a.total += c;
+    a.peak = Math.max(a.peak, c);
+    a.n += 1;
+  }
+  return acc.map((a, hour) => ({
+    hour,
+    avg: a.n ? a.total / a.n : 0,
+    peak: a.peak,
+    samples: a.n,
+  }));
+}
+
+// --- live device breakdown ------------------------------------------------
+
+export interface DeviceGroup {
+  device: string; // device/OS class from deviceLabel
+  count: number; // distinct listeners on this device class right now
+  avgSeconds: number; // mean connected-for across those listeners
+  maxSeconds: number; // longest connected-for in the group
+}
+
+// Fold live listener connections into a per-device-class breakdown with
+// connected-for stats. Input is already deduped to one row per listener
+// (groupConnections on the server), so each row is one distinct listener.
+// Sorted by listener count desc, then by average connected-for desc.
+export function groupConnectionsByDevice(conns: ListenerConnection[]): DeviceGroup[] {
+  const map = new Map<string, { count: number; total: number; max: number }>();
+  for (const c of conns) {
+    const device = deviceLabel(c.userAgent);
+    const secs =
+      Number.isFinite(c.connectedSeconds) && c.connectedSeconds > 0 ? c.connectedSeconds : 0;
+    const g = map.get(device) ?? { count: 0, total: 0, max: 0 };
+    g.count += 1;
+    g.total += secs;
+    g.max = Math.max(g.max, secs);
+    map.set(device, g);
+  }
+  return [...map.entries()]
+    .map(([device, g]) => ({
+      device,
+      count: g.count,
+      avgSeconds: g.count ? g.total / g.count : 0,
+      maxSeconds: g.max,
+    }))
+    .sort((a, b) => b.count - a.count || b.avgSeconds - a.avgSeconds);
+}

--- a/web/lib/clientLabel.ts
+++ b/web/lib/clientLabel.ts
@@ -1,0 +1,92 @@
+// Shared listener-connection helpers for the admin views that read Icecast's
+// per-connection admin feed (GET /listeners/connections): the Dash live table
+// and the Stats "connected now" device breakdown. Extracted from DashPanel so
+// both surfaces label devices and format durations identically.
+
+export interface ListenerConnection {
+  ip: string;
+  mount: string;
+  userAgent: string;
+  connectedSeconds: number;
+  // Raw sockets folded into this row. Safari opens 2 per client (counts as one
+  // listener); >1 surfaces as a ×N badge. Absent/1 for normal single-socket clients.
+  connections?: number;
+}
+
+// connectedSeconds → short human string. Listeners rarely sit for days, so
+// hours is the coarsest unit we bother with.
+export function fmtConnected(s: number): string {
+  if (!Number.isFinite(s) || s < 0) return '—';
+  if (s < 60) return `${Math.round(s)}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+// A dedicated media player (Sonos, VLC, …), or '' if the UA isn't one. Checked
+// before the browser/device families because players embed "Mozilla"
+// boilerplate that would otherwise misclassify them as a browser.
+function playerLabel(u: string): string {
+  if (u.includes('sonos')) return 'Sonos';
+  if (u.includes('vlc')) return 'VLC';
+  if (u.includes('itunes') || u.includes('applecoremedia')) return 'iTunes / Music';
+  if (u.includes('winamp')) return 'Winamp';
+  if (u.includes('foobar')) return 'foobar2000';
+  return '';
+}
+
+// Device / OS token, or '' if unrecognised.
+function deviceToken(u: string): string {
+  return u.includes('iphone')
+    ? 'iPhone'
+    : u.includes('ipad')
+      ? 'iPad'
+      : u.includes('android')
+        ? 'Android'
+        : u.includes('macintosh') || u.includes('mac os')
+          ? 'Mac'
+          : u.includes('windows')
+            ? 'Windows'
+            : u.includes('linux')
+              ? 'Linux'
+              : '';
+}
+
+// Browser family token, or '' if unrecognised. `edg` (Edge) is checked before
+// `chrome` because Edge's UA carries both tokens.
+function browserToken(u: string): string {
+  return u.includes('firefox')
+    ? 'Firefox'
+    : u.includes('edg')
+      ? 'Edge'
+      : u.includes('chrome') || u.includes('chromium')
+        ? 'Chrome'
+        : u.includes('safari')
+          ? 'Safari'
+          : '';
+}
+
+// Collapse a raw user-agent into a short "Device · App" label for the live
+// connections table. Best-effort and deliberately shallow — the full UA stays
+// in the title attribute.
+export function clientLabel(ua: string): string {
+  if (!ua) return 'unknown';
+  const u = ua.toLowerCase();
+  const player = playerLabel(u);
+  if (player) return player;
+  const label = [deviceToken(u), browserToken(u)].filter(Boolean).join(' · ');
+  // Nothing recognised — show the first token of the raw UA rather than a
+  // useless "unknown" (helps with hardware radios / odd clients).
+  return label || ua.split(/[\s/]/)[0] || 'unknown';
+}
+
+// Device / OS class only (iPhone, Mac, Sonos, …) for the aggregate device
+// breakdown. Players report as themselves; an unrecognised UA collapses to
+// 'Other' so the breakdown stays low-cardinality rather than fragmenting on raw
+// tokens (which the per-row clientLabel keeps, but an aggregate must not).
+export function deviceLabel(ua: string): string {
+  if (!ua) return 'Other';
+  const u = ua.toLowerCase();
+  return playerLabel(u) || deviceToken(u) || 'Other';
+}


### PR DESCRIPTION
## What

Two additions to the admin **Stats** page — both **frontend-only**. They aggregate data that two existing admin endpoints already return, so there is **no controller change, no new persisted data, and no new privacy surface**.

### 1. Audience → "busiest hours"
A 24-bar histogram of **average listeners by local hour-of-day**, derived client-side from the existing `/listeners` time-series (respects the 24h/7d range toggle). Answers *"what times of day is the station busiest?"*

### 2. Audience sources → "connected now · by device"
A **live** breakdown from the Icecast admin feed (`/listeners/connections`, already consumed by the Dash), grouping current listeners by **device/OS class** (iPhone, Mac, Sonos, VLC, …) with **how long each class has been connected** (avg, and longest).

- **Aggregate-only, by class** — no IPs shown, no per-individual-device history (deliberately dropped; keeps the station's privacy-by-design model).
- **Source** attribution stays the existing durable referrers/countries.
- Renders **independently of the durable beacon rollup**, so it still shows on a fresh boot with zero recorded beacon sessions.

## Refactor
Extracted `clientLabel` + `fmtConnected` out of `DashPanel.tsx` into a shared **`web/lib/clientLabel.ts`** (plus a new `deviceLabel` returning the device/OS class only, for the aggregate breakdown). The Dash table and the new Stats section now label devices from one source instead of duplicating the parser.

## Design choices (confirmed with the requester)
- Time chart = hour-of-day bars (not a weekday×hour heatmap)
- Device breakdown = live snapshot (not a durable per-day aggregate)
- Device grouping = device/OS class

## Tests / verification
- Pure derivations (`bucketSamplesByHour`, `groupConnectionsByDevice`) live in `web/lib/audienceStats.ts` with unit tests in `web/lib/audienceStats.test.ts` — run: `npx tsx web/lib/audienceStats.test.ts` (10/10 pass).
- `tsc --noEmit` ✅ · `eslint` ✅ · `next build` ✅
- Not exercised against a live station (Icecast + controller stack not available in this environment); the new fetch mirrors the page's existing soft-fail effects and handles 401 / 502 / empty / loading states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)