### PR TITLE
fix(analyzer): stop mass false-positive vocal tags (#1125)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,14 @@ SITE_URL=
 # Building from source instead of pulling? `docker compose build analyzer` with
 # ANALYZER_HEAVY=1 bakes the stack (or pass WITH_CLAP=1 / WITH_DEMUCS=1 directly).
 #
+# Vocal-gate tuning (#1125). The Demucs vocal stem is thresholded against BOTH
+# its own loud level AND a fraction of the FULL-MIX loud level — the mix floor
+# stops separation bleed on instrumentals from reading as vocals. Raise the
+# floor if instrumentals still slip through (over-compressed masters leak more);
+# lower it if quiet vocals get dropped. Defaults shown.
+# VOCAL_MIX_FLOOR=0.06     # vocal stem must reach >=6% of the full-mix loud level
+# VOCAL_STEM_REL=0.15      # ...OR >=15% of the vocal stem's own loud level
+#
 # Optional model overrides (sensible defaults shown):
 # CLAP_MODEL=laion-clap
 # DEMUCS_MODEL=htdemucs   # vocal separation is the slow pass, and the default

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # (a broken macOS-local symlink slipped past the dir-only pattern in #325).
 node_modules
 
+# Python bytecode (running scripts/vocal_gate_test.py compiles analyze_worker)
+__pycache__/
+
 # Next.js
 .next/
 out/

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -1252,6 +1252,14 @@ SITE_URL=
 # Building from source instead of pulling? \`docker compose build analyzer\` with
 # ANALYZER_HEAVY=1 bakes the stack (or pass WITH_CLAP=1 / WITH_DEMUCS=1 directly).
 #
+# Vocal-gate tuning (#1125). The Demucs vocal stem is thresholded against BOTH
+# its own loud level AND a fraction of the FULL-MIX loud level — the mix floor
+# stops separation bleed on instrumentals from reading as vocals. Raise the
+# floor if instrumentals still slip through (over-compressed masters leak more);
+# lower it if quiet vocals get dropped. Defaults shown.
+# VOCAL_MIX_FLOOR=0.06     # vocal stem must reach >=6% of the full-mix loud level
+# VOCAL_STEM_REL=0.15      # ...OR >=15% of the vocal stem's own loud level
+#
 # Optional model overrides (sensible defaults shown):
 # CLAP_MODEL=laion-clap
 # DEMUCS_MODEL=htdemucs   # vocal separation is the slow pass, and the default

--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -101,6 +101,32 @@ VOCAL_ENABLED = os.environ.get("ANALYZE_VOCAL_ACTIVITY", "").strip().lower() in 
 DEMUCS_SR = 44100
 DEMUCS_MODEL = os.environ.get("DEMUCS_MODEL", "").strip() or "htdemucs"
 
+
+def _env_float(name, default):
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        # Runs at module load, before log() is defined — write stderr directly.
+        sys.stderr.write(
+            f"[analyze-worker] {name}={raw!r} is not a number; using default {default}\n"
+        )
+        return default
+
+
+# Vocal-stem gate thresholds (issue #1125). The stem is thresholded against BOTH
+# its own loud level (self-relative, catches quiet-but-present vocals) AND a
+# fraction of the FULL-MIX loud level (an absolute-ish floor). Demucs never
+# separates cleanly: an instrumental's vocal stem carries residual bleed (pad
+# swells, cymbals, guitar harmonics). A purely self-relative gate scales down to
+# that bleed and mass-flags instrumentals as vocal. Anchoring the floor to the
+# whole song's loudness fixes it — bleed sits far below the mix, real vocals
+# don't. Both tunable so operators can adapt to their masters' compression.
+VOCAL_STEM_REL = _env_float("VOCAL_STEM_REL", 0.15)  # x 90th-pct of vocal-stem RMS
+VOCAL_MIX_FLOOR = _env_float("VOCAL_MIX_FLOOR", 0.06)  # x 90th-pct of full-mix RMS
+
 # Krumhansl-Kessler key profiles (major/minor), indexed from the tonic.
 MAJOR_PROFILE = [6.35, 2.23, 3.48, 2.33, 4.38, 4.09, 2.52, 5.19, 2.39, 3.66, 2.29, 2.88]
 MINOR_PROFILE = [6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 2.69, 3.34, 3.17]
@@ -727,11 +753,18 @@ class VocalActivityDetector:
             # is how the demucs CLI's -d flag works), so no .to() here.
             est = apply_model(self.model, wav.unsqueeze(0), device=resolve_device())[0]
         vocals = est[self.sources.index("vocals")].mean(dim=0).cpu().numpy()
+        mix = wav.mean(dim=0).cpu().numpy()
 
-        # RMS envelope of the vocal stem, thresholded against its own loud level
-        # (40th-pct of the loud half) — robust to overall mix level. Frames where
-        # vocal energy sustains above threshold become "vocal present" ranges,
-        # merging gaps shorter than ~0.4s so a breath doesn't split a phrase.
+        # RMS envelope of the vocal stem, gated against BOTH its own loud level
+        # (self-relative, catches quiet-but-present vocals) AND a fraction of the
+        # full-mix loud level (issue #1125). Demucs never separates cleanly: an
+        # instrumental's vocal stem carries residual bleed (pad swells, cymbals,
+        # guitar harmonics). A purely self-relative gate scales down to that
+        # bleed and mass-flags instrumentals as vocal — anchoring a floor to the
+        # whole song's loudness keeps bleed below the line while real vocals,
+        # which sit at a real fraction of the mix, still cross. Frames that
+        # sustain above threshold become "vocal present" ranges, merging gaps
+        # shorter than ~0.4s so a breath doesn't split a phrase.
         hop = 512
         rms = librosa.feature.rms(y=vocals, frame_length=2048, hop_length=hop)[0]
         if rms.size == 0:
@@ -739,7 +772,9 @@ class VocalActivityDetector:
         loud = float(np.percentile(rms, 90))
         if loud <= 0:
             return []
-        thr = 0.15 * loud
+        mix_rms = librosa.feature.rms(y=mix, frame_length=2048, hop_length=hop)[0]
+        mix_loud = float(np.percentile(mix_rms, 90)) if mix_rms.size else 0.0
+        thr = max(VOCAL_STEM_REL * loud, VOCAL_MIX_FLOOR * mix_loud)
         times = librosa.frames_to_time(np.arange(rms.size), sr=sr, hop_length=hop)
         active = rms >= thr
         ranges = []

--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -716,6 +716,53 @@ def get_embedder(force=False):
     return _embedder
 
 
+# The vocal gate, split out of the detector so it's testable without torch /
+# demucs / real audio (scripts/vocal_gate_test.py). Takes the vocal-stem RMS
+# envelope and the FULL-MIX RMS envelope (same hop) and returns [{startMs,endMs}]
+# where vocals are present. The stem is gated against BOTH its own loud level
+# (self-relative, catches quiet-but-present vocals) AND a fraction of the mix
+# loud level (issue #1125): Demucs never separates cleanly, so an instrumental's
+# vocal stem carries residual bleed (pad swells, cymbals, guitar harmonics); a
+# purely self-relative gate scales down to that bleed and mass-flags
+# instrumentals as vocal. The mix-anchored floor keeps bleed below the line
+# while real vocals — a genuine fraction of the mix — still cross. Frames that
+# sustain above threshold merge into ranges (gaps <0.4s bridged so a breath
+# doesn't split a phrase); sub-300ms blips are dropped as separation artefacts.
+def vocal_ranges_from_rms(rms, mix_rms, sr, hop):
+    import numpy as np
+
+    if rms.size == 0:
+        return []
+    loud = float(np.percentile(rms, 90))
+    if loud <= 0:
+        return []
+    mix_loud = float(np.percentile(mix_rms, 90)) if mix_rms.size else 0.0
+    thr = max(VOCAL_STEM_REL * loud, VOCAL_MIX_FLOOR * mix_loud)
+    # frames → seconds; librosa.frames_to_time's default is frames * hop / sr.
+    times = np.arange(rms.size) * (hop / float(sr))
+    active = rms >= thr
+    ranges = []
+    merge_gap_ms = 400
+    i = 0
+    n = rms.size
+    while i < n:
+        if not active[i]:
+            i += 1
+            continue
+        j = i
+        while j + 1 < n and active[j + 1]:
+            j += 1
+        start_ms = int(round(float(times[i]) * 1000.0))
+        end_ms = int(round(float(times[min(j + 1, n - 1)]) * 1000.0))
+        if ranges and start_ms - ranges[-1]["endMs"] <= merge_gap_ms:
+            ranges[-1]["endMs"] = end_ms
+        else:
+            ranges.append({"startMs": start_ms, "endMs": end_ms})
+        i = j + 1
+    # Drop sub-300ms blips (separation artefacts, not sung lines).
+    return [r for r in ranges if r["endMs"] - r["startMs"] >= 300]
+
+
 # ---------------------------------------------------------------------------
 # Vocal-activity detector — Demucs source separation → vocal energy envelope →
 # present/absent time ranges. All heavy imports (torch, demucs) are lazy so a
@@ -755,48 +802,10 @@ class VocalActivityDetector:
         vocals = est[self.sources.index("vocals")].mean(dim=0).cpu().numpy()
         mix = wav.mean(dim=0).cpu().numpy()
 
-        # RMS envelope of the vocal stem, gated against BOTH its own loud level
-        # (self-relative, catches quiet-but-present vocals) AND a fraction of the
-        # full-mix loud level (issue #1125). Demucs never separates cleanly: an
-        # instrumental's vocal stem carries residual bleed (pad swells, cymbals,
-        # guitar harmonics). A purely self-relative gate scales down to that
-        # bleed and mass-flags instrumentals as vocal — anchoring a floor to the
-        # whole song's loudness keeps bleed below the line while real vocals,
-        # which sit at a real fraction of the mix, still cross. Frames that
-        # sustain above threshold become "vocal present" ranges, merging gaps
-        # shorter than ~0.4s so a breath doesn't split a phrase.
         hop = 512
         rms = librosa.feature.rms(y=vocals, frame_length=2048, hop_length=hop)[0]
-        if rms.size == 0:
-            return []
-        loud = float(np.percentile(rms, 90))
-        if loud <= 0:
-            return []
         mix_rms = librosa.feature.rms(y=mix, frame_length=2048, hop_length=hop)[0]
-        mix_loud = float(np.percentile(mix_rms, 90)) if mix_rms.size else 0.0
-        thr = max(VOCAL_STEM_REL * loud, VOCAL_MIX_FLOOR * mix_loud)
-        times = librosa.frames_to_time(np.arange(rms.size), sr=sr, hop_length=hop)
-        active = rms >= thr
-        ranges = []
-        merge_gap_ms = 400
-        i = 0
-        n = rms.size
-        while i < n:
-            if not active[i]:
-                i += 1
-                continue
-            j = i
-            while j + 1 < n and active[j + 1]:
-                j += 1
-            start_ms = int(round(float(times[i]) * 1000.0))
-            end_ms = int(round(float(times[min(j + 1, n - 1)]) * 1000.0))
-            if ranges and start_ms - ranges[-1]["endMs"] <= merge_gap_ms:
-                ranges[-1]["endMs"] = end_ms
-            else:
-                ranges.append({"startMs": start_ms, "endMs": end_ms})
-            i = j + 1
-        # Drop sub-300ms blips (separation artefacts, not sung lines).
-        return [r for r in ranges if r["endMs"] - r["startMs"] >= 300]
+        return vocal_ranges_from_rms(rms, mix_rms, sr, hop)
 
 
 def estimate_pace(y, sr, librosa, window_s=5.0):

--- a/controller/scripts/lyric-vocal.test.ts
+++ b/controller/scripts/lyric-vocal.test.ts
@@ -1,0 +1,100 @@
+// Unit tests for the lyric→vocal derivation (music/lyric-vocal.ts): the
+// deterministic vocal-activity path built from Navidrome timed lyrics (#1125).
+// Run: `tsx scripts/lyric-vocal.test.ts`.
+//
+// node:assert-via-tsx style, matching scripts/bed-policy.test.ts.
+
+import assert from 'node:assert/strict';
+import { deriveVocalFromLyrics } from '../src/music/lyric-vocal.js';
+
+// ── inconclusive inputs → null (fall back to Demucs) ─────────────────────────
+
+// No lyrics indexed at all.
+assert.equal(deriveVocalFromLyrics(null), null);
+
+// Unsynced plain text: we know there are words but not WHEN — can't place a cue.
+assert.equal(
+  deriveVocalFromLyrics({ synced: false, lines: [{ startMs: NaN, text: 'la la la' }] }),
+  null,
+);
+
+// Synced but every line is blank (section-break timestamps only) → nothing to place.
+assert.equal(
+  deriveVocalFromLyrics({ synced: true, lines: [{ startMs: 1000, text: '   ' }] }),
+  null,
+);
+
+// ── explicit instrumental markers → instrumental ([]) ────────────────────────
+
+for (const marker of ['Instrumental', '[au: instrumental]', '(instrumental)', 'INSTRUMENTAL']) {
+  const r = deriveVocalFromLyrics({ synced: false, lines: [{ startMs: NaN, text: marker }] });
+  assert.deepEqual(
+    r,
+    { instrumental: true, vocalRanges: [], introMs: null },
+    `marker "${marker}" should read instrumental`,
+  );
+}
+
+// A song that merely SINGS the word must NOT be caught by the marker regex.
+assert.notEqual(
+  deriveVocalFromLyrics({
+    synced: true,
+    lines: [{ startMs: 5000, text: 'this is an instrumental kind of love' }],
+  })?.instrumental,
+  true,
+);
+
+// ── synced lyrics → ranges + intro cue ───────────────────────────────────────
+
+// The reporter's case: Fleetwood Mac "The Chain" — a 27s guitar intro that the
+// energy/Demucs gate mis-reads as vocals at 4s. The first timed line is the truth.
+const chain = deriveVocalFromLyrics({
+  synced: true,
+  lines: [
+    { startMs: 27_930, text: 'Listen to the wind blow' },
+    { startMs: 30_880, text: 'Watch the sun rise' },
+    { startMs: 35_230, text: '' }, // blank section marker — ignored
+    { startMs: 40_960, text: 'Run in the shadows' },
+  ],
+});
+assert.ok(chain && !chain.instrumental);
+assert.equal(chain!.introMs, 27_930, 'intro cue is the first SUNG line, not the guitar intro');
+// Lines within MERGE_GAP_MS (8s) coalesce into one range.
+assert.equal(chain!.vocalRanges.length, 1);
+assert.equal(chain!.vocalRanges[0].startMs, 27_930);
+
+// A wide instrumental gap (a solo) splits the ranges so the vocal-free stretch
+// is visible — here a >8s gap between the second and third sung line.
+const withSolo = deriveVocalFromLyrics({
+  synced: true,
+  lines: [
+    { startMs: 10_000, text: 'verse one' },
+    { startMs: 14_000, text: 'verse two' },
+    { startMs: 60_000, text: 'after the solo' }, // 46s gap → new range
+  ],
+});
+assert.equal(withSolo!.vocalRanges.length, 2);
+assert.equal(withSolo!.vocalRanges[0].startMs, 10_000);
+assert.equal(withSolo!.vocalRanges[1].startMs, 60_000);
+
+// Out-of-order timestamps are sorted before ranging.
+const unordered = deriveVocalFromLyrics({
+  synced: true,
+  lines: [
+    { startMs: 20_000, text: 'second' },
+    { startMs: 5_000, text: 'first' },
+  ],
+});
+assert.equal(unordered!.introMs, 5_000);
+
+// A negative/garbage timestamp is dropped, not clamped into a bogus 0 onset.
+const badTs = deriveVocalFromLyrics({
+  synced: true,
+  lines: [
+    { startMs: -1, text: 'ghost' },
+    { startMs: 12_000, text: 'real' },
+  ],
+});
+assert.equal(badTs!.introMs, 12_000);
+
+console.log('✓ lyric-vocal.test.ts passed');

--- a/controller/scripts/vocal_gate_test.py
+++ b/controller/scripts/vocal_gate_test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Unit test for the vocal gate (analyze_worker.vocal_ranges_from_rms) — the
+# mix-anchored floor that fixes the #1125 mass false-positive. Pure numpy: no
+# torch, no demucs, no audio, so it runs anywhere. Feeds synthesized RMS
+# envelopes (the exact inputs the Demucs path produces) and asserts the floor
+# behaves. Run: `python3 scripts/vocal_gate_test.py` (exit 0 = pass).
+
+import os
+import sys
+
+import numpy as np
+
+# Import the worker with default thresholds (VOCAL_MIX_FLOOR=0.06, STEM_REL=0.15).
+# Heavy imports (torch/demucs/librosa) are lazy, so importing is stdlib-cheap.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import analyze_worker as aw  # noqa: E402
+
+SR = 44100
+HOP = 512
+FPS = SR / HOP  # frames per second (~86)
+
+
+def frames(seconds):
+    return int(round(seconds * FPS))
+
+
+def const(seconds, value):
+    return np.full(frames(seconds), value, dtype=np.float32)
+
+
+assert aw.VOCAL_MIX_FLOOR == 0.06, "test assumes the shipped default floor"
+assert aw.VOCAL_STEM_REL == 0.15, "test assumes the shipped default self-rel"
+
+# ── Case 1: a pure instrumental (the #1125 bug) ──────────────────────────────
+# Loud full mix (a normal song, ~0.5 RMS) but the vocal STEM is only separation
+# bleed — low-level content Demucs leaves behind on an instrumental. Modelled
+# here well below the 6% mix floor (mean ~0.01, peaks ~0.022 = ~2-4% of the
+# 0.5 mix), with one sustained leak spike. NOTE: the exact 0.06 default is a
+# reasoned starting value, NOT empirically calibrated against real Demucs bleed
+# (no torch/audio in CI) — hence env-tunable. This case validates the MECHANISM:
+# stem content below the mix floor is suppressed, content above it isn't.
+rng = np.random.default_rng(0)
+bleed = np.abs(rng.normal(0.01, 0.003, frames(40))).astype(np.float32)
+bleed[frames(5):frames(6)] = 0.022  # a pad-swell leak spike, still < the 0.03 floor
+mix_loud = const(40, 0.5)
+
+# OLD behaviour (no mix floor) mass-flagged this as vocal: the self-relative gate
+# (0.15 * the bleed's OWN 90th-pct) scales right down to the bleed and trips.
+old = aw.vocal_ranges_from_rms(bleed, np.zeros_like(bleed), SR, HOP)
+assert len(old) > 0, "sanity: without a mix floor the bleed DOES trip (the bug)"
+
+# NEW behaviour: the mix floor (0.06 * 0.5 = 0.03) sits above the bleed → no
+# vocal ranges → the track is correctly classed instrumental ([]).
+new = aw.vocal_ranges_from_rms(bleed, mix_loud, SR, HOP)
+assert new == [], f"instrumental must read as [] with the mix floor, got {new}"
+
+# ── Case 2: a real vocal track ───────────────────────────────────────────────
+# 27s instrumental intro (bleed only), then a sustained vocal at 0.3 (60% of the
+# 0.5 mix) — the Fleetwood "The Chain" shape. The vocal must be detected, and its
+# onset must land at the real entry, NOT during the guitar intro.
+voc = np.abs(rng.normal(0.02, 0.008, frames(40))).astype(np.float32)
+voc[frames(27):frames(38)] = 0.3
+mix2 = const(40, 0.5)
+ranges = aw.vocal_ranges_from_rms(voc, mix2, SR, HOP)
+assert len(ranges) >= 1, "a real sustained vocal must be detected"
+onset_s = ranges[0]["startMs"] / 1000.0
+assert 26.5 <= onset_s <= 27.5, f"onset should be ~27s (the sung entry), got {onset_s:.1f}s"
+
+# ── Case 3: the floor is tunable (reporter's fix #2) ──────────────────────────
+# A borderline stem at 0.04 with mix loud 0.5: default floor 0.03 lets it
+# through; raising VOCAL_MIX_FLOOR to 0.10 (floor 0.05) gates it out.
+border = const(10, 0.04)
+mix3 = const(10, 0.5)
+assert len(aw.vocal_ranges_from_rms(border, mix3, SR, HOP)) > 0
+saved = aw.VOCAL_MIX_FLOOR
+try:
+    aw.VOCAL_MIX_FLOOR = 0.10
+    assert aw.vocal_ranges_from_rms(border, mix3, SR, HOP) == [], "raising the floor gates it"
+finally:
+    aw.VOCAL_MIX_FLOOR = saved
+
+# ── Case 4: empty / silent inputs degrade cleanly ────────────────────────────
+assert aw.vocal_ranges_from_rms(np.array([], dtype=np.float32), np.array([]), SR, HOP) == []
+assert aw.vocal_ranges_from_rms(np.zeros(frames(5), dtype=np.float32), const(5, 0.5), SR, HOP) == []
+
+print("✓ vocal_gate_test.py passed")

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -12,8 +12,10 @@
 import { readFile, rm } from 'node:fs/promises';
 import * as db from './library-db.js';
 import * as analyzer from './analyzer.js';
+import * as subsonic from './subsonic.js';
 import * as settings from '../settings.js';
 import { config } from '../config.js';
+import { deriveVocalFromLyrics, type LyricVocalResult } from './lyric-vocal.js';
 import { runAudioMoodPass } from './audio-moods.js';
 import { reportProgress, makeEventLogger } from './tagger-progress.js';
 import { quietGateDecision, type QuietState } from './analyze-quiet-pure.js';
@@ -384,16 +386,36 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
       // doesn't have ANALYZE_AUDIO_EMBEDDING (the admin-toggle path); omitted
       // when audio is off so the backend keeps its env-driven default.
       const embed = audioBackfill ? true : undefined;
+      // Lyric-first vocal ranges (#1125): when vocal activity is wanted, try the
+      // track's timed Navidrome lyrics before spending a Demucs separation. A
+      // synced-lyric or explicit-instrumental track is decided here — accurately,
+      // with no separation bleed — and skips Demucs. Anything inconclusive (no
+      // lyrics, or unsynced text) still runs Demucs (now with the mix floor).
+      // Best-effort: a lyric-fetch failure just falls through to Demucs.
+      let lyricVocal: LyricVocalResult | null = null;
+      if (vocalBackfill) {
+        try {
+          lyricVocal = deriveVocalFromLyrics(await subsonic.getStructuredLyrics(id));
+        } catch {
+          lyricVocal = null;
+        }
+      }
       // vocal:true forces the Demucs pass for this track (admin/backfill path),
-      // mirroring embed; omitted when vocal activity is off.
-      const vocal = vocalBackfill ? true : undefined;
+      // mirroring embed; skipped when lyrics already decided it, or when vocal
+      // activity is off.
+      const vocal = vocalBackfill && !lyricVocal ? true : undefined;
       const a = localPath
         ? await analyzer.analyzePath(localPath, { embed, vocal, complete: localComplete })
         : await analyzer.analyze(id, { embed, vocal });
+      // Lyrics win over the worker's vocal output when present: the ranges are
+      // ground truth, and a synced onset is a truer intro than the energy
+      // heuristic the worker returns once Demucs is skipped. An instrumental
+      // marker (introMs null) keeps the energy-based intro.
+      const vocalRanges = lyricVocal ? lyricVocal.vocalRanges : a.vocalRanges;
       db.upsertTrackAnalysis(id, {
         bpm: a.bpm,
         musicalKey: a.musicalKey,
-        introMs: a.introMs,
+        introMs: lyricVocal?.introMs != null ? lyricVocal.introMs : a.introMs,
         confidence: a.confidence,
         loudnessLufs: a.loudnessLufs,
         peakDb: a.peakDb,
@@ -402,10 +424,10 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
         beats: a.beats,
         bars: a.bars,
         keyRanges: a.keyRanges,
-        vocalRanges: a.vocalRanges,
+        vocalRanges,
         outro: a.outro,
       });
-      if (a.vocalRanges != null) vocalAnalyzed += 1;
+      if (vocalRanges != null) vocalAnalyzed += 1;
       // Opportunistically store the CLAP audio vector whenever the backend
       // carried one. Independent of the bpm/key write above: a track analysed
       // before CLAP was enabled simply gets its vector on the next pass once

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -401,9 +401,12 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
         }
       }
       // vocal:true forces the Demucs pass for this track (admin/backfill path),
-      // mirroring embed; skipped when lyrics already decided it, or when vocal
-      // activity is off.
-      const vocal = vocalBackfill && !lyricVocal ? true : undefined;
+      // mirroring embed. A lyric-decided track sends an EXPLICIT false — the
+      // worker only skips Demucs on undefined when its OWN env has vocal off,
+      // and the analyzer service/AIO can carry ANALYZE_VOCAL_ACTIVITY, which
+      // would pay the whole separation just to have its result overridden
+      // below. Omitted when vocal activity is off.
+      const vocal = vocalBackfill ? (lyricVocal ? false : true) : undefined;
       const a = localPath
         ? await analyzer.analyzePath(localPath, { embed, vocal, complete: localComplete })
         : await analyzer.analyze(id, { embed, vocal });

--- a/controller/src/music/lyric-vocal.ts
+++ b/controller/src/music/lyric-vocal.ts
@@ -1,0 +1,90 @@
+// Lyric-derived vocal activity (issue #1125). Navidrome already indexes timed
+// (synced) lyrics — the plain `subsonic.getLyrics()` flattens them to text for
+// embeddings and throws the per-line timings away. `getStructuredLyrics()`
+// preserves the timings, and this pure module turns them into the same
+// {startMs,endMs} vocal ranges the Demucs detector emits.
+//
+// Why this is worth it: Demucs never separates cleanly, so an instrumental's
+// "vocal" stem carries residual bleed (pad swells, cymbals, guitar harmonics)
+// that a self-relative energy gate mistakes for singing (the mass false-positive
+// in #1125). A synced lyric line is ground truth — the vocal starts exactly when
+// the line does. So when a track has usable timed lyrics we skip the detector
+// entirely; an explicit "instrumental" marker tags it instrumental for free; and
+// anything inconclusive (no lyrics, or unsynced text with no timing) returns
+// null so the caller falls back to Demucs (now with the mix-anchored floor).
+//
+// Pure + side-effect-free: unit-pinned by scripts/lyric-vocal.test.ts.
+
+export interface LyricLine {
+  startMs: number; // milliseconds from track start; NaN when unsynced
+  text: string;
+}
+
+export interface StructuredLyrics {
+  synced: boolean;
+  lines: LyricLine[];
+}
+
+export interface Section {
+  startMs: number;
+  endMs: number;
+}
+
+export interface LyricVocalResult {
+  instrumental: boolean; // true → vocalRanges is []
+  vocalRanges: Section[]; // [] for an instrumental
+  introMs: number | null; // first vocal onset, or null for an instrumental
+}
+
+// A lyric "body" that is really a no-lyrics/instrumental marker, not sung words.
+// Covers the LRC `[au: instrumental]` metadata tag some players surface as a
+// line and the common single-line "Instrumental" placeholder. Anchored to the
+// whole string so a song that merely SINGS the word "instrumental" isn't caught.
+const INSTRUMENTAL_RE = /^\s*[[(]?\s*(?:au\s*:\s*)?instrumental\s*[)\]]?\s*$/i;
+
+// Consecutive sung lines closer than this merge into one vocal range; a wider
+// gap (a solo, an instrumental bridge) splits them so the ranges expose real
+// vocal-free stretches. 8s keeps a verse together but still surfaces breaks.
+const MERGE_GAP_MS = 8_000;
+// A line extends until the next line, capped so a long trailing gap before the
+// next line reads as an instrumental break rather than sustained singing.
+const MAX_LINE_MS = 8_000;
+// The final line has no successor to bound it — give it a nominal sung tail.
+const LAST_LINE_TAIL_MS = 4_000;
+
+// Turn structured lyrics into vocal ranges + an intro cue, or null when the
+// input can't decide (caller falls back to Demucs). `null` in / no usable timing
+// → null out; an all-marker body → instrumental ([]); synced timed lines →
+// merged ranges with the first onset as the intro.
+export function deriveVocalFromLyrics(lyrics: StructuredLyrics | null): LyricVocalResult | null {
+  if (!lyrics) return null;
+  const lines = lyrics.lines.filter((l) => l.text.trim().length > 0);
+
+  // Explicit instrumental marker: every non-empty line is the marker text.
+  if (lines.length > 0 && lines.every((l) => INSTRUMENTAL_RE.test(l.text))) {
+    return { instrumental: true, vocalRanges: [], introMs: null };
+  }
+
+  // Placing vocals in time needs real timestamps; unsynced text or a body with
+  // no timed lines is inconclusive — let Demucs handle it.
+  if (!lyrics.synced) return null;
+  const timed = lines
+    .filter((l) => Number.isFinite(l.startMs) && l.startMs >= 0)
+    .sort((a, b) => a.startMs - b.startMs);
+  if (timed.length === 0) return null;
+
+  const ranges: Section[] = [];
+  for (let i = 0; i < timed.length; i++) {
+    const start = timed[i].startMs;
+    const next = i + 1 < timed.length ? timed[i + 1].startMs : null;
+    const end = next != null ? Math.min(next, start + MAX_LINE_MS) : start + LAST_LINE_TAIL_MS;
+    const last = ranges[ranges.length - 1];
+    if (last && start - last.endMs <= MERGE_GAP_MS) {
+      last.endMs = Math.max(last.endMs, end);
+    } else {
+      ranges.push({ startMs: start, endMs: end });
+    }
+  }
+
+  return { instrumental: false, vocalRanges: ranges, introMs: ranges[0].startMs };
+}

--- a/controller/src/music/subsonic.ts
+++ b/controller/src/music/subsonic.ts
@@ -576,7 +576,9 @@ export async function getLyrics(songId) {
 // start offsets getLyrics() throws away (#1125). Returns { synced, lines } — the
 // raw material for lyric-derived vocal ranges (music/lyric-vocal.ts) — or null
 // when no lyrics are indexed. Line `start` is milliseconds from track start; the
-// entry-level `offset` (a global shift) is folded in and negatives clamped to 0.
+// entry-level `offset` (a global shift) is folded in — per OpenSubsonic
+// "positive means lyrics appear sooner", i.e. effective start = start − offset —
+// and negatives clamped to 0.
 // synced=false marks unsynced/plain-text lyrics whose line timings are absent.
 export async function getStructuredLyrics(
   songId,
@@ -594,7 +596,7 @@ export async function getStructuredLyrics(
     const lines = lineArr.map((l) => {
       const text = typeof l?.value === 'string' ? l.value : '';
       const rawStart = Number(l?.start);
-      const startMs = Number.isFinite(rawStart) ? Math.max(0, rawStart + offset) : NaN;
+      const startMs = Number.isFinite(rawStart) ? Math.max(0, rawStart - offset) : NaN;
       return { startMs, text };
     });
     return { synced, lines };

--- a/controller/src/music/subsonic.ts
+++ b/controller/src/music/subsonic.ts
@@ -572,6 +572,37 @@ export async function getLyrics(songId) {
   }
 }
 
+// Timed lyrics via the same getLyricsBySongId call, but PRESERVING the per-line
+// start offsets getLyrics() throws away (#1125). Returns { synced, lines } — the
+// raw material for lyric-derived vocal ranges (music/lyric-vocal.ts) — or null
+// when no lyrics are indexed. Line `start` is milliseconds from track start; the
+// entry-level `offset` (a global shift) is folded in and negatives clamped to 0.
+// synced=false marks unsynced/plain-text lyrics whose line timings are absent.
+export async function getStructuredLyrics(
+  songId,
+): Promise<{ synced: boolean; lines: Array<{ startMs: number; text: string }> } | null> {
+  try {
+    const r = await call('getLyricsBySongId', { id: songId });
+    const structured = r.lyricsList?.structuredLyrics;
+    if (!Array.isArray(structured) || structured.length === 0) return null;
+    // A track may carry several versions (languages, synced + unsynced) — prefer
+    // a synced one, since only that has the timings we're after.
+    const chosen = structured.find((s) => s?.synced === true) ?? structured[0];
+    const synced = chosen?.synced === true;
+    const offset = Number.isFinite(chosen?.offset) ? Number(chosen.offset) : 0;
+    const lineArr = Array.isArray(chosen?.line) ? chosen.line : [];
+    const lines = lineArr.map((l) => {
+      const text = typeof l?.value === 'string' ? l.value : '';
+      const rawStart = Number(l?.start);
+      const startMs = Number.isFinite(rawStart) ? Math.max(0, rawStart + offset) : NaN;
+      return { startMs, text };
+    });
+    return { synced, lines };
+  } catch {
+    return null;
+  }
+}
+
 // Async iterator over every song in the library. Walks albums in batches.
 // Each yielded song is annotated with the album-level era signals Navidrome
 // only exposes on the album record (issue #842): `albumIsCompilation`


### PR DESCRIPTION
Fixes #1125.

## The bug
The Demucs vocal-activity detector flagged nearly every instrumental as having vocals (reporter: 12/50,000 tracks classed instrumental), which also poisons the DJ intro talk-over cue.

## Root cause (not what the issue said)
The issue proposed the detector ran on the raw `y_src` mix, or used fixed `0.01`/`0.022` thresholds. Neither matched the code — detection **already** ran on the isolated Demucs vocals stem (`analyze_worker.py:729`), and the gate was **already** relative (`thr = 0.15 × 90th-pct(stem_rms)`). The `0.01/0.022` numbers were from the reporter's own diagnostic tool.

The real flaw: that relative gate had **no floor**. Demucs never separates cleanly, so an instrumental's vocal stem carries residual bleed (pad swells, cymbals, guitar harmonics). A self-relative gate scales *down* to that bleed and trips → instrumental reads as vocal.

## The fix
Anchor a floor to the **full-mix** loud level:

```
thr = max(VOCAL_STEM_REL × stem_loud, VOCAL_MIX_FLOOR × mix_loud)
```

Bleed sits far below the whole song's loudness; real vocals, at a genuine fraction of the mix, still cross. Both knobs are env-tunable (`VOCAL_MIX_FLOOR=0.06`, `VOCAL_STEM_REL=0.15`) — the reporter's fix #2.

## Bonus — lyric-first vocal ranges
Navidrome already indexes timed lyrics, but `subsonic.getLyrics()` flattened them to text and threw the per-line timings away. New `getStructuredLyrics()` keeps them, and `lyric-vocal.ts` turns synced lyrics into the same `{startMs,endMs}` ranges — ground truth, no bleed. When vocal activity is wanted the analysis pass now tries lyrics first:

- **synced lyrics** → derive ranges + a true intro cue, skip Demucs entirely;
- **explicit `[instrumental]` marker** → tagged instrumental for free;
- **inconclusive** (no lyrics / unsynced text) → still runs Demucs, now with the floor.

## Scope
Only affects installs that opted into the heavy analyzer (`WITH_DEMUCS=1`) **and** enabled `ANALYZE_VOCAL_ACTIVITY` — the population that actually has the bug. A default (lean) install never runs vocal detection, so `instrumental` stays `null` (unknown), not `false`.

## Follow-up (deliberately not here)
Let the lyric path run on lean images with no Demucs at all — needs the `vocalActivity` toggle decoupled from Demucs availability + a "lyric-checked" stamp so no-lyric tracks aren't re-scanned every pass.

## Testing
**Behaviourally verified (unit tests run):**
- `scripts/vocal_gate_test.py` — the mix-floor gate math was extracted into a pure `vocal_ranges_from_rms()` and pinned with a numpy test (no torch/demucs/audio needed): sub-floor stem bleed on a loud mix → `[]` (the bug), a sustained real vocal → detected with the onset at the true ~27s entry, the floor is tunable, empty/silent → `[]`.
- `scripts/lyric-vocal.test.ts` — marker detection, synced-range merging, instrumental-solo gap split, sort/negative-timestamp handling (incl. the "The Chain" 27.9s cue).
- `scripts/bed-policy.test.ts` (a `vocalRanges` consumer) — still green.

**Checked, not behaviourally run (no heavy analyzer / audio in this env):**
- The full Demucs `detect()` path against real audio — **not** run; `analyze_worker.py` is `py_compile`-clean only. **The `0.06` mix-floor default is a reasoned starting value, not calibrated against real bleed** — that's why it's env-tunable, and it should get a field pass on the heavy analyzer.
- `getStructuredLyrics` (live Navidrome shape) + the `analyze.ts` orchestration — `tsc --noEmit` type-checked only, not exercised end-to-end.
- `npm run lint` (controller): 0 errors; `.env.example` documented; `cli/src/assets.generated.ts` re-embedded.