### PR TITLE
fix(doctor): retry fast-failing Navidrome ping before alarming the admin banner

### DIFF
--- a/controller/src/music/subsonic.ts
+++ b/controller/src/music/subsonic.ts
@@ -143,15 +143,33 @@ async function call(endpoint, params = {}) {
 // Lightweight connectivity + auth check for the admin Doctor. Hits the cheapest
 // Subsonic endpoint (`ping`) with the controller's own salt+token creds — mirrors
 // the CLI wizard's probeSubsonic but against config.navidrome. Never throws.
+//
+// A failure that lands instantly gets ONE retry: Node's pooled fetch sockets go
+// stale between the controller's bursty Subsonic calls, so a one-off
+// ECONNRESET / "fetch failed" on connection reuse is routine, not an outage —
+// and since the admin NavidromeBanner alarms on a single failed ping (cached
+// 20s), an un-retried blip reads as "Navidrome is down" to the operator. Slow
+// failures (the 30s timeout) don't retry: a second wait wouldn't change the
+// answer, just pin the caller for another timeoutMs.
+const PING_RETRY_IF_FASTER_THAN_MS = 2_000;
+
 export async function ping(): Promise<{ ok: boolean; reason?: string }> {
   if (!config.navidrome.url || !config.navidrome.user || !config.navidrome.password) {
     return { ok: false, reason: 'Navidrome URL / username / password not configured' };
   }
-  try {
-    await call('ping');
-    return { ok: true };
-  } catch (err: any) {
-    return { ok: false, reason: err?.message || 'unreachable' };
+  for (let attempt = 0; ; attempt++) {
+    const started = Date.now();
+    try {
+      await call('ping');
+      return { ok: true };
+    } catch (err: any) {
+      const failedFast = Date.now() - started < PING_RETRY_IF_FASTER_THAN_MS;
+      if (attempt === 0 && failedFast) {
+        await new Promise(resolve => setTimeout(resolve, 500));
+        continue;
+      }
+      return { ok: false, reason: err?.message || 'unreachable' };
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

Discord report (Drachenhort): since "shortly after 0.40", Subwave intermittently says it can't connect to Navidrome on the same machine, then recovers by itself a few seconds later. Their Navidrome login page works the instant the message shows.

Root cause: the always-on admin banner shipped in v0.41.0 (#1014) alarms on a **single** failed `subsonic.ping()`, and `/doctor/navidrome` caches that result for 20s (banner polls every 30s). `ping()` had no retry, so one transient socket-level error — classically Node's pooled fetch reusing a keep-alive connection Navidrome just closed (ECONNRESET / `fetch failed`), easy to hit because the controller's Subsonic traffic is bursty — read as "Navidrome is down" for ~30s. Nothing about connectivity regressed; the new banner just surfaces one-off blips that were always there.

## Fix

`ping()` retries once (after 500ms) when the first attempt failed in under 2s — the stale-socket class fails instantly and a fresh connection succeeds. Slow failures (the 30s timeout) still return immediately so a genuinely hung Navidrome doesn't pin admin requests for 2× `timeoutMs`. The banner and the DJ Doc connectivity finding both go through `ping()`, so they stay in agreement.

## Testing

- `npm run lint` (controller): clean.