### PR TITLE
fix(broadcast): make ICY metadata on Ogg mounts an operator toggle (#1052)

### DIFF
--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -1059,6 +1059,16 @@ const DEFAULTS = {
     aacEnabled: false,
     aacBitrate: 192,
     bitrate: 192,
+    // ICY (out-of-band) per-track titles on the Ogg mounts (/stream.opus +
+    // /stream.flac). ON by default: most internet-radio clients (Ferrosonic,
+    // Cast receivers, Symfonium) read the in-band Ogg comment only once at
+    // connect and freeze on that title without ICY (issue #1052). foobar2000
+    // is the known exception — it parses the in-band chained-Ogg tags
+    // correctly, and the ICY channel on top breaks its Ogg-FLAC metadata — so
+    // operators with fb2k listeners turn this off. Which camp a station's
+    // listeners fall in is unknowable from here, hence a toggle rather than a
+    // hardcoded value. MP3/AAC always use ICY and are unaffected.
+    oggIcyMetadata: true,
     // Idle pause (broadcast/stream-idle.ts). When on, the controller flips
     // radio.liq's idle gate after idleAfterMinutes with zero Icecast
     // listeners: the mounts keep serving (silence), but the music chain
@@ -1912,6 +1922,10 @@ export async function load() {
         typeof stored.stream?.bitrate === 'number' && MP3_BITRATE_SET.has(stored.stream.bitrate)
           ? stored.stream.bitrate
           : DEFAULTS.stream.bitrate,
+      oggIcyMetadata:
+        typeof stored.stream?.oggIcyMetadata === 'boolean'
+          ? stored.stream.oggIcyMetadata
+          : DEFAULTS.stream.oggIcyMetadata,
       idleWhenEmpty:
         typeof stored.stream?.idleWhenEmpty === 'boolean'
           ? stored.stream.idleWhenEmpty
@@ -3082,6 +3096,13 @@ export async function update(patch) {
         restart = true;
       }
     }
+    if (st.oggIcyMetadata !== undefined) {
+      const v = !!st.oggIcyMetadata;
+      if (v !== cur.stream.oggIcyMetadata) {
+        next.stream.oggIcyMetadata = v;
+        restart = true;
+      }
+    }
     if (st.aacEnabled !== undefined) {
       const v = !!st.aacEnabled;
       if (v !== cur.stream.aacEnabled) {
@@ -4106,6 +4127,7 @@ const LIQ_ARCHIVE_BITRATE_PATH = `${STATE_DIR}/liquidsoap_archive_bitrate.txt`;
 const LIQ_OPUS_ENABLED_PATH = `${STATE_DIR}/liquidsoap_opus_enabled.txt`;
 const LIQ_OPUS_BITRATE_PATH = `${STATE_DIR}/liquidsoap_opus_bitrate.txt`;
 const LIQ_FLAC_ENABLED_PATH = `${STATE_DIR}/liquidsoap_flac_enabled.txt`;
+const LIQ_OGG_ICY_METADATA_PATH = `${STATE_DIR}/liquidsoap_ogg_icy_metadata.txt`;
 const LIQ_AAC_ENABLED_PATH = `${STATE_DIR}/liquidsoap_aac_enabled.txt`;
 const LIQ_AAC_BITRATE_PATH = `${STATE_DIR}/liquidsoap_aac_bitrate.txt`;
 const LIQ_STREAM_BITRATE_PATH = `${STATE_DIR}/liquidsoap_stream_bitrate.txt`;
@@ -4119,6 +4141,7 @@ export async function writeLiquidsoapSettings(s) {
   await writeFile(LIQ_OPUS_ENABLED_PATH, s.stream.opusEnabled ? 'true' : 'false');
   await writeFile(LIQ_OPUS_BITRATE_PATH, String(s.stream.opusBitrate));
   await writeFile(LIQ_FLAC_ENABLED_PATH, s.stream.flacEnabled ? 'true' : 'false');
+  await writeFile(LIQ_OGG_ICY_METADATA_PATH, s.stream.oggIcyMetadata ? 'true' : 'false');
   await writeFile(LIQ_AAC_ENABLED_PATH, s.stream.aacEnabled ? 'true' : 'false');
   await writeFile(LIQ_AAC_BITRATE_PATH, String(s.stream.aacBitrate));
   await writeFile(LIQ_STREAM_BITRATE_PATH, String(s.stream.bitrate));

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -28,6 +28,7 @@ flac_enabled = ref(false)
 aac_enabled = ref(false)
 aac_bitrate = ref(192)
 stream_bitrate = ref(192)
+ogg_icy_metadata = ref(true)
 station_name = ref("SUB/WAVE")
 
 # DJ transition effects (filter sweep + echo washout + reverb dissolve + beat
@@ -133,12 +134,21 @@ if file.exists("/var/sub-wave/liquidsoap_flac_enabled.txt") then
   flac_enabled := (raw == "true")
 end
 
+# ICY (out-of-band) per-track titles on BOTH Ogg mounts (/stream.opus +
+# /stream.flac). ON by default — only an explicit "false" disables it, the
+# mirror image of the opt-in mount toggles above. See make_stream_outputs()
+# for the client trade-off this switches between (issue #1052 vs foobar2000).
+if file.exists("/var/sub-wave/liquidsoap_ogg_icy_metadata.txt") then
+  raw = string.trim(file.contents("/var/sub-wave/liquidsoap_ogg_icy_metadata.txt"))
+  ogg_icy_metadata := (raw != "false")
+end
+
 if file.exists("/var/sub-wave/liquidsoap_station_name.txt") then
   raw = string.trim(file.contents("/var/sub-wave/liquidsoap_station_name.txt"))
   if raw != "" then station_name := raw end
 end
 
-log("settings loaded: jingle_ratio=#{jingle_ratio()} crossfade_duration=#{crossfade_duration()} archive_enabled=#{archive_enabled()} archive_bitrate=#{archive_bitrate()} stream_bitrate=#{stream_bitrate()} opus_enabled=#{opus_enabled()} opus_bitrate=#{opus_bitrate()} flac_enabled=#{flac_enabled()} aac_enabled=#{aac_enabled()} aac_bitrate=#{aac_bitrate()} station_name=#{station_name()}")
+log("settings loaded: jingle_ratio=#{jingle_ratio()} crossfade_duration=#{crossfade_duration()} archive_enabled=#{archive_enabled()} archive_bitrate=#{archive_bitrate()} stream_bitrate=#{stream_bitrate()} opus_enabled=#{opus_enabled()} opus_bitrate=#{opus_bitrate()} flac_enabled=#{flac_enabled()} aac_enabled=#{aac_enabled()} aac_bitrate=#{aac_bitrate()} ogg_icy_metadata=#{ogg_icy_metadata()} station_name=#{station_name()}")
 
 # ---------------------------------------------------------------------------
 # HTTP(S) FETCH OVERRIDE — Liquidsoap's built-in http.get.stream returns
@@ -1513,15 +1523,17 @@ def make_stream_outputs() =
         opus_enc,
         id="stream_opus",
         fallible=true,
-        # Force ICY metadata ON. output.icecast leaves send_icy_metadata null by
-        # default, which GUESSES it off for any Ogg-container format and relies on
-        # in-band Ogg header re-emission (a new chained logical stream per track)
-        # instead. Many radio clients — Ferrosonic, Google Cast receivers, Symfonium
-        # — read the Ogg Vorbis comment only once at connect and never re-parse on a
-        # chained boundary, so they freeze on the first track's title (issue #1052).
-        # Icecast relays ICY StreamTitle out-of-band for Ogg mounts too, so enabling
-        # it gives those clients the same reliable per-track updates MP3/AAC get.
-        send_icy_metadata=true,
+        # ICY metadata is an operator toggle (default ON). output.icecast leaves
+        # send_icy_metadata null by default, which GUESSES it off for any
+        # Ogg-container format and relies on in-band Ogg header re-emission (a new
+        # chained logical stream per track) instead. Many radio clients — Ferrosonic,
+        # Google Cast receivers, Symfonium — read the Ogg Vorbis comment only once at
+        # connect and never re-parse on a chained boundary, so without ICY they
+        # freeze on the first track's title (issue #1052). foobar2000 is the
+        # opposite: it parses the in-band chained-Ogg tags correctly and the ICY
+        # channel on top breaks its Ogg-FLAC metadata — no single value suits both
+        # client camps, hence the toggle instead of a hardcoded true.
+        send_icy_metadata=ogg_icy_metadata(),
         host=environment.get(default="icecast", "ICECAST_HOST"),
         port=7702,
         password=environment.get("ICECAST_SOURCE_PASSWORD"),
@@ -1554,10 +1566,11 @@ def make_stream_outputs() =
         ),
         id="stream_flac",
         fallible=true,
-        # Force ICY metadata ON — see the /stream.opus note above. Ogg-FLAC clients
-        # (Ferrosonic and other internet-radio players) otherwise stay stuck on the
-        # connect-time track because they ignore in-band chained-Ogg metadata (#1052).
-        send_icy_metadata=true,
+        # ICY metadata operator toggle — see the /stream.opus note above. Default ON
+        # so Ogg-FLAC internet-radio clients (Ferrosonic etc.) get per-track titles
+        # (#1052); off for stations with foobar2000 listeners, where the ICY channel
+        # breaks fb2k's in-band Ogg-FLAC metadata.
+        send_icy_metadata=ogg_icy_metadata(),
         host=environment.get(default="icecast", "ICECAST_HOST"),
         port=7702,
         password=environment.get("ICECAST_SOURCE_PASSWORD"),

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -124,6 +124,7 @@ export default function SettingsPanel() {
         aacEnabled: v.stream?.aacEnabled ?? false,
         aacBitrate: String(v.stream?.aacBitrate ?? 192),
         bitrate: String(v.stream?.bitrate ?? 192),
+        oggIcyMetadata: v.stream?.oggIcyMetadata ?? true,
         idleWhenEmpty: v.stream?.idleWhenEmpty ?? false,
         idleAfterMinutes: String(v.stream?.idleAfterMinutes ?? 10),
       },
@@ -1148,6 +1149,49 @@ export default function SettingsPanel() {
                     players (VLC, foobar2000, a network streamer) — the web and mobile players
                     stay on MP3/Opus and won&apos;t auto-select it. The mandatory{' '}
                     <code>/stream.mp3</code> mount always serves everyone.
+                  </div>
+                </div>
+              </Card>
+            )}
+
+            {form && (
+              <Card title="Ogg metadata" sub="ICY titles on /stream.opus + /stream.flac">
+                <div className="field">
+                  <div className="flex items-center gap-2">
+                    <Label>Push ICY track titles on the Ogg mounts</Label>
+                    <Pill tone="ink">restart required</Pill>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Seg
+                      options={[
+                        { id: 'on', label: 'On' },
+                        { id: 'off', label: 'Off' },
+                      ]}
+                      value={form.stream.oggIcyMetadata ? 'on' : 'off'}
+                      onChange={id =>
+                        setForm(f =>
+                          f ? { ...f, stream: { ...f.stream, oggIcyMetadata: id === 'on' } } : f,
+                        )
+                      }
+                    />
+                    <Btn
+                      sm
+                      onClick={() =>
+                        saveSettings({ stream: { oggIcyMetadata: form.stream.oggIcyMetadata } })
+                      }
+                      disabled={busy}
+                    >
+                      Save
+                    </Btn>
+                  </div>
+                  <div className="field-hint">
+                    On by default. Sends each track&apos;s title out-of-band (ICY) on the Opus and
+                    FLAC mounts, which most internet-radio players and Cast receivers need — they
+                    read the in-band Ogg tags only once, at connect, and otherwise stay stuck on
+                    the first title. Turn it <strong>off</strong> if your listeners use
+                    foobar2000: it reads the in-band tags correctly, and the extra ICY channel
+                    breaks its FLAC metadata display. The MP3 and AAC mounts always use ICY and
+                    are unaffected either way.
                   </div>
                 </div>
               </Card>

--- a/web/components/admin/settings/shared.tsx
+++ b/web/components/admin/settings/shared.tsx
@@ -172,6 +172,7 @@ export interface StreamForm {
   aacEnabled: boolean;
   aacBitrate: string;
   bitrate: string;
+  oggIcyMetadata: boolean;
   idleWhenEmpty: boolean;
   idleAfterMinutes: string;
 }
@@ -241,6 +242,7 @@ export interface SettingsData {
       aacEnabled?: boolean;
       aacBitrate?: number;
       bitrate?: number;
+      oggIcyMetadata?: boolean;
       idleWhenEmpty?: boolean;
       idleAfterMinutes?: number;
     };


### PR DESCRIPTION
## Summary

Follow-up to #1056 / issue #1052, prompted by [jame25's report](https://github.com/perminder-klair/subwave/issues/1052#issuecomment-5014088163) that forcing `send_icy_metadata=true` breaks FLAC metadata in foobar2000.

The two client camps are irreconcilable on the same mount:
- **Ferrosonic / Cast / Symfonium** read the in-band Ogg comment once at connect and freeze without ICY (the original #1052 bug).
- **foobar2000** parses the in-band chained-Ogg tags correctly, and the ICY channel on top breaks its Ogg-FLAC metadata.

So the hardcoded `true` becomes an operator toggle, **default on** (v0.43.0 behaviour and the original fix hold; fb2k operators opt out).

## Changes

- `controller/src/settings.ts` — new `stream.oggIcyMetadata` (default `true`): DEFAULTS + load normalisation + `update()` handling (restart-required, like the mount toggles) + persisted to `liquidsoap_ogg_icy_metadata.txt` in `writeLiquidsoapSettings`.
- `liquidsoap/radio.liq` — `ogg_icy_metadata` ref read at startup (absent file / anything but an explicit `"false"` → on, matching the controller default), passed as `send_icy_metadata=ogg_icy_metadata()` on both the Opus and FLAC mounts; added to the settings-loaded log line.
- `web/components/admin/SettingsPanel.tsx` + `settings/shared.tsx` — new **Ogg metadata** card between the FLAC and AAC stream cards with the on/off toggle and a hint explaining the foobar2000 trade-off.

MP3/AAC mounts are untouched (they always use ICY).

## Verification

- `controller` and `web` `npm run lint` (eslint + tsc) both pass.
- `liquidsoap --check` on the edited `radio.liq` (via the broadcast image binary) passes.

Closes the follow-up from #1052's latest comment; the issue itself can stay open until jame25 confirms.
