### PR TITLE
feat(web): surface TTS engine availability before selection (#585)

### DIFF
--- a/web/components/admin/personas/PersonaVoiceCard.tsx
+++ b/web/components/admin/personas/PersonaVoiceCard.tsx
@@ -13,7 +13,7 @@ import { Card, Seg } from '../ui';
 import { EngineSelector } from '../tts/EngineSelector';
 import { VoicePreviewButton } from '../tts/VoicePreviewButton';
 import { VoicePicker, type VoicePickerGroup } from '../tts/VoicePicker';
-import { ENGINES } from '../tts/engineMeta';
+import { ENGINES, type EngineAvailability } from '../tts/engineMeta';
 import { Input } from '../../ui/input';
 import { Label } from '../../ui/label';
 import {
@@ -73,6 +73,21 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
     updateTts(patch);
   };
 
+  // Resolve Cloud against this persona's saved provider even before the Cloud
+  // card is selected. openai-compatible has no key-based availability entry and
+  // is trusted by the server, while unknown providers retain the global status.
+  const globalAvail = data?.tts?.available as EngineAvailability | undefined;
+  let selectorAvailable = globalAvail;
+  if (globalAvail) {
+    const prov = persona.tts.cloudProvider;
+    const cloudByProv = globalAvail.cloudByProvider;
+    if (cloudByProv && prov in cloudByProv) {
+      selectorAvailable = { ...globalAvail, cloud: cloudByProv[prov] };
+    } else if (prov === 'openai-compatible') {
+      selectorAvailable = { ...globalAvail, cloud: true };
+    }
+  }
+
   return (
     <Card flat title="Voice" sub="text-to-speech engine">
       {/* Engine — radio-card grid, full width above the two-column body. */}
@@ -81,7 +96,7 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
         <EngineSelector
           value={persona.tts.engine}
           engineIds={ENGINE_IDS}
-          available={data?.tts?.available}
+          available={selectorAvailable}
           onChange={selectEngine}
         />
         <div className="field-hint max-w-[70ch]">

--- a/web/components/admin/personas/types.ts
+++ b/web/components/admin/personas/types.ts
@@ -1,6 +1,9 @@
 // Shared types for the personas editor (/admin/personas). Split out of
 // PersonasPanel so the presentational sub-components can share one shape.
 
+import type { EngineAvailability } from '../tts/engineMeta';
+export type { EngineAvailability };
+
 export interface PersonaTts {
   engine: 'piper' | 'kokoro' | 'chatterbox' | 'pocket-tts' | 'cloud' | 'remote' | string;
   cloudProvider: string;
@@ -101,7 +104,7 @@ export interface SettingsResponse {
     chatterboxVoiceDir?: string;
     pocketTtsVoices?: VoiceOption[];
     pocketTtsCustomVoices?: string[];
-    available?: Record<string, boolean>;
+    available?: EngineAvailability;
     cloudProviders?: string[];
   };
   env?: Record<string, unknown>;

--- a/web/components/admin/tts/EngineSelector.tsx
+++ b/web/components/admin/tts/EngineSelector.tsx
@@ -7,7 +7,7 @@
 // RadioOption pattern. Tailwind-only
 // (no inline styles — issue #50).
 import { cn } from '../../../lib/cn';
-import { ENGINE_META, engineStatus, engineEnableHint, type EngineAvailability } from './engineMeta';
+import { ENGINE_META, engineStatus, type EngineAvailability } from './engineMeta';
 
 interface EngineSelectorProps {
   // Currently selected engine id.
@@ -21,7 +21,7 @@ interface EngineSelectorProps {
 }
 
 export function EngineSelector({ value, engineIds, available, onChange, className }: EngineSelectorProps) {
-  const hint = engineEnableHint(value, available);
+  const hint = engineStatus(value, available).hint;
   return (
     <div className={cn('grid gap-2.5', className)}>
       <div
@@ -33,7 +33,7 @@ export function EngineSelector({ value, engineIds, available, onChange, classNam
           const meta = ENGINE_META[id];
           const status = engineStatus(id, available);
           const active = value === id;
-          const isUnavailable = available?.[id] === false && status.label !== 'starting…';
+          const muted = status.state === 'off';
           return (
             <button
               key={id}
@@ -43,7 +43,7 @@ export function EngineSelector({ value, engineIds, available, onChange, classNam
               onClick={() => onChange(id)}
               className={cn(
                 'grid cursor-pointer content-start gap-1.5 border p-3 text-left font-[inherit]',
-                isUnavailable && !active && 'opacity-60',
+                muted && !active && 'opacity-60',
                 active
                   ? 'border-[var(--accent)] bg-[var(--accent-soft)]'
                   : 'border-ink bg-transparent hover:bg-[var(--ink-softer)]',
@@ -88,12 +88,23 @@ export function EngineSelector({ value, engineIds, available, onChange, classNam
           );
         })}
       </div>
-      {hint && (
-        <p role="status" className="border border-[var(--separator-strong)] bg-[var(--ink-softer)] px-3 py-2 text-[11px] leading-[1.55] text-muted">
-          {hint.reason}.
-          {hint.action && <> Next step: <code>{hint.action}</code>.</>}
-        </p>
-      )}
+      {/* Enable hint for the selected engine. The live region stays mounted
+          (content toggles) so screen readers reliably announce it — a region
+          inserted on demand can miss its first announcement. */}
+      <p
+        role="status"
+        className={cn(
+          'text-[11px] leading-[1.55] text-muted',
+          hint && 'border border-[var(--separator-strong)] bg-[var(--ink-softer)] px-3 py-2',
+        )}
+      >
+        {hint && (
+          <>
+            {hint.reason}.
+            {hint.action && <> Next step: <code>{hint.action}</code>.</>}
+          </>
+        )}
+      </p>
     </div>
   );
 }

--- a/web/components/admin/tts/EngineSelector.tsx
+++ b/web/components/admin/tts/EngineSelector.tsx
@@ -7,7 +7,7 @@
 // RadioOption pattern. Tailwind-only
 // (no inline styles — issue #50).
 import { cn } from '../../../lib/cn';
-import { ENGINE_META, engineStatus, type EngineAvailability } from './engineMeta';
+import { ENGINE_META, engineStatus, engineEnableHint, type EngineAvailability } from './engineMeta';
 
 interface EngineSelectorProps {
   // Currently selected engine id.
@@ -21,68 +21,79 @@ interface EngineSelectorProps {
 }
 
 export function EngineSelector({ value, engineIds, available, onChange, className }: EngineSelectorProps) {
+  const hint = engineEnableHint(value, available);
   return (
-    <div
-      role="radiogroup"
-      aria-label="Voice engine"
-      className={cn('grid grid-cols-2 gap-2.5 md:grid-cols-3', className)}
-    >
-      {engineIds.map(id => {
-        const meta = ENGINE_META[id];
-        const status = engineStatus(id, available);
-        const active = value === id;
-        return (
-          <button
-            key={id}
-            type="button"
-            role="radio"
-            aria-checked={active}
-            onClick={() => onChange(id)}
-            className={cn(
-              'grid cursor-pointer content-start gap-1.5 border p-3 text-left font-[inherit]',
-              active
-                ? 'border-[var(--accent)] bg-[var(--accent-soft)]'
-                : 'border-ink bg-transparent hover:bg-[var(--ink-softer)]',
-            )}
-          >
-            {/* Title row — dot + name only, full card width. The status badge
-                moved to the bottom row so it never crowds long engine names
-                (CHATTERBOX / POCKETTTS), matching the LLM ProviderSelector. */}
-            <div className="flex items-center gap-1.5">
-              <span
-                className={cn(
-                  'size-2 flex-none rounded-full border',
-                  active ? 'border-[var(--accent)] bg-[var(--accent)]' : 'border-ink bg-transparent',
-                )}
-              />
-              <span
-                className={cn(
-                  'min-w-0 text-[10px] font-bold tracking-[0.16em] break-words uppercase',
-                  active ? 'text-vermilion' : 'text-ink',
-                )}
-              >
-                {meta?.label || id}
-              </span>
-            </div>
-            {/* Bottom row — blurb on the left, status badge pinned bottom-right. */}
-            <div className="flex items-end justify-between gap-2">
-              <span className="min-w-0 text-[9px] leading-[1.4] text-muted">{meta?.blurb}</span>
-              {status.label && (
+    <div className={cn('grid gap-2.5', className)}>
+      <div
+        role="radiogroup"
+        aria-label="Voice engine"
+        className="grid grid-cols-2 gap-2.5 md:grid-cols-3"
+      >
+        {engineIds.map(id => {
+          const meta = ENGINE_META[id];
+          const status = engineStatus(id, available);
+          const active = value === id;
+          const isUnavailable = available?.[id] === false && status.label !== 'starting…';
+          return (
+            <button
+              key={id}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={() => onChange(id)}
+              className={cn(
+                'grid cursor-pointer content-start gap-1.5 border p-3 text-left font-[inherit]',
+                isUnavailable && !active && 'opacity-60',
+                active
+                  ? 'border-[var(--accent)] bg-[var(--accent-soft)]'
+                  : 'border-ink bg-transparent hover:bg-[var(--ink-softer)]',
+              )}
+            >
+              {/* Title row — dot + name only, full card width. The status badge
+                  moved to the bottom row so it never crowds long engine names
+                  (CHATTERBOX / POCKETTTS), matching the LLM ProviderSelector. */}
+              <div className="flex items-center gap-1.5">
                 <span
                   className={cn(
-                    'flex-none border px-1 py-[1px] text-[8px] font-bold tracking-[0.1em] uppercase',
-                    status.tone === 'warn'
-                      ? 'border-[var(--danger)] text-[var(--danger)]'
-                      : 'border-[color:var(--separator-strong)] text-muted',
+                    'size-2 flex-none rounded-full border',
+                    active ? 'border-[var(--accent)] bg-[var(--accent)]' : 'border-ink bg-transparent',
+                  )}
+                />
+                <span
+                  className={cn(
+                    'min-w-0 text-[10px] font-bold tracking-[0.16em] break-words uppercase',
+                    active ? 'text-vermilion' : 'text-ink',
                   )}
                 >
-                  {status.label}
+                  {meta?.label || id}
                 </span>
-              )}
-            </div>
-          </button>
-        );
-      })}
+              </div>
+              {/* Bottom row — blurb on the left, status badge pinned bottom-right. */}
+              <div className="flex items-end justify-between gap-2">
+                <span className="min-w-0 text-[9px] leading-[1.4] text-muted">{meta?.blurb}</span>
+                {status.label && (
+                  <span
+                    className={cn(
+                      'flex-none border px-1 py-[1px] text-[8px] font-bold tracking-[0.1em] uppercase',
+                      status.tone === 'warn'
+                        ? 'border-[var(--danger)] text-[var(--danger)]'
+                        : 'border-[color:var(--separator-strong)] text-muted',
+                    )}
+                  >
+                    {status.label}
+                  </span>
+                )}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+      {hint && (
+        <p role="status" className="border border-[var(--separator-strong)] bg-[var(--ink-softer)] px-3 py-2 text-[11px] leading-[1.55] text-muted">
+          {hint.reason}.
+          {hint.action && <> Next step: <code>{hint.action}</code>.</>}
+        </p>
+      )}
     </div>
   );
 }

--- a/web/components/admin/tts/engineMeta.ts
+++ b/web/components/admin/tts/engineMeta.ts
@@ -39,11 +39,12 @@ export interface EngineStatus {
 // null when it's unreachable / not in use.
 export interface EngineAvailability {
   heavyEnabled?: string[] | null;
+  cloudByProvider?: Record<string, boolean>;
   [engine: string]: boolean | string[] | null | Record<string, boolean> | undefined;
 }
 
 // Pure: derive an engine's status badge from the controller's availability map.
-// A missing/undefined flag means "not yet known / assumed up", so we only flag
+// A missing/undefined flag means 'not yet known / assumed up', so we only flag
 // a hard `=== false`. `warn` reads as the recoverable-problem tone (sidecar
 // down, engine disabled, no cloud key); `ok` is the quiet ready state.
 export function engineStatus(
@@ -81,5 +82,45 @@ export function engineStatus(
         : { label: 'ready', tone: 'ok' };
     default:
       return { label: '', tone: 'ok' };
+  }
+}
+
+export interface EngineEnableHint {
+  reason: string;
+  action?: string;
+}
+
+export function engineEnableHint(
+  id: string,
+  available: EngineAvailability | undefined,
+): EngineEnableHint | undefined {
+  const a = available || {};
+  switch (id) {
+    case 'kokoro':
+      return a.kokoro === false
+        ? { reason: 'Kokoro is not installed in the controller image' }
+        : undefined;
+    case 'chatterbox':
+    case 'pocket-tts': {
+      if (a[id] !== false) return undefined;
+      const enabled = Array.isArray(a.heavyEnabled) ? a.heavyEnabled : null;
+      if (enabled && enabled.includes(id)) {
+        return { reason: id + ' is enabled but its sidecar worker is still starting', action: 'wait for the tts-heavy health check, then reload' };
+      }
+      if (enabled) {
+        return { reason: id + ' is disabled by TTS_HEAVY_ENGINES', action: 'enable ' + id + ' in TTS_HEAVY_ENGINES and recreate tts-heavy' };
+      }
+      return { reason: 'tts-heavy sidecar is offline', action: 'docker compose --profile tts-heavy up -d' };
+    }
+    case 'cloud':
+      return a.cloud === false
+        ? { reason: 'no API key is configured for the selected provider', action: 'add it in Settings → Voice' }
+        : undefined;
+    case 'remote':
+      return a.remote === false
+        ? { reason: 'the remote TTS endpoint is unreachable', action: 'check its URL and service status in Settings → Voice' }
+        : undefined;
+    default:
+      return undefined;
   }
 }

--- a/web/components/admin/tts/engineMeta.ts
+++ b/web/components/admin/tts/engineMeta.ts
@@ -27,9 +27,24 @@ export const ENGINE_META: Record<string, EngineMeta> = Object.fromEntries(
 );
 
 export type EngineStatusTone = 'ok' | 'warn';
+// Machine-readable readiness, for logic; `label` is display copy and free to
+// change. 'off' = not usable right now (EngineSelector mutes the card);
+// 'starting' = transient, on its way up (badge only, no muting).
+export type EngineStatusState = 'ready' | 'starting' | 'off';
+
+// Why an engine isn't usable and the exact step that enables it. Shown by
+// EngineSelector as a persistent note when the *selected* engine isn't ready.
+export interface EngineEnableHint {
+  reason: string;
+  action?: string;
+}
+
 export interface EngineStatus {
   label: string;
   tone: EngineStatusTone;
+  state: EngineStatusState;
+  // Present whenever state !== 'ready'.
+  hint?: EngineEnableHint;
 }
 
 // The controller's availability map (SettingsResponse.tts.available). Most keys
@@ -43,10 +58,11 @@ export interface EngineAvailability {
   [engine: string]: boolean | string[] | null | Record<string, boolean> | undefined;
 }
 
-// Pure: derive an engine's status badge from the controller's availability map.
-// A missing/undefined flag means 'not yet known / assumed up', so we only flag
-// a hard `=== false`. `warn` reads as the recoverable-problem tone (sidecar
-// down, engine disabled, no cloud key); `ok` is the quiet ready state.
+// Pure: derive an engine's status (badge + machine state + enable hint) from
+// the controller's availability map, in one branch tree so the three can never
+// disagree. A missing/undefined flag means "not yet known / assumed up", so we
+// only flag a hard `=== false`. `warn` reads as the recoverable-problem tone
+// (sidecar down, engine disabled, no cloud key); `ok` is the quiet ready state.
 export function engineStatus(
   id: string,
   available: EngineAvailability | undefined,
@@ -54,73 +70,52 @@ export function engineStatus(
   const a = available || {};
   switch (id) {
     case 'piper':
-      return { label: 'ready', tone: 'ok' };
+      return { label: 'ready', tone: 'ok', state: 'ready' };
     case 'kokoro':
       return a.kokoro === false
-        ? { label: 'unavailable', tone: 'warn' }
-        : { label: 'ready', tone: 'ok' };
+        ? {
+            label: 'unavailable', tone: 'warn', state: 'off',
+            hint: { reason: 'Kokoro is not installed in the controller image' },
+          }
+        : { label: 'ready', tone: 'ok', state: 'ready' };
     case 'chatterbox':
     case 'pocket-tts': {
-      if (a[id] !== false) return { label: 'ready', tone: 'ok' };
+      if (a[id] !== false) return { label: 'ready', tone: 'ok', state: 'ready' };
       // Engine isn't ready. Use the sidecar's configured engine list to say
       // *why*: deliberately disabled vs still loading vs whole sidecar down.
+      const name = ENGINE_META[id]?.label || id;
       const enabled = Array.isArray(a.heavyEnabled) ? a.heavyEnabled : null;
       if (enabled) {
         return enabled.includes(id)
-          ? { label: 'starting…', tone: 'warn' } // enabled, weights still loading
-          : { label: 'engine off', tone: 'warn' }; // disabled via TTS_HEAVY_ENGINES
+          ? {
+              label: 'starting…', tone: 'warn', state: 'starting', // enabled, weights still loading
+              hint: { reason: `${name} is enabled but its sidecar worker is still starting`, action: 'wait for the tts-heavy health check, then reload' },
+            }
+          : {
+              label: 'engine off', tone: 'warn', state: 'off', // disabled via TTS_HEAVY_ENGINES
+              hint: { reason: `${name} is disabled by TTS_HEAVY_ENGINES`, action: `enable ${id} in TTS_HEAVY_ENGINES and recreate tts-heavy` },
+            };
       }
-      return { label: 'sidecar off', tone: 'warn' };
+      return {
+        label: 'sidecar off', tone: 'warn', state: 'off',
+        hint: { reason: 'The tts-heavy sidecar is offline', action: 'docker compose --profile tts-heavy up -d' },
+      };
     }
     case 'cloud':
       return a.cloud === false
-        ? { label: 'no key', tone: 'warn' }
-        : { label: 'key set', tone: 'ok' };
+        ? {
+            label: 'no key', tone: 'warn', state: 'off',
+            hint: { reason: 'No API key is configured for the selected provider', action: 'add it in Settings → Voice' },
+          }
+        : { label: 'key set', tone: 'ok', state: 'ready' };
     case 'remote':
       return a.remote === false
-        ? { label: 'unreachable', tone: 'warn' }
-        : { label: 'ready', tone: 'ok' };
+        ? {
+            label: 'unreachable', tone: 'warn', state: 'off',
+            hint: { reason: 'The remote TTS endpoint is unreachable', action: 'check its URL and service status in Settings → Voice' },
+          }
+        : { label: 'ready', tone: 'ok', state: 'ready' };
     default:
-      return { label: '', tone: 'ok' };
-  }
-}
-
-export interface EngineEnableHint {
-  reason: string;
-  action?: string;
-}
-
-export function engineEnableHint(
-  id: string,
-  available: EngineAvailability | undefined,
-): EngineEnableHint | undefined {
-  const a = available || {};
-  switch (id) {
-    case 'kokoro':
-      return a.kokoro === false
-        ? { reason: 'Kokoro is not installed in the controller image' }
-        : undefined;
-    case 'chatterbox':
-    case 'pocket-tts': {
-      if (a[id] !== false) return undefined;
-      const enabled = Array.isArray(a.heavyEnabled) ? a.heavyEnabled : null;
-      if (enabled && enabled.includes(id)) {
-        return { reason: id + ' is enabled but its sidecar worker is still starting', action: 'wait for the tts-heavy health check, then reload' };
-      }
-      if (enabled) {
-        return { reason: id + ' is disabled by TTS_HEAVY_ENGINES', action: 'enable ' + id + ' in TTS_HEAVY_ENGINES and recreate tts-heavy' };
-      }
-      return { reason: 'tts-heavy sidecar is offline', action: 'docker compose --profile tts-heavy up -d' };
-    }
-    case 'cloud':
-      return a.cloud === false
-        ? { reason: 'no API key is configured for the selected provider', action: 'add it in Settings → Voice' }
-        : undefined;
-    case 'remote':
-      return a.remote === false
-        ? { reason: 'the remote TTS endpoint is unreachable', action: 'check its URL and service status in Settings → Voice' }
-        : undefined;
-    default:
-      return undefined;
+      return { label: '', tone: 'ok', state: 'ready' };
   }
 }


### PR DESCRIPTION
## What

Rebase + revision of #702 by @MokipoCode (original commit preserved with authorship). Mutes unavailable engine cards in the TTS selector (persona + global default) and shows a persistent, accessible note below the grid when the selected engine is unavailable — with the reason and the exact enable step (`docker compose --profile tts-heavy up -d`, etc.).

Closes #585. Supersedes #702 (conflicted with develop after #759/#1009 touched `PersonaVoiceCard`).

## Why

#673 disabled unavailable cards, creating a catch-22: the inline setup guidance (#238) is gated on the engine being selected, so a greyed-out card hid the very steps needed to enable it. This keeps every card clickable, mutes unavailable ones, and adds a `role="status"` strip instead of a hover `title` — visible on touch and to screen readers.

## How

Original #702 changes, rebased:
- `EngineSelector.tsx`: unavailable cards muted (`opacity-60`) but always clickable; persistent note below the grid for the selected engine.
- `PersonaVoiceCard.tsx`: per-persona cloud availability via `cloudByProvider[provider]` (already exposed by the controller), not just the global flag; `openai-compatible` trusted.
- `types.ts`: `tts.available` typed as `EngineAvailability` instead of `Record<string, boolean>`.

Review fixes on top (second commit):
- **One status tree**: `engineEnableHint()` folded into `engineStatus()` — badge label, machine `state` (`ready | starting | off`) and hint come from a single branch tree and can't drift.
- **No label coupling**: muting keys off `state === 'off'` instead of `status.label !== 'starting…'`, so badge copy changes can't break logic.
- **Reliable live region**: the `role="status"` element stays mounted and toggles content — a region inserted on demand can miss its first announcement.
- Hint copy capitalized and uses display labels (Chatterbox / PocketTTS) instead of raw ids; reverted an unrelated comment-quote flip in `engineMeta.ts`.

## Tested

- `cd web && npm run lint`: clean (eslint + tsc).
- Both `EngineSelector` call sites (`PersonaVoiceCard`, settings `TtsSection`) pass `available`, so the hint strip works on both surfaces with no extra wiring.

AI disclosure: YES