### PR TITLE
fix(web): resolve SEO/share metadata from runtime SITE_URL, fix titles and twitter cards

### DIFF
--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -203,8 +203,8 @@ services:
       context: .
       dockerfile: web/Dockerfile
       args:
-        # Needed at BUILD time for statically-rendered routes (robots, sitemap,
-        # /listen, /landing) — Next bakes their metadata at build.
+        # Belt-and-suspenders for source builds only — every route that emits
+        # absolute URLs renders per-request off the RUNTIME env below.
         - SITE_URL=\${SITE_URL:-}
         # NEXT_PUBLIC_* is inlined into the client bundle at BUILD time.
         - NEXT_PUBLIC_GA_ID=\${NEXT_PUBLIC_GA_ID:-}
@@ -224,9 +224,10 @@ services:
     environment:
       - NODE_ENV=production
       - SUBWAVE_HOMEPAGE=\${SUBWAVE_HOMEPAGE:-player}
-      # Also needed at RUNTIME: the homepage (/) is force-dynamic, so its
-      # share-card tags render per-request. Define SITE_URL once in .env and
-      # both build-arg and runtime env pick it up.
+      # The RUNTIME source of truth for absolute URLs: canonicals, og:url,
+      # robots.txt, and sitemap.xml all render per-request from this env, so
+      # the generic published image serves the operator's real domain. Define
+      # SITE_URL once in .env.
       - SITE_URL=\${SITE_URL:-}
       # Google Analytics Measurement ID at RUNTIME (web/lib/ga.ts). Plumbs the
       # operator's NEXT_PUBLIC_GA_ID from .env into a runtime var, so analytics

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,8 +194,8 @@ services:
       context: .
       dockerfile: web/Dockerfile
       args:
-        # Needed at BUILD time for statically-rendered routes (robots, sitemap,
-        # /listen, /landing) — Next bakes their metadata at build.
+        # Belt-and-suspenders for source builds only — every route that emits
+        # absolute URLs renders per-request off the RUNTIME env below.
         - SITE_URL=${SITE_URL:-}
         # NEXT_PUBLIC_* is inlined into the client bundle at BUILD time.
         - NEXT_PUBLIC_GA_ID=${NEXT_PUBLIC_GA_ID:-}
@@ -215,9 +215,10 @@ services:
     environment:
       - NODE_ENV=production
       - SUBWAVE_HOMEPAGE=${SUBWAVE_HOMEPAGE:-player}
-      # Also needed at RUNTIME: the homepage (/) is force-dynamic, so its
-      # share-card tags render per-request. Define SITE_URL once in .env and
-      # both build-arg and runtime env pick it up.
+      # The RUNTIME source of truth for absolute URLs: canonicals, og:url,
+      # robots.txt, and sitemap.xml all render per-request from this env, so
+      # the generic published image serves the operator's real domain. Define
+      # SITE_URL once in .env.
       - SITE_URL=${SITE_URL:-}
       # Google Analytics Measurement ID at RUNTIME (web/lib/ga.ts). Plumbs the
       # operator's NEXT_PUBLIC_GA_ID from .env into a runtime var, so analytics

--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -32,10 +32,10 @@ COPY web/package.json web/package-lock.json ./
 RUN npm ci
 COPY web/ ./
 ENV NEXT_TELEMETRY_DISABLED=1
-# SITE_URL is frozen into statically-rendered routes (robots, sitemap, OG cards)
-# at build time. For the AIO it's unknown until the operator sets it, so we bake
-# the localhost fallback; the force-dynamic homepage still reads the runtime
-# SITE_URL env for live share-card tags.
+# The routes that emit absolute URLs (robots, sitemap, canonicals, OG cards)
+# all render per-request and read the RUNTIME SITE_URL env (inherited by the
+# web server via the supervisor), so a generic image works for any domain.
+# This build arg is belt-and-suspenders for source builds only.
 ARG SITE_URL
 ENV SITE_URL=${SITE_URL}
 # Admin-console footer version, inlined into the web bundle at build time. See
@@ -205,6 +205,9 @@ COPY controller/scripts ./scripts
 COPY --from=webbuild /web/.next/standalone /web
 COPY --from=webbuild /web/.next/static /web/.next/static
 COPY --from=webbuild /web/public /web/public
+# The /news routes (and the sitemap) render per-request, so the dispatch
+# markdown is read at runtime — the standalone trace doesn't include it.
+COPY --from=webbuild /web/content /web/content
 
 # --- Broadcast + edge config + bundled audio --------------------------------
 COPY docker/icecast.xml.template /etc/icecast2/icecast.xml.template

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -13,10 +13,12 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY web/ ./
 ENV NEXT_TELEMETRY_DISABLED=1
-# Public site origin, baked into the OG/Twitter cards, canonical URLs, robots
-# and sitemap. Next freezes metadata at build time, so this has to be present
-# *here*, not as a runtime container env var. Passed through from compose
-# (docker-compose.yml → web.build.args). Unset → localhost fallback.
+# Public site origin. The routes that emit absolute URLs (canonicals, og:url,
+# robots, sitemap) all render per-request now and read the RUNTIME container
+# env — a published image can't know the operator's domain at build time (see
+# web/lib/site.ts). This build arg remains only as belt-and-suspenders for
+# source builds; leaving it unset is fine as long as SITE_URL is set on the
+# running container (docker-compose.yml → web.environment).
 ARG SITE_URL
 ENV SITE_URL=${SITE_URL}
 # Google Analytics Measurement ID. This build arg bakes it into the client
@@ -51,6 +53,9 @@ COPY --from=build --chown=next:next /app/.next/static ./.next/static
 # `public/` is *not* included by the standalone trace — copy it explicitly so
 # the service worker (/sw.js) and any other static assets are served at root.
 COPY --from=build --chown=next:next /app/public ./public
+# The /news routes (and the sitemap) render per-request, so the dispatch
+# markdown is read at runtime — the standalone trace doesn't include it.
+COPY --from=build --chown=next:next /app/content ./content
 
 USER next
 EXPOSE 7700

--- a/web/app/landing/page.tsx
+++ b/web/app/landing/page.tsx
@@ -9,6 +9,12 @@ export const metadata = pageMeta({
   path: '/landing',
 });
 
+// Render per-request so the canonical/og:url pick up the runtime SITE_URL.
+// The showcase-station fetch keeps its own ISR revalidate window (explicit
+// per-fetch options win over the force-dynamic no-store default), so this
+// costs a re-render from cached data, not a catalog refetch per request.
+export const dynamic = 'force-dynamic';
+
 // Fixed app-shell layout — lock out pinch-zoom on mobile. Merges with root.
 export const viewport = {
   maximumScale: 1,

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -139,8 +139,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 
         {/* Absolute share-card image tags — see the metadata comment above for
             why these bypass the Metadata API. Per-page canonical + og:url are
-            set via lib/seo's pageMeta(). SITE_URL is baked at build time from
-            the Docker build arg. */}
+            set via lib/seo's pageMeta(). SITE_URL is resolved from the runtime
+            container env — the public pages render per-request (see
+            lib/site.ts), so these tags always carry the operator's domain. */}
         <meta property="og:image" content={`${SITE_URL}/og`} />
         <meta property="og:image:type" content="image/png" />
         <meta property="og:image:width" content="1200" />

--- a/web/app/listen/page.tsx
+++ b/web/app/listen/page.tsx
@@ -10,6 +10,10 @@ export const metadata = pageMeta({
   path: '/listen',
 });
 
+// Render per-request so the canonical/og:url pick up the runtime SITE_URL — a
+// build-time render bakes localhost into image-based installs (see lib/site.ts).
+export const dynamic = 'force-dynamic';
+
 // The player is a fixed, app-shell layout — lock out pinch-zoom so it
 // behaves like a native app on mobile. Merges with the root viewport.
 export const viewport: Viewport = {

--- a/web/app/manual/layout.tsx
+++ b/web/app/manual/layout.tsx
@@ -9,6 +9,12 @@ export const metadata: Metadata = {
     'How to use SUB/WAVE — tuning in, making requests, how the AI DJ works, and running the station from the admin console.',
 };
 
+// Render per-request so the absolute canonical/og:url on every manual page
+// picks up the runtime SITE_URL — the published image is built without the
+// operator's domain, so build-time rendering bakes localhost URLs into all
+// image-based installs (see lib/site.ts).
+export const dynamic = 'force-dynamic';
+
 export default function ManualLayout({ children }: { children: ReactNode }) {
   return (
     <DocShell pages={MANUAL_PAGES} eyebrow="THE MANUAL" ariaLabel="Manual contents">

--- a/web/app/news/[slug]/page.tsx
+++ b/web/app/news/[slug]/page.tsx
@@ -2,18 +2,14 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { AnimatedLink } from '@/components/ui/animated-link';
-import {
-  getAllNews,
-  getNewsArticle,
-  getNewsSlugs,
-  formatNewsDate,
-} from '@/lib/news';
+import { getAllNews, getNewsArticle, formatNewsDate } from '@/lib/news';
 import JsonLd from '@/components/JsonLd';
 import { absoluteUrl } from '@/lib/seo';
 
-export function generateStaticParams() {
-  return getNewsSlugs().map((slug) => ({ slug }));
-}
+// Render per-request like the rest of the news segment — generateStaticParams
+// would win over the layout's force-dynamic and prerender each article with
+// the build-time (localhost) SITE_URL baked into its canonical/og:url.
+export const dynamic = 'force-dynamic';
 
 export async function generateMetadata({
   params,
@@ -22,10 +18,12 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params;
   const article = getNewsArticle(slug);
-  if (!article) return { title: 'SUB/WAVE — Dispatches' };
+  if (!article) return { title: { absolute: 'SUB/WAVE — Dispatches' } };
   const url = absoluteUrl(`/news/${article.slug}`);
   return {
-    title: `${article.title} — SUB/WAVE`,
+    // `absolute` opts out of the root layout's `%s · SUB/WAVE` template —
+    // the brand is already appended here.
+    title: { absolute: `${article.title} — SUB/WAVE` },
     description: article.excerpt,
     alternates: { canonical: url },
     openGraph: {
@@ -37,6 +35,13 @@ export async function generateMetadata({
       publishedTime: article.date || undefined,
       modifiedTime: article.date || undefined,
       authors: article.author ? [article.author] : undefined,
+    },
+    // Restated so X shows the article title/excerpt instead of the sitewide
+    // card inherited from the root layout (twitter:* wins over og:* there).
+    twitter: {
+      card: 'summary_large_image',
+      title: article.title,
+      description: article.excerpt,
     },
   };
 }

--- a/web/app/news/layout.tsx
+++ b/web/app/news/layout.tsx
@@ -8,6 +8,13 @@ export const metadata: Metadata = {
     'News and updates from the SUB/WAVE desk — new features, fixes, and short how-tos for running your own AI radio station.',
 };
 
+// Render per-request so canonicals/og:url pick up the runtime SITE_URL — a
+// build-time render bakes localhost into image-based installs (see
+// lib/site.ts). This also moves the content/news markdown read to request
+// time, so the Docker runner stages copy content/ alongside the standalone
+// bundle (web/Dockerfile, docker/Dockerfile.aio).
+export const dynamic = 'force-dynamic';
+
 export default function NewsLayout({ children }: { children: ReactNode }) {
   return <NewsShell>{children}</NewsShell>;
 }

--- a/web/app/onboarding/layout.tsx
+++ b/web/app/onboarding/layout.tsx
@@ -5,7 +5,9 @@ import type { ReactNode } from 'react';
 // request depending on setup state — there is nothing durable to index, so
 // keep it out of search results (it is already absent from the sitemap).
 export const metadata: Metadata = {
-  title: 'SUB/WAVE — Setup',
+  // `absolute` opts out of the root layout's `%s · SUB/WAVE` template — the
+  // brand is already in the title.
+  title: { absolute: 'SUB/WAVE — Setup' },
   robots: { index: false, follow: false },
 };
 

--- a/web/app/privacy/page.tsx
+++ b/web/app/privacy/page.tsx
@@ -7,6 +7,10 @@ export const metadata = pageMeta({
   path: '/privacy',
 });
 
+// Render per-request so the canonical/og:url pick up the runtime SITE_URL — a
+// build-time render bakes localhost into image-based installs (see lib/site.ts).
+export const dynamic = 'force-dynamic';
+
 export default function PrivacyPage() {
   return (
     <article className="bs-article">

--- a/web/app/robots.ts
+++ b/web/app/robots.ts
@@ -4,6 +4,13 @@ import { SITE_URL } from '@/lib/site';
 // Served by Next at /robots.txt. The admin console and the API proxy are
 // disallowed — the admin auth gate is client-side only, so the shell HTML is
 // still served and would otherwise be crawlable.
+
+// Rendered per-request so SITE_URL comes from the runtime container env. The
+// published GHCR image is built without knowing the operator's domain, so a
+// build-time render bakes the localhost fallback into every image-based
+// install. Same reasoning in sitemap.ts and the public page segments.
+export const dynamic = 'force-dynamic';
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {

--- a/web/app/setup/layout.tsx
+++ b/web/app/setup/layout.tsx
@@ -9,6 +9,10 @@ export const metadata: Metadata = {
     'Run your own SUB/WAVE — connect it to your Navidrome library and an LLM provider (Ollama by default) in about ten minutes.',
 };
 
+// Render per-request so canonicals/og:url pick up the runtime SITE_URL — a
+// build-time render bakes localhost into image-based installs (see lib/site.ts).
+export const dynamic = 'force-dynamic';
+
 export default function SetupLayout({ children }: { children: ReactNode }) {
   return (
     <DocShell pages={SETUP_PAGES} eyebrow="THE SETUP GUIDE" ariaLabel="Setup guide contents">

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -3,11 +3,16 @@ import { SITE_URL } from '@/lib/site';
 import { getAllNews } from '@/lib/news';
 
 // Served by Next at /sitemap.xml. Public, indexable routes only — the
-// admin console (/admin/*) is intentionally excluded.
+// admin console (/admin/*), /onboarding, and /observatory are intentionally
+// excluded (all noindexed).
 const ROUTES = [
   '/',
   '/listen',
   '/landing',
+  '/stations',
+  '/personas',
+  '/shows',
+  '/skills',
   '/manual',
   '/manual/getting-started',
   '/manual/requests',
@@ -21,33 +26,43 @@ const ROUTES = [
   '/manual/clients',
   '/manual/skills',
   '/manual/themes',
+  '/manual/analysis',
+  '/manual/observatory',
   '/manual/faq',
   '/setup',
   '/setup/prerequisites',
   '/setup/quick-start',
   '/setup/manual',
   '/setup/development',
+  '/setup/unraid',
   '/setup/updates',
   '/news',
+  '/privacy',
+  '/terms',
 ];
 
+// Rendered per-request so SITE_URL (and the news list) come from the runtime
+// container env / filesystem rather than being baked at image-build time —
+// the published GHCR image can't know the operator's domain. See robots.ts.
+export const dynamic = 'force-dynamic';
+
 export default function sitemap(): MetadataRoute.Sitemap {
-  const buildTime = new Date();
+  const now = new Date();
   const news = getAllNews();
 
   const staticEntries: MetadataRoute.Sitemap = ROUTES.map((route) => ({
     url: `${SITE_URL}${route}`,
-    lastModified: buildTime,
+    lastModified: now,
     changeFrequency: route === '/' || route === '/listen' ? 'daily' : 'monthly',
     priority: route === '/' ? 1 : route === '/listen' ? 0.9 : 0.6,
   }));
 
   // One entry per dispatch, stamped with the article's own date so crawlers
-  // see a stable lastModified instead of the build clock. Stays in sync with
+  // see a stable lastModified instead of the request clock. Stays in sync with
   // the markdown in content/news automatically.
   const newsEntries: MetadataRoute.Sitemap = news.map((a) => ({
     url: `${SITE_URL}/news/${a.slug}`,
-    lastModified: a.date ? new Date(`${a.date}T00:00:00Z`) : buildTime,
+    lastModified: a.date ? new Date(`${a.date}T00:00:00Z`) : now,
     changeFrequency: 'monthly',
     priority: 0.6,
   }));

--- a/web/app/stations/page.tsx
+++ b/web/app/stations/page.tsx
@@ -12,6 +12,11 @@ export const metadata = pageMeta({
   path: '/stations',
 });
 
+// Render per-request so the canonical/og:url pick up the runtime SITE_URL.
+// The directory fetch keeps its own ISR revalidate window (explicit per-fetch
+// options win over the force-dynamic no-store default).
+export const dynamic = 'force-dynamic';
+
 // Submission opens a GitHub Issue Form in the community catalog repo (no fork, no
 // JSON). A workflow there turns the issue into a one-file PR. The old new-file
 // editor link forced non-collaborators to fork the repo (discussion #296), so we

--- a/web/app/terms/page.tsx
+++ b/web/app/terms/page.tsx
@@ -7,6 +7,10 @@ export const metadata = pageMeta({
   path: '/terms',
 });
 
+// Render per-request so the canonical/og:url pick up the runtime SITE_URL — a
+// build-time render bakes localhost into image-based installs (see lib/site.ts).
+export const dynamic = 'force-dynamic';
+
 export default function TermsPage() {
   return (
     <article className="bs-article">

--- a/web/lib/news.ts
+++ b/web/lib/news.ts
@@ -1,7 +1,9 @@
 // News / "Dispatches" loader. Reads the markdown files under web/content/news,
-// parses their frontmatter, and renders the bodies to HTML. Everything here
-// runs server-side at build time (the /news routes are statically generated),
-// so the filesystem read never happens at request time in the standalone image.
+// parses their frontmatter, and renders the bodies to HTML. Server-side only.
+// The /news routes render per-request (see app/news/layout.tsx), so this read
+// happens at request time — the Docker runner stages copy content/ next to the
+// standalone bundle (web/Dockerfile, docker/Dockerfile.aio) to make the
+// markdown available at runtime.
 import fs from 'node:fs';
 import path from 'node:path';
 import matter from 'gray-matter';

--- a/web/lib/seo.ts
+++ b/web/lib/seo.ts
@@ -15,6 +15,14 @@ export function absoluteUrl(path = '/'): string {
 // Next does not deep-merge nested objects like `openGraph` across the
 // layout→page chain, so we restate siteName/title here rather than relying on
 // inheritance from the root layout.
+//
+// - `title` is passed pre-branded ("SUB/WAVE — …"), so it opts out of the root
+//   layout's `%s · SUB/WAVE` template via `absolute` — otherwise every page
+//   renders a doubled "SUB/WAVE — X · SUB/WAVE".
+// - `twitter` is restated because X prefers twitter:title/description over the
+//   og:* tags, and without it every subpage inherits the root layout's
+//   sitewide twitter card. twitter:image stays global (hand-written in the
+//   root layout <head>).
 export function pageMeta({
   title,
   description,
@@ -28,7 +36,7 @@ export function pageMeta({
 }): Metadata {
   const url = absoluteUrl(path);
   return {
-    title,
+    title: { absolute: title },
     ...(description ? { description } : {}),
     alternates: { canonical: url },
     openGraph: {
@@ -37,6 +45,11 @@ export function pageMeta({
       url,
       siteName: 'SUB/WAVE',
       type,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      ...(description ? { description } : {}),
     },
   };
 }

--- a/web/lib/site.ts
+++ b/web/lib/site.ts
@@ -1,16 +1,17 @@
 // Public site origin — the single source of truth for absolute URLs in
 // metadata, Open Graph / Twitter cards, robots, and the sitemap.
 //
-// IMPORTANT: SITE_URL must be set both at BUILD time and at RUNTIME.
-//  - Build: the statically-rendered routes (robots.txt, sitemap.xml, /listen,
-//    /landing, /manual, /setup) bake their share tags at build.
-//  - Runtime: the homepage (/) is force-dynamic, so its share tags render
-//    per-request and read the live container env.
-// The production Docker setup wires it through both (web/Dockerfile build arg
-// + docker-compose.yml `environment`); define SITE_URL once in
-// .env. NEXT_PUBLIC_SITE_URL is accepted as a fallback for older
-// configs. Defaults to the dev origin so local builds still produce a valid
-// `metadataBase` without Next's warning.
+// SITE_URL is resolved at RUNTIME: every route that emits an absolute URL
+// (robots.txt, sitemap.xml, and each public page's canonical/og:url via
+// `export const dynamic = 'force-dynamic'`) renders per-request, so the
+// running container's env is what matters. This is deliberate — the published
+// GHCR image is one generic build shared by every operator, so the domain
+// cannot be known at image-build time; baking it produced localhost URLs on
+// every image-based install. Define SITE_URL once in .env
+// (docker-compose.yml plumbs it into the web container's environment).
+// NEXT_PUBLIC_SITE_URL is accepted as a fallback for older configs. Defaults
+// to the dev origin so local builds still produce a valid `metadataBase`
+// without Next's warning.
 export const SITE_URL = (
   process.env.SITE_URL ||
   process.env.NEXT_PUBLIC_SITE_URL ||


### PR DESCRIPTION
## Problem

The production site is serving broken SEO metadata (verified live on www.getsubwave.com):

- `robots.txt` ends with `Host: http://localhost:7700` / `Sitemap: http://localhost:7700/sitemap.xml`
- every `<loc>` in `sitemap.xml` is `http://localhost:7700/...`
- every statically-rendered page (`/manual/*`, `/setup/*`, `/news/*`, `/privacy`, `/terms`, `/listen`) carries `<link rel="canonical" href="http://localhost:7700/...">` and matching `og:url`/`og:image`

Root cause: those routes render at **image build time**, and the published GHCR image is one generic build shared by every operator — it can't know the domain, so the `SITE_URL` localhost fallback gets baked in. Only the force-dynamic homepage (and ISR'd landing/stations after first revalidate) read the runtime env and came out right.

Three smaller issues rode along: doubled titles (`SUB/WAVE — Stations · SUB/WAVE` from the root title template stacking on pre-branded page titles), subpage X/Twitter shares showing the generic sitewide card (`twitter:*` inherited from the root layout wins over per-page `og:*`), and ~9 public routes missing from the sitemap.

## Fix

- **Runtime URLs**: `robots.ts`, `sitemap.ts`, and every public page segment now `force-dynamic`, so canonicals/og:url/og:image/robots/sitemap read the runtime `SITE_URL` env — which both prod composes already plumb into the web container. The landing/stations catalog fetches keep their explicit `revalidate: 1800`, so no extra upstream traffic.
- **Standalone images**: `web/content` is copied into the runner stage (`web/Dockerfile`, `docker/Dockerfile.aio`) since the /news markdown is now read per-request; `/news/[slug]` drops `generateStaticParams` (it forced prerendering past the layout's force-dynamic).
- **Titles**: `pageMeta()` and the news pages emit `title.absolute` so pre-branded titles opt out of the root `%s · SUB/WAVE` template.
- **Twitter cards**: `pageMeta()` and the news article metadata restate `twitter.title`/`description` per page.
- **Sitemap**: added `/stations` `/personas` `/shows` `/skills` `/privacy` `/terms` `/setup/unraid` `/manual/analysis` `/manual/observatory`; `/observatory` + `/onboarding` stay excluded (noindexed).
- Stale comments updated (`lib/site.ts`, Dockerfiles, compose) — the build-arg path is now belt-and-suspenders only.

## Verification

`npm run lint` clean. Built and booted the **standalone output staged exactly like the Docker runner** with `SITE_URL=https://smoke.example`:

- robots.txt / sitemap.xml: all URLs on the runtime domain, 0 localhost matches, 57 sitemap entries (34 routes + 23 dispatches)
- `/privacy`, `/manual/dj`: correct canonical, single-branded `<title>`, per-page `twitter:title`
- `/news/dj-mode-mixes`: article-specific og/twitter card, runtime canonical
- `og:image` on formerly-static pages now carries the runtime domain

Build route table confirms all public pages are ƒ (dynamic).

## Notes for deploy

The live station gets this via the next image publish + update. Separately (not code): Cloudflare's managed robots.txt rules currently disallow GPTBot/ClaudeBot/CCBot etc. — worth a deliberate keep/drop decision in the CF dashboard.