### PR TITLE
fix(admin): make every admin screen work on a phone

### DIFF
--- a/web/components/ThemeSwitcher.tsx
+++ b/web/components/ThemeSwitcher.tsx
@@ -87,7 +87,12 @@ export default function ThemeSwitcher({ variant = 'player' }: ThemeSwitcherProps
           title="Appearance"
           className={cn(
             'v3-focus inline-flex shrink-0 cursor-pointer items-center justify-center border-0 bg-transparent p-0 leading-none',
-            variant === 'admin' ? 'caption text-muted' : 'text-muted hover:text-ink',
+            // The admin header packs this next to several other icon-only
+            // controls, so it needs a thumb-sized box on a phone; the dense
+            // desktop icon returns at sm. Player chrome is untouched.
+            variant === 'admin'
+              ? 'caption min-h-9 min-w-9 text-muted sm:min-h-0 sm:min-w-0'
+              : 'text-muted hover:text-ink',
           )}
         >
           <Palette className="h-4 w-4" aria-hidden="true" />

--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -776,7 +776,9 @@ function TopBar({ pathname }: { pathname: string | null }) {
 
   return (
     <header className="sticky top-0 z-20 flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-ink bg-[var(--card-bg)] px-4 py-2.5 sm:px-6">
-      <SidebarTrigger className="-ml-1 shrink-0" />
+      {/* Roomier hit box on a phone, where this is the only way back to the
+          nav; the dense desktop button returns at sm. */}
+      <SidebarTrigger className="-ml-1 size-9 shrink-0 sm:size-7" />
       <Separator orientation="vertical" className="hidden h-5 sm:block" />
       {/* Breadcrumb text is hidden on mobile — space is tight next to the
           hamburger, and the current page is already obvious from the drawer. */}
@@ -821,7 +823,7 @@ function TopBar({ pathname }: { pathname: string | null }) {
         <span className="h-4 w-px bg-separator-strong" />
         <Link
           href="/admin/doctor"
-          className="inline-flex items-center gap-1.5 text-[var(--accent)] no-underline"
+          className="inline-flex min-h-9 items-center gap-1.5 text-[var(--accent)] no-underline sm:min-h-0"
           title="DJ Doc — run a station health check and get the producer's review"
         >
           <BoothBuddy mood="onair" size={16} />
@@ -833,7 +835,7 @@ function TopBar({ pathname }: { pathname: string | null }) {
             body scroll lock, so no scrollbar-compensation margin shift. */}
         <DropdownMenu modal={false}>
           <DropdownMenuTrigger
-            className="caption inline-flex cursor-pointer items-center gap-1 text-muted focus:outline-none"
+            className="caption inline-flex min-h-9 cursor-pointer items-center gap-1 text-muted focus:outline-none sm:min-h-0"
             aria-label="Listen and get the app"
             title="Listen"
           >

--- a/web/components/admin/AiFill.tsx
+++ b/web/components/admin/AiFill.tsx
@@ -77,11 +77,17 @@ export function AiFill<T = unknown>({
           if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') generate();
         }}
       />
-      <div className="flex items-center gap-3">
+      {/* Wraps so a long generator error drops under the button on a phone
+          rather than squeezing it or running past the panel edge. */}
+      <div className="flex flex-wrap items-center gap-3">
         <Btn tone="accent" sm onClick={generate} disabled={busy || disabled || !desc.trim()}>
           {busy ? 'Generating…' : 'Generate'}
         </Btn>
-        {err && <span role="alert" className="text-[12px] text-destructive">{err}</span>}
+        {err && (
+          <span role="alert" className="min-w-0 text-[12px] break-words text-destructive">
+            {err}
+          </span>
+        )}
       </div>
     </div>
   );

--- a/web/components/admin/ArchivesPanel.tsx
+++ b/web/components/admin/ArchivesPanel.tsx
@@ -154,13 +154,13 @@ export default function ArchivesPanel() {
             so keep an eye on disk if the station runs 24/7.
           </div>
         </div>
-        <div className="flex items-center gap-4 bg-[var(--ink-softer)] p-3.5">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 bg-[var(--ink-softer)] p-3.5">
           <span className="caption">{entries.length} hour{entries.length === 1 ? '' : 's'}</span>
           <span className="caption text-vermilion">{fmtSize(totalBytes)} total</span>
           <Btn
             sm
             tone="danger"
-            className="ml-auto"
+            className="ml-auto min-h-9 sm:min-h-0"
             onClick={() => setConfirmClear(true)}
             disabled={clearing || entries.length === 0}
           >
@@ -198,8 +198,8 @@ export default function ArchivesPanel() {
         >
           <ul className="divide-y divide-[var(--ink-soft)]">
             {group.items.map(e => (
-              <li key={e.path} className="flex items-center justify-between py-2">
-                <div className="flex items-center gap-3">
+              <li key={e.path} className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5 py-2">
+                <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
                   <span className="mono-num text-[13px] font-bold">{hourLabel(e.hour)}</span>
                   <span className="text-[11px] text-muted">{fmtSize(e.bytes)}</span>
                   <span className="text-[10px] text-muted">{relTime(e.mtime)} ago</span>
@@ -207,6 +207,7 @@ export default function ArchivesPanel() {
                 <Btn
                   sm
                   tone="accent"
+                  className="min-h-9 shrink-0 sm:min-h-0"
                   onClick={() => download(e.path)}
                   disabled={downloading === e.path}
                 >

--- a/web/components/admin/BackupPanel.tsx
+++ b/web/components/admin/BackupPanel.tsx
@@ -231,7 +231,7 @@ export default function BackupPanel() {
             <span className="font-bold text-vermilion">Restored:</span>{' '}
             {result.restored?.length ? result.restored.join(', ') : '(nothing)'}
             {result.requiresRestart && (
-              <div className="mt-2 flex items-center gap-2">
+              <div className="mt-2 flex flex-wrap items-center gap-2">
                 <span className="text-muted">Mixer settings changed. Restart to apply.</span>
                 <Btn sm tone="danger" onClick={restartMixer} disabled={restarting}>
                   {restarting ? 'Restarting…' : 'Restart mixer'}
@@ -274,7 +274,7 @@ export default function BackupPanel() {
           {stateDir ? (
             <>
               {' '}(the directory mounted into the container at{' '}
-              <code className="text-ink">{stateDir}</code>)
+              <code className="break-words text-ink">{stateDir}</code>)
             </>
           ) : null}
           , then <strong>Refresh</strong> and restore it here; it never travels through the proxy.
@@ -298,7 +298,13 @@ export default function BackupPanel() {
                     {fmtSize(f.size)} · {new Date(f.mtime).toLocaleString()}
                   </div>
                 </div>
-                <Btn sm tone="solid" onClick={() => pickDisk(f.name)} disabled={importing}>
+                <Btn
+                  sm
+                  tone="solid"
+                  onClick={() => pickDisk(f.name)}
+                  disabled={importing}
+                  className="shrink-0"
+                >
                   {importing && pending?.kind === 'disk' && pending.name === f.name
                     ? 'Restoring…'
                     : 'Restore'}

--- a/web/components/admin/DashPanel.tsx
+++ b/web/components/admin/DashPanel.tsx
@@ -643,7 +643,7 @@ export default function DashPanel() {
                   not part of the live queue read. */}
               {history.length > 0 && (
                 <QueueSection defaultOpen={false} className="border-t border-separator-strong">
-                  <QueueSectionTrigger className="rounded-none bg-transparent px-1.5 py-2 text-[9px] font-bold tracking-[0.2em] text-muted uppercase hover:bg-[var(--overlay)] hover:text-ink">
+                  <QueueSectionTrigger className="min-h-9 rounded-none bg-transparent px-1.5 py-2 text-[9px] font-bold tracking-[0.2em] text-muted uppercase hover:bg-[var(--overlay)] hover:text-ink sm:min-h-0">
                     <QueueSectionLabel
                       count={history.length}
                       label="recently played"
@@ -746,7 +746,9 @@ export default function DashPanel() {
                         setSayText(text);
                         setSayMode('styled');
                       }}
-                      className="h-auto rounded-none border-separator-strong px-2 py-[3px] text-[9px] font-medium tracking-[0.04em] text-muted normal-case hover:bg-[var(--overlay)] hover:text-ink"
+                      // min-h-9 gives the chip a thumb-sized target on a
+                      // phone; sm: drops back to the dense desktop pill.
+                      className="h-auto min-h-9 rounded-none border-separator-strong px-3 py-[3px] text-[9px] font-medium tracking-[0.04em] text-muted normal-case hover:bg-[var(--overlay)] hover:text-ink sm:min-h-0 sm:px-2"
                     />
                   ))}
                 </Suggestions>
@@ -757,7 +759,7 @@ export default function DashPanel() {
                 disabled={sayGenBusy}
                 title="New prompts — written by the station LLM for right now"
                 aria-label="Generate new prompts"
-                className="shrink-0 border border-separator-strong p-[5px] text-muted transition-colors hover:bg-[var(--overlay)] hover:text-ink disabled:pointer-events-none disabled:opacity-60"
+                className="shrink-0 border border-separator-strong p-3 text-muted transition-colors hover:bg-[var(--overlay)] hover:text-ink disabled:pointer-events-none disabled:opacity-60 sm:p-[5px]"
               >
                 <RefreshCw className={cn('h-3 w-3', sayGenBusy && 'animate-spin')} />
               </button>
@@ -807,7 +809,9 @@ export default function DashPanel() {
           </Card>
 
           <Card title="DJ segments" sub="fire on demand">
-            <div className="grid grid-cols-3 gap-2">
+            {/* 2-up on a phone so each cart pad keeps a full-width label
+                (and a 4th "banter" pad squares off rather than dangling). */}
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
               {[...SEGMENTS, ...((status?.activeShow?.guests?.length ?? 0) > 0 ? [BANTER_SEGMENT] : [])].map(s => {
                 const k = `seg:${s.type}`;
                 return (
@@ -870,7 +874,7 @@ export default function DashPanel() {
           ) : conns && conns.connections.length > 0 ? (
             <button
               type="button"
-              className="text-[9px] font-bold tracking-[0.2em] text-muted uppercase hover:text-ink"
+              className="inline-flex min-h-9 items-center text-[9px] font-bold tracking-[0.2em] text-muted uppercase hover:text-ink sm:min-h-0"
               onClick={() => setRevealIps(v => !v)}
             >
               {revealIps ? 'hide IPs' : 'show IPs'}
@@ -890,7 +894,15 @@ export default function DashPanel() {
               <thead>
                 <tr className="text-left text-[9px] tracking-[0.2em] text-muted uppercase">
                   <SortableTh label="IP" col="ip" sort={sort} onSort={setSort} className="pr-3" />
-                  <SortableTh label="Mount" col="mount" sort={sort} onSort={setSort} className="pr-3" />
+                  {/* Mount is the least useful of the four on a phone — the
+                      remaining three fit 390px without a sideways scroll. */}
+                  <SortableTh
+                    label="Mount"
+                    col="mount"
+                    sort={sort}
+                    onSort={setSort}
+                    className="hidden pr-3 sm:table-cell"
+                  />
                   <SortableTh
                     label="Connected"
                     col="connectedSeconds"
@@ -910,11 +922,13 @@ export default function DashPanel() {
                     <td className="py-1.5 pr-3 font-mono whitespace-nowrap" title={c.ip}>
                       {revealIps ? c.ip || '—' : maskIp(c.ip)}
                     </td>
-                    <td className="py-1.5 pr-3 whitespace-nowrap text-muted">{c.mount}</td>
+                    <td className="hidden py-1.5 pr-3 whitespace-nowrap text-muted sm:table-cell">
+                      {c.mount}
+                    </td>
                     <td className="py-1.5 pr-3 whitespace-nowrap">
                       {fmtConnected(c.connectedSeconds)}
                     </td>
-                    <td className="max-w-[360px] truncate py-1.5" title={c.userAgent}>
+                    <td className="max-w-[150px] truncate py-1.5 sm:max-w-[360px]" title={c.userAgent}>
                       {clientLabel(c.userAgent)}
                       {c.connections && c.connections > 1 ? (
                         <span
@@ -1169,14 +1183,19 @@ function LikesCard({
                 {recent.map((l, i) => (
                   <div
                     key={`${l.likedAt ?? ''}:${i}`}
-                    className="grid grid-cols-[auto_1fr_auto_auto] items-center gap-2.5 text-[12px]"
+                    // Four columns don't leave the title anything to truncate
+                    // into at 390px — the anonymous handle drops on mobile.
+                    className="grid grid-cols-[auto_1fr_auto] items-center gap-2.5 text-[12px] sm:grid-cols-[auto_1fr_auto_auto]"
                   >
                     <span className="font-bold text-vermilion">♥</span>
                     <span className="min-w-0 truncate">
                       {l.title || '—'}
                       {l.artist && <span className="text-muted"> — {l.artist}</span>}
                     </span>
-                    <span className="caption text-[10px]" title="anonymous listener handle">
+                    <span
+                      className="caption hidden text-[10px] sm:inline"
+                      title="anonymous listener handle"
+                    >
                       {l.listener || ''}
                     </span>
                     <span className="mono-num text-[10px] text-muted">
@@ -1208,7 +1227,9 @@ function RequestRow({ r, tz, locale }: { r: RequestEntry; tz?: string; locale?: 
 
   return (
     <details className="border border-separator-strong">
-      <summary className="grid cursor-pointer grid-cols-[auto_1fr_auto_auto] items-center gap-2.5 px-2.5 py-2">
+      {/* The resolve time is diagnostic detail — it drops on a phone so the
+          requester + request text keep a usable truncation width. */}
+      <summary className="grid cursor-pointer grid-cols-[auto_1fr_auto] items-center gap-2.5 px-2.5 py-2 sm:grid-cols-[auto_1fr_auto_auto]">
         <span className={cn('font-bold', ok ? 'text-vermilion' : 'text-[var(--danger)]')}>
           {ok ? '✓' : '✗'}
         </span>
@@ -1216,7 +1237,9 @@ function RequestRow({ r, tz, locale }: { r: RequestEntry; tz?: string; locale?: 
           <span className="font-bold">{r.requester || 'anon'}</span>
           <span className="text-muted"> · {oneLine(r.text)}</span>
         </span>
-        <span className="caption text-[10px]">{r.ms != null ? `${r.ms}ms` : ''}</span>
+        <span className="caption hidden text-[10px] sm:inline">
+          {r.ms != null ? `${r.ms}ms` : ''}
+        </span>
         <span className="mono-num text-[10px] text-muted">
           {fmtClock(r.t, tz, locale) || '—'}
         </span>

--- a/web/components/admin/DebugPanel.tsx
+++ b/web/components/admin/DebugPanel.tsx
@@ -446,7 +446,7 @@ export default function DebugPanel() {
             className="flex h-[440px] flex-col"
             bodyClass="flex flex-1 flex-col min-h-0"
             right={
-              <Label className="flex cursor-pointer items-center gap-1.5 text-[10px] tracking-[0.18em] text-muted uppercase">
+              <Label className="flex min-h-9 cursor-pointer items-center gap-1.5 text-[10px] tracking-[0.18em] text-muted uppercase sm:min-h-0">
                 <Checkbox
                   checked={autoScroll}
                   onCheckedChange={v => setAutoScroll(v === true)}
@@ -707,13 +707,17 @@ function TtsCallList({ calls }: { calls: TtsCall[] }) {
         )}
         {shown.map((c, i) => (
           <details key={i} className="border border-separator-strong">
-            <summary className="grid cursor-pointer grid-cols-[auto_auto_1fr_auto_auto] items-center gap-2.5 px-2.5 py-2">
+            {/* minmax(0,1fr) (not a bare 1fr): an unbroken kind/preview word
+                would otherwise set the track's min-content floor and push the
+                trailing ms/clock cells out past the card's clipped edge on a
+                phone. */}
+            <summary className="grid cursor-pointer grid-cols-[auto_auto_minmax(0,1fr)_auto_auto] items-center gap-2 px-2.5 py-2 sm:gap-2.5">
               <span className={cn('font-bold', c.ok ? 'text-vermilion' : 'text-[var(--danger)]')}>
                 {c.ok ? '✓' : '✗'}
               </span>
-              <span className="grid leading-tight">
-                <span className="text-[12px] font-bold">{c.kind}</span>
-                <span className={cn('text-[10px]', c.fellBack ? 'text-[var(--danger)]' : 'text-muted')}>
+              <span className="grid min-w-0 leading-tight">
+                <span className="truncate text-[12px] font-bold">{c.kind}</span>
+                <span className={cn('truncate text-[10px]', c.fellBack ? 'text-[var(--danger)]' : 'text-muted')}>
                   {c.engine}
                 </span>
               </span>
@@ -887,11 +891,11 @@ function MountsTable({ mounts }: { mounts?: DebugMounts }) {
       <div className="grid gap-1.5">
         <div className="field-hint tracking-wide uppercase">Listen mounts</div>
         {mounts.list.map(m => (
-          <div key={m.path} className="flex items-center justify-between gap-3 text-[12px]">
-            <span className="flex items-center gap-2">
+          <div key={m.path} className="flex flex-wrap items-center justify-between gap-x-3 gap-y-0.5 text-[12px]">
+            <span className="flex min-w-0 items-center gap-2">
               <MountStatus m={m} />
               <span className="font-medium">{m.codec}</span>
-              <code className="text-[11px] text-muted">{m.path}</code>
+              <code className="truncate text-[11px] text-muted">{m.path}</code>
             </span>
             <span className="text-right text-[11px] text-muted">
               {m.live
@@ -1233,7 +1237,9 @@ function FilterChip({ active, onClick, children }: FilterChipProps) {
       type="button"
       onClick={onClick}
       className={cn(
-        'cursor-pointer border border-separator-strong px-2 py-0.5 text-[10px] tracking-[0.08em] uppercase',
+        // Comfortable 36px target on a phone; from sm: up it collapses back to
+        // the original dense inline-block chip.
+        'inline-flex min-h-9 cursor-pointer items-center border border-separator-strong px-2 py-0.5 text-[10px] tracking-[0.08em] uppercase sm:inline-block sm:min-h-0',
         active ? 'bg-vermilion text-bg' : 'bg-transparent text-muted',
       )}
     >
@@ -1291,7 +1297,7 @@ function LlmCalls({ llm }: { llm: DebugLlm | undefined }) {
       {/* Raw-request capture — writes the last N exact request bodies to a file
           operators can open. Toggle here, or set LLM_DEBUG_RAW in the env. */}
       <div className="mb-2 grid gap-1 border border-separator-strong p-2.5">
-        <Label className="flex cursor-pointer items-center gap-2 text-[11px] tracking-[0.12em] text-muted uppercase">
+        <Label className="flex min-h-9 cursor-pointer flex-wrap items-center gap-2 text-[11px] tracking-[0.12em] text-muted uppercase sm:min-h-0">
           <Checkbox
             checked={enabled}
             disabled={viaEnv}
@@ -1320,12 +1326,16 @@ function LlmCalls({ llm }: { llm: DebugLlm | undefined }) {
                 i === 0 && filter === 'all' ? 'bg-[var(--ink-softer)]' : 'bg-transparent',
               )}
             >
-              <summary className="grid cursor-pointer grid-cols-[auto_1fr_auto_auto_auto] items-center gap-2.5 px-2.5 py-2">
+              {/* minmax(0,1fr) + truncate: `djAgentSegment` is one unbroken
+                  word, and a bare 1fr track would take its min-content width
+                  and shove the ms/clock cells off the card's clipped right
+                  edge at phone widths. */}
+              <summary className="grid cursor-pointer grid-cols-[auto_minmax(0,1fr)_auto_auto_auto] items-center gap-2 px-2.5 py-2 sm:gap-2.5">
                 <span className={cn('font-bold', c.ok ? 'text-vermilion' : 'text-[var(--danger)]')}>
                   {c.ok ? '✓' : '✗'}
                 </span>
-                <span className="text-[12px] font-bold">{c.kind}</span>
-                <span className="caption text-[10px]">
+                <span className="truncate text-[12px] font-bold">{c.kind}</span>
+                <span className="caption text-[10px] whitespace-nowrap">
                   {c.toolCalls?.length ? `🔧 ${c.toolCalls.length}` : ''}
                   {c.steps != null ? `${c.toolCalls?.length ? ' · ' : ''}${c.steps} steps` : ''}
                 </span>
@@ -1455,12 +1465,12 @@ function SubsonicCalls({ subsonic }: { subsonic: DebugSubsonic | undefined }) {
               )}
               {shown.map((c, i) => (
                 <details key={i} className="border border-separator-strong">
-                  <summary className="grid cursor-pointer grid-cols-[auto_1fr_auto_auto_auto] items-center gap-2.5 px-2.5 py-2">
+                  <summary className="grid cursor-pointer grid-cols-[auto_minmax(0,1fr)_auto_auto_auto] items-center gap-2 px-2.5 py-2 sm:gap-2.5">
                     <span className={cn('font-bold', c.ok ? 'text-vermilion' : 'text-[var(--danger)]')}>
                       {c.ok ? '✓' : '✗'}
                     </span>
-                    <span className="text-[12px] font-bold">{c.endpoint}</span>
-                    <span className="caption text-[10px]">{c.count} results</span>
+                    <span className="truncate text-[12px] font-bold">{c.endpoint}</span>
+                    <span className="caption text-[10px] whitespace-nowrap">{c.count} results</span>
                     <span className="mono-num text-[11px] text-muted">{c.ms}ms</span>
                     <span className="mono-num text-[10px] text-muted">
                       {c.t ? new Date(c.t).toLocaleTimeString('en-GB', { hour12: false }) : '—'}

--- a/web/components/admin/DoctorPanel.tsx
+++ b/web/components/admin/DoctorPanel.tsx
@@ -598,7 +598,12 @@ export default function DoctorPanel() {
                       >
                         <StatusPill status={f.status} />
                         <span className="font-bold">{f.label}</span>
-                        {f.detail && <span className="font-mono text-[12px] text-muted">{f.detail}</span>}
+                        {/* Details are machine values — model ids, paths, URLs
+                            with no break opportunity. Let them wrap rather than
+                            run past the card's clipped edge on a phone. */}
+                        {f.detail && (
+                          <span className="min-w-0 font-mono text-[12px] break-words text-muted">{f.detail}</span>
+                        )}
                         {f.fix && (
                           <span className="ml-auto">
                             <Btn sm onClick={() => runFix(f.fix as FixAction)} disabled={busyFix === f.fix.id}>
@@ -606,7 +611,7 @@ export default function DoctorPanel() {
                             </Btn>
                           </span>
                         )}
-                        {f.hint && <p className="w-full text-[12px] leading-[1.5] text-muted">{f.hint}</p>}
+                        {f.hint && <p className="w-full text-[12px] leading-[1.5] break-words text-muted">{f.hint}</p>}
                       </TaskItem>
                     ))}
                   </TaskContent>

--- a/web/components/admin/FestivalsSection.tsx
+++ b/web/components/admin/FestivalsSection.tsx
@@ -200,7 +200,7 @@ export default function FestivalsSection() {
         sub="Dates that set a mood, marked across the year. Add your local holidays, regional celebrations, or personal landmarks — the station leans into the nearest one as it comes around."
         metrics={festivals ? [{ n: String(festivals.length), l: `date${festivals.length === 1 ? '' : 's'}`, accent: true }] : undefined}
         actions={
-          <Btn tone="accent" onClick={startAdd} disabled={festivals === null}>
+          <Btn tone="accent" className="min-h-9 sm:min-h-0" onClick={startAdd} disabled={festivals === null}>
             Add festival
           </Btn>
         }
@@ -234,12 +234,15 @@ export default function FestivalsSection() {
                       type="button"
                       disabled={busy}
                       onClick={() => startEdit(idx)}
-                      className="grid w-full cursor-pointer grid-cols-[30px_1fr_auto] items-baseline gap-x-3 px-1.5 py-2 text-left hover:bg-[var(--ink-soft)]"
+                      /* Mobile drops the mood/window facets onto a second row
+                         under the name — three columns leave the name ~170px
+                         at 390px, so long festival names lose their tail. */
+                      className="grid w-full cursor-pointer grid-cols-[30px_minmax(0,1fr)] items-baseline gap-x-3 gap-y-1 px-1.5 py-2 text-left hover:bg-[var(--ink-soft)] sm:grid-cols-[30px_1fr_auto] sm:gap-y-0"
                     >
-                      <span className="mono-num text-[12px] text-muted">
+                      <span className="mono-num col-start-1 row-start-1 text-[12px] text-muted">
                         {String(f.day).padStart(2, '0')}
                       </span>
-                      <span className="min-w-0">
+                      <span className="col-start-2 row-start-1 min-w-0">
                         <span className="flex items-baseline gap-2.5">
                           <span className="truncate text-[13px] font-bold">{f.name}</span>
                           {timings[idx]?.active ? (
@@ -258,7 +261,7 @@ export default function FestivalsSection() {
                           </span>
                         ) : null}
                       </span>
-                      <span className="flex items-baseline gap-2.5 text-[10px] tracking-[0.08em] text-muted">
+                      <span className="col-start-2 row-start-2 flex items-baseline gap-2.5 text-[10px] tracking-[0.08em] text-muted sm:col-start-3 sm:row-start-1">
                         <span>{f.mood}</span>
                         {f.windowDays ? <span className="mono-num">±{f.windowDays}d</span> : null}
                       </span>
@@ -278,19 +281,20 @@ export default function FestivalsSection() {
         sub={editIdx !== null && editing ? editing.name : undefined}
         width={520}
         footer={
-          <div className="flex w-full items-center justify-between gap-2">
+          <div className="flex w-full flex-wrap items-center justify-between gap-2">
             {editIdx !== null ? (
-              <Btn sm tone="danger" onClick={() => setConfirmDelete(editIdx)} disabled={busy}>
+              <Btn sm tone="danger" className="min-h-9 sm:min-h-0" onClick={() => setConfirmDelete(editIdx)} disabled={busy}>
                 Remove
               </Btn>
             ) : (
               <span />
             )}
             <div className="flex items-center gap-2">
-              <Btn sm onClick={cancelEdit} disabled={busy}>Cancel</Btn>
+              <Btn sm className="min-h-9 sm:min-h-0" onClick={cancelEdit} disabled={busy}>Cancel</Btn>
               <Btn
                 sm
                 tone="accent"
+                className="min-h-9 sm:min-h-0"
                 onClick={commitEdit}
                 disabled={busy || !editing?.name.trim()}
               >

--- a/web/components/admin/LibraryPanel.tsx
+++ b/web/components/admin/LibraryPanel.tsx
@@ -23,11 +23,11 @@
 // All colours come from theme tokens (the operator picks a theme in Settings),
 // so the page renders correctly under every palette — no hardcoded hex.
 
-import type { ChangeEvent, FormEvent, ReactNode } from 'react';
+import type { ChangeEvent, FormEvent, ReactNode, RefObject } from 'react';
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Search, RotateCcw, Sparkles, RefreshCw, ListPlus, ListMusic, X, Pencil, Ban,
-  Music, LayoutGrid, Tags, Telescope, ArrowRight, History,
+  Music, LayoutGrid, Tags, Telescope, ArrowRight, History, MoreVertical,
 } from 'lucide-react';
 import { useAdminAuth, ADMIN_API_URL } from '../../lib/adminAuth';
 import { notify, errorMessage } from '../../lib/notify';
@@ -1244,13 +1244,18 @@ export default function LibraryPanel() {
     recentLoading;
 
   return (
-    <div className="grid gap-5">
+    // grid-cols-1: the implicit `auto` track is sized by its items' min-content,
+    // so a doorway card's un-shrinkable copy blew the whole column (and every
+    // card stretched to it) past a phone viewport. minmax(0,1fr) caps the track.
+    <div className="grid grid-cols-1 gap-5">
       {/* Doorways — Playlists and the Observatory live inside Library now
           (pulled out of the sidebar); these are their front doors. */}
-      <div className="grid gap-3 sm:grid-cols-2">
+      <div className="grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2">
         <a
           href="/admin/playlists"
-          className="group flex items-center gap-3.5 border border-ink bg-bg p-3.5 transition-colors hover:bg-ink-soft"
+          // min-w-0: a grid item's automatic minimum is its min-content, which
+          // the nowrap/truncated blurb below would otherwise pin ~510px wide.
+          className="group flex min-w-0 items-center gap-3.5 border border-ink bg-bg p-3.5 transition-colors hover:bg-ink-soft"
         >
           <span className="grid size-9 flex-none place-items-center border border-ink bg-[var(--accent)] text-white">
             <ListMusic size={18} />
@@ -1265,7 +1270,7 @@ export default function LibraryPanel() {
         </a>
         <a
           href="/observatory"
-          className="group flex items-center gap-3.5 border border-ink bg-bg p-3.5 transition-colors hover:bg-ink-soft"
+          className="group flex min-w-0 items-center gap-3.5 border border-ink bg-bg p-3.5 transition-colors hover:bg-ink-soft"
         >
           <span className="grid size-9 flex-none place-items-center border border-ink bg-ink text-bg">
             <Telescope size={18} />
@@ -1384,8 +1389,10 @@ export default function LibraryPanel() {
                 )}
               </div>
             )}
-            <form onSubmit={runSearch} className="grid grid-cols-[1fr_auto_auto] gap-2">
-              <InputGroup>
+            {/* Phone: the query takes a full row of its own and the two buttons
+                share the row under it; from sm: the original single-row grid. */}
+            <form onSubmit={runSearch} className="grid grid-cols-[1fr_auto] gap-2 sm:grid-cols-[1fr_auto_auto]">
+              <InputGroup className="col-span-2 sm:col-span-1">
                 <InputGroupAddon><Search /></InputGroupAddon>
                 <InputGroupInput
                   // `required` only; deliberately no minLength — one-character
@@ -1463,7 +1470,7 @@ export default function LibraryPanel() {
         }
         right={
           tab === 'tracks' ? (
-            <span className="flex items-center gap-2.5">
+            <span className="flex flex-wrap items-center gap-2.5">
               <Seg
                 value={trackMode}
                 options={[
@@ -1511,7 +1518,7 @@ export default function LibraryPanel() {
       )}
 
       {tab === 'browse' && browse && browse.total > PAGE_SIZE && (
-        <div className="flex items-center justify-between text-[11px] text-muted">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 text-[11px] text-muted">
           <span className="mono-num">
             {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, browse.total)} of {num(browse.total)}
           </span>
@@ -1559,13 +1566,18 @@ function Tabs({ tab, setTab }: {
     { id: 'blocked', name: 'Blocked', sub: 'never plays', icon: <Ban size={17} /> },
   ];
   return (
-    <div className="lib-tabs">
+    // The strip is a nowrap `overflow-x:auto` scroller (globals.css). At 390px
+    // five tabs are ~700px, so only two are ever in view and the rest read as
+    // clipped. Below sm: the subtitles drop, the padding tightens and the strip
+    // wraps — three tabs a line, nothing hidden. sm: hands it all back to the
+    // CSS. (`!` because `.admin-root .lib-*` outranks a bare utility.)
+    <div className="lib-tabs !flex-wrap sm:!flex-nowrap">
       {items.map(it => (
-        <button key={it.id} type="button" className={cn('lib-tab', tab === it.id && 'on')} onClick={() => setTab(it.id)}>
+        <button key={it.id} type="button" className={cn('lib-tab !px-2.5 sm:!px-[18px]', tab === it.id && 'on')} onClick={() => setTab(it.id)}>
           {it.icon}
           <span className="min-w-0">
             <span className="lib-tab-name">{it.name}</span>
-            <span className="lib-tab-sub">{it.sub}</span>
+            <span className="lib-tab-sub !hidden sm:!block">{it.sub}</span>
           </span>
         </button>
       ))}
@@ -1694,11 +1706,14 @@ function BrowseFilters(p: BrowseFiltersProps) {
       {/* refine — genre, year and sort share a single row. They wrap together as
           a group on very narrow widths, but none ever strands on its own line. */}
       <div className="flex flex-wrap items-end gap-x-4 gap-y-4 p-4">
-        <div className="flex flex-col gap-2">
+        {/* w-full on phones: three fixed-width dropdowns can't share a 390px
+            row, and a full-width control is a better tap target. sm: restores
+            the content-width group. */}
+        <div className="flex w-full flex-col gap-2 sm:w-auto">
           <Field>
             <FieldLabel htmlFor="genre">genre</FieldLabel>
             <Select value={p.genre || '__any'} onValueChange={v => p.setGenre(v === '__any' ? '' : v)}>
-              <SelectTrigger id="genre" className="min-w-[150px]"><SelectValue placeholder="Any genre" /></SelectTrigger>
+              <SelectTrigger id="genre" className="w-full sm:min-w-[150px]"><SelectValue placeholder="Any genre" /></SelectTrigger>
               <SelectContent>
                 <SelectItem value="__any">Any genre</SelectItem>
                 {p.genreList.slice(0, 80).map(g => (
@@ -1720,11 +1735,11 @@ function BrowseFilters(p: BrowseFiltersProps) {
           </div>
         </div>
 
-        <div className="flex flex-col gap-2">
+        <div className="flex w-full flex-col gap-2 sm:w-auto">
           <Field>
             <FieldLabel htmlFor="sort">sort</FieldLabel>
             <Select value={p.sort} onValueChange={v => p.setSort(v as Sort)}>
-              <SelectTrigger id="sort" className="min-w-[170px]"><SelectValue /></SelectTrigger>
+              <SelectTrigger id="sort" className="w-full sm:min-w-[170px]"><SelectValue /></SelectTrigger>
               <SelectContent>
                 <SelectItem value="artist">Artist / album / title</SelectItem>
                 <SelectItem value="title">Title</SelectItem>
@@ -1794,19 +1809,26 @@ function TrackTable(p: TrackTableProps) {
     // Dim (don't blank) stale rows while a refetch is in flight, so filter
     // changes read as "updating" instead of silently showing old results.
     <div className={cn(p.loading && 'opacity-60 transition-opacity')}>
-      <div className="lib-colhead">
+      {/* Below sm: the 5-column grid (which ends in a fixed 150px actions track)
+          leaves the title ~60px, so header and rows lay out as a plain flex line
+          instead — checkbox · art · title · one overflow menu. `!` is needed to
+          beat `.admin-root .lib-colhead/.lib-row`; sm: hands it back to the CSS
+          grid untouched. */}
+      <div className="lib-colhead !flex sm:!grid">
         <span>
-          <input
-            type="checkbox"
-            checked={allSelected}
-            onChange={() => p.onToggleAll(p.rows)}
-            aria-label={allSelected ? 'deselect all tracks' : 'select all tracks'}
-          />
+          <label className={CHECK_HIT}>
+            <input
+              type="checkbox"
+              checked={allSelected}
+              onChange={() => p.onToggleAll(p.rows)}
+              aria-label={allSelected ? 'deselect all tracks' : 'select all tracks'}
+            />
+          </label>
         </span>
-        <span />
-        <span>title</span>
+        <span className="hidden sm:block" />
+        <span className="flex-1">title</span>
         <span className="h-tags">mood · energy</span>
-        <span />
+        <span className="hidden sm:block" />
       </div>
       {p.rows.map(t => {
         const tagged = !!(t.moods && t.moods.length > 0);
@@ -1814,15 +1836,19 @@ function TrackTable(p: TrackTableProps) {
         const dur = fmtDuration(t.duration);
         return (
           <Fragment key={t.id}>
-          <div className={cn('lib-row', p.flashId === t.id && 'flash')}>
-            <input
-              type="checkbox"
-              checked={p.selected.has(t.id)}
-              onChange={() => p.onToggleSelect(t.id)}
-              aria-label={`select ${t.title || 'track'}`}
-            />
+          <div className={cn('lib-row !flex sm:!grid', p.flashId === t.id && 'flash')}>
+            <label className={CHECK_HIT}>
+              <input
+                type="checkbox"
+                checked={p.selected.has(t.id)}
+                onChange={() => p.onToggleSelect(t.id)}
+                aria-label={`select ${t.title || 'track'}`}
+              />
+            </label>
             <Thumb track={t} />
-            <div className="min-w-0">
+            {/* flex-1 drives the phone layout; grid items ignore flex-*, so the
+                sm:+ grid column sizing is untouched. */}
+            <div className="min-w-0 flex-1">
               <div className="lib-title">{t.title || '—'}</div>
               <div className="lib-artist">{t.artist || '—'}{t.year ? ` · ${t.year}` : ''}{dur ? ` · ${dur}` : ''}</div>
               {t.album && <div className="lib-album">{t.album}</div>}
@@ -1850,13 +1876,30 @@ function TrackTable(p: TrackTableProps) {
               {t.similarity != null && <span className="lib-mtag lib-atag" title="sound match vs your description">≈ {Math.round(t.similarity * 100)}%</span>}
             </div>
             {/* icon-only action cluster — tooltips carry the verbs; the fixed
-                150px grid track keeps it aligned under the (empty) header cell */}
+                150px grid track keeps it aligned under the (empty) header cell.
+                Four 36px buttons are worth more than the title is on a phone, so
+                below sm: they collapse into the single overflow menu below and
+                each inline button hides. */}
             <div className="flex items-center justify-end gap-1.5">
-              <Btn sm onClick={() => p.onQueue(t)} disabled={!!p.queuing} title="Queue on air">
+              <RowActionsMenu
+                track={t}
+                tagged={tagged}
+                editing={editing}
+                queuing={p.queuing === t.id}
+                retagging={p.retagging === t.id}
+                blocking={p.blocking === t.id}
+                disabled={!!p.queuing || !!p.retagging || !!p.manualBusy || !!p.blocking}
+                onQueue={p.onQueue}
+                onEdit={p.onEdit}
+                onRetag={p.onRetag}
+                onBlock={p.onBlock}
+              />
+              <Btn sm className="hidden sm:inline-flex" onClick={() => p.onQueue(t)} disabled={!!p.queuing} title="Queue on air">
                 {p.queuing === t.id ? '…' : <ListPlus size={12} />}
               </Btn>
               <Btn
                 sm
+                className="hidden sm:inline-flex"
                 tone={editing ? 'accent' : undefined}
                 onClick={() => p.onEdit(t)}
                 disabled={!!p.manualBusy}
@@ -1868,6 +1911,7 @@ function TrackTable(p: TrackTableProps) {
                   be LLM-tagged on the spot (/library/retag takes the row body). */}
               <Btn
                 sm
+                className="hidden sm:inline-flex"
                 tone={p.tab === 'untagged' || !tagged ? 'accent' : 'solid'}
                 onClick={() => p.onRetag(t)}
                 disabled={!!p.retagging}
@@ -1878,6 +1922,7 @@ function TrackTable(p: TrackTableProps) {
                   : <Sparkles size={11} />}
               </Btn>
               <BlockMenu
+                className="hidden sm:block"
                 track={t}
                 busy={p.blocking === t.id}
                 disabled={!!p.blocking}
@@ -1902,42 +1947,39 @@ function TrackTable(p: TrackTableProps) {
 }
 
 // ---------------------------------------------------------------------------
-// BlockMenu — the per-row "Never play" action. A Ban button opening a small
-// scope menu (track / album / artist); the server resolves album/artist ids
-// from the track id, so the row only needs t.id. No confirm dialog — blocking
-// is one-click reversible from the Blocked tab.
+// Row disclosure plumbing, shared by BlockMenu and RowActionsMenu.
 // ---------------------------------------------------------------------------
-function BlockMenu({ track, busy, disabled, onBlock }: {
-  track: Track;
-  busy: boolean;
-  disabled: boolean;
-  onBlock: (t: Track, type: BlockType) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const rootRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const pick = (type: BlockType) => { setOpen(false); onBlock(track, type); };
+// Padded label wrapper around a row checkbox: the native box stays 13px, but the
+// negative margin cancels the padding so the ~37px touch target costs the layout
+// nothing. Reset at sm:, where the box sits in a 16px grid column.
+const CHECK_HIT = '-m-3 flex cursor-pointer items-center p-3 sm:m-0 sm:p-0';
 
-  // Dismiss on an outside pointer/touch, on focus leaving the group, or on
-  // Escape — via document listeners rather than a full-screen click-catcher
-  // div, which relies on a non-semantic clickable element with no keyboard
-  // path. `pointerdown` covers mouse, touch, and pen in one listener.
-  //
-  // The disclosed panel is deliberately a plain group of <button>s and NOT
-  // role="menu"/"menuitem": that role pair is a contract for the full menu
-  // keyboard pattern (arrow-key roving focus, Home/End, focus into the first
-  // item on open). Announcing a menu we don't implement leaves screen-reader
-  // users pressing arrow keys at something that only answers to Tab, which is
-  // worse than the plain buttons they'd otherwise get.
+// Dismiss an open disclosure on an outside pointer/touch, on focus leaving the
+// group, or on Escape — via document listeners rather than a full-screen
+// click-catcher div, which relies on a non-semantic clickable element with no
+// keyboard path. `pointerdown` covers mouse, touch, and pen in one listener.
+//
+// The disclosed panels are deliberately plain groups of <button>s and NOT
+// role="menu"/"menuitem": that role pair is a contract for the full menu
+// keyboard pattern (arrow-key roving focus, Home/End, focus into the first
+// item on open). Announcing a menu we don't implement leaves screen-reader
+// users pressing arrow keys at something that only answers to Tab, which is
+// worse than the plain buttons they'd otherwise get.
+function useDismissOnOutside(
+  open: boolean,
+  close: () => void,
+  rootRef: RefObject<HTMLDivElement | null>,
+  triggerRef: RefObject<HTMLButtonElement | null>,
+) {
   useEffect(() => {
     if (!open) return;
     const outside = (target: EventTarget | null) =>
       !!rootRef.current && !rootRef.current.contains(target as Node);
-    const onPointer = (e: PointerEvent) => { if (outside(e.target)) setOpen(false); };
-    const onFocusIn = (e: FocusEvent) => { if (outside(e.target)) setOpen(false); };
+    const onPointer = (e: PointerEvent) => { if (outside(e.target)) close(); };
+    const onFocusIn = (e: FocusEvent) => { if (outside(e.target)) close(); };
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
-      setOpen(false);
+      close();
       // Escape returns focus to the control that opened the panel, so keyboard
       // users don't get dropped back to the top of the document.
       triggerRef.current?.focus();
@@ -1950,10 +1992,118 @@ function BlockMenu({ track, busy, disabled, onBlock }: {
       document.removeEventListener('focusin', onFocusIn);
       document.removeEventListener('keydown', onKey);
     };
+    // close/refs are stable for the life of the row.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
+}
+
+// Shared popup shell + item chrome for both row menus. Items are ≥36px tall so
+// they stay thumb-sized on the phone layout that surfaces them.
+const MENU_PANEL =
+  'absolute top-full right-0 z-50 mt-1 max-w-[calc(100vw-2rem)] min-w-[220px] rounded-md border bg-popover p-1 text-popover-foreground shadow-md';
+const MENU_ITEM =
+  'flex w-full items-center gap-2 rounded px-2.5 py-2.5 text-left text-[12px] hover:bg-[var(--ink-soft)] hover:text-ink disabled:opacity-40';
+
+// ---------------------------------------------------------------------------
+// RowActionsMenu — the phone-only overflow menu. The four inline row buttons
+// (queue / edit / retag / never-play) cost ~160px, which is more than the track
+// title gets at 390px, so below sm: every action lives behind this one control
+// and the inline cluster hides. Same actions, same handlers — no mobile-only
+// behaviour, just a different affordance.
+// ---------------------------------------------------------------------------
+function RowActionsMenu({
+  track, tagged, editing, queuing, retagging, blocking, disabled, onQueue, onEdit, onRetag, onBlock,
+}: {
+  track: Track;
+  tagged: boolean;
+  editing: boolean;
+  queuing: boolean;
+  retagging: boolean;
+  blocking: boolean;
+  disabled: boolean;
+  onQueue: (t: Track) => void;
+  onEdit: (t: Track) => void;
+  onRetag: (t: Track) => void;
+  onBlock: (t: Track, type: BlockType) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const run = (fn: () => void) => { setOpen(false); fn(); };
+  useDismissOnOutside(open, () => setOpen(false), rootRef, triggerRef);
+  const busy = queuing || retagging || blocking;
 
   return (
-    <div ref={rootRef} className="relative">
+    <div ref={rootRef} className="relative sm:hidden">
+      <Btn
+        ref={triggerRef}
+        sm
+        // 36px square: this is the only row action on a phone, so it carries the
+        // whole cluster's tap target.
+        className="size-9"
+        onClick={() => setOpen(o => !o)}
+        aria-label={`actions for ${track.title || 'track'}`}
+        aria-expanded={open}
+        aria-haspopup="true"
+      >
+        {busy ? '…' : <MoreVertical size={15} />}
+      </Btn>
+      {open && (
+        <div className={MENU_PANEL}>
+          <button type="button" className={MENU_ITEM} disabled={disabled} onClick={() => run(() => onQueue(track))}>
+            <ListPlus size={13} /> Queue on air
+          </button>
+          <button type="button" className={MENU_ITEM} disabled={disabled} onClick={() => run(() => onEdit(track))}>
+            {editing ? <X size={13} /> : <Pencil size={13} />} {editing ? 'Close mood editor' : 'Edit moods'}
+          </button>
+          <button type="button" className={MENU_ITEM} disabled={disabled} onClick={() => run(() => onRetag(track))}>
+            {tagged ? <RotateCcw size={13} /> : <Sparkles size={13} />} {tagged ? 'Retag with AI' : 'Tag with AI'}
+          </button>
+          <span className="my-1 block border-t border-dashed border-separator-strong" />
+          <button type="button" className={MENU_ITEM} disabled={disabled} onClick={() => run(() => onBlock(track, 'track'))}>
+            <Ban size={13} /> Never play this track
+          </button>
+          {track.album && (
+            <button type="button" className={MENU_ITEM} disabled={disabled} onClick={() => run(() => onBlock(track, 'album'))}>
+              <Ban size={13} /> Never play this album
+            </button>
+          )}
+          {track.artist && (
+            <button type="button" className={cn(MENU_ITEM, 'items-start')} disabled={disabled} onClick={() => run(() => onBlock(track, 'artist'))}>
+              <Ban size={13} className="mt-px flex-none" />
+              <span>
+                Never play this artist
+                <span className="block text-[10px] text-muted">primary credit only — collabs filed under other artists still play</span>
+              </span>
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// BlockMenu — the per-row "Never play" action. A Ban button opening a small
+// scope menu (track / album / artist); the server resolves album/artist ids
+// from the track id, so the row only needs t.id. No confirm dialog — blocking
+// is one-click reversible from the Blocked tab.
+// ---------------------------------------------------------------------------
+function BlockMenu({ track, busy, disabled, onBlock, className }: {
+  track: Track;
+  busy: boolean;
+  disabled: boolean;
+  onBlock: (t: Track, type: BlockType) => void;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const pick = (type: BlockType) => { setOpen(false); onBlock(track, type); };
+  useDismissOnOutside(open, () => setOpen(false), rootRef, triggerRef);
+
+  return (
+    <div ref={rootRef} className={cn('relative', className)}>
       <Btn
         ref={triggerRef}
         sm
@@ -1966,7 +2116,7 @@ function BlockMenu({ track, busy, disabled, onBlock }: {
         {busy ? '…' : <Ban size={12} />}
       </Btn>
       {open && (
-        <div className="absolute top-full right-0 z-50 mt-1 min-w-[200px] rounded-md border bg-popover p-1 text-popover-foreground shadow-md">
+        <div className="absolute top-full right-0 z-50 mt-1 max-w-[calc(100vw-2rem)] min-w-[200px] rounded-md border bg-popover p-1 text-popover-foreground shadow-md">
           <button type="button" className="block w-full rounded px-2.5 py-1.5 text-left text-[12px] hover:bg-[var(--ink-soft)] hover:text-ink" onClick={() => pick('track')}>
             Never play this track
           </button>
@@ -2149,7 +2299,7 @@ function HistoryTab({ rows, total, page, setPage, loading, queuing, onQueue, onR
       </Card>
 
       {total > PAGE_SIZE && (
-        <div className="flex items-center justify-between text-[11px] text-muted">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 text-[11px] text-muted">
           <span className="mono-num">
             {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, total)} of {num(total)}
           </span>
@@ -2230,7 +2380,7 @@ function ManualTagEditor(props: {
         />
         apply to whole album{track.album ? ` “${track.album}”` : ''}
       </label>
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <Btn sm tone="accent" onClick={() => props.onSave(sel, energyVal, applyToAlbum)} disabled={busy || sel.length === 0}>
           {busy ? 'Saving…' : 'Save tags'}
         </Btn>
@@ -2268,7 +2418,7 @@ function AddToPlaylistBar({ count, playlists, busy, onAdd, onClear }: {
           {count} track{count === 1 ? '' : 's'} selected
         </span>
         <Select value={target} onValueChange={setTarget}>
-          <SelectTrigger className="min-w-[180px]" aria-label="Target playlist"><SelectValue /></SelectTrigger>
+          <SelectTrigger className="max-w-full min-w-[180px]" aria-label="Target playlist"><SelectValue /></SelectTrigger>
           <SelectContent>
             <SelectItem value="__new">New playlist…</SelectItem>
             {(playlists || []).map(p => (
@@ -2282,7 +2432,7 @@ function AddToPlaylistBar({ count, playlists, busy, onAdd, onClear }: {
           <Input
             placeholder="playlist name"
             aria-label="New playlist name"
-            className="w-48"
+            className="w-48 max-w-full"
             value={name}
             onChange={(e: ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
           />

--- a/web/components/admin/LibraryPlaylistsTab.tsx
+++ b/web/components/admin/LibraryPlaylistsTab.tsx
@@ -208,7 +208,7 @@ export default function LibraryPlaylistsTab({
       title="Playlists"
       sub={playlists ? `${rows.length} playlist${rows.length === 1 ? '' : 's'} in Navidrome` : ''}
       right={
-        <span className="flex items-center gap-1.5">
+        <span className="flex flex-wrap items-center gap-1.5">
           <Btn sm tone="accent" onClick={() => setCreating(c => !c)} disabled={busy}>
             <Plus size={11} /> New playlist
           </Btn>
@@ -224,7 +224,7 @@ export default function LibraryPlaylistsTab({
           <Input
             placeholder="playlist name"
             aria-label="New playlist name"
-            className="w-56"
+            className="w-56 max-w-full"
             value={newName}
             autoFocus
             onChange={(e: ChangeEvent<HTMLInputElement>) => setNewName(e.target.value)}
@@ -256,8 +256,8 @@ export default function LibraryPlaylistsTab({
                 aria-expanded={open}
               >
                 {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-                <span className="lib-title">{pl.name}</span>
-                <span className="text-[11px] whitespace-nowrap text-muted">
+                <span className="lib-title min-w-0">{pl.name}</span>
+                <span className="min-w-0 truncate text-[11px] text-muted">
                   {pl.songCount} track{pl.songCount === 1 ? '' : 's'}
                   {pl.durationSec ? ` · ${fmtDuration(pl.durationSec)}` : ''}
                   {pl.owner ? ` · ${pl.owner}` : ''}
@@ -283,7 +283,7 @@ export default function LibraryPlaylistsTab({
             {editId === pl.id && (
               <div className="flex flex-wrap items-center gap-3 border-t border-dashed border-separator-strong bg-[var(--ink-softer)] px-4 py-3">
                 <Input
-                  className="w-56"
+                  className="w-56 max-w-full"
                   aria-label="Playlist name"
                   value={editName}
                   autoFocus

--- a/web/components/admin/LibraryTaggingModal.tsx
+++ b/web/components/admin/LibraryTaggingModal.tsx
@@ -202,7 +202,9 @@ export default function LibraryTaggingModal(p: Props) {
         ))}
       </div>
 
-      <div className="flex flex-col gap-4 p-5">
+      {/* p-3 on phones: the Modal body already carries px-5, so the nested p-5
+          left ~275px of usable width inside a 358px dialog. */}
+      <div className="flex flex-col gap-4 p-3 sm:p-5">
         {/* Daily-token-budget caution — shown on both tabs when the day's spend
             is near (soft) or past (hard) the cap, so a run's LLM steps won't
             surprise the operator with extra spend or mid-run failures. */}
@@ -338,7 +340,7 @@ export default function LibraryTaggingModal(p: Props) {
                 </div>
               )}
             </div>
-            <div className="flex items-center justify-end gap-2.5 border-t border-dashed border-separator-strong pt-3.5">
+            <div className="flex flex-wrap items-center justify-end gap-2.5 border-t border-dashed border-separator-strong pt-3.5">
               <Btn onClick={() => p.onOpenChange(false)}>Cancel</Btn>
               <Btn tone="accent" disabled={!anyPass || p.busy} onClick={runRescan}>
                 <RefreshCw size={12} /> {passAllSelected ? 'Run full re-scan' : 'Run re-scan'}
@@ -388,7 +390,7 @@ export default function LibraryTaggingModal(p: Props) {
                 </span>
               </span>
             </button>
-            <div className="flex items-center justify-end gap-2.5 border-t border-dashed border-separator-strong pt-3.5">
+            <div className="flex flex-wrap items-center justify-end gap-2.5 border-t border-dashed border-separator-strong pt-3.5">
               <Btn onClick={() => p.onOpenChange(false)}>Cancel</Btn>
               {/* second confirmation happens in the danger dialog this opens */}
               <Btn tone="danger" disabled={!resetAck || p.busy} onClick={() => setConfirmReset(true)}>

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -561,7 +561,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
   return (
     <section className="card">
       {/* headline */}
-      <div className="border-b border-ink p-6">
+      <div className="border-b border-ink p-4 sm:p-6">
         <Eyebrow className="text-vermilion">library · tagging</Eyebrow>
         <h1 className="lib-hero-title">
           {pct != null ? (
@@ -580,7 +580,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
 
       {/* coverage — the single hero meter */}
       <div className="border-b border-ink">
-        <div className="p-6">
+        <div className="p-4 sm:p-6">
           <div className="flex flex-wrap items-baseline justify-between gap-3">
             <span className="flex items-center gap-2 text-[11px] font-bold tracking-[0.16em] text-ink uppercase">
               <Sparkles size={14} /> Mood &amp; energy tagged
@@ -667,7 +667,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
           analyze/backfill run is in flight so progress and Pause stay visible;
           manual state wins again once the run finishes. Not persisted — a
           fresh load starts collapsed, same as the log drawer. */}
-      <div className="border-b border-ink px-6 py-3.5">
+      <div className="border-b border-ink px-4 py-3.5 sm:px-6">
         <button
           type="button"
           className={cn(
@@ -687,7 +687,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
         </button>
       </div>
       {showAnalysis && (
-      <div className="flex flex-col gap-3 border-b border-ink px-6 py-4">
+      <div className="flex flex-col gap-3 border-b border-ink px-4 py-4 sm:px-6">
         <div className="flex flex-wrap items-center gap-x-3.5 gap-y-2">
           <span className="caption flex items-center gap-2">
             <Activity size={13} /> Acoustic analysis · bpm / key
@@ -962,7 +962,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
       {/* last-run failure banner — idle only; matches the embeddingStale banner's
           danger styling. 'stopped' runs (Stop / restart-kill) show nothing. */}
       {showFailBanner && (
-        <div className="mx-6 mt-6 flex flex-wrap items-center gap-x-3 gap-y-1 border border-l-[3px] border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger)_8%,transparent)] px-3 py-2 text-[11px] text-ink">
+        <div className="mx-4 mt-6 flex flex-wrap items-center gap-x-3 gap-y-1 border border-l-[3px] border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger)_8%,transparent)] px-3 py-2 text-[11px] text-ink sm:mx-6">
           <span>
             <b>The last {failModeLabel} run failed.</b>
             {lastRun?.error ? <> {lastRun.error}</> : ' Check the log for what went wrong.'}
@@ -986,8 +986,8 @@ export default function TaggingPanel(p: TaggingPanelProps) {
 
       {/* action zone — idle vs running */}
       {!running ? (
-        <div className="flex flex-wrap items-center gap-4 p-6">
-          <div className="min-w-[220px] flex-1 text-[13px]">
+        <div className="flex flex-wrap items-center gap-4 p-4 sm:p-6">
+          <div className="min-w-0 flex-1 text-[13px] sm:min-w-[220px]">
             {libraryCounting ? (
               <>Counting your library&hellip; this only takes a moment.</>
             ) : remaining != null && remaining > 0 ? (
@@ -1015,7 +1015,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
           </div>
         </div>
       ) : (
-        <div className="flex flex-col gap-3 p-6">
+        <div className="flex flex-col gap-3 p-4 sm:p-6">
           <div className="flex flex-wrap items-center justify-between gap-3.5">
             <span className="flex items-center gap-2.5 text-[13px] font-bold">
               <span className="lib-livedot" />
@@ -1103,7 +1103,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
 
       {/* last-run phase breakdown — only when idle and the child reported timings */}
       {lastTimingEntries.length > 0 && (
-        <div className="border-t border-dashed border-separator-strong px-6 py-3 text-[11px] text-muted">
+        <div className="border-t border-dashed border-separator-strong px-4 py-3 text-[11px] text-muted sm:px-6">
           <span className="font-bold text-ink">Last run</span>
           <span className="!normal-case">
             {' · '}
@@ -1115,7 +1115,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
       )}
 
       {/* footer */}
-      <div className="flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-dashed border-separator-strong px-6 py-3">
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-dashed border-separator-strong px-4 py-3 sm:px-6">
         <button
           type="button"
           className={cn(

--- a/web/components/admin/MoodsPanel.tsx
+++ b/web/components/admin/MoodsPanel.tsx
@@ -234,7 +234,14 @@ export default function MoodsPanel() {
             <ScrollArea className="max-h-[420px]">
               <div className="flex flex-col gap-2 pr-2">
                 {moods.map((m, idx) => (
-                  <div key={idx} className="flex items-center gap-2">
+                  /* Mobile: id + bin on row one, the long sound description on
+                     row two (a 160px id beside a bin left ~110px for the
+                     description at 390px). From `sm:` the three sit on one
+                     line exactly as before. */
+                  <div
+                    key={idx}
+                    className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 sm:grid-cols-[160px_minmax(0,1fr)_auto]"
+                  >
                     <Input
                       aria-label="Mood id"
                       value={m.name}
@@ -242,7 +249,7 @@ export default function MoodsPanel() {
                         (list ?? []).map((row, i) => i === idx ? { ...row, name: e.target.value } : row))}
                       placeholder="id (e.g. mellow)"
                       maxLength={40}
-                      className="max-w-[160px] min-w-0 shrink-0"
+                      className="col-start-1 row-start-1 min-w-0"
                     />
                     <Input
                       aria-label="Mood sound description"
@@ -251,12 +258,12 @@ export default function MoodsPanel() {
                         (list ?? []).map((row, i) => i === idx ? { ...row, clapPrompt: e.target.value } : row))}
                       placeholder="sound description for audio tagging (optional)"
                       maxLength={200}
-                      className="min-w-0 flex-1"
+                      className="col-span-2 col-start-1 row-start-2 min-w-0 sm:col-span-1 sm:col-start-2 sm:row-start-1"
                     />
                     <Btn
                       sm
                       title="Remove mood"
-                      className="shrink-0"
+                      className="col-start-2 row-start-1 size-9 shrink-0 sm:col-start-3 sm:size-auto"
                       onClick={() => setMoods(list => (list ?? []).filter((_, i) => i !== idx))}
                     >
                       <Trash2 size={12} />
@@ -265,8 +272,9 @@ export default function MoodsPanel() {
                 ))}
               </div>
             </ScrollArea>
-            <div className="mt-3 flex items-center gap-2">
+            <div className="mt-3 flex flex-wrap items-center gap-2">
               <Btn
+                className="min-h-9 sm:min-h-0"
                 disabled={moods.length >= MOODS_LIMIT}
                 onClick={() => setMoods(list => [...(list ?? []), { name: '', clapPrompt: '' }])}
               >
@@ -274,6 +282,7 @@ export default function MoodsPanel() {
               </Btn>
               <Btn
                 tone="accent"
+                className="min-h-9 sm:min-h-0"
                 disabled={!moodsDirty || busy === 'moods'}
                 onClick={saveMoods}
               >
@@ -290,7 +299,9 @@ export default function MoodsPanel() {
           <Card title="Time of day → mood" sub="the mood your station leans into through the day">
             <div className="grid gap-2">
               {PERIODS.map(p => (
-                <div key={p.id} className="flex items-center justify-between gap-3">
+                /* `flex-wrap` lets the select drop under the label at 390px
+                   rather than being squeezed to a few clipped characters. */
+                <div key={p.id} className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5">
                   <div className="min-w-0">
                     <span className="text-[13px] font-bold">{p.label}</span>
                     <span className="mono-num ml-2 text-[11px] text-muted">{p.hours}</span>
@@ -299,7 +310,7 @@ export default function MoodsPanel() {
                     value={schedule[p.id] || (savedMoodNames[0] ?? '')}
                     onValueChange={v => setSchedule(s => ({ ...s, [p.id]: v }))}
                   >
-                    <SelectTrigger className="max-w-[200px]" aria-label={`Mood for ${p.label}`}>
+                    <SelectTrigger className="max-w-[200px] min-w-[160px]" aria-label={`Mood for ${p.label}`}>
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -311,7 +322,7 @@ export default function MoodsPanel() {
                 </div>
               ))}
               <div className="mt-1">
-                <Btn tone="accent" disabled={!scheduleDirty || busy === 'schedule'} onClick={saveSchedule}>
+                <Btn tone="accent" className="min-h-9 sm:min-h-0" disabled={!scheduleDirty || busy === 'schedule'} onClick={saveSchedule}>
                   {busy === 'schedule' ? 'Saving…' : 'Save time-of-day moods'}
                 </Btn>
               </div>
@@ -321,13 +332,13 @@ export default function MoodsPanel() {
           <Card title="Weather → mood" sub="how live weather colours the mood — this wins over time of day">
             <div className="grid gap-2">
               {CONDITIONS.map(c => (
-                <div key={c.id} className="flex items-center justify-between gap-3">
+                <div key={c.id} className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5">
                   <span className="text-[13px] font-bold">{c.label}</span>
                   <Select
                     value={weather[c.id] ? weather[c.id] : NONE}
                     onValueChange={v => setWeather(w => ({ ...w, [c.id]: v === NONE ? '' : v }))}
                   >
-                    <SelectTrigger className="max-w-[200px]" aria-label={`Mood for ${c.label}`}>
+                    <SelectTrigger className="max-w-[200px] min-w-[160px]" aria-label={`Mood for ${c.label}`}>
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -340,7 +351,7 @@ export default function MoodsPanel() {
                 </div>
               ))}
               <div className="mt-1">
-                <Btn tone="accent" disabled={!weatherDirty || busy === 'weather'} onClick={saveWeather}>
+                <Btn tone="accent" className="min-h-9 sm:min-h-0" disabled={!weatherDirty || busy === 'weather'} onClick={saveWeather}>
                   {busy === 'weather' ? 'Saving…' : 'Save weather moods'}
                 </Btn>
               </div>
@@ -366,7 +377,16 @@ export default function MoodsPanel() {
             <ScrollArea className="max-h-[360px]">
               <div className="flex flex-col gap-2 pr-2">
                 {corrections.map((c, idx) => (
-                  <div key={idx} className="flex items-center gap-2">
+                  /* Mobile: "on air" + bin on row one, "reads as" + the spoken
+                     form on row two — two 220/260px inputs plus a label never
+                     fit the 320px a card body leaves at 390px. `sm:` puts the
+                     four back on one left-aligned line (`justify-start` is what
+                     keeps the auto tracks at content width, as the flex row
+                     was). */
+                  <div
+                    key={idx}
+                    className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 sm:grid-cols-[220px_auto_260px_auto] sm:justify-start"
+                  >
                     <Input
                       aria-label="Text on air"
                       value={c.from}
@@ -374,9 +394,9 @@ export default function MoodsPanel() {
                         list.map((row, i) => i === idx ? { ...row, from: e.target.value } : row))}
                       placeholder="text on air (e.g. GHz)"
                       maxLength={80}
-                      className="max-w-[220px] min-w-0 flex-1"
+                      className="col-span-2 col-start-1 row-start-1 min-w-0 sm:col-span-1"
                     />
-                    <span className="shrink-0 text-[11px] text-muted">reads as</span>
+                    <span className="col-start-1 row-start-2 shrink-0 text-[11px] text-muted sm:col-start-2 sm:row-start-1">reads as</span>
                     <Input
                       aria-label="Spoken form"
                       value={c.to}
@@ -384,12 +404,12 @@ export default function MoodsPanel() {
                         list.map((row, i) => i === idx ? { ...row, to: e.target.value } : row))}
                       placeholder="spoken form (e.g. gigahertz)"
                       maxLength={160}
-                      className="max-w-[260px] min-w-0 flex-1"
+                      className="col-start-2 row-start-2 min-w-0 sm:col-start-3 sm:row-start-1"
                     />
                     <Btn
                       sm
                       title="Remove correction"
-                      className="shrink-0"
+                      className="col-start-3 row-start-1 size-9 shrink-0 sm:col-start-4 sm:size-auto"
                       onClick={() => setCorrections(list => list.filter((_, i) => i !== idx))}
                     >
                       <Trash2 size={12} />
@@ -398,8 +418,9 @@ export default function MoodsPanel() {
                 ))}
               </div>
             </ScrollArea>
-            <div className="mt-3 flex items-center gap-2">
+            <div className="mt-3 flex flex-wrap items-center gap-2">
               <Btn
+                className="min-h-9 sm:min-h-0"
                 disabled={corrections.length >= 100}
                 onClick={() => setCorrections(list => [...list, { from: '', to: '' }])}
               >
@@ -407,6 +428,7 @@ export default function MoodsPanel() {
               </Btn>
               <Btn
                 tone="accent"
+                className="min-h-9 sm:min-h-0"
                 disabled={!correctionsDirty || busy === 'corrections'}
                 onClick={saveCorrections}
               >

--- a/web/components/admin/NavidromeBanner.tsx
+++ b/web/components/admin/NavidromeBanner.tsx
@@ -52,7 +52,7 @@ export default function NavidromeBanner({
   return (
     <div
       role="alert"
-      className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger)_10%,transparent)] px-7 py-2 text-[11px] text-ink"
+      className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger)_10%,transparent)] px-5 py-2 text-[11px] text-ink sm:px-7"
     >
       <AlertTriangle size={14} className="shrink-0 text-[var(--danger)]" aria-hidden="true" />
       <span>
@@ -62,7 +62,7 @@ export default function NavidromeBanner({
       </span>
       <Link
         href="/admin/settings?section=music"
-        className="ml-auto font-bold text-[var(--danger)] underline-offset-2 hover:underline"
+        className="ml-auto inline-flex min-h-9 items-center font-bold text-[var(--danger)] underline-offset-2 hover:underline sm:min-h-0"
       >
         Music source &rarr;
       </Link>

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -536,9 +536,9 @@ export default function PersonasPanel() {
                 p => p.name.trim().toLowerCase() === c.displayName.trim().toLowerCase(),
               );
               return (
-                <div key={c.slug} className="grid grid-cols-[1fr_auto] items-center gap-4 border border-ink p-3">
+                <div key={c.slug} className="grid grid-cols-1 gap-3 border border-ink p-3 sm:grid-cols-[1fr_auto] sm:items-center sm:gap-4">
                   <div>
-                    <div className="flex items-center gap-2">
+                    <div className="flex flex-wrap items-center gap-2">
                       <span className="text-[13px] font-extrabold">{c.displayName}</span>
                       <Pill className="text-[8px]">{c.frequency}</Pill>
                       {c.scriptLength !== 'concise' && <Pill className="text-[8px]">{c.scriptLength}</Pill>}
@@ -577,6 +577,7 @@ export default function PersonasPanel() {
                       <Pill tone="accent" dot>in roster</Pill>
                     ) : (
                       <Btn
+                        className="min-h-9 sm:min-h-0"
                         tone="accent"
                         onClick={() => installCommunity(c.slug)}
                         disabled={installing === c.slug || form.personas.length >= PERSONA_MAX}

--- a/web/components/admin/PlaylistBuilderPanel.tsx
+++ b/web/components/admin/PlaylistBuilderPanel.tsx
@@ -1266,13 +1266,16 @@ export default function PlaylistBuilderPanel() {
                 {/* Deck head — one title row with the toolbar, one meta strip.
                     Caveats and sync fold into the strip; the list gets the rest. */}
                 <div className="flex-none border-b border-ink px-4 pt-1.5 pb-2.5 sm:px-6">
-                  <div className="flex items-center gap-3">
+                  {/* The three deck actions eat ~185px, which leaves a 24px
+                      title field about eight characters at 390px — give the
+                      name its own line and let the actions wrap under it. */}
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
                     <input
                       value={name}
                       onChange={e => setName(e.target.value)}
                       placeholder="Untitled set"
                       aria-label="Playlist name"
-                      className="min-w-0 flex-1 border-b border-transparent bg-transparent py-0.5 font-display text-2xl font-bold tracking-[-0.01em] text-ink outline-none placeholder:text-muted/50 hover:border-separator-soft focus:border-[var(--accent)]"
+                      className="min-w-0 flex-1 basis-full border-b border-transparent bg-transparent py-0.5 font-display text-2xl font-bold tracking-[-0.01em] text-ink outline-none placeholder:text-muted/50 hover:border-separator-soft focus:border-[var(--accent)] sm:basis-0"
                     />
                     <div className="flex flex-none items-center gap-1.5">
                       <Button variant="ghost" size="sm" className="h-8" onClick={openBrowse} title="open a playlist from the music server">
@@ -1433,7 +1436,10 @@ export default function PlaylistBuilderPanel() {
                           </div>
                         )}
                       </div>
-                      <div className="flex items-center gap-2">
+                      {/* The duration/energy block beside three 30px icon
+                          buttons is ~170px wide — stacked, the trailing column
+                          costs 90px and the title keeps the rest. */}
+                      <div className="flex flex-col items-end gap-1 sm:flex-row sm:items-center sm:gap-2">
                         <div className="flex flex-col items-end gap-[3px]">
                           <span className="font-mono text-xs text-ink">{fmtDur(t.durationSec || 0)}</span>
                           <span className="flex items-center gap-[5px] font-mono text-[10px] text-muted">
@@ -1442,9 +1448,12 @@ export default function PlaylistBuilderPanel() {
                           </span>
                         </div>
                         <div className="flex items-center gap-0.5 transition-opacity lg:opacity-0 lg:group-hover:opacity-100">
-                          <IconBtn onClick={() => move(i, i - 1)} disabled={i === 0} title="Move up"><ArrowUp className="size-[15px]" /></IconBtn>
-                          <IconBtn onClick={() => move(i, i + 1)} disabled={i === tracks.length - 1} title="Move down"><ArrowDown className="size-[15px]" /></IconBtn>
-                          <IconBtn onClick={() => removeAt(i)} title="Remove"><X className="size-[15px]" /></IconBtn>
+                          {/* Reorder has no drag handle on mobile (the grip is
+                              `sm:` only), so these are the only way to move a
+                              row — size them for a thumb. */}
+                          <IconBtn className="size-9 sm:size-[30px]" onClick={() => move(i, i - 1)} disabled={i === 0} title="Move up"><ArrowUp className="size-[15px]" /></IconBtn>
+                          <IconBtn className="size-9 sm:size-[30px]" onClick={() => move(i, i + 1)} disabled={i === tracks.length - 1} title="Move down"><ArrowDown className="size-[15px]" /></IconBtn>
+                          <IconBtn className="size-9 sm:size-[30px]" onClick={() => removeAt(i)} title="Remove"><X className="size-[15px]" /></IconBtn>
                         </div>
                       </div>
                     </div>
@@ -1473,8 +1482,8 @@ export default function PlaylistBuilderPanel() {
                         <div className="text-[13px] leading-[1.5] text-muted">Type a mood on the left, optionally add seed tracks and tuning, and let the curator assemble the set.</div>
                       </div>
                     </div>
-                    <div className="flex items-center justify-between gap-3.5 border border-separator-strong p-4">
-                      <div className="flex gap-3.5">
+                    <div className="flex flex-wrap items-center justify-between gap-3.5 border border-separator-strong p-4">
+                      <div className="flex min-w-0 gap-3.5">
                         <div className="grid size-[26px] flex-none place-items-center border border-ink font-mono text-xs font-bold">2</div>
                         <div>
                           <div className="mb-0.5 text-sm font-bold">Open an existing playlist</div>
@@ -1545,7 +1554,7 @@ export default function PlaylistBuilderPanel() {
 
       {/* TOAST */}
       {toast && (
-        <div className="fixed top-[70px] right-6 z-[60] flex max-w-[340px] items-center gap-3 bg-ink px-3.5 py-3 text-bg shadow-drawer">
+        <div className="fixed top-[70px] right-4 left-4 z-[60] flex items-center gap-3 bg-ink px-3.5 py-3 text-bg shadow-drawer sm:right-6 sm:left-auto sm:max-w-[340px]">
           <span className="text-[13px] leading-[1.4]">{toast}</span>
           <button type="button" onClick={() => setToast('')} className="flex-none text-bg/70 hover:text-bg" title="dismiss">
             <X className="size-3.5" />
@@ -1711,11 +1720,11 @@ export default function PlaylistBuilderPanel() {
                 <Switch checked={saveSync} onCheckedChange={setSaveSync} aria-label="Keep in sync" />
               </div>
             </div>
-            <div className="flex items-center justify-between gap-3 border-t border-ink px-5 py-3.5">
+            <div className="flex flex-wrap items-center justify-between gap-3 border-t border-ink px-5 py-3.5">
               <span className="font-mono text-[10px] text-muted">
                 Then pin it to a show in <a href="/admin/shows" className="text-vermilion hover:text-ink">Shows</a> →
               </span>
-              <div className="flex gap-2.5">
+              <div className="flex flex-none gap-2.5">
                 <Button variant="ghost" className="h-10" onClick={() => setModal(null)}>Cancel</Button>
                 <Button variant="accent" className="h-10" disabled={saving || !saveName.trim()} onClick={doSave}>
                   {saving ? 'Saving…' : 'Save playlist'}

--- a/web/components/admin/RosterViewToggle.tsx
+++ b/web/components/admin/RosterViewToggle.tsx
@@ -21,24 +21,26 @@ export function RosterViewToggle({ view, onChange }: RosterViewToggleProps) {
       value={view}
       onChange={v => onChange(v === 'list' ? 'list' : 'cards')}
       options={[
+        // The min-height gives the icon-only tab a comfortable phone tap target
+        // (the Seg item's own padding leaves it ~30px); `sm:` puts it back.
         {
           id: 'cards',
           title: 'Card view',
           label: (
-            <>
+            <span className="flex min-h-[22px] items-center sm:min-h-0">
               <LayoutList size={15} strokeWidth={1.75} aria-hidden />
               <span className="sr-only">Cards</span>
-            </>
+            </span>
           ),
         },
         {
           id: 'list',
           title: 'List view',
           label: (
-            <>
+            <span className="flex min-h-[22px] items-center sm:min-h-0">
               <Rows3 size={15} strokeWidth={1.75} aria-hidden />
               <span className="sr-only">List</span>
-            </>
+            </span>
           ),
         },
       ]}

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -650,7 +650,9 @@ export default function SettingsPanel() {
               <Card title="Idle pause" sub="silence the programme when nobody is listening">
                 <div className="field">
                   <Label>Pause when the room is empty</Label>
-                  <div className="flex items-center gap-2">
+                  {/* Seg + "after" + minutes + "min" + Save is wider than a
+                      phone card, so the row wraps below 640px. */}
+                  <div className="flex flex-wrap items-center gap-2 sm:flex-nowrap">
                     <Seg
                       options={[
                         { id: 'on', label: 'On' },
@@ -841,7 +843,7 @@ export default function SettingsPanel() {
               <Card title="Max track length" sub="cut over-length tracks on air">
                 <div className="field">
                   <Label>Maximum track length</Label>
-                  <div className="flex items-center gap-2">
+                  <div className="flex flex-wrap items-center gap-2 sm:flex-nowrap">
                     <Input
                       className="mono-num w-28"
                       aria-label="Maximum track length (seconds)"
@@ -942,7 +944,7 @@ export default function SettingsPanel() {
                   </div>
                   <div className="field">
                     <Label>Max boost</Label>
-                    <div className="flex items-center gap-2">
+                    <div className="flex flex-wrap items-center gap-2 sm:flex-nowrap">
                       <Input
                         className="mono-num w-28"
                         aria-label="Max boost (dB)"

--- a/web/components/admin/ShowPickers.tsx
+++ b/web/components/admin/ShowPickers.tsx
@@ -81,7 +81,7 @@ export function PersonaPicker({
 }) {
   if (!personas.length) return null;
   return (
-    <div className="grid grid-cols-2 gap-2">
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
       {personas.map((p) => {
         const selected = p.id === value;
         const src = p.avatar ? `${apiBase}/persona-avatar/${encodeURIComponent(p.id)}` : null;
@@ -145,7 +145,7 @@ export function GuestPersonaPicker({
     else if (value.length < max) onChange([...value, id]);
   };
   return (
-    <div className="grid grid-cols-2 gap-2">
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
       {personas.map((p) => {
         const selected = value.includes(p.id);
         const full = !selected && value.length >= max;

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -233,7 +233,9 @@ function ChipRow({ options, selected, onToggle, cap = FILTER_VALUES_MAX }: {
             disabled={atCap}
             onClick={() => onToggle(o.key)}
             className={cn(
-              'border border-ink px-2 py-0.5 text-[12px]',
+              // Comfortable to tap on a phone; the desktop chip keeps its
+              // original padding-driven height.
+              'min-h-9 border border-ink px-2 py-0.5 text-[12px] sm:min-h-0',
               on ? 'bg-ink text-bg' : 'text-ink hover:bg-[var(--ink-soft)]',
               atCap && 'cursor-not-allowed opacity-40',
             )}
@@ -665,12 +667,12 @@ export default function ShowsPanel() {
               listing, and takeovers, hour by hour.
             </div>
           </div>
-          <div className="flex flex-none flex-col items-end gap-2.5">
+          <div className="flex flex-none flex-col items-start gap-2.5 sm:items-end">
             <div className="flex gap-4">
               <Metric n={String(scheduledHours)} l="hours scheduled" />
               <Metric n={String(168 - scheduledHours)} l="silent" accent={scheduledHours < 168} />
             </div>
-            <Button asChild variant="accent" size="sm">
+            <Button asChild variant="accent" size="sm" className="min-h-9 sm:min-h-0">
               <Link href="/admin/shows/schedule">Open the schedule →</Link>
             </Button>
           </div>
@@ -688,9 +690,15 @@ export default function ShowsPanel() {
       {/* ── SHOW DEFINITIONS ─────────────────────────────────────────────── */}
       <div className="mt-1 flex flex-wrap items-center justify-between gap-3">
         <span className="caption">show definitions · {form.shows.length}/{SHOWS_MAX} shows</span>
-        <div className="flex items-center gap-2">
-          <RosterViewToggle view={view} onChange={setView} />
+        {/* Own line on a phone: on one row with the caption the cluster runs
+            out of width and the Cards/List toggle folds into two stacked
+            icons. */}
+        <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:flex-nowrap">
+          <span className="flex-none">
+            <RosterViewToggle view={view} onChange={setView} />
+          </span>
           <Btn
+            className="min-h-9 sm:min-h-0"
             onClick={() => setCommunityOpen(true)}
             disabled={!community}
             title="Browse and install shows shared by other stations"
@@ -702,6 +710,7 @@ export default function ShowsPanel() {
           </Btn>
           <Btn
             tone="accent"
+            className="min-h-9 sm:min-h-0"
             onClick={addShow}
             disabled={form.shows.length >= SHOWS_MAX || personas.length === 0}
           >
@@ -800,12 +809,13 @@ export default function ShowsPanel() {
         sub="shows shared by other stations"
         width={640}
         footer={
-          <div className="flex w-full items-center justify-between gap-3">
-            <span className="text-[11px] leading-[1.5] text-muted">
+          <div className="flex w-full flex-wrap items-center justify-between gap-3">
+            <span className="w-full text-[11px] leading-[1.5] text-muted sm:w-auto sm:flex-1">
               Made a show worth sharing? Submit it to the community catalog — a
               maintainer reviews it, then it ships to every station.
             </span>
             <Btn
+              className="min-h-9 flex-none sm:min-h-0"
               onClick={() => window.open(showSubmitUrl(), '_blank', 'noopener,noreferrer')}
               title="Open a prefilled community submission on GitHub"
             >
@@ -831,7 +841,10 @@ export default function ShowsPanel() {
               );
               const tags = [...c.moods, ...c.genres, ...c.energies].slice(0, 6);
               return (
-                <div key={c.slug} className="grid grid-cols-[1fr_auto] items-center gap-4 border border-ink p-3">
+                <div
+                  key={c.slug}
+                  className="grid grid-cols-1 gap-3 border border-ink p-3 sm:grid-cols-[1fr_auto] sm:items-center sm:gap-4"
+                >
                   <div className="min-w-0">
                     <div className="flex flex-wrap items-center gap-2">
                       <span className="text-[13px] font-extrabold">{c.name}</span>
@@ -872,12 +885,13 @@ export default function ShowsPanel() {
                       </div>
                     )}
                   </div>
-                  <div className="flex flex-col items-end gap-2">
+                  <div className="flex flex-col items-start gap-2 sm:items-end">
                     {inShows ? (
                       <Pill tone="accent" dot>in your shows</Pill>
                     ) : (
                       <Btn
                         tone="accent"
+                        className="min-h-9 sm:min-h-0"
                         onClick={() => install(c.slug)}
                         disabled={installing === c.slug || form.shows.length >= SHOWS_MAX}
                         title={form.shows.length >= SHOWS_MAX ? 'The show list is full' : undefined}
@@ -967,17 +981,21 @@ function ShowEditor({
           {/* left — destructive action */}
           <Btn lg tone="danger" onClick={onRemove}>Remove</Btn>
           {/* right — status + close/save */}
-          <span className="ml-auto flex items-center gap-3">
-            <span
-              className={cn(
-                'size-1.5 flex-none rounded-full',
-                valid ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
-              )}
-            />
-            <span className="text-[11px] text-muted">
-              {!valid
-                ? <span className="text-[var(--danger)]">this show needs a name and a persona</span>
-                : 'saves this show · schedule it on the grid, then Save schedule'}
+          <span className="ml-auto flex w-full flex-wrap items-center gap-3 sm:w-auto sm:flex-nowrap">
+            {/* Dot + status read as one unit so they take their own line on a
+                phone instead of squeezing the message to a 90px column. */}
+            <span className="flex w-full min-w-0 items-center gap-3 sm:w-auto">
+              <span
+                className={cn(
+                  'size-1.5 flex-none rounded-full',
+                  valid ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
+                )}
+              />
+              <span className="min-w-0 text-[11px] text-muted">
+                {!valid
+                  ? <span className="text-[var(--danger)]">this show needs a name and a persona</span>
+                  : 'saves this show · schedule it on the grid, then Save schedule'}
+              </span>
             </span>
             <Btn lg onClick={onClose}>Close</Btn>
             <Btn lg tone="accent" onClick={onSave} disabled={busy || !valid}>
@@ -1173,7 +1191,7 @@ function ShowEditor({
                     key={`${e.fromYear ?? ''}-${e.toYear ?? ''}-${i}`}
                     type="button"
                     onClick={() => update({ eras: show.eras.filter(x => x !== e) })}
-                    className="border border-ink bg-ink px-2 py-0.5 text-[12px] text-bg"
+                    className="min-h-9 border border-ink bg-ink px-2 py-0.5 text-[12px] text-bg sm:min-h-0"
                     title="Remove this custom era window"
                   >
                     {eraLabelOf(e)} ×
@@ -1210,7 +1228,7 @@ function ShowEditor({
                     key={g}
                     type="button"
                     onClick={() => update({ genres: show.genres.filter(x => x !== g) })}
-                    className="border border-ink bg-ink px-2 py-0.5 text-[12px] text-bg"
+                    className="min-h-9 border border-ink bg-ink px-2 py-0.5 text-[12px] text-bg sm:min-h-0"
                     title="Remove this genre"
                   >
                     {g} ×
@@ -1218,7 +1236,7 @@ function ShowEditor({
                 ))}
               </div>
             )}
-            <div className="flex gap-2">
+            <div className="flex min-w-0 gap-2">
               <Input
                 id="show-genre"
                 type="text" value={genreDraft} maxLength={64}
@@ -1229,6 +1247,7 @@ function ShowEditor({
                 disabled={show.genres.length >= FILTER_VALUES_MAX}
               />
               <Btn
+                className="min-h-9 flex-none sm:min-h-0"
                 onClick={() => addGenre(genreDraft)}
                 disabled={!genreDraft.trim() || show.genres.length >= FILTER_VALUES_MAX}
               >

--- a/web/components/admin/ShowsTable.tsx
+++ b/web/components/admin/ShowsTable.tsx
@@ -78,7 +78,10 @@ export function ShowsTable({ rows, onEdit }: ShowsTableProps) {
     {
       key: 'name',
       label: 'Show',
-      className: 'whitespace-nowrap',
+      // Below md the Host column is hidden, so nothing carries the
+      // `w-full max-w-0` pair that lets a cell truncate instead of widening
+      // the table — the show name takes that role until Host reappears.
+      className: 'whitespace-nowrap w-full max-w-0 md:w-auto md:max-w-none',
       render: (r) => (
         // No wrapping anywhere in the row: a chip or pill dropping to a second
         // line would inflate the row height and undo the point of the list.

--- a/web/components/admin/SkillsPanel.tsx
+++ b/web/components/admin/SkillsPanel.tsx
@@ -420,13 +420,17 @@ export default function SkillsPanel() {
             Read this in the manual ↗
           </a>
         </div>
-        <div className="flex items-center gap-4 bg-[var(--ink-softer)] p-3.5">
+        {/* The action cluster is a full-width row of its own on phones — an
+            `ml-auto` cluster beside the counts is what pushed COMMUNITY / NEW
+            SKILL off the right edge at 390px. */}
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-3 bg-[var(--ink-softer)] p-3.5">
           <span className="caption">
             {filtered ? `${visible.length} of ${skills.length}` : skills.length} skill{skills.length === 1 ? '' : 's'}
           </span>
           <span className="caption text-vermilion">{enabledCount} enabled</span>
-          <div className="ml-auto flex items-center gap-2">
+          <div className="flex w-full flex-wrap items-center gap-2 sm:ml-auto sm:w-auto sm:flex-nowrap">
             <Btn
+              className="min-h-9 sm:min-h-0"
               onClick={() => setCommunityOpen(true)}
               disabled={!community}
               title="Browse and install skills shared by other stations"
@@ -436,10 +440,11 @@ export default function SkillsPanel() {
                 <span className="ml-1 text-vermilion">{community.length}</span>
               )}
             </Btn>
-            <Btn tone="accent" onClick={() => setModal({ mode: 'create' })}>
+            <Btn className="min-h-9 sm:min-h-0" tone="accent" onClick={() => setModal({ mode: 'create' })}>
               <Plus size={14} /> New skill
             </Btn>
             <Btn
+              className="min-h-9 min-w-9 sm:min-h-0 sm:min-w-0"
               onClick={rescan}
               disabled={rescanning}
               title={rescanning ? 'Rescanning state/skills…' : 'Rescan state/skills'}
@@ -453,7 +458,9 @@ export default function SkillsPanel() {
       {/* ── ORGANISE — search / filter / sort ─────────────────────────────── */}
       <section className="card p-3.5">
         <div className="flex flex-wrap items-center gap-2">
-          <div className="relative min-w-[200px] flex-1">
+          {/* Phones get the search on its own row and the selects full-width /
+              paired; `sm:` restores the single desktop row of fixed widths. */}
+          <div className="relative w-full flex-none sm:min-w-[200px] sm:flex-1">
             <Search size={14} className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-muted" />
             <Input
               value={query}
@@ -465,7 +472,7 @@ export default function SkillsPanel() {
           </div>
           {personas.length > 0 && (
             <Select value={who} onValueChange={setWho}>
-              <SelectTrigger className="w-[190px]" aria-label="Filter by DJ or show">
+              <SelectTrigger className="w-full sm:w-[190px]" aria-label="Filter by DJ or show">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -487,31 +494,36 @@ export default function SkillsPanel() {
               </SelectContent>
             </Select>
           )}
-          <Select value={status} onValueChange={v => setStatus(v as StatusFilter)}>
-            <SelectTrigger className="w-[130px]" aria-label="Filter by status">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Any status</SelectItem>
-              <SelectItem value="enabled">Enabled</SelectItem>
-              <SelectItem value="disabled">Disabled</SelectItem>
-              <SelectItem value="needs-key">Needs key</SelectItem>
-              <SelectItem value="custom">Custom</SelectItem>
-              <SelectItem value="builtin">Built-in</SelectItem>
-            </SelectContent>
-          </Select>
-          <Select value={sort} onValueChange={v => setSort(v as SortMode)}>
-            <SelectTrigger className="w-[140px]" aria-label="Sort skills">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="az">A–Z</SelectItem>
-              <SelectItem value="enabled">Enabled first</SelectItem>
-              <SelectItem value="cooldown">Cooldown</SelectItem>
-            </SelectContent>
-          </Select>
+          {/* Status + sort own one phone row between them. The wrapper is
+              `display:contents` from sm: up, so on desktop both selects are
+              direct children of the bar again and the row is unchanged. */}
+          <div className="flex w-full gap-2 sm:contents">
+            <Select value={status} onValueChange={v => setStatus(v as StatusFilter)}>
+              <SelectTrigger className="min-w-0 flex-1 sm:w-[130px] sm:flex-none" aria-label="Filter by status">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Any status</SelectItem>
+                <SelectItem value="enabled">Enabled</SelectItem>
+                <SelectItem value="disabled">Disabled</SelectItem>
+                <SelectItem value="needs-key">Needs key</SelectItem>
+                <SelectItem value="custom">Custom</SelectItem>
+                <SelectItem value="builtin">Built-in</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={sort} onValueChange={v => setSort(v as SortMode)}>
+              <SelectTrigger className="min-w-0 flex-1 sm:w-[140px] sm:flex-none" aria-label="Sort skills">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="az">A–Z</SelectItem>
+                <SelectItem value="enabled">Enabled first</SelectItem>
+                <SelectItem value="cooldown">Cooldown</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
           {filtered && (
-            <Btn onClick={clearFilters} title="Clear all filters">
+            <Btn className="min-h-9 sm:min-h-0" onClick={clearFilters} title="Clear all filters">
               <X size={14} /> Clear
             </Btn>
           )}
@@ -533,7 +545,7 @@ export default function SkillsPanel() {
                   aria-pressed={on}
                   onClick={() => setTagSel(cur => (on ? cur.filter(x => x !== t) : [...cur, t]))}
                   className={cn(
-                    'border border-ink px-2 py-0.5 text-[12px]',
+                    'min-h-9 border border-ink px-2 py-0.5 text-[12px] sm:min-h-0',
                     on ? 'bg-ink text-bg' : 'text-ink hover:bg-[var(--ink-soft)]',
                   )}
                 >
@@ -674,7 +686,7 @@ export default function SkillsPanel() {
                       type="button"
                       onClick={(e) => { e.stopPropagation(); runNow(s.name); }}
                       disabled={busy === s.name}
-                      className={cn('seg-pad seg-pad--slim', busy === s.name && 'is-firing')}
+                      className={cn('seg-pad seg-pad--slim min-h-9 sm:min-h-0', busy === s.name && 'is-firing')}
                     >
                       <span className="seg-led" aria-hidden />
                       <span className="seg-label">{busy === s.name ? 'Working…' : 'Run now'}</span>
@@ -711,8 +723,8 @@ export default function SkillsPanel() {
         sub="skills shared by other stations"
         width={640}
         footer={
-          <div className="flex w-full items-center justify-between gap-3">
-            <span className="text-[11px] leading-[1.5] text-muted">
+          <div className="flex w-full flex-wrap items-center justify-between gap-3">
+            <span className="min-w-0 flex-1 text-[11px] leading-[1.5] text-muted">
               Got a skill someone shared as a <code>.zip</code>? Import it here — it may include a
               data tool that runs code, so it arrives disabled for review.
             </span>
@@ -729,6 +741,7 @@ export default function SkillsPanel() {
               }}
             />
             <Btn
+              className="min-h-9 sm:min-h-0"
               onClick={() => fileInputRef.current?.click()}
               disabled={importing}
               title="Install a skill from a .zip bundle"
@@ -748,7 +761,7 @@ export default function SkillsPanel() {
         <div className="mt-4 grid gap-3">
           {community && community.length > 0 ? (
             community.map(c => (
-              <div key={c.slug} className="grid grid-cols-[1fr_auto] items-center gap-4 border border-ink p-3">
+              <div key={c.slug} className="grid grid-cols-1 gap-3 border border-ink p-3 sm:grid-cols-[1fr_auto] sm:items-center sm:gap-4">
                 <div>
                   <div className="flex items-center gap-2">
                     <span className="text-[13px] font-extrabold">{c.label}</span>
@@ -785,6 +798,7 @@ export default function SkillsPanel() {
                     <Pill>reserved name</Pill>
                   ) : (
                     <Btn
+                      className="min-h-9 sm:min-h-0"
                       tone="accent"
                       onClick={() => install(c.slug)}
                       disabled={installing === c.slug}

--- a/web/components/admin/StationHeader.tsx
+++ b/web/components/admin/StationHeader.tsx
@@ -313,17 +313,26 @@ export default function StationHeader({
         </div>
       </div>
 
-      {/* unified status strip */}
-      <div className="hs-strip">
+      {/* Unified status strip. Four instruments at 140–196px can't sit in one
+          390px row, so on a phone the flex rail becomes a 2-up grid and folds
+          to two rows; from sm: up it is byte-for-byte the original single row.
+          The `!` utilities are required because the `.hs-*` rules in
+          globals.css are unlayered and would otherwise outrank Tailwind's
+          utility layer regardless of specificity. Cell dividers are re-flowed
+          the same way `.strip-mobile` does it: no left rule on the cell that
+          starts row 2, a top rule on both cells of that row. */}
+      <div className="hs-strip !grid !grid-cols-2 sm:!flex">
         {/* 01 — listeners needle */}
-        <div className="hs-cell">
+        <div className="hs-cell !min-w-0 sm:!min-w-[140px]">
           <div className="hs-head">
             <div className="hs-lbl">
               <span className="idx">01</span>Listeners
             </div>
           </div>
           <svg ref={listenersSvg} className="hs-gauge" />
-          <div className="hs-read">
+          {/* Readouts wrap on a phone so the trailing peak/redline figure drops
+              to its own line instead of being clipped by the cell. */}
+          <div className="hs-read flex-wrap sm:flex-nowrap">
             <span className="hs-v" ref={listenersV}>
               0
             </span>
@@ -335,17 +344,19 @@ export default function StationHeader({
         </div>
 
         {/* 02 — DJ latency needle */}
-        <div className="hs-cell">
+        <div className="hs-cell !min-w-0 sm:!min-w-[140px]">
           <div className="hs-head">
             <div className="hs-lbl">
               <span className="idx">02</span>DJ&nbsp;Latency
             </div>
-            <div className="hs-sub" ref={zone}>
+            {/* The head's sub-label is nowrap and would squeeze the instrument
+                name to an ellipsis in a half-width cell — hidden on mobile. */}
+            <div className="hs-sub hidden sm:block" ref={zone}>
               nominal
             </div>
           </div>
           <svg ref={latencySvg} className="hs-gauge" />
-          <div className="hs-read" ref={latencyRead}>
+          <div className="hs-read flex-wrap sm:flex-nowrap" ref={latencyRead}>
             <span className="hs-v" ref={latencyV}>
               0
             </span>
@@ -357,12 +368,12 @@ export default function StationHeader({
         </div>
 
         {/* 03 — TTS fallback inverted bar */}
-        <div className="hs-cell">
+        <div className="hs-cell !min-w-0 !border-t !border-l-0 !border-t-separator-strong sm:!min-w-[140px] sm:!border-t-0 sm:!border-l">
           <div className="hs-head">
             <div className="hs-lbl">
               <span className="idx">03</span>TTS&nbsp;Fallback
             </div>
-            <div className="hs-sub">lower&nbsp;=&nbsp;better</div>
+            <div className="hs-sub hidden sm:block">lower&nbsp;=&nbsp;better</div>
           </div>
           <div className="hs-barwrap">
             <div className="hs-track">
@@ -375,7 +386,7 @@ export default function StationHeader({
               <span>100%</span>
             </div>
           </div>
-          <div className="hs-read" ref={ttsRead}>
+          <div className="hs-read flex-wrap sm:flex-nowrap" ref={ttsRead}>
             <span className="hs-v" ref={ttsV}>
               0
             </span>
@@ -384,12 +395,12 @@ export default function StationHeader({
         </div>
 
         {/* 04 — On Air pilot lamp + station context (weather · picker) */}
-        <div className="hs-cell hs-lamp">
+        <div className="hs-cell hs-lamp !min-w-0 !border-t !border-t-separator-strong sm:!min-w-[196px] sm:!border-t-0">
           <div className="hs-head">
             <div className="hs-lbl">
               <span className="idx">04</span>On&nbsp;Air
             </div>
-            <div className="hs-sub">stream</div>
+            <div className="hs-sub hidden sm:block">stream</div>
           </div>
           <div className="hs-lampbody">
             <div className={online ? 'hs-bulb hs-on' : 'hs-bulb'}>

--- a/web/components/admin/StationSwitcher.tsx
+++ b/web/components/admin/StationSwitcher.tsx
@@ -89,7 +89,7 @@ export default function StationSwitcher({ onNavigate }: { onNavigate?: () => voi
                 <span className="flex aspect-square size-8 shrink-0 items-center justify-center rounded-sm border border-ink">
                   <RadioTower className="size-4" />
                 </span>
-                <span className="grid flex-1 text-left leading-tight">
+                <span className="grid min-w-0 flex-1 text-left leading-tight">
                   <span className="truncate text-[13px] font-extrabold tracking-[0.08em] uppercase">
                     {active.name}
                   </span>
@@ -100,7 +100,9 @@ export default function StationSwitcher({ onNavigate }: { onNavigate?: () => voi
                 <ChevronsUpDown className="ml-auto size-4 opacity-60" />
               </SidebarMenuButton>
             </DropdownMenuTrigger>
-            <DropdownMenuContent side="bottom" align="start" className="min-w-[13rem]">
+            {/* A long station name would otherwise size the menu past a phone
+                viewport — cap it and let the item labels truncate. */}
+            <DropdownMenuContent side="bottom" align="start" className="max-w-[calc(100vw-2rem)] min-w-[13rem]">
               <DropdownMenuLabel>Stations</DropdownMenuLabel>
               <DropdownMenuItem disabled className="justify-between gap-2">
                 <span className="truncate">{active.name}</span>

--- a/web/components/admin/StationsPanel.tsx
+++ b/web/components/admin/StationsPanel.tsx
@@ -297,7 +297,7 @@ export default function StationsPanel() {
           <h1 className="m-0 font-display text-[42px] leading-none font-semibold text-ink">
             Stations<span className="text-vermilion">.</span>
           </h1>
-          <div className="flex items-center gap-4">
+          <div className="flex flex-wrap items-center gap-4">
             <div className="font-mono text-[11px] tracking-[0.14em] text-muted uppercase">
               {data ? `${live ? 1 : 0} of ${stations.length} on air` : '—'}
             </div>
@@ -363,14 +363,14 @@ export default function StationsPanel() {
           {[0, 1, 2].map(k => (
             <div
               key={k}
-              className="grid grid-cols-[96px_1fr_auto] items-center gap-6 border-t border-separator-strong p-5 first:border-t-0"
+              className="grid grid-cols-[96px_minmax(0,1fr)] items-center gap-4 border-t border-separator-strong p-5 first:border-t-0 sm:grid-cols-[96px_1fr_auto] sm:gap-6"
             >
               <div className={cn(styles.shimmer, 'h-12 bg-separator-strong')} />
               <div className="grid gap-2">
                 <div className={cn(styles.shimmer, 'h-4 w-[38%] bg-separator-strong')} />
                 <div className={cn(styles.shimmer, 'h-2.5 w-[22%] bg-separator-soft')} />
               </div>
-              <div className={cn(styles.shimmer, 'h-6 w-[120px] bg-separator-soft')} />
+              <div className={cn(styles.shimmer, 'hidden h-6 w-[120px] bg-separator-soft sm:block')} />
             </div>
           ))}
           <div className="border-t border-separator-strong px-5 py-3 font-mono text-[10px] tracking-[0.22em] text-muted uppercase">
@@ -406,7 +406,12 @@ export default function StationsPanel() {
           {stations.map((s, i) => (
             <div
               key={s.id ?? '__install'}
-              className="grid grid-cols-[96px_1fr_auto] items-center gap-6 border-t border-separator-strong first:border-t-0"
+              /* Phone: two columns (preset tile + identity) with the action
+                 cluster dropped onto its own full-width row underneath — a
+                 96px tile, two 24px gaps and three buttons leave the name
+                 column barely 100px wide at 390. Restored to the single
+                 three-column rack row from sm: up. */
+              className="grid grid-cols-[96px_minmax(0,1fr)] items-center gap-x-4 border-t border-separator-strong first:border-t-0 sm:grid-cols-[96px_1fr_auto] sm:gap-6"
             >
               <div
                 className={cn(
@@ -437,9 +442,9 @@ export default function StationsPanel() {
                 </div>
               </div>
 
-              <div className="grid gap-1.5 py-4">
+              <div className="grid gap-1.5 py-4 pr-4 sm:pr-0">
                 <div className="flex flex-wrap items-center gap-3">
-                  <div className="font-display text-[26px] leading-[1.1] font-semibold text-ink">
+                  <div className="font-display text-[26px] leading-[1.1] font-semibold break-words text-ink">
                     {s.name}
                   </div>
                   {s.active ? <OnAirChip /> : null}
@@ -471,7 +476,7 @@ export default function StationsPanel() {
                 ) : null}
               </div>
 
-              <div className="flex items-center justify-end gap-2 pr-5">
+              <div className="col-span-2 flex flex-wrap items-center justify-start gap-2 pr-5 pb-4 pl-5 sm:col-span-1 sm:justify-end sm:pb-0 sm:pl-0">
                 {singleMode ? (
                   <div className="font-mono text-[10px] tracking-[0.16em] text-muted uppercase">
                     single-station install

--- a/web/components/admin/StatsPanel.tsx
+++ b/web/components/admin/StatsPanel.tsx
@@ -284,10 +284,15 @@ function MetricStrip({ children }: MetricStripProps) {
   const count = Array.isArray(children) ? children.length : 1;
   const ref = useRef<HTMLDivElement>(null);
   useDynamicStyle(ref, { gridTemplateColumns: `repeat(${count}, 1fr)` });
+  // `.strip-mobile` reflows to 2 columns under 640px, but StatCell divides with
+  // a RIGHT rule while that helper only clears LEFT ones — so the cell ending
+  // each mobile row left a divider dangling against the card edge. Drop it on
+  // the even (right-hand) cells and restore it from sm: up, skipping the last
+  // cell, which never carries a rule to begin with. Desktop is unchanged.
   return (
     <div
       ref={ref}
-      className="strip-mobile grid border-b border-separator-strong"
+      className="strip-mobile grid border-b border-separator-strong [&>*:nth-child(even)]:border-r-0 sm:[&>*:nth-child(even):not(:last-child)]:border-r"
     >
       {children}
     </div>
@@ -302,7 +307,7 @@ function Bar({ frac }: BarProps) {
   const ref = useRef<HTMLSpanElement>(null);
   useDynamicStyle(ref, { width: `${Math.max(2, Math.round((frac || 0) * 100))}%` });
   return (
-    <span className="inline-block h-1.5 w-14 overflow-hidden rounded-[2px] bg-separator-soft align-middle">
+    <span className="inline-block h-1.5 w-14 shrink-0 overflow-hidden rounded-[2px] bg-separator-soft align-middle">
       <span ref={ref} className="block h-full bg-vermilion" />
     </span>
   );
@@ -325,46 +330,53 @@ function Table<R>({ cols, rows, empty }: TableProps<R>) {
   if (!rows?.length) {
     return <span className="field-hint italic">{empty}</span>;
   }
+  // The wrapper only becomes a scroll container below sm:. A wide breakdown
+  // (five nowrap columns, long model ids) then scrolls sideways inside the card
+  // instead of clipping. From sm: up overflow-x is `visible` again, which keeps
+  // the card free of a scrollport — that matters because <thead> is sticky and
+  // would otherwise resolve against this div instead of the ScrollBox viewport.
   return (
-    <table className="w-full border-collapse">
-      <thead>
-        <tr>
-          {cols.map(c => (
-            <th
-              key={c.key}
-              className={cn(
-                'caption border-b border-separator-strong px-2 py-1 whitespace-nowrap',
-                // Sticky so the header stays put when the table is wrapped in a
-                // ScrollBox; the card-bg masks rows scrolling underneath.
-                'sticky top-0 z-[1] bg-[var(--card-bg)]',
-                c.align === 'right' && 'text-right',
-                c.align === 'center' && 'text-center',
-              )}
-            >
-              {c.label}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((r, i) => (
-          <tr key={i}>
+    <div className="w-full overflow-x-auto sm:overflow-x-visible">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
             {cols.map(c => (
-              <td
+              <th
                 key={c.key}
                 className={cn(
-                  'border-b border-separator-soft px-2 py-1 text-[12px]',
+                  'caption border-b border-separator-strong px-2 py-1 whitespace-nowrap',
+                  // Sticky so the header stays put when the table is wrapped in
+                  // a ScrollBox; the card-bg masks rows scrolling underneath.
+                  'sticky top-0 z-[1] bg-[var(--card-bg)]',
                   c.align === 'right' && 'text-right',
                   c.align === 'center' && 'text-center',
                 )}
               >
-                {c.render ? c.render(r) : ((r as Record<string, unknown>)[c.key] as ReactNode)}
-              </td>
+                {c.label}
+              </th>
             ))}
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => (
+            <tr key={i}>
+              {cols.map(c => (
+                <td
+                  key={c.key}
+                  className={cn(
+                    'border-b border-separator-soft px-2 py-1 text-[12px]',
+                    c.align === 'right' && 'text-right',
+                    c.align === 'center' && 'text-center',
+                  )}
+                >
+                  {c.render ? c.render(r) : ((r as Record<string, unknown>)[c.key] as ReactNode)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }
 
@@ -381,10 +393,15 @@ function BarList({ rows, max }: { rows: BarRow[]; max: number }) {
   return (
     <div className="grid gap-1.5">
       {rows.map(r => (
+        // The label column gives up 22px on a phone so the bar and its
+        // trailing figure (which can read "3 · 5m · up to 41m") still fit on
+        // one line inside a 390px card.
         <div key={r.label} className="flex items-center gap-2.5 text-[12px]">
-          <span className="w-[110px] truncate text-muted" title={r.label}>{r.label}</span>
+          <span className="w-[88px] shrink-0 truncate text-muted sm:w-[110px]" title={r.label}>
+            {r.label}
+          </span>
           <Bar frac={r.count / (max || 1)} />
-          <span className="mono-num font-bold">{r.trailing ?? r.count}</span>
+          <span className="mono-num min-w-0 font-bold">{r.trailing ?? r.count}</span>
         </div>
       ))}
     </div>
@@ -776,7 +793,7 @@ export default function StatsPanel() {
               No IPs here (unlike the Dash) — device class + counts + durations
               only. */}
           <div className="border-b border-separator-strong p-3.5">
-            <div className="mb-2 flex items-center justify-between gap-3">
+            <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
               <span className="caption">connected now · by device</span>
               <span className="caption text-muted">
                 {connErr
@@ -830,7 +847,7 @@ export default function StatsPanel() {
               </MetricStrip>
 
               <div className="stack-mobile grid grid-cols-[1fr_1fr] gap-0">
-                <div className="border-r border-separator-soft p-3.5">
+                <div className="border-b border-separator-soft p-3.5 sm:border-r sm:border-b-0">
                   <div className="caption mb-2">top referrers</div>
                   {audReferrers.length ? (
                     <ScrollBox>
@@ -887,7 +904,7 @@ export default function StatsPanel() {
                 event log), shown regardless of the since-boot call count above,
                 and only when a cap is set. */}
             {llm.budget?.enabled && (
-              <div className="flex items-center justify-between gap-3 border-b border-separator-strong p-3.5">
+              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-separator-strong p-3.5">
                 <span className="caption">
                   Daily token budget<span className="text-muted"> · resets 00:00 UTC</span>
                 </span>
@@ -929,7 +946,7 @@ export default function StatsPanel() {
                 </MetricStrip>
 
                 <div className="stack-mobile grid grid-cols-[1fr_1fr] gap-0">
-                  <div className="border-r border-separator-soft p-3.5">
+                  <div className="border-b border-separator-soft p-3.5 sm:border-r sm:border-b-0">
                     <div className="caption mb-2">by call kind</div>
                     <Table<ByKindRow>
                       empty="No calls"
@@ -988,7 +1005,7 @@ export default function StatsPanel() {
                 </MetricStrip>
 
                 <div className="stack-mobile grid grid-cols-[1fr_1fr] gap-0">
-                  <div className="border-r border-separator-soft p-3.5">
+                  <div className="border-b border-separator-soft p-3.5 sm:border-r sm:border-b-0">
                     <div className="caption mb-2">by engine</div>
                     <Table<ByEngineRow>
                       empty="No segments"
@@ -1047,7 +1064,7 @@ export default function StatsPanel() {
                 </MetricStrip>
 
                 <div className="stack-mobile grid grid-cols-[1fr_1fr] gap-0">
-                  <div className="border-r border-separator-soft p-3.5">
+                  <div className="border-b border-separator-soft p-3.5 sm:border-r sm:border-b-0">
                     <div className="caption mb-2">by resolution path</div>
                     {requests.byPath.length ? (
                       <BarList

--- a/web/components/admin/WebhooksPanel.tsx
+++ b/web/components/admin/WebhooksPanel.tsx
@@ -329,7 +329,7 @@ export default function WebhooksPanel() {
             <code> controller/src/routes/webhooks.ts </code> for the payload shapes.
           </div>
         </div>
-        <div className="flex items-center gap-3 bg-[var(--ink-softer)] p-3.5">
+        <div className="flex flex-wrap items-center gap-3 bg-[var(--ink-softer)] p-3.5">
           <span className="caption">{hooks.length} hook{hooks.length === 1 ? '' : 's'}</span>
           <span className="caption text-vermilion">
             {hooks.filter(h => h.enabled).length} enabled
@@ -392,7 +392,14 @@ export default function WebhooksPanel() {
         return (
           <Card
             key={h.id}
-            title={h.url || <span className="text-muted italic">(new webhook)</span>}
+            /* A webhook URL is one long unbreakable token; `.card-head` is a
+               flex row with no wrapping of its own, so let the title break
+               inside instead of pushing the head past the card. */
+            title={
+              h.url
+                ? <span className="break-all">{h.url}</span>
+                : <span className="text-muted italic">(new webhook)</span>
+            }
             right={
               <>
                 <Pill tone={h.enabled ? 'accent' : 'default'} dot={h.enabled}>
@@ -437,7 +444,9 @@ export default function WebhooksPanel() {
                         tone={on ? 'accent' : 'default'}
                         dot={on}
                         onClick={() => toggleEvent(ev)}
-                        className="cursor-pointer"
+                        // These pills are the event picker, not decoration —
+                        // give them a thumb-sized target on a phone.
+                        className="min-h-9 cursor-pointer sm:min-h-0"
                       >
                         {ev}
                       </Pill>

--- a/web/components/admin/connect/ConnectPanel.tsx
+++ b/web/components/admin/connect/ConnectPanel.tsx
@@ -120,7 +120,7 @@ export default function ConnectPanel() {
             </div>
             <div className="mt-1 text-[11px] leading-[1.6] text-muted">
               Discover the HTTP API, try it live, wire up an MCP client, or point a speaker at the stream.
-              All URLs below are the real addresses for this station (<code>{catalog.origin}</code>).
+              All URLs below are the real addresses for this station (<code className="break-all">{catalog.origin}</code>).
             </div>
           </div>
           <Btn sm onClick={downloadOpenApi} className="flex-none" title="Download an OpenAPI 3.1 spec for this station">

--- a/web/components/admin/connect/EndpointCard.tsx
+++ b/web/components/admin/connect/EndpointCard.tsx
@@ -62,12 +62,16 @@ export default function EndpointCard({ endpoint, apiBase, adminFetch }: Props) {
       onToggle={e => setOpen((e.target as HTMLDetailsElement).open)}
       className="border border-separator-strong bg-bg"
     >
-      <summary className="flex cursor-pointer items-center gap-2 px-3 py-2">
+      {/* Phone: method + path + auth pills stay on the header line and the
+          one-line summary drops underneath (order-last + w-full), instead of
+          the path breaking mid-word to make room for a 4-word blurb. Restored
+          to the single flex row from sm: up. */}
+      <summary className="flex cursor-pointer flex-wrap items-center gap-2 px-3 py-2 sm:flex-nowrap">
         <span className={`shrink-0 border px-1.5 py-[2px] text-[10px] font-bold tracking-[0.1em] ${METHOD_CLASS[endpoint.method] || ''}`}>
           {endpoint.method}
         </span>
-        <code className="text-[12px] font-semibold">{endpoint.path}</code>
-        <span className="truncate text-[11px] text-muted">{endpoint.summary}</span>
+        <code className="shrink-0 text-[12px] font-semibold">{endpoint.path}</code>
+        <span className="order-last w-full truncate text-[11px] text-muted sm:order-none sm:w-auto">{endpoint.summary}</span>
         <span className="ml-auto flex shrink-0 items-center gap-1.5">
           {endpoint.auth === 'admin'
             ? <Pill tone="accent">admin</Pill>
@@ -97,7 +101,11 @@ export default function EndpointCard({ endpoint, apiBase, adminFetch }: Props) {
         <div className="mt-3">
           <div className="caption mb-1 flex items-center gap-3">
             <span>Sample response</span>
-            <button type="button" className="text-[11px] text-[var(--accent)] underline" onClick={copyCurl}>
+            <button
+              type="button"
+              className="inline-flex min-h-9 items-center text-[11px] text-[var(--accent)] underline sm:min-h-0"
+              onClick={copyCurl}
+            >
               Copy as curl
             </button>
           </div>

--- a/web/components/admin/connect/EndpointsTab.tsx
+++ b/web/components/admin/connect/EndpointsTab.tsx
@@ -41,8 +41,8 @@ export default function EndpointsTab({ catalog, adminFetch }: Props) {
             {groups.reduce((n, g) => n + g.endpoints.length, 0)} endpoint
             {groups.reduce((n, g) => n + g.endpoints.length, 0) === 1 ? '' : 's'}
           </span>
-          <span className="caption ml-auto text-muted">
-            Base <code>{catalog.apiBase}</code>
+          <span className="caption ml-auto min-w-0 text-muted">
+            Base <code className="break-all">{catalog.apiBase}</code>
           </span>
         </div>
       </Card>

--- a/web/components/admin/connect/Playground.tsx
+++ b/web/components/admin/connect/Playground.tsx
@@ -188,13 +188,15 @@ export default function Playground({ endpoint, apiBase, adminFetch }: Props) {
         </div>
       )}
 
-      <div className="flex items-center gap-3">
+      {/* The request URL gets its own full-width line on a phone — sharing the
+          row with the Send button leaves it ~200px of scroll-only input. */}
+      <div className="flex flex-wrap items-center gap-3">
         <Btn sm tone={endpoint.mutatesAir ? 'danger' : 'solid'} onClick={send} disabled={sending}>
           {sending ? 'Sending…' : `Send ${endpoint.method}`}
         </Btn>
         <Snippet
           code={`${apiBase}${relPath}`}
-          className="h-7 min-w-0 flex-1 rounded-none border-separator-strong bg-transparent"
+          className="h-7 w-full min-w-0 flex-1 rounded-none border-separator-strong bg-transparent sm:w-auto"
         >
           <SnippetInput className="text-[11px] text-muted" aria-label="Request URL" />
           <SnippetAddon align="inline-end">

--- a/web/components/admin/imaging/BedsSection.tsx
+++ b/web/components/admin/imaging/BedsSection.tsx
@@ -91,8 +91,8 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
         metrics={<TabMetric accent n={pad2(list.length)} l="beds" />}
         actions={
           <>
-            <Btn sm onClick={() => setModal('import')} disabled={busy}>Import</Btn>
-            <Btn sm tone="solid" onClick={() => setModal('create')} disabled={busy}>+ Create</Btn>
+            <Btn sm className="min-h-9 sm:min-h-0" onClick={() => setModal('import')} disabled={busy}>Import</Btn>
+            <Btn sm tone="solid" className="min-h-9 sm:min-h-0" onClick={() => setModal('create')} disabled={busy}>+ Create</Btn>
           </>
         }
       />
@@ -127,9 +127,11 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
       {/* Thresholds */}
       <PanelBox>
         <PanelHead label="when to use a bed" />
-        <div className="grid grid-cols-2">
-          <div className="border-r border-separator-soft p-[18px]">
-            <div className="flex items-center gap-2.5">
+        {/* One column on mobile — two 155px cells can't hold a sentence, a
+            number field and a unit. The divider swaps side with the axis. */}
+        <div className="grid grid-cols-1 sm:grid-cols-2">
+          <div className="border-b border-separator-soft p-[18px] sm:border-r sm:border-b-0">
+            <div className="flex flex-wrap items-center gap-2.5">
               <span className="text-[13px] font-semibold">Bed links longer than</span>
               <Input
                 className="mono-num w-[72px]"
@@ -156,7 +158,7 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
             </p>
           </div>
           <div className="p-[18px]">
-            <div className="flex items-center gap-2.5">
+            <div className="flex flex-wrap items-center gap-2.5">
               <span className="text-[13px] font-semibold">Ramp into the next song</span>
               <Input
                 className="mono-num w-[72px]"
@@ -194,7 +196,9 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
             {list.map(b => (
               <div
                 key={b.name}
-                className="grid grid-cols-[1fr_auto] items-center gap-[18px] px-[18px] py-[15px]"
+                /* Mobile drops the play/delete cluster under the text — see
+                   JinglesSection for the same reflow. */
+                className="grid grid-cols-1 items-center gap-3 px-[18px] py-[15px] sm:grid-cols-[1fr_auto] sm:gap-[18px]"
               >
                 <div className="min-w-0">
                   <div className="flex flex-wrap items-baseline gap-3">
@@ -225,6 +229,7 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
                       variant="ghost"
                       size="icon"
                       aria-label="Delete bed"
+                      className="size-9 sm:size-8"
                       disabled={busy || b.builtin}
                       onClick={() => onDelete(b.name)}
                     >
@@ -246,10 +251,11 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
         sub="an instrumental we’ll generate with ElevenLabs"
         footer={
           <>
-            <Button variant="ghost" size="sm" onClick={() => setModal(null)}>Cancel</Button>
+            <Button variant="ghost" size="sm" className="min-h-9 sm:min-h-0" onClick={() => setModal(null)}>Cancel</Button>
             <Btn
               sm
               tone="accent"
+              className="min-h-9 sm:min-h-0"
               onClick={doCreate}
               disabled={busy || !ready || !bedsForm.name.trim() || !bedsForm.prompt.trim()}
             >
@@ -325,8 +331,8 @@ export function BedsSection({ bedsData, bedsForm, setBedsForm, busy, createBed, 
         sub="an instrumental the DJ can talk over"
         footer={
           <>
-            <Button variant="ghost" size="sm" onClick={() => setModal(null)}>Cancel</Button>
-            <Btn sm tone="accent" onClick={doImport} disabled={busy || !importFile || !importName.trim()}>
+            <Button variant="ghost" size="sm" className="min-h-9 sm:min-h-0" onClick={() => setModal(null)}>Cancel</Button>
+            <Btn sm tone="accent" className="min-h-9 sm:min-h-0" onClick={doImport} disabled={busy || !importFile || !importName.trim()}>
               {busy ? 'Importing…' : 'Import'}
             </Btn>
           </>

--- a/web/components/admin/imaging/ImagingPanel.tsx
+++ b/web/components/admin/imaging/ImagingPanel.tsx
@@ -345,7 +345,7 @@ export default function ImagingPanel() {
           rather than floating on the page background. */}
       <section className="card">
       <header className="p-4 lg:p-5">
-        <div className="flex items-baseline justify-between gap-4">
+        <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
           <MonoLabel>imaging</MonoLabel>
           <span className="flex items-center gap-[7px] font-mono text-[10px] tracking-[0.14em] text-muted uppercase">
             <span className="size-1.5 animate-pulse bg-[var(--accent)]" aria-hidden />

--- a/web/components/admin/imaging/JinglesSection.tsx
+++ b/web/components/admin/imaging/JinglesSection.tsx
@@ -96,8 +96,8 @@ export function JinglesSection({
         }
         actions={
           <>
-            <Btn sm onClick={() => setModal('import')} disabled={busy}>Import</Btn>
-            <Btn sm tone="solid" onClick={() => setModal('create')} disabled={busy}>+ Create</Btn>
+            <Btn sm className="min-h-9 sm:min-h-0" onClick={() => setModal('import')} disabled={busy}>Import</Btn>
+            <Btn sm tone="solid" className="min-h-9 sm:min-h-0" onClick={() => setModal('create')} disabled={busy}>+ Create</Btn>
           </>
         }
       />
@@ -106,7 +106,7 @@ export function JinglesSection({
       <PanelBox>
         <PanelHead label="how often" right={<Badge variant="accent">restart required</Badge>} />
         <div className="flex flex-wrap items-center gap-5 px-[18px] py-[18px]">
-          <div className="flex flex-none items-center gap-2.5">
+          <div className="flex flex-wrap items-center gap-2.5 sm:flex-none">
             <span className="font-mono text-[13px]">1 jingle every</span>
             <Input
               className="mono-num w-[84px]"
@@ -126,6 +126,7 @@ export function JinglesSection({
           <Btn
             sm
             tone="accent"
+            className="min-h-9 sm:min-h-0"
             onClick={() => saveSettings({ jingleRatio: parseInt(jingleRatio, 10) })}
             disabled={busy || !ratioDirty}
           >
@@ -144,7 +145,10 @@ export function JinglesSection({
             {jingles.map(j => (
               <div
                 key={j.filename}
-                className="grid grid-cols-[1fr_auto] items-center gap-[18px] px-[18px] py-[15px]"
+                /* Mobile drops the play/delete cluster under the text: the two
+                   icon buttons plus the gap eat 90px of the ~310px a panel has
+                   at 390px, which squeezes the quote to a two-word column. */
+                className="grid grid-cols-1 items-center gap-3 px-[18px] py-[15px] sm:grid-cols-[1fr_auto] sm:gap-[18px]"
               >
                 <div className="min-w-0">
                   <div className="font-display text-[18px] leading-[1.35] [text-wrap:pretty] italic">
@@ -175,6 +179,7 @@ export function JinglesSection({
                       variant="ghost"
                       size="icon"
                       aria-label="Delete jingle"
+                      className="size-9 sm:size-8"
                       disabled={busy || j.builtin}
                       onClick={() => onDelete(j.filename)}
                     >
@@ -196,8 +201,8 @@ export function JinglesSection({
         sub="we’ll voice it with Piper TTS"
         footer={
           <>
-            <Button variant="ghost" size="sm" onClick={() => setModal(null)}>Cancel</Button>
-            <Btn sm tone="accent" onClick={doCreate} disabled={busy || !jingleText.trim()}>
+            <Button variant="ghost" size="sm" className="min-h-9 sm:min-h-0" onClick={() => setModal(null)}>Cancel</Button>
+            <Btn sm tone="accent" className="min-h-9 sm:min-h-0" onClick={doCreate} disabled={busy || !jingleText.trim()}>
               {busy ? 'Generating…' : 'Create'}
             </Btn>
           </>
@@ -223,8 +228,8 @@ export function JinglesSection({
         sub="bring your own mp3 / wav — select one or many"
         footer={
           <>
-            <Button variant="ghost" size="sm" onClick={closeImport} disabled={!!importProgress}>Cancel</Button>
-            <Btn sm tone="accent" onClick={doImport} disabled={busy || !importFiles.length}>
+            <Button variant="ghost" size="sm" className="min-h-9 sm:min-h-0" onClick={closeImport} disabled={!!importProgress}>Cancel</Button>
+            <Btn sm tone="accent" className="min-h-9 sm:min-h-0" onClick={doImport} disabled={busy || !importFiles.length}>
               {importProgress
                 ? 'Importing…'
                 : importFiles.length > 1

--- a/web/components/admin/imaging/SfxSection.tsx
+++ b/web/components/admin/imaging/SfxSection.tsx
@@ -69,8 +69,8 @@ export function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uplo
         metrics={<TabMetric accent n={pad2(list.length)} l="effects" />}
         actions={
           <>
-            <Btn sm onClick={() => setModal('import')} disabled={busy}>Import</Btn>
-            <Btn sm tone="solid" onClick={() => setModal('create')} disabled={busy}>+ Create</Btn>
+            <Btn sm className="min-h-9 sm:min-h-0" onClick={() => setModal('import')} disabled={busy}>Import</Btn>
+            <Btn sm tone="solid" className="min-h-9 sm:min-h-0" onClick={() => setModal('create')} disabled={busy}>+ Create</Btn>
           </>
         }
       />
@@ -105,7 +105,9 @@ export function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uplo
             {list.map(s => (
               <div
                 key={s.name}
-                className="grid grid-cols-[1fr_auto] items-center gap-[18px] px-[18px] py-[15px]"
+                /* Mobile drops the play/delete cluster under the text — see
+                   JinglesSection for the same reflow. */
+                className="grid grid-cols-1 items-center gap-3 px-[18px] py-[15px] sm:grid-cols-[1fr_auto] sm:gap-[18px]"
               >
                 <div className="min-w-0">
                   <div className="flex flex-wrap items-baseline gap-3">
@@ -135,6 +137,7 @@ export function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uplo
                       variant="ghost"
                       size="icon"
                       aria-label="Delete effect"
+                      className="size-9 sm:size-8"
                       disabled={busy || s.builtin}
                       onClick={() => onDelete(s.name)}
                     >
@@ -156,10 +159,11 @@ export function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uplo
         sub="we’ll generate it with ElevenLabs"
         footer={
           <>
-            <Button variant="ghost" size="sm" onClick={() => setModal(null)}>Cancel</Button>
+            <Button variant="ghost" size="sm" className="min-h-9 sm:min-h-0" onClick={() => setModal(null)}>Cancel</Button>
             <Btn
               sm
               tone="accent"
+              className="min-h-9 sm:min-h-0"
               onClick={doCreate}
               disabled={busy || !ready || !sfxForm.name.trim() || !sfxForm.prompt.trim()}
             >
@@ -230,8 +234,8 @@ export function SfxSection({ sfxData, sfxForm, setSfxForm, busy, createSfx, uplo
         sub="bring your own mp3 / wav — no ElevenLabs key needed"
         footer={
           <>
-            <Button variant="ghost" size="sm" onClick={() => setModal(null)}>Cancel</Button>
-            <Btn sm tone="accent" onClick={doImport} disabled={busy || !importFile || !importName.trim()}>
+            <Button variant="ghost" size="sm" className="min-h-9 sm:min-h-0" onClick={() => setModal(null)}>Cancel</Button>
+            <Btn sm tone="accent" className="min-h-9 sm:min-h-0" onClick={doImport} disabled={busy || !importFile || !importName.trim()}>
               {busy ? 'Importing…' : 'Import'}
             </Btn>
           </>

--- a/web/components/admin/personas/PersonaEditor.tsx
+++ b/web/components/admin/personas/PersonaEditor.tsx
@@ -90,7 +90,14 @@ export function PersonaEditor({
       open={open}
       onOpenChange={(o) => { if (!o) onClose(); }}
       title={<Eyebrow className="text-vermilion">{isNew ? 'New persona' : 'Edit persona'}</Eyebrow>}
-      sub={<span className="caption truncate">{persona.name.trim() || `Persona ${index + 1}`} · {index + 1} of {personaCount}</span>}
+      sub={(
+        // The dialog header holds `sub` in a flex-none cell, so `truncate` needs
+        // a width to bite — cap it on phones (a 40-char persona name would
+        // otherwise push the close button off the edge), unbounded on desktop.
+        <span className="caption block max-w-[42vw] truncate sm:max-w-none">
+          {persona.name.trim() || `Persona ${index + 1}`} · {index + 1} of {personaCount}
+        </span>
+      )}
       footer={
         <div className="flex w-full flex-col gap-2">
           {/* status line — its own row so the action buttons never wrap */}
@@ -113,8 +120,9 @@ export function PersonaEditor({
           </div>
           {/* action row */}
           <div className="flex flex-wrap items-center gap-3">
-            {/* left — persona-scoped actions */}
-            <span className="flex items-center gap-2">
+            {/* left — persona-scoped actions. Wraps on phones: the three lg
+                buttons are ~530px of transport and can't share one line. */}
+            <span className="flex flex-wrap items-center gap-2">
               {persona.id === onAirPersonaId && <Pill tone="accent" className="text-[8px]">on air</Pill>}
               {persona.id === activePersonaId
                 ? <Pill className="text-[8px]">default</Pill>
@@ -138,7 +146,7 @@ export function PersonaEditor({
               </Btn>
             </span>
             {/* right — discard/save */}
-            <span className="ml-auto flex items-center gap-3">
+            <span className="ml-auto flex flex-wrap items-center justify-end gap-3">
               <Btn lg onClick={onDiscard} disabled={busy}>Discard</Btn>
               <Btn lg tone="accent" onClick={onSave} disabled={busy || !canSave}>
                 {busy ? 'Saving…' : 'Save persona'}

--- a/web/components/admin/personas/PersonaHero.tsx
+++ b/web/components/admin/personas/PersonaHero.tsx
@@ -44,7 +44,10 @@ export function PersonaHero({
         {onAirPersona?.tagline.trim() && (
           <span className="text-[11px] text-muted">— {onAirPersona.tagline.trim()}</span>
         )}
-        <span className="caption ml-4">
+        {/* The extra gap is a desktop separator between the name block and the
+            settings block; on a phone this chip starts a wrapped line, where a
+            leading indent just reads as a misalignment. */}
+        <span className="caption sm:ml-4">
           frequency · {onAirPersona ? onAirPersona.frequency : '—'}
         </span>
         <span className="caption">voice · {onAirPersona ? engineLabel(onAirPersona) : '—'}</span>

--- a/web/components/admin/personas/PersonaRoster.tsx
+++ b/web/components/admin/personas/PersonaRoster.tsx
@@ -41,11 +41,14 @@ export function PersonaRoster({
 
   return (
     <section className="grid gap-4">
+      {/* On phones the actions take a full row of their own under the count —
+          squeezed onto the count's line they run past the right edge. */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <span className="caption">roster · {personas.length} / {PERSONA_MAX}</span>
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
           <RosterViewToggle view={view} onChange={setView} />
           <Btn
+            className="min-h-9 sm:min-h-0"
             onClick={onCommunity}
             disabled={communityCount === null}
             title="Browse and install personas shared by other stations"
@@ -55,8 +58,8 @@ export function PersonaRoster({
               <span className="ml-1 text-vermilion">{communityCount}</span>
             )}
           </Btn>
-          <Btn onClick={onOpenPrompt}>System prompt</Btn>
-          <Btn tone="accent" onClick={onAdd} disabled={personas.length >= PERSONA_MAX}>
+          <Btn className="min-h-9 sm:min-h-0" onClick={onOpenPrompt}>System prompt</Btn>
+          <Btn className="min-h-9 sm:min-h-0" tone="accent" onClick={onAdd} disabled={personas.length >= PERSONA_MAX}>
             + Add persona
           </Btn>
         </div>

--- a/web/components/admin/personas/SteppedFader.tsx
+++ b/web/components/admin/personas/SteppedFader.tsx
@@ -102,7 +102,10 @@ export function SteppedFader({ ariaLabel, stops, value, onChange }: SteppedFader
           aria-orientation="horizontal"
           onPointerDown={startDrag}
           onKeyDown={onKeyDown}
-          className="relative h-8 cursor-ew-resize touch-none rounded outline-none select-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg)]"
+          // Taller grab area on phones — the groove, ticks and cap are all
+          // centred on the rail, so the extra height is transparent padding and
+          // the control looks identical; `sm:` restores the desktop 32px.
+          className="relative h-11 cursor-ew-resize touch-none rounded outline-none select-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg)] sm:h-8"
         >
           {/* groove */}
           <div className="absolute top-1/2 right-0 left-0 h-[6px] -translate-y-1/2 rounded-full border border-[#0e0c0a] bg-[linear-gradient(180deg,#161412,#2a2420)] shadow-[inset_0_2px_4px_rgba(0,0,0,0.6)]" />
@@ -141,7 +144,9 @@ export function SteppedFader({ ariaLabel, stops, value, onChange }: SteppedFader
               type="button"
               onClick={() => select(i)}
               className={cn(
-                'absolute top-0 text-[9px] leading-tight font-bold whitespace-nowrap uppercase',
+                // -my-2/py-2 grows the thumb target to ~28px without moving the
+                // label or the row below it. Desktop keeps the bare text box.
+                'absolute top-0 -my-2 py-2 text-[9px] leading-tight font-bold whitespace-nowrap uppercase sm:my-0 sm:py-0',
                 i === 0 ? 'left-0' : i === n - 1 ? 'right-0' : cn(lefts[i], '-translate-x-1/2'),
                 i === idx ? 'text-[var(--accent)]' : 'text-muted hover:text-[var(--ink)]',
               )}

--- a/web/components/admin/personas/SystemPromptModal.tsx
+++ b/web/components/admin/personas/SystemPromptModal.tsx
@@ -89,7 +89,10 @@ export function SystemPromptModal({
     <div
       key={opts.key}
       className={cn(
-        'grid grid-cols-[auto_1fr_auto] items-center gap-3 border p-2.5',
+        // Phones drop the actions onto a second row — radio + name + two
+        // buttons can't share a ~320px line without clipping the name.
+        'grid grid-cols-[auto_1fr] items-center gap-x-3 gap-y-2.5 border p-2.5',
+        'sm:grid-cols-[auto_1fr_auto] sm:gap-3',
         opts.invalid ? 'border-[var(--danger)]' : opts.isActive ? 'border-ink' : 'border-ink/40',
       )}
     >
@@ -100,7 +103,10 @@ export function SystemPromptModal({
         onClick={opts.onUse}
         disabled={opts.isActive}
         className={cn(
-          'v3-focus grid size-4 flex-none place-items-center rounded-full border border-ink bg-transparent p-0',
+          'v3-focus relative grid size-4 flex-none place-items-center rounded-full border border-ink bg-transparent p-0',
+          // Invisible 36px hit box on phones only — the 16px dot is fine with a
+          // mouse but too small for a thumb.
+          "before:absolute before:-inset-2.5 before:content-[''] sm:before:content-none",
           opts.isActive ? 'cursor-default' : 'cursor-pointer hover:border-[var(--accent)]',
         )}
       >
@@ -114,44 +120,49 @@ export function SystemPromptModal({
         </div>
         <div className="caption mt-0.5">{opts.meta}</div>
       </div>
-      <div className="flex flex-none items-center gap-2">{opts.actions}</div>
+      <div className="col-span-2 flex flex-none flex-wrap items-center justify-end gap-2 sm:col-span-1 sm:justify-start">
+        {opts.actions}
+      </div>
     </div>
   );
 
   // ── footer per view ──────────────────────────────────────────────────────
+  // Both footers own a full-width wrapping row rather than sitting as bare
+  // children of the modal's non-wrapping footer flex — on a phone the status
+  // line plus two buttons has to break onto two lines.
   const libraryFooter = (
-    <>
+    <div className="flex w-full flex-wrap items-center justify-end gap-2">
       <span
         className={cn(
           'size-1.5 flex-none rounded-full',
           canSave ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
         )}
       />
-      <span className="mr-auto text-[11px] text-muted">
+      <span className="mr-auto min-w-0 text-[11px] text-muted">
         {!canSave && !promptsOk
           ? <span className="text-[var(--danger)]">fix the incomplete prompt template</span>
           : !canSave && !allPersonasOk
             ? <span className="text-[var(--danger)]">a persona in the roster is incomplete — fix it before saving</span>
             : 'changes apply on the next spoken line · no mixer restart'}
       </span>
-      <Btn onClick={onDiscard} disabled={busy}>Discard</Btn>
-      <Btn tone="accent" onClick={onSave} disabled={busy || !canSave}>
+      <Btn className="min-h-9 sm:min-h-0" onClick={onDiscard} disabled={busy}>Discard</Btn>
+      <Btn className="min-h-9 sm:min-h-0" tone="accent" onClick={onSave} disabled={busy || !canSave}>
         {busy ? 'Saving…' : 'Save system prompt'}
       </Btn>
-    </>
+    </div>
   );
   const editorFooter = (
-    <>
+    <div className="flex w-full flex-wrap items-center justify-end gap-2">
       {editingPreset && (
-        <span className={cn('caption mr-auto', editingTextOk && editingNameOk ? 'text-muted' : 'text-[var(--danger)]')}>
+        <span className={cn('caption mr-auto min-w-0', editingTextOk && editingNameOk ? 'text-muted' : 'text-[var(--danger)]')}>
           {editingText.length}/{PROMPT_MAX} chars
           {!editingNameOk && ' · name required'}
           {!editingText.includes('{name}') && ' · missing {name}'}
           {editingText.length > 0 && editingText.length < PROMPT_MIN && ` · min ${PROMPT_MIN}`}
         </span>
       )}
-      <Btn onClick={() => setEditing(null)}>Back to library</Btn>
-    </>
+      <Btn className="min-h-9 sm:min-h-0" onClick={() => setEditing(null)}>Back to library</Btn>
+    </div>
   );
 
   return (
@@ -191,7 +202,7 @@ export function SystemPromptModal({
                 meta: 'ships with SUB/WAVE · read-only',
                 isActive: activeId === '',
                 onUse: () => onSetActive(''),
-                actions: <Btn sm onClick={() => setEditing('default')}>View</Btn>,
+                actions: <Btn sm className="min-h-9 sm:min-h-0" onClick={() => setEditing('default')}>View</Btn>,
               })}
               {presets.map(p =>
                 row({
@@ -203,8 +214,8 @@ export function SystemPromptModal({
                   onUse: () => onSetActive(p.id),
                   actions: (
                     <>
-                      <Btn sm onClick={() => setEditing(p.id)}>Edit</Btn>
-                      <Btn sm onClick={() => setConfirmDeleteId(p.id)} disabled={busy}>Delete</Btn>
+                      <Btn sm className="min-h-9 sm:min-h-0" onClick={() => setEditing(p.id)}>Edit</Btn>
+                      <Btn sm className="min-h-9 sm:min-h-0" onClick={() => setConfirmDeleteId(p.id)} disabled={busy}>Delete</Btn>
                     </>
                   ),
                 }),
@@ -212,6 +223,7 @@ export function SystemPromptModal({
             </div>
             <div className="mt-3">
               <Btn
+                className="min-h-9 sm:min-h-0"
                 onClick={addPreset}
                 disabled={busy || presets.length >= PROMPT_PRESET_MAX}
                 title={presets.length >= PROMPT_PRESET_MAX ? `The library is full (${PROMPT_PRESET_MAX} templates)` : undefined}

--- a/web/components/admin/schedule/Board.tsx
+++ b/web/components/admin/schedule/Board.tsx
@@ -51,7 +51,7 @@ export default function Board({
 }: BoardProps) {
   return (
     <section>
-      <div className="mb-3 flex flex-wrap items-center gap-3.5 px-[30px]">
+      <div className="mb-3 flex flex-wrap items-center gap-3.5 px-5 sm:px-[30px]">
         <Mu className="tracking-[0.08em]">
           Click a silent hour (or drag a show onto it) to book a show — click a card to edit its order, its × to take it off the air
         </Mu>
@@ -59,7 +59,7 @@ export default function Board({
 
       {/* The shelf — one draggable chip per show, a single scrolling tray so
           any number of shows stays one line tall */}
-      <div className="mx-[30px] mb-3.5 border border-ink bg-[var(--page-bg)]">
+      <div className="mx-5 mb-3.5 border border-ink bg-[var(--page-bg)] sm:mx-[30px]">
         <ScrollArea>
           <div className="flex w-max min-w-full items-center gap-2 px-3 py-2.5">
             <span className="eyebrow mr-1 flex-none text-ink">The shelf</span>
@@ -84,7 +84,7 @@ export default function Board({
             }}
             onClick={() => onArmShow(s.id)}
             title={`Drag onto the board, or click to write an order for “${s.name}”`}
-            className="flex flex-none cursor-grab items-center gap-1.5 border border-separator-strong bg-[var(--card-bg)] px-2.5 py-1.5 hover:border-ink active:cursor-grabbing"
+            className="flex min-h-9 flex-none cursor-grab items-center gap-1.5 border border-separator-strong bg-[var(--card-bg)] px-2.5 py-1.5 hover:border-ink active:cursor-grabbing sm:min-h-0"
           >
             <ColorChip color={colorOf(s.id)} />
             <span className="text-[11.5px] font-semibold whitespace-nowrap text-ink">{s.name}</span>
@@ -96,10 +96,21 @@ export default function Board({
         </ScrollArea>
       </div>
 
+      {/* On a phone the week is a horizontal strip and Radix only reveals its
+          scrollbar on hover, so name the gesture — and the span — outright. */}
+      <Mu className="mb-1.5 flex items-center gap-1.5 px-5 tracking-[0.08em] sm:hidden">
+        <span aria-hidden="true">◂</span>
+        Swipe the board — Mon through Sun
+        <span aria-hidden="true">▸</span>
+      </Mu>
+
       <ScrollArea>
         <div className="flex w-max min-w-full items-start gap-2.5 pb-1.5">
-          {/* Hour gutter — pt clears the 38px column headers (+border+padding) */}
-          <div className="w-[42px] flex-none pt-[43px]">
+          {/* Hour gutter — pt clears the 38px column headers (+border+padding).
+              Pinned while the strip scrolls sideways on a phone, so the hour a
+              card sits on stays readable on any day; static from sm up, where
+              the board usually fits without scrolling. */}
+          <div className="sticky left-0 z-10 w-[42px] flex-none bg-[var(--card-bg)] pt-[43px] sm:static sm:bg-transparent">
             {HOURS.map(h => (
               <div
                 key={h}
@@ -138,7 +149,7 @@ export default function Board({
         </div>
         <ScrollBar orientation="horizontal" />
       </ScrollArea>
-      <Mu className="mt-1 block px-[30px] tracking-[0.08em]">
+      <Mu className="mt-1 block px-5 tracking-[0.08em] sm:px-[30px]">
         Hatched hours are silent — click one to book a show, or leave the station to run itself
       </Mu>
     </section>
@@ -163,7 +174,9 @@ function DayColumn({
   const showById = (id: string | null) => shows.find(s => s.id === id) ?? null;
   const booked = blocks.reduce((a, b) => a + (b.showId ? b.span : 0), 0);
   return (
-    <div className="flex min-w-[188px] flex-1 flex-col border border-ink bg-[var(--page-bg)]">
+    // Narrower on a phone so the next day peeks past the right edge — the
+    // strip reads as scrollable without a permanently-drawn scrollbar.
+    <div className="flex min-w-[164px] flex-1 flex-col border border-ink bg-[var(--page-bg)] sm:min-w-[188px]">
       <button
         type="button"
         onClick={onToggleFold}

--- a/web/components/admin/schedule/EditorBand.tsx
+++ b/web/components/admin/schedule/EditorBand.tsx
@@ -65,7 +65,7 @@ export function LineEditor({
   const lineShow = shows.find(s => s.id === lineShowId) ?? null;
   return (
     <div className="min-w-0">
-      <div className="mb-0.5 flex items-baseline gap-3">
+      <div className="mb-0.5 flex flex-wrap items-baseline gap-x-3 gap-y-0.5">
         <span className="eyebrow flex-none whitespace-nowrap text-ink">Write an order</span>
         <Mu className="min-w-0 flex-1 truncate tracking-[0.08em]">
           Fill in the sentence, then add it to the schedule · {dayName(line.day)} {hhmm(line.start)} → {hhmm(line.end)}{' '}
@@ -115,11 +115,19 @@ export function LineEditor({
           />
           <span className="mx-1 hidden h-5 w-px bg-separator-strong sm:block" />
           <DayPills selected={lineDays} onToggle={onToggleLineDay} />
-          <span className="ml-auto flex gap-2">
-            <Button variant="accent" size="sm" onClick={onAir} disabled={!lineShow}>
+          {/* Its own full-width line on a phone — the sentence above already
+              fills several rows, and the buttons need a real tap target. */}
+          <span className="ml-auto flex w-full gap-2 sm:w-auto">
+            <Button
+              variant="accent"
+              size="sm"
+              className="min-h-9 sm:min-h-0"
+              onClick={onAir}
+              disabled={!lineShow}
+            >
               Add to schedule
             </Button>
-            <Button variant="ghost" size="sm" onClick={onQuiet}>
+            <Button variant="ghost" size="sm" className="min-h-9 sm:min-h-0" onClick={onQuiet}>
               Remove
             </Button>
           </span>
@@ -143,7 +151,7 @@ export default function EditorBand({
 }: EditorBandProps) {
   const hasSuggestions = suggestions.length > 0;
   return (
-    <section className="border-t border-ink bg-[var(--page-bg)] px-[30px] py-[22px]">
+    <section className="border-t border-ink bg-[var(--page-bg)] px-5 py-[22px] sm:px-[30px]">
       <div className={cn('grid items-start gap-x-9 gap-y-7', hasSuggestions && 'xl:grid-cols-[minmax(360px,1fr)_2fr]')}>
         {/* ── Worth a look ──────────────────────────────────────────────── */}
         {hasSuggestions && (
@@ -160,11 +168,16 @@ export default function EditorBand({
                     </span>
                     <span className="text-[12.5px] text-ink">{sug.text}</span>
                   </div>
-                  <div className="flex gap-2">
-                    <Button variant="solid" size="sm" onClick={sug.onAction}>
+                  <div className="flex flex-wrap gap-2">
+                    <Button variant="solid" size="sm" className="min-h-9 sm:min-h-0" onClick={sug.onAction}>
                       {sug.actionLabel}
                     </Button>
-                    <Button variant="ghost" size="sm" onClick={() => onDismissSuggestion(sug.key)}>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="min-h-9 sm:min-h-0"
+                      onClick={() => onDismissSuggestion(sug.key)}
+                    >
                       {sug.dismissLabel}
                     </Button>
                   </div>
@@ -187,7 +200,7 @@ export default function EditorBand({
           </div>
 
           <div className="mt-4 border border-separator-strong bg-[var(--card-bg)] p-4">
-            <div className="mb-[11px] flex items-baseline gap-2">
+            <div className="mb-[11px] flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
               <span className="eyebrow text-ink">Airtime against your target</span>
               <Mu className="text-[9px] tracking-[0.1em]">tick = {target} h</Mu>
             </div>
@@ -228,7 +241,7 @@ function AirtimeBar({ row, tickPct }: { row: AirtimeRow; tickPct: number }) {
   useDynamicStyle(barRef, { width: `${row.pct}%`, background: row.color });
   useDynamicStyle(tickRef, { left: `${tickPct}%` });
   return (
-    <div className="grid grid-cols-[96px_1fr_32px] items-center gap-2.5">
+    <div className="grid grid-cols-[72px_1fr_28px] items-center gap-2 sm:grid-cols-[96px_1fr_32px] sm:gap-2.5">
       <Mu className={cn('truncate text-[9px]', row.under && 'text-vermilion')} >
         {row.name}
       </Mu>

--- a/web/components/admin/schedule/SchedulePanel.tsx
+++ b/web/components/admin/schedule/SchedulePanel.tsx
@@ -439,15 +439,17 @@ export default function SchedulePanel() {
   return (
     <div className="flex min-h-full min-w-0 flex-1 flex-col bg-[var(--card-bg)]">
       {/* ── Header ─────────────────────────────────────────────────────── */}
-      <div className="border-b border-ink px-[30px] pt-4 pb-3.5">
-        <div className="flex items-center justify-between gap-x-6">
+      <div className="border-b border-ink px-5 pt-4 pb-3.5 sm:px-[30px]">
+        {/* The action cluster is `w-full` on a phone so it wraps under the
+            title instead of being pushed off the right edge. */}
+        <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2.5">
           <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
-            <span className="eyebrow text-vermilion">Show plan · The Rundown</span>
-            <span aria-hidden="true" className="h-px w-[18px] bg-[color-mix(in_oklab,var(--ink)_28%,transparent)]" />
+            <span className="eyebrow whitespace-nowrap text-vermilion">Show plan · The Rundown</span>
+            <span aria-hidden="true" className="hidden h-px w-[18px] bg-[color-mix(in_oklab,var(--ink)_28%,transparent)] sm:block" />
             <span className="font-mono text-[11.5px] font-bold tracking-[0.06em] text-ink">{clockLabel}</span>
             <Mu className="text-[9px]">{zoneLabel}</Mu>
           </div>
-          <div className="ml-auto flex flex-none items-center gap-3">
+          <div className="ml-auto flex w-full flex-none flex-wrap items-center gap-3 sm:w-auto sm:flex-nowrap">
             <span className="flex flex-none items-center gap-2">
               {dirty > 0 && <span aria-hidden="true" className="size-1.5 bg-[var(--accent)]" />}
               <Mu className={cn('text-[9px] whitespace-nowrap', dirty > 0 && 'text-ink')}>
@@ -463,10 +465,16 @@ export default function SchedulePanel() {
                 </button>
               )}
             </span>
-            <Button asChild variant="default" size="sm">
+            <Button asChild variant="default" size="sm" className="min-h-9 sm:min-h-0">
               <Link href="/admin/shows">New show →</Link>
             </Button>
-            <Button variant="accent" size="sm" onClick={saveWeek} disabled={busy || dirty === 0}>
+            <Button
+              variant="accent"
+              size="sm"
+              className="min-h-9 sm:min-h-0"
+              onClick={saveWeek}
+              disabled={busy || dirty === 0}
+            >
               {busy ? 'Saving…' : 'Save the week'}
             </Button>
           </div>
@@ -481,7 +489,7 @@ export default function SchedulePanel() {
 
       {/* ── Now band ───────────────────────────────────────────────────── */}
       <div className="border-b border-ink bg-[var(--page-bg)]">
-        <div className="grid grid-cols-3">
+        <div className="grid grid-cols-1 sm:grid-cols-3">
           <NowCell
             label={pinnedShow ? 'On air · takeover' : 'On air'}
             live
@@ -512,12 +520,14 @@ export default function SchedulePanel() {
         </div>
 
         {/* Takeover strip */}
-        <div className="flex flex-wrap items-center gap-x-3.5 gap-y-2 border-t border-separator-strong bg-[color-mix(in_oklab,var(--ink)_5%,var(--page-bg))] px-[22px] py-[11px]">
+        <div className="flex flex-wrap items-center gap-x-3.5 gap-y-2 border-t border-separator-strong bg-[color-mix(in_oklab,var(--ink)_5%,var(--page-bg))] px-5 py-[11px] sm:px-[22px]">
           <span className="eyebrow flex-none text-ink">Takeover</span>
           <Mu className="min-w-0 flex-1 truncate text-[9px]">
             Jump a show to the front of the queue — the schedule picks up again after
           </Mu>
-          <div className="ml-auto flex flex-none items-center gap-2.5">
+          {/* Full-width + wrapping on a phone: the controls run ~430px wide,
+              so on one flex-none line the Pin button falls off the screen. */}
+          <div className="ml-auto flex w-full flex-none flex-wrap items-center gap-2.5 sm:w-auto sm:flex-nowrap">
             {liveOverride && pinnedShow ? (
               <>
                 <ColorChip color={colorOf(pinnedShow.id)} />
@@ -526,7 +536,13 @@ export default function SchedulePanel() {
                   ends {fmtClock(liveOverride.expiresAt, tz, locale)} ·{' '}
                   {Math.max(1, Math.ceil((liveOverride.expiresAt - now.getTime()) / 60_000))} min left
                 </Mu>
-                <Button variant="ghost" size="sm" onClick={cancelPin} disabled={pinBusy}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="min-h-9 sm:min-h-0"
+                  onClick={cancelPin}
+                  disabled={pinBusy}
+                >
                   {pinBusy ? 'Cancelling…' : 'Cancel takeover'}
                 </Button>
               </>
@@ -534,7 +550,9 @@ export default function SchedulePanel() {
               <>
                 <SlotMenu
                   ariaLabel="Pin a show"
-                  className="text-[12px]"
+                  // Reads as a field here (not a word in a sentence), so it can
+                  // carry the same phone tap height as the rest of the strip.
+                  className="min-h-9 text-[12px] sm:min-h-0"
                   label={showById(pinShowId)?.name ?? 'Pin a show…'}
                   options={shows.map(s => ({ key: s.id, label: s.name, chipColor: colorOf(s.id) }))}
                   onSelect={setPinShowId}
@@ -547,7 +565,7 @@ export default function SchedulePanel() {
                     </SegBtn>
                   ))}
                 </div>
-                <label className="flex items-baseline gap-1.5 border border-separator-strong px-2 py-1">
+                <label className="flex items-baseline gap-1.5 border border-separator-strong px-2 py-[9px] sm:py-1">
                   <input
                     type="number"
                     min={PIN_MIN_MINUTES}
@@ -565,6 +583,7 @@ export default function SchedulePanel() {
                 <Button
                   variant="accent"
                   size="sm"
+                  className="min-h-9 sm:min-h-0"
                   onClick={pinShow}
                   disabled={pinBusy || !pinShowId || pinMinutes < PIN_MIN_MINUTES || pinMinutes > PIN_MAX_MINUTES}
                 >
@@ -577,7 +596,7 @@ export default function SchedulePanel() {
       </div>
 
       {/* ── Main: line editor, edge-to-edge board, order desk beneath ──── */}
-      <div className="min-w-0 px-[30px] pt-[22px]">
+      <div className="min-w-0 px-5 pt-[22px] sm:px-[30px]">
         <div ref={bandRef} className="mb-5 scroll-mt-4">
           <LineEditor
             shows={shows}
@@ -671,7 +690,7 @@ export default function SchedulePanel() {
           {editedRanges.map(r => (
             <div
               key={`${r.day}-${r.start}`}
-              className="flex items-baseline gap-3 border-b border-separator-soft px-1 py-1.5"
+              className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5 border-b border-separator-soft px-1 py-1.5"
             >
               <span className="w-[150px] flex-none font-mono text-[11px] font-bold tracking-[0.06em] text-muted">
                 {dayName(r.day)} {hhmm(r.start)} – {hhmm(r.end)}
@@ -705,7 +724,14 @@ function NowCell({
   const barRef = useRef<HTMLDivElement>(null);
   useDynamicStyle(barRef, { width: `${pct ?? 0}%` });
   return (
-    <div className={cn('min-w-0 px-[22px] py-2', !last && 'border-r border-separator-strong')}>
+    <div
+      className={cn(
+        'min-w-0 px-5 py-2 sm:px-[22px]',
+        // Stacked on a phone (grid-cols-1), so the divider runs along the
+        // bottom; the column rule comes back with the 3-up grid at sm.
+        !last && 'border-b border-separator-strong sm:border-r sm:border-b-0',
+      )}
+    >
       <div className="mb-1 flex items-center gap-2">
         {live && <span aria-hidden="true" className="size-[7px] flex-none rounded-full bg-[var(--accent)]" />}
         <span className={cn('eyebrow min-w-0 truncate', live ? 'text-vermilion' : 'text-muted')}>{label}</span>

--- a/web/components/admin/schedule/bits.tsx
+++ b/web/components/admin/schedule/bits.tsx
@@ -113,7 +113,8 @@ export function SegBtn({
       title={title}
       aria-pressed={on}
       className={cn(
-        'cursor-pointer border px-2.5 py-[5px] font-mono text-[10px] font-bold tracking-[0.2em] uppercase',
+        // min-h on the phone only — the desktop metric is the padding.
+        'min-h-9 cursor-pointer border px-2.5 py-[5px] font-mono text-[10px] font-bold tracking-[0.2em] uppercase sm:min-h-0',
         on
           ? 'border-ink bg-ink text-bg'
           : 'border-separator-strong bg-transparent text-muted hover:border-ink hover:text-ink',
@@ -145,7 +146,9 @@ export function DayPills({
             title={d.name}
             onClick={() => onToggle(d.key)}
             className={cn(
-              'flex size-[17px] cursor-pointer items-center justify-center border font-mono text-[8px] font-bold',
+              // Comfortable squares on a phone (7 × 32px + gaps still fits a
+              // 390px screen); back to the dense 17px chip from sm up.
+              'flex size-8 cursor-pointer items-center justify-center border font-mono text-[10px] font-bold sm:size-[17px] sm:text-[8px]',
               on
                 ? 'border-ink bg-ink text-bg'
                 : 'border-separator-strong bg-transparent text-muted hover:border-ink hover:text-ink',

--- a/web/components/admin/settings/LibrarySection.tsx
+++ b/web/components/admin/settings/LibrarySection.tsx
@@ -298,7 +298,7 @@ export function LibrarySection({ data, form, setForm, busy, saveSettings, adminF
       />
 
       <Card title="Tagger" sub="enabled?">
-        <div className="grid grid-cols-[1fr_auto] items-center gap-4">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto] sm:items-center sm:gap-4">
           <div>
             <div className="text-[13px] font-bold">Embedding-propagated tagging</div>
             <div className="mt-0.5 max-w-[480px] text-[14px] leading-[1.5] text-muted">
@@ -428,7 +428,7 @@ export function LibrarySection({ data, form, setForm, busy, saveSettings, adminF
 
           <div className="field">
             <Label>Model</Label>
-            <div className="flex items-stretch gap-2">
+            <div className="flex flex-wrap items-stretch gap-2 sm:flex-nowrap">
               {embedDiscovery.models.length > 0 ? (
                 <ModelCombobox
                   models={embedDiscovery.models}
@@ -809,7 +809,7 @@ export function LibrarySection({ data, form, setForm, busy, saveSettings, adminF
 
       <Card title="Enrichment" sub="signals folded into the embedding text">
         <div className="grid gap-4">
-          <div className="grid grid-cols-[1fr_auto] items-center gap-4">
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto] sm:items-center sm:gap-4">
             <div>
               <div className="text-[13px] font-bold">Last.fm tags</div>
               <div className="mt-0.5 max-w-[480px] text-[14px] leading-[1.5] text-muted">
@@ -839,7 +839,7 @@ export function LibrarySection({ data, form, setForm, busy, saveSettings, adminF
             />
           </div>
 
-          <div className="grid grid-cols-[1fr_auto] items-center gap-4">
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto] sm:items-center sm:gap-4">
             <div>
               <div className="text-[13px] font-bold">Lyrics</div>
               <div className="mt-0.5 max-w-[480px] text-[14px] leading-[1.5] text-muted">

--- a/web/components/admin/settings/LlmSection.tsx
+++ b/web/components/admin/settings/LlmSection.tsx
@@ -419,7 +419,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
             <>
               <div className="field">
                 <Label>Bearer token</Label>
-                <div className="flex items-stretch gap-2">
+                <div className="flex flex-wrap items-stretch gap-2 sm:flex-nowrap">
                   <Input
                     type="password"
                     autoComplete="off"
@@ -487,7 +487,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
               <>
                 <div className="field">
                   <Label>{llmProviderLabel(form.llm.provider)} API key</Label>
-                  <div className="flex items-stretch gap-2">
+                  <div className="flex flex-wrap items-stretch gap-2 sm:flex-nowrap">
                     <Input
                       type="password"
                       autoComplete="off"
@@ -519,7 +519,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
 
           <div className="field">
             <Label>Model</Label>
-            <div className="flex items-stretch gap-2">
+            <div className="flex flex-wrap items-stretch gap-2 sm:flex-nowrap">
               {primaryDiscovery.models.length > 0 ? (
                 <ModelCombobox
                   models={primaryDiscovery.models}
@@ -604,7 +604,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
 
       <Card title="Fallback" sub="backup when the primary is offline">
         <div className="grid gap-[18px]">
-          <div className="grid grid-cols-[1fr_auto] items-center gap-4">
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto] sm:items-center sm:gap-4">
             <div>
               <div className="text-[13px] font-bold">Use a backup LLM</div>
               <div className="mt-0.5 max-w-[480px] text-[14px] leading-[1.5] text-muted">
@@ -736,7 +736,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
                 <>
                   <div className="field">
                     <Label>Bearer token</Label>
-                    <div className="flex items-stretch gap-2">
+                    <div className="flex flex-wrap items-stretch gap-2 sm:flex-nowrap">
                       <Input
                         type="password"
                         autoComplete="off"
@@ -799,7 +799,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
                   <>
                     <div className="field">
                       <Label>{llmProviderLabel(form.llm.fallback.provider)} API key</Label>
-                      <div className="flex items-stretch gap-2">
+                      <div className="flex flex-wrap items-stretch gap-2 sm:flex-nowrap">
                         <Input
                           type="password"
                           autoComplete="off"
@@ -826,7 +826,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
 
               <div className="field">
                 <Label>Backup model</Label>
-                <div className="flex items-stretch gap-2">
+                <div className="flex flex-wrap items-stretch gap-2 sm:flex-nowrap">
                   {fallbackDiscovery.models.length > 0 ? (
                     <ModelCombobox
                       models={fallbackDiscovery.models}
@@ -881,7 +881,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
                 <KeyStatus envVar={fallbackKeyVar} present={!!data.env?.[fallbackKeyVar]} />
               )}
 
-              <div className="grid grid-cols-[1fr_auto] items-center gap-4">
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto] sm:items-center sm:gap-4">
                 <div>
                   <div className="text-[13px] font-bold">Backup chain-of-thought</div>
                   <div className="mt-0.5 max-w-[480px] text-[14px] leading-[1.5] text-muted">
@@ -907,7 +907,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
       </Card>
 
       <Card title="Reasoning" sub="thinking models">
-        <div className="grid grid-cols-[1fr_auto] items-center gap-4">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto] sm:items-center sm:gap-4">
           <div>
             <div className="text-[13px] font-bold">Chain-of-thought</div>
             <div className="field-hint mt-1 max-w-[440px]">
@@ -957,7 +957,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
       </Card>
 
       <Card title="Next-track picker" sub="how the DJ chooses">
-        <div className="grid grid-cols-[1fr_auto] items-center gap-4">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto] sm:items-center sm:gap-4">
           <div>
             <div className="text-[13px] font-bold">Agentic picker</div>
             <div className="field-hint mt-1 max-w-[440px]">
@@ -1003,7 +1003,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
         )}
 
         {form.llm.pickerAgent && (
-          <div className="mt-4 grid grid-cols-[1fr_auto] items-center gap-4">
+          <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto] sm:items-center sm:gap-4">
             <div>
               <div className="text-[13px] font-bold">Resolve described requests via web</div>
               <div className="field-hint mt-1 max-w-[440px]">
@@ -1049,7 +1049,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
       </Card>
 
       <Card title="Idle behaviour" sub="when no one's listening">
-        <div className="grid grid-cols-[1fr_auto] items-center gap-4">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto] sm:items-center sm:gap-4">
           <div>
             <div className="text-[13px] font-bold">Pause DJ when empty</div>
             <div className="field-hint mt-1 max-w-[440px]">
@@ -1119,7 +1119,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
         )}
 
         {form.llm.dailyTokenCap > 0 && (
-          <div className="mt-4 grid grid-cols-[1fr_auto] items-center gap-4">
+          <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto] sm:items-center sm:gap-4">
             <div>
               <div className="text-[13px] font-bold">Always answer requests</div>
               <div className="mt-0.5 max-w-[480px] text-[14px] leading-[1.5] text-muted">

--- a/web/components/admin/settings/SearchSection.tsx
+++ b/web/components/admin/settings/SearchSection.tsx
@@ -176,7 +176,7 @@ export function SearchSection({ data, form, setForm, busy, saveSettings, adminFe
             <>
               <div className="field">
                 <Label>{keyed.name} API key</Label>
-                <div className="flex items-stretch gap-2">
+                <div className="flex flex-wrap items-stretch gap-2 sm:flex-nowrap">
                   <Input
                     type="password"
                     autoComplete="off"
@@ -214,7 +214,7 @@ export function SearchSection({ data, form, setForm, busy, saveSettings, adminFe
             <>
               <div className="field">
                 <Label>SearXNG URL</Label>
-                <div className="flex items-stretch gap-2">
+                <div className="flex flex-wrap items-stretch gap-2 sm:flex-nowrap">
                   <Input
                     type="url"
                     placeholder="http://192.168.0.112:8888"

--- a/web/components/admin/settings/StationSection.tsx
+++ b/web/components/admin/settings/StationSection.tsx
@@ -114,7 +114,7 @@ export function StationSection({ data, form, setForm, busy, saveSettings }: Sect
             onChange={(e: ChangeEvent<HTMLInputElement>) =>
               setForm(f => ({ ...f, station: e.target.value }))
             }
-            className="w-[260px]"
+            className="w-[260px] max-w-full"
             maxLength={80}
           />
           <div className="field-hint">
@@ -194,7 +194,7 @@ export function StationSection({ data, form, setForm, busy, saveSettings }: Sect
             onChange={(e: ChangeEvent<HTMLInputElement>) =>
               setForm(f => ({ ...f, weather: { ...f.weather, onAirLocation: e.target.value } }))
             }
-            className="w-[260px]"
+            className="w-[260px] max-w-full"
             maxLength={80}
           />
           <div className="field-hint">
@@ -221,7 +221,7 @@ export function StationSection({ data, form, setForm, busy, saveSettings }: Sect
               }))
             }
           >
-            <SelectTrigger className="w-[240px]" aria-label="Weather units"><SelectValue /></SelectTrigger>
+            <SelectTrigger className="w-[240px] max-w-full" aria-label="Weather units"><SelectValue /></SelectTrigger>
             <SelectContent>
               <SelectGroup>
                 <SelectItem value="metric">Metric (°C)</SelectItem>
@@ -245,7 +245,7 @@ export function StationSection({ data, form, setForm, busy, saveSettings }: Sect
               setForm(f => ({ ...f, timezone: val === 'auto' ? '' : val }))
             }
           >
-            <SelectTrigger className="w-[300px]" aria-label="Station timezone"><SelectValue /></SelectTrigger>
+            <SelectTrigger className="w-[300px] max-w-full" aria-label="Station timezone"><SelectValue /></SelectTrigger>
             <SelectContent>
               <SelectGroup>
                 <SelectItem value="auto">Auto, server timezone ({serverTz})</SelectItem>
@@ -289,7 +289,7 @@ export function StationSection({ data, form, setForm, busy, saveSettings }: Sect
               setForm(f => ({ ...f, locale: normalizeStationLocale(val) }))
             }
           >
-            <SelectTrigger className="w-[260px]" aria-label="Station locale"><SelectValue /></SelectTrigger>
+            <SelectTrigger className="w-[260px] max-w-full" aria-label="Station locale"><SelectValue /></SelectTrigger>
             <SelectContent>
               <SelectGroup>
                 <SelectItem value="en-GB">English (UK), 24-hour</SelectItem>
@@ -356,9 +356,11 @@ export function StationSection({ data, form, setForm, busy, saveSettings }: Sect
               onChange={(e: ChangeEvent<HTMLInputElement>) =>
                 setForm(f => ({ ...f, privacy: { ...f.privacy, password: e.target.value } }))
               }
-              className="w-[320px]"
+              className="w-[320px] max-w-full"
             />
-            <div className="field-hint">
+            {/* break-words: the tune-in URL below is one 48-char token, wider
+                than a phone card. */}
+            <div className="field-hint break-words">
               One password for everyone, used by both locks above (Icecast is
               basic-auth only, so there are no per-user accounts). The web player asks
               for it once and remembers it. Radio apps, VLC, Sonos and the native app

--- a/web/components/admin/settings/ThemeSection.tsx
+++ b/web/components/admin/settings/ThemeSection.tsx
@@ -198,7 +198,7 @@ function ThemeEditorModal({
           extra={{ mode }}
           onApply={applyDraft}
         />
-        <div className="grid grid-cols-[1fr_auto] items-end gap-3">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_auto] sm:items-end">
           <div className="field">
             <Label>theme name</Label>
             <Input value={name} maxLength={60} onChange={(e: ChangeEvent<HTMLInputElement>) => setName(e.target.value)} placeholder="e.g. Sepia Press" />
@@ -403,13 +403,17 @@ export function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSect
               {themes.map(t => {
                 const isActive = t.id === activeId;
                 return (
-                  <div key={t.id} className="flex items-stretch gap-2">
+                  // basis-full: on a phone the swatch strip + name leaves no
+                  // room beside Edit/Remove, so the picker takes the whole row
+                  // and the actions wrap under it. `sm:basis-0` + `grow` is
+                  // byte-for-byte the old `flex-1`.
+                  <div key={t.id} className="flex flex-wrap items-stretch gap-2 sm:flex-nowrap">
                     <button
                       type="button"
                       onClick={() => choose(t)}
                       disabled={busy}
                       className={cn(
-                        'flex min-w-0 flex-1 items-center gap-3 border p-3 text-left disabled:cursor-not-allowed disabled:opacity-60',
+                        'flex min-w-0 grow basis-full items-center gap-3 border p-3 text-left disabled:cursor-not-allowed disabled:opacity-60 sm:basis-0',
                         isActive
                           ? 'border-vermilion bg-[var(--ink-softer)]'
                           : 'border-ink bg-bg hover:bg-[var(--overlay)]',

--- a/web/components/admin/settings/TtsSection.tsx
+++ b/web/components/admin/settings/TtsSection.tsx
@@ -677,7 +677,7 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
                     setForm(f => ({ ...f, kokoroLang: val === '__auto__' ? '' : val }))
                   }
                 >
-                  <SelectTrigger className="w-[260px]" aria-label="Language override"><SelectValue /></SelectTrigger>
+                  <SelectTrigger className="w-[260px] max-w-full" aria-label="Language override"><SelectValue /></SelectTrigger>
                   <SelectContent>
                     <SelectGroup>
                       <SelectItem value="__auto__">Natural, voice default</SelectItem>
@@ -829,7 +829,7 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
             <div className="mt-3.5 grid grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-[18px]">
               <div className="field">
                 <Label>Model</Label>
-                <div className="flex items-stretch gap-2">
+                <div className="flex flex-wrap items-stretch gap-2 sm:flex-nowrap">
                   {ttsDiscovery.models.length > 0 ? (
                     <ModelCombobox
                       models={ttsDiscovery.models}
@@ -947,7 +947,7 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
                 <>
                   <div className="field">
                     <Label>{form.tts.cloud.provider === 'elevenlabs' ? 'ElevenLabs' : 'OpenAI'} API key</Label>
-                    <div className="flex items-stretch gap-2">
+                    <div className="flex flex-wrap items-stretch gap-2 sm:flex-nowrap">
                       <Input
                         type="password"
                         autoComplete="off"

--- a/web/components/admin/settings/shared.tsx
+++ b/web/components/admin/settings/shared.tsx
@@ -457,15 +457,20 @@ interface SaveBarProps {
 export function SaveBar({ note, busy, onSave, saveLabel, extra }: SaveBarProps) {
   return (
     <div className="flex flex-wrap items-center gap-3 border border-ink bg-[var(--ink-softer)] p-3">
-      <span className="size-1.5 rounded-full bg-vermilion" />
-      <span className="text-[12px] leading-[1.5] text-muted">{note}</span>
-      <span className="ml-auto flex gap-2">
+      <span className="size-1.5 shrink-0 rounded-full bg-vermilion" />
+      {/* min-w-0 + break-words: notes carry unbroken values (an
+          `openai-compatible:Qwen3…gguf` model id) that would otherwise set the
+          flex item's min-content and push the bar past a phone viewport. */}
+      <span className="min-w-0 text-[12px] leading-[1.5] break-words text-muted">{note}</span>
+      {/* Full-width action row on a phone (the note takes the whole first
+          line anyway); `sm:` restores the right-aligned inline cluster. */}
+      <span className="ml-auto flex w-full gap-2 sm:w-auto">
         {extra}
         {/* whileTap fires before the network call — operator feels the
             commit even though the actual save toast lands a few hundred
             ms later. */}
-        <m.span whileTap={{ scale: 0.97 }} className="inline-flex">
-          <Btn tone="accent" onClick={onSave} disabled={busy}>{saveLabel}</Btn>
+        <m.span whileTap={{ scale: 0.97 }} className="inline-flex flex-1 sm:flex-none">
+          <Btn tone="accent" onClick={onSave} disabled={busy} className="w-full sm:w-auto">{saveLabel}</Btn>
         </m.span>
       </span>
     </div>
@@ -521,7 +526,8 @@ export function KeyTestResult({ result }: KeyTestResultProps) {
   return (
     <div
       className={cn(
-        'mt-2 max-w-[560px] rounded border bg-[var(--ink-softer)] px-3 py-2 text-[11px] leading-[1.6]',
+        // break-words: provider errors carry raw URLs / long ids.
+        'mt-2 max-w-[560px] rounded border bg-[var(--ink-softer)] px-3 py-2 text-[11px] leading-[1.6] break-words',
         result.ok
           ? 'border-[var(--accent)] text-[color:var(--accent)]'
           : 'border-[var(--danger)] text-[var(--danger)]',

--- a/web/components/admin/skills/SkillEditModal.tsx
+++ b/web/components/admin/skills/SkillEditModal.tsx
@@ -506,7 +506,9 @@ export default function SkillEditModal({ mode, skill, personas, tagSuggestions, 
   // Close / Save on the right. Border + padding supplied by EditorDialog's footer.
   const footer = (
     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 16, flexWrap: 'wrap' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+      {/* Both clusters wrap: on a 390px phone the left one alone (toggle, RUN
+          NOW, EXPORT, DELETE, SHARE TO COMMUNITY) is ~600px of transport. */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
         {airToggle}
         {isEdit && (
           <button type="button" onClick={run} disabled={acting} style={{ padding: '13px 26px', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', transition: 'transform .1s', border: '1px solid var(--accent)', background: 'var(--accent)', color: '#fff', cursor: acting ? 'wait' : 'pointer', opacity: acting ? 0.7 : 1 }}>
@@ -529,7 +531,7 @@ export default function SkillEditModal({ mode, skill, personas, tagSuggestions, 
           </button>
         )}
       </div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
         {dirty && (
           <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--accent)', fontWeight: 700 }}>
             <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--accent)' }} />UNSAVED EDITS
@@ -573,13 +575,13 @@ export default function SkillEditModal({ mode, skill, personas, tagSuggestions, 
                 style={{ ...inputBase, marginTop: 16, padding: '12px 16px', fontSize: 18, fontWeight: 800, letterSpacing: '-0.01em', width: '100%', boxSizing: 'border-box' }}
               />
               {mode === 'create' && (
-                <label style={{ display: 'inline-flex', alignItems: 'center', gap: 10, marginTop: 14 }}>
+                <label style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 10, marginTop: 14 }}>
                   <span style={{ fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--muted)', fontWeight: 700 }}>SLUG</span>
                   <input
                     value={name}
                     onChange={e => setName(e.target.value.toLowerCase())}
                     placeholder="moon-phase"
-                    style={{ ...inputBase, padding: '8px 12px', fontSize: 13, fontWeight: 700, letterSpacing: '0.04em', width: 200, borderColor: name && !nameValid ? 'var(--accent)' : 'var(--ink)' }}
+                    style={{ ...inputBase, padding: '8px 12px', fontSize: 13, fontWeight: 700, letterSpacing: '0.04em', width: 200, maxWidth: '100%', borderColor: name && !nameValid ? 'var(--accent)' : 'var(--ink)' }}
                   />
                 </label>
               )}
@@ -589,7 +591,7 @@ export default function SkillEditModal({ mode, skill, personas, tagSuggestions, 
             <div className="sw-section">
               <div style={sectionLabel}>COOLDOWN · MINIMUM GAP BETWEEN AIRINGS</div>
               <div style={{ display: 'flex', alignItems: 'center', gap: 18, flexWrap: 'wrap', marginTop: 16 }}>
-                <div style={{ display: 'flex' }}>
+                <div style={{ display: 'flex', flexWrap: 'wrap' }}>
                   {COOLDOWN_PRESETS.map((v, i) => (
                     <button key={v} type="button" onClick={() => patch({ cooldown: v })} style={presetStyle(fields.cooldown === v, i)}>{v}</button>
                   ))}
@@ -599,7 +601,7 @@ export default function SkillEditModal({ mode, skill, personas, tagSuggestions, 
                   value={fields.cooldown}
                   onChange={e => patch({ cooldown: e.target.value })}
                   placeholder="45m"
-                  style={{ ...inputBase, width: 128, padding: '11px 15px', fontSize: 15, fontWeight: 700, letterSpacing: '0.04em', fontVariantNumeric: 'tabular-nums' }}
+                  style={{ ...inputBase, width: 128, maxWidth: '100%', padding: '11px 15px', fontSize: 15, fontWeight: 700, letterSpacing: '0.04em', fontVariantNumeric: 'tabular-nums' }}
                 />
               </div>
               <div style={{ fontSize: 12, color: 'var(--muted)', marginTop: 12, letterSpacing: '0.01em' }}>e.g. 45m, 6h, 2d, or a bare number (minutes).</div>
@@ -609,7 +611,7 @@ export default function SkillEditModal({ mode, skill, personas, tagSuggestions, 
             {custom && (
               <div className="sw-section">
                 <div style={sectionLabel}>WHEN IT CAN AIR</div>
-                <div style={{ display: 'flex', marginTop: 16 }}>
+                <div style={{ display: 'flex', flexWrap: 'wrap', marginTop: 16 }}>
                   {([['any', 'ANY TIME'], ['commute', 'COMMUTE ONLY']] as const).map(([w, lbl], i) => (
                     <button key={w} type="button" onClick={() => patch({ window: w })} style={presetStyle(fields.window === w, i)}>{lbl}</button>
                   ))}
@@ -745,7 +747,7 @@ export default function SkillEditModal({ mode, skill, personas, tagSuggestions, 
 
             {/* Brief */}
             <div className="sw-section">
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
                 <div style={sectionLabel}>THE BRIEF · WHAT THE DJ SAYS, AND WHEN TO STAY SILENT</div>
                 {/* Built-ins revert to their shipped default — restores both the
                     brief (SKILL.md) and the data tool (tool.mjs) from the image. */}

--- a/web/components/admin/skills/SkillsTable.tsx
+++ b/web/components/admin/skills/SkillsTable.tsx
@@ -116,7 +116,7 @@ export function SkillsTable({
           type="button"
           onClick={(e) => { e.stopPropagation(); onRunNow(s.name); }}
           disabled={busy === s.name}
-          className={cn('seg-pad seg-pad--slim', busy === s.name && 'is-firing')}
+          className={cn('seg-pad seg-pad--slim min-h-9 sm:min-h-0', busy === s.name && 'is-firing')}
         >
           <span className="seg-led" aria-hidden />
           <span className="seg-label">{busy === s.name ? 'Working…' : 'Run now'}</span>

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -45,6 +45,19 @@ const nextConfig = {
   // server when it loads tailwind.config.js through the ESM loader. Pin the
   // root to this directory.
   outputFileTracingRoot: __dirname,
+  // Dev only. Next blocks requests for /_next/* dev resources whose Origin
+  // isn't localhost, so opening `npm run dev` from a phone or another box on
+  // the LAN/tailnet serves the HTML but never the client bundle — the admin
+  // console then sits on AdminShell's "loading…" branch forever, because
+  // useAdminAuth never hydrates. Testing the admin UI on a real handset is
+  // exactly when you hit this. Comma-separated hosts, no scheme or port:
+  //   SUBWAVE_DEV_ORIGINS=100.120.114.55,192.168.1.227 npm run dev
+  // (or put it in web/.env.local, which is gitignored). Empty in CI and in
+  // production builds, where the setting is ignored anyway.
+  allowedDevOrigins: (process.env.SUBWAVE_DEV_ORIGINS || '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean),
   // Edge redirect for /admin → /admin/dash. The previous approach of a
   // server-component `redirect()` in app/admin/page.tsx crashed Next 15's
   // Router on the post-sign-in re-render: AdminShell renders its sign-in form


### PR DESCRIPTION
The admin console was built desktop-first and read as messy at 390px. This audits all 18 `/admin` routes against a real 390×844 render — not by inspection — and fixes what turned up.

## Method

Screenshotted every admin route at 390px with an automated probe measuring page `scrollWidth`, elements rendering past the viewport, and sub-32px tap targets. Fixed, then re-shot and re-probed each route (plus the five `?tab=` sub-views on Moods and Imaging, which the first pass never reached).

## Result

Zero horizontal overflow and zero clipped content on all 18 routes. Tap targets:

| Route | before → after | | Route | before → after |
|---|---|---|---|---|
| `/admin/connect` | 31 → 1 | | `/admin/debug` | 27 → 4 |
| `/admin/shows/schedule` | 31 → 10 | | `/admin/skills` | 24 → 8 |
| `/admin/moods` | 23 → 0 | | `/admin/dash` | 19 → 8 |
| `/admin/personas` | 9 → 0 | | `/admin/library` | 260 → 55* |

<sub>* The library remainder is a probe false positive — it measures the 13px `<input>`, but each now sits inside a `-m-3 … p-3 sm:m-0 sm:p-0` label giving a 37px hit box with no layout change.</sub>

## The worst offenders

- **Dash health strip** — a 5-cell flex scroller ≈800px wide, so instrument 03 cut mid-word with no scroll affordance. Now a 2-up grid below `sm`, original single row from `sm` up.
- **The Rundown** — header and Takeover clusters ran ~60px past the viewport, putting `Save the week` and `Pin show` out of reach. Both wrap under their titles. The 7-day board keeps its horizontal strip but gains a sticky hour gutter, narrower columns so the next day peeks past the edge, and an explicit swipe hint — Radix only reveals its scrollbar on hover, which a phone never fires.
- **Library** — doorway cards rendered 512px wide; track rows then fit only by crushing the title to ~60px against four action buttons. The actions collapse into one overflow menu below `sm` so the title gets the width back.
- **Skills** — three fixed-width filter Selects and the Community/New skill cluster couldn't share a line; both wrap and go full-width.

## Safety

Every change is either a mobile-first base class restored by an `sm:`/`lg:` variant, or a strictly-safe addition (`min-w-0`, `flex-wrap`, `max-w-full`, an `overflow-x-auto` wrapper). Desktop spot-checked at 1440px on dash, library and the Rundown — unchanged. No component logic, props or behaviour touched; this is a layout pass.

`npm run lint` passes (0 errors). The three `no-explicit-any` warnings in `PlaylistBuilderPanel` are pre-existing on `develop`.

## Known follow-up

`globals.css` is deliberately untouched. `StationHeader` overrides the unlayered `.hs-*` rules with `!` utilities from the component instead. A media query alongside the existing `.strip-mobile` helper would be cleaner — worth a follow-up, not a blocker.

https://claude.ai/code/session_01HvBkjERdfkLkPdUA7AZSFv