### PR TITLE
fix(llm): count failed calls against the daily token cap

### DIFF
--- a/controller/scripts/llm-budget.test.ts
+++ b/controller/scripts/llm-budget.test.ts
@@ -1,0 +1,111 @@
+// Pins the daily LLM token tally (llm/internal/telemetry/budget.ts) against the
+// call recorder that feeds it (telemetry/log.ts record()).
+//
+// Issue #1195: a call that THROWS is still billed by the provider, and djAgent's
+// cascade can burn several legs before it gives up. The tally therefore counts
+// failed calls that reported usage; the lifetime ticker beside it deliberately
+// does not (it's the listener-facing counter on the player, mirroring
+// summarizeLlm in stats.ts). Two properties are load-bearing:
+//
+//  - The two counters diverge on purpose. A regression that re-unifies them
+//    either re-breaks the cap or makes the public ticker jump on failures.
+//  - The live guard in log.ts and the seed filter in budget.ts are SECOND
+//    copies of one policy, and disagreement is silent: screening `ok` in the
+//    seed while counting failures live makes a mid-day restart re-seed from
+//    successes only and walk the tally BACKWARDS, dropping an operator out of
+//    `hard` on a container bounce. The round-trip below is the real pin —
+//    record a mixed batch, then re-seed from the events file those very calls
+//    wrote and assert the two numbers agree.
+//
+// STATE_DIR is redirected at a throwaway dir BEFORE the first import, so the
+// events log lands nowhere real — hence the dynamic imports. node:assert-via-tsx
+// style, matching scripts/voice-policy.test.ts.
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const root = mkdtempSync(join(tmpdir(), 'subwave-budget-'));
+process.env.STATE_DIR = root;
+
+const { record, lifetimeTokenCount } = await import('../src/llm/internal/telemetry/log.js');
+const { dailyTokensUsed, seedDailyUsageFromLog } = await import('../src/llm/internal/telemetry/budget.js');
+
+const utcDay = () => new Date().toISOString().slice(0, 10);
+const eventsFile = () => join(root, 'logs', `events-${utcDay()}.jsonl`);
+
+// logEvent's append is fire-and-forget (best-effort by design — a log write must
+// never break a broadcast), so wait for the lines to actually land rather than
+// racing them. Fails loudly on timeout instead of silently asserting on 0.
+async function waitForLlmEvents(want: number, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const seen = existsSync(eventsFile())
+      ? readFileSync(eventsFile(), 'utf8').split('\n').filter(Boolean)
+        .filter((l) => { try { return JSON.parse(l)?.type === 'llm'; } catch { return false; } }).length
+      : 0;
+    if (seen >= want) return;
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${want} llm events on the timeline (saw ${seen})`);
+    }
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
+// A minimal record-shaped call. record() only reads ok/usage for the counters;
+// everything else rides through to the ring buffer and the event line.
+const call = (ok: boolean, total: number | undefined) => ({
+  kind: 'pick',
+  ok,
+  ms: 12,
+  model: 'test-model',
+  via: 'ai-sdk',
+  ...(total === undefined ? {} : { usage: { input: 1, output: total - 1, total } }),
+  ...(ok ? {} : { error: 'agent did not call the done tool before stopping' }),
+});
+
+try {
+  // ── Baseline ───────────────────────────────────────────────────────────────
+  assert.equal(dailyTokensUsed(), 0, 'fresh process starts the day at zero');
+  assert.equal(lifetimeTokenCount(), 0, 'fresh process starts the lifetime ticker at zero');
+
+  // ── A successful call feeds both counters ──────────────────────────────────
+  record(call(true, 100));
+  assert.equal(dailyTokensUsed(), 100, 'a success counts toward the daily tally');
+  assert.equal(lifetimeTokenCount(), 100, 'a success counts toward the lifetime ticker');
+
+  // ── A FAILED call feeds the tally only (#1195) ─────────────────────────────
+  // The spend is real — agent.ts sums every leg onto err.usage and
+  // failureDiagnostics normalises it onto the record — so the cap must see it.
+  record(call(false, 250));
+  assert.equal(dailyTokensUsed(), 350, 'a failed call with usage counts toward the daily tally');
+  assert.equal(lifetimeTokenCount(), 100, 'a failed call must NOT move the listener-facing ticker');
+
+  // ── A failure with no usage adds nothing ───────────────────────────────────
+  // Provider HTTP errors and deadline aborts throw bare. Nothing to count, and
+  // nothing may be invented — this is why the cap is more honest, not exhaustive.
+  record(call(false, undefined));
+  assert.equal(dailyTokensUsed(), 350, 'a usage-less failure adds nothing to the tally');
+  assert.equal(lifetimeTokenCount(), 100, 'a usage-less failure adds nothing to the ticker');
+
+  // A zero-token report (local rigs often send one) is not a contribution either.
+  record(call(false, 0));
+  record(call(true, 0));
+  assert.equal(dailyTokensUsed(), 350, 'zero-token reports add nothing, ok or not');
+
+  // ── The restart round-trip: seed filter vs live guard ──────────────────────
+  // Re-seed from the events file the calls above actually wrote. If the two
+  // copies of the policy ever drift, this is where it shows up as a number
+  // moving BACKWARDS across a restart.
+  const live = dailyTokensUsed();
+  await waitForLlmEvents(5);
+  const seeded = await seedDailyUsageFromLog();
+  assert.equal(seeded, live, 'a mid-day restart re-seeds to the same number it was live at');
+  assert.equal(dailyTokensUsed(), live, 'and the tally reads unchanged after the re-seed');
+  assert.ok(seeded >= 250, 'the re-seed carries the failed call, not just the successes');
+
+  console.log('llm-budget: OK (failed calls count toward the daily cap; ticker unmoved; seed round-trips)');
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/controller/src/llm/internal/telemetry/budget.ts
+++ b/controller/src/llm/internal/telemetry/budget.ts
@@ -30,8 +30,10 @@ function rollIfNeeded(): void {
   }
 }
 
-// Add a successful call's token total to today's tally. Called from log.ts
-// record() under the same `ok && usage.total` guard as the lifetime counter.
+// Add a call's token total to today's tally. Called from log.ts record() for
+// every call that reports usage, failed ones included (issue #1195) — unlike
+// the lifetime counter beside it, which stays success-only. The provider bills
+// for a call that throws, so a cap that ignored them capped successful spend.
 export function addDailyUsage(tokens: number): void {
   if (!Number.isFinite(tokens) || tokens <= 0) return;
   rollIfNeeded();
@@ -46,9 +48,17 @@ export function dailyTokensUsed(): number {
 
 // Seed today's tally from the durable event log on boot so a mid-day restart
 // doesn't reset the count (the in-memory tally above is otherwise lost). Sums
-// `usage.total` over today's successful `llm` events. Best-effort: a missing or
-// unreadable file (fresh install, no calls yet) leaves the tally at 0. Run once
-// at startup, before any new calls record — re-running would double-count.
+// `usage.total` over today's `llm` events. Best-effort: a missing or unreadable
+// file (fresh install, no calls yet) leaves the tally at 0. Run once at
+// startup, before any new calls record — re-running would double-count.
+//
+// This filter must stay in lockstep with addDailyUsage's caller in log.ts: it
+// is a SECOND, independent copy of the same policy, and the two disagreeing is
+// silent. Screening `ok` here while log.ts counts failures would make a mid-day
+// restart re-seed from successes only and walk the tally BACKWARDS — an
+// operator pushed into `hard` by failure spend would drop back to `normal` on a
+// container bounce. `logEvent('llm', …)` writes `usage` outside its own ok
+// guard, so failure spend is already on the timeline to be summed.
 export async function seedDailyUsageFromLog(): Promise<number> {
   const day = utcDay();
   let seeded = 0;
@@ -58,7 +68,7 @@ export async function seedDailyUsageFromLog(): Promise<number> {
       if (!line) continue;
       try {
         const e = JSON.parse(line);
-        if (e?.type === 'llm' && e.ok && e.usage?.total) seeded += e.usage.total;
+        if (e?.type === 'llm' && e.usage?.total) seeded += e.usage.total;
       } catch {
         // Skip a malformed line — never let one bad row abort the seed.
       }

--- a/controller/src/llm/internal/telemetry/log.ts
+++ b/controller/src/llm/internal/telemetry/log.ts
@@ -27,11 +27,24 @@ export function record(call: any) {
   recentCalls.unshift(call);
   if (recentCalls.length > MAX_CALLS) recentCalls.length = MAX_CALLS;
   // Mirror summarizeLlm: only successful calls that report usage contribute.
-  if (call.ok && call.usage?.total) {
-    lifetimeTokens += call.usage.total;
-    // Same guard feeds today's tally — the number the daily token cap enforces.
-    addDailyUsage(call.usage.total);
-  }
+  if (call.ok && call.usage?.total) lifetimeTokens += call.usage.total;
+
+  // Today's tally is deliberately NOT under the `ok` guard above (issue #1195).
+  // The provider bills for a call that throws just the same, and djAgent's
+  // cascade can burn several legs' worth before it gives up — a pick that runs
+  // main → recovery → terminal collapse and still throws spent three billable
+  // calls, then falls back to the pool picker (a fourth, which IS counted).
+  // Counting only successes made the cap a cap on *successful* spend, which an
+  // operator on a flaky model could overshoot via failures alone. The number is
+  // already on the record: failureDiagnostics() (core/pure.ts) normalises the
+  // summed `err.usage` that agent.ts attaches on the throw, and failover.ts's
+  // recordFailure spreads it on. The lifetime ticker stays success-only on
+  // purpose — it's the listener-facing counter on the player and mirrors
+  // summarizeLlm (stats.ts), so /stats semantics are unchanged.
+  //
+  // Not every failure carries usage: provider HTTP errors and deadline aborts
+  // throw bare, so this makes the cap more honest, not exhaustive.
+  if (call.usage?.total) addDailyUsage(call.usage.total);
 
   // Durable, trace-correlated event. The ring buffer above is lost on restart
   // and uncorrelated; this lands on the unified events.jsonl timeline.


### PR DESCRIPTION
Closes #1195.

## The change

`record()` (`controller/src/llm/internal/telemetry/log.ts`) gated **both** the lifetime ticker and the daily budget tally behind one `ok && usage.total` guard. A call that ultimately throws contributed nothing to the day's count — but the provider billed for it all the same. With djAgent's cascade that is several legs' worth per failure: a pick that runs main → recovery → terminal collapse and still throws burned three billable calls, then fell back to the pool picker (a fourth, which IS counted). The cap was a cap on *successful* spend.

The number was already sitting on the record — `failureDiagnostics()` (`core/pure.ts`) normalises the summed `err.usage` that `agent.ts` attaches on the throw, and `recordFailure` (`core/failover.ts`) spreads it onto the call. This is purely the policy piece deliberately left out of #1194.

## Only the budget moves

The issue asked whether the lifetime ticker moves with it. It shouldn't: `lifetimeTokens` backs the listener-facing token counter on the player and its comment mirrors `summarizeLlm` (`stats.ts`), which filters `recentCalls` by `ok`. Keeping its guard leaves `/stats` semantics byte-identical and stops the public number jumping on failures, while the cap becomes honest about billed spend.

## The second copy of the policy

`seedDailyUsageFromLog()` (`telemetry/budget.ts`) carries its **own** independent copy of the same filter. It had to move in lockstep, and the failure mode is silent: screening `ok` in the seed while counting failures live makes a mid-day restart re-seed from successes only and walk the tally *backwards* — an operator pushed into `hard` by failure spend drops back to `normal` on a container bounce. Both comments now say so.

## Caveat

Not every failure carries usage. Only the agent done-tool throw, `truncationError`, and the djObject parse error attach it; provider HTTP errors and deadline aborts throw bare. Combined with local rigs reporting zero usage, this makes the cap more honest, not exhaustive — the practical effect lands on cloud providers.

## Testing

New `controller/scripts/llm-budget.test.ts` pins the deliberate divergence (failed call moves the tally, not the ticker), the no-usage and zero-token cases, and round-trips a mixed batch through the events file those very calls wrote — the last one is what catches the two policy copies drifting apart.

Verified it's a real pin, not a passing no-op: reverting the `log.ts` guard fails it, and reverting *only* the seed filter fails it at the round-trip assertion (re-seed reads 100 where live was 350).

- `npm test` — all 56 files pass (`observatory-scale` flaked once under parallel load on the first run, passes standalone and on re-run; it's a perf-budget test, unrelated).
- `npm run lint` — exit 0 (580 pre-existing `any` warnings, 0 errors).

https://claude.ai/code/session_01XNP4h6DGKRMkoxqCHz1EbQ