### PR TITLE
fix(admin): run playlist generation as a polled job so Cloudflare can't kill it

### DIFF
--- a/controller/scripts/playlist-jobs.test.ts
+++ b/controller/scripts/playlist-jobs.test.ts
@@ -1,0 +1,87 @@
+// Unit tests for the playlist builder's async job store
+// (music/playlist-jobs.ts): lifecycle (create → complete/fail → get), the
+// lazy TTL sweep, and the concurrent-run cap. The store is what lets
+// /playlists/generate/jobs outlive Cloudflare's ~100s proxy timeout, so the
+// expiry/cap behaviour here is the contract the panel's poller relies on.
+// Run: `tsx scripts/playlist-jobs.test.ts`.
+//
+// node:assert-via-tsx style, matching scripts/programme.test.ts.
+
+import assert from 'node:assert/strict';
+import * as jobs from '../src/music/playlist-jobs.js';
+import type { GenerateResult } from '../src/music/playlist-gen.js';
+
+const RESULT: GenerateResult = {
+  tracks: [],
+  reasons: [],
+  usedFallback: false,
+  poolSize: 0,
+} as unknown as GenerateResult;
+
+const T0 = 1_000_000;
+
+// ── lifecycle ────────────────────────────────────────────────────────────────
+
+// create → running; complete → done with the result readable via get.
+{
+  jobs._clear();
+  const job = jobs.create(T0);
+  assert.ok(job, 'create returns a job');
+  assert.equal(job!.status, 'running');
+  jobs.complete(job!.id, RESULT, T0 + 1000);
+  const seen = jobs.get(job!.id, T0 + 2000);
+  assert.equal(seen?.status, 'done');
+  assert.equal(seen?.result, RESULT);
+}
+
+// fail → error with the message readable.
+{
+  jobs._clear();
+  const job = jobs.create(T0)!;
+  jobs.fail(job.id, 'model unreachable', T0 + 1000);
+  const seen = jobs.get(job.id, T0 + 2000);
+  assert.equal(seen?.status, 'error');
+  assert.equal(seen?.error, 'model unreachable');
+}
+
+// complete/fail on an already-landed job is a no-op (first landing wins).
+{
+  jobs._clear();
+  const job = jobs.create(T0)!;
+  jobs.complete(job.id, RESULT, T0 + 1000);
+  jobs.fail(job.id, 'late failure', T0 + 2000);
+  assert.equal(jobs.get(job.id, T0 + 3000)?.status, 'done', 'fail after complete ignored');
+}
+
+// ── sweep ────────────────────────────────────────────────────────────────────
+
+// A finished job survives within RESULT_TTL_MS and expires after it.
+{
+  jobs._clear();
+  const job = jobs.create(T0)!;
+  jobs.complete(job.id, RESULT, T0);
+  assert.ok(jobs.get(job.id, T0 + jobs.RESULT_TTL_MS - 1), 'claimable inside the TTL');
+  assert.equal(jobs.get(job.id, T0 + jobs.RESULT_TTL_MS + 1), undefined, 'expired past the TTL');
+}
+
+// A wedged running job is dropped past MAX_AGE_MS (it must not hold a slot).
+{
+  jobs._clear();
+  const job = jobs.create(T0)!;
+  assert.ok(jobs.get(job.id, T0 + jobs.MAX_AGE_MS - 1), 'running job survives inside MAX_AGE');
+  assert.equal(jobs.get(job.id, T0 + jobs.MAX_AGE_MS + 1), undefined, 'wedged job swept past MAX_AGE');
+}
+
+// ── concurrent-run cap ───────────────────────────────────────────────────────
+
+// The MAX_RUNNING'th+1 create is refused; a landed job frees its slot.
+{
+  jobs._clear();
+  const running = Array.from({ length: jobs.MAX_RUNNING }, () => jobs.create(T0)!);
+  assert.equal(running.length, jobs.MAX_RUNNING);
+  assert.equal(jobs.create(T0), null, 'cap refuses another concurrent run');
+  jobs.complete(running[0]!.id, RESULT, T0 + 1000);
+  assert.ok(jobs.create(T0 + 2000), 'a landed job frees its slot');
+}
+
+console.log('playlist-jobs tests passed');

--- a/controller/src/music/playlist-jobs.ts
+++ b/controller/src/music/playlist-jobs.ts
@@ -1,0 +1,89 @@
+// In-memory job store for the playlist builder's async generation flow.
+//
+// POST /playlists/generate/jobs starts a run and returns immediately;
+// GET /playlists/generate/jobs/:id polls until it lands. This exists because a
+// generation legitimately runs for minutes (pool building plus one LLM curation
+// call), which outlives Cloudflare's ~100s proxy timeout — the synchronous
+// endpoint 524s into an HTML error page while the controller keeps working,
+// and WebKit surfaces that page to the operator as the cryptic "The string did
+// not match the expected pattern".
+//
+// Jobs are process-local: a controller restart forgets them, and the panel's
+// poller reports the vanished job as "start again". Sweeping is lazy (on every
+// create/get) so the store never holds a timer open.
+
+import { randomUUID } from 'node:crypto';
+import type { GenerateResult } from './playlist-gen.js';
+
+export type JobStatus = 'running' | 'done' | 'error';
+
+export interface GenerateJob {
+  id: string;
+  status: JobStatus;
+  createdAt: number;
+  finishedAt: number | null;
+  result: GenerateResult | null;
+  error: string | null;
+}
+
+// Finished jobs stay claimable this long after landing; anything older than
+// MAX_AGE_MS is dropped regardless of status, so a wedged run can't hold one
+// of the MAX_RUNNING slots forever.
+export const RESULT_TTL_MS = 10 * 60_000;
+export const MAX_AGE_MS = 30 * 60_000;
+// Each run is pool building + an LLM call — refuse to stack more than this.
+export const MAX_RUNNING = 3;
+
+const jobs = new Map<string, GenerateJob>();
+
+// Returns null when MAX_RUNNING jobs are already in flight.
+export function create(now: number = Date.now()): GenerateJob | null {
+  sweep(now);
+  let running = 0;
+  for (const job of jobs.values()) if (job.status === 'running') running++;
+  if (running >= MAX_RUNNING) return null;
+  const job: GenerateJob = {
+    id: randomUUID(),
+    status: 'running',
+    createdAt: now,
+    finishedAt: null,
+    result: null,
+    error: null,
+  };
+  jobs.set(job.id, job);
+  return job;
+}
+
+export function complete(id: string, result: GenerateResult, now: number = Date.now()): void {
+  const job = jobs.get(id);
+  if (!job || job.status !== 'running') return;
+  job.status = 'done';
+  job.result = result;
+  job.finishedAt = now;
+}
+
+export function fail(id: string, error: string, now: number = Date.now()): void {
+  const job = jobs.get(id);
+  if (!job || job.status !== 'running') return;
+  job.status = 'error';
+  job.error = error;
+  job.finishedAt = now;
+}
+
+export function get(id: string, now: number = Date.now()): GenerateJob | undefined {
+  sweep(now);
+  return jobs.get(id);
+}
+
+export function sweep(now: number = Date.now()): void {
+  for (const [id, job] of jobs) {
+    const expired = job.finishedAt !== null && now - job.finishedAt > RESULT_TTL_MS;
+    const ancient = now - job.createdAt > MAX_AGE_MS;
+    if (expired || ancient) jobs.delete(id);
+  }
+}
+
+// Test seam.
+export function _clear(): void {
+  jobs.clear();
+}

--- a/controller/src/routes/playlists.ts
+++ b/controller/src/routes/playlists.ts
@@ -8,6 +8,7 @@ import * as subsonic from '../music/subsonic.js';
 import * as library from '../music/library.js';
 import { queue } from '../broadcast/queue.js';
 import { generatePlaylist, type GenerateInput } from '../music/playlist-gen.js';
+import * as genJobs from '../music/playlist-jobs.js';
 import * as recipes from '../music/playlist-recipes.js';
 import { syncRecipe } from '../music/playlist-sync.js';
 
@@ -129,12 +130,9 @@ router.post('/playlists/:id/sync', requireAdmin, async (req, res) => {
   }
 });
 
-// POST /playlists/generate — { prompt?, seedTrackIds?, seedArtist?, knobs?,
-// sources?, excludeTrackIds? } → an UNSAVED, ordered candidate list. The
-// operator edits it, then saves via POST /playlists. Never mutates Navidrome.
-router.post('/playlists/generate', requireAdmin, async (req, res) => {
-  const b = req.body || {};
-  const input: GenerateInput = {
+function readGenerateInput(body: any): GenerateInput {
+  const b = body || {};
+  return {
     prompt: typeof b.prompt === 'string' ? b.prompt : undefined,
     seedTrackIds: parseIds(b.seedTrackIds),
     seedArtist: typeof b.seedArtist === 'string' ? b.seedArtist : undefined,
@@ -142,7 +140,10 @@ router.post('/playlists/generate', requireAdmin, async (req, res) => {
     sources: b.sources && typeof b.sources === 'object' ? b.sources : {},
     excludeTrackIds: parseIds(b.excludeTrackIds),
   };
-  const hasIntent = Boolean(
+}
+
+function hasGenerateIntent(input: GenerateInput): boolean {
+  return Boolean(
     input.prompt?.trim() ||
     input.seedTrackIds?.length ||
     input.seedArtist?.trim() ||
@@ -156,20 +157,65 @@ router.post('/playlists/generate', requireAdmin, async (req, res) => {
     input.knobs?.maxBpm ||
     input.knobs?.instrumentalOnly,
   );
-  if (!hasIntent) {
+}
+
+// A finished generation, shaped for the response: empty results carry the
+// "loosen the filters" hint, non-empty ones are logged.
+function finishGenerate(result: Awaited<ReturnType<typeof generatePlaylist>>) {
+  if (!result.tracks.length) {
+    return { ...result, message: 'nothing matched — try loosening the filters, removing seeds, or a broader vibe' };
+  }
+  queue.log('info', `playlist generated (${result.tracks.length} tracks, pool ${result.poolSize}${result.usedFallback ? ', deterministic fallback' : ''})`);
+  return result;
+}
+
+// POST /playlists/generate — { prompt?, seedTrackIds?, seedArtist?, knobs?,
+// sources?, excludeTrackIds? } → an UNSAVED, ordered candidate list. The
+// operator edits it, then saves via POST /playlists. Never mutates Navidrome.
+// Synchronous: the response holds until the generation lands, which can be
+// minutes — anything proxying through Cloudflare should use the jobs flow
+// below instead (CF cuts origin responses off at ~100s).
+router.post('/playlists/generate', requireAdmin, async (req, res) => {
+  const input = readGenerateInput(req.body);
+  if (!hasGenerateIntent(input)) {
     return res.status(400).json({ error: 'give a prompt, seeds, a source, or at least one knob to generate from' });
   }
   try {
-    const result = await generatePlaylist(input);
-    if (!result.tracks.length) {
-      return res.json({ ...result, message: 'nothing matched — try loosening the filters, removing seeds, or a broader vibe' });
-    }
-    queue.log('info', `playlist generated (${result.tracks.length} tracks, pool ${result.poolSize}${result.usedFallback ? ', deterministic fallback' : ''})`);
-    res.json(result);
+    res.json(finishGenerate(await generatePlaylist(input)));
   } catch (err: any) {
     queue.log('error', `playlist generate failed: ${err.message}`);
     res.status(500).json({ error: err.message });
   }
+});
+
+// POST /playlists/generate/jobs — same body as /generate, returns { jobId }
+// immediately; the run continues server-side. Poll the job to collect it.
+router.post('/playlists/generate/jobs', requireAdmin, (req, res) => {
+  const input = readGenerateInput(req.body);
+  if (!hasGenerateIntent(input)) {
+    return res.status(400).json({ error: 'give a prompt, seeds, a source, or at least one knob to generate from' });
+  }
+  const job = genJobs.create();
+  if (!job) return res.status(429).json({ error: 'too many generations already running — collect or wait for one first' });
+  generatePlaylist(input).then(
+    (result) => genJobs.complete(job.id, finishGenerate(result)),
+    (err: any) => {
+      queue.log('error', `playlist generate failed: ${err.message}`);
+      genJobs.fail(job.id, err.message);
+    },
+  );
+  res.status(202).json({ jobId: job.id });
+});
+
+// GET /playlists/generate/jobs/:id — { status: 'running' } | { status: 'done',
+// result } | { status: 'error', error }. 404 once expired (or after a
+// controller restart — the store is in-memory).
+router.get('/playlists/generate/jobs/:id', requireAdmin, (req, res) => {
+  const job = genJobs.get(req.params.id);
+  if (!job) return res.status(404).json({ error: 'unknown or expired generation job — start a new one' });
+  if (job.status === 'running') return res.json({ status: 'running' });
+  if (job.status === 'error') return res.json({ status: 'error', error: job.error || 'generation failed' });
+  res.json({ status: 'done', result: job.result });
 });
 
 // POST /playlists/:id/tracks — { songIds } → append.

--- a/web/components/admin/PlaylistBuilderPanel.tsx
+++ b/web/components/admin/PlaylistBuilderPanel.tsx
@@ -128,6 +128,74 @@ function relTime(iso: string): string {
   if (d < 30) return `${d}d ago`;
   return new Date(iso).toLocaleDateString();
 }
+// ── generation over a server-side job ────────────────────────────────────────
+// A generation legitimately runs for minutes, and Cloudflare cuts proxied
+// responses off at ~100s with an HTML error page — so the panel starts a job
+// (POST /playlists/generate/jobs) and polls it instead of holding one request
+// open. Bodies are also never parsed before checking they ARE JSON: WebKit
+// reports r.json() on that HTML page as the baffling "The string did not
+// match the expected pattern".
+
+type AdminFetch = (path: string, init?: RequestInit) => Promise<Response>;
+
+async function readJsonSafe(r: Response): Promise<any> {
+  const ct = r.headers.get('content-type') || '';
+  if (!ct.includes('application/json')) {
+    throw new Error(`the curation service returned an unexpected response (HTTP ${r.status}) — is the controller reachable?`);
+  }
+  try {
+    return await r.json();
+  } catch {
+    throw new Error(`the curation service returned malformed JSON (HTTP ${r.status})`);
+  }
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const GEN_POLL_MS = 2000;
+const GEN_DEADLINE_MS = 10 * 60_000;
+const GEN_POLL_MISSES = 3; // consecutive transient poll failures tolerated
+
+// Resolves with the GenerateResult payload, throws with an operator-readable
+// message otherwise.
+async function runGenerationJob(adminFetch: AdminFetch, body: unknown): Promise<any> {
+  const init: RequestInit = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+  const start = await adminFetch('/playlists/generate/jobs', init);
+  // A pre-jobs controller 404s here (mid-upgrade version skew) — fall back to
+  // the synchronous endpoint rather than failing the click.
+  if (start.status === 404) {
+    const r = await adminFetch('/playlists/generate', init);
+    const j = await readJsonSafe(r);
+    if (!r.ok) throw new Error(j.error || 'generation failed');
+    return j;
+  }
+  const started = await readJsonSafe(start);
+  if (!start.ok || !started.jobId) throw new Error(started.error || 'generation failed to start');
+  const deadline = Date.now() + GEN_DEADLINE_MS;
+  let misses = 0;
+  while (Date.now() < deadline) {
+    await sleep(GEN_POLL_MS);
+    let poll: any;
+    try {
+      const r = await adminFetch(`/playlists/generate/jobs/${started.jobId}`);
+      poll = await readJsonSafe(r);
+      if (!r.ok) throw new Error(poll.error || `poll failed (HTTP ${r.status})`);
+    } catch (err) {
+      if (++misses >= GEN_POLL_MISSES) throw err instanceof Error ? err : new Error('lost contact with the curation service');
+      continue;
+    }
+    misses = 0;
+    if (poll.status === 'running') continue;
+    if (poll.status === 'error') throw new Error(poll.error || 'generation failed');
+    return poll.result || {};
+  }
+  throw new Error('generation is taking unusually long — it may still land server-side; try again in a minute');
+}
+
 const energyPct = (e?: string | null): number => (e === 'low' ? 34 : e === 'high' ? 92 : 64);
 const energyColor = (e?: string | null): string => (e === 'low' ? EN_LOW : e === 'high' ? EN_HIGH : EN_MED);
 const energyBgClass = (e?: string | null): string => (e === 'low' ? EN_LOW_BG : e === 'high' ? EN_HIGH_BG : EN_MED_BG);
@@ -547,18 +615,7 @@ export default function PlaylistBuilderPanel() {
     const exclude = mode === 'fresh' ? [] : tracks.map(t => t.id);
     setView('generating');
     try {
-      const r = await adminFetch('/playlists/generate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(buildBody(exclude)),
-      });
-      const j = await r.json();
-      if (!r.ok) {
-        setErrorMsg(j.error || 'generation failed');
-        setView(mode === 'more' && tracks.length ? 'result' : 'error');
-        if (mode === 'more' && tracks.length) flash(j.error || 'could not fetch more');
-        return;
-      }
+      const j = await runGenerationJob(adminFetch, buildBody(exclude));
       const got: DraftTrack[] = j.tracks || [];
       if (!got.length) {
         setView(mode === 'more' && tracks.length ? 'result' : 'nomatch');
@@ -582,8 +639,10 @@ export default function PlaylistBuilderPanel() {
       }
       setView('result');
     } catch (err) {
-      setErrorMsg(err instanceof Error ? err.message : 'generation failed');
+      const msg = err instanceof Error ? err.message : 'generation failed';
+      setErrorMsg(msg);
       setView(mode === 'more' && tracks.length ? 'result' : 'error');
+      if (mode === 'more' && tracks.length) flash(msg);
     } finally {
       generatingRef.current = false;
     }


### PR DESCRIPTION
## The bug

Generate in the playlist builder appeared to hang for ~100s and then failed with *"The string did not match the expected pattern. Your recipe is untouched. Try again in a moment."* (Safari/iOS).

Root cause, verified on the production droplet:

- A generation legitimately runs for minutes — **181.9s measured** for a 25-track run direct against the controller (pool building + one LLM curation call).
- `www.getsubwave.com` is Cloudflare-proxied, and CF cuts origin responses off at ~100s, returning an **HTML 524 error page**. The cap isn't configurable below Enterprise.
- `PlaylistBuilderPanel.generate()` called `await r.json()` **before** checking `r.ok`; WebKit reports parsing that HTML page as *"The string did not match the expected pattern"*, which the error toast rendered verbatim. The controller meanwhile finished the playlist into the void (orphan `playlist generated` log lines with no client left to receive them).

## The fix

**Controller** — generation becomes a server-side job:
- `POST /playlists/generate/jobs` → `202 { jobId }` immediately (same body + intent validation as `/generate`).
- `GET /playlists/generate/jobs/:id` → `{status: 'running'} | {status: 'done', result} | {status: 'error', error}`, `404` once expired.
- Backed by `music/playlist-jobs.ts`: in-memory, lazy TTL sweep (results claimable 10 min, hard 30-min age cap so a wedged run frees its slot), max 3 concurrent runs (each is an LLM call). Pinned by `scripts/playlist-jobs.test.ts`.
- The synchronous `POST /playlists/generate` is unchanged for compat.

**Web** — `PlaylistBuilderPanel`:
- Starts the job and polls every 2s (10-min deadline, 3 consecutive transient poll failures tolerated). Every request path is now well under CF's limit.
- Falls back to the synchronous endpoint if the controller predates the jobs routes (mid-upgrade skew).
- `readJsonSafe()` checks content-type before parsing anywhere in the flow, so a dead or proxied-out controller reads as *"the curation service returned an unexpected response (HTTP 524)"* instead of the WebKit parse error.

## Testing

- `controller`: `npm run lint` clean, `tsx scripts/playlist-jobs.test.ts` passes (lifecycle, first-landing-wins, TTL sweep, wedged-job expiry, concurrency cap).
- `web`: `npm run lint` clean.
- Live against the dev stack: `POST …/jobs` returns 202 in 12ms; polling lands `{status: "done", result}`; unknown job → 404 JSON; empty intent → 400 JSON; sync endpoint still 200s.