### PR TITLE
feat(docker): GPU acoustic analysis in the all-in-one image (#1186)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,8 @@ SITE_URL=
 # NVIDIA GPU? The heavy stack can run on CUDA instead — not an .env toggle (a
 # GPU device reservation can't live here); layer the analyzer-gpu overlay:
 #   docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d
+# (AIO one-click users: no overlay — pull subwave-aio-cuda and pass the GPU to
+# the container. See docs/unraid.md.)
 # ANALYZE_DEVICE=    # auto (default) / cpu / cuda — torch device for CLAP/Demucs;
 #                    # only meaningful on the cuda analyzer flavour
 # ANALYZE_IDLE_UNLOAD_S=  # cuda flavour: seconds of no analysis before models are

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -79,6 +79,20 @@ jobs:
             build_args: |
               WITH_CLAP=1
               WITH_DEMUCS=1
+          # CUDA AIO — the heavy one-click container with CLAP + Demucs on cu124
+          # torch wheels, for a box with an NVIDIA card (#1186). The AIO analog of
+          # subwave-analyzer-cuda; the operator points the container at this tag
+          # and adds GPU passthrough to its extra parameters (docs/unraid.md).
+          # ~4GB compressed vs -heavy's ~1.3GB, hence its own tag rather than a
+          # default. Needs the disk reclaim below (see `big_build`).
+          - image: subwave-aio-cuda
+            dockerfile: docker/Dockerfile.aio
+            platforms: linux/amd64
+            big_build: true
+            build_args: |
+              WITH_CLAP=1
+              WITH_DEMUCS=1
+              WITH_CUDA=1
           - image: subwave-tts-heavy
             dockerfile: docker/Dockerfile.tts-heavy
             platforms: linux/amd64
@@ -126,6 +140,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Reclaim runner disk before the biggest builds. A GitHub-hosted
+      # ubuntu-latest has ~14GB free on the root filesystem, which is where
+      # /var/lib/docker lives — and subwave-aio-cuda is ~4GB compressed / ~11GB
+      # unpacked (the cu124 nvidia-*-cu12 wheels), enough to hit ENOSPC mid-build
+      # once the buildx layer cache is added on top. These toolchains ship
+      # preinstalled on the runner image and nothing in this workflow uses them;
+      # dropping them frees ~20GB. Gated on the matrix flag so the small builds
+      # don't pay the ~30s for nothing.
+      - name: Free runner disk space
+        if: matrix.big_build
+        run: |
+          set -eux
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/boost /usr/share/swift
+          df -h /
+
       # The version stamped into the images (admin footer + controller). On a tag
       # push `git describe` returns the tag (e.g. v0.31.0); a branch dispatch
       # yields <tag>-<n>-g<sha>. Empty → builds fall back to package.json.
@@ -166,4 +197,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,scope=${{ matrix.image }},mode=max
+          # mode=max caches every intermediate layer, which is right for the
+          # small images. The cuda build's torch layer alone would be several GB
+          # of a 10GB repo-wide GHA cache budget and evict every other scope, so
+          # that one entry exports only the final layers (mode=min).
+          cache-to: type=gha,scope=${{ matrix.image }},mode=${{ matrix.big_build && 'min' || 'max' }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -198,7 +198,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.image }}
           # mode=max caches every intermediate layer, which is right for the
-          # small images. The cuda build's torch layer alone would be several GB
-          # of a 10GB repo-wide GHA cache budget and evict every other scope, so
-          # that one entry exports only the final layers (mode=min).
-          cache-to: type=gha,scope=${{ matrix.image }},mode=${{ matrix.big_build && 'min' || 'max' }}
+          # small images. The cuda build exports NO cache at all: even mode=min
+          # exports the final image's layers, and its multi-GB torch venv layer
+          # sits in the final stage — one entry would evict most other scopes
+          # from the 10GB repo-wide GHA cache budget. Tag builds are rare, so a
+          # cold rebuild is the cheaper trade. (cache-from above stays — it's a
+          # harmless miss while nothing is ever exported to that scope.)
+          cache-to: ${{ !matrix.big_build && format('type=gha,scope={0},mode=max', matrix.image) || '' }}

--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ Container Toolkit, nothing else):
 docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d
 ```
 
+All-in-one installs have no `analyzer` service to swap, so they take the GPU on
+the image instead: pull `subwave-aio-cuda` and hand the container the card
+(`--gpus all`, or the Unraid steps in [`docs/unraid.md`](docs/unraid.md)).
+
 ### Local dev (contributors)
 
 ```bash
@@ -252,7 +256,7 @@ Icecast stream on `:7702` (all configurable). Point your proxy at those three.
 `docker/Caddyfile` is a working reference for the route table you need to
 replicate. Details in [`DEPLOY.md`](DEPLOY.md#bring-your-own-reverse-proxy).
 
-**Images on GHCR.** Tagged releases publish to `ghcr.io/perminder-klair/subwave-{caddy,broadcast,controller,web}`, the default-on `subwave-analyzer` (lean, multi-arch acoustic analysis) sidecar, and the opt-in `subwave-tts-heavy` (expressive voices) sidecar. Heavy-analysis variants — `subwave-analyzer-heavy` and `subwave-aio-heavy` (CLAP + Demucs, amd64) — are published for operators who enable "sounds-like"/vocals, plus `subwave-analyzer-cuda` (the heavy stack on NVIDIA CUDA, amd64) for GPU hosts via the `docker-compose.analyzer-gpu.yml` overlay.
+**Images on GHCR.** Tagged releases publish to `ghcr.io/perminder-klair/subwave-{caddy,broadcast,controller,web}`, the default-on `subwave-analyzer` (lean, multi-arch acoustic analysis) sidecar, and the opt-in `subwave-tts-heavy` (expressive voices) sidecar. Heavy-analysis variants — `subwave-analyzer-heavy` and `subwave-aio-heavy` (CLAP + Demucs, amd64) — are published for operators who enable "sounds-like"/vocals, plus the NVIDIA CUDA builds of that heavy stack (amd64) — `subwave-analyzer-cuda` for split-stack hosts via the `docker-compose.analyzer-gpu.yml` overlay, and `subwave-aio-cuda` for one-click all-in-one hosts.
 All compose files pull `:latest` by default; pin a version with
 `SUBWAVE_VERSION=v1.2.3` in the root `.env`.
 

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -1235,6 +1235,8 @@ SITE_URL=
 # NVIDIA GPU? The heavy stack can run on CUDA instead — not an .env toggle (a
 # GPU device reservation can't live here); layer the analyzer-gpu overlay:
 #   docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d
+# (AIO one-click users: no overlay — pull subwave-aio-cuda and pass the GPU to
+# the container. See docs/unraid.md.)
 # ANALYZE_DEVICE=    # auto (default) / cpu / cuda — torch device for CLAP/Demucs;
 #                    # only meaningful on the cuda analyzer flavour
 # ANALYZE_IDLE_UNLOAD_S=  # cuda flavour: seconds of no analysis before models are

--- a/controller/src/doctor-knowledge.ts
+++ b/controller/src/doctor-knowledge.ts
@@ -171,9 +171,14 @@ regular cadence — it's cheap insurance.
     a visible GPU the worker logs a warning and runs on CPU.
   - **All-in-one image** (\`analyzer local\` — the AIO bundles the analyzer
     in-process): switch the single container's image to
-    \`ghcr.io/perminder-klair/subwave-aio-heavy\`. Do NOT point an AIO install at
-    \`subwave-analyzer-heavy\` — that's the bare analyzer micro-service, and swapping
-    the AIO container to it replaces the whole station with just an analyzer.
+    \`ghcr.io/perminder-klair/subwave-aio-heavy\`, or on an NVIDIA host
+    \`ghcr.io/perminder-klair/subwave-aio-cuda\` (same heavy features on the GPU)
+    with GPU passthrough — \`--gpus all\`, or on Unraid the nvidia runtime plus
+    NVIDIA_VISIBLE_DEVICES / NVIDIA_DRIVER_CAPABILITIES. There is no compose
+    overlay for the AIO; the GPU rides on the image. Do NOT point an AIO install
+    at \`subwave-analyzer-heavy\` or \`subwave-analyzer-cuda\` — those are the bare
+    analyzer micro-service, and swapping the AIO container to one replaces the
+    whole station with just an analyzer.
   - Or turn the setting off (it's costing nothing but false expectations).
 
 ## Listener-request web-resolve (settings.llm.requestWebResolve)

--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -23,7 +23,9 @@
 # one container with no sidecars, so it bakes the venv in and runs it via the
 # controller's in-process local backend (ANALYZE_PYTHON). The heavy CLAP
 # "sounds-like" + Demucs vocal stack is OFF here (kept lean/small); CI publishes
-# a `subwave-aio-heavy` tag (WITH_CLAP=1 WITH_DEMUCS=1) for operators who want it.
+# a `subwave-aio-heavy` tag (WITH_CLAP=1 WITH_DEMUCS=1) for operators who want it,
+# and a `subwave-aio-cuda` tag (+ WITH_CUDA=1) that runs that same heavy stack on
+# an NVIDIA GPU — see the analyzer block below and docs/unraid.md.
 
 # ---- web build: Next.js standalone (mirrors web/Dockerfile) ----------------
 FROM node:22-bookworm-slim AS webbuild
@@ -151,18 +153,42 @@ ENV KOKORO_MODEL=/opt/kokoro/models/kokoro-v1.0.onnx \
 #
 # Version pins mirror the analyzer venv in docker/Dockerfile.analyzer — keep the
 # two in lockstep (same wheels, reproducible rebuilds). torch/torchaudio are held
-# at 2.6.0 off the CPU wheel index. The AIO deliberately stays CPU-only (no
-# WITH_CUDA here): GPU analysis is the split stack's subwave-analyzer-cuda
-# flavour via the docker-compose.analyzer-gpu.yml overlay — a one-click
-# container with GPU passthrough is its own project.
+# at 2.6.0 repo-wide; WITH_CUDA only switches which 2.6.0 BUILD is installed —
+# the cpu wheel index (default) or cu124.
+#
+# WITH_CUDA=1 is the `subwave-aio-cuda` flavour (#1186): heavy + NVIDIA GPU, for
+# operators who run the one-click container on a box with a card and want CLAP +
+# Demucs off the CPU. It implies the heavy tier (CUDA torch with no CLAP/Demucs
+# would be several GB of dead weight), so CI builds it WITH_CLAP=1 WITH_DEMUCS=1.
+# The cu124 wheels vendor the CUDA runtime as nvidia-*-cu12 pip deps, so the base
+# image stays as-is and the host needs only the NVIDIA driver + container runtime
+# (on Unraid: the Nvidia Driver plugin, plus `--runtime=nvidia` and
+# NVIDIA_VISIBLE_DEVICES in the container's extra parameters — see docs/unraid.md).
+# Nothing else changes: analyze_worker.py picks the device itself (ANALYZE_DEVICE
+# defaults to auto — cuda when torch sees a GPU, else cpu with a logged warning),
+# so this image degrades to CPU on a driverless host rather than failing. It is
+# several GB larger than -heavy; the split stack's equivalent is the
+# subwave-analyzer-cuda image via the docker-compose.analyzer-gpu.yml overlay.
+#
+# NOTE: the analyzer venv runs on this base's system python3 (liquidsoap/Debian
+# trixie → 3.13, unlike Dockerfile.analyzer's python:3.11-slim). torch 2.6.0
+# publishes cp313 wheels on both the cpu and cu124 indexes, so the shared pin
+# holds on either side of the switch.
 ARG WITH_CLAP=0
 ARG WITH_DEMUCS=0
-RUN python3 -m venv /opt/analyzer/venv && \
+ARG WITH_CUDA=0
+RUN TORCH_INDEX="https://download.pytorch.org/whl/cpu" && \
+    if [ "$WITH_CUDA" = "1" ]; then TORCH_INDEX="https://download.pytorch.org/whl/cu124"; fi && \
+    python3 -m venv /opt/analyzer/venv && \
     /opt/analyzer/venv/bin/pip install --no-cache-dir --upgrade pip && \
     /opt/analyzer/venv/bin/pip install --no-cache-dir librosa==0.11.0 soundfile==0.14.0 pyloudnorm==0.2.0 && \
     if [ "$WITH_CLAP" = "1" ]; then \
+      # onnxruntime stays the CPU build even under WITH_CUDA: the ONNX path is
+      # the optional CLAP_MODEL_PATH custom-export route, and onnxruntime-gpu
+      # drags in a fragile CUDA/cuDNN version matrix. The default transformers
+      # path is what runs on the GPU.
       /opt/analyzer/venv/bin/pip install --no-cache-dir \
-        --index-url https://download.pytorch.org/whl/cpu \
+        --index-url "$TORCH_INDEX" \
         --extra-index-url https://pypi.org/simple \
         torch==2.6.0 transformers==5.13.0 onnxruntime==1.27.0 && \
       /opt/analyzer/venv/bin/python -c "import torch, transformers, onnxruntime" ; \
@@ -176,7 +202,7 @@ RUN python3 -m venv /opt/analyzer/venv && \
       # base's apt python3 has none, so python3-dev is required for Python.h.
       apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev python3-dev && \
       /opt/analyzer/venv/bin/pip install --no-cache-dir \
-        --index-url https://download.pytorch.org/whl/cpu \
+        --index-url "$TORCH_INDEX" \
         --extra-index-url https://pypi.org/simple \
         torch==2.6.0 torchaudio==2.6.0 demucs==4.0.1 diffq==0.2.4 && \
       /opt/analyzer/venv/bin/python -c "import torch, demucs, diffq" && \

--- a/docs/gpu-tts.md
+++ b/docs/gpu-tts.md
@@ -8,6 +8,8 @@ to work.
 > **Not TTS?** Library *analysis* (CLAP "sounds-like" + Demucs vocals) has its
 > own GPU path — the `docker-compose.analyzer-gpu.yml` overlay, no rebuild
 > needed. See [docs/tts-heavy.md → Heavy analysis on an NVIDIA GPU](tts-heavy.md#heavy-analysis-on-an-nvidia-gpu-cuda).
+> On the **all-in-one** image there's no overlay: point the container at the
+> `subwave-aio-cuda` tag instead — see [docs/unraid.md](unraid.md#acoustic-analysis-default-on--expressive-voices-opt-in).
 
 | | Easy route (OpenAI layer) | Native route (sidecar on GPU) |
 |---|---|---|

--- a/docs/tts-heavy.md
+++ b/docs/tts-heavy.md
@@ -49,7 +49,8 @@ start getting tempo/key/loudness.
 - **AIO.** The all-in-one image bundles the analyzer *in-process* (a local
   `librosa` venv the controller drives directly), so the one-click container has
   analysis with no second service. (`subwave-aio` is lean; `subwave-aio-heavy`
-  bakes CLAP + Demucs.)
+  bakes CLAP + Demucs, and `subwave-aio-cuda` runs that same pair on an NVIDIA
+  GPU.)
 - **Fallbacks.** If the `analyzer` service isn't reachable, the controller falls
   back to a [local venv](#running-analysis-without-a-sidecar-dev--offline).
   (`tts-heavy` is TTS-only now — it no longer carries the analyzer.)
@@ -77,7 +78,8 @@ Then `docker compose up -d` (Compose re-pulls the `analyzer` service as
   **Save**, then **Pull & Up**.
 - **Unraid one-click (AIO).** There's no second container to swap — instead point
   the container's **Repository** at `ghcr.io/perminder-klair/subwave-aio-heavy`
-  and re-pull.
+  and re-pull. (Got an NVIDIA card? Use `subwave-aio-cuda` and pass the GPU
+  through instead — [full steps](unraid.md#acoustic-analysis-default-on--expressive-voices-opt-in).)
 
 The heavy image is **amd64-only** (the CPU-torch stack). On an arm64 host also
 set `DOCKER_DEFAULT_PLATFORM=linux/amd64` — it runs under emulation (slow, but
@@ -102,8 +104,14 @@ cu124 torch wheels) and hands it the GPU. Requirements: the NVIDIA driver +
 device itself (`ANALYZE_DEVICE=auto`): if the GPU isn't actually visible it logs
 a warning and falls back to CPU rather than failing the pass. `ANALYZER_HEAVY`
 is irrelevant while the overlay is applied — the image is overridden outright.
-(The AIO one-click container stays CPU-only; GPU analysis needs the split
-stack.)
+
+Running the **all-in-one** container instead? It has no `analyzer` service to
+swap, so there's no overlay: pull the `subwave-aio-cuda` tag (the heavy AIO built
+on the same cu124 wheels) and hand the container the GPU directly. Steps for
+Unraid, including the driver plugin and the extra parameters, are in
+[unraid.md](unraid.md#acoustic-analysis-default-on--expressive-voices-opt-in);
+anywhere else it's `--gpus all` on your `docker run`. Everything below about
+device selection and VRAM applies there unchanged.
 
 Sharing the card with a local TTS or LLM? The worker plays nice: after ~5
 minutes with no analysis requests it drops its models out of VRAM and reloads

--- a/docs/unraid.md
+++ b/docs/unraid.md
@@ -201,8 +201,39 @@ that isn't in the lean image (the `-heavy` images are ~1.9 GB):
   into that cache, so give it a few minutes. To go back, edit the Repository
   field back to `subwave-aio` and **Apply**.
 
+  **Got an NVIDIA card in the box?** There's a GPU flavour of the one-click
+  image too — `subwave-aio-cuda`, the same heavy features with CLAP + Demucs
+  running on the card instead of the CPU. It's the identical Edit flow with two
+  extra fields:
+  1. Install the Unraid **Nvidia Driver** plugin (Apps → search *Nvidia
+     Driver*) and reboot if it asks. Note your GPU's UUID from
+     **Settings → Nvidia Driver**.
+  2. **Docker** tab → **subwave** → **Edit** (*Advanced View* on).
+  3. **Repository** → `ghcr.io/perminder-klair/subwave-aio-cuda:latest`.
+  4. **Extra Parameters** → append `--runtime=nvidia` (keep the existing
+     `--add-host` value; the field takes both).
+  5. Set the two variables the template already ships (both blank by default):
+     `NVIDIA_VISIBLE_DEVICES` to your GPU UUID (or `all`), and
+     `NVIDIA_DRIVER_CAPABILITIES` to `compute,utility`.
+  6. **Apply**.
+
+  Nothing else changes — no separate analyzer container, no compose overlay
+  (that's the split stack's route). The analyze worker picks the device itself:
+  it uses the GPU when it can see one and otherwise logs a warning and carries
+  on with the CPU, so a half-finished setup degrades rather than breaking the
+  station. Pin it explicitly with the `ANALYZE_DEVICE` variable (`auto`, the
+  default, `cuda`, or `cpu`) if you'd rather be sure. Between passes the models
+  drop out of VRAM after ~5 idle minutes, so a co-resident Ollama gets the card
+  back (`ANALYZE_IDLE_UNLOAD_S` tunes that; `0` keeps them resident).
+
+  Fair warning on size: the CUDA image is **~4 GB compressed** (~11 GB on disk)
+  against `-heavy`'s ~1.3 GB, because the CUDA runtime ships inside the torch
+  wheels. That's the whole install — you still don't need a CUDA toolkit on the
+  host, just the driver plugin.
+
 Both heavy images are **amd64-only** (~1.9 GB); on an arm64 box you'd also need
-`DOCKER_DEFAULT_PLATFORM=linux/amd64` (emulated).
+`DOCKER_DEFAULT_PLATFORM=linux/amd64` (emulated). The CUDA flavours are
+amd64-only too, and there's no arm64/Jetson build.
 
 > Verify with `docker ps --filter name=sub-wave-analyzer`. Full details, the
 > `ANALYZE_AUDIO_EMBEDDING`/`ANALYZE_VOCAL_ACTIVITY` runtime flags, and

--- a/templates/subwave.xml
+++ b/templates/subwave.xml
@@ -9,7 +9,14 @@
 
   <!-- Lets the in-container controller reach an Ollama (or Navidrome) running
        on the Unraid host itself via http://host.docker.internal:PORT on the
-       default bridge network. Harmless when those services live elsewhere. -->
+       default bridge network. Harmless when those services live elsewhere.
+
+       GPU acoustic analysis (optional): the nvidia runtime flag is deliberately
+       NOT in here. It's a hard failure on a box without the Nvidia Driver
+       plugin, and most Unraid boxes don't have a card, so it stays an opt-in the
+       operator adds by hand alongside repointing Repository at the CUDA image.
+       The full three-step swap is in docs/unraid.md; see also the NVIDIA_*
+       variables below, which are inert until that runtime is enabled. -->
   <ExtraParams>--add-host host.docker.internal:host-gateway</ExtraParams>
 
   <Icon>https://raw.githubusercontent.com/perminder-klair/subwave/main/app/assets/icon.png</Icon>
@@ -46,6 +53,11 @@
 
   <Date>2026-06-22</Date>
   <Changes>
+### 2026-07-26
+- Optional GPU acoustic analysis: point Repository at subwave-aio-cuda and add
+  --runtime=nvidia to run the "sounds-like" + vocal-range models on an NVIDIA
+  card. CPU installs are unaffected.
+
 ### 2026-06-22
 - Initial release: SUB/WAVE all-in-one image on Community Applications.
   </Changes>
@@ -91,4 +103,24 @@
   <Config Name="TZ" Target="TZ" Default="Europe/London"
           Description="Timezone — keeps scheduled shows and hourly-archive timestamps on local time."
           Type="Variable" Display="advanced" Required="false" Mask="false">Europe/London</Config>
+
+  <!-- GPU acoustic analysis (optional, NVIDIA only). These three are inert on a
+       normal CPU install: left empty they change nothing, and the analyzer keeps
+       running on CPU. They only bite once you ALSO switch Repository to
+       ghcr.io/perminder-klair/subwave-aio-cuda:latest and add the nvidia runtime
+       flag to Extra Parameters (Advanced View). Needs the Unraid Nvidia Driver
+       plugin; docs/unraid.md walks the whole swap. If the card ends up not
+       visible the analyze worker logs a warning and falls back to CPU rather
+       than failing. -->
+  <Config Name="NVIDIA_VISIBLE_DEVICES" Target="NVIDIA_VISIBLE_DEVICES" Default=""
+          Description="GPU analysis only: the GPU UUID from Unraid's Nvidia Driver plugin (or 'all'). Leave EMPTY unless you are running the subwave-aio-cuda image with --runtime=nvidia in Extra Parameters."
+          Type="Variable" Display="advanced" Required="false" Mask="false"/>
+
+  <Config Name="NVIDIA_DRIVER_CAPABILITIES" Target="NVIDIA_DRIVER_CAPABILITIES" Default=""
+          Description="GPU analysis only: set to 'compute,utility' when using the subwave-aio-cuda image. Leave EMPTY otherwise."
+          Type="Variable" Display="advanced" Required="false" Mask="false"/>
+
+  <Config Name="ANALYZE_DEVICE" Target="ANALYZE_DEVICE" Default=""
+          Description="Where the heavy acoustic models run: auto (default — GPU when one is visible, else CPU), cuda, or cpu. Leave EMPTY unless you want to pin it; only the -cuda image can use a GPU at all."
+          Type="Variable" Display="advanced" Required="false" Mask="false"/>
 </Container>

--- a/templates/subwave.xml
+++ b/templates/subwave.xml
@@ -15,7 +15,7 @@
        NOT in here. It's a hard failure on a box without the Nvidia Driver
        plugin, and most Unraid boxes don't have a card, so it stays an opt-in the
        operator adds by hand alongside repointing Repository at the CUDA image.
-       The full three-step swap is in docs/unraid.md; see also the NVIDIA_*
+       The full swap is stepped through in docs/unraid.md; see also the NVIDIA_*
        variables below, which are inert until that runtime is enabled. -->
   <ExtraParams>--add-host host.docker.internal:host-gateway</ExtraParams>
 
@@ -51,7 +51,7 @@
   <ExtraSearchTerms>subwave sub-wave sub/wave subwave-aio radio internet radio icecast liquidsoap ai dj navidrome subsonic stream ollama station broadcast</ExtraSearchTerms>
   <Requires>A reachable Navidrome / Subsonic music server and an LLM provider (Ollama local/cloud or a cloud API key), both configured in the browser at /onboarding after first boot.</Requires>
 
-  <Date>2026-06-22</Date>
+  <Date>2026-07-26</Date>
   <Changes>
 ### 2026-07-26
 - Optional GPU acoustic analysis: point Repository at subwave-aio-cuda and add

--- a/web/components/manual/AcousticAnalysis.tsx
+++ b/web/components/manual/AcousticAnalysis.tsx
@@ -143,8 +143,28 @@ ANALYZER_HEAVY=1`}</CodeBlock>
             Point the analyzer container&rsquo;s image at{' '}
             <code className="bs-code-inline">ghcr.io/perminder-klair/subwave-analyzer-cuda</code>{' '}
             and pass the GPU through (<code className="bs-code-inline">--gpus all</code> or
-            your platform&rsquo;s equivalent). The AIO one-click container stays CPU-only —
-            GPU analysis needs the split stack.
+            your platform&rsquo;s equivalent).
+          </p>
+        </div>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">ALL-IN-ONE (ONE-CLICK) INSTALLS</div>
+          <p>
+            The AIO has no separate analyzer to swap, so there&rsquo;s no overlay: the GPU
+            rides on the image. Point the container at{' '}
+            <code className="bs-code-inline">ghcr.io/perminder-klair/subwave-aio-cuda</code>{' '}
+            — the same heavy features on CUDA — and hand it the card
+            (<code className="bs-code-inline">--gpus all</code>, or on Unraid the nvidia
+            runtime plus <code className="bs-code-inline">NVIDIA_VISIBLE_DEVICES</code>;{' '}
+            <a className="bs-link" href="/setup/unraid#acoustic-analysis">
+              step-by-step here
+            </a>
+            ). Everything above about device selection and VRAM applies unchanged.
+          </p>
+          <p>
+            Don&rsquo;t point an AIO install at{' '}
+            <code className="bs-code-inline">subwave-analyzer-cuda</code> — that&rsquo;s the
+            bare analyzer micro-service, and swapping to it replaces your whole station
+            with just an analyzer.
           </p>
         </div>
         <p>

--- a/web/components/setup/Unraid.tsx
+++ b/web/components/setup/Unraid.tsx
@@ -343,6 +343,54 @@ export default function Unraid() {
           </p>
         </div>
         <div className="bs-callout">
+          <div className="bs-eyebrow">GOT AN NVIDIA CARD? THE CUDA TAG</div>
+          <p>
+            There&apos;s a GPU build of the one-click image too,{' '}
+            <code className="bs-code-inline">subwave-aio-cuda</code>, the same
+            heavy features with CLAP and Demucs running on the card instead of
+            your CPU. Same Edit flow, two extra fields:
+          </p>
+          <ul className="bs-list">
+            <li>
+              Install the Unraid <strong>Nvidia Driver</strong> plugin (
+              <strong>Apps</strong> &rarr; search <em>Nvidia Driver</em>) and
+              note your GPU&apos;s UUID from{' '}
+              <strong>Settings &rarr; Nvidia Driver</strong>.
+            </li>
+            <li>
+              <strong>Repository</strong> &rarr;{' '}
+              <code className="bs-code-inline">ghcr.io/perminder-klair/subwave-aio-cuda:latest</code>
+              .
+            </li>
+            <li>
+              <strong>Extra Parameters</strong> &rarr; append{' '}
+              <code className="bs-code-inline">--runtime=nvidia</code> (keep the
+              existing <code className="bs-code-inline">--add-host</code> value).
+            </li>
+            <li>
+              Set <code className="bs-code-inline">NVIDIA_VISIBLE_DEVICES</code>{' '}
+              to your GPU UUID (or <code className="bs-code-inline">all</code>)
+              and{' '}
+              <code className="bs-code-inline">NVIDIA_DRIVER_CAPABILITIES</code>{' '}
+              to <code className="bs-code-inline">compute,utility</code>. Both
+              ship blank on the template.
+            </li>
+            <li>
+              <strong>Apply</strong>.
+            </li>
+          </ul>
+          <p>
+            No second container, no compose overlay, that&apos;s the split
+            stack&apos;s route. If the card ends up invisible the analyzer logs a
+            warning and carries on using the CPU, so a half-finished setup
+            degrades rather than taking the station down. Fair warning on size:
+            the CUDA image is <strong>~4 GB compressed</strong> against{' '}
+            <code className="bs-code-inline">-heavy</code>&apos;s ~1.3 GB, because
+            the CUDA runtime ships inside it. You still don&apos;t need a CUDA
+            toolkit on the host, just the driver plugin.
+          </p>
+        </div>
+        <div className="bs-callout">
           <div className="bs-eyebrow">FULL COMPOSE STACK: ANALYZER_HEAVY=1</div>
           <p>
             On Option 2 the <code className="bs-code-inline">analyzer</code> is

--- a/web/content/news/2026-07-26-one-click-on-the-gpu.md
+++ b/web/content/news/2026-07-26-one-click-on-the-gpu.md
@@ -1,0 +1,42 @@
+---
+title: The all-in-one image can use your GPU now
+date: 2026-07-26
+category: Feature
+author: The SUB/WAVE desk
+excerpt: A new subwave-aio-cuda image runs the sounds-like and vocal analysis on an NVIDIA card, so one-click installs get the fast path without splitting into a five-service stack.
+---
+
+When the CUDA analyzer shipped last week, it only helped one kind of install. The overlay it rides on swaps a container inside the full compose stack, and the one-click image has none to swap. So an operator running the all-in-one asked the obvious question. What about the rest of us?
+
+## What's new
+
+There is a third flavour of the one-click image, `subwave-aio-cuda`. Same whole station in one container, same heavy analysis as `subwave-aio-heavy`, except CLAP and Demucs run on your NVIDIA card instead of your cores.
+
+No overlay this time. There is nothing to layer a second compose file over, so the GPU rides on the image itself.
+
+## Switching on Unraid
+
+Install the Nvidia Driver plugin from Apps first, then note your card's UUID under Settings, Nvidia Driver.
+
+Now open the Docker tab, click the subwave container, hit Edit, and turn on Advanced View. Four fields:
+
+- Repository becomes `ghcr.io/perminder-klair/subwave-aio-cuda:latest`
+- Extra Parameters gets `--runtime=nvidia` appended, keeping the `--add-host` value already there
+- `NVIDIA_VISIBLE_DEVICES` takes your card's UUID, or `all`
+- `NVIDIA_DRIVER_CAPABILITIES` takes `compute,utility`
+
+Apply, and Unraid re-pulls. Anywhere else, it is `--gpus all` on your `docker run`.
+
+Your appdata volume is untouched, so settings, personas, library tags and the cached model weights all survive. Point the Repository field back at `subwave-aio` whenever you want to undo it.
+
+## Worth knowing
+
+The image is around 4 GB compressed, against the heavy image's 1.3 GB, because the CUDA runtime ships inside it. The host still needs nothing but the driver plugin.
+
+If the card ends up invisible, the analyzer says so in the log and carries on using the CPU. A half-finished setup runs slow, not broken.
+
+One trap to avoid. Do not point an all-in-one container at `subwave-analyzer-cuda`. That is the bare analyzer service, and swapping to it replaces your entire station with just an analyzer.
+
+## Why it helps
+
+A one-click install was always a trade, less to configure in exchange for less to tune. This takes one thing off that list. If there is a card in the box, the deep analysis can use it, no five-service stack required.


### PR DESCRIPTION
Closes #1186.

The split stack has had GPU analysis since #1099 — `subwave-analyzer-cuda` plus the `docker-compose.analyzer-gpu.yml` overlay. The AIO deliberately opted out, with a comment pointing GPU users at the split stack. That doesn't help the person in #1186, who is on the one-click container precisely *because* they don't want five services.

## What was already there

The runtime half needed nothing. `analyze_worker.py` already resolves its own device (`ANALYZE_DEVICE` = auto|cpu|cuda, warns and falls back to CPU when no GPU is visible, releases models from VRAM after ~5 idle minutes), and the AIO ships that exact worker. The only missing piece was a torch built against CUDA.

## Changes

- **`docker/Dockerfile.aio`** — `WITH_CUDA` build arg switching the torch wheel index between `cpu` and `cu124`, mirroring the proven `Dockerfile.analyzer` pattern. Only a literal `1` flips it, so `subwave-aio` and `subwave-aio-heavy` resolve the identical cpu index they do today.
- **CI** — publishes `subwave-aio-cuda` (`WITH_CLAP=1 WITH_DEMUCS=1 WITH_CUDA=1`).
- **`templates/subwave.xml`** — `NVIDIA_VISIBLE_DEVICES`, `NVIDIA_DRIVER_CAPABILITIES`, `ANALYZE_DEVICE` as advanced, blank-by-default variables. The nvidia runtime flag stays **out** of `ExtraParams` deliberately: it hard-fails a box without the driver plugin, and most Unraid boxes have no card. GPU stays a manual opt-in.
- **Docs** — `unraid.md` (full six-step swap), `tts-heavy.md`, `gpu-tts.md`, `README`, `.env.example` (+ regenerated CLI asset), and the doctor's knowledge base.
- **Site pages** — `/setup/unraid` gains a CUDA callout beside the heavy-tag swap, and `/manual/analysis` loses the now-false "the AIO one-click container stays CPU-only — GPU analysis needs the split stack" line in favour of an AIO callout. Both also warn against repointing an AIO install at the bare `subwave-analyzer-cuda` service.

## Two things worth a look

**Image size.** Measured off GHCR: CUDA costs +2.6 GB compressed on the analyzer (0.57 → 3.19 GB). `aio-heavy` is 1.32 GB, so `subwave-aio-cuda` should land around **4 GB compressed / ~11 GB on disk**. That's the reason it's its own tag rather than a default, and it's called out plainly in the Unraid docs.

**CI disk.** This is the part most likely to bite. `ubuntu-latest` has ~14 GB free on the filesystem holding `/var/lib/docker`, which an ~11 GB image plus a layer cache can exhaust. The matrix entry carries a `big_build` flag that (a) reclaims ~20 GB of unused preinstalled toolchains first and (b) exports a `mode=min` cache so this one image can't evict every other scope from the 10 GB GHA cache budget. Only that entry pays either cost.

One side effect: adding the `ARG` changes the analyzer `RUN` string, so the existing aio/aio-heavy builds bust that layer's cache once. Resulting content is unchanged.

## Verification

- `docker buildx build --check` on `Dockerfile.aio` — clean, no warnings
- Extracted the analyzer `RUN` block the way Docker hands it to `/bin/sh` (comments stripped) — passes `sh -n`
- Index resolution correct for `0` / `1` / unset / other, so the CPU path is provably unchanged
- `torch` and `torchaudio` `2.6.0+cu124` **cp313** linux_x86_64 wheels confirmed present on the index — worth checking because the AIO base is Debian trixie/py3.13, not the analyzer image's py3.11
- Workflow YAML and the template XML both parse; template default `Repository` untouched
- `controller`: lint exit 0, all 54 test files pass

**Not verified here:** the image is not built and no GPU was involved — I have neither an NVIDIA host nor the ~11 GB of amd64 emulation budget locally. CI's first build on a tag is the real proof, and I'd suggest a `workflow_dispatch` run before relying on it. Marked draft for that reason.
