### PR TITLE
feat(imaging): protect the built-in bed & generate beds via ElevenLabs Music

### DIFF
--- a/controller/src/audio/bed-gen.ts
+++ b/controller/src/audio/bed-gen.ts
@@ -1,0 +1,66 @@
+// ElevenLabs Music client. A bed is an instrumental the DJ talks over BETWEEN
+// songs, so — unlike an sfx stinger (sound-generation, ≤22s) — it needs ≥30s of
+// musical audio. That's a different ElevenLabs endpoint: the Music API
+// (/v1/music), where `force_instrumental` guarantees no vocals and
+// `music_length_ms` sets the length. Same credential as the sfx generator and
+// cloud TTS (audio/elevenlabs.ts).
+
+import { writeFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { elevenLabsKey } from './elevenlabs.js';
+
+// mp3 to match the rest of the library; 44.1kHz is the broadcast source rate.
+const ENDPOINT = 'https://api.elevenlabs.io/v1/music?output_format=mp3_44100_128';
+
+// Ceiling on a generated bed. A bed is trimmed per-link (liq_cue_out), so a clip
+// longer than the DJ's longest script is never heard in full — past ~2 min it
+// only burns Music credits. The floor lives in broadcast/beds.ts
+// (MIN_DURATION_SEC); the caller clamps to [floor, this] before calling.
+export const BED_GEN_MAX_SEC = 120;
+
+// The Music API's own absolute bounds, in ms — a defensive clamp so a bad caller
+// can't send an out-of-range length.
+const API_MIN_MS = 3_000;
+const API_MAX_MS = 600_000;
+const DEFAULT_SEC = 45;
+
+// Generate an instrumental bed from a text prompt and write it to outPath (mp3).
+// durationSec is the desired length in seconds (defaults to 45); it is converted
+// to `music_length_ms` and clamped to the API's bounds. Returns the written path.
+export async function generateBed(
+  prompt: string,
+  { durationSec, outPath }: { durationSec?: number; outPath?: string } = {},
+): Promise<string> {
+  if (!prompt || !prompt.trim()) throw new Error('Empty bed prompt');
+  if (!outPath) throw new Error('generateBed requires an outPath');
+  const key = elevenLabsKey();
+  if (!key) {
+    throw new Error('ElevenLabs API key not configured — set it under cloud TTS, or ELEVENLABS_API_KEY');
+  }
+
+  const d = Number(durationSec);
+  const sec = Number.isFinite(d) && d > 0 ? d : DEFAULT_SEC;
+  const musicLengthMs = Math.min(API_MAX_MS, Math.max(API_MIN_MS, Math.round(sec * 1000)));
+
+  const body = {
+    prompt: prompt.trim(),
+    model_id: 'music_v1',
+    force_instrumental: true,
+    music_length_ms: musicLengthMs,
+  };
+
+  const res = await fetch(ENDPOINT, {
+    method: 'POST',
+    headers: { 'xi-api-key': key, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`ElevenLabs music generation failed (${res.status}): ${detail.slice(0, 200)}`);
+  }
+
+  const buf = Buffer.from(await res.arrayBuffer());
+  await mkdir(path.dirname(outPath), { recursive: true });
+  await writeFile(outPath, buf);
+  return outPath;
+}

--- a/controller/src/audio/elevenlabs.ts
+++ b/controller/src/audio/elevenlabs.ts
@@ -1,0 +1,22 @@
+// Shared ElevenLabs key resolution. Both generator clients — sound effects
+// (audio/sfx-gen.ts) and beds (audio/bed-gen.ts) — hit ElevenLabs REST endpoints
+// with the same credential, and both back a "generatorReady" gate in the admin
+// UI. Keeping the resolver here means beds don't depend on the sfx module and
+// the two can never drift on how the key is found.
+
+import * as settings from '../settings.js';
+
+// Resolve the ElevenLabs key the same way llm/speech.js does: a key typed into
+// Settings only counts when the cloud TTS provider is ElevenLabs; otherwise
+// fall back to the ELEVENLABS_API_KEY env var.
+export function elevenLabsKey(): string {
+  const c = settings.get().tts?.cloud || {};
+  const settingsKey = c.provider === 'elevenlabs' ? c.apiKey : '';
+  return settingsKey || process.env.ELEVENLABS_API_KEY || '';
+}
+
+// True when a key is resolvable — backs the admin UI's "needs a key" state for
+// both the sfx and bed generators.
+export function isConfigured(): boolean {
+  return !!elevenLabsKey();
+}

--- a/controller/src/audio/sfx-gen.ts
+++ b/controller/src/audio/sfx-gen.ts
@@ -5,23 +5,13 @@
 
 import { writeFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
-import * as settings from '../settings.js';
+import { elevenLabsKey, isConfigured } from './elevenlabs.js';
 
 const ENDPOINT = 'https://api.elevenlabs.io/v1/sound-generation';
 
-// Resolve the ElevenLabs key the same way llm/speech.js does: a key typed into
-// Settings only counts when the cloud TTS provider is ElevenLabs; otherwise
-// fall back to the ELEVENLABS_API_KEY env var.
-function apiKey() {
-  const c = settings.get().tts?.cloud || {};
-  const settingsKey = c.provider === 'elevenlabs' ? c.apiKey : '';
-  return settingsKey || process.env.ELEVENLABS_API_KEY || '';
-}
-
-// True when a key is resolvable — backs the admin UI's "needs a key" state.
-export function isConfigured() {
-  return !!apiKey();
-}
+// Re-exported for back-compat with call sites that reach isConfigured through
+// this module; the resolver itself lives in audio/elevenlabs.ts now.
+export { isConfigured };
 
 // Generate a sound effect from a text prompt and write it to outPath (mp3).
 // durationSec is optional — ElevenLabs accepts ~0.5–22s; omit it to let the
@@ -32,7 +22,7 @@ export async function generateSfx(
 ) {
   if (!prompt || !prompt.trim()) throw new Error('Empty SFX prompt');
   if (!outPath) throw new Error('generateSfx requires an outPath');
-  const key = apiKey();
+  const key = elevenLabsKey();
   if (!key) {
     throw new Error('ElevenLabs API key not configured — set it under cloud TTS, or ELEVENLABS_API_KEY');
   }

--- a/controller/src/broadcast/beds.ts
+++ b/controller/src/broadcast/beds.ts
@@ -5,21 +5,26 @@
 // CRUD on top. Files live at <stateDir>/beds/<name>.mp3 — on the shared
 // /var/sub-wave mount, so the path the controller writes into next.txt is one
 // the broadcast container can actually open. The sidecar <stateDir>/beds.json
-// maps name → { name, description, durationSec, file, source, createdAt }.
+// maps name → { name, description, prompt?, durationSec, file, source, builtin,
+// createdAt }.
 //
-// Two deliberate differences from sfx:
+// The bundled default is a protected built-in, exactly like sfx: remove() refuses
+// it and the admin UI disables its delete button. The escape hatch for a bed the
+// operator finds annoying is the FEATURE TOGGLE (settings.beds.enabled, off by
+// default), not deletion — turning beds off silences it without losing the asset.
+// (An earlier design made defaults deletable, remembered via a `retired` list;
+// that list is gone now that the default can't be deleted. loadMeta still tolerates
+// a stale `retired` key so old sidecars don't error — it's simply dropped on the
+// next save.)
 //
-//  1. No generate path. A stinger can be rendered from a text prompt; a bed
-//     can't be TTS'd, so the only ways in are the bundled default and upload.
-//  2. Defaults are DELETABLE. sfx built-ins are undeletable because a missing
-//     stinger is harmless; a bed the operator finds annoying is the entire risk
-//     of the feature (see radio.liq's disabled studio bed), so "delete it" must
-//     work and must stick. `retired` records that, so ensureDefaults doesn't
-//     resurrect it on the next boot.
+// Generation: unlike an sfx stinger (rendered via sound-generation, ≤22s), a bed
+// needs ≥30s of instrumental music, so create() uses the ElevenLabs Music API
+// (audio/bed-gen.ts, force_instrumental) rather than the sfx path.
 
 import { readFile, writeFile, unlink, mkdir, stat, copyFile } from 'node:fs/promises';
 import { STATE_DIR, SOUNDS_DIR } from '../config.js';
 import { transcodeAudio, hasFfmpeg, extOf, isAcceptedAudio, probeDurationSec } from '../audio/audio-import.js';
+import { generateBed, BED_GEN_MAX_SEC } from '../audio/bed-gen.js';
 import { escAnnotate } from '../music/subsonic.js';
 import { writeFileAtomic } from '../util/atomic-file.js';
 import { slugify } from '../util/slug.js';
@@ -42,7 +47,7 @@ const META = `${STATE_DIR}/beds.json`;
 // The reuse is deliberate: that failure was CONTINUOUS playback — a drone
 // running forever underneath both the music and the voice. Here it plays alone
 // for the length of one link and stops, which is a different exposure entirely.
-// If it still grates, it's deletable, which is why defaults are deletable.
+// If it still grates, turn beds off (settings.beds.enabled) — the asset stays.
 const DEFAULT_BEDS = [
   {
     name: 'ambient-room',
@@ -52,11 +57,14 @@ const DEFAULT_BEDS = [
 ];
 
 async function loadMeta(): Promise<any> {
+  // A legacy sidecar may carry a `retired` array (from when defaults were
+  // deletable); it's intentionally not read back — the built-in can't be
+  // deleted now, so nothing retires. Old keys just fall away on the next save.
   try {
     const m = JSON.parse(await readFile(META, 'utf8'));
-    return { items: m.items || {}, retired: Array.isArray(m.retired) ? m.retired : [] };
+    return { items: m.items || {} };
   } catch {
-    return { items: {}, retired: [] };
+    return { items: {} };
   }
 }
 
@@ -83,11 +91,16 @@ export async function list() {
       description: info.description || '',
       durationSec: info.durationSec ?? null,
       source: info.source || 'upload',
+      builtin: !!info.builtin,
       createdAt: info.createdAt,
       size: s.size,
     });
   }
-  out.sort((a: any, b: any) => (a.name || '').localeCompare(b.name || ''));
+  // Built-ins last so operator-created beds appear on top (matches sfx.list).
+  out.sort((a: any, b: any) => {
+    if (a.builtin !== b.builtin) return a.builtin ? 1 : -1;
+    return (a.name || '').localeCompare(b.name || '');
+  });
   return out;
 }
 
@@ -175,37 +188,97 @@ export async function importAudio(
     durationSec: measured,
     file,
     source: 'upload',
+    builtin: false,
     createdAt: new Date().toISOString(),
   };
   await saveMeta(meta);
   return meta.items[slug];
 }
 
-// Delete a bed. Defaults are deletable (see the header) and stay deleted —
-// `retired` is what ensureDefaults checks before reinstalling.
+// Generate an instrumental bed from a text prompt via the ElevenLabs Music API
+// (audio/bed-gen.ts, force_instrumental). Mirrors sfx.create, with a length
+// resolved to the bed floor: default 45s, clamped to [MIN_DURATION_SEC,
+// BED_GEN_MAX_SEC]. A bed is trimmed per-link, so the exact length rarely
+// matters beyond "at least as long as the DJ's longest script".
+export async function create(
+  { name, description = '', prompt, durationSec }:
+    { name: string; description?: string; prompt: string; durationSec?: number | string },
+) {
+  const slug = slugify(name);
+  if (!slug) throw new Error('Bed name is required');
+  if (!prompt || !prompt.trim()) throw new Error('Bed generation prompt is required');
+  await mkdir(DIR, { recursive: true });
+
+  // Reject an existing name so generation can't clobber another bed's audio —
+  // and, as with sfx, can't silently flip a protected built-in to deletable.
+  const meta = await loadMeta();
+  if (meta.items[slug]) throw new Error(`a bed named "${slug}" already exists`);
+
+  const requested = Number(durationSec);
+  const wantSec = Math.min(
+    BED_GEN_MAX_SEC,
+    Math.max(MIN_DURATION_SEC, Number.isFinite(requested) && requested > 0 ? requested : 45),
+  );
+
+  const file = `${slug}.mp3`;
+  await generateBed(prompt.trim(), { durationSec: wantSec, outPath: `${DIR}/${file}` });
+
+  // Same gate as importAudio: pickBed only trusts a real measured length. We
+  // force a ≥30s request, but the probe is the truth — reject anything short.
+  const measured = await probeDurationSec(`${DIR}/${file}`);
+  if (measured == null || measured < MIN_DURATION_SEC) {
+    await unlink(`${DIR}/${file}`).catch(() => {});
+    throw new Error(measured == null
+      ? 'could not measure the generated bed — is ffprobe installed?'
+      : `the generated bed came back only ${Math.round(measured)}s — beds must be at least ${MIN_DURATION_SEC}s`);
+  }
+
+  meta.items[slug] = {
+    name: slug,
+    description: (description || '').trim(),
+    prompt: prompt.trim(),
+    durationSec: measured,
+    file,
+    source: 'generated',
+    builtin: false,
+    createdAt: new Date().toISOString(),
+  };
+  await saveMeta(meta);
+  return meta.items[slug];
+}
+
+// Delete a bed. The bundled default is a protected built-in and refuses deletion
+// (mirrors sfx.remove) — the feature toggle is the way to silence a bed, not
+// deleting the asset.
 export async function remove(name: string) {
   const meta = await loadMeta();
   const info = meta.items[name];
   if (!info) throw new Error(`unknown bed: ${name}`);
+  if (info.builtin) throw new Error('cannot delete the built-in bed');
 
   try { await unlink(`${DIR}/${info.file}`); } catch {}
   delete meta.items[name];
-  if (info.source === 'bundled' && !meta.retired.includes(name)) meta.retired.push(name);
   await saveMeta(meta);
   return { ok: true };
 }
 
-// Called from server startup. Copies in any missing bundled default that the
-// operator hasn't retired. Idempotent.
+// Called from server startup. Ensures the bundled default is present and
+// protected. Idempotent. An install that predates protection (item exists but
+// isn't flagged builtin) is upgraded in place — no re-copy. There's no `retired`
+// check any more: the default can't be deleted, so it's always (re)installed.
 export async function ensureDefaults() {
   await mkdir(DIR, { recursive: true });
   const meta = await loadMeta();
-  let installed = 0;
+  let changed = 0;
 
   for (const def of DEFAULT_BEDS) {
-    if (meta.retired.includes(def.name)) continue;
     const existing = meta.items[def.name];
-    if (existing && (await statOrNull(`${DIR}/${existing.file}`))) continue;
+    if (existing && (await statOrNull(`${DIR}/${existing.file}`))) {
+      // Already installed — just make sure it's flagged as the protected
+      // built-in (upgrades pre-protection sidecars in place).
+      if (!existing.builtin) { existing.builtin = true; changed++; }
+      continue;
+    }
     if (!(await statOrNull(def.bundled))) continue;
 
     try {
@@ -229,14 +302,15 @@ export async function ensureDefaults() {
         durationSec: measured,
         file,
         source: 'bundled',
+        builtin: true,
         createdAt: new Date().toISOString(),
       };
-      installed++;
+      changed++;
       console.log(`[beds] installed bundled default bed → ${def.name}`);
     } catch (err) {
       console.error(`[beds] default "${def.name}" install failed:`, (err as Error).message);
     }
   }
 
-  if (installed) await saveMeta(meta);
+  if (changed) await saveMeta(meta);
 }

--- a/controller/src/routes/beds.ts
+++ b/controller/src/routes/beds.ts
@@ -1,10 +1,14 @@
 // Admin-gated bed library management — the instrumental beds the DJ talks over
 // between songs (see broadcast/beds.ts + broadcast/bed-policy.ts).
 //
-// No generate route, unlike /sfx: a stinger can be rendered from a text prompt,
-// a bed can't. Upload is the only way in beyond the bundled default.
+// Three ways a bed gets in: the bundled default (a protected built-in), an
+// upload, or generation via the ElevenLabs Music API (POST /beds). Generation
+// uses /v1/music rather than the sfx sound-generation endpoint because a bed
+// needs ≥30s of instrumental music (see beds.create / audio/bed-gen.ts).
 import express from 'express';
 import * as beds from '../broadcast/beds.js';
+import { BED_GEN_MAX_SEC } from '../audio/bed-gen.js';
+import { isConfigured } from '../audio/elevenlabs.js';
 import { queue } from '../broadcast/queue.js';
 import { requireAdmin } from '../middleware/auth.js';
 import { audioUpload } from '../middleware/upload.js';
@@ -14,7 +18,37 @@ export const router = express.Router();
 
 router.get('/beds', requireAdmin, async (req, res) => {
   try {
-    res.json({ beds: await beds.list(), minDurationSec: beds.MIN_DURATION_SEC });
+    res.json({
+      beds: await beds.list(),
+      minDurationSec: beds.MIN_DURATION_SEC,
+      maxGenDurationSec: BED_GEN_MAX_SEC,
+      generatorReady: isConfigured(),
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Generate a bed from a text prompt via the ElevenLabs Music API. Mirrors
+// POST /sfx; validation → 400, generation failure → 500.
+router.post('/beds', requireAdmin, async (req, res) => {
+  const name = (req.body?.name || '').trim();
+  const description = (req.body?.description || '').trim();
+  const prompt = (req.body?.prompt || '').trim();
+  const durationSec = req.body?.durationSec;
+  if (!name) return res.status(400).json({ error: 'name is required' });
+  if (!prompt) return res.status(400).json({ error: 'prompt is required' });
+  if (prompt.length > 500) return res.status(400).json({ error: 'prompt too long (max 500)' });
+  if (durationSec != null && durationSec !== '') {
+    const d = Number(durationSec);
+    if (!Number.isFinite(d) || d <= 0) return res.status(400).json({ error: 'durationSec must be a positive number' });
+    if (d < beds.MIN_DURATION_SEC) return res.status(400).json({ error: `durationSec must be at least ${beds.MIN_DURATION_SEC}s` });
+    if (d > BED_GEN_MAX_SEC) return res.status(400).json({ error: `durationSec is capped at ${BED_GEN_MAX_SEC}s` });
+  }
+  try {
+    const created = await beds.create({ name, description, prompt, durationSec });
+    queue.log('scheduler', `New bed generated: "${created.name}" (${Math.round(created.durationSec)}s)`);
+    res.json(created);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/docs/superpowers/specs/2026-07-23-imaging-beds-protect-and-generate-design.md
+++ b/docs/superpowers/specs/2026-07-23-imaging-beds-protect-and-generate-design.md
@@ -1,0 +1,167 @@
+# Imaging → Beds: protect the built-in & generate via ElevenLabs
+
+**Date:** 2026-07-23
+**Area:** `/admin/imaging` → Beds tab; controller bed library; ElevenLabs Music API
+**Status:** proposed — awaiting review
+
+## Summary
+
+Three changes to the admin **Imaging → Beds** area, in order of size:
+
+1. **Ship one built-in bed on new installs** — *already done*, confirmed. Nothing to build.
+2. **Protect the built-in bed from deletion** — mirror the SFX/jingle `builtin` guard. This reverses the current deliberate "beds are deletable" design.
+3. **Generate a bed via ElevenLabs**, mirroring the SFX Create flow — but using the ElevenLabs **Music API** (`/v1/music`, `force_instrumental`) instead of the sound-effects endpoint, because beds must be ≥30 s and sound-generation is capped at 22 s.
+
+Everything reuses existing patterns (SFX library, jingle protection, the shared ElevenLabs key resolution). No new settings keys, no Liquidsoap changes, no changes to bed selection/playback.
+
+## Background: what exists today
+
+- **Bed library backend:** `controller/src/broadcast/beds.ts` — files at `<STATE_DIR>/beds/<slug>.mp3`, sidecar `<STATE_DIR>/beds.json` mapping name → `{name, description, durationSec, file, source, createdAt}`. `source ∈ 'bundled' | 'upload'`. Floor `MIN_DURATION_SEC = 30`.
+- **The bundled default:** `DEFAULT_BEDS = [{ name: 'ambient-room', … bundled: sounds/bed.mp3 }]` (71 s). `ensureDefaults()` copies it into `state/beds/` on first boot (server startup, `server.ts`). So **new installs already get exactly one bed** — Goal 1 is satisfied.
+- **Deletion today is deliberate:** `beds.remove()` deletes *any* bed and, for a bundled one, pushes its name onto a `retired` list so `ensureDefaults()` won't resurrect it. The header comment (`beds.ts:10-18`) spells out that defaults are intentionally deletable, and the delete-confirm dialog (`ImagingPanel.tsx:446`) promises "A bundled bed stays deleted."
+- **SFX is the protection template:** `sfx.ts` items carry `builtin: boolean`; `sfx.remove()` throws `if (info.builtin)`; the route surfaces it as HTTP 400; the UI disables the delete button when `s.builtin` and shows a tooltip.
+- **SFX generation:** `controller/src/audio/sfx-gen.ts` calls ElevenLabs `POST /v1/sound-generation` directly (the AI SDK has no sound-effects primitive). It resolves the key via a private `apiKey()` — `settings.tts.cloud.apiKey` when `tts.cloud.provider === 'elevenlabs'`, else `ELEVENLABS_API_KEY` env — and exposes `isConfigured()`, which backs the UI's `generatorReady` gate. Length is clamped to `[0.5, 22]`.
+- **Beds UI:** `web/components/admin/imaging/BedsSection.tsx` is **import-only** (no Create button; empty-state says "beds can't be generated"). `ImagingPanel.tsx` owns state/handlers (`uploadBed`, `deleteBed`, the delete-confirm dialog). Shapes in `web/components/admin/imaging/types.ts`.
+
+## Why the Music API (Goal 3 rationale)
+
+A bed is an *instrumental the DJ talks over*, and `bed-policy.pickBed` only selects beds whose measured `durationSec ≥` the link length, with a hard floor of 30 s (`MIN_DURATION_SEC`). ElevenLabs sound-generation maxes at 22 s and produces *sound effects*, not musical instrumentals — so a literal "same as SFX" cannot produce a valid bed. The **Music API** fits exactly:
+
+- `POST https://api.elevenlabs.io/v1/music`, header `xi-api-key` (the *same* key as SFX).
+- Body: `prompt`, `music_length_ms` (3 000–600 000), `force_instrumental: true` (guarantees no vocals — essential for a bed), `model_id`.
+- Query `output_format` (default `auto`); we request `mp3_44100_128`.
+- Returns raw audio bytes (200 / `application/octet-stream`); `422` on validation error.
+
+**Caveat carried into the spec:** Music is a separately-metered ElevenLabs feature and may need a specific plan tier. We cannot cheaply probe entitlement, so `generatorReady` for beds means only "a key is present" (same as SFX). A key without Music entitlement surfaces the API's error string on generate, exactly as a failed SFX generate does today.
+
+---
+
+## Design
+
+### Part A — Shared ElevenLabs key resolution (small refactor)
+
+Beds must resolve the ElevenLabs key identically to SFX, and must not import from the sfx module (beds don't depend on sfx). Extract the resolver into a new tiny module.
+
+**New: `controller/src/audio/elevenlabs.ts`**
+```ts
+export function elevenLabsKey(): string   // the current sfx-gen apiKey() body
+export function isConfigured(): boolean    // !!elevenLabsKey()
+```
+
+- `sfx-gen.ts` imports `elevenLabsKey` / `isConfigured` from it (drops its private `apiKey`).
+- `routes/sfx.ts` imports `isConfigured` from `../audio/elevenlabs.js` (was `../audio/sfx-gen.js`).
+- `bed-gen.ts` (Part C) and `routes/beds.ts` import from it too.
+
+This is the only change to SFX code, and it is behaviour-preserving.
+
+### Part B — Protect the built-in bed (Goal 2)
+
+Mirror the SFX `builtin` posture and retire the `retired` mechanism (it existed *solely* to remember a deleted default, which will no longer be possible).
+
+**`beds.ts`:**
+- Sidecar item gains `builtin: boolean`. `list()` returns `builtin: !!info.builtin` (and keeps `source`).
+- `DEFAULT_BEDS` installs are stamped `builtin: true, source: 'bundled'`.
+- `remove()` throws `if (info.builtin) throw new Error('cannot delete the built-in bed')`; drops the `retired` bookkeeping.
+- `ensureDefaults()`:
+  - Drop the `retired` skip. The bundled default is always (re)installed if missing.
+  - **In-place upgrade:** if the default already exists but lacks `builtin: true`, stamp it `true` and persist. This upgrades existing installs' `ambient-room` to protected without re-copying audio.
+- `loadMeta()` stays tolerant of a legacy `retired` key (ignored, not rewritten) so old sidecars don't error.
+
+**`routes/beds.ts`:** `DELETE /beds/:name` already surfaces the thrown error as 400 — no change needed beyond the new message. Update the file header comment (it currently states "no generate route" — see Part C).
+
+**`web/components/admin/imaging/`:**
+- `types.ts`: `BedEntry` gains `builtin?: boolean`.
+- `BedsSection.tsx`: disable the delete `Button` when `b.builtin` (tooltip "Built-in beds can't be deleted"), mirroring `SfxSection.tsx:141-152`. Show a `builtin` badge for it (keep `uploaded` for uploads; the existing `bundled` badge is replaced by `builtin` for clarity/consistency with SFX).
+- `ImagingPanel.tsx`: fix the delete-confirm copy (`:446`) to match SFX/jingles — `Delete the bed "X"? This removes the audio file permanently.` (drop the now-false "stays deleted" sentence; built-ins never reach this dialog).
+
+**Behaviour change to sign off (flagged):** On upgrade, an install that had *deliberately deleted* `ambient-room` (name currently in `retired`) will get it **reinstalled as a protected built-in**. This is intentional: the escape hatch for "I find the bed annoying" is the **feature toggle** — `settings.beds.enabled` defaults to **off**, and turning beds off silences the bed without deleting the asset. Deletion was never the right lever. The beds feature is recent, so few (if any) installs will have retired it. *If you'd rather respect a prior deletion, the alternative is to keep `retired` and only protect the bed when present — say so and I'll switch.*
+
+### Part C — Generate a bed via the Music API (Goal 3)
+
+**New: `controller/src/audio/bed-gen.ts`** (mirrors `sfx-gen.ts`)
+```ts
+export const BED_GEN_MAX_SEC = 120;  // ceiling; a bed is trimmed per-link, so >2 min just burns credits
+export async function generateBed(
+  prompt: string,
+  { durationSec, outPath }: { durationSec?: number; outPath: string },
+): Promise<string>
+```
+- Endpoint `https://api.elevenlabs.io/v1/music?output_format=mp3_44100_128`.
+- Key via `elevenLabsKey()`; throw a clear "key not configured" error when absent.
+- Body: `{ prompt, model_id: 'music_v1', force_instrumental: true, music_length_ms }` where
+  `music_length_ms = round(clamp(durationSec, MIN_DURATION_SEC, BED_GEN_MAX_SEC) * 1000)`, defaulting to **45 s** when unset.
+- On `!res.ok`: throw `ElevenLabs music generation failed (<status>): <detail…>` (mirror `generateSfx`).
+- Write bytes straight to `outPath` (already MP3); no transcode.
+- `model_id` is a single constant — easy to bump to `music_v2` later.
+
+**`beds.ts` → add `create(...)`** (mirrors `sfx.create`)
+```ts
+export async function create({ name, description, prompt, durationSec }): Promise<item>
+```
+- slugify + validate name/prompt; reject an existing name (can't clobber a built-in).
+- Clamp/validate `durationSec` to `[MIN_DURATION_SEC, BED_GEN_MAX_SEC]`.
+- `generateBed(prompt, { durationSec, outPath: <DIR>/<slug>.mp3 })`.
+- Probe measured duration; **same gate as `importAudio`**: if `measured == null || measured < MIN_DURATION_SEC`, unlink + throw (defensive — we force a ≥30 s length, but the probe is truth).
+- Write sidecar item `{ name, description, prompt, durationSec: measured ?? requested, file, source: 'generated', builtin: false, createdAt }`. (New: beds sidecar now stores `prompt` for generated beds; absent/empty for uploads.)
+
+**`routes/beds.ts`:**
+- `GET /beds` → also return `generatorReady: isConfigured()` and `maxGenDurationSec: BED_GEN_MAX_SEC` (alongside existing `beds`, `minDurationSec`).
+- **New `POST /beds`** (generate): validate `name`, `prompt` (≤500), `durationSec` (finite, within `[MIN_DURATION_SEC, BED_GEN_MAX_SEC]`); call `beds.create(...)`; `queue.log('scheduler', …)`; return created. Validation → 400; generation failure → 500 (mirrors `routes/sfx.ts`).
+- Update the header comment (the "no generate route" note is no longer true).
+
+**`bed-policy.ts` / `queue.maybePushBed`:** no change. A generated bed is just a bed with a measured `durationSec`; `pickBed` already handles it.
+
+**UI — `BedsSection.tsx` + `ImagingPanel.tsx`** (mirror the SFX Create flow):
+- Library `PanelHead` gains a `+ Create` button beside `Import`, disabled while `busy`.
+- New Create modal: **Name**, **Duration · s** (`min=30`, `max=120`, default `45`), **Description** (operator-facing), **Generation prompt** (≤500 chars, placeholder e.g. *"warm lo-fi ambient pad, no drums, soft and neutral"*). Create button gated on `bedsData.generatorReady && name && prompt`.
+- When `!generatorReady`, show the same "no ElevenLabs key" `V3Alert` SFX shows (built-in works without a key; a key is only needed to generate).
+- Empty-state caption changes from "beds can't be generated — import an instrumental" to "generate via ElevenLabs or import an instrumental."
+- `types.ts`: add `BedsForm { name; description; prompt; durationSec }` and `BedsData.generatorReady?`, `BedsData.maxGenDurationSec?`.
+- `ImagingPanel.tsx`: add `bedsForm` state + `createBed()` handler (mirror `createSfx()`; `POST /beds`, then `refreshBeds()`).
+
+### Data shape summary
+
+`beds.json` item, after:
+```
+{ name, description, prompt?, durationSec, file, source: 'bundled'|'upload'|'generated', builtin: boolean, createdAt }
+```
+`GET /beds` → `{ beds: BedEntry[], minDurationSec, maxGenDurationSec, generatorReady }`
+`BedEntry` → `{ name, description?, size?, durationSec?, source?, builtin? }`
+
+## Non-goals
+
+- No change to Liquidsoap, bed selection (`bed-policy`), or the push path (`queue.maybePushBed`).
+- No new bundled bed asset — Goal 1 already ships `ambient-room` from `sounds/bed.mp3`.
+- No new settings keys; the ElevenLabs key continues to ride `settings.tts.cloud` / `ELEVENLABS_API_KEY`.
+- No bed loudnorm on generate (consistent with import — level vs. voice is the operator's call; the broadcast limiter catches peaks).
+
+## Files touched
+
+**Controller**
+- `controller/src/audio/elevenlabs.ts` — new (shared key resolver).
+- `controller/src/audio/bed-gen.ts` — new (Music API client).
+- `controller/src/audio/sfx-gen.ts` — use shared resolver.
+- `controller/src/broadcast/beds.ts` — `builtin` flag, protected `remove()`, `create()`, `ensureDefaults()` upgrade + drop `retired`, header comment.
+- `controller/src/routes/beds.ts` — `generatorReady`/`maxGenDurationSec` on GET, new `POST /beds`, header comment.
+- `controller/src/routes/sfx.ts` — import `isConfigured` from the shared module.
+
+**Web**
+- `web/components/admin/imaging/types.ts` — `BedEntry.builtin`, `BedsForm`, `BedsData.generatorReady`/`maxGenDurationSec`.
+- `web/components/admin/imaging/BedsSection.tsx` — Create modal, `+ Create` button, key alert, delete-disable on built-in, empty-state copy.
+- `web/components/admin/imaging/ImagingPanel.tsx` — `bedsForm` state, `createBed()`, delete-confirm copy.
+
+**Docs / copy**
+- Grep `web/` manual + landing for "beds can't be generated" / import-only bed copy and update (recent commit `97711f37` touched manual/landing for Imaging). Update `docs/` if a beds reference exists.
+
+## Testing & rollout
+
+- Merge gate is `npm run lint` (`eslint . && tsc --noEmit`) in `controller/` and `web/` — both must pass.
+- No test runner. The pure clamp in `bed-gen` is trivial; no new pure-test harness unless `bed-policy`'s test file makes one obvious.
+- Manual verification: fresh `state/` boots with one **built-in** bed whose delete button is disabled; with an ElevenLabs key, Create produces a ≥30 s instrumental that appears in the library and is selectable for a long link; without a key, Create is gated and the alert shows; upload path unchanged.
+- Prod note: controller changes need an image rebuild (`docker compose up -d --build controller`); dev hot-reloads.
+
+## Open decisions flagged for review
+
+1. **Retire vs. protect on upgrade** (Part B) — reinstall a previously-deleted `ambient-room` as protected (recommended), or respect the prior deletion?
+2. **Duration range** — Create offers 30–120 s, default 45 s. Reasonable? (Beds are trimmed per-link, so the exact length rarely matters beyond "≥ the longest link.")
+3. **Model** — `music_v1` (safe default) vs `music_v2` (newer, possibly costlier/less available).

--- a/web/components/admin/FestivalsSection.tsx
+++ b/web/components/admin/FestivalsSection.tsx
@@ -192,7 +192,7 @@ export default function FestivalsSection() {
       <SectionHeader
         eyebrow="festivals"
         title="Festival calendar."
-        sub="Mood-forming dates the DJ leans into around the year. Add your local holidays, regional celebrations, or personal landmarks; the station's mood shifts to match the nearest active festival."
+        sub="Dates that set a mood, marked across the year. Add your local holidays, regional celebrations, or personal landmarks — the station leans into the nearest one as it comes around."
         metrics={festivals ? [{ n: String(festivals.length), l: `date${festivals.length === 1 ? '' : 's'}`, accent: true }] : undefined}
         actions={
           <Btn tone="accent" onClick={startAdd} disabled={festivals === null}>
@@ -218,7 +218,7 @@ export default function FestivalsSection() {
         >
           {festivals.length === 0 ? (
             <div className="text-[13px] text-muted italic">
-              No festivals defined. Add one to get started.
+              Nothing on the calendar yet — add your first date to get started.
             </div>
           ) : (
             <div className="grid">
@@ -366,7 +366,7 @@ export default function FestivalsSection() {
                 maxLength={200}
               />
               <div className="field-hint mt-1">
-                A brief note the DJ can weave into its on-air talk when the festival is active.
+                A short note your DJ can weave into its chat while the festival is on.
               </div>
             </div>
 
@@ -400,8 +400,8 @@ export default function FestivalsSection() {
               </div>
             </div>
             <div className="field-hint -mt-2">
-              Music selection and spoken tone shift into the mood for the window around
-              the date, e.g. a 3-day window spans a full week.
+              Music and spoken tone shift into the mood for the days around the date — a 3-day
+              window covers a full week.
             </div>
           </div>
         )}

--- a/web/components/admin/MoodsPanel.tsx
+++ b/web/components/admin/MoodsPanel.tsx
@@ -200,10 +200,9 @@ export default function MoodsPanel() {
             Moods &amp; moments.
           </div>
           <div className="mt-1 text-[11px] leading-[1.6] text-muted">
-            The station&apos;s mood vocabulary and how the autonomous DJ reaches for it — the
-            words the library is tagged with, and which mood each part of the day, the weather,
-            and the calendar leans into. Edit the list, and every show, festival, and auto-DJ
-            pick draws from it.
+            The moods your station knows, and when it reaches for them — the words your library is
+            tagged with, and which mood each part of the day, the weather, and the calendar leans
+            into. Edit the list and every show, festival, and auto-DJ pick draws from it.
           </div>
         </div>
         {/* Shared editorial section-tabs, edge-to-edge along the card's foot. */}
@@ -228,12 +227,12 @@ export default function MoodsPanel() {
         <Card title="Mood vocabulary" sub="the moods every track is tagged with">
           <div className="field">
             <div className="field-hint">
-              Each mood needs a short id (letters, digits, dashes) and an optional
-              sound description used for zero-shot audio tagging (heavy analyzer).
-              Changing moods or their descriptions re-scores audio moods on the
-              next analysis pass and marks LLM tags stale — re-run the tagger to
-              refresh. Removing a mood that a show, festival, or the maps in Moments
-              still use is rejected until you reassign it.
+              Give each mood a short id (letters, digits, dashes) and, if you like, a sound
+              description we use for audio tagging (needs the heavy analyzer). Change a mood or its
+              description and we’ll re-score audio moods on the next analysis pass and mark the
+              older tags stale — re-run the tagger to refresh them. If a mood is still used by a
+              show, festival, or one of the maps in Moments, you’ll need to reassign it before you
+              can remove it.
             </div>
             <ScrollArea className="max-h-[420px]">
               <div className="flex flex-col gap-2 pr-2">
@@ -289,7 +288,7 @@ export default function MoodsPanel() {
       {/* --- Moments: time-of-day + weather --- */}
       {tab === 'moments' && moods !== null && (
         <>
-          <Card title="Time of day → mood" sub="what the autonomous DJ leans into through the day">
+          <Card title="Time of day → mood" sub="the mood your station leans into through the day">
             <div className="grid gap-2">
               {PERIODS.map(p => (
                 <div key={p.id} className="flex items-center justify-between gap-3">
@@ -320,7 +319,7 @@ export default function MoodsPanel() {
             </div>
           </Card>
 
-          <Card title="Weather → mood" sub="how live conditions colour the mood (overrides time of day)">
+          <Card title="Weather → mood" sub="how live weather colours the mood — this wins over time of day">
             <div className="grid gap-2">
               {CONDITIONS.map(c => (
                 <div key={c.id} className="flex items-center justify-between gap-3">
@@ -356,14 +355,14 @@ export default function MoodsPanel() {
 
       {/* --- Speech corrections (relocated from the TTS tab) --- */}
       {tab === 'speech' && moods !== null && (
-        <Card title="Speech corrections" sub="pronunciation fixes">
+        <Card title="Speech corrections" sub="how names and tricky words should sound">
           <div className="field">
             <div className="field-hint">
-              Find→replace rules applied to every spoken line before the voice engine
-              reads it, for names and terms the engines mispronounce (<em>GHz</em> →
-              <em> gigahertz</em>, <em>Hozier</em> → <em>Ho-zeer</em>). Case-insensitive,
-              matches whole words and phrases; leave the spoken form empty to drop the
-              phrase entirely. Saved rules apply from the next spoken line, no restart.
+              Find-and-replace rules we apply to every line before it’s spoken, for names and
+              words the voice tends to get wrong (<em>GHz</em> →<em> gigahertz</em>, <em>Hozier</em>{' '}
+              → <em>Ho-zeer</em>). Case doesn’t matter, and it matches whole words and phrases;
+              leave the spoken form empty to drop a word entirely. New rules kick in from the next
+              line — no restart needed.
             </div>
             <ScrollArea className="max-h-[360px]">
               <div className="flex flex-col gap-2 pr-2">

--- a/web/components/admin/imaging/BedsSection.tsx
+++ b/web/components/admin/imaging/BedsSection.tsx
@@ -116,15 +116,6 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
         </div>
       </PanelBox>
 
-      {!ready && (
-        <V3Alert title="no ElevenLabs key">
-          The built-in bed and uploads work without a key — one is only needed to generate new
-          beds. Set{' '}
-          <code className="font-mono text-[12px]">ELEVENLABS_API_KEY</code> and restart the
-          controller to enable Create.
-        </V3Alert>
-      )}
-
       {enabled && list.length === 0 && (
         <V3Alert title="no beds in the library">
           Beds are on, but the library is empty — links fall back to talking over the incoming

--- a/web/components/admin/imaging/BedsSection.tsx
+++ b/web/components/admin/imaging/BedsSection.tsx
@@ -86,7 +86,7 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
     <section className="grid gap-[22px]">
       <SectionMasthead
         title="Beds"
-        sub="Instrumentals the DJ talks over between songs: the song ends, the bed carries the talk, and the next song ramps in under the DJ’s closing words."
+        sub="Instrumentals your DJ talks over between songs — the track ends, the bed carries the chat, and the next song fades in under the closing words."
         metrics={<TabMetric accent n={pad2(list.length)} l="beds" />}
         actions={
           <>
@@ -103,8 +103,8 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
             <div className="font-mono text-[10px] font-bold tracking-[0.2em] uppercase">talk beds</div>
             <p className="mt-1.5 text-[12px] leading-[1.55] text-muted">
               {enabled
-                ? 'Long links get their own instrumental. Needs at least one bed long enough to carry a script.'
-                : 'Off — every link is talked over the incoming song, as before. The library is kept.'}
+                ? 'When on, longer links get their own instrumental to sit on. You’ll need at least one bed long enough to carry the chat.'
+                : 'Off — links play over the incoming song, like before. Your library stays put.'}
             </p>
           </div>
           <Seg
@@ -118,8 +118,8 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
 
       {enabled && list.length === 0 && (
         <V3Alert title="no beds in the library">
-          Beds are on, but the library is empty — links fall back to talking over the incoming
-          song until you import a bed at least {minSec} seconds long.
+          Beds are on, but there’s nothing here yet — links keep playing over the incoming song
+          until you add a bed at least {minSec} seconds long.
         </V3Alert>
       )}
 
@@ -149,9 +149,9 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
               <span className="font-mono text-[12px] text-muted">seconds</span>
             </div>
             <p className="mt-2.5 text-[12px] leading-[1.55] [text-wrap:pretty] text-muted">
-              Links above this length get their own bed. Where the analyzer has measured a track’s
-              vocals, that measurement wins — a bed exactly when the DJ would otherwise talk over
-              singing; instrumentals never get one. Saves on blur.
+              Anything longer than this gets its own bed. Where we’ve measured a track’s vocals,
+              that wins — a bed lands exactly when your DJ would otherwise talk over singing, and
+              instrumentals never get one. Saves when you click away.
             </p>
           </div>
           <div className="p-[18px]">
@@ -176,8 +176,8 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
               <span className="font-mono text-[12px] text-muted">seconds</span>
             </div>
             <p className="mt-2.5 text-[12px] leading-[1.55] [text-wrap:pretty] text-muted">
-              Crossfade for the next song to fade in under the DJ’s closing words. 0 is a hard cut.
-              Saves on blur.
+              How long the next song takes to fade in under your DJ’s closing words. 0 is a hard
+              cut. Saves when you click away.
             </p>
           </div>
         </div>
@@ -187,7 +187,7 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
       <PanelBox>
         <PanelHead label={`bed library · ${pad2(list.length)}`} />
         {list.length === 0 ? (
-          <EmptyState caption="generate via ElevenLabs or import an instrumental" />
+          <EmptyState caption="generate one with ElevenLabs, or import an instrumental" />
         ) : (
           <div className="divide-y divide-separator-soft">
             {list.map(b => (
@@ -242,7 +242,7 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
         open={modal === 'create'}
         onOpenChange={(o) => { if (!o) setModal(null); }}
         title="create bed"
-        sub="an instrumental generated via ElevenLabs"
+        sub="an instrumental we’ll generate with ElevenLabs"
         footer={
           <>
             <Button variant="ghost" size="sm" onClick={() => setModal(null)}>Cancel</Button>
@@ -260,7 +260,7 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
         <div className="grid gap-3.5">
           {!ready && (
             <V3Alert title="key required">
-              Generation needs an ElevenLabs key. Set{' '}
+              You’ll need an ElevenLabs key to generate. Add{' '}
               <code className="font-mono text-[12px]">ELEVENLABS_API_KEY</code> and restart the
               controller.
             </V3Alert>
@@ -309,9 +309,9 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
             <div className="text-right font-mono text-[11px] text-muted">{bedsForm.prompt.length} / 500</div>
           </div>
           <p className="m-0 text-[12px] leading-[1.55] [text-wrap:pretty] text-muted">
-            Generated instrumental only (no vocals), {minSec}–{maxGenSec}s. A bed is trimmed per
-            link, so it just needs to outlast the DJ’s longest script — atmospheric and neutral
-            travels best.
+            Vocal-free instrumental, {minSec}–{maxGenSec}s. Each bed is trimmed to fit the link, so
+            it just needs to outlast your DJ’s longest bit of chat — atmospheric and neutral works
+            best.
           </p>
         </div>
       </Modal>
@@ -363,8 +363,8 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
             onClick={() => importRef.current?.click()}
           />
           <p className="m-0 text-[12px] leading-[1.55] [text-wrap:pretty] text-muted">
-            A bed is trimmed per link and never looped — it only needs to outlast the DJ’s longest
-            script. Atmospheric, no strong key travels best.
+            Each bed is trimmed to fit the link and never loops — it only needs to outlast your
+            DJ’s longest bit of chat. Atmospheric, with no strong key, works best.
           </p>
         </div>
       </Modal>

--- a/web/components/admin/imaging/BedsSection.tsx
+++ b/web/components/admin/imaging/BedsSection.tsx
@@ -6,20 +6,24 @@ import { Trash2 } from 'lucide-react';
 import { fmtSize } from '../../../lib/format';
 import { Modal } from '../../ui/modal';
 import { Input } from '../../ui/input';
+import { Textarea } from '../../ui/textarea';
 import { Label } from '../../ui/label';
 import { Button } from '../../ui/button';
 import { Badge } from '../../ui/badge';
 import { V3Alert } from '../../ui/alert';
 import { Btn, Seg } from '../ui';
 import { PreviewButton, type SettingsData, type SaveSettings } from '../settings/shared';
-import type { BedsData } from './types';
+import type { BedsData, BedsForm } from './types';
 import {
   SectionMasthead, PanelBox, PanelHead, EmptyState, DropZone, MetaLine, TabMetric, pad2,
 } from './parts';
 
 interface BedsSectionProps {
   bedsData: BedsData | null;
+  bedsForm: BedsForm;
+  setBedsForm: (updater: (f: BedsForm) => BedsForm) => void;
   busy: boolean;
+  createBed: () => Promise<boolean>;
   uploadBed: (file: File, name: string, description: string) => Promise<boolean>;
   onDelete: (name: string | null) => void;
   data: SettingsData | null;
@@ -27,9 +31,9 @@ interface BedsSectionProps {
   adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
 }
 
-export function BedsSection({ bedsData, busy, uploadBed, onDelete, data, saveSettings, adminFetch }: BedsSectionProps) {
+export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, uploadBed, onDelete, data, saveSettings, adminFetch }: BedsSectionProps) {
   // Hooks must run before the early "loading…" return — keep them at the top.
-  const [modal, setModal] = useState(false);
+  const [modal, setModal] = useState<null | 'create' | 'import'>(null);
   const [importFile, setImportFile] = useState<File | null>(null);
   const [importName, setImportName] = useState('');
   const [importDesc, setImportDesc] = useState('');
@@ -47,8 +51,11 @@ export function BedsSection({ bedsData, busy, uploadBed, onDelete, data, saveSet
       setImportName('');
       setImportDesc('');
       if (importRef.current) importRef.current.value = '';
-      setModal(false);
+      setModal(null);
     }
+  };
+  const doCreate = async () => {
+    if (await createBed()) setModal(null);
   };
 
   if (!bedsData) {
@@ -56,6 +63,8 @@ export function BedsSection({ bedsData, busy, uploadBed, onDelete, data, saveSet
   }
   const list = bedsData.beds || [];
   const minSec = bedsData.minDurationSec ?? 30;
+  const maxGenSec = bedsData.maxGenDurationSec ?? 120;
+  const ready = !!bedsData.generatorReady;
   const beds = data?.values?.beds;
   const enabled = beds?.enabled === true;
   const thresholdSec = beds?.thresholdSec ?? 12;
@@ -100,6 +109,15 @@ export function BedsSection({ bedsData, busy, uploadBed, onDelete, data, saveSet
           />
         </div>
       </PanelBox>
+
+      {!ready && (
+        <V3Alert title="no ElevenLabs key">
+          The built-in bed and uploads work without a key — one is only needed to generate new
+          beds. Set{' '}
+          <code className="font-mono text-[12px]">ELEVENLABS_API_KEY</code> and restart the
+          controller to enable Create.
+        </V3Alert>
+      )}
 
       {enabled && list.length === 0 && (
         <V3Alert title="no beds in the library">
@@ -172,10 +190,15 @@ export function BedsSection({ bedsData, busy, uploadBed, onDelete, data, saveSet
       <PanelBox>
         <PanelHead
           label={`bed library · ${pad2(list.length)}`}
-          right={<Btn sm onClick={() => setModal(true)} disabled={busy}>Import</Btn>}
+          right={
+            <>
+              <Btn sm onClick={() => setModal('import')} disabled={busy}>Import</Btn>
+              <Btn sm tone="solid" onClick={() => setModal('create')} disabled={busy}>+ Create</Btn>
+            </>
+          }
         />
         {list.length === 0 ? (
-          <EmptyState caption="beds can’t be generated — import an instrumental" />
+          <EmptyState caption="generate via ElevenLabs or import an instrumental" />
         ) : (
           <div className="divide-y divide-separator-soft">
             {list.map(b => (
@@ -196,7 +219,8 @@ export function BedsSection({ bedsData, busy, uploadBed, onDelete, data, saveSet
                         <span>{Math.round(b.durationSec)}s</span>
                       </>
                     )}
-                    {b.source === 'bundled' && <Badge variant="solid">bundled</Badge>}
+                    {b.builtin && <Badge variant="solid">builtin</Badge>}
+                    {b.source === 'generated' && <Badge variant="ink">generated</Badge>}
                     {b.source === 'upload' && <Badge variant="ink">uploaded</Badge>}
                   </MetaLine>
                 </div>
@@ -205,13 +229,13 @@ export function BedsSection({ bedsData, busy, uploadBed, onDelete, data, saveSet
                     path={`/beds/${encodeURIComponent(b.name)}/audio`}
                     adminFetch={adminFetch}
                   />
-                  <span title="Delete this bed">
+                  <span title={b.builtin ? 'The built-in bed can’t be deleted' : 'Delete this bed'}>
                     <Button
                       type="button"
                       variant="ghost"
                       size="icon"
                       aria-label="Delete bed"
-                      disabled={busy}
+                      disabled={busy || b.builtin}
                       onClick={() => onDelete(b.name)}
                     >
                       <Trash2 aria-hidden />
@@ -224,15 +248,94 @@ export function BedsSection({ bedsData, busy, uploadBed, onDelete, data, saveSet
         )}
       </PanelBox>
 
+      {/* Create — ElevenLabs Music API */}
+      <Modal
+        open={modal === 'create'}
+        onOpenChange={(o) => { if (!o) setModal(null); }}
+        title="create bed"
+        sub="an instrumental generated via ElevenLabs"
+        footer={
+          <>
+            <Button variant="ghost" size="sm" onClick={() => setModal(null)}>Cancel</Button>
+            <Btn
+              sm
+              tone="accent"
+              onClick={doCreate}
+              disabled={busy || !ready || !bedsForm.name.trim() || !bedsForm.prompt.trim()}
+            >
+              {busy ? 'Generating…' : 'Create'}
+            </Btn>
+          </>
+        }
+      >
+        <div className="grid gap-3.5">
+          {!ready && (
+            <V3Alert title="key required">
+              Generation needs an ElevenLabs key. Set{' '}
+              <code className="font-mono text-[12px]">ELEVENLABS_API_KEY</code> and restart the
+              controller.
+            </V3Alert>
+          )}
+          <div className="grid grid-cols-[1fr_120px] gap-3">
+            <div className="grid gap-1.5">
+              <Label>Name</Label>
+              <Input
+                value={bedsForm.name}
+                maxLength={60}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setBedsForm(f => ({ ...f, name: e.target.value }))}
+                placeholder="midnight-drift"
+              />
+            </div>
+            <div className="grid gap-1.5">
+              <Label>Length · s</Label>
+              <Input
+                className="mono-num"
+                type="number"
+                step={1}
+                min={minSec}
+                max={maxGenSec}
+                value={bedsForm.durationSec}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setBedsForm(f => ({ ...f, durationSec: e.target.value }))}
+                placeholder="45"
+              />
+            </div>
+          </div>
+          <div className="grid gap-1.5">
+            <Label>Description · optional</Label>
+            <Input
+              value={bedsForm.description}
+              maxLength={200}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setBedsForm(f => ({ ...f, description: e.target.value }))}
+              placeholder="For your own reference — the DJ never reads this"
+            />
+          </div>
+          <div className="grid gap-1.5">
+            <Label>Generation prompt</Label>
+            <Textarea
+              rows={3}
+              value={bedsForm.prompt}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setBedsForm(f => ({ ...f, prompt: e.target.value.slice(0, 500) }))}
+              placeholder="Describe the instrumental for ElevenLabs — e.g. warm lo-fi ambient pad, no drums, soft and neutral…"
+            />
+            <div className="text-right font-mono text-[11px] text-muted">{bedsForm.prompt.length} / 500</div>
+          </div>
+          <p className="m-0 text-[12px] leading-[1.55] [text-wrap:pretty] text-muted">
+            Generated instrumental only (no vocals), {minSec}–{maxGenSec}s. A bed is trimmed per
+            link, so it just needs to outlast the DJ’s longest script — atmospheric and neutral
+            travels best.
+          </p>
+        </div>
+      </Modal>
+
       {/* Import — bring your own instrumental */}
       <Modal
-        open={modal}
-        onOpenChange={(o) => { if (!o) setModal(false); }}
+        open={modal === 'import'}
+        onOpenChange={(o) => { if (!o) setModal(null); }}
         title="import bed"
         sub="an instrumental the DJ can talk over"
         footer={
           <>
-            <Button variant="ghost" size="sm" onClick={() => setModal(false)}>Cancel</Button>
+            <Button variant="ghost" size="sm" onClick={() => setModal(null)}>Cancel</Button>
             <Btn sm tone="accent" onClick={doImport} disabled={busy || !importFile || !importName.trim()}>
               {busy ? 'Importing…' : 'Import'}
             </Btn>

--- a/web/components/admin/imaging/ImagingPanel.tsx
+++ b/web/components/admin/imaging/ImagingPanel.tsx
@@ -23,7 +23,7 @@ import { Wave } from '../ui';
 import { V3Alert } from '../../ui/alert';
 import { V3AlertDialog } from '../../ui/alert-dialog';
 import type { SettingsData, SaveSettings } from '../settings/shared';
-import type { SfxData, SfxForm, BedsData, JingleImportFailure, JingleImportResult } from './types';
+import type { SfxData, SfxForm, BedsData, BedsForm, JingleImportFailure, JingleImportResult } from './types';
 import { JinglesSection } from './JinglesSection';
 import { SfxSection } from './SfxSection';
 import { BedsSection } from './BedsSection';
@@ -54,6 +54,7 @@ export default function ImagingPanel() {
   const [confirmDeleteSfx, setConfirmDeleteSfx] = useState<string | null>(null);
 
   // Beds
+  const [bedsForm, setBedsForm] = useState<BedsForm>({ name: '', description: '', prompt: '', durationSec: '' });
   const [confirmDeleteBed, setConfirmDeleteBed] = useState<string | null>(null);
 
   const refresh = async () => {
@@ -263,6 +264,31 @@ export default function ImagingPanel() {
     finally { setBusy(false); }
   };
 
+  // Generate a bed via the ElevenLabs Music API — needs a key (unlike uploadBed).
+  const createBed = async (): Promise<boolean> => {
+    if (!bedsForm.name.trim() || !bedsForm.prompt.trim() || busy) return false;
+    setBusy(true);
+    try {
+      const r = await adminFetch('/beds', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: bedsForm.name.trim(),
+          description: bedsForm.description.trim(),
+          prompt: bedsForm.prompt.trim(),
+          durationSec: bedsForm.durationSec ? parseFloat(bedsForm.durationSec) : undefined,
+        }),
+      });
+      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      setBedsForm({ name: '', description: '', prompt: '', durationSec: '' });
+      await refreshBeds();
+      notify.ok('bed generated');
+      return true;
+    } catch (e) { notify.err(`Bed generation failed: ${errorMessage(e)}`); return false; }
+    finally { setBusy(false); }
+  };
+
   const uploadBed = async (file: File, name: string, description: string): Promise<boolean> => {
     if (busy) return false;
     setBusy(true);
@@ -414,7 +440,8 @@ export default function ImagingPanel() {
 
         {tab === 'beds' && (
           <BedsSection
-            bedsData={bedsData} busy={busy} uploadBed={uploadBed}
+            bedsData={bedsData} bedsForm={bedsForm} setBedsForm={setBedsForm}
+            busy={busy} createBed={createBed} uploadBed={uploadBed}
             onDelete={setConfirmDeleteBed}
             data={data} saveSettings={saveSettings} adminFetch={adminFetch}
           />
@@ -443,7 +470,7 @@ export default function ImagingPanel() {
         open={confirmDeleteBed != null}
         onOpenChange={(o) => { if (!o) setConfirmDeleteBed(null); }}
         title="Delete bed"
-        description={confirmDeleteBed ? `Delete the bed "${confirmDeleteBed}"? This removes the audio file permanently. A bundled bed stays deleted — it won't come back on the next restart.` : ''}
+        description={confirmDeleteBed ? `Delete the bed "${confirmDeleteBed}"? This removes the audio file permanently.` : ''}
         confirmLabel="delete"
         danger
         onConfirm={() => { if (confirmDeleteBed) deleteBed(confirmDeleteBed); setConfirmDeleteBed(null); }}

--- a/web/components/admin/imaging/ImagingPanel.tsx
+++ b/web/components/admin/imaging/ImagingPanel.tsx
@@ -353,12 +353,12 @@ export default function ImagingPanel() {
               The sounds between the songs.
             </div>
             <p className="mt-1 max-w-[62ch] text-[11px] leading-[1.6] [text-wrap:pretty] text-muted">
-              Everything the DJ drops between and over the music:{' '}
+              Everything your DJ slips between and over the music:{' '}
               <strong className="font-semibold text-ink">jingles</strong> are the station idents
-              played between tracks, <strong className="font-semibold text-ink">SFX</strong> are
-              stingers mixed under the DJ&rsquo;s voice, and{' '}
-              <strong className="font-semibold text-ink">beds</strong> are instrumentals the DJ
-              talks over when a link runs long.
+              between tracks, <strong className="font-semibold text-ink">SFX</strong> are the little
+              stingers under the voice, and{' '}
+              <strong className="font-semibold text-ink">beds</strong> are instrumentals to talk
+              over when a link runs long.
             </p>
           </div>
           <div className="flex flex-none gap-7">

--- a/web/components/admin/imaging/JinglesSection.tsx
+++ b/web/components/admin/imaging/JinglesSection.tsx
@@ -87,7 +87,7 @@ export function JinglesSection({
     <section className="grid gap-[22px]">
       <SectionMasthead
         title="Jingles"
-        sub="Pre-rendered station idents dropped between tracks. A default ident is generated on first boot and can’t be deleted."
+        sub="Short station idents that play between tracks. One ships with the station and stays put — add as many of your own as you like alongside it."
         metrics={
           <>
             <TabMetric n={pad2(jingles.length)} l="files" />
@@ -104,7 +104,7 @@ export function JinglesSection({
 
       {/* Frequency */}
       <PanelBox>
-        <PanelHead label="frequency" right={<Badge variant="accent">restart required</Badge>} />
+        <PanelHead label="how often" right={<Badge variant="accent">restart required</Badge>} />
         <div className="flex flex-wrap items-center gap-5 px-[18px] py-[18px]">
           <div className="flex flex-none items-center gap-2.5">
             <span className="font-mono text-[13px]">1 jingle every</span>
@@ -120,8 +120,8 @@ export function JinglesSection({
             <span className="font-mono text-[13px]">music tracks</span>
           </div>
           <p className="m-0 min-w-[220px] flex-1 text-[12px] leading-[1.55] text-muted">
-            0 turns jingles off entirely. Changes apply after a mixer restart — the restart
-            control lives in Settings → danger zone.
+            Set it to 0 to switch jingles off altogether. Changes take effect once you restart
+            the mixer — that button lives in Settings → danger zone.
           </p>
           <Btn
             sm
@@ -138,7 +138,7 @@ export function JinglesSection({
       <PanelBox>
         <PanelHead label={`jingle library · ${pad2(jingles.length)}`} />
         {jingles.length === 0 ? (
-          <EmptyState caption="create one via TTS or import your own" />
+          <EmptyState caption="write one and we’ll voice it, or import your own" />
         ) : (
           <div className="divide-y divide-separator-soft">
             {jingles.map(j => (
@@ -193,7 +193,7 @@ export function JinglesSection({
         open={modal === 'create'}
         onOpenChange={(o) => { if (!o) setModal(null); }}
         title="create jingle"
-        sub="rendered via Piper TTS"
+        sub="we’ll voice it with Piper TTS"
         footer={
           <>
             <Button variant="ghost" size="sm" onClick={() => setModal(null)}>Cancel</Button>
@@ -254,7 +254,7 @@ export function JinglesSection({
                 ? `${importFiles.length} file${importFiles.length === 1 ? '' : 's'} selected — click to re-select`
                 : 'choose files…'
             }
-            hint="mp3 · wav · ogg · flac · m4a · aac · opus — up to 25 MB each · converted + level-matched on import"
+            hint="mp3 · wav · ogg · flac · m4a · aac · opus — up to 25 MB each · we convert and level-match them for you"
             onClick={() => importRef.current?.click()}
             disabled={!!importProgress}
           />

--- a/web/components/admin/imaging/SfxSection.tsx
+++ b/web/components/admin/imaging/SfxSection.tsx
@@ -64,7 +64,7 @@ export function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uplo
     <section className="grid gap-[22px]">
       <SectionMasthead
         title="Sound effects"
-        sub="Stingers the segment-director agent mixes under its voice during a spoken break. Built-ins ship with the station."
+        sub="Little stingers your DJ can drop under its voice during a break — a record scratch, an airhorn, a whoosh. A handful ship with the station."
         metrics={<TabMetric accent n={pad2(list.length)} l="effects" />}
         actions={
           <>
@@ -81,8 +81,8 @@ export function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uplo
             <div className="font-mono text-[10px] font-bold tracking-[0.2em] uppercase">stingers</div>
             <p className="mt-1.5 text-[12px] leading-[1.55] text-muted">
               {enabled
-                ? 'The agent sees the effect catalogue and mixes stingers under its voice during spoken breaks.'
-                : 'Off — the agent never sees the catalogue and plays no stingers. The library is kept.'}
+                ? 'When on, your DJ can reach for these and mix them under its voice during a break.'
+                : 'Off — your DJ never reaches for a stinger. Your library stays as it is.'}
             </p>
           </div>
           <Seg
@@ -98,7 +98,7 @@ export function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uplo
       <PanelBox>
         <PanelHead label={`effect library · ${pad2(list.length)}`} />
         {list.length === 0 ? (
-          <EmptyState caption="generate via ElevenLabs or import your own" />
+          <EmptyState caption="generate one with ElevenLabs, or import your own" />
         ) : (
           <div className="divide-y divide-separator-soft">
             {list.map(s => (
@@ -152,7 +152,7 @@ export function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uplo
         open={modal === 'create'}
         onOpenChange={(o) => { if (!o) setModal(null); }}
         title="create effect"
-        sub="rendered via ElevenLabs"
+        sub="we’ll generate it with ElevenLabs"
         footer={
           <>
             <Button variant="ghost" size="sm" onClick={() => setModal(null)}>Cancel</Button>
@@ -170,7 +170,7 @@ export function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uplo
         <div className="grid gap-3.5">
           {!ready && (
             <V3Alert title="key required">
-              Generation needs an ElevenLabs key. Set{' '}
+              You’ll need an ElevenLabs key to generate. Add{' '}
               <code className="font-mono text-[12px]">ELEVENLABS_API_KEY</code> and restart the
               controller.
             </V3Alert>
@@ -205,7 +205,7 @@ export function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uplo
               value={sfxForm.description}
               maxLength={200}
               onChange={(e: ChangeEvent<HTMLInputElement>) => setSfxForm(f => ({ ...f, description: e.target.value }))}
-              placeholder="The agent reads this to decide when the effect fits a line"
+              placeholder="Your DJ reads this to decide when the effect fits a line"
             />
           </div>
           <div className="grid gap-1.5">

--- a/web/components/admin/imaging/SfxSection.tsx
+++ b/web/components/admin/imaging/SfxSection.tsx
@@ -94,14 +94,6 @@ export function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uplo
         </div>
       </PanelBox>
 
-      {!ready && (
-        <V3Alert title="no ElevenLabs key">
-          Built-in effects work without a key — one is only needed to generate new ones. Set{' '}
-          <code className="font-mono text-[12px]">ELEVENLABS_API_KEY</code> and restart the
-          controller to enable Create.
-        </V3Alert>
-      )}
-
       {/* Library */}
       <PanelBox>
         <PanelHead label={`effect library · ${pad2(list.length)}`} />

--- a/web/components/admin/imaging/types.ts
+++ b/web/components/admin/imaging/types.ts
@@ -33,11 +33,21 @@ export interface BedEntry {
   size?: number;
   durationSec?: number | null;
   source?: string;
+  builtin?: boolean;
 }
 
 export interface BedsData {
   beds?: BedEntry[];
   minDurationSec?: number;
+  maxGenDurationSec?: number;
+  generatorReady?: boolean;
+}
+
+export interface BedsForm {
+  name: string;
+  description: string;
+  prompt: string;
+  durationSec: string;
 }
 
 export type JingleImportFailure = { name: string; reason: string };


### PR DESCRIPTION
Brings **Admin → Imaging → Beds** to parity with the SFX tab: the bundled bed is now protected, and beds can be generated from a prompt.

## What changed

**Goal 1 — ship one bed on new installs** — already true; confirmed. `ambient-room` (from `sounds/bed.mp3`) is seeded on first boot. No change.

**Goal 2 — protect the built-in from deletion**
- Bed sidecar items carry a `builtin` flag. `beds.remove()` throws for it (→ HTTP 400), the UI disables its delete button + tooltip, and the delete-confirm copy is corrected.
- `ensureDefaults()` stamps the default `builtin: true` and **upgrades existing installs in place** (no re-copy).
- The old `retired` mechanism is removed — it only existed to remember a deleted default, which is no longer possible. The escape hatch for an unwanted bed is the **feature toggle** (`settings.beds.enabled`, off by default), which silences beds without losing the asset. `loadMeta()` still tolerates a stale `retired` key on old sidecars.
- *Migration note:* an install that had previously deleted `ambient-room` gets it reinstalled as a protected built-in on next boot.

**Goal 3 — generate a bed via ElevenLabs**
- New `audio/bed-gen.ts` calls the ElevenLabs **Music API** (`POST /v1/music`, `force_instrumental: true`) rather than the sfx sound-generation endpoint — a bed needs ≥30 s of instrumental music (sound-generation caps at 22 s).
- `beds.create()` + `POST /beds` mirror the SFX Create flow; length 30–120 s (default 45), gated on the same ElevenLabs key.
- New Create modal in the Beds tab (Name / Length / Description / prompt), with the same "no key" alert SFX shows.

**Refactor:** extracted the shared ElevenLabs key resolver into `audio/elevenlabs.ts` so beds don't import from the sfx module (behaviour-preserving; `sfx-gen` re-exports `isConfigured` for back-compat).

## Notes
- ElevenLabs Music is a separately-metered feature; a key without Music entitlement surfaces the API error on generate (same failure shape as a failed SFX generate). `generatorReady` means only "a key is present".
- No Liquidsoap / bed-selection / playback changes. No new settings keys.
- Model pinned to `music_v1` (one-line constant, easy to bump to `music_v2`).

## Testing
- `npm run lint` (eslint + `tsc --noEmit`) passes in **controller** and **web**.
- Manual: fresh state boots with one built-in bed (delete disabled); with a key, Create yields a ≥30 s instrumental that appears in the library and is selectable for a long link; without a key, Create is gated. Prod controller change needs an image rebuild.

Design spec: `docs/superpowers/specs/2026-07-23-imaging-beds-protect-and-generate-design.md`