### PR TITLE
feat(web): Platter skin (new) + Spool redesign + tune-in overlay toggle

### DIFF
--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -405,7 +405,11 @@ router.get('/state', (req, res) => {
     // Listener-player UI settings ride along with /state like the theme does,
     // so the player can flip them live on the next poll. Defaults off if
     // unset; `skin` defaults to the classic face.
-    ui: { boothBuddy: s?.ui?.boothBuddy ?? false, skin: s?.ui?.skin || 'classic' },
+    ui: {
+      boothBuddy: s?.ui?.boothBuddy ?? false,
+      skin: s?.ui?.skin || 'classic',
+      tuneInOverlay: s?.ui?.tuneInOverlay ?? true,
+    },
     // Station zone for rendering djLog timestamps in station-local time (#418).
     timezone: getStationTimezone(),
     locale: s.locale,

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -1094,7 +1094,10 @@ const DEFAULTS = {
   // `skin` is the station-wide player-skin id — the web app owns the skin
   // registry and falls back to its default on an unknown id, so the
   // controller only stores a slug, never validates against a list.
-  ui: { boothBuddy: false, skin: 'classic' },
+  // `tuneInOverlay` gates the full-bleed "Tap to tune in" gate — ON by default;
+  // OFF drops the takeover and listeners start via the skin's own play button
+  // (browsers still can't autoplay, so a tap is always required somewhere).
+  ui: { boothBuddy: false, skin: 'classic', tuneInOverlay: true },
   // Global DJ prompt template. '' means "use DEFAULT_DJ_PROMPT_TEMPLATE".
   // Always the RESOLVED text of the active djPrompts entry — kept so
   // renderDjPrompt() (and an older controller sharing the same settings.json)
@@ -1911,6 +1914,10 @@ export async function load() {
         typeof stored.ui?.skin === 'string' && stored.ui.skin.trim()
           ? stored.ui.skin.trim()
           : DEFAULTS.ui.skin,
+      tuneInOverlay:
+        typeof stored.ui?.tuneInOverlay === 'boolean'
+          ? stored.ui.tuneInOverlay
+          : DEFAULTS.ui.tuneInOverlay,
     },
     personas,
     activePersonaId,
@@ -3551,6 +3558,9 @@ export async function update(patch) {
       if (/^[a-z0-9][a-z0-9-]{0,31}$/.test(slug)) {
         next.ui.skin = slug;
       }
+    }
+    if (ui.tuneInOverlay !== undefined) {
+      next.ui.tuneInOverlay = !!ui.tuneInOverlay;
     }
   }
   if ('webhooks' in patch) {

--- a/docs/superpowers/specs/2026-07-14-optional-tunein-overlay-design.md
+++ b/docs/superpowers/specs/2026-07-14-optional-tunein-overlay-design.md
@@ -1,0 +1,150 @@
+# Optional tune-in overlay + relocate Booth Buddy toggle
+
+**Date:** 2026-07-14
+**Status:** approved-pending-review
+
+## Goal
+
+Two operator-facing changes, both landing in the admin **Skin & Themes** tab
+(`settings` section id `theme`):
+
+1. Make the full-bleed **"Tap to tune in"** overlay optional across every player
+   skin, controlled by a new station-wide setting.
+2. Move the existing **Booth Buddy** toggle out of the **Station** tab into the
+   **Skin & Themes** tab, next to the new overlay toggle.
+
+## Load-bearing constraint
+
+The tune-in overlay's tap is the **browser's audio-unblock gesture** — browsers
+refuse to start `<audio>` until a user gesture. So "overlay off" **cannot** mean
+autoplay. It means: skip the full-bleed takeover; the listener starts playback
+with the skin's normal transport play button. The `subamp` skin already works
+exactly this way (its gate is inline, no overlay — `SubampSkin.tsx:6`), which is
+the proof this behavior is fine.
+
+Decisions (confirmed with operator):
+- **Scope:** operator-only, station-wide (mirrors Booth Buddy). No per-listener
+  override.
+- **Off behavior:** rely on each skin's existing paused play button. No new
+  inline hint UI.
+
+## Design
+
+### The gate split (`web/components/player/useTuneInGate.ts`)
+
+Today `showTuneIn` conflates two ideas: "the gate is up (not tuned in yet)" and
+"render the overlay." Skins use `showTuneIn` for *both* — the overlay render
+**and** other gate-up behavior (time display shows `--:--`, keyboard shortcuts
+disabled, drift hides tuned-in-only elements, etc.).
+
+We split only the overlay out, leaving gate-up semantics untouched:
+
+- The hook consumes `usePlayerFeed()` and reads
+  `overlayEnabled = state.ui?.tuneInOverlay !== false` (defaults **on** — any
+  value other than an explicit `false`, including `undefined` before `/state`
+  resolves, keeps today's behavior).
+- The hook returns a new field `showOverlay = showTuneIn && overlayEnabled`.
+- `showTuneIn`, `tuneInFromOverlay`, `handleTune` keep their current meaning and
+  return shape (additive change — no existing field changes semantics).
+
+`TuneInGate` interface gains:
+```ts
+/** Render the full-bleed overlay: gate is up AND the operator hasn't
+ *  disabled the overlay (settings.ui.tuneInOverlay). */
+showOverlay: boolean;
+```
+
+### Skins — swap the overlay render gate only
+
+Each skin that renders a full-bleed overlay changes **only** the overlay's
+render condition from `showTuneIn` to `showOverlay`. Every other `showTuneIn`
+usage (time display, keyboard focus, tuned-in-only content) stays as-is, so a
+listener who hasn't tapped play yet still sees the correct paused state.
+
+| Skin | File | Change |
+|---|---|---|
+| classic | `ClassicSkin.tsx:263` | `{showTuneIn && ...` → `{showOverlay && ...}` (the `<TuneInOverlay>`) |
+| spool | `SpoolSkin.tsx:393` | same |
+| tty | `TtySkin.tsx:359` | same |
+| drift | `DriftSkin.tsx:294` | same (leave the `!showTuneIn` gates at 177/224 untouched) |
+| subamp | — | **no change** — already overlay-less; its inline play button is the gate |
+
+The transport/play buttons already tune in via `handleTune` /
+`tuneInFromOverlay`, so with the overlay hidden the first tap on the play button
+still unblocks audio and drops the gate. No skin needs a new control.
+
+### Controller settings (`controller/src/settings.ts`)
+
+Add `tuneInOverlay` to the `ui` block, following `boothBuddy` exactly:
+- **Default** (`DEFAULTS.ui`, ~line 1097): `tuneInOverlay: true`.
+- **Load/migrate** (~line 1905): `typeof stored.ui?.tuneInOverlay === 'boolean' ? … : DEFAULTS.ui.tuneInOverlay`.
+- **Patch** (`update()`, ~line 3542): `if (ui.tuneInOverlay !== undefined) next.ui.tuneInOverlay = !!ui.tuneInOverlay;`.
+- Update the `ui:` comment block to mention the new flag.
+
+### `/state` exposure (`controller/src/routes/public.ts:408`)
+
+```ts
+ui: {
+  boothBuddy: s?.ui?.boothBuddy ?? false,
+  skin: s?.ui?.skin || 'classic',
+  tuneInOverlay: s?.ui?.tuneInOverlay ?? true,
+},
+```
+
+### Web types (`web/lib/types.ts:185`)
+
+```ts
+ui?: { boothBuddy?: boolean; skin?: string; tuneInOverlay?: boolean };
+```
+
+### Admin UI (`web/components/admin/settings/`)
+
+**ThemeSection.tsx** (the "Skin & Themes" tab) gains two cards after the "Player
+skin" card, both saving immediately on toggle via the existing `saveSettings`
+(no `form`/`SaveBar` needed — these are instant-apply toggles like the skin
+gallery):
+
+- **"Tune-in overlay"** card — `Seg` on/off bound to
+  `data.values?.ui?.tuneInOverlay !== false`, saving
+  `saveSettings({ ui: { tuneInOverlay: id === 'on' } })`. Hint explains that OFF
+  drops the full-bleed gate and listeners tap the skin's play button to start
+  (no autoplay possible; applies live, no restart).
+- **"Booth Buddy"** card — moved verbatim from `StationSection.tsx:244-264`
+  (same `Seg`, same `saveSettings({ ui: { boothBuddy } })`, same hint).
+
+`ThemeSection` already imports `Seg` from `../ui` and receives `data`, `busy`,
+`saveSettings` — no new props/imports needed.
+
+**StationSection.tsx** — delete the Booth Buddy card (`:244-264`). Verify `Seg`
+is still used elsewhere in the file; if not, drop it from the import to keep lint
+green.
+
+## Non-goals / YAGNI
+
+- No per-listener overlay override (localStorage). Operator-only.
+- No new "tap to listen" hint UI when the overlay is off.
+- No change to subamp (already overlay-less).
+- No change to the audio/tune mechanics — only whether the overlay paints.
+
+## Testing / verification
+
+No test runner in this repo; the gate is `npm run lint` (eslint + `tsc`) in
+`controller/` and `web/`. Manual dev-stack check:
+1. Admin → Skin & Themes: both toggles present; Station tab no longer shows
+   Booth Buddy.
+2. Overlay ON (default): fresh `/listen` load shows the full-bleed gate on
+   classic/spool/tty/drift.
+3. Overlay OFF: fresh load shows the paused player with no takeover; tapping the
+   skin's play button starts the stream (audio unblocks). Booth Buddy toggle
+   still works from its new home.
+4. Both flags flip live on the next `/state` poll — no mixer restart.
+
+## Files touched
+
+- `controller/src/settings.ts` (3 spots + comment)
+- `controller/src/routes/public.ts` (1 line)
+- `web/lib/types.ts` (1 line)
+- `web/components/player/useTuneInGate.ts` (feed read + `showOverlay`)
+- `web/components/skins/{classic/ClassicSkin,spool/SpoolSkin,tty/TtySkin,drift/DriftSkin}.tsx` (1 line each)
+- `web/components/admin/settings/ThemeSection.tsx` (+2 cards)
+- `web/components/admin/settings/StationSection.tsx` (−1 card)

--- a/web/components/admin/settings/SkinGallery.tsx
+++ b/web/components/admin/settings/SkinGallery.tsx
@@ -175,12 +175,39 @@ function TtyPreview() {
   );
 }
 
+// ── Platter: a reference turntable — the record spins, the arm tracks ─────────
+function PlatterPreview() {
+  return (
+    <div className="flex h-full w-full items-center gap-2 bg-field p-2.5">
+      {/* plinth + spinning record + diagonal tonearm */}
+      <div className="relative grid aspect-square h-full place-items-center border border-ink bg-bg">
+        <span className={cn('relative grid aspect-square h-[74%] place-items-center rounded-full border border-ink bg-ink', REEL)}>
+          <span className="grid aspect-square h-[42%] place-items-center rounded-full border border-bg/70 bg-field">
+            <span className="size-[3px] rounded-full bg-vermilion" />
+          </span>
+        </span>
+        <span className="absolute top-1 right-1 h-[2px] w-[58%] origin-right -rotate-[28deg] bg-ink" />
+        <span className="absolute top-1 right-1 size-[5px] translate-x-1/2 -translate-y-1/2 rounded-full border border-ink bg-field" />
+      </div>
+      {/* metadata stub */}
+      <div className="grid flex-1 content-start gap-1.5">
+        <span className="h-[3px] w-1/3 bg-vermilion" />
+        <span className="h-[4px] w-4/5 bg-ink" />
+        <span className="h-[3px] w-1/2 bg-muted" />
+        <span className="mt-1 h-[3px] w-full bg-soft-border" />
+        <EqRow className="mt-1 h-4 justify-start" />
+      </div>
+    </div>
+  );
+}
+
 const PREVIEWS: Record<string, () => ReactNode> = {
   classic: ClassicPreview,
   spool: SpoolPreview,
   drift: DriftPreview,
   subamp: SubampPreview,
   tty: TtyPreview,
+  platter: PlatterPreview,
 };
 
 // A neutral wireframe for any skin without a bespoke poster (community skins).

--- a/web/components/admin/settings/StationSection.tsx
+++ b/web/components/admin/settings/StationSection.tsx
@@ -8,7 +8,7 @@ import { Label } from '../../ui/label';
 import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel,
 } from '../../ui/select';
-import { Card, Btn, Seg } from '../ui';
+import { Card, Btn } from '../ui';
 import { LocationPicker, type GeocodeResult } from '../../LocationPicker';
 import {
   SectionHeader, SaveBar,
@@ -237,28 +237,6 @@ export function StationSection({ data, form, setForm, busy, saveSettings }: Sect
           </Select>
           <div className="field-hint">
             Sets station-facing display language and clock style. US English uses AM/PM for visible clock times. Applies live.
-          </div>
-        </div>
-      </Card>
-
-      <Card title="Booth Buddy" sub="the DJ-line mascot on the player">
-        <div className="field">
-          <Label>Show the Booth Sprite</Label>
-          <div className="flex items-center gap-2">
-            <Seg
-              options={[
-                { id: 'on', label: 'On' },
-                { id: 'off', label: 'Off' },
-              ]}
-              value={data?.values?.ui?.boothBuddy === true ? 'on' : 'off'}
-              onChange={id => { if (!busy) saveSettings({ ui: { boothBuddy: id === 'on' } }); }}
-            />
-          </div>
-          <div className="field-hint">
-            A small animated mascot that leads the DJ line on the listener player,
-            reacting to what the DJ is doing — on-air, picking, or idle — and tap it
-            for a reaction. When off, the line falls back to the classic ♪/◇ marker.
-            Applies live, no restart.
           </div>
         </div>
       </Card>

--- a/web/components/admin/settings/ThemeSection.tsx
+++ b/web/components/admin/settings/ThemeSection.tsx
@@ -275,6 +275,50 @@ export function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSect
         </div>
       </Card>
 
+      <Card title="Tune-in overlay" sub="the full-bleed “tap to tune in” gate">
+        <div className="field">
+          <Label>Show the tune-in overlay</Label>
+          <div className="flex items-center gap-2">
+            <Seg
+              options={[
+                { id: 'on', label: 'On' },
+                { id: 'off', label: 'Off' },
+              ]}
+              value={data?.values?.ui?.tuneInOverlay !== false ? 'on' : 'off'}
+              onChange={id => { if (!busy) saveSettings({ ui: { tuneInOverlay: id === 'on' } }); }}
+            />
+          </div>
+          <div className="field-hint">
+            The full-screen “Tap to tune in” gate a new listener lands on. When
+            off, the player loads paused with no takeover and listeners start the
+            stream from the skin’s own play button — browsers can’t autoplay, so a
+            tap is always needed somewhere. Applies live, no restart.
+          </div>
+        </div>
+      </Card>
+
+      <Card title="Booth Buddy" sub="the DJ-line mascot on the player">
+        <div className="field">
+          <Label>Show the Booth Sprite</Label>
+          <div className="flex items-center gap-2">
+            <Seg
+              options={[
+                { id: 'on', label: 'On' },
+                { id: 'off', label: 'Off' },
+              ]}
+              value={data?.values?.ui?.boothBuddy === true ? 'on' : 'off'}
+              onChange={id => { if (!busy) saveSettings({ ui: { boothBuddy: id === 'on' } }); }}
+            />
+          </div>
+          <div className="field-hint">
+            A small animated mascot that leads the DJ line on the listener player,
+            reacting to what the DJ is doing — on-air, picking, or idle — and tap it
+            for a reaction. When off, the line falls back to the classic ♪/◇ marker.
+            Applies live, no restart.
+          </div>
+        </div>
+      </Card>
+
       <Card title="Create theme" sub="state/themes/*.json">
         <div className="grid gap-3">
           <div className="flex flex-wrap items-start justify-between gap-3">

--- a/web/components/admin/settings/shared.tsx
+++ b/web/components/admin/settings/shared.tsx
@@ -265,7 +265,7 @@ export interface SettingsData {
       enrichment?: Partial<EmbeddingEnrichmentForm>;
     };
     sfx?: { enabled?: boolean };
-    ui?: { boothBuddy?: boolean; skin?: string };
+    ui?: { boothBuddy?: boolean; skin?: string; tuneInOverlay?: boolean };
     scrobble?: {
       lastfm?: Partial<ScrobbleLastfmForm>;
       listenbrainz?: Partial<ScrobbleListenbrainzForm>;

--- a/web/components/player/useTuneInGate.ts
+++ b/web/components/player/useTuneInGate.ts
@@ -11,11 +11,17 @@
 
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
-import { usePlayerActions, usePlayerAudio } from './PlayerCore';
+import { usePlayerActions, usePlayerAudio, usePlayerFeed } from './PlayerCore';
 
 export interface TuneInGate {
-  /** Render the skin's tune-in overlay while true (and the stream is up). */
+  /** The gate is up — the listener hasn't tuned in yet. Skins key their
+   *  un-tuned state off this (paused time display, keyboard focus, etc.),
+   *  regardless of whether the full-bleed overlay is shown. */
   showTuneIn: boolean;
+  /** Render the skin's full-bleed tune-in overlay: the gate is up AND the
+   *  operator hasn't disabled it (settings.ui.tuneInOverlay). When off,
+   *  listeners tune in via the skin's own play button instead. */
+  showOverlay: boolean;
   /** The overlay's tap handler — dismisses the gate and tunes in. */
   tuneInFromOverlay: () => void;
   /** Tune toggle for shortcuts/palettes — goes through the overlay path
@@ -26,6 +32,11 @@ export interface TuneInGate {
 export function useTuneInGate(): TuneInGate {
   const { tunedIn, idleStopped } = usePlayerAudio();
   const { tune } = usePlayerActions();
+  const { state } = usePlayerFeed();
+  // Operator toggle (station-wide, live via /state). Default ON — anything
+  // other than an explicit false (including undefined before /state resolves)
+  // keeps the full-bleed gate, preserving pre-toggle behavior.
+  const overlayEnabled = state.ui?.tuneInOverlay !== false;
   // Seeded from the live tune state, not `true`: the hook remounts on every
   // skin switch (gate state is per-skin), and a fresh instance while playback
   // is already running must not paint the gate for a frame before the
@@ -57,5 +68,5 @@ export function useTuneInGate(): TuneInGate {
     else tune();
   };
 
-  return { showTuneIn, tuneInFromOverlay, handleTune };
+  return { showTuneIn, showOverlay: showTuneIn && overlayEnabled, tuneInFromOverlay, handleTune };
 }

--- a/web/components/skins/classic/ClassicSkin.tsx
+++ b/web/components/skins/classic/ClassicSkin.tsx
@@ -59,7 +59,7 @@ export default function ClassicSkin({ portalNode }: SkinProps) {
   const { audioRef, tunedIn, status, volume, muted, offline, signal } = usePlayerAudio();
   const { tune, toggleMute, setVolume, submitRequest: coreSubmitRequest, pollRequest } =
     usePlayerActions();
-  const { showTuneIn, tuneInFromOverlay, handleTune } = useTuneInGate();
+  const { showOverlay, tuneInFromOverlay, handleTune } = useTuneInGate();
 
   // Listener count now lives in the footer's signal readout (not the header) —
   // normalise the feed's number | { current } | null shape to a plain count.
@@ -260,7 +260,7 @@ export default function ClassicSkin({ portalNode }: SkinProps) {
       </Sheet>
 
       <AnimatePresence>
-        {showTuneIn && !offline && (
+        {showOverlay && !offline && (
           <TuneInOverlay key="tune-in" onTune={tuneInFromOverlay} nowPlaying={nowPlaying} />
         )}
       </AnimatePresence>

--- a/web/components/skins/drift/DriftSkin.tsx
+++ b/web/components/skins/drift/DriftSkin.tsx
@@ -9,6 +9,7 @@
 // chip; everything else is corners.
 
 import { useEffect, useRef, useState } from 'react';
+import { Headphones } from 'lucide-react';
 import styles from './Drift.module.css';
 import {
   usePlayerActions,
@@ -56,7 +57,7 @@ export default function DriftSkin(_props: SkinProps) {
   } = usePlayerFeed();
   const { tunedIn, volume, muted, offline, signal } = usePlayerAudio();
   const { toggleMute } = usePlayerActions();
-  const { showTuneIn, tuneInFromOverlay, handleTune } = useTuneInGate();
+  const { showOverlay, tuneInFromOverlay, handleTune } = useTuneInGate();
 
   const elapsed = useElapsed(trackStartedAt);
   const clock = useClock();
@@ -151,11 +152,17 @@ export default function DriftSkin(_props: SkinProps) {
         {upNext?.title ? `up next · ${[upNext.title, upNext.artist].filter(Boolean).join(' — ')}` : ''}
       </div>
       <div className="absolute right-8 bottom-7 flex items-baseline gap-2 font-mono text-[10px] tracking-[0.18em] text-muted uppercase">
-        <span className="hidden sm:inline">
-          {[
-            listenerCount != null ? `${listenerCount} listening` : '',
-            signal.latencyMs != null && tunedIn ? `${signal.latencyMs} ms` : '',
-          ].filter(Boolean).join(' · ')}
+        <span className="hidden items-center gap-1.5 sm:inline-flex">
+          {listenerCount != null && (
+            <span className="inline-flex items-center gap-1" aria-label={`${listenerCount} listening`}>
+              <Headphones aria-hidden className="size-3" strokeWidth={1.5} />
+              {listenerCount}
+            </span>
+          )}
+          {listenerCount != null && signal.latencyMs != null && tunedIn && (
+            <span aria-hidden>·</span>
+          )}
+          {signal.latencyMs != null && tunedIn && <span>{signal.latencyMs} ms</span>}
         </span>
         <button type="button" aria-label="Volume down" onClick={() => adjustVolume(-0.05)}
           className="v3-focus cursor-pointer border-0 bg-transparent p-0 text-muted hover:text-ink">−</button>
@@ -170,11 +177,14 @@ export default function DriftSkin(_props: SkinProps) {
           className="v3-focus cursor-pointer border-0 bg-transparent p-0 text-muted hover:text-ink">+</button>
       </div>
 
-      {/* the ten percent of type. pointer-events-none so this full-screen
-          centering layer doesn't sit over the corner controls (ThemeSwitcher,
-          volume) and eat their clicks — the one interactive child (the title,
-          which tunes in) re-enables events on itself. */}
-      {!showTuneIn && (
+      {/* the ten percent of type. Shown whenever the full-bleed gate isn't
+          covering the screen (!showOverlay) — so when the operator disables the
+          tune-in overlay, this layer is drift's tune affordance: the label reads
+          "tap to listen" and the title tunes in. pointer-events-none so this
+          full-screen centering layer doesn't sit over the corner controls
+          (ThemeSwitcher, volume) and eat their clicks — the one interactive
+          child (the title, which tunes in) re-enables events on itself. */}
+      {!showOverlay && (
         <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-4 px-6 text-center">
           {coverSrc && !offline && (
             <div className="h-[128px] w-[128px] border border-soft-border sm:h-[152px] sm:w-[152px]">
@@ -220,13 +230,13 @@ export default function DriftSkin(_props: SkinProps) {
         </div>
       )}
 
-      {/* the ··· chip */}
-      {!showTuneIn && (
+      {/* the ··· chip — available whenever the poster is up (gate not covering) */}
+      {!showOverlay && (
         <button
           type="button"
           onClick={() => setPanelOpen(o => !o)}
           aria-expanded={panelOpen}
-          className="v3-focus absolute bottom-6 left-1/2 -translate-x-1/2 cursor-pointer border border-soft-border bg-[var(--field)] px-4 py-1 font-mono text-[12px] tracking-[0.3em] text-muted hover:text-ink"
+          className="v3-focus absolute bottom-6 left-1/2 -translate-x-1/2 cursor-pointer border border-soft-border/50 bg-[var(--field)]/25 px-4 py-1 font-mono text-[12px] tracking-[0.3em] text-muted backdrop-blur-md hover:bg-[var(--field)]/45 hover:text-ink"
         >
           ···
         </button>
@@ -291,7 +301,7 @@ export default function DriftSkin(_props: SkinProps) {
       )}
 
       {/* the gate: just the wash and one lowercase word */}
-      {showTuneIn && !offline && (
+      {showOverlay && !offline && (
         <button
           type="button"
           onClick={tuneInFromOverlay}

--- a/web/components/skins/drift/DriftSkin.tsx
+++ b/web/components/skins/drift/DriftSkin.tsx
@@ -32,6 +32,7 @@ import {
   lastVoiceLine,
   listenerCountOf,
   progressRatio,
+  stationIdentity,
   turnClock,
 } from '../shared';
 import { useRequestSlip, useVolumeNudge } from '../sharedHooks';
@@ -63,10 +64,7 @@ export default function DriftSkin(_props: SkinProps) {
   const clock = useClock();
   const stationLocale = normalizeStationLocale(locale);
   const listenerCount = listenerCountOf(listeners);
-  const stationName = (typeof dj?.station === 'string' && dj.station) || 'SUB/WAVE';
-  const djName =
-    activeShow?.persona?.name || (typeof dj?.name === 'string' ? dj.name : '') || 'the DJ';
-  const showName = activeShow?.name || context?.time?.show || '';
+  const { stationName, djName, showName } = stationIdentity(dj, activeShow, context);
   const ratio = progressRatio(elapsed, nowPlaying?.duration);
   const voice = lastVoiceLine(session.messages);
   const upNext = state.upcoming?.[0];

--- a/web/components/skins/index.ts
+++ b/web/components/skins/index.ts
@@ -53,6 +53,14 @@ export const SKINS: SkinManifest[] = [
     skinApiVersion: SKIN_API_VERSION,
     load: () => import('./tty/TtySkin'),
   },
+  {
+    id: 'platter',
+    name: 'Platter',
+    description:
+      'The flagship vinyl face — a reference turntable is the interface, needle and all.',
+    skinApiVersion: SKIN_API_VERSION,
+    load: () => import('./platter/PlatterSkin'),
+  },
 ];
 
 // Id facts (default id, legacy aliases) live in lib/skin.ts so the server

--- a/web/components/skins/platter/Platter.module.css
+++ b/web/components/skins/platter/Platter.module.css
@@ -1,0 +1,76 @@
+/* Platter skin — a reference turntable rendered in DOM. Everything that moves
+   is a co-located keyframe so it never re-renders React; each spinner idles at
+   `paused` and only runs when `.playing` is also applied (music is actually
+   airing), which keeps a tuned-out screen still and lets html.lite's global
+   keyframe kill stop the whole deck for free. Design ref: Skins Canvas 3a. */
+
+@keyframes platter-spin { to { transform: rotate(360deg); } }
+@keyframes platter-sheen { to { transform: rotate(360deg); } }
+@keyframes platter-rim { to { transform: rotate(360deg); } }
+@keyframes platter-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.28; } }
+
+/* Shared: paused until the deck is spun up. */
+.record,
+.sheen,
+.rim,
+.pulse {
+  animation-play-state: paused;
+}
+.playing {
+  animation-play-state: running;
+}
+
+.record { animation: platter-spin 8s linear infinite; }
+.sheen {
+  animation: platter-sheen 16s linear infinite;
+  mix-blend-mode: screen;
+  background: conic-gradient(
+    from 210deg,
+    rgba(255, 255, 255, 0) 0deg,
+    rgba(255, 255, 255, 0.16) 42deg,
+    rgba(255, 255, 255, 0) 96deg,
+    rgba(255, 255, 255, 0) 250deg,
+    rgba(255, 255, 255, 0.11) 296deg,
+    rgba(255, 255, 255, 0) 344deg
+  );
+}
+.rim { animation: platter-rim 8s linear infinite; }
+.pulse { animation: platter-pulse 2.4s ease-in-out infinite; }
+
+/* The black vinyl — off-token by nature (a record is black in any theme),
+   like the Spool skin's fixed-dark cassette. Grooves + centre well + a soft
+   drop. */
+.vinyl {
+  background:
+    repeating-radial-gradient(
+      circle at 50% 50%,
+      rgba(255, 255, 255, 0.05) 0 1px,
+      rgba(0, 0, 0, 0) 1px 3px
+    ),
+    radial-gradient(circle at 50% 50%, #1c1815 0 32%, #0c0a09 33% 100%);
+  box-shadow:
+    inset 0 0 55px rgba(0, 0, 0, 0.85),
+    0 16px 42px rgba(0, 0, 0, 0.35);
+}
+
+/* Tonearm — an SVG overlay drawn at its tracking (needle-down) position, then
+   rotated as a whole around the pivot (84% 15% of the square deck) so the
+   headshell always stays welded to the tube end and the stylus stays on the
+   groove. A one-shot transition (not a loop) swings it up off the record when
+   the listener tunes out; the parked angle holds even under html.lite. */
+.arm {
+  transform-origin: 84% 15%;
+  transition: transform 1.1s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.armRest { transform: rotate(-16deg); }
+.armLive { transform: rotate(0deg); }
+
+/* Progress fill — driven by --pf (0..1) set on the skin root via
+   useDynamicStyle, so no inline style attribute. */
+.progFill { width: calc(var(--pf, 0) * 100%); }
+.progHead { left: calc(var(--pf, 0) * 100%); }
+
+/* Vertical volume fader — driven by --vf (0..1). The fill grows up from the
+   bottom to the thumb; the thumb rides at (1 - vf) from the top. */
+.faderFill { top: calc((1 - var(--vf, 0)) * 100%); }
+.faderThumb { top: calc((1 - var(--vf, 0)) * 100%); }

--- a/web/components/skins/platter/PlatterSkin.tsx
+++ b/web/components/skins/platter/PlatterSkin.tsx
@@ -1,0 +1,469 @@
+'use client';
+
+// Platter — the flagship vinyl face: a reference turntable IS the interface.
+// Flagship · warm · hi-fi. Design ref: Skins Canvas 3a.
+//
+// The record spins at 33⅓ while a light-catch sheen sweeps on its own slower
+// cycle and the strobe rim ticks; the tonearm swings from its rest onto the
+// lead-in when the listener drops the needle (tunes in). The plinth holds the
+// transport (START = tune in/out), while the sleeve, metadata, up-next stack,
+// booth quote and request slip live in the right-hand column. Everything that
+// moves is a co-located keyframe (Platter.module.css) so playback churn never
+// touches React.
+
+import { useCallback, useRef } from 'react';
+import styles from './Platter.module.css';
+import {
+  usePlayerActions,
+  usePlayerAudio,
+  usePlayerFeed,
+} from '@/components/player/PlayerCore';
+import { useTuneInGate } from '@/components/player/useTuneInGate';
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import { useElapsed } from '@/hooks/useElapsed';
+import { useDynamicStyle } from '@/hooks/useDynamicStyle';
+import ThemeSwitcher from '@/components/ThemeSwitcher';
+import { cn } from '@/lib/cn';
+import { fmtTime } from '@/lib/format';
+import { useStationClient } from '@/lib/stationClient';
+import {
+  contextLine,
+  lastVoiceLine,
+  listenerCountOf,
+  progressRatio,
+  trackMeta,
+} from '../shared';
+import { useRequestSlip, useVolumeNudge } from '../sharedHooks';
+import type { SkinProps } from '../types';
+
+/** The spinning platter itself — rim, vinyl + printed label, light sheen,
+ *  spindle cap and the tonearm. Sized to fill its square container so it
+ *  scales fluidly; reused (parked, not playing) inside the tune-in gate. */
+function Deck({
+  playing,
+  stationName,
+  title,
+  artist,
+}: {
+  playing: boolean;
+  stationName: string;
+  title: string;
+  artist: string;
+}) {
+  return (
+    <div className="[container-type:inline-size] relative aspect-square w-[min(56vw,30vh,220px)] lg:w-[min(42vw,72vh,520px)]">
+      {/* pitch strobe rim */}
+      <div
+        className={cn(
+          'pointer-events-none absolute inset-[2%] rounded-full border-2 border-dotted border-[var(--muted)] opacity-50',
+          styles.rim,
+          playing && styles.playing,
+        )}
+        aria-hidden="true"
+      />
+
+      {/* the record — grooves, accent ring, printed paper label */}
+      <div
+        className={cn('absolute inset-[6%] rounded-full', styles.vinyl, styles.record, playing && styles.playing)}
+        aria-hidden="true"
+      >
+        <div className="absolute inset-[30.5%] rounded-full border-2 border-[var(--accent)]" />
+        <div className="absolute inset-[32%] flex flex-col items-center justify-center gap-[2%] rounded-full border border-[#0c0a09] bg-[#ece5d6] px-[6%] text-center text-[#161412]">
+          <span className="font-mono text-[clamp(6px,1.3cqw,9px)] font-bold tracking-[0.26em] text-[var(--accent)]">
+            {stationName}
+          </span>
+          <span className="line-clamp-2 font-display text-[clamp(13px,3.1cqw,22px)] leading-[0.95] font-extrabold italic">
+            {title}
+          </span>
+          <span className="truncate font-mono text-[clamp(5px,1.1cqw,8px)] tracking-[0.2em] text-[#7a736a] uppercase">
+            {artist}
+          </span>
+          <span className="my-[2%] size-[6%] rounded-full bg-[#0c0a09]" />
+          <span className="font-mono text-[clamp(5px,0.95cqw,7px)] tracking-[0.22em] text-[#7a736a]">
+            SIDE A · 33⅓ RPM
+          </span>
+        </div>
+      </div>
+
+      {/* light-catch sheen — independent slower sweep */}
+      <div
+        className={cn('pointer-events-none absolute inset-[6%] rounded-full', styles.sheen, playing && styles.playing)}
+        aria-hidden="true"
+      />
+
+      {/* centre spindle cap */}
+      <div
+        className="absolute top-1/2 left-1/2 size-[2.3%] -translate-x-1/2 -translate-y-1/2 rounded-full border border-[#0c0a09] bg-[#b9b1a1]"
+        aria-hidden="true"
+      />
+
+      {/* tonearm — one SVG in the deck's own coordinate space, so the headshell
+          stays welded to the tube end and the stylus lands on the groove. The
+          whole arm swings up off the record when tuned out (see .arm). */}
+      <svg
+        viewBox="0 0 100 100"
+        className={cn(
+          'pointer-events-none absolute inset-0 h-full w-full overflow-visible',
+          styles.arm,
+          playing ? styles.armLive : styles.armRest,
+        )}
+        aria-hidden="true"
+      >
+        {/* arm tube — dark outline under a light-metal core */}
+        <line x1="84" y1="15" x2="30" y2="33" strokeWidth={2.3} strokeLinecap="round" className="stroke-ink" />
+        <line x1="84" y1="15" x2="30" y2="33" strokeWidth={1.1} strokeLinecap="round" className="stroke-[#e6e0d2]" />
+        {/* counterweight past the pivot */}
+        <rect x="85.5" y="11" width="9" height="5" rx="1" strokeWidth={0.6} className="fill-[#22201d] stroke-ink" />
+        {/* pivot mount */}
+        <circle cx="84" cy="15" r="3.6" strokeWidth={0.8} className="fill-[#d9d2c4] stroke-ink" />
+        <circle cx="84" cy="15" r="1.2" className="fill-ink" />
+        {/* headshell + cartridge at the tip */}
+        <rect x="26" y="30" width="8" height="5.4" rx="0.8" strokeWidth={0.6} transform="rotate(18 30 32.7)" className="fill-[#22201d] stroke-ink" />
+        {/* stylus dropped onto the groove */}
+        <line x1="28.6" y1="35" x2="27.6" y2="37.8" strokeWidth={1.1} strokeLinecap="round" className="stroke-[var(--accent)]" />
+      </svg>
+    </div>
+  );
+}
+
+export default function PlatterSkin(_props: SkinProps) {
+  const client = useStationClient();
+  const {
+    nowPlaying, context, dj, activeShow, listeners, state, session,
+    trackStartedAt,
+  } = usePlayerFeed();
+  const { tunedIn, status, volume, muted, offline, signal } = usePlayerAudio();
+  const { toggleMute, setVolume } = usePlayerActions();
+  const { showTuneIn, showOverlay, tuneInFromOverlay, handleTune } = useTuneInGate();
+
+  const elapsed = useElapsed(trackStartedAt);
+  const listenerCount = listenerCountOf(listeners);
+  const stationName = (typeof dj?.station === 'string' && dj.station) || 'SUB/WAVE';
+  const djName =
+    activeShow?.persona?.name || (typeof dj?.name === 'string' ? dj.name : '') || 'the DJ';
+  const showName = activeShow?.name || context?.time?.show || '';
+  const meta = trackMeta(nowPlaying);
+  const ratio = progressRatio(elapsed, nowPlaying?.duration);
+  const voice = lastVoiceLine(session.messages);
+  const upNext = (state.upcoming ?? []).slice(0, 2);
+  const playing = tunedIn && status === 'playing' && !offline;
+
+  const title = offline ? '— off air —' : (nowPlaying?.title ?? 'Scanning the dial…');
+  const artist = offline ? '' : (nowPlaying?.artist ?? '');
+
+  const adjustVolume = useVolumeNudge();
+
+  // The vertical fader doubles as the volume control — map pointer Y to level.
+  const faderRef = useRef<HTMLDivElement | null>(null);
+  const setVolFromPointer = useCallback(
+    (clientY: number) => {
+      const el = faderRef.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      const frac = 1 - (clientY - r.top) / r.height;
+      setVolume(Math.min(1, Math.max(0, Math.round(frac * 100) / 100)));
+    },
+    [setVolume],
+  );
+
+  // Drive the progress + volume fills through CSS vars (no inline style attr).
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  useDynamicStyle(rootRef, { '--pf': ratio ?? 0, '--vf': volume });
+
+  const slip = useRequestSlip({
+    sent: 'Slip on the platter — the booth has your note.',
+    refused: 'The booth waved this one off.',
+    failed: 'The booth line is down — try again in a moment.',
+  });
+  const reqInputRef = useRef<HTMLInputElement | null>(null);
+
+  useKeyboardShortcuts({
+    space: handleTune,
+    k: handleTune,
+    arrowup: () => adjustVolume(0.05),
+    arrowdown: () => adjustVolume(-0.05),
+    m: toggleMute,
+    r: () => { if (!showTuneIn) reqInputRef.current?.focus(); },
+  });
+
+  return (
+    <div ref={rootRef} className="absolute inset-0 flex flex-col overflow-hidden bg-bg font-sans text-ink">
+      {/* masthead */}
+      <div className="flex flex-none items-center justify-between gap-x-6 border-b border-ink px-5 py-3 sm:px-8">
+        <div className="flex min-w-0 items-center gap-3">
+          <span className="flex-none text-[15px] font-extrabold tracking-[0.14em]">{stationName.toUpperCase()}</span>
+        </div>
+        <div className="flex shrink-0 items-center gap-3">
+          <div className="hidden items-center gap-3 font-mono text-[11px] tracking-[0.16em] uppercase md:flex">
+            {showName && <span className="max-w-[22vw] truncate">▸ {showName}</span>}
+            <span className="text-[var(--accent)]">with {djName}</span>
+            <span className="max-w-[24vw] truncate border-l border-soft-border pl-3 text-muted">
+              {contextLine(context) || (offline ? 'off air' : 'on air')}
+            </span>
+          </div>
+          <ThemeSwitcher />
+        </div>
+      </div>
+
+      {/* body — turntable on the left, metadata column on the right */}
+      <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+        {/* ===== the plinth ===== */}
+        <div className="relative flex flex-1 flex-col items-center justify-center gap-6 border-b border-ink bg-linear-to-br from-[var(--field)] to-[color-mix(in_oklab,var(--field)_82%,var(--bg))] px-6 py-6 lg:w-[46%] lg:max-w-[680px] lg:flex-1 lg:flex-row lg:gap-0 lg:border-r lg:border-b-0 lg:py-10">
+          <span className="absolute top-5 left-6 font-mono text-[9px] tracking-[0.24em] text-muted uppercase">
+            direct drive · quartz lock
+          </span>
+
+          <Deck playing={playing} stationName={stationName} title={title} artist={artist} />
+
+          {/* the deck IS the control surface: START/STOP drops or lifts the
+              needle, MUTE sits beside it, and the fader is the volume. Laid out
+              as a row beneath the deck on phones (clear of the vinyl); mounted
+              in the plinth corners from lg up (the wrapper goes display:contents
+              so each cluster positions itself absolutely). */}
+          <div className="flex w-full max-w-[320px] items-end justify-between gap-4 lg:contents">
+            <div className="flex items-end gap-3 lg:absolute lg:bottom-6 lg:left-6">
+              <button
+                type="button"
+                onClick={handleTune}
+                aria-label={tunedIn ? 'Tune out' : 'Tune in'}
+                className={cn(
+                  'v3-focus flex size-20 cursor-pointer flex-col items-center justify-center gap-0.5 rounded-full border border-ink',
+                  tunedIn ? 'bg-[var(--accent)] text-bg' : 'bg-bg text-ink hover:bg-[var(--overlay)]',
+                )}
+              >
+                <span className="text-[30px] leading-none">{tunedIn ? '■' : '▶'}</span>
+                <span className="font-mono text-[8px] font-bold tracking-[0.22em]">{tunedIn ? 'STOP' : 'START'}</span>
+              </button>
+              <button
+                type="button"
+                onClick={toggleMute}
+                aria-pressed={muted}
+                aria-label={muted ? 'Unmute' : 'Mute'}
+                className={cn(
+                  'v3-focus grid size-14 cursor-pointer place-items-center rounded-full border border-ink font-mono text-[9px] font-bold tracking-[0.1em]',
+                  muted ? 'bg-ink text-bg' : 'bg-bg hover:bg-[var(--overlay)]',
+                )}
+              >
+                {muted ? 'MUTED' : 'MUTE'}
+              </button>
+            </div>
+
+            {/* volume fader — the pitch-slider hardware, now the volume control */}
+            <div className="flex flex-col items-center gap-2 lg:absolute lg:right-6 lg:bottom-6">
+              <div
+                ref={faderRef}
+                role="slider"
+                aria-label="Volume"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={Math.round(volume * 100)}
+                tabIndex={0}
+                onPointerDown={e => { e.currentTarget.setPointerCapture(e.pointerId); setVolFromPointer(e.clientY); }}
+                onPointerMove={e => { if (e.buttons) setVolFromPointer(e.clientY); }}
+                onKeyDown={e => {
+                  if (e.key === 'ArrowUp') { e.preventDefault(); adjustVolume(0.05); }
+                  else if (e.key === 'ArrowDown') { e.preventDefault(); adjustVolume(-0.05); }
+                }}
+                className="v3-focus relative h-20 w-7 cursor-pointer touch-none border border-ink bg-bg lg:h-36"
+              >
+                <span className="pointer-events-none absolute top-2 bottom-2 left-1/2 w-px -translate-x-1/2 bg-soft-border" aria-hidden="true" />
+                <span className="pointer-events-none absolute top-2 left-1 h-px w-[3px] bg-[var(--accent)]" aria-hidden="true" />
+                <span className="pointer-events-none absolute bottom-2 left-1 h-px w-[3px] bg-[var(--accent)]" aria-hidden="true" />
+                <span className={cn('pointer-events-none absolute inset-x-0 bottom-0 bg-[var(--muted)]', styles.faderFill)} aria-hidden="true" />
+                <span className={cn('pointer-events-none absolute -right-[3px] -left-[3px] h-3 -translate-y-1/2 border border-ink bg-ink', styles.faderThumb)} aria-hidden="true" />
+              </div>
+              <span className="font-mono text-[8px] font-bold tracking-[0.2em] text-muted uppercase">vol {Math.round(volume * 100)}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* ===== metadata column ===== */}
+        <div className="flex min-h-0 min-w-0 flex-none flex-col gap-3 overflow-hidden p-4 lg:flex-1 lg:gap-4 lg:overflow-y-auto lg:p-6">
+          {/* now playing */}
+          <div className="flex items-start gap-5">
+            <div className="size-[84px] flex-none border border-ink bg-[var(--field)] sm:size-[104px]">
+              {nowPlaying?.subsonic_id && !offline ? (
+                <img src={client.coverUrl(nowPlaying.subsonic_id)} alt="" className="h-full w-full object-cover" />
+              ) : (
+                <div className="grid h-full w-full place-items-center font-mono text-[9px] text-muted">Sleeve</div>
+              )}
+            </div>
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <span className="font-mono text-[10px] font-bold tracking-[0.22em] text-[var(--accent)] uppercase">
+                now spinning
+              </span>
+              <span className="truncate font-display text-[clamp(30px,5vw,54px)] leading-[0.98] font-extrabold italic">
+                {title}
+              </span>
+              {artist && (
+                <span className="truncate font-mono text-[14px] tracking-[0.14em] uppercase">{artist}</span>
+              )}
+              {!offline && (nowPlaying?.album || nowPlaying?.year) && (
+                <span className="truncate font-mono text-[11px] tracking-[0.12em] text-muted uppercase">
+                  {[nowPlaying.album, nowPlaying.year].filter(Boolean).join(' · ')}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* chips */}
+          {(meta.facts.length > 0 || meta.moods.length > 0) && !offline && (
+            <div className="flex flex-nowrap gap-[7px] overflow-hidden lg:flex-wrap">
+              {meta.facts.map(f => (
+                <span key={f} className="border border-ink px-2.5 py-1 font-mono text-[10px] tracking-[0.1em]">{f}</span>
+              ))}
+              {meta.moods.map(m => (
+                <span key={m} className="border border-[var(--accent)] px-2.5 py-1 font-mono text-[10px] tracking-[0.1em] text-[var(--accent)] uppercase">
+                  {m}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* progress */}
+          <div className="flex items-center gap-3">
+            <span className="font-mono text-[13px] font-bold tabular-nums">{fmtTime(elapsed)}</span>
+            <div className="relative h-1 flex-1 bg-soft-border">
+              <div className={cn('absolute inset-y-0 left-0 bg-[var(--accent)]', ratio == null ? 'w-full opacity-40' : styles.progFill)} />
+              {ratio != null && <div className={cn('absolute top-[-5px] h-[13px] w-[3px] bg-ink', styles.progHead)} />}
+            </div>
+            <span className="font-mono text-[13px] text-muted tabular-nums">
+              {nowPlaying?.duration ? fmtTime(nowPlaying.duration) : 'live'}
+            </span>
+          </div>
+
+          <div className="h-px bg-soft-border" />
+
+          {/* up next */}
+          <div className="flex flex-col border border-ink bg-[var(--field)]">
+            <div className="border-b border-soft-border px-3.5 py-2.5 font-mono text-[9px] font-bold tracking-[0.22em] text-muted uppercase">
+              next on the platter
+            </div>
+            {upNext.length > 0 ? (
+              upNext.map((t, i) => (
+                <div
+                  key={`${t.title ?? i}-${i}`}
+                  className={cn(
+                    'flex items-center gap-3 px-3.5 py-2.5',
+                    i < upNext.length - 1 && 'border-b border-soft-border max-lg:border-b-0',
+                    i > 0 && 'hidden lg:flex',
+                  )}
+                >
+                  <span className={cn('font-mono text-[9px] tracking-[0.18em]', i === 0 ? 'text-[var(--accent)]' : 'text-muted')}>
+                    {i === 0 ? 'CUED' : 'THEN'}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-[14px] font-bold">{t.title ?? '—'}</div>
+                    {t.artist && <div className="truncate text-[11px] text-muted">{t.artist}</div>}
+                  </div>
+                </div>
+              ))
+            ) : (
+              <div className="px-3.5 py-2.5 font-mono text-[11px] text-muted">
+                nothing cued — {djName} decides at the run-out
+              </div>
+            )}
+          </div>
+
+          {/* booth quote — the DJ's voice. Hidden in the single-column (phone /
+              narrow) layout so the deck fits one screen without scrolling; it
+              returns in the two-column layout (lg) where the column scrolls. */}
+          {voice && (
+            <div className="hidden flex-1 flex-col gap-2 border border-ink bg-bg px-4 py-3.5 lg:flex">
+              <span className="flex items-center gap-2 font-mono text-[10px] font-bold tracking-[0.18em] text-[var(--accent)] uppercase">
+                <span className={cn('size-[7px] rounded-full bg-[var(--accent)]', styles.pulse, playing && styles.playing)} />
+                on air — {djName}
+              </span>
+              <span className="text-[15px] leading-relaxed italic">“{voice.text}”</span>
+            </div>
+          )}
+
+          {/* request slip */}
+          <form
+            className="border border-ink bg-[var(--field)] px-4 py-3"
+            onSubmit={e => { e.preventDefault(); void slip.send(); }}
+          >
+            {slip.ack ? (
+              <div className="flex flex-col gap-2">
+                <div className="text-[13px] leading-relaxed italic">{slip.ack}</div>
+                <button
+                  type="button"
+                  onClick={slip.reset}
+                  className="v3-focus cursor-pointer self-start border-0 bg-transparent p-0 font-mono text-[10px] font-bold tracking-[0.14em] text-muted uppercase hover:text-ink"
+                >
+                  new slip
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-baseline gap-3">
+                <span className="flex-none font-mono text-[10px] font-bold tracking-[0.16em] text-muted uppercase">Dear DJ —</span>
+                <input
+                  ref={reqInputRef}
+                  value={slip.text}
+                  onChange={e => slip.setText(e.target.value)}
+                  placeholder="a song, an artist, a feeling…"
+                  className="v3-focus min-w-0 flex-1 border-0 border-b border-soft-border bg-transparent pb-1 text-[13px] text-ink italic outline-none placeholder:text-muted"
+                />
+                <button
+                  type="submit"
+                  disabled={slip.sending || !slip.text.trim()}
+                  className={cn(
+                    'v3-focus flex-none border-0 bg-transparent p-0 font-mono text-[10px] font-bold tracking-[0.14em] uppercase',
+                    slip.sending || !slip.text.trim()
+                      ? 'cursor-default text-muted opacity-60'
+                      : 'cursor-pointer text-[var(--accent)] hover:opacity-80',
+                  )}
+                >
+                  {slip.sending ? 'sending…' : 'send ↗'}
+                </button>
+              </div>
+            )}
+          </form>
+        </div>
+      </div>
+
+      {/* footer status strip */}
+      <div className="flex flex-none items-center gap-4 border-t border-ink bg-[var(--field)] px-6 py-3 font-mono text-[10px] tracking-[0.16em] uppercase">
+        <span className={cn('flex items-center gap-2 font-bold', offline ? 'text-muted' : 'text-[var(--accent)]')}>
+          <span className={cn('size-2 rounded-full', offline ? 'bg-[var(--muted)]' : cn('bg-[var(--accent)]', styles.pulse, playing && styles.playing))} />
+          {offline ? 'off air' : playing ? 'tuned · locked' : 'standby'}
+        </span>
+        {listenerCount != null && (
+          <span className="flex items-center gap-1.5 border-l border-soft-border pl-4 text-muted">
+            <svg viewBox="0 0 24 24" className="size-3.5 fill-none stroke-current" strokeWidth={2} aria-hidden="true">
+              <path d="M4 14v-2a8 8 0 0 1 16 0v2" strokeLinecap="round" />
+              <rect x="2.5" y="13" width="4" height="7.5" rx="1.5" />
+              <rect x="17.5" y="13" width="4" height="7.5" rx="1.5" />
+            </svg>
+            {listenerCount}
+            <span className="sr-only">listening</span>
+          </span>
+        )}
+        {signal.latencyMs != null && tunedIn && !offline && (
+          <span className="text-muted">sig {signal.latencyMs} ms · {signal.quality}</span>
+        )}
+        <span className="ml-auto hidden text-muted sm:inline">stereo · 96 kHz</span>
+      </div>
+
+      {/* tune-in gate — the deck sits at rest with the arm parked; one tap
+          drops the needle and the platter spins up. */}
+      {showOverlay && !offline && (
+        <button
+          type="button"
+          onClick={tuneInFromOverlay}
+          className="absolute inset-0 z-40 grid w-full cursor-pointer place-items-center border-0 bg-[var(--bg)]/95 p-6"
+        >
+          <span className="grid justify-items-center gap-6">
+            <Deck playing={false} stationName={stationName} title={nowPlaying?.title ?? 'one live stream'} artist={artist} />
+            <span className="grid justify-items-center gap-1.5 text-center">
+              <span className="font-mono text-[11px] font-bold tracking-[0.24em] text-[var(--accent)] uppercase">
+                ▶ drop the needle
+              </span>
+              <span className="font-mono text-[11px] tracking-[0.2em] text-muted uppercase">tap to tune in</span>
+            </span>
+          </span>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/components/skins/platter/PlatterSkin.tsx
+++ b/web/components/skins/platter/PlatterSkin.tsx
@@ -31,6 +31,7 @@ import {
   lastVoiceLine,
   listenerCountOf,
   progressRatio,
+  stationIdentity,
   trackMeta,
 } from '../shared';
 import { useRequestSlip, useVolumeNudge } from '../sharedHooks';
@@ -138,10 +139,7 @@ export default function PlatterSkin(_props: SkinProps) {
 
   const elapsed = useElapsed(trackStartedAt);
   const listenerCount = listenerCountOf(listeners);
-  const stationName = (typeof dj?.station === 'string' && dj.station) || 'SUB/WAVE';
-  const djName =
-    activeShow?.persona?.name || (typeof dj?.name === 'string' ? dj.name : '') || 'the DJ';
-  const showName = activeShow?.name || context?.time?.show || '';
+  const { stationName, djName, showName } = stationIdentity(dj, activeShow, context);
   const meta = trackMeta(nowPlaying);
   const ratio = progressRatio(elapsed, nowPlaying?.duration);
   const voice = lastVoiceLine(session.messages);

--- a/web/components/skins/shared.ts
+++ b/web/components/skins/shared.ts
@@ -12,7 +12,7 @@ import {
 } from '@/lib/sessionFeed';
 import { fmtClockMinute } from '@/lib/format';
 import type { StationLocale } from '@/lib/format';
-import type { ListenerCount, SessionTurn, StationContext } from '@/lib/types';
+import type { ActiveShow, DjState, ListenerCount, SessionTurn, StationContext } from '@/lib/types';
 
 /** Normalise the feed's `number | { current } | null` listener shape. */
 export function listenerCountOf(
@@ -21,6 +21,35 @@ export function listenerCountOf(
   if (listeners == null) return null;
   if (typeof listeners === 'number') return listeners;
   return listeners.current ?? null;
+}
+
+export interface StationIdentity {
+  /** Broadcaster name — the masthead brand. */
+  stationName: string;
+  /** On-air DJ name — the show's persona if one is airing, else the global DJ. */
+  djName: string;
+  /** Current show title, or the time-of-day period when no show is scheduled. */
+  showName: string;
+}
+
+/** The three masthead facts every skin derives — centralised here so they
+ *  can't drift between skins. DJ name prefers the on-air show's persona (a
+ *  scheduled show can hand the hour to a guest); show name falls back to the
+ *  time-of-day period; both fall back to sensible defaults so a fresh install
+ *  still reads cleanly. */
+export function stationIdentity(
+  dj: DjState | null,
+  activeShow: ActiveShow | null,
+  context: StationContext | null,
+): StationIdentity {
+  return {
+    stationName: (typeof dj?.station === 'string' && dj.station) || 'SUB/WAVE',
+    djName:
+      activeShow?.persona?.name ||
+      (typeof dj?.name === 'string' ? dj.name : '') ||
+      'the DJ',
+    showName: activeShow?.name || context?.time?.show || '',
+  };
 }
 
 export interface BoothLine {

--- a/web/components/skins/spool/Spool.module.css
+++ b/web/components/skins/spool/Spool.module.css
@@ -1,20 +1,54 @@
-/* Spool skin — keyframes for the rotating cassette hubs. The supply reel
-   thins and the take-up reel fattens via dynamic sizing (useDynamicStyle);
-   rotation itself is pure CSS so it never re-renders anything. */
+/* Spool — a tape-deck face. Everything that moves is a co-located keyframe so
+   playback churn never re-renders React; each spinner idles at `paused` and
+   only runs when `.playing` is also applied (music actually airing), which
+   keeps a tuned-out deck still and lets html.lite's global keyframe kill stop
+   the whole deck for free. Reel diameters ride --reel-l/--reel-r (the wound
+   tape thins on the supply reel and fattens on the take-up reel across the
+   runtime). Design ref: Skins Canvas 1a. */
 
-@keyframes spool-spin {
-  to { transform: rotate(360deg); }
+@keyframes spool-spin { to { transform: rotate(360deg); } }
+@keyframes spool-sheen { 0%, 100% { opacity: 0; } 50% { opacity: 0.45; } }
+@keyframes spool-vu {
+  0% { transform: rotate(-20deg); }
+  30% { transform: rotate(24deg); }
+  55% { transform: rotate(4deg); }
+  80% { transform: rotate(18deg); }
+  100% { transform: rotate(-20deg); }
 }
 
+.hub,
+.sheen,
+.vu { animation-play-state: paused; }
+.playing { animation-play-state: running; }
+
+/* Toothed reel hub — a sprocket that turns while playing. */
 .hub {
-  animation: spool-spin 2.4s linear infinite;
-  animation-play-state: paused;
+  background: repeating-conic-gradient(var(--bg) 0 20deg, #cfc9bb 20deg 30deg);
+  animation: spool-spin 4.2s linear infinite;
 }
 
-.hubFast {
-  animation-duration: 1.7s;
+/* Wound tape — the dark grooved disc around the hub. Off-token (tape is dark
+   in any theme, like the record on the Platter skin); diameter set as a % of
+   the tape window via --reel-l / --reel-r so it scales with the deck. */
+.wound {
+  background: repeating-radial-gradient(circle, #211e1b 0 2px, #33302b 2px 4px);
+  border: 1px solid #444038;
+}
+.reelL { width: var(--reel-l, 42%); }
+.reelR { width: var(--reel-r, 32%); }
+
+/* Light sheen crossing the tape window. */
+.sheen {
+  background: linear-gradient(115deg, transparent 40%, rgba(243, 239, 230, 0.18) 50%, transparent 60%);
+  animation: spool-sheen 5.5s ease-in-out infinite;
 }
 
-.spinning {
-  animation-play-state: running;
+/* VU needle — swings while playing (decorative level, not a real analyser). */
+.vu {
+  transform-origin: bottom center;
+  animation: spool-vu 1.3s ease-in-out infinite;
 }
+
+/* Dynamic fills — progress + volume, driven by --pf / --vf on the skin root. */
+.progFill { width: calc(var(--pf, 0) * 100%); }
+.volFill { width: calc(var(--vf, 0) * 100%); }

--- a/web/components/skins/spool/SpoolSkin.tsx
+++ b/web/components/skins/spool/SpoolSkin.tsx
@@ -72,7 +72,7 @@ export default function SpoolSkin(_props: SkinProps) {
   } = usePlayerFeed();
   const { tunedIn, status, volume, muted, offline, signal } = usePlayerAudio();
   const { toggleMute } = usePlayerActions();
-  const { showTuneIn, tuneInFromOverlay, handleTune } = useTuneInGate();
+  const { showTuneIn, showOverlay, tuneInFromOverlay, handleTune } = useTuneInGate();
 
   const elapsed = useElapsed(trackStartedAt);
   const stationLocale = normalizeStationLocale(locale);
@@ -390,7 +390,7 @@ export default function SpoolSkin(_props: SkinProps) {
 
       {/* tune-in gate — the deck sits with its door open; one tap clunks it
           shut and the spools start. */}
-      {showTuneIn && !offline && (
+      {showOverlay && !offline && (
         <button
           type="button"
           onClick={tuneInFromOverlay}

--- a/web/components/skins/spool/SpoolSkin.tsx
+++ b/web/components/skins/spool/SpoolSkin.tsx
@@ -1,14 +1,18 @@
 'use client';
 
-// Spool — a walkman deck; the whole station fits on one cassette.
-// Pocketable · tactile · warm. Design ref: Skins Canvas 1a.
+// Spool — a tape deck; the whole station rides on one cassette.
+// Tactile · warm · mechanical. Design ref: Skins Canvas 1a.
 //
-// The supply reel thins as the take-up reel fattens across the track's
-// runtime (dynamic hub sizes off the progress ratio); both spin while
-// playing. History is a stack of rewound tapes, the queue head sits on the
-// stack, and requests are a Side B paper slip passed to the booth.
+// Desktop is a three-column console: Recently rewound (history) on the left,
+// the deck + cassette hero in the middle, up-next and the Side-B request slip
+// on the right. Mobile collapses to a single screen with a bottom tab bar
+// (Deck / Rewound / Stack / Slip) so nothing scrolls off. Both reels spin
+// while playing; the supply reel's wound tape thins as the take-up reel
+// fattens across the runtime (dynamic diameters), a slow sheen crosses the
+// window, and the VU needle rides. Everything that moves is a co-located
+// keyframe (Spool.module.css) so it never re-renders React.
 
-import { useRef } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import styles from './Spool.module.css';
 import {
   usePlayerActions,
@@ -22,7 +26,6 @@ import { useDynamicStyle } from '@/hooks/useDynamicStyle';
 import ThemeSwitcher from '@/components/ThemeSwitcher';
 import { cn } from '@/lib/cn';
 import { fmtTime, normalizeStationLocale } from '@/lib/format';
-import { useStationClient } from '@/lib/stationClient';
 import {
   contextLine,
   entryTime,
@@ -35,43 +38,66 @@ import {
 import { useRequestSlip, useVolumeNudge } from '../sharedHooks';
 import type { SkinProps } from '../types';
 
-/** Two little tape hubs — the cassette signature, reused on every card. */
+/** One reel — a dark wound-tape disc (diameter rides --reel-l/--reel-r) with a
+ *  toothed sprocket hub that turns while playing. */
+function Reel({
+  playing, reelClass, hubClass, dotClass,
+}: {
+  playing: boolean; reelClass?: string; hubClass: string; dotClass: string;
+}) {
+  return (
+    <div className={cn('relative grid aspect-square flex-none place-items-center', reelClass)} aria-hidden="true">
+      <span className={cn('absolute inset-0 rounded-full', styles.wound)} />
+      <span className={cn('grid place-items-center rounded-full border border-ink', styles.hub, hubClass, playing && styles.playing)}>
+        <span className={cn('rounded-full bg-ink', dotClass)} />
+      </span>
+    </div>
+  );
+}
+
+/** The tape window — the two reels behind glass with the exposed tape bridge,
+ *  capstan and a slow light sheen. Reused across desktop, mobile and the gate. */
+function TapeWindow({
+  playing, hubClass, dotClass, className,
+}: {
+  playing: boolean; hubClass: string; dotClass: string; className?: string;
+}) {
+  return (
+    <div className={cn('relative flex min-h-0 items-center justify-between overflow-hidden bg-ink', className)} aria-hidden="true">
+      <Reel playing={playing} reelClass={styles.reelL} hubClass={hubClass} dotClass={dotClass} />
+      <span className="pointer-events-none absolute inset-x-[8%] bottom-3 h-[2px] bg-linear-to-r from-transparent via-[#4a453c] to-transparent" />
+      <span className="pointer-events-none absolute bottom-2 left-1/2 size-2 -translate-x-1/2 rounded-full border border-ink bg-bg" />
+      <span className={cn('pointer-events-none absolute inset-0', styles.sheen, playing && styles.playing)} />
+      <Reel playing={playing} reelClass={styles.reelR} hubClass={hubClass} dotClass={dotClass} />
+    </div>
+  );
+}
+
+/** Two little reels — the cassette signature on up-next cards. */
 function MiniHubs() {
   return (
-    <div className="flex gap-11" aria-hidden="true">
-      <span className="h-3.5 w-3.5 rounded-full border-[3px] border-[var(--muted)]" />
-      <span className="h-3.5 w-3.5 rounded-full border-[3px] border-[var(--muted)]" />
+    <div className="flex gap-10" aria-hidden="true">
+      <span className="size-3.5 rounded-full border-[3px] border-[var(--muted)]" />
+      <span className="size-3.5 rounded-full border-[3px] border-[var(--muted)]" />
     </div>
   );
 }
 
-function Spool({ playing, fast, sizeRef }: { playing: boolean; fast?: boolean; sizeRef: React.RefObject<HTMLDivElement | null> }) {
-  return (
-    <div
-      ref={sizeRef}
-      className="grid place-items-center rounded-full bg-[var(--muted)]"
-      aria-hidden="true"
-    >
-      <div
-        className={cn(
-          'box-border h-[42px] w-[42px] rounded-full border-[5px] border-dashed border-ink bg-bg',
-          styles.hub,
-          fast && styles.hubFast,
-          playing && styles.spinning,
-        )}
-      />
-    </div>
-  );
-}
+type MobileTab = 'deck' | 'rewound' | 'stack' | 'slip';
+const MOBILE_TABS: { id: MobileTab; label: string }[] = [
+  { id: 'deck', label: 'Deck' },
+  { id: 'rewound', label: 'Rewound' },
+  { id: 'stack', label: 'Stack' },
+  { id: 'slip', label: 'Slip' },
+];
 
 export default function SpoolSkin(_props: SkinProps) {
-  const client = useStationClient();
   const {
     nowPlaying, context, dj, activeShow, listeners, state, session,
     trackStartedAt, timezone, locale,
   } = usePlayerFeed();
-  const { tunedIn, status, volume, muted, offline, signal } = usePlayerAudio();
-  const { toggleMute } = usePlayerActions();
+  const { tunedIn, status, volume, muted, offline } = usePlayerAudio();
+  const { toggleMute, setVolume, stop } = usePlayerActions();
   const { showTuneIn, showOverlay, tuneInFromOverlay, handleTune } = useTuneInGate();
 
   const elapsed = useElapsed(trackStartedAt);
@@ -82,23 +108,42 @@ export default function SpoolSkin(_props: SkinProps) {
     activeShow?.persona?.name || (typeof dj?.name === 'string' ? dj.name : '') || 'the DJ';
   const showName = activeShow?.name || context?.time?.show || '';
   const meta = trackMeta(nowPlaying);
-  const ratio = progressRatio(elapsed, nowPlaying?.duration) ?? 0.5;
+  const ratio = progressRatio(elapsed, nowPlaying?.duration);
+  const ratioSafe = ratio ?? 0.5;
   const voice = lastVoiceLine(session.messages);
-  const upNext = state.upcoming?.[0];
-  const history = (state.history ?? []).slice(0, 2);
+  const upNext = (state.upcoming ?? []).slice(0, 6);
+  const history = (state.history ?? []).slice(0, 12);
   const playing = tunedIn && status === 'playing' && !offline;
 
-  // Supply reel empties into the take-up reel across the runtime.
-  const leftPx = Math.round(100 - 36 * ratio);
-  const rightPx = Math.round(64 + 36 * ratio);
-  const leftRef = useRef<HTMLDivElement | null>(null);
-  const rightRef = useRef<HTMLDivElement | null>(null);
-  useDynamicStyle(leftRef, { width: `${leftPx}px`, height: `${leftPx}px` });
-  useDynamicStyle(rightRef, { width: `${rightPx}px`, height: `${rightPx}px` });
+  const title = offline ? '— off air —' : (nowPlaying?.title ?? 'Scanning the dial…');
+  const artist = offline ? '' : (nowPlaying?.artist ?? '');
 
+  const [tab, setTab] = useState<MobileTab>('deck');
   const adjustVolume = useVolumeNudge();
 
-  // Side B request slip.
+  // Progress + volume fills and reel diameters, all via CSS vars (no inline
+  // style attribute). The supply reel (left) thins as the take-up (right) fills.
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  useDynamicStyle(rootRef, {
+    '--pf': ratio ?? 0,
+    '--vf': volume,
+    '--reel-l': `${(46 - 12 * ratioSafe).toFixed(1)}%`,
+    '--reel-r': `${(30 + 12 * ratioSafe).toFixed(1)}%`,
+  });
+
+  // Horizontal VOL fader (desktop) — map pointer X to level.
+  const volRef = useRef<HTMLDivElement | null>(null);
+  const setVolFromPointer = useCallback(
+    (clientX: number) => {
+      const el = volRef.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      const frac = (clientX - r.left) / r.width;
+      setVolume(Math.min(1, Math.max(0, Math.round(frac * 100) / 100)));
+    },
+    [setVolume],
+  );
+
   const slip = useRequestSlip({
     sent: 'Slip passed to the booth — the DJ has it.',
     refused: 'The booth waved this one off.',
@@ -106,318 +151,456 @@ export default function SpoolSkin(_props: SkinProps) {
   });
   const reqInputRef = useRef<HTMLInputElement | null>(null);
 
-  // Live even while the gate is up so Space/K tune in like every other skin;
-  // only `r` waits — the request input it focuses sits under the gate.
+  const playIn = () => { if (!tunedIn) handleTune(); };
+  const stopOut = () => { if (tunedIn) stop(); };
+
   useKeyboardShortcuts({
     space: handleTune,
     k: handleTune,
     arrowup: () => adjustVolume(0.05),
     arrowdown: () => adjustVolume(-0.05),
     m: toggleMute,
-    r: () => { if (!showTuneIn) reqInputRef.current?.focus(); },
+    r: () => { if (!showTuneIn) { setTab('slip'); reqInputRef.current?.focus(); } },
   });
 
+  // ── shared control atoms ────────────────────────────────────────────────
+  const playKey = (extra: string) => (
+    <button
+      type="button"
+      onClick={playIn}
+      aria-label="Tune in"
+      aria-pressed={playing}
+      className={cn(
+        'v3-focus flex cursor-pointer items-center justify-center gap-2 border border-ink',
+        playing
+          ? 'bg-[var(--accent)] text-bg shadow-[inset_0_3px_6px_rgba(0,0,0,0.25)]'
+          : 'bg-bg hover:bg-[var(--overlay)]',
+        extra,
+      )}
+    >
+      ▶<span className="font-mono font-bold tracking-[0.14em]">PLAY</span>
+    </button>
+  );
+  const stopKey = (extra: string) => (
+    <button
+      type="button"
+      onClick={stopOut}
+      aria-label="Tune out"
+      className={cn('v3-focus flex cursor-pointer items-center justify-center border border-ink bg-bg hover:bg-[var(--overlay)]', extra)}
+    >
+      ■
+    </button>
+  );
+  const muteKey = (extra: string) => (
+    <button
+      type="button"
+      onClick={toggleMute}
+      aria-pressed={muted}
+      aria-label={muted ? 'Unmute' : 'Mute'}
+      className={cn(
+        'v3-focus flex cursor-pointer items-center justify-center border border-ink font-mono font-bold tracking-[0.1em]',
+        muted ? 'bg-ink text-bg' : 'bg-bg hover:bg-[var(--overlay)]',
+        extra,
+      )}
+    >
+      {muted ? 'MUTED' : 'MUTE'}
+    </button>
+  );
+
+  const requestForm = (
+    <form
+      className="flex min-h-0 flex-1 flex-col gap-3"
+      onSubmit={e => { e.preventDefault(); void slip.send(); }}
+    >
+      {slip.ack ? (
+        <div className="flex flex-col gap-2">
+          <div className="text-[13px] leading-relaxed italic">{slip.ack}</div>
+          <button
+            type="button"
+            onClick={slip.reset}
+            className="v3-focus cursor-pointer self-start border-0 bg-transparent p-0 font-mono text-[11px] font-bold tracking-[0.14em] text-muted uppercase hover:text-ink"
+          >
+            new slip
+          </button>
+        </div>
+      ) : (
+        <>
+          <div className="text-[13px] text-muted italic">Dear DJ —</div>
+          <input
+            ref={reqInputRef}
+            value={slip.text}
+            onChange={e => slip.setText(e.target.value)}
+            placeholder="a song, an artist, a feeling…"
+            className="v3-focus w-full border-0 border-b border-soft-border bg-transparent pb-1 text-[13px] text-ink italic outline-none placeholder:text-muted"
+          />
+          <input
+            value={slip.name}
+            onChange={e => slip.setName(e.target.value)}
+            placeholder="from (optional)"
+            className="v3-focus w-full border-0 border-b border-soft-border bg-transparent pb-1 text-[13px] text-ink italic outline-none placeholder:text-muted"
+          />
+          <button
+            type="submit"
+            disabled={slip.sending || !slip.text.trim()}
+            className={cn(
+              'v3-focus mt-auto self-start border-0 bg-transparent p-0 font-mono text-[11px] font-bold tracking-[0.14em] uppercase',
+              slip.sending || !slip.text.trim()
+                ? 'cursor-default text-muted opacity-60'
+                : 'cursor-pointer text-[var(--accent)] hover:opacity-80',
+            )}
+          >
+            {slip.sending ? 'passing…' : 'pass it to the booth ↗'}
+          </button>
+        </>
+      )}
+    </form>
+  );
+
+  const historyList = (
+    <>
+      {history.length === 0 && (
+        <div className="p-4 font-mono text-[11px] text-muted">nothing on the shelf yet</div>
+      )}
+      {history.map((h, i) => (
+        <div
+          key={`${h.t ?? i}-${h.title ?? i}`}
+          className="flex flex-none items-center gap-3 border-b border-soft-border px-4 py-2.5"
+        >
+          <span className="size-2 flex-none rounded-full border-2 border-[var(--muted)]" />
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-[13px] font-bold">{h.title ?? '?'}</div>
+            {h.artist && <div className="truncate text-[11px] text-muted">{h.artist}</div>}
+          </div>
+          <span className="flex-none font-mono text-[10px] text-muted">{turnClock(entryTime(h), timezone, stationLocale)}</span>
+        </div>
+      ))}
+    </>
+  );
+
+  const onAirQuote = (extra?: string) =>
+    voice && (
+      <div className={cn('flex flex-col gap-2 border border-ink bg-bg px-4 py-3.5', extra)}>
+        <span className="flex items-center gap-2 font-mono text-[10px] font-bold tracking-[0.18em] text-[var(--accent)] uppercase">
+          <span className="size-[7px] rounded-full bg-[var(--accent)]" />
+          on air — {djName}
+        </span>
+        <span className="text-[14px] leading-relaxed italic">“{voice.text}”</span>
+      </div>
+    );
+
   return (
-    <div className="absolute inset-0 flex flex-col overflow-y-auto font-sans text-ink">
-      {/* masthead — one row: station line truncates, context is desktop-only,
-          theme icon pinned top-right (never wraps below) */}
-      <div className="flex flex-none items-center justify-between gap-x-6 border-b border-soft-border px-5 py-3 sm:px-8">
+    <div ref={rootRef} className="absolute inset-0 flex flex-col overflow-hidden bg-bg font-sans text-ink">
+      {/* masthead */}
+      <div className="flex flex-none items-center justify-between gap-x-6 border-b border-ink px-5 py-3 sm:px-8">
         <div className="flex min-w-0 items-center gap-3">
           <span className={cn('h-2.5 w-2.5 flex-none rounded-full', offline ? 'bg-[var(--muted)]' : 'bg-[var(--accent)]')} />
           <span className="flex-none text-[15px] font-extrabold tracking-[0.12em]">{stationName.toUpperCase()}</span>
-          {showName && (
-            <span className="hidden truncate font-mono text-[11px] tracking-[0.18em] uppercase sm:inline">▸ {showName}</span>
-          )}
-          <span className="truncate font-mono text-[11px] tracking-[0.18em] text-[var(--accent)] uppercase">with {djName}</span>
+          <span className="hidden border-l border-soft-border pl-3 font-mono text-[10px] tracking-[0.2em] text-muted uppercase sm:inline">
+            SW-90 · portable deck
+          </span>
         </div>
         <div className="flex shrink-0 items-center gap-3">
-          <span className="hidden max-w-[40vw] truncate font-mono text-[11px] tracking-[0.16em] text-muted uppercase sm:inline">
-            {contextLine(context)}
-          </span>
+          <div className="hidden items-center gap-3 font-mono text-[11px] tracking-[0.16em] uppercase md:flex">
+            {showName && <span className="max-w-[20vw] truncate">▸ {showName}</span>}
+            <span className="text-[var(--accent)]">with {djName}</span>
+            <span className="max-w-[22vw] truncate border-l border-soft-border pl-3 text-muted">
+              {contextLine(context) || (offline ? 'off air' : 'on air')}
+            </span>
+          </div>
           <ThemeSwitcher />
         </div>
       </div>
 
-      <div className="grid w-full flex-1 grid-cols-1 gap-8 p-5 sm:p-9 lg:grid-cols-[1fr_300px]">
-        {/* the deck — top-aligned, horizontally centred in its column */}
-        <div className="order-1 flex min-w-0 flex-col gap-4 lg:mx-auto lg:w-full lg:max-w-[640px]">
-          <div className="flex flex-col gap-4 border border-ink bg-[var(--field)] p-4 sm:p-5">
-            {/* cassette label — the cover art tints the whole panel (its shade),
-                and the crisp thumbnail now shows on every screen, mobile too */}
-            <div className="relative overflow-hidden border border-ink bg-bg">
-              {nowPlaying?.subsonic_id && !offline && (
-                <>
-                  <img
-                    src={client.coverUrl(nowPlaying.subsonic_id)}
-                    alt=""
-                    aria-hidden="true"
-                    className="pointer-events-none absolute inset-0 h-full w-full scale-110 object-cover opacity-60 blur-2xl saturate-150"
-                  />
-                  <div className="pointer-events-none absolute inset-0 bg-bg/40" aria-hidden="true" />
-                </>
-              )}
-              <div className="relative h-2 bg-[var(--accent)]" />
-              <div className="relative flex gap-4 p-4 sm:gap-5 sm:p-5">
-                <div className="h-20 w-20 flex-none border border-ink sm:h-[118px] sm:w-[118px]">
-                  {nowPlaying?.subsonic_id && !offline ? (
-                    <img src={client.coverUrl(nowPlaying.subsonic_id)} alt="" className="h-full w-full object-cover" />
-                  ) : (
-                    <div className="grid h-full w-full place-items-center font-mono text-[9px] text-muted">no art</div>
-                  )}
-                </div>
-                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                  <div className="flex items-center justify-between gap-3">
-                    <span className="min-w-0 truncate font-mono text-[10px] tracking-[0.2em] text-muted uppercase">
-                      {stationName} · Side A{showName ? ` — ${showName}` : ''}
-                    </span>
-                    <span className="flex-none border border-ink px-1.5 font-mono text-[12px] font-bold">A</span>
-                  </div>
-                  <div className="truncate font-display text-[clamp(22px,3.2vw,38px)] leading-[1.05] font-bold italic">
-                    {offline ? <span className="text-muted not-italic">— off air —</span> : (nowPlaying?.title ?? 'Scanning the dial…')}
-                  </div>
-                  {!offline && nowPlaying?.artist && (
-                    <div className="truncate font-mono text-[13px] tracking-[0.14em] uppercase">{nowPlaying.artist}</div>
-                  )}
-                  {!offline && (nowPlaying?.album || nowPlaying?.year) && (
-                    <div className="truncate font-mono text-[11px] tracking-[0.12em] text-muted uppercase">
-                      {[nowPlaying.album, nowPlaying.year].filter(Boolean).join(' · ')}
+      <div className="flex min-h-0 flex-1 flex-col">
+        {/* ===================== desktop: three-column console ===================== */}
+        <div className="hidden min-h-0 flex-1 grid-cols-[288px_1fr_288px] gap-7 p-7 lg:grid">
+          {/* left — recently rewound */}
+          <section className="flex min-h-0 flex-col gap-3">
+            <div className="font-mono text-[10px] font-bold tracking-[0.2em] uppercase">Recently rewound</div>
+            <div className="flex min-h-0 flex-1 flex-col border border-ink bg-[var(--field)]">
+              <div className="min-h-0 flex-1 overflow-y-auto">{historyList}</div>
+              <div className="flex flex-none items-center justify-between border-t border-soft-border px-4 py-3 font-mono text-[10px] tracking-[0.14em] text-muted uppercase">
+                <span>{history.length} rewound</span>
+                {listenerCount != null && <span className="font-bold text-[var(--accent)]">{listenerCount} listening</span>}
+              </div>
+            </div>
+          </section>
+
+          {/* center — the deck */}
+          <section className="flex min-h-0 flex-col gap-4">
+            <div className="flex min-h-0 flex-1 flex-col border border-ink bg-[var(--field)]">
+              {/* brand strip */}
+              <div className="flex flex-none items-center justify-between border-b border-soft-border px-5 py-3">
+                <span className="min-w-0 truncate font-mono text-[10px] font-bold tracking-[0.22em] uppercase">
+                  {stationName} · Side A{showName ? ` — ${showName}` : ''}
+                </span>
+                <span className="flex-none font-mono text-[10px] tracking-[0.16em] text-muted uppercase">TYPE II · Dolby NR ●</span>
+              </div>
+
+              {/* cassette hero */}
+              <div className="flex min-h-0 flex-1 items-center justify-center p-5">
+                <div className="relative flex aspect-[512/320] w-full max-w-[512px] flex-col border border-ink bg-bg shadow-[inset_0_0_0_8px_var(--field),inset_0_0_40px_rgba(0,0,0,0.06)]">
+                  <span className="absolute top-4 left-4 size-[7px] rounded-full border border-muted" aria-hidden="true" />
+                  <span className="absolute top-4 right-4 size-[7px] rounded-full border border-muted" aria-hidden="true" />
+                  <span className="absolute bottom-4 left-4 size-[7px] rounded-full border border-muted" aria-hidden="true" />
+                  <span className="absolute right-4 bottom-4 size-[7px] rounded-full border border-muted" aria-hidden="true" />
+
+                  {/* paper label */}
+                  <div className="relative mx-[8%] mt-[8%] mb-[3%] flex-none border border-ink bg-bg">
+                    <div className="absolute inset-y-0 left-0 w-2 bg-[var(--accent)]" aria-hidden="true" />
+                    <div className="flex items-baseline justify-between gap-3 py-2 pr-3.5 pl-5">
+                      <div className="min-w-0">
+                        <div className="truncate font-display text-[clamp(15px,2vw,24px)] leading-tight font-bold italic">
+                          {title}
+                        </div>
+                        <div className="mt-0.5 truncate font-mono text-[10px] tracking-[0.14em] text-muted uppercase">
+                          {[artist, nowPlaying?.year].filter(Boolean).join(' · ') || 'live stream'}
+                        </div>
+                      </div>
+                      <span className="flex-none border border-ink px-2 font-mono text-[12px] font-bold">A</span>
                     </div>
-                  )}
+                  </div>
+
+                  <TapeWindow
+                    playing={playing}
+                    hubClass="size-[46px]"
+                    dotClass="size-[18px]"
+                    className="mx-[8%] mb-[6%] flex-1 px-[7%]"
+                  />
+                </div>
+              </div>
+
+              {/* transport + counter + volume */}
+              <div className="flex flex-none flex-col gap-2.5 px-5 pb-5">
+                <div className="flex items-stretch gap-2.5">
+                  <div className="flex flex-none flex-col justify-center gap-0.5 border border-ink bg-bg px-3 py-2">
+                    <span className="font-mono text-[8px] tracking-[0.2em] text-muted uppercase">counter</span>
+                    <span className="font-mono text-[20px] font-bold tracking-[0.08em] tabular-nums">{fmtTime(elapsed)}</span>
+                  </div>
+                  <div className="flex flex-1 gap-2">
+                    <div className="relative flex w-16 flex-none items-end justify-center overflow-hidden border border-ink bg-ink pb-1.5">
+                      <span className="absolute top-1.5 left-1.5 font-mono text-[7px] tracking-[0.16em] text-bg">VU</span>
+                      <span className={cn('h-8 w-0.5 bg-[var(--accent)]', styles.vu, playing && styles.playing)} />
+                    </div>
+                    {playKey('flex-[1.6] text-[16px]')}
+                    {stopKey('flex-1 text-[12px]')}
+                    {muteKey('flex-1 text-[9px]')}
+                  </div>
+                </div>
+                {/* volume — the deck's output fader (keyboard ↑/↓ also work) */}
+                <div className="flex items-center gap-2">
+                  <span className="font-mono text-[8px] font-bold tracking-[0.2em] text-muted uppercase">vol</span>
+                  <button type="button" aria-label="Volume down" onClick={() => adjustVolume(-0.05)}
+                    className="v3-focus cursor-pointer border-0 bg-transparent px-1 font-mono text-[13px] text-muted hover:text-ink">−</button>
+                  <div
+                    ref={volRef}
+                    role="slider"
+                    aria-label="Volume"
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-valuenow={Math.round(volume * 100)}
+                    tabIndex={0}
+                    onPointerDown={e => { e.currentTarget.setPointerCapture(e.pointerId); setVolFromPointer(e.clientX); }}
+                    onPointerMove={e => { if (e.buttons) setVolFromPointer(e.clientX); }}
+                    onKeyDown={e => {
+                      if (e.key === 'ArrowRight' || e.key === 'ArrowUp') { e.preventDefault(); adjustVolume(0.05); }
+                      else if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') { e.preventDefault(); adjustVolume(-0.05); }
+                    }}
+                    className="v3-focus relative h-1.5 flex-1 cursor-pointer touch-none bg-soft-border"
+                  >
+                    <div className={cn('pointer-events-none absolute inset-y-0 left-0 bg-[var(--muted)]', styles.volFill)} />
+                  </div>
+                  <button type="button" aria-label="Volume up" onClick={() => adjustVolume(0.05)}
+                    className="v3-focus cursor-pointer border-0 bg-transparent px-1 font-mono text-[13px] text-muted hover:text-ink">+</button>
+                  <span className="w-7 text-right font-mono text-[10px] tabular-nums">{Math.round(volume * 100)}</span>
                 </div>
               </div>
             </div>
 
-            {/* the cassette — a dark smoky reel window over a ribbed lower
-                shell. Fixed dark in every theme (the themed ink inverts to a
-                light slab in dark mode); the window keeps its glass sheen and
-                the shell gives the deck a little more length. */}
-            <div className="bg-[#1a1613]">
-              {/* reel window */}
-              <div className="relative flex h-40 items-center justify-around">
-                <div className="absolute right-6 bottom-4 left-6 h-0.5 bg-[var(--muted)]" aria-hidden="true" />
-                <Spool playing={playing} sizeRef={leftRef} />
-                <Spool playing={playing} fast sizeRef={rightRef} />
-                <div className="pointer-events-none absolute inset-0 bg-linear-to-b from-white/10 via-transparent to-black/30" aria-hidden="true" />
-              </div>
-              {/* ribbed lower shell — hub screws either side of a textured band */}
-              <div className="flex items-center gap-3 border-t border-white/10 px-4 py-4">
-                <span className="size-2 rounded-full border border-white/20 bg-black/40" aria-hidden="true" />
-                <span className="h-3.5 flex-1 bg-[repeating-linear-gradient(90deg,transparent_0_4px,rgba(255,255,255,0.06)_4px_6px)]" aria-hidden="true" />
-                <span className="flex-none font-mono text-[9px] tracking-[0.24em] text-white/35 uppercase">Side A · 90 · Dolby B</span>
-                <span className="h-3.5 flex-1 bg-[repeating-linear-gradient(90deg,transparent_0_4px,rgba(255,255,255,0.06)_4px_6px)]" aria-hidden="true" />
-                <span className="size-2 rounded-full border border-white/20 bg-black/40" aria-hidden="true" />
-              </div>
-            </div>
-
+            {/* meta strip */}
             {(meta.facts.length > 0 || meta.moods.length > 0) && !offline && (
-              <div className="flex flex-wrap items-baseline justify-between gap-2">
-                <span className="font-mono text-[11px] tracking-[0.14em] uppercase">{meta.facts.join(' · ')}</span>
+              <div className="flex flex-none items-center justify-between gap-3 border border-ink bg-[var(--field)] px-4 py-2.5">
+                <span className="min-w-0 truncate font-mono text-[11px] tracking-[0.14em] uppercase">{meta.facts.join(' · ')}</span>
                 {meta.moods.length > 0 && (
-                  <span className="font-mono text-[11px] tracking-[0.14em] text-[var(--accent)] uppercase">
-                    ↳ {meta.moods.join(' · ')}
-                  </span>
+                  <span className="flex-none font-mono text-[11px] tracking-[0.14em] text-[var(--accent)] uppercase">↳ {meta.moods.join(' · ')}</span>
                 )}
               </div>
             )}
-          </div>
 
-          {/* transport — mounted on a vintage deck faceplate */}
-          <div className="relative overflow-hidden border border-ink bg-[#1a1613] px-3 pt-2.5 pb-3 sm:px-4">
-            <div className="pointer-events-none absolute inset-0 bg-linear-to-b from-white/8 via-transparent to-black/25" aria-hidden="true" />
-            <span className="pointer-events-none absolute top-2 left-2 size-1.5 rounded-full border border-white/20 bg-black/40" aria-hidden="true" />
-            <span className="pointer-events-none absolute top-2 right-2 size-1.5 rounded-full border border-white/20 bg-black/40" aria-hidden="true" />
-            <span className="pointer-events-none absolute bottom-2 left-2 size-1.5 rounded-full border border-white/20 bg-black/40" aria-hidden="true" />
-            <span className="pointer-events-none absolute right-2 bottom-2 size-1.5 rounded-full border border-white/20 bg-black/40" aria-hidden="true" />
-            {/* faceplate strip */}
-            <div className="relative mb-2.5 flex items-center justify-between border-b border-white/10 px-1 pb-2">
-              <span className="font-mono text-[8px] font-bold tracking-[0.3em] text-white/45 uppercase">Stereo Cassette Deck</span>
-              <span className="flex items-center gap-1.5 font-mono text-[8px] tracking-[0.22em] text-white/45 uppercase">
-                <span className={cn('size-1.5 rounded-full', playing ? 'bg-[var(--accent)]' : 'bg-white/30')} aria-hidden="true" />
-                {playing ? 'play' : 'pause'}
-              </span>
-            </div>
-            {/* controls */}
-            <div className="relative flex flex-wrap items-center gap-3">
-            <div className="flex items-baseline gap-2 border border-ink bg-[var(--field)] px-4 py-2.5">
-              <span className="font-mono text-[22px] font-bold">{fmtTime(elapsed)}</span>
-              <span className="font-mono text-[13px] text-muted">
-                {nowPlaying?.duration ? `/ ${fmtTime(nowPlaying.duration)}` : '· live'}
-              </span>
-            </div>
-            <button
-              type="button"
-              onClick={handleTune}
-              aria-label={tunedIn ? 'Tune out' : 'Tune in'}
-              className={cn(
-                'v3-focus grid h-14 w-14 cursor-pointer place-items-center border text-[20px]',
-                tunedIn
-                  ? 'border-[var(--accent)] bg-[var(--accent)] text-bg'
-                  : 'border-ink bg-bg hover:bg-[var(--overlay)]',
-              )}
-            >
-              {tunedIn ? '■' : '▶'}
-            </button>
-            <button
-              type="button"
-              onClick={toggleMute}
-              aria-pressed={muted}
-              className={cn(
-                'v3-focus grid h-14 w-14 cursor-pointer place-items-center border border-ink font-mono text-[9px] font-bold tracking-[0.14em]',
-                muted ? 'bg-ink text-bg' : 'bg-bg hover:bg-[var(--overlay)]',
-              )}
-            >
-              {muted ? 'MUTED' : 'MUTE'}
-            </button>
-            <div className="flex h-14 items-center gap-1 border border-ink bg-[repeating-linear-gradient(90deg,var(--field)_0_6px,var(--soft-border)_6px_8px)] px-2">
-              <button type="button" aria-label="Volume down" onClick={() => adjustVolume(-0.05)}
-                className="v3-focus cursor-pointer border-0 bg-transparent px-1 font-mono text-[13px] text-muted hover:text-ink">−</button>
-              <span className="border border-soft-border bg-bg px-2 py-0.5 font-mono text-[10px] font-bold tracking-[0.14em]">
-                VOL {Math.round(volume * 100)}
-              </span>
-              <button type="button" aria-label="Volume up" onClick={() => adjustVolume(0.05)}
-                className="v3-focus cursor-pointer border-0 bg-transparent px-1 font-mono text-[13px] text-muted hover:text-ink">+</button>
-            </div>
-            <div className="ml-auto font-mono text-[10px] tracking-[0.14em] whitespace-nowrap text-white/55 uppercase">
-              {offline
-                ? 'off air'
-                : [
-                    signal.latencyMs != null && tunedIn ? `signal ${signal.quality}` : '',
-                    listenerCount != null ? `${listenerCount} ♪` : '',
-                    signal.latencyMs != null && tunedIn ? `${signal.latencyMs} ms` : '',
-                  ].filter(Boolean).join(' · ')}
-            </div>
-            </div>
-          </div>
+            {/* on air */}
+            {voice && (
+              <div className="flex flex-none items-baseline gap-4 border border-ink bg-bg px-4 py-3">
+                <span className="flex-none font-mono text-[10px] font-bold tracking-[0.18em] text-[var(--accent)] uppercase">● on air — {djName}</span>
+                <span className="line-clamp-2 text-[14px] leading-snug italic">“{voice.text}”</span>
+              </div>
+            )}
+          </section>
 
-          {/* booth line — speaker tag on top, quote beneath */}
-          {voice && (
-            <div className="flex flex-col gap-2 border border-ink bg-bg px-4 py-3.5">
-              <span className="font-mono text-[10px] font-bold tracking-[0.18em] text-[var(--accent)] uppercase">
-                ● on air — {djName}
-              </span>
-              <span className="text-[15px] leading-relaxed italic">“{voice.text}”</span>
+          {/* right — up next + request */}
+          <section className="flex min-h-0 flex-col gap-4">
+            <div className="flex min-h-0 flex-1 flex-col border border-ink bg-[var(--field)]">
+              <div className="flex-none border-b border-soft-border px-3.5 py-3 font-mono text-[10px] font-bold tracking-[0.2em] uppercase">Next on the stack</div>
+              <div className="flex min-h-0 flex-1 flex-col gap-3 p-3.5">
+                {upNext[0]?.title ? (
+                  <div className="flex flex-none flex-col gap-2.5 overflow-hidden border border-ink bg-bg p-3.5">
+                    <div className="-mx-3.5 -mt-3.5 mb-1 h-[5px] bg-[var(--accent)]" />
+                    <MiniHubs />
+                    <div>
+                      <div className="font-mono text-[9px] tracking-[0.2em] text-[var(--accent)] uppercase">up next</div>
+                      <div className="mt-1 truncate text-[15px] font-bold">{upNext[0].title}</div>
+                      {upNext[0].artist && <div className="truncate text-[12px] text-muted">{upNext[0].artist}</div>}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="border border-soft-border bg-bg p-3.5 font-mono text-[11px] text-muted">
+                    stack empty — {djName} decides at the wire
+                  </div>
+                )}
+                {upNext.slice(1, 4).map((t, i) => (
+                  <div key={`${t.title ?? i}-${i}`} className="flex flex-none items-center gap-3 border border-soft-border bg-bg px-3.5 py-2.5">
+                    <span className="font-mono text-[9px] tracking-[0.18em] text-muted">THEN</span>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-[13px] font-bold">{t.title ?? '—'}</div>
+                      {t.artist && <div className="truncate text-[11px] text-muted">{t.artist}</div>}
+                    </div>
+                  </div>
+                ))}
+              </div>
             </div>
-          )}
+            <div className="flex min-h-0 flex-1 flex-col border border-ink bg-bg">
+              <div className="flex-none border-b border-soft-border px-3.5 py-3 font-mono text-[10px] font-bold tracking-[0.2em] uppercase">Side B — request slip</div>
+              <div className="flex min-h-0 flex-1 flex-col p-4">{requestForm}</div>
+            </div>
+          </section>
         </div>
 
-        {/* side rail — request slip on top, then recent tapes, then what's next */}
-        <div className="order-2 flex flex-col gap-7">
-          {/* side b request slip */}
-          <form
-            className="flex flex-col gap-2.5 border border-ink bg-bg p-4"
-            onSubmit={e => { e.preventDefault(); void slip.send(); }}
-          >
-            <div className="font-mono text-[10px] font-bold tracking-[0.2em] uppercase">Side B — request slip</div>
-            {slip.ack ? (
-              <>
-                <div className="text-[13px] leading-relaxed italic">{slip.ack}</div>
-                <button
-                  type="button"
-                  onClick={slip.reset}
-                  className="v3-focus cursor-pointer self-start border-0 bg-transparent p-0 font-mono text-[11px] font-bold tracking-[0.14em] text-muted uppercase hover:text-ink"
-                >
-                  new slip
-                </button>
-              </>
-            ) : (
-              <>
-                <div className="text-[13px] text-muted italic">Dear DJ —</div>
-                <input
-                  ref={reqInputRef}
-                  value={slip.text}
-                  onChange={e => slip.setText(e.target.value)}
-                  placeholder="a song, an artist, a feeling…"
-                  className="v3-focus w-full border-0 border-b border-soft-border bg-transparent pb-1 text-[13px] text-ink italic outline-none placeholder:text-muted"
-                />
-                <input
-                  value={slip.name}
-                  onChange={e => slip.setName(e.target.value)}
-                  placeholder="from (optional)"
-                  className="v3-focus w-full border-0 border-b border-soft-border bg-transparent pb-1 text-[13px] text-ink italic outline-none placeholder:text-muted"
-                />
-                <button
-                  type="submit"
-                  disabled={slip.sending || !slip.text.trim()}
-                  className={cn(
-                    'v3-focus self-start border-0 bg-transparent p-0 font-mono text-[11px] font-bold tracking-[0.14em] uppercase',
-                    slip.sending || !slip.text.trim()
-                      ? 'cursor-default text-muted opacity-60'
-                      : 'cursor-pointer text-[var(--accent)] hover:opacity-80',
-                  )}
-                >
-                  {slip.sending ? 'passing…' : 'pass it to the booth ↗'}
-                </button>
-              </>
-            )}
-          </form>
-
-          {/* recently rewound */}
-          <div className="flex flex-col gap-3">
-            <div className="font-mono text-[10px] font-bold tracking-[0.2em] uppercase">Recently rewound</div>
-            {history.length === 0 && (
-              <div className="font-mono text-[11px] text-muted">nothing on the shelf yet</div>
-            )}
-            {history.map((h, i) => (
-              <div key={`${h.t ?? i}-${h.title ?? i}`} className="flex flex-col gap-1.5 border border-soft-border bg-[var(--field)] px-3.5 py-3">
-                <MiniHubs />
-                <div className="flex items-baseline justify-between gap-2">
-                  <span className="min-w-0 truncate text-[13px] font-bold">{h.title ?? '?'}</span>
-                  <span className="flex-none font-mono text-[10px] text-muted">{turnClock(entryTime(h), timezone, stationLocale)}</span>
+        {/* ===================== mobile: single screen + tab bar ===================== */}
+        <div className="flex min-h-0 flex-1 flex-col lg:hidden">
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {tab === 'deck' && (
+              <div className="flex h-full flex-col gap-3.5 p-4">
+                <div className="relative flex h-[190px] flex-none flex-col border border-ink bg-[var(--field)]">
+                  <div className="flex flex-none items-center justify-between border-b border-soft-border px-3.5 py-2">
+                    <span className="min-w-0 truncate font-mono text-[9px] font-bold tracking-[0.18em] uppercase">Side A{showName ? ` · ${showName}` : ''}</span>
+                    <span className="flex-none font-mono text-[8px] tracking-[0.14em] text-muted uppercase">TYPE II</span>
+                  </div>
+                  <TapeWindow
+                    playing={playing}
+                    hubClass="size-[34px]"
+                    dotClass="size-[13px]"
+                    className="m-3 flex-1 px-[7%]"
+                  />
                 </div>
-                {h.artist && <div className="truncate text-[11px] text-muted">{h.artist}</div>}
+
+                <div className="flex-none">
+                  <div className="truncate font-display text-[26px] leading-tight font-bold italic">{title}</div>
+                  <div className="mt-1 truncate font-mono text-[11px] tracking-[0.14em] text-muted uppercase">
+                    {[artist, ...meta.facts].filter(Boolean).join(' · ') || 'live stream'}
+                  </div>
+                </div>
+
+                <div className="flex flex-none items-center gap-3 font-mono text-[11px]">
+                  <span className="font-bold tabular-nums">{fmtTime(elapsed)}</span>
+                  <div className="relative h-1 flex-1 bg-soft-border">
+                    <div className={cn('absolute inset-y-0 left-0 bg-[var(--accent)]', ratio == null ? 'w-full opacity-40' : styles.progFill)} />
+                  </div>
+                  <span className="text-muted tabular-nums">{nowPlaying?.duration ? fmtTime(nowPlaying.duration) : 'live'}</span>
+                </div>
+
+                <div className="flex h-14 flex-none gap-2">
+                  {playKey('flex-[2] text-[18px]')}
+                  {stopKey('flex-1 text-[13px]')}
+                  {muteKey('flex-1 text-[11px]')}
+                </div>
+
+                {upNext[0]?.title && (
+                  <div className="flex flex-none items-center gap-3 border border-ink bg-[var(--field)] px-3.5 py-3">
+                    <MiniHubs />
+                    <div className="min-w-0 flex-1">
+                      <div className="font-mono text-[8px] tracking-[0.2em] text-[var(--accent)] uppercase">up next</div>
+                      <div className="truncate text-[14px] font-bold">{upNext[0].title}</div>
+                      {upNext[0].artist && <div className="truncate text-[11px] text-muted">{upNext[0].artist}</div>}
+                    </div>
+                  </div>
+                )}
+
+                {onAirQuote('min-h-0 flex-1')}
               </div>
-            ))}
+            )}
+
+            {tab === 'rewound' && (
+              <div className="flex flex-col p-4">
+                <div className="mb-3 font-mono text-[10px] font-bold tracking-[0.2em] uppercase">Recently rewound</div>
+                <div className="flex flex-col border border-ink bg-[var(--field)]">{historyList}</div>
+              </div>
+            )}
+
+            {tab === 'stack' && (
+              <div className="flex flex-col gap-3 p-4">
+                <div className="font-mono text-[10px] font-bold tracking-[0.2em] uppercase">Next on the stack</div>
+                {upNext.length === 0 && (
+                  <div className="border border-soft-border bg-[var(--field)] p-3.5 font-mono text-[11px] text-muted">
+                    stack empty — {djName} decides at the wire
+                  </div>
+                )}
+                {upNext.map((t, i) => (
+                  <div key={`${t.title ?? i}-${i}`} className="flex items-center gap-3 border border-soft-border bg-[var(--field)] px-3.5 py-3">
+                    <span className="font-mono text-[9px] tracking-[0.18em] text-[var(--accent)]">{i === 0 ? 'NOW NEXT' : 'THEN'}</span>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-[14px] font-bold">{t.title ?? '—'}</div>
+                      {t.artist && <div className="truncate text-[11px] text-muted">{t.artist}</div>}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {tab === 'slip' && (
+              <div className="flex h-full flex-col p-4">
+                <div className="mb-3 font-mono text-[10px] font-bold tracking-[0.2em] uppercase">Side B — request slip</div>
+                <div className="flex min-h-0 flex-1 flex-col border border-ink bg-bg p-4">{requestForm}</div>
+              </div>
+            )}
           </div>
 
-          {/* next on the stack */}
-          <div className="flex flex-col gap-3">
-            <div className="font-mono text-[10px] font-bold tracking-[0.2em] uppercase">Next on the stack</div>
-          {upNext?.title ? (
-            <div className="flex flex-col gap-2 overflow-hidden border border-ink bg-[var(--field)] p-3.5">
-              <div className="-mx-3.5 -mt-3.5 mb-1 h-[5px] bg-[var(--accent)]" />
-              <MiniHubs />
-              <div className="truncate text-[14px] font-bold">{upNext.title}</div>
-              {upNext.artist && <div className="truncate text-[12px] text-muted">{upNext.artist}</div>}
-            </div>
-          ) : (
-            <div className="border border-soft-border bg-[var(--field)] p-3.5 font-mono text-[11px] text-muted">
-              stack empty — {djName} decides at the wire
-            </div>
-          )}
+          {/* tab bar */}
+          <div className="flex h-14 flex-none border-t border-ink font-mono text-[9px] tracking-[0.12em] uppercase">
+            {MOBILE_TABS.map(t => (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setTab(t.id)}
+                aria-pressed={tab === t.id}
+                className={cn(
+                  'v3-focus flex flex-1 cursor-pointer items-center justify-center border-r border-soft-border last:border-r-0',
+                  tab === t.id ? 'font-bold text-[var(--accent)]' : 'text-muted',
+                )}
+              >
+                {t.label}
+              </button>
+            ))}
           </div>
         </div>
       </div>
 
-      {/* tune-in gate — the deck sits with its door open; one tap clunks it
-          shut and the spools start. */}
+      {/* tune-in gate — the deck sits with the door open; one tap loads the tape
+          and the reels spin up. */}
       {showOverlay && !offline && (
         <button
           type="button"
           onClick={tuneInFromOverlay}
           className="absolute inset-0 z-40 grid w-full cursor-pointer place-items-center border-0 bg-[var(--bg)]/95 p-6"
         >
-          <span className="grid w-full max-w-[420px] -rotate-2 justify-items-stretch gap-3">
-            <span className="block border border-ink bg-[var(--field)] p-4">
-              <span className="block border border-ink bg-bg">
-                <span className="block h-2 bg-[var(--accent)]" />
-                <span className="block px-4 py-3 text-left">
-                  <span className="block font-mono text-[10px] tracking-[0.2em] text-muted uppercase">{stationName} · Side A</span>
-                  <span className="mt-1 block font-display text-[24px] leading-tight font-bold italic">
-                    {nowPlaying?.title ?? 'one live stream'}
-                  </span>
-                </span>
+          <span className="grid w-full max-w-[380px] justify-items-stretch gap-4">
+            <span className="flex flex-col border border-ink bg-[var(--field)]">
+              <span className="flex items-center justify-between border-b border-soft-border px-4 py-2.5">
+                <span className="font-mono text-[10px] font-bold tracking-[0.2em] uppercase">{stationName} · Side A</span>
+                <span className="font-mono text-[9px] tracking-[0.14em] text-muted uppercase">TYPE II</span>
               </span>
-              <span className="mt-3 flex items-center justify-around bg-[#1a1613] py-5">
-                <span className="grid h-16 w-16 place-items-center rounded-full bg-[var(--muted)]">
-                  <span className="box-border block h-[38px] w-[38px] rounded-full border-4 border-dashed border-ink bg-bg" />
-                </span>
-                <span className="grid h-16 w-16 place-items-center rounded-full bg-[var(--muted)]">
-                  <span className="box-border block h-[38px] w-[38px] rounded-full border-4 border-dashed border-ink bg-bg" />
-                </span>
-              </span>
+              <TapeWindow playing={false} hubClass="size-[40px]" dotClass="size-[15px]" className="m-4 h-[150px] px-[8%]" />
             </span>
             <span className="text-center font-mono text-[11px] font-bold tracking-[0.22em] text-ink uppercase">
-              tap to close the deck ▸ tune in
+              ▶ load the tape · tune in
             </span>
           </span>
         </button>

--- a/web/components/skins/spool/SpoolSkin.tsx
+++ b/web/components/skins/spool/SpoolSkin.tsx
@@ -12,7 +12,7 @@
 // window, and the VU needle rides. Everything that moves is a co-located
 // keyframe (Spool.module.css) so it never re-renders React.
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useRef, useState, type RefObject } from 'react';
 import styles from './Spool.module.css';
 import {
   usePlayerActions,
@@ -149,7 +149,11 @@ export default function SpoolSkin(_props: SkinProps) {
     refused: 'The booth waved this one off.',
     failed: 'The booth line is down — try again in a moment.',
   });
-  const reqInputRef = useRef<HTMLInputElement | null>(null);
+  // Desktop and mobile each render their own copy of the request slip (both
+  // in the DOM, one hidden per breakpoint), so each input gets its own ref;
+  // the `r` shortcut focuses whichever slip is actually on screen.
+  const reqDeckRef = useRef<HTMLInputElement | null>(null);
+  const reqSlipRef = useRef<HTMLInputElement | null>(null);
 
   const playIn = () => { if (!tunedIn) handleTune(); };
   const stopOut = () => { if (tunedIn) stop(); };
@@ -160,7 +164,14 @@ export default function SpoolSkin(_props: SkinProps) {
     arrowup: () => adjustVolume(0.05),
     arrowdown: () => adjustVolume(-0.05),
     m: toggleMute,
-    r: () => { if (!showTuneIn) { setTab('slip'); reqInputRef.current?.focus(); } },
+    r: () => {
+      if (showTuneIn) return;
+      const deck = reqDeckRef.current;
+      // offsetParent === null ⇒ that layout is display:none for this breakpoint.
+      if (deck && deck.offsetParent !== null) { deck.focus(); return; }
+      setTab('slip');
+      requestAnimationFrame(() => reqSlipRef.current?.focus());
+    },
   });
 
   // ── shared control atoms ────────────────────────────────────────────────
@@ -207,7 +218,7 @@ export default function SpoolSkin(_props: SkinProps) {
     </button>
   );
 
-  const requestForm = (
+  const requestForm = (ref: RefObject<HTMLInputElement | null>) => (
     <form
       className="flex min-h-0 flex-1 flex-col gap-3"
       onSubmit={e => { e.preventDefault(); void slip.send(); }}
@@ -227,7 +238,7 @@ export default function SpoolSkin(_props: SkinProps) {
         <>
           <div className="text-[13px] text-muted italic">Dear DJ —</div>
           <input
-            ref={reqInputRef}
+            ref={ref}
             value={slip.text}
             onChange={e => slip.setText(e.target.value)}
             placeholder="a song, an artist, a feeling…"
@@ -469,7 +480,7 @@ export default function SpoolSkin(_props: SkinProps) {
             </div>
             <div className="flex min-h-0 flex-1 flex-col border border-ink bg-bg">
               <div className="flex-none border-b border-soft-border px-3.5 py-3 font-mono text-[10px] font-bold tracking-[0.2em] uppercase">Side B — request slip</div>
-              <div className="flex min-h-0 flex-1 flex-col p-4">{requestForm}</div>
+              <div className="flex min-h-0 flex-1 flex-col p-4">{requestForm(reqDeckRef)}</div>
             </div>
           </section>
         </div>
@@ -558,7 +569,7 @@ export default function SpoolSkin(_props: SkinProps) {
             {tab === 'slip' && (
               <div className="flex h-full flex-col p-4">
                 <div className="mb-3 font-mono text-[10px] font-bold tracking-[0.2em] uppercase">Side B — request slip</div>
-                <div className="flex min-h-0 flex-1 flex-col border border-ink bg-bg p-4">{requestForm}</div>
+                <div className="flex min-h-0 flex-1 flex-col border border-ink bg-bg p-4">{requestForm(reqSlipRef)}</div>
               </div>
             )}
           </div>

--- a/web/components/skins/spool/SpoolSkin.tsx
+++ b/web/components/skins/spool/SpoolSkin.tsx
@@ -32,6 +32,7 @@ import {
   lastVoiceLine,
   listenerCountOf,
   progressRatio,
+  stationIdentity,
   trackMeta,
   turnClock,
 } from '../shared';
@@ -103,10 +104,7 @@ export default function SpoolSkin(_props: SkinProps) {
   const elapsed = useElapsed(trackStartedAt);
   const stationLocale = normalizeStationLocale(locale);
   const listenerCount = listenerCountOf(listeners);
-  const stationName = (typeof dj?.station === 'string' && dj.station) || 'SUB/WAVE';
-  const djName =
-    activeShow?.persona?.name || (typeof dj?.name === 'string' ? dj.name : '') || 'the DJ';
-  const showName = activeShow?.name || context?.time?.show || '';
+  const { stationName, djName, showName } = stationIdentity(dj, activeShow, context);
   const meta = trackMeta(nowPlaying);
   const ratio = progressRatio(elapsed, nowPlaying?.duration);
   const ratioSafe = ratio ?? 0.5;

--- a/web/components/skins/subamp/SubampSkin.tsx
+++ b/web/components/skins/subamp/SubampSkin.tsx
@@ -34,6 +34,7 @@ import {
   contextLine,
   entryTime,
   listenerCountOf,
+  stationIdentity,
   trackMeta,
   turnClock,
 } from '../shared';
@@ -91,10 +92,7 @@ export default function SubampSkin(_props: SkinProps) {
   const clock = useClock();
   const stationLocale = normalizeStationLocale(locale);
   const listenerCount = listenerCountOf(listeners);
-  const stationName = (typeof dj?.station === 'string' && dj.station) || 'SUB/WAVE';
-  const djName =
-    activeShow?.persona?.name || (typeof dj?.name === 'string' ? dj.name : '') || 'the DJ';
-  const showName = activeShow?.name || context?.time?.show || '';
+  const { stationName, djName, showName } = stationIdentity(dj, activeShow, context);
   const meta = trackMeta(nowPlaying);
   const booth = boothLines(session.messages, 24);
   const upNext = state.upcoming?.[0];

--- a/web/components/skins/subamp/SubampSkin.tsx
+++ b/web/components/skins/subamp/SubampSkin.tsx
@@ -11,7 +11,11 @@
 import { useRef, useState, type ReactNode } from 'react';
 import styles from './Subamp.module.css';
 import Analyzer from './Analyzer';
-import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  Conversation,
+  ConversationContent,
+  ConversationScrollButton,
+} from '@/components/ai-elements/conversation';
 import {
   usePlayerActions,
   usePlayerAudio,
@@ -258,8 +262,12 @@ export default function SubampSkin(_props: SkinProps) {
 
         {/* ── booth ────────────────────────────────────────── */}
         <Window title={<>BOOTH FEED ▪ {djName.toUpperCase()}</>} className="flex min-h-0 flex-1 flex-col lg:block lg:flex-none">
-          <ScrollArea className="min-h-0 flex-1 lg:max-h-[240px]">
-            <div className="flex flex-col gap-2 px-4 py-3">
+          {/* stick-to-bottom booth tail — the live view holds the newest DJ
+              line at the bottom (same ai-elements Conversation as the admin
+              dash Booth log). Needs a definite height for the scroll region,
+              hence lg:h-[240px] rather than a content-driven max-height. */}
+          <Conversation className="min-h-0 flex-1 lg:h-[240px]">
+            <ConversationContent className="flex flex-col gap-2 px-4 py-3">
               {booth.length === 0 && (
                 <div className="text-[11px] text-muted">waiting for the booth…</div>
               )}
@@ -278,8 +286,9 @@ export default function SubampSkin(_props: SkinProps) {
                   )}
                 </div>
               ))}
-            </div>
-          </ScrollArea>
+            </ConversationContent>
+            <ConversationScrollButton className="bottom-2 size-7 rounded-none border-soft-border bg-[var(--field)] text-ink hover:bg-[var(--overlay)]" />
+          </Conversation>
         </Window>
 
         {/* ── station log ──────────────────────────────────── */}
@@ -287,9 +296,11 @@ export default function SubampSkin(_props: SkinProps) {
           title={<>STATION LOG{listenerCount != null ? ` ▪ ${listenerCount} LISTENING` : ''}</>}
           className="flex min-h-0 flex-1 flex-col lg:block lg:flex-none"
         >
-          <ScrollArea className="min-h-0 flex-1 lg:max-h-[200px]">
-            {/* pr-5 leaves a gutter so the times clear the overlaid scrollbar */}
-            <div className="flex flex-col gap-1.5 py-2.5 pr-5 pl-4">
+          {/* stick-to-bottom log tail — pins the view to the ▶ now-playing /
+              queued lines at the bottom (ai-elements Conversation, like the
+              booth above). Definite height so the scroll region resolves. */}
+          <Conversation className="min-h-0 flex-1 lg:h-[200px]">
+            <ConversationContent className="flex flex-col gap-1.5 py-2.5 pr-5 pl-4">
               {history.map((h, i) => (
                 <div key={`${h.t ?? i}-${h.title ?? i}`} className="flex gap-2.5 text-[11px] tracking-[0.06em] text-muted uppercase">
                   <span>{i + 1}.</span>
@@ -316,8 +327,9 @@ export default function SubampSkin(_props: SkinProps) {
                   <span>queued</span>
                 </div>
               )}
-            </div>
-          </ScrollArea>
+            </ConversationContent>
+            <ConversationScrollButton className="bottom-2 size-7 rounded-none border-soft-border bg-[var(--field)] text-ink hover:bg-[var(--overlay)]" />
+          </Conversation>
 
           {/* request line — pinned below the scrolling log */}
           <form

--- a/web/components/skins/tty/TtySkin.tsx
+++ b/web/components/skins/tty/TtySkin.tsx
@@ -27,6 +27,7 @@ import {
   entryTime,
   listenerCountOf,
   progressRatio,
+  stationIdentity,
   trackMeta,
   turnClock,
 } from '../shared';
@@ -58,10 +59,7 @@ export default function TtySkin(_props: SkinProps) {
   const clock = useClock();
   const stationLocale = normalizeStationLocale(locale);
   const listenerCount = listenerCountOf(listeners);
-  const stationName = (typeof dj?.station === 'string' && dj.station) || 'SUB/WAVE';
-  const djName =
-    activeShow?.persona?.name || (typeof dj?.name === 'string' ? dj.name : '') || 'DJ';
-  const showName = activeShow?.name;
+  const { stationName, djName, showName } = stationIdentity(dj, activeShow, context);
   const meta = trackMeta(nowPlaying);
   const ratio = progressRatio(elapsed, nowPlaying?.duration);
   const booth = boothLines(session.messages, 24);

--- a/web/components/skins/tty/TtySkin.tsx
+++ b/web/components/skins/tty/TtySkin.tsx
@@ -52,7 +52,7 @@ export default function TtySkin(_props: SkinProps) {
   } = usePlayerFeed();
   const { tunedIn, status, volume, muted, offline, signal } = usePlayerAudio();
   const { toggleMute } = usePlayerActions();
-  const { showTuneIn, tuneInFromOverlay, handleTune } = useTuneInGate();
+  const { showTuneIn, showOverlay, tuneInFromOverlay, handleTune } = useTuneInGate();
 
   const elapsed = useElapsed(trackStartedAt);
   const clock = useClock();
@@ -356,7 +356,7 @@ export default function TtySkin(_props: SkinProps) {
 
       {/* boot-log gate — halts at "press any key". The tap/keypress is the
           browser's audio-unblock gesture. */}
-      {showTuneIn && !offline && (
+      {showOverlay && !offline && (
         <button
           type="button"
           onClick={tuneInFromOverlay}

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -181,8 +181,9 @@ export interface StationState {
   timezone?: string;
   locale?: StationLocale;
   /** Station-wide listener-player UI settings (from GET /state). `skin` is
-   *  the operator's player-skin pick (see components/skins). */
-  ui?: { boothBuddy?: boolean; skin?: string };
+   *  the operator's player-skin pick (see components/skins); `tuneInOverlay`
+   *  gates the full-bleed tap-to-tune gate (default on). */
+  ui?: { boothBuddy?: boolean; skin?: string; tuneInOverlay?: boolean };
 }
 
 /** A single turn in the live DJ session — `voice` (spoken on-air), `dj` (the


### PR DESCRIPTION
## Player faces

What started as the optional tune-in overlay grew into a broader pass on the modular player skins.

### New skin — Platter
A reference-turntable face (design "Platter 3a"). The record spins at 33⅓ with a light-catch sheen and a ticking strobe rim; an SVG tonearm drops onto the grooves on tune-in. The plinth carries the transport — START/STOP, MUTE, and a fader that doubles as volume — while now-playing, up-next, booth quote and the request slip live in the right column. On phones the booth hides and the deck centres so the whole face fits one screen without scrolling. Registered in the skin registry with a gallery thumbnail.

### Redesigned skin — Spool
Rebuilt as a tape-deck console.
- **Desktop:** three columns — Recently rewound (history) · deck + cassette hero (paper label, toothed reels that thin/fatten across the runtime, sheen, VU needle, counter, PLAY/STOP/MUTE + a VOL fader) · up-next and the Side-B request slip.
- **Mobile:** collapses to a single no-scroll screen with a bottom tab bar (Deck / Rewound / Stack / Slip).

### Also in this branch
- **Tune-in overlay toggle** (`settings.ui.tuneInOverlay`) — operators can switch off the full-bleed tap-to-tune gate; listeners then tune in via the skin's own play button. Drift skin polish.
- **Subamp polish** — stick-to-bottom booth feed + station log.

## Notes
- Both new/redone skins consume only the core contexts + shared hooks, render the tune-in gate via `useTuneInGate`, honor the 7 theme tokens (verified light + dark) and lite mode, and co-locate their styles. Motion is co-located keyframes gated on playback.
- Lint (`eslint` + `tsc`) passes.
