### PR TITLE
fix(web): keep the landing page from going blank on a station tab swap

### DIFF
--- a/web/components/player/PlayerShell.tsx
+++ b/web/components/player/PlayerShell.tsx
@@ -11,7 +11,7 @@
 // boots straight into the right skin; contained showcases follow the remote
 // station strictly (no override, no cache poisoning).
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useThemeSwitcher } from '@/components/ThemeProvider';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
@@ -177,7 +177,20 @@ function ShellChrome({ skin, contained }: { skin?: SkinComponent; contained: boo
         ) : (
           <>
             <audio ref={audioRef} crossOrigin="anonymous" preload="auto" />
-            <Skin contained={contained} portalNode={portalNode} />
+            {/* Skins are next/dynamic chunks with no boundary of their own, so
+                a face this build hasn't fetched yet SUSPENDS on first render.
+                Without this boundary the suspension escapes to the nearest one
+                up the tree — on the landing page that's the whole page, which
+                React then hides and re-reveals: every motion element in the
+                broadsheet gets its `initial` re-applied without its mount
+                animation re-running, and the page stays at opacity 0 for good
+                (tabbing to a station whose ui.skin isn't the loaded one blanked
+                the entire landing page). Keeping it here also means the swap
+                never disturbs the <audio> element above it — playback rides
+                through a skin change. */}
+            <Suspense fallback={null}>
+              <Skin contained={contained} portalNode={portalNode} />
+            </Suspense>
             {/* Same prompt, overlaid, when only the stream is locked —
                 shell-level so every skin gets it without changes. */}
             <StationPasswordGate phase={auth.phase} unlock={auth.unlock} solid={false} />


### PR DESCRIPTION
## The bug

On the landing page, clicking the **Klair Radio** or **Brisflix Radio** station tab blanks the entire page. It never recovers — clicking back to a working station leaves it blank too. Nothing is logged to the console.

## Why those two tabs

They are exactly the two directory stations whose operator picked a non-`classic` player skin:

| Station | `ui.skin` | tab |
|---|---|---|
| SUB/WAVE, 2618 Home Radio, FoggyMtnDrifter FM | `classic` | fine |
| Klair Radio | `drift` | blanks the page |
| Brisflix Radio | `subamp` | blanks the page |
| WHIG, The Hig | `tty` | would blank it too, when live |

## Mechanism

Skins are registered as `next/dynamic` chunks with no `loading` (`components/skins/index.ts`), so they carry **no Suspense boundary of their own**. Tabbing to a station whose skin this page hasn't fetched makes `<Skin />` suspend, and the suspension escapes to the nearest boundary up the tree — on `/landing`, that's the page.

React hides that tree and re-reveals it when the chunk lands. On the way back, every `EditorialReveal` (`m.section initial={{opacity: 0, y: 12}}`) has its `initial` re-applied *without* its mount animation re-running, so all nine sections are left at `opacity: 0` for good. The DOM is intact the whole time — the page is just invisible, which is why there's no error.

## Fix

Wrap `<Skin />` in its own `<Suspense>` inside `PlayerShell`. The suspension now stops at the player frame instead of the page. The `<audio>` element stays above the boundary, so playback rides through a skin change untouched.

This also covers the full-page player, where the `s` skin-cycle shortcut hits the same lazy-chunk path.

## Verification

Dev builds never showed this — every skin chunk is already loaded there. Repro and verification were done against a production build (`npm run build && next start`), driving a real visible Chrome and reading the computed opacity of `main > section`:

**Before**
```
baseline        ["1","1","1","1"]  getsubwave.com
after Foggy     ["1","1","1","1"]  (classic — fine)
after 2618      ["1","1","1","1"]  (classic — fine)
after Klair     ["0","0","0","0"]  (drift  — blank)
after Brisflix  ["0","0","0","0"]  (subamp — blank)
after SUB/WAVE  ["0","0","0","0"]  (never recovers)
```

**After**
```
baseline        ["1","1","1","1"]
after Foggy     ["1","1","1","1"]
after 2618      ["1","1","1","1"]
after Klair     ["1","1","1","1"]
after Brisflix  ["1","1","1","1"]
after SUB/WAVE  ["1","1","1","1"]
```

Both `drift` and `subamp` render inside the frame after the swap (frame text confirms the Klair and Brisflix faces). `web`: `npm run lint` clean (0 errors; 3 pre-existing `no-explicit-any` warnings in `admin/playlist-builder/generate.ts`, untouched).