### PR TITLE
release: unblock the AIO images from the NodeSource outage

### DIFF
--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -50,6 +50,9 @@ RUN npm run build
 # ---- caddy binary: lift the glibc build from the official Debian image ------
 FROM caddy:2 AS caddybin
 
+# ---- node binary: lift Node 22 from the official image ----------------------
+FROM node:22-bookworm-slim AS nodebin
+
 # ---- final: everything under the liquidsoap (Debian bookworm) base ----------
 # v2.4.5 minimum — same reason as Dockerfile.broadcast: 2.4.4's O(n) clock
 # scan made the per-transition DJ effect chains stall the stream clock.
@@ -68,20 +71,24 @@ ENV DEBIAN_FRONTEND=noninteractive
 #  - ffmpeg: jingle/SFX transcode on import (audio/audio-import.ts)
 #  - python3/python3-venv: the Kokoro worker venv
 #  - wget/tar/xz-utils: Piper + Kokoro model/binary pulls
-#  - gnupg: NodeSource apt key
 RUN apt-get update -qq \
  && apt-get install -y --no-install-recommends \
         icecast2 sudo openssl curl ca-certificates \
         iputils-ping \
         espeak-ng libsndfile1 ffmpeg \
         python3 python3-venv \
-        wget tar xz-utils gnupg \
+        wget tar xz-utils \
  && rm -rf /var/lib/apt/lists/*
 
-# Node.js 22 (NodeSource) — runs both the controller (tsx) and the web server.
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
- && apt-get install -y --no-install-recommends nodejs \
- && rm -rf /var/lib/apt/lists/*
+# Node.js 22 — runs both the controller (tsx) and the web server. Lifted from
+# the official image (same bookworm libc as this base) rather than installed
+# from NodeSource's apt repo: deb.nodesource.com serves per-IP 403s from its
+# CDN (nodesource/distributions#1844) and took out the v1.1.0 publish run.
+COPY --from=nodebin /usr/local/bin/node /usr/local/bin/node
+COPY --from=nodebin /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=nodebin /usr/local/include/node /usr/local/include/node
+RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+ && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 # Caddy — the loopback edge.
 COPY --from=caddybin /usr/bin/caddy /usr/local/bin/caddy


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge with "Create a merge commit"** — not "Squash and merge". Squash collapses the individual `feat:` / `fix:` / `chore:` commits into one `release: …` commit, and release-please then sees no conventional-commit signal and skips the version bump.

## Summary

Single-commit patch release, infra-only. v1.1.0's publish run failed for all three AIO flavours because deb.nodesource.com serves per-IP 403s from its CDN (nodesource/distributions#1844) — a rerun failed identically, so `subwave-aio`, `subwave-aio-heavy`, and `subwave-aio-cuda` never shipped at v1.1.0. This release carries the fix (Node 22 copied from the official image instead of installed via NodeSource) so the tag push republishes everything, AIO included. No app behaviour changes, no migrations, no env-var changes.

**Bug Fixes**
- `4c6a7eaf` fix(aio): copy Node 22 from the official image instead of NodeSource (#1225)

## Test plan
- [ ] The v-tag `Publish images` run builds all three AIO flavours green, with no request to deb.nodesource.com in the build logs
- [ ] ghcr.io shows `subwave-aio`, `subwave-aio-heavy`, `subwave-aio-cuda` at the new version tag (and `latest` moved)
- [ ] An AIO container from the new image boots: controller and web both come up behind Caddy