### PR TITLE
fix(settings): tolerate stale theme ids instead of bricking show saves & restores

### DIFF
--- a/controller/scripts/show-theme-id.test.ts
+++ b/controller/scripts/show-theme-id.test.ts
@@ -1,0 +1,98 @@
+// Regression tests for validateShowsStrict()'s per-show theme override
+// (settings.ts). A show can pin `themeId` to a station theme. Built-in theme
+// ids were RENAMED in 58c3782b ("sunset"/"lab"/"neon"/"press" retired for
+// "blueprint"/"flare"/"recon"/"signal"), so installs that had a show pinned to
+// a now-retired id carried a themeId that no longer resolves.
+//
+// The bug (reported on Discord): validateShowsStrict THREW on that stale id.
+// Because update() re-validates the WHOLE shows array on any shows/schedule
+// save — and POST /shows merges one edit into the full existing array — a
+// single poisoned show bricked every show create/edit, schedule edit, and full
+// restore with `shows[N].themeId "sunset" is not a known theme id`. The theme
+// system already tolerates stale ids everywhere else (the lenient load path and
+// serve-time getTheme() fall back to the station default), so strict validation
+// must DROP an unknown id to "" rather than throw. It must NOT weaken any other
+// strictness, and must never discard a valid (still-known) pick.
+//
+// Run: `tsx scripts/show-theme-id.test.ts`.
+
+import assert from 'node:assert/strict';
+import { validateShowsStrict } from '../src/settings.js';
+
+const personas = [{ id: 'p_host' }, { id: 'p_guest' }];
+const allowed = new Set(['classic-light', 'vinyl', 'blueprint']);
+
+// ── the reported bug: a stale themeId must not brick the save ─────────────────
+
+// A single show pinned to a retired built-in id validates and drops the id to
+// "" (fall back to the station theme), instead of throwing.
+{
+  const out = validateShowsStrict(
+    [{ name: 'Sunset Show', personaId: 'p_host', themeId: 'sunset' }],
+    personas,
+    allowed,
+  );
+  assert.equal(out.length, 1, 'show survives validation');
+  assert.equal(out[0].themeId, '', 'stale "sunset" themeId is dropped to ""');
+  assert.equal(out[0].name, 'Sunset Show', 'the rest of the show is preserved');
+}
+
+// The exact reported shape: editing one show while ANOTHER show (shows[1])
+// still carries the retired id. The whole array must validate — the poisoned
+// sibling can no longer block the edit — and only its dead id is dropped.
+{
+  const out = validateShowsStrict(
+    [
+      { name: 'Breakfast', personaId: 'p_host', themeId: 'vinyl' },
+      { name: 'Old Show', personaId: 'p_guest', themeId: 'sunset' },
+    ],
+    personas,
+    allowed,
+  );
+  assert.equal(out.length, 2, 'both shows validate');
+  assert.equal(out[0].themeId, 'vinyl', 'the edited show keeps its valid theme');
+  assert.equal(out[1].themeId, '', 'the poisoned sibling only loses its dead id');
+}
+
+// ── a valid pick is never discarded ───────────────────────────────────────────
+
+{
+  const out = validateShowsStrict(
+    [{ name: 'Themed', personaId: 'p_host', themeId: 'blueprint' }],
+    personas,
+    allowed,
+  );
+  assert.equal(out[0].themeId, 'blueprint', 'a still-known themeId is preserved verbatim');
+}
+
+// Empty / missing themeId stays "" (no override) — unchanged behaviour.
+{
+  const out = validateShowsStrict(
+    [
+      { name: 'A', personaId: 'p_host', themeId: '' },
+      { name: 'B', personaId: 'p_host' },
+    ],
+    personas,
+    allowed,
+  );
+  assert.equal(out[0].themeId, '', 'explicit empty themeId stays empty');
+  assert.equal(out[1].themeId, '', 'missing themeId stays empty');
+}
+
+// ── strictness is otherwise intact — we only softened the themeId branch ──────
+
+// A dangling persona reference is still a hard error.
+assert.throws(
+  () => validateShowsStrict([{ name: 'Bad', personaId: 'p_nope' }], personas, allowed),
+  /personaId must reference an existing persona/,
+  'unknown personaId still throws',
+);
+
+// A blank name is still a hard error (proves the theme fix did not blanket-soften).
+assert.throws(
+  () => validateShowsStrict([{ name: '', personaId: 'p_host' }], personas, allowed),
+  /name must be 1-60 chars/,
+  'invalid name still throws',
+);
+
+console.log('show-theme-id: all assertions passed');

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -3013,7 +3013,7 @@ export function validatePersonasStrict(raw) {
   });
 }
 
-function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>, moodNames: string[] = SHOW_MOODS) {
+export function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>, moodNames: string[] = SHOW_MOODS) {
   if (!Array.isArray(raw)) throw new Error('shows must be an array');
   if (raw.length > SHOWS_LIMIT) throw new Error(`shows must be at most ${SHOWS_LIMIT} entries`);
   const personaIds = personas.map(p => p.id);
@@ -3047,13 +3047,24 @@ function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>, moodNa
     // Optional per-show theme override. Empty/missing means "fall back to the
     // station default while this show is on air". The allow-set is built once
     // by update() so we stay sync here.
+    //
+    // A stale id (a retired built-in like the old "sunset"/"neon" palettes,
+    // renamed in 58c3782b, or a custom theme file deleted under our feet) is
+    // DROPPED to "" rather than throwing — same tolerance as the lenient load
+    // path and the serve-time getTheme() fallback. Throwing here bricked EVERY
+    // shows/schedule save and full restore for any install still carrying one
+    // retired id on one show, because update() re-validates the whole array
+    // (issue #917 is the theme.active twin of this). Self-heals: the dead id
+    // is gone the next time the array is persisted. This never discards a fresh
+    // operator pick — those come from the live theme list — only a dead one.
     let themeId = '';
     if (item.themeId !== undefined && item.themeId !== null && item.themeId !== '') {
       const v = String(item.themeId).trim();
-      if (!allowedThemeIds.has(v)) {
-        throw new Error(`shows[${i}].themeId "${v}" is not a known theme id`);
+      if (allowedThemeIds.has(v)) {
+        themeId = v;
+      } else {
+        console.warn(`[shows] dropping unknown themeId "${v}" from "${name}" — falling back to the station theme`);
       }
-      themeId = v;
     }
     // Optional music-steering filters — all default to "no constraint" and all
     // multi-value lists (#929, legacy singular fields still accepted). Genres
@@ -3713,10 +3724,16 @@ export async function update(patch) {
     if (t.active !== undefined) {
       const v = String(t.active ?? '').trim();
       if (!v) throw new Error('theme.active must be a theme id');
-      if (!(await isValidThemeId(v))) {
-        throw new Error(`theme.active "${v}" is not a known theme id`);
+      // A stale active theme (a retired built-in renamed in 58c3782b, or a
+      // custom theme that isn't on disk) falls back to the built-in default
+      // rather than failing the save — same tolerance as shows[].themeId above
+      // and the serve-time getTheme() fallback, and the same precedent as the
+      // activeDjPromptId reset. Throwing here aborted the whole restore for any
+      // install whose active theme id had since been retired (issue #917).
+      next.theme.active = (await isValidThemeId(v)) ? v : DEFAULT_THEME_ID;
+      if (next.theme.active !== v) {
+        console.warn(`[theme] active theme "${v}" is not a known theme id — falling back to "${DEFAULT_THEME_ID}"`);
       }
-      next.theme.active = v;
     }
   }
   // Mood system (context-only — no Liquidsoap restart). Validate the vocabulary


### PR DESCRIPTION
## Problem

Operators (multiple, reported on Discord) could not create or edit shows, and could not restore backups. The error at the bottom of the page:

> restore error: shows[1].themeId "sunset" is not a known theme id

A saved show appeared to persist but vanished on refresh; edits silently didn't apply; and backup/restore (including Docker → Community AIO cross-install) aborted with the same error.

## Root cause

Built-in theme ids were **renamed** in `58c3782b` — `sunset`/`lab`/`neon`/`press` were retired for `blueprint`/`flare`/`recon`/`signal`. Any install that had a show (or the station `theme.active`) pinned to a now-retired id carried a `themeId` that no longer resolves.

`validateShowsStrict` **threw** on that stale id. Because `settings.update()` re-validates the *whole* shows array on any shows/schedule save — and `POST /shows` merges one edit into the full existing array — a **single** poisoned show bricked *every* show create/edit, schedule edit, and full restore. `theme.active` had the identical failure mode for the station theme, which a cross-install restore hits next.

The theme system already tolerates stale ids everywhere else: the lenient load path keeps them, and serve-time `getTheme()` falls back to the station default (`routes/public.ts`). The strict `throw` was the lone inconsistency. (This is the retired-**built-in** twin of #917, which only handled custom themes missing from disk during restore.)

## Fix

- `validateShowsStrict`: an unknown per-show `themeId` is **dropped to `""`** (fall back to the station theme) instead of throwing.
- `theme.active`: an unknown active id **resets to the built-in default** (`DEFAULT_THEME_ID`) instead of throwing — mirroring the existing `activeDjPromptId` reset right above it.
- Both log a `console.warn` breadcrumb. **Self-healing**: the dead id is gone the next time the config is persisted.
- A still-known pick is never discarded (real picks always come from the live theme list), and no other strictness is weakened.

## Testing

- New `controller/scripts/show-theme-id.test.ts` reproduces the exact reported multi-show scenario (editing one show while `shows[1]` still carries `sunset`) and pins: stale id dropped, valid id preserved, empty stays empty, and unrelated strictness (bad persona, blank name) still throws.
- `npm test` — all 47 test files pass.
- `npm run lint` — 0 errors; `tsc --noEmit` clean.
