### PR TITLE
feat(tts): discover cloud TTS voices instead of typing ids blind

### DIFF
--- a/controller/scripts/voice-catalog.test.ts
+++ b/controller/scripts/voice-catalog.test.ts
@@ -1,0 +1,206 @@
+// Unit tests for the cloud TTS voice-list normalizer
+// (llm/internal/speech/voice-catalog.ts). `/v1/audio/voices` isn't in the
+// OpenAI spec, so every self-hosted TTS server returns a different shape —
+// these pins cover the four seen in the wild (bare array, {voices}, {data},
+// ElevenLabs objects) plus the junk-in-empty-out contract that keeps a
+// malformed response from ever reaching the admin UI.
+// Run: `npm test -- voice-catalog` (tsx scripts/voice-catalog.test.ts).
+
+import assert from 'node:assert/strict';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { listVoices, normalizeVoiceList } from '../src/llm/internal/speech/voice-catalog.js';
+
+// Spin a throwaway HTTP server that answers only the paths in `routes`, so the
+// probe order and fallback behaviour can be pinned without a real TTS server.
+// Records every path it was asked for.
+async function withServer(
+  routes: Record<string, unknown>,
+  fn: (baseUrl: string, seen: string[], authSeen: (string | undefined)[]) => Promise<void>,
+) {
+  const seen: string[] = [];
+  const authSeen: (string | undefined)[] = [];
+  const server: Server = createServer((req, res) => {
+    seen.push(req.url || '');
+    authSeen.push(req.headers.authorization);
+    const body = routes[req.url || ''];
+    if (body === undefined) {
+      res.writeHead(404).end('not found');
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'application/json' }).end(JSON.stringify(body));
+  });
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  try {
+    await fn(`http://127.0.0.1:${port}/v1`, seen, authSeen);
+  } finally {
+    await new Promise<void>(resolve => { server.close(() => resolve()); });
+  }
+}
+
+let failures = 0;
+function test(name: string, fn: () => void | Promise<void>) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => console.log(`  ✓ ${name}`))
+    .catch((err) => { failures++; console.error(`  ✗ ${name}\n      ${err?.message || err}`); });
+}
+
+async function main() {
+  console.log('payload shapes:');
+  await test('bare array of ids (generic compat server)', () => {
+    assert.deepEqual(normalizeVoiceList(['alloy', 'nova']), [
+      { id: 'alloy', label: 'Alloy' },
+      { id: 'nova', label: 'Nova' },
+    ]);
+  });
+  await test('{voices: [...]} of ids (Kokoro-FastAPI, openedai-speech)', () => {
+    assert.deepEqual(normalizeVoiceList({ voices: ['af_alloy', 'bm_george'] }), [
+      { id: 'af_alloy', label: 'Af Alloy' },
+      { id: 'bm_george', label: 'Bm George' },
+    ]);
+  });
+  await test('{data: [{id}]} (servers mimicking /v1/models)', () => {
+    assert.deepEqual(normalizeVoiceList({ data: [{ id: 'speaker-1' }, { id: 'speaker-2' }] }), [
+      { id: 'speaker-1', label: 'Speaker 1' },
+      { id: 'speaker-2', label: 'Speaker 2' },
+    ]);
+  });
+  await test('ElevenLabs objects: voice_id -> id, name -> label, category -> hint', () => {
+    assert.deepEqual(
+      normalizeVoiceList({
+        voices: [
+          { voice_id: '21m00Tcm4TlvDq8ikWAM', name: 'Rachel', category: 'premade' },
+          { voice_id: 'zzz111', name: 'My Clone', category: 'cloned' },
+        ],
+      }),
+      [
+        { id: '21m00Tcm4TlvDq8ikWAM', label: 'Rachel', hint: 'premade' },
+        { id: 'zzz111', label: 'My Clone', hint: 'cloned' },
+      ],
+    );
+  });
+  await test('objects with only a name use it as both id and label', () => {
+    assert.deepEqual(normalizeVoiceList([{ name: 'Giovanni' }]), [{ id: 'Giovanni', label: 'Giovanni' }]);
+  });
+
+  console.log('labelling:');
+  await test('opaque ids are left alone, not title-cased into noise', () => {
+    assert.deepEqual(normalizeVoiceList(['21m00Tcm4TlvDq8ikWAM']), [
+      { id: '21m00Tcm4TlvDq8ikWAM', label: '21m00Tcm4TlvDq8ikWAM' },
+    ]);
+  });
+  await test('an explicit label always beats the derived one', () => {
+    assert.deepEqual(normalizeVoiceList([{ id: 'af_alloy', label: 'Alloy (US female)' }]), [
+      { id: 'af_alloy', label: 'Alloy (US female)' },
+    ]);
+  });
+
+  console.log('junk in, empty out:');
+  await test('null / undefined / scalar / object payloads yield []', () => {
+    for (const junk of [null, undefined, 42, 'nope', {}, { voices: 'nope' }]) {
+      assert.deepEqual(normalizeVoiceList(junk), [], `payload ${JSON.stringify(junk)} must yield []`);
+    }
+  });
+  await test('entries with no usable id are dropped, survivors kept', () => {
+    assert.deepEqual(normalizeVoiceList([{}, '', '   ', { id: '' }, 'alloy']), [
+      { id: 'alloy', label: 'Alloy' },
+    ]);
+  });
+
+  console.log('guardrails:');
+  await test('duplicate ids are deduped, first wins', () => {
+    assert.deepEqual(normalizeVoiceList([{ id: 'a', name: 'First' }, { id: 'a', name: 'Second' }]), [
+      { id: 'a', label: 'First' },
+    ]);
+  });
+  await test('ids over 100 chars are dropped (normalizeTts would truncate them)', () => {
+    const atLimit = 'x'.repeat(100);
+    const tooLong = 'x'.repeat(101);
+    const kept = normalizeVoiceList([tooLong, atLimit]);
+    assert.equal(kept.length, 1, 'the 101-char id must be dropped');
+    assert.equal(kept[0].id, atLimit);
+  });
+  await test('list is capped at 500 entries', () => {
+    const huge = Array.from({ length: 600 }, (_, i) => `voice${i}`);
+    assert.equal(normalizeVoiceList(huge).length, 500);
+  });
+  await test('hints are truncated to 80 chars', () => {
+    const [v] = normalizeVoiceList([{ id: 'a', description: 'd'.repeat(200) }]);
+    assert.equal(v.hint?.length, 80);
+  });
+
+  console.log('compat probing:');
+  await test('finds /audio/voices on the first try, probes nothing else', async () => {
+    await withServer({ '/v1/audio/voices': { voices: ['alloy'] } }, async (baseUrl, seen) => {
+      const r = await listVoices({ provider: 'openai-compatible', baseUrl });
+      assert.equal(r.ok, true);
+      assert.deepEqual(r.voices, [{ id: 'alloy', label: 'Alloy' }]);
+      assert.deepEqual(seen, ['/v1/audio/voices'], 'must stop at the first hit');
+    });
+  });
+  await test('falls through 404s to a later path', async () => {
+    await withServer({ '/v1/audio/speech/voices': ['nova'] }, async (baseUrl, seen) => {
+      const r = await listVoices({ provider: 'openai-compatible', baseUrl });
+      assert.equal(r.ok, true);
+      assert.deepEqual(r.voices, [{ id: 'nova', label: 'Nova' }]);
+      assert.deepEqual(seen, ['/v1/audio/voices', '/v1/voices', '/v1/audio/speech/voices']);
+    });
+  });
+  await test('a 200 with no voices keeps probing rather than declaring success', async () => {
+    await withServer({ '/v1/audio/voices': { voices: [] }, '/v1/voices': ['echo'] }, async (baseUrl, seen) => {
+      const r = await listVoices({ provider: 'openai-compatible', baseUrl });
+      assert.equal(r.ok, true);
+      assert.deepEqual(r.voices, [{ id: 'echo', label: 'Echo' }]);
+      assert.deepEqual(seen, ['/v1/audio/voices', '/v1/voices']);
+    });
+  });
+  await test('all paths 404 -> ok:false, empty list, no throw', async () => {
+    await withServer({}, async (baseUrl, seen) => {
+      const r = await listVoices({ provider: 'openai-compatible', baseUrl });
+      assert.equal(r.ok, false);
+      assert.deepEqual(r.voices, []);
+      assert.ok(r.error, 'an error message must be reported');
+      assert.equal(seen.length, 3, 'all three paths tried');
+    });
+  });
+  await test('a configured key rides along as a Bearer header', async () => {
+    await withServer({ '/v1/audio/voices': ['alloy'] }, async (baseUrl, _seen, authSeen) => {
+      await listVoices({ provider: 'openai-compatible', baseUrl, apiKey: 'sk-test' });
+      assert.deepEqual(authSeen, ['Bearer sk-test']);
+    });
+  });
+  await test('no key configured means no Authorization header at all', async () => {
+    await withServer({ '/v1/audio/voices': ['alloy'] }, async (baseUrl, _seen, authSeen) => {
+      await listVoices({ provider: 'openai-compatible', baseUrl });
+      assert.deepEqual(authSeen, [undefined]);
+    });
+  });
+
+  console.log('guard rails on the fetch path:');
+  await test('missing baseUrl is refused before any request', async () => {
+    const r = await listVoices({ provider: 'openai-compatible', baseUrl: '' });
+    assert.equal(r.ok, false);
+    assert.match(r.error || '', /baseUrl is required/);
+  });
+  await test('a non-HTTP scheme is refused (hand-edited settings.json)', async () => {
+    const r = await listVoices({ provider: 'openai-compatible', baseUrl: 'file:///etc/passwd' });
+    assert.equal(r.ok, false);
+    assert.match(r.error || '', /http/);
+  });
+  await test('elevenlabs without a key never hits the network', async () => {
+    const r = await listVoices({ provider: 'elevenlabs' });
+    assert.equal(r.ok, false);
+    assert.match(r.error || '', /key/i);
+  });
+  await test('openai reports that it has nothing to discover', async () => {
+    const r = await listVoices({ provider: 'openai', apiKey: 'sk-test' });
+    assert.equal(r.ok, false);
+    assert.deepEqual(r.voices, []);
+  });
+
+  process.exit(failures ? 1 : 0);
+}
+
+main();

--- a/controller/src/llm/internal/speech/voice-catalog.ts
+++ b/controller/src/llm/internal/speech/voice-catalog.ts
@@ -1,0 +1,233 @@
+// Voice-list discovery for the cloud TTS engine.
+//
+// `GET /v1/audio/voices` is NOT part of the OpenAI spec — it's a convention
+// self-hosted TTS servers converged on (Fish, Echo-TTS, Omnivoice, Kokoro-
+// FastAPI, openedai-speech, …), and each one invented its own path and payload
+// shape. So discovery is best-effort: probe a few known paths, accept every
+// response shape seen in the wild, and give up quietly. A station whose server
+// answers none of them is exactly where it was before — a free-text voice box.
+//
+// ElevenLabs is the other discoverable provider: it has a real voice-list API,
+// and it's the one that matters most, since an operator's *cloned* voices can
+// never appear in a hardcoded list.
+//
+// OpenAI is deliberately absent — it publishes no voice-list endpoint, and its
+// voice set is fixed, so the curated list in web/lib/cloudVoices.ts is correct
+// by construction.
+
+import { fetchWithTimeout } from '../../../util/fetch-timeout.js';
+
+export type CloudVoice = { id: string; label: string; hint?: string };
+
+export type VoiceListResult = {
+  ok: boolean;
+  voices: CloudVoice[];
+  error?: string;
+};
+
+// Persona voice ids are capped at 100 chars by normalizeTts() in settings.ts.
+// Offering a voice we could never persist would be a trap, so drop them here.
+const MAX_ID_LEN = 100;
+const MAX_VOICES = 500;
+const MAX_HINT_LEN = 80;
+
+// Probed in order; first response that yields >=1 voice wins.
+const COMPAT_PATHS = ['/audio/voices', '/voices', '/audio/speech/voices'];
+
+// Compat probing walks up to three paths, so each leg gets a short leash and
+// the whole probe is capped. A managed provider is one request against a known
+// endpoint, so it gets the same 10s budget /settings/llm/models allows —
+// establishing the connection can intermittently stall for several seconds,
+// and timing out there would drop the operator back to the curated list for
+// no good reason.
+const PER_ATTEMPT_MS = 3000;
+const TOTAL_MS = 8000;
+const MANAGED_MS = 10_000;
+
+const ID_KEYS = ['id', 'voice_id', 'voiceId', 'name', 'voice'];
+const LABEL_KEYS = ['name', 'label', 'display_name', 'displayName', 'title'];
+const HINT_KEYS = ['category', 'gender', 'language', 'description'];
+
+function pickString(o: Record<string, unknown>, keys: string[]): string {
+  for (const k of keys) {
+    const v = o[k];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return '';
+}
+
+// 'af_alloy' -> 'Af Alloy', 'alloy' -> 'Alloy'. An opaque id (an ElevenLabs
+// voice_id, a hash) is left alone — title-casing it only makes it noisier.
+function labelFor(id: string): string {
+  if (/[_-]/.test(id)) {
+    return id
+      .split(/[_-]+/)
+      .filter(Boolean)
+      .map((w) => w[0].toUpperCase() + w.slice(1))
+      .join(' ');
+  }
+  if (/^[a-z]+$/.test(id)) return id[0].toUpperCase() + id.slice(1);
+  return id;
+}
+
+// Unwrap the common envelopes: {voices: [...]} (Kokoro, openedai-speech),
+// {data: [...]} (servers mimicking /v1/models). Depth-limited so a
+// self-referential or pathological payload can't spin.
+function unwrap(payload: unknown): unknown {
+  let cur = payload;
+  for (let depth = 0; depth < 3; depth++) {
+    if (Array.isArray(cur)) return cur;
+    if (!cur || typeof cur !== 'object') return cur;
+    const o = cur as Record<string, unknown>;
+    const next = o.voices ?? o.data;
+    if (next === undefined) return cur;
+    cur = next;
+  }
+  return cur;
+}
+
+/**
+ * Coerce any of the payload shapes seen in the wild into a clean voice list.
+ * Pure — no I/O. Never throws; junk in yields an empty list out.
+ *
+ * Accepted:
+ *   ["alloy", "nova"]                        bare array of ids
+ *   {"voices": ["af_alloy", ...]}            Kokoro-FastAPI, openedai-speech
+ *   {"data": [{"id": "x"}, ...]}             /v1/models mimics
+ *   [{"voice_id": "x", "name": "Rachel"}]    ElevenLabs
+ */
+export function normalizeVoiceList(payload: unknown): CloudVoice[] {
+  const list = unwrap(payload);
+  if (!Array.isArray(list)) return [];
+
+  const out: CloudVoice[] = [];
+  const seen = new Set<string>();
+
+  for (const item of list) {
+    let id = '';
+    let label = '';
+    let hint = '';
+
+    if (typeof item === 'string') {
+      id = item.trim();
+    } else if (item && typeof item === 'object') {
+      const o = item as Record<string, unknown>;
+      id = pickString(o, ID_KEYS);
+      label = pickString(o, LABEL_KEYS);
+      hint = pickString(o, HINT_KEYS);
+    }
+
+    if (!id || id.length > MAX_ID_LEN) continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+
+    const voice: CloudVoice = { id, label: label || labelFor(id) };
+    if (hint) voice.hint = hint.slice(0, MAX_HINT_LEN);
+    out.push(voice);
+
+    if (out.length >= MAX_VOICES) break;
+  }
+
+  return out;
+}
+
+function briefError(err: unknown): string {
+  if (err instanceof Error) {
+    if (err.name === 'AbortError' || err.name === 'TimeoutError') return 'Timed out';
+    return err.message;
+  }
+  return 'Discovery failed';
+}
+
+// `bodyDeadline` keeps the deadline armed over the JSON read, not just the
+// headers — a server that dribbles a response would otherwise fall through to
+// undici's ~300s default and hang the probe.
+async function fetchVoices(
+  url: string,
+  headers: Record<string, string>,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<CloudVoice[]> {
+  const r = await fetchWithTimeout(url, { headers, timeoutMs, bodyDeadline: true, signal });
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  return normalizeVoiceList(await r.json());
+}
+
+/**
+ * Discover the voices a cloud TTS provider offers.
+ *
+ * Never throws — always resolves to {ok, voices, error?}, matching the
+ * contract of GET /settings/llm/models so the UI has one code path.
+ */
+export async function listVoices(opts: {
+  provider: string;
+  baseUrl?: string;
+  apiKey?: string;
+  signal?: AbortSignal;
+}): Promise<VoiceListResult> {
+  const { provider, signal } = opts;
+  const apiKey = (opts.apiKey || '').trim();
+
+  if (provider === 'elevenlabs') {
+    if (!apiKey) return { ok: false, voices: [], error: 'ElevenLabs API key not set' };
+    try {
+      const voices = await fetchVoices(
+        'https://api.elevenlabs.io/v1/voices',
+        { 'xi-api-key': apiKey },
+        MANAGED_MS,
+        signal,
+      );
+      return { ok: true, voices };
+    } catch (err) {
+      return { ok: false, voices: [], error: briefError(err) };
+    }
+  }
+
+  if (provider !== 'openai-compatible') {
+    // openai has no list endpoint; anything else isn't a cloud TTS provider.
+    return { ok: false, voices: [], error: `${provider || 'provider'} does not support voice discovery` };
+  }
+
+  const baseUrl = (opts.baseUrl || '').trim().replace(/\/+$/, '');
+  if (!baseUrl) return { ok: false, voices: [], error: 'baseUrl is required for openai-compatible' };
+  // settings.update() already enforces this on the write path (settings.ts),
+  // but load() coerces leniently, so a hand-edited settings.json could still
+  // point us at a non-HTTP scheme. Cheap belt-and-braces before we fetch it.
+  if (!/^https?:\/\//i.test(baseUrl)) {
+    return { ok: false, voices: [], error: 'baseUrl must start with http:// or https://' };
+  }
+
+  // Most local servers accept any key, and many need none — send one only if
+  // the operator configured it (mirrors the /v1/models probe in routes/settings).
+  const headers: Record<string, string> = {};
+  if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
+
+  const deadline = Date.now() + TOTAL_MS;
+  let lastError = 'No voice endpoint found';
+
+  for (const path of COMPAT_PATHS) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      lastError = 'Timed out';
+      break;
+    }
+    try {
+      const voices = await fetchVoices(
+        `${baseUrl}${path}`,
+        headers,
+        Math.min(PER_ATTEMPT_MS, remaining),
+        signal,
+      );
+      // A 200 that parses to nothing means "wrong endpoint, right server" as
+      // often as "no voices" — keep probing, but remember it wasn't an error.
+      if (voices.length) return { ok: true, voices };
+      lastError = 'Server returned no voices';
+    } catch (err) {
+      lastError = briefError(err);
+      // A caller-side abort is terminal — don't burn the remaining paths on it.
+      if (signal?.aborted) break;
+    }
+  }
+
+  return { ok: false, voices: [], error: lastError };
+}

--- a/controller/src/llm/speech.ts
+++ b/controller/src/llm/speech.ts
@@ -3,3 +3,5 @@
 // Barrel so call sites keep importing from `llm/speech.js` unchanged.
 
 export { speak, isConfigured } from './internal/speech/cloud-speech.js';
+export { listVoices, normalizeVoiceList } from './internal/speech/voice-catalog.js';
+export type { CloudVoice, VoiceListResult } from './internal/speech/voice-catalog.js';

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -13,6 +13,7 @@ import * as remoteTts from '../audio/remoteTts.js';
 import * as chatterbox from '../audio/chatterbox.js';
 import * as piper from '../audio/piper.js';
 import * as llmProvider from '../llm/provider.js';
+import * as speech from '../llm/speech.js';
 import { probeEmbeddingConfig } from '../music/embeddings.js';
 import { queue } from '../broadcast/queue.js';
 import { restartLiquidsoap, startStream, stopStream, streamStatus } from '../broadcast/liquidsoap-control.js';
@@ -507,6 +508,65 @@ router.post('/settings/tts/preview', requireAdmin, async (req, res) => {
     res.status(422).json({ ok: false, message: (err as { message?: string })?.message || 'Preview synthesis failed' });
   } finally {
     if (filePath) unlink(filePath).catch(() => {});
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /settings/tts/voices — discover the voices a cloud TTS provider offers,
+// so persona + station-default voice fields can be a dropdown instead of a
+// free-text box the operator fills from memory. The TTS twin of
+// /settings/llm/models.
+//
+// Two discoverable providers: `openai-compatible` (probes a few conventional
+// paths on the operator's own server — /v1/audio/voices isn't in the OpenAI
+// spec, so there's no single right answer) and `elevenlabs` (a real API, and
+// the one that matters most since cloned voices can never be hardcoded).
+// `openai` publishes no list endpoint; its curated UI list is already complete.
+//
+// `baseUrl` rides in on the query so the operator can discover against a URL
+// they've typed but not yet saved — same affordance the model dropdown gives.
+// The API key deliberately does NOT: it's read from saved config, so it can't
+// leak into access logs or browser history. ElevenLabs discovery therefore
+// only works once the key is saved, which the UI gates on.
+//
+// Always 200s with { ok, voices, provider, error? } — an unreachable server is
+// a normal answer, and the UI falls back to the free-text input.
+// ---------------------------------------------------------------------------
+router.get('/settings/tts/voices', requireAdmin, async (req, res) => {
+  const provider = String(req.query.provider || '').trim();
+  if (!provider) {
+    return res.json({ ok: false, voices: [], provider: '', error: 'provider is required' });
+  }
+  const baseUrl = String(req.query.baseUrl || '').trim();
+  await settings.load();
+  const cloud = settings.get().tts?.cloud || {};
+
+  // Same precedence as cloud-speech.isConfigured(): a key typed into Settings
+  // counts only for the provider it was entered against, otherwise fall back
+  // to that provider's env var from state/secrets.env.
+  const envKey = provider === 'elevenlabs'
+    ? process.env.ELEVENLABS_API_KEY
+    : process.env.OPENAI_API_KEY;
+  const settingsKey = provider === cloud.provider ? cloud.apiKey : '';
+  const apiKey = (settingsKey || envKey || '').trim();
+
+  // Backstop only — listVoices runs its own per-provider budget (10s managed,
+  // 8s across the compat probe). Sits above both so the inner deadline is what
+  // actually fires and the caller gets a real reason instead of a bare abort.
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 15_000);
+  try {
+    const result = await speech.listVoices({
+      provider,
+      // Fall back to the saved baseUrl so a persona card can discover without
+      // re-sending the station-wide server URL.
+      baseUrl: baseUrl || cloud.baseUrl || '',
+      apiKey,
+      signal: ctrl.signal,
+    });
+    res.json({ ...result, provider });
+  } finally {
+    clearTimeout(timer);
   }
 });
 

--- a/docs/superpowers/specs/2026-07-18-cloud-tts-voice-discovery-design.md
+++ b/docs/superpowers/specs/2026-07-18-cloud-tts-voice-discovery-design.md
@@ -1,0 +1,261 @@
+# Cloud TTS voice discovery
+
+Pull the available voice list from a cloud TTS engine and offer it as a dropdown
+when picking a persona's voice, instead of making the operator paste an opaque
+voice id into a free-text box.
+
+Origin: Discord suggestion from K8-Bit [SBL] — *"it would be good if it was
+possible to pull the available voices from an OpenAI cloud/local TTS engine to
+be able to select in drop-down for the personas. Highly variable, but e.g. on
+the docker deployments I made, they mostly respond to `curl
+http://ip:port/v1/audio/voices` (for Fish, Echo-TTS and Omnivoice anyway)."*
+
+## Background: what already exists
+
+Most of the plumbing is in place. SUB/WAVE's `cloud` TTS engine already supports
+three providers (`TTS_CLOUD_PROVIDERS`, `settings.ts:509`): `openai`,
+`elevenlabs`, `openai-compatible`. The compat provider already has a
+`settings.tts.cloud.baseUrl` (`settings.ts:1176`, documented as needing the
+`/v1` suffix) and is constructed with `createOpenAI({ baseURL, apiKey: apiKey ||
+'unused' })` at `cloud-speech.ts:162-166`.
+
+Critically, **model discovery against a compat server already works**:
+`GET /settings/llm/models` (`routes/settings.ts:608-798`) fetches
+`${baseUrl}/models` and the cloud-TTS section is already wired to it —
+`TtsSection.tsx:312-322` calls `useModelDiscovery` with
+`provider: 'openai-compatible'`. So an operator running Fish or Kokoro already
+gets a model dropdown.
+
+What is missing is the voice half. Today, when the provider is
+`openai-compatible`, the voice is a bare text input in both places it can be
+set:
+
+- station-wide default — `TtsSection.tsx:874-893`, placeholder
+  `"Server-specific (cloning ref or speaker id)"`
+- per persona — `PersonaVoiceCard.tsx:376-388`, same treatment
+
+For `openai` and `elevenlabs` the UI shows a curated hardcoded list
+(`web/lib/cloudVoices.ts` → `CLOUD_VOICES`) plus a `__custom__` free-text
+escape hatch. That list is nine stock ElevenLabs voices — it cannot know about
+an operator's own cloned voices, so ElevenLabs users are pasting raw
+`voice_id`s by hand too.
+
+There is no voice list anywhere in the controller. Cloud voice curation is
+entirely client-side.
+
+## Approaches considered
+
+**A. Mirror the model-discovery route (chosen).** Add
+`GET /settings/tts/voices`, a near-copy of the existing `/settings/llm/models`
+route, plus a `useVoiceDiscovery` hook copied from `useModelDiscovery.ts`, and
+feed the result into the existing `VoicePicker` component. Fits the established
+pattern exactly, reuses a component that already supports grouped options and
+per-row audition, and degrades to today's behaviour when discovery fails.
+
+**B. Client-side fetch straight from the browser.** The admin page would call
+the compat server directly. Rejected: the TTS server is typically on the
+operator's LAN and the admin UI may be reached over the internet through Caddy,
+so the browser often cannot reach it; it would also need CORS on every
+third-party TTS server, which none of them set.
+
+**C. Cache a voice list into `settings.json` at save time.** Discover once when
+the operator saves the TTS config and persist it. Rejected: adds a stale-cache
+failure mode and a settings-schema migration for something that costs one cheap
+fetch on demand. Discovery is a UI affordance, not station state.
+
+## Design
+
+### 1. Voice catalog module (the isolated unit)
+
+New file `controller/src/llm/internal/speech/voice-catalog.ts`, exported through
+the existing barrel `controller/src/llm/speech.ts` (which today re-exports only
+`{ speak, isConfigured }`). Call sites import the barrel — never `internal/`,
+per CLAUDE.md.
+
+Two exports:
+
+```ts
+export type CloudVoice = { id: string; label: string; hint?: string };
+
+// Pure. No I/O. The unit-test seam.
+export function normalizeVoiceList(payload: unknown): CloudVoice[];
+
+// Network. Never throws; returns { ok, voices, error? }.
+export function listVoices(opts: {
+  provider: 'openai-compatible' | 'elevenlabs';
+  baseUrl?: string;
+  apiKey?: string;
+  signal?: AbortSignal;
+}): Promise<{ ok: boolean; voices: CloudVoice[]; error?: string }>;
+```
+
+**`normalizeVoiceList` accepts the shapes the ecosystem actually returns**, since
+`/v1/audio/voices` is not in the OpenAI spec and every server invented its own:
+
+| Payload | Source style |
+|---|---|
+| `["alloy","nova"]` | bare array |
+| `{"voices":["af_alloy",…]}` | Kokoro-FastAPI, openedai-speech |
+| `{"data":[{"id":"x"},…]}` | servers mimicking `/v1/models` |
+| `[{"voice_id":"x","name":"Rachel"}]` | ElevenLabs style |
+
+Rules: unwrap `.voices` or `.data` if the payload is an object; for each item,
+id comes from the string itself or the first present of
+`id | voice_id | name | voice`, label from the first present of
+`name | label | display_name` falling back to a title-cased id; drop entries
+with a blank id; dedupe by id keeping the first; **discard ids longer than 100
+chars** (`normalizeTts` caps persona voice at 100 chars, `settings.ts:1564` — a
+voice we cannot save must not be offered); cap the list at 500 entries.
+
+**`listVoices` probing**, for `openai-compatible`, in order, stopping at the
+first response that parses to at least one voice:
+
+```
+GET {baseUrl}/audio/voices        ← try first
+GET {baseUrl}/voices              ← on non-200 or unparseable
+GET {baseUrl}/audio/speech/voices
+```
+
+Sends `Authorization: Bearer ${apiKey}` only when a key is configured, matching
+`routes/settings.ts:647-650`. Per-attempt timeout ~3s via `AbortSignal.timeout`,
+whole-call budget 8s, mirroring the models route's 10s.
+
+For `elevenlabs`: a single `GET https://api.elevenlabs.io/v1/voices` with the
+`xi-api-key` header — the pattern already used for key validation at
+`routes/settings.ts:348-350`. Maps `voice_id` → id, `name` → label,
+`category` (`premade` / `cloned` / `generated`) → hint.
+
+`openai` is not discoverable — OpenAI publishes no voice-list endpoint. It keeps
+the curated `CLOUD_VOICES.openai` list unchanged.
+
+### 2. Route
+
+`GET /settings/tts/voices?provider=<p>&baseUrl=<u>` in
+`controller/src/routes/settings.ts`, behind the existing `requireAdmin` gate
+like every other settings route.
+
+Always responds 200 with `{ ok, voices, provider, error? }` — same
+never-throw contract as `/settings/llm/models`, so the UI has one code path.
+
+**The API key is never accepted as a query parameter.** It is read from the
+persisted config (`settings.tts.cloud.apiKey`, or `ELEVENLABS_API_KEY` from
+`state/secrets.env`) so it cannot leak into access logs or browser history.
+Consequence: ElevenLabs discovery works only after the key is saved. The UI
+already computes that condition — `ttsKeySet` in `TtsSection.tsx:406-411` —
+and gates the control on it.
+
+`baseUrl` comes from the query rather than settings so the operator can discover
+against a URL they have typed but not yet saved, which is the same affordance
+the model dropdown gives them.
+
+**Hardening (in scope, small):** `settings.tts.cloud.baseUrl` is currently only
+trimmed on load (`settings.ts:2059-2062`) with no shape check, unlike
+`llm.baseUrl` which enforces an `http(s)://` prefix and a 200-char cap
+(`settings.ts:424-431`). Since this feature makes the controller fetch that URL
+on demand, apply the same validation to `tts.cloud.baseUrl`. This adds no new
+capability — the controller already POSTs synthesis requests to that exact URL —
+but it closes the sloppiest input path into a server-side fetch.
+
+### 3. Web hook
+
+New `web/hooks/useVoiceDiscovery.ts`, modeled directly on
+`useModelDiscovery.ts` (92 lines): 400ms debounce, monotonic `reqIdRef` to drop
+stale responses, `AbortController` on unmount, returns
+`{ voices, loading, error, refresh }`.
+
+**Fetch once, not once per persona.** `PersonaVoiceCard` renders per persona, so
+a hook instance inside it would fire N identical requests. Because persona
+overrides only carry `{ provider, voice }` and `baseUrl` is always read from the
+global config (`cloud-speech.ts:231-234`), there are at most two distinct lists
+station-wide. So the parent that already owns the `SettingsResponse` (
+`PersonaEditor` / the personas page) owns the hook(s) and passes
+`cloudVoices: Partial<Record<CloudProvider, CloudVoice[]>>` down as a prop.
+Lists are fetched lazily — only for providers actually selected by the station
+default or by some persona.
+
+### 4. UI
+
+Both call sites switch from "free text for compat, curated Select otherwise" to
+a `VoicePicker` fed by grouped options. `VoicePicker` already takes
+`groups: VoicePickerGroup[]` and already auditions each row through
+`POST /settings/tts/preview`, so discovered voices become playable with no
+change to that component.
+
+- **`openai-compatible`** — `[{label:'Discovered', voices}, {label:'Custom',
+  voices:[__custom__]}]`. With zero discovered voices, the picker is skipped
+  entirely and today's free-text input renders unchanged.
+- **`elevenlabs`** — `[{label:'Your voices', voices: discovered}, {label:
+  'Presets', voices: curated.filter(c => !discovered.some(d => d.id === c.id))},
+  {label:'Custom', …}]`. Discovered wins on id collision because it carries the
+  operator's own name for the voice.
+- **`openai`** — unchanged.
+
+Touch points: `PersonaVoiceCard.tsx:338-432` (cloud branch) and
+`TtsSection.tsx:868-946` (station default voice).
+
+`GET /settings` is **not** changed. Discovery is a separate on-demand route, so
+the fat settings payload does not grow and `SettingsResponse['tts']`
+(`web/components/admin/personas/types.ts:88-107`) is untouched. A voice list is
+fetched only when an operator is actually looking at a cloud voice field.
+
+## Edge cases and regressions to guard
+
+1. **Voice-reset handlers will clobber a discovered voice.** `selectEngine`
+   (`PersonaVoiceCard.tsx:56-74`) resets voice to `CLOUD_VOICES[provider][0].id`
+   when the current value is not a curated preset, and `selectCloudProvider`
+   (`TtsSection.tsx:414-424`) does the same. Both "is this a known voice" checks
+   must be widened to include discovered ids, or switching engine back and forth
+   silently destroys a valid selection.
+2. **Discovery must never block saving.** The `__custom__` free-text path stays
+   in every branch. A server that returns nothing, errors, times out, or is
+   unreachable leaves the operator exactly where they are today.
+3. **Compat personas may legitimately have an empty voice.** `settings.ts:1595`
+   deliberately does not fill a default for `openai-compatible` (the server
+   picks). The picker must treat empty as valid, not coerce to the first
+   discovered entry.
+4. **ElevenLabs auditions cost credits.** Per-row preview already behaves this
+   way for the nine curated voices, so this is not new, but a discovered list can
+   be long — do not auto-preview, keep it click-to-play as it is now.
+5. **`hint` is display-only.** Never persist it; only the id round-trips into
+   settings.
+
+## Out of scope
+
+- `availableEngines().cloudByProvider` omits `openai-compatible`
+  (`tts.ts:438-441`), which the UI works around by hardcoding `cloud: true` at
+  `PersonaVoiceCard.tsx:86-88`. Adjacent, pre-existing, not required here.
+- Voice discovery for local engines (piper/kokoro/chatterbox/pocket-tts). Those
+  already enumerate from the filesystem via `chatterbox.listReferenceVoices()`
+  and `piper.listPiperVoices()`.
+- Any change to how synthesis itself works. This is a picker feature only.
+
+## Testing
+
+- **Pure**: new `controller/scripts/voice-catalog.test.ts` covering all four
+  payload shapes above plus junk (`null`, `{}`, `[{}]`, an id over 100 chars,
+  duplicate ids, a 600-entry list). `controller/scripts/run-tests.ts`
+  auto-discovers any `scripts/*.test.ts`, so `npm test` picks it up with no
+  `package.json` edit.
+- **Route**: manual probe against a live compat server; verify the 200-with-error
+  contract when `baseUrl` is unreachable and when it 404s all three paths.
+- **UI**: `/admin/personas` and `/admin/settings` with (a) a reachable compat
+  server, (b) an unreachable one — must render today's text input, (c) an
+  ElevenLabs key set. The `verify` skill covers the isolated-controller +
+  Playwright loop.
+- **Gate**: `npm run lint` in `controller/` and `web/` (eslint + `tsc --noEmit`),
+  which is the CI merge gate.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `controller/src/llm/internal/speech/voice-catalog.ts` | new — normalizer + fetch |
+| `controller/src/llm/speech.ts` | re-export `listVoices` |
+| `controller/src/routes/settings.ts` | new `GET /settings/tts/voices` |
+| `controller/src/settings.ts` | validate `tts.cloud.baseUrl` shape |
+| `controller/scripts/voice-catalog.test.ts` | new — normalizer cases |
+| `web/hooks/useVoiceDiscovery.ts` | new |
+| `web/components/admin/personas/PersonaVoiceCard.tsx` | picker for compat + merged ElevenLabs groups |
+| `web/components/admin/personas/PersonaEditor.tsx` | own the hook, pass lists down |
+| `web/components/admin/settings/TtsSection.tsx` | same for the station default |
+| `docs/` | brief note on voice discovery in the TTS docs |

--- a/docs/superpowers/specs/2026-07-18-cloud-tts-voice-discovery-design.md
+++ b/docs/superpowers/specs/2026-07-18-cloud-tts-voice-discovery-design.md
@@ -249,13 +249,58 @@ fetched only when an operator is actually looking at a cloud voice field.
 
 | File | Change |
 |---|---|
-| `controller/src/llm/internal/speech/voice-catalog.ts` | new — normalizer + fetch |
-| `controller/src/llm/speech.ts` | re-export `listVoices` |
+| `controller/src/llm/internal/speech/voice-catalog.ts` | new — normalizer + probing fetch |
+| `controller/src/llm/speech.ts` | re-export `listVoices` / `normalizeVoiceList` |
 | `controller/src/routes/settings.ts` | new `GET /settings/tts/voices` |
-| `controller/src/settings.ts` | validate `tts.cloud.baseUrl` shape |
-| `controller/scripts/voice-catalog.test.ts` | new — normalizer cases |
+| `controller/scripts/voice-catalog.test.ts` | new — 24 tests (normalizer + live probing) |
 | `web/hooks/useVoiceDiscovery.ts` | new |
+| `web/lib/cloudVoiceGroups.ts` | new — shared group/merge logic |
 | `web/components/admin/personas/PersonaVoiceCard.tsx` | picker for compat + merged ElevenLabs groups |
-| `web/components/admin/personas/PersonaEditor.tsx` | own the hook, pass lists down |
 | `web/components/admin/settings/TtsSection.tsx` | same for the station default |
-| `docs/` | brief note on voice discovery in the TTS docs |
+
+## Implementation notes — where the build diverged from this design
+
+1. **No `settings.ts` change.** The proposed `tts.cloud.baseUrl` hardening was
+   already implemented at `settings.ts:3385-3391` (200-char cap + `http(s)://`
+   prefix on the write path); the report that prompted it only described the
+   deliberately-lenient `load()` path. A scheme guard went into `listVoices`
+   instead, which also covers a hand-edited `settings.json`.
+2. **The hook lives in `PersonaVoiceCard`, not lifted to `PersonaEditor`.**
+   The spec lifted it to dodge one-fetch-per-persona, but `PersonaEditor` only
+   ever renders the single focused persona, so at most one card is mounted and
+   the concern doesn't arise. `PersonaEditor` is untouched.
+3. **`fetchWithTimeout` instead of a hand-rolled signal.** `util/fetch-timeout.ts`
+   already exists precisely to absorb the AbortController+setTimeout dance; the
+   first draft reinvented it. Uses `bodyDeadline: true` so the deadline covers
+   the JSON read.
+4. **Stale-list fix in the hook.** Discovered during UI testing: on a provider
+   switch the previous provider's voices stayed on screen — labelled as the new
+   provider's — until the new response landed, which can be seconds. An
+   ElevenLabs field offering a local server's speaker ids would save a voice
+   that provider cannot synthesize. `useVoiceDiscovery` now clears on input
+   change rather than on response.
+5. **`selectCloudProvider` blanks the voice for compat**, matching
+   `PersonaVoiceCard`. It previously carried the old provider's id (e.g.
+   `alloy`) onto a self-hosted server that has no such voice.
+6. **Timeouts:** 10s for a managed provider (matching `/settings/llm/models`),
+   8s across the whole compat probe (3s per path), 15s route backstop above
+   both so the inner deadline is what reports.
+
+## Verification status
+
+Verified end to end against an isolated controller + worktree dev server:
+normalizer and probing (24 unit tests, including a real local HTTP server for
+path fallback and auth headers); the route for both providers and every failure
+mode (unreachable, all-404, no key, no provider, 401 unauthenticated); the
+ElevenLabs API returning 30 real voices including cloned ones; and the compat
+picker rendering `DISCOVERED | Bella | George | Narrator Raw | Custom voice id…`
+in the live admin UI.
+
+**Not visually confirmed:** the ElevenLabs list rendered in the browser with real
+account data. Requests originating from the Playwright session stalled past the
+10s budget every time, while `curl` against the same route at the same moment
+answered in ~150ms — a network artifact of the test host, not a code path. The
+timeout degraded exactly as designed (falls back to the curated presets, no
+stale entries), and the grouped `YOUR VOICES` / `PRESETS` layout was observed
+rendering correctly. Worth one look on a real ElevenLabs-configured station
+before this is considered done.

--- a/web/components/admin/personas/PersonaVoiceCard.tsx
+++ b/web/components/admin/personas/PersonaVoiceCard.tsx
@@ -8,6 +8,10 @@ import type { ChangeEvent } from 'react';
 import type { Persona, PersonaTts, SettingsResponse } from './types';
 import type { AdminAuth } from '../../../lib/adminAuth';
 import { CLOUD_VOICES } from '../../../lib/cloudVoices';
+import {
+  buildCloudVoiceGroups, isKnownCloudVoice, providerSupportsDiscovery, CUSTOM_VOICE_ID,
+} from '../../../lib/cloudVoiceGroups';
+import { useVoiceDiscovery } from '../../../hooks/useVoiceDiscovery';
 import { CB_DEFAULT_VOICE, KOKORO_RE, CHATTERBOX_VOICE_RE, POCKET_TTS_VOICE_RE } from './constants';
 import { Card, Seg } from '../ui';
 import { EngineSelector } from '../tts/EngineSelector';
@@ -39,6 +43,21 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
   const pocketTtsVoices = data?.tts?.pocketTtsVoices || [];
   const cloudProviders = data?.tts?.cloudProviders || ['openai', 'elevenlabs'];
 
+  // Voices offered by this persona's cloud provider. The server falls back to
+  // the saved base URL when we don't send one, which is right here: a persona
+  // always uses the station-wide openai-compatible server. ElevenLabs is gated
+  // on a key actually being set, so we don't fire a request we know will fail.
+  const cloudProvider = persona.tts.cloudProvider;
+  const elevenLabsReady = data?.tts?.available?.cloudByProvider?.elevenlabs !== false;
+  const voiceDiscovery = useVoiceDiscovery({
+    provider: cloudProvider,
+    enabled: persona.tts.engine === 'cloud'
+      && providerSupportsDiscovery(cloudProvider)
+      && (cloudProvider !== 'elevenlabs' || elevenLabsReady),
+    adminFetch,
+  });
+  const discoveredVoices = voiceDiscovery.voices;
+
   const gain = persona.tts.gainDb ?? 0;
   const gainLabel = !gain
     ? '0 dB'
@@ -57,8 +76,11 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
     const patch: Partial<PersonaTts> = { engine: v };
     const cur = persona.tts.voice.trim();
     if (v === 'cloud') {
-      const provVoices = CLOUD_VOICES[persona.tts.cloudProvider as keyof typeof CLOUD_VOICES] || [];
-      if (!provVoices.some(pv => pv.id === cur)) {
+      // A discovered voice counts as valid too — otherwise toggling the engine
+      // away and back silently destroys a voice the operator picked from the
+      // server's own list.
+      if (!isKnownCloudVoice(cloudProvider, discoveredVoices, cur)) {
+        const provVoices = CLOUD_VOICES[cloudProvider as keyof typeof CLOUD_VOICES] || [];
         patch.voice = provVoices[0]?.id || cur;
       }
     } else if (v === 'kokoro') {
@@ -336,10 +358,13 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
           })()}
 
           {persona.tts.engine === 'cloud' && (() => {
-            const isCompat = persona.tts.cloudProvider === 'openai-compatible';
-            const provVoices = CLOUD_VOICES[persona.tts.cloudProvider as keyof typeof CLOUD_VOICES] || [];
+            const isCompat = cloudProvider === 'openai-compatible';
             const voice = persona.tts.voice.trim();
-            const isPreset = provVoices.some(v => v.id === voice);
+            const isPreset = isKnownCloudVoice(cloudProvider, discoveredVoices, voice);
+            // A compat server that advertised nothing leaves us with no list to
+            // show, so keep the plain text box it had before discovery existed.
+            const hasList = discoveredVoices.length > 0 || !isCompat;
+            const voiceGroups = buildCloudVoiceGroups(cloudProvider, discoveredVoices);
             return (
               <>
                 {cloudIssueText && (
@@ -357,8 +382,8 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
                       onChange={v => {
                         // Switching provider invalidates the old voice id.
                         // openai-compatible has no curated voices — leave the
-                        // field blank so the operator types their own (server
-                        // picks its default when blank).
+                        // field blank so the operator picks from the new
+                        // server's discovered list (or the server's default).
                         const next = v === 'openai-compatible'
                           ? ''
                           : (CLOUD_VOICES[v as keyof typeof CLOUD_VOICES]?.[0]?.id || persona.tts.voice);
@@ -373,7 +398,7 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
                   </div>
                   <div className="field">
                     <Label>Cloud voice</Label>
-                    {isCompat ? (
+                    {!hasList ? (
                       <>
                         <Input
                           value={persona.tts.voice}
@@ -382,46 +407,48 @@ export function PersonaVoiceCard({ persona, data, defaultEngine, cloudIssueText,
                           onChange={(e: ChangeEvent<HTMLInputElement>) => updateTts({ voice: e.target.value })}
                         />
                         <div className="field-hint">
-                          Server-specific: Chatterbox cloning ref name, Qwen3
-                          speaker id, etc. Leave blank to let the server pick.
+                          {voiceDiscovery.loading
+                            ? 'Checking the server for a voice list…'
+                            : <>Server-specific: Chatterbox cloning ref name, Qwen3
+                                speaker id, etc. Leave blank to let the server pick.</>}
                         </div>
                       </>
                     ) : (
                       <>
                         <VoicePicker
-                          value={isPreset ? voice : '__custom__'}
+                          value={isPreset ? voice : CUSTOM_VOICE_ID}
                           onChange={val => {
                             // "Custom voice id…" clears the preset so isPreset flips
                             // false and the free-text input below appears for entry.
-                            updateTts({ voice: val === '__custom__' ? '' : val });
+                            updateTts({ voice: val === CUSTOM_VOICE_ID ? '' : val });
                           }}
-                          groups={[{
-                            voices: [
-                              ...provVoices.map(v => ({ id: v.id, label: v.label })),
-                              // An action row, not a voice — no preview affordance.
-                              { id: '__custom__', label: 'Custom voice id…', previewVoice: null },
-                            ],
-                          }]}
+                          groups={voiceGroups}
                           title="Cloud voice"
                           preview={{
                             engine: 'cloud',
-                            cloudProvider: persona.tts.cloudProvider,
+                            cloudProvider,
                             speed: persona.tts.speed,
                             adminFetch,
                           }}
                         />
                         {!isPreset && (
                           <Input
-                            className={cn('mt-2', voice ? 'border-ink' : 'border-[var(--danger)]')}
+                            // A blank compat voice is legitimate — the server
+                            // picks its own default — so don't flag it red.
+                            className={cn('mt-2', voice || isCompat ? 'border-ink' : 'border-[var(--danger)]')}
                             value={persona.tts.voice}
                             maxLength={100}
-                            placeholder="Enter a custom voice id"
+                            placeholder={isCompat ? 'Blank = server default' : 'Enter a custom voice id'}
                             onChange={(e: ChangeEvent<HTMLInputElement>) => updateTts({ voice: e.target.value })}
                           />
                         )}
                         <div className="field-hint">
-                          Pick a default voice, or choose <em>Custom voice id…</em> to enter your own
-                          (e.g. an OpenAI voice name or an ElevenLabs voice id).
+                          {discoveredVoices.length > 0
+                            ? <>{discoveredVoices.length} voice{discoveredVoices.length === 1 ? '' : 's'} found
+                                on your {isCompat ? 'server' : 'account'}. Choose <em>Custom voice id…</em> to
+                                enter one that isn&apos;t listed.</>
+                            : <>Pick a default voice, or choose <em>Custom voice id…</em> to enter your own
+                                (e.g. an OpenAI voice name or an ElevenLabs voice id).</>}
                         </div>
                       </>
                     )}

--- a/web/components/admin/settings/TtsSection.tsx
+++ b/web/components/admin/settings/TtsSection.tsx
@@ -4,7 +4,11 @@ import type { ChangeEvent, ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 import { notify, errorMessage } from '../../../lib/notify';
 import { useModelDiscovery } from '@/hooks/useModelDiscovery';
+import { useVoiceDiscovery } from '@/hooks/useVoiceDiscovery';
 import { CLOUD_VOICES, CLOUD_MODELS } from '../../../lib/cloudVoices';
+import {
+  buildCloudVoiceGroups, isKnownCloudVoice, providerSupportsDiscovery, CUSTOM_VOICE_ID,
+} from '../../../lib/cloudVoiceGroups';
 import { Input } from '../../ui/input';
 import { Label } from '../../ui/label';
 import {
@@ -15,6 +19,7 @@ import { ScrollArea } from '../../ui/scroll-area';
 import { Trash2 } from 'lucide-react';
 import { EngineSelector } from '../tts/EngineSelector';
 import { VoicePreviewButton } from '../tts/VoicePreviewButton';
+import { VoicePicker } from '../tts/VoicePicker';
 import { ModelCombobox } from '../llm/ModelCombobox';
 import { cn } from '../../../lib/cn';
 import {
@@ -321,6 +326,17 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
     adminFetch,
   });
 
+  // Voice list from the provider itself — the compat server's /audio/voices, or
+  // the operator's ElevenLabs account (where their cloned voices live). Same
+  // readiness gate as model discovery: a URL for compat, a saved key otherwise.
+  const voiceDiscovery = useVoiceDiscovery({
+    provider: form.tts.cloud.provider,
+    baseUrl: form.tts.cloud.baseUrl,
+    enabled: ttsDiscoveryEnabled && providerSupportsDiscovery(form.tts.cloud.provider),
+    adminFetch,
+  });
+  const discoveredVoices = voiceDiscovery.voices;
+
   const saveKey = async (envVar: string, value: string): Promise<boolean> => {
     if (!value.trim()) return true;
     try {
@@ -413,9 +429,15 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
 
   const selectCloudProvider = (f: FormState, provider: string): FormState => {
     const provVoices = CLOUD_VOICES[provider as keyof typeof CLOUD_VOICES] || [];
-    const voice = provVoices.some(pv => pv.id === f.tts.cloud.voice.trim())
-      ? f.tts.cloud.voice
-      : (provVoices[0]?.id || f.tts.cloud.voice);
+    // Switching provider invalidates the old voice id. openai-compatible has no
+    // curated list, so blank it and let discovery (or the server's own default)
+    // fill in — carrying an OpenAI name like "alloy" over to a local server
+    // would just fail at synthesis time. Matches PersonaVoiceCard.
+    const voice = provider === 'openai-compatible'
+      ? ''
+      : (provVoices.some(pv => pv.id === f.tts.cloud.voice.trim())
+        ? f.tts.cloud.voice
+        : (provVoices[0]?.id || f.tts.cloud.voice));
     const provModels = CLOUD_MODELS[provider as keyof typeof CLOUD_MODELS] || [];
     const model = provModels.includes(f.tts.cloud.model.trim() as never)
       ? f.tts.cloud.model
@@ -866,10 +888,15 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
                 </div>
               </div>
               {(() => {
-                const provVoices = CLOUD_VOICES[form.tts.cloud.provider as keyof typeof CLOUD_VOICES] || [];
+                const provider = form.tts.cloud.provider;
                 const voice = form.tts.cloud.voice.trim();
-                const isPreset = provVoices.some(v => v.id === voice);
-                if (isCompat) {
+                const isPreset = isKnownCloudVoice(provider, discoveredVoices, voice);
+                const setVoice = (v: string) =>
+                  setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, voice: v } } }));
+                // A compat server that advertised no voices leaves nothing to
+                // pick from — keep the plain text box it had before discovery.
+                const hasList = discoveredVoices.length > 0 || !isCompat;
+                if (!hasList) {
                   return (
                     <div className="field">
                       <Label>Default voice</Label>
@@ -877,14 +904,14 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
                         value={form.tts.cloud.voice}
                         maxLength={100}
                         placeholder="Server-specific (cloning ref or speaker id)"
-                        onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                          setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, voice: e.target.value } } }))
-                        }
+                        onChange={(e: ChangeEvent<HTMLInputElement>) => setVoice(e.target.value)}
                       />
                       <div className="field-hint">
-                        Server-specific: Chatterbox cloning ref name, Qwen3
-                        speaker id, etc. Leave blank to let the server pick its
-                        own default.
+                        {voiceDiscovery.loading
+                          ? 'Checking the server for a voice list…'
+                          : <>Server-specific: Chatterbox cloning ref name, Qwen3
+                              speaker id, etc. Leave blank to let the server pick its
+                              own default.</>}
                       </div>
                     </div>
                   );
@@ -892,38 +919,36 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
                 return (
                   <div className="field">
                     <Label>Default voice</Label>
-                    <Select
-                      value={isPreset ? voice : '__custom__'}
-                      onValueChange={val => {
+                    <VoicePicker
+                      value={isPreset ? voice : CUSTOM_VOICE_ID}
+                      onChange={val => {
                         // "Custom voice id…" clears the preset so isPreset flips
                         // false and the free-text input below appears for entry.
-                        setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, voice: val === '__custom__' ? '' : val } } }));
+                        setVoice(val === CUSTOM_VOICE_ID ? '' : val);
                       }}
-                    >
-                      <SelectTrigger><SelectValue /></SelectTrigger>
-                      <SelectContent>
-                        <SelectGroup>
-                          {provVoices.map(v => (
-                            <SelectItem key={v.id} value={v.id}>{v.label}</SelectItem>
-                          ))}
-                          <SelectItem value="__custom__">Custom voice id…</SelectItem>
-                        </SelectGroup>
-                      </SelectContent>
-                    </Select>
+                      groups={buildCloudVoiceGroups(provider, discoveredVoices)}
+                      title="Default cloud voice"
+                      preview={{ engine: 'cloud', cloudProvider: provider, adminFetch }}
+                    />
                     {!isPreset && (
                       <Input
-                        className={cn('mt-2', voice ? 'border-ink' : 'border-[var(--danger)]')}
+                        // A blank compat voice is legitimate — the server picks
+                        // its own default — so don't flag it red.
+                        className={cn('mt-2', voice || isCompat ? 'border-ink' : 'border-[var(--danger)]')}
                         value={form.tts.cloud.voice}
                         maxLength={100}
-                        placeholder="Enter a custom voice id"
-                        onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                          setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, voice: e.target.value } } }))
-                        }
+                        placeholder={isCompat ? 'Blank = server default' : 'Enter a custom voice id'}
+                        onChange={(e: ChangeEvent<HTMLInputElement>) => setVoice(e.target.value)}
                       />
                     )}
                     <div className="field-hint">
-                      Used when a Cloud persona hasn’t set its own voice. Pick a default, or choose
-                      <em> Custom voice id…</em> for any other OpenAI voice name / ElevenLabs voice id.
+                      Used when a Cloud persona hasn’t set its own voice.{' '}
+                      {discoveredVoices.length > 0
+                        ? <>{discoveredVoices.length} voice{discoveredVoices.length === 1 ? '' : 's'} found
+                            on your {isCompat ? 'server' : 'account'} — or choose <em>Custom voice id…</em> to
+                            enter one that isn’t listed.</>
+                        : <>Pick a default, or choose <em>Custom voice id…</em> for any other OpenAI voice
+                            name / ElevenLabs voice id.</>}
                     </div>
                   </div>
                 );

--- a/web/hooks/useVoiceDiscovery.ts
+++ b/web/hooks/useVoiceDiscovery.ts
@@ -1,0 +1,107 @@
+// Pulls the voice list from a cloud TTS provider so the persona + station
+// voice fields can offer a dropdown instead of a free-text box. The TTS twin
+// of useModelDiscovery — same debounce / stale-response / abort contract.
+//
+// Only `openai-compatible` and `elevenlabs` are discoverable (see
+// controller/src/llm/internal/speech/voice-catalog.ts); `openai` has a fixed
+// published voice set that lives in lib/cloudVoices.ts. Discovery failing is a
+// normal outcome, not an error state to shout about — the caller falls back to
+// the free-text input it used before.
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface DiscoveredVoice {
+  id: string;
+  label: string;
+  hint?: string;
+}
+
+interface UseVoiceDiscoveryOpts {
+  provider: string;
+  // openai-compatible server URL (including the /v1 suffix). Sent so the
+  // operator can discover against a URL they've typed but not yet saved.
+  baseUrl?: string;
+  enabled: boolean;
+  adminFetch: (url: string, init?: RequestInit) => Promise<Response>;
+}
+
+interface UseVoiceDiscoveryResult {
+  voices: DiscoveredVoice[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+// Matches useModelDiscovery: one request per multi-character edit of a
+// base-URL field, not one per keystroke.
+const DEBOUNCE_MS = 400;
+
+export function useVoiceDiscovery({
+  provider,
+  baseUrl,
+  enabled,
+  adminFetch,
+}: UseVoiceDiscoveryOpts): UseVoiceDiscoveryResult {
+  const [voices, setVoices] = useState<DiscoveredVoice[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Monotonic request id: only the newest in-flight request may write state,
+  // so a slow response for a stale (provider, baseUrl) can't clobber it.
+  const reqIdRef = useRef(0);
+
+  const runFetch = useCallback(async (signal?: AbortSignal) => {
+    if (!enabled || !provider) {
+      setVoices([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    const reqId = ++reqIdRef.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ provider });
+      if (baseUrl) params.set('baseUrl', baseUrl);
+      const r = await adminFetch(`/settings/tts/voices?${params}`, signal ? { signal } : undefined);
+      const data = await r.json() as { ok: boolean; voices: DiscoveredVoice[]; error?: string };
+      if (reqId !== reqIdRef.current) return;
+      if (data.ok) {
+        setVoices(Array.isArray(data.voices) ? data.voices : []);
+        setError(null);
+      } else {
+        setVoices([]);
+        setError(data.error || 'Discovery failed');
+      }
+    } catch (e: unknown) {
+      if (signal?.aborted || reqId !== reqIdRef.current) return;
+      setVoices([]);
+      setError(e instanceof Error ? e.message : 'Discovery failed');
+    } finally {
+      if (reqId === reqIdRef.current) setLoading(false);
+    }
+  }, [provider, baseUrl, enabled, adminFetch]);
+
+  // Auto-discover on input change, debounced. The AbortController cancels an
+  // in-flight request when the inputs change again before it resolves.
+  useEffect(() => {
+    // The list on screen belongs to the PREVIOUS provider/server. Drop it now
+    // rather than when the new response lands: discovery can take seconds (or
+    // time out), and until then the old provider's voices would sit there
+    // labelled as this one's — an ElevenLabs field offering a local server's
+    // speaker ids, which would save a voice that provider can't synthesize.
+    setVoices([]);
+    setError(null);
+    if (!enabled || !provider) {
+      setLoading(false);
+      return;
+    }
+    const ctrl = new AbortController();
+    const t = setTimeout(() => { runFetch(ctrl.signal); }, DEBOUNCE_MS);
+    return () => { clearTimeout(t); ctrl.abort(); };
+  }, [runFetch, enabled, provider]);
+
+  // Manual refresh fires immediately and bumps the request id, superseding any
+  // debounced or in-flight auto-discovery.
+  const refresh = useCallback(() => { runFetch(); }, [runFetch]);
+
+  return { voices, loading, error, refresh };
+}

--- a/web/lib/cloudVoiceGroups.ts
+++ b/web/lib/cloudVoiceGroups.ts
@@ -1,0 +1,78 @@
+// Merges the voices discovered from a cloud TTS provider with the curated
+// fallback list into VoicePicker groups. Shared by the Personas page
+// (per-persona voice) and the Settings page (the station-wide default) so the
+// two can't drift.
+//
+// Per provider:
+//   openai-compatible — no curated list exists (ids are server-specific), so
+//     the picker is entirely discovered. With nothing discovered the caller
+//     shows the free-text input instead.
+//   elevenlabs — discovered first under "Your voices" (this is where an
+//     operator's *cloned* voices show up, which a hardcoded list can never
+//     know about), then any curated stock voice the account didn't return.
+//   openai — never discoverable; the curated list is complete by construction.
+import { CLOUD_VOICES } from './cloudVoices';
+import type { VoicePickerGroup } from '../components/admin/tts/VoicePicker';
+import type { DiscoveredVoice } from '../hooks/useVoiceDiscovery';
+
+// Sentinel for the "type your own id" action row. Not a voice — the call site
+// maps it to '' on selection.
+export const CUSTOM_VOICE_ID = '__custom__';
+
+const CUSTOM_ROW = { id: CUSTOM_VOICE_ID, label: 'Custom voice id…', previewVoice: null };
+
+// Providers with a voice-list endpoint. Mirrors listVoices() in
+// controller/src/llm/internal/speech/voice-catalog.ts.
+export function providerSupportsDiscovery(provider: string): boolean {
+  return provider === 'openai-compatible' || provider === 'elevenlabs';
+}
+
+function curatedFor(provider: string) {
+  return CLOUD_VOICES[provider as keyof typeof CLOUD_VOICES] || [];
+}
+
+/**
+ * Every voice id the picker can offer for this provider — the test for
+ * "is the current value a known voice, or a custom one?". Callers use it both
+ * to decide whether to reveal the free-text input and to avoid clobbering a
+ * valid selection when the engine or provider changes.
+ */
+export function knownCloudVoiceIds(provider: string, discovered: DiscoveredVoice[]): Set<string> {
+  const ids = new Set<string>();
+  for (const v of curatedFor(provider)) ids.add(v.id);
+  for (const v of discovered) ids.add(v.id);
+  return ids;
+}
+
+export function isKnownCloudVoice(provider: string, discovered: DiscoveredVoice[], voice: string): boolean {
+  const v = voice.trim();
+  return !!v && knownCloudVoiceIds(provider, discovered).has(v);
+}
+
+/**
+ * Build the grouped option list for a cloud provider. Always ends with the
+ * "Custom voice id…" action row so an operator can enter an id the server
+ * never advertised.
+ */
+export function buildCloudVoiceGroups(provider: string, discovered: DiscoveredVoice[]): VoicePickerGroup[] {
+  const curated = curatedFor(provider);
+  const groups: VoicePickerGroup[] = [];
+
+  if (discovered.length) {
+    const discoveredIds = new Set(discovered.map(v => v.id));
+    // Discovered wins on an id collision — it carries the operator's own name
+    // for the voice, which beats our stock label.
+    const rest = curated.filter(v => !discoveredIds.has(v.id));
+    groups.push({
+      label: provider === 'elevenlabs' ? 'Your voices' : 'Discovered',
+      voices: discovered.map(v => ({ id: v.id, label: v.label, hint: v.hint })),
+    });
+    if (rest.length) groups.push({ label: 'Presets', voices: rest.map(v => ({ id: v.id, label: v.label })) });
+  } else if (curated.length) {
+    // Unlabelled single group — matches how the picker looked before discovery.
+    groups.push({ voices: curated.map(v => ({ id: v.id, label: v.label })) });
+  }
+
+  groups.push({ voices: [CUSTOM_ROW] });
+  return groups;
+}


### PR DESCRIPTION
Implements a Discord suggestion from **K8-Bit [SBL]**: pull the available voices from a cloud/local TTS engine so personas can pick from a dropdown instead of typing an opaque voice id from memory.

## Why this was small

Most of the road was already paved. SUB/WAVE already has an `openai-compatible` cloud TTS provider with a `baseUrl`, and already discovers *models* from that server via `GET /v1/models`. This adds the voice half, mirroring the existing model-discovery route almost line for line.

Before, the voice field was:
- **openai-compatible** → a free-text box you filled from memory (`PersonaVoiceCard.tsx`, `TtsSection.tsx`)
- **elevenlabs** → a hardcoded list of nine stock voices, which can never include your own cloned voices
- **openai** → a curated list, which is correct (OpenAI's voice set is fixed and published)

## What's here

`GET /settings/tts/voices` — the TTS twin of `/settings/llm/models`:

- **openai-compatible**: probes `{baseUrl}/audio/voices`, then `/voices`, then `/audio/speech/voices`. That endpoint isn't in the OpenAI spec, so every self-hosted server invented its own path and shape. The normalizer accepts bare arrays, `{voices:[…]}` (Kokoro-FastAPI, openedai-speech), `{data:[{id}]}` (`/v1/models` mimics), and ElevenLabs-style objects.
- **elevenlabs**: `GET /v1/voices` — where cloned voices live.
- **openai**: untouched.

The UI feeds these into the existing `VoicePicker` (already searchable, grouped, with per-row audition). ElevenLabs shows **Your voices** then **Presets**, deduped by id with the discovered label winning. A "Custom voice id…" escape hatch stays in every branch.

**Security:** the API key is read from saved config, never accepted as a query param, so it can't land in access logs or browser history. `baseUrl` still rides the query so you can discover against a URL you've typed but not yet saved.

**Failure is a normal outcome.** An unreachable, silent, or slow server falls back to exactly the free-text input that was there before — no regression, just no help.

## Two bugs fixed on the way

1. **Engine toggle clobbered a discovered voice.** `selectEngine` reset the voice unless it matched a *curated* preset, so toggling the engine away and back destroyed a voice picked from the server's own list.
2. **Stale list across a provider switch.** The previous provider's voices stayed on screen — labelled as the new provider's — until the new response landed, which can take seconds. An ElevenLabs field offering a local server's speaker ids would have saved a voice that provider can't synthesize. Caught during UI testing; the hook now clears on input change rather than on response.

Also: switching the station provider to `openai-compatible` now blanks the voice instead of carrying an OpenAI id like `alloy` onto a self-hosted server (matching what the persona card already did).

## Verification

- **24 unit tests** (`npm test -- voice-catalog`) covering every payload shape, junk input, dedupe, the 100-char id cap that mirrors `normalizeTts`, and — against a real local HTTP server — probe order, path fallback, and auth headers.
- **Full suite green**: 37/37 test files. `npm run lint` clean in both `controller/` and `web/`.
- **End to end** against an isolated controller + worktree dev server: the route for both providers and every failure mode (unreachable, all-404, no key, no provider, 401 unauthenticated); the ElevenLabs API returning 30 real voices including cloned ones; and the compat picker rendering `DISCOVERED | Bella | George | Narrator Raw | Custom voice id…` in the live admin UI.

### One thing to eyeball before merge

The ElevenLabs list **rendered in the browser** with real account data was not visually confirmed. Requests originating from the Playwright session stalled past the timeout every time, while `curl` against the same route at the same moment answered in ~150ms — a network artifact of my test host, not a code path (the module is ~150ms in a standalone process, 3/3). The timeout degraded exactly as designed, and the grouped `YOUR VOICES` / `PRESETS` layout was observed rendering correctly. Worth one look on a station with ElevenLabs configured.

Design doc: `docs/superpowers/specs/2026-07-18-cloud-tts-voice-discovery-design.md` (includes where the build diverged from the design and why).
