### PR TITLE
feat(web): operator-editable moods on a dedicated /admin/moods page

### DIFF
--- a/controller/scripts/moods.test.ts
+++ b/controller/scripts/moods.test.ts
@@ -12,6 +12,10 @@ import {
   moodPromptFor,
   moodScheduleFor,
   weatherMoodFor,
+  validateMoodsStrict,
+  validateMoodScheduleStrict,
+  validateWeatherMoodsStrict,
+  assertNoOrphanMoods,
   MOOD_DEFAULTS,
   PERIOD_MOOD_DEFAULTS,
   WEATHER_MOOD_DEFAULTS,
@@ -58,5 +62,133 @@ for (const cond of WEATHER_CONDITIONS) {
   if (v) assert.ok(moodVocab().includes(v), `${cond} maps to a real mood`);
 }
 assert.equal(weatherMoodFor('cloudy'), '', 'cloudy has no mood steer by default');
+
+// ── validateMoodsStrict ──────────────────────────────────────────────────────
+
+// Valid list round-trips, normalising the id (lowercase, spaces/punct → dashes)
+// and keeping the CLAP prompt.
+assert.deepEqual(
+  validateMoodsStrict([{ name: 'Chill Vibes!', clapPrompt: 'soft downtempo' }]),
+  [{ name: 'chill-vibes', clapPrompt: 'soft downtempo' }],
+  'name normalises to a kebab id; prompt preserved',
+);
+// A missing/blank prompt is allowed (falls back to `${name} music` at read time).
+assert.deepEqual(
+  validateMoodsStrict([{ name: 'mellow' }]),
+  [{ name: 'mellow', clapPrompt: '' }],
+  'clapPrompt is optional',
+);
+// Unknown keys are stripped (rebuilt objects).
+assert.deepEqual(
+  validateMoodsStrict([{ name: 'x', clapPrompt: 'y', bogus: 1 }]),
+  [{ name: 'x', clapPrompt: 'y' }],
+  'unknown keys stripped',
+);
+assert.throws(() => validateMoodsStrict([]), /at least one/, 'empty vocabulary rejected');
+assert.throws(() => validateMoodsStrict('nope' as any), /must be an array/, 'non-array rejected');
+assert.throws(
+  () => validateMoodsStrict([{ name: 'a' }, { name: 'A' }]),
+  /duplicate/,
+  'duplicate names (after normalise) rejected',
+);
+assert.throws(
+  () => validateMoodsStrict([{ name: '' }]),
+  /must be 1-/,
+  'empty name rejected',
+);
+assert.throws(
+  () => validateMoodsStrict(Array.from({ length: 41 }, (_, i) => ({ name: `m${i}` }))),
+  /at most/,
+  'over the 40-entry cap rejected',
+);
+
+// ── validateMoodScheduleStrict ───────────────────────────────────────────────
+
+const NAMES = ['energetic', 'calm', 'focus', 'evening', 'night', 'morning', 'driving', 'reflective'];
+const fullSchedule = Object.fromEntries(MOOD_PERIODS.map((p) => [p, PERIOD_MOOD_DEFAULTS[p]]));
+assert.deepEqual(
+  validateMoodScheduleStrict(fullSchedule, NAMES),
+  fullSchedule,
+  'a complete schedule of known moods round-trips',
+);
+assert.throws(
+  () => validateMoodScheduleStrict({ ...fullSchedule, 'drive-time': 'banana' }, NAMES),
+  /moodSchedule\.drive-time/,
+  'a slot pointing at an unknown mood is rejected, naming the slot',
+);
+assert.throws(
+  () => validateMoodScheduleStrict([] as any, NAMES),
+  /must be an object/,
+  'non-object schedule rejected',
+);
+
+// ── validateWeatherMoodsStrict ───────────────────────────────────────────────
+
+// '' (no steer) is allowed; missing conditions default to '' — so a partial map fills out.
+const weatherOut = validateWeatherMoodsStrict({ clear: 'energetic', rainy: '' }, NAMES);
+assert.equal(weatherOut.clear, 'energetic', 'known mood kept');
+assert.equal(weatherOut.rainy, '', 'blank = no steer kept');
+assert.equal(weatherOut.stormy, '', 'omitted condition defaults to no steer');
+assert.equal(Object.keys(weatherOut).length, WEATHER_CONDITIONS.length, 'all conditions present');
+assert.throws(
+  () => validateWeatherMoodsStrict({ clear: 'banana' }, NAMES),
+  /weatherMoods\.clear/,
+  'a condition pointing at an unknown mood is rejected',
+);
+
+// ── assertNoOrphanMoods (the in-use removal guard) ───────────────────────────
+
+const baseState = () => ({
+  moods: [{ name: 'energetic', clapPrompt: '' }, { name: 'calm', clapPrompt: '' }],
+  moodSchedule: { 'drive-time': 'energetic', evening: 'calm' },
+  weatherMoods: { clear: 'energetic', rainy: '' },
+  festivals: [{ name: 'Diwali', mood: 'calm' }],
+  shows: [{ name: 'Breakfast', moods: ['energetic'] }],
+});
+
+// All references resolve → no throw.
+assert.doesNotThrow(() => assertNoOrphanMoods(baseState()), 'consistent state passes');
+
+// Remove 'calm' while a festival still uses it → rejected, naming the festival.
+{
+  const s = baseState();
+  s.moods = [{ name: 'energetic', clapPrompt: '' }];
+  assert.throws(() => assertNoOrphanMoods(s), /festival "Diwali"/, 'festival ref blocks removal');
+}
+// Schedule slot still referencing the removed mood → names the slot.
+{
+  const s = baseState();
+  s.moods = [{ name: 'energetic', clapPrompt: '' }];
+  s.festivals = [];
+  assert.throws(() => assertNoOrphanMoods(s), /evening time-of-day slot/, 'schedule ref blocks removal');
+}
+// Weather slot referencing the removed mood → names the condition.
+{
+  const s = baseState();
+  s.moods = [{ name: 'calm', clapPrompt: '' }];
+  s.moodSchedule = { 'drive-time': 'calm', evening: 'calm' };
+  s.festivals = [];
+  s.shows = [];
+  assert.throws(() => assertNoOrphanMoods(s), /clear weather slot/, 'weather ref blocks removal');
+}
+// Show referencing the removed mood → names the show.
+{
+  const s = baseState();
+  s.moods = [{ name: 'calm', clapPrompt: '' }];
+  s.moodSchedule = { 'drive-time': 'calm', evening: 'calm' };
+  s.weatherMoods = { clear: 'calm', rainy: '' };
+  s.festivals = [];
+  assert.throws(() => assertNoOrphanMoods(s), /show "Breakfast"/, 'show ref blocks removal');
+}
+// A rename done in one shot (add new, repoint every referrer, drop old) passes.
+{
+  const s = baseState();
+  s.moods = [{ name: 'energetic', clapPrompt: '' }, { name: 'serene', clapPrompt: '' }];
+  s.moodSchedule = { 'drive-time': 'energetic', evening: 'serene' };
+  s.weatherMoods = { clear: 'energetic', rainy: '' };
+  s.festivals = [{ name: 'Diwali', mood: 'serene' }];
+  s.shows = [{ name: 'Breakfast', moods: ['energetic'] }];
+  assert.doesNotThrow(() => assertNoOrphanMoods(s), 'a fully-repointed rename passes');
+}
 
 console.log('moods: all assertions passed');

--- a/controller/scripts/moods.test.ts
+++ b/controller/scripts/moods.test.ts
@@ -1,0 +1,62 @@
+// Unit tests for the live mood accessors (settings.ts): moodVocab / moodEntries
+// / moodPromptFor / moodScheduleFor / weatherMoodFor — the single seam every
+// mood consumer reads through. These must answer from the SEED defaults before
+// settings.load() (get() returns DEFAULTS), which is what keeps the standalone
+// audio-moods + tagger paths working without a loaded settings.json.
+// Run: `tsx scripts/moods.test.ts`.
+
+import assert from 'node:assert/strict';
+import {
+  moodVocab,
+  moodEntries,
+  moodPromptFor,
+  moodScheduleFor,
+  weatherMoodFor,
+  MOOD_DEFAULTS,
+  PERIOD_MOOD_DEFAULTS,
+  WEATHER_MOOD_DEFAULTS,
+  MOOD_PERIODS,
+  WEATHER_CONDITIONS,
+} from '../src/settings.js';
+
+// ── vocabulary ───────────────────────────────────────────────────────────────
+
+// Pre-load, the vocabulary IS the seed defaults (get() → DEFAULTS).
+assert.deepEqual(
+  moodVocab(),
+  MOOD_DEFAULTS.map((m) => m.name),
+  'moodVocab() returns the seed mood names before load()',
+);
+assert.equal(moodEntries().length, MOOD_DEFAULTS.length, 'moodEntries() returns every seed mood');
+assert.ok(moodVocab().includes('energetic'), 'a known default mood is present');
+
+// ── per-mood CLAP prompt ─────────────────────────────────────────────────────
+
+// Every seed mood resolves to its curated description; an unknown mood falls
+// back to the bare "<name> music" form.
+for (const m of MOOD_DEFAULTS) {
+  const expected = m.clapPrompt || `${m.name} music`;
+  assert.equal(moodPromptFor(m.name), expected, `curated prompt for "${m.name}"`);
+}
+assert.equal(moodPromptFor('zydeco'), 'zydeco music', 'unknown mood → bare-word fallback');
+
+// ── time-of-day → mood ───────────────────────────────────────────────────────
+
+// Every fixed period resolves to its seed mood, and each is a real vocabulary entry.
+for (const period of MOOD_PERIODS) {
+  assert.equal(moodScheduleFor(period), PERIOD_MOOD_DEFAULTS[period], `schedule seed for ${period}`);
+  assert.ok(moodVocab().includes(moodScheduleFor(period)), `${period} maps to a real mood`);
+}
+
+// ── weather → mood ───────────────────────────────────────────────────────────
+
+// Every condition resolves to its seed; '' (cloudy) stays "no steer", and any
+// non-empty value is a real vocabulary entry.
+for (const cond of WEATHER_CONDITIONS) {
+  assert.equal(weatherMoodFor(cond), WEATHER_MOOD_DEFAULTS[cond], `weather seed for ${cond}`);
+  const v = weatherMoodFor(cond);
+  if (v) assert.ok(moodVocab().includes(v), `${cond} maps to a real mood`);
+}
+assert.equal(weatherMoodFor('cloudy'), '', 'cloudy has no mood steer by default');
+
+console.log('moods: all assertions passed');

--- a/controller/src/context.ts
+++ b/controller/src/context.ts
@@ -2,25 +2,34 @@
 // Used by the autonomous scheduler to pick mood-appropriate tracks.
 
 import { config } from './config.js';
-import { resolveActiveShow, resolveOnAirLocation, get as getSettings } from './settings.js';
+import { resolveActiveShow, resolveOnAirLocation, get as getSettings, moodScheduleFor, weatherMoodFor } from './settings.js';
 import * as session from './broadcast/session.js';
 import { getListenerCount } from './broadcast/listeners.js';
 import { zonedParts, zonedISODate, clockDisplay, spokenHourPhrase } from './time.js';
 
+// The day-period → {vibe, show} table stays in code (these feed spoken-segment
+// prompts and show resolution). Each period's MOOD is operator-editable
+// (settings.moodSchedule via moodScheduleFor). Note the 'drive-time' vibe reads
+// 'end of the workday', not 'drive home': the vibe string lands in every
+// spoken-segment prompt and the commute framing had the DJ doing traffic-jockey
+// patter for two hours a day. The period names keep driving pick energy, not talk.
+const PERIOD_TABLE: Array<{ from: number; to: number; period: string; vibe: string; show: string }> = [
+  { from: 5, to: 9, period: 'early-morning', vibe: 'gentle waking', show: 'breakfast' },
+  { from: 9, to: 12, period: 'morning', vibe: 'productive', show: 'morning' },
+  { from: 12, to: 14, period: 'midday', vibe: 'lunch hour', show: 'midday' },
+  { from: 14, to: 17, period: 'afternoon', vibe: 'sustained energy', show: 'afternoon' },
+  { from: 17, to: 19, period: 'drive-time', vibe: 'end of the workday', show: 'drive-time' },
+  { from: 19, to: 22, period: 'evening', vibe: 'wind down', show: 'evening' },
+];
+
 export function getTimeContext(date = new Date()) {
   const h = zonedParts(date).hour;
-  if (h >= 5 && h < 9) return { period: 'early-morning', mood: 'morning', vibe: 'gentle waking', show: 'breakfast' };
-  if (h >= 9 && h < 12) return { period: 'morning', mood: 'morning', vibe: 'productive', show: 'morning' };
-  if (h >= 12 && h < 14) return { period: 'midday', mood: 'energetic', vibe: 'lunch hour', show: 'midday' };
-  if (h >= 14 && h < 17) return { period: 'afternoon', mood: 'focus', vibe: 'sustained energy', show: 'afternoon' };
-  // vibe reads 'end of the workday', not 'drive home': the vibe string lands in
-  // every spoken-segment prompt (Period: drive-time (…)) and the commute framing
-  // had the DJ doing traffic-jockey patter for two hours a day. The period/mood
-  // keep their names — they drive pick energy, not talk.
-  if (h >= 17 && h < 19) return { period: 'drive-time', mood: 'driving', vibe: 'end of the workday', show: 'drive-time' };
-  if (h >= 19 && h < 22) return { period: 'evening', mood: 'evening', vibe: 'wind down', show: 'evening' };
-  if (h >= 22 || h < 1) return { period: 'late-evening', mood: 'night', vibe: 'late hours', show: 'late' };
-  return { period: 'after-hours', mood: 'reflective', vibe: 'after hours', show: 'graveyard' };
+  const slot =
+    PERIOD_TABLE.find((s) => h >= s.from && h < s.to) ??
+    (h >= 22 || h < 1
+      ? { period: 'late-evening', vibe: 'late hours', show: 'late' }
+      : { period: 'after-hours', vibe: 'after hours', show: 'graveyard' });
+  return { period: slot.period, mood: moodScheduleFor(slot.period), vibe: slot.vibe, show: slot.show };
 }
 
 // Festival calendar — read from persisted settings so the operator can
@@ -109,19 +118,11 @@ function mapWeatherCode(code: number) {
   return 'cloudy';
 }
 
+// Operator-editable weather → mood map (settings.weatherMoods). '' (no steer)
+// normalises to null so the dominantMood chain (festival > weather > time)
+// falls through to the time mood, exactly as the old hardcoded default did.
 function weatherToMood(condition) {
-  switch (condition) {
-    case 'rainy':
-    case 'foggy':
-    case 'stormy':
-      return 'rainy';
-    case 'clear':
-      return 'sunny';
-    case 'snowy':
-      return 'reflective';
-    default:
-      return null;
-  }
+  return weatherMoodFor(condition) || null;
 }
 
 // ---------------------------------------------------------------------------

--- a/controller/src/llm/internal/prompts/generate.ts
+++ b/controller/src/llm/internal/prompts/generate.ts
@@ -7,7 +7,7 @@
 // generated draft round-trips through Save without surprises.
 
 import { z } from 'zod';
-import { FREQUENCIES, SCRIPT_LENGTHS, SHOW_MOODS, SHOW_ENERGY, SOUL_MAX } from '../../../settings.js';
+import { FREQUENCIES, SCRIPT_LENGTHS, moodVocab, SHOW_ENERGY, SOUL_MAX } from '../../../settings.js';
 import { THEME_TOKEN_KEYS } from '../../../themes.js';
 import { djObject } from '../strategy/object.js';
 import { buildContextLines } from './context.js';
@@ -61,10 +61,11 @@ interface ShowCtx {
 // personaId / themeId / mood / energy / filtersStrict against the live lists
 // (routes/generate.ts) — that normalisation only runs because parse no longer
 // throws here.
-const SHOW_SCHEMA = z.object({
+// The mood field is added per-call in generateShow() from the LIVE vocabulary
+// (settings.moods is operator-editable), so a module-load z.enum can't bake it.
+const SHOW_SCHEMA_BASE = z.object({
   name: z.string().min(1).max(60).describe('the show name shown in the schedule — punchy, 1-4 words').catch('New show'),
   topic: z.string().max(1000).describe('the brief the AI DJ reads before the slot: genres, eras, moods, artists, time of day, listener type, host tone. 1-4 sentences, max 1000 chars.').catch(''),
-  mood: z.enum(SHOW_MOODS as [string, ...string[]]).describe('the single closest music mood for this show').catch(SHOW_MOODS[0]),
   genre: z.string().max(64).describe('a music genre lean if one fits (e.g. "jazz", "gospel", "lofi"); "" for no lean. Prefer a genre present in the supplied library list when relevant.').catch(''),
   filtersStrict: z.boolean().describe('true ONLY when the description demands exclusivity ("only plays hip-hop", "strictly 80s", "nothing but calm tracks") — hard-locks every pick to ALL the filters set (mood, genre, era, energy). false for normal soft leans. Requires at least one filter; leave false when none is set.').catch(false),
   fromYear: z.number().int().nullable().describe('start year of an era window if the show targets a decade (e.g. 1970), else null').catch(null),
@@ -77,6 +78,10 @@ const SHOW_SCHEMA = z.object({
 const SHOW_SYSTEM = `You design radio shows for a personal internet radio station. Given a free-text description, produce a single show definition: a name, a DJ brief (topic), a music mood, an optional genre lean and era window, an energy steer, and the best-matching persona and (optional) theme from the supplied lists. Pick personaId / themeId ONLY from the ids given; use null when nothing clearly fits. The mood MUST be one of the listed moods. Set filtersStrict=true only when the description signals exclusivity ("only", "strictly", "nothing but", "pure <genre>") — it hard-locks every pick to ALL the set filters (mood, genre, era, energy); otherwise keep them soft leans (filtersStrict=false). Keep the topic concrete and useful as a brief — name the kind of music, the moment of day, and the tone.`;
 
 export async function generateShow(description: string, ctx: ShowCtx = {}) {
+  const moods = moodVocab();
+  const showSchema = SHOW_SCHEMA_BASE.extend({
+    mood: z.enum(moods as [string, ...string[]]).describe('the single closest music mood for this show').catch(moods[0]),
+  });
   const lines: string[] = [];
   if (ctx.personas?.length) {
     lines.push('Available personas (id — name):');
@@ -89,12 +94,12 @@ export async function generateShow(description: string, ctx: ShowCtx = {}) {
   if (ctx.genres?.length) {
     lines.push(`Genres present in the library (sample): ${ctx.genres.slice(0, 40).join(', ')}`);
   }
-  lines.push(`Allowed moods: ${SHOW_MOODS.join(', ')}`);
+  lines.push(`Allowed moods: ${moods.join(', ')}`);
 
   return djObject({
     system: SHOW_SYSTEM,
     prompt: `Description of the show the operator wants:\n"${description}"\n\n${lines.join('\n')}\n\nDesign the show.`,
-    schema: SHOW_SCHEMA,
+    schema: showSchema,
     temperature: 0.7,
     kind: 'generateShow',
   });

--- a/controller/src/music/audio-moods.ts
+++ b/controller/src/music/audio-moods.ts
@@ -17,47 +17,25 @@
 import crypto from 'node:crypto';
 import * as db from './library-db.js';
 import * as analyzer from './analyzer.js';
-import { SHOW_MOODS } from '../settings.js';
+import { moodVocab, moodPromptFor } from '../settings.js';
 import { makeEventLogger } from './tagger-progress.js';
 
 const logEvent = makeEventLogger('audio-moods');
 
-// One CLAP text prompt per mood. Deliberately DESCRIPTIVE of sound — CLAP was
-// trained on audio captions, so "how it sounds" phrasing scores far better than
-// the bare vocabulary word (several moods — cooking, focus, morning — are
-// listening contexts, not acoustic qualities). Changing a prompt changes
-// moodVocabHash(), which re-scores the whole library on the next pass.
-const MOOD_PROMPTS: Record<string, string> = {
-  energetic: 'high-energy, upbeat, powerful music with a strong driving beat',
-  calm: 'calm, peaceful, soft, soothing, gentle music',
-  reflective: 'reflective, introspective, melancholic, emotional music',
-  celebratory: 'joyful, festive, celebratory party music',
-  romantic: 'romantic, intimate, tender, loving music',
-  spiritual: 'spiritual, devotional, sacred, meditative music',
-  focus: 'minimal, unobtrusive, ambient instrumental background music for concentration',
-  workout: 'intense, pounding, adrenaline-pumping workout music',
-  driving: 'steady, groovy, mid-tempo cruising music for a road trip',
-  cooking: 'light, cheerful, breezy, feel-good easy-listening music',
-  rainy: 'mellow, wistful, cozy music for a rainy day',
-  sunny: 'bright, warm, sunny, feel-good summer music',
-  night: 'dark, atmospheric, moody late-night music',
-  morning: 'fresh, gentle, optimistic early-morning music',
-  evening: 'smooth, warm, relaxed evening music',
-  festival: 'big, anthemic, euphoric festival crowd music',
-  cultural: 'traditional folk music with regional acoustic instruments',
-};
-
-// Prompt for one mood — unknown vocabulary entries (a future SHOW_MOODS
-// addition without a prompt here) fall back to the bare word, which still
-// works, just less sharply.
+// Prompt for one mood — its operator-edited CLAP sound-description
+// (settings.moods[].clapPrompt), or the bare word for a mood with no prompt.
+// The descriptions are DESCRIPTIVE of sound on purpose — CLAP was trained on
+// audio captions, so "how it sounds" phrasing scores far better than the bare
+// word. Changing a prompt changes moodVocabHash(), which re-scores the whole
+// library on the next pass.
 export function moodPrompt(mood: string): string {
-  return MOOD_PROMPTS[mood] ?? `${mood} music`;
+  return moodPromptFor(mood);
 }
 
 // Hash of the vocabulary + prompts the stored audio_moods were scored with.
 // Stored in audio_embedding_meta.mood_vocab_hash; a mismatch re-scores every
 // vector-carrying track (mirrors the tagger's promptVocabHash pattern).
-export function moodVocabHash(vocab: readonly string[] = SHOW_MOODS): string {
+export function moodVocabHash(vocab: readonly string[] = moodVocab()): string {
   const h = crypto.createHash('sha256');
   for (const m of vocab) h.update(`${m}=${moodPrompt(m)}|`);
   return h.digest('hex').slice(0, 16);
@@ -111,10 +89,12 @@ export async function runAudioMoodPass(): Promise<AudioMoodStats> {
   }
 
   // One round-trip for the whole vocabulary. Generous timeout: the first call
-  // after a cold boot may lazy-load (or download) the CLAP text tower.
-  const prompts = SHOW_MOODS.map(moodPrompt);
+  // after a cold boot may lazy-load (or download) the CLAP text tower. Snapshot
+  // the live vocab once so prompts and the scoring loop stay index-aligned.
+  const vocab = moodVocab();
+  const prompts = vocab.map(moodPrompt);
   const vecs = await analyzer.embedTexts(prompts, { timeoutMs: 10 * 60_000 });
-  if (!vecs || vecs.length !== SHOW_MOODS.length) {
+  if (!vecs || vecs.length !== vocab.length) {
     // A backend that ADVERTISES the text tower but failed the call is a runtime
     // fault (worker error, oversized-response 500 — #996), not a lean build;
     // "enable ANALYZER_HEAVY" would send the operator in the wrong direction.
@@ -144,10 +124,10 @@ export async function runAudioMoodPass(): Promise<AudioMoodStats> {
     const v = db.getAudioVector(id);
     if (!v) continue;
     const scores: Record<string, number> = {};
-    for (let i = 0; i < SHOW_MOODS.length; i++) {
+    for (let i = 0; i < vocab.length; i++) {
       // Both sides are L2-normalised, so the dot IS the cosine. 3 decimals is
       // plenty of precision and keeps the stored JSON small.
-      scores[SHOW_MOODS[i]] = Math.round(dot(v, vecs[i]) * 1000) / 1000;
+      scores[vocab[i]] = Math.round(dot(v, vecs[i]) * 1000) / 1000;
     }
     batch.push({ id, moods: topAudioMoods(scores), scores });
     scored += 1;

--- a/controller/src/music/embeddings.ts
+++ b/controller/src/music/embeddings.ts
@@ -25,7 +25,7 @@ import {
   embeddingTextPrefixes,
 } from '../llm/provider.js';
 import type { EmbeddingCfg, EmbeddingTextPrefixes } from '../llm/provider.js';
-import { SHOW_MOODS as MOOD_VOCAB } from '../settings.js';
+import { moodVocab } from '../settings.js';
 import crypto from 'node:crypto';
 
 const LYRIC_EXCERPT_CHARS = 400; // cap lyrics before they bloat the embedding text
@@ -491,7 +491,7 @@ export function promptVocabHash(systemPrompt: string): string {
     .createHash('sha256')
     .update(systemPrompt)
     .update('|')
-    .update(MOOD_VOCAB.join(','))
+    .update(moodVocab().join(','))
     .digest('hex')
     .slice(0, 16);
 }

--- a/controller/src/music/seed-selector.ts
+++ b/controller/src/music/seed-selector.ts
@@ -15,7 +15,7 @@
 
 import * as subsonic from './subsonic.js';
 import * as db from './library-db.js';
-import { SHOW_MOODS } from '../settings.js';
+import { moodVocab } from '../settings.js';
 import { shuffle } from '../util/shuffle.js';
 
 export interface SeedSelection {
@@ -37,7 +37,11 @@ export interface SelectorOpts {
   untaggedPool?: Set<string>;
 }
 
-const MOOD_WORDS = new Set(SHOW_MOODS.map(s => s.toLowerCase()));
+// Live vocabulary as a lowercased Set — read per call, not at module load, so
+// operator-added moods (settings.moods) still match mood-named playlists.
+function moodWords(): Set<string> {
+  return new Set(moodVocab().map(s => s.toLowerCase()));
+}
 
 export async function selectSeeds(opts: SelectorOpts): Promise<SeedSelection> {
   const alreadyTagged = new Set(db.allTaggedIds());
@@ -82,10 +86,11 @@ export async function selectSeeds(opts: SelectorOpts): Promise<SeedSelection> {
   if (chosen.size < operatorCap) {
     try {
       const playlists = await subsonic.getPlaylists();
+      const moodTokens = moodWords();
       const moodPlaylists = (Array.isArray(playlists) ? playlists : []).filter(
         (p: any) => {
           const name = String(p?.name || '').toLowerCase();
-          for (const mood of MOOD_WORDS) {
+          for (const mood of moodTokens) {
             if (name.includes(mood)) return true;
           }
           return false;

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -51,7 +51,7 @@ import { loadSetupConfig } from '../setup/config.js';
 import { activeModelLabel, primaryLeg, fallbackLeg, probeLegReachable } from '../llm/provider.js';
 import { isUnreachable, isQuotaOrAuthError, errReason } from '../llm/sdk.js';
 import { setRawDebugStderrMirror } from '../llm/log.js';
-import { tagBatch, tagOne, TAGGER_BATCH_SYSTEM, type TagResult } from './tagger-core.js';
+import { tagBatch, tagOne, taggerBatchSystem, type TagResult } from './tagger-core.js';
 import { runAnalysisPass } from './analyze.js';
 import { reportProgress, formatPhaseBreakdown, sortedPhaseTimings, makeEventLogger } from './tagger-progress.js';
 import { planRun } from './rescan-scope.js';
@@ -418,7 +418,7 @@ async function main() {
     if (flags.rescan && reembedIds.length === 0) reembedIds = db.unembeddedIds();
   }
 
-  const promptHash = embeddings.promptVocabHash(TAGGER_BATCH_SYSTEM);
+  const promptHash = embeddings.promptVocabHash(taggerBatchSystem());
   const modelLabel = activeModelLabel();
 
   // Single- vs dual-LLM tagging. Decided once and shared by the seed + active-

--- a/controller/src/music/tagger-core.ts
+++ b/controller/src/music/tagger-core.ts
@@ -5,7 +5,7 @@
 // bulk tag-library.ts script. Both produce identical shapes per track.
 
 import { z } from 'zod';
-import { SHOW_MOODS as MOOD_VOCAB } from '../settings.js';
+import { moodVocab } from '../settings.js';
 import { djObject } from '../llm/sdk.js';
 import { songGenres } from './subsonic.js';
 
@@ -18,11 +18,15 @@ export const BatchTagSchema = z.object({
   results: z.array(TagSchema),
 });
 
-export const TAGGER_SYSTEM = `You tag music tracks with mood and energy for a personal radio station.
+// System prompts are FUNCTIONS, not consts: the mood list is operator-editable
+// (settings.moods) and read live, so the prompt — and the promptVocabHash the
+// tagger keys re-tagging on — reflect the current vocabulary each call.
+export function taggerSystem(): string {
+  return `You tag music tracks with mood and energy for a personal radio station.
 
 For each track, output ONLY a JSON object:
 {
-  "moods": [1-3 strings, each from this exact list: ${MOOD_VOCAB.join(', ')}],
+  "moods": [1-3 strings, each from this exact list: ${moodVocab().join(', ')}],
   "energy": "low" | "medium" | "high"
 }
 
@@ -32,8 +36,10 @@ A high-BPM dance track is "energetic" and "workout" — not "celebratory" unless
 A slow rainy-day instrumental is "calm" and "rainy" — not "evening" just because it's chill.
 
 If you genuinely cannot tell from the title/artist/album, return {"moods":[],"energy":"medium"}. Do not invent.`;
+}
 
-export const TAGGER_BATCH_SYSTEM = `You tag music tracks with mood and energy for a personal radio station.
+export function taggerBatchSystem(): string {
+  return `You tag music tracks with mood and energy for a personal radio station.
 
 You will be given a numbered list of tracks. Return ONLY a JSON object of the form:
 {
@@ -46,7 +52,7 @@ You will be given a numbered list of tracks. Return ONLY a JSON object of the fo
 The results array MUST have exactly one entry per input track, in the same order as the numbered list. Entry 1 in results corresponds to track 1, entry 2 to track 2, and so on.
 
 For each entry:
-- moods: 1-3 strings, each from this exact list: ${MOOD_VOCAB.join(', ')}
+- moods: 1-3 strings, each from this exact list: ${moodVocab().join(', ')}
 - energy: "low" | "medium" | "high"
 
 Choose moods that reflect how the track FEELS to listen to, not just its genre.
@@ -55,6 +61,7 @@ A high-BPM dance track is "energetic" and "workout" — not "celebratory" unless
 A slow rainy-day instrumental is "calm" and "rainy" — not "evening" just because it's chill.
 
 If you genuinely cannot tell from the title/artist/album for a track, return {"moods":[],"energy":"medium"} for that entry. Do not invent.`;
+}
 
 export interface TaggableSong {
   title?: string;
@@ -73,9 +80,10 @@ export interface TagResult {
 }
 
 function sanitizeTag(parsed: { moods?: unknown; energy?: unknown }): TagResult {
+  const vocab = moodVocab();
   const moods = Array.isArray(parsed.moods)
     ? (parsed.moods as unknown[])
-        .filter((m): m is string => typeof m === 'string' && MOOD_VOCAB.includes(m))
+        .filter((m): m is string => typeof m === 'string' && vocab.includes(m))
         .slice(0, 3)
     : [];
   const energy = ['low', 'medium', 'high'].includes(parsed.energy as string)
@@ -110,7 +118,7 @@ export async function tagOne(song: TaggableSong, opts: TagOpts = {}): Promise<Ta
     `Genre: ${songGenres(song).join(', ') || '?'}`;
 
   const parsed = await djObject({
-    system: TAGGER_SYSTEM,
+    system: taggerSystem(),
     prompt: userPrompt,
     schema: TagSchema,
     temperature: 0.2,
@@ -127,7 +135,7 @@ export async function tagBatch(songs: TaggableSong[], opts: TagOpts = {}): Promi
     `Tag these ${songs.length} tracks. Return one entry per track in the same order.\n\n${lines}`;
 
   const parsed = await djObject({
-    system: TAGGER_BATCH_SYSTEM,
+    system: taggerBatchSystem(),
     prompt: userPrompt,
     schema: BatchTagSchema,
     temperature: 0.2,

--- a/controller/src/routes/generate.ts
+++ b/controller/src/routes/generate.ts
@@ -65,7 +65,7 @@ router.post('/generate/show', requireAdmin, async (req, res) => {
     // form is multi-value (#929), so lift each field into a one-element list.
     // An unknown/missing mood becomes [] (Any — the autonomous mood applies)
     // rather than an arbitrary vocabulary entry the operator didn't ask for.
-    const moods = raw.mood && settings.SHOW_MOODS.includes(raw.mood) ? [raw.mood] : [];
+    const moods = raw.mood && settings.moodVocab().includes(raw.mood) ? [raw.mood] : [];
     const genreDraft = typeof raw.genre === 'string' ? raw.genre.trim() : '';
     const showGenres = genreDraft ? [genreDraft] : [];
     const energies = raw.energy && settings.SHOW_ENERGY.includes(raw.energy) ? [raw.energy] : [];

--- a/controller/src/routes/library.ts
+++ b/controller/src/routes/library.ts
@@ -15,7 +15,7 @@ import * as musicbrainz from '../music/musicbrainz.js';
 import * as settings from '../settings.js';
 import * as embeddings from '../music/embeddings.js';
 import { buildGenreSuggest } from '../music/genre-suggest.js';
-import { tagBatch, TAGGER_BATCH_SYSTEM } from '../music/tagger-core.js';
+import { tagBatch, taggerBatchSystem } from '../music/tagger-core.js';
 import { promptVocabHash } from '../music/embeddings.js';
 import { activeModelLabel } from '../llm/provider.js';
 import { queue } from '../broadcast/queue.js';
@@ -78,7 +78,7 @@ router.get('/library/browse', requireAdmin, async (req, res) => {
     const stats = library.stats();
     res.json({
       ...result,
-      moodVocab: settings.SHOW_MOODS,
+      moodVocab: settings.moodVocab(),
       stats: {
         total: stats.total,
         byMood: stats.byMood,
@@ -302,7 +302,7 @@ router.get('/library/observatory', requireAdmin, async (req, res) => {
       // Sound-map provenance — lets the UI say whether nodes sit by sound
       // (projection done) or by genre (fallback), and show job progress.
       mapProjection: mapProjection.projectionStatus(),
-      moodVocab: settings.SHOW_MOODS,
+      moodVocab: settings.moodVocab(),
       stats: {
         total: stats.total,
         distinctArtists: stats.distinctArtists,
@@ -718,7 +718,7 @@ router.post('/library/retag', requireAdmin, async (req, res) => {
       moods,
       energy,
       source: 'llm',
-      promptHash: promptVocabHash(TAGGER_BATCH_SYSTEM),
+      promptHash: promptVocabHash(taggerBatchSystem()),
       model: activeModelLabel(),
     });
     await library.save();
@@ -739,8 +739,9 @@ router.post('/library/retag', requireAdmin, async (req, res) => {
 // `applyToAlbum` resolves the whole album server-side from the track id
 // (subsonic.getSong → albumId → getAlbum) and applies the same tags to every
 // track — this is the "tag an album/folder for targeted queuing" path
-// (discussion #336). Moods are restricted to settings.SHOW_MOODS so manual
-// rows feed songsByMood()/MOOD_NEIGHBOURS exactly like LLM-tagged ones.
+// (discussion #336). Moods are restricted to the live vocabulary
+// (settings.moodVocab()) so manual rows feed songsByMood()/MOOD_NEIGHBOURS
+// exactly like LLM-tagged ones.
 // ---------------------------------------------------------------------------
 router.post('/library/manual-tag', requireAdmin, async (req, res) => {
   const id = req.body?.id;
@@ -750,7 +751,7 @@ router.post('/library/manual-tag', requireAdmin, async (req, res) => {
     return res.status(400).json({ error: 'moods must be an array of strings' });
   }
   if (moods.length > 3) return res.status(400).json({ error: 'at most 3 moods per track' });
-  const unknown = moods.filter((m: string) => !settings.SHOW_MOODS.includes(m));
+  const unknown = moods.filter((m: string) => !settings.moodVocab().includes(m));
   if (unknown.length) {
     return res.status(400).json({ error: `unknown mood(s): ${unknown.join(', ')}` });
   }

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -100,6 +100,11 @@ router.get('/settings', requireAdmin, async (req, res) => {
         locale: s.locale,
         theme: s.theme,
         festivals: s.festivals,
+        // Editable mood system (/admin/moods): the vocabulary + CLAP prompts,
+        // and the time/weather → mood maps.
+        moods: s.moods,
+        moodSchedule: s.moodSchedule,
+        weatherMoods: s.weatherMoods,
         weather: s.weather,
         djPrompt: s.djPrompt,
         djPrompts: s.djPrompts,
@@ -146,7 +151,9 @@ router.get('/settings', requireAdmin, async (req, res) => {
         pocketTtsCustomVoices: customVoices,
         cloudProviders: settings.TTS_CLOUD_PROVIDERS,
         frequencies: settings.FREQUENCIES,
-        moods: settings.SHOW_MOODS,
+        // The live mood NAMES, for the show/festival mood dropdowns. Now driven
+        // by the operator-editable vocabulary rather than the static default.
+        moods: settings.moodVocab(),
       },
       llm: {
         providers: settings.LLM_PROVIDERS,

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -3313,7 +3313,9 @@ function validateWebhooksStrict(raw: unknown, existing: Webhook[] = []) {
 // shape: whole-value replace, indexed throws, rebuilt objects strip unknown
 // keys). `moodNames` is the effective vocabulary being saved, so a schedule /
 // weather / festival entry may reference a mood added in the SAME patch. ---
-function validateMoodsStrict(raw: any): Array<{ name: string; clapPrompt: string }> {
+// Exported for unit tests (scripts/moods.test.ts) — the pure validation/guard
+// logic that keeps the mood system consistent on every save.
+export function validateMoodsStrict(raw: any): Array<{ name: string; clapPrompt: string }> {
   if (!Array.isArray(raw)) throw new Error('moods must be an array');
   if (raw.length < 1) throw new Error('moods must have at least one entry');
   if (raw.length > MOODS_LIMIT) throw new Error(`moods must be at most ${MOODS_LIMIT} entries`);
@@ -3333,7 +3335,7 @@ function validateMoodsStrict(raw: any): Array<{ name: string; clapPrompt: string
   });
 }
 
-function validateMoodScheduleStrict(raw: any, moodNames: string[]): Record<string, string> {
+export function validateMoodScheduleStrict(raw: any, moodNames: string[]): Record<string, string> {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
     throw new Error('moodSchedule must be an object');
   }
@@ -3349,7 +3351,7 @@ function validateMoodScheduleStrict(raw: any, moodNames: string[]): Record<strin
   return out;
 }
 
-function validateWeatherMoodsStrict(raw: any, moodNames: string[]): Record<string, string> {
+export function validateWeatherMoodsStrict(raw: any, moodNames: string[]): Record<string, string> {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
     throw new Error('weatherMoods must be an object');
   }
@@ -3369,7 +3371,7 @@ function validateWeatherMoodsStrict(raw: any, moodNames: string[]): Record<strin
 // festival calendar, either mood map, or a scheduled show. Renames are a
 // two-step (add the new name, repoint the referrers, remove the old) — this is
 // the guard that names exactly what still points at a removed mood.
-function assertNoOrphanMoods(next: any): void {
+export function assertNoOrphanMoods(next: any): void {
   const names = new Set<string>((next.moods || []).map((m: any) => m.name));
   const refs: string[] = [];
   for (const [period, mood] of Object.entries(next.moodSchedule || {})) {

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -585,30 +585,118 @@ export const TTS_CLOUD_PROVIDERS = ['openai', 'elevenlabs', 'openai-compatible']
 // meta-search via settings.search.baseUrl.
 export const SEARCH_PROVIDERS = ['duckduckgo', 'tavily', 'brave', 'searxng'] as const;
 
-// Canonical mood vocabulary. Shared by the library tagger (music/tag-library.js
-// imports this as MOOD_VOCAB) and the Shows scheduler — a show's `moods` (lead
-// entry) override the autonomous dominantMood, so every entry must come from
-// this list. An empty list means "Any": the show pins no mood and the
-// autonomous chain (festival > weather > time) applies while it's on air.
-export const SHOW_MOODS = [
-  'energetic',
-  'calm',
-  'reflective',
-  'celebratory',
-  'romantic',
-  'spiritual',
-  'focus',
-  'workout',
-  'driving',
-  'cooking',
-  'rainy',
-  'sunny',
-  'night',
-  'morning',
-  'evening',
-  'festival',
-  'cultural',
+// Canonical mood vocabulary + each mood's CLAP sound-prompt. This is the SEED:
+// the operator edits the live list from /admin/moods (settings.moods), and every
+// consumer reads it through the moodVocab()/moodEntries()/moodPromptFor()
+// accessors below — NOT this constant. `clapPrompt` is the zero-shot audio
+// sound-description (music/audio-moods.ts); '' falls back to `${name} music`.
+// A show's `moods` (lead entry) override the autonomous dominantMood; every
+// entry must come from the live vocabulary. Empty show moods means "Any".
+export const MOOD_DEFAULTS: Array<{ name: string; clapPrompt: string }> = [
+  { name: 'energetic', clapPrompt: 'high-energy, upbeat, powerful music with a strong driving beat' },
+  { name: 'calm', clapPrompt: 'calm, peaceful, soft, soothing, gentle music' },
+  { name: 'reflective', clapPrompt: 'reflective, introspective, melancholic, emotional music' },
+  { name: 'celebratory', clapPrompt: 'joyful, festive, celebratory party music' },
+  { name: 'romantic', clapPrompt: 'romantic, intimate, tender, loving music' },
+  { name: 'spiritual', clapPrompt: 'spiritual, devotional, sacred, meditative music' },
+  { name: 'focus', clapPrompt: 'minimal, unobtrusive, ambient instrumental background music for concentration' },
+  { name: 'workout', clapPrompt: 'intense, pounding, adrenaline-pumping workout music' },
+  { name: 'driving', clapPrompt: 'steady, groovy, mid-tempo cruising music for a road trip' },
+  { name: 'cooking', clapPrompt: 'light, cheerful, breezy, feel-good easy-listening music' },
+  { name: 'rainy', clapPrompt: 'mellow, wistful, cozy music for a rainy day' },
+  { name: 'sunny', clapPrompt: 'bright, warm, sunny, feel-good summer music' },
+  { name: 'night', clapPrompt: 'dark, atmospheric, moody late-night music' },
+  { name: 'morning', clapPrompt: 'fresh, gentle, optimistic early-morning music' },
+  { name: 'evening', clapPrompt: 'smooth, warm, relaxed evening music' },
+  { name: 'festival', clapPrompt: 'big, anthemic, euphoric festival crowd music' },
+  { name: 'cultural', clapPrompt: 'traditional folk music with regional acoustic instruments' },
 ];
+
+// Back-compat: the default mood NAMES. Kept for the community catalog (shared
+// configs validate against the canonical set, not a local custom vocab) and as
+// the accessor fallback before load(). Live reads go through moodVocab().
+export const SHOW_MOODS = MOOD_DEFAULTS.map((m) => m.name);
+
+// The 8 fixed day-periods (context.ts getTimeContext) and their seed moods.
+// Operators re-point each period's mood from /admin/moods (settings.moodSchedule);
+// the hour ranges + vibe/show labels stay in code.
+export const MOOD_PERIODS = [
+  'early-morning', 'morning', 'midday', 'afternoon',
+  'drive-time', 'evening', 'late-evening', 'after-hours',
+] as const;
+export const PERIOD_MOOD_DEFAULTS: Record<string, string> = {
+  'early-morning': 'morning',
+  morning: 'morning',
+  midday: 'energetic',
+  afternoon: 'focus',
+  'drive-time': 'driving',
+  evening: 'evening',
+  'late-evening': 'night',
+  'after-hours': 'reflective',
+};
+
+// The 6 fixed weather conditions (context.ts mapWeatherCode) and their seed
+// moods. '' = no mood steer for that condition. Editable via settings.weatherMoods.
+export const WEATHER_CONDITIONS = [
+  'clear', 'cloudy', 'foggy', 'rainy', 'snowy', 'stormy',
+] as const;
+export const WEATHER_MOOD_DEFAULTS: Record<string, string> = {
+  clear: 'sunny',
+  cloudy: '',
+  foggy: 'rainy',
+  rainy: 'rainy',
+  snowy: 'reflective',
+  stormy: 'rainy',
+};
+
+// --- Mood vocabulary validation (the seeded-but-editable pattern) ---
+export const MOODS_LIMIT = 40;
+const MOOD_NAME_MAX = 40;
+const MOOD_PROMPT_MAX = 200;
+
+// Normalise a raw mood name to the canonical id form (lowercase, [a-z0-9-]).
+function normalizeMoodName(raw: unknown): string {
+  return String(raw ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+// Lenient on-load pass: never throws, drops malformed/duplicate entries so a
+// hand-edited settings.json can't wedge boot. Empty → the seed defaults (an
+// empty vocabulary is unusable — shows, festivals, and the tagger all need it).
+function normalizeMoods(raw: any): Array<{ name: string; clapPrompt: string }> {
+  if (!Array.isArray(raw)) return MOOD_DEFAULTS;
+  const out: Array<{ name: string; clapPrompt: string }> = [];
+  const seen = new Set<string>();
+  for (const item of raw) {
+    if (out.length >= MOODS_LIMIT) break;
+    if (!item || typeof item !== 'object') continue;
+    const name = normalizeMoodName(item.name);
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    const clapPrompt = typeof item.clapPrompt === 'string'
+      ? item.clapPrompt.trim().slice(0, MOOD_PROMPT_MAX)
+      : '';
+    out.push({ name, clapPrompt });
+  }
+  return out.length ? out : MOOD_DEFAULTS;
+}
+
+// Lenient on-load pass for the fixed-key mood maps: fills every known key from
+// the stored value when it's a string, else from the seed default.
+function normalizeMoodMap(
+  raw: any,
+  keys: readonly string[],
+  defaults: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const k of keys) {
+    out[k] = typeof raw?.[k] === 'string' ? raw[k] : defaults[k];
+  }
+  return out;
+}
 
 // Energy bands a show can pin as a soft music-steering filter. Mirrors the
 // tagger's per-track energy classes and the `tracksByMood` agent-tool filter.
@@ -874,8 +962,13 @@ function coerceShowList<T>(
 }
 
 function coerceShowMoods(item: unknown): string[] {
+  // Lenient on load: keep any non-empty string (moods are now operator-editable,
+  // so the effective vocabulary isn't known while the cache is still being
+  // built — filtering against the seed defaults here would strip an operator's
+  // custom moods). update()'s validateShowsStrict enforces the live vocabulary
+  // on save; a stale mood string just matches nothing at runtime.
   return coerceShowList(item, 'moods', 'mood',
-    (v) => (typeof v === 'string' && SHOW_MOODS.includes(v) ? v : null),
+    (v) => (typeof v === 'string' && v.trim() ? v.trim() : null),
     (v) => v);
 }
 
@@ -1234,6 +1327,14 @@ const DEFAULTS = {
   // so operators can add/edit/remove entries from the admin UI. Fall back to
   // FESTIVAL_DEFAULTS when empty/absent.
   festivals: FESTIVAL_DEFAULTS,
+  // Operator-editable mood system (/admin/moods). `moods` is the vocabulary +
+  // per-mood CLAP prompt; `moodSchedule` maps each fixed day-period to a mood;
+  // `weatherMoods` maps each fixed weather condition to a mood ('' = no steer).
+  // All read live via the moodVocab()/moodScheduleFor()/weatherMoodFor()
+  // accessors. Seeded here; the operator's edits replace them.
+  moods: MOOD_DEFAULTS,
+  moodSchedule: PERIOD_MOOD_DEFAULTS,
+  weatherMoods: WEATHER_MOOD_DEFAULTS,
   // Listener-player UI toggles — purely presentational, station-wide. The web
   // player reads these via GET /state (alongside the theme) and applies them
   // live; no restart. `boothBuddy` gates the DJ-line mascot — OFF by default,
@@ -2193,6 +2294,12 @@ export async function load() {
     // when the key is absent/invalid — a persisted empty array means the
     // operator deleted every entry and must stay empty (calendar off).
     festivals: Array.isArray(stored.festivals) ? stored.festivals : FESTIVAL_DEFAULTS,
+    // Mood system loaded from settings.json (lenient normalise — never wedges
+    // boot). An empty/absent vocabulary reseeds MOOD_DEFAULTS (unusable when
+    // empty); the two maps fill missing keys from their seed defaults.
+    moods: normalizeMoods(stored.moods),
+    moodSchedule: normalizeMoodMap(stored.moodSchedule, MOOD_PERIODS, PERIOD_MOOD_DEFAULTS),
+    weatherMoods: normalizeMoodMap(stored.weatherMoods, WEATHER_CONDITIONS, WEATHER_MOOD_DEFAULTS),
     ui: {
       boothBuddy:
         typeof stored.ui?.boothBuddy === 'boolean'
@@ -2624,6 +2731,30 @@ export function getDefaults() {
   return DEFAULTS;
 }
 
+// --- Live mood accessors — the single seam every consumer reads through, so an
+// operator edit takes effect with no restart. Pre-load, get() returns DEFAULTS,
+// so these still answer with the seed vocabulary (keeps the standalone
+// audio-moods unit test working without a settings.load()). ---
+export function moodEntries(): Array<{ name: string; clapPrompt: string }> {
+  const m = get().moods;
+  return Array.isArray(m) && m.length ? m : MOOD_DEFAULTS;
+}
+export function moodVocab(): string[] {
+  return moodEntries().map((m) => m.name);
+}
+export function moodPromptFor(name: string): string {
+  const e = moodEntries().find((m) => m.name === name);
+  return e?.clapPrompt ? e.clapPrompt : `${name} music`;
+}
+export function moodScheduleFor(period: string): string {
+  const s = get().moodSchedule || {};
+  return s[period] ?? PERIOD_MOOD_DEFAULTS[period] ?? '';
+}
+export function weatherMoodFor(condition: string): string {
+  const w = get().weatherMoods || {};
+  return (w[condition] ?? WEATHER_MOOD_DEFAULTS[condition] ?? '') || '';
+}
+
 // Resolve the operator-entered inline API key for a provider from the
 // per-provider map (issue #657). Returns '' when none is stored, in which case
 // the registry/embedding layer falls through to the provider's env var
@@ -2882,7 +3013,7 @@ export function validatePersonasStrict(raw) {
   });
 }
 
-function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
+function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>, moodNames: string[] = SHOW_MOODS) {
   if (!Array.isArray(raw)) throw new Error('shows must be an array');
   if (raw.length > SHOWS_LIMIT) throw new Error(`shows must be at most ${SHOWS_LIMIT} entries`);
   const personaIds = personas.map(p => p.id);
@@ -2908,8 +3039,8 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>) {
       throw new Error(`shows[${i}].moods must have at most ${SHOW_FILTER_VALUES_MAX} entries`);
     }
     for (const m of rawMoods) {
-      if (typeof m !== 'string' || !SHOW_MOODS.includes(m)) {
-        throw new Error(`shows[${i}].moods entries must be one of: ${SHOW_MOODS.join(', ')}`);
+      if (typeof m !== 'string' || !moodNames.includes(m)) {
+        throw new Error(`shows[${i}].moods entries must be one of: ${moodNames.join(', ')}`);
       }
     }
     const moods = coerceShowMoods({ moods: rawMoods });
@@ -3178,9 +3309,92 @@ function validateWebhooksStrict(raw: unknown, existing: Webhook[] = []) {
   });
 }
 
+// --- Strict update() validators for the mood system (the validateFestivalsStrict
+// shape: whole-value replace, indexed throws, rebuilt objects strip unknown
+// keys). `moodNames` is the effective vocabulary being saved, so a schedule /
+// weather / festival entry may reference a mood added in the SAME patch. ---
+function validateMoodsStrict(raw: any): Array<{ name: string; clapPrompt: string }> {
+  if (!Array.isArray(raw)) throw new Error('moods must be an array');
+  if (raw.length < 1) throw new Error('moods must have at least one entry');
+  if (raw.length > MOODS_LIMIT) throw new Error(`moods must be at most ${MOODS_LIMIT} entries`);
+  const seen = new Set<string>();
+  return raw.map((item, i) => {
+    if (!item || typeof item !== 'object') throw new Error(`moods[${i}] must be an object`);
+    const name = normalizeMoodName(item.name);
+    if (name.length < 1 || name.length > MOOD_NAME_MAX) {
+      throw new Error(`moods[${i}].name must be 1-${MOOD_NAME_MAX} chars (letters, digits, dashes)`);
+    }
+    if (seen.has(name)) throw new Error(`moods[${i}].name "${name}" is a duplicate`);
+    seen.add(name);
+    const clapPrompt = typeof item.clapPrompt === 'string'
+      ? item.clapPrompt.trim().slice(0, MOOD_PROMPT_MAX)
+      : '';
+    return { name, clapPrompt };
+  });
+}
+
+function validateMoodScheduleStrict(raw: any, moodNames: string[]): Record<string, string> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('moodSchedule must be an object');
+  }
+  const names = new Set(moodNames);
+  const out: Record<string, string> = {};
+  for (const period of MOOD_PERIODS) {
+    const v = String(raw[period] ?? '').trim();
+    if (!names.has(v)) {
+      throw new Error(`moodSchedule.${period} must be one of: ${moodNames.join(', ')}`);
+    }
+    out[period] = v;
+  }
+  return out;
+}
+
+function validateWeatherMoodsStrict(raw: any, moodNames: string[]): Record<string, string> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('weatherMoods must be an object');
+  }
+  const names = new Set(moodNames);
+  const out: Record<string, string> = {};
+  for (const cond of WEATHER_CONDITIONS) {
+    const v = String(raw[cond] ?? '').trim();
+    if (v && !names.has(v)) {
+      throw new Error(`weatherMoods.${cond} must be a mood (${moodNames.join(', ')}) or empty`);
+    }
+    out[cond] = v;
+  }
+  return out;
+}
+
+// Reject a vocabulary edit that would orphan a mood still referenced by the
+// festival calendar, either mood map, or a scheduled show. Renames are a
+// two-step (add the new name, repoint the referrers, remove the old) — this is
+// the guard that names exactly what still points at a removed mood.
+function assertNoOrphanMoods(next: any): void {
+  const names = new Set<string>((next.moods || []).map((m: any) => m.name));
+  const refs: string[] = [];
+  for (const [period, mood] of Object.entries(next.moodSchedule || {})) {
+    if (mood && !names.has(mood as string)) refs.push(`the ${period} time-of-day slot`);
+  }
+  for (const [cond, mood] of Object.entries(next.weatherMoods || {})) {
+    if (mood && !names.has(mood as string)) refs.push(`the ${cond} weather slot`);
+  }
+  for (const f of next.festivals || []) {
+    if (f.mood && !names.has(f.mood)) refs.push(`festival "${f.name}"`);
+  }
+  for (const s of next.shows || []) {
+    for (const m of s.moods || []) {
+      if (!names.has(m)) refs.push(`show "${s.name}"`);
+    }
+  }
+  if (refs.length) {
+    const uniq = [...new Set(refs)];
+    throw new Error(`can't remove that mood — still used by ${uniq.join(', ')}. Reassign those first.`);
+  }
+}
+
 const FESTIVALS_LIMIT = 50;
 
-function validateFestivalsStrict(raw) {
+function validateFestivalsStrict(raw, moodNames: string[] = SHOW_MOODS) {
   if (!Array.isArray(raw)) throw new Error('festivals must be an array');
   if (raw.length > FESTIVALS_LIMIT) {
     throw new Error(`festivals must be at most ${FESTIVALS_LIMIT} entries`);
@@ -3201,8 +3415,8 @@ function validateFestivalsStrict(raw) {
       throw new Error(`festivals[${i}].day must be an integer 1-${daysInMonth} for month ${month}`);
     }
     const mood = String(item.mood ?? '').trim();
-    if (!SHOW_MOODS.includes(mood)) {
-      throw new Error(`festivals[${i}].mood must be one of: ${SHOW_MOODS.join(', ')}`);
+    if (!moodNames.includes(mood)) {
+      throw new Error(`festivals[${i}].mood must be one of: ${moodNames.join(', ')}`);
     }
     const description = typeof item.description === 'string' ? item.description.trim().slice(0, 200) : '';
     const windowDays = Number(item.windowDays ?? 0);
@@ -3503,8 +3717,22 @@ export async function update(patch) {
       next.theme.active = v;
     }
   }
+  // Mood system (context-only — no Liquidsoap restart). Validate the vocabulary
+  // first so the maps + festivals in the same patch can reference a newly-added
+  // mood. The in-use removal guard (assertNoOrphanMoods) runs after shows are
+  // validated below, so a same-patch show edit is seen.
+  if ('moods' in patch) {
+    next.moods = validateMoodsStrict(patch.moods);
+  }
+  const moodNames = (next.moods || []).map((m: any) => m.name);
+  if ('moodSchedule' in patch) {
+    next.moodSchedule = validateMoodScheduleStrict(patch.moodSchedule, moodNames);
+  }
+  if ('weatherMoods' in patch) {
+    next.weatherMoods = validateWeatherMoodsStrict(patch.weatherMoods, moodNames);
+  }
   if ('festivals' in patch) {
-    next.festivals = validateFestivalsStrict(patch.festivals);
+    next.festivals = validateFestivalsStrict(patch.festivals, moodNames);
   }
   // Prompt-template library. `djPrompts` replaces the whole library;
   // `activeDjPromptId` switches which entry renders ('' = built-in default).
@@ -3565,13 +3793,19 @@ export async function update(patch) {
     // listThemes() returns built-ins + cached user themes (30 s TTL) — same
     // source the picker reads.
     const allowedThemeIds = new Set((await listThemes()).map(t => t.id));
-    next.shows = validateShowsStrict(patch.shows, next.personas, allowedThemeIds);
+    next.shows = validateShowsStrict(patch.shows, next.personas, allowedThemeIds, moodNames);
   }
   if ('schedule' in patch) {
     next.schedule = validateScheduleStrict(patch.schedule, next.shows);
   }
   if ('scheduleOverride' in patch) {
     next.scheduleOverride = validateScheduleOverrideStrict(patch.scheduleOverride, next.shows);
+  }
+  // In-use removal guard: run once the vocabulary AND any same-patch shows are
+  // validated, so a mood dropped from the vocab is rejected only if something
+  // still references it.
+  if ('moods' in patch) {
+    assertNoOrphanMoods(next);
   }
   if ('activePersonaId' in patch) {
     if (!next.personas.some(p => p.id === patch.activePersonaId)) {

--- a/docs/superpowers/specs/2026-07-23-editable-moods-design.md
+++ b/docs/superpowers/specs/2026-07-23-editable-moods-design.md
@@ -2,7 +2,9 @@
 
 **Date:** 2026-07-23
 **Status:** Draft for review
-**Scope:** Make SUB/WAVE's mood system operator-editable from admin settings, in one combined tab alongside Festivals. Genres are already dynamic (pulled live from Navidrome) — no change there.
+**Scope:** Make SUB/WAVE's mood system operator-editable, and give it (plus the festival calendar and the TTS speech-corrections dictionary) a **brand-new top-level admin page** in the sidebar — pulling all three out of Settings. Genres are already dynamic (pulled live from Navidrome) — no change there.
+
+> **Page name — open decision.** The page anchors on **Moods** but also holds Festivals and Speech corrections. Proposed sidebar label: **"Moods"** (route `/admin/moods`), matching how we've been referring to it. Since it now also owns the festival calendar and the pronunciation dictionary, a broader label ("DJ", "Programming", "Voice") may read better — it's a one-line change in `NAV_SECTIONS`. Flagging for the review pass.
 
 ---
 
@@ -17,7 +19,7 @@ Make all four editable in the admin UI:
 3. **The time-of-day → mood map** — which mood each of the 8 fixed day-periods leans toward.
 4. **The weather → mood map** — which mood each of the 6 fixed weather conditions leans toward.
 
-All of this lives in **one admin tab, merged with the existing Festivals editor** (festivals already reference a mood, so the vocabulary and the festival calendar belong together).
+All of this lives on **one new admin page** in the sidebar, which also absorbs the existing **Festivals** editor (festivals reference a mood, so the vocabulary and the calendar belong together) and the **Speech corrections** editor currently buried in the TTS voice tab. All three move *out* of Settings.
 
 ---
 
@@ -112,18 +114,33 @@ Seeded from `WEATHER_MOOD_DEFAULTS`: `clear→sunny, cloudy→'', foggy→rainy,
 
 ---
 
-## 5. Web UI — one combined "Moods" tab
+## 5. Web UI — a new `/admin/moods` page
 
-Extend the existing self-contained `web/components/admin/FestivalsSection.tsx` into a combined panel (renamed to `MoodsSection.tsx`), and relabel the registry entry. The panel stacks four cards:
+A brand-new top-level admin page, patterned on how existing self-contained pages (e.g. `/admin/debug`) are wired. Three tiny additions, no `SettingsPanel` involvement:
 
-1. **Vocabulary** — a table of `{ name, CLAP prompt }` rows with add / edit / remove (modal editor like the festival row modal). A one-line note: *"Changing moods or their sound descriptions re-scores audio moods on the next analysis pass and marks LLM tags stale — re-run the tagger to refresh."*
-2. **Time of day → mood** — 8 fixed period rows (labelled with their hour ranges), each a mood `<Select>` populated from the current vocabulary.
-3. **Weather → mood** — 6 fixed condition rows, each a mood `<Select>` plus a "— none —" option.
-4. **Festival calendar** — the existing festivals editor, unchanged, its mood dropdown now fed by the same live vocabulary.
+- **Route:** `web/app/admin/moods/page.tsx` — a thin server component mirroring `web/app/admin/debug/page.tsx` (`metadata.title = 'Moods'`, renders `<MoodsPanel />`). The admin layout (`app/admin/layout.tsx`) already wraps every child in `AdminShell`, so the auth gate applies automatically.
+- **Sidebar entry:** one `NavItem` added to `NAV_SECTIONS` in `web/components/admin/AdminShell.tsx` (the "System" group, ~line 79, alongside Settings/Debug): `{ href: '/admin/moods', id: 'moods', label: 'Moods', icon: Palette }`, plus the icon added to the `lucide-react` import. Rendering + breadcrumb pick it up with no further change.
+- **Panel:** `web/components/admin/MoodsPanel.tsx` — `'use client'`, self-contained (calls `useAdminAuth()` for its own `adminFetch`, like `FestivalsSection`). It fetches `/settings` once and stacks five cards:
 
-Registration in `SettingsPanel.tsx` (3 points, per the established pattern): import, one `SECTIONS` entry relabelled **`{ id: 'festivals', label: 'Moods', hint: 'moods · calendar · weather', icon: Palette }`** (keep `id: 'festivals'` so existing `?section=festivals` deep-links still resolve; swap the `CalendarDays` icon for a mood-appropriate one such as `Palette`), and the self-contained render line `{activeSection === 'festivals' && <MoodsSection />}`.
+  1. **Vocabulary** — a table of `{ name, CLAP prompt }` rows with add / edit / remove. A one-line note: *"Changing moods or their sound descriptions re-scores audio moods on the next analysis pass and marks LLM tags stale — re-run the tagger to refresh."* Saves `{ moods: [...] }`.
+  2. **Time of day → mood** — 8 fixed period rows (labelled with their hour ranges), each a mood `<Select>` from the current vocabulary. Saves `{ moodSchedule: {...} }`.
+  3. **Weather → mood** — 6 fixed condition rows, each a mood `<Select>` plus a "— none —" option. Saves `{ weatherMoods: {...} }`.
+  4. **Festival calendar** — the existing `FestivalsSection` **composed as-is** (it already self-fetches/saves via `adminFetch` and reads the live vocabulary for its mood dropdown). No rewrite; just render `<FestivalsSection />` as a card on this page.
+  5. **Speech corrections** — the pronunciation dictionary relocated from the TTS tab (see §5.1). Saves `{ tts: { corrections: [...] } }` (partial `tts` patch; the controller merges it).
 
-Saving keeps the Festivals convention: whole-array/object replace POSTed to `/settings`; each card saves its own slice. Client-side validation stays light (server is authoritative): non-empty unique names, values drawn from the current vocabulary.
+Saving keeps the Festivals convention: whole-array/object replace POSTed to `/settings`; each card saves its own slice. Client-side validation stays light (server is authoritative): non-empty unique mood names, map values drawn from the current vocabulary.
+
+### 5.1 Moving Speech corrections out of the TTS tab
+
+The setting (`settings.tts.corrections`), its `validateTtsCorrectionsStrict`, its on-load normalise, and its runtime consumption (`audio/speech-text.ts` applied by `audio/tts.ts` reading `settings.get().tts.corrections`) are **all UI-location-agnostic — no controller change**. This is a pure front-end relocation:
+
+- **Cut** from `web/components/admin/settings/TtsSection.tsx`: the `<Card title="Speech corrections">` block (`TtsSection.tsx:1106-1186`), the `correctionsDirty` computation (`:504-512`) and its term in `ttsDirty` (`:531`), and the `corrections:` key in TtsSection's `save()` payload (`:422-424`).
+- **Rebuild** in `MoodsPanel` as the fifth card, reading/writing its own `corrections` `useState` seeded from the panel's `/settings` fetch, POSTing `{ tts: { corrections } }` (rows with an empty `from` dropped as drafts, matching current behaviour).
+
+### 5.2 Removing the old Festivals section from Settings
+
+- Remove the `festivals` entry from the `SECTIONS` registry in `SettingsPanel.tsx` (~line 41) and its self-contained render line (~line 607). `FestivalsSection.tsx` itself is **kept** (now imported by `MoodsPanel` instead).
+- Existing deep-links to `/admin/settings?section=festivals` no longer resolve to a section; `SettingsPanel`'s `?section=` validator falls back to its default section (soft, no 404). Optional nicety: a `web/app/admin/archives`-style redirect isn't possible for a query-param section, so we accept the soft fallback (or add a small note in release copy).
 
 No other web change needed — the first audit found only cosmetic mock data in `observatory/data.ts` (an empty-library preview), which stays as-is.
 
@@ -148,8 +165,11 @@ No other web change needed — the first audit found only cosmetic mock data in 
 
 ## 8. Files touched (summary)
 
-**Controller:** `settings.ts` (constants, accessors, seeding, 3 validators, update branches), `context.ts` (2 maps → settings reads), `music/audio-moods.ts`, `music/embeddings.ts`, `music/tagger-core.ts`, `music/seed-selector.ts`, `llm/internal/prompts/generate.ts`, `routes/settings.ts`, `routes/library.ts`. Tests under `controller/scripts/`.
+**Controller (moods only — speech corrections needs none):** `settings.ts` (constants, accessors, seeding, 3 validators, update branches), `context.ts` (2 maps → settings reads), `music/audio-moods.ts`, `music/embeddings.ts`, `music/tagger-core.ts`, `music/seed-selector.ts`, `llm/internal/prompts/generate.ts`, `routes/settings.ts` (expose 3 new keys in GET; `moods:` export → `moodVocab()`), `routes/library.ts`. Tests under `controller/scripts/`.
 
-**Web:** `components/admin/FestivalsSection.tsx` → `MoodsSection.tsx` (extended), `components/admin/SettingsPanel.tsx` (registry relabel).
+**Web:**
+- **New:** `app/admin/moods/page.tsx`, `components/admin/MoodsPanel.tsx`.
+- **Edited:** `components/admin/AdminShell.tsx` (one `NavItem` + icon import), `components/admin/settings/TtsSection.tsx` (cut the Speech-corrections card + its dirty-check/save-key), `components/admin/SettingsPanel.tsx` (drop the `festivals` section entry + render line).
+- **Reused unchanged:** `components/admin/FestivalsSection.tsx` (now composed by `MoodsPanel`).
 
-**No change:** genres (already dynamic), `SHOW_ENERGY`, Liquidsoap / compose / `.env`, native app.
+**No change:** genres (already dynamic), `SHOW_ENERGY`, the speech-corrections setting/validator/runtime (`settings.tts.corrections`, `audio/speech-text.ts`, `audio/tts.ts`), Liquidsoap / compose / `.env`, native app.

--- a/docs/superpowers/specs/2026-07-23-editable-moods-design.md
+++ b/docs/superpowers/specs/2026-07-23-editable-moods-design.md
@@ -173,3 +173,12 @@ No other web change needed — the first audit found only cosmetic mock data in 
 - **Reused unchanged:** `components/admin/FestivalsSection.tsx` (now composed by `MoodsPanel`).
 
 **No change:** genres (already dynamic), `SHOW_ENERGY`, the speech-corrections setting/validator/runtime (`settings.tts.corrections`, `audio/speech-text.ts`, `audio/tts.ts`), Liquidsoap / compose / `.env`, native app.
+
+---
+
+## 9. Implementation notes (as built)
+
+- **Accessor seam:** every consumer now reads `settings.moodVocab()` / `moodEntries()` / `moodPromptFor()` / `moodScheduleFor()` / `weatherMoodFor()`. `SHOW_MOODS` survives as `MOOD_DEFAULTS.map(m => m.name)` for two legitimate default-vocab uses. New accessor test at `controller/scripts/moods.test.ts`; the existing `audio-moods.test.ts` (moodPrompt/moodVocabHash) still passes because `get()` returns `DEFAULTS` pre-load.
+- **`community/registry.ts` intentionally stays on `SHOW_MOODS`** (the default names): a *shared/imported* station config validates against the canonical set, not the local operator's custom vocabulary — coupling it to a local edit would drop moods on import.
+- **Known follow-up — `web/components/admin/PlaylistBuilderPanel.tsx`** hardcodes the mood list (its `MOODS` const). Custom moods work everywhere else (tagging, shows, festivals, autonomous DJ, the Library editor which reads the vocab from the API), but won't appear in the Playlist Builder's mood picker until that panel is pointed at the API vocab. Deferred to keep this PR focused; noted in the PR body.
+- **In-use removal:** enforced server-side by `assertNoOrphanMoods(next)` in `settings.update()` (rejects with the referrer named). Internal, matching the untested-by-convention `validateFestivalsStrict` shape.

--- a/docs/superpowers/specs/2026-07-23-editable-moods-design.md
+++ b/docs/superpowers/specs/2026-07-23-editable-moods-design.md
@@ -1,0 +1,155 @@
+# Editable Moods — Design
+
+**Date:** 2026-07-23
+**Status:** Draft for review
+**Scope:** Make SUB/WAVE's mood system operator-editable from admin settings, in one combined tab alongside Festivals. Genres are already dynamic (pulled live from Navidrome) — no change there.
+
+---
+
+## 1. Goal
+
+Today the mood system is hardcoded in source. `SHOW_MOODS` (17 entries, `controller/src/settings.ts:593`) is the single vocabulary, and three hardcoded maps derive an autonomous mood: the CLAP sound-prompt per mood (`MOOD_PROMPTS`, `music/audio-moods.ts:30`), the time-of-day → mood table (`context.ts:12`), and the weather → mood table (`context.ts:112`).
+
+Make all four editable in the admin UI:
+
+1. **The mood vocabulary** — add / remove / rename any mood (no protected built-ins), each with its CLAP sound-prompt.
+2. **The CLAP prompt per mood** — the sound description used for zero-shot audio tagging.
+3. **The time-of-day → mood map** — which mood each of the 8 fixed day-periods leans toward.
+4. **The weather → mood map** — which mood each of the 6 fixed weather conditions leans toward.
+
+All of this lives in **one admin tab, merged with the existing Festivals editor** (festivals already reference a mood, so the vocabulary and the festival calendar belong together).
+
+---
+
+## 2. Design principles / constraints
+
+- **Mirror the Festivals "seeded-but-editable" pattern exactly** — it's the established convention for an operator-editable list: a `*_DEFAULTS` constant, an `Array.isArray(stored.x) ? stored.x : DEFAULTS` seed guard in `load()`, a `validate*Strict()` that rebuilds and strips unknown keys, a `if ('x' in patch)` branch in `update()`, whole-object persistence, no Liquidsoap restart (mood selection is controller-side only, read live per context build).
+- **Self-healing derived data.** Two hashes already fold the vocabulary + prompts into their cache keys: `moodVocabHash()` (audio moods, `audio-moods.ts`) and `promptVocabHash()` (LLM tags, `embeddings.ts:488`). Routing them through the settings-backed vocabulary means an edit auto-invalidates stale tags — audio moods re-score on the next analysis pass; LLM tags re-tag on the next `npm run tag --upgrade`. We reuse this machinery rather than build new invalidation.
+- **Move static bindings to call-time reads.** Several consumers bind the vocabulary at module load (a Zod enum, tagger system-prompt strings, a `Set`). Those become call-time reads of a new settings accessor so edits take effect without a process restart.
+- **YAGNI:** energy bands (`SHOW_ENERGY`) stay hardcoded — out of scope. No per-mood colour/icon metadata. No rename-with-cascade UI (see §6).
+
+---
+
+## 3. Data model (settings.json)
+
+Three new top-level settings keys, all seeded-but-editable.
+
+### 3.1 `settings.moods` — the vocabulary
+
+```ts
+// One entry per mood. `name` is the id used everywhere (shows, festivals,
+// tagger, maps). `clapPrompt` is the audio sound-description; empty falls back
+// to `${name} music` (the existing moodPrompt fallback).
+type MoodEntry = { name: string; clapPrompt: string };
+settings.moods: MoodEntry[]
+```
+
+Seeded from a new `MOOD_DEFAULTS` constant that merges the current `SHOW_MOODS` names with their `MOOD_PROMPTS` descriptions (moods with no prompt today — `festival`, `cultural`, etc. — seed with `clapPrompt: ''` and use the fallback).
+
+**Empty is invalid** (unlike festivals, where empty = calendar off). The vocabulary must have ≥1 entry, because shows, festivals, the tagger, and the maps all draw from it. Validation enforces `1 ≤ length ≤ 40`.
+
+### 3.2 `settings.moodSchedule` — time-of-day → mood
+
+```ts
+// Keyed by the 8 fixed period ids from context.ts getTimeContext.
+// Only the mood is editable; hour-ranges, `vibe`, and `show` names stay in code
+// (they feed spoken-segment prompts and show resolution — out of scope).
+type Period = 'early-morning'|'morning'|'midday'|'afternoon'|'drive-time'|'evening'|'late-evening'|'after-hours';
+settings.moodSchedule: Record<Period, string>  // value ∈ mood names
+```
+
+Seeded from `PERIOD_MOOD_DEFAULTS` (the current mapping): `early-morning→morning, morning→morning, midday→energetic, afternoon→focus, drive-time→driving, evening→evening, late-evening→night, after-hours→reflective`.
+
+### 3.3 `settings.weatherMoods` — weather → mood
+
+```ts
+// Keyed by the 6 fixed condition ids from context.ts mapWeatherCode.
+// '' means "no mood steer for this condition" (today's `default: null`).
+type Condition = 'clear'|'cloudy'|'foggy'|'rainy'|'snowy'|'stormy';
+settings.weatherMoods: Record<Condition, string>  // value ∈ mood names OR ''
+```
+
+Seeded from `WEATHER_MOOD_DEFAULTS`: `clear→sunny, cloudy→'', foggy→rainy, rainy→rainy, snowy→reflective, stormy→rainy`.
+
+---
+
+## 4. Server changes
+
+### 4.1 `settings.ts`
+
+- **Constants:** add `MOOD_DEFAULTS`, `PERIOD_MOOD_DEFAULTS`, `WEATHER_MOOD_DEFAULTS` beside `FESTIVAL_DEFAULTS` (~line 619). Register the three keys on `DEFAULTS` (~line 1236).
+- **Keep `SHOW_MOODS`** as a derived export `= MOOD_DEFAULTS.map(m => m.name)` for any code that still wants the compile-time default names (and to avoid churn in tests). It is no longer the live source of truth.
+- **New accessors (the migration seam):**
+  - `moodVocab(): string[]` — current mood names from `getSettings().moods`.
+  - `moodEntries(): MoodEntry[]` — full entries (for prompts + hashing).
+  - `moodPromptFor(name): string` — the clapPrompt or `${name} music` fallback.
+  - `moodScheduleFor(period): string` and `weatherMoodFor(condition): string` — map reads with default fallback.
+- **Seeding in `load()`** (~line 2195): three `Array.isArray(stored.x) ? stored.x : X_DEFAULTS` guards. For `moods`, additionally fall back to `MOOD_DEFAULTS` when the stored array is empty (empty vocab is unusable).
+- **Validation:** `validateMoodsStrict`, `validateMoodScheduleStrict`, `validateWeatherMoodsStrict` modelled on `validateFestivalsStrict` (`settings.ts:3181`). Rules:
+  - moods: 1–40 entries; each `name` 1–40 chars, lowercased + trimmed, `[a-z0-9-]` normalised, **unique**; `clapPrompt` optional string ≤200 chars. Rebuild each object (strip unknown keys).
+  - moodSchedule: exactly the 8 known period keys; each value ∈ the vocabulary being saved.
+  - weatherMoods: exactly the 6 known condition keys; each value ∈ vocabulary **or** `''`.
+- **`update()` branches** (~line 3506): `if ('moods' in patch)`, `if ('moodSchedule' in patch)`, `if ('weatherMoods' in patch)`. **No `restart = true`** (context-only). **Cross-validation across the merged `next` state** (see §6): reject removing a mood still referenced by a festival, a show, a schedule slot, or a weather slot, naming the referrer.
+- **Existing `SHOW_MOODS.includes(...)` checks** at `settings.ts:878, 2911, 3204` → `moodVocab().includes(...)` (all inside functions — safe).
+
+### 4.2 Consumers: static → call-time
+
+| File | Now (static, module-load) | After |
+|---|---|---|
+| `music/audio-moods.ts:30` | `MOOD_PROMPTS` const, `moodPrompt`, `moodVocabHash`, `scoreAudioMoods` iterate `SHOW_MOODS` | read `settings.moodEntries()` / `moodPromptFor()`; hash folds settings vocab+prompts (already the design — just re-sourced) |
+| `music/embeddings.ts:494` | `promptVocabHash` folds `MOOD_VOCAB` | fold `settings.moodVocab()` |
+| `music/tagger-core.ts:21,36` | `TAGGER_SYSTEM` / `TAGGER_BATCH_SYSTEM` const strings embed `MOOD_VOCAB.join()` | become `taggerSystem()` / `taggerBatchSystem()` functions reading `moodVocab()`; update callers |
+| `music/seed-selector.ts:40` | `MOOD_WORDS = new Set(SHOW_MOODS…)` const | `moodWords()` function reading `moodVocab()` |
+| `llm/internal/prompts/generate.ts:67,72` | show schema built at module load with `z.enum(SHOW_MOODS)` + `.catch(SHOW_MOODS[0])` | build the show schema inside a function per call, reading `moodVocab()`; line 92 "Allowed moods" already dynamic |
+| `context.ts:12` (`getTimeContext`) | inline period→mood literals | look up `settings.moodScheduleFor(period)` per period |
+| `context.ts:112` (`weatherToMood`) | inline switch | `settings.weatherMoodFor(condition)` |
+| `routes/library.ts:81,305,753` | `settings.SHOW_MOODS` | `settings.moodVocab()` |
+
+### 4.3 API — `routes/settings.ts`
+
+- **GET `/settings`:** add `moods`, `moodSchedule`, `weatherMoods` to the `values:` block (~line 102). Change the controlled-vocabulary export at line 149 from `moods: settings.SHOW_MOODS` → `moods: settings.moodVocab()`, so the **existing** Festivals + Shows mood dropdowns automatically pick up custom moods with zero client change.
+- **POST `/settings`:** no new route — the generic write (`settings.update(req.body)`, line 199) already accepts the three new keys via the `in patch` branches.
+
+---
+
+## 5. Web UI — one combined "Moods" tab
+
+Extend the existing self-contained `web/components/admin/FestivalsSection.tsx` into a combined panel (renamed to `MoodsSection.tsx`), and relabel the registry entry. The panel stacks four cards:
+
+1. **Vocabulary** — a table of `{ name, CLAP prompt }` rows with add / edit / remove (modal editor like the festival row modal). A one-line note: *"Changing moods or their sound descriptions re-scores audio moods on the next analysis pass and marks LLM tags stale — re-run the tagger to refresh."*
+2. **Time of day → mood** — 8 fixed period rows (labelled with their hour ranges), each a mood `<Select>` populated from the current vocabulary.
+3. **Weather → mood** — 6 fixed condition rows, each a mood `<Select>` plus a "— none —" option.
+4. **Festival calendar** — the existing festivals editor, unchanged, its mood dropdown now fed by the same live vocabulary.
+
+Registration in `SettingsPanel.tsx` (3 points, per the established pattern): import, one `SECTIONS` entry relabelled **`{ id: 'festivals', label: 'Moods', hint: 'moods · calendar · weather', icon: Palette }`** (keep `id: 'festivals'` so existing `?section=festivals` deep-links still resolve; swap the `CalendarDays` icon for a mood-appropriate one such as `Palette`), and the self-contained render line `{activeSection === 'festivals' && <MoodsSection />}`.
+
+Saving keeps the Festivals convention: whole-array/object replace POSTed to `/settings`; each card saves its own slice. Client-side validation stays light (server is authoritative): non-empty unique names, values drawn from the current vocabulary.
+
+No other web change needed — the first audit found only cosmetic mock data in `observatory/data.ts` (an empty-library preview), which stays as-is.
+
+---
+
+## 6. Edge cases & policy decisions
+
+- **Removing / renaming an in-use mood (the one real rough edge).** A save is validated as declarative desired-state against the merged `next`. If a mood name disappears while a **festival**, **show**, **schedule slot**, or **weather slot** still references it, `update()` **rejects** with an error naming the referrer (e.g. *"can't remove 'driving' — used by the drive-time schedule slot and 1 show"*). This is consistent with the codebase's strict-validation philosophy and avoids silent misconfiguration. Because each card saves its own slice (the Festivals convention), the operator repoints references first, then removes the old mood — so a **rename is a two-step** (add the new name, repoint every referrer, remove the old). The reject error names exactly what to repoint. *Alternative considered:* auto-cascade (drop from shows, reset slots to a default) and/or an explicit "rename" affordance that repoints in one action. Rejected for v1 as more surprising and more code; can be added later.
+- **Orphaned track tags.** Removing a mood leaves the string on already-tagged tracks (`tracks.moods`, `tracks.audio_moods`). Harmless — the value simply no longer matches anything in the vocabulary and drops out of `songsByMood`. No migration needed.
+- **Adding a mood** does not retroactively LLM-tag the library; it takes effect for new tags and, via the vocab-hash bump, on the next `--upgrade` tagger run. Audio moods (heavy analyzer) re-score automatically next pass. The UI note in §5 surfaces this.
+- **Prod vs dev.** Pure controller settings — persists to `settings.json`, read live per context build. No Liquidsoap restart, no rebuild in dev; prod picks it up on the running controller (settings are read at call time).
+
+---
+
+## 7. Testing
+
+- **Unit (Node, `npm run test:llm` style / existing `scripts/*.test.ts`):** pin `validateMoodsStrict` / `validateMoodScheduleStrict` / `validateWeatherMoodsStrict` (valid + each rejection path, including in-use removal). Pin `moodVocabHash` / `promptVocabHash` change-detection when the settings vocabulary/prompts change. Extend `scripts/audio-moods.test.ts` for settings-sourced prompts.
+- **Lint gate:** `controller/` and `web/` `npm run lint` (`eslint . && tsc --noEmit`) — the merge gate. Watch the `generate.ts` schema refactor for type fallout (the `z.enum` tuple type).
+- **Manual smoke (dev stack):** add a custom mood → confirm it appears in the Festivals + Shows mood dropdowns; set a festival to it; change a period's mood and a weather condition's mood; confirm `getFullContext().dominantMood` reflects the edited maps; confirm a vocab edit bumps the hashes (audio re-score log line, tagger `--upgrade` re-tags).
+
+---
+
+## 8. Files touched (summary)
+
+**Controller:** `settings.ts` (constants, accessors, seeding, 3 validators, update branches), `context.ts` (2 maps → settings reads), `music/audio-moods.ts`, `music/embeddings.ts`, `music/tagger-core.ts`, `music/seed-selector.ts`, `llm/internal/prompts/generate.ts`, `routes/settings.ts`, `routes/library.ts`. Tests under `controller/scripts/`.
+
+**Web:** `components/admin/FestivalsSection.tsx` → `MoodsSection.tsx` (extended), `components/admin/SettingsPanel.tsx` (registry relabel).
+
+**No change:** genres (already dynamic), `SHOW_ENERGY`, Liquidsoap / compose / `.env`, native app.

--- a/web/app/admin/moods/page.tsx
+++ b/web/app/admin/moods/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import MoodsPanel from '../../../components/admin/MoodsPanel';
+
+export const metadata: Metadata = {
+  title: 'Moods',
+};
+
+export default function AdminMoodsPage() {
+  return <MoodsPanel />;
+}

--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -25,6 +25,7 @@ import {
   Coffee,
   MessageCircle,
   Podcast,
+  Palette,
 } from 'lucide-react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import type { SignInResult } from '../../lib/adminAuth';
@@ -70,6 +71,7 @@ const NAV_SECTIONS: NavSection[] = [
       { href: '/admin/library', id: 'library', label: 'Library', icon: Disc3 },
       { href: '/admin/shows', id: 'shows', label: 'Shows', icon: CalendarClock },
       { href: '/admin/personas', id: 'personas', label: 'Personas', icon: Drama },
+      { href: '/admin/moods', id: 'moods', label: 'Moods', icon: Palette },
       { href: '/admin/skills', id: 'skills', label: 'Skills', icon: Sparkles },
       { href: '/admin/imaging', id: 'imaging', label: 'Imaging', icon: Podcast },
     ],

--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -71,9 +71,9 @@ const NAV_SECTIONS: NavSection[] = [
       { href: '/admin/library', id: 'library', label: 'Library', icon: Disc3 },
       { href: '/admin/shows', id: 'shows', label: 'Shows', icon: CalendarClock },
       { href: '/admin/personas', id: 'personas', label: 'Personas', icon: Drama },
-      { href: '/admin/moods', id: 'moods', label: 'Moods', icon: Palette },
       { href: '/admin/skills', id: 'skills', label: 'Skills', icon: Sparkles },
       { href: '/admin/imaging', id: 'imaging', label: 'Imaging', icon: Podcast },
+      { href: '/admin/moods', id: 'moods', label: 'Moods', icon: Palette },
     ],
   },
   {

--- a/web/components/admin/MoodsPanel.tsx
+++ b/web/components/admin/MoodsPanel.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Trash2 } from 'lucide-react';
+import { Trash2, Palette, Clock, CalendarDays, Volume2 } from 'lucide-react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { notify, errorMessage } from '../../lib/notify';
-import { Card, Btn } from './ui';
-import { SectionHeader } from './settings/shared';
+import { cn } from '../../lib/cn';
+import { Card, Btn, Eyebrow } from './ui';
 import { Input } from '../ui/input';
 import { ScrollArea } from '../ui/scroll-area';
 import {
@@ -51,10 +51,14 @@ const NONE = '__none__';
 
 const MOODS_LIMIT = 40; // mirrors the server MOODS_LIMIT
 
+type TabId = 'vocab' | 'moments' | 'festivals' | 'speech';
+const TAB_IDS: TabId[] = ['vocab', 'moments', 'festivals', 'speech'];
+
 export default function MoodsPanel() {
   const { adminFetch, needsAuth, hydrated } = useAdminAuth();
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null); // which card is saving
+  const [tab, setTab] = useState<TabId>('vocab');
 
   // Working copies + saved baselines (for dirty detection).
   const [moods, setMoods] = useState<MoodEntry[] | null>(null);
@@ -104,6 +108,23 @@ export default function MoodsPanel() {
     if (!hydrated || needsAuth) return;
     void load();
   }, [hydrated, needsAuth, load]);
+
+  // Deep-link: /admin/moods?tab=moments opens that tab directly (mirrors
+  // /admin/imaging?tab=… and /admin/connect?tab=…).
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const t = new URLSearchParams(window.location.search).get('tab');
+    if (t && (TAB_IDS as string[]).includes(t)) setTab(t as TabId);
+  }, []);
+
+  const selectTab = useCallback((id: string) => {
+    setTab(id as TabId);
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href);
+      url.searchParams.set('tab', id);
+      window.history.replaceState(null, '', url.toString());
+    }
+  }, []);
 
   // POST one settings slice; on success adopt the sent value as the new
   // baseline. The controller validates strictly and returns a clear message
@@ -162,89 +183,147 @@ export default function MoodsPanel() {
       () => setSavedCorrections(effectiveCorr), 'Speech corrections saved');
   };
 
+  const loading = moods === null && !err;
+  const tabs = [
+    { id: 'vocab' as TabId, label: 'Vocabulary', count: moods?.length, icon: Palette },
+    { id: 'moments' as TabId, label: 'Moments', count: undefined as number | undefined, icon: Clock },
+    { id: 'festivals' as TabId, label: 'Festivals', count: undefined as number | undefined, icon: CalendarDays },
+    { id: 'speech' as TabId, label: 'Speech', count: moods !== null ? corrections.length : undefined, icon: Volume2 },
+  ];
+
   return (
-    <section className="grid gap-6">
-      <SectionHeader
-        eyebrow="moods"
-        title="Moods & moments."
-        sub="The station's mood vocabulary and how the autonomous DJ reaches for it — the words the library is tagged with, and which mood each part of the day, weather, and festival leans into. Edit the list, and every show, festival, and auto-DJ pick draws from it."
-        metrics={moods ? [{ n: String(moods.length), l: `mood${moods.length === 1 ? '' : 's'}`, accent: true }] : undefined}
-      />
+    <div className="grid gap-4">
+      <section className="card">
+        <div className="border-b border-ink p-4">
+          <Eyebrow className="text-vermilion">moods</Eyebrow>
+          <div className="mt-1.5 text-[22px] font-extrabold tracking-[-0.02em]">
+            Moods &amp; moments.
+          </div>
+          <div className="mt-1 text-[11px] leading-[1.6] text-muted">
+            The station&apos;s mood vocabulary and how the autonomous DJ reaches for it — the
+            words the library is tagged with, and which mood each part of the day, the weather,
+            and the calendar leans into. Edit the list, and every show, festival, and auto-DJ
+            pick draws from it.
+          </div>
+        </div>
+        {/* Full-width tab row — active cell filled in the accent, mirroring the
+            Imaging page. */}
+        <div className="grid grid-cols-4" role="tablist" aria-label="Moods sections">
+          {tabs.map((t, i) => {
+            const active = tab === t.id;
+            const Icon = t.icon;
+            return (
+              <button
+                key={t.id}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => selectTab(t.id)}
+                className={cn(
+                  'flex items-center justify-center gap-2.5 px-4 py-4 text-[13px] font-bold tracking-[0.18em] uppercase transition-colors',
+                  i > 0 && 'border-l border-ink',
+                  active
+                    ? 'bg-[var(--accent)] text-white'
+                    : 'bg-[var(--ink-softer)] text-ink hover:bg-ink/10',
+                )}
+              >
+                <Icon size={17} strokeWidth={2} aria-hidden />
+                <span>{t.label}</span>
+                {t.count != null && (
+                  <span
+                    className={cn(
+                      'ml-0.5 min-w-[1.5em] rounded-full px-1.5 py-0.5 text-[10px] leading-none font-bold',
+                      active ? 'bg-white/25 text-white' : 'bg-ink/10 text-muted',
+                    )}
+                  >
+                    {t.count}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </section>
 
       {err && (
-        <Card>
-          <div className="text-[var(--danger)]">{err}</div>
-        </Card>
+        <div className="card border-[var(--danger)]">
+          <div className="card-body text-[12px] text-[var(--danger)]">
+            <strong className="tracking-[0.12em] uppercase">controller error</strong>
+            <div className="mt-1">{err}</div>
+          </div>
+        </div>
       )}
 
-      {moods === null && !err && (
+      {loading && tab !== 'festivals' && (
         <div className="text-[13px] text-muted italic">loading…</div>
       )}
 
-      {moods !== null && (
-        <>
-          {/* --- Vocabulary --- */}
-          <Card title="Mood vocabulary" sub="the moods every track is tagged with">
-            <div className="field">
-              <div className="field-hint">
-                Each mood needs a short id (letters, digits, dashes) and an optional
-                sound description used for zero-shot audio tagging (heavy analyzer).
-                Changing moods or their descriptions re-scores audio moods on the
-                next analysis pass and marks LLM tags stale — re-run the tagger to
-                refresh. Removing a mood that a show, festival, or the maps below
-                still use is rejected until you reassign it.
-              </div>
-              <ScrollArea className="max-h-[360px]">
-                <div className="flex flex-col gap-2 pr-2">
-                  {moods.map((m, idx) => (
-                    <div key={idx} className="flex items-center gap-2">
-                      <Input
-                        value={m.name}
-                        onChange={e => setMoods(list =>
-                          (list ?? []).map((row, i) => i === idx ? { ...row, name: e.target.value } : row))}
-                        placeholder="id (e.g. mellow)"
-                        maxLength={40}
-                        className="max-w-[160px] min-w-0 shrink-0"
-                      />
-                      <Input
-                        value={m.clapPrompt}
-                        onChange={e => setMoods(list =>
-                          (list ?? []).map((row, i) => i === idx ? { ...row, clapPrompt: e.target.value } : row))}
-                        placeholder="sound description for audio tagging (optional)"
-                        maxLength={200}
-                        className="min-w-0 flex-1"
-                      />
-                      <Btn
-                        sm
-                        title="Remove mood"
-                        className="shrink-0"
-                        onClick={() => setMoods(list => (list ?? []).filter((_, i) => i !== idx))}
-                      >
-                        <Trash2 size={12} />
-                      </Btn>
-                    </div>
-                  ))}
-                </div>
-              </ScrollArea>
-              <div className="mt-3 flex items-center gap-2">
-                <Btn
-                  disabled={moods.length >= MOODS_LIMIT}
-                  onClick={() => setMoods(list => [...(list ?? []), { name: '', clapPrompt: '' }])}
-                >
-                  Add mood
-                </Btn>
-                <Btn
-                  tone="accent"
-                  disabled={!moodsDirty || busy === 'moods'}
-                  onClick={saveMoods}
-                >
-                  {busy === 'moods' ? 'Saving…' : 'Save vocabulary'}
-                </Btn>
-              </div>
+      {/* --- Vocabulary --- */}
+      {tab === 'vocab' && moods !== null && (
+        <Card title="Mood vocabulary" sub="the moods every track is tagged with">
+          <div className="field">
+            <div className="field-hint">
+              Each mood needs a short id (letters, digits, dashes) and an optional
+              sound description used for zero-shot audio tagging (heavy analyzer).
+              Changing moods or their descriptions re-scores audio moods on the
+              next analysis pass and marks LLM tags stale — re-run the tagger to
+              refresh. Removing a mood that a show, festival, or the maps in Moments
+              still use is rejected until you reassign it.
             </div>
-          </Card>
+            <ScrollArea className="max-h-[420px]">
+              <div className="flex flex-col gap-2 pr-2">
+                {moods.map((m, idx) => (
+                  <div key={idx} className="flex items-center gap-2">
+                    <Input
+                      value={m.name}
+                      onChange={e => setMoods(list =>
+                        (list ?? []).map((row, i) => i === idx ? { ...row, name: e.target.value } : row))}
+                      placeholder="id (e.g. mellow)"
+                      maxLength={40}
+                      className="max-w-[160px] min-w-0 shrink-0"
+                    />
+                    <Input
+                      value={m.clapPrompt}
+                      onChange={e => setMoods(list =>
+                        (list ?? []).map((row, i) => i === idx ? { ...row, clapPrompt: e.target.value } : row))}
+                      placeholder="sound description for audio tagging (optional)"
+                      maxLength={200}
+                      className="min-w-0 flex-1"
+                    />
+                    <Btn
+                      sm
+                      title="Remove mood"
+                      className="shrink-0"
+                      onClick={() => setMoods(list => (list ?? []).filter((_, i) => i !== idx))}
+                    >
+                      <Trash2 size={12} />
+                    </Btn>
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+            <div className="mt-3 flex items-center gap-2">
+              <Btn
+                disabled={moods.length >= MOODS_LIMIT}
+                onClick={() => setMoods(list => [...(list ?? []), { name: '', clapPrompt: '' }])}
+              >
+                Add mood
+              </Btn>
+              <Btn
+                tone="accent"
+                disabled={!moodsDirty || busy === 'moods'}
+                onClick={saveMoods}
+              >
+                {busy === 'moods' ? 'Saving…' : 'Save vocabulary'}
+              </Btn>
+            </div>
+          </div>
+        </Card>
+      )}
 
-          {/* --- Time of day → mood --- */}
+      {/* --- Moments: time-of-day + weather --- */}
+      {tab === 'moments' && moods !== null && (
+        <>
           <Card title="Time of day → mood" sub="what the autonomous DJ leans into through the day">
             <div className="grid gap-2">
               {PERIODS.map(p => (
@@ -276,7 +355,6 @@ export default function MoodsPanel() {
             </div>
           </Card>
 
-          {/* --- Weather → mood --- */}
           <Card title="Weather → mood" sub="how live conditions colour the mood (overrides time of day)">
             <div className="grid gap-2">
               {CONDITIONS.map(c => (
@@ -305,72 +383,74 @@ export default function MoodsPanel() {
               </div>
             </div>
           </Card>
-
-          {/* --- Speech corrections (relocated from the TTS tab) --- */}
-          <Card title="Speech corrections" sub="pronunciation fixes">
-            <div className="field">
-              <div className="field-hint">
-                Find→replace rules applied to every spoken line before the voice engine
-                reads it, for names and terms the engines mispronounce (<em>GHz</em> →
-                <em> gigahertz</em>, <em>Hozier</em> → <em>Ho-zeer</em>). Case-insensitive,
-                matches whole words and phrases; leave the spoken form empty to drop the
-                phrase entirely. Saved rules apply from the next spoken line, no restart.
-              </div>
-              <ScrollArea className="max-h-[280px]">
-                <div className="flex flex-col gap-2 pr-2">
-                  {corrections.map((c, idx) => (
-                    <div key={idx} className="flex items-center gap-2">
-                      <Input
-                        value={c.from}
-                        onChange={e => setCorrections(list =>
-                          list.map((row, i) => i === idx ? { ...row, from: e.target.value } : row))}
-                        placeholder="text on air (e.g. GHz)"
-                        maxLength={80}
-                        className="max-w-[220px] min-w-0 flex-1"
-                      />
-                      <span className="shrink-0 text-[11px] text-muted">reads as</span>
-                      <Input
-                        value={c.to}
-                        onChange={e => setCorrections(list =>
-                          list.map((row, i) => i === idx ? { ...row, to: e.target.value } : row))}
-                        placeholder="spoken form (e.g. gigahertz)"
-                        maxLength={160}
-                        className="max-w-[260px] min-w-0 flex-1"
-                      />
-                      <Btn
-                        sm
-                        title="Remove correction"
-                        className="shrink-0"
-                        onClick={() => setCorrections(list => list.filter((_, i) => i !== idx))}
-                      >
-                        <Trash2 size={12} />
-                      </Btn>
-                    </div>
-                  ))}
-                </div>
-              </ScrollArea>
-              <div className="mt-3 flex items-center gap-2">
-                <Btn
-                  disabled={corrections.length >= 100}
-                  onClick={() => setCorrections(list => [...list, { from: '', to: '' }])}
-                >
-                  Add correction
-                </Btn>
-                <Btn
-                  tone="accent"
-                  disabled={!correctionsDirty || busy === 'corrections'}
-                  onClick={saveCorrections}
-                >
-                  {busy === 'corrections' ? 'Saving…' : 'Save corrections'}
-                </Btn>
-              </div>
-            </div>
-          </Card>
         </>
       )}
 
-      {/* --- Festival calendar (self-contained, composed as-is) --- */}
-      <FestivalsSection />
-    </section>
+      {/* --- Festivals (self-contained, composed as-is) --- */}
+      {tab === 'festivals' && <FestivalsSection />}
+
+      {/* --- Speech corrections (relocated from the TTS tab) --- */}
+      {tab === 'speech' && moods !== null && (
+        <Card title="Speech corrections" sub="pronunciation fixes">
+          <div className="field">
+            <div className="field-hint">
+              Find→replace rules applied to every spoken line before the voice engine
+              reads it, for names and terms the engines mispronounce (<em>GHz</em> →
+              <em> gigahertz</em>, <em>Hozier</em> → <em>Ho-zeer</em>). Case-insensitive,
+              matches whole words and phrases; leave the spoken form empty to drop the
+              phrase entirely. Saved rules apply from the next spoken line, no restart.
+            </div>
+            <ScrollArea className="max-h-[360px]">
+              <div className="flex flex-col gap-2 pr-2">
+                {corrections.map((c, idx) => (
+                  <div key={idx} className="flex items-center gap-2">
+                    <Input
+                      value={c.from}
+                      onChange={e => setCorrections(list =>
+                        list.map((row, i) => i === idx ? { ...row, from: e.target.value } : row))}
+                      placeholder="text on air (e.g. GHz)"
+                      maxLength={80}
+                      className="max-w-[220px] min-w-0 flex-1"
+                    />
+                    <span className="shrink-0 text-[11px] text-muted">reads as</span>
+                    <Input
+                      value={c.to}
+                      onChange={e => setCorrections(list =>
+                        list.map((row, i) => i === idx ? { ...row, to: e.target.value } : row))}
+                      placeholder="spoken form (e.g. gigahertz)"
+                      maxLength={160}
+                      className="max-w-[260px] min-w-0 flex-1"
+                    />
+                    <Btn
+                      sm
+                      title="Remove correction"
+                      className="shrink-0"
+                      onClick={() => setCorrections(list => list.filter((_, i) => i !== idx))}
+                    >
+                      <Trash2 size={12} />
+                    </Btn>
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+            <div className="mt-3 flex items-center gap-2">
+              <Btn
+                disabled={corrections.length >= 100}
+                onClick={() => setCorrections(list => [...list, { from: '', to: '' }])}
+              >
+                Add correction
+              </Btn>
+              <Btn
+                tone="accent"
+                disabled={!correctionsDirty || busy === 'corrections'}
+                onClick={saveCorrections}
+              >
+                {busy === 'corrections' ? 'Saving…' : 'Save corrections'}
+              </Btn>
+            </div>
+          </div>
+        </Card>
+      )}
+    </div>
   );
 }

--- a/web/components/admin/MoodsPanel.tsx
+++ b/web/components/admin/MoodsPanel.tsx
@@ -1,0 +1,376 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Trash2 } from 'lucide-react';
+import { useAdminAuth } from '../../lib/adminAuth';
+import { notify, errorMessage } from '../../lib/notify';
+import { Card, Btn } from './ui';
+import { SectionHeader } from './settings/shared';
+import { Input } from '../ui/input';
+import { ScrollArea } from '../ui/scroll-area';
+import {
+  Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
+} from '../ui/select';
+import FestivalsSection from './FestivalsSection';
+
+interface MoodEntry {
+  name: string;
+  clapPrompt: string;
+}
+interface Correction {
+  from: string;
+  to: string;
+}
+
+// The 8 fixed day-periods (controller context.ts getTimeContext) — only each
+// period's MOOD is editable here; the hour ranges + vibe/show names stay in code.
+const PERIODS: Array<{ id: string; label: string; hours: string }> = [
+  { id: 'early-morning', label: 'Early morning', hours: '05–09' },
+  { id: 'morning', label: 'Morning', hours: '09–12' },
+  { id: 'midday', label: 'Midday', hours: '12–14' },
+  { id: 'afternoon', label: 'Afternoon', hours: '14–17' },
+  { id: 'drive-time', label: 'Drive-time', hours: '17–19' },
+  { id: 'evening', label: 'Evening', hours: '19–22' },
+  { id: 'late-evening', label: 'Late evening', hours: '22–01' },
+  { id: 'after-hours', label: 'After hours', hours: '01–05' },
+];
+
+// The 6 fixed weather conditions (controller context.ts mapWeatherCode).
+const CONDITIONS: Array<{ id: string; label: string }> = [
+  { id: 'clear', label: 'Clear' },
+  { id: 'cloudy', label: 'Cloudy' },
+  { id: 'foggy', label: 'Foggy' },
+  { id: 'rainy', label: 'Rainy' },
+  { id: 'snowy', label: 'Snowy' },
+  { id: 'stormy', label: 'Stormy' },
+];
+
+// Radix Select forbids an empty-string item value, so the weather "no steer"
+// option rides a sentinel that maps back to '' on save.
+const NONE = '__none__';
+
+const MOODS_LIMIT = 40; // mirrors the server MOODS_LIMIT
+
+export default function MoodsPanel() {
+  const { adminFetch, needsAuth, hydrated } = useAdminAuth();
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null); // which card is saving
+
+  // Working copies + saved baselines (for dirty detection).
+  const [moods, setMoods] = useState<MoodEntry[] | null>(null);
+  const [savedMoods, setSavedMoods] = useState<MoodEntry[]>([]);
+  const [schedule, setSchedule] = useState<Record<string, string>>({});
+  const [savedSchedule, setSavedSchedule] = useState<Record<string, string>>({});
+  const [weather, setWeather] = useState<Record<string, string>>({});
+  const [savedWeather, setSavedWeather] = useState<Record<string, string>>({});
+  const [corrections, setCorrections] = useState<Correction[]>([]);
+  const [savedCorrections, setSavedCorrections] = useState<Correction[]>([]);
+
+  const load = useCallback(async () => {
+    try {
+      const r = await adminFetch('/settings');
+      if (!r.ok) throw new Error(`failed (${r.status})`);
+      const j = (await r.json()) as {
+        values?: {
+          moods?: unknown;
+          moodSchedule?: unknown;
+          weatherMoods?: unknown;
+          tts?: { corrections?: unknown };
+        };
+      } | null;
+      const v = j?.values || {};
+      const loadedMoods = Array.isArray(v.moods) ? (v.moods as MoodEntry[]) : [];
+      const loadedSchedule = (v.moodSchedule && typeof v.moodSchedule === 'object'
+        ? v.moodSchedule : {}) as Record<string, string>;
+      const loadedWeather = (v.weatherMoods && typeof v.weatherMoods === 'object'
+        ? v.weatherMoods : {}) as Record<string, string>;
+      const loadedCorr = Array.isArray(v.tts?.corrections)
+        ? (v.tts!.corrections as Correction[]) : [];
+      setMoods(loadedMoods);
+      setSavedMoods(loadedMoods);
+      setSchedule(loadedSchedule);
+      setSavedSchedule(loadedSchedule);
+      setWeather(loadedWeather);
+      setSavedWeather(loadedWeather);
+      setCorrections(loadedCorr);
+      setSavedCorrections(loadedCorr);
+      setErr(null);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    }
+  }, [adminFetch]);
+
+  useEffect(() => {
+    if (!hydrated || needsAuth) return;
+    void load();
+  }, [hydrated, needsAuth, load]);
+
+  // POST one settings slice; on success adopt the sent value as the new
+  // baseline. The controller validates strictly and returns a clear message
+  // (e.g. an in-use mood removal), which we surface verbatim.
+  const saveSlice = async (
+    card: string,
+    patch: Record<string, unknown>,
+    onOk: () => void,
+    okMsg: string,
+  ) => {
+    setBusy(card);
+    try {
+      const r = await adminFetch('/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      });
+      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      onOk();
+      notify.ok(okMsg);
+    } catch (e) {
+      notify.err(`Save failed: ${errorMessage(e)}`);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (!hydrated || needsAuth) return null;
+
+  const savedMoodNames = savedMoods.map(m => m.name);
+  const moodsDirty = JSON.stringify(moods ?? []) !== JSON.stringify(savedMoods);
+  const scheduleDirty = JSON.stringify(schedule) !== JSON.stringify(savedSchedule);
+  const weatherDirty = JSON.stringify(weather) !== JSON.stringify(savedWeather);
+  const effectiveCorr = corrections
+    .map(c => ({ from: c.from.trim(), to: c.to.trim() }))
+    .filter(c => c.from);
+  const correctionsDirty =
+    JSON.stringify(effectiveCorr) !== JSON.stringify(savedCorrections.map(c => ({ from: c.from ?? '', to: c.to ?? '' })));
+
+  const saveMoods = () => {
+    const payload = (moods ?? []).map(m => ({ name: m.name, clapPrompt: m.clapPrompt }));
+    void saveSlice('moods', { moods: payload }, () => setSavedMoods(payload),
+      `${payload.length} mood${payload.length === 1 ? '' : 's'} saved`);
+  };
+  const saveSchedule = () => {
+    void saveSlice('schedule', { moodSchedule: schedule }, () => setSavedSchedule(schedule),
+      'Time-of-day moods saved');
+  };
+  const saveWeather = () => {
+    void saveSlice('weather', { weatherMoods: weather }, () => setSavedWeather(weather),
+      'Weather moods saved');
+  };
+  const saveCorrections = () => {
+    void saveSlice('corrections', { tts: { corrections: effectiveCorr } },
+      () => setSavedCorrections(effectiveCorr), 'Speech corrections saved');
+  };
+
+  return (
+    <section className="grid gap-6">
+      <SectionHeader
+        eyebrow="moods"
+        title="Moods & moments."
+        sub="The station's mood vocabulary and how the autonomous DJ reaches for it — the words the library is tagged with, and which mood each part of the day, weather, and festival leans into. Edit the list, and every show, festival, and auto-DJ pick draws from it."
+        metrics={moods ? [{ n: String(moods.length), l: `mood${moods.length === 1 ? '' : 's'}`, accent: true }] : undefined}
+      />
+
+      {err && (
+        <Card>
+          <div className="text-[var(--danger)]">{err}</div>
+        </Card>
+      )}
+
+      {moods === null && !err && (
+        <div className="text-[13px] text-muted italic">loading…</div>
+      )}
+
+      {moods !== null && (
+        <>
+          {/* --- Vocabulary --- */}
+          <Card title="Mood vocabulary" sub="the moods every track is tagged with">
+            <div className="field">
+              <div className="field-hint">
+                Each mood needs a short id (letters, digits, dashes) and an optional
+                sound description used for zero-shot audio tagging (heavy analyzer).
+                Changing moods or their descriptions re-scores audio moods on the
+                next analysis pass and marks LLM tags stale — re-run the tagger to
+                refresh. Removing a mood that a show, festival, or the maps below
+                still use is rejected until you reassign it.
+              </div>
+              <ScrollArea className="max-h-[360px]">
+                <div className="flex flex-col gap-2 pr-2">
+                  {moods.map((m, idx) => (
+                    <div key={idx} className="flex items-center gap-2">
+                      <Input
+                        value={m.name}
+                        onChange={e => setMoods(list =>
+                          (list ?? []).map((row, i) => i === idx ? { ...row, name: e.target.value } : row))}
+                        placeholder="id (e.g. mellow)"
+                        maxLength={40}
+                        className="max-w-[160px] min-w-0 shrink-0"
+                      />
+                      <Input
+                        value={m.clapPrompt}
+                        onChange={e => setMoods(list =>
+                          (list ?? []).map((row, i) => i === idx ? { ...row, clapPrompt: e.target.value } : row))}
+                        placeholder="sound description for audio tagging (optional)"
+                        maxLength={200}
+                        className="min-w-0 flex-1"
+                      />
+                      <Btn
+                        sm
+                        title="Remove mood"
+                        className="shrink-0"
+                        onClick={() => setMoods(list => (list ?? []).filter((_, i) => i !== idx))}
+                      >
+                        <Trash2 size={12} />
+                      </Btn>
+                    </div>
+                  ))}
+                </div>
+              </ScrollArea>
+              <div className="mt-3 flex items-center gap-2">
+                <Btn
+                  disabled={moods.length >= MOODS_LIMIT}
+                  onClick={() => setMoods(list => [...(list ?? []), { name: '', clapPrompt: '' }])}
+                >
+                  Add mood
+                </Btn>
+                <Btn
+                  tone="accent"
+                  disabled={!moodsDirty || busy === 'moods'}
+                  onClick={saveMoods}
+                >
+                  {busy === 'moods' ? 'Saving…' : 'Save vocabulary'}
+                </Btn>
+              </div>
+            </div>
+          </Card>
+
+          {/* --- Time of day → mood --- */}
+          <Card title="Time of day → mood" sub="what the autonomous DJ leans into through the day">
+            <div className="grid gap-2">
+              {PERIODS.map(p => (
+                <div key={p.id} className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <span className="text-[13px] font-bold">{p.label}</span>
+                    <span className="mono-num ml-2 text-[11px] text-muted">{p.hours}</span>
+                  </div>
+                  <Select
+                    value={schedule[p.id] || (savedMoodNames[0] ?? '')}
+                    onValueChange={v => setSchedule(s => ({ ...s, [p.id]: v }))}
+                  >
+                    <SelectTrigger className="max-w-[200px]">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {savedMoodNames.map(m => (
+                        <SelectItem key={m} value={m}>{m}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              ))}
+              <div className="mt-1">
+                <Btn tone="accent" disabled={!scheduleDirty || busy === 'schedule'} onClick={saveSchedule}>
+                  {busy === 'schedule' ? 'Saving…' : 'Save time-of-day moods'}
+                </Btn>
+              </div>
+            </div>
+          </Card>
+
+          {/* --- Weather → mood --- */}
+          <Card title="Weather → mood" sub="how live conditions colour the mood (overrides time of day)">
+            <div className="grid gap-2">
+              {CONDITIONS.map(c => (
+                <div key={c.id} className="flex items-center justify-between gap-3">
+                  <span className="text-[13px] font-bold">{c.label}</span>
+                  <Select
+                    value={weather[c.id] ? weather[c.id] : NONE}
+                    onValueChange={v => setWeather(w => ({ ...w, [c.id]: v === NONE ? '' : v }))}
+                  >
+                    <SelectTrigger className="max-w-[200px]">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={NONE}>— none —</SelectItem>
+                      {savedMoodNames.map(m => (
+                        <SelectItem key={m} value={m}>{m}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              ))}
+              <div className="mt-1">
+                <Btn tone="accent" disabled={!weatherDirty || busy === 'weather'} onClick={saveWeather}>
+                  {busy === 'weather' ? 'Saving…' : 'Save weather moods'}
+                </Btn>
+              </div>
+            </div>
+          </Card>
+
+          {/* --- Speech corrections (relocated from the TTS tab) --- */}
+          <Card title="Speech corrections" sub="pronunciation fixes">
+            <div className="field">
+              <div className="field-hint">
+                Find→replace rules applied to every spoken line before the voice engine
+                reads it, for names and terms the engines mispronounce (<em>GHz</em> →
+                <em> gigahertz</em>, <em>Hozier</em> → <em>Ho-zeer</em>). Case-insensitive,
+                matches whole words and phrases; leave the spoken form empty to drop the
+                phrase entirely. Saved rules apply from the next spoken line, no restart.
+              </div>
+              <ScrollArea className="max-h-[280px]">
+                <div className="flex flex-col gap-2 pr-2">
+                  {corrections.map((c, idx) => (
+                    <div key={idx} className="flex items-center gap-2">
+                      <Input
+                        value={c.from}
+                        onChange={e => setCorrections(list =>
+                          list.map((row, i) => i === idx ? { ...row, from: e.target.value } : row))}
+                        placeholder="text on air (e.g. GHz)"
+                        maxLength={80}
+                        className="max-w-[220px] min-w-0 flex-1"
+                      />
+                      <span className="shrink-0 text-[11px] text-muted">reads as</span>
+                      <Input
+                        value={c.to}
+                        onChange={e => setCorrections(list =>
+                          list.map((row, i) => i === idx ? { ...row, to: e.target.value } : row))}
+                        placeholder="spoken form (e.g. gigahertz)"
+                        maxLength={160}
+                        className="max-w-[260px] min-w-0 flex-1"
+                      />
+                      <Btn
+                        sm
+                        title="Remove correction"
+                        className="shrink-0"
+                        onClick={() => setCorrections(list => list.filter((_, i) => i !== idx))}
+                      >
+                        <Trash2 size={12} />
+                      </Btn>
+                    </div>
+                  ))}
+                </div>
+              </ScrollArea>
+              <div className="mt-3 flex items-center gap-2">
+                <Btn
+                  disabled={corrections.length >= 100}
+                  onClick={() => setCorrections(list => [...list, { from: '', to: '' }])}
+                >
+                  Add correction
+                </Btn>
+                <Btn
+                  tone="accent"
+                  disabled={!correctionsDirty || busy === 'corrections'}
+                  onClick={saveCorrections}
+                >
+                  {busy === 'corrections' ? 'Saving…' : 'Save corrections'}
+                </Btn>
+              </div>
+            </div>
+          </Card>
+        </>
+      )}
+
+      {/* --- Festival calendar (self-contained, composed as-is) --- */}
+      <FestivalsSection />
+    </section>
+  );
+}

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -16,10 +16,9 @@ import { Card, Btn, Pill, Seg } from './ui';
 import { cn } from '../../lib/cn';
 import ArchivesPanel from './ArchivesPanel';
 import BackupPanel from './BackupPanel';
-import FestivalsSection from './FestivalsSection';
 import {
   Radio, Palette, Cpu, Mic, Library, Search,
-  Activity, Archive, Save, AlertTriangle, CalendarDays, Heart,
+  Activity, Archive, Save, AlertTriangle, Heart,
 } from 'lucide-react';
 import {
   SectionHeader, ELEVENLABS_VS_DEFAULTS,
@@ -38,7 +37,6 @@ import { LikesSection } from './settings/LikesSection';
 const SECTIONS = [
   { id: 'station',  label: 'Station', hint: 'name · location · locale', icon: Radio },
   { id: 'theme',    label: 'Skin & Themes', hint: 'player skin · palette', icon: Palette },
-  { id: 'festivals', label: 'Festivals', hint: 'calendar · mood', icon: CalendarDays },
   { id: 'llm',      label: 'LLM provider', hint: 'model routing', icon: Cpu },
   { id: 'tts',      label: 'TTS voice', hint: 'default engine', icon: Mic },
   { id: 'library',  label: 'Library tagger', hint: 'embedding · propagation', icon: Library },
@@ -604,7 +602,6 @@ export default function SettingsPanel() {
             )}
           </>
         )}
-        {activeSection === 'festivals' && <FestivalsSection />}
         {activeSection === 'backup' && <BackupPanel />}
         {activeSection === 'danger' && (
           <>

--- a/web/components/admin/settings/TtsSection.tsx
+++ b/web/components/admin/settings/TtsSection.tsx
@@ -15,8 +15,6 @@ import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel,
 } from '../../ui/select';
 import { Card, Btn, Pill, Seg } from '../ui';
-import { ScrollArea } from '../../ui/scroll-area';
-import { Trash2 } from 'lucide-react';
 import { EngineSelector } from '../tts/EngineSelector';
 import { VoicePreviewButton } from '../tts/VoicePreviewButton';
 import { VoicePicker } from '../tts/VoicePicker';
@@ -417,11 +415,6 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
         // Per-engine speech speed (×). Same contract as gainDb; inert for the
         // engines whose workers ignore speed (chatterbox/pocket-tts).
         speed: form.tts.speed,
-        // Whole-list replace. Rows with an empty "text on air" are drafts the
-        // operator never filled in — dropped, not an error.
-        corrections: form.tts.corrections
-          .map(c => ({ from: c.from.trim(), to: c.to.trim() }))
-          .filter(c => c.from),
       },
     });
     // Save cloud API key if typed -- goes to secrets.env, not settings.json
@@ -477,7 +470,6 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
     remote?: { url?: string };
     gainDb?: Record<string, number>;
     speed?: Record<string, number>;
-    corrections?: { from?: string; to?: string }[];
   } = data.values?.tts || {};
   const savedEngine: string = savedTts.defaultEngine || 'piper';
   const savedKokoroVoice: string = savedTts.kokoro?.voice || '';
@@ -501,16 +493,6 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
     e => (form.tts.speed?.[e] ?? 1) !== (savedSpeed[e] ?? 1),
   );
 
-  // Compare what save() would actually send (trimmed, draft rows dropped)
-  // against the saved list, so an untouched empty draft row isn't "unsaved".
-  const effectiveCorrections = (form.tts.corrections || [])
-    .map(c => ({ from: (c.from || '').trim(), to: (c.to || '').trim() }))
-    .filter(c => c.from);
-  const savedCorrections = (savedTts.corrections || [])
-    .map(c => ({ from: c.from ?? '', to: c.to ?? '' }));
-  const correctionsDirty =
-    JSON.stringify(effectiveCorrections) !== JSON.stringify(savedCorrections);
-
   const ttsDirty =
     form.tts.defaultEngine !== savedEngine
     || (form.tts.kokoro?.voice || '') !== savedKokoroVoice
@@ -527,8 +509,7 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
     || form.tts.cloud.voiceUseSpeakerBoost !== (savedCloud.voiceUseSpeakerBoost ?? ELEVENLABS_VS_DEFAULTS.voiceUseSpeakerBoost)
     || (form.tts.remote.url || '').trim() !== savedRemoteUrl
     || gainDirty
-    || speedDirty
-    || correctionsDirty;
+    || speedDirty;
 
   let activeDetail: ReactNode = null;
   if (savedEngine === 'piper') {
@@ -1103,87 +1084,7 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
         </div>
       </Card>
 
-      <Card title="Speech corrections" sub="pronunciation fixes">
-        <div className="field">
-          <div className="field-hint">
-            Find→replace rules applied to every spoken line before the voice engine
-            reads it, for names and terms the engines mispronounce (<em>GHz</em> →
-            <em> gigahertz</em>, <em>Hozier</em> → <em>Ho-zeer</em>). Case-insensitive,
-            matches whole words and phrases; leave the spoken form empty to drop the
-            phrase entirely. Saved rules apply from the next spoken line, no restart.
-          </div>
-          {/* Capped so a long rule list scrolls instead of stretching the card;
-              the pr-2 keeps rows clear of the scrollbar. */}
-          <ScrollArea className="max-h-[280px]">
-            <div className="flex flex-col gap-2 pr-2">
-              {form.tts.corrections.map((c, idx) => (
-                <div key={idx} className="flex items-center gap-2">
-                  <Input
-                    value={c.from}
-                    onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                      setForm(f => ({
-                        ...f,
-                        tts: {
-                          ...f.tts,
-                          corrections: f.tts.corrections.map((row, i) =>
-                            i === idx ? { ...row, from: e.target.value } : row),
-                        },
-                      }))
-                    }
-                    placeholder="text on air (e.g. GHz)"
-                    maxLength={80}
-                    className="max-w-[220px] min-w-0 flex-1"
-                  />
-                  <span className="shrink-0 text-[11px] text-muted">reads as</span>
-                  <Input
-                    value={c.to}
-                    onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                      setForm(f => ({
-                        ...f,
-                        tts: {
-                          ...f.tts,
-                          corrections: f.tts.corrections.map((row, i) =>
-                            i === idx ? { ...row, to: e.target.value } : row),
-                        },
-                      }))
-                    }
-                    placeholder="spoken form (e.g. gigahertz)"
-                    maxLength={160}
-                    className="max-w-[260px] min-w-0 flex-1"
-                  />
-                  <Btn
-                    sm
-                    title="Remove correction"
-                    className="shrink-0"
-                    onClick={() =>
-                      setForm(f => ({
-                        ...f,
-                        tts: { ...f.tts, corrections: f.tts.corrections.filter((_, i) => i !== idx) },
-                      }))
-                    }
-                  >
-                    <Trash2 size={12} />
-                  </Btn>
-                </div>
-              ))}
-            </div>
-          </ScrollArea>
-          <div>
-            <Btn
-              // 100 mirrors the server-side TTS_CORRECTIONS_LIMIT.
-              disabled={form.tts.corrections.length >= 100}
-              onClick={() =>
-                setForm(f => ({
-                  ...f,
-                  tts: { ...f.tts, corrections: [...f.tts.corrections, { from: '', to: '' }] },
-                }))
-              }
-            >
-              Add correction
-            </Btn>
-          </div>
-        </div>
-      </Card>
+      {/* Speech corrections moved to /admin/moods (MoodsPanel). */}
 
       <SaveBar
         note={ttsDirty


### PR DESCRIPTION
## What

Answers "can we make moods editable?" — yes. The mood system was the hardcoded part (genres are already dynamic from Navidrome). This makes it operator-editable and moves it, plus the Festivals calendar and the TTS Speech-corrections dictionary, onto a **new `/admin/moods` sidebar page**, out of Settings.

Spec: `docs/superpowers/specs/2026-07-23-editable-moods-design.md`.

## What became editable
- **Mood vocabulary** — add / remove / rename any mood, each with its CLAP sound-prompt (`settings.moods`).
- **Time-of-day → mood** — the 8 fixed day-periods (`settings.moodSchedule`).
- **Weather → mood** — the 6 fixed conditions (`settings.weatherMoods`).
- **Festivals** + **Speech corrections** — relocated onto the same page.

## How
- Three new **seeded-but-editable** settings keys, mirroring the Festivals pattern (seed-on-absent, `validate*Strict`, per-key `update()` branch, no Liquidsoap restart).
- Every consumer now reads the **live vocabulary** through new accessors (`moodVocab` / `moodEntries` / `moodPromptFor` / `moodScheduleFor` / `weatherMoodFor`) — audio-moods, embeddings, the LLM tagger prompts (now functions), the seed selector, the show-generate Zod schema (built per-call), `context.ts`'s two maps, and the routes.
- **Self-healing derived data:** editing the vocabulary/prompts bumps the existing `moodVocabHash` / `promptVocabHash`, so audio moods re-score on the next analysis pass and LLM tags re-tag on the next `--upgrade`.
- **In-use removal is rejected** (`assertNoOrphanMoods`) naming the referring show / festival / schedule / weather slot; a rename is a two-step.
- **Speech corrections move is UI-only** — `settings.tts.corrections`, its validator, and runtime are unchanged.

## Tests / checks
- New `controller/scripts/moods.test.ts` (accessors + seed defaults).
- `controller` + `web` lint (`eslint . && tsc --noEmit`) green; full controller suite **45/45** passing.

## Notes / follow-ups
- **Page name** defaulted to **"Moods"** — since it now also holds Festivals + pronunciation, happy to rename ("DJ" / "Programming" / "Voice"); one line in `NAV_SECTIONS`.
- **`community/registry.ts`** intentionally still validates *imported shared* configs against the default vocab (not the local custom one).
- **Follow-up:** `web/components/admin/PlaylistBuilderPanel.tsx` still hardcodes its mood list — custom moods work everywhere else but won't list in the playlist-builder picker until that panel reads the API vocab.