### PR TITLE
feat(web): move Jingles / SFX / Beds to their own Imaging admin page

### DIFF
--- a/docs/superpowers/specs/2026-07-23-admin-imaging-page-design.md
+++ b/docs/superpowers/specs/2026-07-23-admin-imaging-page-design.md
@@ -1,0 +1,211 @@
+# Admin "Imaging" page — move Jingles / SFX / Beds out of Settings
+
+**Date:** 2026-07-23
+**Status:** design, awaiting review
+**Scope:** web UI only (no controller, broadcast, or state changes)
+
+## Problem
+
+Three of the fifteen sections in `/admin/settings` — **Jingles**, **Sound FX**, and
+**Beds** — are miscategorised. The rest of Settings is *pure configuration*: knobs you
+set once (Station, LLM, TTS, stream formats, loudness, archives, backup). These three are
+*content you curate*: you upload files, generate audio (TTS / ElevenLabs), and delete
+assets. That is the same category as **Library, Shows, Personas, and Skills** — all of
+which are already **top-level nav items under the "Programming" group**, not buried inside
+Settings.
+
+Each of the three is *mostly* an asset manager with a thin settings header riding on top:
+
+| Section  | Assets (the bulk)                                   | Settings (the header)              |
+|----------|-----------------------------------------------------|------------------------------------|
+| Jingles  | stinger WAVs — TTS-generate, upload, delete         | `jingleRatio` (1 per N tracks)     |
+| Sound FX | ElevenLabs-generated / uploaded effects             | `sfx.enabled` on/off               |
+| Beds     | talk-over instrumentals — upload, delete            | `beds.enabled` + link-length threshold |
+
+They belong together under a single concept: the station's **imaging** — the audio
+furniture the DJ drops between and over tracks (the real-radio term for jingles, IDs,
+stingers, and beds).
+
+## Decision
+
+Create a new top-level admin page **Imaging** at `/admin/imaging`, hosting the three as
+**tabs** (`Jingles · SFX · Beds`), and add it to the sidebar's **Programming** group.
+Remove the three sections from Settings. The thin settings toggles ride along on their
+tabs — same as Personas and Skills, which also mix a little config with their content.
+
+Confirmed decisions:
+- **Name:** Imaging
+- **Structure:** one page, three tabs (mirrors `/admin/connect`'s tab pattern)
+
+## Architecture
+
+The pattern already exists twice in the codebase and we follow it exactly:
+
+- **Route wrapper** (`app/admin/connect/page.tsx`): a server component that sets
+  `metadata.title` and renders the client panel.
+- **Tabbed client panel** (`components/admin/connect/ConnectPanel.tsx`): a `Seg` tab
+  control, `?tab=` deep-linking via `history.replaceState`, one child component per tab.
+- **Deep-link + redirect** (`SettingsPanel.tsx`): the existing precedent where the old
+  standalone `/admin/{archives,backup}` routes redirect into Settings so bookmarks keep
+  working. We do the reverse for the three moved sections.
+
+### New files
+
+**`web/app/admin/imaging/page.tsx`** — route wrapper.
+```tsx
+import type { Metadata } from 'next';
+import ImagingPanel from '../../../components/admin/imaging/ImagingPanel';
+export const metadata: Metadata = { title: 'Imaging' };
+export default function AdminImagingPage() { return <ImagingPanel />; }
+```
+
+**`web/components/admin/imaging/ImagingPanel.tsx`** — the tab host. This is where the
+state and handlers currently living in `SettingsPanel` for these three sections move to.
+It owns:
+
+- **Data fetches** (the three `refresh*` functions, polled on a 3s interval like Settings):
+  - `data` ← `GET /settings` (for `jingleRatio`, `sfx.enabled`, `beds.enabled`, threshold, jingle list)
+  - `sfxData` ← `GET /sfx`
+  - `bedsData` ← `GET /beds`
+- **Handlers** (moved verbatim from `SettingsPanel`): `saveSettings`, `createJingle`,
+  `deleteJingle`, `uploadJingle`, `createSfx`, `deleteSfx`, `uploadSfx`, `uploadBed`,
+  `deleteBed`.
+- **Local UI state:** `busy`, `jingleText`, `sfxForm`, `jingleRatio` (a single string —
+  see refactor below, *not* the whole `FormState`), and the three confirm-dialog states
+  (`confirmDelete`, `confirmDeleteSfx`, `confirmDeleteBed`) with their `V3AlertDialog`s.
+- **Tabs:** `type TabId = 'jingles' | 'sfx' | 'beds'`, default `'jingles'`, `Seg` control,
+  `?tab=` deep-link read on mount + `history.replaceState` on switch (copy from
+  `ConnectPanel`). Tab labels carry the live counts (e.g. `Jingles · 4`) so the
+  at-a-glance count the settings rail used to show is preserved.
+
+**`web/components/admin/imaging/types.ts`** — the imaging-only types moved out of
+`settings/shared.tsx`: `SfxData`, `SfxForm`, `BedsData`, `JingleImportResult`,
+`JingleImportFailure`. (`SettingsData`, `SaveSettings`, and `SectionHeader` stay in
+`settings/shared.tsx` — they are generic settings-save primitives, and Imaging's toggles
+legitimately write settings through them, so importing them from `../settings/shared` is
+correct, not a smell.)
+
+### Moved files
+
+Move the three section components from `components/admin/settings/` to
+`components/admin/imaging/`:
+- `JinglesSection.tsx`
+- `SfxSection.tsx`
+- `BedsSection.tsx`
+
+They keep importing `SectionHeader` / `SaveSettings` / `SettingsData` from
+`../settings/shared`, and their moved types from `./types`.
+
+### Refactor: decouple `JinglesSection` from `FormState`
+
+`JinglesSection` currently `extends SectionProps`, which drags in the entire `form` /
+`setForm` machinery — but it only ever reads/writes **one field**, `form.jingleRatio`
+(confirmed: the only `form.*` references are `form.jingleRatio` on lines 33, 96, 98, 104).
+Rebuilding Settings' ~200-line `FormState` hydration on the Imaging page just to feed one
+string would be wasteful.
+
+Change its props to take that one value directly:
+```ts
+// was: interface JinglesSectionProps extends SectionProps { … }
+interface JinglesSectionProps {
+  data: SettingsData;
+  jingleRatio: string;
+  setJingleRatio: (v: string) => void;
+  busy: boolean;
+  saveSettings: SaveSettings;
+  jingleText: string;
+  setJingleText: (s: string) => void;
+  createJingle: () => Promise<boolean>;
+  uploadJingle: (/* unchanged */) => Promise<JingleImportResult | null>;
+  onDelete: (filename: string | null) => void;
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+}
+```
+`ImagingPanel` holds `jingleRatio` as a `useState<string>` hydrated from
+`data.values.jingleRatio`. `SfxSection` and `BedsSection` already read their toggle
+straight off `data.values` and never touch `form`, so they move with **no signature
+change**.
+
+### Settings cleanup (`SettingsPanel.tsx`)
+
+Remove everything the three sections needed:
+- From `SECTIONS`: drop the `jingles`, `sfx`, `beds` entries.
+- Delete state: `jingleText`, `sfxData`, `sfxForm`, `confirmDeleteSfx`, `bedsData`,
+  `confirmDeleteBed`, `confirmDelete` (jingle), and `refreshSfx` / `refreshBeds` (and
+  their calls in the poll interval and mount effect).
+- Delete handlers: `createJingle`, `deleteJingle`, `uploadJingle`, `createSfx`,
+  `deleteSfx`, `uploadSfx`, `uploadBed`, `deleteBed`.
+- Delete render branches: the `activeSection === 'jingles' | 'sfx' | 'beds'` blocks and
+  their three `V3AlertDialog`s.
+- Delete the sidebar-rail count badge special-casing for `jingles` / `sfx` / `beds`
+  (the `s.id === 'jingles' …` ternary in the section rail collapses back to `s.hint`).
+- Remove `jingleRatio` from `FormState` and its hydration line — it is no longer read by
+  any settings section. (Verify no other Settings section references it first.)
+- Drop now-unused imports (`JinglesSection`, `SfxSection`, `BedsSection`, `Music`,
+  `AudioLines`, `Waves`, and any type-only imports that moved to `imaging/types`).
+
+### Backward-compat redirect
+
+Old bookmarks like `/admin/settings?section=jingles` must not dead-end. Add a small
+effect at the top of `SettingsPanel` (alongside the existing `?section` deep-link
+handler): if `?section` is one of `jingles | sfx | beds`, `router.replace(
+'/admin/imaging?tab=<id>')`. Mirrors the archives/backup precedent already documented in
+`SettingsPanel`.
+
+### Sidebar (`AdminShell.tsx`)
+
+Add to the **Programming** `NAV_SECTIONS` group, after Skills:
+```ts
+{ href: '/admin/imaging', id: 'imaging', label: 'Imaging', icon: Podcast },
+```
+Import `Podcast` from `lucide-react` — a distinct mic/broadcast-waves glyph, deliberately
+different from the three tab icons (Music / AudioLines / Waves) and from every existing
+sidebar icon. The breadcrumb in `ShellHeader` resolves automatically because it
+looks the label up from `NAV` — no special-case needed (unlike DJ Doc / Playlists).
+
+### Internal-link sweep
+
+Grep the web app for links into the moved sections and repoint them at
+`/admin/imaging?tab=…`:
+```
+grep -rn "section=jingles\|section=sfx\|section=beds\|settings?section=jingles" web/
+```
+Check onboarding, dash, and any "manage jingles" call-to-action. The controller API
+routes (`/jingles`, `/sfx`, `/beds`) are unchanged, so no backend link changes.
+
+## Data flow (unchanged)
+
+Imaging talks to the same controller endpoints Settings used:
+`GET/POST/DELETE /jingles`, `POST /jingles/upload`, `GET/POST/DELETE /sfx`,
+`POST /sfx/upload`, `GET /beds`, `POST /beds/upload`, `DELETE /beds/:name`, and
+`POST /settings` for the three toggles. Nothing server-side changes; this is a pure
+front-end reorganisation.
+
+## Testing
+
+- **Lint/type gate:** `cd web && npm run lint` (eslint + `tsc --noEmit`) — the merge gate.
+  Catches dangling imports and the `JinglesSection` prop change.
+- **Manual (dev stack):**
+  1. Sidebar shows **Imaging** under Programming; clicking it lands on `/admin/imaging`
+     with the Jingles tab active and breadcrumb reading "Imaging".
+  2. Each tab: create/generate, upload, and delete an asset; toggles save and reflect.
+  3. Deep-link `/admin/imaging?tab=sfx` opens the SFX tab directly.
+  4. Old `/admin/settings?section=beds` redirects to `/admin/imaging?tab=beds`.
+  5. `/admin/settings` no longer lists Jingles / SFX / Beds and its other 12 sections
+     still work (Station, Danger zone save-and-restart especially).
+
+## Non-goals
+
+- No change to jingle/sfx/bed generation, storage, or Liquidsoap playback.
+- No redesign of the three sections' internals beyond the `JinglesSection` prop slimming.
+- No consolidation of the three into a shared component — they stay three distinct tabs.
+
+## Risks / notes
+
+- **`FormState.jingleRatio` removal** is the one cross-cutting edit inside Settings;
+  verify nothing else in `SettingsPanel` reads it before deleting (grep confirmed only
+  `JinglesSection` did, but re-check after the move).
+- The three components importing from `../settings/shared` creates an `imaging → settings`
+  import edge. Acceptable: those are generic settings-save primitives. If we later want a
+  hard boundary, promote `SectionHeader` + `SaveSettings` + `SettingsData` into a neutral
+  `components/admin/shared/` — out of scope here.

--- a/web/app/admin/imaging/page.tsx
+++ b/web/app/admin/imaging/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import ImagingPanel from '../../../components/admin/imaging/ImagingPanel';
+
+export const metadata: Metadata = {
+  title: 'Imaging',
+};
+
+export default function AdminImagingPage() {
+  return <ImagingPanel />;
+}

--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -23,6 +23,7 @@ import {
   Plug,
   Coffee,
   MessageCircle,
+  Podcast,
 } from 'lucide-react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import type { SignInResult } from '../../lib/adminAuth';
@@ -69,6 +70,7 @@ const NAV_SECTIONS: NavSection[] = [
       { href: '/admin/shows', id: 'shows', label: 'Shows', icon: CalendarClock },
       { href: '/admin/personas', id: 'personas', label: 'Personas', icon: Drama },
       { href: '/admin/skills', id: 'skills', label: 'Skills', icon: Sparkles },
+      { href: '/admin/imaging', id: 'imaging', label: 'Imaging', icon: Podcast },
     ],
   },
   {

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -2,6 +2,7 @@
 
 import type { ChangeEvent } from 'react';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { notify, errorMessage } from '../../lib/notify';
 import { normalizeStationLocale } from '../../lib/format';
 import { useAdminAuth } from '../../lib/adminAuth';
@@ -17,13 +18,12 @@ import ArchivesPanel from './ArchivesPanel';
 import BackupPanel from './BackupPanel';
 import FestivalsSection from './FestivalsSection';
 import {
-  Radio, Palette, Cpu, Mic, Library, Search, Music, AudioLines,
-  Activity, Archive, Save, AlertTriangle, CalendarDays, Heart, Waves,
+  Radio, Palette, Cpu, Mic, Library, Search,
+  Activity, Archive, Save, AlertTriangle, CalendarDays, Heart,
 } from 'lucide-react';
 import {
   SectionHeader, ELEVENLABS_VS_DEFAULTS,
   type FormState, type FormUpdater, type SettingsData, type SaveSettings,
-  type SfxData, type SfxForm, type BedsData, type JingleImportFailure, type JingleImportResult,
   type LoudnessSource, type LlmForm, type LlmFallbackForm,
 } from './settings/shared';
 import { TtsSection } from './settings/TtsSection';
@@ -32,9 +32,6 @@ import { SearchSection } from './settings/SearchSection';
 import { LibrarySection } from './settings/LibrarySection';
 import { StationSection } from './settings/StationSection';
 import { ThemeSection } from './settings/ThemeSection';
-import { JinglesSection } from './settings/JinglesSection';
-import { SfxSection } from './settings/SfxSection';
-import { BedsSection } from './settings/BedsSection';
 import { ScrobbleSection } from './settings/ScrobbleSection';
 import { LikesSection } from './settings/LikesSection';
 
@@ -46,9 +43,6 @@ const SECTIONS = [
   { id: 'tts',      label: 'TTS voice', hint: 'default engine', icon: Mic },
   { id: 'library',  label: 'Library tagger', hint: 'embedding · propagation', icon: Library },
   { id: 'search',   label: 'Web search', hint: 'live-facts backend', icon: Search },
-  { id: 'jingles',  label: 'Jingles', hint: 'stingers', icon: Music },
-  { id: 'sfx',      label: 'Sound FX', hint: 'agent stingers', icon: AudioLines },
-  { id: 'beds',     label: 'Beds', hint: 'talk-over instrumentals', icon: Waves },
   { id: 'scrobble', label: 'Scrobbling', hint: 'last.fm · listenbrainz', icon: Activity },
   { id: 'likes',    label: 'Likes', hint: 'heart button · navidrome stars', icon: Heart },
   { id: 'archives', label: 'Archives', hint: 'hourly recordings', icon: Archive },
@@ -70,18 +64,12 @@ export default function SettingsPanel() {
   const [data, setData] = useState<SettingsData | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  const [jingleText, setJingleText] = useState('');
   const [form, setForm] = useState<FormState | null>(null);
   const [pendingRestart, setPendingRestart] = useState(false);
   const [confirmRestart, setConfirmRestart] = useState(false);
   const [confirmStop, setConfirmStop] = useState(false);
-  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [activeSection, setActiveSection] = useState<SectionId>('station');
-  const [sfxData, setSfxData] = useState<SfxData | null>(null);
-  const [sfxForm, setSfxForm] = useState<SfxForm>({ name: '', description: '', prompt: '', durationSec: '' });
-  const [confirmDeleteSfx, setConfirmDeleteSfx] = useState<string | null>(null);
-  const [bedsData, setBedsData] = useState<BedsData | null>(null);
-  const [confirmDeleteBed, setConfirmDeleteBed] = useState<string | null>(null);
+  const router = useRouter();
 
   const refresh = async () => {
     try {
@@ -92,36 +80,26 @@ export default function SettingsPanel() {
     } catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
   };
 
-  const refreshSfx = async () => {
-    try {
-      const r = await adminFetch('/sfx');
-      if (!r.ok) return;
-      setSfxData((await r.json()) as SfxData);
-    } catch { /* non-fatal */ }
-  };
-
-  const refreshBeds = async () => {
-    try {
-      const r = await adminFetch('/beds');
-      if (!r.ok) return;
-      setBedsData((await r.json()) as BedsData);
-    } catch { /* non-fatal */ }
-  };
-
   // Deep-link: /admin/settings?section=archives opens that rail directly. The
   // old standalone /admin/{archives,backup} routes redirect here, so existing
   // bookmarks keep working after the move into Settings. (Webhooks moved on to
   // its own tab under /admin/connect?tab=webhooks.)
+  //
+  // Jingles / SFX / Beds left Settings for /admin/imaging — send their old
+  // ?section deep-links on to the matching tab so existing bookmarks survive.
   useEffect(() => {
     const s = new URLSearchParams(window.location.search).get('section');
+    if (s === 'jingles' || s === 'sfx' || s === 'beds') {
+      router.replace(`/admin/imaging?tab=${s}`);
+      return;
+    }
     if (s && SECTIONS.some(x => x.id === s)) setActiveSection(s as SectionId);
-  }, []);
+  }, [router]);
 
   useEffect(() => {
     if (!data?.values || form) return;
     const v = data.values;
     setForm({
-      jingleRatio: String(v.jingleRatio ?? ''),
       crossfadeDuration: String(v.crossfadeDuration ?? ''),
       maxTrackSeconds: String(v.maxTrackSeconds ?? 0),
       archive: {
@@ -314,9 +292,7 @@ export default function SettingsPanel() {
   useEffect(() => {
     if (!hydrated || needsAuth) return;
     refresh();
-    refreshSfx();
-    refreshBeds();
-    const id = setInterval(() => { refresh(); refreshSfx(); refreshBeds(); }, 3000);
+    const id = setInterval(() => { refresh(); }, 3000);
     return () => clearInterval(id);
   }, [hydrated, needsAuth]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -377,171 +353,6 @@ export default function SettingsPanel() {
     } finally { setBusy(false); }
   };
 
-  const createJingle = async (): Promise<boolean> => {
-    if (!jingleText.trim() || busy) return false;
-    setBusy(true);
-    try {
-      const r = await adminFetch('/jingles', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text: jingleText.trim() }),
-      });
-      const j = (await r.json().catch(() => ({}))) as { error?: string };
-      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      setJingleText('');
-      await refresh();
-      return true;
-    } catch (e) { notify.err(`Jingle creation failed: ${errorMessage(e)}`); return false; }
-    finally { setBusy(false); }
-  };
-
-  const deleteJingle = async (filename: string) => {
-    setBusy(true);
-    try {
-      const r = await adminFetch(`/jingles/${encodeURIComponent(filename)}`, { method: 'DELETE' });
-      const j = (await r.json().catch(() => ({}))) as { error?: string };
-      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      await refresh();
-    } catch (e) { notify.err(`Delete failed: ${errorMessage(e)}`); }
-    finally { setBusy(false); }
-  };
-
-  // Multipart upload — adminFetch leaves Content-Type unset so the browser
-  // sets the multipart boundary itself. The controller transcodes + levels.
-  // Files upload one request at a time (not one multipart batch) so a big
-  // import doesn't hold 40+ files in memory at once server-side and a single
-  // bad file doesn't sink the rest. `label` only applies when importing a
-  // single file — each file in a batch defaults to its own filename. An
-  // abort via `signal` cancels the in-flight request too; the file it
-  // interrupted counts as skipped, not failed.
-  const uploadJingle = async (
-    files: File[],
-    label: string,
-    opts: { onProgress?: (done: number, total: number) => void; signal?: AbortSignal } = {},
-  ): Promise<JingleImportResult | null> => {
-    if (busy || !files.length) return null;
-    const { onProgress, signal } = opts;
-    setBusy(true);
-    const total = files.length;
-    let ok = 0;
-    let aborted = false;
-    const failures: JingleImportFailure[] = [];
-    try {
-      for (const [i, file] of files.entries()) {
-        if (signal?.aborted) { aborted = true; break; }
-        try {
-          const fd = new FormData();
-          fd.append('file', file);
-          if (total === 1 && label.trim()) fd.append('label', label.trim());
-          const r = await adminFetch('/jingles/upload', { method: 'POST', body: fd, signal });
-          const j = (await r.json().catch(() => ({}))) as { error?: string };
-          if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-          ok++;
-        } catch (e) {
-          if (signal?.aborted) { aborted = true; break; }
-          failures.push({ name: file.name, reason: errorMessage(e) });
-        }
-        onProgress?.(i + 1, total);
-      }
-      if (ok) await refresh();
-      if (aborted) {
-        notify.info(`Import stopped — ${ok}/${total} imported`);
-      } else if (total === 1) {
-        if (ok) notify.ok('jingle imported');
-        else notify.err(`Jingle import failed: ${failures[0]?.reason}`);
-      } else if (failures.length === 0) {
-        notify.ok(`${ok} jingles imported`);
-      } else {
-        notify.err(`${ok}/${total} jingles imported · ${failures.length} failed`);
-      }
-      return { ok, total, failures, aborted };
-    } finally { setBusy(false); }
-  };
-
-  const createSfx = async (): Promise<boolean> => {
-    if (!sfxForm.name.trim() || !sfxForm.prompt.trim() || busy) return false;
-    setBusy(true);
-    try {
-      const r = await adminFetch('/sfx', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: sfxForm.name.trim(),
-          description: sfxForm.description.trim(),
-          prompt: sfxForm.prompt.trim(),
-          durationSec: sfxForm.durationSec ? parseFloat(sfxForm.durationSec) : undefined,
-        }),
-      });
-      const j = (await r.json().catch(() => ({}))) as { error?: string };
-      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      setSfxForm({ name: '', description: '', prompt: '', durationSec: '' });
-      await refreshSfx();
-      return true;
-    } catch (e) { notify.err(`Sound effect creation failed: ${errorMessage(e)}`); return false; }
-    finally { setBusy(false); }
-  };
-
-  const deleteSfx = async (name: string) => {
-    setBusy(true);
-    try {
-      const r = await adminFetch(`/sfx/${encodeURIComponent(name)}`, { method: 'DELETE' });
-      const j = (await r.json().catch(() => ({}))) as { error?: string };
-      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      await refreshSfx();
-    } catch (e) { notify.err(`Delete failed: ${errorMessage(e)}`); }
-    finally { setBusy(false); }
-  };
-
-  // Upload a ready-made effect — no ElevenLabs key required (unlike createSfx).
-  const uploadSfx = async (file: File, name: string, description: string): Promise<boolean> => {
-    if (busy) return false;
-    setBusy(true);
-    try {
-      const fd = new FormData();
-      fd.append('file', file);
-      fd.append('name', name.trim());
-      if (description.trim()) fd.append('description', description.trim());
-      const r = await adminFetch('/sfx/upload', { method: 'POST', body: fd });
-      const j = (await r.json().catch(() => ({}))) as { error?: string };
-      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      await refreshSfx();
-      notify.ok('sound effect imported');
-      return true;
-    } catch (e) { notify.err(`Sound effect import failed: ${errorMessage(e)}`); return false; }
-    finally { setBusy(false); }
-  };
-
-  const uploadBed = async (file: File, name: string, description: string): Promise<boolean> => {
-    if (busy) return false;
-    setBusy(true);
-    try {
-      const fd = new FormData();
-      fd.append('file', file);
-      fd.append('name', name.trim());
-      if (description.trim()) fd.append('description', description.trim());
-      const r = await adminFetch('/beds/upload', { method: 'POST', body: fd });
-      const j = (await r.json().catch(() => ({}))) as { error?: string };
-      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      await refreshBeds();
-      notify.ok('bed imported');
-      return true;
-    } catch (e) { notify.err(`Bed import failed: ${errorMessage(e)}`); return false; }
-    finally { setBusy(false); }
-  };
-
-  const deleteBed = async (name: string) => {
-    if (busy) return;
-    setBusy(true);
-    try {
-      const r = await adminFetch(`/beds/${encodeURIComponent(name)}`, { method: 'DELETE' });
-      const j = (await r.json().catch(() => ({}))) as { error?: string };
-      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      await refreshBeds();
-      notify.ok('bed deleted');
-    } catch (e) { notify.err(`Bed delete failed: ${errorMessage(e)}`); }
-    finally { setBusy(false); }
-  };
-
   return (
     <div className="stack-mobile grid grid-cols-[240px_1fr] items-start gap-6">
       {/* Section rail */}
@@ -565,13 +376,7 @@ export default function SettingsPanel() {
                   {s.label}
                 </span>
                 <span className="text-[9px] tracking-[0.18em] uppercase opacity-70">
-                  {s.id === 'jingles' && data
-                    ? `${data.jingles?.length ?? 0} file${(data.jingles?.length ?? 0) === 1 ? '' : 's'}`
-                    : s.id === 'sfx' && sfxData
-                      ? `${sfxData.sfx?.length ?? 0} effect${(sfxData.sfx?.length ?? 0) === 1 ? '' : 's'}`
-                      : s.id === 'beds' && bedsData
-                        ? `${bedsData.beds?.length ?? 0} bed${(bedsData.beds?.length ?? 0) === 1 ? '' : 's'}`
-                        : s.hint}
+                  {s.hint}
                 </span>
               </span>
             </button>
@@ -656,15 +461,6 @@ export default function SettingsPanel() {
                 adminFetch={adminFetch}
               />
             )}
-            {activeSection === 'jingles' && (
-              <JinglesSection
-                data={data} form={form} setForm={updateForm} busy={busy}
-                jingleText={jingleText} setJingleText={setJingleText}
-                createJingle={createJingle} uploadJingle={uploadJingle}
-                saveSettings={saveSettings}
-                onDelete={setConfirmDelete} adminFetch={adminFetch}
-              />
-            )}
             {activeSection === 'scrobble' && (
               <ScrobbleSection
                 data={data} form={form} setForm={updateForm} busy={busy}
@@ -680,21 +476,6 @@ export default function SettingsPanel() {
           </>
           );
         })()}
-        {activeSection === 'beds' && (
-          <BedsSection
-            bedsData={bedsData} busy={busy} uploadBed={uploadBed}
-            onDelete={setConfirmDeleteBed}
-            data={data} saveSettings={saveSettings} adminFetch={adminFetch}
-          />
-        )}
-        {activeSection === 'sfx' && (
-          <SfxSection
-            sfxData={sfxData} sfxForm={sfxForm} setSfxForm={setSfxForm}
-            busy={busy} createSfx={createSfx} uploadSfx={uploadSfx}
-            onDelete={setConfirmDeleteSfx}
-            data={data} saveSettings={saveSettings} adminFetch={adminFetch}
-          />
-        )}
         {/* Self-contained panels — each re-calls useAdminAuth and owns its
             own data fetch, so they render outside the data && form guard. */}
         {activeSection === 'archives' && (
@@ -1457,33 +1238,6 @@ export default function SettingsPanel() {
         confirmLabel="stop stream"
         danger
         onConfirm={stopStream}
-      />
-      <V3AlertDialog
-        open={confirmDelete != null}
-        onOpenChange={(o) => { if (!o) setConfirmDelete(null); }}
-        title="Delete jingle"
-        description={confirmDelete ? `Delete the jingle "${confirmDelete}"? This removes the rendered audio file permanently.` : ''}
-        confirmLabel="delete"
-        danger
-        onConfirm={() => { if (confirmDelete) deleteJingle(confirmDelete); setConfirmDelete(null); }}
-      />
-      <V3AlertDialog
-        open={confirmDeleteSfx != null}
-        onOpenChange={(o) => { if (!o) setConfirmDeleteSfx(null); }}
-        title="Delete sound effect"
-        description={confirmDeleteSfx ? `Delete the sound effect "${confirmDeleteSfx}"? This removes the rendered audio file permanently.` : ''}
-        confirmLabel="delete"
-        danger
-        onConfirm={() => { if (confirmDeleteSfx) deleteSfx(confirmDeleteSfx); setConfirmDeleteSfx(null); }}
-      />
-      <V3AlertDialog
-        open={confirmDeleteBed != null}
-        onOpenChange={(o) => { if (!o) setConfirmDeleteBed(null); }}
-        title="Delete bed"
-        description={confirmDeleteBed ? `Delete the bed "${confirmDeleteBed}"? This removes the audio file permanently. A bundled bed stays deleted — it won't come back on the next restart.` : ''}
-        confirmLabel="delete"
-        danger
-        onConfirm={() => { if (confirmDeleteBed) deleteBed(confirmDeleteBed); setConfirmDeleteBed(null); }}
       />
     </div>
   );

--- a/web/components/admin/imaging/BedsSection.tsx
+++ b/web/components/admin/imaging/BedsSection.tsx
@@ -7,10 +7,8 @@ import { Modal } from '../../ui/modal';
 import { Input } from '../../ui/input';
 import { Label } from '../../ui/label';
 import { Card, Btn, Pill, Seg } from '../ui';
-import {
-  SectionHeader, PreviewButton,
-  type SettingsData, type SaveSettings, type BedsData,
-} from './shared';
+import { SectionHeader, PreviewButton, type SettingsData, type SaveSettings } from '../settings/shared';
+import type { BedsData } from './types';
 
 interface BedsSectionProps {
   bedsData: BedsData | null;

--- a/web/components/admin/imaging/ImagingPanel.tsx
+++ b/web/components/admin/imaging/ImagingPanel.tsx
@@ -15,9 +15,11 @@
    ConnectPanel (Seg control + ?tab= deep-link). */
 
 import { useCallback, useEffect, useState } from 'react';
+import { Music, AudioLines, Waves } from 'lucide-react';
 import { useAdminAuth } from '../../../lib/adminAuth';
 import { notify, errorMessage } from '../../../lib/notify';
-import { Eyebrow, Seg } from '../ui';
+import { cn } from '../../../lib/cn';
+import { Eyebrow } from '../ui';
 import { V3AlertDialog } from '../../ui/alert-dialog';
 import type { SettingsData, SaveSettings } from '../settings/shared';
 import type { SfxData, SfxForm, BedsData, JingleImportFailure, JingleImportResult } from './types';
@@ -296,9 +298,9 @@ export default function ImagingPanel() {
   const sfxCount = sfxData?.sfx?.length;
   const bedCount = bedsData?.beds?.length;
   const tabs = [
-    { id: 'jingles', label: jingleCount == null ? 'Jingles' : `Jingles · ${jingleCount}` },
-    { id: 'sfx', label: sfxCount == null ? 'SFX' : `SFX · ${sfxCount}` },
-    { id: 'beds', label: bedCount == null ? 'Beds' : `Beds · ${bedCount}` },
+    { id: 'jingles' as TabId, label: 'Jingles', count: jingleCount, icon: Music },
+    { id: 'sfx' as TabId, label: 'SFX', count: sfxCount, icon: AudioLines },
+    { id: 'beds' as TabId, label: 'Beds', count: bedCount, icon: Waves },
   ];
 
   return (
@@ -315,8 +317,42 @@ export default function ImagingPanel() {
             instrumentals the DJ talks over. All of it is created, imported, and managed here.
           </div>
         </div>
-        <div className="flex flex-wrap items-center gap-3 bg-[var(--ink-softer)] p-3.5">
-          <Seg value={tab} options={tabs} accent onChange={selectTab} />
+        {/* Full-width tab row — three equal cells, active one filled in the
+            accent so the current section reads at a glance. */}
+        <div className="grid grid-cols-3" role="tablist" aria-label="Imaging sections">
+          {tabs.map((t, i) => {
+            const active = tab === t.id;
+            const Icon = t.icon;
+            return (
+              <button
+                key={t.id}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => selectTab(t.id)}
+                className={cn(
+                  'flex items-center justify-center gap-2.5 px-4 py-4 text-[13px] font-bold tracking-[0.18em] uppercase transition-colors',
+                  i > 0 && 'border-l border-ink',
+                  active
+                    ? 'bg-[var(--accent)] text-white'
+                    : 'bg-[var(--ink-softer)] text-ink hover:bg-ink/10',
+                )}
+              >
+                <Icon size={17} strokeWidth={2} aria-hidden />
+                <span>{t.label}</span>
+                {t.count != null && (
+                  <span
+                    className={cn(
+                      'ml-0.5 min-w-[1.5em] rounded-full px-1.5 py-0.5 text-[10px] leading-none font-bold',
+                      active ? 'bg-white/25 text-white' : 'bg-ink/10 text-muted',
+                    )}
+                  >
+                    {t.count}
+                  </span>
+                )}
+              </button>
+            );
+          })}
         </div>
       </section>
 

--- a/web/components/admin/imaging/ImagingPanel.tsx
+++ b/web/components/admin/imaging/ImagingPanel.tsx
@@ -1,0 +1,393 @@
+'use client';
+
+/* Admin Imaging page — the station's audio furniture, the sounds the DJ drops
+   between and over tracks. Three tabs:
+   - Jingles: pre-rendered TTS station stingers (+ the jingle-ratio frequency).
+   - SFX: effects the segment-director agent mixes under its voice.
+   - Beds: instrumentals the DJ talks over between songs (long-link beds).
+
+   These used to be three sections inside /admin/settings, but they're asset
+   management (create / upload / delete audio), not configuration — the same
+   category as Library / Shows / Personas / Skills. This panel owns the state
+   and handlers those sections need; the section components themselves moved
+   here from settings/ unchanged apart from imports (JinglesSection also lost
+   its FormState dependency — see its prop comment). Tab pattern mirrors
+   ConnectPanel (Seg control + ?tab= deep-link). */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useAdminAuth } from '../../../lib/adminAuth';
+import { notify, errorMessage } from '../../../lib/notify';
+import { Eyebrow, Seg } from '../ui';
+import { V3AlertDialog } from '../../ui/alert-dialog';
+import type { SettingsData, SaveSettings } from '../settings/shared';
+import type { SfxData, SfxForm, BedsData, JingleImportFailure, JingleImportResult } from './types';
+import { JinglesSection } from './JinglesSection';
+import { SfxSection } from './SfxSection';
+import { BedsSection } from './BedsSection';
+
+type TabId = 'jingles' | 'sfx' | 'beds';
+const TAB_IDS: TabId[] = ['jingles', 'sfx', 'beds'];
+
+export default function ImagingPanel() {
+  const { adminFetch, needsAuth, hydrated } = useAdminAuth();
+  const [data, setData] = useState<SettingsData | null>(null);
+  const [sfxData, setSfxData] = useState<SfxData | null>(null);
+  const [bedsData, setBedsData] = useState<BedsData | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [tab, setTab] = useState<TabId>('jingles');
+
+  // Jingles: the create-text box + the lone settings field this page carries
+  // (the whole FormState stayed behind in SettingsPanel). null = not yet
+  // hydrated from /settings; polling never re-hydrates it, so operator edits
+  // to the ratio input survive the 3s refresh.
+  const [jingleText, setJingleText] = useState('');
+  const [jingleRatio, setJingleRatio] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  // SFX
+  const [sfxForm, setSfxForm] = useState<SfxForm>({ name: '', description: '', prompt: '', durationSec: '' });
+  const [confirmDeleteSfx, setConfirmDeleteSfx] = useState<string | null>(null);
+
+  // Beds
+  const [confirmDeleteBed, setConfirmDeleteBed] = useState<string | null>(null);
+
+  const refresh = async () => {
+    try {
+      const r = await adminFetch('/settings');
+      if (!r.ok) return;
+      const j = (await r.json()) as SettingsData;
+      setData(j); setErr(null);
+    } catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+  };
+
+  const refreshSfx = async () => {
+    try {
+      const r = await adminFetch('/sfx');
+      if (!r.ok) return;
+      setSfxData((await r.json()) as SfxData);
+    } catch { /* non-fatal */ }
+  };
+
+  const refreshBeds = async () => {
+    try {
+      const r = await adminFetch('/beds');
+      if (!r.ok) return;
+      setBedsData((await r.json()) as BedsData);
+    } catch { /* non-fatal */ }
+  };
+
+  // Deep-link: /admin/imaging?tab=sfx opens that tab directly (mirrors
+  // /admin/connect?tab=… and the old /admin/settings?section=…).
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const t = new URLSearchParams(window.location.search).get('tab');
+    if (t && (TAB_IDS as string[]).includes(t)) setTab(t as TabId);
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated || needsAuth) return;
+    refresh(); refreshSfx(); refreshBeds();
+    const id = setInterval(() => { refresh(); refreshSfx(); refreshBeds(); }, 3000);
+    return () => clearInterval(id);
+  }, [hydrated, needsAuth]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Hydrate the jingle-ratio input once, the first time /settings lands.
+  useEffect(() => {
+    if (data?.values && jingleRatio == null) setJingleRatio(String(data.values.jingleRatio ?? ''));
+  }, [data, jingleRatio]);
+
+  const selectTab = useCallback((id: string) => {
+    setTab(id as TabId);
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href);
+      url.searchParams.set('tab', id);
+      window.history.replaceState(null, '', url.toString());
+    }
+  }, []);
+
+  const saveSettings: SaveSettings = async (patch) => {
+    setBusy(true);
+    try {
+      const r = await adminFetch('/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      });
+      const j = (await r.json().catch(() => ({}))) as { error?: string; requiresRestart?: boolean };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      // The jingle-ratio change needs a mixer restart; the restart control
+      // lives in Settings → Danger zone (JinglesSection's hint points there).
+      notify.ok(j.requiresRestart ? 'saved, restart the mixer to apply' : 'saved');
+      await refresh();
+    } catch (e) {
+      notify.err(errorMessage(e));
+    } finally { setBusy(false); }
+  };
+
+  const createJingle = async (): Promise<boolean> => {
+    if (!jingleText.trim() || busy) return false;
+    setBusy(true);
+    try {
+      const r = await adminFetch('/jingles', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: jingleText.trim() }),
+      });
+      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      setJingleText('');
+      await refresh();
+      return true;
+    } catch (e) { notify.err(`Jingle creation failed: ${errorMessage(e)}`); return false; }
+    finally { setBusy(false); }
+  };
+
+  const deleteJingle = async (filename: string) => {
+    setBusy(true);
+    try {
+      const r = await adminFetch(`/jingles/${encodeURIComponent(filename)}`, { method: 'DELETE' });
+      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      await refresh();
+    } catch (e) { notify.err(`Delete failed: ${errorMessage(e)}`); }
+    finally { setBusy(false); }
+  };
+
+  // Multipart upload — adminFetch leaves Content-Type unset so the browser
+  // sets the multipart boundary itself. The controller transcodes + levels.
+  // Files upload one request at a time (not one multipart batch) so a big
+  // import doesn't hold 40+ files in memory at once server-side and a single
+  // bad file doesn't sink the rest. `label` only applies when importing a
+  // single file — each file in a batch defaults to its own filename. An
+  // abort via `signal` cancels the in-flight request too; the file it
+  // interrupted counts as skipped, not failed.
+  const uploadJingle = async (
+    files: File[],
+    label: string,
+    opts: { onProgress?: (done: number, total: number) => void; signal?: AbortSignal } = {},
+  ): Promise<JingleImportResult | null> => {
+    if (busy || !files.length) return null;
+    const { onProgress, signal } = opts;
+    setBusy(true);
+    const total = files.length;
+    let ok = 0;
+    let aborted = false;
+    const failures: JingleImportFailure[] = [];
+    try {
+      for (const [i, file] of files.entries()) {
+        if (signal?.aborted) { aborted = true; break; }
+        try {
+          const fd = new FormData();
+          fd.append('file', file);
+          if (total === 1 && label.trim()) fd.append('label', label.trim());
+          const r = await adminFetch('/jingles/upload', { method: 'POST', body: fd, signal });
+          const j = (await r.json().catch(() => ({}))) as { error?: string };
+          if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+          ok++;
+        } catch (e) {
+          if (signal?.aborted) { aborted = true; break; }
+          failures.push({ name: file.name, reason: errorMessage(e) });
+        }
+        onProgress?.(i + 1, total);
+      }
+      if (ok) await refresh();
+      if (aborted) {
+        notify.info(`Import stopped — ${ok}/${total} imported`);
+      } else if (total === 1) {
+        if (ok) notify.ok('jingle imported');
+        else notify.err(`Jingle import failed: ${failures[0]?.reason}`);
+      } else if (failures.length === 0) {
+        notify.ok(`${ok} jingles imported`);
+      } else {
+        notify.err(`${ok}/${total} jingles imported · ${failures.length} failed`);
+      }
+      return { ok, total, failures, aborted };
+    } finally { setBusy(false); }
+  };
+
+  const createSfx = async (): Promise<boolean> => {
+    if (!sfxForm.name.trim() || !sfxForm.prompt.trim() || busy) return false;
+    setBusy(true);
+    try {
+      const r = await adminFetch('/sfx', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: sfxForm.name.trim(),
+          description: sfxForm.description.trim(),
+          prompt: sfxForm.prompt.trim(),
+          durationSec: sfxForm.durationSec ? parseFloat(sfxForm.durationSec) : undefined,
+        }),
+      });
+      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      setSfxForm({ name: '', description: '', prompt: '', durationSec: '' });
+      await refreshSfx();
+      return true;
+    } catch (e) { notify.err(`Sound effect creation failed: ${errorMessage(e)}`); return false; }
+    finally { setBusy(false); }
+  };
+
+  const deleteSfx = async (name: string) => {
+    setBusy(true);
+    try {
+      const r = await adminFetch(`/sfx/${encodeURIComponent(name)}`, { method: 'DELETE' });
+      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      await refreshSfx();
+    } catch (e) { notify.err(`Delete failed: ${errorMessage(e)}`); }
+    finally { setBusy(false); }
+  };
+
+  // Upload a ready-made effect — no ElevenLabs key required (unlike createSfx).
+  const uploadSfx = async (file: File, name: string, description: string): Promise<boolean> => {
+    if (busy) return false;
+    setBusy(true);
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      fd.append('name', name.trim());
+      if (description.trim()) fd.append('description', description.trim());
+      const r = await adminFetch('/sfx/upload', { method: 'POST', body: fd });
+      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      await refreshSfx();
+      notify.ok('sound effect imported');
+      return true;
+    } catch (e) { notify.err(`Sound effect import failed: ${errorMessage(e)}`); return false; }
+    finally { setBusy(false); }
+  };
+
+  const uploadBed = async (file: File, name: string, description: string): Promise<boolean> => {
+    if (busy) return false;
+    setBusy(true);
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      fd.append('name', name.trim());
+      if (description.trim()) fd.append('description', description.trim());
+      const r = await adminFetch('/beds/upload', { method: 'POST', body: fd });
+      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      await refreshBeds();
+      notify.ok('bed imported');
+      return true;
+    } catch (e) { notify.err(`Bed import failed: ${errorMessage(e)}`); return false; }
+    finally { setBusy(false); }
+  };
+
+  const deleteBed = async (name: string) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const r = await adminFetch(`/beds/${encodeURIComponent(name)}`, { method: 'DELETE' });
+      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      await refreshBeds();
+      notify.ok('bed deleted');
+    } catch (e) { notify.err(`Bed delete failed: ${errorMessage(e)}`); }
+    finally { setBusy(false); }
+  };
+
+  // Live counts ride on the tab labels — the at-a-glance figures the settings
+  // rail used to show. Omitted until each source has loaded.
+  const jingleCount = data?.jingles?.length;
+  const sfxCount = sfxData?.sfx?.length;
+  const bedCount = bedsData?.beds?.length;
+  const tabs = [
+    { id: 'jingles', label: jingleCount == null ? 'Jingles' : `Jingles · ${jingleCount}` },
+    { id: 'sfx', label: sfxCount == null ? 'SFX' : `SFX · ${sfxCount}` },
+    { id: 'beds', label: bedCount == null ? 'Beds' : `Beds · ${bedCount}` },
+  ];
+
+  return (
+    <div className="grid gap-4">
+      <section className="card">
+        <div className="border-b border-ink p-4">
+          <Eyebrow className="text-vermilion">imaging</Eyebrow>
+          <div className="mt-1.5 text-[22px] font-extrabold tracking-[-0.02em]">
+            The sounds between the songs.
+          </div>
+          <div className="mt-1 text-[11px] leading-[1.6] text-muted">
+            Station imaging — the audio furniture the DJ drops between and over tracks. Jingles
+            are pre-recorded stingers, sound effects garnish a spoken break, and beds are
+            instrumentals the DJ talks over. All of it is created, imported, and managed here.
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-3 bg-[var(--ink-softer)] p-3.5">
+          <Seg value={tab} options={tabs} accent onChange={selectTab} />
+        </div>
+      </section>
+
+      {err && (
+        <div className="card border-[var(--danger)]">
+          <div className="card-body text-[12px] text-[var(--danger)]">
+            <strong className="tracking-[0.12em] uppercase">controller error</strong>
+            <div className="mt-1">{err}</div>
+          </div>
+        </div>
+      )}
+
+      {tab === 'jingles' && (
+        data ? (
+          <JinglesSection
+            data={data} busy={busy}
+            jingleRatio={jingleRatio ?? ''} setJingleRatio={setJingleRatio}
+            jingleText={jingleText} setJingleText={setJingleText}
+            createJingle={createJingle} uploadJingle={uploadJingle}
+            saveSettings={saveSettings}
+            onDelete={setConfirmDelete} adminFetch={adminFetch}
+          />
+        ) : (
+          !err && <div className="text-[13px] text-muted italic">loading…</div>
+        )
+      )}
+
+      {tab === 'sfx' && (
+        <SfxSection
+          sfxData={sfxData} sfxForm={sfxForm} setSfxForm={setSfxForm}
+          busy={busy} createSfx={createSfx} uploadSfx={uploadSfx}
+          onDelete={setConfirmDeleteSfx}
+          data={data} saveSettings={saveSettings} adminFetch={adminFetch}
+        />
+      )}
+
+      {tab === 'beds' && (
+        <BedsSection
+          bedsData={bedsData} busy={busy} uploadBed={uploadBed}
+          onDelete={setConfirmDeleteBed}
+          data={data} saveSettings={saveSettings} adminFetch={adminFetch}
+        />
+      )}
+
+      <V3AlertDialog
+        open={confirmDelete != null}
+        onOpenChange={(o) => { if (!o) setConfirmDelete(null); }}
+        title="Delete jingle"
+        description={confirmDelete ? `Delete the jingle "${confirmDelete}"? This removes the rendered audio file permanently.` : ''}
+        confirmLabel="delete"
+        danger
+        onConfirm={() => { if (confirmDelete) deleteJingle(confirmDelete); setConfirmDelete(null); }}
+      />
+      <V3AlertDialog
+        open={confirmDeleteSfx != null}
+        onOpenChange={(o) => { if (!o) setConfirmDeleteSfx(null); }}
+        title="Delete sound effect"
+        description={confirmDeleteSfx ? `Delete the sound effect "${confirmDeleteSfx}"? This removes the rendered audio file permanently.` : ''}
+        confirmLabel="delete"
+        danger
+        onConfirm={() => { if (confirmDeleteSfx) deleteSfx(confirmDeleteSfx); setConfirmDeleteSfx(null); }}
+      />
+      <V3AlertDialog
+        open={confirmDeleteBed != null}
+        onOpenChange={(o) => { if (!o) setConfirmDeleteBed(null); }}
+        title="Delete bed"
+        description={confirmDeleteBed ? `Delete the bed "${confirmDeleteBed}"? This removes the audio file permanently. A bundled bed stays deleted — it won't come back on the next restart.` : ''}
+        confirmLabel="delete"
+        danger
+        onConfirm={() => { if (confirmDeleteBed) deleteBed(confirmDeleteBed); setConfirmDeleteBed(null); }}
+      />
+    </div>
+  );
+}

--- a/web/components/admin/imaging/JinglesSection.tsx
+++ b/web/components/admin/imaging/JinglesSection.tsx
@@ -8,12 +8,18 @@ import { Input } from '../../ui/input';
 import { Textarea } from '../../ui/textarea';
 import { Label } from '../../ui/label';
 import { Card, Btn, Pill } from '../ui';
-import {
-  SectionHeader, PreviewButton,
-  type SectionProps, type JingleImportFailure, type JingleImportResult,
-} from './shared';
+import { SectionHeader, PreviewButton, type SettingsData, type SaveSettings } from '../settings/shared';
+import type { JingleImportFailure, JingleImportResult } from './types';
 
-interface JinglesSectionProps extends SectionProps {
+interface JinglesSectionProps {
+  data: SettingsData;
+  busy: boolean;
+  saveSettings: SaveSettings;
+  // Slimmed from the full FormState — jingleRatio is the only settings field
+  // this section touches, so the Imaging page holds it as a lone string rather
+  // than rebuilding Settings' whole form-hydration machinery.
+  jingleRatio: string;
+  setJingleRatio: (v: string) => void;
   jingleText: string;
   setJingleText: (s: string) => void;
   createJingle: () => Promise<boolean>;
@@ -27,10 +33,10 @@ interface JinglesSectionProps extends SectionProps {
 }
 
 export function JinglesSection({
-  data, form, setForm, busy, jingleText, setJingleText,
+  data, busy, jingleRatio, setJingleRatio, jingleText, setJingleText,
   createJingle, uploadJingle, saveSettings, onDelete, adminFetch,
 }: JinglesSectionProps) {
-  const ratioDirty = form.jingleRatio !== String(data.values?.jingleRatio);
+  const ratioDirty = jingleRatio !== String(data.values?.jingleRatio);
   const jingles = data.jingles || [];
   const [modal, setModal] = useState<null | 'create' | 'import'>(null);
   const [importFiles, setImportFiles] = useState<File[]>([]);
@@ -93,15 +99,13 @@ export function JinglesSection({
               type="number"
               min={0}
               max={1000}
-              value={form.jingleRatio}
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                setForm(f => ({ ...f, jingleRatio: e.target.value }))
-              }
+              value={jingleRatio}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setJingleRatio(e.target.value)}
             />
             <span className="text-[12px] text-muted">music tracks per jingle</span>
             <Btn
               tone="solid"
-              onClick={() => saveSettings({ jingleRatio: parseInt(form.jingleRatio, 10) })}
+              onClick={() => saveSettings({ jingleRatio: parseInt(jingleRatio, 10) })}
               disabled={busy || !ratioDirty}
             >
               Save · needs restart

--- a/web/components/admin/imaging/SfxSection.tsx
+++ b/web/components/admin/imaging/SfxSection.tsx
@@ -8,10 +8,8 @@ import { Input } from '../../ui/input';
 import { Textarea } from '../../ui/textarea';
 import { Label } from '../../ui/label';
 import { Card, Btn, Pill, Seg } from '../ui';
-import {
-  SectionHeader, PreviewButton,
-  type SettingsData, type SaveSettings, type SfxData, type SfxForm,
-} from './shared';
+import { SectionHeader, PreviewButton, type SettingsData, type SaveSettings } from '../settings/shared';
+import type { SfxData, SfxForm } from './types';
 
 interface SfxSectionProps {
   sfxData: SfxData | null;

--- a/web/components/admin/imaging/types.ts
+++ b/web/components/admin/imaging/types.ts
@@ -1,0 +1,49 @@
+// Imaging-page-only types — the asset shapes returned by the controller's
+// /sfx and /beds routes, the SFX create-form, and the jingle bulk-import
+// result. These moved out of settings/shared.tsx when Jingles / SFX / Beds
+// left Settings for their own /admin/imaging page (they were never settings
+// data — they're the station's audio assets). The generic settings-save
+// primitives (SettingsData, SaveSettings, SectionHeader, PreviewButton) stay
+// in settings/shared.tsx; the imaging components still import those from there.
+
+export interface SfxEntry {
+  name: string;
+  description?: string;
+  size?: number;
+  durationSec?: number;
+  builtin?: boolean;
+  source?: string;
+}
+
+export interface SfxData {
+  sfx?: SfxEntry[];
+  generatorReady?: boolean;
+}
+
+export interface SfxForm {
+  name: string;
+  description: string;
+  prompt: string;
+  durationSec: string;
+}
+
+export interface BedEntry {
+  name: string;
+  description?: string;
+  size?: number;
+  durationSec?: number | null;
+  source?: string;
+}
+
+export interface BedsData {
+  beds?: BedEntry[];
+  minDurationSec?: number;
+}
+
+export type JingleImportFailure = { name: string; reason: string };
+export type JingleImportResult = {
+  ok: number;
+  total: number;
+  failures: JingleImportFailure[];
+  aborted: boolean;
+};

--- a/web/components/admin/settings/shared.tsx
+++ b/web/components/admin/settings/shared.tsx
@@ -198,7 +198,6 @@ export interface PrivacyForm {
 }
 
 export interface FormState {
-  jingleRatio: string;
   crossfadeDuration: string;
   maxTrackSeconds: string;
   archive: ArchiveForm;
@@ -226,33 +225,6 @@ export interface JingleEntry {
   createdAt?: string;
   builtin?: boolean;
   source?: string;
-}
-
-export interface SfxEntry {
-  name: string;
-  description?: string;
-  size?: number;
-  durationSec?: number;
-  builtin?: boolean;
-  source?: string;
-}
-
-export interface SfxData {
-  sfx?: SfxEntry[];
-  generatorReady?: boolean;
-}
-
-export interface BedEntry {
-  name: string;
-  description?: string;
-  size?: number;
-  durationSec?: number | null;
-  source?: string;
-}
-
-export interface BedsData {
-  beds?: BedEntry[];
-  minDurationSec?: number;
 }
 
 export interface SettingsData {
@@ -375,18 +347,8 @@ export interface SettingsData {
   serverTimezone?: string;
 }
 
-export interface SfxForm {
-  name: string;
-  description: string;
-  prompt: string;
-  durationSec: string;
-}
-
 export type Patch = Record<string, unknown>;
 export type SaveSettings = (patch: Patch) => Promise<void>;
-
-export type JingleImportFailure = { name: string; reason: string };
-export type JingleImportResult = { ok: number; total: number; failures: JingleImportFailure[]; aborted: boolean };
 
 export type FormUpdater = (updater: (f: FormState) => FormState) => void;
 

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,10 +1,14 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "ES2022"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "ES2022"
+    ],
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "allowJs": true,
@@ -18,9 +22,15 @@
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     },
-    "plugins": [{ "name": "next" }]
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
   "include": [
     "next-env.d.ts",
@@ -30,5 +40,10 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", ".next", "out", "build"]
+  "exclude": [
+    "node_modules",
+    ".next",
+    "out",
+    "build"
+  ]
 }


### PR DESCRIPTION
## What & why

**Jingles**, **Sound FX**, and **Beds** were three sections buried inside `/admin/settings`, but they aren't configuration — they're *asset management* (create / upload / delete audio). That's the same category as Library, Shows, Personas, and Skills, all of which are already top-level nav items under **Programming**. This gives them their own home: a new **Imaging** page (the radio term for the audio furniture the DJ drops between and over tracks).

Design spec: `docs/superpowers/specs/2026-07-23-admin-imaging-page-design.md`.

## Changes

- **New page** `/admin/imaging` (`ImagingPanel`) hosting the three as tabs (`Jingles · SFX · Beds`), following the `/admin/connect` tab pattern (`Seg` control + `?tab=` deep-link). Tab labels carry the live counts the settings rail used to show.
- **Moved** `JinglesSection` / `SfxSection` / `BedsSection` into `components/admin/imaging/` (git tracks them as renames), plus their asset types into `imaging/types.ts`. `ImagingPanel` absorbs the state + handlers those sections needed from `SettingsPanel`.
- **Slimmed** `JinglesSection` off the whole `FormState` — it only ever touched `jingleRatio`, so it now takes that one string + a setter, sparing the new page Settings' ~200-line form hydration.
- **`SettingsPanel`** drops the three sections, their state/handlers/dialogs, and `jingleRatio` from `FormState` (~240 lines lighter).
- **No dead bookmarks:** old `/admin/settings?section={jingles,sfx,beds}` redirects to the matching Imaging tab. (No in-app links pointed at those sections, so nothing else needed repointing.)
- **Sidebar:** `Imaging` added to the Programming group with a distinct `Podcast` icon.

Pure front-end reorganisation — the controller `/jingles`, `/sfx`, `/beds` routes are untouched.

## Verification

- ✅ `cd web && npm run lint` (eslint + `tsc --noEmit`) — the CI merge gate — passes clean.
- ⏳ Live admin click-through not yet run (draft). Worth a manual pass: nav shows Imaging → three tabs create/upload/delete work → `?tab=sfx` deep-link → old `?section=beds` redirects → Settings' remaining 12 sections still work.