### PR TITLE
fix(admin): stop the Rundown's save from scrolling out of reach

### DIFF
--- a/web/components/admin/schedule/SaveBar.tsx
+++ b/web/components/admin/schedule/SaveBar.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+// The unsaved-edits bar — the Rundown's save affordance of record.
+//
+// Every edit on this screen (board click, drag, ×, sentence editor) is a LOCAL
+// write; nothing reaches the controller until the week is saved. The header's
+// "Save the week" is the only other place that says so, and it scrolls out of
+// view the moment the operator drops into the 7 × 24 board — which is exactly
+// where the edits happen. So the same action follows them down the page: this
+// strip is `sticky bottom-0`, pinned to the viewport for as long as the week
+// differs from the server, and gone the instant it doesn't.
+//
+// It's the last child of the panel's flex column, so it also occupies real
+// layout space at the end of the page — it never permanently covers content.
+
+import { AnimatePresence, m } from 'motion/react';
+import { useEffect, useState } from 'react';
+import { Button } from '../../ui/button';
+import { Mu } from './bits';
+
+export interface SaveBarProps {
+  /** Hours differing from the server copy. 0 hides the bar. */
+  dirty: number;
+  busy: boolean;
+  onReview: () => void;
+  onDiscard: () => void;
+  onSave: () => void;
+}
+
+/** The ⌘S / Ctrl+S hint — resolved after mount so SSR and the client agree. */
+function useSaveChord(): string {
+  const [mac, setMac] = useState(false);
+  useEffect(() => {
+    setMac(/mac|iphone|ipad/i.test(navigator.platform || navigator.userAgent));
+  }, []);
+  return mac ? '⌘S' : 'Ctrl+S';
+}
+
+export default function SaveBar({ dirty, busy, onReview, onDiscard, onSave }: SaveBarProps) {
+  const chord = useSaveChord();
+  return (
+    <AnimatePresence>
+      {dirty > 0 && (
+        <m.div
+          initial={{ y: '100%' }}
+          animate={{ y: 0 }}
+          exit={{ y: '100%' }}
+          transition={{ type: 'spring', stiffness: 420, damping: 34 }}
+          // z-30 clears the board's sticky hour rail (z-10) and stays under
+          // the Review / leave-guard modals (z-40+).
+          className="sticky bottom-0 z-30 border-t border-ink bg-[var(--card-bg)] shadow-[0_-6px_18px_-12px_rgba(0,0,0,0.45)]"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 px-5 py-3 sm:px-[30px]">
+            <span className="flex min-w-0 flex-1 items-center gap-2.5">
+              <span aria-hidden="true" className="size-2 flex-none animate-pulse bg-[var(--accent)]" />
+              <span className="flex min-w-0 flex-wrap items-baseline gap-x-2.5 gap-y-0.5">
+                <span className="flex-none font-mono text-[11.5px] font-bold tracking-[0.06em] text-ink">
+                  {dirty} unsaved edit{dirty === 1 ? '' : 's'}
+                </span>
+                <Mu className="min-w-0 text-[9px]">
+                  nothing is on air until you save the week
+                </Mu>
+              </span>
+            </span>
+            {/* Full-width on a phone so the three actions get real tap targets
+                instead of being squeezed onto the end of the message line. */}
+            <span className="ml-auto flex w-full flex-none items-center gap-2 sm:w-auto">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="min-h-9 sm:min-h-0"
+                onClick={onReview}
+                disabled={busy}
+              >
+                Review
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="min-h-9 sm:min-h-0"
+                onClick={onDiscard}
+                disabled={busy}
+              >
+                Discard
+              </Button>
+              <Button
+                variant="accent"
+                size="sm"
+                className="ml-auto min-h-9 sm:ml-0 sm:min-h-0"
+                onClick={onSave}
+                disabled={busy}
+              >
+                {busy ? 'Saving…' : 'Save the week'}
+                {!busy && (
+                  <span aria-hidden="true" className="ml-1.5 hidden opacity-70 sm:inline">
+                    {chord}
+                  </span>
+                )}
+              </Button>
+            </span>
+          </div>
+        </m.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/web/components/admin/schedule/SchedulePanel.tsx
+++ b/web/components/admin/schedule/SchedulePanel.tsx
@@ -15,11 +15,13 @@
 import type { ChangeEvent } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useAdminAuth } from '../../../lib/adminAuth';
 import { notify, errorMessage } from '../../../lib/notify';
 import { fmtClock, normalizeStationLocale, zonedDayHour } from '../../../lib/format';
 import type { StationLocale } from '../../../lib/types';
 import { useDynamicStyle } from '../../../hooks/useDynamicStyle';
+import { useUnsavedGuard } from '../../../hooks/useUnsavedGuard';
 import { cn } from '../../../lib/cn';
 import { Button } from '../../ui/button';
 import { Modal } from '../../ui/modal';
@@ -27,6 +29,7 @@ import { SkeletonRows } from '@/components/ui/skeleton';
 import { ErrorState } from '@/components/ui/error-state';
 import { Card } from '../ui';
 import Board from './Board';
+import SaveBar from './SaveBar';
 import EditorBand, { LineEditor } from './EditorBand';
 import type { EditorLine, Suggestion } from './EditorBand';
 import { ColorChip, Mu, SegBtn, SlotMenu } from './bits';
@@ -93,6 +96,7 @@ function hydrateShow(raw: Record<string, unknown>): ScheduleShow | null {
 
 export default function SchedulePanel() {
   const { adminFetch, needsAuth, hydrated } = useAdminAuth();
+  const router = useRouter();
   const [err, setErr] = useState<string | null>(null);
   const [shows, setShows] = useState<ScheduleShow[]>([]);
   const [personas, setPersonas] = useState<Persona[]>([]);
@@ -117,6 +121,9 @@ export default function SchedulePanel() {
 
   const [dismissed, setDismissed] = useState<string[]>([]);
   const [reviewOpen, setReviewOpen] = useState(false);
+  // The in-app destination an unsaved-edits click was held back from (see the
+  // leave guard below); null when nothing is pending.
+  const [pendingHref, setPendingHref] = useState<string | null>(null);
 
   // Takeover (#930).
   const [override, setOverride] = useState<ScheduleOverride | null>(null);
@@ -282,6 +289,40 @@ export default function SchedulePanel() {
       notify.err(errorMessage(e));
       return false;
     } finally { setBusy(false); }
+  };
+
+  /** Drop every local edit back to the week the controller is running. */
+  const discardEdits = () => {
+    if (serverSchedule) setSchedule(cloneWeek(serverSchedule));
+  };
+
+  // ⌘S / Ctrl+S saves, the way every desktop editor does. Held in a ref so the
+  // listener registers once yet always sees the current week; a modifier chord
+  // is safe to honour with a field focused (it never eats a bare keystroke).
+  const chordSaveRef = useRef<() => boolean>(() => false);
+  chordSaveRef.current = () => {
+    if (dirty === 0 || busy) return false;
+    void saveWeek();
+    return true;
+  };
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.repeat || !(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== 's') return;
+      // Swallow the browser's own Save-page chord only when a week actually
+      // went out with it.
+      if (chordSaveRef.current()) e.preventDefault();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  // Leaving with edits pending used to lose them silently — the whole reason
+  // the save is easy to miss. Hold the click, ask, then navigate.
+  useUnsavedGuard(dirty > 0, setPendingHref);
+
+  const leaveTo = (href: string) => {
+    setPendingHref(null);
+    router.push(href);
   };
 
   // ── takeover ─────────────────────────────────────────────────────────────
@@ -636,7 +677,7 @@ export default function SchedulePanel() {
           onArmShow={setLineShowId}
         />
       </div>
-      <div className="flex-1">
+      <div className="flex-1 pb-1">
         <EditorBand
           stats={{
             booked,
@@ -651,6 +692,15 @@ export default function SchedulePanel() {
         />
       </div>
 
+      {/* The save follows the operator down the page — see SaveBar. */}
+      <SaveBar
+        dirty={dirty}
+        busy={busy}
+        onReview={() => setReviewOpen(true)}
+        onDiscard={discardEdits}
+        onSave={saveWeek}
+      />
+
       {/* Review — the unsaved edits behind the header count */}
       <Modal
         open={reviewOpen}
@@ -664,7 +714,7 @@ export default function SchedulePanel() {
               variant="ghost"
               size="sm"
               onClick={() => {
-                if (serverSchedule) setSchedule(cloneWeek(serverSchedule));
+                discardEdits();
                 setReviewOpen(false);
               }}
             >
@@ -702,6 +752,57 @@ export default function SchedulePanel() {
               </span>
             </div>
           ))}
+        </div>
+      </Modal>
+
+      {/* Leave guard — a link was clicked with the week still unsaved. Three
+          ways out, and the default (accent) one keeps the work. */}
+      <Modal
+        open={pendingHref !== null}
+        onOpenChange={open => { if (!open) setPendingHref(null); }}
+        title="Leave without saving?"
+        sub={`${dirty} hour${dirty === 1 ? '' : 's'} changed`}
+        width={520}
+        footer={
+          <div className="flex w-full flex-wrap items-center gap-2">
+            <Button variant="ghost" size="sm" onClick={() => setPendingHref(null)}>
+              Stay here
+            </Button>
+            <span className="ml-auto flex flex-wrap gap-2">
+              <Button
+                variant="default"
+                size="sm"
+                disabled={busy}
+                onClick={() => { if (pendingHref) leaveTo(pendingHref); }}
+              >
+                Discard and leave
+              </Button>
+              <Button
+                variant="accent"
+                size="sm"
+                disabled={busy}
+                onClick={async () => {
+                  const href = pendingHref;
+                  // Only leave once the week is actually on the controller —
+                  // a failed save keeps the operator here with the edits.
+                  if (href && await saveWeek()) leaveTo(href);
+                }}
+              >
+                {busy ? 'Saving…' : 'Save and leave'}
+              </Button>
+            </span>
+          </div>
+        }
+      >
+        <div className="grid gap-2">
+          <span className="text-[13px] leading-[1.6] text-ink">
+            These edits only exist on this screen. Leave now and the station keeps
+            running the week it already has.
+          </span>
+          <Mu className="text-[9px]">
+            {editedRanges.slice(0, 4).map(r => `${dayName(r.day)} ${hhmm(r.start)}–${hhmm(r.end)}`).join(' · ')}
+            {editedRanges.length > 4 ? ` · +${editedRanges.length - 4} more` : ''}
+          </Mu>
         </div>
       </Modal>
     </div>

--- a/web/hooks/useUnsavedGuard.ts
+++ b/web/hooks/useUnsavedGuard.ts
@@ -1,0 +1,74 @@
+'use client';
+
+// Unsaved-work guard for an admin panel that batches edits locally and pushes
+// them in one save (the Rundown's week, and anything else that grows the same
+// shape). Two exits are covered:
+//
+//   - leaving the site / reloading the tab → the browser's own beforeunload
+//     prompt, which is all a page can do there;
+//   - clicking any in-app link (sidebar, breadcrumb, a card) → intercepted in
+//     the CAPTURE phase before Next's router sees it, handed to the caller as
+//     a href so it can ask what to do and navigate itself.
+//
+// Deliberately NOT covered: the browser back button. Trapping it means pushing
+// a decoy history entry, which breaks back for everyone who has nothing
+// pending — a worse trade than the case it saves.
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * @param active     guard only while there is something to lose.
+ * @param onNavigate called with the intercepted in-app destination (path +
+ *                   query + hash). The caller owns the prompt and the
+ *                   subsequent `router.push`.
+ */
+export function useUnsavedGuard(active: boolean, onNavigate: (href: string) => void): void {
+  // Held in a ref so a caller passing an inline arrow doesn't re-register the
+  // listeners on every render.
+  const cb = useRef(onNavigate);
+  cb.current = onNavigate;
+
+  useEffect(() => {
+    if (!active) return;
+
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // Legacy browsers still key off returnValue; the string itself is never
+      // shown (browsers render their own copy).
+      e.returnValue = '';
+    };
+
+    const onClick = (e: MouseEvent) => {
+      // Anything but a plain left click is the operator asking for a new tab,
+      // a context menu, or a download — none of which lose the pending work.
+      if (e.defaultPrevented || e.button !== 0) return;
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+      const target = e.target as Element | null;
+      const a = target?.closest?.('a[href]') as HTMLAnchorElement | null;
+      if (!a || (a.target && a.target !== '_self') || a.hasAttribute('download')) return;
+      const raw = a.getAttribute('href') || '';
+      if (!raw || raw.startsWith('#')) return;
+      let url: URL;
+      try {
+        url = new URL(a.href, window.location.href);
+      } catch {
+        return;
+      }
+      // Off-origin navigations unload the document, so beforeunload already
+      // prompts — intercepting here would double up.
+      if (url.origin !== window.location.origin) return;
+      // A link back to this very screen changes nothing.
+      if (url.pathname === window.location.pathname && url.search === window.location.search) return;
+      e.preventDefault();
+      e.stopPropagation();
+      cb.current(`${url.pathname}${url.search}${url.hash}`);
+    };
+
+    window.addEventListener('beforeunload', onBeforeUnload);
+    document.addEventListener('click', onClick, true);
+    return () => {
+      window.removeEventListener('beforeunload', onBeforeUnload);
+      document.removeEventListener('click', onClick, true);
+    };
+  }, [active]);
+}


### PR DESCRIPTION
## The problem

On `/admin/shows/schedule` every edit — board click, drag, the card ×, the sentence editor — is a **local** write. Nothing reaches the controller until **Save the week**. But that button lives only in the page header, and the Rundown is a tall page: the header scrolls away the moment you drop into the 7 × 24 board, which is exactly where the editing happens. Operators kept programming a week and walking away from it.

## The change

No change to the data model or the `PUT /schedule` contract.

**1. A sticky save bar** (`web/components/admin/schedule/SaveBar.tsx`) — `sticky bottom-0`, visible for as long as the week differs from the server, gone the instant it doesn't. Carries the edit count, the reason it matters ("nothing is on air until you save the week"), and Review / Discard / Save. It's the last child of the panel column, so it also occupies real layout space at the end of the page and never permanently covers content. `z-30` clears the board's sticky hour rail and stays under the modals.

**2. A leave guard** (`web/hooks/useUnsavedGuard.ts`) — `beforeunload` for tab close/reload, plus a capture-phase intercept of in-app link clicks (before Next's router sees them) that hands the href back to the panel: **Stay here / Discard and leave / Save and leave**. "Save and leave" only navigates once the controller actually has the week — a failed save keeps you on the screen with your edits.

Back/forward is deliberately **not** trapped: that needs a decoy history entry, which breaks back for everyone who has nothing pending.

**3. ⌘S / Ctrl+S saves**, and only swallows the browser's own Save-page chord when a week actually went out with it.

## Verified

Ran the panel against a stub controller in a real browser:

- bar stays pinned to the viewport bottom while scrolled deep in the board, showing `4 unsaved edits`;
- clicking a sidebar link with edits pending holds the navigation and opens the prompt, listing the changed ranges;
- **Save and leave** → `PUT /schedule` → lands on `/admin/dash`;
- **Ctrl+S** → "Week saved" toast, bar retracts;
- no bar at all when the week is clean.

`cd web && npm run lint` (eslint + `tsc --noEmit`) exits 0.

https://claude.ai/code/session_01QJnF3hC9rbnAUakheJtu92