### PR TITLE
fix(analyzer): release CLAP + Demucs after idle on CPU hosts (#1204)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,9 +157,13 @@ SITE_URL=
 # the container. See docs/unraid.md.)
 # ANALYZE_DEVICE=    # auto (default) / cpu / cuda — torch device for CLAP/Demucs;
 #                    # only meaningful on the cuda analyzer flavour
-# ANALYZE_IDLE_UNLOAD_S=  # cuda flavour: seconds of no analysis before models are
-#                         # dropped from VRAM (default 300; 0 = keep resident).
-#                         # Frees the GPU for co-resident TTS/LLM between passes.
+# ANALYZE_IDLE_UNLOAD_S=  # seconds of no CLAP/Demucs use before the models are
+#                         # dropped (0 = keep resident). Defaults per device:
+#                         # 300 on cuda (frees the GPU for co-resident TTS/LLM
+#                         # between passes), 1800 on cpu (a backfill or sound
+#                         # search loads them once and they'd otherwise sit in
+#                         # RAM/swap forever; the longer window keeps the cold
+#                         # reload off interactive sound searches).
 #
 # Runtime flags — env wins ON over the admin toggles (settings.audio.*), never
 # off. A flag with no matching backend in the image is a clean no-op.

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -719,8 +719,11 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=\${ANALYZE_DEVICE:-}
-      # Seconds of no requests before the cuda flavour drops its models out of
-      # VRAM (default 300; 0 = never). CPU images ignore it.
+      # Seconds of no CLAP/Demucs use before the worker drops the models
+      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
+      # 1800 on cpu — one backfill or sound search loads them into the
+      # long-lived worker and nothing else ever releases them, so on a small
+      # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=\${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
@@ -1002,8 +1005,11 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=\${ANALYZE_DEVICE:-}
-      # Seconds of no requests before the cuda flavour drops its models out of
-      # VRAM (default 300; 0 = never). CPU images ignore it.
+      # Seconds of no CLAP/Demucs use before the worker drops the models
+      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
+      # 1800 on cpu — one backfill or sound search loads them into the
+      # long-lived worker and nothing else ever releases them, so on a small
+      # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=\${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -367,8 +367,11 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=\${ANALYZE_DEVICE:-}
-      # Seconds of no requests before the cuda flavour drops its models out of
-      # VRAM (default 300; 0 = never). CPU images ignore it.
+      # Seconds of no CLAP/Demucs use before the worker drops the models
+      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
+      # 1800 on cpu — one backfill or sound search loads them into the
+      # long-lived worker and nothing else ever releases them, so on a small
+      # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=\${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
@@ -1104,10 +1107,11 @@ export const COMPOSE_ANALYZER_GPU_YML = `# GPU opt-in overlay for the analyzer �
 # degrades, not fails). To force CPU temporarily without dropping the overlay,
 # set ANALYZE_DEVICE=cpu in your root .env (the base compose passes it through).
 #
-# VRAM etiquette: after ~5 idle minutes the worker drops its models out of
-# VRAM so a co-resident TTS/LLM gets the card back between passes
-# (ANALYZE_IDLE_UNLOAD_S in .env tunes it; 0 keeps models resident). A few
-# hundred MB of CUDA context remain until the container stops.
+# VRAM etiquette: after ~5 idle minutes with no CLAP/Demucs use the worker
+# drops its models out of VRAM so a co-resident TTS/LLM gets the card back
+# between passes (ANALYZE_IDLE_UNLOAD_S in .env tunes it; 0 keeps models
+# resident). A few hundred MB of CUDA context remain until the container stops.
+# The same release runs on CPU with a longer default window (#1204).
 services:
   analyzer:
     image: ghcr.io/perminder-klair/subwave-analyzer-cuda:\${SUBWAVE_VERSION:-latest}
@@ -1298,9 +1302,13 @@ SITE_URL=
 # the container. See docs/unraid.md.)
 # ANALYZE_DEVICE=    # auto (default) / cpu / cuda — torch device for CLAP/Demucs;
 #                    # only meaningful on the cuda analyzer flavour
-# ANALYZE_IDLE_UNLOAD_S=  # cuda flavour: seconds of no analysis before models are
-#                         # dropped from VRAM (default 300; 0 = keep resident).
-#                         # Frees the GPU for co-resident TTS/LLM between passes.
+# ANALYZE_IDLE_UNLOAD_S=  # seconds of no CLAP/Demucs use before the models are
+#                         # dropped (0 = keep resident). Defaults per device:
+#                         # 300 on cuda (frees the GPU for co-resident TTS/LLM
+#                         # between passes), 1800 on cpu (a backfill or sound
+#                         # search loads them once and they'd otherwise sit in
+#                         # RAM/swap forever; the longer window keeps the cold
+#                         # reload off interactive sound searches).
 #
 # Runtime flags — env wins ON over the admin toggles (settings.audio.*), never
 # off. A flag with no matching backend in the image is a clean no-op.

--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -36,6 +36,7 @@ natural-language "sounds like ..." search and zero-shot mood scoring against
 the stored audio vectors possible.
 """
 
+import ctypes
 import importlib.util
 import json
 import os
@@ -187,30 +188,65 @@ def resolve_device():
     return _DEVICE
 
 
-# --- Idle GPU release (#1099 follow-up) -------------------------------------
-# On the cuda device the resident CLAP + Demucs models hold multiple GB of
-# VRAM even when no analysis is running, starving co-resident GPU work (a
-# local TTS/LLM on the same card OOMed hours after a pass finished). A daemon
-# thread drops the model singletons after ANALYZE_IDLE_UNLOAD_S seconds with
-# no requests (default 300; 0 disables). CUDA-only: on cpu the models stay
-# resident as always — system RAM is cheap and reload latency isn't worth it.
-# The next request lazy-reloads from the on-disk HF cache. NOTE: torch's CUDA
-# context (a few hundred MB) survives until the process exits — stopping the
-# analyzer container is the full release.
-IDLE_UNLOAD_S = float(os.environ.get("ANALYZE_IDLE_UNLOAD_S", "").strip() or "300")
+# --- Idle model release (#1099 follow-up; CPU arming per #1204) -------------
+# The resident CLAP + Demucs models hold multiple GB even when no analysis is
+# running. A daemon thread drops the model singletons after the idle window
+# passes with no HEAVY use (0 disables); the next request lazy-reloads from the
+# on-disk HF / torch-hub cache.
+#
+# On cuda that starves co-resident GPU work (a local TTS/LLM on the same card
+# OOMed hours after a pass finished). On cpu it looked free — "system RAM is
+# cheap" — but #1204 showed otherwise: one admin backfill (or a stem-cache
+# pass, or a single sound search) force-loads both models into the long-lived
+# worker regardless of this process's env defaults, nothing ever releases them,
+# and on a small host the kernel eventually parks ~1.5GB of cold weights in
+# swap indefinitely. So the thread arms on both devices now.
+#
+# The window is device-aware: cuda keeps 300s (VRAM contention is urgent and a
+# GPU reload is fast), cpu defaults longer because a cold CPU reload is seconds
+# of latency that lands on interactive callers (analyzer.embedTexts gives sound
+# search a 20s deadline), and swap pressure is not urgent the way a starved GPU
+# is. ANALYZE_IDLE_UNLOAD_S overrides both. NOTE: torch's imported modules (and
+# on cuda its context) survive until the process exits — a few hundred MB stays
+# resident either way; stopping the analyzer container is the full release.
+IDLE_UNLOAD_CUDA_S = 300.0
+IDLE_UNLOAD_CPU_S = 1800.0
+_IDLE_UNLOAD_ENV = os.environ.get("ANALYZE_IDLE_UNLOAD_S", "").strip()
 
-_last_used = time.time()
+# Heavy-model clock, deliberately NOT a general request clock. A lean
+# bpm/key/loudness request touches no model, so letting it refresh this would
+# pin CLAP + Demucs in memory forever on any station with steady analysis
+# traffic — the release would only ever fire on an idle box (#1204). Only an
+# actual embedder / detector use moves it. `_model_lock` (held across request
+# handling AND unload) is what keeps a release from racing a request in flight.
+_heavy_last_used = time.time()
 _model_lock = threading.Lock()  # held during request handling AND unload
 _idle_thread_started = False
 
 
-def _touch():
-    global _last_used
-    _last_used = time.time()
+def _touch_heavy():
+    """Mark CLAP/Demucs as just used — resets the idle-release countdown."""
+    global _heavy_last_used
+    _heavy_last_used = time.time()
 
 
-def _release_models():
-    """Drop the loaded model singletons and return their VRAM. Leaves the
+def _idle_unload_seconds():
+    """Resolve the idle window. Called only from the arming path, never at
+    import: the default depends on the device, and resolve_device() imports
+    torch — which the lean librosa-only venv doesn't have."""
+    if _IDLE_UNLOAD_ENV:
+        try:
+            return float(_IDLE_UNLOAD_ENV)
+        except ValueError:
+            log(
+                f"ANALYZE_IDLE_UNLOAD_S={_IDLE_UNLOAD_ENV!r} is not a number; "
+                "using the per-device default"
+            )
+    return IDLE_UNLOAD_CUDA_S if resolve_device() == "cuda" else IDLE_UNLOAD_CPU_S
+
+
+def _release_models(idle_s=None):
+    """Drop the loaded model singletons and hand their memory back. Leaves the
     *_failed flags alone, so the next request reloads instead of no-opping."""
     global _embedder, _vocal_detector
     import gc
@@ -225,40 +261,56 @@ def _release_models():
     if not freed:
         return
     gc.collect()
+    where = "system memory"
     try:
         import torch
 
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
+            where = "GPU memory"
     except Exception:  # noqa: BLE001 — freeing is best-effort
         pass
+    # Hand the freed tensor heap back to the OS. gc.collect() returns it to
+    # glibc's arenas, which keeps it as cold anonymous pages the kernel then
+    # swaps out — exactly the 1.5GB #1204 measured. malloc_trim releases the
+    # trimmable top of those arenas instead. No-op (and harmless) off glibc.
+    try:
+        ctypes.CDLL(None).malloc_trim(0)
+    except Exception:  # noqa: BLE001 — best-effort, absent on musl/macOS
+        pass
+    idle_note = f"idle {int(idle_s)}s — " if idle_s else ""
     log(
-        f"idle {int(IDLE_UNLOAD_S)}s — released {' + '.join(freed)} from GPU memory "
+        f"{idle_note}released {' + '.join(freed)} from {where} "
         "(reloads on next use)"
     )
 
 
-def _idle_release_loop():
+def _idle_release_loop(idle_s):
     while True:
         time.sleep(30)
-        if time.time() - _last_used < IDLE_UNLOAD_S:
+        if time.time() - _heavy_last_used < idle_s:
             continue
         with _model_lock:
             # Re-check under the lock: a request may have landed while we
             # waited to acquire it (a slow track holds the lock for minutes).
-            if time.time() - _last_used >= IDLE_UNLOAD_S:
-                _release_models()
+            if time.time() - _heavy_last_used >= idle_s:
+                _release_models(idle_s)
 
 
 def _maybe_start_idle_release():
-    """Arm the idle-release thread — once, and only where it matters (cuda
-    device, unload enabled). Called after a heavy model actually loads."""
+    """Arm the idle-release thread — once, on either device (unload enabled).
+    Called after a heavy model actually loads."""
     global _idle_thread_started
-    if _idle_thread_started or IDLE_UNLOAD_S <= 0 or resolve_device() != "cuda":
+    if _idle_thread_started:
+        return
+    idle_s = _idle_unload_seconds()
+    if idle_s <= 0:
         return
     _idle_thread_started = True
-    threading.Thread(target=_idle_release_loop, daemon=True, name="idle-release").start()
-    log(f"idle GPU release armed — models unload after {int(IDLE_UNLOAD_S)}s without requests")
+    threading.Thread(
+        target=_idle_release_loop, args=(idle_s,), daemon=True, name="idle-release"
+    ).start()
+    log(f"idle model release armed — models unload after {int(idle_s)}s without heavy use")
 
 
 def _pearson(a, b):
@@ -718,6 +770,9 @@ def get_embedder(force=False):
             log(f"CLAP load failed ({ex}); audio embeddings disabled for this run")
             _embed_failed = True
             return None
+    # On the fresh load AND on every cache hit: continued use keeps the model
+    # warm, so a long backfill never releases mid-pass (#1204).
+    _touch_heavy()
     return _embedder
 
 
@@ -898,6 +953,8 @@ def get_vocal_detector(force=False):
             log(f"Demucs load failed ({ex or type(ex).__name__}); vocal activity disabled for this run")
             _vocal_failed = True
             return None
+    # Fresh load AND cache hit — see get_embedder (#1204).
+    _touch_heavy()
     return _vocal_detector
 
 
@@ -1600,7 +1657,6 @@ def main():
             ):
                 emit({"id": rid, "ok": False, "error": "texts must be 1-64 non-empty strings"})
                 continue
-            _touch()
             with _model_lock:
                 embedder = get_embedder(force=True)
                 if embedder is None:
@@ -1610,7 +1666,9 @@ def main():
                     emit({"id": rid, "ok": True, "text_embeddings": embedder.embed_texts(texts)})
                 except Exception as e:  # noqa: BLE001 — one bad request never kills the worker
                     emit({"id": rid, "ok": False, "error": str(e)})
-            _touch()
+                # Re-stamp on the way out so the clock reads from the END of the
+                # work, not its start. get_embedder() stamped on entry.
+                _touch_heavy()
             continue
         url = req.get("url")
         path = req.get("path")
@@ -1620,17 +1678,23 @@ def main():
         try:
             import librosa
 
-            # _touch() on both edges + the lock keep the idle-release thread
-            # honest: the clock reads fresh after a long track, and an unload
-            # can never race a request that's mid-flight.
-            _touch()
+            # No unconditional clock stamp here: this is the general request
+            # path and a lean bpm/key pass must NOT keep CLAP/Demucs pinned
+            # (#1204). The heavy clock is stamped inside get_embedder /
+            # get_vocal_detector; _model_lock is what keeps an unload from
+            # racing this request.
+            heavy_before = _heavy_last_used
             with _model_lock:
                 result = analyze(
                     librosa, url=url, path=path,
                     embed=req.get("embed"), vocal=req.get("vocal"),
                     complete=req.get("complete"), stems_dir=req.get("stems_dir"),
                 )
-            _touch()
+                # If a getter stamped the clock, this request DID use a model —
+                # re-stamp so the countdown starts from the end of the work, not
+                # its start (Demucs on a long track holds the lock for minutes).
+                if _heavy_last_used != heavy_before:
+                    _touch_heavy()
             emit({"id": rid, "ok": True, **result})
         except Exception as e:
             emit({"id": rid, "ok": False, "error": str(e)})

--- a/controller/scripts/idle_release_test.py
+++ b/controller/scripts/idle_release_test.py
@@ -195,11 +195,21 @@ def main():
     # station with steady analysis traffic pins CLAP+Demucs forever and the
     # gate removal above buys nothing.
     def case_lean_request_does_not_refresh():
+        # A lean bpm/key pass reaches the getters exactly like analyze() does —
+        # get_embedder(force=False) / get_vocal_detector(force=False) with the
+        # env flags off — and must bounce off the early return BEFORE the
+        # _touch_heavy() stamp. This is the precise call shape of the #1204
+        # traffic that pinned the models forever under the shared clock.
         reset(heavy_age_s=600.0)
         stale = aw._heavy_last_used
-        # A lean pass calls neither getter (embed/vocal resolve to falsy), so
-        # nothing should touch the clock. Assert the getters are the ONLY writers
-        # by confirming a no-model code path leaves it alone.
+        saved = aw.EMBED_ENABLED, aw.VOCAL_ENABLED
+        try:
+            aw.EMBED_ENABLED = False
+            aw.VOCAL_ENABLED = False
+            assert aw.get_embedder(force=False) is None, "lean pass loads no embedder"
+            assert aw.get_vocal_detector(force=False) is None, "lean pass loads no detector"
+        finally:
+            aw.EMBED_ENABLED, aw.VOCAL_ENABLED = saved
         aw._release_models()  # nothing loaded → no-op, must not stamp either
         assert aw._heavy_last_used == stale, (
             "#1204: a request that loads no model must not refresh the heavy clock"

--- a/controller/scripts/idle_release_test.py
+++ b/controller/scripts/idle_release_test.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# Unit test for the idle model release in analyze_worker (#1099 follow-up, CPU
+# arming per #1204) — the mechanism that hands CLAP/Demucs memory back instead
+# of leaving multiple GB resident for the life of the worker. Pure stdlib: no
+# torch, no demucs, no audio, no network, so it runs anywhere.
+# Run: `python3 scripts/idle_release_test.py` (exit 0 = pass).
+#
+# What this pins down, in the order it matters:
+#   - the models are released, and the *_failed flags are NOT set, so the next
+#     request reloads rather than silently no-opping forever;
+#   - the release arms on cpu (the #1204 regression) as well as cuda;
+#   - the countdown is driven by a HEAVY-use clock, not a general request clock.
+#     That last one is the subtle half of #1204: while the clock was shared, a
+#     station with steady lean bpm/key traffic would refresh it on every request
+#     and the release would only ever fire on an idle box.
+
+import os
+import sys
+
+# Import the worker with its shipped defaults. Heavy imports (torch/demucs/
+# librosa) are lazy, so importing is stdlib-cheap.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import analyze_worker as aw  # noqa: E402
+
+failures = 0
+
+
+def test(name, fn):
+    global failures
+    try:
+        fn()
+        print(f"  ✓ {name}")
+    except Exception as err:  # noqa: BLE001 — a failed assert is a reported case
+        failures += 1
+        print(f"  ✗ {name}\n      {err}")
+
+
+class FakeModel:
+    """Stands in for a loaded ClapEmbedder / VocalActivityDetector. Never
+    constructs a real model — the point is the release bookkeeping."""
+
+
+def reset(embedder=None, detector=None, armed=False, heavy_age_s=0.0):
+    """Put the worker's module-level release state in a known shape."""
+    import time as _t
+
+    aw._embedder = embedder
+    aw._vocal_detector = detector
+    aw._embed_failed = False
+    aw._vocal_failed = False
+    aw._idle_thread_started = armed
+    aw._heavy_last_used = _t.time() - heavy_age_s
+
+
+def with_device(device, fn):
+    """Run fn with resolve_device() stubbed — the real one imports torch."""
+    saved = aw.resolve_device
+    try:
+        aw.resolve_device = lambda: device
+        return fn()
+    finally:
+        aw.resolve_device = saved
+
+
+def with_env(value, fn):
+    """Run fn with the ANALYZE_IDLE_UNLOAD_S override set to `value` (None =
+    unset, i.e. fall through to the per-device default)."""
+    saved = aw._IDLE_UNLOAD_ENV
+    try:
+        aw._IDLE_UNLOAD_ENV = "" if value is None else value
+        return fn()
+    finally:
+        aw._IDLE_UNLOAD_ENV = saved
+
+
+def main():
+    print("idle model release (analyze_worker):")
+
+    # ── Release drops both singletons, keeps the failure flags clear ──────────
+    # The *_failed flags are the "never retry this load" latch. A release must
+    # not trip them, or one idle window would permanently disable embeddings
+    # for the life of the process.
+    def case_release_both():
+        reset(embedder=FakeModel(), detector=FakeModel())
+        aw._release_models()
+        assert aw._embedder is None, "CLAP singleton must be dropped"
+        assert aw._vocal_detector is None, "Demucs singleton must be dropped"
+        assert aw._embed_failed is False, "release must NOT latch the CLAP failure flag"
+        assert aw._vocal_failed is False, "release must NOT latch the Demucs failure flag"
+
+    test("releases both models without latching the failure flags", case_release_both)
+
+    # Releasing just one loaded model leaves the other alone.
+    def case_release_one():
+        keep = FakeModel()
+        reset(embedder=None, detector=keep)
+        aw._release_models()
+        assert aw._vocal_detector is None
+        assert aw._embedder is None
+
+        only_clap = FakeModel()
+        reset(embedder=only_clap, detector=None)
+        aw._release_models()
+        assert aw._embedder is None, "the loaded model is released"
+
+    test("releases whichever models are loaded", case_release_one)
+
+    # Nothing loaded → early return, no log, no trim.
+    def case_release_noop():
+        reset(embedder=None, detector=None)
+        assert aw._release_models() is None, "no-op release returns cleanly"
+
+    test("release with nothing loaded is a clean no-op", case_release_noop)
+
+    # ── malloc_trim is reached and never propagates a failure ────────────────
+    # It's a no-op off glibc (musl, macOS), so it must be swallowed. Force the
+    # failure by pointing ctypes.CDLL at something that raises.
+    def case_trim_safe():
+        import ctypes as _c
+
+        saved = _c.CDLL
+        try:
+            def boom(*_a, **_k):
+                raise OSError("no libc handle here")
+
+            _c.CDLL = boom
+            reset(embedder=FakeModel(), detector=FakeModel())
+            aw._release_models()  # must not raise
+            assert aw._embedder is None, "release still completes when trim is unavailable"
+        finally:
+            _c.CDLL = saved
+
+    test("malloc_trim failure is swallowed (non-glibc hosts)", case_trim_safe)
+
+    # ── Arming: the #1204 regression ─────────────────────────────────────────
+    # Pre-#1204 the guard was `resolve_device() != "cuda"`, so a CPU host never
+    # armed and a backfill's models sat resident until the container stopped.
+    def case_arms_on_cpu():
+        reset(armed=False)
+        with_device("cpu", lambda: with_env(None, aw._maybe_start_idle_release))
+        assert aw._idle_thread_started is True, "#1204: the release must arm on cpu"
+
+    test("arms on cpu (#1204)", case_arms_on_cpu)
+
+    def case_arms_on_cuda():
+        reset(armed=False)
+        with_device("cuda", lambda: with_env(None, aw._maybe_start_idle_release))
+        assert aw._idle_thread_started is True, "cuda must keep arming as before"
+
+    test("still arms on cuda", case_arms_on_cuda)
+
+    def case_disabled():
+        reset(armed=False)
+        with_device("cpu", lambda: with_env("0", aw._maybe_start_idle_release))
+        assert aw._idle_thread_started is False, "0 must disable the release entirely"
+
+    test("ANALYZE_IDLE_UNLOAD_S=0 does not arm", case_disabled)
+
+    def case_arms_once():
+        reset(armed=True)
+        with_device("cpu", lambda: with_env(None, aw._maybe_start_idle_release))
+        assert aw._idle_thread_started is True, "already-armed stays armed, no second thread"
+
+    test("arming is idempotent", case_arms_once)
+
+    # ── The idle window ─────────────────────────────────────────────────────
+    def case_window_defaults():
+        cuda = with_device("cuda", lambda: with_env(None, aw._idle_unload_seconds))
+        cpu = with_device("cpu", lambda: with_env(None, aw._idle_unload_seconds))
+        assert cuda == aw.IDLE_UNLOAD_CUDA_S, f"cuda default, got {cuda}"
+        assert cpu == aw.IDLE_UNLOAD_CPU_S, f"cpu default, got {cpu}"
+        assert cpu > cuda, (
+            "cpu window must be the longer one: a cold CPU reload lands on "
+            "interactive sound search (20s deadline), and swap pressure is not "
+            "as urgent as a starved GPU"
+        )
+
+    test("idle window defaults per device, cpu longer", case_window_defaults)
+
+    def case_window_env_wins():
+        for device in ("cpu", "cuda"):
+            got = with_device(device, lambda: with_env("42", aw._idle_unload_seconds))
+            assert got == 42.0, f"explicit env must win on {device}, got {got}"
+
+    test("ANALYZE_IDLE_UNLOAD_S overrides both devices", case_window_env_wins)
+
+    def case_window_garbage():
+        got = with_device("cpu", lambda: with_env("not-a-number", aw._idle_unload_seconds))
+        assert got == aw.IDLE_UNLOAD_CPU_S, "garbage env falls back to the default, never crashes"
+
+    test("unparseable idle window falls back to the default", case_window_garbage)
+
+    # ── The heavy clock, i.e. the other half of #1204 ────────────────────────
+    # A lean bpm/key request must not refresh the countdown. If it does, any
+    # station with steady analysis traffic pins CLAP+Demucs forever and the
+    # gate removal above buys nothing.
+    def case_lean_request_does_not_refresh():
+        reset(heavy_age_s=600.0)
+        stale = aw._heavy_last_used
+        # A lean pass calls neither getter (embed/vocal resolve to falsy), so
+        # nothing should touch the clock. Assert the getters are the ONLY writers
+        # by confirming a no-model code path leaves it alone.
+        aw._release_models()  # nothing loaded → no-op, must not stamp either
+        assert aw._heavy_last_used == stale, (
+            "#1204: a request that loads no model must not refresh the heavy clock"
+        )
+
+    test("lean request does not refresh the heavy clock (#1204)", case_lean_request_does_not_refresh)
+
+    def case_heavy_use_refreshes():
+        reset(heavy_age_s=600.0)
+        stale = aw._heavy_last_used
+        aw._touch_heavy()
+        assert aw._heavy_last_used > stale, "heavy use must refresh the countdown"
+
+    test("heavy use refreshes the clock", case_heavy_use_refreshes)
+
+    # get_embedder stamps the clock on a CACHE HIT, not just a fresh load —
+    # otherwise a long backfill could release mid-pass while still in use.
+    def case_cache_hit_stamps():
+        reset(embedder=FakeModel(), heavy_age_s=600.0)
+        stale = aw._heavy_last_used
+        got = aw.get_embedder(force=True)
+        assert got is not None, "a cached embedder is returned as-is"
+        assert aw._heavy_last_used > stale, (
+            "a cache hit must refresh the clock, or a long pass could release mid-use"
+        )
+
+    test("get_embedder cache hit refreshes the clock", case_cache_hit_stamps)
+
+    def case_detector_cache_hit_stamps():
+        reset(detector=FakeModel(), heavy_age_s=600.0)
+        stale = aw._heavy_last_used
+        got = aw.get_vocal_detector(force=True)
+        assert got is not None, "a cached detector is returned as-is"
+        assert aw._heavy_last_used > stale, "a cache hit must refresh the clock"
+
+    test("get_vocal_detector cache hit refreshes the clock", case_detector_cache_hit_stamps)
+
+    # A disabled/failed getter must not stamp the clock — it did no heavy work.
+    def case_declined_getter_does_not_stamp():
+        reset(heavy_age_s=600.0)
+        aw._embed_failed = True
+        stale = aw._heavy_last_used
+        assert aw.get_embedder(force=True) is None, "a latched failure returns None"
+        assert aw._heavy_last_used == stale, "a declined getter must not refresh the clock"
+
+    test("declined getter does not refresh the clock", case_declined_getter_does_not_stamp)
+
+    print("✓ idle_release_test.py passed" if not failures else f"✗ {failures} case(s) failed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker-compose.analyzer-gpu.yml
+++ b/docker-compose.analyzer-gpu.yml
@@ -21,10 +21,11 @@
 # degrades, not fails). To force CPU temporarily without dropping the overlay,
 # set ANALYZE_DEVICE=cpu in your root .env (the base compose passes it through).
 #
-# VRAM etiquette: after ~5 idle minutes the worker drops its models out of
-# VRAM so a co-resident TTS/LLM gets the card back between passes
-# (ANALYZE_IDLE_UNLOAD_S in .env tunes it; 0 keeps models resident). A few
-# hundred MB of CUDA context remain until the container stops.
+# VRAM etiquette: after ~5 idle minutes with no CLAP/Demucs use the worker
+# drops its models out of VRAM so a co-resident TTS/LLM gets the card back
+# between passes (ANALYZE_IDLE_UNLOAD_S in .env tunes it; 0 keeps models
+# resident). A few hundred MB of CUDA context remain until the container stops.
+# The same release runs on CPU with a longer default window (#1204).
 services:
   analyzer:
     image: ghcr.io/perminder-klair/subwave-analyzer-cuda:${SUBWAVE_VERSION:-latest}

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -315,8 +315,11 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=${ANALYZE_DEVICE:-}
-      # Seconds of no requests before the cuda flavour drops its models out of
-      # VRAM (default 300; 0 = never). CPU images ignore it.
+      # Seconds of no CLAP/Demucs use before the worker drops the models
+      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
+      # 1800 on cpu — one backfill or sound search loads them into the
+      # long-lived worker and nothing else ever releases them, so on a small
+      # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -255,8 +255,11 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=${ANALYZE_DEVICE:-}
-      # Seconds of no requests before the cuda flavour drops its models out of
-      # VRAM (default 300; 0 = never). CPU images ignore it.
+      # Seconds of no CLAP/Demucs use before the worker drops the models
+      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
+      # 1800 on cpu — one backfill or sound search loads them into the
+      # long-lived worker and nothing else ever releases them, so on a small
+      # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -358,8 +358,11 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=${ANALYZE_DEVICE:-}
-      # Seconds of no requests before the cuda flavour drops its models out of
-      # VRAM (default 300; 0 = never). CPU images ignore it.
+      # Seconds of no CLAP/Demucs use before the worker drops the models
+      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
+      # 1800 on cpu — one backfill or sound search loads them into the
+      # long-lived worker and nothing else ever releases them, so on a small
+      # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}

--- a/docs/tts-heavy.md
+++ b/docs/tts-heavy.md
@@ -114,9 +114,10 @@ anywhere else it's `--gpus all` on your `docker run`. Everything below about
 device selection and VRAM applies there unchanged.
 
 Sharing the card with a local TTS or LLM? The worker plays nice: after ~5
-minutes with no analysis requests it drops its models out of VRAM and reloads
+minutes with no CLAP/Demucs use it drops its models out of VRAM and reloads
 them on the next request (`ANALYZE_IDLE_UNLOAD_S` in `.env` tunes the window;
-`0` keeps them resident). A few hundred MB of CUDA context remain until the
+`0` keeps them resident; CPU-only hosts get the same release with a longer
+30-minute default — #1204). A few hundred MB of CUDA context remain until the
 analyzer container stops. Pair it with the **quiet times** toggle on the admin
 Library page and a long scan pauses — and frees the GPU — whenever listeners
 are tuned in.

--- a/docs/unraid.md
+++ b/docs/unraid.md
@@ -224,7 +224,10 @@ that isn't in the lean image (the `-heavy` images are ~1.9 GB):
   station. Pin it explicitly with the `ANALYZE_DEVICE` variable (`auto`, the
   default, `cuda`, or `cpu`) if you'd rather be sure. Between passes the models
   drop out of VRAM after ~5 idle minutes, so a co-resident Ollama gets the card
-  back (`ANALYZE_IDLE_UNLOAD_S` tunes that; `0` keeps them resident).
+  back (`ANALYZE_IDLE_UNLOAD_S` tunes that; `0` keeps them resident). The same
+  release runs on CPU-only boxes, with a longer default window (30 minutes):
+  the heavy models load once for a backfill or a sound search and would
+  otherwise sit in RAM — and eventually swap — for the life of the container.
 
   Fair warning on size: the CUDA image is **~4 GB compressed** (~11 GB on disk)
   against `-heavy`'s ~1.3 GB, because the CUDA runtime ships inside the torch


### PR DESCRIPTION
## What

Arms the existing idle model unloader on CPU devices, adds `malloc_trim(0)` to `_release_models()`, and splits the idle clock so it tracks heavy model usage rather than every request.

## Why

Fixes #1204.

`_maybe_start_idle_release()` only armed when `resolve_device() == "cuda"`, so on CPU-only hosts nothing ever released the CLAP/Demucs singletons after a backfill or stem cache pass. One field host eventually reached:

- `VmHWM: 2412076 kB`
- `VmRSS: 216584 kB`
- `VmSwap: 1516228 kB`

## How Tested

Testing was performed on an isolated worker running inside a purpose-built LXC matching the field host:

- 6291456 kB RAM
- 3145728 kB swap
- `vm.swappiness=10`
- image digest `sha256:adca29e2...`
- device: `cpu`
- `ANALYZE_IDLE_UNLOAD_S=120`
- `ANALYZE_AUDIO_EMBEDDING` and `ANALYZE_VOCAL_ACTIVITY` unset so models were only loaded through the per-request `force=True` path

The workload consisted of:

- a five-track backfill with `embed`, `vocal`, and `complete`
- lightweight BPM/key requests every 15 seconds throughout the idle window

Peak `VmHWM` reached **2,164,900–2,172,044 kB** across the three runs, compared with **2,412,076 kB** on the field host, indicating the synthetic workload reproduces the real memory profile rather than a substantially smaller one.

Three variants were run on the same host using the same workload.

| | A: shipped | B: gate removal + trim | C: this PR |
|---|---:|---:|---:|
| Before load | 40,540 kB | 41,680 kB | 41,660 kB |
| After backfill | 1,820,900 kB | 1,885,276 kB | 1,752,976 kB |
| After idle window | 1,734,172 kB | 1,652,520 kB | 1,070,352 kB |
| Reclaimed | 86,728 kB | 232,756 kB | 682,624 kB |
| **Release fired** | **NO** | **NO** | **YES** |

The result that matters is the final row rather than the reclaimed RSS. Variants A and B never logged a release, while Variant C logged:

```text
[analyze-worker] analysis device: cpu
[analyze-worker] idle model release armed — models unload after 120s without heavy use
[analyze-worker] idle 120s — released CLAP + Demucs from system memory (reloads on next use)
```

The reclaimed RSS values come from single runs and show visible variance. Variants A and B peaked 68 MB and 132 MB above Variant C on otherwise identical workloads, so those numbers should be treated as indicative rather than precise. The release/no-release behaviour reproduced consistently and is the primary result.

### Why the idle clock split is necessary

Variant B contains only the two obvious changes:

```diff
+ ctypes.CDLL(None).malloc_trim(0)          # in _release_models

- if ... or resolve_device() != "cuda":
+ if _idle_thread_started or IDLE_UNLOAD_S <= 0:
```

Despite those changes, Variant B still never releases the models.

The reason is that the existing `_touch()` updates the idle timer on **every** request. Lightweight BPM/key analysis never loads CLAP or Demucs, but it continually refreshes the timer, preventing the countdown from ever reaching the unload threshold. On any installation with regular analysis traffic, those two changes alone are effectively a no-op.

Variant C resolves this by tracking heavy model usage separately. The idle release occurred between **t = 502.9 s** and **t = 517.9 s** while lightweight requests continued arriving every 15 seconds.

Additional verification:

- `idle_release_test.py`: 16 test cases, all passing in the image's production virtual environment
- `vocal_gate_test.py`: unchanged and still passing
- `npm test`: the same 12 failing TypeScript tests reproduced on a clean `develop` checkout with this branch stashed; this PR does not modify any TypeScript

## Notes for Reviewers

This testing intentionally does **not** establish the following:

- **`VmSwap` remained 0 in all three runs.** The test host had sufficient free RAM, so the kernel never reclaimed pages. This fix prevents model weights from remaining resident long enough to become swap candidates, but it does not reproduce the original swap event.
- **Residual RSS after release remained 1,028,692 kB above baseline**, higher than the few hundred MB discussed in the issue. A CLAP-only run settled at 813,968 kB, suggesting most of the remaining memory is likely librosa, numba, or Torch scratch space rather than model weights. That is probably worth investigating separately.
- **The contribution of `malloc_trim()` is not isolated.** Variant B never reached the unload path, so `malloc_trim()` was never executed there. Its contribution is therefore included within Variant C's total reclaimed memory.
- **The 1800 second CPU default is a judgement call rather than a measured optimum.** All measurements used a 120 second timeout. The implementation is identical apart from the threshold, and I am happy to adjust the default if reviewers prefer a different value.

One remaining correctness gap is worth calling out explicitly: although unit tests verify the singleton and failure-flag behaviour after unloading, I have not yet exercised a real heavy analysis request after an idle release to confirm that models reload correctly from the on-disk cache. I can add that validation before merge if reviewers would find it valuable.

## Out of Scope

While tracing model load paths, I found another force-load path that is unrelated to this issue.

`{"texts": [...]}` requests always call:

```python
get_embedder(force=True)
```

This path is reached by:

- `/library/search-sound`
- the DJ picker's `searchBySound` tool

As a result, CLAP can become resident even without an admin backfill or stem cache pass. That behaviour is unchanged by this PR.