### PR TITLE
feat(web): shared admin loading/empty/error states

### DIFF
--- a/web/components/admin/ArchivesPanel.tsx
+++ b/web/components/admin/ArchivesPanel.tsx
@@ -10,6 +10,9 @@ import { useAdminAuth } from '../../lib/adminAuth';
 import { fmtSize, relTime } from '../../lib/format';
 import { Card, Btn, Eyebrow, Pill } from './ui';
 import { V3AlertDialog } from '../ui/alert-dialog';
+import { SkeletonRows } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
+import { ErrorState } from '@/components/ui/error-state';
 
 interface ArchiveEntry {
   path: string;
@@ -94,14 +97,14 @@ export default function ArchivesPanel() {
   if (err) {
     return (
       <div className="grid gap-4">
-        <Card title="Archives"><div className="text-[13px] text-[var(--danger)]">controller error: {err}</div></Card>
+        <ErrorState error={err} onRetry={load} />
       </div>
     );
   }
   if (!entries) {
     return (
       <div className="grid gap-4">
-        <Card title="Archives"><div className="text-[13px] text-muted italic">loading…</div></Card>
+        <SkeletonRows rows={4} />
       </div>
     );
   }
@@ -174,11 +177,16 @@ export default function ArchivesPanel() {
       )}
 
       {byDate.length === 0 && (
-        <Card title="No recordings yet">
-          <div className="text-[12px] leading-[1.6] text-muted">
-            The first hour writes once the clock crosses the next <code>HH:00</code>. If you started the
-            station mid-hour, you&rsquo;ll see the first file after the next top of the hour.
-          </div>
+        <Card>
+          <EmptyState
+            title="No recordings yet"
+            description={
+              <>
+                The first hour writes once the clock crosses the next <code>HH:00</code>. If you started the
+                station mid-hour, you&rsquo;ll see the first file after the next top of the hour.
+              </>
+            }
+          />
         </Card>
       )}
 

--- a/web/components/admin/BackupPanel.tsx
+++ b/web/components/admin/BackupPanel.tsx
@@ -206,7 +206,7 @@ export default function BackupPanel() {
 
       <Card title="Export" sub="Download a full config + tag-DB snapshot.">
         {exportErr && (
-          <div className="mb-2 text-[12px] text-[var(--danger)]">export error: {exportErr}</div>
+          <div className="mb-2 text-[12px] leading-[1.6] text-[var(--danger)]">export error: {exportErr}</div>
         )}
         <Btn tone="accent" onClick={exportBackup} disabled={exporting}>
           {exporting ? 'Preparing…' : 'Download backup'}
@@ -278,7 +278,7 @@ export default function BackupPanel() {
           ) : null}
           , then <strong>Refresh</strong> and restore it here; it never travels through the proxy.
         </div>
-        {diskErr && <div className="mb-2 text-[12px] text-[var(--danger)]">{diskErr}</div>}
+        {diskErr && <div className="mb-2 text-[12px] leading-[1.6] text-[var(--danger)]">{diskErr}</div>}
         {diskFiles && diskFiles.length === 0 && !diskErr && (
           <div className="text-[12px] text-muted">
             No <code className="text-ink">.zip</code> backups found in the station folder yet.

--- a/web/components/admin/DashPanel.tsx
+++ b/web/components/admin/DashPanel.tsx
@@ -21,7 +21,8 @@ import type {
   StationLocale,
 } from '../../lib/types';
 import { V3AlertDialog } from '../ui/alert-dialog';
-import { V3Alert } from '../ui/alert';
+import { SkeletonText } from '@/components/ui/skeleton';
+import { ErrorState } from '@/components/ui/error-state';
 import { Card, Btn, Pill, Seg, Toggle } from './ui';
 import {
   Queue,
@@ -572,11 +573,7 @@ export default function DashPanel() {
         onSkip={() => setConfirmSkip(true)}
       />
 
-      {err && (
-        <V3Alert tone="error" title="controller error">
-          {err}
-        </V3Alert>
-      )}
+      {err && <ErrorState error={err} />}
 
       {/* ── 2-COL OPS ──────────────────────────────────────────────────── */}
       <div className="stack-mobile grid grid-cols-[1.4fr_1fr] gap-4">
@@ -880,7 +877,7 @@ export default function DashPanel() {
         {connErr ? (
           <div className="text-muted italic">can’t reach Icecast admin: {connErr}</div>
         ) : !conns ? (
-          <div className="text-muted italic">loading…</div>
+          <SkeletonText lines={2} />
         ) : conns.connections.length === 0 ? (
           <div className="text-muted italic">nobody listening right now</div>
         ) : (
@@ -1090,7 +1087,7 @@ function RequestsCard({
       {err ? (
         <div className="text-muted italic">can’t load requests: {err}</div>
       ) : !requests ? (
-        <div className="text-muted italic">loading…</div>
+        <SkeletonText lines={2} />
       ) : requests.length === 0 ? (
         <div className="text-muted italic">no requests yet</div>
       ) : (
@@ -1136,11 +1133,9 @@ function LikesCard({
       {err ? (
         <div className="text-muted italic">can’t load likes: {err}</div>
       ) : !likes ? (
-        <div className="text-muted italic">loading…</div>
+        <SkeletonText lines={2} />
       ) : recent.length === 0 ? (
-        <div className="text-muted italic">
-          no likes yet — the heart button on the player feeds this
-        </div>
+        <span className="text-[12px] text-muted">No likes yet — the heart on the player feeds this.</span>
       ) : (
         <div className="grid gap-3">
           {top.length > 0 && (

--- a/web/components/admin/DebugPanel.tsx
+++ b/web/components/admin/DebugPanel.tsx
@@ -10,6 +10,8 @@ import { Checkbox } from '../ui/checkbox';
 import { Label } from '../ui/label';
 import { Card, Btn, Pill, Eyebrow } from './ui';
 import { ScrollArea } from '../ui/scroll-area';
+import { SkeletonRows } from '@/components/ui/skeleton';
+import { ErrorState } from '@/components/ui/error-state';
 import { cn } from '../../lib/cn';
 import type { StationLocale } from '../../lib/types';
 import {
@@ -374,11 +376,11 @@ export default function DebugPanel() {
         </div>
       </section>
 
-      {err && <V3Alert tone="error" title="controller error">{err}</V3Alert>}
+      {err && <ErrorState error={err} />}
 
       {!data && !err && (
         <Card title="Debug">
-          <span className="field-hint italic">connecting…</span>
+          <SkeletonRows rows={6} />
         </Card>
       )}
 
@@ -699,8 +701,8 @@ function TtsCallList({ calls }: { calls: TtsCall[] }) {
       <ScrollArea className="max-h-[420px]">
         <div className="grid gap-1.5">
         {shown.length === 0 && (
-          <span className="field-hint italic">
-            {calls.length === 0 ? 'no spoken segments yet' : 'no calls match this filter'}
+          <span className="field-hint text-muted">
+            {calls.length === 0 ? 'No spoken segments yet' : 'No calls match this filter'}
           </span>
         )}
         {shown.map((c, i) => (
@@ -1306,8 +1308,8 @@ function LlmCalls({ llm }: { llm: DebugLlm | undefined }) {
       <ScrollArea className="max-h-[600px]">
         <div className="grid gap-1.5">
           {shown.length === 0 && (
-            <span className="field-hint italic">
-              {calls.length === 0 ? 'no calls yet' : 'no calls match this filter'}
+            <span className="field-hint text-muted">
+              {calls.length === 0 ? 'No calls yet' : 'No calls match this filter'}
             </span>
           )}
           {shown.map((c, i) => (
@@ -1400,8 +1402,8 @@ function SubsonicCalls({ subsonic }: { subsonic: DebugSubsonic | undefined }) {
   if (!subsonic || subsonic.error) {
     return (
       <Card title="Subsonic API calls">
-        <span className="field-hint italic">
-          {subsonic?.error || 'no data yet'}
+        <span className="field-hint text-muted">
+          {subsonic?.error || 'No data yet'}
         </span>
       </Card>
     );
@@ -1447,8 +1449,8 @@ function SubsonicCalls({ subsonic }: { subsonic: DebugSubsonic | undefined }) {
           <ScrollArea className="max-h-[480px]">
             <div className="grid gap-1.5">
               {shown.length === 0 && (
-                <span className="field-hint italic">
-                  {calls.length === 0 ? 'no calls yet' : 'no calls match this filter'}
+                <span className="field-hint text-muted">
+                  {calls.length === 0 ? 'No calls yet' : 'No calls match this filter'}
                 </span>
               )}
               {shown.map((c, i) => (

--- a/web/components/admin/DoctorPanel.tsx
+++ b/web/components/admin/DoctorPanel.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { notify, errorMessage } from '../../lib/notify';
 import { Card, Btn, Pill } from './ui';
+import { ErrorState } from '@/components/ui/error-state';
 import BoothBuddy, { type BuddyMood } from '../BoothBuddy';
 import { ChevronDownIcon } from 'lucide-react';
 import { Task, TaskContent, TaskItem, TaskTrigger } from '../ai-elements/task';
@@ -399,7 +400,7 @@ export default function DoctorPanel() {
                   Runs the full check and gets DJ Doc&apos;s read in one go.
                 </span>
               </div>
-              {err && <p className="mt-3 text-[13px] text-[var(--accent)]">{err}</p>}
+              {err && <ErrorState error={err} onRetry={run} />}
             </div>
           </div>
         </Card>
@@ -445,7 +446,7 @@ export default function DoctorPanel() {
                   last run {new Date(report.t).toLocaleTimeString()}
                 </span>
               </div>
-              {err && <p className="mt-3 text-[13px] text-[var(--accent)]">{err}</p>}
+              {err && <ErrorState error={err} onRetry={run} />}
             </div>
           </div>
         </Card>

--- a/web/components/admin/FestivalsSection.tsx
+++ b/web/components/admin/FestivalsSection.tsx
@@ -12,6 +12,9 @@ import {
 } from '../ui/select';
 import { Modal } from '../ui/modal';
 import { V3AlertDialog } from '../ui/alert-dialog';
+import { SkeletonRows } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
+import { ErrorState } from '@/components/ui/error-state';
 
 interface Festival {
   month: number;
@@ -201,15 +204,9 @@ export default function FestivalsSection() {
         }
       />
 
-      {err && (
-        <Card>
-          <div className="text-[var(--danger)]">{err}</div>
-        </Card>
-      )}
+      {err && <ErrorState error={err} onRetry={load} />}
 
-      {festivals === null && !err && (
-        <div className="text-[13px] text-muted italic">loading…</div>
-      )}
+      {festivals === null && !err && <SkeletonRows rows={4} />}
 
       {festivals !== null && (
         <Card
@@ -217,9 +214,10 @@ export default function FestivalsSection() {
           sub={`${festivals.length} date${festivals.length === 1 ? '' : 's'} · click one to edit`}
         >
           {festivals.length === 0 ? (
-            <div className="text-[13px] text-muted italic">
-              No festivals defined. Add one to get started.
-            </div>
+            <EmptyState
+              title="No festivals defined"
+              description="Add one so the station can theme the day around it."
+            />
           ) : (
             <div className="grid">
               {months.map(({ month, rows }) => (

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -42,6 +42,8 @@ import { cn } from '../../lib/cn';
 import TaggingPanel, { num } from './LibraryTaggingPanel';
 import type { Coverage, TaggerState, LibraryStatsLite, Batch, BudgetMode, RescanOpts, TagSteps } from './LibraryTaggingPanel';
 import type { PlaylistSummary } from './LibraryPlaylistsTab';
+import { SkeletonRows, SkeletonText } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
 
 // ---------------------------------------------------------------------------
 // types
@@ -1737,16 +1739,22 @@ interface TrackTableProps {
 
 function TrackTable(p: TrackTableProps) {
   if (p.loading && p.rows.length === 0) {
-    return <div className="px-4 py-8 text-center text-[12px] text-muted italic">loading…</div>;
+    return <SkeletonRows rows={6} />;
   }
   if (p.rows.length === 0) {
     return (
-      <div className="px-4 py-10 text-center text-[12px] text-muted italic">
-        {p.tab === 'browse' && 'no tracks match, try clearing some filters'}
-        {p.tab === 'search' && 'search your library to queue a track on demand'}
-        {p.tab === 'untagged' && 'every track is tagged, nice'}
-        {p.tab === 'recent' && 'nothing here yet'}
-      </div>
+      <>
+        {p.tab === 'browse' && (
+          <EmptyState compact title="No tracks match" description="Try clearing some filters." />
+        )}
+        {p.tab === 'search' && (
+          <EmptyState compact title="Search your library" description="Find a track to queue on demand." />
+        )}
+        {p.tab === 'untagged' && (
+          <EmptyState compact title="Everything's tagged" description="Nice — the whole library has moods." />
+        )}
+        {p.tab === 'recent' && <EmptyState compact title="Nothing here yet" />}
+      </>
     );
   }
 
@@ -1934,11 +1942,15 @@ function BlockedTab({ entries, loading, unblocking, onUnblock, onRefresh }: {
       bodyClass="!p-0"
     >
       {rows.length === 0 ? (
-        <div className="px-4 py-10 text-center text-[12px] text-muted italic">
-          {loading ? 'loading…' : (
-            <>nothing blocked — use the <Ban size={11} className="inline align-[-1px]" /> action on any track row to keep a track, album or artist off the air</>
-          )}
-        </div>
+        loading ? (
+          <SkeletonRows rows={4} className="m-4" />
+        ) : (
+          <EmptyState
+            compact
+            title="Nothing blocked"
+            description={<>Use the <Ban size={11} className="inline align-[-1px]" /> action on any track row to keep a track, album or artist off the air.</>}
+          />
+        )
       ) : (
         <div className={cn(loading && 'opacity-60 transition-opacity')}>
           {rows.map(e => {
@@ -2013,11 +2025,15 @@ function HistoryTab({ rows, total, page, setPage, loading, queuing, onQueue, onR
         bodyClass="!p-0"
       >
         {!rows || rows.length === 0 ? (
-          <div className="px-4 py-10 text-center text-[12px] text-muted italic">
-            {loading || !rows
-              ? 'loading…'
-              : 'nothing on record yet — plays are logged from the moment this version starts airing tracks'}
-          </div>
+          loading || !rows ? (
+            <SkeletonRows rows={4} className="m-4" />
+          ) : (
+            <EmptyState
+              compact
+              title="Nothing on record yet"
+              description="Plays are logged from the moment this version starts airing tracks."
+            />
+          )
         ) : (
           <div className={cn(loading && 'opacity-60 transition-opacity')}>
             {rows.map((p, i) => {
@@ -2111,9 +2127,7 @@ function ManualTagEditor(props: {
       <div className="grid gap-1.5">
         <Eyebrow>moods · up to 3</Eyebrow>
         <div className="flex flex-wrap gap-1.5">
-          {vocab.length === 0 && (
-            <span className="text-[11px] text-muted italic">loading moods…</span>
-          )}
+          {vocab.length === 0 && <SkeletonText lines={1} />}
           {vocab.map(m => {
             const on = sel.includes(m);
             return (

--- a/web/components/admin/LibraryPlaylistsTab.tsx
+++ b/web/components/admin/LibraryPlaylistsTab.tsx
@@ -13,6 +13,8 @@ import { notify, errorMessage } from '../../lib/notify';
 import { Input } from '../ui/input';
 import { Card, Btn } from './ui';
 import { cn } from '../../lib/cn';
+import { SkeletonRows } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
 
 export interface PlaylistSummary {
   id: string;
@@ -233,13 +235,13 @@ export default function LibraryPlaylistsTab({
           <Btn sm onClick={() => { setCreating(false); setNewName(''); }} disabled={busy}>Cancel</Btn>
         </div>
       )}
-      {loading && rows.length === 0 && (
-        <div className="px-4 py-8 text-center text-[12px] text-muted italic">loading…</div>
-      )}
+      {loading && rows.length === 0 && <SkeletonRows rows={4} />}
       {!loading && rows.length === 0 && (
-        <div className="px-4 py-10 text-center text-[12px] text-muted italic">
-          no playlists yet — select tracks in any tab and “Add to playlist”
-        </div>
+        <EmptyState
+          compact
+          title="No playlists yet"
+          description={<>Select tracks in any tab and “Add to playlist” to start one.</>}
+        />
       )}
       {rows.map(pl => {
         const open = openId === pl.id;
@@ -303,9 +305,7 @@ export default function LibraryPlaylistsTab({
             )}
             {open && (
               <div className="border-t border-dashed border-separator-strong bg-[var(--ink-softer)]">
-                {entriesLoading && (
-                  <div className="px-4 py-4 text-center text-[12px] text-muted italic">loading…</div>
-                )}
+                {entriesLoading && <SkeletonRows rows={4} />}
                 {!entriesLoading && entries && entries.length === 0 && (
                   <div className="px-4 py-4 text-center text-[12px] text-muted italic">empty playlist</div>
                 )}

--- a/web/components/admin/MoodsPanel.tsx
+++ b/web/components/admin/MoodsPanel.tsx
@@ -11,6 +11,8 @@ import { ScrollArea } from '../ui/scroll-area';
 import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
 } from '../ui/select';
+import { SkeletonCards } from '@/components/ui/skeleton';
+import { ErrorState } from '@/components/ui/error-state';
 import FestivalsSection from './FestivalsSection';
 
 interface MoodEntry {
@@ -210,18 +212,9 @@ export default function MoodsPanel() {
         <SectionTabs tabs={tabs} value={tab} onChange={selectTab} label="Moods sections" />
       </section>
 
-      {err && (
-        <div className="card border-[var(--danger)]">
-          <div className="card-body text-[12px] text-[var(--danger)]">
-            <strong className="tracking-[0.12em] uppercase">controller error</strong>
-            <div className="mt-1">{err}</div>
-          </div>
-        </div>
-      )}
+      {err && <ErrorState error={err} onRetry={load} />}
 
-      {loading && tab !== 'festivals' && (
-        <div className="text-[13px] text-muted italic">loading…</div>
-      )}
+      {loading && tab !== 'festivals' && <SkeletonCards cards={6} />}
 
       {/* --- Vocabulary --- */}
       {tab === 'vocab' && moods !== null && (

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -14,6 +14,8 @@ import { useEffect, useRef, useState } from 'react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { notify, errorMessage } from '../../lib/notify';
 import { Card, Btn, Pill } from './ui';
+import { SkeletonRows } from '@/components/ui/skeleton';
+import { ErrorState } from '@/components/ui/error-state';
 import { V3AlertDialog } from '../ui/alert-dialog';
 import { Modal } from '../ui/modal';
 import type { Persona, PersonaTts, DjPromptPreset, FormState, SettingsResponse, CommunityPersona } from './personas/types';
@@ -424,7 +426,7 @@ export default function PersonasPanel() {
     return (
       <div className="grid gap-4">
         <Card title="Personas">
-          <div className="text-[13px] text-[var(--danger)]">controller error: {err}</div>
+          <ErrorState error={err} onRetry={load} />
         </Card>
       </div>
     );
@@ -433,7 +435,7 @@ export default function PersonasPanel() {
     return (
       <div className="grid gap-4">
         <Card title="Personas">
-          <div className="text-[13px] text-muted italic">loading…</div>
+          <SkeletonRows rows={4} />
         </Card>
       </div>
     );

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -13,6 +13,8 @@ import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
 } from '../ui/select';
 import { Card, Btn, Pill, Seg } from './ui';
+import { SkeletonForm } from '@/components/ui/skeleton';
+import { ErrorState } from '@/components/ui/error-state';
 import { cn } from '../../lib/cn';
 import ArchivesPanel from './ArchivesPanel';
 import BackupPanel from './BackupPanel';
@@ -384,14 +386,7 @@ export default function SettingsPanel() {
 
       {/* Active section */}
       <div className="grid gap-4">
-        {err && (
-          <div className="card border-[var(--danger)]">
-            <div className="card-body text-[12px] text-[var(--danger)]">
-              <strong className="tracking-[0.12em] uppercase">controller error</strong>
-              <div className="mt-1">{err}</div>
-            </div>
-          </div>
-        )}
+        {err && <ErrorState error={err} onRetry={refresh} />}
         {pendingRestart && (
           <div
             role="alert"
@@ -414,9 +409,7 @@ export default function SettingsPanel() {
             </Btn>
           </div>
         )}
-        {!data && !err && (
-          <div className="text-[13px] text-muted italic">loading…</div>
-        )}
+        {!data && !err && <SkeletonForm fields={5} />}
 
         {data && form && (() => {
           const updateForm: FormUpdater = (updater) =>

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -30,6 +30,9 @@ import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup,
 } from '../ui/select';
 import { Card, Btn, Pill, Eyebrow, Metric, MetaChip, Toggle } from './ui';
+import { SkeletonRows } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
+import { ErrorState } from '@/components/ui/error-state';
 import { V3AlertDialog } from '../ui/alert-dialog';
 import { EditorDialog } from '../ui/editor-dialog';
 import { Modal } from '../ui/modal';
@@ -1028,7 +1031,7 @@ export default function ShowsPanel() {
     return (
       <div className="grid gap-4">
         <Card title="Shows" sub="weekly grid">
-          <div className="text-[13px] text-[var(--danger)]">controller error: {err}</div>
+          <ErrorState error={err} onRetry={load} />
         </Card>
       </div>
     );
@@ -1037,7 +1040,7 @@ export default function ShowsPanel() {
     return (
       <div className="grid gap-4">
         <Card title="Shows" sub="weekly grid">
-          <div className="text-[13px] text-muted italic">loading…</div>
+          <SkeletonRows rows={4} />
         </Card>
       </div>
     );
@@ -1317,9 +1320,10 @@ export default function ShowsPanel() {
         </div>
       </div>
       {form.shows.length === 0 && (
-        <p className="text-[12px] text-muted">
-          No shows yet. Add one to start programming the week.
-        </p>
+        <EmptyState
+          title="No shows scheduled"
+          description="Add one to start programming the week."
+        />
       )}
 
       {form.shows.map((s, i) => {

--- a/web/components/admin/SkillsPanel.tsx
+++ b/web/components/admin/SkillsPanel.tsx
@@ -23,6 +23,9 @@ import {
 import type { LucideIcon } from 'lucide-react';
 import { Card, Btn, Pill, Eyebrow, MetaChip, Toggle } from './ui';
 import { V3Alert } from '../ui/alert';
+import { SkeletonRows } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
+import { ErrorState } from '@/components/ui/error-state';
 import { Modal } from '../ui/modal';
 import { Input } from '../ui/input';
 import {
@@ -340,7 +343,7 @@ export default function SkillsPanel() {
     return (
       <div className="grid gap-4">
         <Card title="Skills">
-          <div className="text-[13px] text-[var(--danger)]">controller error: {err}</div>
+          <ErrorState error={err} />
         </Card>
       </div>
     );
@@ -349,7 +352,7 @@ export default function SkillsPanel() {
     return (
       <div className="grid gap-4">
         <Card title="Skills">
-          <div className="text-[13px] text-muted italic">loading…</div>
+          <SkeletonRows rows={4} />
         </Card>
       </div>
     );
@@ -571,12 +574,15 @@ export default function SkillsPanel() {
       {/* ── SKILL LIST ───────────────────────────────────────────────────── */}
       {visible.length === 0 && (
         <Card title="No matches">
-          <div className="text-[13px] text-muted italic">
-            No skill matches the current filters.{' '}
-            <button type="button" onClick={clearFilters} className="font-bold text-vermilion underline decoration-[1.5px] underline-offset-2">
-              Clear filters
-            </button>
-          </div>
+          <EmptyState
+            title="No skills match"
+            description="Nothing fits the current filters."
+            action={
+              <button type="button" onClick={clearFilters} className="font-bold text-vermilion underline decoration-[1.5px] underline-offset-2">
+                Clear filters
+              </button>
+            }
+          />
         </Card>
       )}
       {visible.map(s => {

--- a/web/components/admin/StatsPanel.tsx
+++ b/web/components/admin/StatsPanel.tsx
@@ -16,7 +16,8 @@ import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { useDynamicStyle } from '../../hooks/useDynamicStyle';
-import { V3Alert } from '../ui/alert';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ErrorState } from '@/components/ui/error-state';
 import { Card, Btn, Pill, Eyebrow, Seg } from './ui';
 import { ScrollArea } from '../ui/scroll-area';
 import { cn } from '../../lib/cn';
@@ -723,7 +724,7 @@ export default function StatsPanel() {
         </div>
       </section>
 
-      {err && <V3Alert tone="error" title="controller error">{err}</V3Alert>}
+      {err && <ErrorState error={err} />}
 
       {/* ── AUDIENCE ────────────────────────────────────────────────────── */}
       <Card
@@ -741,7 +742,7 @@ export default function StatsPanel() {
           <div className="p-3.5">
             {listeners == null ? (
               <div className="flex h-[130px] items-center justify-center">
-                <span className="field-hint italic">loading…</span>
+                <Skeleton className="h-4 w-16" />
               </div>
             ) : (
               <ListenerChart samples={samples} />
@@ -754,7 +755,7 @@ export default function StatsPanel() {
             </div>
             {listeners == null ? (
               <div className="flex h-[110px] items-center justify-center">
-                <span className="field-hint italic">loading…</span>
+                <Skeleton className="h-4 w-16" />
               </div>
             ) : (
               <HourOfDayChart buckets={hourBuckets} />
@@ -790,7 +791,7 @@ export default function StatsPanel() {
             {connErr ? (
               <span className="field-hint italic">{connErr}</span>
             ) : connections == null ? (
-              <span className="field-hint italic">loading…</span>
+              <Skeleton className="h-4 w-16" />
             ) : deviceGroups.length === 0 ? (
               <span className="field-hint italic">nobody connected right now</span>
             ) : (
@@ -811,7 +812,7 @@ export default function StatsPanel() {
               selected range. */}
           {audience == null ? (
             <div className="p-3.5">
-              <span className="field-hint italic">loading…</span>
+              <Skeleton className="h-4 w-16" />
             </div>
           ) : (audSessions ?? 0) === 0 ? (
             <div className="p-3.5">
@@ -931,7 +932,7 @@ export default function StatsPanel() {
                   <div className="border-r border-separator-soft p-3.5">
                     <div className="caption mb-2">by call kind</div>
                     <Table<ByKindRow>
-                      empty="no calls"
+                      empty="No calls"
                       rows={llm.byKind}
                       cols={[
                         { key: 'kind', label: 'Kind', render: r => r.kind.replace(/^sdk\./, '') },
@@ -949,7 +950,7 @@ export default function StatsPanel() {
                   <div className="p-3.5">
                     <div className="caption mb-2">by model</div>
                     <Table<ByModelRow>
-                      empty="no calls"
+                      empty="No calls"
                       rows={llm.byModel}
                       cols={[
                         { key: 'model', label: 'Model' },
@@ -990,7 +991,7 @@ export default function StatsPanel() {
                   <div className="border-r border-separator-soft p-3.5">
                     <div className="caption mb-2">by engine</div>
                     <Table<ByEngineRow>
-                      empty="no segments"
+                      empty="No segments"
                       rows={tts.byEngine}
                       cols={[
                         { key: 'engine', label: 'Engine' },
@@ -1006,7 +1007,7 @@ export default function StatsPanel() {
                   <div className="p-3.5">
                     <div className="caption mb-2">by segment kind</div>
                     <Table<ByTtsKindRow>
-                      empty="no segments"
+                      empty="No segments"
                       rows={tts.byKind}
                       cols={[
                         { key: 'kind', label: 'Kind' },
@@ -1066,7 +1067,7 @@ export default function StatsPanel() {
                       <div className="caption mb-2">by pick source</div>
                       <ScrollBox>
                         <Table<ByPickSourceRow>
-                          empty="no pick sources"
+                          empty="No pick sources"
                           rows={requests.byPickSource}
                           cols={[
                             { key: 'source', label: 'Source' },
@@ -1079,7 +1080,7 @@ export default function StatsPanel() {
                     <div>
                       <div className="caption mb-2">top requesters</div>
                       <Table<TopRequesterRow>
-                        empty="no requesters"
+                        empty="No requesters"
                         rows={requests.topRequesters}
                         cols={[
                           { key: 'requester', label: 'Listener' },
@@ -1118,7 +1119,7 @@ export default function StatsPanel() {
         sub="CPU + memory for the SUB/WAVE containers on this host"
       >
         {systemRes == null ? (
-          <span className="field-hint italic">loading…</span>
+          <Skeleton className="h-4 w-16" />
         ) : (
           <div className="grid gap-0">
             <MetricStrip>
@@ -1145,7 +1146,7 @@ export default function StatsPanel() {
               ) : (
                 <ScrollBox>
                   <Table<ContainerUsage>
-                    empty="no containers"
+                    empty="No containers"
                     rows={sysContainers}
                     cols={[
                       { key: 'service', label: 'Service' },

--- a/web/components/admin/WebhooksPanel.tsx
+++ b/web/components/admin/WebhooksPanel.tsx
@@ -10,6 +10,9 @@ import { useAdminAuth } from '../../lib/adminAuth';
 import { notify, errorMessage } from '../../lib/notify';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
+import { SkeletonRows } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
+import { ErrorState } from '@/components/ui/error-state';
 import { Card, Btn, Pill, Eyebrow, Toggle } from './ui';
 
 interface Webhook {
@@ -298,14 +301,14 @@ export default function WebhooksPanel() {
   if (err) {
     return (
       <div className="grid gap-4">
-        <Card title="Webhooks"><div className="text-[13px] text-[var(--danger)]">controller error: {err}</div></Card>
+        <Card title="Webhooks"><ErrorState error={err} /></Card>
       </div>
     );
   }
   if (!hooks || !events) {
     return (
       <div className="grid gap-4">
-        <Card title="Webhooks"><div className="text-[13px] text-muted italic">loading…</div></Card>
+        <Card title="Webhooks"><SkeletonRows rows={3} /></Card>
       </div>
     );
   }
@@ -366,10 +369,11 @@ export default function WebhooksPanel() {
 
       {hooks.length === 0 && (
         <Card title="No webhooks yet">
-          <div className="text-[12px] leading-[1.6] text-muted">
-            Click <strong>Add</strong> above to wire your first one. Common targets: Discord webhooks (chat),
-            n8n / Pipedream (relay + retry), Home Assistant (lights pulse on a track change).
-          </div>
+          <EmptyState
+            title="No webhooks yet"
+            description="Add one to push now-playing and station events out to other services."
+            action={<Btn sm onClick={() => setHooks([...hooks, blank(events)])}>Add webhook</Btn>}
+          />
         </Card>
       )}
 

--- a/web/components/admin/connect/ConnectPanel.tsx
+++ b/web/components/admin/connect/ConnectPanel.tsx
@@ -16,6 +16,8 @@ import { useAdminAuth } from '../../../lib/adminAuth';
 import { notify, errorMessage } from '../../../lib/notify';
 import type { LucideIcon } from 'lucide-react';
 import { Braces, Boxes, Cable, Webhook } from 'lucide-react';
+import { SkeletonRows } from '@/components/ui/skeleton';
+import { ErrorState } from '@/components/ui/error-state';
 import { Card, Btn, Eyebrow } from '../ui';
 import { SectionTabs } from '../SectionTabs';
 import type { Catalog } from './types';
@@ -95,14 +97,14 @@ export default function ConnectPanel() {
   if (err) {
     return (
       <div className="grid gap-4">
-        <Card title="Connect"><div className="text-[13px] text-[var(--danger)]">controller error: {err}</div></Card>
+        <Card title="Connect"><ErrorState error={err} /></Card>
       </div>
     );
   }
   if (!catalog) {
     return (
       <div className="grid gap-4">
-        <Card title="Connect"><div className="text-[13px] text-muted italic">loading…</div></Card>
+        <Card title="Connect"><SkeletonRows rows={3} /></Card>
       </div>
     );
   }

--- a/web/components/admin/imaging/BedsSection.tsx
+++ b/web/components/admin/imaging/BedsSection.tsx
@@ -10,6 +10,7 @@ import { Label } from '../../ui/label';
 import { Button } from '../../ui/button';
 import { Badge } from '../../ui/badge';
 import { V3Alert } from '../../ui/alert';
+import { SkeletonCards } from '@/components/ui/skeleton';
 import { Btn, Seg } from '../ui';
 import { PreviewButton, type SettingsData, type SaveSettings } from '../settings/shared';
 import type { BedsData } from './types';
@@ -52,7 +53,7 @@ export function BedsSection({ bedsData, busy, uploadBed, onDelete, data, saveSet
   };
 
   if (!bedsData) {
-    return <div className="text-[13px] text-muted italic">loading…</div>;
+    return <SkeletonCards cards={4} />;
   }
   const list = bedsData.beds || [];
   const minSec = bedsData.minDurationSec ?? 30;

--- a/web/components/admin/imaging/ImagingPanel.tsx
+++ b/web/components/admin/imaging/ImagingPanel.tsx
@@ -19,8 +19,9 @@ import { Music, AudioLines, Waves } from 'lucide-react';
 import { useAdminAuth } from '../../../lib/adminAuth';
 import { notify, errorMessage } from '../../../lib/notify';
 import { SectionTabs } from '../SectionTabs';
-import { V3Alert } from '../../ui/alert';
 import { V3AlertDialog } from '../../ui/alert-dialog';
+import { SkeletonCards } from '@/components/ui/skeleton';
+import { ErrorState } from '@/components/ui/error-state';
 import type { SettingsData, SaveSettings } from '../settings/shared';
 import type { SfxData, SfxForm, BedsData, JingleImportFailure, JingleImportResult } from './types';
 import { JinglesSection } from './JinglesSection';
@@ -348,7 +349,7 @@ export default function ImagingPanel() {
       </section>
 
       {err && (
-        <V3Alert tone="error" title="controller error">{err}</V3Alert>
+        <ErrorState error={err} onRetry={refresh} />
       )}
 
       <div>
@@ -363,7 +364,7 @@ export default function ImagingPanel() {
               onDelete={setConfirmDelete} adminFetch={adminFetch}
             />
           ) : (
-            !err && <div className="text-[13px] text-muted italic">loading…</div>
+            !err && <SkeletonCards cards={6} />
           )
         )}
 

--- a/web/components/admin/imaging/SfxSection.tsx
+++ b/web/components/admin/imaging/SfxSection.tsx
@@ -11,6 +11,7 @@ import { Label } from '../../ui/label';
 import { Button } from '../../ui/button';
 import { Badge } from '../../ui/badge';
 import { V3Alert } from '../../ui/alert';
+import { SkeletonCards } from '@/components/ui/skeleton';
 import { Btn, Seg } from '../ui';
 import { PreviewButton, type SettingsData, type SaveSettings } from '../settings/shared';
 import type { SfxData, SfxForm } from './types';
@@ -54,7 +55,7 @@ export function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uplo
   };
 
   if (!sfxData) {
-    return <div className="text-[13px] text-muted italic">loading…</div>;
+    return <SkeletonCards cards={4} />;
   }
   const list = sfxData.sfx || [];
   const ready = !!sfxData.generatorReady;

--- a/web/components/admin/imaging/parts.tsx
+++ b/web/components/admin/imaging/parts.tsx
@@ -10,6 +10,7 @@
 
 import type { ReactNode } from 'react';
 import { cn } from '../../../lib/cn';
+import { EmptyState as SharedEmptyState } from '../../ui/empty-state';
 
 /** Zero-pad a count to two digits, the way the metrics read in the design. */
 export function pad2(n: number): string {
@@ -87,14 +88,11 @@ export function SectionMasthead({
   );
 }
 
-/** Empty-library state: a display-italic "None yet." over a mono caption. */
+/** Empty-library state — the imaging sections' "None yet." over a caption.
+    Thin wrapper over the shared console EmptyState so imaging stays in step
+    with the rest of the admin; the `caption` API is unchanged for callers. */
 export function EmptyState({ caption }: { caption: ReactNode }) {
-  return (
-    <div className="px-[18px] py-11 text-center">
-      <div className="font-display text-[22px] text-muted italic">None yet.</div>
-      <div className="mt-2 font-mono text-[11px] tracking-[0.12em] text-muted uppercase">{caption}</div>
-    </div>
-  );
+  return <SharedEmptyState title="None yet." description={caption} />;
 }
 
 /** Dashed drop-zone that triggers a hidden file input in the import modals. */

--- a/web/components/admin/personas/PersonaSkillsCard.tsx
+++ b/web/components/admin/personas/PersonaSkillsCard.tsx
@@ -18,9 +18,7 @@ export function PersonaSkillsCard({ persona, skillCatalog, setSkills }: PersonaS
         also be enabled station-wide on the <strong>Skills</strong> page.
       </p>
       {skillCatalog.length === 0 ? (
-        <div className="text-[12px] text-muted italic">
-          no skills available
-        </div>
+        <span className="text-[12px] text-muted">No skills available</span>
       ) : (
         <div className="grid gap-x-8 sm:grid-cols-2">
           {skillCatalog.map(s => {

--- a/web/components/admin/settings/ThemeSection.tsx
+++ b/web/components/admin/settings/ThemeSection.tsx
@@ -10,6 +10,7 @@ import { Modal } from '../../ui/modal';
 import { Input } from '../../ui/input';
 import { Label } from '../../ui/label';
 import { Card, Btn, Pill, Seg } from '../ui';
+import { SkeletonRows } from '../../ui/skeleton';
 import { AiFill } from '../AiFill';
 import { cn } from '../../../lib/cn';
 import { SkinGallery } from './SkinGallery';
@@ -396,9 +397,7 @@ export function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSect
               Couldn’t load themes: {error}
             </div>
           )}
-          {!themes && !error && (
-            <div className="text-[13px] text-muted italic">loading…</div>
-          )}
+          {!themes && !error && <SkeletonRows rows={4} />}
           {themes && (
             <div className="grid gap-2">
               {themes.map(t => {

--- a/web/components/admin/skills/SkillEditModal.tsx
+++ b/web/components/admin/skills/SkillEditModal.tsx
@@ -21,6 +21,7 @@ import { notify, errorMessage } from '../../../lib/notify';
 import { useAdminAuth } from '../../../lib/adminAuth';
 import { V3AlertDialog } from '../../ui/alert-dialog';
 import { EditorDialog } from '../../ui/editor-dialog';
+import { SkeletonForm } from '@/components/ui/skeleton';
 import { Eyebrow } from '../ui';
 import { CONTEXT_FIELD_LABELS, CONTEXT_FIELDS_FALLBACK, splitContext } from './contextFields';
 import { skillSubmitUrl } from '../../../lib/repo';
@@ -557,7 +558,7 @@ export default function SkillEditModal({ mode, skill, personas, tagSuggestions, 
       className="sw-seg"
     >
       {!loaded ? (
-        <div style={{ padding: '40px 0', textAlign: 'center', color: 'var(--muted)', fontStyle: 'italic', fontSize: 13 }}>loading…</div>
+        <SkeletonForm fields={4} />
       ) : (
         <div style={{ opacity: isEdit && !enabled ? 0.6 : 1, transition: 'opacity .2s ease' }}>
 

--- a/web/components/ui/empty-state.tsx
+++ b/web/components/ui/empty-state.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/cn';
+
+/* Shared empty state for the admin console — the "there is nothing here yet"
+   panel. Newsprint editorial treatment: an optional bordered icon, a Fraunces
+   display-italic headline, a quiet mono caption, and an optional call to
+   action. Replaces the ~dozen bare lowercase strings ("no calls yet",
+   "nothing here yet") each panel used to render, and the siloed imaging
+   EmptyState (which now delegates here). Copy is caller-supplied so panels can
+   carry a light SUB/WAVE voice where it fits. */
+export interface EmptyStateProps {
+  /** A lucide icon (or any node); sits in a bordered square above the title. */
+  icon?: ReactNode;
+  title?: ReactNode;
+  /** Short guidance under the title — what to do to fill this space. */
+  description?: ReactNode;
+  /** A primary action (usually a <Btn>) rendered under the description. */
+  action?: ReactNode;
+  /** Tighter vertical padding for inline/nested empties (e.g. inside a modal). */
+  compact?: boolean;
+  className?: string;
+}
+
+export function EmptyState({
+  icon,
+  title = 'Nothing here yet',
+  description,
+  action,
+  compact,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center text-center',
+        compact ? 'px-4 py-8' : 'px-[18px] py-11',
+        className,
+      )}
+    >
+      {icon && (
+        <div className="mb-3 flex size-10 items-center justify-center border border-separator-strong text-muted [&_svg]:size-5">
+          {icon}
+        </div>
+      )}
+      <div className="font-display text-[22px] leading-tight text-muted italic">{title}</div>
+      {description && (
+        <div className="mt-2 max-w-[48ch] font-mono text-[11px] leading-[1.7] tracking-[0.06em] [text-wrap:pretty] text-muted">
+          {description}
+        </div>
+      )}
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  );
+}

--- a/web/components/ui/error-state.tsx
+++ b/web/components/ui/error-state.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { V3Alert } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+
+/* Shared error state for the admin console. One look for the "a fetch failed"
+   panel, standardized on V3Alert (tone="error") with an optional Retry — the
+   same shape the admin error boundary (app/admin/error.tsx) already uses.
+   Replaces the three competing patterns the panels grew: the bare
+   `<div class="text-[var(--danger)]">controller error: {err}</div>`, the
+   accent `<p>{err}</p>`, and the assorted hand-rolled V3Alert callouts.
+
+   `error` is the raw controller message (rendered quietly under the body);
+   `onRetry` re-runs the panel's own fetch (panels own their retry logic). */
+export interface ErrorStateProps {
+  /** Callout heading. Defaults to the controller-unreachable framing. */
+  title?: ReactNode;
+  /** Human explanation; a sensible default is shown when omitted. */
+  children?: ReactNode;
+  /** The raw error string/message from the controller, shown de-emphasised. */
+  error?: ReactNode;
+  onRetry?: () => void;
+  retrying?: boolean;
+  retryLabel?: string;
+}
+
+export function ErrorState({
+  title = "Can't reach the controller",
+  children,
+  error,
+  onRetry,
+  retrying,
+  retryLabel = 'Retry',
+}: ErrorStateProps) {
+  return (
+    <div className="grid gap-3">
+      <V3Alert tone="error" title={title}>
+        {children ?? (
+          <p>
+            Something went wrong talking to the controller. It may be restarting — give it a
+            moment and retry.
+          </p>
+        )}
+        {error ? <p className="mt-2 break-words opacity-80">{error}</p> : null}
+      </V3Alert>
+      {onRetry && (
+        <div>
+          <Button variant="accent" size="sm" onClick={onRetry} disabled={retrying}>
+            {retrying ? 'Retrying…' : retryLabel}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/ui/skeleton.tsx
+++ b/web/components/ui/skeleton.tsx
@@ -3,17 +3,171 @@ import * as React from "react"
 import { cn } from "@/lib/cn"
 
 /* Newsprint skeleton — sharp corners, faint ink fill (matches the console's
-   loading placeholders). */
+   loading placeholders). The base `Skeleton` is a single bar; the named shapes
+   below (Rows / Cards / Tiles / Form / Text) compose it into the handful of
+   content silhouettes the admin panels actually render, so a panel swaps its
+   old `<div>loading…</div>` for the shape closest to its real layout.
+
+   `motion-reduce:animate-none` kills the pulse for reduced-motion users. Bar
+   widths come from a fixed cycle (never Math.random) so server and client
+   render identical markup — random widths would hydration-mismatch and trip
+   the same lint rule the rest of the console avoids. */
 function Skeleton({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("animate-pulse rounded-none bg-[var(--ink-soft)]", className)}
+      className={cn(
+        "animate-pulse rounded-none bg-[var(--ink-soft)] motion-reduce:animate-none",
+        className,
+      )}
       {...props}
     />
   )
 }
 
-export { Skeleton }
+// Deterministic width cycle for text-ish bars — indexed by position so the
+// silhouette looks organic without any per-render randomness.
+const BAR_W = ["w-[68%]", "w-[82%]", "w-[54%]", "w-[76%]", "w-[46%]", "w-[88%]"]
+const widthAt = (i: number) => BAR_W[i % BAR_W.length]
+
+interface ShapeProps {
+  className?: string
+  /** Announced to screen readers via the shape's live region. */
+  label?: string
+}
+
+/* Shared wrapper: one polite live region + visually-hidden label per shape, so
+   assistive tech hears "Loading …" once while the bars stay aria-hidden. */
+function LoadingBox({
+  className,
+  label = "Loading",
+  children,
+}: ShapeProps & { children: React.ReactNode }) {
+  return (
+    <div role="status" aria-busy="true" className={className}>
+      <span className="sr-only">{label}…</span>
+      {children}
+    </div>
+  )
+}
+
+/** A stack of text lines — small widgets, prose blocks, generic fallback. */
+function SkeletonText({
+  lines = 3,
+  className,
+  label,
+}: { lines?: number } & ShapeProps) {
+  return (
+    <LoadingBox label={label} className={cn("space-y-2", className)}>
+      {Array.from({ length: lines }).map((_, i) => (
+        <Skeleton
+          key={i}
+          aria-hidden
+          className={cn("h-3.5", i === lines - 1 ? "w-[40%]" : widthAt(i))}
+        />
+      ))}
+    </LoadingBox>
+  )
+}
+
+/** A bordered list/table — Skills, Shows, Debug calls, Webhooks, Personas. */
+function SkeletonRows({
+  rows = 5,
+  className,
+  label,
+}: { rows?: number } & ShapeProps) {
+  return (
+    <LoadingBox
+      label={label}
+      className={cn(
+        "divide-y divide-separator-strong border border-separator-strong",
+        className,
+      )}
+    >
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} aria-hidden className="flex items-center gap-3 px-3 py-3">
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className={cn("h-3.5", widthAt(i))} />
+            <Skeleton className="h-2.5 w-[35%]" />
+          </div>
+          <Skeleton className="h-5 w-14 shrink-0" />
+        </div>
+      ))}
+    </LoadingBox>
+  )
+}
+
+/** A responsive grid of asset cards — Imaging, Moods, Library results. */
+function SkeletonCards({
+  cards = 6,
+  className,
+  label,
+}: { cards?: number } & ShapeProps) {
+  return (
+    <LoadingBox
+      label={label}
+      className={cn(
+        "grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-3",
+        className,
+      )}
+    >
+      {Array.from({ length: cards }).map((_, i) => (
+        <div key={i} aria-hidden className="border border-separator-strong p-3">
+          <Skeleton className="mb-3 h-24 w-full" />
+          <Skeleton className={cn("h-3.5", widthAt(i))} />
+          <Skeleton className="mt-2 h-2.5 w-[50%]" />
+        </div>
+      ))}
+    </LoadingBox>
+  )
+}
+
+/** A row of stat tiles — Dash widgets, Stats figures. */
+function SkeletonTiles({
+  tiles = 4,
+  className,
+  label,
+}: { tiles?: number } & ShapeProps) {
+  return (
+    <LoadingBox
+      label={label}
+      className={cn("grid grid-cols-2 gap-3 sm:grid-cols-4", className)}
+    >
+      {Array.from({ length: tiles }).map((_, i) => (
+        <div key={i} aria-hidden className="border border-separator-strong p-3">
+          <Skeleton className="h-6 w-[60%]" />
+          <Skeleton className="mt-2 h-2.5 w-[80%]" />
+        </div>
+      ))}
+    </LoadingBox>
+  )
+}
+
+/** A stack of label + field rows — Settings sections, edit modals. */
+function SkeletonForm({
+  fields = 4,
+  className,
+  label,
+}: { fields?: number } & ShapeProps) {
+  return (
+    <LoadingBox label={label} className={cn("space-y-4", className)}>
+      {Array.from({ length: fields }).map((_, i) => (
+        <div key={i} aria-hidden className="space-y-2">
+          <Skeleton className="h-2.5 w-24" />
+          <Skeleton className="h-9 w-full" />
+        </div>
+      ))}
+    </LoadingBox>
+  )
+}
+
+export {
+  Skeleton,
+  SkeletonText,
+  SkeletonRows,
+  SkeletonCards,
+  SkeletonTiles,
+  SkeletonForm,
+}


### PR DESCRIPTION
## What

Replaces the crude, copy-pasted state renders across the **entire admin console** with one shared, on-brand state system: proper **skeletons** while loading, real **empty states**, and a consistent **error state** with retry.

### Before
- **~25 identical** `<div className="text-[13px] text-muted italic">loading…</div>` divs — the shipped `Skeleton`/`Spinner` primitives were used **nowhere** in admin.
- **Three competing error patterns**: the good `V3Alert`, a bare `<div class="text-[var(--danger)]">controller error: {err}</div>`, and an accent `<p>{err}</p>` — no retry on most.
- **Empty states were mostly bare lowercase fragments** (`no calls yet`, `nothing here yet`, `no data yet`).

## How

**Three shared primitives in `components/ui/`:**
- `skeleton.tsx` — newsprint skeleton **shapes** (`SkeletonRows` / `SkeletonCards` / `SkeletonTiles` / `SkeletonForm` / `SkeletonText`) built on the existing base bar. Deterministic widths (no `Math.random` → hydration-safe + lint-safe), `role="status"` + sr-only label, `motion-reduce:animate-none`.
- `empty-state.tsx` — shared `EmptyState` (`icon` / `title` / `description` / `action`). Imaging's siloed `EmptyState` now delegates to it.
- `error-state.tsx` — `V3Alert`-based `ErrorState` with an optional **Retry**, mirroring the already-polished `app/admin/error.tsx`.

**Then swept every admin panel** onto them:
- Loading → the skeleton shape matched to each panel's real content (rows for lists, cards for asset grids, small inline bars for dense stat tiles).
- Error → `ErrorState`, wired to the panel's own load/refresh fn where a reusable one exists.
- Empty → `EmptyState` for whole-panel/section empties with a light SUB/WAVE voice; dense table-cell empties standardized to sentence-case muted spans.
- Removed the inline-`style` `loading…` in `SkillEditModal` (the one eslint outlier).

**Deliberately left as-is:** the `AdminShell` pre-hydration gate (sub-second chrome flash) and header-caption status text inside `<span>`/Card `sub` props (a skeleton `<div>` can't nest there).

## Scope
23 panel files + 3 shared components (2 new, 1 extended). Purely presentational — control flow and data-fetching untouched.

## Verification
- `npm run lint` (eslint + `tsc --noEmit`) passes clean.
- Screenshots not yet attached — happy to run the `verify` harness (isolated controller + worktree dev server + Playwright) for before/after visuals if wanted.