### PR TITLE
fix(web): request follow-through in the new player skins

### DIFF
--- a/web/components/ThemeSwitcher.tsx
+++ b/web/components/ThemeSwitcher.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { useCallback, useRef, useState, type ReactNode } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
 import { LayoutTemplate, Palette, Zap } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { useDynamicStyle } from '../hooks/useDynamicStyle';
@@ -26,16 +27,26 @@ function Swatch({ color }: SwatchProps) {
   return <span ref={ref} className="h-4 w-4 sm:h-5 sm:w-5" aria-hidden="true" />;
 }
 
+function SectionLabel({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <span className={cn('v3-eyebrow border-b border-soft-border px-1 pb-1 text-[10px] tracking-[0.3em]', className)}>
+      {children}
+    </span>
+  );
+}
+
 export interface ThemeSwitcherProps {
   /** Visual variant — player chrome (TopBar) or admin header. Controls the
    *  trigger button's text styling so it picks up the right cluster's font. */
   variant?: 'player' | 'admin';
 }
 
-// Per-listener theme override switcher. Drops into a header as an icon button
-// and opens a small dropdown listing every theme the controller exposes. The
-// listener's pick is persisted in localStorage and beats the station-wide
-// default until they hit "Use station default".
+// Per-listener theme + skin switcher. Drops into a header as a palette icon
+// and opens a centered modal listing every theme the controller exposes, the
+// player skins, and the lite-mode toggle. The listener's picks are persisted
+// in localStorage and beat the station-wide defaults until reset. Modal (not a
+// dropdown) so it reads the same on every skin regardless of where the icon
+// sits — an anchored popover collided with each skin's own chrome.
 //
 // The component renders nothing while the theme registry is still loading or
 // is empty — there's nothing useful to show, and bouncing a button in and out
@@ -48,42 +59,12 @@ export default function ThemeSwitcher({ variant = 'player' }: ThemeSwitcherProps
   const skinCtx = useSkinSelection();
   const showSkins = skinCtx != null && skinCtx.skins.length > 1;
   const [open, setOpen] = useState(false);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const popoverRef = useRef<HTMLDivElement>(null);
-  const popoverId = useId();
   const { lite, setLite } = useLiteMode();
 
-  // Close on outside click and Escape. mousedown beats click so the popover
-  // doesn't flicker when a listener clicks a different control elsewhere in
-  // the header.
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      const t = e.target as Node | null;
-      if (!t) return;
-      if (triggerRef.current?.contains(t)) return;
-      if (popoverRef.current?.contains(t)) return;
-      setOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        setOpen(false);
-        triggerRef.current?.focus();
-      }
-    };
-    document.addEventListener('mousedown', onDown);
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('mousedown', onDown);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [open]);
-
-  const onPick = useCallback(
+  const onPickTheme = useCallback(
     (id: string | null) => {
       ctx?.setOverride(id);
       setOpen(false);
-      triggerRef.current?.focus();
     },
     [ctx],
   );
@@ -95,200 +76,189 @@ export default function ThemeSwitcher({ variant = 'player' }: ThemeSwitcherProps
   const { themes, stationActiveId, overrideId, effectiveId } = ctx;
 
   return (
-    <span className="relative inline-flex">
-      <button
-        ref={triggerRef}
-        type="button"
-        onClick={() => setOpen(v => !v)}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        aria-controls={popoverId}
-        aria-label="Choose theme"
-        title="Choose theme"
-        className={cn(
-          'v3-focus inline-flex shrink-0 cursor-pointer items-center justify-center border-0 bg-transparent p-0 leading-none',
-          variant === 'admin' ? 'caption text-muted' : 'text-muted hover:text-ink',
-        )}
-      >
-        <Palette className="h-4 w-4" aria-hidden="true" />
-      </button>
-
-      {open && (
-        <div
-          ref={popoverRef}
-          id={popoverId}
-          role="menu"
-          aria-label="Themes"
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Trigger asChild>
+        <button
+          type="button"
+          aria-label="Appearance — theme and skin"
+          title="Appearance"
           className={cn(
-            // bg-[var(--field)] (not bg-bg) lifts the panel off the page: the
-            // page background is exactly --bg, so a bg-bg panel reads as
-            // transparent — content and chrome show across it. --field is the
-            // per-theme "raised surface" nudge, so the menu stays opaque and
-            // distinct in every theme. A real drop shadow + ring seal the edge.
-            'absolute z-50 mt-1 grid w-[min(280px,calc(100vw-2rem))] gap-1 border border-ink bg-[var(--field)] p-2',
-            'shadow-[0_16px_44px_-12px_rgba(0,0,0,0.7)] ring-1 ring-black/10',
-            // Anchor the popover to the trigger; pull it left so the right
-            // edge lines up with the icon — keeps the panel inside the
-            // viewport when the trigger sits flush with the right gutter.
-            'top-full right-0',
+            'v3-focus inline-flex shrink-0 cursor-pointer items-center justify-center border-0 bg-transparent p-0 leading-none',
+            variant === 'admin' ? 'caption text-muted' : 'text-muted hover:text-ink',
           )}
         >
-          <span className="v3-eyebrow border-b border-soft-border px-1 pb-1 text-[10px] tracking-[0.3em]">
-            Theme
-          </span>
-          {themes.map(t => {
-            const isActive = t.id === effectiveId;
-            return (
-              <button
-                key={t.id}
-                type="button"
-                role="menuitemradio"
-                aria-checked={isActive}
-                onClick={() => onPick(t.id)}
-                className={cn(
-                  'flex w-full items-center gap-2 border px-2 py-1.5 text-left',
-                  isActive
-                    ? 'border-vermilion bg-[var(--ink-softer)]'
-                    : 'border-soft-border bg-bg hover:bg-[var(--overlay)]',
-                )}
-              >
-                <span className="inline-flex shrink-0 border border-ink" aria-hidden="true">
-                  {SWATCH_KEYS.map(k => (
-                    <Swatch key={k} color={t.tokens[k]} />
-                  ))}
-                </span>
-                <span className="grid min-w-0 flex-1 gap-0.5">
-                  <span className="truncate text-[11px] font-bold tracking-[0.12em] uppercase">
-                    {t.name}
-                  </span>
-                  <span className="truncate text-[10px] leading-[1.3] text-muted">
-                    {t.description || (t.mode === 'dark' ? 'Dark palette' : 'Light palette')}
-                  </span>
-                </span>
-              </button>
-            );
-          })}
+          <Palette className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </Dialog.Trigger>
 
-          {/* Reset row — only meaningful when an override is in effect; muted
-              when there's nothing to clear so it doesn't draw the eye. */}
-          <button
-            type="button"
-            role="menuitem"
-            onClick={() => onPick(null)}
-            disabled={!overrideId}
-            className={cn(
-              'mt-1 w-full border-0 bg-transparent px-2 py-1 text-left text-[10px] tracking-[0.2em] text-muted uppercase',
-              overrideId ? 'cursor-pointer hover:text-ink' : 'cursor-default opacity-60',
-            )}
-          >
-            ↺ Use station default
-            {stationActiveId && (
-              <span className="ml-1 normal-case opacity-70">
-                ({themes.find(t => t.id === stationActiveId)?.name ?? stationActiveId})
-              </span>
-            )}
-          </button>
-
-          {/* Player-skin picker — a different face for the whole player, not
-              just a palette. Mirrors the theme rows: listener pick beats the
-              station default until reset. */}
-          {showSkins && skinCtx && (
-            <>
-              <span className="v3-eyebrow mt-2 border-b border-soft-border px-1 pb-1 text-[10px] tracking-[0.3em]">
-                Player skin
-              </span>
-              {skinCtx.skins.map(s => {
-                const isActive = s.id === skinCtx.effectiveId;
-                return (
-                  <button
-                    key={s.id}
-                    type="button"
-                    role="menuitemradio"
-                    aria-checked={isActive}
-                    onClick={() => {
-                      skinCtx.setOverride(s.id);
-                      setOpen(false);
-                      triggerRef.current?.focus();
-                    }}
-                    className={cn(
-                      'flex w-full items-center gap-2 border px-2 py-1.5 text-left',
-                      isActive
-                        ? 'border-vermilion bg-[var(--ink-softer)]'
-                        : 'border-soft-border bg-bg hover:bg-[var(--overlay)]',
-                    )}
-                  >
-                    <LayoutTemplate className="h-4 w-4 shrink-0" aria-hidden="true" />
-                    <span className="grid min-w-0 flex-1 gap-0.5">
-                      <span className="truncate text-[11px] font-bold tracking-[0.12em] uppercase">
-                        {s.name}
-                      </span>
-                      <span className="truncate text-[10px] leading-[1.3] text-muted">
-                        {s.description}
-                      </span>
-                    </span>
-                  </button>
-                );
-              })}
-              <button
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  skinCtx.setOverride(null);
-                  setOpen(false);
-                  triggerRef.current?.focus();
-                }}
-                disabled={!skinCtx.overrideId}
-                className={cn(
-                  'mt-1 w-full border-0 bg-transparent px-2 py-1 text-left text-[10px] tracking-[0.2em] text-muted uppercase',
-                  skinCtx.overrideId ? 'cursor-pointer hover:text-ink' : 'cursor-default opacity-60',
-                )}
-              >
-                ↺ Use station skin
-                <span className="ml-1 normal-case opacity-70">
-                  ({skinCtx.skins.find(s => s.id === skinCtx.stationSkinId)?.name ?? skinCtx.stationSkinId})
-                </span>
-              </button>
-            </>
+      <Dialog.Portal>
+        <Dialog.Overlay className="v3-drawer-overlay fixed inset-0 z-40 bg-overlay [backdrop-filter:blur(6px)] [-webkit-backdrop-filter:blur(6px)]" />
+        <Dialog.Content
+          aria-describedby={undefined}
+          className={cn(
+            'v3-modal-pop fixed top-1/2 left-1/2 z-50 flex flex-col border border-ink bg-bg text-ink shadow-drawer outline-none',
+            '-translate-x-1/2 -translate-y-1/2',
+            'max-h-[calc(100vh-3rem)] w-[min(360px,calc(100vw-2rem))]',
           )}
-
-          {/* Low-power toggle. Drops backdrop blur + animations so weak GPUs
-              (kiosks, Raspberry Pi) stop re-compositing frosted layers every
-              frame. Persists per-browser; a kiosk can also pin it with ?lite=1
-              in its start URL. A top margin sets it off from the theme rows —
-              no section title, by request. */}
-          <button
-            type="button"
-            role="menuitemcheckbox"
-            aria-checked={lite}
-            onClick={() => setLite(!lite)}
-            className={cn(
-              'mt-2 flex w-full items-center gap-2 border px-2 py-1.5 text-left',
-              lite
-                ? 'border-vermilion bg-[var(--ink-softer)]'
-                : 'border-soft-border bg-bg hover:bg-[var(--overlay)]',
-            )}
-          >
-            <Zap className="h-4 w-4 shrink-0" aria-hidden="true" />
-            <span className="grid min-w-0 flex-1 gap-0.5">
-              <span className="truncate text-[11px] font-bold tracking-[0.12em] uppercase">
-                Lite mode
-              </span>
-              <span className="truncate text-[10px] leading-[1.3] text-muted">
-                Improves performance on low-power screens
-              </span>
-            </span>
-            <span
-              className={cn(
-                'shrink-0 text-[10px] font-bold tracking-[0.2em] uppercase',
-                lite ? 'text-vermilion' : 'text-muted',
-              )}
-              aria-hidden="true"
+        >
+          <div className="flex items-baseline justify-between gap-3 border-b border-ink px-5 py-3.5">
+            <Dialog.Title className="v3-eyebrow m-0 text-[12px] tracking-[0.3em]">
+              Appearance
+            </Dialog.Title>
+            <Dialog.Close
+              className="v3-focus cursor-pointer border-0 bg-transparent text-xl leading-none text-muted hover:text-ink"
+              aria-label="Close"
             >
-              {lite ? 'On' : 'Off'}
-            </span>
-          </button>
-        </div>
-      )}
-    </span>
+              ×
+            </Dialog.Close>
+          </div>
+
+          <div className="v3-scroll grid flex-1 gap-1 overflow-auto px-3 py-3">
+            <SectionLabel>Theme</SectionLabel>
+            {themes.map(t => {
+              const isActive = t.id === effectiveId;
+              return (
+                <button
+                  key={t.id}
+                  type="button"
+                  aria-pressed={isActive}
+                  onClick={() => onPickTheme(t.id)}
+                  className={cn(
+                    'v3-focus flex w-full cursor-pointer items-center gap-2 border px-2 py-1.5 text-left',
+                    isActive
+                      ? 'border-vermilion bg-[var(--ink-softer)]'
+                      : 'border-soft-border bg-bg hover:bg-[var(--overlay)]',
+                  )}
+                >
+                  <span className="inline-flex shrink-0 border border-ink" aria-hidden="true">
+                    {SWATCH_KEYS.map(k => (
+                      <Swatch key={k} color={t.tokens[k]} />
+                    ))}
+                  </span>
+                  <span className="grid min-w-0 flex-1 gap-0.5">
+                    <span className="truncate text-[11px] font-bold tracking-[0.12em] uppercase">
+                      {t.name}
+                    </span>
+                    <span className="truncate text-[10px] leading-[1.3] text-muted">
+                      {t.description || (t.mode === 'dark' ? 'Dark palette' : 'Light palette')}
+                    </span>
+                  </span>
+                </button>
+              );
+            })}
+
+            {/* Reset row — only meaningful when an override is in effect; muted
+                when there's nothing to clear so it doesn't draw the eye. */}
+            <button
+              type="button"
+              onClick={() => onPickTheme(null)}
+              disabled={!overrideId}
+              className={cn(
+                'mt-1 w-full border-0 bg-transparent px-2 py-1 text-left text-[10px] tracking-[0.2em] text-muted uppercase',
+                overrideId ? 'v3-focus cursor-pointer hover:text-ink' : 'cursor-default opacity-60',
+              )}
+            >
+              ↺ Use station default
+              {stationActiveId && (
+                <span className="ml-1 normal-case opacity-70">
+                  ({themes.find(t => t.id === stationActiveId)?.name ?? stationActiveId})
+                </span>
+              )}
+            </button>
+
+            {/* Player-skin picker — a different face for the whole player, not
+                just a palette. Mirrors the theme rows: listener pick beats the
+                station default until reset. */}
+            {showSkins && skinCtx && (
+              <>
+                <SectionLabel className="mt-2">Player skin</SectionLabel>
+                {skinCtx.skins.map(s => {
+                  const isActive = s.id === skinCtx.effectiveId;
+                  return (
+                    <button
+                      key={s.id}
+                      type="button"
+                      aria-pressed={isActive}
+                      onClick={() => {
+                        skinCtx.setOverride(s.id);
+                        setOpen(false);
+                      }}
+                      className={cn(
+                        'v3-focus flex w-full cursor-pointer items-center gap-2 border px-2 py-1.5 text-left',
+                        isActive
+                          ? 'border-vermilion bg-[var(--ink-softer)]'
+                          : 'border-soft-border bg-bg hover:bg-[var(--overlay)]',
+                      )}
+                    >
+                      <LayoutTemplate className="h-4 w-4 shrink-0" aria-hidden="true" />
+                      <span className="grid min-w-0 flex-1 gap-0.5">
+                        <span className="truncate text-[11px] font-bold tracking-[0.12em] uppercase">
+                          {s.name}
+                        </span>
+                        <span className="truncate text-[10px] leading-[1.3] text-muted">
+                          {s.description}
+                        </span>
+                      </span>
+                    </button>
+                  );
+                })}
+                <button
+                  type="button"
+                  onClick={() => {
+                    skinCtx.setOverride(null);
+                    setOpen(false);
+                  }}
+                  disabled={!skinCtx.overrideId}
+                  className={cn(
+                    'mt-1 w-full border-0 bg-transparent px-2 py-1 text-left text-[10px] tracking-[0.2em] text-muted uppercase',
+                    skinCtx.overrideId ? 'v3-focus cursor-pointer hover:text-ink' : 'cursor-default opacity-60',
+                  )}
+                >
+                  ↺ Use station skin
+                  <span className="ml-1 normal-case opacity-70">
+                    ({skinCtx.skins.find(s => s.id === skinCtx.stationSkinId)?.name ?? skinCtx.stationSkinId})
+                  </span>
+                </button>
+              </>
+            )}
+
+            {/* Low-power toggle. Drops backdrop blur + animations so weak GPUs
+                (kiosks, Raspberry Pi) stop re-compositing frosted layers every
+                frame. Persists per-browser; a kiosk can also pin it with ?lite=1
+                in its start URL. Stays open on toggle so the effect is visible. */}
+            <button
+              type="button"
+              aria-pressed={lite}
+              onClick={() => setLite(!lite)}
+              className={cn(
+                'v3-focus mt-2 flex w-full cursor-pointer items-center gap-2 border px-2 py-1.5 text-left',
+                lite
+                  ? 'border-vermilion bg-[var(--ink-softer)]'
+                  : 'border-soft-border bg-bg hover:bg-[var(--overlay)]',
+              )}
+            >
+              <Zap className="h-4 w-4 shrink-0" aria-hidden="true" />
+              <span className="grid min-w-0 flex-1 gap-0.5">
+                <span className="truncate text-[11px] font-bold tracking-[0.12em] uppercase">
+                  Lite mode
+                </span>
+                <span className="truncate text-[10px] leading-[1.3] text-muted">
+                  Improves performance on low-power screens
+                </span>
+              </span>
+              <span
+                className={cn(
+                  'shrink-0 text-[10px] font-bold tracking-[0.2em] uppercase',
+                  lite ? 'text-vermilion' : 'text-muted',
+                )}
+                aria-hidden="true"
+              >
+                {lite ? 'On' : 'Off'}
+              </span>
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }

--- a/web/components/skins/drift/DriftSkin.tsx
+++ b/web/components/skins/drift/DriftSkin.tsx
@@ -79,8 +79,8 @@ export default function DriftSkin(_props: SkinProps) {
   const washCRef = useRef<HTMLDivElement | null>(null);
   const c1 = colors.vibrant ?? 'var(--accent)';
   const c2 = colors.average ?? 'var(--muted)';
-  useDynamicStyle(washARef, { '--sw-drift-c': `color-mix(in oklab, ${c1} 22%, transparent)` });
-  useDynamicStyle(washBRef, { '--sw-drift-c': `color-mix(in oklab, ${c2} 26%, transparent)` });
+  useDynamicStyle(washARef, { '--sw-drift-c': `color-mix(in oklab, ${c1} 29%, transparent)` });
+  useDynamicStyle(washBRef, { '--sw-drift-c': `color-mix(in oklab, ${c2} 34%, transparent)` });
   useDynamicStyle(washCRef, { '--sw-drift-c': 'color-mix(in oklab, var(--accent) 10%, transparent)' });
 
   // Progress hairline fill.
@@ -170,11 +170,14 @@ export default function DriftSkin(_props: SkinProps) {
           className="v3-focus cursor-pointer border-0 bg-transparent p-0 text-muted hover:text-ink">+</button>
       </div>
 
-      {/* the ten percent of type */}
+      {/* the ten percent of type. pointer-events-none so this full-screen
+          centering layer doesn't sit over the corner controls (ThemeSwitcher,
+          volume) and eat their clicks — the one interactive child (the title,
+          which tunes in) re-enables events on itself. */}
       {!showTuneIn && (
-        <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 px-6 text-center">
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-4 px-6 text-center">
           {coverSrc && !offline && (
-            <div className="h-[88px] w-[88px] border border-soft-border">
+            <div className="h-[128px] w-[128px] border border-soft-border sm:h-[152px] sm:w-[152px]">
               <img src={coverSrc} alt="" className="h-full w-full object-cover" />
             </div>
           )}
@@ -185,7 +188,7 @@ export default function DriftSkin(_props: SkinProps) {
             <button
               type="button"
               onClick={handleTune}
-              className="v3-focus max-w-full cursor-pointer border-0 bg-transparent p-0 font-display text-[clamp(26px,5vw,46px)] leading-[1.1] font-semibold text-ink"
+              className="v3-focus pointer-events-auto max-w-full cursor-pointer border-0 bg-transparent p-0 font-display text-[clamp(26px,5vw,46px)] leading-[1.1] font-semibold text-ink"
             >
               {nowPlaying?.title ?? 'somewhere on the dial'}
             </button>

--- a/web/components/skins/sharedHooks.ts
+++ b/web/components/skins/sharedHooks.ts
@@ -5,8 +5,16 @@
 // core contexts, per the skin contract (see types.ts); wording and layout
 // stay with each skin.
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { usePlayerActions } from '@/components/player/PlayerCore';
+
+// Poll cadence + give-up window for a submitted request's outcome. Mirrors the
+// classic RequestDrawer (classic/drawers/RequestDrawer.tsx) so every skin gets
+// the same follow-through: accept, then the ack upgrades in place once the DJ
+// picks. The controller resolves within a few seconds; 60s is a generous ceiling
+// after which the accepted line simply stands.
+const POLL_INTERVAL_MS = 1500;
+const POLL_DEADLINE_MS = 60_000;
 
 /** Copy for a request slip's three outcomes, when the controller doesn't
  *  supply its own line — each skin keeps its own voice. */
@@ -25,9 +33,12 @@ export interface RequestSlip {
   /** Optional "from" name — skins without a name field just never set it. */
   name: string;
   setName: (v: string) => void;
-  /** Outcome line to show in place of the form, or null while composing. */
+  /** Outcome line to show in place of the form, or null while composing.
+   *  Upgrades in place: the instant accept ack is replaced by the DJ's on-air
+   *  ack (or the matched track) once the pick resolves, and by the miss copy
+   *  if the booth can't place it. */
   ack: string | null;
-  /** Clear the ack and return to the form. */
+  /** Clear the ack and return to the form. Cancels any in-flight polling. */
   reset: () => void;
   sending: boolean;
   /** Submit the current text. No-op while empty or already sending. */
@@ -37,20 +48,75 @@ export interface RequestSlip {
 /** The request-slip state machine every skin was hand-rolling: compose →
  *  send → show the controller's ack (or the skin's fallback copy) → reset. */
 export function useRequestSlip(copy: RequestSlipCopy): RequestSlip {
-  const { submitRequest } = usePlayerActions();
+  const { submitRequest, pollRequest } = usePlayerActions();
   const [text, setText] = useState('');
   const [name, setName] = useState('');
   const [ack, setAck] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
 
+  // Poll lifecycle held in refs so reset()/unmount can stop an in-flight loop
+  // before a late tick setAck()s onto a torn-down slip.
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pollStopRef = useRef(false);
+  const stopPolling = useCallback(() => {
+    pollStopRef.current = true;
+    if (pollTimerRef.current) {
+      clearTimeout(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  }, []);
+  useEffect(() => stopPolling, [stopPolling]);
+
+  // Poll the controller until the request resolves, fails, or the deadline
+  // passes. The accepted ack holds while pending; on resolve it becomes the
+  // DJ's on-air line (or the matched track), on failure the miss copy.
+  const startPolling = (requestId: string) => {
+    pollStopRef.current = false;
+    const deadline = Date.now() + POLL_DEADLINE_MS;
+    const tick = async () => {
+      if (pollStopRef.current) return;
+      if (Date.now() > deadline) return; // give up quietly; accepted line stands
+      const data = await pollRequest(requestId);
+      if (pollStopRef.current) return;
+      if (data?.status === 'resolved') {
+        const t = data.track;
+        const pos =
+          typeof data.queuePosition === 'number' && data.queuePosition > 0
+            ? ` — #${data.queuePosition} in the queue`
+            : '';
+        setAck(
+          data.ack ||
+            (t?.title
+              ? `Lining up “${t.title}”${t.artist ? ` by ${t.artist}` : ''}${pos}.`
+              : copy.sent),
+        );
+        return;
+      }
+      if (data?.status === 'failed') {
+        setAck(data.message || copy.refused);
+        return;
+      }
+      if (data?.status === 'unknown') return;
+      // pending, or a transient network null — keep polling.
+      pollTimerRef.current = setTimeout(tick, POLL_INTERVAL_MS);
+    };
+    pollTimerRef.current = setTimeout(tick, POLL_INTERVAL_MS);
+  };
+
   const send = async () => {
     const trimmed = text.trim();
     if (!trimmed || sending) return;
+    stopPolling();
     setSending(true);
     try {
       const res = await submitRequest(trimmed, name.trim());
       setAck(res.success ? (res.ack || copy.sent) : (res.message || copy.refused));
-      if (res.success) setText('');
+      if (res.success) {
+        setText('');
+        // Accepted in ~50ms with a request id; the match runs in the booth.
+        // Poll for the real pick so the ack upgrades from "on it" to the answer.
+        if (res.requestId) startPolling(res.requestId);
+      }
     } catch {
       setAck(copy.failed);
     } finally {
@@ -58,7 +124,10 @@ export function useRequestSlip(copy: RequestSlipCopy): RequestSlip {
     }
   };
 
-  const reset = useCallback(() => setAck(null), []);
+  const reset = useCallback(() => {
+    stopPolling();
+    setAck(null);
+  }, [stopPolling]);
   return { text, setText, name, setName, ack, reset, sending, send };
 }
 

--- a/web/components/skins/spool/SpoolSkin.tsx
+++ b/web/components/skins/spool/SpoolSkin.tsx
@@ -119,18 +119,19 @@ export default function SpoolSkin(_props: SkinProps) {
 
   return (
     <div className="absolute inset-0 flex flex-col overflow-y-auto font-sans text-ink">
-      {/* masthead */}
-      <div className="flex flex-none flex-wrap items-center justify-between gap-x-6 gap-y-1 border-b border-soft-border px-5 py-3 sm:px-8">
+      {/* masthead — one row: station line truncates, context is desktop-only,
+          theme icon pinned top-right (never wraps below) */}
+      <div className="flex flex-none items-center justify-between gap-x-6 border-b border-soft-border px-5 py-3 sm:px-8">
         <div className="flex min-w-0 items-center gap-3">
           <span className={cn('h-2.5 w-2.5 flex-none rounded-full', offline ? 'bg-[var(--muted)]' : 'bg-[var(--accent)]')} />
-          <span className="text-[15px] font-extrabold tracking-[0.12em]">{stationName.toUpperCase()}</span>
+          <span className="flex-none text-[15px] font-extrabold tracking-[0.12em]">{stationName.toUpperCase()}</span>
           {showName && (
             <span className="hidden truncate font-mono text-[11px] tracking-[0.18em] uppercase sm:inline">▸ {showName}</span>
           )}
           <span className="truncate font-mono text-[11px] tracking-[0.18em] text-[var(--accent)] uppercase">with {djName}</span>
         </div>
-        <div className="flex min-w-0 items-center gap-3">
-          <span className="truncate font-mono text-[11px] tracking-[0.16em] text-muted uppercase">
+        <div className="flex shrink-0 items-center gap-3">
+          <span className="hidden max-w-[40vw] truncate font-mono text-[11px] tracking-[0.16em] text-muted uppercase sm:inline">
             {contextLine(context)}
           </span>
           <ThemeSwitcher />

--- a/web/components/skins/spool/SpoolSkin.tsx
+++ b/web/components/skins/spool/SpoolSkin.tsx
@@ -253,7 +253,7 @@ export default function SpoolSkin(_props: SkinProps) {
               <button type="button" aria-label="Volume up" onClick={() => adjustVolume(0.05)}
                 className="v3-focus cursor-pointer border-0 bg-transparent px-1 font-mono text-[13px] text-muted hover:text-ink">+</button>
             </div>
-            <div className="ml-auto font-mono text-[10px] tracking-[0.14em] text-muted uppercase">
+            <div className="ml-auto font-mono text-[10px] tracking-[0.14em] whitespace-nowrap text-muted uppercase">
               {offline
                 ? 'off air'
                 : [

--- a/web/components/skins/spool/SpoolSkin.tsx
+++ b/web/components/skins/spool/SpoolSkin.tsx
@@ -137,7 +137,7 @@ export default function SpoolSkin(_props: SkinProps) {
         </div>
       </div>
 
-      <div className="mx-auto grid w-full max-w-[1280px] flex-1 grid-cols-1 gap-8 p-5 sm:p-9 lg:grid-cols-[240px_1fr_240px]">
+      <div className="grid w-full flex-1 grid-cols-1 gap-8 p-5 sm:p-9 lg:grid-cols-[280px_1fr_280px]">
         {/* recently rewound */}
         <div className="order-3 flex flex-col gap-3 lg:order-1">
           <div className="font-mono text-[10px] font-bold tracking-[0.2em] uppercase">Recently rewound</div>
@@ -157,7 +157,7 @@ export default function SpoolSkin(_props: SkinProps) {
         </div>
 
         {/* the deck */}
-        <div className="order-1 flex min-w-0 flex-col gap-4 lg:order-2">
+        <div className="order-1 flex min-w-0 flex-col gap-4 lg:order-2 lg:justify-center">
           <div className="flex flex-col gap-4 border border-ink bg-[var(--field)] p-4 sm:p-5">
             {/* cassette label */}
             <div className="border border-ink bg-bg">

--- a/web/components/skins/subamp/SubampSkin.tsx
+++ b/web/components/skins/subamp/SubampSkin.tsx
@@ -288,7 +288,8 @@ export default function SubampSkin(_props: SkinProps) {
           className="flex min-h-0 flex-1 flex-col lg:block lg:flex-none"
         >
           <ScrollArea className="min-h-0 flex-1 lg:max-h-[200px]">
-            <div className="flex flex-col gap-1.5 px-4 py-2.5">
+            {/* pr-5 leaves a gutter so the times clear the overlaid scrollbar */}
+            <div className="flex flex-col gap-1.5 py-2.5 pr-5 pl-4">
               {history.map((h, i) => (
                 <div key={`${h.t ?? i}-${h.title ?? i}`} className="flex gap-2.5 text-[11px] tracking-[0.06em] text-muted uppercase">
                   <span>{i + 1}.</span>
@@ -298,7 +299,7 @@ export default function SubampSkin(_props: SkinProps) {
                   <span>{turnClock(entryTime(h), timezone, stationLocale)}</span>
                 </div>
               ))}
-              <div className="-mx-2 flex gap-2.5 bg-[var(--field)] px-2 py-0.5 text-[11px] font-bold tracking-[0.06em] text-[var(--accent)] uppercase">
+              <div className="-ml-4 flex gap-2.5 bg-[var(--field)] py-0.5 pl-4 text-[11px] font-bold tracking-[0.06em] text-[var(--accent)] uppercase">
                 <span>{history.length + 1}.</span>
                 <span className="min-w-0 flex-1 truncate">
                   ▶ {offline ? '— off air —' : (nowPlaying?.title ?? 'scanning…')}

--- a/web/components/skins/subamp/SubampSkin.tsx
+++ b/web/components/skins/subamp/SubampSkin.tsx
@@ -11,6 +11,7 @@
 import { useRef, useState, type ReactNode } from 'react';
 import styles from './Subamp.module.css';
 import Analyzer from './Analyzer';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   usePlayerActions,
   usePlayerAudio,
@@ -91,9 +92,9 @@ export default function SubampSkin(_props: SkinProps) {
     activeShow?.persona?.name || (typeof dj?.name === 'string' ? dj.name : '') || 'the DJ';
   const showName = activeShow?.name || context?.time?.show || '';
   const meta = trackMeta(nowPlaying);
-  const booth = boothLines(session.messages, 3);
+  const booth = boothLines(session.messages, 24);
   const upNext = state.upcoming?.[0];
-  const history = (state.history ?? []).slice(0, 3).reverse(); // oldest first
+  const history = (state.history ?? []).slice(0, 24).reverse(); // oldest first
   const playing = tunedIn && status === 'playing' && !offline;
 
   const adjustVolume = useVolumeNudge();
@@ -158,7 +159,7 @@ export default function SubampSkin(_props: SkinProps) {
         double-click a titlebar to roll it up
       </div>
 
-      <div className="relative mx-auto flex min-h-full w-full max-w-[580px] flex-col justify-center gap-2 px-3 py-14">
+      <div className="relative mx-auto flex w-full max-w-[580px] flex-col justify-start gap-2 px-3 pt-12 pb-6 lg:min-h-full lg:justify-center lg:py-14">
         {/* ── deck ─────────────────────────────────────────── */}
         <Window title={<>SUBAMP ▪ LIVE BROADCAST DECK</>}>
           <div className="flex flex-col gap-3 px-4 py-3.5">
@@ -268,65 +269,70 @@ export default function SubampSkin(_props: SkinProps) {
 
         {/* ── booth ────────────────────────────────────────── */}
         <Window title={<>BOOTH FEED ▪ {djName.toUpperCase()}</>}>
-          <div className="flex flex-col gap-2 px-4 py-3">
-            {booth.length === 0 && (
-              <div className="text-[11px] text-muted">waiting for the booth…</div>
-            )}
-            {booth.map((line, i) => (
-              <div key={`${line.t ?? i}-${i}`} className="text-[12px] leading-relaxed break-words">
-                {line.kind === 'voice' ? (
-                  <>
-                    <span className="text-muted">{turnClock(line.t, timezone, stationLocale)}</span>{' '}
-                    <span className="font-bold text-[var(--accent)]">{djName.toUpperCase()} ●</span>{' '}
-                    “{line.text}”
-                  </>
-                ) : (
-                  <span className="text-[11px] text-muted">
-                    {turnClock(line.t, timezone, stationLocale)} {line.kind === 'dj' ? 'dj' : 'sys'} ▸ {line.text}
-                  </span>
-                )}
-              </div>
-            ))}
-          </div>
+          <ScrollArea className="max-h-[240px]">
+            <div className="flex flex-col gap-2 px-4 py-3">
+              {booth.length === 0 && (
+                <div className="text-[11px] text-muted">waiting for the booth…</div>
+              )}
+              {booth.map((line, i) => (
+                <div key={`${line.t ?? i}-${i}`} className="text-[12px] leading-relaxed break-words">
+                  {line.kind === 'voice' ? (
+                    <>
+                      <span className="text-muted">{turnClock(line.t, timezone, stationLocale)}</span>{' '}
+                      <span className="font-bold text-[var(--accent)]">{djName.toUpperCase()} ●</span>{' '}
+                      “{line.text}”
+                    </>
+                  ) : (
+                    <span className="text-[11px] text-muted">
+                      {turnClock(line.t, timezone, stationLocale)} {line.kind === 'dj' ? 'dj' : 'sys'} ▸ {line.text}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </ScrollArea>
         </Window>
 
         {/* ── station log ──────────────────────────────────── */}
         <Window
           title={<>STATION LOG{listenerCount != null ? ` ▪ ${listenerCount} LISTENING` : ''}</>}
         >
-          <div className="flex flex-col gap-1.5 px-4 py-2.5">
-            {history.map((h, i) => (
-              <div key={`${h.t ?? i}-${h.title ?? i}`} className="flex gap-2.5 text-[11px] tracking-[0.06em] text-muted uppercase">
-                <span>{i + 1}.</span>
+          <ScrollArea className="max-h-[200px]">
+            <div className="flex flex-col gap-1.5 px-4 py-2.5">
+              {history.map((h, i) => (
+                <div key={`${h.t ?? i}-${h.title ?? i}`} className="flex gap-2.5 text-[11px] tracking-[0.06em] text-muted uppercase">
+                  <span>{i + 1}.</span>
+                  <span className="min-w-0 flex-1 truncate">
+                    {h.title ?? '?'}{h.artist ? ` — ${h.artist}` : ''}
+                  </span>
+                  <span>{turnClock(entryTime(h), timezone, stationLocale)}</span>
+                </div>
+              ))}
+              <div className="-mx-2 flex gap-2.5 bg-[var(--field)] px-2 py-0.5 text-[11px] font-bold tracking-[0.06em] text-[var(--accent)] uppercase">
+                <span>{history.length + 1}.</span>
                 <span className="min-w-0 flex-1 truncate">
-                  {h.title ?? '?'}{h.artist ? ` — ${h.artist}` : ''}
+                  ▶ {offline ? '— off air —' : (nowPlaying?.title ?? 'scanning…')}
+                  {!offline && nowPlaying?.artist ? ` — ${nowPlaying.artist}` : ''}
                 </span>
-                <span>{turnClock(entryTime(h), timezone, stationLocale)}</span>
+                <span>{fmtTime(elapsed)}</span>
               </div>
-            ))}
-            <div className="-mx-2 flex gap-2.5 bg-[var(--field)] px-2 py-0.5 text-[11px] font-bold tracking-[0.06em] text-[var(--accent)] uppercase">
-              <span>{history.length + 1}.</span>
-              <span className="min-w-0 flex-1 truncate">
-                ▶ {offline ? '— off air —' : (nowPlaying?.title ?? 'scanning…')}
-                {!offline && nowPlaying?.artist ? ` — ${nowPlaying.artist}` : ''}
-              </span>
-              <span>{fmtTime(elapsed)}</span>
+              {upNext?.title && (
+                <div className="flex gap-2.5 text-[11px] tracking-[0.06em] text-muted uppercase">
+                  <span>{history.length + 2}.</span>
+                  <span className="min-w-0 flex-1 truncate">
+                    {upNext.title}{upNext.artist ? ` — ${upNext.artist}` : ''}
+                  </span>
+                  <span>queued</span>
+                </div>
+              )}
             </div>
-            {upNext?.title && (
-              <div className="flex gap-2.5 text-[11px] tracking-[0.06em] text-muted uppercase">
-                <span>{history.length + 2}.</span>
-                <span className="min-w-0 flex-1 truncate">
-                  {upNext.title}{upNext.artist ? ` — ${upNext.artist}` : ''}
-                </span>
-                <span>queued</span>
-              </div>
-            )}
+          </ScrollArea>
 
-            {/* request line */}
-            <form
-              className="mt-1 flex items-baseline gap-2.5 border-t border-soft-border pt-2"
-              onSubmit={e => { e.preventDefault(); void slip.send(); }}
-            >
+          {/* request line — pinned below the scrolling log */}
+          <form
+            className="mx-4 mb-3 flex items-baseline gap-2.5 border-t border-soft-border pt-2"
+            onSubmit={e => { e.preventDefault(); void slip.send(); }}
+          >
               <span className="flex-none text-[10px] tracking-[0.14em] text-muted select-none">DEAR DJ —</span>
               {slip.ack ? (
                 <>
@@ -363,7 +369,6 @@ export default function SubampSkin(_props: SkinProps) {
                 </>
               )}
             </form>
-          </div>
         </Window>
       </div>
     </div>

--- a/web/components/skins/subamp/SubampSkin.tsx
+++ b/web/components/skins/subamp/SubampSkin.tsx
@@ -47,13 +47,13 @@ function Grip() {
 
 /** A Subamp window: dotted-grip titlebar, faux buttons, roll-up on
  *  double-click (or the ▁ button). */
-function Window({ title, children }: { title: ReactNode; children: ReactNode }) {
+function Window({ title, children, className }: { title: ReactNode; children: ReactNode; className?: string }) {
   const [open, setOpen] = useState(true);
   return (
-    <div className="border border-soft-border bg-bg">
+    <div className={cn('border border-soft-border bg-bg', className)}>
       <div
         onDoubleClick={() => setOpen(o => !o)}
-        className="flex items-center gap-2.5 border-b border-soft-border bg-[var(--field)] px-2.5 py-1 select-none"
+        className="flex shrink-0 items-center gap-2.5 border-b border-soft-border bg-[var(--field)] px-2.5 py-1 select-none"
       >
         <Grip />
         <span className="truncate text-[9px] font-bold tracking-[0.24em] uppercase">{title}</span>
@@ -131,7 +131,7 @@ export default function SubampSkin(_props: SkinProps) {
   const digits = showTuneIn || offline ? '--:--' : fmtTime(elapsed);
 
   return (
-    <div className="absolute inset-0 overflow-y-auto font-mono text-ink">
+    <div className="absolute inset-0 overflow-hidden font-mono text-ink lg:overflow-y-auto">
       <div
         className="pointer-events-none absolute inset-0 bg-[radial-gradient(70%_70%_at_50%_42%,color-mix(in_oklab,var(--accent)_5%,transparent),transparent)]"
         aria-hidden="true"
@@ -141,27 +141,16 @@ export default function SubampSkin(_props: SkinProps) {
       <div className="absolute top-7 left-9 hidden text-[10px] tracking-[0.24em] text-muted uppercase lg:block">
         {stationName} — {showName ? `${showName} with ${djName}` : `with ${djName}`}
       </div>
-      <div className="absolute top-6 right-4 z-10 flex items-center gap-3 lg:top-7 lg:right-9">
+      <div className="absolute top-3 right-3 z-10 flex items-center gap-3 lg:top-7 lg:right-9">
         <span className="hidden text-[10px] tracking-[0.24em] text-muted uppercase lg:inline">
           {[clock ? turnClock(clock.getTime(), timezone, stationLocale) : '', contextLine(context)]
             .filter(Boolean).join(' · ')}
         </span>
         <ThemeSwitcher />
       </div>
-      <div className="absolute bottom-7 left-9 hidden text-[10px] tracking-[0.18em] text-muted uppercase lg:block">
-        {offline
-          ? 'off air'
-          : tunedIn
-            ? ['tuned', signal.latencyMs != null ? `sig ${signal.quality} · ${signal.latencyMs} ms` : ''].filter(Boolean).join(' ▪ ')
-            : 'standing by'}
-      </div>
-      <div className="absolute right-9 bottom-7 hidden text-[10px] tracking-[0.18em] text-muted uppercase lg:block">
-        double-click a titlebar to roll it up
-      </div>
-
-      <div className="relative mx-auto flex w-full max-w-[580px] flex-col justify-start gap-2 px-3 pt-12 pb-6 lg:min-h-full lg:justify-center lg:py-14">
+      <div className="relative mx-auto flex h-full w-full max-w-[580px] flex-col gap-2 px-3 pt-9 pb-3 lg:h-auto lg:min-h-full lg:justify-center lg:py-14">
         {/* ── deck ─────────────────────────────────────────── */}
-        <Window title={<>SUBAMP ▪ LIVE BROADCAST DECK</>}>
+        <Window title={<>SUBAMP ▪ LIVE BROADCAST DECK</>} className="flex-none">
           <div className="flex flex-col gap-3 px-4 py-3.5">
             <div className="flex items-stretch gap-3.5">
               <div className="flex flex-col justify-center gap-1">
@@ -268,8 +257,8 @@ export default function SubampSkin(_props: SkinProps) {
         </Window>
 
         {/* ── booth ────────────────────────────────────────── */}
-        <Window title={<>BOOTH FEED ▪ {djName.toUpperCase()}</>}>
-          <ScrollArea className="max-h-[240px]">
+        <Window title={<>BOOTH FEED ▪ {djName.toUpperCase()}</>} className="flex min-h-0 flex-1 flex-col lg:block lg:flex-none">
+          <ScrollArea className="min-h-0 flex-1 lg:max-h-[240px]">
             <div className="flex flex-col gap-2 px-4 py-3">
               {booth.length === 0 && (
                 <div className="text-[11px] text-muted">waiting for the booth…</div>
@@ -296,8 +285,9 @@ export default function SubampSkin(_props: SkinProps) {
         {/* ── station log ──────────────────────────────────── */}
         <Window
           title={<>STATION LOG{listenerCount != null ? ` ▪ ${listenerCount} LISTENING` : ''}</>}
+          className="flex min-h-0 flex-1 flex-col lg:block lg:flex-none"
         >
-          <ScrollArea className="max-h-[200px]">
+          <ScrollArea className="min-h-0 flex-1 lg:max-h-[200px]">
             <div className="flex flex-col gap-1.5 px-4 py-2.5">
               {history.map((h, i) => (
                 <div key={`${h.t ?? i}-${h.title ?? i}`} className="flex gap-2.5 text-[11px] tracking-[0.06em] text-muted uppercase">
@@ -330,7 +320,7 @@ export default function SubampSkin(_props: SkinProps) {
 
           {/* request line — pinned below the scrolling log */}
           <form
-            className="mx-4 mb-3 flex items-baseline gap-2.5 border-t border-soft-border pt-2"
+            className="mx-4 mb-3 flex shrink-0 items-baseline gap-2.5 border-t border-soft-border pt-2"
             onSubmit={e => { e.preventDefault(); void slip.send(); }}
           >
               <span className="flex-none text-[10px] tracking-[0.14em] text-muted select-none">DEAR DJ —</span>

--- a/web/components/skins/tty/TtySkin.tsx
+++ b/web/components/skins/tty/TtySkin.tsx
@@ -119,7 +119,7 @@ export default function TtySkin(_props: SkinProps) {
 
   return (
     <div className="absolute inset-0 overflow-y-auto p-4 font-mono text-[13px] leading-relaxed text-ink sm:p-7">
-      <div className="mx-auto flex min-h-full max-w-[1200px] flex-col gap-3.5">
+      <div className="flex min-h-full w-full flex-col gap-3.5">
 
         {/* header bar */}
         <div className="flex flex-none flex-wrap items-baseline justify-between gap-x-4 gap-y-1 border border-soft-border px-4 py-2.5">

--- a/web/components/skins/tty/TtySkin.tsx
+++ b/web/components/skins/tty/TtySkin.tsx
@@ -20,6 +20,7 @@ import ThemeSwitcher from '@/components/ThemeSwitcher';
 import { cn } from '@/lib/cn';
 import { fmtTime, normalizeStationLocale } from '@/lib/format';
 import { useStationClient } from '@/lib/stationClient';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   boothLines,
   contextLine,
@@ -63,7 +64,7 @@ export default function TtySkin(_props: SkinProps) {
   const showName = activeShow?.name;
   const meta = trackMeta(nowPlaying);
   const ratio = progressRatio(elapsed, nowPlaying?.duration);
-  const booth = boothLines(session.messages, 5);
+  const booth = boothLines(session.messages, 24);
   const upNext = state.upcoming?.[0];
 
   const adjustVolume = useVolumeNudge();
@@ -112,25 +113,26 @@ export default function TtySkin(_props: SkinProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showTuneIn, offline]);
 
-  const history = (state.history ?? []).slice(0, logDeep ? 10 : 3);
+  const history = (state.history ?? []).slice(0, logDeep ? 40 : 12);
   const filled = ratio == null ? 0 : Math.round(ratio * PROGRESS_CELLS);
   const volFilled = Math.round(volume * VOL_CELLS);
   const coverId = nowPlaying?.subsonic_id;
 
   return (
-    <div className="absolute inset-0 overflow-y-auto p-4 font-mono text-[13px] leading-relaxed text-ink sm:p-7">
-      <div className="flex min-h-full w-full flex-col gap-3.5">
+    <div className="absolute inset-0 overflow-hidden p-4 font-mono text-[13px] leading-relaxed text-ink sm:p-7">
+      <div className="flex h-full w-full flex-col gap-3.5">
 
-        {/* header bar */}
-        <div className="flex flex-none flex-wrap items-baseline justify-between gap-x-4 gap-y-1 border border-soft-border px-4 py-2.5">
+        {/* header bar — station line truncates; context is desktop-only so
+            mobile stays one clean row with the theme icon pinned right */}
+        <div className="flex flex-none items-center justify-between gap-x-4 border border-soft-border px-4 py-2.5">
           <div className="min-w-0 truncate text-[13px] tracking-[0.1em]">
             <span className={cn(offline ? 'text-muted' : 'text-[var(--accent)]')}>●</span>{' '}
             <span className="font-bold">{stationName.toUpperCase()}</span>
             {showName ? <> ▸ {showName.toUpperCase()}</> : null}
             <span className="text-[var(--accent)]"> — WITH {djName.toUpperCase()}</span>
           </div>
-          <div className="flex min-w-0 items-center gap-3">
-            <span className="truncate text-[12px] tracking-[0.1em] text-muted uppercase">
+          <div className="flex shrink-0 items-center gap-3">
+            <span className="hidden max-w-[40vw] truncate text-[12px] tracking-[0.1em] text-muted uppercase sm:inline">
               {[contextLine(context), clock ? turnClock(clock.getTime(), timezone, stationLocale) : '']
                 .filter(Boolean).join(' · ')}
             </span>
@@ -138,11 +140,12 @@ export default function TtySkin(_props: SkinProps) {
           </div>
         </div>
 
-        {/* now playing + booth */}
-        <div className="grid flex-1 grid-cols-1 gap-3.5 lg:grid-cols-[1fr_380px]">
-          <section className="flex min-w-0 flex-col gap-4 border border-soft-border px-5 py-5 sm:px-7">
+        {/* now playing + booth — fills most of the middle; stacked on mobile
+            (now-playing auto, booth fills + scrolls), side-by-side on lg */}
+        <div className="grid min-h-0 flex-[2] grid-cols-1 grid-rows-[auto_minmax(0,1fr)] gap-3.5 lg:grid-cols-[1fr_380px] lg:grid-rows-1">
+          <section className="flex min-h-0 min-w-0 flex-col gap-4 overflow-y-auto border border-soft-border px-5 py-5 sm:px-7">
             <Rule>NOW PLAYING</Rule>
-            <div className="flex min-w-0 flex-col-reverse items-start gap-6 sm:flex-row">
+            <div className="flex min-w-0 flex-row items-start gap-4 sm:gap-6">
               <div className="flex min-w-0 flex-1 flex-col gap-3">
                 <div className="text-[clamp(22px,4vw,46px)] leading-[1.05] font-extrabold tracking-[0.06em] uppercase">
                   {offline ? <span className="text-muted">— OFF AIR —</span> : (nowPlaying?.title ?? 'SCANNING…')}
@@ -195,31 +198,36 @@ export default function TtySkin(_props: SkinProps) {
             </div>
           </section>
 
-          <section className="flex min-w-0 flex-col gap-3 border border-soft-border px-5 py-4">
+          <section className="flex min-h-0 min-w-0 flex-col gap-3 border border-soft-border px-5 py-4">
             <Rule>BOOTH · tail -f</Rule>
-            {booth.length === 0 && (
-              <div className="text-[12px] text-muted">▸ waiting for the booth…</div>
-            )}
-            {booth.map((line, i) => (
-              <div key={`${line.t ?? i}-${i}`} className="text-[12px] leading-relaxed break-words">
-                <span className="text-muted">{turnClock(line.t, timezone, stationLocale)}</span>{' '}
-                {line.kind === 'voice' ? (
-                  <>
-                    <span className="font-bold text-[var(--accent)]">{djName.toUpperCase()} ●</span>{' '}
-                    <span>“{line.text}”</span>
-                  </>
-                ) : (
-                  <span className="text-muted">{line.kind === 'dj' ? 'dj' : 'sys'} ▸ {line.text}</span>
+            <ScrollArea className="-mx-5 min-h-0 flex-1">
+              <div className="flex flex-col gap-3 px-5">
+                {booth.length === 0 && (
+                  <div className="text-[12px] text-muted">▸ waiting for the booth…</div>
                 )}
+                {booth.map((line, i) => (
+                  <div key={`${line.t ?? i}-${i}`} className="text-[12px] leading-relaxed break-words">
+                    <span className="text-muted">{turnClock(line.t, timezone, stationLocale)}</span>{' '}
+                    {line.kind === 'voice' ? (
+                      <>
+                        <span className="font-bold text-[var(--accent)]">{djName.toUpperCase()} ●</span>{' '}
+                        <span>“{line.text}”</span>
+                      </>
+                    ) : (
+                      <span className="text-muted">{line.kind === 'dj' ? 'dj' : 'sys'} ▸ {line.text}</span>
+                    )}
+                  </div>
+                ))}
               </div>
-            ))}
+            </ScrollArea>
             <div className={cn('text-[12px] text-muted', styles.cursor)}>▊</div>
           </section>
         </div>
 
-        {/* up next + last */}
-        <div className="grid flex-none grid-cols-1 gap-3.5 sm:grid-cols-2">
-          <section className="flex min-w-0 flex-col gap-2.5 border border-soft-border px-5 py-4">
+        {/* up next + last — last fills + scrolls; stacked on mobile,
+            side-by-side from sm */}
+        <div className="grid min-h-0 flex-[1] grid-cols-1 grid-rows-[auto_minmax(0,1fr)] gap-3.5 sm:grid-cols-2 sm:grid-rows-1">
+          <section className="flex min-h-0 min-w-0 flex-col gap-2.5 border border-soft-border px-5 py-4">
             <Rule>UP NEXT</Rule>
             {upNext?.title ? (
               <>
@@ -235,16 +243,20 @@ export default function TtySkin(_props: SkinProps) {
               <div className="text-[12px] text-muted">queue empty — the DJ decides at the wire</div>
             )}
           </section>
-          <section className="flex min-w-0 flex-col gap-2 border border-soft-border px-5 py-4">
+          <section className="flex min-h-0 min-w-0 flex-col gap-2 border border-soft-border px-5 py-4">
             <Rule>LAST</Rule>
-            {history.length === 0 && <div className="text-[12px] text-muted">nothing yet this session</div>}
-            {history.map((h, i) => (
-              <div key={`${h.t ?? i}-${h.title ?? i}`} className="truncate text-[12px] uppercase">
-                <span className="text-muted">{turnClock(entryTime(h), timezone, stationLocale)}</span>{' '}
-                {h.title ?? '?'}
-                {h.artist && <span className="text-muted"> — {h.artist}</span>}
+            <ScrollArea className="-mx-5 min-h-0 flex-1">
+              <div className="flex flex-col gap-2 px-5">
+                {history.length === 0 && <div className="text-[12px] text-muted">nothing yet this session</div>}
+                {history.map((h, i) => (
+                  <div key={`${h.t ?? i}-${h.title ?? i}`} className="truncate text-[12px] uppercase">
+                    <span className="text-muted">{turnClock(entryTime(h), timezone, stationLocale)}</span>{' '}
+                    {h.title ?? '?'}
+                    {h.artist && <span className="text-muted"> — {h.artist}</span>}
+                  </div>
+                ))}
               </div>
-            ))}
+            </ScrollArea>
           </section>
         </div>
 
@@ -295,17 +307,6 @@ export default function TtySkin(_props: SkinProps) {
             >
               {offline ? 'OFF AIR' : tunedIn ? (status === 'playing' ? 'TUNED ●' : 'TUNING…') : '▶ TUNE IN'}
             </button>
-            <span className="inline-flex items-baseline gap-1.5">
-              <button type="button" aria-label="Volume down" onClick={() => adjustVolume(-0.125)}
-                className="v3-focus cursor-pointer border-0 bg-transparent p-0 text-muted hover:text-ink">−</button>
-              <span aria-label={`Volume ${Math.round(volume * 100)}%`}>
-                VOL <span className="text-ink">{'█'.repeat(volFilled)}</span>
-                <span className="text-muted">{'░'.repeat(VOL_CELLS - volFilled)}</span>{' '}
-                {Math.round(volume * 100)}
-              </span>
-              <button type="button" aria-label="Volume up" onClick={() => adjustVolume(0.125)}
-                className="v3-focus cursor-pointer border-0 bg-transparent p-0 text-muted hover:text-ink">+</button>
-            </span>
             <button
               type="button"
               onClick={toggleMute}
@@ -318,15 +319,15 @@ export default function TtySkin(_props: SkinProps) {
               {muted ? 'MUTED' : 'MUTE'}
             </button>
             {signal.latencyMs != null && tunedIn && (
-              <span className="text-muted uppercase">SIG {signal.latencyMs} MS · {signal.quality}</span>
+              <span className="hidden text-muted uppercase sm:inline">SIG {signal.latencyMs} MS · {signal.quality}</span>
             )}
             {listenerCount != null && (
-              <span className="text-muted uppercase">{listenerCount} LISTENING</span>
+              <span className="hidden text-muted uppercase sm:inline">{listenerCount} LISTENING</span>
             )}
             <button
               type="button"
               onClick={() => setReqOpen(true)}
-              className="v3-focus ml-auto cursor-pointer border-0 bg-transparent p-0 font-bold text-[var(--accent)] uppercase"
+              className="v3-focus cursor-pointer border-0 bg-transparent p-0 font-bold text-[var(--accent)] uppercase"
             >
               :req SEND A REQUEST
             </button>
@@ -337,6 +338,18 @@ export default function TtySkin(_props: SkinProps) {
             >
               :log {logDeep ? 'SHORT LOG' : 'FULL LOG'}
             </button>
+            {/* volume floats to the right end of the status line */}
+            <span className="ml-auto inline-flex items-baseline gap-1.5">
+              <button type="button" aria-label="Volume down" onClick={() => adjustVolume(-0.125)}
+                className="v3-focus cursor-pointer border-0 bg-transparent p-0 text-muted hover:text-ink">−</button>
+              <span aria-label={`Volume ${Math.round(volume * 100)}%`}>
+                VOL <span className="text-ink">{'█'.repeat(volFilled)}</span>
+                <span className="text-muted">{'░'.repeat(VOL_CELLS - volFilled)}</span>{' '}
+                {Math.round(volume * 100)}
+              </span>
+              <button type="button" aria-label="Volume up" onClick={() => adjustVolume(0.125)}
+                className="v3-focus cursor-pointer border-0 bg-transparent p-0 text-muted hover:text-ink">+</button>
+            </span>
           </div>
         )}
       </div>


### PR DESCRIPTION
## What

Stacks on #995. In the new shell+skin player, the four new skins (Spool, Drift, Subamp, TTY) all submit requests through the shared `useRequestSlip` hook — which stopped at the controller's **instant accept** and never polled for the outcome. So a listener submitted a request and saw *"request received — the DJ is on it"*, then never learned which track was matched or where it landed. Classic's `RequestDrawer` polls `pollRequest`; the new skins didn't. (Gap #2 from the #995 review.)

## Fix

Wire `pollRequest` into `useRequestSlip` — same cadence as the classic drawer (1.5s poll, 60s deadline). The `ack` line now **upgrades in place**:

- **accepted** → the DJ's on-air ack (or a composed `Lining up "<title>" by <artist> — #N in the queue.` when the controller sends no ack line) on `resolved`
- **miss copy** on `failed`
- accepted line simply stands on `unknown` / deadline

Poll lifecycle is held in refs so `reset()` and unmount cancel any in-flight loop before a late tick writes `setAck` onto a torn-down slip.

**No skin-side changes** — all four skins already render `slip.ack`, so they light up through the shared hook. `pollRequest` was already exposed on the core (`PlayerCore.tsx`); only the shared hook needed wiring.

## Tested

- `web` `npm run lint` (eslint + `tsc --noEmit`) clean.
- Single-file change: `web/components/skins/sharedHooks.ts` (+75/-6).

## Note

Merge target is `feat/modular-player-skins` so this stacks on #995 rather than dragging the whole feature branch into a develop diff. Retarget to `develop` if #995 lands first.