### PR TITLE
feat(admin): move the show takeover from the Rundown to the dash

### DIFF
--- a/web/components/admin/DashPanel.tsx
+++ b/web/components/admin/DashPanel.tsx
@@ -52,6 +52,7 @@ import StationHeader, { type HealthMetrics } from './StationHeader';
 import { cn } from '../../lib/cn';
 import { LikesCard } from './dash/LikesCard';
 import { RequestsCard } from './dash/RequestsCard';
+import { TakeoverCard } from './dash/TakeoverCard';
 import { BoothTurnText, SegmentButton, SortableTh, ToggleRow, classTone } from './dash/bits';
 import type {
   ActResponse,
@@ -677,6 +678,10 @@ export default function DashPanel() {
               })}
             </div>
           </Card>
+
+          {/* Live show control sits with the other on-air actions — the pads
+              above fire a segment now, this puts a whole show on now. */}
+          <TakeoverCard tz={tz} locale={locale} />
 
           <Card title="Broadcast">
             <div className="grid gap-2.5">

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -10,8 +10,9 @@
 // show list) — the personas pattern: click a show to open it, edit it in place.
 // The weekly plan itself lives on its own full-screen page now — The Rundown
 // at /admin/shows/schedule (components/admin/schedule/) — which owns the
-// board, the on-air listing, takeovers, and PUT /schedule. This page still
-// loads the schedule read-only for the per-show hours-a-week counts.
+// board, the on-air listing, and PUT /schedule. This page still loads the
+// schedule read-only for the per-show hours-a-week counts. Putting a show on
+// the air RIGHT NOW is a takeover, and that lives on the dash.
 import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { Users, Share2 } from 'lucide-react';
@@ -366,8 +367,8 @@ export default function ShowsPanel() {
             </div>
             <div className="mt-1 max-w-[62ch] text-[11px] leading-[1.6] text-muted">
               This page is the roster — each show&apos;s name, host, brief, and
-              sound. The Rundown is the week itself: the board, the on-air
-              listing, and takeovers, hour by hour.
+              sound. The Rundown is the week itself: the board and the on-air
+              listing, hour by hour.
             </div>
           </div>
           <div className="flex flex-none flex-col items-start gap-2.5 sm:items-end">

--- a/web/components/admin/dash/TakeoverCard.tsx
+++ b/web/components/admin/dash/TakeoverCard.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+// Show takeover (#930) — pin one show over the weekly grid for a bounded
+// window, after which the schedule picks up again on its own.
+//
+// This lived as a strip on the Rundown, but it is a live on-air action rather
+// than a piece of programming the week: it belongs beside the manual mic and
+// the segment pads, and its old home spent a row of chrome above a 24-hour
+// board on every load for something reached a few times a month. The Rundown
+// still SHOWS a live takeover — its Now band would otherwise name the show the
+// grid says is on air, which the pin outranks — and links here to change it.
+//
+// Part of the dash/ split — see ../DashPanel.tsx. Unlike the other dash cards
+// this one fetches for itself: GET /schedule and the two /schedule/override
+// mutations are the only calls on this screen no other card wants, so routing
+// them through DashPanel's poll would buy nothing.
+
+import type { ChangeEvent } from 'react';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useAdminAuth } from '../../../lib/adminAuth';
+import { notify, errorMessage } from '../../../lib/notify';
+import { fmtClock } from '../../../lib/format';
+import type { StationLocale } from '../../../lib/types';
+import { cn } from '../../../lib/cn';
+import { Card, Btn, Pill, Seg } from '../ui';
+import { ColorChip, SlotMenu } from '../schedule/bits';
+import { SHOW_COLORS } from '../schedule/lib';
+
+/** One show pinned over the grid until `expiresAt` (epoch ms). */
+interface ScheduleOverride {
+  showId: string;
+  startedAt: number;
+  expiresAt: number;
+}
+
+/** The slice of GET /schedule's show list this card needs. */
+interface TakeoverShow {
+  id: string;
+  name: string;
+}
+
+// Mirror the controller's OVERRIDE_MIN/MAX_MINUTES (settings.ts).
+const MIN_MINUTES = 15;
+const MAX_MINUTES = 720;
+const PRESETS = [
+  { minutes: 60, label: '1h' },
+  { minutes: 120, label: '2h' },
+  { minutes: 180, label: '3h' },
+];
+
+export function TakeoverCard({ tz, locale }: { tz?: string; locale?: StationLocale }) {
+  const { adminFetch, needsAuth, hydrated } = useAdminAuth();
+  const [shows, setShows] = useState<TakeoverShow[]>([]);
+  const [override, setOverride] = useState<ScheduleOverride | null>(null);
+  const [pinShowId, setPinShowId] = useState('');
+  const [minutes, setMinutes] = useState(60);
+  const [busy, setBusy] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+
+  // GET /schedule carries both halves of this card — the show roster and the
+  // pin in force (expired or dangling ones already report as null). The 30s
+  // beat is slow enough to disappear next to the dash's 3s live poll, and it
+  // doubles as the clock behind "min left", so a takeover pinned from another
+  // tab or lapsing on its own lands here without a reload.
+  useEffect(() => {
+    if (!hydrated || needsAuth) return;
+    let cancelled = false;
+    const tick = async () => {
+      setNow(Date.now());
+      try {
+        const r = await adminFetch('/schedule');
+        if (!r.ok || cancelled) return;
+        const j = (await r.json()) as { shows?: TakeoverShow[]; override?: ScheduleOverride | null };
+        setShows(
+          Array.isArray(j.shows)
+            ? j.shows.filter(s => s && typeof s.id === 'string' && s.id)
+            : [],
+        );
+        setOverride(j.override ?? null);
+      } catch {}
+    };
+    tick();
+    const id = setInterval(tick, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [hydrated, needsAuth]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Same index-into-the-roster colour the board and the shows page paint with,
+  // so a pinned show wears the swatch the operator already knows it by.
+  const colorOf = (id: string): string => {
+    const idx = shows.findIndex(s => s.id === id);
+    return idx >= 0 ? (SHOW_COLORS[idx % SHOW_COLORS.length] ?? 'transparent') : 'transparent';
+  };
+  const showById = (id: string) => shows.find(s => s.id === id) ?? null;
+
+  const live = override && override.expiresAt > now ? override : null;
+  const pinned = live ? showById(live.showId) : null;
+  const minutesLeft = live ? Math.max(1, Math.ceil((live.expiresAt - now) / 60_000)) : 0;
+
+  const pin = async () => {
+    if (!pinShowId) return;
+    setBusy(true);
+    try {
+      const r = await adminFetch('/schedule/override', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ showId: pinShowId, minutes }),
+      });
+      const j = (await r.json().catch(() => ({}))) as { error?: string; override?: ScheduleOverride };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      setOverride(j.override ?? null);
+      setNow(Date.now());
+      const name = showById(pinShowId)?.name || 'show';
+      notify.ok(`“${name}” takes over — the switch airs on the next track.`);
+    } catch (e) {
+      notify.err(errorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const cancel = async () => {
+    setBusy(true);
+    try {
+      const r = await adminFetch('/schedule/override', { method: 'DELETE' });
+      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      setOverride(null);
+      notify.ok('Takeover cancelled — back to the weekly schedule.');
+    } catch (e) {
+      notify.err(errorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onAir = !!(live && pinned);
+
+  return (
+    <Card
+      title="Takeover"
+      // No sub while one is live: the pill and the block below both say it, and
+      // a third line of the same news pushes the header onto two rows.
+      sub={onAir ? undefined : 'jump a show to the front'}
+      // A pin outranks the whole week, so a live one wants to catch the eye of
+      // an operator scrolling past — but softly: the tinted block and the
+      // on-air pill inside already say it, and a solid vermilion ring shouted
+      // over every other card on the dash. The ring is a box-shadow rather
+      // than a border because `.admin-root .card` owns the border at a higher
+      // specificity than any utility class can beat.
+      className={cn(onAir && 'shadow-[0_0_0_2px_color-mix(in_oklab,var(--accent)_28%,transparent)]')}
+      right={
+        <span className="flex items-center gap-2">
+          {onAir && (
+            <Pill tone="accent" dot>
+              on air
+            </Pill>
+          )}
+          <Link
+            href="/admin/shows/schedule"
+            className="inline-flex min-h-9 items-center text-[9px] font-bold tracking-[0.2em] text-muted uppercase hover:text-ink sm:min-h-0"
+          >
+            the week →
+          </Link>
+        </span>
+      }
+    >
+      {live && pinned ? (
+        <div className="grid gap-2.5">
+          <div className="grid gap-1 border border-[color-mix(in_oklab,var(--accent)_35%,transparent)] bg-[var(--accent-soft)] px-2.5 py-2">
+            <div className="flex items-baseline gap-2">
+              <ColorChip color={colorOf(pinned.id)} className="size-[11px] self-center" />
+              <span className="min-w-0 truncate text-[13px] font-bold text-ink">{pinned.name}</span>
+              <span className="mono-num ml-auto flex-none text-[10px] whitespace-nowrap text-muted">
+                ends {fmtClock(live.expiresAt, tz, locale)}
+              </span>
+            </div>
+            <div className="text-[10px] text-muted">
+              on air over the schedule · {minutesLeft} min left
+            </div>
+          </div>
+          <Btn sm className="w-full" disabled={busy} onClick={cancel}>
+            {busy ? 'cancelling…' : 'Cancel takeover'}
+          </Btn>
+        </div>
+      ) : shows.length === 0 ? (
+        <div className="text-muted italic">
+          no shows to pin —{' '}
+          <Link href="/admin/shows" className="underline hover:text-ink">
+            build one first
+          </Link>
+        </div>
+      ) : (
+        <div className="grid gap-2.5">
+          <SlotMenu
+            ariaLabel="Pin a show"
+            // justify-self, not self-start: the grid stretches its items across
+            // the column, and a slot underlined the full width of the card
+            // reads as a text field rather than a value you pick. No chip until
+            // a show is chosen — an empty one is the board's SILENT swatch, and
+            // it lands here looking like an unticked checkbox.
+            className="min-h-9 justify-self-start text-[12px] sm:min-h-0"
+            label={showById(pinShowId)?.name ?? 'Pin a show…'}
+            chipColor={pinShowId ? colorOf(pinShowId) : undefined}
+            options={shows.map(s => ({ key: s.id, label: s.name, chipColor: colorOf(s.id) }))}
+            onSelect={setPinShowId}
+          />
+          <div className="flex flex-wrap items-center gap-2.5">
+            {/* The presets are the whole control for most pins; the field is
+                the escape hatch, and a typed value simply lights no preset. */}
+            <Seg
+              value={String(minutes)}
+              options={PRESETS.map(p => ({ id: String(p.minutes), label: p.label }))}
+              onChange={id => setMinutes(Number(id))}
+            />
+            <label className="flex items-baseline gap-1.5 border border-separator-strong px-2 py-[9px] sm:py-1">
+              <input
+                type="number"
+                min={MIN_MINUTES}
+                max={MAX_MINUTES}
+                value={minutes}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                  const v = Number(e.target.value);
+                  if (Number.isFinite(v)) setMinutes(Math.round(v));
+                }}
+                aria-label="Takeover minutes"
+                className="w-11 [appearance:textfield] border-0 bg-transparent p-0 text-right font-mono text-[11px] font-bold text-ink outline-none"
+              />
+              <span className="caption">min</span>
+            </label>
+          </div>
+          <Btn
+            tone="accent"
+            sm
+            className="w-full"
+            disabled={busy || !pinShowId || minutes < MIN_MINUTES || minutes > MAX_MINUTES}
+            onClick={pin}
+          >
+            {busy ? 'pinning…' : 'Pin to air →'}
+          </Btn>
+          <div className="text-[10px] text-muted">
+            the switch airs on the next track · the schedule picks up again after
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/web/components/admin/schedule/SchedulePanel.tsx
+++ b/web/components/admin/schedule/SchedulePanel.tsx
@@ -1,18 +1,24 @@
 'use client';
 
 // The Rundown — /admin/shows/schedule. The dedicated full-screen show-plan
-// view: a live header, the On air / Up next / After that band with the
-// takeover control, the full-width board (7 × 24 kanban), and the order desk
-// beneath it with the sentence-based order editor.
+// view: a live header, the On air / Up next / After that band, the full-width
+// board (7 × 24 kanban), and the order desk beneath it with the sentence-based
+// order editor.
 //
 // The data model is unchanged: the controller's 7×24 `schedule` grid from
 // GET /settings, persisted with PUT /schedule ("Save the week"). Every edit
 // on this screen — sentence editor, board clicks (silent slot books a show,
 // a card's × takes one off the air), drag-and-drop, suggestions — is a local
-// range write until the week is saved. The takeover strip drives the same
-// /schedule/override endpoints the shows page used (#930).
+// range write until the week is saved.
+//
+// Takeovers (#930) are NOT part of this screen — pinning, cancelling and the
+// countdown all live on the dash (components/admin/dash/TakeoverCard): putting
+// a show on the air right now is a live on-air action, not a way of
+// programming the week, and its old strip here cost a row of chrome above a
+// 24-hour board on every load. The one thing that stays is the READ of the
+// pin in force: it outranks the grid in the controller's resolveActiveShow, so
+// the On air cell would otherwise name a show that is not on the air.
 
-import type { ChangeEvent } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -33,7 +39,7 @@ import Board from './Board';
 import SaveBar from './SaveBar';
 import EditorBand, { LineEditor } from './EditorBand';
 import type { EditorLine, Suggestion } from './EditorBand';
-import { ColorChip, Mu, SegBtn, SlotMenu } from './bits';
+import { ColorChip, Mu } from './bits';
 import type { Block, Schedule, ScheduleShow } from './lib';
 import {
   DAYS, SHOW_COLORS, blockAhead, blockAt, bookedHours, cloneWeek, dayBlocks,
@@ -43,15 +49,6 @@ import {
 
 /** The airtime-bar tick — hours a show "should" get in a week. */
 const WEEKLY_TARGET = 12;
-
-// Mirror the controller's OVERRIDE_MIN/MAX_MINUTES (settings.ts).
-const PIN_MIN_MINUTES = 15;
-const PIN_MAX_MINUTES = 720;
-const PIN_PRESETS = [
-  { minutes: 60, label: '1h' },
-  { minutes: 120, label: '2h' },
-  { minutes: 180, label: '3h' },
-];
 
 interface Persona {
   id: string;
@@ -134,16 +131,9 @@ export default function SchedulePanel() {
   // leave guard below); null when nothing is pending.
   const [pendingHref, setPendingHref] = useState<string | null>(null);
 
-  // Takeover (#930).
+  // The live takeover (#930), for the Now band's read of what is actually on
+  // air. Pinning and cancelling happen on the dash.
   const [override, setOverride] = useState<ScheduleOverride | null>(null);
-  const [pinShowId, setPinShowId] = useState('');
-  const [pinMinutes, setPinMinutes] = useState(60);
-  const [pinBusy, setPinBusy] = useState(false);
-  // The takeover controls run ~430px of dropdown, presets, minutes and button
-  // for something reached a few times a month, and they sit between the header
-  // and the board on every load. Collapsed to one line until asked for; a live
-  // takeover always renders in full.
-  const [takeoverOpen, setTakeoverOpen] = useState(false);
 
   useEffect(() => {
     const id = setInterval(() => setNow(new Date()), 1000);
@@ -407,40 +397,6 @@ export default function SchedulePanel() {
     router.push(href);
   };
 
-  // ── takeover ─────────────────────────────────────────────────────────────
-  const pinShow = async () => {
-    if (!pinShowId) return;
-    setPinBusy(true);
-    try {
-      const r = await adminFetch('/schedule/override', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ showId: pinShowId, minutes: pinMinutes }),
-      });
-      const j = (await r.json().catch(() => ({}))) as { error?: string; override?: ScheduleOverride };
-      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      setOverride(j.override ?? null);
-      setTakeoverOpen(false);
-      const name = showById(pinShowId)?.name || 'show';
-      notify.ok(`“${name}” takes over — the switch airs on the next track.`);
-    } catch (e) {
-      notify.err(errorMessage(e));
-    } finally { setPinBusy(false); }
-  };
-
-  const cancelPin = async () => {
-    setPinBusy(true);
-    try {
-      const r = await adminFetch('/schedule/override', { method: 'DELETE' });
-      const j = (await r.json().catch(() => ({}))) as { error?: string };
-      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
-      setOverride(null);
-      notify.ok('Takeover cancelled — back to the weekly schedule.');
-    } catch (e) {
-      notify.err(errorMessage(e));
-    } finally { setPinBusy(false); }
-  };
-
   // ── suggestions ──────────────────────────────────────────────────────────
   const suggestions: Suggestion[] = useMemo(() => {
     if (!schedule) return [];
@@ -643,8 +599,8 @@ export default function SchedulePanel() {
             name={showById(nextBlock.showId)?.name ?? 'Nobody in the chair'}
             color={nextBlock.showId ? colorOf(nextBlock.showId) : null}
             meta={metaOf(nextBlock.showId)}
-            // Hiding "After that" makes this the last cell a phone shows, and
-            // its own rule would double up against the takeover strip's.
+            // Hiding "After that" makes this the last cell a phone shows, so
+            // its own rule would double up against the band's own bottom edge.
             className="max-sm:border-b-0"
           />
           <NowCell
@@ -662,107 +618,6 @@ export default function SchedulePanel() {
           />
         </div>
 
-        {/* Takeover strip */}
-        <div className="flex flex-wrap items-center gap-x-3.5 gap-y-2 border-t border-separator-strong bg-[color-mix(in_oklab,var(--ink)_5%,var(--page-bg))] px-5 py-[11px] sm:px-[22px]">
-          <span className="eyebrow flex-none text-ink">Takeover</span>
-          {/* Truncated to "…THE SCHEDULE PICKS…" on a phone, which is noise
-              rather than explanation — the Pin button and its own controls say
-              the rest. */}
-          <Mu className="hidden min-w-0 flex-1 truncate text-[9px] sm:block">
-            Jump a show to the front of the queue — the schedule picks up again after
-          </Mu>
-          {/* Full-width + wrapping on a phone only once there is something to
-              wrap: expanded, the controls run ~430px and the Pin button would
-              fall off the screen. Collapsed it is one button, and giving that
-              a row of its own is how a monthly action came to cost the same
-              vertical space as an hour of the week. */}
-          <div className={cn(
-            'ml-auto flex flex-none flex-wrap items-center gap-2.5 sm:w-auto sm:flex-nowrap',
-            takeoverOpen || liveOverride ? 'w-full' : 'w-auto',
-          )}>
-            {!liveOverride && !takeoverOpen ? (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="min-h-9 sm:min-h-0"
-                onClick={() => setTakeoverOpen(true)}
-              >
-                Pin a show…
-              </Button>
-            ) : liveOverride && pinnedShow ? (
-              <>
-                <ColorChip color={colorOf(pinnedShow.id)} />
-                <span className="text-[13px] font-bold text-ink">{pinnedShow.name}</span>
-                <Mu className="text-[9px]">
-                  ends {fmtClock(liveOverride.expiresAt, tz, locale)} ·{' '}
-                  {Math.max(1, Math.ceil((liveOverride.expiresAt - now.getTime()) / 60_000))} min left
-                </Mu>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="min-h-9 sm:min-h-0"
-                  onClick={cancelPin}
-                  disabled={pinBusy}
-                >
-                  {pinBusy ? 'Cancelling…' : 'Cancel takeover'}
-                </Button>
-              </>
-            ) : (
-              <>
-                <SlotMenu
-                  ariaLabel="Pin a show"
-                  // Reads as a field here (not a word in a sentence), so it can
-                  // carry the same phone tap height as the rest of the strip.
-                  className="min-h-9 text-[12px] sm:min-h-0"
-                  label={showById(pinShowId)?.name ?? 'Pin a show…'}
-                  options={shows.map(s => ({ key: s.id, label: s.name, chipColor: colorOf(s.id) }))}
-                  onSelect={setPinShowId}
-                  disabled={shows.length === 0}
-                />
-                <div className="flex gap-1.5">
-                  {PIN_PRESETS.map(p => (
-                    <SegBtn key={p.minutes} on={pinMinutes === p.minutes} onClick={() => setPinMinutes(p.minutes)}>
-                      {p.label}
-                    </SegBtn>
-                  ))}
-                </div>
-                <label className="flex items-baseline gap-1.5 border border-separator-strong px-2 py-[9px] sm:py-1">
-                  <input
-                    type="number"
-                    min={PIN_MIN_MINUTES}
-                    max={PIN_MAX_MINUTES}
-                    value={pinMinutes}
-                    onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                      const v = Number(e.target.value);
-                      if (Number.isFinite(v)) setPinMinutes(Math.round(v));
-                    }}
-                    aria-label="Takeover minutes"
-                    className="w-11 [appearance:textfield] border-0 bg-transparent p-0 text-right font-mono text-[11px] font-bold text-ink outline-none"
-                  />
-                  <Mu className="text-[8px]">min</Mu>
-                </label>
-                <Button
-                  variant="accent"
-                  size="sm"
-                  className="min-h-9 sm:min-h-0"
-                  onClick={pinShow}
-                  disabled={pinBusy || !pinShowId || pinMinutes < PIN_MIN_MINUTES || pinMinutes > PIN_MAX_MINUTES}
-                >
-                  {pinBusy ? 'Pinning…' : 'Pin show'}
-                </Button>
-                <button
-                  type="button"
-                  onClick={() => setTakeoverOpen(false)}
-                  aria-label="Close the takeover controls"
-                  title="Close the takeover controls"
-                  className="cursor-pointer border-0 bg-transparent p-1 font-mono text-[13px] leading-none font-bold text-muted hover:text-ink"
-                >
-                  ×
-                </button>
-              </>
-            )}
-          </div>
-        </div>
       </div>
 
       {/* ── Main: line editor, edge-to-edge board, order desk beneath ──── */}

--- a/web/components/admin/schedule/bits.tsx
+++ b/web/components/admin/schedule/bits.tsx
@@ -2,8 +2,7 @@
 
 // Small shared atoms for the schedule page — the design-system patterns the
 // Rundown repeats everywhere: colour chips, the underlined "slot" dropdown
-// (an inline editable value in a sentence), segmented text buttons, and the
-// M T W T F S S day pills.
+// (an inline editable value in a sentence), and the M T W T F S S day pills.
 
 import type { ReactNode } from 'react';
 import { useRef } from 'react';
@@ -91,37 +90,6 @@ export function SlotMenu({
         </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
-  );
-}
-
-/** Segmented text button (the spSeg pattern) — mono caps, ink fill when on. */
-export function SegBtn({
-  on,
-  onClick,
-  children,
-  title,
-}: {
-  on?: boolean;
-  onClick: () => void;
-  children: ReactNode;
-  title?: string;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={title}
-      aria-pressed={on}
-      className={cn(
-        // min-h on the phone only — the desktop metric is the padding.
-        'min-h-9 cursor-pointer border px-2.5 py-[5px] font-mono text-[10px] font-bold tracking-[0.2em] uppercase sm:min-h-0',
-        on
-          ? 'border-ink bg-ink text-bg'
-          : 'border-separator-strong bg-transparent text-muted hover:border-ink hover:text-ink',
-      )}
-    >
-      {children}
-    </button>
   );
 }
 


### PR DESCRIPTION
Moves the timed show takeover (#930) off the schedule screen and onto the admin dash.

## Why

Pinning a show over the weekly grid is a **live on-air action**, not a way of programming the week. On the Rundown it sat between the header and a 24-hour board, spending a row of chrome on every load for something reached a few times a month.

## What changed

**Dash** — new `Takeover` card in the right column, under the segment pads: show picker (same colour chips as the board), 1h/2h/3h presets plus a free minutes field, `Pin to air →`. While a takeover is live the card shows the pinned show, its end time and minutes left, and a `Cancel takeover` button.

A live takeover is **highlighted** so an operator scrolling past can see the schedule is being held off the air: an `on air` pill in the header, an accent-tinted block, and a soft accent ring on the card. (The ring is a `box-shadow` — `.admin-root .card` owns the border at a higher specificity than a utility class can beat.)

**Rundown** — the takeover section is gone entirely. It still *reads* the pin in force, because the override outranks the grid in the controller's `resolveActiveShow`, so without it the On air cell would name a show that is not on the air. The band keeps its `On air · takeover` label and `until HH:MM`.

**Elsewhere** — `SegBtn` is deleted from `schedule/bits.tsx`; the strip's presets were its only caller. Stale copy on the Shows page updated.

No controller changes: `GET /schedule` already returned the roster and the pin, and `POST`/`DELETE /schedule/override` are untouched.

## Verification

- `npm run lint` in `web/` (eslint + tsc) — clean.
- Ran the branch against the live dev stack and checked every state in the browser: idle card, show picked, live takeover (highlight + countdown + cancel), and the Rundown with and without a pin.
- The live-takeover states were exercised with a **client-side injected override** rather than a real pin, so the running station never took an unrequested show to air. The POST/DELETE handlers are the previous panel's, moved verbatim.