### PR TITLE
perf(web): stream /stations + /shows behind Suspense boundaries

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4642,6 +4642,65 @@ html.lite .sw-ripple-circle {
     min-width: 0;
 }
 
+/* Streaming placeholders — the Suspense fallbacks for the catalog-backed
+   regions of /stations and /shows. Both pages are force-dynamic and await a
+   remote catalog before rendering, so without a boundary the hero and the CTA
+   wait on the network too. These reserve the same footprint as the real thing
+   so nothing jumps when the data streams in. Ink-toned, no new colors. */
+.bs-skeleton {
+    display: block;
+    border-radius: 2px;
+    background: var(--separator-strong);
+    opacity: 0.5;
+    animation: bs-skeleton-pulse 1.6s ease-in-out infinite;
+}
+@keyframes bs-skeleton-pulse {
+    50% {
+        opacity: 0.22;
+    }
+}
+@media (prefers-reduced-motion: reduce) {
+    .bs-skeleton {
+        animation: none;
+    }
+}
+/* Matches .bs-stat-strip's display numeral, which sets that row's height. */
+.bs-skeleton-stat {
+    width: min(260px, 60%);
+    height: clamp(28px, 4vw, 44px);
+}
+/* Matches .bs-station-map's padded, rule-bounded block. The chart is a
+   width-100%/height-auto SVG on a 360x180 viewBox, so the placeholder has to
+   track the same 2:1 ratio — a fixed height lands ~200px short at desktop
+   widths and the whole page below the map jumps when the chart streams in. */
+.bs-skeleton-map {
+    width: 100%;
+    aspect-ratio: 360 / 180;
+}
+/* One card's worth of column, mirroring .bs-station-card's top rule. */
+.bs-skeleton-card {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-top: 20px;
+    border-top: 1px solid var(--separator-strong);
+    min-width: 0;
+}
+.bs-skeleton-line {
+    height: 12px;
+}
+.bs-skeleton-line-title {
+    height: clamp(19px, 2vw, 24px);
+    width: 70%;
+}
+/* Ragged widths so a run of cards reads as text, not as a barcode. */
+.bs-skeleton-line-wide {
+    width: 85%;
+}
+.bs-skeleton-line-short {
+    width: 40%;
+}
+
 /* Community-skill card — same newspaper-run column as the station grid, but a
    text-first entry: title + cadence, the DJ brief, context tags, credit line.
    Reuses .bs-stations-grid for layout. */

--- a/web/app/shows/page.tsx
+++ b/web/app/shows/page.tsx
@@ -1,6 +1,8 @@
+import { Suspense } from 'react';
 import { AnimatedLink } from '@/components/ui/animated-link';
 import CommunityShowCard from '@/components/shows/CommunityShowCard';
-import { fetchCommunityShows } from '@/lib/communityShows';
+import { CatalogGridSkeleton, CatalogStatSkeleton } from '@/components/ui/catalog-skeleton';
+import { fetchCommunityShows, type CommunityShow } from '@/lib/communityShows';
 import { pageMeta } from '@/lib/seo';
 import { showSubmitUrl } from '@/lib/repo';
 
@@ -21,9 +23,53 @@ export const dynamic = 'force-dynamic';
 const SUBMIT_URL = showSubmitUrl();
 const DOCS_URL = 'https://github.com/perminder-klair/subwave/blob/main/docs/community.md';
 
-export default async function CommunityShowsIndex() {
-  const shows = await fetchCommunityShows();
-  const count = shows.length;
+// The two catalog-backed regions. Each takes the in-flight promise rather than
+// calling fetchCommunityShows() itself, so the page issues exactly one request
+// no matter how many boundaries read it — no reliance on framework-level fetch
+// memoisation, which fetchCommunityShows opts out of with `cache: 'no-store'`.
+
+async function ShowsStat({ shows }: { shows: Promise<CommunityShow[]> }) {
+  const count = (await shows).length;
+  if (count === 0) return null;
+  return (
+    <p className="bs-stat-strip">
+      <span>
+        <strong>{count}</strong> {count === 1 ? 'show' : 'shows'} in the catalog
+      </span>
+    </p>
+  );
+}
+
+async function ShowsGrid({ shows }: { shows: Promise<CommunityShow[]> }) {
+  const list = await shows;
+  if (list.length === 0) {
+    return (
+      <p className="bs-news-empty">
+        No community shows to show yet — the catalog may still be loading, or this station
+        hasn&rsquo;t shipped one. Be the first to{' '}
+        <AnimatedLink href={SUBMIT_URL} className="bs-link">
+          share a show
+        </AnimatedLink>
+        .
+      </p>
+    );
+  }
+  return (
+    <ul className="bs-stations-grid">
+      {list.map((s) => (
+        <CommunityShowCard key={s.slug} show={s} />
+      ))}
+    </ul>
+  );
+}
+
+export default function CommunityShowsIndex() {
+  // Kick the controller call off but don't await it here: keeping this
+  // component synchronous is what lets the hero, the CTA and the closing note
+  // flush immediately while the catalog streams in behind the boundaries.
+  // fetchCommunityShows never rejects (it resolves to [] on any failure), so
+  // holding the promise unawaited can't produce an unhandled rejection.
+  const shows = fetchCommunityShows();
 
   return (
     <article>
@@ -38,13 +84,9 @@ export default async function CommunityShowsIndex() {
         </p>
       </header>
 
-      {count > 0 ? (
-        <p className="bs-stat-strip">
-          <span>
-            <strong>{count}</strong> {count === 1 ? 'show' : 'shows'} in the catalog
-          </span>
-        </p>
-      ) : null}
+      <Suspense fallback={<CatalogStatSkeleton />}>
+        <ShowsStat shows={shows} />
+      </Suspense>
 
       <div className="bs-station-cta">
         <p className="bs-station-cta-copy">Built a show worth sharing? Add it to the catalog.</p>
@@ -56,22 +98,9 @@ export default async function CommunityShowsIndex() {
         </AnimatedLink>
       </div>
 
-      {count > 0 ? (
-        <ul className="bs-stations-grid">
-          {shows.map((s) => (
-            <CommunityShowCard key={s.slug} show={s} />
-          ))}
-        </ul>
-      ) : (
-        <p className="bs-news-empty">
-          No community shows to show yet — the catalog may still be loading, or this station
-          hasn&rsquo;t shipped one. Be the first to{' '}
-          <AnimatedLink href={SUBMIT_URL} className="bs-link">
-            share a show
-          </AnimatedLink>
-          .
-        </p>
-      )}
+      <Suspense fallback={<CatalogGridSkeleton />}>
+        <ShowsGrid shows={shows} />
+      </Suspense>
 
       <p className="bs-stations-report">
         Installing is a two-tap job in your station&rsquo;s admin: open{' '}

--- a/web/app/stations/page.tsx
+++ b/web/app/stations/page.tsx
@@ -1,7 +1,13 @@
+import { Suspense } from 'react';
 import { AnimatedLink } from '@/components/ui/animated-link';
 import StationCard from '@/components/stations/StationCard';
 import StationMap from '@/components/stations/StationMap';
-import { getAllStations, getStationStats } from '@/lib/stations';
+import {
+  CatalogGridSkeleton,
+  CatalogMapSkeleton,
+  CatalogStatSkeleton,
+} from '@/components/ui/catalog-skeleton';
+import { getAllStations, stationStats, type Station } from '@/lib/stations';
 import { stationSubmitUrl, reportStationUrl, COMMUNITY_REPO_URL } from '@/lib/repo';
 import { pageMeta } from '@/lib/seo';
 
@@ -25,9 +31,56 @@ const SUBMIT_URL = stationSubmitUrl();
 // Report / takedown for a listed station — opens the report-station issue form.
 const REPORT_URL = reportStationUrl();
 
-export default async function StationsIndex() {
-  const stations = await getAllStations();
-  const { count, countries } = await getStationStats();
+// The catalog-backed regions. Each takes the in-flight promise rather than
+// calling getAllStations() itself, so one render issues one catalog fetch
+// regardless of how many boundaries read it.
+
+async function StationsStat({ stations }: { stations: Promise<Station[]> }) {
+  const { count, countries } = stationStats(await stations);
+  if (count === 0) return null;
+  return (
+    <p className="bs-stat-strip">
+      <span>
+        <strong>{count}</strong> {count === 1 ? 'station' : 'stations'}
+      </span>
+      <span aria-hidden="true" className="bs-stat-sep">
+        ·
+      </span>
+      <span>
+        <strong>{countries}</strong> {countries === 1 ? 'country' : 'countries'}
+      </span>
+    </p>
+  );
+}
+
+// The dot field is a 10k-sample computation on every request (this route is
+// force-dynamic), so it earns its own boundary — the hero shouldn't wait on it.
+async function StationsMap({ stations }: { stations: Promise<Station[]> }) {
+  return <StationMap stations={await stations} />;
+}
+
+async function StationsGrid({ stations }: { stations: Promise<Station[]> }) {
+  const all = await stations;
+  if (all.length === 0) {
+    return (
+      <p className="bs-news-empty">
+        No stations on the directory yet. Be the first to add yours above.
+      </p>
+    );
+  }
+  return (
+    <ul className="bs-stations-grid">
+      {all.map((s) => (
+        <StationCard key={s.slug} station={s} />
+      ))}
+    </ul>
+  );
+}
+
+export default function StationsIndex() {
+  // Started, not awaited — see the note on /shows. getAllStations degrades to
+  // an empty list on any catalog failure, so this never rejects.
+  const stations = getAllStations();
 
   return (
     <article>
@@ -40,21 +93,13 @@ export default async function StationsIndex() {
         </p>
       </header>
 
-      {count > 0 ? (
-        <p className="bs-stat-strip">
-          <span>
-            <strong>{count}</strong> {count === 1 ? 'station' : 'stations'}
-          </span>
-          <span aria-hidden="true" className="bs-stat-sep">
-            ·
-          </span>
-          <span>
-            <strong>{countries}</strong> {countries === 1 ? 'country' : 'countries'}
-          </span>
-        </p>
-      ) : null}
+      <Suspense fallback={<CatalogStatSkeleton />}>
+        <StationsStat stations={stations} />
+      </Suspense>
 
-      <StationMap stations={stations} />
+      <Suspense fallback={<CatalogMapSkeleton />}>
+        <StationsMap stations={stations} />
+      </Suspense>
 
       <div className="bs-station-cta">
         <p className="bs-station-cta-copy">
@@ -71,17 +116,9 @@ export default async function StationsIndex() {
         </AnimatedLink>
       </div>
 
-      {stations.length > 0 ? (
-        <ul className="bs-stations-grid">
-          {stations.map((s) => (
-            <StationCard key={s.slug} station={s} />
-          ))}
-        </ul>
-      ) : (
-        <p className="bs-news-empty">
-          No stations on the directory yet. Be the first to add yours above.
-        </p>
-      )}
+      <Suspense fallback={<CatalogGridSkeleton />}>
+        <StationsGrid stations={stations} />
+      </Suspense>
 
       <p className="bs-stations-report">
         Stations are run by their operators, not by SUB/WAVE.{' '}

--- a/web/components/ui/catalog-skeleton.tsx
+++ b/web/components/ui/catalog-skeleton.tsx
@@ -1,0 +1,46 @@
+// Suspense fallbacks for the catalog-backed broadsheet pages (/stations,
+// /shows). Those routes are force-dynamic and await a remote catalog before
+// they can render, so the data-dependent regions sit behind boundaries and the
+// static shell — hero, CTA, footer note — flushes first. These placeholders
+// reserve the real layout's footprint so the stream-in doesn't shift anything.
+//
+// Server components: no state, no effects, nothing to hydrate. Styles live with
+// the rest of the bs- broadsheet vocabulary in app/globals.css.
+
+/** Placeholder for the "12 stations · 7 countries" tally row. */
+export function CatalogStatSkeleton() {
+  return (
+    <p className="bs-stat-strip" role="status" aria-label="Loading catalog">
+      <span className="bs-skeleton bs-skeleton-stat" />
+    </p>
+  );
+}
+
+/** Placeholder for the dotted world chart on /stations. */
+export function CatalogMapSkeleton() {
+  return (
+    <div className="bs-station-map" aria-hidden="true">
+      <span className="bs-skeleton bs-skeleton-map" />
+    </div>
+  );
+}
+
+/**
+ * Placeholder run of cards in the newspaper-column grid. `count` should be
+ * roughly a screenful — enough to hold the scroll height steady, not so many
+ * that a short catalog collapses noticeably when the real list arrives.
+ */
+export function CatalogGridSkeleton({ count = 6 }: { count?: number }) {
+  return (
+    <ul className="bs-stations-grid" role="status" aria-label="Loading catalog">
+      {Array.from({ length: count }, (_, i) => (
+        <li key={i} className="bs-skeleton-card" aria-hidden="true">
+          <span className="bs-skeleton bs-skeleton-line-title" />
+          <span className="bs-skeleton bs-skeleton-line" />
+          <span className="bs-skeleton bs-skeleton-line bs-skeleton-line-wide" />
+          <span className="bs-skeleton bs-skeleton-line bs-skeleton-line-short" />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/lib/stations.ts
+++ b/web/lib/stations.ts
@@ -129,9 +129,11 @@ export async function getShowcaseStations(): Promise<ShowcaseStation[]> {
   return [local, ...all.filter((s) => s !== local)];
 }
 
-/** Header tallies: total stations + distinct countries. */
-export async function getStationStats(): Promise<{ count: number; countries: number }> {
-  const all = await getAllStations();
+/** Header tallies: total stations + distinct countries. Pure, over an
+ *  already-loaded list — /stations reads the directory once and streams it
+ *  into several Suspense boundaries, so a tally helper that re-entered
+ *  getAllStations() would mean a second catalog fetch per render. */
+export function stationStats(all: Station[]): { count: number; countries: number } {
   const countries = new Set(
     all.map((s) => (s.country || s.location || '').trim().toLowerCase()).filter(Boolean),
   );


### PR DESCRIPTION
## What

`/stations` and `/shows` are `force-dynamic` and awaited a remote catalog at the top of the page component, so the hero, the CTA and the closing note all waited on the network before anything painted.

Each page now kicks off its fetch **without awaiting it** and passes the single in-flight promise into async children behind `<Suspense>`. The static shell flushes immediately; the catalog streams in behind it.

## Why this shape

- Keeping the page component **synchronous** is what lets the shell flush first. One `await` at the top and nothing streams.
- Passing **one promise** into the children (rather than each child calling the loader) keeps it to one fetch per render. This matters concretely: `fetchCommunityShows` uses `cache: 'no-store'`, so it opts out of the fetch-level memoisation you'd otherwise be leaning on.
- `getStationStats()` → pure `stationStats(list)`. The old helper re-entered `getAllStations()` itself, which would have meant a second catalog fetch now that the tally renders in its own boundary.

## Measured

Cold request, catalog stubbed to a 3s response:

```
headers + hero + CTA + skeletons   +1274ms
station data                       +7043ms
```

Previously the page was blank for the full 7s. `<template>` / `$RC` chunks in the response confirm React deferred and resolved the boundaries out of order.

`/shows` benefits most — it hits the controller with `cache: 'no-store'` on every request, so it has no cache at all. `/stations` is ISR-cached (`revalidate: 1800`), so its win is on cold cache.

## Note on the map placeholder

First version used a fixed-height block for the world chart. The chart is a `width:100%/height:auto` SVG on a 360×180 viewBox, so it renders ~490px at desktop width — the placeholder landed ~200px short and everything below the map jumped on stream-in. Now it tracks the same 2:1 `aspect-ratio`. Caught by rendering it, not by review.

## Verification

- `npm run lint` (eslint + `tsc --noEmit`) clean
- Rendered both pages cold and warm; checked the loading state, the loaded state, and the degraded path (a stub slower than `fetchCommunityCatalog`'s own 8s `AbortSignal.timeout` correctly falls through to the empty state)

## Not in scope

`StationMap`'s comment claims the route is statically generated and the 10k-sample dot field is computed at build time. It isn't — the route is `force-dynamic`, so that runs per request. Streaming keeps it off the critical path, but it's still per-request CPU and worth its own look.
