### PR TITLE
feat(web): platter tonearm rides the groove with track progress

### DIFF
--- a/web/components/skins/platter/Platter.module.css
+++ b/web/components/skins/platter/Platter.module.css
@@ -58,13 +58,20 @@
    so the headshell always stays welded to the tube end and the stylus stays on
    the groove. A one-shot transition (not a loop) swings it up and out off the
    record when the listener tunes out; the parked angle holds even under
-   html.lite. Origin MUST match the pivot circle in PlatterSkin.tsx. */
+   html.lite. Origin MUST match the pivot circle in PlatterSkin.tsx.
+
+   While live the arm tracks the song: --pf (0..1, same var as the progress
+   bar) sweeps it from the lead-in groove (-14deg, stylus near the outer edge)
+   to the run-out (+8deg, just shy of the label). --pf ticks once a second, so
+   the 1.1s eased transition below is what turns the steps into a creep. The
+   parked angle sits past the platter edge so the tune-in drop stays a
+   readable swing even when a track has just started. */
 .arm {
   transform-origin: 86% 19%;
   transition: transform 1.1s cubic-bezier(0.22, 1, 0.36, 1);
 }
-.armRest { transform: rotate(-16deg); }
-.armLive { transform: rotate(0deg); }
+.armRest { transform: rotate(-24deg); }
+.armLive { transform: rotate(calc(-14deg + var(--pf, 0) * 22deg)); }
 
 /* Progress fill — driven by --pf (0..1) set on the skin root via
    useDynamicStyle, so no inline style attribute. */

--- a/web/components/skins/platter/PlatterSkin.tsx
+++ b/web/components/skins/platter/PlatterSkin.tsx
@@ -5,7 +5,8 @@
 //
 // The record spins at 33⅓ while a light-catch sheen sweeps on its own slower
 // cycle and the strobe rim ticks; the tonearm swings from its rest onto the
-// lead-in when the listener drops the needle (tunes in). The plinth holds the
+// lead-in when the listener drops the needle (tunes in), then rides the groove
+// inward with the track's progress. The plinth holds the
 // transport (START = tune in/out), while the sleeve, metadata, up-next stack,
 // booth quote and request slip live in the right-hand column. Everything that
 // moves is a co-located keyframe (Platter.module.css) so playback churn never
@@ -106,7 +107,9 @@ function Deck({
           pivot sits rear-right (86% 19%) like a real deck; the arm reaches down
           onto the RIGHT-hand grooves (never crossing the label) so the record's
           clockwise spin draws the stylus along the groove instead of shoving it.
-          The whole arm swings up off the record when tuned out (see .arm). */}
+          While playing, .armLive sweeps the arm across the groove band with the
+          track's progress (the shared --pf var); the whole arm swings up off
+          the record when tuned out (see .arm). */}
       <svg
         viewBox="0 0 100 100"
         className={cn(


### PR DESCRIPTION
## What

The platter skin's tonearm now tracks song progress: `.armLive` derives its rotation from the shared `--pf` progress var (the same one driving the progress bar), sweeping the stylus from the lead-in groove (`-14deg`, outer edge) to the run-out (`+8deg`, against the label) as the song plays.

## Details

- `--pf` updates once a second (from `useElapsed`); the arm's existing 1.1s eased transition smooths those steps into a continuous creep.
- When the next track starts, `--pf` snaps back to 0 and the same transition sweeps the arm back out to the lead-in — a free needle-reset moment at every transition.
- The parked angle moves `-16deg → -24deg` so the resting stylus sits genuinely off the platter. At `-16deg` it hovered over the outer grooves, which would have made the tune-in drop indistinguishable from a freshly started track now that the lead-in is `-14deg`.
- Unknown duration → `progressRatio` returns null → `--pf` is 0 → arm holds at the lead-in (same degrade as the progress bar).

## Verification

- `npm run lint` (eslint + tsc) passes in `web/`.
- Geometry verified with a headless-Chromium render of the deck at rest / start / mid / end — stylus stays on the groove band across the whole sweep, direction is inward:

| rest | pf=0 | pf=0.5 | pf=1 |
|---|---|---|---|
| off the platter edge | outer grooves | mid-groove | run-out at the label |