### PR TITLE
fix(handoff): base the show look-ahead on remaining track time

### DIFF
--- a/controller/scripts/handoff-boundary.test.ts
+++ b/controller/scripts/handoff-boundary.test.ts
@@ -166,7 +166,7 @@ function main() {
     assert.equal(pickLeadSec(120), 120);
   });
 
-  test('#1204 — a part-played track cannot push showAt past the boundary', () => {
+  test('#1205 — a part-played track cannot push showAt past the boundary', () => {
     // Reported case: 20:00-22:00 After Hours → 22:00 Discovery. At 21:55 the
     // deadline backstop fires the cycle with an empty queue; the on-air track
     // started 21:50 and runs 7 min, so it ends at 21:57 and the next pick is

--- a/controller/scripts/handoff-boundary.test.ts
+++ b/controller/scripts/handoff-boundary.test.ts
@@ -34,6 +34,7 @@
 
 import assert from 'node:assert/strict';
 import { contextDate, handoffIsStale, rollIsBackward } from '../src/broadcast/session.js';
+import { PICK_SHOW_LOOKAHEAD_SEC, pickLeadSec } from '../src/broadcast/queue/pure.js';
 
 const MAX_AGE = 20 * 60_000;   // mirrors HANDOFF_MAX_AGE_MS in dj-agent.ts
 
@@ -156,6 +157,65 @@ function main() {
     for (const bad of ['not-a-date', '', 12345, {}] as any[]) {
       assert.equal(rollIsBackward(new Date(), bad), false, `ctxAt=${JSON.stringify(bad)}`);
     }
+  });
+
+  console.log('\nlook-ahead lead (pickLeadSec):');
+
+  test('no held predecessor → the on-air track REMAINING, not its duration', () => {
+    // A 7-minute track five minutes in: the next pick starts in 2 min.
+    assert.equal(pickLeadSec(120), 120);
+  });
+
+  test('#1204 — a part-played track cannot push showAt past the boundary', () => {
+    // Reported case: 20:00-22:00 After Hours → 22:00 Discovery. At 21:55 the
+    // deadline backstop fires the cycle with an empty queue; the on-air track
+    // started 21:50 and runs 7 min, so it ends at 21:57 and the next pick is
+    // still After Hours. The old full-duration lead (7 min) probed 22:04 and
+    // aired the handoff mid-song, five minutes early.
+    const now = Date.parse('2026-07-25T21:55:00.000Z');
+    const boundary = Date.parse('2026-07-25T22:00:00.000Z');
+    const lead = pickLeadSec(120);                       // 2 min left of the track
+    const showAt = now + ((lead as number) + PICK_SHOW_LOOKAHEAD_SEC) * 1000;
+    assert.ok(showAt < boundary, `showAt ${new Date(showAt).toISOString()} crossed the boundary`);
+    // The old arithmetic, kept as the thing being regressed against.
+    const oldShowAt = now + (7 * 60 + PICK_SHOW_LOOKAHEAD_SEC) * 1000;
+    assert.ok(oldShowAt > boundary, 'the pre-fix lead should have crossed it');
+  });
+
+  test('a track ending genuinely inside the next show still rolls', () => {
+    // Same grid, but now it IS 21:58 with 90s left: the pick airs at 21:59:30
+    // and plays almost entirely inside Discovery. The look-ahead margin is
+    // what carries it over — that behaviour must survive the fix.
+    const now = Date.parse('2026-07-25T21:58:00.000Z');
+    const boundary = Date.parse('2026-07-25T22:00:00.000Z');
+    const showAt = now + ((pickLeadSec(90) as number) + PICK_SHOW_LOOKAHEAD_SEC) * 1000;
+    assert.ok(showAt > boundary, 'a changeover track should still resolve the incoming show');
+  });
+
+  test('at a track start remaining ≈ duration → byte-for-byte the old lead', () => {
+    assert.equal(pickLeadSec(420), 420);
+  });
+
+  test('held predecessor (deadline path) → remaining + the held track', () => {
+    assert.equal(pickLeadSec(30, 240), 270);
+  });
+
+  test('held predecessor of unknown length → no look-ahead', () => {
+    for (const bad of [0, NaN, Infinity, -5]) {
+      assert.equal(pickLeadSec(30, bad), null, `held=${bad}`);
+    }
+  });
+
+  test('unknown clock → no look-ahead, never a bogus lead', () => {
+    for (const bad of [null, undefined, NaN, Infinity, '120'] as any[]) {
+      assert.equal(pickLeadSec(bad), null, `remaining=${String(bad)}`);
+      assert.equal(pickLeadSec(bad, 240), null, `remaining=${String(bad)} (held)`);
+    }
+  });
+
+  test('a track past its cue-out clamps at 0, never pulls showAt backwards', () => {
+    assert.equal(pickLeadSec(-12), 0);
+    assert.equal(pickLeadSec(-12, 240), 240);
   });
 
   console.log(failures ? `\n${failures} failing` : '\nall passing');

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -1717,7 +1717,11 @@ class Queue {
         // track, and the elapsed part would push `showAt` over the next
         // boundary early, #1205); with one (deadline path) it follows the
         // HELD track, so the lead is on-air remaining + the held track's
-        // length. Unknown clock → no look-ahead, today's behaviour.
+        // length (knownDurationSec — the same library fallback every other
+        // duration read uses). Unknown clock → no look-ahead — rarer than it
+        // was pre-#1205: untracked auto plays carry a start stamp and
+        // usually a library duration, so remainingSecOnAir now gives them a
+        // real lead where the old duration-only read never could.
         //
         // This ONE date then drives the whole boundary sequence below — roll,
         // episode plan, mic-pass, episode hook — not just the pick. It used
@@ -1731,7 +1735,7 @@ class Queue {
         // on-air persona to disagree: there is no second date to disagree with.
         const leadSec = pickLeadSec(
           this.remainingSecOnAir(),
-          predecessorItem ? (Number(predecessorItem.track?.duration) || 0) : null,
+          predecessorItem ? knownDurationSec(predecessorItem.track) : null,
         );
         let showAt: Date | null = null;
         if (leadSec != null) {

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -57,6 +57,7 @@ import {
   PICK_SHOW_LOOKAHEAD_SEC,
   formatAgo,
   knownDurationSec,
+  pickLeadSec,
   pickLinkInterval,
   playAlreadyRecorded,
   shouldDropStaleLink,
@@ -1710,10 +1711,13 @@ class Queue {
         // opener). Probe a little past the pick's expected start so a pick
         // that begins just shy of the boundary — and plays mostly inside the
         // new show — also counts as the new show's. Without a held
-        // predecessor the pick follows the on-air track (its full duration
-        // from now); with one (deadline path) it follows the HELD track, so
-        // the lead is on-air remaining + the held track's length. Unknown
-        // clock → no look-ahead, today's behaviour.
+        // predecessor the pick follows the on-air track, so the lead is what
+        // REMAINS of it (never its full duration — this cycle also runs from
+        // the deadline backstop and from boot recovery, part-way through a
+        // track, and the elapsed part would push `showAt` over the next
+        // boundary early, #1204); with one (deadline path) it follows the
+        // HELD track, so the lead is on-air remaining + the held track's
+        // length. Unknown clock → no look-ahead, today's behaviour.
         //
         // This ONE date then drives the whole boundary sequence below — roll,
         // episode plan, mic-pass, episode hook — not just the pick. It used
@@ -1725,15 +1729,10 @@ class Queue {
         // both off `showAt` makes the mic-pass land in front of that track,
         // and makes it structurally impossible for the pick's brief and the
         // on-air persona to disagree: there is no second date to disagree with.
-        let leadSec: number | null = null;
-        if (predecessorItem) {
-          const rem = this.remainingSecOnAir();
-          const heldDur = Number(predecessorItem.track?.duration) || 0;
-          if (rem != null && heldDur > 0) leadSec = rem + heldDur;
-        } else {
-          const durSec = Number(this.current?.track?.duration);
-          if (Number.isFinite(durSec) && durSec > 0) leadSec = durSec;
-        }
+        const leadSec = pickLeadSec(
+          this.remainingSecOnAir(),
+          predecessorItem ? (Number(predecessorItem.track?.duration) || 0) : null,
+        );
         let showAt: Date | null = null;
         if (leadSec != null) {
           showAt = new Date(Date.now() + (leadSec + PICK_SHOW_LOOKAHEAD_SEC) * 1000);

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -1715,7 +1715,7 @@ class Queue {
         // REMAINS of it (never its full duration — this cycle also runs from
         // the deadline backstop and from boot recovery, part-way through a
         // track, and the elapsed part would push `showAt` over the next
-        // boundary early, #1204); with one (deadline path) it follows the
+        // boundary early, #1205); with one (deadline path) it follows the
         // HELD track, so the lead is on-air remaining + the held track's
         // length. Unknown clock → no look-ahead, today's behaviour.
         //

--- a/controller/src/broadcast/queue/pure.ts
+++ b/controller/src/broadcast/queue/pure.ts
@@ -48,6 +48,34 @@ export const BACKFILL_DEDUP_MAX_GAP_MS = 15 * 60_000;
 // two early — is how real radio tees up a changeover anyway.
 export const PICK_SHOW_LOOKAHEAD_SEC = 120;
 
+// Seconds from NOW until the pick being made will start airing — the lead the
+// show look-ahead adds to the wall clock (see runPickCycle).
+//
+// It must be measured from the on-air track's REMAINING time, never its full
+// duration. The pick cycle doesn't only run at a track start: the pair-drain
+// deadline backstop fires it with an empty queue ~2 min from the end, and boot
+// recovery fires it for a track already part-played. Using the full duration
+// there overstates the lead by everything already elapsed — up to a whole
+// track — which walks `showAt` across the next schedule boundary while the
+// real next track still starts inside the current show. That is what aired a
+// handoff five-plus minutes early, over the middle of a song, with the session
+// flipped to a show `/now-playing` still reported as the old one (#1204).
+//
+//  - `heldSec` null → the pick follows the ON-AIR track: lead = its remaining.
+//  - `heldSec` set  → the deadline path, where the pick follows a HELD track
+//                     queued behind the on-air one: lead = remaining + held.
+//
+// Unknown clock (no start stamp, no duration) or a held track of unknown
+// length → null, i.e. no look-ahead at all, the pre-look-ahead behaviour.
+// Clamped at 0 so a track past its cue-out can't pull `showAt` backwards.
+export function pickLeadSec(remainingSec: number | null, heldSec: number | null = null): number | null {
+  if (typeof remainingSec !== 'number' || !Number.isFinite(remainingSec)) return null;
+  const rem = Math.max(0, remainingSec);
+  if (heldSec == null) return rem;
+  if (!Number.isFinite(heldSec) || heldSec <= 0) return null;
+  return rem + heldSec;
+}
+
 // Has this events-log play already been recorded by recordPlay? The old dedup
 // keyed on `${endedAt}|${title}` — an EXACT timestamp match — but recordPlay's
 // end-stamp never equals the event's start `t`, so it never fired and every

--- a/controller/src/broadcast/queue/pure.ts
+++ b/controller/src/broadcast/queue/pure.ts
@@ -59,7 +59,7 @@ export const PICK_SHOW_LOOKAHEAD_SEC = 120;
 // track — which walks `showAt` across the next schedule boundary while the
 // real next track still starts inside the current show. That is what aired a
 // handoff five-plus minutes early, over the middle of a song, with the session
-// flipped to a show `/now-playing` still reported as the old one (#1204).
+// flipped to a show `/now-playing` still reported as the old one (#1205).
 //
 //  - `heldSec` null → the pick follows the ON-AIR track: lead = its remaining.
 //  - `heldSec` set  → the deadline path, where the pick follows a HELD track


### PR DESCRIPTION
Reported on Discord (Gurthyy, Radio Gurth): a scheduled show handoff aired ~21:54 for a 22:00 boundary, in the middle of a song, and `/now-playing` still reported `activeShow = After Hours` while `session.show` had already flipped to Discovery.

## Cause

`queue.runPickCycle` resolved the boundary from `now + the on-air track's FULL duration + PICK_SHOW_LOOKAHEAD_SEC`, which is only correct when the cycle runs at a track start. It also runs:

- from the **pair-drain deadline backstop** (`maybeDeadlinePick`, empty `upcoming`, ~2 min from the end), and
- from **boot recovery**, for a track already part-played.

In both, the elapsed part of the track inflates the lead by up to a full track length, so `showAt` crosses the next schedule boundary while the real next track still starts inside the current show. The roll, the mic-pass, the programme plan and the pick all key off that one date (deliberately), so everything moved early together — the handoff aired mid-song and the session led the grid by minutes rather than by the intended look-ahead margin.

The original report's guess was right, and this is also the "5-6 minutes before the hour" niggle from the same thread.

## Fix

Lead comes from `remainingSecOnAir()` — which additionally honours `cue_out` and the library duration fallback — through a new pure `pickLeadSec(remaining, held?)` in `broadcast/queue/pure.ts`:

- no held predecessor -> remaining on air
- held predecessor (deadline path) -> remaining + the held track's length (unchanged)
- unknown clock, or a held track of unknown length -> `null`, no look-ahead (unchanged)
- clamped at 0 so a track past its cue-out can't pull `showAt` backwards

At a track start `remaining ~= duration`, so the common path is byte-for-byte what it was. `PICK_SHOW_LOOKAHEAD_SEC` (120s) is untouched, so a track that genuinely straddles the boundary still resolves the incoming show and the changeover still tees up in front of the new DJ.

## Tests

`controller/scripts/handoff-boundary.test.ts` gains a `pickLeadSec` block, including the reported grid as a regression (asserting the old arithmetic crossed the boundary and the new one doesn't) and the case that must still roll early.

`npm test` — all 55 controller test files pass. `npm run lint` — 0 errors.

## Not in scope (same thread, separate asks)

- Gurthyy: option for the outgoing DJ to trail the handoff, play a changeover song, then have the incoming DJ open after that track — a produced-handoff toggle, not a bug.
- Jaz666: prompt hint that several minutes of music pass between sign-off and greeting.

https://claude.ai/code/session_01FpX6S1Yjs1HxWtGoSJPCsH