### PR TITLE
fix(web): Platter — desktop track history + mobile controls/chips polish

### DIFF
--- a/web/components/skins/platter/Platter.module.css
+++ b/web/components/skins/platter/Platter.module.css
@@ -74,3 +74,10 @@
    bottom to the thumb; the thumb rides at (1 - vf) from the top. */
 .faderFill { top: calc((1 - var(--vf, 0)) * 100%); }
 .faderThumb { top: calc((1 - var(--vf, 0)) * 100%); }
+
+/* Metadata chips — a single horizontal lane on phones. The row scrolls rather
+   than wrapping or clipping a chip mid-word (so "92 BPM" never breaks to two
+   lines); the scrollbar is hidden so it reads as a clean strip. In the wide
+   two-column layout it wraps freely (lg:flex-wrap) and this never applies. */
+.chipRow { scrollbar-width: none; }
+.chipRow::-webkit-scrollbar { display: none; }

--- a/web/components/skins/platter/PlatterSkin.tsx
+++ b/web/components/skins/platter/PlatterSkin.tsx
@@ -23,16 +23,19 @@ import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { useElapsed } from '@/hooks/useElapsed';
 import { useDynamicStyle } from '@/hooks/useDynamicStyle';
 import ThemeSwitcher from '@/components/ThemeSwitcher';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/cn';
-import { fmtTime } from '@/lib/format';
+import { fmtTime, normalizeStationLocale } from '@/lib/format';
 import { useStationClient } from '@/lib/stationClient';
 import {
   contextLine,
+  entryTime,
   lastVoiceLine,
   listenerCountOf,
   progressRatio,
   stationIdentity,
   trackMeta,
+  turnClock,
 } from '../shared';
 import { useRequestSlip, useVolumeNudge } from '../sharedHooks';
 import type { SkinProps } from '../types';
@@ -131,7 +134,7 @@ export default function PlatterSkin(_props: SkinProps) {
   const client = useStationClient();
   const {
     nowPlaying, context, dj, activeShow, listeners, state, session,
-    trackStartedAt,
+    trackStartedAt, timezone, locale,
   } = usePlayerFeed();
   const { tunedIn, status, volume, muted, offline, signal } = usePlayerAudio();
   const { toggleMute, setVolume } = usePlayerActions();
@@ -144,6 +147,8 @@ export default function PlatterSkin(_props: SkinProps) {
   const ratio = progressRatio(elapsed, nowPlaying?.duration);
   const voice = lastVoiceLine(session.messages);
   const upNext = (state.upcoming ?? []).slice(0, 2);
+  const history = (state.history ?? []).slice(0, 24);
+  const stationLocale = normalizeStationLocale(locale);
   const playing = tunedIn && status === 'playing' && !offline;
 
   const title = offline ? '— off air —' : (nowPlaying?.title ?? 'Scanning the dial…');
@@ -225,7 +230,7 @@ export default function PlatterSkin(_props: SkinProps) {
               as a row beneath the deck on phones (clear of the vinyl); mounted
               in the plinth corners from lg up (the wrapper goes display:contents
               so each cluster positions itself absolutely). */}
-          <div className="flex w-full items-end justify-center gap-8 lg:contents">
+          <div className="flex w-full items-end justify-between gap-4 lg:contents">
             <div className="flex items-end gap-3 lg:absolute lg:bottom-6 lg:left-6">
               <button
                 type="button"
@@ -283,7 +288,7 @@ export default function PlatterSkin(_props: SkinProps) {
         </div>
 
         {/* ===== metadata column ===== */}
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2.5 overflow-hidden p-4 lg:gap-4 lg:overflow-y-auto lg:p-6">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2.5 overflow-hidden p-4 lg:gap-4 lg:overflow-hidden lg:p-6">
           {/* now playing */}
           <div className="flex items-start gap-5">
             <div className="size-[84px] flex-none border border-ink bg-[var(--field)] sm:size-[104px]">
@@ -313,12 +318,12 @@ export default function PlatterSkin(_props: SkinProps) {
 
           {/* chips */}
           {(meta.facts.length > 0 || meta.moods.length > 0) && !offline && (
-            <div className="flex flex-nowrap gap-[7px] overflow-hidden lg:flex-wrap">
+            <div className={cn('flex gap-[7px] overflow-x-auto lg:flex-wrap lg:overflow-visible', styles.chipRow)}>
               {meta.facts.map(f => (
-                <span key={f} className="border border-ink px-2.5 py-1 font-mono text-[10px] tracking-[0.1em]">{f}</span>
+                <span key={f} className="shrink-0 border border-ink px-2.5 py-1 font-mono text-[10px] tracking-[0.1em] whitespace-nowrap">{f}</span>
               ))}
               {meta.moods.map(m => (
-                <span key={m} className="border border-[var(--accent)] px-2.5 py-1 font-mono text-[10px] tracking-[0.1em] text-[var(--accent)] uppercase">
+                <span key={m} className="shrink-0 border border-[var(--accent)] px-2.5 py-1 font-mono text-[10px] tracking-[0.1em] whitespace-nowrap text-[var(--accent)] uppercase">
                   {m}
                 </span>
               ))}
@@ -374,7 +379,7 @@ export default function PlatterSkin(_props: SkinProps) {
               narrow) layout so the deck fits one screen without scrolling; it
               returns in the two-column layout (lg) where the column scrolls. */}
           {voice && (
-            <div className="hidden flex-1 flex-col gap-2 border border-ink bg-bg px-4 py-3.5 lg:flex">
+            <div className="hidden flex-none flex-col gap-2 border border-ink bg-bg px-4 py-3.5 lg:flex">
               <span className="flex items-center gap-2 font-mono text-[10px] font-bold tracking-[0.18em] text-[var(--accent)] uppercase">
                 <span className={cn('size-[7px] rounded-full bg-[var(--accent)]', styles.pulse, playing && styles.playing)} />
                 on air — {djName}
@@ -382,6 +387,41 @@ export default function PlatterSkin(_props: SkinProps) {
               <span className="text-[15px] leading-relaxed italic">“{voice.text}”</span>
             </div>
           )}
+
+          {/* recently spun — the flip side of the up-next stack, and what fills
+              the tall right column. Desktop only: the phone layout drops it (as
+              the booth quote is) so the deck + metadata fit one screen. The panel
+              takes the leftover height (flex-1) and ONLY its list scrolls (shadcn
+              ScrollArea) — the surrounding column never scrolls (lg:overflow-hidden),
+              so the deck, transport and request slip stay put. */}
+          <div className="hidden min-h-0 flex-1 flex-col border border-ink bg-[var(--field)] lg:flex">
+            <div className="flex-none border-b border-soft-border px-3.5 py-2.5 font-mono text-[9px] font-bold tracking-[0.22em] text-muted uppercase">
+              recently spun
+            </div>
+            <ScrollArea type="auto" className="min-h-0 flex-1">
+              {history.length > 0 ? (
+                history.map((h, i) => (
+                  <div
+                    key={`${entryTime(h) ?? ''}-${h.title ?? i}`}
+                    className="flex items-center gap-3 border-b border-soft-border px-3.5 py-2 last:border-b-0"
+                  >
+                    <span className="size-1.5 flex-none rounded-full border border-[var(--muted)]" aria-hidden="true" />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-[14px] font-bold">{h.title ?? '—'}</div>
+                      {h.artist && <div className="truncate text-[11px] text-muted">{h.artist}</div>}
+                    </div>
+                    <span className="flex-none font-mono text-[10px] text-muted tabular-nums">
+                      {turnClock(entryTime(h), timezone, stationLocale)}
+                    </span>
+                  </div>
+                ))
+              ) : (
+                <div className="px-3.5 py-2.5 font-mono text-[11px] text-muted">
+                  the platter's been quiet — nothing spun yet this session
+                </div>
+              )}
+            </ScrollArea>
+          </div>
 
           {/* request slip */}
           <form


### PR DESCRIPTION
## What

Three fixes to the **Platter** web-player skin, from listener feedback.

### 1. Desktop track history restored
The desktop (lg) metadata column had a big empty gap below the request slip. Added a **Recently Spun** panel (track / artist / station-zone time) that fills it.

- **Desktop only** — hidden on phones (`hidden lg:flex`) so the deck + metadata still fit one screen, matching the existing "booth quote" treatment.
- The **column itself no longer scrolls** — only the history list scrolls, via the shadcn `ScrollArea` (`type="auto"`). The deck, transport and Dear DJ slip stay put.

### 2. Mobile controls split to the edges
START + MUTE were centered next to the volume fader. They now sit **START + MUTE on the left**, **volume fader on the right** (`justify-between`).

### 3. Mobile chips stay on one line
The metadata chips were shrinking and wrapping mid-label (e.g. `92 BPM` broke onto two lines). Chips are now non-shrinking + `whitespace-nowrap` in a horizontally-scrollable row (scrollbar hidden), so each chip stays on one clean line and the row scrolls if it overflows. Unchanged in the wide two-column layout (still wraps).

## Files
- `web/components/skins/platter/PlatterSkin.tsx`
- `web/components/skins/platter/Platter.module.css`

## Verification
`web` lint (`eslint . && tsc --noEmit`) passes. Rendered the live skin against the running controller at desktop (1440×900) and mobile (390×844) viewports:
- Desktop: Recently Spun list scrolls internally (shadcn scrollbar); column doesn't scroll; request slip stays visible.
- Mobile: history panel hidden; controls split left/right; chips single-line each.