### PR TITLE
feat(web): route error, 404 and loading boundaries

### DIFF
--- a/web/app/admin/error.tsx
+++ b/web/app/admin/error.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card, Btn } from '@/components/admin/ui';
+import { V3Alert } from '@/components/ui/alert';
+
+// Admin-scoped error boundary. It nests inside app/admin/layout.tsx, which
+// renders AdminShell — so when a panel throws, the console's own chrome (nav,
+// sign-in state) stays mounted and only the panel area is replaced. Without
+// this file the throw would bubble to app/error.tsx and take the whole console
+// down to the marketing-styled error page, which is both jarring and less
+// useful: the operator loses the nav they need to get to a working panel.
+//
+// Admin panels talk to the controller from the browser and already handle their
+// own fetch failures inline; what reaches this boundary is a render-time throw,
+// so the copy points at that rather than at "the controller is down".
+//
+// `reset()` re-renders without re-fetching; `router.refresh()` re-runs the
+// server render. Panels are client components that fetch on mount, so reset()
+// alone is usually enough here — refresh() is included so a stale RSC payload
+// can't pin the error in place.
+
+export default function AdminError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const router = useRouter();
+  const [retrying, setRetrying] = useState(false);
+
+  useEffect(() => {
+    console.error('[subwave] admin panel error', error.digest ?? '', error);
+  }, [error]);
+
+  function retry() {
+    setRetrying(true);
+    router.refresh();
+    reset();
+  }
+
+  return (
+    <Card>
+      <V3Alert tone="error" title="Panel failed to render">
+        <p>
+          This panel threw while rendering. Other panels are unaffected — use the nav to
+          move on, or retry below.
+        </p>
+        {error.digest ? (
+          <p className="mt-2">
+            Reference <code>{error.digest}</code>.
+          </p>
+        ) : null}
+        {error.message ? (
+          <p className="mt-2 break-words opacity-80">{error.message}</p>
+        ) : null}
+      </V3Alert>
+      <div className="mt-3">
+        <Btn sm tone="accent" onClick={retry} disabled={retrying}>
+          {retrying ? 'Retrying…' : 'Retry panel'}
+        </Btn>
+      </div>
+    </Card>
+  );
+}

--- a/web/app/error.tsx
+++ b/web/app/error.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import Masthead from '@/components/landing/Masthead';
+import StationFooter from '@/components/landing/StationFooter';
+
+// Site-wide error boundary. Wraps every page and nested layout below the root
+// layout; a throw in the root layout itself falls through to global-error.tsx.
+//
+// Most failures here are data failures rather than code failures: the public
+// pages read the local controller or the community catalog at request time, and
+// a self-hosted station can perfectly well have its controller down while the
+// web container is up. So the recovery path has to actually re-fetch.
+//
+// `reset()` alone does NOT re-fetch — it only clears the error state and
+// re-renders the same children, which for a failed server fetch just reproduces
+// the error. `router.refresh()` re-runs the server render, so the pair is what
+// makes "Try again" mean something. (Next 16.2 adds `unstable_retry` which does
+// both, but this ships to self-hosted operators and we'd rather not depend on
+// an `unstable_` export that can change under them.)
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const router = useRouter();
+  const [retrying, setRetrying] = useState(false);
+
+  useEffect(() => {
+    // Surfaces in the browser console and in the container logs when the throw
+    // happened during SSR. Server-thrown errors arrive with their message
+    // stripped in production, so `digest` is the only thing that ties this back
+    // to the controller log line.
+    console.error('[subwave] route error', error.digest ?? '', error);
+  }, [error]);
+
+  function retry() {
+    setRetrying(true);
+    router.refresh();
+    reset();
+  }
+
+  return (
+    <div className="min-h-screen bg-bg text-ink">
+      <Masthead />
+      <main className="bs-paper">
+        <article>
+          <header className="bs-news-hero">
+            <p className="bs-eyebrow">TRANSMISSION FAULT</p>
+            <h1>Something broke.</h1>
+            <p>
+              This page failed to render. That usually means the station&rsquo;s controller
+              is unreachable or still starting up — the broadcast itself is separate, so the
+              stream is probably still running.
+            </p>
+          </header>
+
+          <div className="bs-station-cta">
+            <p className="bs-station-cta-copy">
+              {retrying ? 'Retrying…' : 'Give it another go.'}
+            </p>
+            <button
+              type="button"
+              onClick={retry}
+              disabled={retrying}
+              className="bs-station-cta-link"
+            >
+              Try again
+            </button>
+            <Link href="/listen" className="bs-station-cta-help">
+              Back to the player
+            </Link>
+          </div>
+
+          {error.digest ? (
+            <p className="bs-stations-report">
+              If it keeps happening, quote this reference when you report it:{' '}
+              <code>{error.digest}</code>. It matches the corresponding line in the
+              container logs (<code>docker compose logs web</code>).
+            </p>
+          ) : (
+            <p className="bs-stations-report">
+              If it keeps happening, check <code>docker compose logs controller</code> —
+              this is most often the controller being down rather than a bug in the page.
+            </p>
+          )}
+        </article>
+        <StationFooter />
+      </main>
+    </div>
+  );
+}

--- a/web/app/global-error.tsx
+++ b/web/app/global-error.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useEffect } from 'react';
+
+// Last-resort boundary: catches throws in the ROOT layout itself, which
+// app/error.tsx cannot (error.js never wraps the layout in its own segment).
+//
+// This file REPLACES the root layout when it renders, which has three
+// consequences that shape everything below:
+//   1. It must supply its own <html> and <body>.
+//   2. globals.css is imported by the root layout, so none of it is available —
+//      no bs- classes, no Tailwind, no CSS custom properties. Styles are
+//      self-contained in the <style> block, using the real palette values
+//      copied from globals.css so this still reads as SUB/WAVE.
+//   3. The theme-init script lives in the root layout too, so the stored theme
+//      preference can't be read here. The palette follows the OS colour scheme
+//      via prefers-color-scheme instead, which is the closest honest match.
+//
+// Metadata exports aren't supported in a client component, so the tab title is
+// set with React's <title>.
+//
+// Styles go in a <style> element rather than style props: the repo's eslint
+// config forbids inline styles, and a stylesheet is the right shape for
+// media-query-driven theming anyway.
+
+const CSS = `
+  :root {
+    --ge-bg: #f3efe6;
+    --ge-ink: #161412;
+    --ge-muted: #7a736a;
+    --ge-accent: #d94b2a;
+    --ge-rule: rgba(0, 0, 0, 0.1);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --ge-bg: #100e0c;
+      --ge-ink: #ece6dc;
+      --ge-muted: #8a8278;
+      --ge-rule: rgba(255, 255, 255, 0.12);
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: var(--ge-bg);
+    color: var(--ge-ink);
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+    line-height: 1.6;
+  }
+  .ge-wrap { max-width: 34rem; width: 100%; }
+  .ge-brand {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--ge-muted);
+    margin: 0 0 20px;
+  }
+  .ge-brand b { color: var(--ge-accent); font-weight: 700; }
+  .ge-title {
+    font-size: clamp(32px, 7vw, 52px);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    line-height: 1.05;
+    margin: 0 0 16px;
+  }
+  .ge-body { margin: 0 0 28px; color: var(--ge-muted); }
+  .ge-actions { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
+  .ge-btn {
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+    padding: 10px 18px;
+    color: var(--ge-bg);
+    background: var(--ge-accent);
+    border: 1px solid var(--ge-accent);
+    border-radius: 2px;
+  }
+  .ge-link {
+    font-weight: 600;
+    color: var(--ge-ink);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+  .ge-ref {
+    margin: 28px 0 0;
+    padding-top: 16px;
+    border-top: 1px solid var(--ge-rule);
+    font-size: 13px;
+    color: var(--ge-muted);
+  }
+  .ge-ref code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+  }
+`;
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('[subwave] global error', error.digest ?? '', error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body>
+        <title>SUB/WAVE — transmission fault</title>
+        <style>{CSS}</style>
+        <div className="ge-wrap">
+          <p className="ge-brand">
+            SUB<b>/</b>WAVE
+          </p>
+          <h1 className="ge-title">Total signal loss.</h1>
+          <p className="ge-body">
+            The site shell itself failed to render, so there&rsquo;s nothing left to fall
+            back to. The broadcast runs in a separate container from this web UI, so the
+            stream is very likely still on air.
+          </p>
+          <div className="ge-actions">
+            {/* No router here — the root layout is gone, so a full document
+                reload is the only reliable recovery. reset() is still offered
+                first in case the failure was transient. */}
+            <button type="button" className="ge-btn" onClick={() => reset()}>
+              Try again
+            </button>
+            <a className="ge-link" href="/listen">
+              Reload the player
+            </a>
+          </div>
+          <p className="ge-ref">
+            {error.digest ? (
+              <>
+                Reference <code>{error.digest}</code> — matches the corresponding line in{' '}
+                <code>docker compose logs web</code>.
+              </>
+            ) : (
+              <>
+                Check <code>docker compose logs web</code> for the stack trace.
+              </>
+            )}
+          </p>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4642,6 +4642,65 @@ html.lite .sw-ripple-circle {
     min-width: 0;
 }
 
+/* Streaming placeholders — the Suspense fallbacks for the catalog-backed
+   regions of /stations and /shows. Both pages are force-dynamic and await a
+   remote catalog before rendering, so without a boundary the hero and the CTA
+   wait on the network too. These reserve the same footprint as the real thing
+   so nothing jumps when the data streams in. Ink-toned, no new colors. */
+.bs-skeleton {
+    display: block;
+    border-radius: 2px;
+    background: var(--separator-strong);
+    opacity: 0.5;
+    animation: bs-skeleton-pulse 1.6s ease-in-out infinite;
+}
+@keyframes bs-skeleton-pulse {
+    50% {
+        opacity: 0.22;
+    }
+}
+@media (prefers-reduced-motion: reduce) {
+    .bs-skeleton {
+        animation: none;
+    }
+}
+/* Matches .bs-stat-strip's display numeral, which sets that row's height. */
+.bs-skeleton-stat {
+    width: min(260px, 60%);
+    height: clamp(28px, 4vw, 44px);
+}
+/* Matches .bs-station-map's padded, rule-bounded block. The chart is a
+   width-100%/height-auto SVG on a 360x180 viewBox, so the placeholder has to
+   track the same 2:1 ratio — a fixed height lands ~200px short at desktop
+   widths and the whole page below the map jumps when the chart streams in. */
+.bs-skeleton-map {
+    width: 100%;
+    aspect-ratio: 360 / 180;
+}
+/* One card's worth of column, mirroring .bs-station-card's top rule. */
+.bs-skeleton-card {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-top: 20px;
+    border-top: 1px solid var(--separator-strong);
+    min-width: 0;
+}
+.bs-skeleton-line {
+    height: 12px;
+}
+.bs-skeleton-line-title {
+    height: clamp(19px, 2vw, 24px);
+    width: 70%;
+}
+/* Ragged widths so a run of cards reads as text, not as a barcode. */
+.bs-skeleton-line-wide {
+    width: 85%;
+}
+.bs-skeleton-line-short {
+    width: 40%;
+}
+
 /* Community-skill card — same newspaper-run column as the station grid, but a
    text-first entry: title + cadence, the DJ brief, context tags, credit line.
    Reuses .bs-stations-grid for layout. */

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4700,6 +4700,23 @@ html.lite .sw-ripple-circle {
 .bs-skeleton-line-short {
     width: 40%;
 }
+/* Hero placeholders for the route-level loading.tsx skeletons. Sized to the
+   real .bs-news-hero type so the headline doesn't jump when the page lands. */
+.bs-skeleton-eyebrow {
+    width: 160px;
+    height: 13px;
+    margin-bottom: 18px;
+}
+.bs-skeleton-headline {
+    width: min(520px, 90%);
+    height: clamp(38px, 8vw, 76px);
+    margin-bottom: 20px;
+}
+.bs-skeleton-prose {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
 
 /* Community-skill card — same newspaper-run column as the station grid, but a
    text-first entry: title + cadence, the DJ brief, context tags, credit line.

--- a/web/app/manual/loading.tsx
+++ b/web/app/manual/loading.tsx
@@ -1,0 +1,8 @@
+import BroadsheetPageSkeleton from '@/components/ui/page-skeleton';
+
+// Streams instantly on navigation and, more importantly, gives Next something
+// real to put in the <Link> prefetch for this force-dynamic route. See the note
+// in components/ui/page-skeleton.tsx.
+export default function Loading() {
+  return <BroadsheetPageSkeleton variant="article" />;
+}

--- a/web/app/not-found.tsx
+++ b/web/app/not-found.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+import Masthead from '@/components/landing/Masthead';
+import StationFooter from '@/components/landing/StationFooter';
+import { AnimatedLink } from '@/components/ui/animated-link';
+
+// The site-wide 404. Catches both unmatched URLs and any `notFound()` call that
+// doesn't have a closer not-found.tsx — today that's /news/[slug] for an
+// unknown dispatch slug.
+//
+// Without this file Next serves its own bare "404 | This page could not be
+// found" screen, which lands inside the root layout and so renders with none of
+// the broadsheet chrome. The root layout carries no masthead of its own (each
+// segment brings its own shell), so this page supplies the same Masthead +
+// bs-paper + StationFooter trio the news and stations shells use.
+//
+// Server component: no interactivity, so it stays out of the client bundle.
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-bg text-ink">
+      <Masthead />
+      <main className="bs-paper">
+        <article>
+          <header className="bs-news-hero">
+            <p className="bs-eyebrow">OFF THE DIAL</p>
+            <h1>Dead air.</h1>
+            <p>
+              There&rsquo;s nothing broadcasting on this frequency. The page you asked for
+              either moved, never existed, or was pulled from the schedule.
+            </p>
+          </header>
+
+          <p className="bs-news-empty">
+            The stream itself is unaffected — the music keeps playing whatever this page
+            does.
+          </p>
+
+          {/* Primary recovery only — the StationFooter below already renders
+              the full "Back Pages" index (dispatches, stations, skills,
+              personas, shows), so repeating those links here is noise. */}
+          <div className="bs-station-cta">
+            <p className="bs-station-cta-copy">Try one of these instead.</p>
+            <AnimatedLink href="/listen" variant="arrow" className="bs-station-cta-link">
+              Back to the player
+            </AnimatedLink>
+            <Link href="/manual" className="bs-station-cta-help">
+              Read the manual
+            </Link>
+          </div>
+        </article>
+        <StationFooter />
+      </main>
+    </div>
+  );
+}

--- a/web/app/personas/loading.tsx
+++ b/web/app/personas/loading.tsx
@@ -1,0 +1,8 @@
+import BroadsheetPageSkeleton from '@/components/ui/page-skeleton';
+
+// Streams instantly on navigation and, more importantly, gives Next something
+// real to put in the <Link> prefetch for this force-dynamic route. See the note
+// in components/ui/page-skeleton.tsx.
+export default function Loading() {
+  return <BroadsheetPageSkeleton variant="catalog" cards={6} />;
+}

--- a/web/app/personas/page.tsx
+++ b/web/app/personas/page.tsx
@@ -1,6 +1,8 @@
+import { Suspense } from 'react';
 import { AnimatedLink } from '@/components/ui/animated-link';
+import { CatalogGridSkeleton, CatalogStatSkeleton } from '@/components/ui/catalog-skeleton';
 import CommunityPersonaCard from '@/components/personas/CommunityPersonaCard';
-import { fetchCommunityPersonas } from '@/lib/communityPersonas';
+import { fetchCommunityPersonas, type CommunityPersona } from '@/lib/communityPersonas';
 import { pageMeta } from '@/lib/seo';
 import { personaSubmitUrl } from '@/lib/repo';
 
@@ -20,9 +22,47 @@ export const dynamic = 'force-dynamic';
 // share flow.
 const SUBMIT_URL = personaSubmitUrl();
 
-export default async function CommunityPersonasIndex() {
-  const personas = await fetchCommunityPersonas();
-  const count = personas.length;
+// Catalog-backed regions, each reading the one in-flight promise rather than
+// calling the loader itself — see the note in app/shows/page.tsx.
+
+async function PersonasStat({ personas }: { personas: Promise<CommunityPersona[]> }) {
+  const count = (await personas).length;
+  if (count === 0) return null;
+  return (
+    <p className="bs-stat-strip">
+      <span>
+        <strong>{count}</strong> {count === 1 ? 'persona' : 'personas'} in the catalog
+      </span>
+    </p>
+  );
+}
+
+async function PersonasGrid({ personas }: { personas: Promise<CommunityPersona[]> }) {
+  const list = await personas;
+  if (list.length === 0) {
+    return (
+      <p className="bs-news-empty">
+        No community personas to show yet — the catalog may still be loading, or this station
+        hasn&rsquo;t shipped one. Be the first to{' '}
+        <AnimatedLink href={SUBMIT_URL} className="bs-link">
+          share a persona
+        </AnimatedLink>
+        .
+      </p>
+    );
+  }
+  return (
+    <ul className="bs-stations-grid">
+      {list.map((p) => (
+        <CommunityPersonaCard key={p.slug} persona={p} />
+      ))}
+    </ul>
+  );
+}
+
+export default function CommunityPersonasIndex() {
+  // Started, not awaited, so the hero + CTA flush before the controller answers.
+  const personas = fetchCommunityPersonas();
 
   return (
     <article>
@@ -37,13 +77,9 @@ export default async function CommunityPersonasIndex() {
         </p>
       </header>
 
-      {count > 0 ? (
-        <p className="bs-stat-strip">
-          <span>
-            <strong>{count}</strong> {count === 1 ? 'persona' : 'personas'} in the catalog
-          </span>
-        </p>
-      ) : null}
+      <Suspense fallback={<CatalogStatSkeleton />}>
+        <PersonasStat personas={personas} />
+      </Suspense>
 
       <div className="bs-station-cta">
         <p className="bs-station-cta-copy">Dreamed up a DJ worth sharing? Add them to the catalog.</p>
@@ -55,22 +91,9 @@ export default async function CommunityPersonasIndex() {
         </AnimatedLink>
       </div>
 
-      {count > 0 ? (
-        <ul className="bs-stations-grid">
-          {personas.map((p) => (
-            <CommunityPersonaCard key={p.slug} persona={p} />
-          ))}
-        </ul>
-      ) : (
-        <p className="bs-news-empty">
-          No community personas to show yet — the catalog may still be loading, or this station
-          hasn&rsquo;t shipped one. Be the first to{' '}
-          <AnimatedLink href={SUBMIT_URL} className="bs-link">
-            share a persona
-          </AnimatedLink>
-          .
-        </p>
-      )}
+      <Suspense fallback={<CatalogGridSkeleton />}>
+        <PersonasGrid personas={personas} />
+      </Suspense>
 
       <p className="bs-stations-report">
         Installing is a two-tap job in your station&rsquo;s admin: open{' '}

--- a/web/app/setup/loading.tsx
+++ b/web/app/setup/loading.tsx
@@ -1,0 +1,8 @@
+import BroadsheetPageSkeleton from '@/components/ui/page-skeleton';
+
+// Streams instantly on navigation and, more importantly, gives Next something
+// real to put in the <Link> prefetch for this force-dynamic route. See the note
+// in components/ui/page-skeleton.tsx.
+export default function Loading() {
+  return <BroadsheetPageSkeleton variant="article" />;
+}

--- a/web/app/shows/loading.tsx
+++ b/web/app/shows/loading.tsx
@@ -1,0 +1,8 @@
+import BroadsheetPageSkeleton from '@/components/ui/page-skeleton';
+
+// Streams instantly on navigation and, more importantly, gives Next something
+// real to put in the <Link> prefetch for this force-dynamic route. See the note
+// in components/ui/page-skeleton.tsx.
+export default function Loading() {
+  return <BroadsheetPageSkeleton variant="catalog" cards={6} />;
+}

--- a/web/app/shows/page.tsx
+++ b/web/app/shows/page.tsx
@@ -1,6 +1,8 @@
+import { Suspense } from 'react';
 import { AnimatedLink } from '@/components/ui/animated-link';
 import CommunityShowCard from '@/components/shows/CommunityShowCard';
-import { fetchCommunityShows } from '@/lib/communityShows';
+import { CatalogGridSkeleton, CatalogStatSkeleton } from '@/components/ui/catalog-skeleton';
+import { fetchCommunityShows, type CommunityShow } from '@/lib/communityShows';
 import { pageMeta } from '@/lib/seo';
 import { showSubmitUrl } from '@/lib/repo';
 
@@ -21,9 +23,53 @@ export const dynamic = 'force-dynamic';
 const SUBMIT_URL = showSubmitUrl();
 const DOCS_URL = 'https://github.com/perminder-klair/subwave/blob/main/docs/community.md';
 
-export default async function CommunityShowsIndex() {
-  const shows = await fetchCommunityShows();
-  const count = shows.length;
+// The two catalog-backed regions. Each takes the in-flight promise rather than
+// calling fetchCommunityShows() itself, so the page issues exactly one request
+// no matter how many boundaries read it — no reliance on framework-level fetch
+// memoisation, which fetchCommunityShows opts out of with `cache: 'no-store'`.
+
+async function ShowsStat({ shows }: { shows: Promise<CommunityShow[]> }) {
+  const count = (await shows).length;
+  if (count === 0) return null;
+  return (
+    <p className="bs-stat-strip">
+      <span>
+        <strong>{count}</strong> {count === 1 ? 'show' : 'shows'} in the catalog
+      </span>
+    </p>
+  );
+}
+
+async function ShowsGrid({ shows }: { shows: Promise<CommunityShow[]> }) {
+  const list = await shows;
+  if (list.length === 0) {
+    return (
+      <p className="bs-news-empty">
+        No community shows to show yet — the catalog may still be loading, or this station
+        hasn&rsquo;t shipped one. Be the first to{' '}
+        <AnimatedLink href={SUBMIT_URL} className="bs-link">
+          share a show
+        </AnimatedLink>
+        .
+      </p>
+    );
+  }
+  return (
+    <ul className="bs-stations-grid">
+      {list.map((s) => (
+        <CommunityShowCard key={s.slug} show={s} />
+      ))}
+    </ul>
+  );
+}
+
+export default function CommunityShowsIndex() {
+  // Kick the controller call off but don't await it here: keeping this
+  // component synchronous is what lets the hero, the CTA and the closing note
+  // flush immediately while the catalog streams in behind the boundaries.
+  // fetchCommunityShows never rejects (it resolves to [] on any failure), so
+  // holding the promise unawaited can't produce an unhandled rejection.
+  const shows = fetchCommunityShows();
 
   return (
     <article>
@@ -38,13 +84,9 @@ export default async function CommunityShowsIndex() {
         </p>
       </header>
 
-      {count > 0 ? (
-        <p className="bs-stat-strip">
-          <span>
-            <strong>{count}</strong> {count === 1 ? 'show' : 'shows'} in the catalog
-          </span>
-        </p>
-      ) : null}
+      <Suspense fallback={<CatalogStatSkeleton />}>
+        <ShowsStat shows={shows} />
+      </Suspense>
 
       <div className="bs-station-cta">
         <p className="bs-station-cta-copy">Built a show worth sharing? Add it to the catalog.</p>
@@ -56,22 +98,9 @@ export default async function CommunityShowsIndex() {
         </AnimatedLink>
       </div>
 
-      {count > 0 ? (
-        <ul className="bs-stations-grid">
-          {shows.map((s) => (
-            <CommunityShowCard key={s.slug} show={s} />
-          ))}
-        </ul>
-      ) : (
-        <p className="bs-news-empty">
-          No community shows to show yet — the catalog may still be loading, or this station
-          hasn&rsquo;t shipped one. Be the first to{' '}
-          <AnimatedLink href={SUBMIT_URL} className="bs-link">
-            share a show
-          </AnimatedLink>
-          .
-        </p>
-      )}
+      <Suspense fallback={<CatalogGridSkeleton />}>
+        <ShowsGrid shows={shows} />
+      </Suspense>
 
       <p className="bs-stations-report">
         Installing is a two-tap job in your station&rsquo;s admin: open{' '}

--- a/web/app/skills/loading.tsx
+++ b/web/app/skills/loading.tsx
@@ -1,0 +1,8 @@
+import BroadsheetPageSkeleton from '@/components/ui/page-skeleton';
+
+// Streams instantly on navigation and, more importantly, gives Next something
+// real to put in the <Link> prefetch for this force-dynamic route. See the note
+// in components/ui/page-skeleton.tsx.
+export default function Loading() {
+  return <BroadsheetPageSkeleton variant="catalog" cards={6} />;
+}

--- a/web/app/skills/page.tsx
+++ b/web/app/skills/page.tsx
@@ -1,6 +1,8 @@
+import { Suspense } from 'react';
 import { AnimatedLink } from '@/components/ui/animated-link';
 import CommunitySkillCard from '@/components/skills/CommunitySkillCard';
-import { fetchCommunitySkills } from '@/lib/communitySkills';
+import { CatalogGridSkeleton, CatalogStatSkeleton } from '@/components/ui/catalog-skeleton';
+import { fetchCommunitySkills, type CommunitySkill } from '@/lib/communitySkills';
 import { skillSubmitUrl } from '@/lib/repo';
 import { pageMeta } from '@/lib/seo';
 
@@ -22,9 +24,47 @@ const REPO = 'https://github.com/perminder-klair/subwave';
 const SUBMIT_URL = skillSubmitUrl();
 const DOCS_URL = `${REPO}/blob/main/docs/custom-skills.md`;
 
-export default async function CommunitySkillsIndex() {
-  const skills = await fetchCommunitySkills();
-  const count = skills.length;
+// Catalog-backed regions, each reading the one in-flight promise rather than
+// calling the loader itself — see the note in app/shows/page.tsx.
+
+async function SkillsStat({ skills }: { skills: Promise<CommunitySkill[]> }) {
+  const count = (await skills).length;
+  if (count === 0) return null;
+  return (
+    <p className="bs-stat-strip">
+      <span>
+        <strong>{count}</strong> {count === 1 ? 'skill' : 'skills'} in the catalog
+      </span>
+    </p>
+  );
+}
+
+async function SkillsGrid({ skills }: { skills: Promise<CommunitySkill[]> }) {
+  const list = await skills;
+  if (list.length === 0) {
+    return (
+      <p className="bs-news-empty">
+        No community skills to show yet — the catalog may still be loading, or this station
+        hasn&rsquo;t shipped one. Be the first to{' '}
+        <AnimatedLink href={SUBMIT_URL} className="bs-link">
+          share a skill
+        </AnimatedLink>
+        .
+      </p>
+    );
+  }
+  return (
+    <ul className="bs-stations-grid">
+      {list.map((s) => (
+        <CommunitySkillCard key={s.slug} skill={s} />
+      ))}
+    </ul>
+  );
+}
+
+export default function CommunitySkillsIndex() {
+  // Started, not awaited, so the hero + CTA flush before the controller answers.
+  const skills = fetchCommunitySkills();
 
   return (
     <article>
@@ -39,13 +79,9 @@ export default async function CommunitySkillsIndex() {
         </p>
       </header>
 
-      {count > 0 ? (
-        <p className="bs-stat-strip">
-          <span>
-            <strong>{count}</strong> {count === 1 ? 'skill' : 'skills'} in the catalog
-          </span>
-        </p>
-      ) : null}
+      <Suspense fallback={<CatalogStatSkeleton />}>
+        <SkillsStat skills={skills} />
+      </Suspense>
 
       <div className="bs-station-cta">
         <p className="bs-station-cta-copy">Made a segment worth sharing? Add it to the catalog.</p>
@@ -57,22 +93,9 @@ export default async function CommunitySkillsIndex() {
         </AnimatedLink>
       </div>
 
-      {count > 0 ? (
-        <ul className="bs-stations-grid">
-          {skills.map((s) => (
-            <CommunitySkillCard key={s.slug} skill={s} />
-          ))}
-        </ul>
-      ) : (
-        <p className="bs-news-empty">
-          No community skills to show yet — the catalog may still be loading, or this station
-          hasn&rsquo;t shipped one. Be the first to{' '}
-          <AnimatedLink href={SUBMIT_URL} className="bs-link">
-            share a skill
-          </AnimatedLink>
-          .
-        </p>
-      )}
+      <Suspense fallback={<CatalogGridSkeleton />}>
+        <SkillsGrid skills={skills} />
+      </Suspense>
 
       <p className="bs-stations-report">
         Installing is a two-tap job in your station&rsquo;s admin: open{' '}

--- a/web/app/stations/loading.tsx
+++ b/web/app/stations/loading.tsx
@@ -1,0 +1,8 @@
+import BroadsheetPageSkeleton from '@/components/ui/page-skeleton';
+
+// Streams instantly on navigation and, more importantly, gives Next something
+// real to put in the <Link> prefetch for this force-dynamic route. See the note
+// in components/ui/page-skeleton.tsx.
+export default function Loading() {
+  return <BroadsheetPageSkeleton variant="catalog" cards={6} />;
+}

--- a/web/app/stations/page.tsx
+++ b/web/app/stations/page.tsx
@@ -1,7 +1,13 @@
+import { Suspense } from 'react';
 import { AnimatedLink } from '@/components/ui/animated-link';
 import StationCard from '@/components/stations/StationCard';
 import StationMap from '@/components/stations/StationMap';
-import { getAllStations, getStationStats } from '@/lib/stations';
+import {
+  CatalogGridSkeleton,
+  CatalogMapSkeleton,
+  CatalogStatSkeleton,
+} from '@/components/ui/catalog-skeleton';
+import { getAllStations, stationStats, type Station } from '@/lib/stations';
 import { stationSubmitUrl, reportStationUrl, COMMUNITY_REPO_URL } from '@/lib/repo';
 import { pageMeta } from '@/lib/seo';
 
@@ -25,9 +31,56 @@ const SUBMIT_URL = stationSubmitUrl();
 // Report / takedown for a listed station — opens the report-station issue form.
 const REPORT_URL = reportStationUrl();
 
-export default async function StationsIndex() {
-  const stations = await getAllStations();
-  const { count, countries } = await getStationStats();
+// The catalog-backed regions. Each takes the in-flight promise rather than
+// calling getAllStations() itself, so one render issues one catalog fetch
+// regardless of how many boundaries read it.
+
+async function StationsStat({ stations }: { stations: Promise<Station[]> }) {
+  const { count, countries } = stationStats(await stations);
+  if (count === 0) return null;
+  return (
+    <p className="bs-stat-strip">
+      <span>
+        <strong>{count}</strong> {count === 1 ? 'station' : 'stations'}
+      </span>
+      <span aria-hidden="true" className="bs-stat-sep">
+        ·
+      </span>
+      <span>
+        <strong>{countries}</strong> {countries === 1 ? 'country' : 'countries'}
+      </span>
+    </p>
+  );
+}
+
+// The dot field is a 10k-sample computation on every request (this route is
+// force-dynamic), so it earns its own boundary — the hero shouldn't wait on it.
+async function StationsMap({ stations }: { stations: Promise<Station[]> }) {
+  return <StationMap stations={await stations} />;
+}
+
+async function StationsGrid({ stations }: { stations: Promise<Station[]> }) {
+  const all = await stations;
+  if (all.length === 0) {
+    return (
+      <p className="bs-news-empty">
+        No stations on the directory yet. Be the first to add yours above.
+      </p>
+    );
+  }
+  return (
+    <ul className="bs-stations-grid">
+      {all.map((s) => (
+        <StationCard key={s.slug} station={s} />
+      ))}
+    </ul>
+  );
+}
+
+export default function StationsIndex() {
+  // Started, not awaited — see the note on /shows. getAllStations degrades to
+  // an empty list on any catalog failure, so this never rejects.
+  const stations = getAllStations();
 
   return (
     <article>
@@ -40,21 +93,13 @@ export default async function StationsIndex() {
         </p>
       </header>
 
-      {count > 0 ? (
-        <p className="bs-stat-strip">
-          <span>
-            <strong>{count}</strong> {count === 1 ? 'station' : 'stations'}
-          </span>
-          <span aria-hidden="true" className="bs-stat-sep">
-            ·
-          </span>
-          <span>
-            <strong>{countries}</strong> {countries === 1 ? 'country' : 'countries'}
-          </span>
-        </p>
-      ) : null}
+      <Suspense fallback={<CatalogStatSkeleton />}>
+        <StationsStat stations={stations} />
+      </Suspense>
 
-      <StationMap stations={stations} />
+      <Suspense fallback={<CatalogMapSkeleton />}>
+        <StationsMap stations={stations} />
+      </Suspense>
 
       <div className="bs-station-cta">
         <p className="bs-station-cta-copy">
@@ -71,17 +116,9 @@ export default async function StationsIndex() {
         </AnimatedLink>
       </div>
 
-      {stations.length > 0 ? (
-        <ul className="bs-stations-grid">
-          {stations.map((s) => (
-            <StationCard key={s.slug} station={s} />
-          ))}
-        </ul>
-      ) : (
-        <p className="bs-news-empty">
-          No stations on the directory yet. Be the first to add yours above.
-        </p>
-      )}
+      <Suspense fallback={<CatalogGridSkeleton />}>
+        <StationsGrid stations={stations} />
+      </Suspense>
 
       <p className="bs-stations-report">
         Stations are run by their operators, not by SUB/WAVE.{' '}

--- a/web/components/ui/catalog-skeleton.tsx
+++ b/web/components/ui/catalog-skeleton.tsx
@@ -1,0 +1,46 @@
+// Suspense fallbacks for the catalog-backed broadsheet pages (/stations,
+// /shows). Those routes are force-dynamic and await a remote catalog before
+// they can render, so the data-dependent regions sit behind boundaries and the
+// static shell — hero, CTA, footer note — flushes first. These placeholders
+// reserve the real layout's footprint so the stream-in doesn't shift anything.
+//
+// Server components: no state, no effects, nothing to hydrate. Styles live with
+// the rest of the bs- broadsheet vocabulary in app/globals.css.
+
+/** Placeholder for the "12 stations · 7 countries" tally row. */
+export function CatalogStatSkeleton() {
+  return (
+    <p className="bs-stat-strip" role="status" aria-label="Loading catalog">
+      <span className="bs-skeleton bs-skeleton-stat" />
+    </p>
+  );
+}
+
+/** Placeholder for the dotted world chart on /stations. */
+export function CatalogMapSkeleton() {
+  return (
+    <div className="bs-station-map" aria-hidden="true">
+      <span className="bs-skeleton bs-skeleton-map" />
+    </div>
+  );
+}
+
+/**
+ * Placeholder run of cards in the newspaper-column grid. `count` should be
+ * roughly a screenful — enough to hold the scroll height steady, not so many
+ * that a short catalog collapses noticeably when the real list arrives.
+ */
+export function CatalogGridSkeleton({ count = 6 }: { count?: number }) {
+  return (
+    <ul className="bs-stations-grid" role="status" aria-label="Loading catalog">
+      {Array.from({ length: count }, (_, i) => (
+        <li key={i} className="bs-skeleton-card" aria-hidden="true">
+          <span className="bs-skeleton bs-skeleton-line-title" />
+          <span className="bs-skeleton bs-skeleton-line" />
+          <span className="bs-skeleton bs-skeleton-line bs-skeleton-line-wide" />
+          <span className="bs-skeleton bs-skeleton-line bs-skeleton-line-short" />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/components/ui/page-skeleton.tsx
+++ b/web/components/ui/page-skeleton.tsx
@@ -1,0 +1,71 @@
+// Broadsheet page skeleton — the body of every `loading.tsx` on the public
+// pages. The segment layouts already supply the chrome (Masthead + bs-paper +
+// StationFooter, via NewsShell / StationsShell / the inlined equivalents), and
+// loading.tsx nests inside its layout, so this renders the article body only.
+//
+// Why these files exist at all: the public pages are `force-dynamic`, and a
+// dynamic route with no loading boundary has nothing for Next to prerender into
+// a prefetch. Measured on a production build, the prefetch for /news came back
+// as 183 bytes with `null` where the page segment goes — the request fires but
+// carries no UI, so clicking the link still blocks on a full round trip. A
+// loading.tsx gives the prefetch something real to cache, which is what makes
+// the navigation paint immediately.
+//
+// Server components: no state, nothing to hydrate.
+
+function Line({ className }: { className?: string }) {
+  return <span className={`bs-skeleton bs-skeleton-line ${className ?? ''}`} />;
+}
+
+/** Hero block: eyebrow, headline, two lines of standfirst. */
+function HeroSkeleton() {
+  return (
+    <header className="bs-news-hero">
+      <span className="bs-skeleton bs-skeleton-eyebrow" />
+      <span className="bs-skeleton bs-skeleton-headline" />
+      <Line />
+      <Line className="bs-skeleton-line-wide" />
+    </header>
+  );
+}
+
+/**
+ * `catalog` mirrors the community index pages (stat strip → grid of cards);
+ * `article` mirrors a prose page (manual, setup, a dispatch).
+ */
+export default function BroadsheetPageSkeleton({
+  variant = 'catalog',
+  cards = 6,
+}: {
+  variant?: 'catalog' | 'article';
+  cards?: number;
+}) {
+  return (
+    <article aria-busy="true">
+      <HeroSkeleton />
+      {variant === 'catalog' ? (
+        <>
+          <p className="bs-stat-strip" role="status" aria-label="Loading">
+            <span className="bs-skeleton bs-skeleton-stat" />
+          </p>
+          <ul className="bs-stations-grid">
+            {Array.from({ length: cards }, (_, i) => (
+              <li key={i} className="bs-skeleton-card" aria-hidden="true">
+                <span className="bs-skeleton bs-skeleton-line-title" />
+                <Line />
+                <Line className="bs-skeleton-line-wide" />
+                <Line className="bs-skeleton-line-short" />
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : (
+        <div className="bs-skeleton-prose" role="status" aria-label="Loading">
+          {Array.from({ length: 10 }, (_, i) => (
+            <Line key={i} className={i % 4 === 3 ? 'bs-skeleton-line-short' : undefined} />
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -192,6 +192,20 @@ export default defineConfig([
     },
   },
 
+  // Exemption for the global error boundary. app/global-error.tsx REPLACES the
+  // root layout when it renders, so globals.css — which the root layout imports
+  // — is not loaded. It therefore has to ship its own self-contained stylesheet
+  // and its own ge-* class names, which by design exist nowhere else. Adding
+  // them to globals.css to satisfy the linter would be dead CSS in the one file
+  // that can never reach them.
+  {
+    files: ['app/global-error.tsx'],
+    rules: {
+      'better-tailwindcss/no-unknown-classes': 'off',
+      'better-tailwindcss/enforce-consistent-class-order': 'off',
+    },
+  },
+
   // Exemptions for the Library Observatory — a full-bleed data-art view ported
   // from a Claude Design prototype (web/app/observatory + components/
   // observatory). Its styling is intrinsically dynamic: SVG node positions,

--- a/web/lib/stations.ts
+++ b/web/lib/stations.ts
@@ -129,9 +129,11 @@ export async function getShowcaseStations(): Promise<ShowcaseStation[]> {
   return [local, ...all.filter((s) => s !== local)];
 }
 
-/** Header tallies: total stations + distinct countries. */
-export async function getStationStats(): Promise<{ count: number; countries: number }> {
-  const all = await getAllStations();
+/** Header tallies: total stations + distinct countries. Pure, over an
+ *  already-loaded list — /stations reads the directory once and streams it
+ *  into several Suspense boundaries, so a tally helper that re-entered
+ *  getAllStations() would mean a second catalog fetch per render. */
+export function stationStats(all: Station[]): { count: number; countries: number } {
   const countries = new Set(
     all.map((s) => (s.country || s.location || '').trim().toLowerCase()).filter(Boolean),
   );


### PR DESCRIPTION
> **Stacked.** Base is `chore/next-16` (#1127), which is itself based on develop, and this branch also merges in `perf/stream-catalog-pages` (#1126). Merge order: **#1126 → #1127 → this**. GitHub will retarget this to develop once the parents land.

The app had **no `error.tsx`, `not-found.tsx`, `global-error.tsx` or `loading.tsx` anywhere** across its 50 routes. This adds them, and extends #1126's streaming treatment to the two catalog pages it didn't cover.

## 404

`notFound()` was already being called for an unknown dispatch slug, but with no `not-found.tsx` it rendered Next's bare *"This page could not be found"* — inside a root layout that carries no chrome of its own. `app/not-found.tsx` supplies the same `Masthead` + `bs-paper` + `StationFooter` trio the news and stations shells use, so a wrong URL now lands on a real page. The footer's "Back Pages" index doubles as the recovery nav, so the page doesn't repeat those links itself.

## Errors

- **`app/error.tsx`** — everything below the root layout.
- **`app/global-error.tsx`** — the root layout itself.
- **`app/admin/error.tsx`** — nests inside `AdminShell`, so a panel that throws leaves the console nav mounted instead of dropping the operator onto the marketing-styled error page with no way back.

Recovery is `router.refresh()` + `reset()`, not `reset()` alone. Most failures here are a fetch against a controller that's down, and `reset()` re-renders *without* re-fetching — it would just reproduce the error. Next 16.2's `unstable_retry` does both, but this ships to self-hosted operators and an `unstable_` export isn't something to put under them.

`global-error` replaces the root layout, so `globals.css` never loads there. It carries a self-contained stylesheet using the real palette values and follows `prefers-color-scheme`, since the theme-init script is gone too. That needs an eslint exemption for its `ge-*` classes — added in the same shape as the existing next/og and observatory exemptions.

## Loading — with the prefetch claim actually measured

`/skills` and `/personas` had the same top-level `await` that #1126 fixed on `/shows` and `/stations`; same treatment applied.

`loading.tsx` on the six `force-dynamic` public segments is what makes their `<Link>` prefetch carry anything at all. Measured on a production build:

| Route state | Prefetch payload |
|---|---|
| dynamic route, **no** loading boundary | **183 bytes** — `null` where the page segment goes |
| same route, **with** loading boundary | **~16 KB** of real skeleton markup |

So without a boundary the prefetch fires but caches nothing, and the click still pays a full round trip. This is the Next-15/16 way to get most of what the "instant navigation" guide sells, without `cacheComponents`.

## `/news` deliberately has no loading.tsx

Adding one **regressed `/news/<unknown>` from 404 to 200.** The Suspense boundary starts streaming before `notFound()` runs, and the status code can't change once headers are sent — Next marks it `noindex` so it won't be indexed, but the status is still wrong for monitoring and compliance. The `/news` index is fully synchronous, so the boundary bought it nothing anyway. Correct status codes win; the reasoning is comented in the code so nobody "fixes" the gap later.

This is the one thing worth a careful look in review — it's a trap that applies to any future segment containing a `notFound()` call.

## Verification

On the standalone production build:
- `/does-not-exist` → **404**, `/news/<unknown>` → **404** (regression caught and fixed)
- All public routes → 200
- Prefetch payloads confirmed to carry loading UI on all six boundaried routes
- 404 page rendered and visually checked, including theme inheritance
- `npm run lint` clean
