### PR TITLE
fix(picker): enforce back-to-back artist variety on the agent path (#1124)

### DIFF
--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -31,7 +31,7 @@ import * as budget from './dj-budget.js';
 import { speechPaceScale } from '../audio/tts.js';
 import { normalizeForSpeech } from '../audio/speech-text.js';
 import { withTrace, logEvent } from '../observability/events.js';
-import { recencyWindowsForLibrary, effectiveNoRepeatWindow } from '../music/recency.js';
+import { recencyWindowsForLibrary, effectiveNoRepeatWindow, artistKey } from '../music/recency.js';
 import { hasEraBound, genreResolutionWarningOnce } from '../music/show-filter.js';
 import { djCallsAllowed } from './listeners.js';
 import * as likes from './likes.js';
@@ -563,12 +563,18 @@ async function enqueuePick(
 // the same closing move pickNextTrack already uses. Returns a full pick object
 // (id/reason/say/transition) or null; never throws, so a salvage failure falls
 // through to the caller's pick.rejected path unchanged.
-async function repickFromSeen({ seen, badId, wantLink, showAt = null, playlistResolved = true }: { seen: Map<string, any>; badId: string | null; wantLink: boolean; showAt?: Date | null; playlistResolved?: boolean }) {
+// `reason`, when given, replaces the default "you returned a bad id" framing —
+// the back-to-back artist guard (#1124) reuses this same constrained re-pick
+// but for a valid pick it wants to swap off the on-air artist, so the bad-id
+// wording would be false and confuse the model.
+async function repickFromSeen({ seen, badId, wantLink, showAt = null, playlistResolved = true, reason = null }: { seen: Map<string, any>; badId: string | null; wantLink: boolean; showAt?: Date | null; playlistResolved?: boolean; reason?: string | null }) {
   const ids = [...seen.keys()];
   if (ids.length === 0) return null;
   const schema = modelTolerant(pickSchemaBase().extend({
     id: z.enum(ids as [string, ...string[]]).describe('the exact id of one candidate'),
   }));
+  const why = reason
+    ?? `You explored the library and then answered with ${badId ? `the id "${badId}", which matches none of the tracks your tools returned` : 'no usable track id'}. Only ids from the candidates above are real. Choose the best next track from them.`;
   try {
     return await djObject({
       // Same show snapshot as the failed run (showAt) and the same playlist-
@@ -578,7 +584,7 @@ async function repickFromSeen({ seen, badId, wantLink, showAt = null, playlistRe
       // different show than the run whose candidates we're re-picking from.
       system: pickSystem(showAt, playlistResolved),
       prompt: JSON.stringify({ candidates: [...seen.values()] }, null, 2)
-        + `\n\nYou explored the library and then answered with ${badId ? `the id "${badId}", which matches none of the tracks your tools returned` : 'no usable track id'}. Only ids from the candidates above are real. Choose the best next track from them.`
+        + `\n\n${why}`
         + (wantLink
             ? ' Write the "say" link for the track you choose, following the same rules.'
             : ' Set "say" to null.'),
@@ -734,6 +740,47 @@ async function pickViaAgent(queue, { wantLink, audioWaypoint = null, current = n
     // live trace so agent-pick reliability is real.
     logEvent('pick.rejected', { agent: 'pick', id: object?.id ?? null, candidates: extras.seen.size, steps, toolCalls });
     throw new Error(`agent returned unknown id ${object?.id}`);
+  }
+
+  // Back-to-back artist guard (#1124). The discovery tools — especially
+  // tracksLikeThis / tracksThatSoundLikeThis — return a tight cluster around
+  // the current track, which is frequently a run of the SAME artist, and the
+  // agent path (unlike the pool picker) carries no recentArtists / maxPerArtist
+  // filter (see the buildPickerTools note: an artist strip inside the tools
+  // gutted the similarity pool to ~1 survivor on niche catalogues, #618). So
+  // enforce variety at the point of choice instead: if the pick repeats the
+  // on-air artist and the run surfaced ANY other-artist candidate, re-pick from
+  // just those (a constrained djObject over the run's own `seen`, so it still
+  // reasons about flow and writes a coherent link). Relax — allow the repeat —
+  // only when the whole pool is that one artist, mirroring the pool picker's
+  // never-starve. The relaxation is logged with the candidate count so an
+  // operator can tell "no alternative existed" from a real bug (#1124 ask #2).
+  const curArtist = artistKey(current || {});
+  if (curArtist && artistKey(song) === curArtist) {
+    const alt = new Map<string, any>([...extras.seen].filter(([, s]) => artistKey(s) !== curArtist));
+    if (alt.size) {
+      const repicked = await repickFromSeen({
+        seen: alt, badId: null, wantLink, showAt,
+        playlistResolved: !!playlistTracks?.length,
+        reason: `The track you chose is by ${song.artist}, the artist already on air — never play the same artist twice in a row. Choose a DIFFERENT artist from the candidates above.`,
+      });
+      const altSong = repicked?.id ? extras.seen.get(repicked.id) : null;
+      if (altSong) {
+        logEvent('pick.artistGuard', { relaxed: false, from: song.artist, to: altSong.artist, candidates: alt.size });
+        queue.log('picker', `back-to-back artist "${song.artist}" avoided — re-picked "${altSong.title}" by ${altSong.artist} from ${alt.size} other-artist candidate(s)`);
+        object = repicked;
+        song = altSong;
+      } else {
+        // The constrained re-pick call itself failed (model/parse error). Keep
+        // the original pick rather than drop the slot — but say so, since the
+        // guard did NOT get to relax by choice.
+        logEvent('pick.artistGuard', { relaxed: true, reason: 'repick-failed', artist: song.artist, candidates: alt.size });
+        queue.log('picker', `back-to-back artist "${song.artist}" — re-pick from ${alt.size} other-artist candidate(s) didn't land; keeping original`);
+      }
+    } else {
+      logEvent('pick.artistGuard', { relaxed: true, reason: 'no-other-artist', artist: song.artist, candidates: 0 });
+      queue.log('picker', `back-to-back artist "${song.artist}" allowed — no other-artist candidate in the pool (relaxed)`);
+    }
   }
 
   const rawSay = typeof object.say === 'string' ? object.say.trim() : '';

--- a/controller/src/llm/internal/tools/picker-tools.ts
+++ b/controller/src/llm/internal/tools/picker-tools.ts
@@ -91,7 +91,10 @@ function slim(s: any) {
 // clustered around what's currently playing — i.e. the just-played artist's
 // neighbours — so an artist-recency strip gutted them to ~1 result while the
 // 12h track guard already prevents literal repeats (issue: thin picker pools on
-// niche catalogues). Track-recency alone is enough.
+// niche catalogues). Track-recency alone is enough here; back-to-back artist
+// variety is enforced downstream at the point of choice, in
+// dj-agent.pickViaAgent (re-pick off the on-air artist when possible, #1124),
+// so the tools can keep surfacing same-artist neighbours for the model to weigh.
 export function buildPickerTools({
   recentIds = new Set<string>(),
   recentKeys = new Set<string>(),

--- a/controller/src/music/recency.ts
+++ b/controller/src/music/recency.ts
@@ -45,13 +45,14 @@ export interface CandidateFilterState {
   maxPerArtist?: number;
   cap?: number;
   // Whether a starved result may relax the recent-ARTIST guard. Default true
-  // preserves the pool picker's "never return empty" behaviour. The agent's
-  // per-tool collect() passes false: a single-artist tool (topSongsByArtist /
-  // similarSongs narrowed to one recent artist) then returns empty instead of
-  // handing the just-played artist straight back — the agent reaches for one of
-  // its other six discovery tools. This closes the artist-fixation bypass that
-  // let one artist re-air every ~1.2h despite the 2h artist window. Tracks may
-  // still relax as a last resort, but only for FRESH (non-recent) artists.
+  // preserves the pool picker's "never return empty" behaviour. Only the pool
+  // picker (music/picker.ts) passes recentArtists today, so this flag only bites
+  // there; the agent's per-tool collect() no longer filters by artist at all
+  // (#618 — an artist strip gutted the similarity tools to ~1 survivor on niche
+  // catalogues), which is why it defaults true and is inert on that path.
+  // Back-to-back artist variety on the AGENT path is instead enforced at the
+  // point of choice: dj-agent.pickViaAgent re-picks from other-artist
+  // candidates when a pick would repeat the on-air artist (#1124).
   allowArtistRelaxation?: boolean;
 }
 


### PR DESCRIPTION
Fixes #1124.

## The bug (confirmed from the reporter's investigation)

The DJ **agent** picker has no code-level artist-repeat guard. The discovery tools — especially `tracksLikeThis` / `tracksThatSoundLikeThis` — return a tight cluster around the current track, which is often a run of the **same artist**, and the shared `collect()` filter (`picker-tools.ts`) only strips track-recency: no `recentArtists`, no `maxPerArtist`. The chosen track is then enqueued directly in `pickViaAgent`, so the only artist-repeat protection was the soft `PICKER_CRITERIA` prompt line ("avoid the same artist back-to-back"). When a similarity tool surfaced nothing but the on-air artist, the model had no alternative and the repeat aired (the reporter's Ride → Ride, Faith No More ×3 cases).

The **pool** picker (the fallback) *does* guard this — `recentArtists` (2h window) + `maxPerArtist: 3` — which is exactly why the reporter saw the correlation with `tracksLikeThis`.

## Why it regressed

- **#603** fixed this exact issue ("artist-fixation bypass") by having the agent's `collect()` pass `recentArtists` + `maxPerArtist` + `allowArtistRelaxation:false`.
- **#618** (next day) removed all three — an artist strip gutted the similarity tools to ~1 survivor on niche catalogues — reopening the bypass. The `recency.ts` comment still documented the now-removed protection.

## The fix

Enforce variety at the **point of choice**, not inside the tools (so #618's thin-pool win is preserved and `tracksLikeThis` keeps surfacing same-artist neighbours for the model to weigh):

- `broadcast/dj-agent.ts` — in `pickViaAgent`, after the pick is finalised: if it repeats the on-air artist **and** the run's own `seen` map holds any other-artist candidate, re-pick from just those via the existing constrained `djObject` path (still reasons about flow, still writes a coherent link). Relax — allow the repeat — **only** when the whole pool is that one artist, mirroring the pool picker's never-starve. The relaxation is logged with the candidate count (`pick.artistGuard` event + `picker` log), covering the reporter's ask #2.
- `repickFromSeen` gains an optional `reason` so the artist-swap prompt isn't the misleading "you returned a bad id" framing.
- `music/recency.ts` — corrects the stale `allowArtistRelaxation` comment.
- `llm/internal/tools/picker-tools.ts` — points the no-artist-filter note at the new downstream guard.

Request path is deliberately untouched (listeners can re-request an artist).

## Scope / notes

- The extra `djObject` re-pick fires **only** when the agent actually picks a back-to-back same artist — the misbehaving case — so it's off the happy path. Only runs in the normal budget tier (the soft tier already skips the agent for the pool picker).
- The reporter's longer-term "intentional linked album tracks" idea (e.g. *Dark Side of the Moon*) is left for a follow-up; this guard would need a per-show/per-run opt-out for that.

## Testing

`cd controller && npm run lint` → 0 errors. No test runner in this repo; the guard's decision is straightforward `artistKey` comparison + `seen` filtering reusing existing salvage machinery.