### PR TITLE
feat(personas): raise DJ soul cap from 1000 to 2000 chars (#1105)

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -10,7 +10,7 @@ import assert from 'node:assert/strict';
 import { z } from 'zod';
 import { generateText, APICallError } from 'ai';
 import { MockLanguageModelV3 } from 'ai/test';
-import { stripThinking, truncationError, extractJson, usageOf, perfOf, warningsOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded, isRateLimited, errReason, nearestId, isElevenLabsV3, snapV3Stability, modelTolerant, schemaHint, clipText } from '../src/llm/internal/core/pure.js';
+import { stripThinking, truncationError, extractJson, usageOf, perfOf, warningsOf, budgetMode, isUnreachable, isTransient, isQuotaOrAuthError, isUpstreamOverloaded, isRateLimited, errReason, nearestId, isElevenLabsV3, snapV3Stability, modelTolerant, schemaHint, clipText, soulBrief, SOUL_BRIEF_MAX } from '../src/llm/internal/core/pure.js';
 import { withDeadline, withTransientRetry, retryAfterMs } from '../src/llm/internal/core/retry.js';
 import { reasoningFor, needsToolCallObject, repeatPenaltyApplies, appliedNumCtx, appliedRepeatPenalty, forcedToolChoice } from '../src/llm/internal/provider/capabilities.js';
 import { agentPlan } from '../src/llm/internal/strategy/plan.js';
@@ -1204,6 +1204,34 @@ async function main() {
     assert.equal(clipText(undefined, 20), undefined);
     assert.equal(clipText(42, 20), 42);
     assert.equal(clipText(null, 20), null);
+  });
+
+  console.log('soulBrief (persona souls inlined where they are NOT the speaking seat):');
+  await test('passes a within-cap soul through untouched — the common case stays byte-identical', () => {
+    const soul = 'warm and dry, never corny, favours one good image over a list';
+    assert.equal(soulBrief(soul), soul);
+  });
+  await test('clamps a full-length soul well under the 2000-char settings cap', () => {
+    // A soul written up to SOUL_MAX is a character document; the cast blocks
+    // and the per-line TTS hint must not carry all of it.
+    const out = soulBrief('character detail '.repeat(140).trim()); // ~2000 chars
+    assert.ok(out.length <= SOUL_BRIEF_MAX + 1, `len ${out.length} <= ${SOUL_BRIEF_MAX}+ellipsis`);
+    assert.ok(out.endsWith('…'), 'abridged sketches are marked as abridged');
+  });
+  await test('collapses newlines so a multi-line soul cannot break a cast bullet', () => {
+    const out = soulBrief('line one\nline two\n\nline three');
+    assert.equal(out.includes('\n'), false);
+    assert.equal(out, 'line one line two line three');
+  });
+  await test('never leaves a dangling separator before the ellipsis', () => {
+    const out = soulBrief('alpha, bravo, charlie, delta,   echo', 14);
+    assert.equal(/[,;:.\s]…$/.test(out), false, `got ${JSON.stringify(out)}`);
+    assert.ok(out.endsWith('…'));
+  });
+  await test('coerces empty/absent souls to "" so callers can fall back to "no notes"', () => {
+    assert.equal(soulBrief(undefined), '');
+    assert.equal(soulBrief(null), '');
+    assert.equal(soulBrief('   '), '');
   });
 
   console.log('programme planSchema (the 207-char angle regression — a soft cap, clipped not rejected):');

--- a/controller/src/community/registry.ts
+++ b/controller/src/community/registry.ts
@@ -26,6 +26,7 @@ import {
   SCRIPT_LENGTHS,
   SHOW_MOODS,
   SHOW_ENERGY,
+  SOUL_MAX,
   type EraWindow,
 } from '../settings.js';
 
@@ -174,8 +175,11 @@ function normalizeSkill(raw: any): CommunitySkill | null {
 function normalizePersona(raw: any): CommunityPersona | null {
   const slug = str(raw?.slug);
   if (!SLUG_RE.test(slug)) return null;
+  // Must track SOUL_MAX: an over-cap soul would fail validatePersonasStrict at
+  // install time, so a catalog entry the operator can't actually install is
+  // dropped from the listing rather than offered and then rejected with a 400.
   const soul = str(raw?.soul);
-  if (!soul || soul.length > 1000) return null;
+  if (!soul || soul.length > SOUL_MAX) return null;
   return {
     slug,
     displayName: (str(raw?.displayName) || slug).slice(0, 40),

--- a/controller/src/llm/internal/core/pure.ts
+++ b/controller/src/llm/internal/core/pure.ts
@@ -835,3 +835,26 @@ export function clipText(s: unknown, max: number): unknown {
   const onWord = cut.replace(/\s+\S*$/, '');
   return (onWord.length >= max * 0.6 ? onWord : cut).trim();
 }
+
+// A persona `soul` is capped at settings.SOUL_MAX (2000) because it is injected
+// into every free-text generation call for THAT persona — the seat it was
+// written for, which earns the full length. Two consumers inline a soul where
+// that reasoning doesn't hold, and they clamp to this instead:
+//
+//   - the multi-voice cast blocks (prompts/banter.ts, prompts/programme.ts) —
+//     one entry per cast member (host + up to 3 guests), and the block exists
+//     to say who is in the room, not to hand each of them a character document;
+//   - the cloud-TTS delivery hint (speech/cloud-speech.ts) — rebuilt and sent
+//     on EVERY spoken line, and it only steers tone and pacing, so backstory
+//     and recurring bits enlarge each request without changing the read.
+//
+// Both want the opening sketch, which is where operators put the voice.
+// Whitespace is collapsed because a soul is multi-line free text and the cast
+// blocks are one-bullet-per-speaker — a raw newline would break the list. The
+// ellipsis marks the sketch as abridged rather than reading as a full stop.
+export const SOUL_BRIEF_MAX = 320;
+export function soulBrief(soul: unknown, max: number = SOUL_BRIEF_MAX): string {
+  const s = String(soul ?? '').trim().replace(/\s+/g, ' ');
+  if (s.length <= max) return s;
+  return `${String(clipText(s, max)).replace(/[,;:.]+$/, '')}…`;
+}

--- a/controller/src/llm/internal/prompts/banter.ts
+++ b/controller/src/llm/internal/prompts/banter.ts
@@ -7,6 +7,7 @@
 // can't invent a voice we can't render.
 
 import { z } from 'zod';
+import { soulBrief } from '../core/pure.js';
 import { djObject } from '../strategy/object.js';
 import { buildContextLines } from './context.js';
 
@@ -20,9 +21,12 @@ const BANTER_CONTEXT_FIELDS = ['date', 'clock', 'time', 'festival', 'show', 'lis
 const MIN_LINES = 3;
 const MAX_LINES = 6;
 
+// Souls ride as briefs, not in full: this block repeats once per cast member
+// (host + up to GUESTS_PER_SHOW guests), and it exists to tell the model who
+// is in the room, not to hand each one their whole character document.
 function castBlock(host: any, guests: any[]): string {
   const entry = (p: any, role: string) =>
-    `- ${p.id} — ${p.name} (${role}): ${String(p.soul || '').trim() || 'no notes'}`;
+    `- ${p.id} — ${p.name} (${role}): ${soulBrief(p.soul) || 'no notes'}`;
   return [entry(host, 'HOST'), ...guests.map((g: any) => entry(g, 'GUEST'))].join('\n');
 }
 

--- a/controller/src/llm/internal/prompts/generate.ts
+++ b/controller/src/llm/internal/prompts/generate.ts
@@ -7,7 +7,7 @@
 // generated draft round-trips through Save without surprises.
 
 import { z } from 'zod';
-import { FREQUENCIES, SCRIPT_LENGTHS, SHOW_MOODS, SHOW_ENERGY } from '../../../settings.js';
+import { FREQUENCIES, SCRIPT_LENGTHS, SHOW_MOODS, SHOW_ENERGY, SOUL_MAX } from '../../../settings.js';
 import { THEME_TOKEN_KEYS } from '../../../themes.js';
 import { djObject } from '../strategy/object.js';
 import { buildContextLines } from './context.js';
@@ -26,7 +26,7 @@ import { buildContextLines } from './context.js';
 const PERSONA_SCHEMA = z.object({
   name: z.string().min(1).max(40).describe('the DJ name shown in the player — 1-3 words, evocative, never generic like "DJ" or "Host"').catch('New DJ'),
   tagline: z.string().max(80).describe('a short one-line descriptor shown next to the name (e.g. "atmospheric & immersive"), 0-80 chars; "" if none fits').catch(''),
-  soul: z.string().min(1).max(1000).describe('the personality/voice sketch the DJ speaks with — tone, sensibility, quirks, the kind of imagery they reach for. Aim for 1-3 sentences; max 1000 chars. Concrete and specific, not a list of adjectives.').catch(''),
+  soul: z.string().min(1).max(SOUL_MAX).describe(`the personality/voice sketch the DJ speaks with — tone, sensibility, quirks, the kind of imagery they reach for. Aim for 1-3 sentences; max ${SOUL_MAX} chars. Concrete and specific, not a list of adjectives.`).catch(''),
   frequency: z.enum(FREQUENCIES as [string, ...string[]]).describe('how chatty, ascending: silent (never talks unprompted), quiet (rarely), moderate, chatty, aggressive (talks a lot)').catch('moderate'),
   scriptLength: z.enum(SCRIPT_LENGTHS as [string, ...string[]]).describe('how long each spoken bit runs, ascending: one-liner (a single line), concise (one or two lines), extended (longer riffs), storyteller (long-form)').catch('concise'),
   djMode: z.boolean().describe('true if this host works the desk like a real radio DJ — back-announces tracks, teases what is coming, more present; false for a quieter selector').catch(true),

--- a/controller/src/llm/internal/prompts/programme.ts
+++ b/controller/src/llm/internal/prompts/programme.ts
@@ -10,6 +10,7 @@
 
 import { z } from 'zod';
 import * as settings from '../../../settings.js';
+import { soulBrief } from '../core/pure.js';
 import { djText } from '../strategy/text.js';
 import { djObject } from '../strategy/object.js';
 import { djSystem, lengthPhrase } from './system.js';
@@ -215,9 +216,12 @@ export async function generateProgrammeExchange({
     })).min(MIN_EXCHANGE_LINES).max(MAX_EXCHANGE_LINES).describe('the exchange, in air order — the host opens and closes it'),
   });
 
+  // Briefs, not full souls — same reasoning as banter.ts castBlock: one entry
+  // per cast member, and the block places people in the room rather than
+  // handing each of them their whole character document.
   const castBlock = [
-    `- ${host.id} — ${host.name} (HOST): ${String(host.soul || '').trim() || 'no notes'}`,
-    ...guests.map((g: any) => `- ${g.id} — ${g.name} (GUEST): ${String(g.soul || '').trim() || 'no notes'}`),
+    `- ${host.id} — ${host.name} (HOST): ${soulBrief(host.soul) || 'no notes'}`,
+    ...guests.map((g: any) => `- ${g.id} — ${g.name} (GUEST): ${soulBrief(g.soul) || 'no notes'}`),
   ].join('\n');
 
   const lang = String(host?.language || '').trim();

--- a/controller/src/llm/internal/speech/cloud-speech.ts
+++ b/controller/src/llm/internal/speech/cloud-speech.ts
@@ -14,7 +14,7 @@ import crypto from 'node:crypto';
 import { config } from '../../../config.js';
 import * as settings from '../../../settings.js';
 import { transcodeAudio, hasFfmpeg } from '../../../audio/audio-import.js';
-import { isElevenLabsV3, snapV3Stability } from '../core/pure.js';
+import { isElevenLabsV3, snapV3Stability, soulBrief } from '../core/pure.js';
 
 // Default TTS model per cloud provider. A model id is provider-specific — an
 // OpenAI id like "gpt-4o-mini-tts" is invalid against ElevenLabs and vice
@@ -128,7 +128,11 @@ function deliveryHint(
   model: string,
 ): { instructions?: string; language?: string } {
   const lang = String(language || '').trim();
-  const character = String(soul || '').trim();
+  // Brief, not the full soul: this hint is rebuilt and sent on EVERY spoken
+  // line, and it only steers tone and pacing — the backstory and recurring
+  // bits further down a long soul can't change how a line is read, they just
+  // enlarge every request.
+  const character = soulBrief(soul);
   if (provider === 'openai') {
     // `instructions` only steers gpt-4o*-tts models; tts-1 / tts-1-hd ignore or
     // reject it, so don't send it there (a 400 would drop us to an English

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -712,6 +712,16 @@ const SKILL_SLUG_RE = /^[a-z0-9-]{1,40}$/;
 // Exported for the community-persona install route (routes/personas.ts), which
 // gives a friendly 409 before settings.update() would throw on an oversize roster.
 export const PERSONA_LIMIT = 48;
+// Persona `soul` — the character sketch injected into EVERY free-text DJ
+// generation call, so each char is a recurring per-call token cost. Bounded
+// rather than unbounded for that reason alone; nothing structural depends on
+// the number. Keep in lockstep with SOUL_MAX in
+// web/components/admin/personas/constants.ts and the AI-fill draft schema in
+// llm/internal/prompts/generate.ts. Consumers that inline a soul somewhere it
+// is NOT the speaking seat (the multi-voice cast blocks, the cloud-TTS
+// delivery hint) clamp it further at their own boundary — see soulBrief() in
+// llm/internal/core/pure.ts.
+export const SOUL_MAX = 2000;
 export const SHOWS_LIMIT = 64;
 // Guest co-hosts per show. Small on purpose: each guest is a full persona the
 // speaker rotation can hand a segment to, and past ~3 the host stops sounding
@@ -1710,7 +1720,7 @@ function normalizePersona(raw: unknown) {
   if (!raw || typeof raw !== 'object') return null;
   const r = raw as Record<string, unknown>;
   const name = typeof r.name === 'string' ? r.name.trim().slice(0, 40) : '';
-  const soul = typeof r.soul === 'string' ? r.soul.trim().slice(0, 1000) : '';
+  const soul = typeof r.soul === 'string' ? r.soul.trim().slice(0, SOUL_MAX) : '';
   if (!name || !soul) return null;
   // Avatar — stored as a bare basename. Reset to '' if the persisted value
   // doesn't match the strict basename shape, so a hand-edited settings.json
@@ -2687,8 +2697,8 @@ export function validatePersonasStrict(raw) {
     if (name.length < 1 || name.length > 40)
       throw new Error(`personas[${i}].name must be 1-40 chars`);
     const soul = String(item.soul ?? '').trim();
-    if (soul.length < 1 || soul.length > 1000)
-      throw new Error(`personas[${i}].soul must be 1-1000 chars`);
+    if (soul.length < 1 || soul.length > SOUL_MAX)
+      throw new Error(`personas[${i}].soul must be 1-${SOUL_MAX} chars`);
     const tagline = String(item.tagline ?? '').trim();
     if (tagline.length > 80) throw new Error(`personas[${i}].tagline must be 0-80 chars`);
     // language — optional free text ("Turkish", "Türkçe", …). Absent/empty →

--- a/web/components/admin/personas/PersonaIdentityCard.tsx
+++ b/web/components/admin/personas/PersonaIdentityCard.tsx
@@ -111,7 +111,7 @@ export function PersonaIdentityCard({
         <div className="field mt-4 lg:mt-0">
           <Label>Soul</Label>
           <Textarea
-            rows={9}
+            rows={14}
             value={persona.soul}
             placeholder="e.g. warm and dry, never corny, observant, favours one good image over a list"
             onChange={(e: ChangeEvent<HTMLTextAreaElement>) => update({ soul: e.target.value })}

--- a/web/components/admin/personas/constants.ts
+++ b/web/components/admin/personas/constants.ts
@@ -76,7 +76,7 @@ export const KOKORO_RE = /^[a-z]{2}_[a-z0-9]+$/;
 
 export const NAME_MAX = 40;
 export const TAGLINE_MAX = 80;
-export const SOUL_MAX = 1000;
+export const SOUL_MAX = 2000;
 export const LANGUAGE_MAX = 60;
 export const PROMPT_MIN = 50;
 export const PROMPT_MAX = 4000;


### PR DESCRIPTION
Closes #1105.

## What

Raises the persona `soul` cap from 1000 to **2000** chars.

The issue asked for 4000–5000. I went with 2000 deliberately: `soul` is injected into every free-text DJ generation call, so every char is a recurring per-call token cost the operator pays forever. 2000 doubles the room at half the ceiling cost. Worth knowing this may not fully close the requester's use case — 2000 is ~300 words, so a backstory *plus* quirks *plus* do's and don'ts will still be a squeeze. Easy to move again later; it's now two numbers.

## Why it's safe

Nothing structural depends on the number. The last raise (400→1000, `513bfe8e`, three weeks ago) bounded it for exactly one stated reason — per-call token cost — not a downstream limit. The issue author's read was correct.

## Five enforcement points, not four

The previous raise touched four. There's a fifth that has to track them, and it fails *silently*:

- `settings.ts` — loader slice + `validatePersonasStrict`
- `llm/internal/prompts/generate.ts` — AI-fill draft schema
- `web/components/admin/personas/constants.ts` — `SOUL_MAX`
- **`community/registry.ts`** — the catalog parser **dropped** any community persona whose soul exceeded the cap, so a richer catalog character just vanished from the listing rather than being offered and then 400'ing at install. This is the second-order symptom worth noting on the issue: the community catalog couldn't ship characters over 1000 either.

The controller-side value is now a single exported `SOUL_MAX` the other controller sites derive from.

## Two consumers that needed clamping

Both inline a soul somewhere it is **not** the speaking seat, and both would have absorbed the raise verbatim. They now clamp through a new `soulBrief()` built on the existing, already-tested `clipText()`:

- **Cast blocks** (`prompts/banter.ts`, `prompts/programme.ts`) repeat a full soul once per cast member (host + up to 3 guests). The block exists to say who's in the room, not to hand each of them a character document.
- **Cloud-TTS delivery hint** (`speech/cloud-speech.ts`) is rebuilt and sent on **every spoken line**, and only steers tone and pacing — backstory can't change how a line is read, it just enlarges each request. This one was arguably already mis-sized at 1000.

Souls under the brief cap pass through untouched, so short-soul installs stay byte-identical on both paths.

## Verification

- `controller`: `npm run lint` → 0 errors (551 pre-existing `any` warnings), `tsc --noEmit` clean
- `web`: `npm run lint` → clean
- `npm run test:llm` → all pass, including 5 new `soulBrief` cases pinned alongside `clipText` (pass-through, full-length clamp, newline collapse, no dangling separator before the ellipsis, empty coercion)

Not exercised on a live stack — no runtime behaviour changes for an existing under-1000 roster.