### PR TITLE
fix(web): add missing On: label to Playlist-only (strict) hint

### DIFF
--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -1776,7 +1776,7 @@ function ShowEditor({
               <div className="grid gap-0.5">
                 <Label>Playlist only (strict)</Label>
                 <span className="field-hint">
-                  Play ONLY tracks from the pinned playlist(s) — off-playlist
+                  On: play ONLY tracks from the pinned playlist(s) — off-playlist
                   tracks air only as a last resort to avoid silence. Off: the
                   playlist dominates but the DJ can still wander for variety.
                   Listener requests are always allowed through, either way.


### PR DESCRIPTION
The help text under **Playlist only (strict)** on the edit-show page described the *On* behavior with no label, then labelled the *Off* behavior with `Off:` — so it read as if both halves referred to "off".

Prefixes the first half with `On:` so each state is clearly labelled.

```
On: play ONLY tracks from the pinned playlist(s) — off-playlist tracks air only as a last resort to avoid silence. Off: the playlist dominates but the DJ can still wander for variety. Listener requests are always allowed through, either way.
```