### PR TITLE
fix(web): mobile skin polish — Drift, Subamp, TTY, Platter

### DIFF
--- a/web/components/skins/drift/DriftSkin.tsx
+++ b/web/components/skins/drift/DriftSkin.tsx
@@ -131,12 +131,14 @@ export default function DriftSkin(_props: SkinProps) {
         aria-hidden="true"
       />
 
-      {/* corners */}
-      <div className="absolute top-7 left-8 max-w-[45%] truncate font-mono text-[10px] tracking-[0.24em] text-muted uppercase">
+      {/* corners — on a phone the clock/context text is dropped so the station
+          line and the theme icon can't collide in the middle; it returns from
+          sm up where there's room for both halves. */}
+      <div className="absolute top-7 left-8 max-w-[70%] truncate font-mono text-[10px] tracking-[0.24em] text-muted uppercase sm:max-w-[45%]">
         {stationName} — {showName ? `${showName} with ${djName}` : `small hours with ${djName}`}
       </div>
       <div className="absolute top-7 right-8 flex max-w-[45%] items-center gap-3">
-        <span className="min-w-0 truncate font-mono text-[10px] tracking-[0.24em] text-muted uppercase">
+        <span className="hidden min-w-0 truncate font-mono text-[10px] tracking-[0.24em] text-muted uppercase sm:block">
           {clock
             ? [
                 `${turnClock(clock.getTime(), timezone, stationLocale)} ${stationWeekday(clock, timezone)}`,

--- a/web/components/skins/platter/PlatterSkin.tsx
+++ b/web/components/skins/platter/PlatterSkin.tsx
@@ -52,7 +52,7 @@ function Deck({
   artist: string;
 }) {
   return (
-    <div className="[container-type:inline-size] relative aspect-square w-[min(56vw,30vh,220px)] lg:w-[min(42vw,72vh,520px)]">
+    <div className="[container-type:inline-size] relative aspect-square w-[min(70vw,32vh,270px)] lg:w-[min(42vw,72vh,520px)]">
       {/* pitch strobe rim */}
       <div
         className={cn(
@@ -206,12 +206,18 @@ export default function PlatterSkin(_props: SkinProps) {
       {/* body — turntable on the left, metadata column on the right */}
       <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
         {/* ===== the plinth ===== */}
-        <div className="relative flex flex-1 flex-col items-center justify-center gap-6 border-b border-ink bg-linear-to-br from-[var(--field)] to-[color-mix(in_oklab,var(--field)_82%,var(--bg))] px-6 py-6 lg:w-[46%] lg:max-w-[680px] lg:flex-1 lg:flex-row lg:gap-0 lg:border-r lg:border-b-0 lg:py-10">
+        <div className="relative flex flex-1 flex-col items-center gap-4 border-b border-ink bg-linear-to-br from-[var(--field)] to-[color-mix(in_oklab,var(--field)_82%,var(--bg))] px-6 py-4 lg:w-[46%] lg:max-w-[680px] lg:flex-1 lg:flex-row lg:justify-center lg:gap-0 lg:border-r lg:border-b-0 lg:py-10">
           <span className="absolute top-5 left-6 font-mono text-[9px] tracking-[0.24em] text-muted uppercase">
             direct drive · quartz lock
           </span>
 
-          <Deck playing={playing} stationName={stationName} title={title} artist={artist} />
+          {/* deck-area: on phones this flex-1 wrapper centres the platter in the
+              space above the controls (breathing room above it, not stuck to
+              the top); on lg it collapses (display:contents) so the deck centres
+              in the whole plinth. */}
+          <div className="flex w-full flex-1 items-center justify-center lg:contents">
+            <Deck playing={playing} stationName={stationName} title={title} artist={artist} />
+          </div>
 
           {/* the deck IS the control surface: START/STOP drops or lifts the
               needle, MUTE sits beside it, and the fader is the volume. Laid out

--- a/web/components/skins/platter/PlatterSkin.tsx
+++ b/web/components/skins/platter/PlatterSkin.tsx
@@ -52,7 +52,7 @@ function Deck({
   artist: string;
 }) {
   return (
-    <div className="[container-type:inline-size] relative aspect-square w-[min(70vw,32vh,270px)] lg:w-[min(42vw,72vh,520px)]">
+    <div className="[container-type:inline-size] relative aspect-square w-[min(52vw,29vh,210px)] lg:w-[min(42vw,72vh,520px)]">
       {/* pitch strobe rim */}
       <div
         className={cn(
@@ -203,10 +203,11 @@ export default function PlatterSkin(_props: SkinProps) {
         </div>
       </div>
 
-      {/* body — turntable on the left, metadata column on the right */}
-      <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+      {/* body — turntable over metadata on phones (the body scrolls if the
+          content is taller than the screen); two side-by-side columns on lg. */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden lg:flex-row">
         {/* ===== the plinth ===== */}
-        <div className="relative flex flex-1 flex-col items-center gap-4 border-b border-ink bg-linear-to-br from-[var(--field)] to-[color-mix(in_oklab,var(--field)_82%,var(--bg))] px-6 py-4 lg:w-[46%] lg:max-w-[680px] lg:flex-1 lg:flex-row lg:justify-center lg:gap-0 lg:border-r lg:border-b-0 lg:py-10">
+        <div className="relative flex flex-none flex-col items-center gap-3 border-b border-ink bg-linear-to-br from-[var(--field)] to-[color-mix(in_oklab,var(--field)_82%,var(--bg))] px-6 py-3 lg:w-[46%] lg:max-w-[680px] lg:flex-1 lg:flex-row lg:justify-center lg:gap-0 lg:border-r lg:border-b-0 lg:py-10">
           <span className="absolute top-5 left-6 font-mono text-[9px] tracking-[0.24em] text-muted uppercase">
             direct drive · quartz lock
           </span>
@@ -215,7 +216,7 @@ export default function PlatterSkin(_props: SkinProps) {
               space above the controls (breathing room above it, not stuck to
               the top); on lg it collapses (display:contents) so the deck centres
               in the whole plinth. */}
-          <div className="flex w-full flex-1 items-center justify-center lg:contents">
+          <div className="flex w-full items-center justify-center pt-8 lg:contents">
             <Deck playing={playing} stationName={stationName} title={title} artist={artist} />
           </div>
 
@@ -224,7 +225,7 @@ export default function PlatterSkin(_props: SkinProps) {
               as a row beneath the deck on phones (clear of the vinyl); mounted
               in the plinth corners from lg up (the wrapper goes display:contents
               so each cluster positions itself absolutely). */}
-          <div className="flex w-full max-w-[320px] items-end justify-between gap-4 lg:contents">
+          <div className="flex w-full items-end justify-center gap-8 lg:contents">
             <div className="flex items-end gap-3 lg:absolute lg:bottom-6 lg:left-6">
               <button
                 type="button"
@@ -268,7 +269,7 @@ export default function PlatterSkin(_props: SkinProps) {
                   if (e.key === 'ArrowUp') { e.preventDefault(); adjustVolume(0.05); }
                   else if (e.key === 'ArrowDown') { e.preventDefault(); adjustVolume(-0.05); }
                 }}
-                className="v3-focus relative h-20 w-7 cursor-pointer touch-none border border-ink bg-bg lg:h-36"
+                className="v3-focus relative h-16 w-7 cursor-pointer touch-none border border-ink bg-bg lg:h-36"
               >
                 <span className="pointer-events-none absolute top-2 bottom-2 left-1/2 w-px -translate-x-1/2 bg-soft-border" aria-hidden="true" />
                 <span className="pointer-events-none absolute top-2 left-1 h-px w-[3px] bg-[var(--accent)]" aria-hidden="true" />
@@ -282,7 +283,7 @@ export default function PlatterSkin(_props: SkinProps) {
         </div>
 
         {/* ===== metadata column ===== */}
-        <div className="flex min-h-0 min-w-0 flex-none flex-col gap-3 overflow-hidden p-4 lg:flex-1 lg:gap-4 lg:overflow-y-auto lg:p-6">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2.5 overflow-hidden p-4 lg:gap-4 lg:overflow-y-auto lg:p-6">
           {/* now playing */}
           <div className="flex items-start gap-5">
             <div className="size-[84px] flex-none border border-ink bg-[var(--field)] sm:size-[104px]">

--- a/web/components/skins/subamp/SubampSkin.tsx
+++ b/web/components/skins/subamp/SubampSkin.tsx
@@ -234,6 +234,15 @@ export default function SubampSkin(_props: SkinProps) {
               >
                 MUTE
               </button>
+              <button
+                type="button"
+                onClick={() => reqInputRef.current?.focus()}
+                className="v3-focus grid h-[34px] w-11 cursor-pointer place-items-center border border-[var(--accent)] text-[9px] font-bold tracking-[0.1em] text-[var(--accent)] hover:bg-[var(--overlay)]"
+              >
+                REQ
+              </button>
+              {/* VOL is last so it (not REQ) is the flex item that reflows to a
+                  full-width second line when the deck is too narrow for one row */}
               <div className="ml-2 flex min-w-[120px] flex-1 items-center gap-2">
                 <span className="text-[9px] font-bold tracking-[0.16em] text-muted">VOL</span>
                 <input
@@ -247,13 +256,6 @@ export default function SubampSkin(_props: SkinProps) {
                 />
                 <span className="w-6 text-right text-[10px]">{Math.round(volume * 100)}</span>
               </div>
-              <button
-                type="button"
-                onClick={() => reqInputRef.current?.focus()}
-                className="v3-focus grid h-[34px] w-11 cursor-pointer place-items-center border border-[var(--accent)] text-[9px] font-bold tracking-[0.1em] text-[var(--accent)] hover:bg-[var(--overlay)]"
-              >
-                REQ
-              </button>
             </div>
           </div>
         </Window>

--- a/web/components/skins/tty/TtySkin.tsx
+++ b/web/components/skins/tty/TtySkin.tsx
@@ -183,7 +183,7 @@ export default function TtySkin(_props: SkinProps) {
                   </div>
                 )}
               </div>
-              <div className="flex flex-none flex-col gap-1.5">
+              <div className="hidden flex-none flex-col gap-1.5 sm:flex">
                 <div className="grid h-[120px] w-[120px] place-items-center border border-soft-border sm:h-[148px] sm:w-[148px]">
                   {coverId && !offline ? (
                     <img src={client.coverUrl(coverId)} alt="" className="h-full w-full object-cover" />
@@ -224,7 +224,7 @@ export default function TtySkin(_props: SkinProps) {
 
         {/* up next + last — last fills + scrolls; stacked on mobile,
             side-by-side from sm */}
-        <div className="grid min-h-0 flex-[1] grid-cols-1 grid-rows-[auto_minmax(0,1fr)] gap-3.5 sm:grid-cols-2 sm:grid-rows-1">
+        <div className="grid min-h-0 flex-none grid-cols-1 grid-rows-[auto_minmax(0,1fr)] gap-3.5 sm:flex-[1] sm:grid-cols-2 sm:grid-rows-1">
           <section className="flex min-h-0 min-w-0 flex-col gap-2.5 border border-soft-border px-5 py-4">
             <Rule>UP NEXT</Rule>
             {upNext?.title ? (
@@ -241,7 +241,7 @@ export default function TtySkin(_props: SkinProps) {
               <div className="text-[12px] text-muted">queue empty — the DJ decides at the wire</div>
             )}
           </section>
-          <section className="flex min-h-0 min-w-0 flex-col gap-2 border border-soft-border px-5 py-4">
+          <section className="hidden min-h-0 min-w-0 flex-col gap-2 border border-soft-border px-5 py-4 sm:flex">
             <Rule>LAST</Rule>
             <ScrollArea className="-mx-5 min-h-0 flex-1">
               <div className="flex flex-col gap-2 px-5">


### PR DESCRIPTION
Mobile-layout fixes for go-live, on top of #1036 (merged). Each verified at a phone viewport; lint (`eslint` + `tsc`) green.

### Drift — masthead labels overlapping
Both top-corner labels were absolutely positioned at `max-w-[45%]`, so long strings collided mid-header on phones. On mobile the clock/context text is dropped (theme icon stays) and the station line takes up to 70%; both return from `sm` up.

### Subamp — REQ wrapping to its own line
The flex-1 VOL slider sat in the middle of the transport row, forcing REQ (last item) onto its own line. Moved REQ beside MUTE so VOL is the trailing flex item — VOL now reflows to a full-width second line when the deck is too narrow, and the four buttons stay on one row.

### TTY — cluttered now-playing + LAST pane
On mobile the long artist/album line was cramped into a narrow column beside the fixed cover. Hide the cover on phones (least on-theme for a terminal skin) so the title/artist take full width, and hide the LAST (history) pane below `sm` so the booth feed takes that space. Both return from `sm` up.

### Platter — vinyl stuck to the top
The deck and controls were centred together, so the platter sat high with empty space below. Give the deck its own flex-1 centring area (breathing room above, not hugging the top) and enlarge it (`min(56vw,30vh,220)` → `min(70vw,32vh,270)`). Desktop unchanged.