### PR TITLE
fix(web): spool cassette scales to fit on short viewports (iPad Mini)

### DIFF
--- a/web/components/skins/spool/Spool.module.css
+++ b/web/components/skins/spool/Spool.module.css
@@ -52,3 +52,18 @@
 /* Dynamic fills — progress + volume, driven by --pf / --vf on the skin root. */
 .progFill { width: calc(var(--pf, 0) * 100%); }
 .volFill { width: calc(var(--vf, 0) * 100%); }
+
+/* Cassette hero fit-to-box. The cassette holds its 512/320 ratio but must scale
+   to the SMALLER of the deck's width and height — short viewports (iPad Mini
+   landscape ≈ 1024×768) are height-bound, and a width-only rule (w-full/max-w)
+   let the aspect-locked box overflow the deck vertically. The hero is a size
+   container (its w/h are grid/flex-driven, independent of contents — safe for
+   `size`); cqw/cqh are its padded content box. */
+.hero { container-type: size; }
+.cassette {
+  /* Fallback for engines without container-query units: prior width behaviour. */
+  width: 100%;
+  max-width: 512px;
+  /* width that keeps height (= w·320/512) within the container: w ≤ cqh·512/320. */
+  width: min(100cqw, 512px, calc(100cqh * 512 / 320));
+}

--- a/web/components/skins/spool/SpoolSkin.tsx
+++ b/web/components/skins/spool/SpoolSkin.tsx
@@ -359,8 +359,8 @@ export default function SpoolSkin(_props: SkinProps) {
               </div>
 
               {/* cassette hero */}
-              <div className="flex min-h-0 flex-1 items-center justify-center p-5">
-                <div className="relative flex aspect-[512/320] w-full max-w-[512px] flex-col border border-ink bg-bg shadow-[inset_0_0_0_8px_var(--field),inset_0_0_40px_rgba(0,0,0,0.06)]">
+              <div className={cn(styles.hero, 'flex min-h-0 flex-1 items-center justify-center p-5')}>
+                <div className={cn(styles.cassette, 'relative flex aspect-[512/320] flex-col border border-ink bg-bg shadow-[inset_0_0_0_8px_var(--field),inset_0_0_40px_rgba(0,0,0,0.06)]')}>
                   <span className="absolute top-4 left-4 size-[7px] rounded-full border border-muted" aria-hidden="true" />
                   <span className="absolute top-4 right-4 size-[7px] rounded-full border border-muted" aria-hidden="true" />
                   <span className="absolute bottom-4 left-4 size-[7px] rounded-full border border-muted" aria-hidden="true" />


### PR DESCRIPTION
## Problem

On **iPad Mini landscape (1024×768)** the `spool` skin's cassette breaks out of the top of the deck panel, overlapping the `SUB/WAVE · SIDE A` brand strip.

The cassette hero was **width-driven with a locked aspect ratio and no height bound**:

```
aspect-[512/320] w-full max-w-[512px]   →  always 512 × 320px
```

At 1024px the desktop grid is active (`lg:` = 1024px), but the deck's cassette slot is only ~278px tall. The aspect-locked 320px cassette overflowed **~21px above and below** — `items-center` makes it symmetric, and nothing clips it, so it pokes through the deck panel's top border. It only ever bit on *short* viewports; tall desktops had the vertical headroom to hide it.

## Fix

Make the hero a **size container** and scale the cassette to the *smaller of the deck's width and height* while preserving its 512/320 ratio, via container-query units:

```css
.hero { container-type: size; }
.cassette {
  width: 100%; max-width: 512px;                 /* fallback: prior behaviour */
  width: min(100cqw, 512px, calc(100cqh * 512 / 320));
}
```

Tall viewports keep the cassette at its full 512×320 (width-bound); short viewports scale it down to fit. The fallback line means engines without container-query support are no worse than today.

## Verification

Measured in headless Chromium with the spool skin forced via `subwave-skin-override`:

| Viewport | Cassette | Overflow |
|---|---|---|
| 1024×768 (iPad Mini landscape) | 381×238 — scaled to fit | none (−20px, inside padding) |
| 1440×900 | 512×320 — full size | none |
| 1920×1080 | 512×320 — full size | none |
| iPad portrait 1024×1366 | 512×320 — full size | none |

Reels still animate and inherit `--reel-l/r` through the size container. `npm run lint` (eslint + tsc) clean.

## Scope

Fixes the cassette overflow specifically. The desktop grid still assumes a rough minimum viewport height for its full chrome (masthead + transport + rewound shelf) — comfortable at 768px now, but an extremely short window would still crowd. Not addressed here.