### PR TITLE
fix(scheduler): stamp loudness gain on auto.m3u fallback tracks

### DIFF
--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -357,6 +357,18 @@ async function refreshAutoPlaylistInner() {
     if (allowed.length) { pool.length = 0; pool.push(...allowed); }
   }
 
+  // Loudness normalisation: the queue drain stamps liq_amplify per track, but
+  // this fallback bypasses the drain entirely — without a stamp here every
+  // coast track (queue empty: LLM down/slow, budget-hard, restart) played at
+  // unity gain, so a hot master aired loud until the next queued pick. Same
+  // resolver as the drain path (queue.applyLoudnessGain: ReplayGain tag →
+  // measured LUFS, per settings.loudness.source), so both paths level
+  // identically. Subsonic-sourced pool tracks carry the replayGain field for
+  // free; library-sourced rows recover it via a best-effort getSong (bounded
+  // by TARGET_POOL per refresh). No loudness from any source → no liq_amplify
+  // → unity, exactly as before.
+  for (const t of pool) await queue.applyLoudnessGain(t);
+
   // Stamp the station cap on every fallback entry (#447). max-track-length is a
   // pure on-air cue_out cut, not a selection filter, so over-length tracks stay
   // in the pool and simply crossfade out at the cap when the queue runs dry.


### PR DESCRIPTION
## What
Makes the `auto.m3u` fallback apply the same per-track loudness correction the normal queue does, so tracks played from it aren't louder than everything else.

## Why
I noticed on my station that a track, that was playing when i connected, was way too loud, and then the next one was gain corrected. Turns out the loudness/ReplayGain gain only gets stamped in the queue drain path (`applyLoudnessGain`). The `auto.m3u` fallback writes tracks straight through `getAnnotatedUri` and never calls it, so anything that plays off the fallback (queue's empty because the LLM is off when no one listens (my case) or down or slow, budget cap hit, or right after a restart) just plays at unity gain.

## How tested
Ran `npm run lint` in `controller/` and it passes. Confirmed the fallback pool now goes through the same `applyLoudnessGain` as the drain path before the M3U gets written, so both honor the `settings.loudness.source` setting.