### PR TITLE
fix(tts): use fr-fr for Kokoro French, espeak-ng has no bare fr

### DIFF
--- a/controller/scripts/kokoro-lang.test.ts
+++ b/controller/scripts/kokoro-lang.test.ts
@@ -1,0 +1,93 @@
+// Unit tests for the Kokoro phonemizer language vocabulary (settings/vocab.ts)
+// and its sync with controller/scripts/kokoro_worker.py.
+//
+// Issue #1213: `fr` was offered as a language even though espeak-ng ships no
+// bare `fr` voice (only fr-fr/fr-be/fr-ch). phonemizer's EspeakBackend matches
+// its language argument EXACTLY against espeak-ng's voice table, so every
+// French TTS call threw and fell back to Piper's English voice. The espeak-ng
+// CLI does resolve `-v fr` to a regional voice, which is what made the wrong
+// code look correct until it reached the backend.
+//
+// The two facts pinned here are the ones that let the bug exist and survive:
+//   1. the TS override list and the worker's prefix→lang map must hold the SAME
+//      language codes — the worker rejects any lang outside its own map values
+//      and silently substitutes the voice's own language, so fixing one file
+//      without the other trades a loud failure for a quiet wrong-accent one;
+//   2. legacy codes must canonicalise rather than vanish, so an operator who
+//      picked French before the fix still gets French after upgrading.
+// Run: `tsx scripts/kokoro-lang.test.ts`.
+//
+// node:assert-via-tsx style, matching scripts/tts-fallback.test.ts.
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  KOKORO_LANGS,
+  KOKORO_LANG_RE,
+  KOKORO_LANG_ALIASES,
+  canonicalKokoroLang,
+} from '../src/settings/vocab.js';
+
+const WORKER = fileURLToPath(new URL('./kokoro_worker.py', import.meta.url));
+const workerSrc = readFileSync(WORKER, 'utf8');
+
+// --- the regression itself -------------------------------------------------
+
+assert.ok(
+  !KOKORO_LANGS.includes('fr'),
+  'bare `fr` is not an espeak-ng voice — espeak-ng ships fr-fr/fr-be/fr-ch only (#1213)',
+);
+assert.ok(KOKORO_LANGS.includes('fr-fr'), 'French is still offered, as fr-fr');
+
+// The auto-detect path is the half of #1213 the bug report missed: `ff_siwis`
+// (the only French Kokoro voice) resolves its language from the prefix map, so
+// French was broken even with the override left empty.
+const prefixMap = Object.fromEntries(
+  [...workerSrc.matchAll(/^\s{8}"([a-z])":\s*"([a-z-]+)",$/gm)].map(m => [m[1], m[2]]),
+);
+assert.equal(
+  Object.keys(prefixMap).length,
+  9,
+  'parsed all 9 voice-prefix entries out of kokoro_worker.py',
+);
+assert.equal(prefixMap.f, 'fr-fr', 'the `f` (French) voice prefix auto-detects as fr-fr');
+
+// --- the drift guard -------------------------------------------------------
+
+// The worker's `lang not in lang_mapping.values()` guard means an override the
+// worker doesn't know is dropped, not honoured. Keep the two sides identical.
+assert.deepEqual(
+  [...new Set(Object.values(prefixMap))].sort(),
+  [...KOKORO_LANGS].sort(),
+  'KOKORO_LANGS and kokoro_worker.py lang_mapping carry the same language codes',
+);
+
+// --- legacy canonicalisation ----------------------------------------------
+
+assert.equal(canonicalKokoroLang('fr'), 'fr-fr', 'stored `fr` upgrades to fr-fr');
+assert.ok(
+  KOKORO_LANG_RE.test(canonicalKokoroLang('fr')),
+  'the canonicalised legacy code passes validation, so load() keeps it',
+);
+for (const lang of KOKORO_LANGS) {
+  assert.equal(canonicalKokoroLang(lang), lang, `${lang} is already canonical`);
+}
+assert.equal(canonicalKokoroLang(''), '', 'empty (auto-detect) passes through untouched');
+assert.equal(canonicalKokoroLang('xx'), 'xx', 'unknown codes pass through for the caller to reject');
+assert.ok(!KOKORO_LANG_RE.test('xx'), 'and validation rejects them');
+
+// Alias parity: the worker sees the same legacy value via the KOKORO_LANG env
+// var, which never passes through the TS layer.
+const workerAliases = Object.fromEntries(
+  [...(workerSrc.match(/lang_aliases = \{([^}]*)\}/)?.[1] ?? '').matchAll(
+    /"([a-z-]+)":\s*"([a-z-]+)"/g,
+  )].map(m => [m[1], m[2]]),
+);
+assert.deepEqual(
+  workerAliases,
+  KOKORO_LANG_ALIASES,
+  'KOKORO_LANG_ALIASES and the worker lang_aliases agree',
+);
+
+console.log('kokoro-lang: all assertions passed');

--- a/controller/scripts/kokoro_worker.py
+++ b/controller/scripts/kokoro_worker.py
@@ -60,17 +60,29 @@ def main():
     log("ready")
     emit({"id": None, "ready": True})
 
+    # Voice-code prefix -> phonemizer language. Every value must EXACTLY match a
+    # row in espeak-ng's voice table (`espeak-ng --voices`, Language column):
+    # phonemizer's EspeakBackend validates against that list verbatim and raises
+    # "language X is not supported by the espeak backend" for anything else. The
+    # espeak-ng CLI *does* resolve bare aliases (`-v fr` works), which is exactly
+    # why a wrong entry here looks fine until it reaches the backend. French is
+    # the one language with no bare code — espeak-ng ships fr-fr/fr-be/fr-ch only
+    # (#1213). Synced with KOKORO_LANGS in controller/src/settings/vocab.ts.
     lang_mapping = {
         "a": "en-us",
         "b": "en-gb",
         "e": "es",
         "i": "it",
-        "f": "fr",
+        "f": "fr-fr",
         "h": "hi",
         "p": "pt-br",
         "j": "ja",
         "z": "cmn",
     }
+    # Pre-#1213 settings.json / KOKORO_LANG values that espeak-ng would reject.
+    # Rewritten rather than dropped, so an operator who picked French before the
+    # fix keeps French instead of silently falling back to the voice's own lang.
+    lang_aliases = {"fr": "fr-fr"}
     # EspeakG2P construction isn't free, and there are only a handful of
     # languages, so build each phonemizer once and reuse it across requests.
     g2p_cache = {}
@@ -79,6 +91,7 @@ def main():
         """Return a cached language-aware phonemizer. When `lang` is explicitly
         provided use it directly (voice timbre, accent preserved); otherwise
         auto-detect from the voice code prefix character."""
+        lang = lang_aliases.get(lang, lang)
         if not lang or lang not in lang_mapping.values():
             lang = lang_mapping.get(voice_code[0], "en-gb")  # british english fallback
         g2p = g2p_cache.get(lang)

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -54,6 +54,7 @@ import {
   WEATHER_MOOD_DEFAULTS,
   applyInlineKey,
   applyLlmLegPatch,
+  canonicalKokoroLang,
   clamp01,
   clampAgentTimeout,
   clampBudgetSoftPct,
@@ -535,10 +536,13 @@ export async function load() {
           KOKORO_VOICE_RE.test(stored.tts.kokoro.voice)
             ? stored.tts.kokoro.voice
             : DEFAULTS.tts.kokoro.voice,
+        // Legacy codes are canonicalised first (`fr` → `fr-fr`, #1213), so an
+        // operator who chose French before the fix keeps French rather than
+        // dropping back to the auto-detect default.
         lang:
           typeof stored.tts?.kokoro?.lang === 'string' &&
-          KOKORO_LANG_RE.test(stored.tts.kokoro.lang)
-            ? stored.tts.kokoro.lang
+          KOKORO_LANG_RE.test(canonicalKokoroLang(stored.tts.kokoro.lang))
+            ? canonicalKokoroLang(stored.tts.kokoro.lang)
             : DEFAULTS.tts.kokoro.lang,
       },
       chatterbox: {
@@ -1322,7 +1326,9 @@ export async function update(patch) {
         next.tts.kokoro.voice = v;
       }
       if (k.lang !== undefined) {
-        const v = String(k.lang).trim();
+        // Canonicalise before validating so a pre-#1213 client still posting
+        // `fr` lands on `fr-fr` rather than being rejected outright.
+        const v = canonicalKokoroLang(String(k.lang).trim());
         if (v && !KOKORO_LANG_RE.test(v)) {
           throw new Error(`tts.kokoro.lang must be one of: ${KOKORO_LANGS.join(', ')}`);
         }

--- a/controller/src/settings/vocab.ts
+++ b/controller/src/settings/vocab.ts
@@ -704,8 +704,28 @@ export const KOKORO_VOICE_RE = /^[a-z]{2}_[a-z0-9]+$/;
 // The worker builds an espeak.EspeakG2P for the chosen language (see _phonemize
 // in kokoro_worker.py). Empty string = auto-detect from the voice-code prefix.
 // Synced with the prefix→lang mapping in controller/scripts/kokoro_worker.py.
-export const KOKORO_LANGS = ['en-gb', 'en-us', 'es', 'it', 'fr', 'hi', 'pt-br', 'ja', 'cmn'];
+//
+// Every entry must be an EXACT match for a row in espeak-ng's own voice table
+// (`espeak-ng --voices`, Language column) — phonemizer's EspeakBackend validates
+// against that list verbatim and throws for anything else. espeak-ng's CLI does
+// resolve bare aliases like `fr` to a regional voice, which is what makes a wrong
+// entry here look plausible, but the backend never gets that far. Hence `fr-fr`
+// and not `fr` (#1213): espeak-ng ships fr-fr/fr-be/fr-ch and no bare `fr`.
+export const KOKORO_LANGS = ['en-gb', 'en-us', 'es', 'it', 'fr-fr', 'hi', 'pt-br', 'ja', 'cmn'];
 export const KOKORO_LANG_RE = new RegExp(`^(${KOKORO_LANGS.join('|')})$`);
+
+// Codes that were offered before they were checked against espeak-ng, kept
+// accepted so a stored settings.json (or an old API client) is rewritten to the
+// working equivalent instead of silently reverting to auto-detect. Mirrored by
+// `lang_aliases` in controller/scripts/kokoro_worker.py, which covers the same
+// value arriving through the KOKORO_LANG env var.
+export const KOKORO_LANG_ALIASES: Record<string, string> = { fr: 'fr-fr' };
+
+/** Canonicalise a Kokoro phonemizer language; unknown values pass through for
+ *  the caller's own validation to reject. */
+export function canonicalKokoroLang(lang: string): string {
+  return KOKORO_LANG_ALIASES[lang] || lang;
+}
 
 // PocketTTS built-in voices — the curated set the admin UI offers. Issue #213
 // also surfaced zero-shot cloning, so `tts.voice` for pocket-tts may now be

--- a/web/components/admin/settings/TtsSection.tsx
+++ b/web/components/admin/settings/TtsSection.tsx
@@ -31,7 +31,7 @@ const KOKORO_LANG_LABELS: Record<string, string> = {
   'en-gb': 'English (UK)',
   'en-us': 'English (US)',
   cmn: 'Chinese (Mandarin)',
-  fr: 'French',
+  'fr-fr': 'French',
   hi: 'Hindi',
   it: 'Italian',
   ja: 'Japanese',


### PR DESCRIPTION
Fixes #1213.

## The bug

Choosing French for Kokoro TTS made every call throw and fall back to Piper's English voice, so French personas read French text in a British accent.

`phonemizer`'s `EspeakBackend` matches its `language` argument **exactly** against espeak-ng's voice table, and espeak-ng ships `fr-fr` / `fr-be` / `fr-ch` with **no bare `fr` row**. Verified locally against `espeak-ng --voices` — `fr` is the only code in our list without an exact match:

| Code | exact espeak-ng match |
|---|---|
| en-gb, en-us, es, it, hi, pt-br, ja, cmn | ✅ |
| **fr** | ❌ (only fr-fr / fr-be / fr-ch) |

Worth noting for anyone re-checking: the espeak-ng **CLI** happily resolves `-v fr` to a regional voice, so the code looks valid right up until it reaches the backend. That is what let this ship.

## Two paths carried it — fixing either alone leaves French broken

The issue proposed changing `KOKORO_LANGS`. That is necessary but not sufficient:

1. **`KOKORO_LANGS`** offered `fr` as an explicit override. ✔ addressed by the issue's suggestion.
2. **`kokoro_worker.py`'s prefix map** resolved the `f` voice prefix — i.e. `ff_siwis`, the only French Kokoro voice — to `fr`. So **auto-detect was broken too**, which is the default path with the language dropdown left empty. An operator who never touched the dropdown still got the crash.

They are also coupled: the worker rejects any override outside its own `lang_mapping.values()` and silently substitutes the voice's own language. Correcting only the TS list would have turned a loud failure into a quiet wrong-accent one.

## Changes

- `settings/vocab.ts` — `fr` → `fr-fr` in `KOKORO_LANGS`, plus `KOKORO_LANG_ALIASES` / `canonicalKokoroLang()`.
- `scripts/kokoro_worker.py` — `"f": "fr-fr"` in the prefix map, plus a `lang_aliases` rewrite covering the same legacy value arriving via the `KOKORO_LANG` env var.
- `settings.ts` — canonicalise a stored `fr` on `load()` and on `update()`, so an operator who picked French before this **keeps French** instead of reverting to auto-detect (and an old API client posting `fr` is rewritten rather than rejected).
- `TtsSection.tsx` — the label map is keyed by lang code, so `fr` → `fr-fr` there too or the dropdown renders a raw code.

## Test

New `controller/scripts/kokoro-lang.test.ts` asserts the TS list and the worker's prefix map hold **identical** codes — the drift that allowed this bug — plus the auto-detect entry and the legacy canonicalisation.

Confirmed it fails on the issue's half-fix (vocab.ts changed, worker left on bare `fr`) and passes on the full one.

## Verification

- `controller` lint ✅ · `web` lint ✅ (0 errors both)
- `npm test` — 58/59 pass. The one failure, `aio-log-link.test.ts`, is **pre-existing on clean `develop`** (reproduced on an unmodified checkout) and unrelated to this change.
- Not exercised against a live Kokoro worker — no model/venv in this environment. The espeak-ng voice table was verified directly.