### PR TITLE
fix(settings): bounded archive retention default (30 days) with keep-forever upgrade guard

### DIFF
--- a/controller/scripts/archive-retention.test.ts
+++ b/controller/scripts/archive-retention.test.ts
@@ -1,0 +1,82 @@
+// Pins the bounded archive-retention default and its keep-forever upgrade
+// guard (settings/normalize.ts normalizeArchiveRetentionDays).
+//
+// History: archive.retentionDays defaulted to 0 (keep forever), so operators
+// who enabled hourly archiving grew ~1.4 GB/day until the disk filled — the
+// 99 GB state/archive Discord report. The default is now 30 days, but it must
+// NOT reach installs that were already archiving under keep-forever: for them
+// an upgrade would silently start deleting tapes they may be keeping on
+// purpose. Two properties are load-bearing:
+//
+//  - A stored integer ≥ 0 always wins — explicit 0 stays keep-forever.
+//  - No stored value + archive.enabled === true resolves to 0 (legacy
+//    preserved); any other blob (fresh install, archive off) resolves to 30.
+//
+// STATE_DIR is redirected at a throwaway dir BEFORE the first import, so
+// settings.load()/update() touch nothing real — hence the dynamic imports.
+// Scenarios rewrite settings.json and reset the store cache between loads.
+// node:assert-via-tsx style, matching scripts/house-rules.test.ts.
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const root = mkdtempSync(join(tmpdir(), 'subwave-archret-'));
+process.env.STATE_DIR = root;
+
+const settings = await import('../src/settings.js');
+const store = await import('../src/settings/store.js');
+
+const SETTINGS_PATH = join(root, 'settings.json');
+
+async function loadBlob(blob: unknown) {
+  writeFileSync(SETTINGS_PATH, JSON.stringify(blob));
+  store.setCache(null);
+  await settings.load();
+  return settings.get().archive;
+}
+
+try {
+  // ── Fresh install: no settings.json at all → bounded default ─────────────
+  store.setCache(null);
+  await settings.load();
+  assert.equal(settings.get().archive.enabled, false, 'fresh: archive off');
+  assert.equal(settings.get().archive.retentionDays, 30, 'fresh: bounded default');
+
+  // ── Upgrade guard: legacy enabled archive, no stored retention → 0 ───────
+  let a = await loadBlob({ archive: { enabled: true, bitrate: 128 } });
+  assert.equal(a.retentionDays, 0, 'legacy enabled archive keeps keep-forever');
+
+  // ── Archive off, no stored retention → bounded default ───────────────────
+  a = await loadBlob({ archive: { enabled: false } });
+  assert.equal(a.retentionDays, 30, 'archive off gets the bounded default');
+
+  // ── Stored values always win, 0 included ─────────────────────────────────
+  a = await loadBlob({ archive: { enabled: true, retentionDays: 7 } });
+  assert.equal(a.retentionDays, 7, 'stored window preserved');
+  a = await loadBlob({ archive: { enabled: false, retentionDays: 0 } });
+  assert.equal(a.retentionDays, 0, 'explicit 0 preserved even with archive off');
+
+  // ── Junk falls through the same fork as absent ───────────────────────────
+  a = await loadBlob({ archive: { enabled: true, retentionDays: -5 } });
+  assert.equal(a.retentionDays, 0, 'junk value + enabled → keep-forever guard');
+  a = await loadBlob({ archive: { enabled: false, retentionDays: 'x' } });
+  assert.equal(a.retentionDays, 30, 'junk value + disabled → bounded default');
+
+  // ── update(): enabling archiving later inherits the resolved default ─────
+  await loadBlob({});
+  await settings.update({ archive: { enabled: true } });
+  assert.equal(settings.get().archive.retentionDays, 30, 'enable keeps resolved 30');
+  // Explicit opt-out to keep-forever persists across a reload — update()
+  // stores the 0, so the load-path guard never reinterprets it.
+  await settings.update({ archive: { retentionDays: 0 } });
+  assert.equal(settings.get().archive.retentionDays, 0, 'explicit keep-forever accepted');
+  store.setCache(null);
+  await settings.load();
+  assert.equal(settings.get().archive.retentionDays, 0, 'explicit keep-forever survives reload');
+
+  console.log('archive-retention: all assertions passed');
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/controller/src/broadcast/archives.ts
+++ b/controller/src/broadcast/archives.ts
@@ -88,8 +88,9 @@ export function openStream(abs: string) {
   return createReadStream(abs);
 }
 
-// Retention sweep — delete whole day directories older than `days`. 0 (the
-// default setting) means keep forever, and callers gate on that before calling.
+// Retention sweep — delete whole day directories older than `days`. 0 means
+// keep forever (the pre-30-day-default legacy value, preserved on upgrade by
+// normalizeArchiveRetentionDays), and callers gate on that before calling.
 // Day-granular on purpose: comparing the YYYY-MM-DD directory name against a
 // cutoff date can never touch the file Liquidsoap currently holds open (today's
 // dir is always inside any positive retention window). `.ndignore` and anything

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -87,6 +87,7 @@ import {
 import { minTrackSeconds, peek, setCache } from './settings/store.js';
 import {
   SKILL_RENAMES,
+  normalizeArchiveRetentionDays,
   normalizeDjPrompts,
   normalizePersonaArray,
   normalizeSchedule,
@@ -373,10 +374,9 @@ export async function load() {
           ? stored.archive.enabled
           : DEFAULTS.archive.enabled,
       bitrate: archiveBitrate,
-      retentionDays:
-        Number.isInteger(stored.archive?.retentionDays) && stored.archive.retentionDays >= 0
-          ? stored.archive.retentionDays
-          : DEFAULTS.archive.retentionDays,
+      // Bounded default with the keep-forever upgrade guard — a pre-existing
+      // enabled archive without a stored value stays at 0, never pruned.
+      retentionDays: normalizeArchiveRetentionDays(stored.archive),
     },
     stream: {
       opusEnabled:

--- a/controller/src/settings/defaults.ts
+++ b/controller/src/settings/defaults.ts
@@ -35,9 +35,12 @@ export const DEFAULTS = {
   // paying for the tape by default (issue #137). Dropping the bitrate (e.g.
   // 128 → 64 mono in a future change) also helps for operators who want it.
   // retentionDays: hourly recordings older than this many days are deleted by
-  // the scheduler's hourly cleanup. 0 = keep forever — the default, because a
-  // retention default would silently delete archives operators already have.
-  archive: { enabled: false, bitrate: 128, retentionDays: 0 },
+  // the scheduler's hourly cleanup. Bounded by default — the old keep-forever
+  // default (0) grew ~1.4 GB/day at 128 kbps until the disk filled, and
+  // operators only noticed at 99 GB. The default must NOT reach installs that
+  // already archive under keep-forever: normalizeArchiveRetentionDays keeps
+  // them at 0 (see settings/normalize.ts), so upgrades never delete tapes.
+  archive: { enabled: false, bitrate: 128, retentionDays: 30 },
   // Secondary Ogg-Opus broadcast mount (/stream.opus). Off by default — only
   // Blink (Chrome/Edge) clients ever select it (web/hooks/usePlayer.ts keeps
   // Safari/iOS/Firefox on MP3), and it adds a continuous Opus encoder + a

--- a/controller/src/settings/normalize.ts
+++ b/controller/src/settings/normalize.ts
@@ -43,9 +43,24 @@ import {
   mintId,
   normalizeDial,
 } from './vocab.js';
-import { coerceMaxTrackSeconds, rawMaxTrackSec } from './defaults.js';
+import { DEFAULTS, coerceMaxTrackSeconds, rawMaxTrackSec } from './defaults.js';
 
 // ── normalizers (lenient — used by load(), clamp/default rather than throw) ──
+
+// Archive retention with the keep-forever upgrade guard. A stored integer ≥ 0
+// always wins (0 is a legitimate explicit "keep forever"). When nothing is
+// stored, the fallback depends on whether the blob already archives: an
+// install that enabled archiving under the old keep-forever default must stay
+// at 0 — applying the bounded default there would delete existing tapes on
+// upgrade — while everyone else (fresh installs, archive off) gets
+// DEFAULTS.archive.retentionDays so newly enabled archiving is bounded from
+// day one instead of silently filling the disk.
+export function normalizeArchiveRetentionDays(archive: any): number {
+  const v = archive?.retentionDays;
+  if (Number.isInteger(v) && v >= 0) return v;
+  if (archive?.enabled === true) return 0;
+  return DEFAULTS.archive.retentionDays;
+}
 
 // Persona skill assignment. `null` (raw not an array) is the "all skills"
 // sentinel — used by legacy personas and the code default so behaviour is

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -119,7 +119,7 @@ export default function SettingsPanel() {
       archive: {
         enabled: v.archive?.enabled ?? false,
         bitrate: String(v.archive?.bitrate ?? 128),
-        retentionDays: String(v.archive?.retentionDays ?? 0),
+        retentionDays: String(v.archive?.retentionDays ?? 30),
       },
       stream: {
         opusEnabled: v.stream?.opusEnabled ?? true,
@@ -615,10 +615,12 @@ export default function SettingsPanel() {
                       </Btn>
                     </div>
                     <div className="field-hint">
-                      0 = keep forever (the default). With a window set, the hourly cleanup
-                      deletes whole days of recordings once they age past it. At 128 kbps the
-                      archive grows ~1.4 GB per day, so an unbounded archive eventually fills
-                      the disk. Applies live, no restart.
+                      Defaults to 30 days; 0 = keep forever. With a window set, the hourly
+                      cleanup deletes whole days of recordings once they age past it. At
+                      128 kbps the archive grows ~1.4 GB per day, so an unbounded archive
+                      eventually fills the disk. Stations that were already archiving before
+                      the 30-day default keep their keep-forever setting. Applies live, no
+                      restart.
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## What

A Discord report showed \`state/archive/\` at 99 GB+ — the operator had enabled hourly archiving, and the \`retentionDays: 0\` (keep forever) default meant nothing was ever pruned (~1.4 GB/day at 128 kbps until the disk fills).

- \`DEFAULTS.archive.retentionDays\` is now **30** — anyone enabling archiving from here on gets a bounded archive out of the box.
- **Upgrade guard** (\`normalizeArchiveRetentionDays\` in \`settings/normalize.ts\`): a settings.json that already has \`archive.enabled: true\` with no stored retention resolves to **0** on load, so upgrading never starts deleting tapes an operator may be keeping on purpose. A stored integer ≥ 0 always wins — explicit 0 stays keep-forever.
- Admin UI: retention hint updated (30-day default, legacy stations keep keep-forever); form fallback aligned.
- Comment in \`broadcast/archives.ts\` updated to stop calling 0 "the default".

## Why the guard shape

Flatly changing the default would flip every legacy enabled-archive install to 30 days on their next boot and the daily sweep would delete months of recordings. The fork is on \`archive.enabled === true\` in the *stored* blob at load time: only installs that were already archiving under the old default are pinned to keep-forever; everyone else (fresh installs, archive off) resolves to the bounded default, which then rides along when they enable archiving via \`update()\`.

## Testing

- New \`controller/scripts/archive-retention.test.ts\` pins: fresh → 30, legacy enabled → 0, stored values (0 included) preserved, junk values fall through the same fork, \`update()\` enable inherits 30, explicit 0 survives reload.
- Full controller suite: 65/65 test files pass. \`npm run lint\` clean (0 errors) in \`controller/\` and \`web/\`.