### PR TITLE
fix(web): stop admin editor sections growing their own scrollbars

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3082,9 +3082,13 @@ html:has(.admin-root.paper) {
 }
 .admin-root .card-body {
     /* Same reason — pre/code content inside expanded <details> needs a
-       width constraint to actually wrap. */
+       width constraint to actually wrap. `clip` rather than `hidden`:
+       hidden makes the body a scroll container (overflow-y computes to
+       auto), so a 1px vertical overflow grows a full scrollbar inside
+       every editor section on desktop-scrollbar platforms. clip clips
+       the same horizontal blowout without creating a scroll container. */
     min-width: 0;
-    overflow-x: hidden;
+    overflow-x: clip;
 }
 .admin-root details {
     min-width: 0;


### PR DESCRIPTION
## What

On the `/admin/shows` edit screen (and every other admin editor built from flat `Card` sections), the Identity / Music / Brief sections could each grow their own vertical scrollbar on desktop-scrollbar platforms.

## Why

`.admin-root .card-body { overflow-x: hidden }` — the wrap backstop for long URIs/JSON dumps in debug expansions — makes each card body a scroll container: per the CSS spec, when one axis is `hidden` the other's `visible` computes to `auto`. The measured Identity section body was `scrollHeight 828 / clientHeight 827`, and that 1px overflow is enough to render a full scrollbar track inside the section.

## Fix

`overflow-x: clip` instead of `hidden`. `clip` clips the same horizontal blowout but does **not** create a scroll container, so a card body can never scroll (or show a scrollbar) on its own. The dialog's single `v3-scroll` body scrollbar is untouched, as are the intentional capped playlist checkbox lists (`max-h-44 overflow-y-auto`).

Verified live against the running dev stack: injected the one-line override into `/admin/shows` → the section scrollbar disappears and fields reclaim the gutter width.