### PR TITLE
fix(broadcast): stop a station ident stacking onto a track's own link (#1258)

### DIFF
--- a/controller/scripts/ident-link-collision.test.ts
+++ b/controller/scripts/ident-link-collision.test.ts
@@ -1,0 +1,119 @@
+// Regression test for the ident-vs-link boundary guard (boundaryCarriesTrackVoice).
+// Run: `tsx scripts/ident-link-collision.test.ts`.
+//
+// Issue #1258. Two talkers reach the same track boundary from different clocks:
+//
+//   - the station ident is WALL-CLOCK scheduled (cron at :15/:30/:45), then
+//     deferred by announceAtNextTrack to the next track start;
+//   - a link/intro is TRACK-TIED — it airs when its own song starts.
+//
+// So the ident lands exactly where a link already lives. They're different
+// kinds, so no per-kind cooldown sees the pair, and airVoice's serialiser only
+// stops them OVERLAPPING — back to back with no music between is what it
+// produces. Reported as 16s and 25s gaps, i.e. one segment's own length.
+//
+// The guard answers one question — "does this boundary already speak?" — and
+// airPendingVoice holds the ident for the next boundary when it does. These
+// asserts pin both observed orderings and, crucially, that the ident is NOT
+// suppressed at a boundary that turns out to be silent (idents must still air).
+//
+// node:assert-via-tsx style, matching scripts/stale-link.test.ts.
+
+import assert from 'node:assert/strict';
+import { boundaryCarriesTrackVoice } from '../src/broadcast/queue.js';
+
+const PREV = { id: 'song-P', title: 'Previous Pulsar', artist: 'Artist P' };
+const OTHER = { id: 'song-O', title: 'Other Orbit', artist: 'Artist O' };
+
+let failures = 0;
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err: any) {
+    failures++;
+    console.error(`  ✗ ${name}\n      ${err?.message || err}`);
+  }
+}
+
+function main() {
+  console.log('ident vs track-tied link at one boundary (boundaryCarriesTrackVoice):');
+
+  test('untracked auto-playlist track (no queue item) → boundary is silent, ident airs', () => {
+    assert.equal(boundaryCarriesTrackVoice(null, PREV), false);
+    assert.equal(boundaryCarriesTrackVoice(undefined, PREV), false);
+  });
+
+  test('tracked item with no intro at all → boundary is silent, ident airs', () => {
+    assert.equal(boundaryCarriesTrackVoice({}, PREV), false);
+    assert.equal(boundaryCarriesTrackVoice({ introScript: null, introWav: null }, PREV), false);
+    assert.equal(boundaryCarriesTrackVoice({ introScript: '' }, PREV), false);
+  });
+
+  // Example 1 in the report: 09:34:06 ident, 09:34:22 link — the link was
+  // waiting on the very track the ident's boundary belongs to.
+  test('item carrying an unaired link → boundary speaks, ident holds', () => {
+    assert.equal(
+      boundaryCarriesTrackVoice({ introScript: "here's something new", introKind: 'link' }, PREV),
+      true);
+  });
+
+  test('rendered WAV but no script left on the item → still counts as speaking', () => {
+    assert.equal(boundaryCarriesTrackVoice({ introWav: '/var/sub-wave/voices/link.wav' }, PREV), true);
+  });
+
+  // Example 2 in the report: 09:46:18 link, 09:46:43 ident — reversed, because
+  // onBedStarted aired the link over the bed seconds before the song started.
+  // The item is still in `upcoming` with introAired already set; the listener
+  // has just heard it, so the ident must still stand down.
+  test('BED case — link already aired over the bed, item still upcoming → ident holds', () => {
+    assert.equal(
+      boundaryCarriesTrackVoice(
+        { introScript: 'up next, something warm', introKind: 'link', introAired: true, bedded: true },
+        PREV),
+      true);
+  });
+
+  test('listener request intro (dj-speak, never back-announces) → ident holds', () => {
+    assert.equal(
+      boundaryCarriesTrackVoice(
+        { introScript: 'this one goes out to Sam', introKind: 'dj-speak', linkPrev: null },
+        PREV),
+      true);
+  });
+
+  // airIntro drops a link that NAMES a predecessor which isn't what actually
+  // played (shouldDropStaleLink). That boundary ends up silent, so suppressing
+  // the ident there would trade one voice for none.
+  test('link airIntro will drop as a stale back-announce → boundary is silent, ident airs', () => {
+    assert.equal(
+      boundaryCarriesTrackVoice(
+        { introScript: 'that was Previous Pulsar, and now this', introKind: 'link', linkPrev: PREV },
+        OTHER),
+      false);
+  });
+
+  test('forward-looking link after a queue-jumping request → still speaks, ident holds', () => {
+    assert.equal(
+      boundaryCarriesTrackVoice(
+        { introScript: "keeping it moving, here's the next one", introKind: 'link', linkPrev: PREV },
+        OTHER),
+      true);
+  });
+
+  test('back-announce naming the RIGHT predecessor → speaks, ident holds', () => {
+    assert.equal(
+      boundaryCarriesTrackVoice(
+        { introScript: 'that was Previous Pulsar', introKind: 'link', linkPrev: PREV },
+        PREV),
+      true);
+  });
+
+  if (failures) {
+    console.error(`\n${failures} assertion(s) failed`);
+    process.exit(1);
+  }
+  console.log('\nAll ident/link boundary assertions passed.');
+}
+
+main();

--- a/controller/scripts/ident-link-collision.test.ts
+++ b/controller/scripts/ident-link-collision.test.ts
@@ -59,7 +59,34 @@ function main() {
   });
 
   test('rendered WAV but no script left on the item → still counts as speaking', () => {
+    // No wavExists probe supplied — the file is assumed present.
     assert.equal(boundaryCarriesTrackVoice({ introWav: '/var/sub-wave/voices/link.wav' }, PREV), true);
+  });
+
+  // airIntro's own drop paths, injected via opts — each leaves the boundary
+  // silent, so the ident may take it after all.
+  test('station voice off — airIntro drops the link, boundary silent → ident airs', () => {
+    assert.equal(
+      boundaryCarriesTrackVoice(
+        { introScript: "here's something new", introKind: 'link' },
+        PREV, { voiceAllowed: false }),
+      false);
+  });
+
+  test('WAV reaped and no script to re-render from → boundary silent, ident airs', () => {
+    assert.equal(
+      boundaryCarriesTrackVoice(
+        { introWav: '/var/sub-wave/voices/gone.wav' },
+        PREV, { wavExists: () => false }),
+      false);
+  });
+
+  test('WAV reaped but the script survives (airIntro re-renders) → still speaks', () => {
+    assert.equal(
+      boundaryCarriesTrackVoice(
+        { introScript: "here's something new", introWav: '/var/sub-wave/voices/gone.wav' },
+        PREV, { wavExists: () => false }),
+      true);
   });
 
   // Example 2 in the report: 09:46:18 link, 09:46:43 ident — reversed, because
@@ -69,7 +96,7 @@ function main() {
   test('BED case — link already aired over the bed, item still upcoming → ident holds', () => {
     assert.equal(
       boundaryCarriesTrackVoice(
-        { introScript: 'up next, something warm', introKind: 'link', introAired: true, bedded: true },
+        { introScript: 'up next, something warm', introKind: 'link', introAired: true },
         PREV),
       true);
   });

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -1344,8 +1344,15 @@ class Queue {
     // and can't be moved; the ident is generic, so it keeps its slot and takes
     // the next boundary — with a whole track of music in between, which is the
     // entire point. Nothing is regenerated: the rendered WAV just waits.
+    // voiceAllowed/wavExists cover airIntro's own drop paths — a boundary whose
+    // line airIntro will drop (voice switch off, WAV reaped with no script) is
+    // silent, so holding for it would trade one voice for none. Both checks are
+    // synchronous, keeping the decision ahead of this function's first await.
     const incoming = this.upcoming[this.matchUpcomingIndex(np)] || null;
-    if (boundaryCarriesTrackVoice(incoming, this.current?.track || null)) {
+    if (boundaryCarriesTrackVoice(incoming, this.current?.track || null, {
+      voiceAllowed: autoVoiceAllowed(),
+      wavExists: path => existsSync(path),
+    })) {
       this.log('scheduler',
         `Holding ${p.kind} — the track's own ${KIND_LABEL[incoming!.introKind || 'dj-speak'] || 'intro'} takes this boundary`);
       return;

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -56,6 +56,7 @@ import {
   BACKFILL_DEDUP_MAX_GAP_MS,
   EMPTY_DJ_QUEUE_CLEAR_THRESHOLD,
   PICK_SHOW_LOOKAHEAD_SEC,
+  boundaryCarriesTrackVoice,
   formatAgo,
   knownDurationSec,
   pickLeadSec,
@@ -80,7 +81,7 @@ import {
 } from './queue/voice-io.js';
 
 // Re-exported so every existing `from './queue.js'` import keeps working.
-export { BACKFILL_DEDUP_MAX_GAP_MS, playAlreadyRecorded, shouldDropStaleLink } from './queue/pure.js';
+export { BACKFILL_DEDUP_MAX_GAP_MS, boundaryCarriesTrackVoice, playAlreadyRecorded, shouldDropStaleLink } from './queue/pure.js';
 export { registerSkillKinds } from './queue/kinds.js';
 export type { NowPlaying, QueueItem, Track } from './queue/types.js';
 
@@ -1295,13 +1296,34 @@ class Queue {
     this.log('scheduler', `Dropped pending ${p.kind} — ${reason}`);
   }
 
+  // Index in `upcoming` of the item Liquidsoap is now reporting, or -1. Matched
+  // by subsonic_id first (reliable), falling back to title+artist for older
+  // items that pre-date the id annotation. Extracted from onTrackStarted so
+  // airPendingVoice can look at the SAME incoming item that tick is about to
+  // consume, without a second matcher drifting out of step with this one.
+  matchUpcomingIndex(np: NowPlaying | null): number {
+    if (!np) return -1;
+    let idx = -1;
+    if (np.subsonic_id) {
+      idx = this.upcoming.findIndex(u => u.track.id && u.track.id === np.subsonic_id);
+    }
+    if (idx < 0) {
+      idx = this.upcoming.findIndex(
+        u => u.track.title === np.title && (u.track.artist || '') === (np.artist || '')
+      );
+    }
+    return idx;
+  }
+
   // Air the boundary-deferred segment, if one is pending. Called from
-  // onTrackStarted BEFORE airIntro so the ident lands ahead of the track's own
-  // link in the shared voice chain (ident → link reads as a natural hand-off).
+  // onTrackStarted the moment a new track starts — but NOT at every boundary:
+  // one that already carries the track's own link/intro belongs to that line
+  // alone (#1258), and the ident holds for the next one instead.
   // The prompt context bakes in the local clock, so a clip that waited past
-  // PENDING_VOICE_MAX_AGE_MS (a long mix, a stream stall) is dropped rather
-  // than aired with a stale time reference — the next cron fire replaces it.
-  async airPendingVoice() {
+  // PENDING_VOICE_MAX_AGE_MS (a long mix, a stream stall, a long run of
+  // link-carrying boundaries) is dropped rather than aired with a stale time
+  // reference — the next cron fire replaces it.
+  async airPendingVoice(np: NowPlaying | null = null) {
     // A mic-pass is already pending from an earlier roll (the hourly cron rolls
     // without airing) and will take this boundary. The same-tick case — where
     // the roll happens in onTrackStarted's auto-pick block, AFTER this runs —
@@ -1312,11 +1334,23 @@ class Queue {
     }
     const p = this._pendingVoice;
     if (!p) return;
-    this._pendingVoice = null;
+    // Staleness first: a clip too old to air is dropped outright rather than
+    // held again below, so a busy stretch can't keep re-deferring a dead ident.
     if (Date.now() - p.t > PENDING_VOICE_MAX_AGE_MS) {
-      this.log('scheduler', `Dropped pending ${p.kind} — waited too long for a track boundary`);
+      this.dropPendingVoice('waited too long for a track boundary');
       return;
     }
+    // This boundary already speaks. The track's own line is tied to THIS song
+    // and can't be moved; the ident is generic, so it keeps its slot and takes
+    // the next boundary — with a whole track of music in between, which is the
+    // entire point. Nothing is regenerated: the rendered WAV just waits.
+    const incoming = this.upcoming[this.matchUpcomingIndex(np)] || null;
+    if (boundaryCarriesTrackVoice(incoming, this.current?.track || null)) {
+      this.log('scheduler',
+        `Holding ${p.kind} — the track's own ${KIND_LABEL[incoming!.introKind || 'dj-speak'] || 'intro'} takes this boundary`);
+      return;
+    }
+    this._pendingVoice = null;
     if (!existsSync(p.wavPath)) return;
     try {
       await airVoice(config.liquidsoap.introFile, p.wavPath, p.text, voiceGainDb(p.kind, p.persona));
@@ -1461,10 +1495,13 @@ class Queue {
     this.lastSeenKey = key;
 
     // A fresh track boundary — air any boundary-deferred segment (station
-    // ident) now. Fired BEFORE airIntro below so the shared voice chain plays
-    // ident → link in that order. Fire-and-forget for the same reason as
-    // airIntro: must not stall the watcher tick.
-    void this.airPendingVoice();
+    // ident) now, unless this boundary already carries the incoming track's own
+    // link/intro, in which case the ident holds for the next one (#1258). `np`
+    // is passed so it can see that item while it's still in `upcoming` — the
+    // consume+splice below happens after this, and the decision is made before
+    // this call's first await. Fire-and-forget for the same reason as airIntro:
+    // must not stall the watcher tick.
+    void this.airPendingVoice(np);
 
     // Snapshot the outgoing track BEFORE the history roll mutates `this.current`
     // — scrobble.onTrackEvent below needs the previous play + its start time
@@ -1495,16 +1532,9 @@ class Queue {
     }
 
     // Match upcoming by subsonic_id first (reliable), fall back to title+artist
-    // for older items that pre-date the id annotation.
-    let idx = -1;
-    if (np.subsonic_id) {
-      idx = this.upcoming.findIndex(u => u.track.id && u.track.id === np.subsonic_id);
-    }
-    if (idx < 0) {
-      idx = this.upcoming.findIndex(
-        u => u.track.title === np.title && (u.track.artist || '') === (np.artist || '')
-      );
-    }
+    // for older items that pre-date the id annotation. Same matcher
+    // airPendingVoice used above, so the two always agree on the incoming item.
+    const idx = this.matchUpcomingIndex(np);
 
     if (idx >= 0) {
       // Drop everything ahead of the match too: the queue is strictly FIFO, so

--- a/controller/src/broadcast/queue/pure.ts
+++ b/controller/src/broadcast/queue/pure.ts
@@ -171,6 +171,36 @@ export function shouldDropStaleLink(
   return mentionsTrack(item.introScript, item.linkPrev);     // wrong predecessor — only drop if it's actually named
 }
 
+// Does the track now starting already bring its OWN spoken line to this
+// boundary — an auto-DJ link, or a listener request's intro? If so a
+// boundary-deferred wall-clock segment (the station ident) must NOT also air
+// here: the two are different kinds, so no per-kind cooldown sees the pair, and
+// the airVoice serialiser only stops them OVERLAPPING — back to back with no
+// music between is precisely what it produces (issue #1258).
+//
+// `introAired` is deliberately NOT consulted. An item still sitting in
+// `upcoming` whose intro has already fired is the BED case: onBedStarted airs
+// the link over the instrumental bed seconds before the song itself starts, so
+// the ident would land right behind a link the listener just heard — the same
+// collision with the order reversed.
+//
+// The one exception is a link airIntro is about to drop as a stale
+// back-announce: that boundary ends up silent after all, so the ident is the
+// only thing that would speak and it should. Pure + exported so the rule is
+// unit-pinned (scripts/ident-link-collision.test.ts).
+export function boundaryCarriesTrackVoice(
+  item: {
+    introScript?: string | null;
+    introWav?: string | null;
+    linkPrev?: { id?: string | null; title?: string | null; artist?: string | null } | null;
+  } | null | undefined,
+  predecessor: { id?: string | null; title?: string | null } | null,
+): boolean {
+  if (!item) return false;
+  if (!item.introScript && !item.introWav) return false;
+  return !shouldDropStaleLink(item, predecessor);
+}
+
 // Per-target-file write chain. Liquidsoap polls each handoff file (say.txt,
 // intro.txt, sfx.txt, next.txt) on a 0.5-1.0s interval and DELETES the file
 // after reading it (see liquidsoap/radio.liq poll_voice/poll_intro/poll_sfx/

--- a/controller/src/broadcast/queue/pure.ts
+++ b/controller/src/broadcast/queue/pure.ts
@@ -188,16 +188,37 @@ export function shouldDropStaleLink(
 // back-announce: that boundary ends up silent after all, so the ident is the
 // only thing that would speak and it should. Pure + exported so the rule is
 // unit-pinned (scripts/ident-link-collision.test.ts).
+//
+// The rule mirrors airIntro's own airing decision, and `opts` carries the two
+// runtime drop paths the item's fields alone can't predict — both of which
+// leave the boundary silent, so the ident may take it after all:
+//   - `voiceAllowed` — airIntro's station-voice backstop (settings.tts.enabled
+//     off) drops the line outright. The pending segment itself may still air:
+//     manual /dj/segment triggers are exempt from the voice switch.
+//   - `wavExists` — a rendered WAV the voice reaper has already deleted, with
+//     no script left on the item to re-render from, is a silent return in
+//     airIntro. A surviving script always speaks (airIntro re-renders).
+// Injected rather than read here so the rule stays pure; omitting them assumes
+// voice on and the WAV present.
 export function boundaryCarriesTrackVoice(
   item: {
     introScript?: string | null;
     introWav?: string | null;
+    // Part of the contract even though this rule never reads them: introAired
+    // is deliberately ignored (the BED case above), and introKind doesn't
+    // matter — links and request intros are both track-tied and unmovable.
+    introKind?: string | null;
+    introAired?: boolean;
     linkPrev?: { id?: string | null; title?: string | null; artist?: string | null } | null;
   } | null | undefined,
   predecessor: { id?: string | null; title?: string | null } | null,
+  opts: { voiceAllowed?: boolean; wavExists?: (path: string) => boolean } = {},
 ): boolean {
   if (!item) return false;
-  if (!item.introScript && !item.introWav) return false;
+  if (opts.voiceAllowed === false) return false;
+  const canSpeak = !!item.introScript
+    || (!!item.introWav && (opts.wavExists ? opts.wavExists(item.introWav) : true));
+  if (!canSpeak) return false;
   return !shouldDropStaleLink(item, predecessor);
 }
 


### PR DESCRIPTION
Fixes #1258.

## The collision

Two talkers reach the same track boundary from different clocks:

- **Idents are wall-clock scheduled** — `cron.schedule('15,30,45 * * * *', stationId)`, which calls `runStationId({ atNextTrack: true })` → `announceAtNextTrack()`, parking the rendered WAV in `_pendingVoice` until the next track start.
- **Links are track-tied** — `airIntro()` fires when the pick's own song starts.

`onTrackStarted` then ran `airPendingVoice()` immediately before `airIntro()`, with a comment claiming `ident → link` "reads as a natural hand-off". They're different kinds, so no per-kind cooldown sees the pair, and `airVoice`'s `_voiceChain` only stops them *overlapping* — back to back with no music between is precisely what it produces. The reporter's 16s and 25s gaps are one segment's own playback length.

Their second example has the order reversed, which is a **bed**: `onBedStarted` airs the link over the instrumental bed seconds before the song starts, then the ident lands at the real track boundary.

## The fix

`airPendingVoice` now asks whether the incoming track already brings its own spoken line, and **holds** the ident for the next boundary if so.

Holding rather than dropping is deliberate: the ident isn't lost, it just waits one track, so the cadence stays close to what the frequency rung intends and nothing is regenerated — the WAV sits in the same one-slot `_pendingVoice`, and a fresh cron fire supersedes it as before. The existing `PENDING_VOICE_MAX_AGE_MS` check is moved ahead of the new one, so a long run of link-carrying boundaries drops the clip as stale instead of re-deferring it forever.

The rule is the pure `boundaryCarriesTrackVoice()` in `queue/pure.ts`:

- **Ignores `introAired`** — an item still sitting in `upcoming` whose intro already fired is the bed case above, and the listener has just heard it.
- **Defers to `shouldDropStaleLink`** — a link `airIntro` is about to drop as a stale back-announce leaves the boundary genuinely silent, so the ident airs there after all rather than trading one voice for none.
- Covers listener-request intros (`dj-speak`) as well as auto-DJ links; both are track-tied and unmovable.

`onTrackStarted`'s inline upcoming matcher is extracted to `matchUpcomingIndex()` so both call sites resolve the same incoming item rather than drifting apart. The decision runs synchronously, before `airPendingVoice`'s first `await` and before the consume+splice, so it sees the item while it's still in `upcoming`.

## What is *not* changed

- **Ident vs skill segment** — the segment director already floors against `getLastVoiceAt(['station-id','hourly-check','handoff','banter'])`. Its exclusion of track-tied kinds is deliberate (a global gap over links would mute it outright on a chatty station), so this PR leaves it alone.
- **No new setting.** The rule is structural, not a cadence dial.
- Boundaries with no link behave byte-for-byte as before.

## Note for the reporter

They said they're on `moderate` but their log shows idents at `:30` *and* `:45`. `effectiveFrequency` bumps a DJ-mode persona one rung up, so a moderate DJ-mode persona idents at :15/:30/:45 — three an hour, not two. Lowering persona frequency would only have made the collision rarer, never fixed it.

## Testing

- `controller/scripts/ident-link-collision.test.ts` — 9 assertions pinning both observed orderings (link-about-to-air, and the bed case where it already aired), the stale-link exception, and that a silent boundary still lets the ident through.
- `npm run lint` in `controller/` — 0 errors.
- `npm test` in `controller/` — all 65 test files pass.

https://claude.ai/code/session_01CQfhcgxXdaXsFrFSGpLtnZ
