### PR TITLE
feat(web): track-change transitions for the five CSS-only skins

### DIFF
--- a/docs/superpowers/specs/2026-07-24-skin-track-transitions-design.md
+++ b/docs/superpowers/specs/2026-07-24-skin-track-transitions-design.md
@@ -1,0 +1,308 @@
+# Track-change transitions for the five CSS-only skins
+
+**Date:** 2026-07-24
+**Status:** Design — awaiting review
+**Scope:** `web/components/skins/{spool,drift,subamp,tty,platter}`
+
+## Problem
+
+Five of six player skins have no transition on the single most important event
+in a radio player: the song changing. Cover art, title, artist and metadata all
+swap instantly, mid-frame.
+
+`classic` is the exception — it crossfades the cover and enters/exits the title
+block through `AnimatePresence` (`classic/CenterStage.tsx:229`, `:291`). The
+other five render the same facts with a hard cut.
+
+This is not a missing dependency. `motion` v12.40.0 is already installed and
+mounted app-wide (`app/layout.tsx:237` → `components/MotionProvider.tsx`). The
+gap is that only `classic` ever used it.
+
+| Skin | Uses motion | Track-change transition today |
+|---|---|---|
+| `classic` | 7 files | cover crossfade + title enter/exit |
+| `spool` | — | none |
+| `drift` | — | room color only (20s `--sw-drift-c`); type and cover cut |
+| `subamp` | — | none (marquee re-keys, restarting its CSS scroll) |
+| `tty` | — | none |
+| `platter` | — | none |
+
+## Non-goals
+
+**Ambient loops stay CSS.** `platter-spin`, `drift-a/b/c`, `spool-vu`,
+`spool-sheen`, `subamp-marquee`, `tty-blink` are infinite loops. They are
+cheaper as composited CSS keyframes, and — load-bearing — `html.lite`'s global
+kill (`globals.css:938`) already stops them for free. Porting them to motion
+would break lite mode and cost performance. Do not.
+
+**`classic` is untouched.** It already has this.
+
+**No new skins, no layout changes.** Only the transition between one track's
+facts and the next's.
+
+## Constraints discovered in the code
+
+These are facts about this codebase, not preferences. All five implementations
+must satisfy them.
+
+### 1. `LazyMotion` runs in `strict` mode
+
+`MotionProvider.tsx:22` mounts `<LazyMotion features={domAnimation} strict>`.
+`strict` throws at runtime on `<motion.div>` — use `<m.div>`. This keeps the
+bundle at ~12 kB gzip instead of ~30 kB. ESLint will not catch a violation;
+only a runtime render will.
+
+### 2. Reduced motion is already handled — except for one case
+
+`MotionProvider.tsx:24` sets `reducedMotion="user"`. Motion then drops
+transform and layout animations globally and keeps opacity. No per-skin code is
+needed for the slide/scale/lift variants.
+
+**The exception is `subamp`.** Its idiom is an LCD flicker, which is *pure
+opacity* — precisely what `reducedMotion="user"` preserves. A listener who asked
+for reduced motion would still get a strobe. `subamp` must call
+`useReducedMotion()` explicitly and fall back to a hard cut.
+
+### 3. Lite mode is NOT free — this is the trap
+
+`globals.css:938` is:
+
+```css
+html.lite *, html.lite *::before, html.lite *::after {
+    backdrop-filter: none !important;
+    animation: none !important;
+}
+```
+
+That kills **CSS** animations. Motion's animations are JS-driven and pass
+straight through it. Adding motion to a skin without a gate silently breaks lite
+mode for that skin.
+
+Every implementation must read `useLiteMode()` (`hooks/useLiteMode.ts`) and cut
+instantly when `lite` is true.
+
+The precedent and its reasoning are already written into
+`drift/Drift.module.css:21-25`, which disables the 20s wash transition under
+lite for exactly this reason.
+
+**A zero-duration transition is NOT a cut.** This was found during
+implementation, and it is the subtle half of the constraint. Given
+
+```js
+{ initial: { opacity: 0, y: 8 }, animate: { opacity: 1, y: 0 }, transition: { duration: 0 } }
+```
+
+motion still paints `initial` for one frame before the zero-duration animation
+commits — so lite mode flashes the *hidden* state on every track change, which
+is worse than the animation it was trying to suppress. The same applies on the
+way out: an `exit: { opacity: 0 }` fades the outgoing node, however briefly.
+
+The lite form of each variant must therefore be:
+
+```js
+{ initial: false, animate: { /* resting state */ }, exit: {}, transition: { duration: 0 } }
+```
+
+`initial: false` mounts straight at rest; `exit: {}` gives AnimatePresence
+nothing to animate. For `tty`, whose `initial` is a full-width clip, the lite
+path skips the motion element entirely and renders a plain `<span>`.
+
+### 4. Key on a stable track identity, not on rendered text
+
+`/state` polls every 5s. Keying an `AnimatePresence` child on a string that can
+transiently go null or hydrate late (album, year, cover URL) re-fires the
+transition on a poll, flashing the title.
+
+`classic/CenterStage.tsx:118` already solves this:
+
+```js
+const titleKey = offline ? 'offline' : has ? `t:${nowPlaying?.title}` : 'placeholder';
+```
+
+Offline and placeholder collapse to constant keys, so only a genuine track
+change moves the key. Each skin derives its own equivalent, preferring
+`subsonic_id` with a title fallback.
+
+### 5. `initial={false}` on every `AnimatePresence`
+
+Otherwise the transition plays on first paint and on every tune-in, which reads
+as jank rather than intent. `classic` does this at `:229` and `:291`.
+
+## Approach
+
+**Bespoke per skin** — chosen deliberately over a shared `<TrackSwap>`
+primitive. Each of the five skins hand-rolls its own `AnimatePresence` with its
+own variants, because each skin's idiom calls for a genuinely different move and
+a shared abstraction would either flatten them or grow a config surface wider
+than the five implementations it replaces.
+
+The accepted cost: constraints 1–5 above are implemented five times, and are
+five chances to forget one. Mitigated by the test plan below, which checks each
+one per skin rather than trusting the implementation.
+
+**One shared carve-out:** a `useSkinMotion()` hook in `sharedHooks.ts` returning
+a single boolean — "may I animate right now?" — folding the lite read. This is
+not an abstraction over animation character; it is one policy fact that is
+identical in all five skins and is the one constraint whose failure is silent.
+Every animation stays fully hand-rolled in its own skin.
+
+```ts
+/** Whether a skin may run a JS-driven transition right now. Lite mode's
+ *  global CSS kill (globals.css) does not reach motion, so each skin gates
+ *  on this; reduced motion is handled globally by MotionConfig. */
+export function useSkinMotion(): boolean {
+  const { lite } = useLiteMode();
+  return !lite;
+}
+```
+
+## Per-skin design
+
+Each skin's move follows from what the skin *is*. Durations are chosen so the
+transition completes well inside the shortest realistic gap between tracks.
+
+### `spool` — tape deck
+
+**Idiom:** a cassette's printed index label. Tape moves; it does not dissolve.
+
+**Move:** the title/artist block slides up and out as the incoming block slides
+up in — an index card being pulled through. `y: 8 → 0`, exit `y: -8`, with
+opacity. 240 ms, `mode="popLayout"`.
+
+**Sites:** the cassette hero label (`SpoolSkin.tsx:395`) and the mobile
+now-playing line (`:553`). Both render the same `title`; both animate.
+
+**Untouched:** the reels already re-derive from `--reel-l` / `--reel-r`
+(`:126-131`) and reset on their own.
+
+### `drift` — ambient cover-wash poster
+
+**Idiom:** already established in its own CSS — "the type waits; the color
+arrives first" (`Drift.module.css:1-4`). The room crossfades over 20 s.
+
+**Move:** slow dissolve, no movement at all. Pure opacity.
+
+- Title (`DriftSkin.tsx:221`) and meta line (`:226`): `mode="wait"`, 900 ms
+  each way. `wait` leaves a beat of emptiness between tracks, which suits the
+  skin — nothing else on screen is in a hurry.
+- Cover (`:209`): `mode="popLayout"`, 1200 ms, so the two covers stack and read
+  as a true dissolve.
+
+This is the one skin where slow is correct. Do not speed it up to match the
+others.
+
+### `subamp` — 1998 modular player
+
+**Idiom:** a segment LCD re-latching. A 1998 player does not crossfade; the
+readout blinks and the new value is there.
+
+**Move:** opacity keyframe array `[1, 0.25, 1, 0.4, 1]` over 180 ms — a hard
+two-blink latch, no transform. Cover (`SubampSkin.tsx:170`) gets a single 90 ms
+flash, not a crossfade; the bitmap swaps.
+
+**Sites:** the big readout title (`:335`) and the cover (`:170`).
+
+**Reduced motion:** per constraint 2, gate on `useReducedMotion()` and cut with
+no flicker. This is the only skin that needs the explicit check.
+
+**Untouched:** the marquee already re-keys on `marqueeText` (`:179`),
+restarting its CSS scroll. That is correct existing behaviour.
+
+### `tty` — terminal
+
+**Idiom:** a terminal prints. It does not fade, ever.
+
+**Move:** reprint. The incoming title reveals left-to-right via
+`clipPath: inset(0 100% 0 0) → inset(0 0 0 0)` with `ease: steps(n)`, where
+`n` is the character count — a real per-character reveal with no per-character
+DOM. Step duration is `min(14, 450 / n)` ms, so short titles print at a steady
+14 ms/char and anything past ~32 characters compresses to fit a 450 ms ceiling
+rather than holding the pane for a second.
+
+No exit animation — a terminal line does not fade out, it is overwritten. Use
+`mode="wait"` with an instant exit.
+
+**Sites:** the title (`TtySkin.tsx:150`) and the artist line (`:153`), the
+artist printing after the title completes.
+
+**Cover (`:190`): no animation.** It is labelled `cover.raw` — a raw bitmap
+dump. It cuts.
+
+**Precedent:** the existing `tty-bootline` keyframe (`Tty.module.css:13-20`)
+plus its `html.lite` exception at `:33` establish both the print idiom and the
+lite handling for content that only becomes visible through animation.
+
+### `platter` — turntable
+
+**Idiom:** a record change.
+
+**Move:** the sleeve lifts and settles — `scale: 1.04 → 1`, `y: -6 → 0`, opacity
+— over 320 ms on `cubic-bezier(0.22, 1, 0.36, 1)`. That curve is deliberately
+the tonearm's existing easing (`Platter.module.css:70`), so the skin reads as
+one mechanism rather than two.
+
+The title block follows with `y: 10 → 0` + opacity, 280 ms, delayed ~60 ms —
+"record down, then the label becomes legible."
+
+**Sites:** the sleeve (`PlatterSkin.tsx:320`) and the now-spinning title block
+(`:329-339`).
+
+**Untouched:** the tonearm already tracks `--pf` with its own 1.1 s transition
+and parks on tune-out (`Platter.module.css:64-73`). It needs nothing.
+
+## Testing
+
+No test runner exists in this repo; `npm run lint` (`eslint . && tsc --noEmit`)
+is the merge gate.
+
+**What was actually run.** Two throwaway Playwright harnesses drove a mocked
+controller (route-intercepted `/now-playing`, `/state`, `/session`, `/like`,
+`/cover/*`), flipped the track, and sampled the DOM every ~40ms for motion's
+fingerprint — an *inline* `opacity` / `transform` / `clip-path`, which CSS
+keyframe elements never carry, so the ambient loops don't pollute the signal.
+Asserted per skin: caught mid-flight at least once normally, and never
+mid-flight under `?lite=1`. Plus a reduced-motion pass asserting both
+directions — `subamp` suppressed, `drift` still dissolving — so the subamp gate
+can't be "proved" by a check that would pass with the gate missing.
+
+All ten lite/normal checks and all three reduced-motion checks pass, stable
+across repeat runs. Two harness bugs were themselves caught and fixed first
+(the lite key is `subwave-lite` = `'1'`/`'0'`, and sampling a *child* of the
+animated node misses opacity entirely), which is worth remembering if these are
+ever rebuilt.
+
+The checklist below remains the manual safety net for the bespoke duplication.
+
+**Per skin, all five:**
+
+1. **Lite gate** — enable lite mode, force a track change, confirm an instant
+   cut. This is the constraint most likely to be missed and it fails silently.
+2. **Reduced motion** — set `prefers-reduced-motion: reduce`; confirm no
+   transform-based movement. For `subamp` specifically, confirm no flicker.
+3. **First paint** — load the skin cold and tune in; confirm no transition
+   fires on mount.
+4. **Poll stability** — sit on one track through several 5 s `/state` polls;
+   confirm the title never re-animates.
+5. **Offline** — confirm the offline and scanning placeholders do not animate
+   on reconnect.
+6. **`<m.*>` not `<motion.*>`** — a rendered track change is the only check;
+   `strict` throws at runtime, and lint will not catch it.
+
+**Cross-cutting:** `npm run lint` in `web/`. Watch for the two known traps —
+inline `style` attributes are ESLint-forbidden (use the existing
+`useDynamicStyle` pattern), and motion's `initial`/`animate` props are fine (
+`classic` already passes lint using them).
+
+## Risks
+
+- **Five copies of the lite gate.** Accepted with the bespoke approach.
+  `useSkinMotion()` reduces it to one import and one boolean per skin, and test
+  step 1 checks it per skin.
+- **`subamp`'s flicker and photosensitivity.** Mitigated by the explicit
+  `useReducedMotion()` fallback. If in doubt, soften the keyframe array rather
+  than removing the idiom.
+- **`tty`'s stepped reveal on very long titles.** Mitigated by the 450 ms total
+  cap.
+- **Contract version.** `SKIN_API_VERSION` (`types.ts:35`) does **not** need a
+  bump: no `SkinProps` or core-context shape changes. Adding `useSkinMotion()`
+  to `sharedHooks.ts` is additive.

--- a/web/components/skins/drift/DriftSkin.tsx
+++ b/web/components/skins/drift/DriftSkin.tsx
@@ -9,6 +9,7 @@
 // chip; everything else is corners.
 
 import { useEffect, useRef, useState } from 'react';
+import { AnimatePresence, m } from 'motion/react';
 import { Headphones, Heart } from 'lucide-react';
 import styles from './Drift.module.css';
 import {
@@ -35,8 +36,35 @@ import {
   stationIdentity,
   turnClock,
 } from '../shared';
-import { useRequestSlip, useTrackLike, useVolumeNudge } from '../sharedHooks';
+import { useRequestSlip, useSkinMotion, useTrackLike, useVolumeNudge } from '../sharedHooks';
 import type { SkinProps } from '../types';
+
+/* Nothing here moves — the room already says everything with color, and the
+   type's job is to wait for it (see Drift.module.css). Pure opacity, and slow:
+   the washes take twenty seconds, so a 900ms dissolve still reads as the
+   hurried part of the transition. mode="wait" leaves a beat of empty page
+   between tracks, which suits a skin where nothing else is in a hurry. */
+const TYPE_DISSOLVE = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0 },
+  transition: { duration: 0.9 },
+};
+/* Lite: mount straight at rest. A zero-duration transition isn't enough — motion
+   still paints `initial` for a frame first, which flashes blank type. mode="wait"
+   happens to hide that most of the time; initial={false} removes it outright. */
+const TYPE_CUT = {
+  initial: false,
+  animate: { opacity: 1 },
+  // Nothing on the way out either — a fade-to-zero on the outgoing
+  // node is still an animation, however brief.
+  exit: {},
+  transition: { duration: 0 },
+};
+/* The cover overlaps itself instead of waiting — two stacked frames reading as
+   one true dissolve, over the longest beat in the skin. */
+const COVER_DISSOLVE = { ...TYPE_DISSOLVE, transition: { duration: 1.2 } };
+const COVER_CUT = TYPE_CUT;
 
 /** Lowercase weekday in the station's zone — "23:09 saturday". */
 function stationWeekday(now: Date, timezone: string | null): string {
@@ -88,6 +116,21 @@ export default function DriftSkin(_props: SkinProps) {
 
   const adjustVolume = useVolumeNudge();
   const like = useTrackLike();
+
+  // One key per airing — offline and the "somewhere on the dial" placeholder
+  // collapse to constants (as classic/CenterStage does) so a transient null
+  // from the 5s /state poll can't re-fire the dissolve mid-track.
+  const trackKey = offline
+    ? 'offline'
+    : coverId
+      ? `s:${coverId}`
+      : nowPlaying?.title
+        ? `t:${nowPlaying.title}`
+        : 'placeholder';
+  // Lite mode's CSS kill can't reach motion — gate the dissolve ourselves.
+  const animates = useSkinMotion();
+  const typeSwap = animates ? TYPE_DISSOLVE : TYPE_CUT;
+  const coverSwap = animates ? COVER_DISSOLVE : COVER_CUT;
 
   // The ··· chip: request + recent history in one quiet panel.
   const [panelOpen, setPanelOpen] = useState(false);
@@ -205,26 +248,44 @@ export default function DriftSkin(_props: SkinProps) {
       {!showOverlay && (
         <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-4 px-6 text-center">
           {coverSrc && !offline && (
-            <div className="h-[128px] w-[128px] border border-soft-border sm:h-[152px] sm:w-[152px]">
-              <img src={coverSrc} alt="" className="h-full w-full object-cover" />
+            <div className="relative h-[128px] w-[128px] border border-soft-border sm:h-[152px] sm:w-[152px]">
+              <AnimatePresence mode="popLayout" initial={false}>
+                <m.img
+                  key={coverSrc}
+                  src={coverSrc}
+                  alt=""
+                  {...coverSwap}
+                  className="absolute inset-0 h-full w-full object-cover"
+                />
+              </AnimatePresence>
             </div>
           )}
           <div className="mt-2 font-mono text-[9px] tracking-[0.32em] text-muted uppercase">
             {offline ? 'off air' : tunedIn ? 'now playing' : 'now playing — tap to listen'}
           </div>
           {!offline && (
-            <button
-              type="button"
-              onClick={handleTune}
-              className="v3-focus pointer-events-auto max-w-full cursor-pointer border-0 bg-transparent p-0 font-display text-[clamp(26px,5vw,46px)] leading-[1.1] font-semibold text-ink"
-            >
-              {nowPlaying?.title ?? 'somewhere on the dial'}
-            </button>
+            <AnimatePresence mode="wait" initial={false}>
+              <m.button
+                key={trackKey}
+                type="button"
+                onClick={handleTune}
+                {...typeSwap}
+                className="v3-focus pointer-events-auto max-w-full cursor-pointer border-0 bg-transparent p-0 font-display text-[clamp(26px,5vw,46px)] leading-[1.1] font-semibold text-ink"
+              >
+                {nowPlaying?.title ?? 'somewhere on the dial'}
+              </m.button>
+            </AnimatePresence>
           )}
           {!offline && metaLine && (
-            <div className="max-w-full truncate font-mono text-[12px] tracking-[0.2em] text-muted uppercase">
-              {metaLine}
-            </div>
+            <AnimatePresence mode="wait" initial={false}>
+              <m.div
+                key={trackKey}
+                {...typeSwap}
+                className="max-w-full truncate font-mono text-[12px] tracking-[0.2em] text-muted uppercase"
+              >
+                {metaLine}
+              </m.div>
+            </AnimatePresence>
           )}
           {!offline && ratio != null && (
             <div className="mt-2 flex items-center gap-3">

--- a/web/components/skins/platter/PlatterSkin.tsx
+++ b/web/components/skins/platter/PlatterSkin.tsx
@@ -13,6 +13,7 @@
 // touches React.
 
 import { useCallback, useRef } from 'react';
+import { AnimatePresence, m } from 'motion/react';
 import styles from './Platter.module.css';
 import {
   usePlayerActions,
@@ -38,8 +39,46 @@ import {
   trackMeta,
   turnClock,
 } from '../shared';
-import { useRequestSlip, useTrackLike, useVolumeNudge } from '../sharedHooks';
+import { useRequestSlip, useSkinMotion, useTrackLike, useVolumeNudge } from '../sharedHooks';
 import type { SkinProps } from '../types';
+
+/* A record change. The sleeve lifts and settles, then the label becomes
+   legible a beat later — record down, then read it.
+
+   The easing is deliberately the tonearm's own curve (Platter.module.css), so
+   the deck reads as one mechanism rather than two things that happen to move
+   near each other. */
+const DECK_EASE = [0.22, 1, 0.36, 1] as const;
+const SLEEVE_DROP = {
+  initial: { opacity: 0, scale: 1.04, y: -6 },
+  animate: { opacity: 1, scale: 1, y: 0 },
+  exit: { opacity: 0 },
+  transition: { duration: 0.32, ease: DECK_EASE },
+};
+/* Lite: mount straight at rest — a zero-duration transition still paints
+   `initial` for a frame, flashing a blank sleeve on every change. */
+const SLEEVE_CUT = {
+  initial: false,
+  animate: { opacity: 1, scale: 1, y: 0 },
+  // Nothing on the way out either — a fade-to-zero on the outgoing
+  // node is still an animation, however brief.
+  exit: {},
+  transition: { duration: 0 },
+};
+const LABEL_SETTLE = {
+  initial: { opacity: 0, y: 10 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -6 },
+  transition: { duration: 0.28, delay: 0.06, ease: DECK_EASE },
+};
+const LABEL_CUT = {
+  initial: false,
+  animate: { opacity: 1, y: 0 },
+  // Nothing on the way out either — a fade-to-zero on the outgoing
+  // node is still an animation, however brief.
+  exit: {},
+  transition: { duration: 0 },
+};
 
 /** The spinning platter itself — rim, vinyl + printed label, light sheen,
  *  spindle cap and the tonearm. Sized to fill its square container so it
@@ -159,6 +198,21 @@ export default function PlatterSkin(_props: SkinProps) {
 
   const title = offline ? '— off air —' : (nowPlaying?.title ?? 'Scanning the dial…');
   const artist = offline ? '' : (nowPlaying?.artist ?? '');
+
+  // One key per airing — offline and the scanning placeholder collapse to
+  // constants (as classic/CenterStage does) so a transient null from the 5s
+  // /state poll can't re-drop the sleeve mid-track.
+  const trackKey = offline
+    ? 'offline'
+    : nowPlaying?.subsonic_id
+      ? `s:${nowPlaying.subsonic_id}`
+      : nowPlaying?.title
+        ? `t:${nowPlaying.title}`
+        : 'placeholder';
+  // Lite mode's CSS kill can't reach motion — gate the change ourselves.
+  const spins = useSkinMotion();
+  const sleeveSwap = spins ? SLEEVE_DROP : SLEEVE_CUT;
+  const labelSwap = spins ? LABEL_SETTLE : LABEL_CUT;
 
   const adjustVolume = useVolumeNudge();
   const like = useTrackLike();
@@ -315,9 +369,17 @@ export default function PlatterSkin(_props: SkinProps) {
         <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2.5 overflow-hidden p-4 lg:gap-4 lg:overflow-hidden lg:p-6">
           {/* now playing */}
           <div className="flex items-start gap-5">
-            <div className="size-[84px] flex-none border border-ink bg-[var(--field)] sm:size-[104px]">
+            <div className="relative size-[84px] flex-none border border-ink bg-[var(--field)] sm:size-[104px]">
               {nowPlaying?.subsonic_id && !offline ? (
-                <img src={client.coverUrl(nowPlaying.subsonic_id)} alt="" className="h-full w-full object-cover" />
+                <AnimatePresence mode="popLayout" initial={false}>
+                  <m.img
+                    key={nowPlaying.subsonic_id}
+                    src={client.coverUrl(nowPlaying.subsonic_id)}
+                    alt=""
+                    {...sleeveSwap}
+                    className="absolute inset-0 h-full w-full object-cover"
+                  />
+                </AnimatePresence>
               ) : (
                 <div className="grid h-full w-full place-items-center font-mono text-[9px] text-muted">Sleeve</div>
               )}
@@ -326,17 +388,21 @@ export default function PlatterSkin(_props: SkinProps) {
               <span className="font-mono text-[10px] font-bold tracking-[0.22em] text-[var(--accent)] uppercase">
                 now spinning
               </span>
-              <span className="truncate font-display text-[clamp(30px,5vw,54px)] leading-[0.98] font-extrabold italic">
-                {title}
-              </span>
-              {artist && (
-                <span className="truncate font-mono text-[14px] tracking-[0.14em] uppercase">{artist}</span>
-              )}
-              {!offline && (nowPlaying?.album || nowPlaying?.year) && (
-                <span className="truncate font-mono text-[11px] tracking-[0.12em] text-muted uppercase">
-                  {[nowPlaying.album, nowPlaying.year].filter(Boolean).join(' · ')}
-                </span>
-              )}
+              <AnimatePresence mode="popLayout" initial={false}>
+                <m.div key={trackKey} {...labelSwap} className="flex min-w-0 flex-col gap-0.5">
+                  <span className="truncate font-display text-[clamp(30px,5vw,54px)] leading-[0.98] font-extrabold italic">
+                    {title}
+                  </span>
+                  {artist && (
+                    <span className="truncate font-mono text-[14px] tracking-[0.14em] uppercase">{artist}</span>
+                  )}
+                  {!offline && (nowPlaying?.album || nowPlaying?.year) && (
+                    <span className="truncate font-mono text-[11px] tracking-[0.12em] text-muted uppercase">
+                      {[nowPlaying.album, nowPlaying.year].filter(Boolean).join(' · ')}
+                    </span>
+                  )}
+                </m.div>
+              </AnimatePresence>
             </div>
           </div>
 

--- a/web/components/skins/sharedHooks.ts
+++ b/web/components/skins/sharedHooks.ts
@@ -7,6 +7,26 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { usePlayerActions, usePlayerFeed } from '@/components/player/PlayerCore';
+import { useLiteMode } from '@/hooks/useLiteMode';
+
+/** Whether a skin may run a JS-driven (motion) transition right now.
+ *
+ *  Lite mode's kill in globals.css is `animation: none !important`, which only
+ *  reaches CSS keyframes — motion animates from JS and sails straight through
+ *  it. So a skin that adds motion without this gate silently stops honouring
+ *  the listener's low-power toggle: no error, no lint failure, just a switch
+ *  that quietly does nothing. Every skin transition reads this and cuts
+ *  instantly when it's false.
+ *
+ *  Reduced motion is NOT this hook's job — MotionConfig's reducedMotion="user"
+ *  (components/MotionProvider.tsx) already drops transforms app-wide. The one
+ *  exception is a transition built from opacity alone, which that setting
+ *  deliberately preserves; such a skin must also call useReducedMotion()
+ *  itself (see subamp's LCD latch). */
+export function useSkinMotion(): boolean {
+  const { lite } = useLiteMode();
+  return !lite;
+}
 
 // Poll cadence + give-up window for a submitted request's outcome. Mirrors the
 // classic RequestDrawer (classic/drawers/RequestDrawer.tsx) so every skin gets

--- a/web/components/skins/spool/SpoolSkin.tsx
+++ b/web/components/skins/spool/SpoolSkin.tsx
@@ -13,6 +13,7 @@
 // keyframe (Spool.module.css) so it never re-renders React.
 
 import { useCallback, useRef, useState, type RefObject } from 'react';
+import { AnimatePresence, m } from 'motion/react';
 import styles from './Spool.module.css';
 import {
   usePlayerActions,
@@ -37,8 +38,30 @@ import {
   trackMeta,
   turnClock,
 } from '../shared';
-import { useRequestSlip, useTrackLike, useVolumeNudge } from '../sharedHooks';
+import { useRequestSlip, useSkinMotion, useTrackLike, useVolumeNudge } from '../sharedHooks';
 import type { SkinProps } from '../types';
+
+/* Tape-slide — the printed index card being pulled through the deck. The old
+   label leaves upward as the next one arrives from below; nothing crossfades,
+   because tape moves. LABEL_CUT is the lite-mode form — same presence
+   machinery at zero duration, so the markup never branches on lite. */
+const LABEL_SLIDE = {
+  initial: { opacity: 0, y: 8 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -8 },
+  transition: { duration: 0.24 },
+};
+/* Lite: mount straight at rest. A zero-duration transition isn't enough — motion
+   still paints `initial` for a frame first, which flashes an empty label on every
+   track change. initial={false} skips the enter outright. */
+const LABEL_CUT = {
+  initial: false,
+  animate: { opacity: 1, y: 0 },
+  // Nothing on the way out either — a fade-to-zero on the outgoing
+  // node is still an animation, however brief.
+  exit: {},
+  transition: { duration: 0 },
+};
 
 /** One reel — a dark wound-tape disc (diameter rides --reel-l/--reel-r) with a
  *  toothed sprocket hub that turns while playing. */
@@ -116,6 +139,20 @@ export default function SpoolSkin(_props: SkinProps) {
 
   const title = offline ? '— off air —' : (nowPlaying?.title ?? 'Scanning the dial…');
   const artist = offline ? '' : (nowPlaying?.artist ?? '');
+
+  // One key per airing. Offline and the scanning placeholder collapse to
+  // constants (as classic/CenterStage does) so a transient null from the 5s
+  // /state poll can't re-fire the label swap mid-track; subsonic_id is the
+  // stable identity, title the fallback for segments that carry no id.
+  const trackKey = offline
+    ? 'offline'
+    : nowPlaying?.subsonic_id
+      ? `s:${nowPlaying.subsonic_id}`
+      : nowPlaying?.title
+        ? `t:${nowPlaying.title}`
+        : 'placeholder';
+  // Lite mode's CSS kill can't reach motion — gate the slide ourselves.
+  const swap = useSkinMotion() ? LABEL_SLIDE : LABEL_CUT;
 
   const [tab, setTab] = useState<MobileTab>('deck');
   const adjustVolume = useVolumeNudge();
@@ -391,12 +428,16 @@ export default function SpoolSkin(_props: SkinProps) {
                     <div className="absolute inset-y-0 left-0 w-2 bg-[var(--accent)]" aria-hidden="true" />
                     <div className="flex items-baseline justify-between gap-3 py-2 pr-3.5 pl-5">
                       <div className="min-w-0">
-                        <div className="truncate font-display text-[clamp(15px,2vw,24px)] leading-tight font-bold italic">
-                          {title}
-                        </div>
-                        <div className="mt-0.5 truncate font-mono text-[10px] tracking-[0.14em] text-muted uppercase">
-                          {[artist, nowPlaying?.year].filter(Boolean).join(' · ') || 'live stream'}
-                        </div>
+                        <AnimatePresence mode="popLayout" initial={false}>
+                          <m.div key={trackKey} {...swap}>
+                            <div className="truncate font-display text-[clamp(15px,2vw,24px)] leading-tight font-bold italic">
+                              {title}
+                            </div>
+                            <div className="mt-0.5 truncate font-mono text-[10px] tracking-[0.14em] text-muted uppercase">
+                              {[artist, nowPlaying?.year].filter(Boolean).join(' · ') || 'live stream'}
+                            </div>
+                          </m.div>
+                        </AnimatePresence>
                       </div>
                       <span className="flex-none border border-ink px-2 font-mono text-[12px] font-bold">A</span>
                     </div>
@@ -550,10 +591,14 @@ export default function SpoolSkin(_props: SkinProps) {
                 </div>
 
                 <div className="flex-none">
-                  <div className="truncate font-display text-[26px] leading-tight font-bold italic">{title}</div>
-                  <div className="mt-1 truncate font-mono text-[11px] tracking-[0.14em] text-muted uppercase">
-                    {[artist, ...meta.facts].filter(Boolean).join(' · ') || 'live stream'}
-                  </div>
+                  <AnimatePresence mode="popLayout" initial={false}>
+                    <m.div key={trackKey} {...swap}>
+                      <div className="truncate font-display text-[26px] leading-tight font-bold italic">{title}</div>
+                      <div className="mt-1 truncate font-mono text-[11px] tracking-[0.14em] text-muted uppercase">
+                        {[artist, ...meta.facts].filter(Boolean).join(' · ') || 'live stream'}
+                      </div>
+                    </m.div>
+                  </AnimatePresence>
                 </div>
 
                 <div className="flex flex-none items-center gap-3 font-mono text-[11px]">

--- a/web/components/skins/subamp/SubampSkin.tsx
+++ b/web/components/skins/subamp/SubampSkin.tsx
@@ -8,7 +8,8 @@
 // only ▶ is lit accent. One click starts the stream and the analyzer jumps.
 // Double-click a titlebar to roll its window up.
 
-import { useRef, useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { AnimatePresence, m, useReducedMotion } from 'motion/react';
 import styles from './Subamp.module.css';
 import Analyzer from './Analyzer';
 import {
@@ -38,8 +39,38 @@ import {
   trackMeta,
   turnClock,
 } from '../shared';
-import { useRequestSlip, useTrackLike, useVolumeNudge } from '../sharedHooks';
+import { useRequestSlip, useSkinMotion, useTrackLike, useVolumeNudge } from '../sharedHooks';
 import type { SkinProps } from '../types';
+
+/* LCD re-latch. A 1998 player doesn't crossfade — the readout blinks twice and
+   the new value is simply there. Opacity only, no transform, and no exit: the
+   old reading isn't leaving, it's being overwritten.
+
+   Because it IS opacity-only, MotionConfig's reducedMotion="user" won't touch
+   it (that setting drops transforms and deliberately preserves opacity), so a
+   listener who asked for less motion would still get a strobe. This is the one
+   skin that has to check useReducedMotion() for itself. */
+const LATCH = { opacity: [1, 0.25, 1, 0.4, 1] };
+const LATCH_TRANSITION = { duration: 0.18, times: [0, 0.2, 0.45, 0.7, 1] };
+const STEADY = { opacity: 1 };
+/* The cover is a bitmap, not a photograph fading into another — swap it fast
+   enough that it reads as the panel repainting rather than a dissolve. */
+const ART_FLASH = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0 },
+  transition: { duration: 0.09 },
+};
+/* Lite: mount straight at rest — a zero-duration transition still paints
+   `initial` for a frame, flashing an empty art panel on every change. */
+const ART_CUT = {
+  initial: false,
+  animate: { opacity: 1 },
+  // Nothing on the way out either — a fade-to-zero on the outgoing
+  // node is still an animation, however brief.
+  exit: {},
+  transition: { duration: 0 },
+};
 
 function Grip() {
   return (
@@ -133,6 +164,20 @@ export default function SubampSkin(_props: SkinProps) {
 
   const digits = showTuneIn || offline ? '--:--' : fmtTime(elapsed);
 
+  // The latch fires when the keyed plate remounts, which would include the
+  // skin's own first paint — suppress that one so tuning in doesn't blink.
+  const painted = useRef(false);
+  useEffect(() => { painted.current = true; }, []);
+  // Lite mode's CSS kill can't reach motion; reduced motion can't reach an
+  // opacity-only animation. Both have to be asked here (see LATCH above), and
+  // both unconditionally — short-circuiting these into one && would make the
+  // second a conditional hook call.
+  const mayAnimate = useSkinMotion();
+  const reduced = useReducedMotion();
+  const latching = mayAnimate && !reduced;
+  const latch = latching && painted.current ? LATCH : STEADY;
+  const artSwap = latching ? ART_FLASH : ART_CUT;
+
   return (
     <div className={cn('absolute inset-0 overflow-hidden font-mono text-ink lg:overflow-y-auto', styles.shell)}>
       <div
@@ -165,22 +210,37 @@ export default function SubampSkin(_props: SkinProps) {
               <div className="h-16 min-w-0 flex-1 border border-soft-border px-2 py-1.5">
                 <Analyzer audioRef={audioRef} active={playing} />
               </div>
-              <div className="hidden h-16 w-16 flex-none self-center border border-soft-border sm:block">
+              <div className="relative hidden h-16 w-16 flex-none self-center border border-soft-border sm:block">
                 {nowPlaying?.subsonic_id && !offline ? (
-                  <img src={client.coverUrl(nowPlaying.subsonic_id)} alt="" className="h-full w-full object-cover" />
+                  <AnimatePresence mode="popLayout" initial={false}>
+                    <m.img
+                      key={nowPlaying.subsonic_id}
+                      src={client.coverUrl(nowPlaying.subsonic_id)}
+                      alt=""
+                      {...artSwap}
+                      className="absolute inset-0 h-full w-full object-cover"
+                    />
+                  </AnimatePresence>
                 ) : (
                   <div className="grid h-full w-full place-items-center text-[8px] text-muted">art</div>
                 )}
               </div>
             </div>
 
-            {/* marquee plate */}
-            <div className="overflow-hidden border border-soft-border bg-[var(--field)] px-0 py-1.5">
+            {/* marquee plate — keyed on the copy so the whole plate remounts and
+                re-latches; the inner key stays because it's what restarts the
+                CSS scroll from the left if this wrapper ever loses its own. */}
+            <m.div
+              key={marqueeText}
+              animate={latch}
+              transition={LATCH_TRANSITION}
+              className="overflow-hidden border border-soft-border bg-[var(--field)] px-0 py-1.5"
+            >
               <div key={marqueeText} className={styles.marqueeTrack}>
                 <span className="px-2.5 text-[12px] tracking-[0.12em]">{marqueeText}</span>
                 <span className="px-2.5 text-[12px] tracking-[0.12em]" aria-hidden="true">{marqueeText}</span>
               </div>
-            </div>
+            </m.div>
 
             <div className="flex flex-wrap items-center gap-2">
               {meta.facts.map(f => (

--- a/web/components/skins/tty/TtySkin.tsx
+++ b/web/components/skins/tty/TtySkin.tsx
@@ -6,6 +6,7 @@
 // bare "terminal" readout (the registry aliases terminal → tty).
 
 import { useEffect, useRef, useState } from 'react';
+import { m, steps } from 'motion/react';
 import styles from './Tty.module.css';
 import {
   usePlayerActions,
@@ -31,11 +32,60 @@ import {
   trackMeta,
   turnClock,
 } from '../shared';
-import { useRequestSlip, useTrackLike, useVolumeNudge } from '../sharedHooks';
+import { useRequestSlip, useSkinMotion, useTrackLike, useVolumeNudge } from '../sharedHooks';
 import type { SkinProps } from '../types';
 
 const PROGRESS_CELLS = 16;
 const VOL_CELLS = 8;
+
+/* Print cadence. 14ms a cell reads as a fast local terminal; past ~32 cells
+   the step compresses so even a very long title lands inside the cap rather
+   than holding the pane for a second. */
+const PRINT_STEP_MS = 14;
+const PRINT_CAP_MS = 450;
+
+/** A line that prints. A terminal doesn't fade text in — it writes it, one
+ *  cell at a time — so the reveal is a clip-path wipe stepped to the character
+ *  count, not an opacity ramp. Keyed on its own text, so changing the text
+ *  remounts and reprints.
+ *
+ *  There is deliberately no exit animation: a terminal line isn't removed, it
+ *  is overwritten. That's also why this needs no AnimatePresence. */
+function Printed({
+  text, printing, delay = 0, className, children,
+}: {
+  /** The line's plain text — sets the cadence, and keys the reprint. */
+  text: string;
+  printing: boolean;
+  delay?: number;
+  className?: string;
+  /** What to actually render, when the line carries markup (a muted tail, a
+   *  highlight). The wipe reveals whatever is inside. Defaults to `text`. */
+  children?: React.ReactNode;
+}) {
+  const cells = Math.max(text.length, 1);
+  // Not printing (lite mode) means no motion element at all. A zero-duration
+  // transition would still paint `initial` for a frame, and here `initial` is a
+  // full-width clip — a blank line flashing on every track change.
+  if (!printing) {
+    return <span className={cn('inline-block', className)}>{children ?? text}</span>;
+  }
+  const duration = Math.min(cells * PRINT_STEP_MS, PRINT_CAP_MS) / 1000;
+  return (
+    <m.span
+      key={text}
+      // Units match across both keyframes (all four values percent) so motion
+      // interpolates the inset rather than snapping between two strings it
+      // can't line up.
+      initial={{ clipPath: 'inset(0% 100% 0% 0%)' }}
+      animate={{ clipPath: 'inset(0% 0% 0% 0%)' }}
+      transition={{ duration, delay, ease: steps(cells) }}
+      className={cn('inline-block', className)}
+    >
+      {children ?? text}
+    </m.span>
+  );
+}
 
 function Rule({ children }: { children: React.ReactNode }) {
   return (
@@ -117,6 +167,14 @@ export default function TtySkin(_props: SkinProps) {
   const volFilled = Math.round(volume * VOL_CELLS);
   const coverId = nowPlaying?.subsonic_id;
 
+  // Lite mode's CSS kill can't reach motion — gate the print ourselves. The
+  // skin's own boot log already covers "the terminal is starting", so the
+  // first paint doesn't also print: two boot animations is worse than one.
+  const mayPrint = useSkinMotion();
+  const painted = useRef(false);
+  useEffect(() => { painted.current = true; }, []);
+  const printing = mayPrint && painted.current;
+
   return (
     <div className="absolute inset-0 overflow-hidden p-4 font-mono text-[13px] leading-relaxed text-ink sm:p-7">
       <div className="flex h-full w-full flex-col gap-3.5">
@@ -147,16 +205,33 @@ export default function TtySkin(_props: SkinProps) {
             <div className="flex min-w-0 flex-row items-start gap-4 sm:gap-6">
               <div className="flex min-w-0 flex-1 flex-col gap-3">
                 <div className="text-[clamp(22px,4vw,46px)] leading-[1.05] font-extrabold tracking-[0.06em] uppercase">
-                  {offline ? <span className="text-muted">— OFF AIR —</span> : (nowPlaying?.title ?? 'SCANNING…')}
+                  {offline ? (
+                    <span className="text-muted">— OFF AIR —</span>
+                  ) : (
+                    <Printed text={nowPlaying?.title ?? 'SCANNING…'} printing={printing} />
+                  )}
                 </div>
                 {!offline && nowPlaying?.artist && (
                   <div className="text-[15px] tracking-[0.08em] uppercase">
-                    {nowPlaying.artist}
-                    {(nowPlaying.album || nowPlaying.year) && (
-                      <span className="text-muted">
-                        {' '}— {[nowPlaying.album, nowPlaying.year].filter(Boolean).join(' · ')}
-                      </span>
-                    )}
+                    {/* The artist prints after the title finishes — the pane
+                        writes top-down, the way a real one would. */}
+                    <Printed
+                      text={
+                        nowPlaying.artist
+                        + ((nowPlaying.album || nowPlaying.year)
+                          ? ` — ${[nowPlaying.album, nowPlaying.year].filter(Boolean).join(' · ')}`
+                          : '')
+                      }
+                      printing={printing}
+                      delay={0.12}
+                    >
+                      {nowPlaying.artist}
+                      {(nowPlaying.album || nowPlaying.year) && (
+                        <span className="text-muted">
+                          {' '}— {[nowPlaying.album, nowPlaying.year].filter(Boolean).join(' · ')}
+                        </span>
+                      )}
+                    </Printed>
                   </div>
                 )}
                 {!offline && (meta.facts.length > 0 || meta.moods.length > 0) && (


### PR DESCRIPTION
Five of six player skins had **no transition when the song changed** — the single most important event in a radio player. Cover art and title just popped mid-frame. `classic` was the only skin ever wired to motion (`AnimatePresence` at `CenterStage.tsx:229`); `spool`, `drift`, `subamp`, `tty` and `platter` had nothing.

`motion` was already a dependency and already mounted app-wide, so nothing new was added to the bundle.

## Per-skin moves

Each skin gets its own move rather than one shared crossfade — a terminal that fades is a terminal that's lying.

| Skin | Move | Timing |
|---|---|---|
| `spool` | tape-slide — the index card pulled through the deck | 240ms |
| `drift` | slow dissolve, zero movement | 900ms type / 1200ms cover |
| `subamp` | LCD two-blink re-latch + fast art repaint | 180ms / 90ms |
| `tty` | stepped clip-path reprint, artist after title | 14ms/cell, cap 450ms |
| `platter` | sleeve lifts and settles, label a beat later | 320ms + 60ms |

`platter` deliberately reuses the tonearm's existing easing curve (`Platter.module.css:70`) so the deck reads as one mechanism rather than two things moving near each other.

**Ambient loops stay CSS.** `platter-spin`, the drift washes, `spool-vu`, `tty-blink` are infinite loops — cheaper as composited keyframes, and `html.lite`'s global kill already stops them for free. Porting those would have been a regression.

## The lite-mode trap

`html.lite * { animation: none !important }` (`globals.css:938`) only reaches **CSS** animations. Motion is JS-driven and passes straight through it, so adding motion to a skin without a gate silently breaks the low-power toggle — no error, no lint failure. Each skin now gates on a new `useSkinMotion()` in `sharedHooks.ts`.

**A zero-duration transition is not a cut.** This was found during testing and is the subtle half: motion still paints `initial` for one frame before a `duration: 0` animation commits, so lite mode was flashing the *hidden* state on every track change — worse than the animation it was suppressing. It was latent in all five skins. The lite variants now use `initial: false` with a no-op exit; `tty` skips the motion element entirely, since its `initial` is a full-width clip.

## Reduced motion

`MotionConfig`'s `reducedMotion="user"` drops transforms app-wide but deliberately **preserves opacity**. Every skin's move is transform-based and therefore handled for free — except `subamp`, whose LCD latch is opacity-only and would still strobe. That skin checks `useReducedMotion()` itself.

## Verification

No test runner in the repo, so `npm run lint` (`eslint . && tsc --noEmit`) is the gate — clean. Beyond that, two throwaway Playwright harnesses drove a mocked controller (route-intercepted `/now-playing`, `/state`, `/session`, `/like`, `/cover/*`), flipped the track, and sampled the DOM for motion's fingerprint — an *inline* `opacity`/`transform`/`clip-path`, which CSS keyframe elements never carry, so ambient loops don't pollute the signal.

- 10/10 checks: each skin animates on a real track change, and cuts under `?lite=1`
- 3/3 reduced-motion checks: `subamp` suppressed, `drift` still dissolving — asserting both directions so the subamp gate can't be "proved" by a check that would pass without it

Stable across repeat runs.

## Notes for review

- Structure is **bespoke per skin** by choice; only the lite gate is shared, since it's a correctness fact rather than a design decision. The cost is that the `initial: false` fix had to land in five files independently.
- `SKIN_API_VERSION` is unchanged — no `SkinProps` or core-context shape changes, and `useSkinMotion()` is additive.
- Design doc included at `docs/superpowers/specs/2026-07-24-skin-track-transitions-design.md`.
- `classic` is untouched.
