### PR TITLE
feat(admin): configure Navidrome from Settings → Music source

### DIFF
--- a/controller/src/doctor.ts
+++ b/controller/src/doctor.ts
@@ -494,6 +494,13 @@ export async function navidromeConnectivity(): Promise<{
   return { ...navidromeCache.result, url: config.navidrome.url };
 }
 
+// Drop the cached ping so the banner/Doctor re-probe immediately — called when
+// the admin saves new Navidrome creds, where a stale "down" result would keep
+// the red banner up for the TTL even though the fix just landed.
+export function clearNavidromeCache() {
+  navidromeCache = null;
+}
+
 async function checkBroadcast(): Promise<Finding[]> {
   const out: Finding[] = [];
 

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -93,6 +93,14 @@ async function memo(key, ttl, fn) {
   return val;
 }
 
+// Drop every memoised Subsonic result. Called when the admin points the
+// station at different Navidrome creds — the cached playlists/albums carry
+// song ids from the OLD server, which would feed the picker junk for up to
+// CACHE_TTL_MS otherwise.
+export function clearPoolCache() {
+  cache.clear();
+}
+
 // --- Tempo / harmonic compatibility (Stage B, soft re-rank only) -----------
 // These bias the pool ordering toward smoother transitions; they are NEVER a
 // hard filter, and a track with NULL bpm/key contributes a 0 bonus (so it

--- a/controller/src/music/subsonic.ts
+++ b/controller/src/music/subsonic.ts
@@ -177,7 +177,29 @@ export async function ping(): Promise<{ ok: boolean; reason?: string }> {
 // behind the onboarding wizard's "Test connection" and the admin Settings
 // Music-source test/save flow. Unlike ping() it never touches config.navidrome
 // and never mutates anything; callers pass exactly what to try. Never throws.
-export async function pingWith({
+//
+// One retry on ANY first failure — broader than ping()'s fast-fail-only rule,
+// deliberately. ping()'s 30s timeout makes a slow retry expensive; this probe
+// is 5s-bounded, so the retry costs at most ~5.5s against a truly-dead server.
+// It covers both failure shapes of a warm-but-stale connection pool: the
+// instant reset on reusing a stale socket, AND the full-timeout stall seen
+// when the Navidrome process restarts under pooled connections (the aborted
+// attempt's teardown is what un-wedges the pool, so the second try connects
+// fresh). A Test button reporting either blip as "unreachable" sends the
+// operator chasing a config that actually works.
+export async function pingWith(target: {
+  url: string;
+  user: string;
+  pass: string;
+  client?: string;
+}): Promise<{ ok: boolean; serverVersion?: string; serverType?: string; error?: string }> {
+  const first = await pingWithOnce(target);
+  if (first.ok) return first;
+  await new Promise(resolve => setTimeout(resolve, 500));
+  return pingWithOnce(target);
+}
+
+async function pingWithOnce({
   url,
   user,
   pass,

--- a/controller/src/music/subsonic.ts
+++ b/controller/src/music/subsonic.ts
@@ -173,6 +173,49 @@ export async function ping(): Promise<{ ok: boolean; reason?: string }> {
   }
 }
 
+// One-off connectivity + auth probe with ARBITRARY creds — the shared engine
+// behind the onboarding wizard's "Test connection" and the admin Settings
+// Music-source test/save flow. Unlike ping() it never touches config.navidrome
+// and never mutates anything; callers pass exactly what to try. Never throws.
+export async function pingWith({
+  url,
+  user,
+  pass,
+  client = 'sub-wave-admin',
+}: {
+  url: string;
+  user: string;
+  pass: string;
+  client?: string;
+}): Promise<{ ok: boolean; serverVersion?: string; serverType?: string; error?: string }> {
+  try {
+    const salt = crypto.randomBytes(8).toString('hex');
+    const token = crypto.createHash('md5').update(pass + salt).digest('hex');
+    const probeUrl = new URL(`${url.replace(/\/$/, '')}/rest/ping`);
+    probeUrl.searchParams.set('u', user);
+    probeUrl.searchParams.set('t', token);
+    probeUrl.searchParams.set('s', salt);
+    probeUrl.searchParams.set('v', '1.16.1');
+    probeUrl.searchParams.set('c', client);
+    probeUrl.searchParams.set('f', 'json');
+
+    const res = await fetch(probeUrl.toString(), { signal: AbortSignal.timeout(5000) });
+    if (!res.ok) return { ok: false, error: `Subsonic ping returned HTTP ${res.status}` };
+
+    const body: any = await res.json();
+    const sub = body?.['subsonic-response'];
+    if (sub?.status !== 'ok') {
+      return { ok: false, error: sub?.error?.message || 'Subsonic responded but auth failed' };
+    }
+    return { ok: true, serverVersion: sub.version, serverType: sub.type || 'unknown' };
+  } catch (err: any) {
+    if (err?.name === 'TimeoutError' || err?.name === 'AbortError') {
+      return { ok: false, error: 'Navidrome did not respond within 5s' };
+    }
+    return { ok: false, error: err?.message || 'Navidrome unreachable' };
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Station-archive guard
 // ---------------------------------------------------------------------------

--- a/controller/src/routes/onboarding.ts
+++ b/controller/src/routes/onboarding.ts
@@ -12,7 +12,6 @@
 // the request body's values and report success/failure. They never touch the
 // live settings or live config. Save is the only mutation path.
 
-import crypto from 'node:crypto';
 import express from 'express';
 import { generateText } from 'ai';
 import { createOllama } from 'ai-sdk-ollama';
@@ -24,15 +23,14 @@ import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 
 import { requireAdmin } from '../middleware/auth.js';
 import { DEFAULT_LOCCA_BASE_URL, DEFAULT_REQUESTY_BASE_URL, OPENROUTER_APP_HEADERS, noThinkFetch } from '../llm/provider.js';
-import { config } from '../config.js';
 import * as settings from '../settings.js';
 import * as jingles from '../broadcast/jingles.js';
 import { queue } from '../broadcast/queue.js';
 import { refreshAutoPlaylist } from '../broadcast/scheduler.js';
-import { saveSetupConfig, clearSetupConfigCache } from '../setup/config.js';
+import { applyNavidromeToLiveConfig, saveSetupConfig, clearSetupConfigCache } from '../setup/config.js';
 import { saveSecrets, SECRET_ENV_KEYS } from '../setup/secrets.js';
 import { getSetupStatus } from '../setup/firstRun.js';
-import { fetchWithTimeout } from '../util/fetch-timeout.js';
+import { pingWith } from '../music/subsonic.js';
 
 export const router = express.Router();
 
@@ -72,38 +70,7 @@ router.post('/onboarding/test-navidrome', requireAdmin, async (req, res) => {
     return res.status(400).json({ ok: false, error: 'url, user, and pass are required' });
   }
 
-  try {
-    const salt = crypto.randomBytes(8).toString('hex');
-    const token = crypto.createHash('md5').update(pass + salt).digest('hex');
-    const probeUrl = new URL(`${url}/rest/ping`);
-    probeUrl.searchParams.set('u', user);
-    probeUrl.searchParams.set('t', token);
-    probeUrl.searchParams.set('s', salt);
-    probeUrl.searchParams.set('v', '1.16.1');
-    probeUrl.searchParams.set('c', 'sub-wave-wizard');
-    probeUrl.searchParams.set('f', 'json');
-
-    const r = await fetchWithTimeout(probeUrl.toString(), { timeoutMs: 5000 });
-
-    if (!r.ok) {
-      return res.json({ ok: false, error: `Subsonic ping returned HTTP ${r.status}` });
-    }
-    const body: any = await r.json();
-    const sub = body?.['subsonic-response'];
-    if (sub?.status !== 'ok') {
-      return res.json({
-        ok: false,
-        error: sub?.error?.message || 'Subsonic responded but auth failed',
-      });
-    }
-    res.json({
-      ok: true,
-      serverVersion: sub.version,
-      serverType: sub.type || 'unknown',
-    });
-  } catch (err: any) {
-    res.json({ ok: false, error: err.message || 'Navidrome unreachable' });
-  }
+  res.json(await pingWith({ url, user, pass, client: 'sub-wave-wizard' }));
 });
 
 // ---------------------------------------------------------------------------
@@ -216,9 +183,7 @@ router.post('/onboarding/save', requireAdmin, async (req, res) => {
         },
       });
       // Apply to the live config so subsonic calls work without a restart.
-      if (b.navidrome.url) config.navidrome.url = String(b.navidrome.url).trim().replace(/\/$/, '');
-      if (b.navidrome.user) config.navidrome.user = String(b.navidrome.user).trim();
-      if (b.navidrome.pass !== undefined) config.navidrome.password = String(b.navidrome.pass);
+      applyNavidromeToLiveConfig(b.navidrome);
       clearSetupConfigCache();
     }
 

--- a/controller/src/routes/settings.ts
+++ b/controller/src/routes/settings.ts
@@ -5,6 +5,11 @@ import express from 'express';
 import { readFile, unlink } from 'node:fs/promises';
 import { extname } from 'node:path';
 import { config } from '../config.js';
+import * as subsonic from '../music/subsonic.js';
+import { clearPoolCache } from '../music/picker.js';
+import { clearNavidromeCache } from '../doctor.js';
+import { refreshAutoPlaylist } from '../broadcast/scheduler.js';
+import { applyNavidromeToLiveConfig, saveSetupConfig } from '../setup/config.js';
 import * as library from '../music/library.js';
 import * as jingles from '../broadcast/jingles.js';
 import * as settings from '../settings.js';
@@ -81,6 +86,20 @@ router.get('/settings', requireAdmin, async (req, res) => {
       // this is soft/hard (LLM steps will spend more, or fail until UTC midnight).
       budget: { mode: budgetCurrentMode() },
       ollama: { url: config.ollama.url, model: config.ollama.model },
+      // Navidrome connection — read state for the Settings "Music source"
+      // section. The password never leaves the process (passSet only). Env
+      // flags are per-field because server.ts applies setup-config per-field:
+      // url can be env-managed while user/pass come from the wizard/admin.
+      navidrome: {
+        url: config.navidrome.url,
+        user: config.navidrome.user,
+        passSet: !!config.navidrome.password,
+        env: {
+          url: !!process.env.NAVIDROME_URL,
+          user: !!process.env.NAVIDROME_USER,
+          pass: !!process.env.NAVIDROME_PASS,
+        },
+      },
       // What the configured zone resolves to when timezone is '' (Auto) —
       // lets the UI label the Auto option with the actual server zone.
       serverTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
@@ -267,6 +286,93 @@ router.post('/settings/secrets', requireAdmin, async (req, res) => {
     console.error('[settings/secrets]', err);
     res.status(400).json({ error: 'Failed to save secrets' });
   }
+});
+
+// ---------------------------------------------------------------------------
+// POST /settings/navidrome — change the Navidrome connection from the admin
+// Settings "Music source" section. Persists to state/setup-config.json (the
+// same overlay the wizard and `subwave setup` write — settings.json is NOT
+// the store for these; see setup/config.ts) and applies live, so Subsonic
+// calls use the new creds with no restart.
+//
+// Body { url?, user?, pass? } — submitted fields are validated merged over the
+// currently-effective values (blank pass = keep the one on file), but only the
+// submitted fields are persisted, so an env-shadowed value never gets copied
+// into setup-config.json. Env-managed fields are rejected outright rather than
+// silently persisting a value env would shadow again on next boot.
+// ---------------------------------------------------------------------------
+router.post('/settings/navidrome', requireAdmin, async (req, res) => {
+  try {
+    const b = req.body || {};
+    const submitted: { url?: string; user?: string; pass?: string } = {};
+    if (typeof b.url === 'string') submitted.url = b.url.trim().replace(/\/$/, '');
+    if (typeof b.user === 'string') submitted.user = b.user.trim();
+    if (typeof b.pass === 'string' && b.pass !== '') submitted.pass = b.pass;
+
+    const ENV_LOCKS = [
+      ['url', 'NAVIDROME_URL'],
+      ['user', 'NAVIDROME_USER'],
+      ['pass', 'NAVIDROME_PASS'],
+    ] as const;
+    for (const [field, envVar] of ENV_LOCKS) {
+      if (submitted[field] !== undefined && process.env[envVar]) {
+        return res.status(400).json({
+          ok: false,
+          error: `${field} is managed by ${envVar} in the root .env — env always wins on boot; remove it there to manage it here`,
+        });
+      }
+    }
+
+    // Validate the MERGED result — the connection must stay complete. A blank
+    // submitted url/user is a cleared field, not "keep", and is rejected here.
+    const merged = {
+      url: submitted.url ?? config.navidrome.url,
+      user: submitted.user ?? config.navidrome.user,
+      pass: submitted.pass ?? config.navidrome.password,
+    };
+    if (!merged.url || !merged.user || !merged.pass) {
+      return res.status(400).json({ ok: false, error: 'url, user, and pass are all required' });
+    }
+
+    await saveSetupConfig({ navidrome: submitted });
+    applyNavidromeToLiveConfig(submitted);
+    // The doctor's cached ping and the picker's memoised Subsonic pools both
+    // describe the OLD server — drop them so the banner clears promptly and
+    // the picker can't draw song ids that no longer resolve.
+    clearNavidromeCache();
+    clearPoolCache();
+    queue.log('scheduler', `Navidrome connection updated → ${merged.url} (user ${merged.user})`);
+    // auto.m3u entries carry annotated URIs whose auth tokens derive from the
+    // old password — rebuild it with the new connection. Fire-and-forget so
+    // the save response isn't held up by Navidrome round-trips.
+    refreshAutoPlaylist().catch(err =>
+      queue.log('error', `Post-save playlist refresh failed: ${err.message}`),
+    );
+    res.json({ ok: true });
+  } catch (err: any) {
+    res.status(400).json({ ok: false, error: err.message || 'save failed' });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /settings/navidrome/test — non-mutating connection test. Merges the
+// body over the effective values exactly like save, so "Test" works with the
+// stored password without the browser ever seeing it. (The wizard keeps its
+// own /onboarding/test-navidrome, which deliberately has NO stored-cred
+// fallback — it tests creds that aren't saved anywhere yet.)
+// ---------------------------------------------------------------------------
+router.post('/settings/navidrome/test', requireAdmin, async (req, res) => {
+  const b = req.body || {};
+  const url =
+    typeof b.url === 'string' && b.url.trim()
+      ? b.url.trim().replace(/\/$/, '')
+      : config.navidrome.url;
+  const user = typeof b.user === 'string' && b.user.trim() ? b.user.trim() : config.navidrome.user;
+  const pass = typeof b.pass === 'string' && b.pass ? b.pass : config.navidrome.password;
+  if (!url || !user || !pass) {
+    return res.json({ ok: false, error: 'url, user, and pass are required' });
+  }
+  res.json(await subsonic.pingWith({ url, user, pass, client: 'sub-wave-admin' }));
 });
 
 // ---------------------------------------------------------------------------

--- a/controller/src/setup/config.ts
+++ b/controller/src/setup/config.ts
@@ -13,7 +13,7 @@
 import { existsSync } from 'node:fs';
 import { mkdir, readFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import { STATE_DIR } from '../config.js';
+import { config, STATE_DIR } from '../config.js';
 import { writeFileAtomic } from '../util/atomic-file.js';
 
 const PATH = `${STATE_DIR}/setup-config.json`;
@@ -59,3 +59,14 @@ export async function saveSetupConfig(patch: Partial<SetupConfig>): Promise<Setu
 // Kept for callers that previously invalidated the (now-removed) cache.
 // No-op — every read is fresh from disk.
 export function clearSetupConfigCache() {}
+
+// Apply freshly-saved Navidrome creds to the LIVE config so Subsonic calls use
+// them without a restart. Shared by the onboarding wizard's save and the admin
+// Settings Music-source save — one place, so live-apply behaviour can't drift.
+// Blank/absent fields keep their current live value (partial updates are fine,
+// and a blank password can never clobber a working live one).
+export function applyNavidromeToLiveConfig(nv: { url?: string; user?: string; pass?: string }) {
+  if (nv.url) config.navidrome.url = String(nv.url).trim().replace(/\/$/, '');
+  if (nv.user) config.navidrome.user = String(nv.user).trim();
+  if (nv.pass) config.navidrome.password = String(nv.pass);
+}

--- a/docs/superpowers/specs/2026-07-24-admin-navidrome-settings-design.md
+++ b/docs/superpowers/specs/2026-07-24-admin-navidrome-settings-design.md
@@ -1,0 +1,191 @@
+# Admin-panel Navidrome configuration — design
+
+**Date:** 2026-07-24
+**Status:** Draft for review
+
+## Problem
+
+Navidrome credentials (URL + user + password) can only be set through the
+first-run wizard (`/onboarding`), the CLI (`subwave setup`), or root-`.env`
+vars. Once a station is running there is no way to change them from the admin
+panel — moving Navidrome to a new host, rotating its password, or fixing a typo
+means re-running the wizard or editing files on the host. The always-on
+`NavidromeBanner` even tells the operator to "check the URL / username /
+password in setup" with nowhere in the admin UI to actually do that.
+
+## Goal
+
+A **Music source** section in `/admin/settings` where the operator can view,
+test, and change the Navidrome connection — with the same live-apply behaviour
+the wizard has (no restart needed), and honest handling of the env-always-wins
+rule.
+
+## Approaches considered
+
+- **A (recommended): dedicated `/settings/navidrome` endpoints + a new
+  Settings section.** Read state rides the existing `GET /settings` payload;
+  save/test get small dedicated routes that share the wizard's logic via
+  extracted helpers. Clean surface, no wizard semantics leaking in.
+- **B: reuse the onboarding endpoints from a new admin section.**
+  `POST /onboarding/save` + `POST /onboarding/test-navidrome` already do the
+  work, but there is no GET that returns the saved URL/user for prefill (the
+  wizard never needs one), and `/onboarding/save` stamps `setupCompletedAt` on
+  every call. B needs a new GET anyway, at which point A costs the same and
+  reads better.
+- **C: link out to `/onboarding` from the admin shell.** Zero new code, but
+  the wizard is a full multi-step first-run flow — terrible UX for "rotate one
+  password", and it re-prompts for LLM/TTS/DJ choices.
+
+Approach A is the design below.
+
+## Persistence model (unchanged)
+
+Navidrome creds stay in `state/setup-config.json` via `saveSetupConfig()` —
+the same overlay the wizard and CLI write. `settings.json` is untouched; the
+split documented in `controller/src/setup/config.ts` (settings = runtime admin
+store, setup-config = env-var-shaped fields) is preserved. Env always wins:
+`server.ts` only applies setup-config values where the matching
+`NAVIDROME_*` env var is blank, and that rule is surfaced in the UI rather
+than fought.
+
+Because `setup-config.json` lives under the resolved `STATE_DIR`, multi-station
+profiles get per-station Navidrome for free — the admin section edits the
+active station's file, same as the wizard.
+
+## Controller changes
+
+### 1. Extract shared helpers
+
+- **`setup/config.ts` — `applyNavidromeToLiveConfig(nv)`**: the three
+  `config.navidrome.*` mutations currently inlined in `/onboarding/save`.
+  Both save paths call it so live-apply behaviour can't drift.
+- **`music/subsonic.ts` — `pingWith({ url, user, pass })`**: the one-off
+  salt+token `/rest/ping` probe currently inlined in
+  `/onboarding/test-navidrome` (5s timeout, returns
+  `{ ok, serverVersion?, serverType?, error? }`). The onboarding route becomes
+  a thin wrapper over it; the new test route reuses it. Client id stays
+  distinguishable (`sub-wave-admin` vs `sub-wave-wizard`) via an optional
+  `client` arg.
+
+### 2. `GET /settings` — add a `navidrome` block
+
+```jsonc
+navidrome: {
+  url: "https://music.example.com",   // current effective value (config.navidrome.url)
+  user: "radio",
+  passSet: true,                       // password on file (config), never the value
+  env: { url: false, user: false, pass: false }  // per-field: is NAVIDROME_* set in env?
+}
+```
+
+Per-field env flags (not one boolean) because `server.ts` applies setup-config
+per-field — a station can have `NAVIDROME_URL` in env but user/pass from the
+wizard. The password value itself never leaves the controller, matching the
+`getRedacted()` convention everywhere else.
+
+### 3. `POST /settings/navidrome` — save (admin-gated)
+
+Body `{ url?, user?, pass? }`. Behaviour:
+
+- Merge over the currently effective values: a blank `pass` with a password
+  on file keeps the stored one (the `'set'`-sentinel pattern the LLM/embedding
+  sections use, applied as "blank = keep").
+- Validate the merged result is complete (url + user + pass all non-empty) —
+  clearing creds to empty is not allowed, same threshold `needsSetup` gates
+  on. URL is trimmed and stripped of trailing `/`, as in the wizard.
+- Reject fields that are env-managed (`400` naming the env var) rather than
+  silently persisting a value that env will shadow on next boot.
+- Persist **only the submitted fields** via `saveSetupConfig()` (it already
+  deep-merges the `navidrome` block), so an env-shadowed value never gets
+  copied into `setup-config.json`. Then
+  `applyNavidromeToLiveConfig()` so Subsonic calls use the new creds
+  immediately — no restart, same as the wizard.
+- Post-save side effects:
+  - `refreshAutoPlaylist()` fire-and-forget — `auto.m3u` entries carry
+    annotated URIs with auth tokens derived from the old password, so the
+    playlist must be rebuilt (same rationale as the post-onboarding kick).
+  - Reset the doctor's 20s Navidrome ping cache (export a
+    `clearNavidromeCache()` from `doctor.ts`) so the `NavidromeBanner` and
+    DJ Doc reflect the new target on their next poll instead of up to 20s
+    later.
+  - During implementation, check `music/picker.js` / `music/subsonic.js` for
+    a memo-invalidation hook and call it if one exists; the 30-min Subsonic
+    memos hold song lists whose ids are junk if the operator pointed at a
+    *different* server. If no hook exists, accept the staleness (bounded at
+    30 min, self-heals) rather than building invalidation for this feature.
+- Does **not** stamp `setupCompletedAt` — that stays a wizard concept.
+  (`needsSetup` keys on cred presence, not the stamp, so a fresh install that
+  configures Navidrome here still exits the onboarding redirect.)
+
+### 4. `POST /settings/navidrome/test` — connection test (admin-gated)
+
+Body `{ url?, user?, pass? }`, merged over effective values exactly like save
+(so "Test" works with the stored password without the browser ever seeing it),
+then `pingWith()`. Non-mutating. Returns the wizard shape:
+`{ ok, serverVersion?, serverType?, error? }`.
+
+The onboarding test route stays as-is for the wizard (it must test creds that
+aren't saved anywhere yet and must not fall back to stored ones).
+
+## Web UI changes
+
+### New section in the Settings rail
+
+`{ id: 'music', label: 'Music source', hint: 'navidrome · subsonic', icon: Music2 }`
+inserted directly after `station`. The existing `?section=` deep-link effect
+picks it up with no changes (`/admin/settings?section=music`).
+
+### `web/components/admin/settings/NavidromeSection.tsx`
+
+Follows the established section pattern (`SectionHeader`, `Card`, `SaveBar`
+from `shared.tsx` / `admin/ui`), but holds **local state** instead of joining
+the shared `FormState` — Navidrome isn't part of `settings.json` values, so it
+prefills from the `navidrome` block of the `GET /settings` payload and saves
+through its own endpoint. Needs only `data`, `adminFetch`, and `refresh` as
+props.
+
+- **Fields:** Server URL, Username, Password. Password input is write-only
+  with placeholder `•••••• (on file)` when `passSet`; sent only when typed.
+- **Env-managed fields** render disabled with a hint naming the var:
+  "Set via `NAVIDROME_URL` in the root `.env` — env always wins on boot;
+  remove it there to manage it here." If all three are env-managed, the
+  SaveBar is hidden and the section is a read-only status view.
+- **Test connection** button posts the current form values to
+  `/settings/navidrome/test` and renders the result inline (green
+  "✓ Connected — Navidrome 0.52 (subsonic 1.16.1)" / red error), mirroring
+  the LibrarySection probe styling.
+- **Save** posts to `/settings/navidrome`, toasts via `notify`, refreshes the
+  settings payload. Note under the bar: "Applies immediately — the auto
+  playlist is rebuilt with the new connection; no restart needed."
+
+### `NavidromeBanner` copy fix
+
+The banner's "Check the URL / username / password in setup" becomes a link to
+`/admin/settings?section=music` ("check the connection in Settings → Music
+source"). The DJ Doc link stays.
+
+## Error handling
+
+- Save with an unreachable server still saves (matching the wizard, where
+  test is advisory) — the operator may be pre-configuring a server that isn't
+  up yet. The banner + test button cover reachability; save covers intent.
+- All new routes are `requireAdmin`-gated and return the standard
+  `{ ok:false, error }` / 400 shapes.
+- `settings.ts` (the store) is untouched, so no schema-validation changes.
+
+## Testing
+
+No test runner in the repo; `npm run lint` in `controller/` and `web/` is the
+gate. Manual verification via the `verify` skill flow (isolated controller +
+worktree Next dev server + Playwright against `/admin/settings?section=music`):
+prefill, test-button success/failure, save round-trip, env-locked rendering,
+banner link.
+
+## Out of scope
+
+- Moving Navidrome creds into `settings.json` (the setup-config split is
+  deliberate and documented).
+- Multiple music sources / non-Navidrome Subsonic server presets.
+- Encrypting the password at rest (unchanged from today's setup-config
+  behaviour).
+- CLI changes — `subwave setup` keeps working against the same file.

--- a/web/components/admin/NavidromeBanner.tsx
+++ b/web/components/admin/NavidromeBanner.tsx
@@ -57,8 +57,14 @@ export default function NavidromeBanner({
       <AlertTriangle size={14} className="shrink-0 text-[var(--danger)]" aria-hidden="true" />
       <span>
         <b>Can&rsquo;t reach Navidrome.</b> The DJ has no music source
-        {status.reason ? <> — {status.reason}</> : null}. Check the URL / username / password in
-        setup and that Navidrome is running.
+        {status.reason ? <> — {status.reason}</> : null}. Check the connection in{' '}
+        <Link
+          href="/admin/settings?section=music"
+          className="font-bold underline-offset-2 hover:underline"
+        >
+          Settings &rarr; Music source
+        </Link>{' '}
+        and that Navidrome is running.
       </span>
       <Link
         href="/admin/doctor"

--- a/web/components/admin/NavidromeBanner.tsx
+++ b/web/components/admin/NavidromeBanner.tsx
@@ -57,20 +57,14 @@ export default function NavidromeBanner({
       <AlertTriangle size={14} className="shrink-0 text-[var(--danger)]" aria-hidden="true" />
       <span>
         <b>Can&rsquo;t reach Navidrome.</b> The DJ has no music source
-        {status.reason ? <> — {status.reason}</> : null}. Check the connection in{' '}
-        <Link
-          href="/admin/settings?section=music"
-          className="font-bold underline-offset-2 hover:underline"
-        >
-          Settings &rarr; Music source
-        </Link>{' '}
-        and that Navidrome is running.
+        {status.reason ? <> — {status.reason}</> : null}. Check the connection in Settings &rarr;
+        Music source and that Navidrome is running.
       </span>
       <Link
-        href="/admin/doctor"
+        href="/admin/settings?section=music"
         className="ml-auto font-bold text-[var(--danger)] underline-offset-2 hover:underline"
       >
-        DJ Doc &rarr;
+        Music source &rarr;
       </Link>
     </div>
   );

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -20,7 +20,7 @@ import ArchivesPanel from './ArchivesPanel';
 import BackupPanel from './BackupPanel';
 import {
   Radio, Palette, Cpu, Mic, Library, Search,
-  Activity, Archive, Save, AlertTriangle, Heart,
+  Activity, Archive, Save, AlertTriangle, Heart, Music2,
 } from 'lucide-react';
 import {
   SectionHeader, ELEVENLABS_VS_DEFAULTS,
@@ -35,9 +35,11 @@ import { StationSection } from './settings/StationSection';
 import { ThemeSection } from './settings/ThemeSection';
 import { ScrobbleSection } from './settings/ScrobbleSection';
 import { LikesSection } from './settings/LikesSection';
+import { NavidromeSection } from './settings/NavidromeSection';
 
 const SECTIONS = [
   { id: 'station',  label: 'Station', hint: 'name · location · locale', icon: Radio },
+  { id: 'music',    label: 'Music source', hint: 'navidrome · subsonic', icon: Music2 },
   { id: 'theme',    label: 'Skin & Themes', hint: 'player skin · palette', icon: Palette },
   { id: 'llm',      label: 'LLM provider', hint: 'model routing', icon: Cpu },
   { id: 'tts',      label: 'TTS voice', hint: 'default engine', icon: Mic },
@@ -450,6 +452,9 @@ export default function SettingsPanel() {
                 data={data} form={form} setForm={updateForm} busy={busy}
                 saveSettings={saveSettings}
               />
+            )}
+            {activeSection === 'music' && (
+              <NavidromeSection data={data} adminFetch={adminFetch} refresh={refresh} />
             )}
             {activeSection === 'theme' && (
               <ThemeSection

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -2,7 +2,7 @@
 
 import type { ChangeEvent } from 'react';
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { notify, errorMessage } from '../../lib/notify';
 import { normalizeStationLocale } from '../../lib/format';
 import { useAdminAuth } from '../../lib/adminAuth';
@@ -89,14 +89,20 @@ export default function SettingsPanel() {
   //
   // Jingles / SFX / Beds left Settings for /admin/imaging — send their old
   // ?section deep-links on to the matching tab so existing bookmarks survive.
+  //
+  // useSearchParams (not a one-shot window.location read) so client-side
+  // navigations to ?section=… land too — the NavidromeBanner links here from
+  // every admin page INCLUDING /admin/settings itself, where the panel is
+  // already mounted and only the query changes.
+  const searchParams = useSearchParams();
   useEffect(() => {
-    const s = new URLSearchParams(window.location.search).get('section');
+    const s = searchParams.get('section');
     if (s === 'jingles' || s === 'sfx' || s === 'beds') {
       router.replace(`/admin/imaging?tab=${s}`);
       return;
     }
     if (s && SECTIONS.some(x => x.id === s)) setActiveSection(s as SectionId);
-  }, [router]);
+  }, [router, searchParams]);
 
   useEffect(() => {
     if (!data?.values || form) return;

--- a/web/components/admin/settings/NavidromeSection.tsx
+++ b/web/components/admin/settings/NavidromeSection.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import type { ChangeEvent } from 'react';
+import { useState } from 'react';
+import { notify, errorMessage } from '../../../lib/notify';
+import { Input } from '../../ui/input';
+import { Label } from '../../ui/label';
+import { Btn, Card } from '../ui';
+import { cn } from '../../../lib/cn';
+import { SectionHeader, SaveBar, type SettingsData } from './shared';
+
+// Music source — view, test, and change the Navidrome connection from the
+// admin panel instead of re-running the onboarding wizard. Unlike the other
+// sections this one does NOT ride the shared FormState / saveSettings pair:
+// Navidrome creds live in state/setup-config.json (the wizard's overlay), not
+// settings.json, so the section keeps local state and talks to its own
+// /settings/navidrome endpoints.
+interface NavidromeSectionProps {
+  data: SettingsData;
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+  refresh: () => void;
+}
+
+type TestResult = { ok: boolean; serverVersion?: string; serverType?: string; error?: string };
+
+export function NavidromeSection({ data, adminFetch, refresh }: NavidromeSectionProps) {
+  const nv = data.navidrome;
+  // Seed once from the GET payload; later refreshes must not clobber typing.
+  const [url, setUrl] = useState(() => nv?.url ?? '');
+  const [user, setUser] = useState(() => nv?.user ?? '');
+  const [pass, setPass] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [result, setResult] = useState<TestResult | null>(null);
+
+  const env = { url: !!nv?.env?.url, user: !!nv?.env?.user, pass: !!nv?.env?.pass };
+  const allEnv = env.url && env.user && env.pass;
+  const passSet = !!nv?.passSet;
+
+  // Env-managed fields are omitted from every request body — the server
+  // rejects them anyway (env always wins on boot), and for test it falls back
+  // to the live value, which IS the env value. Blank pass is omitted too:
+  // server-side blank-pass semantics are "keep the one on file".
+  const body = () => {
+    const b: Record<string, string> = {};
+    if (!env.url) b.url = url.trim();
+    if (!env.user) b.user = user.trim();
+    if (!env.pass && pass) b.pass = pass;
+    return b;
+  };
+
+  const test = async () => {
+    setTesting(true);
+    setResult(null);
+    try {
+      const r = await adminFetch('/settings/navidrome/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body()),
+      });
+      setResult((await r.json()) as TestResult);
+    } catch (err) {
+      setResult({ ok: false, error: errorMessage(err) });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const save = async () => {
+    if (!env.url && !url.trim()) return notify.err('Server URL is required');
+    if (!env.user && !user.trim()) return notify.err('Username is required');
+    if (!env.pass && !pass && !passSet) return notify.err('Password is required');
+    setBusy(true);
+    try {
+      const r = await adminFetch('/settings/navidrome', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body()),
+      });
+      const j = (await r.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!r.ok || j.ok === false) {
+        notify.err(j.error || `Save failed (${r.status})`);
+        return;
+      }
+      notify.ok('Navidrome connection saved — auto playlist rebuilding');
+      setPass('');
+      setResult(null);
+      refresh();
+    } catch (err) {
+      notify.err(errorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const envHint = (envVar: string) => (
+    <div className="field-hint">
+      Set via <code>{envVar}</code> in the root <code>.env</code> — env always
+      wins on boot; remove it there to manage it here.
+    </div>
+  );
+
+  return (
+    <>
+      <SectionHeader
+        eyebrow="music source"
+        title="The Navidrome server the DJ pulls from."
+        sub={<>
+          Every track pick, cover, and library lookup goes through this
+          Subsonic connection. Changes apply immediately — no restart — and the
+          auto playlist is rebuilt against the new server. The same values are
+          managed by the onboarding wizard and <code>subwave setup</code>.
+        </>}
+      />
+
+      <Card title="Navidrome server" sub="url · credentials">
+        <div className="grid gap-[18px]">
+          <div className="field">
+            <Label htmlFor="nv-url">Server URL</Label>
+            <Input
+              id="nv-url"
+              value={url}
+              disabled={env.url}
+              onChange={(ev: ChangeEvent<HTMLInputElement>) => setUrl(ev.target.value)}
+              placeholder="https://music.example.com"
+              className="max-w-[420px]"
+            />
+            {env.url ? envHint('NAVIDROME_URL') : (
+              <div className="field-hint">
+                Must be reachable from the controller container. For a Navidrome
+                on the same host use <code>host.docker.internal</code> or the LAN
+                IP, not <code>127.0.0.1</code>.
+              </div>
+            )}
+          </div>
+
+          <div className="field">
+            <Label htmlFor="nv-user">Username</Label>
+            <Input
+              id="nv-user"
+              value={user}
+              disabled={env.user}
+              onChange={(ev: ChangeEvent<HTMLInputElement>) => setUser(ev.target.value)}
+              placeholder="radio"
+              className="max-w-[280px]"
+            />
+            {env.user && envHint('NAVIDROME_USER')}
+          </div>
+
+          <div className="field">
+            <Label htmlFor="nv-pass">Password</Label>
+            <Input
+              id="nv-pass"
+              type="password"
+              autoComplete="off"
+              value={pass}
+              disabled={env.pass}
+              onChange={(ev: ChangeEvent<HTMLInputElement>) => setPass(ev.target.value)}
+              placeholder={passSet ? '•••••• (on file)' : 'password'}
+              className="max-w-[280px]"
+            />
+            {env.pass ? envHint('NAVIDROME_PASS') : (
+              <div className="field-hint">
+                Write-only — the saved password never leaves the server. Leave
+                blank to keep the one on file. Auth uses the Subsonic salt+token
+                scheme, never the plaintext password.
+              </div>
+            )}
+          </div>
+
+          <div className="field">
+            <Btn sm tone="accent" onClick={test} disabled={testing || busy}>
+              {testing ? 'Testing…' : 'Test connection'}
+            </Btn>
+            {result && (
+              <div
+                role="status"
+                className={cn(
+                  'mt-2 max-w-[560px] rounded border bg-[var(--ink-softer)] px-3 py-2 text-[11px] leading-[1.6] whitespace-pre-wrap',
+                  result.ok
+                    ? 'border-[var(--accent)] text-[color:var(--accent)]'
+                    : 'border-[var(--danger)] text-[var(--danger)]',
+                )}
+              >
+                {result.ok
+                  ? `✓ Connected — ${result.serverType || 'subsonic'} ${result.serverVersion || ''}`.trimEnd()
+                  : `✗ ${result.error}`}
+              </div>
+            )}
+          </div>
+        </div>
+      </Card>
+
+      {allEnv ? (
+        <div className="flex flex-wrap items-center gap-3 border border-ink bg-[var(--ink-softer)] p-3 text-[12px] leading-[1.5] text-muted">
+          All three values are managed by <code>NAVIDROME_*</code> vars in the
+          root <code>.env</code>, so there is nothing to save here — edit the
+          file and restart the controller to change them.
+        </div>
+      ) : (
+        <SaveBar
+          note="Applies immediately — the auto playlist is rebuilt with the new connection; no restart needed. Saving with an unreachable server is allowed (it may not be up yet); use Test to check."
+          busy={busy}
+          onSave={save}
+          saveLabel="Save music source"
+        />
+      )}
+    </>
+  );
+}

--- a/web/components/admin/settings/shared.tsx
+++ b/web/components/admin/settings/shared.tsx
@@ -353,6 +353,15 @@ export interface SettingsData {
   };
   tagger?: { running?: boolean };
   env?: Record<string, unknown>;
+  // Navidrome connection read state (Settings → Music source). passSet only —
+  // the password value never reaches the browser. Env flags are per-field:
+  // url can be env-managed while user/pass come from the wizard/admin.
+  navidrome?: {
+    url?: string;
+    user?: string;
+    passSet?: boolean;
+    env?: { url?: boolean; user?: boolean; pass?: boolean };
+  };
   streamOnAir?: boolean;
   // What timezone '' (Auto) resolves to — the controller's own zone.
   serverTimezone?: string;


### PR DESCRIPTION
## What

Adds a **Music source** section to `/admin/settings` so the Navidrome connection (URL / username / password) can be viewed, tested, and changed from the admin panel — previously only possible via the onboarding wizard, `subwave setup`, or root-`.env` edits.

Design spec: `docs/superpowers/specs/2026-07-24-admin-navidrome-settings-design.md`

## Controller

- `GET /settings` gains a `navidrome` read block: `url`, `user`, `passSet`, and **per-field** env flags (server.ts applies setup-config per-field, so url can be env-managed while user/pass aren't). The password value never reaches the browser.
- `POST /settings/navidrome` — persists **only submitted fields** to `state/setup-config.json` (the same overlay the wizard/CLI write; `settings.json` untouched), applies live via the shared helper (no restart), clears the doctor's 20s ping cache + the picker's 30-min Subsonic pool memos, and rebuilds `auto.m3u` fire-and-forget (its annotated URIs carry auth tokens derived from the old password). Env-managed fields are rejected with the var named rather than silently persisting a value env would shadow on next boot. Does **not** stamp `setupCompletedAt` — that stays a wizard concept.
- `POST /settings/navidrome/test` — non-mutating; merges blank fields over stored values so **Test** works with the password on file. The wizard keeps its own test route (deliberately no stored-cred fallback).
- Shared helpers extracted so admin + wizard behaviour can't drift: `subsonic.pingWith()` (one-off salt+token probe, was inlined in the onboarding route) and `setup/config.applyNavidromeToLiveConfig()` (was inlined in onboarding save).

## Web

- New rail entry **Music source** (`?section=music` deep-linkable) rendering `NavidromeSection`: local state (creds aren't part of `settings.json`, so it doesn't join the shared FormState), write-only password with an *on file* placeholder, inline test result, env-locked fields disabled with the var named — all-env renders read-only with no save bar.
- `NavidromeBanner` now links to **Settings → Music source** instead of pointing at "setup".

## Notes

- Saving with an unreachable server is allowed on purpose (pre-configuring a server that isn't up yet) — Test covers reachability, matching wizard semantics.
- Multi-station: `setup-config.json` lives under the resolved `STATE_DIR`, so the section edits the active station's connection, same as the wizard.
- Lint: `controller` + `web` both clean (`eslint && tsc --noEmit`).

## Verification (done)

- [x] Playwright pass against `/admin/settings?section=music` (prefill, test ok/fail, save round-trip, env-locked rendering, banner link)

Verified end-to-end with an isolated worktree controller + web dev server + Playwright (both scenarios):
- **API**: prefill block, test with stored creds (fail + ok), save round-trip (trailing-slash strip, password retained, only submitted fields persisted to disk), cleared-field rejection (400), env-lock rejection naming the var, test fallback to env creds.
- **UI env-locked**: deep-link lands, fields disabled with env hints, no save bar, all-env note, Test still works.
- **UI editable**: prefill + '(on file)' placeholder, Test ok with stored password (never typed), Test fail on dead server, save via UI, banner appears when unreachable and links to the section — including from /admin/settings itself — then restore save.

Verification surfaced two fixes (second commit): pingWith retries once on any first failure (covers the pool stall when Navidrome restarts under warm connections), and the ?section= deep-link now rides useSearchParams so the banner link works without a remount.