### PR TITLE
fix(llm): don't send a thinking budget to Gemma models (#1044)

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -364,6 +364,13 @@ async function main() {
     assert.equal(reasoningFor({ provider: 'google', model: 'gemini-2.5-flash', reasoning: false }), 'none');
     assert.equal(reasoningFor({ provider: 'google', model: 'gemini-3.5-flash', reasoning: true }), undefined);
   });
+  await test('google: Gemma has no thinking mode — omit the param (upstream would 400 on thinkingBudget:0, issue #1044)', () => {
+    // @ai-sdk/google routes any non-gemini-3 id through the gemini-2.5 path, so
+    // 'none' becomes thinkingBudget:0 — which Gemma rejects. Must stay undefined.
+    assert.equal(reasoningFor({ provider: 'google', model: 'gemma-4-31b-it', reasoning: false }), undefined);
+    assert.equal(reasoningFor({ provider: 'google', model: 'gemma-4-31b-it', reasoning: true }), undefined);
+    assert.equal(reasoningFor({ provider: 'google', model: 'gemma-2-27b-it', reasoning: false }), undefined);
+  });
   await test('openai: effort level only on o-series/gpt-5 (sent verbatim as reasoning_effort — gpt-4-class 400s on it)', () => {
     assert.equal(reasoningFor({ provider: 'openai', model: 'o3', reasoning: false }), 'minimal');
     assert.equal(reasoningFor({ provider: 'openai', model: 'o3', reasoning: true }), 'medium');
@@ -379,6 +386,12 @@ async function main() {
     assert.equal(reasoningFor({ provider: 'gateway', model: 'anthropic/claude-haiku-4.5', reasoning: true }), undefined);
     assert.equal(reasoningFor({ provider: 'gateway', model: 'anthropic/claude-haiku-4.5', reasoning: false }), 'none');
     assert.equal(reasoningFor({ provider: 'gateway', model: 'deepseek/deepseek-v4', reasoning: true }, { forceNoThink: true }), 'none');
+  });
+  await test('gateway: Gemma downstream (google/gemma-*) omits the param — no thinkingConfig to a non-thinking model (issue #1044)', () => {
+    assert.equal(reasoningFor({ provider: 'gateway', model: 'google/gemma-4-31b-it', reasoning: false }), undefined);
+    assert.equal(reasoningFor({ provider: 'gateway', model: 'google/gemma-4-31b-it', reasoning: true }, { forceNoThink: true }), undefined);
+    // Non-Gemma google downstreams still get suppressed as before.
+    assert.equal(reasoningFor({ provider: 'gateway', model: 'google/gemini-2.5-flash', reasoning: false }), 'none');
   });
   await test('openrouter: always undefined — reasoning is fixed at model construction (extraBody in the registry)', () => {
     assert.equal(reasoningFor({ provider: 'openrouter', model: 'xiaomi/mimo-v2.5', reasoning: false }), undefined);

--- a/controller/src/llm/internal/provider/capabilities.ts
+++ b/controller/src/llm/internal/provider/capabilities.ts
@@ -141,9 +141,10 @@ const CAPS: Record<string, ProviderCapabilities> = {
     // "Thinking budget is not supported for this model" (issue #1044). Omit the
     // param for Gemma so upstream sends no thinkingConfig at all — matching what
     // v0.39.0's model-gated thinkingBlock did (it fell through to {} for Gemma).
+    // The gemma- test mirrors @ai-sdk/google's own guard (startsWith('gemma-')).
     // forceNoThink not factored — Gemini permits forced tools while reasoning.
     reasoningLevel: ({ modelId, reasoning }) =>
-      (reasoning || /gemma/i.test(modelId) ? undefined : 'none'),
+      (reasoning || /(^|\/)gemma-/i.test(modelId) ? undefined : 'none'),
   },
   deepseek: {
     objectStrategy: 'native',
@@ -192,7 +193,7 @@ const CAPS: Record<string, ProviderCapabilities> = {
     objectStrategy: 'native',
     repeatPenaltyApplies: false,
     reasoningLevel: ({ modelId, reasoning, forceNoThink }) =>
-      ((reasoning && !forceNoThink) || /gemma/i.test(modelId) ? undefined : 'none'),
+      ((reasoning && !forceNoThink) || /(^|\/)gemma-/i.test(modelId) ? undefined : 'none'),
   },
 };
 

--- a/controller/src/llm/internal/provider/capabilities.ts
+++ b/controller/src/llm/internal/provider/capabilities.ts
@@ -135,8 +135,15 @@ const CAPS: Record<string, ProviderCapabilities> = {
     // 'none' suppresses (the provider maps it per model family: gemini-3.x →
     // thinkingLevel:'minimal', gemini-2.5 → thinkingBudget:0 — the same blocks
     // the old thinkingBlock emitted, but the model regexes live upstream now).
+    // Gemma is the exception: it has NO thinking mode, yet @ai-sdk/google's
+    // resolveThinkingConfig routes every non-gemini-3 id (Gemma included) through
+    // the gemini-2.5 path, so 'none' becomes thinkingBudget:0 and the API 400s
+    // "Thinking budget is not supported for this model" (issue #1044). Omit the
+    // param for Gemma so upstream sends no thinkingConfig at all — matching what
+    // v0.39.0's model-gated thinkingBlock did (it fell through to {} for Gemma).
     // forceNoThink not factored — Gemini permits forced tools while reasoning.
-    reasoningLevel: ({ reasoning }) => (reasoning ? undefined : 'none'),
+    reasoningLevel: ({ modelId, reasoning }) =>
+      (reasoning || /gemma/i.test(modelId) ? undefined : 'none'),
   },
   deepseek: {
     objectStrategy: 'native',
@@ -177,12 +184,15 @@ const CAPS: Record<string, ProviderCapabilities> = {
   // reasoning level — to the downstream provider, so 'none' suppresses whatever
   // vendor the `provider/model` id resolves to. (The old shape emitted disable
   // blocks for anthropic + deepseek only; this covers google/openai/xai/zai
-  // downstreams too.)
+  // downstreams too.) Gemma downstreams (google/gemma-*) are the exception: they
+  // have no thinking mode and 400 on any thinkingConfig ("Thinking budget is not
+  // supported for this model", issue #1044), so omit the param for them — the
+  // gateway model id carries the `google/gemma-…` prefix, matched here.
   gateway: {
     objectStrategy: 'native',
     repeatPenaltyApplies: false,
-    reasoningLevel: ({ reasoning, forceNoThink }) =>
-      (reasoning && !forceNoThink ? undefined : 'none'),
+    reasoningLevel: ({ modelId, reasoning, forceNoThink }) =>
+      ((reasoning && !forceNoThink) || /gemma/i.test(modelId) ? undefined : 'none'),
   },
 };
 


### PR DESCRIPTION
## Problem

Issue #1044: on a Gemma model (`google/gemma-4-31b-it`), every DJ LLM call fails with:

> `Thinking budget is not supported for this model.`

Worked in **v0.39.0**, broke in **v0.40.0**.

## Root cause

The AI SDK 7 reasoning migration (#980, `a3f3d041`, first shipped v0.40.0) replaced the model-gated `thinkingBlock` with an unconditional top-level `reasoning:'none'` whenever `llm.reasoning` is off — which is the **default**.

`@ai-sdk/google@4.0.11`'s `resolveThinkingConfig` routes **every non-gemini-3 model id — Gemma included — through the gemini-2.5 path**, where `reasoning === 'none'` becomes `{ thinkingBudget: 0 }`. Gemma has no thinking mode, so the Gemini API rejects any `thinkingConfig`. Upstream's own `isGemmaModel` guard is only used for message formatting, not for suppressing the thinking config.

| | v0.39.0 (worked) | v0.40.0+ (broken) |
|---|---|---|
| `google`, reasoning off | `thinkingBlock` allowlisted `gemini-2.5`/`gemini-3.x`; Gemma fell through to `{}` → no config | `'none'` for every model → upstream emits `thinkingBudget:0` → **400** |
| `gateway` (`google/gemma-*`), reasoning off | only `anthropic`/`deepseek` disable blocks; google downstream got nothing | `'none'` for every downstream → same 400 |

The migration comment assumed "the model regexes live upstream now" — but upstream does not exclude Gemma from the thinking-disable path. That assumption is the defect.

## Fix

Omit the reasoning param (`undefined`) for Gemma on both the `google` and `gateway` descriptors, so upstream sends no `thinkingConfig` at all — restoring v0.39.0 behaviour. A case-insensitive `/gemma/i` test matches both the bare `gemma-4-31b-it` (direct provider) and the `google/gemma-…` gateway id. Suppression for real thinking models (gemini-2.5/3.x and other gateway downstreams) is unchanged.

## Tests

Added regression cases to `controller/scripts/llm-pure.test.ts` (`npm run test:llm`) asserting Gemma → `undefined` on both providers while non-Gemma suppression stays `'none'`. `npm run lint` (eslint + tsc) passes with 0 errors.

Fixes #1044