### PR TITLE
feat(themes): add Factory built-in theme

### DIFF
--- a/controller/src/themes/builtin/factory.json
+++ b/controller/src/themes/builtin/factory.json
@@ -1,0 +1,15 @@
+{
+  "id": "factory",
+  "name": "Factory",
+  "description": "Industrial blueprint — warm-gray paper, charcoal ink, factory-orange accent.",
+  "mode": "light",
+  "tokens": {
+    "--bg": "#e9e9e6",
+    "--ink": "#1a1a16",
+    "--muted": "#6f6d66",
+    "--accent": "#f85000",
+    "--overlay": "rgba(26, 25, 22, 0.06)",
+    "--soft-border": "rgba(26, 25, 22, 0.16)",
+    "--field": "color-mix(in oklab, #e9e9e6 92%, #1a1a16)"
+  }
+}

--- a/web/components/manual/Themes.tsx
+++ b/web/components/manual/Themes.tsx
@@ -133,7 +133,7 @@ export default function Themes() {
         <p>
           The theme is set in the same admin section, each entry a card with a
           four-swatch row (paper, ink, accent, overlay) so you can read the
-          palette without leaving Settings. Five ship with the box:
+          palette without leaving Settings. Six ship with the box:
         </p>
         <ul className="bs-list">
           <li><strong>Classic Light</strong> &mdash; newsprint cream with hot vermilion ink. The default.</li>
@@ -141,6 +141,7 @@ export default function Themes() {
           <li><strong>Sunset</strong> &mdash; warm dusk: plum paper, peach ink, vermilion-magenta accent.</li>
           <li><strong>Vinyl</strong> &mdash; sepia &ldquo;warm record sleeve&rdquo; with mustard accent.</li>
           <li><strong>Cyberpunk</strong> &mdash; near-black paper, cyan ink, hot pink accent.</li>
+          <li><strong>Factory</strong> &mdash; industrial blueprint: warm-gray paper, charcoal ink, factory-orange accent.</li>
         </ul>
         <p className="text-muted">
           The palette recolours both the player <em>and</em> the admin console,


### PR DESCRIPTION
## What

Adds **Factory**, a sixth built-in theme — an industrial blueprint palette.

| Token | Value | Role |
|---|---|---|
| \`--bg\` | \`#e9e9e6\` | warm off-white paper |
| \`--ink\` | \`#1a1a16\` | charcoal near-black text |
| \`--accent\` | \`#f85000\` | factory orange (active states, buttons, playhead, meters) |
| \`--muted\` | \`#6f6d66\` | mid-gray secondary text |
| \`--overlay\` / \`--soft-border\` / \`--field\` | light-mode scrim, dark hairline, inset field |

Light mode. Text contrast ~14.8:1 (ink on paper); muted ~4.2:1.

## Why

A light, technical "spec-sheet" look — the current built-ins are mostly dark or warm/cream. Requested palette, sampled from a blueprint reference (light paper, dark ink, orange as accent rather than field).

## Changes

- \`controller/src/themes/builtin/factory.json\` — new built-in. The loader (\`themes.ts\`) auto-registers every JSON in that dir and reserves the id, so no code change is needed.
- \`web/components/manual/Themes.tsx\` — theme manual updated (five → six, added the Factory entry).

## Verification

- Loads as \`builtin=true\` after a controller restart; total built-in count is 6, no duplicate.
- \`web\` and \`controller\` \`npm run lint\` both pass (0 errors).