### PR TITLE
fix(web): clamp long catalog descriptions on the public showcase pages

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4592,10 +4592,54 @@ html:has(.admin-root.paper) {
     color: var(--muted);
 }
 .bs-skill-brief {
+    display: block;
     margin: 0;
     font-size: 14px;
     line-height: 1.6;
     color: var(--muted);
+}
+/* Long briefs (a persona soul runs to 1000 chars) are wrapped in a native
+   <details> by components/ui/catalog-brief.tsx and clamped to four lines while
+   closed — CSS-only, so the showcase pages stay server-rendered. */
+.bs-skill-brief-block:not([open]) .bs-skill-brief {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+    line-clamp: 4;
+    overflow: hidden;
+}
+.bs-skill-brief-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+    cursor: pointer;
+    /* Drop the native disclosure triangle — the Read more / Show less line is
+       the affordance, and the marker would sit against the clamped prose. */
+    list-style: none;
+}
+.bs-skill-brief-summary::-webkit-details-marker {
+    display: none;
+}
+.bs-skill-brief-toggle {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--accent);
+}
+.bs-skill-brief-summary:hover .bs-skill-brief-toggle {
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+/* One label at a time; display:none keeps the hidden one out of the a11y tree,
+   so the summary reads with the right verb. */
+.bs-skill-brief-close,
+.bs-skill-brief-block[open] .bs-skill-brief-open {
+    display: none;
+}
+.bs-skill-brief-block[open] .bs-skill-brief-close {
+    display: inline;
 }
 .bs-skill-tags {
     list-style: none;

--- a/web/components/personas/CommunityPersonaCard.tsx
+++ b/web/components/personas/CommunityPersonaCard.tsx
@@ -1,3 +1,4 @@
+import CatalogBrief from '@/components/ui/catalog-brief';
 import type { CommunityPersona } from '@/lib/communityPersonas';
 
 // One card in the /personas showcase grid. Browse-only: it presents a
@@ -21,7 +22,7 @@ export default function CommunityPersonaCard({ persona }: { persona: CommunityPe
 
       {persona.tagline && <p className="bs-skill-cadence">{persona.tagline}</p>}
 
-      <p className="bs-skill-brief">{persona.soul}</p>
+      <CatalogBrief text={persona.soul} />
 
       {tags.length > 0 && (
         <ul className="bs-skill-tags" aria-label="Behaviour">

--- a/web/components/shows/CommunityShowCard.tsx
+++ b/web/components/shows/CommunityShowCard.tsx
@@ -1,3 +1,4 @@
+import CatalogBrief from '@/components/ui/catalog-brief';
 import type { CommunityShow, EraWindow } from '@/lib/communityShows';
 
 // Render an era window as a compact label: "1988–1996", a single year when the
@@ -38,7 +39,7 @@ export default function CommunityShowCard({ show }: { show: CommunityShow }) {
         {show.filtersStrict && <span className="bs-skill-cadence">strict filters</span>}
       </div>
 
-      <p className="bs-skill-brief">{show.topic}</p>
+      <CatalogBrief text={show.topic} />
 
       {filters.length > 0 && (
         <ul className="bs-skill-tags" aria-label="Music filters">

--- a/web/components/skills/CommunitySkillCard.tsx
+++ b/web/components/skills/CommunitySkillCard.tsx
@@ -1,3 +1,4 @@
+import CatalogBrief from '@/components/ui/catalog-brief';
 import type { CommunitySkill } from '@/lib/communitySkills';
 
 // One card in the /skills showcase grid. Browse-only: it presents a community
@@ -17,7 +18,7 @@ export default function CommunitySkillCard({ skill }: { skill: CommunitySkill })
         {skill.cooldown && <span className="bs-skill-cadence">{skill.cooldown} cooldown</span>}
       </div>
 
-      <p className="bs-skill-brief">{skill.brief}</p>
+      <CatalogBrief text={skill.brief} />
 
       {contexts.length > 0 && (
         <ul className="bs-skill-tags" aria-label="Uses live context">

--- a/web/components/ui/catalog-brief.tsx
+++ b/web/components/ui/catalog-brief.tsx
@@ -1,0 +1,35 @@
+// The description line shared by the three community showcase cards
+// (/personas, /skills, /shows). Catalog copy runs from ~170 characters to a
+// full 1000-character persona soul, which left the grid badly ragged — one card
+// four lines tall next to one running twenty.
+//
+// Long briefs are clamped to four lines behind a native <details> disclosure, so
+// nothing is lost (these pages are the only place a visitor can read the copy —
+// there is no per-entry detail route) and the showcase pages stay server
+// components with no client JS. Short briefs render as a plain paragraph rather
+// than wearing a toggle that would reveal nothing.
+//
+// The threshold is deliberately below four lines' worth of text at the widest
+// column: an occasional no-op toggle is a smaller sin than text clamped away
+// with no way to open it.
+const CLAMP_CHARS = 240;
+
+export default function CatalogBrief({ text }: { text?: string }) {
+  const body = (text || '').trim();
+  if (!body) return null;
+
+  if (body.length <= CLAMP_CHARS) return <p className="bs-skill-brief">{body}</p>;
+
+  return (
+    <details className="bs-skill-brief-block">
+      {/* Phrasing content only — <summary> can't legally hold a <p>. */}
+      <summary className="bs-skill-brief-summary">
+        <span className="bs-skill-brief">{body}</span>
+        <span className="bs-skill-brief-toggle">
+          <span className="bs-skill-brief-open">Read more</span>
+          <span className="bs-skill-brief-close">Show less</span>
+        </span>
+      </summary>
+    </details>
+  );
+}


### PR DESCRIPTION
## What

`/personas`, `/skills` and `/shows` rendered the **full** catalog description in every card. Community entries run from ~170 characters to a full 1000-character persona soul, so the grid went badly ragged — a four-line card sitting next to one running twenty.

Long briefs now clamp to four lines behind a native `<details>` disclosure, shared by all three cards via a new `components/ui/catalog-brief.tsx`.

## Why this shape

- **CSS-only** (`:not([open])` + `-webkit-line-clamp`), so the three showcase pages stay server components with no client JS.
- **Nothing is lost** — these pages are the only place a visitor can read the copy; there is no per-entry detail route, so a hard truncation would hide substance permanently.
- **Short briefs render as a plain `<p>`** rather than wearing a toggle that would reveal nothing. The 240-char threshold sits deliberately below four lines' worth at the widest column: an occasional no-op toggle is a smaller sin than text clamped away with no way to open it.
- The admin community browser already clamped the same soul to three lines (`PersonasPanel`); this brings the public side in line.

## Verified

- `web` `npm run lint` → 0 errors (3 pre-existing `no-explicit-any` warnings in an unrelated file).
- Ran the dev server against the live controller catalog and checked all three pages: cards now align in clean rows, `READ MORE` expands to the full soul and flips to `SHOW LESS`, and short skill briefs (e.g. *Commute check-in*) render with no toggle.