### PR TITLE
feat(analysis): on-pick "a la carte" track analysis (discussion #1032)

### DIFF
--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -11,6 +11,7 @@ import * as subsonic from '../music/subsonic.js';
 import * as mix from '../music/mix.js';
 import * as library from '../music/library.js';
 import * as blocklist from '../music/blocklist.js';
+import { analyzeOnPick, analyzeOnPickEnabled } from '../music/analyze.js';
 import { speak, voiceGainDb } from '../audio/tts.js';
 import * as djAgent from './dj-agent.js';
 import * as programme from './programme.js';
@@ -956,6 +957,27 @@ class Queue {
         // while we were awaiting the TTS render above — don't hand a removed
         // track to Liquidsoap.
         if (!this.upcoming.includes(item)) continue;
+
+        // On-pick "a la carte" analysis (discussion #1032): when enabled and
+        // this track still needs analysis, analyse it NOW — before the mix
+        // transition below reads the library record — so this very hand-off
+        // gets the fresh bpm/key/outro/vocal/loudness data. Bounded by the
+        // deadline inside analyzeOnPick: past it the item drains with whatever
+        // data exists (today's behaviour) and the analysis keeps running in
+        // the background, caching its result for the next spin. Awaiting here
+        // matches the TTS render above — the drain loop is the queue's one
+        // slow-work seam, a full track away from when this item airs.
+        if (analyzeOnPickEnabled() && item.track?.id) {
+          const got = await analyzeOnPick(item.track.id);
+          if (got === 'analyzed') {
+            this.log('mix', `on-pick analysis cached → ${item.track.title}`);
+          } else if (got === 'pending') {
+            this.log('mix', `on-pick analysis still running — ${item.track.title} airs with existing data; result caches for next time`);
+          }
+          // Same guard as after the TTS await: an operator cancel may have
+          // spliced this item out while we were analysing.
+          if (!this.upcoming.includes(item)) continue;
+        }
 
         // DJ-mode mixing (features 1 & 2): shape the transition INTO this track
         // from its tempo/harmonic compatibility with the track it follows. The

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -964,19 +964,46 @@ class Queue {
         // gets the fresh bpm/key/outro/vocal/loudness data. Bounded by the
         // deadline inside analyzeOnPick: past it the item drains with whatever
         // data exists (today's behaviour) and the analysis keeps running in
-        // the background, caching its result for the next spin. Awaiting here
-        // matches the TTS render above — the drain loop is the queue's one
-        // slow-work seam, a full track away from when this item airs.
+        // the background, caching its result for the next spin.
+        //
+        // Awaited ONLY when this is the sole pending hand-off. The drain loop
+        // holds the senderBusy mutex — the single path every hand-off takes,
+        // listener requests included — so blocking here with more items
+        // waiting would serialize them all behind one track's analysis
+        // (N×deadline in the worst case) and could leave dj_queue empty past
+        // the current track's end. With others waiting, the analysis is
+        // kicked off in the background instead: this item drains with
+        // existing data and the result caches for its next spin.
         if (analyzeOnPickEnabled() && item.track?.id) {
-          const got = await analyzeOnPick(item.track.id);
-          if (got === 'analyzed') {
-            this.log('mix', `on-pick analysis cached → ${item.track.title}`);
-          } else if (got === 'pending') {
-            this.log('mix', `on-pick analysis still running — ${item.track.title} airs with existing data; result caches for next time`);
+          const othersWaiting = this.upcoming.some(i => i !== item && !i.sent);
+          if (othersWaiting) {
+            const title = item.track.title;
+            analyzeOnPick(item.track.id)
+              .then((got) => {
+                // 'current'/'skipped' mean nothing ran — stay quiet in the
+                // steady state; only an actual analysis earns a log line.
+                if (got !== 'current' && got !== 'skipped') {
+                  this.log('mix', `on-pick analysis backgrounded (more hand-offs waiting) — ${title} aired with existing data; result caches for next spin`);
+                }
+              })
+              .catch(() => {});
+          } else {
+            try {
+              const got = await analyzeOnPick(item.track.id);
+              if (got === 'analyzed') {
+                this.log('mix', `on-pick analysis cached → ${item.track.title}`);
+              } else if (got === 'pending') {
+                this.log('mix', `on-pick analysis still running — ${item.track.title} airs with existing data; result caches for next time`);
+              }
+            } catch (err) {
+              // Same containment as the TTS await above: a transient library-db
+              // throw must not reject the fire-and-forget drain promise.
+              this.log('error', `On-pick analysis failed: ${(err as Error).message}`);
+            }
+            // Same guard as after the TTS await: an operator cancel may have
+            // spliced this item out while we were analysing.
+            if (!this.upcoming.includes(item)) continue;
           }
-          // Same guard as after the TTS await: an operator cancel may have
-          // spliced this item out while we were analysing.
-          if (!this.upcoming.includes(item)) continue;
         }
 
         // DJ-mode mixing (features 1 & 2): shape the transition INTO this track

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -16,6 +16,7 @@ import * as settings from '../settings.js';
 import { config } from '../config.js';
 import { runAudioMoodPass } from './audio-moods.js';
 import { reportProgress, makeEventLogger } from './tagger-progress.js';
+import { readPidfile, isPidAlive } from './tagger-lock.js';
 
 // Structured status events for the panel, mirrored to the terse `[analyze] …`
 // console line. Shared by the tagger's analyze phase and the standalone CLI.
@@ -107,6 +108,54 @@ async function scoreAudioMoods(): Promise<void> {
   } catch (err: any) {
     console.error(`[audio-moods] pass failed (non-fatal): ${err?.message || err}`);
   }
+}
+
+// Analyse one track and persist everything the backend returned: bpm/key/etc
+// via upsertTrackAnalysis, plus the CLAP audio vector (stamping the provenance
+// row once per process) when the backend carried one. Shared by the bulk-pass
+// loop and the on-pick path so the store logic lives in exactly one place.
+let audioMetaStamped = false;
+async function analyzeAndStore(
+  id: string,
+  opts: { embed?: boolean; vocal?: boolean; localPath?: string | null; localComplete?: boolean },
+): Promise<{ audioStored: boolean; vocalStored: boolean }> {
+  const { embed, vocal, localPath, localComplete } = opts;
+  const a = localPath
+    ? await analyzer.analyzePath(localPath, { embed, vocal, complete: localComplete })
+    : await analyzer.analyze(id, { embed, vocal });
+  db.upsertTrackAnalysis(id, {
+    bpm: a.bpm,
+    musicalKey: a.musicalKey,
+    introMs: a.introMs,
+    confidence: a.confidence,
+    loudnessLufs: a.loudnessLufs,
+    peakDb: a.peakDb,
+    sections: a.sections,
+    pace: a.paceCurve,
+    beats: a.beats,
+    bars: a.bars,
+    keyRanges: a.keyRanges,
+    vocalRanges: a.vocalRanges,
+    outro: a.outro,
+  });
+  // Opportunistically store the CLAP audio vector whenever the backend carried
+  // one. Independent of the bpm/key write above: a track analysed before CLAP
+  // was enabled simply gets its vector on a later pass. The first vector
+  // written this process stamps the audio-embedding provenance row.
+  let audioStored = false;
+  if (a.audioEmbedding && a.audioEmbedding.length === db.AUDIO_EMBEDDING_DIM) {
+    try {
+      db.upsertTrackAudioVector(id, a.audioEmbedding);
+      if (!audioMetaStamped) {
+        db.setAudioEmbeddingMeta(AUDIO_MODEL_LABEL, db.AUDIO_EMBEDDING_DIM);
+        audioMetaStamped = true;
+      }
+      audioStored = true;
+    } catch (err: any) {
+      console.error(`[analyze] ${id} audio-vector write failed: ${err?.message || err}`);
+    }
+  }
+  return { audioStored, vocalStored: a.vocalRanges != null };
 }
 
 export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<AnalyzeStats> {
@@ -216,10 +265,6 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
   let failed = 0;
   let audioEmbedded = 0;
   let vocalAnalyzed = 0;
-  // Stamp the audio-embedding provenance row once, on the first vector written
-  // this run. Cheap idempotent guard so we don't touch the meta table per track.
-  let audioMetaStamped = false;
-  const audioModelLabel = AUDIO_MODEL_LABEL;
 
   // One-ahead prefetch pipeline: the controller downloads track i+1's audio
   // (network) while the backend computes track i (CPU), so the two overlap.
@@ -269,42 +314,14 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
       // vocal:true forces the Demucs pass for this track (admin/backfill path),
       // mirroring embed; omitted when vocal activity is off.
       const vocal = vocalBackfill ? true : undefined;
-      const a = localPath
-        ? await analyzer.analyzePath(localPath, { embed, vocal, complete: localComplete })
-        : await analyzer.analyze(id, { embed, vocal });
-      db.upsertTrackAnalysis(id, {
-        bpm: a.bpm,
-        musicalKey: a.musicalKey,
-        introMs: a.introMs,
-        confidence: a.confidence,
-        loudnessLufs: a.loudnessLufs,
-        peakDb: a.peakDb,
-        sections: a.sections,
-        pace: a.paceCurve,
-        beats: a.beats,
-        bars: a.bars,
-        keyRanges: a.keyRanges,
-        vocalRanges: a.vocalRanges,
-        outro: a.outro,
+      const { audioStored, vocalStored } = await analyzeAndStore(id, {
+        embed,
+        vocal,
+        localPath,
+        localComplete,
       });
-      if (a.vocalRanges != null) vocalAnalyzed += 1;
-      // Opportunistically store the CLAP audio vector whenever the backend
-      // carried one. Independent of the bpm/key write above: a track analysed
-      // before CLAP was enabled simply gets its vector on the next pass once
-      // unanalysedAudioIds re-targets it. The first vector written stamps the
-      // audio-embedding provenance row.
-      if (a.audioEmbedding && a.audioEmbedding.length === db.AUDIO_EMBEDDING_DIM) {
-        try {
-          db.upsertTrackAudioVector(id, a.audioEmbedding);
-          if (!audioMetaStamped) {
-            db.setAudioEmbeddingMeta(audioModelLabel, db.AUDIO_EMBEDDING_DIM);
-            audioMetaStamped = true;
-          }
-          audioEmbedded += 1;
-        } catch (err: any) {
-          console.error(`[analyze] ${id} audio-vector write failed: ${err?.message || err}`);
-        }
-      }
+      if (vocalStored) vocalAnalyzed += 1;
+      if (audioStored) audioEmbedded += 1;
       analyzed += 1;
     } catch (err: any) {
       failed += 1;
@@ -355,4 +372,117 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
       (failed > 0 ? ` · ${failed.toLocaleString('en-GB')} failed` : ''),
   );
   return { available: true, backend, analyzed, failed, scope: ids.length, audioEmbedded, vocalAnalyzed };
+}
+
+// ---------------------------------------------------------------------------
+// On-pick ("a la carte") analysis — discussion #1032. When the DJ picks a
+// track that still needs analysis, analyse just that one right before the
+// queue hands it to Liquidsoap, so the upcoming transition (ending-aware
+// crossfade, loudness gain, vocal-aware talk timing) already sees the fresh
+// data — and the library backfills organically with what actually airs.
+//
+// Gated on settings.audio.analyzeOnPick (default off). The queue awaits this
+// with a deadline: past ON_PICK_TIMEOUT_MS the hand-off proceeds with whatever
+// data exists (exactly today's behaviour) while the analysis keeps running in
+// the background and still caches its result for the next spin.
+
+export const ON_PICK_TIMEOUT_MS = 60_000;
+
+export function analyzeOnPickEnabled(): boolean {
+  try {
+    return settings.get()?.audio?.analyzeOnPick === true;
+  } catch {
+    return false;
+  }
+}
+
+export type OnPickOutcome =
+  | 'current'   // nothing missing — no analysis needed
+  | 'analyzed'  // fresh analysis stored within the deadline
+  | 'pending'   // still running past the deadline; caches when it finishes
+  | 'skipped'   // not in library.db / bulk run owns the backend / no backend
+  | 'failed';
+
+// Single-flight per id: a request and a pick racing to the same song share one
+// analysis instead of hitting the backend twice.
+const onPickInflight = new Map<string, Promise<boolean>>();
+
+export async function analyzeOnPick(
+  id: string | null | undefined,
+  opts: { timeoutMs?: number } = {},
+): Promise<OnPickOutcome> {
+  if (!id || !db.isOpen()) return 'skipped';
+  // upsertTrackAnalysis is an UPDATE on an existing row — a track the library
+  // sync hasn't ingested yet has nowhere to store results, so skip it.
+  const rec = db.getTrack(id);
+  if (!rec) return 'skipped';
+
+  // Per-track twin of the bulk pass's scoping: base analysis when the version
+  // is missing/stale, plus each opt-in dimension only when it's wanted
+  // (env/admin toggle) AND the backend can actually produce it.
+  const needsBase = rec.analysisVersion == null || rec.analysisVersion < db.ANALYSIS_VERSION;
+  const embed = audioBackfillDefault() && analyzer.audioEmbeddingAvailable() !== false;
+  const vocal = vocalBackfillDefault() && analyzer.vocalActivityAvailable() !== false;
+  const needsAudio = embed && !db.hasAudioVector(id);
+  const needsVocal = vocal && rec.vocalRanges == null;
+  if (!needsBase && !needsAudio && !needsVocal) return 'current';
+
+  // A running bulk tagger/analyzer owns the backend (and will reach this track
+  // anyway) — don't double-hit it from the queue path.
+  const bulk = readPidfile();
+  if (bulk && isPidAlive(bulk.pid)) return 'skipped';
+  if (!(await analyzer.isAvailable())) return 'skipped';
+
+  let job = onPickInflight.get(id);
+  if (!job) {
+    job = analyzeOnPickJob(id, {
+      embed: embed ? true : undefined,
+      vocal: vocal ? true : undefined,
+    }).finally(() => {
+      onPickInflight.delete(id);
+    });
+    onPickInflight.set(id, job);
+  }
+
+  const timeoutMs = opts.timeoutMs ?? ON_PICK_TIMEOUT_MS;
+  const deadline = new Promise<'pending'>((resolve) => {
+    const t = setTimeout(() => resolve('pending'), timeoutMs);
+    t.unref?.();
+  });
+  return Promise.race([job.then((ok): OnPickOutcome => (ok ? 'analyzed' : 'failed')), deadline]);
+}
+
+// The actual work: download (byte-capped, so a skipped outro rides the same
+// completeness flag as the bulk pass), analyse, store — mirroring one
+// iteration of runAnalysisPass's loop, minus the prefetch pipeline.
+async function analyzeOnPickJob(
+  id: string,
+  flags: { embed?: boolean; vocal?: boolean },
+): Promise<boolean> {
+  let localPath: string | null = null;
+  let localComplete: boolean | undefined;
+  try {
+    try {
+      const dl = await analyzer.downloadCapped(id);
+      localPath = dl.path;
+      localComplete = dl.complete;
+    } catch (err: any) {
+      // A non-audio response (stale library entry — file missing on disk) is
+      // not retryable via the url path; surface the real reason.
+      if (err instanceof analyzer.NonAudioResponseError) throw err;
+      console.error(`[analyze] on-pick ${id} prefetch failed (${err?.message || err}); using url path`);
+    }
+    const { audioStored } = await analyzeAndStore(id, { ...flags, localPath, localComplete });
+    // Zero-shot audio moods for the vector this analysis just wrote (plus any
+    // unscored stragglers) — best-effort, never blocks the caller.
+    if (audioStored) void scoreAudioMoods();
+    console.log(`[analyze] on-pick analysed ${id}`);
+    return true;
+  } catch (err: any) {
+    // Leave the row NULL so a later pass retries it; don't stamp a version.
+    console.error(`[analyze] on-pick ${id} failed: ${err?.message || err}`);
+    return false;
+  } finally {
+    if (localPath) await rm(localPath, { force: true }).catch(() => {});
+  }
 }

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -102,12 +102,25 @@ const AUDIO_MODEL_LABEL = process.env.CLAP_MODEL || 'laion-clap';
 
 // Best-effort wrapper — a mood-scoring failure must never fail (or re-run) the
 // analysis pass itself; the next pass simply retries the un-scored remainder.
-async function scoreAudioMoods(): Promise<void> {
-  try {
-    await runAudioMoodPass();
-  } catch (err: any) {
-    console.error(`[audio-moods] pass failed (non-fatal): ${err?.message || err}`);
-  }
+// Single-flight: the on-pick path fires this after every vector-storing
+// analysis, and runAudioMoodPass has no concurrency guard of its own — two
+// overlapping passes would each pay the CLAP text-tower round-trip and write
+// identical scores. A caller that joins a running pass may miss the vector
+// written just after that pass scoped its ids; idsNeedingAudioMoods() picks
+// the straggler up on the next pass, so nothing is lost, only deferred.
+let moodsPassInflight: Promise<void> | null = null;
+function scoreAudioMoods(): Promise<void> {
+  if (moodsPassInflight) return moodsPassInflight;
+  moodsPassInflight = (async () => {
+    try {
+      await runAudioMoodPass();
+    } catch (err: any) {
+      console.error(`[audio-moods] pass failed (non-fatal): ${err?.message || err}`);
+    } finally {
+      moodsPassInflight = null;
+    }
+  })();
+  return moodsPassInflight;
 }
 
 // Analyse one track and persist everything the backend returned: bpm/key/etc
@@ -118,7 +131,7 @@ let audioMetaStamped = false;
 async function analyzeAndStore(
   id: string,
   opts: { embed?: boolean; vocal?: boolean; localPath?: string | null; localComplete?: boolean },
-): Promise<{ audioStored: boolean; vocalStored: boolean }> {
+): Promise<{ audioStored: boolean; vocalStored: boolean; audioReturned: boolean }> {
   const { embed, vocal, localPath, localComplete } = opts;
   const a = localPath
     ? await analyzer.analyzePath(localPath, { embed, vocal, complete: localComplete })
@@ -155,7 +168,10 @@ async function analyzeAndStore(
       console.error(`[analyze] ${id} audio-vector write failed: ${err?.message || err}`);
     }
   }
-  return { audioStored, vocalStored: a.vocalRanges != null };
+  // audioReturned tells the on-pick path apart: "backend produced no vector"
+  // (runtime-degraded CLAP — stop asking) vs "vector arrived but the write
+  // failed" (transient — worth retrying).
+  return { audioStored, vocalStored: a.vocalRanges != null, audioReturned: a.audioEmbedding != null };
 }
 
 export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<AnalyzeStats> {
@@ -400,12 +416,37 @@ export type OnPickOutcome =
   | 'current'   // nothing missing — no analysis needed
   | 'analyzed'  // fresh analysis stored within the deadline
   | 'pending'   // still running past the deadline; caches when it finishes
-  | 'skipped'   // not in library.db / bulk run owns the backend / no backend
+  | 'skipped'   // not in library.db / bulk run owns the backend / no backend / failure cooling down
   | 'failed';
 
 // Single-flight per id: a request and a pick racing to the same song share one
 // analysis instead of hitting the backend twice.
 const onPickInflight = new Map<string, Promise<boolean>>();
+
+// Failure cooldown — a track whose analysis just failed (stale library entry,
+// backend hiccup) must not re-pay a full download+analysis on every future
+// spin. In-memory on purpose: a restart retries, and the bulk pass (which has
+// its own once-per-run scoping) is unaffected.
+const ON_PICK_FAILURE_COOLDOWN_MS = 60 * 60 * 1000;
+const onPickFailedAt = new Map<string, number>();
+function inFailureCooldown(id: string): boolean {
+  const at = onPickFailedAt.get(id);
+  if (at == null) return false;
+  if (Date.now() - at < ON_PICK_FAILURE_COOLDOWN_MS) return true;
+  onPickFailedAt.delete(id);
+  return false;
+}
+
+// Runtime-degraded opt-in dimensions. The worker's capability flags are static
+// find_spec probes — a sidecar built WITH_DEMUCS=1 keeps advertising vocal
+// activity even when Demucs fails to load at runtime (#996), analysing every
+// track "ok" with the ranges omitted. Without this latch, needsVocal/needsAudio
+// would never clear and every spin of every track would re-run the failing
+// pass. A requested dimension coming back absent from an otherwise-successful
+// analysis is that exact signature, so we stop requesting it for the rest of
+// the process (a restart re-probes; the bulk pass keeps its own handling).
+let vocalRuntimeDegraded = false;
+let audioRuntimeDegraded = false;
 
 export async function analyzeOnPick(
   id: string | null | undefined,
@@ -414,24 +455,31 @@ export async function analyzeOnPick(
   if (!id || !db.isOpen()) return 'skipped';
   // upsertTrackAnalysis is an UPDATE on an existing row — a track the library
   // sync hasn't ingested yet has nowhere to store results, so skip it.
-  const rec = db.getTrack(id);
-  if (!rec) return 'skipped';
+  const status = db.getTrackAnalysisStatus(id);
+  if (!status) return 'skipped';
 
   // Per-track twin of the bulk pass's scoping: base analysis when the version
   // is missing/stale, plus each opt-in dimension only when it's wanted
-  // (env/admin toggle) AND the backend can actually produce it.
-  const needsBase = rec.analysisVersion == null || rec.analysisVersion < db.ANALYSIS_VERSION;
-  const embed = audioBackfillDefault() && analyzer.audioEmbeddingAvailable() !== false;
-  const vocal = vocalBackfillDefault() && analyzer.vocalActivityAvailable() !== false;
-  const needsAudio = embed && !db.hasAudioVector(id);
-  const needsVocal = vocal && rec.vocalRanges == null;
-  if (!needsBase && !needsAudio && !needsVocal) return 'current';
+  // (env/admin toggle) and not runtime-degraded. Capability is checked AFTER
+  // the isAvailable() probe below — reading it here would see null on a cold
+  // controller and force an unfulfillable embed/vocal on a lean backend.
+  const needsBase = status.analysisVersion == null || status.analysisVersion < db.ANALYSIS_VERSION;
+  const wantAudio = audioBackfillDefault() && !audioRuntimeDegraded && !db.hasAudioVector(id);
+  const wantVocal = vocalBackfillDefault() && !vocalRuntimeDegraded && !status.hasVocalRanges;
+  if (!needsBase && !wantAudio && !wantVocal) return 'current';
+  if (inFailureCooldown(id)) return 'skipped';
 
   // A running bulk tagger/analyzer owns the backend (and will reach this track
   // anyway) — don't double-hit it from the queue path.
   const bulk = readPidfile();
   if (bulk && isPidAlive(bulk.pid)) return 'skipped';
   if (!(await analyzer.isAvailable())) return 'skipped';
+  // Backend resolved by the probe above — capability answers are real now
+  // (`null` only for an old sidecar whose /health omits the flag; treat that
+  // as maybe-capable, same as the bulk pass).
+  const embed = wantAudio && analyzer.audioEmbeddingAvailable() !== false;
+  const vocal = wantVocal && analyzer.vocalActivityAvailable() !== false;
+  if (!needsBase && !embed && !vocal) return 'current';
 
   let job = onPickInflight.get(id);
   if (!job) {
@@ -445,16 +493,26 @@ export async function analyzeOnPick(
   }
 
   const timeoutMs = opts.timeoutMs ?? ON_PICK_TIMEOUT_MS;
+  let deadlineTimer: NodeJS.Timeout | undefined;
   const deadline = new Promise<'pending'>((resolve) => {
-    const t = setTimeout(() => resolve('pending'), timeoutMs);
-    t.unref?.();
+    deadlineTimer = setTimeout(() => resolve('pending'), timeoutMs);
+    deadlineTimer.unref?.();
   });
-  return Promise.race([job.then((ok): OnPickOutcome => (ok ? 'analyzed' : 'failed')), deadline]);
+  try {
+    return await Promise.race([job.then((ok): OnPickOutcome => (ok ? 'analyzed' : 'failed')), deadline]);
+  } finally {
+    clearTimeout(deadlineTimer);
+  }
 }
 
 // The actual work: download (byte-capped, so a skipped outro rides the same
 // completeness flag as the bulk pass), analyse, store — mirroring one
-// iteration of runAnalysisPass's loop, minus the prefetch pipeline.
+// iteration of runAnalysisPass's loop, minus the prefetch pipeline. Downloads
+// stage in ANALYZE_PICK_TMP_DIR, NOT the bulk pass's analyze-tmp: a bulk run
+// started after this job began would otherwise write the same fixed
+// `<id>.audio` path (interleaved writes → corrupt analysis) and its end-of-run
+// `rm -rf analyze-tmp` would delete the file out from under the sidecar's
+// in-flight read.
 async function analyzeOnPickJob(
   id: string,
   flags: { embed?: boolean; vocal?: boolean },
@@ -463,7 +521,7 @@ async function analyzeOnPickJob(
   let localComplete: boolean | undefined;
   try {
     try {
-      const dl = await analyzer.downloadCapped(id);
+      const dl = await analyzer.downloadCapped(id, analyzer.ANALYZE_PICK_TMP_DIR);
       localPath = dl.path;
       localComplete = dl.complete;
     } catch (err: any) {
@@ -472,14 +530,29 @@ async function analyzeOnPickJob(
       if (err instanceof analyzer.NonAudioResponseError) throw err;
       console.error(`[analyze] on-pick ${id} prefetch failed (${err?.message || err}); using url path`);
     }
-    const { audioStored } = await analyzeAndStore(id, { ...flags, localPath, localComplete });
+    const { audioStored, vocalStored, audioReturned } = await analyzeAndStore(id, { ...flags, localPath, localComplete });
+    // A requested dimension coming back absent from a successful analysis is
+    // the runtime-degraded-worker signature (#996) — latch it so the needs
+    // check stops forcing a pass the backend can never fulfil.
+    if (flags.vocal && !vocalStored && !vocalRuntimeDegraded) {
+      vocalRuntimeDegraded = true;
+      console.warn(`[analyze] on-pick: backend advertises vocal activity but returned none — pausing on-pick vocal requests until restart`);
+    }
+    if (flags.embed && !audioReturned && !audioRuntimeDegraded) {
+      audioRuntimeDegraded = true;
+      console.warn(`[analyze] on-pick: backend advertises audio embeddings but returned none — pausing on-pick embed requests until restart`);
+    }
     // Zero-shot audio moods for the vector this analysis just wrote (plus any
     // unscored stragglers) — best-effort, never blocks the caller.
     if (audioStored) void scoreAudioMoods();
     console.log(`[analyze] on-pick analysed ${id}`);
     return true;
   } catch (err: any) {
-    // Leave the row NULL so a later pass retries it; don't stamp a version.
+    // Leave the row NULL so a later pass retries it; don't stamp a version —
+    // but remember the failure so the next spins of this track don't re-pay a
+    // full download+analysis for the same outcome (the cooldown expires, and a
+    // bulk run or restart retries sooner).
+    onPickFailedAt.set(id, Date.now());
     console.error(`[analyze] on-pick ${id} failed: ${err?.message || err}`);
     return false;
   } finally {

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -131,7 +131,7 @@ let audioMetaStamped = false;
 async function analyzeAndStore(
   id: string,
   opts: { embed?: boolean; vocal?: boolean; localPath?: string | null; localComplete?: boolean },
-): Promise<{ audioStored: boolean; vocalStored: boolean; audioReturned: boolean }> {
+): Promise<{ audioStored: boolean; vocalStored: boolean; audioDim: number | null }> {
   const { embed, vocal, localPath, localComplete } = opts;
   const a = localPath
     ? await analyzer.analyzePath(localPath, { embed, vocal, complete: localComplete })
@@ -168,10 +168,12 @@ async function analyzeAndStore(
       console.error(`[analyze] ${id} audio-vector write failed: ${err?.message || err}`);
     }
   }
-  // audioReturned tells the on-pick path apart: "backend produced no vector"
-  // (runtime-degraded CLAP — stop asking) vs "vector arrived but the write
-  // failed" (transient — worth retrying).
-  return { audioStored, vocalStored: a.vocalRanges != null, audioReturned: a.audioEmbedding != null };
+  // audioDim lets the on-pick path tell three cases apart: null = "backend
+  // produced no vector" (runtime-degraded CLAP — stop asking); wrong dim =
+  // "backend runs a different CLAP model than the DB was stamped with"
+  // (persistent — stop asking); right dim with audioStored false = "vector
+  // arrived but the write failed" (transient — worth retrying).
+  return { audioStored, vocalStored: a.vocalRanges != null, audioDim: a.audioEmbedding?.length ?? null };
 }
 
 export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<AnalyzeStats> {
@@ -416,12 +418,25 @@ export type OnPickOutcome =
   | 'current'   // nothing missing — no analysis needed
   | 'analyzed'  // fresh analysis stored within the deadline
   | 'pending'   // still running past the deadline; caches when it finishes
-  | 'skipped'   // not in library.db / bulk run owns the backend / no backend / failure cooling down
+  | 'skipped'   // not in library.db / bulk run owns the backend / no backend / failure cooling down / another track's analysis inflight
   | 'failed';
 
 // Single-flight per id: a request and a pick racing to the same song share one
 // analysis instead of hitting the backend twice.
 const onPickInflight = new Map<string, Promise<boolean>>();
+
+// Crash-orphan sweep — each job's finally removes its own staging file, but a
+// controller crash mid-analysis leaves the file behind, and unlike the bulk
+// pass's analyze-tmp this dir has no end-of-run rm -rf to reap it. Sweep the
+// whole dir once per process, before the first download stages into it; every
+// job awaits the same promise, so the sweep can never race a live file.
+let pickStagingSwept: Promise<void> | null = null;
+function sweepPickStaging(): Promise<void> {
+  if (!pickStagingSwept) {
+    pickStagingSwept = rm(analyzer.ANALYZE_PICK_TMP_DIR, { recursive: true, force: true }).catch(() => {});
+  }
+  return pickStagingSwept;
+}
 
 // Failure cooldown — a track whose analysis just failed (stale library entry,
 // backend hiccup) must not re-pay a full download+analysis on every future
@@ -483,6 +498,14 @@ export async function analyzeOnPick(
 
   let job = onPickInflight.get(id);
   if (!job) {
+    // Global gate: one on-pick analysis at a time, matching the bulk pass's
+    // serial temperament toward the backend. Without it, a boot-recovery
+    // re-drain of several unsent items would background one analysis per item
+    // — parallel downloads plus parallel librosa/CLAP jobs on a backend sized
+    // for one. A gated-out track airs with existing data and retries on a
+    // later spin, like every other skip. (Synchronous between the get above
+    // and the set below, so the check can't race another caller.)
+    if (onPickInflight.size > 0) return 'skipped';
     job = analyzeOnPickJob(id, {
       embed: embed ? true : undefined,
       vocal: vocal ? true : undefined,
@@ -521,6 +544,7 @@ async function analyzeOnPickJob(
   let localComplete: boolean | undefined;
   try {
     try {
+      await sweepPickStaging();
       const dl = await analyzer.downloadCapped(id, analyzer.ANALYZE_PICK_TMP_DIR);
       localPath = dl.path;
       localComplete = dl.complete;
@@ -530,7 +554,7 @@ async function analyzeOnPickJob(
       if (err instanceof analyzer.NonAudioResponseError) throw err;
       console.error(`[analyze] on-pick ${id} prefetch failed (${err?.message || err}); using url path`);
     }
-    const { audioStored, vocalStored, audioReturned } = await analyzeAndStore(id, { ...flags, localPath, localComplete });
+    const { audioStored, vocalStored, audioDim } = await analyzeAndStore(id, { ...flags, localPath, localComplete });
     // A requested dimension coming back absent from a successful analysis is
     // the runtime-degraded-worker signature (#996) — latch it so the needs
     // check stops forcing a pass the backend can never fulfil.
@@ -538,9 +562,19 @@ async function analyzeOnPickJob(
       vocalRuntimeDegraded = true;
       console.warn(`[analyze] on-pick: backend advertises vocal activity but returned none — pausing on-pick vocal requests until restart`);
     }
-    if (flags.embed && !audioReturned && !audioRuntimeDegraded) {
+    if (flags.embed && audioDim == null && !audioRuntimeDegraded) {
       audioRuntimeDegraded = true;
       console.warn(`[analyze] on-pick: backend advertises audio embeddings but returned none — pausing on-pick embed requests until restart`);
+    }
+    // A vector with the wrong dimensionality is just as persistent: the
+    // backend is running a different CLAP model than the DB was stamped with,
+    // so every retry returns the same unusable vector — without this latch,
+    // every spin of every vector-less track would re-pay a full
+    // download+analysis. A bulk re-analyse (or fixing the backend) is the
+    // operator's path out.
+    if (flags.embed && audioDim != null && audioDim !== db.AUDIO_EMBEDDING_DIM && !audioRuntimeDegraded) {
+      audioRuntimeDegraded = true;
+      console.warn(`[analyze] on-pick: backend returned ${audioDim}-d audio vectors (expected ${db.AUDIO_EMBEDDING_DIM}) — pausing on-pick embed requests until restart`);
     }
     // Zero-shot audio moods for the vector this analysis just wrote (plus any
     // unscored stragglers) — best-effort, never blocks the caller.

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -16,6 +16,7 @@
 
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { existsSync, mkdirSync, createWriteStream, readFileSync } from 'node:fs';
+import { rm as fsRm } from 'node:fs/promises';
 import { pipeline } from 'node:stream/promises';
 import { config } from '../config.js';
 import * as subsonic from './subsonic.js';
@@ -210,6 +211,12 @@ const ANALYZE_MAX_BYTES = parseInt(process.env.ANALYZE_MAX_BYTES || String(12 * 
 // the tts-heavy sidecar), so the path string the controller writes resolves to
 // the same file inside the sidecar — that's what makes the path handoff work.
 const ANALYZE_TMP_DIR = `${config.stateDir}/analyze-tmp`;
+// Separate staging dir for the on-pick (a la carte) path. The bulk pass owns
+// analyze-tmp — including an end-of-run `rm -rf` that reaps its orphans — so
+// on-pick files live in a sibling dir a concurrently-finishing bulk run can
+// never delete out from under an in-flight sidecar read. Also under the
+// shared state dir for the same cross-container path-handoff reason.
+export const ANALYZE_PICK_TMP_DIR = `${config.stateDir}/analyze-tmp-pick`;
 
 // ---------------------------------------------------------------------------
 // Local Python worker (persistent over stdio)
@@ -701,9 +708,10 @@ function subsonicErrorMessage(body: string): string {
 // falls back to the url path for that one track.
 export async function downloadCapped(
   songId: string,
+  destDir: string = ANALYZE_TMP_DIR,
 ): Promise<{ path: string; complete: boolean }> {
-  mkdirSync(ANALYZE_TMP_DIR, { recursive: true });
-  const dest = `${ANALYZE_TMP_DIR}/${encodeURIComponent(songId)}.audio`;
+  mkdirSync(destDir, { recursive: true });
+  const dest = `${destDir}/${encodeURIComponent(songId)}.audio`;
   const url = subsonic.getRawStreamUrl(songId);
   const ac = new AbortController();
   const t = setTimeout(() => ac.abort(), config.analyzer.requestTimeoutMs);
@@ -760,6 +768,12 @@ export async function downloadCapped(
     // exactly cap bytes is flagged incomplete too; erring that way only skips
     // outro analysis, never mis-measures it.)
     return { path: dest, complete: read < ANALYZE_MAX_BYTES };
+  } catch (err) {
+    // A failed download must not leave its partial file behind: the caller
+    // only cleans up paths it was handed, so an orphan here would accumulate
+    // (the on-pick dir has no bulk-style end-of-run sweep to reap it).
+    await fsRm(dest, { force: true }).catch(() => {});
+    throw err;
   } finally {
     clearTimeout(t);
   }

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -1336,6 +1336,24 @@ export function hasAudioVector(id: string): boolean {
   return row != null;
 }
 
+// Per-track analysis status for the on-pick needs check — the single-row twin
+// of the bulk pass's scoping queries, kept beside them so the predicates can't
+// drift: `analysisVersion` mirrors needsAnalysisIds' version gate,
+// `hasVocalRanges` mirrors needsVocalIds' `vocal_ranges_json IS NULL`. A
+// targeted two-column read instead of getTrack()'s full-row JSON-blob parse —
+// this runs on every queue hand-off when analyse-on-pick is enabled (#723
+// taught us what per-poll blob parsing costs). Returns null when the track
+// isn't ingested (upsertTrackAnalysis is an UPDATE — nowhere to store results).
+export function getTrackAnalysisStatus(
+  id: string,
+): { analysisVersion: number | null; hasVocalRanges: boolean } | null {
+  const row = requireDb()
+    .prepare(`SELECT analysis_version, vocal_ranges_json IS NOT NULL AS has_vocal FROM tracks WHERE id = ?`)
+    .get(id) as { analysis_version: number | null; has_vocal: number } | undefined;
+  if (!row) return null;
+  return { analysisVersion: row.analysis_version ?? null, hasVocalRanges: !!row.has_vocal };
+}
+
 // Ids with an audio vector but no audio moods yet — the incremental scope for
 // an unchanged vocabulary (newly analysed tracks since the last scoring pass).
 export function idsNeedingAudioMoods(): string[] {

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -1327,6 +1327,15 @@ export function audioVectorIds(): string[] {
   return rows.map(r => r.id);
 }
 
+// Whether a single track already carries a CLAP audio vector — the per-track
+// twin of unanalysedAudioIds, for the on-pick analysis needs check.
+export function hasAudioVector(id: string): boolean {
+  const row = requireDb()
+    .prepare(`SELECT 1 FROM track_audio_vectors WHERE id = ?`)
+    .get(id);
+  return row != null;
+}
+
 // Ids with an audio vector but no audio moods yet — the incremental scope for
 // an unchanged vocabulary (newly analysed tracks since the last scoring pass).
 export function idsNeedingAudioMoods(): string[] {

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -106,6 +106,11 @@ export function get(songId: string): any {
     durationSec: t.durationSec,
     structure: t.structure,
     vocalRanges: t.vocalRanges, // [] = instrumental, null = not computed
+    // Per-region key ranges (feature: boundary keys). Without this the
+    // `rec?.keyRanges` fallbacks in bpmKeyFor and queue.mixAnalysisFor were
+    // structurally dead — getTrack parses key_ranges_json, but the projection
+    // dropped it, so opening/ending keys always degraded to the dominant key.
+    keyRanges: t.keyRanges,
     paceMean: paceMeanOf(t.pace),
     // Measured ending (fade vs cold, tail loudness/tempo/grid) — feeds the
     // queue's ending-aware exit canvas + effect gating. null = no signal.

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -1416,6 +1416,14 @@ const DEFAULTS = {
     // request is a clean no-op. ANALYZE_VOCAL_ACTIVITY=1 also enables it
     // regardless of this toggle (env wins on, never off). Expensive — opt-in.
     vocalActivity: false,
+    // On-pick ("a la carte") analysis — when the DJ picks a track that hasn't
+    // been analysed yet (or is missing an opted-in dimension: CLAP vector,
+    // vocal ranges), analyse just that track right before it's handed to
+    // Liquidsoap, so the upcoming transition can already use the fresh data
+    // and the library backfills organically with what actually gets airplay
+    // (discussion #1032). Off by default: it can delay the queue hand-off by
+    // up to the analysis timeout, so it's an explicit operator choice.
+    analyzeOnPick: false,
   },
   // Sound-effects library. When disabled, the segment-director agent is never
   // shown the effect catalogue, so it stops garnishing spoken breaks with
@@ -2183,6 +2191,7 @@ export async function load() {
     audio: {
       embeddings: typeof stored.audio?.embeddings === 'boolean' ? stored.audio.embeddings : DEFAULTS.audio.embeddings,
       vocalActivity: typeof stored.audio?.vocalActivity === 'boolean' ? stored.audio.vocalActivity : DEFAULTS.audio.vocalActivity,
+      analyzeOnPick: typeof stored.audio?.analyzeOnPick === 'boolean' ? stored.audio.analyzeOnPick : DEFAULTS.audio.analyzeOnPick,
     },
     sfx: {
       enabled: typeof stored.sfx?.enabled === 'boolean' ? stored.sfx.enabled : DEFAULTS.sfx.enabled,
@@ -3538,6 +3547,9 @@ export async function update(patch) {
     }
     if (au.vocalActivity !== undefined) {
       next.audio.vocalActivity = !!au.vocalActivity;
+    }
+    if (au.analyzeOnPick !== undefined) {
+      next.audio.analyzeOnPick = !!au.analyzeOnPick;
     }
   }
   if ('sfx' in patch) {

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -102,7 +102,7 @@ interface SettingsResponse {
   tagger?: TaggerState;
   libraryStats?: LibraryStatsLite;
   // Only the slice this panel needs from the full settings payload.
-  values?: { audio?: { embeddings?: boolean; vocalActivity?: boolean } };
+  values?: { audio?: { embeddings?: boolean; vocalActivity?: boolean; analyzeOnPick?: boolean } };
   // Daily-token-budget tier — drives the "budget nearly/already used" warning in
   // the Tagging modal. Absent on an old controller → treated as 'normal'.
   budget?: { mode: BudgetMode };
@@ -189,6 +189,8 @@ export default function LibraryPanel() {
   const [audioEnabled, setAudioEnabled] = useState<boolean | null>(null);
   // settings.audio.vocalActivity — null until the first /settings poll lands.
   const [vocalEnabled, setVocalEnabled] = useState<boolean | null>(null);
+  // settings.audio.analyzeOnPick — just-in-time analysis of queued tracks (#1032).
+  const [onPickEnabled, setOnPickEnabled] = useState<boolean | null>(null);
   // Daily-token-budget tier from /settings — null until the first slow poll lands.
   const [budgetMode, setBudgetMode] = useState<BudgetMode | null>(null);
   const [logOpen, setLogOpen] = useState(false);
@@ -356,6 +358,7 @@ export default function LibraryPanel() {
       if (j.values?.audio) {
         setAudioEnabled(!!j.values.audio.embeddings);
         setVocalEnabled(!!j.values.audio.vocalActivity);
+        setOnPickEnabled(!!j.values.audio.analyzeOnPick);
       }
       if (j.budget) setBudgetMode(j.budget.mode);
     } catch { /* transient */ }
@@ -1019,6 +1022,29 @@ export default function LibraryPanel() {
     }
   };
 
+  // Flip settings.audio.analyzeOnPick — just-in-time analysis of queued tracks
+  // (#1032). Mirrors toggleVocal, minus the coverage refresh (no meter row).
+  const toggleOnPick = async () => {
+    if (onPickEnabled == null) return;
+    setTaggerBusy(true);
+    try {
+      const r = await adminFetch('/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ audio: { analyzeOnPick: !onPickEnabled } }),
+      });
+      const j = await r.json().catch(() => ({})) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `save failed (${r.status})`);
+      setOnPickEnabled(!onPickEnabled);
+      notify.ok(!onPickEnabled ? 'analyse-on-pick enabled' : 'analyse-on-pick disabled');
+      void loadSettingsData();
+    } catch (err) {
+      notify.err(errorMessage(err));
+    } finally {
+      setTaggerBusy(false);
+    }
+  };
+
   // Backfill Demucs vocal ranges on tracks that lack them — POST with vocal:true
   // so the analyze pass forces the vocal scope (#646).
   const vocalBackfill = async () => {
@@ -1162,6 +1188,8 @@ export default function LibraryPanel() {
         vocalEnabled={vocalEnabled}
         onToggleVocal={toggleVocal}
         onVocalBackfill={vocalBackfill}
+        onPickEnabled={onPickEnabled}
+        onToggleOnPick={toggleOnPick}
         budgetMode={budgetMode}
       />
 

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -903,40 +903,54 @@ export default function LibraryPanel() {
     }
   };
 
-  // Flip settings.audio.embeddings — the "sounds-like" (CLAP) opt-in. The
-  // toggle only persists the setting; vectors appear after an analysis run.
-  const toggleAudio = async () => {
-    if (audioEnabled == null) return;
+  // Shared save path for the settings.audio boolean opt-ins (sounds-like,
+  // vocal activity, analyse-on-pick): POST the flipped flag, mirror it into
+  // local state, toast, refresh the slow /settings loop. One implementation so
+  // the per-toggle copies can't drift.
+  const saveAudioToggle = async (
+    key: 'embeddings' | 'vocalActivity' | 'analyzeOnPick',
+    current: boolean | null,
+    apply: (next: boolean) => void,
+    okMessage: (next: boolean) => string,
+    afterSave?: () => void,
+  ) => {
+    if (current == null) return;
     setTaggerBusy(true);
     try {
       const r = await adminFetch('/settings', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ audio: { embeddings: !audioEnabled } }),
+        body: JSON.stringify({ audio: { [key]: !current } }),
       });
       const j = await r.json().catch(() => ({})) as { error?: string };
       if (!r.ok) throw new Error(j.error || `save failed (${r.status})`);
-      setAudioEnabled(!audioEnabled);
-      // When the analyzer can't fingerprint yet (lean image), frame enabling as
-      // pending rather than done — the incapable banner below explains the upgrade.
-      const audioPending =
-        coverage?.analysisAvailable !== false && coverage?.audioAnalysisAvailable === false;
-      notify.ok(
-        !audioEnabled
-          ? audioPending
-            ? 'sounds-like enabled — starts once the heavy analyzer is up'
-            : 'sounds-like analysis enabled'
-          : 'sounds-like analysis disabled',
-      );
-      // The toggle lives on the slow /settings loop — refresh it now so a manual
-      // re-open / status recompute doesn't wait up to 30s to reflect the flip.
+      apply(!current);
+      notify.ok(okMessage(!current));
+      // The toggles live on the slow /settings loop — refresh it now so a
+      // manual re-open / status recompute doesn't wait up to 30s for the flip.
       void loadSettingsData();
+      afterSave?.();
     } catch (err) {
       notify.err(errorMessage(err));
     } finally {
       setTaggerBusy(false);
     }
   };
+
+  // Flip settings.audio.embeddings — the "sounds-like" (CLAP) opt-in. The
+  // toggle only persists the setting; vectors appear after an analysis run.
+  // When the analyzer can't fingerprint yet (lean image), frame enabling as
+  // pending rather than done — the incapable banner below explains the upgrade.
+  const toggleAudio = () =>
+    saveAudioToggle('embeddings', audioEnabled, setAudioEnabled, (next) => {
+      const audioPending =
+        coverage?.analysisAvailable !== false && coverage?.audioAnalysisAvailable === false;
+      return next
+        ? audioPending
+          ? 'sounds-like enabled — starts once the heavy analyzer is up'
+          : 'sounds-like analysis enabled'
+        : 'sounds-like analysis disabled';
+    });
 
   // Reconcile with Navidrome — walk the catalogue and prune library entries
   // for tracks that no longer exist (deleted files, or IDs re-minted by a full
@@ -987,63 +1001,32 @@ export default function LibraryPanel() {
   };
 
   // Flip settings.audio.vocalActivity — the Demucs vocal-activity opt-in (#646).
-  // Mirrors toggleAudio; env ANALYZE_VOCAL_ACTIVITY still wins "on".
-  const toggleVocal = async () => {
-    if (vocalEnabled == null) return;
-    setTaggerBusy(true);
-    try {
-      const r = await adminFetch('/settings', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ audio: { vocalActivity: !vocalEnabled } }),
-      });
-      const j = await r.json().catch(() => ({})) as { error?: string };
-      if (!r.ok) throw new Error(j.error || `save failed (${r.status})`);
-      setVocalEnabled(!vocalEnabled);
-      // Mirrors toggleAudio: enabling on a lean analyzer is "armed", not active.
-      const vocalPending =
-        coverage?.analysisAvailable !== false && coverage?.vocalAnalysisAvailable === false;
-      notify.ok(
-        !vocalEnabled
+  // Mirrors toggleAudio; env ANALYZE_VOCAL_ACTIVITY still wins "on". Also
+  // refreshes coverage so the coverage-driven bits (vocalStatus, the vocal
+  // meter row) catch up without waiting out the 60s poll.
+  const toggleVocal = () =>
+    saveAudioToggle(
+      'vocalActivity',
+      vocalEnabled,
+      setVocalEnabled,
+      (next) => {
+        const vocalPending =
+          coverage?.analysisAvailable !== false && coverage?.vocalAnalysisAvailable === false;
+        return next
           ? vocalPending
             ? 'vocal-activity enabled — starts once the heavy analyzer is up'
             : 'vocal-activity analysis enabled'
-          : 'vocal-activity analysis disabled',
-      );
-      // Refresh the slow settings-derived state now rather than waiting for its
-      // tick — and coverage too, so the coverage-driven bits (vocalStatus, the
-      // vocal meter row) catch up without waiting out the 60s poll.
-      void loadSettingsData();
-      void loadCoverage();
-    } catch (err) {
-      notify.err(errorMessage(err));
-    } finally {
-      setTaggerBusy(false);
-    }
-  };
+          : 'vocal-activity analysis disabled';
+      },
+      () => void loadCoverage(),
+    );
 
   // Flip settings.audio.analyzeOnPick — just-in-time analysis of queued tracks
   // (#1032). Mirrors toggleVocal, minus the coverage refresh (no meter row).
-  const toggleOnPick = async () => {
-    if (onPickEnabled == null) return;
-    setTaggerBusy(true);
-    try {
-      const r = await adminFetch('/settings', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ audio: { analyzeOnPick: !onPickEnabled } }),
-      });
-      const j = await r.json().catch(() => ({})) as { error?: string };
-      if (!r.ok) throw new Error(j.error || `save failed (${r.status})`);
-      setOnPickEnabled(!onPickEnabled);
-      notify.ok(!onPickEnabled ? 'analyse-on-pick enabled' : 'analyse-on-pick disabled');
-      void loadSettingsData();
-    } catch (err) {
-      notify.err(errorMessage(err));
-    } finally {
-      setTaggerBusy(false);
-    }
-  };
+  const toggleOnPick = () =>
+    saveAudioToggle('analyzeOnPick', onPickEnabled, setOnPickEnabled, (next) =>
+      next ? 'analyse-on-pick enabled' : 'analyse-on-pick disabled',
+    );
 
   // Backfill Demucs vocal ranges on tracks that lack them — POST with vocal:true
   // so the analyze pass forces the vocal scope (#646).

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -210,6 +210,11 @@ interface TaggingPanelProps {
   // settings poll lands. Drives the "build WITH_DEMUCS=1" warning when on but
   // the backend can't produce vocal ranges.
   vocalEnabled: boolean | null;
+  // On-pick ("a la carte") analysis — analyse a track the moment the DJ queues
+  // it, so its first spin already mixes with fresh data (#1032). Null until the
+  // first settings poll lands.
+  onPickEnabled: boolean | null;
+  onToggleOnPick: () => void;
   // Daily-token-budget tier from /settings — null until the first slow poll lands.
   // Forwarded to the modal for its pre-run spend warning.
   budgetMode: BudgetMode | null;
@@ -852,6 +857,44 @@ export default function TaggingPanel(p: TaggingPanelProps) {
             )}
           </div>
         )}
+        {/* On-pick (a la carte) analysis — analyse a track the moment the DJ
+            queues it for air, so its first spin already mixes with fresh data
+            and the library backfills itself with what actually plays (#1032). */}
+        <div className="flex flex-wrap items-center gap-x-3.5 gap-y-2 border-t border-dashed border-separator-strong pt-3">
+          <span className="caption flex items-center gap-2">
+            <Activity size={13} /> Analyse on pick · just-in-time
+          </span>
+          <span className="lib-opt-tag">optional</span>
+          <span className="caption mono-num !tracking-[0.04em]">
+            {p.onPickEnabled == null
+              ? '…'
+              : p.onPickEnabled
+                ? analysisOff
+                  ? 'on · waiting for the analysis engine'
+                  : 'on'
+                : 'off'}
+          </span>
+          <span className="ml-auto">
+            <Btn
+              sm
+              onClick={p.onToggleOnPick}
+              disabled={p.busy || p.onPickEnabled == null}
+              title={
+                p.onPickEnabled
+                  ? 'Stop just-in-time analysis of queued tracks. Already-cached data stays and keeps being used.'
+                  : 'Analyse each track the moment the DJ queues it (can hold the hand-off up to ~60s) so its first spin already mixes with fresh data.'
+              }
+            >
+              {p.onPickEnabled ? 'Pause' : 'Enable'}
+            </Btn>
+          </span>
+          <span className="caption basis-full !tracking-[0.04em] !normal-case">
+            Analyses each track as it&rsquo;s queued for air — the library backfills itself with
+            what actually plays, no bulk run needed. Uses the same engine and opt-ins
+            (sounds-like, vocal) as the rows above; anything still missing at air time simply
+            plays as today and caches for next time.
+          </span>
+        </div>
         {audioStatus === 'pending-heavy' && p.audioEnabled ? (
           <div className="border border-[color-mix(in_oklab,var(--accent)_35%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] leading-[1.5] text-ink !normal-case">
             <b>Sounds-like is enabled — fingerprinting starts once your analyzer can do it.</b> The


### PR DESCRIPTION
Implements the request in discussion #1032: instead of requiring bulk analysis runs upfront, analyse a track **at the moment the DJ queues it for air**, so its first spin already mixes with fresh data and the library backfills organically with what actually gets airplay.

## How it works

- New setting **`audio.analyzeOnPick`** (default **off**) with an Enable/Pause row in the Library panel's Acoustic analysis section.
- In `queue.drainToLiquidsoap()`, right before `applyMixTransition` reads the library record, the item's track is analysed if it still needs anything: stale/missing bpm/key (`analysis_version`), a missing CLAP "sounds-like" vector, or missing vocal ranges — each opt-in dimension only when it's wanted (env/admin toggle) *and* the backend can produce it, mirroring the bulk pass's gating.
- **Bounded by a 60s deadline**: past it, the hand-off proceeds with whatever data exists (exactly today's behaviour) while the analysis keeps running in the background and still caches its result for the track's next spin. Awaiting in the drain loop matches the existing awaited TTS render — it's the queue's one slow-work seam, a full track away from when the item airs.
- Skips cleanly when: the track isn't in `library.db` yet (`upsertTrackAnalysis` is an UPDATE), a bulk tagger/analyzer run owns the backend (pidfile check via `tagger-lock`, avoiding the `tagger ↔ queue` import cycle), or no analysis backend is up.
- Single-flight per track id — a listener request and a pick racing to the same song share one analysis.
- A stored CLAP vector triggers a best-effort zero-shot audio-mood scoring pass, same as the bulk path.

## Refactor

The per-track analyse+store core (analyze → `upsertTrackAnalysis` → vector + provenance stamp) is extracted from `runAnalysisPass`'s loop into a shared `analyzeAndStore()`, so the bulk pass and the on-pick path share one implementation. The provenance stamp guard moves from per-run to per-process — idempotent row, no behaviour change.

## Testing

- `npm run lint` clean in both `controller/` and `web/` (eslint + tsc).
- Feature is off by default; when off, zero new code runs in the queue path beyond one settings read.