### PR TITLE
fix(stations): env-configured badge + on-air name sync for station profiles

### DIFF
--- a/controller/scripts/stations-manager.test.ts
+++ b/controller/scripts/stations-manager.test.ts
@@ -51,6 +51,11 @@ try {
   assert.equal(night?.configured, false);
   assert.equal(night?.name, 'Night Shift');
 
+  // Env-configured installs (NAVIDROME_* in env, no setup-config.json anywhere)
+  // mark EVERY station configured — env creds are install-level.
+  const envList = manager.listStations(root, 'x', true);
+  assert.ok(envList.every((s) => s.configured));
+
   // Duplicate: allowlist copies, runtime skipped, library.db via callback.
   writeFileSync(join(root, 'stations', 'main', 'library.db'), 'not-really-sqlite');
   const backups: string[] = [];

--- a/controller/scripts/stations-manager.test.ts
+++ b/controller/scripts/stations-manager.test.ts
@@ -46,6 +46,12 @@ try {
   });
   assert.equal(fresh.id, 'night-shift');
   assert.equal(fresh.converted, false);
+  // Fresh create seeds the ON-AIR name — without it the first boot defaults
+  // to "SUB/WAVE" while the rack card says otherwise.
+  assert.equal(
+    JSON.parse(readFileSync(join(root, 'stations', 'night-shift', 'settings.json'), 'utf8')).station,
+    'Night Shift',
+  );
   const list = manager.listStations(root, 'x');
   const night = list.find((s) => s.id === 'night-shift');
   assert.equal(night?.configured, false);
@@ -70,11 +76,20 @@ try {
   assert.ok(existsSync(join(dupDir, 'jingles', 'a.wav')));
   assert.ok(!existsSync(join(dupDir, 'session.json')));
   assert.deepEqual(backups, [join(dupDir, 'library.db')]);
+  // Duplicate overwrites the on-air name copied from the source.
+  assert.equal(
+    JSON.parse(readFileSync(join(dupDir, 'settings.json'), 'utf8')).station,
+    'Night Shift',
+  );
 
-  // Rename touches only the identity card.
+  // Rename updates the identity card AND the dir's on-air name.
   manager.renameStation(root, 'night-shift', 'Graveyard');
   assert.equal(
     JSON.parse(readFileSync(join(root, 'stations', 'night-shift', 'station.json'), 'utf8')).name,
+    'Graveyard',
+  );
+  assert.equal(
+    JSON.parse(readFileSync(join(root, 'stations', 'night-shift', 'settings.json'), 'utf8')).station,
     'Graveyard',
   );
 

--- a/controller/src/routes/stations.ts
+++ b/controller/src/routes/stations.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import express from 'express';
 import { requireAdmin } from '../middleware/auth.js';
 import { STATE_ROOT } from '../config.js';
+import { envHasNavidrome } from '../setup/firstRun.js';
 import { MAX_STATIONS } from '../stations/pure.js';
 import * as settings from '../settings.js';
 import * as manager from '../stations/manager.js';
@@ -92,7 +93,7 @@ router.get('/stations', requireAdmin, (req, res) => {
       multiStation: manager.isMultiStation(STATE_ROOT),
       activeId: manager.activeIdOnDisk(STATE_ROOT),
       limit: MAX_STATIONS,
-      stations: manager.listStations(STATE_ROOT, currentName()),
+      stations: manager.listStations(STATE_ROOT, currentName(), envHasNavidrome()),
     });
   } catch (err) {
     res.status(500).json({ error: (err as Error).message });

--- a/controller/src/routes/stations.ts
+++ b/controller/src/routes/stations.ts
@@ -136,10 +136,19 @@ router.post('/stations', requireAdmin, async (req, res) => {
   }
 });
 
-router.patch('/stations/:id', requireAdmin, (req, res) => {
+router.patch('/stations/:id', requireAdmin, async (req, res) => {
   try {
-    manager.renameStation(STATE_ROOT, String(req.params.id), String(req.body?.name || ''));
-    res.json({ ok: true });
+    const id = String(req.params.id);
+    const resolved = manager.renameStation(STATE_ROOT, id, String(req.body?.name || ''));
+    // The active station's settings live in the running process, not just on
+    // disk — route the name through settings.update() so /state (the player's
+    // name source) flips immediately. It also rewrites settings.json from
+    // memory, which is why renameStation's fs patch alone can't cover this.
+    let requiresRestart = false;
+    if (manager.activeIdOnDisk(STATE_ROOT) === id) {
+      ({ requiresRestart } = await settings.update({ station: resolved }));
+    }
+    res.json({ ok: true, requiresRestart });
   } catch (err) {
     res.status(400).json({ error: (err as Error).message });
   }

--- a/controller/src/setup/firstRun.ts
+++ b/controller/src/setup/firstRun.ts
@@ -16,16 +16,23 @@ export interface SetupStatus {
   navidromeSource: 'env' | 'setup-config' | 'unset';
 }
 
-export async function getSetupStatus(): Promise<SetupStatus> {
-  // config.navidrome.* is populated from env at boot; setup-config.json is the
-  // wizard's persistence layer. If env supplies values, env wins.
-  const envHasNavidrome = Boolean(
+// Env-supplied Navidrome creds configure the whole INSTALL, not one station —
+// env always wins at boot no matter which station dir is active. The stations
+// listing uses this to mark every station configured on env-driven installs
+// (which never write setup-config.json, so the per-dir check alone reads as
+// "needs setup" on a perfectly healthy station).
+export function envHasNavidrome(): boolean {
+  return Boolean(
     process.env.NAVIDROME_URL &&
       process.env.NAVIDROME_USER &&
       process.env.NAVIDROME_PASS,
   );
+}
 
-  if (envHasNavidrome) {
+export async function getSetupStatus(): Promise<SetupStatus> {
+  // config.navidrome.* is populated from env at boot; setup-config.json is the
+  // wizard's persistence layer. If env supplies values, env wins.
+  if (envHasNavidrome()) {
     return {
       needsSetup: false,
       setupCompletedAt: null,
@@ -48,12 +55,7 @@ export async function getSetupStatus(): Promise<SetupStatus> {
 // Falls back to the env check if the cache hasn't loaded yet, which keeps the
 // /state response safe even on the first request after a cold start.
 export function getSetupStatusSync(): SetupStatus {
-  const envHasNavidrome = Boolean(
-    process.env.NAVIDROME_URL &&
-      process.env.NAVIDROME_USER &&
-      process.env.NAVIDROME_PASS,
-  );
-  if (envHasNavidrome) {
+  if (envHasNavidrome()) {
     return { needsSetup: false, setupCompletedAt: null, navidromeSource: 'env' };
   }
   // Read the config we already loaded into memory rather than touching disk.

--- a/controller/src/stations/manager.ts
+++ b/controller/src/stations/manager.ts
@@ -33,7 +33,7 @@ export class StationCreateError extends Error {
 export interface StationInfo {
   id: string | null;          // null = unconverted single-station root
   name: string;
-  configured: boolean;        // has setup-config.json (mirrors needsSetup)
+  configured: boolean;        // has setup-config.json, OR env creds cover the install
   createdAt: string | null;
   active: boolean;
 }
@@ -70,12 +70,21 @@ function readCard(dir: string): { name?: string; createdAt?: string } {
   }
 }
 
-export function listStations(root: string, fallbackName: string): StationInfo[] {
+// envConfigured: env-supplied Navidrome creds apply to EVERY station (env wins
+// at each boot regardless of the active dir), and env-driven installs never
+// write setup-config.json — without this flag they'd all read "needs setup".
+// Threaded in from the route (setup/firstRun.envHasNavidrome) so this module
+// stays fs-only and cycle-free.
+export function listStations(
+  root: string,
+  fallbackName: string,
+  envConfigured = false,
+): StationInfo[] {
   if (!isMultiStation(root)) {
     return [{
       id: null,
       name: fallbackName,
-      configured: existsSync(join(root, 'setup-config.json')),
+      configured: envConfigured || existsSync(join(root, 'setup-config.json')),
       createdAt: null,
       active: true,
     }];
@@ -89,7 +98,7 @@ export function listStations(root: string, fallbackName: string): StationInfo[] 
       return {
         id: e.name,
         name: typeof card.name === 'string' && card.name ? card.name : e.name,
-        configured: existsSync(join(dir, 'setup-config.json')),
+        configured: envConfigured || existsSync(join(dir, 'setup-config.json')),
         createdAt: card.createdAt || null,
         active: e.name === active,
       };

--- a/controller/src/stations/manager.ts
+++ b/controller/src/stations/manager.ts
@@ -70,6 +70,26 @@ function readCard(dir: string): { name?: string; createdAt?: string } {
   }
 }
 
+// Keep the ON-AIR name (settings.station — what the player and /state show) in
+// step with the identity card. Without this, a fresh station boots as the
+// default "SUB/WAVE" and a duplicate carries the source's name — the rack says
+// one thing, the player another. settings.load() merges over DEFAULTS, so a
+// seeded minimal {station} file is a valid settings.json. For the ACTIVE
+// station this fs write alone isn't enough (the live process has settings
+// cached in memory) — the rename route also pushes it through
+// settings.update(), which rewrites this same file from memory afterwards.
+function patchSettingsStation(dir: string, name: string): void {
+  const p = join(dir, 'settings.json');
+  let s: Record<string, unknown> = {};
+  try {
+    s = JSON.parse(readFileSync(p, 'utf8'));
+  } catch {
+    // absent or corrupt — seed minimal; load() fills the rest from DEFAULTS
+  }
+  s.station = name;
+  writeFileSync(p, JSON.stringify(s, null, 2));
+}
+
 // envConfigured: env-supplied Navidrome creds apply to EVERY station (env wins
 // at each boot regardless of the active dir), and env-driven installs never
 // write setup-config.json — without this flag they'd all read "needs setup".
@@ -243,6 +263,9 @@ export async function createStation(root: string, opts: {
         }
       }
     }
+    // Fresh: seeds a minimal settings.json so first boot doesn't default to
+    // "SUB/WAVE". Duplicate: overwrites the name copied from the source.
+    patchSettingsStation(dest, name);
     return { id, converted };
   } catch (err) {
     if (destCreated) {
@@ -257,17 +280,19 @@ export async function createStation(root: string, opts: {
   }
 }
 
-export function renameStation(root: string, id: string, name: string): void {
+// Returns the resolved name so the route can mirror it into the live settings
+// layer when the renamed station is the active one.
+export function renameStation(root: string, id: string, name: string): string {
   const dir = stationPath(root, id);
   if (!existsSync(dir)) throw new Error('no such station');
+  const resolved = String(name || '').trim().slice(0, 80) || id;
   const card = readCard(dir);
   writeFileSync(
     join(dir, 'station.json'),
-    JSON.stringify(
-      { ...card, name: String(name || '').trim().slice(0, 80) || id },
-      null, 2,
-    ),
+    JSON.stringify({ ...card, name: resolved }, null, 2),
   );
+  patchSettingsStation(dir, resolved);
+  return resolved;
 }
 
 export function deleteStation(root: string, id: string): void {


### PR DESCRIPTION
Two multi-station fixes found while dogfooding #1156 on an env-configured install.

## 1. Every station showed NEEDS SETUP on env-driven installs

`listStations` derived `configured` purely from `existsSync(<dir>/setup-config.json)` — but installs whose Navidrome creds come from `NAVIDROME_*` env vars never write that file (env always wins, the wizard never runs), so a perfectly healthy on-air station read as unconfigured in the rack and the sidebar switcher.

Env creds are install-level — they apply to every station at each boot — so the listing now ORs in `envHasNavidrome()` (newly exported from `setup/firstRun.ts`, deduping the two inline copies of the same check). Threaded as a param from the route so the manager keeps its fs-only, no-`config.js`-import contract.

## 2. Create/rename never reached the on-air name — the player kept saying "SUB/WAVE"

The panel only ever wrote the identity card (`station.json`), while the player shows `settings.station` via `/state`:

- a **fresh** station booted with the default `SUB/WAVE`
- a **duplicate** carried the source's name
- a **rename** changed the rack label but never the broadcast

Now:
- `createStation` seeds the new dir's `settings.json` with the station name (fresh) or overwrites the copied name (duplicate) — `settings.load()` merges over `DEFAULTS`, so a minimal seed file is valid
- `renameStation` patches the dir's `settings.json` alongside the card and returns the resolved name
- the rename route additionally pushes the **active** station's name through `settings.update()` so the in-memory settings and `/state` flip immediately (an fs write alone can't reach the live cache), returning `requiresRestart` for the Icecast-side stream name

## Testing

- `stations-manager.test.ts` extended: env-configured listing, fresh-create seed, duplicate overwrite, rename sync
- All three stations test files pass; `npm run lint` clean
- Verified live on the home install: badges cleared, rename flowed through to the player + Icecast after a mixer bounce

Note for #1160: that branch's per-field `navidrome.env` flags are a superset of `envHasNavidrome()` — when both land, the badge could derive from the per-field helpers to keep one env-detection idiom.