### PR TITLE
feat(web): redesign /admin/imaging with editorial layout

### DIFF
--- a/web/components/admin/imaging/BedsSection.tsx
+++ b/web/components/admin/imaging/BedsSection.tsx
@@ -2,13 +2,20 @@
 
 import type { ChangeEvent } from 'react';
 import { useRef, useState } from 'react';
+import { Trash2 } from 'lucide-react';
 import { fmtSize } from '../../../lib/format';
 import { Modal } from '../../ui/modal';
 import { Input } from '../../ui/input';
 import { Label } from '../../ui/label';
-import { Card, Btn, Pill, Seg } from '../ui';
-import { SectionHeader, PreviewButton, type SettingsData, type SaveSettings } from '../settings/shared';
+import { Button } from '../../ui/button';
+import { Badge } from '../../ui/badge';
+import { V3Alert } from '../../ui/alert';
+import { Btn, Seg } from '../ui';
+import { PreviewButton, type SettingsData, type SaveSettings } from '../settings/shared';
 import type { BedsData } from './types';
+import {
+  SectionMasthead, PanelBox, PanelHead, EmptyState, DropZone, MetaLine, TabMetric, pad2,
+} from './parts';
 
 interface BedsSectionProps {
   bedsData: BedsData | null;
@@ -67,196 +74,190 @@ export function BedsSection({ bedsData, busy, uploadBed, onDelete, data, saveSet
   };
 
   return (
-    <>
-      <SectionHeader
-        eyebrow="beds"
-        title="An instrumental bed for the DJ to talk over between songs."
-        sub="Normally a link is talked over the song it's introducing, so every second of DJ costs a second of music. With beds on, a long link gets its own instrumental bed instead: the song ends, the bed carries the talk, and the next song ramps in under the DJ's closing words."
-        metrics={[{ n: String(list.length), l: 'beds', accent: true }]}
+    <section className="grid gap-[22px]">
+      <SectionMasthead
+        title="Beds"
+        sub="Instrumentals the DJ talks over between songs: the song ends, the bed carries the talk, and the next song ramps in under the DJ’s closing words."
+        metrics={<TabMetric accent n={pad2(list.length)} l="beds" />}
       />
 
-      <Card title="Beds" sub="whether long links get a bed of their own">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <div className="text-[13px] font-bold">Enable beds</div>
-            <div className="mt-0.5 max-w-[480px] text-[11px] leading-[1.5] text-muted">
-              When off, every link is talked over the incoming song, exactly as before. The
-              library below is kept either way. Needs at least one bed long enough to carry a
-              script.
-            </div>
+      {/* On/off */}
+      <PanelBox>
+        <div className="flex flex-wrap items-center justify-between gap-5 px-[18px] py-[16px]">
+          <div className="min-w-[240px] flex-1">
+            <div className="font-mono text-[10px] font-bold tracking-[0.2em] uppercase">talk beds</div>
+            <p className="mt-1.5 text-[12px] leading-[1.55] text-muted">
+              {enabled
+                ? 'Long links get their own instrumental. Needs at least one bed long enough to carry a script.'
+                : 'Off — every link is talked over the incoming song, as before. The library is kept.'}
+            </p>
           </div>
           <Seg
             accent
             value={enabled ? 'on' : 'off'}
-            options={[
-              { id: 'off', label: 'Off' },
-              { id: 'on', label: 'On' },
-            ]}
+            options={[{ id: 'on', label: 'On' }, { id: 'off', label: 'Off' }]}
             onChange={v => { if (!busy) saveSettings({ beds: { enabled: v === 'on' } }); }}
           />
         </div>
-      </Card>
+      </PanelBox>
 
       {enabled && list.length === 0 && (
-        <div className="card">
-          <div className="card-body text-[12px] leading-[1.5] text-muted">
-            <strong className="tracking-[0.12em] text-ink uppercase">No beds in the library</strong>
-            <div className="mt-1">
-              Beds are on, but there's nothing to play. Every link will be talked over its song
-              as usual until you add a bed of at least {minSec}s.
-            </div>
-          </div>
-        </div>
+        <V3Alert title="no beds in the library">
+          Beds are on, but the library is empty — links fall back to talking over the incoming
+          song until you import a bed at least {minSec} seconds long.
+        </V3Alert>
       )}
 
-      <Card title="When to use a bed" sub="how long a link has to run before it gets its own bed">
-        <div className="flex items-start justify-between gap-4">
-          <div className="max-w-[480px]">
-            <div className="text-[13px] font-bold">Bed links longer than</div>
-            <div className="mt-0.5 text-[11px] leading-[1.5] text-muted">
-              Where the analyzer has measured a track's vocals, that's used instead: the DJ gets
-              a bed exactly when it would otherwise talk over the singing, and instrumentals
-              never get one. This threshold covers everything else. Lower it and more links get
-              a bed; a bed on <em>every</em> link is a distinctive sound, and not everyone's.
-            </div>
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            <Input
-              className="mono-num w-20"
-              type="number"
-              step={1}
-              min={0}
-              max={60}
-              value={thresholdEdit ?? String(thresholdSec)}
-              disabled={busy}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => setThresholdEdit(e.target.value)}
-              onBlur={() => {
-                if (thresholdEdit == null) return;
-                void saveNumber(thresholdEdit, thresholdSec, 60,
-                  v => ({ beds: { thresholdSec: v } }), setThresholdEdit);
-              }}
-            />
-            <span className="text-[12px] text-muted">sec</span>
-          </div>
-        </div>
-        <div className="mt-4 flex items-start justify-between gap-4 border-t border-dashed border-separator-strong pt-4">
-          <div className="max-w-[480px]">
-            <div className="text-[13px] font-bold">Ramp into the next song</div>
-            <div className="mt-0.5 text-[11px] leading-[1.5] text-muted">
-              How long the next song takes to fade in under the DJ's closing words at the end
-              of the bed. Longer is smoother; shorter is punchier. 0 is a hard cut.
-            </div>
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            <Input
-              className="mono-num w-20"
-              type="number"
-              step={1}
-              min={0}
-              max={15}
-              value={crossEdit ?? String(crossSec)}
-              disabled={busy}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => setCrossEdit(e.target.value)}
-              onBlur={() => {
-                if (crossEdit == null) return;
-                void saveNumber(crossEdit, crossSec, 15,
-                  v => ({ beds: { crossSec: v } }), setCrossEdit);
-              }}
-            />
-            <span className="text-[12px] text-muted">sec</span>
-          </div>
-        </div>
-      </Card>
-
-      <Card
-        title="Bed library"
-        sub={`${list.length} bed${list.length === 1 ? '' : 's'}`}
-        right={
-          <Btn sm tone="accent" onClick={() => setModal(true)} disabled={busy}>
-            Import
-          </Btn>
-        }
-      >
-        {list.length === 0 && (
-          <div className="py-2 text-[12px] text-muted italic">none yet</div>
-        )}
-        {list.map(b => (
-          <div
-            key={b.name}
-            className="flex items-start gap-3 border-b border-dashed border-separator-strong py-3"
-          >
-            <div className="min-w-0 flex-1">
-              <div className="text-[13px] font-bold text-ink">{b.name}</div>
-              {b.description && (
-                <div className="mt-0.5 text-[12px] break-words text-muted">{b.description}</div>
-              )}
-              <div className="mt-1 flex flex-wrap items-center gap-2">
-                <span className="caption">{fmtSize(b.size)}</span>
-                {b.durationSec != null && <span className="caption">{Math.round(b.durationSec)}s</span>}
-                {b.source === 'bundled' && <Pill tone="accent">bundled</Pill>}
-                {b.source === 'upload' && <Pill tone="ink">uploaded</Pill>}
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <PreviewButton
-                path={`/beds/${encodeURIComponent(b.name)}/audio`}
-                adminFetch={adminFetch}
-              />
-              <Btn
-                sm
-                tone="danger"
-                onClick={() => onDelete(b.name)}
+      {/* Thresholds */}
+      <PanelBox>
+        <PanelHead label="when to use a bed" />
+        <div className="grid grid-cols-2">
+          <div className="border-r border-separator-soft p-[18px]">
+            <div className="flex items-center gap-2.5">
+              <span className="text-[13px] font-semibold">Bed links longer than</span>
+              <Input
+                className="mono-num w-[72px]"
+                type="number"
+                step={1}
+                min={0}
+                max={60}
+                value={thresholdEdit ?? String(thresholdSec)}
                 disabled={busy}
-                title="Delete this bed"
-              >
-                Delete
-              </Btn>
+                aria-label="Bed threshold seconds"
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setThresholdEdit(e.target.value)}
+                onBlur={() => {
+                  if (thresholdEdit == null) return;
+                  void saveNumber(thresholdEdit, thresholdSec, 60,
+                    v => ({ beds: { thresholdSec: v } }), setThresholdEdit);
+                }}
+              />
+              <span className="font-mono text-[12px] text-muted">seconds</span>
             </div>
+            <p className="mt-2.5 text-[12px] leading-[1.55] [text-wrap:pretty] text-muted">
+              Links above this length get their own bed. Where the analyzer has measured a track’s
+              vocals, that measurement wins — a bed exactly when the DJ would otherwise talk over
+              singing; instrumentals never get one. Saves on blur.
+            </p>
           </div>
-        ))}
-      </Card>
+          <div className="p-[18px]">
+            <div className="flex items-center gap-2.5">
+              <span className="text-[13px] font-semibold">Ramp into the next song</span>
+              <Input
+                className="mono-num w-[72px]"
+                type="number"
+                step={1}
+                min={0}
+                max={15}
+                value={crossEdit ?? String(crossSec)}
+                disabled={busy}
+                aria-label="Ramp seconds"
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setCrossEdit(e.target.value)}
+                onBlur={() => {
+                  if (crossEdit == null) return;
+                  void saveNumber(crossEdit, crossSec, 15,
+                    v => ({ beds: { crossSec: v } }), setCrossEdit);
+                }}
+              />
+              <span className="font-mono text-[12px] text-muted">seconds</span>
+            </div>
+            <p className="mt-2.5 text-[12px] leading-[1.55] [text-wrap:pretty] text-muted">
+              Crossfade for the next song to fade in under the DJ’s closing words. 0 is a hard cut.
+              Saves on blur.
+            </p>
+          </div>
+        </div>
+      </PanelBox>
 
+      {/* Library */}
+      <PanelBox>
+        <PanelHead
+          label={`bed library · ${pad2(list.length)}`}
+          right={<Btn sm onClick={() => setModal(true)} disabled={busy}>Import</Btn>}
+        />
+        {list.length === 0 ? (
+          <EmptyState caption="beds can’t be generated — import an instrumental" />
+        ) : (
+          <div className="divide-y divide-separator-soft">
+            {list.map(b => (
+              <div
+                key={b.name}
+                className="grid grid-cols-[1fr_auto] items-center gap-[18px] px-[18px] py-[15px]"
+              >
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-baseline gap-3">
+                    <span className="font-mono text-[14px] font-bold">{b.name}</span>
+                    {b.description && <span className="text-[13px] text-muted">{b.description}</span>}
+                  </div>
+                  <MetaLine>
+                    <span>{fmtSize(b.size)}</span>
+                    {b.durationSec != null && (
+                      <>
+                        <span aria-hidden>·</span>
+                        <span>{Math.round(b.durationSec)}s</span>
+                      </>
+                    )}
+                    {b.source === 'bundled' && <Badge variant="solid">bundled</Badge>}
+                    {b.source === 'upload' && <Badge variant="ink">uploaded</Badge>}
+                  </MetaLine>
+                </div>
+                <div className="flex flex-none items-center gap-2">
+                  <PreviewButton
+                    path={`/beds/${encodeURIComponent(b.name)}/audio`}
+                    adminFetch={adminFetch}
+                  />
+                  <span title="Delete this bed">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Delete bed"
+                      disabled={busy}
+                      onClick={() => onDelete(b.name)}
+                    >
+                      <Trash2 aria-hidden />
+                    </Button>
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </PanelBox>
+
+      {/* Import — bring your own instrumental */}
       <Modal
         open={modal}
         onOpenChange={(o) => { if (!o) setModal(false); }}
-        title="Import bed"
+        title="import bed"
         sub="an instrumental the DJ can talk over"
         footer={
           <>
-            <Btn onClick={() => setModal(false)}>Cancel</Btn>
-            <Btn
-              tone="accent"
-              onClick={doImport}
-              disabled={busy || !importFile || !importName.trim()}
-            >
-              {busy ? 'Importing…' : 'Import bed'}
+            <Button variant="ghost" size="sm" onClick={() => setModal(false)}>Cancel</Button>
+            <Btn sm tone="accent" onClick={doImport} disabled={busy || !importFile || !importName.trim()}>
+              {busy ? 'Importing…' : 'Import'}
             </Btn>
           </>
         }
       >
-        <div className="field">
-          <Label>Name</Label>
-          <Input
-            value={importName}
-            maxLength={60}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setImportName(e.target.value)}
-            placeholder="e.g. warm-pad"
-            className="max-w-[280px]"
-          />
-          <div className="field-hint">A short slug: letters, numbers and dashes.</div>
-        </div>
-        <div className="field mt-3.5">
-          <Label>Description</Label>
-          <Input
-            value={importDesc}
-            maxLength={200}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setImportDesc(e.target.value)}
-            placeholder="what this bed sounds like"
-          />
-          <div className="field-hint">For your own reference — the DJ never reads this.</div>
-        </div>
-        <div className="field mt-3.5">
-          <Label>Audio file</Label>
+        <div className="grid gap-3.5">
+          <div className="grid gap-1.5">
+            <Label>Name</Label>
+            <Input
+              value={importName}
+              maxLength={60}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setImportName(e.target.value)}
+              placeholder="midnight-drift"
+            />
+          </div>
+          <div className="grid gap-1.5">
+            <Label>Description · optional</Label>
+            <Input
+              value={importDesc}
+              maxLength={200}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setImportDesc(e.target.value)}
+              placeholder="For your own reference — the DJ never reads this"
+            />
+          </div>
           <input
             ref={importRef}
             type="file"
@@ -264,23 +265,17 @@ export function BedsSection({ bedsData, busy, uploadBed, onDelete, data, saveSet
             onChange={(e: ChangeEvent<HTMLInputElement>) => setImportFile(e.target.files?.[0] ?? null)}
             className="hidden"
           />
-          <div className="flex flex-wrap items-center gap-2.5">
-            <Btn tone="solid" onClick={() => importRef.current?.click()} disabled={busy}>
-              {importFile ? 'Change file…' : 'Choose audio file…'}
-            </Btn>
-            {importFile && <span className="text-[12px] text-ink">{importFile.name}</span>}
-          </div>
-          <div className="field-hint">
-            mp3, wav, ogg, flac, m4a, aac or opus · at least {minSec}s · up to 25 MB · converted to
-            MP3 on import
-          </div>
-        </div>
-        <div className="field-hint mt-3.5">
-          A bed is trimmed to each link, never looped, so it only has to be <em>longer</em> than
-          the DJ's longest script. Something atmospheric with no strong key travels best — it has
-          to sit under whatever song comes next.
+          <DropZone
+            label={importFile ? `${importFile.name} · ${fmtSize(importFile.size)}` : 'choose a file…'}
+            hint={`same formats · at least ${minSec}s · up to 25 MB · converted to MP3`}
+            onClick={() => importRef.current?.click()}
+          />
+          <p className="m-0 text-[12px] leading-[1.55] [text-wrap:pretty] text-muted">
+            A bed is trimmed per link and never looped — it only needs to outlast the DJ’s longest
+            script. Atmospheric, no strong key travels best.
+          </p>
         </div>
       </Modal>
-    </>
+    </section>
   );
 }

--- a/web/components/admin/imaging/ImagingPanel.tsx
+++ b/web/components/admin/imaging/ImagingPanel.tsx
@@ -19,13 +19,15 @@ import { Music, AudioLines, Waves } from 'lucide-react';
 import { useAdminAuth } from '../../../lib/adminAuth';
 import { notify, errorMessage } from '../../../lib/notify';
 import { cn } from '../../../lib/cn';
-import { Eyebrow } from '../ui';
+import { Wave } from '../ui';
+import { V3Alert } from '../../ui/alert';
 import { V3AlertDialog } from '../../ui/alert-dialog';
 import type { SettingsData, SaveSettings } from '../settings/shared';
 import type { SfxData, SfxForm, BedsData, JingleImportFailure, JingleImportResult } from './types';
 import { JinglesSection } from './JinglesSection';
 import { SfxSection } from './SfxSection';
 import { BedsSection } from './BedsSection';
+import { MonoLabel, TabMetric, pad2 } from './parts';
 
 type TabId = 'jingles' | 'sfx' | 'beds';
 const TAB_IDS: TabId[] = ['jingles', 'sfx', 'beds'];
@@ -292,11 +294,14 @@ export default function ImagingPanel() {
     finally { setBusy(false); }
   };
 
-  // Live counts ride on the tab labels — the at-a-glance figures the settings
-  // rail used to show. Omitted until each source has loaded.
+  // Live counts ride on the tab badges + the masthead metrics. Undefined
+  // until each source loads; the badge is simply omitted until then.
   const jingleCount = data?.jingles?.length;
   const sfxCount = sfxData?.sfx?.length;
   const bedCount = bedsData?.beds?.length;
+  const totalAssets = (jingleCount ?? 0) + (sfxCount ?? 0) + (bedCount ?? 0);
+  const ratioVal = data?.values?.jingleRatio;
+  const ratioMetric = ratioVal == null ? '—' : ratioVal === 0 ? 'off' : `1 : ${ratioVal}`;
   const tabs = [
     { id: 'jingles' as TabId, label: 'Jingles', count: jingleCount, icon: Music },
     { id: 'sfx' as TabId, label: 'SFX', count: sfxCount, icon: AudioLines },
@@ -304,98 +309,117 @@ export default function ImagingPanel() {
   ];
 
   return (
-    <div className="grid gap-4">
-      <section className="card">
-        <div className="border-b border-ink p-4">
-          <Eyebrow className="text-vermilion">imaging</Eyebrow>
-          <div className="mt-1.5 text-[22px] font-extrabold tracking-[-0.02em]">
-            The sounds between the songs.
-          </div>
-          <div className="mt-1 text-[11px] leading-[1.6] text-muted">
-            Station imaging — the audio furniture the DJ drops between and over tracks. Jingles
-            are pre-recorded stingers, sound effects garnish a spoken break, and beds are
-            instrumentals the DJ talks over. All of it is created, imported, and managed here.
+    <div className="max-w-[1060px]">
+      {/* Editorial masthead — the sounds between the songs. */}
+      <header>
+        <div className="flex items-baseline justify-between gap-4">
+          <MonoLabel>imaging</MonoLabel>
+          <span className="flex items-center gap-[7px] font-mono text-[10px] tracking-[0.14em] text-muted uppercase">
+            <span className="size-1.5 animate-pulse bg-[var(--accent)]" aria-hidden />
+            live · refreshed every 3s
+          </span>
+        </div>
+        <h1 className="mt-3.5 font-display text-[54px] leading-[1.02] font-semibold tracking-[-0.01em] [text-wrap:balance] lg:text-[62px]">
+          The sounds between the&nbsp;songs.
+        </h1>
+        <div aria-hidden className="my-6">
+          <Wave bars={88} seed={7} h={42} />
+        </div>
+        <div className="flex flex-wrap items-start justify-between gap-x-10 gap-y-5 border-t border-ink pt-[18px]">
+          <p className="m-0 max-w-[62ch] text-[14px] leading-[1.65] [text-wrap:pretty] text-muted">
+            Everything the DJ drops between and over the music:{' '}
+            <strong className="font-semibold text-ink">jingles</strong> are the station idents
+            played between tracks, <strong className="font-semibold text-ink">SFX</strong> are
+            stingers mixed under the DJ&rsquo;s voice, and{' '}
+            <strong className="font-semibold text-ink">beds</strong> are instrumentals the DJ
+            talks over when a link runs long.
+          </p>
+          <div className="flex flex-none gap-7">
+            <TabMetric big n={pad2(totalAssets)} l="assets" />
+            <TabMetric big accent n={ratioMetric} l="jingle ratio" />
           </div>
         </div>
-        {/* Full-width tab row — three equal cells, active one filled in the
-            accent so the current section reads at a glance. */}
-        <div className="grid grid-cols-3" role="tablist" aria-label="Imaging sections">
-          {tabs.map((t, i) => {
-            const active = tab === t.id;
-            const Icon = t.icon;
-            return (
-              <button
-                key={t.id}
-                type="button"
-                role="tab"
-                aria-selected={active}
-                onClick={() => selectTab(t.id)}
-                className={cn(
-                  'flex items-center justify-center gap-2.5 px-4 py-4 text-[13px] font-bold tracking-[0.18em] uppercase transition-colors',
-                  i > 0 && 'border-l border-ink',
-                  active
-                    ? 'bg-[var(--accent)] text-white'
-                    : 'bg-[var(--ink-softer)] text-ink hover:bg-ink/10',
-                )}
-              >
-                <Icon size={17} strokeWidth={2} aria-hidden />
-                <span>{t.label}</span>
-                {t.count != null && (
-                  <span
-                    className={cn(
-                      'ml-0.5 min-w-[1.5em] rounded-full px-1.5 py-0.5 text-[10px] leading-none font-bold',
-                      active ? 'bg-white/25 text-white' : 'bg-ink/10 text-muted',
-                    )}
-                  >
-                    {t.count}
-                  </span>
-                )}
-              </button>
-            );
-          })}
-        </div>
-      </section>
+      </header>
 
       {err && (
-        <div className="card border-[var(--danger)]">
-          <div className="card-body text-[12px] text-[var(--danger)]">
-            <strong className="tracking-[0.12em] uppercase">controller error</strong>
-            <div className="mt-1">{err}</div>
-          </div>
+        <div className="mt-7">
+          <V3Alert tone="error" title="controller error">{err}</V3Alert>
         </div>
       )}
 
-      {tab === 'jingles' && (
-        data ? (
-          <JinglesSection
-            data={data} busy={busy}
-            jingleRatio={jingleRatio ?? ''} setJingleRatio={setJingleRatio}
-            jingleText={jingleText} setJingleText={setJingleText}
-            createJingle={createJingle} uploadJingle={uploadJingle}
-            saveSettings={saveSettings}
-            onDelete={setConfirmDelete} adminFetch={adminFetch}
+      {/* Tab row — three equal cells, the active one inverted with an accent
+          top-rule so the current section reads at a glance. */}
+      <nav
+        className="mt-[34px] grid grid-cols-3 border border-ink"
+        role="tablist"
+        aria-label="Imaging sections"
+      >
+        {tabs.map((t, i) => {
+          const active = tab === t.id;
+          const Icon = t.icon;
+          return (
+            <button
+              key={t.id}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => selectTab(t.id)}
+              className={cn(
+                'relative flex cursor-pointer items-center justify-center gap-2.5 px-3 py-[19px] transition-colors',
+                i > 0 && 'border-l border-ink',
+                active ? 'bg-ink text-bg' : 'text-ink hover:bg-[var(--ink-soft)]',
+              )}
+            >
+              {active && (
+                <span className="absolute -top-px -right-px -left-px h-1 bg-[var(--accent)]" aria-hidden />
+              )}
+              <Icon size={16} strokeWidth={2} aria-hidden />
+              <span className="font-mono text-[12px] font-bold tracking-[0.16em] uppercase">
+                {t.label}
+              </span>
+              {t.count != null && (
+                <span className="min-w-[14px] border border-current px-1.5 py-[2px] text-center font-mono text-[10px] leading-none font-bold">
+                  {pad2(t.count)}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </nav>
+
+      <div className="mt-11">
+        {tab === 'jingles' && (
+          data ? (
+            <JinglesSection
+              data={data} busy={busy}
+              jingleRatio={jingleRatio ?? ''} setJingleRatio={setJingleRatio}
+              jingleText={jingleText} setJingleText={setJingleText}
+              createJingle={createJingle} uploadJingle={uploadJingle}
+              saveSettings={saveSettings}
+              onDelete={setConfirmDelete} adminFetch={adminFetch}
+            />
+          ) : (
+            !err && <div className="text-[13px] text-muted italic">loading…</div>
+          )
+        )}
+
+        {tab === 'sfx' && (
+          <SfxSection
+            sfxData={sfxData} sfxForm={sfxForm} setSfxForm={setSfxForm}
+            busy={busy} createSfx={createSfx} uploadSfx={uploadSfx}
+            onDelete={setConfirmDeleteSfx}
+            data={data} saveSettings={saveSettings} adminFetch={adminFetch}
           />
-        ) : (
-          !err && <div className="text-[13px] text-muted italic">loading…</div>
-        )
-      )}
+        )}
 
-      {tab === 'sfx' && (
-        <SfxSection
-          sfxData={sfxData} sfxForm={sfxForm} setSfxForm={setSfxForm}
-          busy={busy} createSfx={createSfx} uploadSfx={uploadSfx}
-          onDelete={setConfirmDeleteSfx}
-          data={data} saveSettings={saveSettings} adminFetch={adminFetch}
-        />
-      )}
-
-      {tab === 'beds' && (
-        <BedsSection
-          bedsData={bedsData} busy={busy} uploadBed={uploadBed}
-          onDelete={setConfirmDeleteBed}
-          data={data} saveSettings={saveSettings} adminFetch={adminFetch}
-        />
-      )}
+        {tab === 'beds' && (
+          <BedsSection
+            bedsData={bedsData} busy={busy} uploadBed={uploadBed}
+            onDelete={setConfirmDeleteBed}
+            data={data} saveSettings={saveSettings} adminFetch={adminFetch}
+          />
+        )}
+      </div>
 
       <V3AlertDialog
         open={confirmDelete != null}

--- a/web/components/admin/imaging/JinglesSection.tsx
+++ b/web/components/admin/imaging/JinglesSection.tsx
@@ -2,14 +2,20 @@
 
 import type { ChangeEvent } from 'react';
 import { useRef, useState } from 'react';
+import { Trash2 } from 'lucide-react';
 import { fmtSize } from '../../../lib/format';
 import { Modal } from '../../ui/modal';
 import { Input } from '../../ui/input';
 import { Textarea } from '../../ui/textarea';
 import { Label } from '../../ui/label';
-import { Card, Btn, Pill } from '../ui';
-import { SectionHeader, PreviewButton, type SettingsData, type SaveSettings } from '../settings/shared';
+import { Button } from '../../ui/button';
+import { Badge } from '../../ui/badge';
+import { Btn } from '../ui';
+import { PreviewButton, type SettingsData, type SaveSettings } from '../settings/shared';
 import type { JingleImportFailure, JingleImportResult } from './types';
+import {
+  SectionMasthead, PanelBox, PanelHead, EmptyState, DropZone, MetaLine, TabMetric, pad2,
+} from './parts';
 
 interface JinglesSectionProps {
   data: SettingsData;
@@ -36,7 +42,9 @@ export function JinglesSection({
   data, busy, jingleRatio, setJingleRatio, jingleText, setJingleText,
   createJingle, uploadJingle, saveSettings, onDelete, adminFetch,
 }: JinglesSectionProps) {
-  const ratioDirty = jingleRatio !== String(data.values?.jingleRatio);
+  const ratioRaw = data.values?.jingleRatio;
+  const ratioDirty = jingleRatio !== String(ratioRaw);
+  const ratioMetric = ratioRaw == null ? '—' : ratioRaw === 0 ? 'off' : `1 : ${ratioRaw}`;
   const jingles = data.jingles || [];
   const [modal, setModal] = useState<null | 'create' | 'import'>(null);
   const [importFiles, setImportFiles] = useState<File[]>([]);
@@ -76,154 +84,159 @@ export function JinglesSection({
   };
 
   return (
-    <>
-      <SectionHeader
-        eyebrow="jingles"
-        title="Pre-recorded TTS station stingers."
-        sub="A default station ident is generated on first boot; you can add your own here. The built-in ident can’t be deleted."
-        metrics={[
-          { n: String(jingles.length), l: 'files' },
-          { n: data.values?.jingleRatio === 0 ? 'off' : String(data.values?.jingleRatio), l: 'ratio', accent: true },
-        ]}
+    <section className="grid gap-[22px]">
+      <SectionMasthead
+        title="Jingles"
+        sub="Pre-rendered station idents dropped between tracks. A default ident is generated on first boot and can’t be deleted."
+        metrics={
+          <>
+            <TabMetric n={pad2(jingles.length)} l="files" />
+            <TabMetric n={ratioMetric} l="ratio" />
+          </>
+        }
       />
 
-      <Card title="Frequency" sub="needs mixer restart">
-        <div className="field">
-          <div className="flex items-center gap-2">
-            <Label>Jingle ratio</Label>
-            <Pill tone="ink">restart required</Pill>
-          </div>
-          <div className="flex flex-wrap items-center gap-2.5">
+      {/* Frequency */}
+      <PanelBox>
+        <PanelHead label="frequency" right={<Badge variant="accent">restart required</Badge>} />
+        <div className="flex flex-wrap items-center gap-5 px-[18px] py-[18px]">
+          <div className="flex flex-none items-center gap-2.5">
+            <span className="font-mono text-[13px]">1 jingle every</span>
             <Input
-              className="mono-num w-24"
+              className="mono-num w-[84px]"
               type="number"
               min={0}
               max={1000}
               value={jingleRatio}
+              aria-label="Jingle ratio"
               onChange={(e: ChangeEvent<HTMLInputElement>) => setJingleRatio(e.target.value)}
             />
-            <span className="text-[12px] text-muted">music tracks per jingle</span>
-            <Btn
-              tone="solid"
-              onClick={() => saveSettings({ jingleRatio: parseInt(jingleRatio, 10) })}
-              disabled={busy || !ratioDirty}
-            >
-              Save · needs restart
-            </Btn>
+            <span className="font-mono text-[13px]">music tracks</span>
           </div>
-          <div className="field-hint">
-            1 jingle every N music tracks; 0 turns jingles off entirely
-            (current: {data.values?.jingleRatio === 0 ? 'off' : data.values?.jingleRatio}).
-            Restart the mixer from the danger zone to apply.
-          </div>
+          <p className="m-0 min-w-[220px] flex-1 text-[12px] leading-[1.55] text-muted">
+            0 turns jingles off entirely. Changes apply after a mixer restart — the restart
+            control lives in Settings → danger zone.
+          </p>
+          <Btn
+            sm
+            tone="accent"
+            onClick={() => saveSettings({ jingleRatio: parseInt(jingleRatio, 10) })}
+            disabled={busy || !ratioDirty}
+          >
+            Save · needs restart
+          </Btn>
         </div>
-      </Card>
+      </PanelBox>
 
-      <Card
-        title="Jingles"
-        sub={`${jingles.length} file${jingles.length === 1 ? '' : 's'}`}
-        right={
-          <>
-            <Btn sm tone="accent" onClick={() => setModal('create')} disabled={busy}>
-              + Create
-            </Btn>
-            <Btn sm tone="solid" onClick={() => setModal('import')} disabled={busy}>
-              Import
-            </Btn>
-          </>
-        }
-      >
-        {jingles.length === 0 && (
-          <div className="py-2 text-[12px] text-muted italic">
-            none yet
+      {/* Library */}
+      <PanelBox>
+        <PanelHead
+          label={`jingle library · ${pad2(jingles.length)}`}
+          right={
+            <>
+              <Btn sm onClick={() => setModal('import')} disabled={busy}>Import</Btn>
+              <Btn sm tone="solid" onClick={() => setModal('create')} disabled={busy}>+ Create</Btn>
+            </>
+          }
+        />
+        {jingles.length === 0 ? (
+          <EmptyState caption="create one via TTS or import your own" />
+        ) : (
+          <div className="divide-y divide-separator-soft">
+            {jingles.map(j => (
+              <div
+                key={j.filename}
+                className="grid grid-cols-[1fr_auto] items-center gap-[18px] px-[18px] py-[15px]"
+              >
+                <div className="min-w-0">
+                  <div className="font-display text-[18px] leading-[1.35] [text-wrap:pretty] italic">
+                    &ldquo;{j.text || j.filename}&rdquo;
+                  </div>
+                  <MetaLine>
+                    <span className="break-all">{j.filename}</span>
+                    <span aria-hidden>·</span>
+                    <span>{fmtSize(j.size)}</span>
+                    {j.createdAt && (
+                      <>
+                        <span aria-hidden>·</span>
+                        <span>{new Date(j.createdAt).toLocaleString('en-GB')}</span>
+                      </>
+                    )}
+                    {j.builtin && <Badge variant="solid">builtin</Badge>}
+                    {j.source === 'upload' && <Badge variant="ink">uploaded</Badge>}
+                  </MetaLine>
+                </div>
+                <div className="flex flex-none items-center gap-2">
+                  <PreviewButton
+                    path={`/jingles/${encodeURIComponent(j.filename)}/audio`}
+                    adminFetch={adminFetch}
+                  />
+                  <span title={j.builtin ? 'The default ident can’t be deleted' : 'Delete this jingle'}>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Delete jingle"
+                      disabled={busy || j.builtin}
+                      onClick={() => onDelete(j.filename)}
+                    >
+                      <Trash2 aria-hidden />
+                    </Button>
+                  </span>
+                </div>
+              </div>
+            ))}
           </div>
         )}
-        {jingles.map(j => (
-          <div
-            key={j.filename}
-            className="flex items-start gap-3 border-b border-dashed border-separator-strong py-3"
-          >
-            <div className="min-w-0 flex-1">
-              <div className="text-[13px] break-words text-ink">{j.text}</div>
-              <div className="mt-1 flex flex-wrap items-center gap-2">
-                <span className="caption">{j.filename}</span>
-                <span className="caption">{fmtSize(j.size)}</span>
-                {j.createdAt && (
-                  <span className="caption">{new Date(j.createdAt).toLocaleString('en-GB')}</span>
-                )}
-                {j.builtin && <Pill tone="accent">builtin</Pill>}
-                {j.source === 'upload' && <Pill tone="ink">uploaded</Pill>}
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <PreviewButton
-                path={`/jingles/${encodeURIComponent(j.filename)}/audio`}
-                adminFetch={adminFetch}
-              />
-              <Btn
-                sm
-                tone="danger"
-                onClick={() => onDelete(j.filename)}
-                disabled={busy || j.builtin}
-                title={j.builtin ? "Can't delete the built-in ident" : 'Delete this jingle'}
-              >
-                Delete
-              </Btn>
-            </div>
-          </div>
-        ))}
-      </Card>
+      </PanelBox>
 
+      {/* Create — Piper TTS */}
       <Modal
         open={modal === 'create'}
         onOpenChange={(o) => { if (!o) setModal(null); }}
-        title="Create jingle"
+        title="create jingle"
         sub="rendered via Piper TTS"
         footer={
           <>
-            <Btn onClick={() => setModal(null)}>Cancel</Btn>
-            <Btn tone="accent" onClick={doCreate} disabled={busy || !jingleText.trim()}>
-              {busy ? 'Generating…' : 'Create jingle'}
+            <Button variant="ghost" size="sm" onClick={() => setModal(null)}>Cancel</Button>
+            <Btn sm tone="accent" onClick={doCreate} disabled={busy || !jingleText.trim()}>
+              {busy ? 'Generating…' : 'Create'}
             </Btn>
           </>
         }
       >
-        <div className="field">
+        <div className="grid gap-1.5">
           <Label>Jingle text</Label>
           <Textarea
-            rows={3}
+            rows={4}
             value={jingleText}
-            onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setJingleText(e.target.value)}
-            placeholder='e.g. "You are listening to SUB slash WAVE. Requests open all night."'
+            onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setJingleText(e.target.value.slice(0, 500))}
+            placeholder="You’re tuned to SUB/WAVE…"
           />
-          <div className="field-hint">{jingleText.length}/500 chars · Piper TTS</div>
+          <div className="text-right font-mono text-[11px] text-muted">{jingleText.length} / 500</div>
         </div>
       </Modal>
 
+      {/* Import — bring your own audio */}
       <Modal
         open={modal === 'import'}
         onOpenChange={(o) => { if (!o && !importProgress) closeImport(); }}
-        title="Import jingles"
-        sub="bring your own mp3 / wav, select one or many"
+        title="import jingles"
+        sub="bring your own mp3 / wav — select one or many"
         footer={
           <>
-            {importProgress ? (
-              <Btn onClick={() => importAbort.current?.abort()}>Stop</Btn>
-            ) : (
-              <Btn onClick={closeImport}>Cancel</Btn>
-            )}
-            <Btn tone="accent" onClick={doImport} disabled={busy || !importFiles.length}>
+            <Button variant="ghost" size="sm" onClick={closeImport} disabled={!!importProgress}>Cancel</Button>
+            <Btn sm tone="accent" onClick={doImport} disabled={busy || !importFiles.length}>
               {importProgress
-                ? `Importing ${importProgress.done}/${importProgress.total}…`
+                ? 'Importing…'
                 : importFiles.length > 1
                   ? `Import ${importFiles.length} files`
-                  : 'Import jingle'}
+                  : 'Import'}
             </Btn>
           </>
         }
       >
-        <div className="field">
-          <Label>Audio files</Label>
+        <div className="grid gap-3.5">
           <input
             ref={importRef}
             type="file"
@@ -237,46 +250,72 @@ export function JinglesSection({
             }}
             className="hidden"
           />
-          <div className="flex flex-wrap items-center gap-2.5">
-            <Btn tone="solid" onClick={() => importRef.current?.click()} disabled={busy}>
-              {importFiles.length ? 'Change files…' : 'Choose audio files…'}
-            </Btn>
-            {importFiles.length === 1 && (
-              <span className="text-[12px] text-ink">{importFiles[0]?.name}</span>
-            )}
-            {importFiles.length > 1 && (
-              <span className="text-[12px] text-ink">{importFiles.length} files selected</span>
-            )}
-          </div>
-          <div className="field-hint">
-            mp3, wav, ogg, flac, m4a, aac or opus · up to 25 MB each · converted and level-matched on import.
-            Selecting multiple files uploads them one at a time and keeps going past any single failure.
-          </div>
-          {importProgress && (
-            <div className="field-hint">Uploading {importProgress.done}/{importProgress.total}…</div>
+          <DropZone
+            label={
+              importFiles.length
+                ? `${importFiles.length} file${importFiles.length === 1 ? '' : 's'} selected — click to re-select`
+                : 'choose files…'
+            }
+            hint="mp3 · wav · ogg · flac · m4a · aac · opus — up to 25 MB each · converted + level-matched on import"
+            onClick={() => importRef.current?.click()}
+            disabled={!!importProgress}
+          />
+
+          {importFiles.length > 0 && (
+            <div className="max-h-[180px] divide-y divide-separator-soft overflow-auto border border-separator-strong">
+              {importFiles.map((f, i) => (
+                <div
+                  key={`${f.name}-${i}`}
+                  className="flex justify-between gap-3 px-3 py-2 font-mono text-[11px]"
+                >
+                  <span className="truncate">{f.name}</span>
+                  <span className="flex-none text-muted">{fmtSize(f.size)}</span>
+                </div>
+              ))}
+            </div>
           )}
+
+          {importFiles.length === 1 && (
+            <div className="grid gap-1.5">
+              <Label>Label · optional</Label>
+              <Input
+                value={importLabel}
+                maxLength={200}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setImportLabel(e.target.value)}
+                placeholder="Defaults to the file’s own name"
+              />
+            </div>
+          )}
+
+          {importProgress && (
+            <div className="flex items-center justify-between gap-3 border border-ink px-3.5 py-2.5">
+              <span className="font-mono text-[12px] font-bold">
+                Importing {importProgress.done}/{importProgress.total}…
+              </span>
+              <Btn sm tone="danger" onClick={() => importAbort.current?.abort()}>Stop</Btn>
+            </div>
+          )}
+
           {importFailures.length > 0 && (
-            <div className="mt-2 text-[12px] text-[var(--danger)]">
-              <div>{importFailures.length} file{importFailures.length === 1 ? '' : 's'} failed — re-select to retry:</div>
-              <ul className="m-0 list-none p-0">
+            <div className="border border-[var(--destructive)]">
+              <div className="border-b border-separator-soft px-3 py-2 font-mono text-[10px] font-bold tracking-[0.16em] text-[var(--destructive)] uppercase">
+                failed — re-select just these to retry
+              </div>
+              <div className="divide-y divide-separator-soft">
                 {importFailures.map((f, i) => (
-                  <li key={`${f.name}-${i}`} className="truncate">{f.name} — {f.reason}</li>
+                  <div
+                    key={`${f.name}-${i}`}
+                    className="flex justify-between gap-3 px-3 py-2 font-mono text-[11px]"
+                  >
+                    <span className="truncate">{f.name}</span>
+                    <span className="flex-none text-[var(--destructive)]">{f.reason}</span>
+                  </div>
                 ))}
-              </ul>
+              </div>
             </div>
           )}
         </div>
-        <div className="field mt-3.5">
-          <Label>Label (optional)</Label>
-          <Input
-            value={importLabel}
-            maxLength={200}
-            disabled={importFiles.length > 1}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setImportLabel(e.target.value)}
-            placeholder={importFiles.length > 1 ? 'defaults to each file name' : 'shown in the list, defaults to the file name'}
-          />
-        </div>
       </Modal>
-    </>
+    </section>
   );
 }

--- a/web/components/admin/imaging/SfxSection.tsx
+++ b/web/components/admin/imaging/SfxSection.tsx
@@ -2,14 +2,21 @@
 
 import type { ChangeEvent } from 'react';
 import { useRef, useState } from 'react';
+import { Trash2 } from 'lucide-react';
 import { fmtSize } from '../../../lib/format';
 import { Modal } from '../../ui/modal';
 import { Input } from '../../ui/input';
 import { Textarea } from '../../ui/textarea';
 import { Label } from '../../ui/label';
-import { Card, Btn, Pill, Seg } from '../ui';
-import { SectionHeader, PreviewButton, type SettingsData, type SaveSettings } from '../settings/shared';
+import { Button } from '../../ui/button';
+import { Badge } from '../../ui/badge';
+import { V3Alert } from '../../ui/alert';
+import { Btn, Seg } from '../ui';
+import { PreviewButton, type SettingsData, type SaveSettings } from '../settings/shared';
 import type { SfxData, SfxForm } from './types';
+import {
+  SectionMasthead, PanelBox, PanelHead, EmptyState, DropZone, MetaLine, TabMetric, pad2,
+} from './parts';
 
 interface SfxSectionProps {
   sfxData: SfxData | null;
@@ -54,222 +61,210 @@ export function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uplo
   const enabled = data?.values?.sfx?.enabled !== false;
 
   return (
-    <>
-      <SectionHeader
-        eyebrow="sound effects"
-        title="Stingers the DJ agent plays under its voice."
-        sub="The segment-director agent can garnish a spoken break with one of these effects, mixed beneath the voice. Built-in effects ship with the station; add your own by generating one from a text prompt (ElevenLabs) or importing an audio file."
-        metrics={[{ n: String(list.length), l: 'effects', accent: true }]}
+    <section className="grid gap-[22px]">
+      <SectionMasthead
+        title="Sound effects"
+        sub="Stingers the segment-director agent mixes under its voice during a spoken break. Built-ins ship with the station."
+        metrics={<TabMetric accent n={pad2(list.length)} l="effects" />}
       />
 
-      <Card title="Sound effects" sub="whether the DJ agent uses stingers at all">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <div className="text-[13px] font-bold">Enable sound effects</div>
-            <div className="mt-0.5 max-w-[480px] text-[14px] leading-[1.5] text-muted">
-              When off, the segment-director agent is never shown the effect catalogue and stops
-              playing stingers under its voice. The library below is kept either way.
-            </div>
+      {/* On/off */}
+      <PanelBox>
+        <div className="flex flex-wrap items-center justify-between gap-5 px-[18px] py-[16px]">
+          <div className="min-w-[240px] flex-1">
+            <div className="font-mono text-[10px] font-bold tracking-[0.2em] uppercase">stingers</div>
+            <p className="mt-1.5 text-[12px] leading-[1.55] text-muted">
+              {enabled
+                ? 'The agent sees the effect catalogue and mixes stingers under its voice during spoken breaks.'
+                : 'Off — the agent never sees the catalogue and plays no stingers. The library is kept.'}
+            </p>
           </div>
           <Seg
             accent
             value={enabled ? 'on' : 'off'}
-            options={[
-              { id: 'off', label: 'Off' },
-              { id: 'on', label: 'On' },
-            ]}
+            options={[{ id: 'on', label: 'On' }, { id: 'off', label: 'Off' }]}
             onChange={v => { if (!busy) saveSettings({ sfx: { enabled: v === 'on' } }); }}
           />
         </div>
-      </Card>
+      </PanelBox>
 
       {!ready && (
-        <div className="card">
-          <div className="card-body text-[14px] leading-[1.5] text-muted">
-            <strong className="tracking-[0.12em] text-ink uppercase">
-              ElevenLabs key not set
-            </strong>
-            <div className="mt-1">
-              The built-in effects work without a key. An ElevenLabs API key is only needed to
-              generate <em>new</em> effects below. Set <code>ELEVENLABS_API_KEY</code> in{' '}
-              <code>.env</code> (or set the cloud TTS provider to ElevenLabs with a key
-              entered), then restart the controller.
-            </div>
-          </div>
-        </div>
+        <V3Alert title="no ElevenLabs key">
+          Built-in effects work without a key — one is only needed to generate new ones. Set{' '}
+          <code className="font-mono text-[12px]">ELEVENLABS_API_KEY</code> and restart the
+          controller to enable Create.
+        </V3Alert>
       )}
 
-      <Card
-        title="Effect library"
-        sub={`${list.length} effect${list.length === 1 ? '' : 's'}`}
-        right={
-          <>
-            <Btn sm tone="accent" onClick={() => setModal('create')} disabled={busy}>
-              + Create
-            </Btn>
-            <Btn sm tone="solid" onClick={() => setModal('import')} disabled={busy}>
-              Import
-            </Btn>
-          </>
-        }
-      >
-        {list.length === 0 && (
-          <div className="py-2 text-[12px] text-muted italic">
-            none yet
+      {/* Library */}
+      <PanelBox>
+        <PanelHead
+          label={`effect library · ${pad2(list.length)}`}
+          right={
+            <>
+              <Btn sm onClick={() => setModal('import')} disabled={busy}>Import</Btn>
+              <Btn sm tone="solid" onClick={() => setModal('create')} disabled={busy}>+ Create</Btn>
+            </>
+          }
+        />
+        {list.length === 0 ? (
+          <EmptyState caption="generate via ElevenLabs or import your own" />
+        ) : (
+          <div className="divide-y divide-separator-soft">
+            {list.map(s => (
+              <div
+                key={s.name}
+                className="grid grid-cols-[1fr_auto] items-center gap-[18px] px-[18px] py-[15px]"
+              >
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-baseline gap-3">
+                    <span className="font-mono text-[14px] font-bold">{s.name}</span>
+                    {s.description && <span className="text-[13px] text-muted">{s.description}</span>}
+                  </div>
+                  <MetaLine>
+                    <span>{fmtSize(s.size)}</span>
+                    {s.durationSec != null && (
+                      <>
+                        <span aria-hidden>·</span>
+                        <span>{s.durationSec}s</span>
+                      </>
+                    )}
+                    {s.builtin && <Badge variant="solid">builtin</Badge>}
+                    {s.source === 'upload' && <Badge variant="ink">uploaded</Badge>}
+                  </MetaLine>
+                </div>
+                <div className="flex flex-none items-center gap-2">
+                  <PreviewButton
+                    path={`/sfx/${encodeURIComponent(s.name)}/audio`}
+                    adminFetch={adminFetch}
+                  />
+                  <span title={s.builtin ? 'Built-in effects can’t be deleted' : 'Delete this effect'}>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Delete effect"
+                      disabled={busy || s.builtin}
+                      onClick={() => onDelete(s.name)}
+                    >
+                      <Trash2 aria-hidden />
+                    </Button>
+                  </span>
+                </div>
+              </div>
+            ))}
           </div>
         )}
-        {list.map(s => (
-          <div
-            key={s.name}
-            className="flex items-start gap-3 border-b border-dashed border-separator-strong py-3"
-          >
-            <div className="min-w-0 flex-1">
-              <div className="text-[13px] font-bold text-ink">{s.name}</div>
-              {s.description && (
-                <div className="mt-0.5 text-[12px] break-words text-muted">
-                  {s.description}
-                </div>
-              )}
-              <div className="mt-1 flex flex-wrap items-center gap-2">
-                <span className="caption">{fmtSize(s.size)}</span>
-                {s.durationSec && <span className="caption">{s.durationSec}s</span>}
-                {s.builtin && <Pill tone="accent">builtin</Pill>}
-                {s.source === 'upload' && <Pill tone="ink">uploaded</Pill>}
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <PreviewButton
-                path={`/sfx/${encodeURIComponent(s.name)}/audio`}
-                adminFetch={adminFetch}
-              />
-              <Btn
-                sm
-                tone="danger"
-                onClick={() => onDelete(s.name)}
-                disabled={busy || s.builtin}
-                title={s.builtin ? "Can't delete a built-in effect" : 'Delete this effect'}
-              >
-                Delete
-              </Btn>
-            </div>
-          </div>
-        ))}
-      </Card>
+      </PanelBox>
 
+      {/* Create — ElevenLabs */}
       <Modal
         open={modal === 'create'}
         onOpenChange={(o) => { if (!o) setModal(null); }}
-        title="Create sound effect"
+        title="create effect"
         sub="rendered via ElevenLabs"
         footer={
           <>
-            <Btn onClick={() => setModal(null)}>Cancel</Btn>
+            <Button variant="ghost" size="sm" onClick={() => setModal(null)}>Cancel</Button>
             <Btn
+              sm
               tone="accent"
               onClick={doCreate}
               disabled={busy || !ready || !sfxForm.name.trim() || !sfxForm.prompt.trim()}
             >
-              {busy ? 'Generating…' : 'Create sound effect'}
+              {busy ? 'Generating…' : 'Create'}
             </Btn>
           </>
         }
       >
-        {!ready && (
-          <div className="field-hint mb-3.5">
-            An ElevenLabs API key is required to generate effects. Set <code>ELEVENLABS_API_KEY</code>{' '}
-            and restart the controller, or use Import instead.
+        <div className="grid gap-3.5">
+          {!ready && (
+            <V3Alert title="key required">
+              Generation needs an ElevenLabs key. Set{' '}
+              <code className="font-mono text-[12px]">ELEVENLABS_API_KEY</code> and restart the
+              controller.
+            </V3Alert>
+          )}
+          <div className="grid grid-cols-[1fr_120px] gap-3">
+            <div className="grid gap-1.5">
+              <Label>Name</Label>
+              <Input
+                value={sfxForm.name}
+                maxLength={60}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setSfxForm(f => ({ ...f, name: e.target.value }))}
+                placeholder="tape-stop"
+              />
+            </div>
+            <div className="grid gap-1.5">
+              <Label>Duration · s</Label>
+              <Input
+                className="mono-num"
+                type="number"
+                step={0.1}
+                min={0.5}
+                max={22}
+                value={sfxForm.durationSec}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setSfxForm(f => ({ ...f, durationSec: e.target.value }))}
+                placeholder="auto"
+              />
+            </div>
           </div>
-        )}
-        <div className="field">
-          <Label>Name</Label>
-          <Input
-            value={sfxForm.name}
-            maxLength={60}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setSfxForm(f => ({ ...f, name: e.target.value }))}
-            placeholder="e.g. record-scratch"
-            className="max-w-[280px]"
-          />
-          <div className="field-hint">A short slug the agent references: letters, numbers and dashes.</div>
-        </div>
-        <div className="field mt-3.5">
-          <Label>Description</Label>
-          <Input
-            value={sfxForm.description}
-            maxLength={200}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setSfxForm(f => ({ ...f, description: e.target.value }))}
-            placeholder="when the agent should reach for this effect"
-          />
-          <div className="field-hint">The agent reads this to decide when the effect fits a line.</div>
-        </div>
-        <div className="field mt-3.5">
-          <Label>Generation prompt</Label>
-          <Textarea
-            rows={2}
-            value={sfxForm.prompt}
-            onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setSfxForm(f => ({ ...f, prompt: e.target.value }))}
-            placeholder='e.g. "abrupt vinyl record scratch, short and sharp"'
-          />
-          <div className="field-hint">{sfxForm.prompt.length}/500 chars. Describe the sound for ElevenLabs.</div>
-        </div>
-        <div className="field mt-3.5">
-          <Label>Duration (optional)</Label>
-          <div className="flex items-center gap-2">
+          <div className="grid gap-1.5">
+            <Label>Description</Label>
             <Input
-              className="mono-num w-28"
-              type="number"
-              step={0.5}
-              min={0.5}
-              max={22}
-              value={sfxForm.durationSec}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => setSfxForm(f => ({ ...f, durationSec: e.target.value }))}
-              placeholder="auto"
+              value={sfxForm.description}
+              maxLength={200}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setSfxForm(f => ({ ...f, description: e.target.value }))}
+              placeholder="The agent reads this to decide when the effect fits a line"
             />
-            <span className="text-[12px] text-muted">sec · 0.5–22, blank lets the model decide</span>
+          </div>
+          <div className="grid gap-1.5">
+            <Label>Generation prompt</Label>
+            <Textarea
+              rows={3}
+              value={sfxForm.prompt}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setSfxForm(f => ({ ...f, prompt: e.target.value.slice(0, 500) }))}
+              placeholder="Describe the sound for ElevenLabs…"
+            />
+            <div className="text-right font-mono text-[11px] text-muted">{sfxForm.prompt.length} / 500</div>
           </div>
         </div>
       </Modal>
 
+      {/* Import — bring your own audio */}
       <Modal
         open={modal === 'import'}
         onOpenChange={(o) => { if (!o) setModal(null); }}
-        title="Import sound effect"
-        sub="bring your own mp3 / wav, no ElevenLabs key needed"
+        title="import effect"
+        sub="bring your own mp3 / wav — no ElevenLabs key needed"
         footer={
           <>
-            <Btn onClick={() => setModal(null)}>Cancel</Btn>
-            <Btn
-              tone="accent"
-              onClick={doImport}
-              disabled={busy || !importFile || !importName.trim()}
-            >
-              {busy ? 'Importing…' : 'Import sound effect'}
+            <Button variant="ghost" size="sm" onClick={() => setModal(null)}>Cancel</Button>
+            <Btn sm tone="accent" onClick={doImport} disabled={busy || !importFile || !importName.trim()}>
+              {busy ? 'Importing…' : 'Import'}
             </Btn>
           </>
         }
       >
-        <div className="field">
-          <Label>Name</Label>
-          <Input
-            value={importName}
-            maxLength={60}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setImportName(e.target.value)}
-            placeholder="e.g. my-stinger"
-            className="max-w-[280px]"
-          />
-          <div className="field-hint">A short slug the agent references: letters, numbers and dashes.</div>
-        </div>
-        <div className="field mt-3.5">
-          <Label>Description</Label>
-          <Input
-            value={importDesc}
-            maxLength={200}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setImportDesc(e.target.value)}
-            placeholder="when the agent should reach for this effect"
-          />
-          <div className="field-hint">The agent reads this to decide when the effect fits a line.</div>
-        </div>
-        <div className="field mt-3.5">
-          <Label>Audio file</Label>
+        <div className="grid gap-3.5">
+          <div className="grid gap-1.5">
+            <Label>Name</Label>
+            <Input
+              value={importName}
+              maxLength={60}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setImportName(e.target.value)}
+              placeholder="rain-hiss"
+            />
+          </div>
+          <div className="grid gap-1.5">
+            <Label>Description · optional</Label>
+            <Input
+              value={importDesc}
+              maxLength={200}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setImportDesc(e.target.value)}
+              placeholder="When should the agent reach for this?"
+            />
+          </div>
           <input
             ref={importRef}
             type="file"
@@ -277,15 +272,13 @@ export function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uplo
             onChange={(e: ChangeEvent<HTMLInputElement>) => setImportFile(e.target.files?.[0] ?? null)}
             className="hidden"
           />
-          <div className="flex flex-wrap items-center gap-2.5">
-            <Btn tone="solid" onClick={() => importRef.current?.click()} disabled={busy}>
-              {importFile ? 'Change file…' : 'Choose audio file…'}
-            </Btn>
-            {importFile && <span className="text-[12px] text-ink">{importFile.name}</span>}
-          </div>
-          <div className="field-hint">mp3, wav, ogg, flac, m4a, aac or opus · up to 25 MB · converted to MP3 on import</div>
+          <DropZone
+            label={importFile ? `${importFile.name} · ${fmtSize(importFile.size)}` : 'choose a file…'}
+            hint="mp3 · wav · ogg · flac · m4a · aac · opus — up to 25 MB · converted to MP3 on import"
+            onClick={() => importRef.current?.click()}
+          />
         </div>
       </Modal>
-    </>
+    </section>
   );
 }

--- a/web/components/admin/imaging/parts.tsx
+++ b/web/components/admin/imaging/parts.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+/* Presentational helpers for the redesigned Imaging page (Imaging.dc.html).
+   The editorial "newsprint broadsheet" treatment: bare bordered panels with
+   mono uppercase headers, Fraunces display headlines, right-aligned mono
+   metrics. Every static style is a Tailwind utility — inline `style` is
+   eslint-forbidden here (issue #50) — dynamic bar heights ride the shared
+   `Wave` component's DOM-mutation path instead. These are pure layout; all
+   state + controller wiring stays in ImagingPanel and the section files. */
+
+import type { ReactNode } from 'react';
+import { cn } from '../../../lib/cn';
+
+/** Zero-pad a count to two digits, the way the metrics read in the design. */
+export function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+/** The mono micro-label used on every panel header (10px / 700 / 0.2em). */
+export function MonoLabel({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <span className={cn('font-mono text-[10px] font-bold tracking-[0.2em] uppercase', className)}>
+      {children}
+    </span>
+  );
+}
+
+/** A bordered editorial panel. Sharp corners, 1px ink border, no shadow. */
+export function PanelBox({ children, className }: { children: ReactNode; className?: string }) {
+  return <div className={cn('border border-ink', className)}>{children}</div>;
+}
+
+/** Panel header row: mono label on the left, an optional actions cluster on
+    the right, hairline underline. */
+export function PanelHead({ label, right }: { label: ReactNode; right?: ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-separator-strong px-[18px] py-[13px]">
+      <MonoLabel>{label}</MonoLabel>
+      {right && <div className="flex items-center gap-2">{right}</div>}
+    </div>
+  );
+}
+
+/** Right-aligned metric: a big mono figure over a tiny uppercase caption. */
+export function TabMetric({
+  n, l, accent, big,
+}: { n: ReactNode; l: ReactNode; accent?: boolean; big?: boolean }) {
+  return (
+    <div className="text-right">
+      <div
+        className={cn(
+          'font-mono leading-none font-bold',
+          big ? 'text-[26px]' : 'text-[22px]',
+          accent && 'text-[var(--accent)]',
+        )}
+      >
+        {n}
+      </div>
+      <div className="mt-[5px] font-mono text-[9px] tracking-[0.18em] text-muted uppercase">{l}</div>
+    </div>
+  );
+}
+
+/** Per-tab masthead: Fraunces headline + description on the left, metrics on
+    the right. Replaces the boxed SectionHeader inside the imaging tabs. */
+export function SectionMasthead({
+  title, sub, metrics,
+}: { title: ReactNode; sub: ReactNode; metrics: ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-end justify-between gap-x-6 gap-y-4">
+      <div>
+        <h2 className="font-display text-[34px] leading-[1.1] font-semibold">{title}</h2>
+        <p className="mt-2 max-w-[58ch] text-[13px] leading-[1.6] [text-wrap:pretty] text-muted">
+          {sub}
+        </p>
+      </div>
+      <div className="flex flex-none gap-7">{metrics}</div>
+    </div>
+  );
+}
+
+/** Empty-library state: a display-italic "None yet." over a mono caption. */
+export function EmptyState({ caption }: { caption: ReactNode }) {
+  return (
+    <div className="px-[18px] py-11 text-center">
+      <div className="font-display text-[22px] text-muted italic">None yet.</div>
+      <div className="mt-2 font-mono text-[11px] tracking-[0.12em] text-muted uppercase">{caption}</div>
+    </div>
+  );
+}
+
+/** Dashed drop-zone that triggers a hidden file input in the import modals. */
+export function DropZone({
+  label, hint, onClick, disabled,
+}: { label: ReactNode; hint: ReactNode; onClick: () => void; disabled?: boolean }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="block w-full cursor-pointer border border-dashed border-ink px-4 py-[18px] text-center transition-colors hover:bg-[var(--ink-soft)] disabled:cursor-not-allowed disabled:opacity-40"
+    >
+      <div className="font-mono text-[12px] font-bold tracking-[0.12em] uppercase">{label}</div>
+      <div className="mt-1.5 font-mono text-[10px] text-muted">{hint}</div>
+    </button>
+  );
+}
+
+/** The shared asset-row metadata line: mono, muted, dot-separated facets. */
+export function MetaLine({ children }: { children: ReactNode }) {
+  return (
+    <div className="mt-[7px] flex flex-wrap items-center gap-2.5 font-mono text-[11px] text-muted">
+      {children}
+    </div>
+  );
+}

--- a/web/components/admin/settings/shared.tsx
+++ b/web/components/admin/settings/shared.tsx
@@ -6,7 +6,9 @@ import { m } from 'motion/react';
 import { notify, errorMessage } from '../../../lib/notify';
 import { cn } from '../../../lib/cn';
 import type { StationLocale } from '../../../lib/format';
+import { Play } from 'lucide-react';
 import { Btn, Eyebrow, Metric } from '../ui';
+import { Button } from '../../ui/button';
 
 export const KEY_HINTS: Record<string, string> = {
   ANTHROPIC_API_KEY: 'sk-ant-...',
@@ -573,11 +575,28 @@ export function PreviewButton({ path, adminFetch, label = 'Play' }: PreviewButto
     }
   };
 
-  const text = state === 'playing' ? 'Stop' : state === 'loading' ? '…' : label;
-
+  // Icon-ghost preview (Imaging.dc.html): a filled play triangle that swaps to
+  // animated EQ bars while the clip is on air. `label` is the accessible name.
   return (
-    <Btn sm onClick={onClick} title="Preview audio">
-      {text}
-    </Btn>
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      onClick={onClick}
+      aria-label={state === 'playing' ? 'Stop preview' : label}
+      title={state === 'playing' ? 'Stop preview' : 'Preview audio'}
+    >
+      {state === 'playing' ? (
+        <span className="flex h-3.5 items-center gap-[2px]" aria-hidden>
+          <span className="h-3 w-[2px] origin-bottom animate-[skin-eq_.7s_ease-in-out_infinite] bg-[var(--accent)]" />
+          <span className="h-3 w-[2px] origin-bottom animate-[skin-eq_.7s_ease-in-out_.15s_infinite] bg-[var(--accent)]" />
+          <span className="h-3 w-[2px] origin-bottom animate-[skin-eq_.7s_ease-in-out_.3s_infinite] bg-[var(--accent)]" />
+        </span>
+      ) : state === 'loading' ? (
+        <span className="font-mono text-[13px] leading-none" aria-hidden>…</span>
+      ) : (
+        <Play className="fill-current" aria-hidden />
+      )}
+    </Button>
   );
 }


### PR DESCRIPTION
Reimplements the admin **Imaging** page (Jingles / SFX / Beds) to the newsprint-broadsheet design from claude.ai/design (`Imaging.dc.html`).

## What changed (presentation only)
- **Masthead** — Fraunces display headline, a live waveform, a "live · refreshed every 3s" pulse, and mono metrics: total **assets** + **jingle ratio** (`1 : N` / `off`).
- **Tab bar** — three equal cells, the active one inverted (`bg-ink`) with an accent top-rule and zero-padded count badges.
- **Panels** — bordered editorial boxes with mono uppercase headers, replacing the old `Card`/`SectionHeader` chrome. Jingle rows show the ident as italic Fraunces; SFX/Beds rows use mono name + description.
- **Preview** — `PreviewButton` (imaging-only) is now an icon-ghost button whose play triangle swaps to animated EQ bars while a clip is on air.
- **Modals** — create/import redrawn with dashed drop-zones, live counters, batch progress + Stop, and a failures list.

## Not changed
Every controller call, handler, and piece of state is identical — this is a re-skin of the four section components over a new shared `parts.tsx`. All static styles are Tailwind utilities (no inline `style`, per #50).

## Verification
Booted an isolated controller + this worktree's web dev server and drove `/admin/imaging` in the browser:
- All three tabs render faithfully (metrics, badges, counts, ratio formatting, toggles, thresholds, library rows).
- Create-jingle modal (textarea + `41/500` counter + enable-on-input) and import modal (dashed drop-zone, disabled Import with no files) work.
- Accessible names correct ("Jingle ratio", "Play", "Delete jingle"); `?tab=` deep-linking works.
- `npm run lint` (eslint + tsc) is clean.