### PR TITLE
feat(admin): speak the persona's language in the voice Play sample

### DIFF
--- a/controller/scripts/preview-text.test.ts
+++ b/controller/scripts/preview-text.test.ts
@@ -1,0 +1,61 @@
+// Unit tests for the localized "Play sample" sentence lookup
+// (audio/preview-text.ts). The persona `language` field is free operator
+// text, so the pins cover the three key shapes — English name, native name
+// (with diacritics), ISO code — plus the fallback contract: unknown or empty
+// language returns null so the caller keeps the English default.
+// Run: `npm test -- preview-text` (tsx scripts/preview-text.test.ts).
+
+import assert from 'node:assert/strict';
+import { localizedPreviewText } from '../src/audio/preview-text.js';
+
+let failures = 0;
+function test(name: string, fn: () => void | Promise<void>) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => console.log(`  ✓ ${name}`))
+    .catch((err) => { failures++; console.error(`  ✗ ${name}\n      ${err?.message || err}`); });
+}
+
+async function main() {
+  console.log('match shapes:');
+  await test('English language name matches', () => {
+    assert.equal(localizedPreviewText('Turkish'), 'SUB/WAVE dinliyorsunuz. Bu bir ses önizlemesidir.');
+  });
+  await test('native name with diacritics matches (Türkçe → turkce)', () => {
+    assert.equal(localizedPreviewText('Türkçe'), localizedPreviewText('Turkish'));
+  });
+  await test('ISO 639-1 code matches', () => {
+    assert.equal(localizedPreviewText('tr'), localizedPreviewText('Turkish'));
+  });
+  await test('case and surrounding whitespace are ignored', () => {
+    assert.equal(localizedPreviewText('  SPANISH '), localizedPreviewText('es'));
+  });
+  await test('non-Latin native names match (日本語, हिन्दी)', () => {
+    assert.equal(localizedPreviewText('日本語'), localizedPreviewText('Japanese'));
+    assert.equal(localizedPreviewText('हिन्दी'), localizedPreviewText('hi'));
+  });
+
+  console.log('fallback contract:');
+  await test('empty / undefined → null (caller uses the English default)', () => {
+    assert.equal(localizedPreviewText(''), null);
+    assert.equal(localizedPreviewText(undefined), null);
+  });
+  await test('unrecognized language → null', () => {
+    assert.equal(localizedPreviewText('Klingon'), null);
+  });
+  await test('explicit English still matches instead of reading as unknown', () => {
+    assert.equal(localizedPreviewText('English'), "You're listening to SUB/WAVE. This is a voice preview.");
+  });
+
+  console.log('table invariants:');
+  await test('every sample keeps the station name untranslated', () => {
+    for (const lang of ['Spanish', 'French', 'German', 'Japanese', 'Chinese', 'Arabic', 'Hebrew', 'Hindi', 'Punjabi']) {
+      const sample = localizedPreviewText(lang);
+      assert.ok(sample && sample.includes('SUB/WAVE'), `${lang} sample must mention SUB/WAVE verbatim`);
+    }
+  });
+
+  process.exit(failures ? 1 : 0);
+}
+
+main();

--- a/controller/src/audio/preview-text.ts
+++ b/controller/src/audio/preview-text.ts
@@ -1,0 +1,102 @@
+// Localized sample sentences for the admin "Play sample" button. A persona's
+// `language` is free operator text ("Turkish", "Türkçe", "tr", …), so the
+// lookup normalizes (lowercase, diacritics stripped) and matches the English
+// name, native name(s), and ISO 639-1 code. Unknown or empty language → null,
+// and the caller falls back to the English default sentence.
+//
+// Deliberately a static table, NOT an LLM translation call: the audition
+// button must stay instant and keep working with the model down. "SUB/WAVE"
+// stays untranslated in every entry — same proper-noun rule as the on-air
+// languageDirective (issue #349).
+
+interface PreviewEntry {
+  // Normalized match keys: english name, native name(s), ISO 639-1 code.
+  keys: string[];
+  sample: string;
+}
+
+const ENTRIES: PreviewEntry[] = [
+  { keys: ['spanish', 'espanol', 'castellano', 'es'],
+    sample: 'Estás escuchando SUB/WAVE. Esta es una prueba de voz.' },
+  { keys: ['french', 'francais', 'fr'],
+    sample: 'Vous écoutez SUB/WAVE. Ceci est un essai de voix.' },
+  { keys: ['german', 'deutsch', 'de'],
+    sample: 'Du hörst SUB/WAVE. Dies ist eine Sprachvorschau.' },
+  { keys: ['italian', 'italiano', 'it'],
+    sample: "Stai ascoltando SUB/WAVE. Questa è un'anteprima vocale." },
+  { keys: ['portuguese', 'portugues', 'brazilian portuguese', 'pt', 'pt-br'],
+    sample: 'Você está ouvindo SUB/WAVE. Esta é uma amostra de voz.' },
+  { keys: ['dutch', 'nederlands', 'nl'],
+    sample: 'Je luistert naar SUB/WAVE. Dit is een stemvoorbeeld.' },
+  { keys: ['turkish', 'turkce', 'tr'],
+    sample: 'SUB/WAVE dinliyorsunuz. Bu bir ses önizlemesidir.' },
+  { keys: ['polish', 'polski', 'pl'],
+    sample: 'Słuchasz SUB/WAVE. To jest próbka głosu.' },
+  { keys: ['russian', 'russkij', 'русский', 'ru'],
+    sample: 'Вы слушаете SUB/WAVE. Это образец голоса.' },
+  { keys: ['ukrainian', 'украинська', 'українська', 'uk'],
+    sample: 'Ви слухаєте SUB/WAVE. Це зразок голосу.' },
+  { keys: ['czech', 'cestina', 'cs'],
+    sample: 'Posloucháte SUB/WAVE. Toto je ukázka hlasu.' },
+  { keys: ['swedish', 'svenska', 'sv'],
+    sample: 'Du lyssnar på SUB/WAVE. Det här är ett röstprov.' },
+  { keys: ['norwegian', 'norsk', 'no', 'nb'],
+    sample: 'Du hører på SUB/WAVE. Dette er en stemmeprøve.' },
+  { keys: ['danish', 'dansk', 'da'],
+    sample: 'Du lytter til SUB/WAVE. Dette er en stemmeprøve.' },
+  { keys: ['finnish', 'suomi', 'fi'],
+    sample: 'Kuuntelet SUB/WAVE-kanavaa. Tämä on ääninäyte.' },
+  { keys: ['greek', 'ellinika', 'ελληνικα', 'el'],
+    sample: 'Ακούτε το SUB/WAVE. Αυτή είναι μια δοκιμή φωνής.' },
+  { keys: ['romanian', 'romana', 'ro'],
+    sample: 'Ascultați SUB/WAVE. Aceasta este o mostră de voce.' },
+  { keys: ['hungarian', 'magyar', 'hu'],
+    sample: 'A SUB/WAVE adását hallgatod. Ez egy hangminta.' },
+  { keys: ['japanese', 'nihongo', '日本語', 'ja'],
+    sample: 'SUB/WAVEをお聴きいただいています。これは音声プレビューです。' },
+  { keys: ['chinese', 'mandarin', 'zhongwen', '中文', '普通话', 'zh', 'zh-cn'],
+    sample: '您正在收听 SUB/WAVE。这是一段语音试听。' },
+  { keys: ['korean', 'hangugeo', '한국어', 'ko'],
+    sample: 'SUB/WAVE를 듣고 계십니다. 이것은 음성 미리듣기입니다.' },
+  { keys: ['hindi', 'हिन्दी', 'हिंदी', 'hi'],
+    sample: 'आप SUB/WAVE सुन रहे हैं। यह एक आवाज़ का नमूना है।' },
+  { keys: ['punjabi', 'panjabi', 'ਪੰਜਾਬੀ', 'pa'],
+    sample: 'ਤੁਸੀਂ SUB/WAVE ਸੁਣ ਰਹੇ ਹੋ। ਇਹ ਇੱਕ ਆਵਾਜ਼ ਦਾ ਨਮੂਨਾ ਹੈ।' },
+  { keys: ['arabic', 'العربية', 'ar'],
+    sample: 'أنت تستمع إلى SUB/WAVE. هذه معاينة صوتية.' },
+  { keys: ['hebrew', 'עברית', 'he'],
+    sample: 'אתם מאזינים ל-SUB/WAVE. זוהי דוגמת קול.' },
+  { keys: ['vietnamese', 'tieng viet', 'vi'],
+    sample: 'Bạn đang nghe SUB/WAVE. Đây là bản nghe thử giọng nói.' },
+  { keys: ['thai', 'ไทย', 'th'],
+    sample: 'คุณกำลังฟัง SUB/WAVE นี่คือตัวอย่างเสียง' },
+  { keys: ['indonesian', 'bahasa indonesia', 'id'],
+    sample: 'Anda sedang mendengarkan SUB/WAVE. Ini adalah contoh suara.' },
+  // English is the DEFAULT_PREVIEW_TEXT fallback, but an explicit "English"
+  // should still match rather than looking like an unknown language.
+  { keys: ['english', 'en', 'en-gb', 'en-us'],
+    sample: "You're listening to SUB/WAVE. This is a voice preview." },
+];
+
+// "Türkçe" → "turkce": lowercase, strip combining marks, collapse whitespace.
+function normalizeLanguage(raw: string): string {
+  return raw
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const LOOKUP = new Map<string, string>();
+for (const entry of ENTRIES) {
+  for (const key of entry.keys) LOOKUP.set(normalizeLanguage(key), entry.sample);
+}
+
+// The localized preview sentence for a persona's free-text `language`, or
+// null when the language is empty/unrecognized (caller keeps the English
+// default — same behaviour those personas had before this table existed).
+export function localizedPreviewText(language?: string): string | null {
+  if (!language || typeof language !== 'string') return null;
+  return LOOKUP.get(normalizeLanguage(language)) ?? null;
+}

--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -12,6 +12,7 @@ import * as pocketTts from './pocketTts.js';
 import { heavyEnabledEngines } from './ttsHeavyClient.js';
 import * as remoteTts from './remoteTts.js';
 import { normalizeForSpeech } from './speech-text.js';
+import { localizedPreviewText } from './preview-text.js';
 import * as cloud from '../llm/speech.js';
 import { stripThinking } from '../llm/sdk.js';
 import * as settings from '../settings.js';
@@ -247,12 +248,17 @@ const PREVIEW_TEXT_MAX = 200;
 const DEFAULT_PREVIEW_TEXT = "You're listening to SUB/WAVE. This is a voice preview.";
 
 export async function synthesizeSample(
-  { engine, voice = '', cloudProvider = 'openai', speed, lang, text, voiceSettings }: {
+  { engine, voice = '', cloudProvider = 'openai', speed, lang, language, text, voiceSettings }: {
     engine: string;
     voice?: string;
     cloudProvider?: string;
     speed?: number;
     lang?: string;
+    // Persona's free-text on-air language ("Turkish", "Türkçe"). When set and
+    // no explicit `text` is given, the sample sentence is looked up in that
+    // language (preview-text.ts) so the audition matches what the persona
+    // sounds like on air; unrecognized/empty falls back to the English line.
+    language?: string;
     text?: string;
     // Unsaved ElevenLabs voice_settings sliders to audition (issue #696) —
     // same field names as settings.tts.cloud so they merge straight into the
@@ -266,7 +272,9 @@ export async function synthesizeSample(
   },
 ): Promise<string> {
   if (!ENGINES.includes(engine)) throw new Error(`Unknown engine: ${engine}`);
-  const raw = (typeof text === 'string' && text.trim()) ? text.trim() : DEFAULT_PREVIEW_TEXT;
+  const raw = (typeof text === 'string' && text.trim())
+    ? text.trim()
+    : (localizedPreviewText(language) ?? DEFAULT_PREVIEW_TEXT);
   const sample = normalizeForSpeech(raw.slice(0, PREVIEW_TEXT_MAX), settings.get().tts?.corrections);
   const scale = settings.clampTtsSpeed(speed);
   // Clamp the audition voice_settings to ElevenLabs' [0,1] the same way

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -468,7 +468,9 @@ router.post('/settings/secrets/test', requireAdmin, async (req, res) => {
 // POST /settings/tts/preview — synthesize a short sample in an EXPLICIT engine +
 // voice (not the on-air persona) so the admin "Play sample" button can audition
 // a voice/speed before saving. Body: { engine, voice?, cloudProvider?, speed?,
-// lang?, text?, voiceSettings? } — voiceSettings carries UNSAVED ElevenLabs
+// lang?, language?, text?, voiceSettings? } — `language` is the persona's
+// free-text on-air language; when set (and no explicit text), the sample
+// sentence is rendered in that language. voiceSettings carries UNSAVED ElevenLabs
 // slider values (issue #696) so the operator can tune the expressive knobs by
 // ear before saving; synthesizeSample clamps them like settings.update() does.
 // On success streams the rendered WAV (audio/wav). On a synth
@@ -490,6 +492,7 @@ router.post('/settings/tts/preview', requireAdmin, async (req, res) => {
       cloudProvider: typeof body.cloudProvider === 'string' ? body.cloudProvider : 'openai',
       speed: typeof body.speed === 'number' ? body.speed : undefined,
       lang: typeof body.lang === 'string' ? body.lang : undefined,
+      language: typeof body.language === 'string' ? body.language : undefined,
       text: typeof body.text === 'string' ? body.text : undefined,
       voiceSettings: (body.voiceSettings && typeof body.voiceSettings === 'object')
         ? body.voiceSettings

--- a/web/components/admin/personas/PersonaVoiceCard.tsx
+++ b/web/components/admin/personas/PersonaVoiceCard.tsx
@@ -117,7 +117,7 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
                   groups={groups}
                   title="Piper voice"
                   placeholder="Built-in default voice"
-                  preview={{ engine: 'piper', speed: persona.tts.speed, adminFetch }}
+                  preview={{ engine: 'piper', speed: persona.tts.speed, language: persona.language, adminFetch }}
                 />
                 <div className="field-hint">
                   Piper is fast, local, and keyless. Drop a voice’s <code>.onnx</code> and its{' '}
@@ -173,7 +173,7 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
                       ],
                     }]}
                     title="Kokoro voice"
-                    preview={{ engine: 'kokoro', speed: persona.tts.speed, adminFetch }}
+                    preview={{ engine: 'kokoro', speed: persona.tts.speed, language: persona.language, adminFetch }}
                   />
                 </div>
                 <div className="field-hint">The kokoro-onnx voice id for this persona.</div>
@@ -214,7 +214,7 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
                   }]}
                   title="Chatterbox reference voice"
                   placeholder="Built-in default voice"
-                  preview={{ engine: 'chatterbox', speed: persona.tts.speed, adminFetch }}
+                  preview={{ engine: 'chatterbox', speed: persona.tts.speed, language: persona.language, adminFetch }}
                 />
                 <div className="field-hint">
                   ~5s of clean speech is enough to clone a voice. Drop WAVs into{' '}
@@ -280,7 +280,7 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
                       : []),
                   ]}
                   title="PocketTTS voice"
-                  preview={{ engine: 'pocket-tts', speed: persona.tts.speed, adminFetch }}
+                  preview={{ engine: 'pocket-tts', speed: persona.tts.speed, language: persona.language, adminFetch }}
                 />
                 <div className="field-hint">
                   CPU-only, ~6× real-time. Built-in voices cover English, French, German,
@@ -423,11 +423,13 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
               voice={persona.tts.voice}
               cloudProvider={persona.tts.cloudProvider}
               speed={persona.tts.speed}
+              language={persona.language}
               adminFetch={adminFetch}
             />
             <div className="field-hint mt-1.5">
-              Plays a short sample in this persona&apos;s voice. Reflects the voice
-              and speed; the dB trim is applied later, on air.
+              Plays a short sample in this persona&apos;s voice — and language,
+              when one is set. Reflects the voice and speed; the dB trim is
+              applied later, on air.
             </div>
           </div>
         </div>

--- a/web/components/admin/tts/VoicePicker.tsx
+++ b/web/components/admin/tts/VoicePicker.tsx
@@ -55,6 +55,9 @@ export interface VoicePickerPreviewParams {
   cloudProvider?: string;
   speed?: number;
   lang?: string;
+  // Persona's free-text on-air language — the server renders the sample
+  // sentence in this language when it recognizes it.
+  language?: string;
   adminFetch: AdminAuth['adminFetch'];
 }
 
@@ -120,6 +123,7 @@ export function VoicePicker({
       cloudProvider: preview.cloudProvider,
       speed: preview.speed,
       lang: preview.lang,
+      language: preview.language,
     });
     // Another row (or a close) superseded this request while it was in flight.
     if (seq !== seqRef.current) return;

--- a/web/components/admin/tts/VoicePreviewButton.tsx
+++ b/web/components/admin/tts/VoicePreviewButton.tsx
@@ -35,6 +35,9 @@ interface VoicePreviewButtonProps {
   speed?: number;
   // Kokoro phonemizer language override (e.g. "en-gb", "ja").
   lang?: string;
+  // Persona's free-text on-air language ("Turkish", "Türkçe") — the server
+  // renders the sample sentence in this language when it recognizes it.
+  language?: string;
   // Unsaved ElevenLabs voice_settings sliders (issue #696) — sent so the sample
   // auditions the CURRENT slider positions, not the last-saved values. Only
   // meaningful when engine is 'cloud' with the elevenlabs provider; the server
@@ -53,7 +56,7 @@ interface VoicePreviewButtonProps {
 type PreviewState = 'idle' | 'loading' | 'error';
 
 export function VoicePreviewButton({
-  engine, voice, cloudProvider, speed, lang, voiceSettings, adminFetch, disabled, className,
+  engine, voice, cloudProvider, speed, lang, language, voiceSettings, adminFetch, disabled, className,
 }: VoicePreviewButtonProps) {
   const [state, setState] = useState<PreviewState>('idle');
   const [error, setError] = useState<string | null>(null);
@@ -81,7 +84,7 @@ export function VoicePreviewButton({
     discardSample();
     setState('idle');
     setError(null);
-  }, [engine, voice, cloudProvider, speed, lang, discardSample]);
+  }, [engine, voice, cloudProvider, speed, lang, language, discardSample]);
 
   const onClick = async () => {
     // Re-click while synthesizing cancels the request.
@@ -94,7 +97,7 @@ export function VoicePreviewButton({
     try {
       const res = await fetchPreviewSample(
         adminFetch,
-        { engine, voice, cloudProvider, speed, lang, voiceSettings },
+        { engine, voice, cloudProvider, speed, lang, language, voiceSettings },
         ac.signal,
       );
       if (ac.signal.aborted) return;

--- a/web/components/admin/tts/previewApi.ts
+++ b/web/components/admin/tts/previewApi.ts
@@ -16,6 +16,11 @@ export interface PreviewParams {
   speed?: number;
   // Kokoro phonemizer language override (e.g. "en-gb", "ja").
   lang?: string;
+  // Persona's free-text on-air language ("Turkish", "Türkçe"). When set, the
+  // server renders the sample sentence in that language (falling back to the
+  // English line if it doesn't recognize it), so the audition matches what
+  // the persona sounds like on air.
+  language?: string;
   // Unsaved ElevenLabs voice_settings sliders (issue #696) — sent so the
   // sample auditions the CURRENT slider positions, not the last-saved values.
   voiceSettings?: {


### PR DESCRIPTION
## What

The persona editor's **Play sample** button always spoke the hard-coded English preview line ("You're listening to SUB/WAVE. This is a voice preview."), even for personas with an on-air `language` set — that field only ever reached the LLM prompt (`languageDirective`), never the TTS preview. So auditioning a Turkish persona played English.

## How

- **New pure module `controller/src/audio/preview-text.ts`** — maps the persona's free-text language (English name, native name, or ISO 639-1 code; case/diacritics-insensitive, so "Türkçe", "turkish" and "tr" all hit) to a localized sample sentence. ~29 languages; `SUB/WAVE` stays untranslated in every entry (the issue #349 proper-noun rule). Unknown/empty language → `null` → the English default, i.e. exactly today's behaviour.
- Deliberately a **static table, not an LLM translation call** — the audition button stays instant and keeps working with the model down.
- `POST /settings/tts/preview` accepts a `language` body param; `tts.synthesizeSample` resolves the sample text from it when no explicit `text` is supplied.
- Web: `language` threads through `PreviewParams` → `VoicePreviewButton` / `VoicePicker` per-row previews; `PersonaVoiceCard` passes `persona.language` on the main button **and** every voice-picker row, and a rendered sample is discarded as stale when the language changes. The field hint now says the sample reflects the language too.

## Testing

- New `controller/scripts/preview-text.test.ts` (auto-discovered by `npm test`): match shapes (English/native/ISO, diacritics, non-Latin names), the null fallback contract, and the untranslated-station-name invariant — 9/9 passing.
- `npm run lint` clean in both `controller/` and `web/` (0 errors).