### PR TITLE
feat(shows): timed schedule override — pin a show for N hours

### DIFF
--- a/controller/scripts/programme.test.ts
+++ b/controller/scripts/programme.test.ts
@@ -7,7 +7,7 @@
 // node:assert-via-tsx style, matching scripts/auto-pool.test.ts.
 
 import assert from 'node:assert/strict';
-import { showSpan, planFeature, beatWindow } from '../src/broadcast/programme-pure.js';
+import { showSpan, overrideSpan, planFeature, beatWindow } from '../src/broadcast/programme-pure.js';
 
 // A 7×24 grid with every slot null.
 function emptyWeek(): Record<number, (string | null)[]> {
@@ -131,6 +131,30 @@ function emptyWeek(): Record<number, (string | null)[]> {
       assert.equal(hits.length, 1, `offset ${offset}: exactly one */5 tick lands in the ${kind} window`);
     }
   }
+}
+
+// ── overrideSpan ─────────────────────────────────────────────────────────────
+// A timed takeover's window IS the episode: total = whole hours (rounded up),
+// index = hours elapsed since the pin, clamped inside the window.
+{
+  const HOUR = 3_600_000;
+  const t0 = 1_752_000_000_000;
+  const oneHour = { startedAt: t0, expiresAt: t0 + HOUR };
+  assert.deepEqual(overrideSpan(oneHour, t0), { index: 0, total: 1 }, '1h pin, at the start');
+  assert.deepEqual(overrideSpan(oneHour, t0 + HOUR - 1), { index: 0, total: 1 }, '1h pin, final minute');
+
+  const threeHours = { startedAt: t0, expiresAt: t0 + 3 * HOUR };
+  assert.deepEqual(overrideSpan(threeHours, t0 + HOUR / 2), { index: 0, total: 3 }, '3h pin, first hour');
+  assert.deepEqual(overrideSpan(threeHours, t0 + HOUR), { index: 1, total: 3 }, '3h pin, second hour');
+  assert.deepEqual(overrideSpan(threeHours, t0 + 3 * HOUR - 1), { index: 2, total: 3 }, '3h pin, final hour');
+
+  const ninetyMin = { startedAt: t0, expiresAt: t0 + 1.5 * HOUR };
+  assert.deepEqual(overrideSpan(ninetyMin, t0), { index: 0, total: 2 }, 'partial hours round the total up');
+  assert.deepEqual(overrideSpan(ninetyMin, t0 + 1.4 * HOUR), { index: 1, total: 2 }, '90min pin, past the hour mark');
+
+  // Ticks fractionally outside the window clamp instead of indexing off the end.
+  assert.deepEqual(overrideSpan(oneHour, t0 + HOUR + 1), { index: 0, total: 1 }, 'just past expiry clamps');
+  assert.deepEqual(overrideSpan(oneHour, t0 - 1), { index: 0, total: 1 }, 'just before start clamps');
 }
 
 console.log('programme.test.ts: all assertions passed');

--- a/controller/src/broadcast/programme-pure.ts
+++ b/controller/src/broadcast/programme-pure.ts
@@ -25,6 +25,21 @@ export function showSpan(schedule: any, day: number, hour: number): { index: num
   return { index: before, total: before + 1 + after };
 }
 
+// Episode span for a timed takeover (#930). A pinned show usually isn't in the
+// grid at the pinned hours, so showSpan can't see it — the override window
+// itself is the episode: total = the window rounded up to whole hours, index =
+// whole hours elapsed since the pin (clamped inside the window, so a tick
+// arriving fractionally past expiry can't index off the end).
+export function overrideSpan(
+  ov: { startedAt: number; expiresAt: number },
+  nowMs: number,
+): { index: number; total: number } {
+  const HOUR = 3_600_000;
+  const total = Math.max(1, Math.ceil((ov.expiresAt - ov.startedAt) / HOUR));
+  const index = Math.min(total - 1, Math.max(0, Math.floor((nowMs - ov.startedAt) / HOUR)));
+  return { index, total };
+}
+
 // Which beat a STATION-ZONE minute belongs to. The arc's placement is a
 // station-clock fact (":55 of the final hour" must be the show's closing
 // minutes), but crons fire on fixed process-local minutes — and station zones

--- a/controller/src/broadcast/programme.ts
+++ b/controller/src/broadcast/programme.ts
@@ -43,8 +43,18 @@ const INTRO_SUPPRESSES_HOURLY_MS = 45 * 60 * 1000;
 
 // Pure arc helpers live in programme-pure.ts (dependency-free, so the unit
 // test doesn't drag in the queue/settings graph) — re-exported for callers.
-import { showSpan, planFeature, beatWindow } from './programme-pure.js';
-export { showSpan, planFeature, beatWindow };
+import { showSpan, overrideSpan, planFeature, beatWindow } from './programme-pure.js';
+export { showSpan, overrideSpan, planFeature, beatWindow };
+
+// The episode's position/length at `now`. A live takeover (#930) IS the
+// episode — its window drives the arc, since the pinned show usually isn't in
+// the grid at these hours and showSpan can't see it. Otherwise the grid run.
+function episodeSpan(now: Date): { index: number; total: number } {
+  const ov = settings.getScheduleOverride(now.getTime());
+  if (ov) return overrideSpan(ov, now.getTime());
+  const { dow, hour } = zonedParts(now);
+  return showSpan(settings.get().schedule, dow, hour);
+}
 
 // The beat due at this moment on the STATION clock, for the scheduler's
 // 5-minute programme tick (see beatWindow for why crons can't fire on fixed
@@ -137,8 +147,7 @@ export async function ensurePlan(ctx: SessionContext, now = new Date()): Promise
   if (prog.status !== 'pending') return;
   if (!optionalSegmentsAllowed()) return;  // over budget — stay pending, retry later
 
-  const { dow, hour } = zonedParts(now);
-  const span = showSpan(settings.get().schedule, dow, hour);
+  const span = episodeSpan(now);
   // Span is measured from the show's FIRST hour: if the session rolled late
   // (controller boot mid-show), the remaining hours are what the plan covers.
   const hoursLeft = Math.max(1, span.total - span.index);
@@ -243,8 +252,7 @@ export async function featureTick(queue: QueueApi, ctx: SessionContext, now = ne
   const ep = activeEpisode(now);
   const prog = ep && session.getProgramme();
   if (!prog) return;
-  const { dow, hour } = zonedParts(now);
-  const span = showSpan(settings.get().schedule, dow, hour);
+  const span = episodeSpan(now);
   const beat = `feature:${span.index}`;
   if (prog.beats?.[beat]) return;
   if (!djCallsAllowed() || !optionalSegmentsAllowed()) return;
@@ -267,8 +275,7 @@ export async function runFeature(queue: QueueApi, ctx: SessionContext, { hourInd
   if (!show?.programme) throw new Error('no programme show is on air');
   const prog = session.getProgramme();
   const plan = prog?.plan || null;
-  const { dow, hour } = zonedParts(now);
-  const idx = hourIndex ?? showSpan(settings.get().schedule, dow, hour).index;
+  const idx = hourIndex ?? episodeSpan(now).index;
   const feature = planFeature(plan, idx);
   const topic = feature?.topic || show.topic || `the heart of "${show.name}"`;
   const kind = String(show.segmentSkill || '').trim() || feature?.kind || null;
@@ -301,8 +308,7 @@ export async function outroTick(queue: QueueApi, ctx: SessionContext, now = new 
   const ep = activeEpisode(now);
   const prog = ep && session.getProgramme();
   if (!prog || prog.beats?.outro) return;
-  const { dow, hour } = zonedParts(now);
-  const span = showSpan(settings.get().schedule, dow, hour);
+  const span = episodeSpan(now);
   if (span.index !== span.total - 1) return;  // not the final hour yet
   if (!djCallsAllowed() || !optionalSegmentsAllowed()) return;
   session.markProgrammeBeat('outro');

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -431,12 +431,14 @@ export async function runHourlyCheck() {
   });
 }
 
-async function hourlyCheck() {
-  // The top of the hour is the natural show boundary — roll the session here
-  // so a scheduled show starting/ending opens a fresh chat history even if no
-  // track happens to start right on the hour. getFullContext() stays inside the
-  // try — node-cron doesn't catch async throws, so an escape here would be an
-  // unhandled rejection.
+// Roll the DJ session against fresh context and run the boundary hooks —
+// episode plan, persona mic-pass, programme intro. This is the shared
+// boundary sequence: the hourly cron runs it at :00, and the schedule-override
+// routes (routes/shows.ts) fire it in the background so a takeover / early
+// cancel / expiry airs promptly instead of waiting for the next track or hour.
+// Every step traps its own errors — node-cron doesn't catch async throws, and
+// the route callers are fire-and-forget.
+export async function rollSessionNow() {
   let ctx: Awaited<ReturnType<typeof getFullContext>> | null = null;
   try {
     ctx = await getFullContext();
@@ -446,34 +448,42 @@ async function hourlyCheck() {
   }
   // If that roll crossed a persona boundary, air the two-voice mic-pass. It
   // does its own listener/budget gating and marks itself aired, so it's safe to
-  // call unconditionally here (whichever of this cron or a track-start rolls the
-  // session first drives it — the other no-ops). No ctx → the roll above didn't
-  // happen either; leave the handoff pending for the next call site.
-  if (ctx) {
-    // Plan the episode BEFORE the mic-pass so a persona handoff into a
-    // programme show can weave the episode angle into the greeting (the
-    // greeting doubles as the show's intro on a persona-change boundary).
-    try {
-      await programme.ensurePlan(ctx);
-    } catch (err) {
-      queue.log('error', `Programme plan failed: ${err.message}`);
-    }
-    try {
-      await djAgent.runPersonaHandoff(queue, ctx);
-    } catch (err) {
-      queue.log('error', `Persona handoff failed: ${err.message}`);
-    }
-    // Programme shows: open the episode. The intro owns the top of the show's
-    // first hour, so when it airs (now, or minutes ago via the track-start
-    // call site, or as the handoff greeting above) the generic time check
-    // stands down — the same one-talker-per-slot rule as issue #310.
-    try {
-      const introAired = await programme.onSessionSettled(queue, ctx);
-      if (introAired || programme.suppressHourly()) return;
-    } catch (err) {
-      queue.log('error', `Programme episode hook failed: ${err.message}`);
-    }
+  // call unconditionally here (whichever call site rolls the session first
+  // drives it — the others no-op). No ctx → the roll above didn't happen
+  // either; leave the handoff pending for the next call site.
+  if (!ctx) return { ctx: null, introAired: false };
+  // Plan the episode BEFORE the mic-pass so a persona handoff into a
+  // programme show can weave the episode angle into the greeting (the
+  // greeting doubles as the show's intro on a persona-change boundary).
+  try {
+    await programme.ensurePlan(ctx);
+  } catch (err) {
+    queue.log('error', `Programme plan failed: ${err.message}`);
   }
+  try {
+    await djAgent.runPersonaHandoff(queue, ctx);
+  } catch (err) {
+    queue.log('error', `Persona handoff failed: ${err.message}`);
+  }
+  // Programme shows: open the episode. The intro owns the top of the show's
+  // first hour, so when it airs (now, or minutes ago via the track-start
+  // call site, or as the handoff greeting above) the generic time check
+  // stands down — the same one-talker-per-slot rule as issue #310.
+  let introAired = false;
+  try {
+    introAired = await programme.onSessionSettled(queue, ctx);
+  } catch (err) {
+    queue.log('error', `Programme episode hook failed: ${err.message}`);
+  }
+  return { ctx, introAired };
+}
+
+async function hourlyCheck() {
+  // The top of the hour is the natural show boundary — roll the session here
+  // so a scheduled show starting/ending opens a fresh chat history even if no
+  // track happens to start right on the hour.
+  const rolled = await rollSessionNow();
+  if (rolled.ctx && (rolled.introAired || programme.suppressHourly())) return;
   if (!shouldFire('hourly')) return;
   if (!djCallsAllowed()) return;  // nobody listening — stay on the auto playlist
   if (!optionalSegmentsAllowed()) return;  // over the daily token budget — mute optional segments
@@ -740,6 +750,25 @@ async function nightlyDoctor() {
 }
 
 // ---------------------------------------------------------------------------
+// Takeover janitor — resolveActiveShow already ignores an expired schedule
+// override (lazy, date-aware), so correctness never depends on this tick. Its
+// job is promptness + hygiene: clear the persisted override and roll the
+// session so the on-air revert lands within minutes even if no track boundary
+// or hourly cron happens to fire first.
+// ---------------------------------------------------------------------------
+async function overrideJanitor() {
+  try {
+    const ov = settings.get()?.scheduleOverride;
+    if (!ov || Date.now() < ov.expiresAt) return;
+    await settings.update({ scheduleOverride: null });
+    queue.log('scheduler', '[takeover] override expired — back to the weekly schedule');
+    await rollSessionNow();
+  } catch (err) {
+    queue.log('error', `Takeover janitor failed: ${err.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // START
 // ---------------------------------------------------------------------------
 
@@ -771,6 +800,9 @@ export function startScheduler() {
   // show's last hour — dispatched on STATION-zone minute windows (see
   // programmeTick). No-ops outside a programme episode.
   cron.schedule('*/5 * * * *', programmeTick);
+
+  // Takeover expiry sweep — cheap (no LLM unless an expiry actually reverts).
+  cron.schedule('*/5 * * * *', overrideJanitor);
 
   // Cleanup every hour
   cron.schedule('0 * * * *', cleanup);

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -372,6 +372,9 @@ router.get('/schedule', async (req, res) => {
       personas,
       shows,
       schedule: s.schedule,
+      // Timed takeover (#930): the pin currently in force, or null. Expired /
+      // dangling overrides report as null even before the janitor sweeps them.
+      override: settings.getScheduleOverride(),
       // The grid is interpreted in the station's timezone (settings.timezone,
       // falling back to the container TZ) — the browser's local DOW/hour may
       // not match, so pass back the zone the schedule is painted in. The UI

--- a/controller/src/routes/shows.ts
+++ b/controller/src/routes/shows.ts
@@ -19,6 +19,7 @@ import { requireAdmin } from '../middleware/auth.js';
 import { readCommunityShow } from '../shows/community.js';
 import { SLUG_RE } from '../skills/loader.js';
 import { queue } from '../broadcast/queue.js';
+import { rollSessionNow } from '../broadcast/scheduler.js';
 
 export const router = express.Router();
 
@@ -161,6 +162,66 @@ router.post('/shows', requireAdmin, async (req, res) => {
     res.json({ shows: next, show: saved });
   } catch (err: any) {
     queue.log('error', `POST /shows failed: ${err.message}`);
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /schedule/override — pin a show for N minutes (#930): a timed takeover
+// that outranks the weekly grid in resolveActiveShow, then lapses back to
+// normal programming on its own. Re-POSTing while one is live replaces it
+// (switch show or extend the window). The session roll is fire-and-forget —
+// the response returns as soon as the override is persisted; the on-air
+// handoff (LLM + TTS) airs in the background, and the switch fully lands at
+// the next track boundary like any show change.
+// ---------------------------------------------------------------------------
+router.post('/schedule/override', requireAdmin, async (req, res) => {
+  const showId = String(req.body?.showId || '');
+  const minutes = Number(req.body?.minutes);
+  if (
+    !Number.isInteger(minutes) ||
+    minutes < settings.OVERRIDE_MIN_MINUTES ||
+    minutes > settings.OVERRIDE_MAX_MINUTES
+  ) {
+    return res.status(400).json({
+      error: `minutes must be an integer between ${settings.OVERRIDE_MIN_MINUTES} and ${settings.OVERRIDE_MAX_MINUTES}`,
+    });
+  }
+
+  await settings.load();
+  const show = (settings.get().shows || []).find((s: any) => s.id === showId);
+  if (!show) return res.status(404).json({ error: `no such show: ${showId}` });
+
+  const startedAt = Date.now();
+  const override = { showId, startedAt, expiresAt: startedAt + minutes * 60_000 };
+  try {
+    await settings.update({ scheduleOverride: override });
+    queue.log('scheduler', `[takeover] "${show.name}" pinned for ${minutes} min via admin UI`);
+    void rollSessionNow();
+    res.json({ override });
+  } catch (err: any) {
+    queue.log('error', `POST /schedule/override failed: ${err.message}`);
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /schedule/override — cancel a takeover early and resume the weekly
+// schedule. Idempotent: clearing an already-clear override succeeds without
+// airing anything.
+// ---------------------------------------------------------------------------
+router.delete('/schedule/override', requireAdmin, async (req, res) => {
+  await settings.load();
+  const existing = settings.get().scheduleOverride;
+  try {
+    await settings.update({ scheduleOverride: null });
+    if (existing) {
+      queue.log('scheduler', '[takeover] cancelled via admin UI — back to the weekly schedule');
+      void rollSessionNow();
+    }
+    res.json({ override: null });
+  } catch (err: any) {
+    queue.log('error', `DELETE /schedule/override failed: ${err.message}`);
     res.status(400).json({ error: err.message });
   }
 });

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -956,6 +956,19 @@ function emptyWeek() {
   return week;
 }
 
+// Timed schedule takeover (#930): pin one show for a bounded window, then the
+// weekly grid resumes. Epoch-ms so no station-zone interpretation is needed.
+export interface ScheduleOverride {
+  showId: string;
+  startedAt: number;
+  expiresAt: number;
+}
+
+// Bounds for POST /schedule/override's `minutes` — long enough for an all-day
+// takeover, short enough that a forgotten pin can't shadow the grid for days.
+export const OVERRIDE_MIN_MINUTES = 15;
+export const OVERRIDE_MAX_MINUTES = 720;
+
 // Seed roster — three distinct DJs shipped on a fresh install (and used as the
 // migration fallback when a legacy `dj` block carries no real souls). Distinct
 // names, taglines, souls and talk frequency — a real roster, not clones of one
@@ -1115,6 +1128,10 @@ const DEFAULTS = {
   shows: [],
   // 7-day x 24-hour grid of showId|null. An empty hour = run autonomously.
   schedule: emptyWeek(),
+  // Timed takeover (#930): { showId, startedAt, expiresAt } epoch-ms window
+  // that outranks the weekly grid in resolveActiveShow while it's live.
+  // null = no takeover. Persisted in schedule.json alongside shows/schedule.
+  scheduleOverride: null,
   tts: {
     defaultEngine: 'piper',
     // Advisory flag — does the operator intend to run the optional tts-heavy
@@ -1730,6 +1747,21 @@ function normalizeSchedule(raw: unknown, showIds: string[]) {
   return week;
 }
 
+// Lenient load-path coercion for the timed takeover (#930). Anything malformed,
+// dangling, or already expired loads as null — an override is transient state,
+// never worth failing a boot over.
+function normalizeScheduleOverride(raw: unknown, showIds: string[]): ScheduleOverride | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  const showId = typeof o.showId === 'string' ? o.showId : '';
+  const startedAt = typeof o.startedAt === 'number' ? o.startedAt : NaN;
+  const expiresAt = typeof o.expiresAt === 'number' ? o.expiresAt : NaN;
+  if (!showIds.includes(showId)) return null;
+  if (!Number.isFinite(startedAt) || !Number.isFinite(expiresAt)) return null;
+  if (startedAt >= expiresAt || expiresAt <= Date.now()) return null;
+  return { showId, startedAt, expiresAt };
+}
+
 export async function load() {
   if (cache) return cache;
   let stored: any = {};
@@ -1752,6 +1784,7 @@ export async function load() {
       if (sched && typeof sched === 'object') {
         stored.shows = sched.shows;
         stored.schedule = sched.schedule;
+        stored.scheduleOverride = sched.override;
       }
     } catch {}
   }
@@ -1797,6 +1830,10 @@ export async function load() {
   const shows = normalizeShows(stored.shows, personaIds);
   const schedule = normalizeSchedule(
     stored.schedule,
+    shows.map(s => s.id),
+  );
+  const scheduleOverride = normalizeScheduleOverride(
+    stored.scheduleOverride,
     shows.map(s => s.id),
   );
 
@@ -1923,6 +1960,7 @@ export async function load() {
     activePersonaId,
     shows,
     schedule,
+    scheduleOverride,
     tts: {
       defaultEngine: TTS_ENGINES.includes(stored.tts?.defaultEngine)
         ? stored.tts.defaultEngine
@@ -2758,6 +2796,30 @@ function validateScheduleStrict(raw, shows) {
   return week;
 }
 
+// Strict takeover validator — used by update(). null clears; anything else
+// must be a well-formed window over an existing show. The 12h cap is enforced
+// here (not just the route) so no caller can persist an unbounded pin.
+function validateScheduleOverrideStrict(raw, shows): ScheduleOverride | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== 'object') throw new Error('scheduleOverride must be an object or null');
+  const showId = typeof raw.showId === 'string' ? raw.showId : '';
+  if (!shows.some(s => s.id === showId)) {
+    throw new Error('scheduleOverride.showId references an unknown show');
+  }
+  const startedAt = raw.startedAt;
+  const expiresAt = raw.expiresAt;
+  if (!Number.isFinite(startedAt) || !Number.isFinite(expiresAt)) {
+    throw new Error('scheduleOverride.startedAt/expiresAt must be epoch-ms numbers');
+  }
+  if (startedAt >= expiresAt) {
+    throw new Error('scheduleOverride.expiresAt must be after startedAt');
+  }
+  if (expiresAt - startedAt > OVERRIDE_MAX_MINUTES * 60_000) {
+    throw new Error(`scheduleOverride window must be at most ${OVERRIDE_MAX_MINUTES} minutes`);
+  }
+  return { showId, startedAt, expiresAt };
+}
+
 // Strict validator — used by update(). `existing` is the current list, so
 // the operator can keep a previously-set authHeader by sending the redacted
 // sentinel back unchanged.
@@ -3141,6 +3203,9 @@ export async function update(patch) {
   }
   if ('schedule' in patch) {
     next.schedule = validateScheduleStrict(patch.schedule, next.shows);
+  }
+  if ('scheduleOverride' in patch) {
+    next.scheduleOverride = validateScheduleOverrideStrict(patch.scheduleOverride, next.shows);
   }
   if ('activePersonaId' in patch) {
     if (!next.personas.some(p => p.id === patch.activePersonaId)) {
@@ -3634,6 +3699,10 @@ export async function update(patch) {
         }
       }
     }
+    // A takeover pinning a show that no longer exists dies with the show.
+    if (next.scheduleOverride && !showIds.includes(next.scheduleOverride.showId)) {
+      next.scheduleOverride = null;
+    }
     if (!personaIds.includes(next.activePersonaId)) next.activePersonaId = personaIds[0];
 
     // Garbage-collect avatar files for personas that no longer exist. Best
@@ -3665,13 +3734,17 @@ export async function update(patch) {
   // on the first write. The in-memory `cache` keeps the full shape so
   // resolveActiveShow / getEffectivePersona / the integrity sweep all
   // continue to work against one merged view.
-  const { shows: _shows, schedule: _schedule, ...settingsPersist } = next;
+  const { shows: _shows, schedule: _schedule, scheduleOverride: _override, ...settingsPersist } = next;
   // Atomic replace — a crash mid-write must not take the operator's whole
   // config (or show schedule) with it.
   await writeFileAtomic(SETTINGS_PATH, JSON.stringify(settingsPersist, null, 2));
   await writeFileAtomic(
     SCHEDULE_PATH,
-    JSON.stringify({ shows: next.shows, schedule: next.schedule }, null, 2),
+    JSON.stringify(
+      { shows: next.shows, schedule: next.schedule, override: next.scheduleOverride ?? null },
+      null,
+      2,
+    ),
   );
   await writeLiquidsoapSettings(next);
   return { saved: next, requiresRestart: restart };
@@ -3689,9 +3762,20 @@ export function resolvePersonaById(id) {
   return get().personas?.find(p => p.id === id) || null;
 }
 
-// The show scheduled for `date`'s day-of-week + hour, or null. Self-contained
-// (touches only settings data) so context.js can import it without a cycle.
+// The show on air at `date`, or null. A live timed takeover (#930) outranks
+// the weekly grid; both paths resolve through the same shape below.
+// Self-contained (touches only settings data) so context.js can import it
+// without a cycle.
 export function resolveActiveShow(date = new Date(), s = get()) {
+  // Date-aware, lazily-expired takeover check. Comparing `date` (not "now")
+  // means look-ahead callers — the queue picks the next track at its expected
+  // airtime — naturally straddle the pin's start/end boundary.
+  const ov = s?.scheduleOverride;
+  if (ov && date.getTime() >= ov.startedAt && date.getTime() < ov.expiresAt) {
+    const pinned = s.shows?.find(x => x.id === ov.showId);
+    // A dangling showId (show deleted mid-takeover) voids the override.
+    if (pinned) return resolveShowShape(pinned, s);
+  }
   // Station-zone wall clock, not process-local — schedule slots fire at the
   // hours the operator painted them in (issue #353).
   const { dow: day, hour } = zonedParts(date);
@@ -3699,6 +3783,23 @@ export function resolveActiveShow(date = new Date(), s = get()) {
   if (!showId) return null;
   const show = s.shows?.find(x => x.id === showId);
   if (!show) return null;
+  return resolveShowShape(show, s);
+}
+
+// The takeover currently in force, or null (absent, expired, or dangling —
+// the same voiding rules resolveActiveShow applies). Route/janitor helper.
+export function getScheduleOverride(now = Date.now()) {
+  const s = get();
+  const ov = s?.scheduleOverride;
+  if (!ov) return null;
+  if (now >= ov.expiresAt) return null;
+  if (!s.shows?.some(x => x.id === ov.showId)) return null;
+  return ov;
+}
+
+// A stored show, resolved to the consumer-facing shape (persona/guests
+// hydrated, filters coerced). Shared by the grid path and the takeover path.
+function resolveShowShape(show, s) {
   const persona = s.personas?.find(p => p.id === show.personaId) || null;
   return {
     id: show.id,

--- a/docs/superpowers/specs/2026-07-16-schedule-override-pin-show-design.md
+++ b/docs/superpowers/specs/2026-07-16-schedule-override-pin-show-design.md
@@ -1,0 +1,173 @@
+# Schedule override — pin a show for N hours (issue #930)
+
+**Date:** 2026-07-16
+**Issue:** [#930 — Dashboard show picker to pin a selected show for x hours](https://github.com/perminder-klair/subwave/issues/930)
+
+## Problem
+
+To temporarily air a different show (e.g. "Hard Rock for the next hour while I'm at
+the gym"), the operator has to repaint the weekly schedule grid and remember to
+undo it afterwards. There is no transient "play this show now, then go back to
+normal" control.
+
+## Goal
+
+A timed schedule override — "takeover" — set from the admin Shows page:
+
+- Pick any saved show, pick a duration (1h / 2h / 3h / custom), pin it.
+- While the override is live, that show is the on-air show everywhere: picker,
+  auto-playlist steer, DJ prompts, persona/guests, theme, session identity.
+- When the timer expires, the station reverts to the weekly grid automatically.
+- The operator can cancel early and revert immediately.
+
+## Approaches considered
+
+1. **Rewrite the grid temporarily, restore later** — mutates the operator's
+   painted schedule; a crash mid-restore loses the real schedule. Rejected.
+2. **Override checked at every consumer** (picker, prompts, theme, session…) —
+   many touch points, easy to miss one. Rejected.
+3. **Single injection point in `resolveActiveShow`** (chosen) — every consumer
+   of "what show is on air" already flows through
+   `settings.resolveActiveShow(date)` (directly or via `ctx.activeShow`). One
+   date-aware check at the top of that function propagates the pin to picks,
+   prompts, persona, theme, and session key with zero consumer changes.
+
+## Design
+
+### State
+
+New transient field, persisted as a third top-level key in
+`state/schedule.json` (it is schedule-domain state and must survive a
+controller restart):
+
+```jsonc
+{
+  "shows": [...],
+  "schedule": {...},
+  "override": { "showId": "s_ab12cd", "startedAt": 1752663600000, "expiresAt": 1752667200000 }
+}
+```
+
+- `override` is `null` / absent when no takeover is live.
+- Epoch-ms timestamps — no timezone interpretation needed (unlike the grid,
+  which is station-zone wall-clock).
+- In-memory it lives on the settings cache as `scheduleOverride`; `update()`
+  strips it from the `settings.json` payload exactly like `shows`/`schedule`.
+- Validation (`validateScheduleOverrideStrict`): `showId` must reference an
+  existing show; `startedAt < expiresAt`; duration capped at 12h. `null`
+  clears.
+
+### Resolution (the core)
+
+At the top of `resolveActiveShow(date, s)` (`controller/src/settings.ts`):
+
+```ts
+const ov = s?.scheduleOverride;
+if (ov && date.getTime() >= ov.startedAt && date.getTime() < ov.expiresAt) {
+  const show = s.shows?.find(x => x.id === ov.showId);
+  if (show) return resolveShow(show, s);   // same resolved shape as the grid path
+}
+// fall through to the weekly grid
+```
+
+- **Date-aware, lazily expired.** No live timer: a `date` past `expiresAt`
+  simply falls through to the grid. Because the queue picks the *next* track
+  with `getFullContext(atExpectedAirtime)`, picks that straddle the start/end
+  boundary automatically follow whichever show is on air at the pick's
+  airtime.
+- **Session roll is free.** `sessionKeyFor` keys on `ctx.activeShow.id`, so
+  pin/expiry/cancel hard-rolls the DJ session (handoff + persona mic-pass)
+  through the existing `maybeRoll` call sites (track start, hourly cron,
+  requests). Pinning the show that is already on air is a no-op (same key).
+- A dangling `showId` (show deleted mid-override) voids the override — falls
+  through to the grid. Show deletion (`DELETE /shows/:id` and the
+  `settings.update` integrity sweep) also clears an override pointing at the
+  deleted show, so the persisted state never goes stale.
+
+### Takeover/revert latency
+
+Setting or cancelling an override does not interrupt the playing track (shared
+live stream — same reason listener skip doesn't exist). The switch airs at the
+next natural roll point. To make that prompt rather than "up to an hour":
+
+- The override routes fire a **background session-roll** after saving —
+  `getFullContext()` → `session.maybeRoll` → `programme.ensurePlan` →
+  `djAgent.runPersonaHandoff`, the exact `hourlyCheck()` sequence in
+  `broadcast/scheduler.ts`. Exported from scheduler as a reusable
+  `rollSessionNow(reason)` helper; the HTTP response does not wait on it.
+  The next track pick (already in `next.txt`) may still be a pre-pin pick;
+  the takeover fully lands one track later — acceptable and consistent with
+  how show boundaries already behave.
+- **Expiry janitor:** the scheduler's quarter-hour tick checks for a persisted
+  override with `expiresAt <= now`, clears it (`settings.update({
+  scheduleOverride: null })`) and calls `rollSessionNow`. Lazy resolution
+  already guarantees correctness before the janitor runs; the janitor makes
+  the on-air revert prompt (≤15 min worst case, usually sooner via a track
+  boundary) and keeps the persisted file clean.
+
+### API (controller, `routes/shows.ts`, admin-gated)
+
+- `POST /schedule/override` — body `{ showId, minutes }`. `minutes` integer,
+  15–720. Sets `{ showId, startedAt: now, expiresAt: now + minutes*60_000 }`
+  via `settings.update`, kicks the background roll, returns the override.
+  Re-POSTing while one is live replaces it (switch show or extend time).
+- `DELETE /schedule/override` — clears it, kicks the background roll, 204/ok.
+- `GET /schedule` (public, `routes/public.ts`) gains an additive
+  `override: { showId, startedAt, expiresAt } | null` field (expired ⇒
+  reported as `null`) so the admin panel — and any curious skin — can show a
+  countdown. Additive, so the native app is unaffected.
+
+### Programme shows
+
+`showSpan()` (`broadcast/programme-pure.ts`) derives the episode arc from
+contiguous grid slots; a pinned show usually isn't in the grid at that hour.
+While an override is live, the span is derived from the override window
+instead: index = hours elapsed since `startedAt`, total = ceil(window / 1h)
+(pure helper `overrideSpan`, pinned by `scripts/programme.test.ts` alongside
+`showSpan`). A 1-hour pin of a programme show therefore airs as a compact
+single-hour episode — intro, feature, outro.
+
+### Admin UI (`web/components/admin/ShowsPanel.tsx`)
+
+On the "On air" NowCard row:
+
+- **No override live:** a compact "Takeover" control — show `<Select>`
+  (saved shows only) + duration chips `1h / 2h / 3h` + custom-minutes input +
+  "Pin" button → `POST /schedule/override` via `adminFetch`, toast on result.
+- **Override live:** the On-air card shows the pinned show with a
+  `TAKEOVER · ends 15:30` badge (station-zone clock, reusing `fmtClock`) and
+  a "Cancel" button → `DELETE /schedule/override`.
+- Override state comes from the existing panel load (it already fetches
+  `/settings`; the override rides on `GET /schedule` — the panel fetches it
+  alongside) and refreshes after each action. Countdown is rendered from
+  `expiresAt`; no per-second timer needed (per-minute is fine).
+
+### Out of scope (noted for later)
+
+- MCP tool (`subwave_pin_show`) — the existing `subwave_schedule` tool stays
+  read-only; a write tool can follow if wanted.
+- Listener-facing pinning — this is an operator control; listeners still see
+  the outcome via `/state`/`/schedule`.
+- Interrupting the current track on pin — deliberately not done.
+
+## Testing
+
+- No test runner in the repo; `npm run lint` (eslint + tsc) in `controller/`
+  and `web/` is the merge gate.
+- `overrideSpan` is pure → pinned in `controller/scripts/programme.test.ts`
+  (existing `npm run test:*` pattern for pure helpers).
+- Manual verification: pin a show via the API on a dev stack, confirm
+  `resolveActiveShow()` flips, session hard-rolls at next track, `GET
+  /schedule` reports the override, expiry janitor clears it.
+
+## Touch list
+
+| File | Change |
+|---|---|
+| `controller/src/settings.ts` | `scheduleOverride` load/persist/validate; `resolveActiveShow` injection; sweep clears dangling override |
+| `controller/src/routes/shows.ts` | `POST`/`DELETE /schedule/override`; clear override on show delete |
+| `controller/src/routes/public.ts` | `override` field on `GET /schedule` |
+| `controller/src/broadcast/scheduler.ts` | exported `rollSessionNow`; expiry janitor on the quarter-hour tick |
+| `controller/src/broadcast/programme.ts` / `programme-pure.ts` | override-aware episode span (`overrideSpan`) |
+| `controller/scripts/programme.test.ts` | pin `overrideSpan` |
+| `web/components/admin/ShowsPanel.tsx` | Takeover control + active-override badge/cancel |

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -209,6 +209,27 @@ interface Schedule {
   [day: number]: (string | null)[];
 }
 
+/** Timed takeover (#930): one show pinned over the weekly grid until
+ *  `expiresAt` (epoch ms), then normal programming resumes on its own. */
+interface ScheduleOverride {
+  showId: string;
+  startedAt: number;
+  expiresAt: number;
+}
+
+// Mirrors the controller's OVERRIDE_MIN/MAX_MINUTES (settings.ts).
+const PIN_MIN_MINUTES = 15;
+const PIN_MAX_MINUTES = 720;
+const PIN_PRESETS = [
+  { minutes: 60, label: '1h' },
+  { minutes: 120, label: '2h' },
+  { minutes: 180, label: '3h' },
+];
+
+function fmtDuration(minutes: number): string {
+  return minutes % 60 === 0 ? `${minutes / 60} h` : `${minutes} min`;
+}
+
 interface FormState {
   shows: Show[];
   schedule: Schedule;
@@ -461,6 +482,13 @@ export default function ShowsPanel() {
   // Navidrome playlists for the per-show playlist-anchor picker. Admin-gated;
   // failures are silent (the picker just shows no options to choose from).
   const [playlists, setPlaylists] = useState<{ id: string; name: string; songCount: number | null }[]>([]);
+  // Timed takeover (#930): the pin currently in force (null = none), plus the
+  // pin form's own state. `override` comes from GET /schedule and is refreshed
+  // by the pin/cancel actions.
+  const [override, setOverride] = useState<ScheduleOverride | null>(null);
+  const [pinShowId, setPinShowId] = useState('');
+  const [pinMinutes, setPinMinutes] = useState(60);
+  const [pinBusy, setPinBusy] = useState(false);
 
   // Drag-paint stroke: { active, value } — value is the showId/null painted
   // for the whole stroke, decided on mousedown so a drag doesn't flicker.
@@ -550,6 +578,22 @@ export default function ShowsPanel() {
         if (firstValid) setBrush(b => b ?? firstValid.id);
       }
     })();
+  }, [hydrated, needsAuth]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Fetch the live takeover once after sign-in (GET /schedule is public but
+  // adminFetch keeps the base-URL handling consistent). Expired/absent → null.
+  useEffect(() => {
+    if (!hydrated || needsAuth) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await adminFetch('/schedule');
+        if (!r.ok || cancelled) return;
+        const j = (await r.json()) as { override?: ScheduleOverride | null };
+        if (j.override) setOverride(j.override);
+      } catch {}
+    })();
+    return () => { cancelled = true; };
   }, [hydrated, needsAuth]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Fetch the skill catalogue once for the programme feature-segment pin.
@@ -943,6 +987,42 @@ export default function ShowsPanel() {
     } finally { setBusy(false); }
   };
 
+  // Pin a show over the weekly grid for `pinMinutes` (#930). The controller
+  // persists the window, airs the handoff in the background, and reverts on
+  // its own when the timer lapses — nothing here to undo later.
+  const pinShow = async () => {
+    if (!pinShowId) return;
+    setPinBusy(true);
+    try {
+      const r = await adminFetch('/schedule/override', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ showId: pinShowId, minutes: pinMinutes }),
+      });
+      const j = (await r.json().catch(() => ({}))) as { error?: string; override?: ScheduleOverride };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      setOverride(j.override ?? null);
+      const name = showById(pinShowId)?.name?.trim() || 'show';
+      notify.ok(`“${name}” takes over for ${fmtDuration(pinMinutes)} — the switch airs on the next track.`);
+    } catch (e) {
+      notify.err(errorMessage(e));
+    } finally { setPinBusy(false); }
+  };
+
+  // Cancel a takeover early — the weekly schedule resumes on the next roll.
+  const cancelPin = async () => {
+    setPinBusy(true);
+    try {
+      const r = await adminFetch('/schedule/override', { method: 'DELETE' });
+      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      setOverride(null);
+      notify.ok('Takeover cancelled — back to the weekly schedule.');
+    } catch (e) {
+      notify.err(errorMessage(e));
+    } finally { setPinBusy(false); }
+  };
+
   // ── error / loading shells ───────────────────────────────────────────────
   if (err) {
     return (
@@ -964,7 +1044,12 @@ export default function ShowsPanel() {
   }
 
   const validBrushes = form.shows.filter(showValid);
-  const nowShow = showById(form.schedule[nowDay]?.[nowHour] ?? null);
+  // A live takeover outranks the grid on the On-air card — mirror the
+  // controller's resolveActiveShow. `now` ticks every second, so an expiring
+  // pin drops off the card by itself; a pin of a since-deleted show is void.
+  const liveOverride = override && override.expiresAt > now.getTime() ? override : null;
+  const pinnedShow = liveOverride ? showById(liveOverride.showId) : null;
+  const nowShow = pinnedShow ?? showById(form.schedule[nowDay]?.[nowHour] ?? null);
   const upNext = slotAhead(1);
   const after = slotAhead(2);
   const upNextShow = upNext.showId ? showById(upNext.showId) : null;
@@ -1004,8 +1089,8 @@ export default function ShowsPanel() {
 
         {/* Now / Up next / After that strip */}
         <div className="stack-mobile grid grid-cols-3 border-b border-separator-strong">
-          <NowCard label="On air" accent slotHour={nowHour} show={nowShow}
-            color={colorOf(form.schedule[nowDay]?.[nowHour])}
+          <NowCard label={pinnedShow ? 'On air · takeover' : 'On air'} accent slotHour={nowHour} show={nowShow}
+            color={colorOf(pinnedShow ? pinnedShow.id : form.schedule[nowDay]?.[nowHour])}
             personaLabel={nowShow ? personaName(nowShow.personaId) : ''} />
           <NowCard label="Up next" slotHour={upNext.hour} show={upNextShow}
             color={colorOf(upNext.showId)}
@@ -1013,6 +1098,80 @@ export default function ShowsPanel() {
           <NowCard label="After that" slotHour={after.hour} show={afterShow}
             color={colorOf(after.showId)}
             personaLabel={afterShow ? personaName(afterShow.personaId) : ''} />
+        </div>
+
+        {/* Takeover — pin a show over the grid for a while (#930). The switch
+            airs at the next roll; expiry reverts to the schedule on its own. */}
+        <div className="flex flex-wrap items-center gap-2 border-b border-separator-strong p-3.5">
+          <Eyebrow className={liveOverride ? 'text-vermilion' : 'text-muted'}>takeover</Eyebrow>
+          {liveOverride && pinnedShow ? (
+            <>
+              <span className="text-[13px] font-bold text-ink">
+                {pinnedShow.name.trim() || 'untitled'}
+              </span>
+              <span className="text-[12px] text-muted">
+                ends {fmtClock(liveOverride.expiresAt, stationTz, stationLocale)}
+                {' · '}
+                {Math.max(1, Math.ceil((liveOverride.expiresAt - now.getTime()) / 60_000))} min left
+              </span>
+              <Btn sm onClick={cancelPin} disabled={pinBusy}>
+                {pinBusy ? 'cancelling…' : 'Cancel takeover'}
+              </Btn>
+            </>
+          ) : (
+            <>
+              <Select value={pinShowId} onValueChange={setPinShowId}>
+                <SelectTrigger className="h-8 w-52 text-[13px]">
+                  <SelectValue placeholder="pin a show…" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    {validBrushes.map(s => (
+                      <SelectItem key={s.id} value={s.id}>{s.name.trim() || 'untitled'}</SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              {PIN_PRESETS.map(p => (
+                <button
+                  key={p.minutes}
+                  type="button"
+                  aria-pressed={pinMinutes === p.minutes}
+                  onClick={() => setPinMinutes(p.minutes)}
+                  className={cn(
+                    'border border-ink px-2 py-0.5 text-[12px]',
+                    pinMinutes === p.minutes ? 'bg-ink text-bg' : 'text-ink hover:bg-[var(--ink-soft)]',
+                  )}
+                >
+                  {p.label}
+                </button>
+              ))}
+              <Input
+                type="number"
+                min={PIN_MIN_MINUTES}
+                max={PIN_MAX_MINUTES}
+                value={pinMinutes}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                  const v = Number(e.target.value);
+                  if (Number.isFinite(v)) setPinMinutes(Math.round(v));
+                }}
+                className="h-8 w-20 text-[13px]"
+                aria-label="takeover minutes"
+              />
+              <span className="caption">min</span>
+              <Btn
+                sm
+                tone="accent"
+                onClick={pinShow}
+                disabled={pinBusy || !pinShowId || pinMinutes < PIN_MIN_MINUTES || pinMinutes > PIN_MAX_MINUTES}
+              >
+                {pinBusy ? 'pinning…' : 'Pin show'}
+              </Btn>
+              {validBrushes.length === 0 && (
+                <span className="text-[11px] text-muted italic">add a show first</span>
+              )}
+            </>
+          )}
         </div>
       </section>
 


### PR DESCRIPTION
Closes #930.

## What

A **takeover**: pin any saved show over the weekly schedule for a chosen duration (15 min – 12 h). While the pin is live it is the on-air show everywhere — picker, auto-playlist steer, DJ prompts, persona/guests, per-show theme, session identity. When the timer lapses (or on early cancel) the weekly grid resumes automatically.

Design spec: `docs/superpowers/specs/2026-07-16-schedule-override-pin-show-design.md`

## How

- **One injection point.** `scheduleOverride` (`{showId, startedAt, expiresAt}`, persisted as `override` in `state/schedule.json`) is checked at the top of `resolveActiveShow(date)` — date-aware and lazily expired, so look-ahead picks straddle the pin's boundaries correctly and every consumer follows the pin with zero changes. Session rolling comes free: `sessionKeyFor` keys on `activeShow.id`, so pin/expiry/cancel hard-roll the DJ session with the existing handoff/mic-pass.
- **Routes.** `POST /schedule/override {showId, minutes}` + `DELETE /schedule/override` (admin-gated); the live pin rides `GET /schedule` (additive — native app unaffected). Both routes fire a background `rollSessionNow()` (extracted from `hourlyCheck`, behaviour-preserving) so the switch airs promptly; the current track is never interrupted.
- **Janitor.** A `*/5` cron clears an expired pin and rolls the session — correctness never depends on it (lazy expiry), it just makes the revert prompt and keeps the persisted file clean.
- **Programme shows.** A pinned show usually isn't in the grid, so `showSpan` can't see it — a live takeover's window IS the episode span (`overrideSpan`, unit-pinned in `programme.test.ts`).
- **Integrity.** Deleting the pinned show voids the override (update sweep + load-time normalizer); a dangling/expired pin resolves and reports as null everywhere.
- **Admin UI.** Takeover bar in the /admin/shows hero: show picker + 1h/2h/3h presets + custom minutes; while live, the On-air card shows the pinned show with an `On air · takeover` label and the bar shows ends-at + minutes left + Cancel.

## Testing

- `controller` + `web` `npm run lint` clean; controller test suite passes (33 files) incl. new `overrideSpan` assertions.
- End-to-end verified on an isolated worktree stack (fresh controller on a temp STATE_DIR + worktree Next dev server + Playwright): pin via admin UI → controller holds the window and resolveActiveShow flips (now and at +30 min look-ahead, null past expiry), session hard-rolls to `show:<id>`, On-air card shows the takeover badge + countdown; early cancel reverts; deleting the pinned show voids the pin; an expired pin on disk loads as null; a live pin survives a controller restart. Auth (401), minutes bounds, and unknown-show validation all rejected as expected. Not exercised live: the */5 janitor cron (would need a ≥15-min wait; logic is the same lazy-expiry fields).

## Out of scope

MCP write tool (`subwave_pin_show`) and any listener-facing pin UI — noted in the spec as follow-ups.