### PR TITLE
fix(admin): remove name→tags gap on persona & skill cards

### DIFF
--- a/web/components/admin/SkillsPanel.tsx
+++ b/web/components/admin/SkillsPanel.tsx
@@ -623,83 +623,85 @@ export default function SkillsPanel() {
                 <Icon size={20} strokeWidth={1.75} aria-hidden />
               </span>
 
-              {/* body */}
-              <div className="grid min-w-0 flex-1 gap-2.5">
-                <div className="flex items-start gap-3">
+              {/* body — text stack + toggle rail as siblings, so the taller rail
+                  never inflates the name row and pushes the description down */}
+              <div className="flex min-w-0 flex-1 items-start gap-3">
+                {/* text stack — name, description, facets, actions stack tightly */}
+                <div className="grid min-w-0 flex-1 gap-2.5">
                   {/* name + custom flag */}
-                  <div className="flex min-w-0 flex-1 items-center gap-2">
+                  <div className="flex min-w-0 items-center gap-2">
                     <span className="truncate text-[17px] font-extrabold tracking-[-0.01em] text-ink">
                       {s.label || s.name}
                     </span>
                     {s.custom && <Pill className="text-[8px]">custom</Pill>}
                   </div>
 
-                  {/* right rail — the toggle + its state */}
-                  <div className="flex flex-none flex-col items-end gap-1 text-right">
-                    <span onClick={e => e.stopPropagation()}>
-                      <Toggle
-                        on={s.enabled}
-                        disabled={busy === s.name}
-                        onClick={() => toggle(s.name, !s.enabled)}
-                      />
+                  {s.ready === false && (
+                    <V3Alert tone="error" title="API key not set">
+                      This skill needs the <code>{s.requiresKey || 'required API key'}</code> environment
+                      variable set in <code>.env</code>. Until then it stays inert and never
+                      fires autonomously, even when enabled.
+                      {s.keyUrl && (
+                        <>
+                          {' '}
+                          <a
+                            href={s.keyUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            onClick={e => e.stopPropagation()}
+                            className="font-bold text-vermilion underline decoration-[1.5px] underline-offset-2"
+                          >
+                            Get a key here
+                          </a>.
+                        </>
+                      )}
+                    </V3Alert>
+                  )}
+
+                  {/* brief */}
+                  <p className="line-clamp-2 text-[12px] leading-[1.55] text-muted italic">
+                    <SkillDescription text={s.description} keyUrl={s.keyUrl} />
+                  </p>
+
+                  {/* facets — cadence, reach, tags */}
+                  <div className="flex flex-wrap gap-1">
+                    <MetaChip>{cooldownLabel(s.cooldownMs)}</MetaChip>
+                    {assign && <MetaChip>{assign}</MetaChip>}
+                    {pinned && <MetaChip accent>pinned feature</MetaChip>}
+                    {(s.tags || []).map(t => (
+                      <MetaChip key={t}>#{t}</MetaChip>
+                    ))}
+                  </div>
+
+                  {/* actions — Run now on the left, Edit affordance on the right.
+                      Same cart-pad language as the dash DJ segment pads, slimmed
+                      to one line — LED arms on hover, blinks while running. */}
+                  <div className="flex items-center justify-between gap-3">
+                    <button
+                      type="button"
+                      onClick={(e) => { e.stopPropagation(); runNow(s.name); }}
+                      disabled={busy === s.name}
+                      className={cn('seg-pad seg-pad--slim', busy === s.name && 'is-firing')}
+                    >
+                      <span className="seg-led" aria-hidden />
+                      <span className="seg-label">{busy === s.name ? 'Working…' : 'Run now'}</span>
+                    </button>
+                    <span className="inline-flex items-center gap-1 text-[10px] font-bold tracking-[0.16em] text-muted uppercase transition-colors group-hover:text-vermilion">
+                      Edit <span aria-hidden="true">→</span>
                     </span>
-                    <span className="caption">{s.enabled ? 'enabled' : 'disabled'}</span>
                   </div>
                 </div>
 
-                {s.ready === false && (
-                  <V3Alert tone="error" title="API key not set">
-                    This skill needs the <code>{s.requiresKey || 'required API key'}</code> environment
-                    variable set in <code>.env</code>. Until then it stays inert and never
-                    fires autonomously, even when enabled.
-                    {s.keyUrl && (
-                      <>
-                        {' '}
-                        <a
-                          href={s.keyUrl}
-                          target="_blank"
-                          rel="noreferrer"
-                          onClick={e => e.stopPropagation()}
-                          className="font-bold text-vermilion underline decoration-[1.5px] underline-offset-2"
-                        >
-                          Get a key here
-                        </a>.
-                      </>
-                    )}
-                  </V3Alert>
-                )}
-
-                {/* brief */}
-                <p className="line-clamp-2 text-[12px] leading-[1.55] text-muted italic">
-                  <SkillDescription text={s.description} keyUrl={s.keyUrl} />
-                </p>
-
-                {/* facets — cadence, reach, tags */}
-                <div className="flex flex-wrap gap-1">
-                  <MetaChip>{cooldownLabel(s.cooldownMs)}</MetaChip>
-                  {assign && <MetaChip>{assign}</MetaChip>}
-                  {pinned && <MetaChip accent>pinned feature</MetaChip>}
-                  {(s.tags || []).map(t => (
-                    <MetaChip key={t}>#{t}</MetaChip>
-                  ))}
-                </div>
-
-                {/* actions — Run now on the left, Edit affordance on the right.
-                    Same cart-pad language as the dash DJ segment pads, slimmed
-                    to one line — LED arms on hover, blinks while running. */}
-                <div className="flex items-center justify-between gap-3">
-                  <button
-                    type="button"
-                    onClick={(e) => { e.stopPropagation(); runNow(s.name); }}
-                    disabled={busy === s.name}
-                    className={cn('seg-pad seg-pad--slim', busy === s.name && 'is-firing')}
-                  >
-                    <span className="seg-led" aria-hidden />
-                    <span className="seg-label">{busy === s.name ? 'Working…' : 'Run now'}</span>
-                  </button>
-                  <span className="inline-flex items-center gap-1 text-[10px] font-bold tracking-[0.16em] text-muted uppercase transition-colors group-hover:text-vermilion">
-                    Edit <span aria-hidden="true">→</span>
+                {/* right rail — the toggle + its state */}
+                <div className="flex flex-none flex-col items-end gap-1 text-right">
+                  <span onClick={e => e.stopPropagation()}>
+                    <Toggle
+                      on={s.enabled}
+                      disabled={busy === s.name}
+                      onClick={() => toggle(s.name, !s.enabled)}
+                    />
                   </span>
+                  <span className="caption">{s.enabled ? 'enabled' : 'disabled'}</span>
                 </div>
               </div>
             </div>

--- a/web/components/admin/personas/PersonaRoster.tsx
+++ b/web/components/admin/personas/PersonaRoster.tsx
@@ -107,11 +107,13 @@ export function PersonaRoster({
                 )}
               </span>
 
-              {/* body */}
-              <div className="grid min-w-0 flex-1 gap-2.5">
-                <div className="flex items-start gap-3">
+              {/* body — text stack + right rail as siblings, so the taller rail
+                  never inflates the name row and pushes the facets down */}
+              <div className="flex min-w-0 flex-1 items-start gap-3">
+                {/* text stack — kicker + name, facets, brief stack tightly */}
+                <div className="grid min-w-0 flex-1 gap-2.5">
                   {/* kicker + name */}
-                  <div className="min-w-0 flex-1">
+                  <div className="min-w-0">
                     {(isOnAir || isDefault) && (
                       <div className="mb-1 flex flex-wrap items-center gap-1.5">
                         {isOnAir && <Pill tone="accent" dot>on air</Pill>}
@@ -123,35 +125,35 @@ export function PersonaRoster({
                     </div>
                   </div>
 
-                  {/* right rail — status, skill count, edit affordance */}
-                  <div className="flex flex-none flex-col items-end gap-1.5 text-right">
-                    {!valid && (
-                      <Pill className="border-[var(--danger)] text-[var(--danger)]">incomplete</Pill>
+                  {/* facets — how this persona sounds */}
+                  <div className="flex flex-wrap gap-1">
+                    <MetaChip>{p.frequency}</MetaChip>
+                    {p.scriptLength !== 'concise' && <MetaChip>{p.scriptLength}</MetaChip>}
+                    <MetaChip>{p.tts.engine}</MetaChip>
+                    {p.tts.engine !== 'piper' && p.tts.voice.trim() && (
+                      <MetaChip className="max-w-[140px] truncate">{p.tts.voice.trim()}</MetaChip>
                     )}
-                    <div className="leading-none">
-                      <span className="mono-num text-[20px] font-extrabold text-ink">{nSkills}</span>
-                      <span className="caption ml-1">skill{nSkills === 1 ? '' : 's'}</span>
-                    </div>
-                    <span className="inline-flex items-center gap-1 text-[10px] font-bold tracking-[0.16em] text-muted uppercase transition-colors group-hover:text-vermilion">
-                      Edit <span aria-hidden="true">→</span>
-                    </span>
                   </div>
+
+                  {/* brief */}
+                  <p className="line-clamp-2 text-[12px] leading-[1.55] text-muted italic">
+                    {p.tagline.trim() || 'no tagline'}
+                  </p>
                 </div>
 
-                {/* facets — how this persona sounds */}
-                <div className="flex flex-wrap gap-1">
-                  <MetaChip>{p.frequency}</MetaChip>
-                  {p.scriptLength !== 'concise' && <MetaChip>{p.scriptLength}</MetaChip>}
-                  <MetaChip>{p.tts.engine}</MetaChip>
-                  {p.tts.engine !== 'piper' && p.tts.voice.trim() && (
-                    <MetaChip className="max-w-[140px] truncate">{p.tts.voice.trim()}</MetaChip>
+                {/* right rail — status, skill count, edit affordance */}
+                <div className="flex flex-none flex-col items-end gap-1.5 text-right">
+                  {!valid && (
+                    <Pill className="border-[var(--danger)] text-[var(--danger)]">incomplete</Pill>
                   )}
+                  <div className="leading-none">
+                    <span className="mono-num text-[20px] font-extrabold text-ink">{nSkills}</span>
+                    <span className="caption ml-1">skill{nSkills === 1 ? '' : 's'}</span>
+                  </div>
+                  <span className="inline-flex items-center gap-1 text-[10px] font-bold tracking-[0.16em] text-muted uppercase transition-colors group-hover:text-vermilion">
+                    Edit <span aria-hidden="true">→</span>
+                  </span>
                 </div>
-
-                {/* brief */}
-                <p className="line-clamp-2 text-[12px] leading-[1.55] text-muted italic">
-                  {p.tagline.trim() || 'no tagline'}
-                </p>
               </div>
             </div>
           </article>


### PR DESCRIPTION
## What

On **/admin/personas** and **/admin/skills**, every card except the one carrying a `default` / `on air` pill showed an empty gap between the **name** and the **tag/description** row.

## Why

Each card body was a grid whose first row was a `flex items-start` pairing the **name** (left) with the **right rail** — skill count + `Edit →` for personas, the enable **toggle** for skills. That rail is taller than a bare name, so the row grew to the rail's height; with `items-start` the name pinned to the top and the facet/description row underneath got pushed down by the extra height. The card *with* a pill didn't show the gap because its left column (pill + name) already matched the rail's height — exactly the operator's hunch ("maybe it has default at top").

## Fix

Lift the right rail out of the name row and make it a **sibling of the whole text stack**. The name, facets, and brief now stack with a single uniform `gap-2.5`, so spacing is tight and identical on every card regardless of the rail's height. No behaviour, data, or interaction change — pure layout.

## Verification

- `web` lint clean (`eslint . && tsc --noEmit`).
- Rendered both admin pages from this branch (worktree Next dev server against the live controller) and screenshotted — the gap is gone on all persona and skill cards; the rail, toggle, and `Edit →` affordances are unchanged.