### PR TITLE
feat(admin): fit the Rundown board, brush the shelf, resize runs by their edges

### DIFF
--- a/web/components/admin/schedule/Board.tsx
+++ b/web/components/admin/schedule/Board.tsx
@@ -173,11 +173,14 @@ export default function Board({
               readable, which is exactly what releasing this at `sm` broke. */}
           <div className="sticky left-0 z-10 w-[42px] flex-none bg-[var(--card-bg)] pt-[43px]">
             {HOURS.map(h => (
+              // aria-disabled, not disabled: Firefox drops the tooltip (and
+              // focus) on a disabled control, and the title is the only
+              // in-place explanation of what arming a show unlocks here.
               <button
                 key={h}
                 type="button"
-                disabled={!armedShowId}
-                onClick={() => onFillHour(h)}
+                aria-disabled={!armedShowId}
+                onClick={armedShowId ? () => onFillHour(h) : undefined}
                 title={armedName
                   ? `Put “${armedName}” on ${hh(h)}:00 every day (again to clear it)`
                   : `${hh(h)}:00 — arm a show on the shelf to fill this hour all week`}
@@ -260,11 +263,12 @@ function DayColumn({
     <div className="flex min-w-[164px] flex-1 flex-col border border-ink bg-[var(--page-bg)] sm:min-w-0">
       {/* The header fills the day with the armed brush — the bulk gesture the
           paint-brush grid had. Fold moved to the footer, where the column was
-          already printing the word. */}
+          already printing the word. aria-disabled rather than disabled so the
+          explanatory title still shows in Firefox (see the hour gutter). */}
       <button
         type="button"
-        disabled={!armedShowId}
-        onClick={onFillDay}
+        aria-disabled={!armedShowId}
+        onClick={armedShowId ? onFillDay : undefined}
         title={armedName
           ? `Put “${armedName}” on all of ${name} (again to clear it)`
           : `${name} — arm a show on the shelf to fill the whole day in one click`}
@@ -310,11 +314,13 @@ function DayColumn({
       </div>
       <div className="flex items-center gap-2 border-t border-separator-strong px-2.5 py-2">
         <Mu className="text-[8px]">{booked} h booked</Mu>
+        {/* min-h-9 on a phone: fold used to be the 38px header, and an 8px
+            text label alone is no tap target. */}
         <button
           type="button"
           onClick={onToggleFold}
           title={`Fold ${name} out of the way`}
-          className="ml-auto cursor-pointer border-0 bg-transparent p-0 font-mono text-[8px] tracking-[0.16em] text-muted uppercase hover:text-ink"
+          className="ml-auto min-h-9 cursor-pointer border-0 bg-transparent p-0 font-mono text-[8px] tracking-[0.16em] text-muted uppercase hover:text-ink sm:min-h-0"
         >
           Fold
         </button>

--- a/web/components/admin/schedule/Board.tsx
+++ b/web/components/admin/schedule/Board.tsx
@@ -4,7 +4,8 @@
 // days always open. Shows are cards whose height equals their duration; silent
 // runs are hatched slots. Direct manipulation everywhere: click a silent slot
 // (or drop a shelf chip on it) to book a show over those hours, click a card to
-// load its order into the Write-an-order line, click a card's × to take the run
+// load its order into the Write-an-order line, drag a card's top or bottom edge
+// to move that boundary an hour at a time, click a card's × to take the run
 // off the air. Every write is a local edit — Save the week persists.
 //
 // Two geometry rules earn their keep (#1204):
@@ -22,9 +23,12 @@
 //    preference, so the gutter's static `h-[var(--hour-px)]` and each card's
 //    computed `calc()` height can never drift apart.
 
-import type { DragEvent } from 'react';
+import type {
+  ComponentPropsWithoutRef, DragEvent, KeyboardEvent, PointerEvent,
+} from 'react';
 import { useRef, useState } from 'react';
 import Link from 'next/link';
+import { FoldHorizontal, Rows2, Rows4 } from 'lucide-react';
 import { useDynamicStyle } from '../../../hooks/useDynamicStyle';
 import { cn } from '../../../lib/cn';
 import type { BoardDensity } from '../../../lib/adminView';
@@ -39,7 +43,7 @@ import { ScrollArea, ScrollBar } from '../../ui/scroll-area';
 import { Seg } from '../ui';
 import { ColorChip, Mu } from './bits';
 import type { Block, Schedule, ScheduleShow } from './lib';
-import { DAYS, HOURS, dayBlocks, hh } from './lib';
+import { DAYS, HOURS, dayBlocks, hh, resizedRun } from './lib';
 
 const DND_TYPE = 'text/x-subwave-show';
 
@@ -57,6 +61,9 @@ export interface BoardProps {
   hoursOf: (id: string) => number;
   onPick: (b: Block) => void;
   onRemove: (b: Block) => void;
+  /** A card's edge dragged (or arrow-keyed) to new boundaries — the run moves
+   *  to [start, end) and the hours it vacates fall silent. */
+  onResize: (b: Block, start: number, end: number) => void;
   onDropShow: (b: Block, showId: string) => void;
   /** The armed show — the shelf chip acting as a brush, or null. */
   armedShowId: string | null;
@@ -73,7 +80,7 @@ export interface BoardProps {
 
 export default function Board({
   schedule, shows, folded, onToggleFold, todayKey,
-  colorOf, hoursOf, onPick, onRemove, onDropShow,
+  colorOf, hoursOf, onPick, onRemove, onResize, onDropShow,
   armedShowId, onArmShow, onFillDay, onFillHour,
   density, hourPx, onDensity,
 }: BoardProps) {
@@ -87,16 +94,41 @@ export default function Board({
         <Mu className="min-w-0 flex-1 tracking-[0.08em]">
           {armedName
             ? `${armedName} is armed — click any hour to book it, a day header for the whole day, or an hour in the gutter for that hour all week`
-            : 'Click a silent hour (or drag a show onto it) to book a show — click a card to edit its order, its × to take it off the air'}
+            : 'Click a silent hour (or drag a show onto it) to book a show — click a card to edit its order, drag its top or bottom edge to change the hours, its × to take it off the air'}
         </Mu>
         <span className="ml-auto flex flex-none items-center gap-2">
+          {/* The label stays: two row icons on their own in the corner of a
+              toolbar could as easily be a view switch as a density one, and
+              this control is the only thing here that isn't self-evident. */}
           <Mu className="hidden text-[8.5px] sm:inline">Rows</Mu>
           <Seg
             value={density}
             onChange={v => onDensity(v === 'compact' ? 'compact' : 'comfortable')}
             options={[
-              { id: 'comfortable', title: 'Comfortable rows — the full hour range on every card', label: 'Roomy' },
-              { id: 'compact', title: 'Compact rows — a shorter board that clears the fold', label: 'Compact' },
+              // Icon-only, the RosterViewToggle recipe: the glyph carries the
+              // meaning (fewer, taller rows vs more, shorter ones), an sr-only
+              // span carries the name, and `title` carries the explanation.
+              // min-h gives the tab a real tap target on a phone.
+              {
+                id: 'comfortable',
+                title: 'Roomy rows — the full hour range on every card',
+                label: (
+                  <span className="flex min-h-[22px] items-center sm:min-h-0">
+                    <Rows2 size={15} strokeWidth={1.75} aria-hidden />
+                    <span className="sr-only">Roomy</span>
+                  </span>
+                ),
+              },
+              {
+                id: 'compact',
+                title: 'Compact rows — a shorter board that clears the fold',
+                label: (
+                  <span className="flex min-h-[22px] items-center sm:min-h-0">
+                    <Rows4 size={15} strokeWidth={1.75} aria-hidden />
+                    <span className="sr-only">Compact</span>
+                  </span>
+                ),
+              },
             ]}
           />
         </span>
@@ -215,12 +247,14 @@ export default function Board({
                 colorOf={colorOf}
                 shows={shows}
                 density={density}
+                hourPx={hourPx}
                 armedShowId={armedShowId}
                 armedName={armedName}
                 onToggleFold={() => onToggleFold(d.key)}
                 onFillDay={() => onFillDay(d.key)}
                 onPick={onPick}
                 onRemove={onRemove}
+                onResize={onResize}
                 onDropShow={onDropShow}
               />
             ),
@@ -236,8 +270,8 @@ export default function Board({
 }
 
 function DayColumn({
-  label, name, today, blocks, colorOf, shows, density, armedShowId, armedName,
-  onToggleFold, onFillDay, onPick, onRemove, onDropShow,
+  label, name, today, blocks, colorOf, shows, density, hourPx, armedShowId, armedName,
+  onToggleFold, onFillDay, onPick, onRemove, onResize, onDropShow,
 }: {
   label: string;
   name: string;
@@ -246,12 +280,14 @@ function DayColumn({
   colorOf: (id: string | null | undefined) => string;
   shows: ScheduleShow[];
   density: BoardDensity;
+  hourPx: number;
   armedShowId: string | null;
   armedName: string | null;
   onToggleFold: () => void;
   onFillDay: () => void;
   onPick: (b: Block) => void;
   onRemove: (b: Block) => void;
+  onResize: (b: Block, start: number, end: number) => void;
   onDropShow: (b: Block, showId: string) => void;
 }) {
   const showById = (id: string | null) => shows.find(s => s.id === id) ?? null;
@@ -261,31 +297,43 @@ function DayColumn({
     // next day peeks past the right edge; from sm up `min-w-0` lets the seven
     // columns divide the board's width instead of forcing it past the screen.
     <div className="flex min-w-[164px] flex-1 flex-col border border-ink bg-[var(--page-bg)] sm:min-w-0">
-      {/* The header fills the day with the armed brush — the bulk gesture the
-          paint-brush grid had. Fold moved to the footer, where the column was
-          already printing the word. aria-disabled rather than disabled so the
-          explanatory title still shows in Firefox (see the hour gutter). */}
-      <button
-        type="button"
-        aria-disabled={!armedShowId}
-        onClick={armedShowId ? onFillDay : undefined}
-        title={armedName
-          ? `Put “${armedName}” on all of ${name} (again to clear it)`
-          : `${name} — arm a show on the shelf to fill the whole day in one click`}
-        className={cn(
-          'flex h-[38px] items-center gap-2 border-0 border-b border-solid border-b-ink bg-transparent px-2.5',
-          armedShowId ? 'cursor-pointer hover:bg-[var(--ink-soft)]' : 'cursor-default',
-        )}
-      >
-        <span
-          aria-hidden="true"
-          className={cn('size-[7px] rounded-full', today ? 'bg-[var(--accent)]' : 'bg-ink')}
-        />
-        <span className="font-mono text-[11px] font-bold tracking-[0.16em] text-ink">{label}</span>
-        <span className="ml-auto flex h-5 min-w-5 items-center justify-center border border-ink bg-[var(--card-bg)] px-1 font-mono text-[9px] font-bold text-ink">
-          {blocks.filter(b => b.showId).length}
-        </span>
-      </button>
+      {/* The header carries two gestures. Its body folds the column — what it
+          has always done, and the reason the day names read as handles — until
+          a brush is armed, when it fills the whole day instead (the bulk write
+          the paint-brush grid had). Same armed/unarmed split the silent slots
+          make, and the hint line above the shelf names the armed one.
+          The chevron is the constant: it folds in either mode, so an armed
+          brush never leaves the column without a collapse control at the top.
+          Fold also stays in the footer — this column is 24 hours tall, and
+          scrolling ~800px back up to close it is its own annoyance. */}
+      <div className="flex h-[38px] items-stretch border-b border-solid border-b-ink">
+        <button
+          type="button"
+          onClick={armedShowId ? onFillDay : onToggleFold}
+          title={armedName
+            ? `Put “${armedName}” on all of ${name} (again to clear it)`
+            : `Fold ${name} out of the way`}
+          className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 border-0 bg-transparent px-2.5 hover:bg-[var(--ink-soft)]"
+        >
+          <span
+            aria-hidden="true"
+            className={cn('size-[7px] flex-none rounded-full', today ? 'bg-[var(--accent)]' : 'bg-ink')}
+          />
+          <span className="font-mono text-[11px] font-bold tracking-[0.16em] text-ink">{label}</span>
+          <span className="ml-auto flex h-5 min-w-5 flex-none items-center justify-center border border-ink bg-[var(--card-bg)] px-1 font-mono text-[9px] font-bold text-ink">
+            {blocks.filter(b => b.showId).length}
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={onToggleFold}
+          aria-label={`Fold ${name} out of the way`}
+          title={`Fold ${name} out of the way`}
+          className="flex w-7 flex-none cursor-pointer items-center justify-center border-0 border-l border-solid border-l-separator-strong bg-transparent p-0 text-muted hover:bg-[var(--ink-soft)] hover:text-ink"
+        >
+          <FoldHorizontal size={13} strokeWidth={1.75} aria-hidden />
+        </button>
+      </div>
       <div className="flex flex-col gap-1 p-[5px]">
         {blocks.map(b =>
           b.showId ? (
@@ -295,8 +343,10 @@ function DayColumn({
               name={showById(b.showId)?.name ?? 'unknown show'}
               color={colorOf(b.showId)}
               density={density}
+              hourPx={hourPx}
               onPick={onPick}
               onRemove={onRemove}
+              onResize={onResize}
               onDropShow={onDropShow}
             />
           ) : (
@@ -363,25 +413,88 @@ function FoldedRail({
 // compact, which is not two lines of type — it was slicing the show's name
 // through the middle. Anything that short prints the name alone and leaves the
 // hour range to the tooltip, which carried it all along.
+//
+// The two edges are resize handles: drag one to move that boundary an hour at
+// a time. The drag is a PURE PREVIEW — the grid is written once, on release.
+// Writing on every step would be the obvious thing and it does not work: the
+// cards are re-derived from the grid by `dayBlocks` and keyed on `start`, so a
+// top-edge drag would remount the very handle holding the pointer capture and
+// the gesture would die on its first hour. Instead the card draws itself at
+// the drafted size and pulls the difference back out of its own margins, so
+// the run appears to grow over its neighbours without the column reflowing
+// under the cursor.
 function BoardCard({
-  block, name, color, density, onPick, onRemove, onDropShow,
+  block, name, color, density, hourPx, onPick, onRemove, onResize, onDropShow,
 }: {
   block: Block;
   name: string;
   color: string;
   density: BoardDensity;
+  hourPx: number;
   onPick: (b: Block) => void;
   onRemove: (b: Block) => void;
+  onResize: (b: Block, start: number, end: number) => void;
   onDropShow: (b: Block, showId: string) => void;
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const [over, setOver] = useState(false);
+  const [draft, setDraft] = useState<{ start: number; end: number } | null>(null);
+  const drag = useRef<{ edge: ResizeEdge; y0: number } | null>(null);
+
+  const blockEnd = block.start + block.span;
+  const start = draft?.start ?? block.start;
+  const end = draft?.end ?? blockEnd;
+  const span = end - start;
+
   useDynamicStyle(ref, {
-    height: `calc(var(--hour-px) * ${block.span} - 4px)`,
+    height: `calc(var(--hour-px) * ${span} - 4px)`,
+    // Negative when the draft has grown past the real run — the card overlaps
+    // its neighbours instead of displacing them.
+    marginTop: draft ? `calc(var(--hour-px) * ${start - block.start})` : undefined,
+    marginBottom: draft ? `calc(var(--hour-px) * ${blockEnd - end})` : undefined,
     background: color,
   });
+
+  const commit = (r: { start: number; end: number }) => {
+    if (r.start !== block.start || r.end !== blockEnd) onResize(block, r.start, r.end);
+  };
+
+  const edgeHour = (edge: ResizeEdge) => (edge === 'top' ? block.start : blockEnd);
+
+  const handleProps = (edge: ResizeEdge) => ({
+    onPointerDown: (e: PointerEvent<HTMLButtonElement>) => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      e.stopPropagation();
+      e.currentTarget.setPointerCapture(e.pointerId);
+      drag.current = { edge, y0: e.clientY };
+      setDraft({ start: block.start, end: blockEnd });
+    },
+    onPointerMove: (e: PointerEvent<HTMLButtonElement>) => {
+      const d = drag.current;
+      if (!d) return;
+      const steps = Math.round((e.clientY - d.y0) / hourPx);
+      setDraft(resizedRun(block, d.edge, edgeHour(d.edge) + steps));
+    },
+    onPointerUp: () => {
+      if (drag.current && draft) commit(draft);
+      drag.current = null;
+      setDraft(null);
+    },
+    // A cancelled pointer (a system gesture, the page scrolling away) abandons
+    // the draft rather than committing a size the operator never released on.
+    onPointerCancel: () => { drag.current = null; setDraft(null); },
+    onKeyDown: (e: KeyboardEvent) => {
+      const step = e.key === 'ArrowUp' ? -1 : e.key === 'ArrowDown' ? 1 : 0;
+      if (!step) return;
+      e.preventDefault();
+      commit(resizedRun(block, edge, edgeHour(edge) + step));
+    },
+  });
+
   // Two lines need both hour units; compact only has the room from three up.
-  const showRange = density === 'comfortable' ? block.span > 1 : block.span > 2;
+  const showRange = density === 'comfortable' ? span > 1 : span > 2;
+  const range = `${hh(start)} – ${hh(end)}`;
   return (
     <div
       ref={ref}
@@ -397,12 +510,15 @@ function BoardCard({
         'group relative overflow-hidden text-[#f6f2ea]',
         'hover:outline-2 hover:-outline-offset-1 hover:outline-ink',
         over && 'outline-2 -outline-offset-1 outline-ink',
+        // Lifted while drafting so the overlap reads as the card on top of its
+        // neighbours rather than sunk behind them.
+        draft && 'z-20 outline-2 -outline-offset-1 outline-[var(--accent)]',
       )}
     >
       <button
         type="button"
         onClick={() => onPick(block)}
-        title={`${name} · ${hh(block.start)} – ${hh(block.start + block.span)} — click to edit this order`}
+        title={`${name} · ${hh(block.start)} – ${hh(blockEnd)} — click to edit this order, or drag an edge to change the hours`}
         className={cn(
           'flex size-full cursor-pointer flex-col overflow-hidden border-0 bg-transparent px-2 text-left text-inherit',
           showRange ? 'justify-between py-1.5' : 'justify-center py-0.5',
@@ -413,20 +529,72 @@ function BoardCard({
         </span>
         {showRange && (
           <span className="font-mono text-[9px] tracking-[0.06em] whitespace-nowrap opacity-70">
-            {hh(block.start)} – {hh(block.start + block.span)}
+            {range}
           </span>
         )}
       </button>
+      {/* While drafting, the range is the only feedback that matters — print it
+          even on the short cards that normally leave it to the tooltip. */}
+      {draft && !showRange && (
+        <span className="pointer-events-none absolute inset-x-0 bottom-0 bg-[rgba(0,0,0,0.45)] px-1 text-center font-mono text-[8.5px] tracking-[0.06em] whitespace-nowrap">
+          {range}
+        </span>
+      )}
+      <ResizeHandle
+        edge="top"
+        label={`Move the start of “${name}” — currently ${hh(block.start)}:00`}
+        dragging={drag.current?.edge === 'top'}
+        {...handleProps('top')}
+      />
+      <ResizeHandle
+        edge="bottom"
+        label={`Move the end of “${name}” — currently ${hh(blockEnd)}:00`}
+        dragging={drag.current?.edge === 'bottom'}
+        {...handleProps('bottom')}
+      />
       <button
         type="button"
         onClick={() => onRemove(block)}
         aria-label={`Take “${name}” off the air`}
         title={`Take “${name}” off the air`}
-        className="absolute top-[3px] right-[3px] flex size-[17px] cursor-pointer items-center justify-center border-0 bg-transparent p-0 font-mono text-[13px] leading-none font-bold text-inherit opacity-0 group-hover:opacity-100 hover:bg-[rgba(0,0,0,0.35)] focus-visible:opacity-100"
+        className="absolute top-[3px] right-[3px] z-10 flex size-[17px] cursor-pointer items-center justify-center border-0 bg-transparent p-0 font-mono text-[13px] leading-none font-bold text-inherit opacity-0 group-hover:opacity-100 hover:bg-[rgba(0,0,0,0.35)] focus-visible:opacity-100"
       >
         ×
       </button>
     </div>
+  );
+}
+
+type ResizeEdge = 'top' | 'bottom';
+
+// The grab strip on a card's top or bottom edge. Kept to 7px so it still fits
+// either side of a one-hour card (22px of box at the compact unit) — the depth
+// comes from `touch-action: none`, which hands the whole gesture to the
+// pointer handlers instead of the page's scroll. Arrow keys drive the same
+// edge for anyone not dragging.
+function ResizeHandle({
+  edge, label, dragging, ...rest
+}: {
+  edge: ResizeEdge;
+  label: string;
+  dragging: boolean;
+} & ComponentPropsWithoutRef<'button'>) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={`${label}. Drag, or use the up and down arrow keys.`}
+      className={cn(
+        'absolute inset-x-0 z-10 flex h-[7px] cursor-ns-resize touch-none items-center justify-center border-0 bg-transparent p-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100',
+        edge === 'top' ? 'top-0' : 'bottom-0',
+        // A capture can carry the pointer off the card, which drops
+        // `group-hover` — the handle being dragged must not vanish under it.
+        dragging && 'opacity-100',
+      )}
+      {...rest}
+    >
+      <span aria-hidden="true" className="h-[2px] w-6 max-w-[55%] bg-[rgba(246,242,234,0.8)]" />
+    </button>
   );
 }
 

--- a/web/components/admin/schedule/Board.tsx
+++ b/web/components/admin/schedule/Board.tsx
@@ -91,7 +91,17 @@ export default function Board({
   return (
     <section>
       <div className="mb-3 flex flex-wrap items-center gap-x-3.5 gap-y-2 px-5 sm:px-[30px]">
-        <Mu className="min-w-0 flex-1 tracking-[0.08em]">
+        {/* Two lengths, not one truncated line. The long copy runs to three
+            wrapped rows of mono on a phone, and half of what it describes is
+            mouse-only: HTML5 drag-and-drop does not fire from a touch, and the
+            7px card edges are a poor target for a fingertip. The short copy
+            names the gestures a phone can actually perform. */}
+        <Mu className="min-w-0 flex-1 tracking-[0.08em] sm:hidden">
+          {armedName
+            ? `${armedName} is armed — tap an hour to book it, or a day header for the whole day`
+            : 'Tap a silent hour to book a show — tap a card to edit its order, its × to take it off the air'}
+        </Mu>
+        <Mu className="hidden min-w-0 flex-1 tracking-[0.08em] sm:block">
           {armedName
             ? `${armedName} is armed — click any hour to book it, a day header for the whole day, or an hour in the gutter for that hour all week`
             : 'Click a silent hour (or drag a show onto it) to book a show — click a card to edit its order, drag its top or bottom edge to change the hours, its × to take it off the air'}

--- a/web/components/admin/schedule/Board.tsx
+++ b/web/components/admin/schedule/Board.tsx
@@ -1,18 +1,33 @@
 'use client';
 
 // The board — a kanban-style 7-column × 24-hour view of the week, all seven
-// days always open. Shows are cards whose height equals their duration (34px
-// per hour); silent runs are hatched slots. Direct manipulation everywhere:
-// click a silent slot (or drop a shelf chip on it) to book a show over those
-// hours, click a card to load its order into the Write-an-order line, click
-// a card's × to take the run off the air. Every write is a local edit —
-// Save the week persists.
+// days always open. Shows are cards whose height equals their duration; silent
+// runs are hatched slots. Direct manipulation everywhere: click a silent slot
+// (or drop a shelf chip on it) to book a show over those hours, click a card to
+// load its order into the Write-an-order line, click a card's × to take the run
+// off the air. Every write is a local edit — Save the week persists.
+//
+// Two geometry rules earn their keep (#1204):
+//
+//  * The seven columns divide whatever width the board is given from `sm` up
+//    (`sm:w-full` + `sm:min-w-0`) instead of holding a 188px floor. At that
+//    floor the board's intrinsic width was 1428px against ~1072px of admin
+//    content on a 1280 laptop, so a quarter of the week sat off-screen and the
+//    hour gutter — which had been released from `sticky` at `sm` on the
+//    assumption the board fits there — scrolled away with it, leaving an
+//    unlabelled field of hatched rectangles. Columns that shrink mean no
+//    horizontal scroll at all on a laptop, and the gutter now stays pinned at
+//    every width for the narrow windows where scroll survives.
+//  * The hour unit is a CSS variable (`--hour-px`) set from the density
+//    preference, so the gutter's static `h-[var(--hour-px)]` and each card's
+//    computed `calc()` height can never drift apart.
 
 import type { DragEvent } from 'react';
 import { useRef, useState } from 'react';
 import Link from 'next/link';
 import { useDynamicStyle } from '../../../hooks/useDynamicStyle';
 import { cn } from '../../../lib/cn';
+import type { BoardDensity } from '../../../lib/adminView';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -21,6 +36,7 @@ import {
   DropdownMenuTrigger,
 } from '../../ui/dropdown-menu';
 import { ScrollArea, ScrollBar } from '../../ui/scroll-area';
+import { Seg } from '../ui';
 import { ColorChip, Mu } from './bits';
 import type { Block, Schedule, ScheduleShow } from './lib';
 import { DAYS, HOURS, dayBlocks, hh } from './lib';
@@ -42,23 +58,54 @@ export interface BoardProps {
   onPick: (b: Block) => void;
   onRemove: (b: Block) => void;
   onDropShow: (b: Block, showId: string) => void;
+  /** The armed show — the shelf chip acting as a brush, or null. */
+  armedShowId: string | null;
+  /** Arm/disarm a shelf chip (the same id twice disarms). */
   onArmShow: (id: string) => void;
+  /** Bulk writes behind a day header / an hour in the gutter. Only reachable
+   *  with a show armed; both toggle off when the target already runs it. */
+  onFillDay: (day: number) => void;
+  onFillHour: (hour: number) => void;
+  density: BoardDensity;
+  hourPx: number;
+  onDensity: (d: BoardDensity) => void;
 }
 
 export default function Board({
   schedule, shows, folded, onToggleFold, todayKey,
-  colorOf, hoursOf, onPick, onRemove, onDropShow, onArmShow,
+  colorOf, hoursOf, onPick, onRemove, onDropShow,
+  armedShowId, onArmShow, onFillDay, onFillHour,
+  density, hourPx, onDensity,
 }: BoardProps) {
+  const gridRef = useRef<HTMLDivElement>(null);
+  useDynamicStyle(gridRef, { '--hour-px': `${hourPx}px` });
+  const armedName = shows.find(s => s.id === armedShowId)?.name ?? null;
+
   return (
     <section>
-      <div className="mb-3 flex flex-wrap items-center gap-3.5 px-5 sm:px-[30px]">
-        <Mu className="tracking-[0.08em]">
-          Click a silent hour (or drag a show onto it) to book a show — click a card to edit its order, its × to take it off the air
+      <div className="mb-3 flex flex-wrap items-center gap-x-3.5 gap-y-2 px-5 sm:px-[30px]">
+        <Mu className="min-w-0 flex-1 tracking-[0.08em]">
+          {armedName
+            ? `${armedName} is armed — click any hour to book it, a day header for the whole day, or an hour in the gutter for that hour all week`
+            : 'Click a silent hour (or drag a show onto it) to book a show — click a card to edit its order, its × to take it off the air'}
         </Mu>
+        <span className="ml-auto flex flex-none items-center gap-2">
+          <Mu className="hidden text-[8.5px] sm:inline">Rows</Mu>
+          <Seg
+            value={density}
+            onChange={v => onDensity(v === 'compact' ? 'compact' : 'comfortable')}
+            options={[
+              { id: 'comfortable', title: 'Comfortable rows — the full hour range on every card', label: 'Roomy' },
+              { id: 'compact', title: 'Compact rows — a shorter board that clears the fold', label: 'Compact' },
+            ]}
+          />
+        </span>
       </div>
 
       {/* The shelf — one draggable chip per show, a single scrolling tray so
-          any number of shows stays one line tall */}
+          any number of shows stays one line tall. A chip is also a brush:
+          click to arm it, then fill hours, days or a whole hour-of-the-week
+          from the board without returning here. */}
       <div className="mx-5 mb-3.5 border border-ink bg-[var(--page-bg)] sm:mx-[30px]">
         <ScrollArea>
           <div className="flex w-max min-w-full items-center gap-2 px-3 py-2.5">
@@ -72,32 +119,45 @@ export default function Board({
             to start scheduling.
           </Mu>
         )}
-        {shows.map(s => (
-          <button
-            key={s.id}
-            type="button"
-            draggable
-            onDragStart={e => {
-              e.dataTransfer.setData(DND_TYPE, s.id);
-              e.dataTransfer.setData('text/plain', s.id);
-              e.dataTransfer.effectAllowed = 'copy';
-            }}
-            onClick={() => onArmShow(s.id)}
-            title={`Drag onto the board, or click to write an order for “${s.name}”`}
-            className="flex min-h-9 flex-none cursor-grab items-center gap-1.5 border border-separator-strong bg-[var(--card-bg)] px-2.5 py-1.5 hover:border-ink active:cursor-grabbing sm:min-h-0"
-          >
-            <ColorChip color={colorOf(s.id)} />
-            <span className="text-[11.5px] font-semibold whitespace-nowrap text-ink">{s.name}</span>
-            <Mu className="text-[8px]">{hoursOf(s.id)}h</Mu>
-          </button>
-            ))}
+        {shows.map(s => {
+          const armed = s.id === armedShowId;
+          return (
+            <button
+              key={s.id}
+              type="button"
+              draggable
+              aria-pressed={armed}
+              onDragStart={e => {
+                e.dataTransfer.setData(DND_TYPE, s.id);
+                e.dataTransfer.setData('text/plain', s.id);
+                e.dataTransfer.effectAllowed = 'copy';
+              }}
+              onClick={() => onArmShow(s.id)}
+              title={armed
+                ? `“${s.name}” is armed — click hours on the board to book it, or click here to put the brush down`
+                : `Click to arm “${s.name}” as a brush, or drag it onto the board`}
+              className={cn(
+                'flex min-h-9 flex-none cursor-grab items-center gap-1.5 border px-2.5 py-1.5 active:cursor-grabbing sm:min-h-0',
+                armed
+                  ? 'border-ink bg-[var(--ink-soft)] outline-2 -outline-offset-2 outline-[var(--accent)]'
+                  : 'border-separator-strong bg-[var(--card-bg)] hover:border-ink',
+              )}
+            >
+              <ColorChip color={colorOf(s.id)} />
+              <span className="text-[11.5px] font-semibold whitespace-nowrap text-ink">{s.name}</span>
+              <Mu className="text-[8px]">{hoursOf(s.id)}h</Mu>
+            </button>
+          );
+        })}
           </div>
           <ScrollBar orientation="horizontal" />
         </ScrollArea>
       </div>
 
       {/* On a phone the week is a horizontal strip and Radix only reveals its
-          scrollbar on hover, so name the gesture — and the span — outright. */}
+          scrollbar on hover, so name the gesture — and the span — outright.
+          From sm up the columns divide the available width, so there is
+          nothing to swipe. */}
       <Mu className="mb-1.5 flex items-center gap-1.5 px-5 tracking-[0.08em] sm:hidden">
         <span aria-hidden="true">◂</span>
         Swipe the board — Mon through Sun
@@ -105,19 +165,31 @@ export default function Board({
       </Mu>
 
       <ScrollArea>
-        <div className="flex w-max min-w-full items-start gap-2.5 pb-1.5">
+        <div ref={gridRef} className="flex w-max min-w-full items-start gap-2.5 pb-1.5 sm:w-full">
           {/* Hour gutter — pt clears the 38px column headers (+border+padding).
-              Pinned while the strip scrolls sideways on a phone, so the hour a
-              card sits on stays readable on any day; static from sm up, where
-              the board usually fits without scrolling. */}
-          <div className="sticky left-0 z-10 w-[42px] flex-none bg-[var(--card-bg)] pt-[43px] sm:static sm:bg-transparent">
+              Pinned at every width: on a phone the week is a scrolling strip,
+              and in a narrow desktop window the columns bottom out and the
+              board scrolls too. Either way the hour a card sits on has to stay
+              readable, which is exactly what releasing this at `sm` broke. */}
+          <div className="sticky left-0 z-10 w-[42px] flex-none bg-[var(--card-bg)] pt-[43px]">
             {HOURS.map(h => (
-              <div
+              <button
                 key={h}
-                className="flex h-[34px] items-start justify-end pr-[7px] font-mono text-[9px] font-bold text-muted opacity-80"
+                type="button"
+                disabled={!armedShowId}
+                onClick={() => onFillHour(h)}
+                title={armedName
+                  ? `Put “${armedName}” on ${hh(h)}:00 every day (again to clear it)`
+                  : `${hh(h)}:00 — arm a show on the shelf to fill this hour all week`}
+                className={cn(
+                  'flex h-[var(--hour-px)] w-full items-start justify-end border-0 bg-transparent pr-[7px] font-mono text-[9px] font-bold text-muted opacity-80',
+                  armedShowId
+                    ? 'cursor-pointer hover:text-vermilion hover:opacity-100'
+                    : 'cursor-default',
+                )}
               >
                 {hh(h)}
-              </div>
+              </button>
             ))}
           </div>
 
@@ -139,7 +211,11 @@ export default function Board({
                 blocks={dayBlocks(schedule, d.key)}
                 colorOf={colorOf}
                 shows={shows}
+                density={density}
+                armedShowId={armedShowId}
+                armedName={armedName}
                 onToggleFold={() => onToggleFold(d.key)}
+                onFillDay={() => onFillDay(d.key)}
                 onPick={onPick}
                 onRemove={onRemove}
                 onDropShow={onDropShow}
@@ -157,8 +233,8 @@ export default function Board({
 }
 
 function DayColumn({
-  label, name, today, blocks, colorOf, shows,
-  onToggleFold, onPick, onRemove, onDropShow,
+  label, name, today, blocks, colorOf, shows, density, armedShowId, armedName,
+  onToggleFold, onFillDay, onPick, onRemove, onDropShow,
 }: {
   label: string;
   name: string;
@@ -166,7 +242,11 @@ function DayColumn({
   blocks: Block[];
   colorOf: (id: string | null | undefined) => string;
   shows: ScheduleShow[];
+  density: BoardDensity;
+  armedShowId: string | null;
+  armedName: string | null;
   onToggleFold: () => void;
+  onFillDay: () => void;
   onPick: (b: Block) => void;
   onRemove: (b: Block) => void;
   onDropShow: (b: Block, showId: string) => void;
@@ -174,14 +254,24 @@ function DayColumn({
   const showById = (id: string | null) => shows.find(s => s.id === id) ?? null;
   const booked = blocks.reduce((a, b) => a + (b.showId ? b.span : 0), 0);
   return (
-    // Narrower on a phone so the next day peeks past the right edge — the
-    // strip reads as scrollable without a permanently-drawn scrollbar.
-    <div className="flex min-w-[164px] flex-1 flex-col border border-ink bg-[var(--page-bg)] sm:min-w-[188px]">
+    // A phone still gets a fixed-width scrolling strip narrow enough that the
+    // next day peeks past the right edge; from sm up `min-w-0` lets the seven
+    // columns divide the board's width instead of forcing it past the screen.
+    <div className="flex min-w-[164px] flex-1 flex-col border border-ink bg-[var(--page-bg)] sm:min-w-0">
+      {/* The header fills the day with the armed brush — the bulk gesture the
+          paint-brush grid had. Fold moved to the footer, where the column was
+          already printing the word. */}
       <button
         type="button"
-        onClick={onToggleFold}
-        title={`Fold ${name} out of the way`}
-        className="flex h-[38px] cursor-pointer items-center gap-2 border-0 border-b border-solid border-b-ink bg-transparent px-2.5 hover:bg-[var(--ink-soft)]"
+        disabled={!armedShowId}
+        onClick={onFillDay}
+        title={armedName
+          ? `Put “${armedName}” on all of ${name} (again to clear it)`
+          : `${name} — arm a show on the shelf to fill the whole day in one click`}
+        className={cn(
+          'flex h-[38px] items-center gap-2 border-0 border-b border-solid border-b-ink bg-transparent px-2.5',
+          armedShowId ? 'cursor-pointer hover:bg-[var(--ink-soft)]' : 'cursor-default',
+        )}
       >
         <span
           aria-hidden="true"
@@ -200,6 +290,7 @@ function DayColumn({
               block={b}
               name={showById(b.showId)?.name ?? 'unknown show'}
               color={colorOf(b.showId)}
+              density={density}
               onPick={onPick}
               onRemove={onRemove}
               onDropShow={onDropShow}
@@ -210,6 +301,8 @@ function DayColumn({
               block={b}
               shows={shows}
               colorOf={colorOf}
+              armedShowId={armedShowId}
+              armedName={armedName}
               onDropShow={onDropShow}
             />
           ),
@@ -217,7 +310,14 @@ function DayColumn({
       </div>
       <div className="flex items-center gap-2 border-t border-separator-strong px-2.5 py-2">
         <Mu className="text-[8px]">{booked} h booked</Mu>
-        <Mu className="ml-auto text-[8px]">Fold</Mu>
+        <button
+          type="button"
+          onClick={onToggleFold}
+          title={`Fold ${name} out of the way`}
+          className="ml-auto cursor-pointer border-0 bg-transparent p-0 font-mono text-[8px] tracking-[0.16em] text-muted uppercase hover:text-ink"
+        >
+          Fold
+        </button>
       </div>
     </div>
   );
@@ -249,15 +349,21 @@ function FoldedRail({
   );
 }
 
-// One scheduled run as a card — height encodes duration (34px per hour).
-// Clicking the card loads its order into the Write-an-order line; the × in
-// the corner takes the run off the air (a local edit either way).
+// One scheduled run as a card — height encodes duration (one `--hour-px` unit
+// per hour). Clicking the card loads its order into the Write-an-order line;
+// the × in the corner takes the run off the air (a local edit either way).
+//
+// A one-hour card has ~24px of content box at the roomy unit and less when
+// compact, which is not two lines of type — it was slicing the show's name
+// through the middle. Anything that short prints the name alone and leaves the
+// hour range to the tooltip, which carried it all along.
 function BoardCard({
-  block, name, color, onPick, onRemove, onDropShow,
+  block, name, color, density, onPick, onRemove, onDropShow,
 }: {
   block: Block;
   name: string;
   color: string;
+  density: BoardDensity;
   onPick: (b: Block) => void;
   onRemove: (b: Block) => void;
   onDropShow: (b: Block, showId: string) => void;
@@ -265,9 +371,11 @@ function BoardCard({
   const ref = useRef<HTMLDivElement>(null);
   const [over, setOver] = useState(false);
   useDynamicStyle(ref, {
-    height: `${block.span * 34 - 4}px`,
+    height: `calc(var(--hour-px) * ${block.span} - 4px)`,
     background: color,
   });
+  // Two lines need both hour units; compact only has the room from three up.
+  const showRange = density === 'comfortable' ? block.span > 1 : block.span > 2;
   return (
     <div
       ref={ref}
@@ -289,14 +397,19 @@ function BoardCard({
         type="button"
         onClick={() => onPick(block)}
         title={`${name} · ${hh(block.start)} – ${hh(block.start + block.span)} — click to edit this order`}
-        className="flex size-full cursor-pointer flex-col justify-between overflow-hidden border-0 bg-transparent px-2 py-1.5 text-left text-inherit"
+        className={cn(
+          'flex size-full cursor-pointer flex-col overflow-hidden border-0 bg-transparent px-2 text-left text-inherit',
+          showRange ? 'justify-between py-1.5' : 'justify-center py-0.5',
+        )}
       >
-        <span className="max-w-full overflow-hidden pr-4 font-mono text-[10.5px] font-bold tracking-[0.03em] text-ellipsis whitespace-nowrap uppercase">
+        <span className="max-w-full overflow-hidden pr-4 font-mono text-[10.5px] leading-[1.2] font-bold tracking-[0.03em] text-ellipsis whitespace-nowrap uppercase">
           {name}
         </span>
-        <span className="font-mono text-[9px] tracking-[0.06em] whitespace-nowrap opacity-70">
-          {hh(block.start)} – {hh(block.start + block.span)}
-        </span>
+        {showRange && (
+          <span className="font-mono text-[9px] tracking-[0.06em] whitespace-nowrap opacity-70">
+            {hh(block.start)} – {hh(block.start + block.span)}
+          </span>
+        )}
       </button>
       <button
         type="button"
@@ -311,43 +424,59 @@ function BoardCard({
   );
 }
 
-// One silent run as a hatched slot — a drop target, and a click target that
-// opens a picker of shows to book over those hours (same write as a drop).
+// One silent run as a hatched slot — a drop target, and a click target. With a
+// show armed on the shelf the click books it straight away; with nothing armed
+// it opens a picker of shows to book over those hours (the same write either
+// way, and the same write a drop performs).
 function DropSlot({
-  block, shows, colorOf, onDropShow,
+  block, shows, colorOf, armedShowId, armedName, onDropShow,
 }: {
   block: Block;
   shows: ScheduleShow[];
   colorOf: (id: string | null | undefined) => string;
+  armedShowId: string | null;
+  armedName: string | null;
   onDropShow: (b: Block, showId: string) => void;
 }) {
   const ref = useRef<HTMLButtonElement>(null);
   const [over, setOver] = useState(false);
-  useDynamicStyle(ref, { height: `${block.span * 34 - 4}px` });
+  useDynamicStyle(ref, { height: `calc(var(--hour-px) * ${block.span} - 4px)` });
+  const span = `${hh(block.start)} – ${hh(block.start + block.span)}`;
+
+  const slot = (
+    <button
+      ref={ref}
+      type="button"
+      onClick={armedShowId ? () => onDropShow(block, armedShowId) : undefined}
+      onDragOver={e => { e.preventDefault(); e.dataTransfer.dropEffect = 'copy'; setOver(true); }}
+      onDragLeave={() => setOver(false)}
+      onDrop={e => {
+        e.preventDefault();
+        setOver(false);
+        const id = readDraggedShow(e);
+        if (id) onDropShow(block, id);
+      }}
+      title={armedName
+        ? `Silent ${span} — click to put “${armedName}” here`
+        : `Silent ${span} — click to book a show here, or drop one in`}
+      className={cn(
+        'flex cursor-pointer flex-col items-center justify-center overflow-hidden border border-dashed bg-[repeating-linear-gradient(45deg,transparent_0_5px,var(--ink-soft)_5px_10px)] px-1.5 font-mono text-[9px] tracking-[0.12em] text-ellipsis whitespace-nowrap uppercase',
+        over
+          ? 'border-ink text-ink'
+          : 'border-[color-mix(in_oklab,var(--ink)_32%,transparent)] text-muted hover:border-ink hover:text-ink',
+      )}
+    >
+      {armedName ? `+ ${armedName}` : '+ Add a show'}
+    </button>
+  );
+
+  // Armed, the slot writes on click — there is no menu to open.
+  if (armedShowId) return slot;
+
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild disabled={shows.length === 0}>
-        <button
-          ref={ref}
-          type="button"
-          onDragOver={e => { e.preventDefault(); e.dataTransfer.dropEffect = 'copy'; setOver(true); }}
-          onDragLeave={() => setOver(false)}
-          onDrop={e => {
-            e.preventDefault();
-            setOver(false);
-            const id = readDraggedShow(e);
-            if (id) onDropShow(block, id);
-          }}
-          title={`Silent ${hh(block.start)} – ${hh(block.start + block.span)} — click to book a show here, or drop one in`}
-          className={cn(
-            'flex cursor-pointer flex-col items-center justify-center border border-dashed bg-[repeating-linear-gradient(45deg,transparent_0_5px,var(--ink-soft)_5px_10px)] font-mono text-[9px] tracking-[0.12em] uppercase',
-            over
-              ? 'border-ink text-ink'
-              : 'border-[color-mix(in_oklab,var(--ink)_32%,transparent)] text-muted hover:border-ink hover:text-ink',
-          )}
-        >
-          + Add a show
-        </button>
+        {slot}
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="max-h-80 min-w-[10rem] overflow-y-auto">
         <DropdownMenuGroup>

--- a/web/components/admin/schedule/EditorBand.tsx
+++ b/web/components/admin/schedule/EditorBand.tsx
@@ -10,7 +10,7 @@ import { useRef } from 'react';
 import { useDynamicStyle } from '../../../hooks/useDynamicStyle';
 import { cn } from '../../../lib/cn';
 import { Button } from '../../ui/button';
-import { DayPills, Mu, SlotMenu } from './bits';
+import { DayPills, DayPresets, Mu, SlotMenu } from './bits';
 import type { ScheduleShow } from './lib';
 import { HOURS, dayName, hhmm } from './lib';
 
@@ -50,6 +50,8 @@ export interface LineEditorProps {
   onLineChange: (patch: Partial<EditorLine>) => void;
   onLineShow: (id: string) => void;
   onToggleLineDay: (day: number) => void;
+  /** Replace the day set outright — the weekday/weekend/every-day presets. */
+  onSetLineDays: (days: number[]) => void;
   onAir: () => void;
   onQuiet: () => void;
   orderNo: number;
@@ -60,7 +62,7 @@ export interface LineEditorProps {
  *  the tool for finer ranges, other shows, and multi-day writes. */
 export function LineEditor({
   shows, line, lineShowId, lineDays, currentName, colorOf,
-  onLineChange, onLineShow, onToggleLineDay, onAir, onQuiet, orderNo,
+  onLineChange, onLineShow, onToggleLineDay, onSetLineDays, onAir, onQuiet, orderNo,
 }: LineEditorProps) {
   const lineShow = shows.find(s => s.id === lineShowId) ?? null;
   return (
@@ -114,6 +116,7 @@ export function LineEditor({
             onSelect={k => onLineChange({ end: Number(k) })}
           />
           <span className="mx-1 hidden h-5 w-px bg-separator-strong sm:block" />
+          <DayPresets selected={lineDays} onSelect={onSetLineDays} />
           <DayPills selected={lineDays} onToggle={onToggleLineDay} />
           {/* Its own full-width line on a phone — the sentence above already
               fills several rows, and the buttons need a real tap target. */}

--- a/web/components/admin/schedule/EditorBand.tsx
+++ b/web/components/admin/schedule/EditorBand.tsx
@@ -69,11 +69,16 @@ export function LineEditor({
     <div className="min-w-0">
       <div className="mb-0.5 flex flex-wrap items-baseline gap-x-3 gap-y-0.5">
         <span className="eyebrow flex-none whitespace-nowrap text-ink">Write an order</span>
+        {/* The instruction half is the part that truncates on a phone, and the
+            sentence below it is self-evidently a sentence to fill in. What the
+            operator cannot get anywhere else is what those hours run right
+            now, so that half stays at every width. */}
         <Mu className="min-w-0 flex-1 truncate tracking-[0.08em]">
-          Fill in the sentence, then add it to the schedule · {dayName(line.day)} {hhmm(line.start)} → {hhmm(line.end)}{' '}
+          <span className="hidden sm:inline">Fill in the sentence, then add it to the schedule · </span>
+          {dayName(line.day)} {hhmm(line.start)} → {hhmm(line.end)}{' '}
           {currentName ? `is currently ${currentName}` : 'is currently silent'}
         </Mu>
-        <Mu className="ml-auto flex-none text-[8.5px] whitespace-nowrap">Becomes order №{orderNo}</Mu>
+        <Mu className="ml-auto hidden flex-none text-[8.5px] whitespace-nowrap sm:block">Becomes order №{orderNo}</Mu>
       </div>
       <div className="mt-2 border border-ink bg-[var(--page-bg)] p-[15px]">
         <div className="flex flex-wrap items-center gap-2 text-[14.5px] text-ink">

--- a/web/components/admin/schedule/SchedulePanel.tsx
+++ b/web/components/admin/schedule/SchedulePanel.tsx
@@ -255,7 +255,10 @@ export default function SchedulePanel() {
   useEffect(() => {
     if (!armedId) return;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setArmedShowId(null);
+      // A Radix layer that consumed this Escape (the review modal, a slot
+      // menu) preventDefaults it from a document-capture listener before this
+      // bubble listener runs — closing an overlay must not also drop the brush.
+      if (e.key === 'Escape' && !e.defaultPrevented) setArmedShowId(null);
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);

--- a/web/components/admin/schedule/SchedulePanel.tsx
+++ b/web/components/admin/schedule/SchedulePanel.tsx
@@ -38,7 +38,7 @@ import type { Block, Schedule, ScheduleShow } from './lib';
 import {
   DAYS, SHOW_COLORS, blockAhead, blockAt, bookedHours, cloneWeek, dayBlocks,
   dayName, diffCells, diffRanges, emptyWeek, fillDayToggle, fillHourToggle,
-  hhmm, setRange, showHours, weekOrders,
+  hhmm, resizeBlock, setRange, showHours, weekOrders,
 } from './lib';
 
 /** The airtime-bar tick — hours a show "should" get in a week. */
@@ -310,6 +310,21 @@ export default function SchedulePanel() {
     setLine({ day: b.day, start: b.start, end: b.start + b.span });
     setLineDays([b.day]);
     setLineShowId(showId);
+  };
+
+  // A board card's edge dragged to new hours. The vacated hours fall silent
+  // and the gained ones are written over whatever was there — the same
+  // overwrite a drop or the order desk performs, so a run grown into its
+  // neighbour takes those hours rather than stopping short of them.
+  const resizeRun = (b: Block, start: number, end: number) => {
+    if (!schedule || !b.showId) return;
+    setSchedule(resizeBlock(schedule, b, start, end));
+    setLine({ day: b.day, start, end });
+    setLineDays([b.day]);
+    setLineShowId(b.showId);
+    notify.ok(
+      `“${showById(b.showId)?.name ?? 'show'}” now ${dayName(b.day)} ${hhmm(start)} – ${hhmm(end)} — unsaved until you save the week.`,
+    );
   };
 
   // The × on a board card: take the run off the air (a local edit). The
@@ -768,6 +783,7 @@ export default function SchedulePanel() {
           hoursOf={hoursOf}
           onPick={pick}
           onRemove={removeRun}
+          onResize={resizeRun}
           onDropShow={dropShow}
           armedShowId={armedId}
           onArmShow={armShow}

--- a/web/components/admin/schedule/SchedulePanel.tsx
+++ b/web/components/admin/schedule/SchedulePanel.tsx
@@ -17,6 +17,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useAdminAuth } from '../../../lib/adminAuth';
+import { BOARD_HOUR_PX, useBoardDensity } from '../../../lib/adminView';
 import { notify, errorMessage } from '../../../lib/notify';
 import { fmtClock, normalizeStationLocale, zonedDayHour } from '../../../lib/format';
 import type { StationLocale } from '../../../lib/types';
@@ -36,8 +37,8 @@ import { ColorChip, Mu, SegBtn, SlotMenu } from './bits';
 import type { Block, Schedule, ScheduleShow } from './lib';
 import {
   DAYS, SHOW_COLORS, blockAhead, blockAt, bookedHours, cloneWeek, dayBlocks,
-  dayName, diffCells, diffRanges, emptyWeek, hhmm, setRange, showHours,
-  weekOrders,
+  dayName, diffCells, diffRanges, emptyWeek, fillDayToggle, fillHourToggle,
+  hhmm, setRange, showHours, weekOrders,
 } from './lib';
 
 /** The airtime-bar tick — hours a show "should" get in a week. */
@@ -119,6 +120,14 @@ export default function SchedulePanel() {
   const [lineShowId, setLineShowId] = useState<string | null>(null);
   const [lineDays, setLineDays] = useState<number[]>([6]);
 
+  // The armed show — the shelf chip acting as a brush (#1204). Deliberately
+  // its own state rather than reusing `lineShowId`: that one is set by every
+  // card click and load, so hanging the day/hour bulk fills off it would let a
+  // stray click on a day header rewrite 24 hours. Arming is an explicit mode
+  // the operator enters and can leave with Escape.
+  const [armedShowId, setArmedShowId] = useState<string | null>(null);
+  const [density, setDensity] = useBoardDensity();
+
   const [dismissed, setDismissed] = useState<string[]>([]);
   const [reviewOpen, setReviewOpen] = useState(false);
   // The in-app destination an unsaved-edits click was held back from (see the
@@ -130,6 +139,11 @@ export default function SchedulePanel() {
   const [pinShowId, setPinShowId] = useState('');
   const [pinMinutes, setPinMinutes] = useState(60);
   const [pinBusy, setPinBusy] = useState(false);
+  // The takeover controls run ~430px of dropdown, presets, minutes and button
+  // for something reached a few times a month, and they sit between the header
+  // and the board on every load. Collapsed to one line until asked for; a live
+  // takeover always renders in full.
+  const [takeoverOpen, setTakeoverOpen] = useState(false);
 
   useEffect(() => {
     const id = setInterval(() => setNow(new Date()), 1000);
@@ -220,6 +234,56 @@ export default function SchedulePanel() {
 
   const liveOverride = override && override.expiresAt > now.getTime() ? override : null;
   const pinnedShow = liveOverride ? showById(liveOverride.showId) : null;
+
+  // ── the brush ────────────────────────────────────────────────────────────
+  // Resolve through the roster rather than trusting the id: a show deleted on
+  // the Shows page in another tab would otherwise leave a dangling brush that
+  // writes an id no order can render.
+  const armedShow = armedShowId ? showById(armedShowId) : null;
+  const armedId = armedShow?.id ?? null;
+
+  /** Shelf-chip click: arm the show, or put the brush down if it is already
+   *  armed. Either way the sentence editor follows, so the two editing paths
+   *  never disagree about which show is in hand. */
+  const armShow = (id: string) => {
+    setArmedShowId(cur => (cur === id ? null : id));
+    setLineShowId(id);
+  };
+
+  // Escape puts the brush down — the standard way out of a modal tool, and the
+  // only way out that doesn't require finding the armed chip again.
+  useEffect(() => {
+    if (!armedId) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setArmedShowId(null);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [armedId]);
+
+  /** A day header with a show armed: put it on all 24 hours — or clear the day
+   *  when it already runs nothing else, so a second click undoes the first. */
+  const fillDay = (day: number) => {
+    if (!schedule || !armedShow) return;
+    const next = fillDayToggle(schedule, day, armedShow.id);
+    setSchedule(next);
+    const cleared = (next[day] ?? []).every(c => c == null);
+    notify.ok(cleared
+      ? `${dayName(day)} cleared — unsaved until you save the week.`
+      : `“${armedShow.name}” across ${dayName(day)} — unsaved until you save the week.`);
+  };
+
+  /** An hour in the gutter with a show armed: put it on that hour every day,
+   *  with the same toggle-off rule. */
+  const fillHour = (hour: number) => {
+    if (!schedule || !armedShow) return;
+    const next = fillHourToggle(schedule, hour, armedShow.id);
+    setSchedule(next);
+    const cleared = DAYS.every(d => next[d.key]?.[hour] == null);
+    notify.ok(cleared
+      ? `${hhmm(hour)} cleared all week — unsaved until you save the week.`
+      : `“${armedShow.name}” at ${hhmm(hour)} every day — unsaved until you save the week.`);
+  };
 
   // ── editor actions ───────────────────────────────────────────────────────
   const pick = (b: Block) => {
@@ -338,6 +402,7 @@ export default function SchedulePanel() {
       const j = (await r.json().catch(() => ({}))) as { error?: string; override?: ScheduleOverride };
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
       setOverride(j.override ?? null);
+      setTakeoverOpen(false);
       const name = showById(pinShowId)?.name || 'show';
       notify.ok(`“${name}” takes over — the switch airs on the next track.`);
     } catch (e) {
@@ -520,9 +585,11 @@ export default function SchedulePanel() {
             </Button>
           </div>
         </div>
-        <h1 className="mt-2 mb-0 font-display text-[28px] leading-[1.05] font-semibold tracking-[-0.015em]">
-          Programme the week, one hour at a time.
-        </h1>
+        {/* The board is 24 hours tall, so every row of chrome above it costs a
+            row of the week. The display headline went (the eyebrow and the
+            breadcrumb both already name this page); its standing note stays as
+            the accessible h1. */}
+        <h1 className="sr-only">The Rundown — programme the week, one hour at a time</h1>
         <Mu className="mt-1.5 block text-[9px] tracking-[0.1em]">
           Empty hours run autonomously · every change goes live on save
         </Mu>
@@ -569,7 +636,16 @@ export default function SchedulePanel() {
           {/* Full-width + wrapping on a phone: the controls run ~430px wide,
               so on one flex-none line the Pin button falls off the screen. */}
           <div className="ml-auto flex w-full flex-none flex-wrap items-center gap-2.5 sm:w-auto sm:flex-nowrap">
-            {liveOverride && pinnedShow ? (
+            {!liveOverride && !takeoverOpen ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="min-h-9 sm:min-h-0"
+                onClick={() => setTakeoverOpen(true)}
+              >
+                Pin a show…
+              </Button>
+            ) : liveOverride && pinnedShow ? (
               <>
                 <ColorChip color={colorOf(pinnedShow.id)} />
                 <span className="text-[13px] font-bold text-ink">{pinnedShow.name}</span>
@@ -630,6 +706,15 @@ export default function SchedulePanel() {
                 >
                   {pinBusy ? 'Pinning…' : 'Pin show'}
                 </Button>
+                <button
+                  type="button"
+                  onClick={() => setTakeoverOpen(false)}
+                  aria-label="Close the takeover controls"
+                  title="Close the takeover controls"
+                  className="cursor-pointer border-0 bg-transparent p-1 font-mono text-[13px] leading-none font-bold text-muted hover:text-ink"
+                >
+                  ×
+                </button>
               </>
             )}
           </div>
@@ -656,6 +741,13 @@ export default function SchedulePanel() {
                 ? (d === line.day ? cur : cur.filter(x => x !== d))
                 : [...cur, d],
             )}
+            // A preset replaces the set outright, so the sentence's own day has
+            // to move into it — otherwise `applyLine` re-adds the old one and
+            // "Weekdays" quietly writes Saturday too.
+            onSetLineDays={days => {
+              setLineDays(days);
+              if (!days.includes(line.day)) setLine(cur => ({ ...cur, day: days[0] ?? cur.day }));
+            }}
             onAir={() => applyLine(lineShowId)}
             onQuiet={() => applyLine(null)}
             orderNo={orderNo}
@@ -674,7 +766,13 @@ export default function SchedulePanel() {
           onPick={pick}
           onRemove={removeRun}
           onDropShow={dropShow}
-          onArmShow={setLineShowId}
+          armedShowId={armedId}
+          onArmShow={armShow}
+          onFillDay={fillDay}
+          onFillHour={fillHour}
+          density={density}
+          hourPx={BOARD_HOUR_PX[density]}
+          onDensity={setDensity}
         />
       </div>
       <div className="flex-1 pb-1">

--- a/web/components/admin/schedule/SchedulePanel.tsx
+++ b/web/components/admin/schedule/SchedulePanel.tsx
@@ -573,8 +573,17 @@ export default function SchedulePanel() {
             <span className="font-mono text-[11.5px] font-bold tracking-[0.06em] text-ink">{clockLabel}</span>
             <Mu className="text-[9px]">{zoneLabel}</Mu>
           </div>
-          <div className="ml-auto flex w-full flex-none flex-wrap items-center gap-3 sm:w-auto sm:flex-nowrap">
-            <span className="flex flex-none items-center gap-2">
+          {/* Phones get the status and Save from `SaveBar` alone. It is sticky
+              for exactly as long as the week is dirty, carries Review and
+              Discard beside the same button, and follows the operator down
+              into the board where the edits actually happen — so repeating all
+              of it here just spent a row of a 24-hour screen saying it twice.
+              With nothing to save there is nothing to show either. */}
+          {/* No `w-full` on a phone any more: with the status and Save gone,
+              the lone New-show link sizes to its content and sits beside the
+              clock wherever there is room instead of claiming a row. */}
+          <div className="ml-auto flex flex-none flex-wrap items-center gap-3 sm:flex-nowrap">
+            <span className="hidden flex-none items-center gap-2 sm:flex">
               {dirty > 0 && <span aria-hidden="true" className="size-1.5 bg-[var(--accent)]" />}
               <Mu className={cn('text-[9px] whitespace-nowrap', dirty > 0 && 'text-ink')}>
                 {dirty > 0 ? `${dirty} unsaved edit${dirty === 1 ? '' : 's'}` : 'all changes saved'}
@@ -595,7 +604,7 @@ export default function SchedulePanel() {
             <Button
               variant="accent"
               size="sm"
-              className="min-h-9 sm:min-h-0"
+              className="hidden sm:inline-flex"
               onClick={saveWeek}
               disabled={busy || dirty === 0}
             >
@@ -634,6 +643,9 @@ export default function SchedulePanel() {
             name={showById(nextBlock.showId)?.name ?? 'Nobody in the chair'}
             color={nextBlock.showId ? colorOf(nextBlock.showId) : null}
             meta={metaOf(nextBlock.showId)}
+            // Hiding "After that" makes this the last cell a phone shows, and
+            // its own rule would double up against the takeover strip's.
+            className="max-sm:border-b-0"
           />
           <NowCell
             label="After that"
@@ -642,18 +654,32 @@ export default function SchedulePanel() {
             color={laterBlock.showId ? colorOf(laterBlock.showId) : null}
             meta={metaOf(laterBlock.showId)}
             last
+            // Three stacked cells is ~190px of a phone screen spent on what is
+            // playing before any of the week is visible. On air and Up next
+            // are the two an operator acts on; the hour after that is already
+            // in the board they are scrolling to.
+            className="hidden sm:block"
           />
         </div>
 
         {/* Takeover strip */}
         <div className="flex flex-wrap items-center gap-x-3.5 gap-y-2 border-t border-separator-strong bg-[color-mix(in_oklab,var(--ink)_5%,var(--page-bg))] px-5 py-[11px] sm:px-[22px]">
           <span className="eyebrow flex-none text-ink">Takeover</span>
-          <Mu className="min-w-0 flex-1 truncate text-[9px]">
+          {/* Truncated to "…THE SCHEDULE PICKS…" on a phone, which is noise
+              rather than explanation — the Pin button and its own controls say
+              the rest. */}
+          <Mu className="hidden min-w-0 flex-1 truncate text-[9px] sm:block">
             Jump a show to the front of the queue — the schedule picks up again after
           </Mu>
-          {/* Full-width + wrapping on a phone: the controls run ~430px wide,
-              so on one flex-none line the Pin button falls off the screen. */}
-          <div className="ml-auto flex w-full flex-none flex-wrap items-center gap-2.5 sm:w-auto sm:flex-nowrap">
+          {/* Full-width + wrapping on a phone only once there is something to
+              wrap: expanded, the controls run ~430px and the Pin button would
+              fall off the screen. Collapsed it is one button, and giving that
+              a row of its own is how a monthly action came to cost the same
+              vertical space as an hour of the week. */}
+          <div className={cn(
+            'ml-auto flex flex-none flex-wrap items-center gap-2.5 sm:w-auto sm:flex-nowrap',
+            takeoverOpen || liveOverride ? 'w-full' : 'w-auto',
+          )}>
             {!liveOverride && !takeoverOpen ? (
               <Button
                 variant="ghost"
@@ -927,7 +953,7 @@ export default function SchedulePanel() {
 }
 
 function NowCell({
-  label, live, time, left, name, color, meta, pct, last,
+  label, live, time, left, name, color, meta, pct, last, className,
 }: {
   label: string;
   live?: boolean;
@@ -938,6 +964,8 @@ function NowCell({
   meta: string;
   pct?: number;
   last?: boolean;
+  /** Responsive overrides from the caller (which cells a phone shows). */
+  className?: string;
 }) {
   const barRef = useRef<HTMLDivElement>(null);
   useDynamicStyle(barRef, { width: `${pct ?? 0}%` });
@@ -948,6 +976,7 @@ function NowCell({
         // Stacked on a phone (grid-cols-1), so the divider runs along the
         // bottom; the column rule comes back with the 3-up grid at sm.
         !last && 'border-b border-separator-strong sm:border-r sm:border-b-0',
+        className,
       )}
     >
       <div className="mb-1 flex items-center gap-2">

--- a/web/components/admin/schedule/bits.tsx
+++ b/web/components/admin/schedule/bits.tsx
@@ -162,6 +162,51 @@ export function DayPills({
   );
 }
 
+/** Weekday / weekend / whole-week presets for the sentence editor's day set.
+ *  The pills below already write several days at once — this names the three
+ *  sets an operator actually reaches for, so the bulk path stops reading as
+ *  seven separate toggles. `selected` is compared as a set, so the matching
+ *  preset lights up however the days were chosen. */
+export function DayPresets({
+  selected,
+  onSelect,
+}: {
+  selected: number[];
+  onSelect: (days: number[]) => void;
+}) {
+  const sets: { label: string; title: string; days: number[] }[] = [
+    { label: 'Weekdays', title: 'Monday through Friday', days: [1, 2, 3, 4, 5] },
+    { label: 'Weekend', title: 'Saturday and Sunday', days: [6, 0] },
+    { label: 'Every day', title: 'All seven days', days: [1, 2, 3, 4, 5, 6, 0] },
+  ];
+  const same = (a: number[], b: number[]) =>
+    a.length === b.length && a.every(d => b.includes(d));
+  return (
+    <div className="flex gap-1.5">
+      {sets.map(s => {
+        const on = same(selected, s.days);
+        return (
+          <button
+            key={s.label}
+            type="button"
+            aria-pressed={on}
+            title={s.title}
+            onClick={() => onSelect(s.days)}
+            className={cn(
+              'flex min-h-8 cursor-pointer items-center border px-2 font-mono text-[8px] font-bold tracking-[0.14em] uppercase sm:min-h-[17px]',
+              on
+                ? 'border-ink bg-ink text-bg'
+                : 'border-separator-strong bg-transparent text-muted hover:border-ink hover:text-ink',
+            )}
+          >
+            {s.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 /** Muted mono micro-label (the spMu pattern). */
 export function Mu({ children, className }: { children?: ReactNode; className?: string }) {
   return (

--- a/web/components/admin/schedule/lib.ts
+++ b/web/components/admin/schedule/lib.ts
@@ -138,6 +138,23 @@ export function setRange(
   return week;
 }
 
+/** Fill a whole day with `showId` — or clear it when the day already runs
+ *  nothing but that show, so a second click undoes the first. The bulk gesture
+ *  behind a click on a day header. */
+export function fillDayToggle(schedule: Schedule, day: number, showId: string): Schedule {
+  const cells = schedule[day] ?? [];
+  const allSet = cells.length === 24 && cells.every(c => c === showId);
+  return setRange(schedule, [day], 0, 24, allSet ? null : showId);
+}
+
+/** Fill one hour across all seven days — same toggle-off rule as `fillDayToggle`.
+ *  The bulk gesture behind a click on an hour in the gutter. */
+export function fillHourToggle(schedule: Schedule, hour: number, showId: string): Schedule {
+  const days = DAYS.map(d => d.key);
+  const allSet = days.every(d => schedule[d]?.[hour] === showId);
+  return setRange(schedule, days, hour, hour + 1, allSet ? null : showId);
+}
+
 /** Number of cells where the two grids disagree (the unsaved-edit count). */
 export function diffCells(a: Schedule, b: Schedule): number {
   let n = 0;

--- a/web/components/admin/schedule/lib.ts
+++ b/web/components/admin/schedule/lib.ts
@@ -155,6 +155,35 @@ export function fillHourToggle(schedule: Schedule, hour: number, showId: string)
   return setRange(schedule, days, hour, hour + 1, allSet ? null : showId);
 }
 
+/** Where a dragged edge of `block` lands once `hour` is clamped to something
+ *  legal: inside the day, and never shorter than one hour. Pure so the board
+ *  can run it on every pointer move without touching the grid. */
+export function resizedRun(
+  block: Block,
+  edge: 'top' | 'bottom',
+  hour: number,
+): { start: number; end: number } {
+  const end = block.start + block.span;
+  if (edge === 'top') return { start: Math.min(Math.max(hour, 0), end - 1), end };
+  return { start: block.start, end: Math.max(Math.min(hour, 24), block.start + 1) };
+}
+
+/** Move one run's boundaries to [start, end) — the write behind a resize drag.
+ *  The hours it gives up fall silent; the hours it takes over are written to
+ *  its show over whatever was there, the same overwrite every other write on
+ *  this screen performs. Clearing first is what makes a shrink work at all,
+ *  and it must happen before the write or a grow would erase its own gain. */
+export function resizeBlock(
+  schedule: Schedule,
+  block: Block,
+  start: number,
+  end: number,
+): Schedule {
+  if (!block.showId) return schedule;
+  const cleared = setRange(schedule, [block.day], block.start, block.start + block.span, null);
+  return setRange(cleared, [block.day], start, end, block.showId);
+}
+
 /** Number of cells where the two grids disagree (the unsaved-edit count). */
 export function diffCells(a: Schedule, b: Schedule): number {
   let n = 0;

--- a/web/hooks/useDynamicStyle.ts
+++ b/web/hooks/useDynamicStyle.ts
@@ -11,6 +11,15 @@ import type { RefObject } from 'react';
 
 export type StyleVars = Record<string, string | number | null | undefined>;
 
+/** `removeProperty` takes the hyphenated CSS name, so clearing a camelCase key
+ *  like `marginBottom` silently no-ops and the property sticks forever. Setting
+ *  works either way (camelCase assignment), which is why this only ever bit the
+ *  callers that clear a multi-word property. Custom properties are
+ *  case-sensitive and already hyphenated — leave them exactly as given. */
+function cssName(key: string): string {
+  return key.startsWith('--') ? key : key.replace(/[A-Z]/g, c => `-${c.toLowerCase()}`);
+}
+
 export function useDynamicStyle<E extends HTMLElement | SVGElement>(
   ref: RefObject<E | null>,
   vars: StyleVars,
@@ -25,7 +34,7 @@ export function useDynamicStyle<E extends HTMLElement | SVGElement>(
     if (!el) return;
     for (const [k, v] of Object.entries(vars)) {
       if (v == null || v === '') {
-        el.style.removeProperty(k);
+        el.style.removeProperty(cssName(k));
         continue;
       }
       // CSS variables (prefixed with `--`) use setProperty; everything else

--- a/web/lib/adminView.ts
+++ b/web/lib/adminView.ts
@@ -1,9 +1,15 @@
 'use client';
 
-// Roster view preference — cards or list — for the three admin rosters that
-// share the "broadcast slate" card recipe (/admin/skills, /admin/shows,
-// /admin/personas). Cards stay the default; the list view is the second gear
-// for a roster that has outgrown a card stack.
+// Browser-local admin view preferences. Two live here:
+//
+// Roster view — cards or list — for the three admin rosters that share the
+// "broadcast slate" card recipe (/admin/skills, /admin/shows, /admin/personas).
+// Cards stay the default; the list view is the second gear for a roster that
+// has outgrown a card stack.
+//
+// Board density — the Rundown's pixels-per-hour. The board is 24 hours tall, so
+// the hour unit is what decides whether a week clears the fold; compact trades
+// the time range printed on a card for ~200px of height.
 //
 // Stored per surface, not globally: an operator may well want Skills as a
 // dense list while Shows stays on cards (that page already has the weekly grid
@@ -54,4 +60,41 @@ export function useRosterView(surface: RosterSurface): [RosterView, (v: RosterVi
   }, [surface]);
 
   return [view, setView];
+}
+
+export type BoardDensity = 'compact' | 'comfortable';
+
+/** Pixels per hour on the Rundown board, per density. Comfortable is the
+ *  original metric; compact is the tallest unit that still holds one line of
+ *  card text, which puts a 24-hour day at ~630px instead of ~820px. */
+export const BOARD_HOUR_PX: Record<BoardDensity, number> = { compact: 26, comfortable: 34 };
+
+const DENSITY_KEY = 'subwave-admin-board-density';
+
+function isDensity(v: string | null): v is BoardDensity {
+  return v === 'compact' || v === 'comfortable';
+}
+
+/** `[density, setDensity]` for the Rundown board. Same hydration shape as
+ *  `useRosterView` — the default renders on the server, the stored preference
+ *  lands in a mount effect, and the panel is showing a skeleton until the
+ *  settings fetch returns anyway. */
+export function useBoardDensity(): [BoardDensity, (d: BoardDensity) => void] {
+  const [density, setDensityState] = useState<BoardDensity>('comfortable');
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(DENSITY_KEY);
+      if (isDensity(raw)) setDensityState(raw);
+    } catch { /* private-mode browsers throw on getItem — the default stands */ }
+  }, []);
+
+  const setDensity = useCallback((d: BoardDensity) => {
+    setDensityState(d);
+    try {
+      window.localStorage.setItem(DENSITY_KEY, d);
+    } catch { /* as above — the choice still applies for this session */ }
+  }, []);
+
+  return [density, setDensity];
 }


### PR DESCRIPTION
Three rounds of work on the Rundown board (`/admin/shows/schedule`), issue #1204.

## Fit the board to the screen

The seven day columns held a 188px floor, so the board's intrinsic width was 1428px against ~1072px of admin content on a 1280 laptop — a quarter of the week sat off-screen. Columns now divide whatever width they're given from `sm` up.

The hour gutter had been released from `sticky` at `sm` on the assumption the board fits there; it's now pinned at every width, so a narrow window no longer scrolls the hour labels away and leaves an unlabelled field of hatching.

A **density switch** (Roomy 34px/hr, Compact 26px/hr, remembered per browser) puts a 24-hour day at ~630px instead of ~820px. The hour unit is a CSS variable, so the gutter's static height and each card's computed height can't drift apart. The display headline became `sr-only` — the eyebrow and breadcrumb already name the page, and every row of chrome above a 24-hour board costs a row of the week.

## The shelf as a brush

A shelf chip can be **armed**, then painted onto the board: a silent slot books it directly, a day header fills all 24 hours, an hour in the gutter fills that hour across all seven days. Both bulk fills toggle off on a second click. Escape puts the brush down.

Armed state is deliberately separate from the sentence editor's `lineShowId` — that one is set by every card click and load, so hanging the bulk fills off it would let a stray click rewrite 24 hours.

Also: weekday/weekend/every-day presets in the sentence editor, and the takeover controls collapsed behind a link (~430px of dropdowns sitting above the board on every load for something reached a few times a month).

## Resize runs by their edges

Each card carries a grab strip on its top and bottom edge — drag to move that boundary an hour at a time, or arrow-key it from the focused handle.

The drag is a **pure preview**; the grid is written once, on release. Writing on every step is the obvious approach and doesn't work: cards are re-derived by `dayBlocks` and keyed on `start`, so a top-edge drag would remount the very handle holding the pointer capture and the gesture would die on its first hour. Instead the card draws itself at the drafted size and pulls the difference out of its own margins, so a growing run overlaps its neighbours rather than reflowing the column under the cursor.

Growing over a neighbouring show **overwrites** those hours — matching a drop, the order desk, and the brush fills. Flagging it as the one debatable call: the alternative is clamping at the neighbour's boundary, which is safer but means you can't push a show back without first shrinking the one beside it.

## Folding, restored to the header

`98109ee` (earlier in this branch) gave the day header to the fill-day gesture and moved Fold to the column footer — ~800px down a 24-hour column, so in practice it was gone, and with no brush armed the header did nothing at all.

The header body now folds when nothing is armed (what it always did) and fills the day when a brush is — the same armed/unarmed split the silent slots already make. A chevron beside the count folds in **either** mode, so an armed brush never leaves a column without a collapse control at the top. The footer Fold stays for when you're already at the bottom.

The Roomy/Compact tabs also went icon-only (`Rows2`/`Rows4`) on the `RosterViewToggle` recipe — sr-only name, `title` explanation, min-h tap target. The narrower control pulls the board's hint line back onto one row on a laptop, which is another row of the week recovered.

## Testing

`npm run lint` (`eslint . && tsc --noEmit`) passes — the merge gate.

Verified against a live dev stack in Chrome: top- and bottom-edge drags at both densities (26px and 34px per hour, pixel-exact), the mid-drag overlap preview, commit-on-release, arrow-key resize, the toast and order-desk sync, both density icons, header-click fold, rail reopen, and armed-header fill.

The pure write was checked separately against a day with two adjacent runs — a case the dev station couldn't produce, having one show on whole days. Confirmed: growing eats into the neighbour from either edge, swallowing one whole removes it rather than leaving a zero-width block, shrinking frees hours to silence rather than reverting them to the neighbour, both clamps hold (day bounds, one-hour minimum), a silent block is a no-op, and no other day is touched.

### Not covered

- **Touch.** `touch-action: none` hands the gesture to the pointer handlers, but there's no device evidence. 7px handles either side of a one-hour compact card is tight; the sentence editor stays the precise path on a phone.
- **Firefox/Safari.** Chrome only. Firefox is worth a look given the `aria-disabled` care already in this branch.
- **Persistence.** Every test edit was discarded rather than saved, so the resize → save → reload round-trip is unproven. It goes through the same grid as every other edit.
- **No automated coverage.** `web/` has no test suite and CI runs lint only. `resizedRun`/`resizeBlock` are pure and are exactly what `controller/scripts/*.test.ts` would pin, but there's no runner on this side of the repo.


---

## A stuck margin (`useDynamicStyle`)

Caught while auditing the mobile view: a resized card kept its drag-preview `margin-bottom` after the drag committed, so a run shrunk by three hours left three hours of dead space under it until a reload.

The cause is in the shared hook, not the board. `useDynamicStyle` clears with `el.style.removeProperty(key)` using the camelCase key, but `removeProperty()` takes the *hyphenated* CSS name — so clearing `marginBottom` silently no-opped. Setting has always worked (camelCase assignment), which is why nothing hit this before: every other conditional caller passes a `--custom-prop` (already hyphenated) or a single-word `width`/`height`, all of which round-trip fine. The resize preview is the first caller to clear a multi-word property.

Fixed in the hook so it's right for every caller; custom properties pass through untouched.

## Leaning the screen for phones

The Rundown is a 24-hour board, and on a phone roughly two and a half screens of chrome stood between the operator and the first hour of it. All of this is `sm:`-gated — **every desktop width renders exactly as before**, verified side by side.

- **The header stops repeating the save affordance.** `SaveBar` is already sticky for as long as the week is dirty, carries Review and Discard beside the same button, and follows you down into the board where the edits happen. The header was spending a row saying it twice; with nothing to save there's nothing to say. Its New-show link stops claiming a full-width row as a result.
- **"After that" stands down.** Three stacked now/next cells is ~190px before any of the week is visible. On air and Up next are the two you act on; the hour after that is in the board you're scrolling to. Up next drops its rule so it doesn't double against the takeover strip's.
- **The takeover strip is one row again.** Its explanation truncated to "…THE SCHEDULE PICKS…", and the collapsed Pin button no longer takes a full-width row — that's how a monthly action came to cost the same height as an hour of the week. Expanded, it wraps as before, which is what the width was for.
- **The board hint gets a phone-sized version** instead of three wrapped rows of mono. Half the long copy is mouse-only regardless: HTML5 drag-and-drop doesn't fire from a touch, and 7px card edges are a poor fingertip target. The short copy names the gestures a phone can perform.
- **The order band** keeps the half you can't get elsewhere (what those hours run right now) and drops the half that truncates.

Net effect at a 537px viewport: the shelf and the top of the board now clear the first screen, where previously you scrolled past the sentence editor to reach them.
