### PR TITLE
feat(web): station-level social/embed description

### DIFF
--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -339,6 +339,10 @@ router.get('/dj', async (req, res) => {
       djMode: persona?.djMode === true,
       avatar: avatarUrlFor(persona?.id),
       station: s.station,
+      // Station-level share-card blurb. Persona-independent by design, so a
+      // shared link reads the same whoever is on air (issue #1086). '' = unset;
+      // the web app falls back to the persona tagline.
+      stationDescription: s.stationDescription || '',
       location: s.weather?.locationName || '',
       locale: s.locale,
     });

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -94,6 +94,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
         stream: s.stream,
         loudness: s.loudness,
         station: s.station,
+        stationDescription: s.stationDescription,
         timezone: s.timezone,
         locale: s.locale,
         theme: s.theme,

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -1090,6 +1090,13 @@ const DEFAULTS = {
   // still called SUB/WAVE — this is what the operator's station running on it
   // is called (e.g. "Frequency 88", "Late Shift Radio").
   station: 'SUB/WAVE',
+  // Station-level blurb for link previews (og:description, twitter:description,
+  // meta description). Deliberately NOT the on-air persona's tagline: that
+  // changes with whoever is on air, so a shared station link would describe
+  // itself differently depending on the hour (issue #1086). Empty = unset, and
+  // the web app falls back to the persona tagline, preserving the behaviour of
+  // installs that predate this field. Never enters the DJ prompt.
+  stationDescription: '',
   // Station clock — IANA zone driving everything with local-time semantics
   // (time-of-day moods, schedule slots, hourly time checks, festival dates).
   // Empty = Auto: the container's own TZ, so existing installs are untouched.
@@ -1956,6 +1963,10 @@ export async function load() {
       typeof stored.station === 'string' && stored.station.trim()
         ? stored.station.trim().slice(0, 80)
         : DEFAULTS.station,
+    stationDescription:
+      typeof stored.stationDescription === 'string'
+        ? stored.stationDescription.trim().slice(0, 200)
+        : DEFAULTS.stationDescription,
     // Invalid stored zone (hand-edited file) falls back to Auto — the
     // station must never crash on a bad zone.
     timezone:
@@ -3185,6 +3196,15 @@ export async function update(patch) {
       restart = true;
     }
     next.station = resolved;
+  }
+  if ('stationDescription' in patch) {
+    const v = String(patch.stationDescription ?? '').trim();
+    if (v.length > 200) {
+      throw new Error('station description must be 200 chars or fewer');
+    }
+    // No `restart` — this never reaches the DJ prompt or a liquidsoap_*.txt
+    // file; it is read per-request by the web app's generateMetadata().
+    next.stationDescription = v;
   }
   if ('timezone' in patch) {
     const v = String(patch.timezone ?? '').trim();

--- a/web/app/listen/page.tsx
+++ b/web/app/listen/page.tsx
@@ -1,14 +1,36 @@
-import type { Viewport } from 'next';
+import type { Metadata, Viewport } from 'next';
 import PlayerApp from '@/components/PlayerApp';
 import PlayerPageEffects from '@/components/player/PlayerPageEffects';
 import { pageMeta } from '@/lib/seo';
+import { fetchStationMeta } from '@/lib/station';
 
-export const metadata = pageMeta({
+// The generic product copy — what an un-personalised install has always shown,
+// and the fallback whenever the controller has nothing station-specific to say.
+const GENERIC = pageMeta({
   title: 'SUB/WAVE — Player',
   description:
     'Tune in to the SUB/WAVE broadcast — one live stream, with an AI DJ picking tracks and talking between them. See what is on air right now.',
   path: '/listen',
 });
+
+// The other player route, so a branded station's link preview is not labelled
+// with the software it runs on (issue #1086) — before this it always emitted the
+// SUB/WAVE product copy. No persona-tagline fallback: this route never had one,
+// and inheriting it would import exactly the on-air drift #1086 is about. So it
+// reads the station description or nothing personal at all.
+//
+// The route is already force-dynamic, so this runs per-request; on any
+// controller failure fetchStationMeta() returns null and we serve GENERIC.
+export async function generateMetadata(): Promise<Metadata> {
+  const meta = await fetchStationMeta();
+  if (!meta) return GENERIC;
+  return pageMeta({
+    title: `${meta.name} — Player`,
+    description: meta.description,
+    path: '/listen',
+    siteName: meta.name,
+  });
+}
 
 // Render per-request so the canonical/og:url pick up the runtime SITE_URL — a
 // build-time render bakes localhost into image-based installs (see lib/site.ts).

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -3,16 +3,12 @@ import PlayerApp from '@/components/PlayerApp';
 import PlayerPageEffects from '@/components/player/PlayerPageEffects';
 import Landing from '@/components/Landing';
 import { absoluteUrl } from '@/lib/seo';
-import { fetchStationIdentity } from '@/lib/station';
+import { fetchStationMeta } from '@/lib/station';
 import { getShowcaseStations } from '@/lib/stations';
 
 // Read at request time so a deployment can flip player ↔ landing by just
 // restarting the web container with a different env value, no rebuild.
 export const dynamic = 'force-dynamic';
-
-// The product name — also the default value of the controller's
-// `settings.station`, so an un-personalised install reports this verbatim.
-const DEFAULT_STATION = 'SUB/WAVE';
 
 // Per-request metadata for the root. The baseline (always emitted) pins the
 // canonical + og:url to the absolute origin — the Metadata API leaves absolute
@@ -20,10 +16,10 @@ const DEFAULT_STATION = 'SUB/WAVE';
 // route. Title/description/social otherwise inherit from the root layout.
 //
 // When the homepage is the player (not the landing broadsheet), we personalise
-// the share-card preview with the operator's station name + DJ tagline read
-// live from the controller (issue #272). On landing mode, a missing/default
-// station, or any controller failure we fall through to the generic SUB/WAVE
-// branding so the preview never breaks.
+// the share-card preview with the operator's station name + description read
+// live from the controller (issues #272, #1086). On landing mode, a station
+// with nothing operator-specific set, or any controller failure we fall through
+// to the generic SUB/WAVE branding so the preview never breaks.
 export async function generateMetadata(): Promise<Metadata> {
   const base: Metadata = {
     alternates: { canonical: absoluteUrl('/') },
@@ -33,18 +29,12 @@ export async function generateMetadata(): Promise<Metadata> {
   const mode = (process.env.SUBWAVE_HOMEPAGE || 'player').toLowerCase();
   if (mode !== 'player') return base;
 
-  const id = await fetchStationIdentity();
-  const station = id?.station?.trim() || '';
-  const tagline = id?.tagline?.trim() || '';
-
-  // Nothing to personalise: no station (or still the default product name) and
-  // no tagline → behave exactly as an un-personalised install does today.
-  if ((!station || station === DEFAULT_STATION) && !tagline) return base;
-
-  const name = station || DEFAULT_STATION;
-  const description =
-    tagline ||
-    `Tune in to ${name} — one live stream, with an AI DJ picking tracks and talking between them.`;
+  // allowPersonaTagline: issue #272 shipped tagline-personalised previews here,
+  // so keep them for installs that never set a station description. Setting one
+  // (admin → Station → Share description) takes precedence and stops the drift.
+  const meta = await fetchStationMeta({ allowPersonaTagline: true });
+  if (!meta) return base;
+  const { name, description } = meta;
 
   // openGraph/twitter are NOT deep-merged across the layout→page chain (see
   // lib/seo.ts pageMeta), so restate them fully here. The layout's hand-written

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -133,6 +133,7 @@ export default function SettingsPanel() {
         source: v.loudness?.source ?? 'replaygain-then-measured',
       },
       station: v.station ?? '',
+      stationDescription: v.stationDescription ?? '',
       timezone: v.timezone ?? '',
       locale: normalizeStationLocale(v.locale),
       kokoroLang: v.tts?.kokoro?.lang ?? '',

--- a/web/components/admin/settings/StationSection.tsx
+++ b/web/components/admin/settings/StationSection.tsx
@@ -40,6 +40,7 @@ function clockPreview(timeZone: string, locale: StationLocale) {
 export function StationSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
   const save = () => saveSettings({
     station: form.station,
+    stationDescription: form.stationDescription,
     timezone: form.timezone,
     locale: form.locale,
     weather: {
@@ -87,7 +88,7 @@ export function StationSection({ data, form, setForm, busy, saveSettings }: Sect
         ]}
       />
 
-      <Card title="Station name" sub="What the DJ calls this radio on air">
+      <Card title="Station identity" sub="What the DJ calls this radio on air, and how shared links describe it">
         <div className="field">
           <Label>Station name</Label>
           <Input
@@ -101,6 +102,25 @@ export function StationSection({ data, form, setForm, busy, saveSettings }: Sect
           />
           <div className="field-hint">
             Substituted into the DJ prompt’s {'{station}'} placeholder (current: {data.values?.station || 'SUB/WAVE'}). Applies live.
+          </div>
+        </div>
+
+        <div className="field">
+          <Label>Share description</Label>
+          <Input
+            placeholder="A short line describing your station…"
+            value={form.stationDescription}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setForm(f => ({ ...f, stationDescription: e.target.value }))
+            }
+            className="w-full"
+            maxLength={200}
+          />
+          <div className="field-hint">
+            The blurb shown when someone shares a link to this station on social
+            media or chat. Stays the same whoever is on air — leave it empty and
+            the preview falls back to the current DJ’s tagline, which changes
+            with the schedule. Never read on air. {form.stationDescription.length}/200.
           </div>
         </div>
       </Card>

--- a/web/components/admin/settings/shared.tsx
+++ b/web/components/admin/settings/shared.tsx
@@ -192,6 +192,7 @@ export interface FormState {
   stream: StreamForm;
   loudness: LoudnessForm;
   station: string;
+  stationDescription: string;
   timezone: string;
   locale: StationLocale;
   kokoroLang: string;
@@ -246,6 +247,7 @@ export interface SettingsData {
     };
     loudness?: { targetLufs?: number; maxBoostDb?: number; source?: LoudnessSource };
     station?: string;
+    stationDescription?: string;
     timezone?: string;
     locale?: StationLocale;
     theme?: { active?: string };

--- a/web/lib/seo.ts
+++ b/web/lib/seo.ts
@@ -23,16 +23,21 @@ export function absoluteUrl(path = '/'): string {
 //   og:* tags, and without it every subpage inherits the root layout's
 //   sitewide twitter card. twitter:image stays global (hand-written in the
 //   root layout <head>).
+// - `siteName` defaults to the product name. Player routes pass the operator's
+//   own station name so a branded install's share card is not labelled with the
+//   software it happens to run on (issue #1086).
 export function pageMeta({
   title,
   description,
   path,
   type = 'website',
+  siteName = 'SUB/WAVE',
 }: {
   title: string;
   description?: string;
   path: string;
   type?: 'website' | 'article';
+  siteName?: string;
 }): Metadata {
   const url = absoluteUrl(path);
   return {
@@ -43,7 +48,7 @@ export function pageMeta({
       title,
       ...(description ? { description } : {}),
       url,
-      siteName: 'SUB/WAVE',
+      siteName,
       type,
     },
     twitter: {

--- a/web/lib/station.ts
+++ b/web/lib/station.ts
@@ -14,13 +14,18 @@ const CONTROLLER_BASE = (
 
 export interface StationIdentity {
   station: string;
+  stationDescription: string;
   tagline: string;
 }
 
-// Fetch the operator's station name + DJ tagline from the controller's public
-// /dj endpoint. Returns null on any failure (controller down, timeout, non-OK)
-// so the caller can fall back to the generic SUB/WAVE branding — the preview
-// must never break.
+// The product name — also the default value of the controller's
+// `settings.station`, so an un-personalised install reports this verbatim.
+export const DEFAULT_STATION = 'SUB/WAVE';
+
+// Fetch the operator's station name, station-level description and DJ tagline
+// from the controller's public /dj endpoint. Returns null on any failure
+// (controller down, timeout, non-OK) so the caller can fall back to the generic
+// SUB/WAVE branding — the preview must never break.
 export async function fetchStationIdentity(): Promise<StationIdentity | null> {
   try {
     const res = await fetch(`${CONTROLLER_BASE}/dj`, {
@@ -31,9 +36,56 @@ export async function fetchStationIdentity(): Promise<StationIdentity | null> {
     const data = await res.json();
     return {
       station: typeof data?.station === 'string' ? data.station : '',
+      stationDescription:
+        typeof data?.stationDescription === 'string' ? data.stationDescription : '',
       tagline: typeof data?.tagline === 'string' ? data.tagline : '',
     };
   } catch {
     return null;
   }
+}
+
+export interface StationMeta {
+  name: string;
+  description: string;
+}
+
+// Resolve the share-card name + description for a player route. Returns null
+// when there is nothing operator-specific to say, so callers keep whatever
+// generic SUB/WAVE copy they already ship.
+//
+// Description precedence (issue #1086):
+//   1. settings.stationDescription — station-level, persona-independent. What a
+//      shared link *should* say, and stable whoever is on air.
+//   2. the active persona's tagline — only when `allowPersonaTagline`.
+//   3. a generated sentence naming the station.
+//
+// `allowPersonaTagline` exists because rung 2 is the very drift #1086 reports:
+// the tagline changes with whoever is on air, so a link shared at noon and one
+// shared at midnight describe the station differently. It is NOT a good default
+// — it is back-compat. The homepage opts in because issue #272 already shipped
+// tagline-personalised previews there and silently downgrading those installs
+// to a generated sentence would be a visible regression. Routes that never had
+// it (/listen) leave it off, so they are persona-independent from day one.
+export async function fetchStationMeta(
+  { allowPersonaTagline = false }: { allowPersonaTagline?: boolean } = {},
+): Promise<StationMeta | null> {
+  const id = await fetchStationIdentity();
+  const station = id?.station?.trim() || '';
+  const stationDescription = id?.stationDescription?.trim() || '';
+  const tagline = allowPersonaTagline ? id?.tagline?.trim() || '' : '';
+
+  // Nothing to personalise: no station (or still the default product name) and
+  // no usable description source → behave as an un-personalised install.
+  const named = station && station !== DEFAULT_STATION;
+  if (!named && !stationDescription && !tagline) return null;
+
+  const name = station || DEFAULT_STATION;
+  return {
+    name,
+    description:
+      stationDescription ||
+      tagline ||
+      `Tune in to ${name} — one live stream, with an AI DJ picking tracks and talking between them.`,
+  };
 }


### PR DESCRIPTION
From a Discord suggestion: SUB/WAVE took URL-preview metadata (`meta description`, `og:description`, `twitter:description`) from the **active persona's tagline**, so a shared station link described itself differently depending on who was on air — and with scheduled shows, on the hour.

Confirmed in the code: `web/app/page.tsx` → `fetchStationIdentity()` → `GET /dj` → `settings.getEffectivePersona().tagline`, which honours a show's persona override. There was no station-level description anywhere in the schema — only `station` (the name) and `weather.locationName`.

## What this adds

`settings.stationDescription` — persona-independent, 200-char cap, exposed on `GET /dj`, editable at **admin → Station → Share description**. It never enters the DJ prompt and needs no mixer restart.

Both player routes resolve through one helper (`web/lib/station.ts`) so they can't drift apart:

| | station description set | only a persona tagline | neither |
|---|---|---|---|
| `/` | station description | persona tagline *(back-compat)* | generic |
| `/listen` | station description | sentence naming the station | generic |

The asymmetry is deliberate and commented. Issue #272 shipped tagline-personalised previews on `/`, so dropping that silently would visibly regress installs relying on it — the new field simply takes precedence. `/listen` was never station-aware at all (it always emitted the SUB/WAVE product copy, even on a fully branded station), so it opts out of the tagline rung: inheriting it would import the exact drift this change fixes onto a route that never had it.

`pageMeta` gained an optional `siteName` so a branded station's card isn't labelled with the software it happens to run on.

## Verification

Isolated controller (spare port + temp `STATE_DIR`) + worktree web dev server, so the live station was never touched:

- Rendered `og:` / `twitter:` / `meta` tags inspected on **both** routes across all three fallback tiers in the table above
- 200-char validation — 201 rejected, 200 accepted
- Value survives a controller restart (the `load()`/normalize path)
- **Controller down** → both routes still render HTTP 200 with generic copy, no breakage
- Admin field end to end via Playwright: hydrates from settings, saves a changed value through to the API, survives reload
- `npm run lint` clean in both `controller/` and `web/`

## Not included

The OG **image** (`web/app/og/route.js`) stays `force-static` hardcoded SUB/WAVE branding — personalising it means dropping `force-static` and paying a render per share. Worth doing separately if operators ask.