### PR TITLE
refactor(web): drop the Stations link from the admin System nav

### DIFF
--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -38,7 +38,6 @@ import {
   Music,
   AudioLines,
   Waves,
-  RadioTower,
 } from 'lucide-react';
 import { useAdminAuth } from '../../lib/adminAuth';
 import type { SignInResult } from '../../lib/adminAuth';
@@ -196,7 +195,6 @@ const NAV_SECTIONS: NavSection[] = [
     label: 'System',
     items: [
       { href: '/admin/connect', id: 'connect', label: 'Connect', icon: Plug },
-      { href: '/admin/stations', id: 'stations', label: 'Stations', icon: RadioTower },
       { href: '/admin/settings', id: 'settings', label: 'Settings', icon: SlidersHorizontal },
       { href: '/admin/debug', id: 'debug', label: 'Debug', icon: Terminal },
     ],
@@ -231,13 +229,15 @@ const FOOTER_LINKS: { href: string; label: string; icon: NavIcon; pill: string }
   { href: 'https://discord.gg/vjVbVKnMBa', label: 'Discord', icon: MessageCircle, pill: '↗' },
 ];
 
-// Section + page label for the top-bar breadcrumb. Playlists and DJ Doc aren't
-// sidebar items (Playlists lives under Library's doorway, DJ Doc in the header
-// strip), so they're resolved explicitly; Library stays lit in the rail while
+// Section + page label for the top-bar breadcrumb. Playlists, DJ Doc, and
+// Stations aren't sidebar items (Playlists lives under Library's doorway,
+// DJ Doc in the header strip, Stations behind the switcher at the top of the
+// rail), so they're resolved explicitly; Library stays lit in the rail while
 // on Playlists, so the crumb mirrors that with the Programming section.
 function resolveCrumb(pathname: string | null): { section?: string; page: string } {
   if (pathname?.startsWith('/admin/playlists')) return { section: 'Programming', page: 'Playlists' };
   if (pathname?.startsWith('/admin/doctor')) return { section: 'Monitor', page: 'DJ Doc' };
+  if (pathname?.startsWith('/admin/stations')) return { section: 'System', page: 'Stations' };
   for (const section of NAV_SECTIONS) {
     const item = section.items.find(n => pathname?.startsWith(n.href));
     if (item) return { section: section.label, page: item.label };


### PR DESCRIPTION
## What

Removes the **Stations** entry from the System section of the admin sidebar — the station switcher at the top of the rail already links to `/admin/stations`, so the nav item was a duplicate doorway.

## Details

- Nav item + now-unused `RadioTower` import removed from `AdminShell.tsx`.
- `/admin/stations` stays reachable from the StationSwitcher's manage link, so it joins Playlists and DJ Doc in `resolveCrumb`'s explicit list — the top-bar breadcrumb still reads **System / Stations**.

## Verification

- `npm run lint` (eslint + tsc) passes in `web/`.