### PR TITLE
fix(web): card-wrap admin Imaging sections to match Moods/Skills

### DIFF
--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import type { ComponentType, ReactNode } from 'react';
+import type { ComponentType, CSSProperties, ReactNode } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { AnimatePresence, m } from 'motion/react';
 import { useDynamicStyle } from '../../hooks/useDynamicStyle';
@@ -246,7 +246,9 @@ export default function AdminShell({ children, defaultOpen = true }: AdminShellP
 
   return (
     <div className="admin-root paper">
-      <SidebarProvider defaultOpen={defaultOpen}>
+      {/* Narrower rail than the shadcn 16rem default — the admin nav is short
+          labels, so ~13rem reclaims horizontal room for the panels. */}
+      <SidebarProvider defaultOpen={defaultOpen} style={{ '--sidebar-width': '13rem' } as CSSProperties}>
         <AdminSidebar pathname={pathname} onSignOut={signOut} />
         <SidebarInset className="min-w-0 bg-transparent">
           <TopBar pathname={pathname} />

--- a/web/components/admin/MoodsPanel.tsx
+++ b/web/components/admin/MoodsPanel.tsx
@@ -4,8 +4,8 @@ import { useCallback, useEffect, useState } from 'react';
 import { Trash2, Palette, Clock, CalendarDays, Volume2 } from 'lucide-react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { notify, errorMessage } from '../../lib/notify';
-import { cn } from '../../lib/cn';
 import { Card, Btn, Eyebrow } from './ui';
+import { SectionTabs } from './SectionTabs';
 import { Input } from '../ui/input';
 import { ScrollArea } from '../ui/scroll-area';
 import {
@@ -206,43 +206,8 @@ export default function MoodsPanel() {
             pick draws from it.
           </div>
         </div>
-        {/* Full-width tab row — active cell filled in the accent, mirroring the
-            Imaging page. */}
-        <div className="grid grid-cols-4" role="tablist" aria-label="Moods sections">
-          {tabs.map((t, i) => {
-            const active = tab === t.id;
-            const Icon = t.icon;
-            return (
-              <button
-                key={t.id}
-                type="button"
-                role="tab"
-                aria-selected={active}
-                onClick={() => selectTab(t.id)}
-                className={cn(
-                  'flex items-center justify-center gap-2.5 px-4 py-4 text-[13px] font-bold tracking-[0.18em] uppercase transition-colors',
-                  i > 0 && 'border-l border-ink',
-                  active
-                    ? 'bg-[var(--accent)] text-white'
-                    : 'bg-[var(--ink-softer)] text-ink hover:bg-ink/10',
-                )}
-              >
-                <Icon size={17} strokeWidth={2} aria-hidden />
-                <span>{t.label}</span>
-                {t.count != null && (
-                  <span
-                    className={cn(
-                      'ml-0.5 min-w-[1.5em] rounded-full px-1.5 py-0.5 text-[10px] leading-none font-bold',
-                      active ? 'bg-white/25 text-white' : 'bg-ink/10 text-muted',
-                    )}
-                  >
-                    {t.count}
-                  </span>
-                )}
-              </button>
-            );
-          })}
-        </div>
+        {/* Shared editorial section-tabs, edge-to-edge along the card's foot. */}
+        <SectionTabs tabs={tabs} value={tab} onChange={selectTab} label="Moods sections" />
       </section>
 
       {err && (

--- a/web/components/admin/SectionTabs.tsx
+++ b/web/components/admin/SectionTabs.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+/* Shared admin section-tab row — the inverted-ink editorial tabs first used on
+   the Imaging page, now the single implementation across Imaging / Moods /
+   Connect (unified so the three pages can't drift). Renders as the foot of a
+   hero card: edge-to-edge, a top hairline, the active cell filled in ink with
+   an accent top-rule. Wraps to two columns on phones for 4+ tabs so the labels
+   never overlap; three-or-fewer tabs keep a single row and just shrink. */
+
+import type { LucideIcon } from 'lucide-react';
+import { cn } from '../../lib/cn';
+
+export interface SectionTab {
+  id: string;
+  label: string;
+  count?: number;
+  icon: LucideIcon;
+}
+
+// Mobile columns → desktop columns. 4+ tabs drop to a 2-col grid on phones
+// (a single row of long uppercase labels overflows a ~390px screen).
+const COLS: Record<number, string> = {
+  1: 'grid-cols-1',
+  2: 'grid-cols-2',
+  3: 'grid-cols-3',
+  4: 'grid-cols-2 sm:grid-cols-4',
+  5: 'grid-cols-2 sm:grid-cols-5',
+  6: 'grid-cols-3 sm:grid-cols-6',
+};
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+export function SectionTabs({
+  tabs, value, onChange, label,
+}: {
+  tabs: SectionTab[];
+  value: string;
+  onChange: (id: string) => void;
+  label: string;
+}) {
+  // 4+ tabs wrap to 2 columns on mobile, so the dividers must follow the wrap
+  // (left rule on the right column, top rule on the second row). Fewer tabs
+  // stay a single row and just need a left rule between cells.
+  const wraps = tabs.length >= 4;
+  return (
+    <nav
+      className={cn('grid border-t border-ink', COLS[tabs.length] ?? 'grid-cols-2 sm:grid-cols-4')}
+      role="tablist"
+      aria-label={label}
+    >
+      {tabs.map((t) => {
+        const active = value === t.id;
+        const Icon = t.icon;
+        return (
+          <button
+            key={t.id}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(t.id)}
+            className={cn(
+              'relative flex cursor-pointer items-center justify-center gap-2 px-2 py-[17px] transition-colors sm:gap-2.5 sm:px-3 sm:py-[19px]',
+              wraps
+                ? 'border-ink max-sm:even:border-l sm:[&:not(:first-child)]:border-l max-sm:[&:nth-child(n+3)]:border-t'
+                : 'border-ink [&:not(:first-child)]:border-l',
+              active ? 'bg-ink text-bg' : 'text-ink hover:bg-[var(--ink-soft)]',
+            )}
+          >
+            {active && (
+              <span className="absolute -top-px -right-px -left-px h-1 bg-[var(--accent)]" aria-hidden />
+            )}
+            <Icon size={16} strokeWidth={2} aria-hidden />
+            <span className="font-mono text-[11px] font-bold tracking-[0.1em] uppercase sm:text-[12px] sm:tracking-[0.16em]">
+              {t.label}
+            </span>
+            {t.count != null && (
+              <span className="min-w-[14px] border border-current px-1.5 py-[2px] text-center font-mono text-[10px] leading-none font-bold">
+                {pad2(t.count)}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/web/components/admin/connect/ConnectPanel.tsx
+++ b/web/components/admin/connect/ConnectPanel.tsx
@@ -14,7 +14,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useAdminAuth } from '../../../lib/adminAuth';
 import { notify, errorMessage } from '../../../lib/notify';
-import { Card, Btn, Eyebrow, Seg } from '../ui';
+import type { LucideIcon } from 'lucide-react';
+import { Braces, Boxes, Cable, Webhook } from 'lucide-react';
+import { Card, Btn, Eyebrow } from '../ui';
+import { SectionTabs } from '../SectionTabs';
 import type { Catalog } from './types';
 import EndpointsTab from './EndpointsTab';
 import McpTab from './McpTab';
@@ -23,11 +26,11 @@ import WebhooksPanel from '../WebhooksPanel';
 
 type TabId = 'endpoints' | 'mcp' | 'integrations' | 'webhooks';
 
-const TABS: { id: TabId; label: string }[] = [
-  { id: 'endpoints', label: 'Endpoints' },
-  { id: 'mcp', label: 'MCP' },
-  { id: 'integrations', label: 'Integrations' },
-  { id: 'webhooks', label: 'Webhooks' },
+const TABS: { id: TabId; label: string; icon: LucideIcon }[] = [
+  { id: 'endpoints', label: 'Endpoints', icon: Braces },
+  { id: 'mcp', label: 'MCP', icon: Boxes },
+  { id: 'integrations', label: 'Integrations', icon: Cable },
+  { id: 'webhooks', label: 'Webhooks', icon: Webhook },
 ];
 
 export default function ConnectPanel() {
@@ -107,28 +110,23 @@ export default function ConnectPanel() {
   return (
     <div className="grid gap-4">
       <section className="card">
-        <div className="border-b border-ink p-4">
-          <Eyebrow className="text-vermilion">connect</Eyebrow>
-          <div className="mt-1.5 text-[22px] font-extrabold tracking-[-0.02em]">
-            Everything wired to {catalog.station}.
+        <div className="flex flex-wrap items-start justify-between gap-4 border-b border-ink p-4">
+          <div className="min-w-0">
+            <Eyebrow className="text-vermilion">connect</Eyebrow>
+            <div className="mt-1.5 text-[22px] font-extrabold tracking-[-0.02em]">
+              Everything wired to {catalog.station}.
+            </div>
+            <div className="mt-1 text-[11px] leading-[1.6] text-muted">
+              Discover the HTTP API, try it live, wire up an MCP client, or point a speaker at the stream.
+              All URLs below are the real addresses for this station (<code>{catalog.origin}</code>).
+            </div>
           </div>
-          <div className="mt-1 text-[11px] leading-[1.6] text-muted">
-            Discover the HTTP API, try it live, wire up an MCP client, or point a speaker at the stream.
-            All URLs below are the real addresses for this station (<code>{catalog.origin}</code>).
-          </div>
-        </div>
-        <div className="flex flex-wrap items-center gap-3 bg-[var(--ink-softer)] p-3.5">
-          <Seg
-            value={tab}
-            options={TABS.map(t => ({ id: t.id, label: t.label }))}
-            accent
-            onChange={selectTab}
-          />
-          <span className="ml-auto" />
-          <Btn sm onClick={downloadOpenApi} title="Download an OpenAPI 3.1 spec for this station">
+          <Btn sm onClick={downloadOpenApi} className="flex-none" title="Download an OpenAPI 3.1 spec for this station">
             Download OpenAPI
           </Btn>
         </div>
+        {/* Shared editorial section-tabs, edge-to-edge along the card's foot. */}
+        <SectionTabs tabs={TABS} value={tab} onChange={selectTab} label="Connect sections" />
       </section>
 
       {tab === 'endpoints' && <EndpointsTab catalog={catalog} adminFetch={adminFetch} />}

--- a/web/components/admin/imaging/BedsSection.tsx
+++ b/web/components/admin/imaging/BedsSection.tsx
@@ -79,6 +79,7 @@ export function BedsSection({ bedsData, busy, uploadBed, onDelete, data, saveSet
         title="Beds"
         sub="Instrumentals the DJ talks over between songs: the song ends, the bed carries the talk, and the next song ramps in under the DJ’s closing words."
         metrics={<TabMetric accent n={pad2(list.length)} l="beds" />}
+        actions={<Btn sm onClick={() => setModal(true)} disabled={busy}>Import</Btn>}
       />
 
       {/* On/off */}
@@ -170,10 +171,7 @@ export function BedsSection({ bedsData, busy, uploadBed, onDelete, data, saveSet
 
       {/* Library */}
       <PanelBox>
-        <PanelHead
-          label={`bed library · ${pad2(list.length)}`}
-          right={<Btn sm onClick={() => setModal(true)} disabled={busy}>Import</Btn>}
-        />
+        <PanelHead label={`bed library · ${pad2(list.length)}`} />
         {list.length === 0 ? (
           <EmptyState caption="beds can’t be generated — import an instrumental" />
         ) : (

--- a/web/components/admin/imaging/ImagingPanel.tsx
+++ b/web/components/admin/imaging/ImagingPanel.tsx
@@ -18,8 +18,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Music, AudioLines, Waves } from 'lucide-react';
 import { useAdminAuth } from '../../../lib/adminAuth';
 import { notify, errorMessage } from '../../../lib/notify';
-import { cn } from '../../../lib/cn';
-import { Wave } from '../ui';
+import { SectionTabs } from '../SectionTabs';
 import { V3Alert } from '../../ui/alert';
 import { V3AlertDialog } from '../../ui/alert-dialog';
 import type { SettingsData, SaveSettings } from '../settings/shared';
@@ -314,7 +313,7 @@ export default function ImagingPanel() {
           reads as a card like the rest of the admin (Moods / Skills / Shows)
           rather than floating on the page background. */}
       <section className="card">
-      <header className="p-6 lg:p-7">
+      <header className="p-4 lg:p-5">
         <div className="flex items-baseline justify-between gap-4">
           <MonoLabel>imaging</MonoLabel>
           <span className="flex items-center gap-[7px] font-mono text-[10px] tracking-[0.14em] text-muted uppercase">
@@ -322,21 +321,20 @@ export default function ImagingPanel() {
             live · refreshed every 3s
           </span>
         </div>
-        <h1 className="mt-3.5 font-display text-[54px] leading-[1.02] font-semibold tracking-[-0.01em] [text-wrap:balance] lg:text-[62px]">
-          The sounds between the&nbsp;songs.
-        </h1>
-        <div aria-hidden className="my-6">
-          <Wave bars={88} seed={7} h={42} />
-        </div>
-        <div className="flex flex-wrap items-start justify-between gap-x-10 gap-y-5 border-t border-ink pt-[18px]">
-          <p className="m-0 max-w-[62ch] text-[14px] leading-[1.65] [text-wrap:pretty] text-muted">
-            Everything the DJ drops between and over the music:{' '}
-            <strong className="font-semibold text-ink">jingles</strong> are the station idents
-            played between tracks, <strong className="font-semibold text-ink">SFX</strong> are
-            stingers mixed under the DJ&rsquo;s voice, and{' '}
-            <strong className="font-semibold text-ink">beds</strong> are instrumentals the DJ
-            talks over when a link runs long.
-          </p>
+        <div className="mt-2 flex flex-wrap items-start justify-between gap-x-8 gap-y-3">
+          <div className="min-w-0">
+            <div className="text-[22px] leading-tight font-extrabold tracking-[-0.02em]">
+              The sounds between the songs.
+            </div>
+            <p className="mt-1 max-w-[62ch] text-[11px] leading-[1.6] [text-wrap:pretty] text-muted">
+              Everything the DJ drops between and over the music:{' '}
+              <strong className="font-semibold text-ink">jingles</strong> are the station idents
+              played between tracks, <strong className="font-semibold text-ink">SFX</strong> are
+              stingers mixed under the DJ&rsquo;s voice, and{' '}
+              <strong className="font-semibold text-ink">beds</strong> are instrumentals the DJ
+              talks over when a link runs long.
+            </p>
+          </div>
           <div className="flex flex-none gap-7">
             <TabMetric big n={pad2(totalAssets)} l="assets" />
             <TabMetric big accent n={ratioMetric} l="jingle ratio" />
@@ -344,46 +342,9 @@ export default function ImagingPanel() {
         </div>
       </header>
 
-      {/* Tab row — three equal cells edge-to-edge along the card's foot, the
-          active one inverted with an accent top-rule so the current section
-          reads at a glance. */}
-      <nav
-        className="grid grid-cols-3 border-t border-ink"
-        role="tablist"
-        aria-label="Imaging sections"
-      >
-        {tabs.map((t, i) => {
-          const active = tab === t.id;
-          const Icon = t.icon;
-          return (
-            <button
-              key={t.id}
-              type="button"
-              role="tab"
-              aria-selected={active}
-              onClick={() => selectTab(t.id)}
-              className={cn(
-                'relative flex cursor-pointer items-center justify-center gap-2.5 px-3 py-[19px] transition-colors',
-                i > 0 && 'border-l border-ink',
-                active ? 'bg-ink text-bg' : 'text-ink hover:bg-[var(--ink-soft)]',
-              )}
-            >
-              {active && (
-                <span className="absolute -top-px -right-px -left-px h-1 bg-[var(--accent)]" aria-hidden />
-              )}
-              <Icon size={16} strokeWidth={2} aria-hidden />
-              <span className="font-mono text-[12px] font-bold tracking-[0.16em] uppercase">
-                {t.label}
-              </span>
-              {t.count != null && (
-                <span className="min-w-[14px] border border-current px-1.5 py-[2px] text-center font-mono text-[10px] leading-none font-bold">
-                  {pad2(t.count)}
-                </span>
-              )}
-            </button>
-          );
-        })}
-      </nav>
+      {/* Tab row — the shared editorial section-tabs, edge-to-edge along the
+          card's foot. */}
+      <SectionTabs tabs={tabs} value={tab} onChange={selectTab} label="Imaging sections" />
       </section>
 
       {err && (

--- a/web/components/admin/imaging/ImagingPanel.tsx
+++ b/web/components/admin/imaging/ImagingPanel.tsx
@@ -309,9 +309,12 @@ export default function ImagingPanel() {
   ];
 
   return (
-    <div className="max-w-[1060px]">
-      {/* Editorial masthead — the sounds between the songs. */}
-      <header>
+    <div className="grid max-w-[1060px] gap-4">
+      {/* Editorial masthead + tab row, on a lifted card surface so the header
+          reads as a card like the rest of the admin (Moods / Skills / Shows)
+          rather than floating on the page background. */}
+      <section className="card">
+      <header className="p-6 lg:p-7">
         <div className="flex items-baseline justify-between gap-4">
           <MonoLabel>imaging</MonoLabel>
           <span className="flex items-center gap-[7px] font-mono text-[10px] tracking-[0.14em] text-muted uppercase">
@@ -341,16 +344,11 @@ export default function ImagingPanel() {
         </div>
       </header>
 
-      {err && (
-        <div className="mt-7">
-          <V3Alert tone="error" title="controller error">{err}</V3Alert>
-        </div>
-      )}
-
-      {/* Tab row — three equal cells, the active one inverted with an accent
-          top-rule so the current section reads at a glance. */}
+      {/* Tab row — three equal cells edge-to-edge along the card's foot, the
+          active one inverted with an accent top-rule so the current section
+          reads at a glance. */}
       <nav
-        className="mt-[34px] grid grid-cols-3 border border-ink"
+        className="grid grid-cols-3 border-t border-ink"
         role="tablist"
         aria-label="Imaging sections"
       >
@@ -386,8 +384,13 @@ export default function ImagingPanel() {
           );
         })}
       </nav>
+      </section>
 
-      <div className="mt-11">
+      {err && (
+        <V3Alert tone="error" title="controller error">{err}</V3Alert>
+      )}
+
+      <div>
         {tab === 'jingles' && (
           data ? (
             <JinglesSection

--- a/web/components/admin/imaging/JinglesSection.tsx
+++ b/web/components/admin/imaging/JinglesSection.tsx
@@ -94,6 +94,12 @@ export function JinglesSection({
             <TabMetric n={ratioMetric} l="ratio" />
           </>
         }
+        actions={
+          <>
+            <Btn sm onClick={() => setModal('import')} disabled={busy}>Import</Btn>
+            <Btn sm tone="solid" onClick={() => setModal('create')} disabled={busy}>+ Create</Btn>
+          </>
+        }
       />
 
       {/* Frequency */}
@@ -130,15 +136,7 @@ export function JinglesSection({
 
       {/* Library */}
       <PanelBox>
-        <PanelHead
-          label={`jingle library · ${pad2(jingles.length)}`}
-          right={
-            <>
-              <Btn sm onClick={() => setModal('import')} disabled={busy}>Import</Btn>
-              <Btn sm tone="solid" onClick={() => setModal('create')} disabled={busy}>+ Create</Btn>
-            </>
-          }
-        />
+        <PanelHead label={`jingle library · ${pad2(jingles.length)}`} />
         {jingles.length === 0 ? (
           <EmptyState caption="create one via TTS or import your own" />
         ) : (

--- a/web/components/admin/imaging/SfxSection.tsx
+++ b/web/components/admin/imaging/SfxSection.tsx
@@ -66,6 +66,12 @@ export function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uplo
         title="Sound effects"
         sub="Stingers the segment-director agent mixes under its voice during a spoken break. Built-ins ship with the station."
         metrics={<TabMetric accent n={pad2(list.length)} l="effects" />}
+        actions={
+          <>
+            <Btn sm onClick={() => setModal('import')} disabled={busy}>Import</Btn>
+            <Btn sm tone="solid" onClick={() => setModal('create')} disabled={busy}>+ Create</Btn>
+          </>
+        }
       />
 
       {/* On/off */}
@@ -98,15 +104,7 @@ export function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uplo
 
       {/* Library */}
       <PanelBox>
-        <PanelHead
-          label={`effect library · ${pad2(list.length)}`}
-          right={
-            <>
-              <Btn sm onClick={() => setModal('import')} disabled={busy}>Import</Btn>
-              <Btn sm tone="solid" onClick={() => setModal('create')} disabled={busy}>+ Create</Btn>
-            </>
-          }
-        />
+        <PanelHead label={`effect library · ${pad2(list.length)}`} />
         {list.length === 0 ? (
           <EmptyState caption="generate via ElevenLabs or import your own" />
         ) : (

--- a/web/components/admin/imaging/parts.tsx
+++ b/web/components/admin/imaging/parts.tsx
@@ -63,21 +63,27 @@ export function TabMetric({
   );
 }
 
-/** Per-tab masthead: Fraunces headline + description on the left, metrics on
-    the right. Replaces the boxed SectionHeader inside the imaging tabs. */
+/** Per-tab header card: title + description on the left, metrics on the right,
+    and the tab's primary actions on a row below. A card surface (--card-bg)
+    like the rest of the admin, not floating on the page background. */
 export function SectionMasthead({
-  title, sub, metrics,
-}: { title: ReactNode; sub: ReactNode; metrics: ReactNode }) {
+  title, sub, metrics, actions,
+}: { title: ReactNode; sub: ReactNode; metrics?: ReactNode; actions?: ReactNode }) {
   return (
-    <div className="flex flex-wrap items-end justify-between gap-x-6 gap-y-4">
-      <div>
-        <h2 className="font-display text-[34px] leading-[1.1] font-semibold">{title}</h2>
-        <p className="mt-2 max-w-[58ch] text-[13px] leading-[1.6] [text-wrap:pretty] text-muted">
-          {sub}
-        </p>
+    <section className="card">
+      <div className="p-[18px]">
+        <div className="flex flex-wrap items-start justify-between gap-x-6 gap-y-3">
+          <div className="min-w-0">
+            <h2 className="text-[22px] leading-tight font-extrabold tracking-[-0.02em]">{title}</h2>
+            <p className="mt-1.5 max-w-[58ch] text-[12px] leading-[1.6] [text-wrap:pretty] text-muted">
+              {sub}
+            </p>
+          </div>
+          {metrics && <div className="flex flex-none gap-7">{metrics}</div>}
+        </div>
+        {actions && <div className="mt-4 flex flex-wrap items-center gap-2">{actions}</div>}
       </div>
-      <div className="flex flex-none gap-7">{metrics}</div>
-    </div>
+    </section>
   );
 }
 

--- a/web/components/admin/imaging/parts.tsx
+++ b/web/components/admin/imaging/parts.tsx
@@ -25,9 +25,11 @@ export function MonoLabel({ children, className }: { children: ReactNode; classN
   );
 }
 
-/** A bordered editorial panel. Sharp corners, 1px ink border, no shadow. */
+/** A bordered editorial panel. Sharp corners, 1px ink border, no shadow, on
+    the lifted card surface (--card-bg) so sections read as cards over the page
+    background — matching the rest of the admin (Moods / Skills / Shows). */
 export function PanelBox({ children, className }: { children: ReactNode; className?: string }) {
-  return <div className={cn('border border-ink', className)}>{children}</div>;
+  return <div className={cn('border border-ink bg-[var(--card-bg)]', className)}>{children}</div>;
 }
 
 /** Panel header row: mono label on the left, an optional actions cluster on


### PR DESCRIPTION
## What

The recently-shipped **/admin/imaging** page had its masthead, tab row, and content panels sitting directly on the page background, unlike every other admin page (Moods, Skills, Shows) where sections lift onto the `--card-bg` surface as cards.

## Why

Imaging used bare, transparent `border-only` treatments:
- `PanelBox` (all three tabs' content panels) was `border border-ink` with no background fill.
- The editorial masthead + tab row were bare blocks with no card container.

So the content read as floating on the raw page surface rather than as cards.

## Change

- **`parts.tsx`** — `PanelBox` now renders on the `--card-bg` surface (`bg-[var(--card-bg)]`), so the Frequency/Library/SFX/Beds panels lift off the page like the rest of the admin.
- **`ImagingPanel.tsx`** — wrapped the masthead + tab row in a hero `.card` and switched the outer layout to the canonical `grid gap-4` rhythm, mirroring `MoodsPanel`/`SkillsPanel`.

Editorial typography (Fraunces headline, Wave, mono metrics, tab styling) is unchanged — only the surfaces were carded. `npm run lint` (eslint + tsc) passes.