### PR TITLE
fix(controller): clip over-length programme plan fields instead of discarding the whole plan

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -10,7 +10,7 @@ import assert from 'node:assert/strict';
 import { z } from 'zod';
 import { generateText, APICallError } from 'ai';
 import { MockLanguageModelV3 } from 'ai/test';
-import { stripThinking, truncationError, extractJson, usageOf, perfOf, warningsOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded, isRateLimited, errReason, nearestId, isElevenLabsV3, snapV3Stability, modelTolerant, schemaHint } from '../src/llm/internal/core/pure.js';
+import { stripThinking, truncationError, extractJson, usageOf, perfOf, warningsOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded, isRateLimited, errReason, nearestId, isElevenLabsV3, snapV3Stability, modelTolerant, schemaHint, clipText } from '../src/llm/internal/core/pure.js';
 import { withDeadline, withTransientRetry, retryAfterMs } from '../src/llm/internal/core/retry.js';
 import { reasoningFor, needsToolCallObject, repeatPenaltyApplies, appliedNumCtx, appliedRepeatPenalty, forcedToolChoice } from '../src/llm/internal/provider/capabilities.js';
 import { agentPlan } from '../src/llm/internal/strategy/plan.js';
@@ -20,6 +20,7 @@ import { DEFAULT_LOCCA_EMBED_BASE_URL, openAICompatibleFetch } from '../src/llm/
 import { personaToneDirectives, normalizeDial, DIAL_NEUTRAL, validatePersonasStrict, clampTtsSpeed, TTS_SPEED_DEFAULT, clampMaxOutputTokens, resolveMaxOutputTokens, MAX_OUTPUT_TOKENS_MIN, MAX_OUTPUT_TOKENS_MAX, effectiveFrequency, SCRIPT_LENGTHS } from '../src/settings.js';
 import { lengthMode, lengthPhrase } from '../src/llm/internal/prompts/system.js';
 import { showMusicLean } from '../src/llm/internal/prompts/picker.js';
+import { planSchema } from '../src/llm/internal/prompts/programme.js';
 import { resolveCloudModel } from '../src/llm/internal/speech/cloud-speech.js';
 
 let failures = 0;
@@ -1169,6 +1170,59 @@ async function main() {
     assert.equal(hint.includes(longDescription), false);
     assert.equal(hint.includes('the exact id'), false);
     assert.equal(hint.includes('"description"'), false);
+  });
+
+  console.log('clipText (soft length caps for model free-text):');
+  await test('clips over-length text on a word boundary', () => {
+    const s = 'one two three four five six seven eight nine ten';
+    const out = clipText(s, 20) as string;
+    assert.ok(out.length <= 20, `len ${out.length} <= 20`);
+    assert.equal(out, 'one two three four', 'trimmed to a whole word, no dangling partial');
+  });
+  await test('passes through text at or under the cap untouched', () => {
+    assert.equal(clipText('short', 20), 'short');
+    assert.equal(clipText('exactly-twenty-chars', 20), 'exactly-twenty-chars');
+  });
+  await test('hard-cuts when no early word boundary exists (one very long token)', () => {
+    const out = clipText('x'.repeat(50), 20) as string;
+    assert.equal(out.length, 20, 'a single long token still gets capped');
+  });
+  await test('leaves non-strings for the schema to reject', () => {
+    assert.equal(clipText(undefined, 20), undefined);
+    assert.equal(clipText(42, 20), 42);
+    assert.equal(clipText(null, 20), null);
+  });
+
+  console.log('programme planSchema (the 207-char angle regression — a soft cap, clipped not rejected):');
+  await test('clips an over-length angle/topic instead of throwing away the whole plan', () => {
+    const overLongAngle = 'contractual malice '.repeat(20).trim(); // ~380 chars
+    const overLongTopic = 'read the memo aloud '.repeat(20).trim();
+    const plan: any = planSchema(1).parse({
+      angle: overLongAngle,
+      introNote: 'set the tone',
+      features: [{ topic: overLongTopic, kind: 'memo-from-upstairs' }],
+      outroNote: 'walk out',
+    });
+    assert.ok(plan.angle.length <= 200, `angle clipped to <=200 (was ${overLongAngle.length})`);
+    assert.ok(plan.features[0].topic.length <= 240, 'topic clipped to <=240');
+    assert.equal(plan.features[0].kind, 'memo-from-upstairs', 'the rest of the plan survives intact');
+  });
+  await test('leaves a within-cap plan untouched', () => {
+    const plan: any = planSchema(1).parse({
+      angle: 'a tight editorial line',
+      introNote: 'open warm',
+      features: [{ topic: 'the b-side story', kind: null }],
+      outroNote: 'sign off',
+    });
+    assert.equal(plan.angle, 'a tight editorial line');
+    assert.equal(plan.features[0].kind, null);
+  });
+  await test('wire schema keeps the full `required` array under io:\'input\' — clip stays object-level, never per-field', () => {
+    const rendered: any = z.toJSONSchema(planSchema(1), { target: 'draft-7', io: 'input' });
+    assert.deepEqual(rendered.required.sort(), ['angle', 'features', 'introNote', 'outroNote']);
+    assert.deepEqual(rendered.properties.features.items.required.sort(), ['kind', 'topic']);
+    // maxLength is still advertised to the model — the cap is a nudge, kept.
+    assert.equal(rendered.properties.angle.maxLength, 200);
   });
 
   console.log(failures === 0 ? '\nAll llm-pure tests passed.' : `\n${failures} test(s) FAILED.`);

--- a/controller/src/llm/internal/core/pure.ts
+++ b/controller/src/llm/internal/core/pure.ts
@@ -807,3 +807,31 @@ export function schemaHint(schema: z.ZodTypeAny): string | null {
     return null;
   }
 }
+
+// ---------------------------------------------------------------------------
+// Lenient text caps for model-generated free-text fields
+// ---------------------------------------------------------------------------
+
+// Trim `s` to at most `max` characters, on a word boundary where that keeps
+// most of the budget (else a hard char cut, so a single very long token can't
+// defeat the cap). Non-strings pass through untouched — the caller's schema
+// decides how to treat them.
+//
+// The point: a `.max(N)` cap on a model-generated free-text field is a NUDGE,
+// not a hard contract — LLMs can't count characters and no provider enforces
+// `maxLength` via decoding, so a one-sentence field landing a few chars over
+// must not throw and discard the whole structured object (a 207-char programme
+// `angle` vs a 200 cap sank the entire episode plan). Keep the `.max(N)` in the
+// schema (it still advertises brevity to the model on every path) and CLIP the
+// overflow before validation with a TOP-LEVEL z.preprocess over the plain
+// object — the same object-level placement modelTolerant uses, and for the same
+// reason: a per-field preprocess/`.catch()` silently drops the field from the
+// parent's `required` array under io:'input' (see coerceModelPayload's note;
+// pinned in llm-pure.test.ts). Callers walk their own known text fields and
+// apply this in that preprocess.
+export function clipText(s: unknown, max: number): unknown {
+  if (typeof s !== 'string' || s.length <= max) return s;
+  const cut = s.slice(0, max);
+  const onWord = cut.replace(/\s+\S*$/, '');
+  return (onWord.length >= max * 0.6 ? onWord : cut).trim();
+}

--- a/controller/src/llm/internal/prompts/programme.ts
+++ b/controller/src/llm/internal/prompts/programme.ts
@@ -14,6 +14,7 @@ import { djText } from '../strategy/text.js';
 import { djObject } from '../strategy/object.js';
 import { djSystem, lengthPhrase } from './system.js';
 import { buildContextLines, decoratePrompt, randomSeed } from './context.js';
+import { clipText } from '../core/pure.js';
 
 // Same field set as the free-text script generators (scripts.ts): ambient
 // weather stays out (issue #471); the dedicated weather skill owns that beat.
@@ -27,21 +28,52 @@ const MAX_FEATURES = 8;
 // PRODUCER PLAN — one djObject call per episode
 // ---------------------------------------------------------------------------
 
-const planSchema = (maxFeatures: number) => z.object({
-  angle: z.string().min(1).max(200)
+// Character caps for the plan's free-text fields. Kept as data so the wire
+// schema (the plain z.object below) and the pre-validation clip stay in sync.
+// The producer writes at temperature 0.9, and a "one sentence" angle routinely
+// lands a handful of chars over its cap — that overflow must NOT throw away the
+// whole plan and drop the episode to brief-only fallback (a 207-char angle vs
+// the 200 cap did exactly that). So the caps stay advertised to the model but
+// are enforced by clipping, not rejection.
+const ANGLE_MAX = 200;
+const NOTE_MAX = 240;
+const TOPIC_MAX = 240;
+
+// Clip every over-length text field on the raw payload BEFORE validation. This
+// runs as a TOP-LEVEL preprocess over the plain object (see clipText's note):
+// the inner z.object stays the untouched wire contract — every field intact in
+// `required` under io:'input', maxLength still advertised — whereas a per-field
+// clip would silently drop the field from `required` on the forced-tool path.
+function clipPlanText(raw: unknown): unknown {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return raw;
+  const out = { ...(raw as Record<string, unknown>) };
+  out.angle = clipText(out.angle, ANGLE_MAX);
+  out.introNote = clipText(out.introNote, NOTE_MAX);
+  out.outroNote = clipText(out.outroNote, NOTE_MAX);
+  if (Array.isArray(out.features)) {
+    out.features = out.features.map((f) =>
+      f && typeof f === 'object' && !Array.isArray(f)
+        ? { ...(f as Record<string, unknown>), topic: clipText((f as Record<string, unknown>).topic, TOPIC_MAX) }
+        : f);
+  }
+  return out;
+}
+
+export const planSchema = (maxFeatures: number) => z.preprocess(clipPlanText, z.object({
+  angle: z.string().min(1).max(ANGLE_MAX)
     .describe("today's editorial line for the episode — the specific take on the show's brief this airing runs with. One sentence."),
-  introNote: z.string().min(1).max(240)
+  introNote: z.string().min(1).max(NOTE_MAX)
     .describe('what the opening establishes and teases (including a nod to the feature) — a note to the host, not the spoken line itself'),
   features: z.array(z.object({
-    topic: z.string().min(1).max(240)
+    topic: z.string().min(1).max(TOPIC_MAX)
       .describe('what this feature segment covers — concrete and specific, not a category'),
     kind: z.string().nullable()
       .describe('the segment capability kind to build it with, from the kinds offered in the prompt — or null to let the host talk it straight'),
   })).min(1).max(maxFeatures)
     .describe('one feature segment per scheduled hour of the show, in air order'),
-  outroNote: z.string().min(1).max(240)
+  outroNote: z.string().min(1).max(NOTE_MAX)
     .describe('how the sign-off wraps the episode — call back to the angle or the feature; a note to the host'),
-});
+}));
 
 // The producer only picks WHICH capability builds each feature; the full
 // SKILL.md brief is applied by the segment director when the beat actually


### PR DESCRIPTION
## The bug

`generateProgrammePlan` failed with a Zod `too_big` error on `angle`:

```
generateProgrammePlan · google:gemini-flash-lite-latest · ai-sdk:recovery
[{ "code": "too_big", "maximum": 200, "path": ["angle"],
   "message": "Too big: expected string to have <=200 characters" }]
```

The model returned a perfectly good one-sentence editorial angle — it was just **207 chars against a hard `.max(200)`**. That 7-char overflow threw `NoObjectGeneratedError`, so the **entire episode plan was discarded** and the hour degraded to brief-only fallback (losing every cross-reference between intro/feature/outro).

## Root cause

The plan's free-text fields (`angle`, `introNote`, `topic`, `outroNote`) used hard `.max()` caps. LLMs can't count characters and no provider enforces JSON-schema `maxLength` via decoding, so a "one sentence" field routinely lands a few chars over. Every *other* structured generator in the codebase (`generate.ts`'s `PERSONA_SCHEMA`/`SHOW_SCHEMA`) degrades a partial/overshooting result gracefully — the programme plan was the one that didn't.

## The fix

Keep the caps **advertised** to the model (they still coach brevity on the native, forced-tool, and recovery paths) but **enforce them by clipping** the overflow to a word boundary *before* validation, via a single **top-level `z.preprocess` over the plain object** — the same object-level placement `modelTolerant` already uses.

A per-field `preprocess`/`.catch()` was the obvious-but-wrong fix and is explicitly called out in `coerceModelPayload`'s note: under `io:'input'` (Ollama's forced-tool path) it **silently drops the field from the parent's `required` array**, so the model would stop being told `angle`/`introNote`/`outroNote` are required. I reproduced that failure mode before settling on object-level clipping.

## Verification

- The exact model output from the report now parses (angle clipped 207 → 187 on a word boundary; `introNote`/`features`/`outroNote` retained).
- New pins in `llm-pure.test.ts`: `clipText` word-boundary behaviour, the plan clips rather than throws, and the wire schema keeps its full `required` array + advertised `maxLength` under `io:'input'`.
- `npm run test:llm`, `scripts/programme.test.ts`, and `npm run lint` (eslint + `tsc --noEmit`) all pass.