### PR TITLE
fix(web): Spool desktop — 2-row layout, Recently rewound to bottom shelf

### DIFF
--- a/web/components/skins/spool/SpoolSkin.tsx
+++ b/web/components/skins/spool/SpoolSkin.tsx
@@ -3,9 +3,9 @@
 // Spool — a tape deck; the whole station rides on one cassette.
 // Tactile · warm · mechanical. Design ref: Skins Canvas 1a.
 //
-// Desktop is a three-column console: Recently rewound (history) on the left,
-// the deck + cassette hero in the middle, up-next and the Side-B request slip
-// on the right. Mobile collapses to a single screen with a bottom tab bar
+// Desktop is a two-column console — the deck + cassette hero on the left, up-next
+// and the Side-B request slip on the right — over a full-width Recently rewound
+// shelf spanning the bottom. Mobile collapses to a single screen with a bottom tab bar
 // (Deck / Rewound / Stack / Slip) so nothing scrolls off. Both reels spin
 // while playing; the supply reel's wound tape thins as the take-up reel
 // fattens across the runtime (dynamic diameters), a slow sheen crosses the
@@ -286,6 +286,29 @@ export default function SpoolSkin(_props: SkinProps) {
     </>
   );
 
+  // Horizontal variant of historyList for the desktop bottom shelf — tapes lined
+  // up on a shelf (fixed-width cards, right-ruled) that scroll sideways.
+  const historyShelf = (
+    <>
+      {history.length === 0 && (
+        <div className="p-4 font-mono text-[11px] text-muted">nothing on the shelf yet</div>
+      )}
+      {history.map((h, i) => (
+        <div
+          key={`${h.t ?? i}-${h.title ?? i}`}
+          className="flex w-[210px] flex-none items-center gap-3 border-r border-soft-border px-4 py-3 last:border-r-0"
+        >
+          <span className="size-2 flex-none rounded-full border-2 border-[var(--muted)]" />
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-[13px] font-bold">{h.title ?? '?'}</div>
+            {h.artist && <div className="truncate text-[11px] text-muted">{h.artist}</div>}
+          </div>
+          <span className="flex-none font-mono text-[10px] text-muted">{turnClock(entryTime(h), timezone, stationLocale)}</span>
+        </div>
+      ))}
+    </>
+  );
+
   const onAirQuote = (extra?: string) =>
     voice && (
       <div className={cn('flex flex-col gap-2 border border-ink bg-bg px-4 py-3.5', extra)}>
@@ -321,20 +344,8 @@ export default function SpoolSkin(_props: SkinProps) {
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col">
-        {/* ===================== desktop: three-column console ===================== */}
-        <div className="hidden min-h-0 flex-1 grid-cols-[288px_1fr_288px] gap-7 p-7 lg:grid">
-          {/* left — recently rewound */}
-          <section className="flex min-h-0 flex-col gap-3">
-            <div className="font-mono text-[10px] font-bold tracking-[0.2em] uppercase">Recently rewound</div>
-            <div className="flex min-h-0 flex-1 flex-col border border-ink bg-[var(--field)]">
-              <div className="min-h-0 flex-1 overflow-y-auto">{historyList}</div>
-              <div className="flex flex-none items-center justify-between border-t border-soft-border px-4 py-3 font-mono text-[10px] tracking-[0.14em] text-muted uppercase">
-                <span>{history.length} rewound</span>
-                {listenerCount != null && <span className="font-bold text-[var(--accent)]">{listenerCount} listening</span>}
-              </div>
-            </div>
-          </section>
-
+        {/* ============ desktop: two-column console over a full-width rewound shelf ============ */}
+        <div className="hidden min-h-0 flex-1 grid-cols-[1fr_288px] grid-rows-[1fr_auto] gap-7 p-7 lg:grid">
           {/* center — the deck */}
           <section className="flex min-h-0 flex-col gap-4">
             <div className="flex min-h-0 flex-1 flex-col border border-ink bg-[var(--field)]">
@@ -479,6 +490,20 @@ export default function SpoolSkin(_props: SkinProps) {
             <div className="flex min-h-0 flex-1 flex-col border border-ink bg-bg">
               <div className="flex-none border-b border-soft-border px-3.5 py-3 font-mono text-[10px] font-bold tracking-[0.2em] uppercase">Side B — request slip</div>
               <div className="flex min-h-0 flex-1 flex-col p-4">{requestForm(reqDeckRef)}</div>
+            </div>
+          </section>
+
+          {/* bottom — recently rewound, a full-width shelf of tapes */}
+          <section className="col-span-2 flex min-h-0 flex-col gap-3">
+            <div className="flex items-baseline justify-between">
+              <div className="font-mono text-[10px] font-bold tracking-[0.2em] uppercase">Recently rewound</div>
+              <div className="flex items-center gap-3 font-mono text-[10px] tracking-[0.14em] text-muted uppercase">
+                <span>{history.length} rewound</span>
+                {listenerCount != null && <span className="font-bold text-[var(--accent)]">{listenerCount} listening</span>}
+              </div>
+            </div>
+            <div className="flex min-h-0 border border-ink bg-[var(--field)]">
+              <div className="flex min-h-0 flex-1 overflow-x-auto">{historyShelf}</div>
             </div>
           </section>
         </div>

--- a/web/components/skins/spool/SpoolSkin.tsx
+++ b/web/components/skins/spool/SpoolSkin.tsx
@@ -24,6 +24,7 @@ import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { useElapsed } from '@/hooks/useElapsed';
 import { useDynamicStyle } from '@/hooks/useDynamicStyle';
 import ThemeSwitcher from '@/components/ThemeSwitcher';
+import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/cn';
 import { fmtTime, normalizeStationLocale } from '@/lib/format';
 import {
@@ -502,9 +503,10 @@ export default function SpoolSkin(_props: SkinProps) {
                 {listenerCount != null && <span className="font-bold text-[var(--accent)]">{listenerCount} listening</span>}
               </div>
             </div>
-            <div className="flex min-h-0 border border-ink bg-[var(--field)]">
-              <div className="flex min-h-0 flex-1 overflow-x-auto">{historyShelf}</div>
-            </div>
+            <ScrollArea className="border border-ink bg-[var(--field)]">
+              <div className="flex w-max">{historyShelf}</div>
+              <ScrollBar orientation="horizontal" />
+            </ScrollArea>
           </section>
         </div>
 


### PR DESCRIPTION
## What

Spool skin, **desktop only**: reflow the three-column console into two, and give the relocated history shelf a shadcn scrollbar.

- **Before:** three side-by-side columns — Recently rewound | deck | up-next + Side-B slip.
- **After:** a two-column top row (deck on the left, up-next + Side-B request slip on the right) over a **full-width Recently rewound shelf** along the bottom — tapes lined up horizontally on a shelf, scrolling sideways with a **shadcn `ScrollArea`** (styled horizontal scrollbar).

## How

- Outer desktop container goes from `grid-cols-[288px_1fr_288px]` to `grid-cols-[1fr_288px] grid-rows-[1fr_auto]`.
- The left "Recently rewound" column is removed; a new `col-span-2` section is appended after the right column. Grid auto-placement lands the two top sections in row 1 and the span-2 shelf in row 2, so the deck/stack sections needed **no** re-indentation.
- New `historyShelf` (horizontal, fixed-width right-ruled cards) mirrors the existing `historyList`; `{n} rewound / {n} listening` moves into the shelf header.
- The shelf scrolls via the project's shadcn `ScrollArea` + `<ScrollBar orientation="horizontal" />` (inner row `w-max`), replacing native `overflow-x-auto`. No new dependency — `scroll-area` was already installed. Default thumb styling kept (semantic `bg-border` token).

Mobile (tabbed Deck / Rewound / Stack / Slip) is unchanged.

## Verification

- `web` lint gate clean: `eslint . && tsc --noEmit` (both pass).
- Clean dev-server compile; served live from the worktree dev server for review at desktop width. Not independently screenshotted — worth an eyeball on the preview.