### PR TITLE
feat(observatory): production polish — honest legends, projection status, queue-on-air, search fly-to, deep links, keyboard + mobile

### DIFF
--- a/controller/src/routes/library.ts
+++ b/controller/src/routes/library.ts
@@ -404,10 +404,25 @@ router.get('/library/observatory/track/:id', requireAdmin, async (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
+// GET /library/observatory/projection — lightweight sound-map job status. The
+// same object that rides the bulk payload, without the multi-MB track body, so
+// the Observatory can poll a running projection cheaply and know when to
+// reload the map.
+// ---------------------------------------------------------------------------
+router.get('/library/observatory/projection', requireAdmin, async (_req, res) => {
+  try {
+    await library.load();
+    res.json(mapProjection.projectionStatus());
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // POST /library/observatory/project — force a sound-map projection pass now
 // (the boot hook only fires when the map is stale). Spawns the standalone
 // UMAP child; 409 when one is already running. Minutes-long at library scale —
-// the client polls the bulk endpoint's `mapProjection` status for completion.
+// the client polls GET /library/observatory/projection for completion.
 // ---------------------------------------------------------------------------
 router.post('/library/observatory/project', requireAdmin, async (_req, res) => {
   try {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -5014,6 +5014,52 @@ html.lite .sw-ripple-circle {
 @keyframes obs-glabel-in { from { opacity: 0; } }
 @keyframes obs-tlabel-in { from { opacity: 0; } }
 
+/* ---- load-error banner — the map still renders (sample / last good data),
+   but a failed load must never masquerade as a fresh install ---- */
+.observatory-root .obs-error { display: flex; align-items: center; gap: 14px; padding: 8px 22px; border-bottom: 1px solid var(--accent); background: color-mix(in oklab, var(--accent) 9%, var(--bg)); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; font-weight: 700; flex: none; z-index: 4; }
+.observatory-root .obs-error button { margin-left: auto; flex: none; border: 1px solid var(--accent); background: transparent; color: var(--accent); font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase; font-weight: 700; padding: 4px 10px; cursor: pointer; transition: background 0.12s, color 0.12s; }
+.observatory-root .obs-error button:hover:not(:disabled) { background: var(--accent); color: #fff; }
+.observatory-root .obs-error button:disabled { cursor: default; opacity: 0.6; }
+
+/* ---- search jump-to dropdown ---- */
+.observatory-root .rail-search-wrap { position: relative; }
+.observatory-root .rail-search-results { position: absolute; top: 100%; left: 0; right: 0; z-index: 30; border: 1px solid var(--ink); border-top: 0; background: var(--bg); max-height: 300px; overflow-y: auto; box-shadow: 4px 4px 0 var(--separator-strong); }
+.observatory-root .rail-search-hit { display: flex; flex-direction: column; gap: 2px; width: 100%; text-align: left; padding: 8px 10px; background: transparent; border: 0; border-bottom: 1px dashed var(--separator-strong); cursor: pointer; transition: background 0.12s; }
+.observatory-root .rail-search-hit:last-child { border-bottom: 0; }
+.observatory-root .rail-search-hit:hover { background: var(--ink-soft); }
+.observatory-root .hit-title { font-size: 11px; font-weight: 700; color: var(--ink); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.observatory-root .hit-artist { font-size: 9px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* ---- sound-map projection status (rail footer) ---- */
+.observatory-root .rail-proj { display: flex; flex-direction: column; gap: 6px; }
+.observatory-root .rail-proj-live { display: flex; align-items: center; gap: 8px; color: var(--accent); font-weight: 700; }
+.observatory-root .rail-proj-log { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-transform: none; letter-spacing: 0.04em; }
+
+/* ---- dossier queue-on-air ---- */
+.observatory-root .dossier-queue { margin-top: 12px; width: 100%; border: 1px solid var(--accent); background: transparent; color: var(--accent); font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; font-weight: 700; padding: 9px 0; cursor: pointer; transition: background 0.12s, color 0.12s; }
+.observatory-root .dossier-queue:hover:not(:disabled) { background: var(--accent); color: #fff; }
+.observatory-root .dossier-queue:disabled { cursor: default; }
+.observatory-root .dossier-queue.done { background: var(--accent); color: #fff; opacity: 0.85; }
+.observatory-root .dossier-queue-err { margin-top: 6px; color: var(--accent); text-transform: none; letter-spacing: 0.04em; }
+
+/* keyboard focus on the map (tabIndex=0 — arrows pan, +/- zoom) */
+.observatory-root .cmap-galaxy:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+
+/* ---- small screens: stack header → map → filters → panels and let the page
+   scroll. Scoped away from the landing-page embed, which has its own two-row
+   phone layout. ---- */
+@media (max-width: 900px) {
+    .observatory-root:not(.obs-embed) { height: auto; min-height: 100vh; min-height: 100dvh; overflow: visible; }
+    .observatory-root:not(.obs-embed) .obs-top { flex-wrap: wrap; row-gap: 8px; }
+    .observatory-root:not(.obs-embed) .obs-top-r { margin-left: 0; flex-wrap: wrap; row-gap: 8px; }
+    .observatory-root:not(.obs-embed) .obs-main { display: flex; flex-direction: column; min-height: 0; }
+    .observatory-root:not(.obs-embed) .obs-stage { order: -1; min-height: 62vh; border-bottom: 1px solid var(--ink); }
+    .observatory-root:not(.obs-embed) .obs-rail { border-right: 0; border-bottom: 1px solid var(--ink); overflow-y: visible; }
+    .observatory-root:not(.obs-embed) .obs-side { border-left: 0; overflow-y: visible; }
+    .observatory-root:not(.obs-embed) .rail-foot { margin-top: 0; }
+    .observatory-root:not(.obs-embed) .stage-hint { display: none; }
+}
+
 @media (prefers-reduced-motion: reduce) {
     .observatory-root .obs-disc,
     .observatory-root .obs-live-dot::after,

--- a/web/components/manual/Observatory.tsx
+++ b/web/components/manual/Observatory.tsx
@@ -57,7 +57,13 @@ export default function Observatory() {
         <p>
           <strong>Mix Next</strong> lists the closest tracks in vector space, the same similarity the DJ
           leans on when it reaches for what to play next. Those neighbours are wired back onto the map in
-          vermilion so you can see where they sit.
+          vermilion so you can see where they sit; picking one flies the camera to it.
+        </p>
+        <p>
+          The dossier isn't just a viewer: <strong>QUEUE ON AIR</strong> pushes the open track straight to
+          the broadcast queue, the same operator pick as the admin console's Search tab. And a selected
+          track rides the URL, so you can bookmark or share a link that opens the Observatory on that exact
+          star.
         </p>
       </section>
 

--- a/web/components/observatory/ConstellationGalaxy.tsx
+++ b/web/components/observatory/ConstellationGalaxy.tsx
@@ -49,6 +49,9 @@ interface Props {
   selected: ObsTrack | null;
   neighbours: ObsTrack[];
   hovered: ObsTrack | null;
+  // Fly-to request: animate the camera to centre this node. The nonce `n`
+  // distinguishes repeat requests for the same track; map clicks never set it.
+  focus?: { t: ObsTrack; n: number } | null;
   onHover: (t: ObsTrack | null, e?: React.MouseEvent) => void;
   onSelect: (t: ObsTrack | null) => void;
 }
@@ -215,6 +218,7 @@ export default function ConstellationGalaxy({
   selected,
   neighbours,
   hovered,
+  focus,
   onHover,
   onSelect,
 }: Props) {
@@ -803,6 +807,65 @@ export default function ConstellationGalaxy({
       return { k: k2, tx: 500 - ux * k2, ty: 500 - uy * k2 };
     });
 
+  // ---- fly-to: animate the camera to centre a requested node -----------------
+  // Screen centre is always viewbox (500,500) under meet-fit letterboxing, so
+  // the target is exact regardless of stage aspect. Zoom eases geometrically
+  // (perceptually linear), translation linearly on the same eased parameter —
+  // the focal point drifts a hair mid-flight but lands exactly.
+  const flyRaf = useRef<number | null>(null);
+  useEffect(() => {
+    if (!focus) return;
+    const t = focus.t;
+    const from = viewRef.current;
+    const k2 = clampK(Math.max(from.k, 3));
+    const target = { k: k2, tx: 500 - t.x * k2, ty: 500 - t.y * k2 };
+    if (flyRaf.current != null) cancelAnimationFrame(flyRaf.current);
+    if (reducedMotion) {
+      viewRef.current = target;
+      setView(target);
+      return;
+    }
+    const t0 = performance.now();
+    const DUR = 600;
+    const step = () => {
+      const p = Math.min(1, (performance.now() - t0) / DUR);
+      const e = 1 - Math.pow(1 - p, 3);
+      const k = from.k * Math.pow(target.k / from.k, e);
+      const next = {
+        k,
+        tx: from.tx + (target.tx - from.tx) * e,
+        ty: from.ty + (target.ty - from.ty) * e,
+      };
+      viewRef.current = next;
+      setView(next);
+      flyRaf.current = p < 1 ? requestAnimationFrame(step) : null;
+    };
+    flyRaf.current = requestAnimationFrame(step);
+    return () => {
+      if (flyRaf.current != null) {
+        cancelAnimationFrame(flyRaf.current);
+        flyRaf.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focus?.n]);
+
+  // ---- keyboard: pan with arrows, zoom with +/-, 0 resets ---------------------
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if ((e.target as HTMLElement).closest('button')) return; // zoom controls keep their own keys
+    const PAN = 60; // viewbox units per press — a comfortable nudge at any zoom
+    const v = viewRef.current;
+    if (e.key === 'ArrowLeft') commitView({ ...v, tx: v.tx + PAN });
+    else if (e.key === 'ArrowRight') commitView({ ...v, tx: v.tx - PAN });
+    else if (e.key === 'ArrowUp') commitView({ ...v, ty: v.ty + PAN });
+    else if (e.key === 'ArrowDown') commitView({ ...v, ty: v.ty - PAN });
+    else if (e.key === '+' || e.key === '=') zoom(1.3);
+    else if (e.key === '-' || e.key === '_') zoom(0.77);
+    else if (e.key === '0') reset();
+    else return;
+    e.preventDefault();
+  };
+
   const transform = `translate(${view.tx} ${view.ty}) scale(${view.k})`;
   // Constellation names, greedily decluttered: lib.genres is most-populous
   // first, so when two centroids crowd each other (common on the sound map,
@@ -833,6 +896,10 @@ export default function ConstellationGalaxy({
       className="cmap cmap-galaxy"
       ref={wrapRef}
       style={{ cursor: dragging ? 'grabbing' : hovered ? 'pointer' : 'grab' }}
+      tabIndex={0}
+      role="application"
+      aria-label="library map — arrow keys pan, plus and minus zoom, zero resets, click a star to inspect it"
+      onKeyDown={onKeyDown}
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerEnd}
@@ -934,17 +1001,30 @@ export default function ConstellationGalaxy({
         </button>
       </div>
 
-      {/* legend — swatches pass through the same night-lift as the stars */}
+      {/* legend — swatches pass through the same night-lift as the stars, and
+          every colour-by mode gets the key its nodeColor/nodeFilled actually
+          draw: heat ramps for the continuous scalars (with a hollow chip for
+          the unmeasured), palettes for the categoricals */}
       <div className="cmap-legend">
         <span className="t-caption ad-muted">{legendLabel(colorBy)}</span>
-        {colorBy === 'energy' || colorBy === 'confidence' ? (
-          <div className="legend-ramp">
-            <span className="lr-bar" />
-            <span className="t-caption ad-muted">{colorBy === 'energy' ? 'LOW' : '0.0'}</span>
-            <span className="t-caption ad-muted" style={{ marginLeft: 'auto' }}>
-              {colorBy === 'energy' ? 'HIGH' : '1.0'}
-            </span>
-          </div>
+        {colorBy === 'energy' || colorBy === 'confidence' || colorBy === 'loudness' || colorBy === 'pace' ? (
+          <>
+            <div className="legend-ramp">
+              <span className="lr-bar" />
+              <span className="t-caption ad-muted">{RAMP_ENDS[colorBy][0]}</span>
+              <span className="t-caption ad-muted" style={{ marginLeft: 'auto' }}>
+                {RAMP_ENDS[colorBy][1]}
+              </span>
+            </div>
+            {(colorBy === 'loudness' || colorBy === 'pace') && (
+              <div className="legend-keys">
+                <span>
+                  <i className="lk hollow" style={{ borderColor: liftNightCss('#9b948a') }} />
+                  NOT MEASURED
+                </span>
+              </div>
+            )}
+          </>
         ) : colorBy === 'source' ? (
           <div className="legend-keys">
             <span>
@@ -964,6 +1044,21 @@ export default function ConstellationGalaxy({
               UNCERTAIN · LEGACY
             </span>
           </div>
+        ) : colorBy === 'vocal' ? (
+          <div className="legend-keys">
+            <span>
+              <i className="lk" style={{ background: liftNightCss('#d94b2a') }} />
+              VOCAL
+            </span>
+            <span>
+              <i className="lk" style={{ background: liftNightCss('#4a443d') }} />
+              INSTRUMENTAL
+            </span>
+            <span>
+              <i className="lk hollow" style={{ borderColor: liftNightCss('#9b948a') }} />
+              NOT ANALYSED
+            </span>
+          </div>
         ) : (
           <div className="legend-keys">
             <span>
@@ -981,12 +1076,29 @@ export default function ConstellationGalaxy({
   );
 }
 
+// End labels for the heat-ramp legends, per continuous colour-by mode.
+const RAMP_ENDS: Record<'energy' | 'confidence' | 'loudness' | 'pace', [string, string]> = {
+  energy: ['LOW', 'HIGH'],
+  confidence: ['0.0', '1.0'],
+  loudness: ['QUIET', 'LOUD'],
+  pace: ['CALM', 'DRIVING'],
+};
+
 function legendLabel(c: ColorBy): string {
-  return c === 'energy'
-    ? 'NODE COLOUR · ENERGY'
-    : c === 'confidence'
-      ? 'NODE COLOUR · TAG CONFIDENCE'
-      : c === 'source'
-        ? 'NODE COLOUR · TAG SOURCE'
-        : 'NODE COLOUR · ACOUSTIC ANALYSIS';
+  switch (c) {
+    case 'energy':
+      return 'NODE COLOUR · ENERGY';
+    case 'confidence':
+      return 'NODE COLOUR · TAG CONFIDENCE';
+    case 'source':
+      return 'NODE COLOUR · TAG SOURCE';
+    case 'loudness':
+      return 'NODE COLOUR · LOUDNESS';
+    case 'pace':
+      return 'NODE COLOUR · PACE';
+    case 'vocal':
+      return 'NODE COLOUR · VOICE';
+    default:
+      return 'NODE COLOUR · ACOUSTIC ANALYSIS';
+  }
 }

--- a/web/components/observatory/ObservatoryApp.tsx
+++ b/web/components/observatory/ObservatoryApp.tsx
@@ -6,13 +6,20 @@
    ============================================================================ */
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import dynamic from 'next/dynamic';
 import { useObservatory, useTrackDetail } from '../../lib/observatory';
 import { StatsView, Dossier } from './panels';
 import Tooltip, { type TipState } from './Tooltip';
-import { nearest, sourceStyle, tally, type ColorBy, type ObsTrack } from './data';
+import {
+  nearest,
+  sourceStyle,
+  tally,
+  type ColorBy,
+  type MapProjectionStatus,
+  type ObsTrack,
+} from './data';
 
 // The galaxy renderer pulls in three.js + the bloom pipeline — client-only and
 // heavy, so it's split out and never server-rendered.
@@ -77,6 +84,25 @@ const MAX_LADDER = [2000, 4000, 8000, 10000, 16000, 25000, 50000, 100000, 200000
 const DEFAULT_MAX = 25000;
 const MAX_STORAGE_KEY = 'subwave_obs_max';
 
+const COLOR_MODES: [ColorBy, string][] = [
+  ['energy', 'ENERGY'],
+  ['confidence', 'CONF'],
+  ['source', 'SOURCE'],
+  ['analysis', 'ANALYSIS'],
+  ['loudness', 'LOUDNESS'],
+  ['pace', 'PACE'],
+  ['vocal', 'VOICE'],
+];
+const COLOR_IDS = new Set(COLOR_MODES.map(([k]) => k));
+
+// Genre chips shown before the +N MORE toggle expands the full list — a real
+// library can carry hundreds of genres, which otherwise wall off the rail.
+const GENRE_CHIP_CAP = 24;
+
+// A projection needs at least this many audio vectors to be worth offering —
+// mirrors MIN_VECTORS in the controller's map-projection.ts.
+const PROJECTION_MIN_VECTORS = 50;
+
 export default function ObservatoryApp({ adminFetch }: { adminFetch: AdminFetch }) {
   // Persisted node cap (MAP SIZE control). Read once from localStorage; null
   // means "follow the server default" — useObservatory then omits ?max=.
@@ -85,7 +111,7 @@ export default function ObservatoryApp({ adminFetch }: { adminFetch: AdminFetch 
     const stored = Number(window.localStorage.getItem(MAX_STORAGE_KEY));
     return Number.isFinite(stored) && stored > 0 ? stored : null;
   });
-  const { data: lib, loading, error } = useObservatory(adminFetch, true, maxNodes);
+  const { data: lib, loading, error, reload } = useObservatory(adminFetch, true, maxNodes);
   const { detail, loadingId, fetchDetail } = useTrackDetail(adminFetch);
 
   const [q, setQ] = useState('');
@@ -101,14 +127,33 @@ export default function ObservatoryApp({ adminFetch }: { adminFetch: AdminFetch 
     const id = setTimeout(() => setQDebounced(q), 150);
     return () => clearTimeout(id);
   }, [q]);
-  const [colorBy, setColorBy] = useState<ColorBy>('energy');
+  // Colour-by is deep-linkable (?color=); the page only mounts after admin
+  // auth hydrates, so reading the URL in the initializer never runs on SSR.
+  const [colorBy, setColorBy] = useState<ColorBy>(() => {
+    if (typeof window === 'undefined') return 'energy';
+    const c = new URLSearchParams(window.location.search).get('color') as ColorBy | null;
+    return c && COLOR_IDS.has(c) ? c : 'energy';
+  });
   const [energy, setEnergy] = useState<Set<string>>(new Set());
   const [moods, setMoods] = useState<Set<string>>(new Set());
   const [genres, setGenres] = useState<Set<string>>(new Set());
+  const [genresExpanded, setGenresExpanded] = useState(false);
   const [sources, setSources] = useState<Set<string>>(new Set());
   const [analysedOnly, setAnalysedOnly] = useState(false);
   const [selected, setSelected] = useState<ObsTrack | null>(null);
   const [tip, setTip] = useState<TipState | null>(null);
+  const [searchOpen, setSearchOpen] = useState(false);
+
+  // Fly-to requests for the galaxy camera: bumped by search picks, MIX NEXT
+  // picks and deep links — never by plain map clicks (the node is already
+  // under the cursor there).
+  const focusNonce = useRef(0);
+  const [focusOn, setFocusOn] = useState<{ t: ObsTrack; n: number } | null>(null);
+  const jumpTo = useCallback((t: ObsTrack) => {
+    setSelected(t);
+    focusNonce.current += 1;
+    setFocusOn({ t, n: focusNonce.current });
+  }, []);
 
   const setMax = (n: number) => {
     setMaxNodes(n);
@@ -139,6 +184,16 @@ export default function ObservatoryApp({ adminFetch }: { adminFetch: AdminFetch 
   const genreOptions = useMemo(() => (lib ? lib.genres.filter((g) => g !== '—') : []), [lib]);
   const sourceOptions = useMemo(() => (lib ? Object.keys(lib.stats.bySource || {}) : []), [lib]);
 
+  // Genre chips: top-N by population (lib.genres is already sorted), plus any
+  // selected genre that would otherwise be hidden, plus a +N MORE toggle.
+  const visibleGenres = useMemo(() => {
+    if (genresExpanded || genreOptions.length <= GENRE_CHIP_CAP) return genreOptions;
+    const top = genreOptions.slice(0, GENRE_CHIP_CAP);
+    const topSet = new Set(top);
+    for (const g of genres) if (!topSet.has(g) && genreOptions.includes(g)) top.push(g);
+    return top;
+  }, [genreOptions, genresExpanded, genres]);
+
   const matched = useMemo(() => {
     if (!lib) return [];
     const qq = qDebounced.trim().toLowerCase();
@@ -156,6 +211,32 @@ export default function ObservatoryApp({ adminFetch }: { adminFetch: AdminFetch 
   const matchSet = useMemo(() => new Set(matched.map((t) => t.idx)), [matched]);
 
   const byId = useMemo(() => new Map((lib?.tracks || []).map((t) => [t.id, t])), [lib]);
+
+  // A reload (retry button, post-projection refresh) rebuilds every ObsTrack —
+  // re-point the selection at the new object so the highlight ring and wiring
+  // don't sit on stale coordinates (or on a mock node after recovery).
+  useEffect(() => {
+    setSelected((cur) => (cur ? (byId.get(cur.id) ?? null) : cur));
+  }, [byId]);
+
+  // Top search hits for the jump-to dropdown: title matches first, then any
+  // other field match, single pass with an early exit so a keystroke never
+  // pays more than one O(n) scan even at the 500k cap.
+  const searchHits = useMemo(() => {
+    const qq = qDebounced.trim().toLowerCase();
+    if (!qq) return [];
+    const primary: ObsTrack[] = [];
+    const secondary: ObsTrack[] = [];
+    for (const t of matched) {
+      if ((t.title || '').toLowerCase().includes(qq)) {
+        primary.push(t);
+        if (primary.length >= 8) break;
+      } else if (secondary.length < 8) {
+        secondary.push(t);
+      }
+    }
+    return primary.concat(secondary).slice(0, 8);
+  }, [matched, qDebounced]);
 
   // Mix-next nodes (for both the map wiring and the dossier list). Prefer the
   // server's real KNN neighbours; fall back to spatial nearest until the detail
@@ -179,6 +260,117 @@ export default function ObservatoryApp({ adminFetch }: { adminFetch: AdminFetch 
     setAnalysedOnly(false);
   };
 
+  // ---- deep links: ?track=<id> applied once the real library arrives --------
+  // Captured ONCE at mount: the URL-sync effect below rewrites the query string
+  // from the (initially empty) selection before the library has loaded, so by
+  // the time tracks exist the live URL no longer carries the param.
+  const initialTrack = useRef<string | null>(
+    typeof window === 'undefined' ? null : new URLSearchParams(window.location.search).get('track'),
+  );
+  const deepLinked = useRef(false);
+  useEffect(() => {
+    if (!lib || lib.mock || deepLinked.current) return;
+    deepLinked.current = true;
+    const id = initialTrack.current;
+    if (!id) return;
+    const t = byId.get(id);
+    if (t) jumpTo(t);
+  }, [lib, byId, jumpTo]);
+
+  // …and kept in sync (replaceState — no navigation, no history spam).
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const sp = new URLSearchParams(window.location.search);
+    if (selected && !lib?.mock) sp.set('track', selected.id);
+    else sp.delete('track');
+    if (colorBy !== 'energy') sp.set('color', colorBy);
+    else sp.delete('color');
+    const qs = sp.toString();
+    const next = window.location.pathname + (qs ? `?${qs}` : '');
+    if (next !== window.location.pathname + window.location.search) {
+      window.history.replaceState(null, '', next);
+    }
+  }, [selected, colorBy, lib]);
+
+  // ---- Escape backs out: dossier first, then the search query ---------------
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      if (selected) setSelected(null);
+      else if (q) setQ('');
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [selected, q]);
+
+  // ---- sound-map projection: status + manual trigger ------------------------
+  // Adopt the status that rode the bulk load, then poll the lightweight status
+  // endpoint while a run is live; when it finishes, reload the map so the new
+  // coordinates (and the entrance animation they deserve) come in.
+  const [proj, setProj] = useState<MapProjectionStatus | null>(null);
+  const [projBusy, setProjBusy] = useState(false);
+  useEffect(() => {
+    setProj(lib?.mapProjection ?? null);
+  }, [lib]);
+  useEffect(() => {
+    if (!proj?.running) return;
+    let cancelled = false;
+    const id = setInterval(async () => {
+      try {
+        const res = await adminFetch('/library/observatory/projection');
+        if (!res.ok || cancelled) return;
+        const body = (await res.json()) as MapProjectionStatus;
+        if (cancelled) return;
+        setProj(body);
+        if (!body.running) reload();
+      } catch {
+        /* transient — keep polling */
+      }
+    }, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [proj?.running, adminFetch, reload]);
+  const startProjection = useCallback(async () => {
+    setProjBusy(true);
+    try {
+      const res = await adminFetch('/library/observatory/project', { method: 'POST' });
+      const body = await res.json().catch(() => null);
+      if (body?.status) setProj(body.status as MapProjectionStatus);
+    } catch {
+      /* button stays; operator can retry */
+    } finally {
+      setProjBusy(false);
+    }
+  }, [adminFetch]);
+
+  // ---- queue a track on air (the dossier's QUEUE button) ---------------------
+  const queueTrack = useCallback(
+    async (t: ObsTrack): Promise<{ ok: boolean; message: string }> => {
+      try {
+        const res = await adminFetch('/dj/queue-track', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            id: t.id,
+            title: t.title || 'Untitled',
+            artist: t.artist,
+            album: t.album,
+            year: t.year,
+            genre: t.genre,
+          }),
+        });
+        const body = await res.json().catch(() => null);
+        if (!res.ok) return { ok: false, message: body?.error || `queue failed (${res.status})` };
+        return { ok: true, message: 'queued' };
+      } catch (err) {
+        return { ok: false, message: err instanceof Error ? err.message : 'queue failed' };
+      }
+    },
+    [adminFetch],
+  );
+
   // Stable identities so the galaxy's attribute-refresh effects don't re-run
   // on the parent re-render a hover (tip state) triggers.
   const onHover = useCallback((t: ObsTrack | null, e?: React.MouseEvent) => {
@@ -199,6 +391,8 @@ export default function ObservatoryApp({ adminFetch }: { adminFetch: AdminFetch 
   const maxOptions = Array.from(new Set([...MAX_LADDER.filter((n) => n <= hardMax), effectiveMax])).sort(
     (a, b) => a - b,
   );
+
+  const projLastLine = proj?.lastLog?.length ? proj.lastLog[proj.lastLog.length - 1] : null;
 
   return (
     <div className="observatory-root">
@@ -263,28 +457,74 @@ export default function ObservatoryApp({ adminFetch }: { adminFetch: AdminFetch 
         </div>
       </header>
 
+      {/* load failures never blank the view (the sample map fills in) — but
+          they must not masquerade as a fresh install either */}
+      {error && (
+        <div className="obs-error" role="alert">
+          <span>
+            COULDN&apos;T LOAD THE LIBRARY ({error})
+            {lib?.mock ? ' — SHOWING SAMPLE DATA' : ' — SHOWING THE LAST GOOD MAP'}
+          </span>
+          <button onClick={reload} disabled={loading}>
+            {loading ? 'RETRYING…' : 'RETRY'}
+          </button>
+        </div>
+      )}
+
       <div className="obs-main">
         {/* filter rail */}
         <aside className="obs-rail">
-          <div className="rail-search">
-            <span className="rail-search-ico">♪</span>
-            <input value={q} onChange={(e) => setQ(e.target.value)} placeholder="scanning the dial…" />
+          <div className="rail-search-wrap">
+            <div className="rail-search">
+              <span className="rail-search-ico">♪</span>
+              <input
+                value={q}
+                onChange={(e) => {
+                  setQ(e.target.value);
+                  setSearchOpen(true); // typing reopens after a pick closed it
+                }}
+                onFocus={() => setSearchOpen(true)}
+                onBlur={() => setSearchOpen(false)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && searchHits.length) {
+                    jumpTo(searchHits[0]!);
+                    (e.target as HTMLInputElement).blur();
+                  }
+                }}
+                placeholder="scanning the dial…"
+                aria-label="search the library"
+              />
+            </div>
+            {searchOpen && searchHits.length > 0 && (
+              <div className="rail-search-results" role="listbox">
+                {searchHits.map((t) => (
+                  <button
+                    key={t.idx}
+                    className="rail-search-hit"
+                    role="option"
+                    aria-selected={selected?.idx === t.idx}
+                    // mousedown, not click — it must beat the input's blur
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      jumpTo(t);
+                      setSearchOpen(false);
+                    }}
+                  >
+                    <span className="hit-title">{t.title || 'Untitled'}</span>
+                    <span className="hit-artist">
+                      {t.artist || 'Unknown'}
+                      {t.genre ? ` · ${t.genre}` : ''}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
 
           <div className="rail-sec">
             <div className="rail-label">COLOUR BY</div>
             <div className="flt-grid2">
-              {(
-                [
-                  ['energy', 'ENERGY'],
-                  ['confidence', 'CONF'],
-                  ['source', 'SOURCE'],
-                  ['analysis', 'ANALYSIS'],
-                  ['loudness', 'LOUDNESS'],
-                  ['pace', 'PACE'],
-                  ['vocal', 'VOICE'],
-                ] as [ColorBy, string][]
-              ).map(([k, l]) => (
+              {COLOR_MODES.map(([k, l]) => (
                 <button key={k} className={'flt-tog' + (colorBy === k ? ' on' : '')} onClick={() => setColorBy(k)}>
                   {l}
                 </button>
@@ -307,11 +547,16 @@ export default function ObservatoryApp({ adminFetch }: { adminFetch: AdminFetch 
             <div className="rail-sec">
               <div className="rail-label">SCENE</div>
               <div className="flt-chips">
-                {genreOptions.map((g) => (
+                {visibleGenres.map((g) => (
                   <button key={g} className={'flt-chip' + (genres.has(g) ? ' on' : '')} onClick={() => toggleIn(setGenres)(g)}>
                     {g}
                   </button>
                 ))}
+                {genreOptions.length > GENRE_CHIP_CAP && (
+                  <button className="flt-chip flt-chip-more" onClick={() => setGenresExpanded((v) => !v)}>
+                    {genresExpanded ? '− less' : `+ ${genreOptions.length - GENRE_CHIP_CAP} more`}
+                  </button>
+                )}
               </div>
             </div>
           )}
@@ -356,6 +601,27 @@ export default function ObservatoryApp({ adminFetch }: { adminFetch: AdminFetch 
             <div className="ad-muted t-caption">
               GALAXY RENDERER · {lib?.soundMap ? 'PLACED BY SOUND' : 'PLACED BY GENRE'}
             </div>
+            {!lib?.mock &&
+              proj &&
+              (proj.running ? (
+                <div className="rail-proj">
+                  <span className="rail-proj-live t-caption">
+                    <span className="obs-live-dot" /> PROJECTING SOUND MAP…
+                  </span>
+                  {projLastLine && <span className="ad-muted t-caption rail-proj-log">{projLastLine}</span>}
+                </div>
+              ) : proj.audioVectors >= PROJECTION_MIN_VECTORS ? (
+                <div className="rail-proj">
+                  {proj.stale && (
+                    <span className="t-caption" style={{ color: 'var(--accent)' }}>
+                      SOUND MAP OUT OF DATE
+                    </span>
+                  )}
+                  <button className="flt-tog wide" onClick={startProjection} disabled={projBusy}>
+                    {projBusy ? 'STARTING…' : proj.meta ? 'RE-PROJECT SOUND MAP' : 'PROJECT SOUND MAP'}
+                  </button>
+                </div>
+              ) : null)}
           </div>
         </aside>
 
@@ -376,6 +642,7 @@ export default function ObservatoryApp({ adminFetch }: { adminFetch: AdminFetch 
               selected={selected}
               neighbours={mixNodes}
               hovered={tip ? tip.track : null}
+              focus={focusOn}
               onHover={onHover}
               onSelect={onSelect}
             />
@@ -395,8 +662,9 @@ export default function ObservatoryApp({ adminFetch }: { adminFetch: AdminFetch 
                 detail={detail && detail.track.id === selected.id ? detail : null}
                 loading={loadingId === selected.id}
                 mixNodes={mixNodes}
-                onSelect={setSelected}
+                onSelect={jumpTo}
                 onClose={() => setSelected(null)}
+                onQueue={lib.mock ? undefined : queueTrack}
               />
             ) : (
               <StatsView stats={lib.stats} list={matched} filtered={matched.length !== lib.tracks.length} />

--- a/web/components/observatory/data.ts
+++ b/web/components/observatory/data.ts
@@ -221,6 +221,18 @@ export interface ObservatoryStats {
   updatedAt: string | null;
 }
 
+// Sound-map projection job status, mirrored from the controller's
+// map-projection.ts ProjectionStatus. Rides the bulk load and the lightweight
+// GET /library/observatory/projection poll.
+export interface MapProjectionStatus {
+  running: boolean;
+  startedAt: string | null;
+  lastLog: string[];
+  meta: { algo: string; space: string; count: number; setAt: string } | null;
+  audioVectors: number;
+  stale: boolean;
+}
+
 export interface LibraryData {
   tracks: ObsTrack[];
   genres: string[];
@@ -232,6 +244,7 @@ export interface LibraryData {
   sampled: boolean; // truncated via a stratified per-genre sample (vs. full)
   max: number | null; // node cap the server applied to this load (null: mock)
   hardMax: number; // ceiling the UI may raise the node cap to
+  mapProjection: MapProjectionStatus | null; // null: mock / older controller
   mock: boolean;
 }
 
@@ -723,6 +736,7 @@ export function buildMockLibrary(count = 400): LibraryData {
     sampled: false,
     max: null,
     hardMax: 100000,
+    mapProjection: null,
     mock: true,
   };
 }

--- a/web/components/observatory/panels.tsx
+++ b/web/components/observatory/panels.tsx
@@ -8,7 +8,7 @@
    ============================================================================ */
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   heat,
   tally,
@@ -501,6 +501,7 @@ export function Dossier({
   mixNodes,
   onSelect,
   onClose,
+  onQueue,
 }: {
   track: ObsTrack;
   detail: TrackDetail | null;
@@ -508,11 +509,21 @@ export function Dossier({
   mixNodes: ObsTrack[];
   onSelect: (t: ObsTrack) => void;
   onClose: () => void;
+  // Push this track to the live broadcast queue. Absent on the mock/showcase
+  // dossier, which hides the button entirely.
+  onQueue?: (t: ObsTrack) => Promise<{ ok: boolean; message: string }>;
 }) {
   const dur = (s: number | null) => (s == null ? '—' : `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`);
   const d = detail?.track;
   const lastfm = d?.lastfmTags ?? null;
   const lyric = d?.lyricExcerpt ?? null;
+
+  const [queueState, setQueueState] = useState<'idle' | 'busy' | 'done' | 'error'>('idle');
+  const [queueMsg, setQueueMsg] = useState('');
+  useEffect(() => {
+    setQueueState('idle');
+    setQueueMsg('');
+  }, [track.id]);
 
   return (
     <div className="obs-stack dossier">
@@ -534,6 +545,28 @@ export function Dossier({
           <div className="t-caption ad-muted" style={{ marginTop: 4 }}>
             {track.album}
           </div>
+        )}
+        {onQueue && (
+          <>
+            <button
+              className={'dossier-queue' + (queueState === 'done' ? ' done' : '')}
+              disabled={queueState === 'busy' || queueState === 'done'}
+              onClick={async () => {
+                setQueueState('busy');
+                const r = await onQueue(track);
+                setQueueState(r.ok ? 'done' : 'error');
+                setQueueMsg(r.ok ? '' : r.message);
+              }}
+            >
+              {queueState === 'idle' && '▶ QUEUE ON AIR'}
+              {queueState === 'busy' && 'QUEUEING…'}
+              {queueState === 'done' && 'QUEUED ✓'}
+              {queueState === 'error' && 'FAILED — RETRY'}
+            </button>
+            {queueState === 'error' && queueMsg && (
+              <div className="t-caption dossier-queue-err">{queueMsg}</div>
+            )}
+          </>
         )}
       </div>
 

--- a/web/lib/observatory.ts
+++ b/web/lib/observatory.ts
@@ -5,6 +5,7 @@ import {
   layoutTracks,
   buildMockLibrary,
   type LibraryData,
+  type MapProjectionStatus,
   type RawTrack,
   type ObservatoryStats,
   type TrackDetail,
@@ -16,6 +17,7 @@ interface ObservatoryResult {
   data: LibraryData | null;
   loading: boolean;
   error: string | null;
+  reload: () => void;
 }
 
 interface BulkResponse {
@@ -24,6 +26,7 @@ interface BulkResponse {
   sampled?: boolean;
   max: number;
   hardMax?: number;
+  mapProjection?: MapProjectionStatus;
   moodVocab: string[];
   stats: ObservatoryStats;
 }
@@ -34,17 +37,22 @@ interface BulkResponse {
 // Changing `max` (the MAP SIZE control) refetches with a higher/lower cap;
 // `max: null` sends no cap so the server's own default (OBSERVATORY_MAX)
 // applies — the response's `max` reports what was used.
+// On a fetch error the mock only fills an EMPTY view (never a dead screen, but
+// never clobbering a map a previous load produced) and `error` stays set so
+// the UI can say the controller was unreachable; `reload()` refetches in place
+// (the retry button, and the refresh after a projection run completes).
 export function useObservatory(adminFetch: AdminFetch, enabled: boolean, max: number | null): ObservatoryResult {
   const [data, setData] = useState<LibraryData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [nonce, setNonce] = useState(0);
+  const reload = useCallback(() => setNonce((n) => n + 1), []);
 
   useEffect(() => {
     if (!enabled) return;
     let cancelled = false;
     (async () => {
       setLoading(true);
-      setError(null);
       try {
         const res = await adminFetch(
           max == null ? '/library/observatory' : `/library/observatory?max=${encodeURIComponent(max)}`,
@@ -52,6 +60,7 @@ export function useObservatory(adminFetch: AdminFetch, enabled: boolean, max: nu
         if (!res.ok) throw new Error(`controller error (${res.status})`);
         const body = (await res.json()) as BulkResponse;
         if (cancelled) return;
+        setError(null);
         if (!body.tracks || body.tracks.length === 0) {
           setData(buildMockLibrary());
         } else {
@@ -67,14 +76,14 @@ export function useObservatory(adminFetch: AdminFetch, enabled: boolean, max: nu
             sampled: !!body.sampled,
             max: body.max ?? null,
             hardMax: body.hardMax ?? 50000,
+            mapProjection: body.mapProjection ?? null,
             mock: false,
           });
         }
       } catch (err) {
         if (cancelled) return;
         setError(err instanceof Error ? err.message : 'failed to load library');
-        // Still render something useful rather than a dead screen.
-        setData(buildMockLibrary());
+        setData((cur) => cur ?? buildMockLibrary());
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -82,9 +91,9 @@ export function useObservatory(adminFetch: AdminFetch, enabled: boolean, max: nu
     return () => {
       cancelled = true;
     };
-  }, [adminFetch, enabled, max]);
+  }, [adminFetch, enabled, max, nonce]);
 
-  return { data, loading, error };
+  return { data, loading, error, reload };
 }
 
 // Lazily fetches the rich per-track dossier (full record + embeddings +


### PR DESCRIPTION
## What

Production-readiness pass over the Library Observatory (`/observatory`): one legend bug, two "the data existed but the UI dropped it" gaps, and the feature set that turns it from a viewer into a working tool.

### Fixed
- **Legend told the wrong story for 3 of 7 colour-by modes.** LOUDNESS and PACE colour nodes with the heat ramp and VOICE uses a three-way palette, but the legend fell through to the ANALYSED/NOT-ANALYSED key with an 'acoustic analysis' label. Each mode now gets the key its `nodeColor`/`nodeFilled` actually draw.
- **Load failures masqueraded as a fresh install.** An expired session or 500 rendered the seeded mock labeled SAMPLE DATA with no hint anything failed. Errors now ride a banner with RETRY; the mock only fills an *empty* view and never clobbers the last good map.
- **Deep-link ordering**: `?track=` is captured once at mount so the URL-sync effect can't strip it before the library loads.

### Added
- **Sound-map projection surfaced**: new lightweight `GET /library/observatory/projection`; `mapProjection` plumbed through the bulk response into the UI. The rail footer shows a live PROJECTING state with the UMAP child's last log line, flags a stale map, and offers a (RE-)PROJECT button (`POST /library/observatory/project` finally has a UI). The app polls while a run is live and reloads the map when it completes.
- **Search that takes you there**: jump-to dropdown under the rail search (title matches first, Enter picks the first hit) with an animated camera fly-to. MIX NEXT picks fly too.
- **QUEUE ON AIR** in the dossier — pushes the open track to the broadcast queue via the existing `POST /dj/queue-track` (idle/queueing/queued/failed states; hidden on sample data and the landing-page showcase).
- **Deep links**: `?track=<id>&color=<mode>` select + fly on load, kept in sync via `replaceState` — bookmarkable/shareable views.
- **Keyboard access**: Escape closes the dossier (then clears search); the map is focusable — arrows pan, +/− zoom, 0 resets, visible focus ring.
- **Genre chips cap** at 24 with a +N MORE toggle so 100+-genre libraries don't wall off the rail (selected chips stay visible).
- **Mobile**: below 900px the full-page view stacks header → map → filters → panels and the page scrolls (the landing-page embed keeps its own layout, scoped via `:not(.obs-embed)`).
- Manual page (`/manual/observatory`) updated for the queue action, fly-to and shareable links.

## Notes for review
- Reload paths re-point the selection at the rebuilt `ObsTrack` by id so the highlight ring never sits on stale coordinates.
- The fly-to eases zoom geometrically over 600ms and honours `prefers-reduced-motion` (instant jump).
- `searchHits` is a single O(n) pass with early exit — no per-keystroke sort at the 500k cap.
- Showcase/embed unchanged: new `focus`/`onQueue` props are optional.

## Testing
- `web`: `tsc --noEmit` produces **no new errors** vs the develop baseline (the pre-existing `ai-elements`/`ui` module errors come from stale local node_modules, also present untouched on develop); eslint clean on all changed files.
- `controller`: `npm run lint` passes (0 errors).