### PR TITLE
fix(web): stop admin dropdowns shifting the page by the scrollbar width

### DIFF
--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -415,7 +415,12 @@ function AdminSidebar({
             when the rail is collapsed to icons. */}
         <SidebarMenu className="gap-1.5">
           <SidebarMenuItem>
-            <DropdownMenu>
+            {/* Non-modal: a modal Radix menu locks body scroll, and the lock
+                compensates for the removed scrollbar with a 15px right margin
+                on <body> — which pulls the sticky top bar off the right edge
+                for as long as the menu is open. A nav menu has no reason to
+                trap scroll, so opt out and the shift never happens. */}
+            <DropdownMenu modal={false}>
               <DropdownMenuTrigger asChild>
                 <SidebarMenuButton title="More">
                   <MoreHorizontal
@@ -722,7 +727,9 @@ function TopBar({ pathname }: { pathname: string | null }) {
         </Link>
         <ThemeSwitcher variant="admin" />
         {/* Listen — a menu grouping the in-browser player with the native apps. */}
-        <DropdownMenu>
+        {/* modal={false} for the same reason as the sidebar's More menu — no
+            body scroll lock, so no scrollbar-compensation margin shift. */}
+        <DropdownMenu modal={false}>
           <DropdownMenuTrigger
             className="caption inline-flex cursor-pointer items-center gap-1 text-muted focus:outline-none"
             aria-label="Listen and get the app"


### PR DESCRIPTION
## The bug

Open the top-bar **Listen** menu or the sidebar **More** menu on any `/admin` page and the whole shell jumps 15px left, leaving a strip of page background down the right edge of the sticky top bar until the menu closes.

## Why

Both are Radix `DropdownMenu`s, which default to `modal`. A modal menu wraps its content in `react-remove-scroll`, which locks body scroll and compensates for the scrollbar it just removed by injecting:

```css
body[data-scroll-locked] {
  overflow: hidden !important;
  margin-right: 15px !important; /* = measured scrollbar width */
}
```

The admin `<body>` **is** the page scroller (the sidebar is `fixed`, `SidebarInset` sits in body flow) and the top bar is `sticky top-0 … bg-[var(--card-bg)]`, so that margin drags the whole shell inward and exposes `--bg` beside the header.

## The fix

`modal={false}` on both menus — Radix then swaps `RemoveScroll` for a `Fragment` (`react-menu`'s `ScrollLockWrapper`), so the lock never mounts and there is nothing to compensate for. A nav menu has no reason to trap page scroll.

## Verified in Chromium (Playwright, `/admin/dash`)

| | before | after |
|---|---|---|
| `body[data-scroll-locked]` while open | `"1"` | absent |
| header right edge (1280px viewport, 15px gutter simulated) | 1265 | 1280 |

Still correct after the change: both menus open with all items, dismiss on outside click and on Escape, keep arrow-key roving focus, leave `body { pointer-events }` untouched, the page stays scrollable while a menu is open, and **Sign out** still opens its confirm dialog from the More menu.

## Not covered

Radix `Select` and the modal dialogs use the same scroll lock and still compensate — `Select` gives no `modal` prop, and for a dimmed-overlay dialog the lock is intended. Those would need an admin-scoped `scrollbar-gutter: stable` plus a margin override, which is a bigger, browser-behaviour-dependent change; happy to do it as a follow-up if the shift bothers you there too.