### PR TITLE
release: cli compose-sync + player skin polish + themes manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It's *radio*, not a playlist. No per-listener shuffle, no skip button, no
 
 ## Showreel
 
-https://github.com/user-attachments/assets/fac7b723-c54f-438d-8440-bad1e0471e85
+https://github.com/user-attachments/assets/0a2ba78a-eda3-44c1-adce-bfa78ae992cd
 
 ## Live demo
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -30,6 +30,7 @@ Usage:
   subwave restart [svc]    rebuild / restart a service (dev adds \`web-dev\`)
   subwave logs [svc|all]   tail docker compose logs (dev adds \`web-dev\`)
   subwave update           pull new images + recreate changed services
+  subwave sync             refresh compose files that are behind this CLI (--check to dry-run)
   subwave listen [dev|prod] open the web player in a browser
   subwave admin [dev|prod] open the admin console in a browser
   subwave self-update      replace the installed binary with the latest release
@@ -208,6 +209,11 @@ async function main(): Promise<void> {
     case 'update': {
       const { runUpdateCommand } = await import('./commands/update.ts');
       await runUpdateCommand();
+      return;
+    }
+    case 'sync': {
+      const { runSyncCommand } = await import('./commands/sync.ts');
+      await runSyncCommand({ check: rest.includes('--check') });
       return;
     }
     case 'listen':

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -83,7 +83,7 @@ export async function runInitCommand(opts: InitOptions = {}): Promise<void> {
       console.log();
       muted('Next:');
       muted('  subwave start          # docker compose up -d');
-      muted('  subwave setup          # configure Navidrome / LLM / TTS / DJ (and change install dir / mode)');
+      muted('  subwave setup          # configure Navidrome / LLM / TTS / DJ');
     }
     return;
   }

--- a/cli/src/commands/open-web.ts
+++ b/cli/src/commands/open-web.ts
@@ -52,7 +52,7 @@ export async function runOpenWebCommand(
   if (!openUrl(url)) {
     warn('could not launch a browser — open the URL above yourself.');
   } else if (env === 'dev') {
-    muted('dev: if the page does not load, start the web UI with `npm run dev:web`.');
+    muted('dev: if the page does not load, start the web UI with `npm --prefix web run dev`.');
   }
   await pauseForEnter();
 }

--- a/cli/src/commands/self-update.ts
+++ b/cli/src/commands/self-update.ts
@@ -67,6 +67,7 @@ export async function runSelfUpdateCommand(args: { version?: string } = {}): Pro
 
   console.log();
   muted('The running process is still the old binary — next invocation picks up the new one.');
+  muted('Then run `subwave sync` if your compose files are behind the new binary, and `subwave update`.');
   await pauseForEnter();
 }
 

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -68,8 +68,11 @@ import { p, pc, accent, exitIfCancelled, banner, header, ok, warn, err, info, mu
 
 // LLM providers — kept in step with the controller's LLM_PROVIDERS list
 // (controller/src/settings.ts) and the admin Settings UI provider picker.
+// `locca` (first-class local llama.cpp) shares the openai-compatible transport
+// but has a default host base URL and needs no API key, so it's grouped with
+// the keyless local providers here rather than the cloud set.
 type CloudProvider = 'anthropic' | 'openai' | 'google' | 'deepseek' | 'openrouter' | 'requesty' | 'gateway';
-type LlmProvider = 'ollama' | 'openai-compatible' | CloudProvider;
+type LlmProvider = 'ollama' | 'openai-compatible' | 'locca' | CloudProvider;
 
 // Cloud providers whose API key the AI SDK reads from a process.env var.
 // openai-compatible is deliberately absent — it has no canonical env var, so
@@ -386,11 +389,12 @@ async function detectOllamaUrl(): Promise<string | null> {
   return null;
 }
 
-// The provider picker — same eight providers the admin Settings UI offers,
-// in the same order, plus an explicit "configure later" escape hatch.
+// The provider picker — the providers the admin Settings UI offers, plus an
+// explicit "configure later" escape hatch.
 const LLM_PROVIDER_OPTIONS: Array<{ value: LlmProvider | 'later'; label: string; hint: string }> = [
   { value: 'ollama',            label: 'Ollama — local homelab',          hint: 'no API key — point at your homelab box' },
   { value: 'openai-compatible', label: 'OpenAI-compatible — self-hosted',  hint: 'llama.cpp, vLLM, LM Studio — your own server URL' },
+  { value: 'locca',             label: 'locca — local llama.cpp',          hint: 'no API key — defaults to the host locca server' },
   { value: 'anthropic',         label: 'Anthropic — Claude',               hint: 'needs ANTHROPIC_API_KEY' },
   { value: 'openai',            label: 'OpenAI — GPT',                     hint: 'needs OPENAI_API_KEY' },
   { value: 'google',            label: 'Google — Gemini',                  hint: 'needs GOOGLE_GENERATIVE_AI_API_KEY' },
@@ -404,10 +408,11 @@ const LLM_PROVIDER_OPTIONS: Array<{ value: LlmProvider | 'later'; label: string;
 // Example model ids — placeholder hints only, not defaults.
 const EXAMPLE_MODEL: Record<Exclude<LlmProvider, 'ollama'>, string> = {
   'openai-compatible': 'qwen3',
+  locca: 'qwen3',
   anthropic: 'claude-sonnet-4-5',
   openai: 'gpt-4o-mini',
   google: 'gemini-2.5-flash',
-  deepseek: 'deepseek-v4-flash',
+  deepseek: 'deepseek-chat',
   openrouter: 'anthropic/claude-sonnet-4-5',
   requesty: 'openai/gpt-4o-mini',
   gateway: 'anthropic/claude-sonnet-4-5',
@@ -467,6 +472,27 @@ async function collectLlm(): Promise<LlmChoice> {
       mask: '*',
     }), { backOnCancel: false });
     return { provider: 'openai-compatible', baseUrl, model, apiKey: apiKey || undefined };
+  }
+
+  if (choice === 'locca') {
+    // First-class locca: an openai-compatible llama.cpp server with a sane
+    // default (the host locca box, reachable from the container via
+    // host.docker.internal:8080). Collect a host-perspective URL and loopback-
+    // swap it for the container, mirroring the Ollama flow; blank keeps the
+    // controller's built-in default. No API key — it's local.
+    let url = exitIfCancelled(await p.text({
+      message: 'locca server URL (blank = controller default, host :8080/v1)',
+      initialValue: 'http://localhost:8080/v1',
+      placeholder: 'http://localhost:8080/v1',
+      validate: (v: string) => (v && !/^https?:\/\//.test(v) ? 'must start with http(s)://' : undefined),
+    }), { backOnCancel: false });
+    const model = exitIfCancelled(await p.text({
+      message: 'locca model id',
+      placeholder: EXAMPLE_MODEL.locca,
+      validate: (v: string) => (!v ? 'required' : undefined),
+    }), { backOnCancel: false });
+    if (url) url = await maybeSwapLoopbackForContainer(url, 'locca');
+    return { provider: 'locca', baseUrl: url || undefined, model };
   }
 
   // Cloud branch — choice is now narrowed to CloudProvider.
@@ -671,9 +697,10 @@ async function pushOnboardingSave(
     if (llm.provider === 'ollama') {
       if (llm.ollamaUrl) llmPatch.ollamaUrl = llm.ollamaUrl;
       if (llm.ollamaModel) llmPatch.model = llm.ollamaModel;
-    } else if (llm.provider === 'openai-compatible') {
-      // No canonical env var for this provider — server URL and (optional)
-      // key both live in settings.llm.
+    } else if (llm.provider === 'openai-compatible' || llm.provider === 'locca') {
+      // No canonical env var for these — server URL and (optional) key both
+      // live in settings.llm. locca's baseUrl is optional (blank → the
+      // controller's host default) and it carries no key.
       if (llm.baseUrl) llmPatch.baseUrl = llm.baseUrl;
       if (llm.model) llmPatch.model = llm.model;
       if (llm.apiKey) llmPatch.apiKey = llm.apiKey;

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -1,0 +1,82 @@
+// `subwave sync` — re-materialise the embedded compose files + .env.example
+// into the install dir, so a stack scaffolded before a service was added picks
+// it up (the #1043 fix). `init` writes these files once and nothing else
+// rewrites them; this is the explicit "refresh them now" action that the drift
+// warnings in `update` / `doctor` point at. It backs up anything it changes.
+//
+// `--check` is a dry-run: report drift, write nothing, exit non-zero if the
+// files are behind — usable from a script / CI probe.
+
+import { requireSubwaveHome, isCloneMode } from '../home.ts';
+import {
+  resolveInstallMode,
+  detectDrift,
+  hasDrift,
+  syncFiles,
+  type DriftEntry,
+} from '../compose-sync.ts';
+import { banner, header, ok, warn, info, muted, pc, pauseForEnter } from '../ui.ts';
+
+export interface SyncOptions {
+  check?: boolean; // dry-run: report drift, write nothing, non-zero exit if drifted
+}
+
+export async function runSyncCommand(opts: SyncOptions = {}): Promise<void> {
+  banner('sync');
+
+  const { home } = requireSubwaveHome();
+
+  // Clone installs get their compose from the repo — nothing for the CLI to
+  // materialise. Point at git and stop.
+  if (isCloneMode(home)) {
+    header('Clone install');
+    info('This is a git clone — its compose files come from the repo, not the CLI.');
+    muted('→ `git pull` to refresh them.');
+    await pauseForEnter();
+    return;
+  }
+
+  const mode = resolveInstallMode(home);
+  if (!mode) {
+    warn(`couldn't determine the deployment shape at ${home}.`);
+    muted('→ fresh install? run `subwave init`. Otherwise pick a shape with `subwave start prod|prod-byo`.');
+    await pauseForEnter();
+    return;
+  }
+
+  const drift = detectDrift(home, mode);
+  info(`install: ${home}   shape: ${mode}`);
+  console.log();
+
+  if (!hasDrift(drift)) {
+    ok('compose files are up to date — nothing to sync.');
+    if (opts.check) return;
+    await pauseForEnter();
+    return;
+  }
+
+  const behind = drift.filter((e) => e.status !== 'fresh');
+  header(opts.check ? 'Drift detected (check only)' : 'Refreshing compose files');
+  for (const e of behind) reportDrift(e);
+  console.log();
+
+  // Dry-run: report + non-zero exit for scripting, no writes, no pause.
+  if (opts.check) {
+    muted('→ run `subwave sync` to refresh them (backs up any changed file first).');
+    process.exit(1);
+  }
+
+  const results = syncFiles(home, mode);
+  for (const r of results) {
+    if (r.action === 'unchanged') continue;
+    const b = r.backup ? pc.dim(` (backup: ${r.backup})`) : '';
+    ok(`${r.action} ${r.name}${b}`);
+  }
+  console.log();
+  muted('→ apply the changes: `subwave restart`  (or `subwave update` to also pull new images).');
+  await pauseForEnter();
+}
+
+function reportDrift(e: DriftEntry): void {
+  warn(`${e.name} — ${e.status === 'missing' ? 'missing (will be created)' : 'behind this CLI'}`);
+}

--- a/cli/src/commands/uninstall.ts
+++ b/cli/src/commands/uninstall.ts
@@ -15,7 +15,7 @@
 // (clone-mode home) we never delete files — that's the operator's source
 // tree, not a scaffolded install; we only bring the stack down.
 
-import { existsSync, rmSync } from 'node:fs';
+import { existsSync, readdirSync, rmSync } from 'node:fs';
 import { basename, resolve } from 'node:path';
 
 import { resolveSubwaveHome, isCloneMode, HOME_CONFIG_PATH } from '../home.ts';
@@ -32,11 +32,12 @@ export interface UninstallOptions {
 }
 
 // Generated install artifacts `init` writes into the home. Removed on a
-// default uninstall; state/ is deliberately NOT in this list.
+// default uninstall; state/ is deliberately NOT in this list. Keep this in
+// lockstep with init.ts:scaffold() (all three compose files + .env/.env.example).
 const GENERATED_FILES = [
   'docker-compose.yml',
   'docker-compose.byo.yml',
-  'docker-compose.dev.yml',
+  'docker-compose.tts-heavy-gpu.yml',
   '.env',
   '.env.example',
 ];
@@ -124,6 +125,10 @@ export async function runUninstallCommand(opts: UninstallOptions = {}): Promise<
       for (const f of GENERATED_FILES) {
         const p2 = resolve(home, f);
         if (existsSync(p2)) rmSync(p2, { force: true });
+      }
+      // Sweep any `docker-compose*.bak-*` backups `subwave sync` left behind.
+      for (const f of readdirSync(home)) {
+        if (/^docker-compose.*\.bak-/.test(f)) rmSync(resolve(home, f), { force: true });
       }
       ok(`removed compose files + .env (kept ${resolve(home, 'state')})`);
     }

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -17,6 +17,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { detectCompose } from '../compose.ts';
+import { resolveInstallMode, detectDrift, hasDrift } from '../compose-sync.ts';
 import { getSubwaveHome } from '../util.ts';
 import { isCloneMode } from '../home.ts';
 import { cliImageTag, movePinInEnv } from '../version.ts';
@@ -104,6 +105,20 @@ export async function runUpdateCommand(): Promise<void> {
   if (!cloneMode) {
     muted('  `subwave self-update` to refresh the CLI binary itself.');
   }
+
+  // Compose topology (new services, changed env wiring) doesn't ride an image
+  // bump — only `subwave sync` re-materialises it. Flag drift so an install
+  // scaffolded before a service was added (e.g. the analyzer sidecar) doesn't
+  // silently stay behind. See #1043. Clone installs track git, not the binary.
+  if (!cloneMode) {
+    const mode = resolveInstallMode(home);
+    if (mode && hasDrift(detectDrift(home, mode))) {
+      console.log();
+      warn('your compose files are behind this CLI — new services / settings are missing.');
+      muted('  → run `subwave sync` to refresh them (backs up your current files first).');
+    }
+  }
+
   await pauseForEnter();
 }
 

--- a/cli/src/compose-sync.ts
+++ b/cli/src/compose-sync.ts
@@ -1,0 +1,127 @@
+// Compose drift detection + on-demand re-materialisation.
+//
+// `subwave init` writes the embedded compose files + .env.example into the
+// install dir once, and no other command ever rewrites them: `self-update`
+// swaps only the binary, `update`/`start` read the on-disk files. So an install
+// scaffolded before a service was added (e.g. the `analyzer` service in
+// v0.34.0) keeps a compose file that lacks it forever — the root cause of #1043.
+//
+// This module lets the CLI (a) detect that the on-disk files are behind the
+// binary's embedded copies (surfaced as warnings by `update`/`doctor`) and
+// (b) rewrite them on explicit demand (`subwave sync`), backing up anything it
+// changes. It never touches the live .env (secrets live there); .env.example is
+// a pure template, refreshed without a backup so operators can diff it by hand.
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  COMPOSE_YML,
+  COMPOSE_BYO_YML,
+  COMPOSE_TTS_HEAVY_GPU_YML,
+  ENV_EXAMPLE,
+} from './assets.ts';
+import { loadConfig } from './config.ts';
+import { isCloneMode } from './home.ts';
+
+// The deployment shape a standalone install was scaffolded as. Dev/clone
+// installs get their compose from git, so they're out of scope here.
+export type InstallMode = 'prod' | 'prod-byo';
+
+export interface ExpectedFile {
+  name: string; // basename in the install dir
+  content: string; // the embedded copy this CLI would write
+  // .env.example is a pure template — refreshed without a .bak (no operator data).
+  backup: boolean;
+}
+
+export type DriftStatus = 'fresh' | 'drifted' | 'missing';
+
+export interface DriftEntry {
+  name: string;
+  status: DriftStatus;
+}
+
+export interface SyncEntry {
+  name: string;
+  action: 'created' | 'updated' | 'unchanged';
+  backup?: string; // basename of the .bak written, when one was
+}
+
+// The file-set `subwave init` materialises, resolved from the embedded assets
+// for the given mode. Keep in lockstep with init.ts:scaffold().
+export function expectedFiles(mode: InstallMode): ExpectedFile[] {
+  return [
+    {
+      name: 'docker-compose.yml',
+      content: mode === 'prod-byo' ? COMPOSE_BYO_YML : COMPOSE_YML,
+      backup: true,
+    },
+    { name: 'docker-compose.byo.yml', content: COMPOSE_BYO_YML, backup: true },
+    { name: 'docker-compose.tts-heavy-gpu.yml', content: COMPOSE_TTS_HEAVY_GPU_YML, backup: true },
+    { name: '.env.example', content: ENV_EXAMPLE, backup: false },
+  ];
+}
+
+// Resolve the deployment shape of a standalone install. preferredEnv (written
+// by init/start) is authoritative; otherwise infer from the on-disk
+// docker-compose.yml — the prod variant bundles a `caddy:` service, BYO doesn't.
+// Returns null for clone/dev installs or when it can't be determined; backups
+// make even a wrong guess recoverable.
+export function resolveInstallMode(home: string): InstallMode | null {
+  if (isCloneMode(home)) return null;
+  const pref = loadConfig().preferredEnv;
+  if (pref === 'prod' || pref === 'prod-byo') return pref;
+  if (pref === 'dev') return null;
+
+  const composePath = resolve(home, 'docker-compose.yml');
+  if (!existsSync(composePath)) return null;
+  const body = readFileSync(composePath, 'utf8');
+  return /^ {2}caddy:/m.test(body) ? 'prod' : 'prod-byo';
+}
+
+// Byte-compare each expected file against what's on disk.
+export function detectDrift(home: string, mode: InstallMode): DriftEntry[] {
+  return expectedFiles(mode).map(({ name, content }) => {
+    const path = resolve(home, name);
+    if (!existsSync(path)) return { name, status: 'missing' };
+    return { name, status: readFileSync(path, 'utf8') === content ? 'fresh' : 'drifted' };
+  });
+}
+
+export function hasDrift(entries: DriftEntry[]): boolean {
+  return entries.some((e) => e.status !== 'fresh');
+}
+
+// Re-materialise the drifted/missing files, backing up any existing file that
+// changes (except .env.example). Fresh files are left untouched.
+export function syncFiles(home: string, mode: InstallMode): SyncEntry[] {
+  const stamp = backupStamp();
+  const out: SyncEntry[] = [];
+  for (const { name, content, backup } of expectedFiles(mode)) {
+    const path = resolve(home, name);
+    const exists = existsSync(path);
+    if (exists && readFileSync(path, 'utf8') === content) {
+      out.push({ name, action: 'unchanged' });
+      continue;
+    }
+    let backupName: string | undefined;
+    if (exists && backup) {
+      backupName = `${name}.bak-${stamp}`;
+      writeFileSync(resolve(home, backupName), readFileSync(path));
+    }
+    writeFileSync(path, content);
+    out.push({ name, action: exists ? 'updated' : 'created', backup: backupName });
+  }
+  return out;
+}
+
+// Compact local timestamp for backup filenames, e.g. 20260715-142530.
+function backupStamp(): string {
+  const d = new Date();
+  const p2 = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${d.getFullYear()}${p2(d.getMonth() + 1)}${p2(d.getDate())}-` +
+    `${p2(d.getHours())}${p2(d.getMinutes())}${p2(d.getSeconds())}`
+  );
+}

--- a/cli/src/doctor.ts
+++ b/cli/src/doctor.ts
@@ -13,8 +13,10 @@ import { resolve } from 'node:path';
 import { detectCompose, isProdEnv, streamUrlFor, webBaseFor, type ComposeStatus } from './compose.ts';
 import { dockerDaemonOk, composeExec } from './docker.ts';
 import { makeClient, checkNeedsSetup } from './api.ts';
-import { getLegacyControllerEnv, getRootEnv, parseEnvFile, getStateDir, fetchErrorReason } from './util.ts';
+import { getLegacyControllerEnv, getRootEnv, parseEnvFile, getStateDir, getSubwaveHome, fetchErrorReason } from './util.ts';
 import { whoHolds7700, readWebDevPid, getWebDevLog, isWebDevCommand } from './web-dev.ts';
+import { isCloneMode } from './home.ts';
+import { resolveInstallMode, detectDrift, hasDrift } from './compose-sync.ts';
 
 export type Status = 'ok' | 'warn' | 'fail' | 'skip';
 
@@ -87,6 +89,13 @@ function checkHost(): Finding[] {
 
 function checkCompose(compose: ComposeStatus): Finding[] {
   const out: Finding[] = [];
+
+  // Compose freshness runs regardless of up/down — the files live on disk
+  // whether or not the stack is running, and a standalone install can drift
+  // behind the binary's embedded copies (see #1043).
+  const freshness = composeFreshnessFinding();
+  if (freshness) out.push(freshness);
+
   if (compose.env === 'down') {
     out.push({
       label: 'stack',
@@ -123,6 +132,29 @@ function checkCompose(compose: ComposeStatus): Finding[] {
     out.push({ label: `service · ${svc}`, status, detail: state });
   }
   return out;
+}
+
+// Are the on-disk compose files + .env.example still what this CLI would
+// write? Only `subwave sync` re-materialises them, so an install scaffolded
+// before a service was added stays behind until the operator syncs (#1043).
+// Clone/dev installs (git-owned compose) and undeterminable shapes are skipped.
+function composeFreshnessFinding(): Finding | null {
+  const home = getSubwaveHome();
+  if (isCloneMode(home)) return null;
+  const mode = resolveInstallMode(home);
+  if (!mode) return null;
+
+  const drift = detectDrift(home, mode);
+  if (!hasDrift(drift)) {
+    return { label: 'freshness', status: 'ok', detail: 'compose files match this CLI' };
+  }
+  const n = drift.filter((e) => e.status !== 'fresh').length;
+  return {
+    label: 'freshness',
+    status: 'warn',
+    detail: `${n} compose file${n === 1 ? '' : 's'} behind this CLI`,
+    hint: 'Run `subwave sync` to refresh them (backs up current files first).',
+  };
 }
 
 async function checkController(compose: ComposeStatus): Promise<Finding[]> {

--- a/cli/src/menu.ts
+++ b/cli/src/menu.ts
@@ -6,7 +6,7 @@
 
 import { detectCompose } from './compose.ts';
 import { setMenuMode, MENU_BACK, banner, header, ok, warn, muted, exitIfCancelled, p, pc } from './ui.ts';
-import { whoHolds7700 } from './web-dev.ts';
+import { whoHolds7700, isWebDevCommand } from './web-dev.ts';
 import { runStatusCommand } from './commands/status.ts';
 import { runDoctorCommand } from './commands/doctor.ts';
 import { runStartCommand } from './commands/start.ts';
@@ -15,6 +15,10 @@ import { runRestartCommand } from './commands/restart.ts';
 import { runLogsCommand } from './commands/logs.ts';
 import { runOpenWebCommand } from './commands/open-web.ts';
 import { runSetupCommand } from './commands/setup.ts';
+import { runSyncCommand } from './commands/sync.ts';
+import { getSubwaveHome } from './util.ts';
+import { isCloneMode } from './home.ts';
+import { resolveInstallMode, detectDrift, hasDrift } from './compose-sync.ts';
 
 export async function runMenu(): Promise<void> {
   setMenuMode(true);
@@ -35,7 +39,9 @@ export async function runMenu(): Promise<void> {
     if (compose.env === 'dev') {
       const holder = whoHolds7700();
       total += 1;
-      if (holder?.command === 'node') running += 1;
+      // `next dev` reports as `next-server` on Linux, `node` on macOS — match
+      // both (isWebDevCommand), else the banner undercounts on Linux.
+      if (holder && isWebDevCommand(holder.command)) running += 1;
     }
     ok(`stack up · env=${pc.bold(compose.env)} · ${running}/${total} running`);
   }
@@ -58,6 +64,11 @@ export async function runMenu(): Promise<void> {
     options.push({ value: 'stop', label: 'stop', hint: 'docker compose down' });
   }
   options.push({ value: 'setup', label: 'setup', hint: 're-run the install wizard' });
+  // Surface `sync` only when the on-disk compose has fallen behind the binary
+  // — so the operator sees it exactly when it matters (see #1043).
+  if (composeFilesDrifted()) {
+    options.push({ value: 'sync', label: 'sync', hint: pc.yellow('compose files behind this CLI — refresh them') });
+  }
   options.push({ value: 'quit', label: pc.dim('quit') });
 
   let choice: string;
@@ -98,6 +109,7 @@ async function dispatch(choice: string): Promise<void> {
     case 'stop':    return runStopCommand();
     case 'restart': return runRestartCommand();
     case 'logs':    return runLogsCommand();
+    case 'sync':    return runSyncCommand();
     case 'setup': {
       // The setup wizard owns its own Clack lifecycle. Temporarily disable
       // menu-mode so its Esc handling works normally; restore after.
@@ -110,5 +122,19 @@ async function dispatch(choice: string): Promise<void> {
       header('Unknown choice');
       muted(`'${choice}' is not a known command.`);
       return;
+  }
+}
+
+// Cheap on-disk drift probe for the menu (a few readFileSync — no docker/HTTP).
+// Standalone installs only; any resolution error → no hint (never blocks the
+// menu render).
+function composeFilesDrifted(): boolean {
+  try {
+    const home = getSubwaveHome();
+    if (isCloneMode(home)) return false;
+    const mode = resolveInstallMode(home);
+    return mode ? hasDrift(detectDrift(home, mode)) : false;
+  } catch {
+    return false;
   }
 }

--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -364,6 +364,13 @@ async function main() {
     assert.equal(reasoningFor({ provider: 'google', model: 'gemini-2.5-flash', reasoning: false }), 'none');
     assert.equal(reasoningFor({ provider: 'google', model: 'gemini-3.5-flash', reasoning: true }), undefined);
   });
+  await test('google: Gemma has no thinking mode — omit the param (upstream would 400 on thinkingBudget:0, issue #1044)', () => {
+    // @ai-sdk/google routes any non-gemini-3 id through the gemini-2.5 path, so
+    // 'none' becomes thinkingBudget:0 — which Gemma rejects. Must stay undefined.
+    assert.equal(reasoningFor({ provider: 'google', model: 'gemma-4-31b-it', reasoning: false }), undefined);
+    assert.equal(reasoningFor({ provider: 'google', model: 'gemma-4-31b-it', reasoning: true }), undefined);
+    assert.equal(reasoningFor({ provider: 'google', model: 'gemma-2-27b-it', reasoning: false }), undefined);
+  });
   await test('openai: effort level only on o-series/gpt-5 (sent verbatim as reasoning_effort — gpt-4-class 400s on it)', () => {
     assert.equal(reasoningFor({ provider: 'openai', model: 'o3', reasoning: false }), 'minimal');
     assert.equal(reasoningFor({ provider: 'openai', model: 'o3', reasoning: true }), 'medium');
@@ -379,6 +386,12 @@ async function main() {
     assert.equal(reasoningFor({ provider: 'gateway', model: 'anthropic/claude-haiku-4.5', reasoning: true }), undefined);
     assert.equal(reasoningFor({ provider: 'gateway', model: 'anthropic/claude-haiku-4.5', reasoning: false }), 'none');
     assert.equal(reasoningFor({ provider: 'gateway', model: 'deepseek/deepseek-v4', reasoning: true }, { forceNoThink: true }), 'none');
+  });
+  await test('gateway: Gemma downstream (google/gemma-*) omits the param — no thinkingConfig to a non-thinking model (issue #1044)', () => {
+    assert.equal(reasoningFor({ provider: 'gateway', model: 'google/gemma-4-31b-it', reasoning: false }), undefined);
+    assert.equal(reasoningFor({ provider: 'gateway', model: 'google/gemma-4-31b-it', reasoning: true }, { forceNoThink: true }), undefined);
+    // Non-Gemma google downstreams still get suppressed as before.
+    assert.equal(reasoningFor({ provider: 'gateway', model: 'google/gemini-2.5-flash', reasoning: false }), 'none');
   });
   await test('openrouter: always undefined — reasoning is fixed at model construction (extraBody in the registry)', () => {
     assert.equal(reasoningFor({ provider: 'openrouter', model: 'xiaomi/mimo-v2.5', reasoning: false }), undefined);

--- a/controller/src/llm/internal/provider/capabilities.ts
+++ b/controller/src/llm/internal/provider/capabilities.ts
@@ -135,8 +135,16 @@ const CAPS: Record<string, ProviderCapabilities> = {
     // 'none' suppresses (the provider maps it per model family: gemini-3.x →
     // thinkingLevel:'minimal', gemini-2.5 → thinkingBudget:0 — the same blocks
     // the old thinkingBlock emitted, but the model regexes live upstream now).
+    // Gemma is the exception: it has NO thinking mode, yet @ai-sdk/google's
+    // resolveThinkingConfig routes every non-gemini-3 id (Gemma included) through
+    // the gemini-2.5 path, so 'none' becomes thinkingBudget:0 and the API 400s
+    // "Thinking budget is not supported for this model" (issue #1044). Omit the
+    // param for Gemma so upstream sends no thinkingConfig at all — matching what
+    // v0.39.0's model-gated thinkingBlock did (it fell through to {} for Gemma).
+    // The gemma- test mirrors @ai-sdk/google's own guard (startsWith('gemma-')).
     // forceNoThink not factored — Gemini permits forced tools while reasoning.
-    reasoningLevel: ({ reasoning }) => (reasoning ? undefined : 'none'),
+    reasoningLevel: ({ modelId, reasoning }) =>
+      (reasoning || /(^|\/)gemma-/i.test(modelId) ? undefined : 'none'),
   },
   deepseek: {
     objectStrategy: 'native',
@@ -177,12 +185,15 @@ const CAPS: Record<string, ProviderCapabilities> = {
   // reasoning level — to the downstream provider, so 'none' suppresses whatever
   // vendor the `provider/model` id resolves to. (The old shape emitted disable
   // blocks for anthropic + deepseek only; this covers google/openai/xai/zai
-  // downstreams too.)
+  // downstreams too.) Gemma downstreams (google/gemma-*) are the exception: they
+  // have no thinking mode and 400 on any thinkingConfig ("Thinking budget is not
+  // supported for this model", issue #1044), so omit the param for them — the
+  // gateway model id carries the `google/gemma-…` prefix, matched here.
   gateway: {
     objectStrategy: 'native',
     repeatPenaltyApplies: false,
-    reasoningLevel: ({ reasoning, forceNoThink }) =>
-      (reasoning && !forceNoThink ? undefined : 'none'),
+    reasoningLevel: ({ modelId, reasoning, forceNoThink }) =>
+      ((reasoning && !forceNoThink) || /(^|\/)gemma-/i.test(modelId) ? undefined : 'none'),
   },
 };
 

--- a/docs/superpowers/specs/2026-07-15-cli-compose-sync-and-staleness-design.md
+++ b/docs/superpowers/specs/2026-07-15-cli-compose-sync-and-staleness-design.md
@@ -1,0 +1,88 @@
+# CLI compose-sync + staleness cleanup — design
+
+**Date:** 2026-07-15
+**Branch:** `worktree-cli-compose-sync`
+**Issue:** [#1043](https://github.com/perminder-klair/subwave/issues/1043) — "Analyzer container will not start"
+
+## Problem
+
+The standalone `subwave` CLI materialises the embedded compose files + `.env.example` into the install directory **only on `subwave init`**, and refuses to overwrite them. No update path ever refreshes them afterwards:
+
+- `subwave self-update` replaces **only the binary** (`self-update.ts`).
+- `subwave update` reads the **on-disk** compose (`update.ts:28`, `:62`) and pulls images; its own comment wrongly assumes "the binary on PATH already has the latest compose file thanks to `subwave self-update`" — but nothing writes the embedded compose to disk.
+- `subwave start` reads the on-disk compose too.
+
+So any install scaffolded before a service was added keeps a compose file that lacks it forever. The `analyzer` service was added in **v0.34.0** (#717); post-split the controller resolves acoustic analysis **only** from `ANALYZE_URL` (`controller/src/config.ts:80`) with no tts-heavy fallback. Result for #1043: `docker compose up -d analyzer` → "no such service: analyzer", no analyzer container, library shows "engine off", and `ANALYZER_HEAVY=1` does nothing (no service to switch). Image *tags* float forward via `SUBWAVE_VERSION` + pull, but compose **topology** never does.
+
+This design closes that gap (warn-on-drift + explicit sync) and clears the adjacent CLI staleness the audit surfaced.
+
+## Approach (decided)
+
+- **Detect + warn, sync on demand** — the CLI never silently overwrites a possibly-hand-edited compose. `update` and `doctor` warn when the on-disk files are behind the binary's embedded copies; a new explicit `subwave sync` re-materialises them, backing up any changed file first.
+- **Scope:** the core fix **plus** all audit findings (locca in the wizard, uninstall file-set, menu tally, comment/hint drift).
+- **Not touched:** versioning (`cli/package.json` 0.40.0 vs project 0.42.0 is develop-lags-main; release-please self-corrects), deps, `patch-clack`, the install script, embedded assets (already in sync).
+
+## Component 1 — `cli/src/compose-sync.ts` (new, the core seam)
+
+Pure, side-effect-free derivations + one writer. This is the unit-testable core.
+
+**`expectedFiles(mode): { name, content }[]`** — the file-set `init` writes, resolved from embedded assets (`assets.ts`):
+| file | content | notes |
+|---|---|---|
+| `docker-compose.yml` | `mode === 'prod-byo' ? COMPOSE_BYO_YML : COMPOSE_YML` | mode-dependent |
+| `docker-compose.byo.yml` | `COMPOSE_BYO_YML` | init always writes it |
+| `docker-compose.tts-heavy-gpu.yml` | `COMPOSE_TTS_HEAVY_GPU_YML` | GPU overlay |
+| `.env.example` | `ENV_EXAMPLE` | reference template |
+
+**`resolveInstallMode(home): 'prod' | 'prod-byo' | null`** — `loadConfig().preferredEnv` when it is `prod`/`prod-byo`; else infer from the on-disk `docker-compose.yml` (`caddy:` service present → `prod`, absent → `prod-byo`); `null` when undeterminable or clone/dev. Backups make a wrong guess recoverable regardless.
+
+**`detectDrift(home, mode): DriftEntry[]`** — `DriftEntry = { name, status: 'fresh' | 'drifted' | 'missing' }`, byte-compare on-disk vs expected. `hasDrift(...) = entries.some(e => e.status !== 'fresh')`.
+
+**`syncFiles(home, mode): SyncResult[]`** — for each expected file: if drifted/missing, back up the existing file (if any) to `<name>.bak-<timestamp>` then write fresh; `.env.example` is refreshed **without** backup (pure template, no operator data). Never touches the live `.env`. Returns `{ name, action: 'created'|'updated'|'unchanged', backup?: path }[]`.
+
+**Guards:** clone installs (`isCloneMode`) and dev return no drift / refuse sync — git owns their compose. The live `.env` is never rewritten; new optional vars surface only via the refreshed `.env.example` (operators diff manually — merging into a secrets-bearing `.env` is out of scope).
+
+## Component 2 — `subwave sync` (new command)
+
+`cli/src/commands/sync.ts` → `runSyncCommand({ check?: boolean })`:
+
+1. Resolve `home` + `mode`. Clone → message ("clone install — `git pull` to refresh compose") + return. `mode === null` → warn, point to `subwave init`.
+2. `detectDrift`. No drift → "compose files are up to date." return.
+3. Print the drifted/missing files. **`--check`** stops here (dry-run; nonzero exit if drift) for scripting. Otherwise `syncFiles`, print per-file action + backup path, then hint: *"restart to apply: `subwave restart` — or `subwave update` to also pull new images."*
+
+Wire into `cli.ts` dispatch + help text, and add a contextual `sync` entry to `menu.ts` when drift is detected.
+
+## Component 3 — warn hooks
+
+- **`update.ts`** — after "update complete", standalone-only: if `hasDrift`, print a prominent warn block naming the count and pointing at `subwave sync` (backs up first). This is the surface that would have caught #1043.
+- **`doctor.ts`** — add a compose-freshness `Finding` to the existing **Compose** section (`checkCompose`), standalone-only: `warn` + hint `run \`subwave sync\`` when drifted; `ok` when fresh; `skip` in clone/dev.
+- **`self-update.ts`** — one muted closing line suggesting `subwave sync` if compose is behind.
+
+## Component 4 — staleness cleanup (audit findings)
+
+1. **locca in the setup wizard** (`setup.ts`) — the controller has 10 `LLM_PROVIDERS` incl. first-class `locca` (`settings.ts:280`); the wizard knows 9. locca is openai-compatible transport with a **default** base URL (`http://host.docker.internal:8080/v1`, `registry.ts:206`) and **no API key**, so in the wizard it mirrors the Ollama branch, not the cloud branch:
+   - add `'locca'` to the `LlmProvider` union;
+   - add to `LLM_PROVIDER_OPTIONS` after `openai-compatible` (same transport family); soften the "same eight/order as admin" comments (`:69`, `:389`) to stop asserting an exact count/order;
+   - `collectLlm` locca branch: prompt URL (default `http://localhost:8080/v1`, optional, loopback-swap via `maybeSwapLoopbackForContainer`) + model (required); no key; no probe (like openai-compatible);
+   - save block: `provider:'locca'` + `baseUrl` (if set) + `model` (mirror the openai-compatible branch; locca is not in `CLOUD_ENV_VAR`, so no key export — correct);
+   - add a `locca` `EXAMPLE_MODEL` entry.
+2. **uninstall file-set** (`uninstall.ts:36`) — `GENERATED_FILES`: drop `docker-compose.dev.yml` (init never writes it), add `docker-compose.tts-heavy-gpu.yml` (init writes it). Optionally sweep `docker-compose*.bak-*` sync backups.
+3. **menu tally** (`menu.ts:38`) — `holder?.command === 'node'` → `holder && isWebDevCommand(holder.command)` (import from `web-dev.ts`); fixes the Linux undercount (`next-server`).
+4. **comment/hint drift** — `init.ts:86` "change install dir / mode" → what setup actually does; `open-web.ts:55` `npm run dev:web` → `npm --prefix web run dev`; refresh stale `EXAMPLE_MODEL` ids (`setup.ts:405`).
+
+## Out of scope
+
+- Versioning / release wiring (release-please owns it; develop simply lags main). Note only: a hand-built dev binary embeds `0.40.0` and would move `SUBWAVE_VERSION` backward — a dev-build-only edge, not shipped. No guard added.
+- Merging new keys into the live `.env`. No test framework for the CLI (there is none today).
+
+## Testing
+
+- **Gate:** `npm --prefix cli run typecheck` (`tsc --noEmit`) must pass.
+- **Repro #1043 (scratch, uncommitted, under `$CLAUDE_JOB_DIR/tmp`):** scaffold a fake home with an old `docker-compose.yml` (analyzer service removed) + `cli.json` preferredEnv=prod → run `sync --check` (reports drift) then `sync` → assert `analyzer:` now present and a `.bak` was written. Repeat for byo mode and clone-mode no-op.
+- Run the CLI in dev via `tsx cli/src/cli.ts <cmd>` (bun-compiled in prod; tsx for local exercise).
+- Manual sanity: `sync` on an already-fresh install reports "up to date"; `doctor` shows the new freshness finding.
+
+## File change list
+
+**New:** `cli/src/compose-sync.ts`, `cli/src/commands/sync.ts`.
+**Edit:** `cli/src/cli.ts` (dispatch+help), `cli/src/menu.ts` (sync entry + tally fix), `cli/src/commands/update.ts` (drift warn), `cli/src/doctor.ts` (freshness finding), `cli/src/commands/self-update.ts` (hint), `cli/src/commands/setup.ts` (locca + comments + EXAMPLE_MODEL), `cli/src/commands/uninstall.ts` (file-set), `cli/src/commands/init.ts` (hint), `cli/src/commands/open-web.ts` (hint).

--- a/web/app/manual/themes/page.tsx
+++ b/web/app/manual/themes/page.tsx
@@ -2,9 +2,9 @@ import Themes from '../../../components/manual/Themes';
 import { pageMeta } from '@/lib/seo';
 
 export const metadata = pageMeta({
-  title: 'SUB/WAVE — Manual · Themes',
+  title: 'SUB/WAVE — Manual · Skins & Themes',
   description:
-    'Theming SUB/WAVE — switch palettes and tailor the look of the player and the broadsheet to your station.',
+    'Skinning and theming SUB/WAVE — swap the player face between six built-in skins, switch palettes, and fork the reference player when you want to go further.',
   path: '/manual/themes',
 });
 

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -1776,7 +1776,7 @@ function ShowEditor({
               <div className="grid gap-0.5">
                 <Label>Playlist only (strict)</Label>
                 <span className="field-hint">
-                  Play ONLY tracks from the pinned playlist(s) — off-playlist
+                  On: play ONLY tracks from the pinned playlist(s) — off-playlist
                   tracks air only as a last resort to avoid silence. Off: the
                   playlist dominates but the DJ can still wander for variety.
                   Listener requests are always allowed through, either way.

--- a/web/components/manual/Overview.tsx
+++ b/web/components/manual/Overview.tsx
@@ -39,8 +39,8 @@ const GUIDE = [
   },
   {
     href: '/manual/themes',
-    label: 'Themes',
-    blurb: 'Pick the station-wide palette every listener sees, override it per show, or drop in your own.',
+    label: 'Skins & Themes',
+    blurb: 'Swap the player face between six built-in skins, pick the station-wide palette, or fork the reference player entirely.',
   },
   {
     href: '/manual/cli',

--- a/web/components/manual/Themes.tsx
+++ b/web/components/manual/Themes.tsx
@@ -18,34 +18,134 @@ const EXAMPLE_THEME = `{
   }
 }`;
 
+// The six faces the controller ships. Kept here so the copy below and the list
+// stay in lockstep with components/skins/index.ts.
+const SKINS = [
+  {
+    name: 'Classic',
+    blurb: 'The original SUB/WAVE face — masthead, centre stage, waveform, transport deck. The default.',
+  },
+  {
+    name: 'Spool',
+    blurb: 'A walkman deck — the whole station fits on one cassette, reels turning as it plays.',
+  },
+  {
+    name: 'Drift',
+    blurb: 'Ninety percent weather, ten percent type — the cover art blooms out to fill the room.',
+  },
+  {
+    name: 'Subamp',
+    blurb: "A compact modular player — deck, booth and log stacked like it's 1998, with a live spectrum analyzer.",
+  },
+  {
+    name: 'TTY',
+    blurb: 'The station as a live process — panes and a status line, everything tailing like a terminal.',
+  },
+  {
+    name: 'Platter',
+    blurb: 'The flagship vinyl face — a reference turntable is the interface, needle tracking and all.',
+  },
+];
+
 export default function Themes() {
   return (
     <ManualPage
       eyebrow="MANUAL · 09"
-      title="Themes."
-      intro="SUB/WAVE renders the player and the admin console through one shared palette. You pick the station's theme; everyone listening sees the same look. Built-ins ship with the controller, and you can drop your own JSONs in to extend the menu."
+      title="Skins & themes."
+      intro="The look of the player is two independent knobs. A skin is the whole face — the layout every listener sees. A theme is the palette that face is painted in. You set a station-wide default for each; a listener can override either in their own browser without changing what anyone else sees."
       current="/manual/themes"
     >
       <section className="bs-section">
-        <p className="bs-eyebrow">PICKING A THEME</p>
-        <h2>One picker, every surface.</h2>
+        <p className="bs-eyebrow">TWO LAYERS</p>
+        <h2>Skin is the face. Theme is the paint.</h2>
         <p>
-          The station's theme lives in admin → <Link href="/manual/admin" className="bs-link">Settings</Link> →{' '}
-          <strong>Theme</strong>. Each entry is a card with a four-swatch row (paper, ink,
-          accent, overlay) so you can read the palette without leaving Settings. Click a
-          card and the change applies immediately for you, then propagates to every open
-          player within about thirty seconds: no controller restart, no listener reload.
+          They compose. Any skin can wear any theme, and swapping one never
+          disturbs the other: recolour Classic to Cyberpunk and it&rsquo;s the
+          same masthead-and-deck layout in cyan and hot pink; switch Classic to
+          the Platter skin and the palette rides straight across to the
+          turntable. Every skin reads the same live station feed &mdash;
+          now-playing, the booth log, the schedule, requests &mdash; so none of
+          them lose a feature; they just present it differently.
         </p>
         <p>
-          Five palettes ship with the box:
+          Both are picked in admin &rarr;{' '}
+          <Link href="/manual/admin" className="bs-link">Settings</Link> &rarr;{' '}
+          <strong>Skin &amp; themes</strong>, and both propagate to every open
+          player within about thirty seconds: no controller restart, no listener
+          reload.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">THE SKINS</p>
+        <h2>Six faces ship in the box.</h2>
+        <p>
+          Each skin is a completely different full-screen layout built on the
+          same core. The station-wide pick is a contact sheet in admin
+          Settings &mdash; every skin gets a live pure-CSS miniature of its real
+          layout, so you can read the rack at a glance before committing. Click a
+          card marked <em>Set as station skin</em> and it goes on air for
+          everyone.
         </p>
         <ul className="bs-list">
-          <li><strong>Classic Light</strong> — newsprint cream with hot vermilion ink. The default.</li>
-          <li><strong>Classic Dark</strong> — deep charcoal newsprint with the same vermilion accent.</li>
-          <li><strong>Sunset</strong> — warm dusk: plum paper, peach ink, vermilion-magenta accent.</li>
-          <li><strong>Vinyl</strong> — sepia "warm record sleeve" with mustard accent.</li>
-          <li><strong>Cyberpunk</strong> — near-black paper, cyan ink, hot pink accent.</li>
+          {SKINS.map((s) => (
+            <li key={s.name}>
+              <strong>{s.name}</strong> &mdash; {s.blurb}
+            </li>
+          ))}
         </ul>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">SAME STATION, DIFFERENT ROOM</div>
+          <p>
+            Skins are presentation only. Every one honours the theme tokens,
+            renders the same tap-to-tune-in gate (browsers can&rsquo;t autoplay,
+            so the first tap is the audio-unblock gesture), and respects{' '}
+            <strong>lite mode</strong> for low-power screens. Whichever face you
+            choose, listeners hear the exact same broadcast in sync.
+          </p>
+        </div>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">LISTENER OVERRIDES</p>
+        <h2>Anyone can pick their own look.</h2>
+        <p>
+          The station default is just that &mdash; a default. Every player has an{' '}
+          <strong>Appearance</strong> menu (the palette icon in the header) that
+          lets a listener choose a different theme <em>and</em> a different skin
+          for their own browser. The choice is saved locally and beats the
+          station-wide pick until they clear it; a{' '}
+          <em>Use station default</em> / <em>Use station skin</em> row drops them
+          back to whatever the operator is running. The same menu carries the
+          per-browser lite-mode toggle.
+        </p>
+        <p className="text-muted">
+          The skin picker only appears when the build ships more than one skin
+          (it always does today). One listener&rsquo;s override never touches the
+          broadcast or anyone else&rsquo;s screen &mdash; it&rsquo;s purely how{' '}
+          <em>they</em> see the station.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">PICKING A THEME</p>
+        <h2>The palettes.</h2>
+        <p>
+          The theme is set in the same admin section, each entry a card with a
+          four-swatch row (paper, ink, accent, overlay) so you can read the
+          palette without leaving Settings. Five ship with the box:
+        </p>
+        <ul className="bs-list">
+          <li><strong>Classic Light</strong> &mdash; newsprint cream with hot vermilion ink. The default.</li>
+          <li><strong>Classic Dark</strong> &mdash; deep charcoal newsprint with the same vermilion accent.</li>
+          <li><strong>Sunset</strong> &mdash; warm dusk: plum paper, peach ink, vermilion-magenta accent.</li>
+          <li><strong>Vinyl</strong> &mdash; sepia &ldquo;warm record sleeve&rdquo; with mustard accent.</li>
+          <li><strong>Cyberpunk</strong> &mdash; near-black paper, cyan ink, hot pink accent.</li>
+        </ul>
+        <p className="text-muted">
+          The palette recolours both the player <em>and</em> the admin console,
+          so the whole install reads as one station.
+        </p>
       </section>
 
       <section className="bs-section">
@@ -53,7 +153,7 @@ export default function Themes() {
         <h2>A show can carry its own palette.</h2>
         <p>
           A scheduled show can opt into a different theme for its hour. Open a show in
-          admin → <strong>Shows</strong>, pick one from the <em>theme override</em>{' '}
+          admin &rarr; <strong>Shows</strong>, pick one from the <em>theme override</em>{' '}
           dropdown, and the player switches to that palette while the show is on air,
           then back to the station default when the next hour starts.
         </p>
@@ -77,8 +177,8 @@ export default function Themes() {
         </p>
         <CodeBlock>{EXAMPLE_THEME}</CodeBlock>
         <p>
-          After saving the file, hit <strong>Refresh themes</strong> in admin → Settings
-          → Theme. That re-scans the directory, and the new entry appears in the picker.
+          After saving the file, hit <strong>Refresh themes</strong> in admin &rarr; Settings
+          &rarr; Skin &amp; themes. That re-scans the directory, and the new entry appears in the picker.
           No mixer restart, no controller bounce.
         </p>
         <div className="bs-callout">
@@ -86,7 +186,7 @@ export default function Themes() {
             <strong>id and filename should match.</strong> A file named{' '}
             <code className="bs-code-inline">midnight.json</code> should declare{' '}
             <code className="bs-code-inline">"id": "midnight"</code>. The controller still
-            loads mismatches, but a logged warning is the only hint something's off.
+            loads mismatches, but a logged warning is the only hint something&rsquo;s off.
           </p>
         </div>
       </section>
@@ -96,17 +196,17 @@ export default function Themes() {
         <h2>Seven knobs, no surprises.</h2>
         <p>
           A theme writes a fixed set of CSS variables onto <code className="bs-code-inline">&lt;html&gt;</code>.
-          Any other key in your JSON is silently dropped, so a malformed theme can't
+          Any other key in your JSON is silently dropped, so a malformed theme can&rsquo;t
           inject styles or break out into other parts of the page.
         </p>
         <ul className="bs-list">
-          <li><code className="bs-code-inline">--bg</code> — page background ("paper").</li>
-          <li><code className="bs-code-inline">--ink</code> — main text colour.</li>
-          <li><code className="bs-code-inline">--muted</code> — secondary text, captions, dividers.</li>
-          <li><code className="bs-code-inline">--accent</code> — the station's accent (active states, on-air pill, focus rings).</li>
-          <li><code className="bs-code-inline">--overlay</code> — translucent wash used for hover and modal scrims.</li>
-          <li><code className="bs-code-inline">--soft-border</code> — the hairline between sections.</li>
-          <li><code className="bs-code-inline">--field</code> — input/textarea fill.</li>
+          <li><code className="bs-code-inline">--bg</code> &mdash; page background (&ldquo;paper&rdquo;).</li>
+          <li><code className="bs-code-inline">--ink</code> &mdash; main text colour.</li>
+          <li><code className="bs-code-inline">--muted</code> &mdash; secondary text, captions, dividers.</li>
+          <li><code className="bs-code-inline">--accent</code> &mdash; the station&rsquo;s accent (active states, on-air pill, focus rings).</li>
+          <li><code className="bs-code-inline">--overlay</code> &mdash; translucent wash used for hover and modal scrims.</li>
+          <li><code className="bs-code-inline">--soft-border</code> &mdash; the hairline between sections.</li>
+          <li><code className="bs-code-inline">--field</code> &mdash; input/textarea fill.</li>
         </ul>
         <p>
           Any CSS colour value works: hex, <code className="bs-code-inline">rgb()</code>,{' '}
@@ -114,7 +214,8 @@ export default function Themes() {
           <code className="bs-code-inline">color-mix()</code>. <code className="bs-code-inline">mode</code>{' '}
           tells the rest of the stylesheet whether to treat the theme as light or dark;
           it controls the paper-grain blend and the few shadcn rules that still key off{' '}
-          <code className="bs-code-inline">data-theme</code>.
+          <code className="bs-code-inline">data-theme</code>. Because skins consume these
+          same seven tokens, a custom theme retints every skin at once.
         </p>
       </section>
 
@@ -122,19 +223,81 @@ export default function Themes() {
         <p className="bs-eyebrow">UNDER THE HOOD</p>
         <h2>How the player applies it.</h2>
         <p>
-          On every page load, a tiny pre-paint script reads the last-applied theme from
-          the browser's localStorage and writes the seven variables onto{' '}
-          <code className="bs-code-inline">&lt;html&gt;</code> before the first frame, so
-          listeners never see the default palette flash before yours arrives. The
-          controller serves the live registry at{' '}
-          <code className="bs-code-inline">/api/themes</code>; an app-wide bootstrapper
-          polls it every thirty seconds and re-applies whenever the active id changes.
+          On every page load, a tiny pre-paint script reads the last-applied theme and
+          skin from the browser&rsquo;s localStorage and stamps them before the first
+          frame, so listeners never see the default palette or the wrong face flash
+          before yours arrives. The controller serves the live theme registry at{' '}
+          <code className="bs-code-inline">/api/themes</code> and the active skin id on{' '}
+          <code className="bs-code-inline">/state</code>; an app-wide bootstrapper
+          polls every thirty seconds and re-applies whenever either changes.
         </p>
         <p>
-          The "active id" is the per-show override if one is set and resolves, otherwise
-          the station default. Built-in ids are reserved. A user JSON that claims{' '}
-          <code className="bs-code-inline">classic-light</code> is logged and skipped.
+          The &ldquo;active&rdquo; theme is the per-show override if one is set and
+          resolves, otherwise the station default; the active skin is the listener&rsquo;s
+          override if set, otherwise the station default. Built-in ids are reserved &mdash;
+          a user theme JSON that claims <code className="bs-code-inline">classic-light</code>{' '}
+          is logged and skipped &mdash; and an unknown or removed skin id always falls back
+          to Classic so the player never renders blank.
         </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">BEYOND SKINS</p>
+        <h2>Fork the reference player.</h2>
+        <p>
+          Skins reskin the built-in player in place. When you want to go further
+          &mdash; a wholly different app, your own framework, your own everything
+          &mdash; there&rsquo;s the{' '}
+          <a
+            href="https://github.com/getsubwave/web-player"
+            className="bs-link"
+            target="_blank"
+            rel="noreferrer"
+          >
+            SUB/WAVE Web Player ↗
+          </a>
+          : a lean, forkable <strong>reference player</strong> in a separate
+          repo, built with React + Vite + TypeScript + Tailwind. It ships pointed
+          at the live public station, so it plays real radio the moment you run{' '}
+          <code className="bs-code-inline">npm run dev</code> &mdash; no config
+          needed.
+        </p>
+        <p>
+          It&rsquo;s built to be cloned and redesigned. The data layer (a single
+          station API client plus a handful of hooks) is cleanly separated from
+          the presentation (the components), so you keep the plumbing &mdash;
+          now-playing, the booth feed, up-next, requests, the schedule,
+          lock-screen controls &mdash; and rebuild the look however you like.
+          Point it at your own install with one environment variable:
+        </p>
+        <CodeBlock>{`VITE_STATION_URL=https://radio.example.com`}</CodeBlock>
+        <p>
+          From that one origin it derives <code className="bs-code-inline">/api</code>{' '}
+          (the controller) and <code className="bs-code-inline">/stream.mp3</code>{' '}
+          (the audio); it works cross-origin out of the box. Build it to a static{' '}
+          <code className="bs-code-inline">dist/</code> and deploy to any host &mdash;
+          Vercel, Netlify, Cloudflare, or a Docker image &mdash; in one click.
+        </p>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">DESCRIBE IT, DON&rsquo;T CODE IT</div>
+          <p>
+            The repo ships an <code className="bs-code-inline">AGENTS.md</code> and
+            a built-in redesign skill, so a coding agent (Claude Code, Cursor)
+            already understands how the player is wired. Tell it the vibe &mdash;
+            &ldquo;warm 70s vinyl, cream and burnt orange, a serif logo&rdquo; or
+            &ldquo;minimal monospace brutalist&rdquo; &mdash; and it restyles the
+            player while keeping the audio and live data working. Full guide at{' '}
+            <a
+              href="https://getsubwave.github.io/web-player/"
+              className="bs-link"
+              target="_blank"
+              rel="noreferrer"
+            >
+              getsubwave.github.io/web-player ↗
+            </a>
+            .
+          </p>
+        </div>
       </section>
     </ManualPage>
   );

--- a/web/components/manual/pages.ts
+++ b/web/components/manual/pages.ts
@@ -16,7 +16,7 @@ export const MANUAL_PAGES: ManualPageEntry[] = [
   { href: '/manual/skills', label: 'Custom Skills' },
   { href: '/manual/admin', label: 'Admin & Settings' },
   { href: '/manual/observatory', label: 'Library Observatory' },
-  { href: '/manual/themes', label: 'Themes' },
+  { href: '/manual/themes', label: 'Skins & Themes' },
   { href: '/manual/cli', label: 'The Operator CLI' },
   { href: '/manual/llm', label: 'Models & Tokens' },
   { href: '/manual/voices', label: 'Voices & TTS' },

--- a/web/components/skins/platter/Platter.module.css
+++ b/web/components/skins/platter/Platter.module.css
@@ -54,12 +54,13 @@
 }
 
 /* Tonearm — an SVG overlay drawn at its tracking (needle-down) position, then
-   rotated as a whole around the pivot (84% 15% of the square deck) so the
-   headshell always stays welded to the tube end and the stylus stays on the
-   groove. A one-shot transition (not a loop) swings it up off the record when
-   the listener tunes out; the parked angle holds even under html.lite. */
+   rotated as a whole around the rear-right pivot (86% 19% of the square deck)
+   so the headshell always stays welded to the tube end and the stylus stays on
+   the groove. A one-shot transition (not a loop) swings it up and out off the
+   record when the listener tunes out; the parked angle holds even under
+   html.lite. Origin MUST match the pivot circle in PlatterSkin.tsx. */
 .arm {
-  transform-origin: 84% 15%;
+  transform-origin: 86% 19%;
   transition: transform 1.1s cubic-bezier(0.22, 1, 0.36, 1);
 }
 .armRest { transform: rotate(-16deg); }

--- a/web/components/skins/platter/PlatterSkin.tsx
+++ b/web/components/skins/platter/PlatterSkin.tsx
@@ -103,7 +103,10 @@ function Deck({
 
       {/* tonearm — one SVG in the deck's own coordinate space, so the headshell
           stays welded to the tube end and the stylus lands on the groove. The
-          whole arm swings up off the record when tuned out (see .arm). */}
+          pivot sits rear-right (86% 19%) like a real deck; the arm reaches down
+          onto the RIGHT-hand grooves (never crossing the label) so the record's
+          clockwise spin draws the stylus along the groove instead of shoving it.
+          The whole arm swings up off the record when tuned out (see .arm). */}
       <svg
         viewBox="0 0 100 100"
         className={cn(
@@ -114,17 +117,17 @@ function Deck({
         aria-hidden="true"
       >
         {/* arm tube — dark outline under a light-metal core */}
-        <line x1="84" y1="15" x2="30" y2="33" strokeWidth={2.3} strokeLinecap="round" className="stroke-ink" />
-        <line x1="84" y1="15" x2="30" y2="33" strokeWidth={1.1} strokeLinecap="round" className="stroke-[#e6e0d2]" />
+        <line x1="86" y1="19" x2="72.8" y2="58.5" strokeWidth={2.3} strokeLinecap="round" className="stroke-ink" />
+        <line x1="86" y1="19" x2="72.8" y2="58.5" strokeWidth={1.1} strokeLinecap="round" className="stroke-[#e6e0d2]" />
         {/* counterweight past the pivot */}
-        <rect x="85.5" y="11" width="9" height="5" rx="1" strokeWidth={0.6} className="fill-[#22201d] stroke-ink" />
+        <rect x="83.1" y="11.8" width="9" height="5" rx="1" strokeWidth={0.6} transform="rotate(108.4 87.6 14.3)" className="fill-[#22201d] stroke-ink" />
         {/* pivot mount */}
-        <circle cx="84" cy="15" r="3.6" strokeWidth={0.8} className="fill-[#d9d2c4] stroke-ink" />
-        <circle cx="84" cy="15" r="1.2" className="fill-ink" />
+        <circle cx="86" cy="19" r="3.6" strokeWidth={0.8} className="fill-[#d9d2c4] stroke-ink" />
+        <circle cx="86" cy="19" r="1.2" className="fill-ink" />
         {/* headshell + cartridge at the tip */}
-        <rect x="26" y="30" width="8" height="5.4" rx="0.8" strokeWidth={0.6} transform="rotate(18 30 32.7)" className="fill-[#22201d] stroke-ink" />
+        <rect x="67.3" y="60.5" width="8" height="5.4" rx="0.8" strokeWidth={0.6} transform="rotate(130.4 71.3 63.2)" className="fill-[#22201d] stroke-ink" />
         {/* stylus dropped onto the groove */}
-        <line x1="28.6" y1="35" x2="27.6" y2="37.8" strokeWidth={1.1} strokeLinecap="round" className="stroke-[var(--accent)]" />
+        <line x1="70" y1="67" x2="69.4" y2="69.7" strokeWidth={1.1} strokeLinecap="round" className="stroke-[var(--accent)]" />
       </svg>
     </div>
   );
@@ -238,7 +241,7 @@ export default function PlatterSkin(_props: SkinProps) {
                 aria-label={tunedIn ? 'Tune out' : 'Tune in'}
                 className={cn(
                   'v3-focus flex size-20 cursor-pointer flex-col items-center justify-center gap-0.5 rounded-full border border-ink',
-                  tunedIn ? 'bg-[var(--accent)] text-bg' : 'bg-bg text-ink hover:bg-[var(--overlay)]',
+                  tunedIn ? 'bg-[var(--accent)] text-bg' : 'bg-bg text-ink hover:bg-[var(--field)]',
                 )}
               >
                 <span className="text-[30px] leading-none">{tunedIn ? '■' : '▶'}</span>
@@ -251,7 +254,7 @@ export default function PlatterSkin(_props: SkinProps) {
                 aria-label={muted ? 'Unmute' : 'Mute'}
                 className={cn(
                   'v3-focus grid size-14 cursor-pointer place-items-center rounded-full border border-ink font-mono text-[9px] font-bold tracking-[0.1em]',
-                  muted ? 'bg-ink text-bg' : 'bg-bg hover:bg-[var(--overlay)]',
+                  muted ? 'bg-ink text-bg' : 'bg-bg hover:bg-[var(--field)]',
                 )}
               >
                 {muted ? 'MUTED' : 'MUTE'}

--- a/web/components/skins/spool/Spool.module.css
+++ b/web/components/skins/spool/Spool.module.css
@@ -52,3 +52,18 @@
 /* Dynamic fills — progress + volume, driven by --pf / --vf on the skin root. */
 .progFill { width: calc(var(--pf, 0) * 100%); }
 .volFill { width: calc(var(--vf, 0) * 100%); }
+
+/* Cassette hero fit-to-box. The cassette holds its 512/320 ratio but must scale
+   to the SMALLER of the deck's width and height — short viewports (iPad Mini
+   landscape ≈ 1024×768) are height-bound, and a width-only rule (w-full/max-w)
+   let the aspect-locked box overflow the deck vertically. The hero is a size
+   container (its w/h are grid/flex-driven, independent of contents — safe for
+   `size`); cqw/cqh are its padded content box. */
+.hero { container-type: size; }
+.cassette {
+  /* Fallback for engines without container-query units: prior width behaviour. */
+  width: 100%;
+  max-width: 512px;
+  /* width that keeps height (= w·320/512) within the container: w ≤ cqh·512/320. */
+  width: min(100cqw, 512px, calc(100cqh * 512 / 320));
+}

--- a/web/components/skins/spool/SpoolSkin.tsx
+++ b/web/components/skins/spool/SpoolSkin.tsx
@@ -359,8 +359,8 @@ export default function SpoolSkin(_props: SkinProps) {
               </div>
 
               {/* cassette hero */}
-              <div className="flex min-h-0 flex-1 items-center justify-center p-5">
-                <div className="relative flex aspect-[512/320] w-full max-w-[512px] flex-col border border-ink bg-bg shadow-[inset_0_0_0_8px_var(--field),inset_0_0_40px_rgba(0,0,0,0.06)]">
+              <div className={cn(styles.hero, 'flex min-h-0 flex-1 items-center justify-center p-5')}>
+                <div className={cn(styles.cassette, 'relative flex aspect-[512/320] flex-col border border-ink bg-bg shadow-[inset_0_0_0_8px_var(--field),inset_0_0_40px_rgba(0,0,0,0.06)]')}>
                   <span className="absolute top-4 left-4 size-[7px] rounded-full border border-muted" aria-hidden="true" />
                   <span className="absolute top-4 right-4 size-[7px] rounded-full border border-muted" aria-hidden="true" />
                   <span className="absolute bottom-4 left-4 size-[7px] rounded-full border border-muted" aria-hidden="true" />

--- a/web/content/news/2026-07-14-a-turntable-for-your-player.md
+++ b/web/content/news/2026-07-14-a-turntable-for-your-player.md
@@ -1,0 +1,25 @@
+---
+title: A turntable for your player
+date: 2026-07-14
+category: Feature
+author: The SUB/WAVE desk
+excerpt: Platter is the sixth player skin, a working turntable where the record spins as a track plays and the tonearm tracks the groove. Set it station-wide or pick it just for yourself.
+---
+
+The player shipped five skins last time. Here is a sixth, and it is the one we kept wanting to build. Platter, a reference turntable that becomes the whole interface. A record on the platter, a tonearm over it, the label spinning while the station plays.
+
+## What's new
+
+Platter is a full-screen skin like the others, drawn on the same live stream. Nothing changes underneath. The record turns while a track is on air, the tonearm sits over the groove, the label carries the cover art, and the track detail reads off to the side like a sleeve note.
+
+It joins Classic, Spool, Drift, Subamp and TTY. Six faces now, one station.
+
+## How to use it
+
+Set it as the station default in admin. Open Settings, then Skin & Themes, and pick Platter under Player skin. It applies on the next poll, no restart.
+
+Listeners can choose it just for themselves. In the player, tap the Appearance icon (the palette near the top of the header) and pick Platter under Player skin. That choice stays in their browser and beats the station default until they hit Use station skin.
+
+## Why it helps
+
+Ask someone to picture radio as an object and most of them land on a turntable. Platter leans all the way into that. Put it on a screen in the room and the station stops looking like a web page and starts looking like a deck someone is spinning. The audio is the same broadcast everyone else hears, the face just makes it feel like a record.


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge with "Create a merge commit"** — not "Squash and merge". Squash collapses the individual `feat:` / `fix:` / `chore:` commits into one `release: …` commit, and release-please then sees no conventional-commit signal and skips the version bump. See [Step 7](#step-7--how-to-merge-this-pr) for the why.

## Summary

Ships what's queued on `develop`: a new `subwave sync` CLI command that reconciles stale bundled compose files and clears wizard/uninstall drift, a batch of web player skin polish (Platter tonearm + hover, Spool cassette sizing on short viewports, Playlist-only strict-hint label), an LLM provider fix so Gemma models no longer receive an unsupported thinking-budget param, and a rewritten Skins & Themes manual page. Web + CLI heavy, with one controller-side LLM capabilities tweak. No migrations, no env-var changes, no breaking changes.

**Bug Fixes**
- `76630089` fix(cli): sync stale compose files + clear wizard/uninstall drift (#1043) (#1047)
  - Adds the `subwave sync` command (`compose-sync.ts`) plus doctor/menu/update wiring to detect and reconcile drifted compose/.env state without clobbering operator config.
- `8346a7a7` fix(llm): don't send a thinking budget to Gemma models (#1044) (#1045)
- `9dd55f14` fix(web): Platter — tonearm on right grooves + START button hover (#1046)
- `421deab0` fix(web): add missing On: label to Playlist-only (strict) hint (#1050)
- `e5d1aebc` fix(web): spool cassette scales to fit on short viewports (#iPad Mini) (#1053)

**Documentation**
- `69eae2a4` docs(web): manual/themes → Skins & Themes (6 skins + reference player) (#1051)

**Other**
- `3a64e685` Update showreel link in README.md (#1049)

## Test plan
- [x] `subwave sync` reconciles stale compose files and wizard/uninstall drift without overwriting the operator's `.env` / Navidrome creds
- [x] A Gemma model configured as the LLM provider makes DJ calls without erroring on the thinking-budget param
- [x] Platter skin: tonearm sits on the right-side grooves and the START button hover state works
- [x] Spool skin cassette fits without horizontal overflow on a short viewport (iPad Mini)
- [x] The Playlist-only (strict) hint now shows the "On:" label
- [x] Manual → Skins & Themes lists all 6 skins plus the reference player
