### PR TITLE
docs(web): reflect Moods & Imaging admin pages in manual + landing

### DIFF
--- a/web/components/manual/AdminSettings.tsx
+++ b/web/components/manual/AdminSettings.tsx
@@ -32,12 +32,13 @@ export default function AdminSettings() {
             with a way to step into the autonomous DJ and steer it directly.
           </li>
           <li>
-            <strong>Programming — Library, Shows, Personas, Skills.</strong> Everything
-            that shapes what the station plays and who it sounds like.
+            <strong>Programming — Library, Shows, Personas, Skills, Imaging, Moods.</strong>{' '}
+            Everything that shapes what the station plays and who it sounds like.
           </li>
           <li>
-            <strong>System — Stats, Settings, Debug.</strong> How the station is behaving
-            under the hood, the engine-room settings, and a live diagnostic view.
+            <strong>System — Stats, Connect, Settings, Debug.</strong> How the station is
+            behaving under the hood, the ways to plug other tools into it, the engine-room
+            settings, and a live diagnostic view.
           </li>
         </ul>
       </section>
@@ -53,7 +54,11 @@ export default function AdminSettings() {
           <li>
             <strong>Library</strong> — search the music library and check how well it's
             been mood-tagged. The tagger labels tracks with a mood so the DJ can pick by
-            feel; this is where you watch its progress.
+            feel; this is where you watch its progress. Two doorways open from here: the{' '}
+            <strong>Playlist Builder</strong>, where you generate a set from a vibe prompt
+            and tuning, then save it for the DJ and shows to draw on, and the{' '}
+            <Link href="/manual/observatory" className="bs-link">Library Observatory</Link>,
+            a visual map of everything the station has heard.
           </li>
           <li>
             <strong>Shows</strong> — a show is a reusable definition: a name, a topic, a
@@ -71,6 +76,25 @@ export default function AdminSettings() {
             <strong>Skills</strong> — the real-world segments the autonomous DJ can run:
             weather, news, now-playing digs, facts, web search. Toggle each on or off
             station-wide.
+          </li>
+          <li>
+            <strong>Imaging</strong> — the sounds the DJ drops between and over the music.
+            Three tabs: <strong>Jingles</strong> (the short station idents rotated between
+            tracks, plus how often one plays), <strong>SFX</strong> (stingers mixed under
+            the DJ's voice mid-break), and <strong>Beds</strong> (instrumentals the DJ
+            talks over when a link runs long). Render each through the configured voice or
+            a text-to-sound prompt, or import your own audio; new files are picked up
+            automatically.
+          </li>
+          <li>
+            <strong>Moods</strong> — the station's mood vocabulary and how the autonomous
+            DJ reaches for it. Four tabs: <strong>Vocabulary</strong> (the moods every
+            track is tagged with, each with an optional sound description for audio
+            tagging), <strong>Moments</strong> (which mood each part of the day and each
+            weather condition leans into), <strong>Festivals</strong> (the calendar that
+            nudges the mood on the day), and <strong>Speech</strong> (pronunciation fixes
+            applied to every spoken line). Edit the vocabulary and every show, festival,
+            and auto-DJ pick draws from it.
           </li>
         </ul>
       </section>
@@ -107,24 +131,19 @@ export default function AdminSettings() {
             (DuckDuckGo, Tavily, or a self-hosted SearXNG).
           </li>
           <li>
-            <strong>Jingles</strong> — the short pre-rendered idents the station rotates
-            between music tracks, and how often one plays. Render them through the
-            configured voice, or import your own mp3/wav; new files are picked up
-            automatically.
+            <strong>Skin &amp; themes</strong> — the player's default face (skin) and the
+            station-wide colour palette. Covered in{' '}
+            <Link href="/manual/themes" className="bs-link">Skins &amp; Themes</Link>.
           </li>
           <li>
-            <strong>Sound FX</strong> — the library of stingers the DJ can drop into a
-            spoken break. Generate one from a text prompt, or import your own audio file
-            (no ElevenLabs key needed). Toggle the whole library on or off.
+            <strong>Likes</strong> — the listener heart button: whether it shows, whether a
+            like stars the track in Navidrome, and whether recent likes nudge what the DJ
+            plays.
           </li>
           <li>
-            <strong>Theme &amp; Festivals</strong> — the station-wide colour palette, and
-            the festival calendar that nudges the DJ's mood on the day.
-          </li>
-          <li>
-            <strong>Scrobbling, Archives, Webhooks &amp; Backup</strong> — scrobble plays
-            to Last.fm / ListenBrainz, record the broadcast to hourly files, fire outbound
-            webhooks on station events, and export or restore the whole station's config.
+            <strong>Scrobbling, Archives &amp; Backup</strong> — scrobble plays to Last.fm
+            / ListenBrainz, record the broadcast to hourly files, and export or restore the
+            whole station's config.
           </li>
           <li>
             <strong>Danger zone</strong> — the broadcast controls that bite: crossfade

--- a/web/components/manual/ModelsAndTokens.tsx
+++ b/web/components/manual/ModelsAndTokens.tsx
@@ -143,7 +143,7 @@ export default function ModelsAndTokens() {
             calls per hour.
           </li>
           <li>
-            <strong>Sound FX off</strong> (Admin &rarr; Sound FX) — with the effects
+            <strong>Sound FX off</strong> (Admin &rarr; Imaging &rarr; SFX) — with the effects
             library disabled, the DJ is no longer shown the catalogue of stingers when it
             plans a segment, which trims that prompt.
           </li>

--- a/web/components/what/BehindTheDesk.tsx
+++ b/web/components/what/BehindTheDesk.tsx
@@ -45,10 +45,28 @@ const PANELS = [
       'Search the Navidrome library by text, mood, and energy, queue any track, and browse recent additions. The mood tagger walks the library album-by-album and classifies every track.',
   },
   {
+    eyebrow: 'PLAYLISTS',
+    title: 'A generator, not a spreadsheet.',
+    body:
+      'Describe a set in a line, drop in a seed track or artist, and the Playlist Builder curates a running order from your library, with an energy arc you shape and mood, genre, era, and tempo to tune. Save it for a show to anchor to, or for the DJ to draw on.',
+  },
+  {
+    eyebrow: 'IMAGING',
+    title: 'The sounds between the songs.',
+    body:
+      'Jingles are the station idents rotated between tracks, SFX are stingers mixed under the DJ’s voice, and beds are instrumentals the host talks over when a link runs long. Render each from the configured voice or a text-to-sound prompt, or import your own audio.',
+  },
+  {
+    eyebrow: 'MOODS',
+    title: 'The vocabulary of feeling.',
+    body:
+      'The words the library is tagged with, and how the DJ reaches for them: which mood each part of the day and each weather condition leans into, a festival calendar that colors the day, and pronunciation fixes for the voice. Edit the list and every show, festival, and auto-pick draws from it.',
+  },
+  {
     eyebrow: 'DEBUG & STATS',
     title: 'Health and diagnostics.',
     body:
-      'Debug and Stats show health, Liquidsoap logs, LLM call history, and usage at a glance. DJ Doc runs a full station check-up and has your own LLM review the findings. Settings (TTS, LLM, mixer, jingles) and a danger zone that starts, stops, and restarts the broadcast.',
+      'Debug and Stats show health, Liquidsoap logs, LLM call history, and usage at a glance. DJ Doc runs a full station check-up and has your own LLM review the findings. Settings (TTS, LLM, mixer, streams) and a danger zone that starts, stops, and restarts the broadcast.',
   },
 ];
 

--- a/web/content/news/2026-07-23-two-new-pages-in-the-console.md
+++ b/web/content/news/2026-07-23-two-new-pages-in-the-console.md
@@ -1,0 +1,32 @@
+---
+title: Two new pages in the console
+date: 2026-07-23
+category: Feature
+author: The SUB/WAVE desk
+excerpt: Imaging and Moods now have their own pages in the admin sidebar. One holds your jingles, stingers and beds; the other the moods your library is tagged with. Both moved out of Settings.
+---
+
+The admin Settings page had grown into a junk drawer. Your jingles sat next to your Icecast bitrate, your festival calendar next to your scrobbling keys. Two things that are really about programming the station, not configuring the box, now have pages of their own. Look for Imaging and Moods in the sidebar, under Programming.
+
+## Imaging: the sounds between the songs
+
+Open admin and click Imaging. It has three tabs.
+
+- Jingles are the station idents rotated between tracks. Render one through the DJ's voice, or drop in your own mp3 or wav. How often a jingle plays lives here too.
+- SFX are the stingers the DJ mixes under its voice mid-break. Type a description to generate one, or upload a file. Uploads need no ElevenLabs key.
+- Beds are instrumentals the DJ talks over when a link runs long, so a two-line story never plays on top of the song it is setting up.
+
+Make each one from the configured voice or a text-to-sound prompt, or import your own audio. New files are picked up on the fly.
+
+## Moods: the words your library is tagged with
+
+Click Moods. Four tabs again.
+
+- Vocabulary is the list of moods every track gets tagged with, each with an optional sound description the analyzer can listen for.
+- Moments sets which mood each part of the day, and each kind of weather, leans into.
+- Festivals is the calendar that colours the mood on the day.
+- Speech is the pronunciation fixes read before every spoken line.
+
+## Why it helps
+
+The mood list used to live in the code. Changing it meant a rebuild. Now it is a text box, and every show, festival, and auto-pick draws from whatever words you put there. The jingles, stingers and beds moved for a plainer reason: they are audio you make and manage, not knobs you set once, so they belong together in one room instead of buried three sections deep in Settings.


### PR DESCRIPTION
## What

Moods and Imaging now have their own admin sidebar pages, and several controls moved out of Settings. The manual and public landing page still described the old layout. This updates them to match.

## Where things live now
- **Imaging** (Programming) — Jingles, SFX, Beds (was three Settings sections)
- **Moods** (Programming) — mood Vocabulary, Moments (time/weather → mood maps), Festivals, Speech corrections (was scattered across Settings + the TTS tab)
- **Webhooks** — moved to Connect (was in Settings)
- **Playlist Builder** — reached from Library's doorway; was never in the manual or on the landing page

## Changes
- **`manual/admin` (Admin & Settings)**
  - Group overview: Programming now lists Imaging + Moods; System now lists Connect
  - Library bullet notes the Playlist Builder and Library Observatory doorways
  - New Imaging and Moods bullets (with their tabs)
  - Settings section: drop the moved Jingles / Sound FX / Festivals / Webhooks bullets; add **Skin & themes** and **Likes**
- **`manual/llm` (Models & Tokens)** — the Sound FX toggle pointer now reads *Admin → Imaging → SFX*
- **Landing — "Behind the desk"** — add **Playlists**, **Imaging**, and **Moods** cards; drop the stale "jingles" mention from the Settings blurb

## Verification
`npm run lint` (eslint + tsc) passes in `web/`. Docs/landing copy only — no runtime code touched.