### PR TITLE
chore(skills): point the writing skills at no-ai-slop

### DIFF
--- a/.claude/skills/subwave-discord-release/SKILL.md
+++ b/.claude/skills/subwave-discord-release/SKILL.md
@@ -102,9 +102,11 @@ The thank-you sentence follows the same rule: tie it to what actually happened t
 - Straight quotes. Emoji are welcome here (unlike the news dispatch) because it's Discord, but each should carry meaning, not decorate.
 - Keep it scannable: short intro, bulleted features, compact fixes, link, sign-off. Discord readers skim.
 
-## Required: humanize before delivering
+## Required: de-slop before delivering
 
-Run the finished draft through the **`humanizer`** skill and apply its edits before you hand it over. This is where lingering AI tells, any stray em-dash, and rule-of-three habits get caught. It's the same discipline the news dispatch uses, and it's what keeps the post from reading like generated release notes.
+Run the finished draft through the **`no-ai-slop`** skill in edit mode and apply its edits before you hand it over. This is where lingering AI tells, any stray em-dash, and rule-of-three habits get caught. It's the same discipline the news dispatch uses, and it's what keeps the post from reading like generated release notes.
+
+Hold the house voice against it: the no-em-dash rule above is absolute here, and the warm first-person plural and the emoji that carry meaning are voice signals to preserve, not slop to strip.
 
 ## Delivering
 

--- a/.claude/skills/subwave-news-dispatch/SKILL.md
+++ b/.claude/skills/subwave-news-dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: subwave-news-dispatch
-description: Write a news post for the SUB/WAVE "Dispatches" page, a short human-friendly tutorial about a feature, fix, or release. Use this skill whenever the user wants to "write a news post / dispatch / news article", "announce a feature on the news page", "add a changelog entry to the site", "post an update about <feature>", "write release notes for the site", or "tell people about <what shipped>" for SUB/WAVE. The skill knows where the markdown lives (web/content/news), the frontmatter schema, the what/how/why structure, and that every draft must be run through the `humanizer` skill before saving. It does NOT publish or deploy; it just writes the .md file, and the /news page picks it up on the next build.
+description: Write a news post for the SUB/WAVE "Dispatches" page, a short human-friendly tutorial about a feature, fix, or release. Use this skill whenever the user wants to "write a news post / dispatch / news article", "announce a feature on the news page", "add a changelog entry to the site", "post an update about <feature>", "write release notes for the site", or "tell people about <what shipped>" for SUB/WAVE. The skill knows where the markdown lives (web/content/news), the frontmatter schema, the what/how/why structure, and that every draft must be run through the `no-ai-slop` skill before saving. It does NOT publish or deploy; it just writes the .md file, and the /news page picks it up on the next build.
 ---
 
 # SUB/WAVE news dispatch
@@ -56,9 +56,11 @@ Use `##` subheads (sentence case) to break those up. Look at the seed articles f
 - Be specific: real paths, real commands, the real button name in admin. Pull the detail from `git log`, the PR, or the relevant manual page under `web/components/manual/`.
 - Straight quotes, sentence-case headings, no decorative emoji.
 
-## Required: humanize before saving
+## Required: de-slop before saving
 
-ALWAYS run the finished draft through the **`humanizer`** skill, apply its edits, then write the `.md` file. This is not optional. It's the step that keeps the wire from reading like AI release notes, and it's where the em-dash and rule-of-three habits get caught.
+ALWAYS run the finished draft through the **`no-ai-slop`** skill in edit mode, apply its edits, then write the `.md` file. This is not optional. It's the step that keeps the wire from reading like AI release notes, and it's where the em-dash, throat-clearing opener, and rule-of-three habits get caught.
+
+Two things to hold onto when you apply its edits: the no-em-dash rule above is absolute here even though `no-ai-slop` allows 1-2 in longer drafts, and the wire's first-person voice ("we traced it to the Opus mount") is a voice signal to preserve, not throat-clearing to cut.
 
 ## Verify
 


### PR DESCRIPTION
The `humanizer` skill was replaced by `no-ai-slop`, leaving both SUB/WAVE writing skills naming a skill that no longer exists. Since each declares that step as **required** ("ALWAYS run the finished draft through…"), the instruction would have failed to resolve at exactly the point it's meant to be non-optional.

Updates the references in `subwave-discord-release` and `subwave-news-dispatch` — including the news-dispatch frontmatter `description`, which also named the old skill — and specifies edit mode.

While there, records the three places house voice outranks the generic skill, so applying its edits doesn't flatten what makes these posts ours:

- the **no-em-dash** rule is absolute in both, even though `no-ai-slop` tolerates 1–2 in longer drafts
- the dispatch's **first-person voice** ("we traced it to the Opus mount") is a voice signal to preserve, not throat-clearing to cut
- Discord's **emoji that carry meaning** are voice, not decoration to strip

Docs only — no code, no behaviour change. Verified no other file in the repo still references `humanizer`.

Split out of #1235 (deepsec security fixes) so that PR stays a clean security diff.
