### PR TITLE
fix(cli): sync stale compose files + clear wizard/uninstall drift (#1043)

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -30,6 +30,7 @@ Usage:
   subwave restart [svc]    rebuild / restart a service (dev adds \`web-dev\`)
   subwave logs [svc|all]   tail docker compose logs (dev adds \`web-dev\`)
   subwave update           pull new images + recreate changed services
+  subwave sync             refresh compose files that are behind this CLI (--check to dry-run)
   subwave listen [dev|prod] open the web player in a browser
   subwave admin [dev|prod] open the admin console in a browser
   subwave self-update      replace the installed binary with the latest release
@@ -208,6 +209,11 @@ async function main(): Promise<void> {
     case 'update': {
       const { runUpdateCommand } = await import('./commands/update.ts');
       await runUpdateCommand();
+      return;
+    }
+    case 'sync': {
+      const { runSyncCommand } = await import('./commands/sync.ts');
+      await runSyncCommand({ check: rest.includes('--check') });
       return;
     }
     case 'listen':

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -83,7 +83,7 @@ export async function runInitCommand(opts: InitOptions = {}): Promise<void> {
       console.log();
       muted('Next:');
       muted('  subwave start          # docker compose up -d');
-      muted('  subwave setup          # configure Navidrome / LLM / TTS / DJ (and change install dir / mode)');
+      muted('  subwave setup          # configure Navidrome / LLM / TTS / DJ');
     }
     return;
   }

--- a/cli/src/commands/open-web.ts
+++ b/cli/src/commands/open-web.ts
@@ -52,7 +52,7 @@ export async function runOpenWebCommand(
   if (!openUrl(url)) {
     warn('could not launch a browser — open the URL above yourself.');
   } else if (env === 'dev') {
-    muted('dev: if the page does not load, start the web UI with `npm run dev:web`.');
+    muted('dev: if the page does not load, start the web UI with `npm --prefix web run dev`.');
   }
   await pauseForEnter();
 }

--- a/cli/src/commands/self-update.ts
+++ b/cli/src/commands/self-update.ts
@@ -67,6 +67,7 @@ export async function runSelfUpdateCommand(args: { version?: string } = {}): Pro
 
   console.log();
   muted('The running process is still the old binary — next invocation picks up the new one.');
+  muted('Then run `subwave sync` if your compose files are behind the new binary, and `subwave update`.');
   await pauseForEnter();
 }
 

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -68,8 +68,11 @@ import { p, pc, accent, exitIfCancelled, banner, header, ok, warn, err, info, mu
 
 // LLM providers — kept in step with the controller's LLM_PROVIDERS list
 // (controller/src/settings.ts) and the admin Settings UI provider picker.
+// `locca` (first-class local llama.cpp) shares the openai-compatible transport
+// but has a default host base URL and needs no API key, so it's grouped with
+// the keyless local providers here rather than the cloud set.
 type CloudProvider = 'anthropic' | 'openai' | 'google' | 'deepseek' | 'openrouter' | 'requesty' | 'gateway';
-type LlmProvider = 'ollama' | 'openai-compatible' | CloudProvider;
+type LlmProvider = 'ollama' | 'openai-compatible' | 'locca' | CloudProvider;
 
 // Cloud providers whose API key the AI SDK reads from a process.env var.
 // openai-compatible is deliberately absent — it has no canonical env var, so
@@ -386,11 +389,12 @@ async function detectOllamaUrl(): Promise<string | null> {
   return null;
 }
 
-// The provider picker — same eight providers the admin Settings UI offers,
-// in the same order, plus an explicit "configure later" escape hatch.
+// The provider picker — the providers the admin Settings UI offers, plus an
+// explicit "configure later" escape hatch.
 const LLM_PROVIDER_OPTIONS: Array<{ value: LlmProvider | 'later'; label: string; hint: string }> = [
   { value: 'ollama',            label: 'Ollama — local homelab',          hint: 'no API key — point at your homelab box' },
   { value: 'openai-compatible', label: 'OpenAI-compatible — self-hosted',  hint: 'llama.cpp, vLLM, LM Studio — your own server URL' },
+  { value: 'locca',             label: 'locca — local llama.cpp',          hint: 'no API key — defaults to the host locca server' },
   { value: 'anthropic',         label: 'Anthropic — Claude',               hint: 'needs ANTHROPIC_API_KEY' },
   { value: 'openai',            label: 'OpenAI — GPT',                     hint: 'needs OPENAI_API_KEY' },
   { value: 'google',            label: 'Google — Gemini',                  hint: 'needs GOOGLE_GENERATIVE_AI_API_KEY' },
@@ -404,10 +408,11 @@ const LLM_PROVIDER_OPTIONS: Array<{ value: LlmProvider | 'later'; label: string;
 // Example model ids — placeholder hints only, not defaults.
 const EXAMPLE_MODEL: Record<Exclude<LlmProvider, 'ollama'>, string> = {
   'openai-compatible': 'qwen3',
+  locca: 'qwen3',
   anthropic: 'claude-sonnet-4-5',
   openai: 'gpt-4o-mini',
   google: 'gemini-2.5-flash',
-  deepseek: 'deepseek-v4-flash',
+  deepseek: 'deepseek-chat',
   openrouter: 'anthropic/claude-sonnet-4-5',
   requesty: 'openai/gpt-4o-mini',
   gateway: 'anthropic/claude-sonnet-4-5',
@@ -467,6 +472,27 @@ async function collectLlm(): Promise<LlmChoice> {
       mask: '*',
     }), { backOnCancel: false });
     return { provider: 'openai-compatible', baseUrl, model, apiKey: apiKey || undefined };
+  }
+
+  if (choice === 'locca') {
+    // First-class locca: an openai-compatible llama.cpp server with a sane
+    // default (the host locca box, reachable from the container via
+    // host.docker.internal:8080). Collect a host-perspective URL and loopback-
+    // swap it for the container, mirroring the Ollama flow; blank keeps the
+    // controller's built-in default. No API key — it's local.
+    let url = exitIfCancelled(await p.text({
+      message: 'locca server URL (blank = controller default, host :8080/v1)',
+      initialValue: 'http://localhost:8080/v1',
+      placeholder: 'http://localhost:8080/v1',
+      validate: (v: string) => (v && !/^https?:\/\//.test(v) ? 'must start with http(s)://' : undefined),
+    }), { backOnCancel: false });
+    const model = exitIfCancelled(await p.text({
+      message: 'locca model id',
+      placeholder: EXAMPLE_MODEL.locca,
+      validate: (v: string) => (!v ? 'required' : undefined),
+    }), { backOnCancel: false });
+    if (url) url = await maybeSwapLoopbackForContainer(url, 'locca');
+    return { provider: 'locca', baseUrl: url || undefined, model };
   }
 
   // Cloud branch — choice is now narrowed to CloudProvider.
@@ -671,9 +697,10 @@ async function pushOnboardingSave(
     if (llm.provider === 'ollama') {
       if (llm.ollamaUrl) llmPatch.ollamaUrl = llm.ollamaUrl;
       if (llm.ollamaModel) llmPatch.model = llm.ollamaModel;
-    } else if (llm.provider === 'openai-compatible') {
-      // No canonical env var for this provider — server URL and (optional)
-      // key both live in settings.llm.
+    } else if (llm.provider === 'openai-compatible' || llm.provider === 'locca') {
+      // No canonical env var for these — server URL and (optional) key both
+      // live in settings.llm. locca's baseUrl is optional (blank → the
+      // controller's host default) and it carries no key.
       if (llm.baseUrl) llmPatch.baseUrl = llm.baseUrl;
       if (llm.model) llmPatch.model = llm.model;
       if (llm.apiKey) llmPatch.apiKey = llm.apiKey;

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -1,0 +1,82 @@
+// `subwave sync` — re-materialise the embedded compose files + .env.example
+// into the install dir, so a stack scaffolded before a service was added picks
+// it up (the #1043 fix). `init` writes these files once and nothing else
+// rewrites them; this is the explicit "refresh them now" action that the drift
+// warnings in `update` / `doctor` point at. It backs up anything it changes.
+//
+// `--check` is a dry-run: report drift, write nothing, exit non-zero if the
+// files are behind — usable from a script / CI probe.
+
+import { requireSubwaveHome, isCloneMode } from '../home.ts';
+import {
+  resolveInstallMode,
+  detectDrift,
+  hasDrift,
+  syncFiles,
+  type DriftEntry,
+} from '../compose-sync.ts';
+import { banner, header, ok, warn, info, muted, pc, pauseForEnter } from '../ui.ts';
+
+export interface SyncOptions {
+  check?: boolean; // dry-run: report drift, write nothing, non-zero exit if drifted
+}
+
+export async function runSyncCommand(opts: SyncOptions = {}): Promise<void> {
+  banner('sync');
+
+  const { home } = requireSubwaveHome();
+
+  // Clone installs get their compose from the repo — nothing for the CLI to
+  // materialise. Point at git and stop.
+  if (isCloneMode(home)) {
+    header('Clone install');
+    info('This is a git clone — its compose files come from the repo, not the CLI.');
+    muted('→ `git pull` to refresh them.');
+    await pauseForEnter();
+    return;
+  }
+
+  const mode = resolveInstallMode(home);
+  if (!mode) {
+    warn(`couldn't determine the deployment shape at ${home}.`);
+    muted('→ fresh install? run `subwave init`. Otherwise pick a shape with `subwave start prod|prod-byo`.');
+    await pauseForEnter();
+    return;
+  }
+
+  const drift = detectDrift(home, mode);
+  info(`install: ${home}   shape: ${mode}`);
+  console.log();
+
+  if (!hasDrift(drift)) {
+    ok('compose files are up to date — nothing to sync.');
+    if (opts.check) return;
+    await pauseForEnter();
+    return;
+  }
+
+  const behind = drift.filter((e) => e.status !== 'fresh');
+  header(opts.check ? 'Drift detected (check only)' : 'Refreshing compose files');
+  for (const e of behind) reportDrift(e);
+  console.log();
+
+  // Dry-run: report + non-zero exit for scripting, no writes, no pause.
+  if (opts.check) {
+    muted('→ run `subwave sync` to refresh them (backs up any changed file first).');
+    process.exit(1);
+  }
+
+  const results = syncFiles(home, mode);
+  for (const r of results) {
+    if (r.action === 'unchanged') continue;
+    const b = r.backup ? pc.dim(` (backup: ${r.backup})`) : '';
+    ok(`${r.action} ${r.name}${b}`);
+  }
+  console.log();
+  muted('→ apply the changes: `subwave restart`  (or `subwave update` to also pull new images).');
+  await pauseForEnter();
+}
+
+function reportDrift(e: DriftEntry): void {
+  warn(`${e.name} — ${e.status === 'missing' ? 'missing (will be created)' : 'behind this CLI'}`);
+}

--- a/cli/src/commands/uninstall.ts
+++ b/cli/src/commands/uninstall.ts
@@ -15,7 +15,7 @@
 // (clone-mode home) we never delete files — that's the operator's source
 // tree, not a scaffolded install; we only bring the stack down.
 
-import { existsSync, rmSync } from 'node:fs';
+import { existsSync, readdirSync, rmSync } from 'node:fs';
 import { basename, resolve } from 'node:path';
 
 import { resolveSubwaveHome, isCloneMode, HOME_CONFIG_PATH } from '../home.ts';
@@ -32,11 +32,12 @@ export interface UninstallOptions {
 }
 
 // Generated install artifacts `init` writes into the home. Removed on a
-// default uninstall; state/ is deliberately NOT in this list.
+// default uninstall; state/ is deliberately NOT in this list. Keep this in
+// lockstep with init.ts:scaffold() (all three compose files + .env/.env.example).
 const GENERATED_FILES = [
   'docker-compose.yml',
   'docker-compose.byo.yml',
-  'docker-compose.dev.yml',
+  'docker-compose.tts-heavy-gpu.yml',
   '.env',
   '.env.example',
 ];
@@ -124,6 +125,10 @@ export async function runUninstallCommand(opts: UninstallOptions = {}): Promise<
       for (const f of GENERATED_FILES) {
         const p2 = resolve(home, f);
         if (existsSync(p2)) rmSync(p2, { force: true });
+      }
+      // Sweep any `docker-compose*.bak-*` backups `subwave sync` left behind.
+      for (const f of readdirSync(home)) {
+        if (/^docker-compose.*\.bak-/.test(f)) rmSync(resolve(home, f), { force: true });
       }
       ok(`removed compose files + .env (kept ${resolve(home, 'state')})`);
     }

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -17,6 +17,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { detectCompose } from '../compose.ts';
+import { resolveInstallMode, detectDrift, hasDrift } from '../compose-sync.ts';
 import { getSubwaveHome } from '../util.ts';
 import { isCloneMode } from '../home.ts';
 import { cliImageTag, movePinInEnv } from '../version.ts';
@@ -104,6 +105,20 @@ export async function runUpdateCommand(): Promise<void> {
   if (!cloneMode) {
     muted('  `subwave self-update` to refresh the CLI binary itself.');
   }
+
+  // Compose topology (new services, changed env wiring) doesn't ride an image
+  // bump — only `subwave sync` re-materialises it. Flag drift so an install
+  // scaffolded before a service was added (e.g. the analyzer sidecar) doesn't
+  // silently stay behind. See #1043. Clone installs track git, not the binary.
+  if (!cloneMode) {
+    const mode = resolveInstallMode(home);
+    if (mode && hasDrift(detectDrift(home, mode))) {
+      console.log();
+      warn('your compose files are behind this CLI — new services / settings are missing.');
+      muted('  → run `subwave sync` to refresh them (backs up your current files first).');
+    }
+  }
+
   await pauseForEnter();
 }
 

--- a/cli/src/compose-sync.ts
+++ b/cli/src/compose-sync.ts
@@ -1,0 +1,127 @@
+// Compose drift detection + on-demand re-materialisation.
+//
+// `subwave init` writes the embedded compose files + .env.example into the
+// install dir once, and no other command ever rewrites them: `self-update`
+// swaps only the binary, `update`/`start` read the on-disk files. So an install
+// scaffolded before a service was added (e.g. the `analyzer` service in
+// v0.34.0) keeps a compose file that lacks it forever — the root cause of #1043.
+//
+// This module lets the CLI (a) detect that the on-disk files are behind the
+// binary's embedded copies (surfaced as warnings by `update`/`doctor`) and
+// (b) rewrite them on explicit demand (`subwave sync`), backing up anything it
+// changes. It never touches the live .env (secrets live there); .env.example is
+// a pure template, refreshed without a backup so operators can diff it by hand.
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  COMPOSE_YML,
+  COMPOSE_BYO_YML,
+  COMPOSE_TTS_HEAVY_GPU_YML,
+  ENV_EXAMPLE,
+} from './assets.ts';
+import { loadConfig } from './config.ts';
+import { isCloneMode } from './home.ts';
+
+// The deployment shape a standalone install was scaffolded as. Dev/clone
+// installs get their compose from git, so they're out of scope here.
+export type InstallMode = 'prod' | 'prod-byo';
+
+export interface ExpectedFile {
+  name: string; // basename in the install dir
+  content: string; // the embedded copy this CLI would write
+  // .env.example is a pure template — refreshed without a .bak (no operator data).
+  backup: boolean;
+}
+
+export type DriftStatus = 'fresh' | 'drifted' | 'missing';
+
+export interface DriftEntry {
+  name: string;
+  status: DriftStatus;
+}
+
+export interface SyncEntry {
+  name: string;
+  action: 'created' | 'updated' | 'unchanged';
+  backup?: string; // basename of the .bak written, when one was
+}
+
+// The file-set `subwave init` materialises, resolved from the embedded assets
+// for the given mode. Keep in lockstep with init.ts:scaffold().
+export function expectedFiles(mode: InstallMode): ExpectedFile[] {
+  return [
+    {
+      name: 'docker-compose.yml',
+      content: mode === 'prod-byo' ? COMPOSE_BYO_YML : COMPOSE_YML,
+      backup: true,
+    },
+    { name: 'docker-compose.byo.yml', content: COMPOSE_BYO_YML, backup: true },
+    { name: 'docker-compose.tts-heavy-gpu.yml', content: COMPOSE_TTS_HEAVY_GPU_YML, backup: true },
+    { name: '.env.example', content: ENV_EXAMPLE, backup: false },
+  ];
+}
+
+// Resolve the deployment shape of a standalone install. preferredEnv (written
+// by init/start) is authoritative; otherwise infer from the on-disk
+// docker-compose.yml — the prod variant bundles a `caddy:` service, BYO doesn't.
+// Returns null for clone/dev installs or when it can't be determined; backups
+// make even a wrong guess recoverable.
+export function resolveInstallMode(home: string): InstallMode | null {
+  if (isCloneMode(home)) return null;
+  const pref = loadConfig().preferredEnv;
+  if (pref === 'prod' || pref === 'prod-byo') return pref;
+  if (pref === 'dev') return null;
+
+  const composePath = resolve(home, 'docker-compose.yml');
+  if (!existsSync(composePath)) return null;
+  const body = readFileSync(composePath, 'utf8');
+  return /^ {2}caddy:/m.test(body) ? 'prod' : 'prod-byo';
+}
+
+// Byte-compare each expected file against what's on disk.
+export function detectDrift(home: string, mode: InstallMode): DriftEntry[] {
+  return expectedFiles(mode).map(({ name, content }) => {
+    const path = resolve(home, name);
+    if (!existsSync(path)) return { name, status: 'missing' };
+    return { name, status: readFileSync(path, 'utf8') === content ? 'fresh' : 'drifted' };
+  });
+}
+
+export function hasDrift(entries: DriftEntry[]): boolean {
+  return entries.some((e) => e.status !== 'fresh');
+}
+
+// Re-materialise the drifted/missing files, backing up any existing file that
+// changes (except .env.example). Fresh files are left untouched.
+export function syncFiles(home: string, mode: InstallMode): SyncEntry[] {
+  const stamp = backupStamp();
+  const out: SyncEntry[] = [];
+  for (const { name, content, backup } of expectedFiles(mode)) {
+    const path = resolve(home, name);
+    const exists = existsSync(path);
+    if (exists && readFileSync(path, 'utf8') === content) {
+      out.push({ name, action: 'unchanged' });
+      continue;
+    }
+    let backupName: string | undefined;
+    if (exists && backup) {
+      backupName = `${name}.bak-${stamp}`;
+      writeFileSync(resolve(home, backupName), readFileSync(path));
+    }
+    writeFileSync(path, content);
+    out.push({ name, action: exists ? 'updated' : 'created', backup: backupName });
+  }
+  return out;
+}
+
+// Compact local timestamp for backup filenames, e.g. 20260715-142530.
+function backupStamp(): string {
+  const d = new Date();
+  const p2 = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${d.getFullYear()}${p2(d.getMonth() + 1)}${p2(d.getDate())}-` +
+    `${p2(d.getHours())}${p2(d.getMinutes())}${p2(d.getSeconds())}`
+  );
+}

--- a/cli/src/doctor.ts
+++ b/cli/src/doctor.ts
@@ -13,8 +13,10 @@ import { resolve } from 'node:path';
 import { detectCompose, isProdEnv, streamUrlFor, webBaseFor, type ComposeStatus } from './compose.ts';
 import { dockerDaemonOk, composeExec } from './docker.ts';
 import { makeClient, checkNeedsSetup } from './api.ts';
-import { getLegacyControllerEnv, getRootEnv, parseEnvFile, getStateDir, fetchErrorReason } from './util.ts';
+import { getLegacyControllerEnv, getRootEnv, parseEnvFile, getStateDir, getSubwaveHome, fetchErrorReason } from './util.ts';
 import { whoHolds7700, readWebDevPid, getWebDevLog, isWebDevCommand } from './web-dev.ts';
+import { isCloneMode } from './home.ts';
+import { resolveInstallMode, detectDrift, hasDrift } from './compose-sync.ts';
 
 export type Status = 'ok' | 'warn' | 'fail' | 'skip';
 
@@ -87,6 +89,13 @@ function checkHost(): Finding[] {
 
 function checkCompose(compose: ComposeStatus): Finding[] {
   const out: Finding[] = [];
+
+  // Compose freshness runs regardless of up/down — the files live on disk
+  // whether or not the stack is running, and a standalone install can drift
+  // behind the binary's embedded copies (see #1043).
+  const freshness = composeFreshnessFinding();
+  if (freshness) out.push(freshness);
+
   if (compose.env === 'down') {
     out.push({
       label: 'stack',
@@ -123,6 +132,29 @@ function checkCompose(compose: ComposeStatus): Finding[] {
     out.push({ label: `service · ${svc}`, status, detail: state });
   }
   return out;
+}
+
+// Are the on-disk compose files + .env.example still what this CLI would
+// write? Only `subwave sync` re-materialises them, so an install scaffolded
+// before a service was added stays behind until the operator syncs (#1043).
+// Clone/dev installs (git-owned compose) and undeterminable shapes are skipped.
+function composeFreshnessFinding(): Finding | null {
+  const home = getSubwaveHome();
+  if (isCloneMode(home)) return null;
+  const mode = resolveInstallMode(home);
+  if (!mode) return null;
+
+  const drift = detectDrift(home, mode);
+  if (!hasDrift(drift)) {
+    return { label: 'freshness', status: 'ok', detail: 'compose files match this CLI' };
+  }
+  const n = drift.filter((e) => e.status !== 'fresh').length;
+  return {
+    label: 'freshness',
+    status: 'warn',
+    detail: `${n} compose file${n === 1 ? '' : 's'} behind this CLI`,
+    hint: 'Run `subwave sync` to refresh them (backs up current files first).',
+  };
 }
 
 async function checkController(compose: ComposeStatus): Promise<Finding[]> {

--- a/cli/src/menu.ts
+++ b/cli/src/menu.ts
@@ -6,7 +6,7 @@
 
 import { detectCompose } from './compose.ts';
 import { setMenuMode, MENU_BACK, banner, header, ok, warn, muted, exitIfCancelled, p, pc } from './ui.ts';
-import { whoHolds7700 } from './web-dev.ts';
+import { whoHolds7700, isWebDevCommand } from './web-dev.ts';
 import { runStatusCommand } from './commands/status.ts';
 import { runDoctorCommand } from './commands/doctor.ts';
 import { runStartCommand } from './commands/start.ts';
@@ -15,6 +15,10 @@ import { runRestartCommand } from './commands/restart.ts';
 import { runLogsCommand } from './commands/logs.ts';
 import { runOpenWebCommand } from './commands/open-web.ts';
 import { runSetupCommand } from './commands/setup.ts';
+import { runSyncCommand } from './commands/sync.ts';
+import { getSubwaveHome } from './util.ts';
+import { isCloneMode } from './home.ts';
+import { resolveInstallMode, detectDrift, hasDrift } from './compose-sync.ts';
 
 export async function runMenu(): Promise<void> {
   setMenuMode(true);
@@ -35,7 +39,9 @@ export async function runMenu(): Promise<void> {
     if (compose.env === 'dev') {
       const holder = whoHolds7700();
       total += 1;
-      if (holder?.command === 'node') running += 1;
+      // `next dev` reports as `next-server` on Linux, `node` on macOS — match
+      // both (isWebDevCommand), else the banner undercounts on Linux.
+      if (holder && isWebDevCommand(holder.command)) running += 1;
     }
     ok(`stack up · env=${pc.bold(compose.env)} · ${running}/${total} running`);
   }
@@ -58,6 +64,11 @@ export async function runMenu(): Promise<void> {
     options.push({ value: 'stop', label: 'stop', hint: 'docker compose down' });
   }
   options.push({ value: 'setup', label: 'setup', hint: 're-run the install wizard' });
+  // Surface `sync` only when the on-disk compose has fallen behind the binary
+  // — so the operator sees it exactly when it matters (see #1043).
+  if (composeFilesDrifted()) {
+    options.push({ value: 'sync', label: 'sync', hint: pc.yellow('compose files behind this CLI — refresh them') });
+  }
   options.push({ value: 'quit', label: pc.dim('quit') });
 
   let choice: string;
@@ -98,6 +109,7 @@ async function dispatch(choice: string): Promise<void> {
     case 'stop':    return runStopCommand();
     case 'restart': return runRestartCommand();
     case 'logs':    return runLogsCommand();
+    case 'sync':    return runSyncCommand();
     case 'setup': {
       // The setup wizard owns its own Clack lifecycle. Temporarily disable
       // menu-mode so its Esc handling works normally; restore after.
@@ -110,5 +122,19 @@ async function dispatch(choice: string): Promise<void> {
       header('Unknown choice');
       muted(`'${choice}' is not a known command.`);
       return;
+  }
+}
+
+// Cheap on-disk drift probe for the menu (a few readFileSync — no docker/HTTP).
+// Standalone installs only; any resolution error → no hint (never blocks the
+// menu render).
+function composeFilesDrifted(): boolean {
+  try {
+    const home = getSubwaveHome();
+    if (isCloneMode(home)) return false;
+    const mode = resolveInstallMode(home);
+    return mode ? hasDrift(detectDrift(home, mode)) : false;
+  } catch {
+    return false;
   }
 }

--- a/docs/superpowers/specs/2026-07-15-cli-compose-sync-and-staleness-design.md
+++ b/docs/superpowers/specs/2026-07-15-cli-compose-sync-and-staleness-design.md
@@ -1,0 +1,88 @@
+# CLI compose-sync + staleness cleanup — design
+
+**Date:** 2026-07-15
+**Branch:** `worktree-cli-compose-sync`
+**Issue:** [#1043](https://github.com/perminder-klair/subwave/issues/1043) — "Analyzer container will not start"
+
+## Problem
+
+The standalone `subwave` CLI materialises the embedded compose files + `.env.example` into the install directory **only on `subwave init`**, and refuses to overwrite them. No update path ever refreshes them afterwards:
+
+- `subwave self-update` replaces **only the binary** (`self-update.ts`).
+- `subwave update` reads the **on-disk** compose (`update.ts:28`, `:62`) and pulls images; its own comment wrongly assumes "the binary on PATH already has the latest compose file thanks to `subwave self-update`" — but nothing writes the embedded compose to disk.
+- `subwave start` reads the on-disk compose too.
+
+So any install scaffolded before a service was added keeps a compose file that lacks it forever. The `analyzer` service was added in **v0.34.0** (#717); post-split the controller resolves acoustic analysis **only** from `ANALYZE_URL` (`controller/src/config.ts:80`) with no tts-heavy fallback. Result for #1043: `docker compose up -d analyzer` → "no such service: analyzer", no analyzer container, library shows "engine off", and `ANALYZER_HEAVY=1` does nothing (no service to switch). Image *tags* float forward via `SUBWAVE_VERSION` + pull, but compose **topology** never does.
+
+This design closes that gap (warn-on-drift + explicit sync) and clears the adjacent CLI staleness the audit surfaced.
+
+## Approach (decided)
+
+- **Detect + warn, sync on demand** — the CLI never silently overwrites a possibly-hand-edited compose. `update` and `doctor` warn when the on-disk files are behind the binary's embedded copies; a new explicit `subwave sync` re-materialises them, backing up any changed file first.
+- **Scope:** the core fix **plus** all audit findings (locca in the wizard, uninstall file-set, menu tally, comment/hint drift).
+- **Not touched:** versioning (`cli/package.json` 0.40.0 vs project 0.42.0 is develop-lags-main; release-please self-corrects), deps, `patch-clack`, the install script, embedded assets (already in sync).
+
+## Component 1 — `cli/src/compose-sync.ts` (new, the core seam)
+
+Pure, side-effect-free derivations + one writer. This is the unit-testable core.
+
+**`expectedFiles(mode): { name, content }[]`** — the file-set `init` writes, resolved from embedded assets (`assets.ts`):
+| file | content | notes |
+|---|---|---|
+| `docker-compose.yml` | `mode === 'prod-byo' ? COMPOSE_BYO_YML : COMPOSE_YML` | mode-dependent |
+| `docker-compose.byo.yml` | `COMPOSE_BYO_YML` | init always writes it |
+| `docker-compose.tts-heavy-gpu.yml` | `COMPOSE_TTS_HEAVY_GPU_YML` | GPU overlay |
+| `.env.example` | `ENV_EXAMPLE` | reference template |
+
+**`resolveInstallMode(home): 'prod' | 'prod-byo' | null`** — `loadConfig().preferredEnv` when it is `prod`/`prod-byo`; else infer from the on-disk `docker-compose.yml` (`caddy:` service present → `prod`, absent → `prod-byo`); `null` when undeterminable or clone/dev. Backups make a wrong guess recoverable regardless.
+
+**`detectDrift(home, mode): DriftEntry[]`** — `DriftEntry = { name, status: 'fresh' | 'drifted' | 'missing' }`, byte-compare on-disk vs expected. `hasDrift(...) = entries.some(e => e.status !== 'fresh')`.
+
+**`syncFiles(home, mode): SyncResult[]`** — for each expected file: if drifted/missing, back up the existing file (if any) to `<name>.bak-<timestamp>` then write fresh; `.env.example` is refreshed **without** backup (pure template, no operator data). Never touches the live `.env`. Returns `{ name, action: 'created'|'updated'|'unchanged', backup?: path }[]`.
+
+**Guards:** clone installs (`isCloneMode`) and dev return no drift / refuse sync — git owns their compose. The live `.env` is never rewritten; new optional vars surface only via the refreshed `.env.example` (operators diff manually — merging into a secrets-bearing `.env` is out of scope).
+
+## Component 2 — `subwave sync` (new command)
+
+`cli/src/commands/sync.ts` → `runSyncCommand({ check?: boolean })`:
+
+1. Resolve `home` + `mode`. Clone → message ("clone install — `git pull` to refresh compose") + return. `mode === null` → warn, point to `subwave init`.
+2. `detectDrift`. No drift → "compose files are up to date." return.
+3. Print the drifted/missing files. **`--check`** stops here (dry-run; nonzero exit if drift) for scripting. Otherwise `syncFiles`, print per-file action + backup path, then hint: *"restart to apply: `subwave restart` — or `subwave update` to also pull new images."*
+
+Wire into `cli.ts` dispatch + help text, and add a contextual `sync` entry to `menu.ts` when drift is detected.
+
+## Component 3 — warn hooks
+
+- **`update.ts`** — after "update complete", standalone-only: if `hasDrift`, print a prominent warn block naming the count and pointing at `subwave sync` (backs up first). This is the surface that would have caught #1043.
+- **`doctor.ts`** — add a compose-freshness `Finding` to the existing **Compose** section (`checkCompose`), standalone-only: `warn` + hint `run \`subwave sync\`` when drifted; `ok` when fresh; `skip` in clone/dev.
+- **`self-update.ts`** — one muted closing line suggesting `subwave sync` if compose is behind.
+
+## Component 4 — staleness cleanup (audit findings)
+
+1. **locca in the setup wizard** (`setup.ts`) — the controller has 10 `LLM_PROVIDERS` incl. first-class `locca` (`settings.ts:280`); the wizard knows 9. locca is openai-compatible transport with a **default** base URL (`http://host.docker.internal:8080/v1`, `registry.ts:206`) and **no API key**, so in the wizard it mirrors the Ollama branch, not the cloud branch:
+   - add `'locca'` to the `LlmProvider` union;
+   - add to `LLM_PROVIDER_OPTIONS` after `openai-compatible` (same transport family); soften the "same eight/order as admin" comments (`:69`, `:389`) to stop asserting an exact count/order;
+   - `collectLlm` locca branch: prompt URL (default `http://localhost:8080/v1`, optional, loopback-swap via `maybeSwapLoopbackForContainer`) + model (required); no key; no probe (like openai-compatible);
+   - save block: `provider:'locca'` + `baseUrl` (if set) + `model` (mirror the openai-compatible branch; locca is not in `CLOUD_ENV_VAR`, so no key export — correct);
+   - add a `locca` `EXAMPLE_MODEL` entry.
+2. **uninstall file-set** (`uninstall.ts:36`) — `GENERATED_FILES`: drop `docker-compose.dev.yml` (init never writes it), add `docker-compose.tts-heavy-gpu.yml` (init writes it). Optionally sweep `docker-compose*.bak-*` sync backups.
+3. **menu tally** (`menu.ts:38`) — `holder?.command === 'node'` → `holder && isWebDevCommand(holder.command)` (import from `web-dev.ts`); fixes the Linux undercount (`next-server`).
+4. **comment/hint drift** — `init.ts:86` "change install dir / mode" → what setup actually does; `open-web.ts:55` `npm run dev:web` → `npm --prefix web run dev`; refresh stale `EXAMPLE_MODEL` ids (`setup.ts:405`).
+
+## Out of scope
+
+- Versioning / release wiring (release-please owns it; develop simply lags main). Note only: a hand-built dev binary embeds `0.40.0` and would move `SUBWAVE_VERSION` backward — a dev-build-only edge, not shipped. No guard added.
+- Merging new keys into the live `.env`. No test framework for the CLI (there is none today).
+
+## Testing
+
+- **Gate:** `npm --prefix cli run typecheck` (`tsc --noEmit`) must pass.
+- **Repro #1043 (scratch, uncommitted, under `$CLAUDE_JOB_DIR/tmp`):** scaffold a fake home with an old `docker-compose.yml` (analyzer service removed) + `cli.json` preferredEnv=prod → run `sync --check` (reports drift) then `sync` → assert `analyzer:` now present and a `.bak` was written. Repeat for byo mode and clone-mode no-op.
+- Run the CLI in dev via `tsx cli/src/cli.ts <cmd>` (bun-compiled in prod; tsx for local exercise).
+- Manual sanity: `sync` on an already-fresh install reports "up to date"; `doctor` shows the new freshness finding.
+
+## File change list
+
+**New:** `cli/src/compose-sync.ts`, `cli/src/commands/sync.ts`.
+**Edit:** `cli/src/cli.ts` (dispatch+help), `cli/src/menu.ts` (sync entry + tally fix), `cli/src/commands/update.ts` (drift warn), `cli/src/doctor.ts` (freshness finding), `cli/src/commands/self-update.ts` (hint), `cli/src/commands/setup.ts` (locca + comments + EXAMPLE_MODEL), `cli/src/commands/uninstall.ts` (file-set), `cli/src/commands/init.ts` (hint), `cli/src/commands/open-web.ts` (hint).


### PR DESCRIPTION
Fixes #1043.

## Root cause

The standalone `subwave` CLI materialises the embedded compose files + `.env.example` only on `subwave init`, and refuses to overwrite them. No update path refreshes them afterwards: `self-update` swaps **only the binary**, `update`/`start` read the **on-disk** compose. So a stack scaffolded before the `analyzer` service was added (v0.34.0, #717) permanently lacks it — `docker compose up -d analyzer` → "no such service: analyzer", no analyzer container, and the library reads "engine off" (post-split the controller resolves analysis only from `ANALYZE_URL`, no tts-heavy fallback). Image *tags* float forward via `SUBWAVE_VERSION` + pull, but compose *topology* never does.

## Fix — warn on drift, sync on demand

- **`compose-sync.ts`** (new, pure seam): resolves the install's expected file-set from the embedded assets, byte-compares against on-disk, and re-materialises with a timestamped `.bak` backup of anything changed. Never touches the live `.env`; refreshes `.env.example` for manual diffing. Clone/dev installs are no-ops (git owns their compose).
- **`subwave sync`** (new command, `--check` dry-run): the explicit "refresh them now" action.
- **`update`, `doctor`, and the menu** warn when the on-disk files are behind the binary and point at `subwave sync`; `self-update` adds a closing hint.

This is deliberately non-destructive: it never silently overwrites a possibly hand-edited compose — it warns, and `sync` backs up before writing.

## Adjacent staleness (audit-surfaced)

- `locca` added to the `subwave setup` LLM wizard (was missing; keyless local llama.cpp, mirrors the Ollama branch).
- `uninstall` file-set matches `init` (no leftover `docker-compose.tts-heavy-gpu.yml`; sweeps sync `.bak-` backups).
- menu dev-server tally counts `next-server` on Linux (was hardcoded to `node`).
- comment/hint drift: `init` ("change install dir/mode"), `open-web` (`npm run dev:web`), provider-count comments, stale model-id hints.

**Untouched:** versioning (release-please owns it; develop lags main), deps, `patch-clack`, embedded assets (verified still in sync).

## Verification

- `npm --prefix cli run typecheck` (tsc --noEmit) — clean.
- Repro harness (scratch install with the analyzer service stripped): 17/17 assertions — drift detected, `sync` restores the analyzer service, timestamped backup written, idempotent on re-run, `.env.example` created without a backup.
- `subwave sync --check` / `sync` / `sync --check` smoke-tested through `cli.ts` (exit 1 on drift, refresh + backup, exit 0 when fresh).
- caddy-presence mode heuristic validated against the real prod/byo compose files.

Design spec: `docs/superpowers/specs/2026-07-15-cli-compose-sync-and-staleness-design.md`.