### PR TITLE
fix(web): say which provider bills tag-moods vs embeddings in the tagging UI

### DIFF
--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -38,6 +38,7 @@ import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
 } from '../ui/select';
 import { Card, Btn, Eyebrow, Pill, Seg } from './ui';
+import { llmProviderLabel } from './llm/providerMeta';
 import { cn } from '../../lib/cn';
 import TaggingPanel, { num } from './LibraryTaggingPanel';
 import type { Coverage, TaggerState, LibraryStatsLite, Batch, BudgetMode, RescanOpts, TagSteps } from './LibraryTaggingPanel';
@@ -126,6 +127,11 @@ interface SettingsResponse {
       analyzeQuietOnly?: boolean;
       analyzeQuietMinutes?: number;
     };
+    // Provider attribution for the Tagging modal's cost preview (#1162): the
+    // mood/energy seed calls bill to the chat LLM, the embedding calls to the
+    // embedding provider (blank = follows the LLM provider).
+    llm?: { provider?: string; model?: string };
+    embedding?: { provider?: string; model?: string };
   };
   // Daily-token-budget tier — drives the "budget nearly/already used" warning in
   // the Tagging modal. Absent on an old controller → treated as 'normal'.
@@ -219,6 +225,11 @@ export default function LibraryPanel() {
   const [quietMins, setQuietMins] = useState<number | null>(null);
   // Daily-token-budget tier from /settings — null until the first slow poll lands.
   const [budgetMode, setBudgetMode] = useState<BudgetMode | null>(null);
+  // Provider attribution for the Tagging modal (#1162) — "Google · gemini-2.0-
+  // flash-lite" for the LLM seed calls, "OpenAI" for the embedding calls. Null
+  // until the slow poll lands (the modal omits the attribution).
+  const [llmLabel, setLlmLabel] = useState<string | null>(null);
+  const [embedLabel, setEmbedLabel] = useState<string | null>(null);
   const [logOpen, setLogOpen] = useState(false);
   const [queuing, setQueuing] = useState<string | null>(null);
   const [retagging, setRetagging] = useState<string | null>(null);
@@ -398,6 +409,18 @@ export default function LibraryPanel() {
         );
       }
       if (j.budget) setBudgetMode(j.budget.mode);
+      // Which provider each tagging cost bills to (#1162). The tag-moods seed
+      // calls always ride the chat LLM legs (tag-library resolveTagConsumers);
+      // a blank embedding provider follows the LLM provider. Embedding model is
+      // shown only when explicitly set — the provider-default resolution table
+      // lives in Settings → Library and isn't duplicated here.
+      if (j.values?.llm?.provider) {
+        const llm = j.values.llm;
+        setLlmLabel(llmProviderLabel(llm.provider) + (llm.model ? ` · ${llm.model}` : ''));
+        const emb = j.values.embedding || {};
+        const embProvider = emb.provider || llm.provider;
+        setEmbedLabel(llmProviderLabel(embProvider) + (emb.model ? ` · ${emb.model}` : ''));
+      }
     } catch { /* transient */ }
   }, [adminFetch, ready]);
 
@@ -1282,6 +1305,8 @@ export default function LibraryPanel() {
         onToggleQuiet={toggleQuiet}
         onQuietMinutes={saveQuietMinutes}
         budgetMode={budgetMode}
+        llmLabel={llmLabel}
+        embedLabel={embedLabel}
       />
 
       <Tabs tab={tab} setTab={setTab} />

--- a/web/components/admin/LibraryTaggingModal.tsx
+++ b/web/components/admin/LibraryTaggingModal.tsx
@@ -47,6 +47,13 @@ interface Props {
   // Daily-token-budget tier from /settings — drives the pre-run spend warning.
   // null (old controller / not yet polled) is treated as 'normal' (no warning).
   budgetMode: BudgetMode | null;
+  // Provider attribution for the Run tab's cost preview (#1162): the mood/energy
+  // seed calls bill to the DJ's chat LLM (settings.llm), NOT the embedding
+  // provider — operators kept assuming the embedding setting covered the whole
+  // job. llmLabel ≈ "Google · gemini-2.0-flash-lite", embedLabel ≈ "OpenAI".
+  // null until the settings poll lands (the line just omits the attribution).
+  llmLabel: string | null;
+  embedLabel: string | null;
   // when set, the modal opens straight to the matching tab/selection
   intent: 'reembed' | null;
   // handlers
@@ -227,12 +234,14 @@ export default function LibraryTaggingModal(p: Props) {
                 hint="Fetch Last.fm tags + lyrics per track to sharpen the mood read. External API calls — slower on big batches." />
               <Pass on={steps.tagMoods} onClick={() => toggleStep('tagMoods')}
                 name="Tag moods (LLM)" tag="AI · billed"
-                hint="The core step: embeds each track, then your LLM picks mood & energy and spreads tags to similar songs. Uses model calls." />
+                hint="The core step: embeds each track, then your DJ's LLM picks mood & energy and spreads tags to similar songs. Billed to the Settings → LLM provider — the embedding provider only handles similarity." />
               {steps.tagMoods && seedEst != null && inScope != null && (
                 <p className="-mt-1 pl-[26px] text-[11px] leading-[1.5] text-muted">
                   ≈ <span className="mono-num">{num(seedEst)}</span> LLM seed calls in ~
-                  <span className="mono-num">{Math.ceil(seedEst / 25)}</span> batches, plus re-checks
+                  <span className="mono-num">{Math.ceil(seedEst / 25)}</span> batches
+                  {p.llmLabel && <> on <b>{p.llmLabel}</b></>}, plus re-checks
                   for uncertain tracks · ≈ <span className="mono-num">{num(inScope)}</span> embedding calls
+                  {p.embedLabel && <> on <b>{p.embedLabel}</b></>}
                 </p>
               )}
               <Pass on={effSteps.analyze} onClick={() => toggleStep('analyze')} disabled={analyzeLocked}

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -221,6 +221,11 @@ interface TaggingPanelProps {
   // Daily-token-budget tier from /settings — null until the first slow poll lands.
   // Forwarded to the modal for its pre-run spend warning.
   budgetMode: BudgetMode | null;
+  // Provider attribution forwarded to the modal's cost preview (#1162) — which
+  // provider the mood/energy LLM calls vs. the embedding calls actually bill to.
+  // Null until the settings poll lands.
+  llmLabel: string | null;
+  embedLabel: string | null;
 }
 
 // One friendly sentence per pipeline phase — shown under the live progress so
@@ -1170,6 +1175,8 @@ export default function TaggingPanel(p: TaggingPanelProps) {
         // it — otherwise the acoustics steps are bpm/key-only (honest hints).
         soundsLikeActive={!analysisOff && audioStatus !== 'pending-heavy' && !!p.audioEnabled}
         budgetMode={p.budgetMode}
+        llmLabel={p.llmLabel}
+        embedLabel={p.embedLabel}
         onStart={p.onStart}
         onReconcile={p.onReconcile}
         onRescan={p.onRescan}

--- a/web/components/admin/settings/LibrarySection.tsx
+++ b/web/components/admin/settings/LibrarySection.tsx
@@ -281,10 +281,11 @@ export function LibrarySection({ data, form, setForm, busy, saveSettings, adminF
         eyebrow="library tagger"
         title="Embedding-propagated mood tagging."
         sub={<>
-          The tagger embeds every track once, LLM-tags a small representative
-          seed set, then KNN-propagates moods + energy to the rest. Cuts LLM
-          call count ~10× vs. brute-force per-track tagging. Tune below;
-          changes apply the next time the bulk tagger runs.
+          The tagger embeds every track once (embedding provider below),
+          LLM-tags a small representative seed set using your DJ&rsquo;s LLM
+          (Settings → LLM), then KNN-propagates moods + energy to the rest.
+          Cuts LLM call count ~10× vs. brute-force per-track tagging. Tune
+          below; changes apply the next time the bulk tagger runs.
         </>}
         metrics={[
           {
@@ -354,11 +355,14 @@ export function LibrarySection({ data, form, setForm, busy, saveSettings, adminF
             <div className="flex items-start gap-x-2 border border-[color-mix(in_oklab,var(--accent)_30%,transparent)] bg-[var(--accent-soft)] p-3 text-[11px] leading-[1.5] text-ink">
               <span className="flex-none text-[12px] leading-[1.5] text-[var(--accent)]">✓</span>
               <span className="min-w-0">
-                Ready to tag with defaults: <code>{llmProviderLabel(effectiveProvider)}</code>
+                Embeddings ready with defaults: <code>{llmProviderLabel(effectiveProvider)}</code>
                 {!e.provider && <span className="text-muted"> (your DJ&rsquo;s provider)</span>}
                 {' · '}<code>{effectiveModel}</code>
                 {effectiveDim != null && <span className="text-muted"> · {effectiveDim}-d</span>}.
-                <span className="text-muted"> Change the provider or model below to override.</span>
+                <span className="text-muted"> Change the provider or model below to override.
+                This provider makes the similarity vectors only — the per-track
+                mood &amp; energy calls bill to your DJ&rsquo;s LLM
+                (<code>{llmProviderLabel(llmProvider)}</code>, Settings → LLM).</span>
               </span>
             </div>
           )}
@@ -376,7 +380,10 @@ export function LibrarySection({ data, form, setForm, busy, saveSettings, adminF
               className="max-w-[560px]"
             />
             <div className="field-hint">
-              Where the text embeddings come from. Defaults to your DJ&rsquo;s
+              Where the text embeddings come from — used for the sounds-like
+              similarity and tag-propagation steps <em>only</em>. The mood &amp;
+              energy tagging calls themselves always use your DJ&rsquo;s LLM
+              provider (Settings → LLM), and bill there. Defaults to your DJ&rsquo;s
               provider, so Ollama-local users get <code>nomic-embed-text</code> free.
               Anthropic has no first-party embedding API; if your LLM is Anthropic,
               pick OpenAI here (needs <code>OPENAI_API_KEY</code>).


### PR DESCRIPTION
Closes #1162.

The Library Tagging surfaces let operators assume the **embedding** provider covers the whole tagging job — but the per-track mood/energy seed calls ride the **chat LLM** legs (`settings.llm` via `resolveTagConsumers()` in `tag-library.ts`). The reporter pointed embeddings at OpenAI, left the LLM on Google, ran a 55k-track job, and burned a $10 prepay ~10k tracks in.

This is the labeling fix (issue options 1+2 — no behaviour change to the tagger):

## Tagging modal (Run tab)
- **'Tag moods (LLM)' hint** now says the step bills to the Settings → LLM provider, and that the embedding provider only handles similarity.
- **Cost-preview line** attributes each count to its provider, right where the operator commits to spending:
  > ≈ 2,200 LLM seed calls in ~88 batches **on Google · gemini-2.0-flash-lite**, plus re-checks for uncertain tracks · ≈ 55,000 embedding calls **on OpenAI**

  Labels are derived from the existing `/settings` slow poll in `LibraryPanel` (`values.llm` / `values.embedding`, blank embedding provider follows the LLM) and threaded through `TaggingPanel` → modal. Null until the poll lands → the line simply omits the attribution.

## Settings → Library
- The ✓ banner read **"Ready to tag with defaults: OpenAI…"** while sitting on the *embedding* card — the single worst reinforcement of the wrong assumption. Now reads "Embeddings ready with defaults…" and states that mood & energy calls bill to the DJ's LLM (named inline).
- The **Provider field-hint** and the **section intro** carry the same attribution (embeddings = similarity/propagation only).

The issue's option 3 (a dedicated tagging-provider override mirroring `settings.embedding`) is deliberately out of scope — worth its own issue if wanted, since it interacts with dual-LLM mode and the failover legs.

## Testing
- `npm run lint` (eslint + tsc) passes in `web/`.
- Copy-only + prop plumbing; no controller changes (`getRedacted()` already ships `llm`/`embedding` provider+model on `GET /settings`).