### PR TITLE
fix(admin): compact editor footers on mobile

### DIFF
--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -33,7 +33,7 @@ import { SkeletonRows } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/ui/empty-state';
 import { ErrorState } from '@/components/ui/error-state';
 import { V3AlertDialog } from '../ui/alert-dialog';
-import { EditorDialog } from '../ui/editor-dialog';
+import { EditorDialog, EditorFooter } from '../ui/editor-dialog';
 import { Modal } from '../ui/modal';
 import { AiFill } from './AiFill';
 import GenreSuggest from './GenreSuggest';
@@ -977,32 +977,36 @@ function ShowEditor({
       title={<Eyebrow className="text-vermilion">{isNew ? 'New show' : 'Edit show'}</Eyebrow>}
       sub={<span className="caption truncate">{show.name.trim() || 'define a show'}</span>}
       footer={
-        <div className="flex flex-wrap items-center gap-3">
-          {/* left — destructive action */}
-          <Btn lg tone="danger" onClick={onRemove}>Remove</Btn>
-          {/* right — status + close/save */}
-          <span className="ml-auto flex w-full flex-wrap items-center gap-3 sm:w-auto sm:flex-nowrap">
-            {/* Dot + status read as one unit so they take their own line on a
-                phone instead of squeezing the message to a 90px column. */}
-            <span className="flex w-full min-w-0 items-center gap-3 sm:w-auto">
+        <EditorFooter
+          status={(
+            <>
               <span
                 className={cn(
                   'size-1.5 flex-none rounded-full',
                   valid ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
                 )}
               />
-              <span className="min-w-0 text-[11px] text-muted">
+              <span className="min-w-0">
                 {!valid
                   ? <span className="text-[var(--danger)]">this show needs a name and a persona</span>
                   : 'saves this show · schedule it on the grid, then Save schedule'}
               </span>
-            </span>
-            <Btn lg onClick={onClose}>Close</Btn>
-            <Btn lg tone="accent" onClick={onSave} disabled={busy || !valid}>
-              {busy ? 'Saving…' : 'Save show'}
-            </Btn>
-          </span>
-        </div>
+            </>
+          )}
+          actions={[
+            { id: 'remove', label: 'Remove', tone: 'danger', onClick: onRemove },
+          ]}
+          primary={[
+            { id: 'close', label: 'Close', onClick: onClose },
+            {
+              id: 'save',
+              label: busy ? 'Saving…' : 'Save show',
+              tone: 'accent',
+              onClick: onSave,
+              disabled: busy || !valid,
+            },
+          ]}
+        />
       }
     >
       <div ref={editorRef} className="grid">

--- a/web/components/admin/personas/PersonaEditor.tsx
+++ b/web/components/admin/personas/PersonaEditor.tsx
@@ -7,11 +7,11 @@
 import type { RefObject } from 'react';
 import type { Persona, PersonaTts, SettingsResponse, SkillCatalogEntry } from './types';
 import type { AdminAuth } from '../../../lib/adminAuth';
-import { Btn, Eyebrow, Pill } from '../ui';
+import { Eyebrow, Pill } from '../ui';
 import { cn } from '../../../lib/cn';
 import { personaSubmitUrl } from '../../../lib/repo';
 import { DIAL_NEUTRAL } from './constants';
-import { EditorDialog } from '../../ui/editor-dialog';
+import { EditorDialog, EditorFooter } from '../../ui/editor-dialog';
 import { PersonaIdentityCard } from './PersonaIdentityCard';
 import { PersonaBehaviorCard } from './PersonaBehaviorCard';
 import { PersonaVoiceCard } from './PersonaVoiceCard';
@@ -99,61 +99,64 @@ export function PersonaEditor({
         </span>
       )}
       footer={
-        <div className="flex w-full flex-col gap-2">
-          {/* status line — its own row so the action buttons never wrap */}
-          <div className="flex items-center gap-2">
-            <span
-              className={cn(
-                'size-1.5 flex-none rounded-full',
-                canSave ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
-              )}
-            />
-            <span className="text-[11px] text-muted">
-              {!canSave && !focusedOk
-                ? <span className="text-[var(--danger)]">this persona has a missing or invalid field</span>
-                : !canSave && !allPersonasOk
-                  ? <span className="text-[var(--danger)]">another persona in the roster is incomplete</span>
-                  : !canSave && !promptOk
-                    ? <span className="text-[var(--danger)]">fix the system-prompt library</span>
-                    : 'changes apply on the next spoken line · no mixer restart'}
-            </span>
-          </div>
-          {/* action row */}
-          <div className="flex flex-wrap items-center gap-3">
-            {/* left — persona-scoped actions. Wraps on phones: the three lg
-                buttons are ~530px of transport and can't share one line. */}
-            <span className="flex flex-wrap items-center gap-2">
+        <EditorFooter
+          status={(
+            <>
+              <span
+                className={cn(
+                  'size-1.5 flex-none rounded-full',
+                  canSave ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
+                )}
+              />
+              <span className="min-w-0">
+                {!canSave && !focusedOk
+                  ? <span className="text-[var(--danger)]">this persona has a missing or invalid field</span>
+                  : !canSave && !allPersonasOk
+                    ? <span className="text-[var(--danger)]">another persona in the roster is incomplete</span>
+                    : !canSave && !promptOk
+                      ? <span className="text-[var(--danger)]">fix the system-prompt library</span>
+                      : 'changes apply on the next spoken line · no mixer restart'}
+              </span>
+              {/* Standing state, not an action — rides the status row so the
+                  transport stays a row of verbs. */}
               {persona.id === onAirPersonaId && <Pill tone="accent" className="text-[8px]">on air</Pill>}
-              {persona.id === activePersonaId
-                ? <Pill className="text-[8px]">default</Pill>
-                : <Btn lg onClick={onSetActive}>Set as default</Btn>}
-              <Btn
-                lg
-                tone="danger"
-                onClick={onRemove}
-                disabled={personaCount <= 1}
-                title={personaCount > 1 ? 'Remove this persona' : 'At least one persona is required'}
-              >
-                Remove
-              </Btn>
-              <Btn
-                lg
-                onClick={shareToCommunity}
-                disabled={!persona.name.trim() || !persona.soul.trim()}
-                title="Open a prefilled GitHub form to share this persona with every station (voice and avatar stay yours)"
-              >
-                Share to community
-              </Btn>
-            </span>
-            {/* right — discard/save */}
-            <span className="ml-auto flex flex-wrap items-center justify-end gap-3">
-              <Btn lg onClick={onDiscard} disabled={busy}>Discard</Btn>
-              <Btn lg tone="accent" onClick={onSave} disabled={busy || !canSave}>
-                {busy ? 'Saving…' : 'Save persona'}
-              </Btn>
-            </span>
-          </div>
-        </div>
+              {persona.id === activePersonaId && <Pill className="text-[8px]">default</Pill>}
+            </>
+          )}
+          actions={[
+            {
+              id: 'default',
+              label: 'Set as default',
+              onClick: onSetActive,
+              hidden: persona.id === activePersonaId,
+            },
+            {
+              id: 'remove',
+              label: 'Remove',
+              tone: 'danger',
+              onClick: onRemove,
+              disabled: personaCount <= 1,
+              title: personaCount > 1 ? 'Remove this persona' : 'At least one persona is required',
+            },
+            {
+              id: 'share',
+              label: 'Share to community',
+              onClick: shareToCommunity,
+              disabled: !persona.name.trim() || !persona.soul.trim(),
+              title: 'Open a prefilled GitHub form to share this persona with every station (voice and avatar stay yours)',
+            },
+          ]}
+          primary={[
+            { id: 'discard', label: 'Discard', onClick: onDiscard, disabled: busy },
+            {
+              id: 'save',
+              label: busy ? 'Saving…' : 'Save persona',
+              tone: 'accent',
+              onClick: onSave,
+              disabled: busy || !canSave,
+            },
+          ]}
+        />
       }
     >
       <div ref={editorRef} className="grid">

--- a/web/components/admin/skills/SkillEditModal.tsx
+++ b/web/components/admin/skills/SkillEditModal.tsx
@@ -20,7 +20,7 @@ import type { CSSProperties } from 'react';
 import { notify, errorMessage } from '../../../lib/notify';
 import { useAdminAuth } from '../../../lib/adminAuth';
 import { V3AlertDialog } from '../../ui/alert-dialog';
-import { EditorDialog } from '../../ui/editor-dialog';
+import { EditorDialog, EditorFooter } from '../../ui/editor-dialog';
 import { SkeletonForm } from '@/components/ui/skeleton';
 import { Eyebrow } from '../ui';
 import { CONTEXT_FIELD_LABELS, CONTEXT_FIELDS_FALLBACK, splitContext } from './contextFields';
@@ -492,62 +492,91 @@ export default function SkillEditModal({ mode, skill, personas, tagSuggestions, 
   );
   // On-air toggle (edit only) — lives in the footer with the other actions so
   // the header stays uniform across all three editors.
+  // Sized down on a phone (52x26) — the footer is fixed furniture, and the
+  // toggle is the one control that can't collapse into the overflow menu.
   const airToggle = isEdit ? (
     <div
       onClick={() => { if (!acting) toggleEnabled(); }}
       title={enabled ? 'On air — click to take off air' : 'Off air — click to put on air'}
-      style={{ position: 'relative', width: 62, height: 30, border: '1px solid var(--ink)', flex: 'none', cursor: acting ? 'wait' : 'pointer', transition: 'background .15s cubic-bezier(.2,.7,.2,1)', background: enabled ? 'var(--ink)' : 'transparent', opacity: acting ? 0.6 : 1 }}
+      role="switch"
+      aria-checked={enabled}
+      aria-label="On air"
+      className="relative h-[26px] w-[52px] flex-none border border-ink transition-colors sm:h-[30px] sm:w-[62px]"
+      style={{ cursor: acting ? 'wait' : 'pointer', background: enabled ? 'var(--ink)' : 'transparent', opacity: acting ? 0.6 : 1 }}
     >
-      <div style={{ position: 'absolute', top: 2, left: 2, width: 24, height: 24, transition: 'transform .18s cubic-bezier(.2,.7,.2,1)', background: enabled ? 'var(--bg)' : 'var(--ink)', transform: `translateX(${enabled ? 32 : 0}px)` }} />
+      <div
+        className={`absolute top-[2px] left-[2px] size-[20px] transition-transform duration-200 sm:size-[24px] ${
+          enabled ? 'translate-x-[26px] sm:translate-x-[32px]' : 'translate-x-0'
+        }`}
+        style={{ background: enabled ? 'var(--bg)' : 'var(--ink)' }}
+      />
     </div>
   ) : null;
 
-  // Transport bar — on-air toggle / Run / Delete on the left, unsaved / flash /
-  // Close / Save on the right. Border + padding supplied by EditorDialog's footer.
+  // Transport bar — the shared EditorFooter: on-air toggle always visible, the
+  // editor verbs (run / export / delete / share) inline on desktop and behind a
+  // single `⋯` on a phone, Close/Save pinned right. Status (unsaved / flash)
+  // rides its own line. Border + padding come from EditorDialog's footer slot.
   const footer = (
-    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 16, flexWrap: 'wrap' }}>
-      {/* Both clusters wrap: on a 390px phone the left one alone (toggle, RUN
-          NOW, EXPORT, DELETE, SHARE TO COMMUNITY) is ~600px of transport. */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
-        {airToggle}
-        {isEdit && (
-          <button type="button" onClick={run} disabled={acting} style={{ padding: '13px 26px', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', transition: 'transform .1s', border: '1px solid var(--accent)', background: 'var(--accent)', color: '#fff', cursor: acting ? 'wait' : 'pointer', opacity: acting ? 0.7 : 1 }}>
-            ▸ RUN NOW
-          </button>
-        )}
-        {isEdit && (
-          <button type="button" onClick={exportZip} className="sw-ghost" title="Download this skill as a .zip (SKILL.md + tool.mjs)" style={{ padding: '13px 22px', background: 'transparent', color: 'var(--muted)', border: '1px solid color-mix(in oklab, var(--ink) 24%, transparent)', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', cursor: 'pointer' }}>
-            ↓ EXPORT
-          </button>
-        )}
-        {isEdit && custom && (
-          <button type="button" onClick={() => setConfirmDelete(true)} disabled={acting} className="sw-ghost" style={{ padding: '13px 22px', background: 'transparent', color: 'var(--danger)', border: '1px solid var(--danger)', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', cursor: acting ? 'wait' : 'pointer', opacity: acting ? 0.7 : 1 }}>
-            DELETE
-          </button>
-        )}
-        {isEdit && custom && !hasTool && (
-          <button type="button" onClick={shareToCommunity} className="sw-ghost" title="Open a prefilled GitHub issue to share this skill with the community" style={{ padding: '13px 22px', background: 'transparent', color: 'var(--muted)', border: '1px solid color-mix(in oklab, var(--ink) 24%, transparent)', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', cursor: 'pointer' }}>
-            ↗ SHARE TO COMMUNITY
-          </button>
-        )}
-      </div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
-        {dirty && (
-          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--accent)', fontWeight: 700 }}>
-            <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--accent)' }} />UNSAVED EDITS
-          </span>
-        )}
-        {flash && (
-          <span className="v3-blink" style={{ fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--accent)', fontWeight: 700 }}>✓ {flash}</span>
-        )}
-        <button type="button" onClick={onClose} className="sw-ghost" style={{ padding: '13px 22px', background: 'transparent', color: 'var(--muted)', border: '1px solid color-mix(in oklab, var(--ink) 24%, transparent)', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', cursor: 'pointer' }}>
-          CLOSE
-        </button>
-        <button type="button" onClick={save} disabled={!canSave} style={{ padding: '13px 26px', background: canSave ? 'var(--ink)' : 'color-mix(in oklab, var(--ink) 20%, transparent)', color: 'var(--bg)', border: '1px solid var(--ink)', fontSize: 11, fontWeight: 700, letterSpacing: '0.2em', textTransform: 'uppercase', cursor: canSave ? 'pointer' : 'not-allowed' }}>
-          {busy ? (mode === 'create' ? 'CREATING…' : 'SAVING…') : (mode === 'create' ? 'CREATE' : 'SAVE')}
-        </button>
-      </div>
-    </div>
+    <EditorFooter
+      status={(dirty || flash) ? (
+        <>
+          {dirty && (
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--accent)', fontWeight: 700 }}>
+              <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--accent)' }} />UNSAVED EDITS
+            </span>
+          )}
+          {flash && (
+            <span className="v3-blink" style={{ fontSize: 10, letterSpacing: '0.18em', textTransform: 'uppercase', color: 'var(--accent)', fontWeight: 700 }}>✓ {flash}</span>
+          )}
+        </>
+      ) : null}
+      extra={airToggle}
+      actions={[
+        {
+          id: 'run',
+          label: '▸ Run now',
+          tone: 'accent',
+          onClick: run,
+          disabled: acting,
+          hidden: !isEdit,
+        },
+        {
+          id: 'export',
+          label: '↓ Export',
+          onClick: exportZip,
+          title: 'Download this skill as a .zip (SKILL.md + tool.mjs)',
+          hidden: !isEdit,
+        },
+        {
+          id: 'delete',
+          label: 'Delete',
+          tone: 'danger',
+          onClick: () => setConfirmDelete(true),
+          disabled: acting,
+          hidden: !(isEdit && custom),
+        },
+        {
+          id: 'share',
+          label: '↗ Share to community',
+          onClick: shareToCommunity,
+          title: 'Open a prefilled GitHub issue to share this skill with the community',
+          hidden: !(isEdit && custom && !hasTool),
+        },
+      ]}
+      primary={[
+        { id: 'close', label: 'Close', onClick: onClose },
+        {
+          id: 'save',
+          label: busy
+            ? (mode === 'create' ? 'Creating…' : 'Saving…')
+            : (mode === 'create' ? 'Create' : 'Save'),
+          tone: 'solid',
+          onClick: save,
+          disabled: !canSave,
+        },
+      ]}
+    />
   );
 
   return (

--- a/web/components/ui/editor-dialog.tsx
+++ b/web/components/ui/editor-dialog.tsx
@@ -4,7 +4,15 @@ import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { AnimatePresence, m } from 'motion/react';
+import { MoreHorizontal } from 'lucide-react';
 import { cn } from '../../lib/cn';
+import { Button } from './button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from './dropdown-menu';
 
 /* V3 EditorDialog — the full-screen, edge-to-edge editor used for add/edit of
    shows, personas and skills. One shell, three editors, one consistent shape:
@@ -106,10 +114,12 @@ export function EditorDialog({
                   </div>
                 </div>
 
-                {/* Sticky footer — the transport bar; all actions live here */}
+                {/* Sticky footer — the transport bar; all actions live here.
+                    Padding is tighter on a phone: the footer is fixed furniture
+                    stealing height from the form above it. */}
                 {footer && (
                   <div className="flex-none border-t border-ink">
-                    <div className={cn(column, 'py-3')}>
+                    <div className={cn(column, 'py-2 sm:py-3')}>
                       {footer}
                     </div>
                   </div>
@@ -120,5 +130,139 @@ export function EditorDialog({
         )}
       </AnimatePresence>
     </Dialog.Root>
+  );
+}
+
+/* ── EditorFooter ────────────────────────────────────────────────────────────
+   The transport bar shared by the shows / personas / skills editors.
+
+   Each editor used to hand `EditorDialog` its own hand-rolled flex row of `lg`
+   buttons with `flex-wrap`. That reads fine on a desktop and falls apart on a
+   phone: the skills bar alone (on-air toggle, RUN NOW, EXPORT, DELETE, SHARE TO
+   COMMUNITY, CLOSE, SAVE) is ~600px of transport, so it wrapped into four rows
+   and ate half the viewport — leaving a sliver of the form the operator is
+   actually editing.
+
+   So the footer is data-driven, and the phone gets a different shape rather
+   than the same shape reflowed:
+
+     • `primary` (close/save) always stays visible — one row, never wraps.
+     • `actions` (the editor-scoped verbs: remove, run, export, share…) render
+       inline from `sm:` up, and collapse into a single `⋯` overflow menu below
+       it. One button instead of five.
+     • `status` gets its own line above, so a long validation message never
+       pushes the buttons around.
+     • buttons run at the default size on a phone and `lg` from `sm:` up.
+
+   Both branches are rendered and CSS-hidden (not `useIsMobile`) so the footer
+   is stable through hydration — a first paint with the wrong branch would jump
+   the whole panel. */
+export interface EditorAction {
+  id: string;
+  /** Button label. Text only, please — it doubles as the overflow-menu row. */
+  label: ReactNode;
+  onClick: () => void;
+  tone?: 'default' | 'solid' | 'accent' | 'danger';
+  disabled?: boolean;
+  title?: string;
+  /** Left off the bar entirely (keeps call sites free of `&&` gymnastics). */
+  hidden?: boolean;
+  /** Leading icon, rendered in both the button and the menu row. */
+  icon?: ReactNode;
+}
+
+const TONE_VARIANT = {
+  default: 'default',
+  solid: 'solid',
+  accent: 'accent',
+  danger: 'destructive',
+} as const;
+
+/* Default size on a phone, `lg` from sm: up — mirrors buttonVariants' `lg`. */
+const RESPONSIVE_SIZE = 'sm:px-[22px] sm:py-[11px] sm:text-[11px]';
+
+function ActionButton({ action, className }: { action: EditorAction; className?: string }) {
+  return (
+    <Button
+      type="button"
+      variant={TONE_VARIANT[action.tone || 'default']}
+      onClick={action.onClick}
+      disabled={action.disabled}
+      title={action.title}
+      className={cn(RESPONSIVE_SIZE, className)}
+    >
+      {action.icon}
+      {action.label}
+    </Button>
+  );
+}
+
+export interface EditorFooterProps {
+  /** Validation / hint line. Rendered on its own row above the buttons. */
+  status?: ReactNode;
+  /** Always-visible control that isn't a button (the skills on-air toggle). */
+  extra?: ReactNode;
+  /** Editor-scoped verbs. Inline on desktop, `⋯` overflow menu on a phone. */
+  actions?: EditorAction[];
+  /** Close / save. Always visible, always last. */
+  primary?: EditorAction[];
+}
+
+export function EditorFooter({ status, extra, actions = [], primary = [] }: EditorFooterProps) {
+  const visible = actions.filter(a => !a.hidden);
+  const primaryVisible = primary.filter(a => !a.hidden);
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      {status && (
+        <div className="flex min-w-0 flex-wrap items-center gap-2 text-[11px] leading-snug text-muted">
+          {status}
+        </div>
+      )}
+      <div className="flex items-center gap-2 sm:gap-3">
+        {extra}
+
+        {/* phone — every secondary verb behind one trigger */}
+        {visible.length > 0 && (
+          <DropdownMenu modal={false}>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="default"
+                size="icon"
+                className="sm:hidden"
+                aria-label="More actions"
+              >
+                <MoreHorizontal aria-hidden="true" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" side="top" className="min-w-[11rem]">
+              {visible.map(a => (
+                <DropdownMenuItem
+                  key={a.id}
+                  disabled={a.disabled}
+                  onSelect={a.onClick}
+                  className={cn(a.tone === 'danger' && 'text-[var(--danger)]')}
+                >
+                  {a.icon}
+                  {a.label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+
+        {/* desktop — the same verbs, spelled out */}
+        {visible.length > 0 && (
+          <div className="hidden flex-wrap items-center gap-2 sm:flex sm:gap-3">
+            {visible.map(a => <ActionButton key={a.id} action={a} />)}
+          </div>
+        )}
+
+        <div className="ml-auto flex min-w-0 items-center gap-2 sm:gap-3">
+          {primaryVisible.map(a => <ActionButton key={a.id} action={a} />)}
+        </div>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## What

The **shows / personas / skills** editors each hand-rolled their own transport bar — a wrapping flex row of `lg` buttons. Fine on desktop, messy on a phone: the skills bar alone (on-air toggle, RUN NOW, EXPORT, DELETE, SHARE TO COMMUNITY, CLOSE, SAVE) is ~600px of transport, so it wrapped into four rows and ate roughly half the viewport — leaving a sliver of the form you're actually editing.

## How

Adds a shared, data-driven `EditorFooter` next to `EditorDialog` and moves all three editors onto it. The phone gets a **different shape**, not the same shape reflowed:

- **primary** (Close / Save) always visible, one row, never wraps
- **secondary verbs** (Remove, Run now, Export, Share, Set as default) render inline from `sm:` up and collapse behind a single `⋯` overflow menu below it
- **status / validation** gets its own line, so a long message can't push the buttons around
- buttons run at the default size on a phone and `lg` from `sm:` up; the footer's own padding tightens too

Both branches are rendered and CSS-hidden rather than switched on `useIsMobile`, so the bar is stable through hydration (a first paint with the wrong branch would jump the whole panel).

Two smaller consequences:

- persona standing state (`on air` / `default`) moved to the status row — it's state, not a verb
- the skills on-air toggle stays visible and shrinks to 52x26 on a phone; its inline-styled buttons are now shared `Button`s, which also lines that editor up with the other two

## Verified

`npm run lint` clean in `web/`. Walked all three editors in a 390x844 viewport and at 1440x900 against a live dev stack: mobile footer is now one button row (+ a status line where applicable), the `⋯` menu opens upward with the right verbs per editor, and the desktop bars are unchanged apart from the status line moving above the buttons in the shows editor (matching what personas already did).

https://claude.ai/code/session_01XrNNyqsaCjb4Rt7MNdjP3j