### PR TITLE
fix(dj): air show handoffs at a track boundary, in the right voice

### DIFF
--- a/controller/scripts/handoff-boundary.test.ts
+++ b/controller/scripts/handoff-boundary.test.ts
@@ -8,7 +8,7 @@
 // pick off that one date — so the sign-off/greeting land in front of the
 // changeover track, and the pick's brief can't disagree with the on-air persona.
 //
-// Two pure pieces hold that up, pinned here:
+// Three pure pieces hold that up, pinned here:
 //
 //  - contextDate    — reads the `at` stamp getFullContext puts on every context.
 //                     This is the load-bearing bit: session.start() resolves the
@@ -22,11 +22,18 @@
 //                     hourly cron rolls without airing, so with nobody listening
 //                     (or across one very long track) a pending handoff can
 //                     outlive the moment it describes.
+//  - rollIsBackward — refuses to roll the session to an OLDER moment than the
+//                     one it was resolved for. Inside the look-ahead window a
+//                     live-clock maybeRoll caller (routes/request.ts) still
+//                     resolves the outgoing show; unguarded, a listener request
+//                     there would archive the just-rolled session, arm a
+//                     mirrored reverse mic-pass, and voice the request intro as
+//                     the DJ who just signed off.
 //
 // node:assert-via-tsx style, matching scripts/stale-link.test.ts.
 
 import assert from 'node:assert/strict';
-import { contextDate, handoffIsStale } from '../src/broadcast/session.js';
+import { contextDate, handoffIsStale, rollIsBackward } from '../src/broadcast/session.js';
 
 const MAX_AGE = 20 * 60_000;   // mirrors HANDOFF_MAX_AGE_MS in dj-agent.ts
 
@@ -120,6 +127,34 @@ function main() {
   test('non-numeric stamp → treated as unstamped, not stale', () => {
     for (const bad of ['2026-07-18T10:00:00.000Z', NaN, Infinity, {}] as any[]) {
       assert.equal(handoffIsStale(bad, now, MAX_AGE), false, `at=${String(bad)}`);
+    }
+  });
+
+  console.log('\nbackward-roll guard (rollIsBackward):');
+  // The session was look-ahead-rolled for 10:02 at a real time of ~09:58.
+  const sessionAt = '2026-07-18T10:02:00.000Z';
+
+  test('live-clock caller inside the look-ahead window → backward, skip', () => {
+    // A listener request at 09:58:30 still resolves the outgoing show.
+    assert.equal(rollIsBackward(new Date('2026-07-18T09:58:30.000Z'), sessionAt), true);
+  });
+
+  test('caller past the described moment → forward, roll allowed', () => {
+    assert.equal(rollIsBackward(new Date('2026-07-18T10:02:00.001Z'), sessionAt), false);
+  });
+
+  test('exactly the described moment → not backward (strict <)', () => {
+    assert.equal(rollIsBackward(new Date(sessionAt), sessionAt), false);
+  });
+
+  test('session persisted before ctxAt existed → never blocks a roll', () => {
+    assert.equal(rollIsBackward(new Date('2020-01-01T00:00:00.000Z'), undefined), false);
+    assert.equal(rollIsBackward(new Date('2020-01-01T00:00:00.000Z'), null), false);
+  });
+
+  test('garbage stamp → never blocks a roll', () => {
+    for (const bad of ['not-a-date', '', 12345, {}] as any[]) {
+      assert.equal(rollIsBackward(new Date(), bad), false, `ctxAt=${JSON.stringify(bad)}`);
     }
   });
 

--- a/controller/scripts/handoff-boundary.test.ts
+++ b/controller/scripts/handoff-boundary.test.ts
@@ -1,0 +1,130 @@
+// Regression tests for the show-handoff boundary logic.
+// Run: `tsx scripts/handoff-boundary.test.ts`.
+//
+// A persona handoff used to fire from the `0 * * * *` cron and duck the middle
+// of whatever song was playing. It now rides the TRACK grid: queue.onTrackStarted
+// resolves the show for the moment the next pick will air (`showAt = now +
+// duration + PICK_SHOW_LOOKAHEAD_SEC`) and drives the roll, the mic-pass AND the
+// pick off that one date — so the sign-off/greeting land in front of the
+// changeover track, and the pick's brief can't disagree with the on-air persona.
+//
+// Two pure pieces hold that up, pinned here:
+//
+//  - contextDate    — reads the `at` stamp getFullContext puts on every context.
+//                     This is the load-bearing bit: session.start() resolves the
+//                     persona from it, and if it silently fell back to the wall
+//                     clock a look-ahead roll would stamp the OUTGOING persona
+//                     onto the INCOMING show's session. stampRolledFrom would
+//                     then compare that persona against itself, see no change,
+//                     and suppress the mic-pass ENTIRELY — worse than the bug
+//                     being fixed. The fallback must therefore be exercised.
+//  - handoffIsStale — drops a mic-pass that never found a track boundary. The
+//                     hourly cron rolls without airing, so with nobody listening
+//                     (or across one very long track) a pending handoff can
+//                     outlive the moment it describes.
+//
+// node:assert-via-tsx style, matching scripts/stale-link.test.ts.
+
+import assert from 'node:assert/strict';
+import { contextDate, handoffIsStale } from '../src/broadcast/session.js';
+
+const MAX_AGE = 20 * 60_000;   // mirrors HANDOFF_MAX_AGE_MS in dj-agent.ts
+
+let failures = 0;
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err: any) {
+    failures++;
+    console.error(`  ✗ ${name}\n      ${err?.message || err}`);
+  }
+}
+
+// A date is "about now" if it's within a couple of seconds of it — the fallback
+// paths construct `new Date()` internally, so exact equality isn't available.
+function assertAboutNow(d: Date, label: string) {
+  const drift = Math.abs(d.getTime() - Date.now());
+  assert.ok(drift < 2000, `${label}: expected ~now, got ${d.toISOString()} (${drift}ms off)`);
+}
+
+function main() {
+  console.log('context date stamp (contextDate):');
+
+  test('reads the `at` stamp getFullContext writes', () => {
+    const at = '2026-07-18T09:58:30.000Z';
+    assert.equal(contextDate({ at }).toISOString(), at);
+  });
+
+  test('a look-ahead stamp is honoured, not collapsed to now', () => {
+    // The whole point: 09:58 real time, context describing 10:05. If this
+    // returned "now" the roll would resolve the outgoing persona and the
+    // mic-pass would never fire.
+    const ahead = new Date(Date.now() + 7 * 60_000).toISOString();
+    assert.equal(contextDate({ at: ahead }).toISOString(), ahead);
+  });
+
+  test('missing `at` (context from another path) → now', () => {
+    assertAboutNow(contextDate({}), 'missing at');
+  });
+
+  test('null/undefined context → now, never throws', () => {
+    assertAboutNow(contextDate(null), 'null ctx');
+    assertAboutNow(contextDate(undefined), 'undefined ctx');
+  });
+
+  test('unparseable or wrongly-typed `at` → now, never Invalid Date', () => {
+    // A session.json persisted before `at` existed, or a hand-edited one.
+    for (const bad of ['not-a-date', '', 12345, {}, []] as any[]) {
+      const d = contextDate({ at: bad });
+      assert.ok(!Number.isNaN(d.getTime()), `at=${JSON.stringify(bad)} produced an Invalid Date`);
+      assertAboutNow(d, `at=${JSON.stringify(bad)}`);
+    }
+  });
+
+  console.log('\npending mic-pass expiry (handoffIsStale):');
+  const now = Date.parse('2026-07-18T10:00:00.000Z');
+
+  test('no stamp (session rolled before `at` existed) → fresh, still airs', () => {
+    // Deliberate: an in-flight handoff across a deploy should not be swallowed.
+    assert.equal(handoffIsStale(undefined, now, MAX_AGE), false);
+    assert.equal(handoffIsStale(null, now, MAX_AGE), false);
+  });
+
+  test('rolled seconds ago → fresh', () => {
+    assert.equal(handoffIsStale(now - 5_000, now, MAX_AGE), false);
+  });
+
+  test('rolled just inside the window → fresh', () => {
+    assert.equal(handoffIsStale(now - (MAX_AGE - 1), now, MAX_AGE), false);
+  });
+
+  test('exactly at the window edge → fresh (strict >)', () => {
+    assert.equal(handoffIsStale(now - MAX_AGE, now, MAX_AGE), false);
+  });
+
+  test('past the window → stale, drop it', () => {
+    assert.equal(handoffIsStale(now - (MAX_AGE + 1), now, MAX_AGE), true);
+  });
+
+  test('rolled an hour ago with nobody listening → stale', () => {
+    // The real scenario: cron rolls at 10:00 with airHandoff=false, no listener
+    // so no track boundary runs the pick block, someone tunes in at 11:00.
+    assert.equal(handoffIsStale(now - 60 * 60_000, now, MAX_AGE), true);
+  });
+
+  test('a clock skew putting the roll in the future → not stale', () => {
+    assert.equal(handoffIsStale(now + 30_000, now, MAX_AGE), false);
+  });
+
+  test('non-numeric stamp → treated as unstamped, not stale', () => {
+    for (const bad of ['2026-07-18T10:00:00.000Z', NaN, Infinity, {}] as any[]) {
+      assert.equal(handoffIsStale(bad, now, MAX_AGE), false, `at=${String(bad)}`);
+    }
+  });
+
+  console.log(failures ? `\n${failures} failing` : '\nall passing');
+  if (failures) process.exit(1);
+}
+
+main();

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -251,11 +251,12 @@ export function requestSchema() {
 // `showAt` — resolve the show brief/leans for that future moment instead of
 // now: the pick airs when the current track ends, so near a show boundary the
 // INCOMING show's rules are the ones to follow (see the look-ahead in
-// queue.onTrackStarted). The persona stays the live one — the outgoing DJ
-// tees the changeover up in their own voice; the on-air mic-pass is
-// runPersonaHandoff's job.
+// queue.onTrackStarted). The persona now comes from the session, which the
+// same look-ahead has already rolled — the mic-pass aired ahead of this pick,
+// so the incoming DJ introduces their own opener rather than the outgoing DJ
+// teeing up a show they've already signed off from.
 export function pickSystem(showAt: Date | null = null, playlistResolved = true) {
-  const persona = settings.getEffectivePersona();
+  const persona = session.onAirPersona();
   // In DJ mode, lean on the live session history: a working DJ runs threads
   // and calls back to a track or a remark from earlier in the shift. This pairs
   // with the cross-hour memory in broadcast/session.ts, which now keeps that
@@ -315,7 +316,7 @@ Finding candidates: prefer tools backed by the local library — searchLibrary, 
 
 // Exported for scripts/llm-bench, like requestSchema above.
 export function requestSystem() {
-  const persona = settings.getEffectivePersona();
+  const persona = session.onAirPersona();
   return `${settings.agentPersonaPreamble(persona)}
 
 The messages above are the live session. The final user line names the ONE listener request you are resolving now — any earlier request lines are already handled by someone else; ignore them. If the exact ask isn't in the library, pick the closest thing your tools actually returned and own the substitution in the "ack" and "intro" — never pretend it's what they asked for.${settings.agentLanguageReminder(persona, 'the "ack" and "intro" lines')}`;
@@ -336,6 +337,11 @@ const BREAKER_FAILURES = 3;
 const BREAKER_COOLDOWN_MS = 10 * 60_000;
 let breakerFails = 0;
 let breakerOpenUntil = 0;
+
+// How long a rolled-but-unaired mic-pass stays worth airing. Mirrors
+// queue.ts's PENDING_VOICE_MAX_AGE_MS for a deferred ident, for the same
+// reason: the script bakes in a moment, so a late one misreads on air.
+const HANDOFF_MAX_AGE_MS = 20 * 60_000;
 
 function breakerOpen(): boolean {
   return Date.now() < breakerOpenUntil;
@@ -525,6 +531,9 @@ async function enqueuePick(
     intent: reason || 'ai pick',
     introScript: introLink,
     introKind: 'link',
+    // Pin the voice to whoever wrote the line — the render (drainToLiquidsoap)
+    // and the air (airIntro) both happen later and used to re-resolve it.
+    introPersona: session.onAirPersona(),
     aiPicked: true,
     linkPrev,
   });
@@ -785,6 +794,11 @@ async function pickViaPool(queue, ctx, { wantLink, current, showAt = null }: { w
         // set, so its clock is the link's air time — the only case the link may
         // speak it (issue #864: generation-time clocks aired a track late).
         clockIsAirTime: !!showAt,
+        // Name the speaker explicitly. Left unset, scripts.generateLink falls
+        // back to getEffectivePersona() on the wall clock, which disagrees with
+        // the session inside the look-ahead window — the incoming DJ's line
+        // written in the outgoing DJ's voice.
+        persona: session.onAirPersona(),
         recap: queue.getDjRecap(),
         recentTracks: queue.getRecentTracks(),
         recentOpeners: queue.getRecentOpeners(),
@@ -1059,6 +1073,8 @@ async function runRequestViaAgent(queue: any, { requester, text }: { requester: 
       intent: 'listener request',
       introScript: intro || null,
       introKind: 'dj-speak',
+      // Voice the intro as whoever wrote it (see the pool-pick push above).
+      introPersona: session.onAirPersona(),
     });
     // Never-play blocklist refused the pick — throw so the route's stateless
     // fallback cascade runs; its own resolution is blocklist-filtered, so the
@@ -1119,6 +1135,19 @@ export async function runPersonaHandoff(queue: any, ctx: any): Promise<void> {
     return;
   }
 
+  // Expired: the roll happened, but no track boundary came along in time to
+  // air it. The hourly cron rolls without airing (scheduler.rollSessionNow's
+  // airHandoff=false), so with nobody listening — or across one very long
+  // track — a pending mic-pass can outlive the moment it describes. A sign-off
+  // names the show that just ended and a greeting opens the one that started;
+  // airing that an hour late is worse than staying quiet, the same call
+  // airPendingVoice makes for a stale ident.
+  if (session.handoffIsStale(pending.at, Date.now(), HANDOFF_MAX_AGE_MS)) {
+    queue.log('scheduler', `Dropped pending mic-pass from ${pending.personaName || 'the previous DJ'} — no track boundary in time`);
+    session.markHandoffAired();
+    return;
+  }
+
   // Outgoing persona comes from the roll metadata — its clock slot is already
   // over, so getEffectivePersona() no longer returns it. Incoming is the fresh
   // session's persona. A persona deleted mid-shift → nothing to voice; drop it.
@@ -1169,7 +1198,9 @@ export async function runPersonaHandoff(queue: any, ctx: any): Promise<void> {
         episodeAngle: session.getProgramme()?.plan?.angle || null,
         context: ctx, recap: queue.getDjRecap(), recentOpeners,
       });
-      await queue.announce(greeting, 'handoff', { persona: personaIn });
+      await queue.announce(greeting, 'handoff', {
+        persona: personaIn, meta: { personaId: personaIn.id, personaName: personaIn.name },
+      });
       aired = true;
     } catch (err: any) {
       queue.log('error', `Handoff greeting failed: ${err.message}`);

--- a/controller/src/broadcast/programme.ts
+++ b/controller/src/broadcast/programme.ts
@@ -136,7 +136,15 @@ function featureKindMenu(host: { skills?: string[] } | null | undefined): { kind
 // gate leaves the plan `pending` (a later tick retries once budget frees up);
 // a real generation failure marks it `fallback` for the episode (beats then
 // run brief-only — one failed producer call shouldn't burn a retry per tick).
-export async function ensurePlan(ctx: SessionContext, now = new Date()): Promise<void> {
+//
+// `now` defaults to the moment the CONTEXT describes (contextDate), not the
+// wall clock: queue.onTrackStarted rolls the session on a look-ahead context,
+// and judging the episode with a live `now` inside that window makes
+// activeEpisode compare the incoming session key against the OUTGOING show —
+// a silent null, so the plan never builds and the handoff greeting airs with
+// no episode angle. A live context carries a live `at`, so live callers are
+// unchanged.
+export async function ensurePlan(ctx: SessionContext, now = session.contextDate(ctx)): Promise<void> {
   const ep = activeEpisode(now);
   if (!ep) return;
   let prog = session.getProgramme();
@@ -187,7 +195,7 @@ export async function ensurePlan(ctx: SessionContext, now = new Date()): Promise
 // half of the mic-pass already opened the show (with the episode angle woven
 // in — see dj-agent), so the standalone intro is skipped and just marked.
 // Returns true when it aired a standalone intro now.
-export async function maybeRunIntro(queue: QueueApi, ctx: SessionContext, now = new Date()): Promise<boolean> {
+export async function maybeRunIntro(queue: QueueApi, ctx: SessionContext, now = session.contextDate(ctx)): Promise<boolean> {
   const ep = activeEpisode(now);
   const prog = ep && session.getProgramme();
   if (!prog || prog.beats?.intro) return false;
@@ -197,6 +205,13 @@ export async function maybeRunIntro(queue: QueueApi, ctx: SessionContext, now = 
     markIntroAired();
     return false;
   }
+  // The mic-pass is still PENDING for this boundary (the hourly cron rolls
+  // with airHandoff=false and leaves airing to the next track boundary). The
+  // greeting doubles as the intro there — airing the standalone intro now
+  // would duck mid-song, the exact bug the deferral fixes, and introduce the
+  // episode twice. Stay pending: the boundary tick re-runs this after
+  // runPersonaHandoff, which marks handoffAired on every exit path.
+  if (session.pendingHandoff()) return false;
   if (!djCallsAllowed() || !optionalSegmentsAllowed()) return false;  // stays pending — may air later this hour
 
   markIntroAired();
@@ -357,7 +372,8 @@ export async function runOutro(queue: QueueApi, ctx: SessionContext, now = new D
 // runPersonaHandoff: attach + plan the episode, then air the intro if it's
 // still pending. Returns true when a standalone intro aired just now (the
 // hourly cron uses this to skip the generic time check).
-export async function onSessionSettled(queue: QueueApi, ctx: SessionContext, now = new Date()): Promise<boolean> {
+// `now` follows the same contextDate rule as ensurePlan.
+export async function onSessionSettled(queue: QueueApi, ctx: SessionContext, now = session.contextDate(ctx)): Promise<boolean> {
   if (!activeEpisode(now)) return false;
   await ensurePlan(ctx, now);
   return maybeRunIntro(queue, ctx, now);

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -84,6 +84,14 @@ interface QueueItem {
   intent?: string | null;
   introScript?: string | null;
   introKind?: string;
+  // Who WROTE introScript. Carried on the item because the line is rendered in
+  // drainToLiquidsoap and aired in airIntro, both later than generation and
+  // both of which used to re-resolve the speaker from the wall clock — so
+  // across a show boundary a line written for the incoming DJ got spoken in the
+  // outgoing DJ's voice. Decided once, at push time. Not persisted: a restart
+  // drops unrendered intros anyway, and a stale persona blob is worse than the
+  // live fallback.
+  introPersona?: Persona | null;
   aiPicked?: boolean;
   linkPrev?: { id: string | null; title: string | null; artist: string | null } | null;
   introWav?: string | null;
@@ -492,12 +500,13 @@ class Queue {
   // more) older than what actually just played. airIntro() uses linkPrev to
   // detect that and drop the now-stale back-announce rather than air a wrong
   // name. Left null for request intros (they never back-announce).
-  async push({ track, requestedBy = null, intent = null, introScript = null, introKind = 'dj-speak', aiPicked = false, allowDuplicate = false, linkPrev = null }: {
+  async push({ track, requestedBy = null, intent = null, introScript = null, introKind = 'dj-speak', introPersona = null, aiPicked = false, allowDuplicate = false, linkPrev = null }: {
     track: Track;
     requestedBy?: string | null;
     intent?: string | null;
     introScript?: string | null;
     introKind?: string;
+    introPersona?: Persona | null;
     aiPicked?: boolean;
     allowDuplicate?: boolean;
     linkPrev?: { id?: string | null; title?: string | null; artist?: string | null } | null;
@@ -530,7 +539,7 @@ class Queue {
       }
     }
     const item = {
-      track, requestedBy, intent, introScript, introKind, aiPicked,
+      track, requestedBy, intent, introScript, introKind, introPersona, aiPicked,
       // Only stamp a back-announce target when there's actually an intro/link to
       // air against it; a bare track carries no claim about what preceded it.
       linkPrev: (introScript && linkPrev)
@@ -946,7 +955,13 @@ class Queue {
         // #189). airIntro() writes it to the voice file when the track starts.
         if (item.introScript && !item.introWav) {
           try {
-            item.introWav = await speak(item.introScript, { kind: item.introKind || 'dj-speak' });
+            item.introWav = await speak(item.introScript, {
+              kind: item.introKind || 'dj-speak',
+              // Voice it as whoever wrote it. Without this, speak() falls back
+              // to getEffectivePersona() at DRAIN time — minutes after the line
+              // was written, possibly the other side of a show boundary.
+              persona: item.introPersona || null,
+            });
           } catch (err) {
             this.log('error', `TTS failed: ${(err as Error).message}`);
           }
@@ -1089,6 +1104,17 @@ class Queue {
     }
   }
 
+  // Discard a scheduled-but-unaired deferred segment. A mic-pass supersedes an
+  // ident: sign-off + greeting name the station, the outgoing show and the
+  // incoming one, so an ident in front of it is three spoken segments in a row
+  // saying overlapping things. The next cron fire schedules a fresh ident.
+  dropPendingVoice(reason: string) {
+    const p = this._pendingVoice;
+    if (!p) return;
+    this._pendingVoice = null;
+    this.log('scheduler', `Dropped pending ${p.kind} — ${reason}`);
+  }
+
   // Air the boundary-deferred segment, if one is pending. Called from
   // onTrackStarted BEFORE airIntro so the ident lands ahead of the track's own
   // link in the shared voice chain (ident → link reads as a natural hand-off).
@@ -1096,6 +1122,14 @@ class Queue {
   // PENDING_VOICE_MAX_AGE_MS (a long mix, a stream stall) is dropped rather
   // than aired with a stale time reference — the next cron fire replaces it.
   async airPendingVoice() {
+    // A mic-pass is already pending from an earlier roll (the hourly cron rolls
+    // without airing) and will take this boundary. The same-tick case — where
+    // the roll happens in onTrackStarted's auto-pick block, AFTER this runs —
+    // is caught by the matching dropPendingVoice call over there.
+    if (session.pendingHandoff()) {
+      this.dropPendingVoice('the show handoff covers this boundary');
+      return;
+    }
     const p = this._pendingVoice;
     if (!p) return;
     this._pendingVoice = null;
@@ -1142,10 +1176,22 @@ class Queue {
       ? config.liquidsoap.introFile
       : config.liquidsoap.sayFile;
     try {
-      await airVoice(targetFile, item.introWav, item.introScript || '', voiceGainDb(kind));
+      // Same persona the WAV was rendered under (see drainToLiquidsoap) — the
+      // gain trim is per-persona, so re-resolving here would apply one DJ's
+      // trim to another DJ's audio. This was the last voiceGainDb call site
+      // still resolving from the wall clock.
+      await airVoice(targetFile, item.introWav, item.introScript || '', voiceGainDb(kind, item.introPersona || undefined));
       this.persist();
       this.log(kind, item.introScript!);
-      session.appendTurn({ role: 'segment', kind, text: item.introScript! });
+      session.appendTurn({
+        role: 'segment', kind, text: item.introScript!,
+        // Attribute the turn so windowMessages() can name the real speaker when
+        // it wasn't the session's own persona (a link written by the outgoing
+        // DJ airing just after the roll).
+        meta: item.introPersona
+          ? { personaId: item.introPersona.id, personaName: item.introPersona.name }
+          : {},
+      });
       webhooks.notify(kind === 'link' ? 'dj.link' : 'dj.say',
         kind === 'link' ? { text: item.introScript } : { text: item.introScript, kind });
     } catch (err) {
@@ -1392,7 +1438,31 @@ class Queue {
       this.pickerBusy = true;
       (async () => {
         try {
-          const ctx = await getFullContext();
+          // The pick made now airs when the track that just started ends — so
+          // near a show boundary the rules to pick by are the NEXT show's, not
+          // this one's (a pick queued minutes before the boundary used to
+          // follow the outgoing show's brief, handing the incoming DJ an
+          // off-format opener). Probe a little past the pick's expected start
+          // so a pick that begins just shy of the boundary — and plays mostly
+          // inside the new show — also counts as the new show's. Unknown
+          // duration → no look-ahead, today's behaviour.
+          //
+          // This ONE date then drives the whole boundary sequence below — roll,
+          // episode plan, mic-pass, episode hook — not just the pick. It used
+          // to drive only the pick, with the roll and handoff left on the live
+          // clock; that split is what let the two disagree. At 09:58 the live
+          // grid still says "morning show", so the roll here never fired and
+          // the :00 cron won it mid-song — the changeover track (already picked
+          // under the incoming brief) aired BEFORE anyone handed over. Keying
+          // both off `showAt` makes the mic-pass land in front of that track,
+          // and makes it structurally impossible for the pick's brief and the
+          // on-air persona to disagree: there is no second date to disagree with.
+          const durSec = Number(this.current?.track?.duration);
+          let showAt: Date | null = null;
+          if (Number.isFinite(durSec) && durSec > 0) {
+            showAt = new Date(Date.now() + (durSec + PICK_SHOW_LOOKAHEAD_SEC) * 1000);
+          }
+          const ctx = await getFullContext(showAt ?? undefined);
           await session.maybeRoll(ctx);
           // Plan a programme episode BEFORE the mic-pass so a handoff into a
           // programme show can weave the episode angle into its greeting.
@@ -1404,8 +1474,24 @@ class Queue {
           // If that roll crossed a persona boundary, air the mic-pass first
           // (sign-off + greeting) so it plays before the incoming DJ's first
           // pick. Guarded so a handoff failure never blocks the next track.
+          // Drop a still-unaired ident first — airPendingVoice ran earlier in
+          // this same tick, before the roll above existed to be seen.
           try {
-            await djAgent.runPersonaHandoff(this, ctx);
+            if (session.pendingHandoff()) {
+              this.dropPendingVoice('the show handoff covers this boundary');
+              // Identity looks ahead; the CLOCK must not. `ctx` describes
+              // showAt — up to a track-length plus the look-ahead margin from
+              // now — but the mic-pass airs immediately, so its prompt clock
+              // would run minutes fast and the sign-off would misstate the time
+              // on air (the failure #864 fixed for links). Take date/clock/time
+              // from the live moment and keep show/mood/festival from the
+              // look-ahead, which is the show being handed TO. Built only when a
+              // handoff is actually pending, so this costs nothing per track.
+              const live = await getFullContext();
+              await djAgent.runPersonaHandoff(this, {
+                ...ctx, at: live.at, date: live.date, clock: live.clock, time: live.time,
+              });
+            }
           } catch (err) {
             this.log('error', `Persona handoff failed: ${(err as Error).message}`);
           }
@@ -1417,23 +1503,7 @@ class Queue {
           } catch (err) {
             this.log('error', `Programme episode hook failed: ${(err as Error).message}`);
           }
-          // The pick made now airs when the track that just started ends — so
-          // near a show boundary the rules to pick by are the NEXT show's, not
-          // this one's (a pick queued minutes before the boundary used to
-          // follow the outgoing show's brief, handing the incoming DJ an
-          // off-format opener). Probe a little past the pick's expected start
-          // so a pick that begins just shy of the boundary — and plays mostly
-          // inside the new show — also counts as the new show's. The session
-          // roll and handoff above stay on the live clock: only the pick
-          // looks ahead. Unknown duration → no look-ahead, today's behaviour.
-          const durSec = Number(this.current?.track?.duration);
-          let pickCtx = ctx;
-          let showAt: Date | null = null;
-          if (Number.isFinite(durSec) && durSec > 0) {
-            showAt = new Date(Date.now() + (durSec + PICK_SHOW_LOOKAHEAD_SEC) * 1000);
-            pickCtx = await getFullContext(showAt);
-          }
-          await djAgent.runTrackEvent(this, pickCtx, { wantLink, showAt });
+          await djAgent.runTrackEvent(this, ctx, { wantLink, showAt });
         } catch (err) {
           this.log('error', `DJ track event failed: ${(err as Error).message}`);
         } finally {

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -450,7 +450,16 @@ export async function runHourlyCheck() {
 // cancel / expiry airs promptly instead of waiting for the next track or hour.
 // Every step traps its own errors — node-cron doesn't catch async throws, and
 // the route callers are fire-and-forget.
-export async function rollSessionNow() {
+//
+// `airHandoff` decides whether this call site may air the mic-pass itself.
+// The hourly cron passes false: it must still roll the session and plan the
+// episode (that state has to be right whether or not a track boundary is
+// near), but airing at wall-clock :00 ducks the middle of a song. Leaving the
+// handoff pending hands it to the next track boundary, which is where it
+// belongs. The takeover routes keep the default true — an operator action is
+// explicit and should air promptly, the same reasoning that exempts the manual
+// /dj/segment runners from the budget gate.
+export async function rollSessionNow({ airHandoff = true }: { airHandoff?: boolean } = {}) {
   let ctx: Awaited<ReturnType<typeof getFullContext>> | null = null;
   try {
     ctx = await getFullContext();
@@ -458,11 +467,12 @@ export async function rollSessionNow() {
   } catch (err) {
     queue.log('error', `Session roll failed: ${err.message}`);
   }
-  // If that roll crossed a persona boundary, air the two-voice mic-pass. It
-  // does its own listener/budget gating and marks itself aired, so it's safe to
-  // call unconditionally here (whichever call site rolls the session first
-  // drives it — the others no-op). No ctx → the roll above didn't happen
-  // either; leave the handoff pending for the next call site.
+  // If that roll crossed a persona boundary, air the two-voice mic-pass — when
+  // this call site is allowed to (see `airHandoff`). It does its own
+  // listener/budget gating and marks itself aired, so it's safe to call
+  // unconditionally below (whichever call site rolls the session first drives
+  // it — the others no-op). No ctx → the roll above didn't happen either;
+  // leave the handoff pending for the next call site.
   if (!ctx) return { ctx: null, introAired: false };
   // Plan the episode BEFORE the mic-pass so a persona handoff into a
   // programme show can weave the episode angle into the greeting (the
@@ -472,10 +482,12 @@ export async function rollSessionNow() {
   } catch (err) {
     queue.log('error', `Programme plan failed: ${err.message}`);
   }
-  try {
-    await djAgent.runPersonaHandoff(queue, ctx);
-  } catch (err) {
-    queue.log('error', `Persona handoff failed: ${err.message}`);
+  if (airHandoff) {
+    try {
+      await djAgent.runPersonaHandoff(queue, ctx);
+    } catch (err) {
+      queue.log('error', `Persona handoff failed: ${err.message}`);
+    }
   }
   // Programme shows: open the episode. The intro owns the top of the show's
   // first hour, so when it airs (now, or minutes ago via the track-start
@@ -491,10 +503,16 @@ export async function rollSessionNow() {
 }
 
 async function hourlyCheck() {
-  // The top of the hour is the natural show boundary — roll the session here
-  // so a scheduled show starting/ending opens a fresh chat history even if no
-  // track happens to start right on the hour.
-  const rolled = await rollSessionNow();
+  // The top of the hour is the natural show boundary for STATE — roll the
+  // session here so a scheduled show starting/ending opens a fresh chat
+  // history even if no track happens to start right on the hour.
+  //
+  // It is NOT the natural boundary for the AIR, though: :00 lands mid-song.
+  // So don't air the mic-pass from here (issue: handoffs ducking the middle of
+  // a track). The roll leaves it pending and the next track boundary airs it —
+  // normally queue.onTrackStarted has already rolled and aired it a track
+  // earlier via its look-ahead, making this call a no-op.
+  const rolled = await rollSessionNow({ airHandoff: false });
   if (rolled.ctx && (rolled.introAired || programme.suppressHourly())) return;
   if (!shouldFire('hourly')) return;
   if (!djCallsAllowed()) return;  // nobody listening — stay on the auto playlist

--- a/controller/src/broadcast/session.ts
+++ b/controller/src/broadcast/session.ts
@@ -74,10 +74,16 @@ export interface ProgrammeState {
 
 // Outgoing-persona metadata stamped on a hard roll so a caller can air the
 // two-voice mic-pass.
-interface RolledFrom {
+export interface RolledFrom {
   personaId: string;
   personaName: string | null;
   showName: string | null;
+  // When the roll happened (epoch ms), so a mic-pass that never found a track
+  // boundary can expire instead of airing hours late. Optional: sessions
+  // persisted before this field existed read as fresh (see handoffIsStale).
+  // Distinct from the context's `at` — this is when the roll fired, not what
+  // moment the context described.
+  at?: number;
 }
 
 // The live DJ session (also the on-disk shape of session.json).
@@ -121,6 +127,30 @@ function mintId() {
 export function sessionKeyFor(ctx: SessionContext) {
   if (ctx?.activeShow?.id) return `show:${ctx.activeShow.id}`;
   return `auto:${ctx?.time?.period || 'unknown'}:${ctx?.dominantMood || 'none'}`;
+}
+
+// The moment a context describes. `at` is stamped by getFullContext (context.ts);
+// a context from anywhere else, or one persisted before `at` existed, reads as
+// "now" — the pre-look-ahead behaviour. Pure: unit-pinned by
+// scripts/handoff-boundary.test.ts.
+export function contextDate(ctx: { at?: unknown } | null | undefined): Date {
+  const raw = ctx?.at;
+  if (typeof raw !== 'string') return new Date();
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? new Date() : d;
+}
+
+// Whether a pending mic-pass has waited too long to still be worth airing.
+// A sign-off/greeting pair bakes in a time reference and names the show that
+// just ended, so a late one is worse than none — the same call airPendingVoice
+// makes for a stale ident (PENDING_VOICE_MAX_AGE_MS) and shouldDropStaleLink
+// makes for a stale back-announce.
+//
+// A session rolled before `at` existed has no stamp; treat it as fresh so an
+// in-flight handoff across a deploy still airs. Pure.
+export function handoffIsStale(at: unknown, now: number, maxAgeMs: number): boolean {
+  if (typeof at !== 'number' || !Number.isFinite(at)) return false;
+  return now - at > maxAgeMs;
 }
 
 function scenarioOf(ctx: SessionContext): Scenario {
@@ -196,6 +226,22 @@ async function archive(s: Session | null) {
   } catch {}
 }
 
+// The persona currently ON AIR — the one the live session is running as.
+//
+// Prefer this over settings.getEffectivePersona() for anything that writes or
+// voices a line for the current session. getEffectivePersona() reads the weekly
+// grid at the wall clock, but queue.onTrackStarted rolls the session on a
+// look-ahead (so the mic-pass lands in front of the changeover track rather
+// than over the middle of a song), which means the session legitimately leads
+// the grid by up to PICK_SHOW_LOOKAHEAD_SEC. Inside that window the two
+// disagree and the session is the one that's right: the handoff has aired, the
+// incoming DJ is on. Falls back to the grid with no session, or if the
+// session's persona has since been deleted.
+export function onAirPersona() {
+  const id = _session?.persona?.id;
+  return (id && settings.resolvePersonaById(id)) || settings.getEffectivePersona();
+}
+
 export function getSession() {
   return _session;
 }
@@ -215,7 +261,14 @@ export function appendTurn({ role, kind, text, meta = {} }: { role: string; kind
 
 // Start a fresh session for the current context.
 export function start(ctx: SessionContext, handoff: string | null = null): Session {
-  const persona = settings.getEffectivePersona();
+  // Resolve the persona for the moment the CONTEXT describes, not the wall
+  // clock. A boundary roll runs on a look-ahead context (queue.onTrackStarted
+  // rolls for the show that owns the next track), so `show` below comes from
+  // ctx.activeShow at that future moment — the persona has to agree, or
+  // stampRolledFrom compares the outgoing persona against itself, finds no
+  // change, and suppresses the mic-pass entirely. Missing `at` (a context from
+  // some other path) → wall clock, i.e. the previous behaviour.
+  const persona = settings.getEffectivePersona(contextDate(ctx));
   _session = {
     id: mintId(),
     kind: ctx?.activeShow ? 'show' : 'auto',
@@ -303,13 +356,14 @@ function stampRolledFrom(next: Session, prev: Session) {
         personaId: prevId,
         personaName: prev?.persona?.name ?? null,
         showName: prev?.show?.name ?? null,   // show that just ended, or null for an auto block
+        at: Date.now(),
       }
     : null;
 }
 
 // The pending on-air handoff for the live session (outgoing persona metadata),
 // or null when there's nothing to air (no persona change, or already aired).
-export function pendingHandoff(): { personaId: string; personaName: string | null; showName: string | null } | null {
+export function pendingHandoff(): RolledFrom | null {
   if (!_session?.rolledFrom || _session.handoffAired) return null;
   return _session.rolledFrom;
 }

--- a/controller/src/broadcast/session.ts
+++ b/controller/src/broadcast/session.ts
@@ -92,6 +92,12 @@ interface Session {
   kind: 'show' | 'auto';
   key: string;
   startedAt: string;
+  // The moment the key/persona were resolved FOR (the context's `at`): a
+  // look-ahead roll leads the wall clock by up to a track length, so this can
+  // sit ahead of startedAt. maybeRoll refuses to roll to an older moment
+  // (rollIsBackward); absent — a session persisted before this field existed —
+  // the guard never blocks.
+  ctxAt?: string;
   endedAt: string | null;
   show: { id?: string; name?: string; topic?: string } | null;
   persona: { id: string; name: string } | null;
@@ -151,6 +157,17 @@ export function contextDate(ctx: { at?: unknown } | null | undefined): Date {
 export function handoffIsStale(at: unknown, now: number, maxAgeMs: number): boolean {
   if (typeof at !== 'number' || !Number.isFinite(at)) return false;
   return now - at > maxAgeMs;
+}
+
+// Whether a candidate context describes an OLDER moment than the one the live
+// session was resolved for — accepting it would roll the session backward
+// across a boundary the look-ahead already crossed. Missing or garbage stamps
+// (a pre-upgrade session.json, a context without `at`) → false: never block a
+// roll on bad data. Pure: unit-pinned by scripts/handoff-boundary.test.ts.
+export function rollIsBackward(ctxDate: Date, sessionCtxAt: unknown): boolean {
+  const at = typeof sessionCtxAt === 'string' ? Date.parse(sessionCtxAt) : NaN;
+  if (!Number.isFinite(at)) return false;
+  return ctxDate.getTime() < at;
 }
 
 function scenarioOf(ctx: SessionContext): Scenario {
@@ -268,12 +285,14 @@ export function start(ctx: SessionContext, handoff: string | null = null): Sessi
   // stampRolledFrom compares the outgoing persona against itself, finds no
   // change, and suppresses the mic-pass entirely. Missing `at` (a context from
   // some other path) → wall clock, i.e. the previous behaviour.
-  const persona = settings.getEffectivePersona(contextDate(ctx));
+  const at = contextDate(ctx);
+  const persona = settings.getEffectivePersona(at);
   _session = {
     id: mintId(),
     kind: ctx?.activeShow ? 'show' : 'auto',
     key: sessionKeyFor(ctx),
     startedAt: new Date().toISOString(),
+    ctxAt: at.toISOString(),
     endedAt: null,
     show: ctx?.activeShow
       ? { id: ctx.activeShow.id, name: ctx.activeShow.name, topic: ctx.activeShow.topic }
@@ -325,6 +344,16 @@ export async function maybeRoll(ctx: SessionContext): Promise<Session> {
   const nextKey = sessionKeyFor(ctx);
   const aged = Date.now() - new Date(_session.startedAt).getTime() > MAX_SESSION_MS;
   if (_session.key === nextKey && !aged) return _session;
+
+  // A key change that only exists because the CALLER's clock is behind the
+  // session is not a boundary — it's the boundary already crossed, seen from
+  // the wrong side. queue.onTrackStarted rolls on a look-ahead context
+  // (showAt), and inside that window a live-clock caller (routes/request.ts)
+  // still resolves the OUTGOING show: rolling here would archive the
+  // just-started session, stamp a mirrored rolledFrom (a reverse mic-pass
+  // armed for the next boundary), and hand onAirPersona() back to the DJ who
+  // just signed off. Skip it — the live clock catches up within the margin.
+  if (!aged && rollIsBackward(contextDate(ctx), _session.ctxAt)) return _session;
 
   const bothAuto = _session.key.startsWith('auto:') && nextKey.startsWith('auto:');
   if (bothAuto && !aged) return softShift(ctx, nextKey);

--- a/controller/src/context.ts
+++ b/controller/src/context.ts
@@ -325,5 +325,12 @@ export async function getFullContext(at?: Date) {
   // it couldn't be read — callers treat that as "unknown" and stay quiet.
   const listeners = { count: getListenerCount() };
 
-  return { time, weather, festival, dominantMood, date, clock, activeShow, listeners };
+  // The moment this context DESCRIBES, stamped so consumers can tell a
+  // look-ahead context from a live one. Without it a consumer that needs a date
+  // (session.start → getEffectivePersona) silently falls back to the wall clock
+  // and disagrees with the activeShow resolved above — which, on a look-ahead
+  // roll, stamps the OUTGOING persona onto the INCOMING show's session and
+  // makes stampRolledFrom see no persona change at all (mic-pass suppressed).
+  // Note this is distinct from `date` (getDateContext's calendar strings).
+  return { at: now.toISOString(), time, weather, festival, dominantMood, date, clock, activeShow, listeners };
 }

--- a/controller/src/routes/request.ts
+++ b/controller/src/routes/request.ts
@@ -276,6 +276,9 @@ async function resolveRequest(entry) {
     const pos = await queue.push({
       track: pick, requestedBy: requester, intent: 'more_like_this', introScript,
       introKind: 'dj-speak',
+      // Voice it as whoever wrote it — render and air both happen later and
+      // would otherwise re-resolve the speaker off the wall clock.
+      introPersona: session.onAirPersona(),
     });
     entry.pick = pick;
     if (pos === -2) {
@@ -562,6 +565,8 @@ async function resolveRequest(entry) {
     intent: matched.intent,
     introScript,
     introKind: 'dj-speak',
+    // Voice it as whoever wrote it (see the more_like_this push above).
+    introPersona: session.onAirPersona(),
   });
   entry.pick = pick;
   if (pos === -2) {

--- a/docs/superpowers/specs/2026-07-18-handoff-track-boundary-design.md
+++ b/docs/superpowers/specs/2026-07-18-handoff-track-boundary-design.md
@@ -504,3 +504,24 @@ disease Change 0 fixed for `session.start()`, in three more hosts:
    never built at the roll tick and the greeting aired with `episodeAngle:
    null`. Fix: `now` defaults to `session.contextDate(ctx)`, so the date and
    the context can never disagree (the Change 0 principle, applied here).
+
+### Review-fix verification
+
+Beyond the new `rollIsBackward` unit pins, the three fixes were exercised
+against the real settings/session/programme modules with a seeded temp
+STATE_DIR (two adjacent shows on the 10:00 UTC boundary, different personas,
+show B `programme: true`), 11 assertions:
+
+- The Change 0 chain still holds: a roll on a context stamped `10:05` at
+  wall-clock `09:58` lands on show B as the incoming persona with the forward
+  mic-pass armed and `ctxAt` stamped.
+- Replaying the request path (`maybeRoll` with a live `09:58` context) leaves
+  the session, the pending handoff, and `onAirPersona()` untouched.
+- `ensurePlan` with an explicit live-clock `now` reproduces the pre-fix silent
+  no-op (no episode state attached); the `contextDate` default attaches it.
+- `maybeRunIntro` returns pending (intro unmarked) while the handoff is armed,
+  and marks the intro as covered once `handoffAired` flips.
+
+The harness needs the settings graph, so it isn't part of `npm test` (repo
+tests stay dependency-free); it lives outside the repo like the Change 0
+verification.

--- a/docs/superpowers/specs/2026-07-18-handoff-track-boundary-design.md
+++ b/docs/superpowers/specs/2026-07-18-handoff-track-boundary-design.md
@@ -472,3 +472,35 @@ on the hour with different personas:
 - Deferring the other immediate `announce()` callers (hourly check, banter, skill
   segments) to track boundaries. Same class of improvement, but each has different
   timing semantics — the hourly check in particular is *about* the wall clock.
+
+## Review fixes (PR #1090)
+
+Code review found three places where a consumer of session state was still on
+the live clock while the roll had moved to the look-ahead date — the same
+disease Change 0 fixed for `session.start()`, in three more hosts:
+
+1. **`programme.maybeRunIntro` aired the standalone intro mid-song at `:00`.**
+   The hourly cron's `airHandoff: false` leaves `handoffAired` false, but the
+   intro's skip-guard required `rolledFrom && handoffAired` — so a
+   persona-change boundary into a programme show fell through the guard and
+   aired the intro immediately, then the deferred greeting introduced the
+   episode a second time. Fix: while `session.pendingHandoff()` is armed the
+   intro stays pending; the boundary tick resolves it after
+   `runPersonaHandoff` (which marks `handoffAired` on every exit path).
+
+2. **A listener request could roll the session backward.**
+   `routes/request.ts` still calls `session.maybeRoll` with a live-clock
+   context; inside the look-ahead window that context resolves the outgoing
+   show, and `maybeRoll` had no direction guard — a request there archived the
+   just-rolled session, stamped a mirrored reverse `rolledFrom`, and handed
+   `onAirPersona()` back to the DJ who just signed off. Fix: sessions carry
+   `ctxAt` (the moment their key/persona were resolved for) and `maybeRoll`
+   refuses a roll to an older moment (`rollIsBackward`, pure, unit-pinned).
+   The guard lives at the chokepoint, so every live-clock caller is covered.
+
+3. **`programme.ensurePlan`/`onSessionSettled` silently no-oped in the window.**
+   Their `now` defaulted to `new Date()`, so `activeEpisode` compared the
+   incoming session key against the outgoing show and returned null — the plan
+   never built at the roll tick and the greeting aired with `episodeAngle:
+   null`. Fix: `now` defaults to `session.contextDate(ctx)`, so the date and
+   the context can never disagree (the Change 0 principle, applied here).

--- a/docs/superpowers/specs/2026-07-18-handoff-track-boundary-design.md
+++ b/docs/superpowers/specs/2026-07-18-handoff-track-boundary-design.md
@@ -1,0 +1,424 @@
+# Show handoffs on the track grid, not the wall clock
+
+**Date:** 2026-07-18
+**Source:** Discord — Gurthyy [NSTV] and Jaz666, #suggestions
+
+## Problem
+
+A scheduled show/persona handoff fires at wall-clock `:00` and ducks whatever song
+happens to be playing. Two listeners reported it independently:
+
+> "Subwave seems to have a deferred announcement path for station IDs that can wait
+> until the next track boundary. Could show/persona handoffs use that same
+> behavior? Right now a scheduled handoff can fire at the top of the hour over the
+> middle of a song." — Gurthyy
+
+> "There is definitely still room for improvement around handoff time around shows."
+> — Jaz666, with a timeline from a live morning → mid-morning changeover:
+>
+> | time | event |
+> |---|---|
+> | 09:55:03 | programme-outro called |
+> | 09:56:18 | outgoing DJ speaks the outro |
+> | 09:57:12 | outgoing `djAgentPick` with link |
+> | 09:57:31 | outgoing DJ speaks link |
+> | 10:00:06 | `generateProgrammePlan` — outgoing song still playing |
+> | 10:01:10 | incoming `djAgentPick` with link |
+> | 10:01:20 | link generated for the incoming DJ, **spoken in the outgoing DJ's voice** |
+
+Both observations are correct, and they are two symptoms of one root cause.
+
+### The deferred path Gurthyy describes is real
+
+`queue.announceAtNextTrack()` (`controller/src/broadcast/queue.ts:1081`) renders the
+WAV immediately, parks it in a single `_pendingVoice` slot, and airs it from
+`onTrackStarted` (`queue.ts:1195`). It has exactly **one** caller — station IDs
+(`scheduler.ts:677`). The hourly check, links, banter, programme intro/feature/outro
+and the persona handoff all call plain `queue.announce()`, which speaks immediately.
+
+### The handoff has two competing call sites, and the wall-clock one usually wins
+
+`runPersonaHandoff` (`dj-agent.ts:1109`) is reached from two places:
+
+1. **Track-start** — `queue.onTrackStarted`'s auto-pick block (`queue.ts:1393-1411`).
+   This one already lands on a boundary, and its comment already states the intent:
+   *"air the mic-pass first (sign-off + greeting) so it plays before the incoming
+   DJ's first pick."*
+2. **The `0 * * * *` cron** — `hourlyCheck()` → `rollSessionNow()` (`scheduler.ts:441`,
+   `:464`). This fires at wall-clock `:00`, mid-track.
+
+Whichever call site rolls the session first drives the mic-pass; the other no-ops.
+Site 1 calls `session.maybeRoll(ctx)` with `ctx = await getFullContext()` — the
+**live** clock. At 09:58 the grid still says "morning show", so no roll happens.
+The cron then wins at 10:00, mid-song. **Site 1 can essentially never win**, because
+it asks about the present at a moment when the boundary is still in the future.
+
+Meanwhile the *pick* made at 09:58 already looks ahead — `queue.ts:1429-1435`
+computes `showAt = now + duration + PICK_SHOW_LOOKAHEAD_SEC` and resolves the
+**incoming** show's brief. The existing comment makes the split deliberate:
+
+```ts
+// The session roll and handoff above stay on the live clock: only the pick
+// looks ahead. Unknown duration → no look-ahead, today's behaviour.
+```
+
+That is the bug in one line. The pick is chosen for the new show while the mic-pass
+still belongs to the old one, so the changeover track airs *before* anyone has
+handed over.
+
+### The voice mismatch is a separate, narrower defect
+
+The persona is never carried on the queued item. `push()` (`queue.ts:495-541`) stores
+`introScript` / `introKind` / `introWav` / `linkPrev` but nothing identifying who
+wrote the line. So:
+
+- `queue.ts:949` — `speak(item.introScript, { kind: item.introKind })` with no
+  `persona`, so `tts.personaFor()` (`audio/tts.ts:51`) falls through to
+  `settings.getEffectivePersona()` **at drain time**.
+- `queue.ts:1145` — `voiceGainDb(kind)` with no persona, re-resolving **at air time**.
+  This is the *only* `voiceGainDb` call site in the codebase that omits the persona;
+  `:1015`, `:1049` and `:1108` all pass it.
+- `queue.ts:1148` — `session.appendTurn` records no `meta.personaId`, so
+  `windowMessages()`' speaker-attribution guard can't tag the turn.
+
+Generation, WAV render, and air each resolve the persona independently. Away from a
+boundary they agree by luck. Across one they don't — which is exactly Jaz's 10:01:20.
+
+## Goal
+
+1. The mic-pass airs at a track boundary, immediately **before** the first track of
+   the incoming show — never over the middle of a song.
+2. The pick's brief and the mic-pass can no longer disagree about which show is on.
+3. A spoken line is voiced by the persona that wrote it, decided once.
+
+Explicitly *not* a goal: changing ducking, crossfade, or `radio.liq`. This is a
+scheduling and attribution change only.
+
+## Approaches considered
+
+1. **Defer the handoff with `announceAtNextTrack`** — the literal reading of the
+   suggestion. Rejected: `_pendingVoice` is a single slot and a handoff is a
+   two-part exchange, so it would have to become a FIFO. Worse, it puts the sign-off
+   *after* the straddling track — and that track was already picked under the
+   incoming show's brief, so the outgoing DJ would wave goodbye after a new-show
+   song had already played.
+
+2. **Split the exchange across the straddling track** — sign-off before, greeting
+   after (Gurthyy's alternative). The most radio-like, but the exchange stops being
+   atomic: two pending slots, two failure modes, and a window where neither DJ
+   formally owns the air.
+
+3. **Anticipate the roll using the lookahead the pick already computes** (chosen).
+   `queue.onTrackStarted` already knows `showAt` and already resolves the incoming
+   show for the pick. Reusing that same date for `maybeRoll` makes the mic-pass fall
+   naturally in front of the changeover track, with no new deferral machinery. The
+   two-part exchange stays atomic on the existing serialized voice chain.
+
+Approach 3 also turns out to need *less* code than 1 or 2: the "wait for a boundary"
+state already exists as `session.pendingHandoff()`, which stays non-null until
+`markHandoffAired()`. We do not need to generalize `announceAtNextTrack` at all.
+
+## Design
+
+### Change 0 (prerequisite) — the context carries the date it was built for
+
+**Without this, Change 1 does not merely fail — it silently suppresses the mic-pass
+entirely.** This was found while reviewing the design, and it is the load-bearing
+part of the whole thing.
+
+`getFullContext(at?)` (`context.ts:288`) accepts a date and resolves `time`,
+`festival`, `clock` and `activeShow` against it — but the object it returns
+(`{ time, weather, festival, dominantMood, date, clock, activeShow, listeners }`)
+does **not** include that date. Consumers cannot tell a look-ahead context from a
+live one.
+
+`session.start(ctx)` (`session.ts:218`) is such a consumer:
+
+```ts
+export function start(ctx: SessionContext, handoff: string | null = null): Session {
+  const persona = settings.getEffectivePersona();   // ← live clock, ignores ctx
+```
+
+So a roll driven by `pickCtx` would build a session whose `show` is the **incoming**
+show (from `ctx.activeShow`) but whose `persona` is the **outgoing** one (from the
+live clock). `stampRolledFrom` (`session.ts:297-307`) then compares
+`prev.persona.id` against `next.persona.id`, finds them **equal**, and sets
+`rolledFrom = null` — no pending handoff, no mic-pass, ever. `runPersonaHandoff`'s
+`personaIn` (`dj-agent.ts:1127`, reading `cur?.persona?.id`) would be wrong too.
+
+Fix, in two parts:
+
+- `getFullContext` returns `at: now.toISOString()` alongside the rest. (`date` is
+  already taken by `getDateContext(now)`, hence `at`.) It is additive — no existing
+  consumer reads it.
+- `session.start` resolves the persona from that stamp:
+
+```ts
+const persona = settings.getEffectivePersona(ctx?.at ? new Date(ctx.at) : new Date());
+```
+
+Missing `at` → live clock, i.e. today's behaviour, so any context built by another
+path is unaffected.
+
+This is the single point where the design either works or inverts itself, so it is
+worth verifying first: roll on a look-ahead context and assert
+`session.getSession().persona.id` is the **incoming** persona before building
+anything on top.
+
+### Change 1 — the boundary sequence uses the lookahead date
+
+In `queue.onTrackStarted`'s auto-pick block, hoist the `showAt` / `pickCtx`
+computation above the roll, and drive the whole boundary sequence from it:
+
+```ts
+// before: roll on the live clock, then look ahead for the pick only
+const ctx = await getFullContext();
+await session.maybeRoll(ctx);
+await programme.ensurePlan(ctx);
+await djAgent.runPersonaHandoff(this, ctx);
+await programme.onSessionSettled(this, ctx);
+const durSec = Number(this.current?.track?.duration);
+let pickCtx = ctx; let showAt = null;
+if (Number.isFinite(durSec) && durSec > 0) { … pickCtx = await getFullContext(showAt); }
+await djAgent.runTrackEvent(this, pickCtx, { wantLink, showAt });
+
+// after: one date drives roll, plan, mic-pass, episode hook AND pick
+const durSec = Number(this.current?.track?.duration);
+let showAt: Date | null = null;
+if (Number.isFinite(durSec) && durSec > 0) {
+  showAt = new Date(Date.now() + (durSec + PICK_SHOW_LOOKAHEAD_SEC) * 1000);
+}
+const pickCtx = showAt ? await getFullContext(showAt) : await getFullContext();
+await session.maybeRoll(pickCtx);
+await programme.ensurePlan(pickCtx);
+await djAgent.runPersonaHandoff(this, pickCtx);
+await programme.onSessionSettled(this, pickCtx);
+await djAgent.runTrackEvent(this, pickCtx, { wantLink, showAt });
+```
+
+Each step keeps its own `try/catch` — a handoff failure must never block the pick.
+
+The invariant this buys: **the pick's brief and the mic-pass key off one date.**
+Whenever a pick is made under the incoming show's rules, the mic-pass has already
+aired in front of it. They cannot diverge, because there is no longer a second date
+to diverge to.
+
+Unknown duration → no `showAt` → live clock, today's behaviour, unchanged.
+
+The existing `PICK_SHOW_LOOKAHEAD_SEC = 120` over-reach is now load-bearing for the
+handoff too, and its rationale carries over unchanged: a pick starting just shy of
+the boundary plays mostly inside the new show, so it should be the new show's — and
+should therefore be preceded by the mic-pass. Update the comment at `queue.ts:1427`,
+which currently documents the opposite.
+
+### Change 2 — the hourly cron rolls but no longer airs
+
+`rollSessionNow()` gains an option:
+
+```ts
+export async function rollSessionNow({ airHandoff = true } = {}) { … }
+```
+
+- `hourlyCheck()` passes **`airHandoff: false`**. It still rolls the session and
+  plans the episode — that state must be right even when no track boundary is near —
+  but it leaves `pendingHandoff()` set for the next boundary to air.
+- The takeover routes (`routes/shows.ts:200`, `:220`) keep the default `true`. An
+  operator takeover is an explicit action and should air promptly, the same
+  reasoning that exempts manual `/dj/segment` runners from the budget gate.
+
+With Change 1 in place the cron will normally find the session already rolled and
+no-op. It becomes a safety net rather than the primary path.
+
+### Change 3 — a pending handoff expires
+
+Change 2 removes the thing that used to mark an unaired handoff aired, so a pending
+mic-pass could otherwise survive indefinitely. Two ways that goes wrong: nobody is
+listening at the boundary (the track-start path is skipped entirely —
+`djCallsAllowed()` is false at `queue.ts:1383`) and a listener arrives hours later;
+or a very long track means the next boundary is far away.
+
+Stamp the roll and drop a stale mic-pass:
+
+- `RolledFrom` gains `at: number` (epoch ms), set in `stampRolledFrom()`
+  (`session.ts:301`). Sessions already on disk have no `at` — treat missing as
+  "not stale" so an in-flight handoff across a deploy still airs.
+- `runPersonaHandoff` drops and marks aired when
+  `Date.now() - pending.at > HANDOFF_MAX_AGE_MS`, mirroring the existing
+  `PENDING_VOICE_MAX_AGE_MS = 20 * 60_000` drop for pending idents
+  (`queue.ts:1102`) — and for the same reason: a greeting carries a baked-in time
+  reference, so a late one is worse than none.
+
+Silence on a missed changeover beats a mistimed one. This is the same call
+`shouldDropStaleLink` already makes for back-announces.
+
+The decision is pure and gets a test seam:
+
+```ts
+// broadcast/session.ts
+export function handoffIsStale(at: number | undefined, now: number, maxAgeMs: number): boolean {
+  if (!Number.isFinite(at)) return false;   // pre-upgrade session — let it air
+  return now - at! > maxAgeMs;
+}
+```
+
+### Change 4 — a mic-pass supersedes a pending ident
+
+Both a deferred station ID and a handoff can land on the same boundary:
+`airPendingVoice()` fires at `queue.ts:1195`, the mic-pass from the async auto-pick
+block. `airVoice` serializes, so nothing breaks audio-wise, but the listener gets
+ident + sign-off + greeting stacked back to back.
+
+In `airPendingVoice()`, drop the pending ident when `session.pendingHandoff()` is
+non-null — a mic-pass names the station, the outgoing show and the incoming show, so
+it *is* the station identification at that moment. Log it as a skip rather than
+silently discarding, consistent with the `link-skip` log at `queue.ts:1135`.
+
+### Change 5 — carry the persona on the queued item
+
+`QueueItem` gains `introPersona?: Persona | null`, set at `push()` time from the
+persona that actually wrote the line, then honoured at both later resolution points:
+
+| site | today | after |
+|---|---|---|
+| `queue.ts:949` (drain, render) | `speak(text, { kind })` | `speak(text, { kind, persona: item.introPersona })` |
+| `queue.ts:1145` (air, gain) | `voiceGainDb(kind)` | `voiceGainDb(kind, item.introPersona)` |
+| `queue.ts:1148` (session turn) | no `meta` | `meta: { personaId, personaName }` |
+
+On the generation side, the speaker is resolved **once**, from the same date as the
+roll and the brief — `settings.getEffectivePersona(showAt)` — and threaded through:
+
+- `dj-agent.ts:782` — `pickViaPool` currently calls `dj.generateLink({…})` with no
+  `persona` key, so `scripts.ts:137` (`const speaker = persona || settings.getEffectivePersona()`)
+  re-resolves on the live clock. Pass the resolved persona.
+- `dj-agent.ts:258` — `pickSystem`'s `settings.getEffectivePersona()` (no date arg)
+  takes the same resolved persona.
+- `dj-agent.ts:526` — the `queue.push({ introScript: introLink, … })` call gains
+  `introPersona`.
+- `dj-agent.ts:1060`, `:1089` — the request-intro pushes gain it too, so a request
+  intro queued near a boundary is voiced by whoever actually wrote it.
+
+This preserves the documented rule at `settings.ts:3988` — *track picks and their
+tied links stay with the host* — and starts enforcing it at render time, which it
+currently is not.
+
+### Change 6 — the handoff greeting's session turn
+
+`dj-agent.ts:1172` airs the greeting with `{ persona: personaIn }` but no `meta`,
+unlike the sign-off at `:1152`. Its session turn therefore carries no `personaId`,
+so `windowMessages()`' speaker-attribution guard (`session.ts:443`) can't tag it.
+Add `meta: { personaId: personaIn.id, personaName: personaIn.name }`.
+
+## Resulting timeline
+
+Replaying Jaz's changeover with a 5-minute track starting at 09:58:
+
+| time | event |
+|---|---|
+| 09:55 | programme outro (last hour, station-minute :55 window) — unchanged |
+| 09:58 | track A ends; `showAt` = 10:05 → **incoming show** |
+| 09:58 | session rolls to mid-morning; episode plan built |
+| 09:58 | outgoing DJ: sign-off — *at a boundary, over nothing* |
+| 09:58 | incoming DJ: greeting (doubles as the programme intro) |
+| 09:58 | track B starts — picked under the incoming brief, by the incoming host |
+| 10:00 | hourly cron: session already rolled → no-op. **Boundary passes silently.** |
+| 10:03 | track B ends; incoming DJ's link, in the incoming DJ's voice |
+
+## Files touched
+
+| file | change |
+|---|---|
+| `controller/src/context.ts` | Change 0 — return `at` on the context |
+| `controller/src/broadcast/session.ts` | Changes 0, 3 — persona from `ctx.at`; `RolledFrom.at`, `handoffIsStale()` |
+| `controller/src/broadcast/queue.ts` | Changes 1, 4, 5 — hoist lookahead above the roll; ident supersession; `introPersona` on `QueueItem` + `push()` + drain + air |
+| `controller/src/broadcast/scheduler.ts` | Change 2 — `rollSessionNow({ airHandoff })`, `hourlyCheck` passes `false`; settle the three `pickOnAirSpeaker()` sites |
+| `controller/src/broadcast/dj-agent.ts` | Changes 3, 5, 6 — staleness drop; persona threading; greeting `meta` |
+| `controller/scripts/handoff-boundary.test.ts` | new — pure tests |
+
+Note `RolledFrom.at` (Change 3) and the context's `at` (Change 0) are different
+stamps — when the roll happened, versus what moment the context describes. Keep the
+names distinct in code review.
+
+`routes/shows.ts` is unchanged: it keeps the default `airHandoff: true`.
+
+## Testing
+
+No test runner beyond the `scripts/*.test.ts` convention (`npm test` →
+`scripts/run-tests.ts`), so the testable surface is the pure decisions. New
+`scripts/handoff-boundary.test.ts`, modelled on `scripts/stale-link.test.ts`:
+
+- `handoffIsStale` — missing `at` → false; inside window → false; past window → true.
+- The roll-date selection: finite duration → `now + duration + 120`; zero, negative,
+  `NaN`, `undefined` duration → live clock.
+
+Manual verification on the dev stack, which is where the real risk sits:
+
+1. **Change 0 first, on its own.** Roll a session on a look-ahead context across a
+   persona boundary and assert `session.getSession().persona.id` is the *incoming*
+   persona and `pendingHandoff()` is non-null. If this fails, everything downstream
+   is silently a no-op — do not proceed until it passes.
+2. Paint two adjacent shows with different personas on the hour boundary.
+3. Watch `state/logs/events-*.jsonl` for `dj.handoff` and confirm its timestamp
+   falls within a second or two of an `onTrackStarted`, not at `:00`.
+4. Confirm the track that straddles `:00` was picked *after* the handoff event.
+5. Confirm the first link after the changeover is spoken in the incoming persona's
+   voice — the specific regression Jaz reported.
+6. With the stack up and no listeners, confirm the pending handoff expires rather
+   than firing at whatever boundary follows a listener reconnecting.
+
+Lint is the merge gate: `npm run lint` in `controller/` (`eslint . && tsc --noEmit`).
+
+## Risks
+
+- **Early mic-pass.** The 120s over-reach means the changeover can be announced up to
+  ~2 minutes before the grid boundary. This is intentional and matches how the pick
+  already behaves, but it does mean the outgoing DJ's slot ends slightly early. If
+  that reads badly on air, the knob is `PICK_SHOW_LOOKAHEAD_SEC` — and shrinking it
+  moves the pick and the mic-pass together, which is the point of the design.
+- **The session leads the grid by up to ~2 minutes.** This is the sharpest edge of
+  the design and deserves stating plainly: between the anticipated roll and the
+  actual boundary, `session.getSession().persona` is the *incoming* DJ while
+  `settings.getEffectivePersona()` — called with no date, on the live clock — still
+  returns the *outgoing* one. Any code reading the live persona in that window
+  disagrees with the session. Change 5 is what makes this safe on the paths that
+  matter, by resolving the speaker once from `showAt` and carrying it on the item
+  rather than re-deriving it later. The audit is bounded: there are 22 no-argument
+  `getEffectivePersona()` call sites, but most are irrelevant — signature defaults
+  (`settings.ts:120`/`:135`, `system.ts:44`/`:105`), `audio/tts.ts` fallbacks that
+  already receive an explicit persona from the callers Change 5 fixes, and UI reads
+  (`routes/public.ts:203`/`:333`, `routes/settings.ts:55`) where the live clock is
+  the correct answer. The ones that actually pick an on-air speaker are a short list:
+
+  | site | disposition |
+  |---|---|
+  | `session.ts:218` | **Change 0 — mandatory**, or the design inverts |
+  | `dj-agent.ts:258` (`pickSystem`), `:318` | Change 5 |
+  | `scheduler.ts:420`, `:505`, `:669` — `pickOnAirSpeaker()` no-arg (hourly, link, station ID) | decide per site; these already accept a date (`settings.ts:3990`) |
+  | `request.ts:88` | decide; a request landing at 09:59 arguably belongs to the incoming DJ |
+
+  `prompts/system.ts:32` already carries a comment about this exact skew
+  ("clock-driven `getEffectivePersona()` has already moved on by the time they
+  run"), so the codebase has met this class of bug before. Settling these call
+  sites is part of the work, not a follow-up.
+- **Cron no longer airs.** If Change 1 fails to fire for a reason not anticipated
+  here, the mic-pass now waits for a boundary instead of firing at `:00`, so the
+  failure mode is a *missing* handoff rather than a mistimed one. The staleness drop
+  bounds how long a broken one can linger; the `dj.handoff` event is the thing to
+  watch after deploy.
+- **`getFullContext(showAt)` is called once per track start.** It already was, for
+  the pick — this change reuses that value rather than adding a call. The live-clock
+  `getFullContext()` call is dropped when a duration is known, so this is one call
+  fewer on the common path.
+
+## Out of scope
+
+- Generalizing `announceAtNextTrack` into a multi-slot queue. Not needed — the
+  handoff uses `session.pendingHandoff()`, which is already a deferral mechanism.
+- Moving the *session roll* off the cron entirely. The cron remains the only boundary
+  detector when nobody is listening, and shows must roll whether or not anyone hears
+  the changeover.
+- The programme outro's grid-position scheduling (`span.index !== span.total - 1`),
+  which can sign off at a station-minute that isn't the real end for a takeover
+  spanning a partial hour. Real, unrelated, worth its own issue.
+- Deferring the other immediate `announce()` callers (hourly check, banter, skill
+  segments) to track boundaries. Same class of improvement, but each has different
+  timing semantics — the hourly check in particular is *about* the wall clock.

--- a/docs/superpowers/specs/2026-07-18-handoff-track-boundary-design.md
+++ b/docs/superpowers/specs/2026-07-18-handoff-track-boundary-design.md
@@ -409,6 +409,56 @@ Lint is the merge gate: `npm run lint` in `controller/` (`eslint . && tsc --noEm
   `getFullContext()` call is dropped when a duration is known, so this is one call
   fewer on the common path.
 
+## Implementation notes
+
+Three things changed between this design and the shipped code.
+
+**1. Identity looks ahead; the clock does not.** The design said to drive the
+whole boundary sequence off `showAt`. That is right for *identity* (which show
+and persona are on) but wrong for the *clock*: `SCRIPT_CONTEXT_FIELDS` in
+`llm/internal/prompts/scripts.ts` includes `clock`, so the handoff prompts would
+have been handed a time up to a track-length plus the look-ahead margin ahead of
+when the mic-pass actually airs — the DJ misstating the time on air, which is the
+failure issue #864 fixed for links. The queue call site now passes the handoff a
+merged context: `show`/`mood`/`festival` from the look-ahead (the show being
+handed *to*), `date`/`clock`/`time` from the live moment. Built only when a
+handoff is pending, so it costs nothing per track.
+
+**2. `session.onAirPersona()` replaced `getEffectivePersona(showAt)`.** Threading
+a date through every speaker lookup would have meant every call site
+re-deriving the same answer and being able to get it wrong. Since the roll has
+already happened by the time anything writes a line, the session *is* the answer:
+one exported helper in `session.ts` resolves the live session's persona and falls
+back to the grid. Used by `pickSystem`, `requestSystem`, the pool-pick link, and
+all four `introPersona` stamps.
+
+**3. `pickOnAirSpeaker()` call sites were left alone, deliberately.** The three
+no-argument sites in `scheduler.ts` are the hourly check (`:420`), the manual link
+runner (`:505`) and the station ID (`:669`). Idents fire at `:15/:30/:45` and the
+hourly at `:00`, none of which fall inside the ~2-minute window where the session
+leads the grid, so only the manual link route can disagree — a rare operator
+action whose fallback is simply the outgoing DJ speaking once more. Adding a
+session-aware speaker variant for that case is scope the fix doesn't need.
+
+Also shipped beyond the file list: `routes/request.ts` gained `introPersona` on
+its two stateless-fallback pushes (`:276`, `:559`), which have the same
+render-later/air-later split as the agent path.
+
+### Verification performed
+
+Beyond `npm test` (37 files) and `npm run lint` (0 errors), the Change 0 chain was
+exercised against the real modules with a seeded state dir — two adjacent shows
+on the hour with different personas:
+
+- **Positive:** a roll on a context stamped for `10:05`, executed at wall-clock
+  `09:58`, produced a session whose persona was the *incoming* DJ and a
+  `pendingHandoff()` armed from the *outgoing* one, with `at` stamped.
+- **Counter-proof:** the same roll with the `at` stamp stripped rolled the *show*
+  to "Mid Morning" but left the *persona* on the outgoing DJ — so
+  `stampRolledFrom` saw no change and `pendingHandoff()` was `null`. This is the
+  suppression this design predicted, reproduced on demand, confirming Change 0
+  is load-bearing rather than defensive.
+
 ## Out of scope
 
 - Generalizing `announceAtNextTrack` into a multi-slot queue. Not needed — the


### PR DESCRIPTION
Closes the two Discord reports about show changeovers. Spec + implementation.

## The reports

- **Gurthyy [NSTV]** — station IDs have a deferred path that waits for the next track boundary; handoffs should too, instead of firing at the top of the hour over the middle of a song.
- **Jaz666** — a morning → mid-morning changeover where the handoff sprawled across ~6 minutes, and a link generated for the incoming DJ was **spoken in the outgoing DJ's voice**.

## Root cause

Gurthyy is right that the deferred path exists (`queue.announceAtNextTrack`, one caller: station IDs). But the handoff's problem wasn't a missing deferral.

`queue.onTrackStarted` **already** called `runPersonaHandoff` before the pick, and **already** computed a look-ahead (`showAt = now + duration + 120s`) to pick under the incoming show's brief. It just rolled the session on the *live* clock:

```ts
// The session roll and handoff above stay on the live clock: only the pick looks ahead.
```

At 09:58 the grid still says "morning show", so that roll never fired and the `:00` cron won it mid-song. Net effect: the changeover track — already picked *for the new show* — aired **before anyone had handed over**. That is Jaz's timeline exactly.

## What changed

**One date drives the whole boundary sequence.** Roll, episode plan, mic-pass, episode hook and pick all key off `showAt`, so the mic-pass lands in front of the changeover track and the pick's brief can't disagree with the on-air persona — there's no second date to disagree with. This needed *less* machinery than deferring: `session.pendingHandoff()` was already a "wait for a boundary" mechanism, so `announceAtNextTrack` is untouched.

**The hourly cron rolls but no longer airs** (`rollSessionNow({ airHandoff })`). Takeover routes still air immediately — an operator action is explicit. A pending mic-pass expires after 20m, and supersedes a pending station ident on the same boundary.

**The persona is carried on the queue item.** `speak()` at drain and `voiceGainDb()` at air each re-resolved it, so generation, render and air could name three different DJs. `voiceGainDb` in `airIntro` was the last call site in the codebase still resolving from the clock. Speakers now resolve once via `session.onAirPersona()`.

## Two things worth reviewer attention

**1. A prerequisite that inverts the design if missed.** `getFullContext()` didn't return the date it was built for, so `session.start()` resolved the persona off the wall clock. An anticipated roll would build a session with the incoming *show* but the outgoing *persona* — `stampRolledFrom` then sees no persona change, sets `rolledFrom = null`, and the mic-pass is **suppressed entirely**. Worse than the bug being fixed. Contexts now carry `at`.

I verified this both ways against the real modules with a seeded state dir: a look-ahead roll arms the mic-pass with the incoming persona, and **stripping the `at` stamp reproduces the suppression on demand** (show rolls to "Mid Morning", persona stays on the outgoing DJ, `pendingHandoff()` null).

**2. Identity looks ahead; the clock does not.** Caught while implementing: `SCRIPT_CONTEXT_FIELDS` includes `clock`, so driving the handoff prompts off `showAt` would have handed them a time up to a track-length + 2min ahead of when the mic-pass actually airs — the DJ misstating the time on air, the failure #864 fixed for links. The handoff now takes `date`/`clock`/`time` from the live moment and `show`/`mood`/`festival` from the look-ahead.

## Known edge, documented

The session now leads the schedule grid by up to ~2 minutes, so `getEffectivePersona()` (wall clock) disagrees with the session in that window. `session.onAirPersona()` is the fix on the paths that write or voice lines. The three no-arg `pickOnAirSpeaker()` sites in `scheduler.ts` were **deliberately left alone** — idents fire at `:15/:30/:45` and the hourly at `:00`, none inside the window; only the manual link route can disagree, and its fallback is the outgoing DJ speaking once more.

## Verification

- `npm test` — 37/37 files pass, including new `scripts/handoff-boundary.test.ts` (14 assertions pinning `contextDate` and `handoffIsStale`, both pure).
- `npm run lint` — 0 errors (550 pre-existing repo-wide `no-explicit-any` warnings; this branch adds none and removes one).
- Integration check of the Change 0 chain against real modules, positive and counter-proof, as above.

Not yet run on the live stack — the on-air check (handoff timestamp landing next to an `onTrackStarted` rather than `:00`) is listed in the spec's manual verification section.