### PR TITLE
fix(aio): copy Node 22 from the official image instead of NodeSource

### DIFF
--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -50,6 +50,9 @@ RUN npm run build
 # ---- caddy binary: lift the glibc build from the official Debian image ------
 FROM caddy:2 AS caddybin
 
+# ---- node binary: lift Node 22 from the official image ----------------------
+FROM node:22-bookworm-slim AS nodebin
+
 # ---- final: everything under the liquidsoap (Debian bookworm) base ----------
 # v2.4.5 minimum — same reason as Dockerfile.broadcast: 2.4.4's O(n) clock
 # scan made the per-transition DJ effect chains stall the stream clock.
@@ -68,20 +71,24 @@ ENV DEBIAN_FRONTEND=noninteractive
 #  - ffmpeg: jingle/SFX transcode on import (audio/audio-import.ts)
 #  - python3/python3-venv: the Kokoro worker venv
 #  - wget/tar/xz-utils: Piper + Kokoro model/binary pulls
-#  - gnupg: NodeSource apt key
 RUN apt-get update -qq \
  && apt-get install -y --no-install-recommends \
         icecast2 sudo openssl curl ca-certificates \
         iputils-ping \
         espeak-ng libsndfile1 ffmpeg \
         python3 python3-venv \
-        wget tar xz-utils gnupg \
+        wget tar xz-utils \
  && rm -rf /var/lib/apt/lists/*
 
-# Node.js 22 (NodeSource) — runs both the controller (tsx) and the web server.
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
- && apt-get install -y --no-install-recommends nodejs \
- && rm -rf /var/lib/apt/lists/*
+# Node.js 22 — runs both the controller (tsx) and the web server. Lifted from
+# the official image (same bookworm libc as this base) rather than installed
+# from NodeSource's apt repo: deb.nodesource.com serves per-IP 403s from its
+# CDN (nodesource/distributions#1844) and took out the v1.1.0 publish run.
+COPY --from=nodebin /usr/local/bin/node /usr/local/bin/node
+COPY --from=nodebin /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=nodebin /usr/local/include/node /usr/local/include/node
+RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+ && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 # Caddy — the loopback edge.
 COPY --from=caddybin /usr/bin/caddy /usr/local/bin/caddy


### PR DESCRIPTION
## Summary

The v1.1.0 `Publish images` run ([30312389865](https://github.com/perminder-klair/subwave/actions/runs/30312389865)) lost all three AIO flavours (`subwave-aio`, `subwave-aio-heavy`, `subwave-aio-cuda`) at the same `Dockerfile.aio` step: `curl https://deb.nodesource.com/setup_22.x` got an HTTP 403, so the apt repo was never added and `apt-get install nodejs` exited 100. A rerun of the failed jobs hit the same 403. This is [nodesource/distributions#1844](https://github.com/nodesource/distributions/issues/1844): NodeSource's CDN serves per-IP 403s, currently covering `setup_22.x`, `setup_lts.x`, and the `node_22.x` apt repo's own Release file (reproduced from a residential IP too), so there is no NodeSource-side workaround and any future release can trip on it.

The fix removes NodeSource from the release path entirely:

- New `nodebin` alias stage (`FROM node:22-bookworm-slim`), mirroring the existing `caddybin` "lift the binary" pattern. The image is one this Dockerfile already pulls for `webbuild`, so no new external dependency.
- The final stage `COPY --from=nodebin`s `/usr/local/bin/node`, `/usr/local/lib/node_modules`, and `/usr/local/include/node`, then symlinks `npm`/`npx` the same way the official image does. Same Debian bookworm libc on both sides; the alias stage (rather than copying from `webbuild`) keeps the final stage from serializing behind the Next.js build.
- `gnupg` drops out of the apt list — it was only there for the NodeSource signing key.

All three AIO flavours share the same final stage (`savonet/liquidsoap:v2.4.5`), so one change covers lean, heavy, and CUDA.

## Verification

Built a minimal probe image (`nodebin` copy steps on the real `savonet/liquidsoap:v2.4.5` base) locally: `node v22.23.1` and `npm 10.9.8` run, the `npm`/`npx` symlinks resolve, and a node script executes.

## After merge

The v1.1.0 AIO images are still unpublished (the tag predates this fix). Either cut v1.1.1 once this is on develop, or `workflow_dispatch` the publish workflow after the fix reaches main.

## Test plan
- [ ] Next `Publish images` run builds all three AIO flavours without touching deb.nodesource.com
- [ ] AIO container boots: controller (tsx) and web server both come up, `npm ci --omit=dev` succeeded at build time