### PR TITLE
fix(web): hide station-disabled skills and clamp descriptions in persona skills card

### DIFF
--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -4281,6 +4281,18 @@ export async function update(patch) {
           throw new Error(`skills.enabled.${name} must be a boolean`);
         }
         next.skills.enabled[name] = on;
+        // Disabling a skill station-wide also revokes it from every persona
+        // that explicitly carries it, so a later re-enable is a fresh
+        // per-persona opt-in rather than a silent return. The `null` "all
+        // skills" sentinel stays untouched — it means "whatever the station
+        // enables", not a list to edit.
+        if (!on) {
+          for (const p of next.personas) {
+            if (Array.isArray(p.skills) && p.skills.includes(name)) {
+              p.skills = p.skills.filter((slug: string) => slug !== name);
+            }
+          }
+        }
       }
     }
   }

--- a/web/components/admin/personas/PersonaSkillsCard.tsx
+++ b/web/components/admin/personas/PersonaSkillsCard.tsx
@@ -11,26 +11,32 @@ interface PersonaSkillsCardProps {
 }
 
 export function PersonaSkillsCard({ persona, skillCatalog, setSkills }: PersonaSkillsCardProps) {
+  // Skills switched off station-wide can never fire regardless of the ticks
+  // here, so listing them only invites toggles that do nothing. Older
+  // controllers omit `enabled` — treat absent as on.
+  const enabledSkills = skillCatalog.filter(s => s.enabled !== false);
   return (
     <Card flat title="Skills" sub="autonomous segments this persona runs">
       <p className="mb-2.5 max-w-[70ch] text-[12px] leading-[1.6] text-muted">
-        When this persona is on air, only the skills ticked here can fire. A skill must
-        also be enabled station-wide on the <strong>Skills</strong> page.
+        When this persona is on air, only the skills ticked here can fire. Skills
+        disabled station-wide on the <strong>Skills</strong> page are not listed.
       </p>
-      {skillCatalog.length === 0 ? (
-        <span className="text-[12px] text-muted">No skills available</span>
+      {enabledSkills.length === 0 ? (
+        <span className="text-[12px] text-muted">
+          No skills enabled station-wide — enable some on the Skills page first
+        </span>
       ) : (
         <div className="grid gap-x-8 sm:grid-cols-2">
-          {skillCatalog.map(s => {
+          {enabledSkills.map(s => {
             const on = persona.skills.includes(s.name);
             return (
               <div
                 key={s.name}
                 className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-dashed border-separator-strong py-3"
               >
-                <div>
+                <div className="min-w-0">
                   <div className="text-[13px] font-bold">{s.label || s.name}</div>
-                  <div className="mt-0.5 text-[11px] text-muted">
+                  <div className="mt-0.5 line-clamp-2 text-[11px] text-muted" title={s.description || ''}>
                     {s.description}
                   </div>
                 </div>

--- a/web/components/admin/personas/types.ts
+++ b/web/components/admin/personas/types.ts
@@ -64,6 +64,9 @@ export interface SkillCatalogEntry {
   name: string;
   label?: string;
   description?: string;
+  // Station-wide toggle from the Skills page. Optional so the UI degrades
+  // against older controllers that don't send it.
+  enabled?: boolean;
   // Freeform organisation tags from the skill's SKILL.md frontmatter.
   tags?: string[];
 }


### PR DESCRIPTION
## What

Polish around the station-wide skill toggle and the persona edit screen's Skills card.

### Web (persona edit screen)

- **Skills disabled station-wide no longer appear in the persona skills list.** The `/settings` skill catalog already carries the per-skill `enabled` flag from the main Skills page; the card now filters on it. Absent flag (older controllers) is treated as enabled.
- **Long skill descriptions are clamped to two lines** (`line-clamp-2` + full text in the `title` tooltip), mirroring the idiom already used on the main Skills page cards, so a wordy custom skill no longer stretches the grid.
- Helper copy and empty state updated to match ("No skills enabled station-wide — enable some on the Skills page first").

### Controller

- **Disabling a skill station-wide now revokes it from every persona that explicitly carried it.** Implemented in the `skills.enabled` patch handler inside `settings.update()` — the single chokepoint all disable paths go through (admin toggle, MCP, any future caller). Re-enabling the skill later is a fresh per-persona opt-in rather than a silent return.
- The `null` "all skills" sentinel on legacy personas is deliberately left untouched — it means "whatever the station enables", not a list to edit.

## Testing

- `npm run lint` passes in both `web/` and `controller/` (eslint + tsc).
- Behavioral check against a temp `STATE_DIR`: seeded a persona with `['weather','news']`, disabled `weather` station-wide → persona left with `['news']`, the null-sentinel persona stayed `null`, and re-enabling `weather` did not restore the tick.