### PR TITLE
fix(broadcast): update track metadata on Ogg FLAC/Opus streams (#1052)

### DIFF
--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -1490,6 +1490,15 @@ def make_stream_outputs() =
         opus_enc,
         id="stream_opus",
         fallible=true,
+        # Force ICY metadata ON. output.icecast leaves send_icy_metadata null by
+        # default, which GUESSES it off for any Ogg-container format and relies on
+        # in-band Ogg header re-emission (a new chained logical stream per track)
+        # instead. Many radio clients — Ferrosonic, Google Cast receivers, Symfonium
+        # — read the Ogg Vorbis comment only once at connect and never re-parse on a
+        # chained boundary, so they freeze on the first track's title (issue #1052).
+        # Icecast relays ICY StreamTitle out-of-band for Ogg mounts too, so enabling
+        # it gives those clients the same reliable per-track updates MP3/AAC get.
+        send_icy_metadata=true,
         host=environment.get(default="icecast", "ICECAST_HOST"),
         port=7702,
         password=environment.get("ICECAST_SOURCE_PASSWORD"),
@@ -1522,6 +1531,10 @@ def make_stream_outputs() =
         ),
         id="stream_flac",
         fallible=true,
+        # Force ICY metadata ON — see the /stream.opus note above. Ogg-FLAC clients
+        # (Ferrosonic and other internet-radio players) otherwise stay stuck on the
+        # connect-time track because they ignore in-band chained-Ogg metadata (#1052).
+        send_icy_metadata=true,
         host=environment.get(default="icecast", "ICECAST_HOST"),
         port=7702,
         password=environment.get("ICECAST_SOURCE_PASSWORD"),


### PR DESCRIPTION
Fixes #1052

## Problem

On the Ogg-container mounts (`/stream.flac`, `/stream.opus`), the track title/artist froze on whatever was playing when the client connected — subsequent tracks never updated until a manual reconnect. The MP3/AAC mounts were unaffected. Reported against Ferrosonic (Ogg FLAC) and Google Cast.

## Root cause

The station injects per-track metadata onto the shared `radio` bus (`on_meta` → `radio.insert_metadata(...)`), which reaches every encoder. But delivery to the client depends on the container:

- **MP3 / AAC** — `output.icecast` guesses `send_icy_metadata` **on**, so Icecast relays ICY `StreamTitle` out-of-band; clients poll it continuously → updates every track. ✅
- **Ogg FLAC / Ogg Opus** — `send_icy_metadata` was left unset, and Liquidsoap guesses it **off** for Ogg containers. The only remaining path is in-band: Liquidsoap re-emits Ogg headers as a new chained logical stream per track. Ferrosonic, Google Cast receivers, and Symfonium read the Ogg Vorbis comment only once at connect and never re-parse on a chained boundary, so they stay stuck on the first track. ❌

`send_last_metadata_on_connect` (default true) is why the connect-time track shows correctly.

## Fix

Force `send_icy_metadata=true` on both Ogg `output.icecast` blocks so Icecast relays ICY `StreamTitle` out-of-band for those mounts too — the same reliable per-track path the MP3/AAC mounts already use.

## Notes / limitations

- ICY carries a **title string only**, not album art. Cast title will update; cover art won't refresh from the stream (ICY protocol limitation — separate, sender-side concern).
- Liquidsoap change → needs a broadcast rebuild (`docker compose up -d --build broadcast`), not just a restart.

## Testing

`liquidsoap --check` passes on 2.4.5 (in the running broadcast container). Note: the param is `send_icy_metadata` (bool) in 2.4.5 — `icy_metadata` is now the list of keys to send, not the on/off toggle.