### PR TITLE
feat(web): collapsible Library submenu (Playlists + Observatory) in admin sidebar

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -165,7 +165,11 @@
        .admin-root. --page-bg deepens slightly in dark mode below. */
     --card-bg: var(--bg);
     --page-bg: color-mix(in oklab, var(--bg) 90%, var(--ink));
-    --sidebar: var(--page-bg);
+    /* The sidebar rail sits ~12% darker than the admin page so it reads as its
+       own chrome. "Darker" flips direction per theme: toward --ink in light
+       (preserves the paper warmth), toward black in the dark overrides below
+       (where --ink is light and mixing toward it would lighten instead). */
+    --sidebar: color-mix(in oklab, var(--page-bg), var(--ink) 12%);
     --sidebar-foreground: var(--ink);
     --sidebar-primary: var(--ink);
     --sidebar-primary-foreground: var(--bg);
@@ -197,8 +201,10 @@
         --grain-color: 0.55 0.5 0.45;
         --grain-alpha: 0.25;
         --grain-blend: screen;
-        /* Admin page deepens slightly in dark mode (--sidebar tracks it). */
+        /* Admin page deepens slightly in dark mode. */
         --page-bg: color-mix(in oklab, var(--bg) 88%, var(--ink));
+        /* Sidebar darker than the page — toward black, since --ink is light here. */
+        --sidebar: color-mix(in oklab, var(--page-bg), #000 15%);
         color-scheme: dark;
     }
 }
@@ -219,6 +225,8 @@
     --grain-alpha: 0.25;
     --grain-blend: screen;
     --page-bg: color-mix(in oklab, var(--bg) 88%, var(--ink));
+    /* Sidebar darker than the page — toward black, since --ink is light here. */
+    --sidebar: color-mix(in oklab, var(--page-bg), #000 15%);
     color-scheme: dark;
 }
 

--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import type { ComponentType, CSSProperties, ReactNode } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { AnimatePresence, m } from 'motion/react';
@@ -32,6 +32,12 @@ import {
   MoreHorizontal,
   ListMusic,
   Telescope,
+  Clock,
+  CalendarDays,
+  Volume2,
+  Music,
+  AudioLines,
+  Waves,
 } from 'lucide-react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import type { SignInResult } from '../../lib/adminAuth';
@@ -95,6 +101,12 @@ interface NavSubItem {
   id: string;
   label: string;
   icon: NavIcon;
+  // Tab-based children (Moods / Imaging) share the parent's page and differ
+  // only by ?tab=. `tab` is the query value this item selects; `defaultTab`
+  // marks the one shown when the URL carries no (or an unknown) ?tab=. Route
+  // children (Library → Playlists / Observatory) leave both unset.
+  tab?: string;
+  defaultTab?: boolean;
 }
 
 interface NavItem {
@@ -143,8 +155,31 @@ const NAV_SECTIONS: NavSection[] = [
       { href: '/admin/shows', id: 'shows', label: 'Shows', icon: CalendarClock },
       { href: '/admin/personas', id: 'personas', label: 'Personas', icon: Drama },
       { href: '/admin/skills', id: 'skills', label: 'Skills', icon: Sparkles },
-      { href: '/admin/imaging', id: 'imaging', label: 'Imaging', icon: Podcast },
-      { href: '/admin/moods', id: 'moods', label: 'Moods', icon: Palette },
+      // Imaging + Moods are single pages with ?tab= sections; the submenu
+      // deep-links into each tab (see ImagingPanel / MoodsPanel).
+      {
+        href: '/admin/imaging',
+        id: 'imaging',
+        label: 'Imaging',
+        icon: Podcast,
+        children: [
+          { href: '/admin/imaging?tab=jingles', id: 'imaging-jingles', label: 'Jingles', icon: Music, tab: 'jingles', defaultTab: true },
+          { href: '/admin/imaging?tab=sfx', id: 'imaging-sfx', label: 'SFX', icon: AudioLines, tab: 'sfx' },
+          { href: '/admin/imaging?tab=beds', id: 'imaging-beds', label: 'Beds', icon: Waves, tab: 'beds' },
+        ],
+      },
+      {
+        href: '/admin/moods',
+        id: 'moods',
+        label: 'Moods',
+        icon: Palette,
+        children: [
+          { href: '/admin/moods?tab=vocab', id: 'moods-vocab', label: 'Vocabulary', icon: Palette, tab: 'vocab', defaultTab: true },
+          { href: '/admin/moods?tab=moments', id: 'moods-moments', label: 'Moments', icon: Clock, tab: 'moments' },
+          { href: '/admin/moods?tab=festivals', id: 'moods-festivals', label: 'Festivals', icon: CalendarDays, tab: 'festivals' },
+          { href: '/admin/moods?tab=speech', id: 'moods-speech', label: 'Speech', icon: Volume2, tab: 'speech' },
+        ],
+      },
     ],
   },
   {
@@ -519,15 +554,38 @@ function CollapsibleNavItem({
   onNavigate: () => void;
 }) {
   const children = item.children ?? [];
-  const onChild = children.some(c => !!pathname && pathname.startsWith(c.href));
-  const parentActive = !!pathname && pathname.startsWith(item.href) && !onChild;
-  const sectionActive = (!!pathname && pathname.startsWith(item.href)) || onChild;
-  const [open, setOpen] = useState(sectionActive);
+  const searchParams = useSearchParams();
+
+  // Tab-based groups (Moods / Imaging) share the parent page and select a
+  // section via ?tab=; resolve the effective tab (falling back to the group's
+  // default when the URL has none/unknown), then a child is active when the
+  // page matches and its tab is the effective one. Route-based groups (Library)
+  // just prefix-match their child's own path.
+  const tabChildren = children.filter(c => c.tab != null);
+  const validTabs = tabChildren.map(c => c.tab as string);
+  const rawTab = searchParams.get('tab');
+  const effectiveTab =
+    rawTab && validTabs.includes(rawTab)
+      ? rawTab
+      : (tabChildren.find(c => c.defaultTab)?.tab ?? null);
+  const childActive = (sub: NavSubItem): boolean =>
+    sub.tab != null
+      ? pathname === item.href && sub.tab === effectiveTab
+      : !!pathname && pathname.startsWith(sub.href);
+
+  const hasActiveChild = children.some(childActive);
+  const onSection = (!!pathname && pathname.startsWith(item.href)) || hasActiveChild;
+  // Parent shows the filled pill only on its own page with no child selected
+  // (Library's overview). Tab groups always have a child selected, so the pill
+  // moves to the child and the parent stays a plain, open group header.
+  const parentActive = onSection && !hasActiveChild;
+
+  const [open, setOpen] = useState(onSection);
   // Reveal the group whenever a nav lands on one of its pages (the shell is
   // persistent, so the state survives across route changes otherwise).
   useEffect(() => {
-    if (sectionActive) setOpen(true);
-  }, [sectionActive]);
+    if (onSection) setOpen(true);
+  }, [onSection]);
   const Icon = item.icon;
   return (
     <Collapsible open={open} onOpenChange={setOpen} asChild>
@@ -554,11 +612,10 @@ function CollapsibleNavItem({
         <CollapsibleContent>
           <SidebarMenuSub className="mt-1">
             {children.map(sub => {
-              const subActive = !!pathname && pathname.startsWith(sub.href);
               const SubIcon = sub.icon;
               return (
                 <SidebarMenuSubItem key={sub.id}>
-                  <SidebarMenuSubButton asChild isActive={subActive}>
+                  <SidebarMenuSubButton asChild isActive={childActive(sub)}>
                     <Link href={sub.href} onClick={onNavigate}>
                       <SubIcon aria-hidden="true" />
                       <span className="truncate">{sub.label}</span>

--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -28,7 +28,10 @@ import {
   Palette,
   LogOut,
   ChevronDown,
+  ChevronRight,
   MoreHorizontal,
+  ListMusic,
+  Telescope,
 } from 'lucide-react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import type { SignInResult } from '../../lib/adminAuth';
@@ -49,14 +52,19 @@ import {
   SidebarHeader,
   SidebarInset,
   SidebarMenu,
+  SidebarMenuAction,
   SidebarMenuBadge,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
   SidebarProvider,
   SidebarRail,
   SidebarTrigger,
   useSidebar,
 } from '../ui/sidebar';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -82,12 +90,23 @@ type NavIcon = ComponentType<{
   'aria-hidden'?: boolean | 'true' | 'false';
 }>;
 
+interface NavSubItem {
+  href: string;
+  id: string;
+  label: string;
+  icon: NavIcon;
+}
+
 interface NavItem {
   href: string;
   id: string;
   label: string;
   icon: NavIcon;
   pill?: string;
+  // Nested pages surfaced under a collapsible submenu (e.g. Library →
+  // Playlists / Observatory). The parent still links to its own page; the
+  // chevron toggles the sub-items.
+  children?: NavSubItem[];
 }
 
 interface NavSection {
@@ -107,9 +126,20 @@ const NAV_SECTIONS: NavSection[] = [
   {
     label: 'Programming',
     items: [
-      // Playlists (/admin/playlists) and the Observatory (/observatory) are
-      // reached from doorways inside Library — not top-level nav items.
-      { href: '/admin/library', id: 'library', label: 'Library', icon: Disc3 },
+      // Library owns a collapsible submenu — Playlists (/admin/playlists) and
+      // the Observatory (/observatory) live under its wing. The parent still
+      // links to /admin/library; the chevron opens/closes the sub-items (which
+      // also stay reachable from the doorway cards inside the Library page).
+      {
+        href: '/admin/library',
+        id: 'library',
+        label: 'Library',
+        icon: Disc3,
+        children: [
+          { href: '/admin/playlists', id: 'playlists', label: 'Playlists', icon: ListMusic },
+          { href: '/observatory', id: 'observatory', label: 'Observatory', icon: Telescope },
+        ],
+      },
       { href: '/admin/shows', id: 'shows', label: 'Shows', icon: CalendarClock },
       { href: '/admin/personas', id: 'personas', label: 'Personas', icon: Drama },
       { href: '/admin/skills', id: 'skills', label: 'Skills', icon: Sparkles },
@@ -322,41 +352,23 @@ function AdminSidebar({
           <SidebarGroup key={section.label} className="p-0">
             <SidebarGroupLabel>{section.label}</SidebarGroupLabel>
             <SidebarMenu className="gap-1.5">
-              {section.items.map(n => {
-                // Playlists lives under Library's wing — keep Library lit there.
-                const active =
-                  !!pathname &&
-                  (pathname.startsWith(n.href) ||
-                    (n.id === 'library' && pathname.startsWith('/admin/playlists')));
-                const Icon = n.icon;
-                return (
-                  <SidebarMenuItem key={n.id}>
-                    <SidebarMenuButton asChild isActive={active} tooltip={n.label}>
-                      <Link href={n.href} onClick={closeOnMobileNav}>
-                        {/* Active background morphs across nav groups via a
-                            shared layoutId — same trick as DotRail. The icon
-                            and label sit above it via z-index. */}
-                        {active && (
-                          <m.span
-                            layoutId="admin-nav-active"
-                            className="absolute inset-0 z-0 bg-ink"
-                            initial={false}
-                            transition={{ type: 'spring', stiffness: 380, damping: 32 }}
-                            aria-hidden="true"
-                          />
-                        )}
-                        <Icon
-                          className="relative z-[1] shrink-0 opacity-80"
-                          strokeWidth={2}
-                          aria-hidden="true"
-                        />
-                        <span className="relative z-[1] flex-1 truncate">{n.label}</span>
-                      </Link>
-                    </SidebarMenuButton>
-                    {n.pill && <SidebarMenuBadge>{n.pill}</SidebarMenuBadge>}
-                  </SidebarMenuItem>
-                );
-              })}
+              {section.items.map(n =>
+                n.children?.length ? (
+                  <CollapsibleNavItem
+                    key={n.id}
+                    item={n}
+                    pathname={pathname}
+                    onNavigate={closeOnMobileNav}
+                  />
+                ) : (
+                  <NavItemRow
+                    key={n.id}
+                    item={n}
+                    pathname={pathname}
+                    onNavigate={closeOnMobileNav}
+                  />
+                ),
+              )}
             </SidebarMenu>
           </SidebarGroup>
         ))}
@@ -447,6 +459,118 @@ function AdminSidebar({
         onConfirm={onSignOut}
       />
     </Sidebar>
+  );
+}
+
+// The filled active pill, morphed across nav rows via a shared layoutId — same
+// trick as DotRail. Only ever ONE row renders it at a time (sub-items use their
+// own subtler highlight), so the layout animation never doubles up.
+function NavActiveBg() {
+  return (
+    <m.span
+      layoutId="admin-nav-active"
+      className="absolute inset-0 z-0 bg-ink"
+      initial={false}
+      transition={{ type: 'spring', stiffness: 380, damping: 32 }}
+      aria-hidden="true"
+    />
+  );
+}
+
+// A plain (childless) nav row.
+function NavItemRow({
+  item,
+  pathname,
+  onNavigate,
+}: {
+  item: NavItem;
+  pathname: string | null;
+  onNavigate: () => void;
+}) {
+  const active = !!pathname && pathname.startsWith(item.href);
+  const Icon = item.icon;
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton asChild isActive={active} tooltip={item.label}>
+        <Link href={item.href} onClick={onNavigate}>
+          {active && <NavActiveBg />}
+          <Icon className="relative z-[1] shrink-0 opacity-80" strokeWidth={2} aria-hidden="true" />
+          <span className="relative z-[1] flex-1 truncate">{item.label}</span>
+        </Link>
+      </SidebarMenuButton>
+      {item.pill && <SidebarMenuBadge>{item.pill}</SidebarMenuBadge>}
+    </SidebarMenuItem>
+  );
+}
+
+// A nav row that owns a collapsible submenu (Library → Playlists / Observatory).
+// The parent button still links to its own page; a chevron action toggles the
+// sub-items open/closed. The group auto-opens whenever the operator is on the
+// parent or any of its child pages. In the icon-collapsed rail both the chevron
+// and the sub-list hide (built into SidebarMenuAction / SidebarMenuSub), so the
+// parent icon just links straight through.
+function CollapsibleNavItem({
+  item,
+  pathname,
+  onNavigate,
+}: {
+  item: NavItem;
+  pathname: string | null;
+  onNavigate: () => void;
+}) {
+  const children = item.children ?? [];
+  const onChild = children.some(c => !!pathname && pathname.startsWith(c.href));
+  const parentActive = !!pathname && pathname.startsWith(item.href) && !onChild;
+  const sectionActive = (!!pathname && pathname.startsWith(item.href)) || onChild;
+  const [open, setOpen] = useState(sectionActive);
+  // Reveal the group whenever a nav lands on one of its pages (the shell is
+  // persistent, so the state survives across route changes otherwise).
+  useEffect(() => {
+    if (sectionActive) setOpen(true);
+  }, [sectionActive]);
+  const Icon = item.icon;
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} asChild>
+      <SidebarMenuItem>
+        <SidebarMenuButton asChild isActive={parentActive} tooltip={item.label}>
+          <Link href={item.href} onClick={onNavigate}>
+            {parentActive && <NavActiveBg />}
+            <Icon
+              className="relative z-[1] shrink-0 opacity-80"
+              strokeWidth={2}
+              aria-hidden="true"
+            />
+            <span className="relative z-[1] flex-1 truncate">{item.label}</span>
+          </Link>
+        </SidebarMenuButton>
+        <CollapsibleTrigger asChild>
+          <SidebarMenuAction
+            className="z-[2] transition-transform data-[state=open]:rotate-90"
+            aria-label={`Toggle ${item.label} submenu`}
+          >
+            <ChevronRight strokeWidth={2} aria-hidden="true" />
+          </SidebarMenuAction>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <SidebarMenuSub className="mt-1">
+            {children.map(sub => {
+              const subActive = !!pathname && pathname.startsWith(sub.href);
+              const SubIcon = sub.icon;
+              return (
+                <SidebarMenuSubItem key={sub.id}>
+                  <SidebarMenuSubButton asChild isActive={subActive}>
+                    <Link href={sub.href} onClick={onNavigate}>
+                      <SubIcon aria-hidden="true" />
+                      <span className="truncate">{sub.label}</span>
+                    </Link>
+                  </SidebarMenuSubButton>
+                </SidebarMenuSubItem>
+              );
+            })}
+          </SidebarMenuSub>
+        </CollapsibleContent>
+      </SidebarMenuItem>
+    </Collapsible>
   );
 }
 

--- a/web/components/admin/MoodsPanel.tsx
+++ b/web/components/admin/MoodsPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Trash2, Palette, Clock, CalendarDays, Volume2 } from 'lucide-react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { notify, errorMessage } from '../../lib/notify';
@@ -58,7 +59,15 @@ export default function MoodsPanel() {
   const { adminFetch, needsAuth, hydrated } = useAdminAuth();
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null); // which card is saving
-  const [tab, setTab] = useState<TabId>('vocab');
+
+  // The active tab is derived from the URL (?tab=…) so it stays a single source
+  // of truth: both the in-page SectionTabs and the sidebar's Moods submenu drive
+  // it through the router, and switching tabs while already on the page works.
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const rawTab = searchParams.get('tab');
+  const tab: TabId = (TAB_IDS as string[]).includes(rawTab ?? '') ? (rawTab as TabId) : 'vocab';
 
   // Working copies + saved baselines (for dirty detection).
   const [moods, setMoods] = useState<MoodEntry[] | null>(null);
@@ -110,21 +119,16 @@ export default function MoodsPanel() {
   }, [hydrated, needsAuth, load]);
 
   // Deep-link: /admin/moods?tab=moments opens that tab directly (mirrors
-  // /admin/imaging?tab=… and /admin/connect?tab=…).
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const t = new URLSearchParams(window.location.search).get('tab');
-    if (t && (TAB_IDS as string[]).includes(t)) setTab(t as TabId);
-  }, []);
-
-  const selectTab = useCallback((id: string) => {
-    setTab(id as TabId);
-    if (typeof window !== 'undefined') {
-      const url = new URL(window.location.href);
-      url.searchParams.set('tab', id);
-      window.history.replaceState(null, '', url.toString());
-    }
-  }, []);
+  // /admin/imaging?tab=… and /admin/connect?tab=…). Routed through the Next
+  // router so a soft nav (in-page tab or sidebar submenu) re-derives `tab`.
+  const selectTab = useCallback(
+    (id: string) => {
+      const params = new URLSearchParams(Array.from(searchParams.entries()));
+      params.set('tab', id);
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [router, pathname, searchParams],
+  );
 
   // POST one settings slice; on success adopt the sent value as the new
   // baseline. The controller validates strictly and returns a clear message

--- a/web/components/admin/imaging/ImagingPanel.tsx
+++ b/web/components/admin/imaging/ImagingPanel.tsx
@@ -15,6 +15,7 @@
    ConnectPanel (Seg control + ?tab= deep-link). */
 
 import { useCallback, useEffect, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Music, AudioLines, Waves } from 'lucide-react';
 import { useAdminAuth } from '../../../lib/adminAuth';
 import { notify, errorMessage } from '../../../lib/notify';
@@ -38,7 +39,15 @@ export default function ImagingPanel() {
   const [bedsData, setBedsData] = useState<BedsData | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  const [tab, setTab] = useState<TabId>('jingles');
+
+  // Active tab derived from the URL (?tab=…) — single source of truth shared by
+  // the in-page SectionTabs and the sidebar's Imaging submenu (both route
+  // through Next), so switching tabs while already on the page works.
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const rawTab = searchParams.get('tab');
+  const tab: TabId = (TAB_IDS as string[]).includes(rawTab ?? '') ? (rawTab as TabId) : 'jingles';
 
   // Jingles: the create-text box + the lone settings field this page carries
   // (the whole FormState stayed behind in SettingsPanel). null = not yet
@@ -80,14 +89,6 @@ export default function ImagingPanel() {
     } catch { /* non-fatal */ }
   };
 
-  // Deep-link: /admin/imaging?tab=sfx opens that tab directly (mirrors
-  // /admin/connect?tab=… and the old /admin/settings?section=…).
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const t = new URLSearchParams(window.location.search).get('tab');
-    if (t && (TAB_IDS as string[]).includes(t)) setTab(t as TabId);
-  }, []);
-
   useEffect(() => {
     if (!hydrated || needsAuth) return;
     refresh(); refreshSfx(); refreshBeds();
@@ -100,14 +101,17 @@ export default function ImagingPanel() {
     if (data?.values && jingleRatio == null) setJingleRatio(String(data.values.jingleRatio ?? ''));
   }, [data, jingleRatio]);
 
-  const selectTab = useCallback((id: string) => {
-    setTab(id as TabId);
-    if (typeof window !== 'undefined') {
-      const url = new URL(window.location.href);
-      url.searchParams.set('tab', id);
-      window.history.replaceState(null, '', url.toString());
-    }
-  }, []);
+  // Deep-link: /admin/imaging?tab=sfx opens that tab directly (mirrors
+  // /admin/connect?tab=…). Routed through Next so a soft nav (in-page tab or
+  // sidebar submenu) re-derives `tab`.
+  const selectTab = useCallback(
+    (id: string) => {
+      const params = new URLSearchParams(Array.from(searchParams.entries()));
+      params.set('tab', id);
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [router, pathname, searchParams],
+  );
 
   const saveSettings: SaveSettings = async (patch) => {
     setBusy(true);


### PR DESCRIPTION
## What

Turns the admin sidebar's **Library** entry into a collapsible group that opens/collapses to reveal **Playlists** and **Observatory** as sub-items — using shadcn's collapsible-sidebar pattern.

Before, Playlists (`/admin/playlists`) and the Observatory (`/observatory`) were only reachable from doorway cards *inside* the Library page. They're now first-class in the rail while still keeping those doorways.

## How

- Added an optional `children` field to the nav-item model; Library declares Playlists + Observatory children.
- Extracted two row components in `AdminShell.tsx`:
  - `NavItemRow` — the existing plain row (unchanged behaviour).
  - `CollapsibleNavItem` — parent `SidebarMenuButton` (still a `Link` to `/admin/library`) + a `SidebarMenuAction` chevron wired to a `Collapsible`, with `SidebarMenuSub` sub-items.
- The group auto-opens when the operator is on the parent or any child page; the operator can still toggle it by hand.
- Sub-items use their own active highlight, so the shared `admin-nav-active` layoutId pill stays single-instance (no doubled layout animation).
- In the icon-collapsed rail, the chevron and sub-list hide (built into `SidebarMenuAction` / `SidebarMenuSub`) and the parent icon links straight through.

## Verification

- `web` lint (`eslint . && tsc --noEmit`) passes clean.
- Pure presentational change — no controller/API surface touched.