### PR TITLE
feat(llm): OpenRouter app attribution headers

### DIFF
--- a/controller/src/llm/internal/provider/embedding.ts
+++ b/controller/src/llm/internal/provider/embedding.ts
@@ -18,7 +18,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createOllama } from 'ai-sdk-ollama';
 import * as settings from '../../../settings.js';
-import { llmCfg, ollamaBaseUrl, loccaEmbedBaseUrl } from './registry.js';
+import { llmCfg, ollamaBaseUrl, loccaEmbedBaseUrl, OPENROUTER_APP_HEADERS } from './registry.js';
 
 // Separate from the registry's language-model cache — the signature is prefixed
 // `embed|` so there's no key overlap, and keeping it local avoids exporting a
@@ -226,6 +226,7 @@ export function buildEmbeddingModel(cfg: EmbeddingCfg) {
         baseURL: 'https://openrouter.ai/api/v1',
         apiKey: cfg.apiKey || process.env.OPENROUTER_API_KEY || 'unused',
         name: 'openrouter',
+        headers: OPENROUTER_APP_HEADERS,
       });
       return provider.textEmbeddingModel(id);
     }

--- a/controller/src/llm/internal/provider/registry.ts
+++ b/controller/src/llm/internal/provider/registry.ts
@@ -231,6 +231,15 @@ export function loccaEmbedBaseUrl(cfg: any): string {
 // goes through createOpenAI with this base, keyed by REQUESTY_API_KEY.
 export const DEFAULT_REQUESTY_BASE_URL = 'https://router.requesty.ai/v1';
 
+// OpenRouter app attribution (openrouter.ai/docs/app-attribution): HTTP-Referer
+// is the app's identity in OpenRouter's rankings (required for an app page),
+// X-Title its display name. Sent on every OpenRouter request — chat, embeddings,
+// and the key-validation probes — so usage shows up as SUB/WAVE, not anonymous.
+export const OPENROUTER_APP_HEADERS = {
+  'HTTP-Referer': 'https://getsubwave.com',
+  'X-Title': 'SUB/WAVE',
+} as const;
+
 // Build a LanguageModel for any self-hosted OpenAI-compatible server (llama.cpp,
 // vLLM, LM Studio, locca). `.chat()` pins /v1/chat/completions — these servers
 // don't implement the Responses API the default `provider(id)` would target.
@@ -319,7 +328,7 @@ export function languageModel(cfg: any = llmCfg(), opts: { forceNoThink?: boolea
       break;
     }
     case 'openrouter': {
-      const provider = createOpenRouter({ fetch: debugFetch, ...(cfg.apiKey ? { apiKey: cfg.apiKey } : {}) });
+      const provider = createOpenRouter({ fetch: debugFetch, headers: OPENROUTER_APP_HEADERS, ...(cfg.apiKey ? { apiKey: cfg.apiKey } : {}) });
       // OpenRouter reads `reasoning` from construction settings, not per-call
       // providerOptions — so the toggle must be wired HERE or it's dead (we used
       // to pass nothing → models reasoned by default). We MINIMISE rather than

--- a/controller/src/llm/provider.ts
+++ b/controller/src/llm/provider.ts
@@ -11,6 +11,7 @@ export {
   loccaBaseUrl,
   DEFAULT_LOCCA_BASE_URL,
   DEFAULT_REQUESTY_BASE_URL,
+  OPENROUTER_APP_HEADERS,
   noThinkFetch,
 } from './internal/provider/registry.js';
 

--- a/controller/src/routes/onboarding.ts
+++ b/controller/src/routes/onboarding.ts
@@ -23,7 +23,7 @@ import { createDeepSeek } from '@ai-sdk/deepseek';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 
 import { requireAdmin } from '../middleware/auth.js';
-import { DEFAULT_LOCCA_BASE_URL, DEFAULT_REQUESTY_BASE_URL, noThinkFetch } from '../llm/provider.js';
+import { DEFAULT_LOCCA_BASE_URL, DEFAULT_REQUESTY_BASE_URL, OPENROUTER_APP_HEADERS, noThinkFetch } from '../llm/provider.js';
 import { config } from '../config.js';
 import * as settings from '../settings.js';
 import * as jingles from '../broadcast/jingles.js';
@@ -152,7 +152,7 @@ router.post('/onboarding/test-llm', requireAdmin, async (req, res) => {
         m = createDeepSeek(apiKey ? { apiKey } : {})(model);
         break;
       case 'openrouter':
-        m = createOpenRouter(apiKey ? { apiKey } : {})(model);
+        m = createOpenRouter({ headers: OPENROUTER_APP_HEADERS, ...(apiKey ? { apiKey } : {}) })(model);
         break;
       case 'requesty':
         // Requesty is an OpenAI-compatible gateway at a fixed base URL; the test

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -335,7 +335,7 @@ async function probeKey(
     case 'OPENROUTER_API_KEY': {
       try {
         const model = activeModel('openrouter') || 'openai/gpt-4o-mini';
-        const m = createOpenRouter({ apiKey: value })(model);
+        const m = createOpenRouter({ apiKey: value, headers: llmProvider.OPENROUTER_APP_HEADERS })(model);
         await generateText({ model: m, prompt: 'Reply with the single word OK.', maxOutputTokens: 32, abortSignal: AbortSignal.timeout(15000) });
         return { ok: true, message: `✓ OpenRouter key valid · model responded` };
       } catch (err) { return { ok: false, message: briefLlmError(err) }; }


### PR DESCRIPTION
## What

Sends OpenRouter's [app-attribution headers](https://openrouter.ai/docs/app-attribution) on every request the controller makes to OpenRouter, so usage shows up in OpenRouter's rankings/analytics as **SUB/WAVE** instead of anonymous:

- `HTTP-Referer: https://getsubwave.com` — the app's identity in rankings (required for an app page)
- `X-Title: SUB/WAVE` — the display name

## How

One shared `OPENROUTER_APP_HEADERS` constant in `llm/internal/provider/registry.ts`, re-exported through the stable `llm/provider.js` barrel, applied at all four OpenRouter construction sites:

- the chat model builder (`registry.ts`, `createOpenRouter`)
- the embeddings transport (`embedding.ts`, `createOpenAI` against `openrouter.ai/api/v1`)
- the two key-validation probes (`routes/settings.ts`, `routes/onboarding.ts`)

Construction-time wiring only — no per-call changes, no behavior change for any other provider.

## Verification

`npm run lint` in `controller/` passes (eslint 0 errors, `tsc --noEmit` clean).