### PR TITLE
feat(webhooks): include sourceTrackId in track.play payloads

### DIFF
--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -1597,10 +1597,19 @@ class Queue {
       showName: onAirShow?.name || null,
     });
 
+    // `sourceTrackId` is the id from the music backend (Subsonic/Navidrome, or
+    // whatever a router fronts), so a relay can resolve the exact library item
+    // instead of fuzzy-matching artist+title (#1250). Same id `recordPlay` and
+    // `scrobble` already take below. Null when the annotated URI carried no
+    // `subsonic_id` — untracked auto-playlist plays, mainly — so consumers must
+    // handle its absence. Deliberately NOT folded into `source`: that field
+    // means how the track got queued (auto | ai | request) and existing relays
+    // branch on it.
     const trackPayload = {
       title: this.current.track.title,
       artist: this.current.track.artist || null,
       album: this.current.track.album || null,
+      sourceTrackId: this.current.track.id || null,
       source: this.current.source,
       requestedBy: this.current.requestedBy || null,
     };

--- a/controller/src/routes/webhooks.ts
+++ b/controller/src/routes/webhooks.ts
@@ -2,9 +2,13 @@
 // in broadcast/webhooks.ts and reads its config from settings on each fire.
 //
 // Event payloads emitted by the fan-out:
-//   track.play       { event, t, title, artist, album?, source, requestedBy?, listeners? }
+//   track.play       { event, t, title, artist, album?, sourceTrackId?, source,
+//                      requestedBy?, listeners? }
 //                    (when webhooksPolicy.trackPlayListenerGated is on, only POSTs
 //                     when listener count > 0 — fail-closed; `listeners` included)
+//                    `sourceTrackId` is the music backend's own id (Subsonic/
+//                    Navidrome), null when unknown; `source` is how the track got
+//                    queued (auto | ai | request) — two different things.
 //   dj.say           { event, t, text, kind }      // kind is the original `announce` kind
 //   dj.link          { event, t, text }
 //   request.received { event, t, requestedBy, text }   // text is the listener's raw ask

--- a/web/components/admin/WebhooksPanel.tsx
+++ b/web/components/admin/WebhooksPanel.tsx
@@ -65,13 +65,14 @@ interface PayloadDoc {
 const PAYLOADS: PayloadDoc[] = [
   {
     event: 'track.play',
-    blurb: 'A track started. By default always delivered; enable “Gate track.play on listeners” below to skip when nobody is tuned in (fail-closed on unknown count). `source` is "auto" (the playlist), "ai" (picker agent) or "request"; `artist`/`album`/`requestedBy` may be null; `listeners` is included when the gate is on.',
+    blurb: 'A track started. By default always delivered; enable “Gate track.play on listeners” below to skip when nobody is tuned in (fail-closed on unknown count). `sourceTrackId` is the id in your music backend (Subsonic/Navidrome), so a relay can resolve the exact library item without matching on artist+title — null when the track came through without one. `source` is a different thing: how it got queued — "auto" (the playlist), "ai" (picker agent) or "request". `artist`/`album`/`requestedBy` may be null; `listeners` is included when the gate is on.',
     json: `{
   "event": "track.play",
   "t": "2026-06-02T19:04:12.880Z",
   "title": "Teardrop",
   "artist": "Massive Attack",
   "album": "Mezzanine",
+  "sourceTrackId": "4f2c1a9b8e3d",
   "source": "auto",
   "requestedBy": null,
   "listeners": 1


### PR DESCRIPTION
Closes #1250.

## What

`track.play` webhook payloads now carry `sourceTrackId` — the track's id in the music backend (Subsonic/Navidrome, or whatever a router fronts):

```json
{
  "event": "track.play",
  "t": "2026-06-02T19:04:12.880Z",
  "title": "Teardrop",
  "artist": "Massive Attack",
  "album": "Mezzanine",
  "sourceTrackId": "4f2c1a9b8e3d",
  "source": "auto",
  "requestedBy": null
}
```

Lets a relay resolve the exact library item instead of matching on artist + title. The requester's use case is a sidecar that dedupes played tracks into an expiring exclusion playlist — all of that logic stays outside SUB/WAVE; this just exposes an id the station already had.

## How

The id was already in hand at the fan-out site in `queue.ts` — `library.recordPlay` and `scrobble.onTrackEvent` both take `this.current.track.id` a few lines either side of it. Only the webhook payload dropped it. One field on `trackPayload`; it rides the existing listener-gated branch unchanged.

## Two calls worth flagging

**`sourceTrackId` is a new field, not a repurposed `source`.** The issue's example payload had `"source": "navidrome"`, but `source` in `track.play` already means *how the track got queued* (`auto` / `ai` / `request`) and existing relays branch on it. Overloading it would have been a breaking change for every current consumer.

**It's nullable.** Untracked auto-playlist plays only carry an id when the annotated URI supplied `subsonic_id`, so consumers have to handle its absence. Documented in the route comment and the admin panel blurb.

Note the id is opaque and backend-relative — it identifies the item within the configured backend, but doesn't name which backend that is. If someone wants that, it's a separate field.

## Also updated

- Payload doc comment in `routes/webhooks.ts`
- The inline payload sample + blurb in `WebhooksPanel.tsx`, so an operator sees the field (and the `sourceTrackId` vs `source` distinction) without reading controller source

## Testing

- `npm run lint` in `controller/` and `web/` — 0 errors both
- `npm test` in `controller/` — all 64 test files pass

No new test: the field is a literal on an object built deep inside the watcher's now-playing handler, and pinning it would mean mocking the whole tick for no real invariant. The `sourceTrackId` ≠ `source` distinction is held by comments in all three touched files instead.