### PR TITLE
fix(tts): chunk long Chatterbox input to stop autoregressive garbling (#1130)

### DIFF
--- a/controller/scripts/chatterbox_worker.py
+++ b/controller/scripts/chatterbox_worker.py
@@ -22,12 +22,105 @@ resolved through the Hugging Face cache (HF_HOME), pre-warmed at image build.
 
 import json
 import os
+import re
 import sys
 import traceback
 from pathlib import Path
 
 DEVICE = os.environ.get("CHATTERBOX_DEVICE", "cpu").lower()
 DEFAULT_REFERENCE = os.environ.get("CHATTERBOX_REFERENCE_WAV", "")
+
+# --- long-input chunking (issue #1130) -------------------------------------
+# Chatterbox is autoregressive: one generate() over a long block accumulates
+# drift and comes out jumbled/garbled somewhere past ~2 sentences (~300 chars),
+# with NO error thrown — the well-known Chatterbox long-input failure mode, not
+# anything SUB/WAVE-specific. Piper/Kokoro don't hit it (they aren't
+# autoregressive). The mitigation is to synthesise long segments a chunk at a
+# time so the model never sees a block long enough to drift, then stitch the
+# audio back together. Short lines (station IDs, one-line links — the common
+# case) stay a single chunk, so their output is byte-identical to before.
+MAX_CHUNK_CHARS = int(os.environ.get("CHATTERBOX_MAX_CHUNK_CHARS", "280"))
+# Silence inserted between stitched chunks (milliseconds) so a sentence boundary
+# breathes instead of butting straight into the next chunk. Kept short — this is
+# a within-segment pause, not a between-segment one.
+CHUNK_GAP_MS = int(os.environ.get("CHATTERBOX_CHUNK_GAP_MS", "160"))
+
+# Sentence boundary: a .!? followed by whitespace. Clause boundary (fallback for
+# a single sentence longer than the cap): comma / semicolon / colon / dash
+# followed by whitespace — where a speaker would naturally pause.
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+_CLAUSE_SPLIT = re.compile(r"(?<=[,;:—-])\s+")
+
+
+def _hard_wrap(fragment, max_chars):
+    """Last-resort split for a fragment longer than max_chars with no usable
+    punctuation boundary — break on the last space before the cap, else split
+    mid-word. Only reached by pathological input (a single unpunctuated run
+    past the cap); normal DJ copy never gets here."""
+    out = []
+    s = fragment.strip()
+    while len(s) > max_chars:
+        cut = s.rfind(" ", 0, max_chars)
+        if cut <= 0:
+            cut = max_chars
+        out.append(s[:cut].strip())
+        s = s[cut:].strip()
+    if s:
+        out.append(s)
+    return out
+
+
+def chunk_text(text, max_chars=MAX_CHUNK_CHARS):
+    """Pack a spoken segment into <=max_chars chunks on sentence boundaries.
+
+    Never cuts mid-sentence unless a single sentence itself exceeds max_chars —
+    then it falls back to clause boundaries, then a hard word wrap. A line at or
+    under the cap comes back as a single unchanged chunk (the common case, no
+    behaviour change). Pure string logic — no torch/audio deps — so it is
+    unit-testable without loading the model (see test_chatterbox_chunk.py).
+    """
+    text = (text or "").strip()
+    if not text:
+        return []
+    if len(text) <= max_chars:
+        return [text]
+
+    chunks = []
+    current = ""
+
+    def flush():
+        nonlocal current
+        if current:
+            chunks.append(current)
+            current = ""
+
+    def add(piece):
+        nonlocal current
+        piece = piece.strip()
+        if not piece:
+            return
+        if not current:
+            current = piece
+        elif len(current) + 1 + len(piece) <= max_chars:
+            current = f"{current} {piece}"
+        else:
+            flush()
+            current = piece
+
+    for sentence in (s.strip() for s in _SENTENCE_SPLIT.split(text) if s.strip()):
+        if len(sentence) <= max_chars:
+            add(sentence)
+            continue
+        # Sentence alone busts the cap — break it on clause boundaries, and hard
+        # wrap any clause that is still too long, before packing the pieces.
+        for clause in (c.strip() for c in _CLAUSE_SPLIT.split(sentence) if c.strip()):
+            if len(clause) <= max_chars:
+                add(clause)
+            else:
+                for piece in _hard_wrap(clause, max_chars):
+                    add(piece)
+    flush()
+    return chunks
 
 
 def emit(obj):
@@ -43,6 +136,7 @@ def log(msg):
 
 def main():
     try:
+        import numpy as np
         import torch
         import soundfile as sf
         from chatterbox.tts_turbo import ChatterboxTurboTTS
@@ -96,6 +190,23 @@ def main():
         sys.exit(1)
 
     sample_rate = model.sr
+
+    def to_mono_f32(wav):
+        """Reduce a generate() tensor [channels, samples] to a numpy float32
+        array — mono [samples], or [samples, channels] for the rare multichannel
+        case — ready for concatenate + soundfile.write."""
+        if hasattr(wav, "detach"):
+            wav = wav.detach()
+        if hasattr(wav, "cpu"):
+            wav = wav.cpu()
+        samples = wav.numpy() if hasattr(wav, "numpy") else wav
+        if getattr(samples, "ndim", 1) == 2:
+            # [channels, samples] -> mono [samples] or [samples, channels]
+            samples = samples[0] if samples.shape[0] == 1 else samples.T
+        if hasattr(samples, "astype") and getattr(samples, "dtype", None) != "float32":
+            samples = samples.astype("float32")
+        return samples
+
     log("ready")
     emit({"id": None, "ready": True})
 
@@ -119,28 +230,41 @@ def main():
                 reference_wav = ""
             Path(out).parent.mkdir(parents=True, exist_ok=True)
 
+            # Chunk long input so Chatterbox never sees a block long enough to
+            # drift (issue #1130), synthesise each chunk, and stitch. A short
+            # line is a single chunk, so this is a no-op for the common case.
             # Voice cloning is opt-in per request: passing audio_prompt_path
-            # clones the reference clip; omitting it uses the built-in voice.
-            if reference_wav:
-                wav = model.generate(text, audio_prompt_path=reference_wav)
-            else:
-                wav = model.generate(text)
+            # clones the reference clip — the SAME clip on every chunk, so the
+            # cloned voice stays consistent across the stitch; omitting it uses
+            # the built-in voice.
+            pieces = []
+            gap = None
+            for chunk in chunk_text(text):
+                if reference_wav:
+                    wav = model.generate(chunk, audio_prompt_path=reference_wav)
+                else:
+                    wav = model.generate(chunk)
+                samples = to_mono_f32(wav)
+                if pieces:
+                    if gap is None:
+                        gap_len = max(0, int(sample_rate * CHUNK_GAP_MS / 1000.0))
+                        gap = (
+                            np.zeros((gap_len, samples.shape[1]), dtype="float32")
+                            if samples.ndim == 2
+                            else np.zeros(gap_len, dtype="float32")
+                        )
+                    if gap.size:
+                        pieces.append(gap)
+                pieces.append(samples)
 
-            # generate() returns a torch tensor shaped [channels, samples].
-            # Write via soundfile (libsndfile) rather than torchaudio.save:
-            # torch >= 2.8 routes torchaudio.save through torchcodec — an extra
-            # native dep that isn't in the image and whose libnvrtc mismatches
-            # the cu128 wheels on the GPU build. soundfile is already present
-            # (librosa depends on it) and writes the same WAV. It wants a numpy
-            # array shaped [samples] (mono) or [samples, channels].
-            if hasattr(wav, "detach"):
-                wav = wav.detach()
-            if hasattr(wav, "cpu"):
-                wav = wav.cpu()
-            samples = wav.numpy() if hasattr(wav, "numpy") else wav
-            if getattr(samples, "ndim", 1) == 2:
-                # [channels, samples] -> mono [samples] or [samples, channels]
-                samples = samples[0] if samples.shape[0] == 1 else samples.T
+            # Each piece is already a numpy [samples] (mono) or [samples,
+            # channels] float32 array (see to_mono_f32). Write via soundfile
+            # (libsndfile) rather than torchaudio.save: torch >= 2.8 routes
+            # torchaudio.save through torchcodec — an extra native dep that isn't
+            # in the image and whose libnvrtc mismatches the cu128 wheels on the
+            # GPU build. soundfile is already present (librosa depends on it) and
+            # writes the same WAV.
+            samples = np.concatenate(pieces, axis=0) if len(pieces) > 1 else pieces[0]
             sf.write(out, samples, sample_rate)
 
             duration = float(samples.shape[0]) / float(sample_rate)

--- a/controller/scripts/test_chatterbox_chunk.py
+++ b/controller/scripts/test_chatterbox_chunk.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Pure-logic tests for chatterbox_worker.chunk_text (issue #1130).
+
+No torch / audio deps — importing chatterbox_worker only runs its module-level
+setup (env reads + regex compiles), never main(), so this runs with a plain
+stdlib python3:
+
+    python3 controller/scripts/test_chatterbox_chunk.py
+
+CI runs eslint + tsc only (no Python runner), so this is a manual/regression
+harness for the chunker. Exits non-zero on the first failure.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from chatterbox_worker import chunk_text  # noqa: E402
+
+FAILS = []
+
+
+def check(name, cond):
+    status = "PASS" if cond else "FAIL"
+    print(f"[{status}] {name}")
+    if not cond:
+        FAILS.append(name)
+
+
+def within(chunks, cap):
+    return all(len(c) <= cap for c in chunks)
+
+
+def reassembles(chunks, text):
+    """Every non-whitespace char of the original survives, in order (chunking
+    only drops the whitespace it splits on)."""
+    return "".join(chunks).replace(" ", "") == text.replace(" ", "").strip()
+
+
+# 1. Empty / whitespace -> no chunks.
+check("empty string -> []", chunk_text("") == [])
+check("whitespace -> []", chunk_text("   \n  ") == [])
+
+# 2. Short line -> single unchanged chunk (the common case, no behaviour change).
+short = "You're locked into the late show. Here's the next one."
+check("short line is one chunk", chunk_text(short) == [short])
+check("short line unchanged", chunk_text(short)[0] == short)
+
+# 3. A line at exactly the cap stays one chunk; one over splits.
+cap = 40
+exactly = "a" * cap
+check("exactly cap -> one chunk", chunk_text(exactly, max_chars=cap) == [exactly])
+
+# 4. Long multi-sentence segment (weather-report shape) splits on sentence
+#    boundaries, every chunk within the cap, nothing lost.
+weather = (
+    "Good evening across the valley. Right now it's sixteen degrees under a "
+    "clear sky, with a light breeze coming in off the coast. Overnight we'll "
+    "dip to around nine, so grab a jacket if you're heading out late. "
+    "Tomorrow brings more of the same — bright spells, a chance of a shower "
+    "after lunch, and highs near twenty-one degrees."
+)
+wc = chunk_text(weather)
+check("weather splits into multiple chunks", len(wc) > 1)
+check("weather chunks within cap", within(wc, 280))
+check("weather loses no content", reassembles(wc, weather))
+check("weather never starts a chunk mid-word", all(c == c.strip() for c in wc))
+
+# 5. Packing: short adjacent sentences are combined up to the cap rather than
+#    emitted one-per-chunk.
+many = "One. Two. Three. Four. Five. Six. Seven. Eight."
+mc = chunk_text(many, max_chars=20)
+check("short sentences pack together (fewer chunks than sentences)", len(mc) < 8)
+check("packed chunks within cap", within(mc, 20))
+
+# 6. A single sentence longer than the cap falls back to clause boundaries.
+long_sentence = (
+    "It's a night for slow songs, dim lights, and long drives, "
+    "the kind of evening that asks for nothing but a good tune and an open road."
+)
+lc = chunk_text(long_sentence, max_chars=50)
+check("over-cap single sentence still splits", len(lc) > 1)
+check("clause-split chunks within cap", within(lc, 50))
+check("clause-split loses no content", reassembles(lc, long_sentence))
+
+# 7. Pathological: one long unpunctuated run hard-wraps rather than exploding.
+run = "word " * 60  # 300 chars, no sentence punctuation
+rc = chunk_text(run, max_chars=50)
+check("unpunctuated run hard-wraps within cap", within(rc, 50))
+check("hard-wrap loses no content", reassembles(rc, run))
+
+# 8. A single word longer than the cap is broken mid-word (never dropped, never
+#    over-cap) — the true last resort.
+giant = "supercalifragilisticexpialidocious"
+gc = chunk_text(giant, max_chars=10)
+check("giant word splits within cap", within(gc, 10))
+check("giant word loses no content", reassembles(gc, giant))
+
+print()
+if FAILS:
+    print(f"{len(FAILS)} FAILED: {', '.join(FAILS)}")
+    sys.exit(1)
+print("all chunk_text tests passed")


### PR DESCRIPTION
Closes #1130.

## Problem

Chatterbox is autoregressive — it generates audio token-by-token conditioned on its own prior output. On long single-shot inputs it accumulates drift and comes out **jumbled/garbled**, with **no error thrown**. Short lines are fine; segments past ~2 sentences / ~300 chars (weather reports, longer between-track links) garble. Piper/Kokoro don't hit this because they aren't autoregressive. This is the well-known Chatterbox long-input failure mode, not anything SUB/WAVE-specific.

SUB/WAVE reaches the threshold in normal operation: intro links are length-capped (`enforceIntroBudget`), but weather, news, hourly time, station IDs, and longer links are **not** bounded, so they routinely exceed ~300 chars.

## Fix

Chunk the input **inside the engine** — `controller/scripts/chatterbox_worker.py`, the single worker script used by **both** the `subwave-tts-heavy` sidecar (`docker/tts-heavy/server.py` spawns this exact script) and the legacy in-process `--build-arg WITH_CHATTERBOX=1` build. One change fixes every deployment mode.

- `chunk_text()` packs the segment into `<=280`-char chunks on **sentence** boundaries, never cutting mid-sentence — with a fallback cascade for a single over-long sentence (**clause** boundaries → **hard word-wrap**).
- Each chunk is synthesised with the **same** `reference_wav`, so the cloned voice stays consistent across the stitch.
- Chunks are concatenated as float32 with a short silence gap (default 160 ms) and written as **one** WAV; duration is recomputed from total samples.
- A short line yields a single chunk → **no behaviour change** for the common case (no extra latency, byte-identical output).
- Tunable via `CHATTERBOX_MAX_CHUNK_CHARS` / `CHATTERBOX_CHUNK_GAP_MS`.

## Tests

`chunk_text` is pure string logic, unit-tested by `controller/scripts/test_chatterbox_chunk.py` (stdlib-only — importing the worker never runs `main()`/torch). CI runs eslint + tsc only, so this is a manual/regression harness:

```
$ python3 controller/scripts/test_chatterbox_chunk.py
... 18 checks, all chunk_text tests passed
```

Also validated the stitch/concat path with numpy-mocked `generate()` (multi-chunk → correct total length = audio + N gaps, mono float32; single-chunk → no gap, unchanged).

## Verification caveat

Audio **quality** (does it actually sound clean end-to-end) can't be verified without the heavy sidecar and the multi-GB model loaded, which isn't available in CI/this environment. The chunking + stitch logic is verified above; the on-air "sounds clean now" confirmation needs a `subwave-tts-heavy` rebuild + a long-segment generation. @FoggyMtnDrifter offered to help test — this is the piece that needs a real Chatterbox run.