### PR TITLE
style(web): smaller Press Run plates, subtler ink shadow

### DIFF
--- a/web/components/what/PressRun.tsx
+++ b/web/components/what/PressRun.tsx
@@ -47,12 +47,12 @@ function Plate({
       onClick={() => onOpen(plate)}
       tabIndex={ghost ? -1 : 0}
       aria-hidden={ghost || undefined}
-      className="group block w-[min(440px,78vw)] shrink-0 text-left"
+      className="group block w-[min(360px,70vw)] shrink-0 text-left"
     >
       <span
         className={cn(
           'block aspect-[16/10] overflow-hidden border border-ink bg-overlay',
-          'shadow-[5px_5px_0_0_var(--ink)] transition-transform duration-200',
+          'shadow-[2px_2px_0_0_var(--ink)] transition-transform duration-200',
           'group-hover:-translate-y-0.5 group-focus-visible:-translate-y-0.5',
         )}
       >


### PR DESCRIPTION
Follow-up polish to #1217, requested while previewing the live section:

- Plates: 440px → **360px** wide (70vw cap on mobile) — the strip breathes more; the marquee's dynamic copy count keeps wide screens gap-free automatically.
- Shadow: 5px → **2px** hard ink offset — closer to an inked frame than a floating card, better fit for the newsprint feel. (`Figure.tsx` uses no shadow at all; happy to drop it entirely if that reads better.)

Verified with `npm run lint` and live on the worktree dev server against the running station.