### PR TITLE
fix(debug): read radio.log from the state root, not the station dir

### DIFF
--- a/controller/src/routes/debug.ts
+++ b/controller/src/routes/debug.ts
@@ -187,8 +187,12 @@ async function buildDebugSnapshot(req: express.Request): Promise<any> {
   // state dir's logs/ subfolder (see radio.liq + the liquidsoap volume
   // mount), which the controller sees via the shared state mount.
   // Reading it here means no extra controller-side log mount is needed.
+  // Read from the state ROOT, not the active station dir: the compose bind
+  // mount pins /var/log/liquidsoap to the root logs/ (compose can't follow
+  // the active-station pointer), so radio.log is install-level — like
+  // icecast-secrets.env. In single-station mode stateRoot === stateDir.
   try {
-    const log = await readFile(`${config.stateDir}/logs/radio.log`, 'utf8');
+    const log = await readFile(`${config.stateRoot}/logs/radio.log`, 'utf8');
     out.liquidsoapLog = log.split('\n').slice(-100).join('\n');
   } catch (err) {
     out.liquidsoapLog = `error: ${err.message}`;

--- a/controller/src/routes/debug.ts
+++ b/controller/src/routes/debug.ts
@@ -191,8 +191,13 @@ async function buildDebugSnapshot(req: express.Request): Promise<any> {
   // mount pins /var/log/liquidsoap to the root logs/ (compose can't follow
   // the active-station pointer), so radio.log is install-level — like
   // icecast-secrets.env. In single-station mode stateRoot === stateDir.
+  // Station-dir fallback: right after a multi-station conversion the bind
+  // mount still follows the moved logs/ inode into stations/<id>/, so the
+  // live log sits there until the broadcast CONTAINER is recreated (a
+  // telnet mixer restart doesn't remount).
   try {
-    const log = await readFile(`${config.stateRoot}/logs/radio.log`, 'utf8');
+    const log = await readFile(`${config.stateRoot}/logs/radio.log`, 'utf8')
+      .catch(() => readFile(`${config.stateDir}/logs/radio.log`, 'utf8'));
     out.liquidsoapLog = log.split('\n').slice(-100).join('\n');
   } catch (err) {
     out.liquidsoapLog = `error: ${err.message}`;

--- a/docker/aio/supervisor.sh
+++ b/docker/aio/supervisor.sh
@@ -76,9 +76,28 @@ init_state() {
 	# archive mixdowns as junk "HH-00" tracks (issue #273).
 	touch /var/sub-wave/archive/.ndignore
 
-	# Liquidsoap writes radio.log here as the liquidsoap user.
-	mkdir -p /var/log/liquidsoap
-	chown -R liquidsoap:liquidsoap /var/log/liquidsoap 2>/dev/null || true
+	# Liquidsoap writes radio.log to /var/log/liquidsoap. Point that at the
+	# state ROOT's logs/ so the log survives container recreates and the
+	# controller's debug page can tail it (routes/debug.ts reads
+	# <stateRoot>/logs/radio.log — the same install-level location the
+	# compose stacks pin via their ${STATE_DIR}/logs bind mount). A plain
+	# in-container dir here left AIO installs with no radio.log in the
+	# state dir at all, so the debug tail always errored ENOENT.
+	if [ ! -L /var/log/liquidsoap ]; then
+		rm -rf /var/log/liquidsoap
+		ln -s /var/sub-wave/logs /var/log/liquidsoap
+	fi
+
+	# Rotate radio.log on boot once it passes 50MB — same policy as
+	# docker/broadcast-entrypoint.sh. Now that the log persists in state,
+	# it would otherwise append forever; boot is the one safe moment to
+	# move it since liquidsoap isn't holding the fd yet. One .old
+	# generation caps disk at ~2x the threshold.
+	RADIO_LOG=/var/sub-wave/logs/radio.log
+	if [ -f "$RADIO_LOG" ] && [ "$(stat -c %s "$RADIO_LOG" 2>/dev/null || echo 0)" -gt 52428800 ]; then
+		mv -f "$RADIO_LOG" "$RADIO_LOG.old"
+		echo "supervisor: rotated oversized radio.log to radio.log.old" >&2
+	fi
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

On any **multi-station** compose install, the admin debug page shows:

```
error: ENOENT: no such file or directory, open '/var/sub-wave/stations/<id>/logs/radio.log'
```

in the Liquidsoap log tail section. Auditing for other instances of the same class turned up a **second, worse case: every AIO install** (single- or multi-station) has always shown this ENOENT, because the AIO never put radio.log in the state dir at all.

## Root cause

Three things disagree about where `radio.log` lives:

- `docker-compose*.yml` bind-mounts the **root** `state/logs` over `/var/log/liquidsoap` — compose is static and can't follow the `stations/active.json` pointer, which is only resolved by the broadcast entrypoint at container boot.
- `radio.liq` writes to `/var/log/liquidsoap/radio.log`, so on compose hosts the log always lands in the root `state/logs/` — while `routes/debug.ts` read `${config.stateDir}/logs/radio.log`, which in multi-station mode resolves to the **active station dir**, where the file never exists.
- The **AIO supervisor** just `mkdir -p /var/log/liquidsoap` inside the container — no bind mount, no symlink — so radio.log lived (and died) in the container's writable layer and the debug tail could never find it.

The mixer log was never accounted for in the multi-station split: the controller's own logs moved into the station dir, but `radio.log` stayed pinned at the root by the compose mount. It's effectively **install-level** state, like `icecast-secrets.env`.

## Fix

Settle on one home — the **state root's `logs/`** — everywhere:

1. **`routes/debug.ts`**: read `config.stateRoot/logs/radio.log` instead of `config.stateDir`. Correct in both modes — single-station installs have `stateRoot === stateDir`. A station-dir fallback covers the post-conversion window where the compose bind mount still follows the moved `logs/` inode into `stations/<id>/` until the broadcast **container** is recreated (a telnet mixer restart doesn't remount).
2. **`docker/aio/supervisor.sh`**: symlink `/var/log/liquidsoap` → `/var/sub-wave/logs` so the AIO matches the compose stacks, and adopt `broadcast-entrypoint.sh`'s 50 MB boot rotation — required now that the log persists across container recreates instead of dying with the writable layer.

The deeper alternative (making Liquidsoap log into the station dir via `SUBWAVE_STATE_DIR`) would require lockstep changes to `radio.liq`, the entrypoint's chown/rotation logic, and the AIO supervisor, for no real gain — one broadcast only ever serves one station at a time.

## Audit notes — everything else checked clean

- `${STATE_DIR}/logs` is the **only** static subpath mount in all three compose files.
- tts-heavy sidecar: the controller chooses the output path (`req.out`, station-resolved) — safe.
- analyzer/stems: both ends use `config.stateDir` over the shared mount — safe.
- `analyze-tmp`, `hf-cache`, `icecast-secrets.env`: correctly `stateRoot` + classified `INSTALL_LEVEL` in `stations/pure.ts`.
- `scripts/generate-jingles.sh`: already resolves the active station itself.
- `setup-config.json`: station-level (`STATE_DIR`) and in `DUPLICATE_COPY` — consistent.

## Testing

- `npm run lint` — clean (0 errors)
- `npm test` — all 55 test files pass
- `bash -n docker/aio/supervisor.sh` — clean
- Verified on a live multi-station compose install (`stations/klair-radio`): the debug page's Liquidsoap tail renders instead of the ENOENT error.