### PR TITLE
fix(tts): romanize Japanese kana so the DJ stops saying "japanese letter"

### DIFF
--- a/controller/scripts/romanize.test.ts
+++ b/controller/scripts/romanize.test.ts
@@ -1,0 +1,152 @@
+// Unit tests for audio/romanize.ts — the kana → Latin layer that stops espeak
+// reading Japanese metadata as "japanese letter japanese letter" (issue #1179).
+//
+// The cases that matter most are the NEGATIVE ones: this runs over every spoken
+// line on every station, so anything that isn't kana must survive byte-for-byte.
+//
+// Run: npm test -- romanize
+
+import assert from 'node:assert/strict';
+import { romanizeCjk } from '../src/audio/romanize.js';
+import { normalizeForDisplay, normalizeForSpeech } from '../src/audio/speech-text.js';
+
+let failures = 0;
+function test(name: string, fn: () => void | Promise<void>) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => console.log(`  ✓ ${name}`))
+    .catch((err) => { failures++; console.error(`  ✗ ${name}\n      ${err?.message || err}`); });
+}
+
+async function main() {
+  console.log('the reported case:');
+
+  await test('the issue\'s own example romanizes end to end', () => {
+    // Both halves of "ウルフルズ - バカサバイバー" are pure katakana, which is
+    // why this case is fixed without any kanji dictionary.
+    assert.equal(romanizeCjk('ウルフルズ'), 'Urufuruzu');
+    assert.equal(romanizeCjk('バカサバイバー'), 'Bakasabaibaa');
+    assert.equal(romanizeCjk('ウルフルズ - バカサバイバー'), 'Urufuruzu - Bakasabaibaa');
+  });
+
+  await test('a real DJ line keeps its English intact', () => {
+    assert.equal(
+      romanizeCjk('Up next, ウルフルズ with バカサバイバー here on SUB/WAVE'),
+      'Up next, Urufuruzu with Bakasabaibaa here on SUB/WAVE',
+    );
+  });
+
+  console.log('\nkatakana and hiragana:');
+
+  await test('both syllabaries share one table', () => {
+    assert.equal(romanizeCjk('ひらがな'), 'Hiragana');
+    assert.equal(romanizeCjk('カタカナ'), 'Katakana');
+    assert.equal(romanizeCjk('さくら'), 'Sakura');
+  });
+
+  await test('digraphs beat their parts', () => {
+    // きゃ is "kya", never "kiya".
+    assert.equal(romanizeCjk('きゃく'), 'Kyaku');
+    assert.equal(romanizeCjk('しゃしん'), 'Shashin');
+    assert.equal(romanizeCjk('ちょうちょ'), 'Choucho');
+    assert.equal(romanizeCjk('リョウ'), 'Ryou');
+  });
+
+  await test('katakana-only loanword sounds', () => {
+    assert.equal(romanizeCjk('ファイト'), 'Faito');
+    assert.equal(romanizeCjk('ティアー'), 'Tiaa');
+    assert.equal(romanizeCjk('ヴィーナス'), 'Viinasu');
+  });
+
+  await test('prolonged sound mark lengthens the vowel before it', () => {
+    assert.equal(romanizeCjk('ラーメン'), 'Raamen');
+    assert.equal(romanizeCjk('ソード'), 'Soodo');
+    // Nothing to lengthen — dropped rather than emitted as a stray letter.
+    assert.equal(romanizeCjk('ー'), '');
+  });
+
+  await test('sokuon doubles the next consonant, tch for ch', () => {
+    assert.equal(romanizeCjk('がっこう'), 'Gakkou');
+    assert.equal(romanizeCjk('キット'), 'Kitto');
+    assert.equal(romanizeCjk('マッチ'), 'Matchi');
+    // Trailing sokuon has no consonant to double — emits nothing.
+    assert.equal(romanizeCjk('あっ'), 'A');
+  });
+
+  await test('moraic n assimilates before a labial', () => {
+    assert.equal(romanizeCjk('しんばし'), 'Shimbashi');
+    assert.equal(romanizeCjk('さんぽ'), 'Sampo');
+    // ...but stays n everywhere else.
+    assert.equal(romanizeCjk('にほん'), 'Nihon');
+    assert.equal(romanizeCjk('かんじ'), 'Kanji');
+  });
+
+  console.log('\nleaves everything else alone:');
+
+  await test('Latin-only text is byte-identical', () => {
+    for (const s of [
+      'Up next, Fleetwood Mac with Dreams',
+      'AC/DC, Ke$ha, P!nk and Florence & the Machine',
+      '76°F and $5 at the door',
+      'SUB/WAVE',
+      '',
+    ]) {
+      assert.equal(romanizeCjk(s), s);
+    }
+  });
+
+  await test('kanji and Chinese pass through untouched (out of scope)', () => {
+    // Deliberate: a reading for these needs a ~41 MB dictionary. They still
+    // hit the espeak fallback, which is the documented limitation.
+    assert.equal(romanizeCjk('周杰倫'), '周杰倫');
+    assert.equal(romanizeCjk('日本'), '日本');
+    // Mixed kanji + kana: the kana half is still rescued.
+    assert.equal(romanizeCjk('宇多田ヒカル'), '宇多田Hikaru');
+  });
+
+  await test('other non-Latin scripts are not touched', () => {
+    assert.equal(romanizeCjk('Кино'), 'Кино');
+    assert.equal(romanizeCjk('안녕'), '안녕');
+    assert.equal(romanizeCjk('مرحبا'), 'مرحبا');
+  });
+
+  await test('punctuation, spacing and digits survive between kana runs', () => {
+    assert.equal(romanizeCjk('「サクラ」 (2004)'), '「Sakura」 (2004)');
+    assert.equal(romanizeCjk('アイ / ユー'), 'Ai / Yuu');
+  });
+
+  await test('idempotent — a second pass changes nothing', () => {
+    const once = romanizeCjk('ウルフルズ - バカサバイバー');
+    assert.equal(romanizeCjk(once), once);
+  });
+
+  console.log('\nwired into the speech pass only:');
+
+  await test('romanization is speech-only, never display', () => {
+    const line = 'Up next, ウルフルズ with バカサバイバー';
+    // The player feed, booth log and session must keep the real script.
+    assert.equal(normalizeForDisplay(line), line);
+    assert.equal(normalizeForSpeech(line), 'Up next, Urufuruzu with Bakasabaibaa');
+  });
+
+  await test('an operator correction beats the transliteration', () => {
+    // The band's own Latin name is "Ulfuls", not the literal "Urufuruzu" —
+    // so the rule has to match the ORIGINAL script, i.e. corrections must run
+    // before romanization.
+    const rules = [{ from: 'ウルフルズ', to: 'Ulfuls' }];
+    assert.equal(
+      normalizeForSpeech('Up next, ウルフルズ with バカサバイバー', rules),
+      'Up next, Ulfuls with Bakasabaibaa',
+    );
+  });
+
+  await test('romanized text still gets the symbol pass', () => {
+    // Order check: romanization must not short-circuit the rules after it.
+    assert.equal(normalizeForSpeech('サクラ 100% & more'), 'Sakura 100 percent and more');
+  });
+
+  console.log(failures ? `\n${failures} failing` : '\nall passing');
+  process.exit(failures ? 1 : 0);
+}
+
+main();

--- a/controller/src/audio/romanize.ts
+++ b/controller/src/audio/romanize.ts
@@ -1,0 +1,206 @@
+// Kana → Latin romanizer for booth-bound text (issue #1179).
+//
+// THE BUG: every TTS engine here is fed through a phonemizer keyed to the
+// station's language — espeak-ng `en-gb` for the default Kokoro/Piper path.
+// espeak has no reading for Japanese codepoints, so it falls back to its
+// dictionary's character-CLASS names and the DJ literally says "japanese
+// letter japanese letter chinese letter" where an artist or title should be.
+// Non-Latin metadata is common ("ウルフルズ - バカサバイバー"), so a Japanese
+// library turns every link into that.
+//
+// THE FIX: hand the engine Latin letters. "ウルフルズ" → "Urufuruzu" is a
+// broken-accent approximation, which is explicitly what the issue asks for
+// over the placeholder. This is modified-Hepburn, the romanization an English
+// phonemizer guesses closest to.
+//
+// SCOPE IS KANA ONLY — deliberately. Kanji (and Han characters generally) have
+// no reading without a morphological dictionary: 宇多田 is "Utada" only because
+// a dictionary says so, and the smallest Node analyzer that knows carries a
+// ~41 MB IPADIC. So kanji and Chinese runs are passed through UNTOUCHED and
+// still hit the espeak fallback. Half the reported cases, none of the weight.
+// Wiring an analyzer in later means adding a branch in romanizeCjk() — the
+// pipeline position and the speech-only rule below don't change.
+//
+// Two invariants that keep this safe to run over every spoken line:
+//   1. Only kana codepoints are ever rewritten. Latin, punctuation, digits,
+//      kanji, Cyrillic — every other byte survives, so a station with no
+//      Japanese metadata gets byte-identical text and this is a no-op.
+//   2. SPEECH ONLY. Callers must use it from normalizeForSpeech(), never
+//      normalizeForDisplay() — the player feed, booth log and session keep the
+//      real "ウルフルズ". A listener seeing "Urufuruzu" written down is a bug,
+//      the same rule the "Ye" → "Yay" correction layer follows.
+//
+// No imports — pure module, unit-pinned by scripts/romanize.test.ts.
+
+// Katakana ァ(U+30A1)–ヶ(U+30F6) maps onto hiragana ぁ(U+3041)–ゖ(U+3096) by a
+// flat -0x60 offset, so folding katakana to hiragana first lets ONE table
+// serve both syllabaries. The prolonged sound mark ー (U+30FC) sits outside
+// that range and survives the fold to be handled as a vowel-lengthener below.
+const KATAKANA_START = 0x30a1;
+const KATAKANA_END = 0x30f6;
+const KANA_FOLD_OFFSET = 0x60;
+
+const HIRAGANA_START = 0x3041;
+const HIRAGANA_END = 0x3096;
+const PROLONGED = 'ー';
+const SOKUON = 'っ';
+
+// Digraphs first — two-kana sequences whose romaji is not the concatenation of
+// its parts (きゃ is "kya", not "kiya"). Matched greedily before singles.
+const KANA_DIGRAPHS: Record<string, string> = {
+  きゃ: 'kya', きゅ: 'kyu', きょ: 'kyo',
+  ぎゃ: 'gya', ぎゅ: 'gyu', ぎょ: 'gyo',
+  しゃ: 'sha', しゅ: 'shu', しょ: 'sho', しぇ: 'she',
+  じゃ: 'ja', じゅ: 'ju', じょ: 'jo', じぇ: 'je',
+  ちゃ: 'cha', ちゅ: 'chu', ちょ: 'cho', ちぇ: 'che',
+  にゃ: 'nya', にゅ: 'nyu', にょ: 'nyo',
+  ひゃ: 'hya', ひゅ: 'hyu', ひょ: 'hyo',
+  びゃ: 'bya', びゅ: 'byu', びょ: 'byo',
+  ぴゃ: 'pya', ぴゅ: 'pyu', ぴょ: 'pyo',
+  みゃ: 'mya', みゅ: 'myu', みょ: 'myo',
+  りゃ: 'rya', りゅ: 'ryu', りょ: 'ryo',
+  // Katakana-only sounds, reached after the fold above. These carry most
+  // loanword titles — ファイト, ヴィーナス, ティアー.
+  ふぁ: 'fa', ふぃ: 'fi', ふぇ: 'fe', ふぉ: 'fo', ふゅ: 'fyu',
+  ゔぁ: 'va', ゔぃ: 'vi', ゔぇ: 've', ゔぉ: 'vo',
+  てぃ: 'ti', でぃ: 'di', てゅ: 'tyu', でゅ: 'dyu',
+  とぅ: 'tu', どぅ: 'du',
+  つぁ: 'tsa', つぃ: 'tsi', つぇ: 'tse', つぉ: 'tso',
+  うぃ: 'wi', うぇ: 'we', うぉ: 'wo',
+  しぃ: 'shi', じぃ: 'ji',
+};
+
+const KANA_SINGLES: Record<string, string> = {
+  あ: 'a', い: 'i', う: 'u', え: 'e', お: 'o',
+  か: 'ka', き: 'ki', く: 'ku', け: 'ke', こ: 'ko',
+  が: 'ga', ぎ: 'gi', ぐ: 'gu', げ: 'ge', ご: 'go',
+  さ: 'sa', し: 'shi', す: 'su', せ: 'se', そ: 'so',
+  ざ: 'za', じ: 'ji', ず: 'zu', ぜ: 'ze', ぞ: 'zo',
+  た: 'ta', ち: 'chi', つ: 'tsu', て: 'te', と: 'to',
+  だ: 'da', ぢ: 'ji', づ: 'zu', で: 'de', ど: 'do',
+  な: 'na', に: 'ni', ぬ: 'nu', ね: 'ne', の: 'no',
+  は: 'ha', ひ: 'hi', ふ: 'fu', へ: 'he', ほ: 'ho',
+  ば: 'ba', び: 'bi', ぶ: 'bu', べ: 'be', ぼ: 'bo',
+  ぱ: 'pa', ぴ: 'pi', ぷ: 'pu', ぺ: 'pe', ぽ: 'po',
+  ま: 'ma', み: 'mi', む: 'mu', め: 'me', も: 'mo',
+  や: 'ya', ゆ: 'yu', よ: 'yo',
+  ら: 'ra', り: 'ri', る: 'ru', れ: 're', ろ: 'ro',
+  わ: 'wa', ゐ: 'wi', ゑ: 'we', を: 'o',
+  ん: 'n',
+  ゔ: 'vu',
+  // Bare small kana — a leftover ゃ with no consonant before it, or the small
+  // vowels used decoratively in titles. Read as their full-size selves.
+  ぁ: 'a', ぃ: 'i', ぅ: 'u', ぇ: 'e', ぉ: 'o',
+  ゃ: 'ya', ゅ: 'yu', ょ: 'yo', ゎ: 'wa',
+  ゕ: 'ka', ゖ: 'ke',
+};
+
+const VOWELS = new Set(['a', 'i', 'u', 'e', 'o']);
+
+function isKanaChar(ch: string): boolean {
+  const c = ch.codePointAt(0);
+  if (c === undefined) return false;
+  if (c >= HIRAGANA_START && c <= HIRAGANA_END) return true;
+  if (c >= KATAKANA_START && c <= KATAKANA_END) return true;
+  return ch === PROLONGED;
+}
+
+function foldToHiragana(ch: string): string {
+  const c = ch.codePointAt(0);
+  if (c === undefined) return ch;
+  if (c >= KATAKANA_START && c <= KATAKANA_END) {
+    return String.fromCodePoint(c - KANA_FOLD_OFFSET);
+  }
+  return ch;
+}
+
+// Romanize one contiguous kana run. Split from the walker so the syllable
+// rules (sokuon, prolonged mark, moraic n) only ever see kana — they read the
+// PRECEDING output to decide, and letters from surrounding Latin text would
+// give them the wrong answer.
+function romanizeKanaRun(run: string): string {
+  const kana = Array.from(run, foldToHiragana);
+  let out = '';
+  // The small tsu doubles the NEXT consonant, so it can only be resolved once
+  // that syllable is known — carry it forward rather than emitting anything.
+  let pendingSokuon = false;
+
+  for (let i = 0; i < kana.length; i += 1) {
+    const ch = kana[i];
+
+    if (ch === SOKUON) {
+      pendingSokuon = true;
+      continue;
+    }
+
+    // Prolonged sound mark: lengthen whatever vowel we just emitted, which is
+    // what turns バカサバイバー into "bakasabaibaa". With no vowel behind it
+    // (a title opening on ー) there is nothing to double, so drop it.
+    if (ch === PROLONGED) {
+      const last = out.slice(-1);
+      if (VOWELS.has(last)) out += last;
+      continue;
+    }
+
+    const pair = i + 1 < kana.length ? ch + kana[i + 1] : '';
+    let romaji = pair && KANA_DIGRAPHS[pair] ? KANA_DIGRAPHS[pair] : '';
+    if (romaji) {
+      i += 1;
+    } else {
+      romaji = KANA_SINGLES[ch] ?? '';
+    }
+    // Not in either table (an iteration mark, a stray combining char) — skip
+    // it rather than emitting a placeholder. Unspoken beats mangled.
+    if (!romaji) continue;
+
+    if (pendingSokuon) {
+      pendingSokuon = false;
+      // Hepburn spells a doubled ch as "tch" (マッチ → "matchi"), not "chch".
+      out += romaji.startsWith('ch') ? 't' : romaji[0];
+    }
+
+    out += romaji;
+  }
+
+  // Moraic ん assimilates to "m" before a labial — Hepburn's しんばし →
+  // "shimbashi". Applied over the finished run so it can see what followed.
+  return out.replace(/n(?=[bmp])/g, 'm');
+}
+
+/**
+ * Rewrite Japanese kana into Latin letters, leaving every other character
+ * untouched. Kanji and Chinese are out of scope (see the header) and pass
+ * through unchanged.
+ *
+ * Speech-only — see invariant 2 in the header.
+ */
+export function romanizeCjk(text: string): string {
+  if (!text) return text;
+  // Cheap bail so the overwhelmingly common Latin-only line does no work
+  // beyond one regex test.
+  if (!/[ぁ-ゖァ-ヶー]/.test(text)) return text;
+
+  let out = '';
+  let run = '';
+  const flush = () => {
+    if (!run) return;
+    const romaji = romanizeKanaRun(run);
+    // Capitalize the run — kana in a track title is nearly always a proper
+    // noun, and the normalized text surfaces in the TTS stats ring where
+    // "urufuruzu" reads like a bug. Purely cosmetic; the engine is unaffected.
+    out += romaji ? romaji[0].toUpperCase() + romaji.slice(1) : '';
+    run = '';
+  };
+
+  for (const ch of text) {
+    if (isKanaChar(ch)) {
+      run += ch;
+      continue;
+    }
+    flush();
+    out += ch;
+  }
+  flush();
+
+  return out;
+}

--- a/controller/src/audio/speech-text.ts
+++ b/controller/src/audio/speech-text.ts
@@ -19,13 +19,17 @@
 //     feed. Stripping `**bold**` makes a line more readable, never differently
 //     spelled.
 //   normalizeForSpeech()  — the above PLUS the pronunciation layer: operator
-//     corrections, unit/symbol expansion, the SUB/WAVE → "Subwave" rule.
+//     corrections, kana romanization, unit/symbol expansion, the SUB/WAVE →
+//     "Subwave" rule.
 //     These are spelled for an ENGINE's benefit, not a reader's — "Ye" reads
 //     as "Yay" only so the voice says it right, and a listener seeing "Yay"
 //     in the written line is a bug, not a feature. Speech-only spellings must
 //     never be persisted anywhere a human sees them.
 //
-// No imports — pure module, unit-pinned by scripts/speech-text.test.ts.
+// One import — the equally pure, equally settings-free audio/romanize.ts.
+// Still side-effect-free and unit-pinned by scripts/speech-text.test.ts.
+
+import { romanizeCjk } from './romanize.js';
 
 // Operator-defined speech correction: replace `from` with `to` wherever it
 // appears in booth-bound text (settings.tts.corrections, admin → Settings →
@@ -132,6 +136,15 @@ export function normalizeForSpeech(
   // operator sees ("**Hozier**" still matches a "Hozier" rule), and BEFORE
   // the symbol rules so a correction can pre-empt a built-in expansion.
   if (corrections?.length) t = applyCorrections(t, corrections);
+
+  // --- kana → Latin (issue #1179) ---
+  // AFTER corrections, and that order is load-bearing: an operator rule is
+  // written in the ORIGINAL script (`ウルフルズ` → `Ulfuls`, the band's own
+  // Latin name), so romanizing first would leave every such rule unable to
+  // match. A correction therefore always beats the transliteration, which is
+  // the escape hatch for names this approximates badly.
+  // No-op on text without kana, so a Latin-only station is unaffected.
+  t = romanizeCjk(t);
 
   // --- units and symbols (all keyed on an adjacent digit — conservative) ---
   t = t.replace(/(\d)\s*°\s*F\b/g, '$1 degrees Fahrenheit');


### PR DESCRIPTION
Fixes #1179.

## The bug

A track like `ウルフルズ - バカサバイバー` made the DJ say "japanese letter" twelve times instead of the artist and title.

## Root cause

Not the LLM and not a model limitation, which is where the issue thread landed. Every spoken line is phonemized by espeak-ng under the station's language (`en-gb` by default), and espeak has no reading for Japanese codepoints, so it falls back to the literal character-class entry in its dictionary. Reproduced at the phonemizer inside the running controller:

```
$ espeak-ng -v en-gb -q -x "Up next, ウルフルズ with バカサバイバー"
,Vp n'Ekst
dZ'ap@ni:zl,Et3 dZ'ap@ni:zl,Et3 dZ'ap@ni:zl,Et3 ...   (x12)
```

That `dZ'ap@ni:zl,Et3` is literally "japanese letter" — the issue title, straight out of espeak.

```
$ espeak-ng -v en-gb -q -x "Up next, Urufuruzu with Bakasabaibaa"
,Vp n'Ekst
j,U@ru:fjU@r'u:zu: wID b'aka#s,abeIb,A:
```

## The fix

Hand the engine Latin letters. New `controller/src/audio/romanize.ts` converts kana to modified-Hepburn — a broken-accent approximation, explicitly what the issue asks for over the placeholder.

It goes in `normalizeForSpeech()`, the one chokepoint every booth-bound string already passes through, so **Kokoro, Piper, Chatterbox, PocketTTS and the cloud engines are all fixed at once** rather than patching one worker.

Two properties worth reviewing:

- **Speech-only.** `normalizeForDisplay()` is untouched, so the player feed, booth log and session keep the real `ウルフルズ`. Same rule the `Ye` → `Yay` correction layer follows: a listener seeing `Urufuruzu` written down would be a bug.
- **After operator corrections, deliberately.** A `settings.tts.corrections` rule is written in the original script (`ウルフルズ` → `Ulfuls`, the band's own Latin name), so romanizing first would stop every such rule matching. Corrections therefore always beat the transliteration, which is the escape hatch for names this approximates badly.

## Scope: kana only

Kanji and Han characters have no reading without a morphological dictionary — `宇多田` is "Utada" only because a dictionary says so, and the smallest Node analyzer that knows carries a ~41 MB IPADIC (`kuromoji`, CJS-only, last published at v0.1.2). Those runs **pass through untouched and still hit the espeak fallback.**

Both halves of the reported example are katakana, so the issue as filed is fixed. @torytyler's follow-up note about kanji specifically is **not** covered here. Adding an analyzer later means one branch in `romanizeCjk()`; the pipeline position and the speech-only rule do not change.

## Cost

No new dependencies. No settings, no admin UI change. `romanizeCjk()` bails after one regex test on text without kana, so a Latin-only station is byte-identical.

## Testing

`controller/scripts/romanize.test.ts` — 16 cases: the reported example end to end, digraphs (`きゃ` → `kya`, not `kiya`), the prolonged mark, sokuon incl. Hepburn's `tch`, moraic n before labials, plus negative cases pinning that Latin, punctuation, digits, kanji, Cyrillic, Hangul and Arabic all survive byte-for-byte, idempotency, and the display-vs-speech split.

- `npm test` — all 57 files pass
- `npm run lint` — 0 errors; neither new nor edited file appears in the output

https://claude.ai/code/session_01M4514Jut2csAspq5HbSgWz