### PR TITLE
docs(web): illustrate the manual and dispatches with screenshots

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2713,6 +2713,69 @@ html.lite .sw-ripple-circle {
     margin-left: auto;
 }
 
+/* ── Manual figures — screenshots set into a page, broadsheet plate style ── */
+.bs-manual-figure {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin: clamp(18px, 3vw, 28px) 0 0;
+}
+.bs-manual-figure img {
+    display: block;
+    width: 100%;
+    height: auto;
+    border: 1px solid var(--ink);
+    background: var(--bg);
+}
+/* Anything taller than it is wide is framed to its top: a handset shot at
+   handset width, a long scrolling panel wider so its detail stays legible.
+   The frame is an aspect-ratio (not a pixel height) so the crop holds at every
+   column width — a fixed height would start cutting the sides once `cover`
+   had to scale up to fill it. */
+.bs-manual-figure[data-shot="phone"] img,
+.bs-manual-figure[data-shot="tall"] img {
+    object-fit: cover;
+    object-position: top;
+}
+.bs-manual-figure[data-shot="phone"] img {
+    width: min(100%, 300px);
+    aspect-ratio: 828 / 1240;
+}
+.bs-manual-figure[data-shot="tall"] img {
+    width: min(100%, 420px);
+    aspect-ratio: 17 / 20;
+}
+
+.bs-manual-figcaption {
+    margin: 0;
+    font-size: 10px;
+    line-height: 1.5;
+    font-weight: 500;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+.bs-manual-figcaption b {
+    font-weight: 700;
+    color: var(--accent);
+}
+
+/* Two figures side by side — stacks under the sidebar breakpoint. */
+.bs-manual-figrow {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: clamp(14px, 2.4vw, 24px);
+    margin: clamp(18px, 3vw, 28px) 0 0;
+}
+.bs-manual-figrow .bs-manual-figure {
+    margin-top: 0;
+}
+@media (max-width: 720px) {
+    .bs-manual-figrow {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
 /* ─────────────────────────────────────────────────────────────────────────
    NAVIDROME — "works with your library" integration section.
    ───────────────────────────────────────────────────────────────────────── */
@@ -4226,6 +4289,29 @@ html:has(.admin-root.paper) {
     margin: 1.6em 0;
     border: 1px solid var(--ink);
     background: var(--bg);
+}
+/* A shot taller than it is wide — a phone screen, a long scrolling panel —
+   would run to a metre of ribbon at full column width. Wrap it in
+   <figure data-shot="phone|tall"> in the markdown and it gets framed to its
+   top instead, the same treatment as the manual's figures. The frame is an
+   aspect-ratio, not a pixel height, so the crop holds at every column width. */
+.bs-prose figure {
+    margin: 1.6em 0;
+}
+.bs-prose figure img {
+    margin: 0;
+}
+.bs-prose figure[data-shot] img {
+    object-fit: cover;
+    object-position: top;
+}
+.bs-prose figure[data-shot="phone"] img {
+    width: min(100%, 300px);
+    aspect-ratio: 828 / 1240;
+}
+.bs-prose figure[data-shot="tall"] img {
+    width: min(100%, 420px);
+    aspect-ratio: 17 / 20;
 }
 /* Drop cap on the opening paragraph — vermilion, three lines tall. */
 .bs-prose > p:first-of-type::first-letter {

--- a/web/components/manual/AcousticAnalysis.tsx
+++ b/web/components/manual/AcousticAnalysis.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import ManualPage from './ManualPage';
+import ManualFigure from './ManualFigure';
 import CodeBlock from '@/components/CodeBlock';
 
 export default function AcousticAnalysis() {
@@ -28,6 +29,13 @@ export default function AcousticAnalysis() {
           Silicon). Coverage climbs on the <Link href="/admin/library">Library</Link> page
           under <strong>Acoustic analysis · bpm / key</strong>.
         </p>
+        <ManualFigure
+          src="/screenshots/admin-library.webp"
+          alt="The admin Library page, with a one-line acoustic-analysis strip reading bpm/key 99 percent, sounds-like 99 percent, vocal off, beneath the mood-and-energy tagging bar"
+          caption="Coverage lives on the Library page — one line under the tagging bar, a percentage per dimension. Expand it to start a pass or watch one run."
+          width={2732}
+          height={2048}
+        />
         <div className="bs-callout">
           <div className="bs-eyebrow">&ldquo;ENGINE OFF&rdquo;?</div>
           <p>

--- a/web/components/manual/AdminSettings.tsx
+++ b/web/components/manual/AdminSettings.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import ManualPage from './ManualPage';
+import ManualFigure from './ManualFigure';
 
 export default function AdminSettings() {
   return (
@@ -42,6 +43,13 @@ export default function AdminSettings() {
             live diagnostic view.
           </li>
         </ul>
+        <ManualFigure
+          src="/screenshots/admin-dash.webp"
+          alt="The admin Dash: the track on air with a skip button, gauges for listeners, DJ latency and TTS fallback, the queue and booth log on the left, and manual voice, segment fire pads and broadcast switches on the right"
+          caption="The Dash. The track on air and its gauges across the top, the queue and the booth log down the left, and on the right the controls that let you speak through the DJ or fire a segment on demand."
+          width={2732}
+          height={2048}
+        />
       </section>
 
       <section className="bs-section">
@@ -98,6 +106,22 @@ export default function AdminSettings() {
             and auto-DJ pick draws from it.
           </li>
         </ul>
+        <div className="bs-manual-figrow">
+          <ManualFigure
+            src="/screenshots/admin-library.webp"
+            alt="The admin Library page: a headline reading how much of the library the DJ knows, a mood-and-energy tagging progress bar, an acoustic-analysis coverage line, and a list of recently added tracks with their mood tags"
+            caption="Library — how much of the collection is tagged, what the analyzer has measured, and the recently-added tracks still waiting."
+            width={2732}
+            height={2048}
+          />
+          <ManualFigure
+            src="/screenshots/admin-schedule.webp"
+            alt="The admin Schedule page: on air, up next and after that across the top, a sentence-style form for booking a show, a shelf of saved shows, and a seven-column grid of coloured show blocks by hour"
+            caption="Schedule — the week as a grid you paint. On air, up next and after that ride along the top; empty hours run autonomously."
+            width={2732}
+            height={2048}
+          />
+        </div>
       </section>
 
       <section className="bs-section">
@@ -204,6 +228,22 @@ export default function AdminSettings() {
           calls, the mixer's status, and the most recent log lines. It's the first place
           to look if the stream stalls or the DJ goes quiet.
         </p>
+        <div className="bs-manual-figrow">
+          <ManualFigure
+            src="/screenshots/admin-stats.webp"
+            alt="The admin Stats page: listeners over the last 24 hours as a line chart with now, peak, average and low, a breakdown of top referrers and countries, and an LLM usage panel below"
+            caption="Stats — listeners over the last day, where they arrived from, and, below the fold, the model calls behind every word the DJ said."
+            width={2732}
+            height={2048}
+          />
+          <ManualFigure
+            src="/screenshots/admin-debug.webp"
+            alt="The admin Debug page: a live health strip for Icecast, Liquidsoap, the LLM, the picker and the tagger, then panels for now-playing, Icecast, the DJ's context, the redacted config with its stream mounts, TTS routing, and recent LLM calls"
+            caption="Debug — a live health strip, the exact state the DJ is reading, which mounts are up, who voices the next line, and the last hundred model calls."
+            width={2732}
+            height={2048}
+          />
+        </div>
         <p>
           Installing or updating the station rather than tuning it? That's covered in{' '}
           <Link href="/setup" className="bs-link">the setup guide</Link>.

--- a/web/components/manual/CustomSkills.tsx
+++ b/web/components/manual/CustomSkills.tsx
@@ -1,4 +1,5 @@
 import ManualPage from './ManualPage';
+import ManualFigure from './ManualFigure';
 import CodeBlock from "@/components/CodeBlock";
 
 export default function CustomSkills() {
@@ -52,6 +53,13 @@ export default function CustomSkills() {
           a <code className="bs-code-inline">tool.mjs</code> data fetcher is still added on
           disk + Rescan.
         </p>
+        <ManualFigure
+          src="/screenshots/admin-skills.webp"
+          alt="The admin Skills page: a table of skills with their briefs, cooldowns and assigned DJs, each with a Run now button and an on/off switch, above buttons for the community catalog, New skill, and Rescan"
+          caption="The admin Skills page. Custom ones carry a CUSTOM tag; each row shows its brief, its cooldown, and how many DJs may run it. Run now fires one on demand, ignoring both."
+          width={2732}
+          height={2048}
+        />
       </section>
 
       <section className="bs-section">

--- a/web/components/manual/GettingStarted.tsx
+++ b/web/components/manual/GettingStarted.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import ManualPage from './ManualPage';
+import ManualFigure from './ManualFigure';
 
 export default function GettingStarted() {
   return (
@@ -30,7 +31,8 @@ export default function GettingStarted() {
         <h2>What you're looking at.</h2>
         <p>
           The player shows the track that's playing right now (title, artist, and cover
-          art) with a waveform for the transport. Three panels slide out for the rest:
+          art) with a waveform for the transport. Panels slide out from the rail for the
+          rest:
         </p>
         <ul className="bs-list">
           <li>
@@ -44,10 +46,25 @@ export default function GettingStarted() {
             <strong>The booth</strong> — a running feed of what the DJ has been saying:
             intros, station IDs, the time, weather.
           </li>
+          <li>
+            <strong>Schedule</strong> — which show is on air and what's coming up after it.
+          </li>
         </ul>
         <p className="text-muted">
           Now-playing info refreshes every few seconds, so the player stays in step with
           the broadcast without you doing anything.
+        </p>
+        <ManualFigure
+          src="/screenshots/listen.webp"
+          alt="The Classic player face: show and weather along the top, cover art beside the track title and artist, a line from the DJ underneath, the panel rail on the right, and a waveform above the transport bar"
+          caption="The Classic face — the show, mood and weather along the top, the track on air, a line from the booth beneath it, and the panel rail down the right."
+          width={2732}
+          height={2048}
+        />
+        <p className="text-muted">
+          That's one of six faces the player can wear, and the palette icon in the corner
+          switches between them. See{' '}
+          <Link href="/manual/themes" className="bs-link">Skins &amp; Themes</Link>.
         </p>
       </section>
 

--- a/web/components/manual/HowTheDjWorks.tsx
+++ b/web/components/manual/HowTheDjWorks.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import ManualPage from './ManualPage';
+import ManualFigure from './ManualFigure';
 
 export default function HowTheDjWorks() {
   return (
@@ -58,6 +59,13 @@ export default function HowTheDjWorks() {
           shared by other stations — browse it, then install any of them from your own
           admin console.
         </p>
+        <ManualFigure
+          src="/screenshots/admin-personas.webp"
+          alt="The persona editor: avatar, on-air name, tagline and language on the left, the soul text on the right, and below them the talk-frequency and script-length sliders, a DJ mode switch, and three tone dials"
+          caption="One persona, opened up. Identity on top — name, tagline, the soul every line is written from — and the behaviour dials below: talk frequency, script length, DJ mode, and the tone knobs."
+          width={2732}
+          height={2048}
+        />
       </section>
 
       <section className="bs-section">

--- a/web/components/manual/ManualFigure.tsx
+++ b/web/components/manual/ManualFigure.tsx
@@ -1,0 +1,40 @@
+interface ManualFigureProps {
+  /** Path under /public — the shots live in public/screenshots/*.webp. */
+  src: string;
+  /** Describes the image itself, for screen readers. Distinct from the caption. */
+  alt: string;
+  /** The visible FIG. line under the frame. */
+  caption: string;
+  /** Intrinsic pixel size — reserves the box before load so nothing shifts. */
+  width: number;
+  height: number;
+  /**
+   * Shape hint for anything that isn't a landscape screen grab:
+   *  - `phone` — a handset shot, shown whole at handset width.
+   *  - `tall`  — a long scrolling panel, framed to its top so it stays legible
+   *              instead of stretching the column into a ribbon.
+   */
+  shot?: 'phone' | 'tall';
+}
+
+// A screenshot inside a manual page: thin ink frame, broadsheet caption. Server
+// component on purpose — the manual pages are static, so a figure shouldn't
+// drag a client chunk in with it (that's what components/what/Figure.tsx, the
+// animated marketing variant, is for).
+export default function ManualFigure({
+  src,
+  alt,
+  caption,
+  width,
+  height,
+  shot,
+}: ManualFigureProps) {
+  return (
+    <figure className="bs-manual-figure" data-shot={shot}>
+      <img src={src} alt={alt} width={width} height={height} loading="lazy" decoding="async" />
+      <figcaption className="bs-manual-figcaption">
+        <b>FIG.</b> {caption}
+      </figcaption>
+    </figure>
+  );
+}

--- a/web/components/manual/Observatory.tsx
+++ b/web/components/manual/Observatory.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import ManualPage from './ManualPage';
+import ManualFigure from './ManualFigure';
 
 export default function Observatory() {
   return (
@@ -42,6 +43,13 @@ export default function Observatory() {
           the energy split, the mood field, tempo and loudness histograms, a Camelot key wheel, and the
           major/minor and vocal/instrumental balance.
         </p>
+        <ManualFigure
+          src="/screenshots/observatory.webp"
+          alt="The Library Observatory: thousands of glowing points clustered into a single mass with genre names labelling each region, a rail of colour and filter controls on the left, and panels for energy, mood, tempo and loudness on the right"
+          caption="The whole library in one picture — points clustered by genre, lit by energy, with the filter rail on the left and the running read-out of whatever is in view on the right."
+          width={2732}
+          height={2048}
+        />
       </section>
 
       <section className="bs-section">
@@ -65,6 +73,14 @@ export default function Observatory() {
           track rides the URL, so you can bookmark or share a link that opens the Observatory on that exact
           star.
         </p>
+        <ManualFigure
+          src="/screenshots/observatory-track.webp"
+          alt="A track dossier: title, artist and album, then BPM, key, energy and length, the mood tags with energy and acoustic meters, the text and audio embedding heatmaps, and a Mix Next list of nearest tracks"
+          caption="The top of a track dossier — BPM, key, energy and length, then the mood tags and meters. Scrolling on gets you the embedding heatmaps and the Mix Next list."
+          width={907}
+          height={3272}
+          shot="tall"
+        />
       </section>
 
       <section className="bs-section">

--- a/web/components/manual/Overview.tsx
+++ b/web/components/manual/Overview.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import ManualPage from './ManualPage';
+import ManualFigure from './ManualFigure';
 
 const GUIDE = [
   {
@@ -96,6 +97,23 @@ export default function Overview() {
             </li>
           ))}
         </ul>
+
+        <div className="bs-manual-figrow">
+          <ManualFigure
+            src="/screenshots/listen.webp"
+            alt="The SUB/WAVE player: cover art, track title and artist, a line from the DJ, a waveform transport, and a rail of panel buttons"
+            caption="The listener's side — the player at /listen."
+            width={2732}
+            height={2048}
+          />
+          <ManualFigure
+            src="/screenshots/admin-dash.webp"
+            alt="The SUB/WAVE admin Dash: what's on air, listener and latency gauges, the queue, the booth log, and manual voice controls"
+            caption="The operator's side — the admin console at /admin."
+            width={2732}
+            height={2048}
+          />
+        </div>
       </section>
 
       <section className="bs-section">

--- a/web/components/manual/Requests.tsx
+++ b/web/components/manual/Requests.tsx
@@ -1,4 +1,5 @@
 import ManualPage from './ManualPage';
+import ManualFigure from './ManualFigure';
 
 export default function Requests() {
   return (
@@ -21,6 +22,14 @@ export default function Requests() {
           <li><strong>An artist</strong> — &ldquo;something by Aphex Twin.&rdquo;</li>
           <li><strong>A mood</strong> — &ldquo;something for a rainy Sunday morning.&rdquo;</li>
         </ul>
+        <ManualFigure
+          src="/screenshots/player-request-song.webp"
+          alt="The request panel on a phone: a request slip headed LINE OPEN with a written note and a signature, four suggestion chips, and a SEND TO THE BOOTH button"
+          caption="The request slip. The chips underneath fill it in for you — more like this, something for right now, or surprise me."
+          width={828}
+          height={1792}
+          shot="phone"
+        />
       </section>
 
       <section className="bs-section">

--- a/web/components/manual/Themes.tsx
+++ b/web/components/manual/Themes.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import ManualPage from './ManualPage';
+import ManualFigure from './ManualFigure';
 import CodeBlock from '@/components/CodeBlock';
 
 const EXAMPLE_THEME = `{
@@ -94,6 +95,22 @@ export default function Themes() {
             </li>
           ))}
         </ul>
+        <div className="bs-manual-figrow">
+          <ManualFigure
+            src="/screenshots/listen.webp"
+            alt="The Classic skin: a masthead across the top, cover art beside the track title and artist, a line from the DJ, a panel rail on the right, and a waveform above the transport bar"
+            caption="Classic — masthead, centre stage, waveform, transport deck."
+            width={2732}
+            height={2048}
+          />
+          <ManualFigure
+            src="/screenshots/listen-unit.webp"
+            alt="The Unit SW-9 skin: a milled-aluminium panel of soft-touch keys and weighted knobs beside a black dot-matrix window showing the track, elapsed time and a level display"
+            caption="Unit SW-9 — the same broadcast as a tabletop receiver, every live fact on one dot-matrix window."
+            width={2732}
+            height={2048}
+          />
+        </div>
         <div className="bs-callout">
           <div className="bs-eyebrow">SAME STATION, DIFFERENT ROOM</div>
           <p>

--- a/web/content/news/2026-05-12-what-is-subwave.md
+++ b/web/content/news/2026-05-12-what-is-subwave.md
@@ -25,6 +25,8 @@ That's the whole machine.
 
 The DJ pulls from what you actually own, so the station sounds like your taste, not an algorithm's idea of it.
 
+![The player: the show, mood and weather along the top, cover art beside the track title and artist, a line the DJ just read underneath, a panel rail on the right, and a waveform above the transport bar](/screenshots/listen.webp)
+
 ## Tune in
 
 Open the player and hit play. If you're setting up your own, the [setup guide](/setup) gets you on air in about ten minutes. Everything past the first three settings is configured from the admin screen: the DJ's voice, its personality, how chatty it is, the look of the player.

--- a/web/content/news/2026-05-25-request-a-track.md
+++ b/web/content/news/2026-05-25-request-a-track.md
@@ -19,6 +19,10 @@ Open the request panel in the player and type what you're after. You don't need 
 
 Send it. The DJ reads what you meant (the artist, the mood, the intent), finds candidates in your library, and lines one up.
 
+<figure data-shot="phone">
+  <img src="/screenshots/player-request-song.webp" alt="The request panel on a phone: a slip headed LINE OPEN with a handwritten-looking note and a signature underneath, four suggestion chips reading more like this, drive home vibes, overcast mood and surprise me, and a red SEND TO THE BOOTH button." />
+</figure>
+
 ## What happens next
 
 Your pick joins the queue and plays for everyone, because there's only one stream. When it comes on, the DJ usually says a quick line introducing it, sometimes nodding to the request itself. It won't cut off the current song, because tracks always finish, so think of it as leaning over and asking the DJ, not grabbing the aux cord.

--- a/web/content/news/2026-05-31-custom-dj-skills.md
+++ b/web/content/news/2026-05-31-custom-dj-skills.md
@@ -26,6 +26,8 @@ state/skills/
 
 There's a ready-made example in the repo at `docs/examples/skills/moon-phase`. Copy it into `state/skills/`, open the admin Skills page, and hit Rescan. Your skill shows up in the list, ready to toggle on.
 
+![The admin Skills page: a table of skills, each with its brief, cooldown and how many DJs may run it, a Run now button and an on/off switch. The ones written by hand carry a CUSTOM tag next to their name](/screenshots/admin-skills.webp)
+
 Want it to react to real data? Add a `tool.mjs` and the DJ can check something live, like tonight's moon or the surf report, before it opens its mouth.
 
 ## The ones that ship are yours too

--- a/web/content/news/2026-06-01-dj-mode-mixes.md
+++ b/web/content/news/2026-06-01-dj-mode-mixes.md
@@ -30,6 +30,8 @@ Watch the "acoustic analysis · bpm/key" meter on the Library tab in admin fill 
 
 Then turn it on. Open admin, go to Personas, and pick a persona. Switch on its DJ mode toggle, the one that reads "Work the desk like a real DJ." It's set per persona, so one host can mix and back-announce while another stays a quiet between-track narrator. Save when you're done.
 
+![A persona open for editing: name, tagline and soul at the top, and below them the behaviour controls — a talk-frequency slider, a script-length slider, and the DJ mode switch labelled "Work the desk like a real DJ"](/screenshots/admin-personas.webp)
+
 For the riser flourishes, open Settings, go to the Sound FX tab, and leave "Enable sound effects" on. They fire sparingly, only on the transitions that earn them.
 
 ## Why it helps

--- a/web/content/news/2026-06-06-your-dj-knows-your-library.md
+++ b/web/content/news/2026-06-06-your-dj-knows-your-library.md
@@ -10,6 +10,8 @@ Your DJ can only play a track once it knows that track's mood and energy. Workin
 
 ## What's new
 
+![The rebuilt Library page: a headline reading how much of the library the DJ knows, a mood-and-energy progress bar with the tagged count under it, a line of acoustic-analysis coverage, a Start tagging button, and a list of recently added tracks showing their mood tags](/screenshots/admin-library.webp)
+
 The old page had two control strips that both talked about tagging, and neither said why it mattered. Now there's one panel. It opens with a plain line, "Your DJ knows 92% of your library", and under that sits the count of tagged tracks, how many still need it, and one button to close the gap. Every row shows its moods and energy as small tags, so you can see what tagging actually produces. Browse filters by mood, energy, genre, and year.
 
 ## How to use it

--- a/web/content/news/2026-06-13-see-the-shape-of-your-library.md
+++ b/web/content/news/2026-06-13-see-the-shape-of-your-library.md
@@ -31,7 +31,9 @@ Open admin and click Observatory in the nav, or go straight to:
 
 Click any point to open its dossier: BPM, key, energy, loudness, its mood and last.fm tags, and the track's text and audio fingerprints. There's a song-shape timeline too, charting the track end to end: its pace curve, where the intro ends, the sections, the vocal passages, and how the key moves over time. Under that sits Mix Next, the closest tracks in vector space, with the links drawn back onto the map. Recolour the map by energy, confidence, tag source, analysis, loudness, pace, or voice from the left rail, and filter by scene, mood, or tag source.
 
-![A track dossier: BPM, key, energy, mood tags, acoustic meters, the text and audio embedding fingerprints, and the nearest tracks in vector space](/screenshots/observatory-track.webp)
+<figure data-shot="tall">
+  <img src="/screenshots/observatory-track.webp" alt="The top of a track dossier: title, artist and album, then BPM, key, energy and length, the mood tags and their energy and acoustic meters. Below the crop sit the text and audio embedding fingerprints and the nearest tracks in vector space." />
+</figure>
 
 Big library? Use the MAP SIZE control in the rail. It draws up to 25,000 tracks by default and goes to 100,000. Past that it shows an even sample across genres, so the shape stays honest.
 

--- a/web/content/news/2026-07-04-pass-a-skill-along.md
+++ b/web/content/news/2026-07-04-pass-a-skill-along.md
@@ -11,6 +11,8 @@ You spent three evenings getting a skill's brief just right, and now the DJ land
 
 ## Take one from the catalog
 
+![The admin Skills page, with a Community button carrying a count of available skills sitting next to New skill above the list. Two rows in the list are tagged CUSTOM](/screenshots/admin-skills.webp)
+
 The admin Skills page has a Community button, next to New skill. It opens a catalog of skills other operators have contributed, shipped inside the controller image, with a credit line under each one (who wrote it, when it landed). Hit Install and it copies into `state/skills/` like any skill of your own. It arrives switched off, so you can read the brief before it goes on air. The catalog only carries prompts, never code, so installing one runs nothing.
 
 ## Put yours in

--- a/web/content/news/2026-07-13-give-your-player-a-new-face.md
+++ b/web/content/news/2026-07-13-give-your-player-a-new-face.md
@@ -18,6 +18,8 @@ A skin is a full-screen layout drawn on the same live data. The stream underneat
 - Subamp is a compact modular player, with the deck, booth and log stacked like it's 1998.
 - TTY is the station as a live process, all panes and a status line where everything tails.
 
+![The Classic skin: a masthead across the top carrying the show, mood and weather, cover art beside the track title and artist, a line from the booth underneath, the panel rail down the right, and a waveform above the transport bar](/screenshots/listen.webp)
+
 ## How to use it
 
 You set the station default in admin. Open Settings, then Skin & Themes, and pick one under Player skin. It applies live on the next poll, no restart.

--- a/web/content/news/2026-07-27-subwave-is-one-point-oh.md
+++ b/web/content/news/2026-07-27-subwave-is-one-point-oh.md
@@ -11,7 +11,9 @@ The version counter finally rolled over. Three months and forty-eight releases a
 
 ## What's new
 
-The release itself is a normal drop wearing a big number. The player has a new face, Unit SW-9, which replaces the old Spool skin (find it in the palette menu). The all-in-one image now runs acoustic analysis on your GPU, which got its own dispatch yesterday. And stem blends no longer demand a full re-analysis of your library. Turn the stem cache on and it backfills on its own, pass by pass, with a disk budget you can set under Settings → Transitions.
+The release itself is a normal drop wearing a big number. The player has a new face, Unit SW-9, which replaces the old Spool skin (find it in the palette menu).
+
+![The Unit SW-9 skin: a milled-aluminium panel of soft-touch keys and weighted knobs on the left, a dot-matrix grille showing the cover art, and a black window on the right reading the track title, artist, elapsed time and a level display](/screenshots/listen-unit.webp) The all-in-one image now runs acoustic analysis on your GPU, which got its own dispatch yesterday. And stem blends no longer demand a full re-analysis of your library. Turn the stem cache on and it backfills on its own, pass by pass, with a disk budget you can set under Settings → Transitions.
 
 The bigger news is the number itself. From 1.0 on, the surfaces you build a station on are stable. Your `.env`, your `state/settings.json`, the layout of the `state/` folder and the compose files are covered by semver now. If a future release ever has to break one of them, it will be a major version with a migration path, not a surprise inside a minor bump.
 


### PR DESCRIPTION
The manual and the news posts were text-only apart from two dispatches — even though `web/public/screenshots/` already carried a set of current captures that only the `/what` marketing page was using. This puts them to work on both surfaces.

## The manual — 12 figures across 9 pages

| Page | Figures |
|---|---|
| Overview | player + admin dash, two-up — the "both sides of the dial" line in the intro |
| Getting Started | the Classic player face |
| Making Requests | the request slip (phone-framed) |
| How the DJ Works | the persona editor — soul, frequency, tone dials |
| Custom Skills | the admin Skills table |
| Admin & Settings | Dash; Library + Schedule; Stats + Debug |
| Library Observatory | the map; a track dossier |
| Skins & Themes | Classic + Unit SW-9, which is the page's actual argument |
| Acoustic Analysis | the Library coverage strip the copy already points at |

## The dispatches — 8 posts

*What SUB/WAVE actually is* (the player) · *Ask the DJ for a song* (the request slip) · *Teach your DJ a new trick* and *Pass a skill to another station* (the Skills page) · *Your DJ now mixes the tracks* (the persona editor, showing the "Work the desk like a real DJ" switch the post tells you to find) · *Your DJ knows your library* (the rebuilt Library page) · *Give your player a new face* (Classic, the first skin it lists) · *SUB/WAVE is 1.0* (Unit SW-9, named in the post).

## How it's built

`components/manual/ManualFigure.tsx` is a **server** component — the manual pages are static, so a figure shouldn't drag a client chunk in with it, which is what the animated `components/what/Figure.tsx` does. Thin ink frame, broadsheet `FIG.` caption. News keeps plain markdown images with alt text and no visible caption, matching what the two already-illustrated posts did: a dispatch reads as prose, not reference material.

Anything taller than it is wide is framed to its top by **aspect-ratio, not a pixel height** — a fixed height would start cropping the sides once `object-fit: cover` had to scale up to fill it. Two variants shared by both surfaces: `phone` for a handset shot, `tall` for a long scrolling panel. News reaches them through a `<figure data-shot>` wrapper, which the markdown renderer already passes through (first-party content, see the comment in `app/news/[slug]/page.tsx`).

## Two things fixed along the way

- **A 2,866px ribbon.** *See the shape of your library* was rendering the track dossier at 794 × 2866 mid-article. The `tall` framing brings it to 418 × 492.
- **A miscount.** Getting Started said "Three panels slide out" where `ClassicSkin.tsx` has four. The screenshot made the gap obvious — Schedule gets its bullet and the count goes.

## Not done

Seven manual pages and most dispatches have no figure, because no existing asset honestly illustrates them: Listen With / Agent in the booth / the GPU and Unraid posts (no matching capture), *Two new pages in the console* (Imaging and Moods are only slivers in a sidebar in the shots I have), *Bring your own LLM* (the LLM usage panel is below the fold in the Stats capture). Those want new captures rather than a loosely-related screen.

## Verified

- `npm run lint` clean in `web/` (only the three pre-existing `any` warnings in `playlist-builder/generate.ts`)
- Every touched page rendered and inspected with Playwright at **1280px and 420px** — the crop holds at both widths
