### PR TITLE
feat(admin): API key field for the openai-compatible cloud TTS provider

### DIFF
--- a/web/components/admin/settings/TtsSection.tsx
+++ b/web/components/admin/settings/TtsSection.tsx
@@ -305,8 +305,11 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
   const [cloudKeyInput, setCloudKeyInput] = useState('');
   const [cloudKeyTest, setCloudKeyTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
   const [cloudKeyTesting, setCloudKeyTesting] = useState(false);
+  // Compat servers don't use the OPENAI/ELEVENLABS env keys — their optional
+  // bearer lives in settings.tts.cloud.apiKey, so it rides the settings payload.
+  const [compatKeyInput, setCompatKeyInput] = useState('');
 
-  useEffect(() => { setCloudKeyInput(''); }, [form.tts.cloud.provider]);
+  useEffect(() => { setCloudKeyInput(''); setCompatKeyInput(''); }, [form.tts.cloud.provider]);
   useEffect(() => { setCloudKeyTest(null); }, [form.tts.cloud.provider]);
 
   const isCloudEngine = form.tts.defaultEngine === 'cloud';
@@ -403,6 +406,9 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
           voiceStyle: form.tts.cloud.voiceStyle,
           voiceSimilarityBoost: form.tts.cloud.voiceSimilarityBoost,
           voiceUseSpeakerBoost: form.tts.cloud.voiceUseSpeakerBoost,
+          // Only sent when the operator typed one — the controller keeps the
+          // stored key when the field is absent (or the 'set' sentinel).
+          ...(isCompat && compatKeyInput.trim() ? { apiKey: compatKeyInput.trim() } : {}),
         },
         remote: { url: form.tts.remote.url },
         // Per-engine voice-level trim. Always sent (server clamps + drops unknown
@@ -419,7 +425,6 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
       },
     });
     // Save cloud API key if typed -- goes to secrets.env, not settings.json
-    const isCompat = form.tts.cloud.provider === 'openai-compatible';
     if (!isCompat && cloudKeyInput.trim()) {
       const cloudKeyVar = form.tts.cloud.provider === 'elevenlabs' ? 'ELEVENLABS_API_KEY' : 'OPENAI_API_KEY';
       const ok = await saveKey(cloudKeyVar, cloudKeyInput);
@@ -457,6 +462,7 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
     voice?: string;
     model?: string;
     baseUrl?: string;
+    apiKey?: string; // redacted by GET /settings: 'set' when on file, '' otherwise
     voiceStability?: number;
     voiceStyle?: number;
     voiceSimilarityBoost?: number;
@@ -989,9 +995,21 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
               );
             })()}
             {isCompat && (
-              <div className="field-hint mt-3.5">
-                Most self-hosted servers accept any non-empty API key, so no env
-                var is required.
+              <div className="field">
+                <Label>API key</Label>
+                <Input
+                  type="password"
+                  value={compatKeyInput}
+                  placeholder={savedCloud.apiKey === 'set' ? '•••••• (on file)' : 'Optional'}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => setCompatKeyInput(e.target.value)}
+                  className="max-w-[360px]"
+                />
+                <div className="field-hint">
+                  Optional — only if your server requires one (e.g. SUB/WAVE DJ
+                  Brain); most self-hosted servers accept any non-empty key.
+                  Blank keeps the existing key. Saved with these settings, takes
+                  effect immediately.
+                </div>
               </div>
             )}
             <TtsGainField engineId="cloud" form={form} setForm={setForm} />


### PR DESCRIPTION
## What

Adds an optional **API key** password input to the `openai-compatible` branch of admin → Settings → TTS → Cloud. Web-only change — the controller already stores `tts.cloud.apiKey`, redacts it to `'set'` on GET, and sends it as the bearer in `cloud-speech.ts` (falling back to the literal `'unused'` only when empty).

## Why

Keyed compat upstreams — specifically the SUB/WAVE DJ Brain metered proxy — reject the `'unused'` placeholder with 401, and the admin UI had no way to enter a real key (the key field was gated behind `!isCompat`, and the compat branch instead asserted "no env var is required"). The only workaround was POSTing `tts.cloud.apiKey` to `/api/settings` by hand.

## How

- New `compatKeyInput` state, separate from the env-backed `cloudKeyInput` — compat never uses `OPENAI_API_KEY`/`ELEVENLABS_API_KEY`, so the field keys off the round-tripped `settings.tts.cloud.apiKey` sentinel instead of `data.env`: placeholder shows `•••••• (on file)` when `apiKey === 'set'`.
- `apiKey` is included in the save payload **only when the operator typed one**; absent (or `'set'`) leaves the stored key untouched, matching the controller's sentinel handling at `settings.ts:3553`. Blank keeps the existing key, per the field hint.
- Input resets on provider switch, mirroring the existing key input.
- The old "Most self-hosted servers accept any non-empty API key, so no env var is required" hint folds into the new field's hint ("Optional — only if your server requires one (e.g. SUB/WAVE DJ Brain)…").
- Dropped the `const isCompat` re-declaration inside `save()` — it would TDZ-shadow the component-level one now referenced in the payload above it.

Note: `settings.tts.cloud.apiKey` is already a shared slot also consulted by the OpenAI/ElevenLabs paths when set — pre-existing behavior (it was POST-settable before), unchanged here.

Related: this is the minimal unblock; the pending subwave-brain "One-field DJ Brain setup" BrainSection would supersede it for the DJ Brain case, but the field helps any keyed compat TTS server either way.

## Verification

`web` lint (`eslint . && tsc --noEmit`) passes clean.