### PR TITLE
feat: CUDA analyzer flavour + quiet-times analysis gate (#1099)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,6 +122,9 @@ SITE_URL=
 #   docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d
 # ANALYZE_DEVICE=    # auto (default) / cpu / cuda — torch device for CLAP/Demucs;
 #                    # only meaningful on the cuda analyzer flavour
+# ANALYZE_IDLE_UNLOAD_S=  # cuda flavour: seconds of no analysis before models are
+#                         # dropped from VRAM (default 300; 0 = keep resident).
+#                         # Frees the GPU for co-resident TTS/LLM between passes.
 #
 # Runtime flags — env wins ON over the admin toggles (settings.audio.*), never
 # off. A flag with no matching backend in the image is a clean no-op.

--- a/.env.example
+++ b/.env.example
@@ -117,10 +117,19 @@ SITE_URL=
 #                    # set DOCKER_DEFAULT_PLATFORM=linux/amd64 (runs emulated).
 #                    # Unraid one-click (AIO) users instead pull subwave-aio-heavy.
 #
+# NVIDIA GPU? The heavy stack can run on CUDA instead — not an .env toggle (a
+# GPU device reservation can't live here); layer the analyzer-gpu overlay:
+#   docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d
+# ANALYZE_DEVICE=    # auto (default) / cpu / cuda — torch device for CLAP/Demucs;
+#                    # only meaningful on the cuda analyzer flavour
+#
 # Runtime flags — env wins ON over the admin toggles (settings.audio.*), never
 # off. A flag with no matching backend in the image is a clean no-op.
 # ANALYZE_AUDIO_EMBEDDING=   # 1/true = fill CLAP audio vectors (needs ANALYZER_HEAVY)
 # ANALYZE_VOCAL_ACTIVITY=    # 1/true = fill Demucs vocal ranges (needs ANALYZER_HEAVY)
+# ANALYZE_QUIET_ONLY=        # 1/true = pause analysis while anyone is listening;
+#                            # resumes after settings.audio.analyzeQuietMinutes
+#                            # (default 10) with no listeners (#1099)
 #
 # Building from source instead of pulling? `docker compose build analyzer` with
 # ANALYZER_HEAVY=1 bakes the stack (or pass WITH_CLAP=1 / WITH_DEMUCS=1 directly).

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -106,6 +106,18 @@ jobs:
             build_args: |
               WITH_CLAP=1
               WITH_DEMUCS=1
+          # CUDA analyzer — the heavy stack on cu124 torch wheels for NVIDIA
+          # hosts (#1099). amd64-only like heavy. Selected by the
+          # docker-compose.analyzer-gpu.yml overlay (which also adds the GPU
+          # device reservation), not by an .env var. onnxruntime stays the CPU
+          # build — only the transformers CLAP path and Demucs run on the GPU.
+          - image: subwave-analyzer-cuda
+            dockerfile: docker/Dockerfile.analyzer
+            platforms: linux/amd64
+            build_args: |
+              WITH_CLAP=1
+              WITH_DEMUCS=1
+              WITH_CUDA=1
     steps:
       # fetch-depth: 0 pulls full history + tags so `git describe` resolves the
       # version on a workflow_dispatch from a branch (a tag push already has the

--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ That repoints the `analyzer` service at `subwave-analyzer-heavy` (CLAP + Demucs,
 also offers it, and Unraid one-click users pull the `subwave-aio-heavy` image
 instead. Only the expressive *voices* above need the separate `tts-heavy` sidecar.
 
+Hosts with an NVIDIA GPU can run the heavy stack on CUDA instead — layer the
+`docker-compose.analyzer-gpu.yml` overlay, which swaps the service to the
+`subwave-analyzer-cuda` image and reserves the GPU (needs the NVIDIA driver +
+Container Toolkit, nothing else):
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d
+```
+
 ### Local dev (contributors)
 
 ```bash
@@ -227,7 +236,7 @@ Icecast stream on `:7702` (all configurable). Point your proxy at those three.
 `docker/Caddyfile` is a working reference for the route table you need to
 replicate. Details in [`DEPLOY.md`](DEPLOY.md#bring-your-own-reverse-proxy).
 
-**Images on GHCR.** Tagged releases publish to `ghcr.io/perminder-klair/subwave-{caddy,broadcast,controller,web}`, the default-on `subwave-analyzer` (lean, multi-arch acoustic analysis) sidecar, and the opt-in `subwave-tts-heavy` (expressive voices) sidecar. Heavy-analysis variants — `subwave-analyzer-heavy` and `subwave-aio-heavy` (CLAP + Demucs, amd64) — are published for operators who enable "sounds-like"/vocals.
+**Images on GHCR.** Tagged releases publish to `ghcr.io/perminder-klair/subwave-{caddy,broadcast,controller,web}`, the default-on `subwave-analyzer` (lean, multi-arch acoustic analysis) sidecar, and the opt-in `subwave-tts-heavy` (expressive voices) sidecar. Heavy-analysis variants — `subwave-analyzer-heavy` and `subwave-aio-heavy` (CLAP + Demucs, amd64) — are published for operators who enable "sounds-like"/vocals, plus `subwave-analyzer-cuda` (the heavy stack on NVIDIA CUDA, amd64) for GPU hosts via the `docker-compose.analyzer-gpu.yml` overlay.
 All compose files pull `:latest` by default; pin a version with
 `SUBWAVE_VERSION=v1.2.3` in the root `.env`.
 

--- a/cli/scripts/embed-assets.ts
+++ b/cli/scripts/embed-assets.ts
@@ -31,6 +31,7 @@ const ASSETS: Asset[] = [
   { name: 'COMPOSE_BYO_YML',            source: 'docker-compose.byo.yml' },
   { name: 'COMPOSE_DEV_YML',            source: 'docker-compose.dev.yml' },
   { name: 'COMPOSE_TTS_HEAVY_GPU_YML',  source: 'docker-compose.tts-heavy-gpu.yml' },
+  { name: 'COMPOSE_ANALYZER_GPU_YML',   source: 'docker-compose.analyzer-gpu.yml' },
   { name: 'ENV_EXAMPLE',                source: '.env.example' },
 ];
 

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -359,6 +359,9 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=\${ANALYZE_DEVICE:-}
+      # Seconds of no requests before the cuda flavour drops its models out of
+      # VRAM (default 300; 0 = never). CPU images ignore it.
+      - ANALYZE_IDLE_UNLOAD_S=\${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see
@@ -691,6 +694,9 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=\${ANALYZE_DEVICE:-}
+      # Seconds of no requests before the cuda flavour drops its models out of
+      # VRAM (default 300; 0 = never). CPU images ignore it.
+      - ANALYZE_IDLE_UNLOAD_S=\${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see
@@ -967,6 +973,9 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=\${ANALYZE_DEVICE:-}
+      # Seconds of no requests before the cuda flavour drops its models out of
+      # VRAM (default 300; 0 = never). CPU images ignore it.
+      - ANALYZE_IDLE_UNLOAD_S=\${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see
@@ -1068,6 +1077,11 @@ export const COMPOSE_ANALYZER_GPU_YML = `# GPU opt-in overlay for the analyzer �
 # torch sees a GPU, else cpu with a logged warning — a misconfigured host
 # degrades, not fails). To force CPU temporarily without dropping the overlay,
 # set ANALYZE_DEVICE=cpu in your root .env (the base compose passes it through).
+#
+# VRAM etiquette: after ~5 idle minutes the worker drops its models out of
+# VRAM so a co-resident TTS/LLM gets the card back between passes
+# (ANALYZE_IDLE_UNLOAD_S in .env tunes it; 0 keeps models resident). A few
+# hundred MB of CUDA context remain until the container stops.
 services:
   analyzer:
     image: ghcr.io/perminder-klair/subwave-analyzer-cuda:\${SUBWAVE_VERSION:-latest}
@@ -1223,6 +1237,9 @@ SITE_URL=
 #   docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d
 # ANALYZE_DEVICE=    # auto (default) / cpu / cuda — torch device for CLAP/Demucs;
 #                    # only meaningful on the cuda analyzer flavour
+# ANALYZE_IDLE_UNLOAD_S=  # cuda flavour: seconds of no analysis before models are
+#                         # dropped from VRAM (default 300; 0 = keep resident).
+#                         # Frees the GPU for co-resident TTS/LLM between passes.
 #
 # Runtime flags — env wins ON over the admin toggles (settings.audio.*), never
 # off. A flag with no matching backend in the image is a clean no-op.

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -355,6 +355,10 @@ services:
       # pass. Usually unnecessary — the admin toggles drive these per request.
       - ANALYZE_AUDIO_EMBEDDING=\${ANALYZE_AUDIO_EMBEDDING:-}
       - ANALYZE_VOCAL_ACTIVITY=\${ANALYZE_VOCAL_ACTIVITY:-}
+      # Torch device for CLAP/Demucs: auto (default) / cpu / cuda. Only
+      # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
+      # cpu-wheel images always resolve to cpu.
+      - ANALYZE_DEVICE=\${ANALYZE_DEVICE:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see
@@ -683,6 +687,10 @@ services:
       # admin toggles drive these per request.
       - ANALYZE_AUDIO_EMBEDDING=\${ANALYZE_AUDIO_EMBEDDING:-}
       - ANALYZE_VOCAL_ACTIVITY=\${ANALYZE_VOCAL_ACTIVITY:-}
+      # Torch device for CLAP/Demucs: auto (default) / cpu / cuda. Only
+      # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
+      # cpu-wheel images always resolve to cpu.
+      - ANALYZE_DEVICE=\${ANALYZE_DEVICE:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see
@@ -955,6 +963,10 @@ services:
     environment:
       - ANALYZE_AUDIO_EMBEDDING=\${ANALYZE_AUDIO_EMBEDDING:-}
       - ANALYZE_VOCAL_ACTIVITY=\${ANALYZE_VOCAL_ACTIVITY:-}
+      # Torch device for CLAP/Demucs: auto (default) / cpu / cuda. Only
+      # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
+      # cpu-wheel images always resolve to cpu.
+      - ANALYZE_DEVICE=\${ANALYZE_DEVICE:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see
@@ -1022,6 +1034,59 @@ services:
     #   runtime: nvidia
     #   environment:
     #     - TTS_HEAVY_DEVICE=cuda
+    #     - NVIDIA_VISIBLE_DEVICES=all
+    #     - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+`;
+
+// docker-compose.analyzer-gpu.yml
+export const COMPOSE_ANALYZER_GPU_YML = `# GPU opt-in overlay for the analyzer — runs CLAP + Demucs on CUDA (#1099).
+#
+# The default analyzer flavours are CPU-only on purpose: a GPU device
+# reservation can't live in the base compose because \`docker compose up\` errors
+# on a host without the NVIDIA runtime, which would break every CPU install.
+# This overlay swaps the \`analyzer\` service to the published
+# \`subwave-analyzer-cuda\` image (the heavy CLAP + Demucs stack on cu124 torch
+# wheels) and reserves the GPU. ANALYZER_HEAVY in .env is irrelevant while this
+# overlay is applied — the image is overridden outright.
+#
+# Layer it on top of your prod compose file:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d
+#
+# (BYO reverse-proxy hosts: swap docker-compose.yml for docker-compose.byo.yml.)
+#
+# Requirements: an NVIDIA GPU with the driver + NVIDIA Container Toolkit
+# installed — nothing else; the cu124 wheels vendor the CUDA runtime. The
+# worker picks the device itself (ANALYZE_DEVICE defaults to auto: cuda when
+# torch sees a GPU, else cpu with a logged warning — a misconfigured host
+# degrades, not fails). To force CPU temporarily without dropping the overlay,
+# set ANALYZE_DEVICE=cpu in your root .env (the base compose passes it through).
+services:
+  analyzer:
+    image: ghcr.io/perminder-klair/subwave-analyzer-cuda:\${SUBWAVE_VERSION:-latest}
+    # Local \`docker compose build analyzer\` with this overlay applied mirrors
+    # the published cuda image.
+    build:
+      args:
+        WITH_CLAP: 1
+        WITH_DEMUCS: 1
+        WITH_CUDA: 1
+    # Hand the GPU into the container (needs the NVIDIA Container Toolkit).
+    #
+    # The deploy.resources reservation below is the modern (CDI) path. On hosts
+    # where the NVIDIA runtime is registered in LEGACY mode, that reservation
+    # fails with "could not select device driver nvidia"; there, delete the
+    # \`deploy:\` block and instead use the legacy runtime:
+    #
+    #   runtime: nvidia
+    #   environment:
     #     - NVIDIA_VISIBLE_DEVICES=all
     #     - NVIDIA_DRIVER_CAPABILITIES=compute,utility
     deploy:
@@ -1153,10 +1218,19 @@ SITE_URL=
 #                    # set DOCKER_DEFAULT_PLATFORM=linux/amd64 (runs emulated).
 #                    # Unraid one-click (AIO) users instead pull subwave-aio-heavy.
 #
+# NVIDIA GPU? The heavy stack can run on CUDA instead — not an .env toggle (a
+# GPU device reservation can't live here); layer the analyzer-gpu overlay:
+#   docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d
+# ANALYZE_DEVICE=    # auto (default) / cpu / cuda — torch device for CLAP/Demucs;
+#                    # only meaningful on the cuda analyzer flavour
+#
 # Runtime flags — env wins ON over the admin toggles (settings.audio.*), never
 # off. A flag with no matching backend in the image is a clean no-op.
 # ANALYZE_AUDIO_EMBEDDING=   # 1/true = fill CLAP audio vectors (needs ANALYZER_HEAVY)
 # ANALYZE_VOCAL_ACTIVITY=    # 1/true = fill Demucs vocal ranges (needs ANALYZER_HEAVY)
+# ANALYZE_QUIET_ONLY=        # 1/true = pause analysis while anyone is listening;
+#                            # resumes after settings.audio.analyzeQuietMinutes
+#                            # (default 10) with no listeners (#1099)
 #
 # Building from source instead of pulling? \`docker compose build analyzer\` with
 # ANALYZER_HEAVY=1 bakes the stack (or pass WITH_CLAP=1 / WITH_DEMUCS=1 directly).

--- a/cli/src/assets.ts
+++ b/cli/src/assets.ts
@@ -4,4 +4,4 @@
 // strategies later (raw imports, Bun --embed, fetched from GHCR release
 // assets) without touching every caller.
 
-export { COMPOSE_YML, COMPOSE_BYO_YML, COMPOSE_DEV_YML, COMPOSE_TTS_HEAVY_GPU_YML, ENV_EXAMPLE, CLI_VERSION } from './assets.generated.ts';
+export { COMPOSE_YML, COMPOSE_BYO_YML, COMPOSE_DEV_YML, COMPOSE_TTS_HEAVY_GPU_YML, COMPOSE_ANALYZER_GPU_YML, ENV_EXAMPLE, CLI_VERSION } from './assets.generated.ts';

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -15,7 +15,7 @@ import { resolve } from 'node:path';
 import { homedir } from 'node:os';
 import crypto from 'node:crypto';
 
-import { COMPOSE_YML, COMPOSE_BYO_YML, COMPOSE_TTS_HEAVY_GPU_YML, ENV_EXAMPLE } from '../assets.ts';
+import { COMPOSE_YML, COMPOSE_BYO_YML, COMPOSE_TTS_HEAVY_GPU_YML, COMPOSE_ANALYZER_GPU_YML, ENV_EXAMPLE } from '../assets.ts';
 import { DEFAULT_SUBWAVE_HOME, writeHomeConfig } from '../home.ts';
 import { loadConfig, saveConfig } from '../config.ts';
 import { writeEnvFile } from '../util.ts';
@@ -226,14 +226,15 @@ async function scaffold(a: InitAnswers): Promise<void> {
   const composeMainSrc = a.mode === 'prod-byo' ? COMPOSE_BYO_YML : COMPOSE_YML;
   writeFileSync(resolve(a.home, 'docker-compose.yml'), composeMainSrc);
   writeFileSync(resolve(a.home, 'docker-compose.byo.yml'), COMPOSE_BYO_YML);
-  // Also drop the GPU opt-in overlay so operators can layer it on later
-  // (Chatterbox TTS on CUDA) without fetching a file from the repo. See
-  // docs/gpu-tts.md.
+  // Also drop the GPU opt-in overlays so operators can layer them on later
+  // (Chatterbox TTS on CUDA — docs/gpu-tts.md — and the CUDA analyzer for
+  // CLAP/Demucs, #1099) without fetching files from the repo.
   writeFileSync(resolve(a.home, 'docker-compose.tts-heavy-gpu.yml'), COMPOSE_TTS_HEAVY_GPU_YML);
+  writeFileSync(resolve(a.home, 'docker-compose.analyzer-gpu.yml'), COMPOSE_ANALYZER_GPU_YML);
   if (a.mode === 'prod-byo') {
-    ok('wrote docker-compose.yml (BYO-proxy variant) + docker-compose.byo.yml + GPU overlay');
+    ok('wrote docker-compose.yml (BYO-proxy variant) + docker-compose.byo.yml + GPU overlays');
   } else {
-    ok('wrote docker-compose.yml (bundled Caddy) + docker-compose.byo.yml + GPU overlay');
+    ok('wrote docker-compose.yml (bundled Caddy) + docker-compose.byo.yml + GPU overlays');
   }
 
   // 3. Write .env from the embedded template, filling in the operator's

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -548,6 +548,8 @@ async function promptHeavyAnalysis(): Promise<boolean> {
   header('Heavy acoustic analysis (optional)');
   muted('Basic analysis (bpm/key/loudness) is already on. This adds CLAP');
   muted('"sounds-like" similarity + Demucs vocal ranges; pulls a ~1.9 GB image (amd64).');
+  muted('NVIDIA GPU? Skip this and layer docker-compose.analyzer-gpu.yml instead —');
+  muted('it runs the same features on CUDA (see docs/tts-heavy.md).');
   return exitIfCancelled(await p.confirm({
     message: 'Enable heavy analysis (sounds-like + vocals)?',
     initialValue: false,

--- a/cli/src/commands/uninstall.ts
+++ b/cli/src/commands/uninstall.ts
@@ -38,6 +38,7 @@ const GENERATED_FILES = [
   'docker-compose.yml',
   'docker-compose.byo.yml',
   'docker-compose.tts-heavy-gpu.yml',
+  'docker-compose.analyzer-gpu.yml',
   '.env',
   '.env.example',
 ];

--- a/cli/src/compose-sync.ts
+++ b/cli/src/compose-sync.ts
@@ -19,6 +19,7 @@ import {
   COMPOSE_YML,
   COMPOSE_BYO_YML,
   COMPOSE_TTS_HEAVY_GPU_YML,
+  COMPOSE_ANALYZER_GPU_YML,
   ENV_EXAMPLE,
 } from './assets.ts';
 import { loadConfig } from './config.ts';
@@ -59,6 +60,7 @@ export function expectedFiles(mode: InstallMode): ExpectedFile[] {
     },
     { name: 'docker-compose.byo.yml', content: COMPOSE_BYO_YML, backup: true },
     { name: 'docker-compose.tts-heavy-gpu.yml', content: COMPOSE_TTS_HEAVY_GPU_YML, backup: true },
+    { name: 'docker-compose.analyzer-gpu.yml', content: COMPOSE_ANALYZER_GPU_YML, backup: true },
     { name: '.env.example', content: ENV_EXAMPLE, backup: false },
   ];
 }

--- a/controller/scripts/analyze-quiet.test.ts
+++ b/controller/scripts/analyze-quiet.test.ts
@@ -1,0 +1,104 @@
+// Unit tests for the pure quiet-times gate helper in
+// music/analyze-quiet-pure.ts (#1099). Run: `tsx scripts/analyze-quiet.test.ts`
+// (auto-discovered by `npm test`).
+//
+// quietGateDecision decides whether the analysis pass may compute the next
+// track: zero listeners for the configured window → proceed; any listener →
+// pause immediately. The branching is regression-critical in both directions:
+// too eager and a bulk pass churns the CPU while the station is live; too
+// strict (e.g. failing closed on an unknown count) and a stats outage stalls
+// a library scan forever. node:assert-via-tsx style, matching
+// stream-idle.test.ts.
+
+import assert from 'node:assert/strict';
+import { quietGateDecision, type QuietState } from '../src/music/analyze-quiet-pure.js';
+
+let failures = 0;
+function test(name: string, fn: () => void | Promise<void>) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => console.log(`  ✓ ${name}`))
+    .catch((err) => { failures++; console.error(`  ✗ ${name}\n      ${err?.message || err}`); });
+}
+
+const FRESH: QuietState = { quietSince: null };
+const WINDOW = 10 * 60_000; // 10 min
+const T0 = 1_000_000;
+
+async function main() {
+  console.log('quietGateDecision (analysis quiet-times gate):');
+
+  await test('disabled gate always proceeds', () => {
+    const r = quietGateDecision(FRESH, { enabled: false, count: 5, now: T0, quietAfterMs: WINDOW });
+    assert.equal(r.proceed, true);
+    assert.equal(r.state.quietSince, null);
+  });
+
+  await test('a listener pauses immediately and resets the quiet clock', () => {
+    const r = quietGateDecision({ quietSince: T0 }, { enabled: true, count: 1, now: T0 + WINDOW, quietAfterMs: WINDOW });
+    assert.equal(r.proceed, false);
+    assert.equal(r.state.quietSince, null);
+  });
+
+  await test('zero listeners starts the quiet clock but does not proceed yet', () => {
+    const r = quietGateDecision(FRESH, { enabled: true, count: 0, now: T0, quietAfterMs: WINDOW });
+    assert.equal(r.proceed, false);
+    assert.equal(r.state.quietSince, T0);
+  });
+
+  await test('the clock holds across polls while the room stays empty', () => {
+    const r = quietGateDecision({ quietSince: T0 }, { enabled: true, count: 0, now: T0 + WINDOW / 2, quietAfterMs: WINDOW });
+    assert.equal(r.proceed, false);
+    assert.equal(r.state.quietSince, T0); // NOT restarted per poll
+  });
+
+  await test('proceeds once the full window has elapsed at zero', () => {
+    const r = quietGateDecision({ quietSince: T0 }, { enabled: true, count: 0, now: T0 + WINDOW, quietAfterMs: WINDOW });
+    assert.equal(r.proceed, true);
+    assert.equal(r.state.quietSince, T0);
+  });
+
+  await test('keeps proceeding on later polls in an empty room', () => {
+    const r = quietGateDecision({ quietSince: T0 }, { enabled: true, count: 0, now: T0 + WINDOW * 3, quietAfterMs: WINDOW });
+    assert.equal(r.proceed, true);
+  });
+
+  await test('a listener blip mid-window restarts the wait from scratch', () => {
+    const blip = quietGateDecision(
+      { quietSince: T0 },
+      { enabled: true, count: 2, now: T0 + WINDOW - 1_000, quietAfterMs: WINDOW },
+    );
+    assert.equal(blip.proceed, false);
+    assert.equal(blip.state.quietSince, null);
+    const again = quietGateDecision(blip.state, { enabled: true, count: 0, now: T0 + WINDOW, quietAfterMs: WINDOW });
+    assert.equal(again.proceed, false);
+    assert.equal(again.state.quietSince, T0 + WINDOW); // fresh clock
+  });
+
+  await test('unknown count fails OPEN — proceeds despite no quiet history', () => {
+    // The opposite direction from djCallsAllowed(): a stats outage must never
+    // stall a library scan forever.
+    const r = quietGateDecision(FRESH, { enabled: true, count: null, now: T0, quietAfterMs: WINDOW });
+    assert.equal(r.proceed, true);
+    assert.equal(r.state.quietSince, T0); // outage accrues quiet time
+  });
+
+  await test('outage time counts toward the window on recovery at zero', () => {
+    // Icecast down for a full window, then recovers with an empty room: the
+    // pass must keep running, not pause in an empty room to re-earn quiet.
+    const during = quietGateDecision(FRESH, { enabled: true, count: null, now: T0, quietAfterMs: WINDOW });
+    const after = quietGateDecision(during.state, { enabled: true, count: 0, now: T0 + WINDOW, quietAfterMs: WINDOW });
+    assert.equal(after.proceed, true);
+  });
+
+  await test('recovery revealing listeners pauses again and resets the clock', () => {
+    const during = quietGateDecision(FRESH, { enabled: true, count: null, now: T0, quietAfterMs: WINDOW });
+    const after = quietGateDecision(during.state, { enabled: true, count: 3, now: T0 + WINDOW, quietAfterMs: WINDOW });
+    assert.equal(after.proceed, false);
+    assert.equal(after.state.quietSince, null);
+  });
+
+  process.exit(failures ? 1 : 0);
+}
+
+main();

--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -41,6 +41,8 @@ import json
 import os
 import sys
 import tempfile
+import threading
+import time
 import urllib.request
 
 # 40s is enough for stable BPM (beat_track) / key (chroma); intro detection
@@ -145,6 +147,80 @@ def resolve_device():
         _DEVICE = "cpu"
         log("analysis device: cpu")
     return _DEVICE
+
+
+# --- Idle GPU release (#1099 follow-up) -------------------------------------
+# On the cuda device the resident CLAP + Demucs models hold multiple GB of
+# VRAM even when no analysis is running, starving co-resident GPU work (a
+# local TTS/LLM on the same card OOMed hours after a pass finished). A daemon
+# thread drops the model singletons after ANALYZE_IDLE_UNLOAD_S seconds with
+# no requests (default 300; 0 disables). CUDA-only: on cpu the models stay
+# resident as always — system RAM is cheap and reload latency isn't worth it.
+# The next request lazy-reloads from the on-disk HF cache. NOTE: torch's CUDA
+# context (a few hundred MB) survives until the process exits — stopping the
+# analyzer container is the full release.
+IDLE_UNLOAD_S = float(os.environ.get("ANALYZE_IDLE_UNLOAD_S", "").strip() or "300")
+
+_last_used = time.time()
+_model_lock = threading.Lock()  # held during request handling AND unload
+_idle_thread_started = False
+
+
+def _touch():
+    global _last_used
+    _last_used = time.time()
+
+
+def _release_models():
+    """Drop the loaded model singletons and return their VRAM. Leaves the
+    *_failed flags alone, so the next request reloads instead of no-opping."""
+    global _embedder, _vocal_detector
+    import gc
+
+    freed = []
+    if _embedder is not None:
+        _embedder = None
+        freed.append("CLAP")
+    if _vocal_detector is not None:
+        _vocal_detector = None
+        freed.append("Demucs")
+    if not freed:
+        return
+    gc.collect()
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except Exception:  # noqa: BLE001 — freeing is best-effort
+        pass
+    log(
+        f"idle {int(IDLE_UNLOAD_S)}s — released {' + '.join(freed)} from GPU memory "
+        "(reloads on next use)"
+    )
+
+
+def _idle_release_loop():
+    while True:
+        time.sleep(30)
+        if time.time() - _last_used < IDLE_UNLOAD_S:
+            continue
+        with _model_lock:
+            # Re-check under the lock: a request may have landed while we
+            # waited to acquire it (a slow track holds the lock for minutes).
+            if time.time() - _last_used >= IDLE_UNLOAD_S:
+                _release_models()
+
+
+def _maybe_start_idle_release():
+    """Arm the idle-release thread — once, and only where it matters (cuda
+    device, unload enabled). Called after a heavy model actually loads."""
+    global _idle_thread_started
+    if _idle_thread_started or IDLE_UNLOAD_S <= 0 or resolve_device() != "cuda":
+        return
+    _idle_thread_started = True
+    threading.Thread(target=_idle_release_loop, daemon=True, name="idle-release").start()
+    log(f"idle GPU release armed — models unload after {int(IDLE_UNLOAD_S)}s without requests")
 
 
 def _pearson(a, b):
@@ -599,6 +675,7 @@ def get_embedder(force=False):
             e = ClapEmbedder()
             e.load()
             _embedder = e
+            _maybe_start_idle_release()
         except Exception as ex:  # noqa: BLE001 — degrade, never crash the worker
             log(f"CLAP load failed ({ex}); audio embeddings disabled for this run")
             _embed_failed = True
@@ -726,6 +803,7 @@ def get_vocal_detector(force=False):
             d = VocalActivityDetector()
             d.load()
             _vocal_detector = d
+            _maybe_start_idle_release()
         # BaseException, not Exception: demucs' fatal() raises SystemExit on an
         # unusable model (e.g. a *_q quantized checkpoint without diffq), which
         # sails past `except Exception` and killed the whole worker — every
@@ -1046,14 +1124,17 @@ def main():
             ):
                 emit({"id": rid, "ok": False, "error": "texts must be 1-64 non-empty strings"})
                 continue
-            embedder = get_embedder(force=True)
-            if embedder is None:
-                emit({"id": rid, "ok": False, "error": "CLAP unavailable (load failed or libs absent)"})
-                continue
-            try:
-                emit({"id": rid, "ok": True, "text_embeddings": embedder.embed_texts(texts)})
-            except Exception as e:  # noqa: BLE001 — one bad request never kills the worker
-                emit({"id": rid, "ok": False, "error": str(e)})
+            _touch()
+            with _model_lock:
+                embedder = get_embedder(force=True)
+                if embedder is None:
+                    emit({"id": rid, "ok": False, "error": "CLAP unavailable (load failed or libs absent)"})
+                    continue
+                try:
+                    emit({"id": rid, "ok": True, "text_embeddings": embedder.embed_texts(texts)})
+                except Exception as e:  # noqa: BLE001 — one bad request never kills the worker
+                    emit({"id": rid, "ok": False, "error": str(e)})
+            _touch()
             continue
         url = req.get("url")
         path = req.get("path")
@@ -1063,11 +1144,17 @@ def main():
         try:
             import librosa
 
-            result = analyze(
-                librosa, url=url, path=path,
-                embed=req.get("embed"), vocal=req.get("vocal"),
-                complete=req.get("complete"),
-            )
+            # _touch() on both edges + the lock keep the idle-release thread
+            # honest: the clock reads fresh after a long track, and an unload
+            # can never race a request that's mid-flight.
+            _touch()
+            with _model_lock:
+                result = analyze(
+                    librosa, url=url, path=path,
+                    embed=req.get("embed"), vocal=req.get("vocal"),
+                    complete=req.get("complete"),
+                )
+            _touch()
             emit({"id": rid, "ok": True, **result})
         except Exception as e:
             emit({"id": rid, "ok": False, "error": str(e)})

--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -111,6 +111,42 @@ def log(msg):
     sys.stderr.flush()
 
 
+# --- Torch device for the heavy models (CLAP / Demucs) ----------------------
+# ANALYZE_DEVICE ∈ auto (default) | cpu | cuda. `auto` picks cuda when torch
+# actually sees a GPU (the subwave-analyzer-cuda flavour on an NVIDIA host)
+# and cpu everywhere else — on the cpu-wheel images torch.cuda.is_available()
+# is always False, so existing installs behave exactly as before. A cuda
+# request without a visible GPU warns and falls back to cpu: device selection
+# must never fail an analysis pass. The torch import stays lazy — only the
+# heavy code paths call this, so the librosa-only venv never needs torch.
+_DEVICE = None
+
+
+def resolve_device():
+    global _DEVICE
+    if _DEVICE is not None:
+        return _DEVICE
+    import torch
+
+    want = os.environ.get("ANALYZE_DEVICE", "").strip().lower() or "auto"
+    if want not in ("auto", "cpu", "cuda"):
+        log(f"ANALYZE_DEVICE={want} not recognised (auto|cpu|cuda); using auto")
+        want = "auto"
+    if want != "cpu" and torch.cuda.is_available():
+        _DEVICE = "cuda"
+        log(f"analysis device: cuda ({torch.cuda.get_device_name(0)})")
+    else:
+        if want == "cuda":
+            log(
+                "ANALYZE_DEVICE=cuda but torch sees no CUDA device "
+                "(cpu-only wheels, no GPU exposed to the container, or missing "
+                "nvidia-container-toolkit); falling back to cpu"
+            )
+        _DEVICE = "cpu"
+        log("analysis device: cpu")
+    return _DEVICE
+
+
 def _pearson(a, b):
     n = len(a)
     ma = sum(a) / n
@@ -303,6 +339,7 @@ class ClapEmbedder:
 
             self.model = ClapModel.from_pretrained(hf_id)
             self.model.eval()
+            self.model.to(resolve_device())
             self.processor = ClapProcessor.from_pretrained(hf_id)
             self.mode = "transformers"
             log(f"CLAP transformers model loaded: {hf_id}")
@@ -332,6 +369,7 @@ class ClapEmbedder:
         else:
             import torch
 
+            feats = feats.to(resolve_device())
             with torch.no_grad():
                 emb = self.model.get_audio_features(input_features=feats)
             # transformers ≤4.x returns the projected 512-d audio-features
@@ -366,6 +404,7 @@ class ClapEmbedder:
             feat_id = os.environ.get("CLAP_FEATURE_MODEL", "").strip() or hf_id
             m = ClapTextModelWithProjection.from_pretrained(feat_id)
             m.eval()
+            m.to(resolve_device())
             self.text_model = m
             log(f"CLAP text tower loaded: {feat_id}")
         return self.text_model
@@ -380,6 +419,7 @@ class ClapEmbedder:
 
         model = self._resolve_text_model()
         inputs = self.processor(text=list(texts), return_tensors="pt", padding=True)
+        inputs = inputs.to(resolve_device())
         with torch.no_grad():
             emb = model.get_text_features(**inputs) if hasattr(model, "get_text_features") \
                 else model(**inputs)
@@ -599,7 +639,9 @@ class VocalActivityDetector:
         from demucs.apply import apply_model
 
         with torch.no_grad():
-            est = apply_model(self.model, wav.unsqueeze(0), device="cpu")[0]
+            # apply_model moves the model + chunks to the device itself (this
+            # is how the demucs CLI's -d flag works), so no .to() here.
+            est = apply_model(self.model, wav.unsqueeze(0), device=resolve_device())[0]
         vocals = est[self.sources.index("vocals")].mean(dim=0).cpu().numpy()
 
         # RMS envelope of the vocal stem, thresholded against its own loud level

--- a/controller/src/broadcast/listeners.ts
+++ b/controller/src/broadcast/listeners.ts
@@ -100,7 +100,7 @@ function audioParam(src: any, key: 'samplerate' | 'channels'): number | null {
   return m ? Number(m[1]) : null;
 }
 
-async function fetchCount() {
+async function fetchCount(persistHistory = true) {
   let online = false;
   let bitrate: number | null = null;
   let sampleRate: number | null = null;
@@ -162,7 +162,7 @@ async function fetchCount() {
   // Persist at most one row per wall-clock minute. Skip null samples — a
   // stats outage shouldn't leave a misleading "0 listeners" stripe in the
   // graph; the gap itself communicates the outage.
-  if (lastCount !== null) {
+  if (persistHistory && lastCount !== null) {
     const now = new Date();
     const minute = Math.floor(now.getTime() / 60000);
     if (minute !== lastPersistedMinute) {
@@ -200,6 +200,15 @@ export function getStreamStatus(): StreamStatus {
 // connected isn't rejected on a stale cached value.
 export async function refresh() {
   return fetchCount();
+}
+
+// One-shot count probe for out-of-process callers — the analysis quiet gate
+// (#1099) runs inside the tagger/analyze CHILD process, which has no 15s
+// monitor loop. Same status fetch + Safari dedupe as the monitor, but skips
+// the history append: the server process already persists one row per minute,
+// and a second writer would stripe duplicate rows into the sparkline JSONL.
+export async function probeListenerCount(): Promise<number | null> {
+  return fetchCount(false);
 }
 
 // Set by broadcast/stream-idle.ts (via setStreamIdle) while the programme is

--- a/controller/src/doctor-knowledge.ts
+++ b/controller/src/doctor-knowledge.ts
@@ -162,6 +162,13 @@ regular cadence — it's cheap insurance.
     \`docker run\`) change the analyzer container's image to
     \`ghcr.io/perminder-klair/subwave-analyzer-heavy\`. \`ANALYZER_HEAVY\` is a compose
     interpolation variable, so setting it on a container does nothing.
+  - **Split stack on an NVIDIA host**: the CUDA flavour runs the same heavy
+    features on the GPU — layer the \`docker-compose.analyzer-gpu.yml\` overlay
+    (\`docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d\`;
+    \`ANALYZER_HEAVY\` is irrelevant while it's applied), or on non-compose installs
+    point the container at \`ghcr.io/perminder-klair/subwave-analyzer-cuda\` with GPU
+    passthrough (\`--gpus all\`). Needs the NVIDIA driver + Container Toolkit; without
+    a visible GPU the worker logs a warning and runs on CPU.
   - **All-in-one image** (\`analyzer local\` — the AIO bundles the analyzer
     in-process): switch the single container's image to
     \`ghcr.io/perminder-klair/subwave-aio-heavy\`. Do NOT point an AIO install at

--- a/controller/src/music/analyze-quiet-pure.ts
+++ b/controller/src/music/analyze-quiet-pure.ts
@@ -1,0 +1,42 @@
+// Pure decision logic for the analysis quiet-times gate (#1099) — separate
+// file so scripts/analyze-quiet.test.ts can pin it without dragging in the
+// analysis pass's heavy imports (library-db → sqlite, analyzer), the same
+// split as broadcast/stream-idle-pure.ts.
+//
+// The gate is the INVERSE of the stream idle monitor: zero listeners for the
+// configured window means the analysis pass may run; any listener pauses it
+// immediately (freeing the CPU is the whole point — no hysteresis on the way
+// down). The window only gates the occupied → quiet transition, so a listener
+// blip between polls doesn't let a half-quiet station churn.
+
+export interface QuietState {
+  /** Epoch ms when the count first read 0 (or unknown); null while occupied. */
+  quietSince: number | null;
+}
+
+// Pure transition: previous state + (toggle, freshest count, clock, window) →
+// next state and whether the pass may analyse the next track. `count` is null
+// when Icecast couldn't be read.
+//
+// Regression-critical branches:
+//   • fail-open — an unknown count must never stall the pass forever (the
+//     OPPOSITE direction from djCallsAllowed(): if the stats endpoint is
+//     down, odds are nobody is streaming and the CPU is free; worst case is
+//     pre-gate behaviour, analysing while someone listens);
+//   • an outage still accrues quiet time (quietSince holds), so a recovery
+//     at 0 listeners doesn't pause an already-running pass in an empty room;
+//   • any listener resets the quiet clock to null — the full window must
+//     elapse again after they leave.
+export function quietGateDecision(
+  prev: QuietState,
+  input: { enabled: boolean; count: number | null; now: number; quietAfterMs: number },
+): { state: QuietState; proceed: boolean } {
+  const { enabled, count, now, quietAfterMs } = input;
+  if (!enabled) return { state: { quietSince: null }, proceed: true };
+  if (count === null) {
+    return { state: { quietSince: prev.quietSince ?? now }, proceed: true };
+  }
+  if (count > 0) return { state: { quietSince: null }, proceed: false };
+  const quietSince = prev.quietSince ?? now;
+  return { state: { quietSince }, proceed: now - quietSince >= quietAfterMs };
+}

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -16,6 +16,8 @@ import * as settings from '../settings.js';
 import { config } from '../config.js';
 import { runAudioMoodPass } from './audio-moods.js';
 import { reportProgress, makeEventLogger } from './tagger-progress.js';
+import { quietGateDecision, type QuietState } from './analyze-quiet-pure.js';
+import { probeListenerCount } from '../broadcast/listeners.js';
 
 // Structured status events for the panel, mirrored to the terse `[analyze] …`
 // console line. Shared by the tagger's analyze phase and the standalone CLI.
@@ -78,6 +80,89 @@ export function vocalActivityWanted(): boolean {
 // status enum so the panel doesn't have to re-derive the enable precedence.
 export function audioEmbeddingWanted(): boolean {
   return audioBackfillDefault();
+}
+
+// Quiet-times gate (#1099) — same env-wins-on precedence as the toggles above:
+// ANALYZE_QUIET_ONLY=1 forces it on, else the admin toggle
+// (settings.audio.analyzeQuietOnly). Both entry points call settings.load()
+// before the pass, so the child process reads the toggle without new plumbing.
+function quietOnlyDefault(): boolean {
+  const v = (process.env.ANALYZE_QUIET_ONLY || '').toLowerCase();
+  if (v === '1' || v === 'true' || v === 'yes') return true;
+  try {
+    return settings.get()?.audio?.analyzeQuietOnly === true;
+  } catch {
+    return false;
+  }
+}
+
+function quietMinutes(): number {
+  try {
+    const v = settings.get()?.audio?.analyzeQuietMinutes;
+    return Number.isFinite(v) && v >= 1 ? v : 10;
+  } catch {
+    return 10;
+  }
+}
+
+// How often the paused pass re-checks Icecast. One cheap status fetch per
+// tick (probeListenerCount — no history write); 30s keeps the resume latency
+// small without hammering a stream that's busy for hours.
+const QUIET_POLL_MS = 30_000;
+
+interface QuietGate {
+  enabled: boolean;
+  state: QuietState;
+  paused: boolean; // for one-per-transition logging, not decision logic
+}
+
+// Block until the gate allows the next track (immediately when disabled).
+// Sits BETWEEN tracks: an in-flight track finishes (seconds) and the pending
+// prefetch download is left to resolve — only the next *compute* waits. The
+// wait is unbounded by design; the operator's escape hatches are the tagger
+// Stop button and turning the toggle off (read once per pass, like the
+// embeddings/vocal toggles — it applies from the next run).
+async function waitForQuiet(gate: QuietGate, progress: { done: number; total: number }): Promise<void> {
+  if (!gate.enabled) return;
+  for (;;) {
+    const count = await probeListenerCount();
+    const d = quietGateDecision(gate.state, {
+      enabled: true,
+      count,
+      now: Date.now(),
+      quietAfterMs: quietMinutes() * 60_000,
+    });
+    gate.state = d.state;
+    if (d.proceed) {
+      if (gate.paused) {
+        gate.paused = false;
+        logEvent('info', 'Stream is quiet — resuming analysis');
+        // Restore the normal label now — the per-track reporter only fires
+        // every 25 tracks, which would leave "Waiting for quiet" on the panel
+        // long after the pass resumed.
+        reportProgress({ phase: 'analyze', label: 'Analysing audio', done: progress.done, total: progress.total });
+      }
+      return;
+    }
+    // count>0: someone is tuned in. count===0: the room just emptied and the
+    // quiet window is still draining (an unknown count never reaches here —
+    // the gate fails open).
+    const why = count && count > 0 ? `${count} listening` : 'waiting out the quiet window';
+    if (!gate.paused) {
+      gate.paused = true;
+      logEvent(
+        'info',
+        `Analysis paused — ${why}; resumes after ${quietMinutes()} min with no listeners`,
+      );
+    }
+    reportProgress({
+      phase: 'analyze',
+      label: `Waiting for quiet (${why})`,
+      done: progress.done,
+      total: progress.total,
+    });
+    await new Promise((r) => setTimeout(r, QUIET_POLL_MS));
+  }
 }
 
 export interface AnalyzeStats {
@@ -216,6 +301,16 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
   let failed = 0;
   let audioEmbedded = 0;
   let vocalAnalyzed = 0;
+  // Quiet-times gate (#1099). Resolved once per pass, like every other audio
+  // toggle; state carries across tracks so the quiet clock isn't reset by the
+  // loop itself.
+  const quietGate: QuietGate = { enabled: quietOnlyDefault(), state: { quietSince: null }, paused: false };
+  if (quietGate.enabled) {
+    logEvent(
+      'info',
+      `Quiet-times gate on — analysis only runs once the stream has had no listeners for ${quietMinutes()} min`,
+    );
+  }
   // Stamp the audio-embedding provenance row once, on the first vector written
   // this run. Cheap idempotent guard so we don't touch the meta table per track.
   let audioMetaStamped = false;
@@ -239,6 +334,10 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
   let inflight: Prefetch | null = ids.length > 0 ? prefetch(ids[0]) : null;
 
   for (let i = 0; i < ids.length; i++) {
+    // Gate BEFORE the next prefetch is kicked off: while paused, only the
+    // already-inflight download (this track's) is outstanding — the pass
+    // doesn't keep pulling audio for a queue it isn't going to compute yet.
+    await waitForQuiet(quietGate, { done: i, total: ids.length });
     const id = ids[i];
     const downloadPromise = inflight;
     // Kick off the NEXT download before awaiting this one's analysis so the

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -9,7 +9,7 @@
 // local librosa venv). When no backend is available this is a clean no-op, so
 // it's always safe to call as a tagger phase.
 
-import { rm } from 'node:fs/promises';
+import { readFile, rm } from 'node:fs/promises';
 import * as db from './library-db.js';
 import * as analyzer from './analyzer.js';
 import * as settings from '../settings.js';
@@ -84,25 +84,39 @@ export function audioEmbeddingWanted(): boolean {
 
 // Quiet-times gate (#1099) — same env-wins-on precedence as the toggles above:
 // ANALYZE_QUIET_ONLY=1 forces it on, else the admin toggle
-// (settings.audio.analyzeQuietOnly). Both entry points call settings.load()
-// before the pass, so the child process reads the toggle without new plumbing.
-function quietOnlyDefault(): boolean {
-  const v = (process.env.ANALYZE_QUIET_ONLY || '').toLowerCase();
-  if (v === '1' || v === 'true' || v === 'yes') return true;
-  try {
-    return settings.get()?.audio?.analyzeQuietOnly === true;
-  } catch {
-    return false;
-  }
+// (settings.audio.analyzeQuietOnly).
+//
+// Unlike the other audio toggles this one is re-read from DISK on every gate
+// check, not once per pass: settings.load() caches for the child process's
+// lifetime, and a pass over a big library runs for hours — an operator who
+// flips the toggle mid-scan (the reporter's overnight run in #1102) expects
+// the running pass to react, in both directions. Raw read, no normalization:
+// two scalar fields, and any parse failure falls back to the boot-time
+// snapshot (settings.get()) and then the defaults.
+interface QuietConfig {
+  enabled: boolean;
+  minutes: number;
 }
 
-function quietMinutes(): number {
+async function readQuietConfig(): Promise<QuietConfig> {
+  const v = (process.env.ANALYZE_QUIET_ONLY || '').toLowerCase();
+  const envOn = v === '1' || v === 'true' || v === 'yes';
+  let enabled = envOn;
+  let minutes = 10;
+  let audio: any = null;
   try {
-    const v = settings.get()?.audio?.analyzeQuietMinutes;
-    return Number.isFinite(v) && v >= 1 ? v : 10;
+    audio = JSON.parse(await readFile(`${config.stateDir}/settings.json`, 'utf8'))?.audio;
   } catch {
-    return 10;
+    try {
+      audio = settings.get()?.audio;
+    } catch {
+      audio = null;
+    }
   }
+  if (!enabled) enabled = audio?.analyzeQuietOnly === true;
+  const m = audio?.analyzeQuietMinutes;
+  if (Number.isFinite(m) && m >= 1 && m <= 120) minutes = Math.floor(m);
+  return { enabled, minutes };
 }
 
 // How often the paused pass re-checks Icecast. One cheap status fetch per
@@ -111,7 +125,6 @@ function quietMinutes(): number {
 const QUIET_POLL_MS = 30_000;
 
 interface QuietGate {
-  enabled: boolean;
   state: QuietState;
   paused: boolean; // for one-per-transition logging, not decision logic
 }
@@ -119,18 +132,21 @@ interface QuietGate {
 // Block until the gate allows the next track (immediately when disabled).
 // Sits BETWEEN tracks: an in-flight track finishes (seconds) and the pending
 // prefetch download is left to resolve — only the next *compute* waits. The
-// wait is unbounded by design; the operator's escape hatches are the tagger
-// Stop button and turning the toggle off (read once per pass, like the
-// embeddings/vocal toggles — it applies from the next run).
+// wait is unbounded by design; the escape hatches are the tagger Stop button
+// and the admin toggle, which readQuietConfig() re-reads on every check so a
+// mid-pass flip takes effect within one track / one 30s poll.
 async function waitForQuiet(gate: QuietGate, progress: { done: number; total: number }): Promise<void> {
-  if (!gate.enabled) return;
   for (;;) {
-    const count = await probeListenerCount();
+    const quiet = await readQuietConfig();
+    // Skip the Icecast probe entirely while the gate is off (the default
+    // path stays one cheap file read per track); the pure helper still runs
+    // so a disabled gate resets the quiet clock.
+    const count = quiet.enabled ? await probeListenerCount() : null;
     const d = quietGateDecision(gate.state, {
-      enabled: true,
+      enabled: quiet.enabled,
       count,
       now: Date.now(),
-      quietAfterMs: quietMinutes() * 60_000,
+      quietAfterMs: quiet.minutes * 60_000,
     });
     gate.state = d.state;
     if (d.proceed) {
@@ -152,7 +168,7 @@ async function waitForQuiet(gate: QuietGate, progress: { done: number; total: nu
       gate.paused = true;
       logEvent(
         'info',
-        `Analysis paused — ${why}; resumes after ${quietMinutes()} min with no listeners`,
+        `Analysis paused — ${why}; resumes after ${quiet.minutes} min with no listeners`,
       );
     }
     reportProgress({
@@ -301,15 +317,18 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
   let failed = 0;
   let audioEmbedded = 0;
   let vocalAnalyzed = 0;
-  // Quiet-times gate (#1099). Resolved once per pass, like every other audio
-  // toggle; state carries across tracks so the quiet clock isn't reset by the
-  // loop itself.
-  const quietGate: QuietGate = { enabled: quietOnlyDefault(), state: { quietSince: null }, paused: false };
-  if (quietGate.enabled) {
-    logEvent(
-      'info',
-      `Quiet-times gate on — analysis only runs once the stream has had no listeners for ${quietMinutes()} min`,
-    );
+  // Quiet-times gate (#1099). The toggle itself is re-read from disk on every
+  // check (see readQuietConfig); only the quiet-clock STATE lives here, so it
+  // carries across tracks instead of resetting each loop iteration.
+  const quietGate: QuietGate = { state: { quietSince: null }, paused: false };
+  {
+    const quiet = await readQuietConfig();
+    if (quiet.enabled) {
+      logEvent(
+        'info',
+        `Quiet-times gate on — analysis only runs once the stream has had no listeners for ${quiet.minutes} min`,
+      );
+    }
   }
   // Stamp the audio-embedding provenance row once, on the first vector written
   // this run. Cheap idempotent guard so we don't touch the meta table per track.

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -1448,6 +1448,15 @@ const DEFAULTS = {
     // request is a clean no-op. ANALYZE_VOCAL_ACTIVITY=1 also enables it
     // regardless of this toggle (env wins on, never off). Expensive — opt-in.
     vocalActivity: false,
+    // Quiet-times gate (#1099): pause the analysis pass while anyone is
+    // listening, resuming once the stream has been listener-free for
+    // analyzeQuietMinutes. Checked between tracks inside runAnalysisPass, so
+    // it covers both the server-spawned tagger child and `npm run analyze`,
+    // and applies to manual "Analyse now" runs too (a pass outlives the
+    // click; the bypass is turning this off). ANALYZE_QUIET_ONLY=1 also
+    // enables it (env wins on, never off), mirroring the toggles above.
+    analyzeQuietOnly: false,
+    analyzeQuietMinutes: 10,
   },
   // Sound-effects library. When disabled, the segment-director agent is never
   // shown the effect catalogue, so it stops garnishing spoken breaks with
@@ -2263,6 +2272,13 @@ export async function load() {
     audio: {
       embeddings: typeof stored.audio?.embeddings === 'boolean' ? stored.audio.embeddings : DEFAULTS.audio.embeddings,
       vocalActivity: typeof stored.audio?.vocalActivity === 'boolean' ? stored.audio.vocalActivity : DEFAULTS.audio.vocalActivity,
+      analyzeQuietOnly:
+        typeof stored.audio?.analyzeQuietOnly === 'boolean'
+          ? stored.audio.analyzeQuietOnly
+          : DEFAULTS.audio.analyzeQuietOnly,
+      analyzeQuietMinutes: Number.isFinite(stored.audio?.analyzeQuietMinutes)
+        ? Math.max(1, Math.min(120, Math.floor(stored.audio.analyzeQuietMinutes)))
+        : DEFAULTS.audio.analyzeQuietMinutes,
     },
     sfx: {
       enabled: typeof stored.sfx?.enabled === 'boolean' ? stored.sfx.enabled : DEFAULTS.sfx.enabled,
@@ -3682,6 +3698,16 @@ export async function update(patch) {
     }
     if (au.vocalActivity !== undefined) {
       next.audio.vocalActivity = !!au.vocalActivity;
+    }
+    if (au.analyzeQuietOnly !== undefined) {
+      next.audio.analyzeQuietOnly = !!au.analyzeQuietOnly;
+    }
+    if (au.analyzeQuietMinutes !== undefined) {
+      const v = Math.floor(Number(au.analyzeQuietMinutes));
+      if (!Number.isFinite(v) || v < 1 || v > 120) {
+        throw new Error('audio.analyzeQuietMinutes must be between 1 and 120');
+      }
+      next.audio.analyzeQuietMinutes = v;
     }
   }
   if ('sfx' in patch) {

--- a/docker-compose.analyzer-gpu.yml
+++ b/docker-compose.analyzer-gpu.yml
@@ -20,6 +20,11 @@
 # torch sees a GPU, else cpu with a logged warning — a misconfigured host
 # degrades, not fails). To force CPU temporarily without dropping the overlay,
 # set ANALYZE_DEVICE=cpu in your root .env (the base compose passes it through).
+#
+# VRAM etiquette: after ~5 idle minutes the worker drops its models out of
+# VRAM so a co-resident TTS/LLM gets the card back between passes
+# (ANALYZE_IDLE_UNLOAD_S in .env tunes it; 0 keeps models resident). A few
+# hundred MB of CUDA context remain until the container stops.
 services:
   analyzer:
     image: ghcr.io/perminder-klair/subwave-analyzer-cuda:${SUBWAVE_VERSION:-latest}

--- a/docker-compose.analyzer-gpu.yml
+++ b/docker-compose.analyzer-gpu.yml
@@ -1,0 +1,50 @@
+# GPU opt-in overlay for the analyzer — runs CLAP + Demucs on CUDA (#1099).
+#
+# The default analyzer flavours are CPU-only on purpose: a GPU device
+# reservation can't live in the base compose because `docker compose up` errors
+# on a host without the NVIDIA runtime, which would break every CPU install.
+# This overlay swaps the `analyzer` service to the published
+# `subwave-analyzer-cuda` image (the heavy CLAP + Demucs stack on cu124 torch
+# wheels) and reserves the GPU. ANALYZER_HEAVY in .env is irrelevant while this
+# overlay is applied — the image is overridden outright.
+#
+# Layer it on top of your prod compose file:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d
+#
+# (BYO reverse-proxy hosts: swap docker-compose.yml for docker-compose.byo.yml.)
+#
+# Requirements: an NVIDIA GPU with the driver + NVIDIA Container Toolkit
+# installed — nothing else; the cu124 wheels vendor the CUDA runtime. The
+# worker picks the device itself (ANALYZE_DEVICE defaults to auto: cuda when
+# torch sees a GPU, else cpu with a logged warning — a misconfigured host
+# degrades, not fails). To force CPU temporarily without dropping the overlay,
+# set ANALYZE_DEVICE=cpu in your root .env (the base compose passes it through).
+services:
+  analyzer:
+    image: ghcr.io/perminder-klair/subwave-analyzer-cuda:${SUBWAVE_VERSION:-latest}
+    # Local `docker compose build analyzer` with this overlay applied mirrors
+    # the published cuda image.
+    build:
+      args:
+        WITH_CLAP: 1
+        WITH_DEMUCS: 1
+        WITH_CUDA: 1
+    # Hand the GPU into the container (needs the NVIDIA Container Toolkit).
+    #
+    # The deploy.resources reservation below is the modern (CDI) path. On hosts
+    # where the NVIDIA runtime is registered in LEGACY mode, that reservation
+    # fails with "could not select device driver nvidia"; there, delete the
+    # `deploy:` block and instead use the legacy runtime:
+    #
+    #   runtime: nvidia
+    #   environment:
+    #     - NVIDIA_VISIBLE_DEVICES=all
+    #     - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -297,6 +297,10 @@ services:
       # admin toggles drive these per request.
       - ANALYZE_AUDIO_EMBEDDING=${ANALYZE_AUDIO_EMBEDDING:-}
       - ANALYZE_VOCAL_ACTIVITY=${ANALYZE_VOCAL_ACTIVITY:-}
+      # Torch device for CLAP/Demucs: auto (default) / cpu / cuda. Only
+      # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
+      # cpu-wheel images always resolve to cpu.
+      - ANALYZE_DEVICE=${ANALYZE_DEVICE:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -301,6 +301,9 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=${ANALYZE_DEVICE:-}
+      # Seconds of no requests before the cuda flavour drops its models out of
+      # VRAM (default 300; 0 = never). CPU images ignore it.
+      - ANALYZE_IDLE_UNLOAD_S=${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -251,6 +251,9 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=${ANALYZE_DEVICE:-}
+      # Seconds of no requests before the cuda flavour drops its models out of
+      # VRAM (default 300; 0 = never). CPU images ignore it.
+      - ANALYZE_IDLE_UNLOAD_S=${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -247,6 +247,10 @@ services:
     environment:
       - ANALYZE_AUDIO_EMBEDDING=${ANALYZE_AUDIO_EMBEDDING:-}
       - ANALYZE_VOCAL_ACTIVITY=${ANALYZE_VOCAL_ACTIVITY:-}
+      # Torch device for CLAP/Demucs: auto (default) / cpu / cuda. Only
+      # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
+      # cpu-wheel images always resolve to cpu.
+      - ANALYZE_DEVICE=${ANALYZE_DEVICE:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -350,6 +350,9 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=${ANALYZE_DEVICE:-}
+      # Seconds of no requests before the cuda flavour drops its models out of
+      # VRAM (default 300; 0 = never). CPU images ignore it.
+      - ANALYZE_IDLE_UNLOAD_S=${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -346,6 +346,10 @@ services:
       # pass. Usually unnecessary — the admin toggles drive these per request.
       - ANALYZE_AUDIO_EMBEDDING=${ANALYZE_AUDIO_EMBEDDING:-}
       - ANALYZE_VOCAL_ACTIVITY=${ANALYZE_VOCAL_ACTIVITY:-}
+      # Torch device for CLAP/Demucs: auto (default) / cpu / cuda. Only
+      # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
+      # cpu-wheel images always resolve to cpu.
+      - ANALYZE_DEVICE=${ANALYZE_DEVICE:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see

--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -151,7 +151,10 @@ ENV KOKORO_MODEL=/opt/kokoro/models/kokoro-v1.0.onnx \
 #
 # Version pins mirror the analyzer venv in docker/Dockerfile.analyzer — keep the
 # two in lockstep (same wheels, reproducible rebuilds). torch/torchaudio are held
-# at 2.6.0 off the CPU wheel index.
+# at 2.6.0 off the CPU wheel index. The AIO deliberately stays CPU-only (no
+# WITH_CUDA here): GPU analysis is the split stack's subwave-analyzer-cuda
+# flavour via the docker-compose.analyzer-gpu.yml overlay — a one-click
+# container with GPU passthrough is its own project.
 ARG WITH_CLAP=0
 ARG WITH_DEMUCS=0
 RUN python3 -m venv /opt/analyzer/venv && \

--- a/docker/Dockerfile.analyzer
+++ b/docker/Dockerfile.analyzer
@@ -20,14 +20,22 @@
 # long-lived subprocess. Wire contract (/health + /analyze) is identical to
 # tts-heavy's, so the controller treats the two interchangeably.
 #
-# Two published flavours (see .github/workflows/publish-images.yml):
+# Three published flavours (see .github/workflows/publish-images.yml):
 #   * subwave-analyzer        — LEAN (default), ~1.1GB, MULTI-ARCH (amd64+arm64).
 #       librosa + ffmpeg, no torch: bpm/key/intro/loudness. WITH_CLAP=0 WITH_DEMUCS=0.
 #   * subwave-analyzer-heavy  — CLAP + Demucs baked (~1.9GB), amd64-only.
 #       "sounds-like" embeddings + vocal ranges. WITH_CLAP=1 WITH_DEMUCS=1.
+#       CPU-only torch wheels.
+#   * subwave-analyzer-cuda   — heavy + NVIDIA CUDA torch (cu124), amd64-only.
+#       Same features as -heavy with CLAP/Demucs on the GPU. WITH_CUDA=1 flips
+#       the torch wheel index; the host needs only the NVIDIA driver +
+#       nvidia-container-toolkit (cu124 wheels vendor the CUDA runtime). Run it
+#       via the docker-compose.analyzer-gpu.yml overlay, which also adds the
+#       GPU device reservation. Several GB larger than -heavy (nvidia-*-cu12).
 # Operators switch to the heavy image with `ANALYZER_HEAVY=1` in .env (the
-# compose `analyzer` service pulls `subwave-analyzer${ANALYZER_HEAVY:+-heavy}`).
-# CPU-only torch wheels — no CUDA build. Models are NOT baked: the heavy worker
+# compose `analyzer` service pulls `subwave-analyzer${ANALYZER_HEAVY:+-heavy}`);
+# the cuda image is selected by the analyzer-gpu overlay instead (a device
+# reservation can't be toggled from .env). Models are NOT baked: the heavy worker
 # downloads CLAP/Demucs weights into the HF cache (HF_HOME) the first time the
 # analyze pass needs them; the compose files mount a named volume over that
 # cache so the download survives container recreates.
@@ -60,17 +68,27 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # from now resolves the SAME wheels (reproducible, no surprise major bumps).
 # These pins are the single source of truth for the analyzer venv — keep them in
 # lockstep with the mirrored analyzer block in docker/Dockerfile.aio. torch/
-# torchaudio come off the CPU wheel index and are held at 2.6.0 (the version
-# chatterbox pins in docker/Dockerfile.tts-heavy; keeps one CPU-torch repo-wide).
+# torchaudio are held at 2.6.0 (the version chatterbox pins in
+# docker/Dockerfile.tts-heavy; keeps one torch VERSION repo-wide). WITH_CUDA
+# only switches which 2.6.0 build is installed: the cpu wheel index (default)
+# or cu124 (the subwave-analyzer-cuda flavour — cu124 builds of 2.6.0 vendor
+# the CUDA runtime as nvidia-*-cu12 pip deps, so the base image stays slim).
 ARG WITH_CLAP=0
 ARG WITH_DEMUCS=0
+ARG WITH_CUDA=0
 ENV ANALYZER_HF_HOME=/opt/analyzer/hf-cache
-RUN python3 -m venv /opt/analyzer/venv && \
+RUN TORCH_INDEX="https://download.pytorch.org/whl/cpu" && \
+    if [ "$WITH_CUDA" = "1" ]; then TORCH_INDEX="https://download.pytorch.org/whl/cu124"; fi && \
+    python3 -m venv /opt/analyzer/venv && \
     /opt/analyzer/venv/bin/pip install --no-cache-dir --upgrade pip && \
     /opt/analyzer/venv/bin/pip install --no-cache-dir librosa==0.11.0 soundfile==0.14.0 pyloudnorm==0.2.0 && \
     if [ "$WITH_CLAP" = "1" ]; then \
+      # onnxruntime stays the CPU build even under WITH_CUDA: the ONNX path is
+      # the optional CLAP_MODEL_PATH custom-export route, and onnxruntime-gpu
+      # drags in a fragile CUDA/cuDNN version matrix. The default transformers
+      # path is what runs on the GPU.
       /opt/analyzer/venv/bin/pip install --no-cache-dir \
-        --index-url https://download.pytorch.org/whl/cpu \
+        --index-url "$TORCH_INDEX" \
         --extra-index-url https://pypi.org/simple \
         torch==2.6.0 transformers==5.13.0 onnxruntime==1.27.0 && \
       /opt/analyzer/venv/bin/python -c "import torch, transformers, onnxruntime" ; \
@@ -82,7 +100,7 @@ RUN python3 -m venv /opt/analyzer/venv && \
       # purge in the SAME layer — the lean image never pays for any of this.
       apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev && \
       /opt/analyzer/venv/bin/pip install --no-cache-dir \
-        --index-url https://download.pytorch.org/whl/cpu \
+        --index-url "$TORCH_INDEX" \
         --extra-index-url https://pypi.org/simple \
         torch==2.6.0 torchaudio==2.6.0 demucs==4.0.1 diffq==0.2.4 && \
       /opt/analyzer/venv/bin/python -c "import torch, demucs, diffq" && \

--- a/docs/gpu-tts.md
+++ b/docs/gpu-tts.md
@@ -5,6 +5,10 @@ CPU it pegs every core and still renders slower than real time, so a chatty
 station can fall behind. If you have an NVIDIA GPU, there are two ways to put it
 to work.
 
+> **Not TTS?** Library *analysis* (CLAP "sounds-like" + Demucs vocals) has its
+> own GPU path — the `docker-compose.analyzer-gpu.yml` overlay, no rebuild
+> needed. See [docs/tts-heavy.md → Heavy analysis on an NVIDIA GPU](tts-heavy.md#heavy-analysis-on-an-nvidia-gpu-cuda).
+
 | | Easy route (OpenAI layer) | Native route (sidecar on GPU) |
 |---|---|---|
 | Image rebuild | **None** | Required (CUDA PyTorch) |

--- a/docs/superpowers/specs/2026-07-19-issue-1099-analyzer-cuda-quiet-design.md
+++ b/docs/superpowers/specs/2026-07-19-issue-1099-analyzer-cuda-quiet-design.md
@@ -1,0 +1,260 @@
+# Issue #1099 — CUDA analyzer flavour + quiet-times analysis gate
+
+**Date:** 2026-07-19
+**Issue:** [#1099](https://github.com/perminder-klair/subwave/issues/1099) — Support Native GPU / CUDA Acceleration for subwave-analyzer-heavy (CLAP & Demucs)
+
+## Problem
+
+Operators with large libraries and an NVIDIA GPU run `ANALYZER_HEAVY=1` and find CLAP
+embeddings + Demucs vocal separation saturating their CPU with 0% GPU utilisation. This is
+by design today, not a bug:
+
+- `docker/Dockerfile.analyzer` installs torch/torchaudio from the **CPU wheel index**
+  (`--index-url https://download.pytorch.org/whl/cpu`, torch 2.6.0) — the wheels physically
+  lack CUDA kernels, so no compose device reservation can enable GPU.
+- The worker hardcodes CPU: `apply_model(..., device="cpu")`
+  (`controller/scripts/analyze_worker.py:602`); the transformers CLAP model is never moved
+  off the default CPU device; the ONNX path pins `CPUExecutionProvider`.
+
+The issue also asks for a **"run at quiet times"** option: defer/pause the library analysis
+while listeners are on air, resuming after the stream has been idle for N minutes. This
+matters even on CPU-only installs — analysis competes with local LLM/TTS for the same
+cores while the station is broadcasting.
+
+Two independent deliverables, one PR (closes #1099):
+
+- **Part A** — a published `subwave-analyzer-cuda` image flavour + device plumbing in the
+  analyze worker + a compose GPU overlay.
+- **Part B** — a listener-idle gate inside the analysis pass, driven by the existing
+  Icecast listener-count infrastructure.
+
+---
+
+## Part A — CUDA analyzer flavour
+
+### Approaches considered
+
+1. **`.env` var switching only** (e.g. `ANALYZER_CUDA=1` mangling the image suffix like
+   `ANALYZER_HEAVY` does). Rejected: compose variable substitution can't express the
+   *nested* heavy-vs-cuda choice cleanly, and — decisive — a GPU device reservation
+   **cannot be toggled from `.env`** in the base compose file at all. GPU wiring needs a
+   compose-level block either way.
+2. **Compose overlay file** (`docker-compose.gpu.yml`) that overrides the analyzer image
+   to `-cuda` AND adds the nvidia device reservation. **Chosen** — it's the standard
+   compose idiom, keeps the three main compose files untouched, works over both
+   `docker-compose.yml` and `docker-compose.byo.yml`, and puts image selection and GPU
+   wiring in one place so they can't drift apart.
+3. **CUDA in the existing heavy image.** Rejected: cu12 wheels + nvidia runtime libs add
+   multiple GB; the lean/heavy split exists precisely to keep the default pulls small.
+   CUDA is a third, opt-in flavour.
+
+### Dockerfile changes (`docker/Dockerfile.analyzer`)
+
+New build arg `WITH_CUDA=0`. Only meaningful alongside `WITH_CLAP=1`/`WITH_DEMUCS=1`:
+
+- The torch index URL becomes a variable:
+  `cpu` → `https://download.pytorch.org/whl/cpu` (unchanged default),
+  `WITH_CUDA=1` → `https://download.pytorch.org/whl/cu124`.
+  torch/torchaudio stay pinned at **2.6.0** (cu124 builds of 2.6.0 exist), preserving the
+  repo-wide version pin shared with chatterbox in `Dockerfile.tts-heavy`. The
+  "one CPU-torch repo-wide" invariant becomes "one torch *version* repo-wide"; the
+  Dockerfile comment is updated to say so.
+- Base image stays `python:3.11-slim-bookworm`. Modern cu124 wheels vendor the CUDA
+  runtime via `nvidia-*-cu12` pip dependencies, so no `nvidia/cuda` base is needed. Host
+  prerequisites are only the NVIDIA driver + nvidia-container-toolkit.
+- **ONNX CLAP stays CPU** (`onnxruntime`, `CPUExecutionProvider`). The ONNX path is the
+  optional `CLAP_MODEL_PATH` custom-export route; `onnxruntime-gpu` brings a fragile
+  CUDA/cuDNN version matrix for a path almost nobody uses. The default transformers path
+  is what gets CUDA. Noted as a possible follow-up.
+
+### Worker changes (`controller/scripts/analyze_worker.py`)
+
+Small, self-contained device plumbing:
+
+- `resolve_device()`: env `ANALYZE_DEVICE` ∈ `auto` (default) | `cpu` | `cuda`.
+  `auto` → `cuda` when `torch.cuda.is_available()` else `cpu`. `cuda` requested but
+  unavailable → log a warning, fall back to `cpu` (never fail the pass over device
+  selection). Log the resolved device + GPU name once at first model load.
+- `ClapEmbedder` (transformers mode): `self.model.to(device)` after load; input tensors
+  `.to(device)` in `embed()`; outputs already come back via `.cpu().numpy()`. Same for the
+  lazy text tower (`text_model`) and its inputs. ONNX mode unchanged (CPU).
+- `VocalActivityDetector`: `apply_model(self.model, wav.unsqueeze(0), device=device)` —
+  demucs handles the model/input transfer internally; the output already lands via
+  `.cpu().numpy()`.
+- CPU-only installs see zero behaviour change: torch without CUDA support returns
+  `is_available() == False`, `auto` resolves to `cpu`, and every call site passes the same
+  device it effectively used before.
+
+### Published image + CI (`.github/workflows/publish-images.yml`)
+
+New matrix entry:
+
+```
+- image: subwave-analyzer-cuda
+  dockerfile: docker/Dockerfile.analyzer
+  platforms: linux/amd64
+  build_args: |
+    WITH_CLAP=1
+    WITH_DEMUCS=1
+    WITH_CUDA=1
+```
+
+amd64-only (CUDA wheels are amd64; matches the heavy precedent). The cuda flavour **is**
+heavy + CUDA — there is no lean-cuda (librosa alone doesn't use torch, so a GPU lean image
+would be pointless).
+
+### Compose overlay (`docker-compose.gpu.yml`, new file at repo root)
+
+```yaml
+# GPU overlay — run the CUDA analyzer flavour on an NVIDIA host:
+#   docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
+# Requires the NVIDIA driver + nvidia-container-toolkit on the host.
+services:
+  analyzer:
+    image: ghcr.io/perminder-klair/subwave-analyzer-cuda:${SUBWAVE_VERSION:-latest}
+    build:
+      args:
+        WITH_CLAP: 1
+        WITH_DEMUCS: 1
+        WITH_CUDA: 1
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+```
+
+- Composes over the default file or the byo file identically. `ANALYZER_HEAVY` becomes
+  irrelevant when the overlay is applied (the image is overridden outright); README notes
+  this.
+- `mem_limit` stays at the inherited `${ANALYZER_MEM_LIMIT:-6g}` — CUDA host-side
+  allocations fit; operators can raise it in `.env` as today.
+- `ANALYZE_DEVICE` is not set anywhere by default (`auto` in the worker). The overlay
+  documents it in a comment for operators who want to force `cpu` temporarily.
+- Added to the CLI embed list (`cli/scripts/embed-assets.ts`) so `subwave init`
+  materialises the file; then `npm --prefix cli run embed-assets` and commit
+  `cli/src/assets.generated.ts` (CI verify job gates this). A `subwave start --gpu`
+  convenience flag is a follow-up, not in scope — CLI users can run the raw
+  `docker compose -f … -f …` line the overlay header documents.
+
+### Explicitly unchanged
+
+- **`Dockerfile.aio`** keeps its mirrored CPU analyzer block (a one-click Unraid container
+  with GPU passthrough is its own project); a comment points at the sidecar cuda flavour.
+- **tts-heavy** is TTS-only and stays CPU.
+- Model lazy-loading, weight downloads at runtime, the analyze protocol, and the
+  controller-side backend resolution (`ANALYZE_URL` → venv) are all untouched — the CUDA
+  image is a drop-in analyzer sidecar.
+
+---
+
+## Part B — quiet-times analysis gate
+
+### Approaches considered
+
+1. **Gate at scheduling time** (don't start a pass while listeners are on). Rejected: a
+   pass over a large library runs for hours — start-time gating does nothing when a
+   listener tunes in mid-run, which is the reporter's actual complaint.
+2. **Per-track gate inside `runAnalysisPass`**. **Chosen** — the pass is already a
+   resumable per-track loop with progress reporting; a check between tracks pauses within
+   seconds of a listener arriving and covers both entry points (server-spawned tagger
+   child AND standalone `npm run analyze`) with one implementation.
+
+### Settings (`controller/src/settings.ts`)
+
+Two new fields under the existing `audio` section, following the embeddings/vocalActivity
+precedent exactly:
+
+- `audio.analyzeQuietOnly: boolean` (default `false`) — pause the analysis pass while
+  anyone is listening. Env `ANALYZE_QUIET_ONLY=1` wins **on** (never off), mirroring
+  `ANALYZE_AUDIO_EMBEDDING`.
+- `audio.analyzeQuietMinutes: number` (default `10`, clamped 1–120) — how long the stream
+  must be continuously listener-free before the pass starts/resumes.
+
+Both entry points already call `settings.load()` before `runAnalysisPass`, so the child
+process reads the toggle without new plumbing.
+
+### Gate mechanics (`controller/src/music/analyze.ts` + new pure helper)
+
+At the top of the per-track loop (and once before the loop starts):
+
+1. If the gate is off → proceed (zero new work on the default path).
+2. Fetch the current listener count with a **one-shot** Icecast status check. The pass
+   runs in a child process with no `startListenerMonitor()` loop, so it calls
+   `listeners.refresh()` + `getListenerCount()` directly (`config.icecast.statusUrl` is
+   already reachable from the controller container/CLI env; the Safari dedup logic comes
+   for free).
+3. `count === 0` → track `quietSince`; proceed only once `now - quietSince ≥
+   analyzeQuietMinutes`. Any `count > 0` resets `quietSince`.
+4. Not quiet long enough → sleep 30s, re-check. While waiting, emit
+   `reportProgress({ phase: 'analyze', label: 'Waiting for quiet (N listening)', … })` and
+   a `[analyze]` console line (throttled to one per state change) so the admin Library
+   panel shows *why* the pass is stalled rather than a frozen counter.
+
+Decisions inside that flow:
+
+- **Unknown count = proceed.** `getListenerCount()` returns `null` when Icecast is
+  unreachable. The DJ gates fail toward "occupied" (a stats outage must never silence the
+  DJ); the quiet gate fails the **other** way — if Icecast is down, nobody is streaming
+  and CPU is free, and the worst case of a wrong guess is pre-#1099 behaviour (analysing
+  while someone listens). A stats outage must never stall the library scan forever.
+- **In-flight work finishes.** The gate sits between tracks; a listener arriving mid-track
+  lets that one track (seconds) complete. The one-ahead prefetch for track i+1 may already
+  be in flight when the gate pauses — it's a download to the shared volume, harmless; the
+  pause happens before the *compute* is requested.
+- **The gate applies whenever the toggle is on**, including admin-button "Analyse now"
+  runs. A pass is hours long; "explicit action bypasses the gate" (the manual-segment
+  precedent) doesn't transfer to a job that outlives the click. The operator's bypass is
+  turning the toggle off. The admin UI copy states this.
+- **Quiet-state timing is a pure helper** (`quietGateDecision({enabled, count, nowMs,
+  quietSinceMs, quietMinutes})` → `{action: 'proceed'|'wait', quietSinceMs}`), unit-pinned
+  alongside the existing pure-test pattern (`scripts/programme.test.ts` style) so the
+  reset/threshold edge cases are locked without needing Icecast in tests.
+
+### Admin UI (`web/components/admin/settings/LibrarySection.tsx`)
+
+A "Run analysis at quiet times" toggle + a quiet-minutes number input next to the existing
+audio embeddings / vocal activity controls, persisted through the same `/settings` route
+(which already round-trips the `audio` section — extend its validator with the two
+fields). Helper text: "Pauses library analysis while anyone is listening; resumes after
+the stream has been idle this many minutes. Applies to manual runs too."
+
+---
+
+## Error handling summary
+
+| Failure | Behaviour |
+| --- | --- |
+| `ANALYZE_DEVICE=cuda` but no GPU visible | Warn once, run on CPU; pass completes |
+| CUDA OOM / driver fault mid-track | Existing per-track try/catch records the track as failed, row stays NULL, next run retries; `mem_limit` OOM containment unchanged |
+| Icecast unreachable during quiet gate | Count `null` → treated as quiet → analysis proceeds |
+| Toggle flipped off mid-pause | Settings are read once per pass (the embeddings/vocal precedent), so the change applies from the next pass; to unstick a paused pass immediately, use the existing tagger Stop button |
+| Gate on, listeners never drop to 0 | Pass waits indefinitely with a visible "Waiting for quiet" progress label; Stop button remains the escape hatch |
+
+## Testing & verification
+
+- `npm run lint` in `controller/` and `web/` (the merge gate), plus the new pure test for
+  `quietGateDecision` wired into the existing controller test script.
+- **Local (this box, AMD GPU — no CUDA):** `docker build --build-arg WITH_CLAP=1
+  --build-arg WITH_DEMUCS=1 --build-arg WITH_CUDA=1 -f docker/Dockerfile.analyzer .`
+  proves pip resolution (building needs no GPU; only the overlay's device reservation
+  needs one at *run* time). Then `docker run` the built image without the reservation and
+  drive one analysis under `ANALYZE_DEVICE=auto` — proves the no-GPU fallback resolves to
+  CPU and the worker still analyses correctly (no regression).
+- **Quiet gate:** dev-stack run with the toggle on — confirm the pass pauses while a
+  listener is connected, shows the waiting label in the admin panel, and resumes after the
+  configured quiet window.
+- **Actual GPU execution cannot be verified in this environment** (no NVIDIA hardware).
+  The PR will say so and ask the issue reporter (who has the hardware and the motivation)
+  to validate `subwave-analyzer-cuda` from the PR build — mirroring how heavy-image
+  changes have been validated before.
+
+## Out of scope / follow-ups
+
+- `subwave start --gpu` CLI flag (overlay is embedded + documented; flag is convenience).
+- CUDA execution provider for the ONNX CLAP path (`onnxruntime-gpu`).
+- A CUDA AIO flavour.
+- ROCm/Metal backends (issue asks for CUDA; the device plumbing keeps the door open).
+- Scheduling analysis by wall-clock hours (the listener-idle signal subsumes it).

--- a/docs/superpowers/specs/2026-07-19-issue-1099-analyzer-cuda-quiet-design.md
+++ b/docs/superpowers/specs/2026-07-19-issue-1099-analyzer-cuda-quiet-design.md
@@ -230,7 +230,7 @@ the stream has been idle this many minutes. Applies to manual runs too."
 | `ANALYZE_DEVICE=cuda` but no GPU visible | Warn once, run on CPU; pass completes |
 | CUDA OOM / driver fault mid-track | Existing per-track try/catch records the track as failed, row stays NULL, next run retries; `mem_limit` OOM containment unchanged |
 | Icecast unreachable during quiet gate | Count `null` → treated as quiet → analysis proceeds |
-| Toggle flipped off mid-pause | Settings are read once per pass (the embeddings/vocal precedent), so the change applies from the next pass; to unstick a paused pass immediately, use the existing tagger Stop button |
+| Toggle flipped off mid-pause | The gate re-reads settings.json from disk on every check (revised after #1102 field testing — a pass runs for hours, so the once-per-pass read the embeddings/vocal toggles use was too stale here); a flip in either direction applies within one track / one 30s poll |
 | Gate on, listeners never drop to 0 | Pass waits indefinitely with a visible "Waiting for quiet" progress label; Stop button remains the escape hatch |
 
 ## Testing & verification

--- a/docs/superpowers/specs/2026-07-19-issue-1099-analyzer-cuda-quiet-design.md
+++ b/docs/superpowers/specs/2026-07-19-issue-1099-analyzer-cuda-quiet-design.md
@@ -39,7 +39,7 @@ Two independent deliverables, one PR (closes #1099):
    *nested* heavy-vs-cuda choice cleanly, and — decisive — a GPU device reservation
    **cannot be toggled from `.env`** in the base compose file at all. GPU wiring needs a
    compose-level block either way.
-2. **Compose overlay file** (`docker-compose.gpu.yml`) that overrides the analyzer image
+2. **Compose overlay file** (`docker-compose.analyzer-gpu.yml`) that overrides the analyzer image
    to `-cuda` AND adds the nvidia device reservation. **Chosen** — it's the standard
    compose idiom, keeps the three main compose files untouched, works over both
    `docker-compose.yml` and `docker-compose.byo.yml`, and puts image selection and GPU
@@ -103,11 +103,11 @@ amd64-only (CUDA wheels are amd64; matches the heavy precedent). The cuda flavou
 heavy + CUDA — there is no lean-cuda (librosa alone doesn't use torch, so a GPU lean image
 would be pointless).
 
-### Compose overlay (`docker-compose.gpu.yml`, new file at repo root)
+### Compose overlay (`docker-compose.analyzer-gpu.yml`, new file at repo root)
 
 ```yaml
 # GPU overlay — run the CUDA analyzer flavour on an NVIDIA host:
-#   docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
+#   docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d
 # Requires the NVIDIA driver + nvidia-container-toolkit on the host.
 services:
   analyzer:

--- a/docs/tts-heavy.md
+++ b/docs/tts-heavy.md
@@ -84,6 +84,27 @@ set `DOCKER_DEFAULT_PLATFORM=linux/amd64` — it runs under emulation (slow, but
 analysis is a one-time per-track pass). Model weights download lazily into the
 analyzer's HF cache the first time you actually run a sounds-like/vocals rescan.
 
+### Heavy analysis on an NVIDIA GPU (CUDA)
+
+On a host with an NVIDIA card, the heavy stack can run CLAP + Demucs on the GPU
+instead of pinning your CPU cores — a big speed-up on deep library ingestion.
+It's a compose overlay, not an `.env` toggle (a GPU device reservation can't be
+switched from `.env`):
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d
+```
+
+That swaps the `analyzer` service to the `subwave-analyzer-cuda` image (heavy +
+cu124 torch wheels) and hands it the GPU. Requirements: the NVIDIA driver +
+[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+— nothing else; the CUDA runtime rides inside the image. The worker picks the
+device itself (`ANALYZE_DEVICE=auto`): if the GPU isn't actually visible it logs
+a warning and falls back to CPU rather than failing the pass. `ANALYZER_HEAVY`
+is irrelevant while the overlay is applied — the image is overridden outright.
+(The AIO one-click container stays CPU-only; GPU analysis needs the split
+stack.)
+
 ---
 
 ## Voices: why they're off by default

--- a/docs/tts-heavy.md
+++ b/docs/tts-heavy.md
@@ -105,6 +105,14 @@ is irrelevant while the overlay is applied — the image is overridden outright.
 (The AIO one-click container stays CPU-only; GPU analysis needs the split
 stack.)
 
+Sharing the card with a local TTS or LLM? The worker plays nice: after ~5
+minutes with no analysis requests it drops its models out of VRAM and reloads
+them on the next request (`ANALYZE_IDLE_UNLOAD_S` in `.env` tunes the window;
+`0` keeps them resident). A few hundred MB of CUDA context remain until the
+analyzer container stops. Pair it with the **quiet times** toggle on the admin
+Library page and a long scan pauses — and frees the GPU — whenever listeners
+are tuned in.
+
 ---
 
 ## Voices: why they're off by default

--- a/docs/unraid.md
+++ b/docs/unraid.md
@@ -178,6 +178,13 @@ that isn't in the lean image (the `-heavy` images are ~1.9 GB):
 - **Split stack (Compose Manager).** Add `ANALYZER_HEAVY=1` to your **.env**,
   **Save**, then **Pull & Up** — the `analyzer` container re-pulls as
   `subwave-analyzer-heavy`.
+
+  **Got an NVIDIA card in the box?** Use the CUDA flavour instead — same
+  features, GPU-fast: add `docker-compose.analyzer-gpu.yml` from the repo as a
+  second compose file in the stack (it swaps the analyzer to
+  `subwave-analyzer-cuda` and reserves the GPU; `ANALYZER_HEAVY` is then
+  irrelevant). Needs the Unraid **Nvidia Driver** plugin; if the GPU isn't
+  visible the analyzer just falls back to CPU.
 - **All-in-one (one-click from Community Applications).** The heavy/lean split
   is baked into the image, so you switch by pointing the container at the heavy
   tag — **`ANALYZER_HEAVY` does nothing here** (it's the split-stack toggle):

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -117,7 +117,14 @@ interface SettingsResponse {
   tagger?: TaggerState;
   libraryStats?: LibraryStatsLite;
   // Only the slice this panel needs from the full settings payload.
-  values?: { audio?: { embeddings?: boolean; vocalActivity?: boolean } };
+  values?: {
+    audio?: {
+      embeddings?: boolean;
+      vocalActivity?: boolean;
+      analyzeQuietOnly?: boolean;
+      analyzeQuietMinutes?: number;
+    };
+  };
   // Daily-token-budget tier — drives the "budget nearly/already used" warning in
   // the Tagging modal. Absent on an old controller → treated as 'normal'.
   budget?: { mode: BudgetMode };
@@ -204,6 +211,10 @@ export default function LibraryPanel() {
   const [audioEnabled, setAudioEnabled] = useState<boolean | null>(null);
   // settings.audio.vocalActivity — null until the first /settings poll lands.
   const [vocalEnabled, setVocalEnabled] = useState<boolean | null>(null);
+  // settings.audio.analyzeQuietOnly + analyzeQuietMinutes — the quiet-times
+  // gate (#1099); null until the first /settings poll lands.
+  const [quietEnabled, setQuietEnabled] = useState<boolean | null>(null);
+  const [quietMins, setQuietMins] = useState<number | null>(null);
   // Daily-token-budget tier from /settings — null until the first slow poll lands.
   const [budgetMode, setBudgetMode] = useState<BudgetMode | null>(null);
   const [logOpen, setLogOpen] = useState(false);
@@ -377,6 +388,12 @@ export default function LibraryPanel() {
       if (j.values?.audio) {
         setAudioEnabled(!!j.values.audio.embeddings);
         setVocalEnabled(!!j.values.audio.vocalActivity);
+        setQuietEnabled(!!j.values.audio.analyzeQuietOnly);
+        setQuietMins(
+          typeof j.values.audio.analyzeQuietMinutes === 'number'
+            ? j.values.audio.analyzeQuietMinutes
+            : 10,
+        );
       }
       if (j.budget) setBudgetMode(j.budget.mode);
     } catch { /* transient */ }
@@ -1063,6 +1080,57 @@ export default function LibraryPanel() {
     }
   };
 
+  // Flip settings.audio.analyzeQuietOnly — the quiet-times gate (#1099): any
+  // analysis run pauses while listeners are tuned in, resuming after the idle
+  // window. Read once per pass, so it applies from the next run; env
+  // ANALYZE_QUIET_ONLY still wins "on".
+  const toggleQuiet = async () => {
+    if (quietEnabled == null) return;
+    setTaggerBusy(true);
+    try {
+      const r = await adminFetch('/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ audio: { analyzeQuietOnly: !quietEnabled } }),
+      });
+      const j = await r.json().catch(() => ({})) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `save failed (${r.status})`);
+      setQuietEnabled(!quietEnabled);
+      notify.ok(
+        !quietEnabled
+          ? 'quiet times on — analysis pauses while anyone is listening'
+          : 'quiet times off — analysis runs regardless of listeners',
+      );
+      void loadSettingsData();
+    } catch (err) {
+      notify.err(errorMessage(err));
+    } finally {
+      setTaggerBusy(false);
+    }
+  };
+
+  // Persist a new idle window for the quiet-times gate (minutes, 1–120) —
+  // committed by the panel's number input on blur/Enter.
+  const saveQuietMinutes = async (minutes: number) => {
+    setTaggerBusy(true);
+    try {
+      const r = await adminFetch('/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ audio: { analyzeQuietMinutes: minutes } }),
+      });
+      const j = await r.json().catch(() => ({})) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `save failed (${r.status})`);
+      setQuietMins(minutes);
+      notify.ok(`quiet window set — analysis resumes after ${minutes} min with no listeners`);
+      void loadSettingsData();
+    } catch (err) {
+      notify.err(errorMessage(err));
+    } finally {
+      setTaggerBusy(false);
+    }
+  };
+
   // Backfill Demucs vocal ranges on tracks that lack them — POST with vocal:true
   // so the analyze pass forces the vocal scope (#646).
   const vocalBackfill = async () => {
@@ -1206,6 +1274,10 @@ export default function LibraryPanel() {
         vocalEnabled={vocalEnabled}
         onToggleVocal={toggleVocal}
         onVocalBackfill={vocalBackfill}
+        quietEnabled={quietEnabled}
+        quietMinutes={quietMins}
+        onToggleQuiet={toggleQuiet}
+        onQuietMinutes={saveQuietMinutes}
         budgetMode={budgetMode}
       />
 

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -1082,8 +1082,9 @@ export default function LibraryPanel() {
 
   // Flip settings.audio.analyzeQuietOnly — the quiet-times gate (#1099): any
   // analysis run pauses while listeners are tuned in, resuming after the idle
-  // window. Read once per pass, so it applies from the next run; env
-  // ANALYZE_QUIET_ONLY still wins "on".
+  // window. The pass re-reads the toggle from disk on every check, so a flip
+  // takes effect mid-run within one track; env ANALYZE_QUIET_ONLY still wins
+  // "on".
   const toggleQuiet = async () => {
     if (quietEnabled == null) return;
     setTaggerBusy(true);

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -8,9 +8,10 @@
 // stays over there.
 
 import { Fragment, useEffect, useRef, useState } from 'react';
-import { Sparkles, Activity, Play, Square, Terminal, Loader2 } from 'lucide-react';
+import { Sparkles, Activity, Play, Square, Terminal, Loader2, Moon } from 'lucide-react';
 import { useDynamicStyle } from '../../hooks/useDynamicStyle';
 import { Btn, Eyebrow } from './ui';
+import { Input } from '../ui/input';
 import { cn } from '../../lib/cn';
 import LibraryTaggingModal from './LibraryTaggingModal';
 
@@ -210,6 +211,13 @@ interface TaggingPanelProps {
   // settings poll lands. Drives the "build WITH_DEMUCS=1" warning when on but
   // the backend can't produce vocal ranges.
   vocalEnabled: boolean | null;
+  // Quiet-times gate (#1099) — any analysis run pauses while listeners are
+  // tuned in, resuming after the idle window. Null until the settings poll.
+  quietEnabled: boolean | null;
+  quietMinutes: number | null;
+  onToggleQuiet: () => void;
+  // Persist a new idle window (minutes, 1–120) — committed on blur/Enter.
+  onQuietMinutes: (minutes: number) => void;
   // Daily-token-budget tier from /settings — null until the first slow poll lands.
   // Forwarded to the modal for its pre-run spend warning.
   budgetMode: BudgetMode | null;
@@ -357,6 +365,17 @@ export default function TaggingPanel(p: TaggingPanelProps) {
   // they stayed invisible until a repoll/refresh after enabling. Only the
   // analysis-state bits (vocalStatus) stay coverage-driven.
   const vocalOptedIn = p.vocalEnabled ?? vocalWanted;
+
+  // Quiet-times minutes input — validate + commit on blur/Enter; out-of-range
+  // or unparsable values snap back to the persisted setting rather than saving.
+  const commitQuietMinutes = (el: HTMLInputElement) => {
+    const v = Math.floor(Number(el.value));
+    if (!Number.isFinite(v) || v < 1 || v > 120) {
+      el.value = String(p.quietMinutes ?? 10);
+      return;
+    }
+    if (v !== p.quietMinutes) p.onQuietMinutes(v);
+  };
   const vocalOn = (vocalAnalyzed ?? 0) > 0;
   // Whether ANY tagging/analysis work has ever landed. On a completely virgin
   // library the honest affordance is the primary Start-tagging run, so the
@@ -852,6 +871,63 @@ export default function TaggingPanel(p: TaggingPanelProps) {
             )}
           </div>
         )}
+        {/* Quiet-times gate (#1099) — a pass-level control, not a coverage
+            dimension: while on, ANY analysis run (auto or manual) pauses when
+            listeners are tuned in and resumes after the idle window. Engine-
+            independent, so it renders regardless of analyzer capability. */}
+        <div className="flex flex-wrap items-center gap-x-3.5 gap-y-2 border-t border-dashed border-separator-strong pt-3">
+          <span className="caption flex items-center gap-2">
+            <Moon size={13} /> Quiet times · analyse only while idle
+          </span>
+          <span className="lib-opt-tag">optional</span>
+          <span className="caption mono-num !tracking-[0.04em]">
+            {p.quietEnabled == null
+              ? '…'
+              : p.quietEnabled
+                ? `on · after ${p.quietMinutes ?? 10} min with no listeners`
+                : 'off'}
+          </span>
+          <span className="ml-auto flex items-center gap-2">
+            {p.quietEnabled ? (
+              <label className="caption flex items-center gap-1.5 !normal-case">
+                idle
+                <Input
+                  className="mono-num h-7 w-16 px-2 text-xs"
+                  type="number"
+                  min={1}
+                  max={120}
+                  step={1}
+                  key={p.quietMinutes ?? 'unset'}
+                  defaultValue={p.quietMinutes ?? 10}
+                  disabled={p.busy}
+                  aria-label="Minutes with no listeners before analysis resumes"
+                  onBlur={(e) => commitQuietMinutes(e.currentTarget)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') (e.currentTarget as HTMLInputElement).blur();
+                  }}
+                />
+                min
+              </label>
+            ) : null}
+            <Btn
+              sm
+              onClick={p.onToggleQuiet}
+              disabled={p.busy || p.quietEnabled == null}
+              title={
+                p.quietEnabled
+                  ? 'Let analysis run while listeners are tuned in (the default).'
+                  : 'Pause analysis runs while anyone is listening — frees the CPU/GPU for the live station. Applies to manual runs too; a waiting run shows “Waiting for quiet”.'
+              }
+            >
+              {p.quietEnabled ? 'Disable' : 'Enable'}
+            </Btn>
+          </span>
+          <span className="caption basis-full !tracking-[0.04em] !normal-case">
+            {p.quietEnabled
+              ? 'Analysis runs pause while anyone is listening and resume once the stream has been idle this long. Applies to manual runs too — turn this off to analyse regardless.'
+              : 'Pause analysis while anyone is listening, so bulk scans never compete with the live station for CPU/GPU. Off by default.'}
+          </span>
+        </div>
         {audioStatus === 'pending-heavy' && p.audioEnabled ? (
           <div className="border border-[color-mix(in_oklab,var(--accent)_35%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] leading-[1.5] text-ink !normal-case">
             <b>Sounds-like is enabled — fingerprinting starts once your analyzer can do it.</b> The

--- a/web/components/manual/AcousticAnalysis.tsx
+++ b/web/components/manual/AcousticAnalysis.tsx
@@ -147,6 +147,14 @@ ANALYZER_HEAVY=1`}</CodeBlock>
             GPU analysis needs the split stack.
           </p>
         </div>
+        <p>
+          Sharing the card with a local TTS or LLM? After ~5 idle minutes the worker drops
+          its models out of VRAM and reloads them on the next request
+          (<code className="bs-code-inline">ANALYZE_IDLE_UNLOAD_S</code> tunes the window;{' '}
+          <code className="bs-code-inline">0</code> keeps them resident). Pair it with{' '}
+          <strong>Quiet times</strong> below and a long scan frees the GPU whenever
+          listeners are tuned in.
+        </p>
       </section>
 
       <section className="bs-section">

--- a/web/components/manual/AcousticAnalysis.tsx
+++ b/web/components/manual/AcousticAnalysis.tsx
@@ -116,6 +116,60 @@ ANALYZER_HEAVY=1`}</CodeBlock>
           backfill.
         </p>
       </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">ON AN NVIDIA GPU</p>
+        <h2>The CUDA flavour — same features, much faster.</h2>
+        <p>
+          Hosts with an NVIDIA card can run the heavy stack on the GPU instead of pinning
+          CPU cores — a big speed-up on deep library ingestion. It&rsquo;s a compose{' '}
+          <em>overlay</em>, not an <code className="bs-code-inline">.env</code> toggle (a
+          GPU reservation can&rsquo;t be switched from <code className="bs-code-inline">.env</code>):
+        </p>
+        <CodeBlock>{`docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d`}</CodeBlock>
+        <p>
+          That swaps the analyzer to the{' '}
+          <code className="bs-code-inline">subwave-analyzer-cuda</code> image — everything{' '}
+          <code className="bs-code-inline">-heavy</code> does, on CUDA —{' '}so{' '}
+          <code className="bs-code-inline">ANALYZER_HEAVY</code> is unnecessary while the
+          overlay is applied. Requirements: the NVIDIA driver + Container Toolkit on the
+          host, nothing else (the CUDA runtime rides inside the image). If the GPU
+          isn&rsquo;t actually visible, the worker logs a warning and falls back to CPU —
+          analysis never fails over device selection.
+        </p>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">NON-COMPOSE INSTALLS</div>
+          <p>
+            Point the analyzer container&rsquo;s image at{' '}
+            <code className="bs-code-inline">ghcr.io/perminder-klair/subwave-analyzer-cuda</code>{' '}
+            and pass the GPU through (<code className="bs-code-inline">--gpus all</code> or
+            your platform&rsquo;s equivalent). The AIO one-click container stays CPU-only —
+            GPU analysis needs the split stack.
+          </p>
+        </div>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">QUIET TIMES</p>
+        <h2>Let analysis yield to the live station.</h2>
+        <p>
+          A bulk pass over a large library runs for hours, and on a homelab it competes
+          with local LLM / TTS — and the stream itself — for the same CPU or GPU.{' '}
+          <strong>Quiet times</strong> (off by default, on the{' '}
+          <Link href="/admin/library">Library</Link> page next to the sounds-like and vocal
+          controls) pauses any analysis run while someone is listening, and resumes once
+          the stream has had no listeners for the configured window (default 10 minutes).
+        </p>
+        <p>
+          The gate checks between tracks, so a listener tuning in pauses the pass within
+          ~30 seconds; the running view shows{' '}
+          <em>&ldquo;Waiting for quiet&rdquo;</em> while it holds. It applies to manual{' '}
+          <strong>Analyse</strong> runs too — a pass outlives the click, so the bypass is
+          turning the toggle off, not the button. If the listener count can&rsquo;t be read
+          at all (Icecast down), analysis proceeds — a stats outage never stalls a library
+          scan.
+        </p>
+      </section>
     </ManualPage>
   );
 }

--- a/web/content/news/2026-07-21-analyzer-on-the-gpu.md
+++ b/web/content/news/2026-07-21-analyzer-on-the-gpu.md
@@ -1,0 +1,33 @@
+---
+title: Big library? Hand the analysis to your GPU
+date: 2026-07-21
+category: Feature
+author: The SUB/WAVE desk
+excerpt: A new CUDA analyzer image runs sounds-like and vocal analysis on an NVIDIA card, and a quiet-times switch pauses library scans while anyone is tuned in.
+---
+
+This one came straight from a listener request. Deep analysis, the sounds-like fingerprint and the vocal detection, chews through a big library one track at a time on the CPU. If that CPU is also running your local LLM and your voices, the scan and the station end up fighting over the same cores. Two fixes shipped together.
+
+## What's new
+
+There is a third analyzer image, `subwave-analyzer-cuda`. It has everything the heavy image has, but CLAP and Demucs run on an NVIDIA GPU instead of the CPU, and Demucs especially is much faster there.
+
+And for everyone, GPU or not, there is a new quiet-times switch. Turn it on and any analysis run pauses while someone is listening, then resumes once the stream has been empty for a while.
+
+## Put the card to work
+
+One command, no rebuild:
+
+```
+docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d
+```
+
+The overlay swaps the analyzer to the CUDA image and hands it the GPU. The host needs the NVIDIA driver and the Container Toolkit, nothing else. If the card is not visible, the analyzer notes it in the log and runs on CPU, so nothing breaks while you sort the toolkit out. You can drop `ANALYZER_HEAVY` from `.env` too, the overlay covers it.
+
+## Analyse at quiet times
+
+Open the Library page in admin. Next to the sounds-like and vocal controls there is a new row, Quiet times. Enable it and set the idle window, ten minutes by default. A running pass pauses between tracks the moment someone tunes in and shows "Waiting for quiet". Once the room has been empty long enough, it picks up where it left off. It applies to manual runs too, so turn it off if you want a scan right now regardless.
+
+## Why it helps
+
+A big collection gets its fingerprints without a week of pegged cores, and the scan never steals cycles from the broadcast. Turn on quiet times, kick off a full rescan, and the station does the homework in its own gaps.


### PR DESCRIPTION
Closes #1099.

Two independent deliverables from the issue, both behind explicit opt-ins — CPU installs see zero behaviour change.

## Part A — `subwave-analyzer-cuda` (GPU CLAP + Demucs)

The heavy analyzer has always shipped **CPU-only torch wheels**, so `deploy.resources` GPU reservations could never light up the GPU (and `FORCE_CUDA` was never a real flag). This adds a third published flavour and the plumbing to use it:

- **`docker/Dockerfile.analyzer`**: new `WITH_CUDA=1` build arg switches the torch index to **cu124** (torch/torchaudio stay pinned at 2.6.0 — one torch *version* repo-wide, in lockstep with chatterbox). Base image unchanged: cu124 wheels vendor the CUDA runtime, so the host needs only the NVIDIA driver + Container Toolkit.
- **`docker-compose.analyzer-gpu.yml`** (new, mirrors the `tts-heavy-gpu` overlay): swaps the `analyzer` service to `subwave-analyzer-cuda` and reserves the GPU. `docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d`. `ANALYZER_HEAVY` is irrelevant while applied. Embedded into the CLI assets so `subwave init` materialises it.
- **`analyze_worker.py`**: `resolve_device()` (`ANALYZE_DEVICE=auto|cpu|cuda`, auto default) — CLAP transformers model + text tower `.to(device)`, Demucs `apply_model(device=…)`. A cuda request with no visible GPU **warns and falls back to cpu**; the ONNX CLAP path deliberately stays CPU; the AIO stays CPU-only.
- **CI**: new `subwave-analyzer-cuda` matrix entry in `publish-images.yml` (amd64, ~9.9GB — the nvidia-cu12 libs).

## Part B — quiet-times gate ("run at quiet times")

Off by default. When enabled (`settings.audio.analyzeQuietOnly` + `analyzeQuietMinutes`, default 10 min; `ANALYZE_QUIET_ONLY=1` env wins on), the analysis pass **pauses between tracks while anyone is listening** and resumes once the stream has been listener-free for the window.

- Enforced inside `runAnalysisPass`, so it covers the server-spawned tagger child AND `npm run analyze`, and reacts within one 30s poll — start-time gating would do nothing for a pass that runs for hours. Manual "Analyse now" runs are gated too (the bypass is the toggle, not the button).
- Decision logic is a pure helper (`music/analyze-quiet-pure.ts`) pinned by `scripts/analyze-quiet.test.ts`. It **fails open** on an unknown listener count — the opposite direction from `djCallsAllowed()`: a stats outage must never stall a library scan; outage time accrues quiet so a recovery at 0 listeners doesn't pause a running pass in an empty room.
- Count comes from a new `listeners.probeListenerCount()` — same fetch + Safari dedupe as the monitor, minus the history append (a second writer in the child process would stripe duplicate sparkline rows).
- Admin Library panel grows a "Quiet times" row (toggle + idle-minutes input) next to the sounds-like/vocal controls; a waiting run shows "Waiting for quiet (N listening)".

Design spec: `docs/superpowers/specs/2026-07-19-issue-1099-analyzer-cuda-quiet-design.md`.

## Verification

- `npm run lint` clean in controller (0 errors) + web; CLI `tsc --noEmit` clean; `npm test` 37/37 controller test files incl. the new gate suite.
- Compose merges validated over both `docker-compose.yml` and `docker-compose.byo.yml` (rendered service shows the cuda image, build args, and device reservation); CLI embedded assets regenerated (verify job parity).
- **Built the cuda image locally** (amd64, no GPU): torch reports `2.6.0+cu124`, all heavy deps import, `resolve_device()` → cpu with the documented warning both on `auto` and explicit `cuda`. So the fallback path is proven; **actual GPU execution needs validation on NVIDIA hardware, which this machine doesn't have**.
- Quiet gate: `probeListenerCount()` verified live — `null` against an unreachable Icecast (fail-open) and a correct count against a stubbed status endpoint; pause/resume decision branches are unit-pinned.

## Ask for @Jaz666

Could you validate the CUDA flavour from this branch on your NVIDIA host?

```bash
git fetch && git checkout feat/1099-analyzer-cuda-quiet-times
# rebuild ALL services — the quiet-times gate lives in the controller image
# and its toggle in the web image, not just the analyzer
docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d --build
docker exec sub-wave-analyzer /opt/analyzer/venv/bin/python -c "import torch; print(torch.cuda.is_available())"
```

(Note the venv path — the earlier `python3 -c "import torch"` probe failed because torch lives in `/opt/analyzer/venv`, not system python.) Then run a rescan and watch `nvidia-smi` — the analyzer logs `analysis device: cuda (<GPU name>)` on first model load.


## Field-test follow-ups (2nd push)

Overnight testing on real NVIDIA hardware surfaced two problems, both fixed:

- **Quiet gate now reacts mid-scan.** The toggle was read once at pass start; a multi-hour scan never saw a mid-run flip. The gate now re-reads `settings.json` on every check, so flipping it lands within one track / one 30s poll. (The original test instructions above also only rebuilt the analyzer — the gate ships in the controller image; corrected.)
- **Idle GPU release.** The cuda worker dropped nothing from VRAM between passes, starving co-resident TTS/LLM. It now unloads CLAP + Demucs after 5 idle minutes (`ANALYZE_IDLE_UNLOAD_S`, `0` disables) and lazy-reloads on the next request. ~300–500MB of CUDA context remains until the container stops (torch limitation).