### PR TITLE
fix(admin): give the stem cache budget its own save button

### DIFF
--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -829,6 +829,21 @@ export default function SettingsPanel() {
                         ).toLocaleString('en-GB')}{' '}
                         tracks
                       </span>
+                      {/* Every editable field on this page carries its own save button;
+                          without one here operators edit the number, miss the card-level
+                          "Save transitions" two fields below, and the change silently
+                          reverts on the next visit. */}
+                      <Btn
+                        sm
+                        onClick={() =>
+                          saveSettings({
+                            audio: { stemCacheGb: Number(form.transitions.stemCacheGb) },
+                          })
+                        }
+                        disabled={busy}
+                      >
+                        Save budget
+                      </Btn>
                     </div>
                     <div className="field-hint">
                       How much disk the stem cache may use before the oldest entries are evicted


### PR DESCRIPTION
## What

Adds an inline **Save budget** button to the Stem cache budget field in Settings → Danger zone, posting `audio.stemCacheGb` on its own — the same per-field pattern as Save crossfade / Save limit / Save bitrate. **Save transitions** still saves the whole card, budget included.

## Why

Discord report: changing the stem cache budget number in the Danger Zone doesn't persist — it goes back to whatever `settings.json` holds, and the workaround being passed around is hand-editing the file.

Investigated the full path before touching anything:

- `settings.update()` with the exact Save-transitions payload **persists correctly** to `settings.json` (verified with a direct script against a scratch `STATE_DIR`).
- The full browser flow — type a value, click *Save transitions*, reload — **works** (verified with Playwright against an isolated controller + web dev server, on code byte-identical to the v1.0.0 release on this path).
- The typed value survives the 3s settings refresh tick; nothing clobbers the form.

So the data path was never broken. The trap is the affordance: every other editable control on the page has its save button inline next to it, but the budget input had none — its only save was the card-level "Save transitions" button visually attached to the *Stem-blend seams* toggle two fields below, and Enter does nothing. An operator who edits the number and doesn't find that one non-obvious button loses the edit silently on the next visit, which reads exactly as "doesn't persist, reverts to settings.json".

## Verification

Playwright against an isolated worktree stack (spare ports, scratch `STATE_DIR`):

- fill 200 → click **Save budget** → `GET /settings` returns 200 → survives full page reload
- empty input → server rejects (`audio.stemCacheGb must be between 1 and 500`), stored value untouched
- `npm run lint` (web) passes

