### PR TITLE
fix(tts): fall back to the configured default engine before Piper

### DIFF
--- a/controller/scripts/tts-fallback.test.ts
+++ b/controller/scripts/tts-fallback.test.ts
@@ -1,0 +1,84 @@
+// Unit tests for the TTS runtime rescue ordering (audio/tts-fallback.ts):
+// orderedFallbacks builds speak()'s mid-render fallback chain — configured
+// default engine first, then Piper, then Kokoro — dropping the failed primary,
+// duplicates, and anything the availability gate rejects.
+// Run: `tsx scripts/tts-fallback.test.ts`.
+//
+// node:assert-via-tsx style, matching scripts/programme.test.ts.
+
+import assert from 'node:assert/strict';
+import { orderedFallbacks } from '../src/audio/tts-fallback.js';
+
+const allUsable = () => true;
+
+// No configured default: Piper floor, then Kokoro.
+assert.deepEqual(
+  orderedFallbacks('cloud', undefined, allUsable),
+  ['piper', 'kokoro'],
+  'no default → piper then kokoro',
+);
+
+// Configured default leads the chain.
+assert.deepEqual(
+  orderedFallbacks('cloud', 'kokoro', allUsable),
+  ['kokoro', 'piper'],
+  'default engine comes first, then deduped against the piper/kokoro tail',
+);
+
+// The failed primary never re-appears — even when it IS the default.
+assert.deepEqual(
+  orderedFallbacks('kokoro', 'kokoro', allUsable),
+  ['piper'],
+  'default === primary → dropped',
+);
+
+// Piper as primary: the chain still ends in a local engine (Kokoro).
+assert.deepEqual(
+  orderedFallbacks('piper', undefined, allUsable),
+  ['kokoro'],
+  'piper primary → kokoro backstop',
+);
+assert.deepEqual(
+  orderedFallbacks('piper', 'chatterbox', allUsable),
+  ['chatterbox', 'kokoro'],
+  'piper primary with a default → default then kokoro, no piper',
+);
+
+// A default of piper dedupes against the floor slot instead of doubling.
+assert.deepEqual(
+  orderedFallbacks('cloud', 'piper', allUsable),
+  ['piper', 'kokoro'],
+  'default piper appears once',
+);
+
+// The usable gate filters: an unavailable default is skipped, not attempted.
+assert.deepEqual(
+  orderedFallbacks('cloud', 'remote', (e) => e !== 'remote'),
+  ['piper', 'kokoro'],
+  'unusable default filtered',
+);
+
+// Unknown engine ids in settings are rejected by the gate (in prod,
+// engineUsable() returns false for anything outside ENGINES).
+assert.deepEqual(
+  orderedFallbacks('cloud', 'bogus', (e) => e !== 'bogus'),
+  ['piper', 'kokoro'],
+  'invalid default filtered by the gate',
+);
+
+// Kokoro missing (model files absent) with Piper as primary: empty chain —
+// speak() records the failure and rethrows.
+assert.deepEqual(
+  orderedFallbacks('piper', undefined, (e) => e !== 'kokoro'),
+  [],
+  'no usable rescue → empty chain',
+);
+
+// Nothing usable at all: empty chain regardless of configuration.
+assert.deepEqual(
+  orderedFallbacks('cloud', 'kokoro', () => false),
+  [],
+  'gate rejects everything → empty chain',
+);
+
+console.log('tts-fallback.test.ts: all assertions passed');

--- a/controller/src/audio/tts-fallback.ts
+++ b/controller/src/audio/tts-fallback.ts
@@ -1,0 +1,23 @@
+// Pure ordering logic for speak()'s runtime rescue chain — extracted from
+// tts.ts so scripts/tts-fallback.test.ts can pin it without dragging in the
+// engine modules (settings reads, venv existsSyncs, live /health probes).
+//
+// Order: the operator's configured default engine first (their explicit second
+// choice), then Piper (the universal local floor), then Kokoro (for the case
+// where Piper itself was the failed primary). The primary, duplicates, and
+// anything the caller's `usable` gate rejects are dropped — so the chain never
+// re-attempts the engine that just threw, and never attempts one the
+// pre-flight gate already knows can't speak.
+export function orderedFallbacks(
+  primary: string,
+  defaultEngine: string | null | undefined,
+  usable: (engine: string) => boolean,
+): string[] {
+  const out: string[] = [];
+  for (const engine of [defaultEngine, 'piper', 'kokoro']) {
+    if (!engine || engine === primary || out.includes(engine)) continue;
+    if (!usable(engine)) continue;
+    out.push(engine);
+  }
+  return out;
+}

--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -12,6 +12,7 @@ import * as pocketTts from './pocketTts.js';
 import { heavyEnabledEngines } from './ttsHeavyClient.js';
 import * as remoteTts from './remoteTts.js';
 import { normalizeForSpeech } from './speech-text.js';
+import { orderedFallbacks } from './tts-fallback.js';
 import { localizedPreviewText } from './preview-text.js';
 import * as cloud from '../llm/speech.js';
 import { stripThinking } from '../llm/sdk.js';
@@ -98,7 +99,7 @@ function engineUsable(engine: string, cloudProvider?: string | null): boolean {
 // The persona's own cloud provider, but only when the persona is actually ON
 // the cloud engine — otherwise the global Cloud provider applies.
 function personaCloudProvider(personaTts: any): string | null {
-  return (personaTts && personaTts.engine === 'cloud') ? personaTts.cloudProvider : null;
+  return (personaTts && personaTts.engine === 'cloud') ? (personaTts.cloudProvider ?? null) : null;
 }
 
 function resolveEngine(kind: string, personaTts: any) {
@@ -130,16 +131,18 @@ function resolveEngine(kind: string, personaTts: any) {
 //
 // The default engine is checked with the GLOBAL cloud provider (null), not the
 // persona's — falling back to `cloud` means the station default's credentials,
-// not the ones that just failed.
+// not the ones that just failed. The rescue call itself must agree: speak()'s
+// chain loop passes a null personaTts to speakWith() so a cloud-persona rescue
+// can't re-apply the persona's own provider/voice override.
+//
+// At most three rescue attempts — the ordering itself is pure and pinned by
+// scripts/tts-fallback.test.ts.
 function fallbackChain(primary: string): string[] {
-  const def = settings.get().tts?.defaultEngine;
-  const out: string[] = [];
-  for (const engine of [def, 'piper', 'kokoro']) {
-    if (!engine || engine === primary || out.includes(engine)) continue;
-    if (!engineUsable(engine, null)) continue;
-    out.push(engine);
-  }
-  return out;
+  return orderedFallbacks(
+    primary,
+    settings.get().tts?.defaultEngine,
+    (engine) => engineUsable(engine, null),
+  );
 }
 
 // Effective voice level trim (dB) for a spoken segment of `kind`: the resolved
@@ -418,7 +421,16 @@ export async function speak(
     for (const fallback of chain) {
       console.error(`[tts] ${lastEngine} failed for kind=${kind}: ${lastErr.message} — falling back to ${fallback}`);
       try {
-        const result = await speakWith(fallback, speakText, { outPath, speedScale: scale, language, soul }, personaTts);
+        // personaTts is deliberately NOT forwarded to a rescue: speakWith()'s
+        // per-engine branches only read it when personaTts.engine === the
+        // engine being spoken, and the chain excludes the primary — so for
+        // every rescue it's inert EXCEPT the one corner where a cloud persona
+        // was pre-flight-rerouted (its provider unconfigured) and the default
+        // engine is `cloud`: forwarding it would re-apply the persona's dead
+        // provider/voice instead of the station default's credentials the
+        // chain probe just validated. Null keeps probe and call in agreement.
+        // The persona's `language`/`soul` hints still ride via opts.
+        const result = await speakWith(fallback, speakText, { outPath, speedScale: scale, language, soul }, null);
         if (typeof result === 'string') await applyEdgeFades(result);
         recordTts({
           ...callBase, engine: fallback, fellBack: true,

--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -71,6 +71,36 @@ function requestedEngine(kind: string, personaTts: any): string {
   return settings.get().tts?.defaultEngine || 'piper';
 }
 
+// Can this engine plausibly speak right now? The pre-flight availability/key
+// gates, in one predicate so resolveEngine() (which picks the primary) and
+// fallbackChain() (which picks the runtime rescue) can never disagree about
+// what "installed" means.
+//
+// - `cloud` without a configured key would just throw and fall back — skip the
+//   wasted API attempt. `cloudProvider` scopes the key check: a persona on
+//   ElevenLabs needs that provider's key, not the global Cloud provider's.
+// - `chatterbox` / `pocket-tts` are opt-in (--build-arg WITH_CHATTERBOX=1 /
+//   WITH_POCKETTTS=1); without the venv there's no Python to spawn.
+// - `kokoro` ships in the default image, but its model/voices files are pulled
+//   at build time and can be missing if that download failed.
+// - `remote` needs a configured URL AND a reachable sidecar (/health probe).
+// - `piper` is local, keyless and always present — the universal floor.
+function engineUsable(engine: string, cloudProvider?: string | null): boolean {
+  if (!ENGINES.includes(engine)) return false;
+  if (engine === 'cloud') return cloud.isConfigured(cloudProvider ?? null);
+  if (engine === 'chatterbox') return chatterbox.isAvailable();
+  if (engine === 'pocket-tts') return pocketTts.isAvailable();
+  if (engine === 'kokoro') return kokoro.isAvailable();
+  if (engine === 'remote') return remoteTts.isAvailable();
+  return true;
+}
+
+// The persona's own cloud provider, but only when the persona is actually ON
+// the cloud engine — otherwise the global Cloud provider applies.
+function personaCloudProvider(personaTts: any): string | null {
+  return (personaTts && personaTts.engine === 'cloud') ? personaTts.cloudProvider : null;
+}
+
 function resolveEngine(kind: string, personaTts: any) {
   const tts = settings.get().tts || {};
   let chosen;
@@ -80,44 +110,36 @@ function resolveEngine(kind: string, personaTts: any) {
     chosen = tts.defaultEngine || 'piper';   // jingle / fallback
   }
   if (!ENGINES.includes(chosen)) return 'piper';
-  // `cloud` without a configured key would just throw and fall back — skip
-  // the wasted API attempt and resolve straight to a local engine. Check the
-  // persona's own provider: a persona on ElevenLabs needs that provider's key,
-  // not the global Cloud-engine provider's.
-  if (chosen === 'cloud') {
-    const provider = (personaTts && personaTts.engine === 'cloud')
-      ? personaTts.cloudProvider
-      : null;
-    if (!cloud.isConfigured(provider)) {
-      return tts.defaultEngine && tts.defaultEngine !== 'cloud' ? tts.defaultEngine : 'piper';
-    }
-  }
-  // Chatterbox is opt-in — if the controller image wasn't built with
-  // --build-arg WITH_CHATTERBOX=1, the venv isn't there. Skip straight to a
-  // local engine instead of trying to spawn a Python that doesn't exist.
-  if (chosen === 'chatterbox' && !chatterbox.isAvailable()) {
-    return tts.defaultEngine && tts.defaultEngine !== 'chatterbox' ? tts.defaultEngine : 'piper';
-  }
-  // Same story for PocketTTS — opt-in via --build-arg WITH_POCKETTTS=1.
-  // When the venv is absent, route to the saved default (or Piper as the
-  // universal local fallback).
-  if (chosen === 'pocket-tts' && !pocketTts.isAvailable()) {
-    return tts.defaultEngine && tts.defaultEngine !== 'pocket-tts' ? tts.defaultEngine : 'piper';
-  }
-  // Kokoro ships in the default image, but its model/voices files are pulled at
-  // build time and can be missing if that download failed. isAvailable() now
-  // existsSyncs them, so route around a broken Kokoro install instead of
-  // spawning a worker that just dies on load and falls back per segment.
-  if (chosen === 'kokoro' && !kokoro.isAvailable()) {
-    return tts.defaultEngine && tts.defaultEngine !== 'kokoro' ? tts.defaultEngine : 'piper';
-  }
-  // The remote engine needs a configured URL and a reachable sidecar — unlike
-  // the local engines, which gate on installed venvs/models. When the URL is
-  // blank or the /health probe hasn't succeeded yet, fall back to the default.
-  if (chosen === 'remote' && !remoteTts.isAvailable()) {
-    return tts.defaultEngine && tts.defaultEngine !== 'remote' ? tts.defaultEngine : 'piper';
+  // Known-unavailable engine → route to the operator's saved default (or Piper
+  // as the universal local fallback) instead of attempting a call that can only
+  // throw. Note this does NOT verify the default is itself usable; if it isn't,
+  // the runtime chain in speak() picks up the pieces.
+  if (!engineUsable(chosen, personaCloudProvider(personaTts))) {
+    return tts.defaultEngine && tts.defaultEngine !== chosen ? tts.defaultEngine : 'piper';
   }
   return chosen;
+}
+
+// Ordered runtime rescues after `primary` threw mid-render (cloud API 500,
+// worker crash, network timeout — a failure the pre-flight gate can't predict).
+// The operator's configured default engine comes FIRST: it's their explicit
+// second choice, and jumping straight past it to Piper meant a station whose
+// default was, say, Kokoro still dropped to the flattest voice in the box the
+// moment a persona's provider hiccuped. Piper follows as the universal local
+// floor, then Kokoro for the case where Piper itself was the primary.
+//
+// The default engine is checked with the GLOBAL cloud provider (null), not the
+// persona's — falling back to `cloud` means the station default's credentials,
+// not the ones that just failed.
+function fallbackChain(primary: string): string[] {
+  const def = settings.get().tts?.defaultEngine;
+  const out: string[] = [];
+  for (const engine of [def, 'piper', 'kokoro']) {
+    if (!engine || engine === primary || out.includes(engine)) continue;
+    if (!engineUsable(engine, null)) continue;
+    out.push(engine);
+  }
+  return out;
 }
 
 // Effective voice level trim (dB) for a spoken segment of `kind`: the resolved
@@ -379,11 +401,11 @@ export async function speak(
     });
     return result;
   } catch (err) {
-    // Piper is the universal local fallback — no model load, no API key.
-    // From any non-piper engine we always fall back to piper; if piper itself
-    // is the primary, try kokoro (only if its worker is installed).
-    const fallback = primary === 'piper' ? 'kokoro' : 'piper';
-    if (fallback === 'kokoro' && !kokoro.isAvailable()) {
+    // The primary passed the pre-flight gate but threw mid-render. Walk the
+    // rescue chain — configured default engine, then Piper, then Kokoro — so
+    // the DJ never goes silent because one provider hiccuped.
+    const chain = fallbackChain(primary);
+    if (!chain.length) {
       recordTts({
         ...callBase, engine: primary, fellBack: requested !== primary,
         ok: false, ms: Date.now() - started, error: err.message,
@@ -391,23 +413,30 @@ export async function speak(
       });
       throw err;
     }
-    console.error(`[tts] ${primary} failed for kind=${kind}: ${err.message} — falling back to ${fallback}`);
-    try {
-      const result = await speakWith(fallback, speakText, { outPath, speedScale: scale, language, soul }, personaTts);
-      if (typeof result === 'string') await applyEdgeFades(result);
-      recordTts({
-        ...callBase, engine: fallback, fellBack: true,
-        ok: true, ms: Date.now() - started, t: new Date().toISOString(),
-      });
-      return result;
-    } catch (err2) {
-      recordTts({
-        ...callBase, engine: fallback, fellBack: true,
-        ok: false, ms: Date.now() - started, error: err2.message,
-        t: new Date().toISOString(),
-      });
-      throw err2;
+    let lastErr = err;
+    let lastEngine = primary;
+    for (const fallback of chain) {
+      console.error(`[tts] ${lastEngine} failed for kind=${kind}: ${lastErr.message} — falling back to ${fallback}`);
+      try {
+        const result = await speakWith(fallback, speakText, { outPath, speedScale: scale, language, soul }, personaTts);
+        if (typeof result === 'string') await applyEdgeFades(result);
+        recordTts({
+          ...callBase, engine: fallback, fellBack: true,
+          ok: true, ms: Date.now() - started, t: new Date().toISOString(),
+        });
+        return result;
+      } catch (err2) {
+        lastErr = err2;
+        lastEngine = fallback;
+      }
     }
+    // Every rescue failed too — record against the last engine attempted.
+    recordTts({
+      ...callBase, engine: lastEngine, fellBack: true,
+      ok: false, ms: Date.now() - started, error: lastErr.message,
+      t: new Date().toISOString(),
+    });
+    throw lastErr;
   }
 }
 


### PR DESCRIPTION
## What

When a persona's TTS engine fails **mid-render**, the runtime fallback in `speak()` now tries the operator's configured `tts.defaultEngine` before dropping to Piper.

## Why

There are two fallback layers in `audio/tts.ts`, and they disagreed:

| Failure mode | Before | After |
|---|---|---|
| **Pre-flight** — engine known unavailable (no cloud key, venv missing, sidecar down) | → `defaultEngine`, then Piper | unchanged |
| **Runtime** — engine passed the gate but threw (cloud API 500, worker crash, timeout) | → **Piper, always** | → `defaultEngine`, then Piper, then Kokoro |

So a guest persona pinned to ElevenLabs whose API 500s mid-show dropped the station to Piper even when the operator's default was Kokoro — the flattest voice in the box, chosen by nobody. The pre-flight path already respected the default; the runtime path was treated as a pure error path and skipped it.

## How

- **`fallbackChain(primary)`** builds the ordered rescue list `[defaultEngine, 'piper', 'kokoro']`, dropping the primary, duplicates, and anything failing its availability gate. `speak()`'s catch block walks it, returning on the first success.
- **`engineUsable(engine, cloudProvider)`** extracted from the five near-identical availability branches previously inlined in `resolveEngine()` — the cloud-key, chatterbox/pocket-tts venv, kokoro model-file and remote `/health` checks. Both layers now share one definition of "installed" so they can't drift.
- `resolveEngine()` collapses to a single `if (!engineUsable(...))`; **behaviour unchanged**, ~30 lines shorter.

A `cloud` default is probed with the **global** provider, not the persona's — falling back to cloud means the station default's credentials, not the ones that just failed.

`recordTts` still flags every rescue `fellBack: true`, so the admin Stats fallback rate keeps its meaning; the `engine` field now reports whichever engine actually spoke, and a total failure records against the last engine attempted rather than a hardcoded one.

## Testing

- `npx tsc --noEmit` → **0 errors in `audio/tts.ts`**. The repo reports 12 errors, but that's the pre-existing baseline — verified by stashing and re-running to confirm the identical 12 (missing `@modelcontextprotocol/sdk` / `umap-js` deps plus `ai` SDK version drift in `node_modules`, all unrelated to this diff).
- `eslint` clean for this file (warnings are the repo-wide `no-explicit-any` noise).
- No test file covers the dispatcher — the availability gates all reach into module state (venv paths, `existsSync`, live `/health` probes), so there's no pure seam to pin without a refactor I didn't want to smuggle into a fix. Worth a follow-up if you want `fallbackChain` unit-tested; it's pure apart from the `settings.get()` read.

## Not covered

`describeRouting()` still reports only the pre-flight resolution. That stays correct — the runtime chain is an error path with no steady state to display — but if you'd like `/debug` to surface the configured rescue order too, that's a small follow-up.


## Review follow-ups (second commit)

- **Cloud rescues now truly use the station default's credentials.** The chain loop passed `personaTts` through to `speakWith()`; in the one reachable corner (cloud persona with an unconfigured provider, pre-flight-rerouted, `defaultEngine: cloud`) that re-applied the persona's dead provider/voice over the global config — a guaranteed-doomed API call that contradicted `fallbackChain()`'s own comment. Rescues now pass `null` personaTts, which is behaviour-identical everywhere else (each `speakWith` branch only reads it when `personaTts.engine` matches the engine being spoken, and the chain excludes the primary). `language`/`soul` hints still ride via opts.
- **`fallbackChain` ordering is now unit-pinned.** The pure part lives in `audio/tts-fallback.ts` (`orderedFallbacks(primary, defaultEngine, usable)` — no imports); `scripts/tts-fallback.test.ts` pins default-first ordering, primary exclusion, dedup, gate filtering, and the empty-chain case. Auto-discovered by `npm test` (37/37 files pass).
- `personaCloudProvider()` normalises an unset provider to `null` so its signature is honest.

(The "no pure seam to pin" paragraph in Testing above is superseded by this commit.)
