### PR TITLE
fix(analyzer): idle worker recycle, cold-embed retry, /health residency (#1204 follow-ups)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,9 +157,13 @@ SITE_URL=
 # the container. See docs/unraid.md.)
 # ANALYZE_DEVICE=    # auto (default) / cpu / cuda — torch device for CLAP/Demucs;
 #                    # only meaningful on the cuda analyzer flavour
-# ANALYZE_IDLE_UNLOAD_S=  # cuda flavour: seconds of no analysis before models are
-#                         # dropped from VRAM (default 300; 0 = keep resident).
-#                         # Frees the GPU for co-resident TTS/LLM between passes.
+# ANALYZE_IDLE_UNLOAD_S=  # seconds of no CLAP/Demucs use before the models are
+#                         # dropped (0 = keep resident). Defaults per device:
+#                         # 300 on cuda (frees the GPU for co-resident TTS/LLM
+#                         # between passes), 1800 on cpu (a backfill or sound
+#                         # search loads them once and they'd otherwise sit in
+#                         # RAM/swap forever; the longer window keeps the cold
+#                         # reload off interactive sound searches).
 #
 # Runtime flags — env wins ON over the admin toggles (settings.audio.*), never
 # off. A flag with no matching backend in the image is a clean no-op.

--- a/.env.example
+++ b/.env.example
@@ -164,6 +164,13 @@ SITE_URL=
 #                         # search loads them once and they'd otherwise sit in
 #                         # RAM/swap forever; the longer window keeps the cold
 #                         # reload off interactive sound searches).
+# ANALYZE_RECYCLE_IDLE_S= # sidecar only: seconds of no heavy use before the
+#                         # whole worker process is recycled (default 3600;
+#                         # 0 = never). The model release above hands back the
+#                         # weights; the recycle also reclaims the ~1GB of
+#                         # librosa/numba/torch scratch — and on cuda the CUDA
+#                         # context — that survive it. Next request re-pays the
+#                         # worker boot (a few seconds of imports).
 #
 # Runtime flags — env wins ON over the admin toggles (settings.audio.*), never
 # off. A flag with no matching backend in the image is a clean no-op.

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -719,8 +719,11 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=\${ANALYZE_DEVICE:-}
-      # Seconds of no requests before the cuda flavour drops its models out of
-      # VRAM (default 300; 0 = never). CPU images ignore it.
+      # Seconds of no CLAP/Demucs use before the worker drops the models
+      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
+      # 1800 on cpu — one backfill or sound search loads them into the
+      # long-lived worker and nothing else ever releases them, so on a small
+      # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=\${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
@@ -1002,8 +1005,11 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=\${ANALYZE_DEVICE:-}
-      # Seconds of no requests before the cuda flavour drops its models out of
-      # VRAM (default 300; 0 = never). CPU images ignore it.
+      # Seconds of no CLAP/Demucs use before the worker drops the models
+      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
+      # 1800 on cpu — one backfill or sound search loads them into the
+      # long-lived worker and nothing else ever releases them, so on a small
+      # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=\${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -373,6 +373,12 @@ services:
       # long-lived worker and nothing else ever releases them, so on a small
       # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=\${ANALYZE_IDLE_UNLOAD_S:-}
+      # Seconds of no heavy (CLAP/Demucs) use before the sidecar recycles the
+      # whole worker process — the full-memory reclaim behind the model release
+      # above, catching the ~1GB of librosa/numba/torch scratch a release can't
+      # return (default 3600; 0 = never). Requests racing a recycle queue
+      # behind the respawn rather than failing.
+      - ANALYZE_RECYCLE_IDLE_S=\${ANALYZE_RECYCLE_IDLE_S:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see
@@ -725,6 +731,12 @@ services:
       # long-lived worker and nothing else ever releases them, so on a small
       # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=\${ANALYZE_IDLE_UNLOAD_S:-}
+      # Seconds of no heavy (CLAP/Demucs) use before the sidecar recycles the
+      # whole worker process — the full-memory reclaim behind the model release
+      # above, catching the ~1GB of librosa/numba/torch scratch a release can't
+      # return (default 3600; 0 = never). Requests racing a recycle queue
+      # behind the respawn rather than failing.
+      - ANALYZE_RECYCLE_IDLE_S=\${ANALYZE_RECYCLE_IDLE_S:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see
@@ -1011,6 +1023,12 @@ services:
       # long-lived worker and nothing else ever releases them, so on a small
       # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=\${ANALYZE_IDLE_UNLOAD_S:-}
+      # Seconds of no heavy (CLAP/Demucs) use before the sidecar recycles the
+      # whole worker process — the full-memory reclaim behind the model release
+      # above, catching the ~1GB of librosa/numba/torch scratch a release can't
+      # return (default 3600; 0 = never). Requests racing a recycle queue
+      # behind the respawn rather than failing.
+      - ANALYZE_RECYCLE_IDLE_S=\${ANALYZE_RECYCLE_IDLE_S:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see
@@ -1315,6 +1333,13 @@ SITE_URL=
 #                         # search loads them once and they'd otherwise sit in
 #                         # RAM/swap forever; the longer window keeps the cold
 #                         # reload off interactive sound searches).
+# ANALYZE_RECYCLE_IDLE_S= # sidecar only: seconds of no heavy use before the
+#                         # whole worker process is recycled (default 3600;
+#                         # 0 = never). The model release above hands back the
+#                         # weights; the recycle also reclaims the ~1GB of
+#                         # librosa/numba/torch scratch — and on cuda the CUDA
+#                         # context — that survive it. Next request re-pays the
+#                         # worker boot (a few seconds of imports).
 #
 # Runtime flags — env wins ON over the admin toggles (settings.audio.*), never
 # off. A flag with no matching backend in the image is a clean no-op.

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -367,8 +367,11 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=\${ANALYZE_DEVICE:-}
-      # Seconds of no requests before the cuda flavour drops its models out of
-      # VRAM (default 300; 0 = never). CPU images ignore it.
+      # Seconds of no CLAP/Demucs use before the worker drops the models
+      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
+      # 1800 on cpu — one backfill or sound search loads them into the
+      # long-lived worker and nothing else ever releases them, so on a small
+      # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=\${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
@@ -1104,10 +1107,11 @@ export const COMPOSE_ANALYZER_GPU_YML = `# GPU opt-in overlay for the analyzer �
 # degrades, not fails). To force CPU temporarily without dropping the overlay,
 # set ANALYZE_DEVICE=cpu in your root .env (the base compose passes it through).
 #
-# VRAM etiquette: after ~5 idle minutes the worker drops its models out of
-# VRAM so a co-resident TTS/LLM gets the card back between passes
-# (ANALYZE_IDLE_UNLOAD_S in .env tunes it; 0 keeps models resident). A few
-# hundred MB of CUDA context remain until the container stops.
+# VRAM etiquette: after ~5 idle minutes with no CLAP/Demucs use the worker
+# drops its models out of VRAM so a co-resident TTS/LLM gets the card back
+# between passes (ANALYZE_IDLE_UNLOAD_S in .env tunes it; 0 keeps models
+# resident). A few hundred MB of CUDA context remain until the container stops.
+# The same release runs on CPU with a longer default window (#1204).
 services:
   analyzer:
     image: ghcr.io/perminder-klair/subwave-analyzer-cuda:\${SUBWAVE_VERSION:-latest}
@@ -1298,9 +1302,13 @@ SITE_URL=
 # the container. See docs/unraid.md.)
 # ANALYZE_DEVICE=    # auto (default) / cpu / cuda — torch device for CLAP/Demucs;
 #                    # only meaningful on the cuda analyzer flavour
-# ANALYZE_IDLE_UNLOAD_S=  # cuda flavour: seconds of no analysis before models are
-#                         # dropped from VRAM (default 300; 0 = keep resident).
-#                         # Frees the GPU for co-resident TTS/LLM between passes.
+# ANALYZE_IDLE_UNLOAD_S=  # seconds of no CLAP/Demucs use before the models are
+#                         # dropped (0 = keep resident). Defaults per device:
+#                         # 300 on cuda (frees the GPU for co-resident TTS/LLM
+#                         # between passes), 1800 on cpu (a backfill or sound
+#                         # search loads them once and they'd otherwise sit in
+#                         # RAM/swap forever; the longer window keeps the cold
+#                         # reload off interactive sound searches).
 #
 # Runtime flags — env wins ON over the admin toggles (settings.audio.*), never
 # off. A flag with no matching backend in the image is a clean no-op.

--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -279,6 +279,9 @@ def _release_models(idle_s=None):
     except Exception:  # noqa: BLE001 — best-effort, absent on musl/macOS
         pass
     idle_note = f"idle {int(idle_s)}s — " if idle_s else ""
+    # The sidecar's /health residency tracking matches this line on the
+    # worker's stderr ("released" + "reloads on next use" — see
+    # docker/analyzer/server.py _pump_stderr); keep the wording in sync.
     log(
         f"{idle_note}released {' + '.join(freed)} from {where} "
         "(reloads on next use)"

--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -36,6 +36,7 @@ natural-language "sounds like ..." search and zero-shot mood scoring against
 the stored audio vectors possible.
 """
 
+import ctypes
 import importlib.util
 import json
 import os
@@ -187,30 +188,65 @@ def resolve_device():
     return _DEVICE
 
 
-# --- Idle GPU release (#1099 follow-up) -------------------------------------
-# On the cuda device the resident CLAP + Demucs models hold multiple GB of
-# VRAM even when no analysis is running, starving co-resident GPU work (a
-# local TTS/LLM on the same card OOMed hours after a pass finished). A daemon
-# thread drops the model singletons after ANALYZE_IDLE_UNLOAD_S seconds with
-# no requests (default 300; 0 disables). CUDA-only: on cpu the models stay
-# resident as always — system RAM is cheap and reload latency isn't worth it.
-# The next request lazy-reloads from the on-disk HF cache. NOTE: torch's CUDA
-# context (a few hundred MB) survives until the process exits — stopping the
-# analyzer container is the full release.
-IDLE_UNLOAD_S = float(os.environ.get("ANALYZE_IDLE_UNLOAD_S", "").strip() or "300")
+# --- Idle model release (#1099 follow-up; CPU arming per #1204) -------------
+# The resident CLAP + Demucs models hold multiple GB even when no analysis is
+# running. A daemon thread drops the model singletons after the idle window
+# passes with no HEAVY use (0 disables); the next request lazy-reloads from the
+# on-disk HF / torch-hub cache.
+#
+# On cuda that starves co-resident GPU work (a local TTS/LLM on the same card
+# OOMed hours after a pass finished). On cpu it looked free — "system RAM is
+# cheap" — but #1204 showed otherwise: one admin backfill (or a stem-cache
+# pass, or a single sound search) force-loads both models into the long-lived
+# worker regardless of this process's env defaults, nothing ever releases them,
+# and on a small host the kernel eventually parks ~1.5GB of cold weights in
+# swap indefinitely. So the thread arms on both devices now.
+#
+# The window is device-aware: cuda keeps 300s (VRAM contention is urgent and a
+# GPU reload is fast), cpu defaults longer because a cold CPU reload is seconds
+# of latency that lands on interactive callers (analyzer.embedTexts gives sound
+# search a 20s deadline), and swap pressure is not urgent the way a starved GPU
+# is. ANALYZE_IDLE_UNLOAD_S overrides both. NOTE: torch's imported modules (and
+# on cuda its context) survive until the process exits — a few hundred MB stays
+# resident either way; stopping the analyzer container is the full release.
+IDLE_UNLOAD_CUDA_S = 300.0
+IDLE_UNLOAD_CPU_S = 1800.0
+_IDLE_UNLOAD_ENV = os.environ.get("ANALYZE_IDLE_UNLOAD_S", "").strip()
 
-_last_used = time.time()
+# Heavy-model clock, deliberately NOT a general request clock. A lean
+# bpm/key/loudness request touches no model, so letting it refresh this would
+# pin CLAP + Demucs in memory forever on any station with steady analysis
+# traffic — the release would only ever fire on an idle box (#1204). Only an
+# actual embedder / detector use moves it. `_model_lock` (held across request
+# handling AND unload) is what keeps a release from racing a request in flight.
+_heavy_last_used = time.time()
 _model_lock = threading.Lock()  # held during request handling AND unload
 _idle_thread_started = False
 
 
-def _touch():
-    global _last_used
-    _last_used = time.time()
+def _touch_heavy():
+    """Mark CLAP/Demucs as just used — resets the idle-release countdown."""
+    global _heavy_last_used
+    _heavy_last_used = time.time()
 
 
-def _release_models():
-    """Drop the loaded model singletons and return their VRAM. Leaves the
+def _idle_unload_seconds():
+    """Resolve the idle window. Called only from the arming path, never at
+    import: the default depends on the device, and resolve_device() imports
+    torch — which the lean librosa-only venv doesn't have."""
+    if _IDLE_UNLOAD_ENV:
+        try:
+            return float(_IDLE_UNLOAD_ENV)
+        except ValueError:
+            log(
+                f"ANALYZE_IDLE_UNLOAD_S={_IDLE_UNLOAD_ENV!r} is not a number; "
+                "using the per-device default"
+            )
+    return IDLE_UNLOAD_CUDA_S if resolve_device() == "cuda" else IDLE_UNLOAD_CPU_S
+
+
+def _release_models(idle_s=None):
+    """Drop the loaded model singletons and hand their memory back. Leaves the
     *_failed flags alone, so the next request reloads instead of no-opping."""
     global _embedder, _vocal_detector
     import gc
@@ -225,40 +261,56 @@ def _release_models():
     if not freed:
         return
     gc.collect()
+    where = "system memory"
     try:
         import torch
 
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
+            where = "GPU memory"
     except Exception:  # noqa: BLE001 — freeing is best-effort
         pass
+    # Hand the freed tensor heap back to the OS. gc.collect() returns it to
+    # glibc's arenas, which keeps it as cold anonymous pages the kernel then
+    # swaps out — exactly the 1.5GB #1204 measured. malloc_trim releases the
+    # trimmable top of those arenas instead. No-op (and harmless) off glibc.
+    try:
+        ctypes.CDLL(None).malloc_trim(0)
+    except Exception:  # noqa: BLE001 — best-effort, absent on musl/macOS
+        pass
+    idle_note = f"idle {int(idle_s)}s — " if idle_s else ""
     log(
-        f"idle {int(IDLE_UNLOAD_S)}s — released {' + '.join(freed)} from GPU memory "
+        f"{idle_note}released {' + '.join(freed)} from {where} "
         "(reloads on next use)"
     )
 
 
-def _idle_release_loop():
+def _idle_release_loop(idle_s):
     while True:
         time.sleep(30)
-        if time.time() - _last_used < IDLE_UNLOAD_S:
+        if time.time() - _heavy_last_used < idle_s:
             continue
         with _model_lock:
             # Re-check under the lock: a request may have landed while we
             # waited to acquire it (a slow track holds the lock for minutes).
-            if time.time() - _last_used >= IDLE_UNLOAD_S:
-                _release_models()
+            if time.time() - _heavy_last_used >= idle_s:
+                _release_models(idle_s)
 
 
 def _maybe_start_idle_release():
-    """Arm the idle-release thread — once, and only where it matters (cuda
-    device, unload enabled). Called after a heavy model actually loads."""
+    """Arm the idle-release thread — once, on either device (unload enabled).
+    Called after a heavy model actually loads."""
     global _idle_thread_started
-    if _idle_thread_started or IDLE_UNLOAD_S <= 0 or resolve_device() != "cuda":
+    if _idle_thread_started:
+        return
+    idle_s = _idle_unload_seconds()
+    if idle_s <= 0:
         return
     _idle_thread_started = True
-    threading.Thread(target=_idle_release_loop, daemon=True, name="idle-release").start()
-    log(f"idle GPU release armed — models unload after {int(IDLE_UNLOAD_S)}s without requests")
+    threading.Thread(
+        target=_idle_release_loop, args=(idle_s,), daemon=True, name="idle-release"
+    ).start()
+    log(f"idle model release armed — models unload after {int(idle_s)}s without heavy use")
 
 
 def _pearson(a, b):
@@ -718,6 +770,9 @@ def get_embedder(force=False):
             log(f"CLAP load failed ({ex}); audio embeddings disabled for this run")
             _embed_failed = True
             return None
+    # On the fresh load AND on every cache hit: continued use keeps the model
+    # warm, so a long backfill never releases mid-pass (#1204).
+    _touch_heavy()
     return _embedder
 
 
@@ -898,6 +953,8 @@ def get_vocal_detector(force=False):
             log(f"Demucs load failed ({ex or type(ex).__name__}); vocal activity disabled for this run")
             _vocal_failed = True
             return None
+    # Fresh load AND cache hit — see get_embedder (#1204).
+    _touch_heavy()
     return _vocal_detector
 
 
@@ -1600,7 +1657,6 @@ def main():
             ):
                 emit({"id": rid, "ok": False, "error": "texts must be 1-64 non-empty strings"})
                 continue
-            _touch()
             with _model_lock:
                 embedder = get_embedder(force=True)
                 if embedder is None:
@@ -1610,7 +1666,9 @@ def main():
                     emit({"id": rid, "ok": True, "text_embeddings": embedder.embed_texts(texts)})
                 except Exception as e:  # noqa: BLE001 — one bad request never kills the worker
                     emit({"id": rid, "ok": False, "error": str(e)})
-            _touch()
+                # Re-stamp on the way out so the clock reads from the END of the
+                # work, not its start. get_embedder() stamped on entry.
+                _touch_heavy()
             continue
         url = req.get("url")
         path = req.get("path")
@@ -1620,17 +1678,23 @@ def main():
         try:
             import librosa
 
-            # _touch() on both edges + the lock keep the idle-release thread
-            # honest: the clock reads fresh after a long track, and an unload
-            # can never race a request that's mid-flight.
-            _touch()
+            # No unconditional clock stamp here: this is the general request
+            # path and a lean bpm/key pass must NOT keep CLAP/Demucs pinned
+            # (#1204). The heavy clock is stamped inside get_embedder /
+            # get_vocal_detector; _model_lock is what keeps an unload from
+            # racing this request.
+            heavy_before = _heavy_last_used
             with _model_lock:
                 result = analyze(
                     librosa, url=url, path=path,
                     embed=req.get("embed"), vocal=req.get("vocal"),
                     complete=req.get("complete"), stems_dir=req.get("stems_dir"),
                 )
-            _touch()
+                # If a getter stamped the clock, this request DID use a model —
+                # re-stamp so the countdown starts from the end of the work, not
+                # its start (Demucs on a long track holds the lock for minutes).
+                if _heavy_last_used != heavy_before:
+                    _touch_heavy()
             emit({"id": rid, "ok": True, **result})
         except Exception as e:
             emit({"id": rid, "ok": False, "error": str(e)})

--- a/controller/scripts/analyzer-python.test.ts
+++ b/controller/scripts/analyzer-python.test.ts
@@ -1,0 +1,38 @@
+// Shim that folds the pure-stdlib Python suites into `npm test`'s *.test.ts
+// auto-discovery, so they actually run with the rest of the suite instead of
+// only when someone remembers `python3 scripts/<file>.py`. Each suite is
+// deliberately dependency-free (no torch / demucs / librosa / audio), so a
+// plain python3 is the only requirement; a box without one skips cleanly
+// (exit 0) rather than failing the suite — CI runs lint only, so this gate is
+// for contributors' own `npm test` runs.
+
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+
+const SUITES = [
+  'idle_release_test.py', // idle model release + heavy clock (#1099/#1204)
+  'vocal_gate_test.py', // vocal-stem gate thresholds (#1125)
+  'test_chatterbox_chunk.py', // chatterbox chunk_text (#1130)
+];
+
+const probe = spawnSync('python3', ['--version'], { stdio: 'ignore' });
+if (probe.error || probe.status !== 0) {
+  console.log('skipped: python3 not on PATH');
+  process.exit(0);
+}
+
+const failed: string[] = [];
+for (const file of SUITES) {
+  console.log(`— ${file}`);
+  const { status } = spawnSync('python3', [join(scriptsDir, file)], { stdio: 'inherit' });
+  if (status !== 0) failed.push(file);
+}
+
+if (failed.length > 0) {
+  console.error(`✗ python suite(s) failed: ${failed.join(', ')}`);
+  process.exit(1);
+}
+console.log('✓ analyzer-python.test.ts passed');

--- a/controller/scripts/idle_release_test.py
+++ b/controller/scripts/idle_release_test.py
@@ -195,11 +195,21 @@ def main():
     # station with steady analysis traffic pins CLAP+Demucs forever and the
     # gate removal above buys nothing.
     def case_lean_request_does_not_refresh():
+        # A lean bpm/key pass reaches the getters exactly like analyze() does —
+        # get_embedder(force=False) / get_vocal_detector(force=False) with the
+        # env flags off — and must bounce off the early return BEFORE the
+        # _touch_heavy() stamp. This is the precise call shape of the #1204
+        # traffic that pinned the models forever under the shared clock.
         reset(heavy_age_s=600.0)
         stale = aw._heavy_last_used
-        # A lean pass calls neither getter (embed/vocal resolve to falsy), so
-        # nothing should touch the clock. Assert the getters are the ONLY writers
-        # by confirming a no-model code path leaves it alone.
+        saved = aw.EMBED_ENABLED, aw.VOCAL_ENABLED
+        try:
+            aw.EMBED_ENABLED = False
+            aw.VOCAL_ENABLED = False
+            assert aw.get_embedder(force=False) is None, "lean pass loads no embedder"
+            assert aw.get_vocal_detector(force=False) is None, "lean pass loads no detector"
+        finally:
+            aw.EMBED_ENABLED, aw.VOCAL_ENABLED = saved
         aw._release_models()  # nothing loaded → no-op, must not stamp either
         assert aw._heavy_last_used == stale, (
             "#1204: a request that loads no model must not refresh the heavy clock"

--- a/controller/scripts/idle_release_test.py
+++ b/controller/scripts/idle_release_test.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# Unit test for the idle model release in analyze_worker (#1099 follow-up, CPU
+# arming per #1204) — the mechanism that hands CLAP/Demucs memory back instead
+# of leaving multiple GB resident for the life of the worker. Pure stdlib: no
+# torch, no demucs, no audio, no network, so it runs anywhere.
+# Run: `python3 scripts/idle_release_test.py` (exit 0 = pass).
+#
+# What this pins down, in the order it matters:
+#   - the models are released, and the *_failed flags are NOT set, so the next
+#     request reloads rather than silently no-opping forever;
+#   - the release arms on cpu (the #1204 regression) as well as cuda;
+#   - the countdown is driven by a HEAVY-use clock, not a general request clock.
+#     That last one is the subtle half of #1204: while the clock was shared, a
+#     station with steady lean bpm/key traffic would refresh it on every request
+#     and the release would only ever fire on an idle box.
+
+import os
+import sys
+
+# Import the worker with its shipped defaults. Heavy imports (torch/demucs/
+# librosa) are lazy, so importing is stdlib-cheap.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import analyze_worker as aw  # noqa: E402
+
+failures = 0
+
+
+def test(name, fn):
+    global failures
+    try:
+        fn()
+        print(f"  ✓ {name}")
+    except Exception as err:  # noqa: BLE001 — a failed assert is a reported case
+        failures += 1
+        print(f"  ✗ {name}\n      {err}")
+
+
+class FakeModel:
+    """Stands in for a loaded ClapEmbedder / VocalActivityDetector. Never
+    constructs a real model — the point is the release bookkeeping."""
+
+
+def reset(embedder=None, detector=None, armed=False, heavy_age_s=0.0):
+    """Put the worker's module-level release state in a known shape."""
+    import time as _t
+
+    aw._embedder = embedder
+    aw._vocal_detector = detector
+    aw._embed_failed = False
+    aw._vocal_failed = False
+    aw._idle_thread_started = armed
+    aw._heavy_last_used = _t.time() - heavy_age_s
+
+
+def with_device(device, fn):
+    """Run fn with resolve_device() stubbed — the real one imports torch."""
+    saved = aw.resolve_device
+    try:
+        aw.resolve_device = lambda: device
+        return fn()
+    finally:
+        aw.resolve_device = saved
+
+
+def with_env(value, fn):
+    """Run fn with the ANALYZE_IDLE_UNLOAD_S override set to `value` (None =
+    unset, i.e. fall through to the per-device default)."""
+    saved = aw._IDLE_UNLOAD_ENV
+    try:
+        aw._IDLE_UNLOAD_ENV = "" if value is None else value
+        return fn()
+    finally:
+        aw._IDLE_UNLOAD_ENV = saved
+
+
+def main():
+    print("idle model release (analyze_worker):")
+
+    # ── Release drops both singletons, keeps the failure flags clear ──────────
+    # The *_failed flags are the "never retry this load" latch. A release must
+    # not trip them, or one idle window would permanently disable embeddings
+    # for the life of the process.
+    def case_release_both():
+        reset(embedder=FakeModel(), detector=FakeModel())
+        aw._release_models()
+        assert aw._embedder is None, "CLAP singleton must be dropped"
+        assert aw._vocal_detector is None, "Demucs singleton must be dropped"
+        assert aw._embed_failed is False, "release must NOT latch the CLAP failure flag"
+        assert aw._vocal_failed is False, "release must NOT latch the Demucs failure flag"
+
+    test("releases both models without latching the failure flags", case_release_both)
+
+    # Releasing just one loaded model leaves the other alone.
+    def case_release_one():
+        keep = FakeModel()
+        reset(embedder=None, detector=keep)
+        aw._release_models()
+        assert aw._vocal_detector is None
+        assert aw._embedder is None
+
+        only_clap = FakeModel()
+        reset(embedder=only_clap, detector=None)
+        aw._release_models()
+        assert aw._embedder is None, "the loaded model is released"
+
+    test("releases whichever models are loaded", case_release_one)
+
+    # Nothing loaded → early return, no log, no trim.
+    def case_release_noop():
+        reset(embedder=None, detector=None)
+        assert aw._release_models() is None, "no-op release returns cleanly"
+
+    test("release with nothing loaded is a clean no-op", case_release_noop)
+
+    # ── malloc_trim is reached and never propagates a failure ────────────────
+    # It's a no-op off glibc (musl, macOS), so it must be swallowed. Force the
+    # failure by pointing ctypes.CDLL at something that raises.
+    def case_trim_safe():
+        import ctypes as _c
+
+        saved = _c.CDLL
+        try:
+            def boom(*_a, **_k):
+                raise OSError("no libc handle here")
+
+            _c.CDLL = boom
+            reset(embedder=FakeModel(), detector=FakeModel())
+            aw._release_models()  # must not raise
+            assert aw._embedder is None, "release still completes when trim is unavailable"
+        finally:
+            _c.CDLL = saved
+
+    test("malloc_trim failure is swallowed (non-glibc hosts)", case_trim_safe)
+
+    # ── Arming: the #1204 regression ─────────────────────────────────────────
+    # Pre-#1204 the guard was `resolve_device() != "cuda"`, so a CPU host never
+    # armed and a backfill's models sat resident until the container stopped.
+    def case_arms_on_cpu():
+        reset(armed=False)
+        with_device("cpu", lambda: with_env(None, aw._maybe_start_idle_release))
+        assert aw._idle_thread_started is True, "#1204: the release must arm on cpu"
+
+    test("arms on cpu (#1204)", case_arms_on_cpu)
+
+    def case_arms_on_cuda():
+        reset(armed=False)
+        with_device("cuda", lambda: with_env(None, aw._maybe_start_idle_release))
+        assert aw._idle_thread_started is True, "cuda must keep arming as before"
+
+    test("still arms on cuda", case_arms_on_cuda)
+
+    def case_disabled():
+        reset(armed=False)
+        with_device("cpu", lambda: with_env("0", aw._maybe_start_idle_release))
+        assert aw._idle_thread_started is False, "0 must disable the release entirely"
+
+    test("ANALYZE_IDLE_UNLOAD_S=0 does not arm", case_disabled)
+
+    def case_arms_once():
+        reset(armed=True)
+        with_device("cpu", lambda: with_env(None, aw._maybe_start_idle_release))
+        assert aw._idle_thread_started is True, "already-armed stays armed, no second thread"
+
+    test("arming is idempotent", case_arms_once)
+
+    # ── The idle window ─────────────────────────────────────────────────────
+    def case_window_defaults():
+        cuda = with_device("cuda", lambda: with_env(None, aw._idle_unload_seconds))
+        cpu = with_device("cpu", lambda: with_env(None, aw._idle_unload_seconds))
+        assert cuda == aw.IDLE_UNLOAD_CUDA_S, f"cuda default, got {cuda}"
+        assert cpu == aw.IDLE_UNLOAD_CPU_S, f"cpu default, got {cpu}"
+        assert cpu > cuda, (
+            "cpu window must be the longer one: a cold CPU reload lands on "
+            "interactive sound search (20s deadline), and swap pressure is not "
+            "as urgent as a starved GPU"
+        )
+
+    test("idle window defaults per device, cpu longer", case_window_defaults)
+
+    def case_window_env_wins():
+        for device in ("cpu", "cuda"):
+            got = with_device(device, lambda: with_env("42", aw._idle_unload_seconds))
+            assert got == 42.0, f"explicit env must win on {device}, got {got}"
+
+    test("ANALYZE_IDLE_UNLOAD_S overrides both devices", case_window_env_wins)
+
+    def case_window_garbage():
+        got = with_device("cpu", lambda: with_env("not-a-number", aw._idle_unload_seconds))
+        assert got == aw.IDLE_UNLOAD_CPU_S, "garbage env falls back to the default, never crashes"
+
+    test("unparseable idle window falls back to the default", case_window_garbage)
+
+    # ── The heavy clock, i.e. the other half of #1204 ────────────────────────
+    # A lean bpm/key request must not refresh the countdown. If it does, any
+    # station with steady analysis traffic pins CLAP+Demucs forever and the
+    # gate removal above buys nothing.
+    def case_lean_request_does_not_refresh():
+        reset(heavy_age_s=600.0)
+        stale = aw._heavy_last_used
+        # A lean pass calls neither getter (embed/vocal resolve to falsy), so
+        # nothing should touch the clock. Assert the getters are the ONLY writers
+        # by confirming a no-model code path leaves it alone.
+        aw._release_models()  # nothing loaded → no-op, must not stamp either
+        assert aw._heavy_last_used == stale, (
+            "#1204: a request that loads no model must not refresh the heavy clock"
+        )
+
+    test("lean request does not refresh the heavy clock (#1204)", case_lean_request_does_not_refresh)
+
+    def case_heavy_use_refreshes():
+        reset(heavy_age_s=600.0)
+        stale = aw._heavy_last_used
+        aw._touch_heavy()
+        assert aw._heavy_last_used > stale, "heavy use must refresh the countdown"
+
+    test("heavy use refreshes the clock", case_heavy_use_refreshes)
+
+    # get_embedder stamps the clock on a CACHE HIT, not just a fresh load —
+    # otherwise a long backfill could release mid-pass while still in use.
+    def case_cache_hit_stamps():
+        reset(embedder=FakeModel(), heavy_age_s=600.0)
+        stale = aw._heavy_last_used
+        got = aw.get_embedder(force=True)
+        assert got is not None, "a cached embedder is returned as-is"
+        assert aw._heavy_last_used > stale, (
+            "a cache hit must refresh the clock, or a long pass could release mid-use"
+        )
+
+    test("get_embedder cache hit refreshes the clock", case_cache_hit_stamps)
+
+    def case_detector_cache_hit_stamps():
+        reset(detector=FakeModel(), heavy_age_s=600.0)
+        stale = aw._heavy_last_used
+        got = aw.get_vocal_detector(force=True)
+        assert got is not None, "a cached detector is returned as-is"
+        assert aw._heavy_last_used > stale, "a cache hit must refresh the clock"
+
+    test("get_vocal_detector cache hit refreshes the clock", case_detector_cache_hit_stamps)
+
+    # A disabled/failed getter must not stamp the clock — it did no heavy work.
+    def case_declined_getter_does_not_stamp():
+        reset(heavy_age_s=600.0)
+        aw._embed_failed = True
+        stale = aw._heavy_last_used
+        assert aw.get_embedder(force=True) is None, "a latched failure returns None"
+        assert aw._heavy_last_used == stale, "a declined getter must not refresh the clock"
+
+    test("declined getter does not refresh the clock", case_declined_getter_does_not_stamp)
+
+    print("✓ idle_release_test.py passed" if not failures else f"✗ {failures} case(s) failed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/controller/scripts/idle_release_test.py
+++ b/controller/scripts/idle_release_test.py
@@ -90,18 +90,18 @@ def main():
 
     test("releases both models without latching the failure flags", case_release_both)
 
-    # Releasing just one loaded model leaves the other alone.
+    # A release drops whichever singleton is loaded; the absent one stays None
+    # (there is no third state — a release can't resurrect or latch anything).
     def case_release_one():
-        keep = FakeModel()
-        reset(embedder=None, detector=keep)
+        reset(embedder=None, detector=FakeModel())
         aw._release_models()
-        assert aw._vocal_detector is None
-        assert aw._embedder is None
+        assert aw._vocal_detector is None, "the loaded detector is released"
+        assert aw._embed_failed is False, "the absent embedder's flag stays clear"
 
-        only_clap = FakeModel()
-        reset(embedder=only_clap, detector=None)
+        reset(embedder=FakeModel(), detector=None)
         aw._release_models()
-        assert aw._embedder is None, "the loaded model is released"
+        assert aw._embedder is None, "the loaded embedder is released"
+        assert aw._vocal_failed is False, "the absent detector's flag stays clear"
 
     test("releases whichever models are loaded", case_release_one)
 

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -661,6 +661,16 @@ function localEmbedTexts(texts: string[], timeoutMs: number): Promise<number[][]
   });
 }
 
+// A deadline that expired mid-request, as opposed to a refused connection or a
+// capability 404/500 (which fail fast and mean "not available", not "still
+// working"). fetchWithTimeout aborts with a DOMException named 'AbortError';
+// the local stdio path rejects with a "timed out" Error.
+function isTimeoutError(err: unknown): boolean {
+  const name = (err as { name?: unknown } | null)?.name;
+  const message = (err as { message?: unknown } | null)?.message;
+  return name === 'AbortError' || (typeof message === 'string' && message.includes('timed out'));
+}
+
 // Embed a batch of texts through the CLAP TEXT tower — 512-d L2-normalised
 // vectors in the SAME space as the stored track audio vectors, so cosine
 // against them is meaningful (CLAP is contrastive audio–text). Used for
@@ -669,17 +679,28 @@ function localEmbedTexts(texts: string[], timeoutMs: number): Promise<number[][]
 // sidecar without /embed-text, worker without torch) — callers degrade to
 // their non-text behaviour, never throw. `timeoutMs` lets interactive callers
 // (a picker tool mid-pick) use a shorter deadline than a bulk pass.
+//
+// One retry on TIMEOUT only: since the idle model release also runs on CPU
+// (#1204), an interactive call can land on a cold worker whose CLAP reload
+// (seconds on a typical box, longer on the small hosts the release exists
+// for) eats the whole deadline. The backend keeps loading after we stop
+// waiting — the request is already queued behind its single-flight lock — so
+// a second wait usually lands on a warm model instead of failing the search.
+// Non-timeout failures (refused, 404, 500) stay single-shot: they're fast,
+// definitive "not available" signals. Bulk callers whose deadline is already
+// generous pass `coldRetry: false` — a 10-minute timeout means real trouble,
+// not a cold model.
 export async function embedTexts(
   texts: string[],
-  opts: { timeoutMs?: number } = {},
+  opts: { timeoutMs?: number; coldRetry?: boolean } = {},
 ): Promise<number[][] | null> {
   if (texts.length === 0) return [];
   const timeoutMs = opts.timeoutMs ?? config.analyzer.requestTimeoutMs;
   const backend = await resolveBackend();
   if (!backend) return null;
-  if (backend === 'sidecar') {
-    if (_sidecarTextCapable === false) return null;
-    try {
+  if (backend === 'sidecar' && _sidecarTextCapable === false) return null;
+  const attempt = async (): Promise<number[][] | null> => {
+    if (backend === 'sidecar') {
       const res = await fetchWithTimeout(`${_sidecarBase}/embed-text`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -692,15 +713,19 @@ export async function embedTexts(
       if (!res.ok) return null;
       const body = (await res.json()) as { ok?: boolean; embeddings?: unknown };
       return body?.ok ? parseVectors(body.embeddings, texts.length) : null;
+    }
+    if (!ready) await startWorker();
+    return await localEmbedTexts(texts, timeoutMs);
+  };
+  try {
+    return await attempt();
+  } catch (err) {
+    if (opts.coldRetry === false || !isTimeoutError(err)) return null;
+    try {
+      return await attempt();
     } catch {
       return null;
     }
-  }
-  try {
-    if (!ready) await startWorker();
-    return await localEmbedTexts(texts, timeoutMs);
-  } catch {
-    return null;
   }
 }
 

--- a/controller/src/music/audio-moods.ts
+++ b/controller/src/music/audio-moods.ts
@@ -93,7 +93,9 @@ export async function runAudioMoodPass(): Promise<AudioMoodStats> {
   // the live vocab once so prompts and the scoring loop stay index-aligned.
   const vocab = moodVocab();
   const prompts = vocab.map(moodPrompt);
-  const vecs = await analyzer.embedTexts(prompts, { timeoutMs: 10 * 60_000 });
+  // coldRetry off: with a deadline this generous, a timeout means the backend
+  // is broken, not cold — doubling it to 20 minutes would just stall the pass.
+  const vecs = await analyzer.embedTexts(prompts, { timeoutMs: 10 * 60_000, coldRetry: false });
   if (!vecs || vecs.length !== vocab.length) {
     // A backend that ADVERTISES the text tower but failed the call is a runtime
     // fault (worker error, oversized-response 500 — #996), not a lean build;

--- a/docker-compose.analyzer-gpu.yml
+++ b/docker-compose.analyzer-gpu.yml
@@ -21,10 +21,11 @@
 # degrades, not fails). To force CPU temporarily without dropping the overlay,
 # set ANALYZE_DEVICE=cpu in your root .env (the base compose passes it through).
 #
-# VRAM etiquette: after ~5 idle minutes the worker drops its models out of
-# VRAM so a co-resident TTS/LLM gets the card back between passes
-# (ANALYZE_IDLE_UNLOAD_S in .env tunes it; 0 keeps models resident). A few
-# hundred MB of CUDA context remain until the container stops.
+# VRAM etiquette: after ~5 idle minutes with no CLAP/Demucs use the worker
+# drops its models out of VRAM so a co-resident TTS/LLM gets the card back
+# between passes (ANALYZE_IDLE_UNLOAD_S in .env tunes it; 0 keeps models
+# resident). A few hundred MB of CUDA context remain until the container stops.
+# The same release runs on CPU with a longer default window (#1204).
 services:
   analyzer:
     image: ghcr.io/perminder-klair/subwave-analyzer-cuda:${SUBWAVE_VERSION:-latest}

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -315,8 +315,11 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=${ANALYZE_DEVICE:-}
-      # Seconds of no requests before the cuda flavour drops its models out of
-      # VRAM (default 300; 0 = never). CPU images ignore it.
+      # Seconds of no CLAP/Demucs use before the worker drops the models
+      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
+      # 1800 on cpu — one backfill or sound search loads them into the
+      # long-lived worker and nothing else ever releases them, so on a small
+      # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -321,6 +321,12 @@ services:
       # long-lived worker and nothing else ever releases them, so on a small
       # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=${ANALYZE_IDLE_UNLOAD_S:-}
+      # Seconds of no heavy (CLAP/Demucs) use before the sidecar recycles the
+      # whole worker process — the full-memory reclaim behind the model release
+      # above, catching the ~1GB of librosa/numba/torch scratch a release can't
+      # return (default 3600; 0 = never). Requests racing a recycle queue
+      # behind the respawn rather than failing.
+      - ANALYZE_RECYCLE_IDLE_S=${ANALYZE_RECYCLE_IDLE_S:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -255,8 +255,11 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=${ANALYZE_DEVICE:-}
-      # Seconds of no requests before the cuda flavour drops its models out of
-      # VRAM (default 300; 0 = never). CPU images ignore it.
+      # Seconds of no CLAP/Demucs use before the worker drops the models
+      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
+      # 1800 on cpu — one backfill or sound search loads them into the
+      # long-lived worker and nothing else ever releases them, so on a small
+      # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -261,6 +261,12 @@ services:
       # long-lived worker and nothing else ever releases them, so on a small
       # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=${ANALYZE_IDLE_UNLOAD_S:-}
+      # Seconds of no heavy (CLAP/Demucs) use before the sidecar recycles the
+      # whole worker process — the full-memory reclaim behind the model release
+      # above, catching the ~1GB of librosa/numba/torch scratch a release can't
+      # return (default 3600; 0 = never). Requests racing a recycle queue
+      # behind the respawn rather than failing.
+      - ANALYZE_RECYCLE_IDLE_S=${ANALYZE_RECYCLE_IDLE_S:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -358,8 +358,11 @@ services:
       # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
       # cpu-wheel images always resolve to cpu.
       - ANALYZE_DEVICE=${ANALYZE_DEVICE:-}
-      # Seconds of no requests before the cuda flavour drops its models out of
-      # VRAM (default 300; 0 = never). CPU images ignore it.
+      # Seconds of no CLAP/Demucs use before the worker drops the models
+      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
+      # 1800 on cpu — one backfill or sound search loads them into the
+      # long-lived worker and nothing else ever releases them, so on a small
+      # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=${ANALYZE_IDLE_UNLOAD_S:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -364,6 +364,12 @@ services:
       # long-lived worker and nothing else ever releases them, so on a small
       # host they end up parked in swap (#1204).
       - ANALYZE_IDLE_UNLOAD_S=${ANALYZE_IDLE_UNLOAD_S:-}
+      # Seconds of no heavy (CLAP/Demucs) use before the sidecar recycles the
+      # whole worker process — the full-memory reclaim behind the model release
+      # above, catching the ~1GB of librosa/numba/torch scratch a release can't
+      # return (default 3600; 0 = never). Requests racing a recycle queue
+      # behind the respawn rather than failing.
+      - ANALYZE_RECYCLE_IDLE_S=${ANALYZE_RECYCLE_IDLE_S:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}
       # Demucs model + analysis-window overrides (worker reads both; see

--- a/docker/analyzer/server.py
+++ b/docker/analyzer/server.py
@@ -28,6 +28,7 @@ import asyncio
 import json
 import logging
 import os
+import time
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -48,6 +49,37 @@ ANALYZE_SECONDS = os.environ.get("ANALYZE_SECONDS", "").strip() or "40"
 # CLAP_MODEL_PATH is given — transformers then pulls the CLAP weights here. The
 # compose files mount a named volume over it so the download survives recreates.
 ANALYZER_HF_HOME = os.environ.get("ANALYZER_HF_HOME", "/opt/analyzer/hf-cache")
+
+# Idle worker recycle (#1204 follow-up). The worker's own idle release
+# (ANALYZE_IDLE_UNLOAD_S, analyze_worker.py) drops the CLAP/Demucs singletons,
+# but ~1GB of librosa/numba/torch scratch stays resident in the process — heap
+# a release can't reach. Restarting the worker is the only full reclaim (on
+# cuda it also drops the few-hundred-MB CUDA context the docs lament), so after
+# this many seconds with no HEAVY use — same clock semantics as the worker's
+# release: lean bpm/key traffic doesn't count — the shim terminates the worker
+# and lets run()'s supervisor respawn it. The recycle holds the request lock,
+# so a request that lands mid-recycle queues behind the respawn instead of
+# 500ing; the cost is one re-paid boot (imports, a few seconds) on the next
+# request. Default sits above the worker's largest release window so the cheap
+# release always fires first; 0 disables.
+_RECYCLE_ENV = os.environ.get("ANALYZE_RECYCLE_IDLE_S", "").strip()
+try:
+    RECYCLE_IDLE_S = float(_RECYCLE_ENV) if _RECYCLE_ENV else 3600.0
+except ValueError:
+    logging.getLogger("analyzer").warning(
+        f"ANALYZE_RECYCLE_IDLE_S={_RECYCLE_ENV!r} is not a number; using 3600"
+    )
+    RECYCLE_IDLE_S = 3600.0
+
+# Mirror of the worker's env-default flags (same truthy set as
+# analyze_worker.py) — when either is on, the worker loads models even for
+# requests that don't ask, so every /analyze counts as heavy use.
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes")
+
+
+EMBED_DEFAULT = _env_flag("ANALYZE_AUDIO_EMBEDDING")
+VOCAL_DEFAULT = _env_flag("ANALYZE_VOCAL_ACTIVITY")
 
 # Max bytes of one worker stdout line. asyncio's default StreamReader limit is
 # 64 KiB, which a batch /embed-text response blows straight past (17 mood
@@ -91,6 +123,15 @@ class StdioWorker:
         # capability metadata (audio_embedding_capable / vocal_activity_capable).
         # Cleared on every restart cycle.
         self.ready_meta: dict[str, Any] = {}
+        # Heavy-use bookkeeping for /health residency + the idle recycle.
+        # `last_heavy` is monotonic time of the last completed request that
+        # actually exercised CLAP/Demucs (None = none since this spawn);
+        # `models_resident` is best-effort — set true when a heavy request
+        # completes, cleared when the worker's idle-release log line goes by
+        # (see _pump_stderr) or the worker restarts.
+        self.last_heavy: float | None = None
+        self.models_resident = False
+        self.recycles = 0
 
     async def run(self) -> None:
         """Keep the worker alive forever (or until cancelled)."""
@@ -118,6 +159,11 @@ class StdioWorker:
         self.ready = False
         self.proc = None
         self.ready_meta = {}
+        # A fresh worker holds no models (env pre-warm is re-detected at ready);
+        # clearing last_heavy also stands the recycle loop down until the next
+        # heavy request against the new process.
+        self.last_heavy = None
+        self.models_resident = False
 
     def _terminate(self) -> None:
         if self.proc and self.proc.returncode is None:
@@ -158,6 +204,14 @@ class StdioWorker:
             raise
         self.ready_meta = {k: v for k, v in msg.items() if k != "ready"}
         log.info(f"[{self.name}] ready {self.ready_meta or ''}".rstrip())
+        # With an env flag on, the worker pre-warms that model BEFORE ready —
+        # count it as resident (and as heavy use, so the recycle clock runs)
+        # unless the capability probe says the load failed.
+        if (EMBED_DEFAULT and self.ready_meta.get("audio_embedding_capable")) or (
+            VOCAL_DEFAULT and self.ready_meta.get("vocal_activity_capable")
+        ):
+            self.models_resident = True
+            self.last_heavy = time.monotonic()
         self.ready = True
 
     async def _await_message(self) -> dict[str, Any]:
@@ -184,7 +238,30 @@ class StdioWorker:
             line = await proc.stderr.readline()
             if not line:
                 break
-            log.info(f"[{self.name}] {line.decode().rstrip()}")
+            text = line.decode().rstrip()
+            log.info(f"[{self.name}] {text}")
+            # The worker announces its idle release on stderr (the wording is
+            # pinned by a keep-in-sync note at the log call in
+            # analyze_worker._release_models). Unsolicited stdout would corrupt
+            # the one-request-in-flight protocol, so stderr is the only channel
+            # this fact can ride — best-effort by design.
+            if "released" in text and "reloads on next use" in text:
+                self.models_resident = False
+
+    @staticmethod
+    def _wants_models(payload: dict[str, Any]) -> bool:
+        """Whether this request can load/use CLAP or Demucs. Texts always force
+        CLAP; a render_transition mixes already-cached stems (no model); an
+        analyze counts when it opts in per-request OR the worker's env default
+        flags opt every request in."""
+        if payload.get("texts") is not None:
+            return True
+        if payload.get("op"):
+            return False
+        return bool(
+            payload.get("embed") or payload.get("vocal") or payload.get("stems_dir")
+            or EMBED_DEFAULT or VOCAL_DEFAULT
+        )
 
     async def request(self, payload: dict[str, Any]) -> dict[str, Any]:
         async with self.lock:
@@ -198,7 +275,52 @@ class StdioWorker:
             req = json.dumps(payload, ensure_ascii=False)
             self.proc.stdin.write((req + "\n").encode())
             await self.proc.stdin.drain()
-            return await self._await_message()
+            msg = await self._await_message()
+            # Stamp heavy use from what actually came back, not just what was
+            # asked: an analyze whose CLAP load failed still answers ok=true
+            # (graceful degrade) but carries no model-derived fields, and must
+            # not read as "models resident".
+            if self._wants_models(payload) and (
+                (payload.get("texts") is not None and msg.get("ok"))
+                or any(k in msg for k in ("audio_embedding", "vocal_ranges", "stems_cached"))
+            ):
+                self.last_heavy = time.monotonic()
+                self.models_resident = True
+            return msg
+
+    async def recycle_loop(self, idle_s: float) -> None:
+        """Terminate the worker after `idle_s` seconds with no heavy use so
+        run()'s supervisor respawns it fresh — the full-memory counterpart to
+        the worker's own model release (see ANALYZE_RECYCLE_IDLE_S above).
+        Holding the lock across the respawn means a request that races the
+        recycle queues and then runs against the new worker instead of 500ing."""
+        while True:
+            await asyncio.sleep(60)
+            if not self.ready or self.last_heavy is None:
+                continue
+            if time.monotonic() - self.last_heavy < idle_s:
+                continue
+            async with self.lock:
+                # Re-check under the lock: a heavy request may have completed
+                # while we waited to acquire it.
+                if self.last_heavy is None or time.monotonic() - self.last_heavy < idle_s:
+                    continue
+                log.info(
+                    f"[{self.name}] idle {int(idle_s)}s without heavy use — recycling worker "
+                    "for a full memory reclaim (re-pays imports on next request)"
+                )
+                self.recycles += 1
+                self.ready = False
+                self._terminate()
+                # Wait (bounded) for run() to respawn and re-ready before
+                # releasing the lock. On timeout, release anyway — queued
+                # requests then fail fast exactly as they do for a crashed
+                # worker, and run() keeps retrying the respawn upstream.
+                deadline = time.monotonic() + 180.0
+                while time.monotonic() < deadline and not self.ready:
+                    await asyncio.sleep(0.5)
+                if not self.ready:
+                    log.warning(f"[{self.name}] worker not back within 180s of recycle")
 
 
 analyzer_worker = StdioWorker(
@@ -214,12 +336,19 @@ async def lifespan(_app: FastAPI):
     # Kick the worker supervisor as a background task so uvicorn binds :8080
     # immediately — otherwise a cold CLAP/Demucs load would block the port bind
     # and the controller's probe would see "connection refused" during boot.
-    task = asyncio.create_task(analyzer_worker.run(), name="analyze-run")
+    tasks = [asyncio.create_task(analyzer_worker.run(), name="analyze-run")]
+    if RECYCLE_IDLE_S > 0:
+        tasks.append(
+            asyncio.create_task(
+                analyzer_worker.recycle_loop(RECYCLE_IDLE_S), name="analyze-recycle"
+            )
+        )
     try:
         yield
     finally:
-        task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
 
 
 app = FastAPI(title="subwave-analyzer", lifespan=lifespan)
@@ -264,6 +393,22 @@ async def health():
         "analyze_text_capable": (
             analyzer_worker.ready_meta.get("text_embedding_capable") if analyzer_worker.ready else None
         ),
+        # Best-effort residency (#1204 follow-up): whether CLAP/Demucs are
+        # believed loaded in the worker right now — true after a heavy request
+        # completes, false once the worker's idle release fires or the worker
+        # restarts. Lets an operator confirm the release without grepping logs.
+        # None while the worker is down.
+        "analyze_models_resident": analyzer_worker.models_resident if analyzer_worker.ready else None,
+        # Seconds since the last completed heavy (model-using) request against
+        # THIS worker process; null when none has run since it spawned.
+        "analyze_heavy_idle_s": (
+            round(time.monotonic() - analyzer_worker.last_heavy, 1)
+            if analyzer_worker.ready and analyzer_worker.last_heavy is not None
+            else None
+        ),
+        # How many times the idle recycle (ANALYZE_RECYCLE_IDLE_S) has bounced
+        # the worker for a full memory reclaim since the container started.
+        "analyze_worker_recycles": analyzer_worker.recycles,
     }
 
 

--- a/docs/tts-heavy.md
+++ b/docs/tts-heavy.md
@@ -114,9 +114,10 @@ anywhere else it's `--gpus all` on your `docker run`. Everything below about
 device selection and VRAM applies there unchanged.
 
 Sharing the card with a local TTS or LLM? The worker plays nice: after ~5
-minutes with no analysis requests it drops its models out of VRAM and reloads
+minutes with no CLAP/Demucs use it drops its models out of VRAM and reloads
 them on the next request (`ANALYZE_IDLE_UNLOAD_S` in `.env` tunes the window;
-`0` keeps them resident). A few hundred MB of CUDA context remain until the
+`0` keeps them resident; CPU-only hosts get the same release with a longer
+30-minute default — #1204). A few hundred MB of CUDA context remain until the
 analyzer container stops. Pair it with the **quiet times** toggle on the admin
 Library page and a long scan pauses — and frees the GPU — whenever listeners
 are tuned in.

--- a/docs/tts-heavy.md
+++ b/docs/tts-heavy.md
@@ -117,8 +117,12 @@ Sharing the card with a local TTS or LLM? The worker plays nice: after ~5
 minutes with no CLAP/Demucs use it drops its models out of VRAM and reloads
 them on the next request (`ANALYZE_IDLE_UNLOAD_S` in `.env` tunes the window;
 `0` keeps them resident; CPU-only hosts get the same release with a longer
-30-minute default — #1204). A few hundred MB of CUDA context remain until the
-analyzer container stops. Pair it with the **quiet times** toggle on the admin
+30-minute default — #1204). The trade: the first heavy request after a release
+pays a cold reload from the on-disk cache — a few seconds for CLAP on a typical
+box (measured ~2s; a "sounds like ..." search may feel it on slower hardware),
+longer for Demucs. If your station leans on sound search and RAM is plentiful,
+`ANALYZE_IDLE_UNLOAD_S=0` restores the old always-resident behaviour. A few
+hundred MB of CUDA context remain until the analyzer container stops. Pair it with the **quiet times** toggle on the admin
 Library page and a long scan pauses — and frees the GPU — whenever listeners
 are tuned in.
 

--- a/docs/unraid.md
+++ b/docs/unraid.md
@@ -228,6 +228,9 @@ that isn't in the lean image (the `-heavy` images are ~1.9 GB):
   release runs on CPU-only boxes, with a longer default window (30 minutes):
   the heavy models load once for a backfill or a sound search and would
   otherwise sit in RAM — and eventually swap — for the life of the container.
+  The first heavy request after a release pays a cold reload from the on-disk
+  cache (a few seconds for CLAP, longer for Demucs) — set
+  `ANALYZE_IDLE_UNLOAD_S=0` if you'd rather keep them resident.
 
   Fair warning on size: the CUDA image is **~4 GB compressed** (~11 GB on disk)
   against `-heavy`'s ~1.3 GB, because the CUDA runtime ships inside the torch

--- a/docs/unraid.md
+++ b/docs/unraid.md
@@ -224,7 +224,10 @@ that isn't in the lean image (the `-heavy` images are ~1.9 GB):
   station. Pin it explicitly with the `ANALYZE_DEVICE` variable (`auto`, the
   default, `cuda`, or `cpu`) if you'd rather be sure. Between passes the models
   drop out of VRAM after ~5 idle minutes, so a co-resident Ollama gets the card
-  back (`ANALYZE_IDLE_UNLOAD_S` tunes that; `0` keeps them resident).
+  back (`ANALYZE_IDLE_UNLOAD_S` tunes that; `0` keeps them resident). The same
+  release runs on CPU-only boxes, with a longer default window (30 minutes):
+  the heavy models load once for a backfill or a sound search and would
+  otherwise sit in RAM — and eventually swap — for the life of the container.
 
   Fair warning on size: the CUDA image is **~4 GB compressed** (~11 GB on disk)
   against `-heavy`'s ~1.3 GB, because the CUDA runtime ships inside the torch


### PR DESCRIPTION
## What

Follow-ups to #1244 (stacked on that branch — merge #1244 first; this diff includes its commits until then). Also carries one commit meant for #1244 itself (`c8ee4e42`: the cold-reload docs note + a test-nit fix) that couldn't be pushed to the fork branch from this session — if it gets pushed to #1244 directly, it'll fall out of this diff on rebase.

Four pieces:

1. **Cold-reload retry for interactive text embeds** (`music/analyzer.ts`): `embedTexts` now retries once when the deadline expires mid-request — and only then. With the idle release armed on CPU, a "sounds like ..." search can land on a cold worker whose CLAP reload eats the 20s interactive deadline; the backend keeps loading after the controller stops waiting, so the second wait lands on a warm model. Refused/404/500 stay single-shot, and the 10-minute bulk mood-scoring call opts out (`coldRetry: false`).
2. **Idle worker recycle in the sidecar** (`docker/analyzer/server.py`, `ANALYZE_RECYCLE_IDLE_S`, default 3600, `0` = never): #1244's own measurements left ~1GB of librosa/numba/torch scratch resident after a model release — heap `malloc_trim` can't reach. The shim now terminates the worker after an hour with no heavy (CLAP/Demucs) use and lets the existing `run()` supervisor respawn it: a full reclaim (on cuda it also drops the few-hundred-MB CUDA context the docs lament). Same heavy-clock semantics as the worker's release — lean bpm/key traffic never triggers it. The recycle holds the request lock across the respawn, so a racing request queues instead of 500ing; the cost is a few seconds of re-paid imports on the next request.
3. **`/health` residency observability**: three new fields — `analyze_models_resident` (best-effort: set when a heavy request completes, cleared when the worker's release line goes by on stderr or the worker restarts), `analyze_heavy_idle_s`, and `analyze_worker_recycles`. An operator can now confirm the release fired without grepping logs. The release log wording in `analyze_worker.py` carries a keep-in-sync note pointing at the parser.
4. **Python suites wired into `npm test`** (`controller/scripts/analyzer-python.test.ts`): one shim runs all three pure-stdlib Python suites (`idle_release_test.py`, `vocal_gate_test.py`, `test_chatterbox_chunk.py`) through the existing `*.test.ts` auto-discovery; skips cleanly (exit 0) when `python3` isn't on PATH.

Compose files gained the `ANALYZE_RECYCLE_IDLE_S` passthrough (+ `.env.example` docs); `cli/src/assets.generated.ts` re-embedded.

## Why

#1204 review follow-ups. The in-process release (#1244) hands back the model weights; these pieces cover what it can't: the residual scratch (recycle), the first-search-after-release UX on slow hosts (retry), and the "did it actually fire?" question (health fields).

## How tested

- End-to-end against the heavy analyzer image with the modified `server.py` + the #1244 worker mounted in, `ANALYZE_IDLE_UNLOAD_S=30` / `ANALYZE_RECYCLE_IDLE_S=90`:
  - boot → `resident:false / heavy_idle:null / recycles:0`
  - heavy `/embed-text` → `resident:true / heavy_idle:0.1`
  - worker's own release fires (`released CLAP from system memory`) → `resident:false` via the stderr-line parse, `heavy_idle` still counting
  - recycle fires at 90s heavy-idle → `recycles:1`, worker respawned and ready ~3s later
  - post-recycle `/embed-text` → correct embeddings, `resident:true` again
- `python3 -m py_compile` on both Python files; `idle_release_test.py` 16/16.
- `controller` `npm run lint` clean (0 errors) and `npm test` green — 65 files including the new shim.

## Out of scope

- The AIO runs the analyzer in-process (no `server.py`), so the recycle doesn't apply there; the in-process release does, unchanged.
- The residual-RSS investigation itself (which import owns the ~800MB CLAP-only floor) — the recycle sidesteps rather than answers it.
