### PR TITLE
feat(web): list view option for the Skills, Shows and DJs rosters

### DIFF
--- a/docs/superpowers/specs/2026-07-24-admin-roster-list-view-design.md
+++ b/docs/superpowers/specs/2026-07-24-admin-roster-list-view-design.md
@@ -1,0 +1,253 @@
+# Admin roster list view — Design
+
+## Problem
+
+Three admin pages render their roster as a stack of full-width "broadcast
+slate" cards, all built from the same recipe: a status-keyed colour spine, a
+face (avatar or kind glyph), a kicker + bold name, a facet-chip row, a brief,
+and a right rail carrying a metric and the `Edit →` affordance. The whole card
+is the edit target.
+
+- `/admin/skills` — `SkillsPanel.tsx`
+- `/admin/shows` — `ShowDefRow` in `ShowsPanel.tsx`
+- `/admin/personas` — `PersonaRoster.tsx`
+
+Each card is ~140–180px tall. That reads beautifully at 4 items and badly at
+20. The operator feedback that prompted this:
+
+> Would be easier to sort through and configure them if they were more of a
+> table view format. Appreciate the recent enhancements however might be more
+> navigatable in a tabled format, or as an option, instead of just the current
+> card styles especially as the numbers of them grow.
+
+Skills feels it first — the seven built-ins plus community installs plus custom
+skills is already a long scroll, and comparing *cooldown* or *who runs this*
+across skills means holding six cards in your head. Shows and DJs are heading
+the same way.
+
+The cards are not the problem — they're the right default for a small roster
+and they carry information density a table can't (the brief, the facet row).
+The gap is that there is no second gear.
+
+## Solution overview
+
+Add a **Cards ⇄ List** view toggle to each of the three rosters, defaulting to
+Cards (so nothing changes for anyone who doesn't touch it) and remembering the
+choice per surface in `localStorage`.
+
+List view renders the same roster as a dense table: one row per item, the same
+click-row-to-edit contract as the card, the same colour spine, and the same
+inline controls (the Skills enable toggle and Run now stay operable in place).
+Rows are ~40px instead of ~160px, so a 20-skill roster fits one screen and
+columns line up for comparison.
+
+Three surfaces, one shared table primitive, no API or data-shape change.
+
+## Components
+
+### `lib/adminView.ts` — the persisted preference
+
+```ts
+export type RosterSurface = 'skills' | 'shows' | 'personas';
+export type RosterView = 'cards' | 'list';
+
+export function useRosterView(surface: RosterSurface): [RosterView, (v: RosterView) => void];
+```
+
+Key: `subwave-admin-view:<surface>` (dashed style, matching
+`subwave-skin-override` / `subwave-theme-override`).
+
+Per-surface, not global — an operator may well want Skills as a list and Shows
+as cards, since Shows carries a weekly grid above it that already does the
+scanning job.
+
+SSR safety: `useState('cards')` plus a mount effect that reads storage. A
+list-view operator sees one frame of cards on a cold load. That's acceptable
+here and deliberately *not* worth the pre-paint inline-script treatment
+`lib/skin.ts` uses — admin pages render a skeleton while the roster fetch is in
+flight, so in practice the view resolves before there is anything to lay out.
+Storage access is wrapped in `try/catch` (private-mode browsers throw).
+
+### `components/admin/RosterTable.tsx` — the shared primitive
+
+Generic, column-driven, no new dependency. Hand-rolled in the house table
+style already used by `StatsPanel` and `DashPanel` (`caption` header
+typography, `border-separator-soft` row rules, `mono-num` figures) rather than
+pulling in shadcn's `table` — per the Tailwind v4 / shadcn-CLI mismatch the
+project has already been bitten by.
+
+```ts
+export interface RosterColumn<R> {
+  key: string;
+  label: ReactNode;                 // '' for the spine and face columns
+  align?: 'left' | 'right' | 'center';
+  className?: string;               // per-cell classes; responsive hiding lives here
+  headClassName?: string;
+  sortMode?: string;                // present => header is a sort button
+  sortAria?: 'ascending' | 'other'; // aria-sort when active (default 'other')
+  render: (row: R) => ReactNode;
+}
+
+export interface RosterTableProps<R> {
+  cols: RosterColumn<R>[];
+  rows: R[];
+  rowKey: (row: R) => string;
+  rowLabel: (row: R) => string;     // aria-label for the row's button role
+  rowSpine?: (row: R) => string;    // CSS colour for the left spine
+  onRowClick: (row: R) => void;
+  sort?: string;
+  onSort?: (mode: string) => void;
+  caption: string;                  // visually-hidden <caption>
+}
+```
+
+Behaviour:
+
+- **Row is the edit target.** `role="button"`, `tabIndex={0}`, `aria-label`,
+  and an Enter/Space handler carrying the same
+  `if (e.target !== e.currentTarget) return;` guard the Skills card uses — so a
+  keyboard press on an inner control (the enable switch, Run now) acts in place
+  instead of bubbling up and also opening the editor. Inner controls
+  `stopPropagation` on click, exactly as they do in the cards today.
+- **Spine.** `border-left: 4px` on the first `<td>`, coloured through
+  `useDynamicStyle` (the `style` prop is lint-forbidden — issue #50). A border
+  on a cell spans the full row height natively, which is why this beats trying
+  to stretch an absolutely-positioned span inside a table. Each row is its own
+  `RosterRow` component so it can own the ref and the hook call.
+- **Sticky header.** `sticky top-0` with a `--card-bg` backdrop, so the header
+  survives a long roster scrolling under it.
+- **Sortable headers.** A column declaring `sortMode` renders its label as a
+  button that calls `onSort(mode)`; the active header gets `aria-sort` and a
+  vermilion tint. Sort *modes* here are named presets (`az`, `enabled`,
+  `cooldown`), not asc/desc toggles — hence `aria-sort="other"` as the default
+  for anything that isn't a genuine alphabetical sort.
+- **Responsive.** Low-priority columns carry `hidden md:table-cell` /
+  `hidden lg:table-cell` / `hidden xl:table-cell`. The wrapper is
+  `overflow-x-auto` as the floor, so nothing is ever unreachable, but at the
+  documented breakpoints no horizontal scroll should be needed.
+
+### Per-surface tables
+
+Three thin files, each just a column definition over `RosterTable`. Keeping
+them separate from the panels matters most for Shows — `ShowsPanel.tsx` is
+already 2,400 lines.
+
+**`components/admin/skills/SkillsTable.tsx`**
+
+| col | content | breakpoint | sort |
+|---|---|---|---|
+| spine | enabled → `var(--accent)`, else `var(--separator-strong)` | always | — |
+| glyph | the `KIND_ICONS` face, muted when disabled | always | — |
+| Skill | label, `custom` pill, a `needs key` flag when `ready === false` | always | `az` |
+| Brief | `s.description`, one line, truncated | `lg` | — |
+| Cooldown | `cooldownLabel(s.cooldownMs)` | `md` | `cooldown` |
+| DJs | the existing `assignmentLabel(s)` — "All DJs" / "3 of 8 DJs" | `md` | — |
+| Tags | first two `#tag` chips, then `+n` | `xl` | — |
+| Run | the slim `seg-pad` Run now control | always | — |
+| Enabled | the `Toggle` | always | `enabled` |
+
+The three sort modes map 1:1 onto the `SortMode` union the panel's existing
+Sort select already drives, so clicking a header just sets that same state and
+both views stay in agreement. The `needs key` case degrades from the card's
+full `V3Alert` to a compact flag — the alert body is guidance the operator
+reads once, and it's still there in cards and in the edit sheet.
+
+**`components/admin/ShowsTable.tsx`**
+
+| col | content | breakpoint |
+|---|---|---|
+| spine | `SHOW_COLORS[i % n]` — the same colour the weekly grid paints | always |
+| faces | host avatar, guests overlapping | always |
+| Show | name, `Programme` / `Banter` pills | always |
+| Host | host name, `no persona set` in danger when absent | `md` |
+| Plays | first three facet chips, then `+n` | `lg` |
+| h/wk | weekly airtime, or `unscheduled` | always |
+| status | `incomplete` pill | always |
+
+**`components/admin/personas/PersonaTable.tsx`**
+
+| col | content | breakpoint |
+|---|---|---|
+| spine | on air → accent, default → ink, invalid → danger, else hairline | always |
+| avatar | avatar image over initials fallback | always |
+| DJ | name, `on air` / `default` pills | always |
+| Tagline | `p.tagline`, one line, truncated | `lg` |
+| Frequency | `p.frequency` | `md` |
+| Voice | `p.tts.engine`, plus the voice name for non-Piper engines | `md` |
+| Skills | count | always |
+| status | `incomplete` pill | always |
+
+Shows and DJs get **no sortable headers in this change**. Both panels key off
+the roster's array index — `SHOW_COLORS[i]` and the weekly grid for shows,
+`onSelect(i)` for personas — so reordering rows means threading an original
+index through first. That's real work with real breakage risk, and it isn't
+what the request is about. Sorting on those two is called out as a follow-up.
+
+### Toggle placement
+
+- **Skills** — right end of the ORGANISE bar, after the Sort select, before
+  Clear. It belongs with the other view controls.
+- **Shows** — the `show definitions · N/M shows` header row, left of Community.
+- **DJs** — the `roster · N/M` header row, left of Community.
+
+## What does not change
+
+- Cards stay the default view on every surface.
+- No controller route, settings key, or response shape moves.
+- The edit sheets (`SkillEditModal`), the inline `ShowEditor`, and the persona
+  editor are untouched — both views open the same editor with the same
+  argument.
+- The Skills search / DJ-and-show filter / status filter / sort bar applies to
+  both views: it filters the array, and the view only decides how that array
+  draws.
+- Card markup is left alone. This is additive.
+
+## Error handling
+
+There is nothing new to fail — no fetch, no mutation, no server state. The two
+failure modes are both local and both degrade to the current behaviour:
+
+- `localStorage` unavailable or holding junk → `try/catch`, fall back to
+  `'cards'`. An unrecognised stored value is treated as absent (own-key check,
+  the same defensive read `lib/skin.ts` does for skin ids).
+- An empty roster → the panels' existing `EmptyState` renders instead of the
+  table, unchanged; the view toggle stays visible so the operator isn't stuck
+  in a view they can't see out of.
+
+Row actions (toggle, Run now) reuse the panel's existing handlers verbatim,
+including their `notify.err` paths and their `busy` guard.
+
+## Testing
+
+The repo has no test runner; `npm run lint` (`eslint . && tsc --noEmit`) is the
+merge gate. Verification for this change:
+
+1. `npm run lint` in `web/`.
+2. Playwright against a worktree dev stack, per the established admin-UI
+   verification pattern (pre-seed `subwave_admin_auth` in `localStorage`; the
+   sign-in form's delayed push otherwise wrecks dev-mode runs):
+   - each of `/admin/skills`, `/admin/shows`, `/admin/personas` renders in both
+     views;
+   - the view choice survives a reload, and is independent per surface;
+   - a row click opens the same editor the card opens;
+   - keyboard: Tab to a row, Enter opens the editor; Tab to the enable switch,
+     Space toggles it and does *not* open the editor;
+   - Skills header sort clicks agree with the Sort select;
+   - light and dark both read correctly.
+3. Screenshots of all three list views attached to the PR.
+
+## Out of scope — follow-ups
+
+- **Search / filter for Shows and DJs.** Only Skills has them today. The list
+  view makes their absence more obvious, not less, but adding two filter bars
+  is its own change with its own design questions (what do you filter shows
+  by — day, host, mood?).
+- **Sortable headers on Shows and DJs**, which needs the index decoupling
+  described above.
+- **Bulk actions** (multi-select enable/disable across skills). A table is the
+  natural home for them, and this change deliberately doesn't open that door
+  yet.
+- **Server-side / per-operator persistence** of the view choice. Browser-local
+  is right for a preference this cheap.
+- **A list view for the other admin rosters** (playlists, moods, webhooks).
+  Worth doing once this pattern has settled in use.

--- a/web/components/admin/RosterAvatar.tsx
+++ b/web/components/admin/RosterAvatar.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+// A face for the roster tables — the initials-behind-<img> pattern the slate
+// cards use, so a broken or absent avatar still shows something readable.
+// Deliberately dumb: it takes a resolved src and the initials to fall back to,
+// never a Persona, so shows and DJs can both feed it.
+
+import { cn } from '../../lib/cn';
+
+export interface RosterAvatarProps {
+  src: string | null;
+  initials: string;
+  // 'sm' is the table's row face; 'xs' builds the overlapping guest cluster.
+  size?: 'sm' | 'xs';
+  className?: string;
+}
+
+export function RosterAvatar({ src, initials, size = 'sm', className }: RosterAvatarProps) {
+  return (
+    <span
+      className={cn(
+        'relative grid flex-none place-items-center overflow-hidden border border-ink bg-[var(--ink-softer)]',
+        size === 'sm' ? 'size-7' : 'size-5',
+        className,
+      )}
+    >
+      <span className={cn('font-extrabold text-muted', size === 'sm' ? 'text-[9px]' : 'text-[7px]')}>
+        {initials || '—'}
+      </span>
+      {src && (
+        <img
+          src={src}
+          alt=""
+          className="absolute inset-0 h-full w-full object-cover"
+          onError={(e) => { e.currentTarget.style.visibility = 'hidden'; }}
+        />
+      )}
+    </span>
+  );
+}
+
+export default RosterAvatar;

--- a/web/components/admin/RosterTable.tsx
+++ b/web/components/admin/RosterTable.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+// Shared roster table — the "list" half of the cards/list toggle on
+// /admin/skills, /admin/shows and /admin/personas. One row per item at ~40px
+// instead of a ~160px slate card, so a long roster fits one screen and columns
+// line up for comparison.
+//
+// Hand-rolled in the house table style already used by StatsPanel and
+// DashPanel (caption header typography, hairline row rules, mono-num figures)
+// rather than pulling in a table dependency.
+//
+// The row keeps the same contract as the card it replaces: the whole row is
+// the edit target, and any control inside it (an enable switch, a Run now pad)
+// still acts in place.
+
+import type { ReactNode } from 'react';
+import { useRef } from 'react';
+import { cn } from '../../lib/cn';
+import { useDynamicStyle } from '../../hooks/useDynamicStyle';
+
+export interface RosterColumn<R> {
+  key: string;
+  // Header cell content. Empty for the spine and face columns, which are
+  // decoration rather than data.
+  label: ReactNode;
+  align?: 'left' | 'right' | 'center';
+  // Per-cell classes — responsive column hiding (`hidden md:table-cell`) and
+  // width hints live here.
+  className?: string;
+  headClassName?: string;
+  // When set, the header renders as a sort button calling `onSort(sortMode)`.
+  sortMode?: string;
+  // aria-sort for the active header. Sort modes here are named presets
+  // ("enabled first", "cooldown"), not asc/desc toggles, so 'other' is the
+  // honest default; a genuine A–Z column passes 'ascending'.
+  sortAria?: 'ascending' | 'other';
+  render: (row: R) => ReactNode;
+}
+
+export interface RosterTableProps<R> {
+  cols: RosterColumn<R>[];
+  rows: R[];
+  rowKey: (row: R) => string;
+  // aria-label for the row's button role, e.g. "Edit Weather".
+  rowLabel: (row: R) => string;
+  // CSS colour for the row's left spine — the same status signal the card's
+  // spine carries. Omit for no spine.
+  rowSpine?: (row: R) => string;
+  onRowClick: (row: R) => void;
+  // Active sort mode, and the setter the sortable headers call.
+  sort?: string;
+  onSort?: (mode: string) => void;
+  // Visually-hidden <caption> naming the table for screen readers.
+  caption: string;
+}
+
+interface RosterRowProps<R> {
+  row: R;
+  cols: RosterColumn<R>[];
+  label: string;
+  spine?: string;
+  onClick: () => void;
+}
+
+// One row. Its own component so it can hold the ref the spine colour needs —
+// the `style` prop is lint-forbidden (issue #50), so dynamic colours go
+// through useDynamicStyle. A left border on the first cell spans the full row
+// height natively, which is why the spine is a border rather than a stretched
+// span.
+function RosterRow<R>({ row, cols, label, spine, onClick }: RosterRowProps<R>) {
+  const spineRef = useRef<HTMLTableCellElement>(null);
+  useDynamicStyle(spineRef, { borderLeftColor: spine });
+
+  return (
+    <tr
+      role="button"
+      tabIndex={0}
+      aria-label={label}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        // Same guard as the slate cards: a keyboard press on an inner control
+        // must not bubble up and also open the editor.
+        if (e.target !== e.currentTarget) return;
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); }
+      }}
+      className={cn(
+        'cursor-pointer transition-colors hover:bg-[var(--ink-softer)]',
+        'focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--accent)]',
+      )}
+    >
+      {cols.map((c, i) => (
+        <td
+          key={c.key}
+          ref={i === 0 ? spineRef : undefined}
+          className={cn(
+            'border-b border-separator-soft px-2 py-1.5 text-[12px]',
+            i === 0 && spine && 'border-l-4',
+            c.align === 'right' && 'text-right',
+            c.align === 'center' && 'text-center',
+            c.className,
+          )}
+        >
+          {c.render(row)}
+        </td>
+      ))}
+    </tr>
+  );
+}
+
+export function RosterTable<R>({
+  cols, rows, rowKey, rowLabel, rowSpine, onRowClick, sort, onSort, caption,
+}: RosterTableProps<R>) {
+  return (
+    // The wrapper scrolls horizontally as the floor. At the documented
+    // breakpoints the responsive column hiding should mean it never has to.
+    <div className="card overflow-x-auto">
+      <table className="w-full border-collapse">
+        <caption className="sr-only">{caption}</caption>
+        <thead>
+          <tr>
+            {cols.map((c) => {
+              const sortable = !!c.sortMode && !!onSort;
+              const active = sortable && sort === c.sortMode;
+              return (
+                <th
+                  key={c.key}
+                  scope="col"
+                  aria-sort={active ? (c.sortAria ?? 'other') : undefined}
+                  className={cn(
+                    'caption border-b border-ink px-2 py-1.5 whitespace-nowrap',
+                    // Sticky so the header survives a long roster scrolling
+                    // under it; the card background masks the rows.
+                    'sticky top-0 z-[1] bg-[var(--card-bg)]',
+                    c.align === 'right' && 'text-right',
+                    c.align === 'center' && 'text-center',
+                    c.className,
+                    c.headClassName,
+                  )}
+                >
+                  {sortable ? (
+                    <button
+                      type="button"
+                      onClick={() => onSort(c.sortMode as string)}
+                      className={cn(
+                        'inline-flex items-center gap-1 uppercase transition-colors hover:text-vermilion',
+                        active && 'text-vermilion',
+                      )}
+                    >
+                      {c.label}
+                      {active && <span aria-hidden="true">▾</span>}
+                    </button>
+                  ) : c.label}
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(r => (
+            <RosterRow
+              key={rowKey(r)}
+              row={r}
+              cols={cols}
+              label={rowLabel(r)}
+              spine={rowSpine?.(r)}
+              onClick={() => onRowClick(r)}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default RosterTable;

--- a/web/components/admin/RosterViewToggle.tsx
+++ b/web/components/admin/RosterViewToggle.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+// The Cards/List switch that sits above each roster (/admin/skills,
+// /admin/shows, /admin/personas). Icon-only: LayoutList is the slate card's
+// own shape (a face beside stacked lines), Rows3 is the dense table. Each
+// carries a visually-hidden label, so the accessible name is still
+// "Cards"/"List" for screen readers and tests.
+
+import { LayoutList, Rows3 } from 'lucide-react';
+import { Seg } from './ui';
+import type { RosterView } from '../../lib/adminView';
+
+interface RosterViewToggleProps {
+  view: RosterView;
+  onChange: (v: RosterView) => void;
+}
+
+export function RosterViewToggle({ view, onChange }: RosterViewToggleProps) {
+  return (
+    <Seg
+      value={view}
+      onChange={v => onChange(v === 'list' ? 'list' : 'cards')}
+      options={[
+        {
+          id: 'cards',
+          title: 'Card view',
+          label: (
+            <>
+              <LayoutList size={15} strokeWidth={1.75} aria-hidden />
+              <span className="sr-only">Cards</span>
+            </>
+          ),
+        },
+        {
+          id: 'list',
+          title: 'List view',
+          label: (
+            <>
+              <Rows3 size={15} strokeWidth={1.75} aria-hidden />
+              <span className="sr-only">List</span>
+            </>
+          ),
+        },
+      ]}
+    />
+  );
+}
+
+export default RosterViewToggle;

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -29,7 +29,7 @@ import { Field } from '../ui/field';
 import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup,
 } from '../ui/select';
-import { Card, Btn, Pill, Eyebrow, Metric, MetaChip, Toggle } from './ui';
+import { Card, Btn, Pill, Eyebrow, Metric, MetaChip, Toggle, Seg } from './ui';
 import { SkeletonRows } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/ui/empty-state';
 import { ErrorState } from '@/components/ui/error-state';
@@ -39,7 +39,10 @@ import { Modal } from '../ui/modal';
 import { AiFill } from './AiFill';
 import GenreSuggest from './GenreSuggest';
 import { PersonaPicker, GuestPersonaPicker, ThemePicker } from './ShowPickers';
+import ShowsTable from './ShowsTable';
+import type { ShowFacet, ShowRow } from './ShowsTable';
 import { cn } from '../../lib/cn';
+import { useRosterView } from '../../lib/adminView';
 import { showSubmitUrl } from '../../lib/repo';
 
 const NAME_MAX = 60;
@@ -455,6 +458,8 @@ export default function ShowsPanel() {
   // Community show catalog + install state (best-effort; null = still loading).
   const [community, setCommunity] = useState<CommunityShow[] | null>(null);
   const [communityOpen, setCommunityOpen] = useState(false);          // catalog modal open?
+  // Show definitions as cards (default) or a dense table. Per-surface pref.
+  const [view, setView] = useRosterView('shows');
   const [installing, setInstalling] = useState<string | null>(null);  // community slug installing, or null
 
   // Inline editor: `focusIdx` is the show open in the editor below the list
@@ -1300,6 +1305,11 @@ export default function ShowsPanel() {
       <div className="mt-1 flex flex-wrap items-center justify-between gap-3">
         <span className="caption">show definitions · {form.shows.length}/{SHOWS_MAX} shows</span>
         <div className="flex items-center gap-2">
+          <Seg
+            value={view}
+            options={[{ id: 'cards', label: 'Cards' }, { id: 'list', label: 'List' }]}
+            onChange={v => setView(v === 'list' ? 'list' : 'cards')}
+          />
           <Btn
             onClick={() => setCommunityOpen(true)}
             disabled={!community}
@@ -1326,7 +1336,14 @@ export default function ShowsPanel() {
         />
       )}
 
-      {form.shows.map((s, i) => {
+      {view === 'list' && form.shows.length > 0 && (
+        <ShowsTable
+          rows={form.shows.map((s, i) => showRow(s, i, personas, apiBase, countHours(s.id)))}
+          onEdit={r => focusShow(r.index)}
+        />
+      )}
+
+      {view === 'cards' && form.shows.map((s, i) => {
         const ok = showValid(s);
         const hrs = countHours(s.id);
         const host = personas.find(p => p.id === s.personaId) ?? null;
@@ -2285,10 +2302,68 @@ function ShowAvatar({
   );
 }
 
+// "What it plays" facets — moods, genres, eras, energies as chips, plus the
+// hard-lock / playlist / length flags. The visual counterpart to the text
+// showFilterSummary() the strip cards still use. Shared by the slate card and
+// the table row so the two views can't drift.
+function showFacets(s: Show): ShowFacet[] {
+  const facets: ShowFacet[] = [];
+  if (s.moods.length) s.moods.forEach(m => facets.push({ key: `mood-${m}`, label: m }));
+  else facets.push({ key: 'mood-any', label: 'any mood' });
+  s.genres.forEach(g => facets.push({ key: `genre-${g}`, label: g }));
+  s.eras.forEach((e, idx) => facets.push({ key: `era-${idx}`, label: eraLabelOf(e) }));
+  s.energies.forEach(en => facets.push({ key: `energy-${en}`, label: en }));
+  if (s.filtersStrict && hasAnyMusicFilter(s)) facets.push({ key: 'strict', label: 'strict', accent: true });
+  const nPl = s.playlistIds?.length ?? 0;
+  if (nPl) facets.push({ key: 'playlists', label: `${nPl} playlist${nPl > 1 ? 's' : ''}${s.playlistStrict ? ' · strict' : ''}` });
+  const nEx = s.excludedPlaylistIds?.length ?? 0;
+  if (nEx) facets.push({ key: 'excluded', label: `${nEx} excluded` });
+  if (s.maxTrackSeconds != null) {
+    facets.push({ key: 'length', label: s.maxTrackSeconds === 0 ? 'any length' : `≤${s.maxTrackSeconds}s` });
+  }
+  return facets;
+}
+
 // Grammatical name join: "Kai", "Kai & Rae", "Kai, Rae & Sol".
 function joinNames(names: string[]): string {
   if (names.length <= 1) return names[0] ?? '';
   return `${names.slice(0, -1).join(', ')} & ${names[names.length - 1]}`;
+}
+
+// A persona as a table face — resolved avatar URL plus the initials to fall
+// back to. `index` is carried on the row because the panel keys colour and
+// editing off the show's position in the array.
+function faceOf(p: Persona, apiBase: string) {
+  return {
+    key: p.id,
+    initials: abbrev(p.name?.trim() || ''),
+    src: p.avatar ? `${apiBase}/persona-avatar/${encodeURIComponent(p.id)}` : null,
+  };
+}
+
+// Flatten one show into the table's view-model. Everything the row needs is
+// derived here, so ShowsTable never has to know the `Show` shape.
+function showRow(s: Show, index: number, personas: Persona[], apiBase: string, hrs: number): ShowRow {
+  const host = personas.find(p => p.id === s.personaId) ?? null;
+  const guests = (s.guestPersonaIds || [])
+    .map(id => personas.find(p => p.id === id))
+    .filter((p): p is Persona => Boolean(p));
+  return {
+    id: s.id,
+    index,
+    name: s.name.trim(),
+    colour: SHOW_COLORS[index % SHOW_COLORS.length] ?? '#000',
+    programme: !!s.programme,
+    skillPin: s.programme && s.segmentSkill ? s.segmentSkill : '',
+    banter: !!s.banter,
+    host: host ? faceOf(host, apiBase) : null,
+    hostName: host ? (host.name?.trim() || 'Unnamed') : (s.personaId ? 'Unnamed' : ''),
+    guests: guests.map(g => faceOf(g, apiBase)),
+    guestNames: joinNames(guests.map(g => g.name?.trim() || 'Unnamed')),
+    facets: showFacets(s),
+    hrs,
+    ok: showValid(s),
+  };
 }
 
 interface ShowDefRowProps {
@@ -2315,23 +2390,7 @@ function ShowDefRow({ show: s, index: i, ok, hrs, host, guests, apiBase, onEdit 
   const guestNames = guests.map(g => g.name?.trim() || 'Unnamed');
   const skillPin = s.programme && s.segmentSkill ? s.segmentSkill : '';
 
-  // "What it plays" facets — moods, genres, eras, energies as chips, plus the
-  // hard-lock / playlist / length flags. The visual counterpart to the text
-  // showFilterSummary() the strip cards still use.
-  const facets: { key: string; label: string; accent?: boolean }[] = [];
-  if (s.moods.length) s.moods.forEach(m => facets.push({ key: `mood-${m}`, label: m }));
-  else facets.push({ key: 'mood-any', label: 'any mood' });
-  s.genres.forEach(g => facets.push({ key: `genre-${g}`, label: g }));
-  s.eras.forEach((e, idx) => facets.push({ key: `era-${idx}`, label: eraLabelOf(e) }));
-  s.energies.forEach(en => facets.push({ key: `energy-${en}`, label: en }));
-  if (s.filtersStrict && hasAnyMusicFilter(s)) facets.push({ key: 'strict', label: 'strict', accent: true });
-  const nPl = s.playlistIds?.length ?? 0;
-  if (nPl) facets.push({ key: 'playlists', label: `${nPl} playlist${nPl > 1 ? 's' : ''}${s.playlistStrict ? ' · strict' : ''}` });
-  const nEx = s.excludedPlaylistIds?.length ?? 0;
-  if (nEx) facets.push({ key: 'excluded', label: `${nEx} excluded` });
-  if (s.maxTrackSeconds != null) {
-    facets.push({ key: 'length', label: s.maxTrackSeconds === 0 ? 'any length' : `≤${s.maxTrackSeconds}s` });
-  }
+  const facets = showFacets(s);
 
   return (
     <article

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -29,7 +29,8 @@ import { Field } from '../ui/field';
 import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup,
 } from '../ui/select';
-import { Card, Btn, Pill, Eyebrow, Metric, MetaChip, Toggle, Seg } from './ui';
+import { Card, Btn, Pill, Eyebrow, Metric, MetaChip, Toggle } from './ui';
+import RosterViewToggle from './RosterViewToggle';
 import { SkeletonRows } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/ui/empty-state';
 import { ErrorState } from '@/components/ui/error-state';
@@ -1305,11 +1306,7 @@ export default function ShowsPanel() {
       <div className="mt-1 flex flex-wrap items-center justify-between gap-3">
         <span className="caption">show definitions · {form.shows.length}/{SHOWS_MAX} shows</span>
         <div className="flex items-center gap-2">
-          <Seg
-            value={view}
-            options={[{ id: 'cards', label: 'Cards' }, { id: 'list', label: 'List' }]}
-            onChange={v => setView(v === 'list' ? 'list' : 'cards')}
-          />
+          <RosterViewToggle view={view} onChange={setView} />
           <Btn
             onClick={() => setCommunityOpen(true)}
             disabled={!community}

--- a/web/components/admin/ShowsTable.tsx
+++ b/web/components/admin/ShowsTable.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+// Shows roster as a dense table — the "list" half of the cards/list toggle on
+// /admin/shows. Same contract as the slate cards: the row opens the inline
+// editor, and the spine carries the same per-show colour the weekly grid
+// paints with.
+//
+// It takes a prepared view-model rather than the panel's `Show` type: the row
+// is a dumb renderer, and ShowsPanel stays the only place that knows how a
+// show's facets, airtime and validity are derived.
+
+import { useMemo } from 'react';
+import { Pill, MetaChip } from './ui';
+import { RosterTable } from './RosterTable';
+import type { RosterColumn } from './RosterTable';
+import { RosterAvatar } from './RosterAvatar';
+
+export interface ShowFace {
+  key: string;
+  initials: string;
+  src: string | null;
+}
+
+export interface ShowFacet {
+  key: string;
+  label: string;
+  accent?: boolean;
+}
+
+export interface ShowRow {
+  id: string;
+  index: number;
+  name: string;
+  colour: string;
+  programme: boolean;
+  // The pinned feature segment, shown next to the Programme pill.
+  skillPin: string;
+  banter: boolean;
+  host: ShowFace | null;
+  hostName: string;
+  guests: ShowFace[];
+  guestNames: string;
+  facets: ShowFacet[];
+  // Scheduled hours per week; 0 renders as "unscheduled".
+  hrs: number;
+  ok: boolean;
+}
+
+interface ShowsTableProps {
+  rows: ShowRow[];
+  onEdit: (row: ShowRow) => void;
+}
+
+export function ShowsTable({ rows, onEdit }: ShowsTableProps) {
+  const cols = useMemo<RosterColumn<ShowRow>[]>(() => [
+    {
+      key: 'faces',
+      label: '',
+      className: 'w-14',
+      render: (r) => (
+        <span className="flex items-center">
+          <RosterAvatar
+            src={r.host?.src ?? null}
+            initials={r.host?.initials ?? ''}
+          />
+          {r.guests.map((g, i) => (
+            <RosterAvatar
+              key={g.key}
+              src={g.src}
+              initials={g.initials}
+              size="xs"
+              className={i === 0 ? '-ml-1.5 ring-2 ring-[var(--card-bg)]' : '-ml-2 ring-2 ring-[var(--card-bg)]'}
+            />
+          ))}
+        </span>
+      ),
+    },
+    {
+      key: 'name',
+      label: 'Show',
+      className: 'whitespace-nowrap',
+      render: (r) => (
+        // No wrapping anywhere in the row: a chip or pill dropping to a second
+        // line would inflate the row height and undo the point of the list.
+        <span className="flex min-w-0 items-center gap-1.5">
+          <span className="truncate font-extrabold text-ink">{r.name || 'untitled'}</span>
+          {r.programme && (
+            <Pill tone="solid" dot>Programme{r.skillPin ? ` · ${r.skillPin}` : ''}</Pill>
+          )}
+          {r.banter && r.guests.length > 0 && <Pill>Banter</Pill>}
+        </span>
+      ),
+    },
+    {
+      key: 'host',
+      label: 'Host',
+      // `w-full max-w-0` — see the note in SkillsTable: the pair is what lets
+      // the inner span truncate instead of widening the column.
+      className: 'hidden md:table-cell w-full max-w-0',
+      render: (r) => (
+        r.hostName
+          ? (
+            <span className="block truncate text-muted" title={r.hostName}>
+              <span className="font-semibold text-ink">{r.hostName}</span>
+              {r.guestNames && <> · with {r.guestNames}</>}
+            </span>
+          )
+          : <span className="text-[var(--danger)]">no persona set</span>
+      ),
+    },
+    {
+      key: 'plays',
+      label: 'Plays',
+      className: 'hidden lg:table-cell whitespace-nowrap',
+      render: (r) => {
+        if (!r.facets.length) return <span className="text-muted">—</span>;
+        return (
+          <span className="flex items-center gap-1">
+            {r.facets.slice(0, 3).map(f => (
+              <MetaChip key={f.key} accent={f.accent} className="whitespace-nowrap">{f.label}</MetaChip>
+            ))}
+            {r.facets.length > 3 && <MetaChip>+{r.facets.length - 3}</MetaChip>}
+          </span>
+        );
+      },
+    },
+    {
+      key: 'hrs',
+      label: 'h / wk',
+      align: 'right',
+      className: 'whitespace-nowrap',
+      render: (r) => (
+        r.hrs > 0
+          ? <span className="mono-num font-extrabold text-ink">{r.hrs}</span>
+          : <span className="caption">unscheduled</span>
+      ),
+    },
+    {
+      key: 'status',
+      label: '',
+      align: 'right',
+      className: 'w-24 whitespace-nowrap',
+      render: (r) => (r.ok ? null : <Pill tone="accent">incomplete</Pill>),
+    },
+  ], []);
+
+  return (
+    <RosterTable
+      caption="Show definitions"
+      cols={cols}
+      rows={rows}
+      rowKey={r => r.id}
+      rowLabel={r => `Edit ${r.name || 'untitled show'}`}
+      rowSpine={r => r.colour}
+      onRowClick={onEdit}
+    />
+  );
+}
+
+export default ShowsTable;

--- a/web/components/admin/SkillsPanel.tsx
+++ b/web/components/admin/SkillsPanel.tsx
@@ -16,12 +16,9 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from '../../lib/cn';
 import { notify, errorMessage } from '../../lib/notify';
 import { useAdminAuth } from '../../lib/adminAuth';
-import {
-  RefreshCw, Plus, Users, Upload, Search, X,
-  CloudSun, Newspaper, TrafficCone, Lightbulb, Cake, Disc3, Globe, Sparkles,
-} from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
-import { Card, Btn, Pill, Eyebrow, MetaChip, Toggle } from './ui';
+import { useRosterView } from '../../lib/adminView';
+import { RefreshCw, Plus, Users, Upload, Search, X } from 'lucide-react';
+import { Card, Btn, Pill, Eyebrow, MetaChip, Toggle, Seg } from './ui';
 import { V3Alert } from '../ui/alert';
 import { SkeletonRows } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -33,22 +30,9 @@ import {
 } from '../ui/select';
 import SkillEditModal from './skills/SkillEditModal';
 import type { PersonaLite } from './skills/SkillEditModal';
-
-interface Skill {
-  name: string;
-  label?: string;
-  kind?: string;
-  description?: string;
-  enabled?: boolean;
-  ready?: boolean;
-  requiresKey?: string;
-  keyUrl?: string;
-  cooldownMs?: number;
-  custom?: boolean;
-  feed?: string | null;
-  feedMaxItems?: number | null;
-  tags?: string[];
-}
+import SkillsTable from './skills/SkillsTable';
+import { cooldownLabel, iconFor } from './skills/shared';
+import type { Skill, SortMode, StatusFilter } from './skills/shared';
 
 // Slim show shape from GET /settings — enough for the "filter by show" option
 // (a show's skills are its HOST persona's, plus its pinned feature segment).
@@ -63,9 +47,6 @@ interface ShowLite {
 function personaHasSkill(p: PersonaLite, name: string): boolean {
   return p.skills === null || p.skills.includes(name);
 }
-
-type StatusFilter = 'all' | 'enabled' | 'disabled' | 'needs-key' | 'custom' | 'builtin';
-type SortMode = 'az' | 'enabled' | 'cooldown';
 
 // One entry in the shipped community catalog (GET /dj/skills/community).
 interface CommunitySkill {
@@ -102,27 +83,6 @@ interface SkillRunResponse {
 
 // Which skill the modal is editing/creating, if any.
 type ModalState = { mode: 'create' } | { mode: 'edit'; skill: Skill };
-
-function cooldownLabel(ms?: number): string {
-  if (!ms) return 'no cooldown';
-  const min = Math.round(ms / 60000);
-  if (min < 60) return `${min} min cooldown`;
-  const h = Math.round(min / 6) / 10;
-  return `${h} h cooldown`;
-}
-
-// A glyph for each of the seven built-in segment kinds — fills the slate card's
-// "face" slot where personas/shows have an avatar. Custom skills (and any
-// unmapped kind) fall back to Sparkles, so this is not a maintenance trap.
-const KIND_ICONS: Record<string, LucideIcon> = {
-  weather: CloudSun,
-  news: Newspaper,
-  traffic: TrafficCone,
-  curiosity: Lightbulb,
-  'album-anniversary': Cake,
-  'library-deep-cut': Disc3,
-  'web-search': Globe,
-};
 
 interface SkillDescriptionProps {
   text?: string;
@@ -175,6 +135,9 @@ export default function SkillsPanel() {
   const [tagSel, setTagSel] = useState<string[]>([]);
   const [status, setStatus] = useState<StatusFilter>('all');
   const [sort, setSort] = useState<SortMode>('az');
+
+  // Cards (default) or the dense table. Remembered per surface in localStorage.
+  const [view, setView] = useRosterView('skills');
 
   // Pull the slim persona/show roster out of GET /settings. Reused after the
   // modal saves DJ assignments, so the filter + pills stay accurate.
@@ -416,6 +379,11 @@ export default function SkillsPanel() {
     return n === personas.length ? 'All DJs' : `${n} of ${personas.length} DJs`;
   };
 
+  // The show's pinned feature segment — only meaningful while the DJ/show
+  // filter is sitting on a show.
+  const isPinned = (s: Skill): boolean =>
+    who.startsWith('s:') && shows.find(x => x.id === who.slice(2))?.segmentSkill === s.name;
+
   return (
     <div className="grid gap-4">
       {/* ── HERO ─────────────────────────────────────────────────────────── */}
@@ -546,6 +514,15 @@ export default function SkillsPanel() {
               <X size={14} /> Clear
             </Btn>
           )}
+          {/* Cards stay the default; the list is the second gear for a roster
+              that has outgrown a card stack. Filters/sort drive both views. */}
+          <div className="ml-auto">
+            <Seg
+              value={view}
+              options={[{ id: 'cards', label: 'Cards' }, { id: 'list', label: 'List' }]}
+              onChange={v => setView(v === 'list' ? 'list' : 'cards')}
+            />
+          </div>
         </div>
         {allTags.length > 0 && (
           <div className="mt-2.5 flex flex-wrap items-center gap-1">
@@ -585,13 +562,26 @@ export default function SkillsPanel() {
           />
         </Card>
       )}
-      {visible.map(s => {
-        const Icon = KIND_ICONS[s.kind || s.name] ?? Sparkles;
+      {view === 'list' && visible.length > 0 && (
+        <SkillsTable
+          skills={visible}
+          busy={busy}
+          assignmentLabel={assignmentLabel}
+          isPinned={isPinned}
+          sort={sort}
+          onSort={setSort}
+          onEdit={s => setModal({ mode: 'edit', skill: s })}
+          onToggle={toggle}
+          onRunNow={runNow}
+        />
+      )}
+
+      {view === 'cards' && visible.map(s => {
+        const Icon = iconFor(s);
         // Spine keyed to enabled state — the same signal the toggle carries.
         const spine = s.enabled ? 'bg-[var(--accent)]' : 'bg-separator-strong';
         const assign = assignmentLabel(s);
-        const pinned = who.startsWith('s:')
-          && shows.find(x => x.id === who.slice(2))?.segmentSkill === s.name;
+        const pinned = isPinned(s);
         return (
           // The whole card opens the edit sheet; the Toggle, Run now, and the
           // API-key link stopPropagation so they act in place. The onKeyDown

--- a/web/components/admin/SkillsPanel.tsx
+++ b/web/components/admin/SkillsPanel.tsx
@@ -18,7 +18,8 @@ import { notify, errorMessage } from '../../lib/notify';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { useRosterView } from '../../lib/adminView';
 import { RefreshCw, Plus, Users, Upload, Search, X } from 'lucide-react';
-import { Card, Btn, Pill, Eyebrow, MetaChip, Toggle, Seg } from './ui';
+import { Card, Btn, Pill, Eyebrow, MetaChip, Toggle } from './ui';
+import RosterViewToggle from './RosterViewToggle';
 import { V3Alert } from '../ui/alert';
 import { SkeletonRows } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -517,11 +518,7 @@ export default function SkillsPanel() {
           {/* Cards stay the default; the list is the second gear for a roster
               that has outgrown a card stack. Filters/sort drive both views. */}
           <div className="ml-auto">
-            <Seg
-              value={view}
-              options={[{ id: 'cards', label: 'Cards' }, { id: 'list', label: 'List' }]}
-              onChange={v => setView(v === 'list' ? 'list' : 'cards')}
-            />
+            <RosterViewToggle view={view} onChange={setView} />
           </div>
         </div>
         {allTags.length > 0 && (

--- a/web/components/admin/personas/PersonaRoster.tsx
+++ b/web/components/admin/personas/PersonaRoster.tsx
@@ -11,8 +11,9 @@ import { API_BASE, PERSONA_MAX } from './constants';
 import { initialsFor, personaValid } from './helpers';
 import { cn } from '../../../lib/cn';
 import { useRosterView } from '../../../lib/adminView';
-import { Btn, Pill, MetaChip, Seg } from '../ui';
+import { Btn, Pill, MetaChip } from '../ui';
 import PersonaTable from './PersonaTable';
+import RosterViewToggle from '../RosterViewToggle';
 
 interface PersonaRosterProps {
   personas: Persona[];
@@ -43,11 +44,7 @@ export function PersonaRoster({
       <div className="flex flex-wrap items-center justify-between gap-3">
         <span className="caption">roster · {personas.length} / {PERSONA_MAX}</span>
         <div className="flex flex-wrap items-center gap-2">
-          <Seg
-            value={view}
-            options={[{ id: 'cards', label: 'Cards' }, { id: 'list', label: 'List' }]}
-            onChange={v => setView(v === 'list' ? 'list' : 'cards')}
-          />
+          <RosterViewToggle view={view} onChange={setView} />
           <Btn
             onClick={onCommunity}
             disabled={communityCount === null}

--- a/web/components/admin/personas/PersonaRoster.tsx
+++ b/web/components/admin/personas/PersonaRoster.tsx
@@ -10,7 +10,9 @@ import type { Persona } from './types';
 import { API_BASE, PERSONA_MAX } from './constants';
 import { initialsFor, personaValid } from './helpers';
 import { cn } from '../../../lib/cn';
-import { Btn, Pill, MetaChip } from '../ui';
+import { useRosterView } from '../../../lib/adminView';
+import { Btn, Pill, MetaChip, Seg } from '../ui';
+import PersonaTable from './PersonaTable';
 
 interface PersonaRosterProps {
   personas: Persona[];
@@ -33,11 +35,19 @@ export function PersonaRoster({
   personas, activePersonaId, onAirPersonaId, avatarTick,
   onOpenPrompt, onAdd, onSelect, communityCount, onCommunity,
 }: PersonaRosterProps) {
+  // Cards (default) or a dense table. Remembered per surface in localStorage.
+  const [view, setView] = useRosterView('personas');
+
   return (
     <section className="grid gap-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <span className="caption">roster · {personas.length} / {PERSONA_MAX}</span>
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Seg
+            value={view}
+            options={[{ id: 'cards', label: 'Cards' }, { id: 'list', label: 'List' }]}
+            onChange={v => setView(v === 'list' ? 'list' : 'cards')}
+          />
           <Btn
             onClick={onCommunity}
             disabled={communityCount === null}
@@ -54,7 +64,17 @@ export function PersonaRoster({
           </Btn>
         </div>
       </div>
-      {personas.map((p, i) => {
+      {view === 'list' && personas.length > 0 && (
+        <PersonaTable
+          personas={personas}
+          activePersonaId={activePersonaId}
+          onAirPersonaId={onAirPersonaId}
+          avatarTick={avatarTick}
+          onSelect={onSelect}
+        />
+      )}
+
+      {view === 'cards' && personas.map((p, i) => {
         const isOnAir = p.id === onAirPersonaId;
         const isDefault = p.id === activePersonaId;
         const valid = personaValid(p);

--- a/web/components/admin/personas/PersonaTable.tsx
+++ b/web/components/admin/personas/PersonaTable.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+// DJ roster as a dense table — the "list" half of the cards/list toggle on
+// /admin/personas. Same contract as the slate cards: the row opens the editor,
+// and the spine carries the same status colour (on air / default / incomplete).
+
+import { useMemo } from 'react';
+import type { Persona } from './types';
+import { API_BASE } from './constants';
+import { initialsFor, personaValid } from './helpers';
+import { Pill, MetaChip } from '../ui';
+import { RosterTable } from '../RosterTable';
+import type { RosterColumn } from '../RosterTable';
+import { RosterAvatar } from '../RosterAvatar';
+
+interface PersonaTableProps {
+  personas: Persona[];
+  // The admin-selected default — gets the "default" pill.
+  activePersonaId: string;
+  // The persona actually broadcasting now (show override aware).
+  onAirPersonaId: string;
+  // Cache-buster bumped on avatar upload/delete.
+  avatarTick: number;
+  onSelect: (idx: number) => void;
+}
+
+// The roster is index-keyed (onSelect(i)), so the row carries its position.
+interface PersonaRow {
+  persona: Persona;
+  index: number;
+}
+
+export function PersonaTable({
+  personas, activePersonaId, onAirPersonaId, avatarTick, onSelect,
+}: PersonaTableProps) {
+  const rows = useMemo<PersonaRow[]>(
+    () => personas.map((persona, index) => ({ persona, index })),
+    [personas],
+  );
+
+  const cols = useMemo<RosterColumn<PersonaRow>[]>(() => [
+    {
+      key: 'face',
+      label: '',
+      className: 'w-10',
+      render: ({ persona: p }) => (
+        <RosterAvatar
+          src={p.avatar ? `${API_BASE}/persona-avatar/${encodeURIComponent(p.id)}?v=${avatarTick}` : null}
+          initials={initialsFor(p.name)}
+        />
+      ),
+    },
+    {
+      key: 'name',
+      label: 'DJ',
+      className: 'whitespace-nowrap',
+      render: ({ persona: p, index }) => {
+        const isOnAir = p.id === onAirPersonaId;
+        const isDefault = p.id === activePersonaId;
+        return (
+          <span className="flex min-w-0 items-center gap-1.5">
+            <span className="truncate font-extrabold text-ink">
+              {p.name.trim() || `Persona ${index + 1}`}
+            </span>
+            {isOnAir && <Pill tone="accent" dot>on air</Pill>}
+            {isDefault && !isOnAir && <Pill>default</Pill>}
+          </span>
+        );
+      },
+    },
+    {
+      key: 'tagline',
+      label: 'Tagline',
+      // `w-full max-w-0` — see the note in SkillsTable: the pair is what lets
+      // the inner span truncate instead of widening the column.
+      className: 'hidden lg:table-cell w-full max-w-0',
+      render: ({ persona: p }) => (
+        <span className="block truncate text-muted italic" title={p.tagline.trim()}>
+          {p.tagline.trim() || 'no tagline'}
+        </span>
+      ),
+    },
+    {
+      key: 'frequency',
+      label: 'Frequency',
+      className: 'hidden md:table-cell whitespace-nowrap',
+      render: ({ persona: p }) => <span className="text-muted">{p.frequency}</span>,
+    },
+    {
+      key: 'voice',
+      label: 'Voice',
+      className: 'hidden md:table-cell whitespace-nowrap',
+      render: ({ persona: p }) => (
+        <span className="flex items-center gap-1">
+          <MetaChip>{p.tts.engine}</MetaChip>
+          {p.tts.engine !== 'piper' && p.tts.voice.trim() && (
+            <MetaChip className="max-w-[120px] truncate">{p.tts.voice.trim()}</MetaChip>
+          )}
+        </span>
+      ),
+    },
+    {
+      key: 'skills',
+      label: 'Skills',
+      align: 'right',
+      className: 'whitespace-nowrap',
+      render: ({ persona: p }) => (
+        <span className="mono-num font-extrabold text-ink">{p.skills.length}</span>
+      ),
+    },
+    {
+      key: 'status',
+      label: '',
+      align: 'right',
+      className: 'w-24 whitespace-nowrap',
+      render: ({ persona: p }) => (
+        personaValid(p)
+          ? null
+          : <Pill className="border-[var(--danger)] text-[var(--danger)]">incomplete</Pill>
+      ),
+    },
+  ], [activePersonaId, onAirPersonaId, avatarTick]);
+
+  // Same status priority as the card spine: on air wins, then default, then
+  // incomplete, then a plain hairline.
+  const spineFor = ({ persona: p }: PersonaRow): string => {
+    if (p.id === onAirPersonaId) return 'var(--accent)';
+    if (p.id === activePersonaId) return 'var(--ink)';
+    if (!personaValid(p)) return 'var(--danger)';
+    return 'var(--separator-strong)';
+  };
+
+  return (
+    <RosterTable
+      caption="DJ roster"
+      cols={cols}
+      rows={rows}
+      rowKey={r => r.persona.id}
+      rowLabel={r => `Edit ${r.persona.name.trim() || `Persona ${r.index + 1}`}`}
+      rowSpine={spineFor}
+      onRowClick={r => onSelect(r.index)}
+    />
+  );
+}
+
+export default PersonaTable;

--- a/web/components/admin/skills/SkillsTable.tsx
+++ b/web/components/admin/skills/SkillsTable.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+// Skills roster as a dense table — the "list" half of the cards/list toggle on
+// /admin/skills. Same contract as the slate cards: the row opens the edit
+// sheet, and the enable switch and Run now pad still act in place.
+
+import { useMemo } from 'react';
+import { cn } from '../../../lib/cn';
+import { Pill, MetaChip, Toggle } from '../ui';
+import { RosterTable } from '../RosterTable';
+import type { RosterColumn } from '../RosterTable';
+import { cooldownLabel, iconFor } from './shared';
+import type { Skill, SortMode } from './shared';
+
+interface SkillsTableProps {
+  skills: Skill[];
+  // Name of the skill currently mutating (toggle or run), or null.
+  busy: string | null;
+  // "All DJs" / "3 of 8 DJs" — empty string when the roster hasn't loaded.
+  assignmentLabel: (s: Skill) => string;
+  // True when the DJ/show filter is on a show and this is its pinned feature.
+  isPinned: (s: Skill) => boolean;
+  sort: SortMode;
+  onSort: (mode: SortMode) => void;
+  onEdit: (s: Skill) => void;
+  onToggle: (name: string, on: boolean) => void;
+  onRunNow: (name: string) => void;
+}
+
+export function SkillsTable({
+  skills, busy, assignmentLabel, isPinned, sort, onSort, onEdit, onToggle, onRunNow,
+}: SkillsTableProps) {
+  const cols = useMemo<RosterColumn<Skill>[]>(() => [
+    {
+      key: 'face',
+      label: '',
+      className: 'w-9',
+      render: (s) => {
+        const Icon = iconFor(s);
+        return (
+          <span className={cn('grid place-items-center', s.enabled ? 'text-ink' : 'text-muted')}>
+            <Icon size={16} strokeWidth={1.75} aria-hidden />
+          </span>
+        );
+      },
+    },
+    {
+      key: 'name',
+      label: 'Skill',
+      className: 'whitespace-nowrap',
+      sortMode: 'az',
+      sortAria: 'ascending',
+      render: (s) => (
+        // No wrapping in the row — a pill dropping to a second line would
+        // inflate the row height and undo the point of the list.
+        <span className="flex min-w-0 items-center gap-1.5">
+          <span className="truncate font-extrabold text-ink">{s.label || s.name}</span>
+          {s.custom && <Pill className="text-[8px]">custom</Pill>}
+          {/* The card carries the full V3Alert; the table just flags it and the
+              guidance stays one click away in the edit sheet. */}
+          {s.ready === false && (
+            <MetaChip className="border-[var(--danger)] text-[var(--danger)]">needs key</MetaChip>
+          )}
+          {isPinned(s) && <MetaChip accent>pinned</MetaChip>}
+        </span>
+      ),
+    },
+    {
+      key: 'brief',
+      label: 'Brief',
+      // `w-full` claims the table's slack and `max-w-0` lets the inner span
+      // truncate instead of widening the column — the pair is what makes
+      // truncation work at all in an auto-layout table.
+      className: 'hidden lg:table-cell w-full max-w-0',
+      render: (s) => (
+        <span className="block truncate text-muted italic" title={s.description || ''}>
+          {s.description || 'No description.'}
+        </span>
+      ),
+    },
+    {
+      key: 'cooldown',
+      label: 'Cooldown',
+      className: 'hidden md:table-cell whitespace-nowrap',
+      sortMode: 'cooldown',
+      render: (s) => <span className="text-muted">{cooldownLabel(s.cooldownMs)}</span>,
+    },
+    {
+      key: 'djs',
+      label: 'DJs',
+      className: 'hidden md:table-cell whitespace-nowrap',
+      render: (s) => <span className="text-muted">{assignmentLabel(s) || '—'}</span>,
+    },
+    {
+      key: 'tags',
+      label: 'Tags',
+      className: 'hidden xl:table-cell',
+      render: (s) => {
+        const tags = s.tags || [];
+        if (!tags.length) return <span className="text-muted">—</span>;
+        return (
+          <span className="flex items-center gap-1">
+            {tags.slice(0, 2).map(t => <MetaChip key={t} className="whitespace-nowrap">#{t}</MetaChip>)}
+            {tags.length > 2 && <MetaChip>+{tags.length - 2}</MetaChip>}
+          </span>
+        );
+      },
+    },
+    {
+      key: 'run',
+      label: '',
+      align: 'right',
+      className: 'whitespace-nowrap',
+      render: (s) => (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onRunNow(s.name); }}
+          disabled={busy === s.name}
+          className={cn('seg-pad seg-pad--slim', busy === s.name && 'is-firing')}
+        >
+          <span className="seg-led" aria-hidden />
+          <span className="seg-label">{busy === s.name ? 'Working…' : 'Run now'}</span>
+        </button>
+      ),
+    },
+    {
+      key: 'enabled',
+      label: 'On',
+      align: 'right',
+      className: 'w-12',
+      sortMode: 'enabled',
+      render: (s) => (
+        <span onClick={e => e.stopPropagation()}>
+          <Toggle
+            on={s.enabled}
+            disabled={busy === s.name}
+            onClick={() => onToggle(s.name, !s.enabled)}
+          />
+        </span>
+      ),
+    },
+  ], [busy, assignmentLabel, isPinned, onRunNow, onToggle]);
+
+  return (
+    <RosterTable
+      caption="Skills"
+      cols={cols}
+      rows={skills}
+      rowKey={s => s.name}
+      rowLabel={s => `Edit ${s.label || s.name}`}
+      rowSpine={s => (s.enabled ? 'var(--accent)' : 'var(--separator-strong)')}
+      onRowClick={onEdit}
+      sort={sort}
+      onSort={m => onSort(m as SortMode)}
+    />
+  );
+}
+
+export default SkillsTable;

--- a/web/components/admin/skills/shared.ts
+++ b/web/components/admin/skills/shared.ts
@@ -1,0 +1,56 @@
+// Shared skill-catalogue vocabulary for the Skills admin — the row shape from
+// GET /dj/skills, the organise-bar modes, the per-kind glyph, and the cooldown
+// formatter. Lives here so the card list (SkillsPanel) and the table list
+// (SkillsTable) agree without one importing the other.
+
+import type { LucideIcon } from 'lucide-react';
+import {
+  CloudSun, Newspaper, TrafficCone, Lightbulb, Cake, Disc3, Globe, Sparkles,
+} from 'lucide-react';
+
+// The full catalogue row. SkillEditModal's `SkillLike` is the subset of this
+// the edit sheet needs.
+export interface Skill {
+  name: string;
+  label?: string;
+  kind?: string;
+  description?: string;
+  enabled?: boolean;
+  ready?: boolean;
+  requiresKey?: string;
+  keyUrl?: string;
+  cooldownMs?: number;
+  custom?: boolean;
+  feed?: string | null;
+  feedMaxItems?: number | null;
+  tags?: string[];
+}
+
+export type StatusFilter = 'all' | 'enabled' | 'disabled' | 'needs-key' | 'custom' | 'builtin';
+export type SortMode = 'az' | 'enabled' | 'cooldown';
+
+// A glyph for each of the seven built-in segment kinds — fills the slate card's
+// "face" slot where personas/shows have an avatar, and the table's face column.
+// Custom skills (and any unmapped kind) fall back to Sparkles, so this is not a
+// maintenance trap.
+export const KIND_ICONS: Record<string, LucideIcon> = {
+  weather: CloudSun,
+  news: Newspaper,
+  traffic: TrafficCone,
+  curiosity: Lightbulb,
+  'album-anniversary': Cake,
+  'library-deep-cut': Disc3,
+  'web-search': Globe,
+};
+
+export function iconFor(s: Skill): LucideIcon {
+  return KIND_ICONS[s.kind || s.name] ?? Sparkles;
+}
+
+export function cooldownLabel(ms?: number): string {
+  if (!ms) return 'no cooldown';
+  const min = Math.round(ms / 60000);
+  if (min < 60) return `${min} min cooldown`;
+  const h = Math.round(min / 6) / 10;
+  return `${h} h cooldown`;
+}

--- a/web/components/admin/ui.tsx
+++ b/web/components/admin/ui.tsx
@@ -148,6 +148,10 @@ export function Btn({ children, tone, sm, lg, onClick, disabled, type, title, cl
 export interface SegOption {
   id: string;
   label: ReactNode;
+  /* Hover tooltip. Mainly for icon-only tabs, where the label carries no
+     readable text of its own (the accessible name comes from an `sr-only`
+     span inside `label`). */
+  title?: string;
 }
 
 export interface SegProps {
@@ -175,6 +179,7 @@ export function Seg({ value, options, accent, onChange }: SegProps) {
         <ToggleGroupItem
           key={o.id}
           value={o.id}
+          title={o.title}
           className={cn(
             'h-auto min-w-0 rounded-none border-0 px-[13px] py-[7px] text-[10px] font-bold tracking-[0.18em] text-ink uppercase',
             'hover:bg-[var(--ink-soft)] hover:text-ink',

--- a/web/lib/adminView.ts
+++ b/web/lib/adminView.ts
@@ -1,0 +1,57 @@
+'use client';
+
+// Roster view preference — cards or list — for the three admin rosters that
+// share the "broadcast slate" card recipe (/admin/skills, /admin/shows,
+// /admin/personas). Cards stay the default; the list view is the second gear
+// for a roster that has outgrown a card stack.
+//
+// Stored per surface, not globally: an operator may well want Skills as a
+// dense list while Shows stays on cards (that page already has the weekly grid
+// above it doing the scanning job). Browser-local like the skin/theme
+// overrides — this is a cheap preference, not station state.
+
+import { useCallback, useEffect, useState } from 'react';
+
+export type RosterSurface = 'skills' | 'shows' | 'personas';
+export type RosterView = 'cards' | 'list';
+
+const KEY_PREFIX = 'subwave-admin-view:';
+
+function isView(v: string | null): v is RosterView {
+  return v === 'cards' || v === 'list';
+}
+
+export function readRosterView(surface: RosterSurface): RosterView {
+  if (typeof window === 'undefined') return 'cards';
+  try {
+    const raw = window.localStorage.getItem(`${KEY_PREFIX}${surface}`);
+    return isView(raw) ? raw : 'cards';
+  } catch {
+    return 'cards';
+  }
+}
+
+function writeRosterView(surface: RosterSurface, view: RosterView): void {
+  try {
+    window.localStorage.setItem(`${KEY_PREFIX}${surface}`, view);
+  } catch { /* private-mode browsers throw on setItem — the view still works */ }
+}
+
+/* `[view, setView]` for one roster surface. Starts on 'cards' and reads the
+   stored preference in a mount effect rather than in the initial state, so
+   server and first client render agree. A list-view operator sees one frame of
+   cards on a cold load; the panels render a skeleton while the roster fetch is
+   in flight, so in practice the view resolves before there is a roster to
+   draw. */
+export function useRosterView(surface: RosterSurface): [RosterView, (v: RosterView) => void] {
+  const [view, setViewState] = useState<RosterView>('cards');
+
+  useEffect(() => { setViewState(readRosterView(surface)); }, [surface]);
+
+  const setView = useCallback((v: RosterView) => {
+    setViewState(v);
+    writeRosterView(surface, v);
+  }, [surface]);
+
+  return [view, setView];
+}


### PR DESCRIPTION
Closes the operator ask: *"would be easier to sort through and configure them if they were more of a table view format ... or as an option, instead of just the current card styles especially as the numbers of them grow."*

## What

A **Cards / List** toggle on `/admin/skills`, `/admin/shows` and `/admin/personas`. Cards stay the default; the choice is remembered **per surface** in `localStorage`, so nothing changes for anyone who doesn't click it.

List view is a dense table — one ~40px row per item instead of a ~140–180px slate card — keeping the card's contract:

- the whole row is the edit target (opens the same sheet / inline editor);
- the left spine carries the same status colour (enabled, on-air/default/incomplete, per-show grid colour);
- the Skills **enable switch** and **Run now** still act in place, and a keyboard press on them doesn't bubble up and also open the editor.

## Screenshots

| | |
|---|---|
| Skills — list | 7 skills in the space ~1.5 cards used to take; sortable `Skill` / `Cooldown` / `On` headers |
| Shows — list | spines match the weekly-grid brush colours; Programme pill inline; facet chips capped at 3 + `+n` |
| DJs — list | on-air/default pills, frequency, voice, skill count |

## Files

- `lib/adminView.ts` — the per-surface persisted preference (`subwave-admin-view:<surface>`), SSR-safe, `try/catch` around storage.
- `components/admin/RosterTable.tsx` — shared column-driven table. Sticky header, row-as-button, `border-left` spine coloured via `useDynamicStyle` (the `style` prop is lint-forbidden), optional sortable headers with `aria-sort`, responsive column hiding with `overflow-x-auto` as the floor.
- `components/admin/RosterAvatar.tsx` — the initials-behind-`<img>` face, shared by Shows and DJs.
- `components/admin/skills/{SkillsTable,shared}.tsx|ts` — headers sort through the panel's **existing** `az`/`enabled`/`cooldown` modes, so the table and the Sort select can't disagree. `shared.ts` holds the `Skill` shape, kind glyphs and `cooldownLabel` so panel and table agree without a circular import.
- `components/admin/ShowsTable.tsx` — takes a prepared view-model rather than the panel's `Show` type. `showFacets()` is lifted out of `ShowDefRow` to module scope so the card and the row can't drift.
- `components/admin/personas/PersonaTable.tsx`

Hand-rolled in the house table style already used by `StatsPanel`/`DashPanel` — no new dependency, and deliberately not shadcn's `table` given the Tailwind v4 / CLI mismatch this repo has hit before.

## Deliberately not in this PR

- **Sortable headers on Shows and DJs.** Both panels key off the roster's array index (`SHOW_COLORS[i]`, the weekly grid, `onSelect(i)`), so reordering rows needs that decoupled first — real breakage risk, and not what the request is about.
- **Search / filter for Shows and DJs.** Only Skills has them today; the list view makes their absence more visible, but two new filter bars is its own change with its own questions.
- Bulk actions (multi-select enable/disable), and a list view for the other rosters (playlists, moods, webhooks).

All four are written up in the design doc.

## Verification

- `npm run lint` in `web/` (eslint + `tsc --noEmit`) — clean.
- Playwright against an **isolated** controller + worktree dev server (never the operator's stack), with 3 seeded shows and 3 personas:
  - all three surfaces render rows in list view (7 / 3 / 3) and the choice **survives a reload**, independently per surface;
  - a row click opens the edit sheet;
  - clicking the enable switch toggles it (`true → false`, confirmed through the API) and does **not** open the editor;
  - a sort-header click sets `aria-sort`;
  - **zero horizontal page overflow** at 1440px and at 420px.

Not independently verified: dark mode. The isolated station pins the light theme (no themes registered) and the theme token blob overrides `data-theme`, so it couldn't be forced in the harness. Verified by construction instead — the new components contain **no hardcoded colours**, only theme tokens the sibling cards already use on the same pages.

Design doc: `docs/superpowers/specs/2026-07-24-admin-roster-list-view-design.md`