### PR TITLE
feat(web): drive the SW-9 meter from the real stream spectrum

### DIFF
--- a/web/components/skins/unit/Unit.module.css
+++ b/web/components/skins/unit/Unit.module.css
@@ -11,7 +11,9 @@
    its accent lines follow the theme. Everything that moves is a co-located
    keyframe idling at `paused` until `.playing` lands, so a tuned-out unit
    sits still and html.lite's global keyframe kill stops the whole panel for
-   free. */
+   free. The meter bars are the one hybrid: they run on the real stream
+   spectrum when the Web Audio analyser can attach (`.live`, driven from
+   UnitSkin's Bars) and fall back to their keyframe when it can't. */
 
 @keyframes unit-bar {
   0%, 100% { transform: scaleY(0.28); }
@@ -326,6 +328,13 @@
   animation-play-state: paused;
 }
 .playing .bar { animation-play-state: running; }
+/* Audio-driven: UnitSkin's Bars writes each bar's scaleY from the shared Web
+   Audio analyser. A running keyframe would win over that inline transform, so
+   the loop's own class stands the animation down — it's only present while
+   real spectrum data is landing, and drops the moment the analyser dies
+   (iOS/Safari silence, tune-out) so the keyframes take the meter straight
+   back. */
+.live .bar { animation: none; }
 .bar:nth-child(1) { animation-duration: 1.4s; animation-delay: 0s; }
 .bar:nth-child(2) { animation-duration: 1.9s; animation-delay: 0.2s; }
 .bar:nth-child(3) { animation-duration: 1.1s; animation-delay: 0.5s; }
@@ -333,6 +342,14 @@
 .bar:nth-child(5) { animation-duration: 1.6s; animation-delay: 0.35s; }
 .bar:nth-child(6) { animation-duration: 2s; animation-delay: 0.6s; }
 .bar:nth-child(7) { animation-duration: 1.3s; animation-delay: 0.45s; }
+
+/* Reduced motion freezes the meter at its resting height. The JS meter gates
+   itself on the same query (Bars in UnitSkin.tsx) — this is the keyframe half,
+   so the fallback path can't keep bouncing under a listener who asked for
+   stillness. html.lite gets this for free from the global animation kill. */
+@media (prefers-reduced-motion: reduce) {
+  .bar { animation: none; }
+}
 
 /* ── window chrome ────────────────────────────────────────────────────── */
 

--- a/web/components/skins/unit/UnitSkin.tsx
+++ b/web/components/skins/unit/UnitSkin.tsx
@@ -11,7 +11,9 @@
 // the chassis (UnitWindows.tsx). Mobile stacks status strip → wordmark →
 // display → knob rail → grille → key rows; the play-log pads stay desktop-only
 // (history lives behind TIMELINE there). Everything that moves is a co-located
-// keyframe (Unit.module.css), so playback churn never re-renders React.
+// keyframe (Unit.module.css) — the one exception is the display's level meter,
+// which follows the real stream spectrum and writes each bar's scaleY straight
+// to the DOM (see Bars). Either way playback churn never re-renders React.
 
 import {
   useEffect,
@@ -19,6 +21,7 @@ import {
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
+  type RefObject,
 } from 'react';
 import styles from './Unit.module.css';
 import {
@@ -44,32 +47,205 @@ import {
   trackMeta,
   turnClock,
 } from '../shared';
+import { useAnalyser } from '@/lib/hooks';
+import { useLiteMode } from '@/hooks/useLiteMode';
 import { useRequestSlip, useTrackLike, useVolumeNudge } from '../sharedHooks';
 import type { SkinProps } from '../types';
 import { BoothWindow, RequestWindow, TimelineWindow, type UnitModal } from './UnitWindows';
 
 const clamp01 = (v: number) => Math.min(1, Math.max(0, v));
 
-/** Animated level bars inside the display glass. Pure CSS — the keyframes idle
- *  at `paused` until `playing`, and html.lite's global kill freezes them at
- *  their low resting height. */
+// ── meter tuning ────────────────────────────────────────────────────────
+// Resting bar height — the same scaleY the `unit-bar` keyframe idles at, so
+// the audio-driven meter and the CSS fallback sit at an identical floor and
+// swapping between them is invisible.
+const BAR_REST = 0.28;
+
+// The band the meter sweeps, logarithmically: equal width per octave, like
+// hardware. A linear bin split would hand four of seven bars to >8 kHz, where
+// music carries almost no energy, and the right half would never move.
+const BAR_FREQ_LO = 50;
+const BAR_FREQ_HI = 16000;
+
+// Minimum ms between style writes. rAF fires at display refresh (120 Hz+ on
+// ProMotion); the analyser's own smoothing makes frames ~33 ms apart visually
+// identical at a third of the cost.
+const BAR_FRAME_MS = 30;
+
+// How long every bin may read zero before the meter gives up on the analyser
+// and hands the bars back to the CSS keyframes. Desktop Safari wires the graph
+// up and then returns silence on a live MP3 mount (issues #298/#302) in ways
+// the hook's one-shot probe can miss. Long enough that a genuinely quiet
+// passage can't trip it — the stream never carries seconds of digital silence.
+const BAR_DEAD_MS = 2000;
+
+// Asymmetric follower: snap up on a transient, fall back slowly. A symmetric
+// lerp reads as mush on a seven-segment meter — the kick has to punch.
+const BAR_ATTACK = 0.55;
+const BAR_RELEASE = 0.16;
+
+/** Per-bar [start, end) analyser-bin spans for the log sweep. With only 6–7
+ *  bars every span is many bins wide, so there's no need for the fractional
+ *  interpolation the classic skin's 120-bar strip does. */
+function barBinRanges(count: number, binCount: number, sampleRate: number): Array<[number, number]> {
+  const nyquist = sampleRate / 2;
+  const hi = Math.min(BAR_FREQ_HI, nyquist);
+  const ranges: Array<[number, number]> = [];
+  for (let i = 0; i < count; i++) {
+    const f0 = BAR_FREQ_LO * Math.pow(hi / BAR_FREQ_LO, i / count);
+    const f1 = BAR_FREQ_LO * Math.pow(hi / BAR_FREQ_LO, (i + 1) / count);
+    const b0 = Math.min(binCount - 1, Math.max(0, Math.floor((f0 / nyquist) * binCount)));
+    const b1 = Math.min(binCount, Math.max(b0 + 1, Math.ceil((f1 / nyquist) * binCount)));
+    ranges.push([b0, b1]);
+  }
+  return ranges;
+}
+
+/** Level bars inside the display glass — the station's actual spectrum.
+ *
+ *  Real frequency data via the shared Web Audio analyser (the graph is cached
+ *  per <audio> element, so arriving from another skin's visualiser reuses it),
+ *  written straight to each bar's `scaleY` so playback churn still never
+ *  re-renders React. Where the analyser can't deliver — iOS, CORS, a browser
+ *  with no Web Audio, or a graph that goes silent mid-stream — the bars fall
+ *  back to the co-located `unit-bar` keyframes, which is what the meter always
+ *  did. Both paths idle at BAR_REST, so the handover doesn't show.
+ *
+ *  Motion gates: html.lite's global keyframe kill can't reach a rAF loop and
+ *  neither can prefers-reduced-motion, so both are checked here (the CSS
+ *  freezes the keyframe path in lockstep) and the bars simply stand still. */
 function Bars({
   count,
   playing,
   mobile,
   className,
+  audioRef,
 }: {
   count: number;
   playing: boolean;
   mobile?: boolean;
   className?: string;
+  /** The shared stream element. Omitted for decorative meters (the mount
+   *  window's inert preview), which stay on the CSS keyframes. */
+  audioRef?: RefObject<HTMLAudioElement | null>;
 }) {
+  const rootRef = useRef<HTMLSpanElement | null>(null);
+  const { lite } = useLiteMode();
+
+  // Reduced motion is a media query, so it has to be read here rather than
+  // left to CSS — the loop below is JS motion and sails straight through both
+  // the query and lite's `animation: none`.
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setReduced(mq.matches);
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
+
+  const calm = lite || reduced;
+  const canDrive = !!audioRef && playing && !calm;
+  const { ready, read, sampleRate } = useAnalyser(audioRef ?? null, canDrive);
+
+  // Whether the bars are currently audio-driven. Only flips when the analyser
+  // arrives or dies, so it re-renders a handful of times per session — the
+  // per-frame heights never touch React.
+  const [driven, setDriven] = useState(false);
+  const drivenRef = useRef(false);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    const clear = () => {
+      drivenRef.current = false;
+      setDriven(false);
+      for (const el of Array.from(root?.children ?? []) as HTMLElement[]) {
+        el.style.transform = '';
+      }
+    };
+    if (!canDrive || !ready || !root) {
+      clear();
+      return;
+    }
+    const bars = Array.from(root.children) as HTMLElement[];
+    const levels = new Float32Array(count);
+    let ranges: Array<[number, number]> | null = null;
+    let rangeKey = '';
+    let raf = 0;
+    let last = 0;
+    let deadSince: number | null = null;
+
+    const tick = (now: number) => {
+      raf = requestAnimationFrame(tick);
+      if (now - last < BAR_FRAME_MS) return;
+      last = now;
+      const bins = read();
+      if (!bins) return;
+
+      // Silence watchdog — hand the bars back to the keyframes rather than
+      // freeze them at rest, then keep reading so real data can reclaim them.
+      let alive = false;
+      for (let b = 0; b < bins.length; b++) {
+        if (bins[b]) { alive = true; break; }
+      }
+      if (alive) {
+        deadSince = null;
+      } else {
+        if (deadSince == null) deadSince = now;
+        if (now - deadSince >= BAR_DEAD_MS) {
+          if (drivenRef.current) clear();
+          return;
+        }
+        if (!drivenRef.current) return;
+      }
+      if (!drivenRef.current) {
+        drivenRef.current = true;
+        setDriven(true);
+      }
+
+      const key = `${bins.length}:${sampleRate ?? 0}`;
+      if (rangeKey !== key || !ranges) {
+        rangeKey = key;
+        ranges = barBinRanges(count, bins.length, sampleRate ?? 48000);
+      }
+      for (let i = 0; i < count; i++) {
+        const [b0, b1] = ranges[i] ?? [0, 1];
+        let sum = 0;
+        let peak = 0;
+        for (let b = b0; b < b1; b++) {
+          const v = bins[b] ?? 0;
+          sum += v;
+          if (v > peak) peak = v;
+        }
+        // Half mean, half peak. A pure mean over a band this wide is dragged
+        // down by the quiet top of the band and barely twitches; a pure peak
+        // jitters on narrowband content.
+        const raw = (sum / (b1 - b0) / 255) * 0.5 + (peak / 255) * 0.5;
+        // Mild lift toward the top of the sweep — recorded music sheds energy
+        // with frequency, so without it the last two bars sit near the floor.
+        const target = clamp01(Math.pow(clamp01(raw * (1 + 0.45 * (i / Math.max(1, count - 1)))), 0.62));
+        const cur = levels[i] ?? 0;
+        const next = cur + (target - cur) * (target > cur ? BAR_ATTACK : BAR_RELEASE);
+        levels[i] = next;
+        const bar = bars[i];
+        if (bar) bar.style.transform = `scaleY(${(BAR_REST + next * (1 - BAR_REST)).toFixed(3)})`;
+      }
+    };
+    raf = requestAnimationFrame(tick);
+    return () => {
+      cancelAnimationFrame(raf);
+      clear();
+    };
+  }, [canDrive, ready, read, sampleRate, count]);
+
   return (
     <span
+      ref={rootRef}
       className={cn(
         styles.bars,
         mobile && styles.barsM,
         playing && styles.playing,
+        driven && styles.live,
         'flex items-end',
         className,
       )}
@@ -210,7 +386,7 @@ export default function UnitSkin(_props: SkinProps) {
     nowPlaying, context, dj, activeShow, listeners, state,
     trackStartedAt, timezone, locale,
   } = usePlayerFeed();
-  const { tunedIn, status, volume, muted, offline, signal } = usePlayerAudio();
+  const { audioRef, tunedIn, status, volume, muted, offline, signal } = usePlayerAudio();
   const { toggleMute, setVolume } = usePlayerActions();
   const { showOverlay, showTuneIn, tuneInFromOverlay, handleTune } = useTuneInGate();
   const client = useStationClient();
@@ -622,7 +798,12 @@ export default function UnitSkin(_props: SkinProps) {
               />
             </div>
             <div className="mt-auto flex min-h-[96px] flex-1 items-end">
-              <Bars count={7} playing={playing} className="h-full max-h-[300px] flex-1 gap-[9px]" />
+              <Bars
+                count={7}
+                playing={playing}
+                audioRef={audioRef}
+                className="h-full max-h-[300px] flex-1 gap-[9px]"
+              />
             </div>
             <div
               className={cn(
@@ -691,7 +872,13 @@ export default function UnitSkin(_props: SkinProps) {
             <span className="truncate text-[var(--accent)] uppercase">{trackLine}</span>
           </div>
           <div className="flex items-end">
-            <Bars count={6} playing={playing} mobile className="h-[74px] flex-1 gap-[5px]" />
+            <Bars
+              count={6}
+              playing={playing}
+              mobile
+              audioRef={audioRef}
+              className="h-[74px] flex-1 gap-[5px]"
+            />
           </div>
           <div className="flex items-center justify-between gap-3">
             <span className={cn(styles.doto, 'truncate text-[13px] text-[#8a8478] uppercase')}>


### PR DESCRIPTION
## What

The UNIT SW-9 skin's level meter was decoration, not a visualiser. Seven `<span>`s ran a staggered `unit-bar` CSS keyframe that bounced on a loop from the moment you tuned in, regardless of what was on air. Classic (`Waveform.tsx`) and subamp (`Analyzer.tsx`) were the only skins wired to `useAnalyser`.

SW-9 now reads the real stream spectrum.

## How

- **Still DOM spans, not a canvas.** With six or seven bars, a direct `scaleY` write per frame is cheaper than a canvas repaint, and it preserves the segmented-LED `repeating-linear-gradient` exactly as designed. The loop writes straight to the elements, so a moving meter still never re-renders React — only the live/fallback flip touches state.
- **Log-spaced bands** (50 Hz – 16 kHz), each half mean / half peak of its bins. A plain mean over a band this wide barely twitches; a plain peak jitters on narrowband content. Mild lift toward the top of the sweep, since recorded music sheds energy with frequency.
- **Asymmetric follower** (0.55 attack, 0.16 release) so a kick punches rather than smears on a seven-segment meter.
- **The keyframes are now the fallback.** iOS never attaches Web Audio; desktop Safari wires the graph up and then returns only zeros on a live MP3 mount (#298/#302) in ways the hook's one-shot probe can miss. So the loop also watches for 2s of silence in every bin and hands the bars back to CSS, then keeps reading so real data can reclaim them. Both paths idle at the same `0.28` resting height, so the handover doesn't show.
- **Motion gates moved into JS.** `html.lite`'s global `animation: none` and `prefers-reduced-motion` reach keyframes only — a rAF loop sails through both (the hazard `sharedHooks.useSkinMotion` documents). Both are checked before the loop starts. The CSS half of the reduced-motion gate is added alongside, so the fallback path can't keep bouncing under a listener who asked for stillness — previously the unit meter animated through reduced motion.

The mount window's inert preview meter takes no `audioRef` and stays on the keyframes.

## Verification

`npm run lint` (eslint + `tsc --noEmit`) passes in `web/` — the 3 remaining warnings are pre-existing in an unrelated admin file.

Driven in Chrome against the unit skin with a synthetic multi-tone source (Chrome's media stack in the automation tab wouldn't load the live Icecast mount, so the stream itself couldn't be used as the source):

- Real analyser data reaches the loop — 2048 bins, non-zero, `Unit_live__` class applied.
- **Frequency-correct**: bands carrying signal read 0.75–0.87; bands with nothing in them sat at the 0.35 floor.
- **Tracks over time**: sampled across 1.5s, the band crossed by an FM sweep swung 0.43 while steady bands held.
- **Silence watchdog**: 3.2s of digital silence while still playing dropped the `live` class, cleared the inline transforms, and the `unit-bar` keyframe resumed `running`.

Not verified against the live Icecast stream end-to-end — worth a look on a real listen before this leaves draft.