### PR TITLE
fix(aio): stop a symlink cycle on the liquidsoap log path taking the station off air

### DIFF
--- a/controller/scripts/aio-log-link.test.ts
+++ b/controller/scripts/aio-log-link.test.ts
@@ -1,0 +1,254 @@
+// Regression tests for the AIO supervisor's liquidsoap log-path bootstrap
+// (docker/aio/supervisor.sh: link_liquidsoap_log).
+//
+// Why this is worth a test at all: radio.liq opens settings.log.file.path in
+// Dtools.Log.init, the first lifecycle step, so a path liquidsoap cannot open
+// is a FATAL start error rather than a missing log. #1196 pointed
+// /var/log/liquidsoap at <stateRoot>/logs with an unconditional `ln -s` guarded
+// on `[ ! -L /var/log/liquidsoap ]`. When <state>/logs was itself a symlink
+// back at /var/log/liquidsoap — the obvious host-side workaround for the
+// pre-#1196 "AIO writes no radio.log into the state dir" bug — the pair closed
+// a cycle and every liquidsoap start died with
+//
+//   Fatal error: exception Sys_error("/var/log/liquidsoap/radio.log: Too many
+//   levels of symbolic links")
+//
+// The -L guard then skipped the bad link on every later boot, so the install
+// crash-looped forever with no route back: both Doctor broadcast checks red,
+// and its "Restart mixer" button dead because that speaks telnet to a port
+// liquidsoap never reached.
+//
+// The load-bearing property, asserted in every scenario below, is END STATE
+// OPENABILITY: whatever shape the two paths start in, a file must be creatable
+// at <LIQ_LOG_DIR>/radio.log when the function returns. Persistence into the
+// state dir is the goal, but it is explicitly subordinate — the fallback drops
+// persistence to keep the station on air.
+//
+// Run: `tsx scripts/aio-log-link.test.ts`.
+//
+// node:assert-via-tsx style, matching scripts/listener-auth.test.ts.
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync, readFileSync, lstatSync, existsSync, openSync, closeSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SUPERVISOR = join(here, '..', '..', 'docker', 'aio', 'supervisor.sh');
+
+assert.ok(existsSync(SUPERVISOR), `supervisor.sh not found at ${SUPERVISOR}`);
+
+// Drive link_liquidsoap_log() against a scratch STATE_ROOT / log dir by
+// sourcing the supervisor in library mode. Returns its stderr (the log lines).
+function runLinker(stateRoot: string, liqLogDir: string): string {
+  return execFileSync(
+    'bash',
+    [
+      '-c',
+      // `log()` writes to stderr; fold it into stdout so tests can assert on
+      // the warnings the operator would see in `docker logs`.
+      `set -u; SUBWAVE_SUPERVISOR_LIB=1 source "$1"; link_liquidsoap_log 2>&1`,
+      'bash',
+      SUPERVISOR,
+    ],
+    {
+      env: {
+        ...process.env,
+        SUBWAVE_STATE_ROOT: stateRoot,
+        SUBWAVE_LIQ_LOG_DIR: liqLogDir,
+      },
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+}
+
+// The actual contract: can liquidsoap open its log file here?
+function radioLogOpenable(liqLogDir: string): boolean {
+  try {
+    const fd = openSync(join(liqLogDir, 'radio.log'), 'a');
+    closeSync(fd);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+type Scratch = { root: string; stateRoot: string; liqLogDir: string };
+
+const scratches: string[] = [];
+function scratch(): Scratch {
+  const root = mkdtempSync(join(tmpdir(), 'subwave-aio-log-'));
+  scratches.push(root);
+  const stateRoot = join(root, 'var', 'sub-wave');
+  const liqLogDir = join(root, 'var', 'log', 'liquidsoap');
+  mkdirSync(stateRoot, { recursive: true });
+  mkdirSync(dirname(liqLogDir), { recursive: true });
+  return { root, stateRoot, liqLogDir };
+}
+
+// --- 1. THE REPORTED BUG --------------------------------------------------
+// <state>/logs -> /var/log/liquidsoap, which #1196 then linked back at
+// <state>/logs. Pre-fix this produced the ELOOP crash loop; the linker must
+// now break the cycle and leave an openable path.
+{
+  const { stateRoot, liqLogDir } = scratch();
+  symlinkSync(liqLogDir, join(stateRoot, 'logs')); // the host-side half
+
+  // Sanity: the cycle really does reproduce the reported failure first.
+  symlinkSync(join(stateRoot, 'logs'), liqLogDir); // what #1196 added
+  assert.equal(
+    radioLogOpenable(liqLogDir),
+    false,
+    'precondition: the two-link cycle must make radio.log unopenable (ELOOP)',
+  );
+
+  const out = runLinker(stateRoot, liqLogDir);
+
+  assert.ok(
+    radioLogOpenable(liqLogDir),
+    'ELOOP cycle: radio.log must be openable after the linker runs',
+  );
+  assert.ok(
+    !lstatSync(join(stateRoot, 'logs')).isSymbolicLink(),
+    'ELOOP cycle: the broken state-side link must be replaced by a real directory',
+  );
+  assert.match(out, /broken symlink/, 'ELOOP cycle: the repair should be logged');
+}
+
+// --- 2. THE CYCLE IS ACTUALLY BROKEN, NOT JUST PAPERED OVER ---------------
+// Writing through the in-container path must land in the state dir, which is
+// the whole point of #1196 (routes/debug.ts tails <stateRoot>/logs/radio.log).
+{
+  const { stateRoot, liqLogDir } = scratch();
+  symlinkSync(liqLogDir, join(stateRoot, 'logs'));
+  symlinkSync(join(stateRoot, 'logs'), liqLogDir);
+
+  runLinker(stateRoot, liqLogDir);
+  writeFileSync(join(liqLogDir, 'radio.log'), 'on air\n');
+
+  assert.equal(
+    readFileSync(join(stateRoot, 'logs', 'radio.log'), 'utf8'),
+    'on air\n',
+    'ELOOP cycle: after repair the log must still persist into the state dir',
+  );
+}
+
+// --- 3. FRESH INSTALL -----------------------------------------------------
+// Neither path exists yet: link the container path at the state dir.
+{
+  const { stateRoot, liqLogDir } = scratch();
+
+  runLinker(stateRoot, liqLogDir);
+
+  assert.ok(radioLogOpenable(liqLogDir), 'fresh install: radio.log must be openable');
+  assert.ok(
+    lstatSync(liqLogDir).isSymbolicLink(),
+    'fresh install: the container path should be a symlink into the state dir',
+  );
+  writeFileSync(join(liqLogDir, 'radio.log'), 'x');
+  assert.ok(
+    existsSync(join(stateRoot, 'logs', 'radio.log')),
+    'fresh install: writes must persist into the state dir',
+  );
+}
+
+// --- 4. THE #1196 UPGRADE PATH -------------------------------------------
+// Pre-#1196 images left a plain directory at /var/log/liquidsoap, possibly
+// with a radio.log already in it. It gets replaced by the link.
+{
+  const { stateRoot, liqLogDir } = scratch();
+  mkdirSync(liqLogDir, { recursive: true });
+  writeFileSync(join(liqLogDir, 'radio.log'), 'old\n');
+
+  runLinker(stateRoot, liqLogDir);
+
+  assert.ok(radioLogOpenable(liqLogDir), 'upgrade: radio.log must be openable');
+  assert.ok(
+    lstatSync(liqLogDir).isSymbolicLink(),
+    'upgrade: a plain in-container dir should be replaced by the state-dir link',
+  );
+}
+
+// --- 5. IDEMPOTENCE -------------------------------------------------------
+// The supervisor calls this on every boot; repeat runs must not degrade the
+// result or nest a link inside the previous one (`ln -s` without -n plants
+// the new link INSIDE a link-to-directory).
+{
+  const { stateRoot, liqLogDir } = scratch();
+
+  for (let i = 0; i < 3; i++) runLinker(stateRoot, liqLogDir);
+
+  assert.ok(radioLogOpenable(liqLogDir), 'idempotence: still openable after 3 runs');
+  assert.ok(
+    !existsSync(join(stateRoot, 'logs', 'logs')),
+    'idempotence: must not nest a logs/ link inside the target',
+  );
+}
+
+// --- 6. DANGLING STATE-SIDE LINK -----------------------------------------
+// <state>/logs pointing at nothing yields ENOENT rather than ELOOP, but it is
+// the same class of fault and heals the same way.
+{
+  const { root, stateRoot, liqLogDir } = scratch();
+  symlinkSync(join(root, 'nowhere'), join(stateRoot, 'logs'));
+
+  runLinker(stateRoot, liqLogDir);
+
+  assert.ok(radioLogOpenable(liqLogDir), 'dangling link: radio.log must be openable');
+  assert.ok(
+    !lstatSync(join(stateRoot, 'logs')).isSymbolicLink(),
+    'dangling link: must be replaced by a real directory',
+  );
+}
+
+// --- 7. DELIBERATE OPERATOR SYMLINK IS PRESERVED -------------------------
+// A <state>/logs symlink that resolves to a real directory elsewhere is an
+// operator parking logs on another disk. Healing that would be destructive, so
+// only BROKEN links get replaced.
+{
+  const { root, stateRoot, liqLogDir } = scratch();
+  const elsewhere = join(root, 'mnt', 'big-disk', 'logs');
+  mkdirSync(elsewhere, { recursive: true });
+  symlinkSync(elsewhere, join(stateRoot, 'logs'));
+
+  runLinker(stateRoot, liqLogDir);
+
+  assert.ok(radioLogOpenable(liqLogDir), 'operator link: radio.log must be openable');
+  assert.ok(
+    lstatSync(join(stateRoot, 'logs')).isSymbolicLink(),
+    'operator link: a symlink resolving to a real dir must be left alone',
+  );
+  writeFileSync(join(liqLogDir, 'radio.log'), 'y');
+  assert.ok(
+    existsSync(join(elsewhere, 'radio.log')),
+    'operator link: writes must follow it to the operator’s directory',
+  );
+}
+
+// --- 8. FALLBACK KEEPS THE STATION ON AIR --------------------------------
+// If the state dir cannot host logs/ at all (here: a regular FILE sits where
+// the directory belongs, so mkdir fails), the linker must NOT leave liquidsoap
+// with an unopenable path. Persistence is sacrificed, the station is not.
+{
+  const { stateRoot, liqLogDir } = scratch();
+  writeFileSync(join(stateRoot, 'logs'), 'not a directory');
+
+  const out = runLinker(stateRoot, liqLogDir);
+
+  assert.ok(
+    radioLogOpenable(liqLogDir),
+    'fallback: radio.log must be openable even when the state dir cannot host logs/',
+  );
+  assert.ok(
+    !lstatSync(liqLogDir).isSymbolicLink(),
+    'fallback: the container path should be a plain local directory',
+  );
+  assert.match(out, /WARNING/, 'fallback: the degraded mode must be logged loudly');
+}
+
+for (const dir of scratches) rmSync(dir, { recursive: true, force: true });
+
+console.log('aio-log-link: all assertions passed');

--- a/controller/scripts/aio-log-link.test.ts
+++ b/controller/scripts/aio-log-link.test.ts
@@ -42,7 +42,8 @@ assert.ok(existsSync(SUPERVISOR), `supervisor.sh not found at ${SUPERVISOR}`);
 
 // Drive link_liquidsoap_log() against a scratch STATE_ROOT / log dir by
 // sourcing the supervisor in library mode. Returns its stderr (the log lines).
-function runLinker(stateRoot: string, liqLogDir: string): string {
+// extraEnv lets a scenario override PATH etc. (scenario 9 stubs mountpoint(1)).
+function runLinker(stateRoot: string, liqLogDir: string, extraEnv: Record<string, string> = {}): string {
   return execFileSync(
     'bash',
     [
@@ -58,6 +59,7 @@ function runLinker(stateRoot: string, liqLogDir: string): string {
         ...process.env,
         SUBWAVE_STATE_ROOT: stateRoot,
         SUBWAVE_LIQ_LOG_DIR: liqLogDir,
+        ...extraEnv,
       },
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -79,6 +81,11 @@ function radioLogOpenable(liqLogDir: string): boolean {
 type Scratch = { root: string; stateRoot: string; liqLogDir: string };
 
 const scratches: string[] = [];
+// Clean up on 'exit' rather than at the bottom of the file — the handler also
+// fires when an assertion throws, so failed runs don't leak dirs into $TMPDIR.
+process.on('exit', () => {
+  for (const dir of scratches) rmSync(dir, { recursive: true, force: true });
+});
 function scratch(): Scratch {
   const root = mkdtempSync(join(tmpdir(), 'subwave-aio-log-'));
   scratches.push(root);
@@ -249,6 +256,46 @@ function scratch(): Scratch {
   assert.match(out, /WARNING/, 'fallback: the degraded mode must be logged loudly');
 }
 
-for (const dir of scratches) rmSync(dir, { recursive: true, force: true });
+// --- 9. BIND MOUNT AT THE CONTAINER PATH ----------------------------------
+// The split stack's `${STATE_DIR}/logs:/var/log/liquidsoap` mapping copied
+// into an AIO `docker run`. The mounted dir must be used as-is, and — the
+// part the first cut of this fix got wrong — its CONTENTS must survive:
+// `rm -rf` on a mountpoint cannot remove the mountpoint itself but deletes
+// everything inside it, so an unguarded rm wiped the operator's log history
+// on every boot. A real mount needs root, so mountpoint(1) is stubbed via
+// PATH; the on-disk shape (a real, non-symlink dir) is exactly what the
+// supervisor sees over a bind mount.
+{
+  const { root, stateRoot, liqLogDir } = scratch();
+  mkdirSync(liqLogDir, { recursive: true });
+  writeFileSync(join(liqLogDir, 'radio.log'), 'operator history\n');
+
+  const stubBin = join(root, 'stub-bin');
+  mkdirSync(stubBin);
+  writeFileSync(
+    join(stubBin, 'mountpoint'),
+    '#!/usr/bin/env bash\n' +
+      '# test stub: only $SUBWAVE_TEST_MOUNTPOINT is a mount ($1 is -q, $2 the path)\n' +
+      '[ "$2" = "$SUBWAVE_TEST_MOUNTPOINT" ]\n',
+    { mode: 0o755 },
+  );
+
+  const out = runLinker(stateRoot, liqLogDir, {
+    PATH: `${stubBin}:${process.env.PATH ?? ''}`,
+    SUBWAVE_TEST_MOUNTPOINT: liqLogDir,
+  });
+
+  assert.ok(radioLogOpenable(liqLogDir), 'bind mount: radio.log must be openable');
+  assert.ok(
+    !lstatSync(liqLogDir).isSymbolicLink(),
+    'bind mount: the mounted dir must not be replaced by a link',
+  );
+  assert.equal(
+    readFileSync(join(liqLogDir, 'radio.log'), 'utf8'),
+    'operator history\n',
+    'bind mount: existing log history must NOT be wiped by the bootstrap',
+  );
+  assert.match(out, /is a mountpoint — leaving it/, 'bind mount: the decision should be logged');
+}
 
 console.log('aio-log-link: all assertions passed');

--- a/controller/scripts/aio-log-link.test.ts
+++ b/controller/scripts/aio-log-link.test.ts
@@ -298,4 +298,39 @@ function scratch(): Scratch {
   assert.match(out, /is a mountpoint — leaving it/, 'bind mount: the decision should be logged');
 }
 
+// --- 10. THE REPORTED OPERATOR'S POST-UPGRADE BOOT ------------------------
+// The reporter's state dir carries logs -> /var/log/liquidsoap (their
+// workaround for the pre-#1196 missing-radio.log bug), and a FRESH fixed
+// image has a plain real dir at the container path — so the state-side link
+// RESOLVES and can't be caught by the broken-link check. Left in place it
+// re-creates the cycle the moment the container dir is replaced by the link;
+// the probe would then break the cycle but at the price of persistence.
+// Step 1b must instead spot that the link resolves into $LIQ_LOG_DIR and
+// replace it, ending in the fully-healed shape: real state dir, container
+// path linked at it, writes persisting.
+{
+  const { stateRoot, liqLogDir } = scratch();
+  mkdirSync(liqLogDir, { recursive: true });
+  symlinkSync(liqLogDir, join(stateRoot, 'logs')); // resolves — not "broken"
+
+  const out = runLinker(stateRoot, liqLogDir);
+
+  assert.ok(radioLogOpenable(liqLogDir), 'cycle half: radio.log must be openable');
+  assert.ok(
+    !lstatSync(join(stateRoot, 'logs')).isSymbolicLink(),
+    'cycle half: the state-side link into $LIQ_LOG_DIR must become a real directory',
+  );
+  assert.ok(
+    lstatSync(liqLogDir).isSymbolicLink(),
+    'cycle half: the container path should end up linked at the state dir (full heal, not fallback)',
+  );
+  writeFileSync(join(liqLogDir, 'radio.log'), 'healed\n');
+  assert.equal(
+    readFileSync(join(stateRoot, 'logs', 'radio.log'), 'utf8'),
+    'healed\n',
+    'cycle half: persistence must survive the heal — fallback mode would lose it',
+  );
+  assert.match(out, /cycle half/, 'cycle half: the repair should be logged');
+}
+
 console.log('aio-log-link: all assertions passed');

--- a/docker/aio/supervisor.sh
+++ b/docker/aio/supervisor.sh
@@ -83,12 +83,16 @@ init_state() {
 
 	link_liquidsoap_log
 
-	# Rotate radio.log on boot once it passes 50MB — same policy as
-	# docker/broadcast-entrypoint.sh. Now that the log persists in state,
-	# it would otherwise append forever; boot is the one safe moment to
-	# move it since liquidsoap isn't holding the fd yet. One .old
-	# generation caps disk at ~2x the threshold.
-	RADIO_LOG="$STATE_ROOT/logs/radio.log"
+	# Rotate radio.log on boot once it passes 50MB — same policy (and same
+	# container-side path) as docker/broadcast-entrypoint.sh. Now that the
+	# log persists in state, it would otherwise append forever; boot is the
+	# one safe moment to move it since liquidsoap isn't holding the fd yet.
+	# One .old generation caps disk at ~2x the threshold. Rotating via
+	# $LIQ_LOG_DIR (not $STATE_ROOT/logs) matters: after
+	# link_liquidsoap_log it resolves to wherever radio.log actually lands —
+	# state logs, an operator's own disk, a bind mount, or the local
+	# fallback — while the state path misses the last two branches.
+	RADIO_LOG="$LIQ_LOG_DIR/radio.log"
 	if [ -f "$RADIO_LOG" ] && [ "$(stat -c %s "$RADIO_LOG" 2>/dev/null || echo 0)" -gt 52428800 ]; then
 		mv -f "$RADIO_LOG" "$RADIO_LOG.old"
 		echo "supervisor: rotated oversized radio.log to radio.log.old" >&2
@@ -140,21 +144,33 @@ link_liquidsoap_log() {
 	chmod 777 "$target" 2>/dev/null || true
 
 	# 2. Point the in-container path at it — unless something is mounted
-	#    there. `rm -rf` cannot remove a mountpoint, and `ln -s` onto a
-	#    surviving directory silently creates the link INSIDE it
-	#    (/var/log/liquidsoap/logs) instead of replacing it. An operator who
-	#    bind-mounted a host dir onto /var/log/liquidsoap (the split stack's
-	#    compose mapping, copied into an AIO `docker run`) already has a
-	#    persistent log dir, so leaving it alone is the correct outcome.
+	#    there. An operator who bind-mounted a host dir onto
+	#    /var/log/liquidsoap (the split stack's compose mapping, copied into
+	#    an AIO `docker run`) already has a persistent log dir, so it is
+	#    used as-is. The mountpoint test must come BEFORE any `rm -rf`:
+	#    `rm -rf` on a mountpoint can't remove the mountpoint itself but
+	#    DOES delete everything inside it — which would wipe the very log
+	#    history the operator mounted the dir to keep, on every boot.
 	if [ -d "$target" ]; then
-		[ -L "$LIQ_LOG_DIR" ] || rm -rf "$LIQ_LOG_DIR" 2>/dev/null || true
-		if [ -e "$LIQ_LOG_DIR" ] && [ ! -L "$LIQ_LOG_DIR" ]; then
-			log "$LIQ_LOG_DIR is a real directory (bind mount?) — leaving it; radio.log stays there"
+		if [ -e "$LIQ_LOG_DIR" ] && [ ! -L "$LIQ_LOG_DIR" ] && is_mountpoint "$LIQ_LOG_DIR"; then
+			log "$LIQ_LOG_DIR is a mountpoint — leaving it as-is; radio.log stays there"
 		else
-			# -f replaces an existing link (including a looping one, which
-			# is removed rather than followed); -n keeps it from being
-			# planted inside a link-to-directory.
-			ln -sfn "$target" "$LIQ_LOG_DIR" 2>/dev/null || true
+			# Anything unmounted at the container path — a plain dir
+			# from a pre-#1196 image, a stray file — is replaced by
+			# the link. `ln -s` onto a surviving directory would
+			# silently create the link INSIDE it
+			# (/var/log/liquidsoap/logs), hence the rm first.
+			[ -L "$LIQ_LOG_DIR" ] || rm -rf "$LIQ_LOG_DIR" 2>/dev/null || true
+			if [ -e "$LIQ_LOG_DIR" ] && [ ! -L "$LIQ_LOG_DIR" ]; then
+				# Unremovable yet not detected as a mountpoint
+				# (exotic mount setups) — same outcome, use as-is.
+				log "$LIQ_LOG_DIR survived removal (bind mount?) — leaving it; radio.log stays there"
+			else
+				# -f replaces an existing link (including a looping one, which
+				# is removed rather than followed); -n keeps it from being
+				# planted inside a link-to-directory.
+				ln -sfn "$target" "$LIQ_LOG_DIR" 2>/dev/null || true
+			fi
 		fi
 	else
 		log "WARNING $target is not a usable directory — not linking $LIQ_LOG_DIR at it"
@@ -167,8 +183,14 @@ link_liquidsoap_log() {
 	#    across recreates but keeps the station on the air.
 	if ! probe_log_dir; then
 		log "WARNING $LIQ_LOG_DIR is unopenable — falling back to a container-local log dir; radio.log will NOT persist in the state dir"
-		rm -rf "$LIQ_LOG_DIR" 2>/dev/null || true
-		mkdir -p "$LIQ_LOG_DIR" 2>/dev/null || true
+		# A mountpoint can be neither removed nor replaced, so rebuilding
+		# is pointless there — and `rm -rf` on a mount that somehow fails
+		# the probe would only strip the operator's files while leaving
+		# the path just as unopenable. Rebuild unmounted paths only.
+		if ! is_mountpoint "$LIQ_LOG_DIR"; then
+			rm -rf "$LIQ_LOG_DIR" 2>/dev/null || true
+			mkdir -p "$LIQ_LOG_DIR" 2>/dev/null || true
+		fi
 		probe_log_dir || log "ERROR $LIQ_LOG_DIR is still unopenable — liquidsoap will fail to start"
 	fi
 
@@ -176,6 +198,9 @@ link_liquidsoap_log() {
 	# NOT recursive: liquidsoap only needs to create/append radio.log in the
 	# directory itself, and an operator who pointed <state>/logs at their own
 	# disk shouldn't have its existing contents re-owned underneath them.
+	# The directory inode itself IS re-moded/re-owned even when it is the
+	# operator's own — that's the price of liquidsoap being able to create
+	# radio.log inside it; only the contents are left untouched.
 	chmod 777 "$LIQ_LOG_DIR" 2>/dev/null || true
 	chown liquidsoap:liquidsoap "$LIQ_LOG_DIR" 2>/dev/null || true
 }
@@ -189,6 +214,20 @@ probe_log_dir() {
 	: > "$probe" 2>/dev/null || return 1
 	rm -f "$probe" 2>/dev/null || true
 	return 0
+}
+
+# Is $1 a mountpoint? `mountpoint` ships with util-linux on the Debian base;
+# fall back to /proc/self/mountinfo (field 5 is the mount point) so the answer
+# never silently degrades to "not a mount" just because the binary is missing.
+# A symlink is never its own mountpoint, but `mountpoint` resolves it and
+# reports on the target — fine for both call sites, which only ask about
+# non-symlink shapes or paths about to be rebuilt anyway.
+is_mountpoint() {
+	if command -v mountpoint >/dev/null 2>&1; then
+		mountpoint -q "$1" 2>/dev/null
+	else
+		awk -v p="$1" '$5 == p { found = 1; exit } END { exit found ? 0 : 1 }' /proc/self/mountinfo 2>/dev/null
+	fi
 }
 
 # ---------------------------------------------------------------------------

--- a/docker/aio/supervisor.sh
+++ b/docker/aio/supervisor.sh
@@ -140,6 +140,25 @@ link_liquidsoap_log() {
 		log "WARNING $target is a broken symlink (-> $(readlink "$target" 2>/dev/null || echo '?')) — replacing it with a real directory"
 		rm -f "$target" 2>/dev/null || true
 	fi
+
+	# 1b. A state-side link that RESOLVES INTO the container log path is the
+	#     #1196 cycle half wearing a disguise: it only looks healthy while
+	#     the fresh image's plain /var/log/liquidsoap still exists (the
+	#     exact shape the reported operator's install boots into after
+	#     pulling this fix). Linking $LIQ_LOG_DIR at a path that resolves to
+	#     $LIQ_LOG_DIR itself can only re-create the cycle, which the probe
+	#     below would then break — but at the price of dropping persistence.
+	#     Replacing the link with a real directory now keeps it.
+	if [ -L "$target" ] && [ -d "$target" ] && command -v realpath >/dev/null 2>&1; then
+		local target_real liq_real
+		target_real=$(realpath -m -- "$target" 2>/dev/null || true)
+		liq_real=$(realpath -m -- "$LIQ_LOG_DIR" 2>/dev/null || true)
+		if [ -n "$target_real" ] && [ "$target_real" = "$liq_real" ]; then
+			log "WARNING $target resolves into $LIQ_LOG_DIR — the #1196 cycle half; replacing it with a real directory"
+			rm -f "$target" 2>/dev/null || true
+		fi
+	fi
+
 	mkdir -p "$target" 2>/dev/null || true
 	chmod 777 "$target" 2>/dev/null || true
 

--- a/docker/aio/supervisor.sh
+++ b/docker/aio/supervisor.sh
@@ -25,7 +25,12 @@ RENDERED=/etc/icecast2/icecast.xml
 
 # Multi-station pointer (see docker/broadcast-entrypoint.sh — kept in lockstep).
 # Called at the top of run_broadcast so every mixer relaunch re-resolves.
-STATE_ROOT=/var/sub-wave
+#
+# Both paths are env-overridable so scripts/aio-log-link.test.ts can drive
+# link_liquidsoap_log() against a scratch dir. Neither var is set in the image,
+# so the container resolves the same literals it always did.
+STATE_ROOT="${SUBWAVE_STATE_ROOT:-/var/sub-wave}"
+LIQ_LOG_DIR="${SUBWAVE_LIQ_LOG_DIR:-/var/log/liquidsoap}"
 STATE_DIR="$STATE_ROOT"
 resolve_state_dir() {
 	STATE_DIR="$STATE_ROOT"
@@ -76,28 +81,114 @@ init_state() {
 	# archive mixdowns as junk "HH-00" tracks (issue #273).
 	touch /var/sub-wave/archive/.ndignore
 
-	# Liquidsoap writes radio.log to /var/log/liquidsoap. Point that at the
-	# state ROOT's logs/ so the log survives container recreates and the
-	# controller's debug page can tail it (routes/debug.ts reads
-	# <stateRoot>/logs/radio.log — the same install-level location the
-	# compose stacks pin via their ${STATE_DIR}/logs bind mount). A plain
-	# in-container dir here left AIO installs with no radio.log in the
-	# state dir at all, so the debug tail always errored ENOENT.
-	if [ ! -L /var/log/liquidsoap ]; then
-		rm -rf /var/log/liquidsoap
-		ln -s /var/sub-wave/logs /var/log/liquidsoap
-	fi
+	link_liquidsoap_log
 
 	# Rotate radio.log on boot once it passes 50MB — same policy as
 	# docker/broadcast-entrypoint.sh. Now that the log persists in state,
 	# it would otherwise append forever; boot is the one safe moment to
 	# move it since liquidsoap isn't holding the fd yet. One .old
 	# generation caps disk at ~2x the threshold.
-	RADIO_LOG=/var/sub-wave/logs/radio.log
+	RADIO_LOG="$STATE_ROOT/logs/radio.log"
 	if [ -f "$RADIO_LOG" ] && [ "$(stat -c %s "$RADIO_LOG" 2>/dev/null || echo 0)" -gt 52428800 ]; then
 		mv -f "$RADIO_LOG" "$RADIO_LOG.old"
 		echo "supervisor: rotated oversized radio.log to radio.log.old" >&2
 	fi
+}
+
+# ---------------------------------------------------------------------------
+# Point /var/log/liquidsoap at the state ROOT's logs/, but never at the cost of
+# the station.
+#
+# radio.liq opens settings.log.file.path during Dtools.Log.init — the FIRST
+# lifecycle step, before the mixer graph, before the telnet port, before the
+# Icecast connection. An unopenable log path is therefore not a degraded log,
+# it is a fatal startup error. That makes this the one bootstrap step that can
+# take the station off the air, so it fails soft: every branch below ends with
+# a path liquidsoap can actually open, verified by probe rather than assumed.
+#
+# The goal is still #1196's — radio.log has to survive container recreates and
+# routes/debug.ts tails <stateRoot>/logs/radio.log, the same install-level
+# location the compose stacks pin via their ${STATE_DIR}/logs bind mount.
+#
+# What #1196 got wrong: it created the symlink unconditionally and guarded
+# re-entry on `[ ! -L /var/log/liquidsoap ]`. If <state>/logs was itself a
+# symlink pointing back at /var/log/liquidsoap — the natural host-side
+# workaround for the pre-#1196 "AIO has no radio.log in the state dir" bug —
+# the two links closed a cycle and every start died with
+#
+#   Fatal error: exception Sys_error("/var/log/liquidsoap/radio.log: Too many
+#   levels of symbolic links")
+#
+# and because the guard only tested -L, it then SKIPPED (never repaired) the
+# bad link on every subsequent boot: an unbreakable 3s crash loop, both Doctor
+# broadcast checks red, and the "Restart mixer" fix button useless because it
+# speaks telnet to a port liquidsoap never got far enough to bind.
+# ---------------------------------------------------------------------------
+link_liquidsoap_log() {
+	local target="$STATE_ROOT/logs"
+
+	# 1. Heal a broken state-side logs link. `-d` is false for a dangling
+	#    symlink AND for a looping one (stat fails with ELOOP), which is
+	#    exactly the set worth replacing with a real directory. A symlink
+	#    that resolves to a real directory elsewhere is an operator parking
+	#    logs on another disk on purpose — left alone.
+	if [ -L "$target" ] && [ ! -d "$target" ]; then
+		log "WARNING $target is a broken symlink (-> $(readlink "$target" 2>/dev/null || echo '?')) — replacing it with a real directory"
+		rm -f "$target" 2>/dev/null || true
+	fi
+	mkdir -p "$target" 2>/dev/null || true
+	chmod 777 "$target" 2>/dev/null || true
+
+	# 2. Point the in-container path at it — unless something is mounted
+	#    there. `rm -rf` cannot remove a mountpoint, and `ln -s` onto a
+	#    surviving directory silently creates the link INSIDE it
+	#    (/var/log/liquidsoap/logs) instead of replacing it. An operator who
+	#    bind-mounted a host dir onto /var/log/liquidsoap (the split stack's
+	#    compose mapping, copied into an AIO `docker run`) already has a
+	#    persistent log dir, so leaving it alone is the correct outcome.
+	if [ -d "$target" ]; then
+		[ -L "$LIQ_LOG_DIR" ] || rm -rf "$LIQ_LOG_DIR" 2>/dev/null || true
+		if [ -e "$LIQ_LOG_DIR" ] && [ ! -L "$LIQ_LOG_DIR" ]; then
+			log "$LIQ_LOG_DIR is a real directory (bind mount?) — leaving it; radio.log stays there"
+		else
+			# -f replaces an existing link (including a looping one, which
+			# is removed rather than followed); -n keeps it from being
+			# planted inside a link-to-directory.
+			ln -sfn "$target" "$LIQ_LOG_DIR" 2>/dev/null || true
+		fi
+	else
+		log "WARNING $target is not a usable directory — not linking $LIQ_LOG_DIR at it"
+	fi
+
+	# 3. Prove liquidsoap can open a file there before handing over the path.
+	#    This is the backstop that turns the whole ELOOP class of bug into a
+	#    warning: any shape that fails the probe falls back to a plain
+	#    container-local directory, which costs the Debug tail its history
+	#    across recreates but keeps the station on the air.
+	if ! probe_log_dir; then
+		log "WARNING $LIQ_LOG_DIR is unopenable — falling back to a container-local log dir; radio.log will NOT persist in the state dir"
+		rm -rf "$LIQ_LOG_DIR" 2>/dev/null || true
+		mkdir -p "$LIQ_LOG_DIR" 2>/dev/null || true
+		probe_log_dir || log "ERROR $LIQ_LOG_DIR is still unopenable — liquidsoap will fail to start"
+	fi
+
+	# Both follow the link to whatever directory we settled on. Deliberately
+	# NOT recursive: liquidsoap only needs to create/append radio.log in the
+	# directory itself, and an operator who pointed <state>/logs at their own
+	# disk shouldn't have its existing contents re-owned underneath them.
+	chmod 777 "$LIQ_LOG_DIR" 2>/dev/null || true
+	chown liquidsoap:liquidsoap "$LIQ_LOG_DIR" 2>/dev/null || true
+}
+
+# Can a file actually be created under $LIQ_LOG_DIR? Runs as root, so it proves
+# the PATH resolves (the ELOOP/dangling class) rather than that the liquidsoap
+# user has write permission — that part is the chmod/chown at the end of
+# link_liquidsoap_log.
+probe_log_dir() {
+	local probe="$LIQ_LOG_DIR/.write-probe"
+	: > "$probe" 2>/dev/null || return 1
+	rm -f "$probe" 2>/dev/null || true
+	return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -395,7 +486,16 @@ supervise() {
 
 # ---------------------------------------------------------------------------
 # Boot.
+#
+# Sourcing this file with SUBWAVE_SUPERVISOR_LIB=1 defines the functions
+# WITHOUT booting anything — the seam scripts/aio-log-link.test.ts drives to
+# exercise link_liquidsoap_log() against a scratch dir. The image never sets
+# it, so PID 1 always falls through to the real boot below.
 # ---------------------------------------------------------------------------
+if [ "${SUBWAVE_SUPERVISOR_LIB:-}" = "1" ]; then
+	return 0 2>/dev/null || exit 0
+fi
+
 warn_if_state_unmounted
 init_state
 init_secrets


### PR DESCRIPTION
## The report

An AIO operator's station was dead, with both Doctor BROADCAST checks red (`Icecast stream: offline`, `mixer (Liquidsoap): telnet unreachable: connect ECONNREFUSED 127.0.0.1:1234`) and the container looping every 3s on:

```
Fatal error: exception Sys_error("/var/log/liquidsoap/radio.log: Too many levels of symbolic links")
Called from Dtools.Log.init in file "src/modules/dtools/dtools_impl.ml", line 789
[subwave-aio] broadcast pair: a child exited (2) — taking the other down
[subwave-aio] broadcast exited (2) — restarting in 3s
```

Both Doctor failures were one fault. `radio.liq:7` sets `settings.log.file.path := "/var/log/liquidsoap/radio.log"`, and that is opened in `Dtools.Log.init` — the **first** lifecycle step, before the mixer graph, before the telnet port, before the Icecast connection. So an unopenable log path is a fatal start error, not a degraded log; nothing binds :1234 and nothing feeds Icecast.

## Cause

Introduced by #1196 (`949a0d5e`), which replaced a plain `mkdir -p /var/log/liquidsoap` with:

```sh
if [ ! -L /var/log/liquidsoap ]; then
    rm -rf /var/log/liquidsoap
    ln -s /var/sub-wave/logs /var/log/liquidsoap
fi
```

That creates one half of a cycle. It's fatal when `<state>/logs` leads back to `/var/log/liquidsoap` — which is exactly the host-side workaround an operator would have applied for the *pre*-#1196 bug that commit fixed (AIO wrote no `radio.log` into the state dir, so the Debug tail always ENOENT'd). Update to a #1196+ image and the ring closes.

Reproduced verbatim before writing any code:

```
var/log/liquidsoap -> var/sub-wave/logs
var/sub-wave/logs  -> var/log/liquidsoap
$ : > var/log/liquidsoap/radio.log
bash: …/radio.log: Too many levels of symbolic links
```

It also cannot self-heal: once the cycle exists `[ ! -L /var/log/liquidsoap ]` is false, so every later boot **skips** the block rather than repairing it. There is no route back from the admin UI either — Doctor offers "Restart mixer" on both rows, but that POSTs `/restart-mixer` → `restartLiquidsoap()`, which rethrows anything that isn't `ECONNRESET|EPIPE|timeout` (`liquidsoap-control.ts:95`). You cannot telnet-restart a process that never bound the port.

## The fix

`link_liquidsoap_log()` keeps #1196's goal (persist `radio.log` into `<stateRoot>/logs` so it survives container recreates and `routes/debug.ts` can tail it) but repairs instead of assuming:

1. **Heals a broken state-side link.** `-d` is false for both a dangling and a looping symlink — exactly the set worth replacing with a real directory. A symlink resolving to a real directory *elsewhere* is an operator parking logs on another disk, and is left alone. One resolving symlink IS replaced: a state-side link whose `realpath` equals `$LIQ_LOG_DIR`'s is the #1196 cycle half in disguise — it only looks healthy while the fresh image's plain `/var/log/liquidsoap` still exists (the exact shape the reported operator boots into after pulling this fix), and linking the container path at something that resolves to itself can only re-create the cycle. Catching it up front ends in the fully-healed shape instead of the persistence-losing fallback.
2. **Replaces rather than nests.** `ln -sfn` removes a bad link instead of following it, and `-n` stops the new link being planted *inside* a link-to-directory. A bind mount at `/var/log/liquidsoap` — e.g. the split stack's `${STATE_DIR}/logs:/var/log/liquidsoap` mapping copied into an AIO `docker run` — is detected via `is_mountpoint()` (`mountpoint(1)`, `/proc/self/mountinfo` fallback) **before** any `rm -rf`, and used as-is with its contents intact. The order matters: `rm -rf` can't remove a mountpoint, but it *does* delete everything inside one, which would have wiped the operator's log history on every boot.
3. **Probes before handing over.** Whatever shape results, a write probe proves the path actually resolves. Anything that fails falls back to a plain container-local directory, trading the Debug tail's history across recreates for keeping the station on the air. This is the part that turns the whole ELOOP class of bug into a logged warning. The fallback rebuild also skips mountpoints — `rm` there could only strip the operator's files without making the path any more openable.

The `chown` is now non-recursive, so an operator's own log directory doesn't get re-owned underneath them. Boot rotation now checks `$LIQ_LOG_DIR/radio.log` — the same container-side path `docker/broadcast-entrypoint.sh` rotates — so it follows the log wherever it landed; the old `$STATE_ROOT/logs` check missed the bind-mount and fallback branches, leaving those logs to grow unbounded.

## Tests

New `controller/scripts/aio-log-link.test.ts` (auto-registered by dropping it in `scripts/`) drives the function against a scratch dir via a `SUBWAVE_SUPERVISOR_LIB=1` sourcing seam. Ten scenarios, each asserting the load-bearing property — **is `radio.log` openable when the function returns** — with persistence explicitly subordinate to it:

1. the reported cycle (asserts it's unopenable *before* the repair, so the test can't rot into vacuously passing)
2. the cycle is genuinely broken — writes still land in the state dir
3. fresh install
4. the #1196 upgrade path (plain dir with an existing `radio.log`)
5. idempotence across 3 runs, and no nested `logs/logs`
6. dangling state-side link
7. a deliberate operator symlink to another disk is preserved and followed
8. fallback keeps the station on air when the state dir can't host `logs/` at all
9. a bind mount at the container path (PATH-stubbed `mountpoint(1)`) is used as-is — and its existing log history survives the bootstrap
10. the reported operator's post-upgrade boot (state-side link resolving into a fresh image's real `/var/log/liquidsoap`) ends fully healed — real state dir, container path linked at it, writes persisting — not in the fallback

## Verification

- `npm test` in `controller/` — all **56** test files pass, including the new one
- `npm run lint` in `controller/` — exit 0 (580 pre-existing `any` warnings, 0 errors)
- `bash -n docker/aio/supervisor.sh` — clean

**Verified in a real AIO container** (`subwave-aio-heavy:latest` — a post-liquidsoap-2.4 build — with this branch's `supervisor.sh` and `radio.liq` mounted over the baked copies):

- **The reporter's exact state shape** (`<state>/logs -> /var/log/liquidsoap`), full supervised boot: the cycle-half heal fires once, **zero** `Sys_error` lines, **zero** broadcast-pair restarts, `radio.log` lands in the state dir (Liquidsoap 2.4.5's `Dtools.Log.init` opened the healed path), and telnet **:1234 binds** — both red Doctor checks from the report go green.
- **`docker restart`**: no re-heal, no warnings, and one `radio.log` carries two `LOG START` stanzas — persistence across restarts, the original #1196 goal.
- **A real bind mount** (`-v …:/var/log/liquidsoap`, real `mountpoint(1)`, no stub): detected before any `rm`, left as a real dir, pre-existing log content intact, still writable.
- **The verbatim ELOOP cycle at the literal paths** inside the image: reproduced (`Too many levels of symbolic links`), then healed to a real state-side dir with writes persisting through the container path.

Still not exercised: a from-scratch image *build* of this branch (the container runs the branch's files over a published image's filesystem).

## Operator workaround (for anyone hitting this before the image ships)

```bash
docker stop <container>
rm <state>/logs                     # it's a symlink, not a dir
mkdir -p <state>/logs && chmod 777 <state>/logs
docker start <container>
```

Also drop any `-v …:/var/log/liquidsoap` mapping from an AIO `docker run` — the supervisor owns that path.

https://claude.ai/code/session_01KNpg3zsMYaCNHnv4TErsN4
