### PR TITLE
feat(broadcast): idle-pause the programme when nobody is listening

### DIFF
--- a/controller/scripts/stream-idle.test.ts
+++ b/controller/scripts/stream-idle.test.ts
@@ -1,0 +1,110 @@
+// Unit tests for the pure idle-pause transition helper in
+// broadcast/stream-idle-pure.ts. Run: `tsx scripts/stream-idle.test.ts`
+// (folded into `npm run test`).
+//
+// nextIdleState decides when the programme idle-pauses (zero listeners for
+// the configured window) and when it resumes. The branching is
+// regression-critical: too eager and a zero-blip between listeners silences
+// a live station; too lax and the wake-on-connect never fires, leaving a
+// tuned-in listener staring at silence. node:assert-via-tsx style, matching
+// listeners-status.test.ts.
+
+import assert from 'node:assert/strict';
+import { nextIdleState, type IdleState } from '../src/broadcast/stream-idle-pure.js';
+
+let failures = 0;
+function test(name: string, fn: () => void | Promise<void>) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => console.log(`  ✓ ${name}`))
+    .catch((err) => { failures++; console.error(`  ✗ ${name}\n      ${err?.message || err}`); });
+}
+
+const LIVE: IdleState = { idle: false, zeroSince: null };
+const IDLE: IdleState = { idle: true, zeroSince: null };
+const AFTER = 10 * 60_000; // 10 min window
+const T0 = 1_000_000;
+
+async function main() {
+  console.log('nextIdleState (idle-pause transitions):');
+
+  await test('disabled toggle is inert while live', () => {
+    const r = nextIdleState(LIVE, { enabled: false, count: 0, now: T0, idleAfterMs: AFTER });
+    assert.equal(r.action, null);
+    assert.deepEqual(r.state, LIVE);
+  });
+
+  await test('disabling the toggle mid-pause resumes the programme', () => {
+    const r = nextIdleState(IDLE, { enabled: false, count: 0, now: T0, idleAfterMs: AFTER });
+    assert.equal(r.action, 'resume');
+    assert.equal(r.state.idle, false);
+  });
+
+  await test('first zero sample starts the empty clock, no action', () => {
+    const r = nextIdleState(LIVE, { enabled: true, count: 0, now: T0, idleAfterMs: AFTER });
+    assert.equal(r.action, null);
+    assert.equal(r.state.idle, false);
+    assert.equal(r.state.zeroSince, T0);
+  });
+
+  await test('still-empty before the window elapses stays live', () => {
+    const armed: IdleState = { idle: false, zeroSince: T0 };
+    const r = nextIdleState(armed, { enabled: true, count: 0, now: T0 + AFTER - 1, idleAfterMs: AFTER });
+    assert.equal(r.action, null);
+    assert.equal(r.state.idle, false);
+    assert.equal(r.state.zeroSince, T0); // clock keeps its original start
+  });
+
+  await test('window elapsed with the room still empty pauses', () => {
+    const armed: IdleState = { idle: false, zeroSince: T0 };
+    const r = nextIdleState(armed, { enabled: true, count: 0, now: T0 + AFTER, idleAfterMs: AFTER });
+    assert.equal(r.action, 'pause');
+    assert.equal(r.state.idle, true);
+  });
+
+  await test('a listener resets the empty clock', () => {
+    const armed: IdleState = { idle: false, zeroSince: T0 };
+    const r = nextIdleState(armed, { enabled: true, count: 2, now: T0 + AFTER, idleAfterMs: AFTER });
+    assert.equal(r.action, null);
+    assert.equal(r.state.zeroSince, null);
+  });
+
+  await test('an unknown count resets the empty clock (fail-open)', () => {
+    const armed: IdleState = { idle: false, zeroSince: T0 };
+    const r = nextIdleState(armed, { enabled: true, count: null, now: T0 + AFTER, idleAfterMs: AFTER });
+    assert.equal(r.action, null);
+    assert.equal(r.state.zeroSince, null);
+  });
+
+  await test('a listener connecting while idle resumes', () => {
+    const r = nextIdleState(IDLE, { enabled: true, count: 1, now: T0, idleAfterMs: AFTER });
+    assert.equal(r.action, 'resume');
+    assert.equal(r.state.idle, false);
+  });
+
+  await test('an unknown count while idle resumes (fail-open)', () => {
+    const r = nextIdleState(IDLE, { enabled: true, count: null, now: T0, idleAfterMs: AFTER });
+    assert.equal(r.action, 'resume');
+    assert.equal(r.state.idle, false);
+  });
+
+  await test('a still-empty room while idle re-asserts the gate', () => {
+    const r = nextIdleState(IDLE, { enabled: true, count: 0, now: T0, idleAfterMs: AFTER });
+    assert.equal(r.action, 'reassert');
+    assert.equal(r.state.idle, true);
+  });
+
+  await test('resume immediately after re-arms rather than instantly re-pausing', () => {
+    // After a resume the empty clock must be null — a stale zeroSince from
+    // before the pause would re-pause on the very next zero sample.
+    const resumed = nextIdleState(IDLE, { enabled: true, count: 1, now: T0, idleAfterMs: AFTER }).state;
+    const r = nextIdleState(resumed, { enabled: true, count: 0, now: T0 + 1, idleAfterMs: AFTER });
+    assert.equal(r.action, null);
+    assert.equal(r.state.idle, false);
+    assert.equal(r.state.zeroSince, T0 + 1); // clock restarts from now
+  });
+
+  process.exit(failures ? 1 : 0);
+}
+
+main();

--- a/controller/src/broadcast/liquidsoap-control.ts
+++ b/controller/src/broadcast/liquidsoap-control.ts
@@ -152,6 +152,25 @@ export async function streamStatus() {
   return /\bon\b/i.test(res);
 }
 
+// Pause / resume / query the idle gate (radio.liq `idle_gate`). Unlike
+// stream_off, the Icecast mounts stay up serving silence — new listeners
+// connect normally, which is what lets the stream-idle monitor wake the
+// programme when someone tunes in. Both commands are idempotent, so the
+// monitor can re-assert the desired state after a mixer restart.
+export async function idleOn() {
+  return sendCommand('idle_on', 2000);
+}
+
+export async function idleOff() {
+  return sendCommand('idle_off', 2000);
+}
+
+// Returns true when the idle gate is active. `idle_status` replies "on"/"off".
+export async function idleStatus() {
+  const res = await sendCommand('idle_status', 2000);
+  return /\bon\b/i.test(res);
+}
+
 interface DjQueueSnapshot {
   ids: Set<string>;
   // subsonic_id → Liquidsoap request id. First occurrence wins on the off

--- a/controller/src/broadcast/listeners.ts
+++ b/controller/src/broadcast/listeners.ts
@@ -202,11 +202,29 @@ export async function refresh() {
   return fetchCount();
 }
 
+// Set by broadcast/stream-idle.ts (via setStreamIdle) while the programme is
+// idle-paused — a flag pushed in rather than imported out, so listeners.ts
+// and stream-idle.ts don't form an import cycle.
+let streamIdle = false;
+
+export function setStreamIdle(v: boolean) {
+  streamIdle = v;
+}
+
+export function isStreamIdle() {
+  return streamIdle;
+}
+
 // True when autonomous DJ LLM work is allowed right now. When the pause toggle
 // is off, always true. When on, allowed only if at least one listener is
 // counted — an unknown count (Icecast unreachable) is treated as occupied so a
 // stats outage can never take the DJ off the air.
+//
+// An idle-paused stream blocks DJ calls regardless of the LLM toggle: the
+// voice queues aren't being pulled while the idle gate is up, so any WAV
+// written to say.txt/intro.txt would pile up and play back-to-back on resume.
 export function djCallsAllowed() {
+  if (streamIdle) return false;
   if (!settings.get()?.llm?.pauseWhenEmpty) return true;
   if (lastCount === null) return true;
   return lastCount > 0;

--- a/controller/src/broadcast/stream-idle-pure.ts
+++ b/controller/src/broadcast/stream-idle-pure.ts
@@ -1,0 +1,51 @@
+// Pure transition logic for the stream idle monitor (stream-idle.ts) —
+// separate file so scripts/stream-idle.test.ts can pin it without dragging
+// in the monitor's heavy imports (queue.ts → llm/tts/subsonic), same split
+// as programme-pure.ts.
+
+export type IdleAction = 'pause' | 'resume' | 'reassert' | null;
+
+export interface IdleState {
+  idle: boolean;
+  /** Epoch ms when the count first read 0 while live; null once occupied. */
+  zeroSince: number | null;
+}
+
+// Pure transition: current state + (toggle, freshest count, clock) → next
+// state and the telnet action to fire. `count` is null when Icecast couldn't
+// be read. The caller only commits the returned state once the action's
+// telnet call succeeds, so a dropped command self-heals on the next tick.
+//
+// Regression-critical branches:
+//   • fail-open — an unknown count can never hold the station silent;
+//   • reassert — a mixer restart mid-pause always boots live, so the monitor
+//     re-sends idle_on (idempotent) while the room stays empty;
+//   • the empty clock resets the moment anyone (or "unknown") shows up, so a
+//     brief zero blip between listeners never accumulates toward a pause.
+export function nextIdleState(
+  prev: IdleState,
+  input: { enabled: boolean; count: number | null; now: number; idleAfterMs: number },
+): { state: IdleState; action: IdleAction } {
+  const { enabled, count, now, idleAfterMs } = input;
+  if (!enabled) {
+    // Toggle off: make sure the gate is down if we raised it, then stand by.
+    return { state: { idle: false, zeroSince: null }, action: prev.idle ? 'resume' : null };
+  }
+  if (prev.idle) {
+    // Fail-open: an unknown count can't confirm the room is still empty —
+    // resume rather than hold a stream we can't observe.
+    if (count === null || count > 0) {
+      return { state: { idle: false, zeroSince: null }, action: 'resume' };
+    }
+    return { state: prev, action: 'reassert' };
+  }
+  if (count === 0) {
+    const zeroSince = prev.zeroSince ?? now;
+    if (now - zeroSince >= idleAfterMs) {
+      return { state: { idle: true, zeroSince: null }, action: 'pause' };
+    }
+    return { state: { idle: false, zeroSince }, action: null };
+  }
+  // Occupied (or unknown) — reset the empty clock.
+  return { state: { idle: false, zeroSince: null }, action: null };
+}

--- a/controller/src/broadcast/stream-idle.ts
+++ b/controller/src/broadcast/stream-idle.ts
@@ -1,0 +1,103 @@
+// Stream idle monitor — pause the programme while the room is empty.
+//
+// When settings.stream.idleWhenEmpty is on and Icecast has counted zero
+// listeners for idleAfterMinutes, flip radio.liq's idle gate (telnet
+// idle_on): the Icecast mounts stay up serving silence, but the music chain
+// stops being pulled — no track decode, no Navidrome downloads — frozen
+// mid-track. Because the mounts never disappear, any client (VLC, Sonos, the
+// web player) connects normally while idle; this monitor polls the listener
+// count every tick during the pause and resumes the programme (idle_off)
+// within seconds of the first connection, exactly where it froze.
+//
+// Contrast POST /stream-stop (stream_off), which tears the mounts down and
+// 404s new listeners — that's the operator's hard off-air switch; this is
+// the automatic power-save.
+//
+// Fail-open like djCallsAllowed: an unknown count (Icecast unreachable) can
+// never hold the station silent — an unobservable room resumes. Telnet
+// failures keep the current state and retry next tick. Idle state is not
+// persisted; a mixer restart always comes back live, and the monitor
+// re-asserts idle_on (idempotent) on its next tick while the room stays
+// empty. On controller boot the gate's state is adopted from Liquidsoap
+// (idle_status) so a controller restart mid-pause doesn't strand the flag.
+//
+// The transition logic lives in the pure nextIdleState()
+// (stream-idle-pure.ts) so the regression-critical branching (fail-open,
+// re-assert, the empty-clock reset) is unit-pinned in
+// scripts/stream-idle.test.ts.
+
+import * as settings from '../settings.js';
+import { getListenerCount, refresh, setStreamIdle } from './listeners.js';
+import { idleOn, idleOff, idleStatus } from './liquidsoap-control.js';
+import { queue } from './queue.js';
+import { nextIdleState, type IdleState } from './stream-idle-pure.js';
+
+// One tick every 5s: while live it just reads the 15s monitor's cached count
+// (entering idle is not latency-sensitive); while idle it forces a fresh
+// Icecast poll, so a new listener waits ≤ ~5s of silence before the music
+// resumes.
+const TICK_MS = 5000;
+
+let state: IdleState = { idle: false, zeroSince: null };
+
+// True while the programme is idle-paused. Read by GET /state so the player
+// UI can tell "silence because nobody's here" from "stream is broken".
+export function isIdle() {
+  return state.idle;
+}
+
+async function tick() {
+  const st = settings.get()?.stream;
+  const enabled = !!st?.idleWhenEmpty;
+  const idleAfterMin = Number(st?.idleAfterMinutes) >= 1 ? Number(st?.idleAfterMinutes) : 10;
+  // While idle, force a fresh Icecast poll — the 15s monitor cadence would
+  // add up to 15s to the wake-up. While live, the cached count is plenty.
+  const count = state.idle && enabled ? await refresh() : getListenerCount();
+  const { state: next, action } = nextIdleState(state, {
+    enabled,
+    count,
+    now: Date.now(),
+    idleAfterMs: idleAfterMin * 60_000,
+  });
+  try {
+    if (action === 'pause') {
+      await idleOn();
+      queue.log(
+        'scheduler',
+        `programme idle-paused — no listeners for ${idleAfterMin} min (mounts stay up, resumes on connect)`,
+      );
+    } else if (action === 'resume') {
+      await idleOff();
+      queue.log(
+        'scheduler',
+        count !== null && count > 0
+          ? 'programme resumed — listener connected'
+          : 'programme resumed — idle pause released',
+      );
+    } else if (action === 'reassert') {
+      await idleOn();
+    }
+  } catch {
+    return; // telnet unreachable — keep the current state, retry next tick
+  }
+  state = next;
+  setStreamIdle(next.idle);
+}
+
+export function startStreamIdleMonitor() {
+  void (async () => {
+    // Adopt the gate's actual state: a controller restart mid-pause must not
+    // leave Liquidsoap silent while we believe the programme is live.
+    try {
+      if (await idleStatus()) {
+        state = { idle: true, zeroSince: null };
+        setStreamIdle(true);
+      }
+    } catch {
+      /* Liquidsoap not up yet — start live; ticks reconcile from here */
+    }
+    setInterval(() => {
+      tick().catch(() => {});
+    }, TICK_MS);
+  })();
+}

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -11,6 +11,7 @@ import { getFullContext, geocodePlace } from '../context.js';
 import { queue } from '../broadcast/queue.js';
 import * as session from '../broadcast/session.js';
 import { getStreamStatus } from '../broadcast/listeners.js';
+import { isIdle } from '../broadcast/stream-idle.js';
 import { getSetupStatusSync } from '../setup/firstRun.js';
 import { getStationTimezone } from '../time.js';
 import { listThemesAnnotated, DEFAULT_THEME_ID } from '../themes.js';
@@ -401,6 +402,9 @@ router.get('/state', (req, res) => {
   res.json({
     ...snap,
     needsSetup: getSetupStatusSync().needsSetup,
+    // True while the idle gate has the programme paused (zero listeners) —
+    // lets clients tell "silence because the room is empty" from "broken".
+    streamIdle: isIdle(),
     theme: { active: activeThemeId },
     // Listener-player UI settings ride along with /state like the theme does,
     // so the player can flip them live on the next poll. Defaults off if

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -18,6 +18,7 @@ import { getFullContext } from './context.js';
 import { loadCuriosityLedger } from './skills/curiosity.js';
 import { startScheduler } from './broadcast/scheduler.js';
 import { startListenerMonitor } from './broadcast/listeners.js';
+import { startStreamIdleMonitor } from './broadcast/stream-idle.js';
 import { startAudienceMonitor } from './broadcast/audience.js';
 import { cors } from './middleware/cors.js';
 import { assertAdminConfigured } from './middleware/auth.js';
@@ -272,6 +273,7 @@ app.listen(config.server.port, async () => {
 
   queue.startWatcher();
   startListenerMonitor();
+  startStreamIdleMonitor();
   startAudienceMonitor().catch(err => console.error('[audience] init failed:', err.message));
   startScheduler();
   jingles

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -1046,6 +1046,15 @@ const DEFAULTS = {
     aacEnabled: false,
     aacBitrate: 192,
     bitrate: 192,
+    // Idle pause (broadcast/stream-idle.ts). When on, the controller flips
+    // radio.liq's idle gate after idleAfterMinutes with zero Icecast
+    // listeners: the mounts keep serving (silence), but the music chain
+    // stops being pulled — no track decode, no Navidrome downloads — and
+    // resumes mid-track within seconds of anyone connecting. Off by default:
+    // a radio that plays to an empty room is the product's default fiction,
+    // so going dark while unobserved is an explicit operator choice.
+    idleWhenEmpty: false,
+    idleAfterMinutes: 10,
   },
   // Per-track loudness normalisation (music/mix.ts gainForLoudness). targetLufs
   // is what every measured track is pulled toward; maxBoostDb caps the upward
@@ -1847,6 +1856,16 @@ export async function load() {
         typeof stored.stream?.bitrate === 'number' && MP3_BITRATE_SET.has(stored.stream.bitrate)
           ? stored.stream.bitrate
           : DEFAULTS.stream.bitrate,
+      idleWhenEmpty:
+        typeof stored.stream?.idleWhenEmpty === 'boolean'
+          ? stored.stream.idleWhenEmpty
+          : DEFAULTS.stream.idleWhenEmpty,
+      idleAfterMinutes:
+        Number.isInteger(stored.stream?.idleAfterMinutes) &&
+        stored.stream.idleAfterMinutes >= 1 &&
+        stored.stream.idleAfterMinutes <= 1440
+          ? stored.stream.idleAfterMinutes
+          : DEFAULTS.stream.idleAfterMinutes,
     },
     loudness: {
       targetLufs:
@@ -2988,6 +3007,20 @@ export async function update(patch) {
         next.stream.bitrate = v;
         restart = true;
       }
+    }
+    // Idle pause is enforced controller-side over telnet (broadcast/
+    // stream-idle.ts) — no Liquidsoap boot file, no mixer restart. Turning it
+    // off mid-idle is handled by the monitor's next tick, which resumes the
+    // programme.
+    if (st.idleWhenEmpty !== undefined) {
+      next.stream.idleWhenEmpty = !!st.idleWhenEmpty;
+    }
+    if (st.idleAfterMinutes !== undefined) {
+      const v = parseInt(st.idleAfterMinutes, 10);
+      if (!Number.isInteger(v) || v < 1 || v > 1440) {
+        throw new Error('stream.idleAfterMinutes must be an integer between 1 and 1440');
+      }
+      next.stream.idleAfterMinutes = v;
     }
   }
   if ('loudness' in patch) {

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -1280,6 +1280,29 @@ radio = smooth_add(
 emergency = single("/sounds/emergency.mp3")
 radio = fallback(track_sensitive=false, [radio, emergency])
 
+# ---------------------------------------------------------------------------
+# IDLE GATE — silence the programme while nobody is listening
+# ---------------------------------------------------------------------------
+# When the controller has seen zero Icecast listeners for a while it flips
+# idle_mode on (telnet idle_on / idle_off, registered below): the switch
+# selects blank() and the whole chain above — dj_queue, the auto playlist,
+# the cross buffer, the subhttp downloads from Navidrome — stops being
+# pulled, frozen mid-track. The Icecast mounts STAY UP serving silence, so
+# any client (VLC, Sonos, a browser) connects normally; the controller sees
+# the new listener on its next poll, flips idle_mode off, and playback
+# resumes exactly where it froze. Contrast stream_off (further down), which
+# tears the mounts down and 404s new listeners.
+# A plain blank() branch is safe here — the #660 CPU spin was specific to
+# the blank.skip operator, not a blank source.
+# Not persisted: a mixer restart always comes back live (mirrors stream_on);
+# the controller re-asserts idle over telnet if the room is still empty.
+idle_mode = ref(false)
+radio = switch(
+  id="idle_gate",
+  track_sensitive=false,
+  [({idle_mode()}, blank(id="idle_silence")), ({true}, radio)]
+)
+
 # NOTE: a `blank.skip(max_blank=5.0, radio)` used to sit here to skip >5s of
 # digital silence. It was REMOVED (#660). With no music in the chain — a fresh
 # install pre-onboarding, Navidrome down, or the auto playlist exhausted —
@@ -1702,6 +1725,45 @@ server.register(
   description="Report whether the station is on air (on/off)",
   usage="stream_status",
   fun(_) -> if stream_on() then "on" else "off" end
+)
+
+# Pause / resume the programme while keeping the mounts up (the idle gate
+# above). idle_on swaps the broadcast to silence without disconnecting
+# anyone; idle_off resumes mid-track. Driven by the controller's stream-idle
+# monitor when "pause the programme when nobody is listening" is enabled.
+# Both are idempotent and only log on an actual state change, so the
+# controller can re-assert the desired state cheaply after a mixer restart.
+server.register(
+  "idle_on",
+  description="Silence the programme while nobody listens (mounts stay up)",
+  usage="idle_on",
+  fun(_) -> begin
+    if not idle_mode() then
+      log("Idle gate ON via server command — programme paused, mounts stay up")
+    end
+    idle_mode := true
+    "OK"
+  end
+)
+
+server.register(
+  "idle_off",
+  description="Resume the programme after an idle pause",
+  usage="idle_off",
+  fun(_) -> begin
+    if idle_mode() then
+      log("Idle gate OFF via server command — programme resumed")
+    end
+    idle_mode := false
+    "OK"
+  end
+)
+
+server.register(
+  "idle_status",
+  description="Report whether the idle gate is active (on/off)",
+  usage="idle_status",
+  fun(_) -> if idle_mode() then "on" else "off" end
 )
 
 # Skip the currently playing track. `radio` is the final broadcast source;

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -122,6 +122,8 @@ export default function SettingsPanel() {
         aacEnabled: v.stream?.aacEnabled ?? false,
         aacBitrate: String(v.stream?.aacBitrate ?? 192),
         bitrate: String(v.stream?.bitrate ?? 192),
+        idleWhenEmpty: v.stream?.idleWhenEmpty ?? false,
+        idleAfterMinutes: String(v.stream?.idleAfterMinutes ?? 10),
       },
       loudness: {
         targetLufs: String(v.loudness?.targetLufs ?? -14),
@@ -752,6 +754,66 @@ export default function SettingsPanel() {
                 </div>
               </div>
             </Card>
+
+            {form && (
+              <Card title="Idle pause" sub="silence the programme when nobody is listening">
+                <div className="field">
+                  <Label>Pause when the room is empty</Label>
+                  <div className="flex items-center gap-2">
+                    <Seg
+                      options={[
+                        { id: 'on', label: 'On' },
+                        { id: 'off', label: 'Off' },
+                      ]}
+                      value={form.stream.idleWhenEmpty ? 'on' : 'off'}
+                      onChange={id =>
+                        setForm(f =>
+                          f ? { ...f, stream: { ...f.stream, idleWhenEmpty: id === 'on' } } : f,
+                        )
+                      }
+                    />
+                    <span className="text-[12px] text-muted">after</span>
+                    <Input
+                      className="mono-num w-24"
+                      type="number"
+                      step={1}
+                      min={1}
+                      max={1440}
+                      value={form.stream.idleAfterMinutes}
+                      onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                        setForm(f =>
+                          f
+                            ? { ...f, stream: { ...f.stream, idleAfterMinutes: e.target.value } }
+                            : f,
+                        )
+                      }
+                    />
+                    <span className="text-[12px] text-muted">min</span>
+                    <Btn
+                      sm
+                      onClick={() =>
+                        saveSettings({
+                          stream: {
+                            idleWhenEmpty: form.stream.idleWhenEmpty,
+                            idleAfterMinutes: parseInt(form.stream.idleAfterMinutes, 10),
+                          },
+                        })
+                      }
+                      disabled={busy}
+                    >
+                      Save
+                    </Btn>
+                  </div>
+                  <div className="field-hint">
+                    After this long with zero listeners the programme pauses mid-track and the DJ
+                    goes quiet — no track pulls from Navidrome, no LLM or TTS work. The stream
+                    mounts stay up, so any player (VLC, Sonos, the web player) connects normally;
+                    playback resumes where it left off within a few seconds of the first listener
+                    tuning in. Applies live — no mixer restart.
+                  </div>
+                </div>
+              </Card>
+            )}
 
             {form && (
               <Card title="Crossfade" sub="track transition overlap">

--- a/web/components/admin/settings/shared.tsx
+++ b/web/components/admin/settings/shared.tsx
@@ -163,6 +163,8 @@ export interface StreamForm {
   aacEnabled: boolean;
   aacBitrate: string;
   bitrate: string;
+  idleWhenEmpty: boolean;
+  idleAfterMinutes: string;
 }
 
 export type LoudnessSource = 'replaygain-then-measured' | 'replaygain' | 'measured';
@@ -229,6 +231,8 @@ export interface SettingsData {
       aacEnabled?: boolean;
       aacBitrate?: number;
       bitrate?: number;
+      idleWhenEmpty?: boolean;
+      idleAfterMinutes?: number;
     };
     loudness?: { targetLufs?: number; maxBoostDb?: number; source?: LoudnessSource };
     station?: string;


### PR DESCRIPTION
## What

Option B of the empty-room discussion: when nobody is listening, pause the *programme* instead of the LLM alone — while keeping the Icecast mounts up so any client can tune back in and wake it.

- **radio.liq idle gate** — an `idle_mode` ref + `switch` to `blank()` inserted after the emergency fallback. When idle, the whole chain above (dj_queue, auto playlist, cross buffer, subhttp downloads from Navidrome) stops being pulled and freezes mid-track. New telnet commands `idle_on` / `idle_off` / `idle_status`, idempotent, logging only on state change. A plain `blank()` branch is safe — the #660 CPU spin was specific to `blank.skip`.
- **`broadcast/stream-idle.ts` monitor** — 5s tick. Live: reads the 15s listener monitor's cached count and arms an empty-clock; after `idleAfterMinutes` of continuous zero it pauses. Idle: forces a fresh Icecast poll each tick, so the first listener (VLC, Sonos, web player — anything that connects to the still-up mounts) resumes the programme within ~5s, exactly where it froze. Fail-open: an unknown count never holds the station silent. Adopts the gate state from Liquidsoap on controller boot and re-asserts idle after a mixer restart (which always boots live).
- **DJ silenced while idle** — `djCallsAllowed()` returns false during the pause regardless of `llm.pauseWhenEmpty`, so no say.txt/intro.txt WAVs pile up against the un-pulled voice queues and dump on resume.
- **Settings** — `stream.idleWhenEmpty` (default **off**) + `stream.idleAfterMinutes` (default 10, 1–1440). Applied live over telnet; no mixer restart, no liquidsoap_*.txt boot file. Admin → Settings gets an “Idle pause” card next to Broadcast; `GET /state` exposes `streamIdle` so clients can tell “empty room” from “broken”.
- Pure transition logic in `stream-idle-pure.ts` (fail-open / re-assert / empty-clock-reset branches), pinned by `scripts/stream-idle.test.ts` — same split as `programme-pure.ts`.

## Not covered

- `POST /stream-stop` (`stream_off`) is untouched — that remains the operator's hard off-air switch that tears the mounts down.
- Manual operator actions (`/dj/*` runners) intentionally stay un-gated, matching the budget-gate convention; a WAV spoken mid-idle airs on resume.
- now-playing.json is left as-is while idle: the frozen track is what resumes, so the stale title is correct the moment audio returns.

## Verification

- `npm run lint` clean in `controller/` and `web/`; `npm test` — all 34 controller test files pass (incl. the 11 new transition cases).
- `liquidsoap --check` passes on the edited radio.liq (broadcast image).
- Runtime smoke test in a throwaway broadcast container: `idle_status→off`, `idle_on→OK`, `idle_status→on`, `idle_off→OK`; log shows `idle_gate` switching to `idle_silence` and back with transitions.

Prod note: the radio.liq change ships with the broadcast image — needs `up -d --build broadcast` (or a pulled image) like any mixer change.