### PR TITLE
fix(dj): frame request intros for air time, not write time

### DIFF
--- a/controller/scripts/request-intro-airtime.test.ts
+++ b/controller/scripts/request-intro-airtime.test.ts
@@ -1,0 +1,81 @@
+// Regression test for the request-intro AIR-TIME framing clause.
+// Run: `npm test -- request-intro-airtime` (tsx scripts/request-intro-airtime.test.ts).
+//
+// A request intro is WRITTEN when the request resolves but AIRED from
+// onTrackStarted — it plays over the opening seconds of the track it
+// introduces (queue.airIntro, deferred by #189). Requests also append to the
+// END of `upcoming`, so an already-queued track can air in between.
+//
+// Two staleness modes follow. shouldDropStaleLink (scripts/stale-link.test.ts)
+// only ever catches a wrongly NAMED predecessor, and it is disabled for request
+// intros anyway (they carry no linkPrev). So the tense/moment staleness has to
+// be PREVENTED in the prompt — which makes AIR_TIME_CLAUSE the only thing
+// standing between the model and copy like "what comes through the speakers
+// next" (a real logged intro: correct when written, wrong on air).
+//
+// These asserts pin the clause's load-bearing content so a future prompt edit
+// can't quietly drop it. They deliberately do NOT assert exact wording — only
+// the properties that must survive a rewrite.
+
+import assert from 'node:assert/strict';
+import { AIR_TIME_CLAUSE } from '../src/llm/internal/prompts/scripts.js';
+
+let failures = 0;
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err: any) {
+    failures++;
+    console.error(`  ✗ ${name}\n      ${err?.message || err}`);
+  }
+}
+
+function main() {
+  console.log('request-intro air-time clause (AIR_TIME_CLAUSE):');
+
+  test('states that the line airs over the track, not before it', () => {
+    assert.match(AIR_TIME_CLAUSE, /airs over the opening/i);
+    assert.match(AIR_TIME_CLAUSE, /not in the gap before it/i);
+  });
+
+  test('forbids future framing — the #1 observed failure ("next")', () => {
+    assert.match(AIR_TIME_CLAUSE, /never as something still to come/i);
+  });
+
+  test('warns that time and another track may pass before it airs', () => {
+    assert.match(AIR_TIME_CLAUSE, /minutes and another song may pass/i);
+  });
+
+  test('forbids anchoring to the moment (mood staleness, not just names)', () => {
+    // The queue-side guard can only catch a NAMED wrong predecessor, so a line
+    // like "we're leaning into low light now" — stale but naming nobody — has
+    // to be prevented here or not at all.
+    assert.match(AIR_TIME_CLAUSE, /on air at this instant|how the room feels/i);
+  });
+
+  test('offers NO example opening phrasings', () => {
+    // Regression pin: an earlier draft listed present-tense openers ("this
+    // is…", "that's us into…") and a live run put the SAME opener on three
+    // consecutive request intros — the model reads a menu as a template. The
+    // station's opener variety comes from ANGLES + the recent-opener
+    // blocklist; this clause must not compete with them.
+    const seeded = /"[^"]*(this is|that's|here it comes|here's)[^"]*"/i;
+    assert.equal(seeded.test(AIR_TIME_CLAUSE), false,
+      'clause must not quote example openers — it flattens every intro to the same shape');
+  });
+
+  test('is additive — a leading space so it appends cleanly to a prompt', () => {
+    assert.equal(AIR_TIME_CLAUSE.startsWith(' '), true);
+    assert.equal(AIR_TIME_CLAUSE.trim().length > 0, true);
+  });
+
+  if (failures > 0) {
+    console.error(`\n${failures} test(s) failed`);
+    process.exit(1);
+  }
+  console.log('\nall request-intro air-time tests passed');
+  process.exit(0);
+}
+
+main();

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -228,7 +228,7 @@ export function requestSchema() {
   return z.object({
     id: z.string().describe('the exact song id returned by one of the discovery tools — never invent or compose ids'),
     ack: z.string().describe('short on-air acknowledgement of the listener, in character — max 20 words; no "thank you for listening" or self-intros'),
-    intro: z.string().describe(`a natural DJ intro for the track in the DJ voice; weave in what the listener asked for without reading the request back verbatim. ${dj.lengthPhrase('intro')}`),
+    intro: z.string().describe(`a natural DJ intro for the track in the DJ voice; weave in what the listener asked for without reading the request back verbatim. It airs over the track's opening seconds, so write it in the present tense — never "next" or "coming up". ${dj.lengthPhrase('intro')}`),
   });
 }
 
@@ -318,7 +318,9 @@ export function requestSystem() {
   const persona = settings.getEffectivePersona();
   return `${settings.agentPersonaPreamble(persona)}
 
-The messages above are the live session. The final user line names the ONE listener request you are resolving now — any earlier request lines are already handled by someone else; ignore them. If the exact ask isn't in the library, pick the closest thing your tools actually returned and own the substitution in the "ack" and "intro" — never pretend it's what they asked for.${settings.agentLanguageReminder(persona, 'the "ack" and "intro" lines')}`;
+The messages above are the live session. The final user line names the ONE listener request you are resolving now — any earlier request lines are already handled by someone else; ignore them. If the exact ask isn't in the library, pick the closest thing your tools actually returned and own the substitution in the "ack" and "intro" — never pretend it's what they asked for.${settings.agentLanguageReminder(persona, 'the "ack" and "intro" lines')}
+
+The currently-playing track named in that line is there ONLY so you can interpret asks that lean on it ("something like this", "match this energy"). It is not the track your intro introduces and it may well have finished by the time the intro airs — never mention it, back-announce it, or describe the mood it set.${dj.AIR_TIME_CLAUSE}`;
 }
 
 // --- Agent circuit breaker ---------------------------------------------------

--- a/controller/src/llm/dj.ts
+++ b/controller/src/llm/dj.ts
@@ -15,6 +15,7 @@ export {
 export { introBudgetPhrase, enforceIntroBudget } from './internal/prompts/intro-budget.js';
 export { matchRequest, identifyTrackFromText } from './internal/prompts/request.js';
 export {
+  AIR_TIME_CLAUSE,
   generateIntro,
   generateStationId,
   generateSignoff,

--- a/controller/src/llm/internal/prompts/scripts.ts
+++ b/controller/src/llm/internal/prompts/scripts.ts
@@ -18,6 +18,34 @@ import { introBudgetPhrase, introMsFor, bpmKeyFor } from './intro-budget.js';
 // it, a model told to "mention the weather" would only invent it.
 const SCRIPT_CONTEXT_FIELDS = ['date', 'clock', 'time', 'festival', 'show', 'listeners'];
 
+// A request intro is WRITTEN when the request resolves but AIRED from
+// onTrackStarted — it plays over the opening bars of the track it introduces,
+// heavy-ducked, not in the gap before it (queue.airIntro, deferred by #189).
+// Requests also append to the END of `upcoming` (queue.push), so an already-
+// queued track can air in between, putting minutes and a whole other song
+// between writing and airing. Two failure modes follow, and this clause is the
+// single place both are addressed:
+//   1. TENSE — "what comes through the speakers next" is written correctly at
+//      resolve time and is wrong on air, because the track is playing by then.
+//      Observed in the wild even at queue depth 1, with nothing in between.
+//   2. STALE MOMENT — anything anchored to what was on-air, or to the state of
+//      the room "right now", may have been overtaken by the track that slipped
+//      in between. shouldDropStaleLink only catches a wrongly NAMED
+//      predecessor, so tense/mood staleness has to be prevented here.
+// Exported so the request AGENT path (broadcast/dj-agent.ts requestSystem)
+// shares the wording verbatim instead of drifting from this one.
+// NOTE: deliberately no example opening phrasings here. An earlier draft
+// offered a few ("this is…", "that's us into…") and a live run put the SAME
+// opener on three consecutive request intros — the model treats a menu as a
+// template. State the constraint, let ANGLES + the opener blocklist keep the
+// shape varied.
+export const AIR_TIME_CLAUSE = ' Timing: this line airs over the opening seconds'
+  + ' of the track itself, not in the gap before it. The track is already'
+  + ' sounding as you speak — refer to it as present and playing, never as'
+  + ' something still to come. Minutes and another song may pass between writing'
+  + ' this and airing it, so say nothing about what is on air at this instant or'
+  + ' about how the room feels right now.';
+
 export async function generateIntro({ track, context, requestedBy = null, requestText = null, artistMiss = null, recap = null, recentTracks = null, recentOpeners = null }: any) {
   const ctxLines = buildContextLines(context, { recentTracks, contextFields: SCRIPT_CONTEXT_FIELDS });
   if (requestedBy) ctxLines.push(`Requested by: ${requestedBy}`);
@@ -31,18 +59,18 @@ export async function generateIntro({ track, context, requestedBy = null, reques
   // pretending the track is by the requested artist (issue: "asked for Katy
   // Perry, got Daft Punk, intro still said Katy Perry").
   if (artistMiss) {
-    ctxLines.push(`IMPORTANT: We do NOT have "${artistMiss}" in the library. The track coming up is NOT by them — it's a fitting substitute for the moment. Do not imply or claim the track is by "${artistMiss}".`);
+    ctxLines.push(`IMPORTANT: We do NOT have "${artistMiss}" in the library. The track now starting is NOT by them — it's a fitting substitute for the moment. Do not imply or claim the track is by "${artistMiss}".`);
   }
-  ctxLines.push(`Coming up: "${track.title}" by ${track.artist}${track.album ? ` from ${track.album}` : ''}${track.year ? ` (${track.year})` : ''}`);
+  ctxLines.push(`Now starting: "${track.title}" by ${track.artist}${track.album ? ` from ${track.album}` : ''}${track.year ? ` (${track.year})` : ''}`);
 
   // Talk-within-the-intro (A.3 phase 1): when the track's intro runway is
   // known, budget the line to land before the vocals. Advisory + additive —
   // empty for un-analysed tracks, so behaviour is unchanged there.
   const budget = introBudgetPhrase(introMsFor(track));
   const missClause = artistMiss
-    ? ` The listener asked for "${artistMiss}", but we don't have them — briefly own that ("no ${artistMiss} in the crates", or similar), then introduce what's actually coming up as a worthy stand-in. Never pretend the track is by "${artistMiss}".`
+    ? ` The listener asked for "${artistMiss}", but we don't have them — briefly own that ("no ${artistMiss} in the crates", or similar), then introduce what's actually playing as a worthy stand-in. Never pretend the track is by "${artistMiss}".`
     : '';
-  const prompt = `Write an intro for this track. ${lengthPhrase('intro')}${budget ? ' ' + budget : ''} If the listener said something specific, acknowledge their words naturally — don't quote them verbatim, but weave the gist in. Never read the request out loud as-is. This is a listener request — keep the focus on what they asked for and the track coming up; don't back-announce or talk about the track that was just playing.${missClause}\n\n${ctxLines.join('\n')}`;
+  const prompt = `Write an intro for this track. ${lengthPhrase('intro')}${budget ? ' ' + budget : ''} If the listener said something specific, acknowledge their words naturally — don't quote them verbatim, but weave the gist in. Never read the request out loud as-is. This is a listener request — keep the focus on what they asked for and the track now starting; don't back-announce or talk about the track that was just playing.${AIR_TIME_CLAUSE}${missClause}\n\n${ctxLines.join('\n')}`;
 
   return djText({
     system: djSystem(),


### PR DESCRIPTION
From a Discord report by Gurthyy [NSTV]:

> Listener request intros can go stale when the requested song is queued behind another track. The intro seems to be generated when the request is resolved, so if another song plays first, the spoken transition may reference the wrong previous track.

## What's actually happening

The timing in the report is right. A request intro is written when the request resolves, rendered to WAV at queue-drain, and only aired from `onTrackStarted` — so it plays **over the opening bars** of the track it introduces. Requests also append to the **end** of `upcoming` (`queue.push`), so an already-queued track can air in between.

Neither request path accounted for that gap:

- **Stateless cascade** (`generateIntro`) said *"the track coming up"* — right at write time, wrong on air.
- **Agent path** (`requestSystem`, the default when `llm.pickerAgent` is on) said **nothing** about timing, while `runRequestViaAgent` hands it `(currently playing "X" by Y)` in the tail with no instruction not to mention it.

## But not the failure that was reported

Worth being precise, because it changed the fix. The logs do **not** show intros back-announcing a wrong previous track. Across 28 session archives, `that was|we just heard|coming out of|after that` matched **zero** DJ turns — the existing don't-back-announce instruction is holding.

What they do show is the mirror image:

> "That old school bhangra request… **What comes through the speakers next** carries that same weight."

Written at resolve time, "next" was correct. Aired from `onTrackStarted`, the track is already playing. That one was at **queue depth 1 with nothing in between**, so it breaks even when the reported window is closed.

The one case that *did* have a track air in between was only softly stale — a mood claim ("we're leaning into low light now") that had already come true, naming no wrong track.

## Why prompt-side and not a queue-side guard

The obvious-looking fix is to stamp `linkPrev` on request pushes so the existing `shouldDropStaleLink` covers them. That guard only fires when the intro **names** the wrong predecessor (`mentionsTrack`), so it **would not have caught either real example** — both are stale by tense/mood, not by name. It'd be a safety net for a case that isn't occurring, at the cost of touching the queue path. Left out deliberately; easy to add later if a named-predecessor case ever shows up.

## The change

`AIR_TIME_CLAUSE` lives next to `generateIntro` and is re-exported through the `dj` barrel so `requestSystem` shares the wording verbatim rather than drifting. `requestSystem` also now states that the currently-playing track is there **only** to interpret asks like "something like this" — not to mention.

It deliberately carries **no example opening phrasings**. A first draft offered a few ("this is…", "that's us into…") and a live run put the *same* opener on three consecutive intros — the model reads a menu as a template, and it fights the existing `ANGLES` + opener-blocklist variety machinery. There's a regression pin for this in the test.

Blast radius is request intros only: `generateIntro` is called just from `routes/request.ts`. Auto-DJ links are untouched.

## Verification

Live dev stack, driven into the exact reported failure window — request queued behind another track, with a different track airing in between:

```
22:20:24      playing   | Focus (feat. Ikath) — Talwiinder    <- intervening track
22:22:01.722  playing   | Big Bad City — Panjabi MC           <- the requested track
22:22:01.724  dj-speak  | Panjabi MC, "Big Bad City." That bassline doesn't ask permission…
```

Intro fired 2ms after the requested track started, present-tense, referencing nothing stale.

Six request intros generated end to end (positions 2-3, i.e. bug window open): zero future-tense hits, none referencing the current or intervening track, openers varied after the clause was revised.

- `npm run lint` (controller) — 0 errors
- `scripts/request-intro-airtime.test.ts` (new) — pins the clause's load-bearing content and the no-example-openers regression
- `stale-link`, `request-dedup`, `test:llm` — still pass

## Noticed in passing, not fixed here

1. **A possibly-dropped request.** In `sess_7e7b4dac` a resolved request (trackId `ycrfUCjY4iIP2pNS2CMzMJ`) rendered an intro but appears never to have aired, with a *later* request airing ahead of it — which would contradict FIFO `push()`. Inferred from session-archive timestamps, not confirmed. Worth its own look; a silently dropped request is worse than a stale intro.
2. **Stale docs.** `CLAUDE.md` says request-intro TTS "is written ~250ms before the track URI so Liquidsoap picks up the voice file first." That describes pre-#189 behaviour; `drainToLiquidsoap` now renders the WAV without airing it.
3. **Request traffic is near-zero** — 6 requests in the whole log corpus, 4 from a bench harness, and 0 of 470 entries in `recent-plays.json` sourced from a request. Worth knowing when weighing how much this path matters.
